### PR TITLE
Refactor: remove backward compatibility stubs

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -8,9 +8,7 @@ from typing import Final
 # Private API imports (accessible but not in __all__)
 # Users can access private functions via: pantr._basis_impl._function_name, etc.
 from . import (
-    _basis_impl,  # noqa: F401
     _basis_utils,  # noqa: F401
-    _bspline_space_impl,  # noqa: F401
 )
 from ._bspline_space_factory import (
     create_cardinal_Bspline_knot_vector,

--- a/src/pantr/_basis_impl.py
+++ b/src/pantr/_basis_impl.py
@@ -1,7 +1,0 @@
-"""Backward compatibility re-exports for _basis_impl module.
-
-This module re-exports functions from the subdivided basis implementation modules
-to maintain backward compatibility with existing code.
-"""
-
-from __future__ import annotations

--- a/src/pantr/_bspline_space_impl.py
+++ b/src/pantr/_bspline_space_impl.py
@@ -1,7 +1,0 @@
-"""Backward compatibility re-exports for _bspline_space_impl module.
-
-This module re-exports functions from the subdivided B-spline implementation modules
-to maintain backward compatibility with existing code.
-"""
-
-from __future__ import annotations


### PR DESCRIPTION
Removes `_basis_impl.py` and `_bspline_space_impl.py` as well as their internal exports within `pantr.__init__.py`, addressing architectural feedback to reduce unnecessary overhead during the alpha release phase.