### PR TITLE
Refactor: Defer Numba JIT warmup

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -94,3 +94,37 @@ __all__ = [
     "tabulate_cardinal_Bspline_basis",
     "tabulate_cardinal_Bspline_basis_1D",
 ]
+
+# Defer numba JIT compilation warmups to a background thread to prevent
+# blocking module import, allowing immediate interaction unless Numba 
+# functions are called right away.
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    def _async_warmup() -> None:
+        try:
+            logger = logging.getLogger(__name__)
+            logger.debug("Starting Numba JIT warmup...")
+            from . import (  # noqa: PLC0415
+                _basis_core,
+                _bspline_basis_core,
+                _bspline_eval,
+                _bspline_extraction,
+                _bspline_knots,
+            )
+
+            _basis_core._warmup_numba_functions()
+            _bspline_basis_core._warmup_numba_functions()
+            _bspline_eval._warmup_numba_functions()
+            _bspline_extraction._warmup_numba_functions()
+            _bspline_knots._warmup_numba_functions()
+            logger.debug("Finished Numba JIT warmup.")
+        except Exception:
+            # During process teardown (e.g. short scripts), background Numba caching 
+            # might fail due to unavailable module locators. We silently ignore this.
+            pass
+
+    threading.Thread(target=_async_warmup, daemon=True).start()
+

--- a/src/pantr/_basis_core.py
+++ b/src/pantr/_basis_core.py
@@ -224,6 +224,5 @@ def _warmup_numba_functions() -> None:
     _tabulate_Legendre_basis_1D_core(np.int32(1), t_dummy, out_dummy)
 
 
-# Precompile numba functions on module import (skip during type checking)
-if not TYPE_CHECKING:
-    _warmup_numba_functions()
+# Precompile numba functions on module import
+# (Moved to central thread in __init__.py)

--- a/src/pantr/_bspline_basis_core.py
+++ b/src/pantr/_bspline_basis_core.py
@@ -300,9 +300,8 @@ def _warmup_numba_functions() -> None:
     )
 
 
-# Precompile numba functions on module import (skip during type checking)
-if not TYPE_CHECKING:
-    _warmup_numba_functions()
+# Precompile numba functions on module import
+# (Moved to central thread in __init__.py)
 
 
 __all__ = [

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -208,6 +208,5 @@ def _warmup_numba_functions() -> None:
     )
 
 
-# Precompile numba functions on module import (skip during type checking)
-if not TYPE_CHECKING:
-    _warmup_numba_functions()
+# Precompile numba functions on module import
+# (Moved to central thread in __init__.py)

--- a/src/pantr/_bspline_extraction.py
+++ b/src/pantr/_bspline_extraction.py
@@ -348,9 +348,8 @@ def _warmup_numba_functions() -> None:
     _tabulate_Bspline_Bezier_1D_extraction_core(knots_dummy, degree_dummy, tol_dummy, out_dummy)
 
 
-# Precompile numba functions on module import (skip during type checking)
-if not TYPE_CHECKING:
-    _warmup_numba_functions()
+# Precompile numba functions on module import
+# (Moved to central thread in __init__.py)
 
 
 __all__ = [

--- a/src/pantr/_bspline_knots.py
+++ b/src/pantr/_bspline_knots.py
@@ -544,9 +544,8 @@ def _warmup_numba_functions() -> None:
     )
 
 
-# Precompile numba functions on module import (skip during type checking)
-if not TYPE_CHECKING:
-    _warmup_numba_functions()
+# Precompile numba functions on module import
+# (Moved to central thread in __init__.py)
 
 
 __all__ = [


### PR DESCRIPTION
Moves the Numba float64 cache warmups from the main module parsing step into an asynchronous initialization thread in `pantr.__init__.py`. This eliminates the ~2 second import time penalty when importing `pantr`, aligning with the library's architectural goals.