### PR TITLE
Feat: Expose change basis utilities on BsplineSpace1D class

### DIFF
--- a/src/pantr/bspline_space_1D.py
+++ b/src/pantr/bspline_space_1D.py
@@ -19,6 +19,13 @@ from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
 )
+from .basis import LagrangeVariant
+from .change_basis import (
+    compute_Bernstein_to_cardinal_change_basis_1D,
+    compute_Bernstein_to_Lagrange_change_basis_1D,
+    compute_cardinal_to_Bernstein_change_basis_1D,
+    compute_Lagrange_to_Bernstein_change_basis_1D,
+)
 from .tolerance import get_strict_tolerance
 
 if TYPE_CHECKING:
@@ -533,3 +540,81 @@ class BsplineSpace1D:
         return _tabulate_Bspline_cardinal_1D_extraction_impl(
             self.knots, self.degree, self.tolerance, out=out
         )
+
+    def compute_Lagrange_to_Bernstein_change_basis(
+        self,
+        lagrange_variant: LagrangeVariant = LagrangeVariant.EQUISPACES,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Construct the matrix mapping Lagrange basis evaluations to Bernstein basis evaluations.
+
+        This delegates to `pantr.change_basis.compute_Lagrange_to_Bernstein_change_basis_1D`.
+
+        Args:
+            lagrange_variant (LagrangeVariant): Lagrange point distribution.
+                Defaults to LagrangeVariant.EQUISPACES.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+                If None, a new array is allocated.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix.
+        """
+        return compute_Lagrange_to_Bernstein_change_basis_1D(
+            self.degree, lagrange_variant, self.dtype, out=out
+        )
+
+    def compute_Bernstein_to_Lagrange_change_basis(
+        self,
+        lagrange_variant: LagrangeVariant = LagrangeVariant.EQUISPACES,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Construct the matrix mapping Bernstein basis evaluations to Lagrange basis evaluations.
+
+        This delegates to `pantr.change_basis.compute_Bernstein_to_Lagrange_change_basis_1D`.
+
+        Args:
+            lagrange_variant (LagrangeVariant): Lagrange point distribution.
+                Defaults to LagrangeVariant.EQUISPACES.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+                If None, a new array is allocated.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix.
+        """
+        return compute_Bernstein_to_Lagrange_change_basis_1D(
+            self.degree, lagrange_variant, self.dtype, out=out
+        )
+
+    def compute_Bernstein_to_cardinal_change_basis(
+        self,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Create transformation matrix from Bernstein to cardinal B-spline basis.
+
+        This delegates to `pantr.change_basis.compute_Bernstein_to_cardinal_change_basis_1D`.
+
+        Args:
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+                If None, a new array is allocated.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix.
+        """
+        return compute_Bernstein_to_cardinal_change_basis_1D(self.degree, self.dtype, out=out)
+
+    def compute_cardinal_to_Bernstein_change_basis(
+        self,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Create transformation matrix from cardinal B-spline to Bernstein basis.
+
+        This delegates to `pantr.change_basis.compute_cardinal_to_Bernstein_change_basis_1D`.
+
+        Args:
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+                If None, a new array is allocated.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix.
+        """
+        return compute_cardinal_to_Bernstein_change_basis_1D(self.degree, self.dtype, out=out)

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -35,6 +35,12 @@ from pantr.basis import (
     tabulate_Lagrange_basis_1D,
 )
 from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.change_basis import (
+    compute_Bernstein_to_cardinal_change_basis_1D,
+    compute_Bernstein_to_Lagrange_change_basis_1D,
+    compute_cardinal_to_Bernstein_change_basis_1D,
+    compute_Lagrange_to_Bernstein_change_basis_1D,
+)
 from pantr.tolerance import get_strict_tolerance
 
 
@@ -1496,3 +1502,37 @@ class TestOutParameter:
 
         with pytest.raises(ValueError, match="Output array is not writeable"):
             spline.tabulate_cardinal_extraction_operators(out=out)
+
+
+class TestBsplineSpace1DChangeBasis:
+    """Test change of basis wrappers on BsplineSpace1D."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_compute_change_basis_wrappers(self, degree: int) -> None:
+        """Test that the change of basis methods delegate correctly."""
+        knots = create_uniform_open_knot_vector(num_intervals=5, degree=degree, domain=(0.0, 1.0))
+        spline = BsplineSpace1D(knots, degree)
+
+        # 1. Lagrange to Bernstein
+        res1 = spline.compute_Lagrange_to_Bernstein_change_basis(LagrangeVariant.EQUISPACES)
+        exp1 = compute_Lagrange_to_Bernstein_change_basis_1D(
+            degree, LagrangeVariant.EQUISPACES, spline.dtype
+        )
+        np.testing.assert_allclose(res1, exp1)
+
+        # 2. Bernstein to Lagrange
+        res2 = spline.compute_Bernstein_to_Lagrange_change_basis(LagrangeVariant.EQUISPACES)
+        exp2 = compute_Bernstein_to_Lagrange_change_basis_1D(
+            degree, LagrangeVariant.EQUISPACES, spline.dtype
+        )
+        np.testing.assert_allclose(res2, exp2)
+
+        # 3. Bernstein to Cardinal
+        res3 = spline.compute_Bernstein_to_cardinal_change_basis()
+        exp3 = compute_Bernstein_to_cardinal_change_basis_1D(degree, spline.dtype)
+        np.testing.assert_allclose(res3, exp3)
+
+        # 4. Cardinal to Bernstein
+        res4 = spline.compute_cardinal_to_Bernstein_change_basis()
+        exp4 = compute_cardinal_to_Bernstein_change_basis_1D(degree, spline.dtype)
+        np.testing.assert_allclose(res4, exp4)


### PR DESCRIPTION
Addresses Point 5 from the architectural review by wrapping the pure utility transformation matrix functions from `change_basis.py` natively onto the `BsplineSpace1D` object, vastly improving ergonomics and discoverability.