### PR TITLE
fix(bspline): make knots array read-only to prevent silent cache corruption

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -96,13 +96,14 @@ __all__ = [
 ]
 
 # Defer numba JIT compilation warmups to a background thread to prevent
-# blocking module import, allowing immediate interaction unless Numba 
+# blocking module import, allowing immediate interaction unless Numba
 # functions are called right away.
 import logging
 import threading
 from typing import TYPE_CHECKING
 
 if not TYPE_CHECKING:
+
     def _async_warmup() -> None:
         try:
             logger = logging.getLogger(__name__)
@@ -122,9 +123,8 @@ if not TYPE_CHECKING:
             _bspline_knots._warmup_numba_functions()
             logger.debug("Finished Numba JIT warmup.")
         except Exception:
-            # During process teardown (e.g. short scripts), background Numba caching 
+            # During process teardown (e.g. short scripts), background Numba caching
             # might fail due to unavailable module locators. We silently ignore this.
             pass
 
     threading.Thread(target=_async_warmup, daemon=True).start()
-

--- a/src/pantr/bspline_space_1D.py
+++ b/src/pantr/bspline_space_1D.py
@@ -106,6 +106,8 @@ class BsplineSpace1D:
         if snap_knots:
             self._snap_knots()
 
+        self._knots.flags.writeable = False
+
     @staticmethod
     def _validate_input(
         knots: npt.ArrayLike,

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -134,6 +134,13 @@ class TestBsplineSpace1DProperties:
         spline = BsplineSpace1D(knots, degree)
         np.testing.assert_array_equal(spline.knots, np.array(knots))
 
+    def test_knots_immutable(self) -> None:
+        """Test that the knots array is read-only to prevent silent cache corruption."""
+        spline = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
+        assert not spline.knots.flags.writeable
+        with pytest.raises(ValueError):
+            spline.knots[0] = 99.0
+
     def test_periodic_property(self) -> None:
         """Test periodic property."""
         knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]


### PR DESCRIPTION
## Summary

- Sets `self._knots.flags.writeable = False` at the end of `BsplineSpace1D.__init__`, making the array returned by the `knots` property read-only.
- Adds `test_knots_immutable` asserting the flag is set and that attempted writes raise `ValueError`.

## Motivation

The `knots` property returned `self._knots` directly. Any caller could mutate it (e.g. `space.knots[0] = 99`), silently corrupting `functools.cached_property` values (`num_basis`, `domain`, `num_intervals`) and invalidating the `functools.cache`-based knot-multiplicity cache — all without any error or warning.

## Safety

The change is safe because:
- `_snap_knots()` creates a fresh array via `.copy()` and reassigns `self._knots` — it never writes into the existing array in-place.
- All Numba-compiled functions (`_bspline_basis_core`, `_bspline_knots`, `_bspline_extraction`, `_bspline_eval`) only read from the knots array they receive.

## Test plan

- [x] `make pre-pull-request` passes (ruff, mypy, pytest ×2, docs build) — 747 tests, 99% coverage
- [x] `test_knots_immutable` verifies `knots.flags.writeable is False` and that `space.knots[0] = 99` raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)