### PR TITLE
refactor: extract nb_jit boilerplate into _numba_compat module

### DIFF
--- a/src/pantr/_basis_core.py
+++ b/src/pantr/_basis_core.py
@@ -6,25 +6,10 @@ Bernstein, cardinal B-spline, and Legendre basis polynomials.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
-
-import numba as nb
 import numpy as np
 import numpy.typing as npt
 
-F = TypeVar("F", bound=Callable[..., Any])
-
-if TYPE_CHECKING:
-    # During type-checking, make the decorator a no-op that preserves types.
-    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-else:
-    # At runtime, use the real Numba decorator.
-    nb_jit = nb.jit  # type: ignore[attr-defined]
+from ._numba_compat import nb_jit
 
 
 @nb_jit(

--- a/src/pantr/_bspline_basis_core.py
+++ b/src/pantr/_bspline_basis_core.py
@@ -6,10 +6,8 @@ using Cox-de Boor recursion and Bernstein-like evaluation.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
-import numba as nb
 import numpy as np
 import numpy.typing as npt
 
@@ -25,21 +23,10 @@ from ._bspline_knots import (
     _get_last_knot_smaller_equal_impl,
     _is_in_domain_impl,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
+from ._numba_compat import nb_jit
 
 if TYPE_CHECKING:
     from .bspline_space_1D import BsplineSpace1D
-
-    # During type-checking, make the decorator a no-op that preserves types.
-    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-else:
-    # At runtime, use the real Numba decorator.
-    nb_jit = nb.jit  # type: ignore[attr-defined]
 
 
 @nb_jit(

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numba as nb
 import numpy as np
 from numpy import typing as npt
 
@@ -13,25 +12,12 @@ from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
     _get_last_knot_smaller_equal_impl,
 )
+from ._numba_compat import nb_jit
 from .quad import PointsLattice
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, TypeVar
-
-    F = TypeVar("F", bound=Callable[..., Any])
     from .bspline import Bspline
     from .quad import PointsLattice
-
-    # During type-checking, make the decorator a no-op that preserves types.
-    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-else:
-    # At runtime, use the real Numba decorator.
-    nb_jit = nb.jit  # type: ignore[attr-defined]
 
 
 @nb_jit(

--- a/src/pantr/_bspline_extraction.py
+++ b/src/pantr/_bspline_extraction.py
@@ -7,10 +7,6 @@ and B-spline basis functions.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar
-
-import numba as nb
 import numpy as np
 import numpy.typing as npt
 
@@ -21,24 +17,12 @@ from ._bspline_knots import (
     _get_multiplicity_of_first_knot_in_domain_impl,
     _get_unique_knots_and_multiplicity_impl,
 )
+from ._numba_compat import nb_jit
 from .basis import LagrangeVariant
 from .change_basis import (
     compute_cardinal_to_Bernstein_change_basis_1D,
     compute_Lagrange_to_Bernstein_change_basis_1D,
 )
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-if TYPE_CHECKING:
-    # During type-checking, make the decorator a no-op that preserves types.
-    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-else:
-    # At runtime, use the real Numba decorator.
-    nb_jit = nb.jit  # type: ignore[attr-defined]
 
 
 @nb_jit(

--- a/src/pantr/_bspline_knots.py
+++ b/src/pantr/_bspline_knots.py
@@ -7,27 +7,13 @@ cardinal interval identification, and knot vector generation utilities.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import Any, cast
 
-import numba as nb
 import numpy as np
 import numpy.typing as npt
 
 from ._basis_utils import _validate_out_array_bool
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-if TYPE_CHECKING:
-    # During type-checking, make the decorator a no-op that preserves types.
-    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
-        def decorator(func: F) -> F:
-            return func
-
-        return decorator
-else:
-    # At runtime, use the real Numba decorator.
-    nb_jit = nb.jit  # type: ignore[attr-defined]
+from ._numba_compat import nb_jit
 
 
 @nb_jit(

--- a/src/pantr/_numba_compat.py
+++ b/src/pantr/_numba_compat.py
@@ -1,0 +1,22 @@
+"""Numba compatibility shim for type-checker-friendly JIT decoration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+if TYPE_CHECKING:
+    # During type-checking, make the decorator a no-op that preserves types.
+    def nb_jit(*args: object, **kwargs: object) -> Callable[[F], F]:
+        def decorator(func: F) -> F:
+            return func
+
+        return decorator
+
+else:
+    # At runtime, use the real Numba decorator.
+    import numba as nb
+
+    nb_jit = nb.jit  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Creates `src/pantr/_numba_compat.py` with the consolidated Numba compatibility shim (`nb_jit`) — a no-op decorator under `TYPE_CHECKING`, `nb.jit` at runtime
- Replaces the identical 19-line boilerplate block in `_basis_core.py`, `_bspline_basis_core.py`, `_bspline_eval.py`, `_bspline_extraction.py`, and `_bspline_knots.py` with a single `from ._numba_compat import nb_jit` import
- Future changes to the Numba decorator (e.g. adding `fastmath=True` globally, switching to `nb.njit`) now require a single-file edit

## Test plan

- [x] `make pre-pull-request` passes (ruff, mypy on 34 source files, 747 tests ×2, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)