### PR TITLE
fix: bound knot-multiplicity cache with lru_cache(maxsize=128)

### DIFF
--- a/src/pantr/bspline_space_1D.py
+++ b/src/pantr/bspline_space_1D.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     pass
 
 
-@functools.cache
+@functools.lru_cache(maxsize=128)
 def _cached_unique_knots_and_multiplicity(
     knots_repr: tuple[bytes, str, int],
     degree: int,
@@ -33,6 +33,12 @@ def _cached_unique_knots_and_multiplicity(
     in_domain: bool = False,
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
     """Compute unique knots and multiplicities with memoization.
+
+    The cache is bounded to prevent unbounded memory growth in long-running
+    applications that construct many distinct spline spaces.  128 entries is
+    generous for real-world use (an adaptive simulation rarely needs more than
+    a few dozen distinct knot vectors) while still eliminating the risk of a
+    memory leak.
 
     Args:
         knots_repr (tuple[bytes, str, int]): Serialized knot vector bytes, dtype string, and size.

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -34,7 +34,7 @@ from pantr.basis import (
     tabulate_cardinal_Bspline_basis_1D,
     tabulate_Lagrange_basis_1D,
 )
-from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_1D import BsplineSpace1D, _cached_unique_knots_and_multiplicity
 from pantr.tolerance import get_strict_tolerance
 
 
@@ -140,6 +140,21 @@ class TestBsplineSpace1DProperties:
         assert not spline.knots.flags.writeable
         with pytest.raises(ValueError):
             spline.knots[0] = 99.0
+
+    def test_unique_knots_cache_is_bounded(self) -> None:
+        """Test that the knot-multiplicity cache has a finite maxsize.
+
+        An unbounded cache (functools.cache) would leak memory in long-running
+        applications that construct many distinct spline spaces.  Switching to
+        lru_cache(maxsize=N) ensures old entries are evicted when the cache is
+        full.
+        """
+        info = _cached_unique_knots_and_multiplicity.cache_info()
+        assert info.maxsize is not None, (
+            "_cached_unique_knots_and_multiplicity must use lru_cache with a "
+            "finite maxsize, not functools.cache, to avoid unbounded memory growth."
+        )
+        assert info.maxsize > 0
 
     def test_periodic_property(self) -> None:
         """Test periodic property."""


### PR DESCRIPTION
## Summary

- Replaces `@functools.cache` (unbounded) with `@functools.lru_cache(maxsize=128)` on `_cached_unique_knots_and_multiplicity` in `bspline_space_1D.py`
- An unbounded cache retains every distinct knot vector seen during a process lifetime, leaking memory in long-running applications (e.g. adaptive-refinement loops that construct thousands of distinct spline spaces)
- 128 entries covers typical real-world workflows while capping the worst-case footprint; LRU eviction silently drops least-recently-used entries when the limit is reached
- Adds `test_unique_knots_cache_is_bounded` to `tests/test_bspline_space_1D.py` — asserts `cache_info().maxsize is not None` so a future regression back to an unbounded cache is caught immediately

## Notes

The `_ensure_float_dtype_by_name` cache in `tolerance.py` also uses `@cache`, but its key space is naturally bounded to ~4 valid dtype names, so it is left unchanged.

## Test plan

- [x] `make pre-pull-request` passes (ruff, mypy on 34 source files, 748 tests ×2, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)