### PR TITLE
perf: cache change-of-basis matrices in extraction operators

### DIFF
--- a/src/pantr/_bspline_extraction.py
+++ b/src/pantr/_bspline_extraction.py
@@ -20,8 +20,8 @@ from ._bspline_knots import (
 from ._numba_compat import nb_jit
 from .basis import LagrangeVariant
 from .change_basis import (
-    compute_cardinal_to_Bernstein_change_basis_1D,
-    compute_Lagrange_to_Bernstein_change_basis_1D,
+    _cached_cardinal_to_Bernstein_matrix,
+    _cached_Lagrange_to_Bernstein_matrix,
 )
 
 
@@ -241,7 +241,7 @@ def _tabulate_Bspline_Lagrange_1D_extraction_impl(
 
     # Transform to Lagrange extraction in-place to avoid extra copy
     # For every interval, right-multiply the Bezier-to-B-spline extraction by lagr_to_bzr in-place.
-    lagr_to_bzr = compute_Lagrange_to_Bernstein_change_basis_1D(degree, lagrange_variant, dtype)
+    lagr_to_bzr = _cached_Lagrange_to_Bernstein_matrix(degree, lagrange_variant, dtype)
     for i in range(out.shape[0]):
         # Use out[i, :, :] = out[i, :, :] @ lagr_to_bzr, but perform in-place via np.matmul
         # to avoid extra allocation.
@@ -301,7 +301,7 @@ def _tabulate_Bspline_cardinal_1D_extraction_impl(
     _tabulate_Bspline_Bezier_1D_extraction_impl(knots, degree, tol, out=out)
 
     # Transform to cardinal extraction
-    card_to_bzr = compute_cardinal_to_Bernstein_change_basis_1D(degree, dtype)
+    card_to_bzr = _cached_cardinal_to_Bernstein_matrix(degree, dtype)
     # Transform to cardinal extraction in-place to avoid unnecessary copy
     # out[...] = out @ card_to_bzr is not strictly in-place (it creates a new array then assigns)
     # To perform an in-place transformation, use np.matmul (or @) with out as the output

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -6,6 +6,7 @@
 #
 """
 
+import functools
 from collections.abc import Callable
 
 import numpy as np
@@ -309,3 +310,68 @@ def compute_cardinal_to_Bernstein_change_basis_1D(
         dtype=dtype,
         out=out,
     )
+
+
+@functools.lru_cache(maxsize=64)
+def _cached_Lagrange_to_Bernstein_matrix(
+    degree: int,
+    lagrange_variant: LagrangeVariant,
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return a cached, read-only Lagrange-to-Bernstein change-of-basis matrix.
+
+    This is the hot-path counterpart of
+    :func:`compute_Lagrange_to_Bernstein_change_basis_1D` used internally by
+    the extraction-operator routines.  Because the matrix depends only on
+    ``(degree, lagrange_variant, dtype)`` — never on the knot vector — it is
+    safe to share a single immutable copy across all calls with matching
+    arguments.
+
+    The returned array has ``writeable=False`` to guard the cached copy against
+    accidental in-place mutation.  NumPy's ``matmul`` and ``@`` operator accept
+    read-only arrays as non-output arguments, so callers can use the matrix
+    directly with :func:`numpy.matmul`.
+
+    Args:
+        degree (int): Polynomial degree.
+        lagrange_variant (LagrangeVariant): Lagrange node distribution.
+        dtype (np.dtype): Floating-point dtype (``float32`` or ``float64``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Read-only ``(degree+1, degree+1)``
+            transformation matrix such that ``C @ lagrange_values = bernstein_values``.
+    """
+    mat = compute_Lagrange_to_Bernstein_change_basis_1D(degree, lagrange_variant, dtype)
+    mat.flags.writeable = False
+    return mat
+
+
+@functools.lru_cache(maxsize=64)
+def _cached_cardinal_to_Bernstein_matrix(
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return a cached, read-only cardinal-B-spline-to-Bernstein change-of-basis matrix.
+
+    This is the hot-path counterpart of
+    :func:`compute_cardinal_to_Bernstein_change_basis_1D` used internally by
+    the extraction-operator routines.  Because the matrix depends only on
+    ``(degree, dtype)`` — never on the knot vector — it is safe to share a
+    single immutable copy across all calls with matching arguments.
+
+    The returned array has ``writeable=False`` to guard the cached copy against
+    accidental in-place mutation.  NumPy's ``matmul`` and ``@`` operator accept
+    read-only arrays as non-output arguments, so callers can use the matrix
+    directly with :func:`numpy.matmul`.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (np.dtype): Floating-point dtype (``float32`` or ``float64``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Read-only ``(degree+1, degree+1)``
+            transformation matrix such that ``C @ cardinal_values = bernstein_values``.
+    """
+    mat = compute_cardinal_to_Bernstein_change_basis_1D(degree, dtype)
+    mat.flags.writeable = False
+    return mat

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -11,6 +11,8 @@ from pantr.basis import (
     tabulate_Lagrange_basis_1D,
 )
 from pantr.change_basis import (
+    _cached_cardinal_to_Bernstein_matrix,
+    _cached_Lagrange_to_Bernstein_matrix,
     _compute_change_basis_1D,
     compute_Bernstein_to_cardinal_change_basis_1D,
     compute_Bernstein_to_Lagrange_change_basis_1D,
@@ -402,3 +404,71 @@ class TestCreateChangeBasis:
         out_readonly.setflags(write=False)
         with pytest.raises(ValueError, match="Output array is not writeable"):
             _compute_change_basis_1D(bernstein, cardinal, n_quad_pts=degree + 1, out=out_readonly)
+
+
+class TestCachedChangeBasisMatrices:
+    """Tests for the LRU-cached change-of-basis helpers."""
+
+    def test_lagrange_cached_values_match_uncached(self) -> None:
+        """Cached matrix must be numerically identical to the uncached reference."""
+        degree = 3
+        variant = LagrangeVariant.GAUSS_LOBATTO_LEGENDRE
+        dtype = np.dtype(np.float64)
+        expected = compute_Lagrange_to_Bernstein_change_basis_1D(degree, variant, dtype)
+        cached = _cached_Lagrange_to_Bernstein_matrix(degree, variant, dtype)
+        np.testing.assert_array_equal(cached, expected)
+
+    def test_cardinal_cached_values_match_uncached(self) -> None:
+        """Cached matrix must be numerically identical to the uncached reference."""
+        degree = 3
+        dtype = np.dtype(np.float64)
+        expected = compute_cardinal_to_Bernstein_change_basis_1D(degree, dtype)
+        cached = _cached_cardinal_to_Bernstein_matrix(degree, dtype)
+        np.testing.assert_array_equal(cached, expected)
+
+    def test_lagrange_cached_array_is_readonly(self) -> None:
+        """The cached array must be read-only to prevent mutation of the shared copy."""
+        degree = 2
+        dtype = np.dtype(np.float32)
+        mat = _cached_Lagrange_to_Bernstein_matrix(degree, LagrangeVariant.EQUISPACES, dtype)
+        assert not mat.flags.writeable
+        with pytest.raises((ValueError, TypeError)):
+            mat[0, 0] = 0.0
+
+    def test_cardinal_cached_array_is_readonly(self) -> None:
+        """The cached array must be read-only to prevent mutation of the shared copy."""
+        degree = 2
+        dtype = np.dtype(np.float64)
+        mat = _cached_cardinal_to_Bernstein_matrix(degree, dtype)
+        assert not mat.flags.writeable
+        with pytest.raises((ValueError, TypeError)):
+            mat[0, 0] = 0.0
+
+    def test_lagrange_cache_returns_same_object(self) -> None:
+        """Repeated calls with identical arguments must return the exact same object."""
+        degree = 2
+        variant = LagrangeVariant.EQUISPACES
+        dtype = np.dtype(np.float64)
+        mat1 = _cached_Lagrange_to_Bernstein_matrix(degree, variant, dtype)
+        mat2 = _cached_Lagrange_to_Bernstein_matrix(degree, variant, dtype)
+        assert mat1 is mat2
+
+    def test_cardinal_cache_returns_same_object(self) -> None:
+        """Repeated calls with identical arguments must return the exact same object."""
+        degree = 3
+        dtype = np.dtype(np.float64)
+        mat1 = _cached_cardinal_to_Bernstein_matrix(degree, dtype)
+        mat2 = _cached_cardinal_to_Bernstein_matrix(degree, dtype)
+        assert mat1 is mat2
+
+    def test_lagrange_cache_is_bounded(self) -> None:
+        """The Lagrange cache must have a finite maxsize."""
+        info = _cached_Lagrange_to_Bernstein_matrix.cache_info()
+        assert info.maxsize is not None
+        assert info.maxsize > 0
+
+    def test_cardinal_cache_is_bounded(self) -> None:
+        """The cardinal cache must have a finite maxsize."""
+        info = _cached_cardinal_to_Bernstein_matrix.cache_info()
+        assert info.maxsize is not None
+        assert info.maxsize > 0


### PR DESCRIPTION
## Summary

- Adds two `lru_cache`-backed private helpers in `change_basis.py`:
  - `_cached_Lagrange_to_Bernstein_matrix(degree, lagrange_variant, dtype)`
  - `_cached_cardinal_to_Bernstein_matrix(degree, dtype)`
- Updates `_bspline_extraction.py` to use the cached helpers instead of calling the public `compute_*` functions directly on every invocation
- Removes the now-unused public `compute_*` imports from `_bspline_extraction.py`

## Motivation

`_tabulate_Bspline_Lagrange_1D_extraction_impl` and `_tabulate_Bspline_cardinal_1D_extraction_impl` called `compute_Lagrange_to_Bernstein_change_basis_1D` / `compute_cardinal_to_Bernstein_change_basis_1D` fresh on every extraction-operator call. These functions build an `(degree+1)×(degree+1)` matrix via Gauss-Legendre quadrature and a linear solve — non-trivial work that was wasted because the result depends only on `(degree, variant, dtype)`, never on the knot vector.

## Design

- The cached arrays are marked `writeable=False` to prevent accidental mutation of the shared cached copy. NumPy's `matmul` and `@` accept read-only arrays as non-output arguments, so existing callers are unaffected.
- Key space is naturally small (`degree × LagrangeVariant (5) × dtype (2)` ≤ 100 entries), so `maxsize=64` gives full coverage in practice with an explicit ceiling.

## Test plan

- [x] 8 new tests: correctness (values match uncached), read-only flag, cache-hit identity (`is`), and bounded `maxsize` for both cached helpers
- [x] `make pre-pull-request` passes (ruff, mypy on 34 source files, 756 tests ×2, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)