### PR TITLE
perf: parallelize basis kernels with prange

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -105,18 +105,24 @@ from typing import TYPE_CHECKING
 if not TYPE_CHECKING:
 
     def _async_warmup() -> None:
+        from ._numba_compat import _warmup_complete  # noqa: PLC0415
+
         try:
             logger = logging.getLogger(__name__)
             logger.debug("Starting Numba JIT warmup...")
             from . import (  # noqa: PLC0415
-                _basis_core,
                 _bspline_basis_core,
                 _bspline_eval,
                 _bspline_extraction,
                 _bspline_knots,
             )
 
-            _basis_core._warmup_numba_functions()
+            # _basis_core kernels use parallel=True. Numba's default threading
+            # layer (workqueue) is not safe for concurrent parallel calls from
+            # multiple Python threads.  Compiling them here (from a background
+            # thread) while the main thread may also call them leads to a crash.
+            # Instead they compile lazily on first user call (always from the
+            # main / caller thread) and are cached to disk by Numba's cache=True.
             _bspline_basis_core._warmup_numba_functions()
             _bspline_eval._warmup_numba_functions()
             _bspline_extraction._warmup_numba_functions()
@@ -126,5 +132,8 @@ if not TYPE_CHECKING:
             # During process teardown (e.g. short scripts), background Numba caching
             # might fail due to unavailable module locators. We silently ignore this.
             pass
+        finally:
+            # Always signal completion so callers are never blocked indefinitely.
+            _warmup_complete.set()
 
     threading.Thread(target=_async_warmup, daemon=True).start()

--- a/src/pantr/_basis_1D.py
+++ b/src/pantr/_basis_1D.py
@@ -24,6 +24,7 @@ from ._basis_utils import (
     _normalize_points_1D,
     _validate_out_array_1D,
 )
+from ._numba_compat import wait_for_jit_warmup
 
 if TYPE_CHECKING:
     from .basis import LagrangeVariant
@@ -62,6 +63,10 @@ def _tabulate_basis_1D_impl_helper(
         ValueError: If degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
+    # Ensure background JIT compilation is complete before calling Numba
+    # kernels that use parallel=True (avoids concurrent-compilation crash).
+    wait_for_jit_warmup()
+
     if n < 0:
         raise ValueError("degree must be non-negative")
 

--- a/src/pantr/_basis_core.py
+++ b/src/pantr/_basis_core.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 import numpy as np
 import numpy.typing as npt
 
-from ._numba_compat import nb_jit
+from ._numba_compat import nb_jit, nb_prange
 
 
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _tabulate_Bernstein_basis_1D_core(
     n: np.int32,
@@ -36,6 +36,9 @@ def _tabulate_Bernstein_basis_1D_core(
     relation would produce NaN values. At t=1.0, only the last basis function
     B_n,n(1) = 1, while all others are 0.
 
+    Each evaluation point is independent, so the outer loop over points is
+    parallelised with ``numba.prange`` for better throughput on large arrays.
+
     Args:
         n (np.int32): Degree of the Bernstein polynomials. Must be non-negative.
         t (npt.NDArray[np.float32 | np.float64]): 1D array of
@@ -55,12 +58,12 @@ def _tabulate_Bernstein_basis_1D_core(
     """
     if n == 0:
         # The basis is just B_0,0(pts) = 1
-        for j in range(out.shape[0]):
+        for j in nb_prange(out.shape[0]):
             out[j, 0] = 1.0
         return
 
-    # Process each point
-    for j in range(t.shape[0]):
+    # Process each point — rows are independent, so use prange.
+    for j in nb_prange(t.shape[0]):
         u = t[j]
         if u == 1.0:
             # At t=1.0: only B_n,n(1) = 1, all others are 0
@@ -81,7 +84,7 @@ def _tabulate_Bernstein_basis_1D_core(
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _tabulate_cardinal_Bspline_basis_1D_core(
     n: np.int32,
@@ -95,6 +98,9 @@ def _tabulate_cardinal_Bspline_basis_1D_core(
     evaluation point in t. Values are zero outside [0, 1]. Uses the stable
     Cox-de Boor (BasisFuns) recursion specialized to span index i=0.
 
+    Each evaluation point is independent, so the outer loop over points is
+    parallelised with ``numba.prange`` for better throughput on large arrays.
+
     Args:
         n (np.int32): Degree of the B-spline basis (>= 0).
         t (npt.NDArray[np.float32 | np.float64]): 1D array of
@@ -105,14 +111,16 @@ def _tabulate_cardinal_Bspline_basis_1D_core(
             shape and dtype (no validation performed inside this numba-compiled function).
     """
     num_pts = t.shape[0]
-    # Initialize first column to 1.0
-    for j in range(num_pts):
-        out[j, 0] = 1.0
 
-    if n == 0:  # Degree-0: basis function is constant.
+    if n == 0:
+        # Degree-0: basis function is constant.
+        for j in nb_prange(num_pts):
+            out[j, 0] = 1.0
         return
 
-    for j in range(num_pts):
+    # Each row is independent — parallelise over points.
+    for j in nb_prange(num_pts):
+        out[j, 0] = 1.0
         u = t[j]
         one_minus_u = 1.0 - u
 
@@ -130,7 +138,7 @@ def _tabulate_cardinal_Bspline_basis_1D_core(
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _tabulate_Legendre_basis_1D_core(
     n: np.int32,
@@ -149,6 +157,9 @@ def _tabulate_Legendre_basis_1D_core(
     p_i(x) = (sqrt(2i-1)sqrt(2i+1)/i) * (2x-1) * p_{i-1}(x)
              - ((i-1)/i) * sqrt((2i+1)/(2i-3)) * p_{i-2}(x)
 
+    The recurrence coefficients are precomputed once, and the outer loop over
+    evaluation points is parallelised with ``numba.prange``.
+
     Args:
         n (np.int32): Degree of the Legendre polynomials. Must be non-negative.
         t (npt.NDArray[np.float32 | np.float64]): 1D array of
@@ -160,37 +171,32 @@ def _tabulate_Legendre_basis_1D_core(
     """
     num_pts = t.shape[0]
 
-    # p_0(x) = 1
-    for j in range(num_pts):
-        out[j, 0] = 1.0
-
     if n == 0:
+        for j in nb_prange(num_pts):
+            out[j, 0] = 1.0
         return
 
-    # p_1(x) = sqrt(3)(2x-1)
-    sqrt3 = np.sqrt(3.0)
-
-    # Compute 2x - 1 for all points and p_1
-    for j in range(num_pts):
-        two_x_minus_1 = 2.0 * t[j] - 1.0
-        out[j, 1] = sqrt3 * two_x_minus_1
-
+    # Precompute recurrence coefficients a_i, b_i for i = 2..n.
+    # This is O(n) work shared across all points.
+    a_coeffs = np.empty(n + 1)
+    b_coeffs = np.empty(n + 1)
     for i in range(2, n + 1):
-        # Coefficients
-        # a_i = (sqrt(2i-1)sqrt(2i+1)/i)
-        # b_i = ((i-1)/i) * sqrt((2i+1)/(2i-3))
-
         i_float = float(i)
         sqrt_2i_minus_1 = np.sqrt(2.0 * i_float - 1.0)
         sqrt_2i_plus_1 = np.sqrt(2.0 * i_float + 1.0)
         sqrt_2i_minus_3 = np.sqrt(2.0 * i_float - 3.0)
+        a_coeffs[i] = (sqrt_2i_minus_1 * sqrt_2i_plus_1) / i_float
+        b_coeffs[i] = ((i_float - 1.0) / i_float) * (sqrt_2i_plus_1 / sqrt_2i_minus_3)
 
-        a_i = (sqrt_2i_minus_1 * sqrt_2i_plus_1) / i_float
-        b_i = ((i_float - 1.0) / i_float) * (sqrt_2i_plus_1 / sqrt_2i_minus_3)
+    sqrt3 = np.sqrt(3.0)
 
-        for j in range(num_pts):
-            two_x_minus_1 = 2.0 * t[j] - 1.0
-            out[j, i] = a_i * two_x_minus_1 * out[j, i - 1] - b_i * out[j, i - 2]
+    # Each row is independent — parallelise over points.
+    for j in nb_prange(num_pts):
+        two_x_minus_1 = 2.0 * t[j] - 1.0
+        out[j, 0] = 1.0
+        out[j, 1] = sqrt3 * two_x_minus_1
+        for i in range(2, n + 1):
+            out[j, i] = a_coeffs[i] * two_x_minus_1 * out[j, i - 1] - b_coeffs[i] * out[j, i - 2]
 
 
 def _warmup_numba_functions() -> None:

--- a/src/pantr/_numba_compat.py
+++ b/src/pantr/_numba_compat.py
@@ -2,10 +2,35 @@
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+# Event set by the background warmup thread (in __init__.py) once all Numba
+# functions have been compiled.  Callers that invoke parallel Numba kernels
+# should call ``wait_for_jit_warmup()`` before the first Numba call to
+# avoid a concurrent-compilation crash (a known Numba limitation with
+# ``parallel=True``).
+_warmup_complete = threading.Event()
+
+# Fast flag so the common (post-warmup) path is a single boolean check.
+_warmup_done = False
+
+
+def wait_for_jit_warmup() -> None:
+    """Block until the background JIT warmup has finished.
+
+    After the event has been set once, subsequent calls return immediately
+    (no lock, no syscall).
+    """
+    global _warmup_done  # noqa: PLW0603
+    if _warmup_done:
+        return
+    _warmup_complete.wait()
+    _warmup_done = True
+
 
 if TYPE_CHECKING:
     # During type-checking, make the decorator a no-op that preserves types.
@@ -15,8 +40,12 @@ if TYPE_CHECKING:
 
         return decorator
 
+    # During type-checking, prange is just range.
+    nb_prange = range
+
 else:
-    # At runtime, use the real Numba decorator.
+    # At runtime, use the real Numba decorator and parallel range.
     import numba as nb
 
     nb_jit = nb.jit  # type: ignore[attr-defined]
+    nb_prange = nb.prange  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Switches the three `_basis_core.py` Numba kernels from `parallel=False` to `parallel=True` and replaces `range` with `nb_prange` in the outer point-loop — each point is fully independent, so this is textbook embarrassingly-parallel work. Also exports `nb_prange` from `_numba_compat.py`.

**Per-kernel changes**
| Kernel | Change |
|--------|--------|
| `_tabulate_Bernstein_basis_1D_core` | `prange` over points |
| `_tabulate_cardinal_Bspline_basis_1D_core` | `prange` over points; merges init + recurrence into one loop to reduce parallel dispatches |
| `_tabulate_Legendre_basis_1D_core` | precomputes O(n) recurrence coefficients once (shared read-only), then `prange` over points (removes redundant `sqrt` calls from the inner loop) |

## Thread-safety fixes

`parallel=True` introduces two crash modes that are addressed:

**1. Concurrent JIT compilation race**
Numba's JIT compilation is not safe when two threads try to compile the same `parallel=True` function simultaneously (background warmup thread vs. a thread calling the function early). Fixed by:
- Adding `_warmup_complete = threading.Event()` and `wait_for_jit_warmup()` to `_numba_compat.py`
- `__init__.py` sets the event in the `finally` block of `_async_warmup`
- `_tabulate_basis_1D_impl_helper` calls `wait_for_jit_warmup()` before every core invocation; the fast path after warmup is a single `bool` check — no syscall

**2. Concurrent parallel execution on the workqueue layer**
Numba's default threading layer on macOS (`workqueue`) does not support concurrent parallel regions from multiple Python threads (e.g. Sphinx autodoc thread + background warmup thread). Fixed by:
- Removing `_basis_core` from the background warmup entirely
- The three kernels now compile lazily on first user call (always from the main/caller thread, never concurrently) and are persisted to disk by `cache=True`

## Test plan

- [x] `make pre-pull-request` passes (ruff, mypy on 34 source files, 756 tests ×2, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)