### PR TITLE
chore: ignore .claude/ local tool directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ env/
 .idea/
 .vscode/
 *.code-workspace
+.claude/
 
 # Jupyter and notebooks
 .ipynb_checkpoints/
@@ -62,4 +63,3 @@ Thumbs.db
 
 # Hatch build artifacts
 .hatch/
-


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` to exclude Claude Code's local runtime directory (memory files, session state) from version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)