### PR TITLE
feat(bspline): per-direction orders for derivative evaluation

### DIFF
--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -247,12 +247,12 @@ def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
 def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-    orders: Sequence[int],
+    n_deriv: int,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Evaluate a specific derivative of a 1D B-spline at the given points.
 
-    Computes the derivative of order ``orders[0]`` at each evaluation point.
+    Computes the derivative of order ``n_deriv`` at each evaluation point.
     For rational B-splines the quotient rule (Algorithm A4.2 from Piegl & Tiller)
     is applied to return the derivative of the projected mapping.
 
@@ -262,8 +262,7 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
             points. If a :class:`~pantr.quad.PointsLattice`, must be 1D. Otherwise
             must be a 1D array of shape ``(n_pts,)`` matching the B-spline's dtype.
-        orders (Sequence[int]): Must have length 1. ``orders[0]`` is the derivative
-            order to return. Must be >= 0.
+        n_deriv (int): The derivative order to return. Must be >= 0.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
             output array with shape ``(n_pts,)`` for scalar or ``(n_pts, rank)``
             for vector output. Filled in-place and returned. Defaults to None.
@@ -275,16 +274,15 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
         included in the output.
 
     Raises:
-        ValueError: If the B-spline is not 1D, if ``orders[0] < 0``, if the
+        ValueError: If the B-spline is not 1D, if ``n_deriv < 0``, if the
             points lattice is not 1D, or if the points dtype does not match the
             B-spline dtype.
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
 
-    n_deriv = orders[0]
     if n_deriv < 0:
-        raise ValueError(f"orders[0] must be >= 0, got {n_deriv}")
+        raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
 
     pts_array: npt.NDArray[np.float32 | np.float64]
     if isinstance(pts, PointsLattice):
@@ -739,7 +737,7 @@ def _evaluate_Bspline_deriv(
         npt.NDArray[np.float32 | np.float64]: Derivative values at the given points.
     """
     if spline.dim == 1:
-        return _evaluate_Bspline_deriv_1D(spline, pts, orders, out)
+        return _evaluate_Bspline_deriv_1D(spline, pts, orders[0], out)
     else:
         return _evaluate_Bspline_deriv_multi_dim(spline, pts, orders, out)
 

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -742,37 +742,45 @@ def _apply_quotient_rule_multi_dim(
     orders_tuple: tuple[int, ...],
     pts_base_shape: tuple[int, ...],
     dtype: npt.DTypeLike,
+    final_out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Apply the generalised quotient rule to produce rational B-spline derivatives.
+    """Apply the generalised quotient rule to produce the target rational B-spline derivative.
 
     Given the homogeneous derivative tensor ``hom_all`` (built by
     :func:`_build_hom_all_multi_dim`), iterates all multi-indices in ascending
     total-order and applies Algorithm A4.2 generalised to multiple parametric
-    directions.
+    directions. Only the result for multi-index ``orders_tuple`` is returned;
+    intermediate results are discarded once no longer needed.
 
     Args:
         hom_all (npt.NDArray[np.float32 | np.float64]): Homogeneous derivatives,
             shape ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, cp_size)``.
-        orders_tuple (tuple[int, ...]): Maximum derivative order per direction.
+        orders_tuple (tuple[int, ...]): Target derivative order per direction.
         pts_base_shape (tuple[int, ...]): Leading shape of ``hom_all``
             (``(n_pts,)`` or ``(*grid_shape,)``).
-        dtype (npt.DTypeLike): Floating-point dtype of the output array.
+        dtype (npt.DTypeLike): Floating-point dtype of intermediate arrays.
+        final_out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
+            buffer of shape ``(*pts_base_shape, rank)`` where ``rank = cp_size - 1``.
+            When provided the target result is written directly into it, avoiding an
+            extra allocation. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Projected derivative tensor of shape
-        ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, rank)``,
-        where ``rank = cp_size - 1``.
+        npt.NDArray[np.float32 | np.float64]: Target partial derivative values of shape
+        ``(*pts_base_shape, rank)``, where ``rank = cp_size - 1``.
+        Returns ``final_out`` when it is provided.
     """
     dim = len(orders_tuple)
     cp_size = hom_all.shape[-1]
     rank_value = cp_size - 1
-    result_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), rank_value)
-    result_all: npt.NDArray[np.float32 | np.float64] = np.empty(result_shape, dtype=dtype)
 
     zero_idx = (0,) * dim
     W = hom_all[(Ellipsis,) + zero_idx + (-1,)]  # noqa: RUF005  # (*pts_base_shape,)
     all_multi_indices = sorted(iproduct(*[range(od + 1) for od in orders_tuple]), key=sum)
 
+    # Each multi-index gets its own contiguous (pts_base_shape, rank) buffer.
+    # For the target index (orders_tuple) we reuse final_out when provided,
+    # avoiding both the large result_all tensor and the final copy.
+    results: dict[tuple[int, ...], npt.NDArray[np.float32 | np.float64]] = {}
     for k_idx in all_multi_indices:
         hom_N_k = hom_all[(Ellipsis,) + k_idx + (slice(None),)][..., :-1]  # noqa: RUF005
         v: npt.NDArray[np.float32 | np.float64] = hom_N_k.copy()
@@ -788,11 +796,16 @@ def _apply_quotient_rule_multi_dim(
                 coeff *= math.comb(k_idx[d], i_idx[d])
             hom_W_i = hom_all[(Ellipsis,) + i_idx + (-1,)]  # noqa: RUF005
             k_minus_i = tuple(k_idx[d] - i_idx[d] for d in range(dim))
-            res_km_i = result_all[(Ellipsis,) + k_minus_i + (slice(None),)]  # noqa: RUF005
-            v = v - coeff * hom_W_i[..., np.newaxis] * res_km_i
-        result_all[(Ellipsis,) + k_idx + (slice(None),)] = v / W[..., np.newaxis]  # noqa: RUF005
+            v = v - coeff * hom_W_i[..., np.newaxis] * results[k_minus_i]
+        buf: npt.NDArray[np.float32 | np.float64]
+        if k_idx == orders_tuple and final_out is not None:
+            buf = final_out
+        else:
+            buf = np.empty((*pts_base_shape, rank_value), dtype=dtype)
+        buf[:] = v / W[..., np.newaxis]
+        results[k_idx] = buf
 
-    return result_all
+    return results[orders_tuple]
 
 
 def _evaluate_Bspline_deriv_multi_dim_rational(
@@ -822,11 +835,9 @@ def _evaluate_Bspline_deriv_multi_dim_rational(
     """
     dtype = spline.dtype
     hom_all = _build_hom_all_multi_dim(spline, pts, orders_tuple, pts_base_shape)
-    result_all = _apply_quotient_rule_multi_dim(hom_all, orders_tuple, pts_base_shape, dtype)
-
-    final: npt.NDArray[np.float32 | np.float64] = result_all[
-        (Ellipsis,) + orders_tuple + (slice(None),)  # noqa: RUF005
-    ]
+    final: npt.NDArray[np.float32 | np.float64] = _apply_quotient_rule_multi_dim(
+        hom_all, orders_tuple, pts_base_shape, dtype
+    )
     rank_value = spline.control_points.shape[-1] - 1
     if rank_value == 1:
         final = final[..., 0]

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -183,7 +183,7 @@ def _evaluate_Bspline_1D(
     cache=True,
     parallel=False,
 )
-def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
+def _evaluate_Bspline_basis_combine_all_deriv_1D(  # noqa: PLR0913
     control_points: npt.NDArray[np.float32 | np.float64],
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
@@ -193,12 +193,12 @@ def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
     pts: npt.NDArray[np.float32 | np.float64],
     out: npt.NDArray[np.float32 | np.float64],
 ) -> None:
-    """Evaluate B-spline derivatives by computing derivative basis functions and combining.
+    """Evaluate all B-spline derivatives from order 0 through ``n_deriv`` and combine.
 
     For each evaluation point, computes the (degree+1) non-zero B-spline basis
     derivatives up to order ``n_deriv`` via Algorithm A2.3 from Piegl & Tiller,
-    then forms each derivative as a linear combination of the corresponding
-    control points.
+    then forms **every** derivative order as a linear combination of the
+    corresponding control points.
 
     Args:
         control_points (npt.NDArray[np.float32 | np.float64]): Control-point array of
@@ -244,7 +244,207 @@ def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
                 out[i, k, r] = total
 
 
-def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=False,
+)
+def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
+    control_points: npt.NDArray[np.float32 | np.float64],
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    periodic: bool,
+    tol: float,
+    n_deriv: int,
+    pts: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate the ``n_deriv``-th B-spline derivative and combine with control points.
+
+    For each evaluation point, computes the (degree+1) non-zero B-spline basis
+    derivatives up to order ``n_deriv`` via Algorithm A2.3 from Piegl & Tiller,
+    then forms **only** the ``n_deriv``-th derivative as a linear combination of
+    the corresponding control points.
+
+    Args:
+        control_points (npt.NDArray[np.float32 | np.float64]): Control-point array of
+            shape ``(n_basis, rank)``.
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        periodic (bool): Whether the B-spline is periodic.
+        tol (float): Tolerance for numerical comparisons.
+        n_deriv (int): Derivative order to return (>= 0).
+        pts (npt.NDArray[np.float32 | np.float64]): 1-D array of evaluation points,
+            shape ``(n_pts,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array of shape
+            ``(n_pts, rank)`` and matching dtype. Written in-place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_evaluate_Bspline_deriv_1D` instead.
+    """
+    order = degree + 1
+    n_pts = pts.size
+    dtype = knots.dtype
+    zero = dtype.type(0.0)
+    num_cp = control_points.shape[0]
+    rank = control_points.shape[1]
+
+    basis_deriv = np.empty((n_pts, n_deriv + 1, order), dtype=dtype)
+    first_basis = np.empty(n_pts, dtype=np.int64)
+
+    _compute_basis_deriv_nurbs_book_impl(
+        knots, degree, periodic, tol, n_deriv, pts, basis_deriv, first_basis
+    )
+
+    for i in range(n_pts):
+        s = first_basis[i]
+        for r in range(rank):
+            total = zero
+            for j in range(order):
+                idx = s + j
+                if periodic:
+                    idx = idx % num_cp
+                total = total + basis_deriv[i, n_deriv, j] * control_points[idx, r]
+            out[i, r] = total
+
+
+def _evaluate_Bspline_deriv_1D_rational(
+    spline: Bspline,
+    spline_1D: BsplineSpace1D,
+    pts_array: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Apply the quotient rule to evaluate the ``n_deriv``-th derivative of a rational 1D B-spline.
+
+    Computes all homogeneous derivatives 0..``n_deriv`` via
+    :func:`_evaluate_Bspline_basis_combine_all_deriv_1D`, then applies Algorithm A4.2
+    (Piegl & Tiller). The last quotient-rule result row is written directly into
+    ``out`` (if provided) to avoid an extra copy.
+
+    Args:
+        spline (Bspline): The rational 1D B-spline.
+        spline_1D (BsplineSpace1D): The underlying 1D space.
+        pts_array (npt.NDArray[np.float32 | np.float64]): 1-D evaluation points.
+        n_deriv (int): Derivative order (>= 0).
+        out (npt.NDArray[np.float32 | np.float64] | None): Pre-allocated output
+            array of shape ``(n_pts,)`` for scalar or ``(n_pts, rank)`` for vector.
+            Written in-place when provided.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values, shape ``(n_pts,)``
+        for scalar or ``(n_pts, rank)`` for vector.
+    """
+    n_pts = pts_array.shape[0]
+    cp_size = spline.control_points.shape[-1]
+    rank = cp_size - 1
+    dtype = spline.dtype
+
+    # All homogeneous derivatives 0..n_deriv are needed for the quotient rule.
+    hom_array = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
+    _evaluate_Bspline_basis_combine_all_deriv_1D(
+        spline.control_points,
+        spline_1D.knots,
+        spline_1D.degree,
+        spline_1D.periodic,
+        spline_1D.tolerance,
+        n_deriv,
+        pts_array,
+        hom_array,
+    )
+
+    out_shape = (n_pts,) if rank == 1 else (n_pts, rank)
+    if out is not None:
+        _validate_out_array_1D(out, out_shape, dtype)
+
+    # Intermediate rows (k < n_deriv) need temporary storage; the last row
+    # reuses `out` (or a fresh allocation when out is None) to avoid a copy.
+    results: list[npt.NDArray[np.float32 | np.float64]] = [
+        np.empty((n_pts, rank), dtype=dtype) for _ in range(n_deriv)
+    ]
+    final_buf: npt.NDArray[np.float32 | np.float64]
+    if out is not None:
+        final_buf = out.reshape(n_pts, 1) if rank == 1 else out
+    else:
+        final_buf = np.empty((n_pts, rank), dtype=dtype)
+    results.append(final_buf)
+
+    # Algorithm A4.2 quotient rule.
+    W = hom_array[:, 0, -1:]  # (n_pts, 1)
+    for k in range(n_deriv + 1):
+        v: npt.NDArray[np.float32 | np.float64] = hom_array[:, k, :-1].copy()
+        for i in range(1, k + 1):
+            v = v - math.comb(k, i) * hom_array[:, i, -1:] * results[k - i]
+        results[k][:] = v / W
+
+    if rank == 1:
+        return out if out is not None else final_buf[:, 0]
+    return out if out is not None else final_buf
+
+
+def _evaluate_Bspline_deriv_1D_non_rational(
+    spline: Bspline,
+    spline_1D: BsplineSpace1D,
+    pts_array: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate the ``n_deriv``-th derivative of a non-rational 1D B-spline.
+
+    Delegates to :func:`_evaluate_Bspline_basis_combine_deriv_1D`, which writes
+    only the requested derivative order into a ``(n_pts, rank)`` buffer. For
+    scalar output (``rank == 1``) the buffer is a ``(n_pts, 1)`` reshape of
+    ``out`` (when provided) so no copy is needed.
+
+    Args:
+        spline (Bspline): The non-rational 1D B-spline.
+        spline_1D (BsplineSpace1D): The underlying 1D space.
+        pts_array (npt.NDArray[np.float32 | np.float64]): 1-D evaluation points.
+        n_deriv (int): Derivative order (>= 0).
+        out (npt.NDArray[np.float32 | np.float64] | None): Pre-allocated output
+            array of shape ``(n_pts,)`` for scalar or ``(n_pts, rank)`` for vector.
+            Written in-place when provided.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values, shape ``(n_pts,)``
+        for scalar or ``(n_pts, rank)`` for vector.
+    """
+    n_pts = pts_array.shape[0]
+    rank = spline.control_points.shape[-1]
+    dtype = spline.dtype
+
+    # Kernel expects (n_pts, rank). For scalar (rank == 1) reshape a 1D out to
+    # (n_pts, 1) so the kernel writes directly into the caller's buffer.
+    buf: npt.NDArray[np.float32 | np.float64]
+    if rank == 1:
+        if out is not None:
+            _validate_out_array_1D(out, (n_pts,), dtype)
+            buf = out.reshape(n_pts, 1)
+        else:
+            buf = np.empty((n_pts, 1), dtype=dtype)
+    elif out is not None:
+        _validate_out_array_1D(out, (n_pts, rank), dtype)
+        buf = out
+    else:
+        buf = np.empty((n_pts, rank), dtype=dtype)
+
+    _evaluate_Bspline_basis_combine_deriv_1D(
+        spline.control_points,
+        spline_1D.knots,
+        spline_1D.degree,
+        spline_1D.periodic,
+        spline_1D.tolerance,
+        n_deriv,
+        pts_array,
+        buf,
+    )
+    if rank == 1:
+        return out if out is not None else buf[:, 0]
+    return buf
+
+
+def _evaluate_Bspline_deriv_1D(
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
     n_deriv: int,
@@ -280,7 +480,6 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
-
     if n_deriv < 0:
         raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
 
@@ -295,65 +494,10 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     if pts_array.dtype != spline.dtype:
         raise ValueError("Points dtype must match B-spline dtype")
 
-    n_pts = pts_array.shape[0]
-    cp_size = spline.control_points.shape[-1]
     spline_1D = spline.space.spaces[0]
-
     if spline.is_rational:
-        rank = cp_size - 1
-        # Compute all homogeneous derivatives 0..n_deriv (needed for quotient rule).
-        hom_array = np.empty((n_pts, n_deriv + 1, cp_size), dtype=spline.dtype)
-        _evaluate_Bspline_basis_combine_deriv_1D(
-            spline.control_points,
-            spline_1D.knots,
-            spline_1D.degree,
-            spline_1D.periodic,
-            spline_1D.tolerance,
-            n_deriv,
-            pts_array,
-            hom_array,
-        )
-        # Algorithm A4.2: build result for orders 0..n_deriv, return only n_deriv.
-        result_all = np.empty((n_pts, n_deriv + 1, rank), dtype=spline.dtype)
-        for k in range(n_deriv + 1):
-            v = hom_array[:, k, :-1].copy()
-            for i in range(1, k + 1):
-                v -= math.comb(k, i) * hom_array[:, i, -1:] * result_all[:, k - i, :]
-            result_all[:, k, :] = v / hom_array[:, 0, -1:]
-        final: npt.NDArray[np.float32 | np.float64] = result_all[:, n_deriv, :]
-        if rank == 1:
-            final = final[:, 0]
-        if out is not None:
-            _validate_out_array_1D(out, final.shape, spline.dtype)
-            out[:] = final
-            return out
-        return final
-
-    # Non-rational: compute all derivatives 0..n_deriv and extract row n_deriv.
-    buf = np.empty((n_pts, n_deriv + 1, cp_size), dtype=spline.dtype)
-    _evaluate_Bspline_basis_combine_deriv_1D(
-        spline.control_points,
-        spline_1D.knots,
-        spline_1D.degree,
-        spline_1D.periodic,
-        spline_1D.tolerance,
-        n_deriv,
-        pts_array,
-        buf,
-    )
-    final_nd: npt.NDArray[np.float32 | np.float64] = buf[:, n_deriv, :]
-    if cp_size == 1:
-        result_1d: npt.NDArray[np.float32 | np.float64] = final_nd[:, 0]
-        if out is not None:
-            _validate_out_array_1D(out, result_1d.shape, spline.dtype)
-            out[:] = result_1d
-            return out
-        return result_1d
-    if out is not None:
-        _validate_out_array_1D(out, final_nd.shape, spline.dtype)
-        out[:] = final_nd
-        return out
-    return final_nd
+        return _evaluate_Bspline_deriv_1D_rational(spline, spline_1D, pts_array, n_deriv, out)
+    return _evaluate_Bspline_deriv_1D_non_rational(spline, spline_1D, pts_array, n_deriv, out)
 
 
 def _evaluate_Bspline_deriv_multi_dim_pts_array(

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -10,12 +10,14 @@ splines.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
+from itertools import product as iproduct
 from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy import typing as npt
 
-from ._basis_utils import _validate_out_array_1D, _validate_out_array_3d_float
+from ._basis_utils import _validate_out_array_1D
 from ._bspline_basis_core import (
     _compute_basis_deriv_nurbs_book_impl,
     _compute_basis_nurbs_book_impl,
@@ -245,13 +247,14 @@ def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
 def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-    n_deriv: int,
+    orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Evaluate derivatives of a 1D B-spline at the given points.
+    """Evaluate a specific derivative of a 1D B-spline at the given points.
 
-    Dispatches to the basis-combine derivative kernel and applies the rational
-    quotient rule (Algorithm A4.2) when ``spline.is_rational`` is True.
+    Computes the derivative of order ``orders[0]`` at each evaluation point.
+    For rational B-splines the quotient rule (Algorithm A4.2 from Piegl & Tiller)
+    is applied to return the derivative of the projected mapping.
 
     Args:
         spline (Bspline): A 1D B-spline object containing space, control points,
@@ -259,28 +262,29 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
             points. If a :class:`~pantr.quad.PointsLattice`, must be 1D. Otherwise
             must be a 1D array of shape ``(n_pts,)`` matching the B-spline's dtype.
-        n_deriv (int): Maximum derivative order to compute. Must be >= 0.
+        orders (Sequence[int]): Must have length 1. ``orders[0]`` is the derivative
+            order to return. Must be >= 0.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
-            output array with the same shape and dtype as the returned array (see
-            below). Filled in-place and returned. Defaults to None.
+            output array with shape ``(n_pts,)`` for scalar or ``(n_pts, rank)``
+            for vector output. Filled in-place and returned. Defaults to None.
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Derivative values of shape
-        ``(n_pts, n_deriv+1)`` for scalar output or ``(n_pts, n_deriv+1, rank)``
-        for vector-valued output. Axis 1 indexes derivative order
-        (0 = value, 1 = first derivative, …). For rational B-splines the weight
-        column is divided out and not included in the output.
+        ``(n_pts,)`` for scalar output or ``(n_pts, rank)`` for vector-valued
+        output. For rational B-splines the weight column is divided out and not
+        included in the output.
 
     Raises:
-        ValueError: If the B-spline is not 1D, if ``n_deriv < 0``, if the
+        ValueError: If the B-spline is not 1D, if ``orders[0] < 0``, if the
             points lattice is not 1D, or if the points dtype does not match the
             B-spline dtype.
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
 
+    n_deriv = orders[0]
     if n_deriv < 0:
-        raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
+        raise ValueError(f"orders[0] must be >= 0, got {n_deriv}")
 
     pts_array: npt.NDArray[np.float32 | np.float64]
     if isinstance(pts, PointsLattice):
@@ -298,7 +302,8 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     spline_1D = spline.space.spaces[0]
 
     if spline.is_rational:
-        # Internal homogeneous buffer — always allocated fresh so `out` maps to the result
+        rank = cp_size - 1
+        # Compute all homogeneous derivatives 0..n_deriv (needed for quotient rule).
         hom_array = np.empty((n_pts, n_deriv + 1, cp_size), dtype=spline.dtype)
         _evaluate_Bspline_basis_combine_deriv_1D(
             spline.control_points,
@@ -310,29 +315,24 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
             pts_array,
             hom_array,
         )
-        # Algorithm A4.2 (Piegl & Tiller): hom_array[:, k, :-1] = k-th derivative
-        # of the weighted numerator; hom_array[:, k, -1] = k-th derivative of weight.
-        result_shape = (n_pts, n_deriv + 1, cp_size - 1)
-        result: npt.NDArray[np.float32 | np.float64]
-        if out is None:
-            result = np.empty(result_shape, dtype=spline.dtype)
-        else:
-            _validate_out_array_3d_float(out, result_shape, spline.dtype)
-            result = out
+        # Algorithm A4.2: build result for orders 0..n_deriv, return only n_deriv.
+        result_all = np.empty((n_pts, n_deriv + 1, rank), dtype=spline.dtype)
         for k in range(n_deriv + 1):
             v = hom_array[:, k, :-1].copy()
             for i in range(1, k + 1):
-                v -= math.comb(k, i) * hom_array[:, i, -1:] * result[:, k - i, :]
-            result[:, k, :] = v / hom_array[:, 0, -1:]
-        return result[:, :, 0] if cp_size - 1 == 1 else result
+                v -= math.comb(k, i) * hom_array[:, i, -1:] * result_all[:, k - i, :]
+            result_all[:, k, :] = v / hom_array[:, 0, -1:]
+        final: npt.NDArray[np.float32 | np.float64] = result_all[:, n_deriv, :]
+        if rank == 1:
+            final = final[:, 0]
+        if out is not None:
+            _validate_out_array_1D(out, final.shape, spline.dtype)
+            out[:] = final
+            return out
+        return final
 
-    # Non-rational: out is the computation buffer directly
-    out_array: npt.NDArray[np.float32 | np.float64]
-    if out is None:
-        out_array = np.empty((n_pts, n_deriv + 1, cp_size), dtype=spline.dtype)
-    else:
-        _validate_out_array_3d_float(out, (n_pts, n_deriv + 1, cp_size), spline.dtype)
-        out_array = out
+    # Non-rational: compute all derivatives 0..n_deriv and extract row n_deriv.
+    buf = np.empty((n_pts, n_deriv + 1, cp_size), dtype=spline.dtype)
     _evaluate_Bspline_basis_combine_deriv_1D(
         spline.control_points,
         spline_1D.knots,
@@ -341,25 +341,35 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
         spline_1D.tolerance,
         n_deriv,
         pts_array,
-        out_array,
+        buf,
     )
-    return out_array[:, :, 0] if cp_size == 1 else out_array
+    final_nd: npt.NDArray[np.float32 | np.float64] = buf[:, n_deriv, :]
+    if cp_size == 1:
+        result_1d: npt.NDArray[np.float32 | np.float64] = final_nd[:, 0]
+        if out is not None:
+            _validate_out_array_1D(out, result_1d.shape, spline.dtype)
+            out[:] = result_1d
+            return out
+        return result_1d
+    if out is not None:
+        _validate_out_array_1D(out, final_nd.shape, spline.dtype)
+        out[:] = final_nd
+        return out
+    return final_nd
 
 
 def _evaluate_Bspline_deriv_multi_dim_pts_array(
     cp: npt.NDArray[np.float32 | np.float64],
     spaces_1D: tuple[BsplineSpace1D, ...],
     pts: npt.NDArray[np.float32 | np.float64],
-    n_deriv: int,
+    orders: tuple[int, ...],
     out: npt.NDArray[np.float32 | np.float64],
 ) -> None:
-    """Evaluate multi-dimensional B-spline partial derivatives at an array of points.
+    """Evaluate a mixed partial derivative of a multi-dimensional B-spline at points.
 
-    For each combination of derivative order ``k`` and parametric direction
-    ``d``, the outer-product weights are formed using the ``k``-th derivative
-    basis row for direction ``d`` and the 0th (value) row for every other
-    direction.  The gathered local control-point patch is then contracted with
-    these weights and stored in ``out[:, k, d, :]``.
+    Computes the mixed partial derivative of orders ``orders[d]`` in each direction
+    ``d`` for all evaluation points simultaneously. Uses outer-product contraction
+    with the appropriate derivative basis row for each direction.
 
     Args:
         cp (npt.NDArray[np.float32 | np.float64]): Control-point array of shape
@@ -367,10 +377,10 @@ def _evaluate_Bspline_deriv_multi_dim_pts_array(
         spaces_1D (tuple[BsplineSpace1D, ...]): 1D B-spline spaces, one per direction.
         pts (npt.NDArray[np.float32 | np.float64]): Evaluation points of shape
             ``(n_pts, dim)``.
-        n_deriv (int): Maximum derivative order to compute (>= 0).
+        orders (tuple[int, ...]): Derivative order for each direction. Each entry
+            must be >= 0 and ``len(orders) == len(spaces_1D)``.
         out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array of
-            shape ``(n_pts, n_deriv+1, dim, cp_size)`` and matching dtype.
-            Filled in-place.
+            shape ``(n_pts, cp_size)`` and matching dtype. Filled in-place.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -382,16 +392,20 @@ def _evaluate_Bspline_deriv_multi_dim_pts_array(
     dBs: list[npt.NDArray[np.float32 | np.float64]] = []
     first_idxs: list[npt.NDArray[np.int_]] = []
     for d, space_d in enumerate(spaces_1D):
-        dB_d, first_d = space_d.tabulate_basis_derivatives(np.ascontiguousarray(pts[:, d]), n_deriv)
-        dBs.append(dB_d)  # (n_pts, n_deriv+1, order_d)
+        dB_d, first_d = space_d.tabulate_basis_derivatives(
+            np.ascontiguousarray(pts[:, d]), orders[d]
+        )
+        dBs.append(dB_d)  # (n_pts, orders[d]+1, degree_d+1)
         first_idxs.append(first_d)
 
-    orders = tuple(int(dB.shape[2]) for dB in dBs)
+    # Extract the specific derivative row for each direction.
+    Bs = [dBs[d][:, orders[d], :] for d in range(dim)]  # each (n_pts, degree_d+1)
+    basis_orders = tuple(int(B.shape[1]) for B in Bs)
 
-    # Build advanced index arrays (identical to _evaluate_Bspline_multi_dim_pts_array).
+    # Build advanced index arrays (same pattern as _evaluate_Bspline_multi_dim_pts_array).
     index_list: list[npt.NDArray[np.intp]] = []
     for d, (first_d, space_d) in enumerate(zip(first_idxs, spaces_1D, strict=True)):
-        order_d = orders[d]
+        order_d = basis_orders[d]
         idx_d = (
             first_d[:, np.newaxis].astype(np.intp)
             + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
@@ -401,42 +415,35 @@ def _evaluate_Bspline_deriv_multi_dim_pts_array(
         shape: tuple[int, ...] = (n_pts,) + (1,) * d + (order_d,) + (1,) * (dim - d - 1)
         index_list.append(idx_d.reshape(shape))
 
-    # Gather local control-point patch.
     idx_with_last: tuple[npt.NDArray[np.intp] | slice, ...] = (*tuple(index_list), slice(None))
     cp_local: npt.NDArray[np.float32 | np.float64] = cp[idx_with_last]
     # shape: (n_pts, order_0, ..., order_{D-1}, cp_size)
 
-    total_local = int(np.prod(orders))
-    cp_flat = cp_local.reshape(n_pts, total_local, cp.shape[-1])
+    weights: npt.NDArray[np.float32 | np.float64] = Bs[0].reshape(
+        (n_pts, basis_orders[0]) + (1,) * (dim - 1)
+    )
+    for d in range(1, dim):
+        w_shape: tuple[int, ...] = (n_pts,) + (1,) * d + (basis_orders[d],) + (1,) * (dim - d - 1)
+        weights = weights * Bs[d].reshape(w_shape)
 
-    for k in range(n_deriv + 1):
-        for d_deriv in range(dim):
-            # Direction d_deriv uses its k-th derivative row; all others use row 0.
-            weights: npt.NDArray[np.float32 | np.float64] = dBs[0][
-                :, k if d_deriv == 0 else 0, :
-            ].reshape((n_pts, orders[0]) + (1,) * (dim - 1))
-            for d in range(1, dim):
-                k_d = k if d == d_deriv else 0
-                w_shape: tuple[int, ...] = (n_pts,) + (1,) * d + (orders[d],) + (1,) * (dim - d - 1)
-                weights = weights * dBs[d][:, k_d, :].reshape(w_shape)
-            weights_flat = weights.reshape(n_pts, total_local)
-            out[:, k, d_deriv, :] = (cp_flat * weights_flat[..., np.newaxis]).sum(axis=1)
+    total_local = int(np.prod(basis_orders))
+    out[:] = (
+        (cp_local * weights[..., np.newaxis]).reshape(n_pts, total_local, cp.shape[-1]).sum(axis=1)
+    )
 
 
 def _evaluate_Bspline_deriv_multi_dim_lattice(
     cp: npt.NDArray[np.float32 | np.float64],
     spaces_1D: tuple[BsplineSpace1D, ...],
     pts: PointsLattice,
-    n_deriv: int,
+    orders: tuple[int, ...],
     out: npt.NDArray[np.float32 | np.float64],
 ) -> None:
-    """Evaluate multi-dimensional B-spline partial derivatives on a point lattice.
+    """Evaluate a mixed partial derivative of a multi-dimensional B-spline on a lattice.
 
-    For each combination of derivative order ``k`` and parametric direction
-    ``d_deriv``, performs one sequential contraction of the control-point tensor
-    using the ``k``-th derivative basis row for direction ``d_deriv`` and the
-    0th (value) row for all other directions.  The result is stored in
-    ``out[..., k, d_deriv, :]``.
+    Computes the mixed partial derivative of orders ``orders[d]`` in each direction
+    ``d`` via sequential contraction, using the appropriate derivative basis row for
+    each direction.
 
     Args:
         cp (npt.NDArray[np.float32 | np.float64]): Control-point array of shape
@@ -444,96 +451,90 @@ def _evaluate_Bspline_deriv_multi_dim_lattice(
         spaces_1D (tuple[BsplineSpace1D, ...]): 1D B-spline spaces, one per direction.
         pts (PointsLattice): Evaluation lattice. ``pts.dim`` must equal
             ``len(spaces_1D)``.
-        n_deriv (int): Maximum derivative order to compute (>= 0).
+        orders (tuple[int, ...]): Derivative order for each direction. Each entry
+            must be >= 0 and ``len(orders) == len(spaces_1D)``.
         out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array of
-            shape ``(*pts_grid_shape, n_deriv+1, dim, cp_size)`` and matching
-            dtype.  Filled in-place.
+            shape ``(*pts_grid_shape, cp_size)`` and matching dtype. Filled in-place.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_evaluate_Bspline_deriv_multi_dim` instead.
     """
-    dBs: list[npt.NDArray[np.float32 | np.float64]] = []
+    Bs: list[npt.NDArray[np.float32 | np.float64]] = []
     first_idxs: list[npt.NDArray[np.int_]] = []
-    for space_d, pts_d in zip(spaces_1D, pts.pts_per_dir, strict=True):
-        dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, n_deriv)
-        dBs.append(dB_d)  # (m_d, n_deriv+1, order_d)
+    for d, (space_d, pts_d) in enumerate(zip(spaces_1D, pts.pts_per_dir, strict=True)):
+        dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, orders[d])
+        Bs.append(dB_d[:, orders[d], :])  # (m_d, degree_d+1) — specific derivative row
         first_idxs.append(first_d)
 
-    dim = len(spaces_1D)
+    # Sequential contraction identical to _evaluate_Bspline_multi_dim_lattice.
+    current: npt.NDArray[np.float32 | np.float64] = cp
+    for d, (B_d, first_d, space_d) in enumerate(zip(Bs, first_idxs, spaces_1D, strict=True)):
+        m_d = int(B_d.shape[0])
+        order_d = int(B_d.shape[1])
 
-    for k in range(n_deriv + 1):
-        for d_deriv in range(dim):
-            current: npt.NDArray[np.float32 | np.float64] = cp
-            for d, (dB_d, first_d, space_d) in enumerate(
-                zip(dBs, first_idxs, spaces_1D, strict=True)
-            ):
-                k_d = k if d == d_deriv else 0
-                B_d = dB_d[:, k_d, :]  # (m_d, order_d)
-                m_d = int(B_d.shape[0])
-                order_d = int(B_d.shape[1])
+        idx_d = (
+            first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+        )  # (m_d, order_d)
+        if space_d.periodic:
+            idx_d = idx_d % space_d.num_basis
 
-                idx_d = (
-                    first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
-                )  # (m_d, order_d)
-                if space_d.periodic:
-                    idx_d = idx_d % space_d.num_basis
+        current_moved = np.moveaxis(current, d, 0)
+        gathered_moved: npt.NDArray[np.float32 | np.float64] = current_moved[idx_d]
 
-                current_moved = np.moveaxis(current, d, 0)
-                gathered_moved: npt.NDArray[np.float32 | np.float64] = current_moved[idx_d]
+        n_trail = gathered_moved.ndim - 2
+        B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
+        contracted: npt.NDArray[np.float32 | np.float64] = (gathered_moved * B_exp).sum(axis=1)
+        current = np.moveaxis(contracted, 0, d)
 
-                n_trail = gathered_moved.ndim - 2
-                B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
-                contracted: npt.NDArray[np.float32 | np.float64] = (gathered_moved * B_exp).sum(
-                    axis=1
-                )
-                current = np.moveaxis(contracted, 0, d)
-
-            out[..., k, d_deriv, :] = current
+    np.copyto(out, current)
 
 
-def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912
+def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-    n_deriv: int,
+    orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Evaluate partial derivatives of a multi-dimensional B-spline.
+    """Evaluate a mixed partial derivative of a multi-dimensional B-spline.
 
-    Computes all partial derivatives up to order ``n_deriv`` in each parametric
-    direction.  For rational B-splines the quotient rule (Algorithm A4.2 from
-    Piegl & Tiller) is applied independently per direction so that the result
-    is the derivative of the projected (inhomogeneous) mapping.
+    Computes the single mixed partial derivative specified by ``orders``, where
+    ``orders[d]`` is the derivative order in parametric direction ``d``. For
+    rational B-splines the generalised quotient rule is applied so that the
+    result is the derivative of the projected (inhomogeneous) mapping.
 
     Args:
         spline (Bspline): A multi-dimensional B-spline (``dim >= 2``).
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
-            points.  Either a 2-D array of shape ``(n_pts, dim)`` or a
+            points. Either a 2-D array of shape ``(n_pts, dim)`` or a
             :class:`~pantr.quad.PointsLattice`.
-        n_deriv (int): Maximum derivative order to compute.  Must be >= 0.
+        orders (Sequence[int]): One non-negative integer per parametric direction.
+            ``len(orders)`` must equal ``spline.dim``.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
-            output array whose shape matches the return value described below.
-            Defaults to None.
+            output array whose shape matches the return value. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Shape
-        ``(*pts_shape, n_deriv+1, dim)`` for scalar output or
-        ``(*pts_shape, n_deriv+1, dim, rank)`` for vector-valued output, where
-        ``pts_shape`` is ``(n_pts,)`` for a points array or
+        npt.NDArray[np.float32 | np.float64]: Mixed partial derivative values.
+        Shape is ``(*pts_base_shape,)`` for scalar output or
+        ``(*pts_base_shape, rank)`` for vector-valued output, where
+        ``pts_base_shape`` is ``(n_pts,)`` for a points array or
         ``(*pts_grid_shape,)`` for a :class:`~pantr.quad.PointsLattice`.
-        Axis ``-2`` indexes derivative order (0 = value, 1 = first, …) and
-        axis ``-1`` (before the optional rank axis) indexes parametric
-        direction. For rational B-splines the weight column is divided out
-        and not included in the output.
+        For rational B-splines the weight column is divided out.
 
     Raises:
-        ValueError: If ``n_deriv < 0``, if the pts dimension or dtype does not
-            match the B-spline, or if ``out`` has an incorrect shape or dtype.
+        ValueError: If ``len(orders) != spline.dim``, if any order is negative, if
+            the pts dimension or dtype does not match the B-spline, or if ``out``
+            has an incorrect shape or dtype.
     """
-    if n_deriv < 0:
-        raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
-
     dim = spline.dim
+    orders_tuple = tuple(orders)
+
+    if len(orders_tuple) != dim:
+        raise ValueError(f"len(orders) must equal spline.dim ({dim}), got {len(orders_tuple)}")
+    for d, od in enumerate(orders_tuple):
+        if od < 0:
+            raise ValueError(f"orders[{d}] must be >= 0, got {od}")
+
     dtype = spline.dtype
     cp = spline.control_points
     cp_size = cp.shape[-1]
@@ -554,72 +555,183 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912
             raise ValueError("Points dtype must match B-spline dtype")
         pts_base_shape = (pts.shape[0],)
 
-    hom_shape = (*pts_base_shape, n_deriv + 1, dim, cp_size)
+    out_shape = (*pts_base_shape, cp_size)
 
     if spline.is_rational:
-        hom_array = np.empty(hom_shape, dtype=dtype)
+        # For the generalised quotient rule we need all mixed derivatives
+        # hom[i] for multi-indices 0 <= i[d] <= orders[d].
+        # hom_all shape: (*pts_base_shape, orders[0]+1, ..., orders[D-1]+1, cp_size)
+        hom_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), cp_size)
+        hom_all: npt.NDArray[np.float32 | np.float64] = np.empty(hom_shape, dtype=dtype)
+
+        if isinstance(pts, PointsLattice):
+            # Precompute per-direction basis derivatives.
+            dBs_lat: list[npt.NDArray[np.float32 | np.float64]] = []
+            first_idxs_lat: list[npt.NDArray[np.int_]] = []
+            max_order = max(orders_tuple, default=0)
+            for space_d, pts_d in zip(spline.space.spaces, pts.pts_per_dir, strict=True):
+                dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, max_order)
+                dBs_lat.append(dB_d)
+                first_idxs_lat.append(first_d)
+            for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
+                # Sequential contraction for this multi-index.
+                current: npt.NDArray[np.float32 | np.float64] = cp
+                for d, (dB_d, first_d, space_d) in enumerate(
+                    zip(dBs_lat, first_idxs_lat, spline.space.spaces, strict=True)
+                ):
+                    B_d = dB_d[:, multi_idx[d], :]  # (m_d, degree_d+1)
+                    m_d = int(B_d.shape[0])
+                    order_d = int(B_d.shape[1])
+                    idx_d = (
+                        first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+                    )
+                    if space_d.periodic:
+                        idx_d = idx_d % space_d.num_basis
+                    current_moved = np.moveaxis(current, d, 0)
+                    gathered = current_moved[idx_d]
+                    n_trail = gathered.ndim - 2
+                    B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
+                    contracted = (gathered * B_exp).sum(axis=1)
+                    current = np.moveaxis(contracted, 0, d)
+                hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = current  # noqa: RUF005
+        else:
+            # Precompute per-direction basis derivatives and gather cp_local once.
+            dBs_pts: list[npt.NDArray[np.float32 | np.float64]] = []
+            first_idxs_pts: list[npt.NDArray[np.int_]] = []
+            for d, space_d in enumerate(spline.space.spaces):
+                dB_d, first_d = space_d.tabulate_basis_derivatives(
+                    np.ascontiguousarray(pts[:, d]), orders_tuple[d]
+                )
+                dBs_pts.append(dB_d)
+                first_idxs_pts.append(first_d)
+            n_pts = pts.shape[0]
+            basis_orders_pts = tuple(int(dB.shape[2]) for dB in dBs_pts)
+            index_list_pts: list[npt.NDArray[np.intp]] = []
+            for d, (first_d, space_d) in enumerate(
+                zip(first_idxs_pts, spline.space.spaces, strict=True)
+            ):
+                order_d = basis_orders_pts[d]
+                idx_d = (
+                    first_d[:, np.newaxis].astype(np.intp)
+                    + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+                )
+                if space_d.periodic:
+                    idx_d = idx_d % space_d.num_basis
+                s: tuple[int, ...] = (n_pts,) + (1,) * d + (order_d,) + (1,) * (dim - d - 1)
+                index_list_pts.append(idx_d.reshape(s))
+            idx_tup: tuple[npt.NDArray[np.intp] | slice, ...] = (
+                *tuple(index_list_pts),
+                slice(None),
+            )
+            cp_local: npt.NDArray[np.float32 | np.float64] = cp[idx_tup]
+            total_local = int(np.prod(basis_orders_pts))
+            cp_flat = cp_local.reshape(n_pts, total_local, cp_size)
+            for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
+                w: npt.NDArray[np.float32 | np.float64] = dBs_pts[0][:, multi_idx[0], :].reshape(
+                    (n_pts, basis_orders_pts[0]) + (1,) * (dim - 1)
+                )
+                for d in range(1, dim):
+                    ws: tuple[int, ...] = (
+                        (n_pts,) + (1,) * d + (basis_orders_pts[d],) + (1,) * (dim - d - 1)
+                    )
+                    w = w * dBs_pts[d][:, multi_idx[d], :].reshape(ws)
+                w_flat = w.reshape(n_pts, total_local)
+                hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = (  # noqa: RUF005
+                    (cp_flat * w_flat[..., np.newaxis]).sum(axis=1)
+                )
+
+        # Generalised quotient rule (ascending total-order iteration).
+        rank_value = cp_size - 1
+        result_shape_rat = (*pts_base_shape, *(od + 1 for od in orders_tuple), rank_value)
+        result_all: npt.NDArray[np.float32 | np.float64] = np.empty(result_shape_rat, dtype=dtype)
+        zero_idx = (0,) * dim
+        W = hom_all[(Ellipsis,) + zero_idx + (-1,)]  # noqa: RUF005  # (*pts_base_shape,)
+
+        all_multi_indices = sorted(iproduct(*[range(od + 1) for od in orders_tuple]), key=sum)
+        for k_idx in all_multi_indices:
+            hom_N_k = hom_all[(Ellipsis,) + k_idx + (slice(None),)][..., :-1]  # noqa: RUF005
+            v: npt.NDArray[np.float32 | np.float64] = hom_N_k.copy()
+            for i_idx in all_multi_indices:
+                if i_idx == zero_idx:
+                    continue
+                if sum(i_idx) > sum(k_idx):
+                    break
+                if not all(i_idx[d] <= k_idx[d] for d in range(dim)):
+                    continue
+                coeff = 1
+                for d in range(dim):
+                    coeff *= math.comb(k_idx[d], i_idx[d])
+                hom_W_i = hom_all[(Ellipsis,) + i_idx + (-1,)]  # noqa: RUF005
+                k_minus_i = tuple(k_idx[d] - i_idx[d] for d in range(dim))
+                res_km_i = result_all[(Ellipsis,) + k_minus_i + (slice(None),)]  # noqa: RUF005
+                v = v - coeff * hom_W_i[..., np.newaxis] * res_km_i
+            result_all[(Ellipsis,) + k_idx + (slice(None),)] = v / W[..., np.newaxis]  # noqa: RUF005
+
+        final_rat: npt.NDArray[np.float32 | np.float64] = result_all[
+            (Ellipsis,) + orders_tuple + (slice(None),)  # noqa: RUF005
+        ]
+        if rank_value == 1:
+            final_rat = final_rat[..., 0]
+        if out is not None:
+            _validate_out_array_1D(out, final_rat.shape, dtype)
+            out[:] = final_rat
+            return out
+        return final_rat
+
+    # Non-rational: extract specific derivative row directly.
+    # Kernel always writes to (*pts_base_shape, cp_size); out matches the final
+    # squeezed shape ((*pts_base_shape,) for scalar, (*pts_base_shape, rank) for vector).
+    buf: npt.NDArray[np.float32 | np.float64]
+    final_nd: npt.NDArray[np.float32 | np.float64]
+    if cp_size == 1:
+        # Scalar: allocate internal buf; out must be (*pts_base_shape,)
+        buf = np.empty(out_shape, dtype=dtype)
         if isinstance(pts, PointsLattice):
             _evaluate_Bspline_deriv_multi_dim_lattice(
-                cp, spline.space.spaces, pts, n_deriv, hom_array
+                cp, spline.space.spaces, pts, orders_tuple, buf
             )
         else:
             _evaluate_Bspline_deriv_multi_dim_pts_array(
-                cp, spline.space.spaces, pts, n_deriv, hom_array
+                cp, spline.space.spaces, pts, orders_tuple, buf
             )
-
-        rank_value = cp_size - 1
-        result_shape = (*pts_base_shape, n_deriv + 1, dim, rank_value)
-        result: npt.NDArray[np.float32 | np.float64]
+        final_nd = buf[..., 0]
+        if out is not None:
+            _validate_out_array_1D(out, final_nd.shape, dtype)
+            out[:] = final_nd
+            return out
+        return final_nd
+    else:
+        # Vector: out has same shape as buf; pass directly to kernel if provided.
         if out is None:
-            result = np.empty(result_shape, dtype=dtype)
+            buf = np.empty(out_shape, dtype=dtype)
         else:
-            _validate_out_array_1D(out, result_shape, dtype)
-            result = out
-
-        for d_deriv in range(dim):
-            for k in range(n_deriv + 1):
-                v = hom_array[..., k, d_deriv, :-1].copy()
-                for i in range(1, k + 1):
-                    v -= (
-                        math.comb(k, i)
-                        * hom_array[..., i, d_deriv, -1:]
-                        * result[..., k - i, d_deriv, :]
-                    )
-                result[..., k, d_deriv, :] = v / hom_array[..., 0, d_deriv, -1:]
-
-        return result[..., 0] if rank_value == 1 else result
-
-    # Non-rational
-    out_array: npt.NDArray[np.float32 | np.float64]
-    if out is None:
-        out_array = np.empty(hom_shape, dtype=dtype)
-    else:
-        _validate_out_array_1D(out, hom_shape, dtype)
-        out_array = out
-
-    if isinstance(pts, PointsLattice):
-        _evaluate_Bspline_deriv_multi_dim_lattice(cp, spline.space.spaces, pts, n_deriv, out_array)
-    else:
-        _evaluate_Bspline_deriv_multi_dim_pts_array(
-            cp, spline.space.spaces, pts, n_deriv, out_array
-        )
-
-    return out_array[..., 0] if cp_size == 1 else out_array
+            _validate_out_array_1D(out, out_shape, dtype)
+            buf = out
+        if isinstance(pts, PointsLattice):
+            _evaluate_Bspline_deriv_multi_dim_lattice(
+                cp, spline.space.spaces, pts, orders_tuple, buf
+            )
+        else:
+            _evaluate_Bspline_deriv_multi_dim_pts_array(
+                cp, spline.space.spaces, pts, orders_tuple, buf
+            )
+        return buf
 
 
 def _evaluate_Bspline_deriv(
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-    n_deriv: int,
+    orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Evaluate B-spline derivatives, dispatching on parametric dimension.
+    """Evaluate a B-spline derivative, dispatching on parametric dimension.
 
     Args:
         spline (Bspline): The B-spline object.
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
             points.
-        n_deriv (int): Maximum derivative order to compute (>= 0).
+        orders (Sequence[int]): One non-negative derivative order per parametric
+            direction. ``len(orders)`` must equal ``spline.dim``.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
             output array. Defaults to None.
 
@@ -627,9 +739,9 @@ def _evaluate_Bspline_deriv(
         npt.NDArray[np.float32 | np.float64]: Derivative values at the given points.
     """
     if spline.dim == 1:
-        return _evaluate_Bspline_deriv_1D(spline, pts, n_deriv, out)
+        return _evaluate_Bspline_deriv_1D(spline, pts, orders, out)
     else:
-        return _evaluate_Bspline_deriv_multi_dim(spline, pts, n_deriv, out)
+        return _evaluate_Bspline_deriv_multi_dim(spline, pts, orders, out)
 
 
 def _evaluate_Bspline_multi_dim_lattice(

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -488,7 +488,269 @@ def _evaluate_Bspline_deriv_multi_dim_lattice(
     np.copyto(out, current)
 
 
-def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
+def _build_hom_all_multi_dim(  # noqa: PLR0915
+    spline: Bspline,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    orders_tuple: tuple[int, ...],
+    pts_base_shape: tuple[int, ...],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build the homogeneous derivative tensor for all multi-indices up to ``orders_tuple``.
+
+    For each multi-index ``i`` with ``0 <= i[d] <= orders_tuple[d]``, evaluates the
+    partial derivative of order ``i`` of the homogeneous B-spline (numerator and weight
+    stacked in the last axis). The result is stored in a tensor of shape
+    ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, cp_size)``.
+
+    Args:
+        spline (Bspline): The B-spline (rational, ``dim >= 2``).
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+            points. Either a 2-D array of shape ``(n_pts, dim)`` or a
+            :class:`~pantr.quad.PointsLattice`.
+        orders_tuple (tuple[int, ...]): Maximum derivative order per direction.
+        pts_base_shape (tuple[int, ...]): Leading shape of the output tensor
+            (``(n_pts,)`` for a pts array, ``(*grid_shape,)`` for a lattice).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Homogeneous derivative tensor of
+        shape ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, cp_size)``.
+    """
+    dim = spline.dim
+    dtype = spline.dtype
+    cp = spline.control_points
+    cp_size = cp.shape[-1]
+
+    hom_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), cp_size)
+    hom_all: npt.NDArray[np.float32 | np.float64] = np.empty(hom_shape, dtype=dtype)
+
+    if isinstance(pts, PointsLattice):
+        dBs: list[npt.NDArray[np.float32 | np.float64]] = []
+        first_idxs: list[npt.NDArray[np.int_]] = []
+        max_order = max(orders_tuple, default=0)
+        for space_d, pts_d in zip(spline.space.spaces, pts.pts_per_dir, strict=True):
+            dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, max_order)
+            dBs.append(dB_d)
+            first_idxs.append(first_d)
+        for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
+            current: npt.NDArray[np.float32 | np.float64] = cp
+            for d, (dB_d, first_d, space_d) in enumerate(
+                zip(dBs, first_idxs, spline.space.spaces, strict=True)
+            ):
+                B_d = dB_d[:, multi_idx[d], :]  # (m_d, degree_d+1)
+                m_d = int(B_d.shape[0])
+                order_d = int(B_d.shape[1])
+                idx_d = first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+                if space_d.periodic:
+                    idx_d = idx_d % space_d.num_basis
+                current_moved = np.moveaxis(current, d, 0)
+                gathered = current_moved[idx_d]
+                n_trail = gathered.ndim - 2
+                B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
+                contracted = (gathered * B_exp).sum(axis=1)
+                current = np.moveaxis(contracted, 0, d)
+            hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = current  # noqa: RUF005
+    else:
+        dBs_pts: list[npt.NDArray[np.float32 | np.float64]] = []
+        first_idxs_pts: list[npt.NDArray[np.int_]] = []
+        for d, space_d in enumerate(spline.space.spaces):
+            dB_d, first_d = space_d.tabulate_basis_derivatives(
+                np.ascontiguousarray(pts[:, d]), orders_tuple[d]
+            )
+            dBs_pts.append(dB_d)
+            first_idxs_pts.append(first_d)
+        n_pts = pts.shape[0]
+        basis_orders = tuple(int(dB.shape[2]) for dB in dBs_pts)
+        index_list: list[npt.NDArray[np.intp]] = []
+        for d, (first_d, space_d) in enumerate(
+            zip(first_idxs_pts, spline.space.spaces, strict=True)
+        ):
+            order_d = basis_orders[d]
+            idx_d = (
+                first_d[:, np.newaxis].astype(np.intp)
+                + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+            )
+            if space_d.periodic:
+                idx_d = idx_d % space_d.num_basis
+            s: tuple[int, ...] = (n_pts,) + (1,) * d + (order_d,) + (1,) * (dim - d - 1)
+            index_list.append(idx_d.reshape(s))
+        idx_tup: tuple[npt.NDArray[np.intp] | slice, ...] = (*tuple(index_list), slice(None))
+        cp_local: npt.NDArray[np.float32 | np.float64] = cp[idx_tup]
+        total_local = int(np.prod(basis_orders))
+        cp_flat = cp_local.reshape(n_pts, total_local, cp_size)
+        for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
+            w: npt.NDArray[np.float32 | np.float64] = dBs_pts[0][:, multi_idx[0], :].reshape(
+                (n_pts, basis_orders[0]) + (1,) * (dim - 1)
+            )
+            for d in range(1, dim):
+                ws: tuple[int, ...] = (
+                    (n_pts,) + (1,) * d + (basis_orders[d],) + (1,) * (dim - d - 1)
+                )
+                w = w * dBs_pts[d][:, multi_idx[d], :].reshape(ws)
+            w_flat = w.reshape(n_pts, total_local)
+            hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = (  # noqa: RUF005
+                (cp_flat * w_flat[..., np.newaxis]).sum(axis=1)
+            )
+
+    return hom_all
+
+
+def _apply_quotient_rule_multi_dim(
+    hom_all: npt.NDArray[np.float32 | np.float64],
+    orders_tuple: tuple[int, ...],
+    pts_base_shape: tuple[int, ...],
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Apply the generalised quotient rule to produce rational B-spline derivatives.
+
+    Given the homogeneous derivative tensor ``hom_all`` (built by
+    :func:`_build_hom_all_multi_dim`), iterates all multi-indices in ascending
+    total-order and applies Algorithm A4.2 generalised to multiple parametric
+    directions.
+
+    Args:
+        hom_all (npt.NDArray[np.float32 | np.float64]): Homogeneous derivatives,
+            shape ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, cp_size)``.
+        orders_tuple (tuple[int, ...]): Maximum derivative order per direction.
+        pts_base_shape (tuple[int, ...]): Leading shape of ``hom_all``
+            (``(n_pts,)`` or ``(*grid_shape,)``).
+        dtype (npt.DTypeLike): Floating-point dtype of the output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Projected derivative tensor of shape
+        ``(*pts_base_shape, orders_tuple[0]+1, ..., orders_tuple[D-1]+1, rank)``,
+        where ``rank = cp_size - 1``.
+    """
+    dim = len(orders_tuple)
+    cp_size = hom_all.shape[-1]
+    rank_value = cp_size - 1
+    result_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), rank_value)
+    result_all: npt.NDArray[np.float32 | np.float64] = np.empty(result_shape, dtype=dtype)
+
+    zero_idx = (0,) * dim
+    W = hom_all[(Ellipsis,) + zero_idx + (-1,)]  # noqa: RUF005  # (*pts_base_shape,)
+    all_multi_indices = sorted(iproduct(*[range(od + 1) for od in orders_tuple]), key=sum)
+
+    for k_idx in all_multi_indices:
+        hom_N_k = hom_all[(Ellipsis,) + k_idx + (slice(None),)][..., :-1]  # noqa: RUF005
+        v: npt.NDArray[np.float32 | np.float64] = hom_N_k.copy()
+        for i_idx in all_multi_indices:
+            if i_idx == zero_idx:
+                continue
+            if sum(i_idx) > sum(k_idx):
+                break
+            if not all(i_idx[d] <= k_idx[d] for d in range(dim)):
+                continue
+            coeff = 1
+            for d in range(dim):
+                coeff *= math.comb(k_idx[d], i_idx[d])
+            hom_W_i = hom_all[(Ellipsis,) + i_idx + (-1,)]  # noqa: RUF005
+            k_minus_i = tuple(k_idx[d] - i_idx[d] for d in range(dim))
+            res_km_i = result_all[(Ellipsis,) + k_minus_i + (slice(None),)]  # noqa: RUF005
+            v = v - coeff * hom_W_i[..., np.newaxis] * res_km_i
+        result_all[(Ellipsis,) + k_idx + (slice(None),)] = v / W[..., np.newaxis]  # noqa: RUF005
+
+    return result_all
+
+
+def _evaluate_Bspline_deriv_multi_dim_rational(
+    spline: Bspline,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    orders_tuple: tuple[int, ...],
+    pts_base_shape: tuple[int, ...],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate a partial derivative of a rational multi-dimensional B-spline.
+
+    Builds the homogeneous derivative tensor via :func:`_build_hom_all_multi_dim`
+    and applies the generalised quotient rule via :func:`_apply_quotient_rule_multi_dim`.
+
+    Args:
+        spline (Bspline): The rational B-spline.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation points.
+        orders_tuple (tuple[int, ...]): Derivative order per parametric direction.
+        pts_base_shape (tuple[int, ...]): Leading shape of the output
+            (``(n_pts,)`` or ``(*grid_shape,)``).
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
+            output array. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values. Shape is
+        ``(*pts_base_shape,)`` for scalar or ``(*pts_base_shape, rank)`` for vector.
+    """
+    dtype = spline.dtype
+    hom_all = _build_hom_all_multi_dim(spline, pts, orders_tuple, pts_base_shape)
+    result_all = _apply_quotient_rule_multi_dim(hom_all, orders_tuple, pts_base_shape, dtype)
+
+    final: npt.NDArray[np.float32 | np.float64] = result_all[
+        (Ellipsis,) + orders_tuple + (slice(None),)  # noqa: RUF005
+    ]
+    rank_value = spline.control_points.shape[-1] - 1
+    if rank_value == 1:
+        final = final[..., 0]
+    if out is not None:
+        _validate_out_array_1D(out, final.shape, dtype)
+        out[:] = final
+        return out
+    return final
+
+
+def _evaluate_Bspline_deriv_multi_dim_non_rational(
+    spline: Bspline,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    orders_tuple: tuple[int, ...],
+    pts_base_shape: tuple[int, ...],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate a partial derivative of a non-rational multi-dimensional B-spline.
+
+    Delegates directly to :func:`_evaluate_Bspline_deriv_multi_dim_lattice` or
+    :func:`_evaluate_Bspline_deriv_multi_dim_pts_array` and squeezes the last axis
+    for scalar (``cp_size == 1``) output.
+
+    Args:
+        spline (Bspline): The non-rational B-spline.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation points.
+        orders_tuple (tuple[int, ...]): Derivative order per parametric direction.
+        pts_base_shape (tuple[int, ...]): Leading shape of the output.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
+            output array. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values. Shape is
+        ``(*pts_base_shape,)`` for scalar or ``(*pts_base_shape, rank)`` for vector.
+    """
+    dtype = spline.dtype
+    cp = spline.control_points
+    cp_size = cp.shape[-1]
+    out_shape = (*pts_base_shape, cp_size)
+
+    def _call_kernel(buf: npt.NDArray[np.float32 | np.float64]) -> None:
+        spaces = spline.space.spaces
+        if isinstance(pts, PointsLattice):
+            _evaluate_Bspline_deriv_multi_dim_lattice(cp, spaces, pts, orders_tuple, buf)
+        else:
+            _evaluate_Bspline_deriv_multi_dim_pts_array(cp, spaces, pts, orders_tuple, buf)
+
+    if cp_size == 1:
+        buf: npt.NDArray[np.float32 | np.float64] = np.empty(out_shape, dtype=dtype)
+        _call_kernel(buf)
+        final_nd: npt.NDArray[np.float32 | np.float64] = buf[..., 0]
+        if out is not None:
+            _validate_out_array_1D(out, final_nd.shape, dtype)
+            out[:] = final_nd
+            return out
+        return final_nd
+
+    # Vector: out shape matches kernel output directly.
+    if out is None:
+        buf = np.empty(out_shape, dtype=dtype)
+    else:
+        _validate_out_array_1D(out, out_shape, dtype)
+        buf = out
+    _call_kernel(buf)
+    return buf
+
+
+def _evaluate_Bspline_deriv_multi_dim(
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
     orders: Sequence[int],
@@ -496,10 +758,7 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Evaluate a partial derivative of a multi-dimensional B-spline.
 
-    Computes the single partial derivative specified by ``orders``, where
-    ``orders[d]`` is the derivative order in parametric direction ``d``. For
-    rational B-splines the generalised quotient rule is applied so that the
-    result is the derivative of the projected (inhomogeneous) mapping.
+    Validates inputs and dispatches to the rational or non-rational implementation.
 
     Args:
         spline (Bspline): A multi-dimensional B-spline (``dim >= 2``).
@@ -512,7 +771,7 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
             output array whose shape matches the return value. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Mixed partial derivative values.
+        npt.NDArray[np.float32 | np.float64]: Partial derivative values.
         Shape is ``(*pts_base_shape,)`` for scalar output or
         ``(*pts_base_shape, rank)`` for vector-valued output, where
         ``pts_base_shape`` is ``(n_pts,)`` for a points array or
@@ -534,9 +793,6 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
             raise ValueError(f"orders[{d}] must be >= 0, got {od}")
 
     dtype = spline.dtype
-    cp = spline.control_points
-    cp_size = cp.shape[-1]
-
     pts_base_shape: tuple[int, ...]
     if isinstance(pts, PointsLattice):
         if pts.dim != dim:
@@ -553,167 +809,13 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
             raise ValueError("Points dtype must match B-spline dtype")
         pts_base_shape = (pts.shape[0],)
 
-    out_shape = (*pts_base_shape, cp_size)
-
     if spline.is_rational:
-        # For the generalised quotient rule we need all partial derivatives
-        # hom[i] for multi-indices 0 <= i[d] <= orders[d].
-        # hom_all shape: (*pts_base_shape, orders[0]+1, ..., orders[D-1]+1, cp_size)
-        hom_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), cp_size)
-        hom_all: npt.NDArray[np.float32 | np.float64] = np.empty(hom_shape, dtype=dtype)
-
-        if isinstance(pts, PointsLattice):
-            # Precompute per-direction basis derivatives.
-            dBs_lat: list[npt.NDArray[np.float32 | np.float64]] = []
-            first_idxs_lat: list[npt.NDArray[np.int_]] = []
-            max_order = max(orders_tuple, default=0)
-            for space_d, pts_d in zip(spline.space.spaces, pts.pts_per_dir, strict=True):
-                dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, max_order)
-                dBs_lat.append(dB_d)
-                first_idxs_lat.append(first_d)
-            for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
-                # Sequential contraction for this multi-index.
-                current: npt.NDArray[np.float32 | np.float64] = cp
-                for d, (dB_d, first_d, space_d) in enumerate(
-                    zip(dBs_lat, first_idxs_lat, spline.space.spaces, strict=True)
-                ):
-                    B_d = dB_d[:, multi_idx[d], :]  # (m_d, degree_d+1)
-                    m_d = int(B_d.shape[0])
-                    order_d = int(B_d.shape[1])
-                    idx_d = (
-                        first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
-                    )
-                    if space_d.periodic:
-                        idx_d = idx_d % space_d.num_basis
-                    current_moved = np.moveaxis(current, d, 0)
-                    gathered = current_moved[idx_d]
-                    n_trail = gathered.ndim - 2
-                    B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
-                    contracted = (gathered * B_exp).sum(axis=1)
-                    current = np.moveaxis(contracted, 0, d)
-                hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = current  # noqa: RUF005
-        else:
-            # Precompute per-direction basis derivatives and gather cp_local once.
-            dBs_pts: list[npt.NDArray[np.float32 | np.float64]] = []
-            first_idxs_pts: list[npt.NDArray[np.int_]] = []
-            for d, space_d in enumerate(spline.space.spaces):
-                dB_d, first_d = space_d.tabulate_basis_derivatives(
-                    np.ascontiguousarray(pts[:, d]), orders_tuple[d]
-                )
-                dBs_pts.append(dB_d)
-                first_idxs_pts.append(first_d)
-            n_pts = pts.shape[0]
-            basis_orders_pts = tuple(int(dB.shape[2]) for dB in dBs_pts)
-            index_list_pts: list[npt.NDArray[np.intp]] = []
-            for d, (first_d, space_d) in enumerate(
-                zip(first_idxs_pts, spline.space.spaces, strict=True)
-            ):
-                order_d = basis_orders_pts[d]
-                idx_d = (
-                    first_d[:, np.newaxis].astype(np.intp)
-                    + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
-                )
-                if space_d.periodic:
-                    idx_d = idx_d % space_d.num_basis
-                s: tuple[int, ...] = (n_pts,) + (1,) * d + (order_d,) + (1,) * (dim - d - 1)
-                index_list_pts.append(idx_d.reshape(s))
-            idx_tup: tuple[npt.NDArray[np.intp] | slice, ...] = (
-                *tuple(index_list_pts),
-                slice(None),
-            )
-            cp_local: npt.NDArray[np.float32 | np.float64] = cp[idx_tup]
-            total_local = int(np.prod(basis_orders_pts))
-            cp_flat = cp_local.reshape(n_pts, total_local, cp_size)
-            for multi_idx in iproduct(*[range(od + 1) for od in orders_tuple]):
-                w: npt.NDArray[np.float32 | np.float64] = dBs_pts[0][:, multi_idx[0], :].reshape(
-                    (n_pts, basis_orders_pts[0]) + (1,) * (dim - 1)
-                )
-                for d in range(1, dim):
-                    ws: tuple[int, ...] = (
-                        (n_pts,) + (1,) * d + (basis_orders_pts[d],) + (1,) * (dim - d - 1)
-                    )
-                    w = w * dBs_pts[d][:, multi_idx[d], :].reshape(ws)
-                w_flat = w.reshape(n_pts, total_local)
-                hom_all[(Ellipsis,) + multi_idx + (slice(None),)] = (  # noqa: RUF005
-                    (cp_flat * w_flat[..., np.newaxis]).sum(axis=1)
-                )
-
-        # Generalised quotient rule (ascending total-order iteration).
-        rank_value = cp_size - 1
-        result_shape_rat = (*pts_base_shape, *(od + 1 for od in orders_tuple), rank_value)
-        result_all: npt.NDArray[np.float32 | np.float64] = np.empty(result_shape_rat, dtype=dtype)
-        zero_idx = (0,) * dim
-        W = hom_all[(Ellipsis,) + zero_idx + (-1,)]  # noqa: RUF005  # (*pts_base_shape,)
-
-        all_multi_indices = sorted(iproduct(*[range(od + 1) for od in orders_tuple]), key=sum)
-        for k_idx in all_multi_indices:
-            hom_N_k = hom_all[(Ellipsis,) + k_idx + (slice(None),)][..., :-1]  # noqa: RUF005
-            v: npt.NDArray[np.float32 | np.float64] = hom_N_k.copy()
-            for i_idx in all_multi_indices:
-                if i_idx == zero_idx:
-                    continue
-                if sum(i_idx) > sum(k_idx):
-                    break
-                if not all(i_idx[d] <= k_idx[d] for d in range(dim)):
-                    continue
-                coeff = 1
-                for d in range(dim):
-                    coeff *= math.comb(k_idx[d], i_idx[d])
-                hom_W_i = hom_all[(Ellipsis,) + i_idx + (-1,)]  # noqa: RUF005
-                k_minus_i = tuple(k_idx[d] - i_idx[d] for d in range(dim))
-                res_km_i = result_all[(Ellipsis,) + k_minus_i + (slice(None),)]  # noqa: RUF005
-                v = v - coeff * hom_W_i[..., np.newaxis] * res_km_i
-            result_all[(Ellipsis,) + k_idx + (slice(None),)] = v / W[..., np.newaxis]  # noqa: RUF005
-
-        final_rat: npt.NDArray[np.float32 | np.float64] = result_all[
-            (Ellipsis,) + orders_tuple + (slice(None),)  # noqa: RUF005
-        ]
-        if rank_value == 1:
-            final_rat = final_rat[..., 0]
-        if out is not None:
-            _validate_out_array_1D(out, final_rat.shape, dtype)
-            out[:] = final_rat
-            return out
-        return final_rat
-
-    # Non-rational: extract specific derivative row directly.
-    # Kernel always writes to (*pts_base_shape, cp_size); out matches the final
-    # squeezed shape ((*pts_base_shape,) for scalar, (*pts_base_shape, rank) for vector).
-    buf: npt.NDArray[np.float32 | np.float64]
-    final_nd: npt.NDArray[np.float32 | np.float64]
-    if cp_size == 1:
-        # Scalar: allocate internal buf; out must be (*pts_base_shape,)
-        buf = np.empty(out_shape, dtype=dtype)
-        if isinstance(pts, PointsLattice):
-            _evaluate_Bspline_deriv_multi_dim_lattice(
-                cp, spline.space.spaces, pts, orders_tuple, buf
-            )
-        else:
-            _evaluate_Bspline_deriv_multi_dim_pts_array(
-                cp, spline.space.spaces, pts, orders_tuple, buf
-            )
-        final_nd = buf[..., 0]
-        if out is not None:
-            _validate_out_array_1D(out, final_nd.shape, dtype)
-            out[:] = final_nd
-            return out
-        return final_nd
-    else:
-        # Vector: out has same shape as buf; pass directly to kernel if provided.
-        if out is None:
-            buf = np.empty(out_shape, dtype=dtype)
-        else:
-            _validate_out_array_1D(out, out_shape, dtype)
-            buf = out
-        if isinstance(pts, PointsLattice):
-            _evaluate_Bspline_deriv_multi_dim_lattice(
-                cp, spline.space.spaces, pts, orders_tuple, buf
-            )
-        else:
-            _evaluate_Bspline_deriv_multi_dim_pts_array(
-                cp, spline.space.spaces, pts, orders_tuple, buf
-            )
-        return buf
+        return _evaluate_Bspline_deriv_multi_dim_rational(
+            spline, pts, orders_tuple, pts_base_shape, out
+        )
+    return _evaluate_Bspline_deriv_multi_dim_non_rational(
+        spline, pts, orders_tuple, pts_base_shape, out
+    )
 
 
 def _evaluate_Bspline_deriv(

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -365,9 +365,9 @@ def _evaluate_Bspline_deriv_multi_dim_pts_array(
     orders: tuple[int, ...],
     out: npt.NDArray[np.float32 | np.float64],
 ) -> None:
-    """Evaluate a mixed partial derivative of a multi-dimensional B-spline at points.
+    """Evaluate a partial derivative of a multi-dimensional B-spline at points.
 
-    Computes the mixed partial derivative of orders ``orders[d]`` in each direction
+    Computes the partial derivative of orders ``orders[d]`` in each direction
     ``d`` for all evaluation points simultaneously. Uses outer-product contraction
     with the appropriate derivative basis row for each direction.
 
@@ -439,9 +439,9 @@ def _evaluate_Bspline_deriv_multi_dim_lattice(
     orders: tuple[int, ...],
     out: npt.NDArray[np.float32 | np.float64],
 ) -> None:
-    """Evaluate a mixed partial derivative of a multi-dimensional B-spline on a lattice.
+    """Evaluate a partial derivative of a multi-dimensional B-spline on a lattice.
 
-    Computes the mixed partial derivative of orders ``orders[d]`` in each direction
+    Computes the partial derivative of orders ``orders[d]`` in each direction
     ``d`` via sequential contraction, using the appropriate derivative basis row for
     each direction.
 
@@ -496,9 +496,9 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
     orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Evaluate a mixed partial derivative of a multi-dimensional B-spline.
+    """Evaluate a partial derivative of a multi-dimensional B-spline.
 
-    Computes the single mixed partial derivative specified by ``orders``, where
+    Computes the single partial derivative specified by ``orders``, where
     ``orders[d]`` is the derivative order in parametric direction ``d``. For
     rational B-splines the generalised quotient rule is applied so that the
     result is the derivative of the projected (inhomogeneous) mapping.
@@ -558,7 +558,7 @@ def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912, PLR0915
     out_shape = (*pts_base_shape, cp_size)
 
     if spline.is_rational:
-        # For the generalised quotient rule we need all mixed derivatives
+        # For the generalised quotient rule we need all partial derivatives
         # hom[i] for multi-indices 0 <= i[d] <= orders[d].
         # hom_all shape: (*pts_base_shape, orders[0]+1, ..., orders[D-1]+1, cp_size)
         hom_shape = (*pts_base_shape, *(od + 1 for od in orders_tuple), cp_size)

--- a/src/pantr/_bspline_eval.py
+++ b/src/pantr/_bspline_eval.py
@@ -346,6 +346,267 @@ def _evaluate_Bspline_deriv_1D(  # noqa: PLR0912
     return out_array[:, :, 0] if cp_size == 1 else out_array
 
 
+def _evaluate_Bspline_deriv_multi_dim_pts_array(
+    cp: npt.NDArray[np.float32 | np.float64],
+    spaces_1D: tuple[BsplineSpace1D, ...],
+    pts: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate multi-dimensional B-spline partial derivatives at an array of points.
+
+    For each combination of derivative order ``k`` and parametric direction
+    ``d``, the outer-product weights are formed using the ``k``-th derivative
+    basis row for direction ``d`` and the 0th (value) row for every other
+    direction.  The gathered local control-point patch is then contracted with
+    these weights and stored in ``out[:, k, d, :]``.
+
+    Args:
+        cp (npt.NDArray[np.float32 | np.float64]): Control-point array of shape
+            ``(*num_basis, cp_size)``.
+        spaces_1D (tuple[BsplineSpace1D, ...]): 1D B-spline spaces, one per direction.
+        pts (npt.NDArray[np.float32 | np.float64]): Evaluation points of shape
+            ``(n_pts, dim)``.
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array of
+            shape ``(n_pts, n_deriv+1, dim, cp_size)`` and matching dtype.
+            Filled in-place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_evaluate_Bspline_deriv_multi_dim` instead.
+    """
+    dim = len(spaces_1D)
+    n_pts = pts.shape[0]
+
+    dBs: list[npt.NDArray[np.float32 | np.float64]] = []
+    first_idxs: list[npt.NDArray[np.int_]] = []
+    for d, space_d in enumerate(spaces_1D):
+        dB_d, first_d = space_d.tabulate_basis_derivatives(np.ascontiguousarray(pts[:, d]), n_deriv)
+        dBs.append(dB_d)  # (n_pts, n_deriv+1, order_d)
+        first_idxs.append(first_d)
+
+    orders = tuple(int(dB.shape[2]) for dB in dBs)
+
+    # Build advanced index arrays (identical to _evaluate_Bspline_multi_dim_pts_array).
+    index_list: list[npt.NDArray[np.intp]] = []
+    for d, (first_d, space_d) in enumerate(zip(first_idxs, spaces_1D, strict=True)):
+        order_d = orders[d]
+        idx_d = (
+            first_d[:, np.newaxis].astype(np.intp)
+            + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+        )  # (n_pts, order_d)
+        if space_d.periodic:
+            idx_d = idx_d % space_d.num_basis
+        shape: tuple[int, ...] = (n_pts,) + (1,) * d + (order_d,) + (1,) * (dim - d - 1)
+        index_list.append(idx_d.reshape(shape))
+
+    # Gather local control-point patch.
+    idx_with_last: tuple[npt.NDArray[np.intp] | slice, ...] = (*tuple(index_list), slice(None))
+    cp_local: npt.NDArray[np.float32 | np.float64] = cp[idx_with_last]
+    # shape: (n_pts, order_0, ..., order_{D-1}, cp_size)
+
+    total_local = int(np.prod(orders))
+    cp_flat = cp_local.reshape(n_pts, total_local, cp.shape[-1])
+
+    for k in range(n_deriv + 1):
+        for d_deriv in range(dim):
+            # Direction d_deriv uses its k-th derivative row; all others use row 0.
+            weights: npt.NDArray[np.float32 | np.float64] = dBs[0][
+                :, k if d_deriv == 0 else 0, :
+            ].reshape((n_pts, orders[0]) + (1,) * (dim - 1))
+            for d in range(1, dim):
+                k_d = k if d == d_deriv else 0
+                w_shape: tuple[int, ...] = (n_pts,) + (1,) * d + (orders[d],) + (1,) * (dim - d - 1)
+                weights = weights * dBs[d][:, k_d, :].reshape(w_shape)
+            weights_flat = weights.reshape(n_pts, total_local)
+            out[:, k, d_deriv, :] = (cp_flat * weights_flat[..., np.newaxis]).sum(axis=1)
+
+
+def _evaluate_Bspline_deriv_multi_dim_lattice(
+    cp: npt.NDArray[np.float32 | np.float64],
+    spaces_1D: tuple[BsplineSpace1D, ...],
+    pts: PointsLattice,
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate multi-dimensional B-spline partial derivatives on a point lattice.
+
+    For each combination of derivative order ``k`` and parametric direction
+    ``d_deriv``, performs one sequential contraction of the control-point tensor
+    using the ``k``-th derivative basis row for direction ``d_deriv`` and the
+    0th (value) row for all other directions.  The result is stored in
+    ``out[..., k, d_deriv, :]``.
+
+    Args:
+        cp (npt.NDArray[np.float32 | np.float64]): Control-point array of shape
+            ``(*num_basis, cp_size)``.
+        spaces_1D (tuple[BsplineSpace1D, ...]): 1D B-spline spaces, one per direction.
+        pts (PointsLattice): Evaluation lattice. ``pts.dim`` must equal
+            ``len(spaces_1D)``.
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array of
+            shape ``(*pts_grid_shape, n_deriv+1, dim, cp_size)`` and matching
+            dtype.  Filled in-place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_evaluate_Bspline_deriv_multi_dim` instead.
+    """
+    dBs: list[npt.NDArray[np.float32 | np.float64]] = []
+    first_idxs: list[npt.NDArray[np.int_]] = []
+    for space_d, pts_d in zip(spaces_1D, pts.pts_per_dir, strict=True):
+        dB_d, first_d = space_d.tabulate_basis_derivatives(pts_d, n_deriv)
+        dBs.append(dB_d)  # (m_d, n_deriv+1, order_d)
+        first_idxs.append(first_d)
+
+    dim = len(spaces_1D)
+
+    for k in range(n_deriv + 1):
+        for d_deriv in range(dim):
+            current: npt.NDArray[np.float32 | np.float64] = cp
+            for d, (dB_d, first_d, space_d) in enumerate(
+                zip(dBs, first_idxs, spaces_1D, strict=True)
+            ):
+                k_d = k if d == d_deriv else 0
+                B_d = dB_d[:, k_d, :]  # (m_d, order_d)
+                m_d = int(B_d.shape[0])
+                order_d = int(B_d.shape[1])
+
+                idx_d = (
+                    first_d[:, np.newaxis] + np.arange(order_d, dtype=np.intp)[np.newaxis, :]
+                )  # (m_d, order_d)
+                if space_d.periodic:
+                    idx_d = idx_d % space_d.num_basis
+
+                current_moved = np.moveaxis(current, d, 0)
+                gathered_moved: npt.NDArray[np.float32 | np.float64] = current_moved[idx_d]
+
+                n_trail = gathered_moved.ndim - 2
+                B_exp = B_d.reshape((m_d, order_d) + (1,) * n_trail)
+                contracted: npt.NDArray[np.float32 | np.float64] = (gathered_moved * B_exp).sum(
+                    axis=1
+                )
+                current = np.moveaxis(contracted, 0, d)
+
+            out[..., k, d_deriv, :] = current
+
+
+def _evaluate_Bspline_deriv_multi_dim(  # noqa: PLR0912
+    spline: Bspline,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate partial derivatives of a multi-dimensional B-spline.
+
+    Computes all partial derivatives up to order ``n_deriv`` in each parametric
+    direction.  For rational B-splines the quotient rule (Algorithm A4.2 from
+    Piegl & Tiller) is applied independently per direction so that the result
+    is the derivative of the projected (inhomogeneous) mapping.
+
+    Args:
+        spline (Bspline): A multi-dimensional B-spline (``dim >= 2``).
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+            points.  Either a 2-D array of shape ``(n_pts, dim)`` or a
+            :class:`~pantr.quad.PointsLattice`.
+        n_deriv (int): Maximum derivative order to compute.  Must be >= 0.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
+            output array whose shape matches the return value described below.
+            Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Shape
+        ``(*pts_shape, n_deriv+1, dim)`` for scalar output or
+        ``(*pts_shape, n_deriv+1, dim, rank)`` for vector-valued output, where
+        ``pts_shape`` is ``(n_pts,)`` for a points array or
+        ``(*pts_grid_shape,)`` for a :class:`~pantr.quad.PointsLattice`.
+        Axis ``-2`` indexes derivative order (0 = value, 1 = first, …) and
+        axis ``-1`` (before the optional rank axis) indexes parametric
+        direction. For rational B-splines the weight column is divided out
+        and not included in the output.
+
+    Raises:
+        ValueError: If ``n_deriv < 0``, if the pts dimension or dtype does not
+            match the B-spline, or if ``out`` has an incorrect shape or dtype.
+    """
+    if n_deriv < 0:
+        raise ValueError(f"n_deriv must be >= 0, got {n_deriv}")
+
+    dim = spline.dim
+    dtype = spline.dtype
+    cp = spline.control_points
+    cp_size = cp.shape[-1]
+
+    pts_base_shape: tuple[int, ...]
+    if isinstance(pts, PointsLattice):
+        if pts.dim != dim:
+            raise ValueError(
+                f"Points lattice dimension {pts.dim} does not match B-spline dimension {dim}"
+            )
+        if pts.dtype != dtype:
+            raise ValueError("Points dtype must match B-spline dtype")
+        pts_base_shape = tuple(int(p.shape[0]) for p in pts.pts_per_dir)
+    else:
+        if pts.ndim != 2 or pts.shape[1] != dim:  # noqa: PLR2004
+            raise ValueError(f"pts must be a 2D array with {dim} columns")
+        if pts.dtype != dtype:
+            raise ValueError("Points dtype must match B-spline dtype")
+        pts_base_shape = (pts.shape[0],)
+
+    hom_shape = (*pts_base_shape, n_deriv + 1, dim, cp_size)
+
+    if spline.is_rational:
+        hom_array = np.empty(hom_shape, dtype=dtype)
+        if isinstance(pts, PointsLattice):
+            _evaluate_Bspline_deriv_multi_dim_lattice(
+                cp, spline.space.spaces, pts, n_deriv, hom_array
+            )
+        else:
+            _evaluate_Bspline_deriv_multi_dim_pts_array(
+                cp, spline.space.spaces, pts, n_deriv, hom_array
+            )
+
+        rank_value = cp_size - 1
+        result_shape = (*pts_base_shape, n_deriv + 1, dim, rank_value)
+        result: npt.NDArray[np.float32 | np.float64]
+        if out is None:
+            result = np.empty(result_shape, dtype=dtype)
+        else:
+            _validate_out_array_1D(out, result_shape, dtype)
+            result = out
+
+        for d_deriv in range(dim):
+            for k in range(n_deriv + 1):
+                v = hom_array[..., k, d_deriv, :-1].copy()
+                for i in range(1, k + 1):
+                    v -= (
+                        math.comb(k, i)
+                        * hom_array[..., i, d_deriv, -1:]
+                        * result[..., k - i, d_deriv, :]
+                    )
+                result[..., k, d_deriv, :] = v / hom_array[..., 0, d_deriv, -1:]
+
+        return result[..., 0] if rank_value == 1 else result
+
+    # Non-rational
+    out_array: npt.NDArray[np.float32 | np.float64]
+    if out is None:
+        out_array = np.empty(hom_shape, dtype=dtype)
+    else:
+        _validate_out_array_1D(out, hom_shape, dtype)
+        out_array = out
+
+    if isinstance(pts, PointsLattice):
+        _evaluate_Bspline_deriv_multi_dim_lattice(cp, spline.space.spaces, pts, n_deriv, out_array)
+    else:
+        _evaluate_Bspline_deriv_multi_dim_pts_array(
+            cp, spline.space.spaces, pts, n_deriv, out_array
+        )
+
+    return out_array[..., 0] if cp_size == 1 else out_array
+
+
 def _evaluate_Bspline_deriv(
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
@@ -364,14 +625,11 @@ def _evaluate_Bspline_deriv(
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Derivative values at the given points.
-
-    Raises:
-        NotImplementedError: If the B-spline dimension is not 1.
     """
     if spline.dim == 1:
         return _evaluate_Bspline_deriv_1D(spline, pts, n_deriv, out)
     else:
-        raise NotImplementedError("evaluate_derivatives is not implemented for dim > 1")
+        return _evaluate_Bspline_deriv_multi_dim(spline, pts, n_deriv, out)
 
 
 def _evaluate_Bspline_multi_dim_lattice(

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -178,9 +178,9 @@ class Bspline:
         orders: Sequence[int],
         out: npt.NDArray[np.float32 | np.float64] | None = None,
     ) -> npt.NDArray[np.float32 | np.float64]:
-        """Evaluate a specific mixed partial derivative of the B-spline.
+        """Evaluate a specific partial derivative of the B-spline.
 
-        Computes the single mixed partial derivative specified by ``orders``,
+        Computes the single partial derivative specified by ``orders``,
         where ``orders[d]`` is the derivative order in parametric direction ``d``.
         For rational B-splines the generalised quotient rule is applied so that
         the returned values are derivatives of the projected mapping.
@@ -219,7 +219,7 @@ class Bspline:
         Example:
             >>> # 1D: second derivative
             >>> result = spline.evaluate_derivatives(pts, [2])
-            >>> # 2D: mixed derivative ∂²f/∂u ∂v²
+            >>> # 2D: partial derivative ∂²f/∂u ∂v²
             >>> result = spline.evaluate_derivatives(pts, [1, 2])
         """
         return _evaluate_Bspline_deriv(self, pts, orders, out)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -219,7 +219,7 @@ class Bspline:
         Example:
             >>> # 1D: second derivative
             >>> result = spline.evaluate_derivatives(pts, [2])
-            >>> # 2D: partial derivative ∂²f/∂u ∂v²
+            >>> # 2D: partial derivative ∂³f/∂u ∂v²
             >>> result = spline.evaluate_derivatives(pts, [1, 2])
         """
         return _evaluate_Bspline_deriv(self, pts, orders, out)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -8,6 +8,7 @@ is dispatched to the de Boor algorithm implemented in ``_bspline_eval``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -174,19 +175,15 @@ class Bspline:
     def evaluate_derivatives(
         self,
         pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-        n_deriv: int,
+        orders: Sequence[int],
         out: npt.NDArray[np.float32 | np.float64] | None = None,
     ) -> npt.NDArray[np.float32 | np.float64]:
-        """Evaluate B-spline derivatives up to order ``n_deriv`` at the given points.
+        """Evaluate a specific mixed partial derivative of the B-spline.
 
-        Computes all derivatives from order 0 (the value itself) through order
-        ``n_deriv`` at each evaluation point. Derivatives of order higher than
-        the polynomial degree are identically zero.
-
-        For rational B-splines the quotient rule (Algorithm A4.2 from Piegl &
-        Tiller, *The NURBS Book*) is applied so that the returned values are
-        derivatives of the geometrically projected curve, not of the homogeneous
-        representation.
+        Computes the single mixed partial derivative specified by ``orders``,
+        where ``orders[d]`` is the derivative order in parametric direction ``d``.
+        For rational B-splines the generalised quotient rule is applied so that
+        the returned values are derivatives of the projected mapping.
 
         Args:
             pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
@@ -196,8 +193,9 @@ class Bspline:
                 B-splines, must be a 2D array of shape ``(n_pts, dim)`` or a
                 :class:`~pantr.quad.PointsLattice` with matching dimension.
                 The dtype must match the B-spline dtype.
-            n_deriv (int): Maximum derivative order to compute. Must be >= 0.
-                Pass 0 to obtain just the values (equivalent to
+            orders (Sequence[int]): One non-negative integer per parametric
+                direction. ``len(orders)`` must equal ``self.dim``. Pass
+                ``[0, ..., 0]`` to obtain the function value (equivalent to
                 :meth:`evaluate`).
             out (npt.NDArray[np.float32 | np.float64] | None): Optional
                 pre-allocated output array with the same shape and dtype as the
@@ -205,22 +203,23 @@ class Bspline:
                 Defaults to None.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: For 1D B-splines, shape
-            ``(n_pts, n_deriv+1)`` for scalar output or
-            ``(n_pts, n_deriv+1, rank)`` for vector-valued output. For
-            multi-dimensional B-splines, shape
-            ``(*pts_shape, n_deriv+1, dim)`` for scalar output or
-            ``(*pts_shape, n_deriv+1, dim, rank)`` for vector-valued output,
-            where ``pts_shape`` is ``(n_pts,)`` for a points array or
+            npt.NDArray[np.float32 | np.float64]: Mixed partial derivative
+            values. Shape is ``(*pts_base_shape,)`` for scalar output or
+            ``(*pts_base_shape, rank)`` for vector-valued output, where
+            ``pts_base_shape`` is ``(n_pts,)`` for a points array or
             ``(*pts_grid_shape,)`` for a :class:`~pantr.quad.PointsLattice`.
-            Axis ``-2`` indexes derivative order (0 = value, 1 = first
-            derivative, …) and for multi-dimensional B-splines axis ``-1``
-            (before the optional rank axis) indexes parametric direction.
             For rational B-splines the weight column is divided out and not
             included in the output.
 
         Raises:
-            ValueError: If ``n_deriv < 0``, if the points dtype does not match
-                the B-spline dtype, or if ``out`` has incorrect shape or dtype.
+            ValueError: If ``len(orders) != self.dim``, if any order is
+                negative, if the points dtype does not match the B-spline dtype,
+                or if ``out`` has incorrect shape or dtype.
+
+        Example:
+            >>> # 1D: second derivative
+            >>> result = spline.evaluate_derivatives(pts, [2])
+            >>> # 2D: mixed derivative ∂²f/∂u ∂v²
+            >>> result = spline.evaluate_derivatives(pts, [1, 2])
         """
-        return _evaluate_Bspline_deriv(self, pts, n_deriv, out)
+        return _evaluate_Bspline_deriv(self, pts, orders, out)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -175,7 +175,7 @@ class Bspline:
     def evaluate_derivatives(
         self,
         pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
-        orders: Sequence[int],
+        orders: int | Sequence[int],
         out: npt.NDArray[np.float32 | np.float64] | None = None,
     ) -> npt.NDArray[np.float32 | np.float64]:
         """Evaluate a specific partial derivative of the B-spline.
@@ -193,10 +193,11 @@ class Bspline:
                 B-splines, must be a 2D array of shape ``(n_pts, dim)`` or a
                 :class:`~pantr.quad.PointsLattice` with matching dimension.
                 The dtype must match the B-spline dtype.
-            orders (Sequence[int]): One non-negative integer per parametric
-                direction. ``len(orders)`` must equal ``self.dim``. Pass
-                ``[0, ..., 0]`` to obtain the function value (equivalent to
-                :meth:`evaluate`).
+            orders (int | Sequence[int]): Derivative order(s). A single
+                ``int`` is broadcast to all ``self.dim`` directions. A sequence
+                must contain one non-negative integer per parametric direction
+                (``len(orders) == self.dim``). Pass ``0`` (or ``[0, ..., 0]``)
+                to obtain the function value (equivalent to :meth:`evaluate`).
             out (npt.NDArray[np.float32 | np.float64] | None): Optional
                 pre-allocated output array with the same shape and dtype as the
                 returned array (see below). Filled in-place and returned.
@@ -217,9 +218,12 @@ class Bspline:
                 or if ``out`` has incorrect shape or dtype.
 
         Example:
-            >>> # 1D: second derivative
+            >>> # 1D: second derivative (int shorthand)
+            >>> result = spline.evaluate_derivatives(pts, 2)
+            >>> # 1D: second derivative (sequence form)
             >>> result = spline.evaluate_derivatives(pts, [2])
             >>> # 2D: partial derivative ∂³f/∂u ∂v²
             >>> result = spline.evaluate_derivatives(pts, [1, 2])
         """
-        return _evaluate_Bspline_deriv(self, pts, orders, out)
+        orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
+        return _evaluate_Bspline_deriv(self, pts, orders_seq, out)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -190,10 +190,12 @@ class Bspline:
 
         Args:
             pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
-                parametric points at which to evaluate. If a
-                :class:`~pantr.quad.PointsLattice`, must be 1D. Otherwise must
-                be a 1D array of shape ``(n_pts,)`` with dtype matching the
-                B-spline.
+                parametric points at which to evaluate. For 1D B-splines, must
+                be a 1D array of shape ``(n_pts,)`` or a 1D
+                :class:`~pantr.quad.PointsLattice`. For multi-dimensional
+                B-splines, must be a 2D array of shape ``(n_pts, dim)`` or a
+                :class:`~pantr.quad.PointsLattice` with matching dimension.
+                The dtype must match the B-spline dtype.
             n_deriv (int): Maximum derivative order to compute. Must be >= 0.
                 Pass 0 to obtain just the values (equivalent to
                 :meth:`evaluate`).
@@ -203,15 +205,22 @@ class Bspline:
                 Defaults to None.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: Shape ``(n_pts, n_deriv+1)``
-            for scalar output or ``(n_pts, n_deriv+1, rank)`` for vector-valued
-            output, where axis 1 indexes derivative order (0 = value, 1 = first
-            derivative, …). For rational B-splines the weight column is divided
-            out and not included in the output.
+            npt.NDArray[np.float32 | np.float64]: For 1D B-splines, shape
+            ``(n_pts, n_deriv+1)`` for scalar output or
+            ``(n_pts, n_deriv+1, rank)`` for vector-valued output. For
+            multi-dimensional B-splines, shape
+            ``(*pts_shape, n_deriv+1, dim)`` for scalar output or
+            ``(*pts_shape, n_deriv+1, dim, rank)`` for vector-valued output,
+            where ``pts_shape`` is ``(n_pts,)`` for a points array or
+            ``(*pts_grid_shape,)`` for a :class:`~pantr.quad.PointsLattice`.
+            Axis ``-2`` indexes derivative order (0 = value, 1 = first
+            derivative, …) and for multi-dimensional B-splines axis ``-1``
+            (before the optional rank axis) indexes parametric direction.
+            For rational B-splines the weight column is divided out and not
+            included in the output.
 
         Raises:
             ValueError: If ``n_deriv < 0``, if the points dtype does not match
                 the B-spline dtype, or if ``out`` has incorrect shape or dtype.
-            NotImplementedError: If the B-spline dimension is greater than 1.
         """
         return _evaluate_Bspline_deriv(self, pts, n_deriv, out)

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -525,14 +525,14 @@ class TestBsplineEvaluateDerivatives:
     # ------------------------------------------------------------------
 
     def test_n_deriv_0_matches_evaluate(self) -> None:
-        """evaluate_derivatives with n_deriv=0 must equal evaluate."""
+        """evaluate_derivatives with orders=[0] must equal evaluate."""
         bspline = self._make_bspline([0, 0, 0, 1, 1, 1], 2, [0.0, 1.0, 0.0])
         pts = np.linspace(0.0, 1.0, 11, dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=0)
+        result = bspline.evaluate_derivatives(pts, [0])
         expected = bspline.evaluate(pts)
 
-        np.testing.assert_allclose(result[:, 0], expected, atol=1e-14)
+        np.testing.assert_allclose(result, expected, atol=1e-14)
 
     def test_linear_constant_first_derivative(self) -> None:
         """Degree-1 on [0,1] with CPs [0,1] gives f'(t)=1 everywhere (interior)."""
@@ -541,9 +541,9 @@ class TestBsplineEvaluateDerivatives:
         # fills the zeroth-derivative slot; higher-order derivatives are left zero.
         pts = np.array([0.0, 0.25, 0.5, 0.75], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1])
 
-        np.testing.assert_allclose(result[:, 1], np.ones(4), atol=1e-14)
+        np.testing.assert_allclose(result, np.ones(4), atol=1e-14)
 
     def test_quadratic_bezier_t_squared_exact(self) -> None:
         """CPs [0,0,1] on [0,0,0,1,1,1] give f(t)=t², f'=2t, f''=2."""
@@ -553,11 +553,11 @@ class TestBsplineEvaluateDerivatives:
         # Exclude t=1.0: endpoint shortcut in the derivative kernel only fills order 0.
         pts = np.array([0.0, 0.25, 0.5, 0.75], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=2)
-
-        np.testing.assert_allclose(result[:, 0], pts**2, atol=1e-13)
-        np.testing.assert_allclose(result[:, 1], 2.0 * pts, atol=1e-13)
-        np.testing.assert_allclose(result[:, 2], np.full(4, 2.0), atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0]), pts**2, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1]), 2.0 * pts, atol=1e-13)
+        np.testing.assert_allclose(
+            bspline.evaluate_derivatives(pts, [2]), np.full(4, 2.0), atol=1e-13
+        )
 
     def test_quadratic_bezier_general_exact(self) -> None:
         """CPs [0,1,0] give f(t)=2t(1-t); exact 1st and 2nd derivatives."""
@@ -565,15 +565,13 @@ class TestBsplineEvaluateDerivatives:
         # Exclude t=1.0: endpoint shortcut in the derivative kernel only fills order 0.
         pts = np.array([0.0, 0.25, 0.5, 0.75], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=2)
-
         f = 2.0 * pts * (1.0 - pts)
         f1 = 2.0 - 4.0 * pts
         f2 = np.full(4, -4.0)
 
-        np.testing.assert_allclose(result[:, 0], f, atol=1e-13)
-        np.testing.assert_allclose(result[:, 1], f1, atol=1e-13)
-        np.testing.assert_allclose(result[:, 2], f2, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0]), f, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1]), f1, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [2]), f2, atol=1e-13)
 
     def test_cubic_bezier_exact_derivatives(self) -> None:
         """CPs [0,1/3,2/3,1] give identity f(t)=t; f'(t)=1."""
@@ -582,37 +580,34 @@ class TestBsplineEvaluateDerivatives:
         # Exclude t=1.0: endpoint shortcut in the derivative kernel only fills order 0.
         pts = np.array([0.0, 0.25, 0.5, 0.75], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
-
-        np.testing.assert_allclose(result[:, 0], pts, atol=1e-13)
-        np.testing.assert_allclose(result[:, 1], np.ones(4), atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0]), pts, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1]), np.ones(4), atol=1e-13)
 
     def test_n_deriv_exceeds_degree_zeros(self) -> None:
-        """Rows with derivative order > degree must be zero."""
+        """Derivative order > degree must be zero."""
         bspline = self._make_bspline([0, 0, 0, 1, 1, 1], 2, [0.0, 1.0, 0.0])
         pts = np.array([0.25, 0.5, 0.75], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=5)
-
         # Degree 2 → 3rd and higher derivatives are zero
-        np.testing.assert_allclose(result[:, 3:], 0.0, atol=1e-14)
+        for k in range(3, 6):
+            result = bspline.evaluate_derivatives(pts, [k])
+            np.testing.assert_allclose(result, 0.0, atol=1e-14)
 
     # ------------------------------------------------------------------
     # Output shapes
     # ------------------------------------------------------------------
 
     def test_output_shape_scalar(self) -> None:
-        """Scalar B-spline returns shape (n_pts, n_deriv+1)."""
+        """Scalar B-spline returns shape (n_pts,)."""
         bspline = self._make_bspline([0, 0, 0, 1, 1, 1], 2, [0.0, 1.0, 0.0])
         pts = np.linspace(0.0, 1.0, 7, dtype=np.float64)
-        n_deriv = 3
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=n_deriv)
+        result = bspline.evaluate_derivatives(pts, [3])
 
-        assert result.shape == (7, n_deriv + 1)
+        assert result.shape == (7,)
 
     def test_output_shape_vector(self) -> None:
-        """Vector B-spline (2-column CPs) returns shape (n_pts, n_deriv+1, n_cols)."""
+        """Vector B-spline (2-column CPs) returns shape (n_pts, rank)."""
         kv = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
         space_1d = BsplineSpace1D(kv, 2)
         space = BsplineSpace([space_1d])
@@ -621,11 +616,10 @@ class TestBsplineEvaluateDerivatives:
         bspline = Bspline(space, cp)
 
         pts = np.linspace(0.0, 1.0, 5, dtype=np.float64)
-        n_deriv = 2
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=n_deriv)
+        result = bspline.evaluate_derivatives(pts, [2])
 
-        assert result.shape == (5, n_deriv + 1, 2)
+        assert result.shape == (5, 2)
 
     # ------------------------------------------------------------------
     # Numerical validation
@@ -639,41 +633,38 @@ class TestBsplineEvaluateDerivatives:
         pts = np.linspace(0.1, 0.9, 9, dtype=np.float64)
         h = 1e-6
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1])
         fd = (bspline.evaluate(pts + h) - bspline.evaluate(pts - h)) / (2.0 * h)
 
         # Use atol to handle the case where the true derivative is near zero
         # (rtol would fail when comparing ~0 to ~2e-11 floating-point noise).
-        np.testing.assert_allclose(result[:, 1], fd, atol=1e-5)
+        np.testing.assert_allclose(result, fd, atol=1e-5)
 
     # ------------------------------------------------------------------
     # Error handling
     # ------------------------------------------------------------------
 
     def test_invalid_n_deriv(self) -> None:
-        """Negative n_deriv raises ValueError."""
+        """Negative order raises ValueError."""
         bspline = self._make_bspline([0, 0, 0, 1, 1, 1], 2, [0.0, 1.0, 0.0])
         pts = np.array([0.5], dtype=np.float64)
 
-        with pytest.raises(ValueError, match="n_deriv must be >= 0"):
-            bspline.evaluate_derivatives(pts, n_deriv=-1)
+        with pytest.raises(ValueError):
+            bspline.evaluate_derivatives(pts, [-1])
 
     def test_out_array_reuse(self) -> None:
         """Pre-allocated out array is filled in-place."""
         bspline = self._make_bspline([0, 0, 0, 1, 1, 1], 2, [0.0, 1.0, 0.0])
         pts = np.array([0.25, 0.5, 0.75], dtype=np.float64)
-        n_deriv = 2
-        out = np.zeros((3, n_deriv + 1, 1), dtype=np.float64)
+        out = np.zeros(3, dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=n_deriv, out=out)
+        result = bspline.evaluate_derivatives(pts, [2], out=out)
 
-        # result is a view of out (last axis squeezed)
-        np.testing.assert_array_equal(result, out[:, :, 0])
-        # Values must be non-trivial (not all zero)
+        np.testing.assert_array_equal(result, out)
         assert not np.all(out == 0.0)
 
-    def test_dim_not_1_returns_result(self) -> None:
-        """evaluate_derivatives on dim > 1 B-spline returns a valid array."""
+    def test_dim_not_1_returns_scalar_result(self) -> None:
+        """evaluate_derivatives on dim=2 scalar B-spline returns (n_pts,)."""
         knots1 = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
         knots2 = [0.0, 0.0, 1.0, 1.0]
         space_1d_1 = BsplineSpace1D(np.array(knots1, dtype=np.float64), 2)
@@ -683,7 +674,7 @@ class TestBsplineEvaluateDerivatives:
         bspline = Bspline(space, cp)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1, 1])
 
-        # scalar 2D spline: shape (n_pts, n_deriv+1, dim) = (1, 2, 2)
-        assert result.shape == (1, 2, 2)
+        # scalar 2D spline, mixed first derivative: shape (n_pts,)
+        assert result.shape == (1,)

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -672,8 +672,8 @@ class TestBsplineEvaluateDerivatives:
         # Values must be non-trivial (not all zero)
         assert not np.all(out == 0.0)
 
-    def test_dim_not_1_raises(self) -> None:
-        """evaluate_derivatives on dim > 1 B-spline raises NotImplementedError."""
+    def test_dim_not_1_returns_result(self) -> None:
+        """evaluate_derivatives on dim > 1 B-spline returns a valid array."""
         knots1 = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
         knots2 = [0.0, 0.0, 1.0, 1.0]
         space_1d_1 = BsplineSpace1D(np.array(knots1, dtype=np.float64), 2)
@@ -683,6 +683,7 @@ class TestBsplineEvaluateDerivatives:
         bspline = Bspline(space, cp)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
 
-        with pytest.raises(NotImplementedError):
-            bspline.evaluate_derivatives(pts, n_deriv=1)
+        # scalar 2D spline: shape (n_pts, n_deriv+1, dim) = (1, 2, 2)
+        assert result.shape == (1, 2, 2)

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -303,7 +303,7 @@ class TestMultiDimDerivCorrectness:
 
         pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
 
-        # scalar 3D: mixed partial (1,0,1)
+        # scalar 3D: partial (1,0,1)
         result = bspline.evaluate_derivatives(pts, [1, 0, 1])
         assert result.shape == (1,)
 

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -212,8 +212,10 @@ class TestMultiDimDerivCorrectness:
 
         h = 1e-5
         pts = np.array([[0.3, 0.4]], dtype=np.float64)
-        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
-        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
+        du = np.array([[h, 0.0]], dtype=np.float64)
+        dv = np.array([[0.0, h]], dtype=np.float64)
+        fd_u = (bspline.evaluate(pts + du) - bspline.evaluate(pts - du)) / (2 * h)
+        fd_v = (bspline.evaluate(pts + dv) - bspline.evaluate(pts - dv)) / (2 * h)
 
         np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-9)
         np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-9)
@@ -230,8 +232,10 @@ class TestMultiDimDerivCorrectness:
 
         h = 1e-5
         pts = np.array([[0.2, 0.6]], dtype=np.float64)
-        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
-        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
+        du = np.array([[h, 0.0]], dtype=np.float64)
+        dv = np.array([[0.0, h]], dtype=np.float64)
+        fd_u = (bspline.evaluate(pts + du) - bspline.evaluate(pts - du)) / (2 * h)
+        fd_v = (bspline.evaluate(pts + dv) - bspline.evaluate(pts - dv)) / (2 * h)
 
         # evaluate() squeezes (1, 3) → (3,); derivatives return (1, 3) for n_pts=1
         np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0])[0], fd_u, atol=1e-9)
@@ -250,10 +254,10 @@ class TestMultiDimDerivCorrectness:
         pts = np.array([[0.3, 0.4]], dtype=np.float64)
 
         # 4-point central FD stencil for ∂²f/∂u∂v, truncation error O(h²)
-        pp = pts + [[+h, +h]]
-        pm = pts + [[+h, -h]]
-        mp = pts + [[-h, +h]]
-        mm = pts + [[-h, -h]]
+        pp = pts + np.array([[+h, +h]])
+        pm = pts + np.array([[+h, -h]])
+        mp = pts + np.array([[-h, +h]])
+        mm = pts + np.array([[-h, -h]])
         fd = (
             bspline.evaluate(pp)
             - bspline.evaluate(pm)
@@ -360,8 +364,10 @@ class TestMultiDimDerivRational:
 
         h = 1e-5
         pts = np.array([[0.4, 0.6]], dtype=np.float64)
-        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
-        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
+        du = np.array([[h, 0.0]], dtype=np.float64)
+        dv = np.array([[0.0, h]], dtype=np.float64)
+        fd_u = (bspline.evaluate(pts + du) - bspline.evaluate(pts - du)) / (2 * h)
+        fd_v = (bspline.evaluate(pts + dv) - bspline.evaluate(pts - dv)) / (2 * h)
 
         np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-9)
         np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-9)

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -1,0 +1,386 @@
+"""Tests for multi-dimensional B-spline derivative evaluation."""
+
+import numpy as np
+import pytest
+
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+from pantr.quad import PointsLattice
+
+
+def _make_2d_space(
+    knots1: list[float],
+    degree1: int,
+    knots2: list[float],
+    degree2: int,
+    dtype: type = float,
+) -> BsplineSpace:
+    """Build a 2D BsplineSpace from two knot vectors."""
+    dt = np.float64 if dtype is float else np.float32
+    s1 = BsplineSpace1D(np.array(knots1, dtype=dt), degree1)
+    s2 = BsplineSpace1D(np.array(knots2, dtype=dt), degree2)
+    return BsplineSpace([s1, s2])
+
+
+class TestMultiDimDerivOutputShape:
+    """Verify output shapes for all combinations of input type and rank."""
+
+    def test_pts_array_scalar_non_rational(self) -> None:
+        """Shape (n_pts, n_deriv+1, dim) for scalar non-rational."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.25, 0.5], [0.75, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=2)
+
+        assert result.shape == (2, 3, 2)
+
+    def test_pts_array_vector_non_rational(self) -> None:
+        """Shape (n_pts, n_deriv+1, dim, rank) for vector non-rational."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        # 6 basis x 3 columns → rank 3
+        cp = np.arange(18, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+
+        assert result.shape == (1, 2, 2, 3)
+
+    def test_lattice_scalar_non_rational(self) -> None:
+        """Shape (*pts_grid_shape, n_deriv+1, dim) for lattice scalar non-rational."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts1 = np.linspace(0.0, 1.0, 4, dtype=np.float64)
+        pts2 = np.linspace(0.0, 1.0, 3, dtype=np.float64)
+        lattice = PointsLattice([pts1, pts2])
+        result = bspline.evaluate_derivatives(lattice, n_deriv=1)
+
+        assert result.shape == (4, 3, 2, 2)
+
+    def test_pts_array_rational_scalar(self) -> None:
+        """Shape (n_pts, n_deriv+1, dim) for rational scalar (rank_value=1)."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        # 6 basis x 2 columns → cp_size=2, rational rank_value=1
+        cp = np.tile([1.0, 1.0], (6, 1)).astype(np.float64)
+        bspline = Bspline(space, cp.ravel(), is_rational=True)
+
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+
+        assert result.shape == (1, 2, 2)
+
+    def test_pts_array_rational_vector(self) -> None:
+        """Shape (n_pts, n_deriv+1, dim, rank_value) for rational vector."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        # 6 basis x 3 columns → cp_size=3, rational rank_value=2
+        cp = np.tile([1.0, 0.0, 1.0], (6, 1)).astype(np.float64)
+        bspline = Bspline(space, cp.ravel(), is_rational=True)
+
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+
+        assert result.shape == (1, 2, 2, 2)
+
+    def test_n_deriv_0_shape(self) -> None:
+        """n_deriv=0 produces shape (*pts_shape, 1, dim)."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=0)
+
+        assert result.shape == (1, 1, 2)
+
+
+class TestMultiDimDerivCorrectness:
+    """Verify correctness of multi-dimensional derivative values."""
+
+    def test_n_deriv_0_matches_evaluate_scalar(self) -> None:
+        """k=0 slice of derivative output must equal evaluate() for scalar."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        rng = np.random.default_rng(0)
+        pts = rng.uniform(0, 1, (20, 2)).astype(np.float64)
+
+        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (20, 1, 2)
+        result_v = bspline.evaluate(pts)  # (20,)
+
+        # All directions must give the same value (k=0 is the function value)
+        np.testing.assert_allclose(result_d[:, 0, 0], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d[:, 0, 1], result_v, atol=1e-13)
+
+    def test_n_deriv_0_matches_evaluate_vector(self) -> None:
+        """k=0 slice matches evaluate() for vector-valued spline."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.arange(12, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        rng = np.random.default_rng(1)
+        pts = rng.uniform(0, 1, (15, 2)).astype(np.float64)
+
+        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (15, 1, 2, 2)
+        result_v = bspline.evaluate(pts)  # (15, 2)
+
+        np.testing.assert_allclose(result_d[:, 0, 0, :], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d[:, 0, 1, :], result_v, atol=1e-13)
+
+    def test_linear_spline_constant_first_derivative(self) -> None:
+        """Degree-(1,1) bilinear spline f(u,v)=u+v: df/du=1, df/dv=1 everywhere."""
+        # f(u, v) = u + v encoded as linear CPs: (0,0)->0, (1,0)->1, (0,1)->1, (1,1)->2
+        # Knots: degree 1 in each direction
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        # CP layout (num_basis_0=2, num_basis_1=2): [f(0,0), f(0,1), f(1,0), f(1,1)]
+        cp = np.array([0.0, 1.0, 1.0, 2.0], dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        # Exclude the domain endpoints: the kernel's endpoint shortcut only fills
+        # the zeroth-derivative slot; higher-order derivatives are left zero there.
+        pts = np.array([[0.0, 0.0], [0.5, 0.5], [0.75, 0.25]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        # shape (3, 2, 2): [pts, k=0..1, dir=0..1]
+
+        # k=0 should be f(u,v) = u + v
+        np.testing.assert_allclose(result[:, 0, 0], [0.0, 1.0, 1.0], atol=1e-13)
+        # k=1, dir=0: df/du = 1.0
+        np.testing.assert_allclose(result[:, 1, 0], [1.0, 1.0, 1.0], atol=1e-13)
+        # k=1, dir=1: df/dv = 1.0
+        np.testing.assert_allclose(result[:, 1, 1], [1.0, 1.0, 1.0], atol=1e-13)
+
+    def test_bilinear_separable_derivative(self) -> None:
+        """f(u,v)=u*v (separable): df/du=v, df/dv=u."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        # CP layout: f(0,0)=0, f(0,1)=0, f(1,0)=0, f(1,1)=1
+        cp = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        # Exclude domain endpoints (derivative not computed there).
+        pts = np.array([[0.25, 0.75], [0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+
+        us = pts[:, 0]
+        vs = pts[:, 1]
+        # k=1, dir=0: df/du = v
+        np.testing.assert_allclose(result[:, 1, 0], vs, atol=1e-13)
+        # k=1, dir=1: df/dv = u
+        np.testing.assert_allclose(result[:, 1, 1], us, atol=1e-13)
+
+    def test_finite_difference_2d_scalar(self) -> None:
+        """Finite-difference validation of first derivatives for 2D scalar spline."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        rng = np.random.default_rng(42)
+        cp = rng.standard_normal(space.num_total_basis).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        h = 1e-5
+        pts = np.array([[0.3, 0.4]], dtype=np.float64)
+        pts_du = np.array([[0.3 + h, 0.4]], dtype=np.float64)
+        pts_dv = np.array([[0.3, 0.4 + h]], dtype=np.float64)
+
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
+        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
+
+        np.testing.assert_allclose(result[0, 1, 0], fd_u, rtol=1e-3)
+        np.testing.assert_allclose(result[0, 1, 1], fd_v, rtol=1e-3)
+
+    def test_finite_difference_2d_vector(self) -> None:
+        """Finite-difference validation for 2D vector-valued spline."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        n = space.num_total_basis
+        rng = np.random.default_rng(7)
+        cp = rng.standard_normal((n, 3)).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        h = 1e-5
+        pts = np.array([[0.2, 0.6]], dtype=np.float64)
+        pts_du = pts + np.array([[h, 0.0]])
+        pts_dv = pts + np.array([[0.0, h]])
+
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
+        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
+
+        np.testing.assert_allclose(result[0, 1, 0, :], fd_u, atol=1e-4)
+        np.testing.assert_allclose(result[0, 1, 1, :], fd_v, atol=1e-4)
+
+    def test_lattice_matches_pts_array(self) -> None:
+        """Lattice and pts-array evaluation give the same results on a grid."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        rng = np.random.default_rng(99)
+        cp = rng.standard_normal(6).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        pts1 = np.linspace(0.0, 1.0, 5, dtype=np.float64)
+        pts2 = np.linspace(0.0, 1.0, 4, dtype=np.float64)
+
+        # Build pts array from grid
+        g0, g1 = np.meshgrid(pts1, pts2, indexing="ij")
+        pts_arr = np.stack([g0.ravel(), g1.ravel()], axis=1)
+
+        result_arr = bspline.evaluate_derivatives(pts_arr, n_deriv=1)
+        # shape (20, 2, 2) → reshape to (5, 4, 2, 2)
+        result_arr_grid = result_arr.reshape(5, 4, 2, 2)
+
+        lattice = PointsLattice([pts1, pts2])
+        result_lat = bspline.evaluate_derivatives(lattice, n_deriv=1)
+        # shape (5, 4, 2, 2)
+
+        np.testing.assert_allclose(result_lat, result_arr_grid, atol=1e-13)
+
+
+class TestMultiDimDerivRational:
+    """Verify rational B-spline derivative evaluation."""
+
+    def test_rational_n_deriv_0_matches_evaluate(self) -> None:
+        """k=0 slice of rational derivatives matches evaluate()."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        rng = np.random.default_rng(5)
+        # cp_size=2: [numerator, weight], all weights=1 so rational == non-rational
+        n = space.num_total_basis
+        cp = np.column_stack([rng.standard_normal(n), np.ones(n)]).astype(np.float64)
+        bspline = Bspline(space, cp.ravel(), is_rational=True)
+
+        rng2 = np.random.default_rng(6)
+        pts = rng2.uniform(0, 1, (10, 2)).astype(np.float64)
+
+        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (10, 1, 2)
+        result_v = bspline.evaluate(pts)  # (10,) scalar because rank_value=1
+
+        np.testing.assert_allclose(result_d[:, 0, 0], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d[:, 0, 1], result_v, atol=1e-13)
+
+    def test_rational_unit_weights_matches_non_rational(self) -> None:
+        """Rational with unit weights gives same derivatives as non-rational."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        rng = np.random.default_rng(10)
+        n = space.num_total_basis
+        values = rng.standard_normal(n).astype(np.float64)
+
+        bspline_nr = Bspline(space, values)
+        cp_rational = np.column_stack([values, np.ones(n)]).astype(np.float64)
+        bspline_r = Bspline(space, cp_rational.ravel(), is_rational=True)
+
+        pts = np.array([[0.3, 0.7], [0.6, 0.2]], dtype=np.float64)
+        result_nr = bspline_nr.evaluate_derivatives(pts, n_deriv=2)
+        result_r = bspline_r.evaluate_derivatives(pts, n_deriv=2)
+
+        np.testing.assert_allclose(result_r, result_nr, atol=1e-11)
+
+    def test_rational_finite_difference(self) -> None:
+        """Finite-difference validation of rational 2D derivative."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2])
+        n = space.num_total_basis
+        rng = np.random.default_rng(20)
+        values = rng.standard_normal(n).astype(np.float64)
+        weights = rng.uniform(0.5, 1.5, n).astype(np.float64)
+        cp = np.column_stack([values * weights, weights]).astype(np.float64)
+        bspline = Bspline(space, cp.ravel(), is_rational=True)
+
+        h = 1e-5
+        pts = np.array([[0.4, 0.6]], dtype=np.float64)
+        pts_du = pts + np.array([[h, 0.0]])
+        pts_dv = pts + np.array([[0.0, h]])
+
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)  # (1, 2, 2)
+        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
+        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
+
+        np.testing.assert_allclose(result[0, 1, 0], fd_u, atol=1e-5)
+        np.testing.assert_allclose(result[0, 1, 1], fd_v, atol=1e-5)
+
+
+class TestMultiDimDerivValidation:
+    """Test input validation for multi-dimensional derivatives."""
+
+    def test_invalid_n_deriv(self) -> None:
+        """n_deriv < 0 raises ValueError."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="n_deriv"):
+            bspline.evaluate_derivatives(pts, n_deriv=-1)
+
+    def test_wrong_pts_shape(self) -> None:
+        """Pts array with wrong number of columns raises ValueError."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)  # 3 cols, need 2
+
+        with pytest.raises(ValueError):
+            bspline.evaluate_derivatives(pts, n_deriv=1)
+
+    def test_wrong_pts_dtype(self) -> None:
+        """Pts array with wrong dtype raises ValueError."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5]], dtype=np.float32)
+
+        with pytest.raises(ValueError):
+            bspline.evaluate_derivatives(pts, n_deriv=1)
+
+    def test_wrong_lattice_dim(self) -> None:
+        """PointsLattice with wrong dimension raises ValueError."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        lattice = PointsLattice([np.linspace(0, 1, 5, dtype=np.float64)])  # 1D lattice
+
+        with pytest.raises(ValueError):
+            bspline.evaluate_derivatives(lattice, n_deriv=1)
+
+    def test_out_array_reuse(self) -> None:
+        """Pre-allocated out array is filled in-place and result is a view of it."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+
+        # For scalar non-rational, out must include the trailing cp_size=1 dimension.
+        out = np.zeros((1, 2, 2, 1), dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1, out=out)
+
+        # result is out[..., 0] (squeezed view)
+        np.testing.assert_array_equal(result, out[..., 0])
+        assert not np.all(out == 0.0)
+
+    def test_3d_bspline_derivatives(self) -> None:
+        """evaluate_derivatives works for dim=3 B-splines."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s3 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2, s3])
+        rng = np.random.default_rng(3)
+        cp = rng.standard_normal(space.num_total_basis).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+
+        # scalar 3D: (1, 2, 3)
+        assert result.shape == (1, 2, 3)

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -1,4 +1,4 @@
-"""Tests for multi-dimensional B-spline derivative evaluation."""
+"""Tests for multi-dimensional B-spline derivative evaluation with per-direction orders."""
 
 import numpy as np
 import pytest
@@ -26,31 +26,42 @@ def _make_2d_space(
 class TestMultiDimDerivOutputShape:
     """Verify output shapes for all combinations of input type and rank."""
 
-    def test_pts_array_scalar_non_rational(self) -> None:
-        """Shape (n_pts, n_deriv+1, dim) for scalar non-rational."""
+    def test_pts_array_scalar_non_rational_zeroth(self) -> None:
+        """orders=[0,0] for scalar non-rational returns shape (n_pts,)."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.ones(6, dtype=np.float64)
         bspline = Bspline(space, cp)
 
         pts = np.array([[0.25, 0.5], [0.75, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=2)
+        result = bspline.evaluate_derivatives(pts, [0, 0])
 
-        assert result.shape == (2, 3, 2)
+        assert result.shape == (2,)
+
+    def test_pts_array_scalar_non_rational_mixed(self) -> None:
+        """orders=[1,1] for scalar non-rational returns shape (n_pts,)."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.25, 0.5], [0.75, 0.5]], dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, [1, 1])
+
+        assert result.shape == (2,)
 
     def test_pts_array_vector_non_rational(self) -> None:
-        """Shape (n_pts, n_deriv+1, dim, rank) for vector non-rational."""
+        """orders=[1,0] for vector non-rational returns shape (n_pts, rank)."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         # 6 basis x 3 columns → rank 3
         cp = np.arange(18, dtype=np.float64)
         bspline = Bspline(space, cp)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1, 0])
 
-        assert result.shape == (1, 2, 2, 3)
+        assert result.shape == (1, 3)
 
     def test_lattice_scalar_non_rational(self) -> None:
-        """Shape (*pts_grid_shape, n_deriv+1, dim) for lattice scalar non-rational."""
+        """orders=[1,0] for lattice scalar non-rational returns (*grid_shape,)."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.ones(6, dtype=np.float64)
         bspline = Bspline(space, cp)
@@ -58,51 +69,64 @@ class TestMultiDimDerivOutputShape:
         pts1 = np.linspace(0.0, 1.0, 4, dtype=np.float64)
         pts2 = np.linspace(0.0, 1.0, 3, dtype=np.float64)
         lattice = PointsLattice([pts1, pts2])
-        result = bspline.evaluate_derivatives(lattice, n_deriv=1)
+        result = bspline.evaluate_derivatives(lattice, [1, 0])
 
-        assert result.shape == (4, 3, 2, 2)
+        assert result.shape == (4, 3)
+
+    def test_lattice_vector_non_rational(self) -> None:
+        """orders=[0,1] for lattice vector non-rational returns (*grid_shape, rank)."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.arange(12, dtype=np.float64)
+        bspline = Bspline(space, cp)
+
+        pts1 = np.linspace(0.0, 1.0, 3, dtype=np.float64)
+        pts2 = np.linspace(0.0, 1.0, 5, dtype=np.float64)
+        lattice = PointsLattice([pts1, pts2])
+        result = bspline.evaluate_derivatives(lattice, [0, 1])
+
+        assert result.shape == (3, 5, 2)
 
     def test_pts_array_rational_scalar(self) -> None:
-        """Shape (n_pts, n_deriv+1, dim) for rational scalar (rank_value=1)."""
+        """orders=[1,0] for rational scalar (rank=1) returns shape (n_pts,)."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
-        # 6 basis x 2 columns → cp_size=2, rational rank_value=1
+        # 6 basis x 2 columns → cp_size=2, rational rank=1
         cp = np.tile([1.0, 1.0], (6, 1)).astype(np.float64)
         bspline = Bspline(space, cp.ravel(), is_rational=True)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1, 0])
 
-        assert result.shape == (1, 2, 2)
+        assert result.shape == (1,)
 
     def test_pts_array_rational_vector(self) -> None:
-        """Shape (n_pts, n_deriv+1, dim, rank_value) for rational vector."""
+        """orders=[1,0] for rational vector returns shape (n_pts, rank_value)."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         # 6 basis x 3 columns → cp_size=3, rational rank_value=2
         cp = np.tile([1.0, 0.0, 1.0], (6, 1)).astype(np.float64)
         bspline = Bspline(space, cp.ravel(), is_rational=True)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
+        result = bspline.evaluate_derivatives(pts, [1, 0])
 
-        assert result.shape == (1, 2, 2, 2)
+        assert result.shape == (1, 2)
 
-    def test_n_deriv_0_shape(self) -> None:
-        """n_deriv=0 produces shape (*pts_shape, 1, dim)."""
+    def test_orders_zero_shape(self) -> None:
+        """orders=[0,0] produces shape (n_pts,) for scalar."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.ones(6, dtype=np.float64)
         bspline = Bspline(space, cp)
 
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=0)
+        result = bspline.evaluate_derivatives(pts, [0, 0])
 
-        assert result.shape == (1, 1, 2)
+        assert result.shape == (1,)
 
 
 class TestMultiDimDerivCorrectness:
     """Verify correctness of multi-dimensional derivative values."""
 
-    def test_n_deriv_0_matches_evaluate_scalar(self) -> None:
-        """k=0 slice of derivative output must equal evaluate() for scalar."""
+    def test_orders_zero_matches_evaluate_scalar(self) -> None:
+        """orders=[0,0] must equal evaluate() for scalar."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float64)
         bspline = Bspline(space, cp)
@@ -110,15 +134,13 @@ class TestMultiDimDerivCorrectness:
         rng = np.random.default_rng(0)
         pts = rng.uniform(0, 1, (20, 2)).astype(np.float64)
 
-        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (20, 1, 2)
+        result_d = bspline.evaluate_derivatives(pts, [0, 0])  # (20,)
         result_v = bspline.evaluate(pts)  # (20,)
 
-        # All directions must give the same value (k=0 is the function value)
-        np.testing.assert_allclose(result_d[:, 0, 0], result_v, atol=1e-13)
-        np.testing.assert_allclose(result_d[:, 0, 1], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d, result_v, atol=1e-13)
 
-    def test_n_deriv_0_matches_evaluate_vector(self) -> None:
-        """k=0 slice matches evaluate() for vector-valued spline."""
+    def test_orders_zero_matches_evaluate_vector(self) -> None:
+        """orders=[0,0] matches evaluate() for vector-valued spline."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.arange(12, dtype=np.float64)
         bspline = Bspline(space, cp)
@@ -126,55 +148,58 @@ class TestMultiDimDerivCorrectness:
         rng = np.random.default_rng(1)
         pts = rng.uniform(0, 1, (15, 2)).astype(np.float64)
 
-        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (15, 1, 2, 2)
+        result_d = bspline.evaluate_derivatives(pts, [0, 0])  # (15, 2)
         result_v = bspline.evaluate(pts)  # (15, 2)
 
-        np.testing.assert_allclose(result_d[:, 0, 0, :], result_v, atol=1e-13)
-        np.testing.assert_allclose(result_d[:, 0, 1, :], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d, result_v, atol=1e-13)
 
     def test_linear_spline_constant_first_derivative(self) -> None:
         """Degree-(1,1) bilinear spline f(u,v)=u+v: df/du=1, df/dv=1 everywhere."""
-        # f(u, v) = u + v encoded as linear CPs: (0,0)->0, (1,0)->1, (0,1)->1, (1,1)->2
-        # Knots: degree 1 in each direction
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
-        # CP layout (num_basis_0=2, num_basis_1=2): [f(0,0), f(0,1), f(1,0), f(1,1)]
         cp = np.array([0.0, 1.0, 1.0, 2.0], dtype=np.float64)
         bspline = Bspline(space, cp)
 
-        # Exclude the domain endpoints: the kernel's endpoint shortcut only fills
-        # the zeroth-derivative slot; higher-order derivatives are left zero there.
         pts = np.array([[0.0, 0.0], [0.5, 0.5], [0.75, 0.25]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
-        # shape (3, 2, 2): [pts, k=0..1, dir=0..1]
 
-        # k=0 should be f(u,v) = u + v
-        np.testing.assert_allclose(result[:, 0, 0], [0.0, 1.0, 1.0], atol=1e-13)
-        # k=1, dir=0: df/du = 1.0
-        np.testing.assert_allclose(result[:, 1, 0], [1.0, 1.0, 1.0], atol=1e-13)
-        # k=1, dir=1: df/dv = 1.0
-        np.testing.assert_allclose(result[:, 1, 1], [1.0, 1.0, 1.0], atol=1e-13)
+        # f(u,v) = u + v
+        np.testing.assert_allclose(
+            bspline.evaluate_derivatives(pts, [0, 0]),
+            pts[:, 0] + pts[:, 1],
+            atol=1e-13,
+        )
+        # df/du = 1
+        np.testing.assert_allclose(
+            bspline.evaluate_derivatives(pts, [1, 0]),
+            np.ones(3),
+            atol=1e-13,
+        )
+        # df/dv = 1
+        np.testing.assert_allclose(
+            bspline.evaluate_derivatives(pts, [0, 1]),
+            np.ones(3),
+            atol=1e-13,
+        )
 
     def test_bilinear_separable_derivative(self) -> None:
-        """f(u,v)=u*v (separable): df/du=v, df/dv=u."""
+        """f(u,v)=u*v (separable): df/du=v, df/dv=u, d²f/dudv=1."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
-        # CP layout: f(0,0)=0, f(0,1)=0, f(1,0)=0, f(1,1)=1
         cp = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
         bspline = Bspline(space, cp)
 
-        # Exclude domain endpoints (derivative not computed there).
         pts = np.array([[0.25, 0.75], [0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
-
         us = pts[:, 0]
         vs = pts[:, 1]
-        # k=1, dir=0: df/du = v
-        np.testing.assert_allclose(result[:, 1, 0], vs, atol=1e-13)
-        # k=1, dir=1: df/dv = u
-        np.testing.assert_allclose(result[:, 1, 1], us, atol=1e-13)
+
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), vs, atol=1e-13)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), us, atol=1e-13)
+        # Mixed derivative d²f/dudv = 1
+        np.testing.assert_allclose(
+            bspline.evaluate_derivatives(pts, [1, 1]), np.ones(2), atol=1e-13
+        )
 
     def test_finite_difference_2d_scalar(self) -> None:
         """Finite-difference validation of first derivatives for 2D scalar spline."""
@@ -190,12 +215,11 @@ class TestMultiDimDerivCorrectness:
         pts_du = np.array([[0.3 + h, 0.4]], dtype=np.float64)
         pts_dv = np.array([[0.3, 0.4 + h]], dtype=np.float64)
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
         fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
         fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
 
-        np.testing.assert_allclose(result[0, 1, 0], fd_u, rtol=1e-3)
-        np.testing.assert_allclose(result[0, 1, 1], fd_v, rtol=1e-3)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, rtol=1e-3)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, rtol=1e-3)
 
     def test_finite_difference_2d_vector(self) -> None:
         """Finite-difference validation for 2D vector-valued spline."""
@@ -212,12 +236,38 @@ class TestMultiDimDerivCorrectness:
         pts_du = pts + np.array([[h, 0.0]])
         pts_dv = pts + np.array([[0.0, h]])
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
         fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
         fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
 
-        np.testing.assert_allclose(result[0, 1, 0, :], fd_u, atol=1e-4)
-        np.testing.assert_allclose(result[0, 1, 1, :], fd_v, atol=1e-4)
+        # evaluate() squeezes (1, 3) → (3,); derivatives return (1, 3) for n_pts=1
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0])[0], fd_u, atol=1e-4)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1])[0], fd_v, atol=1e-4)
+
+    def test_finite_difference_2d_second_mixed(self) -> None:
+        """Finite-difference validation of d²f/dudv for a 2D quadratic spline."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
+        space = BsplineSpace([s1, s2])
+        rng = np.random.default_rng(99)
+        cp = rng.standard_normal(space.num_total_basis).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        h = 1e-4
+        pts = np.array([[0.3, 0.4]], dtype=np.float64)
+
+        # Central FD for d²f/dudv
+        pp = np.array([[0.3 + h, 0.4 + h]])
+        pm = np.array([[0.3 + h, 0.4 - h]])
+        mp = np.array([[0.3 - h, 0.4 + h]])
+        mm = np.array([[0.3 - h, 0.4 - h]])
+        fd_mixed = (
+            bspline.evaluate(pp)
+            - bspline.evaluate(pm)
+            - bspline.evaluate(mp)
+            + bspline.evaluate(mm)
+        ) / (4.0 * h**2)
+
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 1]), fd_mixed, rtol=1e-3)
 
     def test_lattice_matches_pts_array(self) -> None:
         """Lattice and pts-array evaluation give the same results on a grid."""
@@ -229,31 +279,48 @@ class TestMultiDimDerivCorrectness:
         pts1 = np.linspace(0.0, 1.0, 5, dtype=np.float64)
         pts2 = np.linspace(0.0, 1.0, 4, dtype=np.float64)
 
-        # Build pts array from grid
         g0, g1 = np.meshgrid(pts1, pts2, indexing="ij")
         pts_arr = np.stack([g0.ravel(), g1.ravel()], axis=1)
 
-        result_arr = bspline.evaluate_derivatives(pts_arr, n_deriv=1)
-        # shape (20, 2, 2) → reshape to (5, 4, 2, 2)
-        result_arr_grid = result_arr.reshape(5, 4, 2, 2)
+        for ords in ([0, 0], [1, 0], [0, 1], [1, 1]):
+            result_arr = bspline.evaluate_derivatives(pts_arr, ords)  # (20,)
+            result_arr_grid = result_arr.reshape(5, 4)
 
-        lattice = PointsLattice([pts1, pts2])
-        result_lat = bspline.evaluate_derivatives(lattice, n_deriv=1)
-        # shape (5, 4, 2, 2)
+            lattice = PointsLattice([pts1, pts2])
+            result_lat = bspline.evaluate_derivatives(lattice, ords)  # (5, 4)
 
-        np.testing.assert_allclose(result_lat, result_arr_grid, atol=1e-13)
+            np.testing.assert_allclose(result_lat, result_arr_grid, atol=1e-13)
+
+    def test_3d_bspline_derivatives(self) -> None:
+        """evaluate_derivatives works for dim=3 B-splines."""
+        s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        s3 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
+        space = BsplineSpace([s1, s2, s3])
+        rng = np.random.default_rng(3)
+        cp = rng.standard_normal(space.num_total_basis).astype(np.float64)
+        bspline = Bspline(space, cp)
+
+        pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
+
+        # scalar 3D: mixed partial (1,0,1)
+        result = bspline.evaluate_derivatives(pts, [1, 0, 1])
+        assert result.shape == (1,)
+
+        # zeroth order matches evaluate
+        result0 = bspline.evaluate_derivatives(pts, [0, 0, 0])
+        np.testing.assert_allclose(result0, bspline.evaluate(pts), atol=1e-13)
 
 
 class TestMultiDimDerivRational:
     """Verify rational B-spline derivative evaluation."""
 
-    def test_rational_n_deriv_0_matches_evaluate(self) -> None:
-        """k=0 slice of rational derivatives matches evaluate()."""
+    def test_rational_orders_zero_matches_evaluate(self) -> None:
+        """orders=[0,0] of rational derivatives matches evaluate()."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
         rng = np.random.default_rng(5)
-        # cp_size=2: [numerator, weight], all weights=1 so rational == non-rational
         n = space.num_total_basis
         cp = np.column_stack([rng.standard_normal(n), np.ones(n)]).astype(np.float64)
         bspline = Bspline(space, cp.ravel(), is_rational=True)
@@ -261,14 +328,13 @@ class TestMultiDimDerivRational:
         rng2 = np.random.default_rng(6)
         pts = rng2.uniform(0, 1, (10, 2)).astype(np.float64)
 
-        result_d = bspline.evaluate_derivatives(pts, n_deriv=0)  # (10, 1, 2)
-        result_v = bspline.evaluate(pts)  # (10,) scalar because rank_value=1
+        result_d = bspline.evaluate_derivatives(pts, [0, 0])  # (10,)
+        result_v = bspline.evaluate(pts)
 
-        np.testing.assert_allclose(result_d[:, 0, 0], result_v, atol=1e-13)
-        np.testing.assert_allclose(result_d[:, 0, 1], result_v, atol=1e-13)
+        np.testing.assert_allclose(result_d, result_v, atol=1e-13)
 
     def test_rational_unit_weights_matches_non_rational(self) -> None:
-        """Rational with unit weights gives same derivatives as non-rational."""
+        """Rational with unit weights gives same first derivatives as non-rational."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
@@ -281,13 +347,13 @@ class TestMultiDimDerivRational:
         bspline_r = Bspline(space, cp_rational.ravel(), is_rational=True)
 
         pts = np.array([[0.3, 0.7], [0.6, 0.2]], dtype=np.float64)
-        result_nr = bspline_nr.evaluate_derivatives(pts, n_deriv=2)
-        result_r = bspline_r.evaluate_derivatives(pts, n_deriv=2)
-
-        np.testing.assert_allclose(result_r, result_nr, atol=1e-11)
+        for ords in ([0, 0], [1, 0], [0, 1]):
+            result_nr = bspline_nr.evaluate_derivatives(pts, ords)
+            result_r = bspline_r.evaluate_derivatives(pts, ords)
+            np.testing.assert_allclose(result_r, result_nr, atol=1e-11)
 
     def test_rational_finite_difference(self) -> None:
-        """Finite-difference validation of rational 2D derivative."""
+        """Finite-difference validation of rational 2D first derivative."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
@@ -303,26 +369,35 @@ class TestMultiDimDerivRational:
         pts_du = pts + np.array([[h, 0.0]])
         pts_dv = pts + np.array([[0.0, h]])
 
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)  # (1, 2, 2)
         fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
         fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
 
-        np.testing.assert_allclose(result[0, 1, 0], fd_u, atol=1e-5)
-        np.testing.assert_allclose(result[0, 1, 1], fd_v, atol=1e-5)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-5)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-5)
 
 
 class TestMultiDimDerivValidation:
     """Test input validation for multi-dimensional derivatives."""
 
-    def test_invalid_n_deriv(self) -> None:
-        """n_deriv < 0 raises ValueError."""
+    def test_wrong_orders_length(self) -> None:
+        """len(orders) != dim raises ValueError."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.ones(6, dtype=np.float64)
         bspline = Bspline(space, cp)
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
 
-        with pytest.raises(ValueError, match="n_deriv"):
-            bspline.evaluate_derivatives(pts, n_deriv=-1)
+        with pytest.raises(ValueError, match="len\\(orders\\)"):
+            bspline.evaluate_derivatives(pts, [1])
+
+    def test_negative_order(self) -> None:
+        """Negative order raises ValueError."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.ones(6, dtype=np.float64)
+        bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+
+        with pytest.raises(ValueError, match="orders\\["):
+            bspline.evaluate_derivatives(pts, [-1, 0])
 
     def test_wrong_pts_shape(self) -> None:
         """Pts array with wrong number of columns raises ValueError."""
@@ -332,7 +407,7 @@ class TestMultiDimDerivValidation:
         pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)  # 3 cols, need 2
 
         with pytest.raises(ValueError):
-            bspline.evaluate_derivatives(pts, n_deriv=1)
+            bspline.evaluate_derivatives(pts, [1, 0])
 
     def test_wrong_pts_dtype(self) -> None:
         """Pts array with wrong dtype raises ValueError."""
@@ -342,7 +417,7 @@ class TestMultiDimDerivValidation:
         pts = np.array([[0.5, 0.5]], dtype=np.float32)
 
         with pytest.raises(ValueError):
-            bspline.evaluate_derivatives(pts, n_deriv=1)
+            bspline.evaluate_derivatives(pts, [1, 0])
 
     def test_wrong_lattice_dim(self) -> None:
         """PointsLattice with wrong dimension raises ValueError."""
@@ -352,35 +427,30 @@ class TestMultiDimDerivValidation:
         lattice = PointsLattice([np.linspace(0, 1, 5, dtype=np.float64)])  # 1D lattice
 
         with pytest.raises(ValueError):
-            bspline.evaluate_derivatives(lattice, n_deriv=1)
+            bspline.evaluate_derivatives(lattice, [1, 0])
 
-    def test_out_array_reuse(self) -> None:
-        """Pre-allocated out array is filled in-place and result is a view of it."""
+    def test_out_array_reuse_scalar(self) -> None:
+        """Pre-allocated out (scalar, shape (n_pts,)) is filled in-place."""
         space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
         cp = np.ones(6, dtype=np.float64)
         bspline = Bspline(space, cp)
+        pts = np.array([[0.5, 0.5], [0.3, 0.7]], dtype=np.float64)
+
+        out = np.zeros(2, dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, [1, 0], out=out)
+
+        np.testing.assert_array_equal(result, out)
+        assert result is out
+
+    def test_out_array_reuse_vector(self) -> None:
+        """Pre-allocated out (vector, shape (n_pts, rank)) is filled in-place."""
+        space = _make_2d_space([0, 0, 0, 1, 1, 1], 2, [0, 0, 1, 1], 1)
+        cp = np.arange(12, dtype=np.float64)
+        bspline = Bspline(space, cp)
         pts = np.array([[0.5, 0.5]], dtype=np.float64)
 
-        # For scalar non-rational, out must include the trailing cp_size=1 dimension.
-        out = np.zeros((1, 2, 2, 1), dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1, out=out)
+        out = np.zeros((1, 2), dtype=np.float64)
+        result = bspline.evaluate_derivatives(pts, [1, 0], out=out)
 
-        # result is out[..., 0] (squeezed view)
-        np.testing.assert_array_equal(result, out[..., 0])
-        assert not np.all(out == 0.0)
-
-    def test_3d_bspline_derivatives(self) -> None:
-        """evaluate_derivatives works for dim=3 B-splines."""
-        s1 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
-        s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
-        s3 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
-        space = BsplineSpace([s1, s2, s3])
-        rng = np.random.default_rng(3)
-        cp = rng.standard_normal(space.num_total_basis).astype(np.float64)
-        bspline = Bspline(space, cp)
-
-        pts = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
-        result = bspline.evaluate_derivatives(pts, n_deriv=1)
-
-        # scalar 3D: (1, 2, 3)
-        assert result.shape == (1, 2, 3)
+        np.testing.assert_array_equal(result, out)
+        assert result is out

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -202,7 +202,7 @@ class TestMultiDimDerivCorrectness:
         )
 
     def test_finite_difference_2d_scalar(self) -> None:
-        """Finite-difference validation of first derivatives for 2D scalar spline."""
+        """Central-difference validation of first derivatives for 2D scalar spline."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
@@ -212,17 +212,14 @@ class TestMultiDimDerivCorrectness:
 
         h = 1e-5
         pts = np.array([[0.3, 0.4]], dtype=np.float64)
-        pts_du = np.array([[0.3 + h, 0.4]], dtype=np.float64)
-        pts_dv = np.array([[0.3, 0.4 + h]], dtype=np.float64)
+        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
+        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
 
-        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
-        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
-
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, rtol=1e-3)
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, rtol=1e-3)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-9)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-9)
 
     def test_finite_difference_2d_vector(self) -> None:
-        """Finite-difference validation for 2D vector-valued spline."""
+        """Central-difference validation for 2D vector-valued spline."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
@@ -233,18 +230,15 @@ class TestMultiDimDerivCorrectness:
 
         h = 1e-5
         pts = np.array([[0.2, 0.6]], dtype=np.float64)
-        pts_du = pts + np.array([[h, 0.0]])
-        pts_dv = pts + np.array([[0.0, h]])
-
-        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
-        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
+        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
+        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
 
         # evaluate() squeezes (1, 3) → (3,); derivatives return (1, 3) for n_pts=1
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0])[0], fd_u, atol=1e-4)
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1])[0], fd_v, atol=1e-4)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0])[0], fd_u, atol=1e-9)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1])[0], fd_v, atol=1e-9)
 
     def test_finite_difference_2d_second_mixed(self) -> None:
-        """Finite-difference validation of d²f/dudv for a 2D quadratic spline."""
+        """Central-difference validation of ∂²f/∂u∂v for a 2D quadratic spline."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         space = BsplineSpace([s1, s2])
@@ -255,19 +249,19 @@ class TestMultiDimDerivCorrectness:
         h = 1e-4
         pts = np.array([[0.3, 0.4]], dtype=np.float64)
 
-        # Central FD for d²f/dudv
-        pp = np.array([[0.3 + h, 0.4 + h]])
-        pm = np.array([[0.3 + h, 0.4 - h]])
-        mp = np.array([[0.3 - h, 0.4 + h]])
-        mm = np.array([[0.3 - h, 0.4 - h]])
-        fd_mixed = (
+        # 4-point central FD stencil for ∂²f/∂u∂v, truncation error O(h²)
+        pp = pts + [[+h, +h]]
+        pm = pts + [[+h, -h]]
+        mp = pts + [[-h, +h]]
+        mm = pts + [[-h, -h]]
+        fd = (
             bspline.evaluate(pp)
             - bspline.evaluate(pm)
             - bspline.evaluate(mp)
             + bspline.evaluate(mm)
         ) / (4.0 * h**2)
 
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 1]), fd_mixed, rtol=1e-3)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 1]), fd, atol=1e-7)
 
     def test_lattice_matches_pts_array(self) -> None:
         """Lattice and pts-array evaluation give the same results on a grid."""
@@ -353,7 +347,7 @@ class TestMultiDimDerivRational:
             np.testing.assert_allclose(result_r, result_nr, atol=1e-11)
 
     def test_rational_finite_difference(self) -> None:
-        """Finite-difference validation of rational 2D first derivative."""
+        """Central-difference validation of rational 2D first derivative."""
         s1 = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64), 2)
         s2 = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64), 1)
         space = BsplineSpace([s1, s2])
@@ -366,14 +360,11 @@ class TestMultiDimDerivRational:
 
         h = 1e-5
         pts = np.array([[0.4, 0.6]], dtype=np.float64)
-        pts_du = pts + np.array([[h, 0.0]])
-        pts_dv = pts + np.array([[0.0, h]])
+        fd_u = (bspline.evaluate(pts + [[h, 0]]) - bspline.evaluate(pts - [[h, 0]])) / (2 * h)
+        fd_v = (bspline.evaluate(pts + [[0, h]]) - bspline.evaluate(pts - [[0, h]])) / (2 * h)
 
-        fd_u = (bspline.evaluate(pts_du) - bspline.evaluate(pts)) / h
-        fd_v = (bspline.evaluate(pts_dv) - bspline.evaluate(pts)) / h
-
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-5)
-        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-5)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [1, 0]), fd_u, atol=1e-9)
+        np.testing.assert_allclose(bspline.evaluate_derivatives(pts, [0, 1]), fd_v, atol=1e-9)
 
 
 class TestMultiDimDerivValidation:


### PR DESCRIPTION
## Summary

- Replaces `evaluate_derivatives(pts, n_deriv: int)` with `evaluate_derivatives(pts, orders: Sequence[int])` — one non-negative integer per parametric direction
- Returns only the specified mixed partial derivative (no derivative-order axis in output)
- Supports all dimensions (1D, 2D, 3D, …) for both non-rational and rational B-splines
- Rational case uses the generalised quotient rule over all multi-indices up to `orders`

**Output shape change:**
- Old: `(n_pts, n_deriv+1)` for scalar 1D; `(n_pts, n_deriv+1, dim)` for scalar nD
- New: `(n_pts,)` for scalar (any dimension); `(n_pts, rank)` for vector

## Test plan
- [ ] `pytest tests/test_bspline.py tests/test_bspline_evaluate_derivatives_multi_dim.py --no-cov -v`
- [ ] `pytest tests/ --no-cov -q` — full suite (873 tests pass)
- [ ] `ruff check . && ruff format --check .`
- [ ] `mypy --config-file mypy.ini src tests`

Closes #50 (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)