### PR TITLE
feat(bspline): add multiply and __mul__ for exact 1D B-spline product

### DIFF
--- a/src/pantr/_bspline_product.py
+++ b/src/pantr/_bspline_product.py
@@ -1,0 +1,458 @@
+"""B-spline pointwise product for 1D splines.
+
+This module provides :func:`_multiply_bspline_1d`, which computes the exact
+pointwise product of two 1D B-splines via full-Bézier extraction and the
+Bernstein product formula. Works for both non-rational and rational (NURBS) splines.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knots import _get_unique_knots_and_multiplicity_impl
+from .bspline_space_1D import BsplineSpace1D
+from .bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from .bspline import Bspline
+
+
+def _get_interior_breakpoints_and_mults(
+    space_1d: BsplineSpace1D,
+    tol: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
+    """Return interior breakpoints and their multiplicities for a 1D B-spline space.
+
+    Calls ``_get_unique_knots_and_multiplicity_impl`` with ``in_domain=True`` and strips
+    the two boundary entries, leaving only interior breakpoints.
+
+    Args:
+        space_1d (BsplineSpace1D): The 1D B-spline space to query.
+        tol (float): Tolerance for grouping nearby knots.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Arrays
+        ``(breakpoints, multiplicities)`` of interior knots only.  Both arrays are
+        empty when the space has a single Bézier element.
+    """
+    dtype = space_1d.knots.dtype
+    tol_typed = float(dtype.type(tol))
+    unique, mults = _get_unique_knots_and_multiplicity_impl(
+        space_1d.knots, space_1d.degree, tol_typed, in_domain=True
+    )
+    return unique[1:-1], mults[1:-1]
+
+
+def _merge_interior_breakpoints(
+    bp1: npt.NDArray[np.float32 | np.float64],
+    mult1: npt.NDArray[np.int_],
+    bp2: npt.NDArray[np.float32 | np.float64],
+    mult2: npt.NDArray[np.int_],
+    tol: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
+    """Merge two sorted interior breakpoint arrays with additive multiplicities.
+
+    Uses a two-pointer scan.  When two breakpoints are within ``tol`` of each
+    other they are considered the same knot; their position is averaged and
+    their multiplicities are summed.  A breakpoint absent from one side
+    contributes 0 to the sum (i.e. the other side's multiplicity is taken
+    as-is).
+
+    Args:
+        bp1 (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
+            of the first space.
+        mult1 (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp1``.
+        bp2 (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
+            of the second space.
+        mult2 (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp2``.
+        tol (float): Tolerance for coincidence tests.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Merged
+        ``(all_bp, sum_mults)`` arrays in ascending order.
+    """
+    n1, n2 = len(bp1), len(bp2)
+    i, j = 0, 0
+    all_bp_list: list[float] = []
+    sum_mults_list: list[int] = []
+
+    while i < n1 and j < n2:
+        if abs(float(bp1[i]) - float(bp2[j])) <= tol:
+            all_bp_list.append(float(bp1[i] + bp2[j]) / 2.0)
+            sum_mults_list.append(int(mult1[i]) + int(mult2[j]))
+            i += 1
+            j += 1
+        elif float(bp1[i]) < float(bp2[j]):
+            all_bp_list.append(float(bp1[i]))
+            sum_mults_list.append(int(mult1[i]))
+            i += 1
+        else:
+            all_bp_list.append(float(bp2[j]))
+            sum_mults_list.append(int(mult2[j]))
+            j += 1
+
+    while i < n1:
+        all_bp_list.append(float(bp1[i]))
+        sum_mults_list.append(int(mult1[i]))
+        i += 1
+
+    while j < n2:
+        all_bp_list.append(float(bp2[j]))
+        sum_mults_list.append(int(mult2[j]))
+        j += 1
+
+    dtype = bp1.dtype
+    if len(all_bp_list) == 0:
+        return np.empty(0, dtype=dtype), np.empty(0, dtype=np.int_)
+    return (
+        np.array(all_bp_list, dtype=dtype),
+        np.array(sum_mults_list, dtype=np.int_),
+    )
+
+
+def _lookup_mults_in_space(
+    all_bp: npt.NDArray[np.float32 | np.float64],
+    bp_space: npt.NDArray[np.float32 | np.float64],
+    mult_space: npt.NDArray[np.int_],
+    tol: float,
+) -> npt.NDArray[np.int_]:
+    """Look up the multiplicity of each merged breakpoint within a single space.
+
+    For each entry in ``all_bp``, finds the corresponding entry in ``bp_space``
+    (within ``tol``) and returns its multiplicity; returns 0 for breakpoints
+    absent from that space.
+
+    Both ``all_bp`` and ``bp_space`` must be sorted in ascending order.
+
+    Args:
+        all_bp (npt.NDArray[np.float32 | np.float64]): Merged (union) interior
+            breakpoints, sorted ascending.
+        bp_space (npt.NDArray[np.float32 | np.float64]): Interior breakpoints of
+            one space, sorted ascending.
+        mult_space (npt.NDArray[np.int_]): Multiplicities for ``bp_space``.
+        tol (float): Tolerance for coincidence tests.
+
+    Returns:
+        npt.NDArray[np.int_]: Array of shape ``(len(all_bp),)`` containing the
+        multiplicity in the given space for each entry of ``all_bp`` (0 if absent).
+    """
+    result = np.zeros(len(all_bp), dtype=np.int_)
+    j = 0
+    for i in range(len(all_bp)):
+        xi = float(all_bp[i])
+        while j < len(bp_space) and float(bp_space[j]) < xi - tol:
+            j += 1
+        if j < len(bp_space) and abs(float(bp_space[j]) - xi) <= tol:
+            result[i] = mult_space[j]
+            j += 1
+    return result
+
+
+def _knots_for_full_bezier(
+    space_1d: BsplineSpace1D,
+    all_bp: npt.NDArray[np.float32 | np.float64],
+    mults_in_space: npt.NDArray[np.int_],
+    tol: float,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute the additional knots needed to bring a space to full-Bézier form.
+
+    For each breakpoint ``ξ`` with existing multiplicity ``m`` in ``space_1d``,
+    inserts ``degree - m`` copies of ``ξ`` so that every interior breakpoint
+    reaches multiplicity ``degree`` (full-Bézier / C^0).
+
+    Args:
+        space_1d (BsplineSpace1D): The 1D B-spline space to refine.
+        all_bp (npt.NDArray[np.float32 | np.float64]): Union of interior
+            breakpoints (sorted ascending).
+        mults_in_space (npt.NDArray[np.int_]): Multiplicity of each entry of
+            ``all_bp`` in ``space_1d`` (0 if absent).
+        tol (float): Tolerance (unused here, kept for API symmetry).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Flat sorted array of knot values
+        to insert, possibly empty.
+    """
+    degree = space_1d.degree
+    dtype = space_1d.knots.dtype
+    knots_to_insert: list[float] = []
+    for xi, m in zip(all_bp, mults_in_space, strict=True):
+        n_to_insert = degree - int(m)
+        if n_to_insert > 0:
+            knots_to_insert.extend([float(xi)] * n_to_insert)
+    if len(knots_to_insert) == 0:
+        return np.empty(0, dtype=dtype)
+    return np.array(knots_to_insert, dtype=dtype)
+
+
+def _bernstein_product_coefficients(
+    b_f: npt.NDArray[np.float32 | np.float64],
+    b_g: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Compute Bézier control points of the product of two Bézier segments.
+
+    Applies the Bernstein product formula element-wise over the rank axis:
+
+    .. math::
+
+        d_k = \frac{1}{\binom{p+q}{k}} \sum_{i=\max(0,k-q)}^{\min(p,k)}
+              \binom{p}{i} \binom{q}{k-i}\, b_f[i] \cdot b_g[k-i]
+
+    Args:
+        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            Bézier segment, shape ``(p+1, rank)``.
+        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            Bézier segment, shape ``(q+1, rank)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product Bézier control points of
+        shape ``(p+q+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    p = b_f.shape[0] - 1
+    q = b_g.shape[0] - 1
+    rank = b_f.shape[1]
+    r = p + q
+    dtype = b_f.dtype
+    d = np.zeros((r + 1, rank), dtype=dtype)
+
+    for k in range(r + 1):
+        i_min = max(0, k - q)
+        i_max = min(p, k)
+        cpq_k = math.comb(r, k)
+        for i in range(i_min, i_max + 1):
+            j = k - i
+            coeff = dtype.type(math.comb(p, i) * math.comb(q, j)) / dtype.type(cpq_k)
+            d[k] += coeff * b_f[i] * b_g[j]
+
+    return d
+
+
+def _build_product_knot_vector(
+    domain: tuple[np.float32 | np.float64, np.float32 | np.float64],
+    all_bp: npt.NDArray[np.float32 | np.float64],
+    degree_sum: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build the full-Bézier knot vector for the product B-spline space.
+
+    Assembles a clamped full-Bézier knot vector with:
+    - ``degree_sum + 1`` copies of the left endpoint ``a``
+    - For each interior breakpoint ``ξ``: ``degree_sum`` copies (C^0)
+    - ``degree_sum + 1`` copies of the right endpoint ``b``
+
+    The resulting space has exactly ``n_elements * degree_sum + 1`` basis
+    functions, matching the number of control points assembled by the
+    Bernstein product formula.
+
+    Args:
+        domain (tuple[np.float32 | np.float64, np.float32 | np.float64]): Domain
+            endpoints ``(a, b)`` of the parametric interval.
+        all_bp (npt.NDArray[np.float32 | np.float64]): Interior breakpoints of the
+            union mesh, sorted ascending.
+        degree_sum (int): Total polynomial degree ``p + q`` of the product space;
+            also the interior knot multiplicity (full-Bézier).
+        dtype (npt.DTypeLike): Floating-point dtype for the output knot vector.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Full-Bézier clamped knot vector for
+        the product space.
+    """
+    a, b = domain
+    parts: list[npt.NDArray[np.float32 | np.float64]] = [np.full(degree_sum + 1, a, dtype=dtype)]
+    for xi in all_bp:
+        parts.append(np.full(degree_sum, xi, dtype=dtype))
+    parts.append(np.full(degree_sum + 1, b, dtype=dtype))
+    result: npt.NDArray[np.float32 | np.float64] = np.concatenate(parts)
+    return result
+
+
+def _to_rational(f: Bspline) -> Bspline:
+    """Convert a B-spline to rational form by appending a column of unit weights.
+
+    If ``f`` is already rational, returns it unchanged.  Otherwise, creates a
+    new :class:`~pantr.bspline.Bspline` with the same space and control points
+    augmented by a column of ones (homogeneous weights = 1).
+
+    Args:
+        f (~pantr.bspline.Bspline): The B-spline to convert.
+
+    Returns:
+        ~pantr.bspline.Bspline: Rational B-spline equivalent to ``f``.
+    """
+    if f.is_rational:
+        return f
+    from .bspline import Bspline  # noqa: PLC0415
+
+    n = f.control_points.shape[0]
+    weights = np.ones((n, 1), dtype=f.control_points.dtype)
+    new_ctrl = np.concatenate([f.control_points, weights], axis=-1)
+    return Bspline(f.space, new_ctrl, is_rational=True)
+
+
+def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
+    """Multiply two non-rational 1D B-splines using the full-Bézier approach.
+
+    Refines both operands to full-Bézier form (C^0 at every interior breakpoint),
+    then applies the Bernstein product formula element by element, and assembles
+    the result in the product space.
+
+    This function does not perform input validation; use :func:`_multiply_bspline_1d`
+    for the validated public entry point.
+
+    Args:
+        f (~pantr.bspline.Bspline): First non-rational 1D B-spline operand.
+        g (~pantr.bspline.Bspline): Second non-rational 1D B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Non-rational B-spline ``h`` such that
+        ``h(t) ≈ f(t) * g(t)`` for all ``t`` in the shared domain.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_multiply_bspline_1d` instead.
+    """
+    from .bspline import Bspline  # noqa: PLC0415
+
+    space_f = f.space.spaces[0]
+    space_g = g.space.spaces[0]
+    p = space_f.degree
+    q = space_g.degree
+    tol = max(float(space_f.tolerance), float(space_g.tolerance))
+
+    # --- Step 1: gather interior breakpoints ---
+    bp_f, mf = _get_interior_breakpoints_and_mults(space_f, tol)
+    bp_g, mg = _get_interior_breakpoints_and_mults(space_g, tol)
+
+    # --- Step 2: merge union of interior breakpoints ---
+    all_bp, _ = _merge_interior_breakpoints(bp_f, mf, bp_g, mg, tol)
+    n_elements = int(all_bp.size) + 1
+
+    # --- Step 3: compute per-space multiplicities at union breakpoints ---
+    mults_in_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
+    mults_in_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
+
+    # --- Step 4: refine to full-Bézier ---
+    knots_f_ins = _knots_for_full_bezier(space_f, all_bp, mults_in_f, tol)
+    knots_g_ins = _knots_for_full_bezier(space_g, all_bp, mults_in_g, tol)
+
+    f_bezier: Bspline = f.insert_knots(knots_f_ins) if knots_f_ins.size > 0 else f
+    g_bezier: Bspline = g.insert_knots(knots_g_ins) if knots_g_ins.size > 0 else g
+
+    # --- Step 5: assemble product control points ---
+    rank = int(f.control_points.shape[-1])
+    ctrl_h = np.empty((n_elements * (p + q) + 1, rank), dtype=f.control_points.dtype)
+
+    for e in range(n_elements):
+        b_f_e = f_bezier.control_points[e * p : e * p + p + 1]
+        b_g_e = g_bezier.control_points[e * q : e * q + q + 1]
+        ctrl_h[e * (p + q) : e * (p + q) + p + q + 1] = _bernstein_product_coefficients(
+            b_f_e, b_g_e
+        )
+
+    # --- Step 6: build product knot vector (full-Bézier, interior mult = p+q) ---
+    domain = space_f.domain
+    T_h = _build_product_knot_vector(domain, all_bp, p + q, f.control_points.dtype)
+    space_h = BsplineSpace([BsplineSpace1D(T_h, p + q)])
+    return Bspline(space_h, ctrl_h, is_rational=False)
+
+
+def _multiply_rational_1d(f: Bspline, g: Bspline) -> Bspline:
+    """Multiply two rational 1D B-splines (NURBS) using homogeneous coordinates.
+
+    Decomposes each rational operand into its numerator (weighted coordinates)
+    and denominator (weights) B-splines, multiplies each pair independently
+    using :func:`_multiply_nonrational_1d`, then reassembles the result.
+
+    Both ``f`` and ``g`` must already be rational (``is_rational=True``).
+
+    Args:
+        f (~pantr.bspline.Bspline): First rational 1D B-spline operand.
+        g (~pantr.bspline.Bspline): Second rational 1D B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Rational B-spline ``h`` such that
+        ``h(t) = f(t) * g(t)`` for all ``t`` in the shared domain.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_multiply_bspline_1d` instead.
+    """
+    from .bspline import Bspline  # noqa: PLC0415
+
+    # Split into numerator and denominator non-rational B-splines.
+    N_f = Bspline(f.space, f.control_points[:, :-1])
+    D_f = Bspline(f.space, f.control_points[:, -1:])
+    N_g = Bspline(g.space, g.control_points[:, :-1])
+    D_g = Bspline(g.space, g.control_points[:, -1:])
+
+    H_N = _multiply_nonrational_1d(N_f, N_g)
+    H_D = _multiply_nonrational_1d(D_f, D_g)
+
+    ctrl_h = np.concatenate([H_N.control_points, H_D.control_points], axis=-1)
+    return Bspline(H_N.space, ctrl_h, is_rational=True)
+
+
+def _multiply_bspline_1d(f: Bspline, g: Bspline) -> Bspline:
+    """Compute the exact pointwise product of two 1D B-splines.
+
+    Given B-splines ``f`` and ``g`` over the same 1D parametric domain, returns
+    a new B-spline ``h`` such that ``h(t) = f(t) * g(t)`` for all ``t`` in the
+    domain.  The result lives in the product space of degree ``p + q``.
+
+    Rational operands are handled via homogeneous-coordinate decomposition.  A
+    non-rational operand is silently promoted to rational (unit weights) when the
+    other is rational.
+
+    Args:
+        f (~pantr.bspline.Bspline): First 1D B-spline operand.
+        g (~pantr.bspline.Bspline): Second 1D B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Product B-spline ``h = f * g``.
+
+    Raises:
+        ValueError: If either ``f`` or ``g`` has ``dim != 1``.
+        ValueError: If ``f`` and ``g`` have different dtypes.
+        ValueError: If ``f`` and ``g`` have different ranks.
+        ValueError: If ``f`` and ``g`` have different parametric domains (beyond
+            the shared tolerance).
+        NotImplementedError: If either ``f`` or ``g`` has ``periodic=True``.
+    """
+    if f.dim != 1:
+        raise ValueError(f"f must be a 1D B-spline, got dim={f.dim}")
+    if g.dim != 1:
+        raise ValueError(f"g must be a 1D B-spline, got dim={g.dim}")
+
+    if np.dtype(f.dtype) != np.dtype(g.dtype):
+        raise ValueError(f"f and g must have the same dtype, got {f.dtype} and {g.dtype}")
+
+    if f.rank != g.rank:
+        raise ValueError(f"f and g must have the same rank, got {f.rank} and {g.rank}")
+
+    space_f = f.space.spaces[0]
+    space_g = g.space.spaces[0]
+
+    if space_f.periodic or space_g.periodic:
+        raise NotImplementedError("Multiplication of periodic B-splines is not supported.")
+
+    tol = max(float(space_f.tolerance), float(space_g.tolerance))
+    domain_f = space_f.domain
+    domain_g = space_g.domain
+    if (
+        abs(float(domain_f[0]) - float(domain_g[0])) > tol
+        or abs(float(domain_f[1]) - float(domain_g[1])) > tol
+    ):
+        raise ValueError(
+            f"f and g must share the same parametric domain. Got {domain_f} and {domain_g}."
+        )
+
+    if not f.is_rational and not g.is_rational:
+        return _multiply_nonrational_1d(f, g)
+    else:
+        return _multiply_rational_1d(_to_rational(f), _to_rational(g))

--- a/src/pantr/_bspline_product.py
+++ b/src/pantr/_bspline_product.py
@@ -127,6 +127,8 @@ def _lookup_mults_in_space(
     absent from that space.
 
     Both ``all_bp`` and ``bp_space`` must be sorted in ascending order.
+    Uses ``np.searchsorted`` for efficient binary search (same pattern as
+    :func:`~pantr._bspline_knots._get_last_knot_smaller_equal_impl`).
 
     Args:
         all_bp (npt.NDArray[np.float32 | np.float64]): Merged (union) interior
@@ -141,14 +143,13 @@ def _lookup_mults_in_space(
         multiplicity in the given space for each entry of ``all_bp`` (0 if absent).
     """
     result = np.zeros(len(all_bp), dtype=np.int_)
-    j = 0
-    for i in range(len(all_bp)):
-        xi = float(all_bp[i])
-        while j < len(bp_space) and float(bp_space[j]) < xi - tol:
-            j += 1
-        if j < len(bp_space) and abs(float(bp_space[j]) - xi) <= tol:
-            result[i] = mult_space[j]
-            j += 1
+    if bp_space.size == 0 or all_bp.size == 0:
+        return result
+    indices = np.searchsorted(bp_space, all_bp)
+    safe_idx = np.minimum(indices, bp_space.size - 1)
+    in_range = indices < bp_space.size
+    matched = in_range & (np.abs(bp_space[safe_idx] - all_bp) <= tol)
+    result[matched] = mult_space[safe_idx[matched]]
     return result
 
 

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -319,6 +319,43 @@ class Bspline:
 
         return _insert_knots_bspline(self, new_knots_per_dim)
 
+    def multiply(self, other: Bspline) -> Bspline:
+        """Return the exact pointwise product of this B-spline and another.
+
+        Given B-splines ``self`` and ``other`` over the same 1D parametric
+        domain, returns a new B-spline ``h`` such that ``h(t) = self(t) *
+        other(t)`` for all ``t`` in the domain.  The result lives in the product
+        space of degree ``p + q`` where ``p`` and ``q`` are the degrees of the
+        two operands.
+
+        Both non-rational and rational (NURBS) operands are supported.  A
+        non-rational operand is promoted to rational (unit weights) when the
+        other is rational.
+
+        Args:
+            other (Bspline): The second B-spline operand. Must be 1D with the
+                same dtype, rank, and parametric domain as ``self``.
+
+        Returns:
+            Bspline: A new B-spline representing ``self * other``.
+
+        Raises:
+            ValueError: If either operand has ``dim != 1``.
+            ValueError: If the operands have different dtypes.
+            ValueError: If the operands have different ranks.
+            ValueError: If the operands have different parametric domains.
+            NotImplementedError: If either operand is periodic.
+
+        Example:
+            >>> h = f.multiply(g)
+            >>> h2 = f * g  # equivalent via __mul__
+        """
+        from ._bspline_product import _multiply_bspline_1d  # noqa: PLC0415
+
+        return _multiply_bspline_1d(self, other)
+
+    __mul__ = multiply
+
     def subdivide(
         self,
         n_subdivisions: int | Sequence[int | None],

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -1,0 +1,272 @@
+"""Tests for B-spline pointwise multiplication."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_bspline(
+    knots: list[float],
+    degree: int,
+    ctrl: list[float] | list[list[float]],
+    is_rational: bool = False,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 1D B-spline from plain Python lists."""
+    space_1d = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
+    space = BsplineSpace([space_1d])
+    cp: npt.NDArray[np.float32 | np.float64] = np.array(ctrl, dtype=dtype)
+    return Bspline(space, cp, is_rational=is_rational)
+
+
+def eval_pts(a: float = 0.0, b: float = 1.0, n: int = 201) -> np.ndarray:  # type: ignore[type-arg]
+    """Return n evenly-spaced evaluation points in [a, b]."""
+    return np.linspace(a, b, n, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Non-rational tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalProduct:
+    """Correctness tests for non-rational B-spline multiplication."""
+
+    def test_same_knot_vector_degree2(self) -> None:
+        """Product of two quadratic B-splines on the same mesh."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 1.5, 3.0])
+        g = make_bspline(knots, 2, [0.5, 1.0, 2.0, 0.5])
+
+        h = f.multiply(g)
+
+        pts = eval_pts()
+        f_vals = f.evaluate(pts)
+        g_vals = g.evaluate(pts)
+        h_vals = h.evaluate(pts)
+
+        np.testing.assert_allclose(h_vals, f_vals * g_vals, atol=1e-11)
+
+    def test_different_knot_vectors(self) -> None:
+        """Product with non-matching interior breakpoints (union rule)."""
+        knots_f = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        knots_g = [0.0, 0.0, 0.0, 0.75, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 0.5, 3.0])
+        g = make_bspline(knots_g, 2, [2.0, 1.0, 3.0, 0.5])
+
+        h = f.multiply(g)
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_different_degrees(self) -> None:
+        """Product of splines with different degrees (p=2, q=3)."""
+        knots_f = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        knots_g = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 0.5, 3.0])
+        g = make_bspline(knots_g, 3, [1.0, 0.5, 2.0, 1.5, 0.5])
+
+        h = f.multiply(g)
+
+        assert h.degree == (5,)
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_additive_multiplicity_at_shared_knot(self) -> None:
+        """Interior multiplicity in h equals sum of multiplicities in f and g."""
+        # f: degree 2, interior knot 0.5 with mult 2 (C^0)
+        knots_f = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0]
+        # g: degree 2, interior knot 0.5 with mult 1 (C^1)
+        knots_g = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 3.0, 1.5, 2.0])
+        g = make_bspline(knots_g, 2, [0.5, 1.5, 2.5, 1.0])
+
+        h = f.multiply(g)
+
+        # Product degree = 4, interior mult = 2+1 = 3
+        assert h.degree == (4,)
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_vector_rank(self) -> None:
+        """Component-wise product for rank-2 splines."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [[1.0, 2.0], [0.5, 1.0], [2.0, 3.0], [1.5, 0.5]])
+        g = make_bspline(knots, 2, [[2.0, 0.5], [1.0, 3.0], [0.5, 1.5], [3.0, 2.0]])
+
+        h = f.multiply(g)
+
+        assert h.rank == 2  # noqa: PLR2004
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_three_element_mesh(self) -> None:
+        """Product on a mesh with two interior breakpoints."""
+        # degree=3, knots give 10-3-1=6 basis functions for each spline
+        knots = [0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0, 1.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 3, [1.0, 0.5, 2.0, 1.5, 3.0, 0.5])
+        g = make_bspline(knots, 3, [2.0, 1.0, 0.5, 3.0, 1.5, 2.0])
+
+        h = f.multiply(g)
+
+        assert h.degree == (6,)
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_mul_operator(self) -> None:
+        """``f * g`` is equivalent to ``f.multiply(g)``."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 3.0])
+        g = make_bspline(knots, 2, [2.0, 1.0, 0.5])
+
+        h_mul = f.multiply(g)
+        h_op = f * g
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h_mul.evaluate(pts), h_op.evaluate(pts), atol=1e-15)
+
+
+# ---------------------------------------------------------------------------
+# Rational tests
+# ---------------------------------------------------------------------------
+
+
+class TestRationalProduct:
+    """Tests for products involving rational (NURBS) B-splines."""
+
+    def test_mixed_nonrational_times_rational(self) -> None:
+        """Non-rational x rational: result should be rational."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 3.0])
+        # Rational with non-unit weights: CPs store [w*P, w]
+        g = make_bspline(knots, 2, [[1.0, 1.0], [4.0, 2.0], [3.0, 1.0]], is_rational=True)
+
+        h = f.multiply(g)
+
+        assert h.is_rational
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_rational_times_rational(self) -> None:
+        """Rational x rational with non-unit weights."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        # f: w*P stored in col 0, w in col 1
+        f = make_bspline(
+            knots, 2, [[1.0, 1.0], [4.0, 2.0], [1.5, 1.0], [3.0, 1.5]], is_rational=True
+        )
+        g = make_bspline(
+            knots, 2, [[2.0, 2.0], [1.0, 1.0], [3.0, 1.5], [0.5, 0.5]], is_rational=True
+        )
+
+        h = f.multiply(g)
+
+        assert h.is_rational
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge-case tests for B-spline multiplication."""
+
+    def test_single_bezier_element(self) -> None:
+        """Single-element Bezier x Bezier (no interior breakpoints)."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 3.0])
+        g = make_bspline(knots, 2, [3.0, 1.0, 2.0])
+
+        h = f.multiply(g)
+
+        assert h.degree == (4,)
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_multiply_by_constant(self) -> None:
+        """Multiplying by a degree-0 constant spline scales the result."""
+        knots_f = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 0.5, 3.0])
+        # Degree-0 constant: B-spline of value 2 everywhere
+        knots_c = [0.0, 1.0]
+        c = make_bspline(knots_c, 0, [2.0])
+
+        h = f.multiply(c)
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * 2.0, atol=1e-11)
+
+    def test_multiply_by_one(self) -> None:
+        """Multiplying by the constant spline 1 is the identity (up to degree)."""
+        knots_f = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 0.5, 3.0])
+        knots_one = [0.0, 1.0]
+        one = make_bspline(knots_one, 0, [1.0])
+
+        h = f.multiply(one)
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts), atol=1e-11)
+
+    def test_error_dim_not_1_f(self) -> None:
+        """Raises ValueError when f has dim != 1."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        space_1d = BsplineSpace1D(knots, 2)
+        space_2d = BsplineSpace([space_1d, space_1d])
+        f2d = Bspline(space_2d, np.ones((3, 3, 1), dtype=np.float64))
+
+        knots_1d = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        g = make_bspline(knots_1d, 2, [1.0, 1.0, 1.0])
+
+        with pytest.raises(ValueError, match="dim=2"):
+            f2d.multiply(g)
+
+    def test_error_dtype_mismatch(self) -> None:
+        """Raises ValueError when dtypes differ."""
+        knots64 = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots64, 2, [1.0, 2.0, 3.0], dtype=np.float64)
+        g = make_bspline(knots64, 2, [1.0, 1.0, 1.0], dtype=np.float32)
+
+        with pytest.raises(ValueError, match="dtype"):
+            f.multiply(g)
+
+    def test_error_rank_mismatch(self) -> None:
+        """Raises ValueError when ranks differ."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])  # rank 2
+        g = make_bspline(knots, 2, [1.0, 1.0, 1.0])  # rank 1
+
+        with pytest.raises(ValueError, match="rank"):
+            f.multiply(g)
+
+    def test_error_domain_mismatch(self) -> None:
+        """Raises ValueError when domains differ."""
+        f = make_bspline([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2, [1.0, 2.0, 3.0])
+        g = make_bspline([0.0, 0.0, 0.0, 2.0, 2.0, 2.0], 2, [1.0, 1.0, 1.0])
+
+        with pytest.raises(ValueError, match="domain"):
+            f.multiply(g)
+
+    def test_error_periodic(self) -> None:
+        """Raises NotImplementedError for periodic B-splines."""
+        knots = [0.0, 0.0, 0.5, 1.0, 1.0]
+        f = make_bspline(knots, 1, [1.0, 2.0, 3.0])
+        knots_p = np.array([0.0, 0.5, 1.0, 1.5, 2.0], dtype=np.float64)
+        space_p_1d = BsplineSpace1D(knots_p, 1, periodic=True)
+        space_p = BsplineSpace([space_p_1d])
+        n_basis = space_p.num_total_basis
+        g_p = Bspline(space_p, np.ones(n_basis, dtype=np.float64))
+        with pytest.raises(NotImplementedError):
+            f.multiply(g_p)


### PR DESCRIPTION
## Summary

- Implements exact pointwise multiplication of two 1D B-splines via full-Bézier extraction and the Bernstein product formula
- Works for both non-rational and rational (NURBS) operands; non-rational is promoted to rational with unit weights when needed
- New `_bspline_product.py` (Layer 2) + `Bspline.multiply` / `Bspline.__mul__` on the public API

## Algorithm

1. Gather interior breakpoints and multiplicities from both spaces
2. Merge into a union mesh via two-pointer scan
3. Refine each operand to full-Bézier (C⁰ at every interior breakpoint) by knot insertion
4. Apply the Bernstein product formula element-by-element
5. Assemble control points into a full-Bézier product space of degree `p + q`

The product knot vector uses interior multiplicity `p + q` (full-Bézier), giving `n_elements * (p+q) + 1` basis functions — consistent with the assembled control points.

**Note:** The plan described `sum_mults = m_f + m_g` as the interior multiplicity of the product knot vector, but that is inconsistent with the assembled control point count. The correct representation is full-Bézier (interior mult = `p + q`), which is always a valid (though not minimal) representation of the exact product.

## Test plan

- [x] Non-rational: same knot vector, different knot vectors, different degrees, additive multiplicity, vector rank, three-element mesh, `__mul__` operator
- [x] Rational: non-rational × rational (mixed promotion), rational × rational with non-unit weights
- [x] Edge cases: single Bézier element, multiply by constant, multiply by 1
- [x] Error paths: `dim ≠ 1`, dtype mismatch, rank mismatch, domain mismatch, periodic splines
- [x] All correctness tests evaluate at 201 points and assert `allclose` with `atol=1e-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)