### PR TITLE
feat(bspline-product): optimal-continuity knot vector in 1D product

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -139,6 +139,9 @@ if not TYPE_CHECKING:
             _bspline_extraction._warmup_numba_functions()
             _bspline_knot_insertion_core._warmup_numba_functions()
             _bspline_knots._warmup_numba_functions()
+            from . import _bspline_blossom_core  # noqa: PLC0415
+
+            _bspline_blossom_core._warmup_numba_functions()
             logger.debug("Finished Numba JIT warmup.")
         except Exception:
             # During process teardown (e.g. short scripts), background Numba caching

--- a/src/pantr/_bspline_blossom.py
+++ b/src/pantr/_bspline_blossom.py
@@ -1,0 +1,72 @@
+"""Layer 2 helper for B-spline blossom (polar form) evaluation.
+
+Provides :func:`_evaluate_blossom_1d`, a validated entry point that delegates
+to the Numba kernel in :mod:`pantr._bspline_blossom_core`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_blossom_core import _evaluate_blossom_1d_core
+
+
+def _evaluate_blossom_1d(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    control_points: npt.NDArray[np.float32 | np.float64],
+    u_values: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate the blossom of a 1D B-spline at ``degree`` parameter values.
+
+    Computes the symmetric multilinear polar form ``f[u_0, ..., u_{p-1}]``
+    using the generalized de Boor algorithm.  The diagonal property guarantees
+    ``f[t, ..., t] == f(t)``, and the blossom is symmetric in its arguments.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector of shape
+            ``(n + degree + 2,)``.
+        degree (int): Polynomial degree ``p``.
+        control_points (npt.NDArray[np.float32 | np.float64]): Control point
+            matrix of shape ``(n + 1, rank)``.
+        u_values (npt.NDArray[np.float32 | np.float64]): Array of exactly
+            ``p`` parameter values.  Need not be sorted; values may coincide.
+        tol (float): Tolerance for domain-membership checks.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Blossom value of shape
+        ``(rank,)``.
+
+    Raises:
+        ValueError: If ``len(u_values) != degree``.
+        ValueError: If any entry of ``u_values`` lies outside the domain
+            ``[knots[degree], knots[-degree-1]]`` (beyond ``tol``).
+        ValueError: If ``knots`` and ``u_values`` have incompatible dtypes.
+    """
+    if u_values.shape[0] != degree:
+        raise ValueError(f"u_values must have length degree={degree}, got {u_values.shape[0]}.")
+
+    if degree == 0:
+        # Degree-0: no u_values to check; return the single control point.
+        return _evaluate_blossom_1d_core(
+            knots, degree, control_points, np.empty(0, dtype=knots.dtype)
+        )
+
+    a = float(knots[degree])
+    b = float(knots[knots.shape[0] - degree - 1])
+    for u in u_values:
+        if float(u) < a - tol or float(u) > b + tol:
+            raise ValueError(
+                f"u_values entry {float(u)!r} is outside domain [{a}, {b}] (tol={tol})."
+            )
+
+    # Sort ascending before passing to the kernel (symmetry — order does not
+    # affect the mathematical result, but the kernel relies on ascending order
+    # to find the correct knot span).
+    u_sorted: npt.NDArray[np.float32 | np.float64] = np.sort(u_values)
+    return _evaluate_blossom_1d_core(knots, degree, control_points, u_sorted)
+
+
+__all__ = ["_evaluate_blossom_1d"]

--- a/src/pantr/_bspline_blossom_core.py
+++ b/src/pantr/_bspline_blossom_core.py
@@ -1,0 +1,111 @@
+"""Numba kernel for B-spline blossom (polar form) evaluation.
+
+Implements the generalized de Boor algorithm to evaluate the symmetric
+multilinear polar form of a B-spline at an arbitrary sequence of parameter
+values.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call the Layer 2 helper ``_evaluate_blossom_1d`` in
+    ``_bspline_blossom`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from ._numba_compat import nb_jit
+
+
+@nb_jit(nopython=True, cache=True)
+def _evaluate_blossom_1d_core(
+    knots: npt.NDArray[Any],
+    degree: int,
+    control_points: npt.NDArray[Any],
+    u_values: npt.NDArray[Any],
+) -> npt.NDArray[Any]:
+    """Evaluate the blossom of a 1D B-spline at ``degree`` parameter values.
+
+    Computes the symmetric multilinear polar form ``f[u_0, ..., u_{p-1}]``
+    using the generalized de Boor algorithm.  The blossom satisfies
+    ``f[t, t, ..., t] = f(t)`` (diagonal property) and is symmetric in its
+    arguments.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot vector of shape ``(n + degree + 2,)``.
+        degree (int): Polynomial degree ``p``.
+        control_points (npt.NDArray[Any]): Control point matrix of shape
+            ``(n + 1, rank)``.
+        u_values (npt.NDArray[Any]): Sorted ascending array of ``p`` parameter
+            values at which to evaluate the blossom.
+
+    Returns:
+        npt.NDArray[Any]: Blossom value of shape ``(rank,)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``u_values`` must be sorted in ascending order and have length ``p``.
+        For general use, call ``_evaluate_blossom_1d`` instead.
+    """
+    rank = control_points.shape[1]
+
+    if degree == 0:
+        # Degree-0 blossom: locate the single control point whose support
+        # contains u (there are no u_values since p=0).
+        # For a degree-0 B-spline, B_i has support [t_i, t_{i+1}).
+        # By convention we pick the last active knot span.
+        n = control_points.shape[0] - 1
+        result = np.empty(rank, dtype=control_points.dtype)
+        for r in range(rank):
+            result[r] = control_points[n, r]
+        return result
+
+    # Find knot span for the largest u value (u_values[-1]).
+    u_last = u_values[degree - 1]
+    n = control_points.shape[0] - 1
+    k = n  # default: rightmost span
+    for idx in range(n + degree):
+        if knots[idx] <= u_last < knots[idx + 1]:
+            k = idx
+            break
+
+    # Local copy of control points d[j] = P[k-p+j] for j in 0..p.
+    d = np.empty((degree + 1, rank), dtype=control_points.dtype)
+    for j in range(degree + 1):
+        idx = k - degree + j
+        for r in range(rank):
+            d[j, r] = control_points[idx, r]
+
+    # Generalized de Boor recurrence: level l uses u_values[l-1].
+    for level in range(1, degree + 1):
+        u = u_values[level - 1]
+        for j in range(degree, level - 1, -1):
+            # d[j] corresponds to global index k - degree + j
+            global_j = k - degree + j
+            denom = knots[global_j + degree + 1 - level] - knots[global_j]
+            alpha = (u - knots[global_j]) / denom if denom > 0.0 else 0.0
+            for r in range(rank):
+                d[j, r] = (1.0 - alpha) * d[j - 1, r] + alpha * d[j, r]
+
+    result = np.empty(rank, dtype=control_points.dtype)
+    for r in range(rank):
+        result[r] = d[degree, r]
+    return result
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile Numba functions with float64 signatures for faster first call.
+
+    Triggers compilation of the Numba-decorated functions with float64 arrays
+    so they are cached and ready for use on first call.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+    ctrl = np.array([[0.0], [0.5], [1.0]], dtype=np.float64)
+    u_vals = np.array([0.3, 0.6], dtype=np.float64)
+    _evaluate_blossom_1d_core(knots, 2, ctrl, u_vals)
+
+
+__all__ = ["_evaluate_blossom_1d_core"]

--- a/src/pantr/_bspline_product.py
+++ b/src/pantr/_bspline_product.py
@@ -1,8 +1,13 @@
 """B-spline pointwise product for 1D splines.
 
 This module provides :func:`_multiply_bspline_1d`, which computes the exact
-pointwise product of two 1D B-splines via full-Bézier extraction and the
-Bernstein product formula. Works for both non-rational and rational (NURBS) splines.
+pointwise product of two 1D B-splines via Bézier extraction and the Bernstein
+product formula.  The result lives in the product space of degree ``p + q``
+with **optimal continuity**: each interior knot's multiplicity equals
+``max(m1 + q, m2 + p)`` where ``m1``, ``m2`` are the individual multiplicities
+and ``p``, ``q`` are the respective degrees.
+
+Works for both non-rational and rational (NURBS) splines.
 """
 
 from __future__ import annotations
@@ -47,73 +52,6 @@ def _get_interior_breakpoints_and_mults(
     return unique[1:-1], mults[1:-1]
 
 
-def _merge_interior_breakpoints(
-    bp1: npt.NDArray[np.float32 | np.float64],
-    mult1: npt.NDArray[np.int_],
-    bp2: npt.NDArray[np.float32 | np.float64],
-    mult2: npt.NDArray[np.int_],
-    tol: float,
-) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
-    """Merge two sorted interior breakpoint arrays with additive multiplicities.
-
-    Uses a two-pointer scan.  When two breakpoints are within ``tol`` of each
-    other they are considered the same knot; their position is averaged and
-    their multiplicities are summed.  A breakpoint absent from one side
-    contributes 0 to the sum (i.e. the other side's multiplicity is taken
-    as-is).
-
-    Args:
-        bp1 (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
-            of the first space.
-        mult1 (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp1``.
-        bp2 (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
-            of the second space.
-        mult2 (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp2``.
-        tol (float): Tolerance for coincidence tests.
-
-    Returns:
-        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Merged
-        ``(all_bp, sum_mults)`` arrays in ascending order.
-    """
-    n1, n2 = len(bp1), len(bp2)
-    i, j = 0, 0
-    all_bp_list: list[float] = []
-    sum_mults_list: list[int] = []
-
-    while i < n1 and j < n2:
-        if abs(float(bp1[i]) - float(bp2[j])) <= tol:
-            all_bp_list.append(float(bp1[i] + bp2[j]) / 2.0)
-            sum_mults_list.append(int(mult1[i]) + int(mult2[j]))
-            i += 1
-            j += 1
-        elif float(bp1[i]) < float(bp2[j]):
-            all_bp_list.append(float(bp1[i]))
-            sum_mults_list.append(int(mult1[i]))
-            i += 1
-        else:
-            all_bp_list.append(float(bp2[j]))
-            sum_mults_list.append(int(mult2[j]))
-            j += 1
-
-    while i < n1:
-        all_bp_list.append(float(bp1[i]))
-        sum_mults_list.append(int(mult1[i]))
-        i += 1
-
-    while j < n2:
-        all_bp_list.append(float(bp2[j]))
-        sum_mults_list.append(int(mult2[j]))
-        j += 1
-
-    dtype = bp1.dtype
-    if len(all_bp_list) == 0:
-        return np.empty(0, dtype=dtype), np.empty(0, dtype=np.int_)
-    return (
-        np.array(all_bp_list, dtype=dtype),
-        np.array(sum_mults_list, dtype=np.int_),
-    )
-
-
 def _lookup_mults_in_space(
     all_bp: npt.NDArray[np.float32 | np.float64],
     bp_space: npt.NDArray[np.float32 | np.float64],
@@ -127,8 +65,7 @@ def _lookup_mults_in_space(
     absent from that space.
 
     Both ``all_bp`` and ``bp_space`` must be sorted in ascending order.
-    Uses ``np.searchsorted`` for efficient binary search (same pattern as
-    :func:`~pantr._bspline_knots._get_last_knot_smaller_equal_impl`).
+    Uses ``np.searchsorted`` for efficient binary search.
 
     Args:
         all_bp (npt.NDArray[np.float32 | np.float64]): Merged (union) interior
@@ -151,6 +88,83 @@ def _lookup_mults_in_space(
     matched = in_range & (np.abs(bp_space[safe_idx] - all_bp) <= tol)
     result[matched] = mult_space[safe_idx[matched]]
     return result
+
+
+def _merge_interior_breakpoints(  # noqa: PLR0913
+    bp_f: npt.NDArray[np.float32 | np.float64],
+    mf: npt.NDArray[np.int_],
+    bp_g: npt.NDArray[np.float32 | np.float64],
+    mg: npt.NDArray[np.int_],
+    p: int,
+    q: int,
+    tol: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
+    """Merge two sorted interior breakpoint arrays with optimal product multiplicities.
+
+    Uses a two-pointer scan to compute the union of interior breakpoints from
+    both spaces and assigns each breakpoint the correct multiplicity in the
+    product space of degree ``p + q``.
+
+    The product multiplicity at a shared breakpoint follows the formula::
+
+        m_h(ξ) = max(m_f(ξ) + q, m_g(ξ) + p)
+
+    This ensures the product spline has continuity ``C^{min(p-m_f, q-m_g)}`` at
+    ``ξ``, which is the correct smoothness of the pointwise product of two splines.
+    A breakpoint absent from one operand contributes ``m=0`` for that operand.
+
+    Args:
+        bp_f (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
+            of the first space (degree ``p``).
+        mf (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp_f``.
+        bp_g (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
+            of the second space (degree ``q``).
+        mg (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp_g``.
+        p (int): Degree of the first operand.
+        q (int): Degree of the second operand.
+        tol (float): Tolerance for coincidence tests.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Merged
+        ``(all_bp, product_mults)`` arrays in ascending order.
+    """
+    n1, n2 = len(bp_f), len(bp_g)
+    i, j = 0, 0
+    all_bp_list: list[float] = []
+    mults_list: list[int] = []
+
+    while i < n1 and j < n2:
+        if abs(float(bp_f[i]) - float(bp_g[j])) <= tol:
+            all_bp_list.append(float(bp_f[i] + bp_g[j]) / 2.0)
+            mults_list.append(max(int(mf[i]) + q, int(mg[j]) + p))
+            i += 1
+            j += 1
+        elif float(bp_f[i]) < float(bp_g[j]):
+            all_bp_list.append(float(bp_f[i]))
+            mults_list.append(max(int(mf[i]) + q, q + p))  # m_g=0 → max(mf+q, p+q)=p+q
+            i += 1
+        else:
+            all_bp_list.append(float(bp_g[j]))
+            mults_list.append(max(p + q, int(mg[j]) + p))  # m_f=0 → max(p+q, mg+p)=p+q
+            j += 1
+
+    while i < n1:
+        all_bp_list.append(float(bp_f[i]))
+        mults_list.append(p + q)  # absent from g → C^0 in product
+        i += 1
+
+    while j < n2:
+        all_bp_list.append(float(bp_g[j]))
+        mults_list.append(p + q)  # absent from f → C^0 in product
+        j += 1
+
+    dtype = bp_f.dtype if bp_f.size > 0 else bp_g.dtype
+    if len(all_bp_list) == 0:
+        return np.empty(0, dtype=dtype), np.empty(0, dtype=np.int_)
+    return (
+        np.array(all_bp_list, dtype=dtype),
+        np.array(mults_list, dtype=np.int_),
+    )
 
 
 def _knots_for_full_bezier(
@@ -237,37 +251,39 @@ def _bernstein_product_coefficients(
 def _build_product_knot_vector(
     domain: tuple[np.float32 | np.float64, np.float32 | np.float64],
     all_bp: npt.NDArray[np.float32 | np.float64],
+    product_mults: npt.NDArray[np.int_],
     degree_sum: int,
     dtype: npt.DTypeLike,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Build the full-Bézier knot vector for the product B-spline space.
+    """Build the product B-spline knot vector with optimal continuity.
 
-    Assembles a clamped full-Bézier knot vector with:
+    Assembles a clamped knot vector with:
+
     - ``degree_sum + 1`` copies of the left endpoint ``a``
-    - For each interior breakpoint ``ξ``: ``degree_sum`` copies (C^0)
+    - For each interior breakpoint ``ξ``: ``product_mults[k]`` copies
     - ``degree_sum + 1`` copies of the right endpoint ``b``
 
-    The resulting space has exactly ``n_elements * degree_sum + 1`` basis
-    functions, matching the number of control points assembled by the
-    Bernstein product formula.
+    The interior multiplicities from ``product_mults`` encode the optimal
+    continuity: ``C^{degree_sum - product_mults[k]}`` at breakpoint ``ξ_k``.
 
     Args:
         domain (tuple[np.float32 | np.float64, np.float32 | np.float64]): Domain
             endpoints ``(a, b)`` of the parametric interval.
-        all_bp (npt.NDArray[np.float32 | np.float64]): Interior breakpoints of the
-            union mesh, sorted ascending.
-        degree_sum (int): Total polynomial degree ``p + q`` of the product space;
-            also the interior knot multiplicity (full-Bézier).
+        all_bp (npt.NDArray[np.float32 | np.float64]): Interior breakpoints of
+            the union mesh, sorted ascending.
+        product_mults (npt.NDArray[np.int_]): Product-space multiplicity for
+            each entry of ``all_bp``.
+        degree_sum (int): Total polynomial degree ``p + q`` of the product space.
         dtype (npt.DTypeLike): Floating-point dtype for the output knot vector.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Full-Bézier clamped knot vector for
-        the product space.
+        npt.NDArray[np.float32 | np.float64]: Clamped knot vector for the
+        product space.
     """
     a, b = domain
     parts: list[npt.NDArray[np.float32 | np.float64]] = [np.full(degree_sum + 1, a, dtype=dtype)]
-    for xi in all_bp:
-        parts.append(np.full(degree_sum, xi, dtype=dtype))
+    for xi, m in zip(all_bp, product_mults, strict=True):
+        parts.append(np.full(int(m), xi, dtype=dtype))
     parts.append(np.full(degree_sum + 1, b, dtype=dtype))
     result: npt.NDArray[np.float32 | np.float64] = np.concatenate(parts)
     return result
@@ -297,11 +313,17 @@ def _to_rational(f: Bspline) -> Bspline:
 
 
 def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
-    """Multiply two non-rational 1D B-splines using the full-Bézier approach.
+    """Multiply two non-rational 1D B-splines with optimal-continuity output.
 
-    Refines both operands to full-Bézier form (C^0 at every interior breakpoint),
-    then applies the Bernstein product formula element by element, and assembles
-    the result in the product space.
+    Refines both operands to full-Bézier form (C^0 at every interior
+    breakpoint), applies the Bernstein product formula element by element to
+    obtain control points in a full-Bézier representation, then assembles the
+    result using an optimal-continuity knot vector.
+
+    The product knot vector uses interior multiplicities
+    ``max(m_f(ξ) + q, m_g(ξ) + p)`` at each breakpoint ``ξ``, which is the
+    minimum multiplicity required to represent the product exactly while
+    achieving the maximum possible continuity.
 
     This function does not perform input validation; use :func:`_multiply_bspline_1d`
     for the validated public entry point.
@@ -312,7 +334,7 @@ def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
 
     Returns:
         ~pantr.bspline.Bspline: Non-rational B-spline ``h`` such that
-        ``h(t) ≈ f(t) * g(t)`` for all ``t`` in the shared domain.
+        ``h(t) = f(t) * g(t)`` for all ``t`` in the shared domain.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -326,41 +348,81 @@ def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
     q = space_g.degree
     tol = max(float(space_f.tolerance), float(space_g.tolerance))
 
-    # --- Step 1: gather interior breakpoints ---
+    # --- Step 1: gather interior breakpoints from both operands ---
     bp_f, mf = _get_interior_breakpoints_and_mults(space_f, tol)
     bp_g, mg = _get_interior_breakpoints_and_mults(space_g, tol)
 
-    # --- Step 2: merge union of interior breakpoints ---
-    all_bp, _ = _merge_interior_breakpoints(bp_f, mf, bp_g, mg, tol)
+    # --- Step 2: compute union of breakpoints with optimal product multiplicities ---
+    all_bp, product_mults = _merge_interior_breakpoints(bp_f, mf, bp_g, mg, p, q, tol)
     n_elements = int(all_bp.size) + 1
 
     # --- Step 3: compute per-space multiplicities at union breakpoints ---
     mults_in_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
     mults_in_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
 
-    # --- Step 4: refine to full-Bézier ---
+    # --- Step 4: refine both operands to full-Bézier ---
     knots_f_ins = _knots_for_full_bezier(space_f, all_bp, mults_in_f, tol)
     knots_g_ins = _knots_for_full_bezier(space_g, all_bp, mults_in_g, tol)
 
     f_bezier: Bspline = f.insert_knots(knots_f_ins) if knots_f_ins.size > 0 else f
     g_bezier: Bspline = g.insert_knots(knots_g_ins) if knots_g_ins.size > 0 else g
 
-    # --- Step 5: assemble product control points ---
+    # --- Step 5: assemble product control points (full-Bézier representation) ---
     rank = int(f.control_points.shape[-1])
-    ctrl_h = np.empty((n_elements * (p + q) + 1, rank), dtype=f.control_points.dtype)
+    ctrl_h_bezier = np.empty((n_elements * (p + q) + 1, rank), dtype=f.control_points.dtype)
 
     for e in range(n_elements):
         b_f_e = f_bezier.control_points[e * p : e * p + p + 1]
         b_g_e = g_bezier.control_points[e * q : e * q + q + 1]
-        ctrl_h[e * (p + q) : e * (p + q) + p + q + 1] = _bernstein_product_coefficients(
+        ctrl_h_bezier[e * (p + q) : e * (p + q) + p + q + 1] = _bernstein_product_coefficients(
             b_f_e, b_g_e
         )
 
-    # --- Step 6: build product knot vector (full-Bézier, interior mult = p+q) ---
+    # --- Step 6: build product knot vector with optimal continuity ---
+    # The control points are in full-Bézier form; the product knot vector uses
+    # optimal multiplicities (max(m_f+q, m_g+p)), which may be less than p+q.
+    # To transition from the full-Bézier representation to the optimal one, we
+    # apply knot removal: a knot at ξ can be removed (product_mults[k]) times
+    # from its full-Bézier multiplicity (p+q).  The control points are updated
+    # accordingly via the Oslo algorithm in reverse (knot removal).
     domain = space_f.domain
-    T_h = _build_product_knot_vector(domain, all_bp, p + q, f.control_points.dtype)
-    space_h = BsplineSpace([BsplineSpace1D(T_h, p + q)])
-    return Bspline(space_h, ctrl_h, is_rational=False)
+    dtype = f.control_points.dtype
+
+    # Build the full-Bézier product B-spline first.
+    all_bp_arr = all_bp  # already ndarray
+    full_mults = np.full(all_bp.size, p + q, dtype=np.int_)
+    T_full = _build_product_knot_vector(domain, all_bp_arr, full_mults, p + q, dtype)
+    space_full = BsplineSpace([BsplineSpace1D(T_full, p + q)])
+    h_full = Bspline(space_full, ctrl_h_bezier, is_rational=False)
+
+    # If all product multiplicities equal p+q (e.g. all breakpoints are C^0),
+    # return the full-Bézier spline directly.
+    if all_bp.size == 0 or np.all(product_mults == p + q):
+        return h_full
+
+    # Determine how many knots to remove at each breakpoint.
+    # At each breakpoint ξ_k with full-Bezier mult (p+q), we want to reduce to
+    # product_mults[k].  Use knot removal via inverse Oslo: project the
+    # full-Bézier control points onto the subspace with reduced knots.
+    # The simplest approach: use the Oslo matrix to re-express the full-Bézier
+    # control points in the optimal knot vector space.
+    T_opt = _build_product_knot_vector(domain, all_bp_arr, product_mults, p + q, dtype)
+
+    # Compute the Oslo matrix mapping optimal → full-Bézier, then solve for
+    # optimal control points.  Since the product B-spline lives exactly in the
+    # optimal space, the Oslo matrix should have a (numerically) unique
+    # least-squares solution that recovers the optimal control points.
+    from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core  # noqa: PLC0415
+
+    # oslo[i,j]: coefficient of old CP j in new CP i (old=optimal, new=full-Bezier)
+    oslo = _compute_oslo_matrix_1d_core(p + q, T_opt, T_full)
+
+    # Solve oslo @ ctrl_opt = ctrl_h_bezier (least-squares, should be exact).
+    ctrl_opt, _res, _rank_ls, _sv = np.linalg.lstsq(oslo, ctrl_h_bezier, rcond=None)
+    ctrl_opt = ctrl_opt.astype(dtype)
+
+    space_opt = BsplineSpace([BsplineSpace1D(T_opt, p + q)])
+    return Bspline(space_opt, ctrl_opt, is_rational=False)
 
 
 def _multiply_rational_1d(f: Bspline, g: Bspline) -> Bspline:
@@ -404,7 +466,9 @@ def _multiply_bspline_1d(f: Bspline, g: Bspline) -> Bspline:
 
     Given B-splines ``f`` and ``g`` over the same 1D parametric domain, returns
     a new B-spline ``h`` such that ``h(t) = f(t) * g(t)`` for all ``t`` in the
-    domain.  The result lives in the product space of degree ``p + q``.
+    domain.  The result lives in the product space of degree ``p + q`` with
+    optimal continuity: interior knot multiplicities equal
+    ``max(m_f(ξ) + q, m_g(ξ) + p)``.
 
     Rational operands are handled via homogeneous-coordinate decomposition.  A
     non-rational operand is silently promoted to rational (unit weights) when the

--- a/tests/test_bspline_blossom.py
+++ b/tests/test_bspline_blossom.py
@@ -1,0 +1,204 @@
+"""Tests for B-spline blossom (polar form) evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr._bspline_blossom import _evaluate_blossom_1d
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _eval_blossom(
+    knots: list[float],
+    degree: int,
+    ctrl: list[float] | list[list[float]],
+    u_values: list[float],
+) -> np.ndarray:  # type: ignore[type-arg]
+    """Thin wrapper: build numpy arrays and call _evaluate_blossom_1d."""
+    kv = np.array(knots, dtype=np.float64)
+    cp = np.array(ctrl, dtype=np.float64)
+    if cp.ndim == 1:
+        cp = cp[:, np.newaxis]
+    u = np.array(u_values, dtype=np.float64)
+    tol = float(np.finfo(np.float64).eps * max(1.0, float(np.abs(kv).max())) * 64)
+    return _evaluate_blossom_1d(kv, degree, cp, u, tol)
+
+
+def _eval_spline(
+    knots: list[float],
+    degree: int,
+    ctrl: list[float],
+    t: float,
+) -> float:
+    """Evaluate a 1D B-spline at a single point via de Boor."""
+    kv = np.array(knots, dtype=np.float64)
+    cp = np.array(ctrl, dtype=np.float64)[:, np.newaxis]
+    space = BsplineSpace([BsplineSpace1D(kv, degree)])
+    f = Bspline(space, cp)
+    return float(f.evaluate(np.array([t])))
+
+
+# ---------------------------------------------------------------------------
+# Diagonal property: blossom(t, t, ..., t) == f(t)
+# ---------------------------------------------------------------------------
+
+
+class TestBlossomDiagonal:
+    """Test that the diagonal of the blossom equals the B-spline evaluation."""
+
+    def test_degree2_single_element(self) -> None:
+        """Diagonal property for a degree-2 single-element B-spline."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 2.0, 3.0]
+
+        for t in np.linspace(0.0, 1.0, 9):
+            blossom_val = _eval_blossom(knots, 2, ctrl, [t, t])
+            direct_val = _eval_spline(knots, 2, ctrl, t)
+            np.testing.assert_allclose(blossom_val[0], direct_val, atol=1e-12, err_msg=f"t={t}")
+
+    def test_degree3_two_elements(self) -> None:
+        """Diagonal property for a cubic B-spline with one interior knot."""
+        knots = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 0.5, 2.0, 1.5, 0.5]
+
+        for t in np.linspace(0.0, 1.0, 11):
+            blossom_val = _eval_blossom(knots, 3, ctrl, [t, t, t])
+            direct_val = _eval_spline(knots, 3, ctrl, t)
+            np.testing.assert_allclose(blossom_val[0], direct_val, atol=1e-12, err_msg=f"t={t}")
+
+    def test_degree1_linear(self) -> None:
+        """Diagonal property for a degree-1 B-spline (piecewise linear)."""
+        knots = [0.0, 0.0, 0.5, 1.0, 1.0]
+        ctrl = [1.0, 3.0, 2.0]
+
+        for t in np.linspace(0.0, 1.0, 9):
+            blossom_val = _eval_blossom(knots, 1, ctrl, [t])
+            direct_val = _eval_spline(knots, 1, ctrl, t)
+            np.testing.assert_allclose(blossom_val[0], direct_val, atol=1e-12, err_msg=f"t={t}")
+
+    def test_vector_rank(self) -> None:
+        """Diagonal property holds for each component of a vector-valued spline."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        ctrl = [[1.0, 2.0], [3.0, 0.5], [2.0, 1.5]]
+
+        for t in np.linspace(0.0, 1.0, 7):
+            blossom_val = _eval_blossom(knots, 2, ctrl, [t, t])
+            # Evaluate each component separately
+            val0 = _eval_spline(knots, 2, [row[0] for row in ctrl], t)
+            val1 = _eval_spline(knots, 2, [row[1] for row in ctrl], t)
+            np.testing.assert_allclose(blossom_val[0], val0, atol=1e-12)
+            np.testing.assert_allclose(blossom_val[1], val1, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Symmetry: blossom(u1, u2) == blossom(u2, u1)
+# ---------------------------------------------------------------------------
+
+
+class TestBlossomSymmetry:
+    """Test that the blossom is symmetric in its arguments."""
+
+    def test_degree2_symmetry(self) -> None:
+        """Blossom is symmetric for degree-2 spline."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 2.0, 0.5, 3.0]
+
+        for u1, u2 in [(0.1, 0.4), (0.2, 0.8), (0.5, 0.5), (0.0, 1.0)]:
+            b12 = _eval_blossom(knots, 2, ctrl, [u1, u2])
+            b21 = _eval_blossom(knots, 2, ctrl, [u2, u1])
+            np.testing.assert_allclose(b12, b21, atol=1e-12)
+
+    def test_degree3_symmetry(self) -> None:
+        """Blossom is symmetric for degree-3 spline with two elements."""
+        knots = [0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0, 1.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 0.5, 2.0, 1.5, 3.0, 0.5]
+
+        u1, u2, u3 = 0.1, 0.5, 0.8
+        orderings = [
+            [u1, u2, u3],
+            [u1, u3, u2],
+            [u2, u1, u3],
+            [u2, u3, u1],
+            [u3, u1, u2],
+            [u3, u2, u1],
+        ]
+        results = [_eval_blossom(knots, 3, ctrl, perm) for perm in orderings]
+        for res in results[1:]:
+            np.testing.assert_allclose(res, results[0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Control point recovery: blossom(t_{i+1}, ..., t_{i+p}) == P_i
+# ---------------------------------------------------------------------------
+
+
+class TestBlossomControlPointRecovery:
+    """Test that the blossom at consecutive interior knots recovers control points."""
+
+    def test_degree2_knot_values(self) -> None:
+        """blossom(t_{i+1}, t_{i+2}) == P[i] for degree-2 B-spline."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 2.0, 0.5, 3.0]
+        n = len(ctrl)
+        p = 2
+
+        for i in range(n):
+            u_vals = [float(knots[i + r]) for r in range(1, p + 1)]
+            blossom_val = _eval_blossom(knots, p, ctrl, u_vals)
+            np.testing.assert_allclose(blossom_val[0], ctrl[i], atol=1e-12, err_msg=f"i={i}")
+
+    def test_degree3_knot_values(self) -> None:
+        """blossom(t_{i+1}, t_{i+2}, t_{i+3}) == P[i] for degree-3 B-spline."""
+        knots = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 0.5, 2.0, 1.5, 0.5]
+        n = len(ctrl)
+        p = 3
+
+        for i in range(n):
+            u_vals = [float(knots[i + r]) for r in range(1, p + 1)]
+            blossom_val = _eval_blossom(knots, p, ctrl, u_vals)
+            np.testing.assert_allclose(blossom_val[0], ctrl[i], atol=1e-12, err_msg=f"i={i}")
+
+
+# ---------------------------------------------------------------------------
+# Input validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestBlossomValidation:
+    """Tests for input validation in _evaluate_blossom_1d."""
+
+    def test_wrong_u_values_length(self) -> None:
+        """Raises ValueError when len(u_values) != degree."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        ctrl = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        u = np.array([0.5], dtype=np.float64)  # degree=2 requires 2 values
+        with pytest.raises(ValueError, match="length"):
+            _evaluate_blossom_1d(
+                np.array(knots, dtype=np.float64),
+                2,
+                ctrl,
+                u,
+                1e-12,
+            )
+
+    def test_u_values_out_of_domain(self) -> None:
+        """Raises ValueError when a u value lies outside the domain."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        ctrl = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        u = np.array([0.5, 1.5], dtype=np.float64)  # 1.5 > domain [0, 1]
+        with pytest.raises(ValueError, match="outside domain"):
+            _evaluate_blossom_1d(
+                np.array(knots, dtype=np.float64),
+                2,
+                ctrl,
+                u,
+                1e-12,
+            )

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._bspline_knots import _get_unique_knots_and_multiplicity_impl
 from pantr.bspline import Bspline
 from pantr.bspline_space_1D import BsplineSpace1D
 from pantr.bspline_space_nd import BsplineSpace
@@ -29,7 +30,7 @@ def make_bspline(
     return Bspline(space, cp, is_rational=is_rational)
 
 
-def eval_pts(a: float = 0.0, b: float = 1.0, n: int = 201) -> np.ndarray:  # type: ignore[type-arg]
+def eval_pts(a: float = 0.0, b: float = 1.0, n: int = 201) -> npt.NDArray[np.float64]:
     """Return n evenly-spaced evaluation points in [a, b]."""
     return np.linspace(a, b, n, dtype=np.float64)
 
@@ -93,7 +94,7 @@ class TestNonRationalProduct:
 
         h = f.multiply(g)
 
-        # Product degree = 4, interior mult = 2+1 = 3
+        # Product degree = 4, interior mult = max(2+2, 1+2) = 4
         assert h.degree == (4,)
         pts = eval_pts()
         np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
@@ -270,3 +271,78 @@ class TestEdgeCases:
         g_p = Bspline(space_p, np.ones(n_basis, dtype=np.float64))
         with pytest.raises(NotImplementedError):
             f.multiply(g_p)
+
+
+# ---------------------------------------------------------------------------
+# Optimal continuity tests
+# ---------------------------------------------------------------------------
+
+
+class TestOptimalContinuity:
+    """Tests verifying that the product has optimal continuity in the knot vector."""
+
+    def test_optimal_multiplicity_at_shared_knot(self) -> None:
+        """Interior multiplicity equals max(m_f+q, m_g+p).
+
+        f: degree 2, interior knot 0.5 with mult 2 → C^0
+        g: degree 2, interior knot 0.5 with mult 1 → C^1
+        Product continuity = C^{min(p-m_f, q-m_g)} = C^{min(0,1)} = C^0.
+        Product degree 4, interior mult = max(2+2, 1+2) = 4 = full-Bezier.
+        """
+        knots_f = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0]
+        knots_g = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots_f, 2, [1.0, 2.0, 3.0, 1.5, 2.0])
+        g = make_bspline(knots_g, 2, [0.5, 1.5, 2.5, 1.0])
+
+        h = f.multiply(g)
+
+        # Product degree must be 4.
+        assert h.degree == (4,)
+
+        # Interior multiplicity of 0.5 in the product: max(2+2, 1+2) = 4.
+        h_space = h.space.spaces[0]
+        unique, mults = _get_unique_knots_and_multiplicity_impl(
+            h_space.knots, 4, float(h_space.tolerance), in_domain=True
+        )
+        # unique[0]=0.0, unique[1]=0.5, unique[2]=1.0
+        assert unique.shape[0] == 3  # noqa: PLR2004
+        np.testing.assert_allclose(unique[1], 0.5, atol=1e-12)
+        assert int(mults[1]) == 4  # noqa: PLR2004
+
+        # Correctness check.
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_fewer_basis_than_full_bezier(self) -> None:
+        """Product has fewer basis functions than full-Bezier when interior mults < p+q.
+
+        Both f and g have degree 2 with interior knot 0.5 at mult 1 (C^1).
+        Full-Bezier would give interior mult 4 → 9 basis functions.
+        Optimal: interior mult = max(1+2, 1+2) = 3 → 5+3+5 = 13 knots → 8 basis.
+        """
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 0.5, 3.0])
+        g = make_bspline(knots, 2, [0.5, 1.5, 2.5, 1.0])
+
+        h = f.multiply(g)
+
+        # Full-Bezier product: degree 4, 2 elements → 4*2+1 = 9 basis functions.
+        # Optimal: interior mult = max(1+2, 1+2) = 3 → [0]*5+[0.5]*3+[1]*5 = 13 knots → 8 basis.
+        n_h = h.space.num_total_basis
+        assert n_h == 8  # noqa: PLR2004
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    def test_single_element_no_interior_knots(self) -> None:
+        """Single Bezier element: optimal and full-Bezier coincide (no interior knots)."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        f = make_bspline(knots, 2, [1.0, 2.0, 3.0])
+        g = make_bspline(knots, 2, [3.0, 1.0, 2.0])
+
+        h = f.multiply(g)
+
+        # Single element, degree 4: 5 basis functions.
+        assert h.space.num_total_basis == 5  # noqa: PLR2004
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)


### PR DESCRIPTION
## Summary

- **New**: `_bspline_blossom_core` (Layer 3 Numba kernel) and `_bspline_blossom` (Layer 2 wrapper) implementing the generalized de Boor algorithm for B-spline blossom (polar form) evaluation.
- **Improved**: `_multiply_nonrational_1d` now produces a product with optimal-continuity knot vector instead of always full-Bézier (C^0 at every breakpoint).
- **New tests**: `test_bspline_blossom.py` (diagonal property, symmetry, control-point recovery, validation) and `TestOptimalContinuity` in the product tests.

## Key formula

The product of two B-splines of degrees `p` and `q` with multiplicities `m_f`, `m_g` at a shared breakpoint satisfies the product rule:

```
(f·g) ∈ C^{min(p−m_f, q−m_g)}
```

The required multiplicity in the degree-`(p+q)` product space is therefore:

```
m_h(ξ) = max(m_f(ξ) + q, m_g(ξ) + p)
```

A breakpoint present in only one operand (e.g. `m_g = 0`) still requires full-Bézier multiplicity `p+q` because the other operand is smooth there.

## Implementation

1. Build the product in full-Bézier form via Bernstein product formula (unchanged from previous approach).
2. If all `product_mults == p+q`, return the full-Bézier spline directly (no extra cost).
3. Otherwise, project the full-Bézier control points onto the optimal-continuity knot vector using the Oslo refinement matrix and `np.linalg.lstsq`.

## Test plan

- [x] `pytest tests/test_bspline_blossom.py --no-cov -v` — 10 blossom tests pass
- [x] `pytest tests/test_bspline_product.py --no-cov -v` — 20 product tests pass
- [x] `pytest --no-cov` — 953 tests pass
- [x] `ruff check .` — no issues
- [x] `ruff format --check .` — no issues
- [x] `mypy --config-file mypy.ini src tests` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)