### PR TITLE
fix(bspline): correct knot span at domain endpoint for non-open knots

### DIFF
--- a/src/pantr/_bspline_basis_core.py
+++ b/src/pantr/_bspline_basis_core.py
@@ -75,6 +75,16 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     one = dtype.type(1.0)
 
     knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
+
+    # Clamp knot span indices to the last in-domain span.  For non-open knot
+    # vectors the right domain endpoint knots[-degree-1] is not the last knot
+    # in the vector, so searchsorted can place a point in an out-of-domain
+    # span.  Clamping to knots.size - degree - 2 ensures the Cox-de Boor
+    # recurrence always uses an in-domain span.  For open knot vectors this
+    # subsumes the former ``knot_id == knots.size - 1`` special case.
+    max_knot_id = knots.size - degree - 2
+    knot_ids = np.minimum(knot_ids, max_knot_id)
+
     num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
     out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
 
@@ -86,12 +96,6 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
 
     for pt_id in range(n_pts):
         knot_id = knot_ids[pt_id]
-
-        # Boundary: point coincides with the last knot
-        if knot_id == (knots.size - 1):
-            out_basis[pt_id, -1] = one
-            continue
-
         pt = pts[pt_id]
         N = out_basis[pt_id, :]
         N[0] = one
@@ -158,6 +162,12 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913, PLR0915
     one = dtype.type(1.0)
 
     knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
+
+    # Clamp knot span indices to the last in-domain span (see comment in
+    # _compute_basis_nurbs_book_impl for rationale).
+    max_knot_id = knots.size - degree - 2
+    knot_ids = np.minimum(knot_ids, max_knot_id)
+
     num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
     out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
 
@@ -171,12 +181,6 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913, PLR0915
 
     for pt_id in range(n_pts):
         knot_id = knot_ids[pt_id]
-
-        # Boundary: point coincides with the last knot
-        if knot_id == (knots.size - 1):
-            out_deriv[pt_id, 0, -1] = one
-            continue
-
         pt = pts[pt_id]
 
         # --- Step 1: build ndu table (A2.2 extended to retain intermediate values) ---

--- a/tests/test_bspline_basis_derivatives_1D.py
+++ b/tests/test_bspline_basis_derivatives_1D.py
@@ -108,14 +108,17 @@ class TestComputeBasisDerivNurbsBook:
             np.testing.assert_allclose(sums, 0.0, atol=1e-12, err_msg=f"k={k}")
 
     def test_boundary_last_knot(self) -> None:
-        """Point at the last knot: 0th row has last entry=1, all derivatives=0."""
+        """Point at the last knot: derivatives match the analytical Bernstein values.
+
+        For degree-2 Bernstein basis on [0,1]: B0=(1-t)^2, B1=2t(1-t), B2=t^2.
+        At t=1: B=[0,0,1], B'=[0,-2,2], B''=[2,-4,2].
+        """
         knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
         pts = np.array([1.0], dtype=np.float64)
         out_deriv, _ = self._call(knots, 2, pts, n_deriv=2)
-        expected_basis = np.array([0.0, 0.0, 1.0])
-        np.testing.assert_array_almost_equal(out_deriv[0, 0, :], expected_basis)
-        np.testing.assert_array_almost_equal(out_deriv[0, 1, :], np.zeros(3))
-        np.testing.assert_array_almost_equal(out_deriv[0, 2, :], np.zeros(3))
+        np.testing.assert_array_almost_equal(out_deriv[0, 0, :], [0.0, 0.0, 1.0])
+        np.testing.assert_array_almost_equal(out_deriv[0, 1, :], [0.0, -2.0, 2.0])
+        np.testing.assert_array_almost_equal(out_deriv[0, 2, :], [2.0, -4.0, 2.0])
 
     def test_n_deriv_exceeds_degree_gives_zeros(self) -> None:
         """Derivatives of order > degree are identically zero."""
@@ -294,9 +297,8 @@ class TestMathematicalPropertiesDeriv:
     ) -> None:
         """First derivatives of the quadratic Bézier match analytical values.
 
-        Note: x=1.0 is excluded because the algorithm's boundary-case handler
-        (last-knot special case) only fills the 0th-order value; higher-order
-        derivatives at that endpoint are covered by test_boundary_last_knot.
+        Note: x=1.0 is excluded because the Bernstein fast path has a
+        separate boundary issue (zero derivatives at t=1).
         """
         d, _ = quadratic_single_span.tabulate_basis_derivatives([x], n_deriv=1)
         expected = np.array([-2 * (1 - x), 2 - 4 * x, 2 * x])
@@ -308,7 +310,8 @@ class TestMathematicalPropertiesDeriv:
     ) -> None:
         """Second derivatives of the quadratic Bézier match analytical values.
 
-        Note: x=1.0 excluded for the same reason as test_exact_quadratic_bezier_first_derivative.
+        Note: x=1.0 is excluded because the Bernstein fast path has a
+        separate boundary issue (zero derivatives at t=1).
         """
         d, _ = quadratic_single_span.tabulate_basis_derivatives([x], n_deriv=2)
         expected = np.array([2.0, -4.0, 2.0])

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -730,6 +730,104 @@ class TestEvaluateBasisBasisFuncs:
         np.testing.assert_array_equal(first_basis1, first_basis2)
 
 
+class TestNonOpenKnotSpanBoundary:
+    """Test basis evaluation at domain endpoints for non-open knot vectors.
+
+    For non-open knot vectors the right domain endpoint knots[-degree-1] is
+    not the last knot in the vector.  This class verifies that basis values
+    and derivatives are continuous at the right domain endpoint, i.e. that
+    evaluation at the boundary matches the left-limit.
+    """
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_non_open_basis_continuity_at_right_endpoint(self, degree: int) -> None:
+        """Test basis continuity at right endpoint for non-open knot vectors."""
+        n_intervals = degree + 2
+        n_knots = n_intervals + degree + 1
+        knots = np.linspace(0.0, 1.0, n_knots, dtype=np.float64)
+        space = BsplineSpace1D(knots=knots, degree=degree, periodic=False)
+        assert not space.has_open_knots()
+
+        t_end = space.domain[1]
+        eps = 1e-12
+        pts = np.array([t_end - eps, t_end], dtype=np.float64)
+        basis, fb = space.tabulate_basis(pts)
+
+        # first_basis should be the same for both points
+        assert fb[0] == fb[1]
+        # basis values should be continuous (within tolerance)
+        np.testing.assert_allclose(basis[0], basis[1], atol=1e-8)
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_non_open_basis_continuity_at_left_endpoint(self, degree: int) -> None:
+        """Test basis continuity at left endpoint for non-open knot vectors."""
+        n_intervals = degree + 2
+        n_knots = n_intervals + degree + 1
+        knots = np.linspace(0.0, 1.0, n_knots, dtype=np.float64)
+        space = BsplineSpace1D(knots=knots, degree=degree, periodic=False)
+        assert not space.has_open_knots()
+
+        t_start = space.domain[0]
+        eps = 1e-12
+        pts = np.array([t_start, t_start + eps], dtype=np.float64)
+        basis, fb = space.tabulate_basis(pts)
+
+        assert fb[0] == fb[1]
+        np.testing.assert_allclose(basis[0], basis[1], atol=1e-8)
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_periodic_basis_continuity_at_right_endpoint(self, degree: int) -> None:
+        """Test basis continuity at right endpoint for periodic knot vectors."""
+        knots = create_uniform_periodic_knot_vector(num_intervals=degree + 1, degree=degree)
+        space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
+
+        t_end = space.domain[1]
+        eps = 1e-12
+        pts = np.array([t_end - eps, t_end], dtype=np.float64)
+        basis, fb = space.tabulate_basis(pts)
+
+        assert fb[0] == fb[1]
+        np.testing.assert_allclose(basis[0], basis[1], atol=1e-8)
+
+    @pytest.mark.parametrize("degree", [1, 2, 3])
+    def test_non_open_derivative_continuity_at_right_endpoint(self, degree: int) -> None:
+        """Test derivative continuity at right endpoint for non-open knot vectors."""
+        n_intervals = degree + 2
+        n_knots = n_intervals + degree + 1
+        knots = np.linspace(0.0, 1.0, n_knots, dtype=np.float64)
+        space = BsplineSpace1D(knots=knots, degree=degree, periodic=False)
+
+        t_end = space.domain[1]
+        eps = 1e-12
+        pts = np.array([t_end - eps, t_end], dtype=np.float64)
+        deriv, fb = space.tabulate_basis_derivatives(pts, n_deriv=1)
+
+        assert fb[0] == fb[1]
+        # 0th derivative (basis values) should be continuous
+        np.testing.assert_allclose(deriv[0, 0, :], deriv[1, 0, :], atol=1e-8)
+
+    @pytest.mark.parametrize("degree", [1, 2, 3])
+    def test_open_knots_still_correct_at_endpoints(self, degree: int) -> None:
+        """Test that open knot vectors still produce correct endpoint values."""
+        knots = create_uniform_open_knot_vector(num_intervals=3, degree=degree)
+        space = BsplineSpace1D(knots=knots, degree=degree, periodic=False)
+        assert space.has_open_knots()
+
+        t_start, t_end = space.domain
+        pts = np.array([t_start, t_end], dtype=np.float64)
+        basis, fb = space.tabulate_basis(pts)
+
+        # At left endpoint: first basis function = 1, rest = 0
+        expected_left = np.zeros(degree + 1)
+        expected_left[0] = 1.0
+        np.testing.assert_allclose(basis[0], expected_left, atol=1e-14)
+
+        # At right endpoint: last basis function = 1, rest = 0
+        expected_right = np.zeros(degree + 1)
+        expected_right[-1] = 1.0
+        np.testing.assert_allclose(basis[1], expected_right, atol=1e-14)
+
+
 class TestGetCardinalIntervals:
     """Test the _get_Bspline_cardinal_intervals_1D_impl function."""
 


### PR DESCRIPTION
## Summary

- Fix discontinuous basis function values at the right domain endpoint for non-open and periodic knot vectors
- Clamp `knot_ids` to the last in-domain span (`knots.size - degree - 2`) in both `_compute_basis_nurbs_book_impl` and `_compute_basis_deriv_nurbs_book_impl`, replacing the old `knot_id == knots.size - 1` special case
- Fix derivative computation at the boundary (previously returned all zeros instead of correct analytical values)

## Details

For non-open knot vectors, `searchsorted(side="right") - 1` at the right domain endpoint `knots[-degree-1]` returns a `knot_id` pointing to an out-of-domain span. The old boundary check `knot_id == knots.size - 1` only caught this for open knot vectors. The clamp is a general fix that works for all knot vector types.

**Note:** A related but separate issue exists in the Bernstein fast path (`_tabulate_Bernstein_basis_deriv_1D_core`) which also produces zero derivatives at `t=1`. That would need a separate fix.

## Test plan

- [x] New `TestNonOpenKnotSpanBoundary` class (18 tests) verifying continuity at domain endpoints for non-open, periodic, and open knot vectors
- [x] Updated `test_boundary_last_knot` to expect correct analytical derivative values
- [x] Full test suite passes (971 tests)
- [x] Ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)