### PR TITLE
chore: add Claude Code skills and commit conventions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls tests/test_bs*)",
+      "Bash(ls -la src/pantr/_*.py)",
+      "Bash(conda activate pantr)",
+      "Bash(python3 -c \":*)",
+      "Bash(source activate pantr)",
+      "Bash(/Users/antolin/miniconda3/envs/pantr/bin/python -c \":*)"
+    ]
+  }
+}

--- a/.claude/skills/new-feature/SKILL.md
+++ b/.claude/skills/new-feature/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: new-feature
+description: End-to-end workflow for implementing a new feature, bug fix, or refactor — from creating a worktree and branch through implementation, testing, validation, PR creation, and user notification. Use this skill whenever the user asks you to implement, add, build, create, or fix something that will result in a PR. Trigger on requests like "add support for X", "implement Y", "fix bug Z", "refactor W", or any task that involves writing code that should be merged. Even if the user doesn't mention PRs or branches, if the task involves code changes that need review, use this skill.
+---
+
+# New Feature Workflow
+
+This skill orchestrates the full lifecycle of a code change — from branch creation to PR. Follow these phases in order.
+
+## Phase 1: Worktree and branch
+
+Create an isolated worktree to work in. Use the `EnterWorktree` tool — it will create a new worktree under `.claude/worktrees/` with a fresh branch based on HEAD.
+
+After entering the worktree, rename the branch to follow the convention:
+
+```bash
+git branch -m <type>/<short-description>
+```
+
+Where `<type>` matches the conventional commit type (`feat`, `fix`, `refactor`, etc.) and `<short-description>` is a kebab-case summary (e.g., `feat/periodic-bspline-product`, `fix/bernstein-derivative-at-boundary`).
+
+## Phase 2: Plan
+
+Before writing code, understand the task and form a plan:
+
+1. Read the relevant existing code to understand the architecture and conventions
+2. Identify which layer(s) the change touches (Layer 1 / 2 / 3 — see CLAUDE.md)
+3. Outline the approach — what files to create or modify, what the public API looks like
+4. Share the plan with the user and get confirmation before proceeding
+
+For non-trivial features, use `EnterPlanMode` to align on the approach.
+
+## Phase 3: Implement
+
+Write the code following the project's architecture and conventions:
+
+- **Layer 3 (kernels)**: Pure Numba computation, no validation, `@nb_jit(nopython=True, cache=True)`
+- **Layer 2 (helpers)**: Input validation, array allocation, calls Layer 3
+- **Layer 1 (public API)**: Lightweight validation, delegates to Layer 2
+- Follow strict mypy typing, Google-style docstrings, and all conventions in CLAUDE.md
+
+### Commit conventions
+
+Commit regularly as you complete logical units of work. Use **conventional commits**:
+
+```
+<type>(<scope>): <imperative summary>
+
+Optional body explaining why, not what.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+**Types**: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `perf`, `chore`
+**Scope**: the module or area affected (e.g., `bspline`, `basis`, `quad`, `docs`)
+
+Examples:
+- `feat(bspline): add exact 1D B-spline product via Bezier multiplication`
+- `fix(basis): correct off-by-one in Cox-de Boor recursion`
+- `refactor(bspline): move to_open_bspline to Layer 2`
+- `test(bspline): add boundary case tests for derivative evaluation`
+
+Keep commits focused — one logical change per commit. Do not bundle unrelated changes.
+
+## Phase 4: Test
+
+Write tests for the new code:
+
+- Place tests in the appropriate file under `tests/` (follow existing naming: `test_<module>.py`)
+- Cover normal cases, edge cases, and error cases
+- Test public API (Layer 1) primarily; test Layer 2 directly only if it has complex validation logic
+- Use `pytest --no-cov -v` to run tests during development
+- Commit tests in a dedicated commit (e.g., `test(bspline): add tests for exact product`)
+
+## Phase 5: Pre-PR validation
+
+Before creating the PR, run the full check suite. Invoke the `pre-pr-checks` skill (or run the checks manually):
+
+1. `ruff check .` — lint
+2. `ruff format --check .` — formatting
+3. `mypy --config-file mypy.ini src tests` — type checking
+4. `pytest --no-cov -v` — tests
+5. `NUMBA_DISABLE_JIT=1 sphinx-build -M html docs/ docs/_build -W --keep-going -j auto` — docs
+
+Fix any issues and commit the fixes before proceeding. All checks must pass.
+
+## Phase 6: PR and notify
+
+Once all checks pass:
+
+1. Push the branch:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+2. Create the PR using `gh pr create`:
+   - Title: concise, under 70 characters
+   - Body: summary of changes, test plan, and the generated-by footer
+   - Target the `main` branch
+
+   ```bash
+   gh pr create --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullet points describing the changes>
+
+   ## Test plan
+   - [ ] All existing tests pass
+   - [ ] New tests added for <feature>
+   - [ ] Pre-PR checks pass (ruff, mypy, pytest, docs)
+
+   Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+3. **Notify the user**: Tell them the PR is ready, provide the URL, and give a brief summary of what was done.
+
+## Important notes
+
+- If the user asks you to **plan only** (not implement), stop after Phase 2 and present the plan.
+- If at any point you're unsure about a design decision, ask the user rather than guessing.
+- Do not push or create a PR without running all checks first.
+- Keep the user informed at natural milestones (plan ready, implementation done, tests passing, PR created).

--- a/.claude/skills/pre-pr-checks/SKILL.md
+++ b/.claude/skills/pre-pr-checks/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: pre-pr-checks
+description: Run the full pre-PR validation suite (ruff lint, ruff format check, mypy type checking, pytest tests, and Sphinx documentation build). Use this skill whenever you need to verify code quality before pushing, creating a PR, or when the user asks to "run checks", "validate", "run CI locally", or "make sure everything passes". Also trigger when about to push code or create a pull request — always validate first.
+---
+
+# Pre-PR Checks
+
+Run all quality checks that CI would run, and report results. The goal is to catch issues before they reach the remote, saving CI time and avoiding back-and-forth.
+
+## Environment setup
+
+Activate the conda environment first:
+
+```bash
+conda activate pantr
+```
+
+## Checks to run
+
+Run these checks **sequentially** in this order — later checks are pointless if earlier ones fail on syntax or type errors.
+
+### 1. Ruff lint
+
+```bash
+ruff check .
+```
+
+If there are auto-fixable issues, fix them with `ruff check --fix .` and re-run to confirm. Stage the fixes.
+
+### 2. Ruff format check
+
+```bash
+ruff format --check .
+```
+
+If formatting issues are found, run `ruff format .` to fix them and stage the changes.
+
+### 3. mypy type checking
+
+```bash
+mypy --config-file mypy.ini src tests
+```
+
+If there are type errors, fix them before proceeding. Type errors often indicate real bugs.
+
+### 4. Pytest (without coverage)
+
+```bash
+pytest --no-cov -v
+```
+
+Use `--no-cov` to keep things fast. All tests must pass.
+
+### 5. Documentation build
+
+```bash
+NUMBA_DISABLE_JIT=1 sphinx-build -M html docs/ docs/_build -W --keep-going -j auto
+```
+
+The `-W` flag treats warnings as errors (matching CI). `NUMBA_DISABLE_JIT=1` avoids Numba compilation during doc build.
+
+## Reporting
+
+After running all checks, present a clear summary:
+
+```
+Pre-PR Checks Summary
+---------------------
+Ruff lint:    PASS / FAIL (N issues)
+Ruff format:  PASS / FAIL (N files)
+mypy:         PASS / FAIL (N errors)
+pytest:       PASS / FAIL (N passed, M failed)
+docs build:   PASS / FAIL (N warnings)
+```
+
+If any check failed and you were unable to fix it, explain what went wrong and suggest next steps. If all checks pass, say so clearly — the code is ready to push.
+
+## When auto-fixing
+
+If you fix lint, format, or type issues during this process, commit those fixes in a dedicated commit:
+
+```
+style: fix lint and formatting issues
+```
+
+Keep these commits separate from feature work so the git history stays clean.

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,8 @@ env/
 .idea/
 .vscode/
 *.code-workspace
-.claude/
+.claude/worktrees/
+.claude/settings.local.json
 
 # Jupyter and notebooks
 .ipynb_checkpoints/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,20 @@ mypy --config-file mypy.ini src tests                               # type check
 
 > Default pytest (via `pytest.ini`) adds `--cov`, which slows things down and requires ≥85% coverage. Always pass `--no-cov` during development.
 
+## Commit conventions
+
+Use **conventional commits** with the format:
+
+```
+<type>(<scope>): <imperative summary>
+```
+
+- **Types**: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `perf`, `chore`
+- **Scope**: the module or area affected (e.g., `bspline`, `basis`, `quad`, `docs`)
+- First line: imperative mood, lowercase, no trailing period
+- One logical change per commit — do not bundle unrelated changes
+- Branch names follow the same convention: `<type>/<short-kebab-description>`
+
 ## Architecture
 
 **PaNTr** is a polynomial and NURBS toolkit for geometric modeling and numerical analysis (Python 3.10–3.12).


### PR DESCRIPTION
## Summary
- Add `new-feature` skill: end-to-end workflow from worktree creation through implementation, testing, validation, and PR
- Add `pre-pr-checks` skill: runs ruff, mypy, pytest, and docs build before pushing
- Add commit conventions section to CLAUDE.md
- Track `.claude/` in git (excluding worktrees and local settings)

## Test plan
- [ ] Skills trigger correctly when asking Claude to implement a feature
- [ ] `pre-pr-checks` skill runs all checks in order
- [ ] `.claude/settings.local.json` and `.claude/worktrees/` remain untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)