### PR TITLE
chore: add Claude Code skills and broaden bash permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,21 @@
 {
   "permissions": {
     "allow": [
-      "Bash(ls tests/test_bs*)",
-      "Bash(ls -la src/pantr/_*.py)",
-      "Bash(conda activate pantr)",
-      "Bash(python3 -c \":*)",
-      "Bash(source activate pantr)",
-      "Bash(/Users/antolin/miniconda3/envs/pantr/bin/python -c \":*)"
+      "Bash(conda run -n pantr *)",
+      "Bash(pytest *)",
+      "Bash(ruff *)",
+      "Bash(mypy *)",
+      "Bash(git *)",
+      "Bash(pip *)",
+      "Bash(ls *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(python *)",
+      "Bash(python3 *)",
+      "Bash(cd *)",
+      "Bash(sphinx-build *)",
+      "Bash(make *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `new-feature` and `pre-pr-checks` Claude Code skills for automated workflows
- Broaden `.claude/settings.json` bash permissions to cover common dev commands (`pytest`, `ruff`, `mypy`, `git`, `pip`, `python`, `sphinx-build`, `make`, etc.)
- Document commit conventions in CLAUDE.md

## Test plan
- [x] Verify Claude Code no longer prompts for routine bash commands
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)