### PR TITLE
feat(bspline): add N-dimensional B-spline product

### DIFF
--- a/src/pantr/_bspline_product_nd.py
+++ b/src/pantr/_bspline_product_nd.py
@@ -1,0 +1,631 @@
+"""N-dimensional B-spline pointwise product.
+
+This module provides :func:`_multiply_bspline_nd`, which computes the exact
+pointwise product of two N-dimensional tensor-product B-splines via Bézier
+extraction and the Bernstein product formula.  The result lives in the product
+space of degree ``p_d + q_d`` per direction *d* with **optimal continuity**:
+each interior knot's multiplicity equals ``max(m_f(ξ) + q_d, m_g(ξ) + p_d)``.
+
+Works for non-rational and rational (NURBS) splines of any parametric
+dimension, and correctly preserves per-direction boundary structure
+(open / periodic / non-open).
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knots import _get_Bspline_num_basis_1D_impl, _get_unique_knots_and_multiplicity_impl
+from ._bspline_product import (
+    _build_product_knot_vector,
+    _get_boundary_mults,
+    _get_interior_breakpoints_and_mults,
+    _knots_for_full_bezier,
+    _lookup_mults_in_space,
+    _merge_interior_breakpoints,
+)
+from .bspline_space_1D import BsplineSpace1D
+from .bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from .bspline import Bspline
+
+
+def _bernstein_product_coefficients_nd(
+    b_f: npt.NDArray[np.float32 | np.float64],
+    b_g: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Compute nD Bézier control points of the product of two Bézier patches.
+
+    Applies the tensor-product Bernstein product formula element-wise over the
+    rank axis.  For each multi-index :math:`\gamma`:
+
+    .. math::
+
+        h_\gamma = \frac{1}{\prod_d \binom{r_d}{\gamma_d}}
+                   \sum_{\alpha} \prod_d \binom{p_d}{\alpha_d}
+                   \binom{q_d}{\gamma_d - \alpha_d}\,
+                   b_f[\alpha]\, b_g[\gamma - \alpha]
+
+    where :math:`r_d = p_d + q_d`.
+
+    The nD convolution is computed via the accumulation strategy: for each
+    multi-index :math:`\alpha` of ``b_f``, the weighted product is accumulated
+    into the output at the offset :math:`[\alpha : \alpha + q + 1]`.
+
+    Args:
+        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            Bézier patch, shape ``(p_0+1, ..., p_{D-1}+1, rank)``.
+        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            Bézier patch, shape ``(q_0+1, ..., q_{D-1}+1, rank)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product Bézier control points
+        of shape ``(p_0+q_0+1, ..., p_{D-1}+q_{D-1}+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_multiply_bspline_nd` instead.
+    """
+    ndim = b_f.ndim - 1
+    p = tuple(s - 1 for s in b_f.shape[:ndim])
+    q = tuple(s - 1 for s in b_g.shape[:ndim])
+    r = tuple(pi + qi for pi, qi in zip(p, q, strict=True))
+    dtype = b_f.dtype
+    rank = b_f.shape[-1]
+
+    # Precompute per-direction binomial coefficients.
+    binom_p = [
+        np.array([math.comb(p[d], i) for i in range(p[d] + 1)], dtype=dtype) for d in range(ndim)
+    ]
+    binom_q = [
+        np.array([math.comb(q[d], j) for j in range(q[d] + 1)], dtype=dtype) for d in range(ndim)
+    ]
+    inv_binom_r = [
+        np.array([1.0 / math.comb(r[d], k) for k in range(r[d] + 1)], dtype=dtype)
+        for d in range(ndim)
+    ]
+
+    # Build weight arrays: W_f[alpha] = prod_d C(p_d, alpha_d).
+    # Construct via outer product of per-direction binomial vectors.
+    w_f = binom_p[0]
+    for d in range(1, ndim):
+        w_f = np.multiply.outer(w_f, binom_p[d])
+    w_g = binom_q[0]
+    for d in range(1, ndim):
+        w_g = np.multiply.outer(w_g, binom_q[d])
+    inv_w_r = inv_binom_r[0]
+    for d in range(1, ndim):
+        inv_w_r = np.multiply.outer(inv_w_r, inv_binom_r[d])
+
+    # Weight the control points.
+    weighted_f = w_f[..., np.newaxis] * b_f
+    weighted_g = w_g[..., np.newaxis] * b_g
+
+    # nD convolution via accumulation.
+    result_shape = (*tuple(ri + 1 for ri in r), rank)
+    h_conv = np.zeros(result_shape, dtype=dtype)
+
+    for alpha in itertools.product(*(range(pi + 1) for pi in p)):
+        slices = tuple(slice(a, a + qi + 1) for a, qi in zip(alpha, q, strict=True))
+        h_conv[slices] = h_conv[slices] + weighted_f[alpha] * weighted_g
+
+    # Normalize by inverse product binomial coefficients.
+    return inv_w_r[..., np.newaxis] * h_conv
+
+
+def _extract_bezier_patch(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    element_idx: tuple[int, ...],
+    degrees: tuple[int, ...],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Extract Bézier patch control points for a given element multi-index.
+
+    In a full-Bézier representation, each direction *d* has control points
+    laid out as ``n_elements_d * degree_d + 1`` entries.  Element ``e_d``
+    occupies indices ``[e_d * degree_d, e_d * degree_d + degree_d + 1)``.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Full-Bézier control
+            point array of shape ``(n_0, ..., n_{D-1}, rank)``.
+        element_idx (tuple[int, ...]): Per-direction element index.
+        degrees (tuple[int, ...]): Per-direction polynomial degrees.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Bézier patch control points
+        of shape ``(degree_0+1, ..., degree_{D-1}+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    slices = tuple(
+        slice(e * deg, e * deg + deg + 1) for e, deg in zip(element_idx, degrees, strict=True)
+    )
+    return ctrl[slices]
+
+
+def _place_bezier_patch(
+    ctrl_out: npt.NDArray[np.float32 | np.float64],
+    patch: npt.NDArray[np.float32 | np.float64],
+    element_idx: tuple[int, ...],
+    degrees: tuple[int, ...],
+) -> None:
+    """Place product Bézier patch into the full-Bézier control point array.
+
+    Writes the patch control points into the correct location.  At shared
+    boundaries between adjacent elements, the values are identical, so
+    overwriting is safe.
+
+    Args:
+        ctrl_out (npt.NDArray[np.float32 | np.float64]): Output full-Bézier
+            control point array (modified in-place).
+        patch (npt.NDArray[np.float32 | np.float64]): Bézier patch control
+            points to place.
+        element_idx (tuple[int, ...]): Per-direction element index.
+        degrees (tuple[int, ...]): Per-direction product degrees.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    slices = tuple(
+        slice(e * deg, e * deg + deg + 1) for e, deg in zip(element_idx, degrees, strict=True)
+    )
+    ctrl_out[slices] = patch
+
+
+def _project_to_optimal_nd(
+    ctrl_full: npt.NDArray[np.float32 | np.float64],
+    knots_full_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    knots_opt_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    degrees_sum: tuple[int, ...],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Project full-Bézier control points to optimal-continuity space per direction.
+
+    Applies the Oslo-based least-squares projection direction by direction.
+    For each direction *d*, the Oslo matrix mapping optimal → full-Bézier is
+    computed, and the inverse (least-squares) solve reduces the control point
+    count along that axis.
+
+    Args:
+        ctrl_full (npt.NDArray[np.float32 | np.float64]): Full-Bézier control
+            points of shape ``(n_full_0, ..., n_full_{D-1}, rank)``.
+        knots_full_per_dir (list[npt.NDArray]): Full-Bézier knot vector per direction.
+        knots_opt_per_dir (list[npt.NDArray]): Optimal knot vector per direction.
+        degrees_sum (tuple[int, ...]): Product degree per direction.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Optimal control points.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core  # noqa: PLC0415
+
+    ndim = len(degrees_sum)
+    ctrl = ctrl_full
+    dtype = ctrl_full.dtype
+
+    for d in range(ndim):
+        oslo_d = _compute_oslo_matrix_1d_core(
+            degrees_sum[d], knots_opt_per_dir[d], knots_full_per_dir[d]
+        )
+        # Move axis d to front, flatten the rest into a single trailing axis.
+        moved = np.moveaxis(ctrl, d, 0)
+        leading = moved.shape[0]
+        flat = moved.reshape(leading, -1)
+        projected, *_ = np.linalg.lstsq(oslo_d, flat, rcond=None)
+        new_leading = projected.shape[0]
+        new_shape = (new_leading, *moved.shape[1:])
+        ctrl = np.moveaxis(projected.reshape(new_shape), 0, d).astype(dtype)
+
+    return ctrl
+
+
+def _multiply_nonrational_nd(f: Bspline, g: Bspline) -> Bspline:  # noqa: PLR0915
+    """Multiply two non-rational nD B-splines with optimal-continuity output.
+
+    Refines both operands to full-Bézier form in all directions, applies the
+    nD Bernstein product formula element by element, then projects the result
+    to optimal continuity via per-direction Oslo solves.
+
+    Args:
+        f (~pantr.bspline.Bspline): First non-rational nD B-spline operand.
+        g (~pantr.bspline.Bspline): Second non-rational nD B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Non-rational B-spline ``h`` such that
+        ``h(t) = f(t) * g(t)`` for all ``t`` in the shared domain.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_multiply_bspline_nd` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    ndim = f.dim
+    dtype = f.control_points.dtype
+
+    spaces_f = f.space.spaces
+    spaces_g = g.space.spaces
+    degrees_f = tuple(s.degree for s in spaces_f)
+    degrees_g = tuple(s.degree for s in spaces_g)
+    degrees_sum = tuple(pf + pg for pf, pg in zip(degrees_f, degrees_g, strict=True))
+
+    tol = max(float(s.tolerance) for s in (*spaces_f, *spaces_g))
+
+    # --- Per-direction breakpoint analysis ---
+    all_bp_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
+    product_mults_per_dir: list[npt.NDArray[np.int_]] = []
+    knots_f_ins_per_dir: list[npt.NDArray[np.float32 | np.float64] | None] = []
+    knots_g_ins_per_dir: list[npt.NDArray[np.float32 | np.float64] | None] = []
+
+    for d in range(ndim):
+        bp_f, mf = _get_interior_breakpoints_and_mults(spaces_f[d], tol)
+        bp_g, mg = _get_interior_breakpoints_and_mults(spaces_g[d], tol)
+
+        all_bp, product_mults = _merge_interior_breakpoints(
+            bp_f, mf, bp_g, mg, degrees_f[d], degrees_g[d], tol
+        )
+        all_bp_per_dir.append(all_bp)
+        product_mults_per_dir.append(product_mults)
+
+        mults_in_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
+        mults_in_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
+
+        knots_f_d = _knots_for_full_bezier(spaces_f[d], all_bp, mults_in_f, tol)
+        knots_g_d = _knots_for_full_bezier(spaces_g[d], all_bp, mults_in_g, tol)
+        knots_f_ins_per_dir.append(knots_f_d if knots_f_d.size > 0 else None)
+        knots_g_ins_per_dir.append(knots_g_d if knots_g_d.size > 0 else None)
+
+    # --- Refine both operands to full-Bézier ---
+    if any(k is not None for k in knots_f_ins_per_dir):
+        f = f.insert_knots(knots_f_ins_per_dir)
+    if any(k is not None for k in knots_g_ins_per_dir):
+        g = g.insert_knots(knots_g_ins_per_dir)
+
+    # --- Element-wise nD Bernstein product ---
+    n_elements_per_dir = tuple(int(bp.size) + 1 for bp in all_bp_per_dir)
+    rank = f.control_points.shape[-1]
+    full_shape = tuple(ne * rd + 1 for ne, rd in zip(n_elements_per_dir, degrees_sum, strict=True))
+    ctrl_h_bezier = np.empty((*full_shape, rank), dtype=dtype)
+
+    for elem_idx in itertools.product(*(range(ne) for ne in n_elements_per_dir)):
+        patch_f = _extract_bezier_patch(f.control_points, elem_idx, degrees_f)
+        patch_g = _extract_bezier_patch(g.control_points, elem_idx, degrees_g)
+        product_patch = _bernstein_product_coefficients_nd(patch_f, patch_g)
+        _place_bezier_patch(ctrl_h_bezier, product_patch, elem_idx, degrees_sum)
+
+    # --- Build product knot vectors (full-Bézier and optimal) ---
+    knots_full_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
+    knots_opt_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
+    needs_projection = False
+
+    for d in range(ndim):
+        domain_d = spaces_f[d].domain
+        full_mults_d = np.full(all_bp_per_dir[d].size, degrees_sum[d], dtype=np.int_)
+        t_full_d = _build_product_knot_vector(
+            domain_d, all_bp_per_dir[d], full_mults_d, degrees_sum[d], dtype
+        )
+        t_opt_d = _build_product_knot_vector(
+            domain_d, all_bp_per_dir[d], product_mults_per_dir[d], degrees_sum[d], dtype
+        )
+        knots_full_per_dir.append(t_full_d)
+        knots_opt_per_dir.append(t_opt_d)
+
+        if all_bp_per_dir[d].size > 0 and not np.all(product_mults_per_dir[d] == degrees_sum[d]):
+            needs_projection = True
+
+    # --- Project to optimal continuity if needed ---
+    if needs_projection:
+        ctrl_opt = _project_to_optimal_nd(
+            ctrl_h_bezier, knots_full_per_dir, knots_opt_per_dir, degrees_sum
+        )
+    else:
+        ctrl_opt = ctrl_h_bezier
+
+    # Build the optimal product space.
+    spaces_opt = [BsplineSpace1D(knots_opt_per_dir[d], degrees_sum[d]) for d in range(ndim)]
+    space_opt = BsplineSpace(spaces_opt)
+    return BsplineCls(space_opt, ctrl_opt, is_rational=False)
+
+
+def _to_rational_nd(f: Bspline) -> Bspline:
+    """Convert an nD B-spline to rational form by appending unit weights.
+
+    If ``f`` is already rational, returns it unchanged.  Otherwise, creates a
+    new B-spline with the same space and control points augmented by a
+    trailing column of ones (homogeneous weights = 1).
+
+    Args:
+        f (~pantr.bspline.Bspline): The B-spline to convert.
+
+    Returns:
+        ~pantr.bspline.Bspline: Rational B-spline equivalent to ``f``.
+    """
+    if f.is_rational:
+        return f
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    cp = f.control_points
+    weights = np.ones((*cp.shape[:-1], 1), dtype=cp.dtype)
+    new_ctrl = np.concatenate([cp, weights], axis=-1)
+    return BsplineCls(f.space, new_ctrl, is_rational=True)
+
+
+def _multiply_rational_nd(f: Bspline, g: Bspline) -> Bspline:
+    """Multiply two rational nD B-splines (NURBS) using homogeneous coordinates.
+
+    Decomposes each rational operand into its numerator (weighted coordinates)
+    and denominator (weights) B-splines, multiplies each pair independently
+    using :func:`_multiply_nonrational_nd`, then reassembles the result.
+
+    Both ``f`` and ``g`` must already be rational (``is_rational=True``).
+
+    Args:
+        f (~pantr.bspline.Bspline): First rational nD B-spline operand.
+        g (~pantr.bspline.Bspline): Second rational nD B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Rational B-spline ``h`` such that
+        ``h(t) = f(t) * g(t)`` for all ``t`` in the shared domain.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_multiply_bspline_nd` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    # Split into numerator and denominator non-rational B-splines.
+    n_f = BsplineCls(f.space, f.control_points[..., :-1])
+    d_f = BsplineCls(f.space, f.control_points[..., -1:])
+    n_g = BsplineCls(g.space, g.control_points[..., :-1])
+    d_g = BsplineCls(g.space, g.control_points[..., -1:])
+
+    h_n = _multiply_nonrational_nd(n_f, n_g)
+    h_d = _multiply_nonrational_nd(d_f, d_g)
+
+    ctrl_h = np.concatenate([h_n.control_points, h_d.control_points], axis=-1)
+    return BsplineCls(h_n.space, ctrl_h, is_rational=True)
+
+
+def _convert_boundary_direction(  # noqa: PLR0913
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    axis: int,
+    target_type: str,
+    h_knots_1d: npt.NDArray[np.float32 | np.float64],
+    degree_sum_d: int,
+    space_f_1d: BsplineSpace1D,
+    space_g_1d: BsplineSpace1D,
+) -> tuple[npt.NDArray[np.float32 | np.float64], BsplineSpace1D]:
+    """Convert one direction of the open product to periodic or non-open form.
+
+    Computes the ghost knot vector and Oslo chain for direction *axis*, then
+    solves the least-squares system along that axis to recover the boundary-
+    converted control points.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Current control point
+            array of shape ``(n_0, ..., n_{D-1}, rank)``.
+        axis (int): Parametric direction to convert.
+        target_type (str): ``"periodic"`` or ``"nonopen"``.
+        h_knots_1d (npt.NDArray): Open product knot vector in direction *axis*.
+        degree_sum_d (int): Product degree in direction *axis*.
+        space_f_1d (BsplineSpace1D): Original 1D space of the first operand in
+            direction *axis*.
+        space_g_1d (BsplineSpace1D): Original 1D space of the second operand in
+            direction *axis*.
+
+    Returns:
+        tuple[npt.NDArray, BsplineSpace1D]: Updated control points and the new
+        1D space for direction *axis*.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core  # noqa: PLC0415
+    from ._bspline_product import (  # noqa: PLC0415
+        _build_periodic_product_knot_vector,
+    )
+
+    dtype = ctrl.dtype
+    p_d = space_f_1d.degree
+    q_d = space_g_1d.degree
+    tol = max(float(space_f_1d.tolerance), float(space_g_1d.tolerance))
+    r = degree_sum_d
+
+    # Get interior breakpoints and mults of the open product for this direction.
+    tol_typed = float(dtype.type(tol))
+    unique, mults = _get_unique_knots_and_multiplicity_impl(
+        h_knots_1d, r, tol_typed, in_domain=True
+    )
+    interior_bp, interior_mults = unique[1:-1], mults[1:-1]
+
+    # Compute boundary multiplicity.
+    mf_l, mf_r = _get_boundary_mults(space_f_1d, tol)
+    mg_l, mg_r = _get_boundary_mults(space_g_1d, tol)
+
+    if target_type == "periodic":
+        mf_bdy = mf_l
+        mg_bdy = mg_l
+        m_bdy = max(mf_bdy + q_d, mg_bdy + p_d)
+    else:
+        m_bdy = min(max(mf_l + q_d, mg_l + p_d), max(mf_r + q_d, mg_r + p_d))
+
+    # Build ghost knot vector and Oslo chain for this direction.
+    domain = (h_knots_1d[r], h_knots_1d[-r - 1])
+    t_ghost = _build_periodic_product_knot_vector(
+        domain, interior_bp, interior_mults, m_bdy, r, dtype
+    )
+
+    n_ghost = r + 1 - m_bdy
+    a_val, b_val = float(t_ghost[r]), float(t_ghost[-r - 1])
+    knots_ins = np.array([a_val] * n_ghost + [b_val] * n_ghost, dtype=dtype)
+    t_inter = np.sort(np.concatenate([t_ghost, knots_ins]))
+    oslo1 = _compute_oslo_matrix_1d_core(r, t_ghost, t_inter)
+
+    t_per_open = t_inter[n_ghost : len(t_inter) - n_ghost]
+    n_per_open = len(t_per_open) - r - 1
+    oslo1_trimmed = oslo1[n_ghost : n_ghost + n_per_open, :]
+
+    oslo2 = _compute_oslo_matrix_1d_core(r, t_per_open, h_knots_1d)
+    oslo = oslo2 @ oslo1_trimmed
+
+    # Apply along the specified axis: move it to front, flatten the rest.
+    moved = np.moveaxis(ctrl, axis, 0)
+    leading = moved.shape[0]
+    rest_shape = moved.shape[1:]
+    flat = moved.reshape(leading, -1)
+
+    if target_type == "periodic":
+        n_full = len(t_ghost) - r - 1
+        n_per = int(
+            _get_Bspline_num_basis_1D_impl(t_ghost, r, True, float(np.dtype(dtype).type(tol)))
+        )
+        w_mat = np.zeros((n_full, n_per), dtype=dtype)
+        for i in range(n_full):
+            w_mat[i, i % n_per] = dtype.type(1.0)
+        sol, *_ = np.linalg.lstsq(oslo @ w_mat, flat, rcond=None)
+        new_space_1d = BsplineSpace1D(t_ghost, r, periodic=True)
+    else:
+        sol, *_ = np.linalg.lstsq(oslo, flat, rcond=None)
+        new_space_1d = BsplineSpace1D(t_ghost, r)
+
+    new_leading = sol.shape[0]
+    new_shape = (new_leading, *rest_shape)
+    ctrl = np.moveaxis(sol.astype(dtype).reshape(new_shape), 0, axis)
+    return ctrl, new_space_1d
+
+
+def _multiply_bspline_nd(f: Bspline, g: Bspline) -> Bspline:  # noqa: PLR0912, PLR0915
+    """Compute the exact pointwise product of two nD B-splines.
+
+    Given B-splines ``f`` and ``g`` over the same nD parametric domain, returns
+    a new B-spline ``h`` such that ``h(t) = f(t) * g(t)`` for all ``t`` in the
+    domain.  The result lives in the product space of degree ``p_d + q_d`` per
+    direction with optimal continuity.
+
+    Rational operands are handled via homogeneous-coordinate decomposition.  A
+    non-rational operand is silently promoted to rational when the other is
+    rational.
+
+    Args:
+        f (~pantr.bspline.Bspline): First nD B-spline operand.
+        g (~pantr.bspline.Bspline): Second nD B-spline operand.
+
+    Returns:
+        ~pantr.bspline.Bspline: Product B-spline ``h = f * g``.
+
+    Raises:
+        ValueError: If ``f`` and ``g`` have different dimensions.
+        ValueError: If ``f`` and ``g`` have different dtypes.
+        ValueError: If ``f`` and ``g`` have different ranks.
+        ValueError: If ``f`` and ``g`` have different parametric domains in
+            any direction (beyond the shared tolerance).
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    ndim = f.dim
+
+    if g.dim != ndim:
+        raise ValueError(
+            f"f and g must have the same parametric dimension. Got f.dim={ndim} and g.dim={g.dim}."
+        )
+    if f.dtype != g.dtype:
+        raise ValueError(f"f and g must have the same dtype. Got {f.dtype} and {g.dtype}.")
+    if f.rank != g.rank:
+        raise ValueError(f"f and g must have the same rank. Got {f.rank} and {g.rank}.")
+
+    spaces_f = f.space.spaces
+    spaces_g = g.space.spaces
+
+    # --- Per-direction boundary type detection ---
+    target_types: list[str] = []
+    f_needs_open = False
+    g_needs_open = False
+
+    for d in range(ndim):
+        sf, sg = spaces_f[d], spaces_g[d]
+        f_is_open = sf.has_open_knots() and not sf.periodic
+        g_is_open = sg.has_open_knots() and not sg.periodic
+        f_is_periodic = sf.periodic
+        g_is_periodic = sg.periodic
+
+        if f_is_open or g_is_open:
+            target_types.append("open")
+        elif f_is_periodic and g_is_periodic:
+            target_types.append("periodic")
+        else:
+            target_types.append("nonopen")
+
+        if not f_is_open:
+            f_needs_open = True
+        if not g_is_open:
+            g_needs_open = True
+
+    # Save original spaces for boundary conversion.
+    spaces_f_orig = spaces_f
+    spaces_g_orig = spaces_g
+
+    # Convert non-open operands to open form.
+    if f_needs_open:
+        has_nonopen = any(
+            not spaces_f[d].has_open_knots() or spaces_f[d].periodic for d in range(ndim)
+        )
+        if has_nonopen:
+            f = f.to_open_bspline()
+    if g_needs_open:
+        has_nonopen = any(
+            not spaces_g[d].has_open_knots() or spaces_g[d].periodic for d in range(ndim)
+        )
+        if has_nonopen:
+            g = g.to_open_bspline()
+
+    # Validate per-direction domains.
+    tol = max(float(s.tolerance) for s in (*f.space.spaces, *g.space.spaces))
+    for d in range(ndim):
+        domain_f = f.space.spaces[d].domain
+        domain_g = g.space.spaces[d].domain
+        if (
+            abs(float(domain_f[0]) - float(domain_g[0])) > tol
+            or abs(float(domain_f[1]) - float(domain_g[1])) > tol
+        ):
+            raise ValueError(
+                f"f and g must share the same parametric domain in direction {d}. "
+                f"Got {domain_f} and {domain_g}."
+            )
+
+    # Compute the product in open form.
+    if not f.is_rational and not g.is_rational:
+        h_open = _multiply_nonrational_nd(f, g)
+    else:
+        h_open = _multiply_rational_nd(_to_rational_nd(f), _to_rational_nd(g))
+
+    # Convert to target boundary types per direction.
+    any_nonopen = any(t != "open" for t in target_types)
+    if not any_nonopen:
+        return h_open
+
+    ctrl = h_open.control_points
+    result_spaces: list[BsplineSpace1D] = list(h_open.space.spaces)
+
+    for d in range(ndim):
+        if target_types[d] == "open":
+            continue
+        ctrl, new_space_1d = _convert_boundary_direction(
+            ctrl,
+            axis=d,
+            target_type=target_types[d],
+            h_knots_1d=h_open.space.spaces[d].knots,
+            degree_sum_d=h_open.space.spaces[d].degree,
+            space_f_1d=spaces_f_orig[d],
+            space_g_1d=spaces_g_orig[d],
+        )
+        result_spaces[d] = new_space_1d
+
+    space_result = BsplineSpace(result_spaces)
+    return BsplineCls(space_result, ctrl, is_rational=h_open.is_rational)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -345,40 +345,44 @@ class Bspline:
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.
 
-        Given B-splines ``self`` and ``other`` over the same 1D parametric
+        Given B-splines ``self`` and ``other`` over the same parametric
         domain, returns a new B-spline ``h`` such that ``h(t) = self(t) *
         other(t)`` for all ``t`` in the domain.  The result lives in the product
-        space of degree ``p + q`` where ``p`` and ``q`` are the degrees of the
-        two operands.
+        space of degree ``p_d + q_d`` per direction where ``p_d`` and ``q_d``
+        are the degrees of the two operands in direction *d*.
 
         Both non-rational and rational (NURBS) operands are supported.  A
         non-rational operand is promoted to rational (unit weights) when the
         other is rational.
 
         Args:
-            other (Bspline): The second B-spline operand. Must be 1D with the
-                same dtype, rank, and parametric domain as ``self``.
+            other (Bspline): The second B-spline operand. Must have the
+                same dimension, dtype, rank, and parametric domain as ``self``.
 
         Returns:
             Bspline: A new B-spline representing ``self * other``.
 
         Raises:
-            ValueError: If either operand has ``dim != 1``.
+            ValueError: If the operands have different dimensions.
             ValueError: If the operands have different dtypes.
             ValueError: If the operands have different ranks.
             ValueError: If the operands have different parametric domains.
 
         Note:
-            The boundary structure of the operands is preserved in the result:
+            The boundary structure of the operands is preserved per direction:
             both periodic → periodic, both non-open → non-open, either open → open.
 
         Example:
             >>> h = f.multiply(g)
             >>> h2 = f * g  # equivalent via __mul__
         """
-        from ._bspline_product import _multiply_bspline_1d  # noqa: PLC0415
+        if self.dim == 1:
+            from ._bspline_product import _multiply_bspline_1d  # noqa: PLC0415
 
-        return _multiply_bspline_1d(self, other)
+            return _multiply_bspline_1d(self, other)
+        from ._bspline_product_nd import _multiply_bspline_nd  # noqa: PLC0415
+
+        return _multiply_bspline_nd(self, other)
 
     __mul__ = multiply
 

--- a/tests/test_bspline_product_nd.py
+++ b/tests/test_bspline_product_nd.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._bspline_knots import _get_unique_knots_and_multiplicity_impl
 from pantr._bspline_product import _bernstein_product_coefficients
 from pantr._bspline_product_nd import _bernstein_product_coefficients_nd
 from pantr._bspline_space_factory import create_uniform_periodic_knot_vector
@@ -307,6 +308,178 @@ class TestNonRationalProduct3D:
         h = f * g
         assert h.degree == (3, 3, 5)
         _eval_3d_product(f, g, h)
+
+
+# ---------------------------------------------------------------------------
+# Optimal continuity tests
+# ---------------------------------------------------------------------------
+
+
+def _get_interior_mults(
+    space_1d: BsplineSpace1D,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
+    """Return interior breakpoints and their multiplicities for a 1D space."""
+    unique, mults = _get_unique_knots_and_multiplicity_impl(
+        space_1d.knots, space_1d.degree, float(space_1d.tolerance), in_domain=True
+    )
+    return unique[1:-1], mults[1:-1]
+
+
+class TestOptimalContinuity2D:
+    """Verify that the 2D product has optimal interior multiplicities per direction."""
+
+    def test_same_mesh_c1_both_directions(self) -> None:
+        """Both operands C^1 at 0.5 in both dirs -> product interior mult = max(1+2,1+2) = 3.
+
+        Full-Bezier would give mult 4. Optimal gives mult 3 (C^1).
+        """
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+        n = s.num_basis
+
+        rng = np.random.default_rng(50)
+        f = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+        g = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+
+        h = f * g
+        assert h.degree == (4, 4)
+
+        for d in range(2):
+            bp, mults = _get_interior_mults(h.space.spaces[d])
+            assert len(bp) == 1
+            assert int(mults[0]) == 3  # noqa: PLR2004
+            np.testing.assert_allclose(bp[0], 0.5, atol=1e-12)
+
+        # Fewer basis than full-Bezier: optimal has 8 per dir, full-Bezier has 9.
+        assert h.space.num_basis == (8, 8)
+        _eval_2d_product(f, g, h)
+
+    def test_c0_in_one_direction(self) -> None:
+        """C^0 in u (mult=2) and C^1 in v (mult=1) -> different optimal mults per dir.
+
+        u-direction: max(2+2, 1+2) = 4 (full-Bezier = C^0)
+        v-direction: max(1+2, 1+2) = 3 (C^1)
+        """
+        knots_u_f = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0]  # mult 2 at 0.5
+        knots_u_g = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]  # mult 1 at 0.5
+        knots_v = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]  # mult 1 at 0.5
+
+        s_u_f = _make_space_1d(knots_u_f, 2)
+        s_u_g = _make_space_1d(knots_u_g, 2)
+        s_v = _make_space_1d(knots_v, 2)
+
+        rng = np.random.default_rng(51)
+        f = _make_2d_bspline(s_u_f, s_v, rng.random((5, 4, 1)))
+        g = _make_2d_bspline(s_u_g, s_v, rng.random((4, 4, 1)))
+
+        h = f * g
+        assert h.degree == (4, 4)
+
+        # u-direction: mult = max(2+2, 1+2) = 4 (C^0)
+        bp_u, mults_u = _get_interior_mults(h.space.spaces[0])
+        assert len(bp_u) == 1
+        assert int(mults_u[0]) == 4  # noqa: PLR2004
+
+        # v-direction: mult = max(1+2, 1+2) = 3 (C^1)
+        bp_v, mults_v = _get_interior_mults(h.space.spaces[1])
+        assert len(bp_v) == 1
+        assert int(mults_v[0]) == 3  # noqa: PLR2004
+
+        _eval_2d_product(f, g, h)
+
+    def test_different_degrees_shared_breakpoint(self) -> None:
+        """Mixed degrees with shared breakpoint: p=(2,3), q=(3,2), product=(5,5).
+
+        Both operands share breakpoint 0.5 in both directions.
+        u-direction: f mult 1 (deg 2), g mult 1 (deg 3) -> max(1+3, 1+2) = 4
+        v-direction: f mult 1 (deg 3), g mult 1 (deg 2) -> max(1+2, 1+3) = 4
+        Both are less than full-Bezier (5).
+        """
+        knots_u_f = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]  # degree 2, mult 1
+        knots_v_f = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]  # degree 3, mult 1
+        knots_u_g = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]  # degree 3, mult 1
+        knots_v_g = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]  # degree 2, mult 1
+
+        s_u_f = _make_space_1d(knots_u_f, 2)
+        s_v_f = _make_space_1d(knots_v_f, 3)
+        s_u_g = _make_space_1d(knots_u_g, 3)
+        s_v_g = _make_space_1d(knots_v_g, 2)
+
+        rng = np.random.default_rng(52)
+        f = _make_2d_bspline(s_u_f, s_v_f, rng.random((4, 5, 1)))
+        g = _make_2d_bspline(s_u_g, s_v_g, rng.random((5, 4, 1)))
+
+        h = f * g
+        assert h.degree == (5, 5)
+
+        # u-direction: max(1+3, 1+2) = 4, less than full-Bezier = 5
+        bp_u, mults_u = _get_interior_mults(h.space.spaces[0])
+        assert len(bp_u) == 1
+        assert int(mults_u[0]) == 4  # noqa: PLR2004
+
+        # v-direction: max(1+2, 1+3) = 4, less than full-Bezier = 5
+        bp_v, mults_v = _get_interior_mults(h.space.spaces[1])
+        assert len(bp_v) == 1
+        assert int(mults_v[0]) == 4  # noqa: PLR2004
+
+        _eval_2d_product(f, g, h)
+
+    def test_multiple_shared_breakpoints(self) -> None:
+        """Multiple shared breakpoints with different multiplicities per direction.
+
+        u-direction: shared breakpoints at 1/3 and 2/3, both mult 1.
+           max(1+2, 1+2) = 3.
+        v-direction: shared breakpoints at 0.25, 0.5, 0.75 with mult 1.
+           max(1+2, 1+2) = 3.
+        """
+        knots_u = [0.0, 0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0, 1.0, 1.0, 1.0]
+        knots_v = [0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0]
+
+        s_u = _make_space_1d(knots_u, 2)
+        s_v = _make_space_1d(knots_v, 2)
+
+        rng = np.random.default_rng(53)
+        f = _make_2d_bspline(s_u, s_v, rng.random((5, 6, 1)))
+        g = _make_2d_bspline(s_u, s_v, rng.random((5, 6, 1)))
+
+        h = f * g
+        assert h.degree == (4, 4)
+
+        # u-direction: 2 breakpoints, each with optimal mult 3 < full-Bezier 4.
+        bp_u, mults_u = _get_interior_mults(h.space.spaces[0])
+        assert len(bp_u) == 2  # noqa: PLR2004
+        np.testing.assert_array_equal(mults_u, [3, 3])
+
+        # v-direction: 3 breakpoints, each with optimal mult 3 < full-Bezier 4.
+        bp_v, mults_v = _get_interior_mults(h.space.spaces[1])
+        assert len(bp_v) == 3  # noqa: PLR2004
+        np.testing.assert_array_equal(mults_v, [3, 3, 3])
+
+        _eval_2d_product(f, g, h)
+
+    def test_fewer_basis_than_full_bezier_2d(self) -> None:
+        """Product has fewer total basis functions than full-Bezier in 2D.
+
+        Both operands: degree 2, interior knot 0.5 with mult 1, same in both dirs.
+        Full-Bezier: 9 x 9 = 81 basis.
+        Optimal: 8 x 8 = 64 basis.
+        """
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+        n = s.num_basis
+
+        rng = np.random.default_rng(54)
+        f = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+        g = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+
+        h = f * g
+
+        # Full-Bezier: degree 4, 2 elements per dir -> 9 basis per dir.
+        # Optimal: interior mult 3 -> 8 basis per dir.
+        assert h.space.num_total_basis == 64  # noqa: PLR2004
+        assert h.space.num_basis == (8, 8)
+
+        _eval_2d_product(f, g, h)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bspline_product_nd.py
+++ b/tests/test_bspline_product_nd.py
@@ -1,0 +1,518 @@
+"""Tests for N-dimensional B-spline pointwise multiplication."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._bspline_product import _bernstein_product_coefficients
+from pantr._bspline_product_nd import _bernstein_product_coefficients_nd
+from pantr._bspline_space_factory import create_uniform_periodic_knot_vector
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+from pantr.quad import PointsLattice
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_space_1d(
+    knots: list[float], degree: int, dtype: type = np.float64, periodic: bool = False
+) -> BsplineSpace1D:
+    """Create a 1D B-spline space."""
+    return BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=periodic)
+
+
+def _make_2d_bspline(
+    space_u: BsplineSpace1D,
+    space_v: BsplineSpace1D,
+    ctrl: npt.NDArray[np.float64],
+    is_rational: bool = False,
+) -> Bspline:
+    """Create a 2D B-spline from two 1D spaces and control points."""
+    space = BsplineSpace([space_u, space_v])
+    return Bspline(space, ctrl, is_rational=is_rational)
+
+
+def _make_3d_bspline(
+    space_u: BsplineSpace1D,
+    space_v: BsplineSpace1D,
+    space_w: BsplineSpace1D,
+    ctrl: npt.NDArray[np.float64],
+    is_rational: bool = False,
+) -> Bspline:
+    """Create a 3D B-spline from three 1D spaces and control points."""
+    space = BsplineSpace([space_u, space_v, space_w])
+    return Bspline(space, ctrl, is_rational=is_rational)
+
+
+def _eval_lattice_pts(n: int = 21, a: float = 0.0, b: float = 1.0) -> npt.NDArray[np.float64]:
+    """Return evenly-spaced 1D evaluation points in [a, b]."""
+    return np.linspace(a, b, n, dtype=np.float64)
+
+
+def _eval_2d_product(f: Bspline, g: Bspline, h: Bspline, n: int = 21, atol: float = 1e-10) -> None:
+    """Assert h == f*g by evaluating on a lattice at interior points.
+
+    Uses strictly interior points to avoid boundary evaluation issues with
+    periodic and non-open B-splines.
+    """
+    dom_u, dom_v = f.space.spaces[0].domain, f.space.spaces[1].domain
+    pts_u = _eval_lattice_pts(n, float(dom_u[0]), float(dom_u[1]))[1:-1]
+    pts_v = _eval_lattice_pts(n, float(dom_v[0]), float(dom_v[1]))[1:-1]
+    lattice = PointsLattice([pts_u, pts_v])
+
+    f_vals = f.evaluate(lattice)
+    g_vals = g.evaluate(lattice)
+    h_vals = h.evaluate(lattice)
+    np.testing.assert_allclose(h_vals, f_vals * g_vals, atol=atol)
+
+
+def _eval_3d_product(f: Bspline, g: Bspline, h: Bspline, n: int = 11, atol: float = 1e-10) -> None:
+    """Assert h == f*g by evaluating on a 3D lattice at interior points.
+
+    Uses strictly interior points to avoid boundary evaluation issues with
+    periodic and non-open B-splines.
+    """
+    dom_u = f.space.spaces[0].domain
+    dom_v = f.space.spaces[1].domain
+    dom_w = f.space.spaces[2].domain
+    pts_u = _eval_lattice_pts(n, float(dom_u[0]), float(dom_u[1]))[1:-1]
+    pts_v = _eval_lattice_pts(n, float(dom_v[0]), float(dom_v[1]))[1:-1]
+    pts_w = _eval_lattice_pts(n, float(dom_w[0]), float(dom_w[1]))[1:-1]
+    lattice = PointsLattice([pts_u, pts_v, pts_w])
+
+    f_vals = f.evaluate(lattice)
+    g_vals = g.evaluate(lattice)
+    h_vals = h.evaluate(lattice)
+    np.testing.assert_allclose(h_vals, f_vals * g_vals, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# nD Bernstein product unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinProductND:
+    """Unit tests for the nD Bernstein product formula."""
+
+    def test_1d_matches_existing(self) -> None:
+        """1D nD product matches the existing 1D implementation."""
+        rng = np.random.default_rng(42)
+        b_f = rng.random((4, 2))  # degree 3, rank 2
+        b_g = rng.random((3, 2))  # degree 2, rank 2
+
+        result_1d = _bernstein_product_coefficients(b_f, b_g)
+        result_nd = _bernstein_product_coefficients_nd(b_f, b_g)
+        np.testing.assert_allclose(result_nd, result_1d, atol=1e-13)
+
+    def test_2d_constant(self) -> None:
+        """Product of two constant Bezier patches is constant."""
+        # Degree (1,1) patches, all ctrl = 2.0 and 3.0.
+        b_f = np.full((2, 2, 1), 2.0)
+        b_g = np.full((2, 2, 1), 3.0)
+        result = _bernstein_product_coefficients_nd(b_f, b_g)
+        assert result.shape == (3, 3, 1)
+        np.testing.assert_allclose(result, 6.0, atol=1e-14)
+
+    def test_2d_separable(self) -> None:
+        """Product of separable fields: f(u,v)=f_u(u)*f_v(v), g(u,v)=g_u(u)*g_v(v).
+
+        Product should be (f_u*g_u)(u) * (f_v*g_v)(v).
+        """
+        rng = np.random.default_rng(123)
+        fu = rng.random(3)  # degree 2 in u
+        fv = rng.random(4)  # degree 3 in v
+        gu = rng.random(2)  # degree 1 in u
+        gv = rng.random(3)  # degree 2 in v
+
+        # Build 2D control points as outer products (rank=1).
+        b_f = np.outer(fu, fv)[:, :, np.newaxis]
+        b_g = np.outer(gu, gv)[:, :, np.newaxis]
+
+        result = _bernstein_product_coefficients_nd(b_f, b_g)
+
+        # Expected: outer product of 1D products.
+        prod_u = _bernstein_product_coefficients(fu[:, np.newaxis], gu[:, np.newaxis])[:, 0]
+        prod_v = _bernstein_product_coefficients(fv[:, np.newaxis], gv[:, np.newaxis])[:, 0]
+        expected = np.outer(prod_u, prod_v)[:, :, np.newaxis]
+
+        np.testing.assert_allclose(result, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 2D non-rational product tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalProduct2D:
+    """Correctness tests for 2D non-rational B-spline multiplication."""
+
+    def test_same_spaces_both_directions(self) -> None:
+        """Product of two biquadratic B-splines on the same mesh."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(0)
+        n = 4  # num_basis per direction
+        f = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+        g = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+
+        h = f * g
+
+        assert h.degree == (4, 4)
+        _eval_2d_product(f, g, h)
+
+    def test_different_knots_per_direction(self) -> None:
+        """Product with different knot vectors in u and v."""
+        knots_u = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        knots_v = [0.0, 0.0, 0.0, 0.25, 0.75, 1.0, 1.0, 1.0]
+        s_u = _make_space_1d(knots_u, 2)
+        s_v = _make_space_1d(knots_v, 2)
+
+        rng = np.random.default_rng(1)
+        n_u, n_v = 4, 5
+        f = _make_2d_bspline(s_u, s_v, rng.random((n_u, n_v, 1)))
+        g = _make_2d_bspline(s_u, s_v, rng.random((n_u, n_v, 1)))
+
+        h = f * g
+        _eval_2d_product(f, g, h)
+
+    def test_different_degrees(self) -> None:
+        """Product with different degrees in u (2) and v (3)."""
+        knots_u = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        knots_v = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        s_u = _make_space_1d(knots_u, 2)
+        s_v = _make_space_1d(knots_v, 3)
+
+        rng = np.random.default_rng(2)
+        n_u_f, n_v_f = 4, 5
+        f = _make_2d_bspline(s_u, s_v, rng.random((n_u_f, n_v_f, 1)))
+
+        # g has different degrees: degree 3 in u, degree 1 in v.
+        knots_gu = [0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]
+        knots_gv = [0.0, 0.0, 0.5, 1.0, 1.0]
+        s_gu = _make_space_1d(knots_gu, 3)
+        s_gv = _make_space_1d(knots_gv, 1)
+        n_u_g, n_v_g = 5, 3
+        g = _make_2d_bspline(s_gu, s_gv, rng.random((n_u_g, n_v_g, 1)))
+
+        h = f * g
+        assert h.degree == (5, 4)
+        _eval_2d_product(f, g, h)
+
+    def test_vector_field_rank2(self) -> None:
+        """Product of rank-2 B-spline fields."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(3)
+        n = 3
+        f = _make_2d_bspline(s, s, rng.random((n, n, 2)))
+        g = _make_2d_bspline(s, s, rng.random((n, n, 2)))
+
+        h = f * g
+        _eval_2d_product(f, g, h)
+
+    def test_single_bezier_element(self) -> None:
+        """Product of single Bezier patches (no interior breakpoints)."""
+        knots_u = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        knots_v = [0.0, 0.0, 1.0, 1.0]
+        s_u = _make_space_1d(knots_u, 2)
+        s_v = _make_space_1d(knots_v, 1)
+
+        rng = np.random.default_rng(4)
+        f = _make_2d_bspline(s_u, s_v, rng.random((3, 2, 1)))
+        g = _make_2d_bspline(s_u, s_v, rng.random((3, 2, 1)))
+
+        h = f * g
+        assert h.degree == (4, 2)
+        _eval_2d_product(f, g, h)
+
+    def test_different_meshes_per_operand(self) -> None:
+        """Operands have non-matching interior breakpoints in both directions."""
+        knots_f_u = [0.0, 0.0, 0.0, 0.3, 1.0, 1.0, 1.0]
+        knots_g_u = [0.0, 0.0, 0.0, 0.7, 1.0, 1.0, 1.0]
+        knots_f_v = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        knots_g_v = [0.0, 0.0, 0.0, 0.25, 0.75, 1.0, 1.0, 1.0]
+
+        s_fu = _make_space_1d(knots_f_u, 2)
+        s_gu = _make_space_1d(knots_g_u, 2)
+        s_fv = _make_space_1d(knots_f_v, 2)
+        s_gv = _make_space_1d(knots_g_v, 2)
+
+        rng = np.random.default_rng(5)
+        f = _make_2d_bspline(s_fu, s_fv, rng.random((4, 4, 1)))
+        g = _make_2d_bspline(s_gu, s_gv, rng.random((4, 5, 1)))
+
+        h = f * g
+        _eval_2d_product(f, g, h)
+
+    def test_multiply_by_constant(self) -> None:
+        """Multiplying by a constant field scales the spline."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(6)
+        f = _make_2d_bspline(s, s, rng.random((4, 4, 1)))
+
+        # Constant g: degree 0 Bezier in both directions.
+        knots_const = [0.0, 1.0]
+        s_const = _make_space_1d(knots_const, 0)
+        g = _make_2d_bspline(s_const, s_const, np.array([[[3.0]]]))
+
+        h = f * g
+        _eval_2d_product(f, g, h)
+
+
+# ---------------------------------------------------------------------------
+# 3D non-rational product test
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalProduct3D:
+    """Correctness test for 3D B-spline multiplication."""
+
+    def test_trilinear_product(self) -> None:
+        """Product of two trilinear B-splines."""
+        knots = [0.0, 0.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 1)
+
+        rng = np.random.default_rng(10)
+        n = 2
+        f = _make_3d_bspline(s, s, s, rng.random((n, n, n, 1)))
+        g = _make_3d_bspline(s, s, s, rng.random((n, n, n, 1)))
+
+        h = f * g
+        assert h.degree == (2, 2, 2)
+        _eval_3d_product(f, g, h)
+
+    def test_mixed_degrees_3d(self) -> None:
+        """3D product with different degrees per direction."""
+        knots_1 = [0.0, 0.0, 1.0, 1.0]
+        knots_2 = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        knots_3 = [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+
+        s1 = _make_space_1d(knots_1, 1)
+        s2 = _make_space_1d(knots_2, 2)
+        s3 = _make_space_1d(knots_3, 3)
+
+        rng = np.random.default_rng(11)
+        f = _make_3d_bspline(s1, s2, s3, rng.random((2, 3, 4, 1)))
+        g = _make_3d_bspline(s2, s1, s2, rng.random((3, 2, 3, 1)))
+
+        h = f * g
+        assert h.degree == (3, 3, 5)
+        _eval_3d_product(f, g, h)
+
+
+# ---------------------------------------------------------------------------
+# Rational product tests
+# ---------------------------------------------------------------------------
+
+
+class TestRationalProduct2D:
+    """Tests for rational (NURBS) 2D multiplication."""
+
+    def test_rational_times_rational(self) -> None:
+        """Product of two rational 2D B-splines."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(20)
+        n = 3
+        # Rational: last column is weights (must be > 0).
+        ctrl_f = rng.random((n, n, 2))
+        ctrl_f[..., -1] = np.abs(ctrl_f[..., -1]) + 0.1
+        ctrl_g = rng.random((n, n, 2))
+        ctrl_g[..., -1] = np.abs(ctrl_g[..., -1]) + 0.1
+
+        f = _make_2d_bspline(s, s, ctrl_f, is_rational=True)
+        g = _make_2d_bspline(s, s, ctrl_g, is_rational=True)
+
+        h = f * g
+        assert h.is_rational
+        _eval_2d_product(f, g, h, atol=1e-9)
+
+    def test_mixed_rational_nonrational(self) -> None:
+        """Product of rational x non-rational 2D B-splines."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(21)
+        n = 3
+        ctrl_f = rng.random((n, n, 2))
+        ctrl_f[..., -1] = np.abs(ctrl_f[..., -1]) + 0.1
+        f = _make_2d_bspline(s, s, ctrl_f, is_rational=True)
+        g = _make_2d_bspline(s, s, rng.random((n, n, 1)))
+
+        h = f * g
+        assert h.is_rational
+        _eval_2d_product(f, g, h, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Boundary type tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryTypes2D:
+    """Tests for per-direction boundary type handling in 2D products."""
+
+    def test_both_open(self) -> None:
+        """Both directions open should produce open result."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 2)
+
+        rng = np.random.default_rng(30)
+        f = _make_2d_bspline(s, s, rng.random((4, 4, 1)))
+        g = _make_2d_bspline(s, s, rng.random((4, 4, 1)))
+
+        h = f * g
+        for d in range(2):
+            assert h.space.spaces[d].has_open_knots()
+            assert not h.space.spaces[d].periodic
+        _eval_2d_product(f, g, h)
+
+    def test_both_periodic(self) -> None:
+        """Both directions periodic should produce periodic result.
+
+        Verification: convert operands to open, compute open product, and compare
+        against periodic product converted to open at interior points.
+        """
+        for degree in [1, 2, 3]:
+            n_spans = 4
+            knots = create_uniform_periodic_knot_vector(degree, n_spans)
+            s = BsplineSpace1D(knots, degree, periodic=True)
+            n_per = s.num_basis
+
+            rng = np.random.default_rng(31 + degree)
+            f = _make_2d_bspline(s, s, rng.random((n_per, n_per, 1)))
+            g = _make_2d_bspline(s, s, rng.random((n_per, n_per, 1)))
+
+            h = f * g
+            for d in range(2):
+                assert h.space.spaces[d].periodic
+
+            # Verify correctness: open product of open operands should match.
+            f_o = f.to_open_bspline()
+            g_o = g.to_open_bspline()
+            h_ref = f_o * g_o  # open x open -> open product (trusted)
+            h_o = h.to_open_bspline()
+
+            # Use the intersection of the open domains for evaluation.
+            dom_u = h_o.space.spaces[0].domain
+            dom_v = h_o.space.spaces[1].domain
+            pts_u = _eval_lattice_pts(21, float(dom_u[0]), float(dom_u[1]))[1:-1]
+            pts_v = _eval_lattice_pts(21, float(dom_v[0]), float(dom_v[1]))[1:-1]
+            lattice = PointsLattice([pts_u, pts_v])
+            np.testing.assert_allclose(h_o.evaluate(lattice), h_ref.evaluate(lattice), atol=1e-10)
+
+    def test_mixed_periodic_open(self) -> None:
+        """One direction periodic, one open -> periodic in u, open in v."""
+        degree = 2
+        knots_per = create_uniform_periodic_knot_vector(degree, 4)
+        s_per = BsplineSpace1D(knots_per, degree, periodic=True)
+        knots_open = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        s_open = _make_space_1d(knots_open, 2)
+
+        rng = np.random.default_rng(32)
+        # f: periodic in u, open in v
+        f = _make_2d_bspline(s_per, s_open, rng.random((s_per.num_basis, 4, 1)))
+        # g: same structure
+        g = _make_2d_bspline(s_per, s_open, rng.random((s_per.num_basis, 4, 1)))
+
+        h = f * g
+        # u-direction: periodic x periodic -> periodic
+        assert h.space.spaces[0].periodic
+        # v-direction: open x open -> open
+        assert h.space.spaces[1].has_open_knots()
+        assert not h.space.spaces[1].periodic
+
+        # Verify correctness via open reference.
+        f_o = f.to_open_bspline()
+        g_o = g.to_open_bspline()
+        h_ref = f_o * g_o
+        h_o = h.to_open_bspline()
+
+        dom_u = h_o.space.spaces[0].domain
+        dom_v = h_o.space.spaces[1].domain
+        pts_u = _eval_lattice_pts(21, float(dom_u[0]), float(dom_u[1]))[1:-1]
+        pts_v = _eval_lattice_pts(21, float(dom_v[0]), float(dom_v[1]))[1:-1]
+        lattice = PointsLattice([pts_u, pts_v])
+        np.testing.assert_allclose(h_o.evaluate(lattice), h_ref.evaluate(lattice), atol=1e-10)
+
+    def test_nonopen_both_directions(self) -> None:
+        """Both directions non-open should produce non-open result."""
+        # Non-open knot vector: boundary mult (2) < degree+1 (3).
+        knots_no = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0], dtype=np.float64)
+        s_no = BsplineSpace1D(knots_no, 2)
+
+        rng = np.random.default_rng(33)
+        n = s_no.num_basis
+        f = _make_2d_bspline(s_no, s_no, rng.random((n, n, 1)))
+        g = _make_2d_bspline(s_no, s_no, rng.random((n, n, 1)))
+
+        h = f * g
+        for d in range(2):
+            assert not h.space.spaces[d].has_open_knots()
+            assert not h.space.spaces[d].periodic
+        _eval_2d_product(f, g, h)
+
+
+# ---------------------------------------------------------------------------
+# Validation error tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationErrors:
+    """Test that proper errors are raised for invalid inputs."""
+
+    def test_different_dims(self) -> None:
+        """Multiplying 1D x 2D should raise ValueError."""
+        knots = [0.0, 0.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 1)
+
+        f_1d = Bspline(BsplineSpace([s]), np.array([[1.0], [2.0]]))
+        f_2d = _make_2d_bspline(s, s, np.ones((2, 2, 1)))
+
+        with pytest.raises(ValueError, match="same parametric dimension"):
+            f_2d * f_1d
+
+    def test_different_dtypes(self) -> None:
+        """Multiplying splines with different dtypes should raise."""
+        knots_64 = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64)
+        knots_32 = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float32)
+        s64 = BsplineSpace1D(knots_64, 1)
+        s32 = BsplineSpace1D(knots_32, 1)
+
+        f = _make_2d_bspline(s64, s64, np.ones((2, 2, 1), dtype=np.float64))
+        g = _make_2d_bspline(s32, s32, np.ones((2, 2, 1), dtype=np.float32))
+
+        with pytest.raises(ValueError, match="same dtype"):
+            f * g
+
+    def test_different_ranks(self) -> None:
+        """Multiplying rank-1 x rank-2 should raise."""
+        knots = [0.0, 0.0, 1.0, 1.0]
+        s = _make_space_1d(knots, 1)
+
+        f = _make_2d_bspline(s, s, np.ones((2, 2, 1)))
+        g = _make_2d_bspline(s, s, np.ones((2, 2, 2)))
+
+        with pytest.raises(ValueError, match="same rank"):
+            f * g
+
+    def test_different_domains(self) -> None:
+        """Multiplying splines on different domains should raise."""
+        s1 = _make_space_1d([0.0, 0.0, 1.0, 1.0], 1)
+        s2 = _make_space_1d([0.0, 0.0, 2.0, 2.0], 1)
+
+        f = _make_2d_bspline(s1, s1, np.ones((2, 2, 1)))
+        g = _make_2d_bspline(s1, s2, np.ones((2, 2, 1)))
+
+        with pytest.raises(ValueError, match="same parametric domain"):
+            f * g


### PR DESCRIPTION
## Summary
- Add dimension-independent pointwise multiplication for tensor-product B-splines (2D, 3D, any D)
- New module `_bspline_product_nd.py` with nD Bernstein product via weighted convolution and per-direction Oslo projection
- Supports non-rational, rational (NURBS), open, periodic, and non-open boundary conditions per direction
- `Bspline.multiply()` dispatches to 1D code for `dim==1` (unchanged) and nD code otherwise

## Algorithm
1. Per-direction breakpoint analysis using existing 1D helpers
2. Refine both operands to full-Bezier in all directions
3. Element-wise nD Bernstein product (multi-dimensional weighted convolution)
4. Project to optimal continuity via per-direction Oslo least-squares
5. Per-direction boundary conversion (periodic/non-open) using ghost knot Oslo chains

## Test plan
- [x] 22 new tests covering 2D/3D products, rational, periodic, non-open, mixed boundaries, and validation errors
- [x] All 33 existing 1D product tests pass unchanged
- [x] Full suite (1172 tests) passes
- [x] ruff check, ruff format, mypy all clean

Generated with [Claude Code](https://claude.com/claude-code)