### PR TITLE
feat(bspline): add derivative (hodograph) computation

### DIFF
--- a/src/pantr/_bspline_derivative.py
+++ b/src/pantr/_bspline_derivative.py
@@ -261,7 +261,7 @@ def _refine_to_common_space_1d(
     return a, b
 
 
-def _compute_missing_knots(
+def _compute_missing_knots(  # noqa: PLR0913
     unique_self: npt.NDArray[np.float32 | np.float64],
     mults_self: npt.NDArray[np.int_],
     unique_other: npt.NDArray[np.float32 | np.float64],

--- a/src/pantr/_bspline_derivative.py
+++ b/src/pantr/_bspline_derivative.py
@@ -1,0 +1,445 @@
+"""B-spline derivative (hodograph) computation.
+
+This module provides :func:`_derivative_bspline`, which computes the exact
+first derivative of a B-spline in a given parametric direction, returning a
+new :class:`~pantr.bspline.Bspline` whose value at every point equals the
+derivative of the original.
+
+Works for non-rational and rational (NURBS) B-splines of any parametric
+dimension, and correctly preserves per-direction boundary structure
+(open / periodic / non-open).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knots import _get_Bspline_num_basis_1D_impl
+from .bspline_space_1D import BsplineSpace1D
+from .bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from .bspline import Bspline
+
+
+def _derivative_ctrl_1d(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute derivative control points for a 1D non-rational B-spline.
+
+    Applies the standard B-spline derivative formula:
+    ``Q[i] = p * (P[i+1] - P[i]) / (T[i+p+1] - T[i+1])``
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector of the
+            original B-spline, length ``n + p + 1``.
+        degree (int): Polynomial degree of the original B-spline (``p >= 1``).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(n, ...)``, where ``n`` is the number of basis functions.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative control points of
+        shape ``(n - 1, ...)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    n = ctrl.shape[0]
+    denom = knots[degree + 1 : n + degree] - knots[1:n]
+    # Reshape denom for broadcasting: (n-1,) -> (n-1, 1, 1, ...)
+    for _ in range(ctrl.ndim - 1):
+        denom = denom[..., np.newaxis]
+    diff = ctrl[1:] - ctrl[:-1]
+    return np.where(denom == 0.0, 0.0, degree * diff / denom)
+
+
+def _derivative_nonrational_1d(bspline: Bspline) -> Bspline:
+    """Compute the derivative of a non-rational, non-periodic 1D B-spline.
+
+    Applies the standard B-spline derivative formula to produce a new B-spline
+    of degree ``p - 1``.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A 1D non-rational, non-periodic
+            B-spline with degree >= 1.
+
+    Returns:
+        ~pantr.bspline.Bspline: Derivative B-spline of degree ``p - 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    space_1d = bspline.space.spaces[0]
+    knots = space_1d.knots
+    p = space_1d.degree
+    ctrl = bspline.control_points
+
+    new_knots = knots[1:-1]
+    new_degree = p - 1
+    new_ctrl = _derivative_ctrl_1d(knots, p, ctrl)
+
+    new_space = BsplineSpace([BsplineSpace1D(new_knots, new_degree)])
+    return BsplineCls(new_space, new_ctrl, is_rational=False)
+
+
+def _derivative_periodic_1d(bspline: Bspline) -> Bspline:
+    """Compute the derivative of a periodic 1D B-spline.
+
+    Expands the periodic control points to full representation, applies the
+    derivative formula, then determines the periodic control points of the
+    result.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A 1D non-rational, periodic
+            B-spline with degree >= 1.
+
+    Returns:
+        ~pantr.bspline.Bspline: Periodic derivative B-spline of degree ``p - 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    space_1d = bspline.space.spaces[0]
+    knots = space_1d.knots
+    p = space_1d.degree
+    ctrl = bspline.control_points
+    n_periodic = space_1d.num_basis
+    n_full = len(knots) - p - 1
+
+    # Expand periodic CPs to full representation.
+    indices = np.arange(n_full) % n_periodic
+    ctrl_full = ctrl[indices]
+
+    new_knots = knots[1:-1]
+    new_degree = p - 1
+    new_ctrl_full = _derivative_ctrl_1d(knots, p, ctrl_full)
+
+    # Determine periodic CP count for the derivative space.
+    tol = float(space_1d.tolerance)
+    n_periodic_new = _get_Bspline_num_basis_1D_impl(new_knots, new_degree, True, tol)
+    new_ctrl = new_ctrl_full[:n_periodic_new]
+
+    new_space = BsplineSpace([BsplineSpace1D(new_knots, new_degree, periodic=True)])
+    return BsplineCls(new_space, new_ctrl, is_rational=False)
+
+
+def _derivative_nonrational_nd(bspline: Bspline, direction: int) -> Bspline:
+    """Compute the partial derivative of a non-rational nD B-spline.
+
+    Applies the 1D derivative formula along the given parametric direction
+    using the moveaxis/reshape/restore pattern. Other directions are unchanged.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A non-rational nD B-spline.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bspline.Bspline: Derivative B-spline with degree ``p_d - 1`` in
+        direction ``d`` and unchanged degrees in other directions.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    space_d = bspline.space.spaces[direction]
+    knots = space_d.knots
+    p = space_d.degree
+    ctrl = bspline.control_points
+    is_periodic = space_d.periodic
+
+    # For periodic: expand CPs along the direction axis.
+    if is_periodic:
+        n_periodic = space_d.num_basis
+        n_full = len(knots) - p - 1
+        indices = np.arange(n_full) % n_periodic
+        ctrl = np.take(ctrl, indices, axis=direction)
+
+    # Move target direction to axis 0, flatten the rest.
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    new_pts_2d = _derivative_ctrl_1d(knots, p, pts_2d)
+
+    # Restore shape and move axis back.
+    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+    new_moved = new_pts_2d.reshape(new_shape)
+    new_ctrl = np.moveaxis(new_moved, 0, direction)
+
+    # For periodic: trim to periodic CP count.
+    new_knots = knots[1:-1]
+    new_degree = p - 1
+
+    if is_periodic:
+        tol = float(space_d.tolerance)
+        n_periodic_new = _get_Bspline_num_basis_1D_impl(new_knots, new_degree, True, tol)
+        slices: list[slice] = [slice(None)] * new_ctrl.ndim
+        slices[direction] = slice(0, n_periodic_new)
+        new_ctrl = new_ctrl[tuple(slices)]
+
+    # Build new spaces list: replace direction d, keep others.
+    new_spaces = list(bspline.space.spaces)
+    new_spaces[direction] = BsplineSpace1D(new_knots, new_degree, periodic=is_periodic)
+    new_space = BsplineSpace(new_spaces)
+
+    return BsplineCls(new_space, new_ctrl, is_rational=False)
+
+
+def _refine_to_common_space_1d(
+    a: Bspline,
+    b: Bspline,
+    direction: int,
+) -> tuple[Bspline, Bspline]:
+    """Refine two B-splines to share a common knot vector in one direction.
+
+    Computes the knots missing from each B-spline in direction ``direction``
+    and inserts them so both share the same knot vector in that direction.
+
+    Args:
+        a (~pantr.bspline.Bspline): First B-spline.
+        b (~pantr.bspline.Bspline): Second B-spline.
+        direction (int): Parametric direction to refine.
+
+    Returns:
+        tuple[~pantr.bspline.Bspline, ~pantr.bspline.Bspline]: Both B-splines
+        refined to the same knot vector in direction ``direction``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from ._bspline_knots import _get_unique_knots_and_multiplicity_impl  # noqa: PLC0415
+
+    space_a = a.space.spaces[direction]
+    space_b = b.space.spaces[direction]
+    tol = max(float(space_a.tolerance), float(space_b.tolerance))
+    dtype = a.control_points.dtype
+
+    unique_a, mults_a = _get_unique_knots_and_multiplicity_impl(
+        space_a.knots, space_a.degree, tol, in_domain=True
+    )
+    unique_b, mults_b = _get_unique_knots_and_multiplicity_impl(
+        space_b.knots, space_b.degree, tol, in_domain=True
+    )
+
+    # Find knots to insert into a (present in b but missing/lower-mult in a).
+    knots_to_insert_a = _compute_missing_knots(unique_a, mults_a, unique_b, mults_b, tol, dtype)
+    # Find knots to insert into b (present in a but missing/lower-mult in b).
+    knots_to_insert_b = _compute_missing_knots(unique_b, mults_b, unique_a, mults_a, tol, dtype)
+
+    if knots_to_insert_a.size > 0:
+        if a.dim == 1:
+            a = a.insert_knots(knots_to_insert_a)
+        else:
+            per_dim: list[npt.NDArray[np.float32 | np.float64] | None] = [None] * a.dim
+            per_dim[direction] = knots_to_insert_a
+            a = a.insert_knots(per_dim)
+    if knots_to_insert_b.size > 0:
+        if b.dim == 1:
+            b = b.insert_knots(knots_to_insert_b)
+        else:
+            per_dim_b: list[npt.NDArray[np.float32 | np.float64] | None] = [None] * b.dim
+            per_dim_b[direction] = knots_to_insert_b
+            b = b.insert_knots(per_dim_b)
+
+    return a, b
+
+
+def _compute_missing_knots(
+    unique_self: npt.NDArray[np.float32 | np.float64],
+    mults_self: npt.NDArray[np.int_],
+    unique_other: npt.NDArray[np.float32 | np.float64],
+    mults_other: npt.NDArray[np.int_],
+    tol: float,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute knots present in other but missing or lower-multiplicity in self.
+
+    For each unique knot in ``unique_other``, computes how many additional
+    insertions are needed in ``unique_self`` to match the multiplicity.
+
+    Args:
+        unique_self (npt.NDArray[np.float32 | np.float64]): Unique knots of self.
+        mults_self (npt.NDArray[np.int_]): Multiplicities of self.
+        unique_other (npt.NDArray[np.float32 | np.float64]): Unique knots of other.
+        mults_other (npt.NDArray[np.int_]): Multiplicities of other.
+        tol (float): Tolerance for coincidence tests.
+        dtype (npt.DTypeLike): Output dtype.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Sorted flat array of knots to insert.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    knots_list: list[float] = []
+    j = 0
+    for i in range(len(unique_other)):
+        xi = unique_other[i]
+        m_other = int(mults_other[i])
+        # Find matching knot in self.
+        m_self = 0
+        while j < len(unique_self) and float(unique_self[j]) < float(xi) - tol:
+            j += 1
+        if j < len(unique_self) and abs(float(unique_self[j]) - float(xi)) <= tol:
+            m_self = int(mults_self[j])
+        n_insert = m_other - m_self
+        if n_insert > 0:
+            knots_list.extend([float(xi)] * n_insert)
+    if len(knots_list) == 0:
+        return np.empty(0, dtype=dtype)
+    return np.array(knots_list, dtype=dtype)
+
+
+def _tile_scalar_bspline(w: Bspline, target_rank: int) -> Bspline:
+    """Tile a rank-1 B-spline to match a target rank.
+
+    Repeats the single control point component along the last axis so that
+    the resulting B-spline has ``target_rank`` components, each identical to
+    the original scalar function.
+
+    Args:
+        w (~pantr.bspline.Bspline): A rank-1 (scalar) non-rational B-spline.
+        target_rank (int): Desired number of output components.
+
+    Returns:
+        ~pantr.bspline.Bspline: B-spline with ``target_rank`` identical
+        components.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    ctrl = np.repeat(w.control_points, target_rank, axis=-1)
+    return BsplineCls(w.space, ctrl, is_rational=False)
+
+
+def _derivative_rational(bspline: Bspline, direction: int) -> Bspline:
+    """Compute the partial derivative of a rational (NURBS) B-spline.
+
+    Applies the quotient rule: for ``f = A/w``,
+    ``f' = (A'w - Aw') / w^2``.
+
+    The numerator and denominator are computed via B-spline products and
+    combined into a rational B-spline of degree ``2p`` in the given direction.
+
+    Since ``multiply()`` requires operands to have the same rank, the scalar
+    weight B-splines (rank 1) are tiled to match the vector rank before
+    multiplication.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A rational B-spline.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bspline.Bspline: Rational derivative B-spline.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    ctrl = bspline.control_points
+    vec_rank = ctrl.shape[-1] - 1  # number of non-weight components
+
+    # Decompose into numerator A (weighted coords) and denominator w (weights).
+    a_bspline = BsplineCls(bspline.space, ctrl[..., :-1], is_rational=False)
+    w_bspline = BsplineCls(bspline.space, ctrl[..., -1:], is_rational=False)
+
+    # Compute non-rational derivatives.
+    a_prime = _derivative_nonrational(a_bspline, direction)
+    w_prime = _derivative_nonrational(w_bspline, direction)
+
+    # Tile scalar B-splines to match vector rank for multiply().
+    w_tiled = _tile_scalar_bspline(w_bspline, vec_rank)
+    w_prime_tiled = _tile_scalar_bspline(w_prime, vec_rank)
+
+    # Compute products: A'*w and A*w' (degree 2p-1 each).
+    num1 = a_prime.multiply(w_tiled)
+    num2 = a_bspline.multiply(w_prime_tiled)
+
+    # Subtract CPs (same space guaranteed).
+    numerator_ctrl = num1.control_points - num2.control_points
+    numerator = BsplineCls(num1.space, numerator_ctrl, is_rational=False)
+
+    # Compute denominator: w^2 (degree 2p).
+    denom = w_bspline.multiply(w_bspline)
+
+    # Elevate numerator degree by 1 in the target direction.
+    increments = [0] * bspline.dim
+    increments[direction] = 1
+    numerator = numerator.elevate_degree(increments)
+
+    # Refine both to a common knot vector in the target direction.
+    numerator, denom = _refine_to_common_space_1d(numerator, denom, direction)
+
+    # Assemble rational B-spline.
+    result_ctrl = np.concatenate([numerator.control_points, denom.control_points], axis=-1)
+    return BsplineCls(numerator.space, result_ctrl, is_rational=True)
+
+
+def _derivative_nonrational(bspline: Bspline, direction: int) -> Bspline:
+    """Compute the partial derivative of a non-rational B-spline.
+
+    Dispatches to the appropriate 1D or nD implementation based on the
+    B-spline's dimension and periodicity.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A non-rational B-spline.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bspline.Bspline: Derivative B-spline.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    if bspline.dim == 1:
+        space_1d = bspline.space.spaces[0]
+        if space_1d.periodic:
+            return _derivative_periodic_1d(bspline)
+        return _derivative_nonrational_1d(bspline)
+    return _derivative_nonrational_nd(bspline, direction)
+
+
+def _derivative_bspline(bspline: Bspline, direction: int) -> Bspline:
+    """Compute the first partial derivative of a B-spline.
+
+    This is the main entry point for derivative computation. It dispatches
+    to the appropriate implementation based on the B-spline's properties
+    (rational vs non-rational, dimension, periodicity).
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The B-spline to differentiate.
+        direction (int): Parametric direction for differentiation. Must be
+            in ``[0, dim)``.
+
+    Returns:
+        ~pantr.bspline.Bspline: A new B-spline representing the derivative.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bspline.Bspline.derivative` instead.
+    """
+    if bspline.is_rational:
+        return _derivative_rational(bspline, direction)
+    return _derivative_nonrational(bspline, direction)

--- a/src/pantr/bspline.py
+++ b/src/pantr/bspline.py
@@ -15,6 +15,7 @@ import numpy as np
 from numpy import typing as npt
 
 from ._bspline_degree import _degree_elevate_bspline
+from ._bspline_derivative import _derivative_bspline
 from ._bspline_eval import _evaluate_Bspline, _evaluate_Bspline_deriv
 from ._bspline_knot_insertion import (
     _compute_uniform_subdivision_knots,
@@ -233,6 +234,45 @@ class Bspline:
         """
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_Bspline_deriv(self, pts, orders_seq, out)
+
+    def derivative(self, direction: int = 0) -> Bspline:
+        """Return a B-spline representing the first derivative in the given direction.
+
+        Computes the hodograph: a new B-spline whose value at every parametric
+        point equals the partial derivative of this B-spline with respect to
+        parametric direction ``direction``.
+
+        For non-rational B-splines of degree ``p`` in direction ``d``, the
+        result has degree ``p - 1`` in direction ``d`` and the same degree in
+        all other directions.
+
+        For rational B-splines (NURBS), the quotient rule is applied, producing
+        a rational B-spline of degree ``2p`` in direction ``d``.
+
+        Args:
+            direction (int): Parametric direction for differentiation.
+                Must be in ``[0, dim)``. Defaults to 0.
+
+        Returns:
+            Bspline: A new B-spline representing the derivative.
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+            ValueError: If the degree in the given direction is 0.
+
+        Example:
+            >>> # First derivative of a 1D curve
+            >>> f_prime = f.derivative()
+            >>> # Partial derivative of a surface with respect to direction 1
+            >>> df_dv = surface.derivative(direction=1)
+            >>> # Second derivative (composable)
+            >>> f_double_prime = f.derivative().derivative()
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+        if self.space.spaces[direction].degree < 1:
+            raise ValueError("Derivative of a degree-0 B-spline is not defined.")
+        return _derivative_bspline(self, direction)
 
     def elevate_degree(self, degree_increments: int | Sequence[int]) -> Bspline:
         """Elevate the polynomial degree of the B-spline.

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -1,0 +1,446 @@
+"""Tests for B-spline derivative (hodograph) computation."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._bspline_space_factory import (
+    create_uniform_open_knot_vector,
+    create_uniform_periodic_knot_vector,
+)
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_bspline_1d(
+    knots: list[float],
+    degree: int,
+    ctrl: list[float] | list[list[float]],
+    is_rational: bool = False,
+    periodic: bool = False,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 1D B-spline from plain Python lists."""
+    space_1d = BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=periodic)
+    space = BsplineSpace([space_1d])
+    cp: npt.NDArray[np.float32 | np.float64] = np.array(ctrl, dtype=dtype)
+    return Bspline(space, cp, is_rational=is_rational)
+
+
+def eval_pts(a: float = 0.0, b: float = 1.0, n: int = 201) -> npt.NDArray[np.float64]:
+    """Return n evenly-spaced evaluation points in [a, b]."""
+    return np.linspace(a, b, n, dtype=np.float64)
+
+
+def _make_open(
+    num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
+) -> Bspline:
+    """Create an open 1D B-spline with random-ish CPs."""
+    knots = create_uniform_open_knot_vector(num_intervals, degree, domain=domain)
+    space_1d = BsplineSpace1D(knots, degree)
+    space = BsplineSpace([space_1d])
+    n = space.num_total_basis
+    rng = np.random.default_rng(42 + degree + num_intervals)
+    ctrl = rng.standard_normal(n)
+    return Bspline(space, ctrl)
+
+
+def _make_periodic(
+    num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
+) -> Bspline:
+    """Create a periodic 1D B-spline."""
+    knots = create_uniform_periodic_knot_vector(num_intervals, degree, domain=domain)
+    space_1d = BsplineSpace1D(knots, degree, periodic=True)
+    space = BsplineSpace([space_1d])
+    n = space.num_total_basis
+    rng = np.random.default_rng(17 + degree + num_intervals)
+    ctrl = rng.standard_normal(n)
+    return Bspline(space, ctrl)
+
+
+def _make_nonopen(
+    num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
+) -> Bspline:
+    """Create a non-open, non-periodic B-spline (unclamped boundary knots)."""
+    knots = create_uniform_periodic_knot_vector(num_intervals, degree, domain=domain)
+    space_1d = BsplineSpace1D(knots, degree, periodic=False)
+    space = BsplineSpace([space_1d])
+    n = space.num_total_basis
+    rng = np.random.default_rng(31 + degree + num_intervals)
+    ctrl = rng.standard_normal(n)
+    return Bspline(space, ctrl)
+
+
+def _assert_derivative_matches_evaluate(
+    f: Bspline,
+    direction: int = 0,
+    atol: float = 1e-9,
+) -> Bspline:
+    """Assert that f.derivative() matches f.evaluate_derivatives() pointwise.
+
+    Returns the derivative B-spline for further checks.
+    """
+    space_d = f.space.spaces[direction]
+    a, b = float(space_d.domain[0]), float(space_d.domain[1])
+
+    f_prime = f.derivative(direction=direction)
+
+    if f.dim == 1:
+        pts = eval_pts(a, b, 201)
+        expected = f.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+    else:
+        # Build pts array for nD: use linspace in each direction.
+        n_pts = 51
+        dim = f.dim
+        coords = np.empty((n_pts, dim), dtype=np.float64)
+        rng = np.random.default_rng(99)
+        for d in range(dim):
+            ad, bd = float(f.space.spaces[d].domain[0]), float(f.space.spaces[d].domain[1])
+            coords[:, d] = rng.uniform(ad, bd, n_pts)
+        orders = [0] * dim
+        orders[direction] = 1
+        expected = f.evaluate_derivatives(coords, orders)
+        actual = f_prime.evaluate(coords)
+
+    np.testing.assert_allclose(actual, expected, atol=atol)
+    return f_prime
+
+
+# ---------------------------------------------------------------------------
+# Non-rational 1D open tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalOpen1D:
+    """Derivative of non-rational, open (clamped) 1D B-splines."""
+
+    def test_linear(self) -> None:
+        """Derivative of a linear B-spline (line) is a constant."""
+        f = make_bspline_1d([0.0, 0.0, 1.0, 1.0], 1, [2.0, 5.0])
+        f_prime = f.derivative()
+
+        assert f_prime.space.spaces[0].degree == 0
+        pts = eval_pts()
+        vals = f_prime.evaluate(pts)
+        np.testing.assert_allclose(vals, 3.0, atol=1e-14)
+
+    def test_quadratic(self) -> None:
+        """Derivative of a quadratic B-spline matches evaluate_derivatives."""
+        f = _make_open(3, 2)
+        _assert_derivative_matches_evaluate(f)
+
+    def test_cubic(self) -> None:
+        """Derivative of a cubic B-spline matches evaluate_derivatives."""
+        f = _make_open(4, 3)
+        _assert_derivative_matches_evaluate(f)
+
+    def test_high_degree(self) -> None:
+        """Derivative of degree-5 B-spline."""
+        f = _make_open(3, 5)
+        _assert_derivative_matches_evaluate(f)
+
+    def test_single_element_bezier(self) -> None:
+        """Derivative of a single-element Bezier."""
+        f = make_bspline_1d([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2, [1.0, 3.0, 2.0])
+        f_prime = _assert_derivative_matches_evaluate(f)
+        assert f_prime.space.spaces[0].has_Bezier_like_knots()
+
+    def test_vector_valued(self) -> None:
+        """Derivative of a vector-valued B-spline (2D curve)."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [[0.0, 0.0], [1.0, 2.0], [2.0, 1.0], [3.0, 3.0]]
+        f = make_bspline_1d(knots, 2, ctrl)
+        f_prime = f.derivative()
+
+        pts = eval_pts()
+        expected = f.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-10)
+
+    def test_second_derivative_composable(self) -> None:
+        """f.derivative().derivative() matches second derivative."""
+        f = _make_open(4, 3)
+        f_pp = f.derivative().derivative()
+        a, b = float(f.space.spaces[0].domain[0]), float(f.space.spaces[0].domain[1])
+        pts = eval_pts(a, b, 201)
+        expected = f.evaluate_derivatives(pts, 2)
+        actual = f_pp.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Non-rational 1D non-open tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalNonOpen1D:
+    """Derivative of non-rational, non-open (unclamped) 1D B-splines."""
+
+    def test_nonopen_stays_nonopen(self) -> None:
+        """Derivative of a non-open B-spline is still non-open."""
+        f = _make_nonopen(4, 2)
+        f_prime = f.derivative()
+        space_d = f_prime.space.spaces[0]
+        assert not space_d.has_open_knots()
+        assert not space_d.periodic
+
+    def test_nonopen_matches_evaluate_derivatives(self) -> None:
+        """Derivative evaluation matches evaluate_derivatives for non-open."""
+        f = _make_nonopen(4, 3)
+        f_open = f.to_open_bspline()
+        f_prime = f.derivative()
+        f_prime_open = f_prime.to_open_bspline()
+
+        a, b = float(f_open.space.spaces[0].domain[0]), float(f_open.space.spaces[0].domain[1])
+        pts = eval_pts(a, b, 201)
+        expected = f_open.evaluate_derivatives(pts, 1)
+        actual = f_prime_open.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+    def test_nonopen_degree_reduced(self) -> None:
+        """Degree decreases by 1."""
+        f = _make_nonopen(5, 3)
+        f_prime = f.derivative()
+        assert f_prime.space.spaces[0].degree == 2
+
+
+# ---------------------------------------------------------------------------
+# Non-rational 1D periodic tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalPeriodic1D:
+    """Derivative of non-rational, periodic 1D B-splines."""
+
+    def test_periodic_stays_periodic(self) -> None:
+        """Derivative of a periodic B-spline is still periodic."""
+        f = _make_periodic(4, 2)
+        f_prime = f.derivative()
+        assert f_prime.space.spaces[0].periodic
+
+    def test_periodic_matches_evaluate_derivatives(self) -> None:
+        """Derivative evaluation matches evaluate_derivatives for periodic."""
+        f = _make_periodic(4, 3)
+        f_open = f.to_open_bspline()
+        f_prime = f.derivative()
+        f_prime_open = f_prime.to_open_bspline()
+
+        a, b = float(f_open.space.spaces[0].domain[0]), float(f_open.space.spaces[0].domain[1])
+        pts = eval_pts(a, b, 201)
+        expected = f_open.evaluate_derivatives(pts, 1)
+        actual = f_prime_open.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+    def test_periodic_degree_reduced(self) -> None:
+        """Degree decreases by 1."""
+        f = _make_periodic(5, 3)
+        f_prime = f.derivative()
+        assert f_prime.space.spaces[0].degree == 2
+
+    def test_periodic_second_derivative(self) -> None:
+        """Composable second derivative of periodic B-spline."""
+        f = _make_periodic(5, 3)
+        f_pp = f.derivative().derivative()
+        assert f_pp.space.spaces[0].periodic
+        assert f_pp.space.spaces[0].degree == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-rational nD tests
+# ---------------------------------------------------------------------------
+
+
+class TestNonRationalND:
+    """Derivative of non-rational tensor-product B-splines (nD)."""
+
+    def _make_2d_surface(self) -> Bspline:
+        """Create a 2D B-spline surface."""
+        knots0 = create_uniform_open_knot_vector(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knot_vector(2, 3, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 3)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(55)
+        ctrl = rng.standard_normal((*space.num_basis, 2))
+        return Bspline(space, ctrl)
+
+    def test_partial_direction_0(self) -> None:
+        """Partial derivative in direction 0 matches evaluate_derivatives."""
+        f = self._make_2d_surface()
+        _assert_derivative_matches_evaluate(f, direction=0, atol=1e-8)
+
+    def test_partial_direction_1(self) -> None:
+        """Partial derivative in direction 1 matches evaluate_derivatives."""
+        f = self._make_2d_surface()
+        _assert_derivative_matches_evaluate(f, direction=1, atol=1e-8)
+
+    def test_degree_reduced_only_in_direction(self) -> None:
+        """Only the differentiated direction's degree is reduced."""
+        f = self._make_2d_surface()
+        f_prime = f.derivative(direction=0)
+        assert f_prime.space.spaces[0].degree == 1  # was 2
+        assert f_prime.space.spaces[1].degree == 3  # unchanged
+
+    def test_periodic_direction(self) -> None:
+        """Periodic in one direction, open in another."""
+        knots0 = create_uniform_open_knot_vector(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_periodic_knot_vector(4, 2, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 2, periodic=True)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(77)
+        ctrl = rng.standard_normal((*space.num_basis, 1))
+        f = Bspline(space, ctrl)
+
+        # Derivative in periodic direction.
+        f_prime = f.derivative(direction=1)
+        assert f_prime.space.spaces[1].periodic
+        assert f_prime.space.spaces[1].degree == 1
+        assert f_prime.space.spaces[0].degree == 2  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Rational 1D tests
+# ---------------------------------------------------------------------------
+
+
+class TestRational1D:
+    """Derivative of rational (NURBS) 1D B-splines."""
+
+    def test_rational_matches_evaluate_derivatives(self) -> None:
+        """Rational derivative matches evaluate_derivatives pointwise."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        # CPs store [w*x, w*y, w]: a weighted 2D curve.
+        ctrl = [[1.0, 0.0, 1.0], [2.0, 4.0, 2.0], [1.5, 3.0, 1.0], [3.0, 1.5, 1.5]]
+        f = make_bspline_1d(knots, 2, ctrl, is_rational=True)
+        f_prime = _assert_derivative_matches_evaluate(f, atol=1e-8)
+        assert f_prime.is_rational
+
+    def test_rational_unit_weights_matches_nonrational(self) -> None:
+        """Rational with unit weights should match non-rational derivative."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl_nr = [1.0, 2.0, 0.5, 3.0]
+        f_nr = make_bspline_1d(knots, 2, ctrl_nr)
+        # Same curve, rational with w=1: CPs store [w*P, w] = [P, 1].
+        ctrl_r = [[1.0, 1.0], [2.0, 1.0], [0.5, 1.0], [3.0, 1.0]]
+        f_r = make_bspline_1d(knots, 2, ctrl_r, is_rational=True)
+
+        pts = eval_pts()
+        deriv_nr = f_nr.derivative().evaluate(pts)
+        deriv_r = f_r.derivative().evaluate(pts)
+        np.testing.assert_allclose(deriv_r, deriv_nr, atol=1e-9)
+
+    def test_rational_circle_arc(self) -> None:
+        """Derivative of a quarter circle NURBS arc."""
+        # Quarter circle: P0=(1,0), P1=(1,1) w=1/sqrt(2), P2=(0,1)
+        w = 1.0 / np.sqrt(2.0)
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        # Homogeneous CPs: [w*x, w*y, w]
+        ctrl = [[1.0, 0.0, 1.0], [w * 1.0, w * 1.0, w], [0.0, 1.0, 1.0]]
+        f = make_bspline_1d(knots, 2, ctrl, is_rational=True)
+
+        f_prime = f.derivative()
+        pts = eval_pts()
+        expected = f.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+    def test_rational_degree(self) -> None:
+        """Rational derivative has degree 2p in the given direction."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [[1.0, 0.0, 1.0], [2.0, 4.0, 2.0], [1.5, 3.0, 1.0], [3.0, 1.5, 1.5]]
+        f = make_bspline_1d(knots, 2, ctrl, is_rational=True)
+        f_prime = f.derivative()
+        assert f_prime.space.spaces[0].degree == 4  # 2 * 2 = 4
+
+
+# ---------------------------------------------------------------------------
+# Rational nD tests
+# ---------------------------------------------------------------------------
+
+
+class TestRationalND:
+    """Derivative of rational (NURBS) nD B-splines."""
+
+    def test_rational_2d_surface(self) -> None:
+        """Rational 2D surface derivative matches evaluate_derivatives."""
+        knots0 = create_uniform_open_knot_vector(2, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knot_vector(2, 2, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 2)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(88)
+        n0, n1 = space.num_basis
+        # [w*x, w*y, w] — rank-2 rational surface
+        ctrl = np.empty((n0, n1, 3), dtype=np.float64)
+        ctrl[..., :2] = rng.standard_normal((n0, n1, 2))
+        ctrl[..., 2] = rng.uniform(0.5, 2.0, (n0, n1))
+        # Weight coords: multiply x,y by w.
+        ctrl[..., 0] *= ctrl[..., 2]
+        ctrl[..., 1] *= ctrl[..., 2]
+        f = Bspline(space, ctrl, is_rational=True)
+
+        _assert_derivative_matches_evaluate(f, direction=0, atol=1e-7)
+        _assert_derivative_matches_evaluate(f, direction=1, atol=1e-7)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases and error handling."""
+
+    def test_degree_0_raises(self) -> None:
+        """Derivative of a degree-0 B-spline raises ValueError."""
+        f = make_bspline_1d([0.0, 0.5, 1.0], 0, [1.0, 2.0])
+        with pytest.raises(ValueError, match="degree-0"):
+            f.derivative()
+
+    def test_direction_out_of_range_raises(self) -> None:
+        """Out-of-range direction raises ValueError."""
+        f = _make_open(3, 2)
+        with pytest.raises(ValueError, match="direction"):
+            f.derivative(direction=1)
+        with pytest.raises(ValueError, match="direction"):
+            f.derivative(direction=-1)
+
+    def test_float32_dtype(self) -> None:
+        """Float32 B-spline produces float32 derivative."""
+        knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 2.0, 3.0]
+        f = make_bspline_1d(knots, 2, ctrl, dtype=np.float32)
+        f_prime = f.derivative()
+        assert f_prime.dtype == np.float32
+
+    def test_degree_1_produces_degree_0(self) -> None:
+        """Derivative of degree 1 produces degree 0."""
+        f = _make_open(3, 1)
+        f_prime = f.derivative()
+        assert f_prime.space.spaces[0].degree == 0
+
+    def test_knot_structure_preserved(self) -> None:
+        """Interior knot multiplicities are preserved in derivative."""
+        # Degree 3 with an interior knot of multiplicity 2 (C^1).
+        knots = [0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0]
+        ctrl = [1.0, 2.0, 0.5, 3.0, 1.0, 2.5]
+        f = make_bspline_1d(knots, 3, ctrl)
+        f_prime = f.derivative()
+
+        # Derivative has degree 2, same interior knot at 0.5 with mult 2.
+        space_d = f_prime.space.spaces[0]
+        assert space_d.degree == 2
+        unique, mults = space_d.get_unique_knots_and_multiplicity(in_domain=True)
+        # Interior knots (exclude boundaries).
+        interior_mask = (unique > 0.0 + 1e-10) & (unique < 1.0 - 1e-10)
+        assert np.sum(interior_mask) == 1
+        assert mults[interior_mask][0] == 2

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -24,11 +24,10 @@ def make_bspline_1d(
     degree: int,
     ctrl: list[float] | list[list[float]],
     is_rational: bool = False,
-    periodic: bool = False,
     dtype: type = np.float64,
 ) -> Bspline:
     """Create a 1D B-spline from plain Python lists."""
-    space_1d = BsplineSpace1D(np.array(knots, dtype=dtype), degree, periodic=periodic)
+    space_1d = BsplineSpace1D(np.array(knots, dtype=dtype), degree)
     space = BsplineSpace([space_1d])
     cp: npt.NDArray[np.float32 | np.float64] = np.array(ctrl, dtype=dtype)
     return Bspline(space, cp, is_rational=is_rational)
@@ -209,7 +208,7 @@ class TestNonRationalNonOpen1D:
         """Degree decreases by 1."""
         f = _make_nonopen(5, 3)
         f_prime = f.derivative()
-        assert f_prime.space.spaces[0].degree == 2
+        assert f_prime.space.spaces[0].degree == 2  # noqa: PLR2004
 
 
 # ---------------------------------------------------------------------------
@@ -243,14 +242,14 @@ class TestNonRationalPeriodic1D:
         """Degree decreases by 1."""
         f = _make_periodic(5, 3)
         f_prime = f.derivative()
-        assert f_prime.space.spaces[0].degree == 2
+        assert f_prime.space.spaces[0].degree == 2  # noqa: PLR2004
 
     def test_periodic_second_derivative(self) -> None:
         """Composable second derivative of periodic B-spline."""
         f = _make_periodic(5, 3)
         f_pp = f.derivative().derivative()
         assert f_pp.space.spaces[0].periodic
-        assert f_pp.space.spaces[0].degree == 1
+        assert f_pp.space.spaces[0].degree == 1  # p=3 -> p=2 -> p=1
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +286,7 @@ class TestNonRationalND:
         f = self._make_2d_surface()
         f_prime = f.derivative(direction=0)
         assert f_prime.space.spaces[0].degree == 1  # was 2
-        assert f_prime.space.spaces[1].degree == 3  # unchanged
+        assert f_prime.space.spaces[1].degree == 3  # unchanged  # noqa: PLR2004
 
     def test_periodic_direction(self) -> None:
         """Periodic in one direction, open in another."""
@@ -303,8 +302,8 @@ class TestNonRationalND:
         # Derivative in periodic direction.
         f_prime = f.derivative(direction=1)
         assert f_prime.space.spaces[1].periodic
-        assert f_prime.space.spaces[1].degree == 1
-        assert f_prime.space.spaces[0].degree == 2  # unchanged
+        assert f_prime.space.spaces[1].degree == 1  # p=2 -> p=1
+        assert f_prime.space.spaces[0].degree == 2  # unchanged  # noqa: PLR2004
 
 
 # ---------------------------------------------------------------------------
@@ -359,7 +358,7 @@ class TestRational1D:
         ctrl = [[1.0, 0.0, 1.0], [2.0, 4.0, 2.0], [1.5, 3.0, 1.0], [3.0, 1.5, 1.5]]
         f = make_bspline_1d(knots, 2, ctrl, is_rational=True)
         f_prime = f.derivative()
-        assert f_prime.space.spaces[0].degree == 4  # 2 * 2 = 4
+        assert f_prime.space.spaces[0].degree == 4  # 2 * 2 = 4  # noqa: PLR2004
 
 
 # ---------------------------------------------------------------------------
@@ -438,9 +437,9 @@ class TestEdgeCases:
 
         # Derivative has degree 2, same interior knot at 0.5 with mult 2.
         space_d = f_prime.space.spaces[0]
-        assert space_d.degree == 2
+        assert space_d.degree == 2  # noqa: PLR2004
         unique, mults = space_d.get_unique_knots_and_multiplicity(in_domain=True)
         # Interior knots (exclude boundaries).
         interior_mask = (unique > 0.0 + 1e-10) & (unique < 1.0 - 1e-10)
         assert np.sum(interior_mask) == 1
-        assert mults[interior_mask][0] == 2
+        assert mults[interior_mask][0] == 2  # noqa: PLR2004


### PR DESCRIPTION
## Summary
- Add `Bspline.derivative(direction=0)` method that returns a new B-spline whose value equals the partial derivative of the original
- **Non-rational**: degree `p` → `p-1` via standard B-spline derivative formula `Q[i] = p * (P[i+1] - P[i]) / (T[i+p+1] - T[i+1])`
- **Rational (NURBS)**: quotient rule `f' = (A'w - Aw') / w²` using B-spline products, degree `p` → `2p`
- **Periodic** B-splines: derivative remains periodic
- **Non-open** B-splines: derivative remains non-open
- **N-dimensional**: partial derivatives via tensor-product structure
- Composable: `f.derivative().derivative()` for higher-order derivatives

## Test plan
- [x] Non-rational 1D: open, non-open, periodic (verify via `evaluate_derivatives`)
- [x] Non-rational nD: partial derivatives in each direction, mixed degrees, periodic direction
- [x] Rational 1D: general NURBS, unit weights, circle arc
- [x] Rational nD: 2D NURBS surface
- [x] Composability: second derivative matches `evaluate_derivatives(pts, 2)`
- [x] Edge cases: degree 0 → ValueError, direction out of range, float32, knot structure preservation
- [x] Pre-PR checks pass (ruff, mypy, pytest 1205 passed, docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)