### PR TITLE
feat(bezier): add Bezier class with direct algorithms

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -25,8 +25,6 @@ from ._bspline_space_factory import (
     create_uniform_open_knot_vector,
     create_uniform_periodic_knot_vector,
 )
-
-# Public API imports
 from .basis import (
     LagrangeVariant,
     tabulate_Bernstein_basis,
@@ -37,6 +35,7 @@ from .basis import (
     tabulate_Lagrange_basis_1D,
     tabulate_Legendre_basis_1D,
 )
+from .bezier import Bezier
 from .bspline_space_1D import BsplineSpace1D
 from .bspline_space_nd import BsplineSpace
 from .change_basis import (
@@ -70,6 +69,7 @@ __author__: Final[str] = "Pablo Antolin <pablo.antolin@epfl.ch>"
 
 # Public interface: only functions/classes that don't start with _
 __all__ = [
+    "Bezier",
     "BsplineSpace",
     "BsplineSpace1D",
     "LagrangeVariant",

--- a/src/pantr/_bezier_core.py
+++ b/src/pantr/_bezier_core.py
@@ -1,0 +1,261 @@
+"""Numba-compiled kernels for Bézier evaluation and degree elevation.
+
+Provides fused evaluation kernels that compute Bernstein basis values and
+contract them with control points in a single pass, plus a simplified
+single-element degree elevation kernel.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call the Layer 2 helpers in ``_bezier_eval`` and
+    ``_bezier_degree`` instead.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_degree_core import _bincoeff
+from ._numba_compat import nb_jit, nb_prange
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=True,
+)
+def _evaluate_bezier_1d_core(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate a 1D Bézier curve at the given points.
+
+    Fuses Bernstein basis evaluation with control point contraction: for each
+    evaluation point the ``(p+1)`` Bernstein basis values are computed via the
+    recurrence relation and immediately multiplied with the corresponding
+    control points, avoiding allocation of a full ``(n_pts, p+1)`` basis matrix.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, rank)``.
+        pts (npt.NDArray[np.float32 | np.float64]): 1D evaluation points of
+            shape ``(n_pts,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array
+            of shape ``(n_pts, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_eval._evaluate_bezier` instead.
+    """
+    p = ctrl.shape[0] - 1
+    rank = ctrl.shape[1]
+    n_pts = pts.shape[0]
+
+    for pt_id in nb_prange(n_pts):
+        u = pts[pt_id]
+
+        if p == 0:
+            for r in range(rank):
+                out[pt_id, r] = ctrl[0, r]
+        elif u == 1.0:
+            for r in range(rank):
+                out[pt_id, r] = ctrl[p, r]
+        else:
+            one_minus_u = 1.0 - u
+            # B_0 = (1 - u)^p
+            b_prev = np.power(one_minus_u, p)
+
+            # Accumulate: start with basis[0] * ctrl[0]
+            for r in range(rank):
+                out[pt_id, r] = b_prev * ctrl[0, r]
+
+            if p > 0:
+                t_over_1mt = u / one_minus_u
+                for i in range(1, p + 1):
+                    b_curr = b_prev * ((p - i + 1.0) / i) * t_over_1mt
+                    for r in range(rank):
+                        out[pt_id, r] += b_curr * ctrl[i, r]
+                    b_prev = b_curr
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=True,
+)
+def _evaluate_bezier_deriv_1d_core(  # noqa: PLR0912
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate derivatives of a 1D Bézier curve at the given points.
+
+    Fuses Bernstein derivative basis evaluation (Algorithm A2.3 from Piegl &
+    Tiller specialised for Bernstein polynomials) with control point contraction.
+    For each evaluation point, computes the ``ndu`` table and derivative
+    coefficients, then contracts each derivative order with control points.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, rank)``.
+        pts (npt.NDArray[np.float32 | np.float64]): 1D evaluation points of
+            shape ``(n_pts,)``.
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output array
+            of shape ``(n_pts, n_deriv+1, rank)``. ``out[i, k, :]`` is the
+            k-th derivative of the Bézier at ``pts[i]``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_eval._evaluate_bezier_deriv` instead.
+    """
+    p = ctrl.shape[0] - 1
+    rank = ctrl.shape[1]
+    n_pts = pts.shape[0]
+    order = p + 1
+    dtype = pts.dtype
+    zero = dtype.type(0.0)
+    one = dtype.type(1.0)
+
+    for pt_id in nb_prange(n_pts):
+        s = pts[pt_id]
+
+        # Zero out output for this point
+        for k in range(n_deriv + 1):
+            for r in range(rank):
+                out[pt_id, k, r] = zero
+
+        # --- Build ndu table for uniform Bernstein knots ---
+        ndu = np.zeros((order, order), dtype=dtype)
+        a_arr = np.zeros((2, n_deriv + 1), dtype=dtype)
+
+        ndu[0, 0] = one
+        for j in range(1, order):
+            saved = zero
+            for rr in range(j):
+                ndu[j, rr] = one  # knot difference = 1
+                temp = ndu[rr, j - 1]
+                ndu[rr, j] = saved + (one - s) * temp
+                saved = s * temp
+            ndu[j, j] = saved
+
+        # 0th derivative: contract basis values with control points
+        for j in range(order):
+            basis_val = ndu[j, p]
+            for r in range(rank):
+                out[pt_id, 0, r] += basis_val * ctrl[j, r]
+
+        # k-th derivatives via triangular recursion (A2.3, unit knot spans)
+        # First compute basis derivatives, then contract
+        basis_derivs = np.zeros((n_deriv + 1, order), dtype=dtype)
+        for j in range(order):
+            basis_derivs[0, j] = ndu[j, p]
+
+        for rr in range(order):
+            s1 = 0
+            s2 = 1
+            a_arr[0, 0] = one
+
+            for k in range(1, n_deriv + 1):
+                d = zero
+                rk = rr - k
+                pk = p - k
+
+                if rr >= k:
+                    a_arr[s2, 0] = a_arr[s1, 0]
+                    d = a_arr[s2, 0] * ndu[rk, pk]
+
+                j1 = 1 if rk >= -1 else -rk
+                j2 = k - 1 if (rr - 1) <= pk else p - rr
+
+                for jj in range(j1, j2 + 1):
+                    a_arr[s2, jj] = a_arr[s1, jj] - a_arr[s1, jj - 1]
+                    d += a_arr[s2, jj] * ndu[rk + jj, pk]
+
+                if rr <= pk:
+                    a_arr[s2, k] = -a_arr[s1, k - 1]
+                    d += a_arr[s2, k] * ndu[rr, pk]
+
+                basis_derivs[k, rr] = d
+
+                tmp_s = s1
+                s1 = s2
+                s2 = tmp_s
+
+        # Factorial scaling and contraction
+        fac = p
+        for k in range(1, n_deriv + 1):
+            for j in range(order):
+                scaled = basis_derivs[k, j] * fac
+                for r in range(rank):
+                    out[pt_id, k, r] += scaled * ctrl[j, r]
+            fac *= p - k
+
+
+@nb_jit(nopython=True, cache=True)
+def _degree_elevate_bezier_1d_core(
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degree_increment: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Degree-elevate a single Bézier segment.
+
+    Computes the ``bezalfs`` matrix of Bézier degree elevation coefficients
+    and applies it to the control points:
+
+    .. math::
+
+        Q_i = \sum_{j=\max(0,i-t)}^{\min(p,i)}
+              \frac{\binom{p}{j}\,\binom{t}{i-j}}{\binom{p+t}{i}}\, P_j
+
+    where ``p`` is the original degree and ``t`` the increment.
+
+    Args:
+        degree (int): Original polynomial degree (``p >= 0``).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, rank)``.
+        degree_increment (int): Number of degrees to add (``t >= 1``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Elevated control points of shape
+        ``(p+t+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_degree._degree_elevate_bezier` instead.
+    """
+    p = degree
+    t = degree_increment
+    ph = p + t
+    rank = ctrl.shape[1]
+    ph2 = ph // 2
+
+    # Compute bezalfs coefficients
+    bezalfs = np.zeros((p + 1, ph + 1), dtype=np.float64)
+    bezalfs[0, 0] = 1.0
+    bezalfs[p, ph] = 1.0
+
+    for i in range(1, ph2 + 1):
+        inv = 1.0 / _bincoeff(ph, i)
+        mpi = min(p, i)
+        for j in range(max(0, i - t), mpi + 1):
+            bezalfs[j, i] = inv * _bincoeff(p, j) * _bincoeff(t, i - j)
+
+    # Symmetry
+    for i in range(ph2 + 1, ph):
+        mpi = min(p, i)
+        for j in range(max(0, i - t), mpi + 1):
+            bezalfs[j, i] = bezalfs[p - j, ph - i]
+
+    # Apply elevation: new_ctrl[i] = sum_j bezalfs[j, i] * ctrl[j]
+    new_ctrl = np.zeros((ph + 1, rank), dtype=ctrl.dtype)
+    for i in range(ph + 1):
+        mpi = min(p, i)
+        for j in range(max(0, i - t), mpi + 1):
+            coeff = bezalfs[j, i]
+            for r in range(rank):
+                new_ctrl[i, r] += coeff * ctrl[j, r]
+
+    return new_ctrl

--- a/src/pantr/_bezier_degree.py
+++ b/src/pantr/_bezier_degree.py
@@ -1,0 +1,72 @@
+"""Bézier degree elevation.
+
+This module provides :func:`_degree_elevate_bezier`, which raises the polynomial
+degree of a Bézier in one or more parametric directions while preserving the
+same geometric mapping.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bezier_core import _degree_elevate_bezier_1d_core
+
+if TYPE_CHECKING:
+    from .bezier import Bezier
+
+
+def _degree_elevate_bezier(
+    bezier: Bezier,
+    increments: tuple[int, ...],
+) -> Bezier:
+    """Degree-elevate a Bézier in one or more parametric directions.
+
+    For each direction with a positive increment, applies the Bézier degree
+    elevation kernel using the moveaxis/reshape pattern.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to elevate.
+        increments (tuple[int, ...]): Degree increment per direction. All
+            values must be non-negative; at least one must be positive.
+
+    Returns:
+        ~pantr.bezier.Bezier: New Bézier with elevated degrees and updated
+        control points.
+
+    Note:
+        Inputs are assumed to be validated by the caller (Layer 1).
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
+    degrees = bezier.degree
+
+    for d in range(bezier.dim):
+        inc = increments[d]
+        if inc == 0:
+            continue
+
+        p = degrees[d]
+
+        # Move target direction to axis 0, flatten the rest.
+        moved = np.moveaxis(ctrl, d, 0)
+        orig_shape = moved.shape
+        pts_2d = moved.reshape(orig_shape[0], -1)
+
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        new_pts_2d = _degree_elevate_bezier_1d_core(p, pts_2d, inc)
+
+        # Restore shape and move axis back.
+        new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+        new_moved = new_pts_2d.reshape(new_shape)
+        ctrl = np.moveaxis(new_moved, 0, d)
+
+        # Update degrees for subsequent iterations.
+        degrees = (*degrees[:d], p + inc, *degrees[d + 1 :])
+
+    return BezierCls(ctrl, is_rational=bezier.is_rational)

--- a/src/pantr/_bezier_derivative.py
+++ b/src/pantr/_bezier_derivative.py
@@ -41,7 +41,7 @@ def _derivative_ctrl_1d(
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_derivative_bezier` instead.
     """
-    return degree * (ctrl[1:] - ctrl[:-1])
+    return np.asarray(degree * (ctrl[1:] - ctrl[:-1]), dtype=ctrl.dtype)
 
 
 def _derivative_nonrational_1d(bezier: Bezier) -> Bezier:

--- a/src/pantr/_bezier_derivative.py
+++ b/src/pantr/_bezier_derivative.py
@@ -1,0 +1,233 @@
+"""Bézier derivative (hodograph) computation.
+
+This module provides :func:`_derivative_bezier`, which computes the exact
+first derivative of a Bézier in a given parametric direction, returning a
+new :class:`~pantr.bezier.Bezier` whose value at every point equals the
+derivative of the original.
+
+Works for non-rational and rational Bézier of any parametric dimension.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from .bezier import Bezier
+
+
+def _derivative_ctrl_1d(
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute derivative control points for a 1D non-rational Bézier.
+
+    Applies the standard Bézier derivative formula:
+    ``Q[i] = p * (P[i+1] - P[i])``
+
+    Args:
+        degree (int): Polynomial degree of the original Bézier (``p >= 1``).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, ...)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative control points of
+        shape ``(p, ...)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    return degree * (ctrl[1:] - ctrl[:-1])
+
+
+def _derivative_nonrational_1d(bezier: Bezier) -> Bezier:
+    """Compute the derivative of a non-rational 1D Bézier.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A 1D non-rational Bézier with degree >= 1.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier of degree ``p - 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    p = bezier.degree[0]
+    ctrl = bezier.control_points
+    new_ctrl = _derivative_ctrl_1d(p, ctrl)
+    return BezierCls(new_ctrl, is_rational=False)
+
+
+def _derivative_nonrational_nd(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational nD Bézier.
+
+    Applies the 1D derivative formula along the given parametric direction
+    using the moveaxis/reshape/restore pattern.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational nD Bézier.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier with degree ``p_d - 1`` in
+        direction ``d`` and unchanged degrees in other directions.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    p = bezier.degree[direction]
+    ctrl = bezier.control_points
+
+    # Move target direction to axis 0, flatten the rest.
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    new_pts_2d = _derivative_ctrl_1d(p, pts_2d)
+
+    # Restore shape and move axis back.
+    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+    new_moved = new_pts_2d.reshape(new_shape)
+    new_ctrl = np.moveaxis(new_moved, 0, direction)
+
+    return BezierCls(new_ctrl, is_rational=False)
+
+
+def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational Bézier.
+
+    Dispatches to the 1D or nD implementation.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    if bezier.dim == 1:
+        return _derivative_nonrational_1d(bezier)
+    return _derivative_nonrational_nd(bezier, direction)
+
+
+def _tile_scalar_bezier(w: Bezier, target_rank: int) -> Bezier:
+    """Tile a rank-1 Bézier to match a target rank.
+
+    Repeats the single control point component along the last axis so that
+    the resulting Bézier has ``target_rank`` components, each identical to
+    the original scalar function.
+
+    Args:
+        w (~pantr.bezier.Bezier): A rank-1 (scalar) non-rational Bézier.
+        target_rank (int): Desired number of output components.
+
+    Returns:
+        ~pantr.bezier.Bezier: Bézier with ``target_rank`` identical components.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl = np.repeat(w.control_points, target_rank, axis=-1)
+    return BezierCls(ctrl, is_rational=False)
+
+
+def _derivative_rational(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a rational Bézier.
+
+    Applies the quotient rule: for ``f = A/w``,
+    ``f' = (A'w - Aw') / w^2``.
+
+    The numerator and denominator are computed via Bézier products and
+    combined into a rational Bézier of degree ``2p`` in the given direction.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A rational Bézier.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bezier.Bezier: Rational derivative Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    from ._bezier_degree import _degree_elevate_bezier  # noqa: PLC0415
+    from ._bezier_product import _multiply_bezier  # noqa: PLC0415
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl = bezier.control_points
+    vec_rank = ctrl.shape[-1] - 1  # number of non-weight components
+
+    # Decompose into numerator A (weighted coords) and denominator w (weights).
+    a_bezier = BezierCls(ctrl[..., :-1], is_rational=False)
+    w_bezier = BezierCls(ctrl[..., -1:], is_rational=False)
+
+    # Compute non-rational derivatives.
+    a_prime = _derivative_nonrational(a_bezier, direction)
+    w_prime = _derivative_nonrational(w_bezier, direction)
+
+    # Tile scalar Béziers to match vector rank for multiply().
+    w_tiled = _tile_scalar_bezier(w_bezier, vec_rank)
+    w_prime_tiled = _tile_scalar_bezier(w_prime, vec_rank)
+
+    # Compute products: A'*w and A*w' (degree 2p-1 each).
+    num1 = _multiply_bezier(a_prime, w_tiled)
+    num2 = _multiply_bezier(a_bezier, w_prime_tiled)
+
+    # Subtract CPs (same degree guaranteed).
+    numerator_ctrl = num1.control_points - num2.control_points
+    numerator = BezierCls(numerator_ctrl, is_rational=False)
+
+    # Compute denominator: w^2 (degree 2p).
+    denom = _multiply_bezier(w_bezier, w_bezier)
+
+    # Elevate numerator degree by 1 in the target direction.
+    increments = [0] * bezier.dim
+    increments[direction] = 1
+    numerator = _degree_elevate_bezier(numerator, tuple(increments))
+
+    # Assemble rational Bézier.
+    result_ctrl = np.concatenate([numerator.control_points, denom.control_points], axis=-1)
+    return BezierCls(result_ctrl, is_rational=True)
+
+
+def _derivative_bezier(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the first partial derivative of a Bézier.
+
+    This is the main entry point for derivative computation. Dispatches
+    to the appropriate implementation based on the Bézier's properties.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to differentiate.
+        direction (int): Parametric direction for differentiation. Must be
+            in ``[0, dim)``.
+
+    Returns:
+        ~pantr.bezier.Bezier: A new Bézier representing the derivative.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bezier.Bezier.derivative` instead.
+    """
+    if bezier.is_rational:
+        return _derivative_rational(bezier, direction)
+    return _derivative_nonrational(bezier, direction)

--- a/src/pantr/_bezier_eval.py
+++ b/src/pantr/_bezier_eval.py
@@ -1,0 +1,731 @@
+"""Bézier evaluation helpers.
+
+This module provides Layer 2 evaluation functions for :class:`~pantr.bezier.Bezier`
+objects. It validates inputs, allocates output arrays, and dispatches to Layer 3
+Numba kernels in :mod:`_bezier_core` (for 1D) or performs sequential contraction
+via NumPy (for nD).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._basis_core import _tabulate_Bernstein_basis_1D_core
+from ._basis_utils import _validate_out_array_1D
+from ._bezier_core import _evaluate_bezier_1d_core, _evaluate_bezier_deriv_1d_core
+
+if TYPE_CHECKING:
+    from .bezier import Bezier
+    from .quad import PointsLattice
+
+
+# ---------------------------------------------------------------------------
+# evaluate
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_bezier(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate a Bézier at the given parametric points.
+
+    Dispatches to the 1D fused kernel or the nD contraction path depending on
+    ``bezier.dim``.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to evaluate.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Parametric
+            evaluation points.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
+            output array. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Values at the given points.
+
+    Raises:
+        ValueError: If the points dtype or shape does not match the Bézier.
+    """
+    if bezier.dim == 1:
+        return _evaluate_bezier_1d(bezier, pts, out)
+    return _evaluate_bezier_nd(bezier, pts, out)
+
+
+def _evaluate_bezier_1d(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate a 1D Bézier at the given points.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A 1D Bézier.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): 1D
+            evaluation points.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Values of shape ``(n_pts,)``
+        for scalar or ``(n_pts, rank)`` for vector output.
+
+    Raises:
+        ValueError: If the points dtype does not match the Bézier dtype.
+    """
+    from .quad import PointsLattice as PL  # noqa: PLC0415
+
+    dtype = bezier.dtype
+    ctrl = bezier.control_points
+
+    if isinstance(pts, PL):
+        if pts.dim != 1:
+            raise ValueError("PointsLattice must be 1D for a 1D Bézier.")
+        pts_array = pts.points_1D[0]
+    else:
+        pts_array = np.asarray(pts)
+    if pts_array.ndim != 1:
+        raise ValueError("Points must be a 1D array for a 1D Bézier.")
+    if pts_array.dtype != dtype:
+        raise ValueError(f"Points dtype ({pts_array.dtype}) must match Bézier dtype ({dtype}).")
+
+    n_pts = pts_array.shape[0]
+    cp_size = ctrl.shape[-1]
+
+    # Allocate raw output (includes weight column for rational)
+    out_raw = np.empty((n_pts, cp_size), dtype=dtype)
+    _evaluate_bezier_1d_core(ctrl, pts_array, out_raw)
+
+    if bezier.is_rational:
+        out_raw[:, :-1] = out_raw[:, :-1] / out_raw[:, -1:]
+        result = out_raw[:, :-1]
+    else:
+        result = out_raw
+
+    # Squeeze scalar output
+    if result.shape[-1] == 1:
+        result = result[:, 0]
+
+    if out is not None:
+        _validate_out_array_1D(out, result.shape, dtype)
+        out[:] = result
+        return out
+    return result
+
+
+def _evaluate_bezier_nd(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate an nD Bézier at the given points.
+
+    Uses sequential contraction: evaluates Bernstein basis in each parametric
+    direction and contracts with control points via ``np.einsum`` (arbitrary
+    points) or ``np.tensordot`` (lattice).
+
+    Args:
+        bezier (~pantr.bezier.Bezier): An nD Bézier (``dim >= 2``).
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+            points — either a 2D array of shape ``(n_pts, dim)`` or a
+            :class:`~pantr.quad.PointsLattice`.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Values at the given points.
+
+    Raises:
+        ValueError: If the points shape or dtype does not match the Bézier.
+    """
+    from .quad import PointsLattice as PL  # noqa: PLC0415
+
+    dim = bezier.dim
+    dtype = bezier.dtype
+    ctrl = bezier.control_points
+    degrees = bezier.degree
+
+    if isinstance(pts, PL):
+        return _evaluate_bezier_nd_lattice(bezier, ctrl, pts, degrees, dtype, dim, out)
+    return _evaluate_bezier_nd_pts_array(bezier, ctrl, pts, degrees, dtype, dim, out)
+
+
+def _evaluate_bezier_nd_pts_array(  # noqa: PLR0913
+    bezier: Bezier,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts: npt.NDArray[np.float32 | np.float64],
+    degrees: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    dim: int,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate nD Bézier at arbitrary points using sequential einsum contraction.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points.
+        pts (npt.NDArray[np.float32 | np.float64]): Points of shape
+            ``(n_pts, dim)``.
+        degrees (tuple[int, ...]): Polynomial degrees per direction.
+        dtype (npt.DTypeLike): Floating-point dtype.
+        dim (int): Parametric dimension.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Values of shape ``(n_pts,)`` or
+        ``(n_pts, rank)``.
+
+    Note:
+        Inputs are assumed to be partially validated by the caller.
+    """
+    pts = np.asarray(pts)
+    if pts.ndim != 2 or pts.shape[1] != dim:  # noqa: PLR2004
+        raise ValueError(f"pts must be a 2D array with {dim} columns.")
+    if pts.dtype != dtype:
+        raise ValueError(f"Points dtype ({pts.dtype}) must match Bézier dtype ({dtype}).")
+
+    n_pts = pts.shape[0]
+
+    # Evaluate Bernstein basis per direction
+    bases: list[npt.NDArray[np.float32 | np.float64]] = []
+    for d in range(dim):
+        basis_d = np.empty((n_pts, degrees[d] + 1), dtype=dtype)
+        _tabulate_Bernstein_basis_1D_core(np.int32(degrees[d]), pts[:, d], basis_d)
+        bases.append(basis_d)
+
+    # Sequential contraction
+    # After contracting direction 0: result has shape (n_pts, n_1, ..., n_{d-1}, rank)
+    # After contracting direction 1: result has shape (n_pts, n_2, ..., n_{d-1}, rank)
+    # etc.
+    result: npt.NDArray[np.float32 | np.float64] = np.einsum("pi,i...->p...", bases[0], ctrl)
+    for d in range(1, dim):
+        result = np.einsum("pj,pj...->p...", bases[d], result)
+
+    result = _project_rational(bezier, result)
+
+    if out is not None:
+        _validate_out_array_1D(out, result.shape, dtype)
+        out[:] = result
+        return out
+    return result
+
+
+def _evaluate_bezier_nd_lattice(  # noqa: PLR0913
+    bezier: Bezier,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts: PointsLattice,
+    degrees: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    dim: int,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate nD Bézier on a lattice using sequential tensordot contraction.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points.
+        pts (~pantr.quad.PointsLattice): Lattice of evaluation points.
+        degrees (tuple[int, ...]): Polynomial degrees per direction.
+        dtype (npt.DTypeLike): Floating-point dtype.
+        dim (int): Parametric dimension.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Values with shape
+        ``(*grid_shape,)`` or ``(*grid_shape, rank)``.
+
+    Note:
+        Inputs are assumed to be partially validated by the caller.
+    """
+    if pts.dim != dim:
+        raise ValueError(f"PointsLattice dim ({pts.dim}) must match Bézier dim ({dim}).")
+
+    # Evaluate Bernstein basis per direction on lattice points
+    bases: list[npt.NDArray[np.float32 | np.float64]] = []
+    for d in range(dim):
+        pts_d = pts.points_1D[d]
+        if pts_d.dtype != dtype:
+            raise ValueError(
+                f"PointsLattice dtype ({pts_d.dtype}) must match Bézier dtype ({dtype})."
+            )
+        basis_d = np.empty((pts_d.shape[0], degrees[d] + 1), dtype=dtype)
+        _tabulate_Bernstein_basis_1D_core(np.int32(degrees[d]), pts_d, basis_d)
+        bases.append(basis_d)
+
+    # Sequential tensordot contraction
+    # ctrl has shape (n_0, n_1, ..., n_{d-1}, rank)
+    # basis_d has shape (m_d, n_d)
+    # Contract axis d of result with axis 1 of basis_d
+    result: npt.NDArray[np.float32 | np.float64] = ctrl
+    for d in range(dim):
+        # Contract axis d with basis_d: (m_d, n_d) @ axis d of result
+        result = np.tensordot(bases[d], result, axes=([1], [d]))
+        # tensordot puts the m_d axis first; move it to position d
+        result = np.moveaxis(result, 0, d)
+
+    result = _project_rational(bezier, result)
+
+    if out is not None:
+        _validate_out_array_1D(out, result.shape, dtype)
+        out[:] = result
+        return out
+    return result
+
+
+def _project_rational(
+    bezier: Bezier,
+    raw: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Project rational output by dividing by weights and squeezing scalars.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier (used for ``is_rational`` and
+            ``rank`` checks).
+        raw (npt.NDArray[np.float32 | np.float64]): Raw evaluation output with
+            shape ``(..., cp_size)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Projected result with shape
+        ``(...)`` for scalar or ``(..., rank)`` for vector output.
+    """
+    if bezier.is_rational:
+        raw[..., :-1] = raw[..., :-1] / raw[..., -1:]
+        result = raw[..., :-1]
+    else:
+        result = raw
+
+    if result.shape[-1] == 1:
+        return result[..., 0]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# evaluate_derivatives
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_bezier_deriv(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    orders: Sequence[int],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate partial derivatives of a Bézier.
+
+    Dispatches to the 1D fused kernel or the nD contraction path.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to differentiate.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Parametric
+            evaluation points.
+        orders (Sequence[int]): Derivative order per parametric direction.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values at the given
+        points.
+
+    Raises:
+        ValueError: If ``len(orders) != bezier.dim`` or any order is negative.
+    """
+    orders_tuple = tuple(orders)
+    if len(orders_tuple) != bezier.dim:
+        raise ValueError(f"len(orders) ({len(orders_tuple)}) must match dim ({bezier.dim}).")
+    if any(o < 0 for o in orders_tuple):
+        raise ValueError("All derivative orders must be non-negative.")
+
+    if bezier.dim == 1:
+        return _evaluate_bezier_deriv_1d(bezier, pts, orders_tuple[0], out)
+    return _evaluate_bezier_deriv_nd(bezier, pts, orders_tuple, out)
+
+
+def _evaluate_bezier_deriv_1d(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    n_deriv: int,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate a specific derivative of a 1D Bézier.
+
+    For non-rational Bézier: uses the fused derivative kernel directly.
+    For rational Bézier: computes all homogeneous derivatives 0..n_deriv, then
+    applies Algorithm A4.2 (quotient rule) from Piegl & Tiller.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A 1D Bézier.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+            points.
+        n_deriv (int): Derivative order (>= 0).
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values of shape
+        ``(n_pts,)`` or ``(n_pts, rank)``.
+    """
+    from .quad import PointsLattice as PL  # noqa: PLC0415
+
+    dtype = bezier.dtype
+    ctrl = bezier.control_points
+
+    if isinstance(pts, PL):
+        if pts.dim != 1:
+            raise ValueError("PointsLattice must be 1D for a 1D Bézier.")
+        pts_array = pts.points_1D[0]
+    else:
+        pts_array = np.asarray(pts)
+    if pts_array.ndim != 1:
+        raise ValueError("Points must be a 1D array for a 1D Bézier.")
+    if pts_array.dtype != dtype:
+        raise ValueError(f"Points dtype ({pts_array.dtype}) must match Bézier dtype ({dtype}).")
+
+    n_pts = pts_array.shape[0]
+    cp_size = ctrl.shape[-1]
+
+    if bezier.is_rational:
+        return _evaluate_bezier_deriv_1d_rational(
+            ctrl, pts_array, n_deriv, n_pts, cp_size, dtype, out
+        )
+    return _evaluate_bezier_deriv_1d_non_rational(
+        ctrl, pts_array, n_deriv, n_pts, cp_size, dtype, out
+    )
+
+
+def _evaluate_bezier_deriv_1d_non_rational(  # noqa: PLR0913
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts_array: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    n_pts: int,
+    cp_size: int,
+    dtype: npt.DTypeLike,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate the n_deriv-th derivative of a non-rational 1D Bézier.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points ``(p+1, rank)``.
+        pts_array (npt.NDArray[np.float32 | np.float64]): Evaluation points.
+        n_deriv (int): Derivative order.
+        n_pts (int): Number of points.
+        cp_size (int): Number of control point components.
+        dtype (npt.DTypeLike): Floating-point dtype.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values.
+    """
+    deriv_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
+    _evaluate_bezier_deriv_1d_core(ctrl, pts_array, n_deriv, deriv_all)
+    result = deriv_all[:, n_deriv, :]
+
+    if cp_size == 1:
+        result = result[:, 0]
+
+    if out is not None:
+        _validate_out_array_1D(out, result.shape, dtype)
+        out[:] = result
+        return out
+    return result
+
+
+def _evaluate_bezier_deriv_1d_rational(  # noqa: PLR0913
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts_array: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    n_pts: int,
+    cp_size: int,
+    dtype: npt.DTypeLike,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Apply the quotient rule for the n_deriv-th derivative of a rational 1D Bézier.
+
+    Uses Algorithm A4.2 from Piegl & Tiller.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points ``(p+1, rank+1)``.
+        pts_array (npt.NDArray[np.float32 | np.float64]): Evaluation points.
+        n_deriv (int): Derivative order.
+        n_pts (int): Number of points.
+        cp_size (int): Number of control point components (rank + 1).
+        dtype (npt.DTypeLike): Floating-point dtype.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative values of the
+        projected (physical) mapping.
+    """
+    rank = cp_size - 1
+
+    # Compute all homogeneous derivatives 0..n_deriv
+    hom_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
+    _evaluate_bezier_deriv_1d_core(ctrl, pts_array, n_deriv, hom_all)
+
+    # Algorithm A4.2 quotient rule
+    W = hom_all[:, 0, -1:]  # (n_pts, 1)
+    results: list[npt.NDArray[np.float32 | np.float64]] = []
+    for k in range(n_deriv + 1):
+        v: npt.NDArray[np.float32 | np.float64] = hom_all[:, k, :-1].copy()
+        for i in range(1, k + 1):
+            v = v - math.comb(k, i) * hom_all[:, i, -1:] * results[k - i]
+        results.append(v / W)
+
+    final = results[n_deriv]
+    if rank == 1:
+        final = final[:, 0]
+
+    if out is not None:
+        _validate_out_array_1D(out, final.shape, dtype)
+        out[:] = final
+        return out
+    return final
+
+
+# ---------------------------------------------------------------------------
+# nD derivative evaluation
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_bezier_deriv_nd(
+    bezier: Bezier,
+    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    orders: tuple[int, ...],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate partial derivatives of an nD Bézier.
+
+    For non-rational: evaluates the derivative basis in each direction and
+    contracts with control points.
+    For rational: computes all homogeneous partial derivatives up to the
+    requested order, then applies the generalised quotient rule.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): An nD Bézier.
+        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+            points.
+        orders (tuple[int, ...]): Derivative order per direction.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Partial derivative values.
+    """
+    from .quad import PointsLattice as PL  # noqa: PLC0415
+
+    dim = bezier.dim
+    dtype = bezier.dtype
+    ctrl = bezier.control_points
+    degrees = bezier.degree
+
+    # --- Resolve points ---
+    is_lattice = isinstance(pts, PL)
+    if is_lattice:
+        if pts.dim != dim:
+            raise ValueError(f"PointsLattice dim ({pts.dim}) must match Bézier dim ({dim}).")
+        pts_per_dir: list[npt.NDArray[np.float32 | np.float64]] = list(pts.points_1D)
+        for d in range(dim):
+            if pts_per_dir[d].dtype != dtype:
+                raise ValueError(
+                    f"PointsLattice dtype ({pts_per_dir[d].dtype}) must match "
+                    f"Bézier dtype ({dtype})."
+                )
+    else:
+        pts_arr = np.asarray(pts)
+        if pts_arr.ndim != 2 or pts_arr.shape[1] != dim:  # noqa: PLR2004
+            raise ValueError(f"pts must be a 2D array with {dim} columns.")
+        if pts_arr.dtype != dtype:
+            raise ValueError(f"Points dtype ({pts_arr.dtype}) must match Bézier dtype ({dtype}).")
+        pts_per_dir = [pts_arr[:, d] for d in range(dim)]
+
+    if bezier.is_rational:
+        return _evaluate_bezier_deriv_nd_rational(
+            bezier, ctrl, pts_per_dir, orders, degrees, dtype, dim, is_lattice, out
+        )
+    return _evaluate_bezier_deriv_nd_non_rational(
+        bezier, ctrl, pts_per_dir, orders, degrees, dtype, dim, is_lattice, out
+    )
+
+
+def _evaluate_bezier_deriv_nd_non_rational(  # noqa: PLR0913
+    bezier: Bezier,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    orders: tuple[int, ...],
+    degrees: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    dim: int,
+    is_lattice: bool,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate partial derivatives of a non-rational nD Bézier.
+
+    For each parametric direction ``d``, evaluates the ``orders[d]``-th
+    derivative of the Bernstein basis and contracts with the control points
+    via sequential contraction.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points.
+        pts_per_dir (list[npt.NDArray[np.float32 | np.float64]]): Points arrays
+            per direction.
+        orders (tuple[int, ...]): Derivative order per direction.
+        degrees (tuple[int, ...]): Polynomial degrees per direction.
+        dtype (npt.DTypeLike): Floating-point dtype.
+        dim (int): Parametric dimension.
+        is_lattice (bool): Whether the points come from a lattice.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Partial derivative values.
+    """
+    from ._basis_core import (  # noqa: PLC0415
+        _tabulate_Bernstein_basis_deriv_1D_core,
+    )
+
+    # Evaluate derivative bases per direction
+    bases: list[npt.NDArray[np.float32 | np.float64]] = []
+    for d in range(dim):
+        pts_d = pts_per_dir[d]
+        n_pts_d = pts_d.shape[0]
+        order_d = orders[d]
+        p_d = degrees[d]
+
+        if order_d == 0:
+            # Regular basis
+            basis_d = np.empty((n_pts_d, p_d + 1), dtype=dtype)
+            _tabulate_Bernstein_basis_1D_core(np.int32(p_d), pts_d, basis_d)
+        else:
+            # Derivative basis
+            deriv_all_d = np.empty((n_pts_d, order_d + 1, p_d + 1), dtype=dtype)
+            _tabulate_Bernstein_basis_deriv_1D_core(np.int32(p_d), pts_d, order_d, deriv_all_d)
+            basis_d = deriv_all_d[:, order_d, :]
+        bases.append(basis_d)
+
+    # Sequential contraction
+    if is_lattice:
+        result: npt.NDArray[np.float32 | np.float64] = ctrl
+        for d in range(dim):
+            result = np.tensordot(bases[d], result, axes=([1], [d]))
+            result = np.moveaxis(result, 0, d)
+    else:
+        result = np.einsum("pi,i...->p...", bases[0], ctrl)
+        for d in range(1, dim):
+            result = np.einsum("pj,pj...->p...", bases[d], result)
+
+    # Squeeze scalar
+    if result.shape[-1] == 1:
+        result = result[..., 0]
+
+    if out is not None:
+        _validate_out_array_1D(out, result.shape, dtype)
+        out[:] = result
+        return out
+    return result
+
+
+def _evaluate_bezier_deriv_nd_rational(  # noqa: PLR0913, PLR0912
+    bezier: Bezier,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    pts_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    orders: tuple[int, ...],
+    degrees: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    dim: int,
+    is_lattice: bool,
+    out: npt.NDArray[np.float32 | np.float64] | None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Evaluate partial derivatives of a rational nD Bézier.
+
+    Computes all homogeneous partial derivatives up to the requested order in
+    each direction, then applies the generalised quotient rule (Algorithm A4.2
+    extended to nD).
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier (rational).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points.
+        pts_per_dir (list[npt.NDArray[np.float32 | np.float64]]): Points per dir.
+        orders (tuple[int, ...]): Derivative order per direction.
+        degrees (tuple[int, ...]): Polynomial degrees per direction.
+        dtype (npt.DTypeLike): Floating-point dtype.
+        dim (int): Parametric dimension.
+        is_lattice (bool): Whether the points come from a lattice.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Partial derivative values of the
+        projected mapping.
+    """
+    import itertools  # noqa: PLC0415
+
+    from ._basis_core import (  # noqa: PLC0415
+        _tabulate_Bernstein_basis_deriv_1D_core,
+    )
+
+    cp_size = ctrl.shape[-1]
+    rank = cp_size - 1
+
+    # Evaluate all derivative bases per direction up to orders[d]
+    all_bases: list[list[npt.NDArray[np.float32 | np.float64]]] = []
+    for d in range(dim):
+        pts_d = pts_per_dir[d]
+        n_pts_d = pts_d.shape[0]
+        p_d = degrees[d]
+        max_order_d = orders[d]
+
+        if max_order_d == 0:
+            basis_d = np.empty((n_pts_d, p_d + 1), dtype=dtype)
+            _tabulate_Bernstein_basis_1D_core(np.int32(p_d), pts_d, basis_d)
+            all_bases.append([basis_d])
+        else:
+            deriv_all_d = np.empty((n_pts_d, max_order_d + 1, p_d + 1), dtype=dtype)
+            _tabulate_Bernstein_basis_deriv_1D_core(np.int32(p_d), pts_d, max_order_d, deriv_all_d)
+            all_bases.append([deriv_all_d[:, k, :] for k in range(max_order_d + 1)])
+
+    # Compute all homogeneous partial derivatives
+    hom_all: dict[tuple[int, ...], npt.NDArray[np.float32 | np.float64]] = {}
+    for k_idx in itertools.product(*(range(o + 1) for o in orders)):
+        # Select bases for this multi-index
+        bases_k = [all_bases[d][k_idx[d]] for d in range(dim)]
+
+        # Contract with ctrl
+        if is_lattice:
+            result_k: npt.NDArray[np.float32 | np.float64] = ctrl
+            for d in range(dim):
+                result_k = np.tensordot(bases_k[d], result_k, axes=([1], [d]))
+                result_k = np.moveaxis(result_k, 0, d)
+        else:
+            result_k = np.einsum("pi,i...->p...", bases_k[0], ctrl)
+            for d in range(1, dim):
+                result_k = np.einsum("pj,pj...->p...", bases_k[d], result_k)
+
+        hom_all[k_idx] = result_k
+
+    # Apply generalised quotient rule (A4.2 extended to nD)
+    W = hom_all[tuple(0 for _ in range(dim))][..., -1:]
+    results: dict[tuple[int, ...], npt.NDArray[np.float32 | np.float64]] = {}
+
+    # Iterate all multi-indices in ascending total order
+    for k_idx in itertools.product(*(range(o + 1) for o in orders)):
+        v: npt.NDArray[np.float32 | np.float64] = hom_all[k_idx][..., :-1].copy()
+        for j_idx in itertools.product(*(range(k + 1) for k in k_idx)):
+            if j_idx == tuple(0 for _ in range(dim)):
+                continue
+            # Check j_idx <= k_idx component-wise
+            if any(j > k for j, k in zip(j_idx, k_idx, strict=True)):
+                continue
+            binom_prod = 1
+            for d in range(dim):
+                binom_prod *= math.comb(k_idx[d], j_idx[d])
+            diff_idx = tuple(k - j for k, j in zip(k_idx, j_idx, strict=True))
+            v = v - binom_prod * hom_all[j_idx][..., -1:] * results[diff_idx]
+        results[k_idx] = v / W
+
+    final = results[orders]
+    if rank == 1:
+        final = final[..., 0]
+
+    if out is not None:
+        _validate_out_array_1D(out, final.shape, dtype)
+        out[:] = final
+        return out
+    return final

--- a/src/pantr/_bezier_eval.py
+++ b/src/pantr/_bezier_eval.py
@@ -85,7 +85,7 @@ def _evaluate_bezier_1d(
     if isinstance(pts, PL):
         if pts.dim != 1:
             raise ValueError("PointsLattice must be 1D for a 1D Bézier.")
-        pts_array = pts.points_1D[0]
+        pts_array = pts.pts_per_dir[0]
     else:
         pts_array = np.asarray(pts)
     if pts_array.ndim != 1:
@@ -246,7 +246,7 @@ def _evaluate_bezier_nd_lattice(  # noqa: PLR0913
     # Evaluate Bernstein basis per direction on lattice points
     bases: list[npt.NDArray[np.float32 | np.float64]] = []
     for d in range(dim):
-        pts_d = pts.points_1D[d]
+        pts_d = pts.pts_per_dir[d]
         if pts_d.dtype != dtype:
             raise ValueError(
                 f"PointsLattice dtype ({pts_d.dtype}) must match Bézier dtype ({dtype})."
@@ -373,7 +373,7 @@ def _evaluate_bezier_deriv_1d(
     if isinstance(pts, PL):
         if pts.dim != 1:
             raise ValueError("PointsLattice must be 1D for a 1D Bézier.")
-        pts_array = pts.points_1D[0]
+        pts_array = pts.pts_per_dir[0]
     else:
         pts_array = np.asarray(pts)
     if pts_array.ndim != 1:
@@ -520,9 +520,10 @@ def _evaluate_bezier_deriv_nd(
     # --- Resolve points ---
     is_lattice = isinstance(pts, PL)
     if is_lattice:
+        assert isinstance(pts, PL)
         if pts.dim != dim:
             raise ValueError(f"PointsLattice dim ({pts.dim}) must match Bézier dim ({dim}).")
-        pts_per_dir: list[npt.NDArray[np.float32 | np.float64]] = list(pts.points_1D)
+        pts_per_dir: list[npt.NDArray[np.float32 | np.float64]] = list(pts.pts_per_dir)
         for d in range(dim):
             if pts_per_dir[d].dtype != dtype:
                 raise ValueError(

--- a/src/pantr/_bezier_product.py
+++ b/src/pantr/_bezier_product.py
@@ -1,0 +1,264 @@
+"""Bézier pointwise product.
+
+This module provides :func:`_multiply_bezier`, which computes the exact
+pointwise product of two Bézier objects via the Bernstein product formula.
+The result is a Bézier of degree ``p_d + q_d`` per direction.
+
+The core Bernstein product formulas (:func:`_bernstein_product_coefficients`
+and :func:`_bernstein_product_coefficients_nd`) are also used by the B-spline
+product modules.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from .bezier import Bezier
+
+
+def _bernstein_product_coefficients(
+    b_f: npt.NDArray[np.float32 | np.float64],
+    b_g: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Compute Bézier control points of the product of two Bézier segments.
+
+    Applies the Bernstein product formula element-wise over the rank axis:
+
+    .. math::
+
+        d_k = \frac{1}{\binom{p+q}{k}} \sum_{i=\max(0,k-q)}^{\min(p,k)}
+              \binom{p}{i} \binom{q}{k-i}\, b_f[i] \cdot b_g[k-i]
+
+    Args:
+        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            Bézier segment, shape ``(p+1, rank)``.
+        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            Bézier segment, shape ``(q+1, rank)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product Bézier control points of
+        shape ``(p+q+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    p, q = b_f.shape[0] - 1, b_g.shape[0] - 1
+    r = p + q
+    dtype = b_f.dtype
+
+    cp = np.array([math.comb(p, i) for i in range(p + 1)], dtype=dtype)
+    cq = np.array([math.comb(q, j) for j in range(q + 1)], dtype=dtype)
+    inv_cr = np.array([1.0 / math.comb(r, k) for k in range(r + 1)], dtype=dtype)
+
+    i_idx = np.arange(p + 1)
+    j_idx = np.arange(q + 1)
+    k_mat = i_idx[:, None] + j_idx[None, :]  # (p+1, q+1)
+    coeff = cp[:, None] * cq[None, :] * inv_cr[k_mat]  # (p+1, q+1)
+
+    products = coeff[:, :, None] * b_f[:, None, :] * b_g[None, :, :]
+
+    d = np.zeros((r + 1, b_f.shape[1]), dtype=dtype)
+    np.add.at(d, k_mat.ravel(), products.reshape(-1, b_f.shape[1]))
+    return d
+
+
+def _bernstein_product_coefficients_nd(
+    b_f: npt.NDArray[np.float32 | np.float64],
+    b_g: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Compute nD Bézier control points of the product of two Bézier patches.
+
+    Applies the tensor-product Bernstein product formula element-wise over the
+    rank axis.  For each multi-index :math:`\gamma`:
+
+    .. math::
+
+        h_\gamma = \frac{1}{\prod_d \binom{r_d}{\gamma_d}}
+                   \sum_{\alpha} \prod_d \binom{p_d}{\alpha_d}
+                   \binom{q_d}{\gamma_d - \alpha_d}\,
+                   b_f[\alpha]\, b_g[\gamma - \alpha]
+
+    where :math:`r_d = p_d + q_d`.
+
+    The nD convolution is computed via the accumulation strategy: for each
+    multi-index :math:`\alpha` of ``b_f``, the weighted product is accumulated
+    into the output at the offset :math:`[\alpha : \alpha + q + 1]`.
+
+    Args:
+        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            Bézier patch, shape ``(p_0+1, ..., p_{D-1}+1, rank)``.
+        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            Bézier patch, shape ``(q_0+1, ..., q_{D-1}+1, rank)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product Bézier control points
+        of shape ``(p_0+q_0+1, ..., p_{D-1}+q_{D-1}+1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    ndim = b_f.ndim - 1
+    p = tuple(s - 1 for s in b_f.shape[:ndim])
+    q = tuple(s - 1 for s in b_g.shape[:ndim])
+    r = tuple(pi + qi for pi, qi in zip(p, q, strict=True))
+    dtype = b_f.dtype
+    rank = b_f.shape[-1]
+
+    # Precompute per-direction binomial coefficients.
+    binom_p = [
+        np.array([math.comb(p[d], i) for i in range(p[d] + 1)], dtype=dtype) for d in range(ndim)
+    ]
+    binom_q = [
+        np.array([math.comb(q[d], j) for j in range(q[d] + 1)], dtype=dtype) for d in range(ndim)
+    ]
+    inv_binom_r = [
+        np.array([1.0 / math.comb(r[d], k) for k in range(r[d] + 1)], dtype=dtype)
+        for d in range(ndim)
+    ]
+
+    # Build weight arrays via outer product of per-direction binomial vectors.
+    w_f = binom_p[0]
+    for d in range(1, ndim):
+        w_f = np.multiply.outer(w_f, binom_p[d])
+    w_g = binom_q[0]
+    for d in range(1, ndim):
+        w_g = np.multiply.outer(w_g, binom_q[d])
+    inv_w_r = inv_binom_r[0]
+    for d in range(1, ndim):
+        inv_w_r = np.multiply.outer(inv_w_r, inv_binom_r[d])
+
+    # Weight the control points.
+    weighted_f = w_f[..., np.newaxis] * b_f
+    weighted_g = w_g[..., np.newaxis] * b_g
+
+    # nD convolution via accumulation.
+    result_shape = (*tuple(ri + 1 for ri in r), rank)
+    h_conv = np.zeros(result_shape, dtype=dtype)
+
+    for alpha in itertools.product(*(range(pi + 1) for pi in p)):
+        slices = tuple(slice(a, a + qi + 1) for a, qi in zip(alpha, q, strict=True))
+        h_conv[slices] = h_conv[slices] + weighted_f[alpha] * weighted_g
+
+    # Normalize by inverse product binomial coefficients.
+    return inv_w_r[..., np.newaxis] * h_conv
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def _multiply_bezier(a: Bezier, b: Bezier) -> Bezier:
+    """Compute the exact pointwise product of two Bézier objects.
+
+    Validates that both operands have matching dimension, dtype, and rank,
+    then dispatches to the non-rational or rational implementation.
+
+    Args:
+        a (~pantr.bezier.Bezier): First operand.
+        b (~pantr.bezier.Bezier): Second operand.
+
+    Returns:
+        ~pantr.bezier.Bezier: Product Bézier of degree ``p_d + q_d`` per
+        direction.
+
+    Raises:
+        ValueError: If the operands have different dimensions, dtypes, or ranks.
+    """
+    if a.dim != b.dim:
+        raise ValueError(f"Operands must have the same dimension. Got {a.dim} and {b.dim}.")
+    if a.dtype != b.dtype:
+        raise ValueError(f"Operands must have the same dtype. Got {a.dtype} and {b.dtype}.")
+    if a.rank != b.rank:
+        raise ValueError(f"Operands must have the same rank. Got {a.rank} and {b.rank}.")
+
+    if a.is_rational or b.is_rational:
+        return _multiply_rational(a, b)
+    return _multiply_nonrational(a, b)
+
+
+def _multiply_nonrational(a: Bezier, b: Bezier) -> Bezier:
+    """Compute the product of two non-rational Bézier objects.
+
+    Args:
+        a (~pantr.bezier.Bezier): First operand (non-rational).
+        b (~pantr.bezier.Bezier): Second operand (non-rational).
+
+    Returns:
+        ~pantr.bezier.Bezier: Non-rational product Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    if a.dim == 1:
+        new_ctrl = _bernstein_product_coefficients(a.control_points, b.control_points)
+    else:
+        new_ctrl = _bernstein_product_coefficients_nd(a.control_points, b.control_points)
+    return BezierCls(new_ctrl, is_rational=False)
+
+
+def _multiply_rational(a: Bezier, b: Bezier) -> Bezier:
+    """Compute the product of two Bézier objects where at least one is rational.
+
+    Promotes non-rational operands to rational (unit weights) and multiplies
+    numerators and denominators independently.
+
+    Args:
+        a (~pantr.bezier.Bezier): First operand.
+        b (~pantr.bezier.Bezier): Second operand.
+
+    Returns:
+        ~pantr.bezier.Bezier: Rational product Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    from .bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    # Promote non-rational to rational with unit weights.
+    a_ctrl = _ensure_rational_ctrl(a)
+    b_ctrl = _ensure_rational_ctrl(b)
+
+    # Decompose: numerator (weighted coords) and denominator (weights).
+    a_num = a_ctrl[..., :-1]
+    a_den = a_ctrl[..., -1:]
+    b_num = b_ctrl[..., :-1]
+    b_den = b_ctrl[..., -1:]
+
+    # Multiply numerators and denominators.
+    if a.dim == 1:
+        h_num = _bernstein_product_coefficients(a_num, b_num)
+        h_den = _bernstein_product_coefficients(a_den, b_den)
+    else:
+        h_num = _bernstein_product_coefficients_nd(a_num, b_num)
+        h_den = _bernstein_product_coefficients_nd(a_den, b_den)
+
+    result_ctrl = np.concatenate([h_num, h_den], axis=-1)
+    return BezierCls(result_ctrl, is_rational=True)
+
+
+def _ensure_rational_ctrl(
+    bezier: Bezier,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return control points in homogeneous form, adding unit weights if needed.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier (rational or non-rational).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Control points with shape
+        ``(..., rank+1)`` where the last column is the weight.
+    """
+    ctrl = bezier.control_points
+    if bezier.is_rational:
+        return ctrl
+    weights = np.ones((*ctrl.shape[:-1], 1), dtype=ctrl.dtype)
+    return np.concatenate([ctrl, weights], axis=-1)

--- a/src/pantr/_bspline_product.py
+++ b/src/pantr/_bspline_product.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from ._bezier_product import _bernstein_product_coefficients
 from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
@@ -201,52 +202,6 @@ def _knots_for_full_bezier(
     if len(knots_to_insert) == 0:
         return np.empty(0, dtype=dtype)
     return np.array(knots_to_insert, dtype=dtype)
-
-
-def _bernstein_product_coefficients(
-    b_f: npt.NDArray[np.float32 | np.float64],
-    b_g: npt.NDArray[np.float32 | np.float64],
-) -> npt.NDArray[np.float32 | np.float64]:
-    r"""Compute Bézier control points of the product of two Bézier segments.
-
-    Applies the Bernstein product formula element-wise over the rank axis:
-
-    .. math::
-
-        d_k = \frac{1}{\binom{p+q}{k}} \sum_{i=\max(0,k-q)}^{\min(p,k)}
-              \binom{p}{i} \binom{q}{k-i}\, b_f[i] \cdot b_g[k-i]
-
-    Args:
-        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
-            Bézier segment, shape ``(p+1, rank)``.
-        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
-            Bézier segment, shape ``(q+1, rank)``.
-
-    Returns:
-        npt.NDArray[np.float32 | np.float64]: Product Bézier control points of
-        shape ``(p+q+1, rank)``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-    """
-    p, q = b_f.shape[0] - 1, b_g.shape[0] - 1
-    r = p + q
-    dtype = b_f.dtype
-
-    cp = np.array([math.comb(p, i) for i in range(p + 1)], dtype=dtype)
-    cq = np.array([math.comb(q, j) for j in range(q + 1)], dtype=dtype)
-    inv_cr = np.array([1.0 / math.comb(r, k) for k in range(r + 1)], dtype=dtype)
-
-    i_idx = np.arange(p + 1)
-    j_idx = np.arange(q + 1)
-    k_mat = i_idx[:, None] + j_idx[None, :]  # (p+1, q+1)
-    coeff = cp[:, None] * cq[None, :] * inv_cr[k_mat]  # (p+1, q+1)
-
-    products = coeff[:, :, None] * b_f[:, None, :] * b_g[None, :, :]
-
-    d = np.zeros((r + 1, b_f.shape[1]), dtype=dtype)
-    np.add.at(d, k_mat.ravel(), products.reshape(-1, b_f.shape[1]))
-    return d
 
 
 def _build_product_knot_vector(

--- a/src/pantr/_bspline_product_nd.py
+++ b/src/pantr/_bspline_product_nd.py
@@ -14,12 +14,12 @@ dimension, and correctly preserves per-direction boundary structure
 from __future__ import annotations
 
 import itertools
-import math
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+from ._bezier_product import _bernstein_product_coefficients_nd
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl, _get_unique_knots_and_multiplicity_impl
 from ._bspline_product import (
     _build_product_knot_vector,
@@ -34,89 +34,6 @@ from .bspline_space_nd import BsplineSpace
 
 if TYPE_CHECKING:
     from .bspline import Bspline
-
-
-def _bernstein_product_coefficients_nd(
-    b_f: npt.NDArray[np.float32 | np.float64],
-    b_g: npt.NDArray[np.float32 | np.float64],
-) -> npt.NDArray[np.float32 | np.float64]:
-    r"""Compute nD Bézier control points of the product of two Bézier patches.
-
-    Applies the tensor-product Bernstein product formula element-wise over the
-    rank axis.  For each multi-index :math:`\gamma`:
-
-    .. math::
-
-        h_\gamma = \frac{1}{\prod_d \binom{r_d}{\gamma_d}}
-                   \sum_{\alpha} \prod_d \binom{p_d}{\alpha_d}
-                   \binom{q_d}{\gamma_d - \alpha_d}\,
-                   b_f[\alpha]\, b_g[\gamma - \alpha]
-
-    where :math:`r_d = p_d + q_d`.
-
-    The nD convolution is computed via the accumulation strategy: for each
-    multi-index :math:`\alpha` of ``b_f``, the weighted product is accumulated
-    into the output at the offset :math:`[\alpha : \alpha + q + 1]`.
-
-    Args:
-        b_f (npt.NDArray[np.float32 | np.float64]): Control points of the first
-            Bézier patch, shape ``(p_0+1, ..., p_{D-1}+1, rank)``.
-        b_g (npt.NDArray[np.float32 | np.float64]): Control points of the second
-            Bézier patch, shape ``(q_0+1, ..., q_{D-1}+1, rank)``.
-
-    Returns:
-        npt.NDArray[np.float32 | np.float64]: Product Bézier control points
-        of shape ``(p_0+q_0+1, ..., p_{D-1}+q_{D-1}+1, rank)``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_multiply_bspline_nd` instead.
-    """
-    ndim = b_f.ndim - 1
-    p = tuple(s - 1 for s in b_f.shape[:ndim])
-    q = tuple(s - 1 for s in b_g.shape[:ndim])
-    r = tuple(pi + qi for pi, qi in zip(p, q, strict=True))
-    dtype = b_f.dtype
-    rank = b_f.shape[-1]
-
-    # Precompute per-direction binomial coefficients.
-    binom_p = [
-        np.array([math.comb(p[d], i) for i in range(p[d] + 1)], dtype=dtype) for d in range(ndim)
-    ]
-    binom_q = [
-        np.array([math.comb(q[d], j) for j in range(q[d] + 1)], dtype=dtype) for d in range(ndim)
-    ]
-    inv_binom_r = [
-        np.array([1.0 / math.comb(r[d], k) for k in range(r[d] + 1)], dtype=dtype)
-        for d in range(ndim)
-    ]
-
-    # Build weight arrays: W_f[alpha] = prod_d C(p_d, alpha_d).
-    # Construct via outer product of per-direction binomial vectors.
-    w_f = binom_p[0]
-    for d in range(1, ndim):
-        w_f = np.multiply.outer(w_f, binom_p[d])
-    w_g = binom_q[0]
-    for d in range(1, ndim):
-        w_g = np.multiply.outer(w_g, binom_q[d])
-    inv_w_r = inv_binom_r[0]
-    for d in range(1, ndim):
-        inv_w_r = np.multiply.outer(inv_w_r, inv_binom_r[d])
-
-    # Weight the control points.
-    weighted_f = w_f[..., np.newaxis] * b_f
-    weighted_g = w_g[..., np.newaxis] * b_g
-
-    # nD convolution via accumulation.
-    result_shape = (*tuple(ri + 1 for ri in r), rank)
-    h_conv = np.zeros(result_shape, dtype=dtype)
-
-    for alpha in itertools.product(*(range(pi + 1) for pi in p)):
-        slices = tuple(slice(a, a + qi + 1) for a, qi in zip(alpha, q, strict=True))
-        h_conv[slices] = h_conv[slices] + weighted_f[alpha] * weighted_g
-
-    # Normalize by inverse product binomial coefficients.
-    return inv_w_r[..., np.newaxis] * h_conv
 
 
 def _extract_bezier_patch(

--- a/src/pantr/bezier.py
+++ b/src/pantr/bezier.py
@@ -1,0 +1,373 @@
+"""Bézier geometric objects: the Bezier class.
+
+This module provides :class:`Bezier`, which stores control points to represent
+a parametric Bézier curve, surface, or volume. Degree is derived from the
+control point array shape. Evaluation and manipulation methods use direct
+Bernstein algorithms implemented in ``_bezier_core``, ``_bezier_eval``,
+``_bezier_derivative``, ``_bezier_degree``, and ``_bezier_product``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy import typing as npt
+
+from ._bezier_degree import _degree_elevate_bezier
+from ._bezier_derivative import _derivative_bezier
+from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
+from ._bezier_product import _multiply_bezier
+
+if TYPE_CHECKING:
+    from .bspline import Bspline
+    from .quad import PointsLattice
+
+
+class Bezier:
+    """A parametric Bézier curve, surface, or volume defined by control points.
+
+    Stores only control points and an ``is_rational`` flag. The polynomial
+    degree in each parametric direction is inferred from the control point
+    array shape: ``degree[d] = control_points.shape[d] - 1``.
+
+    Attributes:
+        _control_points (npt.NDArray[np.float32 | np.float64]): Control point
+            array with shape ``(*degrees_plus_1, rank)``, where the last axis
+            is the output rank (including the homogeneous weight for rational).
+        _is_rational (bool): Whether the Bézier is rational (last control
+            point coordinate is a homogeneous weight).
+    """
+
+    def __init__(
+        self,
+        control_points: npt.ArrayLike,
+        is_rational: bool = False,
+    ) -> None:
+        """Initialize a Bézier from control points.
+
+        Args:
+            control_points (npt.ArrayLike): Control points. Shape must be at
+                least 2D: ``(*degrees_plus_1, rank)``. A 1D input of shape
+                ``(n,)`` is reshaped to ``(n, 1)`` (scalar field). Integer
+                arrays are cast to ``float64``.
+            is_rational (bool): Whether the Bézier is rational. Defaults to
+                False.
+
+        Raises:
+            ValueError: If the control points have fewer than 1 entry in any
+                parametric direction.
+            ValueError: If the Bézier has rank smaller than 1.
+        """
+        cp = np.asarray(control_points)
+        if np.issubdtype(cp.dtype, np.integer):
+            cp = cp.astype(np.float64)
+        if cp.ndim < 1:
+            raise ValueError("Control points must be at least 1D.")
+        if cp.ndim == 1:
+            cp = cp[:, np.newaxis]
+
+        if cp.ndim < 2:  # pragma: no cover - guarded by the reshape above  # noqa: PLR2004
+            raise ValueError("Control points must be at least 2D after reshape.")
+
+        for d in range(cp.ndim - 1):
+            if cp.shape[d] < 1:
+                raise ValueError(
+                    f"Control points must have at least 1 entry in parametric "
+                    f"direction {d}, got {cp.shape[d]}."
+                )
+
+        self._control_points: npt.NDArray[np.float32 | np.float64] = cp
+        self._is_rational = is_rational
+
+        if self.rank <= 0:
+            raise ValueError(f"The Bézier must have at least rank one. Got rank {self.rank}.")
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension of the Bézier.
+
+        Returns:
+            int: Number of parametric dimensions.
+        """
+        return self._control_points.ndim - 1
+
+    @property
+    def degree(self) -> tuple[int, ...]:
+        """Get the polynomial degrees per parametric direction.
+
+        Returns:
+            tuple[int, ...]: Polynomial degree for each parametric dimension,
+            computed as ``shape[d] - 1``.
+        """
+        return tuple(s - 1 for s in self._control_points.shape[:-1])
+
+    @property
+    def control_points(self) -> npt.NDArray[np.float32 | np.float64]:
+        """Get the control points of the Bézier.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Control point array with
+            shape ``(*degrees_plus_1, rank)``.
+        """
+        return self._control_points
+
+    @property
+    def is_rational(self) -> bool:
+        """Check whether the Bézier is rational.
+
+        Returns:
+            bool: True if the Bézier is rational (i.e., the last control point
+            coordinate is a homogeneous weight), False otherwise.
+        """
+        return self._is_rational
+
+    @property
+    def rank(self) -> int:
+        """Get the output rank of the Bézier.
+
+        The rank is the number of value dimensions produced by the mapping.
+        For a scalar field it is 1; for a 3D curve it is 3. For rational
+        Béziers the weight coordinate is excluded.
+
+        Returns:
+            int: Output rank of the Bézier.
+        """
+        rk = int(self._control_points.shape[-1])
+        return rk - 1 if self.is_rational else rk
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the floating-point dtype of the Bézier.
+
+        Returns:
+            npt.DTypeLike: The numpy dtype (float32 or float64) of the control
+            point array.
+        """
+        return self._control_points.dtype
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Evaluate the Bézier at the given parametric points.
+
+        Args:
+            pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
+                parametric points at which to evaluate. For 1D Bézier, must be
+                a 1D array of shape ``(n_pts,)``. For multi-dimensional Bézier,
+                must be a 2D array of shape ``(n_pts, dim)`` or a
+                :class:`~pantr.quad.PointsLattice`.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array. Defaults to None.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Bézier values at the given
+            points.
+
+        Raises:
+            ValueError: If the points dtype does not match the Bézier dtype,
+                or if ``out`` has incorrect shape or dtype.
+        """
+        return _evaluate_bezier(self, pts, out)
+
+    def evaluate_derivatives(
+        self,
+        pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+        orders: int | Sequence[int],
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Evaluate a specific partial derivative of the Bézier.
+
+        Computes the single partial derivative specified by ``orders``,
+        where ``orders[d]`` is the derivative order in parametric direction
+        ``d``. For rational Bézier the generalised quotient rule is applied.
+
+        Args:
+            pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
+                parametric points at which to evaluate.
+            orders (int | Sequence[int]): Derivative order(s). A single
+                ``int`` is broadcast to all ``self.dim`` directions. A sequence
+                must contain one non-negative integer per parametric direction.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional
+                pre-allocated output array. Defaults to None.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Mixed partial derivative
+            values.
+
+        Raises:
+            ValueError: If ``len(orders) != self.dim``, if any order is
+                negative, or if the points dtype does not match the Bézier dtype.
+
+        Example:
+            >>> result = bezier.evaluate_derivatives(pts, 2)
+            >>> result = bezier.evaluate_derivatives(pts, [1, 2])
+        """
+        orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
+        return _evaluate_bezier_deriv(self, pts, orders_seq, out)
+
+    # ------------------------------------------------------------------
+    # Derivative (returns new Bezier)
+    # ------------------------------------------------------------------
+
+    def derivative(self, direction: int = 0) -> Bezier:
+        """Return a Bézier representing the first derivative in the given direction.
+
+        Computes the hodograph: a new Bézier whose value at every parametric
+        point equals the partial derivative of this Bézier with respect to
+        parametric direction ``direction``.
+
+        For non-rational Bézier of degree ``p`` in direction ``d``, the
+        result has degree ``p - 1``.
+
+        For rational Bézier, the quotient rule is applied, producing a
+        rational Bézier of degree ``2p`` in direction ``d``.
+
+        Args:
+            direction (int): Parametric direction for differentiation.
+                Must be in ``[0, dim)``. Defaults to 0.
+
+        Returns:
+            Bezier: A new Bézier representing the derivative.
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+            ValueError: If the degree in the given direction is 0.
+
+        Example:
+            >>> f_prime = f.derivative()
+            >>> df_dv = surface.derivative(direction=1)
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+        if self.degree[direction] < 1:
+            raise ValueError("Derivative of a degree-0 Bézier is not defined.")
+        return _derivative_bezier(self, direction)
+
+    # ------------------------------------------------------------------
+    # Degree elevation
+    # ------------------------------------------------------------------
+
+    def elevate_degree(self, degree_increments: int | Sequence[int]) -> Bezier:
+        """Elevate the polynomial degree of the Bézier.
+
+        Creates a new Bézier that represents the same mapping as the original
+        but with higher polynomial degree.
+
+        Args:
+            degree_increments (int | Sequence[int]): Number of degrees to
+                increase. If an integer, the same increment is applied to all
+                parametric directions. If a sequence, must have length equal
+                to ``self.dim``.
+
+        Returns:
+            Bezier: A new Bézier with elevated degrees.
+
+        Raises:
+            ValueError: If any degree increment is negative.
+            ValueError: If the number of increments does not match the dimension.
+        """
+        if isinstance(degree_increments, int):
+            increments = (degree_increments,) * self.dim
+        else:
+            increments = tuple(degree_increments)
+
+        if len(increments) != self.dim:
+            raise ValueError(
+                f"Number of degree increments ({len(increments)}) "
+                f"must match dimension ({self.dim})."
+            )
+
+        if any(inc < 0 for inc in increments):
+            raise ValueError("Degree increments must be non-negative.")
+
+        if all(inc == 0 for inc in increments):
+            return self
+
+        return _degree_elevate_bezier(self, increments)
+
+    # ------------------------------------------------------------------
+    # Multiply
+    # ------------------------------------------------------------------
+
+    def multiply(self, other: Bezier) -> Bezier:
+        """Return the exact pointwise product of this Bézier and another.
+
+        Given Bézier ``self`` and ``other`` over the same parametric domain
+        ``[0, 1]^dim``, returns a new Bézier ``h`` such that
+        ``h(t) = self(t) * other(t)``. The result has degree ``p_d + q_d``
+        per direction.
+
+        Args:
+            other (Bezier): The second Bézier operand. Must have the same
+                dimension, dtype, and rank as ``self``.
+
+        Returns:
+            Bezier: A new Bézier representing ``self * other``.
+
+        Raises:
+            ValueError: If the operands have different dimensions, dtypes,
+                or ranks.
+
+        Example:
+            >>> h = f.multiply(g)
+            >>> h2 = f * g
+        """
+        return _multiply_bezier(self, other)
+
+    __mul__ = multiply
+
+    # ------------------------------------------------------------------
+    # Conversion
+    # ------------------------------------------------------------------
+
+    def to_bspline(self) -> Bspline:
+        """Convert to an equivalent B-spline with Bézier knot vectors.
+
+        Creates a :class:`~pantr.bspline.Bspline` with open knot vectors
+        ``[0]*(p+1) + [1]*(p+1)`` in each parametric direction.
+
+        Returns:
+            ~pantr.bspline.Bspline: Equivalent B-spline representation.
+        """
+        from .bspline import Bspline as BsplineCls  # noqa: PLC0415
+        from .bspline_space_1D import BsplineSpace1D  # noqa: PLC0415
+        from .bspline_space_nd import BsplineSpace  # noqa: PLC0415
+
+        dtype = self.dtype
+        spaces: list[BsplineSpace1D] = []
+        for p in self.degree:
+            knots = np.zeros(2 * (p + 1), dtype=dtype)
+            knots[p + 1 :] = 1.0
+            spaces.append(BsplineSpace1D(knots, p))
+
+        return BsplineCls(BsplineSpace(spaces), self._control_points, self._is_rational)
+
+    @classmethod
+    def from_bspline(cls, bspline: Bspline) -> Bezier:
+        """Create a Bézier from a B-spline with Bézier-like knot vectors.
+
+        Validates that the B-spline has Bézier-like knots (open knots with
+        ``num_basis == degree + 1`` in each direction) and extracts the
+        control points.
+
+        Args:
+            bspline (~pantr.bspline.Bspline): A B-spline with Bézier-like
+                knot structure.
+
+        Returns:
+            Bezier: The equivalent Bézier.
+
+        Raises:
+            ValueError: If the B-spline does not have Bézier-like knots.
+        """
+        if not bspline.space.has_Bezier_like_knots():
+            raise ValueError("B-spline does not have Bézier-like knots. Cannot convert to Bézier.")
+        return cls(bspline.control_points, is_rational=bspline.is_rational)

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -1,0 +1,544 @@
+"""Tests for the Bezier class."""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+from pantr.bspline import Bspline
+from pantr.bspline_space_1D import BsplineSpace1D
+from pantr.bspline_space_nd import BsplineSpace
+from pantr.quad import PointsLattice
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bezier_1d(
+    ctrl: list[float] | list[list[float]],
+    is_rational: bool = False,
+    dtype: type = np.float64,
+) -> Bezier:
+    """Create a 1D Bezier from control points."""
+    cp: npt.NDArray[np.float32 | np.float64] = np.array(ctrl, dtype=dtype)
+    return Bezier(cp, is_rational=is_rational)
+
+
+# ---------------------------------------------------------------------------
+# Init + properties
+# ---------------------------------------------------------------------------
+
+
+class TestBezierInit:
+    """Test Bezier initialization."""
+
+    def test_valid_initialization_1d_scalar(self) -> None:
+        """Test 1D scalar Bezier."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        assert b.dim == 1
+        assert b.degree == (2,)
+        assert b.rank == 1
+        assert b.is_rational is False
+        assert b.control_points.shape == (3, 1)
+        assert b.dtype == np.float64
+
+    def test_valid_initialization_1d_vector(self) -> None:
+        """Test 1D vector Bezier."""
+        b = _make_bezier_1d([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        assert b.dim == 1
+        assert b.degree == (2,)
+        assert b.rank == 2  # noqa: PLR2004
+        assert b.control_points.shape == (3, 2)
+
+    def test_valid_initialization_2d_scalar(self) -> None:
+        """Test 2D scalar Bezier."""
+        ctrl = np.array([[[1.0], [2.0]], [[3.0], [4.0]], [[5.0], [6.0]]])
+        b = Bezier(ctrl)
+        assert b.dim == 2  # noqa: PLR2004
+        assert b.degree == (2, 1)
+        assert b.rank == 1
+        assert b.control_points.shape == (3, 2, 1)
+
+    def test_valid_initialization_2d_vector(self) -> None:
+        """Test 2D vector Bezier."""
+        ctrl = np.arange(36, dtype=np.float64).reshape(3, 2, 6)
+        b = Bezier(ctrl)
+        assert b.dim == 2  # noqa: PLR2004
+        assert b.degree == (2, 1)
+        assert b.rank == 6  # noqa: PLR2004
+
+    def test_valid_initialization_3d(self) -> None:
+        """Test 3D Bezier."""
+        ctrl = np.ones((3, 2, 4, 1), dtype=np.float64)
+        b = Bezier(ctrl)
+        assert b.dim == 3  # noqa: PLR2004
+        assert b.degree == (2, 1, 3)
+
+    def test_rational(self) -> None:
+        """Test rational Bezier."""
+        ctrl = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        assert b.is_rational is True
+        assert b.rank == 2  # noqa: PLR2004
+        assert b.control_points.shape == (3, 3)
+
+    def test_1d_array_reshaped_to_scalar(self) -> None:
+        """Test that 1D input is reshaped to scalar field."""
+        b = Bezier(np.array([1.0, 2.0, 3.0]))
+        assert b.dim == 1
+        assert b.control_points.shape == (3, 1)
+
+    def test_integer_control_points_cast_to_float64(self) -> None:
+        """Test that integer control points are cast to float64."""
+        b = Bezier(np.array([[1, 2], [3, 4], [5, 6]]))
+        assert b.dtype == np.float64
+
+    def test_invalid_rank_zero(self) -> None:
+        """Test that rational Bezier with rank 0 raises."""
+        ctrl = np.array([[1.0], [2.0], [3.0]])
+        with pytest.raises(ValueError, match="rank"):
+            Bezier(ctrl, is_rational=True)
+
+    def test_float32(self) -> None:
+        """Test float32 Bezier."""
+        b = Bezier(np.array([[1.0, 2.0]], dtype=np.float32))
+        assert b.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+
+class TestBezierConversion:
+    """Test Bezier to/from Bspline conversion."""
+
+    def test_to_bspline_1d(self) -> None:
+        """Test conversion to B-spline preserves Bezier knot structure."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b.to_bspline()
+        assert bs.space.has_Bezier_like_knots()
+        assert bs.degree == (2,)
+        np.testing.assert_array_equal(bs.space.spaces[0].knots, [0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+
+    def test_to_bspline_2d(self) -> None:
+        """Test 2D conversion."""
+        ctrl = np.ones((3, 2, 1), dtype=np.float64)
+        b = Bezier(ctrl)
+        bs = b.to_bspline()
+        assert bs.space.has_Bezier_like_knots()
+        assert bs.degree == (2, 1)
+
+    def test_from_bspline_valid(self) -> None:
+        """Test conversion from Bezier-like B-spline."""
+        b_orig = _make_bezier_1d([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        bs = b_orig.to_bspline()
+        b_back = Bezier.from_bspline(bs)
+        np.testing.assert_array_equal(b_back.control_points, b_orig.control_points)
+
+    def test_from_bspline_invalid(self) -> None:
+        """Test that non-Bezier B-spline raises."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        bs = Bspline(space, cp)
+        with pytest.raises(ValueError, match="Bézier-like"):
+            Bezier.from_bspline(bs)
+
+    def test_roundtrip(self) -> None:
+        """Test to_bspline -> from_bspline roundtrip."""
+        b = _make_bezier_1d([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]], is_rational=True)
+        b2 = Bezier.from_bspline(b.to_bspline())
+        np.testing.assert_array_equal(b2.control_points, b.control_points)
+        assert b2.is_rational == b.is_rational
+
+
+# ---------------------------------------------------------------------------
+# Evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestBezierEvaluate:
+    """Test Bezier evaluate."""
+
+    def test_linear_1d(self) -> None:
+        """Test linear Bezier is exact line."""
+        b = _make_bezier_1d([[0.0, 0.0], [1.0, 2.0]])
+        pts = np.array([0.0, 0.5, 1.0])
+        result = b.evaluate(pts)
+        expected = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 2.0]])
+        np.testing.assert_allclose(result, expected, atol=1e-14)
+
+    def test_quadratic_1d(self) -> None:
+        """Test quadratic Bezier at midpoint."""
+        # Quadratic Bezier: P0=(0,0), P1=(0.5,1), P2=(1,0)
+        # At t=0.5: B(0.5) = 0.25*P0 + 0.5*P1 + 0.25*P2 = (0.5, 0.5)
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        pts = np.array([0.5])
+        result = b.evaluate(pts)
+        np.testing.assert_allclose(result, [[0.5, 0.5]], atol=1e-14)
+
+    def test_scalar_1d(self) -> None:
+        """Test scalar Bezier returns 1D array."""
+        b = _make_bezier_1d([1.0, 3.0])
+        pts = np.array([0.0, 0.5, 1.0])
+        result = b.evaluate(pts)
+        assert result.ndim == 1
+        np.testing.assert_allclose(result, [1.0, 2.0, 3.0], atol=1e-14)
+
+    def test_2d_surface(self) -> None:
+        """Test 2D Bezier surface evaluation."""
+        # Bilinear: ctrl[i, j] = (i, j)
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0]],
+                [[1.0, 0.0], [1.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        result = b.evaluate(pts)
+        np.testing.assert_allclose(result, [[0.5, 0.5]], atol=1e-14)
+
+    def test_rational_quarter_circle(self) -> None:
+        """Test rational quadratic Bezier for quarter circle."""
+        w = 1.0 / np.sqrt(2.0)
+        ctrl = np.array(
+            [
+                [1.0, 0.0, 1.0],
+                [w, w, w],
+                [0.0, 1.0, 1.0],
+            ]
+        )
+        b = Bezier(ctrl, is_rational=True)
+        pts = np.linspace(0.0, 1.0, 50, dtype=np.float64)
+        result = b.evaluate(pts)
+        # Points should lie on unit circle
+        radii = np.sqrt(result[:, 0] ** 2 + result[:, 1] ** 2)
+        np.testing.assert_allclose(radii, 1.0, atol=1e-12)
+
+    def test_evaluate_with_out(self) -> None:
+        """Test evaluate with pre-allocated output."""
+        b = _make_bezier_1d([1.0, 3.0])
+        pts = np.array([0.0, 0.5, 1.0])
+        out = np.empty(3, dtype=np.float64)
+        result = b.evaluate(pts, out=out)
+        assert result is out
+        np.testing.assert_allclose(out, [1.0, 2.0, 3.0], atol=1e-14)
+
+    def test_matches_bspline_evaluate(self) -> None:
+        """Test that Bezier evaluate matches Bspline evaluate."""
+        ctrl = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]], dtype=np.float64)
+        b = Bezier(ctrl)
+        bs = b.to_bspline()
+        pts = np.linspace(0.0, 1.0, 20, dtype=np.float64)
+        np.testing.assert_allclose(b.evaluate(pts), bs.evaluate(pts), atol=1e-14)
+
+    def test_2d_lattice(self) -> None:
+        """Test 2D Bezier evaluation on a lattice."""
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0]],
+                [[1.0, 0.0], [1.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        pts_u = np.array([0.0, 0.5, 1.0], dtype=np.float64)
+        pts_v = np.array([0.0, 1.0], dtype=np.float64)
+        lattice = PointsLattice([pts_u, pts_v])
+        result = b.evaluate(lattice)
+        assert result.shape == (3, 2, 2)
+        np.testing.assert_allclose(result[1, 1], [0.5, 1.0], atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Evaluate derivatives
+# ---------------------------------------------------------------------------
+
+
+class TestBezierEvaluateDerivatives:
+    """Test Bezier evaluate_derivatives."""
+
+    def test_first_derivative_1d(self) -> None:
+        """Test first derivative against finite differences."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        pts = np.array([0.25, 0.5, 0.75])
+        h = 1e-7
+        deriv = b.evaluate_derivatives(pts, 1)
+
+        # Finite differences
+        pts_p = np.clip(pts + h, 0, 1)
+        pts_m = np.clip(pts - h, 0, 1)
+        fd = (b.evaluate(pts_p) - b.evaluate(pts_m)) / (pts_p - pts_m)[:, None]
+        np.testing.assert_allclose(deriv, fd, atol=1e-5)
+
+    def test_second_derivative_1d(self) -> None:
+        """Test second derivative of quadratic is constant."""
+        # Quadratic Bezier has constant second derivative
+        b = _make_bezier_1d([[0.0], [0.5], [1.0]])
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        deriv2 = b.evaluate_derivatives(pts, 2)
+        # Second derivative of B(t) = (1-t)^2*0 + 2t(1-t)*0.5 + t^2*1 = t
+        # B'(t) = 1, B''(t) = 0
+        np.testing.assert_allclose(deriv2, 0.0, atol=1e-12)
+
+    def test_derivative_matches_bspline(self) -> None:
+        """Test derivative evaluation matches B-spline."""
+        ctrl = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]], dtype=np.float64)
+        b = Bezier(ctrl)
+        bs = b.to_bspline()
+        pts = np.linspace(0.0, 1.0, 15, dtype=np.float64)
+        np.testing.assert_allclose(
+            b.evaluate_derivatives(pts, 1), bs.evaluate_derivatives(pts, 1), atol=1e-12
+        )
+
+    def test_2d_partial_derivatives(self) -> None:
+        """Test 2D partial derivatives."""
+        # Bilinear surface: f(u, v) = (u, v)
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0]],
+                [[1.0, 0.0], [1.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        # df/du = (1, 0), df/dv = (0, 1)
+        du = b.evaluate_derivatives(pts, [1, 0])
+        dv = b.evaluate_derivatives(pts, [0, 1])
+        np.testing.assert_allclose(du, [[1.0, 0.0]], atol=1e-14)
+        np.testing.assert_allclose(dv, [[0.0, 1.0]], atol=1e-14)
+
+    def test_rational_derivative(self) -> None:
+        """Test rational Bezier derivative against finite differences."""
+        w = 1.0 / np.sqrt(2.0)
+        ctrl = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        pts = np.array([0.25, 0.5, 0.75])
+        h = 1e-7
+        deriv = b.evaluate_derivatives(pts, 1)
+        pts_p = np.clip(pts + h, 0, 1)
+        pts_m = np.clip(pts - h, 0, 1)
+        fd = (b.evaluate(pts_p) - b.evaluate(pts_m)) / (pts_p - pts_m)[:, None]
+        np.testing.assert_allclose(deriv, fd, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Derivative (returns new Bezier)
+# ---------------------------------------------------------------------------
+
+
+class TestBezierDerivative:
+    """Test Bezier derivative method."""
+
+    def test_linear_to_constant(self) -> None:
+        """Test derivative of linear Bezier is constant."""
+        b = _make_bezier_1d([[0.0, 0.0], [1.0, 2.0]])
+        d = b.derivative()
+        assert d.degree == (0,)
+        # Derivative: p * (P1 - P0) = 1 * (1, 2) = (1, 2)
+        np.testing.assert_allclose(d.control_points, [[1.0, 2.0]], atol=1e-14)
+
+    def test_quadratic_to_linear(self) -> None:
+        """Test derivative of quadratic Bezier is linear."""
+        b = _make_bezier_1d([[0.0], [1.0], [0.0]])
+        d = b.derivative()
+        assert d.degree == (1,)
+        # Q0 = 2*(1-0) = 2, Q1 = 2*(0-1) = -2
+        np.testing.assert_allclose(d.control_points, [[2.0], [-2.0]], atol=1e-14)
+
+    def test_derivative_matches_evaluate_derivatives(self) -> None:
+        """Test that derivative().evaluate matches evaluate_derivatives."""
+        ctrl = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]], dtype=np.float64)
+        b = Bezier(ctrl)
+        pts = np.linspace(0.0, 1.0, 20, dtype=np.float64)
+        from_deriv = b.derivative().evaluate(pts)
+        from_eval_deriv = b.evaluate_derivatives(pts, 1)
+        np.testing.assert_allclose(from_deriv, from_eval_deriv, atol=1e-12)
+
+    def test_2d_direction0(self) -> None:
+        """Test 2D partial derivative in direction 0."""
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0]],
+                [[1.0, 0.0], [1.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        d = b.derivative(direction=0)
+        assert d.degree == (0, 1)
+
+    def test_2d_direction1(self) -> None:
+        """Test 2D partial derivative in direction 1."""
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [0.0, 1.0]],
+                [[1.0, 0.0], [1.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        d = b.derivative(direction=1)
+        assert d.degree == (1, 0)
+
+    def test_invalid_direction(self) -> None:
+        """Test that invalid direction raises."""
+        b = _make_bezier_1d([1.0, 2.0])
+        with pytest.raises(ValueError, match="direction"):
+            b.derivative(direction=1)
+
+    def test_degree_0_raises(self) -> None:
+        """Test that degree 0 raises."""
+        b = _make_bezier_1d([1.0])
+        with pytest.raises(ValueError, match="degree-0"):
+            b.derivative()
+
+    def test_rational_derivative(self) -> None:
+        """Test rational Bezier derivative matches evaluate_derivatives."""
+        w = 1.0 / np.sqrt(2.0)
+        ctrl = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        d = b.derivative()
+        pts = np.linspace(0.01, 0.99, 20, dtype=np.float64)
+        from_deriv = d.evaluate(pts)
+        from_eval = b.evaluate_derivatives(pts, 1)
+        np.testing.assert_allclose(from_deriv, from_eval, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Degree elevation
+# ---------------------------------------------------------------------------
+
+
+class TestBezierElevateDegree:
+    """Test Bezier degree elevation."""
+
+    def test_elevate_1d(self) -> None:
+        """Test degree elevation preserves curve values."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        b_elev = b.elevate_degree(1)
+        assert b_elev.degree == (3,)
+        pts = np.linspace(0.0, 1.0, 30, dtype=np.float64)
+        np.testing.assert_allclose(b.evaluate(pts), b_elev.evaluate(pts), atol=1e-13)
+
+    def test_elevate_by_2(self) -> None:
+        """Test degree elevation by 2."""
+        b = _make_bezier_1d([1.0, 3.0])
+        b_elev = b.elevate_degree(2)
+        assert b_elev.degree == (3,)
+        pts = np.linspace(0.0, 1.0, 20, dtype=np.float64)
+        np.testing.assert_allclose(b.evaluate(pts), b_elev.evaluate(pts), atol=1e-13)
+
+    def test_elevate_2d_per_direction(self) -> None:
+        """Test 2D degree elevation per direction."""
+        ctrl = np.ones((3, 2, 1), dtype=np.float64)
+        b = Bezier(ctrl)
+        b_elev = b.elevate_degree([1, 2])
+        assert b_elev.degree == (3, 3)
+
+    def test_zero_increment_returns_self(self) -> None:
+        """Test that zero increment returns self."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        assert b.elevate_degree(0) is b
+
+    def test_negative_increment_raises(self) -> None:
+        """Test that negative increment raises."""
+        b = _make_bezier_1d([1.0, 2.0])
+        with pytest.raises(ValueError, match="non-negative"):
+            b.elevate_degree(-1)
+
+    def test_wrong_length_raises(self) -> None:
+        """Test that wrong increment length raises."""
+        b = _make_bezier_1d([1.0, 2.0])
+        with pytest.raises(ValueError, match="must match dimension"):
+            b.elevate_degree([1, 2])
+
+
+# ---------------------------------------------------------------------------
+# Multiply
+# ---------------------------------------------------------------------------
+
+
+class TestBezierMultiply:
+    """Test Bezier multiply."""
+
+    def test_multiply_1d_scalars(self) -> None:
+        """Test product of two scalar Beziers."""
+        # f(t) = t (linear), g(t) = 1-t (linear)
+        # product = t(1-t), quadratic, max at 0.25
+        f = _make_bezier_1d([0.0, 1.0])
+        g = _make_bezier_1d([1.0, 0.0])
+        h = f.multiply(g)
+        assert h.degree == (2,)
+        pts = np.linspace(0.0, 1.0, 30, dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-14)
+
+    def test_multiply_1d_vectors(self) -> None:
+        """Test product of vector Beziers."""
+        f = _make_bezier_1d([[1.0, 2.0], [3.0, 4.0]])
+        g = _make_bezier_1d([[1.0, 1.0], [0.0, 2.0]])
+        h = f.multiply(g)
+        assert h.degree == (2,)
+        pts = np.linspace(0.0, 1.0, 20, dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-13)
+
+    def test_multiply_different_degrees(self) -> None:
+        """Test product with different degrees."""
+        f = _make_bezier_1d([1.0, 2.0])  # degree 1
+        g = _make_bezier_1d([1.0, 0.0, 1.0])  # degree 2
+        h = f.multiply(g)
+        assert h.degree == (3,)
+        pts = np.linspace(0.0, 1.0, 20, dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-13)
+
+    def test_multiply_2d(self) -> None:
+        """Test 2D Bezier product."""
+        ctrl_f = np.ones((2, 2, 1), dtype=np.float64)
+        ctrl_f[1, 1, 0] = 2.0
+        ctrl_g = np.ones((2, 2, 1), dtype=np.float64) * 3.0
+        f = Bezier(ctrl_f)
+        g = Bezier(ctrl_g)
+        h = f.multiply(g)
+        assert h.degree == (2, 2)
+        pts = np.array([[0.5, 0.5]], dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-13)
+
+    def test_dunder_mul(self) -> None:
+        """Test __mul__ operator."""
+        f = _make_bezier_1d([1.0, 2.0])
+        g = _make_bezier_1d([3.0, 4.0])
+        h = f * g
+        pts = np.linspace(0.0, 1.0, 10, dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-14)
+
+    def test_different_dim_raises(self) -> None:
+        """Test that different dimensions raise."""
+        f = _make_bezier_1d([1.0, 2.0])
+        g = Bezier(np.ones((2, 2, 1), dtype=np.float64))
+        with pytest.raises(ValueError, match="dimension"):
+            f.multiply(g)
+
+    def test_different_dtype_raises(self) -> None:
+        """Test that different dtypes raise."""
+        f = Bezier(np.array([[1.0]], dtype=np.float64))
+        g = Bezier(np.array([[1.0]], dtype=np.float32))
+        with pytest.raises(ValueError, match="dtype"):
+            f.multiply(g)
+
+    def test_different_rank_raises(self) -> None:
+        """Test that different ranks raise."""
+        f = _make_bezier_1d([[1.0, 2.0], [3.0, 4.0]])
+        g = _make_bezier_1d([1.0, 2.0])
+        with pytest.raises(ValueError, match="rank"):
+            f.multiply(g)
+
+    def test_rational_product(self) -> None:
+        """Test rational Bezier product."""
+        ctrl_f = np.array([[1.0, 1.0], [2.0, 1.0]], dtype=np.float64)
+        ctrl_g = np.array([[1.0, 1.0], [3.0, 2.0]], dtype=np.float64)
+        f = Bezier(ctrl_f, is_rational=True)
+        g = Bezier(ctrl_g, is_rational=True)
+        h = f.multiply(g)
+        assert h.is_rational
+        pts = np.linspace(0.01, 0.99, 20, dtype=np.float64)
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-12)

--- a/tests/test_bspline_product_nd.py
+++ b/tests/test_bspline_product_nd.py
@@ -6,9 +6,11 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._bezier_product import (
+    _bernstein_product_coefficients,
+    _bernstein_product_coefficients_nd,
+)
 from pantr._bspline_knots import _get_unique_knots_and_multiplicity_impl
-from pantr._bspline_product import _bernstein_product_coefficients
-from pantr._bspline_product_nd import _bernstein_product_coefficients_nd
 from pantr._bspline_space_factory import create_uniform_periodic_knot_vector
 from pantr.bspline import Bspline
 from pantr.bspline_space_1D import BsplineSpace1D

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,6 +19,8 @@ def test_package_all_exports() -> None:
 
     # Expected public API symbols (functions/classes that don't start with _)
     expected_public_api: Final[set[str]] = {
+        # Bezier
+        "Bezier",
         # Basis functions
         "LagrangeVariant",
         "tabulate_Bernstein_basis",


### PR DESCRIPTION
## Summary
- Introduce an n-dimensional `Bezier` class with direct Bernstein algorithms
- **Layer 3 kernels** (`_bezier_core.py`): fused evaluation (`_evaluate_bezier_1d_core`), fused derivative evaluation (`_evaluate_bezier_deriv_1d_core`), and degree elevation (`_degree_elevate_bezier_1d_core`) — all Numba-compiled
- **Layer 2 helpers**: `_bezier_eval.py` (evaluate, evaluate_derivatives with rational quotient rule), `_bezier_derivative.py` (hodograph for non-rational and rational via quotient rule), `_bezier_degree.py` (degree elevation via moveaxis/reshape pattern), `_bezier_product.py` (Bernstein product formula, 1D and nD)
- **Layer 1 API** (`bezier.py`): `Bezier` class with properties (`dim`, `degree`, `control_points`, `is_rational`, `rank`, `dtype`) and methods (`evaluate`, `evaluate_derivatives`, `derivative`, `elevate_degree`, `multiply`, `to_bspline`, `from_bspline`)
- Move `_bernstein_product_coefficients` and `_bernstein_product_coefficients_nd` from B-spline modules to `_bezier_product.py`; B-spline modules import from there
- Export `Bezier` in `pantr.__init__`

## Test plan
- [x] 51 new tests in `test_bezier.py` covering init, properties, conversion, evaluate (1D/2D/lattice/rational), evaluate_derivatives, derivative (non-rational/rational/nD), elevate_degree, multiply (1D/2D/rational/error cases)
- [x] All 1256 tests pass (including existing B-spline product tests with moved imports)
- [x] Pre-PR checks pass (ruff, ruff format, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)