### PR TITLE
feat(bspline,bezier): add keep_degree parameter to derivative

### DIFF
--- a/src/pantr/bezier/__init__.py
+++ b/src/pantr/bezier/__init__.py
@@ -217,7 +217,7 @@ class Bezier:
     # Derivative (returns new Bezier)
     # ------------------------------------------------------------------
 
-    def derivative(self, direction: int = 0) -> Bezier:
+    def derivative(self, direction: int = 0, *, keep_degree: bool = False) -> Bezier:
         """Return a Bézier representing the first derivative in the given direction.
 
         Computes the hodograph: a new Bézier whose value at every parametric
@@ -225,14 +225,20 @@ class Bezier:
         parametric direction ``direction``.
 
         For non-rational Bézier of degree ``p`` in direction ``d``, the
-        result has degree ``p - 1``.
+        result has degree ``p - 1`` (or ``p`` when ``keep_degree=True``).
 
         For rational Bézier, the quotient rule is applied, producing a
-        rational Bézier of degree ``2p`` in direction ``d``.
+        rational Bézier of degree ``2p`` in direction ``d`` (or the original
+        degree when ``keep_degree=True``).
 
         Args:
             direction (int): Parametric direction for differentiation.
                 Must be in ``[0, dim)``. Defaults to 0.
+            keep_degree (bool): If ``True``, the result preserves the same
+                degree as the original Bézier by fusing derivative and degree
+                elevation. This is useful, for instance, when computing
+                derivatives of rational polynomials (in the numerator).
+                Defaults to ``False``.
 
         Returns:
             Bezier: A new Bézier representing the derivative.
@@ -244,12 +250,13 @@ class Bezier:
         Example:
             >>> f_prime = f.derivative()
             >>> df_dv = surface.derivative(direction=1)
+            >>> f_prime_same_deg = f.derivative(keep_degree=True)
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
         if self.degree[direction] < 1:
             raise ValueError("Derivative of a degree-0 Bézier is not defined.")
-        return _derivative_bezier(self, direction)
+        return _derivative_bezier(self, direction, keep_degree=keep_degree)
 
     # ------------------------------------------------------------------
     # Degree elevation

--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -44,6 +44,46 @@ def _derivative_ctrl_1d(
     return np.asarray(degree * (ctrl[1:] - ctrl[:-1]), dtype=ctrl.dtype)
 
 
+def _derivative_keep_degree_ctrl_1d(
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute derivative control points with degree preservation for a 1D non-rational Bézier.
+
+    Fuses the derivative formula ``Q[i] = p * (P[i+1] - P[i])`` with a
+    single degree elevation, so the result has the same degree ``p`` as the
+    input. The combined formula is:
+
+    ``R[j] = (p - j) * (P[j+1] - P[j]) + j * (P[j] - P[j-1])``
+
+    for ``j = 0, ..., p``.
+
+    Args:
+        degree (int): Polynomial degree of the original Bézier (``p >= 1``).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, ...)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative control points of
+        shape ``(p+1, ...)``, representing a degree-``p`` Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    p = degree
+    n = p + 1  # number of output CPs = same as input
+    result = np.empty_like(ctrl[:n])
+    # j = 0: R[0] = p * (P[1] - P[0])
+    result[0] = p * (ctrl[1] - ctrl[0])
+    # j = 1, ..., p-1
+    for j in range(1, p):
+        result[j] = (p - j) * (ctrl[j + 1] - ctrl[j]) + j * (ctrl[j] - ctrl[j - 1])
+    # j = p: R[p] = p * (P[p] - P[p-1])
+    result[p] = p * (ctrl[p] - ctrl[p - 1])
+    return result
+
+
 def _derivative_nonrational_1d(bezier: Bezier) -> Bezier:
     """Compute the derivative of a non-rational 1D Bézier.
 
@@ -125,6 +165,92 @@ def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
     if bezier.dim == 1:
         return _derivative_nonrational_1d(bezier)
     return _derivative_nonrational_nd(bezier, direction)
+
+
+def _derivative_keep_degree_nonrational_1d(bezier: Bezier) -> Bezier:
+    """Compute the derivative of a non-rational 1D Bézier, preserving degree.
+
+    Fuses the derivative and degree elevation into a single operation,
+    avoiding allocation of an intermediate Bézier.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A 1D non-rational Bézier with degree >= 1.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier of degree ``p`` (same as input).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    p = bezier.degree[0]
+    ctrl = bezier.control_points
+    new_ctrl = _derivative_keep_degree_ctrl_1d(p, ctrl)
+    return BezierCls(new_ctrl, is_rational=False)
+
+
+def _derivative_keep_degree_nonrational_nd(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational nD Bézier, preserving degree.
+
+    Fuses the derivative and degree elevation into a single operation along
+    the given direction using the moveaxis/reshape/restore pattern.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational nD Bézier.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier with the same degree as the
+        input in direction ``d`` and unchanged degrees in other directions.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    p = bezier.degree[direction]
+    ctrl = bezier.control_points
+
+    # Move target direction to axis 0, flatten the rest.
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    new_pts_2d = _derivative_keep_degree_ctrl_1d(p, pts_2d)
+
+    # Restore shape and move axis back.
+    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+    new_moved = new_pts_2d.reshape(new_shape)
+    new_ctrl = np.moveaxis(new_moved, 0, direction)
+
+    return BezierCls(new_ctrl, is_rational=False)
+
+
+def _derivative_keep_degree_nonrational(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational Bézier, preserving degree.
+
+    Dispatches to the 1D or nD keep-degree implementation.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bezier.Bezier: Derivative Bézier with same degree as input.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    if bezier.dim == 1:
+        return _derivative_keep_degree_nonrational_1d(bezier)
+    return _derivative_keep_degree_nonrational_nd(bezier, direction)
 
 
 def _tile_scalar_bezier(w: Bezier, target_rank: int) -> Bezier:
@@ -210,7 +336,7 @@ def _derivative_rational(bezier: Bezier, direction: int) -> Bezier:
     return BezierCls(result_ctrl, is_rational=True)
 
 
-def _derivative_bezier(bezier: Bezier, direction: int) -> Bezier:
+def _derivative_bezier(bezier: Bezier, direction: int, *, keep_degree: bool = False) -> Bezier:
     """Compute the first partial derivative of a Bézier.
 
     This is the main entry point for derivative computation. Dispatches
@@ -220,6 +346,9 @@ def _derivative_bezier(bezier: Bezier, direction: int) -> Bezier:
         bezier (~pantr.bezier.Bezier): The Bézier to differentiate.
         direction (int): Parametric direction for differentiation. Must be
             in ``[0, dim)``.
+        keep_degree (bool): If ``True``, the result has the same degree as the
+            input by fusing derivative and degree elevation. Defaults to
+            ``False``.
 
     Returns:
         ~pantr.bezier.Bezier: A new Bézier representing the derivative.
@@ -228,6 +357,23 @@ def _derivative_bezier(bezier: Bezier, direction: int) -> Bezier:
         Inputs are assumed to be correct (no validation performed).
         For general use, call :meth:`~pantr.bezier.Bezier.derivative` instead.
     """
-    if bezier.is_rational:
-        return _derivative_rational(bezier, direction)
-    return _derivative_nonrational(bezier, direction)
+    if not keep_degree:
+        if bezier.is_rational:
+            return _derivative_rational(bezier, direction)
+        return _derivative_nonrational(bezier, direction)
+
+    # keep_degree=True: non-rational uses fused kernel, rational uses fallback.
+    if not bezier.is_rational:
+        return _derivative_keep_degree_nonrational(bezier, direction)
+
+    # Rational fallback: compute derivative, then elevate degree.
+    from ._bezier_degree import _degree_elevate_bezier  # noqa: PLC0415
+
+    deriv = _derivative_rational(bezier, direction)
+    orig_degree = bezier.degree[direction]
+    deriv_degree = deriv.degree[direction]
+    inc = orig_degree - deriv_degree
+    if inc > 0:
+        increments = tuple(0 if d != direction else inc for d in range(bezier.dim))
+        deriv = _degree_elevate_bezier(deriv, increments)
+    return deriv

--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -282,8 +282,9 @@ def _derivative_rational(bezier: Bezier, direction: int) -> Bezier:
     Applies the quotient rule: for ``f = A/w``,
     ``f' = (A'w - Aw') / w^2``.
 
-    The numerator and denominator are computed via Bézier products and
-    combined into a rational Bézier of degree ``2p`` in the given direction.
+    Uses degree-preserving derivatives for ``A'`` and ``w'`` so that the
+    products ``A'w`` and ``Aw'`` are degree ``2p`` (matching ``w^2``),
+    eliminating the need for a separate numerator degree elevation.
 
     Args:
         bezier (~pantr.bezier.Bezier): A rational Bézier.
@@ -297,7 +298,6 @@ def _derivative_rational(bezier: Bezier, direction: int) -> Bezier:
         For general use, call :func:`_derivative_bezier` instead.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
-    from ._bezier_degree import _degree_elevate_bezier  # noqa: PLC0415
     from ._bezier_product import _multiply_bezier  # noqa: PLC0415
 
     ctrl = bezier.control_points
@@ -307,32 +307,26 @@ def _derivative_rational(bezier: Bezier, direction: int) -> Bezier:
     a_bezier = BezierCls(ctrl[..., :-1], is_rational=False)
     w_bezier = BezierCls(ctrl[..., -1:], is_rational=False)
 
-    # Compute non-rational derivatives.
-    a_prime = _derivative_nonrational(a_bezier, direction)
-    w_prime = _derivative_nonrational(w_bezier, direction)
+    # Degree-preserving derivatives: A' and w' remain degree p.
+    a_prime = _derivative_keep_degree_nonrational(a_bezier, direction)
+    w_prime = _derivative_keep_degree_nonrational(w_bezier, direction)
 
     # Tile scalar Béziers to match vector rank for multiply().
     w_tiled = _tile_scalar_bezier(w_bezier, vec_rank)
     w_prime_tiled = _tile_scalar_bezier(w_prime, vec_rank)
 
-    # Compute products: A'*w and A*w' (degree 2p-1 each).
+    # Products are degree p + p = 2p (same as w^2).
     num1 = _multiply_bezier(a_prime, w_tiled)
     num2 = _multiply_bezier(a_bezier, w_prime_tiled)
 
     # Subtract CPs (same degree guaranteed).
     numerator_ctrl = num1.control_points - num2.control_points
-    numerator = BezierCls(numerator_ctrl, is_rational=False)
 
     # Compute denominator: w^2 (degree 2p).
     denom = _multiply_bezier(w_bezier, w_bezier)
 
-    # Elevate numerator degree by 1 in the target direction.
-    increments = [0] * bezier.dim
-    increments[direction] = 1
-    numerator = _degree_elevate_bezier(numerator, tuple(increments))
-
-    # Assemble rational Bézier.
-    result_ctrl = np.concatenate([numerator.control_points, denom.control_points], axis=-1)
+    # Assemble rational Bézier (numerator and denom are both degree 2p).
+    result_ctrl = np.concatenate([numerator_ctrl, denom.control_points], axis=-1)
     return BezierCls(result_ctrl, is_rational=True)
 
 
@@ -362,18 +356,10 @@ def _derivative_bezier(bezier: Bezier, direction: int, *, keep_degree: bool = Fa
             return _derivative_rational(bezier, direction)
         return _derivative_nonrational(bezier, direction)
 
-    # keep_degree=True: non-rational uses fused kernel, rational uses fallback.
+    # keep_degree=True: non-rational uses fused kernel.
     if not bezier.is_rational:
         return _derivative_keep_degree_nonrational(bezier, direction)
 
-    # Rational fallback: compute derivative, then elevate degree.
-    from ._bezier_degree import _degree_elevate_bezier  # noqa: PLC0415
-
-    deriv = _derivative_rational(bezier, direction)
-    orig_degree = bezier.degree[direction]
-    deriv_degree = deriv.degree[direction]
-    inc = orig_degree - deriv_degree
-    if inc > 0:
-        increments = tuple(0 if d != direction else inc for d in range(bezier.dim))
-        deriv = _degree_elevate_bezier(deriv, increments)
-    return deriv
+    # Rational: derivative already uses degree-preserving A'/w', producing
+    # degree 2p which exceeds the original degree p — no elevation needed.
+    return _derivative_rational(bezier, direction)

--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -351,15 +351,8 @@ def _derivative_bezier(bezier: Bezier, direction: int, *, keep_degree: bool = Fa
         Inputs are assumed to be correct (no validation performed).
         For general use, call :meth:`~pantr.bezier.Bezier.derivative` instead.
     """
-    if not keep_degree:
-        if bezier.is_rational:
-            return _derivative_rational(bezier, direction)
-        return _derivative_nonrational(bezier, direction)
-
-    # keep_degree=True: non-rational uses fused kernel.
-    if not bezier.is_rational:
+    if bezier.is_rational:
+        return _derivative_rational(bezier, direction)
+    if keep_degree:
         return _derivative_keep_degree_nonrational(bezier, direction)
-
-    # Rational: derivative already uses degree-preserving A'/w', producing
-    # degree 2p which exceeds the original degree p — no elevation needed.
-    return _derivative_rational(bezier, direction)
+    return _derivative_nonrational(bezier, direction)

--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -421,7 +421,7 @@ def _derivative_nonrational(bspline: Bspline, direction: int) -> Bspline:
     return _derivative_nonrational_nd(bspline, direction)
 
 
-def _derivative_bspline(bspline: Bspline, direction: int) -> Bspline:
+def _derivative_bspline(bspline: Bspline, direction: int, *, keep_degree: bool = False) -> Bspline:
     """Compute the first partial derivative of a B-spline.
 
     This is the main entry point for derivative computation. It dispatches
@@ -432,6 +432,9 @@ def _derivative_bspline(bspline: Bspline, direction: int) -> Bspline:
         bspline (~pantr.bspline.Bspline): The B-spline to differentiate.
         direction (int): Parametric direction for differentiation. Must be
             in ``[0, dim)``.
+        keep_degree (bool): If ``True``, the result has the same degree as the
+            input by applying degree elevation after differentiation. Defaults
+            to ``False``.
 
     Returns:
         ~pantr.bspline.Bspline: A new B-spline representing the derivative.
@@ -440,6 +443,28 @@ def _derivative_bspline(bspline: Bspline, direction: int) -> Bspline:
         Inputs are assumed to be correct (no validation performed).
         For general use, call :meth:`~pantr.bspline.Bspline.derivative` instead.
     """
+    if not keep_degree:
+        if bspline.is_rational:
+            return _derivative_rational(bspline, direction)
+        return _derivative_nonrational(bspline, direction)
+
+    # keep_degree=True: compute derivative, then elevate to restore degree.
     if bspline.is_rational:
-        return _derivative_rational(bspline, direction)
-    return _derivative_nonrational(bspline, direction)
+        deriv = _derivative_rational(bspline, direction)
+    else:
+        deriv = _derivative_nonrational(bspline, direction)
+
+    orig_degree = bspline.space.spaces[direction].degree
+    deriv_degree = deriv.space.spaces[direction].degree
+    inc = orig_degree - deriv_degree
+    if inc > 0:
+        from ._bspline_degree import _degree_elevate_bspline  # noqa: PLC0415
+
+        # Degree elevation does not support periodic knot vectors, so
+        # convert periodic directions to open representation first.
+        if deriv.space.spaces[direction].periodic:
+            deriv = deriv.to_open_bspline()
+
+        increments = tuple(0 if d != direction else inc for d in range(bspline.dim))
+        deriv = _degree_elevate_bspline(deriv, increments)
+    return deriv

--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -307,6 +307,68 @@ def _compute_missing_knots(  # noqa: PLR0913
     return np.array(knots_list, dtype=dtype)
 
 
+def _derivative_keep_degree_nonrational(bspline: Bspline, direction: int) -> Bspline:
+    """Compute derivative with degree preservation for a non-rational B-spline.
+
+    Computes the derivative (degree ``p - 1``) and degree-elevates by 1 to
+    restore the original degree ``p``.  Works directly with arrays and the
+    degree-elevation kernel to avoid creating an intermediate
+    :class:`~pantr.bspline.Bspline` object.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A non-rational B-spline.
+        direction (int): Parametric direction for differentiation.
+
+    Returns:
+        ~pantr.bspline.Bspline: Derivative B-spline of the same degree as the
+        input.  Periodic directions in the differentiated axis are converted
+        to open representation (degree elevation does not support periodic).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bspline` instead.
+    """
+    from . import Bspline as BsplineCls  # noqa: PLC0415
+    from ._bspline_degree_core import _degree_elevate_1d_core  # noqa: PLC0415
+
+    space_d = bspline.space.spaces[direction]
+    p = space_d.degree
+
+    # Degree elevation requires open knot vectors. For periodic B-splines,
+    # convert to open representation first, then recurse.
+    if space_d.periodic:
+        return _derivative_keep_degree_nonrational(bspline.to_open_bspline(), direction)
+
+    knots = space_d.knots
+    ctrl = bspline.control_points
+
+    # Move target direction to axis 0, flatten the rest.
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    # Derivative (degree p → p-1) + degree elevation (p-1 → p) on arrays.
+    deriv_pts = _derivative_ctrl_1d(knots, p, pts_2d)
+    deriv_knots = knots[1:-1]
+    elevated_pts, elevated_knots = _degree_elevate_1d_core(p - 1, deriv_pts, deriv_knots, 1)
+
+    # Restore shape and move axis back.
+    new_shape = (elevated_pts.shape[0], *orig_shape[1:])
+    new_moved = elevated_pts.reshape(new_shape)
+    new_ctrl = np.moveaxis(new_moved, 0, direction)
+
+    # Build new spaces: replace direction d, keep others unchanged.
+    # Result is open in the differentiated direction.
+    new_spaces = list(bspline.space.spaces)
+    new_spaces[direction] = BsplineSpace1D(elevated_knots, p)
+    new_space = BsplineSpace(new_spaces)
+
+    return BsplineCls(new_space, new_ctrl, is_rational=False)
+
+
 def _tile_scalar_bspline(w: Bspline, target_rank: int) -> Bspline:
     """Tile a rank-1 B-spline to match a target rank.
 
@@ -337,8 +399,9 @@ def _derivative_rational(bspline: Bspline, direction: int) -> Bspline:
     Applies the quotient rule: for ``f = A/w``,
     ``f' = (A'w - Aw') / w^2``.
 
-    The numerator and denominator are computed via B-spline products and
-    combined into a rational B-spline of degree ``2p`` in the given direction.
+    Uses degree-preserving derivatives for ``A'`` and ``w'`` so that the
+    products ``A'w`` and ``Aw'`` are degree ``2p`` (matching ``w^2``),
+    eliminating the need for a separate numerator degree elevation.
 
     Since ``multiply()`` requires operands to have the same rank, the scalar
     weight B-splines (rank 1) are tiled to match the vector rank before
@@ -364,15 +427,15 @@ def _derivative_rational(bspline: Bspline, direction: int) -> Bspline:
     a_bspline = BsplineCls(bspline.space, ctrl[..., :-1], is_rational=False)
     w_bspline = BsplineCls(bspline.space, ctrl[..., -1:], is_rational=False)
 
-    # Compute non-rational derivatives.
-    a_prime = _derivative_nonrational(a_bspline, direction)
-    w_prime = _derivative_nonrational(w_bspline, direction)
+    # Degree-preserving derivatives: A' and w' remain degree p.
+    a_prime = _derivative_keep_degree_nonrational(a_bspline, direction)
+    w_prime = _derivative_keep_degree_nonrational(w_bspline, direction)
 
     # Tile scalar B-splines to match vector rank for multiply().
     w_tiled = _tile_scalar_bspline(w_bspline, vec_rank)
     w_prime_tiled = _tile_scalar_bspline(w_prime, vec_rank)
 
-    # Compute products: A'*w and A*w' (degree 2p-1 each).
+    # Products are degree p + p = 2p (same as w^2).
     num1 = a_prime.multiply(w_tiled)
     num2 = a_bspline.multiply(w_prime_tiled)
 
@@ -382,11 +445,6 @@ def _derivative_rational(bspline: Bspline, direction: int) -> Bspline:
 
     # Compute denominator: w^2 (degree 2p).
     denom = w_bspline.multiply(w_bspline)
-
-    # Elevate numerator degree by 1 in the target direction.
-    increments = [0] * bspline.dim
-    increments[direction] = 1
-    numerator = numerator.elevate_degree(increments)
 
     # Refine both to a common knot vector in the target direction.
     numerator, denom = _refine_to_common_space_1d(numerator, denom, direction)
@@ -448,23 +506,10 @@ def _derivative_bspline(bspline: Bspline, direction: int, *, keep_degree: bool =
             return _derivative_rational(bspline, direction)
         return _derivative_nonrational(bspline, direction)
 
-    # keep_degree=True: compute derivative, then elevate to restore degree.
-    if bspline.is_rational:
-        deriv = _derivative_rational(bspline, direction)
-    else:
-        deriv = _derivative_nonrational(bspline, direction)
+    # keep_degree=True: non-rational uses array-level derivative + elevation.
+    if not bspline.is_rational:
+        return _derivative_keep_degree_nonrational(bspline, direction)
 
-    orig_degree = bspline.space.spaces[direction].degree
-    deriv_degree = deriv.space.spaces[direction].degree
-    inc = orig_degree - deriv_degree
-    if inc > 0:
-        from ._bspline_degree import _degree_elevate_bspline  # noqa: PLC0415
-
-        # Degree elevation does not support periodic knot vectors, so
-        # convert periodic directions to open representation first.
-        if deriv.space.spaces[direction].periodic:
-            deriv = deriv.to_open_bspline()
-
-        increments = tuple(0 if d != direction else inc for d in range(bspline.dim))
-        deriv = _degree_elevate_bspline(deriv, increments)
-    return deriv
+    # Rational: derivative already uses degree-preserving A'/w', producing
+    # degree 2p which exceeds the original degree p — no elevation needed.
+    return _derivative_rational(bspline, direction)

--- a/src/pantr/bspline/_bspline_geom.py
+++ b/src/pantr/bspline/_bspline_geom.py
@@ -235,7 +235,7 @@ class Bspline:
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_Bspline_deriv(self, pts, orders_seq, out)
 
-    def derivative(self, direction: int = 0) -> Bspline:
+    def derivative(self, direction: int = 0, *, keep_degree: bool = False) -> Bspline:
         """Return a B-spline representing the first derivative in the given direction.
 
         Computes the hodograph: a new B-spline whose value at every parametric
@@ -244,14 +244,20 @@ class Bspline:
 
         For non-rational B-splines of degree ``p`` in direction ``d``, the
         result has degree ``p - 1`` in direction ``d`` and the same degree in
-        all other directions.
+        all other directions (or ``p`` when ``keep_degree=True``).
 
         For rational B-splines (NURBS), the quotient rule is applied, producing
-        a rational B-spline of degree ``2p`` in direction ``d``.
+        a rational B-spline of degree ``2p`` in direction ``d`` (or the
+        original degree when ``keep_degree=True``).
 
         Args:
             direction (int): Parametric direction for differentiation.
                 Must be in ``[0, dim)``. Defaults to 0.
+            keep_degree (bool): If ``True``, the result preserves the same
+                degree as the original B-spline by applying degree elevation
+                after differentiation. This is useful, for instance, when
+                computing derivatives of rational polynomials (in the
+                numerator). Defaults to ``False``.
 
         Returns:
             Bspline: A new B-spline representing the derivative.
@@ -267,12 +273,14 @@ class Bspline:
             >>> df_dv = surface.derivative(direction=1)
             >>> # Second derivative (composable)
             >>> f_double_prime = f.derivative().derivative()
+            >>> # Derivative preserving degree
+            >>> f_prime_same_deg = f.derivative(keep_degree=True)
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
         if self.space.spaces[direction].degree < 1:
             raise ValueError("Derivative of a degree-0 B-spline is not defined.")
-        return _derivative_bspline(self, direction)
+        return _derivative_bspline(self, direction, keep_degree=keep_degree)
 
     def elevate_degree(self, degree_increments: int | Sequence[int]) -> Bspline:
         """Elevate the polynomial degree of the B-spline.

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -464,7 +464,7 @@ class TestBezierDerivativeKeepDegree:
         """Rational derivative with keep_degree matches without it.
 
         For rational Bézier of degree p, the derivative has degree 2p > p,
-        so keep_degree has no effect.
+        so keep_degree does not further elevate the result.
         """
         w = 1.0 / np.sqrt(2.0)
         ctrl = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -404,6 +404,78 @@ class TestBezierDerivative:
 
 
 # ---------------------------------------------------------------------------
+# Derivative with keep_degree
+# ---------------------------------------------------------------------------
+
+
+class TestBezierDerivativeKeepDegree:
+    """Test Bezier derivative with keep_degree=True."""
+
+    def test_nonrational_1d_degree_preserved(self) -> None:
+        """Degree is preserved when keep_degree=True."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        d = b.derivative(keep_degree=True)
+        assert d.degree == b.degree
+
+    def test_nonrational_1d_matches_derivative_then_elevate(self) -> None:
+        """Fused result matches derivative + elevate_degree."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        d_fused = b.derivative(keep_degree=True)
+        d_ref = b.derivative().elevate_degree(1)
+        pts = np.linspace(0.0, 1.0, 30, dtype=np.float64)
+        np.testing.assert_allclose(d_fused.evaluate(pts), d_ref.evaluate(pts), atol=1e-13)
+
+    def test_nonrational_1d_matches_evaluate_derivatives(self) -> None:
+        """Derivative values match evaluate_derivatives."""
+        ctrl = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 1.0], [4.0, 0.0]], dtype=np.float64)
+        b = Bezier(ctrl)
+        d = b.derivative(keep_degree=True)
+        pts = np.linspace(0.0, 1.0, 30, dtype=np.float64)
+        np.testing.assert_allclose(d.evaluate(pts), b.evaluate_derivatives(pts, 1), atol=1e-12)
+
+    def test_nonrational_2d_direction0(self) -> None:
+        """2D partial derivative in direction 0 preserves degree."""
+        ctrl = np.random.default_rng(42).standard_normal((4, 3, 2))
+        b = Bezier(ctrl)
+        d = b.derivative(direction=0, keep_degree=True)
+        assert d.degree == b.degree
+
+    def test_nonrational_2d_direction1(self) -> None:
+        """2D partial derivative in direction 1 preserves degree."""
+        ctrl = np.random.default_rng(42).standard_normal((4, 3, 2))
+        b = Bezier(ctrl)
+        d = b.derivative(direction=1, keep_degree=True)
+        assert d.degree == b.degree
+
+    def test_nonrational_2d_matches_evaluate_derivatives(self) -> None:
+        """2D keep_degree derivative matches evaluate_derivatives."""
+        ctrl = np.random.default_rng(42).standard_normal((4, 3, 2))
+        b = Bezier(ctrl)
+        pts = np.random.default_rng(99).uniform(0.0, 1.0, (20, 2))
+        for direction in range(2):
+            d = b.derivative(direction=direction, keep_degree=True)
+            orders = [0, 0]
+            orders[direction] = 1
+            np.testing.assert_allclose(
+                d.evaluate(pts), b.evaluate_derivatives(pts, orders), atol=1e-11
+            )
+
+    def test_rational_1d_same_as_without_keep_degree(self) -> None:
+        """Rational derivative with keep_degree matches without it.
+
+        For rational Bézier of degree p, the derivative has degree 2p > p,
+        so keep_degree has no effect.
+        """
+        w = 1.0 / np.sqrt(2.0)
+        ctrl = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        d_normal = b.derivative()
+        d_keep = b.derivative(keep_degree=True)
+        pts = np.linspace(0.01, 0.99, 20, dtype=np.float64)
+        np.testing.assert_allclose(d_keep.evaluate(pts), d_normal.evaluate(pts), atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
 # Degree elevation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -539,8 +539,7 @@ class TestKeepDegreeRational:
 
     For rational B-splines of degree ``p``, the derivative has degree ``2p``,
     which is already higher than the original degree. In this case,
-    ``keep_degree`` has no effect (degree elevation is not applied since
-    the derivative degree exceeds the original).
+    ``keep_degree`` does not further elevate the result.
     """
 
     def test_rational_1d_same_as_without_keep_degree(self) -> None:

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -392,6 +392,169 @@ class TestRationalND:
 
 
 # ---------------------------------------------------------------------------
+# keep_degree tests
+# ---------------------------------------------------------------------------
+
+
+def _assert_keep_degree_matches_evaluate(
+    f: Bspline,
+    direction: int = 0,
+    atol: float = 1e-9,
+) -> Bspline:
+    """Assert that derivative(keep_degree=True) matches evaluate_derivatives.
+
+    Returns the derivative B-spline for further checks.
+    """
+    space_d = f.space.spaces[direction]
+    a, b = float(space_d.domain[0]), float(space_d.domain[1])
+
+    f_prime = f.derivative(direction=direction, keep_degree=True)
+
+    # Degree must be preserved.
+    assert f_prime.space.spaces[direction].degree == space_d.degree
+
+    if f.dim == 1:
+        pts = eval_pts(a, b, 201)
+        expected = f.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+    else:
+        n_pts = 51
+        dim = f.dim
+        coords = np.empty((n_pts, dim), dtype=np.float64)
+        rng = np.random.default_rng(99)
+        for d in range(dim):
+            ad, bd = float(f.space.spaces[d].domain[0]), float(f.space.spaces[d].domain[1])
+            coords[:, d] = rng.uniform(ad, bd, n_pts)
+        orders = [0] * dim
+        orders[direction] = 1
+        expected = f.evaluate_derivatives(coords, orders)
+        actual = f_prime.evaluate(coords)
+
+    np.testing.assert_allclose(actual, expected, atol=atol)
+    return f_prime
+
+
+class TestKeepDegreeNonRational:
+    """Derivative with keep_degree=True for non-rational B-splines."""
+
+    def test_1d_degree_preserved(self) -> None:
+        """Degree is preserved in 1D case."""
+        f = _make_open(3, 2)
+        f_prime = f.derivative(keep_degree=True)
+        assert f_prime.space.spaces[0].degree == 2  # noqa: PLR2004
+
+    def test_1d_matches_evaluate_derivatives(self) -> None:
+        """Values match evaluate_derivatives for 1D open B-spline."""
+        f = _make_open(4, 3)
+        _assert_keep_degree_matches_evaluate(f)
+
+    def test_1d_cubic(self) -> None:
+        """Cubic keep_degree derivative."""
+        f = _make_open(3, 3)
+        _assert_keep_degree_matches_evaluate(f)
+
+    def test_1d_high_degree(self) -> None:
+        """Degree-5 keep_degree derivative."""
+        f = _make_open(3, 5)
+        _assert_keep_degree_matches_evaluate(f)
+
+    def test_1d_matches_derivative_then_elevate(self) -> None:
+        """Result matches derivative() followed by elevate_degree()."""
+        f = _make_open(4, 3)
+        d_keep = f.derivative(keep_degree=True)
+        d_ref = f.derivative().elevate_degree(1)
+        pts = eval_pts()
+        np.testing.assert_allclose(d_keep.evaluate(pts), d_ref.evaluate(pts), atol=1e-12)
+
+    def test_vector_valued(self) -> None:
+        """Vector-valued B-spline with keep_degree."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [[0.0, 0.0], [1.0, 2.0], [2.0, 1.0], [3.0, 3.0]]
+        f = make_bspline_1d(knots, 2, ctrl)
+        f_prime = f.derivative(keep_degree=True)
+        assert f_prime.space.spaces[0].degree == 2  # noqa: PLR2004
+        pts = eval_pts()
+        expected = f.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-10)
+
+    def test_periodic(self) -> None:
+        """Periodic B-spline with keep_degree (converts to open)."""
+        f = _make_periodic(4, 3)
+        f_prime = f.derivative(keep_degree=True)
+        # Degree elevation doesn't support periodic, so result is open.
+        assert f_prime.space.spaces[0].degree == 3  # noqa: PLR2004
+        assert not f_prime.space.spaces[0].periodic
+
+        # Values must still match.
+        f_open = f.to_open_bspline()
+        a, b = float(f_open.space.spaces[0].domain[0]), float(f_open.space.spaces[0].domain[1])
+        pts = eval_pts(a, b, 201)
+        expected = f_open.evaluate_derivatives(pts, 1)
+        actual = f_prime.evaluate(pts)
+        np.testing.assert_allclose(actual, expected, atol=1e-9)
+
+    def test_2d_direction0(self) -> None:
+        """2D surface keep_degree in direction 0."""
+        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 3)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(55)
+        ctrl = rng.standard_normal((*space.num_basis, 2))
+        f = Bspline(space, ctrl)
+        _assert_keep_degree_matches_evaluate(f, direction=0, atol=1e-8)
+
+    def test_2d_direction1(self) -> None:
+        """2D surface keep_degree in direction 1."""
+        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 3)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(55)
+        ctrl = rng.standard_normal((*space.num_basis, 2))
+        f = Bspline(space, ctrl)
+        _assert_keep_degree_matches_evaluate(f, direction=1, atol=1e-8)
+
+    def test_2d_other_directions_unchanged(self) -> None:
+        """Degrees in non-differentiated directions remain unchanged."""
+        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        s0 = BsplineSpace1D(knots0, 2)
+        s1 = BsplineSpace1D(knots1, 3)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(55)
+        ctrl = rng.standard_normal((*space.num_basis, 2))
+        f = Bspline(space, ctrl)
+
+        f_prime = f.derivative(direction=0, keep_degree=True)
+        assert f_prime.space.spaces[0].degree == 2  # noqa: PLR2004
+        assert f_prime.space.spaces[1].degree == 3  # unchanged  # noqa: PLR2004
+
+
+class TestKeepDegreeRational:
+    """Derivative with keep_degree=True for rational (NURBS) B-splines.
+
+    For rational B-splines of degree ``p``, the derivative has degree ``2p``,
+    which is already higher than the original degree. In this case,
+    ``keep_degree`` has no effect (degree elevation is not applied since
+    the derivative degree exceeds the original).
+    """
+
+    def test_rational_1d_same_as_without_keep_degree(self) -> None:
+        """Rational derivative with keep_degree matches without it."""
+        knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
+        ctrl = [[1.0, 0.0, 1.0], [2.0, 4.0, 2.0], [1.5, 3.0, 1.0], [3.0, 1.5, 1.5]]
+        f = make_bspline_1d(knots, 2, ctrl, is_rational=True)
+        d_normal = f.derivative()
+        d_keep = f.derivative(keep_degree=True)
+        pts = eval_pts()
+        np.testing.assert_allclose(d_keep.evaluate(pts), d_normal.evaluate(pts), atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `keep_degree: bool = False` keyword argument to `Bspline.derivative()` and `Bezier.derivative()`
- When `True`, the derivative preserves the original polynomial degree by combining differentiation with degree elevation
- For non-rational Bézier, uses a fused kernel (`R[j] = (p-j)*(P[j+1]-P[j]) + j*(P[j]-P[j-1])`) that avoids intermediate allocations
- For non-rational B-splines, applies internal degree elevation after differentiation; periodic B-splines are converted to open representation first
- For rational splines, `keep_degree` has no effect since the derivative degree (2p) already exceeds the original (p)

## Test plan
- [x] Non-rational Bézier 1D: degree preserved, values match `evaluate_derivatives` and `derivative().elevate_degree(1)`
- [x] Non-rational Bézier 2D: both directions, degree preserved, values match
- [x] Rational Bézier: `keep_degree` produces same result as without (no-op)
- [x] Non-rational B-spline 1D: open, periodic, various degrees
- [x] Non-rational B-spline 2D: both directions, other directions unchanged
- [x] Rational B-spline: `keep_degree` produces same result as without (no-op)
- [x] Full test suite passes (1275 tests), mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)