### PR TITLE
refactor(bezier): consolidate 1D/nD derivative function pairs

### DIFF
--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -84,35 +84,14 @@ def _derivative_keep_degree_ctrl_1d(
     return result
 
 
-def _derivative_nonrational_1d(bezier: Bezier) -> Bezier:
-    """Compute the derivative of a non-rational 1D Bézier.
-
-    Args:
-        bezier (~pantr.bezier.Bezier): A 1D non-rational Bézier with degree >= 1.
-
-    Returns:
-        ~pantr.bezier.Bezier: Derivative Bézier of degree ``p - 1``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_derivative_bezier` instead.
-    """
-    from . import Bezier as BezierCls  # noqa: PLC0415
-
-    p = bezier.degree[0]
-    ctrl = bezier.control_points
-    new_ctrl = _derivative_ctrl_1d(p, ctrl)
-    return BezierCls(new_ctrl, is_rational=False)
-
-
-def _derivative_nonrational_nd(bezier: Bezier, direction: int) -> Bezier:
-    """Compute the partial derivative of a non-rational nD Bézier.
+def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational Bézier.
 
     Applies the 1D derivative formula along the given parametric direction
     using the moveaxis/reshape/restore pattern.
 
     Args:
-        bezier (~pantr.bezier.Bezier): A non-rational nD Bézier.
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
         direction (int): Parametric direction for differentiation.
 
     Returns:
@@ -146,59 +125,14 @@ def _derivative_nonrational_nd(bezier: Bezier, direction: int) -> Bezier:
     return BezierCls(new_ctrl, is_rational=False)
 
 
-def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
-    """Compute the partial derivative of a non-rational Bézier.
-
-    Dispatches to the 1D or nD implementation.
-
-    Args:
-        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
-        direction (int): Parametric direction for differentiation.
-
-    Returns:
-        ~pantr.bezier.Bezier: Derivative Bézier.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_derivative_bezier` instead.
-    """
-    if bezier.dim == 1:
-        return _derivative_nonrational_1d(bezier)
-    return _derivative_nonrational_nd(bezier, direction)
-
-
-def _derivative_keep_degree_nonrational_1d(bezier: Bezier) -> Bezier:
-    """Compute the derivative of a non-rational 1D Bézier, preserving degree.
-
-    Fuses the derivative and degree elevation into a single operation,
-    avoiding allocation of an intermediate Bézier.
-
-    Args:
-        bezier (~pantr.bezier.Bezier): A 1D non-rational Bézier with degree >= 1.
-
-    Returns:
-        ~pantr.bezier.Bezier: Derivative Bézier of degree ``p`` (same as input).
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_derivative_bezier` instead.
-    """
-    from . import Bezier as BezierCls  # noqa: PLC0415
-
-    p = bezier.degree[0]
-    ctrl = bezier.control_points
-    new_ctrl = _derivative_keep_degree_ctrl_1d(p, ctrl)
-    return BezierCls(new_ctrl, is_rational=False)
-
-
-def _derivative_keep_degree_nonrational_nd(bezier: Bezier, direction: int) -> Bezier:
-    """Compute the partial derivative of a non-rational nD Bézier, preserving degree.
+def _derivative_keep_degree_nonrational(bezier: Bezier, direction: int) -> Bezier:
+    """Compute the partial derivative of a non-rational Bézier, preserving degree.
 
     Fuses the derivative and degree elevation into a single operation along
     the given direction using the moveaxis/reshape/restore pattern.
 
     Args:
-        bezier (~pantr.bezier.Bezier): A non-rational nD Bézier.
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
         direction (int): Parametric direction for differentiation.
 
     Returns:
@@ -230,27 +164,6 @@ def _derivative_keep_degree_nonrational_nd(bezier: Bezier, direction: int) -> Be
     new_ctrl = np.moveaxis(new_moved, 0, direction)
 
     return BezierCls(new_ctrl, is_rational=False)
-
-
-def _derivative_keep_degree_nonrational(bezier: Bezier, direction: int) -> Bezier:
-    """Compute the partial derivative of a non-rational Bézier, preserving degree.
-
-    Dispatches to the 1D or nD keep-degree implementation.
-
-    Args:
-        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
-        direction (int): Parametric direction for differentiation.
-
-    Returns:
-        ~pantr.bezier.Bezier: Derivative Bézier with same degree as input.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_derivative_bezier` instead.
-    """
-    if bezier.dim == 1:
-        return _derivative_keep_degree_nonrational_1d(bezier)
-    return _derivative_keep_degree_nonrational_nd(bezier, direction)
 
 
 def _tile_scalar_bezier(w: Bezier, target_rank: int) -> Bezier:


### PR DESCRIPTION
## Summary
- Remove `_derivative_nonrational_1d` and `_derivative_keep_degree_nonrational_1d` specializations from `_bezier_derivative.py`
- The nD implementations already work correctly for `dim==1` (`moveaxis` with `direction=0` is a no-op in terms of data), so the 1D fast paths were pure duplication
- Eliminates 4 functions → 2 and removes the dispatcher branching on `bezier.dim`
- Net reduction: ~90 lines

## Test plan
- [x] All 1275 existing tests pass
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)