### PR TITLE
feat(bspline): add reverse, permute_directions, and knot removal

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -60,6 +60,7 @@ if not TYPE_CHECKING:
                 _bspline_eval,
                 _bspline_extraction,
                 _bspline_knot_insertion_core,
+                _bspline_knot_removal_core,
                 _bspline_knots,
             )
 
@@ -73,6 +74,7 @@ if not TYPE_CHECKING:
             _bspline_eval._warmup_numba_functions()
             _bspline_extraction._warmup_numba_functions()
             _bspline_knot_insertion_core._warmup_numba_functions()
+            _bspline_knot_removal_core._warmup_numba_functions()
             _bspline_knots._warmup_numba_functions()
             from .bspline import _bspline_blossom_core  # noqa: PLC0415
 

--- a/src/pantr/_control_points_utils.py
+++ b/src/pantr/_control_points_utils.py
@@ -1,0 +1,72 @@
+"""Shared control-point manipulation helpers for reverse and permute operations.
+
+These functions operate purely on control-point arrays and are used by both
+:class:`~pantr.bezier.Bezier` and :class:`~pantr.bspline.Bspline`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+
+def _reverse_control_points(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    direction: int,
+    *,
+    in_place: bool,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Reverse control points along a parametric direction.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control point array with
+            shape ``(*num_basis, rank)``.
+        direction (int): Parametric axis to reverse (must be valid).
+        in_place (bool): If ``True``, flip the array in place and return it.
+            If ``False``, return a new (possibly non-contiguous) flipped array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The reversed control points.
+    """
+    if in_place:
+        idx = [slice(None)] * ctrl.ndim
+        idx[direction] = slice(None, None, -1)
+        ctrl[:] = ctrl[tuple(idx)]
+        return ctrl
+
+    return np.flip(ctrl, axis=direction)
+
+
+def _permute_control_points(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    permutation: Sequence[int],
+    dim: int,
+    *,
+    in_place: bool,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Reorder control-point axes according to a permutation.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control point array with
+            shape ``(*num_basis, rank)``.
+        permutation (Sequence[int]): A permutation of ``range(dim)``.
+        dim (int): Number of parametric dimensions (rank axis is ``dim``).
+        in_place (bool): If ``True``, store the result back into ``ctrl``
+            (requires a contiguous temporary). If ``False``, return a new
+            contiguous array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The permuted control points
+        (contiguous).
+    """
+    axes = [*permutation, dim]
+    new_cp = np.ascontiguousarray(np.transpose(ctrl, axes))
+
+    if in_place:
+        # The shape changes, so we cannot write back into the same buffer.
+        # Replace the reference instead (caller must assign back).
+        return new_cp
+
+    return new_cp

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 from numpy import typing as npt
@@ -329,7 +329,13 @@ class Bezier:
     # Reverse and permute
     # ------------------------------------------------------------------
 
-    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bezier:
+    @overload
+    def reverse(self, direction: int = ..., *, in_place: Literal[False] = ...) -> Bezier: ...
+
+    @overload
+    def reverse(self, direction: int = ..., *, in_place: Literal[True]) -> None: ...
+
+    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bezier | None:
         """Reverse the orientation of one parametric direction.
 
         Flips the control points along the given parametric axis so that the
@@ -339,10 +345,11 @@ class Bezier:
             direction (int): Parametric direction to reverse. Must be in
                 ``[0, dim)``. Defaults to 0.
             in_place (bool): If ``True``, modify this Bézier in place and
-                return it. If ``False`` (default), return a new Bézier.
+                return ``None``. If ``False`` (default), return a new Bézier.
 
         Returns:
-            Bezier: The reversed Bézier (``self`` when ``in_place=True``).
+            Bezier | None: The reversed Bézier, or ``None`` when
+            ``in_place=True``.
 
         Raises:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
@@ -354,14 +361,29 @@ class Bezier:
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
 
-        new_cp = np.flip(self._control_points, axis=direction)
-
         if in_place:
-            self._control_points = np.ascontiguousarray(new_cp)
-            return self
+            # In-place reversal along the given axis using slice assignment.
+            idx = [slice(None)] * self._control_points.ndim
+            idx[direction] = slice(None, None, -1)
+            self._control_points[:] = self._control_points[tuple(idx)]
+            return None
+
+        new_cp = np.flip(self._control_points, axis=direction)
         return Bezier(new_cp, is_rational=self._is_rational)
 
-    def permute_directions(self, permutation: Sequence[int], *, in_place: bool = False) -> Bezier:
+    @overload
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: Literal[False] = ...
+    ) -> Bezier: ...
+
+    @overload
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: Literal[True]
+    ) -> None: ...
+
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: bool = False
+    ) -> Bezier | None:
         """Reorder the parametric directions according to a permutation.
 
         Given a permutation ``[i_0, i_1, …]``, the new direction ``k`` is
@@ -371,10 +393,11 @@ class Bezier:
         Args:
             permutation (Sequence[int]): A permutation of ``range(dim)``.
             in_place (bool): If ``True``, modify this Bézier in place and
-                return it. If ``False`` (default), return a new Bézier.
+                return ``None``. If ``False`` (default), return a new Bézier.
 
         Returns:
-            Bezier: The permuted Bézier (``self`` when ``in_place=True``).
+            Bezier | None: The permuted Bézier, or ``None`` when
+            ``in_place=True``.
 
         Raises:
             ValueError: If ``permutation`` is not a valid permutation of
@@ -389,11 +412,11 @@ class Bezier:
 
         # Transpose parametric axes; keep the rank axis last.
         axes = [*perm, self.dim]
-        new_cp = np.transpose(self._control_points, axes)
+        new_cp = np.ascontiguousarray(np.transpose(self._control_points, axes))
 
         if in_place:
-            self._control_points = np.ascontiguousarray(new_cp)
-            return self
+            self._control_points = new_cp
+            return None
         return Bezier(new_cp, is_rational=self._is_rational)
 
     # ------------------------------------------------------------------

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -361,14 +361,12 @@ class Bezier:
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
 
-        if in_place:
-            # In-place reversal along the given axis using slice assignment.
-            idx = [slice(None)] * self._control_points.ndim
-            idx[direction] = slice(None, None, -1)
-            self._control_points[:] = self._control_points[tuple(idx)]
-            return None
+        from .._control_points_utils import _reverse_control_points  # noqa: PLC0415
 
-        new_cp = np.flip(self._control_points, axis=direction)
+        new_cp = _reverse_control_points(self._control_points, direction, in_place=in_place)
+
+        if in_place:
+            return None
         return Bezier(new_cp, is_rational=self._is_rational)
 
     @overload
@@ -410,9 +408,9 @@ class Bezier:
         if sorted(perm) != list(range(self.dim)):
             raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
 
-        # Transpose parametric axes; keep the rank axis last.
-        axes = [*perm, self.dim]
-        new_cp = np.ascontiguousarray(np.transpose(self._control_points, axes))
+        from .._control_points_utils import _permute_control_points  # noqa: PLC0415
+
+        new_cp = _permute_control_points(self._control_points, perm, self.dim, in_place=in_place)
 
         if in_place:
             self._control_points = new_cp

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -326,6 +326,77 @@ class Bezier:
     __mul__ = multiply
 
     # ------------------------------------------------------------------
+    # Reverse and permute
+    # ------------------------------------------------------------------
+
+    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bezier:
+        """Reverse the orientation of one parametric direction.
+
+        Flips the control points along the given parametric axis so that the
+        mapping is reparametrised in the opposite sense along that direction.
+
+        Args:
+            direction (int): Parametric direction to reverse. Must be in
+                ``[0, dim)``. Defaults to 0.
+            in_place (bool): If ``True``, modify this Bézier in place and
+                return it. If ``False`` (default), return a new Bézier.
+
+        Returns:
+            Bezier: The reversed Bézier (``self`` when ``in_place=True``).
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+
+        Example:
+            >>> rev = bezier.reverse(direction=0)
+            >>> bezier.reverse(direction=1, in_place=True)
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+
+        new_cp = np.flip(self._control_points, axis=direction)
+
+        if in_place:
+            self._control_points = np.ascontiguousarray(new_cp)
+            return self
+        return Bezier(new_cp, is_rational=self._is_rational)
+
+    def permute_directions(self, permutation: Sequence[int], *, in_place: bool = False) -> Bezier:
+        """Reorder the parametric directions according to a permutation.
+
+        Given a permutation ``[i_0, i_1, …]``, the new direction ``k`` is
+        the old direction ``permutation[k]``. For example, ``[1, 2, 0]`` on
+        a 3D volume maps old direction 1 → new 0, old 2 → new 1, old 0 → new 2.
+
+        Args:
+            permutation (Sequence[int]): A permutation of ``range(dim)``.
+            in_place (bool): If ``True``, modify this Bézier in place and
+                return it. If ``False`` (default), return a new Bézier.
+
+        Returns:
+            Bezier: The permuted Bézier (``self`` when ``in_place=True``).
+
+        Raises:
+            ValueError: If ``permutation`` is not a valid permutation of
+                ``range(dim)``.
+
+        Example:
+            >>> surface.permute_directions([1, 0])  # swap u ↔ v
+        """
+        perm = list(permutation)
+        if sorted(perm) != list(range(self.dim)):
+            raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
+
+        # Transpose parametric axes; keep the rank axis last.
+        axes = [*perm, self.dim]
+        new_cp = np.transpose(self._control_points, axes)
+
+        if in_place:
+            self._control_points = np.ascontiguousarray(new_cp)
+            return self
+        return Bezier(new_cp, is_rational=self._is_rational)
+
+    # ------------------------------------------------------------------
     # Conversion
     # ------------------------------------------------------------------
 

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -9,7 +9,7 @@ is dispatched to the de Boor algorithm implemented in ``_bspline_eval``.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 from numpy import typing as npt
@@ -509,7 +509,13 @@ class Bspline:
     # Reverse and permute
     # ------------------------------------------------------------------
 
-    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bspline:
+    @overload
+    def reverse(self, direction: int = ..., *, in_place: Literal[False] = ...) -> Bspline: ...
+
+    @overload
+    def reverse(self, direction: int = ..., *, in_place: Literal[True]) -> None: ...
+
+    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bspline | None:
         """Reverse the orientation of one parametric direction.
 
         Flips the control points along the given parametric axis and reflects
@@ -520,10 +526,11 @@ class Bspline:
             direction (int): Parametric direction to reverse. Must be in
                 ``[0, dim)``. Defaults to 0.
             in_place (bool): If ``True``, modify this B-spline in place and
-                return it. If ``False`` (default), return a new B-spline.
+                return ``None``. If ``False`` (default), return a new B-spline.
 
         Returns:
-            Bspline: The reversed B-spline (``self`` when ``in_place=True``).
+            Bspline | None: The reversed B-spline, or ``None`` when
+            ``in_place=True``.
 
         Raises:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
@@ -538,8 +545,6 @@ class Bspline:
         from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
 
-        new_cp = np.flip(self._control_points, axis=direction)
-
         # Reflect the knot vector: knots_new = a + b - knots[::-1].
         old_space = self._space.spaces[direction]
         knots = old_space.knots
@@ -552,12 +557,29 @@ class Bspline:
         new_space = BsplineSpace(new_spaces)
 
         if in_place:
-            self._control_points = np.ascontiguousarray(new_cp)
+            # In-place reversal along the given axis using slice assignment.
+            idx = [slice(None)] * self._control_points.ndim
+            idx[direction] = slice(None, None, -1)
+            self._control_points[:] = self._control_points[tuple(idx)]
             self._space = new_space
-            return self
+            return None
+
+        new_cp = np.flip(self._control_points, axis=direction)
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
-    def permute_directions(self, permutation: Sequence[int], *, in_place: bool = False) -> Bspline:
+    @overload
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: Literal[False] = ...
+    ) -> Bspline: ...
+
+    @overload
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: Literal[True]
+    ) -> None: ...
+
+    def permute_directions(
+        self, permutation: Sequence[int], *, in_place: bool = False
+    ) -> Bspline | None:
         """Reorder the parametric directions according to a permutation.
 
         Given a permutation ``[i_0, i_1, …]``, the new direction ``k`` is
@@ -567,10 +589,11 @@ class Bspline:
         Args:
             permutation (Sequence[int]): A permutation of ``range(dim)``.
             in_place (bool): If ``True``, modify this B-spline in place and
-                return it. If ``False`` (default), return a new B-spline.
+                return ``None``. If ``False`` (default), return a new B-spline.
 
         Returns:
-            Bspline: The permuted B-spline (``self`` when ``in_place=True``).
+            Bspline | None: The permuted B-spline, or ``None`` when
+            ``in_place=True``.
 
         Raises:
             ValueError: If ``permutation`` is not a valid permutation of
@@ -587,7 +610,7 @@ class Bspline:
 
         # Transpose parametric axes; keep the rank axis last.
         axes = [*perm, self.dim]
-        new_cp = np.transpose(self._control_points, axes)
+        new_cp = np.ascontiguousarray(np.transpose(self._control_points, axes))
 
         # Reorder 1D spaces.
         old_spaces = self._space.spaces
@@ -595,9 +618,9 @@ class Bspline:
         new_space = BsplineSpace(new_spaces)
 
         if in_place:
-            self._control_points = np.ascontiguousarray(new_cp)
+            self._control_points = new_cp
             self._space = new_space
-            return self
+            return None
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
     def subdivide(

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -542,6 +542,7 @@ class Bspline:
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
 
+        from .._control_points_utils import _reverse_control_points  # noqa: PLC0415
         from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
 
@@ -556,15 +557,11 @@ class Bspline:
         new_spaces[direction] = new_space_1d
         new_space = BsplineSpace(new_spaces)
 
+        new_cp = _reverse_control_points(self._control_points, direction, in_place=in_place)
+
         if in_place:
-            # In-place reversal along the given axis using slice assignment.
-            idx = [slice(None)] * self._control_points.ndim
-            idx[direction] = slice(None, None, -1)
-            self._control_points[:] = self._control_points[tuple(idx)]
             self._space = new_space
             return None
-
-        new_cp = np.flip(self._control_points, axis=direction)
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
     @overload
@@ -602,15 +599,14 @@ class Bspline:
         Example:
             >>> surface.permute_directions([1, 0])  # swap u ↔ v
         """
+        from .._control_points_utils import _permute_control_points  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
 
         perm = list(permutation)
         if sorted(perm) != list(range(self.dim)):
             raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
 
-        # Transpose parametric axes; keep the rank axis last.
-        axes = [*perm, self.dim]
-        new_cp = np.ascontiguousarray(np.transpose(self._control_points, axes))
+        new_cp = _permute_control_points(self._control_points, perm, self.dim, in_place=in_place)
 
         # Reorder 1D spaces.
         old_spaces = self._space.spaces

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -434,6 +434,101 @@ class Bspline:
 
     __mul__ = multiply
 
+    # ------------------------------------------------------------------
+    # Reverse and permute
+    # ------------------------------------------------------------------
+
+    def reverse(self, direction: int = 0, *, in_place: bool = False) -> Bspline:
+        """Reverse the orientation of one parametric direction.
+
+        Flips the control points along the given parametric axis and reflects
+        the corresponding knot vector so that the mapping is reparametrised in
+        the opposite sense along that direction.
+
+        Args:
+            direction (int): Parametric direction to reverse. Must be in
+                ``[0, dim)``. Defaults to 0.
+            in_place (bool): If ``True``, modify this B-spline in place and
+                return it. If ``False`` (default), return a new B-spline.
+
+        Returns:
+            Bspline: The reversed B-spline (``self`` when ``in_place=True``).
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+
+        Example:
+            >>> rev = spline.reverse(direction=0)
+            >>> spline.reverse(direction=1, in_place=True)
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+
+        from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
+        from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
+
+        new_cp = np.flip(self._control_points, axis=direction)
+
+        # Reflect the knot vector: knots_new = a + b - knots[::-1].
+        old_space = self._space.spaces[direction]
+        knots = old_space.knots
+        a, b = old_space.domain
+        new_knots = (a + b) - knots[::-1]
+        new_space_1d = BsplineSpace1D(new_knots, old_space.degree, periodic=old_space.periodic)
+
+        new_spaces = list(self._space.spaces)
+        new_spaces[direction] = new_space_1d
+        new_space = BsplineSpace(new_spaces)
+
+        if in_place:
+            self._control_points = np.ascontiguousarray(new_cp)
+            self._space = new_space
+            return self
+        return Bspline(new_space, new_cp, is_rational=self._is_rational)
+
+    def permute_directions(self, permutation: Sequence[int], *, in_place: bool = False) -> Bspline:
+        """Reorder the parametric directions according to a permutation.
+
+        Given a permutation ``[i_0, i_1, …]``, the new direction ``k`` is
+        the old direction ``permutation[k]``. For example, ``[1, 2, 0]`` on
+        a 3D volume maps old direction 1 → new 0, old 2 → new 1, old 0 → new 2.
+
+        Args:
+            permutation (Sequence[int]): A permutation of ``range(dim)``.
+            in_place (bool): If ``True``, modify this B-spline in place and
+                return it. If ``False`` (default), return a new B-spline.
+
+        Returns:
+            Bspline: The permuted B-spline (``self`` when ``in_place=True``).
+
+        Raises:
+            ValueError: If ``permutation`` is not a valid permutation of
+                ``range(dim)``.
+
+        Example:
+            >>> surface.permute_directions([1, 0])  # swap u ↔ v
+        """
+        from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
+
+        perm = list(permutation)
+        if sorted(perm) != list(range(self.dim)):
+            raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
+
+        # Transpose parametric axes; keep the rank axis last.
+        axes = [*perm, self.dim]
+        new_cp = np.transpose(self._control_points, axes)
+
+        # Reorder 1D spaces.
+        old_spaces = self._space.spaces
+        new_spaces = tuple(old_spaces[i] for i in perm)
+        new_space = BsplineSpace(new_spaces)
+
+        if in_place:
+            self._control_points = np.ascontiguousarray(new_cp)
+            self._space = new_space
+            return self
+        return Bspline(new_space, new_cp, is_rational=self._is_rational)
+
     def subdivide(
         self,
         n_subdivisions: int | Sequence[int | None],

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -22,6 +22,7 @@ from ._bspline_knot_insertion import (
     _insert_knots_bspline,
     _to_open_bspline_impl,
 )
+from ._bspline_knot_removal import _remove_knots_bspline
 
 if TYPE_CHECKING:
     from ..quad import PointsLattice
@@ -367,6 +368,76 @@ class Bspline:
             )
 
         return _insert_knots_bspline(self, new_knots_per_dim)
+
+    def remove_knots(
+        self,
+        knot_values: float | npt.ArrayLike | Sequence[npt.ArrayLike | None],
+        *,
+        num: int | None = None,
+        tol: float | None = None,
+    ) -> Bspline:
+        """Return a B-spline with specified interior knots removed.
+
+        Each listed knot value is removed up to *num* times (or as many as
+        possible when ``num=None``), provided the geometric deviation stays
+        within *tol*.
+
+        Args:
+            knot_values (float | npt.ArrayLike | Sequence[npt.ArrayLike | None]):
+                For a 1D B-spline, a single float or a 1D array-like of
+                distinct interior knot values to remove. For multi-dimensional
+                B-splines, a sequence of length ``dim`` where each element is a
+                1D array-like of knot values to remove in that direction, or
+                ``None`` to skip that direction. At least one direction must
+                have a non-empty array of knot values.
+            num (int | None): Maximum number of removals per distinct knot
+                value. ``None`` (default) removes as many as possible (up to
+                the current multiplicity, capped at the degree).
+            tol (float | None): Maximum allowed geometric deviation for each
+                removal step. ``None`` (default) uses ``1e-10``.
+
+        Returns:
+            Bspline: New B-spline with the same geometry (within tolerance)
+            and reduced knot vectors.
+
+        Raises:
+            ValueError: If the B-spline is periodic in any direction.
+            ValueError: If the sequence length does not match ``dim``
+                (multi-dim case).
+            ValueError: If all directions have empty or ``None`` knot arrays.
+            ValueError: If any knot value is not found or is a boundary knot.
+        """
+        # Periodic splines are not supported.
+        for i, sp in enumerate(self._space.spaces):
+            if sp.periodic:
+                raise ValueError(
+                    f"Knot removal is not supported for periodic B-splines "
+                    f"(direction {i} is periodic)."
+                )
+
+        dtype = self.dtype
+
+        if self.dim == 1:
+            arr = np.atleast_1d(np.asarray(knot_values, dtype=dtype)).ravel()
+            kv_per_dim: list[npt.NDArray[np.float32 | np.float64] | None] = [arr]
+        else:
+            seq = list(knot_values)  # type: ignore[arg-type]
+            if len(seq) != self.dim:
+                raise ValueError(
+                    f"knot_values sequence length ({len(seq)}) must match dim ({self.dim})."
+                )
+            kv_per_dim = [
+                None if kv is None else np.atleast_1d(np.asarray(kv, dtype=dtype)).ravel()
+                for kv in seq
+            ]
+
+        # Require at least one non-empty direction.
+        if all(kv is None or kv.size == 0 for kv in kv_per_dim):
+            raise ValueError(
+                "At least one direction must have a non-empty array of knot values to remove."
+            )
+
+        return _remove_knots_bspline(self, kv_per_dim, num, tol)
 
     def to_open_bspline(self) -> Bspline:
         """Return an open (clamped) non-periodic B-spline equivalent to this one.

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -1,0 +1,210 @@
+"""Layer 2 implementation for B-spline knot removal.
+
+This module provides input validation, multiplicity lookup, and
+multi-dimensional orchestration that wrap the Layer 3 knot-removal kernel.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knot_removal_core import _remove_knot_1d_core
+from ._bspline_knots import _get_unique_knots_and_multiplicity_impl
+
+if TYPE_CHECKING:
+    from . import Bspline, BsplineSpace1D
+
+
+def _find_knot_index_and_multiplicity(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    knot_value: float,
+    tol: float,
+) -> tuple[int, int]:
+    """Find the last index and multiplicity of a knot value in the knot vector.
+
+    Searches the knot vector for the last occurrence of *knot_value* (within
+    tolerance) and returns its index *r* together with the multiplicity *s*.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): Polynomial degree.
+        knot_value (float): The knot value to locate.
+        tol (float): Tolerance for numerical comparisons.
+
+    Returns:
+        tuple[int, int]: ``(r, s)`` where *r* is the index of the last
+        occurrence and *s* is the multiplicity.
+
+    Raises:
+        ValueError: If *knot_value* is not found in the knot vector.
+    """
+    unique_knots, mults = _get_unique_knots_and_multiplicity_impl(
+        knots, degree, tol, in_domain=False
+    )
+
+    # Find the matching unique knot.
+    matches = np.where(np.isclose(unique_knots, knot_value, atol=tol))[0]
+    if len(matches) == 0:
+        raise ValueError(f"Knot value {knot_value} not found in knot vector (tolerance={tol}).")
+
+    idx = int(matches[0])
+    s = int(mults[idx])
+
+    # Compute the last index r of this knot value in the full knot vector.
+    # Sum multiplicities up to and including this knot.
+    r = int(np.sum(mults[: idx + 1])) - 1
+
+    return r, s
+
+
+def _remove_knot_bspline_1d_impl(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    knot_value: float,
+    num: int | None,
+    tol_space: float,
+    tol_deviation: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64], int]:
+    """Remove a single knot value from a 1D B-spline.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector of shape
+            ``(n + degree + 2,)``.
+        degree (int): Polynomial degree.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(n + 1, rank)``.
+        knot_value (float): The knot value to remove.
+        num (int | None): Maximum number of removals. ``None`` removes as many
+            as possible (up to the current multiplicity, capped at ``degree``).
+        tol_space (float): Tolerance for knot comparison.
+        tol_deviation (float): Maximum allowed geometric deviation.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray, int]: ``(new_knots, new_ctrl, removals)``
+        where *removals* is the number of knots actually removed.
+
+    Raises:
+        ValueError: If *knot_value* is not found in the knot vector.
+        ValueError: If *knot_value* is a boundary knot of an open (clamped) spline.
+        ValueError: If *num* is not positive.
+    """
+    if num is not None and num < 1:
+        raise ValueError(f"num must be a positive integer or None, got {num}.")
+
+    r, s = _find_knot_index_and_multiplicity(knots, degree, knot_value, tol_space)
+
+    # Boundary knots of open splines cannot be removed.
+    domain_lo = float(knots[degree])
+    domain_hi = float(knots[-degree - 1])
+    if np.isclose(knot_value, domain_lo, atol=tol_space):
+        raise ValueError(f"Cannot remove boundary knot {knot_value} (domain start).")
+    if np.isclose(knot_value, domain_hi, atol=tol_space):
+        raise ValueError(f"Cannot remove boundary knot {knot_value} (domain end).")
+
+    # Cap at the actual multiplicity (and at degree per the algorithm).
+    max_removals = min(s, degree)
+    num = max_removals if num is None else min(num, max_removals)
+
+    # Ensure contiguous layout for the Numba kernel.
+    ctrl_c = ctrl if ctrl.flags.c_contiguous else np.ascontiguousarray(ctrl)
+
+    new_knots, new_ctrl, removals = _remove_knot_1d_core(
+        degree,
+        knots,
+        ctrl_c,
+        float(knot_value),
+        r,
+        s,
+        num,
+        tol_deviation,
+    )
+    return new_knots, new_ctrl, removals
+
+
+def _remove_knots_bspline(
+    bspline: Bspline,
+    knot_values_per_dim: list[npt.NDArray[np.float32 | np.float64] | None],
+    num: int | None,
+    tol: float | None,
+) -> Bspline:
+    """Apply knot removal per parametric direction and return a new B-spline.
+
+    For each direction, iterates over the distinct knot values to remove,
+    applying single-knot removal sequentially (each removal changes the knot
+    indices for subsequent values).
+
+    Args:
+        bspline (Bspline): Original B-spline (must be non-periodic, open).
+        knot_values_per_dim (list[npt.NDArray | None]): Per-direction arrays of
+            distinct knot values to remove. ``None`` or an empty array skips
+            that direction.
+        num (int | None): Maximum removals per knot value. ``None`` removes
+            as many as possible.
+        tol (float | None): Geometric deviation tolerance. ``None`` uses a
+            default of ``1e-10``.
+
+    Returns:
+        Bspline: New B-spline with reduced knot vectors.
+    """
+    dim = bspline.dim
+    ctrl = bspline.control_points
+    tol_deviation = 1e-10 if tol is None else tol
+
+    from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
+
+    new_spaces_1d: list[BsplineSpace1D] = []
+
+    for i in range(dim):
+        space_1d = bspline.space.spaces[i]
+        kv = knot_values_per_dim[i]
+
+        if kv is None or kv.size == 0:
+            new_spaces_1d.append(space_1d)
+            continue
+
+        # Move dimension i to the 0th axis.
+        moved_ctrl = np.moveaxis(ctrl, i, 0)
+        orig_shape = moved_ctrl.shape
+
+        # Flatten remaining axes into a single column dimension.
+        pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        current_knots = space_1d.knots
+        current_ctrl = pts_2d
+
+        # Remove each distinct knot value sequentially.
+        for val in kv:
+            current_knots, current_ctrl, _ = _remove_knot_bspline_1d_impl(
+                current_knots,
+                space_1d.degree,
+                current_ctrl,
+                float(val),
+                num,
+                float(space_1d.tolerance),
+                tol_deviation,
+            )
+
+        # Restore multi-dimensional shape.
+        new_shape = (current_ctrl.shape[0], *orig_shape[1:])
+        new_moved_ctrl = current_ctrl.reshape(new_shape)
+
+        # Move axis back to its original position.
+        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+
+        new_spaces_1d.append(BsplineSpace1D(current_knots, space_1d.degree))
+
+    # Assemble the new B-spline.
+    from . import (  # noqa: PLC0415
+        Bspline,
+        BsplineSpace,
+    )
+
+    new_space = BsplineSpace(new_spaces_1d)
+    return Bspline(new_space, ctrl, is_rational=bspline.is_rational)

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -12,53 +12,10 @@ import numpy as np
 import numpy.typing as npt
 
 from ._bspline_knot_removal_core import _remove_knot_1d_core
-from ._bspline_knots import _get_unique_knots_and_multiplicity_impl
+from ._bspline_knots import _find_knot_index_and_multiplicity
 
 if TYPE_CHECKING:
     from . import Bspline, BsplineSpace1D
-
-
-def _find_knot_index_and_multiplicity(
-    knots: npt.NDArray[np.float32 | np.float64],
-    degree: int,
-    knot_value: float,
-    tol: float,
-) -> tuple[int, int]:
-    """Find the last index and multiplicity of a knot value in the knot vector.
-
-    Searches the knot vector for the last occurrence of *knot_value* (within
-    tolerance) and returns its index *r* together with the multiplicity *s*.
-
-    Args:
-        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
-        degree (int): Polynomial degree.
-        knot_value (float): The knot value to locate.
-        tol (float): Tolerance for numerical comparisons.
-
-    Returns:
-        tuple[int, int]: ``(r, s)`` where *r* is the index of the last
-        occurrence and *s* is the multiplicity.
-
-    Raises:
-        ValueError: If *knot_value* is not found in the knot vector.
-    """
-    unique_knots, mults = _get_unique_knots_and_multiplicity_impl(
-        knots, degree, tol, in_domain=False
-    )
-
-    # Find the matching unique knot.
-    matches = np.where(np.isclose(unique_knots, knot_value, atol=tol))[0]
-    if len(matches) == 0:
-        raise ValueError(f"Knot value {knot_value} not found in knot vector (tolerance={tol}).")
-
-    idx = int(matches[0])
-    s = int(mults[idx])
-
-    # Compute the last index r of this knot value in the full knot vector.
-    # Sum multiplicities up to and including this knot.
-    r = int(np.sum(mults[: idx + 1])) - 1
-
-    return r, s
 
 
 def _remove_knot_bspline_1d_impl(  # noqa: PLR0913

--- a/src/pantr/bspline/_bspline_knot_removal_core.py
+++ b/src/pantr/bspline/_bspline_knot_removal_core.py
@@ -1,0 +1,196 @@
+"""Numba kernel for B-spline knot removal (Algorithm A5.8, Piegl & Tiller).
+
+Implements single-knot removal with tolerance-based acceptance: given a knot
+value, its index, and current multiplicity, attempts up to ``num`` removals,
+accepting each only when the geometric deviation stays within the specified
+tolerance.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call the Layer 2 helpers in ``_bspline_knot_removal`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit
+
+
+@nb_jit(nopython=True, cache=True)
+def _remove_knot_1d_core(  # noqa: PLR0912, PLR0913, PLR0915
+    degree: int,
+    knots: npt.NDArray[Any],
+    ctrl: npt.NDArray[Any],
+    knot_value: float,
+    knot_index: int,
+    multiplicity: int,
+    num: int,
+    tol: float,
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any], int]:
+    """Remove a single knot value up to *num* times from a 1D B-spline.
+
+    Implements Algorithm A5.8 from *The NURBS Book* (Piegl & Tiller, 1997).
+    Each removal is accepted only if the resulting geometric deviation does not
+    exceed *tol*.
+
+    Args:
+        degree (int): Polynomial degree.
+        knots (npt.NDArray[Any]): Knot vector of shape ``(n + degree + 2,)``.
+        ctrl (npt.NDArray[Any]): Control points of shape ``(n + 1, rank)``.
+        knot_value (float): The knot value to remove.
+        knot_index (int): Index *r* such that ``knots[r] == knot_value`` and
+            ``knots[r] != knots[r + 1]`` (i.e. the last occurrence).
+        multiplicity (int): Current multiplicity *s* of *knot_value*.
+        num (int): Maximum number of removals to attempt.
+        tol (float): Maximum allowed Euclidean distance between the two
+            intermediate control-point approximations.
+
+    Returns:
+        tuple[npt.NDArray[Any], npt.NDArray[Any], int]: ``(new_knots, new_ctrl,
+        removals)`` where *removals* is the number of knots actually removed
+        (``0 <= removals <= num``).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call ``_remove_knot_bspline_1d_impl`` instead.
+    """
+    n = ctrl.shape[0] - 1  # last control point index
+    rank = ctrl.shape[1]
+    m = n + degree + 1  # last knot index
+    order = degree + 1
+    r = knot_index
+    s = multiplicity
+
+    # Work on copies so the originals are not modified.
+    work_knots = knots.copy()
+    work_ctrl = ctrl.copy()
+
+    # Temporary control point buffer (maximum size needed: 2*degree+1 rows).
+    temp = np.empty((2 * degree + 1, rank), dtype=ctrl.dtype)
+
+    fout = (2 * r - s - degree) // 2  # first output row that changes
+    first = r - degree
+    last = r - s
+
+    removals = 0
+    for t in range(num):
+        off = first - 1
+        # Seed the temp buffer.
+        for d in range(rank):
+            temp[0, d] = work_ctrl[off, d]
+            temp[last + 1 - off, d] = work_ctrl[last + 1, d]
+
+        # Compute new control points from both sides.
+        i = first
+        ii = 1
+        j = last
+        jj = last - off
+
+        while j - i > t:
+            denom_i = work_knots[i + order + t] - work_knots[i]
+            alpha_i = (knot_value - work_knots[i]) / denom_i if denom_i != 0.0 else 0.0
+
+            denom_j = work_knots[j + order] - work_knots[j - t]
+            alpha_j = (knot_value - work_knots[j - t]) / denom_j if denom_j != 0.0 else 0.0
+
+            for d in range(rank):
+                temp[ii, d] = (work_ctrl[i, d] - (1.0 - alpha_i) * temp[ii - 1, d]) / alpha_i
+                temp[jj, d] = (work_ctrl[j, d] - alpha_j * temp[jj + 1, d]) / (1.0 - alpha_j)
+
+            i += 1
+            ii += 1
+            j -= 1
+            jj -= 1
+
+        # Check deviation.
+        accepted = False
+        if j - i < t:
+            # Odd case: check distance between the two meeting points.
+            dist = 0.0
+            for d in range(rank):
+                diff = temp[ii - 1, d] - temp[jj + 1, d]
+                dist += diff * diff
+            dist = np.sqrt(dist)
+            if dist <= tol:
+                accepted = True
+        else:
+            # Even case: check blended point against both-side approximation.
+            denom_i = work_knots[i + order + t] - work_knots[i]
+            alpha_i = (knot_value - work_knots[i]) / denom_i if denom_i != 0.0 else 0.0
+            dist = 0.0
+            for d in range(rank):
+                blended = alpha_i * temp[ii + t + 1, d] + (1.0 - alpha_i) * temp[ii - 1, d]
+                diff = work_ctrl[i, d] - blended
+                dist += diff * diff
+            dist = np.sqrt(dist)
+            if dist <= tol:
+                accepted = True
+
+        if not accepted:
+            break
+
+        # Accept the removal: write temp back into work_ctrl.
+        i = first
+        j = last
+        while j - i > t:
+            for d in range(rank):
+                work_ctrl[i, d] = temp[i - off, d]
+                work_ctrl[j, d] = temp[j - off, d]
+            i += 1
+            j -= 1
+
+        first -= 1
+        last += 1
+        removals += 1
+
+    if removals == 0:
+        return knots.copy(), ctrl.copy(), 0
+
+    # Compact the knot vector: shift entries after the removed knots.
+    for k in range(r + 1, m + 1):
+        work_knots[k - removals] = work_knots[k]
+
+    new_n_knots = knots.shape[0] - removals
+    new_knots = work_knots[:new_n_knots].copy()
+
+    # Compact the control points: shift entries to fill removed rows.
+    # Determine the gap boundaries after the alternating shift.
+    j_out = fout
+    i_out = j_out
+    for k in range(1, removals):
+        if k % 2 == 1:
+            i_out += 1
+        else:
+            j_out -= 1
+
+    # In-place shift on work_ctrl: copy entries from i_out+1..n into j_out..
+    dest = j_out
+    for k in range(i_out + 1, n + 1):
+        for d in range(rank):
+            work_ctrl[dest, d] = work_ctrl[k, d]
+        dest += 1
+
+    new_n_ctrl = n + 1 - removals
+    new_ctrl = work_ctrl[:new_n_ctrl].copy()
+
+    return new_knots, new_ctrl, removals
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile numba functions with float64 signatures for faster first call.
+
+    This function triggers compilation of the numba-decorated functions
+    with float64 arrays, ensuring they are cached and ready for use.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+    ctrl = np.array([[0.0, 0.0], [0.25, 1.0], [0.5, 0.5], [1.0, 0.0]], dtype=np.float64)
+    _remove_knot_1d_core(2, knots, ctrl, 0.5, 3, 1, 1, 1e-10)
+
+
+__all__ = [
+    "_remove_knot_1d_core",
+]

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -504,6 +504,49 @@ def _get_knots_ends_and_dtype(
     return start_value, end_value, dtype_obj
 
 
+def _find_knot_index_and_multiplicity(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    knot_value: float,
+    tol: float,
+) -> tuple[int, int]:
+    """Find the last index and multiplicity of a knot value in the knot vector.
+
+    Searches the knot vector for the last occurrence of *knot_value* (within
+    tolerance) and returns its index *r* together with the multiplicity *s*.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): Polynomial degree.
+        knot_value (float): The knot value to locate.
+        tol (float): Tolerance for numerical comparisons.
+
+    Returns:
+        tuple[int, int]: ``(r, s)`` where *r* is the index of the last
+        occurrence and *s* is the multiplicity.
+
+    Raises:
+        ValueError: If *knot_value* is not found in the knot vector.
+    """
+    unique_knots, mults = _get_unique_knots_and_multiplicity_impl(
+        knots, degree, tol, in_domain=False
+    )
+
+    # Find the matching unique knot.
+    matches = np.where(np.isclose(unique_knots, knot_value, atol=tol))[0]
+    if len(matches) == 0:
+        raise ValueError(f"Knot value {knot_value} not found in knot vector (tolerance={tol}).")
+
+    idx = int(matches[0])
+    s = int(mults[idx])
+
+    # Compute the last index r of this knot value in the full knot vector.
+    # Sum multiplicities up to and including this knot.
+    r = int(np.sum(mults[: idx + 1])) - 1
+
+    return r, s
+
+
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
@@ -536,6 +579,7 @@ def _warmup_numba_functions() -> None:
 
 __all__ = [
     "_check_spline_info",
+    "_find_knot_index_and_multiplicity",
     "_get_Bspline_cardinal_intervals_1D_impl",
     "_get_Bspline_num_basis_1D_impl",
     "_get_knots_ends_and_dtype",

--- a/tests/test_bezier_reverse_permute.py
+++ b/tests/test_bezier_reverse_permute.py
@@ -1,0 +1,188 @@
+"""Tests for reverse and permute_directions methods on Bezier."""
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bezier_2d_surface() -> Bezier:
+    """Create a 2D Bezier surface with distinct control points.
+
+    Degree (2, 1), rank 3 — a surface in 3D space.
+    Shape: (3, 2, 3).
+    """
+    cp = np.arange(18, dtype=np.float64).reshape(3, 2, 3)
+    return Bezier(cp)
+
+
+def _make_bezier_3d_volume() -> Bezier:
+    """Create a 3D Bezier volume with distinct control points.
+
+    Degree (1, 2, 1), rank 1 — a scalar volume.
+    Shape: (2, 3, 2, 1).
+    """
+    cp = np.arange(12, dtype=np.float64).reshape(2, 3, 2, 1)
+    return Bezier(cp)
+
+
+# ===========================================================================
+# Bezier — reverse
+# ===========================================================================
+
+
+class TestBezierReverse:
+    """Test Bezier.reverse()."""
+
+    def test_reverse_1d(self) -> None:
+        """Reversing a 1D Bezier flips control points."""
+        cp = np.array([[1.0], [2.0], [3.0]])
+        b = Bezier(cp)
+        rev = b.reverse()
+        np.testing.assert_array_equal(rev.control_points, cp[::-1])
+        assert rev is not b
+
+    def test_reverse_2d_direction_0(self) -> None:
+        """Reversing direction 0 of a 2D surface flips first axis."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=0)
+        expected = np.flip(b.control_points, axis=0)
+        np.testing.assert_array_equal(rev.control_points, expected)
+
+    def test_reverse_2d_direction_1(self) -> None:
+        """Reversing direction 1 of a 2D surface flips second axis."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=1)
+        expected = np.flip(b.control_points, axis=1)
+        np.testing.assert_array_equal(rev.control_points, expected)
+
+    def test_reverse_preserves_properties(self) -> None:
+        """Reversing preserves degree, dim, rank, dtype, is_rational."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=0)
+        assert rev.dim == b.dim
+        assert rev.degree == b.degree
+        assert rev.rank == b.rank
+        assert rev.dtype == b.dtype
+        assert rev.is_rational == b.is_rational
+
+    def test_reverse_rational(self) -> None:
+        """Reversing a rational Bezier flips control points including weights."""
+        cp = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 2.0]])
+        b = Bezier(cp, is_rational=True)
+        rev = b.reverse()
+        np.testing.assert_array_equal(rev.control_points, cp[::-1])
+        assert rev.is_rational is True
+
+    def test_reverse_in_place(self) -> None:
+        """in_place=True modifies the original and returns None."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.reverse(direction=0, in_place=True)
+        assert result is None
+        expected = np.flip(original_cp, axis=0)
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_reverse_double_is_identity(self) -> None:
+        """Reversing the same direction twice yields the original."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        rev2 = b.reverse(direction=1).reverse(direction=1)
+        np.testing.assert_array_equal(rev2.control_points, original_cp)
+
+    def test_reverse_invalid_direction(self) -> None:
+        """Raises ValueError for out-of-range direction."""
+        b = _make_bezier_2d_surface()
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=2)
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=-1)
+
+    def test_reverse_evaluates_correctly(self) -> None:
+        """Reversed Bezier evaluates as b(1-t) in that direction."""
+        cp = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 1.0]])
+        b = Bezier(cp)
+        rev = b.reverse()
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        vals_b = b.evaluate(pts)
+        vals_rev = rev.evaluate(1.0 - pts)
+        np.testing.assert_allclose(vals_b, vals_rev, atol=1e-14)
+
+
+# ===========================================================================
+# Bezier — permute_directions
+# ===========================================================================
+
+
+class TestBezierPermuteDirections:
+    """Test Bezier.permute_directions()."""
+
+    def test_permute_2d_swap(self) -> None:
+        """Swapping directions of a 2D surface transposes parametric axes."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([1, 0])
+        expected = np.transpose(b.control_points, (1, 0, 2))
+        np.testing.assert_array_equal(perm.control_points, expected)
+        assert perm.degree == (b.degree[1], b.degree[0])
+
+    def test_permute_3d_cyclic(self) -> None:
+        """Cyclic permutation [1,2,0] on a 3D volume."""
+        b = _make_bezier_3d_volume()
+        perm = b.permute_directions([1, 2, 0])
+        expected = np.transpose(b.control_points, (1, 2, 0, 3))
+        np.testing.assert_array_equal(perm.control_points, expected)
+        assert perm.degree == (b.degree[1], b.degree[2], b.degree[0])
+
+    def test_permute_identity(self) -> None:
+        """Identity permutation [0, 1] is a no-op."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([0, 1])
+        np.testing.assert_array_equal(perm.control_points, b.control_points)
+
+    def test_permute_preserves_properties(self) -> None:
+        """Permutation preserves dim, rank, dtype, is_rational."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([1, 0])
+        assert perm.dim == b.dim
+        assert perm.rank == b.rank
+        assert perm.dtype == b.dtype
+        assert perm.is_rational == b.is_rational
+
+    def test_permute_in_place(self) -> None:
+        """in_place=True modifies the original and returns None."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.permute_directions([1, 0], in_place=True)
+        assert result is None
+        expected = np.transpose(original_cp, (1, 0, 2))
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_permute_inverse_is_identity(self) -> None:
+        """Applying a permutation then its inverse recovers the original."""
+        b = _make_bezier_3d_volume()
+        original_cp = b.control_points.copy()
+        perm = [1, 2, 0]
+        inv_perm = [2, 0, 1]  # inverse of [1, 2, 0]
+        result = b.permute_directions(perm).permute_directions(inv_perm)
+        np.testing.assert_array_equal(result.control_points, original_cp)
+
+    def test_permute_invalid_permutation(self) -> None:
+        """Raises ValueError for invalid permutations."""
+        b = _make_bezier_2d_surface()
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 0])
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 1, 2])
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([1])
+
+    def test_permute_1d_identity(self) -> None:
+        """1D Bezier with [0] is a no-op."""
+        cp = np.array([[1.0], [2.0], [3.0]])
+        b = Bezier(cp)
+        perm = b.permute_directions([0])
+        np.testing.assert_array_equal(perm.control_points, b.control_points)

--- a/tests/test_bspline_reverse_permute.py
+++ b/tests/test_bspline_reverse_permute.py
@@ -1,34 +1,13 @@
-"""Tests for reverse and permute_directions methods on Bezier and Bspline."""
+"""Tests for reverse and permute_directions methods on Bspline."""
 
 import numpy as np
 import pytest
 
-from pantr.bezier import Bezier
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_bezier_2d_surface() -> Bezier:
-    """Create a 2D Bezier surface with distinct control points.
-
-    Degree (2, 1), rank 3 — a surface in 3D space.
-    Shape: (3, 2, 3).
-    """
-    cp = np.arange(18, dtype=np.float64).reshape(3, 2, 3)
-    return Bezier(cp)
-
-
-def _make_bezier_3d_volume() -> Bezier:
-    """Create a 3D Bezier volume with distinct control points.
-
-    Degree (1, 2, 1), rank 1 — a scalar volume.
-    Shape: (2, 3, 2, 1).
-    """
-    cp = np.arange(12, dtype=np.float64).reshape(2, 3, 2, 1)
-    return Bezier(cp)
 
 
 def _make_bspline_2d_surface() -> Bspline:
@@ -61,164 +40,6 @@ def _make_bspline_3d_volume() -> Bspline:
     # num_basis = (2, 3, 3), rank = 1 -> shape (2, 3, 3, 1)
     cp = np.arange(18, dtype=np.float64).reshape(2, 3, 3, 1)
     return Bspline(space, cp)
-
-
-# ===========================================================================
-# Bezier — reverse
-# ===========================================================================
-
-
-class TestBezierReverse:
-    """Test Bezier.reverse()."""
-
-    def test_reverse_1d(self) -> None:
-        """Reversing a 1D Bezier flips control points."""
-        cp = np.array([[1.0], [2.0], [3.0]])
-        b = Bezier(cp)
-        rev = b.reverse()
-        np.testing.assert_array_equal(rev.control_points, cp[::-1])
-        assert rev is not b
-
-    def test_reverse_2d_direction_0(self) -> None:
-        """Reversing direction 0 of a 2D surface flips first axis."""
-        b = _make_bezier_2d_surface()
-        rev = b.reverse(direction=0)
-        expected = np.flip(b.control_points, axis=0)
-        np.testing.assert_array_equal(rev.control_points, expected)
-
-    def test_reverse_2d_direction_1(self) -> None:
-        """Reversing direction 1 of a 2D surface flips second axis."""
-        b = _make_bezier_2d_surface()
-        rev = b.reverse(direction=1)
-        expected = np.flip(b.control_points, axis=1)
-        np.testing.assert_array_equal(rev.control_points, expected)
-
-    def test_reverse_preserves_properties(self) -> None:
-        """Reversing preserves degree, dim, rank, dtype, is_rational."""
-        b = _make_bezier_2d_surface()
-        rev = b.reverse(direction=0)
-        assert rev.dim == b.dim
-        assert rev.degree == b.degree
-        assert rev.rank == b.rank
-        assert rev.dtype == b.dtype
-        assert rev.is_rational == b.is_rational
-
-    def test_reverse_rational(self) -> None:
-        """Reversing a rational Bezier flips control points including weights."""
-        cp = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 2.0]])
-        b = Bezier(cp, is_rational=True)
-        rev = b.reverse()
-        np.testing.assert_array_equal(rev.control_points, cp[::-1])
-        assert rev.is_rational is True
-
-    def test_reverse_in_place(self) -> None:
-        """in_place=True modifies the original and returns None."""
-        b = _make_bezier_2d_surface()
-        original_cp = b.control_points.copy()
-        result = b.reverse(direction=0, in_place=True)
-        assert result is None
-        expected = np.flip(original_cp, axis=0)
-        np.testing.assert_array_equal(b.control_points, expected)
-
-    def test_reverse_double_is_identity(self) -> None:
-        """Reversing the same direction twice yields the original."""
-        b = _make_bezier_2d_surface()
-        original_cp = b.control_points.copy()
-        rev2 = b.reverse(direction=1).reverse(direction=1)
-        np.testing.assert_array_equal(rev2.control_points, original_cp)
-
-    def test_reverse_invalid_direction(self) -> None:
-        """Raises ValueError for out-of-range direction."""
-        b = _make_bezier_2d_surface()
-        with pytest.raises(ValueError, match="direction must be in"):
-            b.reverse(direction=2)
-        with pytest.raises(ValueError, match="direction must be in"):
-            b.reverse(direction=-1)
-
-    def test_reverse_evaluates_correctly(self) -> None:
-        """Reversed Bezier evaluates as b(1-t) in that direction."""
-        cp = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 1.0]])
-        b = Bezier(cp)
-        rev = b.reverse()
-        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
-        vals_b = b.evaluate(pts)
-        vals_rev = rev.evaluate(1.0 - pts)
-        np.testing.assert_allclose(vals_b, vals_rev, atol=1e-14)
-
-
-# ===========================================================================
-# Bezier — permute_directions
-# ===========================================================================
-
-
-class TestBezierPermuteDirections:
-    """Test Bezier.permute_directions()."""
-
-    def test_permute_2d_swap(self) -> None:
-        """Swapping directions of a 2D surface transposes parametric axes."""
-        b = _make_bezier_2d_surface()
-        perm = b.permute_directions([1, 0])
-        expected = np.transpose(b.control_points, (1, 0, 2))
-        np.testing.assert_array_equal(perm.control_points, expected)
-        assert perm.degree == (b.degree[1], b.degree[0])
-
-    def test_permute_3d_cyclic(self) -> None:
-        """Cyclic permutation [1,2,0] on a 3D volume."""
-        b = _make_bezier_3d_volume()
-        perm = b.permute_directions([1, 2, 0])
-        expected = np.transpose(b.control_points, (1, 2, 0, 3))
-        np.testing.assert_array_equal(perm.control_points, expected)
-        assert perm.degree == (b.degree[1], b.degree[2], b.degree[0])
-
-    def test_permute_identity(self) -> None:
-        """Identity permutation [0, 1] is a no-op."""
-        b = _make_bezier_2d_surface()
-        perm = b.permute_directions([0, 1])
-        np.testing.assert_array_equal(perm.control_points, b.control_points)
-
-    def test_permute_preserves_properties(self) -> None:
-        """Permutation preserves dim, rank, dtype, is_rational."""
-        b = _make_bezier_2d_surface()
-        perm = b.permute_directions([1, 0])
-        assert perm.dim == b.dim
-        assert perm.rank == b.rank
-        assert perm.dtype == b.dtype
-        assert perm.is_rational == b.is_rational
-
-    def test_permute_in_place(self) -> None:
-        """in_place=True modifies the original and returns None."""
-        b = _make_bezier_2d_surface()
-        original_cp = b.control_points.copy()
-        result = b.permute_directions([1, 0], in_place=True)
-        assert result is None
-        expected = np.transpose(original_cp, (1, 0, 2))
-        np.testing.assert_array_equal(b.control_points, expected)
-
-    def test_permute_inverse_is_identity(self) -> None:
-        """Applying a permutation then its inverse recovers the original."""
-        b = _make_bezier_3d_volume()
-        original_cp = b.control_points.copy()
-        perm = [1, 2, 0]
-        inv_perm = [2, 0, 1]  # inverse of [1, 2, 0]
-        result = b.permute_directions(perm).permute_directions(inv_perm)
-        np.testing.assert_array_equal(result.control_points, original_cp)
-
-    def test_permute_invalid_permutation(self) -> None:
-        """Raises ValueError for invalid permutations."""
-        b = _make_bezier_2d_surface()
-        with pytest.raises(ValueError, match="permutation must be a permutation"):
-            b.permute_directions([0, 0])
-        with pytest.raises(ValueError, match="permutation must be a permutation"):
-            b.permute_directions([0, 1, 2])
-        with pytest.raises(ValueError, match="permutation must be a permutation"):
-            b.permute_directions([1])
-
-    def test_permute_1d_identity(self) -> None:
-        """1D Bezier with [0] is a no-op."""
-        cp = np.array([[1.0], [2.0], [3.0]])
-        b = Bezier(cp)
-        perm = b.permute_directions([0])
-        np.testing.assert_array_equal(perm.control_points, b.control_points)
 
 
 # ===========================================================================

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -1,0 +1,307 @@
+"""Tests for B-spline knot removal."""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_curve_p2() -> Bspline:
+    """Create a degree-2 B-spline curve with 4 control points in 3D.
+
+    Knots: [0,0,0,0.5,1,1,1] -> 4 basis functions, degree 2.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    cp = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 0.0], [2.0, 1.0, 0.0], [3.0, 0.0, 0.0]])
+    return Bspline(space, cp)
+
+
+def _make_curve_p3() -> Bspline:
+    """Create a degree-3 B-spline curve with 5 control points in 2D.
+
+    Knots: [0,0,0,0,0.5,1,1,1,1] -> 5 basis, degree 3.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0])
+    space = BsplineSpace([BsplineSpace1D(knots, 3)])
+    cp = np.array([[0.0, 0.0], [1.0, 3.0], [2.0, 2.0], [3.0, 3.0], [4.0, 0.0]])
+    return Bspline(space, cp)
+
+
+def _make_surface() -> Bspline:
+    """Create a 2D B-spline surface with an interior knot in the u-direction.
+
+    Degree (2, 1), rank 2.
+    """
+    knots_u = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+    knots_v = np.array([0.0, 0.0, 1.0, 1.0])
+    space_u = BsplineSpace1D(knots_u, 2)
+    space_v = BsplineSpace1D(knots_v, 1)
+    space = BsplineSpace([space_u, space_v])
+    cp = np.arange(16, dtype=np.float64).reshape(4, 2, 2)
+    return Bspline(space, cp)
+
+
+def _assert_same_geometry(a: Bspline, b: Bspline, atol: float = 1e-12) -> None:
+    """Assert two B-splines represent the same geometry via knot insertion.
+
+    Inserts all knots from ``b`` into ``a`` and vice versa to get a common
+    representation, then compares control points.
+    """
+    for i in range(a.dim):
+        knots_a = a.space.spaces[i].knots
+        knots_b = b.space.spaces[i].knots
+
+        # Knots to insert into a to match b.
+        extra_b = _knot_difference(knots_b, knots_a, atol)
+        if extra_b.size > 0:
+            insert_a: list[npt.NDArray[np.float32 | np.float64] | None] = [None] * a.dim
+            insert_a[i] = extra_b
+            a = a.insert_knots(insert_a)
+
+        # Knots to insert into b to match a.
+        extra_a = _knot_difference(knots_a, knots_b, atol)
+        if extra_a.size > 0:
+            insert_b: list[npt.NDArray[np.float32 | np.float64] | None] = [None] * b.dim
+            insert_b[i] = extra_a
+            b = b.insert_knots(insert_b)
+
+    np.testing.assert_allclose(a.control_points, b.control_points, atol=atol)
+
+
+def _knot_difference(
+    knots_a: npt.NDArray[np.float32 | np.float64],
+    knots_b: npt.NDArray[np.float32 | np.float64],
+    atol: float,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return knots in ``a`` that are not in ``b`` (with multiplicity)."""
+    remaining = list(knots_b)
+    diff = []
+    for val in knots_a:
+        found = False
+        for j, rem in enumerate(remaining):
+            if abs(val - rem) <= atol:
+                remaining.pop(j)
+                found = True
+                break
+        if not found:
+            diff.append(val)
+    return np.array(diff, dtype=knots_a.dtype)
+
+
+# ===========================================================================
+# Round-trip: insert then remove
+# ===========================================================================
+
+
+class TestRoundTrip:
+    """Insert knots, then remove them, and verify geometry is preserved."""
+
+    def test_insert_remove_single_knot_p2(self) -> None:
+        """Insert then remove a single knot on a degree-2 curve."""
+        orig = _make_curve_p2()
+        refined = orig.insert_knots(np.array([0.25]))
+        reduced = refined.remove_knots(0.25)
+
+        # Knot vectors should match original.
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, orig.space.spaces[0].knots, atol=1e-14
+        )
+        # Control points should match original.
+        np.testing.assert_allclose(reduced.control_points, orig.control_points, atol=1e-12)
+
+    def test_insert_remove_single_knot_p3(self) -> None:
+        """Insert then remove a single knot on a degree-3 curve."""
+        orig = _make_curve_p3()
+        refined = orig.insert_knots(np.array([0.25]))
+        reduced = refined.remove_knots(0.25)
+
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, orig.space.spaces[0].knots, atol=1e-14
+        )
+        np.testing.assert_allclose(reduced.control_points, orig.control_points, atol=1e-12)
+
+    def test_insert_remove_multiple_same_knot(self) -> None:
+        """Insert a knot twice, then remove it twice."""
+        orig = _make_curve_p3()
+        refined = orig.insert_knots(np.array([0.3, 0.3]))
+        reduced = refined.remove_knots(0.3, num=2)
+
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, orig.space.spaces[0].knots, atol=1e-14
+        )
+        np.testing.assert_allclose(reduced.control_points, orig.control_points, atol=1e-12)
+
+    def test_insert_remove_multiple_distinct_knots(self) -> None:
+        """Insert two different knots, then remove both."""
+        orig = _make_curve_p3()
+        refined = orig.insert_knots(np.array([0.25, 0.75]))
+        reduced = refined.remove_knots(np.array([0.25, 0.75]))
+
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, orig.space.spaces[0].knots, atol=1e-14
+        )
+        np.testing.assert_allclose(reduced.control_points, orig.control_points, atol=1e-12)
+
+    def test_remove_existing_knot_preserves_geometry(self) -> None:
+        """Removing an original interior knot still preserves geometry (within tol)."""
+        orig = _make_curve_p2()
+        reduced = orig.remove_knots(0.5)
+        _assert_same_geometry(orig, reduced)
+
+
+# ===========================================================================
+# Partial removal
+# ===========================================================================
+
+
+class TestPartialRemoval:
+    """Test removing fewer knots than the full multiplicity."""
+
+    def test_remove_one_of_two(self) -> None:
+        """Insert a knot twice, remove only once — multiplicity drops by 1."""
+        orig = _make_curve_p3()
+        refined = orig.insert_knots(np.array([0.3, 0.3]))
+
+        reduced = refined.remove_knots(0.3, num=1)
+
+        # One copy should remain.
+        knots = reduced.space.spaces[0].knots
+        count = np.sum(np.isclose(knots, 0.3, atol=1e-12))
+        assert count == 1
+
+    def test_num_none_removes_all(self) -> None:
+        """num=None should remove as many times as possible."""
+        orig = _make_curve_p3()
+        refined = orig.insert_knots(np.array([0.3, 0.3]))
+
+        reduced = refined.remove_knots(0.3, num=None)
+
+        knots = reduced.space.spaces[0].knots
+        count = np.sum(np.isclose(knots, 0.3, atol=1e-12))
+        assert count == 0
+
+
+# ===========================================================================
+# Multi-dimensional
+# ===========================================================================
+
+
+class TestMultiDim:
+    """Test knot removal on multi-dimensional B-splines."""
+
+    def test_surface_remove_u_direction(self) -> None:
+        """Remove an inserted interior knot from the u-direction of a surface."""
+        orig = _make_surface()
+        refined = orig.insert_knots([np.array([0.25]), None])
+        reduced = refined.remove_knots([np.array([0.25]), None])
+
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, orig.space.spaces[0].knots, atol=1e-14
+        )
+        np.testing.assert_allclose(reduced.control_points, orig.control_points, atol=1e-12)
+
+
+# ===========================================================================
+# Rational (NURBS) support
+# ===========================================================================
+
+
+class TestRational:
+    """Test knot removal on rational B-splines (NURBS)."""
+
+    def test_nurbs_round_trip(self) -> None:
+        """Insert then remove a knot on a NURBS curve."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        # Homogeneous coords: (w*x, w*y, w) — a rational quadratic.
+        cp = np.array([[0.0, 0.0, 1.0], [1.0, 2.0, 0.5], [2.0, 0.0, 1.0]])
+        nurbs = Bspline(space, cp, is_rational=True)
+
+        refined = nurbs.insert_knots(np.array([0.5]))
+        reduced = refined.remove_knots(0.5)
+
+        np.testing.assert_allclose(
+            reduced.space.spaces[0].knots, nurbs.space.spaces[0].knots, atol=1e-14
+        )
+        np.testing.assert_allclose(reduced.control_points, nurbs.control_points, atol=1e-12)
+
+
+# ===========================================================================
+# Error handling
+# ===========================================================================
+
+
+class TestErrors:
+    """Test error conditions for remove_knots."""
+
+    def test_knot_not_found(self) -> None:
+        """Requesting removal of a non-existent knot raises ValueError."""
+        b = _make_curve_p2()
+        with pytest.raises(ValueError, match="not found"):
+            b.remove_knots(0.123)
+
+    def test_boundary_knot(self) -> None:
+        """Attempting to remove a boundary knot raises ValueError."""
+        b = _make_curve_p2()
+        with pytest.raises(ValueError, match="boundary knot"):
+            b.remove_knots(0.0)
+
+    def test_boundary_knot_end(self) -> None:
+        """Attempting to remove the end boundary knot raises ValueError."""
+        b = _make_curve_p2()
+        with pytest.raises(ValueError, match="boundary knot"):
+            b.remove_knots(1.0)
+
+    def test_empty_knot_values(self) -> None:
+        """Empty knot_values array raises ValueError."""
+        b = _make_curve_p2()
+        with pytest.raises(ValueError, match="non-empty"):
+            b.remove_knots(np.array([]))
+
+    def test_dim_mismatch(self) -> None:
+        """Wrong number of direction arrays raises ValueError."""
+        srf = _make_surface()
+        with pytest.raises(ValueError, match="must match dim"):
+            srf.remove_knots([np.array([0.5])])  # only 1 direction, need 2
+
+    def test_periodic_not_supported(self) -> None:
+        """Periodic B-splines raise ValueError."""
+        knots = np.array([-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5])
+        space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+        cp = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]])
+        b = Bspline(space, cp)
+        with pytest.raises(ValueError, match="periodic"):
+            b.remove_knots(0.5)
+
+    def test_num_zero_raises(self) -> None:
+        """num=0 raises ValueError."""
+        b = _make_curve_p2()
+        with pytest.raises(ValueError, match="positive"):
+            b.remove_knots(0.5, num=0)
+
+
+# ===========================================================================
+# Tolerance rejection
+# ===========================================================================
+
+
+class TestToleranceRejection:
+    """Test that tight tolerances prevent removals that would distort geometry."""
+
+    def test_tight_tolerance_prevents_removal(self) -> None:
+        """A knot that exists in the original cannot be removed with tol=0."""
+        b = _make_curve_p2()
+        # The knot 0.5 is part of the original spline definition.
+        # Removing it changes the geometry, so with tol=0 it should fail to remove.
+        result = b.remove_knots(0.5, tol=0.0)
+        # With zero tolerance, geometry must be preserved exactly.
+        # The knot should still be present (removal was rejected).
+        knots = result.space.spaces[0].knots
+        count = np.sum(np.isclose(knots, 0.5, atol=1e-14))
+        assert count == 1

--- a/tests/test_reverse_permute.py
+++ b/tests/test_reverse_permute.py
@@ -112,11 +112,11 @@ class TestBezierReverse:
         assert rev.is_rational is True
 
     def test_reverse_in_place(self) -> None:
-        """in_place=True modifies the original and returns self."""
+        """in_place=True modifies the original and returns None."""
         b = _make_bezier_2d_surface()
         original_cp = b.control_points.copy()
         result = b.reverse(direction=0, in_place=True)
-        assert result is b
+        assert result is None
         expected = np.flip(original_cp, axis=0)
         np.testing.assert_array_equal(b.control_points, expected)
 
@@ -186,11 +186,11 @@ class TestBezierPermuteDirections:
         assert perm.is_rational == b.is_rational
 
     def test_permute_in_place(self) -> None:
-        """in_place=True modifies the original and returns self."""
+        """in_place=True modifies the original and returns None."""
         b = _make_bezier_2d_surface()
         original_cp = b.control_points.copy()
         result = b.permute_directions([1, 0], in_place=True)
-        assert result is b
+        assert result is None
         expected = np.transpose(original_cp, (1, 0, 2))
         np.testing.assert_array_equal(b.control_points, expected)
 
@@ -279,11 +279,11 @@ class TestBsplineReverse:
         assert rev.is_rational == b.is_rational
 
     def test_reverse_in_place(self) -> None:
-        """in_place=True modifies original and returns self."""
+        """in_place=True modifies original and returns None."""
         b = _make_bspline_2d_surface()
         original_cp = b.control_points.copy()
         result = b.reverse(direction=0, in_place=True)
-        assert result is b
+        assert result is None
         expected = np.flip(original_cp, axis=0)
         np.testing.assert_array_equal(b.control_points, expected)
 
@@ -383,11 +383,11 @@ class TestBsplinePermuteDirections:
         assert perm.is_rational == b.is_rational
 
     def test_permute_in_place(self) -> None:
-        """in_place=True modifies original and returns self."""
+        """in_place=True modifies original and returns None."""
         b = _make_bspline_2d_surface()
         original_cp = b.control_points.copy()
         result = b.permute_directions([1, 0], in_place=True)
-        assert result is b
+        assert result is None
         expected = np.transpose(original_cp, (1, 0, 2))
         np.testing.assert_array_equal(b.control_points, expected)
 

--- a/tests/test_reverse_permute.py
+++ b/tests/test_reverse_permute.py
@@ -1,0 +1,422 @@
+"""Tests for reverse and permute_directions methods on Bezier and Bspline."""
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bezier_2d_surface() -> Bezier:
+    """Create a 2D Bezier surface with distinct control points.
+
+    Degree (2, 1), rank 3 — a surface in 3D space.
+    Shape: (3, 2, 3).
+    """
+    cp = np.arange(18, dtype=np.float64).reshape(3, 2, 3)
+    return Bezier(cp)
+
+
+def _make_bezier_3d_volume() -> Bezier:
+    """Create a 3D Bezier volume with distinct control points.
+
+    Degree (1, 2, 1), rank 1 — a scalar volume.
+    Shape: (2, 3, 2, 1).
+    """
+    cp = np.arange(12, dtype=np.float64).reshape(2, 3, 2, 1)
+    return Bezier(cp)
+
+
+def _make_bspline_2d_surface() -> Bspline:
+    """Create a 2D Bspline surface with distinct control points.
+
+    Degree (2, 1), rank 2 — a surface in 2D space.
+    """
+    knots_u = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+    knots_v = np.array([0.0, 0.0, 1.0, 1.0])
+    space_u = BsplineSpace1D(knots_u, 2)
+    space_v = BsplineSpace1D(knots_v, 1)
+    space = BsplineSpace([space_u, space_v])
+    # num_basis = (4, 2), rank = 2 -> shape (4, 2, 2)
+    cp = np.arange(16, dtype=np.float64).reshape(4, 2, 2)
+    return Bspline(space, cp)
+
+
+def _make_bspline_3d_volume() -> Bspline:
+    """Create a 3D Bspline volume with distinct control points.
+
+    Degree (1, 2, 1), rank 1 — a scalar volume.
+    """
+    knots_u = np.array([0.0, 0.0, 1.0, 1.0])
+    knots_v = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+    knots_w = np.array([0.0, 0.0, 0.5, 1.0, 1.0])
+    space_u = BsplineSpace1D(knots_u, 1)
+    space_v = BsplineSpace1D(knots_v, 2)
+    space_w = BsplineSpace1D(knots_w, 1)
+    space = BsplineSpace([space_u, space_v, space_w])
+    # num_basis = (2, 3, 3), rank = 1 -> shape (2, 3, 3, 1)
+    cp = np.arange(18, dtype=np.float64).reshape(2, 3, 3, 1)
+    return Bspline(space, cp)
+
+
+# ===========================================================================
+# Bezier — reverse
+# ===========================================================================
+
+
+class TestBezierReverse:
+    """Test Bezier.reverse()."""
+
+    def test_reverse_1d(self) -> None:
+        """Reversing a 1D Bezier flips control points."""
+        cp = np.array([[1.0], [2.0], [3.0]])
+        b = Bezier(cp)
+        rev = b.reverse()
+        np.testing.assert_array_equal(rev.control_points, cp[::-1])
+        assert rev is not b
+
+    def test_reverse_2d_direction_0(self) -> None:
+        """Reversing direction 0 of a 2D surface flips first axis."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=0)
+        expected = np.flip(b.control_points, axis=0)
+        np.testing.assert_array_equal(rev.control_points, expected)
+
+    def test_reverse_2d_direction_1(self) -> None:
+        """Reversing direction 1 of a 2D surface flips second axis."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=1)
+        expected = np.flip(b.control_points, axis=1)
+        np.testing.assert_array_equal(rev.control_points, expected)
+
+    def test_reverse_preserves_properties(self) -> None:
+        """Reversing preserves degree, dim, rank, dtype, is_rational."""
+        b = _make_bezier_2d_surface()
+        rev = b.reverse(direction=0)
+        assert rev.dim == b.dim
+        assert rev.degree == b.degree
+        assert rev.rank == b.rank
+        assert rev.dtype == b.dtype
+        assert rev.is_rational == b.is_rational
+
+    def test_reverse_rational(self) -> None:
+        """Reversing a rational Bezier flips control points including weights."""
+        cp = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 2.0]])
+        b = Bezier(cp, is_rational=True)
+        rev = b.reverse()
+        np.testing.assert_array_equal(rev.control_points, cp[::-1])
+        assert rev.is_rational is True
+
+    def test_reverse_in_place(self) -> None:
+        """in_place=True modifies the original and returns self."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.reverse(direction=0, in_place=True)
+        assert result is b
+        expected = np.flip(original_cp, axis=0)
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_reverse_double_is_identity(self) -> None:
+        """Reversing the same direction twice yields the original."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        rev2 = b.reverse(direction=1).reverse(direction=1)
+        np.testing.assert_array_equal(rev2.control_points, original_cp)
+
+    def test_reverse_invalid_direction(self) -> None:
+        """Raises ValueError for out-of-range direction."""
+        b = _make_bezier_2d_surface()
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=2)
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=-1)
+
+    def test_reverse_evaluates_correctly(self) -> None:
+        """Reversed Bezier evaluates as b(1-t) in that direction."""
+        cp = np.array([[0.0, 0.0], [1.0, 2.0], [3.0, 1.0]])
+        b = Bezier(cp)
+        rev = b.reverse()
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        vals_b = b.evaluate(pts)
+        vals_rev = rev.evaluate(1.0 - pts)
+        np.testing.assert_allclose(vals_b, vals_rev, atol=1e-14)
+
+
+# ===========================================================================
+# Bezier — permute_directions
+# ===========================================================================
+
+
+class TestBezierPermuteDirections:
+    """Test Bezier.permute_directions()."""
+
+    def test_permute_2d_swap(self) -> None:
+        """Swapping directions of a 2D surface transposes parametric axes."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([1, 0])
+        expected = np.transpose(b.control_points, (1, 0, 2))
+        np.testing.assert_array_equal(perm.control_points, expected)
+        assert perm.degree == (b.degree[1], b.degree[0])
+
+    def test_permute_3d_cyclic(self) -> None:
+        """Cyclic permutation [1,2,0] on a 3D volume."""
+        b = _make_bezier_3d_volume()
+        perm = b.permute_directions([1, 2, 0])
+        expected = np.transpose(b.control_points, (1, 2, 0, 3))
+        np.testing.assert_array_equal(perm.control_points, expected)
+        assert perm.degree == (b.degree[1], b.degree[2], b.degree[0])
+
+    def test_permute_identity(self) -> None:
+        """Identity permutation [0, 1] is a no-op."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([0, 1])
+        np.testing.assert_array_equal(perm.control_points, b.control_points)
+
+    def test_permute_preserves_properties(self) -> None:
+        """Permutation preserves dim, rank, dtype, is_rational."""
+        b = _make_bezier_2d_surface()
+        perm = b.permute_directions([1, 0])
+        assert perm.dim == b.dim
+        assert perm.rank == b.rank
+        assert perm.dtype == b.dtype
+        assert perm.is_rational == b.is_rational
+
+    def test_permute_in_place(self) -> None:
+        """in_place=True modifies the original and returns self."""
+        b = _make_bezier_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.permute_directions([1, 0], in_place=True)
+        assert result is b
+        expected = np.transpose(original_cp, (1, 0, 2))
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_permute_inverse_is_identity(self) -> None:
+        """Applying a permutation then its inverse recovers the original."""
+        b = _make_bezier_3d_volume()
+        original_cp = b.control_points.copy()
+        perm = [1, 2, 0]
+        inv_perm = [2, 0, 1]  # inverse of [1, 2, 0]
+        result = b.permute_directions(perm).permute_directions(inv_perm)
+        np.testing.assert_array_equal(result.control_points, original_cp)
+
+    def test_permute_invalid_permutation(self) -> None:
+        """Raises ValueError for invalid permutations."""
+        b = _make_bezier_2d_surface()
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 0])
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 1, 2])
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([1])
+
+    def test_permute_1d_identity(self) -> None:
+        """1D Bezier with [0] is a no-op."""
+        cp = np.array([[1.0], [2.0], [3.0]])
+        b = Bezier(cp)
+        perm = b.permute_directions([0])
+        np.testing.assert_array_equal(perm.control_points, b.control_points)
+
+
+# ===========================================================================
+# Bspline — reverse
+# ===========================================================================
+
+
+class TestBsplineReverse:
+    """Test Bspline.reverse()."""
+
+    def test_reverse_1d(self) -> None:
+        """Reversing a 1D Bspline flips control points and knots."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]])
+        b = Bspline(space, cp)
+        rev = b.reverse()
+
+        np.testing.assert_array_equal(rev.control_points, cp[::-1])
+        expected_knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        np.testing.assert_allclose(rev.space.spaces[0].knots, expected_knots, atol=1e-14)
+        assert rev is not b
+
+    def test_reverse_2d_direction_0(self) -> None:
+        """Reversing direction 0 flips first axis and reverses knots."""
+        b = _make_bspline_2d_surface()
+        rev = b.reverse(direction=0)
+
+        expected_cp = np.flip(b.control_points, axis=0)
+        np.testing.assert_array_equal(rev.control_points, expected_cp)
+
+        # Direction 0 knots reversed, direction 1 unchanged.
+        old_knots_u = b.space.spaces[0].knots
+        a, c = b.space.spaces[0].domain
+        expected_knots_u = (a + c) - old_knots_u[::-1]
+        np.testing.assert_allclose(rev.space.spaces[0].knots, expected_knots_u, atol=1e-14)
+        np.testing.assert_array_equal(rev.space.spaces[1].knots, b.space.spaces[1].knots)
+
+    def test_reverse_2d_direction_1(self) -> None:
+        """Reversing direction 1 flips second axis and reverses knots."""
+        b = _make_bspline_2d_surface()
+        rev = b.reverse(direction=1)
+
+        expected_cp = np.flip(b.control_points, axis=1)
+        np.testing.assert_array_equal(rev.control_points, expected_cp)
+
+        # Direction 0 unchanged, direction 1 knots reversed.
+        np.testing.assert_array_equal(rev.space.spaces[0].knots, b.space.spaces[0].knots)
+
+    def test_reverse_preserves_properties(self) -> None:
+        """Reversing preserves degree, dim, rank, dtype."""
+        b = _make_bspline_2d_surface()
+        rev = b.reverse(direction=0)
+        assert rev.dim == b.dim
+        assert rev.degree == b.degree
+        assert rev.rank == b.rank
+        assert rev.dtype == b.dtype
+        assert rev.is_rational == b.is_rational
+
+    def test_reverse_in_place(self) -> None:
+        """in_place=True modifies original and returns self."""
+        b = _make_bspline_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.reverse(direction=0, in_place=True)
+        assert result is b
+        expected = np.flip(original_cp, axis=0)
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_reverse_double_is_identity(self) -> None:
+        """Reversing the same direction twice yields the original."""
+        b = _make_bspline_2d_surface()
+        original_cp = b.control_points.copy()
+        original_knots = b.space.spaces[0].knots.copy()
+        rev2 = b.reverse(direction=0).reverse(direction=0)
+        np.testing.assert_allclose(rev2.control_points, original_cp, atol=1e-14)
+        np.testing.assert_allclose(rev2.space.spaces[0].knots, original_knots, atol=1e-14)
+
+    def test_reverse_invalid_direction(self) -> None:
+        """Raises ValueError for out-of-range direction."""
+        b = _make_bspline_2d_surface()
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=2)
+        with pytest.raises(ValueError, match="direction must be in"):
+            b.reverse(direction=-1)
+
+    def test_reverse_evaluates_correctly(self) -> None:
+        """Reversed Bspline evaluates as b(1-t) in that direction."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 1.0], [3.0, 3.0]])
+        b = Bspline(space, cp)
+        rev = b.reverse()
+
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        vals_b = b.evaluate(pts)
+        vals_rev = rev.evaluate(1.0 - pts)
+        np.testing.assert_allclose(vals_b, vals_rev, atol=1e-14)
+
+    def test_reverse_nonunit_domain(self) -> None:
+        """Reversing works on non-[0,1] domain."""
+        knots = np.array([2.0, 2.0, 2.0, 3.0, 5.0, 5.0, 5.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]])
+        b = Bspline(space, cp)
+        rev = b.reverse()
+
+        # Domain should be preserved.
+        assert rev.space.spaces[0].domain == b.space.spaces[0].domain
+
+        # Evaluate: b(t) == rev(a+c-t).
+        a, c = b.space.spaces[0].domain
+        pts = np.array([2.0, 2.5, 3.0, 4.0, 5.0])
+        vals_b = b.evaluate(pts)
+        vals_rev = rev.evaluate((a + c) - pts)
+        np.testing.assert_allclose(vals_b, vals_rev, atol=1e-14)
+
+
+# ===========================================================================
+# Bspline — permute_directions
+# ===========================================================================
+
+
+class TestBsplinePermuteDirections:
+    """Test Bspline.permute_directions()."""
+
+    def test_permute_2d_swap(self) -> None:
+        """Swapping directions transposes control points and spaces."""
+        b = _make_bspline_2d_surface()
+        perm = b.permute_directions([1, 0])
+
+        expected_cp = np.transpose(b.control_points, (1, 0, 2))
+        np.testing.assert_array_equal(perm.control_points, expected_cp)
+        assert perm.degree == (b.degree[1], b.degree[0])
+
+        # Spaces are swapped.
+        np.testing.assert_array_equal(perm.space.spaces[0].knots, b.space.spaces[1].knots)
+        np.testing.assert_array_equal(perm.space.spaces[1].knots, b.space.spaces[0].knots)
+
+    def test_permute_3d_cyclic(self) -> None:
+        """Cyclic permutation [1,2,0] on a 3D volume."""
+        b = _make_bspline_3d_volume()
+        perm = b.permute_directions([1, 2, 0])
+
+        expected_cp = np.transpose(b.control_points, (1, 2, 0, 3))
+        np.testing.assert_array_equal(perm.control_points, expected_cp)
+        assert perm.degree == (b.degree[1], b.degree[2], b.degree[0])
+
+    def test_permute_identity(self) -> None:
+        """Identity permutation is a no-op."""
+        b = _make_bspline_2d_surface()
+        perm = b.permute_directions([0, 1])
+        np.testing.assert_array_equal(perm.control_points, b.control_points)
+        assert perm.degree == b.degree
+
+    def test_permute_preserves_properties(self) -> None:
+        """Permutation preserves dim, rank, dtype."""
+        b = _make_bspline_2d_surface()
+        perm = b.permute_directions([1, 0])
+        assert perm.dim == b.dim
+        assert perm.rank == b.rank
+        assert perm.dtype == b.dtype
+        assert perm.is_rational == b.is_rational
+
+    def test_permute_in_place(self) -> None:
+        """in_place=True modifies original and returns self."""
+        b = _make_bspline_2d_surface()
+        original_cp = b.control_points.copy()
+        result = b.permute_directions([1, 0], in_place=True)
+        assert result is b
+        expected = np.transpose(original_cp, (1, 0, 2))
+        np.testing.assert_array_equal(b.control_points, expected)
+
+    def test_permute_inverse_is_identity(self) -> None:
+        """Applying permutation then its inverse recovers the original."""
+        b = _make_bspline_3d_volume()
+        original_cp = b.control_points.copy()
+        original_knots = [s.knots.copy() for s in b.space.spaces]
+
+        result = b.permute_directions([1, 2, 0]).permute_directions([2, 0, 1])
+        np.testing.assert_array_equal(result.control_points, original_cp)
+        for i in range(3):
+            np.testing.assert_array_equal(result.space.spaces[i].knots, original_knots[i])
+
+    def test_permute_invalid_permutation(self) -> None:
+        """Raises ValueError for invalid permutations."""
+        b = _make_bspline_2d_surface()
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 0])
+        with pytest.raises(ValueError, match="permutation must be a permutation"):
+            b.permute_directions([0, 1, 2])
+
+    def test_permute_evaluates_correctly(self) -> None:
+        """Permuted Bspline evaluates as b(permuted_pts)."""
+        b = _make_bspline_2d_surface()
+        perm = b.permute_directions([1, 0])
+
+        pts = np.array([[0.2, 0.3], [0.5, 0.7], [0.8, 0.1]])
+        pts_swapped = pts[:, [1, 0]]
+        vals_b = b.evaluate(pts)
+        vals_perm = perm.evaluate(pts_swapped)
+        np.testing.assert_allclose(vals_b, vals_perm, atol=1e-14)


### PR DESCRIPTION
## Summary
- Add `reverse(direction, *, in_place=False)` method to both `Bezier` and `Bspline` classes — reverses a single parametric direction by flipping control points (and reflecting the knot vector for B-splines)
- Add `permute_directions(permutation, *, in_place=False)` method to both classes — reorders parametric directions according to a permutation
- Add `Bspline.remove_knots(knot_values, *, num=None, tol=None)` implementing Algorithm A5.8 from *The NURBS Book* (Piegl & Tiller) — tolerance-based knot removal supporting 1D/multi-dimensional B-splines, NURBS, partial removal, and multiple distinct knot values per direction

## Knot removal implementation
- **Layer 3** (`_bspline_knot_removal_core.py`): Numba kernel for the core algorithm
- **Layer 2** (`_bspline_knot_removal.py`): Validation, multiplicity lookup, multi-dim orchestration
- **Layer 1** (`_bspline.py`): Public `remove_knots()` method

## Test plan
- [x] 34 tests for reverse/permute_directions (both Bezier and Bspline)
- [x] 17 tests for knot removal: round-trips, partial removal, multi-dim, NURBS, error handling, tolerance rejection
- [x] All 1326 tests pass (51 new + 1275 existing)
- [x] ruff, mypy, ruff format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)