### PR TITLE
feat(bspline): add Bspline.to_periodic() for open-to-periodic conversion

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -511,7 +511,7 @@ class Bspline:
 
         return _restrict_bspline_impl(self, bounds_per_dim)
 
-    def to_periodic(self, continuity: int | tuple[int, ...] | None = None) -> Bspline:
+    def to_periodic(self, continuity: int | tuple[int | None, ...] | None = None) -> Bspline:
         """Return a periodic B-spline equivalent to this one.
 
         Converts each non-periodic parametric direction to a periodic
@@ -535,17 +535,20 @@ class Bspline:
             fidelity if in doubt.
 
         Args:
-            continuity (int | tuple[int, ...] | None): Target continuity at
-                the seam per direction.  ``None`` (default) requests maximum
-                regularity ``C^{p-1}``.  An integer applies to all directions;
-                a tuple specifies per-direction values.  Must satisfy
-                ``0 <= continuity <= degree - 1`` in each direction.
+            continuity (int | tuple[int | None, ...] | None): Target continuity
+                at the seam per direction.  ``None`` (default) requests maximum
+                regularity ``C^{p-1}`` in every non-periodic direction.  An
+                integer applies to all non-periodic directions; a tuple specifies
+                per-direction values where ``None`` entries skip that direction
+                (leave it unchanged).  Integer values must satisfy
+                ``0 <= continuity <= degree - 1``.
 
         Returns:
-            Bspline: Periodic B-spline with ghost-extended knot vectors.
+            Bspline: B-spline with the requested directions made periodic.
 
         Raises:
-            ValueError: If already periodic in every direction.
+            ValueError: If no direction would be converted (all already periodic
+                or all skipped via ``None`` in the tuple).
             ValueError: If the function is not periodic (endpoint mismatch
                 or residual exceeds tolerance).
             ValueError: If ``continuity`` is out of range.

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -22,6 +22,7 @@ from ._bspline_knot_insertion import (
     _compute_uniform_subdivision_knots,
     _insert_knots_bspline,
     _to_open_bspline_impl,
+    _to_periodic_bspline_impl,
 )
 from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_restrict import _restrict_bspline_impl
@@ -509,6 +510,47 @@ class Bspline:
             bounds_per_dim = seq  # type: ignore[assignment]
 
         return _restrict_bspline_impl(self, bounds_per_dim)
+
+    def to_periodic(self, continuity: int | tuple[int, ...] | None = None) -> Bspline:
+        """Return a periodic B-spline equivalent to this one.
+
+        Converts each non-periodic parametric direction to a periodic
+        representation with the requested continuity at the seam (the domain
+        boundary where the periodic function wraps around).  Directions that
+        are already periodic are left unchanged.
+
+        The conversion performs an exact change of basis: the Oslo algorithm
+        defines the linear map from periodic control points (with modulo
+        wrapping) to open control points, and inverting this map via QR
+        factorization recovers the periodic representation.
+
+        Warning:
+            This method assumes the B-spline represents an inherently periodic
+            function — i.e., the function values and derivatives match at the
+            domain boundaries up to the requested continuity order.  If the
+            function is not periodic, the result will **not** represent the
+            same geometry.  Gross violations raise ``ValueError`` (via a
+            residual check), but small deviations may pass silently.  Use
+            :meth:`to_open_bspline` on the result to verify round-trip
+            fidelity if in doubt.
+
+        Args:
+            continuity (int | tuple[int, ...] | None): Target continuity at
+                the seam per direction.  ``None`` (default) requests maximum
+                regularity ``C^{p-1}``.  An integer applies to all directions;
+                a tuple specifies per-direction values.  Must satisfy
+                ``0 <= continuity <= degree - 1`` in each direction.
+
+        Returns:
+            Bspline: Periodic B-spline with ghost-extended knot vectors.
+
+        Raises:
+            ValueError: If already periodic in every direction.
+            ValueError: If the function is not periodic (endpoint mismatch
+                or residual exceeds tolerance).
+            ValueError: If ``continuity`` is out of range.
+        """
+        return _to_periodic_bspline_impl(self, continuity)
 
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -1,18 +1,23 @@
-"""Layer 2 implementation for B-spline knot insertion.
+"""Layer 2 implementation for B-spline knot insertion and periodic conversion.
 
 This module provides input validation, multi-dimensional looping, and subdivision
-logic that wrap the Layer 3 Oslo-algorithm kernels.
+logic that wrap the Layer 3 Oslo-algorithm kernels.  It also implements the
+open-to-periodic conversion via an exact change-of-basis (Oslo + wrapping matrix).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
 
-from ._bspline_knot_insertion_core import _insert_knots_1d_core
-from ._bspline_knots import _get_unique_knots_and_multiplicity_impl, _is_in_domain_impl
+from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core, _insert_knots_1d_core
+from ._bspline_knots import (
+    _get_Bspline_num_basis_1D_impl,
+    _get_unique_knots_and_multiplicity_impl,
+    _is_in_domain_impl,
+)
 
 if TYPE_CHECKING:
     from . import Bspline, BsplineSpace1D
@@ -327,6 +332,307 @@ def _to_open_bspline_impl(bspline: Bspline) -> Bspline:
 
     new_space = BsplineSpace(new_spaces_1d)
     return Bspline(new_space, ctrl, is_rational=bspline.is_rational)
+
+
+def _build_periodic_knot_vector(
+    open_knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    interior_bp: npt.NDArray[np.float32 | np.float64],
+    interior_mults: npt.NDArray[np.int_],
+    m_bdy: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a periodic knot vector from an open knot vector's breakpoints.
+
+    Constructs the in-domain part ``[a^{m_bdy}, interior, b^{m_bdy}]`` and
+    extends it periodically with ghost knots on each side.  Ghost knots are
+    computed by applying integer shifts to individual breakpoint values
+    (``bp + k * period``) rather than shifting entire arrays, to minimize
+    floating-point drift.
+
+    Args:
+        open_knots (npt.NDArray[np.float32 | np.float64]): Open knot vector.
+        degree (int): Polynomial degree.
+        interior_bp (npt.NDArray[np.float32 | np.float64]): Unique interior
+            breakpoints (between ``a`` and ``b``, exclusive).
+        interior_mults (npt.NDArray[np.int_]): Multiplicity of each interior
+            breakpoint.
+        m_bdy (int): Target boundary multiplicity.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Periodic knot vector with ghost
+        knots.
+    """
+    dtype = open_knots.dtype
+    p = degree
+    a = dtype.type(open_knots[p])
+    b = dtype.type(open_knots[-p - 1])
+    period = dtype.type(b - a)
+
+    n_ghost = p + 1 - m_bdy  # ghost knot entries needed on each side
+
+    # Build the unique breakpoints (with multiplicity) for one period.
+    # "tile" = [a, xi_1, ..., xi_{N-1}], each repeated by its multiplicity.
+    bp_vals = np.concatenate([[a], interior_bp])
+    bp_mults = np.concatenate([[m_bdy], interior_mults]).astype(int)
+
+    # In-domain part: tile + b^{m_bdy}.
+    in_domain_parts: list[npt.NDArray[np.float32 | np.float64]] = []
+    for val, m in zip(bp_vals, bp_mults, strict=True):
+        in_domain_parts.append(np.full(m, dtype.type(val), dtype=dtype))
+    in_domain_parts.append(np.full(m_bdy, b, dtype=dtype))
+    in_domain = np.concatenate(in_domain_parts)
+
+    if n_ghost <= 0:
+        return in_domain
+
+    # Build ghost knots by generating shifted copies of the tile breakpoints.
+    # We create a long enough sequence and slice to n_ghost entries.
+    # Right ghosts: interior breakpoints + period, then a + 2*period, etc.
+    right_entries: list[np.floating[Any]] = []
+    shift = 1
+    while len(right_entries) < n_ghost:
+        for val, m in zip(bp_vals, bp_mults, strict=True):
+            if shift == 1 and val == a:
+                continue  # skip the leading a at shift=1 (it equals b)
+            for _ in range(m):
+                right_entries.append(dtype.type(val + shift * period))
+                if len(right_entries) == n_ghost:
+                    break
+            if len(right_entries) == n_ghost:
+                break
+        shift += 1
+
+    # Left ghosts: full tile shifted by -1, -2, etc.
+    left_entries: list[np.floating[Any]] = []
+    shift = -1
+    while len(left_entries) < n_ghost:
+        for val, m in zip(bp_vals, bp_mults, strict=True):
+            for _ in range(m):
+                left_entries.append(dtype.type(val + shift * period))
+        shift -= 1
+    left_entries = left_entries[-n_ghost:]
+
+    left_arr = np.array(left_entries, dtype=dtype)
+    right_arr = np.array(right_entries, dtype=dtype)
+
+    return np.concatenate([left_arr, in_domain, right_arr])
+
+
+def _to_periodic_bspline_1d_impl(
+    open_knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl_2d: npt.NDArray[np.float32 | np.float64],
+    m_bdy: int,
+    tol: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Convert an open (clamped) 1D B-spline to periodic form.
+
+    Performs an exact change of basis from the open representation to a periodic
+    one with the specified boundary multiplicity ``m_bdy``.  The Oslo matrix
+    defines the linear map from the periodic (ghost-extended, wrapped) basis to
+    the open basis; inverting this map via QR factorization recovers the periodic
+    control points.
+
+    Args:
+        open_knots (npt.NDArray[np.float32 | np.float64]): Open (clamped) knot
+            vector with multiplicity ``degree + 1`` at both boundaries.
+        degree (int): Polynomial degree.
+        ctrl_2d (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(n_open, rank)``.
+        m_bdy (int): Target boundary multiplicity for the periodic knot vector.
+            Must satisfy ``1 <= m_bdy <= degree``.
+        tol (float): Knot comparison tolerance.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray]: ``(periodic_knots, periodic_ctrl)`` where
+        ``periodic_knots`` includes ghost knots and ``periodic_ctrl`` has shape
+        ``(n_periodic, rank)``.
+
+    Raises:
+        ValueError: If the function is not periodic (C^0 check at seam or
+            residual exceeds tolerance).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bspline.Bspline.to_periodic` instead.
+    """
+    p = degree
+    dtype = open_knots.dtype
+
+    a = float(open_knots[p])
+    b = float(open_knots[-p - 1])
+
+    # --- Quick C^0 check when knots are clamped (P_0 = f(a), P_{n-1} = f(b)) ---
+    m_left = int(np.sum(np.isclose(open_knots[: p + 1], a, atol=tol)))
+    m_right = int(np.sum(np.isclose(open_knots[-p - 1 :], b, atol=tol)))
+    is_clamped = m_left == p + 1 and m_right == p + 1
+    if is_clamped:
+        eps = float(np.finfo(np.float64).eps)
+        scale = max(float(np.max(np.abs(ctrl_2d))), 1.0)
+        c0_tol = max(tol, 100.0 * eps * scale)
+        c0_dev = float(np.max(np.abs(ctrl_2d[0] - ctrl_2d[-1])))
+        if c0_dev > c0_tol:
+            raise ValueError(
+                "Function values do not match at the domain endpoints "
+                f"(max deviation {c0_dev:.2e}, tolerance {c0_tol:.2e}). "
+                "The B-spline is not periodic."
+            )
+
+    _, mults_all = _get_unique_knots_and_multiplicity_impl(open_knots, p, tol, in_domain=True)
+    # Extract exact breakpoint values directly from open_knots to avoid
+    # floating-point drift from the averaging in unique-knot computation.
+    # The in-domain knots of open_knots are at indices [p, ..., len-p-1].
+    in_domain_flat = open_knots[p : len(open_knots) - p]
+    # Deduplicate preserving exact values: take the first occurrence of each group.
+    bp_exact: list[np.float32 | np.float64] = [in_domain_flat[0]]
+    for v in in_domain_flat[1:]:
+        if abs(float(v) - float(bp_exact[-1])) > tol:
+            bp_exact.append(v)
+    interior_bp = np.array(bp_exact[1:-1], dtype=dtype)
+    interior_mults = mults_all[1:-1]
+
+    T_per = _build_periodic_knot_vector(open_knots, p, interior_bp, interior_mults, m_bdy)
+
+    # --- Build the Oslo chain: T_per → open_knots ---
+    n_ghost = p + 1 - m_bdy
+    n_open = ctrl_2d.shape[0]
+
+    # Step 1: Insert clamping knots into T_per → T_inter.
+    knots_ins = np.array([a] * n_ghost + [b] * n_ghost, dtype=dtype)
+    T_inter = np.sort(np.concatenate([T_per, knots_ins]))
+    oslo1 = _compute_oslo_matrix_1d_core(p, T_per, T_inter)
+
+    # Step 2: Trim ghost region from T_inter to isolate the open part.
+    n_inter_open = len(T_inter) - 2 * n_ghost - p - 1
+    oslo1_trimmed = oslo1[n_ghost : n_ghost + n_inter_open, :]
+
+    # Step 3: If the trimmed intermediate has more CPs than the open form
+    # (because open_knots has fewer knots), map through a second Oslo step.
+    # Use open_knots directly (not T_inter trimmed) to avoid float artefacts.
+    if n_inter_open == n_open:
+        oslo = oslo1_trimmed
+    else:
+        T_inter_open = T_inter[n_ghost : len(T_inter) - n_ghost]
+        oslo2 = _compute_oslo_matrix_1d_core(p, T_inter_open, open_knots)
+        oslo = oslo2 @ oslo1_trimmed  # shape (n_open, n_full)
+
+    # --- Build the modulo-wrapping matrix W ---
+    n_full = len(T_per) - p - 1
+    n_per = int(_get_Bspline_num_basis_1D_impl(T_per, p, True, tol))
+    W = np.zeros((n_full, n_per), dtype=np.float64)
+    for i in range(n_full):
+        W[i, i % n_per] = 1.0
+
+    # --- Exact solve via QR: M @ C_per = C_open ---
+    M = oslo @ W  # shape (n_open, n_per)
+    Q, R = np.linalg.qr(M)
+    ctrl_per = np.linalg.solve(R, Q.T @ ctrl_2d.astype(np.float64))
+
+    # --- Residual check ---
+    # Use a tolerance relative to the control point magnitude, but at least
+    # 100 * machine epsilon for the working dtype to absorb floating-point
+    # noise from the QR solve and Oslo chain.
+    eps = float(np.finfo(np.float64).eps)
+    scale = max(float(np.max(np.abs(ctrl_2d))), 1.0)
+    residual_tol = max(tol, 100.0 * eps * scale)
+    residual = float(np.max(np.abs(M @ ctrl_per - ctrl_2d.astype(np.float64))))
+    if residual > residual_tol:
+        raise ValueError(
+            f"Residual {residual:.2e} exceeds tolerance {residual_tol:.2e}. "
+            "The B-spline does not have sufficient smoothness at the seam "
+            "for the requested periodic regularity."
+        )
+
+    return T_per, ctrl_per.astype(dtype)
+
+
+def _to_periodic_bspline_impl(
+    bspline: Bspline,
+    continuity: int | tuple[int, ...] | None,
+) -> Bspline:
+    """Convert all parametric directions of a B-spline to periodic form.
+
+    For each direction that is not already periodic, computes an exact
+    change of basis from the open/non-open representation to a periodic one
+    with the requested continuity at the seam.
+
+    Args:
+        bspline (Bspline): Input B-spline.
+        continuity (int | tuple[int, ...] | None): Target continuity at the seam
+            per direction.  ``None`` means maximum regularity (``degree - 1``).
+            An integer applies to all directions; a tuple specifies per-direction.
+
+    Returns:
+        Bspline: New periodic B-spline.
+
+    Raises:
+        ValueError: If already periodic in every direction.
+        ValueError: If the function is not periodic in some direction.
+    """
+    from . import Bspline as BsplineCls  # noqa: PLC0415
+    from . import BsplineSpace, BsplineSpace1D  # noqa: PLC0415
+
+    dim = bspline.dim
+    ctrl = bspline.control_points
+
+    # Check if every direction is already periodic.
+    if all(s.periodic for s in bspline.space.spaces):
+        raise ValueError("B-spline is already periodic in every direction.")
+
+    # Normalize continuity to a per-direction tuple.
+    if continuity is None:
+        cont_per_dir: tuple[int | None, ...] = tuple(None for _ in range(dim))
+    elif isinstance(continuity, int):
+        cont_per_dir = tuple(continuity for _ in range(dim))
+    else:
+        if len(continuity) != dim:
+            raise ValueError(f"continuity tuple length {len(continuity)} != dimension {dim}.")
+        cont_per_dir = tuple(continuity)
+
+    # First, ensure we have an open representation (non-periodic directions
+    # that are not yet open need clamping before conversion).
+    # We process each direction: if periodic, skip; otherwise convert to open
+    # first (if needed), then convert to periodic.
+    new_spaces_1d: list[BsplineSpace1D] = []
+
+    for i in range(dim):
+        space_1d = bspline.space.spaces[i]
+
+        if space_1d.periodic:
+            new_spaces_1d.append(space_1d)
+            continue
+
+        p = space_1d.degree
+
+        # Resolve continuity for this direction.
+        c = cont_per_dir[i]
+        if c is None:
+            c = p - 1
+        if not (0 <= c <= p - 1):
+            raise ValueError(
+                f"continuity must be in [0, degree-1]=[0, {p - 1}] for direction {i}, got {c}."
+            )
+        m_bdy = p - c
+
+        # Ensure direction is open (clamped) before periodic conversion.
+        knots_1d = space_1d.knots
+        tol_1d = float(space_1d.tolerance)
+        moved_ctrl = np.moveaxis(ctrl, i, 0)
+        orig_shape = moved_ctrl.shape
+        pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        per_knots, per_pts_2d = _to_periodic_bspline_1d_impl(knots_1d, p, pts_2d, m_bdy, tol_1d)
+
+        new_shape = (per_pts_2d.shape[0], *orig_shape[1:])
+        new_moved_ctrl = per_pts_2d.reshape(new_shape)
+        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+
+        new_spaces_1d.append(BsplineSpace1D(per_knots, p, periodic=True))
+
+    new_space = BsplineSpace(new_spaces_1d)
+    return BsplineCls(new_space, ctrl, is_rational=bspline.is_rational)
 
 
 def _compute_uniform_subdivision_knots(

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -548,25 +548,27 @@ def _to_periodic_bspline_1d_impl(
 
 def _to_periodic_bspline_impl(
     bspline: Bspline,
-    continuity: int | tuple[int, ...] | None,
+    continuity: int | tuple[int | None, ...] | None,
 ) -> Bspline:
-    """Convert all parametric directions of a B-spline to periodic form.
+    """Convert selected parametric directions of a B-spline to periodic form.
 
-    For each direction that is not already periodic, computes an exact
-    change of basis from the open/non-open representation to a periodic one
-    with the requested continuity at the seam.
+    For each direction that is not already periodic and not explicitly skipped,
+    computes an exact change of basis from the open/non-open representation to
+    a periodic one with the requested continuity at the seam.
 
     Args:
         bspline (Bspline): Input B-spline.
-        continuity (int | tuple[int, ...] | None): Target continuity at the seam
-            per direction.  ``None`` means maximum regularity (``degree - 1``).
-            An integer applies to all directions; a tuple specifies per-direction.
+        continuity (int | tuple[int | None, ...] | None): Target continuity at
+            the seam per direction.  ``None`` means maximum regularity
+            (``degree - 1``) in every non-periodic direction.  An integer
+            applies to all non-periodic directions.  A tuple specifies
+            per-direction values; ``None`` entries skip that direction.
 
     Returns:
-        Bspline: New periodic B-spline.
+        Bspline: New B-spline with the requested directions made periodic.
 
     Raises:
-        ValueError: If already periodic in every direction.
+        ValueError: If no direction would be converted.
         ValueError: If the function is not periodic in some direction.
     """
     from . import Bspline as BsplineCls  # noqa: PLC0415
@@ -575,13 +577,16 @@ def _to_periodic_bspline_impl(
     dim = bspline.dim
     ctrl = bspline.control_points
 
-    # Check if every direction is already periodic.
-    if all(s.periodic for s in bspline.space.spaces):
-        raise ValueError("B-spline is already periodic in every direction.")
-
     # Normalize continuity to a per-direction tuple.
+    # A scalar applies to all non-periodic directions.
+    # A global None means "max regularity in all non-periodic directions."
+    # Per-direction None means "skip this direction (leave unchanged)."
+    # The sentinel _CONVERT_DEFAULT = -1 means "use max regularity."
+    _CONVERT_DEFAULT = -1
+    cont_per_dir: tuple[int | None, ...]
     if continuity is None:
-        cont_per_dir: tuple[int | None, ...] = tuple(None for _ in range(dim))
+        # Default: max regularity for every non-periodic direction.
+        cont_per_dir = tuple(_CONVERT_DEFAULT for _ in range(dim))
     elif isinstance(continuity, int):
         cont_per_dir = tuple(continuity for _ in range(dim))
     else:
@@ -589,16 +594,22 @@ def _to_periodic_bspline_impl(
             raise ValueError(f"continuity tuple length {len(continuity)} != dimension {dim}.")
         cont_per_dir = tuple(continuity)
 
-    # First, ensure we have an open representation (non-periodic directions
-    # that are not yet open need clamping before conversion).
-    # We process each direction: if periodic, skip; otherwise convert to open
-    # first (if needed), then convert to periodic.
+    # Determine which directions will be converted: non-periodic and not skipped.
+    will_convert = [
+        not bspline.space.spaces[i].periodic and cont_per_dir[i] is not None for i in range(dim)
+    ]
+    if not any(will_convert):
+        raise ValueError(
+            "No direction to convert: all directions are either already periodic "
+            "or explicitly skipped."
+        )
+
     new_spaces_1d: list[BsplineSpace1D] = []
 
     for i in range(dim):
         space_1d = bspline.space.spaces[i]
 
-        if space_1d.periodic:
+        if not will_convert[i]:
             new_spaces_1d.append(space_1d)
             continue
 
@@ -606,7 +617,7 @@ def _to_periodic_bspline_impl(
 
         # Resolve continuity for this direction.
         c = cont_per_dir[i]
-        if c is None:
+        if c is None or c == _CONVERT_DEFAULT:
             c = p - 1
         if not (0 <= c <= p - 1):
             raise ValueError(
@@ -614,7 +625,6 @@ def _to_periodic_bspline_impl(
             )
         m_bdy = p - c
 
-        # Ensure direction is open (clamped) before periodic conversion.
         knots_1d = space_1d.knots
         tol_1d = float(space_1d.tolerance)
         moved_ctrl = np.moveaxis(ctrl, i, 0)

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1178,3 +1178,47 @@ class TestToPeriodic:
         pts_v = np.linspace(float(av), float(bv), 11, dtype=np.float64)[1:-1]
         lattice = PointsLattice([pts_u, pts_v])
         np.testing.assert_allclose(f_per.evaluate(lattice), f.evaluate(lattice), atol=1e-10)
+
+    def test_selective_direction_conversion(self) -> None:
+        """to_periodic with tuple continuity converts only selected directions."""
+        from pantr.quad import PointsLattice  # noqa: PLC0415
+
+        # 2D: direction 0 is periodic (open after to_open), direction 1 is open (non-periodic).
+        knots_per = create_uniform_periodic(3, 2)
+        knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace(
+            [
+                BsplineSpace1D(knots_per, 2, periodic=True),
+                BsplineSpace1D(knots_open, 2),
+            ]
+        )
+        n0 = space.spaces[0].num_basis
+        n1 = space.spaces[1].num_basis
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((n0, n1, 1))
+        f = Bspline(space, ctrl)
+
+        # Convert to open in all directions.
+        f_open = f.to_open_bspline()
+        assert not any(s.periodic for s in f_open.space.spaces)
+
+        # Convert only direction 0 back to periodic, skip direction 1.
+        f_mixed = f_open.to_periodic(continuity=(1, None))
+        assert f_mixed.space.spaces[0].periodic
+        assert not f_mixed.space.spaces[1].periodic
+
+        # Evaluation should match on the original domain.
+        a0, b0 = f.space.spaces[0].domain
+        a1, b1 = f.space.spaces[1].domain
+        pts_0 = np.linspace(float(a0), float(b0), 11, dtype=np.float64)[1:-1]
+        pts_1 = np.linspace(float(a1), float(b1), 11, dtype=np.float64)[1:-1]
+        lattice = PointsLattice([pts_0, pts_1])
+        np.testing.assert_allclose(f_mixed.evaluate(lattice), f.evaluate(lattice), atol=1e-10)
+
+    def test_all_skipped_raises(self) -> None:
+        """to_periodic raises when all directions are skipped or already periodic."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        f = Bspline(space, np.array([1.0, 2.0, 3.0, 4.0]))
+        with pytest.raises(ValueError, match="No direction to convert"):
+            f.to_periodic(continuity=(None,))

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1056,3 +1056,125 @@ class TestToOpenBspline:
         vals = f.evaluate(pts)
         derivs = f.evaluate_derivatives(pts, [0])
         np.testing.assert_allclose(derivs, vals, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# to_periodic tests
+# ---------------------------------------------------------------------------
+
+
+class TestToPeriodic:
+    """Tests for Bspline.to_periodic()."""
+
+    @pytest.mark.parametrize(
+        "num_intervals, degree, continuity",
+        [
+            (2, 1, None),
+            (3, 2, None),
+            (4, 3, None),
+            (5, 3, None),
+            (4, 2, 1),
+            (5, 3, 2),
+        ],
+    )
+    def test_round_trip_max_and_high_regularity(
+        self, num_intervals: int, degree: int, continuity: int | None
+    ) -> None:
+        """Periodic -> open -> periodic round-trip preserves evaluation."""
+        f = _make_periodic_bspline(num_intervals, degree, continuity=continuity)
+        f_open = f.to_open_bspline()
+        c = continuity if continuity is not None else degree - 1
+        f_per = f_open.to_periodic(continuity=c)
+
+        assert f_per.space.spaces[0].periodic
+        assert f_per.space.spaces[0].num_basis == f.space.spaces[0].num_basis
+
+        a, b = f.space.spaces[0].domain
+        pts = np.linspace(float(a), float(b), 51, dtype=np.float64)[1:-1]
+        np.testing.assert_allclose(f_per.evaluate(pts), f.evaluate(pts), atol=1e-11)
+
+    def test_round_trip_default_continuity(self) -> None:
+        """to_periodic() with no continuity arg uses max regularity."""
+        f = _make_periodic_bspline(4, 3)
+        f_open = f.to_open_bspline()
+        f_per = f_open.to_periodic()
+
+        assert f_per.space.spaces[0].periodic
+        a, b = f.space.spaces[0].domain
+        pts = np.linspace(float(a), float(b), 51, dtype=np.float64)[1:-1]
+        np.testing.assert_allclose(f_per.evaluate(pts), f.evaluate(pts), atol=1e-11)
+
+    def test_non_periodic_raises(self) -> None:
+        """to_periodic on a non-periodic open B-spline raises ValueError."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        ctrl = np.array([1.0, 2.0, 5.0, 3.0])  # P_0 != P_{n-1}
+        f = Bspline(space, ctrl)
+        with pytest.raises(ValueError, match="not periodic"):
+            f.to_periodic()
+
+    def test_already_periodic_raises(self) -> None:
+        """to_periodic on an already-periodic B-spline raises ValueError."""
+        f = _make_periodic_bspline(3, 2)
+        with pytest.raises(ValueError, match="already periodic"):
+            f.to_periodic()
+
+    def test_continuity_out_of_range_raises(self) -> None:
+        """to_periodic with invalid continuity raises ValueError."""
+        f = _make_periodic_bspline(3, 2)
+        f_open = f.to_open_bspline()
+        with pytest.raises(ValueError, match="continuity"):
+            f_open.to_periodic(continuity=2)  # degree=2, max cont=1
+
+    def test_rational_round_trip(self) -> None:
+        """Rational periodic -> open -> periodic preserves evaluation."""
+        knots = create_uniform_periodic(3, 2)
+        space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+        # 2D rational control points (x, y, w)
+        n = space.spaces[0].num_basis
+        ctrl = np.column_stack(
+            [
+                np.cos(np.linspace(0, 2 * np.pi, n, endpoint=False)),
+                np.sin(np.linspace(0, 2 * np.pi, n, endpoint=False)),
+                np.ones(n),
+            ]
+        )
+        f = Bspline(space, ctrl, is_rational=True)
+        f_open = f.to_open_bspline()
+        f_per = f_open.to_periodic()
+
+        assert f_per.is_rational
+        assert f_per.space.spaces[0].periodic
+        a, b = f.space.spaces[0].domain
+        pts = np.linspace(float(a), float(b), 41, dtype=np.float64)[1:-1]
+        np.testing.assert_allclose(f_per.evaluate(pts), f.evaluate(pts), atol=1e-11)
+
+    def test_multidim_round_trip(self) -> None:
+        """2D B-spline with both directions periodic round-trips correctly."""
+        from pantr.quad import PointsLattice  # noqa: PLC0415
+
+        knots_u = create_uniform_periodic(3, 2)
+        knots_v = create_uniform_periodic(4, 2)
+        space = BsplineSpace(
+            [
+                BsplineSpace1D(knots_u, 2, periodic=True),
+                BsplineSpace1D(knots_v, 2, periodic=True),
+            ]
+        )
+        nu = space.spaces[0].num_basis
+        nv = space.spaces[1].num_basis
+        ctrl = np.arange(1, nu * nv + 1, dtype=np.float64).reshape(nu, nv, 1)
+        f = Bspline(space, ctrl)
+        f_open = f.to_open_bspline()
+        f_per = f_open.to_periodic()
+
+        assert all(s.periodic for s in f_per.space.spaces)
+        assert f_per.space.spaces[0].num_basis == nu
+        assert f_per.space.spaces[1].num_basis == nv
+
+        au, bu = f.space.spaces[0].domain
+        av, bv = f.space.spaces[1].domain
+        pts_u = np.linspace(float(au), float(bu), 11, dtype=np.float64)[1:-1]
+        pts_v = np.linspace(float(av), float(bv), 11, dtype=np.float64)[1:-1]
+        lattice = PointsLattice([pts_u, pts_v])
+        np.testing.assert_allclose(f_per.evaluate(lattice), f.evaluate(lattice), atol=1e-10)


### PR DESCRIPTION
## Summary
- Add `Bspline.to_periodic(continuity=...)` public method that converts open/non-periodic B-splines to periodic form
- Implements exact change-of-basis via Oslo matrix + modulo-wrapping matrix + QR factorization
- Includes built-in periodicity validation (C^0 endpoint check + residual check)
- Supports arbitrary degrees, continuity levels (C^0 to C^{p-1}), rational B-splines, and multi-dimensional cases
- New `_build_periodic_knot_vector` helper constructs ghost-extended knot vectors from exact breakpoint values to avoid floating-point drift

## Test plan
- [x] All 1287 existing tests pass
- [x] 12 new tests for `to_periodic`: round-trip (6 parametrized cases), default continuity, non-periodic error, already-periodic error, continuity range error, rational round-trip, 2D round-trip
- [x] Pre-PR checks pass (ruff, ruff format, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)