### PR TITLE
feat(bspline): add restrict method for Bspline and Bezier

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -474,6 +474,45 @@ class Bezier:
         return Bezier(new_cp, is_rational=self._is_rational)
 
     # ------------------------------------------------------------------
+    # Restrict
+    # ------------------------------------------------------------------
+
+    def restrict(
+        self,
+        bounds: tuple[float, float] | Sequence[tuple[float, float] | None],
+    ) -> Bezier:
+        """Return a Bézier restricted to a sub-region of ``[0, 1]^dim``.
+
+        Extracts the portion of the Bézier defined on the given sub-interval
+        and reparametrizes the result back to ``[0, 1]^dim``.  The returned
+        Bézier has the same degree but different control points that encode
+        the restricted mapping.
+
+        Internally converts to a B-spline, restricts, and converts back.
+
+        Args:
+            bounds (tuple[float, float] | Sequence[tuple[float, float] | None]):
+                For a 1D Bézier, a ``(lower, upper)`` tuple within ``[0, 1]``.
+                For multi-dimensional Bézier, a sequence of length ``dim``
+                where each element is a ``(lower, upper)`` tuple for that
+                direction, or ``None`` to keep the full ``[0, 1]`` range.
+                At least one direction must have non-``None`` bounds that
+                restrict the domain.
+
+        Returns:
+            Bezier: New Bézier on ``[0, 1]^dim`` representing the restriction.
+
+        Raises:
+            ValueError: If the sequence length does not match ``dim``.
+            ValueError: If all directions are ``None`` or match the full domain.
+            ValueError: If any bound lies outside ``[0, 1]``.
+            ValueError: If ``lower >= upper`` in any direction.
+        """
+        bspline = self.to_bspline()
+        restricted = bspline.restrict(bounds)
+        return Bezier.from_bspline(restricted)
+
+    # ------------------------------------------------------------------
     # Conversion
     # ------------------------------------------------------------------
 

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -500,7 +500,7 @@ class Bspline:
                 bounds  # type: ignore[list-item]
             ]
         else:
-            seq = list(bounds)  # type: ignore[arg-type]
+            seq = list(bounds)  # type: ignore[arg-type,unused-ignore]
             if len(seq) != self.dim:
                 raise ValueError(
                     f"bounds sequence length ({len(seq)}) must match dim ({self.dim})."

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -24,6 +24,7 @@ from ._bspline_knot_insertion import (
     _to_open_bspline_impl,
 )
 from ._bspline_knot_removal import _remove_knots_bspline
+from ._bspline_restrict import _restrict_bspline_impl
 
 if TYPE_CHECKING:
     from ..quad import PointsLattice
@@ -462,6 +463,51 @@ class Bspline:
             ValueError: If the B-spline is already open in every direction.
         """
         return _to_open_bspline_impl(self)
+
+    def restrict(
+        self,
+        bounds: tuple[float, float] | Sequence[tuple[float, float] | None],
+    ) -> Bspline:
+        """Return a B-spline restricted to a sub-region of the parametric domain.
+
+        Extracts the portion of the B-spline defined on the given sub-domain by
+        inserting knots at the new boundaries until they reach multiplicity
+        ``degree + 1``, then extracting the relevant knot sub-vector and control
+        points.  Skips insertion when a bound already coincides with a clamped
+        domain endpoint.  Periodic directions are automatically converted to
+        open form before restricting.
+
+        Args:
+            bounds (tuple[float, float] | Sequence[tuple[float, float] | None]):
+                For a 1D B-spline, a ``(lower, upper)`` tuple defining the new
+                domain.  For multi-dimensional B-splines, a sequence of length
+                ``dim`` where each element is a ``(lower, upper)`` tuple for
+                that direction, or ``None`` to keep the full domain in that
+                direction.  At least one direction must have non-``None`` bounds
+                that actually restrict the domain.
+
+        Returns:
+            Bspline: New B-spline defined on the restricted domain.
+
+        Raises:
+            ValueError: If the sequence length does not match ``dim`` (multi-dim).
+            ValueError: If all directions are ``None`` or match the full domain.
+            ValueError: If any bound lies outside its direction's domain.
+            ValueError: If ``lower >= upper`` in any direction.
+        """
+        if self.dim == 1:
+            bounds_per_dim: list[tuple[float, float] | None] = [
+                bounds  # type: ignore[list-item]
+            ]
+        else:
+            seq = list(bounds)  # type: ignore[arg-type]
+            if len(seq) != self.dim:
+                raise ValueError(
+                    f"bounds sequence length ({len(seq)}) must match dim ({self.dim})."
+                )
+            bounds_per_dim = seq  # type: ignore[assignment]
+
+        return _restrict_bspline_impl(self, bounds_per_dim)
 
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -23,50 +23,31 @@ if TYPE_CHECKING:
     from . import Bspline
 
 
-def _restrict_bspline_1d_impl(
+def _validate_restrict_bounds(
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
-    ctrl_2d: npt.NDArray[np.float32 | np.float64],
-    periodic: bool,
     tol: float,
     a_new: float,
     b_new: float,
-) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
-    """Restrict a 1D B-spline to a sub-interval of its parametric domain.
-
-    Inserts knots at ``a_new`` and ``b_new`` until each has multiplicity
-    ``degree + 1``, then extracts the knot sub-vector and control points
-    corresponding to the interval ``[a_new, b_new]``.  Skips insertion when
-    a bound coincides with an already-open domain endpoint.
-
-    For periodic splines, the direction is first converted to open form via
-    :func:`_to_open_bspline_1d_impl`.
+) -> tuple[float, float]:
+    """Validate and snap restriction bounds for a 1D B-spline.
 
     Args:
-        knots: Knot vector of shape ``(len(knots),)``.
+        knots: Knot vector.
         degree: Polynomial degree.
-        ctrl_2d: Control point matrix of shape ``(n, rank)``.
-        periodic: Whether the spline is periodic.
         tol: Knot comparison tolerance.
-        a_new: Left bound of the restricted domain.
-        b_new: Right bound of the restricted domain.
+        a_new: Requested left bound.
+        b_new: Requested right bound.
 
     Returns:
-        tuple[npt.NDArray, npt.NDArray]: ``(restricted_knots, restricted_ctrl)``
-        — the clamped knot vector on ``[a_new, b_new]`` and the corresponding
-        control points.
+        tuple[float, float]: Snapped ``(a_new, b_new)`` bounds.
 
     Raises:
-        ValueError: If ``a_new >= b_new``.
-        ValueError: If ``a_new`` or ``b_new`` lies outside the domain.
-        ValueError: If the bounds match the full domain and the direction is
-            already open (no-op).
+        ValueError: If ``a_new >= b_new`` or bounds lie outside the domain.
     """
-    p = degree
-    a = float(knots[p])
-    b = float(knots[-p - 1])
+    a = float(knots[degree])
+    b = float(knots[-degree - 1])
 
-    # Validate bounds.
     if a_new >= b_new:
         raise ValueError(f"Lower bound ({a_new}) must be strictly less than upper bound ({b_new}).")
 
@@ -81,47 +62,114 @@ def _restrict_bspline_1d_impl(
     if np.isclose(b_new, b, atol=tol):
         b_new = b
 
+    return a_new, b_new
+
+
+def _compute_boundary_knots_to_insert(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    a_new: float,
+    b_new: float,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute knots to insert at the restriction boundaries.
+
+    For each boundary, inserts enough copies to reach multiplicity ``degree + 1``.
+    Skips insertion when the boundary coincides with an already-open domain endpoint.
+
+    Args:
+        knots: Knot vector (must be non-periodic/open-compatible).
+        degree: Polynomial degree.
+        tol: Knot comparison tolerance.
+        a_new: Left bound of the restricted domain.
+        b_new: Right bound of the restricted domain.
+
+    Returns:
+        npt.NDArray: 1D array of knot values to insert (may be empty).
+
+    Raises:
+        ValueError: If the bounds match the full domain and the direction is
+            already open (no-op).
+    """
+    p = degree
+    a = float(knots[p])
+    b = float(knots[-p - 1])
+
+    left_at_domain = np.isclose(a_new, a, atol=tol)
+    right_at_domain = np.isclose(b_new, b, atol=tol)
+    left_open = bool(np.isclose(knots[0], knots[p], atol=tol))
+    right_open = bool(np.isclose(knots[-p - 1], knots[-1], atol=tol))
+
+    if left_at_domain and right_at_domain and left_open and right_open:
+        raise ValueError("Bounds match the full domain and the direction is already open.")
+
+    knots_list: list[float] = []
+
+    if not (left_at_domain and left_open):
+        m_left = int(np.sum(np.isclose(knots, a_new, atol=tol)))
+        deficit = p + 1 - m_left
+        if deficit > 0:
+            knots_list.extend([a_new] * deficit)
+
+    if not (right_at_domain and right_open):
+        m_right = int(np.sum(np.isclose(knots, b_new, atol=tol)))
+        deficit = p + 1 - m_right
+        if deficit > 0:
+            knots_list.extend([b_new] * deficit)
+
+    return np.array(knots_list, dtype=knots.dtype)
+
+
+def _restrict_bspline_1d_impl(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl_2d: npt.NDArray[np.float32 | np.float64],
+    periodic: bool,
+    tol: float,
+    bounds: tuple[float, float],
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Restrict a 1D B-spline to a sub-interval of its parametric domain.
+
+    Inserts knots at the boundaries until each has multiplicity ``degree + 1``,
+    then extracts the knot sub-vector and control points corresponding to the
+    restricted interval.  Skips insertion when a bound coincides with an
+    already-open domain endpoint.
+
+    For periodic splines, the direction is first converted to open form via
+    :func:`_to_open_bspline_1d_impl`.
+
+    Args:
+        knots: Knot vector of shape ``(len(knots),)``.
+        degree: Polynomial degree.
+        ctrl_2d: Control point matrix of shape ``(n, rank)``.
+        periodic: Whether the spline is periodic.
+        tol: Knot comparison tolerance.
+        bounds: ``(a_new, b_new)`` — left and right bounds of the restricted domain.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray]: ``(restricted_knots, restricted_ctrl)``
+        — the clamped knot vector on ``[a_new, b_new]`` and the corresponding
+        control points.
+
+    Raises:
+        ValueError: If ``a_new >= b_new``.
+        ValueError: If ``a_new`` or ``b_new`` lies outside the domain.
+        ValueError: If the bounds match the full domain and the direction is
+            already open (no-op).
+    """
+    p = degree
+    a_new, b_new = _validate_restrict_bounds(knots, p, tol, bounds[0], bounds[1])
+
     # For periodic splines, convert to open form first.
     if periodic:
         knots, ctrl_2d = _to_open_bspline_1d_impl(knots, p, ctrl_2d, periodic, tol)
 
-    # Determine how many knots to insert at each boundary.
-    left_at_domain = np.isclose(a_new, a, atol=tol)
-    right_at_domain = np.isclose(b_new, b, atol=tol)
+    # Compute and insert boundary knots.
+    knots_to_insert = _compute_boundary_knots_to_insert(knots, p, tol, a_new, b_new)
 
-    # Check for no-op: both bounds match the full domain and already open.
-    left_open = bool(np.isclose(knots[0], knots[p], atol=tol))
-    right_open = bool(np.isclose(knots[-p - 1], knots[-1], atol=tol))
-    if left_at_domain and right_at_domain and left_open and right_open:
-        raise ValueError("Bounds match the full domain and the direction is already open.")
-
-    # Count existing multiplicity and compute knots to insert.
-    knots_to_insert_list: list[float] = []
-
-    if left_at_domain and left_open:
-        # Left end is already clamped — no insertion needed.
-        pass
-    else:
-        # Count how many times a_new appears in the knot vector.
-        m_left = int(np.sum(np.isclose(knots, a_new, atol=tol)))
-        deficit = p + 1 - m_left
-        if deficit > 0:
-            knots_to_insert_list.extend([a_new] * deficit)
-
-    if right_at_domain and right_open:
-        # Right end is already clamped — no insertion needed.
-        pass
-    else:
-        m_right = int(np.sum(np.isclose(knots, b_new, atol=tol)))
-        deficit = p + 1 - m_right
-        if deficit > 0:
-            knots_to_insert_list.extend([b_new] * deficit)
-
-    # Insert knots if needed.
     refined_knots: npt.NDArray[np.float32 | np.float64]
     refined_ctrl: npt.NDArray[np.float32 | np.float64]
-    if knots_to_insert_list:
-        knots_to_insert = np.array(knots_to_insert_list, dtype=knots.dtype)
+    if knots_to_insert.size > 0:
         refined_knots, refined_ctrl = _insert_knots_bspline_1d_impl(
             knots, p, ctrl_2d, knots_to_insert, tol
         )
@@ -129,10 +177,8 @@ def _restrict_bspline_1d_impl(
         refined_knots, refined_ctrl = knots, ctrl_2d
 
     # Extract the sub-region [a_new, b_new].
-    # After insertion, a_new has multiplicity p+1 starting at some index i_start,
-    # and b_new has multiplicity p+1 ending at some index i_end.
-    # The new knot vector is refined_knots[i_start : i_end + 1].
-    # The new control points are refined_ctrl[i_start : i_end - p].
+    # After insertion, a_new has multiplicity p+1 starting at index i_start,
+    # and b_new has multiplicity p+1 ending at index i_end.
     i_start = int(np.searchsorted(refined_knots, a_new - tol))
     i_end = int(np.searchsorted(refined_knots, b_new + tol)) - 1
 
@@ -183,8 +229,6 @@ def _restrict_bspline_impl(
             new_spaces_1d.append(space_1d)
             continue
 
-        a_new, b_new = bounds
-
         # Move dimension i to the 0th axis and flatten remaining axes.
         moved_ctrl = np.moveaxis(ctrl, i, 0)
         orig_shape = moved_ctrl.shape
@@ -198,8 +242,7 @@ def _restrict_bspline_impl(
             pts_2d,
             space_1d.periodic,
             float(space_1d.tolerance),
-            a_new,
-            b_new,
+            bounds,
         )
 
         any_restricted = True
@@ -209,7 +252,9 @@ def _restrict_bspline_impl(
         new_moved_ctrl = restricted_pts_2d.reshape(new_shape)
         ctrl = np.moveaxis(new_moved_ctrl, 0, i)
 
-        new_spaces_1d.append(BsplineSpace1D(restricted_knots, space_1d.degree, periodic=False))
+        new_spaces_1d.append(
+            BsplineSpace1D(restricted_knots, space_1d.degree, periodic=False, snap_knots=False)
+        )
 
     if not any_restricted:
         raise ValueError(

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -1,0 +1,220 @@
+"""Layer 2 implementation for B-spline domain restriction.
+
+This module provides the algorithm for extracting a sub-region of the parametric
+domain of a B-spline. The core logic inserts knots at the new boundaries until they
+reach multiplicity ``degree + 1``, then extracts the relevant knot sub-vector and
+control points. An optimization skips insertion when a bound coincides with an
+already-open domain endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knot_insertion import (
+    _insert_knots_bspline_1d_impl,
+    _to_open_bspline_1d_impl,
+)
+
+if TYPE_CHECKING:
+    from . import Bspline
+
+
+def _restrict_bspline_1d_impl(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl_2d: npt.NDArray[np.float32 | np.float64],
+    periodic: bool,
+    tol: float,
+    a_new: float,
+    b_new: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Restrict a 1D B-spline to a sub-interval of its parametric domain.
+
+    Inserts knots at ``a_new`` and ``b_new`` until each has multiplicity
+    ``degree + 1``, then extracts the knot sub-vector and control points
+    corresponding to the interval ``[a_new, b_new]``.  Skips insertion when
+    a bound coincides with an already-open domain endpoint.
+
+    For periodic splines, the direction is first converted to open form via
+    :func:`_to_open_bspline_1d_impl`.
+
+    Args:
+        knots: Knot vector of shape ``(len(knots),)``.
+        degree: Polynomial degree.
+        ctrl_2d: Control point matrix of shape ``(n, rank)``.
+        periodic: Whether the spline is periodic.
+        tol: Knot comparison tolerance.
+        a_new: Left bound of the restricted domain.
+        b_new: Right bound of the restricted domain.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray]: ``(restricted_knots, restricted_ctrl)``
+        — the clamped knot vector on ``[a_new, b_new]`` and the corresponding
+        control points.
+
+    Raises:
+        ValueError: If ``a_new >= b_new``.
+        ValueError: If ``a_new`` or ``b_new`` lies outside the domain.
+        ValueError: If the bounds match the full domain and the direction is
+            already open (no-op).
+    """
+    p = degree
+    a = float(knots[p])
+    b = float(knots[-p - 1])
+
+    # Validate bounds.
+    if a_new >= b_new:
+        raise ValueError(f"Lower bound ({a_new}) must be strictly less than upper bound ({b_new}).")
+
+    if a_new < a and not np.isclose(a_new, a, atol=tol):
+        raise ValueError(f"Lower bound ({a_new}) is below the domain start ({a}).")
+    if b_new > b and not np.isclose(b_new, b, atol=tol):
+        raise ValueError(f"Upper bound ({b_new}) is above the domain end ({b}).")
+
+    # Snap bounds to domain endpoints if within tolerance.
+    if np.isclose(a_new, a, atol=tol):
+        a_new = a
+    if np.isclose(b_new, b, atol=tol):
+        b_new = b
+
+    # For periodic splines, convert to open form first.
+    if periodic:
+        knots, ctrl_2d = _to_open_bspline_1d_impl(knots, p, ctrl_2d, periodic, tol)
+
+    # Determine how many knots to insert at each boundary.
+    left_at_domain = np.isclose(a_new, a, atol=tol)
+    right_at_domain = np.isclose(b_new, b, atol=tol)
+
+    # Check for no-op: both bounds match the full domain and already open.
+    left_open = bool(np.isclose(knots[0], knots[p], atol=tol))
+    right_open = bool(np.isclose(knots[-p - 1], knots[-1], atol=tol))
+    if left_at_domain and right_at_domain and left_open and right_open:
+        raise ValueError("Bounds match the full domain and the direction is already open.")
+
+    # Count existing multiplicity and compute knots to insert.
+    knots_to_insert_list: list[float] = []
+
+    if left_at_domain and left_open:
+        # Left end is already clamped — no insertion needed.
+        pass
+    else:
+        # Count how many times a_new appears in the knot vector.
+        m_left = int(np.sum(np.isclose(knots, a_new, atol=tol)))
+        deficit = p + 1 - m_left
+        if deficit > 0:
+            knots_to_insert_list.extend([a_new] * deficit)
+
+    if right_at_domain and right_open:
+        # Right end is already clamped — no insertion needed.
+        pass
+    else:
+        m_right = int(np.sum(np.isclose(knots, b_new, atol=tol)))
+        deficit = p + 1 - m_right
+        if deficit > 0:
+            knots_to_insert_list.extend([b_new] * deficit)
+
+    # Insert knots if needed.
+    refined_knots: npt.NDArray[np.float32 | np.float64]
+    refined_ctrl: npt.NDArray[np.float32 | np.float64]
+    if knots_to_insert_list:
+        knots_to_insert = np.array(knots_to_insert_list, dtype=knots.dtype)
+        refined_knots, refined_ctrl = _insert_knots_bspline_1d_impl(
+            knots, p, ctrl_2d, knots_to_insert, tol
+        )
+    else:
+        refined_knots, refined_ctrl = knots, ctrl_2d
+
+    # Extract the sub-region [a_new, b_new].
+    # After insertion, a_new has multiplicity p+1 starting at some index i_start,
+    # and b_new has multiplicity p+1 ending at some index i_end.
+    # The new knot vector is refined_knots[i_start : i_end + 1].
+    # The new control points are refined_ctrl[i_start : i_end - p].
+    i_start = int(np.searchsorted(refined_knots, a_new - tol))
+    i_end = int(np.searchsorted(refined_knots, b_new + tol)) - 1
+
+    restricted_knots = refined_knots[i_start : i_end + 1].copy()
+    restricted_ctrl = refined_ctrl[i_start : i_end - p].copy()
+
+    return restricted_knots, restricted_ctrl
+
+
+def _restrict_bspline_impl(
+    bspline: Bspline,
+    bounds_per_dim: list[tuple[float, float] | None],
+) -> Bspline:
+    """Restrict a B-spline to a sub-region of its parametric domain.
+
+    Applies :func:`_restrict_bspline_1d_impl` per parametric direction using the
+    standard moveaxis pattern. Directions with ``None`` bounds are left unchanged.
+
+    Args:
+        bspline: Input B-spline.
+        bounds_per_dim: Per-direction bounds as ``(a_new, b_new)`` or ``None``
+            to skip. Must have length ``dim``.
+
+    Returns:
+        Bspline: New B-spline restricted to the specified sub-domain.
+
+    Raises:
+        ValueError: If every direction is a no-op (bounds match full domain
+            with already-open knots, or ``None``).
+    """
+    from . import (  # noqa: PLC0415
+        Bspline,
+        BsplineSpace,
+        BsplineSpace1D,
+    )
+
+    dim = bspline.dim
+    ctrl = bspline.control_points
+
+    any_restricted = False
+    new_spaces_1d: list[BsplineSpace1D] = []
+
+    for i in range(dim):
+        space_1d = bspline.space.spaces[i]
+        bounds = bounds_per_dim[i]
+
+        if bounds is None:
+            new_spaces_1d.append(space_1d)
+            continue
+
+        a_new, b_new = bounds
+
+        # Move dimension i to the 0th axis and flatten remaining axes.
+        moved_ctrl = np.moveaxis(ctrl, i, 0)
+        orig_shape = moved_ctrl.shape
+        pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        restricted_knots, restricted_pts_2d = _restrict_bspline_1d_impl(
+            space_1d.knots,
+            space_1d.degree,
+            pts_2d,
+            space_1d.periodic,
+            float(space_1d.tolerance),
+            a_new,
+            b_new,
+        )
+
+        any_restricted = True
+
+        # Restore multi-dimensional shape.
+        new_shape = (restricted_pts_2d.shape[0], *orig_shape[1:])
+        new_moved_ctrl = restricted_pts_2d.reshape(new_shape)
+        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+
+        new_spaces_1d.append(BsplineSpace1D(restricted_knots, space_1d.degree, periodic=False))
+
+    if not any_restricted:
+        raise ValueError(
+            "At least one direction must have non-None bounds that restrict the domain."
+        )
+
+    new_space = BsplineSpace(new_spaces_1d)
+    return Bspline(new_space, ctrl, is_rational=bspline.is_rational)

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -1,0 +1,323 @@
+"""Tests for Bspline.restrict() and Bezier.restrict()."""
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.quad import PointsLattice
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_open_bspline_1d(
+    degree: int = 2,
+    n_intervals: int = 4,
+    rank: int = 2,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 1D open B-spline with random control points."""
+    interior = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
+    knots = np.concatenate([[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]).astype(dtype)
+    space_1d = BsplineSpace1D(knots, degree)
+    space = BsplineSpace([space_1d])
+    rng = np.random.default_rng(42)
+    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_open_bspline_2d(
+    degrees: tuple[int, int] = (2, 1),
+    n_intervals: tuple[int, int] = (4, 3),
+    rank: int = 3,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 2D open tensor-product B-spline with random control points."""
+    spaces: list[BsplineSpace1D] = []
+    for p, n_int in zip(degrees, n_intervals, strict=True):
+        interior = np.linspace(0.0, 1.0, n_int + 1, dtype=dtype)[1:-1]
+        knots = np.concatenate([[0.0] * (p + 1), interior, [1.0] * (p + 1)]).astype(dtype)
+        spaces.append(BsplineSpace1D(knots, p))
+    space = BsplineSpace(spaces)
+    rng = np.random.default_rng(42)
+    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_periodic_bspline(
+    num_intervals: int = 4,
+    degree: int = 2,
+    rank: int = 2,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 1D periodic B-spline with random control points."""
+    knots = create_uniform_periodic(num_intervals, degree, dtype=dtype)
+    space_1d = BsplineSpace1D(knots, degree, periodic=True)
+    space = BsplineSpace([space_1d])
+    rng = np.random.default_rng(42)
+    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_rational_bspline_1d(
+    degree: int = 2,
+    n_intervals: int = 3,
+    dtype: type = np.float64,
+) -> Bspline:
+    """Create a 1D rational B-spline (NURBS) with random control points and weights."""
+    interior = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
+    knots = np.concatenate([[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]).astype(dtype)
+    space_1d = BsplineSpace1D(knots, degree)
+    space = BsplineSpace([space_1d])
+    rng = np.random.default_rng(42)
+    n = space.num_total_basis
+    # rank 3: (x, y, w) in homogeneous coordinates
+    ctrl = rng.random((n, 3)).astype(dtype)
+    ctrl[:, 2] = rng.uniform(0.5, 2.0, size=n).astype(dtype)  # positive weights
+    return Bspline(space, ctrl, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Bspline.restrict — 1D
+# ---------------------------------------------------------------------------
+
+
+class TestBsplineRestrict1D:
+    """Tests for Bspline.restrict() on 1D B-splines."""
+
+    def test_interior_subinterval(self) -> None:
+        """Restrict to an interior sub-interval and verify evaluation agreement."""
+        f = _make_open_bspline_1d()
+        r = f.restrict((0.25, 0.75))
+
+        pts = np.linspace(0.25, 0.75, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-14)
+
+    def test_left_at_domain(self) -> None:
+        """Restrict with left bound at domain start (skip left insertion)."""
+        f = _make_open_bspline_1d()
+        r = f.restrict((0.0, 0.5))
+
+        pts = np.linspace(0.0, 0.5, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-14)
+
+    def test_right_at_domain(self) -> None:
+        """Restrict with right bound at domain end (skip right insertion)."""
+        f = _make_open_bspline_1d()
+        r = f.restrict((0.5, 1.0))
+
+        pts = np.linspace(0.5, 1.0, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-14)
+
+    def test_single_span(self) -> None:
+        """Restrict to a single knot span produces a Bézier-like result."""
+        f = _make_open_bspline_1d(degree=2, n_intervals=4)
+        r = f.restrict((0.25, 0.5))
+
+        assert r.space.has_Bezier_like_knots()
+        pts = np.linspace(0.25, 0.5, 50)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-14)
+
+    def test_at_existing_knots(self) -> None:
+        """Restrict at values that are already knots (less insertion needed)."""
+        f = _make_open_bspline_1d(degree=2, n_intervals=4)
+        # Knots are at 0, 0.25, 0.5, 0.75, 1.0
+        r = f.restrict((0.25, 0.75))
+
+        pts = np.linspace(0.25, 0.75, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-14)
+
+    def test_higher_degree(self) -> None:
+        """Restrict works with higher degree B-splines."""
+        f = _make_open_bspline_1d(degree=4, n_intervals=6)
+        r = f.restrict((0.2, 0.8))
+
+        pts = np.linspace(0.2, 0.8, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-13)
+
+    def test_periodic_auto_convert(self) -> None:
+        """Restrict on a periodic B-spline auto-converts to open form."""
+        f = _make_periodic_bspline(num_intervals=4, degree=2)
+        f_open = f.to_open_bspline()
+        r = f.restrict((0.25, 0.75))
+
+        assert not r.space.spaces[0].periodic
+        assert r.space.spaces[0].has_open_knots()
+        pts = np.linspace(0.25, 0.75, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f_open.evaluate(pts), atol=1e-13)
+
+    def test_rational(self) -> None:
+        """Restrict preserves rationality and evaluates correctly."""
+        f = _make_rational_bspline_1d()
+        r = f.restrict((0.2, 0.8))
+
+        assert r.is_rational
+        pts = np.linspace(0.2, 0.8, 100)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-13)
+
+    def test_domain_is_correct(self) -> None:
+        """Restricted B-spline has the correct domain."""
+        f = _make_open_bspline_1d()
+        r = f.restrict((0.3, 0.7))
+
+        domain = r.space.domain
+        np.testing.assert_allclose(domain[0, 0], 0.3, atol=1e-15)
+        np.testing.assert_allclose(domain[0, 1], 0.7, atol=1e-15)
+
+    def test_float32(self) -> None:
+        """Restrict works with float32 B-splines."""
+        f = _make_open_bspline_1d(dtype=np.float32)
+        r = f.restrict((0.25, 0.75))
+
+        assert r.dtype == np.float32
+        pts = np.linspace(0.25, 0.75, 50, dtype=np.float32)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Bspline.restrict — error cases
+# ---------------------------------------------------------------------------
+
+
+class TestBsplineRestrictErrors:
+    """Tests for Bspline.restrict() error handling."""
+
+    def test_full_domain_raises(self) -> None:
+        """Restrict to the full domain raises ValueError."""
+        f = _make_open_bspline_1d()
+        with pytest.raises(ValueError, match="full domain"):
+            f.restrict((0.0, 1.0))
+
+    def test_lower_ge_upper_raises(self) -> None:
+        """Lower bound >= upper bound raises ValueError."""
+        f = _make_open_bspline_1d()
+        with pytest.raises(ValueError, match="strictly less"):
+            f.restrict((0.5, 0.5))
+        with pytest.raises(ValueError, match="strictly less"):
+            f.restrict((0.7, 0.3))
+
+    def test_out_of_domain_lower_raises(self) -> None:
+        """Lower bound below domain raises ValueError."""
+        f = _make_open_bspline_1d()
+        with pytest.raises(ValueError, match="below the domain"):
+            f.restrict((-0.1, 0.5))
+
+    def test_out_of_domain_upper_raises(self) -> None:
+        """Upper bound above domain raises ValueError."""
+        f = _make_open_bspline_1d()
+        with pytest.raises(ValueError, match="above the domain"):
+            f.restrict((0.5, 1.1))
+
+    def test_wrong_dim_raises(self) -> None:
+        """Wrong sequence length for nD raises ValueError."""
+        f = _make_open_bspline_2d()
+        with pytest.raises(ValueError, match="must match dim"):
+            f.restrict([(0.1, 0.9)])  # only 1 direction for a 2D spline
+
+    def test_all_none_raises(self) -> None:
+        """All directions None raises ValueError."""
+        f = _make_open_bspline_2d()
+        with pytest.raises(ValueError, match="non-None bounds"):
+            f.restrict([None, None])
+
+
+# ---------------------------------------------------------------------------
+# Bspline.restrict — nD
+# ---------------------------------------------------------------------------
+
+
+class TestBsplineRestrictND:
+    """Tests for Bspline.restrict() on multi-dimensional B-splines."""
+
+    def test_restrict_one_direction(self) -> None:
+        """Restrict 2D B-spline in one direction only."""
+        f = _make_open_bspline_2d()
+        r = f.restrict([(0.25, 0.75), None])
+
+        # Direction 0 is restricted, direction 1 unchanged.
+        domain = r.space.domain
+        np.testing.assert_allclose(domain[0], [0.25, 0.75], atol=1e-15)
+        np.testing.assert_allclose(domain[1], [0.0, 1.0], atol=1e-15)
+
+    def test_restrict_both_directions(self) -> None:
+        """Restrict 2D B-spline in both directions."""
+        f = _make_open_bspline_2d()
+        r = f.restrict([(0.25, 0.75), (0.33, 0.67)])
+
+        domain = r.space.domain
+        np.testing.assert_allclose(domain[0], [0.25, 0.75], atol=1e-15)
+        np.testing.assert_allclose(domain[1], [0.33, 0.67], atol=1e-15)
+
+    def test_restrict_2d_evaluation(self) -> None:
+        """Restricted 2D B-spline evaluates the same as original on subdomain."""
+        f = _make_open_bspline_2d()
+        r = f.restrict([(0.25, 0.75), (0.33, 0.67)])
+
+        pts_u = np.linspace(0.25, 0.75, 20)
+        pts_v = np.linspace(0.33, 0.67, 15)
+        lattice = PointsLattice([pts_u, pts_v])
+
+        np.testing.assert_allclose(r.evaluate(lattice), f.evaluate(lattice), atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Bezier.restrict
+# ---------------------------------------------------------------------------
+
+
+class TestBezierRestrict:
+    """Tests for Bezier.restrict()."""
+
+    def test_1d_restrict(self) -> None:
+        """Restrict a 1D Bézier to a sub-interval and verify reparametrization."""
+        ctrl = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        bez = Bezier(ctrl)
+        r = bez.restrict((0.2, 0.8))
+
+        assert r.degree == (2,)
+        # r evaluates on [0,1], maps to bez on [0.2, 0.8]
+        t_restr = np.linspace(0.0, 1.0, 100)
+        t_mapped = 0.2 + 0.6 * t_restr
+        np.testing.assert_allclose(r.evaluate(t_restr), bez.evaluate(t_mapped), atol=1e-14)
+
+    def test_1d_restrict_higher_degree(self) -> None:
+        """Restrict a cubic Bézier."""
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((4, 3))
+        bez = Bezier(ctrl)
+        r = bez.restrict((0.1, 0.9))
+
+        t_restr = np.linspace(0.0, 1.0, 100)
+        t_mapped = 0.1 + 0.8 * t_restr
+        np.testing.assert_allclose(r.evaluate(t_restr), bez.evaluate(t_mapped), atol=1e-13)
+
+    def test_nd_restrict_one_direction(self) -> None:
+        """Restrict a 2D Bézier in one direction."""
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((3, 4, 2))
+        bez = Bezier(ctrl)
+        r = bez.restrict([(0.2, 0.8), None])
+
+        assert r.degree == (2, 3)
+
+    def test_rational(self) -> None:
+        """Restrict a rational Bézier preserves rationality."""
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((3, 3))
+        ctrl[:, 2] = rng.uniform(0.5, 2.0, size=3)
+        bez = Bezier(ctrl, is_rational=True)
+        r = bez.restrict((0.2, 0.8))
+
+        assert r.is_rational
+        t_restr = np.linspace(0.0, 1.0, 100)
+        t_mapped = 0.2 + 0.6 * t_restr  # [0,1] -> [0.2, 0.8]
+        np.testing.assert_allclose(r.evaluate(t_restr), bez.evaluate(t_mapped), atol=1e-13)
+
+    def test_full_domain_raises(self) -> None:
+        """Restrict to full [0, 1] raises ValueError."""
+        ctrl = np.array([[0.0], [1.0], [2.0]])
+        bez = Bezier(ctrl)
+        with pytest.raises(ValueError, match="full domain"):
+            bez.restrict((0.0, 1.0))

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -1,6 +1,7 @@
 """Tests for Bspline.restrict() and Bezier.restrict()."""
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
@@ -19,12 +20,14 @@ def _make_open_bspline_1d(
     dtype: type = np.float64,
 ) -> Bspline:
     """Create a 1D open B-spline with random control points."""
-    interior = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
-    knots = np.concatenate([[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]).astype(dtype)
+    interior: npt.NDArray[np.float64] = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
+    knots: npt.NDArray[np.float64] = np.concatenate(
+        [[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]
+    ).astype(dtype)
     space_1d = BsplineSpace1D(knots, degree)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)
-    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    ctrl: npt.NDArray[np.float64] = rng.random((space.num_total_basis, rank)).astype(dtype)
     return Bspline(space, ctrl)
 
 
@@ -37,12 +40,14 @@ def _make_open_bspline_2d(
     """Create a 2D open tensor-product B-spline with random control points."""
     spaces: list[BsplineSpace1D] = []
     for p, n_int in zip(degrees, n_intervals, strict=True):
-        interior = np.linspace(0.0, 1.0, n_int + 1, dtype=dtype)[1:-1]
-        knots = np.concatenate([[0.0] * (p + 1), interior, [1.0] * (p + 1)]).astype(dtype)
+        interior: npt.NDArray[np.float64] = np.linspace(0.0, 1.0, n_int + 1, dtype=dtype)[1:-1]
+        knots: npt.NDArray[np.float64] = np.concatenate(
+            [[0.0] * (p + 1), interior, [1.0] * (p + 1)]
+        ).astype(dtype)
         spaces.append(BsplineSpace1D(knots, p))
     space = BsplineSpace(spaces)
     rng = np.random.default_rng(42)
-    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    ctrl: npt.NDArray[np.float64] = rng.random((space.num_total_basis, rank)).astype(dtype)
     return Bspline(space, ctrl)
 
 
@@ -57,7 +62,7 @@ def _make_periodic_bspline(
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)
-    ctrl = rng.random((space.num_total_basis, rank)).astype(dtype)
+    ctrl: npt.NDArray[np.float64] = rng.random((space.num_total_basis, rank)).astype(dtype)
     return Bspline(space, ctrl)
 
 
@@ -67,14 +72,16 @@ def _make_rational_bspline_1d(
     dtype: type = np.float64,
 ) -> Bspline:
     """Create a 1D rational B-spline (NURBS) with random control points and weights."""
-    interior = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
-    knots = np.concatenate([[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]).astype(dtype)
+    interior: npt.NDArray[np.float64] = np.linspace(0.0, 1.0, n_intervals + 1, dtype=dtype)[1:-1]
+    knots: npt.NDArray[np.float64] = np.concatenate(
+        [[0.0] * (degree + 1), interior, [1.0] * (degree + 1)]
+    ).astype(dtype)
     space_1d = BsplineSpace1D(knots, degree)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)
     n = space.num_total_basis
     # rank 3: (x, y, w) in homogeneous coordinates
-    ctrl = rng.random((n, 3)).astype(dtype)
+    ctrl: npt.NDArray[np.float64] = rng.random((n, 3)).astype(dtype)
     ctrl[:, 2] = rng.uniform(0.5, 2.0, size=n).astype(dtype)  # positive weights
     return Bspline(space, ctrl, is_rational=True)
 


### PR DESCRIPTION
## Summary
- Add `Bspline.restrict(bounds)` method that extracts a sub-region of the parametric domain by inserting knots at the new boundaries until they reach multiplicity `degree + 1`, then slicing the knot vector and control points
- Add `Bezier.restrict(bounds)` method that restricts and reparametrizes back to `[0, 1]` via B-spline conversion
- Smart skip of knot insertion when a bound coincides with an already-open domain endpoint
- Auto-converts periodic B-splines to open form before restricting
- Supports per-direction bounds with `None` to skip directions (nD case)
- Fix `snap_knots` floating-point precision issue by using `snap_knots=False` for restricted knot vectors

## Test plan
- [x] 1D open B-spline: interior sub-interval, boundary-at-domain, single-span, existing-knot, higher-degree
- [x] Periodic B-spline auto-conversion
- [x] Rational B-spline (NURBS)
- [x] float32 dtype
- [x] 2D B-spline: one direction, both directions, lattice evaluation
- [x] Bézier 1D, nD, rational with reparametrization verification
- [x] Error cases: out-of-domain, reversed bounds, full-domain no-op, wrong dim, all-None
- [x] Pre-PR checks pass (ruff, mypy, pytest 1299 passed, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)