### PR TITLE
feat(bspline): add slice and boundary methods

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -25,6 +25,7 @@ from ._bspline_knot_insertion import (
 )
 from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_restrict import _restrict_bspline_impl
+from ._bspline_slice import _slice_bspline
 
 if TYPE_CHECKING:
     from ..quad import PointsLattice
@@ -793,3 +794,92 @@ class Bspline:
                 new_knots_per_dim.append(nk)
 
         return _insert_knots_bspline(self, new_knots_per_dim)
+
+    def slice(self, axis: int, value: float) -> Bspline | npt.NDArray[np.float32 | np.float64]:
+        """Slice the B-spline by fixing one parametric direction at a given value.
+
+        Reduces the parametric dimension by one using de Boor corner cutting
+        on the control points.  A volume becomes a surface, a surface becomes
+        a curve, and a curve becomes a point (returned as a NumPy array).
+
+        When the parameter value coincides with a knot of multiplicity ``s``,
+        only ``p - s`` de Boor iterations are needed.  At a C0 knot
+        (``s >= p``) the result is obtained in O(1) by direct control point
+        lookup.
+
+        Args:
+            axis (int): Parametric direction to fix (0-indexed).
+                Must be in ``[0, dim)``.
+            value (float): Parameter value at which to slice.  Must lie
+                within the domain of the specified direction.
+
+        Returns:
+            Bspline | npt.NDArray[np.float32 | np.float64]:
+            A B-spline with ``dim - 1`` dimensions when ``dim >= 2``,
+            or a NumPy array of shape ``(rank,)`` when ``dim == 1``.
+            Rational B-splines preserve the NURBS structure when ``dim >= 2``;
+            for ``dim == 1`` the result is projected to physical coordinates.
+
+        Raises:
+            ValueError: If ``axis`` is out of range ``[0, dim)``.
+            ValueError: If ``value`` is outside the domain of the specified
+                direction.
+
+        Example:
+            >>> # Slice a surface at v=0.5 to get a curve
+            >>> curve = surface.slice(1, 0.5)
+            >>> # Slice a volume at w=0.3 to get a surface
+            >>> srf = volume.slice(2, 0.3)
+            >>> # Composable: volume -> surface -> curve -> point
+            >>> pt = volume.slice(2, 0.3).slice(1, 0.5).slice(0, 0.2)
+        """
+        if axis < 0 or axis >= self.dim:
+            raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
+
+        space_d = self.space.spaces[axis]
+        domain = space_d.domain
+        tol = float(space_d.tolerance)
+        if value < float(domain[0]) - tol or value > float(domain[1]) + tol:
+            raise ValueError(
+                f"value {value} is outside the domain [{domain[0]}, {domain[1]}] "
+                f"of direction {axis}."
+            )
+
+        return _slice_bspline(self, axis, value)
+
+    def boundary(self, axis: int, side: int) -> Bspline | npt.NDArray[np.float32 | np.float64]:
+        """Extract the boundary of the B-spline along one parametric direction.
+
+        Returns the restriction of the B-spline to one end of the domain
+        in the given direction.
+
+        Args:
+            axis (int): Parametric direction (0-indexed).
+                Must be in ``[0, dim)``.
+            side (int): Which end of the domain: ``0`` for the start,
+                ``1`` for the end.
+
+        Returns:
+            Bspline | npt.NDArray[np.float32 | np.float64]:
+            A B-spline with ``dim - 1`` dimensions when ``dim >= 2``,
+            or a NumPy array of shape ``(rank,)`` when ``dim == 1``.
+
+        Raises:
+            ValueError: If ``axis`` is out of range ``[0, dim)``.
+            ValueError: If ``side`` is not 0 or 1.
+
+        Example:
+            >>> # Extract left boundary of a surface along direction 0
+            >>> left_curve = surface.boundary(0, 0)
+            >>> # Extract right boundary along direction 1
+            >>> right_curve = surface.boundary(1, 1)
+        """
+        if side not in (0, 1):
+            raise ValueError(f"side must be 0 or 1, got {side}.")
+        if axis < 0 or axis >= self.dim:
+            raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
+
+        space_d = self.space.spaces[axis]
+        domain = space_d.domain
+        value = float(domain[0]) if side == 0 else float(domain[1])
+        return self.slice(axis, value)

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -504,6 +504,82 @@ def _get_knots_ends_and_dtype(
     return start_value, end_value, dtype_obj
 
 
+def _find_span(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    n_basis: int,
+    value: float,
+    tol: float,
+) -> tuple[int, float]:
+    """Find the knot span index for a parameter value (Piegl-Tiller convention).
+
+    Returns the span index ``k`` such that ``knots[k] <= u < knots[k+1]``,
+    with the convention that at the right boundary ``k = n_basis - 1``.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): Polynomial degree.
+        n_basis (int): Number of basis functions.
+        value (float): Parameter value (must be in the domain).
+        tol (float): Tolerance for boundary clamping.
+
+    Returns:
+        tuple[int, float]: ``(k, u)`` where ``k`` is the span index and
+        ``u`` is the (possibly clamped) parameter value.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    u = float(value)
+    u_left = float(knots[degree])
+    u_right = float(knots[n_basis])
+
+    # Clamp to domain boundaries.
+    if u <= u_left + tol:
+        return degree, u_left
+    if u >= u_right - tol:
+        return n_basis - 1, u_right
+
+    # Interior: binary search via searchsorted.
+    k = int(np.searchsorted(knots, u, side="right")) - 1
+    return k, u
+
+
+def _count_multiplicity(
+    knots: npt.NDArray[np.float32 | np.float64],
+    k: int,
+    degree: int,
+    u: float,
+    tol: float,
+) -> int:
+    """Count the multiplicity of ``u`` among the local knots around span ``k``.
+
+    Scans knots ``k``, ``k-1``, ... going left while they match ``u``
+    (within tolerance).  This gives the number of consecutive knots equal
+    to ``u`` ending at position ``k``.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        k (int): Span index from :func:`_find_span`.
+        degree (int): Polynomial degree.
+        u (float): Parameter value.
+        tol (float): Tolerance for knot coincidence tests.
+
+    Returns:
+        int: Multiplicity of ``u`` in the local knot neighborhood.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    s = 0
+    for i in range(k, max(k - degree - 1, -1), -1):
+        if abs(float(knots[i]) - u) <= tol:
+            s += 1
+        else:
+            break
+    return s
+
+
 def _find_knot_index_and_multiplicity(
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
@@ -579,7 +655,9 @@ def _warmup_numba_functions() -> None:
 
 __all__ = [
     "_check_spline_info",
+    "_count_multiplicity",
     "_find_knot_index_and_multiplicity",
+    "_find_span",
     "_get_Bspline_cardinal_intervals_1D_impl",
     "_get_Bspline_num_basis_1D_impl",
     "_get_knots_ends_and_dtype",

--- a/src/pantr/bspline/_bspline_slice.py
+++ b/src/pantr/bspline/_bspline_slice.py
@@ -19,88 +19,11 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import numpy.typing as npt
 
+from ._bspline_knots import _count_multiplicity, _find_span
 from ._bspline_space_nd import BsplineSpace
 
 if TYPE_CHECKING:
     from . import Bspline
-
-
-def _find_span(
-    knots: npt.NDArray[np.float32 | np.float64],
-    degree: int,
-    n_basis: int,
-    value: float,
-    tol: float,
-) -> tuple[int, float]:
-    """Find the knot span index for a parameter value (Piegl-Tiller convention).
-
-    Returns the span index ``k`` such that ``knots[k] <= u < knots[k+1]``,
-    with the convention that at the right boundary ``k = n_basis - 1``.
-
-    Args:
-        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
-        degree (int): Polynomial degree.
-        n_basis (int): Number of basis functions.
-        value (float): Parameter value (must be in the domain).
-        tol (float): Tolerance for boundary clamping.
-
-    Returns:
-        tuple[int, float]: ``(k, u)`` where ``k`` is the span index and
-        ``u`` is the (possibly clamped) parameter value.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_slice_bspline` instead.
-    """
-    u = float(value)
-    u_left = float(knots[degree])
-    u_right = float(knots[n_basis])
-
-    # Clamp to domain boundaries.
-    if u <= u_left + tol:
-        return degree, u_left
-    if u >= u_right - tol:
-        return n_basis - 1, u_right
-
-    # Interior: binary search via searchsorted.
-    k = int(np.searchsorted(knots, u, side="right")) - 1
-    return k, u
-
-
-def _count_multiplicity(
-    knots: npt.NDArray[np.float32 | np.float64],
-    k: int,
-    degree: int,
-    u: float,
-    tol: float,
-) -> int:
-    """Count the multiplicity of ``u`` among the local knots around span ``k``.
-
-    Scans knots ``k``, ``k-1``, ... going left while they match ``u``
-    (within tolerance).  This gives the number of consecutive knots equal
-    to ``u`` ending at position ``k``.
-
-    Args:
-        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
-        k (int): Span index from :func:`_find_span`.
-        degree (int): Polynomial degree.
-        u (float): Parameter value.
-        tol (float): Tolerance for knot coincidence tests.
-
-    Returns:
-        int: Multiplicity of ``u`` in the local knot neighborhood.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_slice_bspline` instead.
-    """
-    s = 0
-    for i in range(k, max(k - degree - 1, -1), -1):
-        if abs(float(knots[i]) - u) <= tol:
-            s += 1
-        else:
-            break
-    return s
 
 
 def _slice_bspline_1d(

--- a/src/pantr/bspline/_bspline_slice.py
+++ b/src/pantr/bspline/_bspline_slice.py
@@ -1,0 +1,242 @@
+"""B-spline slicing (dimension reduction by fixing one parametric direction).
+
+This module provides :func:`_slice_bspline`, which fixes one parametric
+direction of a B-spline at a given value and returns a B-spline with one
+fewer dimension.  For a 1D B-spline the result is a plain NumPy array
+(the evaluated point).
+
+The core algorithm is de Boor corner cutting on the control points along
+the sliced axis.  When the parameter value coincides with a knot of high
+multiplicity, fewer de Boor iterations are needed; at a C0 knot
+(multiplicity ``>= p``) the result is obtained in O(1) by direct control
+point lookup.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from . import Bspline
+
+
+def _find_span(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    n_basis: int,
+    value: float,
+    tol: float,
+) -> tuple[int, float]:
+    """Find the knot span index for a parameter value (Piegl-Tiller convention).
+
+    Returns the span index ``k`` such that ``knots[k] <= u < knots[k+1]``,
+    with the convention that at the right boundary ``k = n_basis - 1``.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): Polynomial degree.
+        n_basis (int): Number of basis functions.
+        value (float): Parameter value (must be in the domain).
+        tol (float): Tolerance for boundary clamping.
+
+    Returns:
+        tuple[int, float]: ``(k, u)`` where ``k`` is the span index and
+        ``u`` is the (possibly clamped) parameter value.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_slice_bspline` instead.
+    """
+    u = float(value)
+    u_left = float(knots[degree])
+    u_right = float(knots[n_basis])
+
+    # Clamp to domain boundaries.
+    if u <= u_left + tol:
+        return degree, u_left
+    if u >= u_right - tol:
+        return n_basis - 1, u_right
+
+    # Interior: binary search via searchsorted.
+    k = int(np.searchsorted(knots, u, side="right")) - 1
+    return k, u
+
+
+def _count_multiplicity(
+    knots: npt.NDArray[np.float32 | np.float64],
+    k: int,
+    degree: int,
+    u: float,
+    tol: float,
+) -> int:
+    """Count the multiplicity of ``u`` among the local knots around span ``k``.
+
+    Scans knots ``k``, ``k-1``, ... going left while they match ``u``
+    (within tolerance).  This gives the number of consecutive knots equal
+    to ``u`` ending at position ``k``.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        k (int): Span index from :func:`_find_span`.
+        degree (int): Polynomial degree.
+        u (float): Parameter value.
+        tol (float): Tolerance for knot coincidence tests.
+
+    Returns:
+        int: Multiplicity of ``u`` in the local knot neighborhood.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_slice_bspline` instead.
+    """
+    s = 0
+    for i in range(k, max(k - degree - 1, -1), -1):
+        if abs(float(knots[i]) - u) <= tol:
+            s += 1
+        else:
+            break
+    return s
+
+
+def _slice_bspline_1d(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    value: float,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Slice a 1D B-spline's control points at a parameter value via corner cutting.
+
+    Uses the CurvePntByCornerCut algorithm (Piegl-Tiller A5.1) to evaluate
+    the B-spline at a single parameter value.  The result is computed from
+    ``p - s + 1`` local control points in ``p - s`` triangular iterations,
+    where ``s`` is the knot multiplicity at ``u``.
+
+    When the parameter value coincides with a knot of multiplicity ``s``,
+    only ``p - s`` iterations are needed.  At a C0 knot (``s >= p``)
+    the control point is returned directly with no iteration.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector of length
+            ``n_basis + degree + 1``.
+        degree (int): Polynomial degree.
+        tol (float): Tolerance for knot coincidence tests.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(n_basis, n_cols)``.
+        value (float): Parameter value at which to slice.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Result array of shape ``(n_cols,)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_slice_bspline` instead.
+    """
+    n_basis = ctrl.shape[0]
+    k, u = _find_span(knots, degree, n_basis, value, tol)
+    s = _count_multiplicity(knots, k, degree, u, tol)
+
+    # C0 optimization: when multiplicity >= degree, only one basis function
+    # is non-zero at u (namely B_{k-p}), so the result is that control point.
+    if s >= degree:
+        return cast(npt.NDArray[np.float32 | np.float64], ctrl[k - degree].copy())
+
+    # CurvePntByCornerCut (Piegl-Tiller A5.1).
+    r = degree - s
+    R = ctrl[k - degree : k - degree + r + 1].copy()  # shape (r+1, n_cols)
+
+    _zero_denom_tol = 1e-300
+    for j in range(1, r + 1):
+        for i in range(r - j + 1):
+            left_knot = float(knots[k - degree + j + i])
+            right_knot = float(knots[i + k + 1])
+            denom = right_knot - left_knot
+            alpha = 0.0 if abs(denom) < _zero_denom_tol else (u - left_knot) / denom
+            R[i] = alpha * R[i + 1] + (1.0 - alpha) * R[i]
+
+    return cast(npt.NDArray[np.float32 | np.float64], R[0])
+
+
+def _slice_bspline(
+    bspline: Bspline,
+    axis: int,
+    value: float,
+) -> Bspline | npt.NDArray[np.float32 | np.float64]:
+    """Slice a B-spline by fixing one parametric direction at a given value.
+
+    Reduces the parametric dimension by one.  For a 1D B-spline, returns
+    the evaluated point as a NumPy array.  For higher dimensions, returns
+    a new :class:`~pantr.bspline.Bspline`.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): The B-spline to slice.
+        axis (int): Parametric direction to fix (0-indexed, must be in
+            ``[0, dim)``).
+        value (float): Parameter value at which to slice (must be in the
+            domain of the specified direction).
+
+    Returns:
+        ~pantr.bspline.Bspline | npt.NDArray[np.float32 | np.float64]:
+        A B-spline with ``dim - 1`` dimensions (when ``dim >= 2``),
+        or a NumPy array of shape ``(rank,)`` (when ``dim == 1``).
+        Rational B-splines preserve the NURBS structure when ``dim >= 2``;
+        for ``dim == 1`` the result is projected to physical coordinates.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bspline.Bspline.slice` instead.
+    """
+    from . import Bspline as BsplineCls  # noqa: PLC0415
+
+    space_d = bspline.space.spaces[axis]
+    knots = space_d.knots
+    p = space_d.degree
+    tol = float(space_d.tolerance)
+    ctrl = bspline.control_points
+    is_periodic = space_d.periodic
+
+    # For periodic: expand CPs to full representation along the target axis.
+    if is_periodic:
+        n_periodic = space_d.num_basis
+        n_full = len(knots) - p - 1
+        indices = np.arange(n_full) % n_periodic
+        ctrl = np.take(ctrl, indices, axis=axis)
+
+    # Move target axis to position 0, flatten the rest into a single axis.
+    moved = np.moveaxis(ctrl, axis, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    # Apply 1D de Boor corner cutting.
+    result_1d = _slice_bspline_1d(knots, p, tol, pts_2d, value)
+
+    if bspline.dim == 1:
+        # Result is a point. For rational B-splines, project to physical coords.
+        # Control points shape is (n_basis, rank + 1) for rational.
+        if bspline.is_rational:
+            weight = result_1d[-1]
+            return cast(npt.NDArray[np.float32 | np.float64], result_1d[:-1] / weight)
+        return result_1d
+
+    # Restore shape: remove the sliced axis dimension.
+    new_shape = orig_shape[1:]
+    result_nd = result_1d.reshape(new_shape)
+
+    # Move axis is not needed since we removed axis 0 entirely.
+    # The remaining shape is the original shape minus the sliced direction.
+    # result_nd already has shape (*other_dims, rank).
+    new_ctrl = result_nd
+
+    # Build new spaces list: remove the sliced direction.
+    new_spaces = [s for i, s in enumerate(bspline.space.spaces) if i != axis]
+    new_space = BsplineSpace(new_spaces)
+
+    return BsplineCls(new_space, new_ctrl, is_rational=bspline.is_rational)

--- a/tests/test_bspline_slice.py
+++ b/tests/test_bspline_slice.py
@@ -1,0 +1,366 @@
+"""Tests for Bspline.slice() and Bspline.boundary() methods."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_1d_curve(degree: int = 3, dtype: type = np.float64) -> Bspline:
+    """Create a 1D cubic curve with 5 control points."""
+    knots: npt.NDArray[np.float64] = np.array([0, 0, 0, 0, 0.5, 1, 1, 1, 1], dtype=dtype)
+    ctrl: npt.NDArray[np.float64] = np.array([[0, 0], [1, 2], [3, 3], [5, 1], [6, 0]], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    return Bspline(space, ctrl)
+
+
+def _make_2d_surface(dtype: type = np.float64) -> Bspline:
+    """Create a 2D quadratic surface (3x3 control points, rank 3)."""
+    knots: npt.NDArray[np.float64] = np.array([0, 0, 0, 1, 1, 1], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots, 2), BsplineSpace1D(knots, 2)])
+    rng = np.random.default_rng(42)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_3d_volume(dtype: type = np.float64) -> Bspline:
+    """Create a 3D linear volume (2x2x2 control points, rank 3)."""
+    knots = [0.0, 0.0, 1.0, 1.0]
+    space = BsplineSpace([BsplineSpace1D(knots, 1)] * 3)
+    rng = np.random.default_rng(123)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((2, 2, 2, 3)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_c0_surface(dtype: type = np.float64) -> Bspline:
+    """Create a surface with C0 knot at u=0.5 (quadratic, 2 patches in u)."""
+    knots_u = [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0]
+    knots_v = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    space = BsplineSpace([BsplineSpace1D(knots_u, 2), BsplineSpace1D(knots_v, 2)])
+    rng = np.random.default_rng(7)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((5, 3, 3)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_rational_curve(dtype: type = np.float64) -> Bspline:
+    """Create a rational quadratic B-spline (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    ctrl: npt.NDArray[np.float64] = np.array([[1, 0, 1], [w, w, w], [0, 1, 1]], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    return Bspline(space, ctrl, is_rational=True)
+
+
+def _make_rational_surface(dtype: type = np.float64) -> Bspline:
+    """Create a rational quadratic surface."""
+    knots = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    space = BsplineSpace([BsplineSpace1D(knots, 2), BsplineSpace1D(knots, 2)])
+    rng = np.random.default_rng(99)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    ctrl[:, :, -1] = np.abs(ctrl[:, :, -1]) + 0.5
+    return Bspline(space, ctrl, is_rational=True)
+
+
+def _make_periodic_curve(dtype: type = np.float64) -> Bspline:
+    """Create a periodic cubic B-spline curve."""
+    knots = create_uniform_periodic(num_intervals=4, degree=3, continuity=2, dtype=dtype)
+    space_1d = BsplineSpace1D(knots, 3, periodic=True)
+    space = BsplineSpace([space_1d])
+    rng = np.random.default_rng(55)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((space_1d.num_basis, 2)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_periodic_surface(dtype: type = np.float64) -> Bspline:
+    """Create a surface with one periodic direction."""
+    knots_u = create_uniform_periodic(num_intervals=3, degree=2, continuity=1, dtype=dtype)
+    space_u = BsplineSpace1D(knots_u, 2, periodic=True)
+    space_v = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
+    space = BsplineSpace([space_u, space_v])
+    rng = np.random.default_rng(77)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((space_u.num_basis, 3, 3)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.slice()
+# ---------------------------------------------------------------------------
+
+
+class TestSlice1D:
+    """Test slicing a 1D curve (produces a point)."""
+
+    def test_slice_matches_evaluate(self) -> None:
+        """Slicing a curve at u should match evaluate([u])."""
+        crv = _make_1d_curve()
+        for u in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_slice = crv.slice(0, u)
+            pt_eval = crv.evaluate(np.array([u]))
+            assert isinstance(pt_slice, np.ndarray)
+            np.testing.assert_allclose(pt_slice, pt_eval, atol=1e-14)
+
+    def test_slice_returns_ndarray(self) -> None:
+        """Slicing a 1D B-spline returns an ndarray, not a Bspline."""
+        crv = _make_1d_curve()
+        result = crv.slice(0, 0.5)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+
+    def test_slice_at_boundary_knot(self) -> None:
+        """Slicing at a clamped boundary should return the endpoint control point."""
+        crv = _make_1d_curve()
+        pt_start = crv.slice(0, 0.0)
+        pt_end = crv.slice(0, 1.0)
+        assert isinstance(pt_start, np.ndarray)
+        assert isinstance(pt_end, np.ndarray)
+        np.testing.assert_allclose(pt_start, crv.control_points[0], atol=1e-15)
+        np.testing.assert_allclose(pt_end, crv.control_points[-1], atol=1e-15)
+
+
+class TestSlice2D:
+    """Test slicing a 2D surface (produces a curve)."""
+
+    def test_slice_returns_bspline(self) -> None:
+        """Slicing a 2D surface returns a 1D Bspline."""
+        srf = _make_2d_surface()
+        result = srf.slice(0, 0.5)
+        assert isinstance(result, Bspline)
+        assert result.dim == 1
+
+    def test_slice_axis0_matches_evaluate(self) -> None:
+        """Slicing axis 0 then evaluating should match direct 2D evaluate."""
+        srf = _make_2d_surface()
+        u, v = 0.3, 0.7
+        crv = srf.slice(0, u)
+        assert isinstance(crv, Bspline)
+        pt_slice = crv.evaluate(np.array([v]))
+        pt_direct = srf.evaluate(np.array([[u, v]]))
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+    def test_slice_axis1_matches_evaluate(self) -> None:
+        """Slicing axis 1 then evaluating should match direct 2D evaluate."""
+        srf = _make_2d_surface()
+        u, v = 0.4, 0.6
+        crv = srf.slice(1, v)
+        assert isinstance(crv, Bspline)
+        pt_slice = crv.evaluate(np.array([u]))
+        pt_direct = srf.evaluate(np.array([[u, v]]))
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+
+class TestSlice3D:
+    """Test slicing a 3D volume."""
+
+    def test_volume_to_surface(self) -> None:
+        """Slicing a volume produces a surface."""
+        vol = _make_3d_volume()
+        srf = vol.slice(2, 0.5)
+        assert isinstance(srf, Bspline)
+        expected_dim = 2
+        assert srf.dim == expected_dim
+
+    def test_composable_slice_matches_evaluate(self) -> None:
+        """vol.slice(2,w).slice(1,v).slice(0,u) matches vol.evaluate([u,v,w])."""
+        vol = _make_3d_volume()
+        u, v, w = 0.2, 0.5, 0.8
+        srf = vol.slice(2, w)
+        assert isinstance(srf, Bspline)
+        crv = srf.slice(1, v)
+        assert isinstance(crv, Bspline)
+        pt_slice = crv.slice(0, u)
+        pt_direct = vol.evaluate(np.array([[u, v, w]]))
+        assert isinstance(pt_slice, np.ndarray)
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+    def test_slice_different_axes(self) -> None:
+        """Slicing different axes first should give same final point."""
+        vol = _make_3d_volume()
+        u, v, w = 0.3, 0.6, 0.4
+        # Slice axis 0 first, then 0 (was axis 1), then 0 (was axis 2).
+        srf1 = vol.slice(0, u)
+        assert isinstance(srf1, Bspline)
+        crv1 = srf1.slice(0, v)
+        assert isinstance(crv1, Bspline)
+        pt1 = crv1.slice(0, w)
+        # Slice in reverse order.
+        srf2 = vol.slice(2, w)
+        assert isinstance(srf2, Bspline)
+        crv2 = srf2.slice(1, v)
+        assert isinstance(crv2, Bspline)
+        pt2 = crv2.slice(0, u)
+        pt_direct = vol.evaluate(np.array([[u, v, w]]))
+        assert isinstance(pt1, np.ndarray)
+        assert isinstance(pt2, np.ndarray)
+        np.testing.assert_allclose(pt1, pt_direct, atol=1e-13)
+        np.testing.assert_allclose(pt2, pt_direct, atol=1e-13)
+
+
+class TestSliceC0Knot:
+    """Test the C0 knot optimization (direct control point lookup)."""
+
+    def test_c0_knot_matches_evaluate(self) -> None:
+        """Slicing at a C0 knot should still give correct results."""
+        srf = _make_c0_surface()
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bspline)
+        v = 0.4
+        pt_slice = crv.evaluate(np.array([v]))
+        pt_direct = srf.evaluate(np.array([[0.5, v]]))
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+
+class TestSliceRational:
+    """Test slicing rational (NURBS) B-splines."""
+
+    def test_rational_1d_projects_correctly(self) -> None:
+        """Slicing a rational 1D curve returns projected physical coordinates."""
+        crv = _make_rational_curve()
+        pt = crv.slice(0, 0.5)
+        assert isinstance(pt, np.ndarray)
+        pt_eval = crv.evaluate(np.array([0.5]))
+        np.testing.assert_allclose(pt, pt_eval, atol=1e-14)
+
+    def test_rational_2d_preserves_rationality(self) -> None:
+        """Slicing a rational 2D surface returns a rational 1D curve."""
+        srf = _make_rational_surface()
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bspline)
+        assert crv.is_rational
+
+    def test_rational_2d_matches_evaluate(self) -> None:
+        """Slicing a rational surface then evaluating matches direct evaluation."""
+        srf = _make_rational_surface()
+        u, v = 0.3, 0.7
+        crv = srf.slice(0, u)
+        assert isinstance(crv, Bspline)
+        pt_slice = crv.evaluate(np.array([v]))
+        pt_direct = srf.evaluate(np.array([[u, v]]))
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-12)
+
+
+class TestSlicePeriodic:
+    """Test slicing periodic B-splines."""
+
+    def test_periodic_1d_matches_open_evaluate(self) -> None:
+        """Slicing a periodic 1D curve matches the open-form evaluate."""
+        crv = _make_periodic_curve()
+        crv_open = crv.to_open_bspline()
+        domain = crv.space.spaces[0].domain
+        for t in np.linspace(float(domain[0]), float(domain[1]), 7):
+            pt_slice = crv.slice(0, t)
+            pt_eval = crv_open.evaluate(np.array([t]))
+            assert isinstance(pt_slice, np.ndarray)
+            np.testing.assert_allclose(pt_slice, pt_eval, atol=1e-13)
+
+    def test_periodic_surface_slice_matches_evaluate(self) -> None:
+        """Slicing a periodic surface along the periodic direction matches evaluate."""
+        srf = _make_periodic_surface()
+        domain_u = srf.space.spaces[0].domain
+        u = float(domain_u[0]) + 0.3 * (float(domain_u[1]) - float(domain_u[0]))
+        v = 0.6
+        crv = srf.slice(0, u)
+        assert isinstance(crv, Bspline)
+        pt_slice = crv.evaluate(np.array([v]))
+        pt_direct = srf.evaluate(np.array([[u, v]]))
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-12)
+
+
+class TestSliceDtype:
+    """Test that slice preserves dtype."""
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_slice_preserves_dtype(self, dtype: type) -> None:
+        """Output dtype matches input dtype."""
+        srf = _make_2d_surface(dtype=dtype)
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bspline)
+        assert crv.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_slice_1d_preserves_dtype(self, dtype: type) -> None:
+        """1D slice output array has matching dtype."""
+        crv = _make_1d_curve(dtype=dtype)
+        pt = crv.slice(0, 0.5)
+        assert isinstance(pt, np.ndarray)
+        assert pt.dtype == dtype
+
+
+class TestSliceErrors:
+    """Test error handling for slice."""
+
+    def test_axis_out_of_range(self) -> None:
+        """Axis out of range raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.slice(1, 0.5)
+
+    def test_axis_negative(self) -> None:
+        """Negative axis raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.slice(-1, 0.5)
+
+    def test_value_out_of_domain(self) -> None:
+        """Value outside domain raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="outside the domain"):
+            crv.slice(0, 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.boundary()
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    """Test boundary extraction."""
+
+    def test_boundary_1d_start(self) -> None:
+        """Boundary at side=0 returns the start control point."""
+        crv = _make_1d_curve()
+        pt = crv.boundary(0, 0)
+        assert isinstance(pt, np.ndarray)
+        np.testing.assert_allclose(pt, crv.control_points[0], atol=1e-15)
+
+    def test_boundary_1d_end(self) -> None:
+        """Boundary at side=1 returns the end control point."""
+        crv = _make_1d_curve()
+        pt = crv.boundary(0, 1)
+        assert isinstance(pt, np.ndarray)
+        np.testing.assert_allclose(pt, crv.control_points[-1], atol=1e-15)
+
+    def test_boundary_2d_matches_evaluate(self) -> None:
+        """Boundary curve of a surface matches evaluation at domain boundary."""
+        srf = _make_2d_surface()
+        crv_start = srf.boundary(0, 0)
+        crv_end = srf.boundary(0, 1)
+        assert isinstance(crv_start, Bspline)
+        assert isinstance(crv_end, Bspline)
+
+        v = 0.4
+        pt_start = crv_start.evaluate(np.array([v]))
+        pt_end = crv_end.evaluate(np.array([v]))
+        domain = srf.space.spaces[0].domain
+        pt_start_direct = srf.evaluate(np.array([[float(domain[0]), v]]))
+        pt_end_direct = srf.evaluate(np.array([[float(domain[1]), v]]))
+        np.testing.assert_allclose(pt_start, pt_start_direct, atol=1e-13)
+        np.testing.assert_allclose(pt_end, pt_end_direct, atol=1e-13)
+
+    def test_boundary_invalid_side(self) -> None:
+        """Invalid side raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="side must be 0 or 1"):
+            crv.boundary(0, 2)
+
+    def test_boundary_axis_out_of_range(self) -> None:
+        """Axis out of range raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.boundary(1, 0)


### PR DESCRIPTION
## Summary
- Add `Bspline.slice(axis, value)` method that fixes one parametric direction at a given value, reducing the dimension by one (volume→surface→curve→point)
- Add `Bspline.boundary(axis, side)` convenience method for extracting domain boundaries
- Uses CurvePntByCornerCut algorithm (Piegl-Tiller A5.1) with O(1) shortcut at C0 continuity knots (multiplicity ≥ degree → direct control point lookup, no iteration)
- Handles periodic B-splines (via CP expansion), rational B-splines (NURBS structure preserved or projected), and both float32/float64 dtypes

## Test plan
- [x] 1D curve slice matches evaluate (5 parameter values including boundaries and interior knot)
- [x] 2D surface slice along both axes matches evaluate
- [x] 3D volume composable slicing matches evaluate
- [x] C0 knot optimization produces correct results
- [x] Rational (NURBS) B-splines: projection and rationality preservation
- [x] Periodic B-splines: matches open-form evaluation
- [x] Boundary extraction at both domain endpoints
- [x] Error cases: axis out of range, value out of domain, invalid side
- [x] dtype preservation for float32 and float64
- [x] All 1302 existing tests still pass
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)