### PR TITLE
feat(bezier): add slice and boundary methods

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -82,6 +82,9 @@ if not TYPE_CHECKING:
             from .bspline import _bspline_blossom_core  # noqa: PLC0415
 
             _bspline_blossom_core._warmup_numba_functions()
+            from .bezier import _bezier_core  # noqa: PLC0415
+
+            _bezier_core._warmup_numba_functions()
             logger.debug("Finished Numba JIT warmup.")
         except Exception:
             # During process teardown (e.g. short scripts), background Numba caching

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -13,6 +13,7 @@ from ._bezier_degree import _degree_elevate_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
 from ._bezier_product import _multiply_bezier
+from ._bezier_slice import _slice_bezier
 
 if TYPE_CHECKING:
     from ..bspline import Bspline
@@ -511,6 +512,83 @@ class Bezier:
         bspline = self.to_bspline()
         restricted = bspline.restrict(bounds)
         return Bezier.from_bspline(restricted)
+
+    # ------------------------------------------------------------------
+    # Slice and boundary
+    # ------------------------------------------------------------------
+
+    def slice(self, axis: int, value: float) -> Bezier | npt.NDArray[np.float32 | np.float64]:
+        """Slice the Bézier by fixing one parametric direction at a given value.
+
+        Reduces the parametric dimension by one using the de Casteljau
+        algorithm on the control points.  A surface becomes a curve, a curve
+        becomes a point (returned as a NumPy array).
+
+        At the boundary values ``0`` and ``1`` the result is obtained in
+        O(1) by direct control point lookup.
+
+        Args:
+            axis (int): Parametric direction to fix (0-indexed).
+                Must be in ``[0, dim)``.
+            value (float): Parameter value at which to slice.  Must lie
+                within ``[0, 1]``.
+
+        Returns:
+            Bezier | npt.NDArray[np.float32 | np.float64]:
+            A Bézier with ``dim - 1`` dimensions when ``dim >= 2``,
+            or a NumPy array of shape ``(rank,)`` when ``dim == 1``.
+            Rational Béziers preserve the rational structure when ``dim >= 2``;
+            for ``dim == 1`` the result is projected to physical coordinates.
+
+        Raises:
+            ValueError: If ``axis`` is out of range ``[0, dim)``.
+            ValueError: If ``value`` is outside ``[0, 1]``.
+
+        Example:
+            >>> # Slice a surface at v=0.5 to get a curve
+            >>> curve = surface.slice(1, 0.5)
+            >>> # Composable: surface -> curve -> point
+            >>> pt = surface.slice(1, 0.5).slice(0, 0.2)
+        """
+        if axis < 0 or axis >= self.dim:
+            raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
+        if value < 0.0 or value > 1.0:
+            raise ValueError(f"value must be in [0, 1], got {value}.")
+
+        return _slice_bezier(self, axis, value)
+
+    def boundary(self, axis: int, side: int) -> Bezier | npt.NDArray[np.float32 | np.float64]:
+        """Extract the boundary of the Bézier along one parametric direction.
+
+        Returns the restriction of the Bézier to one end of the ``[0, 1]``
+        domain in the given direction.
+
+        Args:
+            axis (int): Parametric direction (0-indexed).
+                Must be in ``[0, dim)``.
+            side (int): Which end of the domain: ``0`` for the start,
+                ``1`` for the end.
+
+        Returns:
+            Bezier | npt.NDArray[np.float32 | np.float64]:
+            A Bézier with ``dim - 1`` dimensions when ``dim >= 2``,
+            or a NumPy array of shape ``(rank,)`` when ``dim == 1``.
+
+        Raises:
+            ValueError: If ``axis`` is out of range ``[0, dim)``.
+            ValueError: If ``side`` is not 0 or 1.
+
+        Example:
+            >>> # Extract left boundary of a surface along direction 0
+            >>> left_curve = surface.boundary(0, 0)
+        """
+        if side not in (0, 1):
+            raise ValueError(f"side must be 0 or 1, got {side}.")
+        if axis < 0 or axis >= self.dim:
+            raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
+
+        value = 0.0 if side == 0 else 1.0
+        return self.slice(axis, value)
 
     # ------------------------------------------------------------------
     # Conversion

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -259,3 +259,61 @@ def _degree_elevate_bezier_1d_core(
                 new_ctrl[i, r] += coeff * ctrl[j, r]
 
     return new_ctrl
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=True,
+)
+def _slice_bezier_1d_core(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    value: float,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate a 1D Bézier at a single parameter value via de Casteljau.
+
+    Performs the de Casteljau triangular reduction on each column of the
+    control point array independently, parallelized across columns with
+    ``prange``.  At the boundary values ``0`` and ``1``, the first or
+    last control point is returned directly without iteration.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of
+            shape ``(p + 1, n_cols)``, where ``p`` is the polynomial
+            degree and ``n_cols`` is the number of independent columns.
+        value (float): Parameter value in ``[0, 1]``.
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output
+            array of shape ``(n_cols,)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_slice_bezier` in ``_bezier_slice``
+        instead.
+    """
+    p = ctrl.shape[0] - 1
+    n_cols = ctrl.shape[1]
+    u = value
+    one_minus_u = 1.0 - u
+
+    # Boundary shortcuts: O(1) for endpoints.
+    if u == 0.0:
+        for col in nb_prange(n_cols):
+            out[col] = ctrl[0, col]
+        return
+    if u == 1.0:
+        for col in nb_prange(n_cols):
+            out[col] = ctrl[p, col]
+        return
+
+    for col in nb_prange(n_cols):
+        # Local workspace for de Casteljau on this column.
+        d = np.empty(p + 1, dtype=ctrl.dtype)
+        for i in range(p + 1):
+            d[i] = ctrl[i, col]
+
+        for r in range(1, p + 1):
+            for i in range(p - r + 1):
+                d[i] = one_minus_u * d[i] + u * d[i + 1]
+
+        out[col] = d[0]

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -317,3 +317,21 @@ def _slice_bezier_1d_core(
                 d[i] = one_minus_u * d[i] + u * d[i + 1]
 
         out[col] = d[0]
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile numba functions with float64 signatures for faster first call.
+
+    This function triggers compilation of the numba-decorated functions
+    with float64 arrays, ensuring they are cached and ready for use.
+    """
+    ctrl_dummy = np.array([[0.0, 1.0], [1.0, 0.0], [2.0, 1.0]], dtype=np.float64)
+    pts_dummy = np.array([0.5], dtype=np.float64)
+    out_eval_dummy = np.empty((1, 2), dtype=np.float64)
+    out_deriv_dummy = np.empty((1, 1, 2), dtype=np.float64)
+    out_slice_dummy = np.empty(2, dtype=np.float64)
+
+    _evaluate_bezier_1d_core(ctrl_dummy, pts_dummy, out_eval_dummy)
+    _evaluate_bezier_deriv_1d_core(ctrl_dummy, pts_dummy, 0, out_deriv_dummy)
+    _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1)
+    _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -1,0 +1,84 @@
+"""Bézier slicing (dimension reduction by fixing one parametric direction).
+
+This module provides :func:`_slice_bezier`, which fixes one parametric
+direction of a Bézier at a given value and returns a Bézier with one
+fewer dimension.  For a 1D Bézier the result is a plain NumPy array
+(the evaluated point).
+
+The core algorithm is de Casteljau applied to the control points along
+the sliced axis.  At the boundary values ``0`` and ``1`` the first or
+last control point is returned directly in O(1).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import wait_for_jit_warmup
+from ._bezier_core import _slice_bezier_1d_core
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _slice_bezier(
+    bezier: Bezier,
+    axis: int,
+    value: float,
+) -> Bezier | npt.NDArray[np.float32 | np.float64]:
+    """Slice a Bézier by fixing one parametric direction at a given value.
+
+    Reduces the parametric dimension by one.  For a 1D Bézier, returns
+    the evaluated point as a NumPy array.  For higher dimensions, returns
+    a new :class:`~pantr.bezier.Bezier`.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to slice.
+        axis (int): Parametric direction to fix (0-indexed, must be in
+            ``[0, dim)``).
+        value (float): Parameter value at which to slice (must be in
+            ``[0, 1]``).
+
+    Returns:
+        ~pantr.bezier.Bezier | npt.NDArray[np.float32 | np.float64]:
+        A Bézier with ``dim - 1`` dimensions (when ``dim >= 2``),
+        or a NumPy array of shape ``(rank,)`` (when ``dim == 1``).
+        Rational Béziers preserve the rational structure when ``dim >= 2``;
+        for ``dim == 1`` the result is projected to physical coordinates.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bezier.Bezier.slice` instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl = bezier.control_points
+
+    # Move target axis to position 0, flatten the rest into a single axis.
+    moved = np.moveaxis(ctrl, axis, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    # Apply 1D de Casteljau via Numba kernel.
+    result_1d = np.empty(pts_2d.shape[1], dtype=pts_2d.dtype)
+    wait_for_jit_warmup()
+    _slice_bezier_1d_core(pts_2d, value, result_1d)
+
+    if bezier.dim == 1:
+        # Result is a point.  For rational Béziers, project to physical coords.
+        if bezier.is_rational:
+            weight = result_1d[-1]
+            return cast(npt.NDArray[np.float32 | np.float64], result_1d[:-1] / weight)
+        return result_1d
+
+    # Restore shape: remove the sliced axis dimension.
+    new_shape = orig_shape[1:]
+    new_ctrl = result_1d.reshape(new_shape)
+
+    return BezierCls(new_ctrl, is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import numpy.typing as npt
 
-from .._numba_compat import wait_for_jit_warmup
 from ._bezier_core import _slice_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -67,7 +66,6 @@ def _slice_bezier(
 
     # Apply 1D de Casteljau via Numba kernel.
     result_1d = np.empty(pts_2d.shape[1], dtype=pts_2d.dtype)
-    wait_for_jit_warmup()
     _slice_bezier_1d_core(pts_2d, value, result_1d)
 
     if bezier.dim == 1:

--- a/tests/test_bezier_slice.py
+++ b/tests/test_bezier_slice.py
@@ -1,0 +1,295 @@
+"""Tests for Bezier.slice() and Bezier.boundary() methods."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_1d_curve(dtype: type = np.float64) -> Bezier:
+    """Create a 1D cubic Bézier curve (4 control points, rank 2)."""
+    ctrl: npt.NDArray[np.float64] = np.array([[0, 0], [1, 3], [4, 3], [5, 0]], dtype=dtype)
+    return Bezier(ctrl)
+
+
+def _make_2d_surface(dtype: type = np.float64) -> Bezier:
+    """Create a 2D quadratic Bézier surface (3x3 control points, rank 3)."""
+    rng = np.random.default_rng(42)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_3d_volume(dtype: type = np.float64) -> Bezier:
+    """Create a 3D linear Bézier volume (2x2x2 control points, rank 3)."""
+    rng = np.random.default_rng(123)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((2, 2, 2, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_rational_curve(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    ctrl: npt.NDArray[np.float64] = np.array([[1, 0, 1], [w, w, w], [0, 1, 1]], dtype=dtype)
+    return Bezier(ctrl, is_rational=True)
+
+
+def _make_rational_surface(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier surface."""
+    rng = np.random.default_rng(99)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    ctrl[:, :, -1] = np.abs(ctrl[:, :, -1]) + 0.5
+    return Bezier(ctrl, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bezier.slice()
+# ---------------------------------------------------------------------------
+
+
+class TestSlice1D:
+    """Test slicing a 1D curve (produces a point)."""
+
+    def test_slice_matches_evaluate(self) -> None:
+        """Slicing a curve at u should match evaluate([u])."""
+        crv = _make_1d_curve()
+        for u in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_slice = crv.slice(0, u)
+            pt_eval = crv.evaluate(np.array([u])).squeeze()
+            assert isinstance(pt_slice, np.ndarray)
+            np.testing.assert_allclose(pt_slice, pt_eval, atol=1e-14)
+
+    def test_slice_returns_ndarray(self) -> None:
+        """Slicing a 1D Bézier returns an ndarray, not a Bezier."""
+        crv = _make_1d_curve()
+        result = crv.slice(0, 0.5)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+
+    def test_slice_at_boundary(self) -> None:
+        """Slicing at boundaries returns the endpoint control points."""
+        crv = _make_1d_curve()
+        pt_start = crv.slice(0, 0.0)
+        pt_end = crv.slice(0, 1.0)
+        assert isinstance(pt_start, np.ndarray)
+        assert isinstance(pt_end, np.ndarray)
+        np.testing.assert_allclose(pt_start, crv.control_points[0], atol=1e-15)
+        np.testing.assert_allclose(pt_end, crv.control_points[-1], atol=1e-15)
+
+
+class TestSlice2D:
+    """Test slicing a 2D surface (produces a curve)."""
+
+    def test_slice_returns_bezier(self) -> None:
+        """Slicing a 2D Bézier returns a 1D Bezier."""
+        srf = _make_2d_surface()
+        result = srf.slice(0, 0.5)
+        assert isinstance(result, Bezier)
+        assert result.dim == 1
+
+    def test_slice_preserves_degree(self) -> None:
+        """Slicing a quadratic surface along axis 0 gives a quadratic curve."""
+        srf = _make_2d_surface()
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bezier)
+        expected_degree = (2,)
+        assert crv.degree == expected_degree
+
+    def test_slice_axis0_matches_evaluate(self) -> None:
+        """Slicing axis 0 then evaluating should match direct 2D evaluate."""
+        srf = _make_2d_surface()
+        u, v = 0.3, 0.7
+        crv = srf.slice(0, u)
+        assert isinstance(crv, Bezier)
+        pt_slice = crv.evaluate(np.array([v])).squeeze()
+        pt_direct = srf.evaluate(np.array([[u, v]])).squeeze()
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+    def test_slice_axis1_matches_evaluate(self) -> None:
+        """Slicing axis 1 then evaluating should match direct 2D evaluate."""
+        srf = _make_2d_surface()
+        u, v = 0.4, 0.6
+        crv = srf.slice(1, v)
+        assert isinstance(crv, Bezier)
+        pt_slice = crv.evaluate(np.array([u])).squeeze()
+        pt_direct = srf.evaluate(np.array([[u, v]])).squeeze()
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+
+class TestSlice3D:
+    """Test slicing a 3D volume."""
+
+    def test_volume_to_surface(self) -> None:
+        """Slicing a volume produces a surface."""
+        vol = _make_3d_volume()
+        srf = vol.slice(2, 0.5)
+        assert isinstance(srf, Bezier)
+        expected_dim = 2
+        assert srf.dim == expected_dim
+
+    def test_composable_slice_matches_evaluate(self) -> None:
+        """vol.slice(2,w).slice(1,v).slice(0,u) matches vol.evaluate([u,v,w])."""
+        vol = _make_3d_volume()
+        u, v, w = 0.2, 0.5, 0.8
+        srf = vol.slice(2, w)
+        assert isinstance(srf, Bezier)
+        crv = srf.slice(1, v)
+        assert isinstance(crv, Bezier)
+        pt_slice = crv.slice(0, u)
+        pt_direct = vol.evaluate(np.array([[u, v, w]])).squeeze()
+        assert isinstance(pt_slice, np.ndarray)
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-13)
+
+    def test_slice_different_axes(self) -> None:
+        """Slicing different axes first should give same final point."""
+        vol = _make_3d_volume()
+        u, v, w = 0.3, 0.6, 0.4
+        srf1 = vol.slice(0, u)
+        assert isinstance(srf1, Bezier)
+        crv1 = srf1.slice(0, v)
+        assert isinstance(crv1, Bezier)
+        pt1 = crv1.slice(0, w)
+        srf2 = vol.slice(2, w)
+        assert isinstance(srf2, Bezier)
+        crv2 = srf2.slice(1, v)
+        assert isinstance(crv2, Bezier)
+        pt2 = crv2.slice(0, u)
+        pt_direct = vol.evaluate(np.array([[u, v, w]])).squeeze()
+        assert isinstance(pt1, np.ndarray)
+        assert isinstance(pt2, np.ndarray)
+        np.testing.assert_allclose(pt1, pt_direct, atol=1e-13)
+        np.testing.assert_allclose(pt2, pt_direct, atol=1e-13)
+
+
+class TestSliceRational:
+    """Test slicing rational (NURBS) Béziers."""
+
+    def test_rational_1d_projects_correctly(self) -> None:
+        """Slicing a rational 1D curve returns projected physical coordinates."""
+        crv = _make_rational_curve()
+        pt = crv.slice(0, 0.5)
+        assert isinstance(pt, np.ndarray)
+        pt_eval = crv.evaluate(np.array([0.5])).squeeze()
+        np.testing.assert_allclose(pt, pt_eval, atol=1e-14)
+
+    def test_rational_2d_preserves_rationality(self) -> None:
+        """Slicing a rational 2D surface returns a rational 1D curve."""
+        srf = _make_rational_surface()
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bezier)
+        assert crv.is_rational
+
+    def test_rational_2d_matches_evaluate(self) -> None:
+        """Slicing a rational surface then evaluating matches direct evaluation."""
+        srf = _make_rational_surface()
+        u, v = 0.3, 0.7
+        crv = srf.slice(0, u)
+        assert isinstance(crv, Bezier)
+        pt_slice = crv.evaluate(np.array([v])).squeeze()
+        pt_direct = srf.evaluate(np.array([[u, v]])).squeeze()
+        np.testing.assert_allclose(pt_slice, pt_direct, atol=1e-12)
+
+
+class TestSliceDtype:
+    """Test that slice preserves dtype."""
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_slice_preserves_dtype(self, dtype: type) -> None:
+        """Output dtype matches input dtype."""
+        srf = _make_2d_surface(dtype=dtype)
+        crv = srf.slice(0, 0.5)
+        assert isinstance(crv, Bezier)
+        assert crv.dtype == dtype
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_slice_1d_preserves_dtype(self, dtype: type) -> None:
+        """1D slice output array has matching dtype."""
+        crv = _make_1d_curve(dtype=dtype)
+        pt = crv.slice(0, 0.5)
+        assert isinstance(pt, np.ndarray)
+        assert pt.dtype == dtype
+
+
+class TestSliceErrors:
+    """Test error handling for slice."""
+
+    def test_axis_out_of_range(self) -> None:
+        """Axis out of range raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.slice(1, 0.5)
+
+    def test_axis_negative(self) -> None:
+        """Negative axis raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.slice(-1, 0.5)
+
+    def test_value_below_zero(self) -> None:
+        """Value below 0 raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match=r"value must be in \[0, 1\]"):
+            crv.slice(0, -0.1)
+
+    def test_value_above_one(self) -> None:
+        """Value above 1 raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match=r"value must be in \[0, 1\]"):
+            crv.slice(0, 1.5)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bezier.boundary()
+# ---------------------------------------------------------------------------
+
+
+class TestBoundary:
+    """Test boundary extraction."""
+
+    def test_boundary_1d_start(self) -> None:
+        """Boundary at side=0 returns the start control point."""
+        crv = _make_1d_curve()
+        pt = crv.boundary(0, 0)
+        assert isinstance(pt, np.ndarray)
+        np.testing.assert_allclose(pt, crv.control_points[0], atol=1e-15)
+
+    def test_boundary_1d_end(self) -> None:
+        """Boundary at side=1 returns the end control point."""
+        crv = _make_1d_curve()
+        pt = crv.boundary(0, 1)
+        assert isinstance(pt, np.ndarray)
+        np.testing.assert_allclose(pt, crv.control_points[-1], atol=1e-15)
+
+    def test_boundary_2d_matches_evaluate(self) -> None:
+        """Boundary curve of a surface matches evaluation at domain boundary."""
+        srf = _make_2d_surface()
+        crv_start = srf.boundary(0, 0)
+        crv_end = srf.boundary(0, 1)
+        assert isinstance(crv_start, Bezier)
+        assert isinstance(crv_end, Bezier)
+
+        v = 0.4
+        pt_start = crv_start.evaluate(np.array([v])).squeeze()
+        pt_end = crv_end.evaluate(np.array([v])).squeeze()
+        pt_start_direct = srf.evaluate(np.array([[0.0, v]])).squeeze()
+        pt_end_direct = srf.evaluate(np.array([[1.0, v]])).squeeze()
+        np.testing.assert_allclose(pt_start, pt_start_direct, atol=1e-13)
+        np.testing.assert_allclose(pt_end, pt_end_direct, atol=1e-13)
+
+    def test_boundary_invalid_side(self) -> None:
+        """Invalid side raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="side must be 0 or 1"):
+            crv.boundary(0, 2)
+
+    def test_boundary_axis_out_of_range(self) -> None:
+        """Axis out of range raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="axis must be in"):
+            crv.boundary(1, 0)


### PR DESCRIPTION
## Summary
- Add `Bezier.slice(axis, value)` and `Bezier.boundary(axis, side)` methods for dimension reduction
- **Native Bézier implementation** — no conversion to B-spline. Uses a dedicated Numba kernel (`_slice_bezier_1d_core`) that performs de Casteljau triangular reduction parallelized over columns via `prange`
- **O(1) boundary shortcut**: at `u=0` or `u=1`, the kernel directly returns the first/last control point without any iteration
- Handles rational Béziers (NURBS structure preserved for dim ≥ 2, projected for dim = 1) and both float32/float64

## Test plan
- [x] 1D curve slice matches evaluate at 5 parameter values
- [x] 2D surface slice along both axes matches evaluate
- [x] 3D volume composable slicing matches evaluate
- [x] Degree preservation verified
- [x] Rational Béziers: projection and rationality preservation
- [x] Boundary extraction at both endpoints
- [x] Error cases: axis out of range, value out of [0,1], invalid side
- [x] dtype preservation for float32 and float64
- [x] All 1437 existing tests still pass
- [x] Pre-PR checks pass (ruff, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)