### PR TITLE
feat(bezier): add copy parameter to to_bspline and from_bspline

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -594,11 +594,16 @@ class Bezier:
     # Conversion
     # ------------------------------------------------------------------
 
-    def to_bspline(self) -> Bspline:
+    def to_bspline(self, *, copy: bool = True) -> Bspline:
         """Convert to an equivalent B-spline with Bézier knot vectors.
 
         Creates a :class:`~pantr.bspline.Bspline` with open knot vectors
         ``[0]*(p+1) + [1]*(p+1)`` in each parametric direction.
+
+        Args:
+            copy (bool): If ``True`` (default), the control points are
+                deep-copied into the new B-spline. If ``False``, the
+                B-spline shares the same underlying control point array.
 
         Returns:
             ~pantr.bspline.Bspline: Equivalent B-spline representation.
@@ -613,10 +618,11 @@ class Bezier:
             knots[p + 1 :] = 1.0
             spaces.append(BsplineSpace1D(knots, p))
 
-        return BsplineCls(BsplineSpace(spaces), self._control_points, self._is_rational)
+        cp = self._control_points.copy() if copy else self._control_points
+        return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
 
     @classmethod
-    def from_bspline(cls, bspline: Bspline) -> Bezier:
+    def from_bspline(cls, bspline: Bspline, *, copy: bool = True) -> Bezier:
         """Create a Bézier from a B-spline with Bézier-like knot vectors.
 
         Validates that the B-spline has Bézier-like knots (open knots with
@@ -626,6 +632,9 @@ class Bezier:
         Args:
             bspline (~pantr.bspline.Bspline): A B-spline with Bézier-like
                 knot structure.
+            copy (bool): If ``True`` (default), the control points are
+                deep-copied into the new Bézier. If ``False``, the Bézier
+                shares the same underlying control point array.
 
         Returns:
             Bezier: The equivalent Bézier.
@@ -635,4 +644,5 @@ class Bezier:
         """
         if not bspline.space.has_Bezier_like_knots():
             raise ValueError("B-spline does not have Bézier-like knots. Cannot convert to Bézier.")
-        return cls(bspline.control_points, is_rational=bspline.is_rational)
+        cp = bspline.control_points.copy() if copy else bspline.control_points
+        return cls(cp, is_rational=bspline.is_rational)

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -151,6 +151,38 @@ class TestBezierConversion:
         np.testing.assert_array_equal(b2.control_points, b.control_points)
         assert b2.is_rational == b.is_rational
 
+    def test_to_bspline_copy_true(self) -> None:
+        """Test that to_bspline with copy=True creates independent arrays."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b.to_bspline(copy=True)
+        assert not np.shares_memory(b.control_points, bs.control_points)
+
+    def test_to_bspline_copy_false(self) -> None:
+        """Test that to_bspline with copy=False shares the control point array."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b.to_bspline(copy=False)
+        assert np.shares_memory(b.control_points, bs.control_points)
+
+    def test_from_bspline_copy_true(self) -> None:
+        """Test that from_bspline with copy=True creates independent arrays."""
+        b_orig = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b_orig.to_bspline(copy=False)
+        b_back = Bezier.from_bspline(bs, copy=True)
+        assert not np.shares_memory(bs.control_points, b_back.control_points)
+
+    def test_from_bspline_copy_false(self) -> None:
+        """Test that from_bspline with copy=False shares the control point array."""
+        b_orig = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b_orig.to_bspline(copy=False)
+        b_back = Bezier.from_bspline(bs, copy=False)
+        assert np.shares_memory(bs.control_points, b_back.control_points)
+
+    def test_to_bspline_default_copies(self) -> None:
+        """Test that to_bspline copies by default."""
+        b = _make_bezier_1d([1.0, 2.0, 3.0])
+        bs = b.to_bspline()
+        assert not np.shares_memory(b.control_points, bs.control_points)
+
 
 # ---------------------------------------------------------------------------
 # Evaluate


### PR DESCRIPTION
## Summary
- Add keyword-only `copy: bool = True` parameter to `Bezier.to_bspline()` and `Bezier.from_bspline()`
- When `True` (default), control points are deep-copied; when `False`, the underlying array is shared
- Adds 5 new tests covering both modes and the default behavior

## Test plan
- [x] All existing tests pass (1483 passed)
- [x] New tests verify copy/no-copy semantics via `np.shares_memory`
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)