### PR TITLE
feat(bspline): add to_bezier and from_bezier conversion methods

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -509,9 +509,9 @@ class Bezier:
             ValueError: If any bound lies outside ``[0, 1]``.
             ValueError: If ``lower >= upper`` in any direction.
         """
-        bspline = self.to_bspline()
+        bspline = self.to_bspline(copy=False)
         restricted = bspline.restrict(bounds)
-        return Bezier.from_bspline(restricted)
+        return restricted.to_bezier(copy=False)
 
     # ------------------------------------------------------------------
     # Slice and boundary

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -29,6 +29,7 @@ from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
 
 if TYPE_CHECKING:
+    from ..bezier import Bezier
     from ..quad import PointsLattice
     from ..transform import AffineTransform
     from ._bspline_space_nd import BsplineSpace
@@ -554,6 +555,71 @@ class Bspline:
             ValueError: If ``continuity`` is out of range.
         """
         return _to_periodic_bspline_impl(self, continuity)
+
+    def to_bezier(self, *, copy: bool = True) -> Bezier:
+        """Convert to an equivalent Bézier.
+
+        Extracts a :class:`~pantr.bezier.Bezier` from this B-spline when
+        it represents a single polynomial patch (one element per direction).
+        Periodic and non-open B-splines are automatically converted to open
+        form before the check.
+
+        Args:
+            copy (bool): If ``True`` (default), the control points are
+                deep-copied into the new Bézier.  If ``False``, the Bézier
+                shares the same underlying control point array when possible
+                (direct extraction) or owns the freshly allocated array
+                produced by the open-form conversion.
+
+        Returns:
+            ~pantr.bezier.Bezier: Equivalent Bézier representation.
+
+        Raises:
+            ValueError: If the B-spline has more than one element per
+                direction and cannot be represented as a single Bézier.
+        """
+        from ..bezier import Bezier as BezierCls  # noqa: PLC0415
+
+        if self._space.has_Bezier_like_knots():
+            cp = self._control_points.copy() if copy else self._control_points
+            return BezierCls(cp, is_rational=self._is_rational)
+
+        # Already open but not Bezier-like → multi-element, cannot convert.
+        spaces = self._space.spaces
+        if all(s.has_open_knots() and not s.periodic for s in spaces):
+            raise ValueError(
+                "B-spline has more than one element per direction "
+                "and cannot be represented as a single Bézier."
+            )
+
+        # Periodic / non-open: convert to open form first.
+        open_bspline = self.to_open_bspline()
+        if not open_bspline.space.has_Bezier_like_knots():
+            raise ValueError(
+                "B-spline has more than one element per direction "
+                "and cannot be represented as a single Bézier."
+            )
+        cp = open_bspline.control_points.copy() if copy else open_bspline.control_points
+        return BezierCls(cp, is_rational=self._is_rational)
+
+    @classmethod
+    def from_bezier(cls, bezier: Bezier, *, copy: bool = True) -> Bspline:
+        """Create a B-spline from a Bézier.
+
+        Builds a :class:`Bspline` with Bézier-like knot vectors
+        (``[0]*(p+1) + [1]*(p+1)`` per direction) whose control points
+        are taken from the given Bézier.
+
+        Args:
+            bezier (~pantr.bezier.Bezier): The source Bézier.
+            copy (bool): If ``True`` (default), the control points are
+                deep-copied into the new B-spline.  If ``False``, the
+                B-spline shares the same underlying control point array.
+
+        Returns:
+            Bspline: Equivalent B-spline with Bézier-like knots.
+        """
+        return bezier.to_bspline(copy=copy)
 
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1222,3 +1222,169 @@ class TestToPeriodic:
         f = Bspline(space, np.array([1.0, 2.0, 3.0, 4.0]))
         with pytest.raises(ValueError, match="No direction to convert"):
             f.to_periodic(continuity=(None,))
+
+
+# ---------------------------------------------------------------------------
+# To / from Bezier
+# ---------------------------------------------------------------------------
+
+
+class TestToBezier:
+    """Test Bspline.to_bezier conversion."""
+
+    def test_bezier_like_1d(self) -> None:
+        """Test to_bezier for a B-spline with Bézier-like knots."""
+        from pantr.bezier import Bezier
+
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier()
+        assert isinstance(bez, Bezier)
+        assert bez.degree == (2,)
+        np.testing.assert_array_equal(bez.control_points, cp)
+
+    def test_bezier_like_2d(self) -> None:
+        """Test to_bezier for a 2D B-spline with Bézier-like knots."""
+        from pantr.bezier import Bezier
+
+        s0 = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
+        s1 = BsplineSpace1D([0.0, 0.0, 1.0, 1.0], 1)
+        space = BsplineSpace([s0, s1])
+        cp = np.ones((3, 2, 1), dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier()
+        assert isinstance(bez, Bezier)
+        assert bez.degree == (2, 1)
+        np.testing.assert_array_equal(bez.control_points, cp)
+
+    def test_non_open_single_element(self) -> None:
+        """Test to_bezier for a non-open (unclamped) B-spline with one element."""
+        # Degree 1, knots [0, 0.5, 1, 1.5] → 2 basis fns, domain [0.5, 1.0].
+        # Not open, but a single span — opening produces Bézier-like knots.
+        knots = np.array([0.0, 0.5, 1.0, 1.5], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 1)])
+        cp = np.array([[1.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier()
+        # The open form has domain [0.5, 1.0] mapped to Bézier on [0, 1].
+        # Compare via the open B-spline intermediate.
+        bs_open = bs.to_open_bspline()
+        np.testing.assert_array_equal(bez.control_points, bs_open.control_points)
+
+    def test_periodic_multi_element_raises(self) -> None:
+        """Test that to_bezier raises for a periodic B-spline with multiple elements."""
+        f = _make_periodic_bspline(3, 2)
+        with pytest.raises(ValueError, match="more than one element"):
+            f.to_bezier()
+
+    def test_multi_element_raises(self) -> None:
+        """Test that to_bezier raises for multi-element B-splines."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+        bs = Bspline(space, cp)
+        with pytest.raises(ValueError, match="more than one element"):
+            bs.to_bezier()
+
+    def test_copy_true(self) -> None:
+        """Test that to_bezier with copy=True creates independent arrays."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier(copy=True)
+        assert not np.shares_memory(bs.control_points, bez.control_points)
+
+    def test_copy_false(self) -> None:
+        """Test that to_bezier with copy=False shares the control point array."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier(copy=False)
+        assert np.shares_memory(bs.control_points, bez.control_points)
+
+    def test_default_copies(self) -> None:
+        """Test that to_bezier copies by default."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bez = bs.to_bezier()
+        assert not np.shares_memory(bs.control_points, bez.control_points)
+
+    def test_rational(self) -> None:
+        """Test to_bezier preserves rationality."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0, 0.5], [2.0, 1.0], [3.0, 0.5]], dtype=np.float64)
+        bs = Bspline(space, cp, is_rational=True)
+        bez = bs.to_bezier()
+        assert bez.is_rational
+        np.testing.assert_array_equal(bez.control_points, cp)
+
+    def test_roundtrip(self) -> None:
+        """Test to_bezier -> from_bezier roundtrip."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+        bs2 = Bspline.from_bezier(bs.to_bezier())
+        np.testing.assert_array_equal(bs2.control_points, bs.control_points)
+        assert bs2.degree == bs.degree
+
+
+class TestFromBezier:
+    """Test Bspline.from_bezier conversion."""
+
+    def test_from_bezier_1d(self) -> None:
+        """Test from_bezier creates a B-spline with Bézier-like knots."""
+        from pantr.bezier import Bezier
+
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bez = Bezier(cp)
+        bs = Bspline.from_bezier(bez)
+        assert bs.space.has_Bezier_like_knots()
+        assert bs.degree == (2,)
+        np.testing.assert_array_equal(bs.control_points, cp)
+
+    def test_from_bezier_copy_true(self) -> None:
+        """Test that from_bezier with copy=True creates independent arrays."""
+        from pantr.bezier import Bezier
+
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bez = Bezier(cp)
+        bs = Bspline.from_bezier(bez, copy=True)
+        assert not np.shares_memory(bez.control_points, bs.control_points)
+
+    def test_from_bezier_copy_false(self) -> None:
+        """Test that from_bezier with copy=False shares the control point array."""
+        from pantr.bezier import Bezier
+
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bez = Bezier(cp)
+        bs = Bspline.from_bezier(bez, copy=False)
+        assert np.shares_memory(bez.control_points, bs.control_points)
+
+    def test_from_bezier_rational(self) -> None:
+        """Test from_bezier preserves rationality."""
+        from pantr.bezier import Bezier
+
+        cp = np.array([[1.0, 0.5], [2.0, 1.0], [3.0, 0.5]], dtype=np.float64)
+        bez = Bezier(cp, is_rational=True)
+        bs = Bspline.from_bezier(bez)
+        assert bs.is_rational
+        np.testing.assert_array_equal(bs.control_points, cp)
+
+    def test_from_bezier_2d(self) -> None:
+        """Test from_bezier for a 2D Bézier."""
+        from pantr.bezier import Bezier
+
+        cp = np.ones((3, 2, 1), dtype=np.float64)
+        bez = Bezier(cp)
+        bs = Bspline.from_bezier(bez)
+        assert bs.space.has_Bezier_like_knots()
+        assert bs.degree == (2, 1)
+        np.testing.assert_array_equal(bs.control_points, cp)

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr.bezier import Bezier
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 
@@ -1234,8 +1235,6 @@ class TestToBezier:
 
     def test_bezier_like_1d(self) -> None:
         """Test to_bezier for a B-spline with Bézier-like knots."""
-        from pantr.bezier import Bezier
-
         knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
         space = BsplineSpace([BsplineSpace1D(knots, 2)])
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
@@ -1247,8 +1246,6 @@ class TestToBezier:
 
     def test_bezier_like_2d(self) -> None:
         """Test to_bezier for a 2D B-spline with Bézier-like knots."""
-        from pantr.bezier import Bezier
-
         s0 = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
         s1 = BsplineSpace1D([0.0, 0.0, 1.0, 1.0], 1)
         space = BsplineSpace([s0, s1])
@@ -1341,8 +1338,6 @@ class TestFromBezier:
 
     def test_from_bezier_1d(self) -> None:
         """Test from_bezier creates a B-spline with Bézier-like knots."""
-        from pantr.bezier import Bezier
-
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
         bs = Bspline.from_bezier(bez)
@@ -1352,8 +1347,6 @@ class TestFromBezier:
 
     def test_from_bezier_copy_true(self) -> None:
         """Test that from_bezier with copy=True creates independent arrays."""
-        from pantr.bezier import Bezier
-
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
         bs = Bspline.from_bezier(bez, copy=True)
@@ -1361,8 +1354,6 @@ class TestFromBezier:
 
     def test_from_bezier_copy_false(self) -> None:
         """Test that from_bezier with copy=False shares the control point array."""
-        from pantr.bezier import Bezier
-
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
         bs = Bspline.from_bezier(bez, copy=False)
@@ -1370,8 +1361,6 @@ class TestFromBezier:
 
     def test_from_bezier_rational(self) -> None:
         """Test from_bezier preserves rationality."""
-        from pantr.bezier import Bezier
-
         cp = np.array([[1.0, 0.5], [2.0, 1.0], [3.0, 0.5]], dtype=np.float64)
         bez = Bezier(cp, is_rational=True)
         bs = Bspline.from_bezier(bez)
@@ -1380,8 +1369,6 @@ class TestFromBezier:
 
     def test_from_bezier_2d(self) -> None:
         """Test from_bezier for a 2D Bézier."""
-        from pantr.bezier import Bezier
-
         cp = np.ones((3, 2, 1), dtype=np.float64)
         bez = Bezier(cp)
         bs = Bspline.from_bezier(bez)


### PR DESCRIPTION
## Summary
- Add `Bspline.to_bezier(*, copy=True)` — converts to `Bezier` when the B-spline represents a single polynomial patch. Handles periodic and non-open splines by converting to open form first; raises `ValueError` for multi-element splines.
- Add `Bspline.from_bezier(bezier, *, copy=True)` — classmethod that creates a B-spline with Bézier-like knots from a `Bezier`, delegating to `Bezier.to_bspline()`.
- Both methods support the `copy` parameter for controlling memory sharing, consistent with the existing `Bezier.to_bspline`/`from_bspline` pattern.
- Refactored `Bezier.restrict()` to use `restricted.to_bezier(copy=False)` instead of `Bezier.from_bspline(restricted)`, and `copy=False` for the intermediate `to_bspline` call.

## Codebase usage analysis
After implementation, reviewed the codebase for places where `to_bezier(copy=False)` / `from_bezier(copy=False)` could simplify existing code:
- `_bspline_basis_core.py` — operates at `BsplineSpace1D` level, not `Bspline` objects → not applicable
- `_bspline_product.py` — per-element Bézier decomposition, not single-Bézier conversion → not applicable
- `Bezier.restrict()` — was `self.to_bspline() → restrict → Bezier.from_bspline()`, now uses `to_bezier(copy=False)` → **applied**

## Test plan
- [x] All existing tests pass (1498 passed)
- [x] New tests for `to_bezier`: Bézier-like knots (1D/2D), non-open single element, periodic multi-element error, multi-element error, copy true/false, rational, roundtrip
- [x] New tests for `from_bezier`: 1D, 2D, copy true/false, rational
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

Generated with [Claude Code](https://claude.com/claude-code)