### PR TITLE
feat(bezier,bspline): add split method and refactor Bezier.restrict

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -13,7 +13,9 @@ from ._bezier_degree import _degree_elevate_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
 from ._bezier_product import _multiply_bezier
+from ._bezier_restrict import _restrict_bezier
 from ._bezier_slice import _slice_bezier
+from ._bezier_split import _split_bezier
 
 if TYPE_CHECKING:
     from ..bspline import Bspline
@@ -489,7 +491,9 @@ class Bezier:
         Bézier has the same degree but different control points that encode
         the restricted mapping.
 
-        Internally converts to a B-spline, restricts, and converts back.
+        Uses two de Casteljau passes per direction for direct Bernstein
+        coefficient computation without B-spline conversion. The order
+        of the passes is chosen for numerical stability.
 
         Args:
             bounds (tuple[float, float] | Sequence[tuple[float, float] | None]):
@@ -509,9 +513,71 @@ class Bezier:
             ValueError: If any bound lies outside ``[0, 1]``.
             ValueError: If ``lower >= upper`` in any direction.
         """
-        bspline = self.to_bspline(copy=False)
-        restricted = bspline.restrict(bounds)
-        return restricted.to_bezier(copy=False)
+        if self.dim == 1:
+            bounds_per_dim: list[tuple[float, float] | None] = [
+                bounds  # type: ignore[list-item]
+            ]
+        else:
+            seq = list(bounds)  # type: ignore[arg-type,unused-ignore]
+            if len(seq) != self.dim:
+                raise ValueError(
+                    f"bounds sequence length ({len(seq)}) must match dim ({self.dim})."
+                )
+            bounds_per_dim = seq  # type: ignore[assignment]
+
+        # Validate bounds.
+        for i, b in enumerate(bounds_per_dim):
+            if b is None:
+                continue
+            lower, upper = b
+            if lower >= upper:
+                raise ValueError(
+                    f"Lower bound ({lower}) must be strictly less than upper bound ({upper}) "
+                    f"in direction {i}."
+                )
+            if lower < 0.0 or upper > 1.0:
+                raise ValueError(
+                    f"Bounds ({lower}, {upper}) must lie within [0, 1] in direction {i}."
+                )
+
+        return _restrict_bezier(self, bounds_per_dim)
+
+    # ------------------------------------------------------------------
+    # Split
+    # ------------------------------------------------------------------
+
+    def split(self, direction: int, value: float) -> tuple[Bezier, Bezier]:
+        """Split the Bézier into two at a parameter value in one direction.
+
+        Uses the de Casteljau algorithm to subdivide the Bézier into a
+        left half (representing the original on ``[0, value]``) and a right
+        half (representing the original on ``[value, 1]``), both
+        reparametrized to ``[0, 1]``.
+
+        Args:
+            direction (int): Parametric direction along which to split.
+                Must be in ``[0, dim)``.
+            value (float): Parameter value at which to split.  Must lie
+                strictly inside ``(0, 1)``.
+
+        Returns:
+            tuple[Bezier, Bezier]: A pair ``(left, right)`` of Béziers on
+            ``[0, 1]^dim``.
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+            ValueError: If ``value`` is not strictly inside ``(0, 1)``.
+
+        Example:
+            >>> left, right = curve.split(0, 0.5)
+            >>> left, right = surface.split(1, 0.3)
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+        if value <= 0.0 or value >= 1.0:
+            raise ValueError(f"value must be strictly inside (0, 1), got {value}.")
+
+        return _split_bezier(self, direction, value)
 
     # ------------------------------------------------------------------
     # Slice and boundary

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -319,6 +319,140 @@ def _slice_bezier_1d_core(
         out[col] = d[0]
 
 
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=True,
+)
+def _split_bezier_1d_core(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    value: float,
+    out_left: npt.NDArray[np.float32 | np.float64],
+    out_right: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Split a 1D Bézier at a parameter value via de Casteljau.
+
+    Performs a single forward de Casteljau pass that simultaneously produces
+    the control points for both the left ``[0, value]`` and right
+    ``[value, 1]`` halves (reparametrized to ``[0, 1]``).
+
+    After level ``r`` of the forward iteration, the workspace naturally
+    contains ``[d_0^r, d_1^{r-1}, ..., d_p^0]``.  The left-half control
+    points are ``d[0]`` at each level; the right-half control points are
+    the final workspace state.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of
+            shape ``(p + 1, n_cols)``, where ``p`` is the polynomial
+            degree and ``n_cols`` is the number of independent columns.
+        value (float): Parameter value in ``(0, 1)`` at which to split.
+        out_left (npt.NDArray[np.float32 | np.float64]): Pre-allocated
+            output array of shape ``(p + 1, n_cols)`` for the left half.
+        out_right (npt.NDArray[np.float32 | np.float64]): Pre-allocated
+            output array of shape ``(p + 1, n_cols)`` for the right half.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_split_bezier` in ``_bezier_split``
+        instead.
+    """
+    p = ctrl.shape[0] - 1
+    n_cols = ctrl.shape[1]
+    u = value
+    one_minus_u = 1.0 - u
+
+    for col in nb_prange(n_cols):
+        # Local workspace for de Casteljau on this column.
+        d = np.empty(p + 1, dtype=ctrl.dtype)
+        for i in range(p + 1):
+            d[i] = ctrl[i, col]
+
+        # First left control point is the original first control point.
+        out_left[0, col] = d[0]
+
+        for r in range(1, p + 1):
+            for i in range(p - r + 1):
+                d[i] = one_minus_u * d[i] + u * d[i + 1]
+            # After level r, d[0] = d_0^r → left-half control point.
+            out_left[r, col] = d[0]
+
+        # After all iterations, d = [d_0^p, d_1^{p-1}, ..., d_p^0] = right half.
+        for i in range(p + 1):
+            out_right[i, col] = d[i]
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    parallel=True,
+)
+def _restrict_bezier_1d_core(  # noqa: PLR0912
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    lower: float,
+    upper: float,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    r"""Restrict a 1D Bézier to a sub-interval via two de Casteljau passes.
+
+    Computes the Bernstein coefficients of the polynomial restricted to
+    ``[lower, upper]`` and reparametrized to ``[0, 1]``.  Uses the
+    numerically stable two-pass strategy: the order of the left/right
+    passes is chosen to avoid dividing by a small number.
+
+    - If ``|upper| >= |lower - 1|``: left pass at ``upper``, then right
+      pass at ``lower / upper``.
+    - Otherwise: right pass at ``lower``, then left pass at
+      ``(upper - lower) / (1 - lower)``.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of
+            shape ``(p + 1, n_cols)``.
+        lower (float): Left bound of the sub-interval in ``[0, 1)``.
+        upper (float): Right bound of the sub-interval in ``(0, 1]``.
+        out (npt.NDArray[np.float32 | np.float64]): Pre-allocated output
+            array of shape ``(p + 1, n_cols)`` for the restricted
+            coefficients.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_restrict_bezier` in
+        ``_bezier_restrict`` instead.
+    """
+    p = ctrl.shape[0] - 1
+    n_cols = ctrl.shape[1]
+
+    for col in nb_prange(n_cols):
+        d = np.empty(p + 1, dtype=ctrl.dtype)
+        for i in range(p + 1):
+            d[i] = ctrl[i, col]
+
+        if abs(upper) >= abs(lower - 1.0):
+            # deCasteljauLeft(upper), then deCasteljauRight(lower / upper)
+            tau = upper
+            for step in range(1, p + 1):
+                for j in range(p, step - 1, -1):
+                    d[j] = d[j] * tau + d[j - 1] * (1.0 - tau)
+
+            tau2 = lower / upper
+            for step in range(1, p + 1):
+                for j in range(p - step + 1):
+                    d[j] = d[j] * (1.0 - tau2) + d[j + 1] * tau2
+        else:
+            # deCasteljauRight(lower), then deCasteljauLeft((upper-lower)/(1-lower))
+            tau = lower
+            for step in range(1, p + 1):
+                for j in range(p - step + 1):
+                    d[j] = d[j] * (1.0 - tau) + d[j + 1] * tau
+
+            tau2 = (upper - lower) / (1.0 - lower)
+            for step in range(1, p + 1):
+                for j in range(p, step - 1, -1):
+                    d[j] = d[j] * tau2 + d[j - 1] * (1.0 - tau2)
+
+        for i in range(p + 1):
+            out[i, col] = d[i]
+
+
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
@@ -331,7 +465,11 @@ def _warmup_numba_functions() -> None:
     out_deriv_dummy = np.empty((1, 1, 2), dtype=np.float64)
     out_slice_dummy = np.empty(2, dtype=np.float64)
 
+    out_split_dummy = np.empty((3, 2), dtype=np.float64)
+
     _evaluate_bezier_1d_core(ctrl_dummy, pts_dummy, out_eval_dummy)
     _evaluate_bezier_deriv_1d_core(ctrl_dummy, pts_dummy, 0, out_deriv_dummy)
     _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1)
     _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)
+    _split_bezier_1d_core(ctrl_dummy, 0.5, out_split_dummy, out_split_dummy.copy())
+    _restrict_bezier_1d_core(ctrl_dummy, 0.2, 0.8, out_split_dummy)

--- a/src/pantr/bezier/_bezier_restrict.py
+++ b/src/pantr/bezier/_bezier_restrict.py
@@ -1,0 +1,81 @@
+"""Bézier restriction to a sub-interval via de Casteljau.
+
+This module provides :func:`_restrict_bezier`, which restricts a Bézier to a
+sub-region of ``[0, 1]^dim`` and reparametrizes the result back to
+``[0, 1]^dim``.
+
+The algorithm uses two de Casteljau passes per direction (with numerically
+stable pass ordering), avoiding the previous Bézier → B-spline → restrict →
+Bézier round-trip.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._bezier_core import _restrict_bezier_1d_core
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _restrict_bezier(
+    bezier: Bezier,
+    bounds_per_dim: list[tuple[float, float] | None],
+) -> Bezier:
+    """Restrict a Bézier to a sub-region of ``[0, 1]^dim``.
+
+    Applies :func:`_restrict_bezier_1d_core` per parametric direction using the
+    standard moveaxis pattern. Directions with ``None`` bounds are left
+    unchanged.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): Input Bézier.
+        bounds_per_dim: Per-direction bounds as ``(lower, upper)`` or ``None``
+            to skip. Must have length ``dim``.
+
+    Returns:
+        ~pantr.bezier.Bezier: New Bézier on ``[0, 1]^dim`` representing the
+        restriction.
+
+    Raises:
+        ValueError: If every direction is ``None`` or matches the full
+            ``[0, 1]`` domain.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl = bezier.control_points
+    any_restricted = False
+
+    for i, bounds in enumerate(bounds_per_dim):
+        if bounds is None:
+            continue
+
+        lower, upper = bounds
+
+        # Skip full-domain bounds.
+        if lower == 0.0 and upper == 1.0:
+            continue
+
+        any_restricted = True
+
+        # Move target axis to position 0, flatten the rest.
+        moved = np.moveaxis(ctrl, i, 0)
+        orig_shape = moved.shape
+        pts_2d = moved.reshape(orig_shape[0], -1)
+
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        out = np.empty_like(pts_2d)
+        _restrict_bezier_1d_core(pts_2d, lower, upper, out)
+
+        # Restore shape and move axis back.
+        ctrl = np.moveaxis(out.reshape(orig_shape), 0, i)
+
+    if not any_restricted:
+        raise ValueError("Bounds match the full domain; at least one direction must be restricted.")
+
+    return BezierCls(ctrl, is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_split.py
+++ b/src/pantr/bezier/_bezier_split.py
@@ -1,0 +1,76 @@
+"""Bézier splitting (subdivide along one parametric direction).
+
+This module provides :func:`_split_bezier`, which splits a Bézier into two
+new Béziers at a given parameter value in one parametric direction using
+the de Casteljau algorithm.
+
+The core algorithm performs a single forward de Casteljau pass that
+simultaneously produces the control points for both the left ``[0, value]``
+and right ``[value, 1]`` halves, each reparametrized to ``[0, 1]``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._bezier_core import _split_bezier_1d_core
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _split_bezier(
+    bezier: Bezier,
+    direction: int,
+    value: float,
+) -> tuple[Bezier, Bezier]:
+    """Split a Bézier into two at a parameter value in one direction.
+
+    Uses the de Casteljau algorithm to compute the control points for the
+    left ``[0, value]`` and right ``[value, 1]`` halves simultaneously,
+    each reparametrized to ``[0, 1]``.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to split.
+        direction (int): Parametric direction along which to split
+            (0-indexed, must be in ``[0, dim)``).
+        value (float): Parameter value at which to split (must be in
+            ``(0, 1)``).
+
+    Returns:
+        tuple[~pantr.bezier.Bezier, ~pantr.bezier.Bezier]: A pair
+        ``(left, right)`` of Béziers, each on ``[0, 1]^dim``, representing
+        the left and right halves of the original.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bezier.Bezier.split` instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl = bezier.control_points
+
+    # Move target axis to position 0, flatten the rest into a single axis.
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    # Allocate outputs.
+    out_left = np.empty_like(pts_2d)
+    out_right = np.empty_like(pts_2d)
+
+    _split_bezier_1d_core(pts_2d, value, out_left, out_right)
+
+    # Restore multi-dimensional shape and move axis back.
+    left_ctrl = np.moveaxis(out_left.reshape(orig_shape), 0, direction)
+    right_ctrl = np.moveaxis(out_right.reshape(orig_shape), 0, direction)
+
+    return (
+        BezierCls(left_ctrl, is_rational=bezier.is_rational),
+        BezierCls(right_ctrl, is_rational=bezier.is_rational),
+    )

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -27,6 +27,7 @@ from ._bspline_knot_insertion import (
 from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
+from ._bspline_split import _split_bspline_impl
 
 if TYPE_CHECKING:
     from ..bezier import Bezier
@@ -511,6 +512,47 @@ class Bspline:
             bounds_per_dim = seq  # type: ignore[assignment]
 
         return _restrict_bspline_impl(self, bounds_per_dim)
+
+    def split(self, direction: int, value: float) -> tuple[Bspline, Bspline]:
+        """Split the B-spline into two at a parameter value in one direction.
+
+        Inserts knots at ``value`` until the multiplicity reaches
+        ``degree + 1``, then extracts the left and right sub-splines.
+        Periodic directions are automatically converted to open form before
+        splitting.
+
+        Args:
+            direction (int): Parametric direction along which to split.
+                Must be in ``[0, dim)``.
+            value (float): Parameter value at which to split.  Must lie
+                strictly inside the domain of the specified direction.
+
+        Returns:
+            tuple[Bspline, Bspline]: A pair ``(left, right)`` of B-splines.
+            The left sub-spline has domain ``[domain_start, value]`` and
+            the right has domain ``[value, domain_end]`` in the split
+            direction. Other directions are unchanged.
+
+        Raises:
+            ValueError: If ``direction`` is out of range ``[0, dim)``.
+            ValueError: If ``value`` is not strictly inside the domain.
+
+        Example:
+            >>> left, right = spline.split(0, 0.5)
+            >>> left, right = surface.split(1, 0.3)
+        """
+        if direction < 0 or direction >= self.dim:
+            raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
+
+        space_1d = self.space.spaces[direction]
+        domain = space_1d.domain
+        a, b = float(domain[0]), float(domain[1])
+        tol = float(space_1d.tolerance)
+
+        if value <= a + tol or value >= b - tol:
+            raise ValueError(f"value must be strictly inside the domain ({a}, {b}), got {value}.")
+
+        return _split_bspline_impl(self, direction, value)
 
     def to_periodic(self, continuity: int | tuple[int | None, ...] | None = None) -> Bspline:
         """Return a periodic B-spline equivalent to this one.

--- a/src/pantr/bspline/_bspline_split.py
+++ b/src/pantr/bspline/_bspline_split.py
@@ -1,0 +1,155 @@
+"""Layer 2 implementation for B-spline splitting.
+
+This module provides the algorithm for splitting a B-spline into two at a
+given parameter value. The core logic inserts knots at the split point until
+the multiplicity reaches ``degree + 1``, then extracts the left and right
+sub-splines.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bspline_knot_insertion import (
+    _insert_knots_bspline_1d_impl,
+    _to_open_bspline_1d_impl,
+)
+
+if TYPE_CHECKING:
+    from . import Bspline
+
+
+def _split_bspline_1d_impl(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    ctrl_2d: npt.NDArray[np.float32 | np.float64],
+    periodic: bool,
+    tol: float,
+    value: float,
+) -> tuple[
+    tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
+    tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
+]:
+    """Split a 1D B-spline at a parameter value.
+
+    Inserts knots at ``value`` until multiplicity ``degree + 1``, then
+    extracts the left ``[domain_start, value]`` and right
+    ``[value, domain_end]`` sub-splines.
+
+    For periodic splines, the direction is first converted to open form via
+    :func:`_to_open_bspline_1d_impl`.
+
+    Args:
+        knots: Knot vector of shape ``(len(knots),)``.
+        degree: Polynomial degree.
+        ctrl_2d: Control point matrix of shape ``(n, rank)``.
+        periodic: Whether the spline is periodic.
+        tol: Knot comparison tolerance.
+        value: Parameter value at which to split (must lie strictly inside
+            the domain).
+
+    Returns:
+        tuple: ``((left_knots, left_ctrl), (right_knots, right_ctrl))`` — the
+        knot vectors and control points for the left and right sub-splines.
+    """
+    p = degree
+
+    # For periodic splines, convert to open form first.
+    if periodic:
+        knots, ctrl_2d = _to_open_bspline_1d_impl(knots, p, ctrl_2d, periodic, tol)
+
+    # Compute current multiplicity of the split value.
+    m_current = int(np.sum(np.isclose(knots, value, atol=tol)))
+    deficit = p + 1 - m_current
+    if deficit > 0:
+        knots_to_insert = np.full(deficit, value, dtype=knots.dtype)
+        knots, ctrl_2d = _insert_knots_bspline_1d_impl(knots, p, ctrl_2d, knots_to_insert, tol)
+
+    # Find the split index: value now has multiplicity p+1.
+    i_split = int(np.searchsorted(knots, value - tol))
+
+    # Left sub-spline: [domain_start, value].
+    left_knots = knots[: i_split + p + 1].copy()
+    left_ctrl = ctrl_2d[:i_split].copy()
+
+    # Right sub-spline: [value, domain_end].
+    right_knots = knots[i_split:].copy()
+    right_ctrl = ctrl_2d[i_split:].copy()
+
+    return (left_knots, left_ctrl), (right_knots, right_ctrl)
+
+
+def _split_bspline_impl(
+    bspline: Bspline,
+    direction: int,
+    value: float,
+) -> tuple[Bspline, Bspline]:
+    """Split a B-spline into two at a parameter value in one direction.
+
+    Applies :func:`_split_bspline_1d_impl` along the specified parametric
+    direction using the standard moveaxis pattern.
+
+    Args:
+        bspline: Input B-spline.
+        direction: Parametric direction along which to split.
+        value: Parameter value at which to split.
+
+    Returns:
+        tuple[Bspline, Bspline]: ``(left, right)`` — the left and right
+        sub-splines.
+    """
+    from . import Bspline as BsplineCls  # noqa: PLC0415
+    from . import BsplineSpace, BsplineSpace1D  # noqa: PLC0415
+
+    dim = bspline.dim
+    ctrl = bspline.control_points
+
+    # Move the split direction to axis 0, flatten the rest.
+    moved_ctrl = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved_ctrl.shape
+    pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+
+    space_1d = bspline.space.spaces[direction]
+    (left_knots, left_pts_2d), (right_knots, right_pts_2d) = _split_bspline_1d_impl(
+        space_1d.knots,
+        space_1d.degree,
+        pts_2d,
+        space_1d.periodic,
+        float(space_1d.tolerance),
+        value,
+    )
+
+    # Build left B-spline.
+    left_shape = (left_pts_2d.shape[0], *orig_shape[1:])
+    left_ctrl = np.moveaxis(left_pts_2d.reshape(left_shape), 0, direction)
+
+    # Build right B-spline.
+    right_shape = (right_pts_2d.shape[0], *orig_shape[1:])
+    right_ctrl = np.moveaxis(right_pts_2d.reshape(right_shape), 0, direction)
+
+    # Construct the spaces: replace the split direction, keep others.
+    left_spaces: list[BsplineSpace1D] = []
+    right_spaces: list[BsplineSpace1D] = []
+    for i in range(dim):
+        if i == direction:
+            left_spaces.append(
+                BsplineSpace1D(left_knots, space_1d.degree, periodic=False, snap_knots=False)
+            )
+            right_spaces.append(
+                BsplineSpace1D(right_knots, space_1d.degree, periodic=False, snap_knots=False)
+            )
+        else:
+            left_spaces.append(bspline.space.spaces[i])
+            right_spaces.append(bspline.space.spaces[i])
+
+    left_bspline = BsplineCls(BsplineSpace(left_spaces), left_ctrl, is_rational=bspline.is_rational)
+    right_bspline = BsplineCls(
+        BsplineSpace(right_spaces), right_ctrl, is_rational=bspline.is_rational
+    )
+
+    return left_bspline, right_bspline

--- a/tests/test_bezier_split.py
+++ b/tests/test_bezier_split.py
@@ -1,0 +1,364 @@
+"""Tests for Bezier.split() and the refactored Bezier.restrict()."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_1d_curve(dtype: type = np.float64) -> Bezier:
+    """Create a 1D cubic Bézier curve (4 control points, rank 2)."""
+    ctrl: npt.NDArray[np.float64] = np.array([[0, 0], [1, 3], [4, 3], [5, 0]], dtype=dtype)
+    return Bezier(ctrl)
+
+
+def _make_2d_surface(dtype: type = np.float64) -> Bezier:
+    """Create a 2D quadratic Bézier surface (3x3 control points, rank 3)."""
+    rng = np.random.default_rng(42)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_3d_volume(dtype: type = np.float64) -> Bezier:
+    """Create a 3D linear Bézier volume (2x2x2 control points, rank 3)."""
+    rng = np.random.default_rng(123)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((2, 2, 2, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_rational_curve(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    ctrl: npt.NDArray[np.float64] = np.array([[1, 0, 1], [w, w, w], [0, 1, 1]], dtype=dtype)
+    return Bezier(ctrl, is_rational=True)
+
+
+def _make_rational_surface(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier surface."""
+    rng = np.random.default_rng(99)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    ctrl[:, :, -1] = np.abs(ctrl[:, :, -1]) + 0.5
+    return Bezier(ctrl, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bezier.split()
+# ---------------------------------------------------------------------------
+
+
+class TestSplit1D:
+    """Test splitting a 1D Bézier curve."""
+
+    def test_split_returns_two_beziers(self) -> None:
+        """Split returns a tuple of two Béziers with same degree."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.5)
+        assert isinstance(left, Bezier)
+        assert isinstance(right, Bezier)
+        assert left.degree == crv.degree
+        assert right.degree == crv.degree
+
+    def test_split_continuity(self) -> None:
+        """Left(1) == right(0) at the split point."""
+        crv = _make_1d_curve()
+        for u in [0.1, 0.3, 0.5, 0.7, 0.9]:
+            left, right = crv.split(0, u)
+            pt_left = left.evaluate(np.array([1.0])).squeeze()
+            pt_right = right.evaluate(np.array([0.0])).squeeze()
+            np.testing.assert_allclose(pt_left, pt_right, atol=1e-14)
+
+    def test_split_matches_original(self) -> None:
+        """Evaluations on the halves match the original curve."""
+        crv = _make_1d_curve()
+        u_split = 0.4
+        left, right = crv.split(0, u_split)
+
+        # Left half: [0, u_split] mapped to [0, 1].
+        pts_orig_left = np.linspace(0, u_split, 20)
+        pts_mapped_left = pts_orig_left / u_split
+        vals_orig = crv.evaluate(pts_orig_left)
+        vals_left = left.evaluate(pts_mapped_left)
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+
+        # Right half: [u_split, 1] mapped to [0, 1].
+        pts_orig_right = np.linspace(u_split, 1.0, 20)
+        pts_mapped_right = (pts_orig_right - u_split) / (1.0 - u_split)
+        vals_orig = crv.evaluate(pts_orig_right)
+        vals_right = right.evaluate(pts_mapped_right)
+        np.testing.assert_allclose(vals_right, vals_orig, atol=1e-13)
+
+    def test_split_endpoints(self) -> None:
+        """Left starts at original start, right ends at original end."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.6)
+        np.testing.assert_allclose(
+            left.evaluate(np.array([0.0])).squeeze(),
+            crv.evaluate(np.array([0.0])).squeeze(),
+            atol=1e-14,
+        )
+        np.testing.assert_allclose(
+            right.evaluate(np.array([1.0])).squeeze(),
+            crv.evaluate(np.array([1.0])).squeeze(),
+            atol=1e-14,
+        )
+
+    def test_split_degree_0(self) -> None:
+        """Splitting a degree-0 curve produces identical constants."""
+        crv = Bezier(np.array([[3.0, 4.0]]))
+        left, right = crv.split(0, 0.5)
+        np.testing.assert_allclose(left.control_points, crv.control_points)
+        np.testing.assert_allclose(right.control_points, crv.control_points)
+
+
+class TestSplit2D:
+    """Test splitting a 2D Bézier surface."""
+
+    def test_split_preserves_degree_and_dim(self) -> None:
+        """Split preserves parametric dimension and degrees."""
+        srf = _make_2d_surface()
+        left, right = srf.split(0, 0.5)
+        assert left.dim == srf.dim
+        assert right.dim == srf.dim
+        assert left.degree == srf.degree
+        assert right.degree == srf.degree
+
+    def test_split_dir0_matches_original(self) -> None:
+        """Splitting along direction 0 matches original evaluations."""
+        srf = _make_2d_surface()
+        u_split = 0.3
+        left, right = srf.split(0, u_split)
+
+        # Test points along the split boundary.
+        n = 15
+        v_vals = np.linspace(0, 1, n)
+
+        # Original at u=u_split.
+        pts_orig = np.column_stack([np.full(n, u_split), v_vals])
+        vals_orig = srf.evaluate(pts_orig)
+
+        # Left at u=1.
+        pts_left = np.column_stack([np.ones(n), v_vals])
+        vals_left = left.evaluate(pts_left)
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+
+        # Right at u=0.
+        pts_right = np.column_stack([np.zeros(n), v_vals])
+        vals_right = right.evaluate(pts_right)
+        np.testing.assert_allclose(vals_right, vals_orig, atol=1e-13)
+
+    def test_split_dir1_matches_original(self) -> None:
+        """Splitting along direction 1 matches original evaluations."""
+        srf = _make_2d_surface()
+        v_split = 0.6
+        left, right = srf.split(1, v_split)
+
+        n = 15
+        u_vals = np.linspace(0, 1, n)
+
+        # Original at v=v_split.
+        pts_orig = np.column_stack([u_vals, np.full(n, v_split)])
+        vals_orig = srf.evaluate(pts_orig)
+
+        # Left at v=1.
+        pts_left = np.column_stack([u_vals, np.ones(n)])
+        vals_left = left.evaluate(pts_left)
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+
+        # Right at v=0.
+        pts_right = np.column_stack([u_vals, np.zeros(n)])
+        vals_right = right.evaluate(pts_right)
+        np.testing.assert_allclose(vals_right, vals_orig, atol=1e-13)
+
+
+class TestSplit3D:
+    """Test splitting a 3D Bézier volume."""
+
+    def test_split_preserves_degree_and_dim(self) -> None:
+        """Split preserves parametric dimension and degrees."""
+        vol = _make_3d_volume()
+        left, right = vol.split(2, 0.5)
+        assert left.dim == vol.dim
+        assert right.dim == vol.dim
+        assert left.degree == vol.degree
+        assert right.degree == vol.degree
+
+    def test_split_volume_continuity(self) -> None:
+        """Split of a 3D volume preserves continuity at the split plane."""
+        vol = _make_3d_volume()
+        u_split = 0.4
+        left, _right = vol.split(0, u_split)
+
+        n = 10
+        rng = np.random.default_rng(77)
+        vw = rng.uniform(0, 1, (n, 2))
+
+        # Original at u=u_split.
+        pts_orig = np.column_stack([np.full(n, u_split), vw])
+        vals_orig = vol.evaluate(pts_orig)
+
+        # Left at u=1.
+        pts_left = np.column_stack([np.ones(n), vw])
+        vals_left = left.evaluate(pts_left)
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+
+
+class TestSplitRational:
+    """Test splitting rational Bézier curves and surfaces."""
+
+    def test_split_rational_curve(self) -> None:
+        """Splitting a rational curve preserves rational flag and continuity."""
+        crv = _make_rational_curve()
+        left, right = crv.split(0, 0.5)
+        assert left.is_rational
+        assert right.is_rational
+        assert left.rank == crv.rank
+        assert right.rank == crv.rank
+
+        # Continuity at split point.
+        pt_left = left.evaluate(np.array([1.0])).squeeze()
+        pt_right = right.evaluate(np.array([0.0])).squeeze()
+        np.testing.assert_allclose(pt_left, pt_right, atol=1e-14)
+
+    def test_split_rational_matches_original(self) -> None:
+        """Split of a rational curve matches original evaluations."""
+        crv = _make_rational_curve()
+        u_split = 0.3
+        left, _right = crv.split(0, u_split)
+
+        pts_orig = np.linspace(0, u_split, 15)
+        pts_mapped = pts_orig / u_split
+        vals_orig = crv.evaluate(pts_orig)
+        vals_left = left.evaluate(pts_mapped)
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+
+    def test_split_rational_surface(self) -> None:
+        """Splitting a rational surface preserves rational flag."""
+        srf = _make_rational_surface()
+        left, right = srf.split(0, 0.5)
+        assert left.is_rational
+        assert right.is_rational
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bezier.split() error cases
+# ---------------------------------------------------------------------------
+
+
+class TestSplitErrors:
+    """Test that split raises errors for invalid inputs."""
+
+    def test_direction_too_large(self) -> None:
+        """Direction >= dim raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="direction"):
+            crv.split(1, 0.5)
+
+    def test_direction_negative(self) -> None:
+        """Negative direction raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="direction"):
+            crv.split(-1, 0.5)
+
+    def test_value_at_zero(self) -> None:
+        """Value at 0 raises ValueError (must be strictly inside)."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly inside"):
+            crv.split(0, 0.0)
+
+    def test_value_at_one(self) -> None:
+        """Value at 1 raises ValueError (must be strictly inside)."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly inside"):
+            crv.split(0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bezier.restrict() (refactored)
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictRefactored:
+    """Test the refactored restrict (de Casteljau, no Bspline round-trip)."""
+
+    def test_restrict_1d_matches_bspline_roundtrip(self) -> None:
+        """New restrict matches the old Bspline-based restrict."""
+        crv = _make_1d_curve()
+        restricted = crv.restrict((0.2, 0.7))
+
+        # Reference via Bspline round-trip.
+        bspl = crv.to_bspline()
+        ref = Bezier.from_bspline(bspl.restrict((0.2, 0.7)))
+        np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-13)
+
+    def test_restrict_2d_matches_bspline_roundtrip(self) -> None:
+        """New restrict on 2D surface matches old Bspline-based restrict."""
+        srf = _make_2d_surface()
+        restricted = srf.restrict([(0.1, 0.8), (0.2, 0.9)])
+
+        bspl = srf.to_bspline()
+        ref = Bezier.from_bspline(bspl.restrict([(0.1, 0.8), (0.2, 0.9)]))
+        np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-12)
+
+    def test_restrict_partial_direction(self) -> None:
+        """Restrict with None in one direction only restricts the other."""
+        srf = _make_2d_surface()
+        restricted = srf.restrict([(0.3, 0.7), None])
+
+        bspl = srf.to_bspline()
+        ref = Bezier.from_bspline(bspl.restrict([(0.3, 0.7), None]))
+        np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-13)
+
+    def test_restrict_evaluations_match(self) -> None:
+        """Restricted Bézier evaluations match the original on the sub-domain."""
+        crv = _make_1d_curve()
+        a, b = 0.25, 0.75
+        restricted = crv.restrict((a, b))
+
+        # Evaluate original on [a, b].
+        pts_orig = np.linspace(a, b, 30)
+        vals_orig = crv.evaluate(pts_orig)
+
+        # Evaluate restricted on [0, 1] (reparametrized).
+        pts_new = (pts_orig - a) / (b - a)
+        vals_new = restricted.evaluate(pts_new)
+
+        np.testing.assert_allclose(vals_new, vals_orig, atol=1e-13)
+
+    def test_restrict_rational(self) -> None:
+        """Restricting a rational Bézier preserves rational flag."""
+        crv = _make_rational_curve()
+        restricted = crv.restrict((0.2, 0.8))
+        assert restricted.is_rational
+
+        # Check evaluations.
+        a, b = 0.2, 0.8
+        pts_orig = np.linspace(a, b, 15)
+        vals_orig = crv.evaluate(pts_orig)
+        pts_new = (pts_orig - a) / (b - a)
+        vals_new = restricted.evaluate(pts_new)
+        np.testing.assert_allclose(vals_new, vals_orig, atol=1e-13)
+
+    def test_restrict_full_domain_raises(self) -> None:
+        """Restricting to the full domain raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="full domain"):
+            crv.restrict((0.0, 1.0))
+
+    def test_restrict_invalid_bounds(self) -> None:
+        """Invalid bounds (lower >= upper) raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly less"):
+            crv.restrict((0.5, 0.3))
+
+    def test_restrict_out_of_domain(self) -> None:
+        """Bounds outside [0, 1] raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="within"):
+            crv.restrict((-0.1, 0.5))

--- a/tests/test_bspline_split.py
+++ b/tests/test_bspline_split.py
@@ -1,0 +1,238 @@
+"""Tests for Bspline.split() method."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_1d_curve(degree: int = 3, dtype: type = np.float64) -> Bspline:
+    """Create a 1D cubic curve with 5 control points."""
+    knots: npt.NDArray[np.float64] = np.array([0, 0, 0, 0, 0.5, 1, 1, 1, 1], dtype=dtype)
+    ctrl: npt.NDArray[np.float64] = np.array([[0, 0], [1, 2], [3, 3], [5, 1], [6, 0]], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    return Bspline(space, ctrl)
+
+
+def _make_2d_surface(dtype: type = np.float64) -> Bspline:
+    """Create a 2D quadratic surface with interior knot."""
+    knots_u: npt.NDArray[np.float64] = np.array([0, 0, 0, 0.5, 1, 1, 1], dtype=dtype)
+    knots_v: npt.NDArray[np.float64] = np.array([0, 0, 0, 1, 1, 1], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots_u, 2), BsplineSpace1D(knots_v, 2)])
+    rng = np.random.default_rng(42)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((4, 3, 3)).astype(dtype)
+    return Bspline(space, ctrl)
+
+
+def _make_rational_curve(dtype: type = np.float64) -> Bspline:
+    """Create a rational quadratic B-spline (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    knots: npt.NDArray[np.float64] = np.array([0, 0, 0, 1, 1, 1], dtype=dtype)
+    ctrl: npt.NDArray[np.float64] = np.array([[1, 0, 1], [w, w, w], [0, 1, 1]], dtype=dtype)
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    return Bspline(space, ctrl, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.split() 1D
+# ---------------------------------------------------------------------------
+
+
+class TestSplit1D:
+    """Test splitting a 1D B-spline curve."""
+
+    def test_split_returns_two_bsplines(self) -> None:
+        """Split returns a tuple of two Bsplines with same degree."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.3)
+        assert isinstance(left, Bspline)
+        assert isinstance(right, Bspline)
+        assert left.degree == crv.degree
+        assert right.degree == crv.degree
+
+    def test_split_domains(self) -> None:
+        """Split produces correct sub-domains."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.3)
+        np.testing.assert_allclose(left.space.spaces[0].domain, (0.0, 0.3))
+        np.testing.assert_allclose(right.space.spaces[0].domain, (0.3, 1.0))
+
+    def test_split_continuity(self) -> None:
+        """Left and right match at the split point."""
+        crv = _make_1d_curve()
+        for val in [0.1, 0.3, 0.5, 0.7, 0.9]:
+            left, right = crv.split(0, val)
+            pt_left = left.evaluate(np.array([val])).squeeze()
+            pt_right = right.evaluate(np.array([val])).squeeze()
+            np.testing.assert_allclose(pt_left, pt_right, atol=1e-14)
+
+    def test_split_matches_original(self) -> None:
+        """Evaluations on halves match the original curve."""
+        crv = _make_1d_curve()
+        val = 0.4
+        left, right = crv.split(0, val)
+
+        # Left half.
+        pts_left = np.linspace(0, val, 20)
+        np.testing.assert_allclose(left.evaluate(pts_left), crv.evaluate(pts_left), atol=1e-13)
+
+        # Right half.
+        pts_right = np.linspace(val, 1.0, 20)
+        np.testing.assert_allclose(right.evaluate(pts_right), crv.evaluate(pts_right), atol=1e-13)
+
+    def test_split_at_existing_knot(self) -> None:
+        """Splitting at an existing interior knot works correctly."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.5)
+        np.testing.assert_allclose(left.space.spaces[0].domain, (0.0, 0.5))
+        np.testing.assert_allclose(right.space.spaces[0].domain, (0.5, 1.0))
+
+        pt_l = left.evaluate(np.array([0.5])).squeeze()
+        pt_r = right.evaluate(np.array([0.5])).squeeze()
+        pt_o = crv.evaluate(np.array([0.5])).squeeze()
+        np.testing.assert_allclose(pt_l, pt_o, atol=1e-14)
+        np.testing.assert_allclose(pt_r, pt_o, atol=1e-14)
+
+    def test_split_clamped_knots(self) -> None:
+        """Both halves have clamped knot vectors at the split point."""
+        crv = _make_1d_curve()
+        left, right = crv.split(0, 0.3)
+        p = crv.degree[0]
+
+        # Left should end with p+1 copies of 0.3.
+        left_knots = left.space.spaces[0].knots
+        assert left.space.spaces[0].has_right_end_open()
+        np.testing.assert_allclose(left_knots[-p - 1 :], 0.3)
+
+        # Right should start with p+1 copies of 0.3.
+        right_knots = right.space.spaces[0].knots
+        assert right.space.spaces[0].has_left_end_open()
+        np.testing.assert_allclose(right_knots[: p + 1], 0.3)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.split() multi-dim
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMultiDim:
+    """Test splitting multi-dimensional B-splines."""
+
+    def test_split_surface_dir0(self) -> None:
+        """Split a surface along direction 0."""
+        srf = _make_2d_surface()
+        val = 0.3
+        left, right = srf.split(0, val)
+
+        assert left.dim == srf.dim
+        assert right.dim == srf.dim
+        assert left.degree == srf.degree
+        assert right.degree == srf.degree
+
+        # Check domains.
+        np.testing.assert_allclose(left.space.spaces[0].domain, (0.0, val))
+        np.testing.assert_allclose(right.space.spaces[0].domain, (val, 1.0))
+        # Direction 1 unchanged.
+        np.testing.assert_array_equal(left.space.spaces[1].knots, srf.space.spaces[1].knots)
+
+    def test_split_surface_dir1(self) -> None:
+        """Split a surface along direction 1."""
+        srf = _make_2d_surface()
+        val = 0.6
+        left, right = srf.split(1, val)
+
+        np.testing.assert_allclose(left.space.spaces[1].domain, (0.0, val))
+        np.testing.assert_allclose(right.space.spaces[1].domain, (val, 1.0))
+        # Direction 0 unchanged.
+        np.testing.assert_array_equal(left.space.spaces[0].knots, srf.space.spaces[0].knots)
+
+    def test_split_surface_continuity(self) -> None:
+        """Split surface evaluations match at the split boundary."""
+        srf = _make_2d_surface()
+        val = 0.4
+        left, right = srf.split(0, val)
+
+        n = 15
+        v_pts = np.linspace(0, 1, n)
+        pts = np.column_stack([np.full(n, val), v_pts])
+        vals_left = left.evaluate(pts)
+        vals_right = right.evaluate(pts)
+        vals_orig = srf.evaluate(pts)
+
+        np.testing.assert_allclose(vals_left, vals_orig, atol=1e-13)
+        np.testing.assert_allclose(vals_right, vals_orig, atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.split() rational
+# ---------------------------------------------------------------------------
+
+
+class TestSplitRational:
+    """Test splitting rational B-splines."""
+
+    def test_split_rational_preserves_flag(self) -> None:
+        """Split preserves the rational flag."""
+        crv = _make_rational_curve()
+        left, right = crv.split(0, 0.5)
+        assert left.is_rational
+        assert right.is_rational
+        assert left.rank == crv.rank
+
+    def test_split_rational_matches_original(self) -> None:
+        """Split of a rational curve matches original evaluations."""
+        crv = _make_rational_curve()
+        val = 0.4
+        left, right = crv.split(0, val)
+
+        pts_left = np.linspace(0, val, 20)
+        np.testing.assert_allclose(left.evaluate(pts_left), crv.evaluate(pts_left), atol=1e-13)
+
+        pts_right = np.linspace(val, 1.0, 20)
+        np.testing.assert_allclose(right.evaluate(pts_right), crv.evaluate(pts_right), atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Bspline.split() error cases
+# ---------------------------------------------------------------------------
+
+
+class TestSplitErrors:
+    """Test that split raises errors for invalid inputs."""
+
+    def test_direction_out_of_range(self) -> None:
+        """Direction >= dim raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="direction"):
+            crv.split(1, 0.5)
+
+    def test_direction_negative(self) -> None:
+        """Negative direction raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="direction"):
+            crv.split(-1, 0.5)
+
+    def test_value_at_domain_start(self) -> None:
+        """Value at domain start raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly inside"):
+            crv.split(0, 0.0)
+
+    def test_value_at_domain_end(self) -> None:
+        """Value at domain end raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly inside"):
+            crv.split(0, 1.0)
+
+    def test_value_outside_domain(self) -> None:
+        """Value outside domain raises ValueError."""
+        crv = _make_1d_curve()
+        with pytest.raises(ValueError, match="strictly inside"):
+            crv.split(0, 1.5)


### PR DESCRIPTION
## Summary
- Add `Bezier.split(direction, value)` that subdivides a Bézier at a parameter value using a single-pass de Casteljau Numba kernel, producing both left and right halves simultaneously
- Add `Bspline.split(direction, value)` that splits via knot insertion to full multiplicity, then extracts both sub-splines
- Refactor `Bezier.restrict` to use two de Casteljau passes directly (following algoim's numerically stable strategy) instead of the previous Bézier → B-spline → restrict → Bézier round-trip
- Add `_split_bezier_1d_core` and `_restrict_bezier_1d_core` Numba kernels (Layer 3) with prange parallelization

## Test plan
- [x] 41 new tests covering 1D/2D/3D split, rational cases, continuity, evaluation matching, error cases
- [x] Restrict consistency tests verify new implementation matches old Bspline round-trip
- [x] All 1524 existing tests pass
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)