### PR TITLE
feat(bspline): add to_beziers Bezier decomposition

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -28,6 +28,7 @@ from ._bspline_knot_removal import _remove_knots_bspline
 from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
 from ._bspline_split import _split_bspline_impl
+from ._bspline_to_beziers import _to_beziers_impl
 
 if TYPE_CHECKING:
     from ..bezier import Bezier
@@ -48,6 +49,8 @@ class Bspline:
         _control_points (npt.NDArray[np.float32 | np.float64]): Control point
             array reshaped to ``(*num_basis, rank)``.
         _is_rational (bool): Whether the B-spline is rational (NURBS).
+        _beziers_cache (npt.NDArray[np.object_] | None): Cached Bézier
+            decomposition, or ``None`` if not yet computed.
     """
 
     def __init__(
@@ -85,6 +88,7 @@ class Bspline:
             )
 
         self._is_rational = is_rational
+        self._beziers_cache: npt.NDArray[np.object_] | None = None
 
         if self.rank <= 0:
             raise ValueError(f"The B-spline must have at least rank one. Got rank {self.rank}")
@@ -644,6 +648,36 @@ class Bspline:
         cp = open_bspline.control_points.copy() if copy else open_bspline.control_points
         return BezierCls(cp, is_rational=self._is_rational)
 
+    def to_beziers(self) -> npt.NDArray[np.object_]:
+        """Decompose into Bézier patches.
+
+        Decomposes the B-spline into its constituent Bézier patches by applying
+        Bézier extraction operators direction by direction.  Periodic directions
+        are automatically converted to open form first.
+
+        The result is cached: the first call computes and stores the
+        decomposition; subsequent calls return the cached array.  In-place
+        mutations (``reverse``, ``permute_directions``, ``transform`` with
+        ``in_place=True``) invalidate the cache.
+
+        Returns:
+            npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier`
+            objects with shape ``(*num_intervals)`` following the tensor-product
+            interval structure.  For a 1D B-spline with 3 intervals the shape
+            is ``(3,)``.  For a 2D surface with 3×2 intervals the shape is
+            ``(3, 2)``.  The Bézier control points are read-only.
+
+        Example:
+            >>> beziers = spline.to_beziers()
+            >>> beziers.shape
+            (3,)
+            >>> beziers[0].degree
+            (2,)
+        """
+        if self._beziers_cache is None:
+            self._beziers_cache = _to_beziers_impl(self)
+        return self._beziers_cache
+
     @classmethod
     def from_bezier(cls, bezier: Bezier, *, copy: bool = True) -> Bspline:
         """Create a B-spline from a Bézier.
@@ -763,6 +797,7 @@ class Bspline:
 
         if in_place:
             self._space = new_space
+            self._beziers_cache = None
             return None
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
@@ -818,6 +853,7 @@ class Bspline:
         if in_place:
             self._control_points = new_cp
             self._space = new_space
+            self._beziers_cache = None
             return None
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
@@ -872,6 +908,7 @@ class Bspline:
             in_place=in_place,
         )
         if in_place:
+            self._beziers_cache = None
             return None
         return Bspline(self._space, new_cp, is_rational=self._is_rational)
 

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -664,7 +664,7 @@ class Bspline:
             npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier`
             objects with shape ``(*num_intervals)`` following the tensor-product
             interval structure.  For a 1D B-spline with 3 intervals the shape
-            is ``(3,)``.  For a 2D surface with 3×2 intervals the shape is
+            is ``(3,)``.  For a 2D surface with 3x2 intervals the shape is
             ``(3, 2)``.  The Bézier control points are read-only.
 
         Example:

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -49,7 +49,7 @@ class Bspline:
         _control_points (npt.NDArray[np.float32 | np.float64]): Control point
             array reshaped to ``(*num_basis, rank)``.
         _is_rational (bool): Whether the B-spline is rational (NURBS).
-        _beziers_cache (npt.NDArray[np.object_] | None): Cached Bézier
+        _beziers_cache (``npt.NDArray[np.object_] | None``): Cached Bézier
             decomposition, or ``None`` if not yet computed.
     """
 
@@ -661,7 +661,7 @@ class Bspline:
         ``in_place=True``) invalidate the cache.
 
         Returns:
-            npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier`
+            ``npt.NDArray[np.object_]``: Array of :class:`~pantr.bezier.Bezier`
             objects with shape ``(*num_intervals)`` following the tensor-product
             interval structure.  For a 1D B-spline with 3 intervals the shape
             is ``(3,)``.  For a 2D surface with 3x2 intervals the shape is

--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -75,7 +75,7 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
         bspline (Bspline): Input B-spline to decompose.
 
     Returns:
-        npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier` objects
+        ``npt.NDArray[np.object_]``: Array of :class:`~pantr.bezier.Bezier` objects
         with shape ``(*num_intervals)`` following the tensor-product interval
         structure.
     """

--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -1,0 +1,157 @@
+"""Bezier decomposition of B-splines via extraction operators.
+
+This module decomposes a B-spline into its constituent Bezier patches using
+Bezier extraction operators applied direction by direction. The result is a
+multidimensional array of :class:`~pantr.bezier.Bezier` objects following the
+tensor-product interval structure.
+
+The core Numba kernel :func:`_apply_bezier_extraction_1d_core` applies the
+extraction operators for one parametric direction, transforming B-spline
+control points into Bezier control points for all elements simultaneously.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit, nb_prange
+
+if TYPE_CHECKING:
+    from . import Bspline
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def _apply_bezier_extraction_1d_core(
+    extraction_ops: npt.NDArray[Any],
+    ctrl: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+) -> None:
+    r"""Apply Bezier extraction operators to control points along one direction.
+
+    For each element ``i``, computes the Bezier control points as
+    ``C_i^T @ P_local`` where ``C_i`` is the extraction operator and
+    ``P_local = ctrl[i : i + order, :]`` are the local B-spline control points.
+
+    Args:
+        extraction_ops (npt.NDArray[Any]): Bezier extraction operators of shape
+            ``(n_elements, order, order)`` where ``order = degree + 1``.
+        ctrl (npt.NDArray[Any]): B-spline control points of shape
+            ``(n_basis, M)`` where ``M`` is the flattened trailing dimension.
+            Must be C-contiguous.
+        out (npt.NDArray[Any]): Pre-allocated output array of shape
+            ``(n_elements * order, M)`` where Bezier control points are written.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_to_beziers_impl` instead.
+    """
+    n_elements = extraction_ops.shape[0]
+    order = extraction_ops.shape[1]
+    m = ctrl.shape[1]
+
+    for elem in nb_prange(n_elements):
+        c_t = extraction_ops[elem].T
+        out_start = elem * order
+        for i in range(order):
+            for j in range(m):
+                val = c_t.dtype.type(0.0)
+                for k in range(order):
+                    val += c_t[i, k] * ctrl[elem + k, j]
+                out[out_start + i, j] = val
+
+
+def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
+    """Decompose a B-spline into Bezier patches via extraction operators.
+
+    Converts periodic directions to open form, then applies Bezier extraction
+    operators direction by direction using the standard moveaxis pattern. The
+    resulting control point array is reshaped and split into individual
+    :class:`~pantr.bezier.Bezier` objects.
+
+    Args:
+        bspline (Bspline): Input B-spline to decompose.
+
+    Returns:
+        npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier` objects
+        with shape ``(*num_intervals)`` following the tensor-product interval
+        structure.
+    """
+    from ..bezier import Bezier  # noqa: PLC0415
+
+    dim = bspline.dim
+
+    # Convert periodic directions to open form.
+    if any(s.periodic for s in bspline.space.spaces):
+        bspline = bspline.to_open_bspline()
+
+    ctrl = bspline.control_points
+    num_intervals = bspline.space.num_intervals
+    degrees = bspline.degree
+
+    # Apply extraction operators direction by direction.
+    for d in range(dim):
+        space_1d = bspline.space.spaces[d]
+        extraction_ops = space_1d.tabulate_Bezier_extraction_operators()
+        n_el = num_intervals[d]
+        order = degrees[d] + 1
+
+        # Move direction d to axis 0, flatten trailing axes into a 2D matrix.
+        moved_ctrl = np.moveaxis(ctrl, d, 0)
+        orig_shape = moved_ctrl.shape
+        pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        # Apply extraction: (n_basis, M) -> (n_el * order, M).
+        out_2d = np.empty((n_el * order, pts_2d.shape[1]), dtype=pts_2d.dtype)
+        _apply_bezier_extraction_1d_core(extraction_ops, pts_2d, out_2d)
+
+        # Restore shape and move axis back.
+        new_shape = (n_el * order, *orig_shape[1:])
+        ctrl = np.moveaxis(out_2d.reshape(new_shape), 0, d)
+
+    # ctrl now has shape (n_el_0*order_0, n_el_1*order_1, ..., rank).
+    # Reshape to (n_el_0, order_0, n_el_1, order_1, ..., rank).
+    intermediate_shape: list[int] = []
+    for d in range(dim):
+        intermediate_shape.append(num_intervals[d])
+        intermediate_shape.append(degrees[d] + 1)
+    intermediate_shape.append(ctrl.shape[-1])
+
+    ctrl_reshaped = ctrl.reshape(intermediate_shape)
+
+    # Transpose to (n_el_0, n_el_1, ..., order_0, order_1, ..., rank).
+    perm = [2 * d for d in range(dim)] + [2 * d + 1 for d in range(dim)] + [2 * dim]
+    ctrl_transposed = np.transpose(ctrl_reshaped, perm)
+
+    # Build Bezier objects.
+    result = np.empty(num_intervals, dtype=object)
+    is_rational = bspline.is_rational
+
+    for idx in np.ndindex(*num_intervals):
+        bez_ctrl = np.ascontiguousarray(ctrl_transposed[idx])
+        bez_ctrl.flags.writeable = False
+        result[idx] = Bezier(bez_ctrl, is_rational=is_rational)
+
+    return result
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile Numba functions with float64 signatures for faster first call.
+
+    This function triggers compilation of the Numba-decorated functions
+    with float64 arrays, ensuring they are cached and ready for use.
+    """
+    extraction_ops = np.eye(3, dtype=np.float64).reshape(1, 3, 3)
+    ctrl = np.zeros((3, 2), dtype=np.float64)
+    out = np.zeros((3, 2), dtype=np.float64)
+    _apply_bezier_extraction_1d_core(extraction_ops, ctrl, out)
+
+
+__all__ = [
+    "_apply_bezier_extraction_1d_core",
+    "_to_beziers_impl",
+]

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1,5 +1,7 @@
 """Tests for bspline module."""
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -1394,7 +1396,7 @@ def _evaluate_bezier_on_subdomain(
     bezier: Bezier,
     domain: npt.NDArray[np.float64],
     num_pts: int = 5,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+) -> tuple[npt.NDArray[np.floating[Any]], npt.NDArray[np.floating[Any]]]:
     """Evaluate a Bezier on its original sub-domain by mapping to [0, 1].
 
     Args:

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1587,7 +1587,7 @@ class TestToBeziers:
 
     def test_cache_invalidation_transform(self) -> None:
         """Test that in-place transform invalidates the Bezier cache."""
-        from pantr.transform import AffineTransform
+        from pantr.transform import AffineTransform  # noqa: PLC0415
 
         knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
         space = BsplineSpace([BsplineSpace1D(knots, 2)])

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1383,3 +1383,267 @@ class TestFromBezier:
         assert bs.space.has_Bezier_like_knots()
         assert bs.degree == (2, 1)
         np.testing.assert_array_equal(bs.control_points, cp)
+
+
+# ---------------------------------------------------------------------------
+# to_beziers (Bezier decomposition)
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_bezier_on_subdomain(
+    bezier: Bezier,
+    domain: npt.NDArray[np.float64],
+    num_pts: int = 5,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Evaluate a Bezier on its original sub-domain by mapping to [0, 1].
+
+    Args:
+        bezier: Bezier patch.
+        domain: Array of shape (dim, 2) with sub-domain bounds.
+        num_pts: Number of evaluation points per direction.
+
+    Returns:
+        Tuple of (physical_pts, values) where physical_pts are in the original
+        domain and values are the Bezier evaluations.
+    """
+    dim = bezier.dim
+    if dim == 1:
+        xi = np.linspace(0.0, 1.0, num_pts, dtype=np.float64)
+        phys = domain[0, 0] + xi * (domain[0, 1] - domain[0, 0])
+        vals = bezier.evaluate(xi)
+        return phys, vals
+    else:
+        grids = []
+        phys_grids = []
+        for d in range(dim):
+            xi_d = np.linspace(0.0, 1.0, num_pts, dtype=np.float64)
+            phys_d = domain[d, 0] + xi_d * (domain[d, 1] - domain[d, 0])
+            grids.append(xi_d)
+            phys_grids.append(phys_d)
+        mesh_xi = np.array(np.meshgrid(*grids, indexing="ij")).reshape(dim, -1).T
+        mesh_phys = np.array(np.meshgrid(*phys_grids, indexing="ij")).reshape(dim, -1).T
+        vals = bezier.evaluate(mesh_xi)
+        return mesh_phys, vals
+
+
+class TestToBeziers:
+    """Test Bspline.to_beziers decomposition."""
+
+    def test_1d_single_element(self) -> None:
+        """Test to_beziers for a single-element 1D B-spline (Bezier-like)."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        assert beziers.shape == (1,)
+        assert beziers[0].degree == (2,)
+        np.testing.assert_allclose(beziers[0].control_points, cp)
+
+    def test_1d_multi_element(self) -> None:
+        """Test to_beziers for a multi-element 1D B-spline."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[0.0, 0.0], [0.5, 1.0], [0.5, 0.5], [1.0, 0.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        assert beziers.shape == (2,)
+        for i in range(2):
+            assert beziers[i].degree == (2,)
+            assert isinstance(beziers[i], Bezier)
+
+    def test_1d_evaluation_consistency(self) -> None:
+        """Test that each 1D Bezier patch evaluates identically to the original B-spline."""
+        knots = np.array(
+            [0.0, 0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0], dtype=np.float64
+        )
+        space = BsplineSpace([BsplineSpace1D(knots, 3)])
+        rng = np.random.default_rng(42)
+        cp = rng.standard_normal((7, 2))
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        assert beziers.shape == (4,)
+
+        unique_knots, _ = space.spaces[0].get_unique_knots_and_multiplicity(in_domain=True)
+        for i in range(4):
+            domain = np.array([[unique_knots[i], unique_knots[i + 1]]], dtype=np.float64)
+            phys_pts, bez_vals = _evaluate_bezier_on_subdomain(beziers[i], domain, num_pts=7)
+            bs_vals = bs.evaluate(phys_pts)
+            np.testing.assert_allclose(bez_vals, bs_vals, atol=1e-12)
+
+    def test_2d_tensor_product(self) -> None:
+        """Test to_beziers for a 2D tensor-product B-spline."""
+        s0 = BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2)
+        s1 = BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(123)
+        cp = rng.standard_normal((*space.num_basis, 3))
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        assert beziers.shape == (2, 2)
+        for idx in np.ndindex(2, 2):
+            assert beziers[idx].degree == (2, 1)
+            assert isinstance(beziers[idx], Bezier)
+
+    def test_2d_evaluation_consistency(self) -> None:
+        """Test evaluation consistency for a 2D B-spline decomposition."""
+        s0 = BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2)
+        s1 = BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(456)
+        cp = rng.standard_normal((*space.num_basis, 2))
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        uknots_0, _ = s0.get_unique_knots_and_multiplicity(in_domain=True)
+        uknots_1, _ = s1.get_unique_knots_and_multiplicity(in_domain=True)
+
+        for i0 in range(2):
+            for i1 in range(2):
+                domain = np.array(
+                    [
+                        [uknots_0[i0], uknots_0[i0 + 1]],
+                        [uknots_1[i1], uknots_1[i1 + 1]],
+                    ],
+                    dtype=np.float64,
+                )
+                phys_pts, bez_vals = _evaluate_bezier_on_subdomain(
+                    beziers[i0, i1], domain, num_pts=4
+                )
+                bs_vals = bs.evaluate(phys_pts)
+                np.testing.assert_allclose(bez_vals, bs_vals, atol=1e-12)
+
+    def test_3d_shape(self) -> None:
+        """Test to_beziers for a 3D trivariate B-spline."""
+        s0 = BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1)
+        s1 = BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2)
+        s2 = BsplineSpace1D([0.0, 0.0, 0.0, 1.0 / 3, 2.0 / 3, 1.0, 1.0, 1.0], 2)
+        space = BsplineSpace([s0, s1, s2])
+        rng = np.random.default_rng(789)
+        cp = rng.standard_normal((*space.num_basis, 1))
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        assert beziers.shape == (2, 2, 3)
+        for idx in np.ndindex(2, 2, 3):
+            assert beziers[idx].degree == (1, 2, 2)
+
+    def test_periodic(self) -> None:
+        """Test to_beziers for a periodic B-spline."""
+        bs_per = _make_periodic_bspline(3, 2)
+        beziers = bs_per.to_beziers()
+        assert beziers.shape == (3,)
+
+        # Compare to decomposition of the open equivalent.
+        bs_open = bs_per.to_open_bspline()
+        beziers_open = bs_open.to_beziers()
+        for i in range(3):
+            np.testing.assert_allclose(
+                beziers[i].control_points,
+                beziers_open[i].control_points,
+                atol=1e-12,
+            )
+
+    def test_rational(self) -> None:
+        """Test to_beziers preserves rationality on each Bezier."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array(
+            [[0.0, 1.0], [0.5, 1.0], [0.5, 0.5], [1.0, 1.0]],
+            dtype=np.float64,
+        )
+        bs = Bspline(space, cp, is_rational=True)
+        beziers = bs.to_beziers()
+        assert beziers.shape == (2,)
+        for i in range(2):
+            assert beziers[i].is_rational
+
+    def test_caching(self) -> None:
+        """Test that to_beziers caches the result."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        result1 = bs.to_beziers()
+        result2 = bs.to_beziers()
+        assert result1 is result2
+
+    def test_cache_invalidation_reverse(self) -> None:
+        """Test that in-place reverse invalidates the Bezier cache."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        result_before = bs.to_beziers()
+        bs.reverse(in_place=True)
+        result_after = bs.to_beziers()
+        assert result_before is not result_after
+
+    def test_cache_invalidation_transform(self) -> None:
+        """Test that in-place transform invalidates the Bezier cache."""
+        from pantr.transform import AffineTransform
+
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        result_before = bs.to_beziers()
+        bs.transform(AffineTransform(np.eye(1), np.array([1.0])), in_place=True)
+        result_after = bs.to_beziers()
+        assert result_before is not result_after
+
+    def test_cache_invalidation_permute(self) -> None:
+        """Test that in-place permute_directions invalidates the Bezier cache."""
+        s0 = BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2)
+        s1 = BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(99)
+        cp = rng.standard_normal((*space.num_basis, 2))
+        bs = Bspline(space, cp)
+
+        result_before = bs.to_beziers()
+        bs.permute_directions([1, 0], in_place=True)
+        result_after = bs.to_beziers()
+        assert result_before is not result_after
+
+    def test_read_only_control_points(self) -> None:
+        """Test that Bezier control points from to_beziers are read-only."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0], [2.0], [3.0], [4.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        for i in range(2):
+            assert not beziers[i].control_points.flags.writeable
+
+    def test_degree_preserved(self) -> None:
+        """Test that each Bezier has the same degree as the original B-spline."""
+        s0 = BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2)
+        s1 = BsplineSpace1D([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], 3)
+        space = BsplineSpace([s0, s1])
+        rng = np.random.default_rng(11)
+        cp = rng.standard_normal((*space.num_basis, 1))
+        bs = Bspline(space, cp)
+
+        beziers = bs.to_beziers()
+        for idx in np.ndindex(*beziers.shape):
+            assert beziers[idx].degree == bs.degree
+
+    def test_matches_to_bezier_single_element(self) -> None:
+        """Test that to_beziers matches to_bezier for single-element B-splines."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        cp = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+        bs = Bspline(space, cp)
+
+        single_bez = bs.to_bezier()
+        beziers = bs.to_beziers()
+        np.testing.assert_allclose(beziers[0].control_points, single_bez.control_points, atol=1e-14)


### PR DESCRIPTION
## Summary

- Add `Bspline.to_beziers()` method that decomposes a B-spline into its constituent Bezier patches
- Returns a numpy object array of `Bezier` instances with shape `(*num_intervals)` following the tensor-product interval structure
- Uses Bezier extraction operators applied direction by direction (moveaxis pattern) for memory efficiency — avoids materializing a full refined control point grid
- New parallel Numba kernel `_apply_bezier_extraction_1d_core` applies extraction operators for one parametric direction across all elements
- Result is cached on the `Bspline` instance; in-place mutations (`reverse`, `permute_directions`, `transform`) invalidate the cache
- Bezier control points in the cached result are marked read-only

## Test plan

- [x] All existing tests pass (1588 tests)
- [x] 15 new tests covering:
  - 1D/2D/3D shapes and evaluation consistency
  - Periodic and rational B-splines
  - Caching and cache invalidation on in-place mutations
  - Read-only control points, degree preservation
  - Agreement with `to_bezier()` for single-element splines
- [x] Pre-PR checks pass (ruff lint, ruff format, mypy, pytest, sphinx docs)

Generated with [Claude Code](https://claude.com/claude-code)