### PR TITLE
feat(bezier): add degree reduction via least-squares approximation

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import typing as npt
 
 from .._transform_control_points import _apply_affine_to_control_points
-from ._bezier_degree import _degree_elevate_bezier
+from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
 from ._bezier_product import _multiply_bezier
@@ -298,6 +298,63 @@ class Bezier:
             raise ValueError("At least one degree increment must be positive.")
 
         return _degree_elevate_bezier(self, increments)
+
+    # ------------------------------------------------------------------
+    # Degree reduction
+    # ------------------------------------------------------------------
+
+    def reduce_degree(self, degree_decrements: int | Sequence[int]) -> Bezier:
+        """Reduce the polynomial degree of the Bézier via least-squares approximation.
+
+        Creates a new Bézier whose degree is lower by the requested amount in
+        each parametric direction.  The reduction minimises the squared error
+        under the Bernstein degree-elevation matrix using QR factorisation with
+        Givens rotations.
+
+        Unlike :meth:`elevate_degree`, this operation is **not exact** in
+        general: the result is an approximation of the original mapping.
+
+        Args:
+            degree_decrements (int | Sequence[int]): Number of degrees to
+                reduce. If an integer, the same decrement is applied to all
+                parametric directions. If a sequence, must have length equal
+                to ``self.dim``.
+
+        Returns:
+            Bezier: A new Bézier with reduced degrees.
+
+        Raises:
+            ValueError: If any degree decrement is negative.
+            ValueError: If all degree decrements are zero.
+            ValueError: If the number of decrements does not match the dimension.
+            ValueError: If any decrement exceeds the current degree in that
+                direction.
+        """
+        if isinstance(degree_decrements, int):
+            decrements = (degree_decrements,) * self.dim
+        else:
+            decrements = tuple(degree_decrements)
+
+        if len(decrements) != self.dim:
+            raise ValueError(
+                f"Number of degree decrements ({len(decrements)}) "
+                f"must match dimension ({self.dim})."
+            )
+
+        if any(dec < 0 for dec in decrements):
+            raise ValueError("Degree decrements must be non-negative.")
+
+        if all(dec == 0 for dec in decrements):
+            raise ValueError("At least one degree decrement must be positive.")
+
+        for d, dec in enumerate(decrements):
+            if dec > self.degree[d]:
+                raise ValueError(
+                    f"Degree decrement ({dec}) in direction {d} exceeds "
+                    f"current degree ({self.degree[d]})."
+                )
+
+        return _degree_reduce_bezier(self, decrements)
 
     # ------------------------------------------------------------------
     # Multiply

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -1,8 +1,8 @@
-"""Numba-compiled kernels for Bézier evaluation and degree elevation.
+"""Numba-compiled kernels for Bézier evaluation, degree elevation, and degree reduction.
 
 Provides fused evaluation kernels that compute Bernstein basis values and
-contract them with control points in a single pass, plus a simplified
-single-element degree elevation kernel.
+contract them with control points in a single pass, plus degree elevation
+and degree reduction kernels.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
@@ -261,6 +261,113 @@ def _degree_elevate_bezier_1d_core(
     return new_ctrl
 
 
+@nb_jit(nopython=True, cache=True)
+def _degree_reduce_bezier_1d_core(  # noqa: PLR0912
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degree_decrement: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Degree-reduce a single Bézier segment via least-squares approximation.
+
+    The degree elevation matrix from degree ``P-1`` to ``P`` is a
+    ``(P+1) \times P`` lower bidiagonal matrix with diagonal
+    ``a_k = 1 - k/P`` and sub-diagonal ``b_k = (k+1)/P``.  Degree reduction
+    solves the overdetermined system ``M x = c`` in the least-squares sense
+    using QR factorisation with Givens rotations (complexity ``O(P)`` per
+    rank component).
+
+    When ``degree_decrement > 1``, the single-step reduction is applied
+    iteratively.
+
+    Args:
+        degree (int): Current polynomial degree (``p >= 1``).
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p+1, rank)``.
+        degree_decrement (int): Number of degrees to remove (``1 <= t <= p``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Reduced control points of shape
+        ``(p - t + 1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_degree._degree_reduce_bezier`
+        instead.
+    """
+    rank = ctrl.shape[1]
+    cur = np.empty((ctrl.shape[0], rank), dtype=ctrl.dtype)
+    for i in range(ctrl.shape[0]):
+        for r in range(rank):
+            cur[i, r] = ctrl[i, r]
+
+    cur_deg = degree
+
+    for _step in range(degree_decrement):
+        p = cur_deg
+        n_new = p  # reduced degree = p - 1, so p control points
+
+        nxt = np.empty((n_new, rank), dtype=ctrl.dtype)
+
+        # Build diagonal and sub-diagonal of the (P+1) x P elevation matrix.
+        # diagonal:     a[k] = 1 - k/P   for k = 0 .. P-1
+        # sub-diagonal: b[k] = (k+1)/P   for k = 0 .. P-1
+        #
+        # Givens QR: zero each sub-diagonal entry, producing an upper
+        # bidiagonal R and transforming the RHS.  Then back-substitute.
+        diag = np.empty(p, dtype=np.float64)
+        sup = np.empty(p, dtype=np.float64)  # super-diagonal created by Givens
+        rhs = np.empty(p + 1, dtype=np.float64)
+
+        for r in range(rank):
+            # Initialise diagonal entries and RHS for this rank component.
+            for k in range(p):
+                diag[k] = 1.0 - np.float64(k) / np.float64(p)
+            for k in range(p):
+                sup[k] = 0.0
+            for k in range(p + 1):
+                rhs[k] = np.float64(cur[k, r])
+
+            # Forward Givens pass
+            for k in range(p):
+                bk = np.float64(k + 1) / np.float64(p)  # sub-diagonal value
+                ak = diag[k]
+
+                # Givens rotation to zero bk
+                if bk == 0.0:
+                    cs = 1.0
+                    sn = 0.0
+                elif abs(bk) > abs(ak):
+                    tmp = ak / bk
+                    sn = 1.0 / np.sqrt(1.0 + tmp * tmp)
+                    cs = tmp * sn
+                else:
+                    tmp = bk / ak
+                    cs = 1.0 / np.sqrt(1.0 + tmp * tmp)
+                    sn = tmp * cs
+
+                diag[k] = cs * ak + sn * bk  # = hypot(ak, bk)
+
+                # Rotation creates a super-diagonal entry at (k, k+1)
+                if k + 1 < p:
+                    sup[k] = sn * diag[k + 1]
+                    diag[k + 1] = cs * diag[k + 1]
+
+                # Rotate RHS rows k and k+1
+                rk = rhs[k]
+                rhs[k] = cs * rk + sn * rhs[k + 1]
+                rhs[k + 1] = -sn * rk + cs * rhs[k + 1]
+
+            # Back-substitution on upper bidiagonal R
+            nxt[p - 1, r] = ctrl.dtype.type(rhs[p - 1] / diag[p - 1])
+            for k in range(p - 2, -1, -1):
+                nxt[k, r] = ctrl.dtype.type((rhs[k] - sup[k] * np.float64(nxt[k + 1, r])) / diag[k])
+
+        cur = nxt
+        cur_deg = p - 1
+
+    return cur
+
+
 @nb_jit(
     nopython=True,
     cache=True,
@@ -470,6 +577,7 @@ def _warmup_numba_functions() -> None:
     _evaluate_bezier_1d_core(ctrl_dummy, pts_dummy, out_eval_dummy)
     _evaluate_bezier_deriv_1d_core(ctrl_dummy, pts_dummy, 0, out_deriv_dummy)
     _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1)
+    _degree_reduce_bezier_1d_core(2, ctrl_dummy, 1)
     _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)
     _split_bezier_1d_core(ctrl_dummy, 0.5, out_split_dummy, out_split_dummy.copy())
     _restrict_bezier_1d_core(ctrl_dummy, 0.2, 0.8, out_split_dummy)

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -1,8 +1,9 @@
-"""Bézier degree elevation.
+"""Bézier degree elevation and reduction.
 
 This module provides :func:`_degree_elevate_bezier`, which raises the polynomial
 degree of a Bézier in one or more parametric directions while preserving the
-same geometric mapping.
+same geometric mapping, and :func:`_degree_reduce_bezier`, which computes a
+least-squares degree-reduced approximation.
 """
 
 from __future__ import annotations
@@ -12,7 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from ._bezier_core import _degree_elevate_bezier_1d_core
+from ._bezier_core import _degree_elevate_bezier_1d_core, _degree_reduce_bezier_1d_core
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -68,5 +69,61 @@ def _degree_elevate_bezier(
 
         # Update degrees for subsequent iterations.
         degrees = (*degrees[:d], p + inc, *degrees[d + 1 :])
+
+    return BezierCls(ctrl, is_rational=bezier.is_rational)
+
+
+def _degree_reduce_bezier(
+    bezier: Bezier,
+    decrements: tuple[int, ...],
+) -> Bezier:
+    """Degree-reduce a Bézier in one or more parametric directions.
+
+    For each direction with a positive decrement, applies the Bézier degree
+    reduction kernel using the moveaxis/reshape pattern.  The reduction is a
+    least-squares approximation (not exact in general).
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to reduce.
+        decrements (tuple[int, ...]): Degree decrement per direction. All
+            values must be non-negative; at least one must be positive.  No
+            decrement may exceed the current degree in that direction.
+
+    Returns:
+        ~pantr.bezier.Bezier: New Bézier with reduced degrees and updated
+        control points.
+
+    Note:
+        Inputs are assumed to be validated by the caller (Layer 1).
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
+    degrees = bezier.degree
+
+    for d in range(bezier.dim):
+        dec = decrements[d]
+        if dec == 0:
+            continue
+
+        p = degrees[d]
+
+        # Move target direction to axis 0, flatten the rest.
+        moved = np.moveaxis(ctrl, d, 0)
+        orig_shape = moved.shape
+        pts_2d = moved.reshape(orig_shape[0], -1)
+
+        if not pts_2d.flags.c_contiguous:
+            pts_2d = np.ascontiguousarray(pts_2d)
+
+        new_pts_2d = _degree_reduce_bezier_1d_core(p, pts_2d, dec)
+
+        # Restore shape and move axis back.
+        new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+        new_moved = new_pts_2d.reshape(new_shape)
+        ctrl = np.moveaxis(new_moved, 0, d)
+
+        # Update degrees for subsequent iterations.
+        degrees = (*degrees[:d], p - dec, *degrees[d + 1 :])
 
     return BezierCls(ctrl, is_rational=bezier.is_rational)

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -1,0 +1,187 @@
+"""Tests for Bézier degree reduction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+
+
+def _make_bezier_1d(ctrl: list[list[float]], rational: bool = False) -> Bezier:
+    """Create a 1D Bézier from a list of control points."""
+    return Bezier(np.array(ctrl), is_rational=rational)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests: elevate then reduce should recover the original
+# ---------------------------------------------------------------------------
+
+
+class TestBezierReduceDegreeRoundTrip:
+    """Elevate by t then reduce by t should recover the original exactly."""
+
+    def test_linear_elevate_1_reduce_1(self) -> None:
+        """Linear Bézier → elevate by 1 → reduce by 1."""
+        b = _make_bezier_1d([[0.0, 0.0], [1.0, 2.0]])
+        reduced = b.elevate_degree(1).reduce_degree(1)
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-14)
+
+    def test_linear_elevate_3_reduce_3(self) -> None:
+        """Linear Bézier → elevate by 3 → reduce by 3."""
+        b = _make_bezier_1d([[0.0], [5.0]])
+        reduced = b.elevate_degree(3).reduce_degree(3)
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-13)
+
+    def test_quadratic_elevate_2_reduce_2(self) -> None:
+        """Quadratic Bézier → elevate by 2 → reduce by 2."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        reduced = b.elevate_degree(2).reduce_degree(2)
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-13)
+
+    def test_cubic_elevate_4_reduce_4(self) -> None:
+        """Cubic Bézier → elevate by 4 → reduce by 4."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0], [3.0]])
+        reduced = b.elevate_degree(4).reduce_degree(4)
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-12)
+
+    def test_2d_surface_round_trip(self) -> None:
+        """2D tensor-product Bézier (bilinear) → elevate → reduce."""
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]],
+                [[0.0, 1.0], [1.0, 2.0], [2.0, 1.0]],
+            ]
+        )
+        b = Bezier(ctrl)
+        reduced = b.elevate_degree((1, 2)).reduce_degree((1, 2))
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-12)
+
+    def test_2d_different_decrements(self) -> None:
+        """2D Bézier with different elevations per direction."""
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((3, 4, 2))  # degree (2, 3), rank 2
+        b = Bezier(ctrl)
+        reduced = b.elevate_degree((2, 1)).reduce_degree((2, 1))
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-12)
+
+    def test_rational_round_trip(self) -> None:
+        """Rational Bézier: elevate then reduce preserves geometry."""
+        ctrl_h = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0 / np.sqrt(2)], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl_h, is_rational=True)
+        reduced = b.elevate_degree(2).reduce_degree(2)
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-13)
+        assert reduced.is_rational
+
+
+# ---------------------------------------------------------------------------
+# Approximate reduction: reduce a genuine polynomial
+# ---------------------------------------------------------------------------
+
+
+class TestBezierReduceDegreeApproximate:
+    """Reducing a polynomial that is NOT an elevated lower-degree is approximate."""
+
+    def test_cubic_to_quadratic_geometry(self) -> None:
+        """Reducing a true cubic to quadratic preserves geometry approximately."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.3, 1.0], [0.7, 1.0], [1.0, 0.0]])
+        reduced = b.reduce_degree(1)
+        assert reduced.degree == (2,)
+
+        # Evaluate both at sample points and compare
+        pts = np.linspace(0, 1, 50)
+        vals_orig = b.evaluate(pts)
+        vals_red = reduced.evaluate(pts)
+        # The error should be reasonably small (not exact)
+        assert np.max(np.abs(vals_orig - vals_red)) < 0.1
+
+    def test_endpoints_preserved(self) -> None:
+        """After reduction, endpoints should be close to the original."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.3, 1.5], [0.7, -0.5], [1.0, 1.0]])
+        reduced = b.reduce_degree(1)
+
+        pts = np.array([0.0, 1.0])
+        vals_orig = b.evaluate(pts)
+        vals_red = reduced.evaluate(pts)
+        np.testing.assert_allclose(vals_red, vals_orig, atol=0.5)
+
+    def test_reduce_degree_result_type(self) -> None:
+        """Reduced Bézier has correct degree and dtype."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0], [3.0], [4.0]])
+        assert b.degree == (4,)
+
+        reduced = b.reduce_degree(2)
+        assert reduced.degree == (2,)
+        assert reduced.control_points.dtype == b.control_points.dtype
+
+    def test_reduce_by_1_from_degree_1(self) -> None:
+        """Reducing a linear Bézier by 1 gives degree 0 (constant)."""
+        b = _make_bezier_1d([[0.0, 0.0], [2.0, 4.0]])
+        reduced = b.reduce_degree(1)
+        assert reduced.degree == (0,)
+        # The constant is the least-squares fit: average of endpoints
+        expected = np.array([[1.0, 2.0]])
+        np.testing.assert_allclose(reduced.control_points, expected, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestBezierReduceDegreeErrors:
+    """Test that invalid inputs raise appropriate errors."""
+
+    def test_decrement_exceeds_degree(self) -> None:
+        """Decrement > degree should raise ValueError."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0]])  # degree 2
+        with pytest.raises(ValueError, match=r"exceeds current degree"):
+            b.reduce_degree(3)
+
+    def test_negative_decrement(self) -> None:
+        """Negative decrement should raise ValueError."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0]])
+        with pytest.raises(ValueError, match=r"non-negative"):
+            b.reduce_degree(-1)
+
+    def test_all_zero_decrements(self) -> None:
+        """All-zero decrements should raise ValueError."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0]])
+        with pytest.raises(ValueError, match=r"(?i)at least one"):
+            b.reduce_degree(0)
+
+    def test_wrong_length(self) -> None:
+        """Wrong number of decrements should raise ValueError."""
+        b = _make_bezier_1d([[0.0], [1.0], [2.0]])
+        with pytest.raises(ValueError, match=r"must match dimension"):
+            b.reduce_degree((1, 1))
+
+    def test_decrement_exceeds_per_direction(self) -> None:
+        """Per-direction decrement exceeding degree should raise."""
+        ctrl = np.zeros((2, 3, 1))  # degree (1, 2)
+        b = Bezier(ctrl)
+        with pytest.raises(ValueError, match=r"exceeds current degree"):
+            b.reduce_degree((2, 0))
+
+    def test_reduce_degree_0(self) -> None:
+        """Reducing a degree-0 Bézier should raise."""
+        b = Bezier(np.array([[42.0]]))
+        with pytest.raises(ValueError, match=r"exceeds current degree"):
+            b.reduce_degree(1)
+
+
+# ---------------------------------------------------------------------------
+# Float32 support
+# ---------------------------------------------------------------------------
+
+
+class TestBezierReduceDegreeFloat32:
+    """Test that float32 inputs produce float32 outputs."""
+
+    def test_float32_round_trip(self) -> None:
+        """Float32 elevation + reduction round-trip."""
+        ctrl = np.array([[0.0, 0.0], [1.0, 2.0]], dtype=np.float32)
+        b = Bezier(ctrl)
+        reduced = b.elevate_degree(2).reduce_degree(2)
+        assert reduced.control_points.dtype == np.float32
+        np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-5)

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -93,7 +93,8 @@ class TestBezierReduceDegreeApproximate:
         vals_orig = b.evaluate(pts)
         vals_red = reduced.evaluate(pts)
         # The error should be reasonably small (not exact)
-        assert np.max(np.abs(vals_orig - vals_red)) < 0.1
+        max_err_tol = 0.1
+        assert np.max(np.abs(vals_orig - vals_red)) < max_err_tol
 
     def test_endpoints_preserved(self) -> None:
         """After reduction, endpoints should be close to the original."""


### PR DESCRIPTION
## Summary

- Add `Bezier.reduce_degree()` method — the approximate inverse of `elevate_degree()`
- Layer 3 Numba kernel (`_degree_reduce_bezier_1d_core`) implements the bidiagonal least-squares approach from algoim: the degree elevation matrix is lower bidiagonal, solved via QR factorisation with Givens rotations in O(P) per rank component
- Layer 2 wrapper (`_degree_reduce_bezier`) handles multi-dimensional Béziers direction-by-direction using the standard moveaxis/reshape pattern
- Supports arbitrary degree decrements, multi-dimensional, rational, and float32/float64

This is PR 1 of 2 for degree reduction. PR 2 will add B-spline degree reduction.

## Test plan

- [x] Round-trip tests: elevate by t then reduce by t recovers original (1D, 2D, rational)
- [x] Approximate reduction: geometry is close for genuine higher-degree Béziers
- [x] Error cases: decrement > degree, negative, all-zero, wrong length
- [x] Float32 support
- [x] Pre-PR checks pass (ruff, mypy, pytest)

Generated with [Claude Code](https://claude.com/claude-code)