### PR TITLE
feat(viz): add pyvista visualization module with VTK Bezier cells

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 :caption: Contents
 
 getting-started
+visualization
 parallelism
 api/reference
 changelog

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,202 @@
+# Visualization
+
+PaNTr includes an optional visualization module (`pantr.viz`) built on
+[PyVista](https://docs.pyvista.org/) that renders B-spline and Bezier
+geometries using **native VTK higher-order Bezier cell types**.  This means
+exact polynomial geometry at any zoom level -- no tessellation to triangles.
+
+## Installation
+
+PyVista is not installed by default.  Add it with the `viz` extra:
+
+```bash
+pip install pantr[viz]
+```
+
+## Quick start
+
+The simplest way to visualize a geometry is the `plot()` convenience method
+available on both `Bspline` and `Bezier` objects:
+
+```python
+import numpy as np
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# Build a quadratic B-spline curve
+space = BsplineSpace([BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)])
+cp = np.array([
+    [0.0, 0.0, 0.0],
+    [0.5, 1.0, 0.0],
+    [1.0, 0.5, 0.5],
+    [1.5, 1.0, 0.0],
+    [2.0, 0.0, 0.0],
+])
+curve = Bspline(space, cp)
+
+# Interactive visualization
+curve.plot(show_control_points=True, show_knot_lines=True)
+```
+
+For multiple geometries or finer control, use `pantr.viz` directly:
+
+```python
+from pantr.viz import plot
+
+plot(curve, surface, show_control_points=True)
+```
+
+## Scene composition
+
+The `Scene` class lets you combine multiple geometries with individual
+rendering options:
+
+```python
+from pantr.viz import Scene
+
+scene = Scene()
+scene.add(surface, color="lightblue", show_knot_lines=True)
+scene.add(curve, color="red", show_control_points=True, show_control_polygon=True)
+scene.add(boundary_curve, color="black")
+scene.show()
+```
+
+Method chaining is supported:
+
+```python
+(
+    Scene()
+    .add(surface, color="lightblue", opacity=0.8)
+    .add(curve, color="red")
+    .show()
+)
+```
+
+### Per-geometry options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `color` | `str` or `None` | `None` | Surface color (uses colormap for scalar fields if `None`) |
+| `opacity` | `float` | `1.0` | Surface opacity |
+| `show_control_points` | `bool` | `False` | Render control points as spheres |
+| `show_control_polygon` | `bool` | `False` | Render wireframe connecting control points |
+| `show_knot_lines` | `bool` | `False` | Render knot lines (B-splines only) |
+| `control_point_color` | `str` | `"red"` | Color of control point spheres |
+| `control_point_size` | `float` | `8.0` | Size of control point spheres |
+| `control_polygon_color` | `str` | `"gray"` | Color of control polygon wireframe |
+| `knot_line_color` | `str` | `"black"` | Color of knot lines |
+| `knot_line_width` | `float` | `2.0` | Width of knot lines |
+| `scalar_bar` | `bool` | `True` | Show color bar for scalar fields |
+| `elevation` | `bool` | `False` | Use scalar value as z-coordinate (see below) |
+
+## Scalar fields
+
+When a B-spline or Bezier has `rank == 1` (a scalar field), the visualization
+depends on the parametric dimension:
+
+- **dim=1**: line plot -- the parametric coordinate is on the x-axis and the
+  scalar value on the y-axis.
+- **dim=2**: by default, a **color map** on the parametric domain `(u, v, 0)`.
+  Set `elevation=True` to use the scalar as the z-coordinate: `(u, v, f(u,v))`.
+- **dim=3**: color map on the parametric domain `(u, v, w)`.
+
+```python
+from pantr.bezier import Bezier
+
+# A bilinear scalar field on a quad
+cp = np.array([[[0.0], [1.0]], [[2.0], [3.0]]])
+scalar_field = Bezier(cp)
+
+# Flat color map (default)
+scalar_field.plot()
+
+# Elevation surface
+scalar_field.plot(elevation=True)
+```
+
+## Control points and polygon
+
+Control points are rendered as small spheres at their physical locations.
+For rational (NURBS) geometries, the **projected Euclidean coordinates** are
+used (i.e. divided by the homogeneous weight).
+
+The control polygon connects adjacent control points along each parametric
+direction:
+
+- **Curves**: a single polyline.
+- **Surfaces**: a grid of lines along both parametric directions.
+- **Volumes**: edges of the 3D control point lattice.
+
+```python
+curve.plot(show_control_points=True, show_control_polygon=True)
+```
+
+## Knot lines
+
+Knot lines are the images of iso-parametric lines at interior knot values.
+They are only available for B-splines (not Bezier objects, which have a
+single element).
+
+- **Curves (dim=1)**: knot points rendered as dots on the curve.
+- **Surfaces (dim=2)**: iso-parametric curves at each interior knot in each
+  direction, rendered as wireframe lines.
+- **Volumes (dim=3)**: iso-parametric surfaces at each interior knot.
+
+```python
+surface_bspline.plot(show_knot_lines=True)
+```
+
+## Working with pyvista directly
+
+For advanced use cases, convert geometries to pyvista objects and use the
+full pyvista API:
+
+```python
+from pantr.viz import to_pyvista, control_points_mesh, control_polygon_mesh
+
+# Get an UnstructuredGrid with VTK Bezier cells
+grid = to_pyvista(surface)
+
+# Manipulate with pyvista
+grid.plot(show_edges=True, cmap="viridis")
+
+# Access control points as pyvista PolyData
+cp_mesh = control_points_mesh(surface)
+poly_mesh = control_polygon_mesh(surface)
+```
+
+Rational geometries include a `"RationalWeights"` point data array on the
+grid. Scalar fields include the scalar values as point data (named `"scalar"`
+by default, configurable via `scalar_name`).
+
+## Exporting to VTK files
+
+Export geometries to VTK files for visualization in
+[ParaView](https://www.paraview.org/) (version 5.10+ supports Bezier cells
+natively):
+
+```python
+from pantr.viz import save
+
+# XML UnstructuredGrid format (recommended)
+save(surface, "surface.vtu")
+
+# Legacy VTK format
+save(surface, "surface.vtk")
+```
+
+The file format is inferred from the extension.
+
+## Supported geometries
+
+| Parametric dim | Rank | VTK cell type | Description |
+|---|---|---|---|
+| 1 | 2--3 | Bezier curve | 2D/3D curve |
+| 1 | 1 | Bezier curve | Scalar line plot |
+| 2 | 2--3 | Bezier quadrilateral | 2D/3D surface |
+| 2 | 1 | Bezier quadrilateral | Scalar color map / elevation |
+| 3 | 3 | Bezier hexahedron | 3D volume |
+| 3 | 1 | Bezier hexahedron | Scalar color map on volume |
+
+Both non-rational and rational (NURBS) geometries are supported.  Periodic
+and unclamped B-splines are automatically converted to open form before
+visualization.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -34,7 +34,7 @@ cp = np.array([
 curve = Bspline(space, cp)
 
 # Interactive visualization
-curve.plot(show_control_points=True, show_knot_lines=True)
+curve.plot(show_control_polygon=True, show_knot_lines=True)
 ```
 
 For multiple geometries or finer control, use `pantr.viz` directly:
@@ -42,7 +42,7 @@ For multiple geometries or finer control, use `pantr.viz` directly:
 ```python
 from pantr.viz import plot
 
-plot(curve, surface, show_control_points=True)
+plot(curve, surface, show_control_polygon=True)
 ```
 
 ## Scene composition
@@ -55,7 +55,7 @@ from pantr.viz import Scene
 
 scene = Scene()
 scene.add(surface, color="lightblue", show_knot_lines=True)
-scene.add(curve, color="red", show_control_points=True, show_control_polygon=True)
+scene.add(curve, color="red", show_control_polygon=True)
 scene.add(boundary_curve, color="black")
 scene.show()
 ```
@@ -77,8 +77,7 @@ Method chaining is supported:
 |---|---|---|---|
 | `color` | `str` or `None` | `None` | Surface color (uses colormap for scalar fields if `None`) |
 | `opacity` | `float` | `1.0` | Surface opacity |
-| `show_control_points` | `bool` | `False` | Render control points as spheres |
-| `show_control_polygon` | `bool` | `False` | Render wireframe connecting control points |
+| `show_control_polygon` | `bool` | `False` | Render control polygon (points and wireframe) |
 | `show_knot_lines` | `bool` | `False` | Render knot lines (B-splines only) |
 | `control_point_color` | `str` | `"red"` | Color of control point spheres |
 | `control_point_size` | `float` | `8.0` | Size of control point spheres |
@@ -113,21 +112,20 @@ scalar_field.plot()
 scalar_field.plot(elevation=True)
 ```
 
-## Control points and polygon
+## Control polygon
 
-Control points are rendered as small spheres at their physical locations.
-For rational (NURBS) geometries, the **projected Euclidean coordinates** are
-used (i.e. divided by the homogeneous weight).
+The control polygon shows both the control points (as small spheres) and the
+wireframe connecting adjacent control points along each parametric direction:
 
-The control polygon connects adjacent control points along each parametric
-direction:
-
-- **Curves**: a single polyline.
+- **Curves**: a single polyline through all control points.
 - **Surfaces**: a grid of lines along both parametric directions.
 - **Volumes**: edges of the 3D control point lattice.
 
+For rational (NURBS) geometries, the **projected Euclidean coordinates** are
+used (i.e. divided by the homogeneous weight).
+
 ```python
-curve.plot(show_control_points=True, show_control_polygon=True)
+curve.plot(show_control_polygon=True)
 ```
 
 ## Knot lines
@@ -151,7 +149,7 @@ For advanced use cases, convert geometries to pyvista objects and use the
 full pyvista API:
 
 ```python
-from pantr.viz import to_pyvista, control_points_mesh, control_polygon_mesh
+from pantr.viz import to_pyvista, control_polygon_mesh
 
 # Get an UnstructuredGrid with VTK Bezier cells
 grid = to_pyvista(surface)
@@ -159,8 +157,7 @@ grid = to_pyvista(surface)
 # Manipulate with pyvista
 grid.plot(show_edges=True, cmap="viridis")
 
-# Access control points as pyvista PolyData
-cp_mesh = control_points_mesh(surface)
+# Get the control polygon as pyvista PolyData (points + wireframe)
 poly_mesh = control_polygon_mesh(surface)
 ```
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,3 +28,9 @@ ignore_missing_imports = True
 
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-pyvista.*]
+ignore_missing_imports = True
+
+[mypy-vtkmodules.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,5 +38,10 @@ ignore_missing_imports = True
 [mypy-vtkmodules.*]
 ignore_missing_imports = True
 
+[mypy-pantr.viz]
+warn_unused_ignores = False
+warn_return_any = False
+
 [mypy-pantr.viz.*]
 warn_unused_ignores = False
+warn_return_any = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-vtkmodules.*]
 ignore_missing_imports = True
+
+[mypy-pantr.viz.*]
+warn_unused_ignores = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
   "ruff>=0.12.0,<0.13",
   "pre-commit>=3.6,<4",
 ]
+viz = [
+  "pyvista>=0.43,<1",
+]
 docs = [
   "sphinx>=7.2,<8",
   "sphinx-rtd-theme>=1.3,<2",

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -784,7 +784,7 @@ class Bezier:
     ) -> object:
         """Quick interactive visualization of this Bézier (requires pyvista).
 
-        For finer control, use :func:`pantr.viz.Scene` directly.
+        For finer control, use ``pantr.viz.Scene`` directly.
 
         Args:
             color: Surface color.

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -778,7 +778,6 @@ class Bezier:
         self,
         *,
         color: str | None = None,
-        show_control_points: bool = False,
         show_control_polygon: bool = False,
         **plotter_kwargs: Any,  # noqa: ANN401
     ) -> object:
@@ -788,8 +787,7 @@ class Bezier:
 
         Args:
             color: Surface color.
-            show_control_points: Render control points as spheres.
-            show_control_polygon: Render control polygon wireframe.
+            show_control_polygon: Render control polygon (points and wireframe).
             **plotter_kwargs: Additional keyword arguments for ``pv.Plotter()``.
 
         Returns:
@@ -803,7 +801,6 @@ class Bezier:
         return _plot(
             self,
             color=color,
-            show_control_points=show_control_points,
             show_control_polygon=show_control_polygon,
             **plotter_kwargs,
         )

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from numpy import typing as npt
@@ -769,3 +769,41 @@ class Bezier:
             raise ValueError("B-spline does not have Bézier-like knots. Cannot convert to Bézier.")
         cp = bspline.control_points.copy() if copy else bspline.control_points
         return cls(cp, is_rational=bspline.is_rational)
+
+    # ------------------------------------------------------------------
+    # Visualization
+    # ------------------------------------------------------------------
+
+    def plot(
+        self,
+        *,
+        color: str | None = None,
+        show_control_points: bool = False,
+        show_control_polygon: bool = False,
+        **plotter_kwargs: Any,  # noqa: ANN401
+    ) -> object:
+        """Quick interactive visualization of this Bézier (requires pyvista).
+
+        For finer control, use :func:`pantr.viz.Scene` directly.
+
+        Args:
+            color: Surface color.
+            show_control_points: Render control points as spheres.
+            show_control_polygon: Render control polygon wireframe.
+            **plotter_kwargs: Additional keyword arguments for ``pv.Plotter()``.
+
+        Returns:
+            object: The pyvista ``Plotter`` after showing.
+
+        Raises:
+            ImportError: If pyvista is not installed.
+        """
+        from ..viz import plot as _plot  # noqa: PLC0415
+
+        return _plot(
+            self,
+            color=color,
+            show_control_points=show_control_points,
+            show_control_polygon=show_control_polygon,
+            **plotter_kwargs,
+        )

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -1082,7 +1082,6 @@ class Bspline:
         self,
         *,
         color: str | None = None,
-        show_control_points: bool = False,
         show_control_polygon: bool = False,
         show_knot_lines: bool = False,
         **plotter_kwargs: Any,  # noqa: ANN401
@@ -1093,8 +1092,7 @@ class Bspline:
 
         Args:
             color: Surface color.
-            show_control_points: Render control points as spheres.
-            show_control_polygon: Render control polygon wireframe.
+            show_control_polygon: Render control polygon (points and wireframe).
             show_knot_lines: Render knot lines.
             **plotter_kwargs: Additional keyword arguments for ``pv.Plotter()``.
 
@@ -1109,7 +1107,6 @@ class Bspline:
         return _plot(
             self,
             color=color,
-            show_control_points=show_control_points,
             show_control_polygon=show_control_polygon,
             show_knot_lines=show_knot_lines,
             **plotter_kwargs,

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -1089,7 +1089,7 @@ class Bspline:
     ) -> object:
         """Quick interactive visualization of this B-spline (requires pyvista).
 
-        For finer control, use :func:`pantr.viz.Scene` directly.
+        For finer control, use ``pantr.viz.Scene`` directly.
 
         Args:
             color: Surface color.

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -9,7 +9,7 @@ is dispatched to the de Boor algorithm implemented in ``_bspline_eval``.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from numpy import typing as npt
@@ -1073,3 +1073,44 @@ class Bspline:
         domain = space_d.domain
         value = float(domain[0]) if side == 0 else float(domain[1])
         return self.slice(axis, value)
+
+    # ------------------------------------------------------------------
+    # Visualization
+    # ------------------------------------------------------------------
+
+    def plot(
+        self,
+        *,
+        color: str | None = None,
+        show_control_points: bool = False,
+        show_control_polygon: bool = False,
+        show_knot_lines: bool = False,
+        **plotter_kwargs: Any,  # noqa: ANN401
+    ) -> object:
+        """Quick interactive visualization of this B-spline (requires pyvista).
+
+        For finer control, use :func:`pantr.viz.Scene` directly.
+
+        Args:
+            color: Surface color.
+            show_control_points: Render control points as spheres.
+            show_control_polygon: Render control polygon wireframe.
+            show_knot_lines: Render knot lines.
+            **plotter_kwargs: Additional keyword arguments for ``pv.Plotter()``.
+
+        Returns:
+            object: The pyvista ``Plotter`` after showing.
+
+        Raises:
+            ImportError: If pyvista is not installed.
+        """
+        from ..viz import plot as _plot  # noqa: PLC0415
+
+        return _plot(
+            self,
+            color=color,
+            show_control_points=show_control_points,
+            show_control_polygon=show_control_polygon,
+            show_knot_lines=show_knot_lines,
+            **plotter_kwargs,
+        )

--- a/src/pantr/viz/__init__.py
+++ b/src/pantr/viz/__init__.py
@@ -1,0 +1,24 @@
+"""Optional visualization module for PaNTr using pyvista.
+
+Provides conversion of B-spline and Bézier geometries to pyvista
+``UnstructuredGrid`` objects with native VTK Bézier cell types, and
+export to VTK file formats for ParaView.
+
+This module requires ``pyvista`` (optional dependency). Install with::
+
+    pip install pantr[viz]
+
+Main exports:
+
+- :func:`to_pyvista`: Convert a geometry to a pyvista ``UnstructuredGrid``.
+- :func:`save`: Export a geometry to a VTK file.
+"""
+
+from __future__ import annotations
+
+from ._vtk_cells import save, to_pyvista
+
+__all__ = [
+    "save",
+    "to_pyvista",
+]

--- a/src/pantr/viz/__init__.py
+++ b/src/pantr/viz/__init__.py
@@ -14,21 +14,19 @@ Main exports:
 - :func:`save`: Export a geometry to a VTK file.
 - :func:`plot`: Quick interactive visualization of one or more geometries.
 - :class:`Scene`: Composable multi-geometry visualization scene.
-- :func:`control_points_mesh`: Point cloud of control points.
-- :func:`control_polygon_mesh`: Wireframe of the control polygon.
+- :func:`control_polygon_mesh`: Control polygon (points + wireframe).
 - :func:`knot_lines_meshes`: Knot line meshes for B-splines.
 """
 
 from __future__ import annotations
 
-from ._control_points import control_points_mesh, control_polygon_mesh
+from ._control_points import control_polygon_mesh
 from ._knot_lines import knot_lines_meshes
 from ._scene import Scene, plot
 from ._vtk_cells import save, to_pyvista
 
 __all__ = [
     "Scene",
-    "control_points_mesh",
     "control_polygon_mesh",
     "knot_lines_meshes",
     "plot",

--- a/src/pantr/viz/__init__.py
+++ b/src/pantr/viz/__init__.py
@@ -1,8 +1,8 @@
 """Optional visualization module for PaNTr using pyvista.
 
 Provides conversion of B-spline and Bézier geometries to pyvista
-``UnstructuredGrid`` objects with native VTK Bézier cell types, and
-export to VTK file formats for ParaView.
+``UnstructuredGrid`` objects with native VTK Bézier cell types, interactive
+visualization, and export to VTK file formats for ParaView.
 
 This module requires ``pyvista`` (optional dependency). Install with::
 
@@ -12,13 +12,26 @@ Main exports:
 
 - :func:`to_pyvista`: Convert a geometry to a pyvista ``UnstructuredGrid``.
 - :func:`save`: Export a geometry to a VTK file.
+- :func:`plot`: Quick interactive visualization of one or more geometries.
+- :class:`Scene`: Composable multi-geometry visualization scene.
+- :func:`control_points_mesh`: Point cloud of control points.
+- :func:`control_polygon_mesh`: Wireframe of the control polygon.
+- :func:`knot_lines_meshes`: Knot line meshes for B-splines.
 """
 
 from __future__ import annotations
 
+from ._control_points import control_points_mesh, control_polygon_mesh
+from ._knot_lines import knot_lines_meshes
+from ._scene import Scene, plot
 from ._vtk_cells import save, to_pyvista
 
 __all__ = [
+    "Scene",
+    "control_points_mesh",
+    "control_polygon_mesh",
+    "knot_lines_meshes",
+    "plot",
     "save",
     "to_pyvista",
 ]

--- a/src/pantr/viz/_control_points.py
+++ b/src/pantr/viz/_control_points.py
@@ -1,0 +1,193 @@
+"""Control point and control polygon visualization helpers.
+
+Provides functions to create pyvista meshes for:
+
+- **Control points**: a point cloud rendered as small spheres.
+- **Control polygon**: a wireframe connecting adjacent control points along
+  each parametric direction.
+
+Rational geometries always use projected (Euclidean) coordinates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy import typing as npt
+
+from ._lazy_import import _import_pyvista
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+    from ..bezier import Bezier
+    from ..bspline import Bspline
+
+_MAX_PHYSICAL_DIM = 3
+"""Maximum physical dimension for VTK coordinates."""
+
+
+def _get_euclidean_control_points(
+    geom: Bspline | Bezier,
+) -> tuple[npt.NDArray[np.float64], tuple[int, ...], int]:
+    """Extract Euclidean control points from a geometry, padding to 3D.
+
+    For rational geometries, projects to Euclidean space by dividing by
+    the homogeneous weight.
+
+    Args:
+        geom: Input B-spline or Bézier geometry.
+
+    Returns:
+        tuple: ``(points_3d, grid_shape, rank)`` where *points_3d* has shape
+        ``(n_pts, 3)``, *grid_shape* is the tensor-product shape
+        (e.g. ``(5,)`` for a curve with 5 CPs), and *rank* is the geometric
+        output rank.
+    """
+    cp = np.asarray(geom.control_points, dtype=np.float64)
+    grid_shape = cp.shape[:-1]
+    rank = geom.rank
+    n_pts = int(np.prod(grid_shape))
+    flat = cp.reshape(n_pts, -1)
+
+    if geom.is_rational:
+        weights = flat[:, -1:]
+        coords = flat[:, :-1] / weights
+    else:
+        coords = flat
+
+    pts_3d = np.zeros((n_pts, _MAX_PHYSICAL_DIM), dtype=np.float64)
+    pts_3d[:, :rank] = coords[:, :rank]
+    return pts_3d, grid_shape, rank
+
+
+def control_points_mesh(geom: Bspline | Bezier) -> pv.PolyData:
+    """Create a point cloud mesh of control points for visualization.
+
+    Control points are projected to Euclidean space for rational geometries
+    and padded to 3D.
+
+    Args:
+        geom: Input B-spline or Bézier geometry.
+
+    Returns:
+        pv.PolyData: Point cloud suitable for rendering as glyphs (spheres).
+
+    Raises:
+        ImportError: If pyvista is not installed.
+    """
+    pv = _import_pyvista()
+    pts_3d, _, _ = _get_euclidean_control_points(geom)
+    return pv.PolyData(pts_3d)  # type: ignore[no-any-return]
+
+
+def control_polygon_mesh(geom: Bspline | Bezier) -> pv.PolyData:
+    """Create a wireframe mesh of the control polygon.
+
+    Connects adjacent control points along each parametric direction:
+
+    - **dim=1**: a single polyline through all control points.
+    - **dim=2**: a grid of lines along both parametric directions.
+    - **dim=3**: edges of the 3D control point lattice along all three
+      parametric directions.
+
+    Args:
+        geom: Input B-spline or Bézier geometry.
+
+    Returns:
+        pv.PolyData: Wireframe mesh with line cells.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+    """
+    pv = _import_pyvista()
+    pts_3d, grid_shape, _ = _get_euclidean_control_points(geom)
+    dim = len(grid_shape)
+    lines = _build_polygon_lines(grid_shape, dim)
+
+    if not lines:
+        return pv.PolyData(pts_3d)  # type: ignore[no-any-return]
+
+    # pyvista line format: [n_pts_in_line, idx0, idx1, ..., n_pts_in_line, ...]
+    line_cells = np.concatenate(lines)
+    poly = pv.PolyData(pts_3d)
+    poly.lines = line_cells
+    return poly  # type: ignore[no-any-return]
+
+
+def _build_polygon_lines(
+    grid_shape: tuple[int, ...],
+    dim: int,
+) -> list[npt.NDArray[Any]]:
+    """Build line connectivity arrays for the control polygon.
+
+    For each parametric direction, creates polylines connecting control
+    points that are adjacent in that direction.
+
+    Args:
+        grid_shape: Tensor-product shape of the control point grid.
+        dim: Parametric dimension.
+
+    Returns:
+        list: Line cell arrays in pyvista format.
+    """
+    lines: list[npt.NDArray[Any]] = []
+    strides = _compute_strides(grid_shape)
+
+    for direction in range(dim):
+        n_along = grid_shape[direction]
+        if n_along < 2:  # noqa: PLR2004
+            continue
+        # Iterate over all "fibers" in this direction
+        for base_idx in np.ndindex(*_fiber_iteration_shape(grid_shape, direction)):
+            # Compute flat indices along this fiber
+            fiber_start = sum(base_idx[d] * strides[d] for d in range(dim) if d != direction)
+            fiber_indices = np.array(
+                [fiber_start + i * strides[direction] for i in range(n_along)],
+                dtype=np.intp,
+            )
+            # pyvista polyline: [n_pts, idx0, idx1, ...]
+            cell = np.empty(n_along + 1, dtype=np.intp)
+            cell[0] = n_along
+            cell[1:] = fiber_indices
+            lines.append(cell)
+
+    return lines
+
+
+def _compute_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    """Compute row-major strides for a given shape.
+
+    Args:
+        shape: Array shape.
+
+    Returns:
+        tuple[int, ...]: Strides (in elements, not bytes).
+    """
+    strides: list[int] = []
+    stride = 1
+    for s in reversed(shape):
+        strides.append(stride)
+        stride *= s
+    return tuple(reversed(strides))
+
+
+def _fiber_iteration_shape(
+    shape: tuple[int, ...],
+    direction: int,
+) -> tuple[int, ...]:
+    """Get the iteration shape for fibers along a given direction.
+
+    Returns a shape tuple with the given direction set to 1, suitable
+    for ``np.ndindex`` to iterate over all fibers perpendicular to
+    that direction.
+
+    Args:
+        shape: Full grid shape.
+        direction: Direction along which to iterate.
+
+    Returns:
+        tuple[int, ...]: Modified shape with ``shape[direction] = 1``.
+    """
+    return tuple(1 if d == direction else s for d, s in enumerate(shape))

--- a/src/pantr/viz/_control_points.py
+++ b/src/pantr/viz/_control_points.py
@@ -1,10 +1,8 @@
-"""Control point and control polygon visualization helpers.
+"""Control polygon visualization helpers.
 
-Provides functions to create pyvista meshes for:
-
-- **Control points**: a point cloud rendered as small spheres.
-- **Control polygon**: a wireframe connecting adjacent control points along
-  each parametric direction.
+Provides a function to create the control polygon mesh: a wireframe connecting
+adjacent control points along each parametric direction, with the control
+points themselves included as vertices.
 
 Rational geometries always use projected (Euclidean) coordinates.
 """
@@ -62,41 +60,25 @@ def _get_euclidean_control_points(
     return pts_3d, grid_shape, rank
 
 
-def control_points_mesh(geom: Bspline | Bezier) -> pv.PolyData:
-    """Create a point cloud mesh of control points for visualization.
-
-    Control points are projected to Euclidean space for rational geometries
-    and padded to 3D.
-
-    Args:
-        geom: Input B-spline or Bézier geometry.
-
-    Returns:
-        pv.PolyData: Point cloud suitable for rendering as glyphs (spheres).
-
-    Raises:
-        ImportError: If pyvista is not installed.
-    """
-    pv = _import_pyvista()
-    pts_3d, _, _ = _get_euclidean_control_points(geom)
-    return pv.PolyData(pts_3d)  # type: ignore[no-any-return]
-
-
 def control_polygon_mesh(geom: Bspline | Bezier) -> pv.PolyData:
-    """Create a wireframe mesh of the control polygon.
+    """Create the control polygon mesh with points and connecting wireframe.
 
-    Connects adjacent control points along each parametric direction:
+    The mesh contains the control points as vertices and polylines connecting
+    adjacent control points along each parametric direction:
 
     - **dim=1**: a single polyline through all control points.
     - **dim=2**: a grid of lines along both parametric directions.
     - **dim=3**: edges of the 3D control point lattice along all three
       parametric directions.
 
+    Rational geometries use projected (Euclidean) coordinates.
+
     Args:
         geom: Input B-spline or Bézier geometry.
 
     Returns:
-        pv.PolyData: Wireframe mesh with line cells.
+        pv.PolyData: Mesh with control points as vertices and line cells
+        forming the polygon wireframe.
 
     Raises:
         ImportError: If pyvista is not installed.
@@ -109,7 +91,6 @@ def control_polygon_mesh(geom: Bspline | Bezier) -> pv.PolyData:
     if not lines:
         return pv.PolyData(pts_3d)  # type: ignore[no-any-return]
 
-    # pyvista line format: [n_pts_in_line, idx0, idx1, ..., n_pts_in_line, ...]
     line_cells = np.concatenate(lines)
     poly = pv.PolyData(pts_3d)
     poly.lines = line_cells

--- a/src/pantr/viz/_knot_lines.py
+++ b/src/pantr/viz/_knot_lines.py
@@ -1,0 +1,169 @@
+"""Knot line visualization for B-spline geometries.
+
+Knot lines are the images of iso-parametric lines at interior knot values:
+
+- **dim=1 (curves)**: knot *points* — evaluate the curve at each interior knot.
+- **dim=2 (surfaces)**: knot *curves* — slice the surface at each interior knot
+  in each direction, yielding iso-parametric curves.
+- **dim=3 (volumes)**: knot *surfaces* — slice the volume at each interior knot
+  in each direction, yielding iso-parametric surfaces.
+
+Each lower-dimensional slice is converted to a pyvista mesh via
+:func:`~pantr.viz.to_pyvista`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy import typing as npt
+
+from ._lazy_import import _import_pyvista
+from ._vtk_cells import to_pyvista
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+    from ..bspline import Bspline
+
+_MAX_PHYSICAL_DIM = 3
+"""Maximum physical dimension for VTK coordinates."""
+
+
+def _get_interior_knots(
+    bspline: Bspline,
+) -> list[npt.NDArray[np.float32 | np.float64]]:
+    """Get unique interior knot values for each parametric direction.
+
+    Args:
+        bspline: Input B-spline geometry.
+
+    Returns:
+        list: One array per direction containing interior (non-boundary)
+        unique knot values.
+    """
+    interior_knots: list[npt.NDArray[np.float32 | np.float64]] = []
+    for d in range(bspline.dim):
+        sp1d = bspline.space.spaces[d]
+        unique_knots, _ = sp1d.get_unique_knots_and_multiplicity(in_domain=True)
+        # Exclude boundary knots (first and last)
+        n_boundary = 2
+        if len(unique_knots) > n_boundary:
+            interior_knots.append(unique_knots[1:-1])
+        else:
+            interior_knots.append(np.array([], dtype=unique_knots.dtype))
+    return interior_knots
+
+
+def _knot_points_curve(bspline: Bspline) -> pv.PolyData:
+    """Compute knot points for a 1D B-spline curve.
+
+    Evaluates the curve at each interior knot value and returns
+    a point cloud.
+
+    Args:
+        bspline: A 1D B-spline curve.
+
+    Returns:
+        pv.PolyData: Point cloud of knot locations on the curve.
+    """
+    pv = _import_pyvista()
+    interior_knots = _get_interior_knots(bspline)
+    knot_vals = interior_knots[0]
+
+    if len(knot_vals) == 0:
+        return pv.PolyData()  # type: ignore[no-any-return]
+
+    # Evaluate curve at knot values (1D points are flat arrays)
+    pts_param = knot_vals.astype(np.float64)
+    pts_phys = bspline.evaluate(pts_param)
+
+    # evaluate() returns (rank,) for a single point, (n, rank) for multiple
+    if pts_phys.ndim == 1:
+        pts_phys = pts_phys.reshape(1, -1)
+
+    rank = bspline.rank
+    n_pts = len(knot_vals)
+    pts_3d = np.zeros((n_pts, _MAX_PHYSICAL_DIM), dtype=np.float64)
+    pts_3d[:, :rank] = pts_phys[:, :rank]
+    return pv.PolyData(pts_3d)  # type: ignore[no-any-return]
+
+
+def _knot_lines_surface(bspline: Bspline) -> list[pv.UnstructuredGrid]:
+    """Compute knot lines for a 2D B-spline surface.
+
+    Slices the surface at each interior knot in each direction, producing
+    iso-parametric curves that are converted to VTK Bézier curve cells.
+
+    Args:
+        bspline: A 2D B-spline surface.
+
+    Returns:
+        list[pv.UnstructuredGrid]: One grid per knot line (iso-curve).
+    """
+    interior_knots = _get_interior_knots(bspline)
+    grids: list[pv.UnstructuredGrid] = []
+
+    n_directions = 2
+    for direction in range(n_directions):
+        for knot_val in interior_knots[direction]:
+            curve = bspline.slice(direction, float(knot_val))
+            grids.append(to_pyvista(curve))  # type: ignore[arg-type]
+
+    return grids
+
+
+def _knot_surfaces_volume(bspline: Bspline) -> list[pv.UnstructuredGrid]:
+    """Compute knot surfaces for a 3D B-spline volume.
+
+    Slices the volume at each interior knot in each direction, producing
+    iso-parametric surfaces that are converted to VTK Bézier quad cells.
+
+    Args:
+        bspline: A 3D B-spline volume.
+
+    Returns:
+        list[pv.UnstructuredGrid]: One grid per knot surface.
+    """
+    interior_knots = _get_interior_knots(bspline)
+    grids: list[pv.UnstructuredGrid] = []
+
+    for direction in range(_MAX_PHYSICAL_DIM):
+        for knot_val in interior_knots[direction]:
+            surface = bspline.slice(direction, float(knot_val))
+            grids.append(to_pyvista(surface))  # type: ignore[arg-type]
+
+    return grids
+
+
+def knot_lines_meshes(bspline: Bspline) -> list[pv.PolyData | pv.UnstructuredGrid]:
+    """Compute knot line meshes for a B-spline geometry.
+
+    Returns one mesh per knot line (or point, or surface) depending on the
+    parametric dimension:
+
+    - **dim=1**: single ``PolyData`` point cloud of knot locations.
+    - **dim=2**: list of ``UnstructuredGrid`` iso-parametric curves.
+    - **dim=3**: list of ``UnstructuredGrid`` iso-parametric surfaces.
+
+    Args:
+        bspline: Input B-spline geometry (dim 1, 2, or 3).
+
+    Returns:
+        list[pv.PolyData | pv.UnstructuredGrid]: Knot line meshes.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+        ValueError: If the parametric dimension is not 1, 2, or 3.
+    """
+    _import_pyvista()  # ensure pyvista is available
+
+    dim = bspline.dim
+    if dim == 1:
+        return [_knot_points_curve(bspline)]
+    if dim == 2:  # noqa: PLR2004
+        return list(_knot_lines_surface(bspline))
+    if dim == _MAX_PHYSICAL_DIM:
+        return list(_knot_surfaces_volume(bspline))
+    raise ValueError(f"Unsupported parametric dimension {dim}.")

--- a/src/pantr/viz/_lazy_import.py
+++ b/src/pantr/viz/_lazy_import.py
@@ -20,4 +20,4 @@ def _import_pyvista() -> ModuleType:
         raise ImportError(
             "pyvista is required for visualization. Install it with: pip install pantr[viz]"
         ) from None
-    return pv
+    return pv  # type: ignore[return-value]

--- a/src/pantr/viz/_lazy_import.py
+++ b/src/pantr/viz/_lazy_import.py
@@ -20,4 +20,4 @@ def _import_pyvista() -> ModuleType:
         raise ImportError(
             "pyvista is required for visualization. Install it with: pip install pantr[viz]"
         ) from None
-    return pv  # type: ignore[return-value]
+    return pv  # type: ignore[return-value,no-any-return]

--- a/src/pantr/viz/_lazy_import.py
+++ b/src/pantr/viz/_lazy_import.py
@@ -1,0 +1,23 @@
+"""Lazy import helper for optional pyvista dependency."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def _import_pyvista() -> ModuleType:
+    """Import and return the pyvista module, raising a clear error if absent.
+
+    Returns:
+        ModuleType: The ``pyvista`` module.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+    """
+    try:
+        import pyvista as pv  # noqa: PLC0415
+    except ImportError:
+        raise ImportError(
+            "pyvista is required for visualization. Install it with: pip install pantr[viz]"
+        ) from None
+    return pv

--- a/src/pantr/viz/_scene.py
+++ b/src/pantr/viz/_scene.py
@@ -3,7 +3,7 @@
 Provides:
 
 - :class:`Scene`: a builder for adding multiple geometries with per-geometry
-  rendering options (color, opacity, control points, knot lines).
+  rendering options (color, opacity, control polygon, knot lines).
 - :func:`plot`: a convenience function for quick visualization of one or
   more geometries.
 """
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ._control_points import control_points_mesh, control_polygon_mesh
+from ._control_points import control_polygon_mesh
 from ._knot_lines import knot_lines_meshes
 from ._lazy_import import _import_pyvista
 from ._vtk_cells import to_pyvista
@@ -40,7 +40,6 @@ class _GeometryEntry:
         *,
         color: str | None = None,
         opacity: float = 1.0,
-        show_control_points: bool = False,
         show_control_polygon: bool = False,
         show_knot_lines: bool = False,
         control_point_color: str = _DEFAULT_CP_COLOR,
@@ -59,10 +58,9 @@ class _GeometryEntry:
             color: Surface color. ``None`` uses the default colormap for
                 scalar fields or pyvista's default for geometric objects.
             opacity: Surface opacity (0.0 to 1.0).
-            show_control_points: Render control points as spheres.
-            show_control_polygon: Render wireframe connecting control points.
+            show_control_polygon: Render control polygon (points and wireframe).
             show_knot_lines: Render knot lines (B-splines only).
-            control_point_color: Color for control point spheres.
+            control_point_color: Color for control points and polygon wireframe.
             control_point_size: Point size for control points.
             control_polygon_color: Color for control polygon wireframe.
             knot_line_color: Color for knot lines.
@@ -74,7 +72,6 @@ class _GeometryEntry:
         self.geom = geom
         self.color = color
         self.opacity = opacity
-        self.show_control_points = show_control_points
         self.show_control_polygon = show_control_polygon
         self.show_knot_lines = show_knot_lines
         self.control_point_color = control_point_color
@@ -96,7 +93,7 @@ class Scene:
     Example:
         >>> scene = Scene()
         >>> scene.add(surface, color="blue", show_knot_lines=True)
-        >>> scene.add(curve, color="red", show_control_points=True)
+        >>> scene.add(curve, color="red", show_control_polygon=True)
         >>> scene.show()
     """
 
@@ -110,7 +107,6 @@ class Scene:
         *,
         color: str | None = None,
         opacity: float = 1.0,
-        show_control_points: bool = False,
         show_control_polygon: bool = False,
         show_knot_lines: bool = False,
         control_point_color: str = _DEFAULT_CP_COLOR,
@@ -129,10 +125,9 @@ class Scene:
             color: Surface color. ``None`` uses the default colormap for
                 scalar fields or pyvista's default for geometric objects.
             opacity: Surface opacity (0.0 to 1.0).
-            show_control_points: Render control points as spheres.
-            show_control_polygon: Render wireframe connecting control points.
+            show_control_polygon: Render control polygon (points and wireframe).
             show_knot_lines: Render knot lines (B-splines only).
-            control_point_color: Color for control point spheres.
+            control_point_color: Color for control points and polygon wireframe.
             control_point_size: Point size for control points.
             control_polygon_color: Color for control polygon wireframe.
             knot_line_color: Color for knot lines.
@@ -149,7 +144,6 @@ class Scene:
                 geom,
                 color=color,
                 opacity=opacity,
-                show_control_points=show_control_points,
                 show_control_polygon=show_control_polygon,
                 show_knot_lines=show_knot_lines,
                 control_point_color=control_point_color,
@@ -230,23 +224,14 @@ def _add_entry_to_plotter(plotter: pv.Plotter, entry: _GeometryEntry) -> None:
 
     plotter.add_mesh(grid, **mesh_kwargs)
 
-    # Control points
-    if entry.show_control_points:
-        cp_mesh = control_points_mesh(entry.geom)
-        plotter.add_mesh(
-            cp_mesh,
-            color=entry.control_point_color,
-            point_size=entry.control_point_size,
-            render_points_as_spheres=True,
-        )
-
-    # Control polygon
+    # Control polygon (points + wireframe)
     if entry.show_control_polygon:
         poly_mesh = control_polygon_mesh(entry.geom)
         plotter.add_mesh(
             poly_mesh,
-            color=entry.control_polygon_color,
-            style="wireframe",
+            color=entry.control_point_color,
+            point_size=entry.control_point_size,
+            render_points_as_spheres=True,
             line_width=entry.knot_line_width,
         )
 
@@ -266,7 +251,6 @@ def plot(  # noqa: PLR0913
     *geoms: Bspline | Bezier,
     color: str | None = None,
     opacity: float = 1.0,
-    show_control_points: bool = False,
     show_control_polygon: bool = False,
     show_knot_lines: bool = False,
     scalar_name: str = "scalar",
@@ -286,8 +270,7 @@ def plot(  # noqa: PLR0913
         *geoms: One or more B-spline or Bézier geometries.
         color: Surface color for all geometries.
         opacity: Surface opacity for all geometries.
-        show_control_points: Render control points as spheres.
-        show_control_polygon: Render control polygon wireframe.
+        show_control_polygon: Render control polygon (points and wireframe).
         show_knot_lines: Render knot lines (B-splines only).
         scalar_name: Name for scalar point data.
         scalar_bar: Show scalar bar for scalar fields.
@@ -306,7 +289,6 @@ def plot(  # noqa: PLR0913
             geom,
             color=color,
             opacity=opacity,
-            show_control_points=show_control_points,
             show_control_polygon=show_control_polygon,
             show_knot_lines=show_knot_lines,
             scalar_name=scalar_name,

--- a/src/pantr/viz/_scene.py
+++ b/src/pantr/viz/_scene.py
@@ -1,0 +1,316 @@
+"""Composable visualization scene for multiple geometries.
+
+Provides:
+
+- :class:`Scene`: a builder for adding multiple geometries with per-geometry
+  rendering options (color, opacity, control points, knot lines).
+- :func:`plot`: a convenience function for quick visualization of one or
+  more geometries.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ._control_points import control_points_mesh, control_polygon_mesh
+from ._knot_lines import knot_lines_meshes
+from ._lazy_import import _import_pyvista
+from ._vtk_cells import to_pyvista
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+    from ..bezier import Bezier
+    from ..bspline import Bspline
+
+
+_DEFAULT_CP_COLOR = "red"
+_DEFAULT_CP_SIZE = 8.0
+_DEFAULT_POLYGON_COLOR = "gray"
+_DEFAULT_KNOT_COLOR = "black"
+_DEFAULT_KNOT_WIDTH = 2.0
+
+
+class _GeometryEntry:
+    """Internal record of a geometry added to a Scene."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        geom: Bspline | Bezier,
+        *,
+        color: str | None = None,
+        opacity: float = 1.0,
+        show_control_points: bool = False,
+        show_control_polygon: bool = False,
+        show_knot_lines: bool = False,
+        control_point_color: str = _DEFAULT_CP_COLOR,
+        control_point_size: float = _DEFAULT_CP_SIZE,
+        control_polygon_color: str = _DEFAULT_POLYGON_COLOR,
+        knot_line_color: str = _DEFAULT_KNOT_COLOR,
+        knot_line_width: float = _DEFAULT_KNOT_WIDTH,
+        scalar_name: str = "scalar",
+        scalar_bar: bool = True,
+        elevation: bool = False,
+    ) -> None:
+        """Initialize a geometry entry.
+
+        Args:
+            geom: The geometry to visualize.
+            color: Surface color. ``None`` uses the default colormap for
+                scalar fields or pyvista's default for geometric objects.
+            opacity: Surface opacity (0.0 to 1.0).
+            show_control_points: Render control points as spheres.
+            show_control_polygon: Render wireframe connecting control points.
+            show_knot_lines: Render knot lines (B-splines only).
+            control_point_color: Color for control point spheres.
+            control_point_size: Point size for control points.
+            control_polygon_color: Color for control polygon wireframe.
+            knot_line_color: Color for knot lines.
+            knot_line_width: Line width for knot lines.
+            scalar_name: Name for scalar point data.
+            scalar_bar: Show scalar bar for scalar fields.
+            elevation: Use scalar as elevation coordinate.
+        """
+        self.geom = geom
+        self.color = color
+        self.opacity = opacity
+        self.show_control_points = show_control_points
+        self.show_control_polygon = show_control_polygon
+        self.show_knot_lines = show_knot_lines
+        self.control_point_color = control_point_color
+        self.control_point_size = control_point_size
+        self.control_polygon_color = control_polygon_color
+        self.knot_line_color = knot_line_color
+        self.knot_line_width = knot_line_width
+        self.scalar_name = scalar_name
+        self.scalar_bar = scalar_bar
+        self.elevation = elevation
+
+
+class Scene:
+    """Composable multi-geometry visualization scene.
+
+    Add geometries with :meth:`add`, then render with :meth:`show` or
+    create a plotter with :meth:`to_plotter`.
+
+    Example:
+        >>> scene = Scene()
+        >>> scene.add(surface, color="blue", show_knot_lines=True)
+        >>> scene.add(curve, color="red", show_control_points=True)
+        >>> scene.show()
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty scene."""
+        self._entries: list[_GeometryEntry] = []
+
+    def add(  # noqa: PLR0913
+        self,
+        geom: Bspline | Bezier,
+        *,
+        color: str | None = None,
+        opacity: float = 1.0,
+        show_control_points: bool = False,
+        show_control_polygon: bool = False,
+        show_knot_lines: bool = False,
+        control_point_color: str = _DEFAULT_CP_COLOR,
+        control_point_size: float = _DEFAULT_CP_SIZE,
+        control_polygon_color: str = _DEFAULT_POLYGON_COLOR,
+        knot_line_color: str = _DEFAULT_KNOT_COLOR,
+        knot_line_width: float = _DEFAULT_KNOT_WIDTH,
+        scalar_name: str = "scalar",
+        scalar_bar: bool = True,
+        elevation: bool = False,
+    ) -> Scene:
+        """Add a geometry to the scene.
+
+        Args:
+            geom: B-spline or Bézier geometry to add.
+            color: Surface color. ``None`` uses the default colormap for
+                scalar fields or pyvista's default for geometric objects.
+            opacity: Surface opacity (0.0 to 1.0).
+            show_control_points: Render control points as spheres.
+            show_control_polygon: Render wireframe connecting control points.
+            show_knot_lines: Render knot lines (B-splines only).
+            control_point_color: Color for control point spheres.
+            control_point_size: Point size for control points.
+            control_polygon_color: Color for control polygon wireframe.
+            knot_line_color: Color for knot lines.
+            knot_line_width: Line width for knot lines.
+            scalar_name: Name for scalar point data.
+            scalar_bar: Show scalar bar for scalar fields.
+            elevation: Use scalar as elevation coordinate.
+
+        Returns:
+            Scene: Self, for method chaining.
+        """
+        self._entries.append(
+            _GeometryEntry(
+                geom,
+                color=color,
+                opacity=opacity,
+                show_control_points=show_control_points,
+                show_control_polygon=show_control_polygon,
+                show_knot_lines=show_knot_lines,
+                control_point_color=control_point_color,
+                control_point_size=control_point_size,
+                control_polygon_color=control_polygon_color,
+                knot_line_color=knot_line_color,
+                knot_line_width=knot_line_width,
+                scalar_name=scalar_name,
+                scalar_bar=scalar_bar,
+                elevation=elevation,
+            )
+        )
+        return self
+
+    def to_plotter(self, **plotter_kwargs: object) -> pv.Plotter:
+        """Create a pyvista Plotter with all geometries added.
+
+        Args:
+            **plotter_kwargs: Keyword arguments passed to
+                ``pv.Plotter()``.
+
+        Returns:
+            pv.Plotter: A configured plotter (not yet shown).
+
+        Raises:
+            ImportError: If pyvista is not installed.
+        """
+        pv = _import_pyvista()
+        plotter = pv.Plotter(**plotter_kwargs)
+
+        for entry in self._entries:
+            _add_entry_to_plotter(plotter, entry)
+
+        return plotter  # type: ignore[no-any-return]
+
+    def show(self, **plotter_kwargs: object) -> pv.Plotter:
+        """Render the scene interactively.
+
+        Args:
+            **plotter_kwargs: Keyword arguments passed to
+                ``pv.Plotter()``.
+
+        Returns:
+            pv.Plotter: The plotter after showing.
+
+        Raises:
+            ImportError: If pyvista is not installed.
+        """
+        plotter = self.to_plotter(**plotter_kwargs)
+        plotter.show()
+        return plotter
+
+
+def _add_entry_to_plotter(plotter: pv.Plotter, entry: _GeometryEntry) -> None:
+    """Add a single geometry entry to a pyvista plotter.
+
+    Args:
+        plotter: Target pyvista plotter.
+        entry: Geometry entry with rendering options.
+    """
+    from ..bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    grid = to_pyvista(
+        entry.geom,
+        scalar_name=entry.scalar_name,
+        elevation=entry.elevation,
+    )
+
+    # Determine mesh_kwargs for the main geometry
+    mesh_kwargs: dict[str, Any] = {
+        "opacity": entry.opacity,
+    }
+    if entry.color is not None:
+        mesh_kwargs["color"] = entry.color
+    elif entry.scalar_name in grid.point_data:
+        mesh_kwargs["scalars"] = entry.scalar_name
+        mesh_kwargs["show_scalar_bar"] = entry.scalar_bar
+
+    plotter.add_mesh(grid, **mesh_kwargs)
+
+    # Control points
+    if entry.show_control_points:
+        cp_mesh = control_points_mesh(entry.geom)
+        plotter.add_mesh(
+            cp_mesh,
+            color=entry.control_point_color,
+            point_size=entry.control_point_size,
+            render_points_as_spheres=True,
+        )
+
+    # Control polygon
+    if entry.show_control_polygon:
+        poly_mesh = control_polygon_mesh(entry.geom)
+        plotter.add_mesh(
+            poly_mesh,
+            color=entry.control_polygon_color,
+            style="wireframe",
+            line_width=entry.knot_line_width,
+        )
+
+    # Knot lines
+    if entry.show_knot_lines and isinstance(entry.geom, BsplineCls):
+        for kl_mesh in knot_lines_meshes(entry.geom):
+            plotter.add_mesh(
+                kl_mesh,
+                color=entry.knot_line_color,
+                line_width=entry.knot_line_width,
+                render_points_as_spheres=True,
+                point_size=entry.control_point_size * 0.5,
+            )
+
+
+def plot(  # noqa: PLR0913
+    *geoms: Bspline | Bezier,
+    color: str | None = None,
+    opacity: float = 1.0,
+    show_control_points: bool = False,
+    show_control_polygon: bool = False,
+    show_knot_lines: bool = False,
+    scalar_name: str = "scalar",
+    scalar_bar: bool = True,
+    elevation: bool = False,
+    **plotter_kwargs: object,
+) -> pv.Plotter:
+    """Quick visualization of one or more geometries.
+
+    Creates a :class:`Scene`, adds all geometries with the same rendering
+    options, and shows the result interactively.
+
+    For finer control (per-geometry colors, mixing different options), use
+    :class:`Scene` directly.
+
+    Args:
+        *geoms: One or more B-spline or Bézier geometries.
+        color: Surface color for all geometries.
+        opacity: Surface opacity for all geometries.
+        show_control_points: Render control points as spheres.
+        show_control_polygon: Render control polygon wireframe.
+        show_knot_lines: Render knot lines (B-splines only).
+        scalar_name: Name for scalar point data.
+        scalar_bar: Show scalar bar for scalar fields.
+        elevation: Use scalar as elevation coordinate.
+        **plotter_kwargs: Additional keyword arguments for ``pv.Plotter()``.
+
+    Returns:
+        pv.Plotter: The plotter after showing.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+    """
+    scene = Scene()
+    for geom in geoms:
+        scene.add(
+            geom,
+            color=color,
+            opacity=opacity,
+            show_control_points=show_control_points,
+            show_control_polygon=show_control_polygon,
+            show_knot_lines=show_knot_lines,
+            scalar_name=scalar_name,
+            scalar_bar=scalar_bar,
+            elevation=elevation,
+        )
+    return scene.show(**plotter_kwargs)

--- a/src/pantr/viz/_vtk_cells.py
+++ b/src/pantr/viz/_vtk_cells.py
@@ -1,0 +1,383 @@
+"""Convert Bézier and B-spline objects to pyvista UnstructuredGrids.
+
+Implements the core pipeline:
+``Bspline/Bezier → open form → Bézier decomposition → VTK Bézier cells``
+
+Uses native VTK higher-order Bézier cell types (``VTK_BEZIER_CURVE``,
+``VTK_BEZIER_QUADRILATERAL``, ``VTK_BEZIER_HEXAHEDRON``) which render exact
+polynomial geometry without tessellation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy import typing as npt
+
+from ._lazy_import import _import_pyvista
+from ._vtk_ordering import vtk_ordering
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+    from ..bezier import Bezier
+    from ..bspline import Bspline
+
+# VTK cell type constants for Bézier cells.
+VTK_BEZIER_CURVE = 75
+VTK_BEZIER_QUADRILATERAL = 77
+VTK_BEZIER_HEXAHEDRON = 79
+
+_VTK_CELL_TYPE_BY_DIM = {
+    1: VTK_BEZIER_CURVE,
+    2: VTK_BEZIER_QUADRILATERAL,
+    3: VTK_BEZIER_HEXAHEDRON,
+}
+
+_MAX_PHYSICAL_DIM = 3
+"""Maximum physical dimension for VTK coordinates."""
+
+
+def _get_bezier_patches(
+    geom: Bspline | Bezier,
+) -> tuple[npt.NDArray[np.object_], bool]:
+    """Extract Bézier patches from a geometry object.
+
+    For a ``Bspline``, converts to open form if needed and decomposes into
+    Bézier patches.  For a ``Bezier``, wraps it in an object array.
+
+    Args:
+        geom: Input geometry (Bspline or Bezier).
+
+    Returns:
+        tuple: ``(patches, is_rational)`` where *patches* is an object array
+        of :class:`~pantr.bezier.Bezier` objects and *is_rational* is a bool.
+    """
+    from ..bezier import Bezier as BezierCls  # noqa: PLC0415
+    from ..bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    if isinstance(geom, BsplineCls):
+        patches = geom.to_beziers()
+        return patches, geom.is_rational
+    if isinstance(geom, BezierCls):
+        arr = np.empty((1,) * geom.dim, dtype=object)
+        arr.flat[0] = geom
+        return arr, geom.is_rational
+    raise TypeError(f"Expected Bspline or Bezier, got {type(geom).__name__}")
+
+
+@dataclass
+class _PatchGeometry:
+    """Intermediate representation of a single Bézier patch for VTK assembly."""
+
+    points_3d: npt.NDArray[np.float64]
+    """Control points in 3D VTK ordering, shape ``(n_pts, 3)``."""
+
+    weights: npt.NDArray[np.float64] | None
+    """Rational weights in VTK ordering, shape ``(n_pts,)``, or ``None``."""
+
+    scalars: npt.NDArray[np.float64] | None
+    """Scalar values in VTK ordering, shape ``(n_pts,)``, or ``None``."""
+
+
+def _flatten_and_project(
+    cp: npt.NDArray[np.floating[Any]],
+    is_rational: bool,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64] | None]:
+    """Flatten control points and project rational ones to Euclidean space.
+
+    Args:
+        cp: Control points with shape ``(*degrees_plus_1, rank_or_rank_plus_1)``.
+        is_rational: Whether the last coordinate is a homogeneous weight.
+
+    Returns:
+        tuple: ``(coords, weights)`` where *coords* has shape ``(n_pts, rank)``
+        and *weights* is ``(n_pts,)`` or ``None``.
+    """
+    n_pts = int(np.prod(cp.shape[:-1]))
+    flat_cp = cp.reshape(n_pts, -1).astype(np.float64)
+
+    if is_rational:
+        weights = flat_cp[:, -1].copy()
+        coords = flat_cp[:, :-1] / weights[:, np.newaxis]
+        return coords, weights
+    return flat_cp, None
+
+
+def _embed_scalar_field(
+    scalar_vals: npt.NDArray[np.float64],
+    parametric_coords: npt.NDArray[np.float64],
+    dim: int,
+    elevation: bool,
+) -> npt.NDArray[np.float64]:
+    """Embed a scalar field in 3D space for VTK rendering.
+
+    Args:
+        scalar_vals: Scalar values, shape ``(n_pts,)``.
+        parametric_coords: Flat parametric coordinates, shape ``(n_pts, dim)``.
+        dim: Parametric dimension.
+        elevation: Use scalar as a spatial coordinate.
+
+    Returns:
+        NDArray[float64]: Points in 3D, shape ``(n_pts, 3)``.
+    """
+    n_pts = len(scalar_vals)
+    pts_3d = np.zeros((n_pts, _MAX_PHYSICAL_DIM), dtype=np.float64)
+
+    if elevation:
+        # dim=1: (t, f(t), 0);  dim=2: (u, v, f(u,v))
+        pts_3d[:, :dim] = parametric_coords
+        pts_3d[:, min(dim, _MAX_PHYSICAL_DIM - 1)] = scalar_vals
+    else:
+        pts_3d[:, :dim] = parametric_coords
+    return pts_3d
+
+
+def _build_parametric_greville_coords(
+    geom: Bspline | Bezier,
+    bezier_index: tuple[int, ...],
+) -> npt.NDArray[np.float64]:
+    """Build parametric coordinates for control points of a Bézier patch.
+
+    For each parametric direction, creates uniformly spaced points within
+    the knot span corresponding to this Bézier patch.
+
+    Args:
+        geom: The parent geometry (Bspline or Bezier).
+        bezier_index: Multi-index of this Bézier patch within the decomposition.
+
+    Returns:
+        NDArray[float64]: Array of shape ``(n_pts, dim)`` with parametric
+        coordinates for each control point (already flattened).
+    """
+    from ..bezier import Bezier as BezierCls  # noqa: PLC0415
+    from ..bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    if isinstance(geom, BezierCls):
+        dim = geom.dim
+        degree = geom.degree
+        grids_1d = [np.linspace(0.0, 1.0, degree[d] + 1) for d in range(dim)]
+    else:
+        assert isinstance(geom, BsplineCls)
+        dim = geom.dim
+        space = geom.space
+        degree = geom.degree
+        grids_1d = []
+        for d in range(dim):
+            sp1d = space.spaces[d]
+            unique_knots, _ = sp1d.get_unique_knots_and_multiplicity(in_domain=True)
+            t0 = float(unique_knots[bezier_index[d]])
+            t1 = float(unique_knots[bezier_index[d] + 1])
+            grids_1d.append(np.linspace(t0, t1, degree[d] + 1))
+
+    mesh = np.meshgrid(*grids_1d, indexing="ij")
+    coords = np.stack(mesh, axis=-1)
+    n_pts = int(np.prod(coords.shape[:-1]))
+    result: npt.NDArray[np.float64] = coords.reshape(n_pts, -1).astype(np.float64)
+    return result
+
+
+def _process_patch(  # noqa: PLR0913
+    bezier: Bezier,
+    geom: Bspline | Bezier,
+    bezier_index: tuple[int, ...],
+    is_rational: bool,
+    rank: int,
+    dim: int,
+    elevation: bool,
+    ordering: npt.NDArray[np.intp],
+) -> _PatchGeometry:
+    """Convert a single Bézier patch to VTK-ordered 3D geometry.
+
+    Args:
+        bezier: The Bézier patch to convert.
+        geom: The parent geometry (for parametric coordinate computation).
+        bezier_index: Multi-index of the patch within the decomposition.
+        is_rational: Whether the geometry is rational.
+        rank: Output rank (excluding weight).
+        dim: Parametric dimension.
+        elevation: Use scalar value as spatial coordinate.
+        ordering: VTK point ordering permutation.
+
+    Returns:
+        _PatchGeometry: Processed patch with 3D points, weights, and scalars.
+    """
+    cp = bezier.control_points
+    coords, weights = _flatten_and_project(cp, is_rational)
+    scalars: npt.NDArray[np.float64] | None = None
+
+    if rank == 1:
+        scalar_vals = coords[:, 0].copy()
+        param_coords = _build_parametric_greville_coords(geom, bezier_index)
+        pts_3d = _embed_scalar_field(scalar_vals, param_coords, dim, elevation)
+        scalars = scalar_vals[ordering]
+    else:
+        n_pts = coords.shape[0]
+        pts_3d = np.zeros((n_pts, _MAX_PHYSICAL_DIM), dtype=np.float64)
+        pts_3d[:, :rank] = coords
+
+    return _PatchGeometry(
+        points_3d=pts_3d[ordering],
+        weights=weights[ordering] if weights is not None else None,
+        scalars=scalars,
+    )
+
+
+def to_pyvista(
+    geom: Bspline | Bezier,
+    *,
+    scalar_name: str = "scalar",
+    elevation: bool = False,
+) -> pv.UnstructuredGrid:
+    """Convert a B-spline or Bézier geometry to a pyvista UnstructuredGrid.
+
+    Uses native VTK Bézier cell types for exact polynomial rendering.
+    Periodic/unclamped B-splines are automatically converted to open form.
+
+    For scalar fields (``rank == 1``):
+
+    - **dim=1**: always displayed as a line plot ``(t, f(t), 0)``.
+    - **dim=2**: by default a flat color map on ``(u, v, 0)``; set
+      ``elevation=True`` for ``(u, v, f(u,v))``.
+    - **dim=3**: color map on ``(u, v, w)``.
+
+    Args:
+        geom: Input B-spline or Bézier geometry.
+        scalar_name: Name for the scalar point data array when ``rank == 1``.
+        elevation: For scalar fields with dim ≤ 2, use the scalar value as
+            a spatial coordinate instead of a flat color map.  Ignored when
+            ``rank > 1`` or ``dim == 1`` (which always uses elevation).
+
+    Returns:
+        pv.UnstructuredGrid: PyVista unstructured grid with VTK Bézier cells.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+        TypeError: If *geom* is not a ``Bspline`` or ``Bezier``.
+        ValueError: If the parametric dimension is not 1, 2, or 3.
+    """
+    pv = _import_pyvista()
+
+    patches, is_rational = _get_bezier_patches(geom)
+    from ..bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    first_patch: BezierCls = patches.flat[0]  # type: ignore[assignment]
+    dim, rank, degree = first_patch.dim, first_patch.rank, first_patch.degree
+
+    if dim not in _VTK_CELL_TYPE_BY_DIM:
+        raise ValueError(f"Unsupported parametric dimension {dim}.")
+
+    cell_type = _VTK_CELL_TYPE_BY_DIM[dim]
+    ordering = vtk_ordering(degree)
+    n_pts_per_cell = len(ordering)
+    effective_elevation = elevation or (rank == 1 and dim == 1)
+
+    patch_data = [
+        _process_patch(
+            patches[idx],
+            geom,
+            idx,
+            is_rational,
+            rank,
+            dim,
+            effective_elevation,
+            ordering,
+        )
+        for idx in np.ndindex(patches.shape)
+    ]
+
+    return _assemble_grid(
+        pv,
+        patch_data,
+        cell_type,
+        n_pts_per_cell,
+        is_rational=is_rational,
+        rank=rank,
+        scalar_name=scalar_name,
+    )
+
+
+def _assemble_grid(  # noqa: PLR0913
+    pv: Any,  # noqa: ANN401
+    patch_data: list[_PatchGeometry],
+    cell_type: int,
+    n_pts_per_cell: int,
+    *,
+    is_rational: bool,
+    rank: int,
+    scalar_name: str,
+) -> pv.UnstructuredGrid:
+    """Assemble processed patches into a pyvista UnstructuredGrid.
+
+    Args:
+        pv: The pyvista module.
+        patch_data: List of processed patch geometries.
+        cell_type: VTK cell type constant.
+        n_pts_per_cell: Number of points per cell.
+        is_rational: Whether to attach rational weights.
+        rank: Output rank of the geometry.
+        scalar_name: Name for scalar point data.
+
+    Returns:
+        pv.UnstructuredGrid: Assembled grid with cell data and point arrays.
+    """
+    all_points = [p.points_3d for p in patch_data]
+    cells: list[npt.NDArray[np.intp]] = []
+    point_offset = 0
+
+    for _ in patch_data:
+        conn = np.empty(n_pts_per_cell + 1, dtype=np.intp)
+        conn[0] = n_pts_per_cell
+        conn[1:] = np.arange(point_offset, point_offset + n_pts_per_cell)
+        cells.append(conn)
+        point_offset += n_pts_per_cell
+
+    points = np.vstack(all_points)
+    cell_array = np.concatenate(cells)
+    cell_type_array = np.full(len(patch_data), cell_type, dtype=np.uint8)
+
+    grid = pv.UnstructuredGrid(cell_array, cell_type_array, points)
+
+    if is_rational:
+        weight_arrays = [p.weights for p in patch_data if p.weights is not None]
+        if weight_arrays:
+            grid.point_data["RationalWeights"] = np.concatenate(weight_arrays)
+
+    if rank == 1:
+        scalar_arrays = [p.scalars for p in patch_data if p.scalars is not None]
+        if scalar_arrays:
+            grid.point_data[scalar_name] = np.concatenate(scalar_arrays)
+
+    return grid  # type: ignore[no-any-return]
+
+
+def save(
+    geom: Bspline | Bezier,
+    filename: str | Path,
+    *,
+    scalar_name: str = "scalar",
+    elevation: bool = False,
+) -> None:
+    """Export a B-spline or Bézier geometry to a VTK file.
+
+    Converts the geometry to VTK Bézier cells and saves using pyvista.
+    The file format is inferred from the extension (``.vtu`` recommended,
+    ``.vtk`` for legacy format).
+
+    ParaView ≥ 5.10 renders VTK Bézier cells natively with exact geometry.
+
+    Args:
+        geom: Input B-spline or Bézier geometry.
+        filename: Output file path. Extension determines format.
+        scalar_name: Name for scalar point data when ``rank == 1``.
+        elevation: For scalar fields with dim ≤ 2, use scalar as
+            spatial coordinate.
+
+    Raises:
+        ImportError: If pyvista is not installed.
+    """
+    grid = to_pyvista(geom, scalar_name=scalar_name, elevation=elevation)
+    grid.save(str(filename))

--- a/src/pantr/viz/_vtk_ordering.py
+++ b/src/pantr/viz/_vtk_ordering.py
@@ -1,0 +1,310 @@
+"""Tensor-product to VTK Bézier point reordering.
+
+Maps the natural tensor-product (row-major) control point layout used by pantr
+to the point ordering expected by VTK's higher-order Bézier cell types
+(``VTK_BEZIER_CURVE``, ``VTK_BEZIER_QUADRILATERAL``, ``VTK_BEZIER_HEXAHEDRON``).
+
+VTK ordering convention: **corners → edges → faces → interior**, where each
+sub-entity is itself ordered recursively.
+
+All functions in this module are **pure NumPy** — no pyvista dependency — so
+they can be tested without installing pyvista.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import numpy as np
+from numpy import typing as npt
+
+
+def _tp_flat_index(indices: tuple[int, ...], shape: tuple[int, ...]) -> int:
+    """Convert a multi-index into a flat (row-major) index.
+
+    Args:
+        indices: Multi-index tuple, one per dimension.
+        shape: Shape of the tensor-product array.
+
+    Returns:
+        int: Flat row-major index.
+
+    Note:
+        No input validation is performed.
+    """
+    flat = 0
+    stride = 1
+    for i in range(len(shape) - 1, -1, -1):
+        flat += indices[i] * stride
+        stride *= shape[i]
+    return flat
+
+
+@lru_cache(maxsize=64)
+def vtk_ordering_curve(degree: int) -> npt.NDArray[np.intp]:
+    """Return permutation from tensor-product to VTK ordering for a Bézier curve.
+
+    VTK curve ordering: ``[start, end, interior_0, interior_1, ...]``
+    i.e. the two endpoints first, then interior points in order.
+
+    Args:
+        degree: Polynomial degree (≥ 1).
+
+    Returns:
+        NDArray[intp]: Permutation array of length ``degree + 1``.
+    """
+    n = degree + 1
+    if degree <= 1:
+        return np.arange(n, dtype=np.intp)
+    # Corners: 0, degree
+    order = [0, degree]
+    # Interior: 1, 2, ..., degree-1
+    order.extend(range(1, degree))
+    return np.array(order, dtype=np.intp)
+
+
+@lru_cache(maxsize=64)
+def vtk_ordering_quad(degree_u: int, degree_v: int) -> npt.NDArray[np.intp]:
+    """Return permutation from tensor-product to VTK ordering for a Bézier quad.
+
+    Tensor-product control points have shape ``(degree_u + 1, degree_v + 1)``
+    and are stored row-major (u varies slowest).
+
+    VTK quad ordering:
+    1. 4 corners (VTK vertex order)
+    2. 4 edges (interior points only, VTK edge order)
+    3. Face interior (row-major within the interior)
+
+    VTK quad corner mapping (tensor-product ``(i, j)`` indices)::
+
+        VTK vertex 0 → (0, 0)
+        VTK vertex 1 → (degree_u, 0)
+        VTK vertex 2 → (degree_u, degree_v)
+        VTK vertex 3 → (0, degree_v)
+
+    VTK quad edge ordering::
+
+        Edge 0: (0,0)→(degree_u,0)        — bottom, increasing i, j=0
+        Edge 1: (degree_u,0)→(degree_u,degree_v) — right, i=degree_u, increasing j
+        Edge 2: (degree_u,degree_v)→(0,degree_v) — top, decreasing i, j=degree_v
+        Edge 3: (0,0)→(0,degree_v)         — left, i=0, increasing j
+
+    Args:
+        degree_u: Polynomial degree in u direction (≥ 1).
+        degree_v: Polynomial degree in v direction (≥ 1).
+
+    Returns:
+        NDArray[intp]: Permutation array of length ``(degree_u+1) * (degree_v+1)``.
+    """
+    nu = degree_u + 1
+    nv = degree_v + 1
+    shape = (nu, nv)
+    order: list[int] = []
+
+    # --- Corners (4) ---
+    corners = [(0, 0), (degree_u, 0), (degree_u, degree_v), (0, degree_v)]
+    for c in corners:
+        order.append(_tp_flat_index(c, shape))
+
+    # --- Edges (interior points only) ---
+    # Edge 0: bottom (j=0), i = 1..degree_u-1
+    for i in range(1, degree_u):
+        order.append(_tp_flat_index((i, 0), shape))
+    # Edge 1: right (i=degree_u), j = 1..degree_v-1
+    for j in range(1, degree_v):
+        order.append(_tp_flat_index((degree_u, j), shape))
+    # Edge 2: top (j=degree_v), i = degree_u-1..1 (decreasing)
+    for i in range(degree_u - 1, 0, -1):
+        order.append(_tp_flat_index((i, degree_v), shape))
+    # Edge 3: left (i=0), j = 1..degree_v-1
+    for j in range(1, degree_v):
+        order.append(_tp_flat_index((0, j), shape))
+
+    # --- Face interior ---
+    for i in range(1, degree_u):
+        for j in range(1, degree_v):
+            order.append(_tp_flat_index((i, j), shape))
+
+    return np.array(order, dtype=np.intp)
+
+
+@lru_cache(maxsize=64)
+def vtk_ordering_hex(  # noqa: PLR0912
+    degree_u: int, degree_v: int, degree_w: int
+) -> npt.NDArray[np.intp]:
+    """Return permutation from tensor-product to VTK ordering for a Bézier hex.
+
+    Tensor-product control points have shape
+    ``(degree_u + 1, degree_v + 1, degree_w + 1)`` stored row-major
+    (u varies slowest).
+
+    VTK hexahedron ordering:
+    1. 8 corners
+    2. 12 edges (interior points only)
+    3. 6 faces (interior points only)
+    4. Volume interior
+
+    VTK hex corner mapping (tensor-product ``(i, j, k)`` indices)::
+
+        VTK vertex 0 → (0, 0, 0)
+        VTK vertex 1 → (degree_u, 0, 0)
+        VTK vertex 2 → (degree_u, degree_v, 0)
+        VTK vertex 3 → (0, degree_v, 0)
+        VTK vertex 4 → (0, 0, degree_w)
+        VTK vertex 5 → (degree_u, 0, degree_w)
+        VTK vertex 6 → (degree_u, degree_v, degree_w)
+        VTK vertex 7 → (0, degree_v, degree_w)
+
+    VTK hex edge ordering (12 edges)::
+
+        Edge  0: vtx 0→1 — bottom face, j=0, k=0, increasing i
+        Edge  1: vtx 1→2 — bottom face, i=pu, k=0, increasing j
+        Edge  2: vtx 3→2 — bottom face, j=pv, k=0, increasing i
+        Edge  3: vtx 0→3 — bottom face, i=0, k=0, increasing j
+        Edge  4: vtx 4→5 — top face, j=0, k=pw, increasing i
+        Edge  5: vtx 5→6 — top face, i=pu, k=pw, increasing j
+        Edge  6: vtx 7→6 — top face, j=pv, k=pw, increasing i
+        Edge  7: vtx 4→7 — top face, i=0, k=pw, increasing j
+        Edge  8: vtx 0→4 — vertical, i=0, j=0, increasing k
+        Edge  9: vtx 1→5 — vertical, i=pu, j=0, increasing k
+        Edge 10: vtx 2→6 — vertical, i=pu, j=pv, increasing k
+        Edge 11: vtx 3→7 — vertical, i=0, j=pv, increasing k
+
+    VTK hex face ordering (6 faces, interior points only)::
+
+        Face 0: k=0    (bottom)  — ordered in local (i, j) increasing
+        Face 1: k=pw   (top)     — ordered in local (i, j) increasing
+        Face 2: j=0    (front)   — ordered in local (i, k) increasing
+        Face 3: i=pu   (right)   — ordered in local (j, k) increasing
+        Face 4: j=pv   (back)    — ordered in local (i, k) increasing
+        Face 5: i=0    (left)    — ordered in local (j, k) increasing
+
+    Args:
+        degree_u: Polynomial degree in u direction (≥ 1).
+        degree_v: Polynomial degree in v direction (≥ 1).
+        degree_w: Polynomial degree in w direction (≥ 1).
+
+    Returns:
+        NDArray[intp]: Permutation array of length
+            ``(degree_u+1) * (degree_v+1) * (degree_w+1)``.
+    """
+    pu, pv, pw = degree_u, degree_v, degree_w
+    shape = (pu + 1, pv + 1, pw + 1)
+    order: list[int] = []
+
+    def flat(i: int, j: int, k: int) -> int:
+        return _tp_flat_index((i, j, k), shape)
+
+    # --- 8 Corners ---
+    corners = [
+        (0, 0, 0),
+        (pu, 0, 0),
+        (pu, pv, 0),
+        (0, pv, 0),
+        (0, 0, pw),
+        (pu, 0, pw),
+        (pu, pv, pw),
+        (0, pv, pw),
+    ]
+    for c in corners:
+        order.append(flat(*c))
+
+    # --- 12 Edges (interior points only) ---
+    # Edge 0: vtx0→vtx1 (j=0, k=0, increasing i)
+    for i in range(1, pu):
+        order.append(flat(i, 0, 0))
+    # Edge 1: vtx1→vtx2 (i=pu, k=0, increasing j)
+    for j in range(1, pv):
+        order.append(flat(pu, j, 0))
+    # Edge 2: vtx3→vtx2 (j=pv, k=0, increasing i)
+    for i in range(1, pu):
+        order.append(flat(i, pv, 0))
+    # Edge 3: vtx0→vtx3 (i=0, k=0, increasing j)
+    for j in range(1, pv):
+        order.append(flat(0, j, 0))
+    # Edge 4: vtx4→vtx5 (j=0, k=pw, increasing i)
+    for i in range(1, pu):
+        order.append(flat(i, 0, pw))
+    # Edge 5: vtx5→vtx6 (i=pu, k=pw, increasing j)
+    for j in range(1, pv):
+        order.append(flat(pu, j, pw))
+    # Edge 6: vtx7→vtx6 (j=pv, k=pw, increasing i)
+    for i in range(1, pu):
+        order.append(flat(i, pv, pw))
+    # Edge 7: vtx4→vtx7 (i=0, k=pw, increasing j)
+    for j in range(1, pv):
+        order.append(flat(0, j, pw))
+    # Edge 8: vtx0→vtx4 (i=0, j=0, increasing k)
+    for k in range(1, pw):
+        order.append(flat(0, 0, k))
+    # Edge 9: vtx1→vtx5 (i=pu, j=0, increasing k)
+    for k in range(1, pw):
+        order.append(flat(pu, 0, k))
+    # Edge 10: vtx2→vtx6 (i=pu, j=pv, increasing k)
+    for k in range(1, pw):
+        order.append(flat(pu, pv, k))
+    # Edge 11: vtx3→vtx7 (i=0, j=pv, increasing k)
+    for k in range(1, pw):
+        order.append(flat(0, pv, k))
+
+    # --- 6 Faces (interior points only) ---
+    # Face 0: k=0 (bottom), interior (i, j) with i in 1..pu-1, j in 1..pv-1
+    for i in range(1, pu):
+        for j in range(1, pv):
+            order.append(flat(i, j, 0))
+    # Face 1: k=pw (top)
+    for i in range(1, pu):
+        for j in range(1, pv):
+            order.append(flat(i, j, pw))
+    # Face 2: j=0 (front), interior (i, k)
+    for i in range(1, pu):
+        for k in range(1, pw):
+            order.append(flat(i, 0, k))
+    # Face 3: i=pu (right), interior (j, k)
+    for j in range(1, pv):
+        for k in range(1, pw):
+            order.append(flat(pu, j, k))
+    # Face 4: j=pv (back), interior (i, k)
+    for i in range(1, pu):
+        for k in range(1, pw):
+            order.append(flat(i, pv, k))
+    # Face 5: i=0 (left), interior (j, k)
+    for j in range(1, pv):
+        for k in range(1, pw):
+            order.append(flat(0, j, k))
+
+    # --- Volume interior ---
+    for i in range(1, pu):
+        for j in range(1, pv):
+            for k in range(1, pw):
+                order.append(flat(i, j, k))
+
+    return np.array(order, dtype=np.intp)
+
+
+def vtk_ordering(degree: tuple[int, ...]) -> npt.NDArray[np.intp]:
+    """Return the tensor-product to VTK Bézier point ordering permutation.
+
+    Dispatches to the appropriate ordering function based on the parametric
+    dimension (1D, 2D, or 3D).
+
+    Args:
+        degree: Polynomial degrees per parametric direction. Length determines
+            the parametric dimension (1, 2, or 3).
+
+    Returns:
+        NDArray[intp]: Permutation array mapping flat tensor-product indices
+        to VTK ordering.
+
+    Raises:
+        ValueError: If the parametric dimension is not 1, 2, or 3.
+    """
+    _dispatch = {
+        1: lambda d: vtk_ordering_curve(d[0]),
+        2: lambda d: vtk_ordering_quad(d[0], d[1]),
+        3: lambda d: vtk_ordering_hex(d[0], d[1], d[2]),
+    }
+    dim = len(degree)
+    if dim not in _dispatch:
+        raise ValueError(f"Unsupported parametric dimension {dim}. Expected 1, 2, or 3.")
+    return _dispatch[dim](degree)

--- a/tests/test_viz_cells.py
+++ b/tests/test_viz_cells.py
@@ -1,0 +1,265 @@
+"""Tests for Bézier/B-spline to pyvista UnstructuredGrid conversion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pv = pytest.importorskip("pyvista")
+
+from pantr.bezier import Bezier  # noqa: E402
+from pantr.bspline import (  # noqa: E402
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_uniform_periodic,
+)
+from pantr.viz import save, to_pyvista  # noqa: E402
+from pantr.viz._vtk_cells import (  # noqa: E402
+    VTK_BEZIER_CURVE,
+    VTK_BEZIER_HEXAHEDRON,
+    VTK_BEZIER_QUADRILATERAL,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bezier_curve_2d() -> Bezier:
+    """Quadratic Bézier curve in 2D."""
+    cp = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bezier_curve_3d() -> Bezier:
+    """Cubic Bézier curve in 3D."""
+    cp = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [2.0, 1.0, 0.0],
+            [3.0, 0.0, 0.0],
+        ]
+    )
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bezier_surface_3d() -> Bezier:
+    """Biquadratic Bézier surface in 3D."""
+    cp = np.zeros((3, 3, 3))
+    for i in range(3):
+        for j in range(3):
+            cp[i, j] = [i * 0.5, j * 0.5, 0.1 * i * j]
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bezier_scalar_2d() -> Bezier:
+    """Bilinear scalar Bézier (dim=2, rank=1)."""
+    cp = np.array([[[0.0], [1.0]], [[2.0], [3.0]]])
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bspline_curve_3d() -> Bspline:
+    """Quadratic B-spline curve in 3D with 3 elements."""
+    space1d = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    space = BsplineSpace([space1d])
+    cp = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [1.0, 0.5, 0.0],
+            [1.5, 1.0, 0.0],
+            [2.0, 0.0, 0.0],
+        ]
+    )
+    return Bspline(space, cp)
+
+
+@pytest.fixture()
+def rational_bezier_curve() -> Bezier:
+    """Rational quadratic Bézier (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    cp = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])
+    return Bezier(cp, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Bézier → pyvista
+# ---------------------------------------------------------------------------
+
+
+class TestBezierToPyvista:
+    """Tests for converting Bézier objects to pyvista grids."""
+
+    def test_curve_2d_cell_type(self, bezier_curve_2d: Bezier) -> None:
+        grid = to_pyvista(bezier_curve_2d)
+        assert grid.n_cells == 1
+        assert grid.celltypes[0] == VTK_BEZIER_CURVE
+
+    def test_curve_2d_point_count(self, bezier_curve_2d: Bezier) -> None:
+        grid = to_pyvista(bezier_curve_2d)
+        n_expected = 3
+        assert grid.n_points == n_expected
+
+    def test_curve_2d_z_is_zero(self, bezier_curve_2d: Bezier) -> None:
+        grid = to_pyvista(bezier_curve_2d)
+        np.testing.assert_array_equal(grid.points[:, 2], 0.0)
+
+    def test_curve_3d_cell_type(self, bezier_curve_3d: Bezier) -> None:
+        grid = to_pyvista(bezier_curve_3d)
+        assert grid.n_cells == 1
+        assert grid.celltypes[0] == VTK_BEZIER_CURVE
+        n_expected = 4
+        assert grid.n_points == n_expected
+
+    def test_surface_cell_type(self, bezier_surface_3d: Bezier) -> None:
+        grid = to_pyvista(bezier_surface_3d)
+        assert grid.n_cells == 1
+        assert grid.celltypes[0] == VTK_BEZIER_QUADRILATERAL
+        n_expected = 9
+        assert grid.n_points == n_expected
+
+    def test_rational_has_weights(self, rational_bezier_curve: Bezier) -> None:
+        grid = to_pyvista(rational_bezier_curve)
+        assert "RationalWeights" in grid.point_data
+        weights = grid.point_data["RationalWeights"]
+        n_expected = 3
+        assert len(weights) == n_expected
+        assert weights[0] == pytest.approx(1.0)
+
+    def test_scalar_2d_has_point_data(self, bezier_scalar_2d: Bezier) -> None:
+        grid = to_pyvista(bezier_scalar_2d)
+        assert "scalar" in grid.point_data
+        assert grid.n_cells == 1
+        assert grid.celltypes[0] == VTK_BEZIER_QUADRILATERAL
+
+    def test_scalar_2d_custom_name(self, bezier_scalar_2d: Bezier) -> None:
+        grid = to_pyvista(bezier_scalar_2d, scalar_name="temperature")
+        assert "temperature" in grid.point_data
+        assert "scalar" not in grid.point_data
+
+
+# ---------------------------------------------------------------------------
+# B-spline → pyvista
+# ---------------------------------------------------------------------------
+
+
+class TestBsplineToPyvista:
+    """Tests for converting B-spline objects to pyvista grids."""
+
+    def test_curve_multiple_cells(self, bspline_curve_3d: Bspline) -> None:
+        grid = to_pyvista(bspline_curve_3d)
+        n_expected_cells = 3
+        assert grid.n_cells == n_expected_cells
+        assert all(ct == VTK_BEZIER_CURVE for ct in grid.celltypes)
+
+    def test_curve_point_count(self, bspline_curve_3d: Bspline) -> None:
+        grid = to_pyvista(bspline_curve_3d)
+        # 3 cells x 3 points each (degree 2)
+        n_expected = 9
+        assert grid.n_points == n_expected
+
+    def test_periodic_bspline(self) -> None:
+        """Periodic B-spline should convert without error."""
+        knots = create_uniform_periodic(4, 2, domain=(0.0, 1.0))
+        space1d = BsplineSpace1D(knots, 2, periodic=True)
+        space = BsplineSpace([space1d])
+        n_basis = space1d.num_basis
+        cp = np.zeros((n_basis, 3))
+        for i in range(n_basis):
+            angle = 2 * np.pi * i / n_basis
+            cp[i] = [np.cos(angle), np.sin(angle), 0.0]
+        bspline = Bspline(space, cp)
+        grid = to_pyvista(bspline)
+        assert grid.n_cells > 0
+        assert all(ct == VTK_BEZIER_CURVE for ct in grid.celltypes)
+
+
+# ---------------------------------------------------------------------------
+# Scalar fields
+# ---------------------------------------------------------------------------
+
+
+class TestScalarFields:
+    """Tests for scalar field visualization."""
+
+    def test_1d_scalar_elevation(self) -> None:
+        """dim=1 rank=1: should produce line plot (t, f(t), 0)."""
+        cp = np.array([[0.0], [1.0], [0.0]])
+        bezier = Bezier(cp)
+        grid = to_pyvista(bezier)
+        # Points should have nonzero y (elevation)
+        assert grid.points[:, 1].max() > 0.0
+        # z should be zero
+        np.testing.assert_array_equal(grid.points[:, 2], 0.0)
+
+    def test_2d_scalar_flat_default(self) -> None:
+        """dim=2 rank=1: default should be flat (z=0)."""
+        cp = np.array([[[1.0], [2.0]], [[3.0], [4.0]]])
+        bezier = Bezier(cp)
+        grid = to_pyvista(bezier, elevation=False)
+        np.testing.assert_array_equal(grid.points[:, 2], 0.0)
+        assert "scalar" in grid.point_data
+
+    def test_2d_scalar_elevation(self) -> None:
+        """dim=2 rank=1: elevation=True should use scalar as z."""
+        cp = np.array([[[1.0], [2.0]], [[3.0], [4.0]]])
+        bezier = Bezier(cp)
+        grid = to_pyvista(bezier, elevation=True)
+        assert grid.points[:, 2].max() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Save
+# ---------------------------------------------------------------------------
+
+
+class TestSave:
+    """Tests for VTK file export."""
+
+    def test_save_vtu(self, bezier_curve_3d: Bezier, tmp_path: Path) -> None:
+        path = tmp_path / "test.vtu"
+        save(bezier_curve_3d, path)
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+    def test_save_vtk(self, bezier_surface_3d: Bezier, tmp_path: Path) -> None:
+        path = tmp_path / "test.vtk"
+        save(bezier_surface_3d, path)
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_invalid_type(self) -> None:
+        with pytest.raises(TypeError, match="Expected Bspline or Bezier"):
+            to_pyvista("not a geometry")  # type: ignore[arg-type]
+
+    def test_bezier_volume(self) -> None:
+        """Trilinear Bézier volume."""
+        cp = np.zeros((2, 2, 2, 3))
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    cp[i, j, k] = [float(i), float(j), float(k)]
+        bezier = Bezier(cp)
+        grid = to_pyvista(bezier)
+        assert grid.n_cells == 1
+        assert grid.celltypes[0] == VTK_BEZIER_HEXAHEDRON
+        n_expected = 8
+        assert grid.n_points == n_expected

--- a/tests/test_viz_knot_lines.py
+++ b/tests/test_viz_knot_lines.py
@@ -14,7 +14,7 @@ from pantr.bspline import (  # noqa: E402
     BsplineSpace1D,
     create_uniform_open,
 )
-from pantr.viz import control_points_mesh, control_polygon_mesh, knot_lines_meshes  # noqa: E402
+from pantr.viz import control_polygon_mesh, knot_lines_meshes  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -117,20 +117,20 @@ class TestKnotLinesSurface:
 
 
 # ---------------------------------------------------------------------------
-# Control points
+# Control polygon
 # ---------------------------------------------------------------------------
 
 
-class TestControlPointsMesh:
-    """Tests for control point point cloud generation."""
+class TestControlPolygonMesh:
+    """Tests for control polygon (points + wireframe) generation."""
 
     def test_bezier_point_count(self, bezier_curve: Bezier) -> None:
-        mesh = control_points_mesh(bezier_curve)
+        mesh = control_polygon_mesh(bezier_curve)
         n_expected = 3
         assert mesh.n_points == n_expected
 
     def test_bspline_point_count(self, bspline_curve: Bspline) -> None:
-        mesh = control_points_mesh(bspline_curve)
+        mesh = control_polygon_mesh(bspline_curve)
         n_expected = 5
         assert mesh.n_points == n_expected
 
@@ -138,23 +138,14 @@ class TestControlPointsMesh:
         self,
         rational_bezier_curve: Bezier,
     ) -> None:
-        mesh = control_points_mesh(rational_bezier_curve)
-        # First control point is (1, 0) with weight 1 → projected (1, 0, 0)
+        mesh = control_polygon_mesh(rational_bezier_curve)
+        # First control point is (1, 0) with weight 1 -> projected (1, 0, 0)
         np.testing.assert_allclose(mesh.points[0], [1.0, 0.0, 0.0], atol=1e-12)
 
     def test_3d_points_padded(self, bezier_curve: Bezier) -> None:
-        mesh = control_points_mesh(bezier_curve)
+        mesh = control_polygon_mesh(bezier_curve)
         # z should be 0 for this planar curve
         np.testing.assert_array_equal(mesh.points[:, 2], 0.0)
-
-
-# ---------------------------------------------------------------------------
-# Control polygon
-# ---------------------------------------------------------------------------
-
-
-class TestControlPolygonMesh:
-    """Tests for control polygon wireframe generation."""
 
     def test_curve_has_lines(self, bezier_curve: Bezier) -> None:
         mesh = control_polygon_mesh(bezier_curve)

--- a/tests/test_viz_knot_lines.py
+++ b/tests/test_viz_knot_lines.py
@@ -1,0 +1,176 @@
+"""Tests for knot line computation and control point visualization."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pv = pytest.importorskip("pyvista")
+
+from pantr.bezier import Bezier  # noqa: E402
+from pantr.bspline import (  # noqa: E402
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_uniform_open,
+)
+from pantr.viz import control_points_mesh, control_polygon_mesh, knot_lines_meshes  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bspline_curve() -> Bspline:
+    """Quadratic B-spline curve in 3D with 3 elements."""
+    space1d = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    space = BsplineSpace([space1d])
+    cp = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [1.0, 0.5, 0.0],
+            [1.5, 1.0, 0.0],
+            [2.0, 0.0, 0.0],
+        ]
+    )
+    return Bspline(space, cp)
+
+
+@pytest.fixture()
+def bspline_surface() -> Bspline:
+    """Biquadratic B-spline surface in 3D."""
+    knots_u = create_uniform_open(3, 2, domain=(0.0, 1.0))
+    knots_v = create_uniform_open(2, 2, domain=(0.0, 1.0))
+    s_u = BsplineSpace1D(knots_u, 2)
+    s_v = BsplineSpace1D(knots_v, 2)
+    space = BsplineSpace([s_u, s_v])
+    rng = np.random.default_rng(42)
+    cp = rng.standard_normal((*space.num_basis, 3))
+    return Bspline(space, cp)
+
+
+@pytest.fixture()
+def bezier_curve() -> Bezier:
+    """Quadratic Bézier curve in 3D."""
+    cp = np.array([[0.0, 0.0, 0.0], [0.5, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def rational_bezier_curve() -> Bezier:
+    """Rational quadratic Bézier (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    cp = np.array([[1.0, 0.0, 1.0], [w, w, w], [0.0, 1.0, 1.0]])
+    return Bezier(cp, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Knot lines
+# ---------------------------------------------------------------------------
+
+
+class TestKnotLinesCurve:
+    """Tests for knot line computation on 1D B-splines."""
+
+    def test_returns_list(self, bspline_curve: Bspline) -> None:
+        meshes = knot_lines_meshes(bspline_curve)
+        assert isinstance(meshes, list)
+        assert len(meshes) == 1  # single PolyData with all knot points
+
+    def test_knot_point_count(self, bspline_curve: Bspline) -> None:
+        meshes = knot_lines_meshes(bspline_curve)
+        kp = meshes[0]
+        # 3 elements → 2 interior knots
+        n_interior = 2
+        assert kp.n_points == n_interior
+
+    def test_single_element_no_interior_knots(self) -> None:
+        """Single element B-spline has no interior knots."""
+        space1d = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
+        space = BsplineSpace([space1d])
+        cp = np.array([[0.0, 0.0, 0.0], [0.5, 1.0, 0.0], [1.0, 0.0, 0.0]])
+        bspline = Bspline(space, cp)
+        meshes = knot_lines_meshes(bspline)
+        assert meshes[0].n_points == 0
+
+
+class TestKnotLinesSurface:
+    """Tests for knot line computation on 2D B-splines."""
+
+    def test_returns_list_of_grids(self, bspline_surface: Bspline) -> None:
+        meshes = knot_lines_meshes(bspline_surface)
+        assert isinstance(meshes, list)
+        assert len(meshes) > 0
+
+    def test_knot_line_count(self, bspline_surface: Bspline) -> None:
+        meshes = knot_lines_meshes(bspline_surface)
+        # 3 elements in u → 2 interior knots; 2 elements in v → 1 interior knot
+        n_expected = 2 + 1
+        assert len(meshes) == n_expected
+
+    def test_knot_lines_are_curves(self, bspline_surface: Bspline) -> None:
+        meshes = knot_lines_meshes(bspline_surface)
+        for mesh in meshes:
+            assert mesh.n_cells > 0
+
+
+# ---------------------------------------------------------------------------
+# Control points
+# ---------------------------------------------------------------------------
+
+
+class TestControlPointsMesh:
+    """Tests for control point point cloud generation."""
+
+    def test_bezier_point_count(self, bezier_curve: Bezier) -> None:
+        mesh = control_points_mesh(bezier_curve)
+        n_expected = 3
+        assert mesh.n_points == n_expected
+
+    def test_bspline_point_count(self, bspline_curve: Bspline) -> None:
+        mesh = control_points_mesh(bspline_curve)
+        n_expected = 5
+        assert mesh.n_points == n_expected
+
+    def test_rational_uses_projected_coords(
+        self,
+        rational_bezier_curve: Bezier,
+    ) -> None:
+        mesh = control_points_mesh(rational_bezier_curve)
+        # First control point is (1, 0) with weight 1 → projected (1, 0, 0)
+        np.testing.assert_allclose(mesh.points[0], [1.0, 0.0, 0.0], atol=1e-12)
+
+    def test_3d_points_padded(self, bezier_curve: Bezier) -> None:
+        mesh = control_points_mesh(bezier_curve)
+        # z should be 0 for this planar curve
+        np.testing.assert_array_equal(mesh.points[:, 2], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Control polygon
+# ---------------------------------------------------------------------------
+
+
+class TestControlPolygonMesh:
+    """Tests for control polygon wireframe generation."""
+
+    def test_curve_has_lines(self, bezier_curve: Bezier) -> None:
+        mesh = control_polygon_mesh(bezier_curve)
+        assert mesh.n_lines > 0
+
+    def test_curve_line_count(self, bezier_curve: Bezier) -> None:
+        mesh = control_polygon_mesh(bezier_curve)
+        # Single polyline through 3 control points
+        assert mesh.n_lines == 1
+
+    def test_surface_has_lines(self, bspline_surface: Bspline) -> None:
+        mesh = control_polygon_mesh(bspline_surface)
+        assert mesh.n_lines > 0
+
+    def test_bspline_curve_polygon(self, bspline_curve: Bspline) -> None:
+        mesh = control_polygon_mesh(bspline_curve)
+        n_pts = 5
+        assert mesh.n_points == n_pts
+        assert mesh.n_lines == 1  # single polyline

--- a/tests/test_viz_ordering.py
+++ b/tests/test_viz_ordering.py
@@ -1,0 +1,199 @@
+"""Tests for VTK Bézier point ordering (pure NumPy, no pyvista required)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy import typing as npt
+
+from pantr.viz._vtk_ordering import (
+    vtk_ordering,
+    vtk_ordering_curve,
+    vtk_ordering_hex,
+    vtk_ordering_quad,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_permutation(perm: npt.NDArray[np.intp], n: int) -> bool:
+    """Check that *perm* is a valid permutation of 0..n-1."""
+    return perm.shape == (n,) and set(perm.tolist()) == set(range(n))
+
+
+# ---------------------------------------------------------------------------
+# 1D — Curves
+# ---------------------------------------------------------------------------
+
+
+class TestVtkOrderingCurve:
+    """Tests for vtk_ordering_curve."""
+
+    def test_degree_1(self) -> None:
+        perm = vtk_ordering_curve(1)
+        n_pts = 2
+        assert _is_valid_permutation(perm, n_pts)
+        np.testing.assert_array_equal(perm[:n_pts], [0, 1])
+
+    def test_degree_2(self) -> None:
+        perm = vtk_ordering_curve(2)
+        n_pts = 3
+        assert _is_valid_permutation(perm, n_pts)
+        np.testing.assert_array_equal(perm, [0, 2, 1])
+
+    def test_degree_3(self) -> None:
+        perm = vtk_ordering_curve(3)
+        n_pts = 4
+        assert _is_valid_permutation(perm, n_pts)
+        np.testing.assert_array_equal(perm, [0, 3, 1, 2])
+
+    def test_degree_5(self) -> None:
+        degree = 5
+        perm = vtk_ordering_curve(degree)
+        n_pts = degree + 1
+        assert _is_valid_permutation(perm, n_pts)
+        assert perm[0] == 0
+        assert perm[1] == degree
+        np.testing.assert_array_equal(perm[2:], [1, 2, 3, 4])
+
+    def test_corners_first(self) -> None:
+        for p in range(1, 8):
+            perm = vtk_ordering_curve(p)
+            assert perm[0] == 0, f"degree={p}: first corner should be 0"
+            assert perm[1] == p, f"degree={p}: second corner should be {p}"
+
+
+# ---------------------------------------------------------------------------
+# 2D — Quads
+# ---------------------------------------------------------------------------
+
+
+class TestVtkOrderingQuad:
+    """Tests for vtk_ordering_quad."""
+
+    def test_is_valid_permutation(self) -> None:
+        for pu in range(1, 5):
+            for pv in range(1, 5):
+                perm = vtk_ordering_quad(pu, pv)
+                n = (pu + 1) * (pv + 1)
+                assert _is_valid_permutation(perm, n), f"degree=({pu},{pv})"
+
+    def test_degree_1x1(self) -> None:
+        perm = vtk_ordering_quad(1, 1)
+        n_corners = 4
+        assert len(perm) == n_corners
+        # Corners: (0,0), (1,0), (1,1), (0,1) in flat indices with shape (2,2)
+        # (0,0)=0, (1,0)=2, (1,1)=3, (0,1)=1
+        np.testing.assert_array_equal(perm, [0, 2, 3, 1])
+
+    def test_corners_degree_2x2(self) -> None:
+        perm = vtk_ordering_quad(2, 2)
+        n_pts = 9
+        assert len(perm) == n_pts
+        # Corners: (0,0), (2,0), (2,2), (0,2) in shape (3,3)
+        # (0,0)=0, (2,0)=6, (2,2)=8, (0,2)=2
+        np.testing.assert_array_equal(perm[:4], [0, 6, 8, 2])
+
+    def test_corners_are_first_four(self) -> None:
+        """First 4 entries must be the 4 corner indices."""
+        for pu in range(1, 5):
+            for pv in range(1, 5):
+                perm = vtk_ordering_quad(pu, pv)
+                expected_corners = {
+                    0,  # (0, 0)
+                    pu * (pv + 1),  # (pu, 0)
+                    pu * (pv + 1) + pv,  # (pu, pv)
+                    pv,  # (0, pv)
+                }
+                actual_corners = set(perm[:4].tolist())
+                assert actual_corners == expected_corners, f"degree=({pu},{pv})"
+
+    def test_edge_count(self) -> None:
+        """Check the number of edge interior points."""
+        for pu in range(1, 5):
+            for pv in range(1, 5):
+                n_edge_interior = 2 * (pu - 1) + 2 * (pv - 1)
+                n_face_interior = (pu - 1) * (pv - 1)
+                n_total = (pu + 1) * (pv + 1)
+                n_corners = 4
+                assert n_corners + n_edge_interior + n_face_interior == n_total
+
+
+# ---------------------------------------------------------------------------
+# 3D — Hexahedra
+# ---------------------------------------------------------------------------
+
+
+class TestVtkOrderingHex:
+    """Tests for vtk_ordering_hex."""
+
+    def test_is_valid_permutation(self) -> None:
+        for pu in range(1, 4):
+            for pv in range(1, 4):
+                for pw in range(1, 4):
+                    perm = vtk_ordering_hex(pu, pv, pw)
+                    n = (pu + 1) * (pv + 1) * (pw + 1)
+                    assert _is_valid_permutation(perm, n), f"degree=({pu},{pv},{pw})"
+
+    def test_degree_1x1x1(self) -> None:
+        n_corners = 8
+        perm = vtk_ordering_hex(1, 1, 1)
+        assert len(perm) == n_corners
+        # shape (2, 2, 2): flat index = i*4 + j*2 + k
+        # VTK corners: (0,0,0)=0, (1,0,0)=4, (1,1,0)=6, (0,1,0)=2,
+        #              (0,0,1)=1, (1,0,1)=5, (1,1,1)=7, (0,1,1)=3
+        np.testing.assert_array_equal(perm, [0, 4, 6, 2, 1, 5, 7, 3])
+
+    def test_corners_are_first_eight(self) -> None:
+        """First 8 entries must be the 8 corner indices."""
+        for pu in range(1, 4):
+            for pv in range(1, 4):
+                for pw in range(1, 4):
+                    perm = vtk_ordering_hex(pu, pv, pw)
+                    nv = pv + 1
+                    nw = pw + 1
+                    expected_corners = set()
+                    for i in (0, pu):
+                        for j in (0, pv):
+                            for k in (0, pw):
+                                expected_corners.add(i * nv * nw + j * nw + k)
+                    actual_corners = set(perm[:8].tolist())
+                    assert actual_corners == expected_corners, f"degree=({pu},{pv},{pw})"
+
+    def test_total_count(self) -> None:
+        """Verify count decomposition: corners + edges + faces + interior."""
+        n_corners = 8
+        for pu in range(1, 4):
+            for pv in range(1, 4):
+                for pw in range(1, 4):
+                    n_edges = 4 * (pu - 1) + 4 * (pv - 1) + 4 * (pw - 1)
+                    n_faces = (
+                        2 * (pu - 1) * (pv - 1) + 2 * (pu - 1) * (pw - 1) + 2 * (pv - 1) * (pw - 1)
+                    )
+                    n_interior = (pu - 1) * (pv - 1) * (pw - 1)
+                    n_total = (pu + 1) * (pv + 1) * (pw + 1)
+                    assert n_corners + n_edges + n_faces + n_interior == n_total
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestVtkOrdering:
+    """Tests for the vtk_ordering dispatch function."""
+
+    def test_1d(self) -> None:
+        np.testing.assert_array_equal(vtk_ordering((3,)), vtk_ordering_curve(3))
+
+    def test_2d(self) -> None:
+        np.testing.assert_array_equal(vtk_ordering((2, 3)), vtk_ordering_quad(2, 3))
+
+    def test_3d(self) -> None:
+        np.testing.assert_array_equal(vtk_ordering((2, 2, 2)), vtk_ordering_hex(2, 2, 2))
+
+    def test_invalid_dim(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported parametric dimension"):
+            vtk_ordering((1, 1, 1, 1))

--- a/tests/test_viz_scene.py
+++ b/tests/test_viz_scene.py
@@ -88,12 +88,6 @@ class TestScene:
         plotter = scene.to_plotter()
         assert plotter is not None
 
-    def test_with_control_points(self, bezier_curve: Bezier) -> None:
-        scene = Scene()
-        scene.add(bezier_curve, show_control_points=True)
-        plotter = scene.to_plotter()
-        assert plotter is not None
-
     def test_with_control_polygon(self, bezier_curve: Bezier) -> None:
         scene = Scene()
         scene.add(bezier_curve, show_control_polygon=True)

--- a/tests/test_viz_scene.py
+++ b/tests/test_viz_scene.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 pv = pytest.importorskip("pyvista")
-pv.OFF_SCREEN = True  # type: ignore[attr-defined]
+pv.OFF_SCREEN = True
 
 from pantr.bezier import Bezier  # noqa: E402
 from pantr.bspline import (  # noqa: E402

--- a/tests/test_viz_scene.py
+++ b/tests/test_viz_scene.py
@@ -1,0 +1,153 @@
+"""Tests for Scene class and plot() convenience function."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pv = pytest.importorskip("pyvista")
+pv.OFF_SCREEN = True  # type: ignore[attr-defined]
+
+from pantr.bezier import Bezier  # noqa: E402
+from pantr.bspline import (  # noqa: E402
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+)
+from pantr.viz import Scene  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bezier_curve() -> Bezier:
+    """Quadratic Bézier curve in 3D."""
+    cp = np.array([[0.0, 0.0, 0.0], [0.5, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bezier_surface() -> Bezier:
+    """Bilinear Bézier surface in 3D."""
+    cp = np.array(
+        [
+            [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.5]],
+        ]
+    )
+    return Bezier(cp)
+
+
+@pytest.fixture()
+def bspline_curve() -> Bspline:
+    """Quadratic B-spline curve in 3D."""
+    space1d = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+    space = BsplineSpace([space1d])
+    cp = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [1.5, 1.0, 0.0],
+            [2.0, 0.0, 0.0],
+        ]
+    )
+    return Bspline(space, cp)
+
+
+# ---------------------------------------------------------------------------
+# Scene
+# ---------------------------------------------------------------------------
+
+
+class TestScene:
+    """Tests for the Scene class."""
+
+    def test_empty_scene(self) -> None:
+        scene = Scene()
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_single_geometry(self, bezier_curve: Bezier) -> None:
+        scene = Scene()
+        result = scene.add(bezier_curve, color="blue")
+        assert result is scene  # chaining
+
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_multiple_geometries(
+        self,
+        bezier_curve: Bezier,
+        bezier_surface: Bezier,
+    ) -> None:
+        scene = Scene()
+        scene.add(bezier_curve, color="red")
+        scene.add(bezier_surface, color="blue")
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_with_control_points(self, bezier_curve: Bezier) -> None:
+        scene = Scene()
+        scene.add(bezier_curve, show_control_points=True)
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_with_control_polygon(self, bezier_curve: Bezier) -> None:
+        scene = Scene()
+        scene.add(bezier_curve, show_control_polygon=True)
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_with_knot_lines(self, bspline_curve: Bspline) -> None:
+        scene = Scene()
+        scene.add(bspline_curve, show_knot_lines=True)
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_chaining(
+        self,
+        bezier_curve: Bezier,
+        bezier_surface: Bezier,
+    ) -> None:
+        plotter = (
+            Scene().add(bezier_curve, color="red").add(bezier_surface, color="blue").to_plotter()
+        )
+        assert plotter is not None
+
+    def test_scalar_field(self) -> None:
+        """Scene with a scalar Bézier field."""
+        cp = np.array([[[0.0], [1.0]], [[2.0], [3.0]]])
+        scalar_bez = Bezier(cp)
+        scene = Scene()
+        scene.add(scalar_bez, scalar_bar=True)
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+    def test_mixed_dimensions(
+        self,
+        bezier_curve: Bezier,
+        bezier_surface: Bezier,
+    ) -> None:
+        """Curves and surfaces in the same scene."""
+        scene = Scene()
+        scene.add(bezier_curve, color="red")
+        scene.add(bezier_surface, color="blue", opacity=0.5)
+        plotter = scene.to_plotter()
+        assert plotter is not None
+
+
+# ---------------------------------------------------------------------------
+# Bspline.plot() / Bezier.plot() convenience methods
+# ---------------------------------------------------------------------------
+
+
+class TestPlotMethods:
+    """Tests for the convenience plot() methods on geometry classes."""
+
+    def test_bezier_has_plot(self, bezier_curve: Bezier) -> None:
+        assert hasattr(bezier_curve, "plot")
+
+    def test_bspline_has_plot(self, bspline_curve: Bspline) -> None:
+        assert hasattr(bspline_curve, "plot")


### PR DESCRIPTION
## Summary

Add `pantr.viz` module for visualizing B-spline and Bezier geometries using pyvista with native VTK higher-order Bezier cell types. Exact polynomial rendering without tessellation.

### Core conversion (commit 1)
- `to_pyvista()`: convert Bspline/Bezier to pyvista `UnstructuredGrid` with VTK Bezier cells (curve, quad, hex)
- `save()`: export to VTK files (.vtu/.vtk) for ParaView
- Support for rational (NURBS) weights, scalar fields, and all parametric dimensions (1D/2D/3D)
- Scalar fields: elevation plot (dim=1), color map or elevation (dim=2), color map (dim=3)
- pyvista fully optional via `[viz]` extra dependency group

### Visualization features (commit 2)
- `Scene` class for composing multiple geometries with per-geometry color, opacity, control points, knot lines
- `plot()` convenience function for quick visualization
- `control_points_mesh()`: point cloud of control points (projected Euclidean for rational)
- `control_polygon_mesh()`: wireframe connecting adjacent control points
- `knot_lines_meshes()`: knot points (dim=1), iso-curves (dim=2), iso-surfaces (dim=3)
- `Bspline.plot()` and `Bezier.plot()` convenience methods (lazy pyvista import)

### New files
- `src/pantr/viz/` — 7 source files (init, lazy import, VTK ordering, VTK cells, control points, knot lines, scene)
- `tests/test_viz_*.py` — 4 test files, 61 tests total

### Config changes
- `pyproject.toml`: added `[viz]` optional dependency group
- `mypy.ini`: added pyvista/vtkmodules ignore sections

## Test plan

- [x] 61 viz tests pass (18 ordering + 18 cells + 14 knot/control + 11 scene)
- [x] 1609 existing tests pass (no regressions)
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean
- [ ] Manual: visual verification with actual spline geometries

🤖 Generated with [Claude Code](https://claude.com/claude-code)