### PR TITLE
feat(parallel): add thread-count control and parallelize B-spline kernels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 :caption: Contents
 
 getting-started
+parallelism
 api/reference
 changelog
 ```
-

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -1,0 +1,148 @@
+# Parallelism
+
+PaNTr uses [Numba](https://numba.pydata.org/) to JIT-compile performance-critical
+kernels and distribute work across CPU cores via `prange` (parallel range).
+This page explains which operations run in parallel, how to control the
+thread count, and how to avoid over-subscription when composing PaNTr with
+other parallel libraries.
+
+## What runs in parallel
+
+The following operations are parallelized over **evaluation points**:
+
+| Operation | Kernel | Parallelism dimension |
+|---|---|---|
+| B-spline basis evaluation (Cox--de Boor) | `_compute_basis_nurbs_book_impl` | points |
+| B-spline basis derivatives (DerBasisFuncs) | `_compute_basis_deriv_nurbs_book_impl` | points |
+| B-spline evaluation (basis + combine) | `_evaluate_Bspline_basis_combine_1D` | points |
+| B-spline derivative evaluation | `_evaluate_Bspline_basis_combine_*_deriv_1D` | points |
+| Bernstein basis evaluation | `_tabulate_Bernstein_basis_1D_core` | points |
+| Legendre basis evaluation | `_tabulate_Legendre_basis_1D_core` | points |
+| Cardinal B-spline basis evaluation | `_tabulate_cardinal_Bspline_basis_1D_core` | points |
+| Bezier evaluation and derivatives | `_evaluate_bezier_1d_core` | points |
+| Bezier split / slice / restrict | `_split_bezier_1d_core` | control point columns |
+| Bezier extraction (`to_beziers`) | `_apply_bezier_extraction_1d_core` | elements |
+
+By default, all available CPU cores are used.
+
+## Controlling the thread count
+
+PaNTr exposes three functions for thread-pool control:
+
+```python
+import pantr
+
+# Query the current thread count
+n = pantr.get_num_threads()
+
+# Set it globally
+pantr.set_num_threads(4)
+
+# Temporarily override with a context manager
+with pantr.num_threads(2):
+    result = space.tabulate_basis(pts)  # uses 2 threads
+# reverts to previous value here
+```
+
+Setting the thread count to **1** effectively serializes all parallel kernels.
+
+### BLAS / LAPACK coordination
+
+NumPy and SciPy operations (matrix multiplies, solves, etc.) use their own
+thread pools (OpenBLAS, MKL, or Apple Accelerate).  When PaNTr's Numba threads
+*and* BLAS threads are both active, the total number of OS threads can exceed
+the number of physical cores, causing **over-subscription** and degraded
+performance.
+
+The `num_threads` context manager accepts a `limit_blas` flag that throttles
+BLAS thread pools for the duration of the block via the
+[threadpoolctl](https://github.com/joblib/threadpoolctl) package (optional
+dependency):
+
+```python
+with pantr.num_threads(4, limit_blas=True):
+    # Numba uses 4 threads; BLAS also limited to 4
+    result = bspline.evaluate(pts)
+```
+
+If `threadpoolctl` is not installed, `limit_blas=True` is silently ignored.
+
+## Usage patterns
+
+### Pattern 1: PaNTr owns all parallelism (default)
+
+The simplest approach.  Every PaNTr call distributes work across all cores
+internally.  User code stays serial:
+
+```python
+# PaNTr parallelizes over 100k points automatically
+result = bspline.evaluate(pts)
+```
+
+Best when each individual call has a large workload (many evaluation points or
+many elements).
+
+### Pattern 2: User owns outer parallelism, PaNTr runs serially
+
+When you have many independent objects (curves, surfaces, patches) to process,
+it is often better to parallelize *across* objects yourself and let each PaNTr
+call run serially.  This avoids nested thread-pool contention:
+
+```python
+import concurrent.futures
+import pantr
+
+pantr.set_num_threads(1)  # each PaNTr call is serial
+
+with concurrent.futures.ThreadPoolExecutor(8) as pool:
+    futures = [pool.submit(curve.evaluate, pts) for curve in curves]
+    results = [f.result() for f in futures]
+```
+
+This works because **Numba releases the GIL** during execution, so multiple
+Python threads genuinely run Numba-compiled code concurrently.
+
+### Pattern 3: Balanced -- user and PaNTr share cores
+
+Split the available cores between PaNTr's inner parallelism and your own outer
+parallelism:
+
+```python
+pantr.set_num_threads(2)  # PaNTr uses 2 threads per call
+
+with concurrent.futures.ThreadPoolExecutor(4) as pool:
+    futures = [pool.submit(curve.evaluate, pts) for curve in curves]
+    results = [f.result() for f in futures]
+# 4 user threads x 2 Numba threads = 8 total on an 8-core machine
+```
+
+## Threading layer
+
+Numba supports several threading backends: **TBB**, **OpenMP**, and
+**workqueue** (the default).  TBB is the recommended choice for PaNTr because
+it handles nested and concurrent parallel regions safely.  To select it, set
+the environment variable before importing PaNTr:
+
+```bash
+export NUMBA_THREADING_LAYER=tbb
+```
+
+or, in Python before any Numba import:
+
+```python
+import os
+os.environ["NUMBA_THREADING_LAYER"] = "tbb"
+```
+
+The maximum number of threads available to Numba is determined by
+`NUMBA_NUM_THREADS` (defaults to the number of logical cores).
+`pantr.set_num_threads(n)` can lower the count at runtime but cannot exceed
+this maximum.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `NUMBA_NUM_THREADS` | Number of logical cores | Maximum thread-pool size |
+| `NUMBA_THREADING_LAYER` | `workqueue` | Threading backend (`tbb`, `omp`, `workqueue`) |
+| `NUMBA_DISABLE_JIT` | `0` | Set to `1` to disable JIT entirely (useful for coverage) |

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -65,7 +65,7 @@ with pantr.num_threads(4, limit_blas=True):
     result = bspline.evaluate(pts)
 ```
 
-If `threadpoolctl` is not installed, `limit_blas=True` is silently ignored.
+If `threadpoolctl` is not installed, `limit_blas=True` emits a warning.
 
 ## Usage patterns
 

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -70,7 +70,7 @@ with pantr.num_threads(4, limit_blas=True):
 package.  If it is not installed, a `UserWarning` is emitted and BLAS threads are
 **not** limited.  Install it with:
 
-    pip install threadpoolctl
+    pip install pantr[parallel]
 ```
 
 ## Usage patterns

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -65,7 +65,13 @@ with pantr.num_threads(4, limit_blas=True):
     result = bspline.evaluate(pts)
 ```
 
-If `threadpoolctl` is not installed, `limit_blas=True` emits a warning.
+```{warning}
+`limit_blas=True` requires the [threadpoolctl](https://github.com/joblib/threadpoolctl)
+package.  If it is not installed, a `UserWarning` is emitted and BLAS threads are
+**not** limited.  Install it with:
+
+    pip install threadpoolctl
+```
 
 ## Usage patterns
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,3 +28,6 @@ ignore_missing_imports = True
 
 [mypy-pytest]
 ignore_missing_imports = True
+
+[mypy-threadpoolctl]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
   "ruff>=0.12.0,<0.13",
   "pre-commit>=3.6,<4",
 ]
+parallel = [
+  "threadpoolctl>=3.0",
+]
 docs = [
   "sphinx>=7.2,<8",
   "sphinx-rtd-theme>=1.3,<2",

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -23,6 +23,7 @@ from . import (
     tolerance,
     transform,
 )
+from ._parallel import get_num_threads, num_threads, set_num_threads
 from .basis import _basis_utils  # noqa: F401
 
 # Package metadata
@@ -38,7 +39,10 @@ __all__ = [
     "bezier",
     "bspline",
     "change_basis",
+    "get_num_threads",
+    "num_threads",
     "quad",
+    "set_num_threads",
     "tolerance",
     "transform",
 ]

--- a/src/pantr/_parallel.py
+++ b/src/pantr/_parallel.py
@@ -24,6 +24,7 @@ Typical usage::
 from __future__ import annotations
 
 import contextlib
+import warnings
 from collections.abc import Generator
 from typing import Any
 
@@ -70,7 +71,7 @@ def num_threads(n: int, *, limit_blas: bool = False) -> Generator[None, None, No
     Args:
         n (int): Desired thread count for the block.
         limit_blas (bool): If ``True``, also limit BLAS/LAPACK threads
-            via ``threadpoolctl``.  Ignored (with no error) when
+            via ``threadpoolctl``.  Emits a warning when
             ``threadpoolctl`` is not installed.  Defaults to ``False``.
 
     Yields:
@@ -92,7 +93,11 @@ def num_threads(n: int, *, limit_blas: bool = False) -> Generator[None, None, No
             blas_ctx = threadpool_limits(limits=n)
             blas_ctx.__enter__()
         except ImportError:
-            pass
+            warnings.warn(
+                "limit_blas=True requires the 'threadpoolctl' package. "
+                "Install it with: pip install threadpoolctl",
+                stacklevel=2,
+            )
 
     try:
         yield

--- a/src/pantr/_parallel.py
+++ b/src/pantr/_parallel.py
@@ -1,0 +1,109 @@
+"""Thread-count control for PaNTr's parallel kernels.
+
+Provides a thin wrapper around Numba's thread-pool configuration so that
+users can limit (or disable) the parallelism used by PaNTr without
+touching environment variables or Numba internals directly.
+
+Typical usage::
+
+    import pantr
+
+    # Query / set globally
+    pantr.set_num_threads(4)
+    print(pantr.get_num_threads())
+
+    # Scoped override (restores previous value on exit)
+    with pantr.num_threads(1):
+        result = space.tabulate_basis(pts)  # runs serially
+
+    # Also throttle BLAS threads (requires threadpoolctl)
+    with pantr.num_threads(4, limit_blas=True):
+        result = space.tabulate_basis(pts)
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Generator
+from typing import Any
+
+import numba as nb
+
+
+def get_num_threads() -> int:
+    """Return the current number of threads used by parallel kernels.
+
+    Returns:
+        int: Active Numba thread-pool size.
+    """
+    return int(nb.get_num_threads())
+
+
+def set_num_threads(n: int) -> None:
+    """Set the number of threads used by parallel kernels.
+
+    Args:
+        n (int): Desired thread count.  Must be >= 1 and at most
+            ``numba.config.NUMBA_NUM_THREADS``.
+
+    Raises:
+        ValueError: If *n* is less than 1 or exceeds the maximum.
+    """
+    max_threads: int = nb.config.NUMBA_NUM_THREADS
+    if n < 1:
+        raise ValueError(f"n must be >= 1, got {n}")
+    if n > max_threads:
+        raise ValueError(f"n must be <= NUMBA_NUM_THREADS ({max_threads}), got {n}")
+    nb.set_num_threads(n)
+
+
+@contextlib.contextmanager
+def num_threads(n: int, *, limit_blas: bool = False) -> Generator[None, None, None]:
+    """Context manager that temporarily sets the parallel thread count.
+
+    On entry the Numba thread-pool size is changed to *n*; on exit the
+    previous value is restored.  When *limit_blas* is ``True`` and the
+    optional ``threadpoolctl`` package is installed, BLAS/LAPACK thread
+    pools (OpenBLAS, MKL, ...) are also limited to *n* threads for the
+    duration of the block.
+
+    Args:
+        n (int): Desired thread count for the block.
+        limit_blas (bool): If ``True``, also limit BLAS/LAPACK threads
+            via ``threadpoolctl``.  Ignored (with no error) when
+            ``threadpoolctl`` is not installed.  Defaults to ``False``.
+
+    Yields:
+        None
+
+    Example:
+        >>> with pantr.num_threads(1):
+        ...     # all pantr operations run serially here
+        ...     pass
+    """
+    prev = get_num_threads()
+    set_num_threads(n)
+
+    blas_ctx: Any = None
+    if limit_blas:
+        try:
+            from threadpoolctl import threadpool_limits  # noqa: PLC0415
+
+            blas_ctx = threadpool_limits(limits=n)
+            blas_ctx.__enter__()
+        except ImportError:
+            pass
+
+    try:
+        yield
+    finally:
+        if blas_ctx is not None:
+            blas_ctx.__exit__(None, None, None)
+        set_num_threads(prev)
+
+
+__all__ = [
+    "get_num_threads",
+    "num_threads",
+    "set_num_threads",
+]

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
-from .._numba_compat import nb_jit
+from .._numba_compat import nb_jit, nb_prange
 from ..basis._basis_1D import _tabulate_Bernstein_basis_1D_impl
 from ..basis._basis_core import _tabulate_Bernstein_basis_deriv_1D_core
 from ..basis._basis_utils import (
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
@@ -49,7 +49,8 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     """Evaluate B-spline basis functions using BasisFuncs (Piegl & Tiller A2.2).
 
     This function implements Algorithm A2.2 from "The NURBS Book" by Piegl & Tiller.
-    Results are written directly to the output arrays (C-style).
+    Results are written directly to the output arrays (C-style).  The outer loop
+    over evaluation points is parallelized via ``prange``.
 
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
@@ -95,13 +96,11 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
         num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
         out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
 
-    out_basis.fill(zero)
+    for pt_id in nb_prange(n_pts):
+        # Thread-local auxiliary arrays (allocated per iteration for safety).
+        left = np.zeros(order, dtype=dtype)
+        right = np.zeros(order, dtype=dtype)
 
-    # Allocate helper arrays once, reused across points
-    left = np.zeros(order, dtype=dtype)
-    right = np.zeros(order, dtype=dtype)
-
-    for pt_id in range(n_pts):
         knot_id = knot_ids[pt_id]
         pt = pts[pt_id]
         N = out_basis[pt_id, :]
@@ -124,7 +123,7 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
     knots: npt.NDArray[np.float32 | np.float64],
@@ -139,7 +138,8 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
     """Evaluate B-spline basis function derivatives using DerBasisFuncs (Piegl & Tiller A2.3).
 
     This function implements Algorithm A2.3 from "The NURBS Book" by Piegl & Tiller.
-    Results are written directly to the output arrays (C-style).
+    Results are written directly to the output arrays (C-style).  The outer loop
+    over evaluation points is parallelized via ``prange``.
 
     The 0th-order slice ``out_deriv[pt, 0, :]`` contains the plain basis values,
     identical to the output of ``_compute_basis_nurbs_book_impl``.  For
@@ -182,15 +182,13 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
         num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
         out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
 
-    out_deriv.fill(zero)
+    for pt_id in nb_prange(n_pts):
+        # Thread-local auxiliary arrays (allocated per iteration for safety).
+        ndu = np.zeros((order, order), dtype=dtype)
+        left = np.zeros(order, dtype=dtype)
+        right = np.zeros(order, dtype=dtype)
+        a = np.zeros((2, n_deriv + 1), dtype=dtype)
 
-    # Helper arrays allocated once and reused across points
-    ndu = np.zeros((order, order), dtype=dtype)  # basis values and knot differences
-    left = np.zeros(order, dtype=dtype)
-    right = np.zeros(order, dtype=dtype)
-    a = np.zeros((2, n_deriv + 1), dtype=dtype)  # rolling two-row buffer for derivative recursion
-
-    for pt_id in range(n_pts):
         knot_id = knot_ids[pt_id]
         pt = pts[pt_id]
 

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy import typing as npt
 
-from .._numba_compat import nb_jit
+from .._numba_compat import nb_jit, nb_prange
 from ..basis._basis_utils import _validate_out_array_1D
 from ..quad import PointsLattice
 from ._bspline_basis_core import (
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _evaluate_Bspline_basis_combine_1D(  # noqa: PLR0913
     control_points: npt.NDArray[np.float32 | np.float64],
@@ -50,7 +50,8 @@ def _evaluate_Bspline_basis_combine_1D(  # noqa: PLR0913
     functions via the Cox-de Boor recurrence (Algorithm A2.2 from Piegl & Tiller),
     then forms the result as a linear combination of the corresponding control points.
     This separates the O(p^2) scalar recurrence from the rank dimension, reducing
-    the work per point from O(p^2 * rank) to O(p^2 + p * rank).
+    the work per point from O(p^2 * rank) to O(p^2 + p * rank).  The combination
+    loop is parallelized over evaluation points via ``prange``.
 
     Args:
         control_points (npt.NDArray[np.float32 | np.float64]): Control-point array of
@@ -84,7 +85,7 @@ def _evaluate_Bspline_basis_combine_1D(  # noqa: PLR0913
     _compute_basis_nurbs_book_impl(knots, degree, periodic, tol, pts, basis, first_basis)
 
     rank = control_points.shape[1]
-    for i in range(n_pts):
+    for i in nb_prange(n_pts):
         s = first_basis[i]
         for k in range(rank):
             total = zero
@@ -180,7 +181,7 @@ def _evaluate_Bspline_1D(
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _evaluate_Bspline_basis_combine_all_deriv_1D(  # noqa: PLR0913
     control_points: npt.NDArray[np.float32 | np.float64],
@@ -230,7 +231,7 @@ def _evaluate_Bspline_basis_combine_all_deriv_1D(  # noqa: PLR0913
         knots, degree, periodic, tol, n_deriv, pts, basis_deriv, first_basis
     )
 
-    for i in range(n_pts):
+    for i in nb_prange(n_pts):
         s = first_basis[i]
         for k in range(n_deriv + 1):
             for r in range(rank):
@@ -246,7 +247,7 @@ def _evaluate_Bspline_basis_combine_all_deriv_1D(  # noqa: PLR0913
 @nb_jit(
     nopython=True,
     cache=True,
-    parallel=False,
+    parallel=True,
 )
 def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
     control_points: npt.NDArray[np.float32 | np.float64],
@@ -296,7 +297,7 @@ def _evaluate_Bspline_basis_combine_deriv_1D(  # noqa: PLR0913
         knots, degree, periodic, tol, n_deriv, pts, basis_deriv, first_basis
     )
 
-    for i in range(n_pts):
+    for i in nb_prange(n_pts):
         s = first_basis[i]
         for r in range(rank):
             total = zero

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -21,7 +21,10 @@ def test_package_all_exports() -> None:
         "bezier",
         "bspline",
         "change_basis",
+        "get_num_threads",
+        "num_threads",
         "quad",
+        "set_num_threads",
         "tolerance",
         "transform",
     }

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,97 @@
+"""Tests for the parallel thread-count control module."""
+
+from __future__ import annotations
+
+import pytest
+
+import pantr
+from pantr._parallel import get_num_threads, num_threads, set_num_threads
+
+
+class TestGetSetNumThreads:
+    """Tests for get_num_threads / set_num_threads."""
+
+    def test_get_returns_positive(self) -> None:
+        """get_num_threads returns a positive integer."""
+        n = get_num_threads()
+        assert isinstance(n, int)
+        assert n >= 1
+
+    def test_set_and_get_roundtrip(self) -> None:
+        """set_num_threads followed by get_num_threads returns the set value."""
+        prev = get_num_threads()
+        try:
+            set_num_threads(1)
+            assert get_num_threads() == 1
+        finally:
+            set_num_threads(prev)
+
+    def test_set_zero_raises(self) -> None:
+        """set_num_threads(0) raises ValueError."""
+        with pytest.raises(ValueError, match="n must be >= 1"):
+            set_num_threads(0)
+
+    def test_set_negative_raises(self) -> None:
+        """set_num_threads(-1) raises ValueError."""
+        with pytest.raises(ValueError, match="n must be >= 1"):
+            set_num_threads(-1)
+
+    def test_set_exceeds_max_raises(self) -> None:
+        """set_num_threads beyond NUMBA_NUM_THREADS raises ValueError."""
+        import numba as nb  # noqa: PLC0415
+
+        max_threads: int = nb.config.NUMBA_NUM_THREADS
+        with pytest.raises(ValueError, match="NUMBA_NUM_THREADS"):
+            set_num_threads(max_threads + 1)
+
+
+class TestNumThreadsContextManager:
+    """Tests for the num_threads context manager."""
+
+    def test_restores_previous_value(self) -> None:
+        """Thread count is restored after the context manager exits."""
+        prev = get_num_threads()
+        with num_threads(1):
+            assert get_num_threads() == 1
+        assert get_num_threads() == prev
+
+    def test_restores_on_exception(self) -> None:
+        """Thread count is restored even when an exception is raised."""
+        prev = get_num_threads()
+        with pytest.raises(RuntimeError), num_threads(1):
+            raise RuntimeError("test error")
+        assert get_num_threads() == prev
+
+    def test_nested_context_managers(self) -> None:
+        """Nested context managers restore correctly."""
+        prev = get_num_threads()
+        with num_threads(1):
+            assert get_num_threads() == 1
+            with num_threads(1):
+                assert get_num_threads() == 1
+            assert get_num_threads() == 1
+        assert get_num_threads() == prev
+
+    def test_limit_blas_without_threadpoolctl(self) -> None:
+        """limit_blas=True does not error when threadpoolctl is absent."""
+        prev = get_num_threads()
+        # This should not raise even if threadpoolctl is not installed.
+        with num_threads(1, limit_blas=True):
+            assert get_num_threads() == 1
+        assert get_num_threads() == prev
+
+
+class TestPublicReExports:
+    """Tests for the public API re-exports."""
+
+    def test_set_num_threads_reexported(self) -> None:
+        """pantr.set_num_threads is the same function as _parallel.set_num_threads."""
+        assert pantr.set_num_threads is set_num_threads
+
+    def test_get_num_threads_reexported(self) -> None:
+        """pantr.get_num_threads is the same function as _parallel.get_num_threads."""
+        assert pantr.get_num_threads is get_num_threads
+
+    def test_num_threads_reexported(self) -> None:
+        """pantr.num_threads is the same function as _parallel.num_threads."""
+        assert pantr.num_threads is num_threads

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -73,10 +73,9 @@ class TestNumThreadsContextManager:
         assert get_num_threads() == prev
 
     def test_limit_blas_without_threadpoolctl(self) -> None:
-        """limit_blas=True does not error when threadpoolctl is absent."""
+        """limit_blas=True warns when threadpoolctl is absent."""
         prev = get_num_threads()
-        # This should not raise even if threadpoolctl is not installed.
-        with num_threads(1, limit_blas=True):
+        with pytest.warns(UserWarning, match="threadpoolctl"), num_threads(1, limit_blas=True):
             assert get_num_threads() == 1
         assert get_num_threads() == prev
 


### PR DESCRIPTION
## Summary
- Add `pantr.set_num_threads()`, `pantr.get_num_threads()`, and `pantr.num_threads()` context manager for controlling parallel thread count
- Optional BLAS/LAPACK thread coordination via `threadpoolctl` (`limit_blas=True`)
- Parallelize B-spline basis evaluation (`_compute_basis_nurbs_book_impl`, `_compute_basis_deriv_nurbs_book_impl`) over evaluation points using `prange` with thread-local auxiliary arrays
- Parallelize B-spline evaluation combine kernels (`_evaluate_Bspline_basis_combine_1D`, `_evaluate_Bspline_basis_combine_all_deriv_1D`, `_evaluate_Bspline_basis_combine_deriv_1D`) over points
- Add `threadpoolctl` to mypy ignore list

## Test plan
- [x] All 1621 existing tests pass
- [x] New tests for `set_num_threads`, `get_num_threads`, `num_threads` context manager (12 tests)
- [x] Pre-PR checks pass (ruff lint, ruff format, mypy, pytest)

Generated with [Claude Code](https://claude.com/claude-code)