### PR TITLE
feat(bspline): add degree reduction via least-squares approximation

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -15,7 +15,7 @@ import numpy as np
 from numpy import typing as npt
 
 from .._transform_control_points import _apply_affine_to_control_points
-from ._bspline_degree import _degree_elevate_bspline
+from ._bspline_degree import _degree_elevate_bspline, _degree_reduce_bspline
 from ._bspline_derivative import _derivative_bspline
 from ._bspline_eval import _evaluate_Bspline, _evaluate_Bspline_deriv
 from ._bspline_knot_insertion import (
@@ -334,6 +334,58 @@ class Bspline:
             raise ValueError("At least one degree increment must be positive.")
 
         return _degree_elevate_bspline(self, increments)
+
+    def reduce_degree(self, degree_decrements: int | Sequence[int]) -> Bspline:
+        """Reduce the polynomial degree of the B-spline via least-squares approximation.
+
+        Decomposes to Bézier segments, reduces each segment using bidiagonal
+        least-squares (Givens QR), and coarsens the knot vector to restore
+        the original continuity structure.
+
+        Unlike :meth:`elevate_degree`, this operation is **not exact** in
+        general: the result is an approximation of the original mapping.
+
+        Args:
+            degree_decrements (int | Sequence[int]): Number of degrees to
+                reduce. If an integer, the same decrement is applied to all
+                parametric directions. If a sequence, must have length equal
+                to the B-spline dimension.
+
+        Returns:
+            Bspline: A new B-spline with reduced degrees.
+
+        Raises:
+            ValueError: If any degree decrement is negative.
+            ValueError: If all degree decrements are zero.
+            ValueError: If the number of decrements does not match the dimension.
+            ValueError: If any decrement exceeds the current degree in that
+                direction.
+        """
+        if isinstance(degree_decrements, int):
+            decrements = (degree_decrements,) * self.dim
+        else:
+            decrements = tuple(degree_decrements)
+
+        if len(decrements) != self.dim:
+            raise ValueError(
+                f"Number of degree decrements ({len(decrements)}) "
+                f"must match dimension ({self.dim})."
+            )
+
+        if any(dec < 0 for dec in decrements):
+            raise ValueError("Degree decrements must be non-negative.")
+
+        if all(dec == 0 for dec in decrements):
+            raise ValueError("At least one degree decrement must be positive.")
+
+        for d, dec in enumerate(decrements):
+            if dec > self.degree[d]:
+                raise ValueError(
+                    f"Degree decrement ({dec}) in direction {d} exceeds "
+                    f"current degree ({self.degree[d]})."
+                )
+
+        return _degree_reduce_bspline(self, decrements)
 
     def insert_knots(
         self,

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -113,7 +113,7 @@ def _degree_elevate_bspline(bspline: Bspline, degree_increments: tuple[int, ...]
     return Bspline(new_space, ctrl, is_rational=orig_is_rational)
 
 
-def _coarsen_knots_after_reduction(
+def _coarsen_knots_after_reduction(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
     new_degree: int,
     ctrl: npt.NDArray[np.float32 | np.float64],

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -1,8 +1,8 @@
-"""Layer 2 implementation for B-spline degree elevation.
+"""Layer 2 implementation for B-spline degree elevation and reduction.
 
 This module provides the validation and array manipulation logic to
-prepare inputs for the Layer 3 degree elevation kernels and wrap their
-outputs back into a new B-spline degree elevation implementation.
+prepare inputs for the Layer 3 degree elevation/reduction kernels and
+wrap their outputs back into a new B-spline.
 """
 
 from __future__ import annotations
@@ -10,9 +10,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 
-from ._bspline_degree_core import _degree_elevate_1d_core
+from ._bspline_degree_core import _degree_elevate_1d_core, _degree_reduce_1d_core
 from ._bspline_knot_insertion import _to_open_bspline_1d_impl, _to_periodic_bspline_1d_impl
+from ._bspline_knot_removal import _remove_knot_bspline_1d_impl
 from ._bspline_knots import _get_unique_knots_and_multiplicity_impl
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_nd import BsplineSpace
@@ -104,6 +106,170 @@ def _degree_elevate_bspline(bspline: Bspline, degree_increments: tuple[int, ...]
             new_spaces_1d.append(space_1d)
 
     # Assemble the new B-spline
+    from . import Bspline  # noqa: PLC0415
+
+    new_space = BsplineSpace(new_spaces_1d)
+
+    return Bspline(new_space, ctrl, is_rational=orig_is_rational)
+
+
+def _coarsen_knots_after_reduction(
+    knots: npt.NDArray[np.float32 | np.float64],
+    new_degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    orig_unique_knots: npt.NDArray[np.float32 | np.float64],
+    orig_mults: npt.NDArray[np.int_],
+    degree_decrement: int,
+    tol_space: float,
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Remove excess knots from a Bézier-form B-spline after degree reduction.
+
+    After degree reduction the output is in Bézier form (all interior
+    breakpoints have multiplicity ``new_degree``).  This function removes
+    excess copies of each interior knot so that the final multiplicity is
+    ``max(1, m_i - t)`` where ``m_i`` is the original multiplicity and ``t``
+    is the degree decrement, restoring the original continuity structure.
+
+    Args:
+        knots: Knot vector of the Bézier-form reduced B-spline.
+        new_degree: Degree after reduction.
+        ctrl: Control points of shape ``(n_pts, rank)``.
+        orig_unique_knots: Unique interior knot values of the *original*
+            B-spline (before reduction).
+        orig_mults: Corresponding multiplicities of the original interior knots.
+        degree_decrement: How many degrees were reduced.
+        tol_space: Tolerance for knot comparison.
+
+    Returns:
+        tuple: ``(coarsened_knots, coarsened_ctrl)``.
+    """
+    for idx in range(len(orig_unique_knots)):
+        knot_val = float(orig_unique_knots[idx])
+        m_orig = int(orig_mults[idx])
+        target_mult = max(1, m_orig - degree_decrement)
+        # Current multiplicity in the Bézier form is new_degree.
+        num_to_remove = new_degree - target_mult
+        if num_to_remove <= 0:
+            continue
+        # Use a large tolerance for deviation since reduction is approximate.
+        tol_dev = np.inf
+        knots, ctrl, _removed = _remove_knot_bspline_1d_impl(
+            knots, new_degree, ctrl, knot_val, num_to_remove, tol_space, tol_dev
+        )
+    return knots, ctrl
+
+
+def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...]) -> Bspline:
+    """Reduce the degree of a B-spline.
+
+    For each direction with a positive decrement:
+
+    1. Decompose to Bézier segments and reduce each via least-squares.
+    2. Coarsen knots to restore the original continuity structure.
+    3. Handle periodic directions by round-tripping through open form.
+
+    Args:
+        bspline (Bspline): Original B-spline.
+        degree_decrements (tuple[int, ...]): Decrements for each dimension.
+
+    Returns:
+        Bspline: New B-spline with reduced degrees.
+    """
+    dim = bspline.dim
+    ctrl = bspline.control_points
+
+    orig_is_rational = bspline.is_rational
+
+    new_spaces_1d: list[BsplineSpace1D] = []
+
+    for i in range(dim):
+        dec = degree_decrements[i]
+        space_1d = bspline.space.spaces[i]
+
+        if dec > 0:
+            is_periodic = space_1d.periodic
+            tol = float(space_1d.tolerance)
+
+            # Record original interior knot multiplicities before reduction.
+            orig_unique, orig_mults = _get_unique_knots_and_multiplicity_impl(
+                space_1d.knots, space_1d.degree, tol, in_domain=True
+            )
+            # Exclude boundary knots (first and last unique in-domain knots)
+            # from the coarsening — they are clamped and stay at full multiplicity.
+            if len(orig_unique) > 2:  # noqa: PLR2004
+                interior_knots = orig_unique[1:-1]
+                interior_mults = orig_mults[1:-1]
+            else:
+                interior_knots = np.empty(0, dtype=orig_unique.dtype)
+                interior_mults = np.empty(0, dtype=orig_mults.dtype)
+
+            moved_ctrl = np.moveaxis(ctrl, i, 0)
+            orig_shape = moved_ctrl.shape
+
+            pts_2d = moved_ctrl.reshape(orig_shape[0], -1)
+            if not pts_2d.flags.c_contiguous:
+                pts_2d = np.ascontiguousarray(pts_2d)
+
+            if is_periodic:
+                m_bdy = int(orig_mults[0])
+
+                open_knots, open_pts_2d = _to_open_bspline_1d_impl(
+                    space_1d.knots, space_1d.degree, pts_2d, True, tol
+                )
+
+                new_pts_2d, new_knots = _degree_reduce_1d_core(
+                    space_1d.degree, open_pts_2d, open_knots, dec
+                )
+
+                new_degree = space_1d.degree - dec
+
+                # Coarsen interior knots.
+                if len(interior_knots) > 0:
+                    new_knots, new_pts_2d = _coarsen_knots_after_reduction(
+                        new_knots,
+                        new_degree,
+                        new_pts_2d,
+                        interior_knots,
+                        interior_mults,
+                        dec,
+                        tol,
+                    )
+
+                m_bdy_new = m_bdy - dec
+                per_knots, new_pts_2d = _to_periodic_bspline_1d_impl(
+                    new_knots, new_degree, new_pts_2d, m_bdy_new, tol
+                )
+
+                new_space_1d = BsplineSpace1D(per_knots, new_degree, periodic=True)
+            else:
+                new_pts_2d, new_knots = _degree_reduce_1d_core(
+                    space_1d.degree, pts_2d, space_1d.knots, dec
+                )
+                new_degree = space_1d.degree - dec
+
+                # Coarsen interior knots.
+                if len(interior_knots) > 0:
+                    new_knots, new_pts_2d = _coarsen_knots_after_reduction(
+                        new_knots,
+                        new_degree,
+                        new_pts_2d,
+                        interior_knots,
+                        interior_mults,
+                        dec,
+                        tol,
+                    )
+
+                new_space_1d = BsplineSpace1D(new_knots, new_degree)
+
+            # Restore shape.
+            new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
+            new_moved_ctrl = new_pts_2d.reshape(new_shape)
+            ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+
+            new_spaces_1d.append(new_space_1d)
+        else:
+            new_spaces_1d.append(space_1d)
+
     from . import Bspline  # noqa: PLC0415
 
     new_space = BsplineSpace(new_spaces_1d)

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -1,10 +1,12 @@
-"""Numba kernels for B-spline degree elevation.
+"""Numba kernels for B-spline degree elevation and reduction.
 
-These kernels implement the algorithms from The NURBS Book / MATLAB NURBS Toolbox layer.
+These kernels implement the algorithms from The NURBS Book / MATLAB NURBS
+Toolbox layer and the bidiagonal least-squares reduction from algoim.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
-    For general use, call _degree_elevate_bspline instead.
+    For general use, call ``_degree_elevate_bspline`` or
+    ``_degree_reduce_bspline`` instead.
 """
 
 import math
@@ -212,3 +214,242 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
                 ik[kind + i] = ub
 
     return ic[:cind].copy(), ik[: kind + ph + 1].copy()
+
+
+@nb_jit(nopython=True, cache=True)
+def _reduce_bezier_segment(  # noqa: PLR0912
+    degree: int,
+    bpts: npt.NDArray[Any],
+    degree_decrement: int,
+    out: npt.NDArray[Any],
+) -> None:
+    """Degree-reduce a single Bézier segment into a pre-allocated output.
+
+    Implements the same bidiagonal least-squares algorithm as
+    :func:`~pantr.bezier._bezier_core._degree_reduce_bezier_1d_core`.
+    The code is duplicated here because a circular import prevents
+    calling the Bézier kernel directly (``_bezier_core`` already
+    imports ``_bincoeff`` from this module).
+
+    Args:
+        degree (int): Current polynomial degree (``p >= 1``).
+        bpts (npt.NDArray[Any]): Input Bézier control points of shape
+            ``(p + 1, rank)``.
+        degree_decrement (int): Number of degrees to reduce (``1 <= t <= p``).
+        out (npt.NDArray[Any]): Pre-allocated output of shape
+            ``(p - t + 1, rank)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_degree_reduce_bspline` instead.
+    """
+    rank = bpts.shape[1]
+
+    # Pre-allocate scratch arrays sized for the largest step (initial degree).
+    diag = np.empty(degree, dtype=np.float64)
+    sup = np.empty(degree, dtype=np.float64)
+    rhs = np.empty(degree + 1, dtype=np.float64)
+    # Store Givens cosines/sines to avoid recomputing per rank component.
+    cs_arr = np.empty(degree, dtype=np.float64)
+    sn_arr = np.empty(degree, dtype=np.float64)
+
+    cur = np.empty((degree + 1, rank), dtype=bpts.dtype)
+    for i in range(degree + 1):
+        for r in range(rank):
+            cur[i, r] = bpts[i, r]
+
+    cur_deg = degree
+
+    for _step in range(degree_decrement):
+        p = cur_deg
+        n_new = p
+
+        nxt = np.empty((n_new, rank), dtype=bpts.dtype)
+
+        # Compute Givens rotation coefficients (independent of rank).
+        for k in range(p):
+            diag[k] = 1.0 - np.float64(k) / np.float64(p)
+        for k in range(p):
+            sup[k] = 0.0
+
+        for k in range(p):
+            bk = np.float64(k + 1) / np.float64(p)
+            ak = diag[k]
+            if bk == 0.0:
+                cs = 1.0
+                sn = 0.0
+            elif abs(bk) > abs(ak):
+                tmp = ak / bk
+                sn = 1.0 / np.sqrt(1.0 + tmp * tmp)
+                cs = tmp * sn
+            else:
+                tmp = bk / ak
+                cs = 1.0 / np.sqrt(1.0 + tmp * tmp)
+                sn = tmp * cs
+
+            cs_arr[k] = cs
+            sn_arr[k] = sn
+            diag[k] = cs * ak + sn * bk
+            if k + 1 < p:
+                sup[k] = sn * diag[k + 1]
+                diag[k + 1] = cs * diag[k + 1]
+
+        # Apply rotations and back-substitute for each rank component.
+        for r in range(rank):
+            for k in range(p + 1):
+                rhs[k] = np.float64(cur[k, r])
+
+            for k in range(p):
+                cs = cs_arr[k]
+                sn = sn_arr[k]
+                rk = rhs[k]
+                rhs[k] = cs * rk + sn * rhs[k + 1]
+                rhs[k + 1] = -sn * rk + cs * rhs[k + 1]
+
+            nxt[p - 1, r] = bpts.dtype.type(rhs[p - 1] / diag[p - 1])
+            for k in range(p - 2, -1, -1):
+                nxt[k, r] = bpts.dtype.type((rhs[k] - sup[k] * np.float64(nxt[k + 1, r])) / diag[k])
+
+        cur = nxt
+        cur_deg = p - 1
+
+    for i in range(out.shape[0]):
+        for r in range(rank):
+            out[i, r] = cur[i, r]
+
+
+@nb_jit(nopython=True, cache=True)
+def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
+    degree: int,
+    ctrl: npt.NDArray[Any],
+    knots: npt.NDArray[Any],
+    degree_decrement: int,
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any]]:
+    """Degree reduce a B-spline curve by ``degree_decrement``.
+
+    Decomposes the B-spline into Bézier segments by iterating through knot
+    spans (same alpha-blending as the elevation kernel), reduces each segment
+    via bidiagonal least-squares, and stitches the results into a B-spline in
+    Bézier form (C0 at every interior breakpoint).
+
+    Args:
+        degree (int): Original degree.
+        ctrl (npt.NDArray[Any]): Control points of shape ``(n_pts, rank)``.
+        knots (npt.NDArray[Any]): Knot vector of shape ``(n_knots,)``.
+        degree_decrement (int): Number of degrees to reduce (``1 <= t <= degree``).
+
+    Returns:
+        tuple[npt.NDArray[Any], npt.NDArray[Any]]: ``(reduced_ctrl, reduced_knots)``
+        in Bézier form — all interior breakpoints have multiplicity ``new_degree``
+        (C0 continuity).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_degree_reduce_bspline` instead.
+    """
+    n_pts = ctrl.shape[0]
+    rank = ctrl.shape[1]
+    d = degree
+    t = degree_decrement
+    new_deg = d - t
+
+    n = n_pts - 1
+    m = n + d + 1  # last knot index
+
+    bpts = np.zeros((d + 1, rank), dtype=ctrl.dtype)
+    Nextbpts = np.zeros((d + 1, rank), dtype=ctrl.dtype)
+    alfs = np.zeros(d, dtype=np.float64)
+    rbpts = np.empty((new_deg + 1, rank), dtype=ctrl.dtype)
+
+    # Over-allocate output arrays (same pattern as elevation kernel).
+    max_new_knots = len(knots) + len(knots)
+    oc = np.empty((n_pts + len(knots), rank), dtype=ctrl.dtype)
+    ok = np.empty(max_new_knots, dtype=np.float64)
+
+    # Initialise: first boundary knots and first Bézier segment.
+    ua = knots[0]
+    for i in range(new_deg + 1):
+        ok[i] = ua
+    kind = new_deg + 1
+
+    for i in range(d + 1):
+        for ii in range(rank):
+            bpts[i, ii] = ctrl[i, ii]
+
+    cind = 0  # output control point index
+    a = d
+    b = d + 1
+    r = -1
+
+    while b < m:
+        # Find next distinct knot.
+        i = b
+        while b < m and knots[b] == knots[b + 1]:
+            b += 1
+        mul = b - i + 1
+        ub = knots[b]
+        oldr = r
+        r = d - mul
+
+        # Extract Bézier control points for the current span.
+        if r > 0:
+            numer = ub - ua
+            for q in range(d, mul, -1):
+                alfs[q - mul - 1] = numer / (knots[a + q] - ua)
+
+            for j in range(1, r + 1):
+                save = r - j
+                s = mul + j
+                for q in range(d, s - 1, -1):
+                    for ii in range(rank):
+                        bpts[q, ii] = (
+                            alfs[q - s] * bpts[q, ii] + (1.0 - alfs[q - s]) * bpts[q - 1, ii]
+                        )
+                for ii in range(rank):
+                    Nextbpts[save, ii] = bpts[d, ii]
+
+        # --- Reduce the current Bézier segment ---
+        _reduce_bezier_segment(d, bpts, t, rbpts)
+
+        # If this is the very first segment, write all control points.
+        # Otherwise, average the shared boundary point with the previous
+        # segment's last point, then write the interior + end points.
+        if cind == 0:
+            # First segment: write all new_deg + 1 points.
+            for j in range(new_deg + 1):
+                for ii in range(rank):
+                    oc[cind, ii] = rbpts[j, ii]
+                cind += 1
+        else:
+            # Average the shared boundary point.
+            for ii in range(rank):
+                oc[cind - 1, ii] = (oc[cind - 1, ii] + rbpts[0, ii]) * 0.5
+            # Write interior and end points.
+            for j in range(1, new_deg + 1):
+                for ii in range(rank):
+                    oc[cind, ii] = rbpts[j, ii]
+                cind += 1
+
+        # Write interior breakpoint knots (multiplicity = new_deg for C0).
+        if a != d:
+            for _i in range(new_deg):
+                ok[kind] = ua
+                kind += 1
+
+        # Prepare for next span.
+        if b < m:
+            for j in range(r):
+                for ii in range(rank):
+                    bpts[j, ii] = Nextbpts[j, ii]
+            for j in range(r, d + 1):
+                for ii in range(rank):
+                    bpts[j, ii] = ctrl[b - d + j, ii]
+            a = b
+            b += 1
+            ua = ub
+        else:
+            # Write closing knots.
+            for i in range(new_deg + 1):
+                ok[kind + i] = ub
+
+    return oc[:cind].copy(), ok[: kind + new_deg + 1].copy()

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -388,7 +388,7 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
             b += 1
         mul = b - i + 1
         ub = knots[b]
-        oldr = r
+        oldr = r  # noqa: F841
         r = d - mul
 
         # Extract Bézier control points for the current span.

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -1,4 +1,4 @@
-"""Tests for Bézier degree reduction."""
+"""Tests for Bézier and B-spline degree reduction."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from pantr.bezier import Bezier
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
 
 
 def _make_bezier_1d(ctrl: list[list[float]], rational: bool = False) -> Bezier:
@@ -186,3 +187,156 @@ class TestBezierReduceDegreeFloat32:
         reduced = b.elevate_degree(2).reduce_degree(2)
         assert reduced.control_points.dtype == np.float32
         np.testing.assert_allclose(reduced.control_points, b.control_points, atol=1e-5)
+
+
+# ===========================================================================
+# B-spline degree reduction
+# ===========================================================================
+
+
+def _make_bspline_1d(knots: list[float], degree: int, ctrl: list[list[float]]) -> Bspline:
+    """Create a simple 1D open B-spline."""
+    space = BsplineSpace([BsplineSpace1D(np.array(knots), degree)])
+    return Bspline(space, np.array(ctrl))
+
+
+class TestBsplineReduceDegreeRoundTrip:
+    """Elevate by t then reduce by t should recover the original geometry."""
+
+    def test_single_segment_linear(self) -> None:
+        """Single-segment linear B-spline → elevate 2 → reduce 2."""
+        bsp = _make_bspline_1d([0, 0, 1, 1], 1, [[0.0], [1.0]])
+        reduced = bsp.elevate_degree(2).reduce_degree(2)
+        pts = np.linspace(0, 1, 20)
+        np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-13)
+
+    def test_multi_segment_quadratic(self) -> None:
+        """Quadratic B-spline with interior knot → elevate 2 → reduce 2."""
+        bsp = _make_bspline_1d([0, 0, 0, 0.5, 1, 1, 1], 2, [[0.0], [1.0], [0.0], [1.0]])
+        reduced = bsp.elevate_degree(2).reduce_degree(2)
+        pts = np.linspace(0, 1, 30)
+        np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-12)
+
+    def test_multi_segment_cubic(self) -> None:
+        """Cubic B-spline with multiple interior knots."""
+        knots = [0, 0, 0, 0, 0.25, 0.5, 0.75, 1, 1, 1, 1]
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((7, 2))
+        bsp = _make_bspline_1d(knots, 3, ctrl.tolist())
+        reduced = bsp.elevate_degree(1).reduce_degree(1)
+        pts = np.linspace(0, 1, 50)
+        np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-12)
+
+    def test_2d_surface(self) -> None:
+        """2D B-spline surface → elevate → reduce."""
+        knots1 = np.array([0.0, 0.0, 1.0, 1.0])
+        knots2 = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots1, 1), BsplineSpace1D(knots2, 2)])
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((2, 3, 2))
+        bsp = Bspline(space, ctrl)
+
+        reduced = bsp.elevate_degree([1, 1]).reduce_degree([1, 1])
+
+        pts = rng.random((20, 2))
+        np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-12)
+
+    def test_rational(self) -> None:
+        """Rational B-spline (NURBS): elevate then reduce."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        ctrl_h = np.array([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0 / np.sqrt(2)], [0.0, 1.0, 1.0]])
+        space = BsplineSpace([BsplineSpace1D(knots, 2)])
+        bsp = Bspline(space, ctrl_h, is_rational=True)
+
+        reduced = bsp.elevate_degree(1).reduce_degree(1)
+        assert reduced.is_rational
+
+        pts = np.linspace(0, 1, 20)
+        np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-12)
+
+
+class TestBsplineReduceDegreePeriodic:
+    """Test degree reduction for periodic B-splines."""
+
+    @pytest.mark.parametrize(
+        "degree,continuity,dec",
+        [
+            (2, None, 1),
+            (3, None, 1),
+            (3, None, 2),
+            (3, 1, 1),
+        ],
+    )
+    def test_periodic_preserves_geometry(
+        self, degree: int, continuity: int | None, dec: int
+    ) -> None:
+        """Elevate then reduce a periodic B-spline preserves geometry."""
+        knots = create_uniform_periodic(num_intervals=4, degree=degree, continuity=continuity)
+        space = BsplineSpace([BsplineSpace1D(knots, degree, periodic=True)])
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((space.num_total_basis, 2))
+        bsp = Bspline(space, ctrl)
+
+        reduced = bsp.elevate_degree(dec).reduce_degree(dec)
+
+        assert reduced.space.spaces[0].periodic
+        assert reduced.degree == (degree,)
+
+        pts = np.linspace(0.01, 0.99, 50)
+        orig = bsp.to_open_bspline().evaluate(pts)
+        red = reduced.to_open_bspline().evaluate(pts)
+        np.testing.assert_allclose(orig, red, atol=1e-11)
+
+    def test_mixed_periodic_open_2d(self) -> None:
+        """2D mixed periodic/open B-spline: elevate then reduce."""
+        knots_per = create_uniform_periodic(num_intervals=4, degree=2)
+        knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        space = BsplineSpace(
+            [
+                BsplineSpace1D(knots_per, 2, periodic=True),
+                BsplineSpace1D(knots_open, 2),
+            ]
+        )
+        rng = np.random.default_rng(42)
+        ctrl = rng.random((*space.num_basis, 2))
+        bsp = Bspline(space, ctrl)
+
+        reduced = bsp.elevate_degree([1, 1]).reduce_degree([1, 1])
+
+        assert reduced.space.spaces[0].periodic
+        assert not reduced.space.spaces[1].periodic
+        assert reduced.degree == (2, 2)
+
+        pts = rng.random((30, 2))
+        pts[:, 0] = pts[:, 0] * 0.98 + 0.01
+        orig = bsp.to_open_bspline().evaluate(pts)
+        red = reduced.to_open_bspline().evaluate(pts)
+        np.testing.assert_allclose(orig, red, atol=1e-11)
+
+
+class TestBsplineReduceDegreeErrors:
+    """Test that invalid inputs raise appropriate errors."""
+
+    def test_decrement_exceeds_degree(self) -> None:
+        """Decrement > degree should raise ValueError."""
+        bsp = _make_bspline_1d([0, 0, 1, 1], 1, [[0.0], [1.0]])
+        with pytest.raises(ValueError, match=r"exceeds current degree"):
+            bsp.reduce_degree(2)
+
+    def test_negative_decrement(self) -> None:
+        """Negative decrement should raise ValueError."""
+        bsp = _make_bspline_1d([0, 0, 1, 1], 1, [[0.0], [1.0]])
+        with pytest.raises(ValueError, match=r"non-negative"):
+            bsp.reduce_degree(-1)
+
+    def test_all_zero_decrements(self) -> None:
+        """All-zero decrements should raise ValueError."""
+        bsp = _make_bspline_1d([0, 0, 1, 1], 1, [[0.0], [1.0]])
+        with pytest.raises(ValueError, match=r"(?i)at least one"):
+            bsp.reduce_degree(0)
+
+    def test_wrong_length(self) -> None:
+        """Wrong number of decrements should raise ValueError."""
+        bsp = _make_bspline_1d([0, 0, 1, 1], 1, [[0.0], [1.0]])
+        with pytest.raises(ValueError, match=r"must match dimension"):
+            bsp.reduce_degree((1, 1))


### PR DESCRIPTION
## Summary

- Add `Bspline.reduce_degree()` method — approximate inverse of `elevate_degree()`
- Layer 3 Numba kernel (`_degree_reduce_1d_core`) decomposes to Bezier segments, reduces each via bidiagonal least-squares (Givens QR), and stitches into C0 form
- Layer 2 (`_degree_reduce_bspline`) coarsens knots via existing `_remove_knot_bspline_1d_impl` to restore original continuity structure (NURBS Book / SplineLib pattern)
- Supports open, periodic, multi-dimensional, and rational B-splines

**Depends on:** #93 (Bezier degree reduction)

## Test plan

- [x] Round-trip tests: elevate by t then reduce by t (single/multi-segment, 2D, rational)
- [x] Periodic B-splines: preserves periodicity and geometry
- [x] Mixed periodic/open 2D surfaces
- [x] Error cases: decrement > degree, negative, all-zero, wrong length
- [x] Pre-PR checks pass (ruff, mypy, pytest)

Generated with [Claude Code](https://claude.com/claude-code)