### PR TITLE
feat(cad): complete constructive geometry module

### DIFF
--- a/docs/constructive-geometry.md
+++ b/docs/constructive-geometry.md
@@ -1,0 +1,195 @@
+# Constructive Geometry
+
+The `pantr.cad` module provides CAD-style functions for building B-spline
+curves, surfaces, and volumes from geometric descriptions.  All functions
+return {class}`~pantr.bspline.Bspline` objects that integrate with the
+rest of PaNTr (evaluation, derivatives, knot insertion, degree elevation, etc.).
+
+## Primitives
+
+Primitives create B-spline objects directly from geometric parameters.
+All produce rank-3 (3D) output; lower-dimensional inputs are zero-padded.
+
+### Lines and multilinear patches
+
+```python
+from pantr.cad import line, bilinear, trilinear
+
+crv = line([0, 0, 0], [1, 0, 0])           # degree-1 curve
+srf = bilinear()                            # unit square in XY
+vol = trilinear()                           # unit cube
+```
+
+{func}`~pantr.cad.line` creates a degree-1 curve between two points.
+{func}`~pantr.cad.bilinear` creates a degree-(1, 1) surface from four corners.
+{func}`~pantr.cad.trilinear` creates a degree-(1, 1, 1) volume from eight corners.
+
+### Circles and arcs
+
+```python
+from pantr.cad import circle
+import numpy as np
+
+full = circle(radius=2.0)                         # full circle, 4 spans
+arc  = circle(angle=np.pi / 2)                    # quarter arc, 1 span
+arc2 = circle(angle=(np.pi / 4, np.pi), radius=3) # arc from 45 to 180 deg
+```
+
+{func}`~pantr.cad.circle` builds an exact rational quadratic B-spline.
+The number of spans depends on the sweep angle (one span per 90 degrees),
+with C0 interior knots (multiplicity equal to degree).  This is the
+standard conic representation.
+
+### Derived shapes
+
+```python
+from pantr.cad import rectangle, disk, cylinder
+
+rect = rectangle(corner=[0, 0, 0], width=2, height=3)  # closed curve
+ann  = disk(radius_inner=0.5, radius_outer=1.0)         # annular sector
+cyl  = cylinder(radius=1.0, height=5.0)                 # cylindrical surface
+```
+
+{func}`~pantr.cad.rectangle` returns a closed degree-1 curve visiting four corners.
+{func}`~pantr.cad.disk` builds an annular sector (or full disk when `radius_inner=0`)
+via {func}`~pantr.cad.ruled` between inner and outer circles.
+{func}`~pantr.cad.cylinder` extrudes a circle along the z-axis.
+
+## Operations
+
+Operations create higher-dimensional objects from existing ones by adding
+a new parametric direction.
+
+### Extrude
+
+```python
+from pantr.cad import circle, extrude
+
+pipe = extrude(circle(), [0, 0, 2])   # circle -> cylindrical surface
+```
+
+{func}`~pantr.cad.extrude` translates a curve or surface along a displacement
+vector, appending a degree-1 parametric direction.
+
+### Revolve
+
+```python
+from pantr.cad import line, revolve
+import numpy as np
+
+srf = revolve(line([1, 0, 0], [2, 0, 0]), point=0, axis=2)
+quarter = revolve(line([1, 0, 0], [1, 0, 3]), point=0, axis=2,
+                  angle=np.pi / 2)
+```
+
+{func}`~pantr.cad.revolve` rotates a curve or surface around an axis.
+The angular direction inherits the same span structure as
+{func}`~pantr.cad.circle` (one span per 90 degrees, C0 at arc junctions).
+Supports coordinate axes (`axis=0, 1, 2`) and arbitrary axis vectors.
+
+### Ruled
+
+```python
+from pantr.cad import circle, ruled
+
+annulus = ruled(circle(radius=0.5), circle(radius=1.0))
+```
+
+{func}`~pantr.cad.ruled` linearly interpolates between two curves (or
+surfaces) to produce a surface (or volume).  The inputs are automatically
+made compatible via {func}`~pantr.cad.compat`.
+
+### Sweep
+
+```python
+from pantr.cad import line, sweep
+
+srf = sweep(line([0, 0, 0], [1, 0, 0]),    # section
+            line([0, 0, 0], [0, 0, 3]))     # trajectory
+```
+
+{func}`~pantr.cad.sweep` creates a translational sweep:
+$S(u, v) = \text{section}(u) + \text{trajectory}(v)$.
+
+## Coons blending
+
+### Surface
+
+```python
+from pantr.cad import coons_surface, line
+
+c_u0 = line([0, 0, 0], [1, 0, 0])   # bottom
+c_u1 = line([0, 1, 0], [1, 1, 0])   # top
+c_v0 = line([0, 0, 0], [0, 1, 0])   # left
+c_v1 = line([1, 0, 0], [1, 1, 0])   # right
+
+srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+```
+
+{func}`~pantr.cad.coons_surface` builds a bilinearly blended surface from
+four boundary curves using the formula $S = R_0 + R_1 - B$, where $R_0$
+and $R_1$ are ruled surfaces and $B$ is the bilinear corner interpolant.
+
+### Volume
+
+```python
+from pantr.cad import bilinear, coons_volume
+import numpy as np
+
+# Build 6 faces of a unit cube
+face_u0 = bilinear(np.array([[[0,0,0],[0,0,1]],[[0,1,0],[0,1,1]]], dtype=float))
+face_u1 = bilinear(np.array([[[1,0,0],[1,0,1]],[[1,1,0],[1,1,1]]], dtype=float))
+face_v0 = bilinear(np.array([[[0,0,0],[0,0,1]],[[1,0,0],[1,0,1]]], dtype=float))
+face_v1 = bilinear(np.array([[[0,1,0],[0,1,1]],[[1,1,0],[1,1,1]]], dtype=float))
+face_w0 = bilinear(np.array([[[0,0,0],[0,1,0]],[[1,0,0],[1,1,0]]], dtype=float))
+face_w1 = bilinear(np.array([[[0,0,1],[0,1,1]],[[1,0,1],[1,1,1]]], dtype=float))
+
+vol = coons_volume(((face_u0, face_u1),
+                    (face_v0, face_v1),
+                    (face_w0, face_w1)))
+```
+
+{func}`~pantr.cad.coons_volume` builds a trilinearly blended volume from
+six boundary faces using the inclusion-exclusion formula:
+
+$$V = (R_u + R_v + R_w) - (B_{uv} + B_{uw} + B_{vw}) + T$$
+
+where $R$ are ruled volumes from opposite face pairs, $B$ are bilinear
+blend volumes from edge quadruples, and $T$ is the trilinear corner
+interpolant.  Edges and corners are extracted automatically from face
+boundaries.
+
+## Compatibility and assembly
+
+### compat
+
+```python
+from pantr.cad import compat, circle, line
+
+c1 = line([0, 0, 0], [1, 0, 0])   # degree 1
+c2 = circle(angle=np.pi / 2)       # degree 2, different knots
+r1, r2 = compat(c1, c2)            # now same degree and knots
+```
+
+{func}`~pantr.cad.compat` makes N B-splines compatible along specified axes by:
+1. Remapping domains to a common envelope.
+2. Elevating degrees to the maximum.
+3. Merging knot vectors (union of breakpoints with max multiplicities).
+
+This is called internally by {func}`~pantr.cad.ruled`,
+{func}`~pantr.cad.coons_surface`, {func}`~pantr.cad.coons_volume`, and
+{func}`~pantr.cad.join`.
+
+### join
+
+```python
+from pantr.cad import join, line
+
+c1 = line([0, 0, 0], [1, 0, 0])
+c2 = line([1, 0, 0], [2, 1, 0])
+merged = join(c1, c2, axis=0)
+```
+
+{func}`~pantr.cad.join` concatenates two B-splines along a parametric
+axis with C0 continuity.  Knots are automatically removed at the junction
+when the geometry permits higher smoothness.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 :caption: Contents
 
 getting-started
+constructive-geometry
 visualization
 parallelism
 api/reference

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -5,8 +5,10 @@ B-spline geometric objects:
 
 - **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
   :func:`trilinear`.
+- **Compatibility**: :func:`compat`.
 """
 
+from ._compat import compat
 from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
@@ -16,6 +18,7 @@ __all__ = [
     "_promote_to_rational",
     "bilinear",
     "circle",
+    "compat",
     "line",
     "trilinear",
 ]

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -9,10 +9,12 @@ B-spline geometric objects:
 - **Operations**: :func:`extrude`, :func:`revolve`, :func:`ruled`,
   :func:`sweep`.
 - **Coons blending**: :func:`coons_surface`, :func:`coons_volume`.
+- **Assembly**: :func:`join`.
 """
 
 from ._compat import compat
 from ._coons import coons_surface, coons_volume
+from ._join import join
 from ._operations import extrude, revolve, ruled, sweep
 from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
@@ -27,6 +29,7 @@ __all__ = [
     "coons_surface",
     "coons_volume",
     "extrude",
+    "join",
     "line",
     "revolve",
     "ruled",

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -3,10 +3,11 @@
 This package provides CAD-style functions for creating and combining
 B-spline geometric objects:
 
-- **Primitives**: :func:`line`, :func:`bilinear`, :func:`trilinear`.
+- **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
+  :func:`trilinear`.
 """
 
-from ._primitives import bilinear, line, trilinear
+from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "_pad_to_3d",
     "_promote_to_rational",
     "bilinear",
+    "circle",
     "line",
     "trilinear",
 ]

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -8,9 +8,11 @@ B-spline geometric objects:
 - **Compatibility**: :func:`compat`.
 - **Operations**: :func:`extrude`, :func:`revolve`, :func:`ruled`,
   :func:`sweep`.
+- **Coons blending**: :func:`coons_surface`, :func:`coons_volume`.
 """
 
 from ._compat import compat
+from ._coons import coons_surface, coons_volume
 from ._operations import extrude, revolve, ruled, sweep
 from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
@@ -22,6 +24,8 @@ __all__ = [
     "bilinear",
     "circle",
     "compat",
+    "coons_surface",
+    "coons_volume",
     "extrude",
     "line",
     "revolve",

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -5,6 +5,8 @@ B-spline geometric objects:
 
 - **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
   :func:`trilinear`.
+- **Derived primitives**: :func:`rectangle`, :func:`disk`,
+  :func:`cylinder`.
 - **Compatibility**: :func:`compat`.
 - **Operations**: :func:`extrude`, :func:`revolve`, :func:`ruled`,
   :func:`sweep`.
@@ -14,6 +16,7 @@ B-spline geometric objects:
 
 from ._compat import compat
 from ._coons import coons_surface, coons_volume
+from ._derived import cylinder, disk, rectangle
 from ._join import join
 from ._operations import extrude, revolve, ruled, sweep
 from ._primitives import bilinear, circle, line, trilinear
@@ -28,9 +31,12 @@ __all__ = [
     "compat",
     "coons_surface",
     "coons_volume",
+    "cylinder",
+    "disk",
     "extrude",
     "join",
     "line",
+    "rectangle",
     "revolve",
     "ruled",
     "sweep",

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -6,9 +6,11 @@ B-spline geometric objects:
 - **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
   :func:`trilinear`.
 - **Compatibility**: :func:`compat`.
+- **Operations**: :func:`extrude`, :func:`ruled`.
 """
 
 from ._compat import compat
+from ._operations import extrude, ruled
 from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
@@ -19,6 +21,8 @@ __all__ = [
     "bilinear",
     "circle",
     "compat",
+    "extrude",
     "line",
+    "ruled",
     "trilinear",
 ]

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -6,11 +6,12 @@ B-spline geometric objects:
 - **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
   :func:`trilinear`.
 - **Compatibility**: :func:`compat`.
-- **Operations**: :func:`extrude`, :func:`ruled`.
+- **Operations**: :func:`extrude`, :func:`revolve`, :func:`ruled`,
+  :func:`sweep`.
 """
 
 from ._compat import compat
-from ._operations import extrude, ruled
+from ._operations import extrude, revolve, ruled, sweep
 from ._primitives import bilinear, circle, line, trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
@@ -23,6 +24,8 @@ __all__ = [
     "compat",
     "extrude",
     "line",
+    "revolve",
     "ruled",
+    "sweep",
     "trilinear",
 ]

--- a/src/pantr/cad/_compat.py
+++ b/src/pantr/cad/_compat.py
@@ -1,0 +1,260 @@
+"""B-spline compatibility: match degrees and knot vectors across objects.
+
+Provides :func:`compat`, which takes N B-splines and returns new objects
+that share the same degree and knot vector along each specified axis.
+This is the prerequisite for operations like ``ruled``, ``coons``, and
+``join`` that combine control points from different B-splines.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+from numpy import typing as npt
+
+from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ..bspline._bspline_product import (
+    _get_interior_breakpoints_and_mults,
+    _lookup_mults_in_space,
+)
+
+
+def _remap_domain_1d(
+    space_1d: BsplineSpace1D,
+    new_domain: tuple[float, float],
+) -> BsplineSpace1D:
+    """Affinely remap a 1D B-spline space to a new parameter domain.
+
+    Args:
+        space_1d: Original 1D space.
+        new_domain: Target domain ``(a_new, b_new)``.
+
+    Returns:
+        BsplineSpace1D: New space with remapped knots, same degree.
+    """
+    a_old, b_old = space_1d.domain
+    a_new, b_new = new_domain
+    scale = (b_new - a_new) / (b_old - a_old)
+    new_knots = a_new + (space_1d.knots - a_old) * scale
+    return BsplineSpace1D(new_knots, space_1d.degree, periodic=space_1d.periodic)
+
+
+def _remap_bspline(bspline: Bspline, axis: int, new_domain: tuple[float, float]) -> Bspline:
+    """Remap one axis of a B-spline to a new domain (pure reparametrization).
+
+    Control points are unchanged because this is a parameter-space
+    transformation only.
+
+    Args:
+        bspline: Input B-spline.
+        axis: Parametric axis to remap.
+        new_domain: Target domain ``(a_new, b_new)``.
+
+    Returns:
+        Bspline: New B-spline with remapped knot vector on *axis*.
+    """
+    spaces = list(bspline.space.spaces)
+    spaces[axis] = _remap_domain_1d(spaces[axis], new_domain)
+    new_space = BsplineSpace(spaces)
+    return Bspline(new_space, bspline.control_points.copy(), is_rational=bspline.is_rational)
+
+
+def _merge_breakpoints_n_way(
+    bp_list: list[npt.NDArray[np.float32 | np.float64]],
+    mult_list: list[npt.NDArray[np.int_]],
+    tol: float,
+) -> tuple[npt.NDArray[np.float64], list[npt.NDArray[np.int_]]]:
+    """Merge interior breakpoints from N spaces, returning per-space deficits.
+
+    Args:
+        bp_list: Interior breakpoints per B-spline (sorted, ascending).
+        mult_list: Multiplicities per B-spline, matching *bp_list*.
+        tol: Tolerance for coincidence.
+
+    Returns:
+        tuple: ``(union_bp, deficits)`` where *union_bp* is the sorted union
+        of all breakpoints and *deficits[i]* is an int array of knots-to-insert
+        counts for B-spline *i* at each union breakpoint.
+    """
+    # Collect all breakpoints into a sorted union
+    non_empty = [bp for bp in bp_list if bp.size > 0]
+    if not non_empty:
+        return np.empty(0, dtype=np.float64), [np.empty(0, dtype=np.int_) for _ in bp_list]
+
+    union_bp: npt.NDArray[np.float64] = np.unique(np.concatenate(non_empty)).astype(np.float64)
+
+    # Target multiplicity = element-wise max across all spaces
+    target_mults = np.zeros(len(union_bp), dtype=np.int_)
+    per_space_mults: list[npt.NDArray[np.int_]] = []
+    for bp, mult in zip(bp_list, mult_list, strict=True):
+        m = _lookup_mults_in_space(union_bp, bp, mult, tol)
+        target_mults = np.maximum(target_mults, m)
+        per_space_mults.append(m)
+
+    # Deficit per space = target - current
+    deficits = [target_mults - m for m in per_space_mults]
+    return union_bp, deficits
+
+
+def compat(
+    *bsplines: Bspline,
+    axes: int | Sequence[int] | None = None,
+) -> list[Bspline]:
+    """Make B-splines compatible along specified parametric axes.
+
+    Returns new B-splines that share the same polynomial degree and
+    knot vector along the given axes.  The geometric mapping of each
+    B-spline is preserved exactly.
+
+    The algorithm proceeds in three stages:
+
+    1. **Same domain** -- remap knot vectors to the common envelope
+       ``[min(starts), max(ends)]`` per axis.
+    2. **Same degree** -- elevate each B-spline to the maximum degree
+       per axis.
+    3. **Merge knots** -- insert knots so all B-splines share the
+       same interior breakpoints with the maximum multiplicity.
+
+    Periodic B-splines are converted to open form before processing.
+
+    Args:
+        *bsplines: Two or more B-splines to make compatible.
+            All must have the same parametric dimension.
+        axes: Parametric axes along which to operate.  ``None``
+            (default) means all axes.  A single ``int`` or a sequence
+            of ``int`` selects specific axes.
+
+    Returns:
+        list[Bspline]: New B-splines with identical knot structure
+        along the specified axes.
+
+    Raises:
+        ValueError: If fewer than 2 B-splines are provided.
+        ValueError: If B-splines have different parametric dimensions.
+        ValueError: If any axis index is out of range.
+    """
+    if len(bsplines) < 2:  # noqa: PLR2004
+        return list(bsplines)
+
+    dims = {b.dim for b in bsplines}
+    if len(dims) != 1:
+        raise ValueError(f"All B-splines must have the same parametric dimension, got {dims}.")
+    dim = dims.pop()
+
+    # Normalize axes
+    if axes is None:
+        axes_list = list(range(dim))
+    elif isinstance(axes, int):
+        axes_list = [axes]
+    else:
+        axes_list = list(axes)
+    for a in axes_list:
+        if a < 0 or a >= dim:
+            raise ValueError(f"Axis {a} out of range for dim={dim}.")
+    if not axes_list:
+        return list(bsplines)
+
+    # Convert periodic to open
+    results: list[Bspline] = []
+    for b in bsplines:
+        needs_open = any(b.space.spaces[a].periodic for a in axes_list)
+        results.append(b.to_open_bspline() if needs_open else b)
+
+    # Stage 1: Same domain
+    results = _same_domain(results, axes_list)
+
+    # Stage 2: Same degree
+    results = _same_degree(results, axes_list, dim)
+
+    # Stage 3: Merge knots
+    results = _merge_knots(results, axes_list, dim)
+
+    return results
+
+
+def _same_domain(results: list[Bspline], axes_list: list[int]) -> list[Bspline]:
+    """Remap all B-splines to a common domain per axis.
+
+    Args:
+        results: List of B-splines.
+        axes_list: Axes to process.
+
+    Returns:
+        list[Bspline]: B-splines with remapped domains.
+    """
+    for a in axes_list:
+        domains = [
+            (float(b.space.spaces[a].domain[0]), float(b.space.spaces[a].domain[1]))
+            for b in results
+        ]
+        common_start = min(d[0] for d in domains)
+        common_end = max(d[1] for d in domains)
+        common = (common_start, common_end)
+        for i, b in enumerate(results):
+            if domains[i] != common:
+                results[i] = _remap_bspline(b, a, common)
+    return results
+
+
+def _same_degree(results: list[Bspline], axes_list: list[int], dim: int) -> list[Bspline]:
+    """Elevate degrees to the maximum per axis.
+
+    Args:
+        results: List of B-splines.
+        axes_list: Axes to process.
+        dim: Parametric dimension.
+
+    Returns:
+        list[Bspline]: B-splines with elevated degrees.
+    """
+    max_degrees = [0] * dim
+    for a in axes_list:
+        max_degrees[a] = max(b.space.spaces[a].degree for b in results)
+
+    for i, b in enumerate(results):
+        increments = tuple(
+            max_degrees[a] - b.space.spaces[a].degree if a in axes_list else 0 for a in range(dim)
+        )
+        if any(inc > 0 for inc in increments):
+            results[i] = b.elevate_degree(increments)
+    return results
+
+
+def _merge_knots(results: list[Bspline], axes_list: list[int], dim: int) -> list[Bspline]:
+    """Insert knots so all B-splines share the same knot vectors per axis.
+
+    Args:
+        results: List of B-splines (already same domain and degree).
+        axes_list: Axes to process.
+        dim: Parametric dimension.
+
+    Returns:
+        list[Bspline]: B-splines with merged knot vectors.
+    """
+    for a in axes_list:
+        tol = results[0].space.spaces[a].tolerance
+
+        # Collect interior breakpoints and multiplicities
+        bp_list = []
+        mult_list = []
+        for b in results:
+            bp, mult = _get_interior_breakpoints_and_mults(b.space.spaces[a], tol)
+            bp_list.append(bp)
+            mult_list.append(mult)
+
+        union_bp, deficits = _merge_breakpoints_n_way(bp_list, mult_list, tol)
+        if union_bp.size == 0:
+            continue
+
+        for i, deficit in enumerate(deficits):
+            knots_to_insert = np.repeat(union_bp, deficit).astype(results[i].dtype)
+            if knots_to_insert.size == 0:
+                continue
+            if dim == 1:
+                results[i] = results[i].insert_knots(knots_to_insert)
+            else:
+                per_dim: list[npt.NDArray[np.float64] | None] = [None] * dim
+                per_dim[a] = knots_to_insert
+                results[i] = results[i].insert_knots(per_dim)
+    return results

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -1,0 +1,372 @@
+"""Coons patch and volume constructions.
+
+Provides :func:`coons_surface` (bilinear blending from 4 boundary curves)
+and :func:`coons_volume` (trilinear blending from 6 boundary faces).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import typing as npt
+
+from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ._compat import compat
+from ._operations import ruled
+from ._primitives import _linear_space_1d, bilinear, trilinear
+from ._validation import _promote_to_rational
+
+
+def _combine_control_points(
+    bsplines: list[Bspline],
+    signs: list[int],
+) -> tuple[npt.NDArray[np.float64], bool]:
+    """Linearly combine control points of compatible B-splines.
+
+    Args:
+        bsplines: B-splines that share the same space (after compat).
+        signs: Coefficients (+1 or -1) for each B-spline.
+
+    Returns:
+        tuple: ``(control_points, is_rational)`` for the combined result.
+    """
+    is_rational = any(b.is_rational for b in bsplines)
+    if is_rational:
+        bsplines = [_promote_to_rational(b) for b in bsplines]
+
+    cp = np.zeros_like(bsplines[0].control_points, dtype=np.float64)
+    for b, s in zip(bsplines, signs, strict=True):
+        cp += s * b.control_points.astype(np.float64)
+    return cp, is_rational
+
+
+def coons_surface(
+    curves: tuple[tuple[Bspline, Bspline], tuple[Bspline, Bspline]],
+) -> Bspline:
+    """Construct a Coons patch from four boundary curves.
+
+    Builds a bilinearly blended surface from four boundary curves using
+    the formula ``S = R0 + R1 - B``, where *R0* and *R1* are ruled
+    surfaces and *B* is the bilinear interpolant of the four corners.
+
+    The curve layout is::
+
+             C_u1
+         o-----------o
+         |  v        |
+         |  ^        |
+    C_v0 |  |        | C_v1
+         |  +---> u  |
+         o-----------o
+             C_u0
+
+    Args:
+        curves: ``((C_v0, C_v1), (C_u0, C_u1))`` -- two pairs of
+            opposite boundary curves.  ``C_v0`` and ``C_v1`` run in the
+            v-direction (left/right).  ``C_u0`` and ``C_u1`` run in the
+            u-direction (bottom/top).  All must be 1D B-splines.
+
+    Returns:
+        Bspline: A 2D B-spline surface.
+
+    Raises:
+        ValueError: If any curve is not 1D.
+        ValueError: If corner points are not geometrically consistent.
+    """
+    (c_v0, c_v1), (c_u0, c_u1) = curves
+
+    for c in (c_v0, c_v1, c_u0, c_u1):
+        if c.dim != 1:
+            raise ValueError(f"All curves must be 1D, got dim={c.dim}.")
+
+    # Make opposite pairs compatible
+    c_u0, c_u1 = compat(c_u0, c_u1)
+    c_v0, c_v1 = compat(c_v0, c_v1)
+
+    # Extract and verify corner points
+    p00 = np.asarray(c_u0.boundary(0, 0), dtype=np.float64)
+    p10 = np.asarray(c_u0.boundary(0, 1), dtype=np.float64)
+    p01 = np.asarray(c_u1.boundary(0, 0), dtype=np.float64)
+    p11 = np.asarray(c_u1.boundary(0, 1), dtype=np.float64)
+
+    _verify_corners_2d((p00, p10, p01, p11), c_v0, c_v1)
+
+    # R0: ruled in v from C_v0 to C_v1, then transpose to (u, v)
+    r0 = ruled(c_v0, c_v1).permute_directions([1, 0])
+    # R1: ruled in u from C_u0 to C_u1 (already in (u, v) order)
+    r1 = ruled(c_u0, c_u1)
+    # B: bilinear from corners
+    corners = np.zeros((2, 2, p00.size), dtype=np.float64)
+    corners[0, 0] = p00
+    corners[1, 0] = p10
+    corners[0, 1] = p01
+    corners[1, 1] = p11
+    b = bilinear(corners)
+
+    r0, r1, b = compat(r0, r1, b)
+
+    cp, is_rational = _combine_control_points([r0, r1, b], [+1, +1, -1])
+    return Bspline(r0.space, cp, is_rational=is_rational)
+
+
+def _verify_corners_2d(
+    u_corners: tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+    ],
+    c_v0: Bspline,
+    c_v1: Bspline,
+) -> None:
+    """Verify that corner points from u-curves match v-curves.
+
+    Args:
+        u_corners: Corners (p00, p10, p01, p11) extracted from u-curves.
+        c_v0: Left boundary curve (v-direction at u=0).
+        c_v1: Right boundary curve (v-direction at u=1).
+
+    Raises:
+        ValueError: If any pair of corners does not match.
+    """
+    p00, p10, p01, p11 = u_corners
+    q00 = np.asarray(c_v0.boundary(0, 0), dtype=np.float64)
+    q01 = np.asarray(c_v0.boundary(0, 1), dtype=np.float64)
+    q10 = np.asarray(c_v1.boundary(0, 0), dtype=np.float64)
+    q11 = np.asarray(c_v1.boundary(0, 1), dtype=np.float64)
+
+    tol = 1e-12
+    for label, pu, qv in [
+        ("(0,0)", p00, q00),
+        ("(1,0)", p10, q10),
+        ("(0,1)", p01, q01),
+        ("(1,1)", p11, q11),
+    ]:
+        if not np.allclose(pu, qv, atol=tol, rtol=0):
+            raise ValueError(f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv}.")
+
+
+def coons_volume(
+    faces: tuple[
+        tuple[Bspline, Bspline],
+        tuple[Bspline, Bspline],
+        tuple[Bspline, Bspline],
+    ],
+) -> Bspline:
+    """Construct a trivariate Coons blending volume from 6 boundary faces.
+
+    Uses the trilinear Coons formula:
+
+    ``V = (R_u + R_v + R_w) - (B_uv + B_uw + B_vw) + T``
+
+    where *R* are ruled volumes from opposite face pairs, *B* are
+    bilinear blend volumes from edge quadruples, and *T* is the
+    trilinear corner interpolant.
+
+    Edges and corners are derived automatically from face boundaries.
+
+    Face labelling convention:
+
+    - ``faces[0] = (face_u0, face_u1)``: faces at u=0 and u=1,
+      each a surface parameterized by (v, w).
+    - ``faces[1] = (face_v0, face_v1)``: faces at v=0 and v=1,
+      each a surface parameterized by (u, w).
+    - ``faces[2] = (face_w0, face_w1)``: faces at w=0 and w=1,
+      each a surface parameterized by (u, v).
+
+    Args:
+        faces: Three pairs of opposite boundary faces.
+
+    Returns:
+        Bspline: A 3D (trivariate) B-spline volume.
+
+    Raises:
+        ValueError: If any face is not a 2D B-spline.
+    """
+    (face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1) = faces
+
+    for f in (face_u0, face_u1, face_v0, face_v1, face_w0, face_w1):
+        if f.dim != 2:  # noqa: PLR2004
+            raise ValueError(f"All faces must be 2D B-splines, got dim={f.dim}.")
+
+    # Make opposite face pairs compatible
+    face_u0, face_u1 = compat(face_u0, face_u1)
+    face_v0, face_v1 = compat(face_v0, face_v1)
+    face_w0, face_w1 = compat(face_w0, face_w1)
+
+    # Extract edges from faces
+    edges = _extract_edges((face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1))
+
+    # Extract corners from edges
+    corners = _extract_corners(edges)
+
+    # Build 3 ruled volumes
+    r_u = ruled(face_u0, face_u1).permute_directions([2, 0, 1])
+    r_v = ruled(face_v0, face_v1).permute_directions([0, 2, 1])
+    r_w = ruled(face_w0, face_w1)  # already (u, v, w)
+
+    # Build 3 bilinear blend volumes
+    # B_uv: raw axes (u, v, w) → permute to (u, v, w) = identity
+    b_uv = _build_bilinear_volume(
+        edges["w_u0_v0"],
+        edges["w_u1_v0"],
+        edges["w_u0_v1"],
+        edges["w_u1_v1"],
+        permutation=(0, 1, 2),
+    )
+    # B_uw: raw axes (u, w, v) → permute to (u, v, w)
+    b_uw = _build_bilinear_volume(
+        edges["v_u0_w0"],
+        edges["v_u1_w0"],
+        edges["v_u0_w1"],
+        edges["v_u1_w1"],
+        permutation=(0, 2, 1),
+    )
+    # B_vw: raw axes (v, w, u) → permute to (u, v, w)
+    b_vw = _build_bilinear_volume(
+        edges["u_v0_w0"],
+        edges["u_v1_w0"],
+        edges["u_v0_w1"],
+        edges["u_v1_w1"],
+        permutation=(2, 0, 1),
+    )
+
+    # Build trilinear volume
+    t = trilinear(corners)
+
+    # Make all 7 terms compatible and combine
+    r_u, r_v, r_w, b_uv, b_uw, b_vw, t = compat(r_u, r_v, r_w, b_uv, b_uw, b_vw, t)
+
+    cp, is_rational = _combine_control_points(
+        [r_u, r_v, r_w, b_uv, b_uw, b_vw, t],
+        [+1, +1, +1, -1, -1, -1, +1],
+    )
+    return Bspline(r_u.space, cp, is_rational=is_rational)
+
+
+def _extract_edges(
+    u_faces: tuple[Bspline, Bspline],
+    v_faces: tuple[Bspline, Bspline],
+    w_faces: tuple[Bspline, Bspline],
+) -> dict[str, Bspline]:
+    """Extract 12 edges from 6 faces.
+
+    Each edge is extracted from the first face that contains it.
+    Edge naming: ``{free_param}_{fixed1}_{fixed2}``.
+
+    Args:
+        u_faces: ``(face_u0, face_u1)`` at u=0 and u=1, parameterized by (v, w).
+        v_faces: ``(face_v0, face_v1)`` at v=0 and v=1, parameterized by (u, w).
+        w_faces: Not used for edge extraction but reserved for future validation.
+
+    Returns:
+        dict[str, Bspline]: Dictionary of 12 named edge curves.
+    """
+    face_u0, face_u1 = u_faces
+    face_v0, face_v1 = v_faces
+
+    # All faces are 2D, so boundary() returns Bspline (not ndarray).
+    # We cast to satisfy mypy.
+    def _bdy(face: Bspline, ax: int, side: int) -> Bspline:
+        result = face.boundary(ax, side)
+        assert isinstance(result, Bspline)
+        return result
+
+    return {
+        # w-edges (free=w): from face_u (v,w) boundaries at v=0,1
+        "w_u0_v0": _bdy(face_u0, 0, 0),
+        "w_u0_v1": _bdy(face_u0, 0, 1),
+        "w_u1_v0": _bdy(face_u1, 0, 0),
+        "w_u1_v1": _bdy(face_u1, 0, 1),
+        # v-edges (free=v): from face_u (v,w) boundaries at w=0,1
+        "v_u0_w0": _bdy(face_u0, 1, 0),
+        "v_u0_w1": _bdy(face_u0, 1, 1),
+        "v_u1_w0": _bdy(face_u1, 1, 0),
+        "v_u1_w1": _bdy(face_u1, 1, 1),
+        # u-edges (free=u): from face_v (u,w) boundaries at w=0,1
+        "u_v0_w0": _bdy(face_v0, 1, 0),
+        "u_v0_w1": _bdy(face_v0, 1, 1),
+        "u_v1_w0": _bdy(face_v1, 1, 0),
+        "u_v1_w1": _bdy(face_v1, 1, 1),
+    }
+
+
+def _extract_corners(edges: dict[str, Bspline]) -> npt.NDArray[np.float64]:
+    """Extract 8 corner points from edges.
+
+    Args:
+        edges: Dictionary of 12 named edge curves.
+
+    Returns:
+        npt.NDArray[np.float64]: Array of shape ``(2, 2, 2, rank)``.
+    """
+    e = edges["u_v0_w0"]
+    rank = e.control_points.shape[-1]
+    corners = np.zeros((2, 2, 2, rank), dtype=np.float64)
+
+    # Corners from u-edges (boundary of a 1D curve returns ndarray)
+    corners[0, 0, 0] = np.asarray(edges["u_v0_w0"].boundary(0, 0))
+    corners[1, 0, 0] = np.asarray(edges["u_v0_w0"].boundary(0, 1))
+    corners[0, 1, 0] = np.asarray(edges["u_v1_w0"].boundary(0, 0))
+    corners[1, 1, 0] = np.asarray(edges["u_v1_w0"].boundary(0, 1))
+    corners[0, 0, 1] = np.asarray(edges["u_v0_w1"].boundary(0, 0))
+    corners[1, 0, 1] = np.asarray(edges["u_v0_w1"].boundary(0, 1))
+    corners[0, 1, 1] = np.asarray(edges["u_v1_w1"].boundary(0, 0))
+    corners[1, 1, 1] = np.asarray(edges["u_v1_w1"].boundary(0, 1))
+    return corners
+
+
+def _build_bilinear_volume(
+    e_00: Bspline,
+    e_10: Bspline,
+    e_01: Bspline,
+    e_11: Bspline,
+    permutation: tuple[int, int, int],
+) -> Bspline:
+    """Build a trivariate B-spline bilinear in two directions, free in one.
+
+    The four input edges are 1D curves that share the same free parameter.
+    They are placed at the four combinations of the two bilinear parameters.
+    The raw axes are ``(bilinear_0, bilinear_1, free)``, then permuted to
+    ``(u, v, w)`` via *permutation*.
+
+    Args:
+        e_00: Edge at (bilinear_0=0, bilinear_1=0).
+        e_10: Edge at (bilinear_0=1, bilinear_1=0).
+        e_01: Edge at (bilinear_0=0, bilinear_1=1).
+        e_11: Edge at (bilinear_0=1, bilinear_1=1).
+        permutation: Permutation such that ``new[i] = old[permutation[i]]``,
+            mapping from raw (bilinear_0, bilinear_1, free) to (u, v, w).
+
+    Returns:
+        Bspline: A 3D B-spline volume in (u, v, w) order.
+    """
+    e_00, e_10, e_01, e_11 = compat(e_00, e_10, e_01, e_11)
+
+    is_rational = any(e.is_rational for e in (e_00, e_10, e_01, e_11))
+    if is_rational:
+        e_00 = _promote_to_rational(e_00)
+        e_10 = _promote_to_rational(e_10)
+        e_01 = _promote_to_rational(e_01)
+        e_11 = _promote_to_rational(e_11)
+
+    cp = e_00.control_points
+    n_free = cp.shape[0]
+    rank_full = cp.shape[-1]
+
+    # Shape: (2, 2, n_free, rank_full) = (bilinear_0, bilinear_1, free, rank)
+    new_cp = np.empty((2, 2, n_free, rank_full), dtype=np.float64)
+    new_cp[0, 0] = e_00.control_points
+    new_cp[1, 0] = e_10.control_points
+    new_cp[0, 1] = e_01.control_points
+    new_cp[1, 1] = e_11.control_points
+
+    lin = _linear_space_1d()
+    spaces_raw = [
+        BsplineSpace1D(lin.knots.copy(), degree=1),
+        BsplineSpace1D(lin.knots.copy(), degree=1),
+        e_00.space.spaces[0],
+    ]
+    space = BsplineSpace(spaces_raw)
+    vol = Bspline(space, new_cp, is_rational=is_rational)
+
+    return vol.permute_directions(list(permutation))

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -50,14 +50,14 @@ def coons_surface(
 
     The curve layout is::
 
-             C_u1
-         o-----------o
-         |  v        |
-         |  ^        |
-    C_v0 |  |        | C_v1
-         |  +---> u  |
-         o-----------o
-             C_u0
+               C_u1
+        o--------------o
+        |  v           |
+        |  ^           |
+        |  |     C_v1  |
+        |  +---> u     |
+        o--------------o
+        C_v0   C_u0
 
     Args:
         curves: ``((C_v0, C_v1), (C_u0, C_u1))`` -- two pairs of

--- a/src/pantr/cad/_derived.py
+++ b/src/pantr/cad/_derived.py
@@ -1,0 +1,137 @@
+"""Derived primitives built from core operations.
+
+Provides higher-level geometric primitives constructed by composing
+:func:`circle`, :func:`extrude`, :func:`ruled`, and :func:`revolve`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import typing as npt
+
+from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ._operations import extrude, ruled
+from ._primitives import circle
+from ._validation import _PHYSICAL_DIM, _pad_to_3d
+
+
+def rectangle(
+    corner: npt.ArrayLike = (0.0, 0.0, 0.0),
+    width: float = 1.0,
+    height: float = 1.0,
+) -> Bspline:
+    """Construct a closed rectangular B-spline curve in the xy-plane.
+
+    Creates a degree-1 curve with 5 control points (the first point
+    repeated to close the loop) and 4 knot spans.
+
+    Args:
+        corner: Bottom-left corner (up to 3D, zero-padded).
+        width: Rectangle width along the x-axis.
+        height: Rectangle height along the y-axis.
+
+    Returns:
+        Bspline: A 1D, degree-1, rank-3, non-rational closed curve.
+
+    Example:
+        >>> rect = rectangle([0, 0], 2, 3)
+        >>> rect.dim
+        1
+    """
+    c = _pad_to_3d(corner)
+    dx = np.array([width, 0.0, 0.0])
+    dy = np.array([0.0, height, 0.0])
+
+    # 5 control points: close the rectangle
+    cp = np.array([c, c + dx, c + dx + dy, c + dy, c], dtype=np.float64)
+
+    # 4 spans, degree 1: knots [0,0, 0.25,0.25, 0.5,0.5, 0.75,0.75, 1,1]
+    n_spans = 4
+    knots = np.empty(2 * (n_spans + 1), dtype=np.float64)
+    knots[0] = 0.0
+    knots[-1] = 1.0
+    knots[1:-1] = np.linspace(0.0, 1.0, n_spans + 1).repeat(2)[1:-1]
+
+    # Actually for degree 1 with 5 CPs we need 7 knots: n + p + 1 = 5+1+1=7
+    # knots = [0, 0, 0.25, 0.5, 0.75, 1, 1]
+    knots = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0], dtype=np.float64)
+
+    space = BsplineSpace([BsplineSpace1D(knots, degree=1)])
+    return Bspline(space, cp)
+
+
+def disk(
+    radius_inner: float = 0.0,
+    radius_outer: float = 1.0,
+    center: npt.ArrayLike | None = None,
+    angle: float | tuple[float, float] | None = None,
+) -> Bspline:
+    """Construct a disk or annular sector as a NURBS surface.
+
+    When ``radius_inner > 0``, produces an annular sector via
+    :func:`ruled` between inner and outer circular arcs.  When
+    ``radius_inner == 0``, the inner boundary degenerates to a point.
+
+    Args:
+        radius_inner: Inner radius.  Use 0 for a full disk.
+        radius_outer: Outer radius.
+        center: Center point (up to 3D, zero-padded).  If ``None``,
+            centered at the origin.
+        angle: Sweep specification (same as :func:`circle`).
+
+    Returns:
+        Bspline: A 2D rational B-spline surface.
+
+    Example:
+        >>> d = disk(radius_outer=2.0)
+        >>> d.dim
+        2
+    """
+    outer = circle(radius=radius_outer, center=center, angle=angle)
+
+    if radius_inner > 0:
+        inner = circle(radius=radius_inner, center=center, angle=angle)
+        return ruled(inner, outer)
+
+    # Degenerate inner: all control points at center
+    c = _pad_to_3d(center) if center is not None else np.zeros(_PHYSICAL_DIM)
+    n_cp = outer.control_points.shape[0]
+    rank_full = outer.control_points.shape[-1]
+
+    # Build inner as a rational curve with all points at center
+    inner_cp = np.zeros((n_cp, rank_full), dtype=np.float64)
+    # Copy weights from outer arc
+    inner_cp[:, _PHYSICAL_DIM] = outer.control_points[:, _PHYSICAL_DIM]
+    # Set weighted coordinates: w * center
+    for i in range(_PHYSICAL_DIM):
+        inner_cp[:, i] = inner_cp[:, _PHYSICAL_DIM] * c[i]
+
+    inner = Bspline(outer.space, inner_cp, is_rational=True)
+    return ruled(inner, outer)
+
+
+def cylinder(
+    radius: float = 1.0,
+    height: float = 1.0,
+    center: npt.ArrayLike | None = None,
+    angle: float | tuple[float, float] | None = None,
+) -> Bspline:
+    """Construct a cylindrical NURBS surface.
+
+    Built by extruding a circle along the z-axis.
+
+    Args:
+        radius: Cylinder radius.
+        height: Cylinder height along the z-axis.
+        center: Center of the base circle (up to 3D, zero-padded).
+        angle: Sweep specification (same as :func:`circle`).
+
+    Returns:
+        Bspline: A 2D rational B-spline surface.
+
+    Example:
+        >>> cyl = cylinder(radius=2, height=5)
+        >>> cyl.dim
+        2
+    """
+    return extrude(circle(radius=radius, center=center, angle=angle), [0, 0, height])

--- a/src/pantr/cad/_join.py
+++ b/src/pantr/cad/_join.py
@@ -1,0 +1,206 @@
+"""Join two B-spline patches along a parametric axis.
+
+Provides :func:`join` for C0-concatenation of B-splines.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import typing as npt
+
+from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ._compat import _remap_bspline, compat
+from ._validation import _promote_to_rational
+
+
+def _prepare_for_join(
+    bspline1: Bspline,
+    bspline2: Bspline,
+    axis: int,
+) -> tuple[Bspline, Bspline, bool]:
+    """Prepare two B-splines for joining along an axis.
+
+    Makes them compatible on non-join axes, promotes rational if mixed,
+    clamps if needed, elevates to max degree on the join axis, and
+    remaps b2 so it starts where b1 ends.
+
+    Args:
+        bspline1: First B-spline.
+        bspline2: Second B-spline.
+        axis: Join axis.
+
+    Returns:
+        tuple: ``(b1, b2, is_rational)`` ready for concatenation.
+    """
+    dim = bspline1.dim
+
+    # Make compatible on non-join axes
+    non_join = [i for i in range(dim) if i != axis]
+    if non_join:
+        b1, b2 = compat(bspline1, bspline2, axes=non_join)
+    else:
+        b1, b2 = bspline1, bspline2
+
+    # Promote to rational if mixed
+    is_rational = b1.is_rational or b2.is_rational
+    if is_rational:
+        b1 = _promote_to_rational(b1)
+        b2 = _promote_to_rational(b2)
+
+    # Clamp if needed
+    if any(s.periodic or not s.has_open_knots() for s in b1.space.spaces):
+        b1 = b1.to_open_bspline()
+    if any(s.periodic or not s.has_open_knots() for s in b2.space.spaces):
+        b2 = b2.to_open_bspline()
+
+    # Elevate to max degree on the join axis
+    p1 = b1.degree[axis]
+    p2 = b2.degree[axis]
+    p = max(p1, p2)
+    if p > p1:
+        inc = [0] * dim
+        inc[axis] = p - p1
+        b1 = b1.elevate_degree(inc)
+    if p > p2:
+        inc = [0] * dim
+        inc[axis] = p - p2
+        b2 = b2.elevate_degree(inc)
+
+    # Remap b2 so it starts where b1 ends
+    u1_end = float(b1.space.spaces[axis].domain[1])
+    u2_start = float(b2.space.spaces[axis].domain[0])
+    u2_end = float(b2.space.spaces[axis].domain[1])
+    new_end = u1_end + (u2_end - u2_start)
+    b2 = _remap_bspline(b2, axis, (u1_end, new_end))
+
+    return b1, b2, is_rational
+
+
+def _concatenate_along_axis(
+    b1: Bspline,
+    b2: Bspline,
+    axis: int,
+    is_rational: bool,
+) -> Bspline:
+    """Concatenate two prepared B-splines along an axis.
+
+    Averages the shared boundary control points, merges knot vectors,
+    and builds the result.
+
+    Args:
+        b1: First B-spline (left side).
+        b2: Second B-spline (right side, already remapped).
+        axis: Join axis.
+        is_rational: Whether the result is rational.
+
+    Returns:
+        Bspline: The concatenated B-spline.
+    """
+    dim = b1.dim
+    p = b1.degree[axis]
+    cp1 = b1.control_points
+    cp2 = b2.control_points
+
+    # Slice indices for the join axis (+ rank dimension)
+    ndim = dim + 1
+    idx_left: list[int | slice | None] = [slice(None)] * ndim
+    idx_right: list[int | slice | None] = [slice(None)] * ndim
+    idx_b1_last: list[int | slice | None] = [slice(None)] * ndim
+    idx_b2_first: list[int | slice | None] = [slice(None)] * ndim
+
+    idx_left[axis] = slice(0, -1)
+    idx_right[axis] = slice(1, None)
+    idx_b1_last[axis] = -1
+    idx_b2_first[axis] = 0
+
+    cp_left = cp1[tuple(idx_left)]
+    cp_right = cp2[tuple(idx_right)]
+    cp_mid = (cp1[tuple(idx_b1_last)] + cp2[tuple(idx_b2_first)]) / 2.0
+
+    idx_expand: list[int | slice | None] = [slice(None)] * ndim
+    idx_expand[axis] = np.newaxis
+    cp_mid_expanded = cp_mid[tuple(idx_expand)]
+
+    new_cp = np.concatenate([cp_left, cp_mid_expanded, cp_right], axis=axis)
+
+    # Merge knot vectors
+    u_junction = float(b1.space.spaces[axis].domain[1])
+    kl = b1.space.spaces[axis].knots[: -p - 1]
+    kr = b2.space.spaces[axis].knots[p + 1 :]
+    kc = np.full(p, u_junction)
+    new_knots = np.concatenate([kl, kc, kr])
+
+    spaces = list(b1.space.spaces)
+    spaces[axis] = BsplineSpace1D(new_knots, degree=p)
+    new_space = BsplineSpace(spaces)
+
+    result = Bspline(new_space, new_cp, is_rational=is_rational)
+
+    # Try to remove junction knots for smoother join
+    if p > 1:
+        result = _try_remove_junction_knots(result, axis, u_junction, p)
+
+    return result
+
+
+def join(bspline1: Bspline, bspline2: Bspline, axis: int) -> Bspline:
+    """Join two B-splines along a parametric axis with C0 continuity.
+
+    The two inputs are made compatible on all non-join axes (degree and
+    knots), elevated to the same degree on the join axis, and then
+    concatenated.  The shared boundary control points are averaged.
+
+    Optionally, knots are removed at the junction to recover higher
+    smoothness when the geometry permits it.
+
+    Args:
+        bspline1: First B-spline (left side of the join).
+        bspline2: Second B-spline (right side of the join).
+        axis: Parametric axis along which to join (0-indexed).
+
+    Returns:
+        Bspline: A single B-spline spanning both inputs.
+
+    Raises:
+        ValueError: If the inputs have different parametric dimensions.
+        ValueError: If *axis* is out of range.
+    """
+    dim = bspline1.dim
+    if dim != bspline2.dim:
+        raise ValueError(
+            f"Both B-splines must have the same dim, got {bspline1.dim} and {bspline2.dim}."
+        )
+    if axis < 0 or axis >= dim:
+        raise ValueError(f"axis must be in [0, {dim}), got {axis}.")
+
+    b1, b2, is_rational = _prepare_for_join(bspline1, bspline2, axis)
+    return _concatenate_along_axis(b1, b2, axis, is_rational)
+
+
+def _try_remove_junction_knots(
+    bspline: Bspline,
+    axis: int,
+    u_junction: float,
+    p: int,
+) -> Bspline:
+    """Try removing junction knots to increase smoothness.
+
+    Attempts to remove up to ``p - 1`` copies of the junction knot.
+
+    Args:
+        bspline: The joined B-spline.
+        axis: Join axis.
+        u_junction: Knot value at the junction.
+        p: Degree on the join axis.
+
+    Returns:
+        Bspline: B-spline with some junction knots removed, or the
+        original if removal was not possible.
+    """
+    dim = bspline.dim
+    if dim == 1:
+        return bspline.remove_knots(u_junction, num=p - 1)
+
+    per_dim: list[npt.ArrayLike | None] = [None] * dim
+    per_dim[axis] = np.array([u_junction])
+    return bspline.remove_knots(per_dim, num=p - 1)

--- a/src/pantr/cad/_operations.py
+++ b/src/pantr/cad/_operations.py
@@ -1,8 +1,8 @@
-"""Constructive operations: extrude and ruled.
+"""Constructive operations: extrude, revolve, ruled, and sweep.
 
 Provides functions that create higher-dimensional B-spline objects
-by combining existing ones: extrusion along a vector and ruled
-interpolation between two patches.
+by combining existing ones: extrusion along a vector, revolution
+around an axis, ruled interpolation, and translational sweep.
 """
 
 from __future__ import annotations
@@ -11,11 +11,13 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace
+from ..transform import AffineTransform
 from ._compat import compat
-from ._primitives import _linear_space_1d
+from ._primitives import _linear_space_1d, circle
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
 _MAX_DIM_FOR_OPERATIONS = 2
+_NORM_TOL = 1e-14
 
 
 def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
@@ -119,5 +121,234 @@ def ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
     new_cp[..., 1, :] = cp2
 
     spaces = [*b1.space.spaces, _linear_space_1d(dtype=b1.dtype)]
+    new_space = BsplineSpace(spaces)
+    return Bspline(new_space, new_cp, is_rational=is_rational)
+
+
+def _normalize_axis_vector(axis: int | npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """Convert an axis specification to a unit 3D vector.
+
+    Args:
+        axis: An ``int`` (coordinate axis) or array-like direction.
+
+    Returns:
+        npt.NDArray[np.float64]: Unit vector of shape ``(3,)``.
+
+    Raises:
+        ValueError: If the vector is zero.
+    """
+    if isinstance(axis, int | np.integer):
+        v = np.zeros(_PHYSICAL_DIM, dtype=np.float64)
+        v[int(axis)] = 1.0
+        return v
+
+    v = np.zeros(_PHYSICAL_DIM, dtype=np.float64)
+    arr = np.asarray(axis, dtype=np.float64).ravel()
+    v[: arr.size] = arr
+    norm = np.linalg.norm(v)
+    if norm == 0:
+        raise ValueError("Rotation axis must be non-zero.")
+    v /= norm
+    return v
+
+
+def _build_axis_alignment_transform(
+    pt: npt.NDArray[np.float64],
+    v: npt.NDArray[np.float64],
+) -> AffineTransform:
+    """Build a transform that translates *pt* to origin and aligns *v* with Z.
+
+    Args:
+        pt: Point on the rotation axis (shape ``(3,)``).
+        v: Unit rotation axis vector (shape ``(3,)``).
+
+    Returns:
+        AffineTransform: The combined translate-then-rotate transform.
+    """
+    z_hat = np.array([0.0, 0.0, 1.0])
+    n = np.cross(v, z_hat)
+    gamma = float(np.arccos(np.clip(v[2], -1.0, 1.0)))
+
+    t_translate = AffineTransform.translation(-pt)
+    if np.linalg.norm(n) > _NORM_TOL:
+        t_rotate = AffineTransform.rotation_3d(gamma, axis=n)
+        return t_rotate @ t_translate
+    elif v[2] < 0:
+        # v = -z, flip via rotation by pi around x
+        t_rotate = AffineTransform.rotation_3d(np.pi, axis=0)
+        return t_rotate @ t_translate
+    else:
+        return t_translate
+
+
+def _revolve_control_points(
+    cw: npt.NDArray[np.float64],
+    arc: Bspline,
+) -> npt.NDArray[np.float64]:
+    """Revolve weighted homogeneous control points around the Z axis.
+
+    For each control point in *cw*, builds a per-point transform
+    ``M = Rz(theta) * Tz(z) * Sxy(rho)`` and applies it to the arc
+    control points, multiplying by the original weight.
+
+    Args:
+        cw: Control points in Z-aligned frame, shape ``(*num_basis, 4)``.
+        arc: Circular arc B-spline.
+
+    Returns:
+        npt.NDArray[np.float64]: Revolved control points of shape
+        ``(*num_basis, n_arc, 4)``.
+    """
+    aw = arc.control_points
+    nrb_shape = cw.shape[:-1]
+    n_arc = aw.shape[0]
+    qw = np.empty((*nrb_shape, n_arc, _PHYSICAL_DIM + 1), dtype=np.float64)
+
+    wx = cw[..., 0]
+    wy = cw[..., 1]
+    wz = cw[..., 2]
+    w = cw[..., _PHYSICAL_DIM]
+    rho = np.hypot(wx, wy)
+    theta = np.arctan2(wy, wx)
+    theta[theta < 0] += 2 * np.pi
+    sin_t = np.sin(theta)
+    cos_t = np.cos(theta)
+
+    for idx in np.ndindex(nrb_shape):
+        r = float(rho[idx])
+        r_cos = r * float(cos_t[idx])
+        r_sin = r * float(sin_t[idx])
+
+        m = np.zeros((4, 4), dtype=np.float64)
+        m[0, 0] = r_cos
+        m[0, 1] = -r_sin
+        m[1, 0] = r_sin
+        m[1, 1] = r_cos
+        m[2, 3] = float(wz[idx])
+        m[3, 3] = 1.0
+
+        qi = aw @ m.T
+        qi[..., _PHYSICAL_DIM] *= float(w[idx])
+        qw[idx] = qi
+
+    return qw
+
+
+def revolve(
+    bspline: Bspline,
+    point: npt.ArrayLike,
+    axis: int | npt.ArrayLike = 2,
+    angle: float | tuple[float, float] | None = None,
+) -> Bspline:
+    """Revolve a B-spline curve or surface around an axis.
+
+    Creates a new B-spline with one additional parametric dimension
+    (the angular direction, appended last).  The input is first
+    promoted to rational if needed, then transformed to a coordinate
+    system aligned with the rotation axis, revolved via the circular
+    arc construction, and transformed back.
+
+    The angular direction inherits the same span/continuity structure
+    as :func:`circle`: one span per 90 degrees, C0 at arc junctions.
+
+    Args:
+        bspline: Input curve (dim=1) or surface (dim=2) with rank 3.
+        point: A point on the rotation axis (up to 3D, zero-padded).
+        axis: Rotation axis.  An ``int`` in ``{0, 1, 2}`` selects
+            a coordinate axis.  An array-like of length 3 specifies
+            an arbitrary axis direction (normalised internally).
+        angle: Sweep specification (same as :func:`circle`).
+
+    Returns:
+        Bspline: A rational B-spline with ``dim + 1`` dimensions.
+
+    Raises:
+        ValueError: If ``bspline.dim > 2``.
+        ValueError: If ``bspline.rank != 3``.
+    """
+    if bspline.dim > _MAX_DIM_FOR_OPERATIONS:
+        raise ValueError(f"revolve requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}.")
+    if bspline.rank != _PHYSICAL_DIM:
+        raise ValueError(f"revolve requires rank == {_PHYSICAL_DIM}, got {bspline.rank}.")
+
+    pt = _pad_to_3d(point)
+    v = _normalize_axis_vector(axis)
+    t = _build_axis_alignment_transform(pt, v)
+
+    nrb = _promote_to_rational(bspline)
+    nrb_transformed = nrb.transform(t)
+    assert nrb_transformed is not None
+
+    arc = circle(angle=angle)
+    qw = _revolve_control_points(np.asarray(nrb_transformed.control_points, dtype=np.float64), arc)
+
+    spaces = [*nrb_transformed.space.spaces, *arc.space.spaces]
+    new_space = BsplineSpace(spaces)
+    result = Bspline(new_space, qw, is_rational=True)
+    result_back = result.transform(t.inverse)
+    assert result_back is not None
+    return result_back
+
+
+def sweep(section: Bspline, trajectory: Bspline) -> Bspline:
+    """Construct the translational sweep of a section along a trajectory.
+
+    Creates a new B-spline by summing the section and trajectory
+    geometries: ``S(u, v) = section(u) + trajectory(v)``.  The
+    trajectory direction is appended as the last parametric axis.
+
+    For rational B-splines the product formula applies: the result
+    weight is the product of section and trajectory weights, and the
+    weighted coordinates combine as
+    ``w_s * C_t + w_t * C_s``.
+
+    Args:
+        section: Section curve (dim=1) or surface (dim=2).
+        trajectory: Trajectory curve (dim=1).
+
+    Returns:
+        Bspline: A B-spline with ``section.dim + 1`` dimensions.
+
+    Raises:
+        ValueError: If ``section.dim > 2``.
+        ValueError: If ``trajectory.dim != 1``.
+    """
+    if section.dim > _MAX_DIM_FOR_OPERATIONS:
+        raise ValueError(
+            f"sweep requires section.dim <= {_MAX_DIM_FOR_OPERATIONS}, got {section.dim}."
+        )
+    if trajectory.dim != 1:
+        raise ValueError(f"sweep requires trajectory.dim == 1, got {trajectory.dim}.")
+
+    is_rational = section.is_rational or trajectory.is_rational
+
+    if is_rational:
+        sec = _promote_to_rational(section)
+        traj = _promote_to_rational(trajectory)
+        cp_s = sec.control_points
+        cp_t = traj.control_points
+
+        ws = cp_s[..., _PHYSICAL_DIM]
+        wt = cp_t[..., _PHYSICAL_DIM]
+        cs = cp_s[..., :_PHYSICAL_DIM]
+        ct = cp_t[..., :_PHYSICAL_DIM]
+
+        # Weighted coords: w_t * C_s + w_s * C_t
+        term_s = cs[..., np.newaxis, :] * wt[..., np.newaxis]
+        term_t = ct * ws[..., np.newaxis, np.newaxis]
+        new_coords = term_s + term_t
+        new_weights = ws[..., np.newaxis] * wt
+
+        new_cp = np.concatenate(
+            [new_coords, new_weights[..., np.newaxis]],
+            axis=-1,
+        )
+        spaces = [*sec.space.spaces, *traj.space.spaces]
+    else:
+        cp_s = section.control_points
+        cp_t = trajectory.control_points
+        new_cp = cp_s[..., np.newaxis, :] + cp_t
+        spaces = [*section.space.spaces, *trajectory.space.spaces]
+
     new_space = BsplineSpace(spaces)
     return Bspline(new_space, new_cp, is_rational=is_rational)

--- a/src/pantr/cad/_operations.py
+++ b/src/pantr/cad/_operations.py
@@ -1,0 +1,123 @@
+"""Constructive operations: extrude and ruled.
+
+Provides functions that create higher-dimensional B-spline objects
+by combining existing ones: extrusion along a vector and ruled
+interpolation between two patches.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import typing as npt
+
+from ..bspline import Bspline, BsplineSpace
+from ._compat import compat
+from ._primitives import _linear_space_1d
+from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
+
+_MAX_DIM_FOR_OPERATIONS = 2
+
+
+def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
+    """Extrude a B-spline curve or surface along a displacement vector.
+
+    Creates a new B-spline with one additional parametric dimension by
+    translating the input along the given vector.  The new direction is
+    appended as the last parametric axis with degree 1 and knots
+    ``[0, 0, 1, 1]``.
+
+    Args:
+        bspline: Input curve (dim=1) or surface (dim=2).
+        displacement: Translation vector (up to 3D, zero-padded).
+
+    Returns:
+        Bspline: A B-spline with ``dim + 1`` parametric dimensions.
+
+    Raises:
+        ValueError: If ``bspline.dim > 2``.
+
+    Example:
+        >>> from pantr.cad import circle, extrude
+        >>> cyl = extrude(circle(), [0, 0, 1])
+        >>> cyl.dim
+        2
+    """
+    if bspline.dim > _MAX_DIM_FOR_OPERATIONS:
+        raise ValueError(f"extrude requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}.")
+
+    disp = _pad_to_3d(displacement)
+    cp = bspline.control_points
+    orig_shape = cp.shape[:-1]  # (*num_basis,)
+    rank_full = cp.shape[-1]
+
+    new_cp = np.empty((*orig_shape, 2, rank_full), dtype=cp.dtype)
+    new_cp[..., 0, :] = cp
+
+    if bspline.is_rational:
+        # Weighted homogeneous: (w*x, w*y, w*z, w)
+        # Translated: (w*x + w*dx, w*y + w*dy, w*z + w*dz, w)
+        new_cp[..., 1, :] = cp
+        weights = cp[..., _PHYSICAL_DIM : _PHYSICAL_DIM + 1]
+        new_cp[..., 1, :_PHYSICAL_DIM] = cp[..., :_PHYSICAL_DIM] + weights * disp
+    else:
+        new_cp[..., 1, :] = cp + disp[:rank_full].astype(cp.dtype)
+
+    spaces = [*bspline.space.spaces, _linear_space_1d(dtype=bspline.dtype)]
+    new_space = BsplineSpace(spaces)
+    return Bspline(new_space, new_cp, is_rational=bspline.is_rational)
+
+
+def ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
+    """Construct a ruled surface or volume between two B-splines.
+
+    Creates a new B-spline by linearly interpolating control points
+    between *bspline1* (at parameter 0) and *bspline2* (at parameter 1)
+    along a new last parametric axis with degree 1.
+
+    The two inputs are first made compatible via :func:`compat` so they
+    share the same degree and knot vectors.  If one is rational and the
+    other is not, the non-rational one is promoted.
+
+    Args:
+        bspline1: First boundary (curve or surface, dim <= 2).
+        bspline2: Second boundary (same dim as *bspline1*).
+
+    Returns:
+        Bspline: A B-spline with ``dim + 1`` parametric dimensions.
+
+    Raises:
+        ValueError: If the inputs have different parametric dimensions.
+        ValueError: If either input has ``dim > 2``.
+
+    Example:
+        >>> from pantr.cad import circle, ruled
+        >>> annulus = ruled(circle(radius=0.5), circle(radius=1.0))
+        >>> annulus.dim
+        2
+    """
+    if bspline1.dim != bspline2.dim:
+        raise ValueError(
+            f"Both B-splines must have the same dim, got {bspline1.dim} and {bspline2.dim}."
+        )
+    if bspline1.dim > _MAX_DIM_FOR_OPERATIONS:
+        raise ValueError(f"ruled requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline1.dim}.")
+
+    b1, b2 = compat(bspline1, bspline2)
+
+    # Promote to rational if needed
+    is_rational = b1.is_rational or b2.is_rational
+    if is_rational:
+        b1 = _promote_to_rational(b1)
+        b2 = _promote_to_rational(b2)
+
+    cp1 = b1.control_points
+    cp2 = b2.control_points
+    rank_full = cp1.shape[-1]
+
+    new_cp = np.empty((*cp1.shape[:-1], 2, rank_full), dtype=cp1.dtype)
+    new_cp[..., 0, :] = cp1
+    new_cp[..., 1, :] = cp2
+
+    spaces = [*b1.space.spaces, _linear_space_1d(dtype=b1.dtype)]
+    new_space = BsplineSpace(spaces)
+    return Bspline(new_space, new_cp, is_rational=is_rational)

--- a/src/pantr/cad/_primitives.py
+++ b/src/pantr/cad/_primitives.py
@@ -21,7 +21,7 @@ _BILINEAR_SHAPE = (2, 2)
 _TRILINEAR_SHAPE = (2, 2, 2)
 
 
-def _linear_space_1d(dtype: type[np.float64] = np.float64) -> BsplineSpace1D:
+def _linear_space_1d(dtype: npt.DTypeLike = np.float64) -> BsplineSpace1D:
     """Create a degree-1 B-spline space on [0, 1].
 
     Args:

--- a/src/pantr/cad/_primitives.py
+++ b/src/pantr/cad/_primitives.py
@@ -1,9 +1,9 @@
-"""Constructive geometry primitives: line, bilinear, and trilinear.
+"""Constructive geometry primitives: line, circle, bilinear, and trilinear.
 
 Provides functions to create basic B-spline objects from geometric
-descriptions (points, corners).  All primitives produce rank-3 (3D)
-output so they can be freely composed with higher-level operations
-such as ``extrude`` and ``revolve``.
+descriptions (points, corners, radii, angles).  All primitives produce
+rank-3 (3D) output so they can be freely composed with higher-level
+operations such as ``extrude`` and ``revolve``.
 """
 
 from __future__ import annotations
@@ -12,8 +12,11 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ..transform import AffineTransform
 from ._validation import _PHYSICAL_DIM, _pad_to_3d
 
+_DEGREE_CIRCLE = 2
+_QUADRANT_BOUNDS = (0.0, np.pi / 2, np.pi, 3 * np.pi / 2)
 _BILINEAR_SHAPE = (2, 2)
 _TRILINEAR_SHAPE = (2, 2, 2)
 
@@ -60,6 +63,181 @@ def line(
     control_points = np.stack([pt0, pt1])  # shape (2, 3)
     space = BsplineSpace([_linear_space_1d()])
     return Bspline(space, control_points)
+
+
+def _rotate_weighted(
+    cw: npt.NDArray[np.float64],
+    angle: float,
+    axis: int = 2,
+) -> npt.NDArray[np.float64]:
+    """Rotate weighted homogeneous control points around a coordinate axis.
+
+    For a point ``(w*x, w*y, w*z, w)``, the rotation is applied to the
+    spatial part ``(w*x, w*y, w*z)`` while the weight ``w`` is preserved.
+
+    Args:
+        cw: Control points of shape ``(..., 4)`` in weighted homogeneous form.
+        angle: Rotation angle in radians.
+        axis: Coordinate axis (0, 1, or 2).
+
+    Returns:
+        npt.NDArray[np.float64]: Rotated control points, same shape as *cw*.
+    """
+    R = AffineTransform.rotation_3d(angle, axis=axis)
+    out = cw.copy()
+    out[..., :_PHYSICAL_DIM] = cw[..., :_PHYSICAL_DIM] @ R.matrix.T
+    return out
+
+
+def circle(
+    radius: float = 1.0,
+    center: npt.ArrayLike | None = None,
+    angle: float | tuple[float, float] | None = None,
+) -> Bspline:
+    """Construct a NURBS circular arc or full circle.
+
+    Creates a degree-2 rational B-spline curve in the *xy*-plane.  The
+    arc is split into spans of at most 90 degrees each.  Interior knots
+    have multiplicity 2 (equal to the degree), giving C0 continuity at
+    arc junctions.  This is the standard exact representation of conics
+    using rational quadratic B-splines.
+
+    The number of spans depends on the sweep angle:
+
+    - ``|sweep| <= 90``: 1 span, 3 control points
+    - ``90 < |sweep| <= 180``: 2 spans, 5 control points
+    - ``180 < |sweep| <= 270``: 3 spans, 7 control points
+    - ``270 < |sweep| <= 360``: 4 spans, 9 control points
+
+    Args:
+        radius: Circle radius.  Defaults to 1.
+        center: Center point (up to 3D, zero-padded).  If ``None``,
+            the circle is centered at the origin.
+        angle: Sweep specification.
+
+            - ``None`` -- full circle (360 degrees).
+            - ``float`` -- arc from angle 0 to the given value (radians).
+            - ``(start, end)`` -- arc from *start* to *end* (radians).
+
+    Returns:
+        Bspline: A 1D, degree-2, rank-3, rational B-spline curve.
+
+    Example:
+        >>> crv = circle()
+        >>> crv.degree
+        (2,)
+        >>> crv.is_rational
+        True
+    """
+    if angle is None:
+        cw = _build_full_circle(radius)
+        spans = 4
+    else:
+        if isinstance(angle, tuple | list):
+            start, end = angle
+        else:
+            start, end = 0.0, float(angle)
+        sweep = end - start
+        spans = int(np.searchsorted(_QUADRANT_BOUNDS, abs(sweep)))
+        spans = max(spans, 1)
+        cw = _build_arc(radius, start, sweep, spans)
+
+    # Translate to center
+    if center is not None:
+        c = _pad_to_3d(center)
+        # For weighted homogeneous: (w*x, w*y, w*z, w) -> (w*x + w*cx, ...)
+        cw[:, :_PHYSICAL_DIM] += cw[:, _PHYSICAL_DIM : _PHYSICAL_DIM + 1] * c
+
+    # Build knot vector: [0,0,0, u1,u1, u2,u2, ..., 1,1,1]
+    knots = np.empty(2 * (spans + 1) + 2, dtype=np.float64)
+    knots[0] = 0.0
+    knots[-1] = 1.0
+    knots[1:-1] = np.linspace(0.0, 1.0, spans + 1).repeat(2)
+
+    space = BsplineSpace([BsplineSpace1D(knots, degree=_DEGREE_CIRCLE)])
+    return Bspline(space, cw, is_rational=True)
+
+
+def _build_full_circle(radius: float) -> npt.NDArray[np.float64]:
+    """Build weighted homogeneous control points for a full circle.
+
+    Args:
+        radius: Circle radius.
+
+    Returns:
+        npt.NDArray[np.float64]: Array of shape ``(9, 4)``.
+    """
+    wm = np.sqrt(2.0) / 2.0
+    cw = np.zeros((9, _PHYSICAL_DIM + 1), dtype=np.float64)
+    cw[:, :2] = [
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [-1, 1],
+        [-1, 0],
+        [-1, -1],
+        [0, -1],
+        [1, -1],
+        [1, 0],
+    ]
+    cw[:, :2] *= radius
+    cw[:, _PHYSICAL_DIM] = 1.0
+    cw[1::2, :] *= wm
+    return cw
+
+
+def _build_arc(
+    radius: float,
+    start: float,
+    sweep: float,
+    spans: int,
+) -> npt.NDArray[np.float64]:
+    """Build weighted homogeneous control points for a circular arc.
+
+    Constructs a template arc bisected by the +X axis, then rotates it
+    to the correct starting angle.  Subsequent spans are obtained by
+    successive rotation of the previous span's last two control points.
+
+    Args:
+        radius: Circle radius.
+        start: Start angle in radians.
+        sweep: Sweep angle in radians (may be negative).
+        spans: Number of quadratic arc spans.
+
+    Returns:
+        npt.NDArray[np.float64]: Array of shape ``(2*spans+1, 4)``.
+    """
+    alpha = sweep / (2 * spans)
+    sin_a = np.sin(alpha)
+    cos_a = np.cos(alpha)
+    tan_a = np.tan(alpha)
+    x = radius * cos_a
+    y = radius * sin_a
+    wm = cos_a
+    xm = x + y * tan_a
+
+    # Template arc: 3 control points bisected by +X axis
+    template = np.array(
+        [
+            [x, -y, 0.0, 1.0],
+            [wm * xm, 0.0, 0.0, wm],
+            [x, y, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+
+    # Rotate template to the correct starting position
+    cw = np.empty((2 * spans + 1, _PHYSICAL_DIM + 1), dtype=np.float64)
+    cw[0:3] = _rotate_weighted(template, alpha + start)
+
+    # Each subsequent span is a rotation of the previous one
+    if spans > 1:
+        two_alpha = 2.0 * alpha
+        for i in range(1, spans):
+            n = 2 * i + 1
+            cw[n : n + 2] = _rotate_weighted(cw[n - 2 : n], two_alpha)
+
+    return cw
 
 
 def bilinear(corners: npt.ArrayLike | None = None) -> Bspline:

--- a/tests/test_cad_compat.py
+++ b/tests/test_cad_compat.py
@@ -1,0 +1,193 @@
+"""Tests for the compat (B-spline compatibility) function."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.cad import circle, compat, line
+
+_KNOT_TOL = 1e-14
+
+
+def _make_curve(knots: list[float], degree: int, rank: int = 1) -> Bspline:
+    """Build a simple 1D B-spline curve with sequential control points."""
+    sp = BsplineSpace1D(np.array(knots, dtype=np.float64), degree)
+    n = sp.num_basis
+    cp = np.arange(n * rank, dtype=np.float64).reshape(n, rank)
+    return Bspline(BsplineSpace([sp]), cp)
+
+
+def _make_surface(
+    knots_u: list[float],
+    deg_u: int,
+    knots_v: list[float],
+    deg_v: int,
+) -> Bspline:
+    """Build a simple 2D B-spline surface with sequential control points."""
+    sp_u = BsplineSpace1D(np.array(knots_u, dtype=np.float64), deg_u)
+    sp_v = BsplineSpace1D(np.array(knots_v, dtype=np.float64), deg_v)
+    space = BsplineSpace([sp_u, sp_v])
+    n = space.num_total_basis
+    cp = np.arange(n * 3, dtype=np.float64).reshape(*space.num_basis, 3)
+    return Bspline(space, cp)
+
+
+class TestCompatBasic:
+    """Test basic compat behavior."""
+
+    def test_single_input_returned_unchanged(self) -> None:
+        """Test that a single B-spline is returned as-is."""
+        crv = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
+        result = compat(crv)
+        assert len(result) == 1
+        assert_allclose(result[0].control_points, crv.control_points)
+
+    def test_identical_curves_unchanged(self) -> None:
+        """Test that two identical curves come back with same structure."""
+        crv = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
+        r1, r2 = compat(crv, crv)
+        assert r1.degree == crv.degree
+        assert_allclose(r1.space.spaces[0].knots, crv.space.spaces[0].knots)
+
+    def test_different_dim_raises(self) -> None:
+        """Test that mixing curve and surface raises ValueError."""
+        crv = _make_curve([0, 0, 1, 1], degree=1)
+        srf = _make_surface([0, 0, 1, 1], 1, [0, 0, 1, 1], 1)
+        with pytest.raises(ValueError, match="dimension"):
+            compat(crv, srf)
+
+    def test_axis_out_of_range_raises(self) -> None:
+        """Test that an out-of-range axis raises ValueError."""
+        crv = _make_curve([0, 0, 1, 1], degree=1)
+        with pytest.raises(ValueError, match="out of range"):
+            compat(crv, crv, axes=5)
+
+
+class TestCompatDegreeElevation:
+    """Test that compat elevates degrees to match."""
+
+    def test_different_degrees(self) -> None:
+        """Test curves with different degrees get elevated to max."""
+        c1 = _make_curve([0, 0, 1, 1], degree=1)
+        c2 = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
+        r1, r2 = compat(c1, c2)
+        assert r1.degree == (2,)
+        assert r2.degree == (2,)
+
+    def test_geometric_invariance_after_elevation(self) -> None:
+        """Test that degree elevation preserves the geometry."""
+        c1 = line([0, 0, 0], [1, 0, 0])
+        c2 = circle(angle=np.pi / 2)
+        t = np.linspace(0, 1, 20)
+        pts_before_1 = c1.evaluate(t)
+        pts_before_2 = c2.evaluate(t)
+        r1, r2 = compat(c1, c2)
+        pts_after_1 = r1.evaluate(t)
+        pts_after_2 = r2.evaluate(t)
+        assert_allclose(pts_after_1, pts_before_1, atol=1e-13)
+        assert_allclose(pts_after_2, pts_before_2, atol=1e-13)
+
+
+class TestCompatDomainRemap:
+    """Test that compat remaps domains to a common envelope."""
+
+    def test_different_domains(self) -> None:
+        """Test curves with different domains get remapped."""
+        c1 = _make_curve([0, 0, 1, 1], degree=1)
+        c2 = _make_curve([2, 2, 3, 3], degree=1)
+        r1, r2 = compat(c1, c2)
+        assert_allclose(r1.space.spaces[0].domain, [0, 3])
+        assert_allclose(r2.space.spaces[0].domain, [0, 3])
+
+
+class TestCompatKnotMerge:
+    """Test that compat merges knot vectors."""
+
+    def test_different_interior_knots(self) -> None:
+        """Test curves with different interior knots get merged."""
+        # c1 has interior knot at 0.5; c2 has interior knot at 0.3
+        c1 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
+        c2 = _make_curve([0, 0, 0, 0.3, 1, 1, 1], degree=2)
+        r1, r2 = compat(c1, c2)
+        # Both should have interior knots at 0.3 and 0.5
+        knots1 = r1.space.spaces[0].knots
+        knots2 = r2.space.spaces[0].knots
+        assert_allclose(knots1, knots2)
+        # Check that both 0.3 and 0.5 appear in the knot vector
+        assert np.any(np.abs(knots1 - 0.3) < _KNOT_TOL)
+        assert np.any(np.abs(knots1 - 0.5) < _KNOT_TOL)
+
+    def test_geometric_invariance_after_knot_insertion(self) -> None:
+        """Test that knot insertion preserves the geometry."""
+        c1 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2, rank=3)
+        c2 = _make_curve([0, 0, 0, 0.3, 1, 1, 1], degree=2, rank=3)
+        t = np.linspace(0, 1, 30)
+        pts_before_1 = c1.evaluate(t)
+        pts_before_2 = c2.evaluate(t)
+        r1, r2 = compat(c1, c2)
+        pts_after_1 = r1.evaluate(t)
+        pts_after_2 = r2.evaluate(t)
+        assert_allclose(pts_after_1, pts_before_1, atol=1e-12)
+        assert_allclose(pts_after_2, pts_before_2, atol=1e-12)
+
+    def test_multiplicity_max(self) -> None:
+        """Test that merged knot has max multiplicity across inputs."""
+        # c1: knot at 0.5 with mult 1; c2: knot at 0.5 with mult 2
+        c1 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
+        c2 = _make_curve([0, 0, 0, 0.5, 0.5, 1, 1, 1], degree=2)
+        r1, r2 = compat(c1, c2)
+        knots1 = r1.space.spaces[0].knots
+        knots2 = r2.space.spaces[0].knots
+        assert_allclose(knots1, knots2)
+        # 0.5 should appear with multiplicity 2
+        count_05 = np.sum(np.abs(knots1 - 0.5) < _KNOT_TOL)
+        assert count_05 == 2  # noqa: PLR2004
+
+
+class TestCompatSurface:
+    """Test compat on surfaces with selective axes."""
+
+    def test_selective_axis(self) -> None:
+        """Test compat on a single axis of a 2D B-spline."""
+        s1 = _make_surface([0, 0, 1, 1], 1, [0, 0, 0, 1, 1, 1], 2)
+        s2 = _make_surface([0, 0, 0, 1, 1, 1], 2, [0, 0, 0, 1, 1, 1], 2)
+        r1, r2 = compat(s1, s2, axes=0)
+        # Axis 0 should be elevated to degree 2
+        assert r1.degree[0] == 2  # noqa: PLR2004
+        assert r2.degree[0] == 2  # noqa: PLR2004
+        # Axis 1 should be unchanged for s1
+        assert r1.degree[1] == 2  # noqa: PLR2004
+
+
+class TestCompatCombined:
+    """Test compat with all three stages active simultaneously."""
+
+    def test_degree_and_knots(self) -> None:
+        """Test compat with both different degrees and different knots."""
+        c1 = _make_curve([0, 0, 1, 1], degree=1)
+        c2 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
+        r1, r2 = compat(c1, c2)
+        assert r1.degree == r2.degree
+        assert_allclose(r1.space.spaces[0].knots, r2.space.spaces[0].knots)
+
+    def test_three_curves(self) -> None:
+        """Test compat with three different curves."""
+        c1 = _make_curve([0, 0, 1, 1], degree=1, rank=3)
+        c2 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2, rank=3)
+        c3 = _make_curve([0, 0, 0, 0, 0.3, 0.7, 1, 1, 1, 1], degree=3, rank=3)
+        r1, r2, r3 = compat(c1, c2, c3)
+        # All should have degree 3
+        assert r1.degree == (3,)
+        assert r2.degree == (3,)
+        assert r3.degree == (3,)
+        # All should share the same knot vector
+        assert_allclose(r1.space.spaces[0].knots, r2.space.spaces[0].knots)
+        assert_allclose(r2.space.spaces[0].knots, r3.space.spaces[0].knots)
+        # Geometry preserved
+        t = np.linspace(0, 1, 30)
+        assert_allclose(r1.evaluate(t), c1.evaluate(t), atol=1e-12)
+        assert_allclose(r2.evaluate(t), c2.evaluate(t), atol=1e-12)
+        assert_allclose(r3.evaluate(t), c3.evaluate(t), atol=1e-12)

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -1,0 +1,172 @@
+"""Tests for Coons surface and volume constructions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.bspline import Bspline
+from pantr.cad import bilinear, coons_surface, coons_volume, line
+
+_RANK_3D = 3
+
+
+class TestCoonsSurface:
+    """Test the coons_surface function."""
+
+    def test_four_straight_lines_gives_bilinear(self) -> None:
+        """Test Coons from 4 straight lines matches bilinear."""
+        c_u0 = line([0, 0, 0], [1, 0, 0])
+        c_u1 = line([0, 1, 0], [1, 1, 0])
+        c_v0 = line([0, 0, 0], [0, 1, 0])
+        c_v1 = line([1, 0, 0], [1, 1, 0])
+
+        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        assert srf.dim == 2  # noqa: PLR2004
+        assert srf.rank == _RANK_3D
+
+        # Should match bilinear
+        corners = np.array(
+            [[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]],
+            dtype=np.float64,
+        )
+        ref = bilinear(corners)
+        t = np.linspace(0, 1, 10)
+        params = np.array([[u, v] for u in t for v in t])
+        assert_allclose(srf.evaluate(params), ref.evaluate(params), atol=1e-13)
+
+    def test_evaluate_corners(self) -> None:
+        """Test that Coons surface evaluates correctly at corners."""
+        c_u0 = line([0, 0, 0], [3, 0, 0])
+        c_u1 = line([0, 2, 0], [3, 2, 0])
+        c_v0 = line([0, 0, 0], [0, 2, 0])
+        c_v1 = line([3, 0, 0], [3, 2, 0])
+
+        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        pts = srf.evaluate(
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                ]
+            )
+        )
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [3, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [0, 2, 0], atol=1e-14)
+        assert_allclose(pts[3], [3, 2, 0], atol=1e-14)
+
+    def test_non_planar_coons(self) -> None:
+        """Test Coons with non-planar boundaries."""
+        c_u0 = line([0, 0, 0], [1, 0, 0])
+        c_u1 = line([0, 0, 1], [1, 0, 1])
+        c_v0 = line([0, 0, 0], [0, 0, 1])
+        c_v1 = line([1, 0, 0], [1, 0, 1])
+
+        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        # Should be a flat rectangle in the xz plane
+        pt = srf.evaluate(np.array([[0.5, 0.5]]))
+        assert_allclose(pt, [0.5, 0, 0.5], atol=1e-13)
+
+    def test_non_1d_curve_raises(self) -> None:
+        """Test that a surface as input raises ValueError."""
+        srf = bilinear()
+        crv = line([0, 0, 0], [1, 0, 0])
+        with pytest.raises(ValueError, match="1D"):
+            coons_surface(((crv, crv), (srf, crv)))
+
+    def test_corner_mismatch_raises(self) -> None:
+        """Test that inconsistent corners raise ValueError."""
+        c_u0 = line([0, 0, 0], [1, 0, 0])
+        c_u1 = line([0, 1, 0], [1, 1, 0])
+        c_v0 = line([0, 0, 0], [0, 1, 0])
+        c_v1 = line([2, 0, 0], [2, 1, 0])  # wrong: should start at (1,0,0)
+
+        with pytest.raises(ValueError, match="mismatch"):
+            coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+
+
+class TestCoonsVolume:
+    """Test the coons_volume function."""
+
+    def _make_cube_faces(
+        self,
+    ) -> tuple[
+        tuple[Bspline, Bspline],
+        tuple[Bspline, Bspline],
+        tuple[Bspline, Bspline],
+    ]:
+        """Build 6 planar faces of the unit cube [0,1]^3."""
+        # face_u0: u=0 plane, parameterized by (v, w)
+        face_u0 = bilinear(
+            np.array([[[0, 0, 0], [0, 0, 1]], [[0, 1, 0], [0, 1, 1]]], dtype=np.float64)
+        )
+        # face_u1: u=1 plane
+        face_u1 = bilinear(
+            np.array([[[1, 0, 0], [1, 0, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=np.float64)
+        )
+        # face_v0: v=0 plane, parameterized by (u, w)
+        face_v0 = bilinear(
+            np.array([[[0, 0, 0], [0, 0, 1]], [[1, 0, 0], [1, 0, 1]]], dtype=np.float64)
+        )
+        # face_v1: v=1 plane
+        face_v1 = bilinear(
+            np.array([[[0, 1, 0], [0, 1, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=np.float64)
+        )
+        # face_w0: w=0 plane, parameterized by (u, v)
+        face_w0 = bilinear(
+            np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64)
+        )
+        # face_w1: w=1 plane
+        face_w1 = bilinear(
+            np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=np.float64)
+        )
+        return (face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1)
+
+    def test_cube_properties(self) -> None:
+        """Test that Coons volume from cube faces has correct properties."""
+        faces = self._make_cube_faces()
+        vol = coons_volume(faces)
+        assert vol.dim == _RANK_3D
+        assert vol.rank == _RANK_3D
+
+    def test_cube_evaluate_center(self) -> None:
+        """Test evaluation at the center of the unit cube."""
+        faces = self._make_cube_faces()
+        vol = coons_volume(faces)
+        pt = vol.evaluate(np.array([[0.5, 0.5, 0.5]]))
+        assert_allclose(pt, [0.5, 0.5, 0.5], atol=1e-13)
+
+    def test_cube_evaluate_corners(self) -> None:
+        """Test evaluation at all 8 corners of the unit cube."""
+        faces = self._make_cube_faces()
+        vol = coons_volume(faces)
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    pt = vol.evaluate(np.array([[float(i), float(j), float(k)]]))
+                    assert_allclose(pt, [float(i), float(j), float(k)], atol=1e-13)
+
+    def test_cube_boundaries_match_faces(self) -> None:
+        """Test that volume boundaries match the input faces."""
+        faces = self._make_cube_faces()
+        vol = coons_volume(faces)
+        # Evaluate on the u=0 face
+        t = np.linspace(0, 1, 5)
+        params_face_u0 = np.array([[0.0, v, w] for v in t for w in t])
+        pts_vol = vol.evaluate(params_face_u0)
+        # Compare with face_u0 evaluation
+        params_face = np.array([[v, w] for v in t for w in t])
+        (face_u0, _), _, _ = faces
+        pts_face = face_u0.evaluate(params_face)
+        assert_allclose(pts_vol, pts_face, atol=1e-12)
+
+    def test_non_2d_face_raises(self) -> None:
+        """Test that a 1D input raises ValueError."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = bilinear()
+        with pytest.raises(ValueError, match="2D"):
+            coons_volume(((crv, crv), (srf, srf), (srf, srf)))

--- a/tests/test_cad_derived.py
+++ b/tests/test_cad_derived.py
@@ -1,0 +1,151 @@
+"""Tests for derived CAD primitives: rectangle, disk, cylinder."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from pantr.cad import cylinder, disk, rectangle
+
+_RANK_3D = 3
+
+
+class TestRectangle:
+    """Test the rectangle primitive."""
+
+    def test_default_rectangle(self) -> None:
+        """Test default unit rectangle."""
+        rect = rectangle()
+        assert rect.dim == 1
+        assert rect.rank == _RANK_3D
+        assert rect.degree == (1,)
+        assert not rect.is_rational
+
+    def test_closed_curve(self) -> None:
+        """Test that the rectangle is a closed curve."""
+        rect = rectangle()
+        domain = rect.space.spaces[0].domain
+        pt_start = rect.evaluate(np.array([float(domain[0])]))
+        pt_end = rect.evaluate(np.array([float(domain[1])]))
+        assert_allclose(pt_start, pt_end, atol=1e-14)
+
+    def test_custom_rectangle(self) -> None:
+        """Test rectangle with custom corner, width, height."""
+        rect = rectangle(corner=[1, 2, 0], width=3, height=4)
+        domain = rect.space.spaces[0].domain
+        t = np.linspace(float(domain[0]), float(domain[1]), 5)
+        pts = rect.evaluate(t)
+        # First point = corner, last = same (closed)
+        assert_allclose(pts[0], [1, 2, 0], atol=1e-14)
+        assert_allclose(pts[-1], [1, 2, 0], atol=1e-14)
+        # Second point should be corner + (3, 0, 0)
+        assert_allclose(pts[1], [4, 2, 0], atol=1e-14)
+
+    def test_rectangle_four_sides(self) -> None:
+        """Test that the rectangle visits all four corners."""
+        rect = rectangle(corner=[0, 0, 0], width=2, height=3)
+        domain = rect.space.spaces[0].domain
+        t = np.linspace(float(domain[0]), float(domain[1]), 5)
+        pts = rect.evaluate(t)
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [2, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [2, 3, 0], atol=1e-14)
+        assert_allclose(pts[3], [0, 3, 0], atol=1e-14)
+        assert_allclose(pts[4], [0, 0, 0], atol=1e-14)
+
+
+class TestDisk:
+    """Test the disk primitive."""
+
+    def test_full_disk(self) -> None:
+        """Test a full disk (inner radius = 0)."""
+        d = disk(radius_outer=2.0)
+        assert d.dim == 2  # noqa: PLR2004
+        assert d.is_rational
+
+    def test_annulus(self) -> None:
+        """Test an annular sector."""
+        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        assert ann.dim == 2  # noqa: PLR2004
+        assert ann.is_rational
+
+    def test_disk_points_within_radius(self) -> None:
+        """Test that disk points lie within the outer radius."""
+        d = disk(radius_outer=3.0)
+        u = np.linspace(0, 1, 15)
+        v = np.linspace(0, 1, 5)
+        params = np.array([[ui, vi] for ui in u for vi in v])
+        pts = d.evaluate(params)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert np.all(radii <= 3.0 + 1e-12)
+
+    def test_annulus_inner_boundary(self) -> None:
+        """Test that annulus inner boundary has correct radius."""
+        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        u = np.linspace(0, 1, 20)
+        params_inner = np.column_stack([u, np.zeros_like(u)])
+        pts = ann.evaluate(params_inner)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 1.0, atol=1e-13)
+
+    def test_annulus_outer_boundary(self) -> None:
+        """Test that annulus outer boundary has correct radius."""
+        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        u = np.linspace(0, 1, 20)
+        params_outer = np.column_stack([u, np.ones_like(u)])
+        pts = ann.evaluate(params_outer)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 2.0, atol=1e-13)
+
+    def test_disk_with_center(self) -> None:
+        """Test disk with offset center."""
+        d = disk(radius_outer=1.0, center=[5, 0, 0])
+        pt = d.evaluate(np.array([[0.0, 1.0]]))
+        # At v=1 (outer), u=0: should be at (6, 0, 0)
+        assert_allclose(pt, [6, 0, 0], atol=1e-13)
+
+    def test_disk_with_angle(self) -> None:
+        """Test partial disk (sector)."""
+        d = disk(radius_outer=1.0, angle=np.pi / 2)
+        assert d.dim == 2  # noqa: PLR2004
+
+
+class TestCylinder:
+    """Test the cylinder primitive."""
+
+    def test_default_cylinder(self) -> None:
+        """Test default cylinder."""
+        cyl = cylinder()
+        assert cyl.dim == 2  # noqa: PLR2004
+        assert cyl.is_rational
+
+    def test_cylinder_radius(self) -> None:
+        """Test that cylinder points lie on the correct radius."""
+        r = 2.5
+        cyl = cylinder(radius=r, height=3.0)
+        u = np.linspace(0, 1, 20)
+        v = np.array([0.0, 0.5, 1.0])
+        params = np.array([[ui, vi] for ui in u for vi in v])
+        pts = cyl.evaluate(params)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, r, atol=1e-13)
+
+    def test_cylinder_height(self) -> None:
+        """Test that cylinder z-range matches height."""
+        cyl = cylinder(radius=1.0, height=7.0)
+        # At v=0, z should be 0; at v=1, z should be 7
+        pt_bottom = cyl.evaluate(np.array([[0.0, 0.0]]))
+        pt_top = cyl.evaluate(np.array([[0.0, 1.0]]))
+        assert_allclose(pt_bottom[2], 0.0, atol=1e-14)
+        assert_allclose(pt_top[2], 7.0, atol=1e-13)
+
+    def test_cylinder_with_center(self) -> None:
+        """Test cylinder with offset center."""
+        cyl = cylinder(radius=1.0, height=1.0, center=[3, 0, 0])
+        pt = cyl.evaluate(np.array([[0.0, 0.0]]))
+        assert_allclose(pt, [4, 0, 0], atol=1e-14)
+
+    def test_cylinder_partial_angle(self) -> None:
+        """Test partial cylinder (angular sector)."""
+        cyl = cylinder(radius=1.0, height=1.0, angle=np.pi / 2)
+        assert cyl.dim == 2  # noqa: PLR2004

--- a/tests/test_cad_join.py
+++ b/tests/test_cad_join.py
@@ -1,0 +1,103 @@
+"""Tests for the join operation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.cad import bilinear, join, line
+
+
+class TestJoinCurves:
+    """Test joining 1D B-spline curves."""
+
+    def test_join_two_line_segments(self) -> None:
+        """Test joining two collinear line segments."""
+        c1 = line([0, 0, 0], [1, 0, 0])
+        c2 = line([1, 0, 0], [2, 0, 0])
+        result = join(c1, c2, axis=0)
+        assert result.dim == 1
+        # Evaluate over the full domain
+        domain = result.space.spaces[0].domain
+        t = np.linspace(float(domain[0]), float(domain[1]), 11)
+        pts = result.evaluate(t)
+        expected_x = np.linspace(0, 2, 11)
+        assert_allclose(pts[:, 0], expected_x, atol=1e-13)
+        assert_allclose(pts[:, 1], 0.0, atol=1e-14)
+        assert_allclose(pts[:, 2], 0.0, atol=1e-14)
+
+    def test_join_preserves_geometry(self) -> None:
+        """Test that join preserves the geometry of both segments."""
+        c1 = line([0, 0, 0], [1, 1, 0])
+        c2 = line([1, 1, 0], [3, 0, 0])
+        result = join(c1, c2, axis=0)
+        domain = result.space.spaces[0].domain
+        pt_start = result.evaluate(np.array([float(domain[0])]))
+        pt_end = result.evaluate(np.array([float(domain[1])]))
+        assert_allclose(pt_start, [0, 0, 0], atol=1e-14)
+        assert_allclose(pt_end, [3, 0, 0], atol=1e-14)
+
+    def test_join_c0_at_junction(self) -> None:
+        """Test C0 continuity at the junction point."""
+        c1 = line([0, 0, 0], [1, 0, 0])
+        c2 = line([1, 0, 0], [1, 1, 0])
+        result = join(c1, c2, axis=0)
+        # The junction should be at parameter u=1 (end of c1's domain)
+        pt = result.evaluate(np.array([1.0]))
+        assert_allclose(pt, [1, 0, 0], atol=1e-12)
+
+
+class TestJoinSurfaces:
+    """Test joining 2D B-spline surfaces."""
+
+    def test_join_two_bilinear_patches(self) -> None:
+        """Test joining two bilinear patches along axis 0."""
+        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
+        s2 = bilinear(np.array([[[1, 0, 0], [1, 1, 0]], [[2, 0, 0], [2, 1, 0]]], dtype=np.float64))
+        result = join(s1, s2, axis=0)
+        assert result.dim == 2  # noqa: PLR2004
+        domain_u = result.space.spaces[0].domain
+        u_end = float(domain_u[1])
+        pts = result.evaluate(
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [u_end, 0.0],
+                    [0.0, 1.0],
+                    [u_end, 1.0],
+                ]
+            )
+        )
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-13)
+        assert_allclose(pts[1], [2, 0, 0], atol=1e-13)
+        assert_allclose(pts[2], [0, 1, 0], atol=1e-13)
+        assert_allclose(pts[3], [2, 1, 0], atol=1e-13)
+
+    def test_join_along_axis_1(self) -> None:
+        """Test joining two patches along the second axis."""
+        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
+        s2 = bilinear(np.array([[[0, 1, 0], [0, 2, 0]], [[1, 1, 0], [1, 2, 0]]], dtype=np.float64))
+        result = join(s1, s2, axis=1)
+        domain_v = result.space.spaces[1].domain
+        v_end = float(domain_v[1])
+        pt = result.evaluate(np.array([[0.5, v_end]]))
+        assert_allclose(pt, [0.5, 2, 0], atol=1e-13)
+
+
+class TestJoinErrors:
+    """Test error handling in join."""
+
+    def test_different_dim_raises(self) -> None:
+        """Test that different dimensions raises ValueError."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = bilinear()
+        with pytest.raises(ValueError, match="same dim"):
+            join(crv, srf, axis=0)
+
+    def test_axis_out_of_range_raises(self) -> None:
+        """Test that out-of-range axis raises ValueError."""
+        c1 = line([0, 0, 0], [1, 0, 0])
+        c2 = line([1, 0, 0], [2, 0, 0])
+        with pytest.raises(ValueError, match="axis"):
+            join(c1, c2, axis=1)

--- a/tests/test_cad_operations.py
+++ b/tests/test_cad_operations.py
@@ -1,0 +1,169 @@
+"""Tests for CAD operations: extrude and ruled."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.cad import bilinear, circle, extrude, line, ruled
+
+_RANK_3D = 3
+
+
+class TestExtrude:
+    """Test the extrude operation."""
+
+    def test_line_to_surface(self) -> None:
+        """Test extruding a line into a surface."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = extrude(crv, [0, 0, 1])
+        assert srf.dim == 2  # noqa: PLR2004
+        assert srf.rank == _RANK_3D
+        assert not srf.is_rational
+
+    def test_extrude_degree(self) -> None:
+        """Test that the new direction has degree 1."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = extrude(crv, [0, 1, 0])
+        assert srf.degree == (1, 1)
+
+    def test_extrude_evaluate_corners(self) -> None:
+        """Test evaluation at the four corners of an extruded line."""
+        crv = line([0, 0, 0], [2, 0, 0])
+        srf = extrude(crv, [0, 3, 0])
+        pts = srf.evaluate(
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                ]
+            )
+        )
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [2, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [0, 3, 0], atol=1e-14)
+        assert_allclose(pts[3], [2, 3, 0], atol=1e-14)
+
+    def test_extrude_circle_to_cylinder(self) -> None:
+        """Test extruding a circle produces a cylinder."""
+        crv = circle(radius=2.0)
+        cyl = extrude(crv, [0, 0, 5])
+        assert cyl.dim == 2  # noqa: PLR2004
+        assert cyl.is_rational
+        # Evaluate on a grid and check all points lie on the cylinder
+        u = np.linspace(0, 1, 20)
+        v = np.array([0.0, 0.5, 1.0])
+        params = np.array([[ui, vi] for ui in u for vi in v])
+        pts = cyl.evaluate(params)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 2.0, atol=1e-13)
+        # z should range from 0 to 5
+        assert_allclose(pts[params[:, 1] == 0.0, 2], 0.0, atol=1e-14)
+        assert_allclose(pts[params[:, 1] == 1.0, 2], 5.0, atol=1e-13)
+
+    def test_extrude_surface_to_volume(self) -> None:
+        """Test extruding a surface into a volume."""
+        srf = bilinear()
+        vol = extrude(srf, [0, 0, 1])
+        assert vol.dim == _RANK_3D
+        assert vol.degree == (1, 1, 1)
+
+    def test_extrude_volume_raises(self) -> None:
+        """Test that extruding a volume raises ValueError."""
+        vol = extrude(bilinear(), [0, 0, 1])
+        with pytest.raises(ValueError, match="dim"):
+            extrude(vol, [0, 0, 1])
+
+    def test_extrude_2d_displacement(self) -> None:
+        """Test that 2D displacement is zero-padded to 3D."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = extrude(crv, [0, 1])
+        pt = srf.evaluate(np.array([[0.5, 1.0]]))
+        assert_allclose(pt, [0.5, 1.0, 0.0], atol=1e-14)
+
+
+class TestRuled:
+    """Test the ruled surface/volume construction."""
+
+    def test_ruled_two_lines(self) -> None:
+        """Test ruled surface between two parallel lines."""
+        c1 = line([0, 0, 0], [1, 0, 0])
+        c2 = line([0, 1, 0], [1, 1, 0])
+        srf = ruled(c1, c2)
+        assert srf.dim == 2  # noqa: PLR2004
+        assert srf.degree == (1, 1)
+        assert not srf.is_rational
+
+    def test_ruled_evaluate_corners(self) -> None:
+        """Test evaluation at the four parametric corners."""
+        c1 = line([0, 0, 0], [3, 0, 0])
+        c2 = line([0, 2, 0], [3, 2, 0])
+        srf = ruled(c1, c2)
+        pts = srf.evaluate(
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                ]
+            )
+        )
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [3, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [0, 2, 0], atol=1e-14)
+        assert_allclose(pts[3], [3, 2, 0], atol=1e-14)
+
+    def test_ruled_annulus(self) -> None:
+        """Test ruled surface between two circles forms an annulus."""
+        inner = circle(radius=1.0)
+        outer = circle(radius=2.0)
+        annulus = ruled(inner, outer)
+        assert annulus.dim == 2  # noqa: PLR2004
+        assert annulus.is_rational
+        # Evaluate and check radii
+        u = np.linspace(0, 1, 30)
+        params_inner = np.column_stack([u, np.zeros_like(u)])
+        params_outer = np.column_stack([u, np.ones_like(u)])
+        pts_inner = annulus.evaluate(params_inner)
+        pts_outer = annulus.evaluate(params_outer)
+        radii_inner = np.sqrt(pts_inner[:, 0] ** 2 + pts_inner[:, 1] ** 2)
+        radii_outer = np.sqrt(pts_outer[:, 0] ** 2 + pts_outer[:, 1] ** 2)
+        assert_allclose(radii_inner, 1.0, atol=1e-13)
+        assert_allclose(radii_outer, 2.0, atol=1e-13)
+
+    def test_ruled_different_degrees(self) -> None:
+        """Test that ruled makes inputs compatible (different degrees)."""
+        c1 = line([0, 0, 0], [1, 0, 0])  # degree 1
+        c2 = circle(angle=np.pi / 2)  # degree 2
+        srf = ruled(c1, c2)
+        # Both should have been elevated to degree 2
+        assert srf.degree[0] == 2  # noqa: PLR2004
+
+    def test_ruled_mixed_rational(self) -> None:
+        """Test that mixing rational and non-rational promotes correctly."""
+        c1 = line([1, 0, 0], [2, 0, 0])  # non-rational
+        c2 = circle(radius=1.5, angle=np.pi / 4)  # rational
+        srf = ruled(c1, c2)
+        assert srf.is_rational
+
+    def test_ruled_different_dim_raises(self) -> None:
+        """Test that different dimensions raises ValueError."""
+        crv = line([0, 0, 0], [1, 0, 0])
+        srf = bilinear()
+        with pytest.raises(ValueError, match="same dim"):
+            ruled(crv, srf)
+
+    def test_ruled_volume_from_surfaces(self) -> None:
+        """Test ruled volume between two surfaces."""
+        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
+        s2 = bilinear(np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=np.float64))
+        vol = ruled(s1, s2)
+        assert vol.dim == _RANK_3D
+        assert vol.degree == (1, 1, 1)
+        # Center should be at (0.5, 0.5, 0.5)
+        pt = vol.evaluate(np.array([[0.5, 0.5, 0.5]]))
+        assert_allclose(pt, [0.5, 0.5, 0.5], atol=1e-14)

--- a/tests/test_cad_primitives.py
+++ b/tests/test_cad_primitives.py
@@ -1,4 +1,4 @@
-"""Tests for CAD primitive functions: line, bilinear, trilinear."""
+"""Tests for CAD primitive functions: line, circle, bilinear, trilinear."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pantr.cad import bilinear, line, trilinear
+from pantr.cad import bilinear, circle, line, trilinear
 
 _RANK_3D = 3
 
@@ -244,3 +244,119 @@ class TestTrilinear:
         vol = trilinear()
         for sp in vol.space.spaces:
             assert_allclose(sp.knots, [0.0, 0.0, 1.0, 1.0])
+
+
+class TestCircle:
+    """Test the circle / circular arc primitive."""
+
+    def test_full_circle_properties(self) -> None:
+        """Test that the default full circle has the expected structure."""
+        crv = circle()
+        assert crv.dim == 1
+        assert crv.degree == (_RANK_3D - 1,)  # degree 2
+        assert crv.rank == _RANK_3D
+        assert crv.is_rational
+
+    def test_full_circle_control_point_count(self) -> None:
+        """Test full circle has 9 control points (4 spans)."""
+        crv = circle()
+        assert crv.control_points.shape[0] == 9  # noqa: PLR2004
+
+    def test_full_circle_knot_structure(self) -> None:
+        """Test full circle knot vector: 4 spans, double interior knots."""
+        crv = circle()
+        sp = crv.space.spaces[0]
+        knots = sp.knots
+        # [0,0,0, 0.25,0.25, 0.5,0.5, 0.75,0.75, 1,1,1]
+        expected = np.array([0, 0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1, 1, 1])
+        assert_allclose(knots, expected)
+
+    def test_full_circle_evaluate_cardinal_points(self) -> None:
+        """Test full circle evaluates to correct cardinal points."""
+        crv = circle()
+        pts = crv.evaluate(np.array([0.0, 0.25, 0.5, 0.75, 1.0]))
+        assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [0, 1, 0], atol=1e-14)
+        assert_allclose(pts[2], [-1, 0, 0], atol=1e-14)
+        assert_allclose(pts[3], [0, -1, 0], atol=1e-14)
+        assert_allclose(pts[4], [1, 0, 0], atol=1e-14)
+
+    def test_full_circle_points_on_circle(self) -> None:
+        """Test that evaluated points lie on the unit circle."""
+        crv = circle()
+        t = np.linspace(0, 1, 50)
+        pts = crv.evaluate(t)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 1.0, atol=1e-14)
+        assert_allclose(pts[:, 2], 0.0, atol=1e-14)
+
+    def test_radius(self) -> None:
+        """Test circle with custom radius."""
+        r = 3.5
+        crv = circle(radius=r)
+        t = np.linspace(0, 1, 30)
+        pts = crv.evaluate(t)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, r, atol=1e-14)
+
+    def test_quarter_arc_structure(self) -> None:
+        """Test arc <= 90 deg has 1 span, 3 control points, no interior knots."""
+        crv = circle(angle=np.pi / 2)
+        assert crv.control_points.shape[0] == _RANK_3D  # 3 control points
+        expected_knots = np.array([0, 0, 0, 1, 1, 1], dtype=np.float64)
+        assert_allclose(crv.space.spaces[0].knots, expected_knots)
+
+    def test_quarter_arc_endpoints(self) -> None:
+        """Test quarter arc from 0 to pi/2."""
+        crv = circle(angle=np.pi / 2)
+        pts = crv.evaluate(np.array([0.0, 1.0]))
+        assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [0, 1, 0], atol=1e-14)
+
+    def test_half_circle_structure(self) -> None:
+        """Test arc <= 180 deg has 2 spans, 5 control points, 1 double knot."""
+        crv = circle(angle=np.pi)
+        assert crv.control_points.shape[0] == 5  # noqa: PLR2004
+        expected_knots = np.array([0, 0, 0, 0.5, 0.5, 1, 1, 1])
+        assert_allclose(crv.space.spaces[0].knots, expected_knots)
+
+    def test_three_quarter_arc_structure(self) -> None:
+        """Test arc <= 270 deg has 3 spans, 7 control points, 2 double knots."""
+        crv = circle(angle=3 * np.pi / 2)
+        assert crv.control_points.shape[0] == 7  # noqa: PLR2004
+
+    def test_arc_points_on_circle(self) -> None:
+        """Test that arc points lie on the circle."""
+        crv = circle(radius=2.0, angle=np.pi)
+        t = np.linspace(0, 1, 30)
+        pts = crv.evaluate(t)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 2.0, atol=1e-13)
+
+    def test_angle_tuple(self) -> None:
+        """Test arc with (start, end) angle tuple."""
+        crv = circle(radius=2, angle=(np.pi / 2, -np.pi / 2))
+        pts = crv.evaluate(np.array([0.0, 0.5, 1.0]))
+        assert_allclose(pts[0], [0, 2, 0], atol=1e-14)
+        assert_allclose(pts[1], [2, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [0, -2, 0], atol=1e-14)
+
+    def test_center_translation(self) -> None:
+        """Test that center translates the circle."""
+        crv = circle(radius=1, center=(1, 2, 0))
+        pt = crv.evaluate(np.array([0.0]))
+        assert_allclose(pt, [2, 2, 0], atol=1e-14)
+
+    def test_center_2d(self) -> None:
+        """Test center with 2D coordinates (zero-padded to 3D)."""
+        crv = circle(radius=3, center=2, angle=np.pi / 2)
+        pts = crv.evaluate(np.array([0.0, 1.0]))
+        assert_allclose(pts[0], [5, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [2, 3, 0], atol=1e-14)
+
+    def test_negative_sweep(self) -> None:
+        """Test arc with negative sweep (clockwise)."""
+        crv = circle(angle=-np.pi / 2)
+        pts = crv.evaluate(np.array([0.0, 1.0]))
+        assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [0, -1, 0], atol=1e-14)

--- a/tests/test_cad_revolve_sweep.py
+++ b/tests/test_cad_revolve_sweep.py
@@ -1,0 +1,164 @@
+"""Tests for CAD operations: revolve and sweep."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.cad import bilinear, circle, extrude, line, revolve, sweep
+
+_RANK_3D = 3
+
+
+class TestRevolve:
+    """Test the revolve operation."""
+
+    def test_line_to_annulus(self) -> None:
+        """Test revolving a radial line produces a full annulus."""
+        crv = line([1, 0, 0], [2, 0, 0])
+        srf = revolve(crv, point=0, axis=2)
+        assert srf.dim == 2  # noqa: PLR2004
+        assert srf.is_rational
+
+    def test_revolve_points_on_cylinder(self) -> None:
+        """Test revolving a vertical line around Z produces a cylinder."""
+        crv = line([1, 0, 0], [1, 0, 3])
+        srf = revolve(crv, point=0, axis=2)
+        # Evaluate on a grid
+        u = np.linspace(0, 1, 10)
+        v = np.linspace(0, 1, 20)
+        params = np.array([[ui, vi] for ui in u for vi in v])
+        pts = srf.evaluate(params)
+        radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 1.0, atol=1e-12)
+
+    def test_revolve_quarter_turn(self) -> None:
+        """Test revolving a line by pi/2 around Z."""
+        crv = line([1, 0, 0], [2, 0, 0])
+        srf = revolve(crv, point=0, axis=2, angle=np.pi / 2)
+        # At v=0 should be on +X axis, at v=1 on +Y axis
+        pt_start = srf.evaluate(np.array([[0.5, 0.0]]))
+        pt_end = srf.evaluate(np.array([[0.5, 1.0]]))
+        r = 1.5  # midpoint of [1, 2]
+        assert_allclose(pt_start, [r, 0, 0], atol=1e-12)
+        assert_allclose(pt_end, [0, r, 0], atol=1e-12)
+
+    def test_revolve_around_y_axis(self) -> None:
+        """Test revolving around the Y axis."""
+        crv = line([1, 0, 0], [1, 0, 1])
+        srf = revolve(crv, point=0, axis=1, angle=np.pi / 2)
+        # At v=1, (x, z) should rotate to (z, -x) for Y-axis rotation
+        pt = srf.evaluate(np.array([[0.0, 1.0]]))
+        assert_allclose(pt, [0, 0, -1], atol=1e-12)
+
+    def test_revolve_with_center(self) -> None:
+        """Test revolving around an offset point."""
+        crv = line([3, 0, 0], [3, 0, 1])
+        srf = revolve(crv, point=[2, 0, 0], axis=2)
+        # At v=0, should be at original position
+        pt = srf.evaluate(np.array([[0.0, 0.0]]))
+        assert_allclose(pt, [3, 0, 0], atol=1e-12)
+        # All points should be distance 1 from (2, 0, z)
+        u = np.linspace(0, 1, 5)
+        v = np.linspace(0, 1, 20)
+        params = np.array([[ui, vi] for ui in u for vi in v])
+        pts = srf.evaluate(params)
+        radii = np.sqrt((pts[:, 0] - 2) ** 2 + pts[:, 1] ** 2)
+        assert_allclose(radii, 1.0, atol=1e-12)
+
+    def test_revolve_negative_angle(self) -> None:
+        """Test revolving with a negative angle (clockwise)."""
+        crv = line([1, 0, 0], [2, 0, 0])
+        srf = revolve(crv, point=0, axis=2, angle=-np.pi / 2)
+        pt = srf.evaluate(np.array([[0.5, 1.0]]))
+        r = 1.5
+        assert_allclose(pt, [0, -r, 0], atol=1e-12)
+
+    def test_revolve_angle_tuple(self) -> None:
+        """Test revolving with (start, end) angle tuple."""
+        crv = line([1, 0, 0], [2, 0, 0])
+        srf = revolve(crv, point=0, axis=2, angle=(np.pi / 2, np.pi))
+        # At v=0, should be at angle pi/2 (on +Y axis)
+        pt0 = srf.evaluate(np.array([[0.5, 0.0]]))
+        r = 1.5
+        assert_allclose(pt0, [0, r, 0], atol=1e-12)
+        # At v=1, should be at angle pi (on -X axis)
+        pt1 = srf.evaluate(np.array([[0.5, 1.0]]))
+        assert_allclose(pt1, [-r, 0, 0], atol=1e-12)
+
+    def test_revolve_dim_too_large_raises(self) -> None:
+        """Test that revolving a volume raises ValueError."""
+        vol = extrude(bilinear(), [0, 0, 1])
+        with pytest.raises(ValueError, match="dim"):
+            revolve(vol, point=0, axis=2)
+
+    def test_revolve_wrong_rank_raises(self) -> None:
+        """Test that rank != 3 raises ValueError."""
+        knots = np.array([0.0, 0.0, 1.0, 1.0])
+        sp = BsplineSpace([BsplineSpace1D(knots, 1)])
+        crv = Bspline(sp, np.array([[0.0, 0.0], [1.0, 1.0]]))
+        with pytest.raises(ValueError, match="rank"):
+            revolve(crv, point=0, axis=2)
+
+
+class TestSweep:
+    """Test the translational sweep operation."""
+
+    def test_sweep_line_along_line(self) -> None:
+        """Test sweeping a line along a line produces a bilinear surface."""
+        section = line([0, 0, 0], [1, 0, 0])
+        trajectory = line([0, 0, 0], [0, 1, 0])
+        srf = sweep(section, trajectory)
+        assert srf.dim == 2  # noqa: PLR2004
+        assert srf.rank == _RANK_3D
+        # Evaluate corners
+        pts = srf.evaluate(
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                ]
+            )
+        )
+        assert_allclose(pts[0], [0, 0, 0], atol=1e-14)
+        assert_allclose(pts[1], [1, 0, 0], atol=1e-14)
+        assert_allclose(pts[2], [0, 1, 0], atol=1e-14)
+        assert_allclose(pts[3], [1, 1, 0], atol=1e-14)
+
+    def test_sweep_preserves_section_geometry(self) -> None:
+        """Test that at trajectory start the section geometry is preserved."""
+        section = circle(radius=2.0, angle=np.pi / 2)
+        trajectory = line([0, 0, 0], [0, 0, 5])
+        srf = sweep(section, trajectory)
+        # At v=0 (trajectory start), should match the section
+        u = np.linspace(0, 1, 20)
+        params_v0 = np.column_stack([u, np.zeros_like(u)])
+        pts = srf.evaluate(params_v0)
+        section_pts = section.evaluate(u)
+        assert_allclose(pts, section_pts, atol=1e-13)
+
+    def test_sweep_trajectory_offset(self) -> None:
+        """Test that the trajectory adds an offset."""
+        section = line([0, 0, 0], [1, 0, 0])
+        trajectory = line([0, 0, 0], [0, 0, 3])
+        srf = sweep(section, trajectory)
+        pt = srf.evaluate(np.array([[0.5, 1.0]]))
+        assert_allclose(pt, [0.5, 0, 3], atol=1e-14)
+
+    def test_sweep_section_dim2_raises_for_dim3(self) -> None:
+        """Test that section dim > 2 raises ValueError."""
+        vol = extrude(bilinear(), [0, 0, 1])
+        traj = line([0, 0, 0], [1, 0, 0])
+        with pytest.raises(ValueError, match="section.dim"):
+            sweep(vol, traj)
+
+    def test_sweep_trajectory_dim2_raises(self) -> None:
+        """Test that trajectory dim != 1 raises ValueError."""
+        sec = line([0, 0, 0], [1, 0, 0])
+        traj = bilinear()
+        with pytest.raises(ValueError, match="trajectory.dim"):
+            sweep(sec, traj)


### PR DESCRIPTION
## Summary
Completes the `pantr.cad` constructive geometry subpackage (building on the merged PR #94 which added `line`, `bilinear`, `trilinear`):

- **Primitives**: `circle` (rational quadratic arcs, angle-dependent spans)
- **Compatibility**: `compat` (match degrees, domains, knot vectors across N B-splines)
- **Operations**: `extrude`, `revolve`, `ruled`, `sweep`
- **Coons blending**: `coons_surface` (4 boundary curves), `coons_volume` (6 boundary faces, trilinear formula)
- **Assembly**: `join` (C0 concatenation with optional knot removal)
- **Derived primitives**: `rectangle`, `disk`, `cylinder`
- **Docs**: Sphinx API reference entry, numpy typing warning suppression

## Test plan
- [x] 90 new tests across 6 test files
- [x] All 1724 tests pass (no regressions)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)