### PR TITLE
feat(bezier): add L2 norm via Bernstein mass matrix

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -12,6 +12,7 @@ from .._transform_control_points import _apply_affine_to_control_points
 from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
+from ._bezier_norm import _l2_norm_bezier, _squared_l2_norm_bezier
 from ._bezier_product import _multiply_bezier
 from ._bezier_restrict import _restrict_bezier
 from ._bezier_slice import _slice_bezier
@@ -386,6 +387,54 @@ class Bezier:
         return _multiply_bezier(self, other)
 
     __mul__ = multiply
+
+    # ------------------------------------------------------------------
+    # Norms
+    # ------------------------------------------------------------------
+
+    def squared_l2_norm(self) -> np.floating[Any]:
+        r"""Compute the squared L2 norm over the unit hypercube.
+
+        .. math::
+
+            \|p\|^2 = \int_{[0,1]^D} \|p(x)\|^2 \, dx
+
+        For scalar Bézier this equals :math:`c^T M c` where :math:`M` is
+        the Bernstein mass matrix.  For vector-valued Bézier (rank > 1) it
+        equals the sum of component-wise squared norms.
+
+        Returns:
+            np.floating[Any]: The squared L2 norm.
+
+        Raises:
+            ValueError: If the Bézier is rational.
+
+        Example:
+            >>> b = Bezier([1.0, 1.0, 1.0])
+            >>> float(b.squared_l2_norm())
+            1.0
+        """
+        return _squared_l2_norm_bezier(self)
+
+    def l2_norm(self) -> np.floating[Any]:
+        r"""Compute the L2 norm over the unit hypercube.
+
+        .. math::
+
+            \|p\| = \sqrt{\int_{[0,1]^D} \|p(x)\|^2 \, dx}
+
+        Returns:
+            np.floating[Any]: The L2 norm (non-negative scalar).
+
+        Raises:
+            ValueError: If the Bézier is rational.
+
+        Example:
+            >>> b = Bezier([1.0, 1.0, 1.0])
+            >>> float(b.l2_norm())
+            1.0
+        """
+        return _l2_norm_bezier(self)
 
     # ------------------------------------------------------------------
     # Reverse and permute

--- a/src/pantr/bezier/_bezier_norm.py
+++ b/src/pantr/bezier/_bezier_norm.py
@@ -1,0 +1,126 @@
+r"""Bézier L2 norm computation.
+
+This module provides :func:`_squared_l2_norm_bezier` and
+:func:`_l2_norm_bezier`, which compute the squared L2 norm and L2 norm of a
+non-rational Bézier over the unit hypercube :math:`[0, 1]^D`.
+
+The computation uses the Bernstein mass matrix, which is separable as a
+Kronecker product of 1D mass matrices.  Each 1D mass matrix is applied via
+:func:`numpy.tensordot` along its corresponding spatial axis, avoiding
+formation of the full nD mass matrix.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _bernstein_mass_matrix_1d(
+    degree: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Build the 1D Bernstein mass matrix for a given degree.
+
+    The mass matrix ``M`` has entries:
+
+    .. math::
+
+        M_{ij} = \frac{\binom{n}{i}\,\binom{n}{j}}
+                      {(2n + 1)\,\binom{2n}{i + j}}
+
+    where :math:`n` = *degree*.  This matrix is symmetric and positive
+    semi-definite.
+
+    Args:
+        degree (int): Polynomial degree (:math:`n \ge 0`).
+        dtype (npt.DTypeLike): Floating-point dtype for the output.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Symmetric mass matrix of shape
+        ``(degree + 1, degree + 1)``.
+    """
+    n = degree
+    size = n + 1
+    binom_n = np.array([math.comb(n, i) for i in range(size)], dtype=dtype)
+    inv_binom_2n = np.array([1.0 / math.comb(2 * n, k) for k in range(2 * n + 1)], dtype=dtype)
+    i_idx = np.arange(size)
+    sum_idx = i_idx[:, None] + i_idx[None, :]  # (size, size)
+    result: npt.NDArray[np.float32 | np.float64] = (
+        binom_n[:, None] * binom_n[None, :] * inv_binom_2n[sum_idx]
+    ) / (2 * n + 1)
+    return result
+
+
+def _squared_l2_norm_bezier(
+    bezier: Bezier,
+) -> np.floating[Any]:
+    r"""Compute the squared L2 norm of a non-rational Bézier over :math:`[0, 1]^D`.
+
+    .. math::
+
+        \|p\|^2 = \int_{[0,1]^D} \|p(x)\|^2 \, dx
+
+    For scalar Bézier this equals :math:`c^T M c` where :math:`M` is the
+    Bernstein mass matrix.  For vector-valued Bézier (rank > 1) it equals
+    :math:`\sum_r c_r^T M c_r`.
+
+    The mass matrix is separable (Kronecker product of 1D matrices) and is
+    applied via successive :func:`numpy.tensordot` contractions along each
+    spatial axis.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
+
+    Returns:
+        np.floating[Any]: The squared L2 norm (non-negative up to
+        floating-point round-off).
+
+    Raises:
+        ValueError: If the Bézier is rational.
+    """
+    if bezier.is_rational:
+        raise ValueError("L2 norm is not supported for rational Bézier.")
+
+    ctrl = bezier.control_points
+    dim = bezier.dim
+    degrees = bezier.degree
+    dtype = bezier.dtype
+
+    mass_1d = [_bernstein_mass_matrix_1d(degrees[d], dtype) for d in range(dim)]
+
+    mc = ctrl
+    for d in range(dim):
+        mc = np.tensordot(mass_1d[d], mc, axes=([1], [d]))
+        mc = np.moveaxis(mc, 0, d)
+
+    result: np.floating[Any] = np.sum(ctrl * mc)
+    return result
+
+
+def _l2_norm_bezier(
+    bezier: Bezier,
+) -> np.floating[Any]:
+    r"""Compute the L2 norm of a non-rational Bézier over :math:`[0, 1]^D`.
+
+    .. math::
+
+        \|p\| = \sqrt{\int_{[0,1]^D} \|p(x)\|^2 \, dx}
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational Bézier.
+
+    Returns:
+        np.floating[Any]: The L2 norm (non-negative scalar).
+
+    Raises:
+        ValueError: If the Bézier is rational.
+    """
+    result: np.floating[Any] = np.sqrt(np.abs(_squared_l2_norm_bezier(bezier)))
+    return result

--- a/tests/test_bezier_norm.py
+++ b/tests/test_bezier_norm.py
@@ -1,0 +1,122 @@
+"""Tests for Bézier L2 norm computation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+
+
+class TestSquaredL2Norm:
+    """Tests for ``Bezier.squared_l2_norm``."""
+
+    def test_constant_1d(self) -> None:
+        """Constant p(x) = 3: ||p||^2 = 9."""
+        b = Bezier([3.0, 3.0, 3.0])
+        np.testing.assert_allclose(b.squared_l2_norm(), 9.0, atol=1e-14)
+
+    def test_constant_2d(self) -> None:
+        """Constant p(x,y) = 2: ||p||^2 = 4."""
+        ctrl = 2.0 * np.ones((3, 4, 1))
+        b = Bezier(ctrl)
+        np.testing.assert_allclose(b.squared_l2_norm(), 4.0, atol=1e-14)
+
+    def test_constant_3d(self) -> None:
+        """Constant p(x,y,z) = 5: ||p||^2 = 25."""
+        ctrl = 5.0 * np.ones((2, 2, 2, 1))
+        b = Bezier(ctrl)
+        np.testing.assert_allclose(b.squared_l2_norm(), 25.0, atol=1e-14)
+
+    def test_linear_1d_identity(self) -> None:
+        """p(x) = x: ||p||^2 = integral(x^2, 0, 1) = 1/3."""
+        b = Bezier([0.0, 1.0])
+        np.testing.assert_allclose(b.squared_l2_norm(), 1.0 / 3.0, atol=1e-14)
+
+    def test_linear_1d_complement(self) -> None:
+        """p(x) = 1-x: ||p||^2 = integral((1-x)^2, 0, 1) = 1/3."""
+        b = Bezier([1.0, 0.0])
+        np.testing.assert_allclose(b.squared_l2_norm(), 1.0 / 3.0, atol=1e-14)
+
+    def test_quadratic_1d(self) -> None:
+        """p(x) = (1-x)^2 via coefficients [1, 0, 0]: ||p||^2 = 1/5."""
+        b = Bezier([1.0, 0.0, 0.0])
+        np.testing.assert_allclose(b.squared_l2_norm(), 1.0 / 5.0, atol=1e-14)
+
+    def test_degree_zero(self) -> None:
+        """Degree-0 Bézier p(x) = 7: ||p||^2 = 49."""
+        b = Bezier([7.0])
+        np.testing.assert_allclose(b.squared_l2_norm(), 49.0, atol=1e-14)
+
+    def test_2d_separable(self) -> None:
+        """Separable 2D: p(x,y) = f(x)*g(y), ||p||^2 = ||f||^2 * ||g||^2."""
+        f_ctrl = np.array([0.0, 1.0])  # f(x) = x
+        g_ctrl = np.array([1.0, 0.0])  # g(y) = 1-y
+        ctrl_2d = np.outer(f_ctrl, g_ctrl)[:, :, np.newaxis]
+        b2d = Bezier(ctrl_2d)
+
+        bf = Bezier(f_ctrl)
+        bg = Bezier(g_ctrl)
+        expected = float(bf.squared_l2_norm()) * float(bg.squared_l2_norm())
+        np.testing.assert_allclose(b2d.squared_l2_norm(), expected, atol=1e-14)
+
+    def test_vector_valued(self) -> None:
+        """Vector-valued: ||p||^2 = sum of component-wise squared norms."""
+        ctrl = np.array([[0.0, 1.0], [1.0, 0.0]])  # rank 2
+        b = Bezier(ctrl)
+
+        # Component 0: coefficients [0, 1] -> p(x) = x, ||p||^2 = 1/3
+        # Component 1: coefficients [1, 0] -> p(x) = 1-x, ||p||^2 = 1/3
+        np.testing.assert_allclose(b.squared_l2_norm(), 2.0 / 3.0, atol=1e-14)
+
+    def test_rational_raises(self) -> None:
+        """Rational Bézier raises ValueError."""
+        ctrl = np.array([[1.0, 1.0], [2.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        with pytest.raises(ValueError, match="rational"):
+            b.squared_l2_norm()
+
+    def test_float32(self) -> None:
+        """Float32 dtype is supported."""
+        ctrl = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        b = Bezier(ctrl)
+        result = b.squared_l2_norm()
+        assert result.dtype == np.float32
+        np.testing.assert_allclose(float(result), 1.0, atol=1e-6)
+
+    def test_cross_validate_via_product_2d(self) -> None:
+        """Cross-validate against product + coefficient-mean integration."""
+        rng = np.random.default_rng(42)
+        ctrl = rng.standard_normal((4, 5, 1))
+        b = Bezier(ctrl)
+
+        # ||p||^2 = integral(p^2) = integral of (b*b).
+        # For a Bernstein polynomial q of degree r_d per direction,
+        # integral over [0,1]^D = mean of all coefficients.
+        product = b * b
+        product_ctrl = product.control_points
+        # Sum over spatial axes, then sum over rank.
+        ref = float(np.mean(product_ctrl[..., 0]))
+        np.testing.assert_allclose(b.squared_l2_norm(), ref, rtol=1e-14)
+
+
+class TestL2Norm:
+    """Tests for ``Bezier.l2_norm``."""
+
+    def test_matches_sqrt_of_squared(self) -> None:
+        """l2_norm == sqrt(abs(squared_l2_norm))."""
+        b = Bezier([0.0, 1.0])
+        expected = np.sqrt(np.abs(b.squared_l2_norm()))
+        np.testing.assert_allclose(b.l2_norm(), expected, atol=1e-14)
+
+    def test_constant(self) -> None:
+        """Constant p(x) = 3: ||p|| = 3."""
+        b = Bezier([3.0, 3.0])
+        np.testing.assert_allclose(b.l2_norm(), 3.0, atol=1e-14)
+
+    def test_rational_raises(self) -> None:
+        """Rational Bézier raises ValueError."""
+        ctrl = np.array([[1.0, 1.0], [2.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        with pytest.raises(ValueError, match="rational"):
+            b.l2_norm()


### PR DESCRIPTION
## Summary

- Add `squared_l2_norm()` and `l2_norm()` public methods to `Bezier`
- Compute the integral analytically using the **Bernstein mass matrix**, which is separable as a Kronecker product of 1D matrices
- Apply each 1D mass matrix via `np.tensordot` contractions — BLAS-backed, O(D·M·n) instead of O(M²) for the naive double sum
- 15 tests covering 1D/2D/3D, vector-valued, float32, degree-0 edge case, and cross-validation against the product + coefficient-mean integration path

## Test plan

- [x] `pytest tests/test_bezier_norm.py --no-cov -v` — 15 tests pass
- [x] `ruff check .` — no lint issues
- [x] `ruff format --check .` — properly formatted
- [x] `mypy --config-file mypy.ini src tests` — no type errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)