### PR TITLE
feat(bezier): add auto_reduce_degree for non-rational Bézier

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -9,7 +9,11 @@ import numpy as np
 from numpy import typing as npt
 
 from .._transform_control_points import _apply_affine_to_control_points
-from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
+from ._bezier_degree import (
+    _auto_reduce_degree_bezier,
+    _degree_elevate_bezier,
+    _degree_reduce_bezier,
+)
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
 from ._bezier_product import _multiply_bezier
@@ -355,6 +359,46 @@ class Bezier:
                 )
 
         return _degree_reduce_bezier(self, decrements)
+
+    def auto_reduce_degree(self, tol: float | None = None) -> Bezier:
+        """Automatically reduce polynomial degree where possible.
+
+        Iteratively tries to lower the degree by one in each parametric
+        direction, keeping the reduction only when the L2 norm of the
+        round-trip error (reduce then re-elevate) stays below ``tol`` times
+        the L2 norm of the current polynomial.  This follows the
+        *autoReduction* strategy from algoim (Saye, *J. Comput. Phys.* 448,
+        110720, 2022).
+
+        Args:
+            tol (float | None): Relative tolerance for accepting a degree
+                reduction.  If ``None`` (default), uses
+                ``1e3 * machine_epsilon`` for the control-point dtype.
+
+        Returns:
+            Bezier: A new Bézier with potentially reduced degrees, or the
+            original instance if no reduction was possible.
+
+        Raises:
+            TypeError: If the Bézier is rational.
+            ValueError: If *tol* is not positive.
+        """
+        if self.is_rational:
+            raise TypeError("auto_reduce_degree is only supported for non-rational Bézier.")
+
+        tol_value: float
+        if tol is None:
+            if self._control_points.dtype == np.float32:
+                tol_value = float(1e3 * np.finfo(np.float32).eps)
+            else:
+                tol_value = float(1e3 * np.finfo(np.float64).eps)
+        else:
+            tol_value = tol
+
+        if tol_value <= 0:
+            raise ValueError(f"Tolerance must be positive, got {tol_value}.")
+
+        return _auto_reduce_degree_bezier(self, tol_value)
 
     # ------------------------------------------------------------------
     # Multiply

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -376,8 +376,8 @@ class Bezier:
                 ``1e3 * machine_epsilon`` for the control-point dtype.
 
         Returns:
-            Bezier: A new Bézier with potentially reduced degrees, or the
-            original instance if no reduction was possible.
+            Bezier: A new Bézier (always a copy) with potentially reduced
+            degrees.
 
         Raises:
             TypeError: If the Bézier is rational.

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -1,13 +1,17 @@
-"""Bézier degree elevation and reduction.
+"""Bézier degree elevation, reduction, and automatic degree reduction.
 
 This module provides :func:`_degree_elevate_bezier`, which raises the polynomial
 degree of a Bézier in one or more parametric directions while preserving the
-same geometric mapping, and :func:`_degree_reduce_bezier`, which computes a
-least-squares degree-reduced approximation.
+same geometric mapping, :func:`_degree_reduce_bezier`, which computes a
+least-squares degree-reduced approximation, and :func:`_auto_reduce_degree_bezier`,
+which automatically reduces degree in each direction while the approximation
+error remains below a relative tolerance.
 """
 
 from __future__ import annotations
 
+import math
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -127,3 +131,189 @@ def _degree_reduce_bezier(
         degrees = (*degrees[:d], p - dec, *degrees[d + 1 :])
 
     return BezierCls(ctrl, is_rational=bezier.is_rational)
+
+
+@lru_cache(maxsize=64)
+def _bernstein_gram_1d(n: int) -> npt.NDArray[np.float64]:
+    r"""Compute the Gram matrix of the Bernstein basis of degree ``n`` on [0, 1].
+
+    The entry ``G[i, j]`` equals the L2 inner product of Bernstein
+    polynomials ``B_i^n`` and ``B_j^n``:
+
+    .. math::
+
+        G_{ij} = \frac{\binom{n}{i}\,\binom{n}{j}}
+                       {\binom{2n}{i+j}\,(2n+1)}
+
+    The returned array is read-only to protect the cache.
+
+    Args:
+        n (int): Polynomial degree (``n >= 0``).
+
+    Returns:
+        npt.NDArray[np.float64]: Symmetric positive-definite matrix of shape
+        ``(n + 1, n + 1)``.
+    """
+    size = n + 1
+    gram = np.empty((size, size), dtype=np.float64)
+    denom_factor = 2 * n + 1
+    for i in range(size):
+        binom_ni = math.comb(n, i)
+        for j in range(i + 1):
+            val = binom_ni * math.comb(n, j) / (math.comb(2 * n, i + j) * denom_factor)
+            gram[i, j] = val
+            gram[j, i] = val
+    gram.flags.writeable = False
+    return gram
+
+
+def _squared_l2_norm_bernstein(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degrees: tuple[int, ...],
+) -> float:
+    r"""Compute the squared L2 norm of a Bernstein polynomial.
+
+    For a polynomial with control-point tensor ``ctrl`` of shape
+    ``(*degrees_plus_1, rank)``, computes
+
+    .. math::
+
+        \|f\|_{L^2}^2
+          = \sum_r \mathbf{c}_r^{\!\top}
+            (G_0 \otimes \cdots \otimes G_{N-1})\,\mathbf{c}_r
+
+    using successive mode-*d* contractions with the 1-D Gram matrices.
+    The result may be very slightly negative due to round-off; callers
+    should take ``abs()`` before square-rooting.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array of
+            shape ``(*degrees_plus_1, rank)``.
+        degrees (tuple[int, ...]): Polynomial degree per parametric direction.
+
+    Returns:
+        float: The squared L2 norm (scalar).
+    """
+    ndim = len(degrees)
+    ctrl_f64 = np.asarray(ctrl, dtype=np.float64)
+    temp = ctrl_f64
+    for d in range(ndim):
+        gram = _bernstein_gram_1d(degrees[d])
+        temp = np.moveaxis(np.tensordot(gram, temp, axes=([1], [d])), 0, d)
+    return float(np.sum(ctrl_f64 * temp))
+
+
+def _reduce_ctrl_along(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    direction: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Reduce degree by 1 along *direction*, returning the new control-point array.
+
+    Applies the moveaxis/reshape -> kernel -> reshape/moveaxis pattern for a
+    single direction with decrement 1.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array.
+        degree (int): Current degree in *direction*.
+        direction (int): Parametric direction to reduce.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Reduced control points (one
+        fewer entry along *direction*).
+    """
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+    new_2d = _degree_reduce_bezier_1d_core(degree, pts_2d, 1)
+    return np.moveaxis(new_2d.reshape(new_2d.shape[0], *orig_shape[1:]), 0, direction)
+
+
+def _elevate_ctrl_along(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    direction: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Elevate degree by 1 along *direction*, returning the new control-point array.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array.
+        degree (int): Current degree in *direction*.
+        direction (int): Parametric direction to elevate.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Elevated control points (one
+        more entry along *direction*).
+    """
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+    new_2d = _degree_elevate_bezier_1d_core(degree, pts_2d, 1)
+    return np.moveaxis(new_2d.reshape(new_2d.shape[0], *orig_shape[1:]), 0, direction)
+
+
+def _auto_reduce_degree_bezier(
+    bezier: Bezier,
+    tol: float,
+) -> Bezier:
+    """Automatically reduce the degree of a non-rational Bezier.
+
+    For each parametric direction, iteratively attempts to reduce the degree
+    by one.  A reduction is accepted when the L2 norm of the round-trip error
+    (reduce then re-elevate) is below ``tol`` times the L2 norm of the
+    current polynomial.  This follows the *autoReduction* strategy described
+    in R. I. Saye, *J. Comput. Phys.* 448, 110720 (2022).
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A non-rational Bezier.
+        tol (float): Relative tolerance (must be positive).
+
+    Returns:
+        ~pantr.bezier.Bezier: A new Bezier with (potentially) lower degrees,
+        or the original object if no reduction was possible.
+
+    Note:
+        Inputs are assumed to be validated by the caller (Layer 1).
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
+    degrees = list(bezier.degree)
+    ndim = bezier.dim
+    tol_sq = tol * tol
+    changed = False
+
+    d = 0
+    while d < ndim:
+        if degrees[d] < 1:
+            d += 1
+            continue
+
+        p = degrees[d]
+
+        # Reduce by 1 in direction d, then elevate back.
+        reduced_ctrl = _reduce_ctrl_along(ctrl, p, d)
+        re_elevated = _elevate_ctrl_along(reduced_ctrl, p - 1, d)
+
+        # Compute error in-place to avoid an extra allocation.
+        error = re_elevated - ctrl
+
+        deg_tuple = tuple(degrees)
+        error_norm_sq = _squared_l2_norm_bernstein(error, deg_tuple)
+        orig_norm_sq = _squared_l2_norm_bernstein(ctrl, deg_tuple)
+
+        if abs(error_norm_sq) < tol_sq * abs(orig_norm_sq):
+            ctrl = reduced_ctrl
+            degrees[d] = p - 1
+            changed = True
+            # Stay on the same direction -- try reducing again.
+        else:
+            d += 1
+
+    if changed:
+        return BezierCls(ctrl, is_rational=False)
+    return bezier

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -273,8 +273,8 @@ def _auto_reduce_degree_bezier(
         tol (float): Relative tolerance (must be positive).
 
     Returns:
-        ~pantr.bezier.Bezier: A new Bezier with (potentially) lower degrees,
-        or the original object if no reduction was possible.
+        ~pantr.bezier.Bezier: A new Bezier (always a copy) with potentially
+        lower degrees.
 
     Note:
         Inputs are assumed to be validated by the caller (Layer 1).
@@ -316,4 +316,4 @@ def _auto_reduce_degree_bezier(
 
     if changed:
         return BezierCls(ctrl, is_rational=False)
-    return bezier
+    return BezierCls(bezier.control_points.copy(), is_rational=False)

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -11,6 +11,7 @@ error remains below a relative tolerance.
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
@@ -203,6 +204,39 @@ def _squared_l2_norm_bernstein(
     return float(np.sum(ctrl_f64 * temp))
 
 
+def _apply_1d_kernel_along(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    direction: int,
+    kernel: Callable[..., npt.NDArray[np.float32 | np.float64]],
+    degree: int,
+    amount: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Apply a 1-D Bézier kernel along a single parametric direction.
+
+    Encapsulates the moveaxis/reshape -> kernel -> reshape/moveaxis pattern
+    shared by degree elevation and reduction along a single direction.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array.
+        direction (int): Parametric direction to apply the kernel to.
+        kernel (Callable[..., npt.NDArray[np.float32 | np.float64]]): 1-D kernel
+            callable with signature ``(degree, pts_2d, amount)``.
+        degree (int): Current degree in *direction*, passed to *kernel*.
+        amount (int): Degree increment or decrement, passed to *kernel*.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Updated control points after
+        applying the kernel along *direction*.
+    """
+    moved = np.moveaxis(ctrl, direction, 0)
+    orig_shape = moved.shape
+    pts_2d = moved.reshape(orig_shape[0], -1)
+    if not pts_2d.flags.c_contiguous:
+        pts_2d = np.ascontiguousarray(pts_2d)
+    new_2d = kernel(degree, pts_2d, amount)
+    return np.moveaxis(new_2d.reshape(new_2d.shape[0], *orig_shape[1:]), 0, direction)
+
+
 def _reduce_ctrl_along(
     ctrl: npt.NDArray[np.float32 | np.float64],
     degree: int,
@@ -210,8 +244,7 @@ def _reduce_ctrl_along(
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Reduce degree by 1 along *direction*, returning the new control-point array.
 
-    Applies the moveaxis/reshape -> kernel -> reshape/moveaxis pattern for a
-    single direction with decrement 1.
+    Delegates to :func:`_apply_1d_kernel_along` with the degree-reduction kernel.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array.
@@ -222,13 +255,7 @@ def _reduce_ctrl_along(
         npt.NDArray[np.float32 | np.float64]: Reduced control points (one
         fewer entry along *direction*).
     """
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d = moved.reshape(orig_shape[0], -1)
-    if not pts_2d.flags.c_contiguous:
-        pts_2d = np.ascontiguousarray(pts_2d)
-    new_2d = _degree_reduce_bezier_1d_core(degree, pts_2d, 1)
-    return np.moveaxis(new_2d.reshape(new_2d.shape[0], *orig_shape[1:]), 0, direction)
+    return _apply_1d_kernel_along(ctrl, direction, _degree_reduce_bezier_1d_core, degree, 1)
 
 
 def _elevate_ctrl_along(
@@ -237,6 +264,8 @@ def _elevate_ctrl_along(
     direction: int,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Elevate degree by 1 along *direction*, returning the new control-point array.
+
+    Delegates to :func:`_apply_1d_kernel_along` with the degree-elevation kernel.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control-point array.
@@ -247,13 +276,7 @@ def _elevate_ctrl_along(
         npt.NDArray[np.float32 | np.float64]: Elevated control points (one
         more entry along *direction*).
     """
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d = moved.reshape(orig_shape[0], -1)
-    if not pts_2d.flags.c_contiguous:
-        pts_2d = np.ascontiguousarray(pts_2d)
-    new_2d = _degree_elevate_bezier_1d_core(degree, pts_2d, 1)
-    return np.moveaxis(new_2d.reshape(new_2d.shape[0], *orig_shape[1:]), 0, direction)
+    return _apply_1d_kernel_along(ctrl, direction, _degree_elevate_bezier_1d_core, degree, 1)
 
 
 def _auto_reduce_degree_bezier(
@@ -306,7 +329,7 @@ def _auto_reduce_degree_bezier(
         error_norm_sq = _squared_l2_norm_bernstein(error, deg_tuple)
         orig_norm_sq = _squared_l2_norm_bernstein(ctrl, deg_tuple)
 
-        if abs(error_norm_sq) < tol_sq * abs(orig_norm_sq):
+        if orig_norm_sq == 0.0 or abs(error_norm_sq) < tol_sq * abs(orig_norm_sq):
             ctrl = reduced_ctrl
             degrees[d] = p - 1
             changed = True

--- a/tests/test_auto_reduce_degree.py
+++ b/tests/test_auto_reduce_degree.py
@@ -1,0 +1,215 @@
+"""Tests for Bézier auto degree reduction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# 1D tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReduceDegree1D:
+    """Auto-reduce for univariate Bézier curves."""
+
+    def test_constant_elevated_to_high_degree(self) -> None:
+        """A constant elevated to degree 5 should reduce back to degree 0."""
+        b = Bezier(np.array([[3.0]] * 6))  # degree 5, all coeffs identical
+        reduced = b.auto_reduce_degree()
+        assert reduced.degree == (0,)
+        np.testing.assert_allclose(reduced.control_points, [[3.0]], atol=1e-12)
+
+    def test_linear_elevated_to_quartic(self) -> None:
+        """A linear polynomial elevated to degree 4 should reduce to degree 1."""
+        original = Bezier(np.array([[0.0, 0.0], [1.0, 2.0]]))
+        elevated = original.elevate_degree(3)
+        assert elevated.degree == (4,)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (1,)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-12)
+
+    def test_quadratic_elevated(self) -> None:
+        """A quadratic elevated to degree 6 should reduce back to degree 2."""
+        original = Bezier(np.array([[0.0], [1.0], [0.0]]))
+        elevated = original.elevate_degree(4)
+        assert elevated.degree == (6,)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (2,)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-11)
+
+    def test_genuine_cubic_not_reduced(self) -> None:
+        """A genuine cubic should not reduce (it's not an elevated lower-degree)."""
+        b = Bezier(np.array([[0.0, 0.0], [0.3, 1.0], [0.7, -1.0], [1.0, 0.0]]))
+        reduced = b.auto_reduce_degree()
+        assert reduced.degree == b.degree
+        assert reduced is b  # same object when no reduction
+
+    def test_returns_original_when_no_reduction(self) -> None:
+        """When no reduction is possible, the original object is returned."""
+        b = Bezier(np.array([[0.0], [1.0]]))  # already linear
+        reduced = b.auto_reduce_degree()
+        assert reduced is b
+
+    def test_degree_0_unchanged(self) -> None:
+        """A degree-0 Bézier (constant) cannot be reduced further."""
+        b = Bezier(np.array([[42.0]]))
+        reduced = b.auto_reduce_degree()
+        assert reduced is b
+        assert reduced.degree == (0,)
+
+
+# ---------------------------------------------------------------------------
+# Multi-dimensional tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReduceDegreeMultiDim:
+    """Auto-reduce for multivariate tensor-product Bézier."""
+
+    def test_bilinear_elevated_both_dirs(self) -> None:
+        """A bilinear surface elevated to (3, 4) should reduce to (1, 1)."""
+        ctrl = np.array(
+            [
+                [[0.0, 0.0], [1.0, 0.0]],
+                [[0.0, 1.0], [1.0, 1.0]],
+            ]
+        )
+        original = Bezier(ctrl)
+        elevated = original.elevate_degree((2, 3))
+        assert elevated.degree == (3, 4)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (1, 1)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-11)
+
+    def test_mixed_reducible_directions(self) -> None:
+        """Only the direction with elevated degree should be reduced."""
+        # Degree (1, 2) surface: linear in dir 0, quadratic in dir 1.
+        rng = np.random.default_rng(123)
+        ctrl = rng.random((2, 3, 2))  # degree (1, 2), rank 2
+        original = Bezier(ctrl)
+        # Elevate only direction 0 by 3.
+        elevated = original.elevate_degree((3, 0))
+        assert elevated.degree == (4, 2)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (1, 2)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-11)
+
+    def test_3d_volume_elevated(self) -> None:
+        """A trilinear volume elevated to (3, 3, 3) reduces to (1, 1, 1)."""
+        ctrl = np.zeros((2, 2, 2, 3))
+        ctrl[0, 0, 0] = [0, 0, 0]
+        ctrl[1, 0, 0] = [1, 0, 0]
+        ctrl[0, 1, 0] = [0, 1, 0]
+        ctrl[1, 1, 0] = [1, 1, 0]
+        ctrl[0, 0, 1] = [0, 0, 1]
+        ctrl[1, 0, 1] = [1, 0, 1]
+        ctrl[0, 1, 1] = [0, 1, 1]
+        ctrl[1, 1, 1] = [1, 1, 1]
+        original = Bezier(ctrl)
+        elevated = original.elevate_degree((2, 2, 2))
+        assert elevated.degree == (3, 3, 3)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (1, 1, 1)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-10)
+
+    def test_no_reduction_possible_2d(self) -> None:
+        """A genuine (2, 2) surface should not be reduced."""
+        rng = np.random.default_rng(99)
+        ctrl = rng.random((3, 3, 2))
+        b = Bezier(ctrl)
+        reduced = b.auto_reduce_degree()
+        assert reduced.degree == (2, 2)
+        assert reduced is b
+
+
+# ---------------------------------------------------------------------------
+# Tolerance tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReduceDegreeTolerance:
+    """Tests for tolerance handling."""
+
+    def test_tight_tolerance_prevents_reduction(self) -> None:
+        """With a very tight tolerance, even elevated polynomials may not reduce."""
+        # A cubic elevated by 1 — the round-trip is exact, should still reduce.
+        original = Bezier(np.array([[0.0], [1.0], [0.0], [1.0]]))
+        elevated = original.elevate_degree(1)
+        # Even with tight tolerance, exact elevations should be detectable.
+        reduced = elevated.auto_reduce_degree(tol=1e-14)
+        assert reduced.degree == (3,)
+
+    def test_loose_tolerance_allows_more_reduction(self) -> None:
+        """With a loose tolerance, approximate reductions are accepted."""
+        # A genuine cubic — normally not reduced. With loose tol it might be.
+        b = Bezier(np.array([[0.0], [0.3], [0.7], [1.0]]))
+        reduced = b.auto_reduce_degree(tol=0.5)
+        assert reduced.degree[0] < b.degree[0]
+
+    def test_custom_tolerance(self) -> None:
+        """Auto-reduce with explicit tolerance value."""
+        original = Bezier(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        elevated = original.elevate_degree(5)
+        reduced = elevated.auto_reduce_degree(tol=1e-10)
+        assert reduced.degree == (1,)
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# dtype tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReduceDegreeDtype:
+    """Dtype handling."""
+
+    def test_float32(self) -> None:
+        """Auto-reduce works with float32 control points."""
+        ctrl = np.array([[0.0], [1.0]], dtype=np.float32)
+        original = Bezier(ctrl)
+        elevated = original.elevate_degree(3)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (1,)
+        assert reduced.control_points.dtype == np.float32
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-4)
+
+    def test_float64(self) -> None:
+        """Auto-reduce with float64 control points (default)."""
+        ctrl = np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 0.0]], dtype=np.float64)
+        original = Bezier(ctrl)
+        elevated = original.elevate_degree(4)
+        reduced = elevated.auto_reduce_degree()
+        assert reduced.degree == (2,)
+        assert reduced.control_points.dtype == np.float64
+        np.testing.assert_allclose(reduced.control_points, original.control_points, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestAutoReduceDegreeErrors:
+    """Error cases."""
+
+    def test_rational_raises(self) -> None:
+        """Rational Bézier should raise TypeError."""
+        ctrl = np.array([[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]])
+        b = Bezier(ctrl, is_rational=True)
+        with pytest.raises(TypeError, match="non-rational"):
+            b.auto_reduce_degree()
+
+    def test_negative_tolerance_raises(self) -> None:
+        """Negative tolerance should raise ValueError."""
+        b = Bezier(np.array([[0.0], [1.0]]))
+        with pytest.raises(ValueError, match="positive"):
+            b.auto_reduce_degree(tol=-1.0)
+
+    def test_zero_tolerance_raises(self) -> None:
+        """Zero tolerance should raise ValueError."""
+        b = Bezier(np.array([[0.0], [1.0]]))
+        with pytest.raises(ValueError, match="positive"):
+            b.auto_reduce_degree(tol=0.0)

--- a/tests/test_auto_reduce_degree.py
+++ b/tests/test_auto_reduce_degree.py
@@ -45,20 +45,23 @@ class TestAutoReduceDegree1D:
         b = Bezier(np.array([[0.0, 0.0], [0.3, 1.0], [0.7, -1.0], [1.0, 0.0]]))
         reduced = b.auto_reduce_degree()
         assert reduced.degree == b.degree
-        assert reduced is b  # same object when no reduction
+        np.testing.assert_array_equal(reduced.control_points, b.control_points)
+        assert reduced is not b  # always returns a copy
 
-    def test_returns_original_when_no_reduction(self) -> None:
-        """When no reduction is possible, the original object is returned."""
+    def test_returns_copy_when_no_reduction(self) -> None:
+        """When no reduction is possible, a copy is returned."""
         b = Bezier(np.array([[0.0], [1.0]]))  # already linear
         reduced = b.auto_reduce_degree()
-        assert reduced is b
+        assert reduced is not b
+        np.testing.assert_array_equal(reduced.control_points, b.control_points)
 
     def test_degree_0_unchanged(self) -> None:
         """A degree-0 Bézier (constant) cannot be reduced further."""
         b = Bezier(np.array([[42.0]]))
         reduced = b.auto_reduce_degree()
-        assert reduced is b
+        assert reduced is not b
         assert reduced.degree == (0,)
+        np.testing.assert_array_equal(reduced.control_points, b.control_points)
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +125,8 @@ class TestAutoReduceDegreeMultiDim:
         b = Bezier(ctrl)
         reduced = b.auto_reduce_degree()
         assert reduced.degree == (2, 2)
-        assert reduced is b
+        assert reduced is not b
+        np.testing.assert_array_equal(reduced.control_points, b.control_points)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auto_reduce_degree.py
+++ b/tests/test_auto_reduce_degree.py
@@ -63,6 +63,14 @@ class TestAutoReduceDegree1D:
         assert reduced.degree == (0,)
         np.testing.assert_array_equal(reduced.control_points, b.control_points)
 
+    def test_zero_polynomial_reduced_to_degree_0(self) -> None:
+        """A zero polynomial of arbitrary degree should reduce to degree 0."""
+        ctrl = np.zeros((4, 2))  # degree 3, rank 2, all zero
+        b = Bezier(ctrl)
+        reduced = b.auto_reduce_degree()
+        assert reduced.degree == (0,)
+        np.testing.assert_array_equal(reduced.control_points, np.zeros((1, 2)))
+
 
 # ---------------------------------------------------------------------------
 # Multi-dimensional tests


### PR DESCRIPTION
## Summary
- Implement the algoim *autoReduction* strategy (Saye, JCP 448, 2022) as `Bezier.auto_reduce_degree(tol)`, iteratively reducing degree per direction while the L2 round-trip error stays below a relative tolerance
- Multi-dimensional L2 norm computed via successive mode-d contractions with LRU-cached 1-D Bernstein Gram matrices — no Kronecker product formed
- Reuses existing Numba kernels (`_degree_reduce_bezier_1d_core`, `_degree_elevate_bezier_1d_core`); no new Numba compilation needed

## Test plan
- [x] 1D: constant/linear/quadratic elevated then auto-reduced back to original degree
- [x] 1D: genuine cubic not reduced; degree-0 unchanged; identity when no reduction
- [x] Multi-dim: bilinear surface, mixed reducible directions, trilinear volume
- [x] Tolerance: tight/loose/custom tolerance behavior
- [x] Dtype: float32 and float64
- [x] Errors: rational raises TypeError, non-positive tol raises ValueError
- [x] Full test suite passes (1828 tests), mypy clean, ruff clean, docs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)