### PR TITLE
feat(bezier): add collapse_along_axis method

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -759,15 +759,7 @@ class Bezier:
         if axis < 0 or axis >= self.dim:
             raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
 
-        values_arr = np.asarray(values, dtype=self.dtype)
-        if values_arr.ndim != 1 or values_arr.shape[0] != self.dim - 1:
-            raise ValueError(
-                f"values must have length dim - 1 = {self.dim - 1}, got shape {values_arr.shape}."
-            )
-        if np.any(values_arr < 0.0) or np.any(values_arr > 1.0):
-            raise ValueError("All values must be in [0, 1].")
-
-        return _collapse_along_axis(self, axis, values_arr)
+        return _collapse_along_axis(self, axis, values)
 
     # ------------------------------------------------------------------
     # Conversion

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy import typing as npt
 
 from .._transform_control_points import _apply_affine_to_control_points
+from ._bezier_collapse import _collapse_along_axis
 from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
@@ -712,6 +713,58 @@ class Bezier:
 
         value = 0.0 if side == 0 else 1.0
         return self.slice(axis, value)
+
+    # ------------------------------------------------------------------
+    # Collapse along axis
+    # ------------------------------------------------------------------
+
+    def collapse_along_axis(
+        self,
+        axis: int,
+        values: npt.ArrayLike,
+    ) -> Bezier:
+        """Collapse to a univariate Bézier along one parametric direction.
+
+        Fixes all parametric directions except ``axis`` at the given parameter
+        values, producing a 1D Bézier whose control points are the Bernstein
+        coefficients along ``axis``.  This is a tensor contraction: for each
+        collapsed direction, the Bernstein basis is evaluated at the given
+        value and contracted with the control point array.
+
+        Args:
+            axis (int): Parametric direction to keep (0-indexed).
+                Must be in ``[0, dim)``.
+            values (npt.ArrayLike): Parameter values for all directions
+                except ``axis``.  Must have length ``dim - 1`` with all
+                values in ``[0, 1]``.  ``values[i]`` corresponds to
+                direction ``i`` for ``i < axis``, and direction ``i + 1``
+                for ``i >= axis``.
+
+        Returns:
+            Bezier: A 1D Bézier with degree ``self.degree[axis]`` and
+            the same rank and rationality as the input.
+
+        Raises:
+            ValueError: If ``axis`` is out of range ``[0, dim)``.
+            ValueError: If ``values`` does not have length ``dim - 1``.
+            ValueError: If any value is outside ``[0, 1]``.
+
+        Example:
+            >>> # Collapse a 3D volume along axis 1 at (u=0.3, w=0.7)
+            >>> curve = volume.collapse_along_axis(1, [0.3, 0.7])
+        """
+        if axis < 0 or axis >= self.dim:
+            raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
+
+        values_arr = np.asarray(values, dtype=self.dtype)
+        if values_arr.ndim != 1 or values_arr.shape[0] != self.dim - 1:
+            raise ValueError(
+                f"values must have length dim - 1 = {self.dim - 1}, got shape {values_arr.shape}."
+            )
+        if np.any(values_arr < 0.0) or np.any(values_arr > 1.0):
+            raise ValueError("All values must be in [0, 1].")
+
+        return _collapse_along_axis(self, axis, values_arr)
 
     # ------------------------------------------------------------------
     # Conversion

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -745,6 +745,7 @@ class Bezier:
             the same rank and rationality as the input.
 
         Raises:
+            ValueError: If ``dim < 2`` (nothing to collapse).
             ValueError: If ``axis`` is out of range ``[0, dim)``.
             ValueError: If ``values`` does not have length ``dim - 1``.
             ValueError: If any value is outside ``[0, 1]``.
@@ -753,6 +754,8 @@ class Bezier:
             >>> # Collapse a 3D volume along axis 1 at (u=0.3, w=0.7)
             >>> curve = volume.collapse_along_axis(1, [0.3, 0.7])
         """
+        if self.dim < 2:  # noqa: PLR2004
+            raise ValueError("collapse_along_axis requires dim >= 2.")
         if axis < 0 or axis >= self.dim:
             raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
 

--- a/src/pantr/bezier/_bezier_collapse.py
+++ b/src/pantr/bezier/_bezier_collapse.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def _collapse_along_axis(
     bezier: Bezier,
     axis: int,
-    values: npt.NDArray[np.float64],
+    values: npt.ArrayLike,
 ) -> Bezier:
     """Collapse a Bézier to a univariate polynomial along one parametric direction.
 
@@ -40,22 +40,23 @@ def _collapse_along_axis(
     to keep axis indices stable.
 
     Args:
-        bezier (~pantr.bezier.Bezier): The Bézier to collapse.
-        axis (int): Parametric direction to keep (0-indexed, must be in
-            ``[0, dim)``).
-        values (npt.NDArray[np.float64]): Parameter values for all directions
-            except ``axis``, of shape ``(dim - 1,)``.  ``values[i]``
-            corresponds to direction ``i`` for ``i < axis``, and direction
-            ``i + 1`` for ``i >= axis``.
+        bezier (~pantr.bezier.Bezier): The Bézier to collapse.  ``dim >= 2``
+            and ``axis`` bounds are assumed valid (checked by the public method).
+        axis (int): Parametric direction to keep (0-indexed).
+        values (npt.ArrayLike): Parameter values for all directions except
+            ``axis``, of length ``dim - 1``.  ``values[i]`` corresponds to
+            direction ``i`` for ``i < axis``, and direction ``i + 1`` for
+            ``i >= axis``.  Values are cast to ``bezier.dtype``; passing
+            higher-precision values to a ``float32`` Bézier will silently
+            reduce precision.
 
     Returns:
         ~pantr.bezier.Bezier: A 1D Bézier with degree ``bezier.degree[axis]``
         and the same rank and rationality as the input.
 
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :meth:`~pantr.bezier.Bezier.collapse_along_axis`
-        instead.
+    Raises:
+        ValueError: If ``values`` does not have length ``dim - 1``.
+        ValueError: If any value is outside ``[0, 1]``.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
@@ -63,6 +64,14 @@ def _collapse_along_axis(
     ctrl = bezier.control_points
     dtype = bezier.dtype
     degrees = bezier.degree
+
+    values_arr = np.asarray(values, dtype=dtype)
+    if values_arr.ndim != 1 or values_arr.shape[0] != dim - 1:
+        raise ValueError(
+            f"values must have length dim - 1 = {dim - 1}, got shape {values_arr.shape}."
+        )
+    if np.any(values_arr < 0.0) or np.any(values_arr > 1.0):
+        raise ValueError("All values must be in [0, 1].")
 
     # Contract directions from highest to lowest, skipping `axis`.
     # Processing high-to-low ensures that the current array index of each
@@ -75,7 +84,7 @@ def _collapse_along_axis(
         val_idx = d if d < axis else d - 1
 
         # Evaluate Bernstein basis at the single parameter value.
-        pts_d = np.array([values[val_idx]], dtype=dtype)
+        pts_d = np.array([values_arr[val_idx]])
         basis_d = np.empty((1, degrees[d] + 1), dtype=dtype)
         _tabulate_Bernstein_basis_1D_core(np.int32(degrees[d]), pts_d, basis_d)
         basis_1d: npt.NDArray[np.float32 | np.float64] = basis_d[0]

--- a/src/pantr/bezier/_bezier_collapse.py
+++ b/src/pantr/bezier/_bezier_collapse.py
@@ -1,0 +1,90 @@
+"""Bézier collapse along axis (reduce to univariate by partial evaluation).
+
+This module provides :func:`_collapse_along_axis`, which fixes all parametric
+directions of a Bézier except one at given parameter values, producing a
+univariate Bézier along the remaining direction.
+
+The algorithm evaluates the Bernstein basis in each collapsed direction at the
+given parameter value, then contracts the control point tensor against these
+basis vectors using :func:`numpy.tensordot`.  This mirrors the single-pass
+tensor contraction strategy used in algoim's ``collapseAlongAxis``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _collapse_along_axis(
+    bezier: Bezier,
+    axis: int,
+    values: npt.NDArray[np.float64],
+) -> Bezier:
+    """Collapse a Bézier to a univariate polynomial along one parametric direction.
+
+    Fixes all parametric directions except ``axis`` at the parameter values
+    given in ``values``, producing a 1D Bézier whose control points are the
+    Bernstein coefficients along ``axis``.
+
+    The contraction is performed by evaluating the Bernstein basis in each
+    collapsed direction and contracting the control point array via
+    :func:`numpy.tensordot`, processing directions from highest to lowest
+    to keep axis indices stable.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to collapse.
+        axis (int): Parametric direction to keep (0-indexed, must be in
+            ``[0, dim)``).
+        values (npt.NDArray[np.float64]): Parameter values for all directions
+            except ``axis``, of shape ``(dim - 1,)``.  ``values[i]``
+            corresponds to direction ``i`` for ``i < axis``, and direction
+            ``i + 1`` for ``i >= axis``.
+
+    Returns:
+        ~pantr.bezier.Bezier: A 1D Bézier with degree ``bezier.degree[axis]``
+        and the same rank and rationality as the input.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bezier.Bezier.collapse_along_axis`
+        instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    dim = bezier.dim
+
+    if dim == 1:
+        return BezierCls(bezier.control_points.copy(), is_rational=bezier.is_rational)
+
+    ctrl = bezier.control_points
+    dtype = bezier.dtype
+    degrees = bezier.degree
+
+    # Contract directions from highest to lowest, skipping `axis`.
+    # Processing high-to-low ensures that the current array index of each
+    # direction equals its original index when we reach it.
+    result: npt.NDArray[np.float32 | np.float64] = ctrl
+    for d in range(dim - 1, -1, -1):
+        if d == axis:
+            continue
+
+        val_idx = d if d < axis else d - 1
+
+        # Evaluate Bernstein basis at the single parameter value.
+        pts_d = np.array([values[val_idx]], dtype=dtype)
+        basis_d = np.empty((1, degrees[d] + 1), dtype=dtype)
+        _tabulate_Bernstein_basis_1D_core(np.int32(degrees[d]), pts_d, basis_d)
+        basis_1d: npt.NDArray[np.float32 | np.float64] = basis_d[0]
+
+        # Contract along direction d.
+        result = np.tensordot(basis_1d, result, axes=([0], [d]))
+
+    return BezierCls(result, is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_collapse.py
+++ b/src/pantr/bezier/_bezier_collapse.py
@@ -60,10 +60,6 @@ def _collapse_along_axis(
     from . import Bezier as BezierCls  # noqa: PLC0415
 
     dim = bezier.dim
-
-    if dim == 1:
-        return BezierCls(bezier.control_points.copy(), is_rational=bezier.is_rational)
-
     ctrl = bezier.control_points
     dtype = bezier.dtype
     degrees = bezier.degree

--- a/tests/test_bezier_collapse.py
+++ b/tests/test_bezier_collapse.py
@@ -61,21 +61,13 @@ def _make_rational_surface(dtype: type = np.float64) -> Bezier:
 
 
 class TestCollapse1D:
-    """Test collapse on a 1D Bézier (should be a no-op copy)."""
+    """Test that collapsing a 1D Bézier raises an error."""
 
-    def test_returns_copy(self) -> None:
-        """Collapsing a 1D Bézier returns a copy with same control points."""
+    def test_raises_on_1d(self) -> None:
+        """Collapsing a 1D Bézier raises ValueError."""
         crv = _make_1d_curve()
-        result = crv.collapse_along_axis(0, [])
-        assert isinstance(result, Bezier)
-        assert result.dim == 1
-        np.testing.assert_array_equal(result.control_points, crv.control_points)
-
-    def test_is_independent_copy(self) -> None:
-        """The returned Bézier does not share memory with the original."""
-        crv = _make_1d_curve()
-        result = crv.collapse_along_axis(0, [])
-        assert not np.shares_memory(result.control_points, crv.control_points)
+        with pytest.raises(ValueError, match="dim >= 2"):
+            crv.collapse_along_axis(0, [])
 
 
 # ---------------------------------------------------------------------------
@@ -229,12 +221,11 @@ class TestCollapse3DHigherDegree:
 class TestCollapseRational:
     """Test collapse on rational Béziers."""
 
-    def test_rational_1d_is_noop(self) -> None:
-        """Collapsing a rational 1D curve returns a rational copy."""
+    def test_rational_1d_raises(self) -> None:
+        """Collapsing a rational 1D curve raises ValueError."""
         crv = _make_rational_curve()
-        result = crv.collapse_along_axis(0, [])
-        assert result.is_rational
-        np.testing.assert_array_equal(result.control_points, crv.control_points)
+        with pytest.raises(ValueError, match="dim >= 2"):
+            crv.collapse_along_axis(0, [])
 
     def test_rational_2d_preserves_rationality(self) -> None:
         """Collapsing a rational 2D surface preserves is_rational."""

--- a/tests/test_bezier_collapse.py
+++ b/tests/test_bezier_collapse.py
@@ -1,0 +1,308 @@
+"""Tests for Bezier.collapse_along_axis() method."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_1d_curve(dtype: type = np.float64) -> Bezier:
+    """Create a 1D cubic Bézier curve (4 control points, rank 2)."""
+    ctrl: npt.NDArray[np.float64] = np.array([[0, 0], [1, 3], [4, 3], [5, 0]], dtype=dtype)
+    return Bezier(ctrl)
+
+
+def _make_2d_surface(dtype: type = np.float64) -> Bezier:
+    """Create a 2D quadratic Bézier surface (3x3 control points, rank 3)."""
+    rng = np.random.default_rng(42)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_3d_volume(dtype: type = np.float64) -> Bezier:
+    """Create a 3D linear Bézier volume (2x2x2 control points, rank 3)."""
+    rng = np.random.default_rng(123)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((2, 2, 2, 3)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_3d_higher_degree(dtype: type = np.float64) -> Bezier:
+    """Create a 3D Bézier volume with degrees (2, 3, 4)."""
+    rng = np.random.default_rng(456)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 4, 5, 2)).astype(dtype)
+    return Bezier(ctrl)
+
+
+def _make_rational_curve(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier (quarter circle)."""
+    w = np.sqrt(2.0) / 2.0
+    ctrl: npt.NDArray[np.float64] = np.array([[1, 0, 1], [w, w, w], [0, 1, 1]], dtype=dtype)
+    return Bezier(ctrl, is_rational=True)
+
+
+def _make_rational_surface(dtype: type = np.float64) -> Bezier:
+    """Create a rational quadratic Bézier surface."""
+    rng = np.random.default_rng(99)
+    ctrl: npt.NDArray[np.float64] = rng.standard_normal((3, 3, 3)).astype(dtype)
+    ctrl[:, :, -1] = np.abs(ctrl[:, :, -1]) + 0.5
+    return Bezier(ctrl, is_rational=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: 1D (no-op case)
+# ---------------------------------------------------------------------------
+
+
+class TestCollapse1D:
+    """Test collapse on a 1D Bézier (should be a no-op copy)."""
+
+    def test_returns_copy(self) -> None:
+        """Collapsing a 1D Bézier returns a copy with same control points."""
+        crv = _make_1d_curve()
+        result = crv.collapse_along_axis(0, [])
+        assert isinstance(result, Bezier)
+        assert result.dim == 1
+        np.testing.assert_array_equal(result.control_points, crv.control_points)
+
+    def test_is_independent_copy(self) -> None:
+        """The returned Bézier does not share memory with the original."""
+        crv = _make_1d_curve()
+        result = crv.collapse_along_axis(0, [])
+        assert not np.shares_memory(result.control_points, crv.control_points)
+
+
+# ---------------------------------------------------------------------------
+# Tests: 2D surface
+# ---------------------------------------------------------------------------
+
+
+class TestCollapse2D:
+    """Test collapse of a 2D surface to a 1D curve."""
+
+    def test_collapse_axis0_returns_1d(self) -> None:
+        """Collapsing along axis 0 produces a 1D Bézier."""
+        srf = _make_2d_surface()
+        crv = srf.collapse_along_axis(0, [0.5])
+        assert isinstance(crv, Bezier)
+        assert crv.dim == 1
+        assert crv.degree == (srf.degree[0],)
+
+    def test_collapse_axis1_returns_1d(self) -> None:
+        """Collapsing along axis 1 produces a 1D Bézier."""
+        srf = _make_2d_surface()
+        crv = srf.collapse_along_axis(1, [0.5])
+        assert isinstance(crv, Bezier)
+        assert crv.dim == 1
+        assert crv.degree == (srf.degree[1],)
+
+    def test_collapse_axis0_evaluate_matches(self) -> None:
+        """Evaluating the collapsed curve matches evaluating the surface."""
+        srf = _make_2d_surface()
+        v = 0.6
+        crv = srf.collapse_along_axis(0, [v])
+        for u in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_collapse = crv.evaluate(np.array([u], dtype=srf.dtype)).squeeze()
+            pt_direct = srf.evaluate(np.array([[u, v]], dtype=srf.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-13)
+
+    def test_collapse_axis1_evaluate_matches(self) -> None:
+        """Evaluating the collapsed curve matches evaluating the surface."""
+        srf = _make_2d_surface()
+        u = 0.3
+        crv = srf.collapse_along_axis(1, [u])
+        for v in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_collapse = crv.evaluate(np.array([v], dtype=srf.dtype)).squeeze()
+            pt_direct = srf.evaluate(np.array([[u, v]], dtype=srf.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-13)
+
+    def test_collapse_at_boundary_zero(self) -> None:
+        """Collapsing at boundary 0 matches slicing."""
+        srf = _make_2d_surface()
+        crv_collapse = srf.collapse_along_axis(0, [0.0])
+        crv_slice = srf.slice(1, 0.0)
+        assert isinstance(crv_slice, Bezier)
+        np.testing.assert_allclose(
+            crv_collapse.control_points, crv_slice.control_points, atol=1e-14
+        )
+
+    def test_collapse_at_boundary_one(self) -> None:
+        """Collapsing at boundary 1 matches slicing."""
+        srf = _make_2d_surface()
+        crv_collapse = srf.collapse_along_axis(1, [1.0])
+        crv_slice = srf.slice(0, 1.0)
+        assert isinstance(crv_slice, Bezier)
+        np.testing.assert_allclose(
+            crv_collapse.control_points, crv_slice.control_points, atol=1e-14
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: 3D volume
+# ---------------------------------------------------------------------------
+
+
+class TestCollapse3D:
+    """Test collapse of a 3D volume to a 1D curve."""
+
+    def test_collapse_axis0(self) -> None:
+        """Collapsing along axis 0 matches sequential slicing."""
+        vol = _make_3d_volume()
+        v, w = 0.4, 0.7
+        crv = vol.collapse_along_axis(0, [v, w])
+        assert crv.dim == 1
+        assert crv.degree == (vol.degree[0],)
+        for u in [0.0, 0.5, 1.0]:
+            pt_collapse = crv.evaluate(np.array([u], dtype=vol.dtype)).squeeze()
+            pt_direct = vol.evaluate(np.array([[u, v, w]], dtype=vol.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-13)
+
+    def test_collapse_axis1(self) -> None:
+        """Collapsing along axis 1 matches direct evaluation."""
+        vol = _make_3d_volume()
+        u, w = 0.3, 0.8
+        crv = vol.collapse_along_axis(1, [u, w])
+        assert crv.dim == 1
+        assert crv.degree == (vol.degree[1],)
+        for v in [0.0, 0.5, 1.0]:
+            pt_collapse = crv.evaluate(np.array([v], dtype=vol.dtype)).squeeze()
+            pt_direct = vol.evaluate(np.array([[u, v, w]], dtype=vol.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-13)
+
+    def test_collapse_axis2(self) -> None:
+        """Collapsing along axis 2 matches direct evaluation."""
+        vol = _make_3d_volume()
+        u, v = 0.2, 0.6
+        crv = vol.collapse_along_axis(2, [u, v])
+        assert crv.dim == 1
+        assert crv.degree == (vol.degree[2],)
+        for w in [0.0, 0.5, 1.0]:
+            pt_collapse = crv.evaluate(np.array([w], dtype=vol.dtype)).squeeze()
+            pt_direct = vol.evaluate(np.array([[u, v, w]], dtype=vol.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-13)
+
+
+class TestCollapse3DHigherDegree:
+    """Test collapse of a 3D Bézier with non-uniform degrees."""
+
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_collapse_preserves_degree(self, axis: int) -> None:
+        """Collapsed curve has the correct degree."""
+        vol = _make_3d_higher_degree()
+        values = [0.3, 0.7]
+        crv = vol.collapse_along_axis(axis, values)
+        assert crv.degree == (vol.degree[axis],)
+
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_collapse_matches_evaluate(self, axis: int) -> None:
+        """Collapsed curve evaluation matches full volume evaluation."""
+        vol = _make_3d_higher_degree()
+        # Fixed values for non-axis directions
+        fixed = [0.3, 0.7]
+        crv = vol.collapse_along_axis(axis, fixed)
+        for t in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_collapse = crv.evaluate(np.array([t], dtype=vol.dtype)).squeeze()
+            # Build full point
+            full_pt = np.empty(3, dtype=vol.dtype)
+            val_idx = 0
+            for d in range(3):
+                if d == axis:
+                    full_pt[d] = t
+                else:
+                    full_pt[d] = fixed[val_idx]
+                    val_idx += 1
+            pt_direct = vol.evaluate(full_pt.reshape(1, 3)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Tests: rational Béziers
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseRational:
+    """Test collapse on rational Béziers."""
+
+    def test_rational_1d_is_noop(self) -> None:
+        """Collapsing a rational 1D curve returns a rational copy."""
+        crv = _make_rational_curve()
+        result = crv.collapse_along_axis(0, [])
+        assert result.is_rational
+        np.testing.assert_array_equal(result.control_points, crv.control_points)
+
+    def test_rational_2d_preserves_rationality(self) -> None:
+        """Collapsing a rational 2D surface preserves is_rational."""
+        srf = _make_rational_surface()
+        crv = srf.collapse_along_axis(0, [0.5])
+        assert crv.is_rational
+
+    def test_rational_2d_evaluate_matches(self) -> None:
+        """Collapsed rational curve evaluation matches surface evaluation."""
+        srf = _make_rational_surface()
+        v = 0.4
+        crv = srf.collapse_along_axis(0, [v])
+        for u in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_collapse = crv.evaluate(np.array([u], dtype=srf.dtype)).squeeze()
+            pt_direct = srf.evaluate(np.array([[u, v]], dtype=srf.dtype)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Tests: dtype preservation
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseDtype:
+    """Test that collapse preserves dtype."""
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_preserves_dtype(self, dtype: type) -> None:
+        """Output dtype matches input dtype."""
+        srf = _make_2d_surface(dtype=dtype)
+        crv = srf.collapse_along_axis(0, [0.5])
+        assert crv.dtype == dtype
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseErrors:
+    """Test error handling for collapse_along_axis."""
+
+    def test_axis_out_of_range(self) -> None:
+        """Axis out of range raises ValueError."""
+        srf = _make_2d_surface()
+        with pytest.raises(ValueError, match="axis must be in"):
+            srf.collapse_along_axis(2, [0.5])
+
+    def test_axis_negative(self) -> None:
+        """Negative axis raises ValueError."""
+        srf = _make_2d_surface()
+        with pytest.raises(ValueError, match="axis must be in"):
+            srf.collapse_along_axis(-1, [0.5])
+
+    def test_wrong_values_length(self) -> None:
+        """Wrong number of values raises ValueError."""
+        srf = _make_2d_surface()
+        with pytest.raises(ValueError, match="values must have length"):
+            srf.collapse_along_axis(0, [0.3, 0.5])
+
+    def test_value_below_zero(self) -> None:
+        """Value below 0 raises ValueError."""
+        srf = _make_2d_surface()
+        with pytest.raises(ValueError, match="All values must be in"):
+            srf.collapse_along_axis(0, [-0.1])
+
+    def test_value_above_one(self) -> None:
+        """Value above 1 raises ValueError."""
+        srf = _make_2d_surface()
+        with pytest.raises(ValueError, match="All values must be in"):
+            srf.collapse_along_axis(0, [1.5])

--- a/tests/test_bezier_collapse.py
+++ b/tests/test_bezier_collapse.py
@@ -259,6 +259,18 @@ class TestCollapseDtype:
         crv = srf.collapse_along_axis(0, [0.5])
         assert crv.dtype == dtype
 
+    def test_float32_values_cast_and_correct(self) -> None:
+        """float64 values passed to a float32 Bézier produce correct float32 output."""
+        srf = _make_2d_surface(dtype=np.float32)
+        v = 0.3  # float64 literal
+        crv = srf.collapse_along_axis(0, [v])
+        assert crv.dtype == np.float32
+        # Evaluation should still match the surface within float32 tolerance.
+        for u in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            pt_collapse = crv.evaluate(np.array([u], dtype=np.float32)).squeeze()
+            pt_direct = srf.evaluate(np.array([[u, v]], dtype=np.float32)).squeeze()
+            np.testing.assert_allclose(pt_collapse, pt_direct, atol=1e-5)
+
 
 # ---------------------------------------------------------------------------
 # Tests: error handling


### PR DESCRIPTION
## Summary
- Add `Bezier.collapse_along_axis(axis, values)` method that collapses a multivariate Bézier to a univariate polynomial along one parametric direction
- Fixes all parametric directions except `axis` at given parameter values via Bernstein basis evaluation and `np.tensordot` contraction (mirroring algoim's `collapseAlongAxis` strategy)
- Layer 2 helper in `_bezier_collapse.py`, Layer 1 public method in `_bezier.py`

## Test plan
- [x] All existing tests pass (1837 passed)
- [x] New tests added for `collapse_along_axis` (27 tests covering 1D/2D/3D, rational, dtype, errors)
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

Generated with [Claude Code](https://claude.com/claude-code)