### PR TITLE
feat(bezier): add Bezier composition

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy import typing as npt
 
 from .._transform_control_points import _apply_affine_to_control_points
+from ._bezier_compose import _compose_bezier
 from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
@@ -386,6 +387,37 @@ class Bezier:
         return _multiply_bezier(self, other)
 
     __mul__ = multiply
+
+    # ------------------------------------------------------------------
+    # Compose
+    # ------------------------------------------------------------------
+
+    def compose(self, inner: Bezier) -> Bezier:
+        """Compose this Bézier with another: ``result(t) = self(inner(t))``.
+
+        Computes the exact composition of two non-rational Bézier objects.
+        The result is a new Bézier with parametric dimension equal to
+        ``inner.dim``, rank equal to ``self.rank``, and degree
+        ``sum(self.degree) * inner.degree[s]`` in each direction ``s``.
+
+        Args:
+            inner (Bezier): The inner Bézier (reparametrization). Must be
+                non-rational and satisfy ``inner.rank == self.dim``.
+
+        Returns:
+            Bezier: A new Bézier representing ``self(inner(t))``.
+
+        Raises:
+            TypeError: If either Bézier is rational.
+            ValueError: If ``inner.rank != self.dim``.
+            ValueError: If the operands have different dtypes.
+
+        Example:
+            >>> f = Bezier(np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]]))
+            >>> g = Bezier(np.array([[0.2], [0.8]]))
+            >>> h = f.compose(g)
+        """
+        return _compose_bezier(self, inner)
 
     # ------------------------------------------------------------------
     # Reverse and permute

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -1,0 +1,264 @@
+"""Bézier composition.
+
+This module provides :func:`_compose_bezier`, which computes the exact
+composition of two non-rational Bézier objects: ``outer(inner(t))``.
+
+The algorithm decomposes each scalar component of the inner Bézier into
+Bernstein basis evaluations of the outer's degree, then combines them
+with the outer's control points via a multi-index weighted summation.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bezier_core import _scalar_bernstein_product_1d_core
+from ._bezier_product import (
+    _bernstein_product_coefficients,
+    _bernstein_product_coefficients_nd,
+)
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
+    """Compose two non-rational Bézier objects: ``outer(inner(t))``.
+
+    Validates that both operands are non-rational, that the inner's rank
+    matches the outer's parametric dimension, and that their dtypes match,
+    then dispatches to the composition implementation.
+
+    Args:
+        outer (~pantr.bezier.Bezier): The outer Bézier (the mapping being
+            composed). Must be non-rational.
+        inner (~pantr.bezier.Bezier): The inner Bézier (the reparametrization).
+            Must be non-rational and satisfy ``inner.rank == outer.dim``.
+
+    Returns:
+        ~pantr.bezier.Bezier: Composed Bézier with ``dim = inner.dim``,
+        ``rank = outer.rank``, and degree ``sum(outer.degree) * inner.degree[s]``
+        in each parametric direction ``s``.
+
+    Raises:
+        TypeError: If either operand is rational.
+        ValueError: If ``inner.rank != outer.dim``.
+        ValueError: If the operands have different dtypes.
+    """
+    if outer.is_rational:
+        raise TypeError("Composition is not supported for rational Béziers (outer is rational).")
+    if inner.is_rational:
+        raise TypeError("Composition is not supported for rational Béziers (inner is rational).")
+    if inner.rank != outer.dim:
+        raise ValueError(
+            f"Inner Bézier rank ({inner.rank}) must equal outer Bézier "
+            f"parametric dimension ({outer.dim})."
+        )
+    if outer.dtype != inner.dtype:
+        raise ValueError(f"Operands must have the same dtype. Got {outer.dtype} and {inner.dtype}.")
+
+    return _compose_impl(outer, inner)
+
+
+def _compose_impl(outer: Bezier, inner: Bezier) -> Bezier:
+    """Compute the composition of two non-rational Bézier objects.
+
+    Implements the Bernstein basis decomposition algorithm:
+
+    1. For each parametric direction ``d`` of ``outer``, extract the ``d``-th
+       scalar component of ``inner`` and compute the Bernstein basis evaluations
+       ``B_i^{m_d}(g_d)`` for ``i = 0, ..., m_d``.
+    2. Iterate over all multi-indices of the outer control points, compute the
+       tensor product of Bernstein bases, and accumulate weighted by the
+       control point values.
+
+    Args:
+        outer (~pantr.bezier.Bezier): The outer Bézier (non-rational, validated).
+        inner (~pantr.bezier.Bezier): The inner Bézier (non-rational, validated).
+
+    Returns:
+        ~pantr.bezier.Bezier: The composed Bézier.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_compose_bezier` instead.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    dim_f = outer.dim
+    dim_g = inner.dim
+    deg_f = outer.degree
+    rank = outer.rank
+    dtype = outer.dtype
+
+    # Choose product function based on inner dimensionality.
+    use_1d_kernel = dim_g == 1
+
+    # Step 1: Compute Bernstein bases for each direction of outer.
+    all_bases: list[list[npt.NDArray[np.float32 | np.float64]]] = []
+    for d in range(dim_f):
+        g_d_ctrl = _extract_scalar_component(inner.control_points, d)
+        bases_d = _compute_bernstein_bases(g_d_ctrl, deg_f[d], use_1d_kernel)
+        all_bases.append(bases_d)
+
+    # Step 2: Compute result degree and accumulate.
+    sum_deg_f = sum(deg_f)
+    if dim_g == 1:
+        result_shape = (sum_deg_f * inner.degree[0] + 1,)
+    else:
+        result_shape = tuple(sum_deg_f * n + 1 for n in inner.degree)
+
+    result_ctrl = np.zeros((*result_shape, rank), dtype=dtype)
+
+    outer_ctrl = outer.control_points
+    for multi_idx in itertools.product(*(range(m + 1) for m in deg_f)):
+        coef = outer_ctrl[multi_idx]  # shape (rank,)
+
+        # Compute tensor product of Bernstein bases across all directions.
+        basis = all_bases[0][multi_idx[0]]
+        for d in range(1, dim_f):
+            basis = _product_fn(basis, all_bases[d][multi_idx[d]], use_1d_kernel)
+
+        # Accumulate: broadcast coef (rank,) with basis (*result_shape, 1).
+        result_ctrl += coef * basis
+
+    return BezierCls(result_ctrl, is_rational=False)
+
+
+def _extract_scalar_component(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    component: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Extract a scalar component from control points, keeping the rank axis.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points with shape
+            ``(*degrees_plus_1, rank)``.
+        component (int): Index of the component to extract.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Scalar control points with shape
+        ``(*degrees_plus_1, 1)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    return ctrl[..., component : component + 1]
+
+
+def _compute_bernstein_bases(
+    g_ctrl: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    use_1d_kernel: bool,
+) -> list[npt.NDArray[np.float32 | np.float64]]:
+    r"""Compute the Bernstein basis evaluations ``B_i^m(g)`` for ``i = 0, ..., m``.
+
+    Given a scalar Bézier ``g`` and a target degree ``m``, computes
+    ``B_i^m(g) = \binom{m}{i}\, g^i\, (1 - g)^{m - i}`` for each ``i``.
+
+    The computation uses pre-computed powers of ``g`` and ``(1 - g)`` via
+    iterative Bernstein products.
+
+    Args:
+        g_ctrl (npt.NDArray[np.float32 | np.float64]): Control points of a
+            scalar Bézier with shape ``(*degrees_plus_1, 1)``.
+        degree (int): Target Bernstein degree (``m >= 0``).
+        use_1d_kernel (bool): Whether to use the 1D Numba kernel for products.
+
+    Returns:
+        list[npt.NDArray[np.float32 | np.float64]]: List of ``degree + 1``
+        arrays, each with shape ``(*result_degrees_plus_1, 1)``, representing
+        the Bernstein basis evaluations in Bézier form.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    if degree == 0:
+        # B_0^0 = 1: constant Bézier with coefficient 1.
+        ones = np.ones_like(g_ctrl)
+        return [ones]
+
+    # Compute (1 - g) control points (partition of unity property).
+    one_minus_g_ctrl = 1.0 - g_ctrl
+
+    # Compute powers: g^1, ..., g^degree and (1-g)^1, ..., (1-g)^degree.
+    g_powers = _compute_scalar_powers(g_ctrl, degree, use_1d_kernel)
+    one_minus_g_powers = _compute_scalar_powers(one_minus_g_ctrl, degree, use_1d_kernel)
+
+    # Build Bernstein bases.
+    bases: list[npt.NDArray[np.float32 | np.float64]] = [None] * (degree + 1)  # type: ignore[list-item]
+    bases[0] = one_minus_g_powers[degree - 1]  # (1-g)^m
+    bases[degree] = g_powers[degree - 1]  # g^m
+
+    for i in range(1, degree):
+        binom_coeff = math.comb(degree, i)
+        prod = _product_fn(g_powers[i - 1], one_minus_g_powers[degree - i - 1], use_1d_kernel)
+        bases[i] = float(binom_coeff) * prod
+
+    return bases
+
+
+def _compute_scalar_powers(
+    g_ctrl: npt.NDArray[np.float32 | np.float64],
+    max_power: int,
+    use_1d_kernel: bool,
+) -> list[npt.NDArray[np.float32 | np.float64]]:
+    """Compute successive powers of a scalar Bézier: ``g^1, g^2, ..., g^{max_power}``.
+
+    Each power is computed iteratively via Bernstein product:
+    ``g^k = g^{k-1} * g``.
+
+    Args:
+        g_ctrl (npt.NDArray[np.float32 | np.float64]): Control points of a
+            scalar Bézier with shape ``(*degrees_plus_1, 1)``.
+        max_power (int): Maximum power to compute (``>= 1``).
+        use_1d_kernel (bool): Whether to use the 1D Numba kernel for products.
+
+    Returns:
+        list[npt.NDArray[np.float32 | np.float64]]: List of ``max_power``
+        arrays, where entry ``k`` (0-indexed) is ``g^{k+1}`` in Bézier form.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    powers: list[npt.NDArray[np.float32 | np.float64]] = [g_ctrl]
+    for _ in range(1, max_power):
+        powers.append(_product_fn(powers[-1], g_ctrl, use_1d_kernel))
+    return powers
+
+
+def _product_fn(
+    a: npt.NDArray[np.float32 | np.float64],
+    b: npt.NDArray[np.float32 | np.float64],
+    use_1d_kernel: bool,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute the Bernstein product of two scalar Bézier control point arrays.
+
+    Dispatches to the 1D Numba kernel or the general nD NumPy implementation
+    based on the ``use_1d_kernel`` flag.
+
+    Args:
+        a (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            scalar Bézier.
+        b (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            scalar Bézier.
+        use_1d_kernel (bool): If True, use the 1D Numba kernel (expects shape
+            ``(n, 1)``). If False, use the nD NumPy implementation.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product Bézier control points.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    if use_1d_kernel:
+        result_1d = _scalar_bernstein_product_1d_core(a[:, 0], b[:, 0])
+        return result_1d[:, np.newaxis]
+    if a.ndim - 1 == 1:
+        return _bernstein_product_coefficients(a, b)
+    return _bernstein_product_coefficients_nd(a, b)

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -179,8 +179,9 @@ def _compute_bernstein_bases(
         Inputs are assumed to be correct (no validation performed).
     """
     if degree == 0:
-        # B_0^0 = 1: constant Bézier with coefficient 1.
-        ones = np.ones_like(g_ctrl)
+        # B_0^0 = 1: constant (degree-0) Bézier with coefficient 1.
+        shape = (*tuple(1 for _ in g_ctrl.shape[:-1]), 1)
+        ones = np.ones(shape, dtype=g_ctrl.dtype)
         return [ones]
 
     # Compute (1 - g) control points (partition of unity property).

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -108,10 +108,7 @@ def _compose_impl(outer: Bezier, inner: Bezier) -> Bezier:
 
     # Step 2: Compute result degree and accumulate.
     sum_deg_f = sum(deg_f)
-    if dim_g == 1:
-        result_shape = (sum_deg_f * inner.degree[0] + 1,)
-    else:
-        result_shape = tuple(sum_deg_f * n + 1 for n in inner.degree)
+    result_shape: tuple[int, ...] = tuple(sum_deg_f * n + 1 for n in inner.degree)
 
     result_ctrl = np.zeros((*result_shape, rank), dtype=dtype)
 

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -18,10 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ._bezier_core import _scalar_bernstein_product_1d_core
-from ._bezier_product import (
-    _bernstein_product_coefficients,
-    _bernstein_product_coefficients_nd,
-)
+from ._bezier_product import _bernstein_product_coefficients_nd
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -85,8 +82,8 @@ def _compose_impl(outer: Bezier, inner: Bezier) -> Bezier:
         ~pantr.bezier.Bezier: The composed Bézier.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_compose_bezier` instead.
+        Validation is performed by :func:`_compose_bezier`; this function
+        assumes both operands have already been validated.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
@@ -188,15 +185,13 @@ def _compute_bernstein_bases(
     g_powers = _compute_scalar_powers(g_ctrl, degree, use_1d_kernel)
     one_minus_g_powers = _compute_scalar_powers(one_minus_g_ctrl, degree, use_1d_kernel)
 
-    # Build Bernstein bases.
-    bases: list[npt.NDArray[np.float32 | np.float64]] = [None] * (degree + 1)  # type: ignore[list-item]
-    bases[0] = one_minus_g_powers[degree - 1]  # (1-g)^m
-    bases[degree] = g_powers[degree - 1]  # g^m
-
+    # Build Bernstein bases in order: B_0^m, B_1^m, ..., B_m^m.
+    bases: list[npt.NDArray[np.float32 | np.float64]] = [one_minus_g_powers[degree - 1]]
     for i in range(1, degree):
         binom_coeff = math.comb(degree, i)
         prod = _product_fn(g_powers[i - 1], one_minus_g_powers[degree - i - 1], use_1d_kernel)
-        bases[i] = float(binom_coeff) * prod
+        bases.append(float(binom_coeff) * prod)
+    bases.append(g_powers[degree - 1])
 
     return bases
 
@@ -245,8 +240,9 @@ def _product_fn(
             scalar Bézier.
         b (npt.NDArray[np.float32 | np.float64]): Control points of the second
             scalar Bézier.
-        use_1d_kernel (bool): If True, use the 1D Numba kernel (expects shape
-            ``(n, 1)``). If False, use the nD NumPy implementation.
+        use_1d_kernel (bool): If True, use the 1D Numba kernel (shape ``(n, 1)``
+            arrays, set when the inner Bézier is 1D). If False, use the nD
+            NumPy implementation.
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Product Bézier control points.
@@ -257,6 +253,4 @@ def _product_fn(
     if use_1d_kernel:
         result_1d = _scalar_bernstein_product_1d_core(a[:, 0], b[:, 0])
         return result_1d[:, np.newaxis]
-    if a.ndim - 1 == 1:
-        return _bernstein_product_coefficients(a, b)
     return _bernstein_product_coefficients_nd(a, b)

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -560,6 +560,53 @@ def _restrict_bezier_1d_core(  # noqa: PLR0912
             out[i, col] = d[i]
 
 
+@nb_jit(nopython=True, cache=True)
+def _scalar_bernstein_product_1d_core(
+    a: npt.NDArray[np.float32 | np.float64],
+    b: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Compute the Bernstein product of two scalar 1D Bézier curves.
+
+    Given two scalar Bézier curves with control points ``a`` (degree ``p``)
+    and ``b`` (degree ``q``), computes the product curve of degree ``p + q``
+    using the binomial-scaled convolution formula:
+
+    .. math::
+
+        c_k = \frac{1}{\binom{p+q}{k}} \sum_{i=\max(0,k-q)}^{\min(p,k)}
+              \binom{p}{i}\,\binom{q}{k-i}\, a_i\, b_{k-i}
+
+    Args:
+        a (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            scalar Bézier, shape ``(p + 1,)``.
+        b (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            scalar Bézier, shape ``(q + 1,)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Product control points of shape
+        ``(p + q + 1,)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_compose._compose_bezier` instead.
+    """
+    p = a.shape[0] - 1
+    q = b.shape[0] - 1
+    r = p + q
+
+    out = np.zeros(r + 1, dtype=a.dtype)
+
+    for i in range(p + 1):
+        ai_scaled = a[i] * _bincoeff(p, i)
+        for j in range(q + 1):
+            out[i + j] += ai_scaled * b[j] * _bincoeff(q, j)
+
+    for k in range(r + 1):
+        out[k] /= _bincoeff(r, k)
+
+    return out
+
+
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
@@ -581,3 +628,7 @@ def _warmup_numba_functions() -> None:
     _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)
     _split_bezier_1d_core(ctrl_dummy, 0.5, out_split_dummy, out_split_dummy.copy())
     _restrict_bezier_1d_core(ctrl_dummy, 0.2, 0.8, out_split_dummy)
+
+    a_dummy = np.array([0.0, 1.0], dtype=np.float64)
+    b_dummy = np.array([1.0, 0.0], dtype=np.float64)
+    _scalar_bernstein_product_1d_core(a_dummy, b_dummy)

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -560,7 +560,7 @@ def _restrict_bezier_1d_core(  # noqa: PLR0912
             out[i, col] = d[i]
 
 
-@nb_jit(nopython=True, cache=True)
+@nb_jit(nopython=True, cache=True, parallel=True)
 def _scalar_bernstein_product_1d_core(
     a: npt.NDArray[np.float32 | np.float64],
     b: npt.NDArray[np.float32 | np.float64],
@@ -601,7 +601,7 @@ def _scalar_bernstein_product_1d_core(
         for j in range(q + 1):
             out[i + j] += ai_scaled * b[j] * _bincoeff(q, j)
 
-    for k in range(r + 1):
+    for k in nb_prange(r + 1):
         out[k] /= _bincoeff(r, k)
 
     return out

--- a/tests/test_bezier_compose.py
+++ b/tests/test_bezier_compose.py
@@ -1,0 +1,333 @@
+"""Tests for Bézier composition."""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from numpy.testing import assert_allclose
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RNG = np.random.default_rng(42)
+
+
+def _random_bezier(
+    degree: tuple[int, ...],
+    rank: int,
+    *,
+    rng: np.random.Generator = RNG,
+) -> Bezier:
+    """Create a Bezier with random control points in [0, 1]."""
+    shape = (*tuple(d + 1 for d in degree), rank)
+    ctrl: npt.NDArray[np.float64] = rng.random(shape)
+    return Bezier(ctrl)
+
+
+def _identity_bezier(dim: int) -> Bezier:
+    """Create an identity Bezier mapping (degree 1 in each direction).
+
+    The identity maps [0,1]^dim -> [0,1]^dim such that f(x) = x.
+    """
+    if dim == 1:
+        return Bezier(np.array([[0.0], [1.0]]))
+    if dim == 2:  # noqa: PLR2004
+        ctrl = np.zeros((2, 2, 2))
+        for i in range(2):
+            for j in range(2):
+                ctrl[i, j, 0] = float(i)
+                ctrl[i, j, 1] = float(j)
+        return Bezier(ctrl)
+    if dim == 3:  # noqa: PLR2004
+        ctrl = np.zeros((2, 2, 2, 3))
+        for i in range(2):
+            for j in range(2):
+                for k in range(2):
+                    ctrl[i, j, k, 0] = float(i)
+                    ctrl[i, j, k, 1] = float(j)
+                    ctrl[i, j, k, 2] = float(k)
+        return Bezier(ctrl)
+    raise NotImplementedError
+
+
+def _verify_composition(
+    outer: Bezier,
+    inner: Bezier,
+    composed: Bezier,
+    n_pts: int = 50,
+    *,
+    atol: float = 1e-12,
+) -> None:
+    """Verify that composed(t) == outer(inner(t)) at random points."""
+    rng = np.random.default_rng(123)
+    dtype = inner.dtype
+    if inner.dim == 1:
+        pts = rng.random(n_pts).astype(dtype)
+    else:
+        pts = rng.random((n_pts, inner.dim)).astype(dtype)
+
+    inner_vals = inner.evaluate(pts)
+    expected = outer.evaluate(inner_vals)
+    actual = composed.evaluate(pts)
+    assert_allclose(actual, expected, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# 1D -> 1D
+# ---------------------------------------------------------------------------
+
+
+class TestCompose1Dto1D:
+    """Test composition of 1D Beziers with 1D inner."""
+
+    def test_linear_reparametrization(self) -> None:
+        """Test composing a quadratic curve with a linear reparametrization."""
+        f = Bezier(np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 0.0]]))
+        g = Bezier(np.array([[0.2], [0.8]]))
+        h = f.compose(g)
+
+        assert h.dim == 1
+        assert h.degree == (2,)
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(f, g, h)
+
+    def test_quadratic_with_quadratic(self) -> None:
+        """Test composing two quadratic curves."""
+        f = _random_bezier((3,), 2, rng=np.random.default_rng(1))
+        g = _random_bezier((2,), 1, rng=np.random.default_rng(2))
+        h = f.compose(g)
+
+        assert h.degree == (6,)
+        _verify_composition(f, g, h)
+
+    def test_high_degree(self) -> None:
+        """Test composition with higher-degree curves."""
+        f = _random_bezier((5,), 3, rng=np.random.default_rng(3))
+        g = _random_bezier((4,), 1, rng=np.random.default_rng(4))
+        h = f.compose(g)
+
+        assert h.degree == (20,)
+        _verify_composition(f, g, h)
+
+    def test_scalar_rank(self) -> None:
+        """Test composition with rank-1 (scalar) outer."""
+        f = _random_bezier((3,), 1, rng=np.random.default_rng(5))
+        g = _random_bezier((2,), 1, rng=np.random.default_rng(6))
+        h = f.compose(g)
+
+        assert h.rank == 1
+        _verify_composition(f, g, h)
+
+
+# ---------------------------------------------------------------------------
+# nD -> 1D
+# ---------------------------------------------------------------------------
+
+
+class TestComposeNDto1D:
+    """Test composition of nD Beziers with 1D inner (curve on surface/volume)."""
+
+    def test_surface_with_curve(self) -> None:
+        """Test composing a 2D surface with a 1D curve."""
+        surface = _random_bezier((2, 3), 2, rng=np.random.default_rng(10))
+        curve = _random_bezier((2,), 2, rng=np.random.default_rng(11))
+        h = surface.compose(curve)
+
+        assert h.dim == 1
+        assert h.degree == (10,)  # (2+3) * 2
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(surface, curve, h)
+
+    def test_volume_with_curve(self) -> None:
+        """Test composing a 3D volume with a 1D curve."""
+        volume = _random_bezier((2, 2, 2), 2, rng=np.random.default_rng(20))
+        curve = _random_bezier((2,), 3, rng=np.random.default_rng(21))
+        h = volume.compose(curve)
+
+        assert h.dim == 1
+        assert h.degree == (12,)  # (2+2+2) * 2
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(volume, curve, h)
+
+    def test_surface_with_linear_curve(self) -> None:
+        """Test composing a surface with a linear curve (degree 1)."""
+        surface = _random_bezier((3, 2), 3, rng=np.random.default_rng(30))
+        curve = _random_bezier((1,), 2, rng=np.random.default_rng(31))
+        h = surface.compose(curve)
+
+        assert h.degree == (5,)  # (3+2) * 1
+        _verify_composition(surface, curve, h)
+
+
+# ---------------------------------------------------------------------------
+# nD -> 2D
+# ---------------------------------------------------------------------------
+
+
+class TestComposeNDto2D:
+    """Test composition of nD Beziers with 2D inner (surface reparametrization)."""
+
+    def test_surface_with_surface(self) -> None:
+        """Test composing a 2D surface with a 2D surface reparametrization."""
+        surface = _random_bezier((2, 3), 2, rng=np.random.default_rng(40))
+        inner = _random_bezier((2, 2), 2, rng=np.random.default_rng(41))
+        h = surface.compose(inner)
+
+        assert h.dim == 2  # noqa: PLR2004
+        assert h.degree == (10, 10)  # (2+3)*2, (2+3)*2
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(surface, inner, h)
+
+    def test_volume_with_surface(self) -> None:
+        """Test composing a 3D volume with a 2D surface."""
+        volume = _random_bezier((2, 2, 2), 2, rng=np.random.default_rng(50))
+        inner = _random_bezier((2, 2), 3, rng=np.random.default_rng(51))
+        h = volume.compose(inner)
+
+        assert h.dim == 2  # noqa: PLR2004
+        assert h.degree == (12, 12)  # (2+2+2)*2, (2+2+2)*2
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(volume, inner, h)
+
+
+# ---------------------------------------------------------------------------
+# nD -> 3D (including 3D -> 3D)
+# ---------------------------------------------------------------------------
+
+
+class TestComposeNDto3D:
+    """Test composition with 3D inner Beziers."""
+
+    def test_volume_with_volume(self) -> None:
+        """Test composing a 3D volume with a 3D volume reparametrization."""
+        volume = _random_bezier((2, 2, 2), 2, rng=np.random.default_rng(60))
+        inner = _random_bezier((1, 1, 1), 3, rng=np.random.default_rng(61))
+        h = volume.compose(inner)
+
+        assert h.dim == 3  # noqa: PLR2004
+        assert h.degree == (6, 6, 6)  # (2+2+2)*1
+        assert h.rank == 2  # noqa: PLR2004
+        _verify_composition(volume, inner, h)
+
+
+# ---------------------------------------------------------------------------
+# Identity composition
+# ---------------------------------------------------------------------------
+
+
+class TestComposeIdentity:
+    """Test that composing with the identity Bezier returns an equivalent result."""
+
+    def test_identity_1d(self) -> None:
+        """Test composing a 1D curve with the 1D identity."""
+        f = _random_bezier((3,), 2, rng=np.random.default_rng(70))
+        identity = _identity_bezier(1)
+        h = f.compose(identity)
+
+        assert h.degree == (3,)
+        _verify_composition(f, identity, h)
+
+    def test_identity_2d(self) -> None:
+        """Test composing a 2D surface with the 2D identity."""
+        f = _random_bezier((2, 3), 2, rng=np.random.default_rng(71))
+        identity = _identity_bezier(2)
+        h = f.compose(identity)
+
+        assert h.degree == (5, 5)  # (2+3)*1
+        _verify_composition(f, identity, h)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestComposeEdgeCases:
+    """Test edge cases for Bezier composition."""
+
+    def test_degree_zero_outer(self) -> None:
+        """Test composing a degree-0 (constant) outer with a curve."""
+        f = Bezier(np.array([[3.0, 7.0]]))  # constant, degree 0
+        g = _random_bezier((3,), 1, rng=np.random.default_rng(80))
+        h = f.compose(g)
+
+        assert h.degree == (0,)
+        assert_allclose(h.control_points, f.control_points)
+
+    def test_degree_zero_inner(self) -> None:
+        """Test composing with a degree-0 (constant) inner."""
+        f = _random_bezier((3,), 2, rng=np.random.default_rng(81))
+        g = Bezier(np.array([[0.5]]))  # constant, degree 0
+        h = f.compose(g)
+
+        assert h.degree == (0,)
+        # h should be f(0.5) as a constant Bezier
+        expected = f.evaluate(np.array([0.5]))
+        assert_allclose(h.control_points, expected, atol=1e-14)
+
+    def test_degree_zero_outer_2d(self) -> None:
+        """Test composing a degree-(0,0) constant surface with an inner."""
+        f = Bezier(np.array([[[1.0, 2.0]]]))  # degree (0,0), rank 2
+        g = _random_bezier((2,), 2, rng=np.random.default_rng(82))
+        h = f.compose(g)
+
+        assert h.degree == (0,)
+
+    def test_mixed_degrees(self) -> None:
+        """Test outer with different degrees per direction."""
+        surface = _random_bezier((1, 4), 2, rng=np.random.default_rng(83))
+        curve = _random_bezier((3,), 2, rng=np.random.default_rng(84))
+        h = surface.compose(curve)
+
+        assert h.degree == (15,)  # (1+4)*3
+        _verify_composition(surface, curve, h)
+
+    def test_float32(self) -> None:
+        """Test composition with float32 operands."""
+        f_ctrl = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]], dtype=np.float32)
+        g_ctrl = np.array([[0.2], [0.8]], dtype=np.float32)
+        f = Bezier(f_ctrl)
+        g = Bezier(g_ctrl)
+        h = f.compose(g)
+
+        assert h.dtype == np.float32
+        _verify_composition(f, g, h, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestComposeErrors:
+    """Test error handling for Bezier composition."""
+
+    def test_rational_outer(self) -> None:
+        """Test that rational outer raises TypeError."""
+        f = Bezier(np.array([[0.0, 0.0, 1.0], [1.0, 1.0, 1.0]]), is_rational=True)
+        g = Bezier(np.array([[0.0], [1.0]]))
+        with pytest.raises(TypeError, match="outer is rational"):
+            f.compose(g)
+
+    def test_rational_inner(self) -> None:
+        """Test that rational inner raises TypeError."""
+        f = Bezier(np.array([[0.0], [1.0]]))
+        g = Bezier(np.array([[0.0, 1.0], [1.0, 1.0]]), is_rational=True)
+        with pytest.raises(TypeError, match="inner is rational"):
+            f.compose(g)
+
+    def test_rank_dim_mismatch(self) -> None:
+        """Test that rank/dim mismatch raises ValueError."""
+        f = Bezier(np.array([[[0.0], [1.0]], [[2.0], [3.0]]]))  # dim=2
+        g = Bezier(np.array([[0.0], [1.0]]))  # rank=1, but outer.dim=2
+        with pytest.raises(ValueError, match=r"rank.*must equal.*dimension"):
+            f.compose(g)
+
+    def test_dtype_mismatch(self) -> None:
+        """Test that dtype mismatch raises ValueError."""
+        f = Bezier(np.array([[0.0], [1.0]], dtype=np.float64))
+        g = Bezier(np.array([[0.0], [1.0]], dtype=np.float32))
+        with pytest.raises(ValueError, match="dtype"):
+            f.compose(g)

--- a/tests/test_bezier_compose.py
+++ b/tests/test_bezier_compose.py
@@ -285,7 +285,7 @@ class TestComposeEdgeCases:
         _verify_composition(surface, curve, h)
 
     def test_float32(self) -> None:
-        """Test composition with float32 operands."""
+        """Test composition with float32 operands (1D → 1D)."""
         f_ctrl = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]], dtype=np.float32)
         g_ctrl = np.array([[0.2], [0.8]], dtype=np.float32)
         f = Bezier(f_ctrl)
@@ -294,6 +294,31 @@ class TestComposeEdgeCases:
 
         assert h.dtype == np.float32
         _verify_composition(f, g, h, atol=1e-5)
+
+    def test_float32_nd(self) -> None:
+        """Test composition with float32 operands (2D surface → 1D curve)."""
+        surface = _random_bezier((2, 3), 2, rng=np.random.default_rng(85))
+        curve = _random_bezier((2,), 2, rng=np.random.default_rng(86))
+        # Cast to float32
+        surface_f32 = Bezier(surface.control_points.astype(np.float32))
+        curve_f32 = Bezier(curve.control_points.astype(np.float32))
+        h = surface_f32.compose(curve_f32)
+
+        assert h.dtype == np.float32
+        assert h.dim == 1
+        _verify_composition(surface_f32, curve_f32, h, atol=1e-4)
+
+    def test_degree_zero_inner_one_direction(self) -> None:
+        """Test composing a 2D surface with an inner that is constant in one direction."""
+        surface = _random_bezier((2, 3), 2, rng=np.random.default_rng(87))
+        # Inner has degree (2, 0): linear in s, constant in t — maps to a curve
+        inner = Bezier(np.array([[[0.3, 0.5]], [[0.7, 0.5]]], dtype=np.float64))
+        assert inner.degree == (1, 0)
+        h = surface.compose(inner)
+
+        assert h.dim == 2  # noqa: PLR2004
+        assert h.degree == (5, 0)  # (2+3)*1, (2+3)*0
+        _verify_composition(surface, inner, h)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `Bezier.compose(inner)` computing `self(inner(t))` for non-rational Beziers
- Supports all dimension combinations: 1D→1D, nD→1D, nD→2D, nD→nD (including 3D→3D)
- Algorithm: Bernstein basis decomposition via iterative power computation + multi-index weighted summation
- New `_scalar_bernstein_product_1d_core` Numba kernel for fast 1D scalar Bernstein product
- Layer 2 module `_bezier_compose.py` with full input validation

## Test plan
- [x] All 1831 existing tests pass
- [x] 21 new tests covering all dimension combos, identity, edge cases, and errors
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)