### PR TITLE
feat(bezier): add uniform sign detection

### DIFF
--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -1,13 +1,13 @@
-"""Numba-compiled kernels for Bézier evaluation, degree elevation, and degree reduction.
+"""Numba-compiled kernels for Bézier operations.
 
 Provides fused evaluation kernels that compute Bernstein basis values and
-contract them with control points in a single pass, plus degree elevation
-and degree reduction kernels.
+contract them with control points in a single pass, plus degree elevation,
+degree reduction, and uniform sign detection kernels.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
-    For general use, call the Layer 2 helpers in ``_bezier_eval`` and
-    ``_bezier_degree`` instead.
+    For general use, call the Layer 2 helpers in ``_bezier_eval``,
+    ``_bezier_degree``, and ``_bezier_sign`` instead.
 """
 
 from __future__ import annotations
@@ -607,6 +607,48 @@ def _scalar_bernstein_product_1d_core(
     return out
 
 
+@nb_jit(nopython=True, cache=True)
+def _uniform_sign_core(
+    coeffs: npt.NDArray[np.float64],
+) -> np.intp:
+    """Check whether all Bernstein coefficients share the same strict sign.
+
+    Returns ``+1`` if every coefficient is strictly positive, ``-1`` if every
+    coefficient is strictly negative, and ``0`` otherwise (mixed signs or at
+    least one zero coefficient).
+
+    Args:
+        coeffs (npt.NDArray[np.float64]): Flattened Bernstein coefficients of a
+            scalar Bézier, shape ``(n,)``.
+
+    Returns:
+        np.intp: ``+1``, ``-1``, or ``0``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_bezier_sign._uniform_sign` instead.
+    """
+    n = coeffs.shape[0]
+    if n == 0:
+        return np.intp(0)
+
+    has_pos = False
+    has_neg = False
+    for i in range(n):
+        if coeffs[i] > 0.0:
+            has_pos = True
+        elif coeffs[i] < 0.0:
+            has_neg = True
+        else:
+            return np.intp(0)
+        if has_pos and has_neg:
+            return np.intp(0)
+
+    if has_pos:
+        return np.intp(1)
+    return np.intp(-1)
+
+
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
@@ -632,3 +674,6 @@ def _warmup_numba_functions() -> None:
     a_dummy = np.array([0.0, 1.0], dtype=np.float64)
     b_dummy = np.array([1.0, 0.0], dtype=np.float64)
     _scalar_bernstein_product_1d_core(a_dummy, b_dummy)
+
+    sign_dummy = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    _uniform_sign_core(sign_dummy)

--- a/src/pantr/bezier/_bezier_sign.py
+++ b/src/pantr/bezier/_bezier_sign.py
@@ -1,0 +1,54 @@
+"""Uniform sign detection for scalar non-rational Bézier polynomials.
+
+Provides :func:`_uniform_sign`, which determines whether all Bernstein
+coefficients of a scalar Bézier share the same strict sign.  By the convex
+hull property of Bernstein polynomials, a uniform sign on the coefficients
+guarantees the polynomial does not change sign over its domain.
+
+This is the ``uniformSign`` utility from the algoim library
+(R. I. Saye, *J. Comput. Phys.* 448, 110720, 2022).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import numpy.typing as npt
+
+from ._bezier_core import _uniform_sign_core
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _uniform_sign(bezier: Bezier) -> int:
+    """Check whether a scalar non-rational Bézier has uniform sign.
+
+    Returns ``+1`` if every Bernstein coefficient is strictly positive,
+    ``-1`` if every coefficient is strictly negative, and ``0`` otherwise
+    (mixed signs or at least one zero coefficient).
+
+    Args:
+        bezier (~pantr.bezier.Bezier): A scalar (``rank == 1``),
+            non-rational Bézier of any parametric dimension.
+
+    Returns:
+        int: ``+1``, ``-1``, or ``0``.
+
+    Raises:
+        TypeError: If ``bezier`` is rational.
+        ValueError: If ``bezier`` is not scalar (``rank != 1``).
+    """
+    if bezier.is_rational:
+        raise TypeError("uniform_sign is only defined for non-rational Bézier polynomials.")
+    if bezier.rank != 1:
+        raise ValueError(
+            f"uniform_sign requires a scalar Bézier (rank == 1), got rank {bezier.rank}."
+        )
+
+    coeffs: npt.NDArray[np.floating[Any]] = bezier.control_points[..., 0].ravel()
+    # Ensure contiguous for the kernel (int arrays are already cast in Bezier constructor).
+    coeffs = np.ascontiguousarray(coeffs, dtype=bezier.dtype)
+
+    return int(_uniform_sign_core(coeffs))

--- a/src/pantr/bezier/_bezier_sign.py
+++ b/src/pantr/bezier/_bezier_sign.py
@@ -11,6 +11,7 @@ This is the ``uniformSign`` utility from the algoim library
 
 from __future__ import annotations
 
+import enum
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -22,19 +23,38 @@ if TYPE_CHECKING:
     from . import Bezier
 
 
-def _uniform_sign(bezier: Bezier) -> int:
+class UniformSign(enum.IntEnum):
+    """Result of a uniform sign test on Bernstein coefficients.
+
+    Attributes:
+        NEGATIVE: All coefficients are strictly negative.
+        MIXED: Coefficients have mixed signs or at least one is zero.
+        POSITIVE: All coefficients are strictly positive.
+    """
+
+    NEGATIVE = -1
+    """All coefficients are strictly negative."""
+
+    MIXED = 0
+    """Coefficients have mixed signs or at least one is zero."""
+
+    POSITIVE = 1
+    """All coefficients are strictly positive."""
+
+
+def _uniform_sign(bezier: Bezier) -> UniformSign:
     """Check whether a scalar non-rational Bézier has uniform sign.
 
-    Returns ``+1`` if every Bernstein coefficient is strictly positive,
-    ``-1`` if every coefficient is strictly negative, and ``0`` otherwise
-    (mixed signs or at least one zero coefficient).
+    Uses the convex hull property of Bernstein polynomials: if all coefficients
+    share the same strict sign, the polynomial cannot change sign over its
+    domain.
 
     Args:
         bezier (~pantr.bezier.Bezier): A scalar (``rank == 1``),
             non-rational Bézier of any parametric dimension.
 
     Returns:
-        int: ``+1``, ``-1``, or ``0``.
+        UniformSign: The uniform sign of the Bernstein coefficients.
 
     Raises:
         TypeError: If ``bezier`` is rational.
@@ -51,4 +71,4 @@ def _uniform_sign(bezier: Bezier) -> int:
     # Ensure contiguous for the kernel (int arrays are already cast in Bezier constructor).
     coeffs = np.ascontiguousarray(coeffs, dtype=bezier.dtype)
 
-    return int(_uniform_sign_core(coeffs))
+    return UniformSign(int(_uniform_sign_core(coeffs)))

--- a/tests/test_bezier_sign.py
+++ b/tests/test_bezier_sign.py
@@ -1,0 +1,110 @@
+"""Tests for uniform sign detection of scalar non-rational Bézier polynomials."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+from pantr.bezier._bezier_sign import _uniform_sign
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scalar_bezier(
+    ctrl: Sequence[float] | npt.NDArray[np.floating[Any]],
+    dtype: type = np.float64,
+) -> Bezier:
+    """Create a 1D scalar Bézier from a flat list of coefficients."""
+    return Bezier(np.array(ctrl, dtype=dtype))
+
+
+# ---------------------------------------------------------------------------
+# Tests — valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestUniformSign1D:
+    """Uniform sign for 1D (univariate) scalar Béziers."""
+
+    def test_all_positive(self) -> None:
+        assert _uniform_sign(_scalar_bezier([1.0, 2.0, 3.0])) == 1
+
+    def test_all_negative(self) -> None:
+        assert _uniform_sign(_scalar_bezier([-1.0, -2.0, -3.0])) == -1
+
+    def test_mixed_signs(self) -> None:
+        assert _uniform_sign(_scalar_bezier([-1.0, 2.0, -3.0])) == 0
+
+    def test_zero_coefficient(self) -> None:
+        assert _uniform_sign(_scalar_bezier([1.0, 0.0, 3.0])) == 0
+
+    def test_all_zeros(self) -> None:
+        assert _uniform_sign(_scalar_bezier([0.0, 0.0])) == 0
+
+    def test_single_positive(self) -> None:
+        assert _uniform_sign(_scalar_bezier([5.0])) == 1
+
+    def test_single_negative(self) -> None:
+        assert _uniform_sign(_scalar_bezier([-5.0])) == -1
+
+    def test_single_zero(self) -> None:
+        assert _uniform_sign(_scalar_bezier([0.0])) == 0
+
+    def test_high_degree(self) -> None:
+        coeffs = list(range(1, 21))  # degree 19, all positive
+        assert _uniform_sign(_scalar_bezier(coeffs)) == 1
+
+    def test_float32(self) -> None:
+        b = _scalar_bezier([1.0, 2.0, 3.0], dtype=np.float32)
+        assert _uniform_sign(b) == 1
+
+    def test_negative_near_zero(self) -> None:
+        """Tiny negative coefficient breaks uniform positive sign."""
+        assert _uniform_sign(_scalar_bezier([1.0, 1e-15, 1.0])) == 1
+        assert _uniform_sign(_scalar_bezier([1.0, -1e-15, 1.0])) == 0
+
+
+class TestUniformSignND:
+    """Uniform sign for multi-dimensional scalar Béziers."""
+
+    def test_2d_all_positive(self) -> None:
+        ctrl = np.array([[[1.0], [2.0]], [[3.0], [4.0]]])
+        assert _uniform_sign(Bezier(ctrl)) == 1
+
+    def test_2d_all_negative(self) -> None:
+        ctrl = np.array([[[-1.0], [-2.0]], [[-3.0], [-4.0]]])
+        assert _uniform_sign(Bezier(ctrl)) == -1
+
+    def test_2d_mixed(self) -> None:
+        ctrl = np.array([[[1.0], [-2.0]], [[3.0], [4.0]]])
+        assert _uniform_sign(Bezier(ctrl)) == 0
+
+    def test_3d_all_positive(self) -> None:
+        ctrl = np.ones((2, 3, 4, 1), dtype=np.float64)
+        assert _uniform_sign(Bezier(ctrl)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestUniformSignErrors:
+    """Error handling for invalid Bézier inputs."""
+
+    def test_rational_raises(self) -> None:
+        b = Bezier(np.array([[1.0, 1.0], [2.0, 1.0], [3.0, 1.0]]), is_rational=True)
+        with pytest.raises(TypeError, match="non-rational"):
+            _uniform_sign(b)
+
+    def test_vector_raises(self) -> None:
+        b = Bezier(np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))
+        with pytest.raises(ValueError, match="rank == 1"):
+            _uniform_sign(b)

--- a/tests/test_bezier_sign.py
+++ b/tests/test_bezier_sign.py
@@ -10,7 +10,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.bezier._bezier_sign import _uniform_sign
+from pantr.bezier._bezier_sign import UniformSign, _uniform_sign
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,41 +34,47 @@ class TestUniformSign1D:
     """Uniform sign for 1D (univariate) scalar Béziers."""
 
     def test_all_positive(self) -> None:
-        assert _uniform_sign(_scalar_bezier([1.0, 2.0, 3.0])) == 1
+        assert _uniform_sign(_scalar_bezier([1.0, 2.0, 3.0])) is UniformSign.POSITIVE
 
     def test_all_negative(self) -> None:
-        assert _uniform_sign(_scalar_bezier([-1.0, -2.0, -3.0])) == -1
+        assert _uniform_sign(_scalar_bezier([-1.0, -2.0, -3.0])) is UniformSign.NEGATIVE
 
     def test_mixed_signs(self) -> None:
-        assert _uniform_sign(_scalar_bezier([-1.0, 2.0, -3.0])) == 0
+        assert _uniform_sign(_scalar_bezier([-1.0, 2.0, -3.0])) is UniformSign.MIXED
 
     def test_zero_coefficient(self) -> None:
-        assert _uniform_sign(_scalar_bezier([1.0, 0.0, 3.0])) == 0
+        assert _uniform_sign(_scalar_bezier([1.0, 0.0, 3.0])) is UniformSign.MIXED
 
     def test_all_zeros(self) -> None:
-        assert _uniform_sign(_scalar_bezier([0.0, 0.0])) == 0
+        assert _uniform_sign(_scalar_bezier([0.0, 0.0])) is UniformSign.MIXED
 
     def test_single_positive(self) -> None:
-        assert _uniform_sign(_scalar_bezier([5.0])) == 1
+        assert _uniform_sign(_scalar_bezier([5.0])) is UniformSign.POSITIVE
 
     def test_single_negative(self) -> None:
-        assert _uniform_sign(_scalar_bezier([-5.0])) == -1
+        assert _uniform_sign(_scalar_bezier([-5.0])) is UniformSign.NEGATIVE
 
     def test_single_zero(self) -> None:
-        assert _uniform_sign(_scalar_bezier([0.0])) == 0
+        assert _uniform_sign(_scalar_bezier([0.0])) is UniformSign.MIXED
 
     def test_high_degree(self) -> None:
         coeffs = list(range(1, 21))  # degree 19, all positive
-        assert _uniform_sign(_scalar_bezier(coeffs)) == 1
+        assert _uniform_sign(_scalar_bezier(coeffs)) is UniformSign.POSITIVE
 
     def test_float32(self) -> None:
         b = _scalar_bezier([1.0, 2.0, 3.0], dtype=np.float32)
-        assert _uniform_sign(b) == 1
+        assert _uniform_sign(b) is UniformSign.POSITIVE
 
     def test_negative_near_zero(self) -> None:
         """Tiny negative coefficient breaks uniform positive sign."""
-        assert _uniform_sign(_scalar_bezier([1.0, 1e-15, 1.0])) == 1
-        assert _uniform_sign(_scalar_bezier([1.0, -1e-15, 1.0])) == 0
+        assert _uniform_sign(_scalar_bezier([1.0, 1e-15, 1.0])) is UniformSign.POSITIVE
+        assert _uniform_sign(_scalar_bezier([1.0, -1e-15, 1.0])) is UniformSign.MIXED
+
+    def test_int_enum_comparison(self) -> None:
+        """UniformSign values compare equal to their integer counterparts."""
+        assert _uniform_sign(_scalar_bezier([1.0, 2.0])) == 1
+        assert _uniform_sign(_scalar_bezier([-1.0, -2.0])) == -1
+        assert _uniform_sign(_scalar_bezier([-1.0, 2.0])) == 0
 
 
 class TestUniformSignND:
@@ -76,19 +82,19 @@ class TestUniformSignND:
 
     def test_2d_all_positive(self) -> None:
         ctrl = np.array([[[1.0], [2.0]], [[3.0], [4.0]]])
-        assert _uniform_sign(Bezier(ctrl)) == 1
+        assert _uniform_sign(Bezier(ctrl)) is UniformSign.POSITIVE
 
     def test_2d_all_negative(self) -> None:
         ctrl = np.array([[[-1.0], [-2.0]], [[-3.0], [-4.0]]])
-        assert _uniform_sign(Bezier(ctrl)) == -1
+        assert _uniform_sign(Bezier(ctrl)) is UniformSign.NEGATIVE
 
     def test_2d_mixed(self) -> None:
         ctrl = np.array([[[1.0], [-2.0]], [[3.0], [4.0]]])
-        assert _uniform_sign(Bezier(ctrl)) == 0
+        assert _uniform_sign(Bezier(ctrl)) is UniformSign.MIXED
 
     def test_3d_all_positive(self) -> None:
         ctrl = np.ones((2, 3, 4, 1), dtype=np.float64)
-        assert _uniform_sign(Bezier(ctrl)) == 1
+        assert _uniform_sign(Bezier(ctrl)) is UniformSign.POSITIVE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_uniform_sign` (Layer 2) and `_uniform_sign_core` (Layer 3 Numba kernel) for checking whether all Bernstein coefficients of a scalar non-rational Bézier share the same strict sign
- Returns `+1` (all positive), `-1` (all negative), or `0` (mixed/zero) — leverages the convex hull property
- First building block for algoim-style implicit quadrature (Saye, JCP 2022)

## Test plan
- [x] 1D scalar Bézier: all positive, all negative, mixed, zero coefficients, single coefficient
- [x] Multi-dimensional scalar Bézier (2D, 3D)
- [x] float32 support
- [x] Error handling: rational and non-scalar Bézier rejected
- [x] Pre-PR checks: ruff, mypy, pytest (1877 passed), docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)