### PR TITLE
chore: allow conda activate in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,8 @@
       "Bash(python3 *)",
       "Bash(cd *)",
       "Bash(sphinx-build *)",
-      "Bash(make *)"
+      "Bash(make *)",
+      "Bash(conda activate *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `Bash(conda activate *)` to the allowed permissions in `.claude/settings.json`

## Test plan
- [x] Verify `settings.json` is valid JSON (pre-commit hook passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)