### PR TITLE
feat(quad): add modified Chebyshev nodes for Bernstein interpolation

### DIFF
--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -189,6 +189,41 @@ def get_chebyshev_gauss_1st_kind_1d(
     return _scale_and_cast_nodes_and_weights(nodes, weights, dtype)
 
 
+def get_modified_chebyshev_nodes_1d(
+    n_pts: int, dtype: npt.DTypeLike = np.float64
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Get modified Chebyshev nodes on [0, 1] for the given number of points.
+
+    Returns Chebyshev nodes of the second kind (Chebyshev-Lobatto points)
+    mapped to [0, 1].  These include both endpoints and are suitable for
+    polynomial interpolation into the Bernstein basis.
+
+    Unlike the quadrature functions in this module, this returns only nodes
+    (no weights) since it is intended for interpolation, not integration.
+
+    Args:
+        n_pts (int): Number of nodes.  Must be at least 2.
+        dtype (npt.DTypeLike): Floating dtype; float32 or float64.
+            Defaults to float64.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Array of shape ``(n_pts,)`` with
+        nodes in [0, 1], starting at 0 and ending at 1.
+
+    Raises:
+        ValueError: If *n_pts* < 2 or *dtype* is not float32 or float64.
+    """
+    _validate_n_pts_and_dtype(n_pts, dtype)
+
+    if n_pts < 2:  # noqa: PLR2004
+        raise ValueError("n_pts must be at least 2")
+
+    dtype_obj = np.dtype(dtype)
+    i = np.arange(n_pts, dtype=dtype_obj)
+    nodes: npt.NDArray[np.float32 | np.float64] = 0.5 - 0.5 * np.cos(np.pi * i / (n_pts - 1))
+    return nodes
+
+
 def get_chebyshev_gauss_2nd_kind_1d(
     n_pts: int, dtype: npt.DTypeLike = np.float64
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
@@ -360,5 +395,6 @@ __all__ = [
     "get_chebyshev_gauss_2nd_kind_1d",
     "get_gauss_legendre_1d",
     "get_gauss_lobatto_legendre_1d",
+    "get_modified_chebyshev_nodes_1d",
     "get_trapezoidal_1d",
 ]

--- a/tests/test_quad.py
+++ b/tests/test_quad.py
@@ -19,6 +19,7 @@ from pantr.quad import (
     get_chebyshev_gauss_2nd_kind_1d,
     get_gauss_legendre_1d,
     get_gauss_lobatto_legendre_1d,
+    get_modified_chebyshev_nodes_1d,
     get_trapezoidal_1d,
 )
 from pantr.tolerance import get_conservative, get_default, get_strict
@@ -399,3 +400,52 @@ class TestCreateLagrangePointsLattice:
         assert all_pts.shape == (6, 2)
         # Verify all points are in [0, 1]
         assert np.all((all_pts >= 0.0) & (all_pts <= 1.0))
+
+
+class TestModifiedChebyshevNodes:
+    """Tests for get_modified_chebyshev_nodes_1d."""
+
+    def test_invalid_n_pts_raises(self) -> None:
+        """n_pts < 2 must raise."""
+        with pytest.raises(ValueError, match="at least 2"):
+            get_modified_chebyshev_nodes_1d(1)
+
+    def test_invalid_dtype_raises(self) -> None:
+        """Non-floating dtype must raise."""
+        with pytest.raises(ValueError, match="float32 or float64"):
+            get_modified_chebyshev_nodes_1d(3, np.int32)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_endpoints(self, dtype: npt.DTypeLike) -> None:
+        """First node is 0, last node is 1."""
+        nodes = get_modified_chebyshev_nodes_1d(5, dtype)
+        nptest.assert_allclose(nodes[0], 0.0, atol=1e-15)
+        nptest.assert_allclose(nodes[-1], 1.0, atol=1e-15)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_shape_and_dtype(self, dtype: npt.DTypeLike) -> None:
+        """Output shape and dtype are correct."""
+        n = 7
+        nodes = get_modified_chebyshev_nodes_1d(n, dtype)
+        assert nodes.shape == (n,)
+        assert nodes.dtype == np.dtype(dtype)
+
+    def test_two_points(self) -> None:
+        """n_pts=2 gives [0, 1]."""
+        nodes = get_modified_chebyshev_nodes_1d(2)
+        nptest.assert_allclose(nodes, [0.0, 1.0], atol=1e-15)
+
+    def test_three_points(self) -> None:
+        """n_pts=3 gives [0, 0.5, 1]."""
+        nodes = get_modified_chebyshev_nodes_1d(3)
+        nptest.assert_allclose(nodes, [0.0, 0.5, 1.0], atol=1e-15)
+
+    def test_symmetry(self) -> None:
+        """Nodes are symmetric about 0.5: nodes[i] + nodes[n-1-i] == 1."""
+        nodes = get_modified_chebyshev_nodes_1d(8)
+        nptest.assert_allclose(nodes + nodes[::-1], 1.0, atol=1e-15)
+
+    def test_monotonicity(self) -> None:
+        """Nodes are strictly increasing."""
+        nodes = get_modified_chebyshev_nodes_1d(10)
+        assert np.all(np.diff(nodes) > 0)


### PR DESCRIPTION
## Summary
- Add `get_modified_chebyshev_nodes_1d(n_pts, dtype)` to `quad.py` — returns Chebyshev-Lobatto points (Chebyshev nodes of the second kind) mapped to [0, 1]
- These are the interpolation nodes used by `bernsteinInterpolate` in the algoim implicit quadrature pipeline
- Follows the existing `quad.py` conventions (validation via `_validate_n_pts_and_dtype`, float32/float64 support)

## Test plan
- [x] 10 new tests: endpoints, symmetry, monotonicity, known values (n=2, n=3), shape/dtype, validation
- [x] All existing tests pass
- [x] Pre-PR checks pass (ruff lint, ruff format, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)