### PR TITLE
feat(bezier): add determinant and rank via QR with Givens rotations

### DIFF
--- a/src/pantr/bezier/_resultant_matrices.py
+++ b/src/pantr/bezier/_resultant_matrices.py
@@ -250,9 +250,10 @@ def _det_qr(
     Args:
         A (npt.NDArray[np.floating[Any]]): Square matrix of shape ``(n, n)``
             with ``n >= 1``.  **Overwritten** on return.
-        tol (float): Tolerance multiplier for rank estimation.  A diagonal
-            entry of *R* is considered nonzero when
-            ``|R_{ii}| > tol * max|R_{jj}| * n * eps``.  Defaults to 10.0.
+        tol (float): Tolerance multiplier for rank estimation (must be > 0).
+            A diagonal entry of *R* is considered nonzero when
+            ``|R_{ii}| > tol * max|R_{jj}| * n * eps``.  Defaults to 10.0,
+            matching the algoim reference implementation.
 
     Returns:
         tuple[float, int]: ``(det, rank)`` where ``det`` is the determinant
@@ -260,7 +261,7 @@ def _det_qr(
 
     Raises:
         ValueError: If ``A`` is not a 2-D square array with floating dtype
-            and ``n >= 1``, or if it is not writeable.
+            and ``n >= 1``, or if it is not writeable, or if ``tol <= 0``.
     """
     # --- validation ---
     if not isinstance(A, np.ndarray):
@@ -274,6 +275,8 @@ def _det_qr(
         raise ValueError("`A` must have size >= 1.")
     if not A.flags.writeable:
         raise ValueError("`A` must be writeable (it is modified in place).")
+    if tol <= 0.0:
+        raise ValueError(f"`tol` must be positive, got {tol}.")
 
     # --- QR with column pivoting via Givens rotations ---
     det = 1.0
@@ -281,11 +284,16 @@ def _det_qr(
 
     for j in range(n):
         # Column pivoting: find column with largest squared norm among j..n-1.
+        # Note: the norm is computed over the *full* column (all n rows), not
+        # just the trailing sub-column (rows j..n-1) as in standard LAPACK
+        # column-pivoting QR.  This matches algoim's det_qr implementation and
+        # is intentional — for the small matrices used in implicit quadrature,
+        # the difference in pivoting quality is negligible.
         best_norm: float = -1.0
         best_k = j
         for k in range(j, n):
             col_norm = float(np.dot(A[:, k], A[:, k]))
-            if col_norm >= best_norm:
+            if col_norm > best_norm:
                 best_norm = col_norm
                 best_k = k
 

--- a/src/pantr/bezier/_resultant_matrices.py
+++ b/src/pantr/bezier/_resultant_matrices.py
@@ -265,7 +265,7 @@ def _det_qr(
     # --- validation ---
     if not isinstance(A, np.ndarray):
         raise ValueError(f"`A` must be a numpy array, got {type(A).__name__}.")
-    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:  # noqa: PLR2004
         raise ValueError(f"`A` must be a 2-D square array, got shape {A.shape}.")
     if not np.issubdtype(A.dtype, np.floating):
         raise ValueError(f"`A` must have floating dtype, got {A.dtype}.")

--- a/src/pantr/bezier/_resultant_matrices.py
+++ b/src/pantr/bezier/_resultant_matrices.py
@@ -11,6 +11,10 @@ in the algoim-style implicit quadrature pipeline (R. I. Saye, *J. Comput. Phys.*
 - The **Bezout matrix** applies to polynomials of *equal* degree ``n`` and has
   size ``n x n``.  It is symmetric and generally better conditioned than the
   Sylvester matrix for same-degree pairs.
+
+Additionally, :func:`_det_qr` computes the determinant and approximate rank of
+a square matrix via QR factorisation with column pivoting using Givens rotations,
+following the implementation in algoim.
 """
 
 from __future__ import annotations
@@ -197,6 +201,118 @@ def _bezout_matrix(
     out[il[1], il[0]] = out[il[0], il[1]]
 
     return out
+
+
+# ---------------------------------------------------------------------------
+# QR-based determinant and rank
+# ---------------------------------------------------------------------------
+
+
+def _givens_rotation(a: float, b: float) -> tuple[float, float]:
+    """Compute the Givens rotation that zeroes the second component.
+
+    Finds ``(c, s)`` such that applying the rotation matrix
+    ``[[c, s], [-s, c]]`` to the vector ``(a, b)`` yields ``(r, 0)``.
+
+    Args:
+        a (float): First component.
+        b (float): Second component (to be zeroed).
+
+    Returns:
+        tuple[float, float]: The cosine ``c`` and sine ``s`` of the rotation.
+    """
+    if b == 0.0:
+        return 1.0, 0.0
+    if abs(b) > abs(a):
+        tmp = a / b
+        s = 1.0 / math.sqrt(1.0 + tmp * tmp)
+        c = tmp * s
+    else:
+        tmp = b / a
+        c = 1.0 / math.sqrt(1.0 + tmp * tmp)
+        s = tmp * c
+    return c, s
+
+
+def _det_qr(
+    A: npt.NDArray[np.floating[Any]],
+    tol: float = 10.0,
+) -> tuple[float, int]:
+    """Compute the determinant and approximate rank of a square matrix.
+
+    Uses QR factorisation with column pivoting via Givens rotations.  The
+    matrix ``A`` is overwritten with the upper-triangular factor *R* during
+    the computation.
+
+    The algorithm follows the ``det_qr`` routine from the algoim library
+    (R. I. Saye, *J. Comput. Phys.* 448, 110720, 2022).
+
+    Args:
+        A (npt.NDArray[np.floating[Any]]): Square matrix of shape ``(n, n)``
+            with ``n >= 1``.  **Overwritten** on return.
+        tol (float): Tolerance multiplier for rank estimation.  A diagonal
+            entry of *R* is considered nonzero when
+            ``|R_{ii}| > tol * max|R_{jj}| * n * eps``.  Defaults to 10.0.
+
+    Returns:
+        tuple[float, int]: ``(det, rank)`` where ``det`` is the determinant
+            and ``rank`` is the estimated rank.
+
+    Raises:
+        ValueError: If ``A`` is not a 2-D square array with floating dtype
+            and ``n >= 1``, or if it is not writeable.
+    """
+    # --- validation ---
+    if not isinstance(A, np.ndarray):
+        raise ValueError(f"`A` must be a numpy array, got {type(A).__name__}.")
+    if A.ndim != 2 or A.shape[0] != A.shape[1]:
+        raise ValueError(f"`A` must be a 2-D square array, got shape {A.shape}.")
+    if not np.issubdtype(A.dtype, np.floating):
+        raise ValueError(f"`A` must have floating dtype, got {A.dtype}.")
+    n = A.shape[0]
+    if n < 1:
+        raise ValueError("`A` must have size >= 1.")
+    if not A.flags.writeable:
+        raise ValueError("`A` must be writeable (it is modified in place).")
+
+    # --- QR with column pivoting via Givens rotations ---
+    det = 1.0
+    max_diag_r = 0.0
+
+    for j in range(n):
+        # Column pivoting: find column with largest squared norm among j..n-1.
+        best_norm: float = -1.0
+        best_k = j
+        for k in range(j, n):
+            col_norm = float(np.dot(A[:, k], A[:, k]))
+            if col_norm >= best_norm:
+                best_norm = col_norm
+                best_k = k
+
+        # Swap columns j and best_k.
+        if best_k != j:
+            A[:, [j, best_k]] = A[:, [best_k, j]]
+            det *= -1.0
+
+        # Apply Givens rotations from bottom to top to zero out entries below
+        # the diagonal in column j.
+        for i in range(n - 1, j, -1):
+            c, s = _givens_rotation(A[i - 1, j], A[i, j])
+            # Rotate rows i-1 and i for columns j..n-1.
+            for col in range(j, n):
+                x, y = A[i - 1, col], A[i, col]
+                A[i - 1, col] = c * x + s * y
+                A[i, col] = -s * x + c * y
+
+        det *= float(A[j, j])
+        max_diag_r = max(max_diag_r, abs(float(A[j, j])))
+
+    # --- rank estimation ---
+    eps = float(np.finfo(A.dtype).eps)
+    threshold = tol * max_diag_r * n * eps
+    rank = int(np.sum(np.abs(np.diag(A)) > threshold))
+
+    return det, rank
 
 
 # ---------------------------------------------------------------------------

--- a/src/pantr/bezier/_resultant_matrices.py
+++ b/src/pantr/bezier/_resultant_matrices.py
@@ -289,13 +289,8 @@ def _det_qr(
         # column-pivoting QR.  This matches algoim's det_qr implementation and
         # is intentional — for the small matrices used in implicit quadrature,
         # the difference in pivoting quality is negligible.
-        best_norm: float = -1.0
-        best_k = j
-        for k in range(j, n):
-            col_norm = float(np.dot(A[:, k], A[:, k]))
-            if col_norm > best_norm:
-                best_norm = col_norm
-                best_k = k
+        col_norms = np.einsum("ij,ij->j", A[:, j:], A[:, j:])
+        best_k = j + int(np.argmax(col_norms))
 
         # Swap columns j and best_k.
         if best_k != j:
@@ -303,14 +298,19 @@ def _det_qr(
             det *= -1.0
 
         # Apply Givens rotations from bottom to top to zero out entries below
-        # the diagonal in column j.
+        # the diagonal in column j.  The loop over i is inherently sequential
+        # (each rotation modifies A[i-1, j] which is read by the next one),
+        # but the row update itself is vectorised across all columns >= j.
         for i in range(n - 1, j, -1):
-            c, s = _givens_rotation(A[i - 1, j], A[i, j])
-            # Rotate rows i-1 and i for columns j..n-1.
-            for col in range(j, n):
-                x, y = A[i - 1, col], A[i, col]
-                A[i - 1, col] = c * x + s * y
-                A[i, col] = -s * x + c * y
+            b_val = float(A[i, j])
+            if b_val == 0.0:
+                continue
+            c, s = _givens_rotation(float(A[i - 1, j]), b_val)
+            # Save row i-1 before overwriting it; row i is updated second so
+            # its old values are still available from the original A[i, j:].
+            x = A[i - 1, j:].copy()
+            A[i - 1, j:] = c * x + s * A[i, j:]
+            A[i, j:] = -s * x + c * A[i, j:]
 
         det *= float(A[j, j])
         max_diag_r = max(max_diag_r, abs(float(A[j, j])))

--- a/tests/test_bezier_resultant_matrices.py
+++ b/tests/test_bezier_resultant_matrices.py
@@ -304,3 +304,26 @@ class TestDetQr:
         A.flags.writeable = False
         with pytest.raises(ValueError, match="writeable"):
             _det_qr(A)
+
+    def test_non_array_raises(self) -> None:
+        """Non-ndarray input raises ValueError."""
+        with pytest.raises(ValueError, match="numpy array"):
+            _det_qr([[1.0, 0.0], [0.0, 1.0]])  # type: ignore[arg-type]
+
+    def test_non_2d_raises(self) -> None:
+        """1-D array raises ValueError."""
+        with pytest.raises(ValueError, match="square"):
+            _det_qr(np.array([1.0, 2.0, 3.0]))
+
+    def test_empty_matrix_raises(self) -> None:
+        """0x0 matrix raises ValueError."""
+        with pytest.raises(ValueError, match="size >= 1"):
+            _det_qr(np.empty((0, 0)))
+
+    def test_non_positive_tol_raises(self) -> None:
+        """Non-positive tol raises ValueError."""
+        A = np.eye(2)
+        with pytest.raises(ValueError, match="tol"):
+            _det_qr(A, tol=0.0)
+        with pytest.raises(ValueError, match="tol"):
+            _det_qr(A.copy(), tol=-1.0)

--- a/tests/test_bezier_resultant_matrices.py
+++ b/tests/test_bezier_resultant_matrices.py
@@ -242,7 +242,7 @@ class TestDetQr:
         A = np.array([[1.0, 2.0], [2.0, 4.0]])
         det, rank = _det_qr(A)
         np.testing.assert_allclose(det, 0.0, atol=1e-12)
-        assert rank < 2
+        assert rank < 2  # noqa: PLR2004
 
     def test_rank_deficient_matrix(self) -> None:
         """Matrix with known rank deficiency."""
@@ -253,7 +253,7 @@ class TestDetQr:
         A = U @ V
         det, rank = _det_qr(A.copy())
         np.testing.assert_allclose(det, 0.0, atol=1e-10)
-        assert rank == 2
+        assert rank == 2  # noqa: PLR2004
 
     def test_diagonal_matrix(self) -> None:
         """Determinant of a diagonal matrix is the product of diagonal entries."""
@@ -261,7 +261,7 @@ class TestDetQr:
         A = np.diag(diag)
         det, rank = _det_qr(A)
         np.testing.assert_allclose(det, np.prod(diag), rtol=1e-12)
-        assert rank == 4
+        assert rank == 4  # noqa: PLR2004
 
     def test_overwrites_input(self) -> None:
         """The input matrix is modified in place."""

--- a/tests/test_bezier_resultant_matrices.py
+++ b/tests/test_bezier_resultant_matrices.py
@@ -1,9 +1,14 @@
-"""Tests for Sylvester and Bezout matrix construction."""
+"""Tests for Sylvester and Bezout matrix construction, and QR determinant."""
 
 import numpy as np
 import pytest
 
-from pantr.bezier._resultant_matrices import _bezout_matrix, _sylvester_matrix
+from pantr.bezier._resultant_matrices import (
+    _bezout_matrix,
+    _det_qr,
+    _givens_rotation,
+    _sylvester_matrix,
+)
 
 _DET_ATOL = 1e-12
 """Absolute tolerance for determinant-is-zero checks."""
@@ -177,3 +182,125 @@ class TestBezoutMatrix:
         b = np.array([0.4, -0.25, 0.1])
         mat = _bezout_matrix(a, b)
         np.testing.assert_allclose(np.linalg.det(mat), 0.0, atol=_DET_ATOL)
+
+
+class TestGivensRotation:
+    """Test _givens_rotation helper."""
+
+    def test_zeroes_second_component(self) -> None:
+        """Applying the rotation to (a, b) gives (r, 0)."""
+        a, b = 3.0, 4.0
+        c, s = _givens_rotation(a, b)
+        r = c * a + s * b
+        zero = -s * a + c * b
+        np.testing.assert_allclose(zero, 0.0, atol=1e-15)
+        np.testing.assert_allclose(r, 5.0, atol=1e-15)
+
+    def test_identity_when_b_is_zero(self) -> None:
+        """When b == 0, the rotation is the identity."""
+        c, s = _givens_rotation(7.0, 0.0)
+        assert c == 1.0
+        assert s == 0.0
+
+    def test_abs_b_greater_than_abs_a(self) -> None:
+        """Branch where |b| > |a|."""
+        c, s = _givens_rotation(1.0, 10.0)
+        zero = -s * 1.0 + c * 10.0
+        np.testing.assert_allclose(zero, 0.0, atol=1e-15)
+        assert c * c + s * s == pytest.approx(1.0)
+
+    def test_negative_values(self) -> None:
+        """Works correctly with negative inputs."""
+        c, s = _givens_rotation(-3.0, 4.0)
+        zero = -s * (-3.0) + c * 4.0
+        np.testing.assert_allclose(zero, 0.0, atol=1e-15)
+
+
+class TestDetQr:
+    """Test _det_qr determinant and rank computation."""
+
+    def test_identity_matrix(self) -> None:
+        """Determinant of identity is 1, rank is n."""
+        n = 5
+        A = np.eye(n)
+        det, rank = _det_qr(A)
+        np.testing.assert_allclose(det, 1.0, atol=1e-12)
+        assert rank == n
+
+    def test_known_determinant(self) -> None:
+        """Compare with np.linalg.det on a random matrix."""
+        rng = np.random.default_rng(123)
+        for n in [2, 3, 5, 8]:
+            A = rng.standard_normal((n, n))
+            expected = np.linalg.det(A)
+            det, rank = _det_qr(A.copy())
+            np.testing.assert_allclose(det, expected, rtol=1e-10)
+            assert rank == n
+
+    def test_singular_matrix_zero_det(self) -> None:
+        """Singular matrix has det ~ 0 and rank < n."""
+        A = np.array([[1.0, 2.0], [2.0, 4.0]])
+        det, rank = _det_qr(A)
+        np.testing.assert_allclose(det, 0.0, atol=1e-12)
+        assert rank < 2
+
+    def test_rank_deficient_matrix(self) -> None:
+        """Matrix with known rank deficiency."""
+        # Rank-2 matrix of size 4x4.
+        rng = np.random.default_rng(42)
+        U = rng.standard_normal((4, 2))
+        V = rng.standard_normal((2, 4))
+        A = U @ V
+        det, rank = _det_qr(A.copy())
+        np.testing.assert_allclose(det, 0.0, atol=1e-10)
+        assert rank == 2
+
+    def test_diagonal_matrix(self) -> None:
+        """Determinant of a diagonal matrix is the product of diagonal entries."""
+        diag = np.array([2.0, -3.0, 0.5, 4.0])
+        A = np.diag(diag)
+        det, rank = _det_qr(A)
+        np.testing.assert_allclose(det, np.prod(diag), rtol=1e-12)
+        assert rank == 4
+
+    def test_overwrites_input(self) -> None:
+        """The input matrix is modified in place."""
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        original = A.copy()
+        _det_qr(A)
+        assert not np.array_equal(A, original)
+
+    def test_1x1_matrix(self) -> None:
+        """1x1 matrix determinant is the single entry."""
+        A = np.array([[42.0]])
+        det, rank = _det_qr(A)
+        np.testing.assert_allclose(det, 42.0, atol=1e-15)
+        assert rank == 1
+
+    def test_resultant_matrix_det(self) -> None:
+        """det_qr agrees with np.linalg.det on a Sylvester matrix."""
+        a = np.array([1.0, -1.0, 0.5])
+        b = np.array([0.0, 1.0])
+        mat = _sylvester_matrix(a, b)
+        expected = np.linalg.det(mat)
+        det, rank = _det_qr(mat.copy())
+        np.testing.assert_allclose(det, expected, rtol=1e-10)
+
+    def test_non_square_raises(self) -> None:
+        """Non-square input raises ValueError."""
+        A = np.ones((2, 3))
+        with pytest.raises(ValueError, match="square"):
+            _det_qr(A)
+
+    def test_integer_dtype_raises(self) -> None:
+        """Integer dtype raises ValueError."""
+        A = np.array([[1, 2], [3, 4]])
+        with pytest.raises(ValueError, match="floating"):
+            _det_qr(A)
+
+    def test_non_writeable_raises(self) -> None:
+        """Non-writeable array raises ValueError."""
+        A = np.eye(3)
+        A.flags.writeable = False
+        with pytest.raises(ValueError, match="writeable"):
+            _det_qr(A)


### PR DESCRIPTION
## Summary
- Add `_det_qr` function that computes the determinant and approximate rank of a square matrix via QR factorisation with column pivoting using Givens rotations
- Add `_givens_rotation` helper for computing Givens rotation parameters
- Both functions are ported from algoim's `det_qr` in `quadrature_multipoly.hpp`

## Test plan
- [x] All existing tests pass (2013 passed)
- [x] New tests for `_givens_rotation` (4 tests) and `_det_qr` (11 tests) covering identity, random, singular, rank-deficient, diagonal, 1x1 matrices, and error cases
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)