### PR TITLE
feat(quad): add tanh-sinh quadrature rule

### DIFF
--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -254,6 +254,150 @@ def get_chebyshev_gauss_2nd_kind_1d(
     return _scale_and_cast_nodes_and_weights(nodes, weights, dtype)
 
 
+def _lambert_w(z: float) -> float:
+    """Compute the principal branch of the Lambert W function.
+
+    Solves ``w * exp(w) = z`` for ``w >= 0`` using Newton's method.
+
+    Args:
+        z (float): Input value. Must be non-negative.
+
+    Returns:
+        float: The Lambert W function value ``W(z)``.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    import math  # noqa: PLC0415
+
+    w = z - 0.45 * z * z if z < 1.0 else 0.75 * math.log(z)
+    for _ in range(10):
+        ew = math.exp(w)
+        w -= (w * ew - z) / (ew + w * ew)
+    return w
+
+
+def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
+    """Generate tanh-sinh quadrature nodes and weights on [-1, 1].
+
+    Computes an *n*-point tanh-sinh scheme.  Nodes near the endpoints that
+    are indistinguishable from -1 or 1 in floating-point arithmetic are
+    snapped to the boundary and their weights accumulated, so the effective
+    number of nodes *m* may be less than *n*.
+
+    Args:
+        n (int): Requested number of quadrature points (must be >= 1).
+
+    Returns:
+        tuple[npt.NDArray[np.float64], int]: A pair ``(data, m)`` where
+        *data* has shape ``(m, 2)`` with columns ``[node, weight]`` on
+        ``[-1, 1]``, and *m* is the effective node count.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    if n == 1:
+        return np.array([[0.0, 2.0]]), 1
+
+    h_a = 0.6 * 0.5 * np.pi
+    h = 2.0 * _lambert_w(2.0 * h_a * (n - 1)) / n
+
+    # Pre-allocate for worst case: n pairs
+    buf = np.empty((n, 2), dtype=np.float64)
+    count = 0
+
+    # Central node for odd n
+    if n % 2:
+        buf[count] = [0.0, np.pi * 0.5]
+        count += 1
+
+    snapped_endpoint = False
+
+    for i in range(n // 2):
+        t = float(i + 1) * h if n % 2 else (float(i) + 0.5) * h
+        exp_t = np.exp(t)
+        exp_mt = 1.0 / exp_t
+        omega = 0.25 * np.pi * (exp_t - exp_mt)  # pi/2 * sinh(t)
+        exp_omega = np.exp(omega)
+        cosh_omega_2 = exp_omega + 1.0 / exp_omega  # 2 * cosh(omega)
+        cosh_t_2 = exp_t + exp_mt  # 2 * cosh(t)
+
+        w = np.pi * cosh_t_2 / (cosh_omega_2 * cosh_omega_2)
+        xc = 2.0 / (1.0 + exp_omega * exp_omega)  # 1 - x(t)
+
+        # Snap test: if 1 - xc rounds to 1 then xc is effectively 0
+        test = np.float64(1.0) - np.float64(xc)
+        if abs(float(test) - 1.0) <= 0.0:
+            if snapped_endpoint:
+                # Accumulate weights to existing -1 and +1 nodes
+                buf[count - 2, 1] += w
+                buf[count - 1, 1] += w
+            else:
+                buf[count] = [-1.0, w]
+                count += 1
+                buf[count] = [1.0, w]
+                count += 1
+                snapped_endpoint = True
+        else:
+            buf[count] = [-1.0 + xc, w]
+            count += 1
+            buf[count] = [1.0 - xc, w]
+            count += 1
+
+    data = buf[:count].copy()
+
+    # Normalize weights to sum to 2 (measure of [-1, 1])
+    weight_sum = np.sum(data[:, 1])
+    data[:, 1] *= 2.0 / weight_sum
+
+    return data, count
+
+
+def get_tanh_sinh_1d(
+    n_pts: int, dtype: npt.DTypeLike = np.float64
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Get tanh-sinh quadrature nodes on [0, 1] for the given number of points.
+
+    Tanh-sinh (double-exponential) quadrature clusters nodes near the
+    endpoints of the interval, making it well suited for integrands with
+    endpoint singularities or steep boundary layers.  The scheme is
+    symmetric and nodes near the endpoints that are indistinguishable from
+    0 or 1 in floating-point arithmetic are snapped to the boundary, so
+    the effective number of returned nodes may be less than *n_pts*.
+
+    Args:
+        n_pts (int): Requested number of quadrature points.  Must be at
+            least 1.
+        dtype (npt.DTypeLike): Floating-point dtype for the output arrays.
+            Must be ``float32`` or ``float64``.  Defaults to ``float64``.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+            ``(nodes, weights)`` on ``[0, 1]``.  Both arrays have the same
+            length, which may be less than *n_pts* due to endpoint
+            snapping.  Weights sum to 1.
+
+    Raises:
+        ValueError: If *n_pts* < 1 or *dtype* is not ``float32``/``float64``.
+
+    Example:
+        >>> nodes, weights = get_tanh_sinh_1d(5)
+        >>> nodes.shape[0] <= 5
+        True
+        >>> abs(weights.sum() - 1.0) < 1e-14
+        True
+    """
+    _validate_n_pts_and_dtype(n_pts, dtype)
+
+    data, _ = _generate_tanh_sinh(n_pts)
+
+    # Transform from [-1, 1] to [0, 1]
+    nodes = ((data[:, 0] + 1.0) * 0.5).astype(dtype)
+    weights = (data[:, 1] * 0.5).astype(dtype)
+
+    return nodes, weights
+
+
 class PointsLattice:
     """A tensor-product grid of evaluation points in multiple dimensions.
 
@@ -396,5 +540,6 @@ __all__ = [
     "get_gauss_legendre_1d",
     "get_gauss_lobatto_legendre_1d",
     "get_modified_chebyshev_nodes_1d",
+    "get_tanh_sinh_1d",
     "get_trapezoidal_1d",
 ]

--- a/tests/test_quad_tanh_sinh.py
+++ b/tests/test_quad_tanh_sinh.py
@@ -1,0 +1,197 @@
+"""Tests for tanh-sinh quadrature in pantr.quad."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import numpy.testing as nptest
+import numpy.typing as npt
+import pytest
+
+from pantr.quad import get_tanh_sinh_1d
+from pantr.tolerance import get_conservative
+
+
+class TestTanhSinhValidation:
+    """Input validation tests for get_tanh_sinh_1d."""
+
+    def test_invalid_n_pts_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            get_tanh_sinh_1d(0)
+
+    def test_negative_n_pts_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            get_tanh_sinh_1d(-1)
+
+    def test_invalid_dtype_raises(self) -> None:
+        with pytest.raises(ValueError, match="float32 or float64"):
+            get_tanh_sinh_1d(5, np.int32)
+
+
+class TestTanhSinhBasicProperties:
+    """Basic structural tests for tanh-sinh quadrature."""
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_n1_midpoint_rule(self, dtype: npt.DTypeLike) -> None:
+        """n=1 returns the midpoint rule: node=0.5, weight=1."""
+        nodes, weights = get_tanh_sinh_1d(1, dtype)
+        assert nodes.shape == (1,)
+        assert weights.shape == (1,)
+        nptest.assert_allclose(nodes, [0.5], atol=1e-15)
+        nptest.assert_allclose(weights, [1.0], atol=1e-15)
+        assert nodes.dtype == np.dtype(dtype)
+        assert weights.dtype == np.dtype(dtype)
+
+    @pytest.mark.parametrize("n_pts", [2, 3, 5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_weights_sum_to_one(self, n_pts: int, dtype: npt.DTypeLike) -> None:
+        """Weights on [0,1] sum to 1."""
+        _, weights = get_tanh_sinh_1d(n_pts, dtype)
+        nptest.assert_allclose(np.sum(weights, dtype=np.float64), 1.0, rtol=get_conservative(dtype))
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_nodes_in_unit_interval(self, n_pts: int, dtype: npt.DTypeLike) -> None:
+        """All nodes lie in [0, 1]."""
+        nodes, _ = get_tanh_sinh_1d(n_pts, dtype)
+        assert np.all(nodes >= 0.0)
+        assert np.all(nodes <= 1.0)
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_positive_weights(self, n_pts: int, dtype: npt.DTypeLike) -> None:
+        """All weights are strictly positive."""
+        _, weights = get_tanh_sinh_1d(n_pts, dtype)
+        assert np.all(weights > 0.0)
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_output_dtype(self, n_pts: int, dtype: npt.DTypeLike) -> None:
+        """Output arrays have the requested dtype."""
+        nodes, weights = get_tanh_sinh_1d(n_pts, dtype)
+        assert nodes.dtype == np.dtype(dtype)
+        assert weights.dtype == np.dtype(dtype)
+
+    @pytest.mark.parametrize("n_pts", [2, 3, 5, 10])
+    def test_effective_nodes_le_n(self, n_pts: int) -> None:
+        """Effective number of nodes is at most n_pts."""
+        nodes, _ = get_tanh_sinh_1d(n_pts)
+        assert len(nodes) <= n_pts
+
+
+class TestTanhSinhEndpointSnapping:
+    """Tests for endpoint snapping behavior at large n."""
+
+    def test_snapping_reduces_node_count(self) -> None:
+        """For large n, endpoint snapping reduces effective node count."""
+        n_requested = 100
+        nodes, _ = get_tanh_sinh_1d(n_requested)
+        assert len(nodes) < n_requested
+
+    def test_snapped_nodes_include_endpoints(self) -> None:
+        """After snapping, 0 and 1 appear as nodes."""
+        nodes, _ = get_tanh_sinh_1d(100)
+        assert np.isclose(nodes.min(), 0.0, atol=1e-15)
+        assert np.isclose(nodes.max(), 1.0, atol=1e-15)
+
+    def test_snapped_weights_still_sum_to_one(self) -> None:
+        """Weights sum to 1 even after endpoint snapping."""
+        _, weights = get_tanh_sinh_1d(100)
+        nptest.assert_allclose(np.sum(weights), 1.0, rtol=1e-14)
+
+
+class TestTanhSinhSymmetry:
+    """Tests for symmetry of the tanh-sinh scheme."""
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 10, 20])
+    def test_node_symmetry_about_half(self, n_pts: int) -> None:
+        """Nodes are symmetric about 0.5: for each node x, 1-x also exists."""
+        nodes, _ = get_tanh_sinh_1d(n_pts)
+        sorted_nodes = np.sort(nodes)
+        reversed_nodes = 1.0 - np.sort(nodes)[::-1]
+        nptest.assert_allclose(sorted_nodes, reversed_nodes, atol=1e-14)
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 10, 20])
+    def test_weight_symmetry(self, n_pts: int) -> None:
+        """Symmetric node pairs have equal weights."""
+        nodes, weights = get_tanh_sinh_1d(n_pts)
+        order = np.argsort(nodes)
+        sorted_w = weights[order]
+        nptest.assert_allclose(sorted_w, sorted_w[::-1], atol=1e-14)
+
+
+class TestTanhSinhIntegration:
+    """Integration accuracy tests for tanh-sinh quadrature."""
+
+    @staticmethod
+    def _integrate(n_pts: int, f: Any, dtype: npt.DTypeLike = np.float64) -> np.floating[Any]:
+        """Integrate f on [0,1] using n-point tanh-sinh."""
+        nodes, weights = get_tanh_sinh_1d(n_pts, dtype)
+        result = np.sum(weights * f(nodes))
+        return cast(np.floating[Any], result)
+
+    @pytest.mark.parametrize("power", [0, 1, 2, 3])
+    def test_polynomial_integration(self, power: int) -> None:
+        """Tanh-sinh integrates low-degree polynomials accurately with 30 points."""
+        approx = self._integrate(30, lambda x: x**power)
+        exact = 1.0 / (power + 1)
+        nptest.assert_allclose(approx, exact, rtol=1e-10)
+
+    @pytest.mark.parametrize("n_pts", [10, 20, 50])
+    def test_smooth_function_convergence(self, n_pts: int) -> None:
+        """Integration of exp(x) on [0,1] converges with increasing n."""
+        approx = self._integrate(n_pts, np.exp)
+        exact = np.e - 1.0
+        if n_pts >= 50:  # noqa: PLR2004
+            nptest.assert_allclose(approx, exact, rtol=1e-14)
+        elif n_pts >= 20:  # noqa: PLR2004
+            nptest.assert_allclose(approx, exact, rtol=1e-9)
+        else:
+            nptest.assert_allclose(approx, exact, rtol=1e-5)
+
+    def test_endpoint_singular_integrand(self) -> None:
+        """Tanh-sinh handles sqrt(x) (endpoint singularity) better than GL at same n."""
+        from pantr.quad import get_gauss_legendre_1d  # noqa: PLC0415
+
+        n = 30
+        exact = 2.0 / 3.0  # integral of sqrt(x) on [0,1]
+
+        ts_nodes, ts_weights = get_tanh_sinh_1d(n)
+        ts_approx = float(np.sum(ts_weights * np.sqrt(ts_nodes)))
+
+        gl_nodes, gl_weights = get_gauss_legendre_1d(n)
+        gl_approx = float(np.sum(gl_weights * np.sqrt(gl_nodes)))
+
+        ts_err = abs(ts_approx - exact)
+        gl_err = abs(gl_approx - exact)
+
+        # Tanh-sinh should outperform GL for endpoint-singular integrands
+        assert ts_err < gl_err
+
+    def test_constant_function(self) -> None:
+        """Integral of 1 on [0,1] = 1, exact for any n."""
+        for n in [1, 2, 5, 10]:
+            approx = self._integrate(n, lambda x: np.ones_like(x))
+            nptest.assert_allclose(approx, 1.0, rtol=1e-14)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_integration_dtype_consistency(self, dtype: npt.DTypeLike) -> None:
+        """Integration result respects output dtype precision."""
+        approx = self._integrate(30, lambda x: x**2, dtype)
+        rtol = get_conservative(dtype)
+        nptest.assert_allclose(float(approx), 1.0 / 3.0, rtol=rtol)
+
+
+class TestTanhSinhOddEven:
+    """Tests for odd vs even n_pts behavior."""
+
+    def test_odd_n_has_midpoint(self) -> None:
+        """Odd n includes a node at 0.5."""
+        nodes, _ = get_tanh_sinh_1d(5)
+        assert np.any(np.isclose(nodes, 0.5, atol=1e-14))
+
+    def test_even_n_no_midpoint(self) -> None:
+        """Even n does not include a node at 0.5."""
+        nodes, _ = get_tanh_sinh_1d(6)
+        assert not np.any(np.isclose(nodes, 0.5, atol=1e-14))


### PR DESCRIPTION
## Summary

- Add `get_tanh_sinh_1d()` implementing tanh-sinh (double-exponential) quadrature on [0, 1], following the algoim library (Saye, J. Comput. Phys. 448, 2022)
- Includes Lambert W function, symmetric node generation with endpoint snapping, and weight normalization
- Key building block for the implicit quadrature pipeline — used when vertical tangents are detected during dimension reduction

## Test plan

- [x] Validation tests (invalid n_pts, invalid dtype)
- [x] Basic properties: weights sum to 1, nodes in [0,1], positive weights, correct dtype
- [x] Endpoint snapping for large n (n=100 → 84 effective nodes)
- [x] Symmetry of nodes and weights about 0.5
- [x] Integration accuracy: polynomials, exp(x), constant function
- [x] Outperforms Gauss-Legendre for endpoint-singular integrand (sqrt(x))
- [x] Odd n includes midpoint, even n does not
- [x] All 67 new tests pass; all 175 quad tests pass
- [x] ruff, mypy, ruff format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)