### PR TITLE
feat(bezier): add Bezier.interpolate and Bezier.fit classmethods

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -851,10 +851,12 @@ class Bezier:
 
         Args:
             func (Callable[..., npt.ArrayLike]): Function to interpolate.
-                Called as ``func(x0, x1, ...)`` where each ``xi`` has shape
-                ``(*grid_shape)`` (meshgrid broadcasting).  Must return an
-                array of shape ``(*grid_shape)`` for a scalar-valued function
-                or ``(*grid_shape, rank)`` for a vector-valued function.
+                Called as ``func(pts)`` where ``pts`` is a NumPy array of
+                parametric coordinates: shape ``(n_total,)`` for 1D or
+                ``(n_total, dim)`` for multi-dimensional (matching the
+                convention of :meth:`evaluate`).  Must return an array of
+                shape ``(n_total,)`` for scalar or ``(n_total, rank)`` for
+                vector-valued functions.
             n_pts (int | Sequence[int]): Number of sample points per
                 parametric direction.  A single ``int`` gives a 1D Bézier.
             degree (int | Sequence[int] | None): Polynomial degree per

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
@@ -14,6 +14,7 @@ from ._bezier_compose import _compose_bezier
 from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
+from ._bezier_interpolate import _fit_bezier, _interpolate_bezier
 from ._bezier_product import _multiply_bezier
 from ._bezier_restrict import _restrict_bezier
 from ._bezier_slice import _slice_bezier
@@ -823,6 +824,119 @@ class Bezier:
 
         cp = self._control_points.copy() if copy else self._control_points
         return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
+
+    @classmethod
+    def interpolate(  # noqa: PLR0913
+        cls,
+        func: Callable[..., npt.ArrayLike],
+        n_pts: int | Sequence[int],
+        *,
+        degree: int | Sequence[int] | None = None,
+        nodes: (
+            Literal["chebyshev", "uniform"]
+            | npt.NDArray[np.floating[Any]]
+            | Sequence[npt.NDArray[np.floating[Any]]]
+            | None
+        ) = None,
+        dtype: npt.DTypeLike = np.float64,
+        tol: float | None = None,
+    ) -> Bezier:
+        """Interpolate a callable function into a Bézier in Bernstein form.
+
+        Evaluates ``func`` on a tensor-product grid of interpolation nodes
+        and recovers the Bernstein coefficients via truncated SVD.
+
+        The parametric dimension is determined by the length of ``n_pts``
+        (when given as a sequence) or defaults to 1 (when a scalar ``int``).
+
+        Args:
+            func (Callable[..., npt.ArrayLike]): Function to interpolate.
+                Called as ``func(x0, x1, ...)`` where each ``xi`` has shape
+                ``(*grid_shape)`` (meshgrid broadcasting).  Must return an
+                array of shape ``(*grid_shape)`` for a scalar-valued function
+                or ``(*grid_shape, rank)`` for a vector-valued function.
+            n_pts (int | Sequence[int]): Number of sample points per
+                parametric direction.  A single ``int`` gives a 1D Bézier.
+            degree (int | Sequence[int] | None): Polynomial degree per
+                direction.  If *None* (default), ``degree = n_pts - 1``
+                (exact interpolation).  If provided, must satisfy
+                ``degree < n_pts`` in each direction; the result is a
+                least-squares approximation.
+            nodes: Interpolation node selection.
+
+                - ``None`` or ``"chebyshev"`` (default): modified
+                  Chebyshev-Lobatto nodes on [0, 1].
+                - ``"uniform"``: equispaced nodes on [0, 1].
+                - A 1D ``ndarray``: custom nodes broadcast to all directions.
+                - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
+            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+            tol (float | None): SVD truncation tolerance. If *None*, uses a
+                default based on machine epsilon.
+
+        Returns:
+            Bezier: A non-rational Bézier whose evaluation approximates
+            ``func``.
+
+        Raises:
+            ValueError: If ``n_pts`` values are < 1, *degree* >= *n_pts*,
+                or *nodes* is inconsistent with *n_pts*.
+            ValueError: If the callable returns an unexpected shape.
+
+        Example:
+            >>> import numpy as np
+            >>> b = Bezier.interpolate(lambda x: x**2, 5)
+            >>> b.degree
+            (4,)
+        """
+        return _interpolate_bezier(func, n_pts, degree=degree, nodes=nodes, dtype=dtype, tol=tol)
+
+    @classmethod
+    def fit(
+        cls,
+        values: npt.ArrayLike,
+        nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+        *,
+        degree: int | Sequence[int] | None = None,
+        dtype: npt.DTypeLike = np.float64,
+        tol: float | None = None,
+    ) -> Bezier:
+        """Construct a Bézier from pre-evaluated sample values at known nodes.
+
+        Given function values on a tensor-product grid of nodes, recovers the
+        Bernstein coefficients via truncated SVD.
+
+        Args:
+            values (npt.ArrayLike): Sample values on the tensor-product grid.
+                Shape ``(*n_pts_per_dir)`` for scalar or
+                ``(*n_pts_per_dir, rank)`` for vector-valued.
+            nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
+                A single 1D array for 1D fitting, or a sequence of 1D arrays
+                (one per parametric direction) for N-D.
+            degree (int | Sequence[int] | None): Polynomial degree per
+                direction.  If *None* (default), ``degree = n_pts - 1``
+                (exact interpolation).  If provided, must satisfy
+                ``degree < n_pts`` in each direction; the result is a
+                least-squares approximation.
+            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+            tol (float | None): SVD truncation tolerance. If *None*, uses a
+                default based on machine epsilon.
+
+        Returns:
+            Bezier: A non-rational Bézier.
+
+        Raises:
+            ValueError: If *nodes* lengths are inconsistent with *values*
+                shape, or *degree* >= *n_pts* in any direction.
+
+        Example:
+            >>> import numpy as np
+            >>> nodes = np.array([0.0, 0.5, 1.0])
+            >>> vals = nodes**2
+            >>> b = Bezier.fit(vals, nodes)
+            >>> b.degree
+            (2,)
+        """
+        return _fit_bezier(values, nodes, degree=degree, dtype=dtype, tol=tol)
 
     @classmethod
     def from_bspline(cls, bspline: Bspline, *, copy: bool = True) -> Bezier:

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -826,7 +826,7 @@ class Bezier:
         return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
 
     @classmethod
-    def interpolate(  # noqa: PLR0913
+    def interpolate(
         cls,
         func: Callable[..., npt.ArrayLike],
         n_pts: int | Sequence[int],
@@ -834,29 +834,35 @@ class Bezier:
         degree: int | Sequence[int] | None = None,
         nodes: (
             Literal["chebyshev", "uniform"]
+            | PointsLattice
             | npt.NDArray[np.floating[Any]]
             | Sequence[npt.NDArray[np.floating[Any]]]
             | None
         ) = None,
-        dtype: npt.DTypeLike = np.float64,
         tol: float | None = None,
     ) -> Bezier:
         """Interpolate a callable function into a Bézier in Bernstein form.
 
         Evaluates ``func`` on a tensor-product grid of interpolation nodes
-        and recovers the Bernstein coefficients via truncated SVD.
+        and recovers the Bernstein coefficients by solving the Bernstein
+        Vandermonde system via truncated SVD pseudo-inverse.  The SVD
+        regularises the solve, which is important because the Bernstein
+        Vandermonde matrix becomes ill-conditioned at high polynomial
+        degree.
 
         The parametric dimension is determined by the length of ``n_pts``
         (when given as a sequence) or defaults to 1 (when a scalar ``int``).
 
+        The output dtype is inferred from the return value of ``func``.
+
         Args:
             func (Callable[..., npt.ArrayLike]): Function to interpolate.
-                Called as ``func(pts)`` where ``pts`` is a NumPy array of
-                parametric coordinates: shape ``(n_total,)`` for 1D or
-                ``(n_total, dim)`` for multi-dimensional (matching the
-                convention of :meth:`evaluate`).  Must return an array of
-                shape ``(n_total,)`` for scalar or ``(n_total, rank)`` for
-                vector-valued functions.
+                Called as ``func(lattice)`` where ``lattice`` is a
+                :class:`~pantr.quad.PointsLattice` representing the
+                tensor-product sampling grid.  The callable may also accept
+                a plain ``ndarray``.  Must return an array of shape
+                ``(n_total,)`` for scalar or ``(n_total, rank)`` for
+                vector-valued functions, where ``n_total = prod(n_pts)``.
             n_pts (int | Sequence[int]): Number of sample points per
                 parametric direction.  A single ``int`` gives a 1D Bézier.
             degree (int | Sequence[int] | None): Polynomial degree per
@@ -869,11 +875,17 @@ class Bezier:
                 - ``None`` or ``"chebyshev"`` (default): modified
                   Chebyshev-Lobatto nodes on [0, 1].
                 - ``"uniform"``: equispaced nodes on [0, 1].
+                - A :class:`~pantr.quad.PointsLattice`: custom
+                  tensor-product grid.
                 - A 1D ``ndarray``: custom nodes broadcast to all directions.
-                - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
-            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
-            tol (float | None): SVD truncation tolerance. If *None*, uses a
-                default based on machine epsilon.
+                - A sequence of 1D ``ndarray`` values: per-direction custom
+                  nodes.
+            tol (float | None): Truncation tolerance for the SVD
+                pseudo-inverse.  Singular values below
+                ``tol * sigma_max`` are treated as zero, which
+                regularises the ill-conditioned Bernstein Vandermonde
+                matrix at high degree.  If *None*, defaults to
+                ``100 * machine_epsilon``.
 
         Returns:
             Bezier: A non-rational Bézier whose evaluation approximates
@@ -886,49 +898,69 @@ class Bezier:
 
         Example:
             >>> import numpy as np
-            >>> b = Bezier.interpolate(lambda x: x**2, 5)
+            >>> b = Bezier.interpolate(
+            ...     lambda lat: lat.pts_per_dir[0] ** 2, 5
+            ... )
             >>> b.degree
             (4,)
         """
-        return _interpolate_bezier(func, n_pts, degree=degree, nodes=nodes, dtype=dtype, tol=tol)
+        return _interpolate_bezier(func, n_pts, degree=degree, nodes=nodes, tol=tol)
 
     @classmethod
     def fit(
         cls,
         values: npt.ArrayLike,
-        nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+        nodes: (
+            PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
+        ),
         *,
         degree: int | Sequence[int] | None = None,
-        dtype: npt.DTypeLike = np.float64,
         tol: float | None = None,
     ) -> Bezier:
         """Construct a Bézier from pre-evaluated sample values at known nodes.
 
-        Given function values on a tensor-product grid of nodes, recovers the
-        Bernstein coefficients via truncated SVD.
+        Recovers the Bernstein coefficients by solving the Bernstein
+        Vandermonde system via truncated SVD pseudo-inverse, which
+        regularises the ill-conditioned Vandermonde at high degree.
+
+        The output dtype is inferred from *values*.
+
+        Supports two point layouts:
+
+        - **Tensor-product** (a :class:`~pantr.quad.PointsLattice`, a single
+          1D array, or a sequence of 1D arrays): ``values`` must have shape
+          ``(*n_pts_per_dir)`` (scalar) or ``(*n_pts_per_dir, rank)``
+          (vector).
+        - **Scattered** (a 2D ``ndarray`` of shape ``(n_pts, dim)``):
+          ``values`` must have shape ``(n_pts,)`` (scalar) or
+          ``(n_pts, rank)`` (vector).  ``degree`` is required.
 
         Args:
-            values (npt.ArrayLike): Sample values on the tensor-product grid.
-                Shape ``(*n_pts_per_dir)`` for scalar or
-                ``(*n_pts_per_dir, rank)`` for vector-valued.
-            nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
-                A single 1D array for 1D fitting, or a sequence of 1D arrays
-                (one per parametric direction) for N-D.
+            values (npt.ArrayLike): Sample values at the nodes.
+            nodes: Interpolation nodes.
+
+                - A :class:`~pantr.quad.PointsLattice`: tensor-product grid.
+                - A 1D ``ndarray``: 1D tensor-product (single direction).
+                - A sequence of 1D ``ndarray`` values: N-D tensor-product.
+                - A 2D ``ndarray`` of shape ``(n_pts, dim)``: scattered
+                  points.
             degree (int | Sequence[int] | None): Polynomial degree per
-                direction.  If *None* (default), ``degree = n_pts - 1``
-                (exact interpolation).  If provided, must satisfy
-                ``degree < n_pts`` in each direction; the result is a
-                least-squares approximation.
-            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
-            tol (float | None): SVD truncation tolerance. If *None*, uses a
-                default based on machine epsilon.
+                direction.  Required for scattered nodes.  If *None*
+                (default) for tensor-product nodes, ``degree = n_pts - 1``
+                (exact interpolation).
+            tol (float | None): Truncation tolerance for the SVD
+                pseudo-inverse.  Singular values below
+                ``tol * sigma_max`` are treated as zero, which
+                regularises the ill-conditioned Bernstein Vandermonde
+                matrix at high degree.  If *None*, defaults to
+                ``100 * machine_epsilon``.
 
         Returns:
             Bezier: A non-rational Bézier.
 
         Raises:
-            ValueError: If *nodes* lengths are inconsistent with *values*
-                shape, or *degree* >= *n_pts* in any direction.
+            ValueError: If *nodes* are inconsistent with *values*, *degree*
+                is invalid, or *degree* is missing for scattered nodes.
 
         Example:
             >>> import numpy as np
@@ -938,7 +970,7 @@ class Bezier:
             >>> b.degree
             (2,)
         """
-        return _fit_bezier(values, nodes, degree=degree, dtype=dtype, tol=tol)
+        return _fit_bezier(values, nodes, degree=degree, tol=tol)
 
     @classmethod
     def from_bspline(cls, bspline: Bspline, *, copy: bool = True) -> Bezier:

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -1,0 +1,612 @@
+"""Bernstein interpolation and fitting: construct a Bézier from function samples or values.
+
+Provides :func:`_interpolate_bezier` (callable-based) and :func:`_fit_bezier`
+(pre-evaluated values), which recover the Bernstein coefficients via truncated
+SVD of the Bernstein Vandermonde matrix.
+
+Supporting utilities (used internally and by the resultant pipeline):
+
+- :func:`_bernstein_vandermonde_svd` — SVD of the Bernstein Vandermonde
+  matrix at modified Chebyshev nodes.
+- :func:`_bernstein_interpolate_1d` — 1D SVD-based interpolation from
+  node values to Bernstein coefficients.
+- :func:`_bernstein_interpolate` — Tensor-product extension to N-D.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+
+from ..quad import get_modified_chebyshev_nodes_1d
+
+if TYPE_CHECKING:
+    from . import Bezier
+
+
+def _bernstein_vandermonde_svd(
+    n: int,
+    dtype: npt.DTypeLike = np.float64,
+) -> tuple[
+    npt.NDArray[np.floating[Any]],
+    npt.NDArray[np.floating[Any]],
+    npt.NDArray[np.floating[Any]],
+]:
+    """Compute the SVD of the Bernstein Vandermonde matrix at modified Chebyshev nodes.
+
+    The Vandermonde matrix ``V`` has entries ``V[i, j] = B_{j,n-1}(x_i)``
+    where ``x_i`` are the modified Chebyshev nodes and ``B_{j,n-1}`` is the
+    ``j``-th Bernstein basis function of degree ``n - 1``.
+
+    Args:
+        n (int): Number of nodes/coefficients (degree + 1). Must be >= 1.
+        dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray, npt.NDArray]: ``(U, sigma, Vt)`` where
+        ``V = U @ diag(sigma) @ Vt``.
+    """
+    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
+
+    nodes = get_modified_chebyshev_nodes_1d(max(n, 2), dtype)[:n]
+    V = np.empty((n, n), dtype=dtype)
+    _tabulate_Bernstein_basis_1D_core(np.int32(n - 1), nodes, V)
+    U, sigma, Vt = np.linalg.svd(V, full_matrices=True)
+    return U, sigma, Vt
+
+
+def _bernstein_interpolate_1d(
+    f: npt.NDArray[np.floating[Any]],
+    tol: float | None = None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Interpolate values at modified Chebyshev nodes to 1D Bernstein coefficients.
+
+    Given function values ``f[i]`` sampled at the modified Chebyshev nodes
+    of order ``len(f)``, compute the Bernstein coefficients of the
+    interpolating polynomial via truncated SVD.
+
+    Args:
+        f (npt.NDArray[np.floating[Any]]): Function values at modified
+            Chebyshev nodes.  Shape ``(n,)`` where ``n >= 1``.
+        tol (float | None): SVD truncation tolerance (relative to the
+            largest singular value).  If *None*, uses
+            ``100 * eps`` where ``eps`` is machine epsilon.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Bernstein coefficients, shape ``(n,)``.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    n = f.shape[0]
+    dtype = f.dtype
+
+    if n == 1:
+        return f.copy()
+
+    eps = float(np.finfo(dtype).eps)
+    if tol is None:
+        tol = 100.0 * eps
+
+    U, sigma, Vt = _bernstein_vandermonde_svd(n, dtype)
+
+    # Apply U^T to f
+    tmp = U.T @ f
+
+    # Truncated pseudo-inverse: zero out small singular values
+    min_sigma = tol * sigma[0]
+    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
+    tmp *= inv_sigma
+
+    # Apply V to get coefficients
+    out = Vt.T @ tmp
+    return out.astype(dtype)
+
+
+def _bernstein_interpolate(
+    f: npt.NDArray[np.floating[Any]],
+    tol: float | None = None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Interpolate tensor-product values at modified Chebyshev nodes to Bernstein coefficients.
+
+    Applies :func:`_bernstein_interpolate_1d` sequentially along each
+    dimension of the input array.
+
+    Args:
+        f (npt.NDArray[np.floating[Any]]): Function values at the tensor
+            product of modified Chebyshev nodes.  Shape
+            ``(n_0, n_1, ..., n_{N-1})``.
+        tol (float | None): SVD truncation tolerance.  If *None*, uses a
+            default based on machine epsilon.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Bernstein coefficients with the same
+        shape as ``f``.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    result = f.copy()
+    ndim = f.ndim
+
+    for dim in range(ndim):
+        n = result.shape[dim]
+        if n == 1:
+            continue
+
+        U, sigma, Vt = _bernstein_vandermonde_svd(n, f.dtype)
+
+        eps = float(np.finfo(f.dtype).eps)
+        actual_tol = tol if tol is not None else 100.0 * eps
+        min_sigma = actual_tol * sigma[0]
+        inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
+
+        # Pseudoinverse matrix: V @ diag(1/sigma) @ U^T
+        pinv = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
+
+        # Apply along dimension `dim`
+        result = np.tensordot(pinv, result, axes=([1], [dim]))
+        # tensordot puts the result dimension first; move it back to `dim`
+        result = np.moveaxis(result, 0, dim)
+
+    return result
+
+
+def _resolve_nodes(
+    n_pts: tuple[int, ...],
+    nodes: (
+        Literal["chebyshev", "uniform"]
+        | npt.NDArray[np.floating[Any]]
+        | Sequence[npt.NDArray[np.floating[Any]]]
+        | None
+    ),
+    dtype: np.dtype[np.float32] | np.dtype[np.float64],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Resolve the *nodes* parameter into a list of 1D node arrays.
+
+    Args:
+        n_pts (tuple[int, ...]): Number of sample points per direction.
+        nodes: Node specification — ``None`` or ``"chebyshev"`` for modified
+            Chebyshev-Lobatto nodes, ``"uniform"`` for equispaced nodes, a
+            single 1D array (broadcast to every direction), or a sequence of
+            1D arrays (one per direction).
+        dtype (np.dtype): Floating dtype for generated nodes.
+
+    Returns:
+        list[npt.NDArray[np.floating[Any]]]: One 1D node array per parametric
+        direction.
+
+    Raises:
+        ValueError: If *nodes* is inconsistent with *n_pts*.
+    """
+    if nodes is None or (isinstance(nodes, str) and nodes == "chebyshev"):
+        return [
+            get_modified_chebyshev_nodes_1d(n, dtype)
+            if n >= 2  # noqa: PLR2004
+            else np.array([0.5], dtype=dtype)
+            for n in n_pts
+        ]
+
+    if isinstance(nodes, str) and nodes == "uniform":
+        result: list[npt.NDArray[np.floating[Any]]] = [
+            np.linspace(0.0, 1.0, n, dtype=dtype) for n in n_pts
+        ]
+        return result
+
+    # User-provided nodes
+    if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
+        # Single array — broadcast to all directions
+        arr: npt.NDArray[np.floating[Any]] = nodes.astype(dtype, copy=False)
+        for n in n_pts:
+            if arr.shape[0] != n:
+                raise ValueError(f"Node array length {arr.shape[0]} does not match n_pts={n}.")
+        return [arr] * len(n_pts)
+
+    # Sequence of arrays
+    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list) != len(n_pts):
+        raise ValueError(f"Expected {len(n_pts)} node arrays, got {len(node_list)}.")
+    for i, (arr, n) in enumerate(zip(node_list, n_pts, strict=True)):
+        if arr.ndim != 1 or arr.shape[0] != n:
+            raise ValueError(
+                f"Node array for direction {i} has shape {arr.shape}, expected ({n},)."
+            )
+    return node_list
+
+
+def _build_bernstein_pinv(
+    nodes: npt.NDArray[np.floating[Any]],
+    tol: float | None = None,
+    degree: int | None = None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Build the Bernstein pseudo-inverse matrix for arbitrary 1D nodes.
+
+    Given a set of 1D interpolation nodes, constructs the matrix that maps
+    function values at those nodes to Bernstein coefficients via truncated SVD.
+
+    When ``degree`` is *None* or equals ``len(nodes) - 1``, the Vandermonde
+    matrix is square and the result is an exact interpolation matrix.  When
+    ``degree < len(nodes) - 1``, the Vandermonde is rectangular and the
+    pseudo-inverse yields a least-squares fit.
+
+    Args:
+        nodes (npt.NDArray[np.floating[Any]]): 1D interpolation nodes on
+            [0, 1], shape ``(n_pts,)``.
+        tol (float | None): SVD truncation tolerance. If *None*, uses
+            ``100 * eps``.
+        degree (int | None): Polynomial degree of the output Bernstein
+            representation.  If *None*, defaults to ``n_pts - 1`` (exact
+            interpolation).
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix, shape
+        ``(degree + 1, n_pts)``.
+    """
+    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
+
+    n_pts = nodes.shape[0]
+    dtype = nodes.dtype
+    deg = n_pts - 1 if degree is None else degree
+
+    if n_pts == 1 and deg == 0:
+        return np.ones((1, 1), dtype=dtype)
+
+    n_coeffs = deg + 1
+    V = np.empty((n_pts, n_coeffs), dtype=dtype)
+    _tabulate_Bernstein_basis_1D_core(np.int32(deg), nodes, V)
+    U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
+
+    eps = float(np.finfo(dtype).eps)
+    actual_tol = tol if tol is not None else 100.0 * eps
+    min_sigma = actual_tol * sigma[0]
+    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
+
+    pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
+    return pinv
+
+
+def _validate_n_pts(
+    n_pts: int | Sequence[int],
+) -> tuple[int, ...]:
+    """Normalise and validate *n_pts* to a tuple of positive integers.
+
+    Args:
+        n_pts (int | Sequence[int]): Number of sample points per direction.
+
+    Returns:
+        tuple[int, ...]: Validated tuple.
+
+    Raises:
+        ValueError: If any value is < 1.
+    """
+    n_pts_tuple = (n_pts,) if isinstance(n_pts, int) else tuple(n_pts)
+    for i, n in enumerate(n_pts_tuple):
+        if n < 1:
+            raise ValueError(f"n_pts[{i}] must be >= 1, got {n}.")
+    return n_pts_tuple
+
+
+def _validate_degree(
+    degree: int | Sequence[int] | None,
+    n_pts_tuple: tuple[int, ...],
+) -> tuple[int, ...] | None:
+    """Normalise and validate the *degree* parameter.
+
+    Args:
+        degree (int | Sequence[int] | None): Requested degree per direction.
+        n_pts_tuple (tuple[int, ...]): Number of sample points per direction.
+
+    Returns:
+        tuple[int, ...] | None: Validated degree tuple, or *None* if degree
+        was not specified (meaning degree = n_pts - 1).
+
+    Raises:
+        ValueError: If degree >= n_pts in any direction.
+    """
+    if degree is None:
+        return None
+    deg_tuple = (degree,) * len(n_pts_tuple) if isinstance(degree, int) else tuple(degree)
+    if len(deg_tuple) != len(n_pts_tuple):
+        raise ValueError(f"degree has {len(deg_tuple)} entries but n_pts has {len(n_pts_tuple)}.")
+    for i, (d, n) in enumerate(zip(deg_tuple, n_pts_tuple, strict=True)):
+        if d < 0:
+            raise ValueError(f"degree[{i}] must be >= 0, got {d}.")
+        if d >= n:
+            raise ValueError(
+                f"degree[{i}]={d} must be < n_pts[{i}]={n} "
+                f"(need at least degree + 1 sample points)."
+            )
+    return deg_tuple
+
+
+def _resolve_dtype(
+    dtype: npt.DTypeLike,
+) -> np.dtype[np.float32] | np.dtype[np.float64]:
+    """Validate and resolve a dtype to float32 or float64.
+
+    Args:
+        dtype (npt.DTypeLike): Requested dtype.
+
+    Returns:
+        np.dtype[np.float32] | np.dtype[np.float64]: Resolved dtype.
+
+    Raises:
+        ValueError: If dtype is not a floating type.
+    """
+    dtype_raw = np.dtype(dtype)
+    if not np.issubdtype(dtype_raw, np.floating):
+        raise ValueError(f"dtype must be a floating type, got {dtype_raw}.")
+    if dtype_raw == np.float32:
+        dtype_obj: np.dtype[np.float32] | np.dtype[np.float64] = np.dtype(np.float32)
+    else:
+        dtype_obj = np.dtype(np.float64)
+    return dtype_obj
+
+
+def _split_components(
+    values: npt.NDArray[np.floating[Any]],
+    grid_shape: tuple[int, ...],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Split function values into per-component arrays.
+
+    Args:
+        values (npt.NDArray[np.floating[Any]]): Function output array.
+        grid_shape (tuple[int, ...]): Expected grid shape.
+
+    Returns:
+        list[npt.NDArray[np.floating[Any]]]: One array per output component.
+
+    Raises:
+        ValueError: If values shape is incompatible with grid_shape.
+    """
+    if values.shape == grid_shape:
+        return [values]
+    if values.shape[: len(grid_shape)] == grid_shape and values.ndim == len(grid_shape) + 1:
+        return [values[..., r] for r in range(values.shape[-1])]
+    raise ValueError(
+        f"Function returned shape {values.shape}, expected {grid_shape} "
+        f"(scalar) or {(*grid_shape, 'rank')} (vector)."
+    )
+
+
+def _fit_from_values(
+    components: list[npt.NDArray[np.floating[Any]]],
+    node_arrays: list[npt.NDArray[np.floating[Any]]],
+    degree_tuple: tuple[int, ...] | None,
+    tol: float | None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Fit Bernstein coefficients from per-component value arrays.
+
+    This is the shared core for both :func:`_interpolate_bezier` and
+    :func:`_fit_bezier`.
+
+    Args:
+        components (list[npt.NDArray[np.floating[Any]]]): Per-component value
+            arrays, each with shape ``(*n_pts_per_dir)``.
+        node_arrays (list[npt.NDArray[np.floating[Any]]]): One 1D node array
+            per parametric direction.
+        degree_tuple (tuple[int, ...] | None): Degree per direction, or *None*
+            for exact interpolation (``degree = n_pts - 1``).
+        tol (float | None): SVD truncation tolerance.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Control points with shape
+        ``(*orders, rank)`` where ``orders[d] = degree[d] + 1``.
+    """
+    ndim = len(node_arrays)
+
+    # Build pseudo-inverse matrices per direction
+    pinvs = [
+        _build_bernstein_pinv(
+            node_arrays[d],
+            tol,
+            degree_tuple[d] if degree_tuple is not None else None,
+        )
+        for d in range(ndim)
+    ]
+
+    # Interpolate each component to Bernstein coefficients
+    ctrl_components: list[npt.NDArray[np.floating[Any]]] = []
+    for comp_values in components:
+        result = comp_values.copy()
+        for dim in range(ndim):
+            if result.shape[dim] == 1 and pinvs[dim].shape == (1, 1):
+                continue
+            result = np.tensordot(pinvs[dim], result, axes=([1], [dim]))
+            result = np.moveaxis(result, 0, dim)
+        ctrl_components.append(result)
+
+    return np.stack(ctrl_components, axis=-1)
+
+
+def _interpolate_bezier(  # noqa: PLR0913
+    func: Callable[..., npt.ArrayLike],
+    n_pts: int | Sequence[int],
+    *,
+    degree: int | Sequence[int] | None = None,
+    nodes: (
+        Literal["chebyshev", "uniform"]
+        | npt.NDArray[np.floating[Any]]
+        | Sequence[npt.NDArray[np.floating[Any]]]
+        | None
+    ) = None,
+    dtype: npt.DTypeLike = np.float64,
+    tol: float | None = None,
+) -> Bezier:
+    """Interpolate a callable function into a Bézier in Bernstein form.
+
+    Evaluates ``func`` on a tensor-product grid of interpolation nodes and
+    recovers the Bernstein coefficients via truncated SVD.
+
+    The parametric dimension is determined by the length of ``n_pts`` (when
+    given as a sequence) or defaults to 1 (when given as a scalar ``int``).
+
+    Args:
+        func (Callable[..., npt.ArrayLike]): Function to interpolate.  Called
+            as ``func(x0, x1, ...)`` where each ``xi`` is a 1D array of
+            shape ``(n_pts_i,)`` broadcast over a meshgrid (i.e. arrays with
+            shape ``(*grid_shape)``).  Must return an array of shape
+            ``(*grid_shape)`` for a scalar-valued function or
+            ``(*grid_shape, rank)`` for a vector-valued function.
+        n_pts (int | Sequence[int]): Number of sample points per parametric
+            direction.  A single ``int`` gives a 1D Bézier.
+        degree (int | Sequence[int] | None): Polynomial degree per direction.
+            If *None* (default), ``degree = n_pts - 1`` (exact interpolation).
+            If provided, must satisfy ``degree < n_pts`` in each direction;
+            the result is a least-squares approximation.
+        nodes: Interpolation node selection.
+
+            - ``None`` or ``"chebyshev"`` (default): modified Chebyshev-Lobatto
+              nodes on [0, 1].
+            - ``"uniform"``: equispaced nodes on [0, 1].
+            - A 1D ``ndarray``: custom nodes broadcast to all directions.
+            - A sequence of 1D ``ndarray``s: per-direction custom nodes.
+        dtype (npt.DTypeLike): Floating dtype for nodes and output.
+            Defaults to ``float64``.
+        tol (float | None): SVD truncation tolerance. If *None*, uses a
+            default based on machine epsilon.
+
+    Returns:
+        ~pantr.bezier.Bezier: A non-rational Bézier whose evaluation
+        approximates ``func``.
+
+    Raises:
+        ValueError: If ``n_pts`` values are < 1, *degree* >= *n_pts*, *nodes*
+            is inconsistent with *n_pts*, or the callable returns an
+            unexpected shape.
+
+    Example:
+        >>> from pantr.bezier import Bezier
+        >>> import numpy as np
+        >>> b = Bezier.interpolate(lambda x: x**2, 5)
+        >>> b.degree
+        (4,)
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    dtype_obj = _resolve_dtype(dtype)
+    n_pts_tuple = _validate_n_pts(n_pts)
+    degree_tuple = _validate_degree(degree, n_pts_tuple)
+    ndim = len(n_pts_tuple)
+
+    # Resolve nodes and build meshgrid
+    node_arrays = _resolve_nodes(n_pts_tuple, nodes, dtype_obj)
+    grids = [node_arrays[0]] if ndim == 1 else list(np.meshgrid(*node_arrays, indexing="ij"))
+
+    # Evaluate function and split into per-component arrays
+    values: npt.NDArray[np.floating[Any]] = np.asarray(func(*grids), dtype=dtype_obj)
+    components = _split_components(values, n_pts_tuple)
+
+    ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
+    return BezierCls(ctrl, is_rational=False)
+
+
+def _resolve_nodes_from_user(
+    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    n_pts_tuple: tuple[int, ...],
+    dtype: np.dtype[np.float32] | np.dtype[np.float64],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Resolve user-provided nodes for :func:`_fit_bezier`.
+
+    Args:
+        nodes: A single 1D array (for 1D fitting) or a sequence of 1D arrays.
+        n_pts_tuple (tuple[int, ...]): Expected number of points per direction.
+        dtype (np.dtype): Floating dtype.
+
+    Returns:
+        list[npt.NDArray[np.floating[Any]]]: One 1D node array per direction.
+
+    Raises:
+        ValueError: If nodes are inconsistent with the expected grid shape.
+    """
+    # Single 1D array
+    if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
+        if len(n_pts_tuple) != 1:
+            raise ValueError(
+                f"A single node array implies 1D fitting, but values have "
+                f"{len(n_pts_tuple)} parametric dimensions."
+            )
+        arr: npt.NDArray[np.floating[Any]] = nodes.astype(dtype, copy=False)
+        if arr.shape[0] != n_pts_tuple[0]:
+            raise ValueError(
+                f"Node array length {arr.shape[0]} does not match "
+                f"values grid size {n_pts_tuple[0]}."
+            )
+        return [arr]
+
+    # Sequence of arrays
+    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list) != len(n_pts_tuple):
+        raise ValueError(f"Expected {len(n_pts_tuple)} node arrays, got {len(node_list)}.")
+    for i, (arr_i, n) in enumerate(zip(node_list, n_pts_tuple, strict=True)):
+        if arr_i.ndim != 1 or arr_i.shape[0] != n:
+            raise ValueError(
+                f"Node array for direction {i} has shape {arr_i.shape}, expected ({n},)."
+            )
+    return node_list
+
+
+def _fit_bezier(
+    values: npt.ArrayLike,
+    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    *,
+    degree: int | Sequence[int] | None = None,
+    dtype: npt.DTypeLike = np.float64,
+    tol: float | None = None,
+) -> Bezier:
+    """Construct a Bézier from pre-evaluated sample values at known nodes.
+
+    Given function values on a tensor-product grid of nodes, recovers the
+    Bernstein coefficients via truncated SVD.
+
+    Args:
+        values (npt.ArrayLike): Sample values on the tensor-product grid.
+            Shape ``(*n_pts_per_dir)`` for scalar or
+            ``(*n_pts_per_dir, rank)`` for vector-valued.
+        nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
+            A single 1D array for 1D fitting, or a sequence of 1D arrays
+            (one per parametric direction) for N-D.
+        degree (int | Sequence[int] | None): Polynomial degree per direction.
+            If *None* (default), ``degree = n_pts - 1`` (exact interpolation).
+            If provided, must satisfy ``degree < n_pts`` in each direction;
+            the result is a least-squares approximation.
+        dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+        tol (float | None): SVD truncation tolerance. If *None*, uses a
+            default based on machine epsilon.
+
+    Returns:
+        ~pantr.bezier.Bezier: A non-rational Bézier.
+
+    Raises:
+        ValueError: If *nodes* lengths are inconsistent with *values* shape,
+            or *degree* >= *n_pts* in any direction.
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    dtype_obj = _resolve_dtype(dtype)
+    values_arr: npt.NDArray[np.floating[Any]] = np.asarray(values, dtype=dtype_obj)
+
+    # Determine parametric dimension from nodes
+    ndim_param = 1 if isinstance(nodes, np.ndarray) and nodes.ndim == 1 else len(nodes)
+
+    # Infer n_pts from values shape: first ndim_param dimensions are the grid
+    if values_arr.ndim == ndim_param:
+        # Scalar-valued
+        n_pts_tuple = values_arr.shape
+    elif values_arr.ndim == ndim_param + 1:
+        # Vector-valued
+        n_pts_tuple = values_arr.shape[:ndim_param]
+    else:
+        raise ValueError(
+            f"values has {values_arr.ndim} dimensions, expected {ndim_param} "
+            f"(scalar) or {ndim_param + 1} (vector) for {ndim_param}D fitting."
+        )
+
+    degree_tuple = _validate_degree(degree, n_pts_tuple)
+    node_arrays = _resolve_nodes_from_user(nodes, n_pts_tuple, dtype_obj)
+    components = _split_components(values_arr, n_pts_tuple)
+    ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
+    return BezierCls(ctrl, is_rational=False)

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -446,11 +446,12 @@ def _interpolate_bezier(  # noqa: PLR0913
 
     Args:
         func (Callable[..., npt.ArrayLike]): Function to interpolate.  Called
-            as ``func(x0, x1, ...)`` where each ``xi`` is a 1D array of
-            shape ``(n_pts_i,)`` broadcast over a meshgrid (i.e. arrays with
-            shape ``(*grid_shape)``).  Must return an array of shape
-            ``(*grid_shape)`` for a scalar-valued function or
-            ``(*grid_shape, rank)`` for a vector-valued function.
+            as ``func(pts)`` where ``pts`` is a NumPy array of parametric
+            coordinates: shape ``(n_total,)`` for 1D or
+            ``(n_total, dim)`` for multi-dimensional (matching the convention
+            of :meth:`~pantr.bezier.Bezier.evaluate`).  Must return an array
+            of shape ``(n_total,)`` for a scalar-valued function or
+            ``(n_total, rank)`` for a vector-valued function.
         n_pts (int | Sequence[int]): Number of sample points per parametric
             direction.  A single ``int`` gives a 1D Bézier.
         degree (int | Sequence[int] | None): Polynomial degree per direction.
@@ -463,7 +464,7 @@ def _interpolate_bezier(  # noqa: PLR0913
               nodes on [0, 1].
             - ``"uniform"``: equispaced nodes on [0, 1].
             - A 1D ``ndarray``: custom nodes broadcast to all directions.
-            - A sequence of 1D ``ndarray``s: per-direction custom nodes.
+            - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
         dtype (npt.DTypeLike): Floating dtype for nodes and output.
             Defaults to ``float64``.
         tol (float | None): SVD truncation tolerance. If *None*, uses a
@@ -492,14 +493,36 @@ def _interpolate_bezier(  # noqa: PLR0913
     degree_tuple = _validate_degree(degree, n_pts_tuple)
     ndim = len(n_pts_tuple)
 
-    # Resolve nodes and build meshgrid
+    # Resolve nodes and build flat points array
     node_arrays = _resolve_nodes(n_pts_tuple, nodes, dtype_obj)
-    grids = [node_arrays[0]] if ndim == 1 else list(np.meshgrid(*node_arrays, indexing="ij"))
+    n_total = int(np.prod(n_pts_tuple))
 
-    # Evaluate function and split into per-component arrays
-    values: npt.NDArray[np.floating[Any]] = np.asarray(func(*grids), dtype=dtype_obj)
+    if ndim == 1:
+        pts_flat = node_arrays[0]
+    else:
+        grids = np.meshgrid(*node_arrays, indexing="ij")
+        pts_flat = np.column_stack([g.ravel() for g in grids])
+
+    # Evaluate function and reshape to grid
+    raw: npt.NDArray[np.floating[Any]] = np.asarray(func(pts_flat), dtype=dtype_obj)
+    if raw.ndim == 1:
+        if raw.shape[0] != n_total:
+            raise ValueError(
+                f"Function returned shape {raw.shape}, expected ({n_total},) or ({n_total}, rank)."
+            )
+        values = raw.reshape(n_pts_tuple)
+    elif raw.ndim == 2:  # noqa: PLR2004
+        if raw.shape[0] != n_total:
+            raise ValueError(
+                f"Function returned shape {raw.shape}, expected ({n_total},) or ({n_total}, rank)."
+            )
+        values = raw.reshape(*n_pts_tuple, raw.shape[1])
+    else:
+        raise ValueError(
+            f"Function returned shape {raw.shape}, expected ({n_total},) or ({n_total}, rank)."
+        )
+
     components = _split_components(values, n_pts_tuple)
-
     ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
     return BezierCls(ctrl, is_rational=False)
 

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -1,8 +1,19 @@
 """Bernstein interpolation and fitting: construct a Bézier from function samples or values.
 
 Provides :func:`_interpolate_bezier` (callable-based) and :func:`_fit_bezier`
-(pre-evaluated values), which recover the Bernstein coefficients via truncated
-SVD of the Bernstein Vandermonde matrix.
+(pre-evaluated values), which recover the Bernstein coefficients from the
+Bernstein Vandermonde system.
+
+The Bernstein Vandermonde matrix becomes increasingly ill-conditioned as the
+polynomial degree grows, making a direct solve numerically unstable.  To handle
+this, all solvers in this module use a **truncated SVD** pseudo-inverse:
+singular values smaller than ``tol * sigma_max`` are zeroed out, which
+regularises the inversion and yields robust results even at high degree.
+
+Both functions support **tensor-product** grids (represented as a
+:class:`~pantr.quad.PointsLattice` or a sequence of 1D node arrays) and
+**scattered** point sets (represented as a 2D array of shape
+``(n_pts, dim)``).
 
 Supporting utilities (used internally and by the resultant pipeline):
 
@@ -21,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import numpy.typing as npt
 
-from ..quad import get_modified_chebyshev_nodes_1d
+from ..quad import PointsLattice, get_modified_chebyshev_nodes_1d
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -159,6 +170,7 @@ def _resolve_nodes(
     n_pts: tuple[int, ...],
     nodes: (
         Literal["chebyshev", "uniform"]
+        | PointsLattice
         | npt.NDArray[np.floating[Any]]
         | Sequence[npt.NDArray[np.floating[Any]]]
         | None
@@ -171,8 +183,9 @@ def _resolve_nodes(
         n_pts (tuple[int, ...]): Number of sample points per direction.
         nodes: Node specification — ``None`` or ``"chebyshev"`` for modified
             Chebyshev-Lobatto nodes, ``"uniform"`` for equispaced nodes, a
-            single 1D array (broadcast to every direction), or a sequence of
-            1D arrays (one per direction).
+            :class:`~pantr.quad.PointsLattice`, a single 1D array (broadcast
+            to every direction), or a sequence of 1D arrays (one per
+            direction).
         dtype (np.dtype): Floating dtype for generated nodes.
 
     Returns:
@@ -196,6 +209,20 @@ def _resolve_nodes(
         ]
         return result
 
+    # PointsLattice
+    if isinstance(nodes, PointsLattice):
+        if nodes.dim != len(n_pts):
+            raise ValueError(f"PointsLattice has {nodes.dim} dimensions, expected {len(n_pts)}.")
+        node_list: list[npt.NDArray[np.floating[Any]]] = [
+            np.asarray(a, dtype=dtype) for a in nodes.pts_per_dir
+        ]
+        for i, (arr_i, n) in enumerate(zip(node_list, n_pts, strict=True)):
+            if arr_i.shape[0] != n:
+                raise ValueError(
+                    f"PointsLattice direction {i} has {arr_i.shape[0]} nodes, expected n_pts={n}."
+                )
+        return node_list
+
     # User-provided nodes
     if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
         # Single array — broadcast to all directions
@@ -206,15 +233,15 @@ def _resolve_nodes(
         return [arr] * len(n_pts)
 
     # Sequence of arrays
-    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
-    if len(node_list) != len(n_pts):
-        raise ValueError(f"Expected {len(n_pts)} node arrays, got {len(node_list)}.")
-    for i, (arr, n) in enumerate(zip(node_list, n_pts, strict=True)):
+    node_list_seq: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list_seq) != len(n_pts):
+        raise ValueError(f"Expected {len(n_pts)} node arrays, got {len(node_list_seq)}.")
+    for i, (arr, n) in enumerate(zip(node_list_seq, n_pts, strict=True)):
         if arr.ndim != 1 or arr.shape[0] != n:
             raise ValueError(
                 f"Node array for direction {i} has shape {arr.shape}, expected ({n},)."
             )
-    return node_list
+    return node_list_seq
 
 
 def _build_bernstein_pinv(
@@ -266,6 +293,106 @@ def _build_bernstein_pinv(
 
     pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
     return pinv
+
+
+def _build_nd_bernstein_vandermonde(
+    pts: npt.NDArray[np.floating[Any]],
+    degree_tuple: tuple[int, ...],
+) -> npt.NDArray[np.floating[Any]]:
+    """Build the full tensor-product Bernstein Vandermonde matrix at scattered points.
+
+    For ``N``-dimensional points with degrees ``(p_0, ..., p_{N-1})``, the
+    Vandermonde matrix has shape ``(n_pts, prod(p_d + 1))`` where each row
+    contains the products of univariate Bernstein basis values across all
+    directions.
+
+    Args:
+        pts (npt.NDArray[np.floating[Any]]): Evaluation points, shape
+            ``(n_pts,)`` for 1D or ``(n_pts, ndim)`` for N-D.
+        degree_tuple (tuple[int, ...]): Polynomial degree per parametric
+            direction.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Vandermonde matrix, shape
+        ``(n_pts, prod(degree[d] + 1))``.
+    """
+    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
+
+    ndim = len(degree_tuple)
+    dtype = pts.dtype
+
+    pts_2d = pts[:, np.newaxis] if pts.ndim == 1 else pts
+    n_pts = pts_2d.shape[0]
+
+    # Evaluate univariate Bernstein bases per direction
+    basis_per_dir: list[npt.NDArray[np.floating[Any]]] = []
+    for d in range(ndim):
+        n_coeffs = degree_tuple[d] + 1
+        B_d = np.empty((n_pts, n_coeffs), dtype=dtype)
+        _tabulate_Bernstein_basis_1D_core(np.int32(degree_tuple[d]), pts_2d[:, d], B_d)
+        basis_per_dir.append(B_d)
+
+    # Build tensor-product Vandermonde via successive Kronecker-like expansion
+    V = basis_per_dir[0]
+    for d in range(1, ndim):
+        # V has shape (n_pts, cols_so_far), basis_per_dir[d] has shape (n_pts, n_d)
+        # Result: (n_pts, cols_so_far * n_d) via row-wise outer product
+        V = (V[:, :, np.newaxis] * basis_per_dir[d][:, np.newaxis, :]).reshape(n_pts, -1)
+
+    return V
+
+
+def _fit_from_scattered(
+    values: npt.NDArray[np.floating[Any]],
+    pts: npt.NDArray[np.floating[Any]],
+    degree_tuple: tuple[int, ...],
+    tol: float | None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Fit Bernstein coefficients from scattered (non-tensor-product) point values.
+
+    Builds the full tensor-product Bernstein Vandermonde at the given points
+    and recovers the coefficients via truncated SVD pseudo-inverse.
+
+    Args:
+        values (npt.NDArray[np.floating[Any]]): Function values at scattered
+            points.  Shape ``(n_pts,)`` for scalar or ``(n_pts, rank)`` for
+            vector-valued.
+        pts (npt.NDArray[np.floating[Any]]): Evaluation points, shape
+            ``(n_pts,)`` for 1D or ``(n_pts, ndim)`` for N-D.
+        degree_tuple (tuple[int, ...]): Polynomial degree per parametric
+            direction.
+        tol (float | None): SVD truncation tolerance.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Control points with shape
+        ``(*orders, rank)`` where ``orders[d] = degree[d] + 1``.
+    """
+    dtype = values.dtype
+    orders = tuple(d + 1 for d in degree_tuple)
+
+    V = _build_nd_bernstein_vandermonde(pts, degree_tuple)
+
+    # SVD pseudo-inverse with truncation
+    U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
+    eps = float(np.finfo(dtype).eps)
+    actual_tol = tol if tol is not None else 100.0 * eps
+    min_sigma = actual_tol * sigma[0]
+    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
+    pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
+
+    # Solve for each component
+    is_vector = values.ndim == 2  # noqa: PLR2004
+    if is_vector:
+        rank = values.shape[1]
+        components: list[npt.NDArray[np.floating[Any]]] = []
+        for r in range(rank):
+            coeffs_flat = pinv @ values[:, r]
+            components.append(coeffs_flat.reshape(orders).astype(dtype))
+        return np.stack(components, axis=-1)
+
+    coeffs_flat = pinv @ values
+    ctrl = coeffs_flat.reshape(orders).astype(dtype)
+    return ctrl[..., np.newaxis]
 
 
 def _validate_n_pts(
@@ -320,30 +447,6 @@ def _validate_degree(
                 f"(need at least degree + 1 sample points)."
             )
     return deg_tuple
-
-
-def _resolve_dtype(
-    dtype: npt.DTypeLike,
-) -> np.dtype[np.float32] | np.dtype[np.float64]:
-    """Validate and resolve a dtype to float32 or float64.
-
-    Args:
-        dtype (npt.DTypeLike): Requested dtype.
-
-    Returns:
-        np.dtype[np.float32] | np.dtype[np.float64]: Resolved dtype.
-
-    Raises:
-        ValueError: If dtype is not a floating type.
-    """
-    dtype_raw = np.dtype(dtype)
-    if not np.issubdtype(dtype_raw, np.floating):
-        raise ValueError(f"dtype must be a floating type, got {dtype_raw}.")
-    if dtype_raw == np.float32:
-        dtype_obj: np.dtype[np.float32] | np.dtype[np.float64] = np.dtype(np.float32)
-    else:
-        dtype_obj = np.dtype(np.float64)
-    return dtype_obj
 
 
 def _split_components(
@@ -422,18 +525,18 @@ def _fit_from_values(
     return np.stack(ctrl_components, axis=-1)
 
 
-def _interpolate_bezier(  # noqa: PLR0913
+def _interpolate_bezier(
     func: Callable[..., npt.ArrayLike],
     n_pts: int | Sequence[int],
     *,
     degree: int | Sequence[int] | None = None,
     nodes: (
         Literal["chebyshev", "uniform"]
+        | PointsLattice
         | npt.NDArray[np.floating[Any]]
         | Sequence[npt.NDArray[np.floating[Any]]]
         | None
     ) = None,
-    dtype: npt.DTypeLike = np.float64,
     tol: float | None = None,
 ) -> Bezier:
     """Interpolate a callable function into a Bézier in Bernstein form.
@@ -444,14 +547,17 @@ def _interpolate_bezier(  # noqa: PLR0913
     The parametric dimension is determined by the length of ``n_pts`` (when
     given as a sequence) or defaults to 1 (when given as a scalar ``int``).
 
+    The output dtype is inferred from the return value of ``func``.
+
     Args:
         func (Callable[..., npt.ArrayLike]): Function to interpolate.  Called
-            as ``func(pts)`` where ``pts`` is a NumPy array of parametric
-            coordinates: shape ``(n_total,)`` for 1D or
-            ``(n_total, dim)`` for multi-dimensional (matching the convention
-            of :meth:`~pantr.bezier.Bezier.evaluate`).  Must return an array
-            of shape ``(n_total,)`` for a scalar-valued function or
-            ``(n_total, rank)`` for a vector-valued function.
+            as ``func(lattice)`` where ``lattice`` is a
+            :class:`~pantr.quad.PointsLattice` representing the tensor-product
+            sampling grid.  The callable may also accept a plain ``ndarray``
+            (for compatibility with :meth:`Bezier.evaluate` signatures).
+            Must return an array of shape ``(n_total,)`` for a scalar-valued
+            function or ``(n_total, rank)`` for a vector-valued function,
+            where ``n_total = prod(n_pts)``.
         n_pts (int | Sequence[int]): Number of sample points per parametric
             direction.  A single ``int`` gives a 1D Bézier.
         degree (int | Sequence[int] | None): Polynomial degree per direction.
@@ -463,10 +569,9 @@ def _interpolate_bezier(  # noqa: PLR0913
             - ``None`` or ``"chebyshev"`` (default): modified Chebyshev-Lobatto
               nodes on [0, 1].
             - ``"uniform"``: equispaced nodes on [0, 1].
+            - A :class:`~pantr.quad.PointsLattice`: custom tensor-product grid.
             - A 1D ``ndarray``: custom nodes broadcast to all directions.
             - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
-        dtype (npt.DTypeLike): Floating dtype for nodes and output.
-            Defaults to ``float64``.
         tol (float | None): SVD truncation tolerance. If *None*, uses a
             default based on machine epsilon.
 
@@ -482,29 +587,26 @@ def _interpolate_bezier(  # noqa: PLR0913
     Example:
         >>> from pantr.bezier import Bezier
         >>> import numpy as np
-        >>> b = Bezier.interpolate(lambda x: x**2, 5)
+        >>> b = Bezier.interpolate(lambda lattice: lattice.get_all_points()[:, 0] ** 2, [5])
         >>> b.degree
         (4,)
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
-    dtype_obj = _resolve_dtype(dtype)
     n_pts_tuple = _validate_n_pts(n_pts)
     degree_tuple = _validate_degree(degree, n_pts_tuple)
-    ndim = len(n_pts_tuple)
 
-    # Resolve nodes and build flat points array
-    node_arrays = _resolve_nodes(n_pts_tuple, nodes, dtype_obj)
+    # Resolve nodes and build PointsLattice (default to float64 for generated nodes)
+    node_arrays = _resolve_nodes(n_pts_tuple, nodes, np.dtype(np.float64))
+    lattice = PointsLattice(node_arrays)
     n_total = int(np.prod(n_pts_tuple))
 
-    if ndim == 1:
-        pts_flat = node_arrays[0]
-    else:
-        grids = np.meshgrid(*node_arrays, indexing="ij")
-        pts_flat = np.column_stack([g.ravel() for g in grids])
+    # Evaluate function and infer dtype from the return value
+    raw_untyped = np.asarray(func(lattice))
+    if not np.issubdtype(raw_untyped.dtype, np.floating):
+        raw_untyped = raw_untyped.astype(np.float64)
+    raw: npt.NDArray[np.floating[Any]] = raw_untyped
 
-    # Evaluate function and reshape to grid
-    raw: npt.NDArray[np.floating[Any]] = np.asarray(func(pts_flat), dtype=dtype_obj)
     if raw.ndim == 1:
         if raw.shape[0] != n_total:
             raise ValueError(
@@ -528,14 +630,15 @@ def _interpolate_bezier(  # noqa: PLR0913
 
 
 def _resolve_nodes_from_user(
-    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    nodes: PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
     n_pts_tuple: tuple[int, ...],
     dtype: np.dtype[np.float32] | np.dtype[np.float64],
 ) -> list[npt.NDArray[np.floating[Any]]]:
-    """Resolve user-provided nodes for :func:`_fit_bezier`.
+    """Resolve user-provided tensor-product nodes for :func:`_fit_bezier`.
 
     Args:
-        nodes: A single 1D array (for 1D fitting) or a sequence of 1D arrays.
+        nodes: A :class:`~pantr.quad.PointsLattice`, a single 1D array
+            (for 1D fitting), or a sequence of 1D arrays.
         n_pts_tuple (tuple[int, ...]): Expected number of points per direction.
         dtype (np.dtype): Floating dtype.
 
@@ -545,6 +648,22 @@ def _resolve_nodes_from_user(
     Raises:
         ValueError: If nodes are inconsistent with the expected grid shape.
     """
+    if isinstance(nodes, PointsLattice):
+        if nodes.dim != len(n_pts_tuple):
+            raise ValueError(
+                f"PointsLattice has {nodes.dim} dimensions, but values have "
+                f"{len(n_pts_tuple)} parametric dimensions."
+            )
+        node_list: list[npt.NDArray[np.floating[Any]]] = [
+            np.asarray(a, dtype=dtype) for a in nodes.pts_per_dir
+        ]
+        for i, (arr_i, n) in enumerate(zip(node_list, n_pts_tuple, strict=True)):
+            if arr_i.shape[0] != n:
+                raise ValueError(
+                    f"PointsLattice direction {i} has {arr_i.shape[0]} nodes, expected {n}."
+                )
+        return node_list
+
     # Single 1D array
     if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
         if len(n_pts_tuple) != 1:
@@ -561,42 +680,75 @@ def _resolve_nodes_from_user(
         return [arr]
 
     # Sequence of arrays
-    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
-    if len(node_list) != len(n_pts_tuple):
-        raise ValueError(f"Expected {len(n_pts_tuple)} node arrays, got {len(node_list)}.")
-    for i, (arr_i, n) in enumerate(zip(node_list, n_pts_tuple, strict=True)):
+    node_list_seq: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list_seq) != len(n_pts_tuple):
+        raise ValueError(f"Expected {len(n_pts_tuple)} node arrays, got {len(node_list_seq)}.")
+    for i, (arr_i, n) in enumerate(zip(node_list_seq, n_pts_tuple, strict=True)):
         if arr_i.ndim != 1 or arr_i.shape[0] != n:
             raise ValueError(
                 f"Node array for direction {i} has shape {arr_i.shape}, expected ({n},)."
             )
-    return node_list
+    return node_list_seq
 
 
-def _fit_bezier(
+def _is_scattered_nodes(
+    nodes: (
+        PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
+    ),
+) -> bool:
+    """Check whether *nodes* represents scattered (non-tensor-product) points.
+
+    Args:
+        nodes: The nodes argument passed to :func:`_fit_bezier`.
+
+    Returns:
+        bool: ``True`` if *nodes* is a 2D array (scattered points),
+        ``False`` if it is a :class:`~pantr.quad.PointsLattice`, a 1D array,
+        or a sequence of 1D arrays (tensor-product).
+    """
+    if isinstance(nodes, PointsLattice):
+        return False
+    return isinstance(nodes, np.ndarray) and nodes.ndim == 2  # noqa: PLR2004
+
+
+def _fit_bezier(  # noqa: PLR0912
     values: npt.ArrayLike,
-    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    nodes: (
+        PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
+    ),
     *,
     degree: int | Sequence[int] | None = None,
-    dtype: npt.DTypeLike = np.float64,
     tol: float | None = None,
 ) -> Bezier:
     """Construct a Bézier from pre-evaluated sample values at known nodes.
 
-    Given function values on a tensor-product grid of nodes, recovers the
-    Bernstein coefficients via truncated SVD.
+    The output dtype is inferred from *values*.
+
+    Supports two point layouts:
+
+    - **Tensor-product** (a :class:`~pantr.quad.PointsLattice`, a single 1D
+      array, or a sequence of 1D arrays): values must have shape
+      ``(*n_pts_per_dir)`` (scalar) or ``(*n_pts_per_dir, rank)`` (vector).
+      Per-direction SVD pseudo-inverse is used (efficient).
+    - **Scattered** (a 2D ``ndarray`` of shape ``(n_pts, dim)``): values must
+      have shape ``(n_pts,)`` (scalar) or ``(n_pts, rank)`` (vector).
+      ``degree`` is required. A full tensor-product Vandermonde is built and
+      solved via SVD.
 
     Args:
-        values (npt.ArrayLike): Sample values on the tensor-product grid.
-            Shape ``(*n_pts_per_dir)`` for scalar or
-            ``(*n_pts_per_dir, rank)`` for vector-valued.
-        nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
-            A single 1D array for 1D fitting, or a sequence of 1D arrays
-            (one per parametric direction) for N-D.
+        values (npt.ArrayLike): Sample values.
+        nodes: Interpolation nodes.
+
+            - A :class:`~pantr.quad.PointsLattice`: tensor-product grid.
+            - A 1D ``ndarray``: 1D tensor-product (single direction).
+            - A sequence of 1D ``ndarray`` values: N-D tensor-product.
+            - A 2D ``ndarray`` of shape ``(n_pts, dim)``: scattered points.
         degree (int | Sequence[int] | None): Polynomial degree per direction.
-            If *None* (default), ``degree = n_pts - 1`` (exact interpolation).
-            If provided, must satisfy ``degree < n_pts`` in each direction;
-            the result is a least-squares approximation.
-        dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+            Required for scattered nodes.  If *None* (default) for
+            tensor-product nodes, ``degree = n_pts - 1`` (exact
+            interpolation).  Must satisfy
+            ``prod(degree + 1) <= n_pts`` for scattered nodes and
+            ``degree < n_pts`` per direction for tensor-product.
         tol (float | None): SVD truncation tolerance. If *None*, uses a
             default based on machine epsilon.
 
@@ -604,16 +756,65 @@ def _fit_bezier(
         ~pantr.bezier.Bezier: A non-rational Bézier.
 
     Raises:
-        ValueError: If *nodes* lengths are inconsistent with *values* shape,
-            or *degree* >= *n_pts* in any direction.
+        ValueError: If *nodes* are inconsistent with *values*, *degree* is
+            invalid, or *degree* is missing for scattered nodes.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
-    dtype_obj = _resolve_dtype(dtype)
-    values_arr: npt.NDArray[np.floating[Any]] = np.asarray(values, dtype=dtype_obj)
+    values_untyped = np.asarray(values)
+    if not np.issubdtype(values_untyped.dtype, np.floating):
+        values_untyped = values_untyped.astype(np.float64)
+    values_arr: npt.NDArray[np.floating[Any]] = values_untyped
+    dtype_obj = values_arr.dtype
 
+    # --- Scattered path ---
+    if _is_scattered_nodes(nodes):
+        pts: npt.NDArray[np.floating[Any]] = np.asarray(nodes, dtype=dtype_obj)
+        ndim_param = pts.shape[1]
+        n_pts = pts.shape[0]
+
+        if degree is None:
+            raise ValueError("degree is required for scattered (non-tensor-product) nodes.")
+
+        degree_tuple = (degree,) * ndim_param if isinstance(degree, int) else tuple(degree)
+        if len(degree_tuple) != ndim_param:
+            raise ValueError(
+                f"degree has {len(degree_tuple)} entries but nodes have {ndim_param} columns."
+            )
+        n_coeffs = int(np.prod(tuple(d + 1 for d in degree_tuple)))
+        if n_coeffs > n_pts:
+            raise ValueError(
+                f"Underdetermined: {n_coeffs} coefficients but only {n_pts} sample points."
+            )
+
+        # Validate values shape
+        if values_arr.ndim == 1:
+            if values_arr.shape[0] != n_pts:
+                raise ValueError(
+                    f"values has {values_arr.shape[0]} entries but nodes has {n_pts} points."
+                )
+        elif values_arr.ndim == 2:  # noqa: PLR2004
+            if values_arr.shape[0] != n_pts:
+                raise ValueError(
+                    f"values has {values_arr.shape[0]} rows but nodes has {n_pts} points."
+                )
+        else:
+            raise ValueError(
+                f"For scattered nodes, values must be 1D (scalar) or 2D "
+                f"(vector), got {values_arr.ndim}D."
+            )
+
+        ctrl = _fit_from_scattered(values_arr, pts, degree_tuple, tol)
+        return BezierCls(ctrl, is_rational=False)
+
+    # --- Tensor-product path ---
     # Determine parametric dimension from nodes
-    ndim_param = 1 if isinstance(nodes, np.ndarray) and nodes.ndim == 1 else len(nodes)
+    if isinstance(nodes, PointsLattice):
+        ndim_param = nodes.dim
+    elif isinstance(nodes, np.ndarray) and nodes.ndim == 1:
+        ndim_param = 1
+    else:
+        ndim_param = len(nodes)
 
     # Infer n_pts from values shape: first ndim_param dimensions are the grid
     if values_arr.ndim == ndim_param:
@@ -628,8 +829,8 @@ def _fit_bezier(
             f"(scalar) or {ndim_param + 1} (vector) for {ndim_param}D fitting."
         )
 
-    degree_tuple = _validate_degree(degree, n_pts_tuple)
+    degree_tuple_tp = _validate_degree(degree, n_pts_tuple)
     node_arrays = _resolve_nodes_from_user(nodes, n_pts_tuple, dtype_obj)
     components = _split_components(values_arr, n_pts_tuple)
-    ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
+    ctrl = _fit_from_values(components, node_arrays, degree_tuple_tp, tol)
     return BezierCls(ctrl, is_rational=False)

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -1,4 +1,4 @@
-"""Tests for Bezier.interpolate and the Bernstein interpolation pipeline."""
+"""Tests for Bezier.interpolate and Bezier.fit (including scattered fitting)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
+from pantr.quad import PointsLattice
 
 # ---------------------------------------------------------------------------
 # 1D scalar interpolation
@@ -21,7 +22,7 @@ class TestInterpolate1DScalar:
 
     def test_linear(self) -> None:
         """Interpolating a linear function with 2 points recovers it exactly."""
-        b = Bezier.interpolate(lambda x: 2.0 * x + 1.0, 2)
+        b = Bezier.interpolate(lambda lat: 2.0 * lat.pts_per_dir[0] + 1.0, 2)
         assert b.degree == (1,)
         assert b.rank == 1
         pts = np.array([0.0, 0.5, 1.0])
@@ -30,7 +31,7 @@ class TestInterpolate1DScalar:
 
     def test_quadratic(self) -> None:
         """Interpolating x^2 with 3 points recovers it exactly."""
-        b = Bezier.interpolate(lambda x: x**2, 3)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3)
         assert b.degree == (2,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         expected = pts**2
@@ -38,14 +39,14 @@ class TestInterpolate1DScalar:
 
     def test_cubic(self) -> None:
         """Interpolating x^3 with 4 points recovers it exactly."""
-        b = Bezier.interpolate(lambda x: x**3, 4)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 3, 4)
         assert b.degree == (3,)
         pts = np.linspace(0, 1, 10)
         nptest.assert_allclose(b.evaluate(pts), pts**3, atol=1e-12)
 
     def test_single_point(self) -> None:
         """A single interpolation point gives a degree-0 (constant) Bezier."""
-        b = Bezier.interpolate(lambda x: np.full_like(x, 7.0), 1)
+        b = Bezier.interpolate(lambda lat: np.full(1, 7.0), 1)
         assert b.degree == (0,)
         nptest.assert_allclose(b.evaluate(np.array([0.5])), [7.0], atol=1e-14)
 
@@ -61,7 +62,8 @@ class TestInterpolate1DVector:
     def test_circle_arc(self) -> None:
         """Interpolate a quarter-circle parametric curve."""
 
-        def quarter_circle(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+        def quarter_circle(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            t = lat.pts_per_dir[0]
             theta = t * (np.pi / 2.0)
             return np.stack([np.cos(theta), np.sin(theta)], axis=-1)
 
@@ -78,7 +80,8 @@ class TestInterpolate1DVector:
     def test_linear_curve(self) -> None:
         """A linear vector-valued function is recovered exactly."""
 
-        def line(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+        def line(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            t = lat.pts_per_dir[0]
             return np.stack([t, 2.0 * t + 1.0, -t + 3.0], axis=-1)
 
         b = Bezier.interpolate(line, 2)
@@ -99,7 +102,12 @@ class TestInterpolate2DScalar:
 
     def test_bilinear(self) -> None:
         """Interpolating a bilinear function with (2,2) points recovers it."""
-        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [2, 2])
+
+        def bilinear(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
+            return pts[:, 0] + pts[:, 1]
+
+        b = Bezier.interpolate(bilinear, [2, 2])
         assert b.degree == (1, 1)
         assert b.rank == 1
         pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]])
@@ -108,7 +116,12 @@ class TestInterpolate2DScalar:
 
     def test_biquadratic(self) -> None:
         """Interpolating x^2 + y^2 with (3,3) points."""
-        b = Bezier.interpolate(lambda pts: pts[:, 0] ** 2 + pts[:, 1] ** 2, [3, 3])
+
+        def biquad(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
+            return pts[:, 0] ** 2 + pts[:, 1] ** 2
+
+        b = Bezier.interpolate(biquad, [3, 3])
         assert b.degree == (2, 2)
         pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
         expected = pts[:, 0] ** 2 + pts[:, 1] ** 2
@@ -126,7 +139,8 @@ class TestInterpolate2DVector:
     def test_planar_surface(self) -> None:
         """A linear vector-valued 2D function is recovered exactly."""
 
-        def plane(pts: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+        def plane(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
             x, y = pts[:, 0], pts[:, 1]
             return np.stack([x, y, x + y], axis=-1)
 
@@ -148,26 +162,26 @@ class TestNodeSelection:
 
     def test_chebyshev_default(self) -> None:
         """Default (Chebyshev) nodes recover a quadratic exactly."""
-        b = Bezier.interpolate(lambda x: x**2, 3, nodes=None)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes=None)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_chebyshev_explicit(self) -> None:
         """Explicitly requesting 'chebyshev' is the same as default."""
-        b = Bezier.interpolate(lambda x: x**2, 3, nodes="chebyshev")
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes="chebyshev")
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_uniform_nodes(self) -> None:
         """Uniform nodes can also recover polynomials (less stable for high degree)."""
-        b = Bezier.interpolate(lambda x: x**2, 3, nodes="uniform")
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes="uniform")
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
     def test_custom_nodes_array(self) -> None:
         """User-provided custom nodes as a single array."""
         custom = np.array([0.0, 0.5, 1.0])
-        b = Bezier.interpolate(lambda x: x**2, 3, nodes=custom)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes=custom)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
@@ -175,7 +189,67 @@ class TestNodeSelection:
         """User-provided custom nodes as a sequence of arrays (2D)."""
         nodes_x = np.array([0.0, 0.5, 1.0])
         nodes_y = np.array([0.0, 1.0])
-        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 2], nodes=[nodes_x, nodes_y])
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
+            return pts[:, 0] + pts[:, 1]
+
+        b = Bezier.interpolate(func, [3, 2], nodes=[nodes_x, nodes_y])
+        assert b.degree == (2, 1)
+        pts = np.array([[0.5, 0.5]])
+        nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Callable receives PointsLattice
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateCallableLattice:
+    """Tests verifying that the callable receives a PointsLattice."""
+
+    def test_1d_receives_lattice(self) -> None:
+        """1D interpolation passes a PointsLattice to the callable."""
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            assert isinstance(lat, PointsLattice)
+            assert lat.dim == 1
+            return lat.pts_per_dir[0] ** 2
+
+        b = Bezier.interpolate(func, 3)
+        assert b.degree == (2,)
+
+    def test_2d_receives_lattice(self) -> None:
+        """2D interpolation passes a PointsLattice to the callable."""
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            assert isinstance(lat, PointsLattice)
+            assert lat.dim == 2  # noqa: PLR2004
+            pts = lat.get_all_points()
+            return pts[:, 0] + pts[:, 1]
+
+        b = Bezier.interpolate(func, [3, 3])
+        assert b.degree == (2, 2)
+
+    def test_lattice_has_correct_nodes(self) -> None:
+        """The PointsLattice contains the correct node arrays."""
+        custom_nodes = np.array([0.0, 0.5, 1.0])
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            nptest.assert_allclose(lat.pts_per_dir[0], custom_nodes)
+            return lat.pts_per_dir[0]
+
+        Bezier.interpolate(func, 3, nodes=custom_nodes)
+
+    def test_points_lattice_as_nodes(self) -> None:
+        """Passing a PointsLattice as the nodes parameter works."""
+        lattice = PointsLattice([np.array([0.0, 0.5, 1.0]), np.array([0.0, 1.0])])
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
+            return pts[:, 0] + pts[:, 1]
+
+        b = Bezier.interpolate(func, [3, 2], nodes=lattice)
         assert b.degree == (2, 1)
         pts = np.array([[0.5, 0.5]])
         nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
@@ -187,16 +261,23 @@ class TestNodeSelection:
 
 
 class TestDtype:
-    """Tests for dtype propagation."""
+    """Tests for dtype inference."""
 
     def test_float64_default(self) -> None:
-        """Default dtype is float64."""
-        b = Bezier.interpolate(lambda x: x, 2)
+        """Default dtype is float64 when func returns float64."""
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 2)
         assert b.dtype == np.float64
 
-    def test_float32(self) -> None:
-        """Requesting float32 propagates through."""
-        b = Bezier.interpolate(lambda x: x, 2, dtype=np.float32)
+    def test_int_return_promoted_to_float64(self) -> None:
+        """Integer return from func is promoted to float64."""
+        b = Bezier.interpolate(lambda lat: np.ones(len(lat.pts_per_dir[0]), dtype=int), 2)
+        assert b.dtype == np.float64
+
+    def test_fit_infers_from_values(self) -> None:
+        """Bezier.fit infers dtype from the values array."""
+        nodes = np.array([0.0, 1.0], dtype=np.float32)
+        vals = np.array([1.0, 2.0], dtype=np.float32)
+        b = Bezier.fit(vals, nodes)
         assert b.dtype == np.float32
 
 
@@ -211,23 +292,18 @@ class TestInterpolateValidation:
     def test_n_pts_too_small(self) -> None:
         """n_pts < 1 raises ValueError."""
         with pytest.raises(ValueError, match="n_pts.*>= 1"):
-            Bezier.interpolate(lambda x: x, 0)
-
-    def test_non_floating_dtype(self) -> None:
-        """Non-floating dtype raises ValueError."""
-        with pytest.raises(ValueError, match="floating"):
-            Bezier.interpolate(lambda x: x, 3, dtype=np.int32)
+            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 0)
 
     def test_mismatched_nodes_n_pts(self) -> None:
         """Custom nodes with wrong length raises ValueError."""
         with pytest.raises(ValueError, match="does not match"):
-            Bezier.interpolate(lambda x: x, 3, nodes=np.array([0.0, 1.0]))
+            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, nodes=np.array([0.0, 1.0]))
 
     def test_wrong_number_of_node_arrays(self) -> None:
         """Wrong number of node arrays for 2D raises ValueError."""
         with pytest.raises(ValueError, match="Expected 2"):
             Bezier.interpolate(
-                lambda pts: pts[:, 0] + pts[:, 1],
+                lambda lat: lat.get_all_points()[:, 0],
                 [3, 3],
                 nodes=[np.array([0.0, 0.5, 1.0])],
             )
@@ -235,7 +311,7 @@ class TestInterpolateValidation:
     def test_bad_function_output_shape(self) -> None:
         """Function returning wrong shape raises ValueError."""
         with pytest.raises(ValueError, match="Function returned shape"):
-            Bezier.interpolate(lambda x: np.ones((2, 3)), 3)
+            Bezier.interpolate(lambda lat: np.ones((2, 3)), 3)
 
 
 # ---------------------------------------------------------------------------
@@ -248,28 +324,33 @@ class TestInterpolateDegree:
 
     def test_exact_when_degree_equals_n_pts_minus_1(self) -> None:
         """Explicit degree = n_pts - 1 gives the same result as default."""
-        b = Bezier.interpolate(lambda x: x**2, 5, degree=4)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 5, degree=4)
         assert b.degree == (4,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_least_squares_quadratic(self) -> None:
         """Fitting x^2 with degree=2 from 5 sample points recovers it."""
-        b = Bezier.interpolate(lambda x: x**2, 5, degree=2)
+        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 5, degree=2)
         assert b.degree == (2,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
     def test_least_squares_linear(self) -> None:
         """Fitting a linear function with degree=1 from 10 points."""
-        b = Bezier.interpolate(lambda x: 3.0 * x + 1.0, 10, degree=1)
+        b = Bezier.interpolate(lambda lat: 3.0 * lat.pts_per_dir[0] + 1.0, 10, degree=1)
         assert b.degree == (1,)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), [1.0, 2.5, 4.0], atol=1e-12)
 
     def test_2d_least_squares(self) -> None:
         """Fitting x+y with degree=(1,1) from (3,3) samples."""
-        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1, 1])
+
+        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+            pts = lat.get_all_points()
+            return pts[:, 0] + pts[:, 1]
+
+        b = Bezier.interpolate(func, [3, 3], degree=[1, 1])
         assert b.degree == (1, 1)
         pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
         expected = pts[:, 0] + pts[:, 1]
@@ -278,17 +359,17 @@ class TestInterpolateDegree:
     def test_degree_too_large_raises(self) -> None:
         """Degree >= n_pts raises ValueError."""
         with pytest.raises(ValueError, match="must be < n_pts"):
-            Bezier.interpolate(lambda x: x, 3, degree=3)
+            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, degree=3)
 
     def test_degree_negative_raises(self) -> None:
         """Negative degree raises ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            Bezier.interpolate(lambda x: x, 3, degree=-1)
+            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, degree=-1)
 
     def test_degree_length_mismatch_raises(self) -> None:
         """Degree sequence length != n_pts sequence length raises ValueError."""
         with pytest.raises(ValueError, match="entries"):
-            Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1])
+            Bezier.interpolate(lambda lat: lat.get_all_points()[:, 0], [3, 3], degree=[1])
 
 
 # ---------------------------------------------------------------------------
@@ -345,7 +426,7 @@ class TestFit1DVector:
 
 
 # ---------------------------------------------------------------------------
-# Bezier.fit — 2D
+# Bezier.fit — 2D tensor-product
 # ---------------------------------------------------------------------------
 
 
@@ -363,6 +444,18 @@ class TestFit2D:
         pts = np.array([[0.5, 0.5], [0.0, 1.0]])
         expected = pts[:, 0] + pts[:, 1]
         nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-12)
+
+    def test_with_points_lattice(self) -> None:
+        """Fitting bilinear values using a PointsLattice for nodes."""
+        nodes_x = np.array([0.0, 1.0])
+        nodes_y = np.array([0.0, 1.0])
+        lattice = PointsLattice([nodes_x, nodes_y])
+        xx, yy = np.meshgrid(nodes_x, nodes_y, indexing="ij")
+        vals = xx + yy
+        b = Bezier.fit(vals, lattice)
+        assert b.degree == (1, 1)
+        pts = np.array([[0.5, 0.5]])
+        nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +485,100 @@ class TestFitDegree:
 
 
 # ---------------------------------------------------------------------------
-# Bezier.fit — validation
+# Bezier.fit — scattered (non-tensor-product) points
+# ---------------------------------------------------------------------------
+
+
+class TestFitScattered1D:
+    """Tests for 1D scattered fitting."""
+
+    def test_linear_scattered(self) -> None:
+        """Fit a linear from scattered 1D points (presented as 2D array)."""
+        pts = np.array([[0.0], [0.3], [0.7], [1.0]])
+        vals = 2.0 * pts[:, 0] + 1.0
+        b = Bezier.fit(vals, pts, degree=1)
+        assert b.degree == (1,)
+        eval_pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(eval_pts), [1.0, 2.0, 3.0], atol=1e-12)
+
+    def test_quadratic_scattered(self) -> None:
+        """Fit x^2 from scattered 1D points."""
+        pts = np.array([[0.0], [0.2], [0.5], [0.8], [1.0]])
+        vals = pts[:, 0] ** 2
+        b = Bezier.fit(vals, pts, degree=2)
+        assert b.degree == (2,)
+        eval_pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        nptest.assert_allclose(b.evaluate(eval_pts), eval_pts**2, atol=1e-12)
+
+
+class TestFitScattered2D:
+    """Tests for 2D scattered fitting."""
+
+    def test_bilinear_scattered(self) -> None:
+        """Fit x + y from scattered 2D points."""
+        rng = np.random.default_rng(42)
+        pts = rng.random((20, 2))
+        vals = pts[:, 0] + pts[:, 1]
+        b = Bezier.fit(vals, pts, degree=[1, 1])
+        assert b.degree == (1, 1)
+        eval_pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
+        expected = eval_pts[:, 0] + eval_pts[:, 1]
+        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
+
+    def test_biquadratic_scattered(self) -> None:
+        """Fit x^2 + y^2 from scattered 2D points."""
+        rng = np.random.default_rng(123)
+        pts = rng.random((30, 2))
+        vals = pts[:, 0] ** 2 + pts[:, 1] ** 2
+        b = Bezier.fit(vals, pts, degree=[2, 2])
+        assert b.degree == (2, 2)
+        eval_pts = np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])
+        expected = eval_pts[:, 0] ** 2 + eval_pts[:, 1] ** 2
+        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
+
+    def test_vector_scattered(self) -> None:
+        """Fit a vector-valued function from scattered 2D points."""
+        rng = np.random.default_rng(7)
+        pts = rng.random((20, 2))
+        vals = np.stack([pts[:, 0], pts[:, 1], pts[:, 0] + pts[:, 1]], axis=-1)
+        b = Bezier.fit(vals, pts, degree=[1, 1])
+        assert b.degree == (1, 1)
+        nptest.assert_equal(b.rank, 3)
+        eval_pts = np.array([[0.5, 0.5]])
+        expected = np.array([[0.5, 0.5, 1.0]])
+        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
+
+
+class TestFitScatteredValidation:
+    """Validation tests for scattered fitting."""
+
+    def test_degree_required(self) -> None:
+        """Scattered fitting without degree raises ValueError."""
+        pts = np.array([[0.0], [0.5], [1.0]])
+        with pytest.raises(ValueError, match="degree is required"):
+            Bezier.fit(np.array([1.0, 2.0, 3.0]), pts)
+
+    def test_underdetermined(self) -> None:
+        """Too few points for the requested degree raises ValueError."""
+        pts = np.array([[0.0, 0.0], [1.0, 1.0]])
+        with pytest.raises(ValueError, match="Underdetermined"):
+            Bezier.fit(np.array([1.0, 2.0]), pts, degree=[2, 2])
+
+    def test_values_pts_mismatch(self) -> None:
+        """Mismatched number of values and points raises ValueError."""
+        pts = np.array([[0.0], [0.5], [1.0]])
+        with pytest.raises(ValueError, match="entries"):
+            Bezier.fit(np.array([1.0, 2.0]), pts, degree=1)
+
+    def test_degree_dim_mismatch(self) -> None:
+        """Degree length != number of point columns raises ValueError."""
+        pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
+        with pytest.raises(ValueError, match="columns"):
+            Bezier.fit(np.array([1.0, 2.0, 3.0]), pts, degree=[1])
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — validation (tensor-product)
 # ---------------------------------------------------------------------------
 
 
@@ -403,11 +589,6 @@ class TestFitValidation:
         """Node array length != values length raises ValueError."""
         with pytest.raises(ValueError, match="does not match"):
             Bezier.fit(np.array([1.0, 2.0, 3.0]), np.array([0.0, 1.0]))
-
-    def test_non_floating_dtype(self) -> None:
-        """Non-floating dtype raises ValueError."""
-        with pytest.raises(ValueError, match="floating"):
-            Bezier.fit(np.array([1.0, 2.0]), np.array([0.0, 1.0]), dtype=np.int32)
 
     def test_degree_too_large(self) -> None:
         """Degree >= n_pts raises ValueError."""

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -1,0 +1,429 @@
+"""Tests for Bezier.interpolate and the Bernstein interpolation pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.testing as nptest
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+
+# ---------------------------------------------------------------------------
+# 1D scalar interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate1DScalar:
+    """Tests for 1D scalar-valued interpolation."""
+
+    def test_linear(self) -> None:
+        """Interpolating a linear function with 2 points recovers it exactly."""
+        b = Bezier.interpolate(lambda x: 2.0 * x + 1.0, 2)
+        assert b.degree == (1,)
+        assert b.rank == 1
+        pts = np.array([0.0, 0.5, 1.0])
+        vals = b.evaluate(pts)
+        nptest.assert_allclose(vals, [1.0, 2.0, 3.0], atol=1e-14)
+
+    def test_quadratic(self) -> None:
+        """Interpolating x^2 with 3 points recovers it exactly."""
+        b = Bezier.interpolate(lambda x: x**2, 3)
+        assert b.degree == (2,)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        expected = pts**2
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-13)
+
+    def test_cubic(self) -> None:
+        """Interpolating x^3 with 4 points recovers it exactly."""
+        b = Bezier.interpolate(lambda x: x**3, 4)
+        assert b.degree == (3,)
+        pts = np.linspace(0, 1, 10)
+        nptest.assert_allclose(b.evaluate(pts), pts**3, atol=1e-12)
+
+    def test_single_point(self) -> None:
+        """A single interpolation point gives a degree-0 (constant) Bezier."""
+        b = Bezier.interpolate(lambda x: np.full_like(x, 7.0), 1)
+        assert b.degree == (0,)
+        nptest.assert_allclose(b.evaluate(np.array([0.5])), [7.0], atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# 1D vector-valued interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate1DVector:
+    """Tests for 1D vector-valued interpolation (parametric curves)."""
+
+    def test_circle_arc(self) -> None:
+        """Interpolate a quarter-circle parametric curve."""
+
+        def quarter_circle(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+            theta = t * (np.pi / 2.0)
+            return np.stack([np.cos(theta), np.sin(theta)], axis=-1)
+
+        b = Bezier.interpolate(quarter_circle, 8)
+        assert b.degree == (7,)
+        nptest.assert_equal(b.rank, 2)
+
+        # Evaluate at midpoint
+        pts = np.array([0.5])
+        result = b.evaluate(pts)
+        theta = 0.5 * np.pi / 2.0
+        nptest.assert_allclose(result, [[np.cos(theta), np.sin(theta)]], atol=1e-6)
+
+    def test_linear_curve(self) -> None:
+        """A linear vector-valued function is recovered exactly."""
+
+        def line(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+            return np.stack([t, 2.0 * t + 1.0, -t + 3.0], axis=-1)
+
+        b = Bezier.interpolate(line, 2)
+        assert b.degree == (1,)
+        nptest.assert_equal(b.rank, 3)
+        pts = np.array([0.0, 0.5, 1.0])
+        expected = np.array([[0.0, 1.0, 3.0], [0.5, 2.0, 2.5], [1.0, 3.0, 2.0]])
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# 2D scalar interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate2DScalar:
+    """Tests for 2D scalar-valued interpolation."""
+
+    def test_bilinear(self) -> None:
+        """Interpolating a bilinear function with (2,2) points recovers it."""
+        b = Bezier.interpolate(lambda x, y: x + y, [2, 2])
+        assert b.degree == (1, 1)
+        assert b.rank == 1
+        pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]])
+        expected = pts[:, 0] + pts[:, 1]
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-13)
+
+    def test_biquadratic(self) -> None:
+        """Interpolating x^2 + y^2 with (3,3) points."""
+        b = Bezier.interpolate(lambda x, y: x**2 + y**2, [3, 3])
+        assert b.degree == (2, 2)
+        pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
+        expected = pts[:, 0] ** 2 + pts[:, 1] ** 2
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 2D vector-valued interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate2DVector:
+    """Tests for 2D vector-valued interpolation (parametric surfaces)."""
+
+    def test_planar_surface(self) -> None:
+        """A linear vector-valued 2D function is recovered exactly."""
+
+        def plane(
+            x: npt.NDArray[np.floating[Any]], y: npt.NDArray[np.floating[Any]]
+        ) -> npt.NDArray[np.floating[Any]]:
+            return np.stack([x, y, x + y], axis=-1)
+
+        b = Bezier.interpolate(plane, [2, 2])
+        assert b.degree == (1, 1)
+        nptest.assert_equal(b.rank, 3)
+        pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
+        expected = np.array([[0.5, 0.5, 1.0], [0.0, 1.0, 1.0], [1.0, 0.0, 1.0]])
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Node selection
+# ---------------------------------------------------------------------------
+
+
+class TestNodeSelection:
+    """Tests for different node selection strategies."""
+
+    def test_chebyshev_default(self) -> None:
+        """Default (Chebyshev) nodes recover a quadratic exactly."""
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes=None)
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
+
+    def test_chebyshev_explicit(self) -> None:
+        """Explicitly requesting 'chebyshev' is the same as default."""
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes="chebyshev")
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
+
+    def test_uniform_nodes(self) -> None:
+        """Uniform nodes can also recover polynomials (less stable for high degree)."""
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes="uniform")
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
+
+    def test_custom_nodes_array(self) -> None:
+        """User-provided custom nodes as a single array."""
+        custom = np.array([0.0, 0.5, 1.0])
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes=custom)
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
+
+    def test_custom_nodes_sequence(self) -> None:
+        """User-provided custom nodes as a sequence of arrays (2D)."""
+        nodes_x = np.array([0.0, 0.5, 1.0])
+        nodes_y = np.array([0.0, 1.0])
+        b = Bezier.interpolate(lambda x, y: x + y, [3, 2], nodes=[nodes_x, nodes_y])
+        assert b.degree == (2, 1)
+        pts = np.array([[0.5, 0.5]])
+        nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# dtype handling
+# ---------------------------------------------------------------------------
+
+
+class TestDtype:
+    """Tests for dtype propagation."""
+
+    def test_float64_default(self) -> None:
+        """Default dtype is float64."""
+        b = Bezier.interpolate(lambda x: x, 2)
+        assert b.dtype == np.float64
+
+    def test_float32(self) -> None:
+        """Requesting float32 propagates through."""
+        b = Bezier.interpolate(lambda x: x, 2, dtype=np.float32)
+        assert b.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateValidation:
+    """Input validation tests."""
+
+    def test_n_pts_too_small(self) -> None:
+        """n_pts < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="n_pts.*>= 1"):
+            Bezier.interpolate(lambda x: x, 0)
+
+    def test_non_floating_dtype(self) -> None:
+        """Non-floating dtype raises ValueError."""
+        with pytest.raises(ValueError, match="floating"):
+            Bezier.interpolate(lambda x: x, 3, dtype=np.int32)
+
+    def test_mismatched_nodes_n_pts(self) -> None:
+        """Custom nodes with wrong length raises ValueError."""
+        with pytest.raises(ValueError, match="does not match"):
+            Bezier.interpolate(lambda x: x, 3, nodes=np.array([0.0, 1.0]))
+
+    def test_wrong_number_of_node_arrays(self) -> None:
+        """Wrong number of node arrays for 2D raises ValueError."""
+        with pytest.raises(ValueError, match="Expected 2"):
+            Bezier.interpolate(
+                lambda x, y: x + y,
+                [3, 3],
+                nodes=[np.array([0.0, 0.5, 1.0])],
+            )
+
+    def test_bad_function_output_shape(self) -> None:
+        """Function returning wrong shape raises ValueError."""
+        with pytest.raises(ValueError, match="Function returned shape"):
+            Bezier.interpolate(lambda x: np.ones((2, 3)), 3)
+
+
+# ---------------------------------------------------------------------------
+# Degree parameter (least-squares approximation)
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateDegree:
+    """Tests for the optional degree parameter on Bezier.interpolate."""
+
+    def test_exact_when_degree_equals_n_pts_minus_1(self) -> None:
+        """Explicit degree = n_pts - 1 gives the same result as default."""
+        b = Bezier.interpolate(lambda x: x**2, 5, degree=4)
+        assert b.degree == (4,)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
+
+    def test_least_squares_quadratic(self) -> None:
+        """Fitting x^2 with degree=2 from 5 sample points recovers it."""
+        b = Bezier.interpolate(lambda x: x**2, 5, degree=2)
+        assert b.degree == (2,)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
+
+    def test_least_squares_linear(self) -> None:
+        """Fitting a linear function with degree=1 from 10 points."""
+        b = Bezier.interpolate(lambda x: 3.0 * x + 1.0, 10, degree=1)
+        assert b.degree == (1,)
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), [1.0, 2.5, 4.0], atol=1e-12)
+
+    def test_2d_least_squares(self) -> None:
+        """Fitting x+y with degree=(1,1) from (3,3) samples."""
+        b = Bezier.interpolate(lambda x, y: x + y, [3, 3], degree=[1, 1])
+        assert b.degree == (1, 1)
+        pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
+        expected = pts[:, 0] + pts[:, 1]
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-12)
+
+    def test_degree_too_large_raises(self) -> None:
+        """Degree >= n_pts raises ValueError."""
+        with pytest.raises(ValueError, match="must be < n_pts"):
+            Bezier.interpolate(lambda x: x, 3, degree=3)
+
+    def test_degree_negative_raises(self) -> None:
+        """Negative degree raises ValueError."""
+        with pytest.raises(ValueError, match="must be >= 0"):
+            Bezier.interpolate(lambda x: x, 3, degree=-1)
+
+    def test_degree_length_mismatch_raises(self) -> None:
+        """Degree sequence length != n_pts sequence length raises ValueError."""
+        with pytest.raises(ValueError, match="entries"):
+            Bezier.interpolate(lambda x, y: x + y, [3, 3], degree=[1])
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — 1D scalar
+# ---------------------------------------------------------------------------
+
+
+class TestFit1DScalar:
+    """Tests for 1D scalar-valued fitting from pre-evaluated values."""
+
+    def test_exact_linear(self) -> None:
+        """Fitting 2 values at nodes recovers a linear Bezier."""
+        nodes = np.array([0.0, 1.0])
+        vals = 2.0 * nodes + 1.0
+        b = Bezier.fit(vals, nodes)
+        assert b.degree == (1,)
+        pts = np.array([0.0, 0.5, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), [1.0, 2.0, 3.0], atol=1e-13)
+
+    def test_exact_quadratic(self) -> None:
+        """Fitting 3 values recovers a quadratic."""
+        nodes = np.array([0.0, 0.5, 1.0])
+        vals = nodes**2
+        b = Bezier.fit(vals, nodes)
+        assert b.degree == (2,)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
+
+    def test_single_value(self) -> None:
+        """Fitting a single value gives a degree-0 Bezier."""
+        b = Bezier.fit(np.array([7.0]), np.array([0.5]))
+        assert b.degree == (0,)
+        nptest.assert_allclose(b.evaluate(np.array([0.5])), [7.0], atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — 1D vector
+# ---------------------------------------------------------------------------
+
+
+class TestFit1DVector:
+    """Tests for 1D vector-valued fitting."""
+
+    def test_linear_vector(self) -> None:
+        """Fitting a linear vector-valued function."""
+        nodes = np.array([0.0, 1.0])
+        vals = np.stack([nodes, 2.0 * nodes + 1.0], axis=-1)
+        b = Bezier.fit(vals, nodes)
+        assert b.degree == (1,)
+        nptest.assert_equal(b.rank, 2)
+        pts = np.array([0.0, 0.5, 1.0])
+        expected = np.array([[0.0, 1.0], [0.5, 2.0], [1.0, 3.0]])
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — 2D
+# ---------------------------------------------------------------------------
+
+
+class TestFit2D:
+    """Tests for 2D fitting from pre-evaluated values."""
+
+    def test_bilinear(self) -> None:
+        """Fitting bilinear values on a 2x2 grid."""
+        nodes_x = np.array([0.0, 1.0])
+        nodes_y = np.array([0.0, 1.0])
+        xx, yy = np.meshgrid(nodes_x, nodes_y, indexing="ij")
+        vals = xx + yy
+        b = Bezier.fit(vals, [nodes_x, nodes_y])
+        assert b.degree == (1, 1)
+        pts = np.array([[0.5, 0.5], [0.0, 1.0]])
+        expected = pts[:, 0] + pts[:, 1]
+        nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — degree (least-squares)
+# ---------------------------------------------------------------------------
+
+
+class TestFitDegree:
+    """Tests for the degree parameter on Bezier.fit."""
+
+    def test_least_squares_quadratic(self) -> None:
+        """Fitting x^2 from 5 points with degree=2."""
+        nodes = np.linspace(0.0, 1.0, 5)
+        vals = nodes**2
+        b = Bezier.fit(vals, nodes, degree=2)
+        assert b.degree == (2,)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
+
+    def test_least_squares_constant(self) -> None:
+        """Fitting a constant from 5 points with degree=0."""
+        nodes = np.linspace(0.0, 1.0, 5)
+        vals = np.full(5, 3.14)
+        b = Bezier.fit(vals, nodes, degree=0)
+        assert b.degree == (0,)
+        nptest.assert_allclose(b.evaluate(np.array([0.5])), [3.14], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Bezier.fit — validation
+# ---------------------------------------------------------------------------
+
+
+class TestFitValidation:
+    """Input validation tests for Bezier.fit."""
+
+    def test_mismatched_nodes_values(self) -> None:
+        """Node array length != values length raises ValueError."""
+        with pytest.raises(ValueError, match="does not match"):
+            Bezier.fit(np.array([1.0, 2.0, 3.0]), np.array([0.0, 1.0]))
+
+    def test_non_floating_dtype(self) -> None:
+        """Non-floating dtype raises ValueError."""
+        with pytest.raises(ValueError, match="floating"):
+            Bezier.fit(np.array([1.0, 2.0]), np.array([0.0, 1.0]), dtype=np.int32)
+
+    def test_degree_too_large(self) -> None:
+        """Degree >= n_pts raises ValueError."""
+        with pytest.raises(ValueError, match="must be < n_pts"):
+            Bezier.fit(np.array([1.0, 2.0]), np.array([0.0, 1.0]), degree=2)
+
+    def test_node_arrays_ndim_mismatch(self) -> None:
+        """Node arrays implying different ndim than values raises ValueError."""
+        vals = np.ones((3, 3))
+        nodes_1d = np.array([0.0, 0.5, 1.0])
+        # 3 node arrays implies 3D, but values is 2D
+        with pytest.raises(ValueError, match="dimensions"):
+            Bezier.fit(vals, [nodes_1d, nodes_1d, nodes_1d])
+
+    def test_values_wrong_ndim(self) -> None:
+        """Values with wrong number of dims raises ValueError."""
+        with pytest.raises(ValueError, match="dimensions"):
+            Bezier.fit(np.ones((2, 3, 4)), np.array([0.0, 1.0]))

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -99,7 +99,7 @@ class TestInterpolate2DScalar:
 
     def test_bilinear(self) -> None:
         """Interpolating a bilinear function with (2,2) points recovers it."""
-        b = Bezier.interpolate(lambda x, y: x + y, [2, 2])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [2, 2])
         assert b.degree == (1, 1)
         assert b.rank == 1
         pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]])
@@ -108,7 +108,7 @@ class TestInterpolate2DScalar:
 
     def test_biquadratic(self) -> None:
         """Interpolating x^2 + y^2 with (3,3) points."""
-        b = Bezier.interpolate(lambda x, y: x**2 + y**2, [3, 3])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] ** 2 + pts[:, 1] ** 2, [3, 3])
         assert b.degree == (2, 2)
         pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
         expected = pts[:, 0] ** 2 + pts[:, 1] ** 2
@@ -126,9 +126,8 @@ class TestInterpolate2DVector:
     def test_planar_surface(self) -> None:
         """A linear vector-valued 2D function is recovered exactly."""
 
-        def plane(
-            x: npt.NDArray[np.floating[Any]], y: npt.NDArray[np.floating[Any]]
-        ) -> npt.NDArray[np.floating[Any]]:
+        def plane(pts: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+            x, y = pts[:, 0], pts[:, 1]
             return np.stack([x, y, x + y], axis=-1)
 
         b = Bezier.interpolate(plane, [2, 2])
@@ -176,7 +175,7 @@ class TestNodeSelection:
         """User-provided custom nodes as a sequence of arrays (2D)."""
         nodes_x = np.array([0.0, 0.5, 1.0])
         nodes_y = np.array([0.0, 1.0])
-        b = Bezier.interpolate(lambda x, y: x + y, [3, 2], nodes=[nodes_x, nodes_y])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 2], nodes=[nodes_x, nodes_y])
         assert b.degree == (2, 1)
         pts = np.array([[0.5, 0.5]])
         nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
@@ -228,7 +227,7 @@ class TestInterpolateValidation:
         """Wrong number of node arrays for 2D raises ValueError."""
         with pytest.raises(ValueError, match="Expected 2"):
             Bezier.interpolate(
-                lambda x, y: x + y,
+                lambda pts: pts[:, 0] + pts[:, 1],
                 [3, 3],
                 nodes=[np.array([0.0, 0.5, 1.0])],
             )
@@ -270,7 +269,7 @@ class TestInterpolateDegree:
 
     def test_2d_least_squares(self) -> None:
         """Fitting x+y with degree=(1,1) from (3,3) samples."""
-        b = Bezier.interpolate(lambda x, y: x + y, [3, 3], degree=[1, 1])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1, 1])
         assert b.degree == (1, 1)
         pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
         expected = pts[:, 0] + pts[:, 1]
@@ -289,7 +288,7 @@ class TestInterpolateDegree:
     def test_degree_length_mismatch_raises(self) -> None:
         """Degree sequence length != n_pts sequence length raises ValueError."""
         with pytest.raises(ValueError, match="entries"):
-            Bezier.interpolate(lambda x, y: x + y, [3, 3], degree=[1])
+            Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `Bezier.interpolate` classmethod: construct a Bézier from a callable function via SVD-based Bernstein interpolation
- Add `Bezier.fit` classmethod: construct a Bézier from pre-evaluated sample values at known nodes
- Support optional `degree` parameter for least-squares approximation (rectangular Vandermonde) when `degree < n_pts - 1`
- Support 1D/ND tensor-product, scalar/vector outputs, Chebyshev/uniform/custom node selection

## Test plan
- [x] 40 tests covering interpolation (1D/2D, scalar/vector), fitting, degree parameter, node selection, dtype, and validation
- [x] ruff, mypy, and Sphinx docs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)