### PR TITLE
feat(bezier): add resultant, discriminant, and minimize_degree

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -11,7 +11,11 @@ from numpy import typing as npt
 from .._transform_control_points import _apply_affine_to_control_points
 from ._bezier_collapse import _collapse_along_axis
 from ._bezier_compose import _compose_bezier
-from ._bezier_degree import _degree_elevate_bezier, _degree_reduce_bezier
+from ._bezier_degree import (
+    _degree_elevate_bezier,
+    _degree_reduce_bezier,
+    _minimize_degree_bezier,
+)
 from ._bezier_derivative import _derivative_bezier
 from ._bezier_eval import _evaluate_bezier, _evaluate_bezier_deriv
 from ._bezier_interpolate import _fit_bezier, _interpolate_bezier
@@ -358,6 +362,33 @@ class Bezier:
                 )
 
         return _degree_reduce_bezier(self, decrements)
+
+    def minimize_degree(self, tol: float | None = None) -> Bezier:
+        """Find the lowest degree that preserves accuracy within tolerance.
+
+        Iterates over each parametric direction and repeatedly tries to
+        reduce the degree by 1.  A reduction is accepted when the
+        round-trip (reduce then elevate) relative L2 error stays below
+        ``tol``.  For vector-valued Bézier, all rank components are
+        checked simultaneously.
+
+        Args:
+            tol (float | None): Relative tolerance for accepting a degree
+                reduction.  If *None*, uses a default based on machine
+                epsilon (``1e3 * eps``).
+
+        Returns:
+            Bezier: A new Bézier with the lowest degree that preserves
+            accuracy.  If no reduction is possible, returns a copy.
+
+        Example:
+            >>> import numpy as np
+            >>> b = Bezier(np.array([3.0, 3.0, 3.0, 1.0]).reshape(4, 1))
+            >>> b.degree
+            (3,)
+            >>> b_min = b.minimize_degree()
+        """
+        return _minimize_degree_bezier(self, tol)
 
     # ------------------------------------------------------------------
     # Multiply

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -826,42 +826,37 @@ class Bezier:
         return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
 
     @classmethod
-    def interpolate(
+    def interpolate(  # noqa: PLR0913
         cls,
-        func: Callable[[PointsLattice], npt.ArrayLike],
+        func: Callable[..., npt.ArrayLike],
         n_pts: int | Sequence[int],
         *,
         degree: int | Sequence[int] | None = None,
         nodes: (
             Literal["chebyshev", "uniform"]
-            | PointsLattice
             | npt.NDArray[np.floating[Any]]
             | Sequence[npt.NDArray[np.floating[Any]]]
             | None
         ) = None,
+        dtype: npt.DTypeLike = np.float64,
         tol: float | None = None,
     ) -> Bezier:
         """Interpolate a callable function into a Bézier in Bernstein form.
 
         Evaluates ``func`` on a tensor-product grid of interpolation nodes
-        and recovers the Bernstein coefficients by solving the Bernstein
-        Vandermonde system via truncated SVD pseudo-inverse.  The SVD
-        regularises the solve, which is important because the Bernstein
-        Vandermonde matrix becomes ill-conditioned at high polynomial
-        degree.
+        and recovers the Bernstein coefficients via truncated SVD.
 
         The parametric dimension is determined by the length of ``n_pts``
         (when given as a sequence) or defaults to 1 (when a scalar ``int``).
 
-        The output dtype is inferred from the return value of ``func``.
-
         Args:
-            func (Callable[[PointsLattice], npt.ArrayLike]): Function to
-                interpolate.  Called as ``func(lattice)`` where ``lattice``
-                is a :class:`~pantr.quad.PointsLattice` representing the
-                tensor-product sampling grid.  Must return an array of shape
-                ``(n_total,)`` for scalar or ``(n_total, rank)`` for
-                vector-valued functions, where ``n_total = prod(n_pts)``.
+            func (Callable[..., npt.ArrayLike]): Function to interpolate.
+                Called as ``func(pts)`` where ``pts`` is a NumPy array of
+                parametric coordinates: shape ``(n_total,)`` for 1D or
+                ``(n_total, dim)`` for multi-dimensional (matching the
+                convention of :meth:`evaluate`).  Must return an array of
+                shape ``(n_total,)`` for scalar or ``(n_total, rank)`` for
+                vector-valued functions.
             n_pts (int | Sequence[int]): Number of sample points per
                 parametric direction.  A single ``int`` gives a 1D Bézier.
             degree (int | Sequence[int] | None): Polynomial degree per
@@ -874,17 +869,11 @@ class Bezier:
                 - ``None`` or ``"chebyshev"`` (default): modified
                   Chebyshev-Lobatto nodes on [0, 1].
                 - ``"uniform"``: equispaced nodes on [0, 1].
-                - A :class:`~pantr.quad.PointsLattice`: custom
-                  tensor-product grid.
                 - A 1D ``ndarray``: custom nodes broadcast to all directions.
-                - A sequence of 1D ``ndarray`` values: per-direction custom
-                  nodes.
-            tol (float | None): Truncation tolerance for the SVD
-                pseudo-inverse.  Singular values below
-                ``tol * sigma_max`` are treated as zero, which
-                regularises the ill-conditioned Bernstein Vandermonde
-                matrix at high degree.  If *None*, defaults to
-                ``100 * machine_epsilon``.
+                - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
+            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+            tol (float | None): SVD truncation tolerance. If *None*, uses a
+                default based on machine epsilon.
 
         Returns:
             Bezier: A non-rational Bézier whose evaluation approximates
@@ -897,69 +886,49 @@ class Bezier:
 
         Example:
             >>> import numpy as np
-            >>> b = Bezier.interpolate(
-            ...     lambda lat: lat.get_all_points()[:, 0] ** 2, [5]
-            ... )
+            >>> b = Bezier.interpolate(lambda x: x**2, 5)
             >>> b.degree
             (4,)
         """
-        return _interpolate_bezier(func, n_pts, degree=degree, nodes=nodes, tol=tol)
+        return _interpolate_bezier(func, n_pts, degree=degree, nodes=nodes, dtype=dtype, tol=tol)
 
     @classmethod
     def fit(
         cls,
         values: npt.ArrayLike,
-        nodes: (
-            PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
-        ),
+        nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
         *,
         degree: int | Sequence[int] | None = None,
+        dtype: npt.DTypeLike = np.float64,
         tol: float | None = None,
     ) -> Bezier:
         """Construct a Bézier from pre-evaluated sample values at known nodes.
 
-        Recovers the Bernstein coefficients by solving the Bernstein
-        Vandermonde system via truncated SVD pseudo-inverse, which
-        regularises the ill-conditioned Vandermonde at high degree.
-
-        The output dtype is inferred from *values*.
-
-        Supports two point layouts:
-
-        - **Tensor-product** (a :class:`~pantr.quad.PointsLattice`, a single
-          1D array, or a sequence of 1D arrays): ``values`` must have shape
-          ``(*n_pts_per_dir)`` (scalar) or ``(*n_pts_per_dir, rank)``
-          (vector).
-        - **Scattered** (a 2D ``ndarray`` of shape ``(n_pts, dim)``):
-          ``values`` must have shape ``(n_pts,)`` (scalar) or
-          ``(n_pts, rank)`` (vector).  ``degree`` is required.
+        Given function values on a tensor-product grid of nodes, recovers the
+        Bernstein coefficients via truncated SVD.
 
         Args:
-            values (npt.ArrayLike): Sample values at the nodes.
-            nodes: Interpolation nodes.
-
-                - A :class:`~pantr.quad.PointsLattice`: tensor-product grid.
-                - A 1D ``ndarray``: 1D tensor-product (single direction).
-                - A sequence of 1D ``ndarray`` values: N-D tensor-product.
-                - A 2D ``ndarray`` of shape ``(n_pts, dim)``: scattered
-                  points.
+            values (npt.ArrayLike): Sample values on the tensor-product grid.
+                Shape ``(*n_pts_per_dir)`` for scalar or
+                ``(*n_pts_per_dir, rank)`` for vector-valued.
+            nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
+                A single 1D array for 1D fitting, or a sequence of 1D arrays
+                (one per parametric direction) for N-D.
             degree (int | Sequence[int] | None): Polynomial degree per
-                direction.  Required for scattered nodes.  If *None*
-                (default) for tensor-product nodes, ``degree = n_pts - 1``
-                (exact interpolation).
-            tol (float | None): Truncation tolerance for the SVD
-                pseudo-inverse.  Singular values below
-                ``tol * sigma_max`` are treated as zero, which
-                regularises the ill-conditioned Bernstein Vandermonde
-                matrix at high degree.  If *None*, defaults to
-                ``100 * machine_epsilon``.
+                direction.  If *None* (default), ``degree = n_pts - 1``
+                (exact interpolation).  If provided, must satisfy
+                ``degree < n_pts`` in each direction; the result is a
+                least-squares approximation.
+            dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+            tol (float | None): SVD truncation tolerance. If *None*, uses a
+                default based on machine epsilon.
 
         Returns:
             Bezier: A non-rational Bézier.
 
         Raises:
-            ValueError: If *nodes* are inconsistent with *values*, *degree*
-                is invalid, or *degree* is missing for scattered nodes.
+            ValueError: If *nodes* lengths are inconsistent with *values*
+                shape, or *degree* >= *n_pts* in any direction.
 
         Example:
             >>> import numpy as np
@@ -969,7 +938,7 @@ class Bezier:
             >>> b.degree
             (2,)
         """
-        return _fit_bezier(values, nodes, degree=degree, tol=tol)
+        return _fit_bezier(values, nodes, degree=degree, dtype=dtype, tol=tol)
 
     @classmethod
     def from_bspline(cls, bspline: Bspline, *, copy: bool = True) -> Bezier:

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -1,14 +1,16 @@
-"""Bézier degree elevation and reduction.
+"""Bézier degree elevation, reduction, and minimization.
 
 This module provides :func:`_degree_elevate_bezier`, which raises the polynomial
 degree of a Bézier in one or more parametric directions while preserving the
-same geometric mapping, and :func:`_degree_reduce_bezier`, which computes a
-least-squares degree-reduced approximation.
+same geometric mapping, :func:`_degree_reduce_bezier`, which computes a
+least-squares degree-reduced approximation, and :func:`_minimize_degree_bezier`,
+which automatically finds the lowest degree that preserves accuracy.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import math
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -17,6 +19,9 @@ from ._bezier_core import _degree_elevate_bezier_1d_core, _degree_reduce_bezier_
 
 if TYPE_CHECKING:
     from . import Bezier
+
+_AUTO_REDUCTION_TOL_FACTOR: float = 1.0e3
+"""Factor multiplied by machine epsilon for automatic degree reduction."""
 
 
 def _degree_elevate_bezier(
@@ -127,3 +132,149 @@ def _degree_reduce_bezier(
         degrees = (*degrees[:d], p - dec, *degrees[d + 1 :])
 
     return BezierCls(ctrl, is_rational=bezier.is_rational)
+
+
+def _squared_l2_norm(
+    coeffs: npt.NDArray[np.floating[Any]],
+) -> float:
+    r"""Compute the squared L2 norm of a Bernstein polynomial.
+
+    Uses the Bernstein inner product formula:
+
+    .. math::
+
+        \int_0^1 B_{i,n}(x) B_{j,n}(x)\,dx
+        = \frac{1}{2n+1} \frac{\binom{n}{i} \binom{n}{j}}{\binom{2n}{i+j}}
+
+    extended to tensor products for multivariate polynomials.
+
+    Args:
+        coeffs (npt.NDArray[np.floating[Any]]): Bernstein coefficients
+            (any shape).
+
+    Returns:
+        float: The squared L2 norm ``||p||_2^2``.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    ndim = coeffs.ndim
+    shape = coeffs.shape
+
+    # Precompute binomial rows and Gram factors per dimension
+    binom_rows = []
+    binom_double = []
+    for d in range(ndim):
+        n = shape[d] - 1
+        brow = np.array([math.comb(n, i) for i in range(n + 1)], dtype=np.float64)
+        bdbl = np.array([math.comb(2 * n, k) for k in range(2 * n + 1)], dtype=np.float64)
+        binom_rows.append(brow)
+        binom_double.append(bdbl)
+
+    # Flatten and compute all pairwise products with Gram weights
+    flat = coeffs.ravel().astype(np.float64)
+    indices = np.array(np.unravel_index(np.arange(flat.size), shape)).T  # (size, ndim)
+
+    # For each pair (i, j): gram_weight = product over dims of binom(n_d, i_d)*binom(n_d, j_d) /
+    #                                      binom(2*n_d, i_d + j_d)
+    # This is O(size^2) but polynomials are small in practice.
+    delta = 0.0
+    for idx_i in range(flat.size):
+        for idx_j in range(flat.size):
+            g = 1.0
+            for d in range(ndim):
+                ii = indices[idx_i, d]
+                jj = indices[idx_j, d]
+                g *= (binom_rows[d][ii] * binom_rows[d][jj]) / binom_double[d][ii + jj]
+            delta += flat[idx_i] * flat[idx_j] * g
+
+    for d in range(ndim):
+        delta /= 2.0 * shape[d] - 1.0
+
+    return abs(delta)
+
+
+def _minimize_degree_bezier(
+    bezier: Bezier,
+    tol: float | None = None,
+) -> Bezier:
+    """Automatically reduce the degree of a Bézier while maintaining accuracy.
+
+    Iterates over each parametric direction and repeatedly tries to reduce
+    the degree by 1.  A reduction is accepted when the round-trip
+    (reduce then elevate) relative L2 error stays below ``tol``.  For
+    vector-valued Bézier, all rank components are checked simultaneously.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier to simplify.
+        tol (float | None): Relative tolerance for accepting a degree
+            reduction.  If *None*, uses
+            :data:`_AUTO_REDUCTION_TOL_FACTOR` ``* eps``.
+
+    Returns:
+        ~pantr.bezier.Bezier: A new Bézier with the lowest degree that
+        preserves accuracy within ``tol``.  If no reduction is possible,
+        returns a copy of the input.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    ctrl: npt.NDArray[np.floating[Any]] = bezier.control_points  # (*orders, rank)
+    n_param = bezier.dim
+    eps = float(np.finfo(ctrl.dtype).eps)
+    if tol is None:
+        tol = _AUTO_REDUCTION_TOL_FACTOR * eps
+
+    if tol <= 0.0:
+        return BezierCls(ctrl.copy(), is_rational=bezier.is_rational)
+
+    result = ctrl
+    changed = False
+
+    for dim in range(n_param):
+        while result.shape[dim] >= 2:  # noqa: PLR2004
+            degree = result.shape[dim] - 1
+
+            # Reduce all rank components together along this dimension
+            moved = np.moveaxis(result, dim, 0)
+            shape_after = moved.shape
+            flat = moved.reshape(shape_after[0], -1)
+            if not flat.flags.c_contiguous:
+                flat = np.ascontiguousarray(flat)
+            reduced_flat = _degree_reduce_bezier_1d_core(degree, flat, 1)
+            reduced = np.moveaxis(
+                reduced_flat.reshape(reduced_flat.shape[0], *shape_after[1:]), 0, dim
+            )
+
+            # Elevate back to original shape for error check
+            moved_r = np.moveaxis(reduced, dim, 0)
+            shape_r = moved_r.shape
+            flat_r = moved_r.reshape(shape_r[0], -1)
+            if not flat_r.flags.c_contiguous:
+                flat_r = np.ascontiguousarray(flat_r)
+            elevated_flat = _degree_elevate_bezier_1d_core(degree - 1, flat_r, 1)
+            elevated = np.moveaxis(
+                elevated_flat.reshape(elevated_flat.shape[0], *shape_r[1:]), 0, dim
+            )
+
+            # Check L2 error summed across all rank components
+            diff = elevated - result
+            diff_norm = sum(_squared_l2_norm(diff[..., r]) for r in range(result.shape[-1]))
+            orig_norm = sum(_squared_l2_norm(result[..., r]) for r in range(result.shape[-1]))
+
+            if orig_norm > 0.0:
+                rel_error = math.sqrt(abs(diff_norm)) / math.sqrt(abs(orig_norm))
+            else:
+                rel_error = math.sqrt(abs(diff_norm))
+
+            if rel_error < tol:
+                result = reduced
+                changed = True
+            else:
+                break
+
+    if not changed:
+        return BezierCls(ctrl.copy(), is_rational=bezier.is_rational)
+    return BezierCls(result, is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -84,6 +84,38 @@ def _derivative_keep_degree_ctrl_1d(
     return result
 
 
+def _derivative_ctrl_nd(
+    coeffs: npt.NDArray[np.float32 | np.float64],
+    dim: int,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Compute the partial derivative of an N-D coefficient array along one axis.
+
+    Applies :func:`_derivative_ctrl_1d` along dimension ``dim`` using the
+    moveaxis/reshape/restore pattern, reducing the size in that dimension
+    by 1.
+
+    Args:
+        coeffs (npt.NDArray[np.float32 | np.float64]): Coefficient array with
+            shape ``(n_0, ..., n_{N-1})``.  ``n_dim >= 2``.
+        dim (int): Direction to differentiate.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Derivative coefficients with shape
+        ``(n_0, ..., n_dim - 1, ..., n_{N-1})``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_derivative_bezier` instead.
+    """
+    degree = coeffs.shape[dim] - 1
+    moved = np.moveaxis(coeffs, dim, 0)
+    orig_shape = moved.shape
+    flat = moved.reshape(orig_shape[0], -1)
+    result = _derivative_ctrl_1d(degree, flat)
+    new_shape = (result.shape[0], *orig_shape[1:])
+    return np.moveaxis(result.reshape(new_shape), 0, dim)
+
+
 def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
     """Compute the partial derivative of a non-rational Bézier.
 
@@ -104,24 +136,7 @@ def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
-    p = bezier.degree[direction]
-    ctrl = bezier.control_points
-
-    # Move target direction to axis 0, flatten the rest.
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d = moved.reshape(orig_shape[0], -1)
-
-    if not pts_2d.flags.c_contiguous:
-        pts_2d = np.ascontiguousarray(pts_2d)
-
-    new_pts_2d = _derivative_ctrl_1d(p, pts_2d)
-
-    # Restore shape and move axis back.
-    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-    new_moved = new_pts_2d.reshape(new_shape)
-    new_ctrl = np.moveaxis(new_moved, 0, direction)
-
+    new_ctrl = _derivative_ctrl_nd(bezier.control_points, direction)
     return BezierCls(new_ctrl, is_rational=False)
 
 

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -1,19 +1,15 @@
 """Bernstein interpolation and fitting: construct a Bézier from function samples or values.
 
 Provides :func:`_interpolate_bezier` (callable-based) and :func:`_fit_bezier`
-(pre-evaluated values), which recover the Bernstein coefficients from the
-Bernstein Vandermonde system.
+(pre-evaluated values), which recover the Bernstein coefficients via truncated
+SVD of the Bernstein Vandermonde matrix.
 
-The Bernstein Vandermonde matrix becomes increasingly ill-conditioned as the
-polynomial degree grows, making a direct solve numerically unstable.  To handle
-this, all solvers in this module use a **truncated SVD** pseudo-inverse:
-singular values smaller than ``tol * sigma_max`` are zeroed out, which
-regularises the inversion and yields robust results even at high degree.
+Supporting utilities (used internally and by the resultant pipeline):
 
-Both functions support **tensor-product** grids (represented as a
-:class:`~pantr.quad.PointsLattice` or a sequence of 1D node arrays) and
-**scattered** point sets (represented as a 2D array of shape
-``(n_pts, dim)``).
+- :func:`_bernstein_vandermonde_svd` — SVD of the Bernstein Vandermonde
+  matrix at modified Chebyshev nodes.
+- :func:`_bernstein_interpolate` — Tensor-product SVD-based interpolation
+  from values at modified Chebyshev nodes to N-D Bernstein coefficients.
 """
 
 from __future__ import annotations
@@ -24,110 +20,101 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import numpy.typing as npt
 
-from ..quad import PointsLattice, get_modified_chebyshev_nodes_1d
+from ..quad import get_modified_chebyshev_nodes_1d
 
 if TYPE_CHECKING:
     from . import Bezier
 
+_SVD_TOL_FACTOR: float = 100.0
+"""Factor multiplied by machine epsilon for SVD truncation tolerance."""
 
-def _truncated_svd_pinv(
-    U: npt.NDArray[np.floating[Any]],
-    sigma: npt.NDArray[np.floating[Any]],
-    Vt: npt.NDArray[np.floating[Any]],
-    tol: float | None,
-    dtype: np.dtype[np.floating[Any]],
+
+def _bernstein_vandermonde_svd(
+    n: int,
+    dtype: npt.DTypeLike = np.float64,
+) -> tuple[
+    npt.NDArray[np.floating[Any]],
+    npt.NDArray[np.floating[Any]],
+    npt.NDArray[np.floating[Any]],
+]:
+    """Compute the SVD of the Bernstein Vandermonde matrix at modified Chebyshev nodes.
+
+    The Vandermonde matrix ``V`` has entries ``V[i, j] = B_{j,n-1}(x_i)``
+    where ``x_i`` are the modified Chebyshev nodes and ``B_{j,n-1}`` is the
+    ``j``-th Bernstein basis function of degree ``n - 1``.
+
+    Args:
+        n (int): Number of nodes/coefficients (degree + 1). Must be >= 1.
+        dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+
+    Returns:
+        tuple[npt.NDArray, npt.NDArray, npt.NDArray]: ``(U, sigma, Vt)`` where
+        ``V = U @ diag(sigma) @ Vt``.
+    """
+    # Deferred to avoid import-time Numba JIT that would race with _async_warmup.
+    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
+
+    nodes = get_modified_chebyshev_nodes_1d(max(n, 2), dtype)[:n]
+    V = np.empty((n, n), dtype=dtype)
+    _tabulate_Bernstein_basis_1D_core(np.int32(n - 1), nodes, V)
+    U, sigma, Vt = np.linalg.svd(V, full_matrices=True)
+    return U, sigma, Vt
+
+
+def _bernstein_interpolate(
+    f: npt.NDArray[np.floating[Any]],
+    tol: float | None = None,
 ) -> npt.NDArray[np.floating[Any]]:
-    """Compute the truncated SVD pseudo-inverse from precomputed SVD factors.
+    """Interpolate tensor-product values at modified Chebyshev nodes to Bernstein coefficients.
 
-    Singular values below ``tol * sigma_max`` are zeroed out, which
-    regularises the inversion.
-
-    Args:
-        U (npt.NDArray[np.floating[Any]]): Left singular vectors.
-        sigma (npt.NDArray[np.floating[Any]]): Singular values.
-        Vt (npt.NDArray[np.floating[Any]]): Right singular vectors (transposed).
-        tol (float | None): Truncation tolerance relative to the largest
-            singular value.  If *None*, defaults to ``100 * eps``.
-        dtype (np.dtype): Floating dtype used to determine machine epsilon.
-
-    Returns:
-        npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix.
-    """
-    eps = float(np.finfo(dtype).eps)
-    actual_tol = tol if tol is not None else 100.0 * eps
-    min_sigma = actual_tol * sigma[0]
-    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
-    pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
-    return pinv
-
-
-def _resolve_node_arrays(
-    nodes: PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
-    n_pts: tuple[int, ...],
-    dtype: np.dtype[np.float32] | np.dtype[np.float64],
-) -> list[npt.NDArray[np.floating[Any]]]:
-    """Resolve concrete node objects into a validated list of 1D node arrays.
-
-    Handles three concrete node types: :class:`~pantr.quad.PointsLattice`,
-    a single 1D ``ndarray`` (broadcast to all directions or 1D-only), and
-    a sequence of 1D ``ndarray`` values (one per direction).
+    Computes the truncated SVD pseudo-inverse of the Bernstein Vandermonde
+    matrix and applies it sequentially along each dimension of the input
+    array via :func:`numpy.tensordot`.
 
     Args:
-        nodes: Concrete node specification (not a string selector).
-        n_pts (tuple[int, ...]): Expected number of points per direction.
-        dtype (np.dtype): Floating dtype for generated nodes.
+        f (npt.NDArray[np.floating[Any]]): Function values at the tensor
+            product of modified Chebyshev nodes.  Shape
+            ``(n_0, n_1, ..., n_{N-1})``.
+        tol (float | None): SVD truncation tolerance.  If *None*, uses a
+            default based on machine epsilon.
 
     Returns:
-        list[npt.NDArray[np.floating[Any]]]: One 1D node array per parametric
-        direction.
+        npt.NDArray[np.floating[Any]]: Bernstein coefficients with the same
+        shape as ``f``.
 
-    Raises:
-        ValueError: If *nodes* is inconsistent with *n_pts*.
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
     """
-    if isinstance(nodes, PointsLattice):
-        if nodes.dim != len(n_pts):
-            raise ValueError(f"PointsLattice has {nodes.dim} dimensions, expected {len(n_pts)}.")
-        node_list: list[npt.NDArray[np.floating[Any]]] = [
-            np.asarray(a, dtype=dtype) for a in nodes.pts_per_dir
-        ]
-        for i, (arr_i, n) in enumerate(zip(node_list, n_pts, strict=True)):
-            if arr_i.shape[0] != n:
-                raise ValueError(
-                    f"PointsLattice direction {i} has {arr_i.shape[0]} nodes, expected {n}."
-                )
-        return node_list
+    result = f.copy()
+    ndim = f.ndim
 
-    if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
-        arr: npt.NDArray[np.floating[Any]] = nodes.astype(dtype, copy=False)
-        if len(n_pts) == 1:
-            if arr.shape[0] != n_pts[0]:
-                raise ValueError(
-                    f"Node array length {arr.shape[0]} does not match n_pts={n_pts[0]}."
-                )
-            return [arr]
-        # Broadcast single array to all directions
-        for n in n_pts:
-            if arr.shape[0] != n:
-                raise ValueError(f"Node array length {arr.shape[0]} does not match n_pts={n}.")
-        return [arr.copy() for _ in n_pts]
+    for dim in range(ndim):
+        n = result.shape[dim]
+        if n == 1:
+            continue
 
-    # Sequence of arrays
-    node_list_seq: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
-    if len(node_list_seq) != len(n_pts):
-        raise ValueError(f"Expected {len(n_pts)} node arrays, got {len(node_list_seq)}.")
-    for i, (arr_i, n) in enumerate(zip(node_list_seq, n_pts, strict=True)):
-        if arr_i.ndim != 1 or arr_i.shape[0] != n:
-            raise ValueError(
-                f"Node array for direction {i} has shape {arr_i.shape}, expected ({n},)."
-            )
-    return node_list_seq
+        U, sigma, Vt = _bernstein_vandermonde_svd(n, f.dtype)
+
+        eps = float(np.finfo(f.dtype).eps)
+        actual_tol = tol if tol is not None else _SVD_TOL_FACTOR * eps
+        min_sigma = actual_tol * sigma[0]
+        inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
+
+        # Pseudoinverse matrix: V @ diag(1/sigma) @ U^T
+        pinv = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
+
+        # Apply along dimension `dim`
+        result = np.tensordot(pinv, result, axes=([1], [dim]))
+        # tensordot puts the result dimension first; move it back to `dim`
+        result = np.moveaxis(result, 0, dim)
+
+    return result
 
 
 def _resolve_nodes(
     n_pts: tuple[int, ...],
     nodes: (
         Literal["chebyshev", "uniform"]
-        | PointsLattice
         | npt.NDArray[np.floating[Any]]
         | Sequence[npt.NDArray[np.floating[Any]]]
         | None
@@ -136,16 +123,12 @@ def _resolve_nodes(
 ) -> list[npt.NDArray[np.floating[Any]]]:
     """Resolve the *nodes* parameter into a list of 1D node arrays.
 
-    Handles string selectors (``None``/``"chebyshev"``/``"uniform"``) and
-    delegates concrete node types to :func:`_resolve_node_arrays`.
-
     Args:
         n_pts (tuple[int, ...]): Number of sample points per direction.
         nodes: Node specification — ``None`` or ``"chebyshev"`` for modified
             Chebyshev-Lobatto nodes, ``"uniform"`` for equispaced nodes, a
-            :class:`~pantr.quad.PointsLattice`, a single 1D array (broadcast
-            to every direction), or a sequence of 1D arrays (one per
-            direction).
+            single 1D array (broadcast to every direction), or a sequence of
+            1D arrays (one per direction).
         dtype (np.dtype): Floating dtype for generated nodes.
 
     Returns:
@@ -169,7 +152,25 @@ def _resolve_nodes(
         ]
         return result
 
-    return _resolve_node_arrays(nodes, n_pts, dtype)
+    # User-provided nodes
+    if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
+        # Single array — broadcast to all directions
+        arr: npt.NDArray[np.floating[Any]] = nodes.astype(dtype, copy=False)
+        for n in n_pts:
+            if arr.shape[0] != n:
+                raise ValueError(f"Node array length {arr.shape[0]} does not match n_pts={n}.")
+        return [arr] * len(n_pts)
+
+    # Sequence of arrays
+    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list) != len(n_pts):
+        raise ValueError(f"Expected {len(n_pts)} node arrays, got {len(node_list)}.")
+    for i, (arr, n) in enumerate(zip(node_list, n_pts, strict=True)):
+        if arr.ndim != 1 or arr.shape[0] != n:
+            raise ValueError(
+                f"Node array for direction {i} has shape {arr.shape}, expected ({n},)."
+            )
+    return node_list
 
 
 def _build_bernstein_pinv(
@@ -200,6 +201,7 @@ def _build_bernstein_pinv(
         npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix, shape
         ``(degree + 1, n_pts)``.
     """
+    # Deferred to avoid import-time Numba JIT that would race with _async_warmup.
     from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
 
     n_pts = nodes.shape[0]
@@ -214,102 +216,13 @@ def _build_bernstein_pinv(
     _tabulate_Bernstein_basis_1D_core(np.int32(deg), nodes, V)
     U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
 
-    return _truncated_svd_pinv(U, sigma, Vt, tol, dtype)
+    eps = float(np.finfo(dtype).eps)
+    actual_tol = tol if tol is not None else 100.0 * eps
+    min_sigma = actual_tol * sigma[0]
+    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
 
-
-def _build_nd_bernstein_vandermonde(
-    pts: npt.NDArray[np.floating[Any]],
-    degree_tuple: tuple[int, ...],
-) -> npt.NDArray[np.floating[Any]]:
-    """Build the full tensor-product Bernstein Vandermonde matrix at scattered points.
-
-    For ``N``-dimensional points with degrees ``(p_0, ..., p_{N-1})``, the
-    Vandermonde matrix has shape ``(n_pts, prod(p_d + 1))`` where each row
-    contains the products of univariate Bernstein basis values across all
-    directions.
-
-    Args:
-        pts (npt.NDArray[np.floating[Any]]): Evaluation points, shape
-            ``(n_pts,)`` for 1D or ``(n_pts, ndim)`` for N-D.
-        degree_tuple (tuple[int, ...]): Polynomial degree per parametric
-            direction.
-
-    Returns:
-        npt.NDArray[np.floating[Any]]: Vandermonde matrix, shape
-        ``(n_pts, prod(degree[d] + 1))``.
-    """
-    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
-
-    ndim = len(degree_tuple)
-    dtype = pts.dtype
-
-    pts_2d = pts[:, np.newaxis] if pts.ndim == 1 else pts
-    n_pts = pts_2d.shape[0]
-
-    # Evaluate univariate Bernstein bases per direction
-    basis_per_dir: list[npt.NDArray[np.floating[Any]]] = []
-    for d in range(ndim):
-        n_coeffs = degree_tuple[d] + 1
-        B_d = np.empty((n_pts, n_coeffs), dtype=dtype)
-        _tabulate_Bernstein_basis_1D_core(np.int32(degree_tuple[d]), pts_2d[:, d], B_d)
-        basis_per_dir.append(B_d)
-
-    # Build tensor-product Vandermonde via successive Kronecker-like expansion
-    V = basis_per_dir[0]
-    for d in range(1, ndim):
-        # V has shape (n_pts, cols_so_far), basis_per_dir[d] has shape (n_pts, n_d)
-        # Result: (n_pts, cols_so_far * n_d) via row-wise outer product
-        V = (V[:, :, np.newaxis] * basis_per_dir[d][:, np.newaxis, :]).reshape(n_pts, -1)
-
-    return V
-
-
-def _fit_from_scattered(
-    values: npt.NDArray[np.floating[Any]],
-    pts: npt.NDArray[np.floating[Any]],
-    degree_tuple: tuple[int, ...],
-    tol: float | None,
-) -> npt.NDArray[np.floating[Any]]:
-    """Fit Bernstein coefficients from scattered (non-tensor-product) point values.
-
-    Builds the full tensor-product Bernstein Vandermonde at the given points
-    and recovers the coefficients via truncated SVD pseudo-inverse.
-
-    Args:
-        values (npt.NDArray[np.floating[Any]]): Function values at scattered
-            points.  Shape ``(n_pts,)`` for scalar or ``(n_pts, rank)`` for
-            vector-valued.
-        pts (npt.NDArray[np.floating[Any]]): Evaluation points, shape
-            ``(n_pts,)`` for 1D or ``(n_pts, ndim)`` for N-D.
-        degree_tuple (tuple[int, ...]): Polynomial degree per parametric
-            direction.
-        tol (float | None): SVD truncation tolerance.
-
-    Returns:
-        npt.NDArray[np.floating[Any]]: Control points with shape
-        ``(*orders, rank)`` where ``orders[d] = degree[d] + 1``.
-    """
-    dtype = values.dtype
-    orders = tuple(d + 1 for d in degree_tuple)
-
-    V = _build_nd_bernstein_vandermonde(pts, degree_tuple)
-
-    U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
-    pinv = _truncated_svd_pinv(U, sigma, Vt, tol, dtype)
-
-    # Solve for each component
-    is_vector = values.ndim == 2  # noqa: PLR2004
-    if is_vector:
-        rank = values.shape[1]
-        components: list[npt.NDArray[np.floating[Any]]] = []
-        for r in range(rank):
-            coeffs_flat = pinv @ values[:, r]
-            components.append(coeffs_flat.reshape(orders).astype(dtype))
-        return np.stack(components, axis=-1)
-
-    coeffs_flat = pinv @ values
-    ctrl = coeffs_flat.reshape(orders).astype(dtype)
-    return ctrl[..., np.newaxis]
+    pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
+    return pinv
 
 
 def _validate_n_pts(
@@ -364,6 +277,30 @@ def _validate_degree(
                 f"(need at least degree + 1 sample points)."
             )
     return deg_tuple
+
+
+def _resolve_dtype(
+    dtype: npt.DTypeLike,
+) -> np.dtype[np.float32] | np.dtype[np.float64]:
+    """Validate and resolve a dtype to float32 or float64.
+
+    Args:
+        dtype (npt.DTypeLike): Requested dtype.
+
+    Returns:
+        np.dtype[np.float32] | np.dtype[np.float64]: Resolved dtype.
+
+    Raises:
+        ValueError: If dtype is not a floating type.
+    """
+    dtype_raw = np.dtype(dtype)
+    if not np.issubdtype(dtype_raw, np.floating):
+        raise ValueError(f"dtype must be a floating type, got {dtype_raw}.")
+    if dtype_raw == np.float32:
+        dtype_obj: np.dtype[np.float32] | np.dtype[np.float64] = np.dtype(np.float32)
+    else:
+        dtype_obj = np.dtype(np.float64)
+    return dtype_obj
 
 
 def _split_components(
@@ -442,18 +379,18 @@ def _fit_from_values(
     return np.stack(ctrl_components, axis=-1)
 
 
-def _interpolate_bezier(
-    func: Callable[[PointsLattice], npt.ArrayLike],
+def _interpolate_bezier(  # noqa: PLR0913
+    func: Callable[..., npt.ArrayLike],
     n_pts: int | Sequence[int],
     *,
     degree: int | Sequence[int] | None = None,
     nodes: (
         Literal["chebyshev", "uniform"]
-        | PointsLattice
         | npt.NDArray[np.floating[Any]]
         | Sequence[npt.NDArray[np.floating[Any]]]
         | None
     ) = None,
+    dtype: npt.DTypeLike = np.float64,
     tol: float | None = None,
 ) -> Bezier:
     """Interpolate a callable function into a Bézier in Bernstein form.
@@ -464,16 +401,14 @@ def _interpolate_bezier(
     The parametric dimension is determined by the length of ``n_pts`` (when
     given as a sequence) or defaults to 1 (when given as a scalar ``int``).
 
-    The output dtype is inferred from the return value of ``func``.
-
     Args:
-        func (Callable[[PointsLattice], npt.ArrayLike]): Function to
-            interpolate.  Called as ``func(lattice)`` where ``lattice`` is a
-            :class:`~pantr.quad.PointsLattice` representing the tensor-product
-            sampling grid.
-            Must return an array of shape ``(n_total,)`` for a scalar-valued
-            function or ``(n_total, rank)`` for a vector-valued function,
-            where ``n_total = prod(n_pts)``.
+        func (Callable[..., npt.ArrayLike]): Function to interpolate.  Called
+            as ``func(pts)`` where ``pts`` is a NumPy array of parametric
+            coordinates: shape ``(n_total,)`` for 1D or
+            ``(n_total, dim)`` for multi-dimensional (matching the convention
+            of :meth:`~pantr.bezier.Bezier.evaluate`).  Must return an array
+            of shape ``(n_total,)`` for a scalar-valued function or
+            ``(n_total, rank)`` for a vector-valued function.
         n_pts (int | Sequence[int]): Number of sample points per parametric
             direction.  A single ``int`` gives a 1D Bézier.
         degree (int | Sequence[int] | None): Polynomial degree per direction.
@@ -485,9 +420,10 @@ def _interpolate_bezier(
             - ``None`` or ``"chebyshev"`` (default): modified Chebyshev-Lobatto
               nodes on [0, 1].
             - ``"uniform"``: equispaced nodes on [0, 1].
-            - A :class:`~pantr.quad.PointsLattice`: custom tensor-product grid.
             - A 1D ``ndarray``: custom nodes broadcast to all directions.
             - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
+        dtype (npt.DTypeLike): Floating dtype for nodes and output.
+            Defaults to ``float64``.
         tol (float | None): SVD truncation tolerance. If *None*, uses a
             default based on machine epsilon.
 
@@ -503,26 +439,29 @@ def _interpolate_bezier(
     Example:
         >>> from pantr.bezier import Bezier
         >>> import numpy as np
-        >>> b = Bezier.interpolate(lambda lat: lat.get_all_points()[:, 0] ** 2, [5])
+        >>> b = Bezier.interpolate(lambda x: x**2, 5)
         >>> b.degree
         (4,)
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
+    dtype_obj = _resolve_dtype(dtype)
     n_pts_tuple = _validate_n_pts(n_pts)
     degree_tuple = _validate_degree(degree, n_pts_tuple)
+    ndim = len(n_pts_tuple)
 
-    # Resolve nodes and build PointsLattice (default to float64 for generated nodes)
-    node_arrays = _resolve_nodes(n_pts_tuple, nodes, np.dtype(np.float64))
-    lattice = PointsLattice(node_arrays)
+    # Resolve nodes and build flat points array
+    node_arrays = _resolve_nodes(n_pts_tuple, nodes, dtype_obj)
     n_total = int(np.prod(n_pts_tuple))
 
-    # Evaluate function and infer dtype from the return value
-    raw_untyped = np.asarray(func(lattice))
-    if not np.issubdtype(raw_untyped.dtype, np.floating):
-        raw_untyped = raw_untyped.astype(np.float64)
-    raw: npt.NDArray[np.floating[Any]] = raw_untyped
+    if ndim == 1:
+        pts_flat = node_arrays[0]
+    else:
+        grids = np.meshgrid(*node_arrays, indexing="ij")
+        pts_flat = np.column_stack([g.ravel() for g in grids])
 
+    # Evaluate function and reshape to grid
+    raw: npt.NDArray[np.floating[Any]] = np.asarray(func(pts_flat), dtype=dtype_obj)
     if raw.ndim == 1:
         if raw.shape[0] != n_total:
             raise ValueError(
@@ -545,130 +484,100 @@ def _interpolate_bezier(
     return BezierCls(ctrl, is_rational=False)
 
 
-def _is_scattered_nodes(
-    nodes: (
-        PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
-    ),
-) -> bool:
-    """Check whether *nodes* represents scattered (non-tensor-product) points.
-
-    A 2D ``ndarray`` of shape ``(n_pts, dim)`` is interpreted as scattered
-    points.  Note that a column vector of shape ``(n, 1)`` is treated as
-    scattered 1D points; pass a 1D array instead for tensor-product semantics.
+def _resolve_nodes_from_user(
+    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    n_pts_tuple: tuple[int, ...],
+    dtype: np.dtype[np.float32] | np.dtype[np.float64],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Resolve user-provided nodes for :func:`_fit_bezier`.
 
     Args:
-        nodes: The nodes argument passed to :func:`_fit_bezier`.
+        nodes: A single 1D array (for 1D fitting) or a sequence of 1D arrays.
+        n_pts_tuple (tuple[int, ...]): Expected number of points per direction.
+        dtype (np.dtype): Floating dtype.
 
     Returns:
-        bool: ``True`` if *nodes* is a 2D array (scattered points),
-        ``False`` if it is a :class:`~pantr.quad.PointsLattice`, a 1D array,
-        or a sequence of 1D arrays (tensor-product).
-    """
-    if isinstance(nodes, PointsLattice):
-        return False
-    return isinstance(nodes, np.ndarray) and nodes.ndim == 2  # noqa: PLR2004
-
-
-def _fit_bezier_scattered(
-    values_arr: npt.NDArray[np.floating[Any]],
-    nodes: npt.NDArray[np.floating[Any]],
-    degree: int | Sequence[int] | None,
-    tol: float | None,
-) -> Bezier:
-    """Handle the scattered (non-tensor-product) path for :func:`_fit_bezier`.
-
-    Args:
-        values_arr (npt.NDArray[np.floating[Any]]): Sample values.
-        nodes (npt.NDArray[np.floating[Any]]): Scattered points, shape
-            ``(n_pts, dim)``.
-        degree (int | Sequence[int] | None): Polynomial degree per direction.
-        tol (float | None): SVD truncation tolerance.
-
-    Returns:
-        ~pantr.bezier.Bezier: A non-rational Bézier.
+        list[npt.NDArray[np.floating[Any]]]: One 1D node array per direction.
 
     Raises:
-        ValueError: If *degree* is missing, inconsistent with *nodes*, or
-            the system is underdetermined.
+        ValueError: If nodes are inconsistent with the expected grid shape.
     """
-    from . import Bezier as BezierCls  # noqa: PLC0415
-
-    dtype_obj = values_arr.dtype
-    pts: npt.NDArray[np.floating[Any]] = np.asarray(nodes, dtype=dtype_obj)
-    ndim_param = pts.shape[1]
-    n_pts = pts.shape[0]
-
-    if degree is None:
-        raise ValueError("degree is required for scattered (non-tensor-product) nodes.")
-
-    degree_tuple = (degree,) * ndim_param if isinstance(degree, int) else tuple(degree)
-    if len(degree_tuple) != ndim_param:
-        raise ValueError(
-            f"degree has {len(degree_tuple)} entries but nodes have {ndim_param} columns."
-        )
-    n_coeffs = int(np.prod(tuple(d + 1 for d in degree_tuple)))
-    if n_coeffs > n_pts:
-        raise ValueError(
-            f"Underdetermined: {n_coeffs} coefficients but only {n_pts} sample points."
-        )
-
-    # Validate values shape
-    if values_arr.ndim == 1:
-        if values_arr.shape[0] != n_pts:
+    # Single 1D array
+    if isinstance(nodes, np.ndarray) and nodes.ndim == 1:
+        if len(n_pts_tuple) != 1:
             raise ValueError(
-                f"values has {values_arr.shape[0]} entries but nodes has {n_pts} points."
+                f"A single node array implies 1D fitting, but values have "
+                f"{len(n_pts_tuple)} parametric dimensions."
             )
-    elif values_arr.ndim == 2:  # noqa: PLR2004
-        if values_arr.shape[0] != n_pts:
-            raise ValueError(f"values has {values_arr.shape[0]} rows but nodes has {n_pts} points.")
-    else:
-        raise ValueError(
-            f"For scattered nodes, values must be 1D (scalar) or 2D "
-            f"(vector), got {values_arr.ndim}D."
-        )
+        arr: npt.NDArray[np.floating[Any]] = nodes.astype(dtype, copy=False)
+        if arr.shape[0] != n_pts_tuple[0]:
+            raise ValueError(
+                f"Node array length {arr.shape[0]} does not match "
+                f"values grid size {n_pts_tuple[0]}."
+            )
+        return [arr]
 
-    ctrl = _fit_from_scattered(values_arr, pts, degree_tuple, tol)
-    return BezierCls(ctrl, is_rational=False)
+    # Sequence of arrays
+    node_list: list[npt.NDArray[np.floating[Any]]] = [np.asarray(a, dtype=dtype) for a in nodes]
+    if len(node_list) != len(n_pts_tuple):
+        raise ValueError(f"Expected {len(n_pts_tuple)} node arrays, got {len(node_list)}.")
+    for i, (arr_i, n) in enumerate(zip(node_list, n_pts_tuple, strict=True)):
+        if arr_i.ndim != 1 or arr_i.shape[0] != n:
+            raise ValueError(
+                f"Node array for direction {i} has shape {arr_i.shape}, expected ({n},)."
+            )
+    return node_list
 
 
-def _fit_bezier_tensor_product(
-    values_arr: npt.NDArray[np.floating[Any]],
-    nodes: PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
-    degree: int | Sequence[int] | None,
-    tol: float | None,
+def _fit_bezier(
+    values: npt.ArrayLike,
+    nodes: npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]],
+    *,
+    degree: int | Sequence[int] | None = None,
+    dtype: npt.DTypeLike = np.float64,
+    tol: float | None = None,
 ) -> Bezier:
-    """Handle the tensor-product path for :func:`_fit_bezier`.
+    """Construct a Bézier from pre-evaluated sample values at known nodes.
+
+    Given function values on a tensor-product grid of nodes, recovers the
+    Bernstein coefficients via truncated SVD.
 
     Args:
-        values_arr (npt.NDArray[np.floating[Any]]): Sample values.
-        nodes: Tensor-product nodes (PointsLattice, 1D array, or sequence of
-            1D arrays).
+        values (npt.ArrayLike): Sample values on the tensor-product grid.
+            Shape ``(*n_pts_per_dir)`` for scalar or
+            ``(*n_pts_per_dir, rank)`` for vector-valued.
+        nodes (npt.NDArray | Sequence[npt.NDArray]): Interpolation nodes.
+            A single 1D array for 1D fitting, or a sequence of 1D arrays
+            (one per parametric direction) for N-D.
         degree (int | Sequence[int] | None): Polynomial degree per direction.
-        tol (float | None): SVD truncation tolerance.
+            If *None* (default), ``degree = n_pts - 1`` (exact interpolation).
+            If provided, must satisfy ``degree < n_pts`` in each direction;
+            the result is a least-squares approximation.
+        dtype (npt.DTypeLike): Floating dtype. Defaults to ``float64``.
+        tol (float | None): SVD truncation tolerance. If *None*, uses a
+            default based on machine epsilon.
 
     Returns:
         ~pantr.bezier.Bezier: A non-rational Bézier.
 
     Raises:
-        ValueError: If *nodes* are inconsistent with *values* or *degree* is
-            invalid.
+        ValueError: If *nodes* lengths are inconsistent with *values* shape,
+            or *degree* >= *n_pts* in any direction.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
-    dtype_obj = values_arr.dtype
+    dtype_obj = _resolve_dtype(dtype)
+    values_arr: npt.NDArray[np.floating[Any]] = np.asarray(values, dtype=dtype_obj)
 
     # Determine parametric dimension from nodes
-    if isinstance(nodes, PointsLattice):
-        ndim_param = nodes.dim
-    elif isinstance(nodes, np.ndarray) and nodes.ndim == 1:
-        ndim_param = 1
-    else:
-        ndim_param = len(nodes)
+    ndim_param = 1 if isinstance(nodes, np.ndarray) and nodes.ndim == 1 else len(nodes)
 
     # Infer n_pts from values shape: first ndim_param dimensions are the grid
     if values_arr.ndim == ndim_param:
+        # Scalar-valued
         n_pts_tuple = values_arr.shape
     elif values_arr.ndim == ndim_param + 1:
+        # Vector-valued
         n_pts_tuple = values_arr.shape[:ndim_param]
     else:
         raise ValueError(
@@ -677,66 +586,7 @@ def _fit_bezier_tensor_product(
         )
 
     degree_tuple = _validate_degree(degree, n_pts_tuple)
-    node_arrays = _resolve_node_arrays(nodes, n_pts_tuple, dtype_obj)
+    node_arrays = _resolve_nodes_from_user(nodes, n_pts_tuple, dtype_obj)
     components = _split_components(values_arr, n_pts_tuple)
     ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
     return BezierCls(ctrl, is_rational=False)
-
-
-def _fit_bezier(
-    values: npt.ArrayLike,
-    nodes: (
-        PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
-    ),
-    *,
-    degree: int | Sequence[int] | None = None,
-    tol: float | None = None,
-) -> Bezier:
-    """Construct a Bézier from pre-evaluated sample values at known nodes.
-
-    The output dtype is inferred from *values*.
-
-    Supports two point layouts:
-
-    - **Tensor-product** (a :class:`~pantr.quad.PointsLattice`, a single 1D
-      array, or a sequence of 1D arrays): values must have shape
-      ``(*n_pts_per_dir)`` (scalar) or ``(*n_pts_per_dir, rank)`` (vector).
-      Per-direction SVD pseudo-inverse is used (efficient).
-    - **Scattered** (a 2D ``ndarray`` of shape ``(n_pts, dim)``): values must
-      have shape ``(n_pts,)`` (scalar) or ``(n_pts, rank)`` (vector).
-      ``degree`` is required. A full tensor-product Vandermonde is built and
-      solved via SVD.
-
-    Args:
-        values (npt.ArrayLike): Sample values.
-        nodes: Interpolation nodes.
-
-            - A :class:`~pantr.quad.PointsLattice`: tensor-product grid.
-            - A 1D ``ndarray``: 1D tensor-product (single direction).
-            - A sequence of 1D ``ndarray`` values: N-D tensor-product.
-            - A 2D ``ndarray`` of shape ``(n_pts, dim)``: scattered points.
-        degree (int | Sequence[int] | None): Polynomial degree per direction.
-            Required for scattered nodes.  If *None* (default) for
-            tensor-product nodes, ``degree = n_pts - 1`` (exact
-            interpolation).  Must satisfy
-            ``prod(degree + 1) <= n_pts`` for scattered nodes and
-            ``degree < n_pts`` per direction for tensor-product.
-        tol (float | None): SVD truncation tolerance. If *None*, uses a
-            default based on machine epsilon.
-
-    Returns:
-        ~pantr.bezier.Bezier: A non-rational Bézier.
-
-    Raises:
-        ValueError: If *nodes* are inconsistent with *values*, *degree* is
-            invalid, or *degree* is missing for scattered nodes.
-    """
-    values_untyped = np.asarray(values)
-    if not np.issubdtype(values_untyped.dtype, np.floating):
-        values_untyped = values_untyped.astype(np.float64)
-    values_arr: npt.NDArray[np.floating[Any]] = values_untyped
-
-    if _is_scattered_nodes(nodes):
-        assert isinstance(nodes, np.ndarray)
-        return _fit_bezier_scattered(values_arr, nodes, degree, tol)
-    return _fit_bezier_tensor_product(values_arr, nodes, degree, tol)

--- a/src/pantr/bezier/_resultant.py
+++ b/src/pantr/bezier/_resultant.py
@@ -1,0 +1,414 @@
+"""Resultant and discriminant computation for multivariate Bernstein polynomials.
+
+Provides :func:`_resultant` and :func:`_discriminant`, which compute the
+resultant and discriminant of multivariate Bernstein polynomials by evaluating
+the Sylvester/Bezout matrix determinant at modified Chebyshev nodes and
+interpolating back to Bernstein form via SVD.
+
+This implements the dimension-elimination step of the algoim-style implicit
+quadrature pipeline (R. I. Saye, *J. Comput. Phys.* 448, 110720, 2022).
+
+Supporting functions:
+
+- :func:`_normalise` — Scale polynomial by its largest coefficient.
+- :func:`_resultant_order` — Compute the output order of a resultant.
+- :func:`_discriminant_order` — Compute the output order of a discriminant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from ..quad import get_modified_chebyshev_nodes_1d
+from ._bezier_derivative import _derivative_ctrl_nd
+from ._bezier_interpolate import _SVD_TOL_FACTOR, _bernstein_interpolate
+from ._resultant_matrices import _bezout_matrix, _det_qr, _sylvester_matrix
+
+_RESULTANT_REDUCTION_TOL_FACTOR: float = 1.0e4
+"""Factor multiplied by machine epsilon for resultant auto-reduction."""
+
+
+def _normalise(
+    coeffs: npt.NDArray[np.floating[Any]],
+) -> npt.NDArray[np.floating[Any]]:
+    """Scale polynomial coefficients by their maximum absolute value.
+
+    Args:
+        coeffs (npt.NDArray[np.floating[Any]]): Bernstein coefficients
+            (any shape). Modified in place.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The normalised array (same object as
+        ``coeffs``).
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    x = float(np.max(np.abs(coeffs)))
+    if x > 0.0:
+        coeffs *= 1.0 / x
+    return coeffs
+
+
+def _resultant_order(
+    order_p: tuple[int, ...],
+    order_q: tuple[int, ...],
+    dim: int,
+) -> tuple[int, ...]:
+    r"""Compute the output order of the resultant of two polynomials.
+
+    The order of a polynomial is its degree plus one, i.e. the number of
+    Bernstein coefficients per direction.
+
+    The resultant of ``p`` and ``q`` along dimension ``dim`` is a polynomial
+    in all remaining dimensions.  Its order in direction ``i``
+    (skipping ``dim``) is:
+
+    .. math::
+
+        (P_{\mathrm{dim}} - 1)(Q_i - 1) + (Q_{\mathrm{dim}} - 1)(P_i - 1) + 1
+
+    where ``P_i`` and ``Q_i`` are the orders (degree + 1) of ``p`` and ``q``.
+
+    Args:
+        order_p (tuple[int, ...]): Orders of polynomial ``p`` per direction.
+        order_q (tuple[int, ...]): Orders of polynomial ``q`` per direction.
+        dim (int): Elimination dimension.
+
+    Returns:
+        tuple[int, ...]: Orders of the resultant (one dimension fewer).
+    """
+    N = len(order_p)
+    result = []
+    for i in range(N):
+        if i == dim:
+            continue
+        ord_i = (order_p[dim] - 1) * (order_q[i] - 1) + (order_q[dim] - 1) * (order_p[i] - 1) + 1
+        result.append(max(ord_i, 1))
+    return tuple(result)
+
+
+def _discriminant_order(
+    order_p: tuple[int, ...],
+    dim: int,
+) -> tuple[int, ...]:
+    """Compute the output order of the discriminant of a polynomial.
+
+    The order of a polynomial is its degree plus one, i.e. the number of
+    Bernstein coefficients per direction.
+
+    The discriminant along ``dim`` is the resultant of ``p`` with its
+    partial derivative in direction ``dim``.
+
+    Args:
+        order_p (tuple[int, ...]): Orders (degree + 1) of polynomial ``p``.
+        dim (int): Elimination dimension.
+
+    Returns:
+        tuple[int, ...]: Orders of the discriminant (one dimension fewer).
+    """
+    N = len(order_p)
+    result = []
+    for i in range(N):
+        if i == dim:
+            continue
+        ord_i = (2 * order_p[dim] - 3) * (order_p[i] - 1) + 1
+        result.append(max(ord_i, 1))
+    return tuple(result)
+
+
+def _collapse_along_axis_raw(
+    coeffs: npt.NDArray[np.floating[Any]],
+    x0: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> npt.NDArray[np.floating[Any]]:
+    """Collapse a multivariate Bernstein polynomial along all axes except one.
+
+    Evaluates Bernstein basis functions at ``x0`` for each direction other
+    than ``dim``, contracting the coefficient tensor to produce a 1D array
+    of Bernstein coefficients along ``dim``.
+
+    Args:
+        coeffs (npt.NDArray[np.floating[Any]]): N-D Bernstein coefficients.
+        x0 (npt.NDArray[np.floating[Any]]): Parameter values for dimensions
+            other than ``dim``.  Length ``N - 1``.
+        dim (int): Direction to keep.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: 1D Bernstein coefficients along ``dim``,
+        shape ``(coeffs.shape[dim],)``.
+
+    Note:
+        No input validation is performed.
+    """
+    from ..basis._basis_core import _tabulate_Bernstein_basis_1D_core  # noqa: PLC0415
+
+    ndim = coeffs.ndim
+    dtype = coeffs.dtype
+    result = coeffs
+
+    # Contract from highest dimension to lowest, skipping `dim`
+    for d in range(ndim - 1, -1, -1):
+        if d == dim:
+            continue
+
+        val_idx = d if d < dim else d - 1
+        pts = np.array([x0[val_idx]], dtype=dtype)
+        basis = np.empty((1, result.shape[d]), dtype=dtype)
+        _tabulate_Bernstein_basis_1D_core(np.int32(result.shape[d] - 1), pts, basis)
+        basis_1d = basis[0]
+
+        result = np.tensordot(basis_1d, result, axes=([0], [d]))
+
+    return result.ravel()
+
+
+def _resultant(
+    p: npt.NDArray[np.floating[Any]],
+    q: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> npt.NDArray[np.floating[Any]]:
+    """Compute the resultant of two multivariate Bernstein polynomials.
+
+    Eliminates dimension ``dim`` by evaluating the Sylvester/Bezout matrix
+    determinant at modified Chebyshev nodes in the remaining dimensions,
+    then interpolating back to Bernstein form via SVD.
+
+    For 1D inputs (``p.ndim == 1``), returns the scalar resultant as a
+    0-D array.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): Bernstein coefficients of the
+            first polynomial.  Order (degree + 1) in ``dim`` must be >= 2.
+        q (npt.NDArray[np.floating[Any]]): Bernstein coefficients of the
+            second polynomial.  Must have the same number of dimensions as
+            ``p``.
+        dim (int): Dimension to eliminate (0-indexed).
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Resultant Bernstein coefficients with
+        one fewer dimension.  Shape is determined by
+        :func:`_resultant_order`.
+
+    Raises:
+        ValueError: If ``dim`` is out of range, orders are too small, or
+            arrays have different numbers of dimensions.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    _validate_resultant_inputs(p, q, dim)
+    return _resultant_core(p, q, dim)
+
+
+def _discriminant(
+    p: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> npt.NDArray[np.floating[Any]]:
+    """Compute the discriminant of a multivariate Bernstein polynomial.
+
+    The discriminant along ``dim`` is the resultant of ``p`` with its
+    partial derivative ``dp/dx_dim``.  It identifies the locus where ``p``
+    and ``dp/dx_dim`` share a common root along ``dim``.
+
+    For 1D inputs (``p.ndim == 1``), returns the scalar discriminant as a
+    0-D array.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): Bernstein coefficients.  Order
+            (degree + 1) in ``dim`` must be >= 3.
+        dim (int): Dimension to eliminate.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Discriminant Bernstein coefficients
+        with one fewer dimension.
+
+    Raises:
+        ValueError: If ``dim`` is out of range or order in ``dim`` < 3.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+    """
+    _validate_resultant_inputs_single(p, dim)
+
+    if p.shape[dim] < 3:  # noqa: PLR2004
+        raise ValueError(
+            f"Discriminant requires order >= 3 in dimension {dim} "
+            f"(degree >= 2), got {p.shape[dim]}."
+        )
+
+    # Compute partial derivative along dim
+    dp = _derivative_ctrl_nd(p, dim)
+
+    return _resultant_core(p, dp, dim)
+
+
+def _validate_resultant_inputs(
+    p: npt.NDArray[np.floating[Any]],
+    q: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> None:
+    """Validate inputs for resultant computation.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): First polynomial.
+        q (npt.NDArray[np.floating[Any]]): Second polynomial.
+        dim (int): Elimination dimension.
+
+    Raises:
+        ValueError: If inputs are invalid.
+    """
+    if p.ndim != q.ndim:
+        raise ValueError(
+            f"p and q must have the same number of dimensions, got {p.ndim} and {q.ndim}."
+        )
+    if not np.issubdtype(p.dtype, np.floating):
+        raise ValueError(f"p must have floating dtype, got {p.dtype}.")
+    if not np.issubdtype(q.dtype, np.floating):
+        raise ValueError(f"q must have floating dtype, got {q.dtype}.")
+    if dim < 0 or dim >= p.ndim:
+        raise ValueError(f"dim must be in [0, {p.ndim}), got {dim}.")
+    if p.shape[dim] < 2:  # noqa: PLR2004
+        raise ValueError(f"p must have order >= 2 in dimension {dim}, got {p.shape[dim]}.")
+    if q.shape[dim] < 2:  # noqa: PLR2004
+        raise ValueError(f"q must have order >= 2 in dimension {dim}, got {q.shape[dim]}.")
+
+
+def _validate_resultant_inputs_single(
+    p: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> None:
+    """Validate inputs for discriminant computation.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): Polynomial.
+        dim (int): Elimination dimension.
+
+    Raises:
+        ValueError: If inputs are invalid.
+    """
+    if not np.issubdtype(p.dtype, np.floating):
+        raise ValueError(f"p must have floating dtype, got {p.dtype}.")
+    if dim < 0 or dim >= p.ndim:
+        raise ValueError(f"dim must be in [0, {p.ndim}), got {dim}.")
+    if p.shape[dim] < 2:  # noqa: PLR2004
+        raise ValueError(f"p must have order >= 2 in dimension {dim}, got {p.shape[dim]}.")
+
+
+def _evaluate_det_on_grid(
+    p: npt.NDArray[np.floating[Any]],
+    q: npt.NDArray[np.floating[Any]],
+    dim: int,
+    grid_shape: tuple[int, ...],
+) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate resultant-matrix determinants on a tensor-product Chebyshev grid.
+
+    Collapses ``p`` and ``q`` to 1D along ``dim`` at each grid point, builds
+    the Sylvester or Bezout matrix, and stores the determinant.  The result
+    is normalised and interpolated back to Bernstein coefficients.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): First polynomial (N-D, N >= 2).
+        q (npt.NDArray[np.floating[Any]]): Second polynomial (same ndim).
+        dim (int): Elimination dimension.
+        grid_shape (tuple[int, ...]): Shape of the output Chebyshev grid
+            (one entry per remaining dimension).
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Bernstein coefficients of the
+        interpolated resultant on the given grid.
+
+    Note:
+        No input validation is performed.
+    """
+    dtype = np.result_type(p.dtype, q.dtype)
+    eps = float(np.finfo(dtype).eps)
+    ndim = p.ndim
+    P = p.shape[dim]
+    Q = q.shape[dim]
+
+    f = np.empty(grid_shape, dtype=dtype)
+
+    nodes_per_dim = []
+    for d in range(len(grid_shape)):
+        n = grid_shape[d]
+        if n >= 2:  # noqa: PLR2004
+            nodes_per_dim.append(get_modified_chebyshev_nodes_1d(n, dtype))
+        else:
+            nodes_per_dim.append(np.array([0.5], dtype=dtype))
+
+    for flat_idx in range(f.size):
+        multi_idx = np.unravel_index(flat_idx, grid_shape)
+
+        x0 = np.empty(ndim - 1, dtype=dtype)
+        for i, idx_val in enumerate(multi_idx):
+            x0[i] = nodes_per_dim[i][idx_val]
+
+        pk = _collapse_along_axis_raw(p, x0, dim)
+        qk = _collapse_along_axis_raw(q, x0, dim)
+
+        mat = _bezout_matrix(pk, qk) if P == Q else _sylvester_matrix(pk, qk)
+        det, _ = _det_qr(mat)
+        f[multi_idx] = det
+
+    _normalise(f)
+    interp_tol = (_SVD_TOL_FACTOR * eps) ** (1.0 / max(ndim - 1, 1))
+    return _bernstein_interpolate(f, interp_tol)
+
+
+def _resultant_core(
+    p: npt.NDArray[np.floating[Any]],
+    q: npt.NDArray[np.floating[Any]],
+    dim: int,
+) -> npt.NDArray[np.floating[Any]]:
+    """Core resultant computation via interpolation at Chebyshev nodes.
+
+    Assumes inputs have already been validated by the caller.
+
+    Args:
+        p (npt.NDArray[np.floating[Any]]): First polynomial.
+        q (npt.NDArray[np.floating[Any]]): Second polynomial.
+        dim (int): Dimension to eliminate.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Resultant coefficients.
+
+    Note:
+        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+        No input validation is performed.
+    """
+    dtype = np.result_type(p.dtype, q.dtype)
+    p = p.astype(dtype, copy=False)
+    q = q.astype(dtype, copy=False)
+    ndim = p.ndim
+
+    P = p.shape[dim]
+    Q = q.shape[dim]
+
+    if ndim == 1:
+        # 1D case: direct matrix determinant, no interpolation needed
+        mat = _bezout_matrix(p, q) if P == Q else _sylvester_matrix(p, q)
+        det, _ = _det_qr(mat)
+        return np.array(det, dtype=dtype)
+
+    # N-D case: interpolate determinant values at modified Chebyshev nodes
+    out_order = _resultant_order(p.shape, q.shape, dim)
+    out = _evaluate_det_on_grid(p, q, dim, out_order)
+
+    # Automatic degree reduction via Bezier.minimize_degree
+    from . import Bezier as BezierCls  # noqa: PLC0415
+
+    eps = float(np.finfo(dtype).eps)
+    auto_tol = _RESULTANT_REDUCTION_TOL_FACTOR * eps
+    out_bezier = BezierCls(out[..., np.newaxis], is_rational=False)
+    reduced_bezier = out_bezier.minimize_degree(tol=auto_tol)
+
+    if reduced_bezier.degree != out_bezier.degree:
+        # Recompute on reduced grid for better conditioning
+        reduced_shape = tuple(d + 1 for d in reduced_bezier.degree)
+        return _evaluate_det_on_grid(p, q, dim, reduced_shape)
+
+    return out

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -1,4 +1,4 @@
-"""Tests for Bezier.interpolate and Bezier.fit (including scattered fitting)."""
+"""Tests for Bezier.interpolate and the Bernstein interpolation pipeline."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.quad import PointsLattice
 
 # ---------------------------------------------------------------------------
 # 1D scalar interpolation
@@ -22,7 +21,7 @@ class TestInterpolate1DScalar:
 
     def test_linear(self) -> None:
         """Interpolating a linear function with 2 points recovers it exactly."""
-        b = Bezier.interpolate(lambda lat: 2.0 * lat.pts_per_dir[0] + 1.0, 2)
+        b = Bezier.interpolate(lambda x: 2.0 * x + 1.0, 2)
         assert b.degree == (1,)
         assert b.rank == 1
         pts = np.array([0.0, 0.5, 1.0])
@@ -31,7 +30,7 @@ class TestInterpolate1DScalar:
 
     def test_quadratic(self) -> None:
         """Interpolating x^2 with 3 points recovers it exactly."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3)
+        b = Bezier.interpolate(lambda x: x**2, 3)
         assert b.degree == (2,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         expected = pts**2
@@ -39,14 +38,14 @@ class TestInterpolate1DScalar:
 
     def test_cubic(self) -> None:
         """Interpolating x^3 with 4 points recovers it exactly."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 3, 4)
+        b = Bezier.interpolate(lambda x: x**3, 4)
         assert b.degree == (3,)
         pts = np.linspace(0, 1, 10)
         nptest.assert_allclose(b.evaluate(pts), pts**3, atol=1e-12)
 
     def test_single_point(self) -> None:
         """A single interpolation point gives a degree-0 (constant) Bezier."""
-        b = Bezier.interpolate(lambda lat: np.full(1, 7.0), 1)
+        b = Bezier.interpolate(lambda x: np.full_like(x, 7.0), 1)
         assert b.degree == (0,)
         nptest.assert_allclose(b.evaluate(np.array([0.5])), [7.0], atol=1e-14)
 
@@ -62,8 +61,7 @@ class TestInterpolate1DVector:
     def test_circle_arc(self) -> None:
         """Interpolate a quarter-circle parametric curve."""
 
-        def quarter_circle(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            t = lat.pts_per_dir[0]
+        def quarter_circle(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
             theta = t * (np.pi / 2.0)
             return np.stack([np.cos(theta), np.sin(theta)], axis=-1)
 
@@ -80,8 +78,7 @@ class TestInterpolate1DVector:
     def test_linear_curve(self) -> None:
         """A linear vector-valued function is recovered exactly."""
 
-        def line(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            t = lat.pts_per_dir[0]
+        def line(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
             return np.stack([t, 2.0 * t + 1.0, -t + 3.0], axis=-1)
 
         b = Bezier.interpolate(line, 2)
@@ -102,12 +99,7 @@ class TestInterpolate2DScalar:
 
     def test_bilinear(self) -> None:
         """Interpolating a bilinear function with (2,2) points recovers it."""
-
-        def bilinear(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
-            return pts[:, 0] + pts[:, 1]
-
-        b = Bezier.interpolate(bilinear, [2, 2])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [2, 2])
         assert b.degree == (1, 1)
         assert b.rank == 1
         pts = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]])
@@ -116,12 +108,7 @@ class TestInterpolate2DScalar:
 
     def test_biquadratic(self) -> None:
         """Interpolating x^2 + y^2 with (3,3) points."""
-
-        def biquad(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
-            return pts[:, 0] ** 2 + pts[:, 1] ** 2
-
-        b = Bezier.interpolate(biquad, [3, 3])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] ** 2 + pts[:, 1] ** 2, [3, 3])
         assert b.degree == (2, 2)
         pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
         expected = pts[:, 0] ** 2 + pts[:, 1] ** 2
@@ -139,8 +126,7 @@ class TestInterpolate2DVector:
     def test_planar_surface(self) -> None:
         """A linear vector-valued 2D function is recovered exactly."""
 
-        def plane(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
+        def plane(pts: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
             x, y = pts[:, 0], pts[:, 1]
             return np.stack([x, y, x + y], axis=-1)
 
@@ -162,26 +148,26 @@ class TestNodeSelection:
 
     def test_chebyshev_default(self) -> None:
         """Default (Chebyshev) nodes recover a quadratic exactly."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes=None)
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes=None)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_chebyshev_explicit(self) -> None:
         """Explicitly requesting 'chebyshev' is the same as default."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes="chebyshev")
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes="chebyshev")
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_uniform_nodes(self) -> None:
         """Uniform nodes can also recover polynomials (less stable for high degree)."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes="uniform")
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes="uniform")
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
     def test_custom_nodes_array(self) -> None:
         """User-provided custom nodes as a single array."""
         custom = np.array([0.0, 0.5, 1.0])
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 3, nodes=custom)
+        b = Bezier.interpolate(lambda x: x**2, 3, nodes=custom)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
@@ -189,67 +175,7 @@ class TestNodeSelection:
         """User-provided custom nodes as a sequence of arrays (2D)."""
         nodes_x = np.array([0.0, 0.5, 1.0])
         nodes_y = np.array([0.0, 1.0])
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
-            return pts[:, 0] + pts[:, 1]
-
-        b = Bezier.interpolate(func, [3, 2], nodes=[nodes_x, nodes_y])
-        assert b.degree == (2, 1)
-        pts = np.array([[0.5, 0.5]])
-        nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
-
-
-# ---------------------------------------------------------------------------
-# Callable receives PointsLattice
-# ---------------------------------------------------------------------------
-
-
-class TestInterpolateCallableLattice:
-    """Tests verifying that the callable receives a PointsLattice."""
-
-    def test_1d_receives_lattice(self) -> None:
-        """1D interpolation passes a PointsLattice to the callable."""
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            assert isinstance(lat, PointsLattice)
-            assert lat.dim == 1
-            return lat.pts_per_dir[0] ** 2
-
-        b = Bezier.interpolate(func, 3)
-        assert b.degree == (2,)
-
-    def test_2d_receives_lattice(self) -> None:
-        """2D interpolation passes a PointsLattice to the callable."""
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            assert isinstance(lat, PointsLattice)
-            assert lat.dim == 2  # noqa: PLR2004
-            pts = lat.get_all_points()
-            return pts[:, 0] + pts[:, 1]
-
-        b = Bezier.interpolate(func, [3, 3])
-        assert b.degree == (2, 2)
-
-    def test_lattice_has_correct_nodes(self) -> None:
-        """The PointsLattice contains the correct node arrays."""
-        custom_nodes = np.array([0.0, 0.5, 1.0])
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            nptest.assert_allclose(lat.pts_per_dir[0], custom_nodes)
-            return lat.pts_per_dir[0]
-
-        Bezier.interpolate(func, 3, nodes=custom_nodes)
-
-    def test_points_lattice_as_nodes(self) -> None:
-        """Passing a PointsLattice as the nodes parameter works."""
-        lattice = PointsLattice([np.array([0.0, 0.5, 1.0]), np.array([0.0, 1.0])])
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
-            return pts[:, 0] + pts[:, 1]
-
-        b = Bezier.interpolate(func, [3, 2], nodes=lattice)
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 2], nodes=[nodes_x, nodes_y])
         assert b.degree == (2, 1)
         pts = np.array([[0.5, 0.5]])
         nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
@@ -261,23 +187,16 @@ class TestInterpolateCallableLattice:
 
 
 class TestDtype:
-    """Tests for dtype inference."""
+    """Tests for dtype propagation."""
 
     def test_float64_default(self) -> None:
-        """Default dtype is float64 when func returns float64."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 2)
+        """Default dtype is float64."""
+        b = Bezier.interpolate(lambda x: x, 2)
         assert b.dtype == np.float64
 
-    def test_int_return_promoted_to_float64(self) -> None:
-        """Integer return from func is promoted to float64."""
-        b = Bezier.interpolate(lambda lat: np.ones(len(lat.pts_per_dir[0]), dtype=int), 2)
-        assert b.dtype == np.float64
-
-    def test_fit_infers_from_values(self) -> None:
-        """Bezier.fit infers dtype from the values array."""
-        nodes = np.array([0.0, 1.0], dtype=np.float32)
-        vals = np.array([1.0, 2.0], dtype=np.float32)
-        b = Bezier.fit(vals, nodes)
+    def test_float32(self) -> None:
+        """Requesting float32 propagates through."""
+        b = Bezier.interpolate(lambda x: x, 2, dtype=np.float32)
         assert b.dtype == np.float32
 
 
@@ -292,18 +211,23 @@ class TestInterpolateValidation:
     def test_n_pts_too_small(self) -> None:
         """n_pts < 1 raises ValueError."""
         with pytest.raises(ValueError, match="n_pts.*>= 1"):
-            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 0)
+            Bezier.interpolate(lambda x: x, 0)
+
+    def test_non_floating_dtype(self) -> None:
+        """Non-floating dtype raises ValueError."""
+        with pytest.raises(ValueError, match="floating"):
+            Bezier.interpolate(lambda x: x, 3, dtype=np.int32)
 
     def test_mismatched_nodes_n_pts(self) -> None:
         """Custom nodes with wrong length raises ValueError."""
         with pytest.raises(ValueError, match="does not match"):
-            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, nodes=np.array([0.0, 1.0]))
+            Bezier.interpolate(lambda x: x, 3, nodes=np.array([0.0, 1.0]))
 
     def test_wrong_number_of_node_arrays(self) -> None:
         """Wrong number of node arrays for 2D raises ValueError."""
         with pytest.raises(ValueError, match="Expected 2"):
             Bezier.interpolate(
-                lambda lat: lat.get_all_points()[:, 0],
+                lambda pts: pts[:, 0] + pts[:, 1],
                 [3, 3],
                 nodes=[np.array([0.0, 0.5, 1.0])],
             )
@@ -311,7 +235,7 @@ class TestInterpolateValidation:
     def test_bad_function_output_shape(self) -> None:
         """Function returning wrong shape raises ValueError."""
         with pytest.raises(ValueError, match="Function returned shape"):
-            Bezier.interpolate(lambda lat: np.ones((2, 3)), 3)
+            Bezier.interpolate(lambda x: np.ones((2, 3)), 3)
 
 
 # ---------------------------------------------------------------------------
@@ -324,33 +248,28 @@ class TestInterpolateDegree:
 
     def test_exact_when_degree_equals_n_pts_minus_1(self) -> None:
         """Explicit degree = n_pts - 1 gives the same result as default."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 5, degree=4)
+        b = Bezier.interpolate(lambda x: x**2, 5, degree=4)
         assert b.degree == (4,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
 
     def test_least_squares_quadratic(self) -> None:
         """Fitting x^2 with degree=2 from 5 sample points recovers it."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 5, degree=2)
+        b = Bezier.interpolate(lambda x: x**2, 5, degree=2)
         assert b.degree == (2,)
         pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
         nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
 
     def test_least_squares_linear(self) -> None:
         """Fitting a linear function with degree=1 from 10 points."""
-        b = Bezier.interpolate(lambda lat: 3.0 * lat.pts_per_dir[0] + 1.0, 10, degree=1)
+        b = Bezier.interpolate(lambda x: 3.0 * x + 1.0, 10, degree=1)
         assert b.degree == (1,)
         pts = np.array([0.0, 0.5, 1.0])
         nptest.assert_allclose(b.evaluate(pts), [1.0, 2.5, 4.0], atol=1e-12)
 
     def test_2d_least_squares(self) -> None:
         """Fitting x+y with degree=(1,1) from (3,3) samples."""
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            pts = lat.get_all_points()
-            return pts[:, 0] + pts[:, 1]
-
-        b = Bezier.interpolate(func, [3, 3], degree=[1, 1])
+        b = Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1, 1])
         assert b.degree == (1, 1)
         pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
         expected = pts[:, 0] + pts[:, 1]
@@ -359,17 +278,17 @@ class TestInterpolateDegree:
     def test_degree_too_large_raises(self) -> None:
         """Degree >= n_pts raises ValueError."""
         with pytest.raises(ValueError, match="must be < n_pts"):
-            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, degree=3)
+            Bezier.interpolate(lambda x: x, 3, degree=3)
 
     def test_degree_negative_raises(self) -> None:
         """Negative degree raises ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            Bezier.interpolate(lambda lat: lat.pts_per_dir[0], 3, degree=-1)
+            Bezier.interpolate(lambda x: x, 3, degree=-1)
 
     def test_degree_length_mismatch_raises(self) -> None:
         """Degree sequence length != n_pts sequence length raises ValueError."""
         with pytest.raises(ValueError, match="entries"):
-            Bezier.interpolate(lambda lat: lat.get_all_points()[:, 0], [3, 3], degree=[1])
+            Bezier.interpolate(lambda pts: pts[:, 0] + pts[:, 1], [3, 3], degree=[1])
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +345,7 @@ class TestFit1DVector:
 
 
 # ---------------------------------------------------------------------------
-# Bezier.fit — 2D tensor-product
+# Bezier.fit — 2D
 # ---------------------------------------------------------------------------
 
 
@@ -444,18 +363,6 @@ class TestFit2D:
         pts = np.array([[0.5, 0.5], [0.0, 1.0]])
         expected = pts[:, 0] + pts[:, 1]
         nptest.assert_allclose(b.evaluate(pts), expected, atol=1e-12)
-
-    def test_with_points_lattice(self) -> None:
-        """Fitting bilinear values using a PointsLattice for nodes."""
-        nodes_x = np.array([0.0, 1.0])
-        nodes_y = np.array([0.0, 1.0])
-        lattice = PointsLattice([nodes_x, nodes_y])
-        xx, yy = np.meshgrid(nodes_x, nodes_y, indexing="ij")
-        vals = xx + yy
-        b = Bezier.fit(vals, lattice)
-        assert b.degree == (1, 1)
-        pts = np.array([[0.5, 0.5]])
-        nptest.assert_allclose(b.evaluate(pts), [1.0], atol=1e-12)
 
 
 # ---------------------------------------------------------------------------
@@ -485,100 +392,7 @@ class TestFitDegree:
 
 
 # ---------------------------------------------------------------------------
-# Bezier.fit — scattered (non-tensor-product) points
-# ---------------------------------------------------------------------------
-
-
-class TestFitScattered1D:
-    """Tests for 1D scattered fitting."""
-
-    def test_linear_scattered(self) -> None:
-        """Fit a linear from scattered 1D points (presented as 2D array)."""
-        pts = np.array([[0.0], [0.3], [0.7], [1.0]])
-        vals = 2.0 * pts[:, 0] + 1.0
-        b = Bezier.fit(vals, pts, degree=1)
-        assert b.degree == (1,)
-        eval_pts = np.array([0.0, 0.5, 1.0])
-        nptest.assert_allclose(b.evaluate(eval_pts), [1.0, 2.0, 3.0], atol=1e-12)
-
-    def test_quadratic_scattered(self) -> None:
-        """Fit x^2 from scattered 1D points."""
-        pts = np.array([[0.0], [0.2], [0.5], [0.8], [1.0]])
-        vals = pts[:, 0] ** 2
-        b = Bezier.fit(vals, pts, degree=2)
-        assert b.degree == (2,)
-        eval_pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
-        nptest.assert_allclose(b.evaluate(eval_pts), eval_pts**2, atol=1e-12)
-
-
-class TestFitScattered2D:
-    """Tests for 2D scattered fitting."""
-
-    def test_bilinear_scattered(self) -> None:
-        """Fit x + y from scattered 2D points."""
-        rng = np.random.default_rng(42)
-        pts = rng.random((20, 2))
-        vals = pts[:, 0] + pts[:, 1]
-        b = Bezier.fit(vals, pts, degree=[1, 1])
-        assert b.degree == (1, 1)
-        eval_pts = np.array([[0.5, 0.5], [0.0, 1.0], [1.0, 0.0]])
-        expected = eval_pts[:, 0] + eval_pts[:, 1]
-        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
-
-    def test_biquadratic_scattered(self) -> None:
-        """Fit x^2 + y^2 from scattered 2D points."""
-        rng = np.random.default_rng(123)
-        pts = rng.random((30, 2))
-        vals = pts[:, 0] ** 2 + pts[:, 1] ** 2
-        b = Bezier.fit(vals, pts, degree=[2, 2])
-        assert b.degree == (2, 2)
-        eval_pts = np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])
-        expected = eval_pts[:, 0] ** 2 + eval_pts[:, 1] ** 2
-        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
-
-    def test_vector_scattered(self) -> None:
-        """Fit a vector-valued function from scattered 2D points."""
-        rng = np.random.default_rng(7)
-        pts = rng.random((20, 2))
-        vals = np.stack([pts[:, 0], pts[:, 1], pts[:, 0] + pts[:, 1]], axis=-1)
-        b = Bezier.fit(vals, pts, degree=[1, 1])
-        assert b.degree == (1, 1)
-        nptest.assert_equal(b.rank, 3)
-        eval_pts = np.array([[0.5, 0.5]])
-        expected = np.array([[0.5, 0.5, 1.0]])
-        nptest.assert_allclose(b.evaluate(eval_pts), expected, atol=1e-10)
-
-
-class TestFitScatteredValidation:
-    """Validation tests for scattered fitting."""
-
-    def test_degree_required(self) -> None:
-        """Scattered fitting without degree raises ValueError."""
-        pts = np.array([[0.0], [0.5], [1.0]])
-        with pytest.raises(ValueError, match="degree is required"):
-            Bezier.fit(np.array([1.0, 2.0, 3.0]), pts)
-
-    def test_underdetermined(self) -> None:
-        """Too few points for the requested degree raises ValueError."""
-        pts = np.array([[0.0, 0.0], [1.0, 1.0]])
-        with pytest.raises(ValueError, match="Underdetermined"):
-            Bezier.fit(np.array([1.0, 2.0]), pts, degree=[2, 2])
-
-    def test_values_pts_mismatch(self) -> None:
-        """Mismatched number of values and points raises ValueError."""
-        pts = np.array([[0.0], [0.5], [1.0]])
-        with pytest.raises(ValueError, match="entries"):
-            Bezier.fit(np.array([1.0, 2.0]), pts, degree=1)
-
-    def test_degree_dim_mismatch(self) -> None:
-        """Degree length != number of point columns raises ValueError."""
-        pts = np.array([[0.0, 0.0], [1.0, 1.0], [0.5, 0.5]])
-        with pytest.raises(ValueError, match="columns"):
-            Bezier.fit(np.array([1.0, 2.0, 3.0]), pts, degree=[1])
-
-
-# ---------------------------------------------------------------------------
-# Bezier.fit — validation (tensor-product)
+# Bezier.fit — validation
 # ---------------------------------------------------------------------------
 
 
@@ -589,6 +403,11 @@ class TestFitValidation:
         """Node array length != values length raises ValueError."""
         with pytest.raises(ValueError, match="does not match"):
             Bezier.fit(np.array([1.0, 2.0, 3.0]), np.array([0.0, 1.0]))
+
+    def test_non_floating_dtype(self) -> None:
+        """Non-floating dtype raises ValueError."""
+        with pytest.raises(ValueError, match="floating"):
+            Bezier.fit(np.array([1.0, 2.0]), np.array([0.0, 1.0]), dtype=np.int32)
 
     def test_degree_too_large(self) -> None:
         """Degree >= n_pts raises ValueError."""
@@ -607,81 +426,3 @@ class TestFitValidation:
         """Values with wrong number of dims raises ValueError."""
         with pytest.raises(ValueError, match="dimensions"):
             Bezier.fit(np.ones((2, 3, 4)), np.array([0.0, 1.0]))
-
-    def test_points_lattice_dim_mismatch(self) -> None:
-        """PointsLattice with wrong dimension count raises ValueError."""
-        lattice = PointsLattice([np.array([0.0, 1.0]), np.array([0.0, 1.0])])
-        # 2D lattice but 1D values
-        with pytest.raises(ValueError, match="dimensions"):
-            Bezier.fit(np.array([1.0, 2.0]), lattice)
-
-
-# ---------------------------------------------------------------------------
-# SVD tolerance parameter
-# ---------------------------------------------------------------------------
-
-
-class TestTolParameter:
-    """Tests for the tol parameter on interpolate and fit."""
-
-    def test_tol_affects_interpolate_result(self) -> None:
-        """A very aggressive tol changes the interpolation result."""
-        func = lambda lat: lat.pts_per_dir[0] ** 10  # noqa: E731
-
-        b_default = Bezier.interpolate(func, 15)
-        # tol=0.5 is extremely aggressive — will zero out most singular values
-        b_aggressive = Bezier.interpolate(func, 15, tol=0.5)
-
-        pts = np.array([0.25, 0.5, 0.75])
-        result_default = b_default.evaluate(pts)
-        result_aggressive = b_aggressive.evaluate(pts)
-        # The aggressive tol should produce a noticeably different result
-        assert not np.allclose(result_default, result_aggressive, atol=1e-3)
-
-    def test_tol_affects_fit_result(self) -> None:
-        """A very aggressive tol changes the fit result."""
-        nodes = np.linspace(0.0, 1.0, 15)
-        vals = nodes**10
-
-        b_default = Bezier.fit(vals, nodes)
-        b_aggressive = Bezier.fit(vals, nodes, tol=0.5)
-
-        pts = np.array([0.25, 0.5, 0.75])
-        result_default = b_default.evaluate(pts)
-        result_aggressive = b_aggressive.evaluate(pts)
-        assert not np.allclose(result_default, result_aggressive, atol=1e-3)
-
-    def test_small_tol_preserves_accuracy(self) -> None:
-        """A small (but non-default) tol still produces accurate results."""
-        b = Bezier.interpolate(lambda lat: lat.pts_per_dir[0] ** 2, 5, tol=1e-14)
-        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
-        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-12)
-
-
-# ---------------------------------------------------------------------------
-# float32 through interpolate path
-# ---------------------------------------------------------------------------
-
-
-class TestInterpolateFloat32:
-    """Tests for float32 dtype through the interpolate path."""
-
-    def test_float32_func_promoted_to_float64(self) -> None:
-        """Float32 return from func is promoted to float64 by the float64 nodes."""
-
-        def func(lat: PointsLattice) -> npt.NDArray[np.floating[Any]]:
-            t = np.asarray(lat.pts_per_dir[0], dtype=np.float32)
-            return t**2
-
-        b = Bezier.interpolate(func, 3)
-        # Nodes are generated as float64, so SVD operations promote to float64
-        assert b.dtype == np.float64
-        pts = np.array([0.0, 0.5, 1.0])
-        nptest.assert_allclose(b.evaluate(pts), pts**2, atol=1e-13)
-
-    def test_float32_with_float32_custom_nodes(self) -> None:
-        """Float32 nodes + float32 func return preserves float32 through fit."""
-        nodes = np.array([0.0, 0.5, 1.0], dtype=np.float32)
-        vals = np.array([0.0, 0.25, 1.0], dtype=np.float32)
-        b = Bezier.fit(vals, nodes)
-        assert b.dtype == np.float32

--- a/tests/test_bezier_resultant.py
+++ b/tests/test_bezier_resultant.py
@@ -1,0 +1,338 @@
+"""Tests for the resultant and discriminant computation pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.testing as nptest
+import numpy.typing as npt
+import pytest
+
+from pantr.basis._basis_core import _tabulate_Bernstein_basis_1D_core
+from pantr.bezier._bezier_derivative import _derivative_ctrl_1d, _derivative_ctrl_nd
+from pantr.bezier._bezier_interpolate import _bernstein_interpolate
+from pantr.bezier._resultant import (
+    _discriminant,
+    _discriminant_order,
+    _normalise,
+    _resultant,
+    _resultant_order,
+)
+from pantr.quad import get_modified_chebyshev_nodes_1d
+
+# ---------------------------------------------------------------------------
+# Bernstein derivative
+# ---------------------------------------------------------------------------
+
+
+class TestDerivativeCtrl1D:
+    """Tests for _derivative_ctrl_1d (Bernstein derivative on raw arrays)."""
+
+    def test_linear(self) -> None:
+        """Derivative of a linear: d/dx(a0(1-x) + a1*x) = a1 - a0."""
+        coeffs = np.array([1.0, 3.0])
+        result = _derivative_ctrl_1d(1, coeffs)
+        assert result.shape == (1,)
+        nptest.assert_allclose(result, [2.0])
+
+    def test_quadratic(self) -> None:
+        """Derivative of degree-2 Bernstein: out[i] = 2*(a[i+1]-a[i])."""
+        coeffs = np.array([1.0, 2.0, 5.0])
+        result = _derivative_ctrl_1d(2, coeffs)
+        assert result.shape == (2,)
+        nptest.assert_allclose(result, [2.0, 6.0])
+
+    def test_constant(self) -> None:
+        """Derivative of constant (degree 1 Bernstein [c, c]) is 0."""
+        coeffs = np.array([3.0, 3.0])
+        result = _derivative_ctrl_1d(1, coeffs)
+        nptest.assert_allclose(result, [0.0], atol=1e-15)
+
+
+class TestDerivativeCtrlND:
+    """Tests for _derivative_ctrl_nd."""
+
+    def test_2d_dim0(self) -> None:
+        """Derivative along dim=0 reduces order in that direction."""
+        coeffs = np.array([[1.0, 2.0], [3.0, 4.0], [7.0, 8.0]])
+        result = _derivative_ctrl_nd(coeffs, 0)
+        assert result.shape == (2, 2)
+        # d/dx along dim=0: (P-1)*(a[i+1,j] - a[i,j]) with P=3
+        expected = 2.0 * np.array([[2.0, 2.0], [4.0, 4.0]])
+        nptest.assert_allclose(result, expected)
+
+    def test_2d_dim1(self) -> None:
+        """Derivative along dim=1 reduces order in that direction."""
+        coeffs = np.array([[1.0, 2.0, 5.0], [3.0, 4.0, 9.0]])
+        result = _derivative_ctrl_nd(coeffs, 1)
+        assert result.shape == (2, 2)
+        # d/dy along dim=1: (Q-1)*(a[i,j+1] - a[i,j]) with Q=3
+        expected = 2.0 * np.array([[1.0, 3.0], [1.0, 5.0]])
+        nptest.assert_allclose(result, expected)
+
+
+# ---------------------------------------------------------------------------
+# Bernstein interpolation
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinInterpolate1D:
+    """Tests for 1D _bernstein_interpolate roundtrips."""
+
+    def test_roundtrip_linear(self) -> None:
+        """Interpolating linear Bernstein at 2 Chebyshev nodes recovers coefficients."""
+        coeffs = np.array([1.0, 3.0])
+        vals = self._eval_bernstein_at_chebyshev(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-14)
+
+    def test_roundtrip_quadratic(self) -> None:
+        """Interpolating quadratic Bernstein at 3 Chebyshev nodes recovers coefficients."""
+        coeffs = np.array([1.0, 2.0, 5.0])
+        vals = self._eval_bernstein_at_chebyshev(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-13)
+
+    def test_roundtrip_cubic(self) -> None:
+        """Interpolating cubic Bernstein at 4 nodes recovers coefficients."""
+        coeffs = np.array([1.0, 2.0, 0.5, 3.0])
+        vals = self._eval_bernstein_at_chebyshev(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-13)
+
+    def test_single_coefficient(self) -> None:
+        """Single-element input returns a copy."""
+        coeffs = np.array([42.0])
+        recovered = _bernstein_interpolate(coeffs)
+        nptest.assert_array_equal(recovered, coeffs)
+
+    @staticmethod
+    def _eval_bernstein_at_chebyshev(
+        coeffs: npt.NDArray[np.floating[Any]],
+    ) -> npt.NDArray[np.floating[Any]]:
+        """Evaluate Bernstein polynomial at modified Chebyshev nodes."""
+        n = len(coeffs)
+        nodes = get_modified_chebyshev_nodes_1d(n)
+        basis = np.empty((n, n), dtype=np.float64)
+        _tabulate_Bernstein_basis_1D_core(np.int32(n - 1), nodes, basis)
+        return basis @ coeffs
+
+
+class TestBernsteinInterpolateND:
+    """Tests for _bernstein_interpolate (N-D)."""
+
+    def test_2d_roundtrip(self) -> None:
+        """Interpolating 2D Bernstein coefficients at Chebyshev nodes recovers them."""
+        coeffs = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        # Evaluate at tensor-product Chebyshev nodes
+        n0, n1 = coeffs.shape
+        nodes0 = get_modified_chebyshev_nodes_1d(n0)
+        nodes1 = get_modified_chebyshev_nodes_1d(n1)
+        B0 = np.empty((n0, n0), dtype=np.float64)
+        B1 = np.empty((n1, n1), dtype=np.float64)
+        _tabulate_Bernstein_basis_1D_core(np.int32(n0 - 1), nodes0, B0)
+        _tabulate_Bernstein_basis_1D_core(np.int32(n1 - 1), nodes1, B1)
+        vals = B0 @ coeffs @ B1.T
+
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Normalise
+# ---------------------------------------------------------------------------
+
+
+class TestNormalise:
+    """Tests for _normalise."""
+
+    def test_scales_by_max(self) -> None:
+        """Max absolute value becomes 1 after normalisation."""
+        arr = np.array([2.0, -4.0, 1.0])
+        _normalise(arr)
+        nptest.assert_allclose(np.max(np.abs(arr)), 1.0, atol=1e-15)
+
+    def test_zero_array_unchanged(self) -> None:
+        """Zero array stays zero."""
+        arr = np.zeros(5)
+        _normalise(arr)
+        nptest.assert_array_equal(arr, np.zeros(5))
+
+    def test_modifies_in_place(self) -> None:
+        """Normalise modifies the input array."""
+        arr = np.array([2.0, -4.0])
+        result = _normalise(arr)
+        assert result is arr
+
+
+# ---------------------------------------------------------------------------
+# Extent computation
+# ---------------------------------------------------------------------------
+
+
+class TestResultantOrder:
+    """Tests for _resultant_order."""
+
+    def test_two_linears_2d(self) -> None:
+        """Two (2,2) polynomials along dim=0."""
+        ord_ = _resultant_order((2, 2), (2, 2), 0)
+        # (2-1)*(2-1) + (2-1)*(2-1) + 1 = 3
+        assert ord_ == (3,)
+
+    def test_two_linears_2d_dim1(self) -> None:
+        """Two (2,2) polynomials along dim=1."""
+        ord_ = _resultant_order((2, 2), (2, 2), 1)
+        assert ord_ == (3,)
+
+    def test_mixed_orders(self) -> None:
+        """Different orders in each direction."""
+        ord_ = _resultant_order((3, 2), (2, 3), 0)
+        # dim=0 eliminated. Remaining: dim=1.
+        # (3-1)*(3-1) + (2-1)*(2-1) + 1 = 4 + 1 + 1 = 6
+        assert ord_ == (6,)
+
+
+class TestDiscriminantOrder:
+    """Tests for _discriminant_order."""
+
+    def test_quadratic_2d(self) -> None:
+        """Discriminant of a (3, 2) polynomial along dim=0."""
+        ord_ = _discriminant_order((3, 2), 0)
+        # (2*3 - 3)*(2-1) + 1 = 3*1 + 1 = 4
+        assert ord_ == (4,)
+
+    def test_linear_2d(self) -> None:
+        """Discriminant of a (2, 2) polynomial along dim=0."""
+        ord_ = _discriminant_order((2, 2), 0)
+        # (2*2-3)*(2-1) + 1 = 1*1 + 1 = 2
+        assert ord_ == (2,)
+
+
+# ---------------------------------------------------------------------------
+# Resultant
+# ---------------------------------------------------------------------------
+
+
+class TestResultant1D:
+    """Tests for 1D resultant computation."""
+
+    def test_common_root(self) -> None:
+        """Resultant is zero when polynomials share a root."""
+        # p(x) = 1-2x, q(x) = x-0.5 — both zero at x=0.5
+        p = np.array([1.0, -1.0])
+        q = np.array([-0.5, 0.5])
+        res = _resultant(p, q, 0)
+        nptest.assert_allclose(float(res), 0.0, atol=1e-14)
+
+    def test_coprime(self) -> None:
+        """Resultant is nonzero for coprime polynomials."""
+        p = np.array([0.0, 1.0])  # x
+        q = np.array([1.0, 1.0])  # 1
+        res = _resultant(p, q, 0)
+        assert float(res) != 0.0
+
+    def test_quadratic_vs_linear(self) -> None:
+        """Resultant of quadratic and linear with different degrees."""
+        # p(x) = x^2 in Bernstein degree 2: [0, 0, 1]
+        # q(x) = x in Bernstein degree 1: [0, 1]
+        # Common root at x=0
+        p = np.array([0.0, 0.0, 1.0])
+        q = np.array([0.0, 1.0])
+        res = _resultant(p, q, 0)
+        nptest.assert_allclose(float(res), 0.0, atol=1e-14)
+
+
+class TestResultant2D:
+    """Tests for 2D resultant computation."""
+
+    def test_eliminates_dim0(self) -> None:
+        """Resultant along dim=0 produces a 1D polynomial."""
+        p = np.array([[0.0, 0.0], [1.0, 1.0]])
+        q = np.array([[1.0, -1.0], [1.0, -1.0]])
+        res = _resultant(p, q, 0)
+        assert res.ndim == 1
+
+    def test_result_proportional_to_expected(self) -> None:
+        """Res_x(x, 1-2y) ~ (1-2y) in Bernstein basis."""
+        p = np.array([[0.0, 0.0], [1.0, 1.0]])  # x
+        q = np.array([[1.0, -1.0], [1.0, -1.0]])  # 1-2y
+        res = _resultant(p, q, 0)
+        # Result should be proportional to [1, -1] (i.e. 1-2y in Bernstein)
+        _normalise(res)
+        nptest.assert_allclose(np.abs(res), [1.0, 1.0], atol=1e-10)
+
+    def test_coprime_gives_nonzero(self) -> None:
+        """Coprime polynomials in x give nonzero resultant."""
+        p = np.array([[0.0, 0.0], [1.0, 1.0]])  # x
+        q = np.array([[-0.5, -0.5], [0.5, 0.5]])  # x - 0.5
+        res = _resultant(p, q, 0)
+        assert np.any(res != 0.0)
+
+
+class TestResultantValidation:
+    """Input validation tests for _resultant."""
+
+    def test_mismatched_ndim(self) -> None:
+        with pytest.raises(ValueError, match="same number of dimensions"):
+            _resultant(np.array([1.0, 2.0]), np.array([[1.0, 2.0]]), 0)
+
+    def test_non_floating(self) -> None:
+        with pytest.raises(ValueError, match="floating dtype"):
+            _resultant(np.array([1, 2]), np.array([1, 2]), 0)
+
+    def test_dim_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match="dim must be"):
+            _resultant(np.array([1.0, 2.0]), np.array([1.0, 2.0]), 1)
+
+    def test_p_order_too_small(self) -> None:
+        with pytest.raises(ValueError, match="order >= 2"):
+            _resultant(np.array([1.0]), np.array([1.0, 2.0]), 0)
+
+    def test_q_order_too_small(self) -> None:
+        with pytest.raises(ValueError, match="order >= 2"):
+            _resultant(np.array([1.0, 2.0]), np.array([3.0]), 0)
+
+
+# ---------------------------------------------------------------------------
+# Discriminant
+# ---------------------------------------------------------------------------
+
+
+class TestDiscriminant1D:
+    """Tests for 1D discriminant computation."""
+
+    def test_double_root(self) -> None:
+        """Discriminant vanishes for polynomial with double root."""
+        # (x-0.5)^2 in Bernstein degree 2: [0.25, -0.25, 0.25]
+        p = np.array([0.25, -0.25, 0.25])
+        disc = _discriminant(p, 0)
+        nptest.assert_allclose(float(disc), 0.0, atol=1e-14)
+
+    def test_distinct_roots(self) -> None:
+        """Discriminant is nonzero for polynomial with distinct roots."""
+        # x(1-x) in Bernstein: [0, 0.5, 0]
+        p = np.array([0.0, 0.5, 0.0])
+        disc = _discriminant(p, 0)
+        assert float(disc) != 0.0
+
+    def test_linear_raises(self) -> None:
+        """Discriminant of a linear raises because degree must be >= 2."""
+        p = np.array([1.0, 3.0])
+        with pytest.raises(ValueError, match="order >= 3"):
+            _discriminant(p, 0)
+
+
+class TestDiscriminant2D:
+    """Tests for 2D discriminant computation."""
+
+    def test_reduces_dimension(self) -> None:
+        """Discriminant along one dim produces result with one fewer dim."""
+        p = np.array([[1.0, 0.0, 1.0], [2.0, 1.0, 2.0]])
+        disc = _discriminant(p, 1)
+        assert disc.ndim == 1
+
+    def test_discriminant_validation(self) -> None:
+        """Non-floating input raises ValueError."""
+        with pytest.raises(ValueError, match="floating dtype"):
+            _discriminant(np.array([1, 2, 3]), 0)

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -173,6 +173,59 @@ class TestBezierReduceDegreeErrors:
 
 
 # ---------------------------------------------------------------------------
+# Minimize degree
+# ---------------------------------------------------------------------------
+
+
+class TestBezierMinimizeDegree:
+    """Test Bezier.minimize_degree."""
+
+    def test_constant_reduces_to_degree_0(self) -> None:
+        """A constant elevated to degree 2 should reduce back to degree 0."""
+        b = _make_bezier_1d([[3.0], [3.0], [3.0]])
+        b_min = b.minimize_degree()
+        assert b_min.degree[0] < b.degree[0]
+        pts = np.linspace(0.0, 1.0, 10, dtype=np.float64)
+        np.testing.assert_allclose(b_min.evaluate(pts), b.evaluate(pts), atol=1e-12)
+
+    def test_true_quadratic_not_reduced(self) -> None:
+        """A genuine quadratic should not be reduced."""
+        b = _make_bezier_1d([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]])
+        b_min = b.minimize_degree()
+        assert b_min.degree == b.degree
+
+    def test_linear_elevated_reduces(self) -> None:
+        """A linear elevated to degree 3 should reduce back."""
+        b = _make_bezier_1d([[1.0], [3.0]])
+        b_elev = b.elevate_degree(2)
+        assert b_elev.degree == (3,)
+        b_min = b_elev.minimize_degree()
+        assert b_min.degree[0] < b_elev.degree[0]
+        pts = np.linspace(0.0, 1.0, 10, dtype=np.float64)
+        np.testing.assert_allclose(b_min.evaluate(pts), b.evaluate(pts), atol=1e-12)
+
+    def test_2d_constant_in_one_direction(self) -> None:
+        """A 2D polynomial constant in one direction reduces along it."""
+        ctrl = np.array([[[0.0], [1.0], [0.0]], [[0.0], [1.0], [0.0]]])  # (2, 3, 1)
+        b = Bezier(ctrl)
+        assert b.degree == (1, 2)
+        b_min = b.minimize_degree()
+        assert b_min.degree[0] < b.degree[0]
+        assert b_min.degree[1] == b.degree[1]
+
+    def test_vector_valued(self) -> None:
+        """Vector-valued Bezier: all components checked together."""
+        # Linear in both components, elevated to degree 2
+        b = Bezier(np.array([[0.0, 0.0], [1.0, 2.0]]))
+        b_elev = b.elevate_degree(1)
+        assert b_elev.degree == (2,)
+        b_min = b_elev.minimize_degree()
+        assert b_min.degree[0] < b_elev.degree[0]
+        pts = np.linspace(0.0, 1.0, 10, dtype=np.float64)
+        np.testing.assert_allclose(b_min.evaluate(pts), b.evaluate(pts), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
 # Float32 support
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `Bezier.interpolate` / `Bezier.fit` classmethods and the underlying Bernstein interpolation pipeline (SVD of Vandermonde matrix at modified Chebyshev nodes)
- Add `Bezier.minimize_degree(tol)` — automatically finds the lowest polynomial degree preserving accuracy within tolerance
- Add resultant and discriminant computation for multivariate Bernstein polynomials via Sylvester/Bezout matrix determinants, following the algoim pipeline (Saye, J. Comput. Phys. 448, 2022)
- Extract `_derivative_ctrl_nd` helper for N-D coefficient array differentiation

## Test plan
- [x] 39 interpolation tests (1D/2D, scalar/vector, node selection, dtype, validation, least-squares)
- [x] 5 minimize_degree tests (constant, quadratic, elevated, 2D, vector-valued)
- [x] 33 resultant/discriminant tests (derivatives, interpolation roundtrips, normalisation, resultant 1D/2D, discriminant 1D/2D, validation)
- [x] ruff, mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)