### PR TITLE
refactor(root_finding): unify single and batch root-finding APIs

### DIFF
--- a/src/pantr/bezier/__init__.py
+++ b/src/pantr/bezier/__init__.py
@@ -10,27 +10,21 @@ Bernstein algorithms implemented in ``_bezier_core``, ``_bezier_eval``,
 
 Root-finding exports:
 
-- :func:`find_roots` -- find all roots (single polynomial, auto-dispatch).
-- :func:`find_roots_batch` -- find roots of many same-degree polynomials.
-- :func:`solve_monotone_root` -- fast solver for a single monotone polynomial.
-- :func:`solve_monotone_root_batch` -- batch-parallel monotone solver.
+- :func:`find_roots` -- find all roots (single or batch, auto-dispatch).
+- :func:`solve_monotone_root` -- fast solver for monotone polynomials (single or batch).
 """
 
 from ._bezier import Bezier
 from ._bezier_interpolate import fit_bezier, interpolate_bezier
 from ._root_finding import (
     find_roots,
-    find_roots_batch,
     solve_monotone_root,
-    solve_monotone_root_batch,
 )
 
 __all__ = [
     "Bezier",
     "find_roots",
-    "find_roots_batch",
     "fit_bezier",
     "interpolate_bezier",
     "solve_monotone_root",
-    "solve_monotone_root_batch",
 ]

--- a/src/pantr/bezier/_root_finding.py
+++ b/src/pantr/bezier/_root_finding.py
@@ -4,16 +4,14 @@ This module contains the Layer 1 public functions for finding roots of
 scalar Bernstein polynomials on [0, 1]. Each function performs lightweight
 validation and delegates to Layer 2 implementations in :mod:`_find_roots`.
 
-- :func:`find_roots` -- find all roots (single Bezier, auto-dispatch).
-- :func:`find_roots_batch` -- find roots of many same-degree Beziers.
-- :func:`solve_monotone_root` -- fast solver for a single monotone Bezier.
-- :func:`solve_monotone_root_batch` -- batch-parallel monotone solver.
+- :func:`find_roots` -- find all roots (single or batch, auto-dispatch).
+- :func:`solve_monotone_root` -- fast solver for monotone Beziers (single or batch).
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 from numpy import typing as npt
@@ -29,59 +27,50 @@ if TYPE_CHECKING:
     from pantr.bezier._bezier import Bezier
 
 
+@overload
 def find_roots(
     bezier: Bezier,
     *,
+    tol: float | None = ...,
+) -> npt.NDArray[np.float64]: ...
+
+
+@overload
+def find_roots(
+    bezier: Sequence[Bezier],
+    *,
+    tol: float | None = ...,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]: ...
+
+
+def find_roots(
+    bezier: Bezier | Sequence[Bezier],
+    *,
     tol: float | None = None,
-) -> npt.NDArray[np.float64]:
-    """Find all roots of a scalar Bezier curve in [0, 1].
+) -> npt.NDArray[np.float64] | tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]:
+    """Find all roots of one or more scalar Bezier curves in [0, 1].
 
     Auto-selects between Yuksel's monotone-decomposition algorithm and Bezier
     clipping based on polynomial degree and coefficient dynamic range.
 
+    When called with a single :class:`Bezier`, returns a sorted array of root
+    parameters. When called with a sequence of Beziers (batch mode), all curves
+    must have the same degree and the function returns a ``(roots, counts)``
+    tuple.
+
     Args:
-        bezier (Bezier): A 1-D (``dim == 1``) scalar (``rank == 1``) Bezier
-            curve. For rational Beziers, roots are found on the numerator
-            polynomial (first homogeneous component).
+        bezier (Bezier | Sequence[Bezier]): A single 1-D (``dim == 1``) scalar
+            (``rank == 1``) Bezier curve, or a sequence of such curves (all with
+            the same degree). For rational Beziers, roots are found on the
+            numerator polynomial (first homogeneous component).
         tol (float | None): Root-finding tolerance (bracket-width
             termination). Defaults to ``tolerance.get_strict(bezier.dtype)``.
 
     Returns:
-        npt.NDArray[np.float64]: Sorted array of root parameters in [0, 1].
-            Empty if no roots exist. Always float64 regardless of input dtype.
-
-    Raises:
-        TypeError: If ``bezier`` is not a :class:`Bezier` instance.
-        ValueError: If ``bezier.dim != 1``, ``bezier.rank != 1``, or ``tol``
-            is not positive.
-
-    Example:
-        >>> import numpy as np
-        >>> from pantr.bezier import Bezier, find_roots
-        >>> find_roots(Bezier([1.0, -1.0]))
-        array([0.5])
-    """
-    return _find_roots_impl(bezier, tol=tol)
-
-
-def find_roots_batch(
-    beziers: Sequence[Bezier],
-    *,
-    tol: float | None = None,
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]:
-    """Find roots of multiple same-degree scalar Bezier curves in parallel.
-
-    All Beziers in the batch must have the same degree.
-
-    Args:
-        beziers (Sequence[Bezier]): Sequence of 1-D (``dim == 1``) scalar
-            (``rank == 1``) Bezier curves, all with the same degree. For
-            rational Beziers, roots are found on the numerator polynomial.
-        tol (float | None): Root-finding tolerance. Defaults to
-            ``tolerance.get_strict(dtype)`` of the first Bezier.
-
-    Returns:
-        tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]:
+        npt.NDArray[np.float64]: *(single mode)* Sorted array of root
+            parameters in [0, 1]. Empty if no roots exist. Always float64
+            regardless of input dtype.
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]: *(batch mode)*
             - ``roots``: padded array of shape ``(n_polys, degree)`` where
               only the first ``counts[i]`` entries per row are valid.
               Always float64.
@@ -89,73 +78,86 @@ def find_roots_batch(
               of valid roots per polynomial.
 
     Raises:
-        TypeError: If any element is not a :class:`Bezier` instance.
-        ValueError: If any Bezier has ``dim != 1`` or ``rank != 1``, or if
-            degrees are not uniform, or ``tol`` is not positive.
+        TypeError: If ``bezier`` is not a :class:`Bezier` instance (or sequence
+            thereof).
+        ValueError: If any Bezier has ``dim != 1`` or ``rank != 1``, or ``tol``
+            is not positive. In batch mode, also raised if degrees are not
+            uniform.
 
     Note:
-        The batch path uses a simpler fixed-threshold dedup (no
-        derivative-aware merge radius) compared to :func:`find_roots`.
-        In rare edge cases involving near-duplicate roots, the two
-        functions may report different root counts.
+        In batch mode, a simpler fixed-threshold dedup (no derivative-aware
+        merge radius) is used compared to single mode. In rare edge cases
+        involving near-duplicate roots, the two modes may report different
+        root counts.
+
+    Example:
+        >>> import numpy as np
+        >>> from pantr.bezier import Bezier, find_roots
+        >>> find_roots(Bezier([1.0, -1.0]))
+        array([0.5])
     """
-    return _find_roots_batch_impl(beziers, tol=tol)
+    from pantr.bezier._bezier import Bezier as BezierCls  # noqa: PLC0415
+
+    if isinstance(bezier, BezierCls):
+        return _find_roots_impl(bezier, tol=tol)
+    return _find_roots_batch_impl(bezier, tol=tol)
 
 
+@overload
 def solve_monotone_root(
     bezier: Bezier,
     *,
-    tol: float | None = None,
-) -> float:
-    """Find the unique root of a monotone scalar Bezier curve in [0, 1].
+    tol: float | None = ...,
+) -> float: ...
 
-    Uses a Newton/bisection hybrid with false-position initialization. The
-    Bezier must be monotone on [0, 1] (i.e. its derivative does not
-    change sign).
+
+@overload
+def solve_monotone_root(
+    bezier: Sequence[Bezier],
+    *,
+    tol: float | None = ...,
+) -> npt.NDArray[np.float64]: ...
+
+
+def solve_monotone_root(
+    bezier: Bezier | Sequence[Bezier],
+    *,
+    tol: float | None = None,
+) -> float | npt.NDArray[np.float64]:
+    """Find the unique root of one or more monotone scalar Bezier curves in [0, 1].
+
+    Uses a Newton/bisection hybrid with false-position initialization. Each
+    Bezier must be monotone on [0, 1] (i.e. its derivative does not change
+    sign).
+
+    When called with a single :class:`Bezier`, returns a float. When called
+    with a sequence of Beziers (batch mode), all curves must have the same
+    degree and the function returns an array.
 
     Args:
-        bezier (Bezier): A 1-D (``dim == 1``) scalar (``rank == 1``) Bezier
-            curve. For rational Beziers, roots are found on the numerator
-            polynomial.
+        bezier (Bezier | Sequence[Bezier]): A single 1-D (``dim == 1``) scalar
+            (``rank == 1``) Bezier curve, or a sequence of such curves (all with
+            the same degree). For rational Beziers, roots are found on the
+            numerator polynomial.
         tol (float | None): Parameter-space termination tolerance. Defaults
             to ``tolerance.get_strict(bezier.dtype)``.
 
     Returns:
-        float: Root parameter in [0, 1], or ``NaN`` if no root exists (no
-            sign change across the interval).
+        float: *(single mode)* Root parameter in [0, 1], or ``NaN`` if no root
+            exists (no sign change across the interval).
+        npt.NDArray[np.float64]: *(batch mode)* 1-D array of shape
+            ``(n_polys,)`` with root values. Contains ``NaN`` where no root
+            exists. Always float64.
 
     Raises:
-        TypeError: If ``bezier`` is not a :class:`Bezier` instance.
-        ValueError: If ``bezier.dim != 1``, ``bezier.rank != 1``, or ``tol``
-            is not positive.
+        TypeError: If ``bezier`` is not a :class:`Bezier` instance (or sequence
+            thereof).
+        ValueError: If any Bezier has ``dim != 1`` or ``rank != 1``, or ``tol``
+            is not positive. In batch mode, also raised if degrees are not
+            uniform.
     """
-    return _solve_monotone_root_impl(bezier, tol=tol)
+    from pantr.bezier._bezier import Bezier as BezierCls  # noqa: PLC0415
 
-
-def solve_monotone_root_batch(
-    beziers: Sequence[Bezier],
-    *,
-    tol: float | None = None,
-) -> npt.NDArray[np.float64]:
-    """Solve for roots on multiple monotone scalar Bezier curves in parallel.
-
-    Each Bezier must be monotone on [0, 1]. The batch must have uniform
-    degree.
-
-    Args:
-        beziers (Sequence[Bezier]): Sequence of 1-D (``dim == 1``) scalar
-            (``rank == 1``) Bezier curves, all with the same degree. For
-            rational Beziers, roots are found on the numerator polynomial.
-        tol (float | None): Parameter-space termination tolerance. Defaults
-            to ``tolerance.get_strict(dtype)`` of the first Bezier.
-
-    Returns:
-        npt.NDArray[np.float64]: 1-D array of shape ``(n_polys,)`` with root
-            values. Contains ``NaN`` where no root exists. Always float64.
-
-    Raises:
-        TypeError: If any element is not a :class:`Bezier` instance.
-        ValueError: If any Bezier has ``dim != 1`` or ``rank != 1``, or if
-            degrees are not uniform, or ``tol`` is not positive.
-    """
-    return _solve_monotone_root_batch_impl(beziers, tol=tol)
+    if isinstance(bezier, BezierCls):
+        return _solve_monotone_root_impl(bezier, tol=tol)
+    return _solve_monotone_root_batch_impl(bezier, tol=tol)

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -417,7 +417,7 @@ class TestFindRoots(unittest.TestCase):
     def test_non_bezier_raises(self) -> None:
         """Non-Bezier input raises TypeError."""
         with self.assertRaises(TypeError):
-            find_roots(np.array([1.0, -1.0]))  # type: ignore[arg-type]
+            find_roots(np.array([1.0, -1.0]))  # type: ignore
 
     def test_dim_not_one_raises(self) -> None:
         """Bezier surface (dim=2) raises ValueError."""
@@ -498,7 +498,7 @@ class TestSolveMonotoneRoot(unittest.TestCase):
     def test_non_bezier_raises(self) -> None:
         """Non-Bezier input raises TypeError."""
         with self.assertRaises(TypeError):
-            solve_monotone_root(np.array([-1.0, 1.0]))  # type: ignore[arg-type]
+            solve_monotone_root(np.array([-1.0, 1.0]))  # type: ignore
 
 
 class TestFindRootsBatch(unittest.TestCase):

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -2,10 +2,8 @@
 
 Covers:
 
-- :func:`find_roots` -- auto-dispatch root finder (single Bezier).
-- :func:`find_roots_batch` -- batch-parallel root finder.
-- :func:`solve_monotone_root` -- Newton/bisection on monotone Beziers.
-- :func:`solve_monotone_root_batch` -- batch-parallel monotone solver.
+- :func:`find_roots` -- auto-dispatch root finder (single or batch).
+- :func:`solve_monotone_root` -- Newton/bisection on monotone Beziers (single or batch).
 - Internal helpers: de Casteljau scalar, split, subdivide, sign changes,
   convex hull clipping, Newton polish.
 """
@@ -20,9 +18,7 @@ from numpy.testing import assert_allclose
 from pantr.bezier import (
     Bezier,
     find_roots,
-    find_roots_batch,
     solve_monotone_root,
-    solve_monotone_root_batch,
 )
 from pantr.bezier._clipping_core import (
     _clip_roots_core,
@@ -506,13 +502,13 @@ class TestSolveMonotoneRoot(unittest.TestCase):
 
 
 class TestFindRootsBatch(unittest.TestCase):
-    """Tests for :func:`find_roots_batch` (public API)."""
+    """Tests for :func:`find_roots` batch mode (public API)."""
 
     def test_single_polynomial(self) -> None:
         """Batch of one polynomial matches single-poly result."""
         bez = Bezier([0.1, -0.3, 0.1])
         roots_single = find_roots(bez, tol=1e-12)
-        roots_batch, counts = find_roots_batch([bez], tol=1e-12)
+        roots_batch, counts = find_roots([bez], tol=1e-12)
         self.assertEqual(counts[0], len(roots_single))
         assert_allclose(
             np.sort(roots_batch[0, : counts[0]]),
@@ -527,7 +523,7 @@ class TestFindRootsBatch(unittest.TestCase):
             Bezier([1.0, 2.0, 3.0]),  # no roots
             Bezier([0.1, -0.3, 0.1]),  # two roots
         ]
-        roots, counts = find_roots_batch(beziers, tol=1e-12)
+        roots, counts = find_roots(beziers, tol=1e-12)
         self.assertEqual(roots.shape[0], 3)
         self.assertGreaterEqual(counts[0], 1)
         self.assertEqual(counts[1], 0)
@@ -536,29 +532,29 @@ class TestFindRootsBatch(unittest.TestCase):
     def test_degree_zero_batch(self) -> None:
         """Batch of degree-0 Beziers: all return 0 roots."""
         beziers = [Bezier([5.0]), Bezier([3.0])]
-        _, counts = find_roots_batch(beziers)
+        _, counts = find_roots(beziers)
         self.assertEqual(counts[0], 0)
         self.assertEqual(counts[1], 0)
 
     def test_empty_batch(self) -> None:
         """Empty batch returns empty arrays without error."""
-        roots, counts = find_roots_batch([])
+        roots, counts = find_roots([])
         self.assertEqual(roots.shape, (0, 1))
         self.assertEqual(counts.shape, (0,))
 
     def test_mismatched_degree_raises(self) -> None:
         """Beziers with different degrees raise ValueError."""
         with self.assertRaises(ValueError, msg="same degree"):
-            find_roots_batch([Bezier([1.0, -1.0]), Bezier([1.0, 0.0, -1.0])])
+            find_roots([Bezier([1.0, -1.0]), Bezier([1.0, 0.0, -1.0])])
 
     def test_non_bezier_in_batch_raises(self) -> None:
         """Non-Bezier element in batch raises TypeError."""
         with self.assertRaises(TypeError):
-            find_roots_batch([Bezier([1.0, -1.0]), np.array([1.0, -1.0])])  # type: ignore[list-item]
+            find_roots([Bezier([1.0, -1.0]), np.array([1.0, -1.0])])  # type: ignore[list-item]
 
 
 class TestSolveMonotoneRootBatch(unittest.TestCase):
-    """Tests for :func:`solve_monotone_root_batch` (public API)."""
+    """Tests for :func:`solve_monotone_root` batch mode (public API)."""
 
     def test_mixed_roots(self) -> None:
         """Batch with some roots and some NaN."""
@@ -567,7 +563,7 @@ class TestSolveMonotoneRootBatch(unittest.TestCase):
             Bezier([1.0, 2.0]),  # no root
             Bezier([0.0, 1.0]),  # root at 0.0
         ]
-        roots = solve_monotone_root_batch(beziers)
+        roots = solve_monotone_root(beziers)
         self.assertAlmostEqual(roots[0], 0.5, places=12)
         self.assertTrue(np.isnan(roots[1]))
         self.assertAlmostEqual(roots[2], 0.0, places=10)
@@ -576,19 +572,19 @@ class TestSolveMonotoneRootBatch(unittest.TestCase):
         """Batch of one matches single-poly result."""
         bez = Bezier([-1.0, 0.0, 1.0])
         root_single = solve_monotone_root(bez)
-        roots_batch = solve_monotone_root_batch([bez])
+        roots_batch = solve_monotone_root([bez])
         self.assertAlmostEqual(roots_batch[0], root_single, places=12)
 
     def test_all_no_roots(self) -> None:
         """Batch where no Bezier has a root."""
         beziers = [Bezier([1.0, 2.0, 3.0]), Bezier([4.0, 5.0, 6.0])]
-        roots = solve_monotone_root_batch(beziers)
+        roots = solve_monotone_root(beziers)
         self.assertTrue(np.isnan(roots[0]))
         self.assertTrue(np.isnan(roots[1]))
 
     def test_empty_batch(self) -> None:
         """Empty batch returns empty array without error."""
-        roots = solve_monotone_root_batch([])
+        roots = solve_monotone_root([])
         self.assertEqual(roots.shape, (0,))
 
 

--- a/tests/test_root_finding_stress.py
+++ b/tests/test_root_finding_stress.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 from numpy import typing as npt
 
-from pantr.bezier import Bezier, find_roots, find_roots_batch
+from pantr.bezier import Bezier, find_roots
 from pantr.bezier._clipping_core import _clip_roots_core, _dedup_roots
 from pantr.bezier._root_finding_core import _de_casteljau_eval_scalar
 from pantr.bezier._yuksel_core import _yuksel_roots
@@ -295,7 +295,7 @@ class TestBatchConsistency:
         coeffs = rng.uniform(-2.0, 2.0, (n_polys, degree + 1)).astype(np.float64)
 
         beziers = [Bezier(coeffs[i]) for i in range(n_polys)]
-        roots_batch, counts_batch = find_roots_batch(beziers, tol=1e-12)
+        roots_batch, counts_batch = find_roots(beziers, tol=1e-12)
 
         for i in range(n_polys):
             roots_single = find_roots(beziers[i], tol=1e-12)


### PR DESCRIPTION
## Summary
- Merge `find_roots` and `find_roots_batch` into a single `find_roots` that accepts either a `Bezier` or a `Sequence[Bezier]`, dispatching via `isinstance`
- Merge `solve_monotone_root` and `solve_monotone_root_batch` into a single `solve_monotone_root` with the same pattern
- Use `@overload` decorators for correct return-type narrowing (single → sorted array/float, batch → tuple/array)
- Remove `find_roots_batch` and `solve_monotone_root_batch` from public exports

## Test plan
- [x] All 69 root-finding tests pass
- [ ] Stress tests pass (`pytest tests/test_root_finding_stress.py --no-cov -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)