### PR TITLE
fix(bspline,bezier): address PR #122 review issues

### DIFF
--- a/src/pantr/_interpolation_utils.py
+++ b/src/pantr/_interpolation_utils.py
@@ -1,0 +1,48 @@
+"""Shared utilities for interpolation and fitting modules.
+
+Provides constants and helpers used by both
+:mod:`pantr.bezier._bezier_interpolate` and
+:mod:`pantr.bspline._bspline_interpolate`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+SVD_TOL_FACTOR: float = 100.0
+"""Factor multiplied by machine epsilon for default SVD truncation tolerance."""
+
+
+def split_components(
+    values: npt.NDArray[np.floating[Any]],
+    grid_shape: tuple[int, ...],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Split function values into per-component arrays.
+
+    For scalar-valued data (shape matches *grid_shape* exactly), returns a
+    single-element list. For vector-valued data (shape is
+    ``(*grid_shape, rank)``), returns one array per trailing component.
+
+    Args:
+        values (npt.NDArray[np.floating[Any]]): Function output array.
+        grid_shape (tuple[int, ...]): Expected grid shape
+            ``(n_0, n_1, ...)``.
+
+    Returns:
+        list[npt.NDArray[np.floating[Any]]]: One array per output component,
+        each with shape ``grid_shape``.
+
+    Raises:
+        ValueError: If *values* shape is incompatible with *grid_shape*.
+    """
+    if values.shape == grid_shape:
+        return [values]
+    if values.shape[: len(grid_shape)] == grid_shape and values.ndim == len(grid_shape) + 1:
+        return [values[..., r] for r in range(values.shape[-1])]
+    raise ValueError(
+        f"Values have shape {values.shape}, expected {grid_shape} "
+        f"(scalar) or {(*grid_shape, 'rank')} (vector)."
+    )

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -32,13 +32,11 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import numpy.typing as npt
 
+from .._interpolation_utils import SVD_TOL_FACTOR, split_components
 from ..quad import PointsLattice, get_modified_chebyshev_nodes_1d
 
 if TYPE_CHECKING:
     from . import Bezier
-
-_SVD_TOL_FACTOR: float = 100.0
-"""Factor multiplied by machine epsilon for SVD truncation tolerance."""
 
 
 def _bernstein_vandermonde_svd(
@@ -103,7 +101,7 @@ def _bernstein_interpolate_1d(
 
     eps = float(np.finfo(dtype).eps)
     if tol is None:
-        tol = 100.0 * eps
+        tol = SVD_TOL_FACTOR * eps
 
     U, sigma, Vt = _bernstein_vandermonde_svd(n, dtype)
 
@@ -154,7 +152,7 @@ def _bernstein_interpolate(
         U, sigma, Vt = _bernstein_vandermonde_svd(n, f.dtype)
 
         eps = float(np.finfo(f.dtype).eps)
-        actual_tol = tol if tol is not None else 100.0 * eps
+        actual_tol = tol if tol is not None else SVD_TOL_FACTOR * eps
         min_sigma = actual_tol * sigma[0]
         inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
 
@@ -290,7 +288,7 @@ def _build_bernstein_pinv(
     U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
 
     eps = float(np.finfo(dtype).eps)
-    actual_tol = tol if tol is not None else 100.0 * eps
+    actual_tol = tol if tol is not None else SVD_TOL_FACTOR * eps
     min_sigma = actual_tol * sigma[0]
     inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
 
@@ -378,7 +376,7 @@ def _fit_from_scattered(
     # SVD pseudo-inverse with truncation
     U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
     eps = float(np.finfo(dtype).eps)
-    actual_tol = tol if tol is not None else 100.0 * eps
+    actual_tol = tol if tol is not None else SVD_TOL_FACTOR * eps
     min_sigma = actual_tol * sigma[0]
     inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
     pinv: npt.NDArray[np.floating[Any]] = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
@@ -450,32 +448,6 @@ def _validate_degree(
                 f"(need at least degree + 1 sample points)."
             )
     return deg_tuple
-
-
-def _split_components(
-    values: npt.NDArray[np.floating[Any]],
-    grid_shape: tuple[int, ...],
-) -> list[npt.NDArray[np.floating[Any]]]:
-    """Split function values into per-component arrays.
-
-    Args:
-        values (npt.NDArray[np.floating[Any]]): Function output array.
-        grid_shape (tuple[int, ...]): Expected grid shape.
-
-    Returns:
-        list[npt.NDArray[np.floating[Any]]]: One array per output component.
-
-    Raises:
-        ValueError: If values shape is incompatible with grid_shape.
-    """
-    if values.shape == grid_shape:
-        return [values]
-    if values.shape[: len(grid_shape)] == grid_shape and values.ndim == len(grid_shape) + 1:
-        return [values[..., r] for r in range(values.shape[-1])]
-    raise ValueError(
-        f"Function returned shape {values.shape}, expected {grid_shape} "
-        f"(scalar) or {(*grid_shape, 'rank')} (vector)."
-    )
 
 
 def _fit_from_values(
@@ -627,7 +599,7 @@ def interpolate_bezier(
             f"Function returned shape {raw.shape}, expected ({n_total},) or ({n_total}, rank)."
         )
 
-    components = _split_components(values, n_pts_tuple)
+    components = split_components(values, n_pts_tuple)
     ctrl = _fit_from_values(components, node_arrays, degree_tuple, tol)
     return BezierCls(ctrl, is_rational=False)
 
@@ -834,6 +806,6 @@ def fit_bezier(  # noqa: PLR0912
 
     degree_tuple_tp = _validate_degree(degree, n_pts_tuple)
     node_arrays = _resolve_nodes_from_user(nodes, n_pts_tuple, dtype_obj)
-    components = _split_components(values_arr, n_pts_tuple)
+    components = split_components(values_arr, n_pts_tuple)
     ctrl = _fit_from_values(components, node_arrays, degree_tuple_tp, tol)
     return BezierCls(ctrl, is_rational=False)

--- a/src/pantr/bezier/_resultant.py
+++ b/src/pantr/bezier/_resultant.py
@@ -22,9 +22,10 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
+from .._interpolation_utils import SVD_TOL_FACTOR
 from ..quad import get_modified_chebyshev_nodes_1d
 from ._bezier_derivative import _derivative_ctrl_nd
-from ._bezier_interpolate import _SVD_TOL_FACTOR, _bernstein_interpolate
+from ._bezier_interpolate import _bernstein_interpolate
 from ._resultant_matrices import _bezout_matrix, _det_qr, _sylvester_matrix
 
 _RESULTANT_REDUCTION_TOL_FACTOR: float = 1.0e4
@@ -355,7 +356,7 @@ def _evaluate_det_on_grid(
         f[multi_idx] = det
 
     _normalise(f)
-    interp_tol = (_SVD_TOL_FACTOR * eps) ** (1.0 / max(ndim - 1, 1))
+    interp_tol = (SVD_TOL_FACTOR * eps) ** (1.0 / max(ndim - 1, 1))
     return _bernstein_interpolate(f, interp_tol)
 
 

--- a/src/pantr/bspline/_bspline_interpolate.py
+++ b/src/pantr/bspline/_bspline_interpolate.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from numpy import typing as npt
 
+from .._interpolation_utils import SVD_TOL_FACTOR, split_components
 from ..quad import PointsLattice
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_factory import greville_abscissae, greville_lattice
@@ -51,14 +52,15 @@ def _build_collocation_matrix_1d(
     order = space.degree + 1
 
     mat = np.zeros((n_pts, n_basis), dtype=nodes.dtype)
-    for i in range(n_pts):
-        fb = first_basis[i]
-        if space.periodic:
-            for j in range(order):
-                col = (fb + j) % n_basis
-                mat[i, col] += basis_vals[i, j]
-        else:
-            mat[i, fb : fb + order] = basis_vals[i, :order]
+    row_idx = np.arange(n_pts)[:, np.newaxis]  # (n_pts, 1)
+    local_offsets = np.arange(order)[np.newaxis, :]  # (1, order)
+    col_idx = first_basis[:, np.newaxis] + local_offsets  # (n_pts, order)
+
+    if space.periodic:
+        col_idx = col_idx % n_basis
+        np.add.at(mat, (row_idx, col_idx), basis_vals[:, :order])
+    else:
+        mat[row_idx, col_idx] = basis_vals[:, :order]
 
     return mat
 
@@ -83,7 +85,7 @@ def _build_collocation_deriv_matrix_1d(
     Note:
         No input validation is performed.
     """
-    pts = np.array([node], dtype=type(node))
+    pts = np.array([node], dtype=node.dtype)
     deriv_vals, first_basis = space.tabulate_basis_derivatives(pts, n_derivs)
     # deriv_vals shape: (1, n_derivs+1, degree+1)
     n_basis = space.num_basis
@@ -100,8 +102,6 @@ def _build_collocation_deriv_matrix_1d(
 # ---------------------------------------------------------------------------
 # SVD pseudo-inverse solve
 # ---------------------------------------------------------------------------
-
-_DEFAULT_TOL_FACTOR: float = 100.0
 
 
 def _solve_1d(
@@ -134,7 +134,7 @@ def _solve_1d(
     # Truncated SVD pseudo-inverse for rectangular or singular systems.
     u, s, vt = np.linalg.svd(mat, full_matrices=False)
     eps = float(np.finfo(mat.dtype).eps)  # type: ignore[misc]
-    threshold = (tol if tol is not None else _DEFAULT_TOL_FACTOR * eps) * s[0]
+    threshold = (tol if tol is not None else SVD_TOL_FACTOR * eps) * s[0]
     s_inv = np.where(s > threshold, 1.0 / s, 0.0)
     # pinv @ rhs = Vt.T @ diag(s_inv) @ U.T @ rhs
     result: npt.NDArray[np.float32 | np.float64]
@@ -235,37 +235,11 @@ def _evaluate_func_on_lattice(
             f"Function returned shape {raw.shape}, expected ({n_total},) or ({n_total}, rank)."
         )
 
-    components = _split_components(values, grid_shape)
+    components = split_components(values, grid_shape)
     _f32: np.dtype[np.float32] = np.dtype(np.float32)
     _f64: np.dtype[np.float64] = np.dtype(np.float64)
     out_dtype = _f32 if raw.dtype == _f32 else _f64
     return components, out_dtype
-
-
-def _split_components(
-    values: npt.NDArray[np.floating[Any]],
-    grid_shape: tuple[int, ...],
-) -> list[npt.NDArray[np.floating[Any]]]:
-    """Split function values into per-component arrays.
-
-    Args:
-        values (npt.NDArray): Function output array.
-        grid_shape (tuple[int, ...]): Expected grid shape.
-
-    Returns:
-        list[npt.NDArray]: One array per output component.
-
-    Raises:
-        ValueError: If values shape is incompatible with *grid_shape*.
-    """
-    if values.shape == grid_shape:
-        return [values]
-    if values.shape[: len(grid_shape)] == grid_shape and values.ndim == len(grid_shape) + 1:
-        return [values[..., r] for r in range(values.shape[-1])]
-    raise ValueError(
-        f"Values have shape {values.shape}, expected {grid_shape} "
-        f"(scalar) or {(*grid_shape, 'rank')} (vector)."
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -387,7 +361,9 @@ def interpolate_bspline(
         tol (float | None): SVD truncation tolerance for the
             collocation solve. Singular values below
             ``tol * sigma_max`` are treated as zero. If *None*,
-            defaults to ``100 * machine_epsilon``.
+            defaults to ``100 * machine_epsilon``. Only affects
+            overdetermined or near-singular systems; square
+            well-conditioned systems use a direct solve.
 
     Returns:
         Bspline: A non-rational B-spline whose evaluation approximates
@@ -425,9 +401,7 @@ def interpolate_bspline(
 
     # Modify RHS for boundary derivative constraints.
     if boundary_derivatives is not None:
-        components = _apply_boundary_deriv_rhs(
-            func, space, node_arrays, components, boundary_derivatives
-        )
+        components = _apply_boundary_deriv_rhs(space, components, boundary_derivatives)
 
     # Solve per-component via Kronecker structure.
     ctrl_components: list[npt.NDArray[np.floating[Any]]] = []
@@ -480,24 +454,18 @@ def _build_collocation_matrices(
 
 
 def _apply_boundary_deriv_rhs(
-    func: Callable[..., npt.ArrayLike],
     space: BsplineSpace,
-    node_arrays: list[npt.NDArray[np.float32 | np.float64]],
     components: list[npt.NDArray[np.floating[Any]]],
     boundary_derivatives: Sequence[tuple[int, ...] | None],
 ) -> list[npt.NDArray[np.floating[Any]]]:
     """Replace RHS entries corresponding to derivative rows with zero.
 
-    For boundary derivative constraints, the function values at the boundary
-    nodes adjacent to the endpoints are replaced by the derivative values.
-    Since we don't have derivative information from the callable (which only
-    provides values), the derivative RHS entries are set to zero — meaning
-    we constrain the derivatives to be zero at the boundaries.
+    Boundary derivative constraints force the specified derivative orders to
+    zero at the domain endpoints (the callable provides values only, not
+    derivatives).
 
     Args:
-        func (Callable): The original callable.
         space (BsplineSpace): Target B-spline space.
-        node_arrays (list[npt.NDArray]): Per-direction node arrays.
         components (list[npt.NDArray]): Per-component value arrays.
         boundary_derivatives: Per-direction ``(n_left, n_right)`` or ``None``.
 
@@ -568,7 +536,9 @@ def fit_bspline(
               points.
         space (~pantr.bspline.BsplineSpace): The target B-spline space.
         tol (float | None): SVD truncation tolerance. If *None*,
-            defaults to ``100 * machine_epsilon``.
+            defaults to ``100 * machine_epsilon``. Only affects
+            overdetermined or near-singular systems; square
+            well-conditioned systems use a direct solve.
 
     Returns:
         Bspline: A non-rational B-spline.
@@ -635,7 +605,7 @@ def _fit_from_tensor_product(
             raise ValueError(f"Expected {space.dim} node arrays, got {len(node_arrays)}.")
 
     grid_shape = tuple(a.shape[0] for a in node_arrays)
-    components = _split_components(values, grid_shape)
+    components = split_components(values, grid_shape)
 
     matrices = [
         _build_collocation_matrix_1d(s, n) for s, n in zip(space.spaces, node_arrays, strict=True)

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -442,8 +442,7 @@ def _infer_ndim(
         if (
             isinstance(arg, tuple)
             and len(arg) == 2  # noqa: PLR2004
-            and isinstance(arg[0], int | float | np.integer | np.floating)
-            and not isinstance(arg[0], bool | np.bool_)
+            and isinstance(arg[0], float | np.floating)
         ):
             continue  # single domain pair like (0.0, 1.0), treated as scalar
         if not isinstance(arg, Sequence):

--- a/tests/test_bspline_interpolate.py
+++ b/tests/test_bspline_interpolate.py
@@ -132,6 +132,14 @@ class TestCreateUniformSpace:
         assert space.spaces[0].periodic is True
         assert space.spaces[1].periodic is False
 
+    def test_tuple_degree_infers_ndim(self) -> None:
+        """A tuple degree=(3, 4) with scalar num_intervals infers ndim=2."""
+        space = create_uniform_space(degree=(3, 4), num_intervals=4)
+        assert space.dim == 2  # noqa: PLR2004
+        assert space.degrees == (3, 4)
+        assert space.spaces[0].degree == 3  # noqa: PLR2004
+        assert space.spaces[1].degree == 4  # noqa: PLR2004
+
     def test_inconsistent_lengths_raises(self) -> None:
         """Inconsistent sequence lengths raise ValueError."""
         with pytest.raises(ValueError, match="Inconsistent"):


### PR DESCRIPTION
## Summary

Fixes all issues identified in the PR #122 review:

- **Bug**: `_infer_ndim` incorrectly treated integer tuples like `(3, 4)` as domain pairs, so `create_uniform_space(degree=(3, 4), num_intervals=4)` raised a confusing error instead of creating a 2D space. Restricted the domain-pair heuristic to float values only.
- **Dead code**: Removed unused `func` and `node_arrays` parameters from `_apply_boundary_deriv_rhs`. The function only zeros derivative RHS entries and never used these parameters.
- **Documentation**: Clarified in `interpolate_bspline` and `fit_bspline` docstrings that `tol` only affects overdetermined or near-singular systems (square well-conditioned systems use a direct solve).
- **Code smell**: Replaced `dtype=type(node)` with `dtype=node.dtype` in `_build_collocation_deriv_matrix_1d`.
- **DRY**: Extracted shared `_interpolation_utils` module with `split_components()` and `SVD_TOL_FACTOR`, eliminating duplicated code between bezier and bspline interpolation modules.
- **Performance**: Vectorized `_build_collocation_matrix_1d` using array indexing and `np.add.at`, replacing the O(n·p) Python loop.

## Test plan

- [x] New test: `TestCreateUniformSpace::test_tuple_degree_infers_ndim` verifies the `_infer_ndim` fix
- [x] All 2340 existing tests pass (`NUMBA_DISABLE_JIT=1 pytest --no-cov`)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)