### PR TITLE
refactor(bspline,bezier): rename public functions for clarity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: docs/_build/doctrees
-          key: ${{ runner.os }}-sphinx-${{ hashFiles('docs/**/*.md', 'docs/conf.py', 'pyproject.toml') }}
+          key: ${{ runner.os }}-sphinx-${{ hashFiles('docs/**/*.md', 'docs/conf.py', 'pyproject.toml', 'src/**/*.py') }}
           restore-keys: |
             ${{ runner.os }}-sphinx-
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,8 +176,6 @@ jobs:
         with:
           path: docs/_build/doctrees
           key: ${{ runner.os }}-sphinx-${{ hashFiles('docs/**/*.md', 'docs/conf.py', 'pyproject.toml', 'src/**/*.py') }}
-          restore-keys: |
-            ${{ runner.os }}-sphinx-
 
       - name: Cache intersphinx inventories
         id: cache-intersphinx

--- a/src/pantr/bezier/__init__.py
+++ b/src/pantr/bezier/__init__.py
@@ -11,20 +11,20 @@ Bernstein algorithms implemented in ``_bezier_core``, ``_bezier_eval``,
 Root-finding exports:
 
 - :func:`find_roots` -- find all roots (single or batch, auto-dispatch).
-- :func:`solve_monotone_root` -- fast solver for monotone polynomials (single or batch).
+- :func:`find_monotone_root` -- fast solver for monotone polynomials (single or batch).
 """
 
 from ._bezier import Bezier
 from ._bezier_interpolate import fit_bezier, interpolate_bezier
 from ._root_finding import (
+    find_monotone_root,
     find_roots,
-    solve_monotone_root,
 )
 
 __all__ = [
     "Bezier",
+    "find_monotone_root",
     "find_roots",
     "fit_bezier",
     "interpolate_bezier",
-    "solve_monotone_root",
 ]

--- a/src/pantr/bezier/_find_roots.py
+++ b/src/pantr/bezier/_find_roots.py
@@ -332,7 +332,7 @@ def _solve_monotone_root_impl(
     *,
     tol: float | None = None,
 ) -> float:
-    """L2 implementation for :func:`pantr.bezier.solve_monotone_root`."""
+    """L2 implementation for :func:`pantr.bezier.find_monotone_root`."""
     _validate_bezier_for_roots(bezier)
     coeff = _extract_coeff(bezier)
     wait_for_jit_warmup()

--- a/src/pantr/bezier/_root_finding.py
+++ b/src/pantr/bezier/_root_finding.py
@@ -5,7 +5,7 @@ scalar Bernstein polynomials on [0, 1]. Each function performs lightweight
 validation and delegates to Layer 2 implementations in :mod:`_find_roots`.
 
 - :func:`find_roots` -- find all roots (single or batch, auto-dispatch).
-- :func:`solve_monotone_root` -- fast solver for monotone Beziers (single or batch).
+- :func:`find_monotone_root` -- fast solver for monotone Beziers (single or batch).
 """
 
 from __future__ import annotations
@@ -104,7 +104,7 @@ def find_roots(
 
 
 @overload
-def solve_monotone_root(
+def find_monotone_root(
     bezier: Bezier,
     *,
     tol: float | None = ...,
@@ -112,14 +112,14 @@ def solve_monotone_root(
 
 
 @overload
-def solve_monotone_root(
+def find_monotone_root(
     bezier: Sequence[Bezier],
     *,
     tol: float | None = ...,
 ) -> npt.NDArray[np.float64]: ...
 
 
-def solve_monotone_root(
+def find_monotone_root(
     bezier: Bezier | Sequence[Bezier],
     *,
     tol: float | None = None,

--- a/src/pantr/bezier/_yuksel_core.py
+++ b/src/pantr/bezier/_yuksel_core.py
@@ -80,7 +80,7 @@ def _solve_monotone_root_kernel(
 
     Note:
         Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`pantr.bezier.solve_monotone_root`
+        For general use, call :func:`pantr.bezier.find_monotone_root`
         instead.
     """
     lo = 0.0

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -5,10 +5,10 @@ This package consolidates the B-spline API:
 - :class:`Bspline`: parametric B-spline curves, surfaces, and volumes.
 - :class:`BsplineSpace1D`: 1D B-spline space (knot vector + degree).
 - :class:`BsplineSpace`: multi-dimensional tensor-product B-spline spaces.
-- :func:`create_uniform_open`, :func:`create_uniform_periodic`,
-  :func:`create_cardinal`: knot vector construction helpers.
+- :func:`create_uniform_open_knots`, :func:`create_uniform_periodic_knots`,
+  :func:`create_cardinal_knots`: knot vector construction helpers.
 - :func:`create_uniform_space`: convenience factory for tensor-product spaces.
-- :func:`greville_abscissae`, :func:`greville_lattice`: Greville point
+- :func:`get_greville_abscissae`, :func:`create_greville_lattice`: Greville point
   utilities.
 - :func:`interpolate_bspline`, :func:`fit_bspline`,
   :func:`l2_project_bspline`: approximation functions.
@@ -18,12 +18,12 @@ from ._bspline import Bspline
 from ._bspline_interpolate import fit_bspline, interpolate_bspline, l2_project_bspline
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_factory import (
-    create_cardinal,
-    create_uniform_open,
-    create_uniform_periodic,
+    create_cardinal_knots,
+    create_greville_lattice,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
     create_uniform_space,
-    greville_abscissae,
-    greville_lattice,
+    get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace
 
@@ -31,13 +31,13 @@ __all__ = [
     "Bspline",
     "BsplineSpace",
     "BsplineSpace1D",
-    "create_cardinal",
-    "create_uniform_open",
-    "create_uniform_periodic",
+    "create_cardinal_knots",
+    "create_greville_lattice",
+    "create_uniform_open_knots",
+    "create_uniform_periodic_knots",
     "create_uniform_space",
     "fit_bspline",
-    "greville_abscissae",
-    "greville_lattice",
+    "get_greville_abscissae",
     "interpolate_bspline",
     "l2_project_bspline",
 ]

--- a/src/pantr/bspline/_bspline_interpolate.py
+++ b/src/pantr/bspline/_bspline_interpolate.py
@@ -15,7 +15,7 @@ from numpy import typing as npt
 
 from ..quad import PointsLattice
 from ._bspline_space_1d import BsplineSpace1D
-from ._bspline_space_factory import greville_abscissae, greville_lattice
+from ._bspline_space_factory import create_greville_lattice, get_greville_abscissae
 from ._bspline_space_nd import BsplineSpace
 
 if TYPE_CHECKING:
@@ -296,7 +296,7 @@ def _resolve_nodes(
         ValueError: If nodes are inconsistent with the space.
     """
     if nodes is None or nodes == "greville":
-        lattice = greville_lattice(space)
+        lattice = create_greville_lattice(space)
         return list(lattice.pts_per_dir)
 
     if isinstance(nodes, PointsLattice):
@@ -1110,7 +1110,7 @@ def _evaluate_func_at_boundary(  # noqa: PLR0913
 
     # nD: create a lattice with a single point in the boundary direction
     # and Greville nodes in the other directions.
-    greville_nodes = [greville_abscissae(s) for s in space.spaces]
+    greville_nodes = [get_greville_abscissae(s) for s in space.spaces]
     boundary_nodes = [
         np.array([boundary_value], dtype=dtype) if d == direction else greville_nodes[d]
         for d in range(space.dim)

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -1,9 +1,9 @@
 """Knot vector construction and space factory functions for B-splines.
 
-Provides knot vector constructors (:func:`create_uniform_open`,
-:func:`create_uniform_periodic`, :func:`create_cardinal`), a convenience
+Provides knot vector constructors (:func:`create_uniform_open_knots`,
+:func:`create_uniform_periodic_knots`, :func:`create_cardinal_knots`), a convenience
 space factory (:func:`create_uniform_space`), and Greville abscissa
-utilities (:func:`greville_abscissae`, :func:`greville_lattice`).
+utilities (:func:`get_greville_abscissae`, :func:`create_greville_lattice`).
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_nd import BsplineSpace
 
 
-def create_uniform_open(
+def create_uniform_open_knots(
     num_intervals: int,
     degree: int,
     continuity: int | None = None,
@@ -52,7 +52,7 @@ def create_uniform_open(
         ValueError: If any parameter is invalid.
 
     Example:
-        >>> create_uniform_open(2, 2, domain=(0.0, 1.0))
+        >>> create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
         array([0., 0., 0., 0.5, 1., 1., 1.])
     """
     start_value: np.float32 | np.float64 | None
@@ -89,7 +89,7 @@ def create_uniform_open(
     return knots
 
 
-def create_uniform_periodic(
+def create_uniform_periodic_knots(
     num_intervals: int,
     degree: int,
     continuity: int | None = None,
@@ -118,7 +118,7 @@ def create_uniform_periodic(
         ValueError: If any parameter is invalid.
 
     Example:
-        >>> create_uniform_periodic(2, 2, domain=(0.0, 1.0))
+        >>> create_uniform_periodic_knots(2, 2, domain=(0.0, 1.0))
         array([-1. , -0.5,  0. ,  0.5,  1. ,  1.5,  2. ])
     """
     start_value: np.float32 | np.float64 | None
@@ -177,7 +177,7 @@ def create_uniform_periodic(
     return knots
 
 
-def create_cardinal(
+def create_cardinal_knots(
     num_intervals: int,
     degree: int,
     dtype: npt.DTypeLike = np.float64,
@@ -202,7 +202,7 @@ def create_cardinal(
         ValueError: If num_intervals < 1, degree < 0, or dtype is not float32/float64.
 
     Example:
-        >>> create_cardinal(2, 2)
+        >>> create_cardinal_knots(2, 2)
         array([-2., -1.,  0.,  1.,  2.,  3., 4.])
     """
     if num_intervals < 1:
@@ -224,7 +224,7 @@ def create_cardinal(
         start_value = np.float32(0)
         end_value = np.float32(num_intervals)
 
-    return create_uniform_periodic(
+    return create_uniform_periodic_knots(
         num_intervals,
         degree,
         continuity=degree - 1,
@@ -233,7 +233,7 @@ def create_cardinal(
     )
 
 
-def greville_abscissae(
+def get_greville_abscissae(
     space: BsplineSpace1D,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Compute the Greville abscissae (knot averages) of a 1D B-spline space.
@@ -253,10 +253,10 @@ def greville_abscissae(
             containing one Greville abscissa per basis function.
 
     Example:
-        >>> from pantr.bspline import BsplineSpace1D, create_uniform_open
-        >>> knots = create_uniform_open(4, 3)
+        >>> from pantr.bspline import BsplineSpace1D, create_uniform_open_knots
+        >>> knots = create_uniform_open_knots(4, 3)
         >>> space = BsplineSpace1D(knots, 3)
-        >>> greville_abscissae(space)
+        >>> get_greville_abscissae(space)
         array([0.  , 0.08333333, 0.25, 0.5 , 0.75, 0.91666667, 1.  ])
     """
     if not isinstance(space, BsplineSpace1D):
@@ -284,7 +284,7 @@ def greville_abscissae(
     return greville
 
 
-def greville_lattice(
+def create_greville_lattice(
     space: BsplineSpace,
 ) -> PointsLattice:
     """Compute the tensor-product Greville abscissae as a :class:`PointsLattice`.
@@ -299,18 +299,18 @@ def greville_lattice(
         PointsLattice: Tensor-product grid of Greville abscissae.
 
     Example:
-        >>> from pantr.bspline import BsplineSpace1D, BsplineSpace, create_uniform_open
-        >>> knots = create_uniform_open(2, 2)
+        >>> from pantr.bspline import BsplineSpace1D, BsplineSpace, create_uniform_open_knots
+        >>> knots = create_uniform_open_knots(2, 2)
         >>> s1d = BsplineSpace1D(knots, 2)
         >>> space = BsplineSpace([s1d, s1d])
-        >>> lattice = greville_lattice(space)
+        >>> lattice = create_greville_lattice(space)
         >>> lattice.pts_per_dir[0]
         array([0. , 0.25, 0.75, 1.  ])
     """
     if not isinstance(space, BsplineSpace):
         raise TypeError(f"Expected BsplineSpace, got {type(space).__name__}")
 
-    pts_per_dir = [greville_abscissae(s) for s in space.spaces]
+    pts_per_dir = [get_greville_abscissae(s) for s in space.spaces]
     return PointsLattice(pts_per_dir)
 
 
@@ -333,8 +333,8 @@ def create_uniform_space(  # noqa: PLR0913
     dimension is inferred from whichever argument is given as a sequence (they
     must all agree in length when more than one is a sequence).
 
-    Uses :func:`create_uniform_open` for non-periodic directions and
-    :func:`create_uniform_periodic` for periodic ones.
+    Uses :func:`create_uniform_open_knots` for non-periodic directions and
+    :func:`create_uniform_periodic_knots` for periodic ones.
 
     Args:
         degree (int | Sequence[int]): Polynomial degree per direction.
@@ -394,7 +394,7 @@ def create_uniform_space(  # noqa: PLR0913
     spaces_1d: list[BsplineSpace1D] = []
     for d in range(ndim):
         if periodicities[d]:
-            knots = create_uniform_periodic(
+            knots = create_uniform_periodic_knots(
                 n_intervals[d],
                 degrees[d],
                 continuity=continuities[d],
@@ -402,7 +402,7 @@ def create_uniform_space(  # noqa: PLR0913
                 dtype=dtype,
             )
         else:
-            knots = create_uniform_open(
+            knots = create_uniform_open_knots(
                 n_intervals[d],
                 degrees[d],
                 continuity=continuities[d],

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -287,7 +287,7 @@ def get_greville_abscissae(
 def create_greville_lattice(
     space: BsplineSpace,
 ) -> PointsLattice:
-    """Compute the tensor-product Greville abscissae as a :class:`PointsLattice`.
+    """Compute the tensor-product Greville abscissae as a :class:`~pantr.quad.PointsLattice`.
 
     Returns a :class:`~pantr.quad.PointsLattice` whose per-direction arrays are
     the Greville abscissae of each 1D sub-space.

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 
 # ---------------------------------------------------------------------------
@@ -33,7 +33,7 @@ def _make_periodic_bspline(
     Returns:
         Bspline: A 1D periodic scalar B-spline.
     """
-    knots = create_uniform_periodic(num_intervals, degree, continuity=continuity, dtype=dtype)
+    knots = create_uniform_periodic_knots(num_intervals, degree, continuity=continuity, dtype=dtype)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis
@@ -216,7 +216,7 @@ class TestToOpenBspline:
     def test_multidim_periodic_to_open(self) -> None:
         """to_open_bspline on a 2D spline with one periodic and one open direction."""
         # Direction 0: periodic degree-2, Direction 1: open degree-1
-        knots_per = create_uniform_periodic(4, 2, dtype=np.float64)
+        knots_per = create_uniform_periodic_knots(4, 2, dtype=np.float64)
         knots_open = np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float64)
         space_per = BsplineSpace1D(knots_per, 2, periodic=True)
         space_open = BsplineSpace1D(knots_open, 1)
@@ -247,7 +247,7 @@ class TestToOpenBspline:
 
     def test_rational_periodic_to_open(self) -> None:
         """to_open_bspline works on rational periodic B-splines."""
-        knots = create_uniform_periodic(3, 2, dtype=np.float64)
+        knots = create_uniform_periodic_knots(3, 2, dtype=np.float64)
         space_1d = BsplineSpace1D(knots, 2, periodic=True)
         space = BsplineSpace([space_1d])
         n = space.num_total_basis
@@ -390,7 +390,7 @@ class TestToPeriodic:
 
     def test_rational_round_trip(self) -> None:
         """Rational periodic -> open -> periodic preserves evaluation."""
-        knots = create_uniform_periodic(3, 2)
+        knots = create_uniform_periodic_knots(3, 2)
         space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
         # 2D rational control points (x, y, w)
         n = space.spaces[0].num_basis
@@ -415,8 +415,8 @@ class TestToPeriodic:
         """2D B-spline with both directions periodic round-trips correctly."""
         from pantr.quad import PointsLattice  # noqa: PLC0415
 
-        knots_u = create_uniform_periodic(3, 2)
-        knots_v = create_uniform_periodic(4, 2)
+        knots_u = create_uniform_periodic_knots(3, 2)
+        knots_v = create_uniform_periodic_knots(4, 2)
         space = BsplineSpace(
             [
                 BsplineSpace1D(knots_u, 2, periodic=True),
@@ -446,7 +446,7 @@ class TestToPeriodic:
         from pantr.quad import PointsLattice  # noqa: PLC0415
 
         # 2D: direction 0 is periodic (open after to_open), direction 1 is open (non-periodic).
-        knots_per = create_uniform_periodic(3, 2)
+        knots_per = create_uniform_periodic_knots(3, 2)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
         space = BsplineSpace(
             [

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -10,8 +10,8 @@ from pantr.bspline import (
     Bspline,
     BsplineSpace,
     BsplineSpace1D,
-    create_uniform_open,
-    create_uniform_periodic,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
 )
 
 # ---------------------------------------------------------------------------
@@ -42,7 +42,7 @@ def _make_open(
     num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
 ) -> Bspline:
     """Create an open 1D B-spline with random-ish CPs."""
-    knots = create_uniform_open(num_intervals, degree, domain=domain)
+    knots = create_uniform_open_knots(num_intervals, degree, domain=domain)
     space_1d = BsplineSpace1D(knots, degree)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis
@@ -55,7 +55,7 @@ def _make_periodic(
     num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
 ) -> Bspline:
     """Create a periodic 1D B-spline."""
-    knots = create_uniform_periodic(num_intervals, degree, domain=domain)
+    knots = create_uniform_periodic_knots(num_intervals, degree, domain=domain)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis
@@ -68,7 +68,7 @@ def _make_nonopen(
     num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
 ) -> Bspline:
     """Create a non-open, non-periodic B-spline (unclamped boundary knots)."""
-    knots = create_uniform_periodic(num_intervals, degree, domain=domain)
+    knots = create_uniform_periodic_knots(num_intervals, degree, domain=domain)
     space_1d = BsplineSpace1D(knots, degree, periodic=False)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis
@@ -260,8 +260,8 @@ class TestNonRationalND:
 
     def _make_2d_surface(self) -> Bspline:
         """Create a 2D B-spline surface."""
-        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knots(2, 3, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 3)
         space = BsplineSpace([s0, s1])
@@ -288,8 +288,8 @@ class TestNonRationalND:
 
     def test_periodic_direction(self) -> None:
         """Periodic in one direction, open in another."""
-        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_periodic(4, 2, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_periodic_knots(4, 2, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 2, periodic=True)
         space = BsplineSpace([s0, s1])
@@ -369,8 +369,8 @@ class TestRationalND:
 
     def test_rational_2d_surface(self) -> None:
         """Rational 2D surface derivative matches evaluate_derivatives."""
-        knots0 = create_uniform_open(2, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_open(2, 2, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 2)
         space = BsplineSpace([s0, s1])
@@ -493,8 +493,8 @@ class TestKeepDegreeNonRational:
 
     def test_2d_direction0(self) -> None:
         """2D surface keep_degree in direction 0."""
-        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knots(2, 3, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 3)
         space = BsplineSpace([s0, s1])
@@ -505,8 +505,8 @@ class TestKeepDegreeNonRational:
 
     def test_2d_direction1(self) -> None:
         """2D surface keep_degree in direction 1."""
-        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knots(2, 3, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 3)
         space = BsplineSpace([s0, s1])
@@ -517,8 +517,8 @@ class TestKeepDegreeNonRational:
 
     def test_2d_other_directions_unchanged(self) -> None:
         """Degrees in non-differentiated directions remain unchanged."""
-        knots0 = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots1 = create_uniform_open(2, 3, domain=(0.0, 1.0))
+        knots0 = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots1 = create_uniform_open_knots(2, 3, domain=(0.0, 1.0))
         s0 = BsplineSpace1D(knots0, 2)
         s1 = BsplineSpace1D(knots1, 3)
         space = BsplineSpace([s0, s1])

--- a/tests/test_bspline_evaluate_derivatives_multi_dim.py
+++ b/tests/test_bspline_evaluate_derivatives_multi_dim.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.quad import PointsLattice
 
 
@@ -489,7 +489,7 @@ class TestPeriodicMultiDimDerivEvaluation:
     )
     def test_2d_one_periodic_C0_derivatives_finite_diff(self, orders: list[int]) -> None:
         """2-D (periodic C^0 x open) evaluate_derivatives agrees with finite differences."""
-        knots_per = create_uniform_periodic(4, 2, continuity=0, dtype=np.float64)
+        knots_per = create_uniform_periodic_knots(4, 2, continuity=0, dtype=np.float64)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
         s_per = BsplineSpace1D(knots_per, 2, periodic=True)
         s_open = BsplineSpace1D(knots_open, 2)
@@ -524,8 +524,8 @@ class TestPeriodicMultiDimDerivEvaluation:
     )
     def test_2d_both_periodic_C0_derivatives_finite_diff(self, orders: list[int]) -> None:
         """2-D (periodic C^0 x periodic C^0) evaluate_derivatives agrees with finite diffs."""
-        knots0 = create_uniform_periodic(4, 2, continuity=0, dtype=np.float64)
-        knots1 = create_uniform_periodic(4, 2, continuity=0, dtype=np.float64)
+        knots0 = create_uniform_periodic_knots(4, 2, continuity=0, dtype=np.float64)
+        knots1 = create_uniform_periodic_knots(4, 2, continuity=0, dtype=np.float64)
         s0 = BsplineSpace1D(knots0, 2, periodic=True)
         s1 = BsplineSpace1D(knots1, 2, periodic=True)
         space = BsplineSpace([s0, s1])
@@ -549,7 +549,7 @@ class TestPeriodicMultiDimDerivEvaluation:
 
     def test_2d_periodic_degree3_C1_derivatives_finite_diff(self) -> None:
         """2-D (periodic degree-3 C^1 x open) evaluate_derivatives agrees with finite diffs."""
-        knots_per = create_uniform_periodic(5, 3, continuity=1, dtype=np.float64)
+        knots_per = create_uniform_periodic_knots(5, 3, continuity=1, dtype=np.float64)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
         s_per = BsplineSpace1D(knots_per, 3, periodic=True)
         s_open = BsplineSpace1D(knots_open, 2)

--- a/tests/test_bspline_evaluate_multi_dim.py
+++ b/tests/test_bspline_evaluate_multi_dim.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.quad import PointsLattice
 
 # ---------------------------------------------------------------------------
@@ -346,7 +346,9 @@ class TestPeriodicMultiDimEvaluation:
         Returns:
             Bspline: A 2-D B-spline with one periodic and one open direction.
         """
-        knots_per = create_uniform_periodic(n_per, deg_per, continuity=continuity, dtype=np.float64)
+        knots_per = create_uniform_periodic_knots(
+            n_per, deg_per, continuity=continuity, dtype=np.float64
+        )
         knots_open = np.array(
             [0.0] * (deg_open + 1)
             + list(np.linspace(0, 1, n_open + 1)[1:-1])
@@ -388,8 +390,8 @@ class TestPeriodicMultiDimEvaluation:
 
     def test_2d_both_periodic_C0_evaluate_consistent(self) -> None:
         """2-D (periodic C^0 x periodic C^0) evaluate is consistent with evaluate_derivatives."""
-        knots0 = create_uniform_periodic(4, 2, continuity=0, dtype=np.float64)
-        knots1 = create_uniform_periodic(4, 2, continuity=0, dtype=np.float64)
+        knots0 = create_uniform_periodic_knots(4, 2, continuity=0, dtype=np.float64)
+        knots1 = create_uniform_periodic_knots(4, 2, continuity=0, dtype=np.float64)
         s0 = BsplineSpace1D(knots0, 2, periodic=True)
         s1 = BsplineSpace1D(knots1, 2, periodic=True)
         space = BsplineSpace([s0, s1])
@@ -408,7 +410,7 @@ class TestPeriodicMultiDimEvaluation:
 
     def test_2d_one_periodic_max_continuity_constant_field(self) -> None:
         """Periodic x open spline with all-ones ctrl evaluates to f=1 (partition of unity)."""
-        knots_per = create_uniform_periodic(4, 2, dtype=np.float64)
+        knots_per = create_uniform_periodic_knots(4, 2, dtype=np.float64)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64)
         s_per = BsplineSpace1D(knots_per, 2, periodic=True)
         s_open = BsplineSpace1D(knots_open, 2)
@@ -428,8 +430,8 @@ class TestPeriodicMultiDimEvaluation:
 
     def test_2d_both_periodic_max_continuity_constant_field(self) -> None:
         """Periodic x periodic spline with all-ones ctrl evaluates to f=1 (partition of unity)."""
-        knots0 = create_uniform_periodic(4, 2, dtype=np.float64)
-        knots1 = create_uniform_periodic(4, 2, dtype=np.float64)
+        knots0 = create_uniform_periodic_knots(4, 2, dtype=np.float64)
+        knots1 = create_uniform_periodic_knots(4, 2, dtype=np.float64)
         s0 = BsplineSpace1D(knots0, 2, periodic=True)
         s1 = BsplineSpace1D(knots1, 2, periodic=True)
         space = BsplineSpace([s0, s1])

--- a/tests/test_bspline_evaluation.py
+++ b/tests/test_bspline_evaluation.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 
 
@@ -250,7 +250,7 @@ def _make_periodic_bspline(
     Returns:
         Bspline: A 1D periodic scalar B-spline.
     """
-    knots = create_uniform_periodic(num_intervals, degree, continuity=continuity, dtype=dtype)
+    knots = create_uniform_periodic_knots(num_intervals, degree, continuity=continuity, dtype=dtype)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis

--- a/tests/test_bspline_interpolate.py
+++ b/tests/test_bspline_interpolate.py
@@ -11,12 +11,12 @@ import pytest
 
 from pantr.bspline import (
     BsplineSpace1D,
-    create_uniform_open,
-    create_uniform_periodic,
+    create_greville_lattice,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
     create_uniform_space,
     fit_bspline,
-    greville_abscissae,
-    greville_lattice,
+    get_greville_abscissae,
     interpolate_bspline,
     l2_project_bspline,
 )
@@ -28,21 +28,21 @@ from pantr.quad import PointsLattice
 
 
 class TestGrevilleAbscissae:
-    """Tests for greville_abscissae."""
+    """Tests for get_greville_abscissae."""
 
     def test_open_degree2(self) -> None:
         """Greville points for open degree-2 space with 2 intervals."""
-        knots = create_uniform_open(2, 2)
+        knots = create_uniform_open_knots(2, 2)
         space = BsplineSpace1D(knots, 2)
-        g = greville_abscissae(space)
+        g = get_greville_abscissae(space)
         assert g.shape == (space.num_basis,)
         nptest.assert_allclose(g, [0.0, 0.25, 0.75, 1.0], atol=1e-14)
 
     def test_open_degree3(self) -> None:
         """Greville points for open degree-3 space with 4 intervals."""
-        knots = create_uniform_open(4, 3)
+        knots = create_uniform_open_knots(4, 3)
         space = BsplineSpace1D(knots, 3)
-        g = greville_abscissae(space)
+        g = get_greville_abscissae(space)
         assert g.shape == (space.num_basis,)
         # Endpoints should be exactly at domain boundaries.
         assert g[0] == pytest.approx(0.0, abs=1e-14)
@@ -50,9 +50,9 @@ class TestGrevilleAbscissae:
 
     def test_periodic(self) -> None:
         """Greville points for periodic space are sorted and inside domain."""
-        knots = create_uniform_periodic(4, 3)
+        knots = create_uniform_periodic_knots(4, 3)
         space = BsplineSpace1D(knots, 3, periodic=True)
-        g = greville_abscissae(space)
+        g = get_greville_abscissae(space)
         assert g.shape == (space.num_basis,)
         a, b = space.domain
         assert np.all(g >= a - 1e-14)
@@ -62,25 +62,25 @@ class TestGrevilleAbscissae:
 
     def test_degree0(self) -> None:
         """Greville points for degree-0 space are midpoints."""
-        knots = create_uniform_open(3, 0)
+        knots = create_uniform_open_knots(3, 0)
         space = BsplineSpace1D(knots, 0)
-        g = greville_abscissae(space)
+        g = get_greville_abscissae(space)
         expected = np.array([1.0 / 6, 0.5, 5.0 / 6])
         nptest.assert_allclose(g, expected, atol=1e-14)
 
     def test_type_error(self) -> None:
         """Passing wrong type raises TypeError."""
         with pytest.raises(TypeError, match="Expected BsplineSpace1D"):
-            greville_abscissae("not a space")  # type: ignore[arg-type]
+            get_greville_abscissae("not a space")  # type: ignore[arg-type]
 
 
 class TestGrevilleLattice:
-    """Tests for greville_lattice."""
+    """Tests for create_greville_lattice."""
 
     def test_2d(self) -> None:
         """Greville lattice for a 2D space has correct structure."""
         space = create_uniform_space([2, 3], [3, 4])
-        lat = greville_lattice(space)
+        lat = create_greville_lattice(space)
         assert isinstance(lat, PointsLattice)
         assert lat.dim == 2  # noqa: PLR2004
         assert lat.pts_per_dir[0].shape[0] == space.num_basis[0]
@@ -285,7 +285,7 @@ class TestFitTensorProduct:
     def test_exact_fit_1d(self) -> None:
         """Exact fit with n_nodes = n_basis recovers polynomial."""
         space = create_uniform_space(3, 4)
-        nodes = greville_abscissae(space.spaces[0])
+        nodes = get_greville_abscissae(space.spaces[0])
         vals = nodes**2
         b = fit_bspline(vals, [nodes], space)
         pts = np.linspace(0, 1, 11)
@@ -303,8 +303,8 @@ class TestFitTensorProduct:
     def test_2d_fit(self) -> None:
         """2D tensor-product fit."""
         space = create_uniform_space([2, 2], [3, 3])
-        nodes_x = greville_abscissae(space.spaces[0])
-        nodes_y = greville_abscissae(space.spaces[1])
+        nodes_x = get_greville_abscissae(space.spaces[0])
+        nodes_y = get_greville_abscissae(space.spaces[1])
 
         xx, yy = np.meshgrid(nodes_x, nodes_y, indexing="ij")
         vals = xx + yy
@@ -319,7 +319,7 @@ class TestFitTensorProduct:
     def test_vector_valued_fit(self) -> None:
         """Fit vector-valued function (rank > 1)."""
         space = create_uniform_space(3, 4)
-        nodes = greville_abscissae(space.spaces[0])
+        nodes = get_greville_abscissae(space.spaces[0])
         vals = np.stack([nodes**2, nodes**3], axis=-1)
         b = fit_bspline(vals, [nodes], space)
         assert b.rank == 2  # noqa: PLR2004

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 from pantr.bspline._bspline_knots import _get_unique_knots_and_multiplicity_impl
 
@@ -262,7 +262,7 @@ class TestEdgeCases:
     def test_error_periodic_was_removed(self) -> None:
         """Periodic B-splines no longer raise NotImplementedError; they are converted."""
         # Periodic degree-1 spline over domain [0, 1]: knots [-0.5, 0, 0.5, 1, 1.5].
-        knots_p = create_uniform_periodic(2, 1, domain=(0.0, 1.0))
+        knots_p = create_uniform_periodic_knots(2, 1, domain=(0.0, 1.0))
         space_p_1d = BsplineSpace1D(knots_p, 1, periodic=True)
         space_p = BsplineSpace([space_p_1d])
         n_basis = space_p.num_total_basis
@@ -357,7 +357,7 @@ def _make_periodic(
     num_intervals: int, degree: int, domain: tuple[float, float] = (0.0, 1.0)
 ) -> Bspline:
     """Create a periodic B-spline with simple linear control points."""
-    knots = create_uniform_periodic(num_intervals, degree, domain=domain)
+    knots = create_uniform_periodic_knots(num_intervals, degree, domain=domain)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis
@@ -525,7 +525,7 @@ def _make_nonopen(
     Uses a periodic knot vector but with ``periodic=False``, giving an unclamped
     spline with boundary multiplicity < degree + 1.
     """
-    knots = create_uniform_periodic(num_intervals, degree, domain=domain)
+    knots = create_uniform_periodic_knots(num_intervals, degree, domain=domain)
     space_1d = BsplineSpace1D(knots, degree, periodic=False)
     space = BsplineSpace([space_1d])
     n = space.num_total_basis

--- a/tests/test_bspline_product_nd.py
+++ b/tests/test_bspline_product_nd.py
@@ -10,7 +10,7 @@ from pantr.bezier._bezier_product import (
     _bernstein_product_coefficients,
     _bernstein_product_coefficients_nd,
 )
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_knots import _get_unique_knots_and_multiplicity_impl
 from pantr.quad import PointsLattice
 
@@ -557,7 +557,7 @@ class TestBoundaryTypes2D:
         """
         for degree in [1, 2, 3]:
             n_spans = 4
-            knots = create_uniform_periodic(degree, n_spans)
+            knots = create_uniform_periodic_knots(degree, n_spans)
             s = BsplineSpace1D(knots, degree, periodic=True)
             n_per = s.num_basis
 
@@ -582,7 +582,7 @@ class TestBoundaryTypes2D:
     def test_mixed_periodic_open(self) -> None:
         """One direction periodic, one open -> periodic in u, open in v."""
         degree = 2
-        knots_per = create_uniform_periodic(degree, 4)
+        knots_per = create_uniform_periodic_knots(degree, 4)
         s_per = BsplineSpace1D(knots_per, degree, periodic=True)
         knots_open = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]
         s_open = _make_space_1d(knots_open, 2)

--- a/tests/test_bspline_slice.py
+++ b/tests/test_bspline_slice.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -70,7 +70,7 @@ def _make_rational_surface(dtype: type = np.float64) -> Bspline:
 
 def _make_periodic_curve(dtype: type = np.float64) -> Bspline:
     """Create a periodic cubic B-spline curve."""
-    knots = create_uniform_periodic(num_intervals=4, degree=3, continuity=2, dtype=dtype)
+    knots = create_uniform_periodic_knots(num_intervals=4, degree=3, continuity=2, dtype=dtype)
     space_1d = BsplineSpace1D(knots, 3, periodic=True)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(55)
@@ -80,7 +80,7 @@ def _make_periodic_curve(dtype: type = np.float64) -> Bspline:
 
 def _make_periodic_surface(dtype: type = np.float64) -> Bspline:
     """Create a surface with one periodic direction."""
-    knots_u = create_uniform_periodic(num_intervals=3, degree=2, continuity=1, dtype=dtype)
+    knots_u = create_uniform_periodic_knots(num_intervals=3, degree=2, continuity=1, dtype=dtype)
     space_u = BsplineSpace1D(knots_u, 2, periodic=True)
     space_v = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
     space = BsplineSpace([space_u, space_v])

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -14,9 +14,9 @@ from pantr.basis import (
 )
 from pantr.bspline import (
     BsplineSpace1D,
-    create_cardinal,
-    create_uniform_open,
-    create_uniform_periodic,
+    create_cardinal_knots,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_basis_core import (
     _compute_basis_nurbs_book_impl,
@@ -66,7 +66,7 @@ class TestBsplineSpace1DInit:
 
     def test_periodic_initialization(self) -> None:
         """Test periodic BsplineSpace1D initialization."""
-        knots = create_uniform_periodic(num_intervals=3, degree=2, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(num_intervals=3, degree=2, domain=(0.0, 1.0))
         degree = 2
         spline = BsplineSpace1D(knots, degree, periodic=True)
 
@@ -194,7 +194,7 @@ class TestBsplineSpace1DMethods:
     def test_get_num_basis_periodic(self) -> None:
         """Test get_num_basis for periodic spline."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(num_intervals=3, degree=degree, domain=(0.0, 1.0))
         spline = BsplineSpace1D(knots, degree, periodic=True)
         # For periodic splines, the number of basis functions is reduced
         assert spline.num_basis == 3  # noqa: PLR2004
@@ -227,7 +227,7 @@ class TestBsplineSpace1DMethods:
         """Test get_num_intervals method."""
         num_intervals = 2
         degree = 2
-        knots = create_uniform_open(num_intervals, degree)
+        knots = create_uniform_open_knots(num_intervals, degree)
         spline = BsplineSpace1D(knots, degree)
         assert spline.num_intervals == num_intervals
 
@@ -299,7 +299,7 @@ class TestBsplineSpace1DMethods:
         """Test has_Bezier_like_knots returns False for periodic splines."""
         # Use a valid periodic knot vector
         degree = 2
-        knots = create_uniform_periodic(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(num_intervals=3, degree=degree, domain=(0.0, 1.0))
         spline = BsplineSpace1D(knots, degree, periodic=True)
         assert bool(spline.has_Bezier_like_knots()) is False
 
@@ -320,7 +320,7 @@ class TestBsplineSpace1DWithKnotGenerators:
 
     def test_with_uniform_open_knot_vector(self) -> None:
         """Test BsplineSpace1D with uniform open knot vector."""
-        knots = create_uniform_open(num_intervals=2, degree=2, domain=(0.0, 1.0))
+        knots = create_uniform_open_knots(num_intervals=2, degree=2, domain=(0.0, 1.0))
         degree = 2
         spline = BsplineSpace1D(knots, degree)
 
@@ -332,7 +332,7 @@ class TestBsplineSpace1DWithKnotGenerators:
     def test_with_uniform_periodic_knot_vector(self) -> None:
         """Test BsplineSpace1D with uniform periodic knot vector."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(num_intervals=3, degree=degree, domain=(0.0, 1.0))
         spline = BsplineSpace1D(knots, degree, periodic=True)
 
         assert spline.degree == degree
@@ -342,7 +342,7 @@ class TestBsplineSpace1DWithKnotGenerators:
     def test_with_cardinal_bspline_knot_vector(self) -> None:
         """Test BsplineSpace1D with cardinal B-spline knot vector."""
         degree = 2
-        knots = create_cardinal(2, degree)
+        knots = create_cardinal_knots(2, degree)
         spline = BsplineSpace1D(knots, degree)
 
         assert spline.degree == degree
@@ -416,8 +416,10 @@ class TestBsplineSpace1DIntegration:
         """Test consistency between periodic and non-periodic versions."""
         # Create equivalent knot vectors
         degree = 2
-        knots_open = create_uniform_open(num_intervals=3, degree=degree, domain=(0.0, 1.0))
-        knots_periodic = create_uniform_periodic(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots_open = create_uniform_open_knots(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots_periodic = create_uniform_periodic_knots(
+            num_intervals=3, degree=degree, domain=(0.0, 1.0)
+        )
 
         spline_open = BsplineSpace1D(knots_open, degree, periodic=False)
         spline_periodic = BsplineSpace1D(knots_periodic, degree, periodic=True)
@@ -771,7 +773,7 @@ class TestNonOpenKnotSpanBoundary:
     @pytest.mark.parametrize("degree", [1, 2, 3, 4])
     def test_periodic_basis_continuity_at_right_endpoint(self, degree: int) -> None:
         """Test basis continuity at right endpoint for periodic knot vectors."""
-        knots = create_uniform_periodic(num_intervals=degree + 1, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 1, degree=degree)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_end = space.domain[1]
@@ -802,7 +804,7 @@ class TestNonOpenKnotSpanBoundary:
     @pytest.mark.parametrize("degree", [1, 2, 3])
     def test_open_knots_still_correct_at_endpoints(self, degree: int) -> None:
         """Test that open knot vectors still produce correct endpoint values."""
-        knots = create_uniform_open(num_intervals=3, degree=degree)
+        knots = create_uniform_open_knots(num_intervals=3, degree=degree)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=False)
         assert space.has_open_knots()
 
@@ -923,7 +925,7 @@ class TestPeriodicBasisTabulation:
     """Test tabulate_basis and tabulate_basis_derivatives for periodic B-spline spaces.
 
     Covers both maximum continuity (C^{degree-1}) and reduced continuity (e.g., C^0, C^1)
-    cases created via create_uniform_periodic with the ``continuity`` parameter.
+    cases created via create_uniform_periodic_knots with the ``continuity`` parameter.
     """
 
     @pytest.mark.parametrize(
@@ -943,7 +945,7 @@ class TestPeriodicBasisTabulation:
     ) -> None:
         """Periodic B-spline basis values sum to 1.0 at all interior points."""
         num_intervals = degree + 3
-        knots = create_uniform_periodic(
+        knots = create_uniform_periodic_knots(
             num_intervals=num_intervals, degree=degree, continuity=continuity
         )
         space = BsplineSpace1D(knots, degree, periodic=True)
@@ -961,7 +963,7 @@ class TestPeriodicBasisTabulation:
     @pytest.mark.parametrize("degree", [1, 2, 3, 4])
     def test_periodic_tabulate_basis_continuity_at_left_endpoint(self, degree: int) -> None:
         """Periodic basis is continuous at the left domain endpoint."""
-        knots = create_uniform_periodic(num_intervals=degree + 3, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 3, degree=degree)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_start = space.domain[0]
@@ -975,7 +977,7 @@ class TestPeriodicBasisTabulation:
     @pytest.mark.parametrize("degree", [1, 2, 3, 4])
     def test_periodic_C0_basis_continuity_at_right_endpoint(self, degree: int) -> None:
         """Periodic C^0 basis is continuous at the right domain endpoint."""
-        knots = create_uniform_periodic(num_intervals=degree + 3, degree=degree, continuity=0)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 3, degree=degree, continuity=0)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_end = space.domain[1]
@@ -989,7 +991,7 @@ class TestPeriodicBasisTabulation:
     @pytest.mark.parametrize("degree", [1, 2, 3, 4])
     def test_periodic_C0_basis_continuity_at_left_endpoint(self, degree: int) -> None:
         """Periodic C^0 basis is continuous at the left domain endpoint."""
-        knots = create_uniform_periodic(num_intervals=degree + 3, degree=degree, continuity=0)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 3, degree=degree, continuity=0)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_start = space.domain[0]
@@ -1016,7 +1018,7 @@ class TestPeriodicBasisTabulation:
     ) -> None:
         """Periodic basis derivatives satisfy: 0th order sums to 1, higher orders sum to 0."""
         num_intervals = degree + 3
-        knots = create_uniform_periodic(
+        knots = create_uniform_periodic_knots(
             num_intervals=num_intervals, degree=degree, continuity=continuity
         )
         space = BsplineSpace1D(knots, degree, periodic=True)
@@ -1046,7 +1048,7 @@ class TestPeriodicBasisTabulation:
     @pytest.mark.parametrize("degree", [2, 3])
     def test_periodic_derivative_continuity_at_right_endpoint(self, degree: int) -> None:
         """Periodic basis derivatives are continuous at the right domain endpoint."""
-        knots = create_uniform_periodic(num_intervals=degree + 3, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 3, degree=degree)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_end = space.domain[1]
@@ -1063,7 +1065,7 @@ class TestPeriodicBasisTabulation:
     @pytest.mark.parametrize("degree", [2, 3])
     def test_periodic_derivative_continuity_at_left_endpoint(self, degree: int) -> None:
         """Periodic basis derivatives are continuous at the left domain endpoint."""
-        knots = create_uniform_periodic(num_intervals=degree + 3, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=degree + 3, degree=degree)
         space = BsplineSpace1D(knots=knots, degree=degree, periodic=True)
 
         t_start = space.domain[0]
@@ -1115,7 +1117,7 @@ class TestGetCardinalIntervals:
     def test_periodic_uniform_all_cardinal(self) -> None:
         """Uniform periodic knot vector (max continuity) has all-cardinal intervals."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=4, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree)
         tol = 1e-10
         result = _get_Bspline_cardinal_intervals_1D_impl(knots, degree, tol)
 
@@ -1131,7 +1133,7 @@ class TestGetCardinalIntervals:
         so no intervals are cardinal.
         """
         degree = 2
-        knots = create_uniform_periodic(num_intervals=4, degree=degree, continuity=0)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree, continuity=0)
         tol = 1e-10
         result = _get_Bspline_cardinal_intervals_1D_impl(knots, degree, tol)
 
@@ -1463,7 +1465,7 @@ class TestCreateBsplineCardinalExtractionOperators:
     def test_all_intervals_cardinal(self) -> None:
         """Test when all intervals are cardinal (uniform spacing)."""
         # Create uniform knot vector with cardinal intervals
-        knots = create_uniform_open(num_intervals=3, degree=2, domain=(0.0, 1.0))
+        knots = create_uniform_open_knots(num_intervals=3, degree=2, domain=(0.0, 1.0))
         degree = 2
         tol = 1e-10
         result = _tabulate_Bspline_cardinal_1D_extraction_impl(knots, degree, tol)
@@ -1555,7 +1557,7 @@ class TestBsplineSpace1DCoverageTargets:
     def test_open_end_checks_are_false_for_periodic(self) -> None:
         """has_left_end_open/has_right_end_open should return False if periodic."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=3, degree=degree, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(num_intervals=3, degree=degree, domain=(0.0, 1.0))
         spl = BsplineSpace1D(knots, degree, periodic=True)
         assert spl.has_left_end_open() is False
         assert spl.has_right_end_open() is False
@@ -1594,8 +1596,8 @@ class TestExtractionOperatorCorrectness:
     @pytest.mark.parametrize(
         "knots_factory",
         [
-            lambda d: create_uniform_open(num_intervals=2, degree=d),  # 2 intervals
-            lambda d: create_uniform_open(num_intervals=3, degree=d),  # 3 intervals
+            lambda d: create_uniform_open_knots(num_intervals=2, degree=d),  # 2 intervals
+            lambda d: create_uniform_open_knots(num_intervals=3, degree=d),  # 3 intervals
             lambda d: [0.0] * (d + 1) + [0.5, 1.0] + [2.0] * (d + 1),  # 2 intervals, different end
             lambda d: (
                 [0.0] * (d + 1)
@@ -1605,11 +1607,11 @@ class TestExtractionOperatorCorrectness:
                 + [4.0, 5.0]
                 + [6.0] * (d + 1)
             ),  # 5 intervals with different continuities
-            lambda d: create_cardinal(num_intervals=4, degree=d),  # cardinal intervals
-            lambda d: create_uniform_periodic(
+            lambda d: create_cardinal_knots(num_intervals=4, degree=d),  # cardinal intervals
+            lambda d: create_uniform_periodic_knots(
                 num_intervals=d + 3, degree=d
             ),  # periodic, max continuity
-            lambda d: create_uniform_periodic(
+            lambda d: create_uniform_periodic_knots(
                 num_intervals=d + 3, degree=d, continuity=0
             ),  # periodic, C^0 continuity
             lambda d: np.linspace(0.0, 1.0, 2 * d + 4, dtype=np.float64),  # non-open non-periodic

--- a/tests/test_degree_elevation.py
+++ b/tests/test_degree_elevation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 
 
 def test_degree_elevation_1d_linear_to_quadratic() -> None:
@@ -136,7 +136,7 @@ def _make_periodic_bspline(
     rank: int = 2,
 ) -> Bspline:
     """Create a 1D periodic B-spline with random control points."""
-    knots = create_uniform_periodic(num_intervals, degree, continuity=continuity)
+    knots = create_uniform_periodic_knots(num_intervals, degree, continuity=continuity)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)
@@ -193,7 +193,7 @@ class TestPeriodicBsplineElevateDegree:
 
     def test_elevate_degree_multidim_mixed_periodic_open(self) -> None:
         """elevate_degree preserves periodicity for mixed periodic/open 2D splines."""
-        knots_per = create_uniform_periodic(num_intervals=4, degree=2)
+        knots_per = create_uniform_periodic_knots(num_intervals=4, degree=2)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
         space = BsplineSpace(
             [
@@ -219,7 +219,7 @@ class TestPeriodicBsplineElevateDegree:
 
     def test_elevate_degree_rational_periodic(self) -> None:
         """elevate_degree preserves periodic NURBS geometry."""
-        knots = create_uniform_periodic(num_intervals=4, degree=3)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=3)
         space_1d = BsplineSpace1D(knots, 3, periodic=True)
         space = BsplineSpace([space_1d])
         n = space.num_total_basis

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 
 
 def _make_bezier_1d(ctrl: list[list[float]], rational: bool = False) -> Bezier:
@@ -324,7 +324,7 @@ class TestBsplineReduceDegreePeriodic:
         self, degree: int, continuity: int | None, dec: int
     ) -> None:
         """Elevate then reduce a periodic B-spline preserves geometry."""
-        knots = create_uniform_periodic(num_intervals=4, degree=degree, continuity=continuity)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree, continuity=continuity)
         space = BsplineSpace([BsplineSpace1D(knots, degree, periodic=True)])
         rng = np.random.default_rng(42)
         ctrl = rng.random((space.num_total_basis, 2))
@@ -342,7 +342,7 @@ class TestBsplineReduceDegreePeriodic:
 
     def test_mixed_periodic_open_2d(self) -> None:
         """2D mixed periodic/open B-spline: elevate then reduce."""
-        knots_per = create_uniform_periodic(num_intervals=4, degree=2)
+        knots_per = create_uniform_periodic_knots(num_intervals=4, degree=2)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
         space = BsplineSpace(
             [

--- a/tests/test_knot_insertion.py
+++ b/tests/test_knot_insertion.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -524,7 +524,7 @@ class TestPeriodicInsertKnotsFlag:
     def test_insert_knots_periodic_loses_periodicity(self) -> None:
         """insert_knots on a periodic space returns a non-periodic space."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=4, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree)
         space = BsplineSpace1D(knots, degree, periodic=True)
         assert space.periodic
 
@@ -535,7 +535,7 @@ class TestPeriodicInsertKnotsFlag:
     def test_insert_knots_C0_periodic_loses_periodicity(self) -> None:
         """insert_knots on a C^0 periodic space returns a non-periodic space."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=4, degree=degree, continuity=0)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree, continuity=0)
         space = BsplineSpace1D(knots, degree, periodic=True)
         assert space.periodic
 
@@ -546,7 +546,7 @@ class TestPeriodicInsertKnotsFlag:
     def test_subdivide_periodic_loses_periodicity(self) -> None:
         """Subdivide on a periodic space returns a non-periodic space."""
         degree = 2
-        knots = create_uniform_periodic(num_intervals=4, degree=degree)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=degree)
         space = BsplineSpace1D(knots, degree, periodic=True)
         assert space.periodic
 
@@ -567,7 +567,7 @@ def _make_periodic_bspline(
     rank: int = 2,
 ) -> Bspline:
     """Create a 1D periodic B-spline with sequential control points."""
-    knots = create_uniform_periodic(num_intervals, degree, continuity=continuity)
+    knots = create_uniform_periodic_knots(num_intervals, degree, continuity=continuity)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)
@@ -606,7 +606,7 @@ class TestPeriodicBsplineInsertKnots:
     def test_insert_knots_multidim_mixed_periodic_open(self) -> None:
         """insert_knots preserves periodicity for mixed periodic/open 2D splines."""
         # Direction 0: periodic, direction 1: open
-        knots_per = create_uniform_periodic(num_intervals=4, degree=2)
+        knots_per = create_uniform_periodic_knots(num_intervals=4, degree=2)
         knots_open = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
         space = BsplineSpace(
             [
@@ -631,7 +631,7 @@ class TestPeriodicBsplineInsertKnots:
 
     def test_insert_knots_rational_periodic(self) -> None:
         """insert_knots preserves periodic NURBS geometry."""
-        knots = create_uniform_periodic(num_intervals=4, degree=3)
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=3)
         space_1d = BsplineSpace1D(knots, 3, periodic=True)
         space = BsplineSpace([space_1d])
         n = space.num_total_basis

--- a/tests/test_knots_1D.py
+++ b/tests/test_knots_1D.py
@@ -10,9 +10,9 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bspline import (
-    create_cardinal,
-    create_uniform_open,
-    create_uniform_periodic,
+    create_cardinal_knots,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_knots import (
     _get_knots_ends_and_dtype,
@@ -171,11 +171,11 @@ class TestGetEndsAndType:
 
 
 class TestCreateUniformOpenKnotVector:
-    """Tests for `create_uniform_open`."""
+    """Tests for `create_uniform_open_knots`."""
 
     def test_basic_functionality(self) -> None:
         """Create uniform open knot vector with default continuity."""
-        result = create_uniform_open(2, 2, domain=(0.0, 1.0))
+        result = create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
             dtype=np.float64,
@@ -185,13 +185,13 @@ class TestCreateUniformOpenKnotVector:
 
     def test_degree_zero(self) -> None:
         """Handle degree 0 splines."""
-        result = create_uniform_open(2, 0, domain=(0.0, 1.0))
+        result = create_uniform_open_knots(2, 0, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array([0.0, 0.5, 1.0], dtype=np.float64)
         nptest.assert_allclose(result, expected)
 
     def test_degree_one(self) -> None:
         """Handle degree 1 splines."""
-        result = create_uniform_open(2, 1, domain=(0.0, 1.0))
+        result = create_uniform_open_knots(2, 1, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [0.0, 0.0, 0.5, 1.0, 1.0],
             dtype=np.float64,
@@ -200,7 +200,7 @@ class TestCreateUniformOpenKnotVector:
 
     def test_single_interval(self) -> None:
         """Handle the single-interval case."""
-        result = create_uniform_open(1, 2, domain=(0.0, 1.0))
+        result = create_uniform_open_knots(1, 2, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
             dtype=np.float64,
@@ -209,7 +209,7 @@ class TestCreateUniformOpenKnotVector:
 
     def test_custom_continuity(self) -> None:
         """Increase interior knot multiplicity when continuity decreases."""
-        result = create_uniform_open(2, 2, continuity=0, domain=(0.0, 1.0))
+        result = create_uniform_open_knots(2, 2, continuity=0, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0],
             dtype=np.float64,
@@ -218,7 +218,7 @@ class TestCreateUniformOpenKnotVector:
 
     def test_custom_domain(self) -> None:
         """Respect non-default domain."""
-        result = create_uniform_open(2, 2, domain=(1.0, 3.0))
+        result = create_uniform_open_knots(2, 2, domain=(1.0, 3.0))
         expected: npt.NDArray[np.float64] = np.array(
             [1.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0],
             dtype=np.float64,
@@ -227,7 +227,7 @@ class TestCreateUniformOpenKnotVector:
 
     def test_float32_dtype(self) -> None:
         """Preserve float32 dtype requests."""
-        result = create_uniform_open(2, 2, dtype=np.float32)
+        result = create_uniform_open_knots(2, 2, dtype=np.float32)
         expected: npt.NDArray[np.float32] = np.array(
             [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
             dtype=np.float32,
@@ -238,25 +238,25 @@ class TestCreateUniformOpenKnotVector:
     def test_negative_num_intervals_error(self) -> None:
         """Reject negative interval counts."""
         with pytest.raises(ValueError, match="num_intervals must be non-negative"):
-            create_uniform_open(-1, 2)
+            create_uniform_open_knots(-1, 2)
 
     def test_negative_degree_error(self) -> None:
         """Reject negative degrees."""
         with pytest.raises(ValueError, match="degree must be non-negative"):
-            create_uniform_open(2, -1)
+            create_uniform_open_knots(2, -1)
 
     def test_invalid_continuity_error(self) -> None:
         """Reject continuity outside valid range."""
         with pytest.raises(ValueError, match="Continuity must be between"):
-            create_uniform_open(2, 2, continuity=2)
+            create_uniform_open_knots(2, 2, continuity=2)
 
 
 class TestCreateUniformPeriodicKnotVector:
-    """Tests for `create_uniform_periodic`."""
+    """Tests for `create_uniform_periodic_knots`."""
 
     def test_basic_functionality(self) -> None:
         """Create periodic knot vector extending beyond the domain."""
-        result = create_uniform_periodic(2, 2, domain=(0.0, 1.0))
+        result = create_uniform_periodic_knots(2, 2, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0],
             dtype=np.float64,
@@ -265,13 +265,13 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_degree_zero(self) -> None:
         """Handle degree 0 periodic splines."""
-        result = create_uniform_periodic(2, 0, domain=(0.0, 1.0))
+        result = create_uniform_periodic_knots(2, 0, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array([0.0, 0.5, 1.0], dtype=np.float64)
         nptest.assert_allclose(result, expected)
 
     def test_degree_one(self) -> None:
         """Handle degree 1 periodic splines."""
-        result = create_uniform_periodic(2, 1, domain=(0.0, 1.0))
+        result = create_uniform_periodic_knots(2, 1, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [-0.5, 0.0, 0.5, 1.0, 1.5],
             dtype=np.float64,
@@ -280,7 +280,7 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_single_interval(self) -> None:
         """Handle periodic construction with a single interval."""
-        result = create_uniform_periodic(1, 2, domain=(0.0, 1.0))
+        result = create_uniform_periodic_knots(1, 2, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
             dtype=np.float64,
@@ -289,7 +289,7 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_custom_continuity(self) -> None:
         """Respect reduced continuity via increased multiplicity."""
-        result = create_uniform_periodic(2, 2, continuity=0, domain=(0.0, 1.0))
+        result = create_uniform_periodic_knots(2, 2, continuity=0, domain=(0.0, 1.0))
         expected: npt.NDArray[np.float64] = np.array(
             [-0.5, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.5],
             dtype=np.float64,
@@ -298,7 +298,7 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_custom_domain(self) -> None:
         """Respect non-default domains."""
-        result = create_uniform_periodic(2, 2, domain=(1.0, 3.0))
+        result = create_uniform_periodic_knots(2, 2, domain=(1.0, 3.0))
         expected: npt.NDArray[np.float64] = np.array(
             [-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             dtype=np.float64,
@@ -307,7 +307,7 @@ class TestCreateUniformPeriodicKnotVector:
 
     def test_float32_dtype(self) -> None:
         """Preserve float32 dtype requests."""
-        result = create_uniform_periodic(2, 2, dtype=np.float32)
+        result = create_uniform_periodic_knots(2, 2, dtype=np.float32)
         expected: npt.NDArray[np.float32] = np.array(
             [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0],
             dtype=np.float32,
@@ -318,25 +318,25 @@ class TestCreateUniformPeriodicKnotVector:
     def test_negative_num_intervals_error(self) -> None:
         """Reject negative interval counts."""
         with pytest.raises(ValueError, match="num_intervals must be non-negative"):
-            create_uniform_periodic(-1, 2)
+            create_uniform_periodic_knots(-1, 2)
 
     def test_negative_degree_error(self) -> None:
         """Reject negative degrees."""
         with pytest.raises(ValueError, match="degree must be non-negative"):
-            create_uniform_periodic(2, -1)
+            create_uniform_periodic_knots(2, -1)
 
     def test_invalid_continuity_error(self) -> None:
         """Reject continuity outside valid range."""
         with pytest.raises(ValueError, match="Continuity must be between"):
-            create_uniform_periodic(2, 2, continuity=2)
+            create_uniform_periodic_knots(2, 2, continuity=2)
 
 
 class TestCreateCardinalBsplineKnotVector:
-    """Tests for `create_cardinal`."""
+    """Tests for `create_cardinal_knots`."""
 
     def test_basic_functionality(self) -> None:
         """Create cardinal knot vector with default dtype."""
-        result = create_cardinal(2, 2)
+        result = create_cardinal_knots(2, 2)
         expected: npt.NDArray[np.float64] = np.array(
             [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0],
             dtype=np.float64,
@@ -345,13 +345,13 @@ class TestCreateCardinalBsplineKnotVector:
 
     def test_degree_zero(self) -> None:
         """Handle degree 0."""
-        result = create_cardinal(2, 0)
+        result = create_cardinal_knots(2, 0)
         expected: npt.NDArray[np.float64] = np.array([0.0, 1.0, 2.0], dtype=np.float64)
         nptest.assert_allclose(result, expected)
 
     def test_degree_one(self) -> None:
         """Handle degree 1."""
-        result = create_cardinal(2, 1)
+        result = create_cardinal_knots(2, 1)
         expected: npt.NDArray[np.float64] = np.array(
             [-1.0, 0.0, 1.0, 2.0, 3.0],
             dtype=np.float64,
@@ -360,7 +360,7 @@ class TestCreateCardinalBsplineKnotVector:
 
     def test_single_interval(self) -> None:
         """Handle single interval."""
-        result = create_cardinal(1, 2)
+        result = create_cardinal_knots(1, 2)
         expected: npt.NDArray[np.float64] = np.array(
             [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
             dtype=np.float64,
@@ -369,7 +369,7 @@ class TestCreateCardinalBsplineKnotVector:
 
     def test_high_degree(self) -> None:
         """Handle higher degrees."""
-        result = create_cardinal(2, 5)
+        result = create_cardinal_knots(2, 5)
         expected: npt.NDArray[np.float64] = np.array(
             [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
             dtype=np.float64,
@@ -378,7 +378,7 @@ class TestCreateCardinalBsplineKnotVector:
 
     def test_float32_dtype(self) -> None:
         """Preserve float32 dtype requests."""
-        result = create_cardinal(2, 2, dtype=np.float32)
+        result = create_cardinal_knots(2, 2, dtype=np.float32)
         expected: npt.NDArray[np.float32] = np.array(
             [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0],
             dtype=np.float32,
@@ -389,17 +389,17 @@ class TestCreateCardinalBsplineKnotVector:
     def test_invalid_num_intervals_error(self) -> None:
         """Reject interval counts less than one."""
         with pytest.raises(ValueError, match="num_intervals must be at least 1"):
-            create_cardinal(0, 2)
+            create_cardinal_knots(0, 2)
 
     def test_negative_degree_error(self) -> None:
         """Reject negative degrees."""
         with pytest.raises(ValueError, match="degree must be non-negative"):
-            create_cardinal(2, -1)
+            create_cardinal_knots(2, -1)
 
     def test_invalid_dtype_error(self) -> None:
         """Reject non-floating dtype requests."""
         with pytest.raises(ValueError, match="dtype must be float32 or float64"):
-            create_cardinal(2, 2, dtype=np.int32)
+            create_cardinal_knots(2, 2, dtype=np.int32)
 
 
 class TestKnotVectorIntegration:
@@ -407,9 +407,9 @@ class TestKnotVectorIntegration:
 
     def test_consistency_across_functions(self) -> None:
         """Ensure outputs are non-decreasing and float64 by default."""
-        knots_open = create_uniform_open(3, 2, domain=(0.0, 1.0))
-        knots_periodic = create_uniform_periodic(3, 2, domain=(0.0, 1.0))
-        knots_cardinal = create_cardinal(3, 2)
+        knots_open = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+        knots_periodic = create_uniform_periodic_knots(3, 2, domain=(0.0, 1.0))
+        knots_cardinal = create_cardinal_knots(3, 2)
         for knots in (knots_open, knots_periodic, knots_cardinal):
             diffs = np.diff(knots.astype(np.float64))
             assert np.all(diffs >= 0.0)
@@ -421,8 +421,8 @@ class TestKnotVectorIntegration:
         end = np.float64(2.5)
         degree = 2
         domain = (start, end)
-        knots_open = create_uniform_open(2, degree, domain=domain)
-        knots_periodic = create_uniform_periodic(2, degree, domain=domain)
+        knots_open = create_uniform_open_knots(2, degree, domain=domain)
+        knots_periodic = create_uniform_periodic_knots(2, degree, domain=domain)
         assert knots_open[degree] == start
         assert knots_open[-degree - 1] == end
         assert knots_periodic[degree] == start
@@ -433,8 +433,10 @@ class TestKnotVectorIntegration:
         degree = 3
         continuity = 1
         domain = (0.0, 1.0)
-        knots_open = create_uniform_open(2, degree, continuity=continuity, domain=domain)
-        knots_periodic = create_uniform_periodic(2, degree, continuity=continuity, domain=domain)
+        knots_open = create_uniform_open_knots(2, degree, continuity=continuity, domain=domain)
+        knots_periodic = create_uniform_periodic_knots(
+            2, degree, continuity=continuity, domain=domain
+        )
         multiplicity = degree - continuity
         for knots in (knots_open, knots_periodic):
             tol = get_strict(knots.dtype)
@@ -455,9 +457,9 @@ class TestKnotVectorIntegration:
         degree = 2
         continuity = degree - 1
         multiplicity = degree - continuity
-        knots_open = create_uniform_open(num_intervals, degree)
-        knots_periodic = create_uniform_periodic(num_intervals, degree)
-        knots_cardinal = create_cardinal(num_intervals, degree)
+        knots_open = create_uniform_open_knots(num_intervals, degree)
+        knots_periodic = create_uniform_periodic_knots(num_intervals, degree)
+        knots_cardinal = create_cardinal_knots(num_intervals, degree)
         expected_open = 2 * (degree + 1) + (num_intervals - 1) * multiplicity
         expected_periodic = 2 * (degree + 1 - multiplicity) + (num_intervals + 1) * multiplicity
         expected_cardinal = expected_periodic
@@ -468,9 +470,9 @@ class TestKnotVectorIntegration:
     def test_dtype_consistency(self) -> None:
         """Respect dtype arguments across generators."""
         dtype = np.dtype(np.float32)
-        knots_open = create_uniform_open(2, 2, dtype=dtype)
-        knots_periodic = create_uniform_periodic(2, 2, dtype=dtype)
-        knots_cardinal = create_cardinal(2, 2, dtype=dtype)
+        knots_open = create_uniform_open_knots(2, 2, dtype=dtype)
+        knots_periodic = create_uniform_periodic_knots(2, 2, dtype=dtype)
+        knots_cardinal = create_cardinal_knots(2, 2, dtype=dtype)
         assert knots_open.dtype == dtype
         assert knots_periodic.dtype == dtype
         assert knots_cardinal.dtype == dtype

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -57,7 +57,7 @@ def test_submodule_all_exports() -> None:
     assert "Bspline" in bspline.__all__
     assert "BsplineSpace1D" in bspline.__all__
     assert "BsplineSpace" in bspline.__all__
-    assert "create_uniform_open" in bspline.__all__
+    assert "create_uniform_open_knots" in bspline.__all__
 
     assert "compute_bernstein_to_lagrange_1d" in change_basis.__all__
 

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -5,7 +5,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.quad import PointsLattice
 
 # ---------------------------------------------------------------------------
@@ -58,7 +58,7 @@ def _make_periodic_bspline(
     dtype: type = np.float64,
 ) -> Bspline:
     """Create a 1D periodic B-spline with random control points."""
-    knots = create_uniform_periodic(num_intervals, degree, dtype=dtype)
+    knots = create_uniform_periodic_knots(num_intervals, degree, dtype=dtype)
     space_1d = BsplineSpace1D(knots, degree, periodic=True)
     space = BsplineSpace([space_1d])
     rng = np.random.default_rng(42)

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -3,7 +3,7 @@
 Covers:
 
 - :func:`find_roots` -- auto-dispatch root finder (single or batch).
-- :func:`solve_monotone_root` -- Newton/bisection on monotone Beziers (single or batch).
+- :func:`find_monotone_root` -- Newton/bisection on monotone Beziers (single or batch).
 - Internal helpers: de Casteljau scalar, split, subdivide, sign changes,
   convex hull clipping, Newton polish.
 """
@@ -17,8 +17,8 @@ from numpy.testing import assert_allclose
 
 from pantr.bezier import (
     Bezier,
+    find_monotone_root,
     find_roots,
-    solve_monotone_root,
 )
 from pantr.bezier._clipping_core import (
     _clip_roots_core,
@@ -473,32 +473,32 @@ class TestFindRoots(unittest.TestCase):
 
 
 class TestSolveMonotoneRoot(unittest.TestCase):
-    """Tests for :func:`solve_monotone_root` (public API)."""
+    """Tests for :func:`find_monotone_root` (public API)."""
 
     def test_linear_root(self) -> None:
         """Linear: root at t = 0.5."""
-        root = solve_monotone_root(Bezier([-1.0, 1.0]))
+        root = find_monotone_root(Bezier([-1.0, 1.0]))
         self.assertAlmostEqual(root, 0.5, places=13)
 
     def test_quadratic_root(self) -> None:
         """Quadratic [-1, 0, 1]: root at 0.5."""
-        root = solve_monotone_root(Bezier([-1.0, 0.0, 1.0]))
+        root = find_monotone_root(Bezier([-1.0, 0.0, 1.0]))
         self.assertAlmostEqual(root, 0.5, places=12)
 
     def test_no_root_returns_nan(self) -> None:
         """All-positive: returns NaN."""
-        root = solve_monotone_root(Bezier([1.0, 2.0, 3.0]))
+        root = find_monotone_root(Bezier([1.0, 2.0, 3.0]))
         self.assertTrue(np.isnan(root))
 
     def test_custom_tolerance(self) -> None:
         """Custom tolerance works."""
-        root = solve_monotone_root(Bezier([-1.0, 1.0]), tol=1e-6)
+        root = find_monotone_root(Bezier([-1.0, 1.0]), tol=1e-6)
         self.assertAlmostEqual(root, 0.5, places=5)
 
     def test_non_bezier_raises(self) -> None:
         """Non-Bezier input raises TypeError."""
         with self.assertRaises(TypeError):
-            solve_monotone_root(np.array([-1.0, 1.0]))  # type: ignore
+            find_monotone_root(np.array([-1.0, 1.0]))  # type: ignore
 
 
 class TestFindRootsBatch(unittest.TestCase):
@@ -554,7 +554,7 @@ class TestFindRootsBatch(unittest.TestCase):
 
 
 class TestSolveMonotoneRootBatch(unittest.TestCase):
-    """Tests for :func:`solve_monotone_root` batch mode (public API)."""
+    """Tests for :func:`find_monotone_root` batch mode (public API)."""
 
     def test_mixed_roots(self) -> None:
         """Batch with some roots and some NaN."""
@@ -563,7 +563,7 @@ class TestSolveMonotoneRootBatch(unittest.TestCase):
             Bezier([1.0, 2.0]),  # no root
             Bezier([0.0, 1.0]),  # root at 0.0
         ]
-        roots = solve_monotone_root(beziers)
+        roots = find_monotone_root(beziers)
         self.assertAlmostEqual(roots[0], 0.5, places=12)
         self.assertTrue(np.isnan(roots[1]))
         self.assertAlmostEqual(roots[2], 0.0, places=10)
@@ -571,20 +571,20 @@ class TestSolveMonotoneRootBatch(unittest.TestCase):
     def test_single_polynomial(self) -> None:
         """Batch of one matches single-poly result."""
         bez = Bezier([-1.0, 0.0, 1.0])
-        root_single = solve_monotone_root(bez)
-        roots_batch = solve_monotone_root([bez])
+        root_single = find_monotone_root(bez)
+        roots_batch = find_monotone_root([bez])
         self.assertAlmostEqual(roots_batch[0], root_single, places=12)
 
     def test_all_no_roots(self) -> None:
         """Batch where no Bezier has a root."""
         beziers = [Bezier([1.0, 2.0, 3.0]), Bezier([4.0, 5.0, 6.0])]
-        roots = solve_monotone_root(beziers)
+        roots = find_monotone_root(beziers)
         self.assertTrue(np.isnan(roots[0]))
         self.assertTrue(np.isnan(roots[1]))
 
     def test_empty_batch(self) -> None:
         """Empty batch returns empty array without error."""
-        roots = solve_monotone_root([])
+        roots = find_monotone_root([])
         self.assertEqual(roots.shape, (0,))
 
 

--- a/tests/test_viz_cells.py
+++ b/tests/test_viz_cells.py
@@ -14,7 +14,7 @@ from pantr.bspline import (  # noqa: E402
     Bspline,
     BsplineSpace,
     BsplineSpace1D,
-    create_uniform_periodic,
+    create_uniform_periodic_knots,
 )
 from pantr.viz import save, to_pyvista  # noqa: E402
 from pantr.viz._vtk_cells import (  # noqa: E402
@@ -169,7 +169,7 @@ class TestBsplineToPyvista:
 
     def test_periodic_bspline(self) -> None:
         """Periodic B-spline should convert without error."""
-        knots = create_uniform_periodic(4, 2, domain=(0.0, 1.0))
+        knots = create_uniform_periodic_knots(4, 2, domain=(0.0, 1.0))
         space1d = BsplineSpace1D(knots, 2, periodic=True)
         space = BsplineSpace([space1d])
         n_basis = space1d.num_basis

--- a/tests/test_viz_knot_lines.py
+++ b/tests/test_viz_knot_lines.py
@@ -12,7 +12,7 @@ from pantr.bspline import (  # noqa: E402
     Bspline,
     BsplineSpace,
     BsplineSpace1D,
-    create_uniform_open,
+    create_uniform_open_knots,
 )
 from pantr.viz import control_polygon_mesh, knot_lines_meshes  # noqa: E402
 
@@ -41,8 +41,8 @@ def bspline_curve() -> Bspline:
 @pytest.fixture()
 def bspline_surface() -> Bspline:
     """Biquadratic B-spline surface in 3D."""
-    knots_u = create_uniform_open(3, 2, domain=(0.0, 1.0))
-    knots_v = create_uniform_open(2, 2, domain=(0.0, 1.0))
+    knots_u = create_uniform_open_knots(3, 2, domain=(0.0, 1.0))
+    knots_v = create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
     s_u = BsplineSpace1D(knots_u, 2)
     s_v = BsplineSpace1D(knots_v, 2)
     space = BsplineSpace([s_u, s_v])


### PR DESCRIPTION
## Summary
- Rename knot factory functions to include `_knots` suffix: `create_cardinal_knots`, `create_uniform_open_knots`, `create_uniform_periodic_knots`
- Rename `greville_abscissae` → `get_greville_abscissae` and `greville_lattice` → `create_greville_lattice` for consistent verb prefixes
- Rename `solve_monotone_root` → `find_monotone_root` to match the `find_roots` naming convention

## Test plan
- [x] All 2339 existing tests pass
- [x] Pre-PR checks pass (ruff, ruff format, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)