### PR TITLE
refactor(cad): rename public functions for clarity

### DIFF
--- a/docs/constructive-geometry.md
+++ b/docs/constructive-geometry.md
@@ -13,29 +13,29 @@ All produce rank-3 (3D) output; lower-dimensional inputs are zero-padded.
 ### Lines and multilinear patches
 
 ```python
-from pantr.cad import line, bilinear, trilinear
+from pantr.cad import create_line, create_bilinear, create_trilinear
 
-crv = line([0, 0, 0], [1, 0, 0])           # degree-1 curve
-srf = bilinear()                            # unit square in XY
-vol = trilinear()                           # unit cube
+crv = create_line([0, 0, 0], [1, 0, 0])    # degree-1 curve
+srf = create_bilinear()                     # unit square in XY
+vol = create_trilinear()                    # unit cube
 ```
 
-{func}`~pantr.cad.line` creates a degree-1 curve between two points.
-{func}`~pantr.cad.bilinear` creates a degree-(1, 1) surface from four corners.
-{func}`~pantr.cad.trilinear` creates a degree-(1, 1, 1) volume from eight corners.
+{func}`~pantr.cad.create_line` creates a degree-1 curve between two points.
+{func}`~pantr.cad.create_bilinear` creates a degree-(1, 1) surface from four corners.
+{func}`~pantr.cad.create_trilinear` creates a degree-(1, 1, 1) volume from eight corners.
 
 ### Circles and arcs
 
 ```python
-from pantr.cad import circle
+from pantr.cad import create_circle
 import numpy as np
 
-full = circle(radius=2.0)                         # full circle, 4 spans
-arc  = circle(angle=np.pi / 2)                    # quarter arc, 1 span
-arc2 = circle(angle=(np.pi / 4, np.pi), radius=3) # arc from 45 to 180 deg
+full = create_circle(radius=2.0)                         # full circle, 4 spans
+arc  = create_circle(angle=np.pi / 2)                    # quarter arc, 1 span
+arc2 = create_circle(angle=(np.pi / 4, np.pi), radius=3) # arc from 45 to 180 deg
 ```
 
-{func}`~pantr.cad.circle` builds an exact rational quadratic B-spline.
+{func}`~pantr.cad.create_circle` builds an exact rational quadratic B-spline.
 The number of spans depends on the sweep angle (one span per 90 degrees),
 with C0 interior knots (multiplicity equal to degree).  This is the
 standard conic representation.
@@ -43,17 +43,17 @@ standard conic representation.
 ### Derived shapes
 
 ```python
-from pantr.cad import rectangle, disk, cylinder
+from pantr.cad import create_rectangle, create_disk, create_cylinder
 
-rect = rectangle(corner=[0, 0, 0], width=2, height=3)  # closed curve
-ann  = disk(radius_inner=0.5, radius_outer=1.0)         # annular sector
-cyl  = cylinder(radius=1.0, height=5.0)                 # cylindrical surface
+rect = create_rectangle(corner=[0, 0, 0], width=2, height=3)  # closed curve
+ann  = create_disk(radius_inner=0.5, radius_outer=1.0)         # annular sector
+cyl  = create_cylinder(radius=1.0, height=5.0)                 # cylindrical surface
 ```
 
-{func}`~pantr.cad.rectangle` returns a closed degree-1 curve visiting four corners.
-{func}`~pantr.cad.disk` builds an annular sector (or full disk when `radius_inner=0`)
-via {func}`~pantr.cad.ruled` between inner and outer circles.
-{func}`~pantr.cad.cylinder` extrudes a circle along the z-axis.
+{func}`~pantr.cad.create_rectangle` returns a closed degree-1 curve visiting four corners.
+{func}`~pantr.cad.create_disk` builds an annular sector (or full disk when `radius_inner=0`)
+via {func}`~pantr.cad.create_ruled` between inner and outer circles.
+{func}`~pantr.cad.create_cylinder` extrudes a circle along the z-axis.
 
 ## Operations
 
@@ -63,9 +63,9 @@ a new parametric direction.
 ### Extrude
 
 ```python
-from pantr.cad import circle, extrude
+from pantr.cad import create_circle, extrude
 
-pipe = extrude(circle(), [0, 0, 2])   # circle -> cylindrical surface
+pipe = extrude(create_circle(), [0, 0, 2])   # circle -> cylindrical surface
 ```
 
 {func}`~pantr.cad.extrude` translates a curve or surface along a displacement
@@ -74,38 +74,38 @@ vector, appending a degree-1 parametric direction.
 ### Revolve
 
 ```python
-from pantr.cad import line, revolve
+from pantr.cad import create_line, revolve
 import numpy as np
 
-srf = revolve(line([1, 0, 0], [2, 0, 0]), point=0, axis=2)
-quarter = revolve(line([1, 0, 0], [1, 0, 3]), point=0, axis=2,
+srf = revolve(create_line([1, 0, 0], [2, 0, 0]), point=0, axis=2)
+quarter = revolve(create_line([1, 0, 0], [1, 0, 3]), point=0, axis=2,
                   angle=np.pi / 2)
 ```
 
 {func}`~pantr.cad.revolve` rotates a curve or surface around an axis.
 The angular direction inherits the same span structure as
-{func}`~pantr.cad.circle` (one span per 90 degrees, C0 at arc junctions).
+{func}`~pantr.cad.create_circle` (one span per 90 degrees, C0 at arc junctions).
 Supports coordinate axes (`axis=0, 1, 2`) and arbitrary axis vectors.
 
 ### Ruled
 
 ```python
-from pantr.cad import circle, ruled
+from pantr.cad import create_circle, create_ruled
 
-annulus = ruled(circle(radius=0.5), circle(radius=1.0))
+annulus = create_ruled(create_circle(radius=0.5), create_circle(radius=1.0))
 ```
 
-{func}`~pantr.cad.ruled` linearly interpolates between two curves (or
+{func}`~pantr.cad.create_ruled` linearly interpolates between two curves (or
 surfaces) to produce a surface (or volume).  The inputs are automatically
-made compatible via {func}`~pantr.cad.compat`.
+made compatible via {func}`~pantr.cad.make_compat`.
 
 ### Sweep
 
 ```python
-from pantr.cad import line, sweep
+from pantr.cad import create_line, sweep
 
-srf = sweep(line([0, 0, 0], [1, 0, 0]),    # section
-            line([0, 0, 0], [0, 0, 3]))     # trajectory
+srf = sweep(create_line([0, 0, 0], [1, 0, 0]),    # section
+            create_line([0, 0, 0], [0, 0, 3]))     # trajectory
 ```
 
 {func}`~pantr.cad.sweep` creates a translational sweep:
@@ -116,40 +116,40 @@ $S(u, v) = \text{section}(u) + \text{trajectory}(v)$.
 ### Surface
 
 ```python
-from pantr.cad import coons_surface, line
+from pantr.cad import create_coons_surface, create_line
 
-c_u0 = line([0, 0, 0], [1, 0, 0])   # bottom
-c_u1 = line([0, 1, 0], [1, 1, 0])   # top
-c_v0 = line([0, 0, 0], [0, 1, 0])   # left
-c_v1 = line([1, 0, 0], [1, 1, 0])   # right
+c_u0 = create_line([0, 0, 0], [1, 0, 0])   # bottom
+c_u1 = create_line([0, 1, 0], [1, 1, 0])   # top
+c_v0 = create_line([0, 0, 0], [0, 1, 0])   # left
+c_v1 = create_line([1, 0, 0], [1, 1, 0])   # right
 
-srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
 ```
 
-{func}`~pantr.cad.coons_surface` builds a bilinearly blended surface from
+{func}`~pantr.cad.create_coons_surface` builds a bilinearly blended surface from
 four boundary curves using the formula $S = R_0 + R_1 - B$, where $R_0$
 and $R_1$ are ruled surfaces and $B$ is the bilinear corner interpolant.
 
 ### Volume
 
 ```python
-from pantr.cad import bilinear, coons_volume
+from pantr.cad import create_bilinear, create_coons_volume
 import numpy as np
 
 # Build 6 faces of a unit cube
-face_u0 = bilinear(np.array([[[0,0,0],[0,0,1]],[[0,1,0],[0,1,1]]], dtype=float))
-face_u1 = bilinear(np.array([[[1,0,0],[1,0,1]],[[1,1,0],[1,1,1]]], dtype=float))
-face_v0 = bilinear(np.array([[[0,0,0],[0,0,1]],[[1,0,0],[1,0,1]]], dtype=float))
-face_v1 = bilinear(np.array([[[0,1,0],[0,1,1]],[[1,1,0],[1,1,1]]], dtype=float))
-face_w0 = bilinear(np.array([[[0,0,0],[0,1,0]],[[1,0,0],[1,1,0]]], dtype=float))
-face_w1 = bilinear(np.array([[[0,0,1],[0,1,1]],[[1,0,1],[1,1,1]]], dtype=float))
+face_u0 = create_bilinear(np.array([[[0,0,0],[0,0,1]],[[0,1,0],[0,1,1]]], dtype=float))
+face_u1 = create_bilinear(np.array([[[1,0,0],[1,0,1]],[[1,1,0],[1,1,1]]], dtype=float))
+face_v0 = create_bilinear(np.array([[[0,0,0],[0,0,1]],[[1,0,0],[1,0,1]]], dtype=float))
+face_v1 = create_bilinear(np.array([[[0,1,0],[0,1,1]],[[1,1,0],[1,1,1]]], dtype=float))
+face_w0 = create_bilinear(np.array([[[0,0,0],[0,1,0]],[[1,0,0],[1,1,0]]], dtype=float))
+face_w1 = create_bilinear(np.array([[[0,0,1],[0,1,1]],[[1,0,1],[1,1,1]]], dtype=float))
 
-vol = coons_volume(((face_u0, face_u1),
-                    (face_v0, face_v1),
-                    (face_w0, face_w1)))
+vol = create_coons_volume(((face_u0, face_u1),
+                           (face_v0, face_v1),
+                           (face_w0, face_w1)))
 ```
 
-{func}`~pantr.cad.coons_volume` builds a trilinearly blended volume from
+{func}`~pantr.cad.create_coons_volume` builds a trilinearly blended volume from
 six boundary faces using the inclusion-exclusion formula:
 
 $$V = (R_u + R_v + R_w) - (B_{uv} + B_{uw} + B_{vw}) + T$$
@@ -161,32 +161,32 @@ boundaries.
 
 ## Compatibility and assembly
 
-### compat
+### make_compat
 
 ```python
-from pantr.cad import compat, circle, line
+from pantr.cad import make_compat, create_circle, create_line
 
-c1 = line([0, 0, 0], [1, 0, 0])   # degree 1
-c2 = circle(angle=np.pi / 2)       # degree 2, different knots
-r1, r2 = compat(c1, c2)            # now same degree and knots
+c1 = create_line([0, 0, 0], [1, 0, 0])   # degree 1
+c2 = create_circle(angle=np.pi / 2)       # degree 2, different knots
+r1, r2 = make_compat(c1, c2)              # now same degree and knots
 ```
 
-{func}`~pantr.cad.compat` makes N B-splines compatible along specified axes by:
+{func}`~pantr.cad.make_compat` makes N B-splines compatible along specified axes by:
 1. Remapping domains to a common envelope.
 2. Elevating degrees to the maximum.
 3. Merging knot vectors (union of breakpoints with max multiplicities).
 
-This is called internally by {func}`~pantr.cad.ruled`,
-{func}`~pantr.cad.coons_surface`, {func}`~pantr.cad.coons_volume`, and
+This is called internally by {func}`~pantr.cad.create_ruled`,
+{func}`~pantr.cad.create_coons_surface`, {func}`~pantr.cad.create_coons_volume`, and
 {func}`~pantr.cad.join`.
 
 ### join
 
 ```python
-from pantr.cad import join, line
+from pantr.cad import join, create_line
 
-c1 = line([0, 0, 0], [1, 0, 0])
-c2 = line([1, 0, 0], [2, 1, 0])
+c1 = create_line([0, 0, 0], [1, 0, 0])
+c2 = create_line([1, 0, 0], [2, 1, 0])
 merged = join(c1, c2, axis=0)
 ```
 

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -3,42 +3,42 @@
 This package provides CAD-style functions for creating and combining
 B-spline geometric objects:
 
-- **Primitives**: :func:`line`, :func:`circle`, :func:`bilinear`,
-  :func:`trilinear`.
-- **Derived primitives**: :func:`rectangle`, :func:`disk`,
-  :func:`cylinder`.
-- **Compatibility**: :func:`compat`.
-- **Operations**: :func:`extrude`, :func:`revolve`, :func:`ruled`,
+- **Primitives**: :func:`create_line`, :func:`create_circle`,
+  :func:`create_bilinear`, :func:`create_trilinear`.
+- **Derived primitives**: :func:`create_rectangle`, :func:`create_disk`,
+  :func:`create_cylinder`.
+- **Compatibility**: :func:`make_compat`.
+- **Operations**: :func:`extrude`, :func:`revolve`, :func:`create_ruled`,
   :func:`sweep`.
-- **Coons blending**: :func:`coons_surface`, :func:`coons_volume`.
+- **Coons blending**: :func:`create_coons_surface`, :func:`create_coons_volume`.
 - **Assembly**: :func:`join`.
 """
 
-from ._compat import compat
-from ._coons import coons_surface, coons_volume
-from ._derived import cylinder, disk, rectangle
+from ._compat import make_compat
+from ._coons import create_coons_surface, create_coons_volume
+from ._derived import create_cylinder, create_disk, create_rectangle
 from ._join import join
-from ._operations import extrude, revolve, ruled, sweep
-from ._primitives import bilinear, circle, line, trilinear
+from ._operations import create_ruled, extrude, revolve, sweep
+from ._primitives import create_bilinear, create_circle, create_line, create_trilinear
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
 __all__ = [
     "_PHYSICAL_DIM",
     "_pad_to_3d",
     "_promote_to_rational",
-    "bilinear",
-    "circle",
-    "compat",
-    "coons_surface",
-    "coons_volume",
-    "cylinder",
-    "disk",
+    "create_bilinear",
+    "create_circle",
+    "create_coons_surface",
+    "create_coons_volume",
+    "create_cylinder",
+    "create_disk",
+    "create_line",
+    "create_rectangle",
+    "create_ruled",
+    "create_trilinear",
     "extrude",
     "join",
-    "line",
-    "rectangle",
+    "make_compat",
     "revolve",
-    "ruled",
     "sweep",
-    "trilinear",
 ]

--- a/src/pantr/cad/_compat.py
+++ b/src/pantr/cad/_compat.py
@@ -2,8 +2,9 @@
 
 Provides :func:`make_compat`, which takes N B-splines and returns new objects
 that share the same degree and knot vector along each specified axis.
-This is the prerequisite for operations like ``create_ruled``, ``coons``, and
-``join`` that combine control points from different B-splines.
+This is the prerequisite for operations like ``create_ruled``,
+``create_coons_surface``, and ``join`` that combine control points from
+different B-splines.
 """
 
 from __future__ import annotations

--- a/src/pantr/cad/_compat.py
+++ b/src/pantr/cad/_compat.py
@@ -1,8 +1,8 @@
 """B-spline compatibility: match degrees and knot vectors across objects.
 
-Provides :func:`compat`, which takes N B-splines and returns new objects
+Provides :func:`make_compat`, which takes N B-splines and returns new objects
 that share the same degree and knot vector along each specified axis.
-This is the prerequisite for operations like ``ruled``, ``coons``, and
+This is the prerequisite for operations like ``create_ruled``, ``coons``, and
 ``join`` that combine control points from different B-splines.
 """
 
@@ -97,7 +97,7 @@ def _merge_breakpoints_n_way(
     return union_bp, deficits
 
 
-def compat(
+def make_compat(
     *bsplines: Bspline,
     axes: int | Sequence[int] | None = None,
 ) -> list[Bspline]:

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -1,7 +1,7 @@
 """Coons patch and volume constructions.
 
-Provides :func:`coons_surface` (bilinear blending from 4 boundary curves)
-and :func:`coons_volume` (trilinear blending from 6 boundary faces).
+Provides :func:`create_coons_surface` (bilinear blending from 4 boundary curves)
+and :func:`create_coons_volume` (trilinear blending from 6 boundary faces).
 """
 
 from __future__ import annotations
@@ -10,9 +10,9 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
-from ._compat import compat
-from ._operations import ruled
-from ._primitives import _linear_space_1d, bilinear, trilinear
+from ._compat import make_compat
+from ._operations import create_ruled
+from ._primitives import _linear_space_1d, create_bilinear, create_trilinear
 from ._validation import _promote_to_rational
 
 
@@ -39,7 +39,7 @@ def _combine_control_points(
     return cp, is_rational
 
 
-def coons_surface(
+def create_coons_surface(
     curves: tuple[tuple[Bspline, Bspline], tuple[Bspline, Bspline]],
 ) -> Bspline:
     """Construct a Coons patch from four boundary curves.
@@ -79,8 +79,8 @@ def coons_surface(
             raise ValueError(f"All curves must be 1D, got dim={c.dim}.")
 
     # Make opposite pairs compatible
-    c_u0, c_u1 = compat(c_u0, c_u1)
-    c_v0, c_v1 = compat(c_v0, c_v1)
+    c_u0, c_u1 = make_compat(c_u0, c_u1)
+    c_v0, c_v1 = make_compat(c_v0, c_v1)
 
     # Extract and verify corner points
     p00 = np.asarray(c_u0.boundary(0, 0), dtype=np.float64)
@@ -91,18 +91,18 @@ def coons_surface(
     _verify_corners_2d((p00, p10, p01, p11), c_v0, c_v1)
 
     # R0: ruled in v from C_v0 to C_v1, then transpose to (u, v)
-    r0 = ruled(c_v0, c_v1).permute_directions([1, 0])
+    r0 = create_ruled(c_v0, c_v1).permute_directions([1, 0])
     # R1: ruled in u from C_u0 to C_u1 (already in (u, v) order)
-    r1 = ruled(c_u0, c_u1)
+    r1 = create_ruled(c_u0, c_u1)
     # B: bilinear from corners
     corners = np.zeros((2, 2, p00.size), dtype=np.float64)
     corners[0, 0] = p00
     corners[1, 0] = p10
     corners[0, 1] = p01
     corners[1, 1] = p11
-    b = bilinear(corners)
+    b = create_bilinear(corners)
 
-    r0, r1, b = compat(r0, r1, b)
+    r0, r1, b = make_compat(r0, r1, b)
 
     cp, is_rational = _combine_control_points([r0, r1, b], [+1, +1, -1])
     return Bspline(r0.space, cp, is_rational=is_rational)
@@ -145,7 +145,7 @@ def _verify_corners_2d(
             raise ValueError(f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv}.")
 
 
-def coons_volume(
+def create_coons_volume(
     faces: tuple[
         tuple[Bspline, Bspline],
         tuple[Bspline, Bspline],
@@ -189,9 +189,9 @@ def coons_volume(
             raise ValueError(f"All faces must be 2D B-splines, got dim={f.dim}.")
 
     # Make opposite face pairs compatible
-    face_u0, face_u1 = compat(face_u0, face_u1)
-    face_v0, face_v1 = compat(face_v0, face_v1)
-    face_w0, face_w1 = compat(face_w0, face_w1)
+    face_u0, face_u1 = make_compat(face_u0, face_u1)
+    face_v0, face_v1 = make_compat(face_v0, face_v1)
+    face_w0, face_w1 = make_compat(face_w0, face_w1)
 
     # Extract edges from faces
     edges = _extract_edges((face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1))
@@ -200,9 +200,9 @@ def coons_volume(
     corners = _extract_corners(edges)
 
     # Build 3 ruled volumes
-    r_u = ruled(face_u0, face_u1).permute_directions([2, 0, 1])
-    r_v = ruled(face_v0, face_v1).permute_directions([0, 2, 1])
-    r_w = ruled(face_w0, face_w1)  # already (u, v, w)
+    r_u = create_ruled(face_u0, face_u1).permute_directions([2, 0, 1])
+    r_v = create_ruled(face_v0, face_v1).permute_directions([0, 2, 1])
+    r_w = create_ruled(face_w0, face_w1)  # already (u, v, w)
 
     # Build 3 bilinear blend volumes
     # B_uv: raw axes (u, v, w) → permute to (u, v, w) = identity
@@ -231,10 +231,10 @@ def coons_volume(
     )
 
     # Build trilinear volume
-    t = trilinear(corners)
+    t = create_trilinear(corners)
 
     # Make all 7 terms compatible and combine
-    r_u, r_v, r_w, b_uv, b_uw, b_vw, t = compat(r_u, r_v, r_w, b_uv, b_uw, b_vw, t)
+    r_u, r_v, r_w, b_uv, b_uw, b_vw, t = make_compat(r_u, r_v, r_w, b_uv, b_uw, b_vw, t)
 
     cp, is_rational = _combine_control_points(
         [r_u, r_v, r_w, b_uv, b_uw, b_vw, t],
@@ -340,7 +340,7 @@ def _build_bilinear_volume(
     Returns:
         Bspline: A 3D B-spline volume in (u, v, w) order.
     """
-    e_00, e_10, e_01, e_11 = compat(e_00, e_10, e_01, e_11)
+    e_00, e_10, e_01, e_11 = make_compat(e_00, e_10, e_01, e_11)
 
     is_rational = any(e.is_rational for e in (e_00, e_10, e_01, e_11))
     if is_rational:

--- a/src/pantr/cad/_derived.py
+++ b/src/pantr/cad/_derived.py
@@ -1,7 +1,7 @@
 """Derived primitives built from core operations.
 
 Provides higher-level geometric primitives constructed by composing
-:func:`circle`, :func:`extrude`, :func:`ruled`, and :func:`revolve`.
+:func:`create_circle`, :func:`extrude`, :func:`create_ruled`, and :func:`revolve`.
 """
 
 from __future__ import annotations
@@ -10,12 +10,12 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
-from ._operations import extrude, ruled
-from ._primitives import circle
+from ._operations import create_ruled, extrude
+from ._primitives import create_circle
 from ._validation import _PHYSICAL_DIM, _pad_to_3d
 
 
-def rectangle(
+def create_rectangle(
     corner: npt.ArrayLike = (0.0, 0.0, 0.0),
     width: float = 1.0,
     height: float = 1.0,
@@ -34,7 +34,7 @@ def rectangle(
         Bspline: A 1D, degree-1, rank-3, non-rational closed curve.
 
     Example:
-        >>> rect = rectangle([0, 0], 2, 3)
+        >>> rect = create_rectangle([0, 0], 2, 3)
         >>> rect.dim
         1
     """
@@ -60,7 +60,7 @@ def rectangle(
     return Bspline(space, cp)
 
 
-def disk(
+def create_disk(
     radius_inner: float = 0.0,
     radius_outer: float = 1.0,
     center: npt.ArrayLike | None = None,
@@ -69,7 +69,7 @@ def disk(
     """Construct a disk or annular sector as a NURBS surface.
 
     When ``radius_inner > 0``, produces an annular sector via
-    :func:`ruled` between inner and outer circular arcs.  When
+    :func:`create_ruled` between inner and outer circular arcs.  When
     ``radius_inner == 0``, the inner boundary degenerates to a point.
 
     Args:
@@ -77,21 +77,21 @@ def disk(
         radius_outer: Outer radius.
         center: Center point (up to 3D, zero-padded).  If ``None``,
             centered at the origin.
-        angle: Sweep specification (same as :func:`circle`).
+        angle: Sweep specification (same as :func:`create_circle`).
 
     Returns:
         Bspline: A 2D rational B-spline surface.
 
     Example:
-        >>> d = disk(radius_outer=2.0)
+        >>> d = create_disk(radius_outer=2.0)
         >>> d.dim
         2
     """
-    outer = circle(radius=radius_outer, center=center, angle=angle)
+    outer = create_circle(radius=radius_outer, center=center, angle=angle)
 
     if radius_inner > 0:
-        inner = circle(radius=radius_inner, center=center, angle=angle)
-        return ruled(inner, outer)
+        inner = create_circle(radius=radius_inner, center=center, angle=angle)
+        return create_ruled(inner, outer)
 
     # Degenerate inner: all control points at center
     c = _pad_to_3d(center) if center is not None else np.zeros(_PHYSICAL_DIM)
@@ -107,10 +107,10 @@ def disk(
         inner_cp[:, i] = inner_cp[:, _PHYSICAL_DIM] * c[i]
 
     inner = Bspline(outer.space, inner_cp, is_rational=True)
-    return ruled(inner, outer)
+    return create_ruled(inner, outer)
 
 
-def cylinder(
+def create_cylinder(
     radius: float = 1.0,
     height: float = 1.0,
     center: npt.ArrayLike | None = None,
@@ -124,14 +124,14 @@ def cylinder(
         radius: Cylinder radius.
         height: Cylinder height along the z-axis.
         center: Center of the base circle (up to 3D, zero-padded).
-        angle: Sweep specification (same as :func:`circle`).
+        angle: Sweep specification (same as :func:`create_circle`).
 
     Returns:
         Bspline: A 2D rational B-spline surface.
 
     Example:
-        >>> cyl = cylinder(radius=2, height=5)
+        >>> cyl = create_cylinder(radius=2, height=5)
         >>> cyl.dim
         2
     """
-    return extrude(circle(radius=radius, center=center, angle=angle), [0, 0, height])
+    return extrude(create_circle(radius=radius, center=center, angle=angle), [0, 0, height])

--- a/src/pantr/cad/_join.py
+++ b/src/pantr/cad/_join.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
-from ._compat import _remap_bspline, compat
+from ._compat import _remap_bspline, make_compat
 from ._validation import _promote_to_rational
 
 
@@ -37,7 +37,7 @@ def _prepare_for_join(
     # Make compatible on non-join axes
     non_join = [i for i in range(dim) if i != axis]
     if non_join:
-        b1, b2 = compat(bspline1, bspline2, axes=non_join)
+        b1, b2 = make_compat(bspline1, bspline2, axes=non_join)
     else:
         b1, b2 = bspline1, bspline2
 

--- a/src/pantr/cad/_operations.py
+++ b/src/pantr/cad/_operations.py
@@ -12,8 +12,8 @@ from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace
 from ..transform import AffineTransform
-from ._compat import compat
-from ._primitives import _linear_space_1d, circle
+from ._compat import make_compat
+from ._primitives import _linear_space_1d, create_circle
 from ._validation import _PHYSICAL_DIM, _pad_to_3d, _promote_to_rational
 
 _MAX_DIM_FOR_OPERATIONS = 2
@@ -39,8 +39,8 @@ def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
         ValueError: If ``bspline.dim > 2``.
 
     Example:
-        >>> from pantr.cad import circle, extrude
-        >>> cyl = extrude(circle(), [0, 0, 1])
+        >>> from pantr.cad import create_circle, extrude
+        >>> cyl = extrude(create_circle(), [0, 0, 1])
         >>> cyl.dim
         2
     """
@@ -69,14 +69,14 @@ def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
     return Bspline(new_space, new_cp, is_rational=bspline.is_rational)
 
 
-def ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
+def create_ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
     """Construct a ruled surface or volume between two B-splines.
 
     Creates a new B-spline by linearly interpolating control points
     between *bspline1* (at parameter 0) and *bspline2* (at parameter 1)
     along a new last parametric axis with degree 1.
 
-    The two inputs are first made compatible via :func:`compat` so they
+    The two inputs are first made compatible via :func:`make_compat` so they
     share the same degree and knot vectors.  If one is rational and the
     other is not, the non-rational one is promoted.
 
@@ -92,8 +92,8 @@ def ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
         ValueError: If either input has ``dim > 2``.
 
     Example:
-        >>> from pantr.cad import circle, ruled
-        >>> annulus = ruled(circle(radius=0.5), circle(radius=1.0))
+        >>> from pantr.cad import create_circle, create_ruled
+        >>> annulus = create_ruled(create_circle(radius=0.5), create_circle(radius=1.0))
         >>> annulus.dim
         2
     """
@@ -104,7 +104,7 @@ def ruled(bspline1: Bspline, bspline2: Bspline) -> Bspline:
     if bspline1.dim > _MAX_DIM_FOR_OPERATIONS:
         raise ValueError(f"ruled requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline1.dim}.")
 
-    b1, b2 = compat(bspline1, bspline2)
+    b1, b2 = make_compat(bspline1, bspline2)
 
     # Promote to rational if needed
     is_rational = b1.is_rational or b2.is_rational
@@ -249,7 +249,7 @@ def revolve(
     arc construction, and transformed back.
 
     The angular direction inherits the same span/continuity structure
-    as :func:`circle`: one span per 90 degrees, C0 at arc junctions.
+    as :func:`create_circle`: one span per 90 degrees, C0 at arc junctions.
 
     Args:
         bspline: Input curve (dim=1) or surface (dim=2) with rank 3.
@@ -257,7 +257,7 @@ def revolve(
         axis: Rotation axis.  An ``int`` in ``{0, 1, 2}`` selects
             a coordinate axis.  An array-like of length 3 specifies
             an arbitrary axis direction (normalised internally).
-        angle: Sweep specification (same as :func:`circle`).
+        angle: Sweep specification (same as :func:`create_circle`).
 
     Returns:
         Bspline: A rational B-spline with ``dim + 1`` dimensions.
@@ -279,7 +279,7 @@ def revolve(
     nrb_transformed = nrb.transform(t)
     assert nrb_transformed is not None
 
-    arc = circle(angle=angle)
+    arc = create_circle(angle=angle)
     qw = _revolve_control_points(np.asarray(nrb_transformed.control_points, dtype=np.float64), arc)
 
     spaces = [*nrb_transformed.space.spaces, *arc.space.spaces]

--- a/src/pantr/cad/_primitives.py
+++ b/src/pantr/cad/_primitives.py
@@ -1,4 +1,6 @@
-"""Constructive geometry primitives: line, circle, bilinear, and trilinear.
+"""Constructive geometry primitives.
+
+Defines create_line, create_circle, create_bilinear, and create_trilinear.
 
 Provides functions to create basic B-spline objects from geometric
 descriptions (points, corners, radii, angles).  All primitives produce
@@ -34,7 +36,7 @@ def _linear_space_1d(dtype: npt.DTypeLike = np.float64) -> BsplineSpace1D:
     return BsplineSpace1D(knots, degree=1)
 
 
-def line(
+def create_line(
     p0: npt.ArrayLike = (0.0, 0.0, 0.0),
     p1: npt.ArrayLike = (1.0, 0.0, 0.0),
 ) -> Bspline:
@@ -52,7 +54,7 @@ def line(
         Bspline: A 1D, degree-1, rank-3, non-rational B-spline curve.
 
     Example:
-        >>> crv = line([0, 0], [1, 1])
+        >>> crv = create_line([0, 0], [1, 1])
         >>> crv.degree
         (1,)
         >>> crv.rank
@@ -89,7 +91,7 @@ def _rotate_weighted(
     return out
 
 
-def circle(
+def create_circle(
     radius: float = 1.0,
     center: npt.ArrayLike | None = None,
     angle: float | tuple[float, float] | None = None,
@@ -123,7 +125,7 @@ def circle(
         Bspline: A 1D, degree-2, rank-3, rational B-spline curve.
 
     Example:
-        >>> crv = circle()
+        >>> crv = create_circle()
         >>> crv.degree
         (2,)
         >>> crv.is_rational
@@ -240,7 +242,7 @@ def _build_arc(
     return cw
 
 
-def bilinear(corners: npt.ArrayLike | None = None) -> Bspline:
+def create_bilinear(corners: npt.ArrayLike | None = None) -> Bspline:
     """Construct a bilinear B-spline surface from four corner points.
 
     Creates a degree (1, 1), non-rational B-spline surface with 2 x 2
@@ -271,7 +273,7 @@ def bilinear(corners: npt.ArrayLike | None = None) -> Bspline:
             with ``1 <= rank <= 3``.
 
     Example:
-        >>> srf = bilinear()
+        >>> srf = create_bilinear()
         >>> srf.degree
         (1, 1)
         >>> srf.dim
@@ -299,7 +301,7 @@ def bilinear(corners: npt.ArrayLike | None = None) -> Bspline:
     return Bspline(space, cp)
 
 
-def trilinear(corners: npt.ArrayLike | None = None) -> Bspline:
+def create_trilinear(corners: npt.ArrayLike | None = None) -> Bspline:
     """Construct a trilinear B-spline volume from eight corner points.
 
     Creates a degree (1, 1, 1), non-rational B-spline volume with
@@ -334,7 +336,7 @@ def trilinear(corners: npt.ArrayLike | None = None) -> Bspline:
             with ``1 <= rank <= 3``.
 
     Example:
-        >>> vol = trilinear()
+        >>> vol = create_trilinear()
         >>> vol.degree
         (1, 1, 1)
         >>> vol.dim

--- a/tests/test_cad_compat.py
+++ b/tests/test_cad_compat.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
-from pantr.cad import circle, compat, line
+from pantr.cad import create_circle, create_line, make_compat
 
 _KNOT_TOL = 1e-14
 
@@ -41,14 +41,14 @@ class TestCompatBasic:
     def test_single_input_returned_unchanged(self) -> None:
         """Test that a single B-spline is returned as-is."""
         crv = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
-        result = compat(crv)
+        result = make_compat(crv)
         assert len(result) == 1
         assert_allclose(result[0].control_points, crv.control_points)
 
     def test_identical_curves_unchanged(self) -> None:
         """Test that two identical curves come back with same structure."""
         crv = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
-        r1, _r2 = compat(crv, crv)
+        r1, _r2 = make_compat(crv, crv)
         assert r1.degree == crv.degree
         assert_allclose(r1.space.spaces[0].knots, crv.space.spaces[0].knots)
 
@@ -57,13 +57,13 @@ class TestCompatBasic:
         crv = _make_curve([0, 0, 1, 1], degree=1)
         srf = _make_surface([0, 0, 1, 1], 1, [0, 0, 1, 1], 1)
         with pytest.raises(ValueError, match="dimension"):
-            compat(crv, srf)
+            make_compat(crv, srf)
 
     def test_axis_out_of_range_raises(self) -> None:
         """Test that an out-of-range axis raises ValueError."""
         crv = _make_curve([0, 0, 1, 1], degree=1)
         with pytest.raises(ValueError, match="out of range"):
-            compat(crv, crv, axes=5)
+            make_compat(crv, crv, axes=5)
 
 
 class TestCompatDegreeElevation:
@@ -73,18 +73,18 @@ class TestCompatDegreeElevation:
         """Test curves with different degrees get elevated to max."""
         c1 = _make_curve([0, 0, 1, 1], degree=1)
         c2 = _make_curve([0, 0, 0, 1, 1, 1], degree=2)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         assert r1.degree == (2,)
         assert r2.degree == (2,)
 
     def test_geometric_invariance_after_elevation(self) -> None:
         """Test that degree elevation preserves the geometry."""
-        c1 = line([0, 0, 0], [1, 0, 0])
-        c2 = circle(angle=np.pi / 2)
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_circle(angle=np.pi / 2)
         t = np.linspace(0, 1, 20)
         pts_before_1 = c1.evaluate(t)
         pts_before_2 = c2.evaluate(t)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         pts_after_1 = r1.evaluate(t)
         pts_after_2 = r2.evaluate(t)
         assert_allclose(pts_after_1, pts_before_1, atol=1e-13)
@@ -98,7 +98,7 @@ class TestCompatDomainRemap:
         """Test curves with different domains get remapped."""
         c1 = _make_curve([0, 0, 1, 1], degree=1)
         c2 = _make_curve([2, 2, 3, 3], degree=1)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         assert_allclose(r1.space.spaces[0].domain, [0, 3])
         assert_allclose(r2.space.spaces[0].domain, [0, 3])
 
@@ -111,7 +111,7 @@ class TestCompatKnotMerge:
         # c1 has interior knot at 0.5; c2 has interior knot at 0.3
         c1 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
         c2 = _make_curve([0, 0, 0, 0.3, 1, 1, 1], degree=2)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         # Both should have interior knots at 0.3 and 0.5
         knots1 = r1.space.spaces[0].knots
         knots2 = r2.space.spaces[0].knots
@@ -127,7 +127,7 @@ class TestCompatKnotMerge:
         t = np.linspace(0, 1, 30)
         pts_before_1 = c1.evaluate(t)
         pts_before_2 = c2.evaluate(t)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         pts_after_1 = r1.evaluate(t)
         pts_after_2 = r2.evaluate(t)
         assert_allclose(pts_after_1, pts_before_1, atol=1e-12)
@@ -138,7 +138,7 @@ class TestCompatKnotMerge:
         # c1: knot at 0.5 with mult 1; c2: knot at 0.5 with mult 2
         c1 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
         c2 = _make_curve([0, 0, 0, 0.5, 0.5, 1, 1, 1], degree=2)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         knots1 = r1.space.spaces[0].knots
         knots2 = r2.space.spaces[0].knots
         assert_allclose(knots1, knots2)
@@ -154,7 +154,7 @@ class TestCompatSurface:
         """Test compat on a single axis of a 2D B-spline."""
         s1 = _make_surface([0, 0, 1, 1], 1, [0, 0, 0, 1, 1, 1], 2)
         s2 = _make_surface([0, 0, 0, 1, 1, 1], 2, [0, 0, 0, 1, 1, 1], 2)
-        r1, r2 = compat(s1, s2, axes=0)
+        r1, r2 = make_compat(s1, s2, axes=0)
         # Axis 0 should be elevated to degree 2
         assert r1.degree[0] == 2  # noqa: PLR2004
         assert r2.degree[0] == 2  # noqa: PLR2004
@@ -169,7 +169,7 @@ class TestCompatCombined:
         """Test compat with both different degrees and different knots."""
         c1 = _make_curve([0, 0, 1, 1], degree=1)
         c2 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2)
-        r1, r2 = compat(c1, c2)
+        r1, r2 = make_compat(c1, c2)
         assert r1.degree == r2.degree
         assert_allclose(r1.space.spaces[0].knots, r2.space.spaces[0].knots)
 
@@ -178,7 +178,7 @@ class TestCompatCombined:
         c1 = _make_curve([0, 0, 1, 1], degree=1, rank=3)
         c2 = _make_curve([0, 0, 0, 0.5, 1, 1, 1], degree=2, rank=3)
         c3 = _make_curve([0, 0, 0, 0, 0.3, 0.7, 1, 1, 1, 1], degree=3, rank=3)
-        r1, r2, r3 = compat(c1, c2, c3)
+        r1, r2, r3 = make_compat(c1, c2, c3)
         # All should have degree 3
         assert r1.degree == (3,)
         assert r2.degree == (3,)

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pantr.bspline import Bspline
-from pantr.cad import bilinear, coons_surface, coons_volume, line
+from pantr.cad import create_bilinear, create_coons_surface, create_coons_volume, create_line
 
 _RANK_3D = 3
 
@@ -15,14 +15,14 @@ _RANK_3D = 3
 class TestCoonsSurface:
     """Test the coons_surface function."""
 
-    def test_four_straight_lines_gives_bilinear(self) -> None:
+    def test_four_straight_lines_gives_create_bilinear(self) -> None:
         """Test Coons from 4 straight lines matches bilinear."""
-        c_u0 = line([0, 0, 0], [1, 0, 0])
-        c_u1 = line([0, 1, 0], [1, 1, 0])
-        c_v0 = line([0, 0, 0], [0, 1, 0])
-        c_v1 = line([1, 0, 0], [1, 1, 0])
+        c_u0 = create_line([0, 0, 0], [1, 0, 0])
+        c_u1 = create_line([0, 1, 0], [1, 1, 0])
+        c_v0 = create_line([0, 0, 0], [0, 1, 0])
+        c_v1 = create_line([1, 0, 0], [1, 1, 0])
 
-        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.rank == _RANK_3D
 
@@ -31,19 +31,19 @@ class TestCoonsSurface:
             [[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]],
             dtype=np.float64,
         )
-        ref = bilinear(corners)
+        ref = create_bilinear(corners)
         t = np.linspace(0, 1, 10)
         params = np.array([[u, v] for u in t for v in t])
         assert_allclose(srf.evaluate(params), ref.evaluate(params), atol=1e-13)
 
     def test_evaluate_corners(self) -> None:
         """Test that Coons surface evaluates correctly at corners."""
-        c_u0 = line([0, 0, 0], [3, 0, 0])
-        c_u1 = line([0, 2, 0], [3, 2, 0])
-        c_v0 = line([0, 0, 0], [0, 2, 0])
-        c_v1 = line([3, 0, 0], [3, 2, 0])
+        c_u0 = create_line([0, 0, 0], [3, 0, 0])
+        c_u1 = create_line([0, 2, 0], [3, 2, 0])
+        c_v0 = create_line([0, 0, 0], [0, 2, 0])
+        c_v1 = create_line([3, 0, 0], [3, 2, 0])
 
-        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
         pts = srf.evaluate(
             np.array(
                 [
@@ -61,32 +61,32 @@ class TestCoonsSurface:
 
     def test_non_planar_coons(self) -> None:
         """Test Coons with non-planar boundaries."""
-        c_u0 = line([0, 0, 0], [1, 0, 0])
-        c_u1 = line([0, 0, 1], [1, 0, 1])
-        c_v0 = line([0, 0, 0], [0, 0, 1])
-        c_v1 = line([1, 0, 0], [1, 0, 1])
+        c_u0 = create_line([0, 0, 0], [1, 0, 0])
+        c_u1 = create_line([0, 0, 1], [1, 0, 1])
+        c_v0 = create_line([0, 0, 0], [0, 0, 1])
+        c_v1 = create_line([1, 0, 0], [1, 0, 1])
 
-        srf = coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
         # Should be a flat rectangle in the xz plane
         pt = srf.evaluate(np.array([[0.5, 0.5]]))
         assert_allclose(pt, [0.5, 0, 0.5], atol=1e-13)
 
     def test_non_1d_curve_raises(self) -> None:
         """Test that a surface as input raises ValueError."""
-        srf = bilinear()
-        crv = line([0, 0, 0], [1, 0, 0])
+        srf = create_bilinear()
+        crv = create_line([0, 0, 0], [1, 0, 0])
         with pytest.raises(ValueError, match="1D"):
-            coons_surface(((crv, crv), (srf, crv)))
+            create_coons_surface(((crv, crv), (srf, crv)))
 
     def test_corner_mismatch_raises(self) -> None:
         """Test that inconsistent corners raise ValueError."""
-        c_u0 = line([0, 0, 0], [1, 0, 0])
-        c_u1 = line([0, 1, 0], [1, 1, 0])
-        c_v0 = line([0, 0, 0], [0, 1, 0])
-        c_v1 = line([2, 0, 0], [2, 1, 0])  # wrong: should start at (1,0,0)
+        c_u0 = create_line([0, 0, 0], [1, 0, 0])
+        c_u1 = create_line([0, 1, 0], [1, 1, 0])
+        c_v0 = create_line([0, 0, 0], [0, 1, 0])
+        c_v1 = create_line([2, 0, 0], [2, 1, 0])  # wrong: should start at (1,0,0)
 
         with pytest.raises(ValueError, match="mismatch"):
-            coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+            create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
 
 
 class TestCoonsVolume:
@@ -101,27 +101,27 @@ class TestCoonsVolume:
     ]:
         """Build 6 planar faces of the unit cube [0,1]^3."""
         # face_u0: u=0 plane, parameterized by (v, w)
-        face_u0 = bilinear(
+        face_u0 = create_bilinear(
             np.array([[[0, 0, 0], [0, 0, 1]], [[0, 1, 0], [0, 1, 1]]], dtype=np.float64)
         )
         # face_u1: u=1 plane
-        face_u1 = bilinear(
+        face_u1 = create_bilinear(
             np.array([[[1, 0, 0], [1, 0, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=np.float64)
         )
         # face_v0: v=0 plane, parameterized by (u, w)
-        face_v0 = bilinear(
+        face_v0 = create_bilinear(
             np.array([[[0, 0, 0], [0, 0, 1]], [[1, 0, 0], [1, 0, 1]]], dtype=np.float64)
         )
         # face_v1: v=1 plane
-        face_v1 = bilinear(
+        face_v1 = create_bilinear(
             np.array([[[0, 1, 0], [0, 1, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=np.float64)
         )
         # face_w0: w=0 plane, parameterized by (u, v)
-        face_w0 = bilinear(
+        face_w0 = create_bilinear(
             np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64)
         )
         # face_w1: w=1 plane
-        face_w1 = bilinear(
+        face_w1 = create_bilinear(
             np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=np.float64)
         )
         return (face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1)
@@ -129,21 +129,21 @@ class TestCoonsVolume:
     def test_cube_properties(self) -> None:
         """Test that Coons volume from cube faces has correct properties."""
         faces = self._make_cube_faces()
-        vol = coons_volume(faces)
+        vol = create_coons_volume(faces)
         assert vol.dim == _RANK_3D
         assert vol.rank == _RANK_3D
 
     def test_cube_evaluate_center(self) -> None:
         """Test evaluation at the center of the unit cube."""
         faces = self._make_cube_faces()
-        vol = coons_volume(faces)
+        vol = create_coons_volume(faces)
         pt = vol.evaluate(np.array([[0.5, 0.5, 0.5]]))
         assert_allclose(pt, [0.5, 0.5, 0.5], atol=1e-13)
 
     def test_cube_evaluate_corners(self) -> None:
         """Test evaluation at all 8 corners of the unit cube."""
         faces = self._make_cube_faces()
-        vol = coons_volume(faces)
+        vol = create_coons_volume(faces)
         for i in range(2):
             for j in range(2):
                 for k in range(2):
@@ -153,7 +153,7 @@ class TestCoonsVolume:
     def test_cube_boundaries_match_faces(self) -> None:
         """Test that volume boundaries match the input faces."""
         faces = self._make_cube_faces()
-        vol = coons_volume(faces)
+        vol = create_coons_volume(faces)
         # Evaluate on the u=0 face
         t = np.linspace(0, 1, 5)
         params_face_u0 = np.array([[0.0, v, w] for v in t for w in t])
@@ -166,7 +166,7 @@ class TestCoonsVolume:
 
     def test_non_2d_face_raises(self) -> None:
         """Test that a 1D input raises ValueError."""
-        crv = line([0, 0, 0], [1, 0, 0])
-        srf = bilinear()
+        crv = create_line([0, 0, 0], [1, 0, 0])
+        srf = create_bilinear()
         with pytest.raises(ValueError, match="2D"):
-            coons_volume(((crv, crv), (srf, srf), (srf, srf)))
+            create_coons_volume(((crv, crv), (srf, srf), (srf, srf)))

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -15,7 +15,7 @@ _RANK_3D = 3
 class TestCoonsSurface:
     """Test the coons_surface function."""
 
-    def test_four_straight_lines_gives_create_bilinear(self) -> None:
+    def test_four_straight_lines_gives_bilinear(self) -> None:
         """Test Coons from 4 straight lines matches bilinear."""
         c_u0 = create_line([0, 0, 0], [1, 0, 0])
         c_u1 = create_line([0, 1, 0], [1, 1, 0])

--- a/tests/test_cad_derived.py
+++ b/tests/test_cad_derived.py
@@ -13,7 +13,7 @@ _RANK_3D = 3
 class TestRectangle:
     """Test the rectangle primitive."""
 
-    def test_default_create_rectangle(self) -> None:
+    def test_default_rectangle(self) -> None:
         """Test default unit rectangle."""
         rect = create_rectangle()
         assert rect.dim == 1
@@ -29,7 +29,7 @@ class TestRectangle:
         pt_end = rect.evaluate(np.array([float(domain[1])]))
         assert_allclose(pt_start, pt_end, atol=1e-14)
 
-    def test_custom_create_rectangle(self) -> None:
+    def test_custom_rectangle(self) -> None:
         """Test rectangle with custom corner, width, height."""
         rect = create_rectangle(corner=[1, 2, 0], width=3, height=4)
         domain = rect.space.spaces[0].domain
@@ -57,7 +57,7 @@ class TestRectangle:
 class TestDisk:
     """Test the disk primitive."""
 
-    def test_full_create_disk(self) -> None:
+    def test_full_disk(self) -> None:
         """Test a full disk (inner radius = 0)."""
         d = create_disk(radius_outer=2.0)
         assert d.dim == 2  # noqa: PLR2004
@@ -113,7 +113,7 @@ class TestDisk:
 class TestCylinder:
     """Test the cylinder primitive."""
 
-    def test_default_create_cylinder(self) -> None:
+    def test_default_cylinder(self) -> None:
         """Test default cylinder."""
         cyl = create_cylinder()
         assert cyl.dim == 2  # noqa: PLR2004

--- a/tests/test_cad_derived.py
+++ b/tests/test_cad_derived.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 from numpy.testing import assert_allclose
 
-from pantr.cad import cylinder, disk, rectangle
+from pantr.cad import create_cylinder, create_disk, create_rectangle
 
 _RANK_3D = 3
 
@@ -13,9 +13,9 @@ _RANK_3D = 3
 class TestRectangle:
     """Test the rectangle primitive."""
 
-    def test_default_rectangle(self) -> None:
+    def test_default_create_rectangle(self) -> None:
         """Test default unit rectangle."""
-        rect = rectangle()
+        rect = create_rectangle()
         assert rect.dim == 1
         assert rect.rank == _RANK_3D
         assert rect.degree == (1,)
@@ -23,15 +23,15 @@ class TestRectangle:
 
     def test_closed_curve(self) -> None:
         """Test that the rectangle is a closed curve."""
-        rect = rectangle()
+        rect = create_rectangle()
         domain = rect.space.spaces[0].domain
         pt_start = rect.evaluate(np.array([float(domain[0])]))
         pt_end = rect.evaluate(np.array([float(domain[1])]))
         assert_allclose(pt_start, pt_end, atol=1e-14)
 
-    def test_custom_rectangle(self) -> None:
+    def test_custom_create_rectangle(self) -> None:
         """Test rectangle with custom corner, width, height."""
-        rect = rectangle(corner=[1, 2, 0], width=3, height=4)
+        rect = create_rectangle(corner=[1, 2, 0], width=3, height=4)
         domain = rect.space.spaces[0].domain
         t = np.linspace(float(domain[0]), float(domain[1]), 5)
         pts = rect.evaluate(t)
@@ -43,7 +43,7 @@ class TestRectangle:
 
     def test_rectangle_four_sides(self) -> None:
         """Test that the rectangle visits all four corners."""
-        rect = rectangle(corner=[0, 0, 0], width=2, height=3)
+        rect = create_rectangle(corner=[0, 0, 0], width=2, height=3)
         domain = rect.space.spaces[0].domain
         t = np.linspace(float(domain[0]), float(domain[1]), 5)
         pts = rect.evaluate(t)
@@ -57,21 +57,21 @@ class TestRectangle:
 class TestDisk:
     """Test the disk primitive."""
 
-    def test_full_disk(self) -> None:
+    def test_full_create_disk(self) -> None:
         """Test a full disk (inner radius = 0)."""
-        d = disk(radius_outer=2.0)
+        d = create_disk(radius_outer=2.0)
         assert d.dim == 2  # noqa: PLR2004
         assert d.is_rational
 
     def test_annulus(self) -> None:
         """Test an annular sector."""
-        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        ann = create_disk(radius_inner=1.0, radius_outer=2.0)
         assert ann.dim == 2  # noqa: PLR2004
         assert ann.is_rational
 
     def test_disk_points_within_radius(self) -> None:
         """Test that disk points lie within the outer radius."""
-        d = disk(radius_outer=3.0)
+        d = create_disk(radius_outer=3.0)
         u = np.linspace(0, 1, 15)
         v = np.linspace(0, 1, 5)
         params = np.array([[ui, vi] for ui in u for vi in v])
@@ -81,7 +81,7 @@ class TestDisk:
 
     def test_annulus_inner_boundary(self) -> None:
         """Test that annulus inner boundary has correct radius."""
-        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        ann = create_disk(radius_inner=1.0, radius_outer=2.0)
         u = np.linspace(0, 1, 20)
         params_inner = np.column_stack([u, np.zeros_like(u)])
         pts = ann.evaluate(params_inner)
@@ -90,7 +90,7 @@ class TestDisk:
 
     def test_annulus_outer_boundary(self) -> None:
         """Test that annulus outer boundary has correct radius."""
-        ann = disk(radius_inner=1.0, radius_outer=2.0)
+        ann = create_disk(radius_inner=1.0, radius_outer=2.0)
         u = np.linspace(0, 1, 20)
         params_outer = np.column_stack([u, np.ones_like(u)])
         pts = ann.evaluate(params_outer)
@@ -99,30 +99,30 @@ class TestDisk:
 
     def test_disk_with_center(self) -> None:
         """Test disk with offset center."""
-        d = disk(radius_outer=1.0, center=[5, 0, 0])
+        d = create_disk(radius_outer=1.0, center=[5, 0, 0])
         pt = d.evaluate(np.array([[0.0, 1.0]]))
         # At v=1 (outer), u=0: should be at (6, 0, 0)
         assert_allclose(pt, [6, 0, 0], atol=1e-13)
 
     def test_disk_with_angle(self) -> None:
         """Test partial disk (sector)."""
-        d = disk(radius_outer=1.0, angle=np.pi / 2)
+        d = create_disk(radius_outer=1.0, angle=np.pi / 2)
         assert d.dim == 2  # noqa: PLR2004
 
 
 class TestCylinder:
     """Test the cylinder primitive."""
 
-    def test_default_cylinder(self) -> None:
+    def test_default_create_cylinder(self) -> None:
         """Test default cylinder."""
-        cyl = cylinder()
+        cyl = create_cylinder()
         assert cyl.dim == 2  # noqa: PLR2004
         assert cyl.is_rational
 
     def test_cylinder_radius(self) -> None:
         """Test that cylinder points lie on the correct radius."""
         r = 2.5
-        cyl = cylinder(radius=r, height=3.0)
+        cyl = create_cylinder(radius=r, height=3.0)
         u = np.linspace(0, 1, 20)
         v = np.array([0.0, 0.5, 1.0])
         params = np.array([[ui, vi] for ui in u for vi in v])
@@ -132,7 +132,7 @@ class TestCylinder:
 
     def test_cylinder_height(self) -> None:
         """Test that cylinder z-range matches height."""
-        cyl = cylinder(radius=1.0, height=7.0)
+        cyl = create_cylinder(radius=1.0, height=7.0)
         # At v=0, z should be 0; at v=1, z should be 7
         pt_bottom = cyl.evaluate(np.array([[0.0, 0.0]]))
         pt_top = cyl.evaluate(np.array([[0.0, 1.0]]))
@@ -141,11 +141,11 @@ class TestCylinder:
 
     def test_cylinder_with_center(self) -> None:
         """Test cylinder with offset center."""
-        cyl = cylinder(radius=1.0, height=1.0, center=[3, 0, 0])
+        cyl = create_cylinder(radius=1.0, height=1.0, center=[3, 0, 0])
         pt = cyl.evaluate(np.array([[0.0, 0.0]]))
         assert_allclose(pt, [4, 0, 0], atol=1e-14)
 
     def test_cylinder_partial_angle(self) -> None:
         """Test partial cylinder (angular sector)."""
-        cyl = cylinder(radius=1.0, height=1.0, angle=np.pi / 2)
+        cyl = create_cylinder(radius=1.0, height=1.0, angle=np.pi / 2)
         assert cyl.dim == 2  # noqa: PLR2004

--- a/tests/test_cad_join.py
+++ b/tests/test_cad_join.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pantr.cad import bilinear, join, line
+from pantr.cad import create_bilinear, create_line, join
 
 
 class TestJoinCurves:
@@ -14,8 +14,8 @@ class TestJoinCurves:
 
     def test_join_two_line_segments(self) -> None:
         """Test joining two collinear line segments."""
-        c1 = line([0, 0, 0], [1, 0, 0])
-        c2 = line([1, 0, 0], [2, 0, 0])
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([1, 0, 0], [2, 0, 0])
         result = join(c1, c2, axis=0)
         assert result.dim == 1
         # Evaluate over the full domain
@@ -29,8 +29,8 @@ class TestJoinCurves:
 
     def test_join_preserves_geometry(self) -> None:
         """Test that join preserves the geometry of both segments."""
-        c1 = line([0, 0, 0], [1, 1, 0])
-        c2 = line([1, 1, 0], [3, 0, 0])
+        c1 = create_line([0, 0, 0], [1, 1, 0])
+        c2 = create_line([1, 1, 0], [3, 0, 0])
         result = join(c1, c2, axis=0)
         domain = result.space.spaces[0].domain
         pt_start = result.evaluate(np.array([float(domain[0])]))
@@ -40,8 +40,8 @@ class TestJoinCurves:
 
     def test_join_c0_at_junction(self) -> None:
         """Test C0 continuity at the junction point."""
-        c1 = line([0, 0, 0], [1, 0, 0])
-        c2 = line([1, 0, 0], [1, 1, 0])
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([1, 0, 0], [1, 1, 0])
         result = join(c1, c2, axis=0)
         # The junction should be at parameter u=1 (end of c1's domain)
         pt = result.evaluate(np.array([1.0]))
@@ -53,8 +53,10 @@ class TestJoinSurfaces:
 
     def test_join_two_bilinear_patches(self) -> None:
         """Test joining two bilinear patches along axis 0."""
-        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
-        s2 = bilinear(np.array([[[1, 0, 0], [1, 1, 0]], [[2, 0, 0], [2, 1, 0]]], dtype=np.float64))
+        corners1 = np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64)
+        corners2 = np.array([[[1, 0, 0], [1, 1, 0]], [[2, 0, 0], [2, 1, 0]]], dtype=np.float64)
+        s1 = create_bilinear(corners1)
+        s2 = create_bilinear(corners2)
         result = join(s1, s2, axis=0)
         assert result.dim == 2  # noqa: PLR2004
         domain_u = result.space.spaces[0].domain
@@ -76,8 +78,10 @@ class TestJoinSurfaces:
 
     def test_join_along_axis_1(self) -> None:
         """Test joining two patches along the second axis."""
-        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
-        s2 = bilinear(np.array([[[0, 1, 0], [0, 2, 0]], [[1, 1, 0], [1, 2, 0]]], dtype=np.float64))
+        corners1 = np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64)
+        corners2 = np.array([[[0, 1, 0], [0, 2, 0]], [[1, 1, 0], [1, 2, 0]]], dtype=np.float64)
+        s1 = create_bilinear(corners1)
+        s2 = create_bilinear(corners2)
         result = join(s1, s2, axis=1)
         domain_v = result.space.spaces[1].domain
         v_end = float(domain_v[1])
@@ -90,14 +94,14 @@ class TestJoinErrors:
 
     def test_different_dim_raises(self) -> None:
         """Test that different dimensions raises ValueError."""
-        crv = line([0, 0, 0], [1, 0, 0])
-        srf = bilinear()
+        crv = create_line([0, 0, 0], [1, 0, 0])
+        srf = create_bilinear()
         with pytest.raises(ValueError, match="same dim"):
             join(crv, srf, axis=0)
 
     def test_axis_out_of_range_raises(self) -> None:
         """Test that out-of-range axis raises ValueError."""
-        c1 = line([0, 0, 0], [1, 0, 0])
-        c2 = line([1, 0, 0], [2, 0, 0])
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([1, 0, 0], [2, 0, 0])
         with pytest.raises(ValueError, match="axis"):
             join(c1, c2, axis=1)

--- a/tests/test_cad_operations.py
+++ b/tests/test_cad_operations.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pantr.cad import bilinear, circle, extrude, line, ruled
+from pantr.cad import create_bilinear, create_circle, create_line, create_ruled, extrude
 
 _RANK_3D = 3
 
@@ -16,7 +16,7 @@ class TestExtrude:
 
     def test_line_to_surface(self) -> None:
         """Test extruding a line into a surface."""
-        crv = line([0, 0, 0], [1, 0, 0])
+        crv = create_line([0, 0, 0], [1, 0, 0])
         srf = extrude(crv, [0, 0, 1])
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.rank == _RANK_3D
@@ -24,13 +24,13 @@ class TestExtrude:
 
     def test_extrude_degree(self) -> None:
         """Test that the new direction has degree 1."""
-        crv = line([0, 0, 0], [1, 0, 0])
+        crv = create_line([0, 0, 0], [1, 0, 0])
         srf = extrude(crv, [0, 1, 0])
         assert srf.degree == (1, 1)
 
     def test_extrude_evaluate_corners(self) -> None:
         """Test evaluation at the four corners of an extruded line."""
-        crv = line([0, 0, 0], [2, 0, 0])
+        crv = create_line([0, 0, 0], [2, 0, 0])
         srf = extrude(crv, [0, 3, 0])
         pts = srf.evaluate(
             np.array(
@@ -49,7 +49,7 @@ class TestExtrude:
 
     def test_extrude_circle_to_cylinder(self) -> None:
         """Test extruding a circle produces a cylinder."""
-        crv = circle(radius=2.0)
+        crv = create_circle(radius=2.0)
         cyl = extrude(crv, [0, 0, 5])
         assert cyl.dim == 2  # noqa: PLR2004
         assert cyl.is_rational
@@ -66,20 +66,20 @@ class TestExtrude:
 
     def test_extrude_surface_to_volume(self) -> None:
         """Test extruding a surface into a volume."""
-        srf = bilinear()
+        srf = create_bilinear()
         vol = extrude(srf, [0, 0, 1])
         assert vol.dim == _RANK_3D
         assert vol.degree == (1, 1, 1)
 
     def test_extrude_volume_raises(self) -> None:
         """Test that extruding a volume raises ValueError."""
-        vol = extrude(bilinear(), [0, 0, 1])
+        vol = extrude(create_bilinear(), [0, 0, 1])
         with pytest.raises(ValueError, match="dim"):
             extrude(vol, [0, 0, 1])
 
     def test_extrude_2d_displacement(self) -> None:
         """Test that 2D displacement is zero-padded to 3D."""
-        crv = line([0, 0, 0], [1, 0, 0])
+        crv = create_line([0, 0, 0], [1, 0, 0])
         srf = extrude(crv, [0, 1])
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         assert_allclose(pt, [0.5, 1.0, 0.0], atol=1e-14)
@@ -90,18 +90,18 @@ class TestRuled:
 
     def test_ruled_two_lines(self) -> None:
         """Test ruled surface between two parallel lines."""
-        c1 = line([0, 0, 0], [1, 0, 0])
-        c2 = line([0, 1, 0], [1, 1, 0])
-        srf = ruled(c1, c2)
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([0, 1, 0], [1, 1, 0])
+        srf = create_ruled(c1, c2)
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.degree == (1, 1)
         assert not srf.is_rational
 
     def test_ruled_evaluate_corners(self) -> None:
         """Test evaluation at the four parametric corners."""
-        c1 = line([0, 0, 0], [3, 0, 0])
-        c2 = line([0, 2, 0], [3, 2, 0])
-        srf = ruled(c1, c2)
+        c1 = create_line([0, 0, 0], [3, 0, 0])
+        c2 = create_line([0, 2, 0], [3, 2, 0])
+        srf = create_ruled(c1, c2)
         pts = srf.evaluate(
             np.array(
                 [
@@ -119,9 +119,9 @@ class TestRuled:
 
     def test_ruled_annulus(self) -> None:
         """Test ruled surface between two circles forms an annulus."""
-        inner = circle(radius=1.0)
-        outer = circle(radius=2.0)
-        annulus = ruled(inner, outer)
+        inner = create_circle(radius=1.0)
+        outer = create_circle(radius=2.0)
+        annulus = create_ruled(inner, outer)
         assert annulus.dim == 2  # noqa: PLR2004
         assert annulus.is_rational
         # Evaluate and check radii
@@ -137,31 +137,33 @@ class TestRuled:
 
     def test_ruled_different_degrees(self) -> None:
         """Test that ruled makes inputs compatible (different degrees)."""
-        c1 = line([0, 0, 0], [1, 0, 0])  # degree 1
-        c2 = circle(angle=np.pi / 2)  # degree 2
-        srf = ruled(c1, c2)
+        c1 = create_line([0, 0, 0], [1, 0, 0])  # degree 1
+        c2 = create_circle(angle=np.pi / 2)  # degree 2
+        srf = create_ruled(c1, c2)
         # Both should have been elevated to degree 2
         assert srf.degree[0] == 2  # noqa: PLR2004
 
     def test_ruled_mixed_rational(self) -> None:
         """Test that mixing rational and non-rational promotes correctly."""
-        c1 = line([1, 0, 0], [2, 0, 0])  # non-rational
-        c2 = circle(radius=1.5, angle=np.pi / 4)  # rational
-        srf = ruled(c1, c2)
+        c1 = create_line([1, 0, 0], [2, 0, 0])  # non-rational
+        c2 = create_circle(radius=1.5, angle=np.pi / 4)  # rational
+        srf = create_ruled(c1, c2)
         assert srf.is_rational
 
     def test_ruled_different_dim_raises(self) -> None:
         """Test that different dimensions raises ValueError."""
-        crv = line([0, 0, 0], [1, 0, 0])
-        srf = bilinear()
+        crv = create_line([0, 0, 0], [1, 0, 0])
+        srf = create_bilinear()
         with pytest.raises(ValueError, match="same dim"):
-            ruled(crv, srf)
+            create_ruled(crv, srf)
 
     def test_ruled_volume_from_surfaces(self) -> None:
         """Test ruled volume between two surfaces."""
-        s1 = bilinear(np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64))
-        s2 = bilinear(np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=np.float64))
-        vol = ruled(s1, s2)
+        corners1 = np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=np.float64)
+        corners2 = np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=np.float64)
+        s1 = create_bilinear(corners1)
+        s2 = create_bilinear(corners2)
+        vol = create_ruled(s1, s2)
         assert vol.dim == _RANK_3D
         assert vol.degree == (1, 1, 1)
         # Center should be at (0.5, 0.5, 0.5)

--- a/tests/test_cad_primitives.py
+++ b/tests/test_cad_primitives.py
@@ -1,4 +1,4 @@
-"""Tests for CAD primitive functions: line, circle, bilinear, trilinear."""
+"""Tests for CAD primitive functions."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pantr.cad import bilinear, circle, line, trilinear
+from pantr.cad import create_bilinear, create_circle, create_line, create_trilinear
 
 _RANK_3D = 3
 
@@ -14,9 +14,9 @@ _RANK_3D = 3
 class TestLine:
     """Test the line primitive."""
 
-    def test_default_line(self) -> None:
+    def test_default_create_line(self) -> None:
         """Test default line from origin to (1, 0, 0)."""
-        crv = line()
+        crv = create_line()
         assert crv.dim == 1
         assert crv.degree == (1,)
         assert crv.rank == _RANK_3D
@@ -26,53 +26,53 @@ class TestLine:
 
     def test_custom_3d_endpoints(self) -> None:
         """Test line with explicit 3D endpoints."""
-        crv = line([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+        crv = create_line([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
         assert_allclose(crv.control_points[0], [1.0, 2.0, 3.0])
         assert_allclose(crv.control_points[1], [4.0, 5.0, 6.0])
 
     def test_2d_endpoints_zero_padded(self) -> None:
         """Test that 2D endpoints are zero-padded to 3D."""
-        crv = line([0, 0], [1, 1])
+        crv = create_line([0, 0], [1, 1])
         assert crv.rank == _RANK_3D
         assert_allclose(crv.control_points[0], [0.0, 0.0, 0.0])
         assert_allclose(crv.control_points[1], [1.0, 1.0, 0.0])
 
     def test_1d_endpoints(self) -> None:
         """Test that 1D endpoints are zero-padded to 3D."""
-        crv = line([0], [5])
+        crv = create_line([0], [5])
         assert_allclose(crv.control_points[0], [0.0, 0.0, 0.0])
         assert_allclose(crv.control_points[1], [5.0, 0.0, 0.0])
 
     def test_evaluate_midpoint(self) -> None:
         """Test that midpoint evaluates to the average of endpoints."""
-        crv = line([0, 0, 0], [2, 4, 6])
+        crv = create_line([0, 0, 0], [2, 4, 6])
         mid = crv.evaluate(np.array([0.5]))
         assert_allclose(mid, [1.0, 2.0, 3.0])
 
     def test_evaluate_endpoints(self) -> None:
         """Test evaluation at parameter boundaries."""
-        crv = line([1, 2, 3], [4, 5, 6])
+        crv = create_line([1, 2, 3], [4, 5, 6])
         pts = crv.evaluate(np.array([0.0, 1.0]))
         assert_allclose(pts[0], [1.0, 2.0, 3.0])
         assert_allclose(pts[1], [4.0, 5.0, 6.0])
 
     def test_knot_vector(self) -> None:
         """Test that the knot vector is [0, 0, 1, 1]."""
-        crv = line()
+        crv = create_line()
         assert_allclose(crv.space.spaces[0].knots, [0.0, 0.0, 1.0, 1.0])
 
     def test_point_too_long_raises(self) -> None:
         """Test that a point with more than 3 coordinates raises."""
         with pytest.raises(ValueError, match="at most 3"):
-            line([1, 2, 3, 4], [0, 0, 0])
+            create_line([1, 2, 3, 4], [0, 0, 0])
 
 
 class TestBilinear:
     """Test the bilinear surface primitive."""
 
-    def test_default_bilinear(self) -> None:
+    def test_default_create_bilinear(self) -> None:
         """Test default unit square surface."""
-        srf = bilinear()
+        srf = create_bilinear()
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.degree == (1, 1)
         assert srf.rank == _RANK_3D
@@ -80,7 +80,7 @@ class TestBilinear:
 
     def test_default_corners(self) -> None:
         """Test that the default corners form a unit square in XY."""
-        srf = bilinear()
+        srf = create_bilinear()
         cp = srf.control_points
         assert_allclose(cp[0, 0], [-0.5, -0.5, 0.0])
         assert_allclose(cp[1, 0], [+0.5, -0.5, 0.0])
@@ -96,7 +96,7 @@ class TestBilinear:
             ],
             dtype=np.float64,
         )
-        srf = bilinear(corners)
+        srf = create_bilinear(corners)
         assert_allclose(srf.control_points[1, 1], [1.0, 1.0, 1.0])
 
     def test_2d_corners_padded(self) -> None:
@@ -108,13 +108,13 @@ class TestBilinear:
             ],
             dtype=np.float64,
         )
-        srf = bilinear(corners)
+        srf = create_bilinear(corners)
         assert srf.rank == _RANK_3D
         assert_allclose(srf.control_points[1, 1], [1.0, 1.0, 0.0])
 
     def test_evaluate_center(self) -> None:
         """Test evaluation at the center of the default patch."""
-        srf = bilinear()
+        srf = create_bilinear()
         pts = srf.evaluate(np.array([[0.5, 0.5]]))
         assert_allclose(pts, [0.0, 0.0, 0.0], atol=1e-15)
 
@@ -127,7 +127,7 @@ class TestBilinear:
             ],
             dtype=np.float64,
         )
-        srf = bilinear(corners)
+        srf = create_bilinear(corners)
         pts = srf.evaluate(
             np.array(
                 [
@@ -146,16 +146,16 @@ class TestBilinear:
     def test_wrong_shape_raises(self) -> None:
         """Test that corners with wrong shape raises ValueError."""
         with pytest.raises(ValueError, match="shape"):
-            bilinear(np.ones((3, 2, 3)))
+            create_bilinear(np.ones((3, 2, 3)))
 
     def test_rank_too_large_raises(self) -> None:
         """Test that corners with rank > 3 raises ValueError."""
         with pytest.raises(ValueError, match="rank"):
-            bilinear(np.ones((2, 2, 4)))
+            create_bilinear(np.ones((2, 2, 4)))
 
     def test_knot_vectors(self) -> None:
         """Test that knot vectors are [0, 0, 1, 1] in each direction."""
-        srf = bilinear()
+        srf = create_bilinear()
         for sp in srf.space.spaces:
             assert_allclose(sp.knots, [0.0, 0.0, 1.0, 1.0])
 
@@ -163,9 +163,9 @@ class TestBilinear:
 class TestTrilinear:
     """Test the trilinear volume primitive."""
 
-    def test_default_trilinear(self) -> None:
+    def test_default_create_trilinear(self) -> None:
         """Test default unit cube volume."""
-        vol = trilinear()
+        vol = create_trilinear()
         assert vol.dim == _RANK_3D
         assert vol.degree == (1, 1, 1)
         assert vol.rank == _RANK_3D
@@ -173,7 +173,7 @@ class TestTrilinear:
 
     def test_default_corners(self) -> None:
         """Test that the default corners form a unit cube."""
-        vol = trilinear()
+        vol = create_trilinear()
         cp = vol.control_points
         assert_allclose(cp[0, 0, 0], [-0.5, -0.5, -0.5])
         assert_allclose(cp[1, 1, 1], [+0.5, +0.5, +0.5])
@@ -187,13 +187,13 @@ class TestTrilinear:
             for j in range(2):
                 for k in range(2):
                     corners[i, j, k] = [i, j, k]
-        vol = trilinear(corners)
+        vol = create_trilinear(corners)
         assert_allclose(vol.control_points[0, 0, 0], [0.0, 0.0, 0.0])
         assert_allclose(vol.control_points[1, 1, 1], [1.0, 1.0, 1.0])
 
     def test_evaluate_center(self) -> None:
         """Test evaluation at the center of the default cube."""
-        vol = trilinear()
+        vol = create_trilinear()
         pts = vol.evaluate(np.array([[0.5, 0.5, 0.5]]))
         assert_allclose(pts, [0.0, 0.0, 0.0], atol=1e-15)
 
@@ -204,7 +204,7 @@ class TestTrilinear:
             for j in range(2):
                 for k in range(2):
                     corners[i, j, k] = [float(i), float(j), float(k)]
-        vol = trilinear(corners)
+        vol = create_trilinear(corners)
         pts = vol.evaluate(
             np.array(
                 [
@@ -225,23 +225,23 @@ class TestTrilinear:
     def test_2d_corners_padded(self) -> None:
         """Test that 2D corners are zero-padded to 3D."""
         corners = np.ones((2, 2, 2, 2), dtype=np.float64)
-        vol = trilinear(corners)
+        vol = create_trilinear(corners)
         assert vol.rank == _RANK_3D
         assert_allclose(vol.control_points[0, 0, 0, 2], 0.0)
 
     def test_wrong_shape_raises(self) -> None:
         """Test that corners with wrong shape raises ValueError."""
         with pytest.raises(ValueError, match="shape"):
-            trilinear(np.ones((2, 2, 3, 3)))
+            create_trilinear(np.ones((2, 2, 3, 3)))
 
     def test_rank_too_large_raises(self) -> None:
         """Test that corners with rank > 3 raises ValueError."""
         with pytest.raises(ValueError, match="rank"):
-            trilinear(np.ones((2, 2, 2, 4)))
+            create_trilinear(np.ones((2, 2, 2, 4)))
 
     def test_knot_vectors(self) -> None:
         """Test that knot vectors are [0, 0, 1, 1] in each direction."""
-        vol = trilinear()
+        vol = create_trilinear()
         for sp in vol.space.spaces:
             assert_allclose(sp.knots, [0.0, 0.0, 1.0, 1.0])
 
@@ -251,7 +251,7 @@ class TestCircle:
 
     def test_full_circle_properties(self) -> None:
         """Test that the default full circle has the expected structure."""
-        crv = circle()
+        crv = create_circle()
         assert crv.dim == 1
         assert crv.degree == (_RANK_3D - 1,)  # degree 2
         assert crv.rank == _RANK_3D
@@ -259,12 +259,12 @@ class TestCircle:
 
     def test_full_circle_control_point_count(self) -> None:
         """Test full circle has 9 control points (4 spans)."""
-        crv = circle()
+        crv = create_circle()
         assert crv.control_points.shape[0] == 9  # noqa: PLR2004
 
     def test_full_circle_knot_structure(self) -> None:
         """Test full circle knot vector: 4 spans, double interior knots."""
-        crv = circle()
+        crv = create_circle()
         sp = crv.space.spaces[0]
         knots = sp.knots
         # [0,0,0, 0.25,0.25, 0.5,0.5, 0.75,0.75, 1,1,1]
@@ -273,7 +273,7 @@ class TestCircle:
 
     def test_full_circle_evaluate_cardinal_points(self) -> None:
         """Test full circle evaluates to correct cardinal points."""
-        crv = circle()
+        crv = create_circle()
         pts = crv.evaluate(np.array([0.0, 0.25, 0.5, 0.75, 1.0]))
         assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
         assert_allclose(pts[1], [0, 1, 0], atol=1e-14)
@@ -281,9 +281,9 @@ class TestCircle:
         assert_allclose(pts[3], [0, -1, 0], atol=1e-14)
         assert_allclose(pts[4], [1, 0, 0], atol=1e-14)
 
-    def test_full_circle_points_on_circle(self) -> None:
+    def test_full_circle_points_on_create_circle(self) -> None:
         """Test that evaluated points lie on the unit circle."""
-        crv = circle()
+        crv = create_circle()
         t = np.linspace(0, 1, 50)
         pts = crv.evaluate(t)
         radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
@@ -293,7 +293,7 @@ class TestCircle:
     def test_radius(self) -> None:
         """Test circle with custom radius."""
         r = 3.5
-        crv = circle(radius=r)
+        crv = create_circle(radius=r)
         t = np.linspace(0, 1, 30)
         pts = crv.evaluate(t)
         radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
@@ -301,33 +301,33 @@ class TestCircle:
 
     def test_quarter_arc_structure(self) -> None:
         """Test arc <= 90 deg has 1 span, 3 control points, no interior knots."""
-        crv = circle(angle=np.pi / 2)
+        crv = create_circle(angle=np.pi / 2)
         assert crv.control_points.shape[0] == _RANK_3D  # 3 control points
         expected_knots = np.array([0, 0, 0, 1, 1, 1], dtype=np.float64)
         assert_allclose(crv.space.spaces[0].knots, expected_knots)
 
     def test_quarter_arc_endpoints(self) -> None:
         """Test quarter arc from 0 to pi/2."""
-        crv = circle(angle=np.pi / 2)
+        crv = create_circle(angle=np.pi / 2)
         pts = crv.evaluate(np.array([0.0, 1.0]))
         assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
         assert_allclose(pts[1], [0, 1, 0], atol=1e-14)
 
     def test_half_circle_structure(self) -> None:
         """Test arc <= 180 deg has 2 spans, 5 control points, 1 double knot."""
-        crv = circle(angle=np.pi)
+        crv = create_circle(angle=np.pi)
         assert crv.control_points.shape[0] == 5  # noqa: PLR2004
         expected_knots = np.array([0, 0, 0, 0.5, 0.5, 1, 1, 1])
         assert_allclose(crv.space.spaces[0].knots, expected_knots)
 
     def test_three_quarter_arc_structure(self) -> None:
         """Test arc <= 270 deg has 3 spans, 7 control points, 2 double knots."""
-        crv = circle(angle=3 * np.pi / 2)
+        crv = create_circle(angle=3 * np.pi / 2)
         assert crv.control_points.shape[0] == 7  # noqa: PLR2004
 
-    def test_arc_points_on_circle(self) -> None:
+    def test_arc_points_on_create_circle(self) -> None:
         """Test that arc points lie on the circle."""
-        crv = circle(radius=2.0, angle=np.pi)
+        crv = create_circle(radius=2.0, angle=np.pi)
         t = np.linspace(0, 1, 30)
         pts = crv.evaluate(t)
         radii = np.sqrt(pts[:, 0] ** 2 + pts[:, 1] ** 2)
@@ -335,7 +335,7 @@ class TestCircle:
 
     def test_angle_tuple(self) -> None:
         """Test arc with (start, end) angle tuple."""
-        crv = circle(radius=2, angle=(np.pi / 2, -np.pi / 2))
+        crv = create_circle(radius=2, angle=(np.pi / 2, -np.pi / 2))
         pts = crv.evaluate(np.array([0.0, 0.5, 1.0]))
         assert_allclose(pts[0], [0, 2, 0], atol=1e-14)
         assert_allclose(pts[1], [2, 0, 0], atol=1e-14)
@@ -343,20 +343,20 @@ class TestCircle:
 
     def test_center_translation(self) -> None:
         """Test that center translates the circle."""
-        crv = circle(radius=1, center=(1, 2, 0))
+        crv = create_circle(radius=1, center=(1, 2, 0))
         pt = crv.evaluate(np.array([0.0]))
         assert_allclose(pt, [2, 2, 0], atol=1e-14)
 
     def test_center_2d(self) -> None:
         """Test center with 2D coordinates (zero-padded to 3D)."""
-        crv = circle(radius=3, center=2, angle=np.pi / 2)
+        crv = create_circle(radius=3, center=2, angle=np.pi / 2)
         pts = crv.evaluate(np.array([0.0, 1.0]))
         assert_allclose(pts[0], [5, 0, 0], atol=1e-14)
         assert_allclose(pts[1], [2, 3, 0], atol=1e-14)
 
     def test_negative_sweep(self) -> None:
         """Test arc with negative sweep (clockwise)."""
-        crv = circle(angle=-np.pi / 2)
+        crv = create_circle(angle=-np.pi / 2)
         pts = crv.evaluate(np.array([0.0, 1.0]))
         assert_allclose(pts[0], [1, 0, 0], atol=1e-14)
         assert_allclose(pts[1], [0, -1, 0], atol=1e-14)

--- a/tests/test_cad_primitives.py
+++ b/tests/test_cad_primitives.py
@@ -14,7 +14,7 @@ _RANK_3D = 3
 class TestLine:
     """Test the line primitive."""
 
-    def test_default_create_line(self) -> None:
+    def test_default_line(self) -> None:
         """Test default line from origin to (1, 0, 0)."""
         crv = create_line()
         assert crv.dim == 1
@@ -70,7 +70,7 @@ class TestLine:
 class TestBilinear:
     """Test the bilinear surface primitive."""
 
-    def test_default_create_bilinear(self) -> None:
+    def test_default_bilinear(self) -> None:
         """Test default unit square surface."""
         srf = create_bilinear()
         assert srf.dim == 2  # noqa: PLR2004
@@ -163,7 +163,7 @@ class TestBilinear:
 class TestTrilinear:
     """Test the trilinear volume primitive."""
 
-    def test_default_create_trilinear(self) -> None:
+    def test_default_trilinear(self) -> None:
         """Test default unit cube volume."""
         vol = create_trilinear()
         assert vol.dim == _RANK_3D
@@ -281,7 +281,7 @@ class TestCircle:
         assert_allclose(pts[3], [0, -1, 0], atol=1e-14)
         assert_allclose(pts[4], [1, 0, 0], atol=1e-14)
 
-    def test_full_circle_points_on_create_circle(self) -> None:
+    def test_full_circle_points_on_circle(self) -> None:
         """Test that evaluated points lie on the unit circle."""
         crv = create_circle()
         t = np.linspace(0, 1, 50)
@@ -325,7 +325,7 @@ class TestCircle:
         crv = create_circle(angle=3 * np.pi / 2)
         assert crv.control_points.shape[0] == 7  # noqa: PLR2004
 
-    def test_arc_points_on_create_circle(self) -> None:
+    def test_arc_points_on_circle(self) -> None:
         """Test that arc points lie on the circle."""
         crv = create_circle(radius=2.0, angle=np.pi)
         t = np.linspace(0, 1, 30)

--- a/tests/test_cad_revolve_sweep.py
+++ b/tests/test_cad_revolve_sweep.py
@@ -106,7 +106,7 @@ class TestRevolve:
 class TestSweep:
     """Test the translational sweep operation."""
 
-    def test_sweep_line_along_create_line(self) -> None:
+    def test_sweep_line_along_line(self) -> None:
         """Test sweeping a line along a line produces a bilinear surface."""
         section = create_line([0, 0, 0], [1, 0, 0])
         trajectory = create_line([0, 0, 0], [0, 1, 0])

--- a/tests/test_cad_revolve_sweep.py
+++ b/tests/test_cad_revolve_sweep.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
-from pantr.cad import bilinear, circle, extrude, line, revolve, sweep
+from pantr.cad import create_bilinear, create_circle, create_line, extrude, revolve, sweep
 
 _RANK_3D = 3
 
@@ -17,14 +17,14 @@ class TestRevolve:
 
     def test_line_to_annulus(self) -> None:
         """Test revolving a radial line produces a full annulus."""
-        crv = line([1, 0, 0], [2, 0, 0])
+        crv = create_line([1, 0, 0], [2, 0, 0])
         srf = revolve(crv, point=0, axis=2)
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.is_rational
 
     def test_revolve_points_on_cylinder(self) -> None:
         """Test revolving a vertical line around Z produces a cylinder."""
-        crv = line([1, 0, 0], [1, 0, 3])
+        crv = create_line([1, 0, 0], [1, 0, 3])
         srf = revolve(crv, point=0, axis=2)
         # Evaluate on a grid
         u = np.linspace(0, 1, 10)
@@ -36,7 +36,7 @@ class TestRevolve:
 
     def test_revolve_quarter_turn(self) -> None:
         """Test revolving a line by pi/2 around Z."""
-        crv = line([1, 0, 0], [2, 0, 0])
+        crv = create_line([1, 0, 0], [2, 0, 0])
         srf = revolve(crv, point=0, axis=2, angle=np.pi / 2)
         # At v=0 should be on +X axis, at v=1 on +Y axis
         pt_start = srf.evaluate(np.array([[0.5, 0.0]]))
@@ -47,7 +47,7 @@ class TestRevolve:
 
     def test_revolve_around_y_axis(self) -> None:
         """Test revolving around the Y axis."""
-        crv = line([1, 0, 0], [1, 0, 1])
+        crv = create_line([1, 0, 0], [1, 0, 1])
         srf = revolve(crv, point=0, axis=1, angle=np.pi / 2)
         # At v=1, (x, z) should rotate to (z, -x) for Y-axis rotation
         pt = srf.evaluate(np.array([[0.0, 1.0]]))
@@ -55,7 +55,7 @@ class TestRevolve:
 
     def test_revolve_with_center(self) -> None:
         """Test revolving around an offset point."""
-        crv = line([3, 0, 0], [3, 0, 1])
+        crv = create_line([3, 0, 0], [3, 0, 1])
         srf = revolve(crv, point=[2, 0, 0], axis=2)
         # At v=0, should be at original position
         pt = srf.evaluate(np.array([[0.0, 0.0]]))
@@ -70,7 +70,7 @@ class TestRevolve:
 
     def test_revolve_negative_angle(self) -> None:
         """Test revolving with a negative angle (clockwise)."""
-        crv = line([1, 0, 0], [2, 0, 0])
+        crv = create_line([1, 0, 0], [2, 0, 0])
         srf = revolve(crv, point=0, axis=2, angle=-np.pi / 2)
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         r = 1.5
@@ -78,7 +78,7 @@ class TestRevolve:
 
     def test_revolve_angle_tuple(self) -> None:
         """Test revolving with (start, end) angle tuple."""
-        crv = line([1, 0, 0], [2, 0, 0])
+        crv = create_line([1, 0, 0], [2, 0, 0])
         srf = revolve(crv, point=0, axis=2, angle=(np.pi / 2, np.pi))
         # At v=0, should be at angle pi/2 (on +Y axis)
         pt0 = srf.evaluate(np.array([[0.5, 0.0]]))
@@ -90,7 +90,7 @@ class TestRevolve:
 
     def test_revolve_dim_too_large_raises(self) -> None:
         """Test that revolving a volume raises ValueError."""
-        vol = extrude(bilinear(), [0, 0, 1])
+        vol = extrude(create_bilinear(), [0, 0, 1])
         with pytest.raises(ValueError, match="dim"):
             revolve(vol, point=0, axis=2)
 
@@ -106,10 +106,10 @@ class TestRevolve:
 class TestSweep:
     """Test the translational sweep operation."""
 
-    def test_sweep_line_along_line(self) -> None:
+    def test_sweep_line_along_create_line(self) -> None:
         """Test sweeping a line along a line produces a bilinear surface."""
-        section = line([0, 0, 0], [1, 0, 0])
-        trajectory = line([0, 0, 0], [0, 1, 0])
+        section = create_line([0, 0, 0], [1, 0, 0])
+        trajectory = create_line([0, 0, 0], [0, 1, 0])
         srf = sweep(section, trajectory)
         assert srf.dim == 2  # noqa: PLR2004
         assert srf.rank == _RANK_3D
@@ -131,8 +131,8 @@ class TestSweep:
 
     def test_sweep_preserves_section_geometry(self) -> None:
         """Test that at trajectory start the section geometry is preserved."""
-        section = circle(radius=2.0, angle=np.pi / 2)
-        trajectory = line([0, 0, 0], [0, 0, 5])
+        section = create_circle(radius=2.0, angle=np.pi / 2)
+        trajectory = create_line([0, 0, 0], [0, 0, 5])
         srf = sweep(section, trajectory)
         # At v=0 (trajectory start), should match the section
         u = np.linspace(0, 1, 20)
@@ -143,22 +143,22 @@ class TestSweep:
 
     def test_sweep_trajectory_offset(self) -> None:
         """Test that the trajectory adds an offset."""
-        section = line([0, 0, 0], [1, 0, 0])
-        trajectory = line([0, 0, 0], [0, 0, 3])
+        section = create_line([0, 0, 0], [1, 0, 0])
+        trajectory = create_line([0, 0, 0], [0, 0, 3])
         srf = sweep(section, trajectory)
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         assert_allclose(pt, [0.5, 0, 3], atol=1e-14)
 
     def test_sweep_section_dim2_raises_for_dim3(self) -> None:
         """Test that section dim > 2 raises ValueError."""
-        vol = extrude(bilinear(), [0, 0, 1])
-        traj = line([0, 0, 0], [1, 0, 0])
+        vol = extrude(create_bilinear(), [0, 0, 1])
+        traj = create_line([0, 0, 0], [1, 0, 0])
         with pytest.raises(ValueError, match=r"section\.dim"):
             sweep(vol, traj)
 
     def test_sweep_trajectory_dim2_raises(self) -> None:
         """Test that trajectory dim != 1 raises ValueError."""
-        sec = line([0, 0, 0], [1, 0, 0])
-        traj = bilinear()
+        sec = create_line([0, 0, 0], [1, 0, 0])
+        traj = create_bilinear()
         with pytest.raises(ValueError, match=r"trajectory\.dim"):
             sweep(sec, traj)


### PR DESCRIPTION
## Summary
- Rename CAD primitive/derived functions to use `create_` prefix: `line` → `create_line`, `circle` → `create_circle`, `bilinear` → `create_bilinear`, `trilinear` → `create_trilinear`, `rectangle` → `create_rectangle`, `disk` → `create_disk`, `cylinder` → `create_cylinder`, `ruled` → `create_ruled`, `coons_surface` → `create_coons_surface`, `coons_volume` → `create_coons_volume`
- Rename `compat` → `make_compat` to distinguish it as a compatibility utility rather than a geometry constructor
- Update all internal cross-references, imports, `__all__`, docstrings, and tests across 14 files

## Test plan
- [x] All 115 CAD tests pass
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy strict passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)