### PR TITLE
refactor(bspline,bezier): extract conversion classmethods as module functions

### DIFF
--- a/src/pantr/bezier/__init__.py
+++ b/src/pantr/bezier/__init__.py
@@ -7,6 +7,7 @@ Bernstein algorithms implemented in ``_bezier_core``, ``_bezier_eval``,
 ``_bezier_derivative``, ``_bezier_degree``, and ``_bezier_product``.
 
 - :func:`interpolate_bezier`, :func:`fit_bezier`: approximation functions.
+- :func:`create_from_bspline`: create a Bézier from a B-spline.
 
 Root-finding exports:
 
@@ -14,7 +15,7 @@ Root-finding exports:
 - :func:`find_monotone_root` -- fast solver for monotone polynomials (single or batch).
 """
 
-from ._bezier import Bezier
+from ._bezier import Bezier, create_from_bspline
 from ._bezier_interpolate import fit_bezier, interpolate_bezier
 from ._root_finding import (
     find_monotone_root,
@@ -23,6 +24,7 @@ from ._root_finding import (
 
 __all__ = [
     "Bezier",
+    "create_from_bspline",
     "find_monotone_root",
     "find_roots",
     "fit_bezier",

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -855,32 +855,6 @@ class Bezier:
         cp = self._control_points.copy() if copy else self._control_points
         return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
 
-    @classmethod
-    def from_bspline(cls, bspline: Bspline, *, copy: bool = True) -> Bezier:
-        """Create a Bézier from a B-spline with Bézier-like knot vectors.
-
-        Validates that the B-spline has Bézier-like knots (open knots with
-        ``num_basis == degree + 1`` in each direction) and extracts the
-        control points.
-
-        Args:
-            bspline (~pantr.bspline.Bspline): A B-spline with Bézier-like
-                knot structure.
-            copy (bool): If ``True`` (default), the control points are
-                deep-copied into the new Bézier. If ``False``, the Bézier
-                shares the same underlying control point array.
-
-        Returns:
-            Bezier: The equivalent Bézier.
-
-        Raises:
-            ValueError: If the B-spline does not have Bézier-like knots.
-        """
-        if not bspline.space.has_Bezier_like_knots():
-            raise ValueError("B-spline does not have Bézier-like knots. Cannot convert to Bézier.")
-        cp = bspline.control_points.copy() if copy else bspline.control_points
-        return cls(cp, is_rational=bspline.is_rational)
-
     # ------------------------------------------------------------------
     # Visualization
     # ------------------------------------------------------------------
@@ -915,3 +889,29 @@ class Bezier:
             show_control_polygon=show_control_polygon,
             **plotter_kwargs,
         )
+
+
+def create_from_bspline(bspline: Bspline, *, copy: bool = True) -> Bezier:
+    """Create a Bézier from a B-spline with Bézier-like knot vectors.
+
+    Validates that the B-spline has Bézier-like knots (open knots with
+    ``num_basis == degree + 1`` in each direction) and extracts the
+    control points.
+
+    Args:
+        bspline (~pantr.bspline.Bspline): A B-spline with Bézier-like
+            knot structure.
+        copy (bool): If ``True`` (default), the control points are
+            deep-copied into the new Bézier. If ``False``, the Bézier
+            shares the same underlying control point array.
+
+    Returns:
+        Bezier: The equivalent Bézier.
+
+    Raises:
+        ValueError: If the B-spline does not have Bézier-like knots.
+    """
+    if not bspline.space.has_Bezier_like_knots():
+        raise ValueError("B-spline does not have Bézier-like knots. Cannot convert to Bézier.")
+    cp = bspline.control_points.copy() if copy else bspline.control_points
+    return Bezier(cp, is_rational=bspline.is_rational)

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -12,9 +12,10 @@ This package consolidates the B-spline API:
   utilities.
 - :func:`interpolate_bspline`, :func:`fit_bspline`,
   :func:`l2_project_bspline`: approximation functions.
+- :func:`create_from_bezier`: create a B-spline from a Bézier.
 """
 
-from ._bspline import Bspline
+from ._bspline import Bspline, create_from_bezier
 from ._bspline_interpolate import fit_bspline, interpolate_bspline, l2_project_bspline
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_factory import (
@@ -32,6 +33,7 @@ __all__ = [
     "BsplineSpace",
     "BsplineSpace1D",
     "create_cardinal_knots",
+    "create_from_bezier",
     "create_greville_lattice",
     "create_uniform_open_knots",
     "create_uniform_periodic_knots",

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -730,25 +730,6 @@ class Bspline:
             self._beziers_cache = _to_beziers_impl(self)
         return self._beziers_cache
 
-    @classmethod
-    def from_bezier(cls, bezier: Bezier, *, copy: bool = True) -> Bspline:
-        """Create a B-spline from a Bézier.
-
-        Builds a :class:`Bspline` with Bézier-like knot vectors
-        (``[0]*(p+1) + [1]*(p+1)`` per direction) whose control points
-        are taken from the given Bézier.
-
-        Args:
-            bezier (~pantr.bezier.Bezier): The source Bézier.
-            copy (bool): If ``True`` (default), the control points are
-                deep-copied into the new B-spline.  If ``False``, the
-                B-spline shares the same underlying control point array.
-
-        Returns:
-            Bspline: Equivalent B-spline with Bézier-like knots.
-        """
-        return bezier.to_bspline(copy=copy)
-
     def multiply(self, other: Bspline) -> Bspline:
         """Return the exact pointwise product of this B-spline and another.
 
@@ -1163,3 +1144,22 @@ class Bspline:
             show_knot_lines=show_knot_lines,
             **plotter_kwargs,
         )
+
+
+def create_from_bezier(bezier: Bezier, *, copy: bool = True) -> Bspline:
+    """Create a B-spline from a Bézier.
+
+    Builds a :class:`Bspline` with Bézier-like knot vectors
+    (``[0]*(p+1) + [1]*(p+1)`` per direction) whose control points
+    are taken from the given Bézier.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The source Bézier.
+        copy (bool): If ``True`` (default), the control points are
+            deep-copied into the new B-spline.  If ``False``, the
+            B-spline shares the same underlying control point array.
+
+    Returns:
+        Bspline: Equivalent B-spline with Bézier-like knots.
+    """
+    return bezier.to_bspline(copy=copy)

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bezier import Bezier
+from pantr.bezier import Bezier, create_from_bspline
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.quad import PointsLattice
 
@@ -132,7 +132,7 @@ class TestBezierConversion:
         """Test conversion from Bezier-like B-spline."""
         b_orig = _make_bezier_1d([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
         bs = b_orig.to_bspline()
-        b_back = Bezier.from_bspline(bs)
+        b_back = create_from_bspline(bs)
         np.testing.assert_array_equal(b_back.control_points, b_orig.control_points)
 
     def test_from_bspline_invalid(self) -> None:
@@ -142,12 +142,12 @@ class TestBezierConversion:
         cp = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
         bs = Bspline(space, cp)
         with pytest.raises(ValueError, match="Bézier-like"):
-            Bezier.from_bspline(bs)
+            create_from_bspline(bs)
 
     def test_roundtrip(self) -> None:
         """Test to_bspline -> from_bspline roundtrip."""
         b = _make_bezier_1d([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]], is_rational=True)
-        b2 = Bezier.from_bspline(b.to_bspline())
+        b2 = create_from_bspline(b.to_bspline())
         np.testing.assert_array_equal(b2.control_points, b.control_points)
         assert b2.is_rational == b.is_rational
 
@@ -167,14 +167,14 @@ class TestBezierConversion:
         """Test that from_bspline with copy=True creates independent arrays."""
         b_orig = _make_bezier_1d([1.0, 2.0, 3.0])
         bs = b_orig.to_bspline(copy=False)
-        b_back = Bezier.from_bspline(bs, copy=True)
+        b_back = create_from_bspline(bs, copy=True)
         assert not np.shares_memory(bs.control_points, b_back.control_points)
 
     def test_from_bspline_copy_false(self) -> None:
         """Test that from_bspline with copy=False shares the control point array."""
         b_orig = _make_bezier_1d([1.0, 2.0, 3.0])
         bs = b_orig.to_bspline(copy=False)
-        b_back = Bezier.from_bspline(bs, copy=False)
+        b_back = create_from_bspline(bs, copy=False)
         assert np.shares_memory(bs.control_points, b_back.control_points)
 
     def test_to_bspline_default_copies(self) -> None:

--- a/tests/test_bezier_split.py
+++ b/tests/test_bezier_split.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bezier import Bezier
+from pantr.bezier import Bezier, create_from_bspline
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -294,7 +294,7 @@ class TestRestrictRefactored:
 
         # Reference via Bspline round-trip.
         bspl = crv.to_bspline()
-        ref = Bezier.from_bspline(bspl.restrict((0.2, 0.7)))
+        ref = create_from_bspline(bspl.restrict((0.2, 0.7)))
         np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-13)
 
     def test_restrict_2d_matches_bspline_roundtrip(self) -> None:
@@ -303,7 +303,7 @@ class TestRestrictRefactored:
         restricted = srf.restrict([(0.1, 0.8), (0.2, 0.9)])
 
         bspl = srf.to_bspline()
-        ref = Bezier.from_bspline(bspl.restrict([(0.1, 0.8), (0.2, 0.9)]))
+        ref = create_from_bspline(bspl.restrict([(0.1, 0.8), (0.2, 0.9)]))
         np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-12)
 
     def test_restrict_partial_direction(self) -> None:
@@ -312,7 +312,7 @@ class TestRestrictRefactored:
         restricted = srf.restrict([(0.3, 0.7), None])
 
         bspl = srf.to_bspline()
-        ref = Bezier.from_bspline(bspl.restrict([(0.3, 0.7), None]))
+        ref = create_from_bspline(bspl.restrict([(0.3, 0.7), None]))
         np.testing.assert_allclose(restricted.control_points, ref.control_points, atol=1e-13)
 
     def test_restrict_evaluations_match(self) -> None:

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -7,7 +7,13 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_from_bezier,
+    create_uniform_periodic_knots,
+)
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 
 # ---------------------------------------------------------------------------
@@ -589,19 +595,19 @@ class TestToBezier:
         space = BsplineSpace([BsplineSpace1D(knots, 2)])
         cp = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
         bs = Bspline(space, cp)
-        bs2 = Bspline.from_bezier(bs.to_bezier())
+        bs2 = create_from_bezier(bs.to_bezier())
         np.testing.assert_array_equal(bs2.control_points, bs.control_points)
         assert bs2.degree == bs.degree
 
 
 class TestFromBezier:
-    """Test Bspline.from_bezier conversion."""
+    """Test create_from_bezier conversion."""
 
     def test_from_bezier_1d(self) -> None:
         """Test from_bezier creates a B-spline with Bézier-like knots."""
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
-        bs = Bspline.from_bezier(bez)
+        bs = create_from_bezier(bez)
         assert bs.space.has_Bezier_like_knots()
         assert bs.degree == (2,)
         np.testing.assert_array_equal(bs.control_points, cp)
@@ -610,21 +616,21 @@ class TestFromBezier:
         """Test that from_bezier with copy=True creates independent arrays."""
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
-        bs = Bspline.from_bezier(bez, copy=True)
+        bs = create_from_bezier(bez, copy=True)
         assert not np.shares_memory(bez.control_points, bs.control_points)
 
     def test_from_bezier_copy_false(self) -> None:
         """Test that from_bezier with copy=False shares the control point array."""
         cp = np.array([[1.0], [2.0], [3.0]], dtype=np.float64)
         bez = Bezier(cp)
-        bs = Bspline.from_bezier(bez, copy=False)
+        bs = create_from_bezier(bez, copy=False)
         assert np.shares_memory(bez.control_points, bs.control_points)
 
     def test_from_bezier_rational(self) -> None:
         """Test from_bezier preserves rationality."""
         cp = np.array([[1.0, 0.5], [2.0, 1.0], [3.0, 0.5]], dtype=np.float64)
         bez = Bezier(cp, is_rational=True)
-        bs = Bspline.from_bezier(bez)
+        bs = create_from_bezier(bez)
         assert bs.is_rational
         np.testing.assert_array_equal(bs.control_points, cp)
 
@@ -632,7 +638,7 @@ class TestFromBezier:
         """Test from_bezier for a 2D Bézier."""
         cp = np.ones((3, 2, 1), dtype=np.float64)
         bez = Bezier(cp)
-        bs = Bspline.from_bezier(bez)
+        bs = create_from_bezier(bez)
         assert bs.space.has_Bezier_like_knots()
         assert bs.degree == (2, 1)
         np.testing.assert_array_equal(bs.control_points, cp)


### PR DESCRIPTION
## Summary
- Move `Bspline.from_bezier` classmethod to standalone `create_from_bezier()` in `pantr.bspline`
- Move `Bezier.from_bspline` classmethod to standalone `create_from_bspline()` in `pantr.bezier`
- Update all test call sites and package exports

## Test plan
- [x] All existing tests pass (2340 passed)
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)