### PR TITLE
refactor(bezier): delegate _gauss_legendre_01 to pantr.quad

### DIFF
--- a/src/pantr/bezier/implicit/_implicit_quad.py
+++ b/src/pantr/bezier/implicit/_implicit_quad.py
@@ -1097,14 +1097,14 @@ def _gauss_legendre_01(q: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.
     Returns:
         tuple: (nodes, weights) both of shape ``(q,)``.
     """
-    from numpy.polynomial.legendre import leggauss  # noqa: PLC0415
+    from pantr.quad import get_gauss_legendre_1d  # noqa: PLC0415
 
-    pts, wts = leggauss(q)  # type: ignore[no-untyped-call]
-    nodes = np.ascontiguousarray(0.5 * (pts + 1.0))
-    weights = np.ascontiguousarray(0.5 * wts)
-    nodes.flags.writeable = False
-    weights.flags.writeable = False
-    return nodes, weights
+    nodes, weights = get_gauss_legendre_1d(q)
+    nodes_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(nodes))
+    weights_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(weights))
+    nodes_f64.flags.writeable = False
+    weights_f64.flags.writeable = False
+    return nodes_f64, weights_f64
 
 
 @functools.lru_cache(maxsize=32)

--- a/src/pantr/bezier/implicit/_implicit_quad.py
+++ b/src/pantr/bezier/implicit/_implicit_quad.py
@@ -1092,19 +1092,21 @@ def _gauss_legendre_01(q: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.
     are read-only to prevent accidental mutation of the cached data.
 
     Args:
-        q (int): Number of quadrature points.
+        q (int): Number of quadrature points. Must be >= 1.
 
     Returns:
-        tuple: (nodes, weights) both of shape ``(q,)``.
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+            (nodes, weights) both of shape ``(q,)``.
+
+    Raises:
+        ValueError: If ``q < 1``.
     """
     from pantr.quad import get_gauss_legendre_1d  # noqa: PLC0415
 
     nodes, weights = get_gauss_legendre_1d(q)
-    nodes_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(nodes))
-    weights_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(weights))
-    nodes_f64.flags.writeable = False
-    weights_f64.flags.writeable = False
-    return nodes_f64, weights_f64
+    nodes.flags.writeable = False
+    weights.flags.writeable = False
+    return cast(npt.NDArray[np.float64], nodes), cast(npt.NDArray[np.float64], weights)
 
 
 @functools.lru_cache(maxsize=32)
@@ -1115,16 +1117,18 @@ def _tanh_sinh_01(q: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float
     are read-only to prevent accidental mutation of the cached data.
 
     Args:
-        q (int): Number of quadrature points.
+        q (int): Number of quadrature points. Must be >= 1.
 
     Returns:
-        tuple: (nodes, weights) both of shape ``(q,)``.
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+            (nodes, weights) both of shape ``(q,)``.
+
+    Raises:
+        ValueError: If ``q < 1``.
     """
     from pantr.quad import get_tanh_sinh_1d  # noqa: PLC0415
 
     nodes, weights = get_tanh_sinh_1d(q)
-    nodes_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(nodes))
-    weights_f64 = cast(npt.NDArray[np.float64], np.ascontiguousarray(weights))
-    nodes_f64.flags.writeable = False
-    weights_f64.flags.writeable = False
-    return nodes_f64, weights_f64
+    nodes.flags.writeable = False
+    weights.flags.writeable = False
+    return cast(npt.NDArray[np.float64], nodes), cast(npt.NDArray[np.float64], weights)


### PR DESCRIPTION
## Summary
- Replace the inline `leggauss` + affine-map implementation in `_gauss_legendre_01` with a call to `get_gauss_legendre_1d` from `pantr.quad`
- Matches the delegation pattern `_tanh_sinh_01` already uses
- Eliminates duplicated Gauss-Legendre quadrature logic in the implicit module

## Test plan
- [x] All 2484 tests pass (`pytest --no-cov`)
- [x] Ruff lint and format clean
- [x] mypy strict passes
- [x] Docs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)