### PR TITLE
docs(bezier): add
  algoim attribution and third-party notice

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,72 @@
+Third-Party Notices
+===================
+
+This file acknowledges third-party software whose algorithms or code
+influenced this project.
+
+-------------------------------------------------------------------------------
+
+Algoim
+------
+
+The implicit-domain quadrature module (`pantr.bezier.implicit`) is a
+reimplementation of the algorithms described in:
+
+    Robert Saye, "High-order quadrature on multi-component domains
+    implicitly defined by multivariate polynomials", Journal of
+    Computational Physics, 448, 110720, 2022.
+    https://doi.org/10.1016/j.jcp.2021.110720
+
+The original C++ implementation is available at:
+
+    https://github.com/algoim/algoim
+
+The PaNTr code is an independent implementation in Python/Numba, not a
+direct translation of the algoim source. The algoim license is
+reproduced below for attribution purposes.
+
+Algoim License (BSD 3-Clause variant)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Algoim Copyright (c) 2022, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+(1) Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+(2) Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+(3) Neither the name of the University of California, Lawrence Berkeley
+National Laboratory, U.S. Dept. of Energy nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes,
+patches, or upgrades to the features, functionality or performance of
+the source code ("Enhancements") to anyone; however, if you choose to
+make your Enhancements available either publicly, or directly to
+Lawrence Berkeley National Laboratory, without imposing a separate
+written license agreement for such Enhancements, then you hereby grant
+the following license: a non-exclusive, royalty-free perpetual license
+to install, use, modify, prepare derivative works, incorporate into
+other computer software, distribute, and sublicense such enhancements
+or derivative works thereof, in binary and source code form.

--- a/src/pantr/bezier/implicit/__init__.py
+++ b/src/pantr/bezier/implicit/__init__.py
@@ -1,9 +1,19 @@
 """High-order quadrature on domains implicitly defined by multivariate polynomials.
 
-Implements the dimension-reduction algorithm of Saye (JCP 2022) entirely in
-Numba nopython mode for near-C++ performance. The algorithm recasts implicitly
-defined geometry as the graph of a multi-valued height function and applies
-recursive dimension reduction down to one-dimensional quadrature.
+This module is an independent Python/Numba reimplementation of the algorithms
+from the `algoim <https://github.com/algoim/algoim>`_ library by Robert Saye
+(Lawrence Berkeley National Laboratory). The original algorithm is described in:
+
+    R. Saye, "High-order quadrature on multi-component domains implicitly
+    defined by multivariate polynomials", J. Comput. Phys., 448, 110720, 2022.
+    https://doi.org/10.1016/j.jcp.2021.110720
+
+See ``THIRD_PARTY_NOTICES`` in the repository root for the full algoim license.
+
+The implementation uses Numba nopython mode for near-C++ performance.
+The algorithm recasts implicitly defined geometry as the graph of a
+multi-valued height function and applies recursive dimension reduction down
+to one-dimensional quadrature.
 
 The algorithm has two phases:
 


### PR DESCRIPTION
## Summary
  - Add THIRD_PARTY_NOTICES file with full algoim BSD license and credit to Robert Saye
  (LBNL)
  - Update pantr.bezier.implicit module docstring with paper citation, DOI link, and pointer
  to the notice file

  ## Test plan
  - [x] No code changes -- documentation/attribution only
  - [x] Pre-commit hooks pass (ruff, mypy, etc.)

  Generated with [Claude Code](https://claude.com/claude-code)