### PR TITLE
refactor(change_basis): add monomial→Bernstein 1D and reuse in bezier/implicit

### DIFF
--- a/src/pantr/bezier/implicit/_convert_core.py
+++ b/src/pantr/bezier/implicit/_convert_core.py
@@ -17,6 +17,8 @@ from math import comb
 import numpy as np
 from numpy import typing as npt
 
+from pantr.change_basis import compute_monomial_to_bernstein_1d
+
 
 def _validate_degrees(
     mono_shape: tuple[int, ...],
@@ -101,7 +103,9 @@ def monomial_to_bernstein_2d(
                     cy = comb(iy, q) * lo_y ** (iy - q) * hy**q
                     mapped[p, q] += c * cx * cy
 
-    return _m2b_mat(dx) @ mapped @ _m2b_mat(dy).T
+    mx = compute_monomial_to_bernstein_1d(dx)
+    my = compute_monomial_to_bernstein_1d(dy)
+    return np.asarray(mx @ mapped @ my.T, dtype=np.float64)
 
 
 def monomial_to_bernstein_3d(
@@ -155,25 +159,9 @@ def monomial_to_bernstein_3d(
                             cz = comb(iz, r) * lo_z ** (iz - r) * hz**r
                             mapped[p, q, r] += c * cx * cy * cz
 
-    mx, my, mz = _m2b_mat(dx), _m2b_mat(dy), _m2b_mat(dz)
+    mx = compute_monomial_to_bernstein_1d(dx)
+    my = compute_monomial_to_bernstein_1d(dy)
+    mz = compute_monomial_to_bernstein_1d(dz)
     tmp1 = np.einsum("ip,pqr->iqr", mx, mapped)
     tmp2 = np.einsum("jq,iqr->ijr", my, tmp1)
     return np.asarray(np.einsum("kr,ijr->ijk", mz, tmp2), dtype=np.float64)
-
-
-def _m2b_mat(n: int) -> npt.NDArray[np.float64]:
-    """Monomial-to-Bernstein conversion matrix for degree *n*.
-
-    ``M[i, j] = C(i, j) / C(n, j)`` for ``j <= i``, else 0.
-
-    Args:
-        n (int): Polynomial degree.
-
-    Returns:
-        npt.NDArray[np.float64]: Lower-triangular matrix of shape ``(n+1, n+1)``.
-    """
-    mat = np.zeros((n + 1, n + 1))
-    for i in range(n + 1):
-        for j in range(i + 1):
-            mat[i, j] = comb(i, j) / comb(n, j)
-    return mat

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -13,6 +13,7 @@ space objects.
 
 import functools
 from collections.abc import Callable
+from math import comb
 
 import numpy as np
 import numpy.typing as npt
@@ -317,6 +318,60 @@ def compute_cardinal_to_bernstein_1d(
     )
 
 
+def compute_monomial_to_bernstein_1d(
+    degree: int,
+    dtype: npt.DTypeLike = np.float64,
+    out: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Create transformation matrix from monomial to Bernstein basis on [0, 1].
+
+    Given a polynomial of degree ``degree`` written in the monomial basis on
+    ``[0, 1]``, the returned matrix ``M`` converts its coefficient vector to
+    the Bernstein basis: ``bern_coeffs = M @ mono_coeffs``. Equivalently, on
+    basis evaluations, ``monomial(x) = M.T @ bernstein(x)``.
+
+    The entries are ``M[i, j] = C(i, j) / C(degree, j)`` for ``j <= i``, else
+    ``0``, where ``C(n, k)`` is the binomial coefficient.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative.
+        dtype (npt.DTypeLike): Floating point type for the output matrix.
+            Defaults to np.float64.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
+            where the result will be stored. If None, a new array is allocated.
+            Must have shape (degree+1, degree+1) and dtype matching the `dtype` parameter
+            if provided. This follows NumPy's style for output arrays. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) lower-triangular
+            transformation matrix ``M`` such that ``M @ [monomial coefficients] =
+            [Bernstein coefficients]``. If `out` was provided, returns the same array.
+
+    Raises:
+        ValueError: If degree is negative, dtype is not float32 or float64, or if `out`
+            is provided and has incorrect shape or dtype.
+    """
+    if degree < 0:
+        raise ValueError("Degree must be non-negative")
+    if dtype not in (np.float32, np.float64):
+        raise ValueError("dtype must be float32 or float64")
+
+    expected_shape = (degree + 1, degree + 1)
+    expected_dtype = dtype
+
+    if out is None:
+        out = np.zeros(expected_shape, dtype=expected_dtype)
+    else:
+        _validate_out_array_multidimensional(out, expected_shape, expected_dtype)
+        out[:] = 0
+
+    for i in range(degree + 1):
+        for j in range(i + 1):
+            out[i, j] = comb(i, j) / comb(degree, j)
+
+    return out
+
+
 @functools.lru_cache(maxsize=64)
 def _cached_lagrange_to_bernstein_matrix(
     degree: int,
@@ -387,4 +442,5 @@ __all__ = [
     "compute_bernstein_to_lagrange_1d",
     "compute_cardinal_to_bernstein_1d",
     "compute_lagrange_to_bernstein_1d",
+    "compute_monomial_to_bernstein_1d",
 ]

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -18,6 +18,7 @@ from pantr.change_basis import (
     compute_bernstein_to_lagrange_1d,
     compute_cardinal_to_bernstein_1d,
     compute_lagrange_to_bernstein_1d,
+    compute_monomial_to_bernstein_1d,
 )
 
 
@@ -466,3 +467,96 @@ class TestCachedChangeBasisMatrices:
         info = _cached_cardinal_to_bernstein_matrix.cache_info()
         assert info.maxsize is not None
         assert info.maxsize > 0
+
+
+class TestMonomialToBernsteinBasisOperator:
+    """Test the compute_monomial_to_bernstein_1d function."""
+
+    def test_negative_degree_error(self) -> None:
+        """Test that negative degree raises ValueError."""
+        with pytest.raises(ValueError, match="Degree must be non-negative"):
+            compute_monomial_to_bernstein_1d(-1)
+
+    def test_invalid_dtype_error(self) -> None:
+        """Test that invalid dtype raises ValueError."""
+        with pytest.raises(ValueError, match="dtype must be float32 or float64"):
+            compute_monomial_to_bernstein_1d(2, dtype=np.int32)
+        with pytest.raises(ValueError, match="dtype must be float32 or float64"):
+            compute_monomial_to_bernstein_1d(2, dtype=np.float16)
+
+    def test_out_parameter(self) -> None:
+        """Test that out parameter works correctly."""
+        degree = 3
+
+        result1 = compute_monomial_to_bernstein_1d(degree)
+        assert result1.shape == (degree + 1, degree + 1)
+        assert result1.dtype == np.float64
+
+        out = np.empty((degree + 1, degree + 1), dtype=np.float64)
+        result2 = compute_monomial_to_bernstein_1d(degree, out=out)
+        assert result2 is out
+        np.testing.assert_array_equal(result1, result2)
+
+        out_f32 = np.empty((degree + 1, degree + 1), dtype=np.float32)
+        result3 = compute_monomial_to_bernstein_1d(degree, dtype=np.float32, out=out_f32)
+        assert result3 is out_f32
+        assert result3.dtype == np.float32
+
+    def test_out_parameter_validation(self) -> None:
+        """Test that out parameter validation works correctly."""
+        degree = 2
+
+        out_wrong_shape = np.empty((degree + 2, degree + 1), dtype=np.float64)
+        with pytest.raises(ValueError, match="Output array has shape"):
+            compute_monomial_to_bernstein_1d(degree, out=out_wrong_shape)
+
+        out_wrong_dtype = np.empty((degree + 1, degree + 1), dtype=np.float32)
+        with pytest.raises(ValueError, match="Output array has dtype"):
+            compute_monomial_to_bernstein_1d(degree, out=out_wrong_dtype)
+
+        out_readonly = np.empty((degree + 1, degree + 1), dtype=np.float64)
+        out_readonly.setflags(write=False)
+        with pytest.raises(ValueError, match="Output array is not writeable"):
+            compute_monomial_to_bernstein_1d(degree, out=out_readonly)
+
+    def test_degree_zero(self) -> None:
+        """Degree 0 returns the 1x1 identity."""
+        mat = compute_monomial_to_bernstein_1d(0)
+        np.testing.assert_array_equal(mat, np.array([[1.0]]))
+
+    def test_known_values_degree_2(self) -> None:
+        """Degree 2: 1 = B0+B1+B2, t = (1/2)B1 + B2, t^2 = B2."""
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [1.0, 0.5, 0.0],
+                [1.0, 1.0, 1.0],
+            ]
+        )
+        np.testing.assert_array_almost_equal(compute_monomial_to_bernstein_1d(2), expected)
+
+    def test_known_values_degree_3(self) -> None:
+        """Degree 3 reference values: M[i, j] = C(i, j) / C(3, j)."""
+        expected = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0 / 3.0, 0.0, 0.0],
+                [1.0, 2.0 / 3.0, 1.0 / 3.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0],
+            ]
+        )
+        np.testing.assert_array_almost_equal(compute_monomial_to_bernstein_1d(3), expected)
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5, 6])
+    def test_polynomial_reconstruction(self, degree: int) -> None:
+        """Bernstein coefficients from the matrix must reproduce the monomial polynomial."""
+        rng = np.random.default_rng(degree)
+        mono = rng.standard_normal(degree + 1)
+
+        bern_coeffs = compute_monomial_to_bernstein_1d(degree) @ mono
+
+        tt = np.linspace(0.0, 1.0, 25)
+        p_mono = sum(mono[k] * tt**k for k in range(degree + 1))
+        p_bern = tabulate_bernstein_1d(degree, tt) @ bern_coeffs
+
+        np.testing.assert_array_almost_equal(p_bern, p_mono)


### PR DESCRIPTION
## Summary

- Promote the private `_m2b_mat` helper from `pantr.bezier.implicit._convert_core` to a public `compute_monomial_to_bernstein_1d` in `pantr.change_basis`, where it fits the module's charter of providing 1D basis-transformation matrices.
- `monomial_to_bernstein_2d/3d` stay in `_convert_core` (they also perform domain reparameterization from `[lo, hi]^d` to `[0, 1]^d`, which is outside `change_basis`' scope) and now call the new function instead of maintaining their own 1D matrix.
- Add unit tests for `compute_monomial_to_bernstein_1d` mirroring the style of existing `compute_*_1d` tests: input validation, `out` handling, hand-computed degree-2/3 references, and polynomial round-trip via `tabulate_bernstein_1d`.

## Test plan

- [x] `pytest tests/test_change_basis_1D.py::TestMonomialToBernsteinBasisOperator --no-cov -v` (13 new tests pass)
- [x] `pytest tests/test_implicit_quad.py tests/test_implicit_reparam.py tests/test_change_basis_1D.py --no-cov` (206 passed, confirms 2D/3D output unchanged)
- [x] `pytest --no-cov` (full suite: 2497 passed)
- [x] `ruff check . && ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `cd docs && make html` (docs build clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)