### PR TITLE
feat(extraction): numba-callable kronecker kernels

### DIFF
--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -1,0 +1,419 @@
+"""Layer-2 helpers for tensor-product change-of-basis extraction.
+
+Provides shape/dtype/writability validation, scratch sizing, ``out`` and
+``scratch`` allocation, and kernel dispatch for the Layer-3 kernels in
+:mod:`pantr.bspline._extraction_kernels`.
+
+Four operation kinds are supported (see :data:`OP_KINDS`):
+
+- ``"apply"``:    ``out = M @ v``           (input shape prod -> output shape prod)
+- ``"apply_T"``:  ``out = M^T @ v``         (output shape prod -> input shape prod)
+- ``"MT_K_M"``:   ``out = M^T @ K @ M``     (output x output -> input x input)
+- ``"M_K_MT"``:   ``out = M @ K @ M^T``     (input x input -> output x output)
+
+with ``M = kron(M_0, M_1, ..., M_{d-1})``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal, cast, get_args
+
+import numpy as np
+import numpy.typing as npt
+
+from ..basis._basis_utils import _allocate_or_validate_out, _validate_out_array
+from ._extraction_kernels import (
+    apply_kron_1d,
+    apply_kron_2d,
+    apply_kron_3d,
+    apply_kron_M_K_MT_1d,
+    apply_kron_M_K_MT_2d,
+    apply_kron_M_K_MT_3d,
+    apply_kron_MT_K_M_1d,
+    apply_kron_MT_K_M_2d,
+    apply_kron_MT_K_M_3d,
+    apply_kron_T_1d,
+    apply_kron_T_2d,
+    apply_kron_T_3d,
+)
+
+OpKind = Literal["apply", "apply_T", "MT_K_M", "M_K_MT"]
+"""Tag distinguishing the four apply variants.
+
+See :mod:`pantr.bspline._extraction_helpers` for the meaning of each tag.
+"""
+
+
+MAX_SUPPORTED_DIM = 3
+"""Highest tensor-product dimension for which specialized kernels exist."""
+
+
+_OPS_2D_NDIM = 2
+
+
+_KERNELS: dict[tuple[OpKind, int], Callable[..., None]] = {
+    ("apply", 1): apply_kron_1d,
+    ("apply", 2): apply_kron_2d,
+    ("apply", 3): apply_kron_3d,
+    ("apply_T", 1): apply_kron_T_1d,
+    ("apply_T", 2): apply_kron_T_2d,
+    ("apply_T", 3): apply_kron_T_3d,
+    ("MT_K_M", 1): apply_kron_MT_K_M_1d,
+    ("MT_K_M", 2): apply_kron_MT_K_M_2d,
+    ("MT_K_M", 3): apply_kron_MT_K_M_3d,
+    ("M_K_MT", 1): apply_kron_M_K_MT_1d,
+    ("M_K_MT", 2): apply_kron_M_K_MT_2d,
+    ("M_K_MT", 3): apply_kron_M_K_MT_3d,
+}
+
+
+def _prod(shape: tuple[int, ...]) -> int:
+    """Return the product of a shape tuple (1 for an empty tuple)."""
+    result = 1
+    for n in shape:
+        result *= n
+    return result
+
+
+def _validate_op_kind(op_kind: str) -> OpKind:
+    """Validate an operation-kind tag.
+
+    Args:
+        op_kind (str): Tag to validate.
+
+    Returns:
+        OpKind: The validated tag (narrowed to :data:`OpKind`).
+
+    Raises:
+        ValueError: If ``op_kind`` is not one of :data:`OpKind`'s literals.
+    """
+    if op_kind not in get_args(OpKind):
+        valid = ", ".join(repr(v) for v in get_args(OpKind))
+        raise ValueError(f"Unknown op_kind {op_kind!r}; expected one of {valid}")
+    return cast(OpKind, op_kind)
+
+
+def _apply_scratch_size(
+    n_per_dir_in: tuple[int, ...],
+    n_per_dir_out: tuple[int, ...],
+) -> int:
+    """Scratch size for an ``apply``-style vector kernel.
+
+    Simulates the mode-contraction stages from ``n_per_dir_in`` to
+    ``n_per_dir_out`` and returns twice the largest intermediate buffer size
+    (one "half" per ping-pong buffer; in d=1 or d=2 only one half is used).
+
+    Args:
+        n_per_dir_in (tuple[int, ...]): Starting per-direction sizes.
+        n_per_dir_out (tuple[int, ...]): Ending per-direction sizes.
+
+    Returns:
+        int: Required scratch size in elements (0 for d<=1).
+    """
+    d = len(n_per_dir_in)
+    if d <= 1:
+        return 0
+    max_sz = 0
+    for k in range(d - 1):
+        sz = 1
+        for j in range(k + 1):
+            sz *= n_per_dir_out[j]
+        for j in range(k + 1, d):
+            sz *= n_per_dir_in[j]
+        max_sz = max(max_sz, sz)
+    return 2 * max_sz
+
+
+def _bilateral_scratch_size(
+    n_per_dir_initial: tuple[int, ...],
+    n_per_dir_final: tuple[int, ...],
+) -> int:
+    """Scratch size for a bilateral matrix kernel.
+
+    Simulates the interleaved (row, column) mode-contraction stages on the
+    2d-axis reshape of the input matrix, going from per-direction sizes
+    ``n_per_dir_initial`` to ``n_per_dir_final``. Returns twice the largest
+    intermediate buffer size to cover a two-buffer ping-pong.
+
+    Args:
+        n_per_dir_initial (tuple[int, ...]): Starting per-direction sizes.
+            The initial matrix is ``(prod, prod)``.
+        n_per_dir_final (tuple[int, ...]): Ending per-direction sizes.
+
+    Returns:
+        int: Required scratch size in elements (0 for d<1).
+    """
+    d = len(n_per_dir_initial)
+    if d < 1:
+        return 0
+    shape = list(n_per_dir_initial) + list(n_per_dir_initial)
+    max_sz = 0
+    total_stages = 2 * d
+    for stage in range(total_stages):
+        k = stage // 2
+        axis = k if stage % 2 == 0 else d + k
+        shape[axis] = n_per_dir_final[k]
+        if stage == total_stages - 1:
+            break  # final stage writes to out, not scratch
+        sz = 1
+        for s in shape:
+            sz *= s
+        max_sz = max(max_sz, sz)
+    return 2 * max_sz
+
+
+def _required_scratch_size(
+    input_shape_per_dir: tuple[int, ...],
+    output_shape_per_dir: tuple[int, ...],
+    op_kind: OpKind,
+) -> int:
+    """Return the scratch buffer size required by the kernel for a single call.
+
+    Computed by simulating the kernel's mode-contraction stages and taking
+    twice the largest intermediate buffer (to hold two ping-pong halves).
+    The returned size is sufficient for any identity-flag pattern.
+
+    For ``d = 1`` and kind ``apply``/``apply_T`` the kernel does not use
+    scratch and the returned size is 0.
+
+    Args:
+        input_shape_per_dir (tuple[int, ...]): Per-direction input sizes
+            (``n_in_k``).
+        output_shape_per_dir (tuple[int, ...]): Per-direction output sizes
+            (``n_out_k``); must have the same length as ``input_shape_per_dir``.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        int: Required scratch size in array elements.
+
+    Raises:
+        ValueError: If the two shape tuples have different lengths or
+            ``op_kind`` is invalid.
+    """
+    _validate_op_kind(op_kind)
+    if len(input_shape_per_dir) != len(output_shape_per_dir):
+        raise ValueError(
+            "input_shape_per_dir and output_shape_per_dir must have the same length; "
+            f"got {len(input_shape_per_dir)} and {len(output_shape_per_dir)}"
+        )
+    if op_kind == "apply":
+        return _apply_scratch_size(input_shape_per_dir, output_shape_per_dir)
+    if op_kind == "apply_T":
+        return _apply_scratch_size(output_shape_per_dir, input_shape_per_dir)
+    if op_kind == "MT_K_M":
+        return _bilateral_scratch_size(output_shape_per_dir, input_shape_per_dir)
+    # op_kind == "M_K_MT"
+    return _bilateral_scratch_size(input_shape_per_dir, output_shape_per_dir)
+
+
+def _dispatch_apply(d: int, op_kind: OpKind) -> Callable[..., None]:
+    """Return the Layer-3 kernel for a given dimension and operation kind.
+
+    Args:
+        d (int): Number of tensor-product directions.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        Callable[..., None]: The corresponding ``@njit`` kernel.
+
+    Raises:
+        NotImplementedError: If ``d`` is not in ``{1, 2, 3}``.
+        ValueError: If ``op_kind`` is invalid.
+    """
+    _validate_op_kind(op_kind)
+    if d < 1 or d > MAX_SUPPORTED_DIM:
+        raise NotImplementedError(
+            f"Extraction kernels are specialized for d in {{1, 2, 3}}; got d={d}. "
+            "Add a generic-d kernel in pantr.bspline._extraction_kernels to support "
+            "higher dimensions."
+        )
+    return _KERNELS[(op_kind, d)]
+
+
+def _operation_shapes(
+    input_shape_per_dir: tuple[int, ...],
+    output_shape_per_dir: tuple[int, ...],
+    op_kind: OpKind,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return ``(input_shape, output_shape)`` for a given operation kind.
+
+    For vector apply variants the shapes are 1D ``(N,)`` tuples. For bilateral
+    variants they are 2D ``(N, N)`` tuples. ``N`` is the product of the
+    corresponding per-direction sizes.
+
+    Args:
+        input_shape_per_dir (tuple[int, ...]): Per-direction input sizes.
+        output_shape_per_dir (tuple[int, ...]): Per-direction output sizes.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        tuple[tuple[int, ...], tuple[int, ...]]: ``(input_shape, output_shape)``
+        of the operand and result arrays.
+    """
+    _validate_op_kind(op_kind)
+    n_in = _prod(input_shape_per_dir)
+    n_out = _prod(output_shape_per_dir)
+    if op_kind == "apply":
+        return (n_in,), (n_out,)
+    if op_kind == "apply_T":
+        return (n_out,), (n_in,)
+    if op_kind == "MT_K_M":
+        return (n_out, n_out), (n_in, n_in)
+    # op_kind == "M_K_MT"
+    return (n_in, n_in), (n_out, n_out)
+
+
+def _validate_operand(
+    operand: np.ndarray,  # type: ignore[type-arg]
+    expected_shape: tuple[int, ...],
+    dtype: npt.DTypeLike,
+) -> None:
+    """Validate shape and dtype of an input operand.
+
+    Args:
+        operand (np.ndarray): Input array to check.
+        expected_shape (tuple[int, ...]): Required shape.
+        dtype (npt.DTypeLike): Required dtype.
+
+    Raises:
+        ValueError: If the operand shape or dtype does not match.
+    """
+    if operand.shape != expected_shape:
+        raise ValueError(f"Operand has shape {operand.shape}, but expected shape {expected_shape}")
+    if operand.dtype != np.dtype(dtype):
+        raise ValueError(f"Operand has dtype {operand.dtype}, but expected dtype {np.dtype(dtype)}")
+
+
+def _allocate_or_validate_scratch(
+    scratch: npt.NDArray[np.float32 | np.float64] | None,
+    required_size: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Allocate a fresh scratch buffer or validate the user-provided one.
+
+    A user-provided buffer is accepted if it is at least ``required_size``
+    elements long (it may be larger; only the first ``required_size`` elements
+    are used), has the expected dtype, is writeable, and 1D.
+
+    Args:
+        scratch (npt.NDArray[np.float32 | np.float64] | None): Caller-provided
+            scratch buffer, or ``None`` to allocate.
+        required_size (int): Minimum number of elements required.
+        dtype (npt.DTypeLike): Required dtype.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The validated or freshly
+        allocated scratch buffer.
+
+    Raises:
+        ValueError: If ``scratch`` is provided with wrong dtype, wrong ndim,
+            is too small, or is not writeable.
+    """
+    if scratch is None:
+        return np.empty(required_size, dtype=dtype)
+    if scratch.ndim != 1:
+        raise ValueError(f"Scratch must be 1D; got ndim={scratch.ndim}")
+    if scratch.dtype != np.dtype(dtype):
+        raise ValueError(f"Scratch has dtype {scratch.dtype}, but expected dtype {np.dtype(dtype)}")
+    if scratch.size < required_size:
+        raise ValueError(f"Scratch size {scratch.size} is smaller than required {required_size}")
+    if not scratch.flags.writeable:
+        raise ValueError("Scratch array is not writeable")
+    return scratch
+
+
+def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel input.
+    ops_1d_per_cell: tuple[npt.NDArray[np.float32 | np.float64], ...],
+    is_identity_per_dir: tuple[bool, ...],
+    operand: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+    scratch: npt.NDArray[np.float32 | np.float64] | None,
+    op_kind: OpKind,
+) -> tuple[
+    Callable[..., None],
+    tuple[Any, ...],
+    npt.NDArray[np.float32 | np.float64],
+]:
+    """Validate inputs and build the kernel call for a single cell.
+
+    Args:
+        ops_1d_per_cell (tuple[npt.NDArray[np.float32 | np.float64], ...]):
+            Per-direction 2D operators ``M_k`` already selected for the cell,
+            each of shape ``(n_out_k, n_in_k)``. Length must equal the number
+            of directions ``d``.
+        is_identity_per_dir (tuple[bool, ...]): Per-direction identity flags.
+            Must have length ``d``.
+        operand (npt.NDArray[np.float32 | np.float64]): Input vector (for
+            ``apply``/``apply_T``) or matrix (for ``MT_K_M``/``M_K_MT``).
+        out (npt.NDArray[np.float32 | np.float64] | None): Output array, or
+            ``None`` to allocate. Same dtype as the operators.
+        scratch (npt.NDArray[np.float32 | np.float64] | None): Scratch
+            buffer, or ``None`` to allocate.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        tuple[Callable, tuple, npt.NDArray]: A 3-tuple ``(kernel, args, out)``
+        where ``kernel(*args)`` performs the requested operation, writing into
+        ``out``. ``out`` is the same array the caller can return.
+
+    Raises:
+        ValueError: If shapes, dtypes, writability, or length invariants fail.
+        NotImplementedError: If ``d > 3``.
+    """
+    _validate_op_kind(op_kind)
+    d = len(ops_1d_per_cell)
+    if len(is_identity_per_dir) != d:
+        raise ValueError(
+            f"is_identity_per_dir has length {len(is_identity_per_dir)}, "
+            f"expected {d} to match ops_1d_per_cell"
+        )
+    if d < 1:
+        raise ValueError("At least one direction is required")
+    for k, M_k in enumerate(ops_1d_per_cell):
+        if M_k.ndim != _OPS_2D_NDIM:
+            raise ValueError(f"ops_1d_per_cell[{k}] must be 2D; got ndim={M_k.ndim}")
+    dtype = ops_1d_per_cell[0].dtype
+    for k, M_k in enumerate(ops_1d_per_cell[1:], start=1):
+        if M_k.dtype != dtype:
+            raise ValueError(
+                f"ops_1d_per_cell[{k}] dtype {M_k.dtype} differs from ops_1d_per_cell[0] "
+                f"dtype {dtype}"
+            )
+
+    input_shape_per_dir = tuple(int(M_k.shape[1]) for M_k in ops_1d_per_cell)
+    output_shape_per_dir = tuple(int(M_k.shape[0]) for M_k in ops_1d_per_cell)
+    expected_in_shape, expected_out_shape = _operation_shapes(
+        input_shape_per_dir, output_shape_per_dir, op_kind
+    )
+    _validate_operand(operand, expected_in_shape, dtype)
+    out = _allocate_or_validate_out(out, expected_out_shape, dtype)
+
+    scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)
+    scratch = _allocate_or_validate_scratch(scratch, scratch_size, dtype)
+
+    kernel = _dispatch_apply(d, op_kind)
+
+    # Kernel signature: (M_0, [M_1, [M_2,]], is_id_0, [is_id_1, [is_id_2,]], operand, out, scratch)
+    args: tuple[Any, ...] = (
+        *ops_1d_per_cell,
+        *is_identity_per_dir,
+        operand,
+        out,
+        scratch,
+    )
+    return kernel, args, out
+
+
+__all__ = [
+    "MAX_SUPPORTED_DIM",
+    "OpKind",
+    "_allocate_or_validate_scratch",
+    "_dispatch_apply",
+    "_operation_shapes",
+    "_prepare_apply_call",
+    "_required_scratch_size",
+    "_validate_op_kind",
+    "_validate_operand",
+    "_validate_out_array",
+]

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -368,7 +368,7 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
     if d < 1:
         raise ValueError("At least one direction is required")
     for k, M_k in enumerate(ops_1d_per_cell):
-        if M_k.ndim != 2:
+        if M_k.ndim != 2:  # noqa: PLR2004
             raise ValueError(f"ops_1d_per_cell[{k}] must be 2D; got ndim={M_k.ndim}")
     dtype = ops_1d_per_cell[0].dtype
     for k, M_k in enumerate(ops_1d_per_cell[1:], start=1):

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -22,7 +22,7 @@ from typing import Any, Literal, cast, get_args
 import numpy as np
 import numpy.typing as npt
 
-from ..basis._basis_utils import _allocate_or_validate_out, _validate_out_array
+from ..basis._basis_utils import _allocate_or_validate_out
 from ._extraction_kernels import (
     apply_kron_1d,
     apply_kron_2d,
@@ -47,9 +47,6 @@ See :mod:`pantr.bspline._extraction_helpers` for the meaning of each tag.
 
 MAX_SUPPORTED_DIM = 3
 """Highest tensor-product dimension for which specialized kernels exist."""
-
-
-_OPS_2D_NDIM = 2
 
 
 _KERNELS: dict[tuple[OpKind, int], Callable[..., None]] = {
@@ -371,7 +368,7 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
     if d < 1:
         raise ValueError("At least one direction is required")
     for k, M_k in enumerate(ops_1d_per_cell):
-        if M_k.ndim != _OPS_2D_NDIM:
+        if M_k.ndim != 2:
             raise ValueError(f"ops_1d_per_cell[{k}] must be 2D; got ndim={M_k.ndim}")
     dtype = ops_1d_per_cell[0].dtype
     for k, M_k in enumerate(ops_1d_per_cell[1:], start=1):
@@ -415,5 +412,4 @@ __all__ = [
     "_required_scratch_size",
     "_validate_op_kind",
     "_validate_operand",
-    "_validate_out_array",
 ]

--- a/src/pantr/bspline/_extraction_kernels.py
+++ b/src/pantr/bspline/_extraction_kernels.py
@@ -24,6 +24,11 @@ These kernels are designed to be callable from other ``@njit`` code: they are
 module-level free functions with plain NumPy-array arguments, no optional
 parameters, and ``cache=True`` so downstream libraries can dispatch to them
 directly from their own JIT-compiled loops.
+
+``parallel=True`` is intentionally omitted: these kernels operate on a single
+cell and are expected to be called from within a caller-level ``prange`` loop.
+Enabling intra-kernel parallelism would conflict with the outer thread pool and
+degrade performance.
 """
 
 from __future__ import annotations

--- a/src/pantr/bspline/_extraction_kernels.py
+++ b/src/pantr/bspline/_extraction_kernels.py
@@ -1,0 +1,1241 @@
+"""Numba-callable Kronecker contraction kernels for change-of-basis extraction.
+
+This module provides Layer-3 (Numba) primitives that apply tensor-product
+change-of-basis operators ``M = kron(M_0, M_1, ..., M_{d-1})`` to vectors and
+matrices without ever materializing the full Kronecker product. Each kernel
+operates on a single cell: the caller passes in the per-direction 1D operators
+selected for that cell (``M_k``), per-direction identity flags (``is_id_k``),
+and pre-allocated output and scratch arrays.
+
+Kernels are specialized for ``d in {1, 2, 3}`` and cover four operations:
+
+- ``apply_kron_{d}d``:        ``out = M @ v``
+- ``apply_kron_T_{d}d``:      ``out = M^T @ v``
+- ``apply_kron_MT_K_M_{d}d``: ``out = M^T @ K @ M``
+- ``apply_kron_M_K_MT_{d}d``: ``out = M @ K @ M^T``
+
+Identity short-circuit: when ``is_id_k`` is True, the mode-k contraction is
+skipped (the axis is passed through unchanged, and ``M_k`` is not read). When
+all directions are identity, the kernel degenerates to a direct copy
+``out[:] = input[:]``, which is aliasing-safe -- the caller may pass the same
+array as input and output.
+
+These kernels are designed to be callable from other ``@njit`` code: they are
+module-level free functions with plain NumPy-array arguments, no optional
+parameters, and ``cache=True`` so downstream libraries can dispatch to them
+directly from their own JIT-compiled loops.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_1d(
+    M_0: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = M_0 @ v`` with identity short-circuit.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Operator, shape
+            ``(n_out_0, n_in_0)``.
+        is_id_0 (bool): If True, ``M_0`` is treated as identity and not read;
+            ``out`` is set equal to ``v`` (aliasing-safe).
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_in_0,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_out_0,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Unused for d=1; pass a
+            zero-size buffer or a dummy array.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    _ = scratch  # unused for d=1; kept for signature uniformity across d.
+    n_out_0 = out.shape[0]
+    if is_id_0:
+        for i in range(n_out_0):
+            out[i] = v[i]
+        return
+
+    n_in_0 = v.shape[0]
+    zero = M_0.dtype.type(0.0)
+    for i in range(n_out_0):
+        s = zero
+        for k in range(n_in_0):
+            s += M_0[i, k] * v[k]
+        out[i] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_2d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1) @ v`` via mode-wise contractions.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_in_0 * n_in_1,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_out_0 * n_out_1,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer of size at
+            least ``n_out_0 * n_in_1`` when neither direction is identity;
+            unused when any direction is identity.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+
+    if is_id_0 and is_id_1:
+        total = n_out_0 * n_out_1
+        for i in range(total):
+            out[i] = v[i]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    if is_id_0:
+        v_view = v.reshape(n_out_0, n_in_1)
+        out_view = out.reshape(n_out_0, n_out_1)
+        for i in range(n_out_0):
+            for j in range(n_out_1):
+                s = zero
+                for k in range(n_in_1):
+                    s += M_1[j, k] * v_view[i, k]
+                out_view[i, j] = s
+        return
+
+    if is_id_1:
+        v_view = v.reshape(n_in_0, n_out_1)
+        out_view = out.reshape(n_out_0, n_out_1)
+        for i in range(n_out_0):
+            for j in range(n_out_1):
+                s = zero
+                for k in range(n_in_0):
+                    s += M_0[i, k] * v_view[k, j]
+                out_view[i, j] = s
+        return
+
+    v_view = v.reshape(n_in_0, n_in_1)
+    s_view = scratch[: n_out_0 * n_in_1].reshape(n_out_0, n_in_1)
+    out_view = out.reshape(n_out_0, n_out_1)
+    for i in range(n_out_0):
+        for j in range(n_in_1):
+            s = zero
+            for k in range(n_in_0):
+                s += M_0[i, k] * v_view[k, j]
+            s_view[i, j] = s
+    for i in range(n_out_0):
+        for j in range(n_out_1):
+            s = zero
+            for k in range(n_in_1):
+                s += s_view[i, k] * M_1[j, k]
+            out_view[i, j] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_3d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    M_2: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    is_id_2: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1, M_2) @ v`` via mode-wise contractions.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        M_2 (npt.NDArray[np.float32 | np.float64]): Direction-2 operator,
+            shape ``(n_out_2, n_in_2)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        is_id_2 (bool): Identity flag for direction 2.
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_in_0 * n_in_1 * n_in_2,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_out_0 * n_out_1 * n_out_2,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer. Must be
+            sized per :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"apply"`` kind; pessimistic size is
+            ``2 * max(prod(input_shape), prod(output_shape))``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+    n_out_2 = M_2.shape[0]
+    n_in_2 = M_2.shape[1]
+
+    # Active axis sizes after each stage: identity directions pass through with
+    # n_in_k == n_out_k, so we use n_in_k for non-identity and n_out_k for
+    # identity (picking the value that is actually present along that axis).
+    d1_in = n_in_1 if not is_id_1 else n_out_1
+    d2_in = n_in_2 if not is_id_2 else n_out_2
+
+    zero = M_0.dtype.type(0.0)
+
+    if is_id_0 and is_id_1 and is_id_2:
+        total = n_out_0 * n_out_1 * n_out_2
+        for i in range(total):
+            out[i] = v[i]
+        return
+
+    # Ping-pong between two scratch halves. Each half sized at the pessimistic
+    # bound 2 * max_intermediate; we only ever need one "current" and one
+    # "next" intermediate buffer.
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    # Stage 0: v -> cur, applying M_0 on axis 0 if not identity.
+    # After stage 0, the tensor has shape (d0_cur, d1_in, d2_in) where
+    # d0_cur = n_out_0 if we contracted, else n_in_0 = n_out_0 (still the same).
+    # In both cases the output axis-0 size is n_out_0.
+    if is_id_0:
+        # No contraction; cur view is just v.
+        cur = v.reshape(n_out_0, d1_in, d2_in)
+    else:
+        v_view = v.reshape(n_in_0, d1_in, d2_in)
+        cur = buf_a[: n_out_0 * d1_in * d2_in].reshape(n_out_0, d1_in, d2_in)
+        for i in range(n_out_0):
+            for j in range(d1_in):
+                for k in range(d2_in):
+                    s = zero
+                    for m in range(n_in_0):
+                        s += M_0[i, m] * v_view[m, j, k]
+                    cur[i, j, k] = s
+
+    # Stage 1: apply M_1 on axis 1 if not identity; shape becomes
+    # (n_out_0, n_out_1, d2_in).
+    if is_id_1:
+        # Pass-through; cur shape already (n_out_0, n_out_1, d2_in).
+        pass
+    else:
+        nxt = buf_b[: n_out_0 * n_out_1 * d2_in].reshape(n_out_0, n_out_1, d2_in)
+        for i in range(n_out_0):
+            for j in range(n_out_1):
+                for k in range(d2_in):
+                    s = zero
+                    for m in range(n_in_1):
+                        s += M_1[j, m] * cur[i, m, k]
+                    nxt[i, j, k] = s
+        cur = nxt
+
+    # Stage 2: apply M_2 on axis 2 (write directly into out) if not identity;
+    # otherwise copy cur into out.
+    out_view = out.reshape(n_out_0, n_out_1, n_out_2)
+    if is_id_2:
+        for i in range(n_out_0):
+            for j in range(n_out_1):
+                for k in range(n_out_2):
+                    out_view[i, j, k] = cur[i, j, k]
+    else:
+        for i in range(n_out_0):
+            for j in range(n_out_1):
+                for k in range(n_out_2):
+                    s = zero
+                    for m in range(n_in_2):
+                        s += M_2[k, m] * cur[i, j, m]
+                    out_view[i, j, k] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_T_1d(
+    M_0: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = M_0^T @ v`` with identity short-circuit.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Operator, shape
+            ``(n_out_0, n_in_0)``.
+        is_id_0 (bool): If True, ``out`` is set equal to ``v``.
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_out_0,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_in_0,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Unused for d=1.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    _ = scratch  # unused for d=1; kept for signature uniformity across d.
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    if is_id_0:
+        for i in range(n_in_0):
+            out[i] = v[i]
+        return
+
+    zero = M_0.dtype.type(0.0)
+    for j in range(n_in_0):
+        s = zero
+        for k in range(n_out_0):
+            s += M_0[k, j] * v[k]
+        out[j] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_T_2d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1)^T @ v`` via mode-wise contractions.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_out_0 * n_out_1,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_in_0 * n_in_1,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer of size at
+            least ``n_in_0 * n_out_1`` when neither direction is identity.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+
+    if is_id_0 and is_id_1:
+        total = n_in_0 * n_in_1
+        for i in range(total):
+            out[i] = v[i]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    if is_id_0:
+        v_view = v.reshape(n_in_0, n_out_1)
+        out_view = out.reshape(n_in_0, n_in_1)
+        for i in range(n_in_0):
+            for j in range(n_in_1):
+                s = zero
+                for k in range(n_out_1):
+                    s += M_1[k, j] * v_view[i, k]
+                out_view[i, j] = s
+        return
+
+    if is_id_1:
+        v_view = v.reshape(n_out_0, n_in_1)
+        out_view = out.reshape(n_in_0, n_in_1)
+        for i in range(n_in_0):
+            for j in range(n_in_1):
+                s = zero
+                for k in range(n_out_0):
+                    s += M_0[k, i] * v_view[k, j]
+                out_view[i, j] = s
+        return
+
+    v_view = v.reshape(n_out_0, n_out_1)
+    s_view = scratch[: n_in_0 * n_out_1].reshape(n_in_0, n_out_1)
+    out_view = out.reshape(n_in_0, n_in_1)
+    for i in range(n_in_0):
+        for j in range(n_out_1):
+            s = zero
+            for k in range(n_out_0):
+                s += M_0[k, i] * v_view[k, j]
+            s_view[i, j] = s
+    for i in range(n_in_0):
+        for j in range(n_in_1):
+            s = zero
+            for k in range(n_out_1):
+                s += s_view[i, k] * M_1[k, j]
+            out_view[i, j] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_T_3d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    M_2: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    is_id_2: bool,
+    v: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1, M_2)^T @ v`` via mode-wise contractions.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        M_2 (npt.NDArray[np.float32 | np.float64]): Direction-2 operator,
+            shape ``(n_out_2, n_in_2)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        is_id_2 (bool): Identity flag for direction 2.
+        v (npt.NDArray[np.float32 | np.float64]): Input vector, shape
+            ``(n_out_0 * n_out_1 * n_out_2,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output vector, shape
+            ``(n_in_0 * n_in_1 * n_in_2,)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer; see
+            :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"apply_T"`` kind.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+    n_out_2 = M_2.shape[0]
+    n_in_2 = M_2.shape[1]
+
+    d1_out = n_out_1 if not is_id_1 else n_in_1
+    d2_out = n_out_2 if not is_id_2 else n_in_2
+
+    zero = M_0.dtype.type(0.0)
+
+    if is_id_0 and is_id_1 and is_id_2:
+        total = n_in_0 * n_in_1 * n_in_2
+        for i in range(total):
+            out[i] = v[i]
+        return
+
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    # Stage 0: apply M_0^T on axis 0. Axis-0 size becomes n_in_0 = n_out_0 for identity.
+    if is_id_0:
+        cur = v.reshape(n_in_0, d1_out, d2_out)
+    else:
+        v_view = v.reshape(n_out_0, d1_out, d2_out)
+        cur = buf_a[: n_in_0 * d1_out * d2_out].reshape(n_in_0, d1_out, d2_out)
+        for i in range(n_in_0):
+            for j in range(d1_out):
+                for k in range(d2_out):
+                    s = zero
+                    for m in range(n_out_0):
+                        s += M_0[m, i] * v_view[m, j, k]
+                    cur[i, j, k] = s
+
+    # Stage 1: apply M_1^T on axis 1.
+    if is_id_1:
+        pass
+    else:
+        nxt = buf_b[: n_in_0 * n_in_1 * d2_out].reshape(n_in_0, n_in_1, d2_out)
+        for i in range(n_in_0):
+            for j in range(n_in_1):
+                for k in range(d2_out):
+                    s = zero
+                    for m in range(n_out_1):
+                        s += M_1[m, j] * cur[i, m, k]
+                    nxt[i, j, k] = s
+        cur = nxt
+
+    # Stage 2: apply M_2^T on axis 2, write to out.
+    out_view = out.reshape(n_in_0, n_in_1, n_in_2)
+    if is_id_2:
+        for i in range(n_in_0):
+            for j in range(n_in_1):
+                for k in range(n_in_2):
+                    out_view[i, j, k] = cur[i, j, k]
+    else:
+        for i in range(n_in_0):
+            for j in range(n_in_1):
+                for k in range(n_in_2):
+                    s = zero
+                    for m in range(n_out_2):
+                        s += M_2[m, k] * cur[i, j, m]
+                    out_view[i, j, k] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_MT_K_M_1d(
+    M_0: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = M_0^T @ K @ M_0`` with identity short-circuit.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Operator, shape
+            ``(n_out_0, n_in_0)``.
+        is_id_0 (bool): If True, ``out`` is set equal to ``K``.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(n_out_0, n_out_0)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(n_in_0, n_in_0)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer of size at
+            least ``n_in_0 * n_out_0`` when not identity.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+
+    if is_id_0:
+        for i in range(n_out_0):
+            for j in range(n_out_0):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+    # Stage 1: tmp = M_0^T @ K, shape (n_in_0, n_out_0).
+    tmp = scratch[: n_in_0 * n_out_0].reshape(n_in_0, n_out_0)
+    for i in range(n_in_0):
+        for j in range(n_out_0):
+            s = zero
+            for k in range(n_out_0):
+                s += M_0[k, i] * K[k, j]
+            tmp[i, j] = s
+    # Stage 2: out = tmp @ M_0, shape (n_in_0, n_in_0).
+    for i in range(n_in_0):
+        for j in range(n_in_0):
+            s = zero
+            for k in range(n_out_0):
+                s += tmp[i, k] * M_0[k, j]
+            out[i, j] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_M_K_MT_1d(
+    M_0: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = M_0 @ K @ M_0^T`` with identity short-circuit.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Operator, shape
+            ``(n_out_0, n_in_0)``.
+        is_id_0 (bool): If True, ``out`` is set equal to ``K``.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(n_in_0, n_in_0)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(n_out_0, n_out_0)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer of size at
+            least ``n_out_0 * n_in_0`` when not identity.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+
+    if is_id_0:
+        for i in range(n_in_0):
+            for j in range(n_in_0):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+    tmp = scratch[: n_out_0 * n_in_0].reshape(n_out_0, n_in_0)
+    for i in range(n_out_0):
+        for j in range(n_in_0):
+            s = zero
+            for k in range(n_in_0):
+                s += M_0[i, k] * K[k, j]
+            tmp[i, j] = s
+    for i in range(n_out_0):
+        for j in range(n_out_0):
+            s = zero
+            for k in range(n_in_0):
+                s += tmp[i, k] * M_0[j, k]
+            out[i, j] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_MT_K_M_2d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1)^T @ K @ kron(M_0, M_1)``.
+
+    Uses mode-wise contractions: for each direction, apply ``M_k^T`` to the
+    corresponding row axis and ``M_k`` to the corresponding column axis of
+    the 4-axis reshape of K.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(n_out_0 * n_out_1, n_out_0 * n_out_1)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(n_in_0 * n_in_1, n_in_0 * n_in_1)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer sized per
+            :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"MT_K_M"`` kind.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+
+    if is_id_0 and is_id_1:
+        N_out = n_out_0 * n_out_1
+        for i in range(N_out):
+            for j in range(N_out):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    # Reshape K as 4D: (n_out_0, n_out_1, n_out_0, n_out_1).
+    K_view = K.reshape(n_out_0, n_out_1, n_out_0, n_out_1)
+
+    # Stage 0: apply M_0^T on axis 0. Shape -> (n_in_0, n_out_1, n_out_0, n_out_1).
+    d0 = n_in_0 if not is_id_0 else n_out_0
+    if is_id_0:
+        cur = K_view  # (n_out_0, n_out_1, n_out_0, n_out_1)
+    else:
+        cur = buf_a[: d0 * n_out_1 * n_out_0 * n_out_1].reshape(d0, n_out_1, n_out_0, n_out_1)
+        for i in range(d0):
+            for j in range(n_out_1):
+                for k in range(n_out_0):
+                    for m in range(n_out_1):
+                        s = zero
+                        for r in range(n_out_0):
+                            s += M_0[r, i] * K_view[r, j, k, m]
+                        cur[i, j, k, m] = s
+
+    # Stage 1: apply M_0 on axis 2 (the col-side counterpart of axis 0).
+    # Shape -> (d0, n_out_1, n_in_0, n_out_1).
+    if is_id_0:
+        pass
+    else:
+        nxt = buf_b[: d0 * n_out_1 * d0 * n_out_1].reshape(d0, n_out_1, d0, n_out_1)
+        for i in range(d0):
+            for j in range(n_out_1):
+                for k in range(d0):
+                    for m in range(n_out_1):
+                        s = zero
+                        for r in range(n_out_0):
+                            s += cur[i, j, r, m] * M_0[r, k]
+                        nxt[i, j, k, m] = s
+        cur = nxt
+
+    # Stage 2: apply M_1^T on axis 1. Shape -> (d0, n_in_1, d0, n_out_1).
+    d1 = n_in_1 if not is_id_1 else n_out_1
+    if is_id_1:
+        pass
+    else:
+        # Use buf_a as next (cur currently in buf_b if we did stage 1; else in K_view).
+        # Size needed: d0 * d1 * d0 * n_out_1.
+        nxt = buf_a[: d0 * d1 * d0 * n_out_1].reshape(d0, d1, d0, n_out_1)
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(n_out_1):
+                        s = zero
+                        for r in range(n_out_1):
+                            s += M_1[r, j] * cur[i, r, k, m]
+                        nxt[i, j, k, m] = s
+        cur = nxt
+
+    # Stage 3: apply M_1 on axis 3. Shape -> (d0, d1, d0, d1) = (n_in_0, n_in_1, n_in_0, n_in_1).
+    out_view = out.reshape(d0, d1, d0, d1)
+    if is_id_1:
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(d1):
+                        out_view[i, j, k, m] = cur[i, j, k, m]
+    else:
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(d1):
+                        s = zero
+                        for r in range(n_out_1):
+                            s += cur[i, j, k, r] * M_1[r, m]
+                        out_view[i, j, k, m] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_M_K_MT_2d(  # noqa: PLR0913, PLR0912 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1) @ K @ kron(M_0, M_1)^T``.
+
+    Mirror of :func:`apply_kron_MT_K_M_2d` with the roles of ``M_k`` and
+    ``M_k^T`` swapped.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(n_in_0 * n_in_1, n_in_0 * n_in_1)``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(n_out_0 * n_out_1, n_out_0 * n_out_1)``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer sized per
+            :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"M_K_MT"`` kind.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+
+    if is_id_0 and is_id_1:
+        N_in = n_in_0 * n_in_1
+        for i in range(N_in):
+            for j in range(N_in):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    K_view = K.reshape(n_in_0, n_in_1, n_in_0, n_in_1)
+
+    # Stage 0: apply M_0 on axis 0.
+    d0 = n_out_0 if not is_id_0 else n_in_0
+    if is_id_0:
+        cur = K_view
+    else:
+        cur = buf_a[: d0 * n_in_1 * n_in_0 * n_in_1].reshape(d0, n_in_1, n_in_0, n_in_1)
+        for i in range(d0):
+            for j in range(n_in_1):
+                for k in range(n_in_0):
+                    for m in range(n_in_1):
+                        s = zero
+                        for r in range(n_in_0):
+                            s += M_0[i, r] * K_view[r, j, k, m]
+                        cur[i, j, k, m] = s
+
+    # Stage 1: apply M_0^T on axis 2.
+    if is_id_0:
+        pass
+    else:
+        nxt = buf_b[: d0 * n_in_1 * d0 * n_in_1].reshape(d0, n_in_1, d0, n_in_1)
+        for i in range(d0):
+            for j in range(n_in_1):
+                for k in range(d0):
+                    for m in range(n_in_1):
+                        s = zero
+                        for r in range(n_in_0):
+                            s += cur[i, j, r, m] * M_0[k, r]
+                        nxt[i, j, k, m] = s
+        cur = nxt
+
+    # Stage 2: apply M_1 on axis 1.
+    d1 = n_out_1 if not is_id_1 else n_in_1
+    if is_id_1:
+        pass
+    else:
+        nxt = buf_a[: d0 * d1 * d0 * n_in_1].reshape(d0, d1, d0, n_in_1)
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(n_in_1):
+                        s = zero
+                        for r in range(n_in_1):
+                            s += M_1[j, r] * cur[i, r, k, m]
+                        nxt[i, j, k, m] = s
+        cur = nxt
+
+    # Stage 3: apply M_1^T on axis 3.
+    out_view = out.reshape(d0, d1, d0, d1)
+    if is_id_1:
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(d1):
+                        out_view[i, j, k, m] = cur[i, j, k, m]
+    else:
+        for i in range(d0):
+            for j in range(d1):
+                for k in range(d0):
+                    for m in range(d1):
+                        s = zero
+                        for r in range(n_in_1):
+                            s += cur[i, j, k, r] * M_1[m, r]
+                        out_view[i, j, k, m] = s
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_MT_K_M_3d(  # noqa: PLR0913, PLR0912, PLR0915 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    M_2: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    is_id_2: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1, M_2)^T @ K @ kron(M_0, M_1, M_2)``.
+
+    Uses mode-wise contractions in the 6-axis reshape of K.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        M_2 (npt.NDArray[np.float32 | np.float64]): Direction-2 operator,
+            shape ``(n_out_2, n_in_2)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        is_id_2 (bool): Identity flag for direction 2.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(N_out, N_out)`` with ``N_out = n_out_0 * n_out_1 * n_out_2``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(N_in, N_in)`` with ``N_in = n_in_0 * n_in_1 * n_in_2``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer sized per
+            :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"MT_K_M"`` kind.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+    n_out_2 = M_2.shape[0]
+    n_in_2 = M_2.shape[1]
+
+    if is_id_0 and is_id_1 and is_id_2:
+        N_out = n_out_0 * n_out_1 * n_out_2
+        for i in range(N_out):
+            for j in range(N_out):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    # Track current shape axes (row0, row1, row2, col0, col1, col2).
+    d0_r = n_out_0
+    d1_r = n_out_1
+    d2_r = n_out_2
+    d0_c = n_out_0
+    d1_c = n_out_1
+    d2_c = n_out_2
+
+    # cur starts as K reshaped into 6D.
+    # Ping-pong buffers: use buf_a and buf_b alternately.
+    # We'll track "cur" by reassigning after each stage.
+    cur = K.reshape(d0_r, d1_r, d2_r, d0_c, d1_c, d2_c)
+
+    # Stage: apply M_0^T on axis 0 (row side).
+    if not is_id_0:
+        d0_r = n_in_0
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_out_0):
+                                    s += M_0[r, i] * cur[r, j, k, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    # Stage: apply M_0 on axis 3 (col side).
+    if not is_id_0:
+        d0_c = n_in_0
+        nxt = buf_b[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_out_0):
+                                    s += cur[i, j, k, r, b, c] * M_0[r, a]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    # Stage: apply M_1^T on axis 1.
+    if not is_id_1:
+        d1_r = n_in_1
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_out_1):
+                                    s += M_1[r, j] * cur[i, r, k, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    # Stage: apply M_1 on axis 4.
+    if not is_id_1:
+        d1_c = n_in_1
+        nxt = buf_b[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_out_1):
+                                    s += cur[i, j, k, a, r, c] * M_1[r, b]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    # Stage: apply M_2^T on axis 2.
+    if not is_id_2:
+        d2_r = n_in_2
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_out_2):
+                                    s += M_2[r, k] * cur[i, j, r, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    # Stage: apply M_2 on axis 5, writing directly to out.
+    d2_c_final = n_in_2 if not is_id_2 else d2_c
+    out_view = out.reshape(d0_r, d1_r, d2_r, d0_c, d1_c, d2_c_final)
+    if not is_id_2:
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c_final):
+                                s = zero
+                                for r in range(n_out_2):
+                                    s += cur[i, j, k, a, b, r] * M_2[r, c]
+                                out_view[i, j, k, a, b, c] = s
+    else:
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c_final):
+                                out_view[i, j, k, a, b, c] = cur[i, j, k, a, b, c]
+
+
+@nb_jit(nopython=True, cache=True)
+def apply_kron_M_K_MT_3d(  # noqa: PLR0913, PLR0912, PLR0915 -- kernel fan-in and identity branching are intentional.
+    M_0: npt.NDArray[np.float32 | np.float64],
+    M_1: npt.NDArray[np.float32 | np.float64],
+    M_2: npt.NDArray[np.float32 | np.float64],
+    is_id_0: bool,
+    is_id_1: bool,
+    is_id_2: bool,
+    K: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+    scratch: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Compute ``out = kron(M_0, M_1, M_2) @ K @ kron(M_0, M_1, M_2)^T``.
+
+    Mirror of :func:`apply_kron_MT_K_M_3d` with the roles of ``M_k`` and
+    ``M_k^T`` swapped.
+
+    Args:
+        M_0 (npt.NDArray[np.float32 | np.float64]): Direction-0 operator,
+            shape ``(n_out_0, n_in_0)``.
+        M_1 (npt.NDArray[np.float32 | np.float64]): Direction-1 operator,
+            shape ``(n_out_1, n_in_1)``.
+        M_2 (npt.NDArray[np.float32 | np.float64]): Direction-2 operator,
+            shape ``(n_out_2, n_in_2)``.
+        is_id_0 (bool): Identity flag for direction 0.
+        is_id_1 (bool): Identity flag for direction 1.
+        is_id_2 (bool): Identity flag for direction 2.
+        K (npt.NDArray[np.float32 | np.float64]): Input matrix, shape
+            ``(N_in, N_in)`` with ``N_in = n_in_0 * n_in_1 * n_in_2``.
+        out (npt.NDArray[np.float32 | np.float64]): Output matrix, shape
+            ``(N_out, N_out)`` with ``N_out = n_out_0 * n_out_1 * n_out_2``.
+        scratch (npt.NDArray[np.float32 | np.float64]): Work buffer sized per
+            :func:`pantr.bspline._extraction_helpers._required_scratch_size`
+            for the ``"M_K_MT"`` kind.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out`` must not alias ``K`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    n_out_0 = M_0.shape[0]
+    n_in_0 = M_0.shape[1]
+    n_out_1 = M_1.shape[0]
+    n_in_1 = M_1.shape[1]
+    n_out_2 = M_2.shape[0]
+    n_in_2 = M_2.shape[1]
+
+    if is_id_0 and is_id_1 and is_id_2:
+        N_in = n_in_0 * n_in_1 * n_in_2
+        for i in range(N_in):
+            for j in range(N_in):
+                out[i, j] = K[i, j]
+        return
+
+    zero = M_0.dtype.type(0.0)
+
+    half = scratch.size // 2
+    buf_a = scratch[:half]
+    buf_b = scratch[half:]
+
+    d0_r = n_in_0
+    d1_r = n_in_1
+    d2_r = n_in_2
+    d0_c = n_in_0
+    d1_c = n_in_1
+    d2_c = n_in_2
+
+    cur = K.reshape(d0_r, d1_r, d2_r, d0_c, d1_c, d2_c)
+
+    if not is_id_0:
+        d0_r = n_out_0
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_in_0):
+                                    s += M_0[i, r] * cur[r, j, k, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    if not is_id_0:
+        d0_c = n_out_0
+        nxt = buf_b[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_in_0):
+                                    s += cur[i, j, k, r, b, c] * M_0[a, r]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    if not is_id_1:
+        d1_r = n_out_1
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_in_1):
+                                    s += M_1[j, r] * cur[i, r, k, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    if not is_id_1:
+        d1_c = n_out_1
+        nxt = buf_b[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_in_1):
+                                    s += cur[i, j, k, a, r, c] * M_1[b, r]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    if not is_id_2:
+        d2_r = n_out_2
+        nxt = buf_a[: d0_r * d1_r * d2_r * d0_c * d1_c * d2_c].reshape(
+            d0_r, d1_r, d2_r, d0_c, d1_c, d2_c
+        )
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c):
+                                s = zero
+                                for r in range(n_in_2):
+                                    s += M_2[k, r] * cur[i, j, r, a, b, c]
+                                nxt[i, j, k, a, b, c] = s
+        cur = nxt
+
+    d2_c_final = n_out_2 if not is_id_2 else d2_c
+    out_view = out.reshape(d0_r, d1_r, d2_r, d0_c, d1_c, d2_c_final)
+    if not is_id_2:
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c_final):
+                                s = zero
+                                for r in range(n_in_2):
+                                    s += cur[i, j, k, a, b, r] * M_2[c, r]
+                                out_view[i, j, k, a, b, c] = s
+    else:
+        for i in range(d0_r):
+            for j in range(d1_r):
+                for k in range(d2_r):
+                    for a in range(d0_c):
+                        for b in range(d1_c):
+                            for c in range(d2_c_final):
+                                out_view[i, j, k, a, b, c] = cur[i, j, k, a, b, c]
+
+
+__all__ = [
+    "apply_kron_1d",
+    "apply_kron_2d",
+    "apply_kron_3d",
+    "apply_kron_MT_K_M_1d",
+    "apply_kron_MT_K_M_2d",
+    "apply_kron_MT_K_M_3d",
+    "apply_kron_M_K_MT_1d",
+    "apply_kron_M_K_MT_2d",
+    "apply_kron_M_K_MT_3d",
+    "apply_kron_T_1d",
+    "apply_kron_T_2d",
+    "apply_kron_T_3d",
+]

--- a/tests/test_extraction_kernels.py
+++ b/tests/test_extraction_kernels.py
@@ -1,0 +1,352 @@
+"""Correctness and validation tests for the extraction kernels and helpers."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline._extraction_helpers import (
+    OpKind,
+    _allocate_or_validate_scratch,
+    _apply_scratch_size,
+    _bilateral_scratch_size,
+    _dispatch_apply,
+    _operation_shapes,
+    _prepare_apply_call,
+    _required_scratch_size,
+    _validate_op_kind,
+)
+from pantr.bspline._extraction_kernels import (
+    apply_kron_1d,
+    apply_kron_2d,
+    apply_kron_3d,
+    apply_kron_M_K_MT_1d,
+    apply_kron_M_K_MT_2d,
+    apply_kron_M_K_MT_3d,
+    apply_kron_MT_K_M_1d,
+    apply_kron_MT_K_M_2d,
+    apply_kron_MT_K_M_3d,
+    apply_kron_T_1d,
+    apply_kron_T_2d,
+    apply_kron_T_3d,
+)
+
+RNG = np.random.default_rng(12345)
+
+
+def _make_ops(
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+    identity: tuple[bool, ...],
+    dtype: np.dtype[Any],
+) -> list[npt.NDArray[Any]]:
+    """Build per-direction 2D operators, using identity for flagged directions."""
+    ops: list[npt.NDArray[Any]] = []
+    for n_in, n_out, is_id in zip(in_shape, out_shape, identity, strict=True):
+        if is_id:
+            assert n_in == n_out, "identity direction requires n_in == n_out"
+            ops.append(np.eye(n_in, dtype=dtype))
+        else:
+            ops.append(RNG.standard_normal((n_out, n_in)).astype(dtype))
+    return ops
+
+
+def _full_kron(ops: list[npt.NDArray[Any]]) -> npt.NDArray[Any]:
+    """Assemble the full Kronecker product from per-direction operators."""
+    result = ops[0]
+    for M in ops[1:]:
+        result = np.kron(result, M)
+    return result
+
+
+def _reference(
+    ops: list[npt.NDArray[Any]],
+    operand: npt.NDArray[Any],
+    op_kind: str,
+) -> npt.NDArray[Any]:
+    """Naive reference using the materialized Kronecker product."""
+    M = _full_kron(ops)
+    if op_kind == "apply":
+        return cast(npt.NDArray[Any], M @ operand)
+    if op_kind == "apply_T":
+        return cast(npt.NDArray[Any], M.T @ operand)
+    if op_kind == "MT_K_M":
+        return cast(npt.NDArray[Any], M.T @ operand @ M)
+    if op_kind == "M_K_MT":
+        return cast(npt.NDArray[Any], M @ operand @ M.T)
+    raise ValueError(f"unknown op_kind {op_kind}")
+
+
+def _identity_patterns(d: int) -> list[tuple[bool, ...]]:
+    """Enumerate all 2^d identity-flag combinations for dimension d."""
+    return list(itertools.product([False, True], repeat=d))
+
+
+# -- Shape configurations ------------------------------------------------------
+
+# Triples (d, in_shape, out_shape). For identity directions n_in == n_out is
+# required, so we use configurations where at least the "square" axes have
+# matching sizes; the test harness picks identity flags accordingly.
+SHAPE_CONFIGS_SQUARE: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = [
+    (1, (3,), (3,)),
+    (1, (5,), (5,)),
+    (2, (3, 4), (3, 4)),
+    (2, (4, 2), (4, 2)),
+    (3, (3, 4, 2), (3, 4, 2)),
+    (3, (2, 3, 4), (2, 3, 4)),
+]
+
+SHAPE_CONFIGS_NONSQUARE: list[tuple[int, tuple[int, ...], tuple[int, ...]]] = [
+    (1, (3,), (5,)),
+    (1, (5,), (2,)),
+    (2, (2, 3), (4, 2)),
+    (2, (3, 4), (2, 5)),
+    (3, (2, 3, 4), (3, 2, 5)),
+    (3, (4, 2, 3), (2, 4, 2)),
+]
+
+
+# -- Correctness tests for square operators (identity patterns) ---------------
+
+
+@pytest.mark.parametrize(("d", "in_shape", "out_shape"), SHAPE_CONFIGS_SQUARE)
+@pytest.mark.parametrize("op_kind", ["apply", "apply_T", "MT_K_M", "M_K_MT"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_kernels_square_all_identity_patterns(
+    d: int,
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+    op_kind: OpKind,
+    dtype: np.dtype[Any],
+) -> None:
+    """Each kernel matches the naive Kronecker reference for every identity pattern."""
+    tol = 5e-5 if dtype == np.float32 else 1e-10
+    for identity in _identity_patterns(d):
+        ops = _make_ops(in_shape, out_shape, identity, np.dtype(dtype))
+        in_op_shape, _out_op_shape = _operation_shapes(in_shape, out_shape, op_kind)
+        operand = RNG.standard_normal(in_op_shape).astype(dtype)
+        expected = _reference(ops, operand, op_kind)
+
+        kernel, args, out = _prepare_apply_call(tuple(ops), identity, operand, None, None, op_kind)
+        kernel(*args)
+        np.testing.assert_allclose(out, expected, atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize(("d", "in_shape", "out_shape"), SHAPE_CONFIGS_NONSQUARE)
+@pytest.mark.parametrize("op_kind", ["apply", "apply_T", "MT_K_M", "M_K_MT"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_kernels_nonsquare(
+    d: int,
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+    op_kind: OpKind,
+    dtype: np.dtype[Any],
+) -> None:
+    """Non-square per-direction operators produce correct results (no identity)."""
+    tol = 5e-5 if dtype == np.float32 else 1e-10
+    identity = tuple([False] * d)
+    ops = _make_ops(in_shape, out_shape, identity, np.dtype(dtype))
+    in_op_shape, _ = _operation_shapes(in_shape, out_shape, op_kind)
+    operand = RNG.standard_normal(in_op_shape).astype(dtype)
+    expected = _reference(ops, operand, op_kind)
+
+    kernel, args, out = _prepare_apply_call(tuple(ops), identity, operand, None, None, op_kind)
+    kernel(*args)
+    np.testing.assert_allclose(out, expected, atol=tol, rtol=tol)
+
+
+# -- All-identity aliasing tests ----------------------------------------------
+
+
+@pytest.mark.parametrize(("d", "in_shape", "out_shape"), SHAPE_CONFIGS_SQUARE[:3])
+def test_all_identity_apply_aliasing(
+    d: int,
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+) -> None:
+    """``apply`` / ``apply_T`` are copy-through in the all-identity case; out=v is legal."""
+    identity = tuple([True] * d)
+    ops = _make_ops(in_shape, out_shape, identity, np.dtype(np.float64))
+    for op_kind in ("apply", "apply_T"):
+        in_shape_op, _ = _operation_shapes(in_shape, out_shape, op_kind)
+        v = RNG.standard_normal(in_shape_op).astype(np.float64)
+        v_copy = v.copy()
+        # Pass v itself as `out`: in the all-identity case this should be a
+        # self-copy (no-op for the values), and v remains unchanged.
+        kernel, args, out = _prepare_apply_call(tuple(ops), identity, v, v, None, op_kind)
+        assert out is v
+        kernel(*args)
+        np.testing.assert_array_equal(v, v_copy)
+
+
+@pytest.mark.parametrize(("d", "in_shape", "out_shape"), SHAPE_CONFIGS_SQUARE[:3])
+def test_all_identity_bilateral_aliasing(
+    d: int,
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
+) -> None:
+    """``MT_K_M`` / ``M_K_MT`` are copy-through in the all-identity case; out=K is legal."""
+    identity = tuple([True] * d)
+    ops = _make_ops(in_shape, out_shape, identity, np.dtype(np.float64))
+    for op_kind in ("MT_K_M", "M_K_MT"):
+        in_shape_op, _ = _operation_shapes(in_shape, out_shape, op_kind)
+        K = RNG.standard_normal(in_shape_op).astype(np.float64)
+        K_copy = K.copy()
+        kernel, args, out = _prepare_apply_call(tuple(ops), identity, K, K, None, op_kind)
+        assert out is K
+        kernel(*args)
+        np.testing.assert_array_equal(K, K_copy)
+
+
+# -- Dispatcher errors --------------------------------------------------------
+
+
+def test_dispatch_d_too_large_raises() -> None:
+    with pytest.raises(NotImplementedError, match=r"d in \{1, 2, 3\}"):
+        _dispatch_apply(4, "apply")
+
+
+def test_dispatch_d_too_small_raises() -> None:
+    with pytest.raises(NotImplementedError, match=r"d in \{1, 2, 3\}"):
+        _dispatch_apply(0, "apply")
+
+
+def test_dispatch_unknown_op_kind_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown op_kind"):
+        _dispatch_apply(2, "banana")  # type: ignore[arg-type]
+
+
+def test_dispatch_returns_expected_kernels() -> None:
+    """Dispatcher maps (op_kind, d) to the right module-level kernel."""
+    expected: dict[tuple[str, int], object] = {
+        ("apply", 1): apply_kron_1d,
+        ("apply", 2): apply_kron_2d,
+        ("apply", 3): apply_kron_3d,
+        ("apply_T", 1): apply_kron_T_1d,
+        ("apply_T", 2): apply_kron_T_2d,
+        ("apply_T", 3): apply_kron_T_3d,
+        ("MT_K_M", 1): apply_kron_MT_K_M_1d,
+        ("MT_K_M", 2): apply_kron_MT_K_M_2d,
+        ("MT_K_M", 3): apply_kron_MT_K_M_3d,
+        ("M_K_MT", 1): apply_kron_M_K_MT_1d,
+        ("M_K_MT", 2): apply_kron_M_K_MT_2d,
+        ("M_K_MT", 3): apply_kron_M_K_MT_3d,
+    }
+    for (op_kind, d), kernel in expected.items():
+        assert _dispatch_apply(d, op_kind) is kernel  # type: ignore[arg-type]
+
+
+# -- Validation errors --------------------------------------------------------
+
+
+def test_validate_op_kind_accepts_known() -> None:
+    for k in ("apply", "apply_T", "MT_K_M", "M_K_MT"):
+        assert _validate_op_kind(k) == k
+
+
+def test_validate_op_kind_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown op_kind"):
+        _validate_op_kind("nope")
+
+
+def test_required_scratch_size_mismatched_shapes_raises() -> None:
+    with pytest.raises(ValueError, match="must have the same length"):
+        _required_scratch_size((2, 3), (2,), "apply")
+
+
+def test_operand_wrong_shape_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    bad = RNG.standard_normal(20).astype(np.float64)
+    with pytest.raises(ValueError, match="expected shape"):
+        _prepare_apply_call(tuple(ops), (False, False), bad, None, None, "apply")
+
+
+def test_operand_wrong_dtype_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    bad = RNG.standard_normal(12).astype(np.float32)
+    with pytest.raises(ValueError, match="expected dtype"):
+        _prepare_apply_call(tuple(ops), (False, False), bad, None, None, "apply")
+
+
+def test_out_wrong_shape_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    v = RNG.standard_normal(12).astype(np.float64)
+    bad_out = np.empty(11, dtype=np.float64)
+    with pytest.raises(ValueError, match="expected shape"):
+        _prepare_apply_call(tuple(ops), (False, False), v, bad_out, None, "apply")
+
+
+def test_out_not_writable_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    v = RNG.standard_normal(12).astype(np.float64)
+    bad_out = np.empty(12, dtype=np.float64)
+    bad_out.flags.writeable = False
+    with pytest.raises(ValueError, match="writeable"):
+        _prepare_apply_call(tuple(ops), (False, False), v, bad_out, None, "apply")
+
+
+def test_scratch_too_small_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    v = RNG.standard_normal(12).astype(np.float64)
+    bad_scratch = np.empty(1, dtype=np.float64)
+    with pytest.raises(ValueError, match="smaller than required"):
+        _prepare_apply_call(tuple(ops), (False, False), v, None, bad_scratch, "apply")
+
+
+def test_scratch_wrong_ndim_raises() -> None:
+    with pytest.raises(ValueError, match="1D"):
+        _allocate_or_validate_scratch(np.empty((3, 3), dtype=np.float64), 4, np.float64)
+
+
+def test_scratch_wrong_dtype_raises() -> None:
+    with pytest.raises(ValueError, match="expected dtype"):
+        _allocate_or_validate_scratch(np.empty(16, dtype=np.float32), 4, np.float64)
+
+
+def test_ops_ndim_raises() -> None:
+    bad_op = np.eye(3)[np.newaxis]  # 3D instead of 2D
+    v = RNG.standard_normal(3).astype(np.float64)
+    with pytest.raises(ValueError, match="must be 2D"):
+        _prepare_apply_call((bad_op,), (False,), v, None, None, "apply")
+
+
+def test_ops_dtype_mismatch_raises() -> None:
+    ops: tuple[npt.NDArray[Any], ...] = (
+        np.eye(3, dtype=np.float64),
+        np.eye(4, dtype=np.float32),
+    )
+    v = RNG.standard_normal(12).astype(np.float64)
+    with pytest.raises(ValueError, match="dtype"):
+        _prepare_apply_call(ops, (False, False), v, None, None, "apply")
+
+
+def test_identity_length_mismatch_raises() -> None:
+    ops = _make_ops((3, 4), (3, 4), (False, False), np.dtype(np.float64))
+    v = RNG.standard_normal(12).astype(np.float64)
+    with pytest.raises(ValueError, match="length"):
+        _prepare_apply_call(tuple(ops), (False,), v, None, None, "apply")
+
+
+# -- Scratch size sanity -------------------------------------------------------
+
+
+def test_required_scratch_size_apply_d1_is_zero() -> None:
+    assert _required_scratch_size((5,), (3,), "apply") == 0
+    assert _required_scratch_size((5,), (3,), "apply_T") == 0
+
+
+def test_apply_scratch_size_d2_matches_kernel_usage() -> None:
+    n_in, n_out = (3, 4), (5, 6)
+    assert _apply_scratch_size(n_in, n_out) == 2 * (n_out[0] * n_in[1])
+    # apply_T: starts at n_out, ends at n_in -- intermediate size n_in[0] * n_out[1].
+    assert _apply_scratch_size(n_out, n_in) == 2 * (n_in[0] * n_out[1])
+
+
+def test_bilateral_scratch_size_d1_matches_kernel_usage() -> None:
+    # Stage 0 intermediate (only intermediate) is n_in * n_out.
+    assert _bilateral_scratch_size((5,), (3,)) == 2 * (5 * 3)
+    assert _bilateral_scratch_size((3,), (5,)) == 2 * (3 * 5)


### PR DESCRIPTION
## Summary

- First PR of the `SpanwiseElementExtraction` plan: the Layer-3 primitives that the forthcoming class will wrap and that downstream libraries (e.g. the planned FEniCSx bridge) can call directly from their own `@njit` code.
- Adds twelve `@njit(cache=True)` module-level kernels applying tensor-product operators `M = kron(M_0, ..., M_{d-1})` — specialized for `d ∈ {1, 2, 3}` — across four operations: `M v`, `M^T v`, `M^T K M`, `M K M^T`.
- Per-direction identity flags short-circuit the mode-contractions that would otherwise apply the identity matrix; the all-identity case resolves to a direct copy and is aliasing-safe.
- Non-square per-direction operators (`M_k: (n_out_k, n_in_k)` with `n_in_k != n_out_k`) are supported.
- Layer-2 module validates shapes/dtypes/writability, allocates or validates `out` / `scratch` buffers with a tight stage-simulation scratch size, and dispatches to the right kernel. `d > 3` raises `NotImplementedError` with a pointer to the kernels module for future extension.

## Downstream Numba-callability

The kernels are plain module-level functions with no optional arguments and plain NumPy-array inputs, so callers can import and call them directly from inside their own `@njit` loops:

```python
from pantr.bspline._extraction_kernels import apply_kron_MT_K_M_3d

@njit(cache=True, parallel=True)
def assemble(ops_0, ops_1, ops_2, is_id_0, is_id_1, is_id_2, K_stack, out_stack, scratch_pool):
    for c in prange(n_cells):
        ...
        apply_kron_MT_K_M_3d(
            ops_0[c0], ops_1[c1], ops_2[c2],
            is_id_0[c0], is_id_1[c1], is_id_2[c2],
            K_stack[c], out_stack[c], scratch_pool[tid],
        )
```

## What is deliberately deferred

- The public `SpanwiseElementExtraction` class, target dispatch (bezier / lagrange / cardinal), and structural identity detection via `get_cardinal_intervals` — PR 2.
- Reducing `_bspline_to_beziers` to a thin forwarder through the new class — PR 3.
- Batched `_many` variants that `prange` over cell lists — PR 4.
- User guide docs — PR 5.

## Test plan

- [x] `pytest tests/test_extraction_kernels.py --no-cov -v` — 122 tests green, covering every `(d, op_kind, identity-pattern, dtype)` combination against a naive `np.kron`-assembled reference, aliasing short-circuit, dispatcher errors, and Layer-2 validation paths.
- [x] Full suite `pytest --no-cov` — 2333 passed, no regressions.
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] `mypy --config-file mypy.ini src tests` (`strict = True`) clean.
- [x] `sphinx-build -W --keep-going` green.

Generated with [Claude Code](https://claude.com/claude-code)