### PR TITLE
feat(extraction): add SpanwiseElementExtraction class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,11 +144,15 @@ release = pantr.__version__
 nitpicky = True
 
 # Private NumPy typing internals are not exposed in the public inventory.
+# CellIndex and Target are Literal/Union type aliases; Sphinx resolves them as
+# py:class but they have no class inventory entry.
 nitpick_ignore = [
     ("py:class", "numpy._typing._array_like._SupportsArray"),
     ("py:class", "numpy._typing._dtype_like._DTypeDict"),
     ("py:class", "numpy._typing._dtype_like._SupportsDType"),
     ("py:class", "numpy._typing._nested_sequence._NestedSequence"),
+    ("py:class", "CellIndex"),
+    ("py:class", "Target"),
 ]
 
 # Short-form NumPy aliases used in type annotations (np.*, npt.*, numpy.*)

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -13,6 +13,8 @@ This package consolidates the B-spline API:
 - :func:`interpolate_bspline`, :func:`fit_bspline`,
   :func:`l2_project_bspline`: approximation functions.
 - :func:`create_from_bezier`: create a B-spline from a Bézier.
+- :class:`SpanwiseElementExtraction`: lazy tensor-product change-of-basis
+  operator across B-spline elements (Bézier/Lagrange/cardinal targets).
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -27,11 +29,13 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace
+from .spanwise_element_extraction import SpanwiseElementExtraction
 
 __all__ = [
     "Bspline",
     "BsplineSpace",
     "BsplineSpace1D",
+    "SpanwiseElementExtraction",
     "create_cardinal_knots",
     "create_from_bezier",
     "create_greville_lattice",

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -1,0 +1,643 @@
+"""Tensor-product change-of-basis extraction across B-spline elements.
+
+This module exposes :class:`SpanwiseElementExtraction`, a lazy tensor-product
+change-of-basis object. It eagerly caches the per-direction 1D extraction
+operators once at construction time and, on demand, dispatches to the Layer-3
+Kronecker kernels in :mod:`pantr.bspline._extraction_kernels` to apply the
+d-dimensional operator for a single element.
+
+Three targets are supported (the source basis is always the B-spline basis):
+
+- ``"bezier"``:   Bernstein (Bézier) basis on each element.
+- ``"lagrange"``: Lagrange basis on each element, at the chosen point
+  distribution (see :class:`pantr.basis.LagrangeVariant`).
+- ``"cardinal"``: cardinal B-spline basis on each element.
+
+Identity short-circuit is used wherever possible: for ``"cardinal"`` the
+structural mask from :meth:`BsplineSpace1D.get_cardinal_intervals` labels every
+interval as identity or not; for ``"bezier"`` and ``"lagrange"`` a per-element
+numerical test ``|C - I|_max < tol`` marks trivial elements (for instance, a
+C0 Bezier space has identity Bezier extraction everywhere).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Literal, get_args
+
+import numpy as np
+import numpy.typing as npt
+
+from ..basis import LagrangeVariant
+from ..basis._basis_utils import _allocate_or_validate_out
+from ._extraction_helpers import OpKind, _operation_shapes, _prepare_apply_call
+
+if TYPE_CHECKING:
+    from ._bspline_space_nd import BsplineSpace
+
+
+Target = Literal["bezier", "lagrange", "cardinal"]
+"""Supported target bases for spanwise element extraction."""
+
+
+CellIndex = int | tuple[int, ...] | list[int] | npt.NDArray[np.int_]
+"""Accepted cell-index forms: flat ``int``, or a per-direction integer sequence."""
+
+
+class SpanwiseElementExtraction:
+    """Tensor-product change-of-basis operator across B-spline elements.
+
+    For a :class:`BsplineSpace` of dimension ``d`` and a chosen ``target``
+    basis, this class eagerly builds the per-direction 1D extraction operator
+    arrays ``ops_1d[k]`` of shape ``(n_elements_k, n_out_k, n_in_k)``. Per-
+    element d-dimensional operators are never materialized unless explicitly
+    requested via :meth:`operator` or :meth:`tabulate`: instead the apply-style
+    methods dispatch to the matrix-free Kronecker kernels in
+    :mod:`pantr.bspline._extraction_kernels`.
+
+    With the current 1D builders all per-direction operators are square of
+    size ``(degree_k + 1, degree_k + 1)``. The class also supports non-square
+    per-direction operators, so new 1D builders can plug in without changes.
+
+    The per-direction data is also exposed as tuples of NumPy arrays
+    (:attr:`ops_1d`, :attr:`is_identity_mask_1d`) so that downstream Numba
+    code can consume the raw arrays and call the Layer-3 kernels directly.
+
+    Attributes:
+        _space (BsplineSpace): Underlying multi-dimensional B-spline space.
+        _target (Target): Target basis tag.
+        _lagrange_variant (LagrangeVariant): Point distribution used when
+            ``target == "lagrange"``; ignored otherwise.
+        _identity_tol (float): Numerical tolerance used for identity
+            detection on ``"bezier"`` and ``"lagrange"`` targets.
+        _ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]):
+            Per-direction 3D operator arrays of shape
+            ``(n_elements_k, n_out_k, n_in_k)``.
+        _is_identity_mask_1d (tuple[npt.NDArray[np.bool_], ...]): Per-direction
+            identity masks of shape ``(n_elements_k,)``.
+    """
+
+    _space: BsplineSpace
+    _target: Target
+    _lagrange_variant: LagrangeVariant
+    _identity_tol: float
+    _ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...]
+    _is_identity_mask_1d: tuple[npt.NDArray[np.bool_], ...]
+
+    def __init__(
+        self,
+        space: BsplineSpace,
+        target: Target,
+        *,
+        lagrange_variant: LagrangeVariant = LagrangeVariant.EQUISPACES,
+        identity_tol: float | None = None,
+    ) -> None:
+        """Build the per-direction operators and identity masks.
+
+        Args:
+            space (BsplineSpace): Multi-dimensional B-spline space.
+            target (Target): One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+            lagrange_variant (LagrangeVariant): Point distribution used when
+                ``target == "lagrange"``. Defaults to
+                :attr:`LagrangeVariant.EQUISPACES`.
+            identity_tol (float | None): Absolute tolerance for numerical
+                identity detection on ``"bezier"`` and ``"lagrange"`` targets.
+                If ``None``, uses :attr:`BsplineSpace.tolerance`.
+
+        Raises:
+            ValueError: If ``target`` is not a recognized tag.
+            NotImplementedError: If any direction of ``space`` is periodic;
+                periodic support is deferred to a later version.
+        """
+        if target not in get_args(Target):
+            valid = ", ".join(repr(v) for v in get_args(Target))
+            raise ValueError(f"Unknown target {target!r}; expected one of {valid}")
+
+        if any(s.periodic for s in space.spaces):
+            raise NotImplementedError(
+                "SpanwiseElementExtraction does not yet support periodic directions. "
+                "Convert the B-spline to open form first (see Bspline.to_open_bspline)."
+            )
+
+        self._space = space
+        self._target = target
+        self._lagrange_variant = lagrange_variant
+        self._identity_tol = float(space.tolerance) if identity_tol is None else float(identity_tol)
+
+        ops_1d: list[npt.NDArray[np.float32 | np.float64]] = []
+        masks_1d: list[npt.NDArray[np.bool_]] = []
+        for space_1d in space.spaces:
+            if target == "bezier":
+                ops = space_1d.tabulate_Bezier_extraction_operators()
+                mask = _numerical_identity_mask(ops, self._identity_tol)
+            elif target == "lagrange":
+                ops = space_1d.tabulate_Lagrange_extraction_operators(
+                    lagrange_variant=lagrange_variant
+                )
+                mask = _numerical_identity_mask(ops, self._identity_tol)
+            else:  # target == "cardinal"
+                ops = space_1d.tabulate_cardinal_extraction_operators()
+                mask = space_1d.get_cardinal_intervals()
+            ops.flags.writeable = False
+            mask.flags.writeable = False
+            ops_1d.append(ops)
+            masks_1d.append(mask)
+
+        self._ops_1d = tuple(ops_1d)
+        self._is_identity_mask_1d = tuple(masks_1d)
+
+    # ---------------------------------------------------------------- properties
+
+    @property
+    def space(self) -> BsplineSpace:
+        """Get the underlying B-spline space.
+
+        Returns:
+            BsplineSpace: The space supplied at construction time.
+        """
+        return self._space
+
+    @property
+    def target(self) -> Target:
+        """Get the target basis tag.
+
+        Returns:
+            Target: One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+        """
+        return self._target
+
+    @property
+    def lagrange_variant(self) -> LagrangeVariant:
+        """Get the Lagrange point distribution used for ``"lagrange"`` target.
+
+        Returns:
+            LagrangeVariant: The point distribution. Meaningless for other targets.
+        """
+        return self._lagrange_variant
+
+    @property
+    def identity_tol(self) -> float:
+        """Get the tolerance used for numerical identity detection.
+
+        Returns:
+            float: The absolute tolerance.
+        """
+        return self._identity_tol
+
+    @property
+    def dim(self) -> int:
+        """Get the number of tensor-product directions.
+
+        Returns:
+            int: The dimension ``d`` of the space.
+        """
+        return self._space.dim
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the floating-point dtype shared by all operators.
+
+        Returns:
+            npt.DTypeLike: The dtype inherited from the space (``float32`` or ``float64``).
+        """
+        return self._space.dtype
+
+    @property
+    def num_intervals(self) -> tuple[int, ...]:
+        """Get the per-direction number of elements (intervals).
+
+        Returns:
+            tuple[int, ...]: Length-``d`` tuple ``(n_elements_0, …, n_elements_{d-1})``.
+        """
+        return self._space.num_intervals
+
+    @property
+    def num_total_intervals(self) -> int:
+        """Get the total number of elements across the tensor-product grid.
+
+        Returns:
+            int: ``prod(num_intervals)``.
+        """
+        return self._space.num_total_intervals
+
+    @property
+    def ops_1d(self) -> tuple[npt.NDArray[np.float32 | np.float64], ...]:
+        """Get the per-direction 1D operator arrays.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ...]: Length-``d`` tuple
+            of read-only 3D arrays; ``ops_1d[k]`` has shape
+            ``(n_elements_k, n_out_k, n_in_k)``. Intended for consumption by
+            downstream ``@njit`` code.
+        """
+        return self._ops_1d
+
+    @property
+    def is_identity_mask_1d(self) -> tuple[npt.NDArray[np.bool_], ...]:
+        """Get the per-direction identity masks.
+
+        Returns:
+            tuple[npt.NDArray[np.bool_], ...]: Length-``d`` tuple of read-only
+            1D boolean arrays; ``is_identity_mask_1d[k][i]`` is ``True`` iff
+            the ``i``-th element in direction ``k`` has an identity operator.
+        """
+        return self._is_identity_mask_1d
+
+    @property
+    def input_shape_per_dir(self) -> tuple[int, ...]:
+        """Get the per-direction input sizes of each element's operator.
+
+        Returns:
+            tuple[int, ...]: ``(n_in_0, …, n_in_{d-1})``.
+        """
+        return tuple(int(ops.shape[2]) for ops in self._ops_1d)
+
+    @property
+    def output_shape_per_dir(self) -> tuple[int, ...]:
+        """Get the per-direction output sizes of each element's operator.
+
+        Returns:
+            tuple[int, ...]: ``(n_out_0, …, n_out_{d-1})``.
+        """
+        return tuple(int(ops.shape[1]) for ops in self._ops_1d)
+
+    # ---------------------------------------------------------------- identity queries
+
+    def is_identity_at(self, cell_idx: CellIndex) -> bool:
+        """Check whether the per-element operator is identity along every direction.
+
+        Args:
+            cell_idx (CellIndex): Element index (flat or per-direction).
+
+        Returns:
+            bool: ``True`` iff the ``d``-dimensional operator at ``cell_idx``
+            is the identity (all per-direction operators are identity).
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        return all(bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True))
+
+    @property
+    def num_identity_elements(self) -> int:
+        """Count elements whose per-direction operators are all identity.
+
+        Returns:
+            int: The number of fully-identity elements on the tensor-product grid.
+        """
+        count = 1
+        for mask in self._is_identity_mask_1d:
+            count *= int(np.count_nonzero(mask))
+        return count
+
+    def per_direction_identity_flags(self, cell_idx: CellIndex) -> tuple[bool, ...]:
+        """Return the per-direction identity flags for a single element.
+
+        Args:
+            cell_idx (CellIndex): Element index (flat or per-direction).
+
+        Returns:
+            tuple[bool, ...]: Length-``d`` tuple of identity flags for the element.
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        return tuple(
+            bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
+        )
+
+    # ---------------------------------------------------------------- per-cell applies
+
+    def apply(
+        self,
+        v: npt.NDArray[np.float32 | np.float64],
+        cell_idx: CellIndex,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out = M @ v`` for the element at ``cell_idx``.
+
+        Here ``M = kron(M_0, …, M_{d-1})`` with ``M_k`` the 1D operator at
+        ``cell_idx`` in direction ``k``; identity directions short-circuit.
+
+        Args:
+            v (npt.NDArray[np.float32 | np.float64]): Input vector of shape
+                ``(prod(input_shape_per_dir),)``.
+            cell_idx (CellIndex): Element index (flat or per-direction).
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(prod(output_shape_per_dir),)``. Allocated
+                if ``None``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                scratch buffer. Allocated if ``None``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result array (the same
+            array as ``out`` when ``out`` was provided).
+        """
+        return self._apply(v, cell_idx, "apply", out, scratch)
+
+    def apply_transpose(
+        self,
+        v: npt.NDArray[np.float32 | np.float64],
+        cell_idx: CellIndex,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out = M^T @ v`` for the element at ``cell_idx``.
+
+        Args:
+            v (npt.NDArray[np.float32 | np.float64]): Input vector of shape
+                ``(prod(output_shape_per_dir),)``.
+            cell_idx (CellIndex): Element index.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(prod(input_shape_per_dir),)``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                scratch buffer.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result array.
+        """
+        return self._apply(v, cell_idx, "apply_T", out, scratch)
+
+    def apply_MT_K_M(
+        self,
+        K: npt.NDArray[np.float32 | np.float64],
+        cell_idx: CellIndex,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out = M^T @ K @ M`` for the element at ``cell_idx``.
+
+        Args:
+            K (npt.NDArray[np.float32 | np.float64]): Input matrix of shape
+                ``(N_out, N_out)`` with ``N_out = prod(output_shape_per_dir)``.
+            cell_idx (CellIndex): Element index.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                matrix of shape ``(N_in, N_in)`` with
+                ``N_in = prod(input_shape_per_dir)``. Must not alias ``K``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                scratch buffer.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result matrix.
+        """
+        return self._apply(K, cell_idx, "MT_K_M", out, scratch)
+
+    def apply_M_K_MT(
+        self,
+        K: npt.NDArray[np.float32 | np.float64],
+        cell_idx: CellIndex,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out = M @ K @ M^T`` for the element at ``cell_idx``.
+
+        Args:
+            K (npt.NDArray[np.float32 | np.float64]): Input matrix of shape
+                ``(N_in, N_in)`` with ``N_in = prod(input_shape_per_dir)``.
+            cell_idx (CellIndex): Element index.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                matrix of shape ``(N_out, N_out)`` with
+                ``N_out = prod(output_shape_per_dir)``. Must not alias ``K``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                scratch buffer.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result matrix.
+        """
+        return self._apply(K, cell_idx, "M_K_MT", out, scratch)
+
+    def operator(
+        self,
+        cell_idx: CellIndex,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Materialize the full ``(N_out, N_in)`` operator for one element.
+
+        Uses :func:`numpy.kron` and is intended for testing or debugging;
+        production code should prefer the matrix-free apply methods.
+
+        Args:
+            cell_idx (CellIndex): Element index.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                matrix of shape ``(N_out, N_in)``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The full Kronecker operator.
+        """
+        ops = self._ops_for_cell(cell_idx)
+        n_out = int(np.prod(self.output_shape_per_dir))
+        n_in = int(np.prod(self.input_shape_per_dir))
+        out = _allocate_or_validate_out(out, (n_out, n_in), self.dtype)
+        result = ops[0]
+        for M in ops[1:]:
+            result = np.kron(result, M)
+        out[...] = result
+        return out
+
+    def tabulate(
+        self,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Materialize per-element operators for every element on the grid.
+
+        Args:
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(num_total_intervals, N_out, N_in)``. Cells
+                are ordered row-major over :attr:`num_intervals` (so flat
+                index ``f`` corresponds to multi-index
+                ``np.unravel_index(f, num_intervals)``).
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Stacked per-element operators.
+        """
+        n_out = int(np.prod(self.output_shape_per_dir))
+        n_in = int(np.prod(self.input_shape_per_dir))
+        expected = (self.num_total_intervals, n_out, n_in)
+        out = _allocate_or_validate_out(out, expected, self.dtype)
+        for flat in range(self.num_total_intervals):
+            self.operator(flat, out=out[flat])
+        return out
+
+    # ---------------------------------------------------------------- indexing / iteration
+
+    def __len__(self) -> int:
+        """Return the total number of elements on the tensor-product grid.
+
+        Returns:
+            int: Equal to :attr:`num_total_intervals`.
+        """
+        return self.num_total_intervals
+
+    def __getitem__(
+        self, cell_idx: CellIndex
+    ) -> tuple[tuple[npt.NDArray[np.float32 | np.float64], ...], tuple[bool, ...]]:
+        """Return the per-direction operators and identity flags for one element.
+
+        Args:
+            cell_idx (CellIndex): Element index (flat or per-direction).
+
+        Returns:
+            tuple[tuple[npt.NDArray[np.float32 | np.float64], ...], tuple[bool, ...]]:
+            ``(ops_for_cell, identity_flags)`` where ``ops_for_cell[k]`` is a
+            view into :attr:`ops_1d` ``[k]`` and ``identity_flags`` is the
+            per-direction identity mask at this element.
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        ops = tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+        flags = tuple(
+            bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
+        )
+        return ops, flags
+
+    def __iter__(
+        self,
+    ) -> Iterator[tuple[tuple[npt.NDArray[np.float32 | np.float64], ...], tuple[bool, ...]]]:
+        """Iterate over all elements in row-major order over :attr:`num_intervals`.
+
+        Yields:
+            tuple[tuple[npt.NDArray[np.float32 | np.float64], ...], tuple[bool, ...]]:
+            Same shape as :meth:`__getitem__`'s return value.
+        """
+        for flat in range(self.num_total_intervals):
+            yield self[flat]
+
+    # ---------------------------------------------------------------- internals
+
+    def _normalize_cell_idx(self, cell_idx: CellIndex) -> tuple[int, ...]:
+        """Convert a flat or per-direction index into a validated per-direction tuple.
+
+        Args:
+            cell_idx (CellIndex): Flat ``int`` or per-direction sequence.
+
+        Returns:
+            tuple[int, ...]: Length-``d`` tuple of non-negative element indices.
+
+        Raises:
+            IndexError: If a flat index is out of range, or a per-direction
+                entry is out of range for its direction.
+            ValueError: If a per-direction index has the wrong length.
+            TypeError: If ``cell_idx`` is not an ``int`` or sequence of ``int``.
+        """
+        num_intervals = self.num_intervals
+        d = len(num_intervals)
+        if isinstance(cell_idx, int | np.integer):
+            flat = int(cell_idx)
+            total = self.num_total_intervals
+            if flat < 0 or flat >= total:
+                raise IndexError(f"Flat cell index {flat} out of range for {total} elements")
+            multi = np.unravel_index(flat, num_intervals)
+            return tuple(int(i) for i in multi)
+        if isinstance(cell_idx, tuple | list | np.ndarray):
+            seq = tuple(int(x) for x in cell_idx)
+            if len(seq) != d:
+                raise ValueError(f"Per-direction cell index has length {len(seq)}, expected {d}")
+            for k, (i, n) in enumerate(zip(seq, num_intervals, strict=True)):
+                if i < 0 or i >= n:
+                    raise IndexError(
+                        f"Cell index {i} out of range for direction {k} with {n} elements"
+                    )
+            return seq
+        raise TypeError(f"cell_idx must be int or sequence of int; got {type(cell_idx).__name__}")
+
+    def _ops_for_cell(
+        self, cell_idx: CellIndex
+    ) -> tuple[npt.NDArray[np.float32 | np.float64], ...]:
+        """Return the per-direction operators at one element.
+
+        Args:
+            cell_idx (CellIndex): Element index.
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ...]: Per-direction
+            2D operators, each of shape ``(n_out_k, n_in_k)``.
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        return tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+
+    def _apply(
+        self,
+        operand: npt.NDArray[np.float32 | np.float64],
+        cell_idx: CellIndex,
+        op_kind: OpKind,
+        out: npt.NDArray[np.float32 | np.float64] | None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Dispatch a single-element apply variant through the Layer-2 helper.
+
+        Args:
+            operand (npt.NDArray[np.float32 | np.float64]): Input vector or
+                matrix (shape depends on ``op_kind``).
+            cell_idx (CellIndex): Element index.
+            op_kind (OpKind): Which apply variant to dispatch.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional scratch.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result array.
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        ops = tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+        flags = tuple(
+            bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
+        )
+        kernel, args, result = _prepare_apply_call(ops, flags, operand, out, scratch, op_kind)
+        kernel(*args)
+        return result
+
+
+def _numerical_identity_mask(
+    ops: npt.NDArray[np.float32 | np.float64], tol: float
+) -> npt.NDArray[np.bool_]:
+    """Compute a per-element identity mask by comparing each matrix against ``I``.
+
+    Non-square matrices are always reported as non-identity.
+
+    Args:
+        ops (npt.NDArray[np.float32 | np.float64]): Stack of 2D operators,
+            shape ``(n_elements, n_out, n_in)``.
+        tol (float): Absolute tolerance used element-wise.
+
+    Returns:
+        npt.NDArray[np.bool_]: Boolean array of shape ``(n_elements,)``.
+    """
+    n_elements, n_out, n_in = ops.shape
+    mask = np.zeros(n_elements, dtype=np.bool_)
+    if n_out != n_in:
+        return mask
+    eye = np.eye(n_out, dtype=ops.dtype)
+    for i in range(n_elements):
+        if np.max(np.abs(ops[i] - eye)) <= tol:
+            mask[i] = True
+    return mask
+
+
+# The op_kind shape helper is kept import-local so downstream callers can build
+# operands of the right shape without reaching into Layer 2 directly.
+def operand_shape(
+    extraction: SpanwiseElementExtraction, op_kind: OpKind
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return the expected ``(input_shape, output_shape)`` for an apply variant.
+
+    Args:
+        extraction (SpanwiseElementExtraction): Extraction object supplying
+            per-direction shapes.
+        op_kind (OpKind): One of ``"apply"``, ``"apply_T"``, ``"MT_K_M"``,
+            ``"M_K_MT"``.
+
+    Returns:
+        tuple[tuple[int, ...], tuple[int, ...]]: ``(input_shape, output_shape)``.
+    """
+    return _operation_shapes(
+        extraction.input_shape_per_dir, extraction.output_shape_per_dir, op_kind
+    )
+
+
+__all__ = [
+    "CellIndex",
+    "SpanwiseElementExtraction",
+    "Target",
+    "operand_shape",
+]

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -3,7 +3,7 @@
 This module exposes :class:`SpanwiseElementExtraction`, a lazy tensor-product
 change-of-basis object. It eagerly caches the per-direction 1D extraction
 operators once at construction time and, on demand, dispatches to the Layer-3
-Kronecker kernels in :mod:`pantr.bspline._extraction_kernels` to apply the
+Kronecker kernels in ``pantr.bspline._extraction_kernels`` to apply the
 d-dimensional operator for a single element.
 
 Three targets are supported (the source basis is always the B-spline basis):
@@ -56,7 +56,7 @@ class SpanwiseElementExtraction:
     element d-dimensional operators are never materialized unless explicitly
     requested via :meth:`operator` or :meth:`tabulate`: instead the apply-style
     methods dispatch to the matrix-free Kronecker kernels in
-    :mod:`pantr.bspline._extraction_kernels`.
+    ``pantr.bspline._extraction_kernels``.
 
     With the current 1D builders all per-direction operators are square of
     size ``(degree_k + 1, degree_k + 1)``. The class also supports non-square
@@ -102,7 +102,7 @@ class SpanwiseElementExtraction:
             target (Target): One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
             lagrange_variant (LagrangeVariant): Point distribution used when
                 ``target == "lagrange"``. Defaults to
-                :attr:`LagrangeVariant.EQUISPACES`.
+                :attr:`pantr.basis.LagrangeVariant.EQUISPACES`.
             identity_tol (float | None): Absolute tolerance for numerical
                 identity detection on ``"bezier"`` and ``"lagrange"`` targets.
                 If ``None``, defaults to ``space.tolerance``.

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -76,7 +76,7 @@ class SpanwiseElementExtraction:
         _ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]):
             Per-direction 3D operator arrays of shape
             ``(n_elements_k, n_out_k, n_in_k)``.
-        _is_identity_mask_1d (tuple[npt.NDArray[np.bool_], ...]): Per-direction
+        _is_identity_mask_1d (tuple[npt.NDArray[bool], ...]): Per-direction
             identity masks of shape ``(n_elements_k,)``.
     """
 
@@ -259,7 +259,7 @@ class SpanwiseElementExtraction:
         ``|C - I|_max < identity_tol`` test per element.
 
         Returns:
-            tuple[npt.NDArray[np.bool_], ...]: Length-``d`` tuple of read-only
+            tuple[npt.NDArray[bool], ...]: Length-``d`` tuple of read-only
             1D boolean arrays; ``is_identity_mask_1d[k][i]`` is ``True`` iff
             the ``i``-th element in direction ``k`` has an identity operator.
         """
@@ -651,7 +651,7 @@ def _numerical_identity_mask(
         tol (float): Absolute tolerance used element-wise.
 
     Returns:
-        npt.NDArray[np.bool_]: Boolean array of shape ``(n_elements,)``.
+        npt.NDArray[bool]: Boolean array of shape ``(n_elements,)``.
     """
     n_elements, n_out, n_in = ops.shape
     if n_out != n_in:

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -14,14 +14,17 @@ Three targets are supported (the source basis is always the B-spline basis):
 - ``"cardinal"``: cardinal B-spline basis on each element.
 
 Identity short-circuit is used wherever possible: for ``"cardinal"`` the
-structural mask from :meth:`BsplineSpace1D.get_cardinal_intervals` labels every
-interval as identity or not; for ``"bezier"`` and ``"lagrange"`` a per-element
-numerical test ``|C - I|_max < tol`` marks trivial elements (for instance, a
-C0 Bezier space has identity Bezier extraction everywhere).
+structural mask from :meth:`BsplineSpace1D.get_cardinal_intervals` labels each
+interval whose knot spans are uniform (a *cardinal* interval); on such an
+interval the cardinal extraction operator is exactly the identity matrix. For
+``"bezier"`` and ``"lagrange"`` a per-element numerical test
+``|C - I|_max < tol`` marks trivial elements (for instance, a C⁰ Bézier space
+has identity Bézier extraction everywhere).
 """
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Literal, get_args
 
@@ -102,10 +105,11 @@ class SpanwiseElementExtraction:
                 :attr:`LagrangeVariant.EQUISPACES`.
             identity_tol (float | None): Absolute tolerance for numerical
                 identity detection on ``"bezier"`` and ``"lagrange"`` targets.
-                If ``None``, uses :attr:`BsplineSpace.tolerance`.
+                If ``None``, defaults to ``space.tolerance``.
 
         Raises:
             ValueError: If ``target`` is not a recognized tag.
+            ValueError: If ``identity_tol`` is negative or NaN.
             NotImplementedError: If any direction of ``space`` is periodic;
                 periodic support is deferred to a later version.
         """
@@ -122,7 +126,10 @@ class SpanwiseElementExtraction:
         self._space = space
         self._target = target
         self._lagrange_variant = lagrange_variant
-        self._identity_tol = float(space.tolerance) if identity_tol is None else float(identity_tol)
+        tol = float(space.tolerance) if identity_tol is None else float(identity_tol)
+        if not (tol >= 0.0):
+            raise ValueError(f"identity_tol must be non-negative; got {tol!r}")
+        self._identity_tol = tol
 
         ops_1d: list[npt.NDArray[np.float32 | np.float64]] = []
         masks_1d: list[npt.NDArray[np.bool_]] = []
@@ -145,6 +152,15 @@ class SpanwiseElementExtraction:
 
         self._ops_1d = tuple(ops_1d)
         self._is_identity_mask_1d = tuple(masks_1d)
+
+        if len(self._ops_1d) > 1:
+            dtype_0 = self._ops_1d[0].dtype
+            for k, _ops in enumerate(self._ops_1d[1:], start=1):
+                if _ops.dtype != dtype_0:
+                    raise ValueError(
+                        f"Per-direction operators have inconsistent dtypes: "
+                        f"ops_1d[0].dtype={dtype_0}, ops_1d[{k}].dtype={_ops.dtype}"
+                    )
 
     # ---------------------------------------------------------------- properties
 
@@ -236,6 +252,12 @@ class SpanwiseElementExtraction:
     def is_identity_mask_1d(self) -> tuple[npt.NDArray[np.bool_], ...]:
         """Get the per-direction identity masks.
 
+        For the ``"cardinal"`` target each entry reflects whether the interval
+        has a uniform (cardinal) knot span, which is exactly when the cardinal
+        extraction operator is the identity matrix. For ``"bezier"`` and
+        ``"lagrange"`` targets the mask is computed by a numerical
+        ``|C - I|_max < identity_tol`` test per element.
+
         Returns:
             tuple[npt.NDArray[np.bool_], ...]: Length-``d`` tuple of read-only
             1D boolean arrays; ``is_identity_mask_1d[k][i]`` is ``True`` iff
@@ -276,7 +298,7 @@ class SpanwiseElementExtraction:
         multi = self._normalize_cell_idx(cell_idx)
         return all(bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True))
 
-    @property
+    @functools.cached_property
     def num_identity_elements(self) -> int:
         """Count elements whose per-direction operators are all identity.
 
@@ -287,6 +309,16 @@ class SpanwiseElementExtraction:
         for mask in self._is_identity_mask_1d:
             count *= int(np.count_nonzero(mask))
         return count
+
+    @property
+    def is_identity(self) -> bool:
+        """Check whether every element on the grid has an identity operator.
+
+        Returns:
+            bool: ``True`` iff all per-direction identity masks are all-``True``,
+            meaning every element's operator is the identity.
+        """
+        return all(bool(mask.all()) for mask in self._is_identity_mask_1d)
 
     def per_direction_identity_flags(self, cell_idx: CellIndex) -> tuple[bool, ...]:
         """Return the per-direction identity flags for a single element.
@@ -330,6 +362,10 @@ class SpanwiseElementExtraction:
         Returns:
             npt.NDArray[np.float32 | np.float64]: The result array (the same
             array as ``out`` when ``out`` was provided).
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions;
+                specialized kernels only exist for ``d in {1, 2, 3}``.
         """
         return self._apply(v, cell_idx, "apply", out, scratch)
 
@@ -354,6 +390,10 @@ class SpanwiseElementExtraction:
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: The result array.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions;
+                specialized kernels only exist for ``d in {1, 2, 3}``.
         """
         return self._apply(v, cell_idx, "apply_T", out, scratch)
 
@@ -379,6 +419,10 @@ class SpanwiseElementExtraction:
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: The result matrix.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions;
+                specialized kernels only exist for ``d in {1, 2, 3}``.
         """
         return self._apply(K, cell_idx, "MT_K_M", out, scratch)
 
@@ -404,6 +448,10 @@ class SpanwiseElementExtraction:
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: The result matrix.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions;
+                specialized kernels only exist for ``d in {1, 2, 3}``.
         """
         return self._apply(K, cell_idx, "M_K_MT", out, scratch)
 
@@ -415,8 +463,9 @@ class SpanwiseElementExtraction:
     ) -> npt.NDArray[np.float32 | np.float64]:
         """Materialize the full ``(N_out, N_in)`` operator for one element.
 
-        Uses :func:`numpy.kron` and is intended for testing or debugging;
-        production code should prefer the matrix-free apply methods.
+        Assembles the full Kronecker product in memory using :func:`numpy.kron`.
+        Prefer the matrix-free apply methods in production code when the full
+        matrix is not needed explicitly.
 
         Args:
             cell_idx (CellIndex): Element index.
@@ -516,8 +565,9 @@ class SpanwiseElementExtraction:
             tuple[int, ...]: Length-``d`` tuple of non-negative element indices.
 
         Raises:
-            IndexError: If a flat index is out of range, or a per-direction
-                entry is out of range for its direction.
+            IndexError: If a flat index is out of range (negative indices are
+                not supported and are also rejected), or a per-direction entry
+                is out of range for its direction.
             ValueError: If a per-direction index has the wrong length.
             TypeError: If ``cell_idx`` is not an ``int`` or sequence of ``int``.
         """
@@ -604,14 +654,11 @@ def _numerical_identity_mask(
         npt.NDArray[np.bool_]: Boolean array of shape ``(n_elements,)``.
     """
     n_elements, n_out, n_in = ops.shape
-    mask = np.zeros(n_elements, dtype=np.bool_)
     if n_out != n_in:
-        return mask
+        return np.zeros(n_elements, dtype=np.bool_)
     eye = np.eye(n_out, dtype=ops.dtype)
-    for i in range(n_elements):
-        if np.max(np.abs(ops[i] - eye)) <= tol:
-            mask[i] = True
-    return mask
+    result: npt.NDArray[np.bool_] = np.max(np.abs(ops - eye[np.newaxis]), axis=(1, 2)) <= tol
+    return result
 
 
 # The op_kind shape helper is kept import-local so downstream callers can build
@@ -624,8 +671,8 @@ def operand_shape(
     Args:
         extraction (SpanwiseElementExtraction): Extraction object supplying
             per-direction shapes.
-        op_kind (OpKind): One of ``"apply"``, ``"apply_T"``, ``"MT_K_M"``,
-            ``"M_K_MT"``.
+        op_kind (OpKind): One of the :data:`OpKind` literals: ``"apply"``,
+            ``"apply_T"``, ``"MT_K_M"``, ``"M_K_MT"``.
 
     Returns:
         tuple[tuple[int, ...], tuple[int, ...]]: ``(input_shape, output_shape)``.

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -3,16 +3,19 @@
 Covers:
 
 - Target dispatch (``bezier``, ``lagrange``, ``cardinal``) and construction
-  errors (unknown target, periodic directions).
+  errors (unknown target, periodic directions, invalid ``identity_tol``).
 - Shape/dtype and identity-mask properties.
 - Per-cell :meth:`apply` / :meth:`apply_transpose` / :meth:`apply_MT_K_M` /
   :meth:`apply_M_K_MT` against a dense reference ``kron(M_0, M_1, …)``.
-- :meth:`operator` / :meth:`tabulate` round-trip consistency.
-- Identity-query correctness: cardinal spaces use the structural mask from
-  :meth:`BsplineSpace1D.get_cardinal_intervals`, C⁰ Bézier spaces detect
-  numerical identity on every element.
-- Cell-index normalization (flat int, tuple, list; IndexError / ValueError
-  on invalid input).
+- :meth:`operator` / :meth:`tabulate` round-trip consistency, including
+  user-provided ``out`` arrays.
+- Identity-query correctness: :attr:`is_identity`, :attr:`num_identity_elements`,
+  :meth:`per_direction_identity_flags`; cardinal spaces use the structural mask
+  from :meth:`BsplineSpace1D.get_cardinal_intervals`; C⁰ Bézier spaces detect
+  numerical identity on every element; ``identity_tol`` controls detection.
+- Cell-index normalization (flat int, tuple, list, ndarray; negative indices
+  rejected; IndexError / ValueError / TypeError on invalid input).
+- 1D spaces and rejection of dim > 3 via :exc:`NotImplementedError`.
 """
 
 from __future__ import annotations
@@ -46,11 +49,11 @@ def _space_3d() -> BsplineSpace:
 def _dense_operator(
     ext: SpanwiseElementExtraction, cell_idx: int
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Build the per-cell Kronecker operator via explicit ``np.kron``."""
-    ops, _flags = ext[cell_idx]
-    result = ops[0]
-    for M in ops[1:]:
-        result = np.kron(result, M)
+    """Build the per-cell Kronecker operator from ``ops_1d`` without using ``__getitem__``."""
+    multi = np.unravel_index(cell_idx, ext.num_intervals)
+    result: npt.NDArray[np.float32 | np.float64] = ext.ops_1d[0][int(multi[0])]
+    for k in range(1, ext.dim):
+        result = np.kron(result, ext.ops_1d[k][int(multi[k])])
     return result
 
 
@@ -321,3 +324,154 @@ def test_operand_shape_returns_vector_and_matrix_shapes() -> None:
     assert operand_shape(ext, "apply_T") == ((n_out,), (n_in,))
     assert operand_shape(ext, "MT_K_M") == ((n_out, n_out), (n_in, n_in))
     assert operand_shape(ext, "M_K_MT") == ((n_in, n_in), (n_out, n_out))
+
+
+# ---------------------------------------------------------------- construction validation
+
+
+def test_identity_tol_negative_rejected() -> None:
+    """Negative and NaN ``identity_tol`` raise ValueError."""
+    sp = _space_2d()
+    with pytest.raises(ValueError, match="non-negative"):
+        SpanwiseElementExtraction(sp, "bezier", identity_tol=-1.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        SpanwiseElementExtraction(sp, "bezier", identity_tol=float("nan"))
+
+
+# ---------------------------------------------------------------- identity queries (extended)
+
+
+def test_is_identity_property_true_for_c0_bezier() -> None:
+    """``is_identity`` is ``True`` when every element has an identity operator."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 1, 1, 2, 2, 2], 2)
+    sp = BsplineSpace([sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert ext.is_identity
+
+
+def test_is_identity_property_false_for_smooth_space() -> None:
+    """``is_identity`` is ``False`` when some elements have non-identity operators."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert not ext.is_identity
+
+
+def test_num_identity_elements_formula_is_product_not_sum() -> None:
+    """``num_identity_elements`` uses the tensor-product formula, not a sum."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "cardinal")
+    counts = [int(np.count_nonzero(m)) for m in ext.is_identity_mask_1d]
+    assert ext.num_identity_elements == counts[0] * counts[1]
+    # Meaningful only when there is more than one identity interval per direction
+    assert all(c > 1 for c in counts), "space must have >1 identity per direction"
+
+
+def test_per_direction_identity_flags_matches_mask_lookup() -> None:
+    """``per_direction_identity_flags`` matches per-direction mask lookup for every cell."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "cardinal")
+    for flat in range(ext.num_total_intervals):
+        multi = np.unravel_index(flat, ext.num_intervals)
+        expected = tuple(
+            bool(m[int(i)]) for m, i in zip(ext.is_identity_mask_1d, multi, strict=True)
+        )
+        assert ext.per_direction_identity_flags(flat) == expected
+        assert ext.per_direction_identity_flags(tuple(int(i) for i in multi)) == expected
+
+
+def test_identity_tol_affects_detection() -> None:
+    """A custom ``identity_tol`` changes which elements are flagged as identity."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    sp = BsplineSpace([sp1])
+    ext_default = SpanwiseElementExtraction(sp, "bezier")
+    # With an enormous tolerance every element looks like identity
+    ext_huge = SpanwiseElementExtraction(sp, "bezier", identity_tol=1e100)
+    assert ext_huge.is_identity_mask_1d[0].all()
+    assert ext_huge.identity_tol == 1e100  # noqa: PLR2004
+    # The default space is not all-identity (smooth space has non-trivial Bezier ops)
+    if not ext_default.is_identity_mask_1d[0].all():
+        assert not ext_default.is_identity
+
+
+# ---------------------------------------------------------------- operator / tabulate (extended)
+
+
+def test_operator_accepts_user_out() -> None:
+    """User-provided ``out`` to ``operator`` is written into and returned."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    out = np.zeros((n_out, n_in), dtype=ext.dtype)
+    result = ext.operator(7, out=out)
+    assert result is out
+    np.testing.assert_allclose(result, _dense_operator(ext, 7), atol=1e-12)
+
+
+def test_tabulate_accepts_user_out() -> None:
+    """User-provided ``out`` to ``tabulate`` is written into and returned."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    out = np.zeros((ext.num_total_intervals, n_out, n_in), dtype=ext.dtype)
+    result = ext.tabulate(out=out)
+    assert result is out
+    for flat in range(ext.num_total_intervals):
+        np.testing.assert_allclose(result[flat], _dense_operator(ext, flat), atol=1e-12)
+
+
+# ---------------------------------------------------------------- 1D spaces
+
+
+def test_1d_space_apply_matches_dense() -> None:
+    """A 1D space (dim=1) works correctly for all four apply variants."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    sp = BsplineSpace([sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert ext.dim == 1
+    n_in = ext.input_shape_per_dir[0]
+    n_out = ext.output_shape_per_dir[0]
+    for cell in range(ext.num_total_intervals):
+        M = ext.ops_1d[0][cell]
+        v = RNG.standard_normal(n_in).astype(ext.dtype)
+        np.testing.assert_allclose(ext.apply(v, cell), M @ v, atol=1e-12)
+        w = RNG.standard_normal(n_out).astype(ext.dtype)
+        np.testing.assert_allclose(ext.apply_transpose(w, cell), M.T @ w, atol=1e-12)
+        K = RNG.standard_normal((n_out, n_out)).astype(ext.dtype)
+        np.testing.assert_allclose(ext.apply_MT_K_M(K, cell), M.T @ K @ M, atol=1e-11)
+        K2 = RNG.standard_normal((n_in, n_in)).astype(ext.dtype)
+        np.testing.assert_allclose(ext.apply_M_K_MT(K2, cell), M @ K2 @ M.T, atol=1e-11)
+
+
+# ---------------------------------------------------------------- dim > 3
+
+
+def test_dim_4_apply_raises_not_implemented() -> None:
+    """Calling any apply variant on a 4D space raises NotImplementedError."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+    sp = BsplineSpace([sp1, sp1, sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    v = np.zeros(n_in, dtype=ext.dtype)
+    with pytest.raises(NotImplementedError):
+        ext.apply(v, 0)
+
+
+# ---------------------------------------------------------------- negative indices
+
+
+def test_negative_flat_index_rejected() -> None:
+    """Negative flat indices raise IndexError (Python-style wrap-around is not supported)."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    with pytest.raises(IndexError):
+        ext.is_identity_at(-1)
+
+
+def test_negative_per_direction_index_rejected() -> None:
+    """Negative per-direction indices raise IndexError."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    with pytest.raises(IndexError):
+        ext.is_identity_at((-1, 0))

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -1,0 +1,323 @@
+"""Tests for :class:`SpanwiseElementExtraction`.
+
+Covers:
+
+- Target dispatch (``bezier``, ``lagrange``, ``cardinal``) and construction
+  errors (unknown target, periodic directions).
+- Shape/dtype and identity-mask properties.
+- Per-cell :meth:`apply` / :meth:`apply_transpose` / :meth:`apply_MT_K_M` /
+  :meth:`apply_M_K_MT` against a dense reference ``kron(M_0, M_1, …)``.
+- :meth:`operator` / :meth:`tabulate` round-trip consistency.
+- Identity-query correctness: cardinal spaces use the structural mask from
+  :meth:`BsplineSpace1D.get_cardinal_intervals`, C⁰ Bézier spaces detect
+  numerical identity on every element.
+- Cell-index normalization (flat int, tuple, list; IndexError / ValueError
+  on invalid input).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.basis import LagrangeVariant
+from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
+from pantr.bspline.spanwise_element_extraction import (
+    _numerical_identity_mask,
+    operand_shape,
+)
+
+RNG = np.random.default_rng(20260421)
+
+
+def _space_2d() -> BsplineSpace:
+    """Build a small 2D open-knot space with a mix of cardinal / non-cardinal intervals."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], 2)
+    return BsplineSpace([sp1, sp1])
+
+
+def _space_3d() -> BsplineSpace:
+    """Build a small 3D space suitable for all four apply variants."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    return BsplineSpace([sp1, sp1, sp1])
+
+
+def _dense_operator(
+    ext: SpanwiseElementExtraction, cell_idx: int
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build the per-cell Kronecker operator via explicit ``np.kron``."""
+    ops, _flags = ext[cell_idx]
+    result = ops[0]
+    for M in ops[1:]:
+        result = np.kron(result, M)
+    return result
+
+
+# ---------------------------------------------------------------- construction
+
+
+def test_unknown_target_rejected() -> None:
+    """Unknown target tags raise ValueError."""
+    sp = _space_2d()
+    with pytest.raises(ValueError, match="Unknown target"):
+        SpanwiseElementExtraction(sp, "spline")  # type: ignore[arg-type]
+
+
+def test_periodic_rejected() -> None:
+    """Periodic directions raise NotImplementedError in v0."""
+    sp1 = BsplineSpace1D([0, 1, 2, 3, 4, 5], 1, periodic=True)
+    sp = BsplineSpace([sp1])
+    with pytest.raises(NotImplementedError, match="periodic"):
+        SpanwiseElementExtraction(sp, "bezier")
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_per_direction_shapes(target: str) -> None:
+    """``ops_1d`` and identity masks match the space's per-direction sizes."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    assert ext.dim == 2  # noqa: PLR2004
+    assert ext.num_intervals == (6, 6)
+    assert ext.num_total_intervals == 36  # noqa: PLR2004
+    assert len(ext.ops_1d) == 2  # noqa: PLR2004
+    for ops in ext.ops_1d:
+        assert ops.shape == (6, 3, 3)
+        assert ops.dtype == ext.dtype
+    for mask in ext.is_identity_mask_1d:
+        assert mask.shape == (6,)
+        assert mask.dtype == np.bool_
+
+
+# ---------------------------------------------------------------- identity detection
+
+
+def test_cardinal_identity_structural_matches_space() -> None:
+    """Cardinal identity mask equals ``BsplineSpace1D.get_cardinal_intervals``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "cardinal")
+    for space_1d, mask in zip(sp.spaces, ext.is_identity_mask_1d, strict=True):
+        np.testing.assert_array_equal(mask, space_1d.get_cardinal_intervals())
+
+
+def test_bezier_c0_space_is_numerically_identity_everywhere() -> None:
+    """A C⁰ Bézier space has identity Bézier extraction on every element."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 1, 1, 2, 2, 2], 2)
+    sp = BsplineSpace([sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    for mask in ext.is_identity_mask_1d:
+        assert mask.all()
+    assert ext.is_identity_at(0)
+    assert ext.num_identity_elements == ext.num_total_intervals
+
+
+def test_numerical_identity_mask_ignores_nonsquare() -> None:
+    """Non-square operators are never detected as identity."""
+    ops = np.empty((2, 3, 4), dtype=np.float64)
+    ops[0] = 0.0
+    ops[1] = 1.0
+    mask = _numerical_identity_mask(ops, 1e-12)
+    assert not mask.any()
+
+
+# ---------------------------------------------------------------- apply correctness
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize("cell_idx", [0, 5, 20, 35])
+def test_apply_matches_dense_kron(target: str, cell_idx: int) -> None:
+    """``apply`` matches ``kron(M_0, M_1) @ v`` for assorted cells."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    v = RNG.standard_normal(n_in).astype(ext.dtype)
+    result = ext.apply(v, cell_idx)
+    expected = _dense_operator(ext, cell_idx) @ v
+    np.testing.assert_allclose(result, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_apply_transpose_matches_dense(target: str) -> None:
+    """``apply_transpose`` matches ``M.T @ v``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    v = RNG.standard_normal(n_out).astype(ext.dtype)
+    result = ext.apply_transpose(v, 7)
+    expected = _dense_operator(ext, 7).T @ v
+    np.testing.assert_allclose(result, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_apply_MT_K_M_matches_dense(target: str) -> None:
+    """``apply_MT_K_M`` matches ``M.T @ K @ M``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    K = RNG.standard_normal((n_out, n_out)).astype(ext.dtype)
+    result = ext.apply_MT_K_M(K, 12)
+    M = _dense_operator(ext, 12)
+    expected = M.T @ K @ M
+    np.testing.assert_allclose(result, expected, atol=1e-11)
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_apply_M_K_MT_matches_dense(target: str) -> None:
+    """``apply_M_K_MT`` matches ``M @ K @ M.T``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    K = RNG.standard_normal((n_in, n_in)).astype(ext.dtype)
+    result = ext.apply_M_K_MT(K, (2, 3))
+    M = _dense_operator(ext, int(np.ravel_multi_index((2, 3), ext.num_intervals)))
+    expected = M @ K @ M.T
+    np.testing.assert_allclose(result, expected, atol=1e-11)
+
+
+def test_apply_3d_matches_dense() -> None:
+    """Sanity check for d=3: apply and bilateral variants match dense references."""
+    sp = _space_3d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    cell = (1, 2, 0)
+    flat = int(np.ravel_multi_index(cell, ext.num_intervals))
+
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    v = RNG.standard_normal(n_in).astype(ext.dtype)
+    M = _dense_operator(ext, flat)
+    np.testing.assert_allclose(ext.apply(v, cell), M @ v, atol=1e-11)
+
+    w = RNG.standard_normal(n_out).astype(ext.dtype)
+    np.testing.assert_allclose(ext.apply_transpose(w, flat), M.T @ w, atol=1e-11)
+
+    K = RNG.standard_normal((n_out, n_out)).astype(ext.dtype)
+    np.testing.assert_allclose(ext.apply_MT_K_M(K, flat), M.T @ K @ M, atol=1e-10)
+    K2 = RNG.standard_normal((n_in, n_in)).astype(ext.dtype)
+    np.testing.assert_allclose(ext.apply_M_K_MT(K2, flat), M @ K2 @ M.T, atol=1e-10)
+
+
+def test_apply_accepts_user_out_and_scratch() -> None:
+    """User-provided ``out`` and ``scratch`` are written into and returned."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    v = RNG.standard_normal(n_in).astype(ext.dtype)
+    out = np.zeros(n_out, dtype=ext.dtype)
+    scratch = np.zeros(4 * n_out * n_in, dtype=ext.dtype)
+    result = ext.apply(v, 0, out=out, scratch=scratch)
+    assert result is out
+    np.testing.assert_allclose(result, _dense_operator(ext, 0) @ v, atol=1e-12)
+
+
+# ---------------------------------------------------------------- operator / tabulate
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_operator_matches_kron(target: str) -> None:
+    """``operator(cell)`` equals the explicit Kronecker product at that cell."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    for cell in (0, 3, 17, 35):
+        np.testing.assert_allclose(ext.operator(cell), _dense_operator(ext, cell), atol=1e-12)
+
+
+def test_tabulate_has_correct_shape_and_matches_per_cell_operator() -> None:
+    """``tabulate()`` stacks per-cell operators in row-major order."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "lagrange")
+    stacked = ext.tabulate()
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    assert stacked.shape == (ext.num_total_intervals, n_out, n_in)
+    for flat in range(ext.num_total_intervals):
+        np.testing.assert_allclose(stacked[flat], ext.operator(flat), atol=1e-12)
+
+
+def test_lagrange_variant_is_respected() -> None:
+    """Different Lagrange variants produce different operators.
+
+    Uses degree ≥ 3 because for degree ≤ 2 the equispaced and GLL point sets
+    coincide, so the resulting extraction operators are identical.
+    """
+    sp1 = BsplineSpace1D([0, 0, 0, 0, 1, 2, 3, 3, 3, 3], 3)
+    sp = BsplineSpace([sp1, sp1])
+    eq = SpanwiseElementExtraction(sp, "lagrange", lagrange_variant=LagrangeVariant.EQUISPACES)
+    gll = SpanwiseElementExtraction(
+        sp, "lagrange", lagrange_variant=LagrangeVariant.GAUSS_LOBATTO_LEGENDRE
+    )
+    assert not np.allclose(eq.ops_1d[0], gll.ops_1d[0])
+
+
+# ---------------------------------------------------------------- iteration / indexing
+
+
+def test_len_and_iter_yield_per_cell_entries() -> None:
+    """``len`` and ``__iter__`` match ``num_total_intervals`` and ``__getitem__``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert len(ext) == ext.num_total_intervals
+    items = list(ext)
+    assert len(items) == ext.num_total_intervals
+    for flat, (ops, flags) in enumerate(items):
+        ref_ops, ref_flags = ext[flat]
+        assert flags == ref_flags
+        for M, M_ref in zip(ops, ref_ops, strict=True):
+            np.testing.assert_array_equal(M, M_ref)
+
+
+def test_cell_index_accepts_flat_and_multi() -> None:
+    """Flat ``int``, tuple, list, and ndarray indices are all accepted."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    multi = (4, 1)
+    flat = int(np.ravel_multi_index(multi, ext.num_intervals))
+    ops_flat, _ = ext[flat]
+    ops_tuple, _ = ext[multi]
+    ops_list, _ = ext[[4, 1]]
+    ops_arr, _ = ext[np.array(multi)]
+    for a, b, c, d in zip(ops_flat, ops_tuple, ops_list, ops_arr, strict=True):
+        np.testing.assert_array_equal(a, b)
+        np.testing.assert_array_equal(a, c)
+        np.testing.assert_array_equal(a, d)
+
+
+def test_cell_index_out_of_range() -> None:
+    """Out-of-range flat and per-direction indices raise IndexError."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    with pytest.raises(IndexError):
+        ext.is_identity_at(ext.num_total_intervals)
+    with pytest.raises(IndexError):
+        ext.is_identity_at((6, 0))
+
+
+def test_cell_index_wrong_length() -> None:
+    """Per-direction index with wrong length raises ValueError."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    with pytest.raises(ValueError, match="length"):
+        ext.is_identity_at((0, 1, 2))
+
+
+def test_cell_index_wrong_type() -> None:
+    """Non-int, non-sequence cell indices raise TypeError."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    with pytest.raises(TypeError):
+        ext.is_identity_at("0")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------- operand_shape helper
+
+
+def test_operand_shape_returns_vector_and_matrix_shapes() -> None:
+    """``operand_shape`` returns the expected vector/matrix shapes per ``op_kind``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    assert operand_shape(ext, "apply") == ((n_in,), (n_out,))
+    assert operand_shape(ext, "apply_T") == ((n_out,), (n_in,))
+    assert operand_shape(ext, "MT_K_M") == ((n_out, n_out), (n_in, n_in))
+    assert operand_shape(ext, "M_K_MT") == ((n_in, n_in), (n_out, n_out))


### PR DESCRIPTION
## Summary

Implements PR 2 of the extraction class plan (tracking issue #141), built on the numba-callable kernels merged in #140.

- New public class `SpanwiseElementExtraction` at `src/pantr/bspline/spanwise_element_extraction.py`, exported from `pantr.bspline`.
- Lazy tensor-product change-of-basis operator over B-spline elements, dispatching to three targets:
  - `"bezier"` — uses `tabulate_Bezier_extraction_operators`
  - `"lagrange"` — uses `tabulate_Lagrange_extraction_operators` (respects `lagrange_variant`)
  - `"cardinal"` — uses `tabulate_cardinal_extraction_operators`
- Per-direction operators and identity masks are precomputed once at construction and exposed as tuples of read-only NumPy arrays (`ops_1d`, `is_identity_mask_1d`) so downstream numba kernels can consume them directly.
- Identity short-circuit: cardinal targets use the structural mask from `BsplineSpace1D.get_cardinal_intervals()`; bezier/lagrange use a numerical `|M - I|_max < tol` test per element.
- Public API: `apply`, `apply_transpose`, `apply_MT_K_M`, `apply_M_K_MT`, `operator`, `tabulate`, `__getitem__`, `__iter__`, `__len__`, plus identity-query properties (`is_identity`, `is_identity_at`).
- Supports non-square per-direction operators (e.g. Lagrange with `n_out != n_in`).
- Rejects periodic spaces with `NotImplementedError` (v0 non-goal, per #141).

## Test plan

- [x] 42 new tests in `tests/test_spanwise_element_extraction.py` covering:
  - Unknown target / periodic rejection
  - Per-direction shapes and dtypes
  - Cardinal structural identity match; C0 Bezier numerical identity
  - Non-square ops never claim identity
  - `apply` / `apply_T` / `MT_K_M` / `M_K_MT` against explicit `np.kron` reference in 2D for all targets and multiple cells (atol 1e-12)
  - 3D sanity check
  - User-supplied `out` and `scratch`
  - `operator`, `tabulate`, `len`/`iter`
  - Flat / tuple / list / ndarray cell indexing and error paths
  - `lagrange_variant` distinguishes equispaced vs GLL at degree 3
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini src tests` — clean
- [x] `pytest --no-cov` — 2375 passed
- [x] `sphinx-build -W --keep-going` — build finished

Refs #141.

Generated with [Claude Code](https://claude.com/claude-code)