### PR TITLE
refactor(bspline): route nD Bezier extraction through SpanwiseElementExtraction

### DIFF
--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -8,6 +8,10 @@ tensor-product interval structure.
 The core Numba kernel :func:`_apply_bezier_extraction_1d_core` applies the
 extraction operators for one parametric direction, transforming B-spline
 control points into Bezier control points for all elements simultaneously.
+
+Extraction operators are sourced from :class:`~pantr.bspline.SpanwiseElementExtraction`
+(target ``"bezier"``), which caches them once per construction and exposes them via
+:attr:`~pantr.bspline.SpanwiseElementExtraction.ops_1d`.
 """
 
 from __future__ import annotations
@@ -19,6 +23,7 @@ import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from .._numba_compat import nb_jit, nb_prange
+from .spanwise_element_extraction import SpanwiseElementExtraction
 
 if TYPE_CHECKING:
     from . import Bspline
@@ -67,10 +72,11 @@ def _apply_bezier_extraction_1d_core(
 def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
     """Decompose a B-spline into Bezier patches via extraction operators.
 
-    Converts periodic directions to open form, then applies Bezier extraction
-    operators direction by direction using the standard moveaxis pattern. The
-    resulting control point array is reshaped and split into individual
-    :class:`~pantr.bezier.Bezier` objects.
+    Converts periodic directions to open form, then delegates operator
+    construction to :class:`SpanwiseElementExtraction` (target ``"bezier"``).
+    Extraction operators are applied direction by direction using the standard
+    moveaxis pattern. The resulting control point array is reshaped and split
+    into individual :class:`~pantr.bezier.Bezier` objects.
 
     Args:
         bspline (Bspline): Input B-spline to decompose.
@@ -88,14 +94,15 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
     if any(s.periodic for s in bspline.space.spaces):
         bspline = bspline.to_open_bspline()
 
+    extraction = SpanwiseElementExtraction(bspline.space, target="bezier")
+
     ctrl = bspline.control_points
     num_intervals = bspline.space.num_intervals
     degrees = bspline.degree
 
     # Apply extraction operators direction by direction.
     for d in range(dim):
-        space_1d = bspline.space.spaces[d]
-        extraction_ops = space_1d.tabulate_Bezier_extraction_operators()
+        extraction_ops = extraction.ops_1d[d]
         n_el = num_intervals[d]
         order = degrees[d] + 1
 

--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -82,7 +82,7 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
         bspline (Bspline): Input B-spline to decompose.
 
     Returns:
-        ``npt.NDArray[np.object_]``: Array of :class:`~pantr.bezier.Bezier` objects
+        npt.NDArray[np.object_]: Array of :class:`~pantr.bezier.Bezier` objects
         with shape ``(*num_intervals)`` following the tensor-product interval
         structure.
     """
@@ -94,6 +94,8 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
     if any(s.periodic for s in bspline.space.spaces):
         bspline = bspline.to_open_bspline()
 
+    # is_identity_mask_1d is also built but unused here; its overhead is minor
+    # relative to the Numba kernel and accepted for the sake of consolidation.
     extraction = SpanwiseElementExtraction(bspline.space, target="bezier")
 
     ctrl = bspline.control_points

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -15,6 +15,7 @@ from pantr.bspline import (
     create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
+from pantr.bspline.spanwise_element_extraction import SpanwiseElementExtraction
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -870,3 +871,77 @@ class TestToBeziers:
         single_bez = bs.to_bezier()
         beziers = bs.to_beziers()
         np.testing.assert_allclose(beziers[0].control_points, single_bez.control_points, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Regression parity: to_beziers() vs SpanwiseElementExtraction
+# ---------------------------------------------------------------------------
+
+
+class TestToBeziersSpanwiseParity:
+    """Parity: to_beziers() control points match ``operator(idx).T @ ctrl_local``.
+
+    These tests catch drift between _to_beziers_impl and the extraction operators
+    cached by SpanwiseElementExtraction. The identity verified is::
+
+        beziers[idx].control_points.reshape(N, rank) == M.T @ ctrl_local.reshape(N, rank)
+
+    where ``M = extraction.operator(idx) = kron(C_0[i0], ..., C_{d-1}[i_{d-1}])`` and
+    ``ctrl_local = ctrl[i0:i0+order_0, ..., i_{d-1}:i_{d-1}+order_{d-1}, :]``.
+    """
+
+    @pytest.mark.parametrize(
+        "spaces,rng_seed",
+        [
+            ([BsplineSpace1D([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], 2)], 10),
+            (
+                [
+                    BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2),
+                    BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1),
+                ],
+                20,
+            ),
+            (
+                [
+                    BsplineSpace1D([0.0, 0.0, 0.5, 1.0, 1.0], 1),
+                    BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2),
+                    BsplineSpace1D([0.0, 0.0, 0.0, 1.0 / 3, 2.0 / 3, 1.0, 1.0, 1.0], 2),
+                ],
+                30,
+            ),
+        ],
+        ids=["1d", "2d", "3d"],
+    )
+    def test_element_cp_matches_operator_transpose(
+        self, spaces: list[BsplineSpace1D], rng_seed: int
+    ) -> None:
+        """Bezier control points equal SpanwiseElementExtraction.operator(idx).T @ ctrl_local."""
+        space = BsplineSpace(spaces)
+        rng = np.random.default_rng(rng_seed)
+        cp = rng.standard_normal((*space.num_basis, 3))
+        bs = Bspline(space, cp)
+        beziers = bs.to_beziers()
+
+        extraction = SpanwiseElementExtraction(space, target="bezier")
+        degrees = bs.degree
+        orders = tuple(p + 1 for p in degrees)
+
+        for idx in np.ndindex(*space.num_intervals):
+            # Gather local B-spline control points for this element.
+            slices: tuple[slice | int, ...] = tuple(
+                slice(i, i + orders[d]) for d, i in enumerate(idx)
+            )
+            ctrl_local = bs.control_points[(*slices, slice(None))]
+            n_in = int(np.prod(orders))
+            rank = ctrl_local.shape[-1]
+
+            # Full Kronecker operator from SpanwiseElementExtraction.
+            M = extraction.operator(idx)
+            expected = (M.T @ ctrl_local.reshape(n_in, rank)).reshape(*orders, rank)
+
+            np.testing.assert_allclose(
+                beziers[idx].control_points,
+                expected,
+                atol=1e-12,
+                err_msg=f"Mismatch at element {idx}",
+            )

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -888,6 +888,13 @@ class TestToBeziersSpanwiseParity:
 
     where ``M = extraction.operator(idx) = kron(C_0[i0], ..., C_{d-1}[i_{d-1}])`` and
     ``ctrl_local = ctrl[i0:i0+order_0, ..., i_{d-1}:i_{d-1}+order_{d-1}, :]``.
+
+    The ``.T`` arises because ``_apply_bezier_extraction_1d_core`` computes
+    ``C_i^T @ P_local`` (column-convention operators matching the kernel at
+    ``_bspline_to_beziers.py:62``).
+
+    Periodic spaces are excluded: ``SpanwiseElementExtraction`` raises
+    ``NotImplementedError`` for them; periodic coverage lives in ``TestToBeziers``.
     """
 
     @pytest.mark.parametrize(
@@ -909,8 +916,14 @@ class TestToBeziersSpanwiseParity:
                 ],
                 30,
             ),
+            # Single-element space: Bezier extraction is the identity everywhere,
+            # so expected == ctrl_local. Exercises the identity short-circuit path.
+            ([BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)], 40),
+            # Degree-3 space: exercises order=4 in the Numba kernel and higher-degree
+            # extraction operators with non-trivial entries.
+            ([BsplineSpace1D([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], 3)], 50),
         ],
-        ids=["1d", "2d", "3d"],
+        ids=["1d", "2d", "3d", "1d_single", "1d_deg3"],
     )
     def test_element_cp_matches_operator_transpose(
         self, spaces: list[BsplineSpace1D], rng_seed: int


### PR DESCRIPTION
Closes part of #141 (PR 3 of 5).

## Summary

- `_to_beziers_impl` now builds a `SpanwiseElementExtraction(space, target="bezier")` once before the direction-by-direction sweep and sources `extraction_ops` from `extraction.ops_1d[d]`, replacing the previous direct call to `space_1d.tabulate_Bezier_extraction_operators()` per direction.
- The parallel batch kernel `_apply_bezier_extraction_1d_core` and the reshape/Bezier-construction logic are unchanged.
- Added `TestToBeziersSpanwiseParity` — parametrized 1D/2D/3D fixture verifying that each patch's control points equal `extraction.operator(idx).T @ ctrl_local`, which would catch future drift between `_to_beziers_impl` and the operators cached by `SpanwiseElementExtraction`.

## Test plan

- [x] All 2390 existing tests pass
- [x] 3 new parity tests pass (1D, 2D, 3D)
- [x] ruff lint and format: clean
- [x] mypy strict: 0 errors
- [x] Sphinx docs build: 0 warnings

Generated with [Claude Code](https://claude.com/claude-code)