### PR TITLE
perf(extraction): add batch apply methods to SpanwiseElementExtraction

### DIFF
--- a/benchmarks/bench_extraction_batch.py
+++ b/benchmarks/bench_extraction_batch.py
@@ -1,0 +1,93 @@
+"""Benchmark: apply_many vs. per-cell apply loop for SpanwiseElementExtraction.
+
+Usage::
+
+    conda run -n pantr python benchmarks/bench_extraction_batch.py
+
+Constructs a 3D B-spline space (degree 3, 20 elements per direction) and
+times ``apply_many`` against a Python loop over ``apply`` for a range of
+batch sizes. Prints a table of loop_ms vs. batch_ms with speedup.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
+
+_N_REPEATS = 5
+_BATCH_SIZES = [1, 10, 50, 100, 500, 1000, 5000]
+
+
+def _build_space() -> BsplineSpace:
+    """3D space: degree 3, 20 elements per direction, ~50k DOFs."""
+    knots = np.concatenate(
+        [
+            np.zeros(4),
+            np.arange(1, 20),
+            np.full(4, 20),
+        ]
+    ).astype(np.float64)
+    sp1 = BsplineSpace1D(knots, 3)
+    return BsplineSpace([sp1, sp1, sp1])
+
+
+def _time_loop(
+    ext: SpanwiseElementExtraction,
+    v: np.ndarray,
+    flat_idx: np.ndarray,
+) -> float:
+    """Time a Python loop over per-cell apply; return minimum wall time in ms."""
+    n_cells = v.shape[0]
+    best = float("inf")
+    for _ in range(_N_REPEATS):
+        t0 = time.perf_counter()
+        out = np.empty_like(v[:, : int(np.prod(ext.output_shape_per_dir))])
+        for c in range(n_cells):
+            out[c] = ext.apply(v[c], int(flat_idx[c]))
+        best = min(best, time.perf_counter() - t0)
+    return best * 1e3
+
+
+def _time_batch(
+    ext: SpanwiseElementExtraction,
+    v: np.ndarray,
+    flat_idx: np.ndarray,
+) -> float:
+    """Time apply_many; return minimum wall time in ms."""
+    best = float("inf")
+    for _ in range(_N_REPEATS):
+        t0 = time.perf_counter()
+        ext.apply_many(v, flat_idx)
+        best = min(best, time.perf_counter() - t0)
+    return best * 1e3
+
+
+def main() -> None:
+    """Run the benchmark and print results."""
+    sp = _build_space()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    total = ext.num_total_intervals
+
+    print(f"Space: 3D, degree 3, {ext.num_intervals} intervals, {total} total cells")
+    print(f"N_in per cell: {n_in},  N_repeats: {_N_REPEATS}")
+    print()
+    print(f"{'n_cells':>8}  {'loop_ms':>10}  {'batch_ms':>10}  {'speedup':>8}")
+    print("-" * 44)
+
+    rng = np.random.default_rng(0)
+    for n_cells in _BATCH_SIZES:
+        flat_idx = rng.integers(0, total, size=n_cells)
+        v = rng.standard_normal((n_cells, n_in))
+
+        loop_ms = _time_loop(ext, v, flat_idx)
+        batch_ms = _time_batch(ext, v, flat_idx)
+        speedup = loop_ms / batch_ms if batch_ms > 0 else float("nan")
+        print(f"{n_cells:>8}  {loop_ms:>10.3f}  {batch_ms:>10.3f}  {speedup:>8.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_extraction_batch.py
+++ b/benchmarks/bench_extraction_batch.py
@@ -22,7 +22,7 @@ _BATCH_SIZES = [1, 10, 50, 100, 500, 1000, 5000]
 
 
 def _build_space() -> BsplineSpace:
-    """3D space: degree 3, 20 elements per direction, ~50k DOFs."""
+    """3D space: degree 3, 20 elements per direction, ~12k DOFs."""
     knots = np.concatenate(
         [
             np.zeros(4),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,7 @@ nitpick_ignore = [
     ("py:class", "numpy._typing._dtype_like._SupportsDType"),
     ("py:class", "numpy._typing._nested_sequence._NestedSequence"),
     ("py:class", "CellIndex"),
+    ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),
 ]
 

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -436,6 +436,17 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
     )
     _validate_operand(operand, expected_in_shape, dtype)
     out = _allocate_or_validate_out(out, expected_out_shape, dtype)
+    # When every direction is identity the bilateral kernel is a pure copy, so
+    # aliasing out=K is safe.  Only raise for the general (non-identity) case.
+    if (
+        op_kind in ("MT_K_M", "M_K_MT")
+        and not all(is_identity_per_dir)
+        and np.shares_memory(operand, out)
+    ):
+        raise ValueError(
+            "out must not alias the operand (K) for bilateral operations; "
+            "the kernel reads and writes overlapping memory"
+        )
 
     scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)
     scratch = _allocate_or_validate_scratch(scratch, scratch_size, dtype)
@@ -496,17 +507,17 @@ def _allocate_or_validate_scratch_many(
         raise ValueError(
             f"Batch scratch shape[0]={scratch.shape[0]} does not match n_cells={n_cells}"
         )
-    if scratch.shape[1] < scratch_size_per_cell:
+    if scratch.shape[1] < alloc_width:
         raise ValueError(
             f"Batch scratch shape[1]={scratch.shape[1]} is smaller than "
-            f"required scratch_size_per_cell={scratch_size_per_cell}"
+            f"required width={alloc_width}"
         )
     if not scratch.flags.writeable:
         raise ValueError("Batch scratch array is not writeable")
     return scratch
 
 
-def _prepare_apply_many_call(  # noqa: PLR0913
+def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
     ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...],
     is_identity_masks: tuple[npt.NDArray[np.bool_], ...],
     cell_indices: npt.NDArray[np.intp],
@@ -530,8 +541,10 @@ def _prepare_apply_many_call(  # noqa: PLR0913
             shape ``(n_cells, d)``. Values must be non-negative and within the
             per-direction element counts from ``ops_1d``.
         operand (npt.NDArray[np.float32 | np.float64]): Batch input array.
-            Shape ``(n_cells, N_in)`` for vector kinds or
-            ``(n_cells, N, N)`` for bilateral kinds.
+            Shape ``(n_cells, N_in)`` for ``"apply"``,
+            ``(n_cells, N_out)`` for ``"apply_T"``,
+            ``(n_cells, N_out, N_out)`` for ``"MT_K_M"``, or
+            ``(n_cells, N_in, N_in)`` for ``"M_K_MT"``.
         out (npt.NDArray[np.float32 | np.float64] | None): Batch output array,
             or ``None`` to allocate.
         scratch (npt.NDArray[np.float32 | np.float64] | None): Per-cell scratch
@@ -560,6 +573,8 @@ def _prepare_apply_many_call(  # noqa: PLR0913
     for k, op in enumerate(ops_1d[1:], start=1):
         if op.dtype != dtype:
             raise ValueError(f"ops_1d[{k}] dtype {op.dtype} differs from ops_1d[0] dtype {dtype}")
+    if np.dtype(dtype).type not in (np.float32, np.float64):
+        raise ValueError(f"ops_1d operators must have dtype float32 or float64; got {dtype}")
 
     if cell_indices.ndim != 2:  # noqa: PLR2004
         raise ValueError(f"cell_indices must be 2D; got ndim={cell_indices.ndim}")
@@ -582,6 +597,15 @@ def _prepare_apply_many_call(  # noqa: PLR0913
     expected_out_shape = (n_cells, *per_cell_out)
     _validate_operand(operand, expected_operand, dtype)
     out = _allocate_or_validate_out(out, expected_out_shape, dtype)
+    if op_kind in ("MT_K_M", "M_K_MT") and np.shares_memory(operand, out):
+        all_identity = n_cells == 0 or all(
+            bool(is_identity_masks[k][cell_indices[:, k]].all()) for k in range(d)
+        )
+        if not all_identity:
+            raise ValueError(
+                "out must not alias the operand (K) for bilateral operations; "
+                "the kernel reads and writes overlapping memory"
+            )
 
     scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)
     scratch = _allocate_or_validate_scratch_many(scratch, n_cells, scratch_size, dtype)

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -27,12 +27,24 @@ from ._extraction_kernels import (
     apply_kron_1d,
     apply_kron_2d,
     apply_kron_3d,
+    apply_kron_apply_many_1d,
+    apply_kron_apply_many_2d,
+    apply_kron_apply_many_3d,
+    apply_kron_apply_T_many_1d,
+    apply_kron_apply_T_many_2d,
+    apply_kron_apply_T_many_3d,
     apply_kron_M_K_MT_1d,
     apply_kron_M_K_MT_2d,
     apply_kron_M_K_MT_3d,
+    apply_kron_M_K_MT_many_1d,
+    apply_kron_M_K_MT_many_2d,
+    apply_kron_M_K_MT_many_3d,
     apply_kron_MT_K_M_1d,
     apply_kron_MT_K_M_2d,
     apply_kron_MT_K_M_3d,
+    apply_kron_MT_K_M_many_1d,
+    apply_kron_MT_K_M_many_2d,
+    apply_kron_MT_K_M_many_3d,
     apply_kron_T_1d,
     apply_kron_T_2d,
     apply_kron_T_3d,
@@ -62,6 +74,21 @@ _KERNELS: dict[tuple[OpKind, int], Callable[..., None]] = {
     ("M_K_MT", 1): apply_kron_M_K_MT_1d,
     ("M_K_MT", 2): apply_kron_M_K_MT_2d,
     ("M_K_MT", 3): apply_kron_M_K_MT_3d,
+}
+
+_KERNELS_MANY: dict[tuple[OpKind, int], Callable[..., None]] = {
+    ("apply", 1): apply_kron_apply_many_1d,
+    ("apply", 2): apply_kron_apply_many_2d,
+    ("apply", 3): apply_kron_apply_many_3d,
+    ("apply_T", 1): apply_kron_apply_T_many_1d,
+    ("apply_T", 2): apply_kron_apply_T_many_2d,
+    ("apply_T", 3): apply_kron_apply_T_many_3d,
+    ("MT_K_M", 1): apply_kron_MT_K_M_many_1d,
+    ("MT_K_M", 2): apply_kron_MT_K_M_many_2d,
+    ("MT_K_M", 3): apply_kron_MT_K_M_many_3d,
+    ("M_K_MT", 1): apply_kron_M_K_MT_many_1d,
+    ("M_K_MT", 2): apply_kron_M_K_MT_many_2d,
+    ("M_K_MT", 3): apply_kron_M_K_MT_many_3d,
 }
 
 
@@ -202,6 +229,30 @@ def _required_scratch_size(
         return _bilateral_scratch_size(output_shape_per_dir, input_shape_per_dir)
     # op_kind == "M_K_MT"
     return _bilateral_scratch_size(input_shape_per_dir, output_shape_per_dir)
+
+
+def _dispatch_apply_many(d: int, op_kind: OpKind) -> Callable[..., None]:
+    """Return the batch Layer-3 kernel for a given dimension and operation kind.
+
+    Args:
+        d (int): Number of tensor-product directions.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        Callable[..., None]: The corresponding ``@njit(parallel=True)`` kernel.
+
+    Raises:
+        NotImplementedError: If ``d`` is not in ``{1, 2, 3}``.
+        ValueError: If ``op_kind`` is invalid.
+    """
+    _validate_op_kind(op_kind)
+    if d < 1 or d > MAX_SUPPORTED_DIM:
+        raise NotImplementedError(
+            f"Extraction kernels are specialized for d in {{1, 2, 3}}; got d={d}. "
+            "Add a generic-d kernel in pantr.bspline._extraction_kernels to support "
+            "higher dimensions."
+        )
+    return _KERNELS_MANY[(op_kind, d)]
 
 
 def _dispatch_apply(d: int, op_kind: OpKind) -> Callable[..., None]:
@@ -402,13 +453,154 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
     return kernel, args, out
 
 
+def _allocate_or_validate_scratch_many(
+    scratch: npt.NDArray[np.float32 | np.float64] | None,
+    n_cells: int,
+    scratch_size_per_cell: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Allocate or validate the per-cell scratch buffer for a batch call.
+
+    The scratch array has shape ``(n_cells, max(scratch_size_per_cell, 1))``
+    so that ``scratch[cell]`` is always a non-empty 1D view (even when the
+    per-cell kernel does not use scratch).
+
+    A user-provided buffer is accepted when it has the correct dtype, is
+    writeable, is 2D, has ``shape[0] == n_cells``, and
+    ``shape[1] >= scratch_size_per_cell``.
+
+    Args:
+        scratch (npt.NDArray[np.float32 | np.float64] | None): Caller-provided
+            scratch array, or ``None`` to allocate.
+        n_cells (int): Number of cells in the batch.
+        scratch_size_per_cell (int): Minimum scratch elements required per cell
+            (may be 0 for d=1 vector kernels).
+        dtype (npt.DTypeLike): Required dtype.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The validated or freshly
+        allocated 2D scratch array.
+
+    Raises:
+        ValueError: If a provided ``scratch`` has wrong dtype, wrong ndim,
+            wrong ``shape[0]``, is too narrow, or is not writeable.
+    """
+    alloc_width = max(scratch_size_per_cell, 1)
+    if scratch is None:
+        return np.empty((n_cells, alloc_width), dtype=dtype)
+    if scratch.ndim != 2:  # noqa: PLR2004
+        raise ValueError(f"Batch scratch must be 2D; got ndim={scratch.ndim}")
+    if scratch.dtype != np.dtype(dtype):
+        raise ValueError(f"Batch scratch has dtype {scratch.dtype}, but expected {np.dtype(dtype)}")
+    if scratch.shape[0] != n_cells:
+        raise ValueError(
+            f"Batch scratch shape[0]={scratch.shape[0]} does not match n_cells={n_cells}"
+        )
+    if scratch.shape[1] < scratch_size_per_cell:
+        raise ValueError(
+            f"Batch scratch shape[1]={scratch.shape[1]} is smaller than "
+            f"required scratch_size_per_cell={scratch_size_per_cell}"
+        )
+    if not scratch.flags.writeable:
+        raise ValueError("Batch scratch array is not writeable")
+    return scratch  # type: ignore[return-value]
+
+
+def _prepare_apply_many_call(  # noqa: PLR0913
+    ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...],
+    is_identity_masks: tuple[npt.NDArray[np.bool_], ...],
+    cell_indices: npt.NDArray[np.intp],
+    operand: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64] | None,
+    scratch: npt.NDArray[np.float32 | np.float64] | None,
+    op_kind: OpKind,
+) -> tuple[
+    Callable[..., None],
+    tuple[Any, ...],
+    npt.NDArray[np.float32 | np.float64],
+]:
+    """Validate inputs and build the kernel call for a batch of cells.
+
+    Args:
+        ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]): Full per-direction
+            3D operator arrays ``(n_el_k, n_out_k, n_in_k)``. Length must equal ``d``.
+        is_identity_masks (tuple[npt.NDArray[np.bool_], ...]): Full per-direction
+            identity mask arrays of shape ``(n_el_k,)``. Length must equal ``d``.
+        cell_indices (npt.NDArray[np.intp]): Per-direction element indices,
+            shape ``(n_cells, d)``. Values must be non-negative and within the
+            per-direction element counts from ``ops_1d``.
+        operand (npt.NDArray[np.float32 | np.float64]): Batch input array.
+            Shape ``(n_cells, N_in)`` for vector kinds or
+            ``(n_cells, N, N)`` for bilateral kinds.
+        out (npt.NDArray[np.float32 | np.float64] | None): Batch output array,
+            or ``None`` to allocate.
+        scratch (npt.NDArray[np.float32 | np.float64] | None): Per-cell scratch
+            array of shape ``(n_cells, s)`` with ``s >= scratch_size_per_cell``,
+            or ``None`` to allocate.
+        op_kind (OpKind): Operation kind.
+
+    Returns:
+        tuple[Callable, tuple, npt.NDArray]: ``(kernel, args, out)`` where
+        ``kernel(*args)`` runs the batch operation, writing into ``out``.
+
+    Raises:
+        ValueError: If shapes, dtypes, writability, or index-range invariants fail.
+        NotImplementedError: If ``d > 3``.
+    """
+    _validate_op_kind(op_kind)
+    d = len(ops_1d)
+    if len(is_identity_masks) != d:
+        raise ValueError(f"is_identity_masks has length {len(is_identity_masks)}, expected {d}")
+    if d < 1:
+        raise ValueError("At least one direction is required")
+    for k, op in enumerate(ops_1d):
+        if op.ndim != 3:  # noqa: PLR2004
+            raise ValueError(f"ops_1d[{k}] must be 3D; got ndim={op.ndim}")
+    dtype = ops_1d[0].dtype
+    for k, op in enumerate(ops_1d[1:], start=1):
+        if op.dtype != dtype:
+            raise ValueError(f"ops_1d[{k}] dtype {op.dtype} differs from ops_1d[0] dtype {dtype}")
+
+    if cell_indices.ndim != 2:  # noqa: PLR2004
+        raise ValueError(f"cell_indices must be 2D; got ndim={cell_indices.ndim}")
+    if cell_indices.shape[1] != d:
+        raise ValueError(f"cell_indices.shape[1]={cell_indices.shape[1]} does not match d={d}")
+    n_cells = cell_indices.shape[0]
+    if n_cells > 0:
+        for k, op in enumerate(ops_1d):
+            n_el_k = op.shape[0]
+            col = cell_indices[:, k]
+            if int(col.min()) < 0 or int(col.max()) >= n_el_k:
+                raise IndexError(f"cell_indices[:, {k}] contains values outside [0, {n_el_k})")
+
+    input_shape_per_dir = tuple(int(op.shape[2]) for op in ops_1d)
+    output_shape_per_dir = tuple(int(op.shape[1]) for op in ops_1d)
+    per_cell_in, per_cell_out = _operation_shapes(
+        input_shape_per_dir, output_shape_per_dir, op_kind
+    )
+    expected_operand = (n_cells, *per_cell_in)
+    expected_out_shape = (n_cells, *per_cell_out)
+    _validate_operand(operand, expected_operand, dtype)
+    out = _allocate_or_validate_out(out, expected_out_shape, dtype)
+
+    scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)
+    scratch = _allocate_or_validate_scratch_many(scratch, n_cells, scratch_size, dtype)
+
+    kernel = _dispatch_apply_many(d, op_kind)
+    args: tuple[Any, ...] = (*ops_1d, *is_identity_masks, cell_indices, operand, out, scratch)
+    return kernel, args, out
+
+
 __all__ = [
     "MAX_SUPPORTED_DIM",
     "OpKind",
     "_allocate_or_validate_scratch",
+    "_allocate_or_validate_scratch_many",
     "_dispatch_apply",
+    "_dispatch_apply_many",
     "_operation_shapes",
     "_prepare_apply_call",
+    "_prepare_apply_many_call",
     "_required_scratch_size",
     "_validate_op_kind",
     "_validate_operand",

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -503,7 +503,7 @@ def _allocate_or_validate_scratch_many(
         )
     if not scratch.flags.writeable:
         raise ValueError("Batch scratch array is not writeable")
-    return scratch  # type: ignore[return-value]
+    return scratch
 
 
 def _prepare_apply_many_call(  # noqa: PLR0913

--- a/src/pantr/bspline/_extraction_kernels.py
+++ b/src/pantr/bspline/_extraction_kernels.py
@@ -2,17 +2,23 @@
 
 This module provides Layer-3 (Numba) primitives that apply tensor-product
 change-of-basis operators ``M = kron(M_0, M_1, ..., M_{d-1})`` to vectors and
-matrices without ever materializing the full Kronecker product. Each kernel
-operates on a single cell: the caller passes in the per-direction 1D operators
-selected for that cell (``M_k``), per-direction identity flags (``is_id_k``),
-and pre-allocated output and scratch arrays.
+matrices without ever materializing the full Kronecker product.
 
-Kernels are specialized for ``d in {1, 2, 3}`` and cover four operations:
+**Per-cell kernels** (single cell, no ``parallel``; callable from outer prange):
 
 - ``apply_kron_{d}d``:        ``out = M @ v``
 - ``apply_kron_T_{d}d``:      ``out = M^T @ v``
 - ``apply_kron_MT_K_M_{d}d``: ``out = M^T @ K @ M``
 - ``apply_kron_M_K_MT_{d}d``: ``out = M @ K @ M^T``
+
+**Batch kernels** (``parallel=True``; ``prange`` over cells):
+
+- ``apply_kron_apply_many_{d}d``:    ``out[c] = M_c @ v[c]``
+- ``apply_kron_apply_T_many_{d}d``:  ``out[c] = M_c^T @ v[c]``
+- ``apply_kron_MT_K_M_many_{d}d``:   ``out[c] = M_c^T @ K[c] @ M_c``
+- ``apply_kron_M_K_MT_many_{d}d``:   ``out[c] = M_c @ K[c] @ M_c^T``
+
+All kernels are specialized for ``d in {1, 2, 3}``.
 
 Identity short-circuit: when ``is_id_k`` is True, the mode-k contraction is
 skipped (the axis is passed through unchanged, and ``M_k`` is not read). When
@@ -20,23 +26,20 @@ all directions are identity, the kernel degenerates to a direct copy
 ``out[:] = input[:]``, which is aliasing-safe -- the caller may pass the same
 array as input and output.
 
-These kernels are designed to be callable from other ``@njit`` code: they are
+Per-cell kernels are designed to be callable from other ``@njit`` code: they are
 module-level free functions with plain NumPy-array arguments, no optional
-parameters, and ``cache=True`` so downstream libraries can dispatch to them
-directly from their own JIT-compiled loops.
-
-``parallel=True`` is intentionally omitted: these kernels operate on a single
-cell and are expected to be called from within a caller-level ``prange`` loop.
-Enabling intra-kernel parallelism would conflict with the outer thread pool and
-degrade performance.
+parameters, and ``cache=True``. The batch kernels use ``parallel=True`` and
+dispatch to the per-cell kernels inside the ``prange`` body.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import numpy.typing as npt
 
-from .._numba_compat import nb_jit
+from .._numba_compat import nb_jit, nb_prange
 
 
 @nb_jit(nopython=True, cache=True)
@@ -1230,6 +1233,558 @@ def apply_kron_M_K_MT_3d(  # noqa: PLR0913, PLR0912, PLR0915 -- kernel fan-in an
                                 out_view[i, j, k, a, b, c] = cur[i, j, k, a, b, c]
 
 
+# ---------------------------------------------------------------- batch kernels
+# Each batch kernel wraps the corresponding per-cell kernel in a prange loop
+# over cells. Scratch is 2D: shape (n_cells, scratch_size_per_cell). Indexing
+# scratch[cell] gives the 1D per-cell slice that the per-cell kernels expect.
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
+    ops_0: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``M_0 @ v[c]`` for every cell ``c`` in the batch (d=1).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 1)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_in)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``; unused for d=1.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        apply_kron_1d(ops_0[i0], is_id_0[i0], v[cell], out[cell], scratch[cell])
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_many_2d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``kron(M_0, M_1) @ v[c]`` for every cell ``c`` in the batch (d=2).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 2)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_in)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        apply_kron_2d(
+            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], v[cell], out[cell], scratch[cell]
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_many_3d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    ops_2: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    is_id_2: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``kron(M_0, M_1, M_2) @ v[c]`` for every cell ``c`` in the batch (d=3).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
+            shape ``(n_el_2, n_out_2, n_in_2)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        is_id_2 (npt.NDArray[Any]): Per-element identity flags for direction 2,
+            shape ``(n_el_2,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 3)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_in)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        i2 = cell_indices[cell, 2]
+        apply_kron_3d(
+            ops_0[i0],
+            ops_1[i1],
+            ops_2[i2],
+            is_id_0[i0],
+            is_id_1[i1],
+            is_id_2[i2],
+            v[cell],
+            out[cell],
+            scratch[cell],
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_T_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
+    ops_0: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``M_0^T @ v[c]`` for every cell ``c`` in the batch (d=1).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
+            ``(n_el_0,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 1)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_out)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``; unused for d=1.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        apply_kron_T_1d(ops_0[i0], is_id_0[i0], v[cell], out[cell], scratch[cell])
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_T_many_2d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``kron(M_0, M_1)^T @ v[c]`` for every cell ``c`` in the batch (d=2).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 2)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_out)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        apply_kron_T_2d(
+            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], v[cell], out[cell], scratch[cell]
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_apply_T_many_3d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    ops_2: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    is_id_2: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Apply ``kron(M_0, M_1, M_2)^T @ v[c]`` for every cell ``c`` in the batch (d=3).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
+            shape ``(n_el_2, n_out_2, n_in_2)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        is_id_2 (npt.NDArray[Any]): Per-element identity flags for direction 2,
+            shape ``(n_el_2,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 3)`` integer.
+        v (npt.NDArray[Any]): Batch input vectors, shape ``(n_cells, N_out)``.
+        out (npt.NDArray[Any]): Batch output vectors, shape ``(n_cells, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        i2 = cell_indices[cell, 2]
+        apply_kron_T_3d(
+            ops_0[i0],
+            ops_1[i1],
+            ops_2[i2],
+            is_id_0[i0],
+            is_id_1[i1],
+            is_id_2[i2],
+            v[cell],
+            out[cell],
+            scratch[cell],
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_MT_K_M_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
+    ops_0: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``M_0^T @ K[c] @ M_0`` for every cell ``c`` in the batch (d=1).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
+            ``(n_el_0,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 1)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        apply_kron_MT_K_M_1d(ops_0[i0], is_id_0[i0], K[cell], out[cell], scratch[cell])
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_MT_K_M_many_2d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``kron(M_0,M_1)^T @ K[c] @ kron(M_0,M_1)`` for every cell (d=2).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 2)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        apply_kron_MT_K_M_2d(
+            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], K[cell], out[cell], scratch[cell]
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    ops_2: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    is_id_2: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``kron(M_0,M_1,M_2)^T @ K[c] @ kron(M_0,M_1,M_2)`` for every cell (d=3).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
+            shape ``(n_el_2, n_out_2, n_in_2)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        is_id_2 (npt.NDArray[Any]): Per-element identity flags for direction 2,
+            shape ``(n_el_2,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 3)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        i2 = cell_indices[cell, 2]
+        apply_kron_MT_K_M_3d(
+            ops_0[i0],
+            ops_1[i1],
+            ops_2[i2],
+            is_id_0[i0],
+            is_id_1[i1],
+            is_id_2[i2],
+            K[cell],
+            out[cell],
+            scratch[cell],
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_M_K_MT_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
+    ops_0: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``M_0 @ K[c] @ M_0^T`` for every cell ``c`` in the batch (d=1).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
+            ``(n_el_0,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 1)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        apply_kron_M_K_MT_1d(ops_0[i0], is_id_0[i0], K[cell], out[cell], scratch[cell])
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_M_K_MT_many_2d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``kron(M_0,M_1) @ K[c] @ kron(M_0,M_1)^T`` for every cell (d=2).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 2)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        apply_kron_M_K_MT_2d(
+            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], K[cell], out[cell], scratch[cell]
+        )
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def apply_kron_M_K_MT_many_3d(  # noqa: PLR0913
+    ops_0: npt.NDArray[Any],
+    ops_1: npt.NDArray[Any],
+    ops_2: npt.NDArray[Any],
+    is_id_0: npt.NDArray[Any],
+    is_id_1: npt.NDArray[Any],
+    is_id_2: npt.NDArray[Any],
+    cell_indices: npt.NDArray[Any],
+    K: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    """Compute ``kron(M_0,M_1,M_2) @ K[c] @ kron(M_0,M_1,M_2)^T`` for every cell (d=3).
+
+    Args:
+        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
+            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
+            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
+            shape ``(n_el_2, n_out_2, n_in_2)``.
+        is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
+            shape ``(n_el_0,)`` boolean.
+        is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
+            shape ``(n_el_1,)`` boolean.
+        is_id_2 (npt.NDArray[Any]): Per-element identity flags for direction 2,
+            shape ``(n_el_2,)`` boolean.
+        cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
+            ``(n_cells, 3)`` integer.
+        K (npt.NDArray[Any]): Batch input matrices, shape
+            ``(n_cells, N_in, N_in)``.
+        out (npt.NDArray[Any]): Batch output matrices, shape
+            ``(n_cells, N_out, N_out)``.
+        scratch (npt.NDArray[Any]): Per-cell scratch buffers, shape
+            ``(n_cells, scratch_size)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        ``out[c]`` must not alias ``K[c]`` except in the all-identity case.
+        For general use, call the Layer-2 dispatcher in
+        :mod:`pantr.bspline._extraction_helpers` instead.
+    """
+    for cell in nb_prange(cell_indices.shape[0]):
+        i0 = cell_indices[cell, 0]
+        i1 = cell_indices[cell, 1]
+        i2 = cell_indices[cell, 2]
+        apply_kron_M_K_MT_3d(
+            ops_0[i0],
+            ops_1[i1],
+            ops_2[i2],
+            is_id_0[i0],
+            is_id_1[i1],
+            is_id_2[i2],
+            K[cell],
+            out[cell],
+            scratch[cell],
+        )
+
+
 __all__ = [
     "apply_kron_1d",
     "apply_kron_2d",
@@ -1237,10 +1792,22 @@ __all__ = [
     "apply_kron_MT_K_M_1d",
     "apply_kron_MT_K_M_2d",
     "apply_kron_MT_K_M_3d",
+    "apply_kron_MT_K_M_many_1d",
+    "apply_kron_MT_K_M_many_2d",
+    "apply_kron_MT_K_M_many_3d",
     "apply_kron_M_K_MT_1d",
     "apply_kron_M_K_MT_2d",
     "apply_kron_M_K_MT_3d",
+    "apply_kron_M_K_MT_many_1d",
+    "apply_kron_M_K_MT_many_2d",
+    "apply_kron_M_K_MT_many_3d",
     "apply_kron_T_1d",
     "apply_kron_T_2d",
     "apply_kron_T_3d",
+    "apply_kron_apply_T_many_1d",
+    "apply_kron_apply_T_many_2d",
+    "apply_kron_apply_T_many_3d",
+    "apply_kron_apply_many_1d",
+    "apply_kron_apply_many_2d",
+    "apply_kron_apply_many_3d",
 ]

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -671,7 +671,15 @@ class SpanwiseElementExtraction:
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional scratch.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: The result array.
+            npt.NDArray[np.float32 | np.float64]: Result array of shape
+            ``(n_cells, N_out)`` for vector kinds or ``(n_cells, N_out, N_out)`` /
+            ``(n_cells, N_in, N_in)`` for bilateral kinds.
+
+        Raises:
+            IndexError: If any cell index is out of range.
+            ValueError: If operand shape/dtype or ``out``/``scratch`` are invalid.
+            TypeError: If ``cell_indices`` contains non-integer values.
+            NotImplementedError: If the space has more than 3 directions.
         """
         idx2d = normalize_cell_indices(cell_indices, self.num_intervals)
         kernel, args, result = _prepare_apply_many_call(
@@ -835,18 +843,22 @@ def normalize_cell_indices(
         npt.NDArray[np.intp]: 2-D integer array of shape ``(n_cells, d)``.
 
     Raises:
-        ValueError: If ``cell_indices`` has wrong shape or out-of-range values.
-        TypeError: If ``cell_indices`` is not an array-like of integers.
+        IndexError: If any value is out of range for its per-direction bound.
+        ValueError: If ``cell_indices`` has the wrong shape or ndim.
+        TypeError: If ``cell_indices`` contains non-integer values.
     """
     d = len(num_intervals)
-    arr = np.asarray(cell_indices, dtype=np.intp)
+    arr_raw = np.asarray(cell_indices)
+    if arr_raw.size > 0 and not np.issubdtype(arr_raw.dtype, np.integer):
+        raise TypeError(f"cell_indices must contain integers; got dtype {arr_raw.dtype}")
+    arr = arr_raw.astype(np.intp)
     if arr.ndim == 1:
         n_cells = arr.shape[0]
         total = 1
         for n in num_intervals:
             total *= n
         if n_cells > 0 and (int(arr.min()) < 0 or int(arr.max()) >= total):
-            raise ValueError(
+            raise IndexError(
                 f"Flat cell indices must be in [0, {total}); "
                 f"got range [{int(arr.min())}, {int(arr.max())}]"
             )
@@ -862,7 +874,7 @@ def normalize_cell_indices(
             for k, n_el in enumerate(num_intervals):
                 col = arr[:, k]
                 if int(col.min()) < 0 or int(col.max()) >= n_el:
-                    raise ValueError(
+                    raise IndexError(
                         f"cell_indices[:, {k}] must be in [0, {n_el}); "
                         f"got range [{int(col.min())}, {int(col.max())}]"
                     )

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -33,7 +33,12 @@ import numpy.typing as npt
 
 from ..basis import LagrangeVariant
 from ..basis._basis_utils import _allocate_or_validate_out
-from ._extraction_helpers import OpKind, _operation_shapes, _prepare_apply_call
+from ._extraction_helpers import (
+    OpKind,
+    _operation_shapes,
+    _prepare_apply_call,
+    _prepare_apply_many_call,
+)
 
 if TYPE_CHECKING:
     from ._bspline_space_nd import BsplineSpace
@@ -45,6 +50,17 @@ Target = Literal["bezier", "lagrange", "cardinal"]
 
 CellIndex = int | tuple[int, ...] | list[int] | npt.NDArray[np.int_]
 """Accepted cell-index forms: flat ``int``, or a per-direction integer sequence."""
+
+CellIndicesBatch = npt.NDArray[np.int_] | list[int] | list[tuple[int, ...]] | list[list[int]]
+"""Accepted batch cell-index forms.
+
+May be:
+
+- 1-D integer array or list of ``n_cells`` flat indices (row-major over
+  :attr:`~SpanwiseElementExtraction.num_intervals`).
+- 2-D integer array of shape ``(n_cells, d)`` with per-direction indices.
+- List of per-direction integer tuples or lists of length ``d``.
+"""
 
 
 class SpanwiseElementExtraction:
@@ -637,6 +653,222 @@ class SpanwiseElementExtraction:
         kernel(*args)
         return result
 
+    def _apply_many(
+        self,
+        operand: npt.NDArray[np.float32 | np.float64],
+        cell_indices: CellIndicesBatch,
+        op_kind: OpKind,
+        out: npt.NDArray[np.float32 | np.float64] | None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Dispatch a batch apply variant through the Layer-2 helper.
+
+        Args:
+            operand (npt.NDArray[np.float32 | np.float64]): Batch input array.
+            cell_indices (CellIndicesBatch): Flat or per-direction cell indices.
+            op_kind (OpKind): Which apply variant to dispatch.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional scratch.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: The result array.
+        """
+        idx2d = normalize_cell_indices(cell_indices, self.num_intervals)
+        kernel, args, result = _prepare_apply_many_call(
+            self._ops_1d,
+            self._is_identity_mask_1d,
+            idx2d,
+            operand,
+            out,
+            scratch,
+            op_kind,
+        )
+        kernel(*args)
+        return result
+
+    # ---------------------------------------------------------------- batch applies
+
+    def apply_many(
+        self,
+        v: npt.NDArray[np.float32 | np.float64],
+        cell_indices: CellIndicesBatch,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out[c] = M_c @ v[c]`` for all cells in the batch.
+
+        ``M_c = kron(M_0[c_0], …, M_{d-1}[c_{d-1}])`` with ``M_k[c_k]`` the
+        1D operator at element ``c_k`` in direction ``k``; identity directions
+        short-circuit per cell.
+
+        Args:
+            v (npt.NDArray[np.float32 | np.float64]): Batch input vectors,
+                shape ``(n_cells, N_in)`` with
+                ``N_in = prod(input_shape_per_dir)``.
+            cell_indices (CellIndicesBatch): Cell indices — flat 1-D array of
+                shape ``(n_cells,)`` or per-direction 2-D array of shape
+                ``(n_cells, d)``.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(n_cells, N_out)``. Allocated if ``None``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                per-cell scratch array of shape ``(n_cells, s)`` with
+                ``s >= scratch_size_per_cell``. Allocated if ``None``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Result array of shape
+            ``(n_cells, N_out)``.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions.
+        """
+        return self._apply_many(v, cell_indices, "apply", out, scratch)
+
+    def apply_transpose_many(
+        self,
+        v: npt.NDArray[np.float32 | np.float64],
+        cell_indices: CellIndicesBatch,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out[c] = M_c^T @ v[c]`` for all cells in the batch.
+
+        Args:
+            v (npt.NDArray[np.float32 | np.float64]): Batch input vectors,
+                shape ``(n_cells, N_out)`` with
+                ``N_out = prod(output_shape_per_dir)``.
+            cell_indices (CellIndicesBatch): Cell indices — flat or per-direction.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(n_cells, N_in)``. Allocated if ``None``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                per-cell scratch array. Allocated if ``None``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Result array of shape
+            ``(n_cells, N_in)``.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions.
+        """
+        return self._apply_many(v, cell_indices, "apply_T", out, scratch)
+
+    def apply_MT_K_M_many(
+        self,
+        K: npt.NDArray[np.float32 | np.float64],
+        cell_indices: CellIndicesBatch,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out[c] = M_c^T @ K[c] @ M_c`` for all cells in the batch.
+
+        Args:
+            K (npt.NDArray[np.float32 | np.float64]): Batch input matrices,
+                shape ``(n_cells, N_out, N_out)`` with
+                ``N_out = prod(output_shape_per_dir)``.
+            cell_indices (CellIndicesBatch): Cell indices — flat or per-direction.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(n_cells, N_in, N_in)``. Must not alias ``K``.
+                Allocated if ``None``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                per-cell scratch array. Allocated if ``None``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Result array of shape
+            ``(n_cells, N_in, N_in)``.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions.
+        """
+        return self._apply_many(K, cell_indices, "MT_K_M", out, scratch)
+
+    def apply_M_K_MT_many(
+        self,
+        K: npt.NDArray[np.float32 | np.float64],
+        cell_indices: CellIndicesBatch,
+        *,
+        out: npt.NDArray[np.float32 | np.float64] | None = None,
+        scratch: npt.NDArray[np.float32 | np.float64] | None = None,
+    ) -> npt.NDArray[np.float32 | np.float64]:
+        """Compute ``out[c] = M_c @ K[c] @ M_c^T`` for all cells in the batch.
+
+        Args:
+            K (npt.NDArray[np.float32 | np.float64]): Batch input matrices,
+                shape ``(n_cells, N_in, N_in)`` with
+                ``N_in = prod(input_shape_per_dir)``.
+            cell_indices (CellIndicesBatch): Cell indices — flat or per-direction.
+            out (npt.NDArray[np.float32 | np.float64] | None): Optional output
+                array of shape ``(n_cells, N_out, N_out)``. Must not alias ``K``.
+                Allocated if ``None``.
+            scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
+                per-cell scratch array. Allocated if ``None``.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Result array of shape
+            ``(n_cells, N_out, N_out)``.
+
+        Raises:
+            NotImplementedError: If the space has more than 3 directions.
+        """
+        return self._apply_many(K, cell_indices, "M_K_MT", out, scratch)
+
+
+def normalize_cell_indices(
+    cell_indices: CellIndicesBatch,
+    num_intervals: tuple[int, ...],
+) -> npt.NDArray[np.intp]:
+    """Convert batch cell indices to a validated ``(n_cells, d)`` integer array.
+
+    Accepts flat indices (row-major over ``num_intervals``) or per-direction
+    indices, in array or list form. Validates that all values are within their
+    respective per-direction bounds and that the shape is consistent.
+
+    Args:
+        cell_indices (CellIndicesBatch): Flat 1-D array or list of ``n_cells``
+            flat indices, or 2-D array/list of shape ``(n_cells, d)`` with
+            per-direction indices.
+        num_intervals (tuple[int, ...]): Per-direction element counts
+            ``(n_el_0, …, n_el_{d-1})``.
+
+    Returns:
+        npt.NDArray[np.intp]: 2-D integer array of shape ``(n_cells, d)``.
+
+    Raises:
+        ValueError: If ``cell_indices`` has wrong shape or out-of-range values.
+        TypeError: If ``cell_indices`` is not an array-like of integers.
+    """
+    d = len(num_intervals)
+    arr = np.asarray(cell_indices, dtype=np.intp)
+    if arr.ndim == 1:
+        n_cells = arr.shape[0]
+        total = 1
+        for n in num_intervals:
+            total *= n
+        if n_cells > 0 and (int(arr.min()) < 0 or int(arr.max()) >= total):
+            raise ValueError(
+                f"Flat cell indices must be in [0, {total}); "
+                f"got range [{int(arr.min())}, {int(arr.max())}]"
+            )
+        rows = np.unravel_index(arr, num_intervals)
+        return np.stack(rows, axis=1)
+    if arr.ndim == 2:  # noqa: PLR2004
+        if arr.shape[1] != d:
+            raise ValueError(
+                f"Per-direction cell_indices must have shape (n_cells, {d}); got shape {arr.shape}"
+            )
+        n_cells = arr.shape[0]
+        if n_cells > 0:
+            for k, n_el in enumerate(num_intervals):
+                col = arr[:, k]
+                if int(col.min()) < 0 or int(col.max()) >= n_el:
+                    raise ValueError(
+                        f"cell_indices[:, {k}] must be in [0, {n_el}); "
+                        f"got range [{int(col.min())}, {int(col.max())}]"
+                    )
+        return arr
+    raise ValueError(f"cell_indices must be 1-D (flat) or 2-D (per-direction); got ndim={arr.ndim}")
+
 
 def _numerical_identity_mask(
     ops: npt.NDArray[np.float32 | np.float64], tol: float
@@ -684,7 +916,9 @@ def operand_shape(
 
 __all__ = [
     "CellIndex",
+    "CellIndicesBatch",
     "SpanwiseElementExtraction",
     "Target",
+    "normalize_cell_indices",
     "operand_shape",
 ]

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -19,10 +19,12 @@ Covers:
 - Batch :meth:`apply_many` / :meth:`apply_transpose_many` /
   :meth:`apply_MT_K_M_many` / :meth:`apply_M_K_MT_many`: round-trip match
   against per-cell :meth:`apply` for all (d, op_kind, target, dtype) combos,
-  flat and per-direction index forms, user-provided ``out``/``scratch``,
-  empty batch, and validation errors.
+  flat and per-direction index forms, user-provided ``out``/``scratch`` for all
+  four variants (including bilateral), empty batch for all four variants,
+  batch-size-1, aliasing rejection, wrong ``out`` shape, and validation errors
+  for :func:`_allocate_or_validate_scratch_many`.
 - :func:`normalize_cell_indices`: flat-to-2D conversion, per-direction
-  pass-through, and error cases.
+  pass-through, negative index rejection, float input rejection, and error cases.
 """
 
 from __future__ import annotations
@@ -35,6 +37,10 @@ import pytest
 
 from pantr.basis import LagrangeVariant
 from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
+from pantr.bspline._extraction_helpers import (
+    _allocate_or_validate_scratch_many,
+    _required_scratch_size,
+)
 from pantr.bspline.spanwise_element_extraction import (
     _numerical_identity_mask,
     normalize_cell_indices,
@@ -524,15 +530,27 @@ def test_normalize_empty_batch() -> None:
 
 
 def test_normalize_flat_out_of_range() -> None:
-    """Flat indices outside [0, total) raise ValueError."""
-    with pytest.raises(ValueError, match="Flat cell indices"):
+    """Flat indices outside [0, total) raise IndexError."""
+    with pytest.raises(IndexError, match="Flat cell indices"):
         normalize_cell_indices(np.array([12]), (3, 4))  # 3*4=12, so 12 is OOB
 
 
+def test_normalize_negative_flat_index_raises() -> None:
+    """Negative flat indices raise IndexError."""
+    with pytest.raises(IndexError, match="Flat cell indices"):
+        normalize_cell_indices(np.array([-1]), (3, 4))
+
+
 def test_normalize_per_direction_out_of_range() -> None:
-    """Per-direction indices outside per-direction bounds raise ValueError."""
-    with pytest.raises(ValueError, match="cell_indices"):
+    """Per-direction indices outside per-direction bounds raise IndexError."""
+    with pytest.raises(IndexError, match="cell_indices"):
         normalize_cell_indices(np.array([[3, 0]]), (3, 4))  # dir-0 max is 2
+
+
+def test_normalize_float_input_raises() -> None:
+    """Float cell_indices raise TypeError."""
+    with pytest.raises(TypeError, match="integers"):
+        normalize_cell_indices(np.array([0.0, 1.5, 2.9]), (3, 4))
 
 
 def test_normalize_wrong_ndim_raises() -> None:
@@ -764,7 +782,7 @@ def test_batch_apply_out_of_range_cell_index_raises() -> None:
     """Out-of-range cell index raises IndexError."""
     ext = SpanwiseElementExtraction(_space_2d(), "bezier")
     n_in = int(np.prod(ext.input_shape_per_dir))
-    with pytest.raises((IndexError, ValueError)):
+    with pytest.raises(IndexError):
         ext.apply_many(np.zeros((1, n_in)), np.array([ext.num_total_intervals]))
 
 
@@ -776,3 +794,128 @@ def test_batch_apply_dim4_raises_not_implemented() -> None:
     n_in = int(np.prod(ext.input_shape_per_dir))
     with pytest.raises(NotImplementedError):
         ext.apply_many(np.zeros((1, n_in)), np.array([0]))
+
+
+def test_batch_apply_size_one_matches_per_cell() -> None:
+    """A batch of exactly one cell produces the same result as the per-cell method."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    rng = np.random.default_rng(42)
+    v = rng.standard_normal((1, n_in))
+    cell = 7
+    out_batch = ext.apply_many(v, np.array([cell]))
+    out_single = ext.apply(v[0], cell)
+    np.testing.assert_allclose(out_batch[0], out_single, atol=1e-12)
+
+
+def test_batch_apply_bilateral_accepts_user_out_and_scratch() -> None:
+    """User-provided ``out`` and ``scratch`` work correctly for bilateral variants."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(5)
+    n_cells = 3
+    flat = rng.integers(0, ext.num_total_intervals, size=n_cells)
+
+    # MT_K_M: operand (n_cells, N_out, N_out) → out (n_cells, N_in, N_in)
+    K_mtk = rng.standard_normal((n_cells, n_out, n_out))
+    scratch_sz = _required_scratch_size(ext.input_shape_per_dir, ext.output_shape_per_dir, "MT_K_M")
+    out_mtk = np.zeros((n_cells, n_in, n_in))
+    scratch_mtk = np.zeros((n_cells, max(scratch_sz, 1)))
+    result_mtk = ext.apply_MT_K_M_many(K_mtk, flat, out=out_mtk, scratch=scratch_mtk)
+    assert result_mtk is out_mtk
+    for c in range(n_cells):
+        ref = ext.apply_MT_K_M(K_mtk[c], int(flat[c]))
+        np.testing.assert_allclose(out_mtk[c], ref, atol=1e-11)
+
+    # M_K_MT: operand (n_cells, N_in, N_in) → out (n_cells, N_out, N_out)
+    K_mkt = rng.standard_normal((n_cells, n_in, n_in))
+    scratch_sz2 = _required_scratch_size(
+        ext.input_shape_per_dir, ext.output_shape_per_dir, "M_K_MT"
+    )
+    out_mkt = np.zeros((n_cells, n_out, n_out))
+    scratch_mkt = np.zeros((n_cells, max(scratch_sz2, 1)))
+    result_mkt = ext.apply_M_K_MT_many(K_mkt, flat, out=out_mkt, scratch=scratch_mkt)
+    assert result_mkt is out_mkt
+    for c in range(n_cells):
+        ref = ext.apply_M_K_MT(K_mkt[c], int(flat[c]))
+        np.testing.assert_allclose(out_mkt[c], ref, atol=1e-11)
+
+
+def test_batch_apply_empty_batch_bilateral_shapes() -> None:
+    """Empty batch returns the correct shape for all four variants."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    empty = np.array([], dtype=np.intp)
+
+    assert ext.apply_many(np.empty((0, n_in)), empty).shape == (0, n_out)
+    assert ext.apply_transpose_many(np.empty((0, n_out)), empty).shape == (0, n_in)
+    assert ext.apply_MT_K_M_many(np.empty((0, n_out, n_out)), empty).shape == (0, n_in, n_in)
+    assert ext.apply_M_K_MT_many(np.empty((0, n_in, n_in)), empty).shape == (0, n_out, n_out)
+
+
+def test_batch_apply_bilateral_aliasing_raises() -> None:
+    """Passing the same array as both K and out raises ValueError."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    rng = np.random.default_rng(7)
+    flat = rng.integers(0, ext.num_total_intervals, size=2)
+
+    K = rng.standard_normal((2, n_out, n_out))
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply_MT_K_M_many(K, flat, out=K)
+
+    K2 = rng.standard_normal((2, n_in, n_in))
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply_M_K_MT_many(K2, flat, out=K2)
+
+
+def test_batch_apply_wrong_out_shape_raises() -> None:
+    """Wrong ``out`` shape raises ValueError."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_cells = 3
+    v = np.zeros((n_cells, n_in))
+    flat = np.arange(n_cells)
+    with pytest.raises(ValueError, match="shape"):
+        ext.apply_many(v, flat, out=np.zeros((n_cells, n_out + 1)))
+
+
+def test_allocate_or_validate_scratch_many_rejects_invalid() -> None:
+    """All five rejection branches in ``_allocate_or_validate_scratch_many`` raise ValueError."""
+    n_cells, width, dtype = 4, 8, np.float64
+
+    # Wrong ndim
+    with pytest.raises(ValueError, match="2D"):
+        _allocate_or_validate_scratch_many(np.zeros(n_cells * width), n_cells, width, dtype)
+
+    # Wrong dtype
+    with pytest.raises(ValueError, match="dtype"):
+        _allocate_or_validate_scratch_many(
+            np.zeros((n_cells, width), dtype=np.float32), n_cells, width, dtype
+        )
+
+    # Wrong shape[0]
+    with pytest.raises(ValueError, match="n_cells"):
+        _allocate_or_validate_scratch_many(
+            np.zeros((n_cells + 1, width), dtype=dtype), n_cells, width, dtype
+        )
+
+    # Too narrow (scratch.shape[1] < alloc_width = max(width, 1))
+    with pytest.raises(ValueError, match="width"):
+        _allocate_or_validate_scratch_many(
+            np.zeros((n_cells, width - 1), dtype=dtype), n_cells, width, dtype
+        )
+
+    # d=1 case: scratch_size_per_cell=0 so alloc_width=1; shape[1]=0 must be rejected
+    with pytest.raises(ValueError, match="width"):
+        _allocate_or_validate_scratch_many(np.zeros((n_cells, 0), dtype=dtype), n_cells, 0, dtype)
+
+    # Not writeable
+    ro = np.zeros((n_cells, width), dtype=dtype)
+    ro.flags.writeable = False
+    with pytest.raises(ValueError, match="writeable"):
+        _allocate_or_validate_scratch_many(ro, n_cells, width, dtype)

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -16,9 +16,18 @@ Covers:
 - Cell-index normalization (flat int, tuple, list, ndarray; negative indices
   rejected; IndexError / ValueError / TypeError on invalid input).
 - 1D spaces and rejection of dim > 3 via :exc:`NotImplementedError`.
+- Batch :meth:`apply_many` / :meth:`apply_transpose_many` /
+  :meth:`apply_MT_K_M_many` / :meth:`apply_M_K_MT_many`: round-trip match
+  against per-cell :meth:`apply` for all (d, op_kind, target, dtype) combos,
+  flat and per-direction index forms, user-provided ``out``/``scratch``,
+  empty batch, and validation errors.
+- :func:`normalize_cell_indices`: flat-to-2D conversion, per-direction
+  pass-through, and error cases.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -28,6 +37,7 @@ from pantr.basis import LagrangeVariant
 from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
 from pantr.bspline.spanwise_element_extraction import (
     _numerical_identity_mask,
+    normalize_cell_indices,
     operand_shape,
 )
 
@@ -475,3 +485,294 @@ def test_negative_per_direction_index_rejected() -> None:
     ext = SpanwiseElementExtraction(sp, "bezier")
     with pytest.raises(IndexError):
         ext.is_identity_at((-1, 0))
+
+
+# ---------------------------------------------------------------- normalize_cell_indices
+
+
+def test_normalize_flat_indices_converts_to_2d() -> None:
+    """Flat 1-D indices are converted to per-direction 2-D array correctly."""
+    num_intervals = (4, 5)
+    flat = np.array([0, 1, 9, 19])
+    result = normalize_cell_indices(flat, num_intervals)
+    assert result.shape == (4, 2)
+    for i, f in enumerate(flat):
+        expected = np.unravel_index(f, num_intervals)
+        np.testing.assert_array_equal(result[i], expected)
+
+
+def test_normalize_2d_indices_passthrough() -> None:
+    """2-D per-direction indices are returned as a numpy array unchanged."""
+    num_intervals = (3, 4, 2)
+    idx = np.array([[0, 1, 0], [2, 3, 1]])
+    result = normalize_cell_indices(idx, num_intervals)
+    assert result.shape == (2, 3)
+    np.testing.assert_array_equal(result, idx)
+
+
+def test_normalize_list_of_flat_indices() -> None:
+    """A plain Python list of flat integers is accepted."""
+    num_intervals = (6, 6)
+    result = normalize_cell_indices([0, 7, 35], num_intervals)
+    assert result.shape == (3, 2)
+
+
+def test_normalize_empty_batch() -> None:
+    """An empty batch produces a (0, d) output array."""
+    result = normalize_cell_indices(np.array([], dtype=np.intp), (3, 4))
+    assert result.shape == (0, 2)
+
+
+def test_normalize_flat_out_of_range() -> None:
+    """Flat indices outside [0, total) raise ValueError."""
+    with pytest.raises(ValueError, match="Flat cell indices"):
+        normalize_cell_indices(np.array([12]), (3, 4))  # 3*4=12, so 12 is OOB
+
+
+def test_normalize_per_direction_out_of_range() -> None:
+    """Per-direction indices outside per-direction bounds raise ValueError."""
+    with pytest.raises(ValueError, match="cell_indices"):
+        normalize_cell_indices(np.array([[3, 0]]), (3, 4))  # dir-0 max is 2
+
+
+def test_normalize_wrong_ndim_raises() -> None:
+    """3-D or 0-D input raises ValueError."""
+    with pytest.raises(ValueError, match="ndim"):
+        normalize_cell_indices(np.zeros((2, 3, 4), dtype=np.intp), (3, 4))
+
+
+def test_normalize_wrong_d_raises() -> None:
+    """2-D input with wrong number of columns raises ValueError."""
+    with pytest.raises(ValueError, match="shape"):
+        normalize_cell_indices(np.array([[0, 1, 0]]), (3, 4))  # 3 cols but d=2
+
+
+# ---------------------------------------------------------------- batch apply helpers
+
+
+def _space_1d() -> BsplineSpace:
+    """Small 1D space for batch d=1 tests."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    return BsplineSpace([sp1])
+
+
+_BATCH_SPACES: list[tuple[int, BsplineSpace]] = [
+    (1, _space_1d()),
+    (2, _space_2d()),
+    (3, _space_3d()),
+]
+
+_OP_KINDS = ["apply", "apply_T", "MT_K_M", "M_K_MT"]
+_TARGETS = ["bezier", "lagrange", "cardinal"]
+
+
+def _batch_method(ext: SpanwiseElementExtraction, op_kind: str) -> Any:
+    """Return the batch method corresponding to op_kind."""
+    if op_kind == "apply":
+        return ext.apply_many
+    if op_kind == "apply_T":
+        return ext.apply_transpose_many
+    if op_kind == "MT_K_M":
+        return ext.apply_MT_K_M_many
+    return ext.apply_M_K_MT_many
+
+
+def _per_cell_method(ext: SpanwiseElementExtraction, op_kind: str) -> Any:
+    """Return the per-cell method corresponding to op_kind."""
+    if op_kind == "apply":
+        return ext.apply
+    if op_kind == "apply_T":
+        return ext.apply_transpose
+    if op_kind == "MT_K_M":
+        return ext.apply_MT_K_M
+    return ext.apply_M_K_MT
+
+
+# ---------------------------------------------------------------- batch correctness
+
+
+@pytest.mark.parametrize("target", _TARGETS)
+@pytest.mark.parametrize("op_kind", _OP_KINDS)
+@pytest.mark.parametrize(("d", "sp"), _BATCH_SPACES)
+def test_batch_apply_matches_per_cell(
+    d: int,
+    sp: BsplineSpace,
+    op_kind: str,
+    target: str,
+) -> None:
+    """Batch apply matches per-cell apply for every (d, op_kind, target) combo."""
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(0)
+    n_cells = min(ext.num_total_intervals, 8)
+    flat_idx = rng.integers(0, ext.num_total_intervals, size=n_cells)
+    dt = ext.dtype
+
+    if op_kind == "apply":
+        operand = rng.standard_normal((n_cells, n_in)).astype(dt)
+    elif op_kind == "apply_T":
+        operand = rng.standard_normal((n_cells, n_out)).astype(dt)
+    elif op_kind == "MT_K_M":
+        operand = rng.standard_normal((n_cells, n_out, n_out)).astype(dt)
+    else:
+        operand = rng.standard_normal((n_cells, n_in, n_in)).astype(dt)
+
+    batch_fn = _batch_method(ext, op_kind)
+    per_cell_fn = _per_cell_method(ext, op_kind)
+    out_batch = batch_fn(operand, flat_idx)
+
+    for c in range(n_cells):
+        ref = per_cell_fn(operand[c], int(flat_idx[c]))
+        np.testing.assert_allclose(out_batch[c], ref, atol=1e-11, rtol=1e-11)
+
+
+@pytest.mark.parametrize("op_kind", _OP_KINDS)
+def test_batch_apply_float32_space(op_kind: str) -> None:
+    """Batch apply works correctly on a float32 B-spline space."""
+    knots = np.array([0, 0, 0, 1, 2, 3, 3, 3], dtype=np.float32)
+    sp1 = BsplineSpace1D(knots, 2)
+    sp = BsplineSpace([sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert ext.dtype == np.float32
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(99)
+    n_cells = 4
+    flat_idx = rng.integers(0, ext.num_total_intervals, size=n_cells)
+
+    if op_kind == "apply":
+        operand = rng.standard_normal((n_cells, n_in)).astype(np.float32)
+    elif op_kind == "apply_T":
+        operand = rng.standard_normal((n_cells, n_out)).astype(np.float32)
+    elif op_kind == "MT_K_M":
+        operand = rng.standard_normal((n_cells, n_out, n_out)).astype(np.float32)
+    else:
+        operand = rng.standard_normal((n_cells, n_in, n_in)).astype(np.float32)
+
+    batch_fn = _batch_method(ext, op_kind)
+    per_cell_fn = _per_cell_method(ext, op_kind)
+    out_batch = batch_fn(operand, flat_idx)
+
+    for c in range(n_cells):
+        ref = per_cell_fn(operand[c], int(flat_idx[c]))
+        np.testing.assert_allclose(out_batch[c], ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("op_kind", _OP_KINDS)
+def test_batch_apply_per_direction_index_form(op_kind: str) -> None:
+    """2-D per-direction cell_indices produce the same result as flat indices."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(1)
+    n_cells = 5
+    flat = rng.integers(0, ext.num_total_intervals, size=n_cells)
+    multi = np.stack(np.unravel_index(flat, ext.num_intervals), axis=1)
+
+    if op_kind == "apply":
+        operand = rng.standard_normal((n_cells, n_in))
+    elif op_kind == "apply_T":
+        operand = rng.standard_normal((n_cells, n_out))
+    elif op_kind == "MT_K_M":
+        operand = rng.standard_normal((n_cells, n_out, n_out))
+    else:
+        operand = rng.standard_normal((n_cells, n_in, n_in))
+
+    batch_fn = _batch_method(ext, op_kind)
+    out_flat = batch_fn(operand, flat)
+    out_multi = batch_fn(operand, multi)
+    np.testing.assert_allclose(out_flat, out_multi, atol=1e-14)
+
+
+@pytest.mark.parametrize("op_kind", _OP_KINDS)
+def test_batch_apply_identity_pattern_shortcircuits(op_kind: str) -> None:
+    """C⁰ Bézier space (all identity) gives the same result as no operator."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 1, 1, 2, 2, 2], 2)
+    sp = BsplineSpace([sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    assert ext.is_identity, "Space should have all-identity extraction"
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(2)
+    n_cells = 4
+    flat = rng.integers(0, ext.num_total_intervals, size=n_cells)
+
+    if op_kind in ("apply", "apply_T"):
+        operand = rng.standard_normal((n_cells, n_in if op_kind == "apply" else n_out))
+        out = _batch_method(ext, op_kind)(operand, flat)
+        np.testing.assert_allclose(out, operand, atol=1e-12)
+    elif op_kind == "MT_K_M":
+        K = rng.standard_normal((n_cells, n_out, n_out))
+        out = ext.apply_MT_K_M_many(K, flat)
+        np.testing.assert_allclose(out, K, atol=1e-12)
+    else:
+        K = rng.standard_normal((n_cells, n_in, n_in))
+        out = ext.apply_M_K_MT_many(K, flat)
+        np.testing.assert_allclose(out, K, atol=1e-12)
+
+
+# ---------------------------------------------------------------- batch edge cases / validation
+
+
+def test_batch_apply_empty_batch_returns_correct_shape() -> None:
+    """An empty batch (n_cells=0) returns an array with the right shape and no errors."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    empty_idx = np.array([], dtype=np.intp)
+    out = ext.apply_many(np.empty((0, n_in)), empty_idx)
+    assert out.shape == (0, n_out)
+
+
+def test_batch_apply_accepts_user_out_and_scratch() -> None:
+    """User-provided ``out`` and ``scratch`` are written into and returned."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    rng = np.random.default_rng(3)
+    n_cells = 3
+    flat = rng.integers(0, ext.num_total_intervals, size=n_cells)
+    v = rng.standard_normal((n_cells, n_in))
+    out = np.zeros((n_cells, n_out))
+    scratch = np.zeros((n_cells, 4 * n_in * n_out))
+    result = ext.apply_many(v, flat, out=out, scratch=scratch)
+    assert result is out
+
+    for c in range(n_cells):
+        ref = ext.apply(v[c], int(flat[c]))
+        np.testing.assert_allclose(out[c], ref, atol=1e-12)
+
+
+def test_batch_apply_wrong_operand_shape_raises() -> None:
+    """Wrong operand shape raises ValueError."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    with pytest.raises(ValueError, match="shape"):
+        ext.apply_many(np.zeros((3, n_in + 1)), np.array([0, 1, 2]))
+
+
+def test_batch_apply_wrong_cell_indices_ndim_raises() -> None:
+    """3-D cell_indices raises ValueError."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    with pytest.raises(ValueError):
+        ext.apply_many(np.zeros((1, n_in)), np.zeros((1, 1, 2), dtype=np.intp))
+
+
+def test_batch_apply_out_of_range_cell_index_raises() -> None:
+    """Out-of-range cell index raises IndexError."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    with pytest.raises((IndexError, ValueError)):
+        ext.apply_many(np.zeros((1, n_in)), np.array([ext.num_total_intervals]))
+
+
+def test_batch_apply_dim4_raises_not_implemented() -> None:
+    """A 4D space raises NotImplementedError for all batch apply variants."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+    sp = BsplineSpace([sp1, sp1, sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    with pytest.raises(NotImplementedError):
+        ext.apply_many(np.zeros((1, n_in)), np.array([0]))


### PR DESCRIPTION
## Summary

Part of #141 (PR 4 of SpanwiseElementExtraction v0 series).

- **Layer 3**: 12 new Numba kernels (`apply_kron_{apply,apply_T,MT_K_M,M_K_MT}_many_{1,2,3}d`) — `prange` over cells, dispatch to per-cell kernels, `parallel=True`
- **Layer 2**: `_prepare_apply_many_call` helper — validates `(n_cells, N_in)` operand and `(n_cells, N_out)` output, allocates/validates 2D scratch `(n_cells, scratch_size_per_cell)`
- **Layer 1**: `apply_many`, `apply_transpose_many`, `apply_MT_K_M_many`, `apply_M_K_MT_many` on `SpanwiseElementExtraction`; module-level `normalize_cell_indices` converts flat or per-direction cell indices to canonical `(n_cells, d)` int array
- **Benchmark**: `benchmarks/bench_extraction_batch.py` — 3D degree-3 space, batch sizes 1–5000, shows ~36× speedup over a Python loop at n_cells=5000

## Test plan

- [x] All existing tests pass (2454 total)
- [x] New batch tests cover every `(d, op_kind, identity-pattern)` combination, float32 space, flat vs. per-direction indices, empty batch, user-supplied out/scratch, validation errors, `d>3` NotImplementedError
- [x] `normalize_cell_indices` tested independently (flat conversion, 2D passthrough, OOB errors)
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs)

Generated with [Claude Code](https://claude.com/claude-code)