### PR TITLE
docs(extraction): user guide for SpanwiseElementExtraction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ getting-started
 constructive-geometry
 visualization
 parallelism
+spanwise-element-extraction
 api/reference
 changelog
 ```

--- a/docs/spanwise-element-extraction.md
+++ b/docs/spanwise-element-extraction.md
@@ -1,0 +1,264 @@
+# SpanwiseElementExtraction
+
+{class}`~pantr.bspline.SpanwiseElementExtraction` is the central object for
+element-local change-of-basis operations on tensor-product B-spline spaces.
+It converts a local patch of a B-spline space into an equivalent Bézier,
+Lagrange, or cardinal B-spline representation — one element at a time, or
+in parallel over a batch of elements — without ever forming the full
+$d$-dimensional Kronecker product in memory.
+
+## Layer architecture
+
+The implementation spans three layers that each have a distinct
+responsibility:
+
+| Layer | Module | Role |
+|---|---|---|
+| 3 — kernels | `pantr.bspline._extraction_kernels` | `@njit(cache=True)` free functions; pure computation, no validation |
+| 2 — helpers | `pantr.bspline._extraction_helpers` | shape/dtype/writability validation, scratch allocation, kernel dispatch |
+| 1 — class | `pantr.bspline.SpanwiseElementExtraction` | construction, target dispatch, identity detection, public API |
+
+**Layer 3** contains 24 Numba-compiled kernels: four operation kinds
+(`apply`, `apply_T`, `MT_K_M`, `M_K_MT`) × three dimensions ($d \in \{1, 2, 3\}$)
+× two calling modes (single-cell, batch-over-many-cells).  All kernels accept
+plain NumPy arrays, which makes them callable from other `@njit` functions.
+
+**Layer 2** is pure Python.  It validates operand shapes, dtypes, and array
+writability; sizes the intermediate scratch buffer; and selects the right
+Layer-3 kernel for the given operation kind and dimension.
+
+**Layer 1** (`SpanwiseElementExtraction`) builds the per-direction 1D
+operator stacks once at construction time and exposes the high-level API.
+It never contains Numba code.
+
+## Construction
+
+```python
+import pantr
+from pantr.bspline import SpanwiseElementExtraction
+
+space = pantr.BsplineSpace(...)          # any BsplineSpace
+
+ext = SpanwiseElementExtraction(space, "bezier")    # Bézier target
+ext = SpanwiseElementExtraction(space, "lagrange")  # Lagrange target
+ext = SpanwiseElementExtraction(space, "cardinal")  # cardinal B-spline target
+```
+
+Three targets are supported:
+
+| Target | Description | Identity detection |
+|---|---|---|
+| `"bezier"` | Bernstein / Bézier basis on each element | Numerical: $\lVert C - I \rVert_{\max} < \text{tol}$ per element |
+| `"lagrange"` | Lagrange basis at the chosen point distribution | Numerical: same test |
+| `"cardinal"` | Cardinal B-spline basis on each element | Structural: `BsplineSpace1D.get_cardinal_intervals()` |
+
+Additional keyword arguments:
+
+```python
+from pantr.basis import LagrangeVariant
+
+ext = SpanwiseElementExtraction(
+    space, "lagrange",
+    lagrange_variant=LagrangeVariant.GAUSS_LOBATTO,  # default: EQUISPACES
+    identity_tol=1e-12,                              # default: space.tolerance
+)
+```
+
+Construction is $O(n_{\text{elements}} \cdot p^2)$ per direction and happens
+once; all subsequent apply calls reuse the cached operator stacks.
+
+## Apply variants
+
+Four operation kinds are available, matching the bilateral assembly pattern
+common in IGA:
+
+| Method | Formula | Typical use |
+|---|---|---|
+| `apply` | $\mathbf{y} = M \mathbf{v}$ | basis conversion (B-spline → target) |
+| `apply_transpose` | $\mathbf{y} = M^T \mathbf{v}$ | adjoint / dual conversion |
+| `apply_MT_K_M` | $B = M^T K M$ | pull-back of a target-basis matrix to B-spline basis |
+| `apply_M_K_MT` | $B = M K M^T$ | push-forward of a B-spline-basis matrix to target basis |
+
+Here $M = M_0 \otimes \cdots \otimes M_{d-1}$ is the $d$-dimensional
+Kronecker operator; identity directions short-circuit and are skipped.
+
+### Single-cell applies
+
+Each method takes a cell index and an operand, and optionally a pre-allocated
+`out` array and `scratch` buffer (both allocated internally when omitted):
+
+```python
+import numpy as np
+
+# single-cell apply (index as flat int or per-direction tuple)
+cell = 5                        # flat index, row-major over num_intervals
+cell = (1, 2)                   # per-direction index for a 2D space
+
+N_in  = int(np.prod(ext.input_shape_per_dir))
+N_out = int(np.prod(ext.output_shape_per_dir))
+
+v = np.ones(N_in, dtype=np.float64)
+y = ext.apply(v, cell)                         # y.shape == (N_out,)
+y = ext.apply_transpose(y, cell)               # y.shape == (N_in,)
+
+K_out = np.eye(N_out, dtype=np.float64)
+B = ext.apply_MT_K_M(K_out, cell)             # B.shape == (N_in, N_in)
+
+K_in  = np.eye(N_in, dtype=np.float64)
+B = ext.apply_M_K_MT(K_in, cell)              # B.shape == (N_out, N_out)
+```
+
+Pre-allocated buffers avoid repeated heap allocation in loops over elements:
+
+```python
+out     = np.empty(N_out, dtype=np.float64)
+scratch = np.empty(128,   dtype=np.float64)   # size: any >= _extraction_helpers minimum
+
+for cell in range(len(ext)):
+    ext.apply(v, cell, out=out, scratch=scratch)
+    # use out ...
+```
+
+### Batch applies
+
+The `_many` variants parallelize over a batch of cells via `prange` in the
+Layer-3 kernels.  Pass a flat 1-D cell-index array or a per-direction 2-D
+array:
+
+```python
+n_cells = 200
+all_cells = np.arange(n_cells, dtype=np.intp)           # flat indices
+# or: all_cells = np.stack([idx_dir0, idx_dir1], axis=1) # per-direction
+
+V = np.random.default_rng(0).random((n_cells, N_in))
+Y = ext.apply_many(V, all_cells)                        # (n_cells, N_out)
+
+K_batch = np.eye(N_out)[np.newaxis].repeat(n_cells, axis=0)  # (n_cells, N_out, N_out)
+B_batch = ext.apply_MT_K_M_many(K_batch, all_cells)          # (n_cells, N_in, N_in)
+```
+
+The full matrix of batch methods mirrors the single-cell API:
+
+| Method | Input shape | Output shape |
+|---|---|---|
+| `apply_many` | `(n_cells, N_in)` | `(n_cells, N_out)` |
+| `apply_transpose_many` | `(n_cells, N_out)` | `(n_cells, N_in)` |
+| `apply_MT_K_M_many` | `(n_cells, N_out, N_out)` | `(n_cells, N_in, N_in)` |
+| `apply_M_K_MT_many` | `(n_cells, N_in, N_in)` | `(n_cells, N_out, N_out)` |
+
+Passing `all_cells = np.arange(ext.num_total_intervals)` processes every
+element.  You can also pass a subset to skip elements or process patches in
+a different order.
+
+## Identity detection and short-circuit
+
+When a 1D operator $M_k$ for direction $k$ at element $i$ is the identity
+matrix, applying it is a no-op.  The kernels exploit this: an identity flag
+is passed alongside the operator pointer, and the kernel skips the matrix
+multiply for that direction.
+
+### How flags are determined
+
+**`"cardinal"` target** — flags come from the *structural* mask returned by
+{meth}`~pantr.bspline.BsplineSpace1D.get_cardinal_intervals`.  An interval is
+cardinal if and only if its knot span is uniform (same width as its
+neighbours); on such intervals the cardinal extraction operator is provably
+the identity.  No numerical comparison is performed.
+
+**`"bezier"` and `"lagrange"` targets** — flags are computed *numerically*
+at construction time using $\lVert C_i - I \rVert_{\max} < \text{tol}$.  This
+catches practical cases such as a $C^0$ Bézier space, where every element's
+Bézier extraction operator is already the identity.
+
+### Querying identity flags
+
+```python
+# global: True only if every element in every direction is identity
+if ext.is_identity:
+    ...
+
+# per-element
+if ext.is_identity_at(cell):
+    ...
+
+# per-direction flags for a single element
+flags = ext.per_direction_identity_flags(cell)  # tuple[bool, ...] of length d
+
+# count of fully-identity elements
+n_trivial = ext.num_identity_elements
+
+# raw masks for programmatic use
+masks = ext.is_identity_mask_1d  # tuple of 1-D bool arrays, one per direction
+```
+
+## Numba-callability contract
+
+{attr}`~pantr.bspline.SpanwiseElementExtraction.ops_1d` and
+{attr}`~pantr.bspline.SpanwiseElementExtraction.is_identity_mask_1d` are
+read-only NumPy arrays and can be passed directly into `@njit` functions.
+The Layer-3 kernels are importable free functions:
+
+```python
+from numba import njit
+from pantr.bspline._extraction_kernels import apply_kron_2d, apply_kron_MT_K_M_2d
+
+ops_1d   = ext.ops_1d                    # tuple of float64 arrays (read-only)
+masks_1d = ext.is_identity_mask_1d       # tuple of bool arrays (read-only)
+
+M0, M1 = ops_1d[0], ops_1d[1]           # (n_el_0, p+1, p+1), (n_el_1, p+1, p+1)
+f0, f1 = masks_1d[0], masks_1d[1]       # (n_el_0,), (n_el_1,)
+
+@njit(cache=True)
+def my_kernel(M0, f0, M1, f1, v, out, scratch):
+    i0, i1 = 3, 7
+    apply_kron_2d(M0[i0], f0[i0], M1[i1], f1[i1], v, out, scratch)
+```
+
+Available kernels follow the naming pattern
+`apply_kron_{op_kind}_{d}d` for single-cell and
+`apply_kron_{op_kind}_many_{d}d` for batch:
+
+| op_kind | Single-cell | Batch |
+|---|---|---|
+| `apply` / `apply_T` | `apply_kron_{1,2,3}d` / `apply_kron_T_{1,2,3}d` | `apply_kron_apply_many_{1,2,3}d` / `apply_kron_apply_T_many_{1,2,3}d` |
+| `MT_K_M` | `apply_kron_MT_K_M_{1,2,3}d` | `apply_kron_MT_K_M_many_{1,2,3}d` |
+| `M_K_MT` | `apply_kron_M_K_MT_{1,2,3}d` | `apply_kron_M_K_MT_many_{1,2,3}d` |
+
+All kernels accept only plain NumPy arrays (no Python objects).  Dimensions
+above 3 raise `NotImplementedError` from the Layer-2 dispatcher.
+
+## Materializing operators
+
+Use {meth}`~pantr.bspline.SpanwiseElementExtraction.operator` to assemble the
+full $(N_{\text{out}} \times N_{\text{in}})$ Kronecker product for a single
+element, or {meth}`~pantr.bspline.SpanwiseElementExtraction.tabulate` to
+produce the complete `(num_total_intervals, N_out, N_in)` stack:
+
+```python
+M_cell = ext.operator(cell)   # (N_out, N_in), assembled via np.kron
+M_all  = ext.tabulate()       # (num_total_intervals, N_out, N_in)
+```
+
+Both use `numpy.kron` and allocate a fresh matrix.  Prefer the matrix-free
+apply methods in performance-critical code.
+
+{meth}`~pantr.bspline.SpanwiseElementExtraction.tabulate` is the canonical way
+to obtain the Bézier extraction operators used by
+{meth}`~pantr.bspline.Bspline.to_beziers` — in fact the `to_beziers`
+implementation sources its operators from `ops_1d` directly.
+
+## Iteration and indexing
+
+`SpanwiseElementExtraction` supports `len`, index access, and iteration:
+
+```python
+len(ext)          # == ext.num_total_intervals
+
+ops, flags = ext[cell]    # per-direction ops and identity flags at one element
+
+for ops, flags in ext:    # row-major over num_intervals
+    ...
+```
+
+Each `ops` is a tuple of 2D views into `ops_1d`; each `flags` is a tuple of
+bools from `is_identity_mask_1d`.

--- a/docs/spanwise-element-extraction.md
+++ b/docs/spanwise-element-extraction.md
@@ -48,7 +48,7 @@ Three targets are supported:
 
 | Target | Description | Identity detection |
 |---|---|---|
-| `"bezier"` | Bernstein / Bézier basis on each element | Numerical: $\lVert C - I \rVert_{\max} < \text{tol}$ per element |
+| `"bezier"` | Bernstein / Bézier basis on each element | Numerical: $\lVert C - I \rVert_{\max} \leq \text{tol}$ per element |
 | `"lagrange"` | Lagrange basis at the chosen point distribution | Numerical: same test |
 | `"cardinal"` | Cardinal B-spline basis on each element | Structural: `BsplineSpace1D.get_cardinal_intervals()` |
 
@@ -91,8 +91,9 @@ Each method takes a cell index and an operand, and optionally a pre-allocated
 import numpy as np
 
 # single-cell apply (index as flat int or per-direction tuple)
-cell = 5                        # flat index, row-major over num_intervals
-cell = (1, 2)                   # per-direction index for a 2D space
+cell_flat = 5                   # flat index, row-major over num_intervals
+cell_nd   = (1, 2)              # per-direction index for a 2D space
+cell = cell_flat                # use either form below
 
 N_in  = int(np.prod(ext.input_shape_per_dir))
 N_out = int(np.prod(ext.output_shape_per_dir))
@@ -111,11 +112,10 @@ B = ext.apply_M_K_MT(K_in, cell)              # B.shape == (N_out, N_out)
 Pre-allocated buffers avoid repeated heap allocation in loops over elements:
 
 ```python
-out     = np.empty(N_out, dtype=np.float64)
-scratch = np.empty(128,   dtype=np.float64)   # size: any >= _extraction_helpers minimum
+out = np.empty(N_out, dtype=np.float64)
 
 for cell in range(len(ext)):
-    ext.apply(v, cell, out=out, scratch=scratch)
+    ext.apply(v, cell, out=out)
     # use out ...
 ```
 
@@ -161,12 +161,13 @@ multiply for that direction.
 
 **`"cardinal"` target** — flags come from the *structural* mask returned by
 {meth}`~pantr.bspline.BsplineSpace1D.get_cardinal_intervals`.  An interval is
-cardinal if and only if its knot span is uniform (same width as its
-neighbours); on such intervals the cardinal extraction operator is provably
-the identity.  No numerical comparison is performed.
+cardinal if it has the same span length as the $p - 1$ preceding and $p - 1$
+following non-zero spans (where $p$ is the polynomial degree); on such
+intervals the cardinal extraction operator is provably the identity.  No
+numerical comparison is performed.
 
 **`"bezier"` and `"lagrange"` targets** — flags are computed *numerically*
-at construction time using $\lVert C_i - I \rVert_{\max} < \text{tol}$.  This
+at construction time using $\lVert C_i - I \rVert_{\max} \leq \text{tol}$.  This
 catches practical cases such as a $C^0$ Bézier space, where every element's
 Bézier extraction operator is already the identity.
 
@@ -214,9 +215,8 @@ def my_kernel(M0, f0, M1, f1, v, out, scratch):
     apply_kron_2d(M0[i0], f0[i0], M1[i1], f1[i1], v, out, scratch)
 ```
 
-Available kernels follow the naming pattern
-`apply_kron_{op_kind}_{d}d` for single-cell and
-`apply_kron_{op_kind}_many_{d}d` for batch:
+Batch kernels follow `apply_kron_{op_kind}_many_{d}d`.  Single-cell kernels
+drop the redundant `apply` prefix — as shown in the table below:
 
 | op_kind | Single-cell | Batch |
 |---|---|---|


### PR DESCRIPTION
Closes the docs phase of #141. Also ticks off PR 4 (batch apply methods, #145) which wasn't checked in the tracking issue.

## Summary

- Adds `docs/spanwise-element-extraction.md` — a user guide for `SpanwiseElementExtraction`
- Covers: layer architecture (kernels → helpers → class), construction and targets, all four apply variants (single-cell and batch), identity detection and short-circuit behaviour for each target, the Numba-callability contract (`ops_1d` / `is_identity_mask_1d`), and operator materialisation
- Adds the page to the toctree in `docs/index.md`

## Test plan

- [x] All 2462 existing tests pass (`pytest --no-cov`)
- [x] Ruff lint and format clean
- [x] mypy strict passes (docs-only change, no new source files)
- [x] Sphinx build passes with `-W` (no warnings)

Generated with [Claude Code](https://claude.com/claude-code)