### PR TITLE
perf(extraction): compact storage for identity-heavy spaces

### DIFF
--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -519,6 +519,7 @@ def _allocate_or_validate_scratch_many(
 
 def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
     ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...],
+    idx_maps_1d: tuple[npt.NDArray[np.intp], ...],
     is_identity_masks: tuple[npt.NDArray[np.bool_], ...],
     cell_indices: npt.NDArray[np.intp],
     operand: npt.NDArray[np.float32 | np.float64],
@@ -533,13 +534,18 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
     """Validate inputs and build the kernel call for a batch of cells.
 
     Args:
-        ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]): Full per-direction
-            3D operator arrays ``(n_el_k, n_out_k, n_in_k)``. Length must equal ``d``.
+        ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]): Compact
+            per-direction 3D operator arrays ``(n_compact_k, n_out_k, n_in_k)``
+            containing only non-identity rows. Length must equal ``d``.
+        idx_maps_1d (tuple[npt.NDArray[np.intp], ...]): Per-direction compact
+            index maps of shape ``(n_el_k,)``; ``idx_maps_1d[k][e]`` is the row
+            index into ``ops_1d[k]`` for element ``e`` (undefined for identity
+            elements). Length must equal ``d``.
         is_identity_masks (tuple[npt.NDArray[np.bool_], ...]): Full per-direction
             identity mask arrays of shape ``(n_el_k,)``. Length must equal ``d``.
         cell_indices (npt.NDArray[np.intp]): Per-direction element indices,
             shape ``(n_cells, d)``. Values must be non-negative and within the
-            per-direction element counts from ``ops_1d``.
+            per-direction element counts from ``is_identity_masks``.
         operand (npt.NDArray[np.float32 | np.float64]): Batch input array.
             Shape ``(n_cells, N_in)`` for ``"apply"``,
             ``(n_cells, N_out)`` for ``"apply_T"``,
@@ -562,6 +568,8 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
     """
     _validate_op_kind(op_kind)
     d = len(ops_1d)
+    if len(idx_maps_1d) != d:
+        raise ValueError(f"idx_maps_1d has length {len(idx_maps_1d)}, expected {d}")
     if len(is_identity_masks) != d:
         raise ValueError(f"is_identity_masks has length {len(is_identity_masks)}, expected {d}")
     if d < 1:
@@ -575,6 +583,17 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
             raise ValueError(f"ops_1d[{k}] dtype {op.dtype} differs from ops_1d[0] dtype {dtype}")
     if np.dtype(dtype).type not in (np.float32, np.float64):
         raise ValueError(f"ops_1d operators must have dtype float32 or float64; got {dtype}")
+    for k, (idx_map, mask) in enumerate(zip(idx_maps_1d, is_identity_masks, strict=True)):
+        n_el_k = mask.shape[0]
+        if idx_map.ndim != 1:
+            raise ValueError(f"idx_maps_1d[{k}] must be 1D; got ndim={idx_map.ndim}")
+        if not np.issubdtype(idx_map.dtype, np.integer):
+            raise ValueError(f"idx_maps_1d[{k}] must be integer; got dtype {idx_map.dtype}")
+        if idx_map.shape[0] != n_el_k:
+            raise ValueError(
+                f"idx_maps_1d[{k}] has length {idx_map.shape[0]}, "
+                f"expected {n_el_k} to match is_identity_masks[{k}]"
+            )
 
     if cell_indices.ndim != 2:  # noqa: PLR2004
         raise ValueError(f"cell_indices must be 2D; got ndim={cell_indices.ndim}")
@@ -582,8 +601,8 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
         raise ValueError(f"cell_indices.shape[1]={cell_indices.shape[1]} does not match d={d}")
     n_cells = cell_indices.shape[0]
     if n_cells > 0:
-        for k, op in enumerate(ops_1d):
-            n_el_k = op.shape[0]
+        for k, mask in enumerate(is_identity_masks):
+            n_el_k = mask.shape[0]
             col = cell_indices[:, k]
             if int(col.min()) < 0 or int(col.max()) >= n_el_k:
                 raise IndexError(f"cell_indices[:, {k}] contains values outside [0, {n_el_k})")
@@ -611,7 +630,16 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
     scratch = _allocate_or_validate_scratch_many(scratch, n_cells, scratch_size, dtype)
 
     kernel = _dispatch_apply_many(d, op_kind)
-    args: tuple[Any, ...] = (*ops_1d, *is_identity_masks, cell_indices, operand, out, scratch)
+    idx_maps_intp = tuple(m if m.dtype == np.intp else m.astype(np.intp) for m in idx_maps_1d)
+    args: tuple[Any, ...] = (
+        *ops_1d,
+        *idx_maps_intp,
+        *is_identity_masks,
+        cell_indices,
+        operand,
+        out,
+        scratch,
+    )
     return kernel, args, out
 
 

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -12,6 +12,10 @@ Four operation kinds are supported (see :data:`OP_KINDS`):
 - ``"M_K_MT"``:   ``out = M @ K @ M^T``     (input x input -> output x output)
 
 with ``M = kron(M_0, M_1, ..., M_{d-1})``.
+
+The batch dispatch path (:func:`_prepare_apply_many_call`) uses compact operator
+storage (non-identity rows only) together with per-direction index maps, as built
+by :class:`~pantr.bspline.spanwise_element_extraction.SpanwiseElementExtraction`.
 """
 
 from __future__ import annotations
@@ -517,7 +521,7 @@ def _allocate_or_validate_scratch_many(
     return scratch
 
 
-def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
+def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913, PLR0915
     ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...],
     idx_maps_1d: tuple[npt.NDArray[np.intp], ...],
     is_identity_masks: tuple[npt.NDArray[np.bool_], ...],
@@ -539,8 +543,9 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
             containing only non-identity rows. Length must equal ``d``.
         idx_maps_1d (tuple[npt.NDArray[np.intp], ...]): Per-direction compact
             index maps of shape ``(n_el_k,)``; ``idx_maps_1d[k][e]`` is the row
-            index into ``ops_1d[k]`` for element ``e`` (undefined for identity
-            elements). Length must equal ``d``.
+            index into ``ops_1d[k]`` for element ``e`` (0 for identity elements,
+            unused; the kernel short-circuits on ``is_identity_masks``). Length
+            must equal ``d``.
         is_identity_masks (tuple[npt.NDArray[np.bool_], ...]): Full per-direction
             identity mask arrays of shape ``(n_el_k,)``. Length must equal ``d``.
         cell_indices (npt.NDArray[np.intp]): Per-direction element indices,
@@ -583,7 +588,9 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
             raise ValueError(f"ops_1d[{k}] dtype {op.dtype} differs from ops_1d[0] dtype {dtype}")
     if np.dtype(dtype).type not in (np.float32, np.float64):
         raise ValueError(f"ops_1d operators must have dtype float32 or float64; got {dtype}")
-    for k, (idx_map, mask) in enumerate(zip(idx_maps_1d, is_identity_masks, strict=True)):
+    for k, (idx_map, mask, op) in enumerate(
+        zip(idx_maps_1d, is_identity_masks, ops_1d, strict=True)
+    ):
         n_el_k = mask.shape[0]
         if idx_map.ndim != 1:
             raise ValueError(f"idx_maps_1d[{k}] must be 1D; got ndim={idx_map.ndim}")
@@ -593,6 +600,12 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913
             raise ValueError(
                 f"idx_maps_1d[{k}] has length {idx_map.shape[0]}, "
                 f"expected {n_el_k} to match is_identity_masks[{k}]"
+            )
+        non_id_vals = idx_map[~mask]
+        if len(non_id_vals) > 0 and int(non_id_vals.max()) >= int(op.shape[0]):
+            raise ValueError(
+                f"idx_maps_1d[{k}] contains out-of-range values for ops_1d[{k}]: "
+                f"max value {int(non_id_vals.max())} >= n_compact_{k}={int(op.shape[0])}"
             )
 
     if cell_indices.ndim != 2:  # noqa: PLR2004

--- a/src/pantr/bspline/_extraction_kernels.py
+++ b/src/pantr/bspline/_extraction_kernels.py
@@ -1242,6 +1242,7 @@ def apply_kron_M_K_MT_3d(  # noqa: PLR0913, PLR0912, PLR0915 -- kernel fan-in an
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_apply_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     ops_0: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
     v: npt.NDArray[Any],
@@ -1251,8 +1252,11 @@ def apply_kron_apply_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """Apply ``M_0 @ v[c]`` for every cell ``c`` in the batch (d=1).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer; ``idx_map_0[e]`` is the row index into
+            ``ops_0`` for element ``e`` (undefined for identity elements).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1269,13 +1273,15 @@ def apply_kron_apply_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """
     for cell in nb_prange(cell_indices.shape[0]):
         i0 = cell_indices[cell, 0]
-        apply_kron_1d(ops_0[i0], is_id_0[i0], v[cell], out[cell], scratch[cell])
+        apply_kron_1d(ops_0[idx_map_0[i0]], is_id_0[i0], v[cell], out[cell], scratch[cell])
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_apply_many_2d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
@@ -1286,10 +1292,14 @@ def apply_kron_apply_many_2d(  # noqa: PLR0913
     """Apply ``kron(M_0, M_1) @ v[c]`` for every cell ``c`` in the batch (d=2).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1310,7 +1320,13 @@ def apply_kron_apply_many_2d(  # noqa: PLR0913
         i0 = cell_indices[cell, 0]
         i1 = cell_indices[cell, 1]
         apply_kron_2d(
-            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], v[cell], out[cell], scratch[cell]
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            is_id_0[i0],
+            is_id_1[i1],
+            v[cell],
+            out[cell],
+            scratch[cell],
         )
 
 
@@ -1319,6 +1335,9 @@ def apply_kron_apply_many_3d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
     ops_2: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
+    idx_map_2: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     is_id_2: npt.NDArray[Any],
@@ -1330,12 +1349,18 @@ def apply_kron_apply_many_3d(  # noqa: PLR0913
     """Apply ``kron(M_0, M_1, M_2) @ v[c]`` for every cell ``c`` in the batch (d=3).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
-        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
-            shape ``(n_el_2, n_out_2, n_in_2)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
+            shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
+        idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
+            ``(n_el_2,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1359,9 +1384,9 @@ def apply_kron_apply_many_3d(  # noqa: PLR0913
         i1 = cell_indices[cell, 1]
         i2 = cell_indices[cell, 2]
         apply_kron_3d(
-            ops_0[i0],
-            ops_1[i1],
-            ops_2[i2],
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            ops_2[idx_map_2[i2]],
             is_id_0[i0],
             is_id_1[i1],
             is_id_2[i2],
@@ -1374,6 +1399,7 @@ def apply_kron_apply_many_3d(  # noqa: PLR0913
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_apply_T_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     ops_0: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
     v: npt.NDArray[Any],
@@ -1383,8 +1409,10 @@ def apply_kron_apply_T_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional
     """Apply ``M_0^T @ v[c]`` for every cell ``c`` in the batch (d=1).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1401,13 +1429,15 @@ def apply_kron_apply_T_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional
     """
     for cell in nb_prange(cell_indices.shape[0]):
         i0 = cell_indices[cell, 0]
-        apply_kron_T_1d(ops_0[i0], is_id_0[i0], v[cell], out[cell], scratch[cell])
+        apply_kron_T_1d(ops_0[idx_map_0[i0]], is_id_0[i0], v[cell], out[cell], scratch[cell])
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_apply_T_many_2d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
@@ -1418,10 +1448,14 @@ def apply_kron_apply_T_many_2d(  # noqa: PLR0913
     """Apply ``kron(M_0, M_1)^T @ v[c]`` for every cell ``c`` in the batch (d=2).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1442,7 +1476,13 @@ def apply_kron_apply_T_many_2d(  # noqa: PLR0913
         i0 = cell_indices[cell, 0]
         i1 = cell_indices[cell, 1]
         apply_kron_T_2d(
-            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], v[cell], out[cell], scratch[cell]
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            is_id_0[i0],
+            is_id_1[i1],
+            v[cell],
+            out[cell],
+            scratch[cell],
         )
 
 
@@ -1451,6 +1491,9 @@ def apply_kron_apply_T_many_3d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
     ops_2: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
+    idx_map_2: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     is_id_2: npt.NDArray[Any],
@@ -1462,12 +1505,18 @@ def apply_kron_apply_T_many_3d(  # noqa: PLR0913
     """Apply ``kron(M_0, M_1, M_2)^T @ v[c]`` for every cell ``c`` in the batch (d=3).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
-        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
-            shape ``(n_el_2, n_out_2, n_in_2)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
+            shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
+        idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
+            ``(n_el_2,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1491,9 +1540,9 @@ def apply_kron_apply_T_many_3d(  # noqa: PLR0913
         i1 = cell_indices[cell, 1]
         i2 = cell_indices[cell, 2]
         apply_kron_T_3d(
-            ops_0[i0],
-            ops_1[i1],
-            ops_2[i2],
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            ops_2[idx_map_2[i2]],
             is_id_0[i0],
             is_id_1[i1],
             is_id_2[i2],
@@ -1506,6 +1555,7 @@ def apply_kron_apply_T_many_3d(  # noqa: PLR0913
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_MT_K_M_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     ops_0: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
     K: npt.NDArray[Any],
@@ -1515,8 +1565,10 @@ def apply_kron_MT_K_M_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """Compute ``M_0^T @ K[c] @ M_0`` for every cell ``c`` in the batch (d=1).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1536,13 +1588,15 @@ def apply_kron_MT_K_M_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """
     for cell in nb_prange(cell_indices.shape[0]):
         i0 = cell_indices[cell, 0]
-        apply_kron_MT_K_M_1d(ops_0[i0], is_id_0[i0], K[cell], out[cell], scratch[cell])
+        apply_kron_MT_K_M_1d(ops_0[idx_map_0[i0]], is_id_0[i0], K[cell], out[cell], scratch[cell])
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_MT_K_M_many_2d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
@@ -1553,10 +1607,14 @@ def apply_kron_MT_K_M_many_2d(  # noqa: PLR0913
     """Compute ``kron(M_0,M_1)^T @ K[c] @ kron(M_0,M_1)`` for every cell (d=2).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1580,7 +1638,13 @@ def apply_kron_MT_K_M_many_2d(  # noqa: PLR0913
         i0 = cell_indices[cell, 0]
         i1 = cell_indices[cell, 1]
         apply_kron_MT_K_M_2d(
-            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], K[cell], out[cell], scratch[cell]
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            is_id_0[i0],
+            is_id_1[i1],
+            K[cell],
+            out[cell],
+            scratch[cell],
         )
 
 
@@ -1589,6 +1653,9 @@ def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
     ops_2: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
+    idx_map_2: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     is_id_2: npt.NDArray[Any],
@@ -1600,12 +1667,18 @@ def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
     """Compute ``kron(M_0,M_1,M_2)^T @ K[c] @ kron(M_0,M_1,M_2)`` for every cell (d=3).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
-        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
-            shape ``(n_el_2, n_out_2, n_in_2)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
+            shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
+        idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
+            ``(n_el_2,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1632,9 +1705,9 @@ def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
         i1 = cell_indices[cell, 1]
         i2 = cell_indices[cell, 2]
         apply_kron_MT_K_M_3d(
-            ops_0[i0],
-            ops_1[i1],
-            ops_2[i2],
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            ops_2[idx_map_2[i2]],
             is_id_0[i0],
             is_id_1[i1],
             is_id_2[i2],
@@ -1647,6 +1720,7 @@ def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_M_K_MT_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     ops_0: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
     K: npt.NDArray[Any],
@@ -1656,8 +1730,10 @@ def apply_kron_M_K_MT_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """Compute ``M_0 @ K[c] @ M_0^T`` for every cell ``c`` in the batch (d=1).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1677,13 +1753,15 @@ def apply_kron_M_K_MT_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
     """
     for cell in nb_prange(cell_indices.shape[0]):
         i0 = cell_indices[cell, 0]
-        apply_kron_M_K_MT_1d(ops_0[i0], is_id_0[i0], K[cell], out[cell], scratch[cell])
+        apply_kron_M_K_MT_1d(ops_0[idx_map_0[i0]], is_id_0[i0], K[cell], out[cell], scratch[cell])
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
 def apply_kron_M_K_MT_many_2d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     cell_indices: npt.NDArray[Any],
@@ -1694,10 +1772,14 @@ def apply_kron_M_K_MT_many_2d(  # noqa: PLR0913
     """Compute ``kron(M_0,M_1) @ K[c] @ kron(M_0,M_1)^T`` for every cell (d=2).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1721,7 +1803,13 @@ def apply_kron_M_K_MT_many_2d(  # noqa: PLR0913
         i0 = cell_indices[cell, 0]
         i1 = cell_indices[cell, 1]
         apply_kron_M_K_MT_2d(
-            ops_0[i0], ops_1[i1], is_id_0[i0], is_id_1[i1], K[cell], out[cell], scratch[cell]
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            is_id_0[i0],
+            is_id_1[i1],
+            K[cell],
+            out[cell],
+            scratch[cell],
         )
 
 
@@ -1730,6 +1818,9 @@ def apply_kron_M_K_MT_many_3d(  # noqa: PLR0913
     ops_0: npt.NDArray[Any],
     ops_1: npt.NDArray[Any],
     ops_2: npt.NDArray[Any],
+    idx_map_0: npt.NDArray[Any],
+    idx_map_1: npt.NDArray[Any],
+    idx_map_2: npt.NDArray[Any],
     is_id_0: npt.NDArray[Any],
     is_id_1: npt.NDArray[Any],
     is_id_2: npt.NDArray[Any],
@@ -1741,12 +1832,18 @@ def apply_kron_M_K_MT_many_3d(  # noqa: PLR0913
     """Compute ``kron(M_0,M_1,M_2) @ K[c] @ kron(M_0,M_1,M_2)^T`` for every cell (d=3).
 
     Args:
-        ops_0 (npt.NDArray[Any]): All element operators for direction 0,
-            shape ``(n_el_0, n_out_0, n_in_0)``.
-        ops_1 (npt.NDArray[Any]): All element operators for direction 1,
-            shape ``(n_el_1, n_out_1, n_in_1)``.
-        ops_2 (npt.NDArray[Any]): All element operators for direction 2,
-            shape ``(n_el_2, n_out_2, n_in_2)``.
+        ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
+            shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
+        ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
+            shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
+        ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
+            shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
+        idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
+            ``(n_el_0,)`` integer.
+        idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
+            ``(n_el_1,)`` integer.
+        idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
+            ``(n_el_2,)`` integer.
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1773,9 +1870,9 @@ def apply_kron_M_K_MT_many_3d(  # noqa: PLR0913
         i1 = cell_indices[cell, 1]
         i2 = cell_indices[cell, 2]
         apply_kron_M_K_MT_3d(
-            ops_0[i0],
-            ops_1[i1],
-            ops_2[i2],
+            ops_0[idx_map_0[i0]],
+            ops_1[idx_map_1[i1]],
+            ops_2[idx_map_2[i2]],
             is_id_0[i0],
             is_id_1[i1],
             is_id_2[i2],

--- a/src/pantr/bspline/_extraction_kernels.py
+++ b/src/pantr/bspline/_extraction_kernels.py
@@ -1256,7 +1256,8 @@ def apply_kron_apply_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
             shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
             ``(n_el_0,)`` integer; ``idx_map_0[e]`` is the row index into
-            ``ops_0`` for element ``e`` (undefined for identity elements).
+            ``ops_0`` for element ``e`` (0 for identity elements, unused; kernel
+            short-circuits on ``is_id_0``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1297,9 +1298,11 @@ def apply_kron_apply_many_2d(  # noqa: PLR0913
         ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
             shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1356,11 +1359,14 @@ def apply_kron_apply_many_3d(  # noqa: PLR0913
         ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
             shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
-            ``(n_el_2,)`` integer.
+            ``(n_el_2,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_2``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1412,7 +1418,8 @@ def apply_kron_apply_T_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional
         ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
             shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1453,9 +1460,11 @@ def apply_kron_apply_T_many_2d(  # noqa: PLR0913
         ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
             shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1512,11 +1521,14 @@ def apply_kron_apply_T_many_3d(  # noqa: PLR0913
         ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
             shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
-            ``(n_el_2,)`` integer.
+            ``(n_el_2,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_2``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1568,7 +1580,8 @@ def apply_kron_MT_K_M_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
         ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
             shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1612,9 +1625,11 @@ def apply_kron_MT_K_M_many_2d(  # noqa: PLR0913
         ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
             shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1674,11 +1689,14 @@ def apply_kron_MT_K_M_many_3d(  # noqa: PLR0913
         ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
             shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
-            ``(n_el_2,)`` integer.
+            ``(n_el_2,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_2``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1733,7 +1751,8 @@ def apply_kron_M_K_MT_many_1d(  # noqa: PLR0913 -- kernel fan-in is intentional.
         ops_0 (npt.NDArray[Any]): Compact element operators for direction 0,
             shape ``(n_compact_0, n_out_0, n_in_0)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags, shape
             ``(n_el_0,)`` boolean.
         cell_indices (npt.NDArray[Any]): Per-direction element indices, shape
@@ -1777,9 +1796,11 @@ def apply_kron_M_K_MT_many_2d(  # noqa: PLR0913
         ops_1 (npt.NDArray[Any]): Compact element operators for direction 1,
             shape ``(n_compact_1, n_out_1, n_in_1)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,
@@ -1839,11 +1860,14 @@ def apply_kron_M_K_MT_many_3d(  # noqa: PLR0913
         ops_2 (npt.NDArray[Any]): Compact element operators for direction 2,
             shape ``(n_compact_2, n_out_2, n_in_2)``; only non-identity rows.
         idx_map_0 (npt.NDArray[Any]): Compact index map for direction 0, shape
-            ``(n_el_0,)`` integer.
+            ``(n_el_0,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_0``).
         idx_map_1 (npt.NDArray[Any]): Compact index map for direction 1, shape
-            ``(n_el_1,)`` integer.
+            ``(n_el_1,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_1``).
         idx_map_2 (npt.NDArray[Any]): Compact index map for direction 2, shape
-            ``(n_el_2,)`` integer.
+            ``(n_el_2,)`` integer; 0 for identity elements (unused; kernel
+            short-circuits on ``is_id_2``).
         is_id_0 (npt.NDArray[Any]): Per-element identity flags for direction 0,
             shape ``(n_el_0,)`` boolean.
         is_id_1 (npt.NDArray[Any]): Per-element identity flags for direction 1,

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -110,7 +110,7 @@ class SpanwiseElementExtraction:
             index maps of shape ``(n_elements_k,)``; ``_idx_maps_1d[k][e]`` is
             the row index into ``_compact_ops_1d[k]`` for element ``e``
             (undefined for identity elements, stored as 0).
-        _is_identity_mask_1d (tuple[npt.NDArray[bool], ...]): Per-direction
+        _is_identity_mask_1d (tuple[npt.NDArray[np.bool_], ...]): Per-direction
             identity masks of shape ``(n_elements_k,)``.
     """
 
@@ -271,7 +271,8 @@ class SpanwiseElementExtraction:
 
         Reconstructs the full ``(n_elements_k, n_out_k, n_in_k)`` array from
         compact storage on first access and caches the result. Identity elements
-        are filled with the identity matrix; non-identity elements are read from
+        are filled with ``numpy.eye(n_out, n_in)`` (rectangular identity for
+        non-square operators); non-identity elements are read from
         :attr:`compact_ops_1d`.
 
         Returns:
@@ -287,16 +288,14 @@ class SpanwiseElementExtraction:
             self._compact_ops_1d, self._idx_maps_1d, self._is_identity_mask_1d, strict=True
         ):
             n_el = int(mask.shape[0])
+            # shape[1] and shape[2] are direction-wide constants (same for compact and full)
             n_out, n_in = int(compact_ops.shape[1]), int(compact_ops.shape[2])
             full: npt.NDArray[np.float32 | np.float64] = np.empty(
                 (n_el, n_out, n_in), dtype=compact_ops.dtype
             )
             eye = np.eye(n_out, n_in, dtype=compact_ops.dtype)
-            for e in range(n_el):
-                if mask[e]:
-                    full[e] = eye
-                else:
-                    full[e] = compact_ops[idx_map[e]]
+            full[mask] = eye
+            full[~mask] = compact_ops[idx_map[~mask]]
             full.flags.writeable = False
             dense.append(full)
         return tuple(dense)
@@ -343,7 +342,7 @@ class SpanwiseElementExtraction:
         of :meth:`BsplineSpace1D.get_cardinal_intervals`.
 
         Returns:
-            tuple[npt.NDArray[bool], ...]: Length-``d`` tuple of read-only
+            tuple[npt.NDArray[np.bool_], ...]: Length-``d`` tuple of read-only
             1D boolean arrays; ``is_identity_mask_1d[k][i]`` is ``True`` iff
             the ``i``-th element in direction ``k`` has an identity operator.
         """
@@ -356,6 +355,7 @@ class SpanwiseElementExtraction:
         Returns:
             tuple[int, ...]: ``(n_in_0, …, n_in_{d-1})``.
         """
+        # shape[2] is the per-direction input size, identical between compact and full layouts
         return tuple(int(ops.shape[2]) for ops in self._compact_ops_1d)
 
     @property
@@ -365,6 +365,7 @@ class SpanwiseElementExtraction:
         Returns:
             tuple[int, ...]: ``(n_out_0, …, n_out_{d-1})``.
         """
+        # shape[1] is the per-direction output size, identical between compact and full layouts
         return tuple(int(ops.shape[1]) for ops in self._compact_ops_1d)
 
     # ---------------------------------------------------------------- identity queries
@@ -615,14 +616,12 @@ class SpanwiseElementExtraction:
         Returns:
             tuple[tuple[npt.NDArray[np.float32 | np.float64], ...], tuple[bool, ...]]:
             ``(ops_for_cell, identity_flags)`` where ``ops_for_cell[k]`` is a
-            view into :attr:`ops_1d` ``[k]`` and ``identity_flags`` is the
-            per-direction identity mask at this element.
+            2D array of shape ``(n_out_k, n_in_k)`` (identity elements return a
+            fresh ``numpy.eye``; non-identity elements return a row from
+            :attr:`compact_ops_1d`) and ``identity_flags`` is the per-direction
+            identity mask at this element.
         """
-        multi = self._normalize_cell_idx(cell_idx)
-        ops = tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
-        flags = tuple(
-            bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
-        )
+        ops, flags = self._ops_and_flags_for_cell(self._normalize_cell_idx(cell_idx))
         return ops, flags
 
     def __iter__(
@@ -676,6 +675,36 @@ class SpanwiseElementExtraction:
             return seq
         raise TypeError(f"cell_idx must be int or sequence of int; got {type(cell_idx).__name__}")
 
+    def _ops_and_flags_for_cell(
+        self, multi: tuple[int, ...]
+    ) -> tuple[
+        tuple[npt.NDArray[np.float32 | np.float64], ...],
+        tuple[bool, ...],
+    ]:
+        """Extract per-direction operators and identity flags from compact storage.
+
+        Args:
+            multi (tuple[int, ...]): Already-validated per-direction element indices.
+
+        Returns:
+            tuple[tuple[npt.NDArray, ...], tuple[bool, ...]]: ``(ops, flags)``
+            where each ``ops[k]`` is a 2D ``(n_out_k, n_in_k)`` array from
+            compact storage (or a fresh ``numpy.eye`` for identity elements).
+        """
+        ops: list[npt.NDArray[np.float32 | np.float64]] = []
+        flags: list[bool] = []
+        for compact, idx_map, mask, i in zip(
+            self._compact_ops_1d, self._idx_maps_1d, self._is_identity_mask_1d, multi, strict=True
+        ):
+            n_out, n_in = int(compact.shape[1]), int(compact.shape[2])
+            is_id = bool(mask[i])
+            flags.append(is_id)
+            if is_id:
+                ops.append(np.eye(n_out, n_in, dtype=compact.dtype))
+            else:
+                ops.append(compact[int(idx_map[i])])
+        return tuple(ops), tuple(flags)
+
     def _ops_for_cell(
         self, cell_idx: CellIndex
     ) -> tuple[npt.NDArray[np.float32 | np.float64], ...]:
@@ -688,8 +717,8 @@ class SpanwiseElementExtraction:
             tuple[npt.NDArray[np.float32 | np.float64], ...]: Per-direction
             2D operators, each of shape ``(n_out_k, n_in_k)``.
         """
-        multi = self._normalize_cell_idx(cell_idx)
-        return tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
+        ops, _ = self._ops_and_flags_for_cell(self._normalize_cell_idx(cell_idx))
+        return ops
 
     def _apply(
         self,
@@ -712,11 +741,7 @@ class SpanwiseElementExtraction:
         Returns:
             npt.NDArray[np.float32 | np.float64]: The result array.
         """
-        multi = self._normalize_cell_idx(cell_idx)
-        ops = tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
-        flags = tuple(
-            bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
-        )
+        ops, flags = self._ops_and_flags_for_cell(self._normalize_cell_idx(cell_idx))
         kernel, args, result = _prepare_apply_call(ops, flags, operand, out, scratch, op_kind)
         kernel(*args)
         return result
@@ -739,9 +764,10 @@ class SpanwiseElementExtraction:
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional scratch.
 
         Returns:
-            npt.NDArray[np.float32 | np.float64]: Result array of shape
-            ``(n_cells, N_out)`` for vector kinds or ``(n_cells, N_out, N_out)`` /
-            ``(n_cells, N_in, N_in)`` for bilateral kinds.
+            npt.NDArray[np.float32 | np.float64]: Result array; shape is
+            ``(n_cells, N_out)`` for ``"apply"``, ``(n_cells, N_in)`` for
+            ``"apply_T"``, ``(n_cells, N_in, N_in)`` for ``"MT_K_M"``, or
+            ``(n_cells, N_out, N_out)`` for ``"M_K_MT"``.
 
         Raises:
             IndexError: If any cell index is out of range.

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -110,7 +110,7 @@ class SpanwiseElementExtraction:
             index maps of shape ``(n_elements_k,)``; ``_idx_maps_1d[k][e]`` is
             the row index into ``_compact_ops_1d[k]`` for element ``e``
             (undefined for identity elements, stored as 0).
-        _is_identity_mask_1d (tuple[npt.NDArray[np.bool_], ...]): Per-direction
+        _is_identity_mask_1d (tuple[npt.NDArray[bool], ...]): Per-direction
             identity masks of shape ``(n_elements_k,)``.
     """
 
@@ -342,7 +342,7 @@ class SpanwiseElementExtraction:
         of :meth:`BsplineSpace1D.get_cardinal_intervals`.
 
         Returns:
-            tuple[npt.NDArray[np.bool_], ...]: Length-``d`` tuple of read-only
+            tuple[npt.NDArray[bool], ...]: Length-``d`` tuple of read-only
             1D boolean arrays; ``is_identity_mask_1d[k][i]`` is ``True`` iff
             the ``i``-th element in direction ``k`` has an identity operator.
         """

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -77,29 +77,39 @@ class SpanwiseElementExtraction:
     """Tensor-product change-of-basis operator across B-spline elements.
 
     For a :class:`BsplineSpace` of dimension ``d`` and a chosen ``target``
-    basis, this class eagerly builds the per-direction 1D extraction operator
-    arrays ``ops_1d[k]`` of shape ``(n_elements_k, n_out_k, n_in_k)``. Per-
-    element d-dimensional operators are never materialized unless explicitly
-    requested via :meth:`operator` or :meth:`tabulate`: instead the apply-style
-    methods dispatch to the matrix-free Kronecker kernels in
-    ``pantr.bspline._extraction_kernels``.
+    basis, this class eagerly builds per-direction compact operator storage:
+    only the non-identity rows of each direction's extraction operator array
+    are retained, reducing memory for identity-heavy spaces (e.g. cardinal
+    spaces on uniform meshes). Per-element d-dimensional operators are never
+    materialized unless explicitly requested via :meth:`operator` or
+    :meth:`tabulate`: instead the apply-style methods dispatch to the
+    matrix-free Kronecker kernels in ``pantr.bspline._extraction_kernels``.
 
     With the current 1D builders all per-direction operators are square of
     size ``(degree_k + 1, degree_k + 1)``. The class also supports non-square
     per-direction operators, so new 1D builders can plug in without changes.
 
-    The per-direction data is also exposed as tuples of NumPy arrays
-    (:attr:`ops_1d`, :attr:`is_identity_mask_1d`) so that downstream Numba
-    code can consume the raw arrays and call the Layer-3 kernels directly.
+    The per-direction data is exposed as two complementary representations:
+
+    - *Compact* (:attr:`compact_ops_1d`, :attr:`idx_maps_1d`,
+      :attr:`is_identity_mask_1d`): primary storage, suitable for downstream
+      ``@njit`` code that calls the Layer-3 batch kernels directly.
+    - *Dense* (:attr:`ops_1d`): the full ``(n_elements_k, n_out_k, n_in_k)``
+      layout, reconstructed lazily from compact storage on first access.
 
     Attributes:
         _space (BsplineSpace): Underlying multi-dimensional B-spline space.
         _target (Target): Target basis tag.
         _lagrange_variant (LagrangeVariant): Point distribution used when
             ``target == "lagrange"``; ignored otherwise.
-        _ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]):
-            Per-direction 3D operator arrays of shape
-            ``(n_elements_k, n_out_k, n_in_k)``.
+        _compact_ops_1d (tuple[npt.NDArray[np.float32 | np.float64], ...]):
+            Per-direction compact 3D operator arrays of shape
+            ``(n_compact_k, n_out_k, n_in_k)``; only non-identity rows are
+            stored. Always has at least one row to ensure safe Numba indexing.
+        _idx_maps_1d (tuple[npt.NDArray[np.intp], ...]): Per-direction compact
+            index maps of shape ``(n_elements_k,)``; ``_idx_maps_1d[k][e]`` is
+            the row index into ``_compact_ops_1d[k]`` for element ``e``
+            (undefined for identity elements, stored as 0).
         _is_identity_mask_1d (tuple[npt.NDArray[bool], ...]): Per-direction
             identity masks of shape ``(n_elements_k,)``.
     """
@@ -107,7 +117,8 @@ class SpanwiseElementExtraction:
     _space: BsplineSpace
     _target: Target
     _lagrange_variant: LagrangeVariant
-    _ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...]
+    _compact_ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...]
+    _idx_maps_1d: tuple[npt.NDArray[np.intp], ...]
     _is_identity_mask_1d: tuple[npt.NDArray[np.bool_], ...]
 
     def __init__(
@@ -145,7 +156,8 @@ class SpanwiseElementExtraction:
         self._target = target
         self._lagrange_variant = lagrange_variant
 
-        ops_1d: list[npt.NDArray[np.float32 | np.float64]] = []
+        compact_ops_1d: list[npt.NDArray[np.float32 | np.float64]] = []
+        idx_maps_1d: list[npt.NDArray[np.intp]] = []
         masks_1d: list[npt.NDArray[np.bool_]] = []
         for space_1d in space.spaces:
             if target == "bezier":
@@ -159,17 +171,29 @@ class SpanwiseElementExtraction:
             else:  # target == "cardinal"
                 ops = space_1d.tabulate_cardinal_extraction_operators()
                 mask = space_1d.get_cardinal_intervals()
-            ops.flags.writeable = False
+            non_id_idx = np.where(~mask)[0]
+            n_non_id = int(non_id_idx.shape[0])
+            n_out, n_in = int(ops.shape[1]), int(ops.shape[2])
+            if n_non_id > 0:
+                compact_ops = ops[non_id_idx].copy()
+            else:
+                compact_ops = np.zeros((1, n_out, n_in), dtype=ops.dtype)
+            idx_map = np.zeros(int(mask.shape[0]), dtype=np.intp)
+            idx_map[non_id_idx] = np.arange(n_non_id, dtype=np.intp)
+            compact_ops.flags.writeable = False
+            idx_map.flags.writeable = False
             mask.flags.writeable = False
-            ops_1d.append(ops)
+            compact_ops_1d.append(compact_ops)
+            idx_maps_1d.append(idx_map)
             masks_1d.append(mask)
 
-        self._ops_1d = tuple(ops_1d)
+        self._compact_ops_1d = tuple(compact_ops_1d)
+        self._idx_maps_1d = tuple(idx_maps_1d)
         self._is_identity_mask_1d = tuple(masks_1d)
 
-        if len(self._ops_1d) > 1:
-            dtype_0 = self._ops_1d[0].dtype
-            for k, _ops in enumerate(self._ops_1d[1:], start=1):
+        if len(self._compact_ops_1d) > 1:
+            dtype_0 = self._compact_ops_1d[0].dtype
+            for k, _ops in enumerate(self._compact_ops_1d[1:], start=1):
                 if _ops.dtype != dtype_0:
                     raise ValueError(
                         f"Per-direction operators have inconsistent dtypes: "
@@ -241,17 +265,69 @@ class SpanwiseElementExtraction:
         """
         return self._space.num_total_intervals
 
-    @property
+    @functools.cached_property
     def ops_1d(self) -> tuple[npt.NDArray[np.float32 | np.float64], ...]:
-        """Get the per-direction 1D operator arrays.
+        """Get the per-direction 1D operator arrays (dense, reconstructed lazily).
+
+        Reconstructs the full ``(n_elements_k, n_out_k, n_in_k)`` array from
+        compact storage on first access and caches the result. Identity elements
+        are filled with the identity matrix; non-identity elements are read from
+        :attr:`compact_ops_1d`.
 
         Returns:
             tuple[npt.NDArray[np.float32 | np.float64], ...]: Length-``d`` tuple
             of read-only 3D arrays; ``ops_1d[k]`` has shape
             ``(n_elements_k, n_out_k, n_in_k)``. Intended for consumption by
-            downstream ``@njit`` code.
+            downstream ``@njit`` code when the full dense layout is required.
+            For compact-aware downstream code, prefer :attr:`compact_ops_1d` and
+            :attr:`idx_maps_1d`.
         """
-        return self._ops_1d
+        dense: list[npt.NDArray[np.float32 | np.float64]] = []
+        for compact_ops, idx_map, mask in zip(
+            self._compact_ops_1d, self._idx_maps_1d, self._is_identity_mask_1d, strict=True
+        ):
+            n_el = int(mask.shape[0])
+            n_out, n_in = int(compact_ops.shape[1]), int(compact_ops.shape[2])
+            full: npt.NDArray[np.float32 | np.float64] = np.empty(
+                (n_el, n_out, n_in), dtype=compact_ops.dtype
+            )
+            eye = np.eye(n_out, n_in, dtype=compact_ops.dtype)
+            for e in range(n_el):
+                if mask[e]:
+                    full[e] = eye
+                else:
+                    full[e] = compact_ops[idx_map[e]]
+            full.flags.writeable = False
+            dense.append(full)
+        return tuple(dense)
+
+    @property
+    def compact_ops_1d(self) -> tuple[npt.NDArray[np.float32 | np.float64], ...]:
+        """Get the per-direction compact operator arrays (non-identity rows only).
+
+        Returns:
+            tuple[npt.NDArray[np.float32 | np.float64], ...]: Length-``d`` tuple
+            of read-only 3D arrays; ``compact_ops_1d[k]`` has shape
+            ``(n_compact_k, n_out_k, n_in_k)`` where ``n_compact_k`` is the
+            number of non-identity elements in direction ``k`` (at least 1 to
+            ensure safe Numba indexing). Intended for downstream ``@njit`` code
+            alongside :attr:`idx_maps_1d` and :attr:`is_identity_mask_1d`.
+        """
+        return self._compact_ops_1d
+
+    @property
+    def idx_maps_1d(self) -> tuple[npt.NDArray[np.intp], ...]:
+        """Get the per-direction compact index maps.
+
+        Returns:
+            tuple[npt.NDArray[np.intp], ...]: Length-``d`` tuple of read-only
+            1D integer arrays; ``idx_maps_1d[k]`` has shape ``(n_elements_k,)``
+            and ``idx_maps_1d[k][e]`` is the row index into
+            :attr:`compact_ops_1d` ``[k]`` for element ``e``. For identity
+            elements the stored value is 0 (unused; the kernel short-circuits on
+            :attr:`is_identity_mask_1d`). Intended for downstream ``@njit`` code.
+        """
+        return self._idx_maps_1d
 
     @property
     def is_identity_mask_1d(self) -> tuple[npt.NDArray[np.bool_], ...]:
@@ -280,7 +356,7 @@ class SpanwiseElementExtraction:
         Returns:
             tuple[int, ...]: ``(n_in_0, …, n_in_{d-1})``.
         """
-        return tuple(int(ops.shape[2]) for ops in self._ops_1d)
+        return tuple(int(ops.shape[2]) for ops in self._compact_ops_1d)
 
     @property
     def output_shape_per_dir(self) -> tuple[int, ...]:
@@ -289,7 +365,7 @@ class SpanwiseElementExtraction:
         Returns:
             tuple[int, ...]: ``(n_out_0, …, n_out_{d-1})``.
         """
-        return tuple(int(ops.shape[1]) for ops in self._ops_1d)
+        return tuple(int(ops.shape[1]) for ops in self._compact_ops_1d)
 
     # ---------------------------------------------------------------- identity queries
 
@@ -543,7 +619,7 @@ class SpanwiseElementExtraction:
             per-direction identity mask at this element.
         """
         multi = self._normalize_cell_idx(cell_idx)
-        ops = tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+        ops = tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
         flags = tuple(
             bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
         )
@@ -613,7 +689,7 @@ class SpanwiseElementExtraction:
             2D operators, each of shape ``(n_out_k, n_in_k)``.
         """
         multi = self._normalize_cell_idx(cell_idx)
-        return tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+        return tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
 
     def _apply(
         self,
@@ -637,7 +713,7 @@ class SpanwiseElementExtraction:
             npt.NDArray[np.float32 | np.float64]: The result array.
         """
         multi = self._normalize_cell_idx(cell_idx)
-        ops = tuple(ops_dir[i] for ops_dir, i in zip(self._ops_1d, multi, strict=True))
+        ops = tuple(ops_dir[i] for ops_dir, i in zip(self.ops_1d, multi, strict=True))
         flags = tuple(
             bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
         )
@@ -675,7 +751,8 @@ class SpanwiseElementExtraction:
         """
         idx2d = normalize_cell_indices(cell_indices, self.num_intervals)
         kernel, args, result = _prepare_apply_many_call(
-            self._ops_1d,
+            self._compact_ops_1d,
+            self._idx_maps_1d,
             self._is_identity_mask_1d,
             idx2d,
             operand,

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -38,6 +38,7 @@ from pantr.basis import LagrangeVariant
 from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
 from pantr.bspline._extraction_helpers import (
     _allocate_or_validate_scratch_many,
+    _prepare_apply_many_call,
     _required_scratch_size,
 )
 from pantr.bspline.spanwise_element_extraction import (
@@ -983,3 +984,178 @@ def test_allocate_or_validate_scratch_many_rejects_invalid() -> None:
     ro.flags.writeable = False
     with pytest.raises(ValueError, match="writeable"):
         _allocate_or_validate_scratch_many(ro, n_cells, width, dtype)
+
+
+# ---------------------------------------------------------------- compact storage
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_compact_ops_1d_shape(target: str, dtype: str) -> None:
+    """``compact_ops_1d[k]`` has exactly as many rows as non-identity elements."""
+    sp1 = BsplineSpace1D(np.array([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], dtype=dtype), 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), target)  # type: ignore[arg-type]
+    for k, (compact_ops, mask) in enumerate(
+        zip(ext.compact_ops_1d, ext.is_identity_mask_1d, strict=True)
+    ):
+        n_non_id = int(np.sum(~mask))
+        # Always at least 1 row (safe Numba indexing invariant)
+        assert compact_ops.shape[0] >= 1, f"dir {k}: compact_ops has 0 rows"
+        if n_non_id > 0:
+            assert compact_ops.shape[0] == n_non_id, (
+                f"dir {k}: expected {n_non_id} compact rows, got {compact_ops.shape[0]}"
+            )
+        assert compact_ops.shape[1:] == (3, 3)
+        assert not compact_ops.flags.writeable
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_idx_maps_1d_shape_and_type(target: str) -> None:
+    """``idx_maps_1d[k]`` has length ``n_elements_k``, integer dtype, and is read-only."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    for k, (idx_map, mask) in enumerate(zip(ext.idx_maps_1d, ext.is_identity_mask_1d, strict=True)):
+        assert idx_map.ndim == 1, f"dir {k}: idx_map not 1D"
+        assert idx_map.shape[0] == mask.shape[0], f"dir {k}: length mismatch"
+        assert np.issubdtype(idx_map.dtype, np.integer), f"dir {k}: not integer dtype"
+        assert not idx_map.flags.writeable, f"dir {k}: idx_map is writeable"
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_idx_maps_1d_non_negative(target: str) -> None:
+    """All values in ``idx_maps_1d[k]`` are non-negative (0 for identity elements)."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    for k, idx_map in enumerate(ext.idx_maps_1d):
+        assert int(idx_map.min()) >= 0, f"dir {k}: negative idx_map entry"
+
+
+def test_compact_ops_saves_memory_for_cardinal() -> None:
+    """Cardinal spaces with uniform interior have fewer compact rows than elements."""
+    # 10 uniform interior elements → most are cardinal-identity
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10], 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), "cardinal")
+    for k, (compact_ops, mask) in enumerate(
+        zip(ext.compact_ops_1d, ext.is_identity_mask_1d, strict=True)
+    ):
+        n_id = int(np.sum(mask))
+        n_el = int(mask.shape[0])
+        assert n_id > 0, f"dir {k}: expected some identity elements for cardinal"
+        assert compact_ops.shape[0] < n_el, (
+            f"dir {k}: compact storage not smaller than dense ({compact_ops.shape[0]} >= {n_el})"
+        )
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_ops_1d_round_trip(target: str, dtype: str) -> None:
+    """Lazy-reconstructed ``ops_1d`` matches ``tabulate`` element-by-element."""
+    sp1 = BsplineSpace1D(np.array([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], dtype=dtype), 2)
+    sp = BsplineSpace([sp1, sp1])
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
+    tabulated = ext.tabulate()  # shape (n_total, N_out, N_in)
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    for flat in range(ext.num_total_intervals):
+        multi = np.unravel_index(flat, ext.num_intervals)
+        M_ref = tabulated[flat]
+        # Build from ops_1d (cached property)
+        M_ops = ext.ops_1d[0][int(multi[0])]
+        for k in range(1, ext.dim):
+            M_ops = np.kron(M_ops, ext.ops_1d[k][int(multi[k])])
+        assert M_ops.shape == (n_out, n_in)
+        np.testing.assert_allclose(
+            M_ops,
+            M_ref,
+            atol=1e-6 if np.dtype(dtype) == np.dtype(np.float32) else 1e-12,
+            err_msg=f"ops_1d round-trip mismatch at flat index {flat}",
+        )
+
+
+def test_compact_idx_map_correctness() -> None:
+    """Non-identity elements map to the correct compact operator via ``idx_maps_1d``."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "cardinal")
+    for k, (compact_ops, idx_map, mask) in enumerate(
+        zip(ext.compact_ops_1d, ext.idx_maps_1d, ext.is_identity_mask_1d, strict=True)
+    ):
+        full_ops = ext.ops_1d[k]  # reconstructed dense array
+        for e in range(int(mask.shape[0])):
+            if not mask[e]:
+                np.testing.assert_array_equal(
+                    compact_ops[idx_map[e]],
+                    full_ops[e],
+                    err_msg=f"dir {k}, element {e}: compact op != full op",
+                )
+
+
+def test_all_identity_direction_compact_shape() -> None:
+    """When all elements are identity the compact array has exactly 1 dummy row."""
+    # Bezier decomposition: every interior knot has mult >= degree+1 → all elements identity
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3], 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), "bezier")
+    for k, (compact_ops, mask) in enumerate(
+        zip(ext.compact_ops_1d, ext.is_identity_mask_1d, strict=True)
+    ):
+        assert mask.all(), f"dir {k}: expected all-identity for Bezier decomposition space"
+        assert compact_ops.shape[0] == 1, (
+            f"dir {k}: all-identity compact should have 1 dummy row, got {compact_ops.shape[0]}"
+        )
+
+
+def test_idx_maps_1d_validation_in_prepare_many_call() -> None:
+    """``_prepare_apply_many_call`` validates idx_maps_1d length and dtype."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    flat = np.array([0, 1, 2], dtype=np.intp)
+    idx2d = normalize_cell_indices(flat, ext.num_intervals)
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    v = RNG.random((3, n_in))
+
+    # Wrong length for idx_maps_1d
+    bad_idx_map = (np.zeros(1, dtype=np.intp), np.zeros(1, dtype=np.intp))
+    with pytest.raises(ValueError, match="idx_maps_1d"):
+        _prepare_apply_many_call(
+            ext.compact_ops_1d,
+            bad_idx_map,
+            ext.is_identity_mask_1d,
+            idx2d,
+            v,
+            None,
+            None,
+            "apply",
+        )
+
+    # Non-integer idx_map — deliberately pass wrong dtype to trigger validation error
+    bad_float_map: Any = (
+        np.zeros(ext.num_intervals[0], dtype=np.float64),
+        np.zeros(ext.num_intervals[1], dtype=np.intp),
+    )
+    with pytest.raises(ValueError, match="integer"):
+        _prepare_apply_many_call(
+            ext.compact_ops_1d,
+            bad_float_map,
+            ext.is_identity_mask_1d,
+            idx2d,
+            v,
+            None,
+            None,
+            "apply",
+        )
+
+    # idx_map 2D instead of 1D
+    bad_2d_map = (
+        np.zeros((ext.num_intervals[0], 2), dtype=np.intp),
+        np.zeros(ext.num_intervals[1], dtype=np.intp),
+    )
+    with pytest.raises(ValueError, match="1D"):
+        _prepare_apply_many_call(
+            ext.compact_ops_1d,
+            bad_2d_map,
+            ext.is_identity_mask_1d,
+            idx2d,
+            v,
+            None,
+            None,
+            "apply",
+        )

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -991,7 +991,7 @@ def test_allocate_or_validate_scratch_many_rejects_invalid() -> None:
 
 @pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
-def test_compact_ops_1d_shape(target: str, dtype: str) -> None:
+def test_compact_ops_1d_shape(target: str, dtype: npt.DTypeLike) -> None:
     """``compact_ops_1d[k]`` has exactly as many rows as non-identity elements."""
     sp1 = BsplineSpace1D(np.array([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], dtype=dtype), 2)
     ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), target)  # type: ignore[arg-type]
@@ -1048,7 +1048,7 @@ def test_compact_ops_saves_memory_for_cardinal() -> None:
 
 @pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
-def test_ops_1d_round_trip(target: str, dtype: str) -> None:
+def test_ops_1d_round_trip(target: str, dtype: npt.DTypeLike) -> None:
     """Lazy-reconstructed ``ops_1d`` matches ``tabulate`` element-by-element."""
     sp1 = BsplineSpace1D(np.array([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], dtype=dtype), 2)
     sp = BsplineSpace([sp1, sp1])
@@ -1072,10 +1072,11 @@ def test_ops_1d_round_trip(target: str, dtype: str) -> None:
         )
 
 
-def test_compact_idx_map_correctness() -> None:
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_compact_idx_map_correctness(target: str) -> None:
     """Non-identity elements map to the correct compact operator via ``idx_maps_1d``."""
     sp = _space_2d()
-    ext = SpanwiseElementExtraction(sp, "cardinal")
+    ext = SpanwiseElementExtraction(sp, target)  # type: ignore[arg-type]
     for k, (compact_ops, idx_map, mask) in enumerate(
         zip(ext.compact_ops_1d, ext.idx_maps_1d, ext.is_identity_mask_1d, strict=True)
     ):
@@ -1087,6 +1088,18 @@ def test_compact_idx_map_correctness() -> None:
                     full_ops[e],
                     err_msg=f"dir {k}, element {e}: compact op != full op",
                 )
+
+
+def test_compact_idx_map_identity_sentinel() -> None:
+    """Identity elements have ``idx_map[e] == 0`` (the unused sentinel value)."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "cardinal")
+    for k, (idx_map, mask) in enumerate(zip(ext.idx_maps_1d, ext.is_identity_mask_1d, strict=True)):
+        np.testing.assert_array_equal(
+            idx_map[mask],
+            0,
+            err_msg=f"dir {k}: identity elements should store idx_map sentinel 0",
+        )
 
 
 def test_all_identity_direction_compact_shape() -> None:
@@ -1103,6 +1116,44 @@ def test_all_identity_direction_compact_shape() -> None:
         )
 
 
+def test_all_non_identity_compact_shape() -> None:
+    """When no elements are identity the compact array has exactly n_el_k rows."""
+    # Bezier target on a non-decomposed space: no elements are identity
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), "bezier")
+    for k, (compact_ops, mask) in enumerate(
+        zip(ext.compact_ops_1d, ext.is_identity_mask_1d, strict=True)
+    ):
+        n_el = int(mask.shape[0])
+        assert not mask.any(), f"dir {k}: expected no identity elements"
+        assert compact_ops.shape[0] == n_el, (
+            f"dir {k}: all-non-identity compact should have {n_el} rows, got {compact_ops.shape[0]}"
+        )
+
+
+def test_idx_maps_1d_wrong_tuple_length_validation() -> None:
+    """``_prepare_apply_many_call`` rejects idx_maps_1d whose tuple length != d."""
+    sp = _space_2d()
+    ext = SpanwiseElementExtraction(sp, "bezier")
+    flat = np.array([0, 1, 2], dtype=np.intp)
+    idx2d = normalize_cell_indices(flat, ext.num_intervals)
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    v = RNG.random((3, n_in))
+
+    # d=2 space but only 1 idx_map tuple element
+    with pytest.raises(ValueError, match="idx_maps_1d"):
+        _prepare_apply_many_call(
+            ext.compact_ops_1d,
+            (np.zeros(ext.num_intervals[0], dtype=np.intp),),
+            ext.is_identity_mask_1d,
+            idx2d,
+            v,
+            None,
+            None,
+            "apply",
+        )
+
+
 def test_idx_maps_1d_validation_in_prepare_many_call() -> None:
     """``_prepare_apply_many_call`` validates idx_maps_1d length and dtype."""
     sp = _space_2d()
@@ -1112,7 +1163,7 @@ def test_idx_maps_1d_validation_in_prepare_many_call() -> None:
     n_in = int(np.prod(ext.input_shape_per_dir))
     v = RNG.random((3, n_in))
 
-    # Wrong length for idx_maps_1d
+    # Wrong element-length for idx_maps_1d (each map has length 1 instead of n_el_k)
     bad_idx_map = (np.zeros(1, dtype=np.intp), np.zeros(1, dtype=np.intp))
     with pytest.raises(ValueError, match="idx_maps_1d"):
         _prepare_apply_many_call(


### PR DESCRIPTION
Closes part of #141 (PR 7).

## Summary

- **Compact storage**: `SpanwiseElementExtraction` now stores only non-identity rows per direction. `_compact_ops_1d[k]` has shape `(n_compact_k, n_out_k, n_in_k)` where `n_compact_k ≤ n_elements_k`. An always-present dummy row (when all elements are identity) keeps Numba indexing safe.
- **Index maps**: `_idx_maps_1d[k]` of shape `(n_elements_k,)` maps each element to its compact row. Identity elements store 0 (value unused; kernel short-circuits on the identity flag).
- **`ops_1d` cached property**: lazily reconstructs the full dense `(n_elements_k, n_out_k, n_in_k)` layout from compact storage on first access; single-cell code paths continue to use it transparently.
- **New properties**: `compact_ops_1d` and `idx_maps_1d` expose compact format for downstream `@njit` callers alongside the existing `is_identity_mask_1d`.
- **Batch kernels**: all 12 `*_many_*` Layer-3 kernels gain `idx_map_k` parameters (inserted between the `ops_k` and `is_id_k` groups) and index as `ops_k[idx_map_k[i_k]]`.
- **Layer-2 helper**: `_prepare_apply_many_call` gains an `idx_maps_1d` parameter with shape/dtype validation; element-count bounds checks now use `is_identity_masks[k].shape[0]`.

For cardinal spaces on uniform meshes the compact form is significantly smaller than the dense form (only the 2 boundary elements per direction are non-identity).

## Test plan

- [x] All existing 2468 tests pass unchanged
- [x] New tests: `compact_ops_1d` shape, `idx_maps_1d` shape/type/read-only, `ops_1d` round-trip vs `tabulate`, memory-savings assertion for cardinal, compact index correctness, all-identity dummy-row invariant, `_prepare_apply_many_call` validation
- [x] Pre-PR checks pass: ruff lint, ruff format, mypy (strict), pytest, Sphinx docs

Generated with [Claude Code](https://claude.com/claude-code)