### PR TITLE
feat(extraction): struct-view for Numba-callable downstream code

### DIFF
--- a/docs/spanwise-element-extraction.md
+++ b/docs/spanwise-element-extraction.md
@@ -234,6 +234,39 @@ drop the redundant `apply` prefix — as shown in the table below:
 All kernels accept only plain NumPy arrays (no Python objects).  Dimensions
 above 3 raise `NotImplementedError` from the Layer-2 dispatcher.
 
+### Struct view for `@njit` callers
+
+{class}`~pantr.bspline.ExtractionStructView` bundles the compact storage and
+shape metadata of a {class}`~pantr.bspline.SpanwiseElementExtraction` into a
+single immutable `typing.NamedTuple` that Numba can unbox.  Pass it as a
+single argument instead of forwarding seven separate objects.
+
+```python
+from numba import njit
+from pantr.bspline import SpanwiseElementExtraction, make_struct_view
+from pantr.bspline._extraction_kernels import apply_kron_apply_many_2d
+
+ext  = SpanwiseElementExtraction(space, "bezier")
+view = make_struct_view(ext)   # shares arrays; no copies
+
+@njit(cache=True)
+def batch_apply(view, cell_indices, v, out, scratch):
+    apply_kron_apply_many_2d(
+        view.compact_ops_1d[0],       view.compact_ops_1d[1],
+        view.idx_maps_1d[0],          view.idx_maps_1d[1],
+        view.is_identity_mask_1d[0],  view.is_identity_mask_1d[1],
+        cell_indices, v, out, scratch,
+    )
+```
+
+The struct view exposes the same arrays and integer metadata already
+available on the extraction object — see the
+{class}`~pantr.bspline.ExtractionStructView` API reference for the full
+field list.  Because every field has a uniform Numba type (homogeneous
+tuples of arrays, plain ints, and int tuples), the view is a drop-in
+argument for any `@njit` function that previously took the individual
+pieces.
+
 ## Materializing operators
 
 Use {meth}`~pantr.bspline.SpanwiseElementExtraction.operator` to assemble the

--- a/docs/spanwise-element-extraction.md
+++ b/docs/spanwise-element-extraction.md
@@ -239,7 +239,7 @@ above 3 raise `NotImplementedError` from the Layer-2 dispatcher.
 {class}`~pantr.bspline.ExtractionStructView` bundles the compact storage and
 shape metadata of a {class}`~pantr.bspline.SpanwiseElementExtraction` into a
 single immutable `typing.NamedTuple` that Numba can unbox.  Pass it as a
-single argument instead of forwarding seven separate objects.
+single argument instead of forwarding the per-direction arrays individually.
 
 ```python
 from numba import njit

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -15,6 +15,9 @@ This package consolidates the B-spline API:
 - :func:`create_from_bezier`: create a B-spline from a Bézier.
 - :class:`SpanwiseElementExtraction`: lazy tensor-product change-of-basis
   operator across B-spline elements (Bézier/Lagrange/cardinal targets).
+- :class:`ExtractionStructView`, :func:`make_struct_view`: Numba-passable
+  bundle of a :class:`SpanwiseElementExtraction`'s compact storage for
+  downstream ``@njit`` code.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -29,12 +32,17 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace
-from .spanwise_element_extraction import SpanwiseElementExtraction
+from .spanwise_element_extraction import (
+    ExtractionStructView,
+    SpanwiseElementExtraction,
+    make_struct_view,
+)
 
 __all__ = [
     "Bspline",
     "BsplineSpace",
     "BsplineSpace1D",
+    "ExtractionStructView",
     "SpanwiseElementExtraction",
     "create_cardinal_knots",
     "create_from_bezier",
@@ -46,4 +54,5 @@ __all__ = [
     "get_greville_abscissae",
     "interpolate_bspline",
     "l2_project_bspline",
+    "make_struct_view",
 ]

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Literal, get_args
+from typing import TYPE_CHECKING, Literal, NamedTuple, get_args
 
 import numpy as np
 import numpy.typing as npt
@@ -1055,11 +1055,87 @@ def operand_shape(
     )
 
 
+class ExtractionStructView(NamedTuple):
+    """Immutable struct view of a :class:`SpanwiseElementExtraction` for ``@njit`` callers.
+
+    A :class:`typing.NamedTuple` bundling the compact per-direction operator
+    storage, index maps, identity masks, and shape metadata into a single
+    object that Numba can unbox. Each field of a given type is homogeneous
+    (e.g. all ``compact_ops_1d`` entries share dtype and ndim), so Numba
+    represents the tuple fields as ``UniTuple`` inside an ``@njit`` function.
+    This makes ``ExtractionStructView`` a drop-in replacement for the separate
+    ``(ops_1d, idx_maps_1d, is_identity_mask_1d, …)`` bundle when calling the
+    Layer-3 batch kernels in ``pantr.bspline._extraction_kernels`` from
+    downstream Numba code.
+
+    Construct via :func:`make_struct_view`. Field semantics mirror the
+    same-named members of :class:`SpanwiseElementExtraction`:
+
+    - ``compact_ops_1d`` — per-direction compact 3D operator arrays of shape
+      ``(n_compact_k, n_out_k, n_in_k)``; only non-identity rows.
+    - ``idx_maps_1d`` — per-direction compact index maps of shape
+      ``(n_elements_k,)``.
+    - ``is_identity_mask_1d`` — per-direction identity masks of shape
+      ``(n_elements_k,)``.
+    - ``num_intervals`` — per-direction number of elements.
+    - ``input_shape_per_dir`` — per-direction input sizes
+      ``(n_in_0, …, n_in_{d-1})``.
+    - ``output_shape_per_dir`` — per-direction output sizes
+      ``(n_out_0, …, n_out_{d-1})``.
+    - ``dim`` — number of tensor-product directions ``d``.
+    """
+
+    compact_ops_1d: tuple[npt.NDArray[np.float32 | np.float64], ...]
+    idx_maps_1d: tuple[npt.NDArray[np.intp], ...]
+    is_identity_mask_1d: tuple[npt.NDArray[np.bool_], ...]
+    num_intervals: tuple[int, ...]
+    input_shape_per_dir: tuple[int, ...]
+    output_shape_per_dir: tuple[int, ...]
+    dim: int
+
+
+def make_struct_view(extraction: SpanwiseElementExtraction) -> ExtractionStructView:
+    """Bundle a :class:`SpanwiseElementExtraction` into a Numba-passable struct view.
+
+    Shares the underlying per-direction arrays (no copies). The arrays are
+    already marked read-only by :class:`SpanwiseElementExtraction`, so the
+    returned view is safe to pass into ``@njit`` code without risk of
+    accidental mutation.
+
+    Args:
+        extraction (SpanwiseElementExtraction): Source extraction object.
+
+    Returns:
+        ExtractionStructView: Named tuple wrapping the extraction's compact
+        storage and shape metadata. Suitable for direct use as a single
+        argument to ``@njit`` functions that call the Layer-3 batch kernels
+        in ``pantr.bspline._extraction_kernels``.
+
+    Example:
+        >>> from pantr.bspline import SpanwiseElementExtraction, make_struct_view
+        >>> ext = SpanwiseElementExtraction(space, "bezier")
+        >>> view = make_struct_view(ext)
+        >>> view.dim
+        2
+    """
+    return ExtractionStructView(
+        compact_ops_1d=extraction.compact_ops_1d,
+        idx_maps_1d=extraction.idx_maps_1d,
+        is_identity_mask_1d=extraction.is_identity_mask_1d,
+        num_intervals=tuple(int(n) for n in extraction.num_intervals),
+        input_shape_per_dir=extraction.input_shape_per_dir,
+        output_shape_per_dir=extraction.output_shape_per_dir,
+        dim=int(extraction.dim),
+    )
+
+
 __all__ = [
     "CellIndex",
     "CellIndicesBatch",
+    "ExtractionStructView",
     "SpanwiseElementExtraction",
     "Target",
+    "make_struct_view",
     "normalize_cell_indices",
     "operand_shape",
 ]

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -1060,9 +1060,10 @@ class ExtractionStructView(NamedTuple):
 
     A :class:`typing.NamedTuple` bundling the compact per-direction operator
     storage, index maps, identity masks, and shape metadata into a single
-    object that Numba can unbox. Each field of a given type is homogeneous
-    (e.g. all ``compact_ops_1d`` entries share dtype and ndim), so Numba
-    represents the tuple fields as ``UniTuple`` inside an ``@njit`` function.
+    object that Numba can unbox. Each array field is homogeneous in dtype and
+    array dimensionality across all directions (per-direction shapes may
+    differ), so Numba represents those tuple fields as ``UniTuple`` inside an
+    ``@njit`` function.
     This makes ``ExtractionStructView`` a drop-in replacement for the separate
     ``(ops_1d, idx_maps_1d, is_identity_mask_1d, …)`` bundle when calling the
     Layer-3 batch kernels in ``pantr.bspline._extraction_kernels`` from
@@ -1072,7 +1073,9 @@ class ExtractionStructView(NamedTuple):
     same-named members of :class:`SpanwiseElementExtraction`:
 
     - ``compact_ops_1d`` — per-direction compact 3D operator arrays of shape
-      ``(n_compact_k, n_out_k, n_in_k)``; only non-identity rows.
+      ``(n_compact_k, n_out_k, n_in_k)``; only non-identity rows are stored.
+      Always has at least one row (sentinel zeros) to ensure safe Numba
+      indexing.
     - ``idx_maps_1d`` — per-direction compact index maps of shape
       ``(n_elements_k,)``.
     - ``is_identity_mask_1d`` — per-direction identity masks of shape
@@ -1112,7 +1115,10 @@ def make_struct_view(extraction: SpanwiseElementExtraction) -> ExtractionStructV
         in ``pantr.bspline._extraction_kernels``.
 
     Example:
+        >>> from pantr.bspline import BsplineSpace1D, BsplineSpace
         >>> from pantr.bspline import SpanwiseElementExtraction, make_struct_view
+        >>> sp = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+        >>> space = BsplineSpace([sp, sp])
         >>> ext = SpanwiseElementExtraction(space, "bezier")
         >>> view = make_struct_view(ext)
         >>> view.dim

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -34,12 +34,24 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._numba_compat import nb_jit
 from pantr.basis import LagrangeVariant
-from pantr.bspline import BsplineSpace, BsplineSpace1D, SpanwiseElementExtraction
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    ExtractionStructView,
+    SpanwiseElementExtraction,
+    make_struct_view,
+)
 from pantr.bspline._extraction_helpers import (
     _allocate_or_validate_scratch_many,
     _prepare_apply_many_call,
     _required_scratch_size,
+)
+from pantr.bspline._extraction_kernels import (
+    apply_kron_apply_many_1d,
+    apply_kron_apply_many_2d,
+    apply_kron_apply_many_3d,
 )
 from pantr.bspline.spanwise_element_extraction import (
     _bezier_structural_identity_mask,
@@ -1210,3 +1222,220 @@ def test_idx_maps_1d_validation_in_prepare_many_call() -> None:
             None,
             "apply",
         )
+
+
+# ---------------------------------------------------------------- struct view
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+def test_struct_view_is_named_tuple_instance(target: str) -> None:
+    """The factory returns an ExtractionStructView (a NamedTuple subclass)."""
+    ext = SpanwiseElementExtraction(_space_2d(), target)  # type: ignore[arg-type]
+    view = make_struct_view(ext)
+    assert isinstance(view, ExtractionStructView)
+    assert isinstance(view, tuple)
+    # NamedTuple has _fields
+    assert set(view._fields) == {
+        "compact_ops_1d",
+        "idx_maps_1d",
+        "is_identity_mask_1d",
+        "num_intervals",
+        "input_shape_per_dir",
+        "output_shape_per_dir",
+        "dim",
+    }
+
+
+def _assert_struct_view_mirrors(view: ExtractionStructView, ext: SpanwiseElementExtraction) -> None:
+    """Check scalar and tuple metadata on ``view`` match the source extraction."""
+    assert view.dim == ext.dim
+    assert view.num_intervals == ext.num_intervals
+    assert view.input_shape_per_dir == ext.input_shape_per_dir
+    assert view.output_shape_per_dir == ext.output_shape_per_dir
+    assert len(view.compact_ops_1d) == ext.dim
+    assert len(view.idx_maps_1d) == ext.dim
+    assert len(view.is_identity_mask_1d) == ext.dim
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize("space_factory", [_space_1d, _space_2d, _space_3d])
+def test_struct_view_fields_match_extraction(space_factory: Any, target: str) -> None:
+    """The view's fields mirror the extraction's compact storage and shape metadata."""
+    ext = SpanwiseElementExtraction(space_factory(), target)  # type: ignore[arg-type]
+    view = make_struct_view(ext)
+    _assert_struct_view_mirrors(view, ext)
+    # Arrays are shared, not copied.
+    for k in range(ext.dim):
+        assert view.compact_ops_1d[k] is ext.compact_ops_1d[k]
+        assert view.idx_maps_1d[k] is ext.idx_maps_1d[k]
+        assert view.is_identity_mask_1d[k] is ext.is_identity_mask_1d[k]
+        # Shape invariants inherited from the extraction
+        assert view.compact_ops_1d[k].ndim == 3  # noqa: PLR2004
+        assert view.compact_ops_1d[k].dtype == ext.dtype
+        assert view.idx_maps_1d[k].shape == (ext.num_intervals[k],)
+        assert view.is_identity_mask_1d[k].shape == (ext.num_intervals[k],)
+
+
+def test_struct_view_ints_are_python_ints() -> None:
+    """Scalar fields are plain ``int`` (not ``np.int*``), for clean Numba unboxing."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    view = make_struct_view(ext)
+    assert type(view.dim) is int
+    for n in view.num_intervals:
+        assert type(n) is int
+    for n in view.input_shape_per_dir:
+        assert type(n) is int
+    for n in view.output_shape_per_dir:
+        assert type(n) is int
+
+
+def test_struct_view_unpacks_by_position_and_name() -> None:
+    """NamedTuple ordering is stable: positional and keyword access agree."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    view = make_struct_view(ext)
+    compact, idx_maps, masks, num_int, in_shape, out_shape, dim = view
+    assert compact is view.compact_ops_1d
+    assert idx_maps is view.idx_maps_1d
+    assert masks is view.is_identity_mask_1d
+    assert num_int is view.num_intervals
+    assert in_shape is view.input_shape_per_dir
+    assert out_shape is view.output_shape_per_dir
+    assert dim is view.dim
+
+
+# A small set of @njit functions that unbox an ExtractionStructView and drive
+# the Layer-3 batch kernels purely through the view's fields.  These exist
+# solely to prove that the struct view is passable into Numba code in the
+# same way that the (ops_1d, idx_maps_1d, is_identity_mask_1d, ...) tuple
+# bundle is.
+
+
+@nb_jit(nopython=True, cache=True)
+def _njit_apply_many_1d_via_view(  # pragma: no cover -- executed through Numba.
+    view: ExtractionStructView,
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    apply_kron_apply_many_1d(
+        view.compact_ops_1d[0],
+        view.idx_maps_1d[0],
+        view.is_identity_mask_1d[0],
+        cell_indices,
+        v,
+        out,
+        scratch,
+    )
+
+
+@nb_jit(nopython=True, cache=True)
+def _njit_apply_many_2d_via_view(  # pragma: no cover -- executed through Numba.
+    view: ExtractionStructView,
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    apply_kron_apply_many_2d(
+        view.compact_ops_1d[0],
+        view.compact_ops_1d[1],
+        view.idx_maps_1d[0],
+        view.idx_maps_1d[1],
+        view.is_identity_mask_1d[0],
+        view.is_identity_mask_1d[1],
+        cell_indices,
+        v,
+        out,
+        scratch,
+    )
+
+
+@nb_jit(nopython=True, cache=True)
+def _njit_apply_many_3d_via_view(  # pragma: no cover -- executed through Numba.
+    view: ExtractionStructView,
+    cell_indices: npt.NDArray[Any],
+    v: npt.NDArray[Any],
+    out: npt.NDArray[Any],
+    scratch: npt.NDArray[Any],
+) -> None:
+    apply_kron_apply_many_3d(
+        view.compact_ops_1d[0],
+        view.compact_ops_1d[1],
+        view.compact_ops_1d[2],
+        view.idx_maps_1d[0],
+        view.idx_maps_1d[1],
+        view.idx_maps_1d[2],
+        view.is_identity_mask_1d[0],
+        view.is_identity_mask_1d[1],
+        view.is_identity_mask_1d[2],
+        cell_indices,
+        v,
+        out,
+        scratch,
+    )
+
+
+@nb_jit(nopython=True, cache=True)
+def _njit_read_scalar_fields(  # pragma: no cover -- executed through Numba.
+    view: ExtractionStructView,
+) -> int:
+    # Exercises Numba's unboxing of the scalar/UniTuple-of-int fields.
+    total = view.dim
+    for n in view.num_intervals:
+        total += n
+    for n in view.input_shape_per_dir:
+        total += n
+    for n in view.output_shape_per_dir:
+        total += n
+    return total
+
+
+_VIEW_NJIT_KERNELS = {
+    1: _njit_apply_many_1d_via_view,
+    2: _njit_apply_many_2d_via_view,
+    3: _njit_apply_many_3d_via_view,
+}
+
+
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize(
+    ("space_factory", "dim"),
+    [(_space_1d, 1), (_space_2d, 2), (_space_3d, 3)],
+)
+def test_struct_view_is_numba_callable(space_factory: Any, dim: int, target: str) -> None:
+    """An ``@njit`` function unboxes the view and drives the Layer-3 batch kernel."""
+    ext = SpanwiseElementExtraction(space_factory(), target)  # type: ignore[arg-type]
+    view = make_struct_view(ext)
+
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    cell_indices = normalize_cell_indices(
+        np.arange(ext.num_total_intervals, dtype=np.intp), ext.num_intervals
+    )
+    n_cells = cell_indices.shape[0]
+    v = RNG.standard_normal((n_cells, n_in)).astype(ext.dtype)
+    out = np.empty((n_cells, n_out), dtype=ext.dtype)
+    scratch_size = _required_scratch_size(
+        ext.input_shape_per_dir, ext.output_shape_per_dir, "apply"
+    )
+    scratch = np.empty((n_cells, max(scratch_size, 1)), dtype=ext.dtype)
+
+    kernel = _VIEW_NJIT_KERNELS[dim]
+    kernel(view, cell_indices, v, out, scratch)
+
+    expected = ext.apply_many(v, cell_indices)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_struct_view_scalar_fields_are_numba_unboxable() -> None:
+    """``dim`` and the per-direction int tuples unbox cleanly inside an ``@njit`` function."""
+    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    view = make_struct_view(ext)
+    expected = (
+        view.dim
+        + sum(view.num_intervals)
+        + sum(view.input_shape_per_dir)
+        + sum(view.output_shape_per_dir)
+    )
+    assert _njit_read_scalar_fields(view) == expected

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -1269,6 +1269,10 @@ def test_struct_view_fields_match_extraction(space_factory: Any, target: str) ->
         assert view.compact_ops_1d[k] is ext.compact_ops_1d[k]
         assert view.idx_maps_1d[k] is ext.idx_maps_1d[k]
         assert view.is_identity_mask_1d[k] is ext.is_identity_mask_1d[k]
+        # Shared arrays must remain read-only (the factory's safety guarantee).
+        assert not view.compact_ops_1d[k].flags.writeable
+        assert not view.idx_maps_1d[k].flags.writeable
+        assert not view.is_identity_mask_1d[k].flags.writeable
         # Shape invariants inherited from the extraction
         assert view.compact_ops_1d[k].ndim == 3  # noqa: PLR2004
         assert view.compact_ops_1d[k].dtype == ext.dtype
@@ -1276,9 +1280,11 @@ def test_struct_view_fields_match_extraction(space_factory: Any, target: str) ->
         assert view.is_identity_mask_1d[k].shape == (ext.num_intervals[k],)
 
 
-def test_struct_view_ints_are_python_ints() -> None:
+@pytest.mark.parametrize("target", ["bezier", "lagrange", "cardinal"])
+@pytest.mark.parametrize("space_factory", [_space_1d, _space_2d, _space_3d])
+def test_struct_view_ints_are_python_ints(space_factory: Any, target: str) -> None:
     """Scalar fields are plain ``int`` (not ``np.int*``), for clean Numba unboxing."""
-    ext = SpanwiseElementExtraction(_space_2d(), "bezier")
+    ext = SpanwiseElementExtraction(space_factory(), target)  # type: ignore[arg-type]
     view = make_struct_view(ext)
     assert type(view.dim) is int
     for n in view.num_intervals:
@@ -1300,7 +1306,7 @@ def test_struct_view_unpacks_by_position_and_name() -> None:
     assert num_int is view.num_intervals
     assert in_shape is view.input_shape_per_dir
     assert out_shape is view.output_shape_per_dir
-    assert dim is view.dim
+    assert dim == view.dim
 
 
 # A small set of @njit functions that unbox an ExtractionStructView and drive
@@ -1439,3 +1445,29 @@ def test_struct_view_scalar_fields_are_numba_unboxable() -> None:
         + sum(view.output_shape_per_dir)
     )
     assert _njit_read_scalar_fields(view) == expected
+
+
+def test_struct_view_float32_is_numba_callable() -> None:
+    """``@njit`` unboxing works for float32 operator arrays (distinct Numba specialisation)."""
+    knots = np.array([0, 0, 0, 1, 2, 3, 3, 3], dtype=np.float32)
+    sp1 = BsplineSpace1D(knots, 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp1]), "bezier")
+    assert ext.dtype == np.float32
+    view = make_struct_view(ext)
+
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    cell_indices = normalize_cell_indices(
+        np.arange(ext.num_total_intervals, dtype=np.intp), ext.num_intervals
+    )
+    n_cells = cell_indices.shape[0]
+    v = RNG.standard_normal((n_cells, n_in)).astype(np.float32)
+    out = np.empty((n_cells, n_out), dtype=np.float32)
+    scratch_size = _required_scratch_size(
+        ext.input_shape_per_dir, ext.output_shape_per_dir, "apply"
+    )
+    scratch = np.empty((n_cells, max(scratch_size, 1)), dtype=np.float32)
+
+    _njit_apply_many_2d_via_view(view, cell_indices, v, out, scratch)
+    expected = ext.apply_many(v, cell_indices)
+    np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary

Closes PR 8 of the SpanwiseElementExtraction v0 plan (#141).

- Adds `ExtractionStructView`, a `typing.NamedTuple` that bundles a
  `SpanwiseElementExtraction`'s compact per-direction operators, index maps,
  identity masks, and shape metadata into a single Numba-unboxable object.
- Adds `make_struct_view(extraction)` — a factory that shares (not copies)
  the underlying arrays.
- Exposes both from `pantr.bspline`.
- User-guide section under `docs/spanwise-element-extraction.md` with a
  runnable snippet showing an `@njit` kernel that unboxes the view and
  dispatches to the Layer-3 batch kernels.
- 24 new tests: field correctness, array identity, Numba unboxing and
  round-trip match against `SpanwiseElementExtraction.apply_many` for
  `d ∈ {1, 2, 3}` × all three targets, plus a scalar-field sanity check
  that exercises unboxing of the `UniTuple[int64, ...]` metadata fields.

The MPI design (#142) can now consume the extraction as a single argument.

## Test plan

- [x] `pytest --no-cov` — 2519 passed
- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `NUMBA_DISABLE_JIT=1 sphinx-build -M html docs/ docs/_build -W --keep-going -j auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)