### PR TITLE
perf(ci): speed up test suite and CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-
 
+      - name: Cache Numba compiled objects
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/pantr/basis/__pycache__
+            src/pantr/bezier/__pycache__
+            src/pantr/bspline/__pycache__
+          key: ${{ runner.os }}-numba-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('src/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-numba-${{ steps.setup-python.outputs.python-version }}-
+
       - name: Create venv and install dev deps (on cache miss)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -150,6 +161,11 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      - name: Run tests with JIT (populates Numba cache)
+        run: |
+          . .venv/bin/activate
+          make test
 
       - name: Run pytest with coverage
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 
 # Run the test suite with Numba JIT enabled
 test:
-	pytest
+	pytest -n auto
 
 # Generate an XML coverage report with Numba JIT disabled
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ help:
 
 # Run the test suite with Numba JIT enabled
 test:
-	pytest --no-cov
+	pytest
 
 # Generate an XML coverage report with Numba JIT disabled
 coverage:
-	COVERAGE_FILE=/tmp/.coverage NUMBA_DISABLE_JIT=1 pytest -m "not slow" --cov=src/pantr --cov-report=xml
+	COVERAGE_FILE=/tmp/.coverage NUMBA_DISABLE_JIT=1 pytest -m "not slow" --cov=src/pantr --cov-report=term-missing --cov-report=xml
 
 # Remove build artifacts
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 dev = [
   "pytest>=7.4,<9",
   "pytest-cov>=4,<6",
+  "pytest-xdist>=3,<4",
   "mypy>=1.10,<2",
   "ruff>=0.12.0,<0.13",
   "pre-commit>=3.6,<4",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 minversion = 7.4
-addopts = --strict-config --strict-markers --cov=pantr --cov-report=term-missing --cov-report=xml
+addopts = --strict-config --strict-markers
 testpaths = tests
 python_files = test_*.py
 markers =

--- a/tests/test_root_finding_stress.py
+++ b/tests/test_root_finding_stress.py
@@ -196,6 +196,7 @@ def _assert_algorithms_agree(
 # =====================================================================
 
 
+@pytest.mark.slow
 class TestAlgorithmAgreement:
     """Cross-validate Yuksel vs Bezier clipping on random polynomials."""
 
@@ -283,6 +284,7 @@ class TestAlgorithmAgreement:
             _assert_algorithms_agree(coeff, f"rational/s{seed}/i{i}")
 
 
+@pytest.mark.slow
 class TestBatchConsistency:
     """Verify batch API matches single-polynomial results."""
 


### PR DESCRIPTION
## Summary

Four targeted changes to reduce CI time and improve the local dev experience:

- **Remove `--cov` from `pytest.ini` addopts** — coverage was being instrumented on every `pytest` invocation, requiring `--no-cov` in all dev commands. Coverage flags now live exclusively in `make coverage`. Also fixes a double-instrumentation bug where `make coverage` was passing `--cov` twice (once from ini, once from the Makefile target).

- **Mark stress tests as `@pytest.mark.slow`** — `TestAlgorithmAgreement` and `TestBatchConsistency` in `test_root_finding_stress.py` are randomised cross-validation suites that take ~4 s locally (vs <0.1 s for a typical test). The `make coverage` command already had `-m "not slow"` filtering but nothing was tagged. Now those 55 tests are skipped by the coverage run, shaving ~20 % off its wall-clock time (~20 s on GH Actions). They still run under `make test`.

- **Add `pytest-xdist` for parallel test execution** — `make test` now runs with `-n auto`, cutting the JIT-enabled suite from ~73 s to ~29 s locally (2.5×). Not applied to `make coverage` — the JIT-disabled suite is already fast (~17 s) and xdist process-startup overhead exceeds the gain for sub-100 ms tests.

- **Cache Numba compiled objects in GH Actions** — adds a cache step for the `__pycache__` dirs of Numba kernel modules, keyed on Python version + source hash. A new "Run tests with JIT" step before `make coverage` populates the cache on first run; subsequent runs skip the ~2–4 min compilation cost entirely.

## Test plan

- [x] All 2528 tests pass (`pytest --no-cov`)
- [x] 55 stress tests correctly deselected under `-m "not slow"` (2473 pass)
- [x] Parallel JIT run passes (`pytest -n auto --no-cov`)
- [x] Coverage run with JIT disabled passes and reports 94% coverage
- [x] Ruff lint and format: clean
- [x] mypy strict: clean (139 files)
- [x] Sphinx docs build: clean

Generated with [Claude Code](https://claude.com/claude-code)