### PR TITLE
feat(transform): harden AffineTransform validation (scaling/rotation/mirror)

### DIFF
--- a/src/pantr/transform.py
+++ b/src/pantr/transform.py
@@ -289,7 +289,7 @@ class AffineTransform:
             u = np.asarray(axis, dtype=np.float64).ravel()
             if u.shape != (3,):
                 raise ValueError(f"Rotation axis must have shape (3,), got {u.shape}.")
-            norm = float(np.linalg.norm(u))
+            norm = np.linalg.norm(u)
             if norm == 0.0 or not np.isfinite(norm):
                 raise ValueError(f"Rotation axis must be a finite non-zero vector, got {u!r}.")
             u = u / norm
@@ -336,7 +336,7 @@ class AffineTransform:
             ValueError: If *normal* is zero or non-finite.
         """
         n = np.asarray(normal, dtype=np.float64).ravel()
-        norm = float(np.linalg.norm(n))
+        norm = np.linalg.norm(n)
         if norm == 0.0 or not np.isfinite(norm):
             raise ValueError(f"Mirror normal must be a finite non-zero vector, got {n!r}.")
         n = n / norm

--- a/src/pantr/transform.py
+++ b/src/pantr/transform.py
@@ -12,6 +12,8 @@ Main exports:
 
 from __future__ import annotations
 
+import functools
+
 import numpy as np
 from numpy import typing as npt
 
@@ -53,7 +55,7 @@ class AffineTransform:
             ValueError: If *translation* length does not match the matrix
                 dimension.
         """
-        mat = np.asarray(matrix, dtype=np.float64)
+        mat = np.ascontiguousarray(np.asarray(matrix, dtype=np.float64))
         if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:  # noqa: PLR2004
             raise ValueError(f"matrix must be a square 2-D array, got shape {mat.shape}.")
 
@@ -63,7 +65,7 @@ class AffineTransform:
         if translation is None:
             tvec = np.zeros(n, dtype=np.float64)
         else:
-            tvec = np.asarray(translation, dtype=np.float64)
+            tvec = np.ascontiguousarray(np.asarray(translation, dtype=np.float64))
             if tvec.shape != (n,):
                 raise ValueError(f"translation must have shape ({n},), got {tvec.shape}.")
 
@@ -103,9 +105,12 @@ class AffineTransform:
         """
         return self._translation
 
-    @property
+    @functools.cached_property
     def inverse(self) -> AffineTransform:
         """Get the inverse transformation.
+
+        Computed once and cached; subsequent accesses are free. Safe because
+        an :class:`AffineTransform` is immutable.
 
         Returns:
             AffineTransform: The inverse such that ``T @ T.inverse`` is the
@@ -171,7 +176,8 @@ class AffineTransform:
 
         Raises:
             ValueError: If *factors* is a scalar and *center* is ``None``
-                (dimension cannot be inferred).
+                (dimension cannot be inferred), if any factor is non-finite or
+                zero (singular transform), or if *center* has the wrong shape.
         """
         f = np.asarray(factors, dtype=np.float64)
         if f.ndim == 0:
@@ -182,10 +188,27 @@ class AffineTransform:
                     "array of per-axis factors so the dimension can be "
                     "inferred."
                 )
+            fval = float(f)
+            if not np.isfinite(fval):
+                raise ValueError(f"scaling factors must be finite, got {fval!r}.")
+            if fval == 0.0:
+                raise ValueError(
+                    f"scaling factors must be non-zero (singular transform), got {fval!r}."
+                )
             c = np.asarray(center, dtype=np.float64).ravel()
-            f = np.full(len(c), float(f))
+            f = np.full(len(c), fval)
         else:
             f = f.ravel()
+            if not np.all(np.isfinite(f)):
+                raise ValueError(f"scaling factors must be finite, got {f!r}.")
+            if np.any(f == 0.0):
+                raise ValueError(
+                    f"scaling factors must be non-zero (singular transform), got {f!r}."
+                )
+            if center is not None:
+                c = np.asarray(center, dtype=np.float64).ravel()
+                if c.shape != (len(f),):
+                    raise ValueError(f"center must have shape ({len(f)},), got {c.shape}.")
 
         mat = np.diag(f)
         t = AffineTransform(mat)
@@ -247,9 +270,11 @@ class AffineTransform:
             u[axis_int] = 1.0
         else:
             u = np.asarray(axis, dtype=np.float64).ravel()
-            norm = np.linalg.norm(u)
-            if norm == 0.0:
-                raise ValueError("Rotation axis must be non-zero.")
+            if u.shape != (3,):
+                raise ValueError(f"Rotation axis must have shape (3,), got {u.shape}.")
+            norm = float(np.linalg.norm(u))
+            if norm == 0.0 or not np.isfinite(norm):
+                raise ValueError(f"Rotation axis must be a finite non-zero vector, got {u!r}.")
             u = u / norm
 
         # Rodrigues rotation matrix: R = I cos(t) + (1-cos(t)) u u^T + sin(t) [u]x
@@ -291,9 +316,9 @@ class AffineTransform:
             ValueError: If *normal* has zero norm.
         """
         n = np.asarray(normal, dtype=np.float64).ravel()
-        norm = np.linalg.norm(n)
-        if norm == 0.0:
-            raise ValueError("Mirror normal must be non-zero.")
+        norm = float(np.linalg.norm(n))
+        if norm == 0.0 or not np.isfinite(norm):
+            raise ValueError(f"Mirror normal must be a finite non-zero vector, got {n!r}.")
         n = n / norm
         mat = np.eye(len(n)) - 2.0 * np.outer(n, n)
         t = AffineTransform(mat)
@@ -438,8 +463,15 @@ def _apply_center(
 
     Returns:
         AffineTransform: The re-centred transformation.
+
+    Raises:
+        ValueError: If ``center`` does not have shape ``(transform.dim,)``.
     """
     c = np.asarray(center, dtype=np.float64).ravel()
+    if c.shape != (transform.dim,):
+        raise ValueError(
+            f"center must have shape ({transform.dim},), got {np.asarray(center).shape}."
+        )
     t_neg = AffineTransform.translation(-c)
     t_pos = AffineTransform.translation(c)
     return t_pos @ transform @ t_neg

--- a/src/pantr/transform.py
+++ b/src/pantr/transform.py
@@ -7,7 +7,7 @@ and composition operators.
 
 Main exports:
 
-- :class:`AffineTransform` — immutable affine-transformation object.
+- :class:`AffineTransform` — logically immutable affine-transformation object.
 """
 
 from __future__ import annotations
@@ -22,8 +22,9 @@ class AffineTransform:
     """An affine transformation T(x) = A x + b in n-dimensional space.
 
     The transformation is defined by a square matrix ``A`` (the linear part)
-    and a translation vector ``b``.  Instances are immutable: every mutation
-    returns a new :class:`AffineTransform`.
+    and a translation vector ``b``.  Instances are treated as immutable: every
+    factory method and operator returns a new :class:`AffineTransform`; no
+    method mutates an existing instance.
 
     Attributes:
         _matrix (npt.NDArray[np.float64]): The ``(n, n)`` linear part.
@@ -54,6 +55,10 @@ class AffineTransform:
             ValueError: If *matrix* is not 2-D or not square.
             ValueError: If *translation* length does not match the matrix
                 dimension.
+
+        Note:
+            Both *matrix* and *translation* are stored as C-contiguous,
+            read-only ``float64`` arrays.
         """
         mat = np.ascontiguousarray(np.asarray(matrix, dtype=np.float64))
         if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:  # noqa: PLR2004
@@ -110,7 +115,8 @@ class AffineTransform:
         """Get the inverse transformation.
 
         Computed once and cached; subsequent accesses are free. Safe because
-        an :class:`AffineTransform` is immutable.
+        neither the matrix nor the translation is ever modified after
+        construction.
 
         Returns:
             AffineTransform: The inverse such that ``T @ T.inverse`` is the
@@ -176,8 +182,13 @@ class AffineTransform:
 
         Raises:
             ValueError: If *factors* is a scalar and *center* is ``None``
-                (dimension cannot be inferred), if any factor is non-finite or
-                zero (singular transform), or if *center* has the wrong shape.
+                (dimension cannot be inferred).
+            ValueError: If *factors* is a scalar and *center* is not a 1-D
+                array-like.
+            ValueError: If any factor is non-finite or zero (singular
+                transform).
+            ValueError: If *factors* is an array and *center* has the wrong
+                shape.
         """
         f = np.asarray(factors, dtype=np.float64)
         if f.ndim == 0:
@@ -195,7 +206,9 @@ class AffineTransform:
                 raise ValueError(
                     f"scaling factors must be non-zero (singular transform), got {fval!r}."
                 )
-            c = np.asarray(center, dtype=np.float64).ravel()
+            c = np.asarray(center, dtype=np.float64)
+            if c.ndim != 1:
+                raise ValueError(f"center must be a 1-D array, got shape {c.shape}.")
             f = np.full(len(c), fval)
         else:
             f = f.ravel()
@@ -205,10 +218,6 @@ class AffineTransform:
                 raise ValueError(
                     f"scaling factors must be non-zero (singular transform), got {f!r}."
                 )
-            if center is not None:
-                c = np.asarray(center, dtype=np.float64).ravel()
-                if c.shape != (len(f),):
-                    raise ValueError(f"center must have shape ({len(f)},), got {c.shape}.")
 
         mat = np.diag(f)
         t = AffineTransform(mat)
@@ -230,8 +239,14 @@ class AffineTransform:
 
         Returns:
             AffineTransform: The 2-D rotation.
+
+        Raises:
+            ValueError: If *angle* is non-finite.
         """
-        c, s = np.cos(angle), np.sin(angle)
+        angle_f = float(angle)
+        if not np.isfinite(angle_f):
+            raise ValueError(f"angle must be finite, got {angle_f!r}.")
+        c, s = np.cos(angle_f), np.sin(angle_f)
         mat = np.array([[c, -s], [s, c]], dtype=np.float64)
         t = AffineTransform(mat)
         if center is not None:
@@ -259,8 +274,10 @@ class AffineTransform:
             AffineTransform: The 3-D rotation.
 
         Raises:
+            ValueError: If *angle* is non-finite.
             ValueError: If an integer axis is not in ``{0, 1, 2}``.
-            ValueError: If a vector axis has zero norm.
+            ValueError: If a vector axis does not have shape ``(3,)``.
+            ValueError: If a vector axis is zero or non-finite.
         """
         if isinstance(axis, int | np.integer):
             axis_int = int(axis)
@@ -277,8 +294,11 @@ class AffineTransform:
                 raise ValueError(f"Rotation axis must be a finite non-zero vector, got {u!r}.")
             u = u / norm
 
+        angle_f = float(angle)
+        if not np.isfinite(angle_f):
+            raise ValueError(f"angle must be finite, got {angle_f!r}.")
         # Rodrigues rotation matrix: R = I cos(t) + (1-cos(t)) u u^T + sin(t) [u]x
-        c, s = np.cos(angle), np.sin(angle)
+        c, s = np.cos(angle_f), np.sin(angle_f)
         ux, uy, uz = u
         K = np.array(
             [[0.0, -uz, uy], [uz, 0.0, -ux], [-uy, ux, 0.0]],
@@ -313,7 +333,7 @@ class AffineTransform:
             AffineTransform: The reflection.
 
         Raises:
-            ValueError: If *normal* has zero norm.
+            ValueError: If *normal* is zero or non-finite.
         """
         n = np.asarray(normal, dtype=np.float64).ravel()
         norm = float(np.linalg.norm(n))
@@ -350,6 +370,7 @@ class AffineTransform:
         Raises:
             ValueError: If *component* equals *direction*.
             ValueError: If *component* or *direction* is out of range.
+            ValueError: If *factor* is non-finite.
         """
         if component == direction:
             raise ValueError("component and direction must differ.")
@@ -357,8 +378,11 @@ class AffineTransform:
             raise ValueError(f"component must be in [0, {dim}), got {component}.")
         if not (0 <= direction < dim):
             raise ValueError(f"direction must be in [0, {dim}), got {direction}.")
+        factor_f = float(factor)
+        if not np.isfinite(factor_f):
+            raise ValueError(f"factor must be finite, got {factor_f!r}.")
         mat = np.eye(dim, dtype=np.float64)
-        mat[component, direction] = float(factor)
+        mat[component, direction] = factor_f
         return AffineTransform(mat)
 
     # ------------------------------------------------------------------
@@ -465,7 +489,7 @@ def _apply_center(
         AffineTransform: The re-centred transformation.
 
     Raises:
-        ValueError: If ``center`` does not have shape ``(transform.dim,)``.
+        ValueError: If *center* does not have shape ``(transform.dim,)``.
     """
     c = np.asarray(center, dtype=np.float64).ravel()
     if c.shape != (transform.dim,):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -157,6 +157,26 @@ class TestAffineTransformScaling:
         npt.assert_allclose(t(np.array([1.0, 0.0])), [1.0, 0.0])
         npt.assert_allclose(t(np.array([2.0, 1.0])), [3.0, 3.0])
 
+    def test_zero_factor_scalar_raises(self) -> None:
+        """A zero isotropic factor is a singular transform and raises."""
+        with pytest.raises(ValueError, match="non-zero"):
+            AffineTransform.scaling(0.0, center=[1.0, 1.0])
+
+    def test_zero_factor_array_raises(self) -> None:
+        """A zero per-axis factor raises."""
+        with pytest.raises(ValueError, match="non-zero"):
+            AffineTransform.scaling([2.0, 0.0])
+
+    def test_non_finite_factor_raises(self) -> None:
+        """A non-finite factor raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.scaling([np.inf, 1.0])
+
+    def test_center_wrong_shape_raises(self) -> None:
+        """A center whose shape mismatches the factors raises."""
+        with pytest.raises(ValueError, match="center must have shape"):
+            AffineTransform.scaling([2.0, 3.0], center=[1.0, 0.0, 0.0])
+
 
 class TestAffineTransformRotation2D:
     """Tests for AffineTransform.rotation_2d."""
@@ -223,6 +243,16 @@ class TestAffineTransformRotation3D:
         # (2,0,0) rotated 90 about z through (1,0,0) -> (1,1,0)
         npt.assert_allclose(t(np.array([2.0, 0.0, 0.0])), [1.0, 1.0, 0.0], atol=1e-15)
 
+    def test_axis_wrong_shape_raises(self) -> None:
+        """A vector axis that is not length-3 raises."""
+        with pytest.raises(ValueError, match=r"shape \(3,\)"):
+            AffineTransform.rotation_3d(0.5, axis=[1.0, 0.0])
+
+    def test_non_finite_axis_raises(self) -> None:
+        """A non-finite axis raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.rotation_3d(0.5, axis=[np.inf, 0.0, 0.0])
+
 
 class TestAffineTransformMirror:
     """Tests for AffineTransform.mirror."""
@@ -255,6 +285,11 @@ class TestAffineTransformMirror:
         """Zero-length normal raises."""
         with pytest.raises(ValueError, match="non-zero"):
             AffineTransform.mirror([0.0, 0.0])
+
+    def test_non_finite_normal_raises(self) -> None:
+        """A non-finite normal raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.mirror([np.inf, 0.0])
 
 
 class TestAffineTransformShear:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -177,6 +177,26 @@ class TestAffineTransformScaling:
         with pytest.raises(ValueError, match="center must have shape"):
             AffineTransform.scaling([2.0, 3.0], center=[1.0, 0.0, 0.0])
 
+    def test_non_finite_scalar_factor_raises(self) -> None:
+        """A non-finite isotropic factor raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.scaling(np.inf, center=[1.0, 1.0])
+
+    def test_nan_scalar_factor_raises(self) -> None:
+        """A NaN isotropic factor raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.scaling(np.nan, center=[1.0, 1.0])
+
+    def test_nan_factor_array_raises(self) -> None:
+        """A NaN per-axis factor raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.scaling([np.nan, 1.0])
+
+    def test_center_wrong_ndim_scalar_raises(self) -> None:
+        """A non-1-D center for isotropic scaling raises."""
+        with pytest.raises(ValueError, match="1-D"):
+            AffineTransform.scaling(2.0, center=[[1.0, 0.0], [0.0, 1.0]])
+
 
 class TestAffineTransformRotation2D:
     """Tests for AffineTransform.rotation_2d."""
@@ -197,6 +217,16 @@ class TestAffineTransformRotation2D:
         # Rotate (2,1) by 90 degrees about (1,1) -> (1,2)
         t = AffineTransform.rotation_2d(np.pi / 2, center=[1.0, 1.0])
         npt.assert_allclose(t(np.array([2.0, 1.0])), [1.0, 2.0], atol=1e-15)
+
+    def test_non_finite_angle_raises(self) -> None:
+        """A non-finite angle raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.rotation_2d(np.inf)
+
+    def test_center_wrong_shape_raises(self) -> None:
+        """A center whose shape mismatches the rotation dimension raises."""
+        with pytest.raises(ValueError, match="center must have shape"):
+            AffineTransform.rotation_2d(np.pi / 2, center=[1.0, 0.0, 0.0])
 
 
 class TestAffineTransformRotation3D:
@@ -253,6 +283,21 @@ class TestAffineTransformRotation3D:
         with pytest.raises(ValueError, match="finite"):
             AffineTransform.rotation_3d(0.5, axis=[np.inf, 0.0, 0.0])
 
+    def test_nan_axis_raises(self) -> None:
+        """A NaN component in the axis raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.rotation_3d(0.5, axis=[np.nan, 0.0, 0.0])
+
+    def test_non_finite_angle_raises(self) -> None:
+        """A non-finite angle raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.rotation_3d(np.nan, axis=2)
+
+    def test_center_wrong_shape_raises(self) -> None:
+        """A center whose shape mismatches the rotation dimension raises."""
+        with pytest.raises(ValueError, match="center must have shape"):
+            AffineTransform.rotation_3d(np.pi / 2, axis=2, center=[1.0, 0.0])
+
 
 class TestAffineTransformMirror:
     """Tests for AffineTransform.mirror."""
@@ -291,6 +336,16 @@ class TestAffineTransformMirror:
         with pytest.raises(ValueError, match="finite"):
             AffineTransform.mirror([np.inf, 0.0])
 
+    def test_nan_normal_raises(self) -> None:
+        """A NaN component in the normal raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.mirror([np.nan, 0.0])
+
+    def test_center_wrong_shape_raises(self) -> None:
+        """A center whose shape mismatches the mirror dimension raises."""
+        with pytest.raises(ValueError, match="center must have shape"):
+            AffineTransform.mirror([1.0, 0.0], center=[1.0, 0.0, 0.0])
+
 
 class TestAffineTransformShear:
     """Tests for AffineTransform.shear."""
@@ -309,6 +364,11 @@ class TestAffineTransformShear:
         """Out-of-range component raises."""
         with pytest.raises(ValueError, match="component"):
             AffineTransform.shear(dim=2, component=2, direction=0, factor=1.0)
+
+    def test_non_finite_factor_raises(self) -> None:
+        """A non-finite shear factor raises."""
+        with pytest.raises(ValueError, match="finite"):
+            AffineTransform.shear(dim=2, component=0, direction=1, factor=np.inf)
 
 
 # ======================================================================
@@ -373,6 +433,11 @@ class TestAffineTransformInverse:
         t = AffineTransform(np.zeros((2, 2)))
         with pytest.raises(ValueError, match="singular"):
             _ = t.inverse
+
+    def test_inverse_cached(self) -> None:
+        """Repeated accesses to inverse return the same object."""
+        t = AffineTransform(np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([5.0, 6.0]))
+        assert t.inverse is t.inverse
 
 
 # ======================================================================


### PR DESCRIPTION
## Summary

Hardens `pantr.transform.AffineTransform`'s input validation to match the stricter behaviour ocelat's local copy enforced, so ocelat — and the rest of the stack — can adopt pantr's `AffineTransform` and drop the duplicate. The new checks reject only previously-mishandled invalid inputs, so behaviour for valid inputs is unchanged.

## Details

- `scaling`: reject non-finite / zero factors (singular transform) and validate the `center` shape.
- `rotation_3d`: validate the vector-axis shape `(3,)` and finiteness.
- `mirror`: reject a non-finite normal.
- `_apply_center`: validate the `center` shape.
- `inverse` is now a `cached_property` (safe — the transform is immutable).
- The constructor stores `matrix` / `translation` as C-contiguous arrays.

## Validation

Full pantr suite **2582 passed**; ruff + mypy clean. New tests cover each rejection path (zero/non-finite scaling factors, bad `rotation_3d` axis, non-finite `mirror` normal, center-shape mismatch).

## Context

First step of unifying `AffineTransform` across the stack (pantr ← ocelat). The companion ocelat PR re-points its imports to `pantr.transform` and deletes its local `_affine.py`. Version bump deferred to the release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
