### PR TITLE
fix(version): sync __version__ to 0.4.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,13 @@
   parametric domains and grid-cell bounds; decoupled from any concrete affine
   transform via a structural `_AffineMap` protocol.
 
+### Changed
+- `pantr.transform.AffineTransform`: stricter input validation (reject
+  zero / non-finite scaling factors; validate rotation-axis and mirror-normal
+  finiteness and the `center` shape), a cached `inverse`, and C-contiguous
+  stored arrays (#154). Enables ocelat to adopt pantr's `AffineTransform` and
+  drop its local copy.
+
 ## 0.3.0 (2026-05-06)
 
 ### Added

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -32,7 +32,7 @@ from ._parallel import get_num_threads, num_threads, set_num_threads
 from .basis import _basis_utils  # noqa: F401
 
 # Package metadata
-__version__: Final[str] = "0.3.0"
+__version__: Final[str] = "0.4.0"
 __license__: Final[str] = "MIT"
 __author__: Final[str] = "Pablo Antolin <pablo.antolin@epfl.ch>"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -35,7 +35,7 @@ def test_package_all_exports() -> None:
 
 def test_package_metadata_values() -> None:
     """Validate the package metadata constants."""
-    assert pantr.__version__ == "0.3.0"
+    assert pantr.__version__ == "0.4.0"
     assert pantr.__license__ == "MIT"
     assert pantr.__author__ == "Pablo Antolin <pablo.antolin@epfl.ch>"
 
@@ -43,7 +43,7 @@ def test_package_metadata_values() -> None:
 def test_metadata_import_stability() -> None:
     """Verify metadata survives module reloads."""
     module = importlib.reload(pantr)
-    assert module.__version__ == "0.3.0"
+    assert module.__version__ == "0.4.0"
 
 
 def test_submodule_all_exports() -> None:


### PR DESCRIPTION
## Summary

The `0.4.0` release is half-applied: `pyproject.toml` is `0.4.0` and `v0.4.0` is tagged, but `src/pantr/__init__.py` still declared `__version__ = "0.3.0"` and `tests/test_metadata.py` still *asserted* `"0.3.0"` (so the metadata test was green on the stale value, and `pantr.__version__` reported the wrong number).

This:
- syncs `__version__` → `"0.4.0"`,
- updates the two `test_metadata.py` assertions → `"0.4.0"`,
- adds the missing `0.4.0` changelog entry for the `AffineTransform` hardening (#154). The AABB entry (#153) was already present.

## Validation

ruff + mypy clean; `test_metadata` passes; `pantr.__version__` now reports `0.4.0`.

## Note on the tag

The existing `v0.4.0` tag points at a commit where `__version__` is still `0.3.0`. After this merges, either **re-cut `v0.4.0`** so the tag carries the correct in-code version, or let the fix ride into the next release — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
