### PR TITLE
fix(grid): post-review fixes for pantr.grid foundation

### DIFF
--- a/benchmarks/bench_grid_footprint.py
+++ b/benchmarks/bench_grid_footprint.py
@@ -1,0 +1,80 @@
+"""Benchmark: TensorProductGrid memory footprint vs. cell count.
+
+Usage::
+
+    conda run -n pantr python benchmarks/bench_grid_footprint.py
+
+Demonstrates that a :class:`pantr.grid.TensorProductGrid` stores only its
+per-axis breakpoint arrays (plus a little metadata) -- a payload proportional to
+``sum_k (cells_per_axis[k] + 1)`` -- and never materializes per-cell data until
+a spatial query lazily builds the BVH. The reported "grid payload" stays tiny as
+the cell count grows by orders of magnitude; for contrast, the table also shows
+the size of a densely materialized ``(num_cells, ndim)`` bounds array and the
+lazily-built BVH.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pantr.geometry import AABB
+from pantr.grid import TensorProductGrid, uniform_grid
+
+_CASES = [
+    (2, 10),
+    (2, 100),
+    (2, 1000),
+    (3, 10),
+    (3, 50),
+    (3, 100),
+]
+
+
+def _grid_payload_bytes(g: TensorProductGrid) -> int:
+    """Sum the bytes retained by the grid's stored arrays."""
+    total = sum(bp.nbytes for bp in g.breakpoints)
+    total += g.bounds.nbytes
+    total += g._strides.nbytes
+    return total
+
+
+def _bvh_bytes(g: TensorProductGrid) -> int:
+    """Sum the bytes of the (lazily built) BVH node arrays."""
+    bvh = g.cell_bvh()
+    return int(
+        bvh.node_lo.nbytes
+        + bvh.node_hi.nbytes
+        + bvh.node_left.nbytes
+        + bvh.node_right.nbytes
+        + bvh.node_cell.nbytes
+    )
+
+
+def main() -> None:
+    """Run the footprint benchmark and print a table."""
+    print(
+        f"{'ndim':>4}  {'cells/axis':>10}  {'num_cells':>11}  "
+        f"{'grid B':>9}  {'dense B':>12}  {'bvh B':>12}  {'grid/dense':>10}"
+    )
+    print("-" * 80)
+    for ndim, n in _CASES:
+        g = uniform_grid([[0.0, 1.0]] * ndim, n)
+        num_cells = g.num_cells
+        grid_b = _grid_payload_bytes(g)
+        dense_b = num_cells * ndim * 8  # float64 (num_cells, ndim) bounds (one corner)
+        assert g._bvh is None
+        # Touch a query to force the lazy BVH, then measure it.
+        g.query_aabb(AABB(np.zeros(ndim), np.full(ndim, 0.1)))
+        bvh_b = _bvh_bytes(g)
+        ratio = grid_b / dense_b if dense_b else float("nan")
+        print(
+            f"{ndim:>4}  {n:>10}  {num_cells:>11}  {grid_b:>9}  "
+            f"{dense_b:>12}  {bvh_b:>12}  {ratio:>10.2e}"
+        )
+    print()
+    print("grid payload grows with sum(cells_per_axis), NOT num_cells;")
+    print("the O(num_cells) BVH is built only on the first query_aabb.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_grid_locate.py
+++ b/benchmarks/bench_grid_locate.py
@@ -1,0 +1,68 @@
+"""Benchmark: TensorProductGrid.locate_many vs. a Python loop over locate.
+
+Usage::
+
+    conda run -n pantr python benchmarks/bench_grid_locate.py
+
+Builds a 3D uniform grid and times the Numba batch ``locate_many`` kernel against
+a Python loop calling ``locate`` per point, for a range of batch sizes. Prints a
+table of loop_ms vs. batch_ms with speedup.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from pantr.grid import uniform_grid
+
+_N_REPEATS = 5
+_BATCH_SIZES = [1, 100, 1000, 10_000, 100_000]
+
+
+def _time_loop(grid, pts: np.ndarray) -> float:  # noqa: ANN001
+    """Time a Python loop over per-point locate; return minimum wall time (ms)."""
+    n = pts.shape[0]
+    best = float("inf")
+    for _ in range(_N_REPEATS):
+        t0 = time.perf_counter()
+        out = np.empty(n, dtype=np.int64)
+        for i in range(n):
+            cid = grid.locate(pts[i])
+            out[i] = -1 if cid is None else cid
+        best = min(best, time.perf_counter() - t0)
+    return best * 1e3
+
+
+def _time_batch(grid, pts: np.ndarray) -> float:  # noqa: ANN001
+    """Time locate_many; return minimum wall time (ms)."""
+    best = float("inf")
+    for _ in range(_N_REPEATS):
+        t0 = time.perf_counter()
+        grid.locate_many(pts)
+        best = min(best, time.perf_counter() - t0)
+    return best * 1e3
+
+
+def main() -> None:
+    """Run the locate benchmark and print results."""
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]], 50)
+    print(f"Grid: 3D uniform, {grid.cells_per_axis} cells, {grid.num_cells} total")
+    rng = np.random.default_rng(0)
+
+    # Warm up the JIT kernel so compile time is excluded from the timings.
+    grid.locate_many(rng.uniform(0.0, 1.0, size=(8, 3)))
+
+    print(f"{'n_pts':>9}  {'loop_ms':>10}  {'batch_ms':>10}  {'speedup':>8}")
+    print("-" * 44)
+    for n_pts in _BATCH_SIZES:
+        pts = rng.uniform(-0.1, 1.1, size=(n_pts, 3))
+        loop_ms = _time_loop(grid, pts)
+        batch_ms = _time_batch(grid, pts)
+        speedup = loop_ms / batch_ms if batch_ms > 0 else float("nan")
+        print(f"{n_pts:>9}  {loop_ms:>10.3f}  {batch_ms:>10.3f}  {speedup:>8.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -36,6 +36,11 @@ For transformations between these domains, the `pantr.change_basis` utilities ac
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: pantr.grid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: pantr.quad
    :members:
    :undoc-members:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `pantr.grid`: new structured-grid layer. `Grid` is an abstract base class
+  defining the grid contract (cell bounds, point location, facet neighbours)
+  with axis-aligned box defaults for facets, reference maps, neighbour lists,
+  batch point location, and AABB queries. `TensorProductGrid` is a concrete,
+  low-footprint tensor-product grid of axis-aligned boxes with per-axis
+  breakpoints and row-major (C-order) cell ids matching
+  `SpanwiseElementExtraction`. Factories `uniform_grid` and `tensor_product_grid`
+  build a uniform grid and a B-spline knot-span grid respectively. `BVH` is a
+  bounding-volume hierarchy over cell AABBs (lazily built, backing
+  `Grid.query_aabb`), and `CellTags` / `FacetTags` are sparse, dolfinx-style
+  named tag registries for cells and facets.
+- `pantr.viz.grid_to_pyvista`: export a 1-D/2-D/3-D `Grid` to a pyvista
+  `UnstructuredGrid` (lines / quads / hexahedra).
+
 ## 0.4.0 (2026-06-02)
 
 ### Added

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -8,6 +8,7 @@ The main modules are:
 - :mod:`pantr.bspline`: B-spline spaces, geometric objects, and knot vector factories.
 - :mod:`pantr.change_basis`: Transformation matrices between different bases.
 - :mod:`pantr.geometry`: Axis-aligned bounding boxes and geometry primitives.
+- :mod:`pantr.grid`: Structured cell grids (tensor-product, BVH, tags).
 - :mod:`pantr.quad`: Quadrature rules and evaluation grid helpers.
 - :mod:`pantr.tolerance`: Uniform floating-point tolerance utilities.
 - :mod:`pantr.transform`: Affine transformations for geometric objects.
@@ -24,6 +25,7 @@ from . import (
     cad,
     change_basis,
     geometry,
+    grid,
     quad,
     tolerance,
     transform,
@@ -47,6 +49,7 @@ __all__ = [
     "change_basis",
     "geometry",
     "get_num_threads",
+    "grid",
     "num_threads",
     "quad",
     "set_num_threads",

--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -1,0 +1,47 @@
+"""Structured cell grids for the PaNTr stack.
+
+This package provides a small, performance-conscious grid layer: a partition of
+a parametric domain into cells with *implicit* (computed, not stored)
+connectivity. It is the shared grid abstraction consumed by immersed / unfitted
+discretizations, B-spline knot-span grids, and (later) hierarchical refinement
+grids.
+
+The :class:`TensorProductGrid` is deliberately low-footprint: it stores only the
+per-axis breakpoint arrays and a little metadata, computing cell bounds,
+neighbours, and ids on demand. The only ``O(num_cells)`` structure -- a
+:class:`BVH` spatial index -- is built lazily on the first
+:meth:`~Grid.query_aabb`, so a grid used purely as a B-spline's knot grid stays
+proportional to its breakpoints, not its cell count.
+
+Main exports:
+
+- :class:`Grid`: abstract base class defining the grid contract and supplying
+  axis-aligned box defaults for facets, neighbours, reference maps, batch point
+  location, and spatial queries.
+- :class:`TensorProductGrid`: concrete tensor-product grid of axis-aligned boxes
+  with per-axis breakpoints and row-major (C-order) cell ids.
+- :func:`uniform_grid`: build a uniform grid on a bounding box.
+- :func:`tensor_product_grid`: build the knot-span grid of a
+  :class:`pantr.bspline.BsplineSpace`.
+- :class:`BVH`: bounding-volume hierarchy over cell AABBs, backing
+  :meth:`Grid.query_aabb`.
+- :class:`CellTags`, :class:`FacetTags`: sparse, dolfinx-style named tag
+  registries for cells and facets.
+"""
+
+from __future__ import annotations
+
+from ._bvh import BVH
+from ._grid import Grid
+from ._tags import CellTags, FacetTags
+from ._tensor_product_grid import TensorProductGrid, tensor_product_grid, uniform_grid
+
+__all__ = [
+    "BVH",
+    "CellTags",
+    "FacetTags",
+    "Grid",
+    "TensorProductGrid",
+    "tensor_product_grid",
+    "uniform_grid",
+]

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -193,6 +193,11 @@ class BVH:
         n_cells, ndim = int(lo.shape[0]), int(lo.shape[1])
         if ndim < 1:
             raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
+        if not np.all(np.isfinite(lo)) or not np.all(np.isfinite(hi)):
+            raise ValueError(
+                "BVH.from_cell_bounds: cell_lo and cell_hi must contain only finite "
+                "values; got NaN or Inf."
+            )
         if np.any(hi < lo):
             raise ValueError(
                 "Every cell must satisfy cell_hi >= cell_lo on every axis; "
@@ -415,8 +420,10 @@ def _build_tree(
         next_idx += 2
         node_left[idx] = left_idx
         node_right[idx] = right_idx
-        # Push right first so left pops first (preorder visit order matches the
-        # recursive description in the module docstring).
+        # Push right first so left pops first (preorder left-to-right construction
+        # order, matching the _bvh.py module docstring). Note: the query kernels
+        # in _bvh_core.py push left first and visit right first — opposite
+        # direction — but count and emit use the same order, so results agree.
         work.append((right_idx, mid, end))
         work.append((left_idx, start, mid))
     return node_lo, node_hi, node_left, node_right, node_cell

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -1,0 +1,390 @@
+"""Bounding-volume hierarchy over grid cells.
+
+A simple but efficient BVH that indexes a fixed collection of axis-aligned
+bounding boxes (one per grid cell). The tree is built once (Layer 2, Python) by
+recursive median-of-longest-axis splits; queries descend iteratively via the
+Layer-3 kernels in :mod:`pantr.grid._bvh_core`.
+
+Layout
+------
+
+The BVH is held as five parallel arrays, matching the representation consumed by
+the kernels:
+
+- ``node_lo`` / ``node_hi``: per-node AABB corners, shape ``(n_nodes, ndim)``.
+- ``node_left`` / ``node_right``: child indices; ``-1`` on leaves.
+- ``node_cell``: cell identifier on leaves; ``-1`` on internal nodes.
+
+The root is always node ``0`` and covers every cell. For ``N`` cells the tree
+has exactly ``2 * N - 1`` nodes (``N`` leaves, ``N - 1`` internal nodes).
+Internal-node AABBs are tight: the union of the children's AABBs. Construction
+stops at one cell per leaf, so leaves and cells are in one-to-one correspondence.
+The construction order (preorder) is deterministic, which keeps query results
+reproducible.
+
+Queries
+-------
+
+:meth:`BVH.query_aabb` returns the ids of cells whose AABB overlaps the query
+box. A touching-face pair counts as overlapping (inclusive comparison) to match
+:meth:`pantr.geometry.AABB.overlaps`. Queries run in two passes: a count-only
+descent sizes the output, then an emit descent writes the cell ids. Both passes
+visit the same nodes in the same order, so the result is a fresh, compact
+``int64`` array with no Python-side list growth.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._bvh_core import (
+    _BVH_STACK_DEPTH,
+    _bvh_query_count_core,
+    _bvh_query_emit_core,
+)
+from ._grid_utils import _as_float64
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from ..geometry import AABB
+
+
+class BVH:
+    """Bounding-volume hierarchy indexing a fixed collection of AABBs.
+
+    Instances are immutable: once built, the internal arrays are flagged
+    read-only. Queries allocate fresh ``int64`` output arrays per call.
+
+    Build by passing per-cell AABBs to :meth:`from_cell_bounds`; direct
+    construction from the raw array representation is supported via the default
+    constructor but is mostly intended for tests and round-trip serialization.
+
+    Attributes:
+        ndim (int): Spatial dimension of the indexed AABBs (``>= 1``).
+        n_cells (int): Number of cells indexed (equal to the number of leaves).
+        n_nodes (int): Total number of nodes (``2 * n_cells - 1`` for
+            ``n_cells > 0``, else ``0``).
+    """
+
+    __slots__ = (
+        "_node_cell",
+        "_node_hi",
+        "_node_left",
+        "_node_lo",
+        "_node_right",
+        "n_cells",
+        "n_nodes",
+        "ndim",
+    )
+
+    def __init__(  # noqa: PLR0913 -- BVH is a five-array flat struct
+        self,
+        node_lo: npt.NDArray[np.float64],
+        node_hi: npt.NDArray[np.float64],
+        node_left: npt.NDArray[np.int64],
+        node_right: npt.NDArray[np.int64],
+        node_cell: npt.NDArray[np.int64],
+        *,
+        n_cells: int,
+    ) -> None:
+        """Store the raw BVH arrays after validating their shapes.
+
+        Callers should prefer :meth:`from_cell_bounds`; this constructor is
+        useful for tests that need to poke specific tree shapes.
+
+        Args:
+            node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners, shape
+                ``(n_nodes, ndim)``.
+            node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners, shape
+                ``(n_nodes, ndim)``.
+            node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on
+                leaves. Shape ``(n_nodes,)``.
+            node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on
+                leaves.
+            node_cell (npt.NDArray[np.int64]): Leaf cell identifiers; ``-1`` on
+                internal nodes.
+            n_cells (int): Number of indexed cells (leaves).
+
+        Raises:
+            TypeError: If any array has the wrong dtype.
+            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, or
+                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``).
+        """
+        if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
+            raise TypeError(
+                f"node_lo / node_hi must be float64; got {node_lo.dtype!r} / {node_hi.dtype!r}."
+            )
+        if node_lo.ndim != 2:  # noqa: PLR2004
+            raise ValueError(f"node_lo must be 2-D (n_nodes, ndim); got shape {node_lo.shape}.")
+        if node_hi.shape != node_lo.shape:
+            raise ValueError(
+                f"node_hi shape {node_hi.shape} must match node_lo shape {node_lo.shape}."
+            )
+        n_nodes, ndim = int(node_lo.shape[0]), int(node_lo.shape[1])
+        if ndim < 1:
+            raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
+        for arr, name in (
+            (node_left, "node_left"),
+            (node_right, "node_right"),
+            (node_cell, "node_cell"),
+        ):
+            if arr.dtype != np.int64:
+                raise TypeError(f"{name} must be int64; got {arr.dtype!r}.")
+            if arr.shape != (n_nodes,):
+                raise ValueError(f"{name} must have shape ({n_nodes},); got {arr.shape}.")
+        n_cells_int = int(n_cells)
+        expected_nodes = 2 * n_cells_int - 1 if n_cells_int > 0 else 0
+        if n_nodes != expected_nodes:
+            raise ValueError(
+                f"BVH: n_cells={n_cells_int} implies n_nodes={expected_nodes}; "
+                f"got node arrays with {n_nodes} rows."
+            )
+        self._node_lo = np.ascontiguousarray(node_lo, dtype=np.float64)
+        self._node_hi = np.ascontiguousarray(node_hi, dtype=np.float64)
+        self._node_left = np.ascontiguousarray(node_left, dtype=np.int64)
+        self._node_right = np.ascontiguousarray(node_right, dtype=np.int64)
+        self._node_cell = np.ascontiguousarray(node_cell, dtype=np.int64)
+        for arr_ro in (
+            self._node_lo,
+            self._node_hi,
+            self._node_left,
+            self._node_right,
+            self._node_cell,
+        ):
+            arr_ro.flags.writeable = False
+        self.ndim = ndim
+        self.n_cells = n_cells_int
+        self.n_nodes = n_nodes
+
+    @classmethod
+    def from_cell_bounds(
+        cls,
+        cell_lo: npt.ArrayLike,
+        cell_hi: npt.ArrayLike,
+    ) -> BVH:
+        """Build a BVH over ``n_cells`` axis-aligned cell AABBs.
+
+        Uses a top-down recursive median-of-longest-axis split. Cells are sorted
+        by centroid on the longest axis; the median splits the list into two
+        halves of equal size (``+/- 1``). Each leaf indexes exactly one cell.
+
+        Args:
+            cell_lo (npt.ArrayLike): Per-cell lo corners; shape
+                ``(n_cells, ndim)`` with ``ndim >= 1``. Validated, not mutated.
+            cell_hi (npt.ArrayLike): Per-cell hi corners; same shape and
+                conventions as ``cell_lo``. Each entry must satisfy
+                ``cell_hi >= cell_lo``.
+
+        Returns:
+            BVH: The constructed hierarchy.
+
+        Raises:
+            TypeError: If inputs cannot be cast to ``float64``.
+            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, any cell
+                has ``hi < lo``, or the implied tree exceeds the internal stack
+                depth.
+        """
+        lo = _as_float64(cell_lo, name="cell_lo")
+        hi = _as_float64(cell_hi, name="cell_hi")
+        if lo.ndim != 2:  # noqa: PLR2004
+            raise ValueError(f"cell_lo must be 2-D (n_cells, ndim); got shape {lo.shape}.")
+        if hi.shape != lo.shape:
+            raise ValueError(f"cell_hi shape {hi.shape} must match cell_lo shape {lo.shape}.")
+        n_cells, ndim = int(lo.shape[0]), int(lo.shape[1])
+        if ndim < 1:
+            raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
+        if np.any(hi < lo):
+            raise ValueError(
+                "Every cell must satisfy cell_hi >= cell_lo on every axis; "
+                "at least one cell violates this."
+            )
+        if n_cells == 0:
+            empty_lo = np.zeros((0, ndim), dtype=np.float64)
+            empty_hi = np.zeros((0, ndim), dtype=np.float64)
+            empty_i = np.zeros(0, dtype=np.int64)
+            return cls(empty_lo, empty_hi, empty_i, empty_i, empty_i, n_cells=0)
+        # Guard against the fixed-depth Numba stack in :mod:`pantr.grid._bvh_core`.
+        # Median-of-longest-axis splits produce a balanced tree of height
+        # ``ceil(log2(n_cells)) + 1``; the ``+ 1`` accounts for the root push.
+        max_depth = int(np.ceil(np.log2(n_cells))) + 1 if n_cells > 1 else 1
+        if max_depth > _BVH_STACK_DEPTH:
+            raise ValueError(
+                f"BVH.from_cell_bounds: {n_cells} cells would produce a tree of depth "
+                f">= {max_depth}, exceeding the internal stack depth {_BVH_STACK_DEPTH}. "
+                f"This is a library limit; please report this as an issue."
+            )
+        node_lo, node_hi, node_left, node_right, node_cell = _build_tree(lo, hi)
+        return cls(node_lo, node_hi, node_left, node_right, node_cell, n_cells=n_cells)
+
+    def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
+        """Return the ids of every leaf cell whose AABB overlaps ``aabb``.
+
+        Args:
+            aabb (AABB): Query box; must match :attr:`ndim`.
+
+        Returns:
+            npt.NDArray[np.int64]: Overlapping cell ids. Order matches the
+            internal preorder traversal; callers that need a particular order
+            should sort the result.
+
+        Raises:
+            ValueError: If ``aabb.ndim != self.ndim``.
+        """
+        if aabb.ndim != self.ndim:
+            raise ValueError(
+                f"BVH.query_aabb: aabb.ndim ({aabb.ndim}) must match self.ndim ({self.ndim})."
+            )
+        if self.n_cells == 0:
+            return np.zeros(0, dtype=np.int64)
+        count = int(
+            _bvh_query_count_core(
+                aabb.lo,
+                aabb.hi,
+                self._node_lo,
+                self._node_hi,
+                self._node_left,
+                self._node_right,
+                self._node_cell,
+            )
+        )
+        out = np.empty(count, dtype=np.int64)
+        if count == 0:
+            return out
+        written = int(
+            _bvh_query_emit_core(
+                aabb.lo,
+                aabb.hi,
+                self._node_lo,
+                self._node_hi,
+                self._node_left,
+                self._node_right,
+                self._node_cell,
+                out,
+            )
+        )
+        if written != count:
+            raise RuntimeError(
+                f"BVH.query_aabb: internal count/emit mismatch (count pass returned {count}, "
+                f"emit pass wrote {written}). This is a bug in the BVH kernel; please report it."
+            )
+        return out
+
+    @property
+    def node_lo(self) -> npt.NDArray[np.float64]:
+        """Get the read-only view of per-node AABB lo corners.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(n_nodes, ndim)``.
+        """
+        return self._node_lo
+
+    @property
+    def node_hi(self) -> npt.NDArray[np.float64]:
+        """Get the read-only view of per-node AABB hi corners.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(n_nodes, ndim)``.
+        """
+        return self._node_hi
+
+    @property
+    def node_left(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-node left-child indices.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on leaves.
+        """
+        return self._node_left
+
+    @property
+    def node_right(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-node right-child indices.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on leaves.
+        """
+        return self._node_right
+
+    @property
+    def node_cell(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-leaf cell identifiers.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on internal
+            nodes, ``0 <= id < n_cells`` on leaves.
+        """
+        return self._node_cell
+
+
+def _build_tree(
+    cell_lo: npt.NDArray[np.float64],
+    cell_hi: npt.NDArray[np.float64],
+) -> tuple[
+    npt.NDArray[np.float64],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+]:
+    """Build the BVH arrays from validated per-cell AABBs.
+
+    Iterative top-down construction with a work stack. The root claims node index
+    ``0``; subsequent splits claim indices in preorder.
+
+    Args:
+        cell_lo (npt.NDArray[np.float64]): Per-cell lo corners, shape
+            ``(n_cells, ndim)``, ``n_cells >= 1``.
+        cell_hi (npt.NDArray[np.float64]): Per-cell hi corners, same shape;
+            ``hi >= lo`` is assumed.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64],
+        npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        ``(node_lo, node_hi, node_left, node_right, node_cell)`` as defined in the
+        module docstring.
+
+    Note:
+        Inputs are assumed validated by the caller. This helper never raises.
+    """
+    n_cells, ndim = cell_lo.shape
+    max_nodes = 2 * n_cells - 1
+    node_lo = np.empty((max_nodes, ndim), dtype=np.float64)
+    node_hi = np.empty((max_nodes, ndim), dtype=np.float64)
+    node_left = np.full(max_nodes, -1, dtype=np.int64)
+    node_right = np.full(max_nodes, -1, dtype=np.int64)
+    node_cell = np.full(max_nodes, -1, dtype=np.int64)
+    centroid = 0.5 * (cell_lo + cell_hi)
+    perm = np.arange(n_cells, dtype=np.int64)
+    # Work stack: (node_idx, cell_start, cell_end).
+    work: list[tuple[int, int, int]] = [(0, 0, n_cells)]
+    next_idx = 1
+    while work:
+        idx, start, end = work.pop()
+        sub = perm[start:end]
+        node_lo[idx] = cell_lo[sub].min(axis=0)
+        node_hi[idx] = cell_hi[sub].max(axis=0)
+        count = end - start
+        if count == 1:
+            node_cell[idx] = int(sub[0])
+            continue
+        extent = node_hi[idx] - node_lo[idx]
+        axis = int(np.argmax(extent))
+        order = np.argsort(centroid[sub, axis], kind="stable")
+        perm[start:end] = sub[order]
+        mid = start + count // 2
+        left_idx = next_idx
+        right_idx = next_idx + 1
+        next_idx += 2
+        node_left[idx] = left_idx
+        node_right[idx] = right_idx
+        # Push right first so left pops first (preorder visit order matches the
+        # recursive description in the module docstring).
+        work.append((right_idx, mid, end))
+        work.append((left_idx, start, mid))
+    return node_lo, node_hi, node_left, node_right, node_cell
+
+
+__all__ = ["BVH"]

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -60,41 +60,35 @@ class BVH:
 
     Build by passing per-cell AABBs to :meth:`from_cell_bounds`; direct
     construction from the raw array representation is supported via the default
-    constructor but is mostly intended for tests and round-trip serialization.
+    constructor but is mostly intended for tests.
     """
 
     __slots__ = (
+        "_n_cells",
+        "_n_nodes",
+        "_ndim",
         "_node_cell",
         "_node_hi",
         "_node_left",
         "_node_lo",
         "_node_right",
-        "n_cells",
-        "n_nodes",
-        "ndim",
     )
 
-    #: Spatial dimension of the indexed AABBs (``>= 1``).
-    ndim: int
-    #: Number of cells indexed (equal to the number of leaves).
-    n_cells: int
-    #: Total number of nodes (``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``).
-    n_nodes: int
-
-    def __init__(  # noqa: PLR0913 -- BVH is a five-array flat struct
+    def __init__(
         self,
         node_lo: npt.NDArray[np.float64],
         node_hi: npt.NDArray[np.float64],
         node_left: npt.NDArray[np.int64],
         node_right: npt.NDArray[np.int64],
         node_cell: npt.NDArray[np.int64],
-        *,
-        n_cells: int,
     ) -> None:
         """Store the raw BVH arrays after validating their shapes.
 
-        Callers should prefer :meth:`from_cell_bounds`; this constructor is
-        useful for tests that need to poke specific tree shapes.
+        ``n_cells`` is derived from ``node_lo.shape[0]`` as
+        ``(n_nodes + 1) // 2`` (or ``0`` when ``n_nodes == 0``); callers do not
+        pass it explicitly.  Callers should prefer :meth:`from_cell_bounds`;
+        this constructor is useful for tests that need to poke specific tree
+        shapes.
 
         Args:
             node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners, shape
@@ -107,12 +101,12 @@ class BVH:
                 leaves.
             node_cell (npt.NDArray[np.int64]): Leaf cell identifiers; ``-1`` on
                 internal nodes.
-            n_cells (int): Number of indexed cells (leaves).
 
         Raises:
             TypeError: If any array has the wrong dtype.
             ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, or
-                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``).
+                ``n_nodes`` is not ``0`` or ``2 * n_cells - 1`` for some
+                ``n_cells >= 1``.
         """
         if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
             raise TypeError(
@@ -136,12 +130,14 @@ class BVH:
                 raise TypeError(f"{name} must be int64; got {arr.dtype!r}.")
             if arr.shape != (n_nodes,):
                 raise ValueError(f"{name} must have shape ({n_nodes},); got {arr.shape}.")
-        n_cells_int = int(n_cells)
+        # Derive n_cells from n_nodes; validate the implied node-count formula.
+        n_cells_int = (n_nodes + 1) // 2 if n_nodes > 0 else 0
         expected_nodes = 2 * n_cells_int - 1 if n_cells_int > 0 else 0
         if n_nodes != expected_nodes:
             raise ValueError(
-                f"BVH: n_cells={n_cells_int} implies n_nodes={expected_nodes}; "
-                f"got node arrays with {n_nodes} rows."
+                f"BVH: n_nodes={n_nodes} is not a valid BVH node count "
+                f"(must be 0 or 2*n_cells-1 for some n_cells >= 1); "
+                f"implied n_cells={n_cells_int} implies n_nodes={expected_nodes}."
             )
         self._node_lo = np.ascontiguousarray(node_lo, dtype=np.float64)
         self._node_hi = np.ascontiguousarray(node_hi, dtype=np.float64)
@@ -156,9 +152,9 @@ class BVH:
             self._node_cell,
         ):
             arr_ro.flags.writeable = False
-        self.ndim = ndim
-        self.n_cells = n_cells_int
-        self.n_nodes = n_nodes
+        self._ndim = ndim
+        self._n_cells = n_cells_int
+        self._n_nodes = n_nodes
 
     @classmethod
     def from_cell_bounds(
@@ -206,7 +202,7 @@ class BVH:
             empty_lo = np.zeros((0, ndim), dtype=np.float64)
             empty_hi = np.zeros((0, ndim), dtype=np.float64)
             empty_i = np.zeros(0, dtype=np.int64)
-            return cls(empty_lo, empty_hi, empty_i, empty_i, empty_i, n_cells=0)
+            return cls(empty_lo, empty_hi, empty_i, empty_i, empty_i)
         # Guard against the fixed-depth Numba stack in :mod:`pantr.grid._bvh_core`.
         # Median-of-longest-axis splits produce a balanced tree of height
         # ``ceil(log2(n_cells)) + 1``; the ``+ 1`` accounts for the root push.
@@ -218,7 +214,7 @@ class BVH:
                 f"This is a library limit; please report this as an issue."
             )
         node_lo, node_hi, node_left, node_right, node_cell = _build_tree(lo, hi)
-        return cls(node_lo, node_hi, node_left, node_right, node_cell, n_cells=n_cells)
+        return cls(node_lo, node_hi, node_left, node_right, node_cell)
 
     def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
         """Return the ids of every leaf cell whose AABB overlaps ``aabb``.
@@ -234,11 +230,11 @@ class BVH:
         Raises:
             ValueError: If ``aabb.ndim != self.ndim``.
         """
-        if aabb.ndim != self.ndim:
+        if aabb.ndim != self._ndim:
             raise ValueError(
-                f"BVH.query_aabb: aabb.ndim ({aabb.ndim}) must match self.ndim ({self.ndim})."
+                f"BVH.query_aabb: aabb.ndim ({aabb.ndim}) must match self.ndim ({self._ndim})."
             )
-        if self.n_cells == 0:
+        if self._n_cells == 0:
             return np.zeros(0, dtype=np.int64)
         count = int(
             _bvh_query_count_core(
@@ -268,10 +264,48 @@ class BVH:
         )
         if written != count:
             raise RuntimeError(
-                f"BVH.query_aabb: internal count/emit mismatch (count pass returned {count}, "
-                f"emit pass wrote {written}). This is a bug in the BVH kernel; please report it."
+                f"BVH.query_aabb: internal count/emit mismatch "
+                f"(count={count}, written={written}, "
+                f"n_cells={self._n_cells}, ndim={self._ndim}, "
+                f"query=[{aabb.lo.tolist()}, {aabb.hi.tolist()}]). "
+                f"This is a bug in the BVH kernel; please report it."
             )
         return out
+
+    @property
+    def ndim(self) -> int:
+        """Get the spatial dimension of the indexed AABBs.
+
+        Returns:
+            int: Number of axes (``>= 1``).
+        """
+        return self._ndim
+
+    @property
+    def n_cells(self) -> int:
+        """Get the number of cells indexed (equal to the number of leaves).
+
+        Returns:
+            int: ``(n_nodes + 1) // 2``, or ``0`` for an empty BVH.
+        """
+        return self._n_cells
+
+    @property
+    def n_nodes(self) -> int:
+        """Get the total number of nodes.
+
+        Returns:
+            int: ``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``.
+        """
+        return self._n_nodes
+
+    def __repr__(self) -> str:
+        """Return a concise representation useful for debugging.
+
+        Returns:
+            str: ``"BVH(ndim=..., n_cells=..., n_nodes=...)"``
+        """
+        return f"BVH(ndim={self._ndim}, n_cells={self._n_cells}, n_nodes={self._n_nodes})"
 
     @property
     def node_lo(self) -> npt.NDArray[np.float64]:

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -61,12 +61,6 @@ class BVH:
     Build by passing per-cell AABBs to :meth:`from_cell_bounds`; direct
     construction from the raw array representation is supported via the default
     constructor but is mostly intended for tests and round-trip serialization.
-
-    Attributes:
-        ndim (int): Spatial dimension of the indexed AABBs (``>= 1``).
-        n_cells (int): Number of cells indexed (equal to the number of leaves).
-        n_nodes (int): Total number of nodes (``2 * n_cells - 1`` for
-            ``n_cells > 0``, else ``0``).
     """
 
     __slots__ = (
@@ -79,6 +73,13 @@ class BVH:
         "n_nodes",
         "ndim",
     )
+
+    #: Spatial dimension of the indexed AABBs (``>= 1``).
+    ndim: int
+    #: Number of cells indexed (equal to the number of leaves).
+    n_cells: int
+    #: Total number of nodes (``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``).
+    n_nodes: int
 
     def __init__(  # noqa: PLR0913 -- BVH is a five-array flat struct
         self,

--- a/src/pantr/grid/_bvh_core.py
+++ b/src/pantr/grid/_bvh_core.py
@@ -15,7 +15,10 @@ Two kernels are exposed to Layer 2:
 Both kernels share the same traversal structure and visit nodes in an identical
 order so that ``count`` and ``emit`` agree on the output size. The traversal is
 deterministic: the left child is pushed first and the right child last, so the
-stack pops right first and the tree is visited in preorder, right to left.
+stack pops right first and the tree is visited in preorder, right to left. This
+is the opposite of the left-to-right construction order in ``_build_tree``
+(:mod:`pantr.grid._bvh`); both are preorder, but only the count/emit consistency
+matters for correctness.
 
 The stack is a fixed-size ``int64`` array. For ``N`` cells a balanced
 median-split BVH has height ``ceil(log2(N)) + 1``; depth 128 covers any

--- a/src/pantr/grid/_bvh_core.py
+++ b/src/pantr/grid/_bvh_core.py
@@ -14,8 +14,8 @@ Two kernels are exposed to Layer 2:
 
 Both kernels share the same traversal structure and visit nodes in an identical
 order so that ``count`` and ``emit`` agree on the output size. The traversal is
-deterministic: the right child is pushed first and the left child last, so the
-stack pops left first and the tree is visited in preorder, left to right.
+deterministic: the left child is pushed first and the right child last, so the
+stack pops right first and the tree is visited in preorder, right to left.
 
 The stack is a fixed-size ``int64`` array. For ``N`` cells a balanced
 median-split BVH has height ``ceil(log2(N)) + 1``; depth 128 covers any

--- a/src/pantr/grid/_bvh_core.py
+++ b/src/pantr/grid/_bvh_core.py
@@ -1,0 +1,197 @@
+"""Layer-3 Numba kernels for the bounding-volume hierarchy over grid cells.
+
+The BVH is stored as five parallel arrays (see :mod:`pantr.grid._bvh` for the
+Layer-2 wrapper that owns them). Queries use a single-threaded iterative descent
+with an explicit fixed-size stack so the code stays fast and allocation-free
+under Numba ``nopython=True``.
+
+Two kernels are exposed to Layer 2:
+
+- :func:`_bvh_query_count_core` -- counts the leaves whose AABB overlaps the
+  query box. Called first so Layer 2 can allocate an exact-size output array.
+- :func:`_bvh_query_emit_core` -- fills a preallocated output array with the
+  cell identifiers of overlapping leaves.
+
+Both kernels share the same traversal structure and visit nodes in an identical
+order so that ``count`` and ``emit`` agree on the output size. The traversal is
+deterministic: the right child is pushed first and the left child last, so the
+stack pops left first and the tree is visited in preorder, left to right.
+
+The stack is a fixed-size ``int64`` array. For ``N`` cells a balanced
+median-split BVH has height ``ceil(log2(N)) + 1``; depth 128 covers any
+realistic cell count on a single process. Layer 2 validates the depth bound at
+construction time so the kernels never overflow their stack.
+
+The AABB overlap test is inclusive on every face so that a query box sharing a
+face with a cell is reported as overlapping, matching
+:meth:`pantr.geometry.AABB.overlaps`.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call :class:`pantr.grid.BVH` instead.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+from .._numba_compat import nb_jit
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+# Maximum depth of the iterative-descent stack. 128 is far larger than any
+# balanced BVH over an ``int64``-indexed cell set but small enough to stay
+# comfortably on the Numba-allocated function stack.
+_BVH_STACK_DEPTH: Final[int] = 128
+
+
+@nb_jit(nopython=True, cache=True)
+def _bvh_query_count_core(  # noqa: PLR0913 -- kernel consumes a flat BVH struct
+    qlo: npt.NDArray[np.float64],
+    qhi: npt.NDArray[np.float64],
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+) -> int:
+    """Count leaves whose AABB overlaps the query box.
+
+    Args:
+        qlo (npt.NDArray[np.float64]): Query AABB lower corner, ``float64``,
+            shape ``(ndim,)``.
+        qhi (npt.NDArray[np.float64]): Query AABB upper corner, ``float64``,
+            shape ``(ndim,)``.
+        node_lo (npt.NDArray[np.float64]): Per-node AABB lower corners, shape
+            ``(n_nodes, ndim)``.
+        node_hi (npt.NDArray[np.float64]): Per-node AABB upper corners, shape
+            ``(n_nodes, ndim)``.
+        node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` marks a
+            leaf. Shape ``(n_nodes,)``.
+        node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` marks a
+            leaf. Shape ``(n_nodes,)``.
+        node_cell (npt.NDArray[np.int64]): Cell identifier per leaf; ``-1`` on
+            internal nodes. Shape ``(n_nodes,)``.
+
+    Returns:
+        int: Number of overlapping leaves.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`pantr.grid.BVH.query_aabb` instead.
+    """
+    ndim = qlo.shape[0]
+    stack = np.empty(_BVH_STACK_DEPTH, dtype=np.int64)
+    stack[0] = 0
+    top = 1
+    count = 0
+    while top > 0:
+        top -= 1
+        idx = stack[top]
+        overlaps = True
+        for d in range(ndim):
+            if qhi[d] < node_lo[idx, d] or qlo[d] > node_hi[idx, d]:
+                overlaps = False
+                break
+        if not overlaps:
+            continue
+        cell = node_cell[idx]
+        if cell >= 0:
+            count += 1
+        else:
+            stack[top] = node_left[idx]
+            top += 1
+            stack[top] = node_right[idx]
+            top += 1
+    return count
+
+
+@nb_jit(nopython=True, cache=True)
+def _bvh_query_emit_core(  # noqa: PLR0913 -- kernel consumes a flat BVH struct
+    qlo: npt.NDArray[np.float64],
+    qhi: npt.NDArray[np.float64],
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+    out: npt.NDArray[np.int64],
+) -> int:
+    """Emit overlapping leaf cell ids into ``out`` and return the count.
+
+    Uses the same traversal order as :func:`_bvh_query_count_core`, so
+    ``out[:count]`` holds exactly the same cells that would have been counted.
+    ``out`` must be large enough to hold every overlapping cell; Layer 2 sizes
+    it using the count pass.
+
+    Args:
+        qlo (npt.NDArray[np.float64]): Query AABB lower corner.
+        qhi (npt.NDArray[np.float64]): Query AABB upper corner.
+        node_lo (npt.NDArray[np.float64]): Per-node AABB lower corners.
+        node_hi (npt.NDArray[np.float64]): Per-node AABB upper corners.
+        node_left (npt.NDArray[np.int64]): Left-child indices.
+        node_right (npt.NDArray[np.int64]): Right-child indices.
+        node_cell (npt.NDArray[np.int64]): Leaf cell ids (or ``-1``).
+        out (npt.NDArray[np.int64]): Output buffer, shape ``(n_overlaps_or_more,)``.
+
+    Returns:
+        int: Number of cell ids written to ``out``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`pantr.grid.BVH.query_aabb` instead.
+    """
+    ndim = qlo.shape[0]
+    stack = np.empty(_BVH_STACK_DEPTH, dtype=np.int64)
+    stack[0] = 0
+    top = 1
+    count = 0
+    while top > 0:
+        top -= 1
+        idx = stack[top]
+        overlaps = True
+        for d in range(ndim):
+            if qhi[d] < node_lo[idx, d] or qlo[d] > node_hi[idx, d]:
+                overlaps = False
+                break
+        if not overlaps:
+            continue
+        cell = node_cell[idx]
+        if cell >= 0:
+            out[count] = cell
+            count += 1
+        else:
+            stack[top] = node_left[idx]
+            top += 1
+            stack[top] = node_right[idx]
+            top += 1
+    return count
+
+
+def _warmup_numba_functions() -> None:
+    """Trigger compilation of the BVH kernels on a tiny single-cell tree.
+
+    Provided for explicit, on-demand warmup (for example in benchmarks). It is
+    deliberately *not* called from :mod:`pantr`'s import-time warmup: the grid
+    kernels compile lazily on first use and are cached to disk by Numba's
+    ``cache=True``.
+    """
+    node_lo = np.zeros((1, 1), dtype=np.float64)
+    node_hi = np.ones((1, 1), dtype=np.float64)
+    leaf = np.zeros(1, dtype=np.int64)
+    internal = np.full(1, -1, dtype=np.int64)
+    qlo = np.zeros(1, dtype=np.float64)
+    qhi = np.ones(1, dtype=np.float64)
+    _bvh_query_count_core(qlo, qhi, node_lo, node_hi, internal, internal, leaf)
+    out = np.empty(1, dtype=np.int64)
+    _bvh_query_emit_core(qlo, qhi, node_lo, node_hi, internal, internal, leaf, out)
+
+
+__all__ = [
+    "_bvh_query_count_core",
+    "_bvh_query_emit_core",
+]

--- a/src/pantr/grid/_cell_index.py
+++ b/src/pantr/grid/_cell_index.py
@@ -1,0 +1,96 @@
+"""Row-major (C-order) cell-index helpers for tensor-product grids.
+
+A tensor-product grid with per-axis cell counts ``cells_per_axis`` numbers its
+cells in row-major (C) order: the *last* axis varies fastest, matching
+:func:`numpy.ravel_multi_index` / :func:`numpy.unravel_index` with their default
+``order="C"``. This is the same convention used by
+:class:`pantr.bspline.SpanwiseElementExtraction` (whose flat element index ``f``
+maps to ``numpy.unravel_index(f, num_intervals)``), so a grid and an extraction
+operator built on the same :class:`pantr.bspline.BsplineSpace` agree on cell
+ids without any reindexing.
+
+The helpers here centralize that convention so the rest of the package never
+hard-codes a strides formula.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy.typing as npt
+
+
+def c_order_strides(cells_per_axis: Sequence[int]) -> npt.NDArray[np.int64]:
+    """Return the row-major (C-order) flat strides for ``cells_per_axis``.
+
+    The flat id of multi-index ``(i_0, ..., i_{d-1})`` is
+    ``sum_k i_k * strides[k]`` with ``strides[d-1] == 1`` and
+    ``strides[k] == prod(cells_per_axis[k+1:])``.
+
+    Args:
+        cells_per_axis (Sequence[int]): Per-axis cell counts.
+
+    Returns:
+        npt.NDArray[np.int64]: Length-``d`` array of C-order strides.
+    """
+    d = len(cells_per_axis)
+    strides = np.empty(d, dtype=np.int64)
+    stride = 1
+    for k in range(d - 1, -1, -1):
+        strides[k] = stride
+        stride *= int(cells_per_axis[k])
+    return strides
+
+
+def flat_to_multi(flat: int, cells_per_axis: Sequence[int]) -> tuple[int, ...]:
+    """Convert a flat cell id to its per-axis multi-index (C-order).
+
+    Args:
+        flat (int): Flat cell id in ``[0, prod(cells_per_axis))``.
+        cells_per_axis (Sequence[int]): Per-axis cell counts.
+
+    Returns:
+        tuple[int, ...]: Length-``d`` per-axis index tuple.
+
+    Raises:
+        IndexError: If ``flat`` is out of range.
+    """
+    total = 1
+    for n in cells_per_axis:
+        total *= int(n)
+    if not 0 <= int(flat) < total:
+        raise IndexError(f"flat cell id {flat!r} is out of range [0, {total}).")
+    multi = np.unravel_index(int(flat), tuple(int(n) for n in cells_per_axis))
+    return tuple(int(i) for i in multi)
+
+
+def multi_to_flat(multi: Sequence[int], cells_per_axis: Sequence[int]) -> int:
+    """Convert a per-axis multi-index to its flat cell id (C-order).
+
+    Args:
+        multi (Sequence[int]): Length-``d`` per-axis index sequence; each entry
+            must satisfy ``0 <= i_k < cells_per_axis[k]``.
+        cells_per_axis (Sequence[int]): Per-axis cell counts.
+
+    Returns:
+        int: Flat cell id.
+
+    Raises:
+        ValueError: If ``len(multi) != len(cells_per_axis)``.
+        IndexError: If any per-axis index is out of range.
+    """
+    if len(multi) != len(cells_per_axis):
+        raise ValueError(f"multi-index has length {len(multi)}; expected {len(cells_per_axis)}.")
+    for k, (i, n) in enumerate(zip(multi, cells_per_axis, strict=True)):
+        if not 0 <= int(i) < int(n):
+            raise IndexError(f"axis {k} index {int(i)} out of range [0, {int(n)}).")
+    flat = np.ravel_multi_index(tuple(int(i) for i in multi), tuple(int(n) for n in cells_per_axis))
+    return int(flat)
+
+
+__all__ = ["c_order_strides", "flat_to_multi", "multi_to_flat"]

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -1,0 +1,526 @@
+"""Abstract base class for structured cell grids.
+
+A :class:`Grid` is a partition of a parametric domain into cells with *implicit*
+(computed, not stored) connectivity. It is the shared grid abstraction for the
+PaNTr stack: background grids for immersed / unfitted discretizations, knot-span
+grids of B-spline spaces, and (later) hierarchical refinement grids all satisfy
+this contract.
+
+Design
+------
+
+The contract is deliberately small. A concrete grid must define only:
+
+- :attr:`Grid.ndim`, :attr:`Grid.num_cells` -- size metadata;
+- :meth:`Grid.cell_bounds` -- the axis-aligned ``(lo, hi)`` corners of a cell;
+- :meth:`Grid.locate` -- the cell containing a point (or ``None``);
+- :meth:`Grid.neighbor_across_facet` -- the cell across a given local facet.
+
+Everything else has a concrete default built from those primitives, assuming the
+common case of axis-aligned box cells with ``2 * ndim`` facets: cell AABBs,
+reference maps, facet bounds, neighbour lists, boundary-facet detection, batch
+point location, and an :class:`AABB` overlap query backed by a lazily-built
+:class:`pantr.grid.BVH`. Subclasses override any default for which they have a
+cheaper specialization (for example, :class:`pantr.grid.TensorProductGrid`
+replaces :meth:`locate`, :meth:`neighbor_across_facet`, and the cell-bounds
+collection with per-axis arithmetic).
+
+Cells live in parametric coordinates; mapping to physical space is the
+responsibility of the geometry (for example, a B-spline) layered on top of the
+grid -- the grid itself stores no geometry map.
+
+Tagging
+-------
+
+Each grid exposes two lazily-created sparse tag registries,
+:attr:`Grid.cell_tags` and :attr:`Grid.facet_tags`, for attaching integer labels
+to a subset of cells / facets (in / out / cut classification, boundary-condition
+markers, ...). They stay empty until first use, so an untagged grid carries no
+per-cell tag footprint. Deciding *what* to tag is the consumer's job.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._grid_utils import _as_float64
+from ._tags import CellTags, FacetTags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import numpy.typing as npt
+
+    from ..geometry import AABB
+    from ..transform import AffineTransform
+    from ._bvh import BVH
+
+
+class Grid(abc.ABC):
+    """Abstract structured cell grid with implicit connectivity.
+
+    See the module docstring for the contract and the set of methods a subclass
+    must implement versus those provided as overridable defaults.
+
+    Attributes:
+        ndim (int): Spatial dimension of the grid (``>= 1``).
+        num_cells (int): Number of cells in this (local) grid.
+    """
+
+    __slots__ = ("_bvh", "_cell_tags", "_facet_tags")
+
+    def __init__(self) -> None:
+        """Initialize the lazy spatial-index and tag-registry slots.
+
+        Subclasses must call ``super().__init__()`` before use so the lazy
+        :attr:`cell_tags`, :attr:`facet_tags`, and :meth:`query_aabb` caches are
+        available.
+        """
+        self._bvh: BVH | None = None
+        self._cell_tags: CellTags | None = None
+        self._facet_tags: FacetTags | None = None
+
+    # ------------------------------------------------------------------
+    # Abstract contract
+    # ------------------------------------------------------------------
+
+    @property
+    @abc.abstractmethod
+    def ndim(self) -> int:
+        """Get the spatial dimension of the grid.
+
+        Returns:
+            int: Number of axes (``>= 1``).
+        """
+
+    @property
+    @abc.abstractmethod
+    def num_cells(self) -> int:
+        """Get the number of cells in this (local) grid.
+
+        Returns:
+            int: Non-negative cell count.
+        """
+
+    @abc.abstractmethod
+    def cell_bounds(
+        self,
+        cid: int,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Return the axis-aligned ``(lo, hi)`` corners of cell ``cid``.
+
+        Args:
+            cid (int): Cell identifier; must satisfy ``0 <= cid < num_cells``.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: Fresh,
+            writeable length-``ndim`` ``float64`` arrays.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+
+    @abc.abstractmethod
+    def locate(self, pt: npt.ArrayLike) -> int | None:
+        """Return the cell containing ``pt``, or ``None`` if ``pt`` is outside.
+
+        Args:
+            pt (npt.ArrayLike): Length-``ndim`` point in parametric coordinates.
+
+        Returns:
+            int | None: Containing cell id, or ``None`` when ``pt`` lies outside
+            every cell.
+
+        Raises:
+            ValueError: If ``pt`` does not have length ``ndim``.
+        """
+
+    @abc.abstractmethod
+    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
+        """Return the cell across local facet ``lfid`` of ``cid``, or ``None``.
+
+        The result is ``None`` iff the facet lies on the grid's outer boundary.
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, num_local_facets(cid))``.
+
+        Returns:
+            int | None: Neighbouring cell id, or ``None`` on a boundary facet.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+
+    # ------------------------------------------------------------------
+    # Cell accessors (defaults built on the contract)
+    # ------------------------------------------------------------------
+
+    def iter_cells(self) -> Iterator[int]:
+        """Yield every cell identifier exactly once, in id order.
+
+        Returns:
+            Iterator[int]: ``iter(range(num_cells))``.
+        """
+        return iter(range(self.num_cells))
+
+    def cell_aabb(self, cid: int) -> AABB:
+        """Return cell ``cid``'s axis-aligned bounding box.
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            AABB: Equivalent to ``AABB(*self.cell_bounds(cid))``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        from ..geometry import AABB  # noqa: PLC0415
+
+        lo, hi = self.cell_bounds(cid)
+        return AABB(lo, hi)
+
+    def cell_level(self, cid: int) -> int:
+        """Return the refinement level of cell ``cid``.
+
+        Non-hierarchical grids always return ``0``; hierarchical backends use
+        level ``>= 1`` for refined cells.
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            int: Refinement level (``0`` for a flat grid).
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        self._check_cid(cid)
+        return 0
+
+    def child_cells(self, cid: int) -> tuple[int, ...]:
+        """Return the immediate refinement children of cell ``cid``.
+
+        For a flat (non-hierarchical) grid this is always empty.
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            tuple[int, ...]: Child cell ids; empty for a flat grid.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        self._check_cid(cid)
+        return ()
+
+    def reference_map(self, cid: int) -> AffineTransform:
+        """Return the affine map ``[0, 1]^ndim -> cell`` for cell ``cid``.
+
+        For an axis-aligned cell this is ``T(u) = diag(hi - lo) @ u + lo``.
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            AffineTransform: Push-forward from the unit cube to the cell.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        from ..transform import AffineTransform  # noqa: PLC0415
+
+        lo, hi = self.cell_bounds(cid)
+        return AffineTransform(np.diag(hi - lo), lo)
+
+    def neighbors(self, cid: int) -> list[int]:
+        """Return the facet-neighbour cell ids of ``cid``.
+
+        Built by collecting :meth:`neighbor_across_facet` over every local facet
+        and dropping boundary facets (``None``).
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            list[int]: Neighbouring cell ids; length between ``ndim`` (corner
+            cell) and ``2 * ndim`` (interior cell) for a box grid.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        result: list[int] = []
+        for lfid in range(self.num_local_facets(cid)):
+            neighbor = self.neighbor_across_facet(cid, lfid)
+            if neighbor is not None:
+                result.append(neighbor)
+        return result
+
+    # ------------------------------------------------------------------
+    # Facet accessors (axis-aligned box defaults)
+    # ------------------------------------------------------------------
+
+    def num_local_facets(self, cid: int) -> int:
+        """Return the number of local facets of cell ``cid``.
+
+        Defaults to ``2 * ndim`` (an axis-aligned box).
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            int: ``2 * ndim``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        self._check_cid(cid)
+        return 2 * self.ndim
+
+    def local_facet_axis_side(self, cid: int, lfid: int) -> tuple[int, int]:
+        """Return ``(axis, side)`` for local facet ``lfid`` of cell ``cid``.
+
+        Uses the conventional ``lfid = 2 * axis + side`` encoding, with
+        ``axis in [0, ndim)`` and ``side in {0, 1}`` (``0`` = low face,
+        ``1`` = high face).
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, 2 * ndim)``.
+
+        Returns:
+            tuple[int, int]: ``(axis, side)``.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+        self._check_lfid(cid, lfid)
+        axis, side = divmod(int(lfid), 2)
+        return axis, side
+
+    def local_facet_bounds(
+        self,
+        cid: int,
+        lfid: int,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Return the degenerate ``(lo, hi)`` AABB of facet ``lfid`` of cell ``cid``.
+
+        On the facet's normal axis both corners coincide (the cell's lo corner
+        for ``side == 0``, hi corner for ``side == 1``); the other axes span the
+        cell's extent.
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, 2 * ndim)``.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: Fresh,
+            writeable length-``ndim`` ``float64`` arrays.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+        axis, side = self.local_facet_axis_side(cid, lfid)
+        lo, hi = self.cell_bounds(cid)
+        if side == 0:
+            hi[axis] = lo[axis]
+        else:
+            lo[axis] = hi[axis]
+        return lo, hi
+
+    def is_mesh_boundary_facet(self, cid: int, lfid: int) -> bool:
+        """Return whether facet ``lfid`` of cell ``cid`` is on the grid's outer boundary.
+
+        Defaults to ``neighbor_across_facet(cid, lfid) is None``.
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, num_local_facets(cid))``.
+
+        Returns:
+            bool: ``True`` iff no neighbouring cell shares the facet.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+        return self.neighbor_across_facet(cid, lfid) is None
+
+    # ------------------------------------------------------------------
+    # Point location and spatial queries
+    # ------------------------------------------------------------------
+
+    def locate_many(self, points: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        """Locate a batch of points, returning one cell id per point.
+
+        Points outside the grid map to ``-1``. The default loops over
+        :meth:`locate`; subclasses may override with a vectorized kernel.
+
+        Args:
+            points (npt.ArrayLike): ``(npts, ndim)`` array-like of points, or a
+                single length-``ndim`` point.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(npts,)`` cell ids; ``-1`` for points
+            outside the grid.
+
+        Raises:
+            ValueError: If the trailing axis of ``points`` is not ``ndim``.
+        """
+        pts = self._normalize_points(points)
+        out = np.empty(pts.shape[0], dtype=np.int64)
+        for i in range(pts.shape[0]):
+            cid = self.locate(pts[i])
+            out[i] = -1 if cid is None else cid
+        return out
+
+    def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
+        """Return the ids of every cell whose AABB overlaps ``aabb``.
+
+        Backed by a :class:`pantr.grid.BVH` over the grid's cell AABBs, built
+        lazily on first call and cached for the grid's lifetime. Cells touching
+        ``aabb`` on a shared face are included.
+
+        Args:
+            aabb (AABB): Query box; must match :attr:`ndim`.
+
+        Returns:
+            npt.NDArray[np.int64]: Overlapping cell ids (unordered).
+
+        Raises:
+            ValueError: If ``aabb.ndim != self.ndim``.
+        """
+        return self.cell_bvh().query_aabb(aabb)
+
+    def cell_bvh(self) -> BVH:
+        """Return the cached :class:`pantr.grid.BVH` over the grid's cell AABBs.
+
+        Built lazily on first call from :meth:`_collect_cell_bounds` and cached.
+        Building the BVH materializes ``O(num_cells)`` node arrays, so it is
+        deferred until an :meth:`query_aabb` (or direct) call needs it -- an
+        untagged, un-queried grid never pays this cost.
+
+        Returns:
+            BVH: The grid's spatial index over its cell AABBs.
+        """
+        from ._bvh import BVH  # noqa: PLC0415
+
+        if self._bvh is None:
+            cell_lo, cell_hi = self._collect_cell_bounds()
+            self._bvh = BVH.from_cell_bounds(cell_lo, cell_hi)
+        return self._bvh
+
+    def _collect_cell_bounds(
+        self,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Materialize per-cell ``(lo, hi)`` as ``(num_cells, ndim)`` arrays.
+
+        The default iterates :meth:`cell_bounds` over every cell in id order.
+        Subclasses with structure (for example, tensor-product grids) should
+        override this with a vectorized construction.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+            ``(cell_lo, cell_hi)`` of shape ``(num_cells, ndim)``.
+        """
+        n = self.num_cells
+        cell_lo = np.empty((n, self.ndim), dtype=np.float64)
+        cell_hi = np.empty((n, self.ndim), dtype=np.float64)
+        for cid in range(n):
+            lo, hi = self.cell_bounds(cid)
+            cell_lo[cid] = lo
+            cell_hi[cid] = hi
+        return cell_lo, cell_hi
+
+    # ------------------------------------------------------------------
+    # Tagging
+    # ------------------------------------------------------------------
+
+    @property
+    def cell_tags(self) -> CellTags:
+        """Get the grid's sparse cell-tag registry (created lazily).
+
+        Returns:
+            CellTags: A registry of named ``(cell_ids, values)`` associations,
+            empty until first use.
+        """
+        if self._cell_tags is None:
+            self._cell_tags = CellTags(self.num_cells)
+        return self._cell_tags
+
+    @property
+    def facet_tags(self) -> FacetTags:
+        """Get the grid's sparse facet-tag registry (created lazily).
+
+        Returns:
+            FacetTags: A registry of named ``((cell_id, local_facet_id), value)``
+            associations, empty until first use. Sized for ``2 * ndim`` facets
+            per cell (an axis-aligned box grid).
+        """
+        if self._facet_tags is None:
+            self._facet_tags = FacetTags(self.num_cells, 2 * self.ndim)
+        return self._facet_tags
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check_cid(self, cid: int) -> None:
+        """Raise :class:`IndexError` if ``cid`` is out of range.
+
+        Args:
+            cid (int): Candidate cell identifier.
+
+        Raises:
+            IndexError: If ``cid`` is negative or ``>= num_cells``.
+        """
+        if not 0 <= int(cid) < self.num_cells:
+            raise IndexError(f"cell id {cid!r} is out of range [0, {self.num_cells}).")
+
+    def _check_lfid(self, cid: int, lfid: int) -> None:
+        """Raise :class:`IndexError` if ``lfid`` is not a valid facet of ``cid``.
+
+        Args:
+            cid (int): Cell identifier (validated first).
+            lfid (int): Candidate local facet identifier.
+
+        Raises:
+            IndexError: If ``cid`` is out of range or ``lfid`` is not in
+                ``[0, num_local_facets(cid))``.
+        """
+        self._check_cid(cid)
+        n_facets = self.num_local_facets(cid)
+        if not 0 <= int(lfid) < n_facets:
+            raise IndexError(f"local facet id {lfid!r} is out of range [0, {n_facets}).")
+
+    def _normalize_points(self, points: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        """Coerce ``points`` to a C-contiguous ``(npts, ndim)`` ``float64`` array.
+
+        A single length-``ndim`` point is promoted to shape ``(1, ndim)``.
+
+        Args:
+            points (npt.ArrayLike): Points array-like.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(npts, ndim)``.
+
+        Raises:
+            ValueError: If the trailing axis is not ``ndim`` or the rank is not
+                1 or 2.
+        """
+        arr = _as_float64(points, name="points")
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+        if arr.ndim != 2 or arr.shape[1] != self.ndim:  # noqa: PLR2004
+            raise ValueError(
+                f"points must have shape (npts, {self.ndim}) or ({self.ndim},); "
+                f"got shape {arr.shape}."
+            )
+        return np.ascontiguousarray(arr)
+
+
+__all__ = ["Grid"]

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -63,11 +63,9 @@ class Grid(abc.ABC):
     """Abstract structured cell grid with implicit connectivity.
 
     See the module docstring for the contract and the set of methods a subclass
-    must implement versus those provided as overridable defaults.
-
-    Attributes:
-        ndim (int): Spatial dimension of the grid (``>= 1``).
-        num_cells (int): Number of cells in this (local) grid.
+    must implement versus those provided as overridable defaults. The size
+    metadata is exposed through the :attr:`ndim` and :attr:`num_cells`
+    properties.
     """
 
     __slots__ = ("_bvh", "_cell_tags", "_facet_tags")
@@ -399,7 +397,7 @@ class Grid(abc.ABC):
     def cell_bvh(self) -> BVH:
         """Return the cached :class:`pantr.grid.BVH` over the grid's cell AABBs.
 
-        Built lazily on first call from :meth:`_collect_cell_bounds` and cached.
+        Built lazily on first call from ``_collect_cell_bounds`` and cached.
         Building the BVH materializes ``O(num_cells)`` node arrays, so it is
         deferred until an :meth:`query_aabb` (or direct) call needs it -- an
         untagged, un-queried grid never pays this cost.

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -404,6 +404,11 @@ class Grid(abc.ABC):
 
         Returns:
             BVH: The grid's spatial index over its cell AABBs.
+
+        Warning:
+            Not thread-safe: concurrent first calls from multiple Python threads
+            may each construct and store a separate :class:`BVH` instance.  Call
+            this method once on the main thread before sharing the grid.
         """
         from ._bvh import BVH  # noqa: PLC0415
 
@@ -445,6 +450,10 @@ class Grid(abc.ABC):
         Returns:
             CellTags: A registry of named ``(cell_ids, values)`` associations,
             empty until first use.
+
+        Warning:
+            Not thread-safe on first access.  Create the registry on the main
+            thread before sharing the grid across threads.
         """
         if self._cell_tags is None:
             self._cell_tags = CellTags(self.num_cells)
@@ -458,6 +467,10 @@ class Grid(abc.ABC):
             FacetTags: A registry of named ``((cell_id, local_facet_id), value)``
             associations, empty until first use. Sized for ``2 * ndim`` facets
             per cell (an axis-aligned box grid).
+
+        Warning:
+            Not thread-safe on first access.  Create the registry on the main
+            thread before sharing the grid across threads.
         """
         if self._facet_tags is None:
             self._facet_tags = FacetTags(self.num_cells, 2 * self.ndim)

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -380,8 +380,9 @@ class Grid(abc.ABC):
         """Return the ids of every cell whose AABB overlaps ``aabb``.
 
         Backed by a :class:`pantr.grid.BVH` over the grid's cell AABBs, built
-        lazily on first call and cached for the grid's lifetime. Cells touching
-        ``aabb`` on a shared face are included.
+        lazily on first call and cached for the grid's lifetime. The overlap test
+        is inclusive on every axis, so cells touching ``aabb`` on any face, edge,
+        or corner are included.
 
         Args:
             aabb (AABB): Query box; must match :attr:`ndim`.
@@ -406,9 +407,13 @@ class Grid(abc.ABC):
             BVH: The grid's spatial index over its cell AABBs.
 
         Warning:
-            Not thread-safe: concurrent first calls from multiple Python threads
-            may each construct and store a separate :class:`BVH` instance.  Call
-            this method once on the main thread before sharing the grid.
+            Not fully thread-safe. Under CPython (with the GIL), concurrent
+            first calls may each build a valid :class:`BVH` and the second write
+            silently wins — the only cost is redundant construction. Under
+            free-threaded Python 3.13+ (``--disable-gil``) the assignment is not
+            atomic and a concurrent caller could observe a partially-written
+            reference. Call this method once on the main thread before sharing
+            the grid across threads.
         """
         from ._bvh import BVH  # noqa: PLC0415
 

--- a/src/pantr/grid/_grid_utils.py
+++ b/src/pantr/grid/_grid_utils.py
@@ -1,0 +1,47 @@
+"""Shared Layer-2 helpers for the grid package.
+
+Small validation utilities used across :mod:`pantr.grid`. Kept package-local so
+the grid layer is self-contained and does not reach into another module's
+private API.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+def _as_float64(arr: npt.ArrayLike, *, name: str) -> npt.NDArray[np.float64]:
+    """Coerce ``arr`` to a ``float64`` array, preserving rank.
+
+    Integer and unsigned-integer inputs are cast to ``float64``; boolean and
+    non-numeric inputs are rejected. Results of rank ``>= 1`` are made
+    C-contiguous.
+
+    Args:
+        arr (npt.ArrayLike): Input array or array-like.
+        name (str): Argument name, used in error messages.
+
+    Returns:
+        npt.NDArray[np.float64]: A ``float64`` view or copy of ``arr``. May
+        alias the input when it is already C-contiguous ``float64``; treat as
+        read-only.
+
+    Raises:
+        TypeError: If ``arr`` cannot be converted to an ndarray, or its dtype is
+            neither integer nor floating-point (e.g. boolean, complex, object).
+    """
+    try:
+        a = np.asarray(arr)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} could not be converted to an ndarray: {exc}") from exc
+    if a.dtype.kind not in ("f", "i", "u"):
+        raise TypeError(f"{name} must have a numeric (int or float) dtype; got {a.dtype!r}.")
+    a = a.astype(np.float64, copy=False)
+    if a.ndim >= 1 and not a.flags.c_contiguous:
+        a = np.ascontiguousarray(a)
+    return a

--- a/src/pantr/grid/_locate_core.py
+++ b/src/pantr/grid/_locate_core.py
@@ -1,0 +1,111 @@
+"""Layer-3 Numba kernel for batch point location on a tensor-product grid.
+
+Locating a point on an axis-aligned tensor-product grid reduces to one
+independent binary search per axis: the per-axis cell index is the interval of
+the axis knot vector that contains the coordinate, and the flat cell id is the
+row-major (C-order) combination of the per-axis indices.
+
+The kernel processes a batch of points in parallel. Per-axis knot vectors of
+differing lengths are passed as a single concatenated ``float64`` array plus
+per-axis start offsets and cell counts, which keeps the signature Numba-friendly
+(no ragged list of arrays).
+
+A point exactly on an interior breakpoint is assigned to the lower-indexed cell
+sharing that face; a point on the outer boundary is assigned to the adjacent
+boundary cell. Points outside the grid domain map to ``-1``.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call :meth:`pantr.grid.TensorProductGrid.locate_many`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .._numba_compat import nb_jit, nb_prange
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+@nb_jit(nopython=True, cache=True, parallel=True)
+def _locate_points_core(  # noqa: PLR0913 -- flat tensor-product grid descriptor
+    points: npt.NDArray[np.float64],
+    knots_flat: npt.NDArray[np.float64],
+    knot_starts: npt.NDArray[np.int64],
+    cells_per_axis: npt.NDArray[np.int64],
+    strides: npt.NDArray[np.int64],
+    out: npt.NDArray[np.int64],
+) -> None:
+    """Locate a batch of points on an axis-aligned tensor-product grid.
+
+    Args:
+        points (npt.NDArray[np.float64]): Query points, shape ``(npts, ndim)``.
+        knots_flat (npt.NDArray[np.float64]): All per-axis knot vectors
+            concatenated end to end; axis ``d`` occupies
+            ``knots_flat[knot_starts[d] : knot_starts[d] + cells_per_axis[d] + 1]``
+            and must be strictly increasing.
+        knot_starts (npt.NDArray[np.int64]): Per-axis start offset into
+            ``knots_flat``. Shape ``(ndim,)``.
+        cells_per_axis (npt.NDArray[np.int64]): Per-axis cell counts. Shape
+            ``(ndim,)``.
+        strides (npt.NDArray[np.int64]): Per-axis C-order flat strides. Shape
+            ``(ndim,)``.
+        out (npt.NDArray[np.int64]): Output flat cell ids, shape ``(npts,)``;
+            ``-1`` for points outside the grid domain.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`pantr.grid.TensorProductGrid.locate_many`.
+    """
+    npts = points.shape[0]
+    ndim = points.shape[1]
+    for p in nb_prange(npts):
+        cid = 0
+        inside = True
+        for d in range(ndim):
+            start = knot_starts[d]
+            ncells = cells_per_axis[d]
+            x = points[p, d]
+            if x < knots_flat[start] or x > knots_flat[start + ncells]:
+                inside = False
+                break
+            # lower_bound: first index idx with knots[idx] >= x.
+            lo_i = 0
+            hi_i = ncells + 1
+            while lo_i < hi_i:
+                mid = (lo_i + hi_i) // 2
+                if knots_flat[start + mid] < x:
+                    lo_i = mid + 1
+                else:
+                    hi_i = mid
+            cell_i = lo_i - 1
+            if cell_i < 0:
+                cell_i = 0
+            elif cell_i > ncells - 1:
+                cell_i = ncells - 1
+            cid += cell_i * strides[d]
+        out[p] = cid if inside else -1
+
+
+def _warmup_numba_functions() -> None:
+    """Trigger compilation of the locate kernel on a tiny single-cell grid.
+
+    Provided for explicit, on-demand warmup (for example in benchmarks). It is
+    deliberately *not* called from :mod:`pantr`'s import-time warmup: the grid
+    kernels compile lazily on first use and are cached to disk by Numba's
+    ``cache=True``.
+    """
+    points = np.array([[0.5]], dtype=np.float64)
+    knots_flat = np.array([0.0, 1.0], dtype=np.float64)
+    knot_starts = np.zeros(1, dtype=np.int64)
+    cells_per_axis = np.ones(1, dtype=np.int64)
+    strides = np.ones(1, dtype=np.int64)
+    out = np.empty(1, dtype=np.int64)
+    _locate_points_core(points, knots_flat, knot_starts, cells_per_axis, strides, out)
+
+
+__all__ = ["_locate_points_core"]

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -1,0 +1,421 @@
+"""Sparse named tags for grid cells and facets.
+
+Two lazy registries attach integer labels to a sparse subset of a grid's
+entities, following the model used by ``dolfinx.mesh.MeshTags``: each named tag
+is a pair of parallel arrays ``(ids, values)`` (or ``(keys, values)`` for
+facets). Entities not listed are untagged. This keeps memory proportional to the
+number of *tagged* entities, which suits both whole-grid classification
+(``in`` / ``out`` / ``cut``) and boundary-condition marking on a handful of
+facets.
+
+- :class:`CellTags` -- named ``(cell_ids, values)`` associations, with
+  :meth:`CellTags.to_dense` to scatter a tag into a dense ``(num_cells,)`` array
+  when a downstream Numba kernel needs one.
+- :class:`FacetTags` -- named ``(keys, values)`` associations where each key is a
+  ``(cell_id, local_facet_id)`` pair.
+
+Both registries are created lazily by :class:`pantr.grid.Grid` and stay empty
+(zero per-cell footprint) until the first :meth:`set` call. Classification logic
+(deciding which cells are inside / outside / cut) is the consumer's
+responsibility; these classes only store the result.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import numpy.typing as npt
+
+
+# A facet key is the pair (cell_id, local_facet_id); stored as a (M, 2) array.
+_FACET_KEY_WIDTH: Final[int] = 2
+
+
+def _as_int64_1d(values: npt.ArrayLike, *, name: str) -> npt.NDArray[np.int64]:
+    """Coerce ``values`` to a 1-D ``int64`` array.
+
+    Args:
+        values (npt.ArrayLike): Integer array-like.
+        name (str): Argument name, used in error messages.
+
+    Returns:
+        npt.NDArray[np.int64]: A C-contiguous 1-D ``int64`` array.
+
+    Raises:
+        TypeError: If ``values`` does not have an integer dtype.
+        ValueError: If ``values`` is not 1-D.
+    """
+    arr = np.asarray(values)
+    if arr.dtype.kind not in ("i", "u"):
+        raise TypeError(f"{name} must have an integer dtype; got {arr.dtype!r}.")
+    arr = np.ascontiguousarray(arr.astype(np.int64, copy=False))
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be 1-D; got shape {arr.shape}.")
+    return arr
+
+
+def _broadcast_values(
+    values: npt.ArrayLike,
+    n: int,
+    *,
+    name: str,
+) -> npt.NDArray[np.int64]:
+    """Coerce ``values`` to an ``int64`` array of length ``n`` (scalars broadcast).
+
+    Args:
+        values (npt.ArrayLike): Scalar integer or length-``n`` integer
+            array-like.
+        n (int): Required length.
+        name (str): Argument name, used in error messages.
+
+    Returns:
+        npt.NDArray[np.int64]: A fresh, writeable length-``n`` ``int64`` array.
+
+    Raises:
+        TypeError: If ``values`` does not have an integer dtype.
+        ValueError: If ``values`` is array-like with a length other than ``n``.
+    """
+    arr = np.asarray(values)
+    if arr.dtype.kind not in ("i", "u"):
+        raise TypeError(f"{name} must have an integer dtype; got {arr.dtype!r}.")
+    if arr.ndim == 0:
+        return np.full(n, int(arr), dtype=np.int64)
+    flat = np.ascontiguousarray(arr.astype(np.int64, copy=False)).ravel()
+    if flat.shape[0] != n:
+        raise ValueError(f"{name} must be a scalar or have length {n}; got length {flat.shape[0]}.")
+    return flat
+
+
+class CellTags:
+    """Sparse named integer tags over a grid's cells.
+
+    Each tag named ``name`` is a pair of parallel ``int64`` arrays
+    ``(ids, values)`` sorted by ``ids``; a cell not listed in ``ids`` is
+    untagged under ``name``. Distinct tag names are independent.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid; cell ids must lie
+            in ``[0, num_cells)``.
+    """
+
+    __slots__ = ("_num_cells", "_tags")
+
+    def __init__(self, num_cells: int) -> None:
+        """Create an empty cell-tag registry.
+
+        Args:
+            num_cells (int): Number of cells in the owning grid (``>= 0``).
+
+        Raises:
+            ValueError: If ``num_cells`` is negative.
+        """
+        if int(num_cells) < 0:
+            raise ValueError(f"num_cells must be >= 0; got {num_cells}.")
+        self._num_cells = int(num_cells)
+        self._tags: dict[str, tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]] = {}
+
+    @property
+    def num_cells(self) -> int:
+        """Get the number of cells in the owning grid.
+
+        Returns:
+            int: The cell count; valid cell ids are ``[0, num_cells)``.
+        """
+        return self._num_cells
+
+    def set(self, name: str, ids: npt.ArrayLike, values: npt.ArrayLike) -> None:
+        """Create or replace the tag ``name`` with the association ``ids -> values``.
+
+        Args:
+            name (str): Tag name. Replaces any existing tag with the same name.
+            ids (npt.ArrayLike): 1-D integer array-like of cell ids; each must
+                satisfy ``0 <= id < num_cells`` and be unique.
+            values (npt.ArrayLike): Scalar integer (broadcast to every id) or a
+                1-D integer array-like of the same length as ``ids``.
+
+        Raises:
+            TypeError: If ``ids`` or ``values`` is not integer-typed.
+            ValueError: If ``ids`` is not 1-D, contains duplicates, or has an id
+                out of range, or if ``values`` has a length other than
+                ``len(ids)``.
+        """
+        id_arr = _as_int64_1d(ids, name="ids")
+        if id_arr.shape[0] > 0 and (int(id_arr.min()) < 0 or int(id_arr.max()) >= self._num_cells):
+            raise ValueError(
+                f"cell ids must be in [0, {self._num_cells}); "
+                f"got range [{int(id_arr.min())}, {int(id_arr.max())}]."
+            )
+        if np.unique(id_arr).shape[0] != id_arr.shape[0]:
+            raise ValueError(f"cell ids for tag {name!r} must be unique; got duplicates.")
+        val_arr = _broadcast_values(values, id_arr.shape[0], name="values")
+        order = np.argsort(id_arr, kind="stable")
+        sorted_ids = np.ascontiguousarray(id_arr[order])
+        sorted_vals = np.ascontiguousarray(val_arr[order])
+        sorted_ids.flags.writeable = False
+        sorted_vals.flags.writeable = False
+        self._tags[str(name)] = (sorted_ids, sorted_vals)
+
+    def __getitem__(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        """Return the ``(ids, values)`` arrays for tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Returns:
+            tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: Read-only
+            ``(ids, values)`` arrays sorted by ``ids``.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        return self._tags[name]
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag.
+        """
+        return name in self._tags
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the registered tag names.
+
+        Returns:
+            Iterator[str]: Iterator over tag names in insertion order.
+        """
+        return iter(self._tags)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._tags)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._tags)
+
+    def remove(self, name: str) -> None:
+        """Delete the tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        del self._tags[name]
+
+    def to_dense(
+        self,
+        name: str,
+        *,
+        fill: int = 0,
+        dtype: npt.DTypeLike = np.int64,
+    ) -> npt.NDArray[np.int_]:
+        """Scatter tag ``name`` into a dense ``(num_cells,)`` array.
+
+        Untagged cells receive ``fill``. Useful when a downstream Numba kernel
+        wants a per-cell label array rather than the sparse representation.
+
+        Args:
+            name (str): Tag name.
+            fill (int): Value for untagged cells. Defaults to ``0``.
+            dtype (npt.DTypeLike): Output integer dtype. Defaults to
+                :data:`numpy.int64`.
+
+        Returns:
+            npt.NDArray[np.int_]: Fresh, writeable ``(num_cells,)`` array.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        ids, values = self._tags[name]
+        out = np.full(self._num_cells, fill, dtype=dtype)
+        out[ids] = values
+        return out
+
+
+class FacetTags:
+    """Sparse named integer tags over a grid's local facets.
+
+    Each facet is addressed by a ``(cell_id, local_facet_id)`` key, with
+    ``local_facet_id`` in ``[0, facets_per_cell)``. Each tag named ``name`` is a
+    pair ``(keys, values)`` where ``keys`` is an ``(M, 2)`` ``int64`` array of
+    ``(cell_id, local_facet_id)`` rows and ``values`` is a length-``M``
+    ``int64`` array, sorted lexicographically by key.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        facets_per_cell (int): Number of local facets per cell (``2 * ndim`` for
+            an axis-aligned box grid).
+    """
+
+    __slots__ = ("_facets_per_cell", "_num_cells", "_tags")
+
+    def __init__(self, num_cells: int, facets_per_cell: int) -> None:
+        """Create an empty facet-tag registry.
+
+        Args:
+            num_cells (int): Number of cells in the owning grid (``>= 0``).
+            facets_per_cell (int): Number of local facets per cell (``>= 1``).
+
+        Raises:
+            ValueError: If ``num_cells`` is negative or ``facets_per_cell`` is
+                ``< 1``.
+        """
+        if int(num_cells) < 0:
+            raise ValueError(f"num_cells must be >= 0; got {num_cells}.")
+        if int(facets_per_cell) < 1:
+            raise ValueError(f"facets_per_cell must be >= 1; got {facets_per_cell}.")
+        self._num_cells = int(num_cells)
+        self._facets_per_cell = int(facets_per_cell)
+        self._tags: dict[str, tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]] = {}
+
+    @property
+    def num_cells(self) -> int:
+        """Get the number of cells in the owning grid.
+
+        Returns:
+            int: The cell count.
+        """
+        return self._num_cells
+
+    @property
+    def facets_per_cell(self) -> int:
+        """Get the number of local facets per cell.
+
+        Returns:
+            int: ``2 * ndim`` for an axis-aligned box grid.
+        """
+        return self._facets_per_cell
+
+    def set(self, name: str, keys: npt.ArrayLike, values: npt.ArrayLike) -> None:
+        """Create or replace the tag ``name`` with the association ``keys -> values``.
+
+        Args:
+            name (str): Tag name. Replaces any existing tag with the same name.
+            keys (npt.ArrayLike): ``(M, 2)`` integer array-like of
+                ``(cell_id, local_facet_id)`` rows; each row must be unique with
+                ``0 <= cell_id < num_cells`` and
+                ``0 <= local_facet_id < facets_per_cell``.
+            values (npt.ArrayLike): Scalar integer (broadcast to every key) or a
+                1-D integer array-like of length ``M``.
+
+        Raises:
+            TypeError: If ``keys`` or ``values`` is not integer-typed.
+            ValueError: If ``keys`` does not have shape ``(M, 2)``, contains a
+                duplicate or out-of-range key, or ``values`` has a length other
+                than ``M``.
+        """
+        key_raw = np.asarray(keys)
+        if key_raw.dtype.kind not in ("i", "u"):
+            raise TypeError(f"keys must have an integer dtype; got {key_raw.dtype!r}.")
+        key_arr = np.ascontiguousarray(key_raw.astype(np.int64, copy=False))
+        if key_arr.ndim != _FACET_KEY_WIDTH or key_arr.shape[1] != _FACET_KEY_WIDTH:
+            raise ValueError(f"keys must have shape (M, 2); got shape {key_arr.shape}.")
+        if key_arr.shape[0] > 0:
+            cids = key_arr[:, 0]
+            lfids = key_arr[:, 1]
+            if int(cids.min()) < 0 or int(cids.max()) >= self._num_cells:
+                raise ValueError(
+                    f"facet cell ids must be in [0, {self._num_cells}); "
+                    f"got range [{int(cids.min())}, {int(cids.max())}]."
+                )
+            if int(lfids.min()) < 0 or int(lfids.max()) >= self._facets_per_cell:
+                raise ValueError(
+                    f"local facet ids must be in [0, {self._facets_per_cell}); "
+                    f"got range [{int(lfids.min())}, {int(lfids.max())}]."
+                )
+            if np.unique(key_arr, axis=0).shape[0] != key_arr.shape[0]:
+                raise ValueError(f"facet keys for tag {name!r} must be unique; got duplicates.")
+        val_arr = _broadcast_values(values, key_arr.shape[0], name="values")
+        # Lexicographic sort by (cell_id, local_facet_id) for deterministic order.
+        order = np.lexsort((key_arr[:, 1], key_arr[:, 0]))
+        sorted_keys = np.ascontiguousarray(key_arr[order])
+        sorted_vals = np.ascontiguousarray(val_arr[order])
+        sorted_keys.flags.writeable = False
+        sorted_vals.flags.writeable = False
+        self._tags[str(name)] = (sorted_keys, sorted_vals)
+
+    def __getitem__(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        """Return the ``(keys, values)`` arrays for tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Returns:
+            tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: Read-only
+            ``(keys, values)`` where ``keys`` has shape ``(M, 2)`` and is sorted
+            lexicographically.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        return self._tags[name]
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag.
+        """
+        return name in self._tags
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the registered tag names.
+
+        Returns:
+            Iterator[str]: Iterator over tag names in insertion order.
+        """
+        return iter(self._tags)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._tags)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._tags)
+
+    def remove(self, name: str) -> None:
+        """Delete the tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        del self._tags[name]
+
+
+__all__ = ["CellTags", "FacetTags"]

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -242,11 +242,22 @@ class CellTags:
 
         Raises:
             KeyError: If no tag named ``name`` exists.
+            TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
         """
+        if np.dtype(dtype).kind not in ("i", "u"):
+            raise TypeError(f"dtype must be an integer dtype; got {np.dtype(dtype)!r}.")
         ids, values = self._tags[name]
         out = np.full(self._num_cells, fill, dtype=dtype)
         out[ids] = values
         return out
+
+    def __repr__(self) -> str:
+        """Return a concise representation showing the cell count and tag names.
+
+        Returns:
+            str: ``"CellTags(num_cells=..., tags=[...])"``
+        """
+        return f"CellTags(num_cells={self._num_cells}, tags={list(self._tags)!r})"
 
 
 class FacetTags:
@@ -322,7 +333,7 @@ class FacetTags:
         if key_raw.dtype.kind not in ("i", "u"):
             raise TypeError(f"keys must have an integer dtype; got {key_raw.dtype!r}.")
         key_arr = np.ascontiguousarray(key_raw.astype(np.int64, copy=False))
-        if key_arr.ndim != _FACET_KEY_WIDTH or key_arr.shape[1] != _FACET_KEY_WIDTH:
+        if key_arr.ndim != 2 or key_arr.shape[1] != _FACET_KEY_WIDTH:  # noqa: PLR2004
             raise ValueError(f"keys must have shape (M, 2); got shape {key_arr.shape}.")
         if key_arr.shape[0] > 0:
             cids = key_arr[:, 0]
@@ -410,6 +421,52 @@ class FacetTags:
             KeyError: If no tag named ``name`` exists.
         """
         del self._tags[name]
+
+    def to_dense(
+        self,
+        name: str,
+        *,
+        fill: int = 0,
+        dtype: npt.DTypeLike = np.int64,
+    ) -> npt.NDArray[np.int_]:
+        r"""Scatter tag ``name`` into a dense ``(num_cells, facets_per_cell)`` array.
+
+        Untagged facets receive ``fill``. Useful when a downstream Numba kernel
+        wants a per-facet label array rather than the sparse representation.
+
+        Args:
+            name (str): Tag name.
+            fill (int): Value for untagged facets. Defaults to ``0``.
+            dtype (npt.DTypeLike): Output integer dtype. Defaults to
+                ``numpy.int64``.
+
+        Returns:
+            npt.NDArray[np.int\_]: Fresh, writeable
+            ``(num_cells, facets_per_cell)`` array.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+            TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
+        """
+        if np.dtype(dtype).kind not in ("i", "u"):
+            raise TypeError(f"dtype must be an integer dtype; got {np.dtype(dtype)!r}.")
+        keys, values = self._tags[name]
+        out = np.full((self._num_cells, self._facets_per_cell), fill, dtype=dtype)
+        if keys.shape[0] > 0:
+            out[keys[:, 0], keys[:, 1]] = values
+        return out
+
+    def __repr__(self) -> str:
+        """Return a concise representation showing the cell/facet counts and tag names.
+
+        Returns:
+            str: ``"FacetTags(num_cells=..., facets_per_cell=..., tags=[...])"``
+        """
+        return (
+            f"FacetTags(num_cells={self._num_cells}, "
+            f"facets_per_cell={self._facets_per_cell}, "
+            f"tags={list(self._tags)!r})"
+        )
 
 
 __all__ = ["CellTags", "FacetTags"]

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -96,11 +96,8 @@ class CellTags:
 
     Each tag named ``name`` is a pair of parallel ``int64`` arrays
     ``(ids, values)`` sorted by ``ids``; a cell not listed in ``ids`` is
-    untagged under ``name``. Distinct tag names are independent.
-
-    Attributes:
-        num_cells (int): Number of cells in the owning grid; cell ids must lie
-            in ``[0, num_cells)``.
+    untagged under ``name``. Distinct tag names are independent. The owning
+    grid's cell count is exposed through the :attr:`num_cells` property.
     """
 
     __slots__ = ("_num_cells", "_tags")
@@ -229,7 +226,7 @@ class CellTags:
         fill: int = 0,
         dtype: npt.DTypeLike = np.int64,
     ) -> npt.NDArray[np.int_]:
-        """Scatter tag ``name`` into a dense ``(num_cells,)`` array.
+        r"""Scatter tag ``name`` into a dense ``(num_cells,)`` array.
 
         Untagged cells receive ``fill``. Useful when a downstream Numba kernel
         wants a per-cell label array rather than the sparse representation.
@@ -238,10 +235,10 @@ class CellTags:
             name (str): Tag name.
             fill (int): Value for untagged cells. Defaults to ``0``.
             dtype (npt.DTypeLike): Output integer dtype. Defaults to
-                :data:`numpy.int64`.
+                ``numpy.int64``.
 
         Returns:
-            npt.NDArray[np.int_]: Fresh, writeable ``(num_cells,)`` array.
+            npt.NDArray[np.int\_]: Fresh, writeable ``(num_cells,)`` array.
 
         Raises:
             KeyError: If no tag named ``name`` exists.
@@ -259,12 +256,9 @@ class FacetTags:
     ``local_facet_id`` in ``[0, facets_per_cell)``. Each tag named ``name`` is a
     pair ``(keys, values)`` where ``keys`` is an ``(M, 2)`` ``int64`` array of
     ``(cell_id, local_facet_id)`` rows and ``values`` is a length-``M``
-    ``int64`` array, sorted lexicographically by key.
-
-    Attributes:
-        num_cells (int): Number of cells in the owning grid.
-        facets_per_cell (int): Number of local facets per cell (``2 * ndim`` for
-            an axis-aligned box grid).
+    ``int64`` array, sorted lexicographically by key. The owning grid's cell
+    count and per-cell facet count are exposed through the :attr:`num_cells` and
+    :attr:`facets_per_cell` properties.
     """
 
     __slots__ = ("_facets_per_cell", "_num_cells", "_tags")

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -22,7 +22,7 @@ responsibility; these classes only store the result.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import numpy as np
 
@@ -225,7 +225,7 @@ class CellTags:
         *,
         fill: int = 0,
         dtype: npt.DTypeLike = np.int64,
-    ) -> npt.NDArray[np.int_]:
+    ) -> npt.NDArray[Any]:
         r"""Scatter tag ``name`` into a dense ``(num_cells,)`` array.
 
         Untagged cells receive ``fill``. Useful when a downstream Numba kernel
@@ -235,19 +235,35 @@ class CellTags:
             name (str): Tag name.
             fill (int): Value for untagged cells. Defaults to ``0``.
             dtype (npt.DTypeLike): Output integer dtype. Defaults to
-                ``numpy.int64``.
+                ``numpy.int64``. Values are stored as ``int64`` internally; if
+                ``dtype`` is narrower than ``int64`` and any stored value falls
+                outside the dtype's representable range, an ``OverflowError`` is
+                raised rather than silently truncating the value.
 
         Returns:
-            npt.NDArray[np.int\_]: Fresh, writeable ``(num_cells,)`` array.
+            npt.NDArray[Any]: Fresh, writeable ``(num_cells,)`` array with
+            ``dtype`` as the scalar type.
 
         Raises:
             KeyError: If no tag named ``name`` exists.
             TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
+            OverflowError: If any stored value cannot be represented exactly in
+                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``).
         """
-        if np.dtype(dtype).kind not in ("i", "u"):
-            raise TypeError(f"dtype must be an integer dtype; got {np.dtype(dtype)!r}.")
+        out_dtype = np.dtype(dtype)
+        if out_dtype.kind not in ("i", "u"):
+            raise TypeError(f"dtype must be an integer dtype; got {out_dtype!r}.")
         ids, values = self._tags[name]
-        out = np.full(self._num_cells, fill, dtype=dtype)
+        if ids.shape[0] > 0 and out_dtype.itemsize < 8:  # noqa: PLR2004
+            info = np.iinfo(out_dtype)
+            vmin, vmax = int(values.min()), int(values.max())
+            if vmin < info.min or vmax > info.max:
+                raise OverflowError(
+                    f"dtype {out_dtype!r} cannot represent all tag values without "
+                    f"truncation; value range [{vmin}, {vmax}] exceeds "
+                    f"dtype range [{info.min}, {info.max}]."
+                )
+        out = np.full(self._num_cells, fill, dtype=out_dtype)
         out[ids] = values
         return out
 
@@ -428,7 +444,7 @@ class FacetTags:
         *,
         fill: int = 0,
         dtype: npt.DTypeLike = np.int64,
-    ) -> npt.NDArray[np.int_]:
+    ) -> npt.NDArray[Any]:
         r"""Scatter tag ``name`` into a dense ``(num_cells, facets_per_cell)`` array.
 
         Untagged facets receive ``fill``. Useful when a downstream Numba kernel
@@ -438,20 +454,35 @@ class FacetTags:
             name (str): Tag name.
             fill (int): Value for untagged facets. Defaults to ``0``.
             dtype (npt.DTypeLike): Output integer dtype. Defaults to
-                ``numpy.int64``.
+                ``numpy.int64``. Values are stored as ``int64`` internally; if
+                ``dtype`` is narrower than ``int64`` and any stored value falls
+                outside the dtype's representable range, an ``OverflowError`` is
+                raised rather than silently truncating the value.
 
         Returns:
-            npt.NDArray[np.int\_]: Fresh, writeable
-            ``(num_cells, facets_per_cell)`` array.
+            npt.NDArray[Any]: Fresh, writeable ``(num_cells, facets_per_cell)``
+            array with ``dtype`` as the scalar type.
 
         Raises:
             KeyError: If no tag named ``name`` exists.
             TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
+            OverflowError: If any stored value cannot be represented exactly in
+                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``).
         """
-        if np.dtype(dtype).kind not in ("i", "u"):
-            raise TypeError(f"dtype must be an integer dtype; got {np.dtype(dtype)!r}.")
+        out_dtype = np.dtype(dtype)
+        if out_dtype.kind not in ("i", "u"):
+            raise TypeError(f"dtype must be an integer dtype; got {out_dtype!r}.")
         keys, values = self._tags[name]
-        out = np.full((self._num_cells, self._facets_per_cell), fill, dtype=dtype)
+        if keys.shape[0] > 0 and out_dtype.itemsize < 8:  # noqa: PLR2004
+            info = np.iinfo(out_dtype)
+            vmin, vmax = int(values.min()), int(values.max())
+            if vmin < info.min or vmax > info.max:
+                raise OverflowError(
+                    f"dtype {out_dtype!r} cannot represent all tag values without "
+                    f"truncation; value range [{vmin}, {vmax}] exceeds "
+                    f"dtype range [{info.min}, {info.max}]."
+                )
+        out = np.full((self._num_cells, self._facets_per_cell), fill, dtype=out_dtype)
         if keys.shape[0] > 0:
             out[keys[:, 0], keys[:, 1]] = values
         return out

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -46,12 +46,33 @@ if TYPE_CHECKING:
 
     from ..bspline import BsplineSpace
 
-# Absolute tolerance for detecting uniform per-axis spacing. Chosen so a
-# ``1e6``-cell uniform grid still registers as uniform despite double-precision
-# round-off from the ``linspace`` that generated it.
-_UNIFORM_SPACING_ATOL: Final[float] = 1e-10
+# Relative tolerance for detecting uniform per-axis spacing. Applied as
+# ``ptp(diff) < _UNIFORM_SPACING_RTOL * mean(diff)`` so the check scales with
+# the actual breakpoint spacing and works correctly for grids at any physical
+# scale (e.g. millimetre meshes or kilometre-scale domains).
+_UNIFORM_SPACING_RTOL: Final[float] = 1e-10
 # Smallest useful grid: at least one cell per axis (two breakpoints).
 _MIN_BREAKPOINTS_PER_AXIS: Final[int] = 2
+
+
+def _is_axis_uniform(bp: npt.NDArray[np.float64]) -> bool:
+    """Return whether the breakpoint vector ``bp`` has uniform spacing.
+
+    A single-interval axis (two breakpoints) is vacuously uniform. Longer
+    axes use a relative tolerance: ``ptp(diff) < RTOL * mean(diff)``.
+
+    Args:
+        bp (npt.NDArray[np.float64]): Strictly increasing breakpoint vector,
+            length ``>= 2``.
+
+    Returns:
+        bool: ``True`` iff the spacing is uniform to within
+        ``_UNIFORM_SPACING_RTOL``.
+    """
+    if bp.shape[0] <= 2:  # noqa: PLR2004
+        return True
+    diff = np.diff(bp)
+    return bool(float(np.ptp(diff)) < _UNIFORM_SPACING_RTOL * float(diff.mean()))
 
 
 class TensorProductGrid(Grid):
@@ -120,10 +141,7 @@ class TensorProductGrid(Grid):
         self._bounds = bounds
         self._strides = c_order_strides(self._cells_per_axis)
         self._strides.flags.writeable = False
-        self._is_uniform = all(
-            bool(np.ptp(np.diff(bp)) < _UNIFORM_SPACING_ATOL) if bp.shape[0] > 2 else True  # noqa: PLR2004
-            for bp in self._breakpoints
-        )
+        self._is_uniform = all(_is_axis_uniform(bp) for bp in self._breakpoints)
 
     # ------------------------------------------------------------------
     # Read-only attributes
@@ -334,7 +352,7 @@ class TensorProductGrid(Grid):
     def _collect_cell_bounds(
         self,
     ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
-        """Materialize per-cell ``(lo, hi)`` in C-order via per-axis broadcasting.
+        """Materialize per-cell ``(lo, hi)`` in C-order via meshgrid and fancy indexing.
 
         Returns:
             tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
@@ -356,7 +374,7 @@ class TensorProductGrid(Grid):
         """Return a compact representation useful for debugging.
 
         Returns:
-            str: ``"TensorProductGrid(ndim=..., cells_per_axis=...)"``.
+            str: ``"TensorProductGrid(ndim=..., cells_per_axis=..., uniform=...)"``
         """
         return (
             f"TensorProductGrid(ndim={self._ndim}, cells_per_axis={self._cells_per_axis}, "

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -59,17 +59,9 @@ class TensorProductGrid(Grid):
 
     Cells are numbered in row-major (C) order over :attr:`cells_per_axis` (last
     axis varies fastest). See the module docstring for the footprint and
-    construction notes.
-
-    Attributes:
-        ndim (int): Spatial dimension (``>= 1``).
-        num_cells (int): Total number of cells (product of per-axis counts).
-        cells_per_axis (tuple[int, ...]): Per-axis cell counts.
-        breakpoints (tuple[npt.NDArray[np.float64], ...]): Per-axis strictly
-            increasing breakpoint arrays; ``breakpoints[d]`` has length
-            ``cells_per_axis[d] + 1``.
-        bounds (npt.NDArray[np.float64]): ``(ndim, 2)`` array of per-axis
-            ``[lo, hi]`` extremes.
+    construction notes. Size and geometry metadata are exposed through the
+    :attr:`ndim`, :attr:`num_cells`, :attr:`cells_per_axis`, :attr:`breakpoints`,
+    and :attr:`bounds` properties.
     """
 
     __slots__ = (

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -30,6 +30,7 @@ Construction
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
@@ -132,7 +133,7 @@ class TensorProductGrid(Grid):
         self._ndim = ndim
         self._breakpoints = tuple(validated)
         self._cells_per_axis = tuple(cells_per_axis)
-        self._num_cells = int(np.prod(self._cells_per_axis))
+        self._num_cells = math.prod(self._cells_per_axis)
         bounds = np.empty((ndim, 2), dtype=np.float64)
         for d in range(ndim):
             bounds[d, 0] = self._breakpoints[d][0]
@@ -198,8 +199,8 @@ class TensorProductGrid(Grid):
         """Get whether every axis has uniform breakpoint spacing.
 
         Returns:
-            bool: ``True`` iff each axis's spacing is constant to within an
-            absolute tolerance.
+            bool: ``True`` iff each axis's spacing is constant to within a
+            relative tolerance (``_UNIFORM_SPACING_RTOL``).
         """
         return self._is_uniform
 

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -1,0 +1,450 @@
+"""Tensor-product grid with per-axis breakpoint vectors.
+
+:class:`TensorProductGrid` is the first-class concrete :class:`pantr.grid.Grid`:
+a tensor product of axis-aligned boxes, stored as one strictly-increasing
+breakpoint array per axis. A cell is addressed by a flat row-major (C-order)
+identifier; see :mod:`pantr.grid._cell_index` for the convention, which matches
+:class:`pantr.bspline.SpanwiseElementExtraction` so a grid and an extraction
+operator built on the same :class:`pantr.bspline.BsplineSpace` agree on cell ids.
+
+Footprint
+---------
+
+The grid stores only references to the per-axis breakpoint arrays (total size
+``sum_k (cells_per_axis[k] + 1)``) plus a handful of small metadata arrays. It
+never materializes per-cell bounds or connectivity -- those are computed on
+demand. The only ``O(num_cells)`` structure, the :class:`pantr.grid.BVH` behind
+:meth:`~pantr.grid.Grid.query_aabb`, is built lazily on first query, so a grid
+used purely for geometry (the common case for a B-spline knot grid) stays
+proportional to the breakpoints, not to the cell count.
+
+Construction
+------------
+
+- ``TensorProductGrid(breakpoints)`` -- from explicit per-axis breakpoint arrays.
+- :func:`uniform_grid` -- a uniform grid on a bounding box with given per-axis
+  cell counts.
+- :func:`tensor_product_grid` -- the knot-span grid of a
+  :class:`pantr.bspline.BsplineSpace` (its per-axis unique in-domain knots).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+from ._cell_index import c_order_strides, flat_to_multi, multi_to_flat
+from ._grid import Grid
+from ._grid_utils import _as_float64
+from ._locate_core import _locate_points_core
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy.typing as npt
+
+    from ..bspline import BsplineSpace
+
+# Absolute tolerance for detecting uniform per-axis spacing. Chosen so a
+# ``1e6``-cell uniform grid still registers as uniform despite double-precision
+# round-off from the ``linspace`` that generated it.
+_UNIFORM_SPACING_ATOL: Final[float] = 1e-10
+# Smallest useful grid: at least one cell per axis (two breakpoints).
+_MIN_BREAKPOINTS_PER_AXIS: Final[int] = 2
+
+
+class TensorProductGrid(Grid):
+    """Tensor-product grid of axis-aligned boxes with per-axis breakpoints.
+
+    Cells are numbered in row-major (C) order over :attr:`cells_per_axis` (last
+    axis varies fastest). See the module docstring for the footprint and
+    construction notes.
+
+    Attributes:
+        ndim (int): Spatial dimension (``>= 1``).
+        num_cells (int): Total number of cells (product of per-axis counts).
+        cells_per_axis (tuple[int, ...]): Per-axis cell counts.
+        breakpoints (tuple[npt.NDArray[np.float64], ...]): Per-axis strictly
+            increasing breakpoint arrays; ``breakpoints[d]`` has length
+            ``cells_per_axis[d] + 1``.
+        bounds (npt.NDArray[np.float64]): ``(ndim, 2)`` array of per-axis
+            ``[lo, hi]`` extremes.
+    """
+
+    __slots__ = (
+        "_bounds",
+        "_breakpoints",
+        "_cells_per_axis",
+        "_is_uniform",
+        "_ndim",
+        "_num_cells",
+        "_strides",
+    )
+
+    def __init__(self, breakpoints: Sequence[npt.ArrayLike]) -> None:
+        """Build a tensor-product grid from per-axis breakpoint vectors.
+
+        Args:
+            breakpoints (Sequence[npt.ArrayLike]): One strictly increasing
+                ``float64`` array-like per axis, each of length
+                ``cells_per_axis[d] + 1 >= 2``.
+
+        Raises:
+            ValueError: If ``breakpoints`` is empty, any axis has fewer than two
+                entries, or any axis is non-finite or not strictly increasing.
+            TypeError: If a breakpoint array cannot be cast to ``float64``.
+        """
+        super().__init__()
+        ndim = len(breakpoints)
+        if ndim < 1:
+            raise ValueError(f"TensorProductGrid needs at least one axis; got {ndim}.")
+        validated: list[npt.NDArray[np.float64]] = []
+        cells_per_axis: list[int] = []
+        for d, bp in enumerate(breakpoints):
+            arr = _as_float64(bp, name=f"breakpoints[{d}]").ravel()
+            if arr.shape[0] < _MIN_BREAKPOINTS_PER_AXIS:
+                raise ValueError(
+                    f"breakpoints[{d}] must have at least {_MIN_BREAKPOINTS_PER_AXIS} entries "
+                    f"(>= 1 cell); got shape {arr.shape}."
+                )
+            if not np.all(np.isfinite(arr)):
+                raise ValueError(f"breakpoints[{d}] must contain only finite values.")
+            if not np.all(np.diff(arr) > 0.0):
+                raise ValueError(f"breakpoints[{d}] must be strictly increasing.")
+            frozen = np.ascontiguousarray(arr.copy(), dtype=np.float64)
+            frozen.flags.writeable = False
+            validated.append(frozen)
+            cells_per_axis.append(int(frozen.shape[0]) - 1)
+        self._ndim = ndim
+        self._breakpoints = tuple(validated)
+        self._cells_per_axis = tuple(cells_per_axis)
+        self._num_cells = int(np.prod(self._cells_per_axis))
+        bounds = np.empty((ndim, 2), dtype=np.float64)
+        for d in range(ndim):
+            bounds[d, 0] = self._breakpoints[d][0]
+            bounds[d, 1] = self._breakpoints[d][-1]
+        bounds.flags.writeable = False
+        self._bounds = bounds
+        self._strides = c_order_strides(self._cells_per_axis)
+        self._strides.flags.writeable = False
+        self._is_uniform = all(
+            bool(np.ptp(np.diff(bp)) < _UNIFORM_SPACING_ATOL) if bp.shape[0] > 2 else True  # noqa: PLR2004
+            for bp in self._breakpoints
+        )
+
+    # ------------------------------------------------------------------
+    # Read-only attributes
+    # ------------------------------------------------------------------
+
+    @property
+    def ndim(self) -> int:
+        """Get the spatial dimension of the grid.
+
+        Returns:
+            int: Number of axes (``>= 1``).
+        """
+        return self._ndim
+
+    @property
+    def num_cells(self) -> int:
+        """Get the total number of cells.
+
+        Returns:
+            int: Product of the per-axis cell counts.
+        """
+        return self._num_cells
+
+    @property
+    def cells_per_axis(self) -> tuple[int, ...]:
+        """Get the per-axis cell counts.
+
+        Returns:
+            tuple[int, ...]: Length-``ndim`` tuple of per-axis counts.
+        """
+        return self._cells_per_axis
+
+    @property
+    def breakpoints(self) -> tuple[npt.NDArray[np.float64], ...]:
+        """Get the per-axis strictly increasing breakpoint arrays.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], ...]: Read-only ``float64`` arrays;
+            ``breakpoints[d]`` has length ``cells_per_axis[d] + 1``.
+        """
+        return self._breakpoints
+
+    @property
+    def bounds(self) -> npt.NDArray[np.float64]:
+        """Get the per-axis ``[lo, hi]`` extremes.
+
+        Returns:
+            npt.NDArray[np.float64]: Read-only ``(ndim, 2)`` array.
+        """
+        return self._bounds
+
+    @property
+    def is_uniform(self) -> bool:
+        """Get whether every axis has uniform breakpoint spacing.
+
+        Returns:
+            bool: ``True`` iff each axis's spacing is constant to within an
+            absolute tolerance.
+        """
+        return self._is_uniform
+
+    # ------------------------------------------------------------------
+    # Index helpers (row-major C-order)
+    # ------------------------------------------------------------------
+
+    def cell_multi_index(self, cid: int) -> tuple[int, ...]:
+        """Return the per-axis indices ``(i_0, ..., i_{ndim-1})`` of cell ``cid``.
+
+        Args:
+            cid (int): Flat cell identifier.
+
+        Returns:
+            tuple[int, ...]: Length-``ndim`` per-axis index tuple (C-order).
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        return flat_to_multi(int(cid), self._cells_per_axis)
+
+    def flat_cell_index(self, multi: Sequence[int]) -> int:
+        """Map per-axis cell indices to the flat cell identifier (C-order).
+
+        Args:
+            multi (Sequence[int]): Length-``ndim`` per-axis indices; each entry
+                must satisfy ``0 <= i_k < cells_per_axis[k]``.
+
+        Returns:
+            int: Flat cell identifier.
+
+        Raises:
+            ValueError: If ``len(multi) != ndim``.
+            IndexError: If any per-axis index is out of range.
+        """
+        return multi_to_flat(multi, self._cells_per_axis)
+
+    # ------------------------------------------------------------------
+    # Grid contract overrides
+    # ------------------------------------------------------------------
+
+    def cell_bounds(
+        self,
+        cid: int,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Return cell ``cid``'s axis-aligned ``(lo, hi)`` corners.
+
+        Args:
+            cid (int): Cell identifier.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: Fresh,
+            writeable length-``ndim`` ``float64`` arrays.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        multi = self.cell_multi_index(cid)
+        lo = np.empty(self._ndim, dtype=np.float64)
+        hi = np.empty(self._ndim, dtype=np.float64)
+        for d, i in enumerate(multi):
+            lo[d] = self._breakpoints[d][i]
+            hi[d] = self._breakpoints[d][i + 1]
+        return lo, hi
+
+    def locate(self, pt: npt.ArrayLike) -> int | None:
+        """Return the cell containing ``pt``, or ``None`` if ``pt`` is outside.
+
+        A point exactly on an interior breakpoint is assigned to the
+        lower-indexed cell sharing that face; a point on the outer boundary is
+        assigned to the adjacent boundary cell.
+
+        Args:
+            pt (npt.ArrayLike): Length-``ndim`` point.
+
+        Returns:
+            int | None: Containing cell id, or ``None`` when ``pt`` lies outside
+            the grid domain.
+
+        Raises:
+            ValueError: If ``pt`` does not have length ``ndim``.
+        """
+        arr = _as_float64(pt, name="pt").ravel()
+        if arr.shape != (self._ndim,):
+            raise ValueError(f"pt must have shape ({self._ndim},); got {arr.shape}.")
+        cid = 0
+        for d in range(self._ndim):
+            bp = self._breakpoints[d]
+            x = float(arr[d])
+            if x < bp[0] or x > bp[-1]:
+                return None
+            idx = int(np.searchsorted(bp, x, side="left")) - 1
+            idx = min(max(idx, 0), self._cells_per_axis[d] - 1)
+            cid += idx * int(self._strides[d])
+        return cid
+
+    def locate_many(self, points: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        """Locate a batch of points via the Numba per-axis search kernel.
+
+        Args:
+            points (npt.ArrayLike): ``(npts, ndim)`` array-like of points, or a
+                single length-``ndim`` point.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(npts,)`` cell ids; ``-1`` for points
+            outside the grid.
+
+        Raises:
+            ValueError: If the trailing axis of ``points`` is not ``ndim``.
+        """
+        pts = self._normalize_points(points)
+        counts = np.array([bp.shape[0] for bp in self._breakpoints], dtype=np.int64)
+        knot_starts = np.zeros(self._ndim, dtype=np.int64)
+        knot_starts[1:] = np.cumsum(counts[:-1])
+        knots_flat = np.concatenate(self._breakpoints).astype(np.float64, copy=False)
+        cells_per_axis = np.array(self._cells_per_axis, dtype=np.int64)
+        out = np.empty(pts.shape[0], dtype=np.int64)
+        _locate_points_core(pts, knots_flat, knot_starts, cells_per_axis, self._strides, out)
+        return out
+
+    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
+        """Return the cell across local facet ``lfid`` of ``cid``, or ``None``.
+
+        Uses the ``lfid = 2 * axis + side`` encoding and per-axis arithmetic.
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, 2 * ndim)``.
+
+        Returns:
+            int | None: Neighbouring cell id, or ``None`` on a boundary facet.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+        self._check_lfid(cid, lfid)
+        axis, side = divmod(int(lfid), 2)
+        multi = list(self.cell_multi_index(cid))
+        i = multi[axis]
+        if side == 0:
+            if i == 0:
+                return None
+            multi[axis] = i - 1
+        else:
+            if i == self._cells_per_axis[axis] - 1:
+                return None
+            multi[axis] = i + 1
+        return self.flat_cell_index(multi)
+
+    def _collect_cell_bounds(
+        self,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        """Materialize per-cell ``(lo, hi)`` in C-order via per-axis broadcasting.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+            ``(cell_lo, cell_hi)`` of shape ``(num_cells, ndim)`` in cell-id
+            order.
+        """
+        lo_axes = [bp[:-1] for bp in self._breakpoints]
+        hi_axes = [bp[1:] for bp in self._breakpoints]
+        idx_grids = np.meshgrid(*[np.arange(n) for n in self._cells_per_axis], indexing="ij")
+        cell_lo = np.empty((self._num_cells, self._ndim), dtype=np.float64)
+        cell_hi = np.empty((self._num_cells, self._ndim), dtype=np.float64)
+        for d in range(self._ndim):
+            flat_idx = idx_grids[d].ravel()
+            cell_lo[:, d] = lo_axes[d][flat_idx]
+            cell_hi[:, d] = hi_axes[d][flat_idx]
+        return cell_lo, cell_hi
+
+    def __repr__(self) -> str:
+        """Return a compact representation useful for debugging.
+
+        Returns:
+            str: ``"TensorProductGrid(ndim=..., cells_per_axis=...)"``.
+        """
+        return (
+            f"TensorProductGrid(ndim={self._ndim}, cells_per_axis={self._cells_per_axis}, "
+            f"uniform={self._is_uniform})"
+        )
+
+
+def uniform_grid(
+    bounds: npt.ArrayLike,
+    cells: int | Sequence[int],
+) -> TensorProductGrid:
+    """Build a uniform :class:`TensorProductGrid` on a bounding box.
+
+    Args:
+        bounds (npt.ArrayLike): ``(ndim, 2)`` array-like of per-axis
+            ``[lo, hi]`` pairs with ``ndim >= 1``.
+        cells (int | Sequence[int]): Number of cells per axis. A scalar is
+            broadcast to every axis; a length-``ndim`` sequence gives per-axis
+            counts. Each count must be ``>= 1``.
+
+    Returns:
+        TensorProductGrid: A uniform tensor-product grid.
+
+    Raises:
+        ValueError: If ``bounds`` does not have shape ``(ndim, 2)``, any axis has
+            ``lo >= hi``, ``cells`` has the wrong length, or any count is ``< 1``.
+        TypeError: If ``bounds`` cannot be cast to ``float64``.
+    """
+    arr = _as_float64(bounds, name="bounds")
+    if arr.ndim != 2 or arr.shape[-1] != 2:  # noqa: PLR2004
+        raise ValueError(f"uniform_grid: bounds must have shape (ndim, 2); got {arr.shape}.")
+    ndim = int(arr.shape[0])
+    if ndim < 1:
+        raise ValueError(f"uniform_grid: ndim must be >= 1; got {ndim}.")
+    if not np.all(arr[:, 0] < arr[:, 1]):
+        raise ValueError(
+            f"uniform_grid: bounds must satisfy lo < hi on every axis; got {arr.tolist()!r}."
+        )
+    cells_tuple = (int(cells),) * ndim if isinstance(cells, int) else tuple(int(c) for c in cells)
+    if len(cells_tuple) != ndim:
+        raise ValueError(
+            f"uniform_grid: cells must be a scalar or a length-{ndim} sequence; "
+            f"got length {len(cells_tuple)}."
+        )
+    if any(c < 1 for c in cells_tuple):
+        raise ValueError(f"uniform_grid: every cells entry must be >= 1; got {cells_tuple!r}.")
+    breakpoints = [
+        np.linspace(arr[d, 0], arr[d, 1], cells_tuple[d] + 1, dtype=np.float64) for d in range(ndim)
+    ]
+    return TensorProductGrid(breakpoints)
+
+
+def tensor_product_grid(space: BsplineSpace) -> TensorProductGrid:
+    """Build the knot-span grid of a :class:`pantr.bspline.BsplineSpace`.
+
+    The grid's per-axis breakpoints are the unique in-domain knots of each
+    1-D sub-space, so its cells are exactly the space's knot spans and its cell
+    ids match :class:`pantr.bspline.SpanwiseElementExtraction` on the same space.
+
+    Args:
+        space (BsplineSpace): A tensor-product B-spline space. Periodic
+            directions are rejected: a periodic knot vector does not map cleanly
+            to a bounded grid.
+
+    Returns:
+        TensorProductGrid: A grid whose cells are the knot spans of ``space``.
+
+    Raises:
+        ValueError: If any direction of ``space`` is periodic.
+    """
+    breakpoints: list[npt.NDArray[np.float64]] = []
+    for d, sub in enumerate(space.spaces):
+        if sub.periodic:
+            raise ValueError(
+                f"tensor_product_grid: axis {d} is periodic; periodic B-spline spaces "
+                "do not map to a bounded tensor-product grid."
+            )
+        unique, _ = sub.get_unique_knots_and_multiplicity(in_domain=True)
+        breakpoints.append(_as_float64(unique, name=f"space.spaces[{d}] unique knots").ravel())
+    return TensorProductGrid(breakpoints)
+
+
+__all__ = ["TensorProductGrid", "tensor_product_grid", "uniform_grid"]

--- a/src/pantr/viz/__init__.py
+++ b/src/pantr/viz/__init__.py
@@ -16,11 +16,13 @@ Main exports:
 - :class:`Scene`: Composable multi-geometry visualization scene.
 - :func:`control_polygon_mesh`: Control polygon (points + wireframe).
 - :func:`knot_lines_meshes`: Knot line meshes for B-splines.
+- :func:`grid_to_pyvista`: Convert a :class:`pantr.grid.Grid` to an ``UnstructuredGrid``.
 """
 
 from __future__ import annotations
 
 from ._control_points import control_polygon_mesh
+from ._grid import grid_to_pyvista
 from ._knot_lines import knot_lines_meshes
 from ._scene import Scene, plot
 from ._vtk_cells import save, to_pyvista
@@ -28,6 +30,7 @@ from ._vtk_cells import save, to_pyvista
 __all__ = [
     "Scene",
     "control_polygon_mesh",
+    "grid_to_pyvista",
     "knot_lines_meshes",
     "plot",
     "save",

--- a/src/pantr/viz/_grid.py
+++ b/src/pantr/viz/_grid.py
@@ -1,0 +1,99 @@
+"""Export a :class:`pantr.grid.Grid` to a pyvista ``UnstructuredGrid``.
+
+Builds one VTK cell per grid cell -- a line (1-D), quad (2-D), or hexahedron
+(3-D) -- from the cell's axis-aligned ``(lo, hi)`` corners. Vertices are emitted
+per cell (not shared between neighbours), which keeps the export independent of
+the grid's internal structure and therefore works for any :class:`Grid`
+subclass. Cell ordering matches :meth:`pantr.grid.Grid.iter_cells`, so an array
+indexed by cell id can be attached directly as ``grid.cell_data``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+from ._lazy_import import _import_pyvista
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    import pyvista as pv
+
+    from ..grid import Grid
+
+# VTK cell-type codes, re-declared so this module needs no ``vtk`` import.
+_VTK_LINE: Final[int] = 3
+_VTK_QUAD: Final[int] = 9
+_VTK_HEXAHEDRON: Final[int] = 12
+
+# Per-dimension (vtk cell type, corner-sign table). Each row of the sign table
+# selects lo (0) or hi (1) on each axis for one vertex, in VTK vertex order.
+_CORNER_SIGNS: Final[dict[int, tuple[int, npt.NDArray[np.int64]]]] = {
+    1: (_VTK_LINE, np.array([[0], [1]], dtype=np.int64)),
+    2: (_VTK_QUAD, np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.int64)),
+    3: (
+        _VTK_HEXAHEDRON,
+        np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+            ],
+            dtype=np.int64,
+        ),
+    ),
+}
+
+
+def grid_to_pyvista(grid: Grid) -> pv.UnstructuredGrid:
+    """Convert a 1-D, 2-D, or 3-D :class:`pantr.grid.Grid` to a pyvista grid.
+
+    Args:
+        grid (Grid): The grid to export. Must have ``ndim in {1, 2, 3}``.
+
+    Returns:
+        pyvista.UnstructuredGrid: A grid of lines (1-D), quads (2-D), or
+        hexahedra (3-D), one cell per grid cell, in :meth:`Grid.iter_cells`
+        order. Points are padded to 3-D (``z = 0``, and ``y = 0`` in 1-D).
+
+    Raises:
+        ValueError: If ``grid.ndim`` is not 1, 2, or 3.
+        ImportError: If pyvista is not installed.
+    """
+    if grid.ndim not in _CORNER_SIGNS:
+        raise ValueError(f"grid_to_pyvista supports ndim in {{1, 2, 3}}; got ndim={grid.ndim}.")
+    pv = _import_pyvista()
+    ndim = grid.ndim
+    n = grid.num_cells
+    vtk_type, signs = _CORNER_SIGNS[ndim]
+    n_verts = signs.shape[0]
+
+    cell_lo = np.empty((n, ndim), dtype=np.float64)
+    cell_hi = np.empty((n, ndim), dtype=np.float64)
+    for cid in range(n):
+        lo, hi = grid.cell_bounds(cid)
+        cell_lo[cid] = lo
+        cell_hi[cid] = hi
+
+    # Per-cell vertices, interleaved so point id == cid * n_verts + vertex.
+    points = np.zeros((n * n_verts, 3), dtype=np.float64)
+    for v in range(n_verts):
+        for d in range(ndim):
+            points[v::n_verts, d] = cell_hi[:, d] if signs[v, d] else cell_lo[:, d]
+
+    # Connectivity in pyvista's prepended-count format: [n_verts, v0, v1, ...].
+    base = (np.arange(n, dtype=np.int64) * n_verts)[:, np.newaxis]
+    conn = np.empty((n, n_verts + 1), dtype=np.int64)
+    conn[:, 0] = n_verts
+    conn[:, 1:] = base + np.arange(n_verts, dtype=np.int64)
+    cell_types = np.full(n, vtk_type, dtype=np.uint8)
+    return pv.UnstructuredGrid(conn.ravel(), cell_types, points)
+
+
+__all__ = ["grid_to_pyvista"]

--- a/tests/test_grid_abc.py
+++ b/tests/test_grid_abc.py
@@ -1,0 +1,159 @@
+"""Tests for the ``pantr.grid.Grid`` abstract base class and its defaults.
+
+The generic, box-geometry defaults on :class:`Grid` are validated by wrapping a
+:class:`TensorProductGrid` in a minimal subclass (:class:`_PlainGrid`) that
+forwards only the five abstract methods and inherits every default. Comparing
+the wrapper's default outputs against the tensor-product grid's specialized
+overrides (notably ``locate_many`` and the lazy BVH built from
+``_collect_cell_bounds``) checks the defaults for correctness.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from pantr.geometry import AABB
+from pantr.grid import Grid, TensorProductGrid, uniform_grid
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class _PlainGrid(Grid):
+    """Minimal Grid: forwards the abstract contract to a wrapped tensor grid.
+
+    Every non-abstract method is left as the :class:`Grid` default, so this
+    class exercises the base-class implementations rather than the
+    tensor-product specializations.
+    """
+
+    __slots__ = ("_inner",)
+
+    def __init__(self, inner: TensorProductGrid) -> None:
+        super().__init__()
+        self._inner = inner
+
+    @property
+    def ndim(self) -> int:
+        return self._inner.ndim
+
+    @property
+    def num_cells(self) -> int:
+        return self._inner.num_cells
+
+    def cell_bounds(self, cid: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        return self._inner.cell_bounds(cid)
+
+    def locate(self, pt: npt.ArrayLike) -> int | None:
+        return self._inner.locate(pt)
+
+    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
+        return self._inner.neighbor_across_facet(cid, lfid)
+
+
+def test_grid_is_abstract() -> None:
+    """Grid cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="abstract"):
+        Grid()  # type: ignore[abstract]
+
+
+def test_incomplete_subclass_is_abstract() -> None:
+    """A subclass missing an abstract method cannot be instantiated."""
+
+    class _Incomplete(Grid):
+        @property
+        def ndim(self) -> int:
+            return 1
+
+        @property
+        def num_cells(self) -> int:
+            return 0
+
+    with pytest.raises(TypeError, match="abstract"):
+        _Incomplete()  # type: ignore[abstract]
+
+
+def test_default_locate_many_matches_kernel() -> None:
+    """The default (looping) locate_many matches the tensor-grid kernel."""
+    tpg = uniform_grid([[0.0, 4.0], [0.0, 3.0]], [4, 3])
+    plain = _PlainGrid(tpg)
+    rng = np.random.default_rng(2)
+    pts = rng.uniform(-1.0, 5.0, size=(40, 2))
+    np.testing.assert_array_equal(plain.locate_many(pts), tpg.locate_many(pts))
+
+
+def test_default_query_aabb_matches_specialized() -> None:
+    """The default _collect_cell_bounds builds a BVH matching the tensor grid."""
+    tpg = uniform_grid([[0.0, 5.0], [0.0, 5.0]], 5)
+    plain = _PlainGrid(tpg)
+    box = AABB([1.5, 1.5], [3.5, 3.5])
+    assert sorted(plain.query_aabb(box).tolist()) == sorted(tpg.query_aabb(box).tolist())
+
+
+def test_default_neighbors_and_boundary() -> None:
+    """Default neighbours and boundary-facet detection match the tensor grid."""
+    tpg = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    plain = _PlainGrid(tpg)
+    for cid in range(tpg.num_cells):
+        assert sorted(plain.neighbors(cid)) == sorted(tpg.neighbors(cid))
+        for lfid in range(plain.num_local_facets(cid)):
+            assert plain.is_mesh_boundary_facet(cid, lfid) == tpg.is_mesh_boundary_facet(cid, lfid)
+
+
+def test_default_cell_aabb_and_reference_map() -> None:
+    """Default cell_aabb and reference_map reproduce the cell geometry."""
+    tpg = TensorProductGrid([[0.0, 2.0, 5.0], [0.0, 4.0]])
+    plain = _PlainGrid(tpg)
+    cid = tpg.flat_cell_index((1, 0))
+    box = plain.cell_aabb(cid)
+    assert isinstance(box, AABB)
+    assert box.lo.tolist() == [2.0, 0.0]
+    assert box.hi.tolist() == [5.0, 4.0]
+    image = plain.reference_map(cid)(np.array([[1.0, 1.0]]))
+    np.testing.assert_allclose(image, [[5.0, 4.0]])
+
+
+def test_default_facet_accessors() -> None:
+    """Default facet count / axis-side / bounds follow the box convention."""
+    tpg = uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2)
+    plain = _PlainGrid(tpg)
+    assert plain.num_local_facets(0) == 4  # noqa: PLR2004
+    assert plain.local_facet_axis_side(0, 3) == (1, 1)
+    lo, hi = plain.local_facet_bounds(0, 0)  # axis 0, low face
+    assert lo[0] == hi[0] == 0.0
+
+
+def test_default_level_children_and_iter() -> None:
+    """Flat-grid defaults: level 0, no children, in-order iteration."""
+    tpg = uniform_grid([[0.0, 3.0]], 3)
+    plain = _PlainGrid(tpg)
+    assert plain.cell_level(0) == 0
+    assert plain.child_cells(0) == ()
+    assert list(plain.iter_cells()) == [0, 1, 2]
+
+
+def test_default_tags_available() -> None:
+    """A bare subclass still gets working lazy tag registries."""
+    plain = _PlainGrid(uniform_grid([[0.0, 4.0]], 4))
+    plain.cell_tags.set("a", [0, 2], 1)
+    assert plain.cell_tags.to_dense("a").tolist() == [1, 0, 1, 0]
+    assert plain.facet_tags.facets_per_cell == 2 * plain.ndim
+
+
+def test_check_cid_bounds() -> None:
+    """Default accessors validate the cell id."""
+    plain = _PlainGrid(uniform_grid([[0.0, 2.0]], 2))
+    with pytest.raises(IndexError):
+        plain.cell_level(5)
+    with pytest.raises(IndexError):
+        plain.num_local_facets(-1)
+
+
+def test_locate_many_bad_shape_raises() -> None:
+    """Default locate_many validates the trailing axis."""
+    plain = _PlainGrid(uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2))
+    with pytest.raises(ValueError, match="shape"):
+        plain.locate_many(np.zeros((4, 3)))

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -1,0 +1,159 @@
+"""Tests for the grid bounding-volume hierarchy (``pantr.grid.BVH``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.geometry import AABB
+from pantr.grid import BVH
+
+
+def _grid_cells(nx: int, ny: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return per-cell ``(lo, hi)`` for an ``nx`` x ``ny`` unit-cell grid."""
+    lo = []
+    hi = []
+    for i in range(nx):
+        for j in range(ny):
+            lo.append([float(i), float(j)])
+            hi.append([float(i + 1), float(j + 1)])
+    return np.array(lo, dtype=np.float64), np.array(hi, dtype=np.float64)
+
+
+def test_build_node_count() -> None:
+    """A BVH over N cells has 2N-1 nodes and N leaves."""
+    lo, hi = _grid_cells(4, 4)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    assert bvh.n_cells == 16  # noqa: PLR2004
+    assert bvh.n_nodes == 2 * 16 - 1
+    assert bvh.ndim == 2  # noqa: PLR2004
+    n_leaves = int(np.sum(bvh.node_cell >= 0))
+    assert n_leaves == 16  # noqa: PLR2004
+
+
+def test_query_returns_all_overlapping() -> None:
+    """A query box returns exactly the overlapping cells (touching faces count)."""
+    lo, hi = _grid_cells(3, 3)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    # Box covering the lower-left 2x2 block of unit cells. With the axis-0-major
+    # ordering of _grid_cells, cells (i, j) map to id i*3 + j.
+    result = sorted(int(c) for c in bvh.query_aabb(AABB([0.0, 0.0], [1.5, 1.5])))
+    expected = sorted([0, 1, 3, 4])  # (0,0),(0,1),(1,0),(1,1)
+    assert result == expected
+
+
+def test_query_touching_face_is_inclusive() -> None:
+    """A box touching a cell only on a shared face still reports that cell."""
+    lo, hi = _grid_cells(3, 3)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    # The box [0,2]x[0,2] touches the line x=2 / y=2, so the i==2 / j==2 cells
+    # (spanning [2,3]) are included: every cell overlaps.
+    result = sorted(int(c) for c in bvh.query_aabb(AABB([0.0, 0.0], [2.0, 2.0])))
+    assert result == list(range(9))
+
+
+def test_query_single_cell() -> None:
+    """A tiny query box inside one cell returns just that cell."""
+    lo, hi = _grid_cells(5, 5)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    result = bvh.query_aabb(AABB([2.4, 3.4], [2.6, 3.6]))
+    assert result.tolist() == [2 * 5 + 3]
+
+
+def test_query_disjoint_empty() -> None:
+    """A query box outside the grid returns no cells."""
+    lo, hi = _grid_cells(2, 2)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    assert bvh.query_aabb(AABB([10.0, 10.0], [11.0, 11.0])).shape == (0,)
+
+
+def test_single_cell_tree() -> None:
+    """A one-cell BVH has a single leaf node and answers queries."""
+    bvh = BVH.from_cell_bounds(np.array([[0.0, 0.0]]), np.array([[1.0, 1.0]]))
+    assert bvh.n_cells == 1
+    assert bvh.n_nodes == 1
+    assert bvh.query_aabb(AABB([0.5, 0.5], [0.5, 0.5])).tolist() == [0]
+    assert bvh.query_aabb(AABB([2.0, 2.0], [3.0, 3.0])).shape == (0,)
+
+
+def test_empty_tree() -> None:
+    """A zero-cell BVH is valid and returns nothing."""
+    bvh = BVH.from_cell_bounds(np.zeros((0, 3)), np.zeros((0, 3)))
+    assert bvh.n_cells == 0
+    assert bvh.n_nodes == 0
+    assert bvh.ndim == 3  # noqa: PLR2004
+    assert bvh.query_aabb(AABB([0.0, 0.0, 0.0], [1.0, 1.0, 1.0])).shape == (0,)
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4])
+def test_general_dimension(ndim: int) -> None:
+    """The BVH works for any spatial dimension >= 1."""
+    rng = np.random.default_rng(ndim)
+    n = 20
+    lo = rng.uniform(0.0, 5.0, size=(n, ndim))
+    hi = lo + rng.uniform(0.1, 1.0, size=(n, ndim))
+    bvh = BVH.from_cell_bounds(lo, hi)
+    assert bvh.ndim == ndim
+    # Query the whole domain: every cell overlaps.
+    big = AABB(np.full(ndim, -1.0), np.full(ndim, 10.0))
+    assert sorted(int(c) for c in bvh.query_aabb(big)) == list(range(n))
+
+
+def test_query_matches_brute_force() -> None:
+    """BVH query agrees with an O(n) brute-force overlap scan."""
+    rng = np.random.default_rng(0)
+    n = 200
+    lo = rng.uniform(0.0, 10.0, size=(n, 3))
+    hi = lo + rng.uniform(0.1, 2.0, size=(n, 3))
+    bvh = BVH.from_cell_bounds(lo, hi)
+    q = AABB([3.0, 3.0, 3.0], [6.0, 6.0, 6.0])
+    got = sorted(int(c) for c in bvh.query_aabb(q))
+    brute = sorted(i for i in range(n) if AABB(lo[i], hi[i]).overlaps(q))
+    assert got == brute
+
+
+def test_query_ndim_mismatch_raises() -> None:
+    """Querying with a wrong-dimension AABB raises ValueError."""
+    bvh = BVH.from_cell_bounds(np.array([[0.0, 0.0]]), np.array([[1.0, 1.0]]))
+    with pytest.raises(ValueError, match="must match"):
+        bvh.query_aabb(AABB([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+
+
+def test_hi_below_lo_raises() -> None:
+    """A cell with hi < lo is rejected."""
+    with pytest.raises(ValueError, match="cell_hi >= cell_lo"):
+        BVH.from_cell_bounds(np.array([[1.0, 1.0]]), np.array([[0.0, 0.0]]))
+
+
+def test_inconsistent_shapes_raise() -> None:
+    """Mismatched lo/hi shapes are rejected."""
+    with pytest.raises(ValueError, match="must match"):
+        BVH.from_cell_bounds(np.zeros((3, 2)), np.zeros((3, 3)))
+
+
+def test_ctor_node_count_validation() -> None:
+    """The raw constructor checks n_nodes == 2*n_cells - 1."""
+    node_lo = np.zeros((2, 2), dtype=np.float64)
+    node_hi = np.ones((2, 2), dtype=np.float64)
+    idx = np.zeros(2, dtype=np.int64)
+    with pytest.raises(ValueError, match="implies n_nodes"):
+        BVH(node_lo, node_hi, idx, idx, idx, n_cells=2)
+
+
+def test_ctor_dtype_validation() -> None:
+    """The raw constructor rejects non-int64 child arrays."""
+    node_lo = np.zeros((1, 2), dtype=np.float64)
+    node_hi = np.ones((1, 2), dtype=np.float64)
+    bad = np.zeros(1, dtype=np.int32)
+    with pytest.raises(TypeError, match="int64"):
+        BVH(node_lo, node_hi, bad, bad, bad, n_cells=1)  # type: ignore[arg-type]
+
+
+def test_nodes_are_read_only() -> None:
+    """The stored node arrays are flagged read-only."""
+    lo, hi = _grid_cells(2, 2)
+    bvh = BVH.from_cell_bounds(lo, hi)
+    assert not bvh.node_lo.flags.writeable
+    assert not bvh.node_cell.flags.writeable
+    with pytest.raises(ValueError, match="read-only|assignment"):
+        bvh.node_lo[0, 0] = 5.0

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from pantr.geometry import AABB
 from pantr.grid import BVH
 
 
-def _grid_cells(nx: int, ny: int) -> tuple[np.ndarray, np.ndarray]:
+def _grid_cells(nx: int, ny: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Return per-cell ``(lo, hi)`` for an ``nx`` x ``ny`` unit-cell grid."""
     lo = []
     hi = []

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -133,12 +133,13 @@ def test_inconsistent_shapes_raise() -> None:
 
 
 def test_ctor_node_count_validation() -> None:
-    """The raw constructor checks n_nodes == 2*n_cells - 1."""
+    """The raw constructor rejects n_nodes values that are not 2*n_cells - 1."""
+    # 2 nodes → implied n_cells=1 → expected n_nodes=1 → mismatch.
     node_lo = np.zeros((2, 2), dtype=np.float64)
     node_hi = np.ones((2, 2), dtype=np.float64)
     idx = np.zeros(2, dtype=np.int64)
-    with pytest.raises(ValueError, match="implies n_nodes"):
-        BVH(node_lo, node_hi, idx, idx, idx, n_cells=2)
+    with pytest.raises(ValueError, match="valid BVH node count"):
+        BVH(node_lo, node_hi, idx, idx, idx)
 
 
 def test_ctor_dtype_validation() -> None:
@@ -147,7 +148,7 @@ def test_ctor_dtype_validation() -> None:
     node_hi = np.ones((1, 2), dtype=np.float64)
     bad = np.zeros(1, dtype=np.int32)
     with pytest.raises(TypeError, match="int64"):
-        BVH(node_lo, node_hi, bad, bad, bad, n_cells=1)  # type: ignore[arg-type]
+        BVH(node_lo, node_hi, bad, bad, bad)  # type: ignore[arg-type]
 
 
 def test_nodes_are_read_only() -> None:
@@ -158,3 +159,31 @@ def test_nodes_are_read_only() -> None:
     assert not bvh.node_cell.flags.writeable
     with pytest.raises(ValueError, match="read-only|assignment"):
         bvh.node_lo[0, 0] = 5.0
+
+
+def test_query_1d_partial() -> None:
+    """A 1-D BVH returns the cells that partially overlap the query range."""
+    lo = np.arange(5, dtype=np.float64).reshape(-1, 1)
+    hi = lo + 1.0  # cells [0,1],[1,2],[2,3],[3,4],[4,5]
+    bvh = BVH.from_cell_bounds(lo, hi)
+    result = sorted(int(c) for c in bvh.query_aabb(AABB([1.5], [3.5])))
+    assert result == [1, 2, 3]  # cells [1,2],[2,3],[3,4] overlap [1.5, 3.5]
+
+
+def test_build_tree_3_cells_structure() -> None:
+    """A 3-cell BVH has 5 nodes and each cell is individually queryable."""
+    lo = np.array([[0.0], [1.0], [2.0]])
+    hi = lo + 1.0
+    bvh = BVH.from_cell_bounds(lo, hi)
+    assert bvh.n_nodes == 5  # noqa: PLR2004
+    assert bvh.n_cells == 3  # noqa: PLR2004
+    for c in range(3):
+        mid = float(lo[c, 0]) + 0.5
+        result = bvh.query_aabb(AABB([mid - 0.1], [mid + 0.1]))
+        assert c in result.tolist()
+
+
+def test_from_cell_bounds_1d_array_raises() -> None:
+    """from_cell_bounds rejects a flat (1-D) input array."""
+    with pytest.raises(ValueError, match="2-D"):
+        BVH.from_cell_bounds(np.array([0.0, 1.0]), np.array([1.0, 2.0]))

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -187,3 +187,24 @@ def test_from_cell_bounds_1d_array_raises() -> None:
     """from_cell_bounds rejects a flat (1-D) input array."""
     with pytest.raises(ValueError, match="2-D"):
         BVH.from_cell_bounds(np.array([0.0, 1.0]), np.array([1.0, 2.0]))
+
+
+def test_from_cell_bounds_rejects_nan_inf() -> None:
+    """Non-finite cell bounds raise ValueError before building the BVH."""
+    lo = np.array([[0.0, 0.0]])
+    hi_nan = np.array([[np.nan, 1.0]])
+    hi_inf = np.array([[np.inf, 1.0]])
+    with pytest.raises(ValueError, match="finite"):
+        BVH.from_cell_bounds(lo, hi_nan)
+    with pytest.raises(ValueError, match="finite"):
+        BVH.from_cell_bounds(lo, hi_inf)
+
+
+def test_stack_overflow_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """from_cell_bounds raises when the tree depth would overflow the kernel stack."""
+    import pantr.grid._bvh as _bvh_mod  # noqa: PLC0415
+
+    monkeypatch.setattr(_bvh_mod, "_BVH_STACK_DEPTH", 1)
+    lo, hi = _grid_cells(2, 2)  # 4 cells → depth 3 > 1
+    with pytest.raises(ValueError, match="stack depth"):
+        BVH.from_cell_bounds(lo, hi)

--- a/tests/test_grid_tags.py
+++ b/tests/test_grid_tags.py
@@ -1,0 +1,162 @@
+"""Tests for the sparse cell/facet tag registries (``pantr.grid``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.grid import CellTags, FacetTags, uniform_grid
+
+
+def test_cell_tags_set_get() -> None:
+    """A cell tag stores sorted (ids, values) and reads them back."""
+    tags = CellTags(num_cells=10)
+    tags.set("location", [4, 1, 7], [2, 1, 2])
+    ids, values = tags["location"]
+    assert ids.tolist() == [1, 4, 7]  # sorted by id
+    assert values.tolist() == [1, 2, 2]
+
+
+def test_cell_tags_scalar_broadcast() -> None:
+    """A scalar value broadcasts to every id."""
+    tags = CellTags(num_cells=10)
+    tags.set("inside", [2, 3, 5], 1)
+    _, values = tags["inside"]
+    assert values.tolist() == [1, 1, 1]
+
+
+def test_cell_tags_to_dense() -> None:
+    """to_dense scatters the sparse tag into a (num_cells,) array."""
+    tags = CellTags(num_cells=6)
+    tags.set("location", [0, 4], [1, 2])
+    dense = tags.to_dense("location", fill=0)
+    assert dense.tolist() == [1, 0, 0, 0, 2, 0]
+    assert dense.shape == (6,)
+
+
+def test_cell_tags_to_dense_custom_fill() -> None:
+    """to_dense honours a custom fill for untagged cells."""
+    tags = CellTags(num_cells=4)
+    tags.set("m", [1], [9])
+    assert tags.to_dense("m", fill=-1).tolist() == [-1, 9, -1, -1]
+
+
+def test_cell_tags_membership_and_names() -> None:
+    """The registry supports containment, names, len, and iteration."""
+    tags = CellTags(num_cells=5)
+    tags.set("a", [0], 1)
+    tags.set("b", [1], 2)
+    assert "a" in tags
+    assert "c" not in tags
+    assert set(tags.names) == {"a", "b"}
+    assert len(tags) == 2  # noqa: PLR2004
+    assert set(iter(tags)) == {"a", "b"}
+
+
+def test_cell_tags_replace_and_remove() -> None:
+    """Set replaces an existing tag; remove deletes it."""
+    tags = CellTags(num_cells=5)
+    tags.set("a", [0, 1], 1)
+    tags.set("a", [2], 9)  # replace
+    ids, values = tags["a"]
+    assert ids.tolist() == [2]
+    assert values.tolist() == [9]
+    tags.remove("a")
+    assert "a" not in tags
+    with pytest.raises(KeyError):
+        tags["a"]
+
+
+def test_cell_tags_values_are_read_only() -> None:
+    """Stored tag arrays are read-only."""
+    tags = CellTags(num_cells=5)
+    tags.set("a", [0, 1], [3, 4])
+    ids, values = tags["a"]
+    assert not ids.flags.writeable
+    assert not values.flags.writeable
+
+
+def test_cell_tags_validation() -> None:
+    """Out-of-range ids, duplicates, length mismatch, and bad dtype are rejected."""
+    tags = CellTags(num_cells=5)
+    with pytest.raises(ValueError, match="in range|in \\[0"):
+        tags.set("a", [5], 1)  # id == num_cells out of range
+    with pytest.raises(ValueError, match="unique"):
+        tags.set("a", [1, 1], 1)
+    with pytest.raises(ValueError, match="length"):
+        tags.set("a", [0, 1, 2], [1, 2])
+    with pytest.raises(TypeError, match="integer"):
+        tags.set("a", [0.5, 1.5], 1)
+
+
+def test_cell_tags_negative_num_cells() -> None:
+    """A negative num_cells is rejected."""
+    with pytest.raises(ValueError, match=">= 0"):
+        CellTags(num_cells=-1)
+
+
+def test_facet_tags_set_get() -> None:
+    """A facet tag stores sorted (keys, values) keyed by (cid, lfid)."""
+    tags = FacetTags(num_cells=10, facets_per_cell=4)
+    tags.set("bc", [[3, 1], [0, 0], [3, 0]], [7, 5, 6])
+    keys, values = tags["bc"]
+    # lexicographic sort by (cid, lfid)
+    assert keys.tolist() == [[0, 0], [3, 0], [3, 1]]
+    assert values.tolist() == [5, 6, 7]
+
+
+def test_facet_tags_scalar_broadcast() -> None:
+    """A scalar value broadcasts to every facet key."""
+    tags = FacetTags(num_cells=4, facets_per_cell=4)
+    tags.set("dirichlet", [[0, 0], [1, 2]], 1)
+    _, values = tags["dirichlet"]
+    assert values.tolist() == [1, 1]
+
+
+def test_facet_tags_validation() -> None:
+    """Bad key shape, out-of-range cid/lfid, duplicates are rejected."""
+    tags = FacetTags(num_cells=4, facets_per_cell=4)
+    with pytest.raises(ValueError, match="shape"):
+        tags.set("a", [0, 1, 2], 1)  # not (M, 2)
+    with pytest.raises(ValueError, match="cell ids"):
+        tags.set("a", [[4, 0]], 1)  # cid out of range
+    with pytest.raises(ValueError, match="facet ids"):
+        tags.set("a", [[0, 4]], 1)  # lfid out of range
+    with pytest.raises(ValueError, match="unique"):
+        tags.set("a", [[0, 0], [0, 0]], 1)
+
+
+def test_facet_tags_membership() -> None:
+    """The facet registry supports containment, names, len, remove."""
+    tags = FacetTags(num_cells=4, facets_per_cell=4)
+    tags.set("a", [[0, 0]], 1)
+    assert "a" in tags
+    assert tags.names == ("a",)
+    assert len(tags) == 1
+    assert tags.facets_per_cell == 4  # noqa: PLR2004
+    tags.remove("a")
+    assert "a" not in tags
+
+
+def test_grid_tags_are_lazy_and_cached() -> None:
+    """A grid creates empty tag registries lazily and caches them."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    assert g._cell_tags is None
+    assert g._facet_tags is None
+    ct = g.cell_tags
+    assert ct is g.cell_tags  # cached
+    assert len(ct) == 0
+    assert g.facet_tags.facets_per_cell == 2 * g.ndim
+    assert g.cell_tags.num_cells == g.num_cells
+
+
+def test_grid_cell_tags_round_trip() -> None:
+    """Tags set through a grid persist and scatter to a dense per-cell array."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
+    cut = [g.flat_cell_index((0, 0)), g.flat_cell_index((2, 1))]
+    g.cell_tags.set("location", cut, 2)
+    dense = g.cell_tags.to_dense("location", fill=0)
+    assert dense.shape == (g.num_cells,)
+    assert dense[cut[0]] == 2  # noqa: PLR2004
+    assert dense[cut[1]] == 2  # noqa: PLR2004
+    assert int(np.count_nonzero(dense)) == 2  # noqa: PLR2004

--- a/tests/test_grid_tags.py
+++ b/tests/test_grid_tags.py
@@ -160,3 +160,63 @@ def test_grid_cell_tags_round_trip() -> None:
     assert dense[cut[0]] == 2  # noqa: PLR2004
     assert dense[cut[1]] == 2  # noqa: PLR2004
     assert int(np.count_nonzero(dense)) == 2  # noqa: PLR2004
+
+
+def test_cell_tags_to_dense_missing_key_raises() -> None:
+    """to_dense raises KeyError for an unregistered tag name."""
+    tags = CellTags(num_cells=4)
+    with pytest.raises(KeyError):
+        tags.to_dense("nonexistent")
+
+
+def test_cell_tags_to_dense_custom_dtype() -> None:
+    """to_dense respects a caller-supplied integer dtype."""
+    tags = CellTags(num_cells=4)
+    tags.set("m", [0, 2], [1, 2])
+    dense = tags.to_dense("m", dtype=np.int32)
+    assert dense.dtype == np.int32
+    assert dense.tolist() == [1, 0, 2, 0]
+
+
+def test_cell_tags_to_dense_float_dtype_raises() -> None:
+    """to_dense rejects non-integer dtypes."""
+    tags = CellTags(num_cells=4)
+    tags.set("m", [0], [1])
+    with pytest.raises(TypeError, match="integer"):
+        tags.to_dense("m", dtype=np.float64)
+
+
+def test_cell_tags_empty_set() -> None:
+    """Setting an empty tag is valid; to_dense returns the fill value everywhere."""
+    tags = CellTags(num_cells=4)
+    tags.set("empty", np.array([], dtype=np.int64), 0)
+    dense = tags.to_dense("empty", fill=7)
+    assert dense.tolist() == [7, 7, 7, 7]
+
+
+def test_facet_tags_empty_set() -> None:
+    """Setting an empty facet tag is valid."""
+    tags = FacetTags(num_cells=4, facets_per_cell=4)
+    tags.set("none", np.zeros((0, 2), dtype=np.int64), np.zeros(0, dtype=np.int64))
+    keys, values = tags["none"]
+    assert keys.shape == (0, 2)
+    assert values.shape == (0,)
+
+
+def test_facet_tags_to_dense() -> None:
+    """to_dense scatters a facet tag into a (num_cells, facets_per_cell) array."""
+    tags = FacetTags(num_cells=3, facets_per_cell=4)
+    tags.set("bc", [[0, 0], [2, 3]], [1, 2])
+    dense = tags.to_dense("bc", fill=0)
+    assert dense.shape == (3, 4)
+    assert dense[0, 0] == 1
+    assert dense[2, 3] == 2  # noqa: PLR2004
+    assert int(np.count_nonzero(dense)) == 2  # noqa: PLR2004
+
+
+def test_facet_tags_to_dense_float_dtype_raises() -> None:
+    """FacetTags.to_dense rejects non-integer dtypes."""
+    tags = FacetTags(num_cells=2, facets_per_cell=4)
+    tags.set("a", [[0, 0]], [1])
+    with pytest.raises(TypeError, match="integer"):
+        tags.to_dense("a", dtype=np.float32)

--- a/tests/test_grid_tags.py
+++ b/tests/test_grid_tags.py
@@ -220,3 +220,22 @@ def test_facet_tags_to_dense_float_dtype_raises() -> None:
     tags.set("a", [[0, 0]], [1])
     with pytest.raises(TypeError, match="integer"):
         tags.to_dense("a", dtype=np.float32)
+
+
+def test_cell_tags_to_dense_overflow_raises() -> None:
+    """to_dense raises OverflowError when a narrow dtype cannot hold a stored value."""
+    tags = CellTags(num_cells=4)
+    tags.set("m", [0, 1], [200, 1])  # 200 does not fit in int8 (-128..127)
+    with pytest.raises(OverflowError, match="truncation"):
+        tags.to_dense("m", dtype=np.int8)
+    # int16 range is -32768..32767; 200 fits fine.
+    dense = tags.to_dense("m", dtype=np.int16)
+    assert dense.tolist() == [200, 1, 0, 0]
+
+
+def test_facet_tags_to_dense_overflow_raises() -> None:
+    """FacetTags.to_dense raises OverflowError when a narrow dtype cannot hold a value."""
+    tags = FacetTags(num_cells=2, facets_per_cell=4)
+    tags.set("bc", [[0, 0]], [200])
+    with pytest.raises(OverflowError, match="truncation"):
+        tags.to_dense("bc", dtype=np.int8)

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -295,3 +295,39 @@ def test_tensor_product_grid_periodic_rejected() -> None:
     space = BsplineSpace([sp_per])
     with pytest.raises(ValueError, match="periodic"):
         tensor_product_grid(space)
+
+
+def test_locate_many_1d() -> None:
+    """locate_many on a 1-D grid matches scalar locate, including boundaries."""
+    g = uniform_grid([[0.0, 4.0]], 4)
+    pts = np.array([[-0.5], [0.0], [0.999], [1.0], [2.5], [3.999], [4.0], [5.0]])
+    result = g.locate_many(pts)
+    for i, p in enumerate(pts[:, 0]):
+        single = g.locate([p])
+        assert result[i] == (-1 if single is None else single)
+
+
+def test_construction_rejects_complex_breakpoints() -> None:
+    """Complex-valued breakpoints are rejected with TypeError."""
+    with pytest.raises(TypeError, match="numeric"):
+        TensorProductGrid([np.array([0 + 0j, 1 + 0j, 2 + 0j])])
+
+
+def test_construction_rejects_bool_breakpoints() -> None:
+    """Boolean breakpoints are rejected with TypeError."""
+    with pytest.raises(TypeError, match="numeric"):
+        TensorProductGrid([np.array([False, True, True])])
+
+
+def test_flat_cell_index_wrong_ndim_raises() -> None:
+    """flat_cell_index raises ValueError when multi-index has wrong length."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
+    with pytest.raises(ValueError, match="length"):
+        g.flat_cell_index([0])
+
+
+def test_flat_cell_index_out_of_range_raises() -> None:
+    """flat_cell_index raises IndexError when a per-axis index is out of range."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
+    with pytest.raises(IndexError):
+        g.flat_cell_index([3, 0])  # axis 0 index 3 >= cells_per_axis[0]=3

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -1,0 +1,297 @@
+"""Tests for ``pantr.grid.TensorProductGrid`` and its factories."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.geometry import AABB
+from pantr.grid import TensorProductGrid, tensor_product_grid, uniform_grid
+from pantr.transform import AffineTransform
+
+
+def test_construction_metadata() -> None:
+    """Per-axis breakpoints set ndim, counts, bounds, and num_cells."""
+    g = TensorProductGrid([[0.0, 1.0, 2.0, 3.0], [0.0, 2.0, 4.0]])
+    assert g.ndim == 2  # noqa: PLR2004
+    assert g.cells_per_axis == (3, 2)
+    assert g.num_cells == 6  # noqa: PLR2004
+    assert g.bounds.tolist() == [[0.0, 3.0], [0.0, 4.0]]
+    assert [b.tolist() for b in g.breakpoints] == [[0.0, 1.0, 2.0, 3.0], [0.0, 2.0, 4.0]]
+
+
+def test_breakpoints_are_read_only() -> None:
+    """Stored breakpoint and bounds arrays are read-only."""
+    g = uniform_grid([[0.0, 1.0]], 4)
+    assert not g.breakpoints[0].flags.writeable
+    assert not g.bounds.flags.writeable
+
+
+@pytest.mark.parametrize(
+    ("cells_per_axis", "cid", "multi"),
+    [
+        ((3, 2), 0, (0, 0)),
+        ((3, 2), 1, (0, 1)),  # last axis fastest (C-order)
+        ((3, 2), 2, (1, 0)),
+        ((3, 2), 5, (2, 1)),
+        ((2, 2, 2), 1, (0, 0, 1)),
+        ((2, 2, 2), 4, (1, 0, 0)),
+    ],
+)
+def test_c_order_addressing(
+    cells_per_axis: tuple[int, ...], cid: int, multi: tuple[int, ...]
+) -> None:
+    """Flat cell ids are row-major (C-order) over cells_per_axis."""
+    g = uniform_grid([[0.0, float(n)] for n in cells_per_axis], list(cells_per_axis))
+    assert g.cell_multi_index(cid) == multi
+    assert g.flat_cell_index(multi) == cid
+
+
+def test_addressing_round_trip() -> None:
+    """Multi -> flat -> multi is the identity over all cells."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 4.0], [0.0, 2.0]], [3, 4, 2])
+    for cid in range(g.num_cells):
+        assert g.flat_cell_index(g.cell_multi_index(cid)) == cid
+
+
+def test_cell_bounds() -> None:
+    """cell_bounds returns the box corners of the addressed cell."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0], [0.0, 10.0]])  # cells_per_axis (2, 1)
+    lo, hi = g.cell_bounds(g.flat_cell_index((1, 0)))
+    assert lo.tolist() == [1.0, 0.0]
+    assert hi.tolist() == [3.0, 10.0]
+
+
+def test_cell_bounds_writeable_and_fresh() -> None:
+    """cell_bounds returns fresh, writeable arrays each call."""
+    g = uniform_grid([[0.0, 1.0]], 2)
+    lo1, _ = g.cell_bounds(0)
+    lo2, _ = g.cell_bounds(0)
+    assert lo1 is not lo2
+    assert lo1.flags.writeable
+
+
+def test_locate_interior_and_outside() -> None:
+    """Locate returns the containing cell or None when outside."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
+    assert g.locate([0.5, 1.5]) == g.flat_cell_index((0, 1))
+    assert g.locate([2.9, 0.1]) == g.flat_cell_index((2, 0))
+    assert g.locate([10.0, 10.0]) is None
+    assert g.locate([-1.0, 0.0]) is None
+
+
+def test_locate_breakpoint_tie_goes_to_lower_cell() -> None:
+    """A point on an interior breakpoint maps to the lower-indexed cell."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0, 6.0]])
+    assert g.locate(1.0) == 0  # face between cell 0 and 1 -> cell 0
+    assert g.locate(3.0) == 1
+    assert g.locate(0.0) == 0  # left boundary -> cell 0
+    assert g.locate(6.0) == 2  # noqa: PLR2004 -- right boundary -> last cell
+
+
+def test_locate_wrong_shape_raises() -> None:
+    """Locate rejects a point of the wrong length."""
+    g = uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2)
+    with pytest.raises(ValueError, match="shape"):
+        g.locate([0.5, 0.5, 0.5])
+
+
+def test_locate_many_matches_locate() -> None:
+    """locate_many agrees with per-point locate, with -1 for outside."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 3.0]], [4, 3])
+    rng = np.random.default_rng(1)
+    pts = rng.uniform(-1.0, 5.0, size=(50, 2))
+    batch = g.locate_many(pts)
+    for i, p in enumerate(pts):
+        single = g.locate(p)
+        assert batch[i] == (-1 if single is None else single)
+
+
+def test_locate_many_single_point() -> None:
+    """locate_many accepts a single point and returns a length-1 array."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2)
+    out = g.locate_many([0.5, 1.5])
+    assert out.shape == (1,)
+    assert out[0] == g.locate([0.5, 1.5])
+
+
+def test_neighbors_interior_and_corner() -> None:
+    """Interior cells have 2*ndim neighbours; corner cells have ndim."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    center = g.flat_cell_index((1, 1))
+    assert len(g.neighbors(center)) == 4  # noqa: PLR2004
+    corner = g.flat_cell_index((0, 0))
+    assert len(g.neighbors(corner)) == 2  # noqa: PLR2004
+
+
+def test_neighbor_across_facet() -> None:
+    """neighbor_across_facet steps one cell along the facet's axis/side."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    cid = g.flat_cell_index((1, 1))
+    # lfid = 2*axis + side. axis 0 low -> (0,1); axis 0 high -> (2,1).
+    assert g.neighbor_across_facet(cid, 0) == g.flat_cell_index((0, 1))
+    assert g.neighbor_across_facet(cid, 1) == g.flat_cell_index((2, 1))
+    assert g.neighbor_across_facet(cid, 2) == g.flat_cell_index((1, 0))
+    assert g.neighbor_across_facet(cid, 3) == g.flat_cell_index((1, 2))
+
+
+def test_neighbor_across_boundary_facet_is_none() -> None:
+    """A boundary facet has no neighbour."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    corner = g.flat_cell_index((0, 0))
+    assert g.neighbor_across_facet(corner, 0) is None  # axis 0 low
+    assert g.neighbor_across_facet(corner, 2) is None  # axis 1 low
+    assert g.is_mesh_boundary_facet(corner, 0)
+    assert not g.is_mesh_boundary_facet(corner, 1)
+
+
+def test_facet_accessors() -> None:
+    """Facet count, axis/side decoding, and degenerate facet bounds."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2)
+    cid = g.flat_cell_index((0, 0))
+    assert g.num_local_facets(cid) == 4  # noqa: PLR2004
+    assert g.local_facet_axis_side(cid, 0) == (0, 0)
+    assert g.local_facet_axis_side(cid, 3) == (1, 1)
+    lo, hi = g.local_facet_bounds(cid, 1)  # axis 0, high face
+    assert lo[0] == hi[0] == 1.0
+    assert (lo[1], hi[1]) == (0.0, 1.0)
+
+
+def test_reference_map() -> None:
+    """reference_map sends the unit cube to the cell box."""
+    g = TensorProductGrid([[0.0, 2.0, 5.0], [0.0, 4.0]])
+    cid = g.flat_cell_index((1, 0))  # cell [2,5] x [0,4]
+    rm = g.reference_map(cid)
+    assert isinstance(rm, AffineTransform)
+    corner = rm(np.array([[0.0, 0.0], [1.0, 1.0]]))
+    np.testing.assert_allclose(corner, [[2.0, 0.0], [5.0, 4.0]])
+
+
+def test_cell_level_and_children() -> None:
+    """A flat grid reports level 0 and no children."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    assert g.cell_level(0) == 0
+    assert g.child_cells(0) == ()
+
+
+def test_query_aabb_builds_lazy_bvh() -> None:
+    """query_aabb builds the BVH lazily on first use and caches it."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    assert g._bvh is None  # not built at construction
+    # cells (0,0),(0,1),(1,0),(1,1) touch the box [0,1]^2.
+    expected = sorted(g.flat_cell_index(m) for m in [(0, 0), (0, 1), (1, 0), (1, 1)])
+    result = g.query_aabb(AABB([0.0, 0.0], [1.0, 1.0]))
+    assert sorted(int(c) for c in result) == expected
+    assert g.cell_bvh() is g.cell_bvh()  # built once, then cached
+
+
+def test_is_uniform_flag() -> None:
+    """is_uniform reflects per-axis spacing regularity."""
+    assert uniform_grid([[0.0, 4.0]], 4).is_uniform
+    assert not TensorProductGrid([[0.0, 1.0, 3.0]]).is_uniform
+
+
+def test_cell_aabb() -> None:
+    """cell_aabb wraps cell_bounds as an AABB."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2)
+    box = g.cell_aabb(0)
+    assert isinstance(box, AABB)
+    assert box.lo.tolist() == [0.0, 0.0]
+    assert box.hi.tolist() == [1.0, 1.0]
+
+
+def test_out_of_range_cid_raises() -> None:
+    """Out-of-range cell ids raise IndexError."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    with pytest.raises(IndexError):
+        g.cell_bounds(5)
+    with pytest.raises(IndexError):
+        g.cell_multi_index(-1)
+
+
+def test_invalid_construction() -> None:
+    """Degenerate or non-monotone breakpoints are rejected."""
+    with pytest.raises(ValueError, match="at least"):
+        TensorProductGrid([[0.0]])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        TensorProductGrid([[0.0, 1.0, 1.0]])
+    with pytest.raises(ValueError, match="finite"):
+        TensorProductGrid([[0.0, np.inf]])
+    with pytest.raises(ValueError, match="at least one axis"):
+        TensorProductGrid([])
+
+
+def test_repr() -> None:
+    """Repr reports ndim, cell counts, and uniformity."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2)
+    text = repr(g)
+    assert "TensorProductGrid" in text
+    assert "cells_per_axis=(2, 2)" in text
+
+
+# ---------------------------------------------------------------- factories
+
+
+def test_uniform_grid_scalar_and_sequence_cells() -> None:
+    """uniform_grid broadcasts a scalar count and accepts a per-axis sequence."""
+    g1 = uniform_grid([[0.0, 2.0], [0.0, 4.0]], 2)
+    assert g1.cells_per_axis == (2, 2)
+    g2 = uniform_grid([[0.0, 2.0], [0.0, 4.0]], [2, 4])
+    assert g2.cells_per_axis == (2, 4)
+    np.testing.assert_allclose(g2.breakpoints[1], [0.0, 1.0, 2.0, 3.0, 4.0])
+
+
+def test_uniform_grid_validation() -> None:
+    """uniform_grid rejects bad bounds, lo>=hi, wrong cell length, count<1."""
+    with pytest.raises(ValueError, match="shape"):
+        uniform_grid([0.0, 1.0], 2)
+    with pytest.raises(ValueError, match="lo < hi"):
+        uniform_grid([[1.0, 0.0]], 2)
+    with pytest.raises(ValueError, match="length"):
+        uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2, 2])
+    with pytest.raises(ValueError, match=">= 1"):
+        uniform_grid([[0.0, 1.0]], 0)
+
+
+def test_tensor_product_grid_from_space() -> None:
+    """tensor_product_grid uses a space's unique in-domain knots as breakpoints."""
+    from pantr.bspline import BsplineSpace, BsplineSpace1D  # noqa: PLC0415
+
+    sp = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)  # 2 intervals on [0, 2]
+    space = BsplineSpace([sp, sp])
+    g = tensor_product_grid(space)
+    assert g.cells_per_axis == space.num_intervals
+    assert g.ndim == 2  # noqa: PLR2004
+    np.testing.assert_allclose(g.bounds, [[0.0, 2.0], [0.0, 2.0]], atol=1e-9)
+
+
+def test_tensor_product_grid_matches_extraction_ids() -> None:
+    """Grid cell ids agree with SpanwiseElementExtraction's flat ordering."""
+    from pantr.bspline import (  # noqa: PLC0415
+        BsplineSpace,
+        BsplineSpace1D,
+        SpanwiseElementExtraction,
+    )
+
+    sp_x = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)  # 3 intervals
+    sp_y = BsplineSpace1D([0, 0, 1, 2, 2], 1)  # 2 intervals
+    space = BsplineSpace([sp_x, sp_y])
+    g = tensor_product_grid(space)
+    ext = SpanwiseElementExtraction(space, "bezier")
+    assert g.cells_per_axis == ext.num_intervals
+    assert g.num_cells == ext.num_total_intervals
+
+
+def test_tensor_product_grid_periodic_rejected() -> None:
+    """A periodic direction cannot become a bounded grid."""
+    from pantr.bspline import (  # noqa: PLC0415
+        BsplineSpace,
+        BsplineSpace1D,
+        create_uniform_periodic_knots,
+    )
+
+    knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+    sp_per = BsplineSpace1D(knots, 2, periodic=True)
+    space = BsplineSpace([sp_per])
+    with pytest.raises(ValueError, match="periodic"):
+        tensor_product_grid(space)

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -331,3 +331,59 @@ def test_flat_cell_index_out_of_range_raises() -> None:
     g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
     with pytest.raises(IndexError):
         g.flat_cell_index([3, 0])  # axis 0 index 3 >= cells_per_axis[0]=3
+
+
+def test_locate_many_interior_breakpoint_tie() -> None:
+    """locate_many Numba kernel agrees with scalar locate at every interior breakpoint."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0, 6.0], [0.0, 2.0, 5.0]])
+    # Interior breakpoints are at x=1.0, x=3.0 (axis 0) and y=2.0 (axis 1).
+    breakpoints_2d = [[1.0, 0.5], [1.0, 2.0], [3.0, 0.5], [3.0, 2.0]]
+    pts = np.array(breakpoints_2d, dtype=np.float64)
+    batch = g.locate_many(pts)
+    for i, pt in enumerate(breakpoints_2d):
+        single = g.locate(pt)
+        expected = -1 if single is None else single
+        assert int(batch[i]) == expected, (
+            f"locate_many disagreed with locate at breakpoint {pt}: "
+            f"batch={batch[i]}, single={single}"
+        )
+
+
+def test_locate_many_3d() -> None:
+    """locate_many works correctly for 3-D tensor-product grids."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 3.0], [0.0, 4.0]], [2, 3, 4])
+    rng = np.random.default_rng(42)
+    pts = rng.uniform(-0.5, 4.5, size=(60, 3))
+    batch = g.locate_many(pts)
+    for i, pt in enumerate(pts):
+        single = g.locate(pt)
+        assert int(batch[i]) == (-1 if single is None else single)
+
+
+def test_query_aabb_3d() -> None:
+    """query_aabb works correctly for 3-D tensor-product grids."""
+    from pantr.geometry import AABB  # noqa: PLC0415
+
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0], [0.0, 3.0]], 3)
+    # Each axis has cells [0,1), [1,2), [2,3). A query box [0.5,1.5]^3
+    # strictly overlaps only the 8 cells in the lower 2x2x2 block (indices 0
+    # or 1 on every axis).
+    box = AABB([0.5, 0.5, 0.5], [1.5, 1.5, 1.5])
+    result = sorted(int(c) for c in g.query_aabb(box))
+    expected = sorted(
+        g.flat_cell_index(m)
+        for m in [(i, j, k) for i in range(2) for j in range(2) for k in range(2)]
+    )
+    assert result == expected
+
+
+def test_uniform_grid_single_cell_per_axis() -> None:
+    """uniform_grid with cells=1 produces a single-cell grid per axis."""
+    g = uniform_grid([[0.0, 5.0], [1.0, 3.0]], 1)
+    assert g.cells_per_axis == (1, 1)
+    assert g.num_cells == 1
+    assert g.locate([2.5, 2.0]) == 0
+    assert g.locate([5.0, 3.0]) == 0  # right boundary → only cell
+    assert g.locate([5.1, 2.0]) is None
+    out = g.locate_many(np.array([[2.5, 2.0], [-1.0, 2.0]]))
+    assert out.tolist() == [0, -1]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,6 +24,7 @@ def test_package_all_exports() -> None:
         "change_basis",
         "geometry",
         "get_num_threads",
+        "grid",
         "num_threads",
         "quad",
         "set_num_threads",

--- a/tests/test_viz_grid.py
+++ b/tests/test_viz_grid.py
@@ -1,0 +1,68 @@
+"""Tests for ``pantr.viz.grid_to_pyvista``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pv = pytest.importorskip("pyvista")
+
+from pantr.grid import TensorProductGrid, uniform_grid  # noqa: E402
+from pantr.viz import grid_to_pyvista  # noqa: E402
+
+_VTK_LINE = 3
+_VTK_QUAD = 9
+_VTK_HEXAHEDRON = 12
+
+
+def test_2d_quads() -> None:
+    """A 2-D grid exports one quad per cell with 4 vertices each."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 3.0]], [4, 3])
+    ug = grid_to_pyvista(g)
+    assert ug.n_cells == 12  # noqa: PLR2004
+    assert ug.n_points == 12 * 4
+    assert np.all(ug.celltypes == _VTK_QUAD)
+
+
+def test_3d_hexes() -> None:
+    """A 3-D grid exports one hexahedron per cell with 8 vertices each."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 2.0], [0.0, 2.0]], 2)
+    ug = grid_to_pyvista(g)
+    assert ug.n_cells == 8  # noqa: PLR2004
+    assert ug.n_points == 8 * 8
+    assert np.all(ug.celltypes == _VTK_HEXAHEDRON)
+
+
+def test_1d_lines() -> None:
+    """A 1-D grid exports one line per cell."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0, 6.0]])
+    ug = grid_to_pyvista(g)
+    assert ug.n_cells == 3  # noqa: PLR2004
+    assert np.all(ug.celltypes == _VTK_LINE)
+
+
+def test_cell_bounds_recovered() -> None:
+    """Each exported cell's point bounds match the grid cell box."""
+    g = TensorProductGrid([[0.0, 2.0, 5.0], [0.0, 4.0]])
+    ug = grid_to_pyvista(g)
+    for cid in range(g.num_cells):
+        lo, hi = g.cell_bounds(cid)
+        cell = ug.get_cell(cid)
+        pts = np.asarray(cell.points)
+        np.testing.assert_allclose(pts[:, :2].min(axis=0), lo)
+        np.testing.assert_allclose(pts[:, :2].max(axis=0), hi)
+
+
+def test_cell_data_attachable() -> None:
+    """An array indexed by cell id attaches directly as cell_data."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 2.0]], [3, 2])
+    ug = grid_to_pyvista(g)
+    ug.cell_data["loc"] = np.arange(g.num_cells)
+    assert ug.cell_data["loc"].tolist() == list(range(g.num_cells))
+
+
+def test_unsupported_ndim_raises() -> None:
+    """grid_to_pyvista rejects ndim outside {1, 2, 3}."""
+    g = uniform_grid([[0.0, 1.0]] * 4, 1)
+    with pytest.raises(ValueError, match="ndim"):
+        grid_to_pyvista(g)

--- a/tests/test_viz_grid.py
+++ b/tests/test_viz_grid.py
@@ -66,3 +66,15 @@ def test_unsupported_ndim_raises() -> None:
     g = uniform_grid([[0.0, 1.0]] * 4, 1)
     with pytest.raises(ValueError, match="ndim"):
         grid_to_pyvista(g)
+
+
+def test_1d_points_padded_to_3d() -> None:
+    """1-D grid points are padded to 3-D with y=z=0."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0]])
+    ug = grid_to_pyvista(g)
+    pts = np.asarray(ug.points)
+    assert pts.shape[1] == 3  # noqa: PLR2004
+    np.testing.assert_array_equal(pts[:, 1], 0.0)
+    np.testing.assert_array_equal(pts[:, 2], 0.0)
+    assert float(pts[:, 0].min()) == pytest.approx(0.0)
+    assert float(pts[:, 0].max()) == pytest.approx(3.0)


### PR DESCRIPTION
## Summary

Follow-up to #156, addressing issues found in code review of the `pantr.grid` foundation.

- **Docstrings corrected**: `is_uniform` "absolute" → "relative" tolerance; `query_aabb` inclusion semantics now say "any face, edge, or corner" (not just "shared face"); `cell_bvh` thread-safety warning distinguishes CPython vs free-threaded Python; `_bvh_core.py` traversal direction clarified vs `_build_tree` construction order.
- **`to_dense` return type**: `NDArray[np.int_]` → `NDArray[Any]` (mypy strict).
- **`to_dense` silent truncation**: raises `OverflowError` when a narrow dtype cannot hold stored `int64` values.
- **`num_cells` overflow**: `math.prod` (Python arbitrary-precision) replaces `np.prod` (silent int64 wrap for very large grids).
- **BVH non-finite bounds**: `from_cell_bounds` now rejects NaN/Inf cell corners before building the tree.

## Test plan

- [x] BVH stack-overflow guard (monkeypatched `_BVH_STACK_DEPTH`)
- [x] BVH NaN/Inf cell-bound rejection
- [x] `locate_many` Numba kernel vs scalar `locate` at exact interior breakpoints
- [x] `locate_many` and `query_aabb` for 3-D `TensorProductGrid`
- [x] `uniform_grid(cells=1)` single-cell degenerate case
- [x] `to_dense` `OverflowError` for `CellTags` and `FacetTags`

Note: this branch (`feat/grid-foundation`) and `feat/hierarchical-grid` have diverged since #156 was squash-merged — some changes here (BVH constructor, `is_uniform` logic) may need forward-porting or conflict resolution during merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)