### PR TITLE
chore(release): pantr 0.5.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.0 (2026-06-03)
 
 ### Added
 - `pantr.grid`: new structured-grid layer. `Grid` is an abstract base class
@@ -14,6 +14,12 @@
   bounding-volume hierarchy over cell AABBs (lazily built, backing
   `Grid.query_aabb`), and `CellTags` / `FacetTags` are sparse, dolfinx-style
   named tag registries for cells and facets.
+- `pantr.grid.HierarchicalGrid`: hierarchical refinement grid with a fixed
+  per-direction subdivision factor (octree = the dyadic case). Active cells are
+  stored as rectangular blocks per level (no per-cell storage); supports
+  `refine(level, lo, hi)` with union semantics, automatic single-level balance,
+  `refine_cells`, and `hanging_neighbors` for hanging-node facets. Built with the
+  `hierarchical_grid(root, factor)` factory.
 - `pantr.viz.grid_to_pyvista`: export a 1-D/2-D/3-D `Grid` to a pyvista
   `UnstructuredGrid` (lines / quads / hexahedra).
 - `pantr.quad.QuadratureRule`: immutable d-dimensional quadrature rule on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pantr"
-version = "0.4.0"
+version = "0.5.0"
 description = "Polynomial And NURBS Toolkit"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -34,7 +34,7 @@ from ._parallel import get_num_threads, num_threads, set_num_threads
 from .basis import _basis_utils  # noqa: F401
 
 # Package metadata
-__version__: Final[str] = "0.4.0"
+__version__: Final[str] = "0.5.0"
 __license__: Final[str] = "MIT"
 __author__: Final[str] = "Pablo Antolin <pablo.antolin@epfl.ch>"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,7 +36,7 @@ def test_package_all_exports() -> None:
 
 def test_package_metadata_values() -> None:
     """Validate the package metadata constants."""
-    assert pantr.__version__ == "0.4.0"
+    assert pantr.__version__ == "0.5.0"
     assert pantr.__license__ == "MIT"
     assert pantr.__author__ == "Pablo Antolin <pablo.antolin@epfl.ch>"
 
@@ -44,7 +44,7 @@ def test_package_metadata_values() -> None:
 def test_metadata_import_stability() -> None:
     """Verify metadata survives module reloads."""
     module = importlib.reload(pantr)
-    assert module.__version__ == "0.4.0"
+    assert module.__version__ == "0.5.0"
 
 
 def test_submodule_all_exports() -> None:


### PR DESCRIPTION
## Summary

Release **pantr 0.5.0**, shipping the `pantr.grid` structured-grid layer:
- `Grid` ABC + `TensorProductGrid` + `BVH` + `CellTags`/`FacetTags` + factories (#156)
- `HierarchicalGrid` + `hierarchical_grid` (#157)
- `QuadratureRule` + `tensor_product_quadrature`/`gauss_legendre_quadrature` and the `cell_quadrature` bridge (#159)
- `pantr.viz.grid_to_pyvista`

Changes:
- Bump version `0.4.0` → `0.5.0` in `pyproject.toml` and `src/pantr/__init__.py` (kept in sync), and `tests/test_metadata.py`.
- Finalize `docs/changelog.md`: `Unreleased` → `0.5.0`, **adding the previously-missing `HierarchicalGrid` entry** so the release notes are complete.

This is the release ocelat pins to before migrating onto `pantr.grid`. Tag `v0.5.0` to be cut on `main` after merge.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean (160 files)
- [x] `pytest --no-cov` — 2814 passed (incl. updated `test_metadata`)
- [x] Sphinx `-W` docs build succeeds
- [x] `pyproject` version and `__version__` verified in sync

Generated with [Claude Code](https://claude.com/claude-code)