### PR TITLE
feat(grid): add overlay for coarsest common refinement of two grids

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `pantr.grid.overlay`: build the coarsest `TensorProductGrid` that refines two
+  input tensor-product grids — its per-axis breakpoints are the union of both
+  inputs' breakpoints restricted to their domain overlap, so every overlay cell
+  lies inside one cell of each input. Defined for any `ndim >= 1`. The
+  background-grid bridge for immersed / unfitted quadrature.
+
 ## 0.5.0 (2026-06-03)
 
 ### Added

--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -32,6 +32,8 @@ Main exports:
   registries for cells and facets.
 - :func:`cell_quadrature`: map a :class:`pantr.quad.QuadratureRule` from the
   unit cube onto a grid's cells (per-cell points and weights).
+- :func:`overlay`: the coarsest :class:`TensorProductGrid` refining two input
+  tensor-product grids (union of per-axis breakpoints on their domain overlap).
 """
 
 from __future__ import annotations
@@ -40,6 +42,7 @@ from ._bvh import BVH
 from ._cell_quadrature import cell_quadrature
 from ._grid import Grid
 from ._hierarchical_grid import HierarchicalGrid, hierarchical_grid
+from ._overlay import overlay
 from ._tags import CellTags, FacetTags
 from ._tensor_product_grid import TensorProductGrid, tensor_product_grid, uniform_grid
 
@@ -52,6 +55,7 @@ __all__ = [
     "TensorProductGrid",
     "cell_quadrature",
     "hierarchical_grid",
+    "overlay",
     "tensor_product_grid",
     "uniform_grid",
 ]

--- a/src/pantr/grid/_overlay.py
+++ b/src/pantr/grid/_overlay.py
@@ -1,0 +1,126 @@
+"""Overlay of two tensor-product grids.
+
+:func:`overlay` takes two :class:`TensorProductGrid` instances and returns a
+third whose per-axis breakpoints are the union of both inputs' breakpoints,
+restricted to the intersection of their domains. The overlay is the coarsest
+tensor-product grid that simultaneously refines both inputs: every overlay cell
+is contained in exactly one cell of each input.
+
+This is the background-grid bridge for immersed / unfitted quadrature. When a
+B-spline (one knot structure) is integrated over an immersion grid (a different
+structure), each overlay cell falls inside one polynomial piece of the B-spline
+*and* one immersion cell, so a Bernstein patch can be reused without further
+subdivision.
+
+The operation is symmetric -- ``overlay(a, b)`` and ``overlay(b, a)`` produce
+the same breakpoints up to floating-point noise -- and is defined for any
+``ndim >= 1``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ..tolerance import get_default
+from ._tensor_product_grid import TensorProductGrid
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+def overlay(grid_a: TensorProductGrid, grid_b: TensorProductGrid) -> TensorProductGrid:
+    """Return the tensor-product overlay of ``grid_a`` and ``grid_b``.
+
+    The overlay's per-axis breakpoints are the sorted union of both inputs'
+    breakpoint arrays restricted to the intersection of their domains.
+    Breakpoints closer than the default ``float64`` tolerance
+    (:func:`pantr.tolerance.get_default`) are merged into one. The result is the
+    coarsest :class:`TensorProductGrid` that refines both inputs.
+
+    Args:
+        grid_a (TensorProductGrid): First input grid.
+        grid_b (TensorProductGrid): Second input grid; must share
+            :attr:`~TensorProductGrid.ndim` with ``grid_a`` and have a non-empty
+            domain intersection on every axis.
+
+    Returns:
+        TensorProductGrid: The overlay grid.
+
+    Raises:
+        TypeError: If either argument is not a :class:`TensorProductGrid`.
+        ValueError: If the grids have different
+            :attr:`~TensorProductGrid.ndim`, or if their domains do not overlap
+            on some axis (the per-axis intersection is empty or degenerate).
+
+    Example:
+        >>> from pantr.grid import uniform_grid, overlay
+        >>> a = uniform_grid([[0.0, 1.0]], 2)
+        >>> b = uniform_grid([[0.0, 1.0]], 3)
+        >>> overlay(a, b).breakpoints[0]
+        array([0.        , 0.33333333, 0.5       , 0.66666667, 1.        ])
+    """
+    if not isinstance(grid_a, TensorProductGrid) or not isinstance(grid_b, TensorProductGrid):
+        raise TypeError(
+            "overlay() requires two TensorProductGrid instances; got "
+            f"{type(grid_a).__name__!r} and {type(grid_b).__name__!r}."
+        )
+    if grid_a.ndim != grid_b.ndim:
+        raise ValueError(f"overlay(): grids must share ndim; got {grid_a.ndim} vs {grid_b.ndim}.")
+    atol = get_default(np.float64)
+    merged: list[npt.NDArray[np.float64]] = []
+    for d in range(grid_a.ndim):
+        ba = grid_a.breakpoints[d]
+        bb = grid_b.breakpoints[d]
+        lo = max(float(ba[0]), float(bb[0]))
+        hi = min(float(ba[-1]), float(bb[-1]))
+        if hi - lo <= atol:
+            raise ValueError(
+                f"overlay(): domains do not overlap on axis {d}; grid_a extent "
+                f"[{ba[0]}, {ba[-1]}] vs grid_b extent [{bb[0]}, {bb[-1]}]."
+            )
+        merged.append(_merge_axis_breakpoints(ba, bb, lo, hi, atol))
+    return TensorProductGrid(merged)
+
+
+def _merge_axis_breakpoints(
+    ba: npt.NDArray[np.float64],
+    bb: npt.NDArray[np.float64],
+    lo: float,
+    hi: float,
+    atol: float,
+) -> npt.NDArray[np.float64]:
+    """Merge two 1-D breakpoint arrays into their sorted, deduplicated union.
+
+    Only breakpoints strictly inside ``(lo, hi)`` participate; the ``lo`` / ``hi``
+    intersection bounds are always emitted as the first and last entries.
+    Breakpoints closer than ``atol`` are folded into a single entry.
+
+    Args:
+        ba (npt.NDArray[np.float64]): First input's 1-D breakpoints.
+        bb (npt.NDArray[np.float64]): Second input's 1-D breakpoints.
+        lo (float): Lower intersection bound; always emitted first.
+        hi (float): Upper intersection bound; always emitted last.
+        atol (float): Absolute tolerance for merging near-coincident entries.
+
+    Returns:
+        npt.NDArray[np.float64]: Strictly increasing ``float64`` array starting
+        with ``lo`` and ending with ``hi`` (at least two entries).
+    """
+    candidates = np.concatenate(
+        [
+            np.asarray([lo, hi], dtype=np.float64),
+            ba[(ba > lo + atol) & (ba < hi - atol)],
+            bb[(bb > lo + atol) & (bb < hi - atol)],
+        ]
+    )
+    candidates.sort(kind="stable")
+    keep = np.ones(candidates.shape[0], dtype=bool)
+    keep[1:] = np.diff(candidates) > atol
+    merged = candidates[keep]
+    # Pin the exact intersection bounds to wash out any drift from the
+    # concatenate / sort roundtrip (they are already first / last by build).
+    merged[0] = lo
+    merged[-1] = hi
+    return np.ascontiguousarray(merged, dtype=np.float64)

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -1,0 +1,113 @@
+"""Tests for pantr.grid.overlay (coarsest common refinement of two grids)."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as nptest
+import pytest
+
+from pantr.grid import TensorProductGrid, overlay, uniform_grid
+
+
+def test_overlay_union_1d() -> None:
+    """Overlay merges per-axis breakpoints into their sorted union."""
+    result = overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[0.0, 1.0]], 3))
+    nptest.assert_allclose(
+        result.breakpoints[0],
+        [0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0],
+    )
+
+
+def test_overlay_returns_tensor_product_grid() -> None:
+    """Overlay returns a TensorProductGrid of the shared dimension."""
+    result = overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[0.0, 1.0]], 3))
+    assert isinstance(result, TensorProductGrid)
+    assert result.ndim == 1
+
+
+def test_overlay_is_symmetric() -> None:
+    """overlay(a, b) and overlay(b, a) yield the same breakpoints."""
+    a = uniform_grid([[0.0, 2.0], [0.0, 1.0]], [3, 2])
+    b = uniform_grid([[0.0, 2.0], [0.0, 1.0]], [2, 5])
+    ab = overlay(a, b)
+    ba = overlay(b, a)
+    for d in range(a.ndim):
+        nptest.assert_allclose(ab.breakpoints[d], ba.breakpoints[d])
+
+
+def test_overlay_union_2d() -> None:
+    """Each axis of a 2-D overlay is the union of the two inputs' breakpoints."""
+    a = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2])
+    b = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 3])
+    result = overlay(a, b)
+    nptest.assert_allclose(result.breakpoints[0], [0.0, 0.25, 0.5, 0.75, 1.0])
+    nptest.assert_allclose(result.breakpoints[1], [0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0])
+
+
+def test_overlay_refines_both_inputs() -> None:
+    """Every overlay cell lies inside exactly one cell of each input."""
+    a = uniform_grid([[0.0, 2.0], [0.0, 2.0]], [2, 3])
+    b = uniform_grid([[0.0, 2.0], [0.0, 2.0]], [3, 2])
+    result = overlay(a, b)
+    for cid in range(result.num_cells):
+        lo, hi = result.cell_bounds(cid)
+        center = 0.5 * (lo + hi)
+        for parent in (a, b):
+            pid = parent.locate(center)
+            assert pid is not None
+            plo, phi = parent.cell_bounds(pid)
+            assert np.all(plo <= lo + 1e-12)
+            assert np.all(hi <= phi + 1e-12)
+
+
+def test_overlay_high_dimension() -> None:
+    """Overlay is defined for ndim > 3 (generalized beyond ocelat's 2/3-D cap)."""
+    a = uniform_grid([[0.0, 1.0]] * 4, 2)
+    b = uniform_grid([[0.0, 1.0]] * 4, 3)
+    result = overlay(a, b)
+    assert result.ndim == 4
+    for d in range(4):
+        nptest.assert_allclose(result.breakpoints[d], [0.0, 1.0 / 3.0, 0.5, 2.0 / 3.0, 1.0])
+
+
+def test_overlay_restricts_to_domain_intersection() -> None:
+    """Overlay is taken over the intersection of the two domains."""
+    a = uniform_grid([[0.0, 2.0]], 4)  # breakpoints 0, 0.5, 1, 1.5, 2
+    b = uniform_grid([[1.0, 3.0]], 4)  # breakpoints 1, 1.5, 2, 2.5, 3
+    result = overlay(a, b)
+    nptest.assert_allclose(result.breakpoints[0], [1.0, 1.5, 2.0])
+
+
+def test_overlay_merges_near_coincident_breakpoints() -> None:
+    """Breakpoints closer than the float64 tolerance collapse into one."""
+    a = TensorProductGrid([[0.0, 0.5, 1.0]])
+    b = TensorProductGrid([[0.0, 0.5 + 1e-13, 1.0]])
+    result = overlay(a, b)
+    nptest.assert_allclose(result.breakpoints[0], [0.0, 0.5, 1.0])
+
+
+def test_overlay_keeps_distinct_close_breakpoints() -> None:
+    """Breakpoints farther apart than the tolerance are both retained."""
+    a = TensorProductGrid([[0.0, 0.5, 1.0]])
+    b = TensorProductGrid([[0.0, 0.5 + 1e-3, 1.0]])
+    result = overlay(a, b)
+    assert result.breakpoints[0].shape[0] == 4
+
+
+def test_overlay_ndim_mismatch_raises() -> None:
+    """Mismatched ndim is a ValueError."""
+    with pytest.raises(ValueError, match="share ndim"):
+        overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2))
+
+
+def test_overlay_disjoint_domains_raises() -> None:
+    """Non-overlapping domains are a ValueError."""
+    with pytest.raises(ValueError, match="do not overlap"):
+        overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[2.0, 3.0]], 2))
+
+
+def test_overlay_non_grid_input_raises() -> None:
+    """Non-TensorProductGrid inputs are a TypeError."""
+    grid = uniform_grid([[0.0, 1.0]], 2)
+    with pytest.raises(TypeError, match="TensorProductGrid"):
+        overlay(grid, object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Add `pantr.grid.overlay(grid_a, grid_b) -> TensorProductGrid`: the coarsest tensor-product grid that simultaneously refines both inputs. Per-axis breakpoints are the union of both inputs' breakpoints, restricted to their domain overlap, so every overlay cell lies inside exactly one cell of each input.
- Generalized to any `ndim >= 1` (drops ocelat's 2-D/3-D cap); uses pantr's `ValueError`/`TypeError` and the project `float64` tolerance (`pantr.tolerance.get_default`) for near-coincident breakpoint merging.
- Exported from `pantr.grid`; documented via `automodule`; changelog entry under Unreleased.

This is the per-cell-quadrature background-grid bridge for immersed / unfitted discretizations, promoted from `ocelat.mesh._overlay` as the next step of the `pantr.grid` migration (#152). A pantr 0.5.1 release will ship it so ocelat can consume it and drop its own mesh layer.

## Test plan
- [x] New `tests/test_grid_overlay.py` (12 tests): union correctness (1-D/2-D/4-D), symmetry, refinement invariant (each overlay cell ⊂ one cell of each input), domain-intersection restriction, tolerance dedup vs. distinct-close retention, ndim-mismatch/disjoint-domain `ValueError`, non-grid `TypeError`.
- [x] Full suite: 2826 passed.
- [x] Pre-PR checks: ruff, ruff-format, mypy, `-W` docs build.

Generated with [Claude Code](https://claude.com/claude-code)