### PR TITLE
chore(release): pantr 0.5.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.1 (2026-06-03)
 
 ### Added
 - `pantr.grid.overlay`: build the coarsest `TensorProductGrid` that refines two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pantr"
-version = "0.5.0"
+version = "0.5.1"
 description = "Polynomial And NURBS Toolkit"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -34,7 +34,7 @@ from ._parallel import get_num_threads, num_threads, set_num_threads
 from .basis import _basis_utils  # noqa: F401
 
 # Package metadata
-__version__: Final[str] = "0.5.0"
+__version__: Final[str] = "0.5.1"
 __license__: Final[str] = "MIT"
 __author__: Final[str] = "Pablo Antolin <pablo.antolin@epfl.ch>"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,7 +36,7 @@ def test_package_all_exports() -> None:
 
 def test_package_metadata_values() -> None:
     """Validate the package metadata constants."""
-    assert pantr.__version__ == "0.5.0"
+    assert pantr.__version__ == "0.5.1"
     assert pantr.__license__ == "MIT"
     assert pantr.__author__ == "Pablo Antolin <pablo.antolin@epfl.ch>"
 
@@ -44,7 +44,7 @@ def test_package_metadata_values() -> None:
 def test_metadata_import_stability() -> None:
     """Verify metadata survives module reloads."""
     module = importlib.reload(pantr)
-    assert module.__version__ == "0.5.0"
+    assert module.__version__ == "0.5.1"
 
 
 def test_submodule_all_exports() -> None:


### PR DESCRIPTION
## Summary
- Release **pantr 0.5.1**, shipping `pantr.grid.overlay` (#161) — the coarsest common refinement of two tensor-product grids (background-grid bridge for immersed/unfitted quadrature).
- Version bump in `pyproject.toml`, `pantr.__version__`, and `tests/test_metadata.py`; changelog `## Unreleased` → `## 0.5.1 (2026-06-03)`.

This unblocks the ocelat migration onto `pantr.grid` (ocelat pins `pantr` by tag).

## Test plan
- [x] `tests/test_metadata.py` passes with `0.5.1`.
- [x] Full suite + ruff + mypy + docs green on the overlay PR (#161) already in `main`.

Generated with [Claude Code](https://claude.com/claude-code)