### PR TITLE
fix(grid): address overlay post-merge review findings

### DIFF
--- a/src/pantr/grid/_overlay.py
+++ b/src/pantr/grid/_overlay.py
@@ -55,11 +55,14 @@ def overlay(grid_a: TensorProductGrid, grid_b: TensorProductGrid) -> TensorProdu
             on some axis (the per-axis intersection is empty or degenerate).
 
     Example:
+        >>> import numpy.testing as npt
         >>> from pantr.grid import uniform_grid, overlay
         >>> a = uniform_grid([[0.0, 1.0]], 2)
         >>> b = uniform_grid([[0.0, 1.0]], 3)
-        >>> overlay(a, b).breakpoints[0]
-        array([0.        , 0.33333333, 0.5       , 0.66666667, 1.        ])
+        >>> npt.assert_allclose(
+        ...     overlay(a, b).breakpoints[0],
+        ...     [0.0, 1/3, 0.5, 2/3, 1.0],
+        ... )
     """
     if not isinstance(grid_a, TensorProductGrid) or not isinstance(grid_b, TensorProductGrid):
         raise TypeError(
@@ -119,8 +122,8 @@ def _merge_axis_breakpoints(
     keep = np.ones(candidates.shape[0], dtype=bool)
     keep[1:] = np.diff(candidates) > atol
     merged = candidates[keep]
-    # Pin the exact intersection bounds to wash out any drift from the
-    # concatenate / sort roundtrip (they are already first / last by build).
+    # Belt-and-suspenders: re-pin lo/hi so any float conversion noise in
+    # the sort/concatenate path doesn't alter the caller-supplied bounds.
     merged[0] = lo
     merged[-1] = hi
     return np.ascontiguousarray(merged, dtype=np.float64)

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -106,6 +106,12 @@ def test_overlay_disjoint_domains_raises() -> None:
         overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[2.0, 3.0]], 2))
 
 
+def test_overlay_touching_domains_raises() -> None:
+    """Domains that share only an endpoint (zero-width intersection) are a ValueError."""
+    with pytest.raises(ValueError, match="do not overlap"):
+        overlay(uniform_grid([[0.0, 1.0]], 2), uniform_grid([[1.0, 2.0]], 2))
+
+
 def test_overlay_non_grid_input_raises() -> None:
     """Non-TensorProductGrid inputs are a TypeError."""
     grid = uniform_grid([[0.0, 1.0]], 2)


### PR DESCRIPTION
## Summary

- Replace version-sensitive `array([...])` repr in the `overlay()` docstring example with `npt.assert_allclose(...)` so doctests do not break across NumPy versions.
- Clarify the lo/hi re-pinning comment in `_merge_axis_breakpoints`: belt-and-suspenders against float conversion noise, not expected drift.
- Add `test_overlay_touching_domains_raises` to cover the zero-width intersection edge case (`[0,1]` + `[1,2]` → `ValueError`).

## Test plan

- [ ] `pytest tests/test_grid_overlay.py --no-cov` — all 13 tests pass (12 original + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)