### PR TITLE
feat(bspline): THBSplineSpace core — hierarchical B-spline space (HB path, PR1 of #164)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -18,6 +18,8 @@ This package consolidates the B-spline API:
 - :class:`ExtractionStructView`, :func:`make_struct_view`: Numba-passable
   bundle of a :class:`SpanwiseElementExtraction`'s compact storage for
   downstream ``@njit`` code.
+- :class:`THBSplineSpace`: hierarchical B-spline space (truncated /
+  non-truncated) on a :class:`pantr.grid.HierarchicalGrid`.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -32,6 +34,7 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace
+from ._thb_spline_space import THBSplineSpace
 from .spanwise_element_extraction import (
     ExtractionStructView,
     SpanwiseElementExtraction,
@@ -44,6 +47,7 @@ __all__ = [
     "BsplineSpace1D",
     "ExtractionStructView",
     "SpanwiseElementExtraction",
+    "THBSplineSpace",
     "create_cardinal_knots",
     "create_from_bezier",
     "create_greville_lattice",

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -133,8 +133,6 @@ class THBSplineSpace:
         "_truncate",
     )
 
-    _support: tuple[tuple[_Support1D, ...], ...]
-
     def __init__(
         self,
         root_space: BsplineSpace,

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -3,13 +3,8 @@
 This module defines :class:`THBSplineSpace`, a hierarchical spline space built on
 a :class:`pantr.grid.HierarchicalGrid`.  It follows the G+Smo *self-evaluating*
 model: per level it stores the Kraft selection of active tensor-product B-splines,
-and (from PR2 onward) a sparse coefficient vector only for truncated functions.
-Untruncated functions are plain tensor-product B-splines.
-
-This first increment implements the **non-truncated hierarchical (HB)** path
-(``truncate=False``): nested per-level spaces, the active-function selection, and
-value evaluation.  Truncation (``truncate=True``) and derivatives land in later
-increments (see GitHub issue #164).
+and (once truncation is implemented, GitHub issue #164) a sparse coefficient vector
+only for truncated functions.  Untruncated functions are plain tensor-product B-splines.
 
 Main exports:
 
@@ -78,6 +73,10 @@ def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
             if first_cell[i] < 0:
                 first_cell[i] = interval
             last_cell[i] = interval
+    assert np.all(first_cell >= 0), (
+        f"B-spline function(s) with empty support detected at indices "
+        f"{np.where(first_cell < 0)[0].tolist()}. This indicates an invalid B-spline space."
+    )
     return first_basis, first_cell, last_cell
 
 
@@ -92,31 +91,40 @@ class THBSplineSpace:
     its support lies in the level-``l`` subdomain :math:`\Omega_l` but not entirely
     in the finer subdomain :math:`\Omega_{l+1}`.
 
-    This increment implements only the **non-truncated (HB)** basis
-    (``truncate=False``); ``truncate=True`` raises :class:`NotImplementedError`
-    (truncation lands in a later increment, GitHub issue #164).
+    This space is a snapshot of the grid at construction time.  Calling
+    :meth:`~pantr.grid.HierarchicalGrid.refine` on the underlying grid after
+    construction invalidates this space; subsequent calls to :meth:`active_basis` or
+    :meth:`tabulate_basis` will raise :class:`RuntimeError`.  Create a new
+    :class:`THBSplineSpace` from the updated grid instead.
+
+    Truncation (``truncate=True``) is not yet implemented; see GitHub issue #164.
 
     Attributes:
         _root_space (BsplineSpace): The level-0 tensor-product space.
-        _grid (HierarchicalGrid): The active-cell hierarchy.
-        _truncate (bool): Whether the basis is truncated (always ``False`` here).
+        _grid (HierarchicalGrid): The active-cell hierarchy (snapshot reference).
+        _truncate (bool): Whether the truncated (THB) basis is used; ``False`` for
+            the plain hierarchical (HB) basis.
         _regularity (tuple[int | None, ...]): Per-direction continuity used when
             subdividing to build finer levels.
         _level_spaces (tuple[BsplineSpace, ...]): Per-level tensor-product spaces;
             index ``l`` is the root subdivided to level ``l``.
-        _support (tuple): Per-level, per-direction function-to-cell support arrays
-            (one ``_Support1D`` triple per direction per level).
+        _support (tuple[tuple[_Support1D, ...], ...]): Per-level, per-direction
+            function-to-cell support arrays (one ``_Support1D`` triple per direction
+            per level).
         _active_funcs (tuple[npt.NDArray[np.int64], ...]): Per-level sorted flat
             (C-order) indices of the active tensor-product functions.
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
             ``num_levels + 1`` (cumulative active-function counts).
         _num_active (int): Total number of active hierarchical functions.
+        _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
+            construction; used to detect post-construction grid mutations.
     """
 
     __slots__ = (
         "_active_funcs",
         "_func_offset",
         "_grid",
+        "_grid_snapshot",
         "_level_spaces",
         "_num_active",
         "_regularity",
@@ -125,12 +133,14 @@ class THBSplineSpace:
         "_truncate",
     )
 
+    _support: tuple[tuple[_Support1D, ...], ...]
+
     def __init__(
         self,
         root_space: BsplineSpace,
         grid: HierarchicalGrid,
         *,
-        truncate: bool = True,
+        truncate: bool = False,
         regularity: int | Sequence[int | None] | None = None,
     ) -> None:
         """Create a hierarchical B-spline space.
@@ -139,19 +149,26 @@ class THBSplineSpace:
             root_space (BsplineSpace): The level-0 tensor-product B-spline space.
             grid (HierarchicalGrid): Hierarchical grid whose root knot-span grid
                 matches ``root_space``.
-            truncate (bool): If ``True`` (default), build the truncated basis.
-                **Not yet implemented** — raises :class:`NotImplementedError`.
-                Use ``truncate=False`` for the non-truncated hierarchical basis.
+            truncate (bool): If ``True``, build the truncated basis.  **Not yet
+                implemented** — raises :class:`NotImplementedError`.  Defaults to
+                ``False`` (non-truncated hierarchical basis).
             regularity (int | Sequence[int | None] | None): Per-direction continuity
                 at the knots inserted when subdividing to finer levels.  A scalar is
                 broadcast to every axis; ``None`` (default) uses maximal smoothness.
+                Each non-``None`` entry must satisfy ``-1 <= regularity[k] < degree[k]``.
 
         Raises:
-            TypeError: If ``grid`` is not a :class:`~pantr.grid.HierarchicalGrid`.
+            TypeError: If ``root_space`` is not a :class:`~pantr.bspline.BsplineSpace`
+                or ``grid`` is not a :class:`~pantr.grid.HierarchicalGrid`.
             ValueError: If ``grid`` and ``root_space`` disagree on dimension or on
-                the root knot-span grid, or if ``regularity`` has the wrong length.
+                the root knot-span grid, if ``regularity`` has the wrong length, or
+                if any per-direction regularity value is out of range.
             NotImplementedError: If ``truncate`` is ``True``.
         """
+        if not isinstance(root_space, BsplineSpace):
+            raise TypeError(
+                f"root_space must be a BsplineSpace; got {type(root_space).__name__!r}."
+            )
         if not isinstance(grid, HierarchicalGrid):
             raise TypeError(f"grid must be a HierarchicalGrid; got {type(grid).__name__!r}.")
         dim = root_space.dim
@@ -175,6 +192,11 @@ class THBSplineSpace:
             if len(reg) != dim:
                 raise ValueError(
                     f"regularity must be a scalar or length-{dim} sequence; got length {len(reg)}."
+                )
+        for k, (r, d) in enumerate(zip(reg, root_space.degrees, strict=False)):
+            if r is not None and not (-1 <= r < d):
+                raise ValueError(
+                    f"regularity[{k}]={r!r} must be in [-1, degree[{k}]-1={d - 1}]; got {r!r}."
                 )
 
         if truncate:
@@ -200,6 +222,7 @@ class THBSplineSpace:
             np.int64
         )
         self._num_active = int(self._func_offset[-1])
+        self._grid_snapshot = (grid.max_level, grid.num_cells)
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -230,9 +253,9 @@ class THBSplineSpace:
     def _select_active_functions(self) -> tuple[npt.NDArray[np.int64], ...]:
         r"""Compute the Kraft selection of active functions per level.
 
-        A level-``l`` tensor-product function is selected iff its support lies in
-        :math:`\Omega_l` (``subdomain_mask``) but not entirely in
-        :math:`\Omega_{l+1}` (``subdomain_mask & ~active_leaf_mask``).
+        A level-``l`` tensor-product function is selected iff its support lies
+        entirely in :math:`\Omega_l` (``subdomain_mask``) but not entirely in the
+        further-refined region (``subdomain_mask & ~active_leaf_mask``).
 
         Returns:
             tuple[npt.NDArray[np.int64], ...]: Per-level sorted flat (C-order)
@@ -273,17 +296,31 @@ class THBSplineSpace:
             active.append(np.array(sorted(selected), dtype=np.int64))
         return tuple(active)
 
+    def _check_not_stale(self) -> None:
+        """Raise if the grid has been modified since this space was constructed.
+
+        Raises:
+            RuntimeError: If the grid's ``max_level`` or ``num_cells`` differs from
+                the snapshot taken at construction.
+        """
+        if (self._grid.max_level, self._grid.num_cells) != self._grid_snapshot:
+            raise RuntimeError(
+                "THBSplineSpace is stale: the underlying HierarchicalGrid has been modified "
+                "after construction. Create a new THBSplineSpace from the updated grid."
+            )
+
     def _cell_contributions(self, cid: int) -> list[tuple[int, int, tuple[int, ...]]]:
         """Return the active functions non-zero on cell ``cid``.
 
         Args:
-            cid (int): Active cell flat id.
+            cid (int): Active cell flat id in ``[0, grid.num_cells)``.
 
         Returns:
             list[tuple[int, int, tuple[int, ...]]]: ``(global_dof, level, multi)``
-            triples sorted by ``global_dof``, where ``multi`` is the contributing
-            function's flat-free multi-index in its level space.
+            triples sorted by ``global_dof``, where ``multi`` is the per-axis function
+            index tuple (multi-index) in its level space.
         """
+        self._check_not_stale()
         cell_level = self._grid.cell_level(cid)
         cell_midx = self._grid.cell_multi_index(cid)
         factor = self._grid.factor
@@ -351,19 +388,20 @@ class THBSplineSpace:
 
     @property
     def num_levels(self) -> int:
-        """Get the number of hierarchy levels.
+        """Get the number of hierarchy levels at construction time.
 
         Returns:
-            int: ``grid.max_level + 1``.
+            int: Number of levels; stable even if the grid is later refined.
         """
-        return self._grid.max_level + 1
+        return len(self._level_spaces)
 
     @property
     def truncate(self) -> bool:
         """Get whether the hierarchical basis is truncated.
 
         Returns:
-            bool: ``True`` for THB, ``False`` for plain HB.
+            bool: ``True`` for THB, ``False`` for plain HB.  Always ``False``
+            until truncation is implemented (GitHub issue #164).
         """
         return self._truncate
 
@@ -427,14 +465,15 @@ class THBSplineSpace:
         """Return the global dofs of the active functions non-zero on cell ``cid``.
 
         Args:
-            cid (int): Active cell flat id.
+            cid (int): Active cell flat id in ``[0, grid.num_cells)``.
 
         Returns:
             npt.NDArray[np.int64]: Sorted global hierarchical-dof indices of the
             functions whose support intersects cell ``cid``.
 
         Raises:
-            IndexError: If ``cid`` is out of range.
+            IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
+            RuntimeError: If the grid has been modified since construction.
         """
         return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
 
@@ -452,9 +491,10 @@ class THBSplineSpace:
         :meth:`active_basis` (sorted global dof).
 
         Args:
-            cid (int): Active cell flat id.
+            cid (int): Active cell flat id in ``[0, grid.num_cells)``.
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
-                cell ``cid``.
+                cell ``cid``.  Points outside the cell's bounds raise
+                :class:`ValueError`.
             out (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
                 ``None``.
@@ -463,11 +503,13 @@ class THBSplineSpace:
             npt.NDArray[np.float64]: Function values of shape ``(..., K)``.
 
         Raises:
-            IndexError: If ``cid`` is out of range.
-            ValueError: If ``pts`` does not have trailing dimension ``dim`` or
-                ``out`` has the wrong shape, dtype, or is not writeable.
+            IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
+            ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
+                point lies outside the bounds of cell ``cid``, or if ``out`` has the
+                wrong shape, dtype, or is not writeable.
+            RuntimeError: If the grid has been modified since construction.
         """
-        contribs = self._cell_contributions(cid)
+        contribs = self._cell_contributions(cid)  # validates cid; raises if stale
         n_active = len(contribs)
 
         pts_arr = np.asarray(pts, dtype=np.float64)
@@ -478,6 +520,14 @@ class THBSplineSpace:
         lead = pts_arr.shape[:-1]
         num_pts = int(np.prod(lead)) if lead else 1
         flat_pts = pts_arr.reshape(num_pts, self.dim)
+
+        cell_lo, cell_hi = self._grid.cell_bounds(cid)
+        _tol = 1e-12
+        if not (np.all(flat_pts >= cell_lo - _tol) and np.all(flat_pts <= cell_hi + _tol)):
+            raise ValueError(
+                f"pts must lie inside cell {cid!r} with bounds lo={cell_lo}, hi={cell_hi}."
+            )
+
         out_shape = (*lead, n_active)
 
         if out is None:
@@ -519,10 +569,11 @@ class THBSplineSpace:
         return result
 
     def __repr__(self) -> str:
-        """Return a compact developer-friendly representation.
+        """Return a compact string representation.
 
         Returns:
-            str: Shows dimension, degrees, level count, and active-function count.
+            str: Shows dimension, degrees, level count, active-function count, and
+            truncation flag.
         """
         return (
             f"THBSplineSpace(dim={self.dim}, degrees={self.degrees}, "

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1,0 +1,531 @@
+"""Truncated hierarchical B-spline spaces (THB-splines).
+
+This module defines :class:`THBSplineSpace`, a hierarchical spline space built on
+a :class:`pantr.grid.HierarchicalGrid`.  It follows the G+Smo *self-evaluating*
+model: per level it stores the Kraft selection of active tensor-product B-splines,
+and (from PR2 onward) a sparse coefficient vector only for truncated functions.
+Untruncated functions are plain tensor-product B-splines.
+
+This first increment implements the **non-truncated hierarchical (HB)** path
+(``truncate=False``): nested per-level spaces, the active-function selection, and
+value evaluation.  Truncation (``truncate=True``) and derivatives land in later
+increments (see GitHub issue #164).
+
+Main exports:
+
+- :class:`THBSplineSpace`: hierarchical B-spline space on a
+  :class:`~pantr.grid.HierarchicalGrid`.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ..grid import HierarchicalGrid
+from ._bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy.typing as npt
+
+    from ._bspline_space_1d import BsplineSpace1D
+
+_Support1D = tuple[
+    "npt.NDArray[np.int64]",
+    "npt.NDArray[np.int64]",
+    "npt.NDArray[np.int64]",
+]
+"""Per-direction function support at one level.
+
+``(first_basis_per_interval, first_cell_per_function, last_cell_per_function)``,
+all ``int64`` arrays.
+"""
+
+
+def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
+    """Compute the cell support of every B-spline function of a 1D space.
+
+    The first non-zero function index per interval is obtained from
+    :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` evaluated at interval
+    midpoints (robust to knot multiplicities), then inverted to give, for each
+    function ``i``, the inclusive interval (cell) range ``[first_cell, last_cell]``
+    it is supported on.
+
+    Args:
+        space (BsplineSpace1D): The 1D B-spline space.
+
+    Returns:
+        _Support1D: ``(first_basis, first_cell, last_cell)`` where ``first_basis``
+        has length ``num_intervals`` and ``first_cell`` / ``last_cell`` have length
+        ``num_basis``.
+    """
+    unique_knots, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
+    midpoints = 0.5 * (unique_knots[:-1] + unique_knots[1:])
+    _, first_basis_per_pt = space.tabulate_basis(midpoints)
+    first_basis = np.asarray(first_basis_per_pt, dtype=np.int64)
+
+    degree = space.degree
+    n_basis = space.num_basis
+    first_cell = np.full(n_basis, -1, dtype=np.int64)
+    last_cell = np.full(n_basis, -1, dtype=np.int64)
+    for interval in range(first_basis.shape[0]):
+        lo_i = int(first_basis[interval])
+        for i in range(lo_i, lo_i + degree + 1):
+            if first_cell[i] < 0:
+                first_cell[i] = interval
+            last_cell[i] = interval
+    return first_basis, first_cell, last_cell
+
+
+class THBSplineSpace:
+    r"""Hierarchical B-spline space on a :class:`~pantr.grid.HierarchicalGrid`.
+
+    Built from a root :class:`~pantr.bspline.BsplineSpace` (level 0) and a
+    :class:`~pantr.grid.HierarchicalGrid` carrying the active-cell hierarchy.  The
+    per-level tensor-product spaces are obtained by uniformly subdividing the root
+    space according to the grid's per-direction ``factor``.  The active hierarchical
+    basis is the Kraft selection: a level-``l`` tensor-product B-spline is active iff
+    its support lies in the level-``l`` subdomain :math:`\Omega_l` but not entirely
+    in the finer subdomain :math:`\Omega_{l+1}`.
+
+    This increment implements only the **non-truncated (HB)** basis
+    (``truncate=False``); ``truncate=True`` raises :class:`NotImplementedError`
+    (truncation lands in a later increment, GitHub issue #164).
+
+    Attributes:
+        _root_space (BsplineSpace): The level-0 tensor-product space.
+        _grid (HierarchicalGrid): The active-cell hierarchy.
+        _truncate (bool): Whether the basis is truncated (always ``False`` here).
+        _regularity (tuple[int | None, ...]): Per-direction continuity used when
+            subdividing to build finer levels.
+        _level_spaces (tuple[BsplineSpace, ...]): Per-level tensor-product spaces;
+            index ``l`` is the root subdivided to level ``l``.
+        _support (tuple): Per-level, per-direction function-to-cell support arrays
+            (one ``_Support1D`` triple per direction per level).
+        _active_funcs (tuple[npt.NDArray[np.int64], ...]): Per-level sorted flat
+            (C-order) indices of the active tensor-product functions.
+        _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
+            ``num_levels + 1`` (cumulative active-function counts).
+        _num_active (int): Total number of active hierarchical functions.
+    """
+
+    __slots__ = (
+        "_active_funcs",
+        "_func_offset",
+        "_grid",
+        "_level_spaces",
+        "_num_active",
+        "_regularity",
+        "_root_space",
+        "_support",
+        "_truncate",
+    )
+
+    def __init__(
+        self,
+        root_space: BsplineSpace,
+        grid: HierarchicalGrid,
+        *,
+        truncate: bool = True,
+        regularity: int | Sequence[int | None] | None = None,
+    ) -> None:
+        """Create a hierarchical B-spline space.
+
+        Args:
+            root_space (BsplineSpace): The level-0 tensor-product B-spline space.
+            grid (HierarchicalGrid): Hierarchical grid whose root knot-span grid
+                matches ``root_space``.
+            truncate (bool): If ``True`` (default), build the truncated basis.
+                **Not yet implemented** — raises :class:`NotImplementedError`.
+                Use ``truncate=False`` for the non-truncated hierarchical basis.
+            regularity (int | Sequence[int | None] | None): Per-direction continuity
+                at the knots inserted when subdividing to finer levels.  A scalar is
+                broadcast to every axis; ``None`` (default) uses maximal smoothness.
+
+        Raises:
+            TypeError: If ``grid`` is not a :class:`~pantr.grid.HierarchicalGrid`.
+            ValueError: If ``grid`` and ``root_space`` disagree on dimension or on
+                the root knot-span grid, or if ``regularity`` has the wrong length.
+            NotImplementedError: If ``truncate`` is ``True``.
+        """
+        if not isinstance(grid, HierarchicalGrid):
+            raise TypeError(f"grid must be a HierarchicalGrid; got {type(grid).__name__!r}.")
+        dim = root_space.dim
+        if grid.ndim != dim:
+            raise ValueError(f"grid.ndim ({grid.ndim}) must equal root_space.dim ({dim}).")
+        if tuple(grid.root.cells_per_axis) != tuple(root_space.num_intervals):
+            raise ValueError(
+                f"grid root cells_per_axis {tuple(grid.root.cells_per_axis)!r} must match "
+                f"root_space.num_intervals {tuple(root_space.num_intervals)!r}."
+            )
+        if not np.allclose(
+            np.asarray(grid.root.bounds, dtype=np.float64),
+            np.asarray(root_space.domain, dtype=np.float64),
+        ):
+            raise ValueError("grid root bounds must match root_space domain.")
+
+        if regularity is None or isinstance(regularity, int):
+            reg: tuple[int | None, ...] = (regularity,) * dim
+        else:
+            reg = tuple(regularity)
+            if len(reg) != dim:
+                raise ValueError(
+                    f"regularity must be a scalar or length-{dim} sequence; got length {len(reg)}."
+                )
+
+        if truncate:
+            raise NotImplementedError(
+                "truncation (truncate=True) is not implemented yet; it lands in a later "
+                "increment (GitHub issue #164). Use truncate=False for the non-truncated "
+                "hierarchical (HB) basis."
+            )
+
+        self._root_space = root_space
+        self._grid = grid
+        self._truncate = truncate
+        self._regularity = reg
+
+        self._level_spaces = self._build_level_spaces()
+        self._support = tuple(
+            tuple(_func_support_1d(sp1d) for sp1d in level_space.spaces)
+            for level_space in self._level_spaces
+        )
+        self._active_funcs = self._select_active_functions()
+        counts = [int(a.shape[0]) for a in self._active_funcs]
+        self._func_offset = np.concatenate(([0], np.cumsum(counts, dtype=np.int64))).astype(
+            np.int64
+        )
+        self._num_active = int(self._func_offset[-1])
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    def _build_level_spaces(self) -> tuple[BsplineSpace, ...]:
+        """Build the nested per-level tensor-product spaces.
+
+        Level ``l + 1`` is obtained from level ``l`` by subdividing every 1D space
+        by the grid ``factor`` (skipping axes whose factor is ``1``), which keeps
+        the level spaces nested.
+
+        Returns:
+            tuple[BsplineSpace, ...]: Spaces of length ``num_levels``.
+        """
+        factor = self._grid.factor
+        reg = self._regularity
+        current = list(self._root_space.spaces)
+        level_spaces: list[BsplineSpace] = [self._root_space]
+        for _ in range(1, self._grid.max_level + 1):
+            current = [
+                sp if factor[k] == 1 else sp.subdivide(factor[k], reg[k])
+                for k, sp in enumerate(current)
+            ]
+            level_spaces.append(BsplineSpace(current))
+        return tuple(level_spaces)
+
+    def _select_active_functions(self) -> tuple[npt.NDArray[np.int64], ...]:
+        r"""Compute the Kraft selection of active functions per level.
+
+        A level-``l`` tensor-product function is selected iff its support lies in
+        :math:`\Omega_l` (``subdomain_mask``) but not entirely in
+        :math:`\Omega_{l+1}` (``subdomain_mask & ~active_leaf_mask``).
+
+        Returns:
+            tuple[npt.NDArray[np.int64], ...]: Per-level sorted flat (C-order)
+            indices of the active functions.
+        """
+        dim = self.dim
+        active: list[npt.NDArray[np.int64]] = []
+        for level in range(self.num_levels):
+            num_basis = self._level_spaces[level].num_basis
+            subdomain = self._grid.subdomain_mask(level)
+            refined = subdomain & ~self._grid.active_leaf_mask(level)
+            support = self._support[level]
+
+            true_coords = np.argwhere(subdomain)
+            if true_coords.shape[0] == 0:
+                active.append(np.empty(0, dtype=np.int64))
+                continue
+            bbox_lo = true_coords.min(axis=0)
+            bbox_hi = true_coords.max(axis=0) + 1
+
+            candidates_per_dir: list[list[int]] = []
+            for k in range(dim):
+                _, first_cell, last_cell = support[k]
+                overlaps = (last_cell >= bbox_lo[k]) & (first_cell < bbox_hi[k])
+                candidates_per_dir.append(np.nonzero(overlaps)[0].tolist())
+
+            selected: list[int] = []
+            for multi in itertools.product(*candidates_per_dir):
+                box = tuple(
+                    slice(int(support[k][1][multi[k]]), int(support[k][2][multi[k]]) + 1)
+                    for k in range(dim)
+                )
+                if not bool(subdomain[box].all()):
+                    continue
+                if bool(refined[box].all()):
+                    continue
+                selected.append(int(np.ravel_multi_index(multi, num_basis)))
+            active.append(np.array(sorted(selected), dtype=np.int64))
+        return tuple(active)
+
+    def _cell_contributions(self, cid: int) -> list[tuple[int, int, tuple[int, ...]]]:
+        """Return the active functions non-zero on cell ``cid``.
+
+        Args:
+            cid (int): Active cell flat id.
+
+        Returns:
+            list[tuple[int, int, tuple[int, ...]]]: ``(global_dof, level, multi)``
+            triples sorted by ``global_dof``, where ``multi`` is the contributing
+            function's flat-free multi-index in its level space.
+        """
+        cell_level = self._grid.cell_level(cid)
+        cell_midx = self._grid.cell_multi_index(cid)
+        factor = self._grid.factor
+        dim = self.dim
+        contribs: list[tuple[int, int, tuple[int, ...]]] = []
+        for level in range(cell_level + 1):
+            divisor = tuple(factor[k] ** (cell_level - level) for k in range(dim))
+            cell_at_level = tuple(cell_midx[k] // divisor[k] for k in range(dim))
+            num_basis = self._level_spaces[level].num_basis
+            support = self._support[level]
+            ranges = []
+            for k in range(dim):
+                first_basis = support[k][0]
+                f0 = int(first_basis[cell_at_level[k]])
+                ranges.append(range(f0, f0 + self.degrees[k] + 1))
+            active_at_level = self._active_funcs[level]
+            offset = int(self._func_offset[level])
+            for multi in itertools.product(*ranges):
+                flat = int(np.ravel_multi_index(multi, num_basis))
+                pos = int(np.searchsorted(active_at_level, flat))
+                if pos < active_at_level.shape[0] and int(active_at_level[pos]) == flat:
+                    contribs.append((offset + pos, level, multi))
+        contribs.sort(key=lambda triple: triple[0])
+        return contribs
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def grid(self) -> HierarchicalGrid:
+        """Get the underlying hierarchical grid.
+
+        Returns:
+            HierarchicalGrid: The active-cell hierarchy this space is built on.
+        """
+        return self._grid
+
+    @property
+    def root_space(self) -> BsplineSpace:
+        """Get the level-0 tensor-product space.
+
+        Returns:
+            BsplineSpace: The root B-spline space.
+        """
+        return self._root_space
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension.
+
+        Returns:
+            int: Number of parametric directions.
+        """
+        return self._root_space.dim
+
+    @property
+    def degrees(self) -> tuple[int, ...]:
+        """Get the per-direction polynomial degrees.
+
+        Returns:
+            tuple[int, ...]: Degree per direction (the same at every level).
+        """
+        return self._root_space.degrees
+
+    @property
+    def num_levels(self) -> int:
+        """Get the number of hierarchy levels.
+
+        Returns:
+            int: ``grid.max_level + 1``.
+        """
+        return self._grid.max_level + 1
+
+    @property
+    def truncate(self) -> bool:
+        """Get whether the hierarchical basis is truncated.
+
+        Returns:
+            bool: ``True`` for THB, ``False`` for plain HB.
+        """
+        return self._truncate
+
+    @property
+    def num_active_functions(self) -> int:
+        """Get the total number of active hierarchical functions.
+
+        Returns:
+            int: Total active-function count across all levels.
+        """
+        return self._num_active
+
+    @property
+    def num_active_functions_per_level(self) -> tuple[int, ...]:
+        """Get the number of active functions at each level.
+
+        Returns:
+            tuple[int, ...]: Active-function count per level.
+        """
+        return tuple(int(a.shape[0]) for a in self._active_funcs)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def level_space(self, level: int) -> BsplineSpace:
+        """Return the tensor-product space at ``level``.
+
+        Args:
+            level (int): Hierarchy level in ``[0, num_levels)``.
+
+        Returns:
+            BsplineSpace: The root space subdivided to ``level``.
+
+        Raises:
+            IndexError: If ``level`` is out of range.
+        """
+        if not (0 <= level < self.num_levels):
+            raise IndexError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
+        return self._level_spaces[level]
+
+    def active_function_indices(self, level: int) -> npt.NDArray[np.int64]:
+        """Return the flat indices of the active functions at ``level``.
+
+        Args:
+            level (int): Hierarchy level in ``[0, num_levels)``.
+
+        Returns:
+            npt.NDArray[np.int64]: Sorted flat (C-order) level-``level`` function
+            indices selected by the Kraft rule.  A fresh copy is returned.
+
+        Raises:
+            IndexError: If ``level`` is out of range.
+        """
+        if not (0 <= level < self.num_levels):
+            raise IndexError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
+        indices: npt.NDArray[np.int64] = self._active_funcs[level].copy()
+        return indices
+
+    def active_basis(self, cid: int) -> npt.NDArray[np.int64]:
+        """Return the global dofs of the active functions non-zero on cell ``cid``.
+
+        Args:
+            cid (int): Active cell flat id.
+
+        Returns:
+            npt.NDArray[np.int64]: Sorted global hierarchical-dof indices of the
+            functions whose support intersects cell ``cid``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+        """
+        return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
+
+    def tabulate_basis(
+        self,
+        cid: int,
+        pts: npt.ArrayLike,
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Evaluate the active hierarchical functions on cell ``cid`` at ``pts``.
+
+        For the non-truncated basis, each active function is a single
+        tensor-product B-spline; the value is the product of its 1D B-spline values
+        at the corresponding level.  The returned columns are ordered as
+        :meth:`active_basis` (sorted global dof).
+
+        Args:
+            cid (int): Active cell flat id.
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
+                cell ``cid``.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
+                ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: Function values of shape ``(..., K)``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+            ValueError: If ``pts`` does not have trailing dimension ``dim`` or
+                ``out`` has the wrong shape, dtype, or is not writeable.
+        """
+        contribs = self._cell_contributions(cid)
+        n_active = len(contribs)
+
+        pts_arr = np.asarray(pts, dtype=np.float64)
+        if pts_arr.ndim == 0 or pts_arr.shape[-1] != self.dim:
+            raise ValueError(
+                f"pts must have trailing dimension {self.dim}; got shape {pts_arr.shape}."
+            )
+        lead = pts_arr.shape[:-1]
+        num_pts = int(np.prod(lead)) if lead else 1
+        flat_pts = pts_arr.reshape(num_pts, self.dim)
+        out_shape = (*lead, n_active)
+
+        if out is None:
+            result = np.empty(out_shape, dtype=np.float64)
+        else:
+            if out.shape != out_shape:
+                raise ValueError(f"out must have shape {out_shape}; got {out.shape}.")
+            if out.dtype != np.float64:
+                raise ValueError(f"out must have dtype float64; got {out.dtype}.")
+            if not out.flags.writeable:
+                raise ValueError("out must be writeable.")
+            result = out
+
+        buffer = np.empty((num_pts, n_active), dtype=np.float64)
+        eval_cache: dict[
+            tuple[int, int], tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]
+        ] = {}
+        point_index = np.arange(num_pts)
+        for col, (_, level, multi) in enumerate(contribs):
+            column = np.ones(num_pts, dtype=np.float64)
+            for k in range(self.dim):
+                key = (level, k)
+                if key not in eval_cache:
+                    sp1d = self._level_spaces[level].spaces[k]
+                    values, first_basis = sp1d.tabulate_basis(np.ascontiguousarray(flat_pts[:, k]))
+                    eval_cache[key] = (
+                        np.asarray(values, dtype=np.float64),
+                        np.asarray(first_basis, dtype=np.int64),
+                    )
+                values, first_basis = eval_cache[key]
+                local = multi[k] - first_basis
+                degree_k = self.degrees[k]
+                valid = (local >= 0) & (local <= degree_k)
+                gathered = values[point_index, np.clip(local, 0, degree_k)]
+                column *= np.where(valid, gathered, 0.0)
+            buffer[:, col] = column
+
+        result[...] = buffer.reshape(out_shape)
+        return result
+
+    def __repr__(self) -> str:
+        """Return a compact developer-friendly representation.
+
+        Returns:
+            str: Shows dimension, degrees, level count, and active-function count.
+        """
+        return (
+            f"THBSplineSpace(dim={self.dim}, degrees={self.degrees}, "
+            f"num_levels={self.num_levels}, num_active_functions={self._num_active}, "
+            f"truncate={self._truncate})"
+        )

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -108,9 +108,9 @@ class THBSplineSpace:
             subdividing to build finer levels.
         _level_spaces (tuple[BsplineSpace, ...]): Per-level tensor-product spaces;
             index ``l`` is the root subdivided to level ``l``.
-        _support (tuple[tuple[_Support1D, ...], ...]): Per-level, per-direction
-            function-to-cell support arrays (one ``_Support1D`` triple per direction
-            per level).
+        _support (tuple): Per-level, per-direction function-to-cell support arrays;
+            each entry is a tuple of ``(first_basis, first_cell, last_cell)`` int64
+            arrays for one direction at one level.
         _active_funcs (tuple[npt.NDArray[np.int64], ...]): Per-level sorted flat
             (C-order) indices of the active tensor-product functions.
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -725,8 +725,15 @@ class HierarchicalGrid(Grid):
     def level_cells_per_axis(self, level: int) -> tuple[int, ...]:
         """Return the per-axis cell count of the level-``level`` grid.
 
+        This is a pure formula — ``level`` need not be an existing hierarchy level.
+        Values above ``max_level`` return the count for the hypothetical finer grid
+        that would result from additional uniform subdivision.  This differs from
+        :meth:`active_blocks`, :meth:`active_leaf_mask`, and :meth:`subdomain_mask`,
+        which all require ``level <= max_level``.
+
         Args:
-            level (int): Hierarchy level.  Must be ``>= 0``.
+            level (int): Hierarchy level.  Must be ``>= 0``; values above
+                ``max_level`` are accepted and return the geometrically valid count.
 
         Returns:
             tuple[int, ...]: ``root.cells_per_axis[k] * factor[k] ** level`` for

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -472,6 +472,18 @@ class HierarchicalGrid(Grid):
         """
         return int(self._root.cells_per_axis[axis]) * int(self._factor[axis] ** level)
 
+    def _check_level(self, level: int) -> None:
+        """Validate that ``level`` is an existing hierarchy level.
+
+        Args:
+            level (int): Hierarchy level to validate.
+
+        Raises:
+            ValueError: If ``level`` is outside ``[0, max_level]``.
+        """
+        if not (0 <= level <= self.max_level):
+            raise ValueError(f"level must be in [0, {self.max_level}]; got {level!r}.")
+
     # ------------------------------------------------------------------
     # Grid contract
     # ------------------------------------------------------------------
@@ -705,6 +717,102 @@ class HierarchicalGrid(Grid):
         self._check_cid(cid)
         _, midx = self._decode_flat_id(cid)
         return midx
+
+    # ------------------------------------------------------------------
+    # Active-set accessors
+    # ------------------------------------------------------------------
+
+    def level_cells_per_axis(self, level: int) -> tuple[int, ...]:
+        """Return the per-axis cell count of the level-``level`` grid.
+
+        Args:
+            level (int): Hierarchy level.  Must be ``>= 0``.
+
+        Returns:
+            tuple[int, ...]: ``root.cells_per_axis[k] * factor[k] ** level`` for
+            every axis ``k``.
+
+        Raises:
+            ValueError: If ``level < 0``.
+        """
+        if level < 0:
+            raise ValueError(f"level must be >= 0; got {level!r}.")
+        return tuple(self._n_cells_at_level_k(level, k) for k in range(self.ndim))
+
+    def active_blocks(self, level: int) -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+        """Return the active-leaf blocks at ``level``.
+
+        Args:
+            level (int): Hierarchy level.  Must be in ``[0, max_level]``.
+
+        Returns:
+            tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]: The sorted,
+            non-overlapping ``(lo, hi)`` integer rectangles of active (leaf) cells
+            at ``level``, in level-``level`` coordinates.
+
+        Raises:
+            ValueError: If ``level`` is outside ``[0, max_level]``.
+        """
+        self._check_level(level)
+        return tuple(self._blocks[level])
+
+    def active_leaf_mask(self, level: int) -> npt.NDArray[np.bool_]:
+        """Return a boolean mask of the active-leaf cells at ``level``.
+
+        Args:
+            level (int): Hierarchy level.  Must be in ``[0, max_level]``.
+
+        Returns:
+            npt.NDArray[bool]: Fresh array of shape
+            ``level_cells_per_axis(level)``; ``True`` where the level-``level``
+            cell ``(level, midx)`` is an active (leaf) cell.
+
+        Raises:
+            ValueError: If ``level`` is outside ``[0, max_level]``.
+        """
+        self._check_level(level)
+        mask = np.zeros(self.level_cells_per_axis(level), dtype=np.bool_)
+        for lo, hi in self._blocks[level]:
+            mask[tuple(slice(lo_k, hi_k) for lo_k, hi_k in zip(lo, hi, strict=False))] = True
+        return mask
+
+    def subdomain_mask(self, level: int) -> npt.NDArray[np.bool_]:
+        r"""Return a boolean mask of the level-``level`` refined subdomain.
+
+        A level-``level`` cell lies in the subdomain :math:`\Omega_{level}` (the
+        region refined to at least ``level``) iff it is **not** covered by an
+        active leaf of a coarser level.  The mask is computed at the level-``level``
+        resolution by projecting every coarser active-leaf block up to ``level`` and
+        clearing those cells.
+
+        Args:
+            level (int): Hierarchy level.  Must be in ``[0, max_level]``.
+
+        Returns:
+            npt.NDArray[bool]: Fresh array of shape
+            ``level_cells_per_axis(level)``; ``True`` where the level-``level``
+            cell lies in :math:`\Omega_{level}`.
+
+        Raises:
+            ValueError: If ``level`` is outside ``[0, max_level]``.
+
+        Note:
+            The mask is sized to the level-``level`` cell grid (computed on demand,
+            never stored).  Block-wise selection is a future optimization for deep
+            hierarchies.
+        """
+        self._check_level(level)
+        mask = np.ones(self.level_cells_per_axis(level), dtype=np.bool_)
+        for m in range(level):
+            scale = tuple(self._factor[k] ** (level - m) for k in range(self.ndim))
+            for lo, hi in self._blocks[m]:
+                mask[
+                    tuple(
+                        slice(lo_k * s, hi_k * s)
+                        for lo_k, hi_k, s in zip(lo, hi, scale, strict=False)
+                    )
+                ] = False
+        return mask
 
     # ------------------------------------------------------------------
     # Refinement

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
-import numpy.testing as npt
+import numpy.testing as np_testing
 import pytest
 
 from pantr.geometry import AABB
@@ -171,11 +171,11 @@ class TestHierarchicalGridInitialCells:
         g = _grid_1d(5, 2)
         all_lo = sorted(float(g.cell_bounds(cid)[0][0]) for cid in range(g.num_cells))
         all_hi = sorted(float(g.cell_bounds(cid)[1][0]) for cid in range(g.num_cells))
-        npt.assert_allclose(all_lo[0], 0.0)
-        npt.assert_allclose(all_hi[-1], 1.0)
+        np_testing.assert_allclose(all_lo[0], 0.0)
+        np_testing.assert_allclose(all_hi[-1], 1.0)
         # Adjacent cells tile without gaps or overlaps.
         for lo, hi in zip(all_hi[:-1], all_lo[1:], strict=False):
-            npt.assert_allclose(lo, hi)
+            np_testing.assert_allclose(lo, hi)
 
     def test_cell_level_zero_before_refine(self) -> None:
         g = _grid_2d(3, 2)
@@ -227,8 +227,8 @@ class TestHierarchicalGridRefine:
         # Union of fine cells = parent
         all_lo = np.min(fine_los, axis=0)
         all_hi = np.max(fine_his, axis=0)
-        npt.assert_allclose(all_lo, parent_lo)
-        npt.assert_allclose(all_hi, parent_hi)
+        np_testing.assert_allclose(all_lo, parent_lo)
+        np_testing.assert_allclose(all_hi, parent_hi)
 
     def test_refine_cell_levels(self) -> None:
         g = _grid_1d(4, 2)
@@ -399,7 +399,7 @@ class TestHierarchicalGridNeighbors:
         nbr = g.neighbor_across_facet(0, 1)
         assert nbr is not None
         lo_nbr, _hi_nbr = g.cell_bounds(nbr)
-        npt.assert_allclose(lo_nbr[0], 0.25)
+        np_testing.assert_allclose(lo_nbr[0], 0.25)
 
     def test_fine_to_coarse_neighbor(self) -> None:
         """Fine cell adjacent to a coarser frame cell → the coarse cell."""
@@ -566,3 +566,25 @@ class TestActiveSetAccessors:
         g.refine(0, [0], [2])
         with pytest.raises(ValueError, match="level"):
             g.subdomain_mask(2)
+
+    def test_active_blocks_negative_level_raises(self) -> None:
+        with pytest.raises(ValueError, match="level"):
+            _grid_1d(4, 2).active_blocks(-1)
+
+    def test_active_leaf_mask_negative_level_raises(self) -> None:
+        with pytest.raises(ValueError, match="level"):
+            _grid_1d(4, 2).active_leaf_mask(-1)
+
+    def test_subdomain_mask_three_levels(self) -> None:
+        # Refine the left half at level 0, then refine all level-1 cells.
+        # Exercises the two-iteration accumulation path in subdomain_mask.
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])  # level-0 block [(2,), (4,)]; level-1 block [(0,), (4,)]
+        g.refine(1, [0], [4])  # level-1 block emptied; level-2 block [(0,), (8,)]
+        # Level-2 grid: 4 * 2^2 = 16 cells.
+        # Subdomain mask: start all True, clear cells covered by coarser leaves.
+        # Level-0 leaf block [(2,), (4,)) → scale 4 → slice [8, 16): cleared.
+        # Level-1 has no leaf blocks → nothing more to clear.
+        expected = np.zeros(16, dtype=bool)
+        expected[:8] = True
+        np.testing.assert_array_equal(g.subdomain_mask(2), expected)

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -500,3 +500,69 @@ class TestHierarchicalGridTags:
         _ = g.facet_tags  # create
         g.refine(0, [1], [3])
         assert g._facet_tags is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Active-set accessors
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestActiveSetAccessors:
+    """Tests for level_cells_per_axis, active_blocks, and the masks."""
+
+    def test_level_cells_per_axis(self) -> None:
+        g = _grid_1d(4, 2)
+        assert g.level_cells_per_axis(0) == (4,)
+        assert g.level_cells_per_axis(2) == (16,)
+
+    def test_level_cells_per_axis_2d_anisotropic(self) -> None:
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), (2, 1))
+        assert g.level_cells_per_axis(1) == (8, 4)
+
+    def test_level_cells_per_axis_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="level"):
+            _grid_1d(4, 2).level_cells_per_axis(-1)
+
+    def test_active_blocks_fresh(self) -> None:
+        g = _grid_1d(4, 2)
+        assert g.active_blocks(0) == (((0,), (4,)),)
+
+    def test_active_blocks_after_refine(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        assert g.active_blocks(0) == (((2,), (4,)),)
+        assert g.active_blocks(1) == (((0,), (4,)),)
+
+    def test_active_blocks_out_of_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="level"):
+            _grid_1d(4, 2).active_blocks(1)
+
+    def test_active_leaf_mask_total_equals_num_cells(self) -> None:
+        g = _grid_2d(4, 2)
+        g.refine(0, [0, 0], [2, 2])
+        g.refine(1, [0, 0], [2, 2])
+        total = sum(int(g.active_leaf_mask(level).sum()) for level in range(g.max_level + 1))
+        assert total == g.num_cells
+
+    def test_subdomain_mask_level0_all_true(self) -> None:
+        g = _grid_2d(4, 2)
+        g.refine(0, [0, 0], [2, 2])
+        assert g.subdomain_mask(0).all()
+
+    def test_mask_consistency_1d(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        np.testing.assert_array_equal(g.active_leaf_mask(0), [False, False, True, True])
+        np.testing.assert_array_equal(g.subdomain_mask(0), [True, True, True, True])
+        np.testing.assert_array_equal(
+            g.subdomain_mask(1), [True, True, True, True, False, False, False, False]
+        )
+        np.testing.assert_array_equal(
+            g.active_leaf_mask(1), [True, True, True, True, False, False, False, False]
+        )
+
+    def test_subdomain_mask_out_of_range_raises(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        with pytest.raises(ValueError, match="level"):
+            g.subdomain_mask(2)

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -87,13 +87,18 @@ def _max_reproduction_residual(
 class TestConstruction:
     """Constructor validation and the deferred-truncation guard."""
 
+    def test_default_truncate_false_succeeds(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        assert thb.truncate is False
+
     def test_truncate_true_raises(self) -> None:
         with pytest.raises(NotImplementedError, match="truncate=False"):
-            THBSplineSpace(_root_1d(), _grid_1d())
-
-    def test_truncate_true_explicit_raises(self) -> None:
-        with pytest.raises(NotImplementedError):
             THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
+
+    def test_root_space_not_bspline_raises(self) -> None:
+        sp1d = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+        with pytest.raises(TypeError, match="BsplineSpace"):
+            THBSplineSpace(sp1d, _grid_1d(), truncate=False)  # type: ignore[arg-type]
 
     def test_grid_not_hierarchical_raises(self) -> None:
         flat = uniform_grid([[0.0, 1.0]], 4)
@@ -117,6 +122,16 @@ class TestConstruction:
     def test_regularity_length_mismatch_raises(self) -> None:
         with pytest.raises(ValueError, match="regularity"):
             THBSplineSpace(_root_1d(), _grid_1d(), truncate=False, regularity=[1, 1])
+
+    def test_regularity_value_too_high_raises(self) -> None:
+        # degree=2 → max regularity is 1; regularity=2 is invalid.
+        with pytest.raises(ValueError, match="regularity"):
+            THBSplineSpace(_root_1d(), _grid_1d(), truncate=False, regularity=2)
+
+    def test_regularity_value_too_low_raises(self) -> None:
+        # -1 is the minimum (C^{-1}); -2 is invalid.
+        with pytest.raises(ValueError, match="regularity"):
+            THBSplineSpace(_root_1d(), _grid_1d(), truncate=False, regularity=-2)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -151,6 +166,14 @@ class TestUnrefined:
         thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
         mat, _ = _collocation(thb)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-12)
+
+    def test_repr_smoke(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        r = repr(thb)
+        assert "THBSplineSpace" in r
+        assert "dim=1" in r
+        assert "num_levels=1" in r
+        assert "truncate=False" in r
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -234,13 +257,23 @@ class TestSelection:
     def test_active_indices_returns_copy(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         idx = thb.active_function_indices(0)
+        original_first = int(idx[0])
         idx[0] = -999
-        np.testing.assert_array_equal(thb.active_function_indices(0)[0], 0)
+        assert int(thb.active_function_indices(0)[0]) == original_first
 
     def test_active_function_indices_out_of_range(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         with pytest.raises(IndexError):
             thb.active_function_indices(5)
+
+    def test_fully_refined_level_has_no_active_functions(self) -> None:
+        # Refining the entire domain at level 0 displaces all level-0 functions.
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [4])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        assert thb.num_active_functions_per_level[0] == 0
+        assert thb.num_active_functions_per_level[1] > 0
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -289,10 +322,48 @@ class TestEvaluation:
         with pytest.raises(ValueError, match="shape"):
             thb.tabulate_basis(0, np.array([[0.1]]), out=np.empty((1, 99)))
 
+    def test_tabulate_basis_bad_out_dtype_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        k = thb.active_basis(0).shape[0]
+        out_bad = np.empty((1, k), dtype=np.float32)
+        with pytest.raises(ValueError, match="dtype"):
+            thb.tabulate_basis(0, np.array([[0.1]]), out=out_bad)  # type: ignore[arg-type]
+
+    def test_tabulate_basis_readonly_out_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        k = thb.active_basis(0).shape[0]
+        out = np.empty((1, k), dtype=np.float64)
+        out.flags.writeable = False
+        with pytest.raises(ValueError, match="writeable"):
+            thb.tabulate_basis(0, np.array([[0.1]]), out=out)
+
     def test_tabulate_basis_bad_point_dim_raises(self) -> None:
         thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
         with pytest.raises(ValueError, match="trailing dimension"):
             thb.tabulate_basis(0, np.array([[0.1, 0.2, 0.3]]))
+
+    def test_active_basis_bad_cid_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(IndexError):
+            thb.active_basis(999)
+
+    def test_tabulate_basis_bad_cid_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(IndexError):
+            thb.tabulate_basis(999, np.array([[0.5]]))
+
+    def test_tabulate_basis_pts_outside_cell_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        # Cell 0 covers [0.0, 0.25); point 0.5 is outside.
+        with pytest.raises(ValueError, match="bounds"):
+            thb.tabulate_basis(0, np.array([[0.5]]))
+
+    def test_tabulate_basis_scalar_point(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        # Shape (dim,) — single point without a leading batch dimension.
+        result = thb.tabulate_basis(0, np.array([0.1]))
+        assert result.ndim == 1
+        assert result.shape[0] == thb.active_basis(0).shape[0]
 
     def test_not_partition_of_unity_when_refined(self) -> None:
         # HB (non-truncated) is NOT a partition of unity over refined regions.
@@ -302,8 +373,40 @@ class TestEvaluation:
         thb = THBSplineSpace(root, grid, truncate=False)
         cid = grid.locate([0.1])
         assert cid is not None
-        total = thb.tabulate_basis(cid, np.array([[0.1]])).sum()
-        assert total > 1.0 + 1e-3
+        lo, hi = grid.cell_bounds(cid)
+        mid = float(0.5 * (lo[0] + hi[0]))
+        total = thb.tabulate_basis(cid, np.array([[mid]])).sum()
+        # Functions from both level 0 and level 1 contribute; sum > 1.
+        assert total > 1.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stale-grid detection
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestStaleGrid:
+    """THBSplineSpace raises RuntimeError if the grid is modified after construction."""
+
+    def test_stale_grid_active_basis_raises(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            thb.active_basis(0)
+
+    def test_stale_grid_tabulate_basis_raises(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            thb.tabulate_basis(0, np.array([[0.1]]))
+
+    def test_unmodified_grid_does_not_raise(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        # No refine call — must not raise.
+        _ = thb.active_basis(0)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -342,4 +445,5 @@ class TestLevelSpaces:
         # Axis 0 subdivided (8 intervals), axis 1 unchanged (4 intervals).
         assert level1.num_intervals == (8, 4)
         assert level0.num_intervals == (4, 4)
+        assert thb.num_active_functions == sum(thb.num_active_functions_per_level)
         assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1,0 +1,344 @@
+"""Tests for pantr.bspline.THBSplineSpace (non-truncated / HB path)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
+from pantr.bspline._thb_spline_space import _func_support_1d
+from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _root_1d() -> BsplineSpace:
+    """Degree-2 open space with 4 intervals on [0, 1]."""
+    return BsplineSpace([BsplineSpace1D(_KNOTS_DEG2_4, 2)])
+
+
+def _root_2d() -> BsplineSpace:
+    """Degree-(2, 2) open space with 4x4 intervals on [0, 1]^2."""
+    sp = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+    return BsplineSpace([sp, sp])
+
+
+def _grid_1d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+
+
+def _grid_2d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+
+
+def _collocation(
+    thb: THBSplineSpace, n_per_axis: int | None = None
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a global collocation matrix and sample points.
+
+    Returns ``(A, pts)`` where ``A[r, dof]`` is the value of active function ``dof``
+    at sample point ``pts[r]`` (zero where the function is inactive on the point's
+    cell), sampling interior points of every active cell.
+    """
+    grid = thb.grid
+    dim = thb.dim
+    n_active = thb.num_active_functions
+    npa = (thb.degrees[0] + 3) if n_per_axis is None else n_per_axis
+    u = np.linspace(0.0, 1.0, npa)[1:-1]
+    rows: list[np.ndarray] = []
+    pts: list[np.ndarray] = []
+    for cid in range(grid.num_cells):
+        lo, hi = grid.cell_bounds(cid)
+        axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(dim)]
+        mesh = np.meshgrid(*axes, indexing="ij")
+        cell_pts = np.stack([m.ravel() for m in mesh], axis=-1)
+        active = thb.active_basis(cid)
+        values = thb.tabulate_basis(cid, cell_pts)
+        for i in range(cell_pts.shape[0]):
+            row = np.zeros(n_active)
+            row[active] = values[i]
+            rows.append(row)
+            pts.append(cell_pts[i])
+    return np.asarray(rows), np.asarray(pts)
+
+
+def _max_reproduction_residual(
+    thb: THBSplineSpace, target: Callable[[np.ndarray], np.ndarray]
+) -> float:
+    """Least-squares fit ``target`` with the HB basis; return max residual."""
+    mat, pts = _collocation(thb)
+    rhs = target(pts)
+    coef, _, _, _ = np.linalg.lstsq(mat, rhs, rcond=None)
+    return float(np.abs(mat @ coef - rhs).max())
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Construction / validation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    """Constructor validation and the deferred-truncation guard."""
+
+    def test_truncate_true_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match="truncate=False"):
+            THBSplineSpace(_root_1d(), _grid_1d())
+
+    def test_truncate_true_explicit_raises(self) -> None:
+        with pytest.raises(NotImplementedError):
+            THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
+
+    def test_grid_not_hierarchical_raises(self) -> None:
+        flat = uniform_grid([[0.0, 1.0]], 4)
+        with pytest.raises(TypeError, match="HierarchicalGrid"):
+            THBSplineSpace(_root_1d(), flat, truncate=False)  # type: ignore[arg-type]
+
+    def test_dim_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="ndim"):
+            THBSplineSpace(_root_1d(), _grid_2d(), truncate=False)
+
+    def test_root_grid_cell_count_mismatch_raises(self) -> None:
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 5), 2)
+        with pytest.raises(ValueError, match="num_intervals"):
+            THBSplineSpace(_root_1d(), grid, truncate=False)
+
+    def test_root_grid_bounds_mismatch_raises(self) -> None:
+        grid = hierarchical_grid(uniform_grid([[0.0, 2.0]], 4), 2)
+        with pytest.raises(ValueError, match="bounds"):
+            THBSplineSpace(_root_1d(), grid, truncate=False)
+
+    def test_regularity_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="regularity"):
+            THBSplineSpace(_root_1d(), _grid_1d(), truncate=False, regularity=[1, 1])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Properties / unrefined behaviour
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestUnrefined:
+    """An unrefined hierarchy reduces to the root tensor-product basis."""
+
+    def test_properties(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        assert thb.dim == 1
+        assert thb.degrees == (2,)
+        assert thb.num_levels == 1
+        assert thb.truncate is False
+        assert isinstance(thb.grid, HierarchicalGrid)
+        assert thb.root_space is not None
+
+    def test_active_count_equals_root_1d(self) -> None:
+        root = _root_1d()
+        thb = THBSplineSpace(root, _grid_1d(), truncate=False)
+        assert thb.num_active_functions == root.num_total_basis
+        assert thb.num_active_functions_per_level == (root.num_total_basis,)
+
+    def test_active_count_equals_root_2d(self) -> None:
+        root = _root_2d()
+        thb = THBSplineSpace(root, _grid_2d(), truncate=False)
+        assert thb.num_active_functions == root.num_total_basis
+
+    def test_partition_of_unity_when_unrefined(self) -> None:
+        thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-12)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coarse-space reproduction (the HB correctness check)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestReproduction:
+    """V_0 ⊆ V_h: the HB basis reproduces coarse polynomials exactly."""
+
+    def test_reproduce_1d_three_levels(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        assert thb.num_levels == 3
+        assert _max_reproduction_residual(thb, lambda p: np.ones(len(p))) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0]) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0] ** 2) < 1e-9
+
+    def test_reproduce_2d_corner_refinement(self) -> None:
+        root = _root_2d()
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        assert _max_reproduction_residual(thb, lambda p: np.ones(len(p))) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0]) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 1]) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
+
+    def test_reproduce_2d_two_levels(self) -> None:
+        root = _root_2d()
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [3, 3])
+        grid.refine(1, [2, 2], [6, 6])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        assert thb.num_levels == 3
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Kraft selection
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSelection:
+    """Active-function selection (the Kraft rule)."""
+
+    def test_hand_example_1d(self) -> None:
+        # Degree 2, 4 cells, refine the left half [0, 2) at level 0.
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        assert thb.num_active_functions_per_level == (4, 4)
+        np.testing.assert_array_equal(thb.active_function_indices(0), [2, 3, 4, 5])
+        np.testing.assert_array_equal(thb.active_function_indices(1), [0, 1, 2, 3])
+
+    def test_selection_invariant(self) -> None:
+        # Every active function: support ⊆ Ω_l and ⊄ Ω_{l+1}.
+        root = _root_2d()
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        grid.refine(1, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        for level in range(thb.num_levels):
+            space = thb.level_space(level)
+            num_basis = space.num_basis
+            subdomain = grid.subdomain_mask(level)
+            refined = subdomain & ~grid.active_leaf_mask(level)
+            support = [_func_support_1d(sp1d) for sp1d in space.spaces]
+            for flat in thb.active_function_indices(level):
+                multi = np.unravel_index(int(flat), num_basis)
+                box = tuple(
+                    slice(int(support[k][1][multi[k]]), int(support[k][2][multi[k]]) + 1)
+                    for k in range(thb.dim)
+                )
+                assert subdomain[box].all(), (level, multi)
+                assert not refined[box].all(), (level, multi)
+
+    def test_active_indices_returns_copy(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        idx = thb.active_function_indices(0)
+        idx[0] = -999
+        np.testing.assert_array_equal(thb.active_function_indices(0)[0], 0)
+
+    def test_active_function_indices_out_of_range(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(IndexError):
+            thb.active_function_indices(5)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Evaluation / active_basis
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestEvaluation:
+    """Per-cell evaluation and the active-basis index set."""
+
+    def test_active_basis_matches_nonzeros(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        for cid in range(grid.num_cells):
+            lo, hi = grid.cell_bounds(cid)
+            mid = (0.5 * (lo + hi)).reshape(1, thb.dim)
+            active = thb.active_basis(cid)
+            values = thb.tabulate_basis(cid, mid)
+            assert values.shape == (1, active.shape[0])
+            # B-splines nonzero on the cell are strictly positive at its midpoint.
+            assert np.all(values[0] > 0.0)
+            # active_basis is sorted and unique.
+            assert np.all(np.diff(active) > 0)
+
+    def test_values_nonnegative(self) -> None:
+        root = _root_2d()
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        mat, _ = _collocation(thb)
+        assert mat.min() >= 0.0
+
+    def test_tabulate_basis_out_argument(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        pts = np.array([[0.1], [0.2]])
+        k = thb.active_basis(0).shape[0]
+        out = np.empty((2, k), dtype=np.float64)
+        ret = thb.tabulate_basis(0, pts, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, thb.tabulate_basis(0, pts))
+
+    def test_tabulate_basis_bad_out_shape_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(ValueError, match="shape"):
+            thb.tabulate_basis(0, np.array([[0.1]]), out=np.empty((1, 99)))
+
+    def test_tabulate_basis_bad_point_dim_raises(self) -> None:
+        thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
+        with pytest.raises(ValueError, match="trailing dimension"):
+            thb.tabulate_basis(0, np.array([[0.1, 0.2, 0.3]]))
+
+    def test_not_partition_of_unity_when_refined(self) -> None:
+        # HB (non-truncated) is NOT a partition of unity over refined regions.
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        cid = grid.locate([0.1])
+        assert cid is not None
+        total = thb.tabulate_basis(cid, np.array([[0.1]])).sum()
+        assert total > 1.0 + 1e-3
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Level spaces / nesting
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestLevelSpaces:
+    """Nested per-level tensor-product spaces."""
+
+    def test_level_space_out_of_range(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(IndexError):
+            thb.level_space(1)
+
+    def test_levels_are_nested_1d(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        for level in range(thb.num_levels - 1):
+            coarse = thb.level_space(level).spaces[0].knots
+            fine = set(np.round(thb.level_space(level + 1).spaces[0].knots, 12))
+            for knot in coarse:
+                assert round(float(knot), 12) in fine
+
+    def test_factor_one_axis_not_subdivided(self) -> None:
+        # Anisotropic refinement: factor 1 on the second axis.
+        root = _root_2d()
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), (2, 1))
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=False)
+        level0 = thb.level_space(0)
+        level1 = thb.level_space(1)
+        # Axis 0 subdivided (8 intervals), axis 1 unchanged (4 intervals).
+        assert level1.num_intervals == (8, 4)
+        assert level0.num_intervals == (4, 4)
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
@@ -39,7 +40,7 @@ def _grid_2d() -> HierarchicalGrid:
 
 def _collocation(
     thb: THBSplineSpace, n_per_axis: int | None = None
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Build a global collocation matrix and sample points.
 
     Returns ``(A, pts)`` where ``A[r, dof]`` is the value of active function ``dof``
@@ -51,8 +52,8 @@ def _collocation(
     n_active = thb.num_active_functions
     npa = (thb.degrees[0] + 3) if n_per_axis is None else n_per_axis
     u = np.linspace(0.0, 1.0, npa)[1:-1]
-    rows: list[np.ndarray] = []
-    pts: list[np.ndarray] = []
+    rows: list[npt.NDArray[np.float64]] = []
+    pts: list[npt.NDArray[np.float64]] = []
     for cid in range(grid.num_cells):
         lo, hi = grid.cell_bounds(cid)
         axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(dim)]
@@ -69,7 +70,7 @@ def _collocation(
 
 
 def _max_reproduction_residual(
-    thb: THBSplineSpace, target: Callable[[np.ndarray], np.ndarray]
+    thb: THBSplineSpace, target: Callable[[npt.NDArray[np.float64]], npt.NDArray[np.float64]]
 ) -> float:
     """Least-squares fit ``target`` with the HB basis; return max residual."""
     mat, pts = _collocation(thb)


### PR DESCRIPTION
## Summary

PR1 of the multi-PR THB-spline feature (tracking issue #164). Adds `THBSplineSpace` — the **G+Smo self-evaluating** hierarchical spline space on a `HierarchicalGrid` — implementing the **non-truncated hierarchical (HB)** path (`truncate=False`). Truncation (`truncate=True`), derivatives, refinement, coarsening, Bézier-extraction export, and quasi-interpolants follow in later PRs per #164.

### `pantr.grid` (additive)
New public `HierarchicalGrid` accessors the space derives its active functions from:
- `level_cells_per_axis(level)`, `active_blocks(level)`
- `active_leaf_mask(level)` and `subdomain_mask(level)` (the refined subdomain `Ω_level`), computed on demand so the grid stays low-footprint.

### `pantr.bspline`
- `THBSplineSpace(root_space, grid, *, truncate=True, regularity=None)`:
  - nested per-level tensor-product spaces (root subdivided by the grid `factor`, maximal smoothness by default), reusing `BsplineSpace1D.subdivide`;
  - Kraft active-function selection from the grid masks (only truncated functions will carry stored coefficients later; untruncated are plain B-splines);
  - per-cell `active_basis(cid)` and value `tabulate_basis(cid, pts)`, reusing the existing Numba-backed B-spline tabulation (no new Layer-3 kernel).
  - `truncate=True` raises `NotImplementedError` (final signature ships now; PR2 implements the branch).

### Design note (correction vs. the original plan)
The **non-truncated HB basis is NOT a partition of unity** over refined regions — that is a *truncated* (THB) property. So the HB correctness check is **coarse-space reproduction** (`V_0 ⊆ V_h`): the basis reproduces `1`, `x`, `x²`, `x·y` exactly (≤4e-15 residual). PoU verification moves to PR2.

## Test plan
- [x] New tests: `tests/test_thb_spline_space.py` (construction/validation, coarse-space reproduction in 1D/2D multi-level hierarchies, Kraft selection on a hand example + invariant, `active_basis`, evaluation/`out=`, nesting, anisotropic factor-1 axes) and active-set accessor tests in `tests/test_grid_hierarchical.py`.
- [x] Full suite: `pytest --no-cov` — 2864 passed.
- [x] `ruff check` / `ruff format --check` / `mypy` clean.
- [x] Docs build clean (`sphinx-build -W`).

Tracking: #164 · builds on #152 (`HierarchicalGrid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
