### PR TITLE
feat(bspline): THB truncation for THBSplineSpace (PR2 of #164)

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -378,7 +378,8 @@ class THBSplineSpace:
             rows = np.nonzero(np.any(cols != 0.0, axis=1))[0]
             nlo, nhi = int(rows[0]), int(rows[-1]) + 1
             sub = alpha[nlo:nhi, box_lo[k] : box_hi[k]]
-            out = np.moveaxis(np.tensordot(sub, out, axes=([1], [k])), 0, k)
+            contracted = np.asarray(np.tensordot(sub, out, axes=([1], [k])), dtype=np.float64)
+            out = np.moveaxis(contracted, 0, k)
             new_lo[k], new_hi[k] = nlo, nhi
         return out, new_lo, new_hi
 
@@ -726,7 +727,7 @@ class THBSplineSpace:
         func_subs = letters[:dim]
         pt_sub = letters[dim]
         subscripts = f"{func_subs},{','.join(pt_sub + func_subs[k] for k in range(dim))}->{pt_sub}"
-        column: npt.NDArray[np.float64] = np.einsum(subscripts, coeffs, *value_mats)
+        column = np.asarray(np.einsum(subscripts, coeffs, *value_mats), dtype=np.float64)
         return column
 
     def tabulate_basis(

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -171,9 +171,8 @@ class THBSplineSpace:
         _num_active (int): Total number of active hierarchical functions.
         _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
             construction; used to detect post-construction grid mutations.
-        _trunc (dict[int, _TruncCoeffs]): Map from global dof to stored truncated
-            coefficients; only truncated functions appear (empty when
-            ``truncate=False``).
+        _trunc (dict): Map from global dof (int) to ``_TruncCoeffs``; only
+            truncated functions appear (empty when ``truncate=False``).
     """
 
     __slots__ = (

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import itertools
 import string
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
@@ -43,22 +43,42 @@ _Support1D = tuple[
 all ``int64`` arrays.
 """
 
-_TruncCoeffs = tuple[int, "tuple[int, ...]", "npt.NDArray[np.float64]"]
-"""Stored representation of a truncated function.
 
-``(rep_level, box_lo, coeffs)``: ``coeffs`` is a dense array of the function's
-coefficients in the level-``rep_level`` tensor-product basis over the box of
-function multi-indices starting at ``box_lo`` (one axis per direction).
-"""
+class _TruncCoeffs(NamedTuple):
+    """Stored representation of a truncated function.
 
-_EvalCache = dict[
-    tuple[int, int],
-    "tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]",
-]
-"""Per-call cache of 1D basis evaluations keyed by ``(level, direction)``.
+    ``rep_level`` is the finest level at which the function is expressed.
+    ``box_lo[k]`` is the per-direction lower function index of the coefficient
+    box; ``coeffs.shape[k] == box_hi[k] - box_lo[k]`` (``box_hi`` is implicit
+    in the array shape).  ``coeffs`` holds the function's coefficients in the
+    level-``rep_level`` tensor-product basis.
+    """
 
-Maps to ``(values, first_basis)`` from
-:meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` at the query points.
+    rep_level: int
+    box_lo: tuple[int, ...]
+    coeffs: npt.NDArray[np.float64]
+
+
+class _BasisEval1D(NamedTuple):
+    """Cached result of a single 1D basis evaluation.
+
+    ``values`` has shape ``(num_pts, degree + 1)``; ``first_basis`` has shape
+    ``(num_pts,)``.  Both come from a single call to
+    :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`.
+    """
+
+    values: npt.NDArray[np.float64]
+    first_basis: npt.NDArray[np.int64]
+
+
+_EvalCache = dict[tuple[int, int], _BasisEval1D]
+"""Per-call cache of 1D basis evaluations keyed by ``(level, direction)``."""
+
+_EINSUM_MAX_DIM = 24
+"""Maximum parametric dimension supported by the single-letter einsum subscript scheme.
+
+``string.ascii_lowercase`` provides 26 letters; the einsum needs ``dim`` letters for the
+coefficient axes plus one for the point axis, leaving a safe ceiling of 24 dimensions.
 """
 
 
@@ -151,9 +171,9 @@ class THBSplineSpace:
         _num_active (int): Total number of active hierarchical functions.
         _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
             construction; used to detect post-construction grid mutations.
-        _trunc (dict): Map from global dof to stored truncated coefficients
-            ``(rep_level, box_lo, coeffs)``; only truncated functions appear (empty
-            when ``truncate=False``).
+        _trunc (dict[int, _TruncCoeffs]): Map from global dof to stored truncated
+            coefficients; only truncated functions appear (empty when
+            ``truncate=False``).
     """
 
     __slots__ = (
@@ -333,7 +353,7 @@ class THBSplineSpace:
 
         Returns:
             tuple[tuple[npt.NDArray[np.float64], ...], ...]: Matrices indexed by
-            ``[m][k]`` for ``m`` in ``[0, num_levels - 1)``.
+            ``[m][k]`` for ``m`` in ``[0, num_levels - 2]``.
         """
         mats: list[tuple[npt.NDArray[np.float64], ...]] = []
         for m in range(self.num_levels - 1):
@@ -367,7 +387,12 @@ class THBSplineSpace:
 
         Returns:
             tuple[npt.NDArray[np.float64], list[int], list[int]]: Refined
-            coefficients and the new ``(box_lo, box_hi)``.
+            coefficients and fresh lists ``(box_lo, box_hi)`` for the next
+            level; the input lists are not modified.
+
+        Raises:
+            ValueError: If the Oslo matrix slice for any direction is entirely
+                zero, indicating a degenerate box or invalid knot refinement.
         """
         new_lo = list(box_lo)
         new_hi = list(box_hi)
@@ -376,6 +401,12 @@ class THBSplineSpace:
             alpha = oslo_m[k]
             cols = alpha[:, box_lo[k] : box_hi[k]]
             rows = np.nonzero(np.any(cols != 0.0, axis=1))[0]
+            if rows.size == 0:
+                raise ValueError(
+                    f"_refine_box: Oslo matrix slice for direction {k} "
+                    f"(columns [{box_lo[k]}:{box_hi[k]}]) is entirely zero — "
+                    "degenerate or invalid knot refinement."
+                )
             nlo, nhi = int(rows[0]), int(rows[-1]) + 1
             sub = alpha[nlo:nhi, box_lo[k] : box_hi[k]]
             contracted = np.asarray(np.tensordot(sub, out, axes=([1], [k])), dtype=np.float64)
@@ -391,16 +422,18 @@ class THBSplineSpace:
         active_at_level: npt.NDArray[np.int64],
         num_basis: tuple[int, ...],
     ) -> bool:
-        """Zero coefficients on active functions (in place); report if any zeroed.
+        """Zero basis coefficients at active-function positions (in place); report if any zeroed.
 
         Args:
             coeffs (npt.NDArray[np.float64]): Coefficients over the box (modified in
                 place).
             box_lo (list[int]): Per-direction lower function index of the box.
             box_hi (list[int]): Per-direction upper (exclusive) function index.
-            active_at_level (npt.NDArray[np.int64]): Sorted flat indices of the
-                active functions at this level.
-            num_basis (tuple[int, ...]): Per-direction function counts at this level.
+            active_at_level (npt.NDArray[np.int64]): Sorted flat indices of the active
+                functions at the refined level (the level whose basis ``coeffs`` is
+                expressed in).
+            num_basis (tuple[int, ...]): Per-direction function counts at the refined
+                level.
 
         Returns:
             bool: ``True`` iff at least one coefficient was zeroed.
@@ -420,8 +453,10 @@ class THBSplineSpace:
         For each active function that straddles a finer refinement boundary, the
         function is represented in successively finer bases (two-scale refinement),
         zeroing the components on active finer functions at each level (truncation),
-        until its support no longer reaches deeper refinement.  Untruncated functions
-        are omitted.
+        until its support no longer reaches deeper refinement.  Truncation is applied
+        at each level in the support chain, not only the first; a function may be
+        truncated against active sets at multiple levels before its support clears all
+        refinement.  Untruncated functions are omitted.
 
         Returns:
             dict[int, _TruncCoeffs]: Map from global dof to ``(rep_level, box_lo,
@@ -469,8 +504,11 @@ class THBSplineSpace:
                         self._level_spaces[m].num_basis,
                     )
                     any_zeroed = any_zeroed or zeroed
+                # A function whose support enters a refined region but whose
+                # coefficient box at every finer level has no overlap with active
+                # finer functions requires no truncation (remains a plain B-spline).
                 if any_zeroed:
-                    trunc[offset + pos] = (rep, tuple(box_lo), coeffs)
+                    trunc[offset + pos] = _TruncCoeffs(rep, tuple(box_lo), coeffs)
         return trunc
 
     def _check_not_stale(self) -> None:
@@ -660,18 +698,18 @@ class THBSplineSpace:
         k: int,
         flat_pts: npt.NDArray[np.float64],
         eval_cache: _EvalCache,
-    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
+    ) -> _BasisEval1D:
         """Evaluate (and cache) the level-``level`` 1D basis in direction ``k``.
 
         Args:
             level (int): Hierarchy level whose 1D space is evaluated.
             k (int): Parametric direction.
-            flat_pts (npt.NDArray[np.float64]): Points of shape ``(num_pts, dim)``.
+            flat_pts (npt.NDArray[np.float64]): All parametric points of shape
+                ``(num_pts, dim)``; column ``k`` is used.
             eval_cache (_EvalCache): Per-call cache keyed by ``(level, k)``.
 
         Returns:
-            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
-            ``(values, first_basis)`` as returned by
+            _BasisEval1D: ``(values, first_basis)`` as returned by
             :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`.
         """
         key = (level, k)
@@ -679,7 +717,7 @@ class THBSplineSpace:
         if cached is None:
             sp1d = self._level_spaces[level].spaces[k]
             values, first_basis = sp1d.tabulate_basis(np.ascontiguousarray(flat_pts[:, k]))
-            cached = (
+            cached = _BasisEval1D(
                 np.asarray(values, dtype=np.float64),
                 np.asarray(first_basis, dtype=np.int64),
             )
@@ -711,6 +749,11 @@ class THBSplineSpace:
         """
         rep_level, box_lo, coeffs = entry
         dim = self.dim
+        if dim > _EINSUM_MAX_DIM:
+            raise NotImplementedError(
+                f"_truncated_column uses single-letter einsum subscripts; "
+                f"only dim ≤ {_EINSUM_MAX_DIM} is supported, got dim={dim}."
+            )
         value_mats: list[npt.NDArray[np.float64]] = []
         for k in range(dim):
             values, first_basis = self._basis_1d_cached(rep_level, k, flat_pts, eval_cache)

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -3,8 +3,9 @@
 This module defines :class:`THBSplineSpace`, a hierarchical spline space built on
 a :class:`pantr.grid.HierarchicalGrid`.  It follows the G+Smo *self-evaluating*
 model: per level it stores the Kraft selection of active tensor-product B-splines,
-and (once truncation is implemented, GitHub issue #164) a sparse coefficient vector
-only for truncated functions.  Untruncated functions are plain tensor-product B-splines.
+and a coefficient vector only for truncated functions.  Untruncated functions are
+plain tensor-product B-splines.  Both the truncated (THB, default) and non-truncated
+(HB) bases are supported via the ``truncate`` flag.
 
 Main exports:
 
@@ -15,11 +16,13 @@ Main exports:
 from __future__ import annotations
 
 import itertools
+import string
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from ..grid import HierarchicalGrid
+from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core
 from ._bspline_space_nd import BsplineSpace
 
 if TYPE_CHECKING:
@@ -38,6 +41,24 @@ _Support1D = tuple[
 
 ``(first_basis_per_interval, first_cell_per_function, last_cell_per_function)``,
 all ``int64`` arrays.
+"""
+
+_TruncCoeffs = tuple[int, "tuple[int, ...]", "npt.NDArray[np.float64]"]
+"""Stored representation of a truncated function.
+
+``(rep_level, box_lo, coeffs)``: ``coeffs`` is a dense array of the function's
+coefficients in the level-``rep_level`` tensor-product basis over the box of
+function multi-indices starting at ``box_lo`` (one axis per direction).
+"""
+
+_EvalCache = dict[
+    tuple[int, int],
+    "tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]",
+]
+"""Per-call cache of 1D basis evaluations keyed by ``(level, direction)``.
+
+Maps to ``(values, first_basis)`` from
+:meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` at the query points.
 """
 
 
@@ -91,13 +112,25 @@ class THBSplineSpace:
     its support lies in the level-``l`` subdomain :math:`\Omega_l` but not entirely
     in the finer subdomain :math:`\Omega_{l+1}`.
 
+    With ``truncate=True`` (the default) the *truncated* hierarchical basis (THB) is
+    built: each active function that straddles a finer-level refinement boundary has
+    its components on active finer functions removed (Giannelli-Jüttler-Speleers
+    truncation), restoring the partition of unity.  Only truncated functions store a
+    coefficient vector (in the finest tensor-product basis their support reaches);
+    untruncated functions remain plain tensor-product B-splines.  With
+    ``truncate=False`` the non-truncated hierarchical basis (HB) is built.
+
     This space is a snapshot of the grid at construction time.  Calling
     :meth:`~pantr.grid.HierarchicalGrid.refine` on the underlying grid after
     construction invalidates this space; subsequent calls to :meth:`active_basis` or
     :meth:`tabulate_basis` will raise :class:`RuntimeError`.  Create a new
     :class:`THBSplineSpace` from the updated grid instead.
 
-    Truncation (``truncate=True``) is not yet implemented; see GitHub issue #164.
+    Note:
+        :meth:`active_basis` lists functions whose *untruncated* support covers a
+        cell; under truncation a few of those may evaluate to exactly zero on the
+        cell.  :meth:`tabulate_basis` always returns the correct (possibly zero)
+        values.
 
     Attributes:
         _root_space (BsplineSpace): The level-0 tensor-product space.
@@ -118,6 +151,9 @@ class THBSplineSpace:
         _num_active (int): Total number of active hierarchical functions.
         _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
             construction; used to detect post-construction grid mutations.
+        _trunc (dict): Map from global dof to stored truncated coefficients
+            ``(rep_level, box_lo, coeffs)``; only truncated functions appear (empty
+            when ``truncate=False``).
     """
 
     __slots__ = (
@@ -130,6 +166,7 @@ class THBSplineSpace:
         "_regularity",
         "_root_space",
         "_support",
+        "_trunc",
         "_truncate",
     )
 
@@ -138,7 +175,7 @@ class THBSplineSpace:
         root_space: BsplineSpace,
         grid: HierarchicalGrid,
         *,
-        truncate: bool = False,
+        truncate: bool = True,
         regularity: int | Sequence[int | None] | None = None,
     ) -> None:
         """Create a hierarchical B-spline space.
@@ -147,9 +184,8 @@ class THBSplineSpace:
             root_space (BsplineSpace): The level-0 tensor-product B-spline space.
             grid (HierarchicalGrid): Hierarchical grid whose root knot-span grid
                 matches ``root_space``.
-            truncate (bool): If ``True``, build the truncated basis.  **Not yet
-                implemented** — raises :class:`NotImplementedError`.  Defaults to
-                ``False`` (non-truncated hierarchical basis).
+            truncate (bool): If ``True`` (default), build the truncated (THB) basis;
+                if ``False``, build the non-truncated hierarchical (HB) basis.
             regularity (int | Sequence[int | None] | None): Per-direction continuity
                 at the knots inserted when subdividing to finer levels.  A scalar is
                 broadcast to every axis; ``None`` (default) uses maximal smoothness.
@@ -161,7 +197,6 @@ class THBSplineSpace:
             ValueError: If ``grid`` and ``root_space`` disagree on dimension or on
                 the root knot-span grid, if ``regularity`` has the wrong length, or
                 if any per-direction regularity value is out of range.
-            NotImplementedError: If ``truncate`` is ``True``.
         """
         if not isinstance(root_space, BsplineSpace):
             raise TypeError(
@@ -197,13 +232,6 @@ class THBSplineSpace:
                     f"regularity[{k}]={r!r} must be in [-1, degree[{k}]-1={d - 1}]; got {r!r}."
                 )
 
-        if truncate:
-            raise NotImplementedError(
-                "truncation (truncate=True) is not implemented yet; it lands in a later "
-                "increment (GitHub issue #164). Use truncate=False for the non-truncated "
-                "hierarchical (HB) basis."
-            )
-
         self._root_space = root_space
         self._grid = grid
         self._truncate = truncate
@@ -221,6 +249,7 @@ class THBSplineSpace:
         )
         self._num_active = int(self._func_offset[-1])
         self._grid_snapshot = (grid.max_level, grid.num_cells)
+        self._trunc = self._compute_truncated_coeffs() if truncate else {}
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -293,6 +322,155 @@ class THBSplineSpace:
                 selected.append(int(np.ravel_multi_index(multi, num_basis)))
             active.append(np.array(sorted(selected), dtype=np.int64))
         return tuple(active)
+
+    def _build_oslo_matrices(self) -> tuple[tuple[npt.NDArray[np.float64], ...], ...]:
+        """Build the per-direction two-scale (Oslo) matrices between levels.
+
+        Entry ``[m][k]`` is the refinement matrix ``alpha`` of shape
+        ``(num_basis_{m+1,k}, num_basis_{m,k})`` such that a level-``m`` B-spline
+        ``B_i`` equals ``sum_j alpha[j, i] B_j`` in the level-``(m+1)`` basis (the
+        identity when ``factor[k] == 1``).
+
+        Returns:
+            tuple[tuple[npt.NDArray[np.float64], ...], ...]: Matrices indexed by
+            ``[m][k]`` for ``m`` in ``[0, num_levels - 1)``.
+        """
+        mats: list[tuple[npt.NDArray[np.float64], ...]] = []
+        for m in range(self.num_levels - 1):
+            per_dir: list[npt.NDArray[np.float64]] = []
+            for k in range(self.dim):
+                old = self._level_spaces[m].spaces[k]
+                new = self._level_spaces[m + 1].spaces[k]
+                alpha = _compute_oslo_matrix_1d_core(old.degree, old.knots, new.knots)
+                per_dir.append(np.asarray(alpha, dtype=np.float64))
+            mats.append(tuple(per_dir))
+        return tuple(mats)
+
+    @staticmethod
+    def _refine_box(
+        coeffs: npt.NDArray[np.float64],
+        box_lo: list[int],
+        box_hi: list[int],
+        oslo_m: tuple[npt.NDArray[np.float64], ...],
+    ) -> tuple[npt.NDArray[np.float64], list[int], list[int]]:
+        """Refine a dense coefficient box from one level to the next.
+
+        Applies, per direction, the two-scale matrix restricted to the current
+        function box, growing the box to the band of non-zero finer functions.
+
+        Args:
+            coeffs (npt.NDArray[np.float64]): Coefficients over the current box.
+            box_lo (list[int]): Per-direction lower function index of the box.
+            box_hi (list[int]): Per-direction upper (exclusive) function index.
+            oslo_m (tuple[npt.NDArray[np.float64], ...]): Per-direction two-scale
+                matrices for this level transition.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], list[int], list[int]]: Refined
+            coefficients and the new ``(box_lo, box_hi)``.
+        """
+        new_lo = list(box_lo)
+        new_hi = list(box_hi)
+        out = coeffs
+        for k in range(out.ndim):
+            alpha = oslo_m[k]
+            cols = alpha[:, box_lo[k] : box_hi[k]]
+            rows = np.nonzero(np.any(cols != 0.0, axis=1))[0]
+            nlo, nhi = int(rows[0]), int(rows[-1]) + 1
+            sub = alpha[nlo:nhi, box_lo[k] : box_hi[k]]
+            out = np.moveaxis(np.tensordot(sub, out, axes=([1], [k])), 0, k)
+            new_lo[k], new_hi[k] = nlo, nhi
+        return out, new_lo, new_hi
+
+    @staticmethod
+    def _truncate_box(
+        coeffs: npt.NDArray[np.float64],
+        box_lo: list[int],
+        box_hi: list[int],
+        active_at_level: npt.NDArray[np.int64],
+        num_basis: tuple[int, ...],
+    ) -> bool:
+        """Zero coefficients on active functions (in place); report if any zeroed.
+
+        Args:
+            coeffs (npt.NDArray[np.float64]): Coefficients over the box (modified in
+                place).
+            box_lo (list[int]): Per-direction lower function index of the box.
+            box_hi (list[int]): Per-direction upper (exclusive) function index.
+            active_at_level (npt.NDArray[np.int64]): Sorted flat indices of the
+                active functions at this level.
+            num_basis (tuple[int, ...]): Per-direction function counts at this level.
+
+        Returns:
+            bool: ``True`` iff at least one coefficient was zeroed.
+        """
+        ranges = [np.arange(box_lo[k], box_hi[k]) for k in range(coeffs.ndim)]
+        mesh = np.meshgrid(*ranges, indexing="ij")
+        flat = np.ravel_multi_index([m.ravel() for m in mesh], num_basis)
+        is_active = np.isin(flat, active_at_level).reshape(coeffs.shape)
+        if not bool(is_active.any()):
+            return False
+        coeffs[is_active] = 0.0
+        return True
+
+    def _compute_truncated_coeffs(self) -> dict[int, _TruncCoeffs]:
+        """Build the truncated-coefficient map for the THB basis.
+
+        For each active function that straddles a finer refinement boundary, the
+        function is represented in successively finer bases (two-scale refinement),
+        zeroing the components on active finer functions at each level (truncation),
+        until its support no longer reaches deeper refinement.  Untruncated functions
+        are omitted.
+
+        Returns:
+            dict[int, _TruncCoeffs]: Map from global dof to ``(rep_level, box_lo,
+            coeffs)`` for every truncated function.
+        """
+        trunc: dict[int, _TruncCoeffs] = {}
+        if self.num_levels == 1:
+            return trunc
+        oslo = self._build_oslo_matrices()
+        refined = [
+            self._grid.subdomain_mask(m) & ~self._grid.active_leaf_mask(m)
+            for m in range(self.num_levels)
+        ]
+        dim = self.dim
+        for level in range(self.num_levels - 1):
+            num_basis = self._level_spaces[level].num_basis
+            offset = int(self._func_offset[level])
+            for pos, flat in enumerate(self._active_funcs[level].tolist()):
+                multi = np.unravel_index(int(flat), num_basis)
+                box_lo = [int(multi[k]) for k in range(dim)]
+                box_hi = [int(multi[k]) + 1 for k in range(dim)]
+                coeffs = np.ones((1,) * dim, dtype=np.float64)
+                rep = level
+                any_zeroed = False
+                m = level
+                while m + 1 < self.num_levels:
+                    support_m = self._support[m]
+                    cell_box = tuple(
+                        slice(
+                            int(support_m[k][1][box_lo[k]]),
+                            int(support_m[k][2][box_hi[k] - 1]) + 1,
+                        )
+                        for k in range(dim)
+                    )
+                    if not bool(refined[m][cell_box].any()):
+                        break
+                    coeffs, box_lo, box_hi = self._refine_box(coeffs, box_lo, box_hi, oslo[m])
+                    m += 1
+                    rep = m
+                    zeroed = self._truncate_box(
+                        coeffs,
+                        box_lo,
+                        box_hi,
+                        self._active_funcs[m],
+                        self._level_spaces[m].num_basis,
+                    )
+                    any_zeroed = any_zeroed or zeroed
+                if any_zeroed:
+                    trunc[offset + pos] = (rep, tuple(box_lo), coeffs)
+        return trunc
 
     def _check_not_stale(self) -> None:
         """Raise if the grid has been modified since this space was constructed.
@@ -398,8 +576,8 @@ class THBSplineSpace:
         """Get whether the hierarchical basis is truncated.
 
         Returns:
-            bool: ``True`` for THB, ``False`` for plain HB.  Always ``False``
-            until truncation is implemented (GitHub issue #164).
+            bool: ``True`` for the truncated (THB) basis, ``False`` for the plain
+            hierarchical (HB) basis.
         """
         return self._truncate
 
@@ -475,6 +653,82 @@ class THBSplineSpace:
         """
         return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
 
+    def _basis_1d_cached(
+        self,
+        level: int,
+        k: int,
+        flat_pts: npt.NDArray[np.float64],
+        eval_cache: _EvalCache,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
+        """Evaluate (and cache) the level-``level`` 1D basis in direction ``k``.
+
+        Args:
+            level (int): Hierarchy level whose 1D space is evaluated.
+            k (int): Parametric direction.
+            flat_pts (npt.NDArray[np.float64]): Points of shape ``(num_pts, dim)``.
+            eval_cache (_EvalCache): Per-call cache keyed by ``(level, k)``.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
+            ``(values, first_basis)`` as returned by
+            :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`.
+        """
+        key = (level, k)
+        cached = eval_cache.get(key)
+        if cached is None:
+            sp1d = self._level_spaces[level].spaces[k]
+            values, first_basis = sp1d.tabulate_basis(np.ascontiguousarray(flat_pts[:, k]))
+            cached = (
+                np.asarray(values, dtype=np.float64),
+                np.asarray(first_basis, dtype=np.int64),
+            )
+            eval_cache[key] = cached
+        return cached
+
+    def _truncated_column(
+        self,
+        entry: _TruncCoeffs,
+        flat_pts: npt.NDArray[np.float64],
+        eval_cache: _EvalCache,
+        point_index: npt.NDArray[np.int64],
+        num_pts: int,
+    ) -> npt.NDArray[np.float64]:
+        """Evaluate one truncated function from its stored coefficients.
+
+        Computes ``sum_multi coeffs[multi] * prod_k B^rep_{box_lo[k] + multi_k}(pt)``
+        over the stored coefficient box via a tensor contraction.
+
+        Args:
+            entry (_TruncCoeffs): ``(rep_level, box_lo, coeffs)`` for the function.
+            flat_pts (npt.NDArray[np.float64]): Points of shape ``(num_pts, dim)``.
+            eval_cache (_EvalCache): Per-call 1D-basis evaluation cache.
+            point_index (npt.NDArray[np.int64]): ``arange(num_pts)`` for gathering.
+            num_pts (int): Number of points.
+
+        Returns:
+            npt.NDArray[np.float64]: Function values of shape ``(num_pts,)``.
+        """
+        rep_level, box_lo, coeffs = entry
+        dim = self.dim
+        value_mats: list[npt.NDArray[np.float64]] = []
+        for k in range(dim):
+            values, first_basis = self._basis_1d_cached(rep_level, k, flat_pts, eval_cache)
+            degree_k = self.degrees[k]
+            width = coeffs.shape[k]
+            vmat = np.zeros((num_pts, width), dtype=np.float64)
+            for j in range(width):
+                local = (box_lo[k] + j) - first_basis
+                valid = (local >= 0) & (local <= degree_k)
+                vmat[:, j] = np.where(valid, values[point_index, np.clip(local, 0, degree_k)], 0.0)
+            value_mats.append(vmat)
+
+        letters = string.ascii_lowercase
+        func_subs = letters[:dim]
+        pt_sub = letters[dim]
+        subscripts = f"{func_subs},{','.join(pt_sub + func_subs[k] for k in range(dim))}->{pt_sub}"
+        column: npt.NDArray[np.float64] = np.einsum(subscripts, coeffs, *value_mats)
+        return column
+
     def tabulate_basis(
         self,
         cid: int,
@@ -483,10 +737,11 @@ class THBSplineSpace:
     ) -> npt.NDArray[np.float64]:
         """Evaluate the active hierarchical functions on cell ``cid`` at ``pts``.
 
-        For the non-truncated basis, each active function is a single
-        tensor-product B-spline; the value is the product of its 1D B-spline values
-        at the corresponding level.  The returned columns are ordered as
-        :meth:`active_basis` (sorted global dof).
+        Untruncated functions are a single tensor-product B-spline (the product of
+        their 1D B-spline values).  Truncated functions are evaluated from their
+        stored coefficients in the finest tensor-product basis their support reaches.
+        The returned columns are ordered as :meth:`active_basis` (sorted global dof);
+        a listed truncated function may evaluate to exactly zero on the cell.
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
@@ -540,28 +795,24 @@ class THBSplineSpace:
             result = out
 
         buffer = np.empty((num_pts, n_active), dtype=np.float64)
-        eval_cache: dict[
-            tuple[int, int], tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]
-        ] = {}
+        eval_cache: _EvalCache = {}
         point_index = np.arange(num_pts)
-        for col, (_, level, multi) in enumerate(contribs):
-            column = np.ones(num_pts, dtype=np.float64)
-            for k in range(self.dim):
-                key = (level, k)
-                if key not in eval_cache:
-                    sp1d = self._level_spaces[level].spaces[k]
-                    values, first_basis = sp1d.tabulate_basis(np.ascontiguousarray(flat_pts[:, k]))
-                    eval_cache[key] = (
-                        np.asarray(values, dtype=np.float64),
-                        np.asarray(first_basis, dtype=np.int64),
-                    )
-                values, first_basis = eval_cache[key]
-                local = multi[k] - first_basis
-                degree_k = self.degrees[k]
-                valid = (local >= 0) & (local <= degree_k)
-                gathered = values[point_index, np.clip(local, 0, degree_k)]
-                column *= np.where(valid, gathered, 0.0)
-            buffer[:, col] = column
+        for col, (gdof, level, multi) in enumerate(contribs):
+            entry = self._trunc.get(gdof)
+            if entry is None:
+                column = np.ones(num_pts, dtype=np.float64)
+                for k in range(self.dim):
+                    values, first_basis = self._basis_1d_cached(level, k, flat_pts, eval_cache)
+                    local = multi[k] - first_basis
+                    degree_k = self.degrees[k]
+                    valid = (local >= 0) & (local <= degree_k)
+                    gathered = values[point_index, np.clip(local, 0, degree_k)]
+                    column *= np.where(valid, gathered, 0.0)
+                buffer[:, col] = column
+            else:
+                buffer[:, col] = self._truncated_column(
+                    entry, flat_pts, eval_cache, point_index, num_pts
+                )
 
         result[...] = buffer.reshape(out_shape)
         return result

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -544,3 +544,83 @@ class TestTruncation:
     def test_repr_truncate_true(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
         assert "truncate=True" in repr(thb)
+
+    def test_tabulate_basis_out_argument_truncated(self) -> None:
+        thb = _refined_2d_corner()
+        cid = thb.grid.locate([0.1, 0.1])
+        assert cid is not None
+        active = thb.active_basis(cid)
+        assert any(dof in thb._trunc for dof in active), "no truncated dof on this cell"
+        pts = np.array([[0.1, 0.1]])
+        out = np.empty((1, active.shape[0]), dtype=np.float64)
+        ret = thb.tabulate_basis(cid, pts, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, thb.tabulate_basis(cid, pts))
+
+    def test_deepest_level_functions_not_in_trunc(self) -> None:
+        # Active functions at the deepest level have no finer level below;
+        # _compute_truncated_coeffs iterates over level < num_levels-1 only.
+        thb = _refined_1d_three_levels()
+        deepest = thb.num_levels - 1
+        offset = int(thb._func_offset[deepest])
+        count = int(thb.num_active_functions_per_level[deepest])
+        for i in range(count):
+            assert offset + i not in thb._trunc
+
+    def test_partition_of_unity_with_regularity_c0(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=True, regularity=0)
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_truncated_function_column_strictly_less_than_hb(self) -> None:
+        # A truncated function on a refined cell evaluates to a value strictly
+        # less than its HB counterpart (truncation reduced it) and >= 0.
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        hb = THBSplineSpace(root, grid, truncate=False)
+        cid = grid.locate([0.3])
+        assert cid is not None
+        lo, hi = grid.cell_bounds(cid)
+        mid = (0.5 * (lo + hi)).reshape(1, -1)
+        thb_active = thb.active_basis(cid)
+        hb_active = hb.active_basis(cid)
+        thb_vals = thb.tabulate_basis(cid, mid)[0]
+        hb_vals = hb.tabulate_basis(cid, mid)[0]
+        found_truncated = False
+        for i, dof in enumerate(thb_active):
+            if dof in thb._trunc:
+                found_truncated = True
+                thb_val = float(thb_vals[i])
+                j = int(np.searchsorted(hb_active, dof))
+                hb_val = float(hb_vals[j])
+                assert thb_val >= 0.0
+                assert thb_val < hb_val - 1e-10, (
+                    f"dof {dof}: THB value {thb_val:.6f} not < HB value {hb_val:.6f}"
+                )
+        assert found_truncated, "no truncated dof found on refined cell"
+
+    def test_partition_of_unity_anisotropic_truncated(self) -> None:
+        root = _root_2d()
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), (2, 1))
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_tabulate_basis_multidim_leading_shape_truncated(self) -> None:
+        thb = _refined_2d_corner()
+        cid = thb.grid.locate([0.1, 0.1])
+        assert cid is not None
+        lo, hi = thb.grid.cell_bounds(cid)
+        ts = np.linspace(0.1, 0.9, 6)
+        pts_flat = lo + (hi - lo) * ts[:, None]  # (6, 2)
+        pts = pts_flat.reshape(2, 3, thb.dim)
+        result = thb.tabulate_basis(cid, pts)
+        n_active = thb.active_basis(cid).shape[0]
+        assert result.shape == (2, 3, n_active)
+        np.testing.assert_allclose(result.sum(axis=-1), 1.0, atol=1e-10)

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -85,15 +85,15 @@ def _max_reproduction_residual(
 
 
 class TestConstruction:
-    """Constructor validation and the deferred-truncation guard."""
+    """Constructor validation and the ``truncate`` flag."""
 
-    def test_default_truncate_false_succeeds(self) -> None:
+    def test_default_is_truncated(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        assert thb.truncate is False
+        assert thb.truncate is True
 
-    def test_truncate_true_raises(self) -> None:
-        with pytest.raises(NotImplementedError, match="truncate=False"):
-            THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
+    def test_truncate_false_succeeds(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        assert thb.truncate is False
 
     def test_root_space_not_bspline_raises(self) -> None:
         sp1d = BsplineSpace1D(_KNOTS_DEG2_4, 2)
@@ -447,3 +447,100 @@ class TestLevelSpaces:
         assert level0.num_intervals == (4, 4)
         assert thb.num_active_functions == sum(thb.num_active_functions_per_level)
         assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Truncation (THB)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _refined_1d_three_levels() -> THBSplineSpace:
+    """Degree-2 1D space with the left region refined twice (truncated)."""
+    grid = _grid_1d()
+    grid.refine(0, [0], [2])
+    grid.refine(1, [0], [2])
+    return THBSplineSpace(_root_1d(), grid, truncate=True)
+
+
+def _refined_2d_corner() -> THBSplineSpace:
+    """Degree-(2, 2) space with the lower-left corner refined once (truncated)."""
+    grid = _grid_2d()
+    grid.refine(0, [0, 0], [2, 2])
+    return THBSplineSpace(_root_2d(), grid, truncate=True)
+
+
+class TestTruncation:
+    """Truncated (THB) basis: partition of unity, nonnegativity, reproduction."""
+
+    def test_partition_of_unity_1d(self) -> None:
+        mat, _ = _collocation(_refined_1d_three_levels())
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_partition_of_unity_2d_corner(self) -> None:
+        mat, _ = _collocation(_refined_2d_corner())
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_partition_of_unity_2d_three_levels(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [3, 3])
+        grid.refine(1, [2, 2], [6, 6])
+        thb = THBSplineSpace(_root_2d(), grid, truncate=True)
+        assert thb.num_levels == 3
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_values_nonnegative(self) -> None:
+        mat, _ = _collocation(_refined_2d_corner())
+        assert mat.min() >= -1e-14
+
+    def test_reproduces_coarse_space_2d(self) -> None:
+        # V_0 ⊆ V_h holds for THB as well (same space as HB, just truncated basis).
+        thb = _refined_2d_corner()
+        assert _max_reproduction_residual(thb, lambda p: np.ones(len(p))) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0]) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 1]) < 1e-9
+        assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
+
+    def test_some_functions_truncated(self) -> None:
+        thb = _refined_2d_corner()
+        n_truncated = len(thb._trunc)
+        assert 0 < n_truncated < thb.num_active_functions
+
+    def test_no_truncation_when_unrefined(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
+        assert len(thb._trunc) == 0
+        assert thb.num_active_functions == _root_1d().num_total_basis
+
+    def test_truncation_identity_outside_refinement(self) -> None:
+        # On a cell entirely outside the refined region, truncation changes nothing:
+        # THB and HB values coincide there (same selection, same values).
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])  # refine left half [0, 0.5)
+        thb = THBSplineSpace(root, grid, truncate=True)
+        hb = THBSplineSpace(root, grid, truncate=False)
+        cid = grid.locate([0.9])  # cell [0.75, 1.0], outside the refinement
+        assert cid is not None
+        lo, hi = grid.cell_bounds(cid)
+        pts = lo + (hi - lo) * np.linspace(0.1, 0.9, 5)[:, None]
+        np.testing.assert_array_equal(thb.active_basis(cid), hb.active_basis(cid))
+        np.testing.assert_allclose(
+            thb.tabulate_basis(cid, pts), hb.tabulate_basis(cid, pts), atol=1e-12
+        )
+
+    def test_truncation_restores_partition_of_unity_on_refined_cell(self) -> None:
+        # Where HB over-sums (> 1), THB sums to exactly 1.
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        hb = THBSplineSpace(root, grid, truncate=False)
+        cid = grid.locate([0.1])  # refined region
+        assert cid is not None
+        pt = np.array([[0.1]])
+        assert thb.tabulate_basis(cid, pt).sum() == pytest.approx(1.0, abs=1e-12)
+        assert hb.tabulate_basis(cid, pt).sum() > 1.0 + 1e-3
+
+    def test_repr_truncate_true(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
+        assert "truncate=True" in repr(thb)


### PR DESCRIPTION
## Summary

PR2 of the THB-spline feature (#164). Implements **truncation** — the mathematical core of the G+Smo self-evaluating model — on top of the HB scaffolding from PR1 (#165).

- **Truncated-coefficient construction.** Each active function that straddles a finer-level refinement boundary is refined level by level via the two-scale (Oslo) matrices (`_compute_oslo_matrix_1d_core`), zeroing its components on active finer functions at each level (Giannelli–Jüttler–Speleers truncation). Only **truncated** functions store a coefficient vector (dense over the box of finest-level functions their support reaches); untruncated functions remain plain tensor-product B-splines (no storage).
- **Truncated evaluation.** `tabulate_basis` evaluates truncated functions by contracting the stored coefficients with the representation-level 1D bases (`np.einsum`); the untruncated fast path is unchanged.
- **Default flip.** `truncate` now defaults to `True` (THB) — the agreed THB default; PR1 shipped `False` only because truncation wasn't implemented yet. `truncate=False` remains the HB path.

### Behaviour notes
- **Partition of unity** is restored by truncation (verified to ~1e-16); the HB basis is *not* a partition of unity over refined regions.
- THB is **nonnegative** and reproduces the coarse space (`1, x, y, xy`) like HB (same space `V_h`, different basis).
- `active_basis(cid)` lists functions by their **untruncated** support; under truncation a few listed functions may evaluate to exactly zero on the cell. `tabulate_basis` always returns the correct (possibly zero) values. Documented on the class.

## Test plan
- [x] New `TestTruncation`: partition of unity (1D, 2D corner, 2D 3-level), nonnegativity, coarse-space reproduction, truncated-count bounds, no-truncation-when-unrefined, truncation identity outside the refined region (THB == HB there), PoU restored on a refined cell where HB over-sums.
- [x] Updated construction tests for the `truncate=True` default; all PR1 HB tests retained (they pin `truncate=False`).
- [x] Full suite: `pytest --no-cov` — 2891 passed.
- [x] `ruff check` / `ruff format --check` / `mypy` clean; docs build clean (`sphinx-build -W`).

Tracking: #164 · builds on #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
