### PR TITLE
feat(bspline): derivative evaluation for THBSplineSpace (PR3 of #164)

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -71,8 +71,11 @@ class _BasisEval1D(NamedTuple):
     first_basis: npt.NDArray[np.int64]
 
 
-_EvalCache = dict[tuple[int, int], _BasisEval1D]
-"""Per-call cache of 1D basis evaluations keyed by ``(level, direction)``."""
+_EvalCache = dict[tuple[int, int, int], _BasisEval1D]
+"""Per-call cache of 1D basis evaluations keyed by ``(level, direction, order)``.
+
+``order`` is the derivative order evaluated in that direction (``0`` for values).
+"""
 
 _EINSUM_MAX_DIM = 24
 """Maximum parametric dimension supported by the single-letter einsum subscript scheme.
@@ -695,67 +698,77 @@ class THBSplineSpace:
         self,
         level: int,
         k: int,
+        order: int,
         flat_pts: npt.NDArray[np.float64],
         eval_cache: _EvalCache,
     ) -> _BasisEval1D:
-        """Evaluate (and cache) the level-``level`` 1D basis in direction ``k``.
+        """Evaluate (and cache) the level-``level`` 1D basis (or a derivative).
 
         Args:
             level (int): Hierarchy level whose 1D space is evaluated.
             k (int): Parametric direction.
+            order (int): Derivative order in direction ``k`` (``0`` for values).
             flat_pts (npt.NDArray[np.float64]): All parametric points of shape
                 ``(num_pts, dim)``; column ``k`` is used.
-            eval_cache (_EvalCache): Per-call cache keyed by ``(level, k)``.
+            eval_cache (_EvalCache): Per-call cache keyed by ``(level, k, order)``.
 
         Returns:
-            _BasisEval1D: ``(values, first_basis)`` as returned by
-            :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`.
+            _BasisEval1D: ``(values, first_basis)`` where ``values`` holds the
+            ``order``-th derivative of each local basis function (the function
+            values when ``order == 0``).
         """
-        key = (level, k)
+        key = (level, k, order)
         cached = eval_cache.get(key)
         if cached is None:
             sp1d = self._level_spaces[level].spaces[k]
-            values, first_basis = sp1d.tabulate_basis(np.ascontiguousarray(flat_pts[:, k]))
-            cached = _BasisEval1D(
-                np.asarray(values, dtype=np.float64),
-                np.asarray(first_basis, dtype=np.int64),
-            )
+            pts_k = np.ascontiguousarray(flat_pts[:, k])
+            if order == 0:
+                values, first_basis = sp1d.tabulate_basis(pts_k)
+                deriv = np.asarray(values, dtype=np.float64)
+            else:
+                all_deriv, first_basis = sp1d.tabulate_basis_derivatives(pts_k, order)
+                deriv = np.asarray(all_deriv, dtype=np.float64)[:, order, :]
+            cached = _BasisEval1D(deriv, np.asarray(first_basis, dtype=np.int64))
             eval_cache[key] = cached
         return cached
 
     def _truncated_column(
         self,
         entry: _TruncCoeffs,
+        orders: tuple[int, ...],
         flat_pts: npt.NDArray[np.float64],
         eval_cache: _EvalCache,
-        point_index: npt.NDArray[np.int64],
-        num_pts: int,
     ) -> npt.NDArray[np.float64]:
-        """Evaluate one truncated function from its stored coefficients.
+        """Evaluate one truncated function (or a derivative) from its coefficients.
 
-        Computes ``sum_multi coeffs[multi] * prod_k B^rep_{box_lo[k] + multi_k}(pt)``
-        over the stored coefficient box via a tensor contraction.
+        Computes ``sum_multi coeffs[multi] * prod_k D^orders[k] B^rep_{box_lo[k] +
+        multi_k}(pt)`` over the stored coefficient box via a tensor contraction,
+        where ``D^orders[k]`` is the ``orders[k]``-th derivative in direction ``k``.
 
         Args:
             entry (_TruncCoeffs): ``(rep_level, box_lo, coeffs)`` for the function.
+            orders (tuple[int, ...]): Per-direction derivative orders (all ``0`` for
+                function values).
             flat_pts (npt.NDArray[np.float64]): Points of shape ``(num_pts, dim)``.
             eval_cache (_EvalCache): Per-call 1D-basis evaluation cache.
-            point_index (npt.NDArray[np.int64]): ``arange(num_pts)`` for gathering.
-            num_pts (int): Number of points.
 
         Returns:
-            npt.NDArray[np.float64]: Function values of shape ``(num_pts,)``.
+            npt.NDArray[np.float64]: Values of shape ``(num_pts,)``.
         """
         rep_level, box_lo, coeffs = entry
         dim = self.dim
+        num_pts = flat_pts.shape[0]
+        point_index = np.arange(num_pts)
         if dim > _EINSUM_MAX_DIM:
             raise NotImplementedError(
                 f"_truncated_column uses single-letter einsum subscripts; "
-                f"only dim ≤ {_EINSUM_MAX_DIM} is supported, got dim={dim}."
+                f"only dim <= {_EINSUM_MAX_DIM} is supported, got dim={dim}."
             )
         value_mats: list[npt.NDArray[np.float64]] = []
         for k in range(dim):
-            values, first_basis = self._basis_1d_cached(rep_level, k, flat_pts, eval_cache)
+            values, first_basis = self._basis_1d_cached(
+                rep_level, k, orders[k], flat_pts, eval_cache
+            )
             degree_k = self.degrees[k]
             width = coeffs.shape[k]
             vmat = np.zeros((num_pts, width), dtype=np.float64)
@@ -772,37 +785,32 @@ class THBSplineSpace:
         column = np.asarray(np.einsum(subscripts, coeffs, *value_mats), dtype=np.float64)
         return column
 
-    def tabulate_basis(
+    def _tabulate_orders(
         self,
         cid: int,
         pts: npt.ArrayLike,
-        out: npt.NDArray[np.float64] | None = None,
+        orders: tuple[int, ...],
+        out: npt.NDArray[np.float64] | None,
     ) -> npt.NDArray[np.float64]:
-        """Evaluate the active hierarchical functions on cell ``cid`` at ``pts``.
+        """Evaluate the active functions' ``orders`` mixed partial on cell ``cid``.
 
-        Untruncated functions are a single tensor-product B-spline (the product of
-        their 1D B-spline values).  Truncated functions are evaluated from their
-        stored coefficients in the finest tensor-product basis their support reaches.
-        The returned columns are ordered as :meth:`active_basis` (sorted global dof);
-        a listed truncated function may evaluate to exactly zero on the cell.
+        Shared implementation for :meth:`tabulate_basis` (``orders`` all zero) and
+        :meth:`tabulate_basis_derivatives`.
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
-            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
-                cell ``cid``.  Points outside the cell's bounds raise
-                :class:`ValueError`.
-            out (npt.NDArray[np.float64] | None): Optional output array of shape
-                ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
-                ``None``.
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` in the cell.
+            orders (tuple[int, ...]): Per-direction derivative orders.
+            out (npt.NDArray[np.float64] | None): Optional output of shape ``(..., K)``.
 
         Returns:
-            npt.NDArray[np.float64]: Function values of shape ``(..., K)``.
+            npt.NDArray[np.float64]: Values of shape ``(..., K)``.
 
         Raises:
             IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
             ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
-                point lies outside the bounds of cell ``cid``, or if ``out`` has the
-                wrong shape, dtype, or is not writeable.
+                point lies outside cell ``cid``, or if ``out`` has the wrong shape,
+                dtype, or is not writeable.
             RuntimeError: If the grid has been modified since construction.
         """
         contribs = self._cell_contributions(cid)  # validates cid; raises if stale
@@ -845,7 +853,9 @@ class THBSplineSpace:
             if entry is None:
                 column = np.ones(num_pts, dtype=np.float64)
                 for k in range(self.dim):
-                    values, first_basis = self._basis_1d_cached(level, k, flat_pts, eval_cache)
+                    values, first_basis = self._basis_1d_cached(
+                        level, k, orders[k], flat_pts, eval_cache
+                    )
                     local = multi[k] - first_basis
                     degree_k = self.degrees[k]
                     valid = (local >= 0) & (local <= degree_k)
@@ -853,12 +863,98 @@ class THBSplineSpace:
                     column *= np.where(valid, gathered, 0.0)
                 buffer[:, col] = column
             else:
-                buffer[:, col] = self._truncated_column(
-                    entry, flat_pts, eval_cache, point_index, num_pts
-                )
+                buffer[:, col] = self._truncated_column(entry, orders, flat_pts, eval_cache)
 
         result[...] = buffer.reshape(out_shape)
         return result
+
+    def tabulate_basis(
+        self,
+        cid: int,
+        pts: npt.ArrayLike,
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Evaluate the active hierarchical functions on cell ``cid`` at ``pts``.
+
+        Untruncated functions are a single tensor-product B-spline (the product of
+        their 1D B-spline values).  Truncated functions are evaluated from their
+        stored coefficients in the finest tensor-product basis their support reaches.
+        The returned columns are ordered as :meth:`active_basis` (sorted global dof);
+        a listed truncated function may evaluate to exactly zero on the cell.
+
+        Args:
+            cid (int): Active cell flat id in ``[0, grid.num_cells)``.
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
+                cell ``cid``.  Points outside the cell's bounds raise
+                :class:`ValueError`.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
+                ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: Function values of shape ``(..., K)``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
+            ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
+                point lies outside the bounds of cell ``cid``, or if ``out`` has the
+                wrong shape, dtype, or is not writeable.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        return self._tabulate_orders(cid, pts, (0,) * self.dim, out)
+
+    def tabulate_basis_derivatives(
+        self,
+        cid: int,
+        pts: npt.ArrayLike,
+        orders: int | Sequence[int],
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        r"""Evaluate a mixed partial derivative of the active functions on cell ``cid``.
+
+        Computes the single mixed partial :math:`\partial^{orders}` of each active
+        hierarchical function, where ``orders[k]`` is the derivative order in
+        parametric direction ``k`` (derivatives are with respect to the parametric
+        coordinates).  Untruncated functions differentiate as a tensor product of 1D
+        B-spline derivatives; truncated functions apply their stored coefficients to
+        the B-spline derivatives at their representation level.  The returned columns
+        are ordered as :meth:`active_basis` (sorted global dof).
+
+        Args:
+            cid (int): Active cell flat id in ``[0, grid.num_cells)``.
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
+                cell ``cid``.  Points outside the cell's bounds raise
+                :class:`ValueError`.
+            orders (int | Sequence[int]): Per-direction derivative orders.  A scalar
+                is broadcast to every direction.  Each entry must be ``>= 0``; orders
+                exceeding the degree yield zero.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
+                ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: Derivative values of shape ``(..., K)``.
+
+        Raises:
+            IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
+            ValueError: If ``orders`` has the wrong length or a negative entry, if
+                ``pts`` does not have trailing dimension ``dim``, if any point lies
+                outside cell ``cid``, or if ``out`` has the wrong shape, dtype, or is
+                not writeable.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        if isinstance(orders, int):
+            orders_t = (orders,) * self.dim
+        else:
+            orders_t = tuple(int(o) for o in orders)
+            if len(orders_t) != self.dim:
+                raise ValueError(
+                    f"orders must be a scalar or length-{self.dim} sequence; "
+                    f"got length {len(orders_t)}."
+                )
+        if any(o < 0 for o in orders_t):
+            raise ValueError(f"orders must be non-negative; got {orders_t!r}.")
+        return self._tabulate_orders(cid, pts, orders_t, out)
 
     def __repr__(self) -> str:
         """Return a compact string representation.

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -165,10 +165,10 @@ class THBSplineSpace:
             subdividing to build finer levels.
         _level_spaces (tuple[BsplineSpace, ...]): Per-level tensor-product spaces;
             index ``l`` is the root subdivided to level ``l``.
-        _support (tuple[tuple[_Support1D, ...], ...]): Per-level, per-direction
-            function-to-cell support arrays; ``_support[level][k]`` is the
-            ``(first_basis, first_cell, last_cell)`` int64 triple for direction
-            ``k`` at ``level``.
+        _support (tuple): Per-level, per-direction function-to-cell support
+            arrays; ``_support[level][k]`` is the
+            ``(first_basis, first_cell, last_cell)`` int64 triple
+            (a ``_Support1D``) for direction ``k`` at ``level``.
         _active_funcs (tuple[npt.NDArray[np.int64], ...]): Per-level sorted flat
             (C-order) indices of the active tensor-product functions.
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
@@ -176,9 +176,8 @@ class THBSplineSpace:
         _num_active (int): Total number of active hierarchical functions.
         _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
             construction; used to detect post-construction grid mutations.
-        _trunc (dict[int, _TruncCoeffs]): Map from global dof to
-            ``_TruncCoeffs``; only truncated functions appear (empty when
-            ``truncate=False``).
+        _trunc (dict): Map from global dof (``int``) to ``_TruncCoeffs``;
+            only truncated functions appear (empty when ``truncate=False``).
     """
 
     __slots__ = (

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -117,10 +117,11 @@ def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
             if first_cell[i] < 0:
                 first_cell[i] = interval
             last_cell[i] = interval
-    assert np.all(first_cell >= 0), (
-        f"B-spline function(s) with empty support detected at indices "
-        f"{np.where(first_cell < 0)[0].tolist()}. This indicates an invalid B-spline space."
-    )
+    if not np.all(first_cell >= 0):
+        raise RuntimeError(
+            f"B-spline function(s) with empty support detected at indices "
+            f"{np.where(first_cell < 0)[0].tolist()}. This indicates an invalid B-spline space."
+        )
     return first_basis, first_cell, last_cell
 
 
@@ -164,9 +165,10 @@ class THBSplineSpace:
             subdividing to build finer levels.
         _level_spaces (tuple[BsplineSpace, ...]): Per-level tensor-product spaces;
             index ``l`` is the root subdivided to level ``l``.
-        _support (tuple): Per-level, per-direction function-to-cell support arrays;
-            each entry is a tuple of ``(first_basis, first_cell, last_cell)`` int64
-            arrays for one direction at one level.
+        _support (tuple[tuple[_Support1D, ...], ...]): Per-level, per-direction
+            function-to-cell support arrays; ``_support[level][k]`` is the
+            ``(first_basis, first_cell, last_cell)`` int64 triple for direction
+            ``k`` at ``level``.
         _active_funcs (tuple[npt.NDArray[np.int64], ...]): Per-level sorted flat
             (C-order) indices of the active tensor-product functions.
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
@@ -174,8 +176,9 @@ class THBSplineSpace:
         _num_active (int): Total number of active hierarchical functions.
         _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
             construction; used to detect post-construction grid mutations.
-        _trunc (dict): Map from global dof (int) to ``_TruncCoeffs``; only
-            truncated functions appear (empty when ``truncate=False``).
+        _trunc (dict[int, _TruncCoeffs]): Map from global dof to
+            ``_TruncCoeffs``; only truncated functions appear (empty when
+            ``truncate=False``).
     """
 
     __slots__ = (
@@ -510,6 +513,12 @@ class THBSplineSpace:
                 # coefficient box at every finer level has no overlap with active
                 # finer functions requires no truncation (remains a plain B-spline).
                 if any_zeroed:
+                    if len(box_lo) != coeffs.ndim:
+                        raise RuntimeError(
+                            f"_compute_truncated_coeffs: box_lo length {len(box_lo)} "
+                            f"!= coeffs.ndim {coeffs.ndim}."
+                        )
+                    coeffs.flags.writeable = False
                     trunc[offset + pos] = _TruncCoeffs(rep, tuple(box_lo), coeffs)
         return trunc
 
@@ -647,6 +656,9 @@ class THBSplineSpace:
     def level_space(self, level: int) -> BsplineSpace:
         """Return the tensor-product space at ``level``.
 
+        Returns a construction-time snapshot; not affected by subsequent grid
+        mutations (no stale check is performed).
+
         Args:
             level (int): Hierarchy level in ``[0, num_levels)``.
 
@@ -654,14 +666,17 @@ class THBSplineSpace:
             BsplineSpace: The root space subdivided to ``level``.
 
         Raises:
-            IndexError: If ``level`` is out of range.
+            ValueError: If ``level`` is out of range.
         """
         if not (0 <= level < self.num_levels):
-            raise IndexError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
+            raise ValueError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
         return self._level_spaces[level]
 
     def active_function_indices(self, level: int) -> npt.NDArray[np.int64]:
         """Return the flat indices of the active functions at ``level``.
+
+        Returns a construction-time snapshot; not affected by subsequent grid
+        mutations (no stale check is performed).
 
         Args:
             level (int): Hierarchy level in ``[0, num_levels)``.
@@ -671,15 +686,15 @@ class THBSplineSpace:
             indices selected by the Kraft rule.  A fresh copy is returned.
 
         Raises:
-            IndexError: If ``level`` is out of range.
+            ValueError: If ``level`` is out of range.
         """
         if not (0 <= level < self.num_levels):
-            raise IndexError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
+            raise ValueError(f"level must be in [0, {self.num_levels - 1}]; got {level!r}.")
         indices: npt.NDArray[np.int64] = self._active_funcs[level].copy()
         return indices
 
     def active_basis(self, cid: int) -> npt.NDArray[np.int64]:
-        """Return the global dofs of the active functions non-zero on cell ``cid``.
+        """Return the global dofs of the active functions whose support intersects cell ``cid``.
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
@@ -753,7 +768,11 @@ class THBSplineSpace:
             eval_cache (_EvalCache): Per-call 1D-basis evaluation cache.
 
         Returns:
-            npt.NDArray[np.float64]: Values of shape ``(num_pts,)``.
+            npt.NDArray[np.float64]: Function values of shape ``(num_pts,)``.
+
+        Raises:
+            NotImplementedError: If ``self.dim > _EINSUM_MAX_DIM`` (24); the
+                einsum subscript scheme requires one letter per axis.
         """
         rep_level, box_lo, coeffs = entry
         dim = self.dim
@@ -799,9 +818,13 @@ class THBSplineSpace:
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
-            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` in the cell.
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
+                cell ``cid``.  A tolerance of ``1e-12`` is applied at the cell
+                boundary; points further outside raise :class:`ValueError`.
             orders (tuple[int, ...]): Per-direction derivative orders.
-            out (npt.NDArray[np.float64] | None): Optional output of shape ``(..., K)``.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
+                ``None``.
 
         Returns:
             npt.NDArray[np.float64]: Values of shape ``(..., K)``.

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -770,7 +770,7 @@ class HierarchicalGrid(Grid):
             level (int): Hierarchy level.  Must be in ``[0, max_level]``.
 
         Returns:
-            npt.NDArray[np.bool_]: Fresh array of shape
+            npt.NDArray[np.bool\_]: Fresh array of shape
             ``level_cells_per_axis(level)``; ``True`` where the level-``level``
             cell ``(level, midx)`` is an active (leaf) cell.
 
@@ -796,7 +796,7 @@ class HierarchicalGrid(Grid):
             level (int): Hierarchy level.  Must be in ``[0, max_level]``.
 
         Returns:
-            npt.NDArray[np.bool_]: Fresh array of shape
+            npt.NDArray[np.bool\_]: Fresh array of shape
             ``level_cells_per_axis(level)``; ``True`` where the level-``level``
             cell lies in :math:`\Omega_{level}`.
 

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -770,7 +770,7 @@ class HierarchicalGrid(Grid):
             level (int): Hierarchy level.  Must be in ``[0, max_level]``.
 
         Returns:
-            npt.NDArray[bool]: Fresh array of shape
+            npt.NDArray[np.bool_]: Fresh array of shape
             ``level_cells_per_axis(level)``; ``True`` where the level-``level``
             cell ``(level, midx)`` is an active (leaf) cell.
 
@@ -796,7 +796,7 @@ class HierarchicalGrid(Grid):
             level (int): Hierarchy level.  Must be in ``[0, max_level]``.
 
         Returns:
-            npt.NDArray[bool]: Fresh array of shape
+            npt.NDArray[np.bool_]: Fresh array of shape
             ``level_cells_per_axis(level)``; ``True`` where the level-``level``
             cell lies in :math:`\Omega_{level}`.
 
@@ -804,9 +804,8 @@ class HierarchicalGrid(Grid):
             ValueError: If ``level`` is outside ``[0, max_level]``.
 
         Note:
-            The mask is sized to the level-``level`` cell grid (computed on demand,
-            never stored).  Block-wise selection is a future optimization for deep
-            hierarchies.
+            The mask is sized to the level-``level`` cell grid and computed on
+            demand; it is never stored.
         """
         self._check_level(level)
         mask = np.ones(self.level_cells_per_axis(level), dtype=np.bool_)

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -764,7 +764,7 @@ class HierarchicalGrid(Grid):
         return tuple(self._blocks[level])
 
     def active_leaf_mask(self, level: int) -> npt.NDArray[np.bool_]:
-        """Return a boolean mask of the active-leaf cells at ``level``.
+        r"""Return a boolean mask of the active-leaf cells at ``level``.
 
         Args:
             level (int): Hierarchy level.  Must be in ``[0, max_level]``.

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1,8 +1,8 @@
-"""Tests for pantr.bspline.THBSplineSpace (non-truncated / HB path)."""
+"""Tests for pantr.bspline.THBSplineSpace (HB and THB bases, values and derivatives)."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -624,3 +624,148 @@ class TestTruncation:
         n_active = thb.active_basis(cid).shape[0]
         assert result.shape == (2, 3, n_active)
         np.testing.assert_allclose(result.sum(axis=-1), 1.0, atol=1e-10)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Derivatives
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _collocation_derivatives(
+    thb: THBSplineSpace, orders: int | Sequence[int]
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Like :func:`_collocation` but evaluates the ``orders`` mixed partial."""
+    grid = thb.grid
+    dim = thb.dim
+    n_active = thb.num_active_functions
+    u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
+    rows: list[npt.NDArray[np.float64]] = []
+    pts: list[npt.NDArray[np.float64]] = []
+    for cid in range(grid.num_cells):
+        lo, hi = grid.cell_bounds(cid)
+        axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(dim)]
+        mesh = np.meshgrid(*axes, indexing="ij")
+        cell_pts = np.stack([m.ravel() for m in mesh], axis=-1)
+        active = thb.active_basis(cid)
+        values = thb.tabulate_basis_derivatives(cid, cell_pts, orders)
+        for i in range(cell_pts.shape[0]):
+            row = np.zeros(n_active)
+            row[active] = values[i]
+            rows.append(row)
+            pts.append(cell_pts[i])
+    return np.asarray(rows), np.asarray(pts)
+
+
+class TestDerivatives:
+    """Parametric derivatives via tabulate_basis_derivatives (HB and THB)."""
+
+    def test_order_zero_equals_values_thb(self) -> None:
+        thb = _refined_2d_corner()
+        cid = thb.grid.locate([0.1, 0.1])
+        assert cid is not None
+        lo, hi = thb.grid.cell_bounds(cid)
+        pts = (lo + (hi - lo) * 0.5).reshape(1, thb.dim)
+        np.testing.assert_allclose(
+            thb.tabulate_basis_derivatives(cid, pts, 0), thb.tabulate_basis(cid, pts)
+        )
+
+    def test_order_zero_equals_values_hb(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        hb = THBSplineSpace(root, grid, truncate=False)
+        cid = grid.locate([0.1])
+        assert cid is not None
+        lo, hi = grid.cell_bounds(cid)
+        pts = lo + (hi - lo) * np.array([0.25, 0.5, 0.75])[:, None]
+        np.testing.assert_allclose(
+            hb.tabulate_basis_derivatives(cid, pts, 0), hb.tabulate_basis(cid, pts)
+        )
+
+    def test_partition_of_unity_derivative_is_zero_1d(self) -> None:
+        # d/dx of (sum of THB basis = 1) is 0 everywhere.
+        mat, _ = _collocation_derivatives(_refined_1d_three_levels(), 1)
+        np.testing.assert_allclose(mat.sum(axis=1), 0.0, atol=1e-10)
+
+    def test_partition_of_unity_derivative_is_zero_2d(self) -> None:
+        thb = _refined_2d_corner()
+        for orders in ([1, 0], [0, 1]):
+            mat, _ = _collocation_derivatives(thb, orders)
+            np.testing.assert_allclose(mat.sum(axis=1), 0.0, atol=1e-10)
+
+    def test_reproduce_first_derivative_1d(self) -> None:
+        thb = _refined_1d_three_levels()
+        a_val, pts = _collocation(thb)
+        a_dx, _ = _collocation_derivatives(thb, 1)
+        coef, _, _, _ = np.linalg.lstsq(a_val, pts[:, 0] ** 2, rcond=None)  # reproduce x^2
+        assert np.abs(a_dx @ coef - 2.0 * pts[:, 0]).max() < 1e-9  # d/dx (x^2) = 2x
+
+    def test_reproduce_second_derivative_1d(self) -> None:
+        thb = _refined_1d_three_levels()
+        a_val, pts = _collocation(thb)
+        a_dxx, _ = _collocation_derivatives(thb, 2)
+        coef, _, _, _ = np.linalg.lstsq(a_val, pts[:, 0] ** 2, rcond=None)
+        assert np.abs(a_dxx @ coef - 2.0).max() < 1e-9  # d2/dx2 (x^2) = 2
+
+    def test_reproduce_mixed_derivative_2d(self) -> None:
+        thb = _refined_2d_corner()
+        a_val, pts = _collocation(thb)
+        coef, _, _, _ = np.linalg.lstsq(a_val, pts[:, 0] * pts[:, 1], rcond=None)  # reproduce xy
+        a_dx, _ = _collocation_derivatives(thb, [1, 0])
+        a_dxy, _ = _collocation_derivatives(thb, [1, 1])
+        assert np.abs(a_dx @ coef - pts[:, 1]).max() < 1e-9  # d/dx (xy) = y
+        assert np.abs(a_dxy @ coef - 1.0).max() < 1e-9  # d2/dxdy (xy) = 1
+
+    def test_finite_difference_1d(self) -> None:
+        thb = _refined_1d_three_levels()
+        h = 1e-6
+        for cid in range(thb.grid.num_cells):
+            lo, hi = thb.grid.cell_bounds(cid)
+            x = float(0.5 * (lo[0] + hi[0]))
+            fd = (
+                thb.tabulate_basis(cid, np.array([[x + h]]))
+                - thb.tabulate_basis(cid, np.array([[x - h]]))
+            ) / (2.0 * h)
+            analytic = thb.tabulate_basis_derivatives(cid, np.array([[x]]), 1)
+            np.testing.assert_allclose(fd, analytic, atol=1e-6)
+
+    def test_high_order_is_zero(self) -> None:
+        # Degree 2: the third derivative is identically zero.
+        thb = _refined_1d_three_levels()
+        cid = thb.grid.locate([0.1])
+        assert cid is not None
+        result = thb.tabulate_basis_derivatives(cid, np.array([[0.1]]), 3)
+        np.testing.assert_allclose(result, 0.0, atol=1e-12)
+
+    def test_orders_length_mismatch_raises(self) -> None:
+        thb = _refined_2d_corner()
+        with pytest.raises(ValueError, match="orders"):
+            thb.tabulate_basis_derivatives(0, np.array([[0.1, 0.1]]), [1])
+
+    def test_negative_order_raises(self) -> None:
+        thb = _refined_1d_three_levels()
+        with pytest.raises(ValueError, match="non-negative"):
+            thb.tabulate_basis_derivatives(0, np.array([[0.1]]), -1)
+
+    def test_out_argument(self) -> None:
+        thb = _refined_1d_three_levels()
+        cid = thb.grid.locate([0.1])
+        assert cid is not None
+        lo, hi = thb.grid.cell_bounds(cid)
+        pts = lo + (hi - lo) * np.array([0.3, 0.6])[:, None]
+        k = thb.active_basis(cid).shape[0]
+        out = np.empty((2, k), dtype=np.float64)
+        ret = thb.tabulate_basis_derivatives(cid, pts, 1, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, thb.tabulate_basis_derivatives(cid, pts, 1))
+
+    def test_hb_derivative_reproduction(self) -> None:
+        root = _root_1d()
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        hb = THBSplineSpace(root, grid, truncate=False)
+        a_val, pts = _collocation(hb)
+        a_dx, _ = _collocation_derivatives(hb, 1)
+        coef, _, _, _ = np.linalg.lstsq(a_val, pts[:, 0] ** 2, rcond=None)
+        assert np.abs(a_dx @ coef - 2.0 * pts[:, 0]).max() < 1e-9

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -263,7 +263,7 @@ class TestSelection:
 
     def test_active_function_indices_out_of_range(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             thb.active_function_indices(5)
 
     def test_fully_refined_level_has_no_active_functions(self) -> None:
@@ -419,7 +419,7 @@ class TestLevelSpaces:
 
     def test_level_space_out_of_range(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             thb.level_space(1)
 
     def test_levels_are_nested_1d(self) -> None:
@@ -624,6 +624,57 @@ class TestTruncation:
         n_active = thb.active_basis(cid).shape[0]
         assert result.shape == (2, 3, n_active)
         np.testing.assert_allclose(result.sum(axis=-1), 1.0, atol=1e-10)
+
+    def test_thb_and_hb_same_active_count(self) -> None:
+        # Truncation changes function values but not the active-function selection.
+        root, grid = _root_2d(), _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        hb = THBSplineSpace(root, grid, truncate=False)
+        assert thb.num_active_functions == hb.num_active_functions
+        assert thb.num_active_functions_per_level == hb.num_active_functions_per_level
+        assert thb.num_active_functions == sum(thb.num_active_functions_per_level)
+
+    def test_active_basis_union_covers_all_dofs(self) -> None:
+        # The union of active_basis(cid) over all cells must equal {0, …, N-1}.
+        thb = _refined_2d_corner()
+        seen: set[int] = set()
+        for cid in range(thb.grid.num_cells):
+            seen.update(thb.active_basis(cid).tolist())
+        assert seen == set(range(thb.num_active_functions))
+
+    def test_partition_of_unity_factor3(self) -> None:
+        # Verify that factor=3 (non-power-of-2) refinement still gives partition of unity.
+        root = _root_1d()
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 3)
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_partition_of_unity_degree1(self) -> None:
+        # Degree-1 (linear): support = 1 interval per function; different truncation geometry.
+        knots = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0])
+        sp1d = BsplineSpace1D(knots, 1)
+        root = BsplineSpace([sp1d])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid, truncate=True)
+        mat, _ = _collocation(thb)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_regularity_sequence_form(self) -> None:
+        # Scalar regularity=0 and equivalent sequence form [0] produce the same space.
+        root = _root_1d()
+        grid1 = _grid_1d()
+        grid1.refine(0, [0], [2])
+        thb_scalar = THBSplineSpace(root, grid1, truncate=True, regularity=0)
+        grid2 = _grid_1d()
+        grid2.refine(0, [0], [2])
+        thb_seq = THBSplineSpace(root, grid2, truncate=True, regularity=[0])
+        assert thb_scalar.num_active_functions == thb_seq.num_active_functions
+        mat, _ = _collocation(thb_seq)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR3 of the THB-spline feature (#164). Adds **parametric derivative evaluation** to `THBSplineSpace`, on top of the value evaluation (PR1 #165) and truncation (PR2 #166).

- **`tabulate_basis_derivatives(cid, pts, orders, out=None)`** — evaluates the single mixed partial `∂^orders` of each active hierarchical function at the points on cell `cid`. `orders` is a per-direction multi-index (`int` broadcast to all directions), matching `Bezier.evaluate_derivatives`. Columns are ordered as `active_basis(cid)`.
- **Untruncated** functions differentiate as a tensor product of 1D B-spline derivatives; **truncated** functions apply their stored coefficients (from PR2) to the B-spline *derivatives* at their representation level — the same coefficients as the value evaluation.
- The value and derivative paths now share a single `_tabulate_orders` implementation parameterized by a per-direction derivative order (the 1D-basis cache is keyed by `(level, direction, order)`). `tabulate_basis` is `_tabulate_orders` with all-zero orders, so **order-0 derivatives equal the values exactly**.
- Derivatives are w.r.t. the **parametric** coordinates (no geometry Jacobian — that is downstream).

## Test plan
- [x] New `TestDerivatives`: order-0 equals values (HB & THB), **∂(partition of unity) = 0** for THB in 1D/2D, exact reproduction of polynomial derivatives (`d/dx x² = 2x`, `d²/dx² x² = 2`, `∂xy/∂x = y`, `∂²xy/∂x∂y = 1`), finite-difference agreement, high-order-is-zero, `out=` arg, and `orders` validation (length / negativity).
- [x] Full suite: `pytest --no-cov` — 2910 passed.
- [x] `ruff` / `ruff format` / `mypy` clean; docs build clean (`sphinx-build -W`).

Tracking: #164 · builds on #165, #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
