### PR TITLE
feat(bspline): THBSplineSpace refinement + prolongation (PR4 of #164)

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -991,8 +991,8 @@ class THBSplineSpace:
     ) -> THBSplineSpace:
         """Return a new space with the marked cells refined.
 
-        The space is immutable: a fresh grid is refined and a new
-        :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
+        This method does not mutate ``self`` or its grid: a fresh grid is refined
+        and a new :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
 
         With ``admissible_class=m`` (the default ``m=2``) the refinement is graded so
         the resulting mesh is admissible of class ``m`` (the truncated functions
@@ -1022,9 +1022,10 @@ class THBSplineSpace:
                 f"admissible_class must be an integer >= 2 or None; got {admissible_class!r}."
             )
         ids = np.unique(np.asarray(cell_ids, dtype=np.int64).ravel())
-        if ids.size and (int(ids[0]) < 0 or int(ids[-1]) >= self._grid.num_cells):
+        bad = [int(x) for x in ids if int(x) < 0 or int(x) >= self._grid.num_cells]
+        if bad:
             raise IndexError(
-                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id."
+                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id(s): {bad}."
             )
         # Convert to (level, midx) on the original grid before any refinement, since
         # flat ids are reassigned by every grid.refine call.
@@ -1061,6 +1062,11 @@ class THBSplineSpace:
             level (int): Level of the cell to refine.
             midx (tuple[int, ...]): Per-axis index of the cell at ``level``.
             m (int): Admissibility class (``>= 2``).
+
+        Raises:
+            RecursionError: Unreachable in practice — recursion depth is bounded by
+                ``level <= grid.max_level``, which is bounded by available memory long
+                before Python's default recursion limit.
         """
         for nlevel, nmidx in self._refinement_neighborhood(level, midx, m, grid):
             self._refine_recursive(grid, nlevel, nmidx, m)
@@ -1076,9 +1082,10 @@ class THBSplineSpace:
     ) -> list[tuple[int, tuple[int, ...]]]:
         """Return the refinement neighborhood of cell ``(level, midx)`` for class ``m``.
 
-        Implements Definition 3.4 of Carraturo et al. (2019): the active cells at level
-        ``level - m + 1`` that are parents of a cell in the multilevel support extension
-        of ``(level, midx)`` at level ``level - m + 2``.
+        Implements Definition 3.4 of Carraturo et al. (2019). Finds all cells at level
+        ``level - m + 1`` that are parents of a level-``level - m + 2`` cell touched by
+        any B-spline whose support covers the containing cell of ``(level, midx)`` at
+        level ``level - m + 2``.
 
         Args:
             level (int): Level of the cell.
@@ -1096,6 +1103,10 @@ class THBSplineSpace:
         if k_nbr < 0:
             return []
         k_ext = level - m + 2  # = k_nbr + 1; <= level because m >= 2
+        # k_ext < len(self._support) because level <= original max_level = num_levels - 1
+        assert k_ext < len(self._support), (
+            f"k_ext={k_ext} out of range; level={level}, m={m}, num_levels={self.num_levels}"
+        )
         support_ext = self._support[k_ext]
         # Containing cell of (level, midx) at level k_ext.
         q = tuple(midx[d] // factor[d] ** (level - k_ext) for d in range(dim))
@@ -1129,7 +1140,9 @@ class THBSplineSpace:
         Args:
             dof (int): Global active-function index.
             oslo (tuple[tuple[npt.NDArray[np.float64], ...], ...]): Per-level,
-                per-direction two-scale matrices spanning ``0 .. target_level - 1``.
+                per-direction two-scale matrices; must be indexed from at least
+                ``0`` through ``target_level - 1``.  Only ``oslo[start..target_level-1]``
+                is accessed, where ``start`` is the dof's native or representation level.
             target_level (int): Level whose TP basis the result is expressed in.
 
         Returns:
@@ -1159,8 +1172,8 @@ class THBSplineSpace:
     def prolongation_to(self, fine: THBSplineSpace) -> npt.NDArray[np.float64]:
         """Return the prolongation matrix from this space to a refinement ``fine``.
 
-        The hierarchical spaces are nested (``V_h subset of V_h'``), so every function
-        of this (coarse) space lies in ``fine``.  The returned matrix ``P`` maps a
+        The hierarchical spaces are nested (``V_h ⊆ V_h'``), so every function of this
+        (coarse) space lies in ``fine``.  The returned matrix ``P`` maps a
         coefficient vector in this space's basis to the coefficients of the **same
         function** in ``fine``'s basis: if ``u`` are coarse coefficients, ``P @ u`` are
         the fine coefficients.
@@ -1186,18 +1199,30 @@ class THBSplineSpace:
         """
         if not isinstance(fine, THBSplineSpace):
             raise TypeError(f"fine must be a THBSplineSpace; got {type(fine).__name__!r}.")
-        if (
-            fine.dim != self.dim
-            or fine._truncate != self._truncate
-            or tuple(fine._grid.factor) != tuple(self._grid.factor)
-            or fine._regularity != self._regularity
-            or fine.num_levels < self.num_levels
-            or not all(
-                np.array_equal(fine._root_space.spaces[k].knots, self._root_space.spaces[k].knots)
-                for k in range(self.dim)
+        mismatches: list[str] = []
+        if fine.dim != self.dim:
+            mismatches.append(f"dim: self={self.dim} vs fine={fine.dim}")
+        if fine._truncate != self._truncate:
+            mismatches.append(f"truncate: self={self._truncate} vs fine={fine._truncate}")
+        if tuple(fine._grid.factor) != tuple(self._grid.factor):
+            mismatches.append(f"factor: self={self._grid.factor} vs fine={fine._grid.factor}")
+        if fine._regularity != self._regularity:
+            mismatches.append(f"regularity: self={self._regularity} vs fine={fine._regularity}")
+        if fine.num_levels < self.num_levels:
+            mismatches.append(
+                f"fine.num_levels={fine.num_levels} < self.num_levels={self.num_levels}"
             )
+        if not all(
+            np.array_equal(fine._root_space.spaces[k].knots, self._root_space.spaces[k].knots)
+            for k in range(self.dim)
         ):
-            raise ValueError("fine must be a refinement of this space (incompatible spaces).")
+            mismatches.append("root knot vectors differ")
+        if mismatches:
+            raise ValueError(
+                "fine must be a refinement of this space; mismatches: "
+                + "; ".join(mismatches)
+                + "."
+            )
 
         target = fine.num_levels - 1
         oslo = fine._build_oslo_matrices()
@@ -1230,7 +1255,8 @@ class THBSplineSpace:
 
         solution, *_ = np.linalg.lstsq(fine_mat, coarse_mat, rcond=None)
         prolongation: npt.NDArray[np.float64] = np.asarray(solution, dtype=np.float64)
-        residual = float(np.abs(fine_mat @ prolongation - coarse_mat).max())
+        diff = np.abs(fine_mat @ prolongation - coarse_mat)
+        residual = float(diff.max()) if diff.size > 0 else 0.0
         if residual > 1e-8 * (1.0 + float(np.abs(coarse_mat).max())):
             raise ValueError(
                 f"fine is not a refinement of this space (prolongation residual {residual:.2e})."

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -15,6 +15,7 @@ Main exports:
 
 from __future__ import annotations
 
+import copy
 import itertools
 import string
 from typing import TYPE_CHECKING, NamedTuple
@@ -977,6 +978,264 @@ class THBSplineSpace:
         if any(o < 0 for o in orders_t):
             raise ValueError(f"orders must be non-negative; got {orders_t!r}.")
         return self._tabulate_orders(cid, pts, orders_t, out)
+
+    # ------------------------------------------------------------------
+    # Refinement
+    # ------------------------------------------------------------------
+
+    def refine(
+        self,
+        cell_ids: npt.ArrayLike,
+        *,
+        admissible_class: int | None = 2,
+    ) -> THBSplineSpace:
+        """Return a new space with the marked cells refined.
+
+        The space is immutable: a fresh grid is refined and a new
+        :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
+
+        With ``admissible_class=m`` (the default ``m=2``) the refinement is graded so
+        the resulting mesh is admissible of class ``m`` (the truncated functions
+        acting on any cell span at most ``m`` successive levels), following the
+        recursive refinement-neighborhood algorithm of Carraturo et al. (2019).  This
+        assumes the current mesh is already admissible of class ``m`` (true for the
+        root and for any mesh built via graded :meth:`refine`).  With
+        ``admissible_class=None`` exactly the marked cells are refined (no grading).
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat ids of active cells to refine.
+            admissible_class (int | None): Admissibility class ``m >= 2`` to maintain,
+                or ``None`` for ungraded refinement.  Defaults to ``2``.
+
+        Returns:
+            THBSplineSpace: A new space on the refined grid (same ``root_space``,
+            ``truncate``, and ``regularity``).
+
+        Raises:
+            IndexError: If any id is outside ``[0, grid.num_cells)``.
+            ValueError: If ``admissible_class`` is an integer ``< 2``.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        self._check_not_stale()
+        if admissible_class is not None and admissible_class < 2:  # noqa: PLR2004
+            raise ValueError(
+                f"admissible_class must be an integer >= 2 or None; got {admissible_class!r}."
+            )
+        ids = np.unique(np.asarray(cell_ids, dtype=np.int64).ravel())
+        if ids.size and (int(ids[0]) < 0 or int(ids[-1]) >= self._grid.num_cells):
+            raise IndexError(
+                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id."
+            )
+        # Convert to (level, midx) on the original grid before any refinement, since
+        # flat ids are reassigned by every grid.refine call.
+        marked = [(self._grid.cell_level(int(c)), self._grid.cell_multi_index(int(c))) for c in ids]
+        grid_copy = copy.deepcopy(self._grid)
+        for level, midx in marked:
+            if admissible_class is None:
+                if grid_copy.is_active_leaf(level, midx):
+                    grid_copy.refine(level, list(midx), [i + 1 for i in midx])
+            else:
+                self._refine_recursive(grid_copy, level, midx, admissible_class)
+        return THBSplineSpace(
+            self._root_space,
+            grid_copy,
+            truncate=self._truncate,
+            regularity=self._regularity,
+        )
+
+    def _refine_recursive(
+        self,
+        grid: HierarchicalGrid,
+        level: int,
+        midx: tuple[int, ...],
+        m: int,
+    ) -> None:
+        """Refine cell ``(level, midx)`` on ``grid``, grading for class-``m`` admissibility.
+
+        Refines every cell in the refinement neighborhood (recursively, at the coarser
+        level ``level - m + 1``) before subdividing ``(level, midx)``, per Algorithm 4
+        of Carraturo et al. (2019).
+
+        Args:
+            grid (HierarchicalGrid): The (mutable) grid copy being refined.
+            level (int): Level of the cell to refine.
+            midx (tuple[int, ...]): Per-axis index of the cell at ``level``.
+            m (int): Admissibility class (``>= 2``).
+        """
+        for nlevel, nmidx in self._refinement_neighborhood(level, midx, m, grid):
+            self._refine_recursive(grid, nlevel, nmidx, m)
+        if grid.is_active_leaf(level, midx):
+            grid.refine(level, list(midx), [i + 1 for i in midx])
+
+    def _refinement_neighborhood(
+        self,
+        level: int,
+        midx: tuple[int, ...],
+        m: int,
+        grid: HierarchicalGrid,
+    ) -> list[tuple[int, tuple[int, ...]]]:
+        """Return the refinement neighborhood of cell ``(level, midx)`` for class ``m``.
+
+        Implements Definition 3.4 of Carraturo et al. (2019): the active cells at level
+        ``level - m + 1`` that are parents of a cell in the multilevel support extension
+        of ``(level, midx)`` at level ``level - m + 2``.
+
+        Args:
+            level (int): Level of the cell.
+            midx (tuple[int, ...]): Per-axis index of the cell at ``level``.
+            m (int): Admissibility class (``>= 2``, so ``level - m + 2 <= level``).
+            grid (HierarchicalGrid): The grid copy whose active set is queried.
+
+        Returns:
+            list[tuple[int, tuple[int, ...]]]: ``(level - m + 1, parent_midx)`` cells in
+            the neighborhood that are currently active leaves.
+        """
+        dim = self.dim
+        factor = self._grid.factor
+        k_nbr = level - m + 1
+        if k_nbr < 0:
+            return []
+        k_ext = level - m + 2  # = k_nbr + 1; <= level because m >= 2
+        support_ext = self._support[k_ext]
+        # Containing cell of (level, midx) at level k_ext.
+        q = tuple(midx[d] // factor[d] ** (level - k_ext) for d in range(dim))
+        parent_ranges = []
+        for d in range(dim):
+            first_basis, first_cell, last_cell = support_ext[d]
+            fb = int(first_basis[q[d]])
+            s_lo = int(first_cell[fb])
+            s_hi = int(last_cell[fb + self.degrees[d]]) + 1
+            parent_ranges.append(range(s_lo // factor[d], (s_hi - 1) // factor[d] + 1))
+        return [
+            (k_nbr, p) for p in itertools.product(*parent_ranges) if grid.is_active_leaf(k_nbr, p)
+        ]
+
+    # ------------------------------------------------------------------
+    # Prolongation
+    # ------------------------------------------------------------------
+
+    def _finest_tp_coeffs(
+        self,
+        dof: int,
+        oslo: tuple[tuple[npt.NDArray[np.float64], ...], ...],
+        target_level: int,
+    ) -> tuple[list[int], npt.NDArray[np.float64]]:
+        """Express active function ``dof`` in the level-``target_level`` TP basis.
+
+        Takes the function's native representation (a single B-spline for untruncated
+        functions, the stored coefficients for truncated ones) and refines it purely
+        (two-scale, no truncation) up to ``target_level``.
+
+        Args:
+            dof (int): Global active-function index.
+            oslo (tuple[tuple[npt.NDArray[np.float64], ...], ...]): Per-level,
+                per-direction two-scale matrices spanning ``0 .. target_level - 1``.
+            target_level (int): Level whose TP basis the result is expressed in.
+
+        Returns:
+            tuple[list[int], npt.NDArray[np.float64]]: ``(box_lo, coeffs)`` over the
+            level-``target_level`` function box.
+        """
+        dim = self.dim
+        level = int(np.searchsorted(self._func_offset, dof, side="right")) - 1
+        pos = dof - int(self._func_offset[level])
+        flat = int(self._active_funcs[level][pos])
+        entry = self._trunc.get(dof)
+        if entry is None:
+            multi = np.unravel_index(flat, self._level_spaces[level].num_basis)
+            box_lo = [int(multi[d]) for d in range(dim)]
+            box_hi = [int(multi[d]) + 1 for d in range(dim)]
+            coeffs = np.ones((1,) * dim, dtype=np.float64)
+            start = level
+        else:
+            start = entry.rep_level
+            box_lo = list(entry.box_lo)
+            box_hi = [entry.box_lo[d] + entry.coeffs.shape[d] for d in range(dim)]
+            coeffs = entry.coeffs
+        for lvl in range(start, target_level):
+            coeffs, box_lo, box_hi = self._refine_box(coeffs, box_lo, box_hi, oslo[lvl])
+        return box_lo, coeffs
+
+    def prolongation_to(self, fine: THBSplineSpace) -> npt.NDArray[np.float64]:
+        """Return the prolongation matrix from this space to a refinement ``fine``.
+
+        The hierarchical spaces are nested (``V_h subset of V_h'``), so every function
+        of this (coarse) space lies in ``fine``.  The returned matrix ``P`` maps a
+        coefficient vector in this space's basis to the coefficients of the **same
+        function** in ``fine``'s basis: if ``u`` are coarse coefficients, ``P @ u`` are
+        the fine coefficients.
+
+        It is built by expressing every coarse and every fine basis function in the
+        common finest tensor-product basis of ``fine`` and solving the (consistent)
+        linear systems in the least-squares sense.
+
+        Args:
+            fine (THBSplineSpace): A refinement of this space (same ``root_space``,
+                ``factor``, ``regularity``, and ``truncate``; more levels / refined
+                cells).
+
+        Returns:
+            npt.NDArray[np.float64]: Matrix ``P`` of shape
+            ``(fine.num_active_functions, self.num_active_functions)``.
+
+        Raises:
+            TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
+            ValueError: If ``fine`` is not a refinement of this space (mismatched
+                root/factor/regularity/truncation, fewer levels, or the prolongation
+                residual is non-negligible).
+        """
+        if not isinstance(fine, THBSplineSpace):
+            raise TypeError(f"fine must be a THBSplineSpace; got {type(fine).__name__!r}.")
+        if (
+            fine.dim != self.dim
+            or fine._truncate != self._truncate
+            or tuple(fine._grid.factor) != tuple(self._grid.factor)
+            or fine._regularity != self._regularity
+            or fine.num_levels < self.num_levels
+            or not all(
+                np.array_equal(fine._root_space.spaces[k].knots, self._root_space.spaces[k].knots)
+                for k in range(self.dim)
+            )
+        ):
+            raise ValueError("fine must be a refinement of this space (incompatible spaces).")
+
+        target = fine.num_levels - 1
+        oslo = fine._build_oslo_matrices()
+        num_basis_finest = fine.level_space(target).num_basis
+
+        def column_flats(
+            space: THBSplineSpace, dof: int
+        ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]:
+            box_lo, coeffs = space._finest_tp_coeffs(dof, oslo, target)
+            ranges = [np.arange(box_lo[d], box_lo[d] + coeffs.shape[d]) for d in range(self.dim)]
+            mesh = np.meshgrid(*ranges, indexing="ij")
+            flats = np.ravel_multi_index([g.ravel() for g in mesh], num_basis_finest)
+            return flats, coeffs.ravel()
+
+        coarse_cols = [column_flats(self, i) for i in range(self.num_active_functions)]
+        fine_cols = [column_flats(fine, j) for j in range(fine.num_active_functions)]
+
+        touched = sorted(
+            {int(f) for flats, _ in (*coarse_cols, *fine_cols) for f in flats.tolist()}
+        )
+        touched_arr = np.array(touched, dtype=np.int64)
+        n_rows = touched_arr.shape[0]
+
+        coarse_mat = np.zeros((n_rows, self.num_active_functions), dtype=np.float64)
+        for i, (flats, vals) in enumerate(coarse_cols):
+            coarse_mat[np.searchsorted(touched_arr, flats), i] = vals
+        fine_mat = np.zeros((n_rows, fine.num_active_functions), dtype=np.float64)
+        for j, (flats, vals) in enumerate(fine_cols):
+            fine_mat[np.searchsorted(touched_arr, flats), j] = vals
+
+        solution, *_ = np.linalg.lstsq(fine_mat, coarse_mat, rcond=None)
+        prolongation: npt.NDArray[np.float64] = np.asarray(solution, dtype=np.float64)
+        residual = float(np.abs(fine_mat @ prolongation - coarse_mat).max())
+        if residual > 1e-8 * (1.0 + float(np.abs(coarse_mat).max())):
+            raise ValueError(
+                f"fine is not a refinement of this space (prolongation residual {residual:.2e})."
+            )
+        return prolongation
 
     def __repr__(self) -> str:
         """Return a compact string representation.

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -718,6 +718,25 @@ class HierarchicalGrid(Grid):
         _, midx = self._decode_flat_id(cid)
         return midx
 
+    def is_active_leaf(self, level: int, midx: Sequence[int]) -> bool:
+        """Return whether ``(level, midx)`` is an active (leaf) cell.
+
+        Args:
+            level (int): Hierarchy level.
+            midx (Sequence[int]): Per-axis index in level-``level`` coordinates.
+
+        Returns:
+            bool: ``True`` iff a cell with this level and multi-index is currently
+            active (a leaf); ``False`` if it is out of range, not yet created, or has
+            been refined away.
+        """
+        if level < 0 or level >= len(self._blocks):
+            return False
+        midx_t = tuple(int(i) for i in midx)
+        if len(midx_t) != self.ndim or any(i < 0 for i in midx_t):
+            return False
+        return self._encode_midx(level, midx_t) is not None
+
     # ------------------------------------------------------------------
     # Active-set accessors
     # ------------------------------------------------------------------

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -598,3 +598,16 @@ class TestActiveSetAccessors:
         assert not g.is_active_leaf(1, (0, 0))  # wrong ndim
         assert not g.is_active_leaf(0, (-1,))  # out of range
         assert not g.is_active_leaf(5, (0,))  # nonexistent level
+
+    def test_is_active_leaf_2d(self) -> None:
+        g = _grid_2d(4, 2)
+        # Refine level-0 cell (0, 0) -> children at level 1 in [0,2)x[0,2)
+        g.refine(0, [0, 0], [1, 1])
+        assert not g.is_active_leaf(0, (0, 0))  # refined away
+        assert g.is_active_leaf(0, (1, 0))  # unrefined level-0 leaf
+        assert g.is_active_leaf(0, (0, 1))  # unrefined level-0 leaf
+        assert g.is_active_leaf(1, (0, 0))  # active level-1 leaf
+        assert g.is_active_leaf(1, (1, 1))  # active level-1 leaf (sibling)
+        assert not g.is_active_leaf(1, (0,))  # wrong ndim (1D tuple on 2D grid)
+        assert not g.is_active_leaf(0, (-1, 0))  # negative index
+        assert not g.is_active_leaf(5, (0, 0))  # nonexistent level

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -588,3 +588,13 @@ class TestActiveSetAccessors:
         expected = np.zeros(16, dtype=bool)
         expected[:8] = True
         np.testing.assert_array_equal(g.subdomain_mask(2), expected)
+
+    def test_is_active_leaf(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 8)
+        assert g.is_active_leaf(0, (2,))  # active level-0 leaf
+        assert not g.is_active_leaf(0, (0,))  # refined away
+        assert g.is_active_leaf(1, (0,))  # active level-1 leaf
+        assert not g.is_active_leaf(1, (0, 0))  # wrong ndim
+        assert not g.is_active_leaf(0, (-1,))  # out of range
+        assert not g.is_active_leaf(5, (0,))  # nonexistent level

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -833,7 +833,11 @@ def _dof_level(thb: THBSplineSpace, dof: int) -> int:
 
 
 def _nonzero_level_span(thb: THBSplineSpace) -> int:
-    """Return the max number of successive levels of nonzero THB functions on any cell."""
+    """Return the max number of successive levels of nonzero THB functions on any cell.
+
+    Uses tabulated values to filter: fully-truncated functions evaluate to exactly
+    zero on cells where they have no truncated support, and correctly don't count.
+    """
     grid = thb.grid
     u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
     worst = 0
@@ -898,15 +902,41 @@ class TestRefine:
         fine = coarse.refine([], admissible_class=None)
         assert fine.grid.num_cells == coarse.grid.num_cells
 
+    def test_ungraded_refines_exactly_marked_multi_cell(self) -> None:
+        # Verifies the is_active_leaf guard: already-coarse cells not in [0, 1] are untouched.
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0, 1], admissible_class=None)
+        assert fine.grid.max_level == 1
+        # Cells 2 and 3 (the unmarked level-0 leaves) must still be at level 0.
+        for unmarked_pt in [0.6, 0.9]:
+            cid = fine.grid.locate([unmarked_pt])
+            assert cid is not None
+            assert fine.grid.cell_level(cid) == 0
+        # Cells 0 and 1 are split: point inside each should be at level 1.
+        for marked_pt in [0.06, 0.18]:
+            cid = fine.grid.locate([marked_pt])
+            assert cid is not None
+            assert fine.grid.cell_level(cid) == 1
+
     def test_refine_out_of_range_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
-        with pytest.raises(IndexError):
+        with pytest.raises(IndexError, match=r"\[0, 4\)"):
             coarse.refine([999])
+
+    def test_refine_negative_id_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(IndexError, match=r"\[0, 4\)"):
+            coarse.refine([-1])
 
     def test_admissible_class_below_two_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="admissible_class"):
             coarse.refine([0], admissible_class=1)
+
+    def test_admissible_class_zero_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="admissible_class"):
+            coarse.refine([0], admissible_class=0)
 
     def test_stale_grid_refine_raises(self) -> None:
         grid = _grid_1d()
@@ -937,13 +967,16 @@ class TestAdmissibility:
         deeper = fine.refine([_locate(fine.grid, [0.05, 0.05])], admissible_class=None)
         assert _nonzero_level_span(deeper) > 2  # grading is what bounds the span
 
-    def test_grading_refines_at_least_as_many(self) -> None:
+    def test_grading_refines_strictly_more(self) -> None:
+        # A level-1 cell has a non-empty neighborhood at level 0 (k_nbr = 1 - 2 + 1 = 0).
+        # Graded refinement must pre-refine those level-0 neighbors, producing strictly
+        # more cells than the ungraded path which only splits the one marked cell.
         coarse = THBSplineSpace(_root_2d(), _grid_2d())
         f_g = coarse.refine([0], admissible_class=2)
         deep_g = f_g.refine([_locate(f_g.grid, [0.05, 0.05])], admissible_class=2)
         f_u = coarse.refine([0], admissible_class=None)
         deep_u = f_u.refine([_locate(f_u.grid, [0.05, 0.05])], admissible_class=None)
-        assert deep_g.grid.num_cells >= deep_u.grid.num_cells
+        assert deep_g.grid.num_cells > deep_u.grid.num_cells
 
 
 class TestProlongation:
@@ -1020,6 +1053,18 @@ class TestProlongation:
         other = THBSplineSpace(_root_2d(), _grid_2d())
         with pytest.raises(ValueError, match="refinement"):
             coarse.prolongation_to(other)
+
+    def test_truncate_mismatch_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())  # truncate=True (default)
+        fine_hb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(ValueError, match="truncate"):
+            coarse.prolongation_to(fine_hb)
+
+    def test_regularity_mismatch_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())  # regularity=None (default)
+        fine_reg0 = THBSplineSpace(_root_1d(), _grid_1d(), regularity=0)
+        with pytest.raises(ValueError, match="regularity"):
+            coarse.prolongation_to(fine_reg0)
 
     def test_non_thb_argument_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -820,3 +820,208 @@ class TestDerivatives:
         a_dx, _ = _collocation_derivatives(hb, 1)
         coef, _, _, _ = np.linalg.lstsq(a_val, pts[:, 0] ** 2, rcond=None)
         assert np.abs(a_dx @ coef - 2.0 * pts[:, 0]).max() < 1e-9
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Refinement / admissibility / prolongation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _dof_level(thb: THBSplineSpace, dof: int) -> int:
+    """Return the hierarchy level owning global dof ``dof``."""
+    return int(np.searchsorted(thb._func_offset, dof, side="right")) - 1
+
+
+def _nonzero_level_span(thb: THBSplineSpace) -> int:
+    """Return the max number of successive levels of nonzero THB functions on any cell."""
+    grid = thb.grid
+    u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
+    worst = 0
+    for cid in range(grid.num_cells):
+        lo, hi = grid.cell_bounds(cid)
+        mesh = np.meshgrid(*[lo[k] + (hi[k] - lo[k]) * u for k in range(thb.dim)], indexing="ij")
+        pts = np.stack([m.ravel() for m in mesh], axis=-1)
+        active = thb.active_basis(cid)
+        vals = thb.tabulate_basis(cid, pts)
+        nonzero = active[np.abs(vals).max(axis=0) > 1e-12]
+        if nonzero.size == 0:
+            continue
+        levels = [_dof_level(thb, int(d)) for d in nonzero]
+        worst = max(worst, max(levels) - min(levels) + 1)
+    return worst
+
+
+def _field_at(
+    thb: THBSplineSpace, coeffs: npt.NDArray[np.float64], cid: int, pts: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    """Evaluate the field ``sum coeffs[i] Phi_i`` at ``pts`` on cell ``cid``."""
+    active = thb.active_basis(cid)
+    result: npt.NDArray[np.float64] = thb.tabulate_basis(cid, pts) @ coeffs[active]
+    return result
+
+
+def _locate(grid: HierarchicalGrid, point: list[float]) -> int:
+    """Locate the active cell containing ``point`` (asserting it exists)."""
+    cid = grid.locate(point)
+    assert cid is not None
+    return cid
+
+
+class TestRefine:
+    """THBSplineSpace.refine returns a new, refined, non-mutating space."""
+
+    def test_returns_new_space_original_unchanged(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        n_cells, n_active = coarse.grid.num_cells, coarse.num_active_functions
+        fine = coarse.refine([0, 1], admissible_class=None)
+        assert fine is not coarse
+        assert coarse.grid.num_cells == n_cells
+        assert coarse.num_active_functions == n_active
+        assert fine.grid.num_cells > n_cells
+
+    def test_refine_preserves_partition_of_unity(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0])
+        mat, _ = _collocation(fine)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_basic_refines_exactly_marked(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0], admissible_class=None)
+        assert fine.grid.max_level == 1
+        child = fine.grid.locate([0.06])  # inside marked cell 0 = [0, 0.25]
+        assert child is not None
+        assert fine.grid.cell_level(child) == 1
+
+    def test_refine_empty_copies_grid(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([], admissible_class=None)
+        assert fine.grid.num_cells == coarse.grid.num_cells
+
+    def test_refine_out_of_range_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(IndexError):
+            coarse.refine([999])
+
+    def test_admissible_class_below_two_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="admissible_class"):
+            coarse.refine([0], admissible_class=1)
+
+    def test_stale_grid_refine_raises(self) -> None:
+        grid = _grid_1d()
+        coarse = THBSplineSpace(_root_1d(), grid)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            coarse.refine([0])
+
+
+class TestAdmissibility:
+    """Graded refinement maintains class-m admissibility (Carraturo et al. 2019)."""
+
+    def test_graded_class_two_2d(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0], admissible_class=2)
+        deeper = fine.refine([_locate(fine.grid, [0.05, 0.05])], admissible_class=2)
+        assert _nonzero_level_span(deeper) <= 2
+
+    def test_graded_class_two_1d(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0], admissible_class=2)
+        deeper = fine.refine([_locate(fine.grid, [0.03])], admissible_class=2)
+        assert _nonzero_level_span(deeper) <= 2
+
+    def test_ungraded_can_violate_class_two(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0], admissible_class=None)
+        deeper = fine.refine([_locate(fine.grid, [0.05, 0.05])], admissible_class=None)
+        assert _nonzero_level_span(deeper) > 2  # grading is what bounds the span
+
+    def test_grading_refines_at_least_as_many(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        f_g = coarse.refine([0], admissible_class=2)
+        deep_g = f_g.refine([_locate(f_g.grid, [0.05, 0.05])], admissible_class=2)
+        f_u = coarse.refine([0], admissible_class=None)
+        deep_u = f_u.refine([_locate(f_u.grid, [0.05, 0.05])], admissible_class=None)
+        assert deep_g.grid.num_cells >= deep_u.grid.num_cells
+
+
+class TestProlongation:
+    """The coarse->fine prolongation transfers a coefficient field exactly."""
+
+    def _check_reproduction(
+        self, coarse: THBSplineSpace, fine: THBSplineSpace, rng: np.random.Generator
+    ) -> None:
+        p = coarse.prolongation_to(fine)
+        assert p.shape == (fine.num_active_functions, coarse.num_active_functions)
+        u_coarse = rng.random(coarse.num_active_functions)
+        u_fine = p @ u_coarse
+        u_axis = np.linspace(0.1, 0.9, 3)
+        err = 0.0
+        for cid in range(fine.grid.num_cells):
+            lo, hi = fine.grid.cell_bounds(cid)
+            mesh = np.meshgrid(
+                *[lo[k] + (hi[k] - lo[k]) * u_axis for k in range(fine.dim)], indexing="ij"
+            )
+            pts = np.stack([m.ravel() for m in mesh], axis=-1)
+            f_fine = _field_at(fine, u_fine, cid, pts)
+            coarse_cid = coarse.grid.locate(pts[0])
+            assert coarse_cid is not None
+            f_coarse = _field_at(coarse, u_coarse, coarse_cid, pts)
+            err = max(err, float(np.abs(f_fine - f_coarse).max()))
+        assert err < 1e-9
+
+    def test_reproduction_1d_thb(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0, 1])
+        self._check_reproduction(coarse, fine, np.random.default_rng(0))
+
+    def test_reproduction_2d_thb(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0])
+        self._check_reproduction(coarse, fine, np.random.default_rng(1))
+
+    def test_reproduction_hb(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        fine = coarse.refine([0, 1], admissible_class=None)
+        self._check_reproduction(coarse, fine, np.random.default_rng(2))
+
+    def test_reproduction_multi_level(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        f1 = coarse.refine([0], admissible_class=None)
+        f2 = f1.refine([_locate(f1.grid, [0.05, 0.05])], admissible_class=None)
+        assert f2.num_levels >= 3
+        self._check_reproduction(coarse, f2, np.random.default_rng(3))
+
+    def test_identity_when_no_refinement(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        p = coarse.prolongation_to(coarse)
+        np.testing.assert_allclose(p, np.eye(coarse.num_active_functions), atol=1e-10)
+
+    def test_columns_reproduce_basis_functions(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0])
+        p = coarse.prolongation_to(fine)
+        unit = np.zeros(coarse.num_active_functions)
+        unit[2] = 1.0  # a single coarse basis function
+        col = p[:, 2]
+        for cid in range(fine.grid.num_cells):
+            lo, hi = fine.grid.cell_bounds(cid)
+            mid = (0.5 * (lo + hi)).reshape(1, 1)
+            coarse_cid = coarse.grid.locate(mid[0])
+            assert coarse_cid is not None
+            assert (
+                abs(_field_at(fine, col, cid, mid)[0] - _field_at(coarse, unit, coarse_cid, mid)[0])
+                < 1e-9
+            )
+
+    def test_non_refinement_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        other = THBSplineSpace(_root_2d(), _grid_2d())
+        with pytest.raises(ValueError, match="refinement"):
+            coarse.prolongation_to(other)
+
+    def test_non_thb_argument_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(TypeError, match="THBSplineSpace"):
+            coarse.prolongation_to(_grid_1d())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

PR4 of the THB-spline feature (#164): **adaptive refinement** with admissible grading, plus the **prolongation operator**. Builds on PR1–3 (values, truncation, derivatives).

### `THBSplineSpace.refine(cell_ids, *, admissible_class=2) -> THBSplineSpace`
Non-mutating: deep-copies the grid, refines the marked active cells, and rebuilds the space (same `root_space`, `truncate`, `regularity`). The original space and its grid are untouched.
- `admissible_class=m` (default **2**): graded so the resulting mesh is **admissible of class m** — the truncated functions acting on any cell span at most `m` successive levels — via the recursive refinement-neighborhood algorithm of **Carraturo–Giannelli–Reali–Vázquez (2019)** (Defs 3.3–3.4, Alg 4; the GeoPDEs algorithm). Assumes the input mesh is already class-m admissible (true for the root and any graded-`refine` result).
- `admissible_class=None`: refines exactly the marked cells (no grading).

### `THBSplineSpace.prolongation_to(fine) -> ndarray` (shape `(fine_dofs, coarse_dofs)`)
Transfers a coefficient field from this space to a refinement: `P @ u_coarse` are the fine coefficients of the **same function** (exact, since `V_h ⊆ V_h'`). Built by expressing every coarse and fine basis function in the common finest tensor-product basis and solving the consistent least-squares systems; the residual is asserted tiny (guards against a non-refinement argument).

### `pantr.grid`
Adds public `HierarchicalGrid.is_active_leaf(level, midx)` — the predicate the refinement driver needs to query/grade the active set in level/multi-index coordinates (stable across flat-id reassignment).

### Notes
- T-admissible (the GeoPDEs neighborhood); `m >= 2` (the `m=1` extension `S(Q, ℓ+1)` is undefined). H-admissible variant deferred.
- The prolongation's dense finest-TP assembly is correctness-first (one-time per refinement); a sparse/recursive build is a future optimization.

## Test plan
- [x] `TestRefine`: non-mutating new space; refined-space partition of unity; basic refine hits exactly the marked cells; validation (out-of-range id, `admissible_class<2`, stale grid).
- [x] `TestAdmissibility`: graded `m=2` keeps the nonzero-function level span ≤ 2 (1D & 2D); ungraded refinement reaches span 3; graded refines ≥ as many cells.
- [x] `TestProlongation`: reproduces random fields to ~1e-15 (1D/2D, HB & THB, multi-level); identity with no refinement; columns reproduce coarse basis functions; non-refinement / non-THB args raise.
- [x] Full suite: `pytest --no-cov` — **2934 passed**. `ruff` / `ruff format` / `mypy` clean; docs build clean (`make docs -W`).

Tracking: #164 · builds on #165, #166, #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
