### PR TITLE
feat(bspline): THBSplineSpace coarsening + restriction (PR5 of #164)

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1131,8 +1131,10 @@ class THBSplineSpace:
 
         A parent cell is reactivated (its children removed) only when **all** of its
         children are marked active leaves, mirroring the coarsening algorithm of
-        Carraturo et al. (2019, Alg. 5).  This is the inverse of :meth:`refine`:
-        ``space.refine(cells).coarsen(children_of(cells))`` recovers ``space``.
+        Carraturo et al. (2019, Alg. 5).  With ``admissible_class=None`` this is the
+        exact inverse of :meth:`refine`: ``space.refine(cells).coarsen(children_of(cells))``
+        recovers ``space``.  With ``admissible_class=m`` the guard may suppress some
+        coarsenings, so the recovery holds only when the guard permits them all.
 
         With ``admissible_class=m`` (the default ``m=2``) a parent is reactivated only
         if its coarsening neighborhood (Def. 3.5) is empty, so the resulting mesh stays
@@ -1140,9 +1142,11 @@ class THBSplineSpace:
 
         The space is immutable: a fresh grid is coarsened and a new
         :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
+        An empty ``cell_ids`` is valid and returns an unchanged copy of the space.
 
         Args:
             cell_ids (npt.ArrayLike): Flat ids of active leaf cells to coarsen away.
+                An empty array is valid and produces an unchanged copy.
             admissible_class (int | None): Admissibility class ``m >= 2`` to maintain,
                 or ``None`` to skip the admissibility guard.  Defaults to ``2``.
 
@@ -1161,9 +1165,10 @@ class THBSplineSpace:
                 f"admissible_class must be an integer >= 2 or None; got {admissible_class!r}."
             )
         ids = np.unique(np.asarray(cell_ids, dtype=np.int64).ravel())
-        if ids.size and (int(ids[0]) < 0 or int(ids[-1]) >= self._grid.num_cells):
+        bad = [int(x) for x in ids if int(x) < 0 or int(x) >= self._grid.num_cells]
+        if bad:
             raise IndexError(
-                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id."
+                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id(s): {bad}."
             )
         dim = self.dim
         factor = self._grid.factor
@@ -1218,6 +1223,11 @@ class THBSplineSpace:
         Returns:
             bool: ``True`` iff no active cell at level ``parent_level + m`` lies in the
             support extension of the parent's children.
+
+        Note:
+            Assumes ``parent_level + 1 < self.num_levels`` and ``m >= 2``; both are
+            guaranteed by the calling context in :meth:`coarsen`.  No input validation
+            is performed.
         """
         dim = self.dim
         factor = self._grid.factor
@@ -1406,6 +1416,8 @@ class THBSplineSpace:
             TypeError: If ``coarse`` is not a :class:`THBSplineSpace`.
             ValueError: If ``self`` is not a refinement of ``coarse``.
         """
+        if not isinstance(coarse, THBSplineSpace):
+            raise TypeError(f"coarse must be a THBSplineSpace; got {type(coarse)!r}.")
         prolongation = coarse.prolongation_to(self)
         restriction: npt.NDArray[np.float64] = np.asarray(
             np.linalg.pinv(prolongation), dtype=np.float64

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1121,6 +1121,127 @@ class THBSplineSpace:
             (k_nbr, p) for p in itertools.product(*parent_ranges) if grid.is_active_leaf(k_nbr, p)
         ]
 
+    def coarsen(
+        self,
+        cell_ids: npt.ArrayLike,
+        *,
+        admissible_class: int | None = 2,
+    ) -> THBSplineSpace:
+        """Return a new space with the marked cells coarsened away.
+
+        A parent cell is reactivated (its children removed) only when **all** of its
+        children are marked active leaves, mirroring the coarsening algorithm of
+        Carraturo et al. (2019, Alg. 5).  This is the inverse of :meth:`refine`:
+        ``space.refine(cells).coarsen(children_of(cells))`` recovers ``space``.
+
+        With ``admissible_class=m`` (the default ``m=2``) a parent is reactivated only
+        if its coarsening neighborhood (Def. 3.5) is empty, so the resulting mesh stays
+        admissible of class ``m``.  With ``admissible_class=None`` that guard is skipped.
+
+        The space is immutable: a fresh grid is coarsened and a new
+        :class:`THBSplineSpace` is built; ``self`` and its grid are unchanged.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat ids of active leaf cells to coarsen away.
+            admissible_class (int | None): Admissibility class ``m >= 2`` to maintain,
+                or ``None`` to skip the admissibility guard.  Defaults to ``2``.
+
+        Returns:
+            THBSplineSpace: A new space on the coarsened grid (same ``root_space``,
+            ``truncate``, and ``regularity``).
+
+        Raises:
+            IndexError: If any id is outside ``[0, grid.num_cells)``.
+            ValueError: If ``admissible_class`` is an integer ``< 2``.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        self._check_not_stale()
+        if admissible_class is not None and admissible_class < 2:  # noqa: PLR2004
+            raise ValueError(
+                f"admissible_class must be an integer >= 2 or None; got {admissible_class!r}."
+            )
+        ids = np.unique(np.asarray(cell_ids, dtype=np.int64).ravel())
+        if ids.size and (int(ids[0]) < 0 or int(ids[-1]) >= self._grid.num_cells):
+            raise IndexError(
+                f"cell_ids must lie in [0, {self._grid.num_cells}); got out-of-range id."
+            )
+        dim = self.dim
+        factor = self._grid.factor
+        marked = {(self._grid.cell_level(int(c)), self._grid.cell_multi_index(int(c))) for c in ids}
+        parents = {
+            (level - 1, tuple(midx[d] // factor[d] for d in range(dim)))
+            for level, midx in marked
+            if level >= 1
+        }
+        grid_copy = copy.deepcopy(self._grid)
+        for parent_level, pmidx in sorted(parents, key=lambda pc: -pc[0]):
+            children = [
+                tuple(pmidx[d] * factor[d] + off[d] for d in range(dim))
+                for off in itertools.product(*(range(factor[d]) for d in range(dim)))
+            ]
+            if not all(grid_copy.is_active_leaf(parent_level + 1, c) for c in children):
+                continue
+            if not all((parent_level + 1, c) in marked for c in children):
+                continue
+            if admissible_class is not None and not self._coarsening_neighborhood_empty(
+                parent_level, pmidx, admissible_class, grid_copy
+            ):
+                continue
+            grid_copy.coarsen(parent_level, list(pmidx), [p + 1 for p in pmidx])
+        return THBSplineSpace(
+            self._root_space,
+            grid_copy,
+            truncate=self._truncate,
+            regularity=self._regularity,
+        )
+
+    def _coarsening_neighborhood_empty(
+        self,
+        parent_level: int,
+        pmidx: tuple[int, ...],
+        m: int,
+        grid: HierarchicalGrid,
+    ) -> bool:
+        """Return whether the coarsening neighborhood of a parent is empty (Def. 3.5).
+
+        The neighborhood is the set of active cells at level ``parent_level + m``
+        contained in the multilevel support extension (at level ``parent_level + 1``)
+        of the parent's children.  When it is empty, reactivating the parent preserves
+        class-``m`` admissibility (Carraturo et al. 2019).
+
+        Args:
+            parent_level (int): Level of the parent being considered for coarsening.
+            pmidx (tuple[int, ...]): Per-axis index of the parent at ``parent_level``.
+            m (int): Admissibility class (``>= 2``).
+            grid (HierarchicalGrid): The grid copy whose active set is queried.
+
+        Returns:
+            bool: ``True`` iff no active cell at level ``parent_level + m`` lies in the
+            support extension of the parent's children.
+        """
+        dim = self.dim
+        factor = self._grid.factor
+        support = self._support[parent_level + 1]
+        ext_lo: list[int] = []
+        ext_hi: list[int] = []
+        for d in range(dim):
+            first_basis, first_cell, last_cell = support[d]
+            c_lo = pmidx[d] * factor[d]
+            c_hi = (pmidx[d] + 1) * factor[d]
+            fmin = int(first_basis[c_lo])
+            fmax = int(first_basis[c_hi - 1]) + self.degrees[d]
+            ext_lo.append(int(first_cell[fmin]))
+            ext_hi.append(int(last_cell[fmax]) + 1)
+        target = parent_level + m
+        if target > grid.max_level:
+            return True
+        box_lo = [ext_lo[d] * factor[d] ** (m - 1) for d in range(dim)]
+        box_hi = [ext_hi[d] * factor[d] ** (m - 1) for d in range(dim)]
+        for blk_lo, blk_hi in grid.active_blocks(target):
+            if all(max(box_lo[d], blk_lo[d]) < min(box_hi[d], blk_hi[d]) for d in range(dim)):
+                return False
+        return True
+
     # ------------------------------------------------------------------
     # Prolongation
     # ------------------------------------------------------------------
@@ -1212,7 +1333,7 @@ class THBSplineSpace:
             mismatches.append(
                 f"fine.num_levels={fine.num_levels} < self.num_levels={self.num_levels}"
             )
-        if not all(
+        if fine.dim == self.dim and not all(
             np.array_equal(fine._root_space.spaces[k].knots, self._root_space.spaces[k].knots)
             for k in range(self.dim)
         ):
@@ -1262,6 +1383,34 @@ class THBSplineSpace:
                 f"fine is not a refinement of this space (prolongation residual {residual:.2e})."
             )
         return prolongation
+
+    def restriction_to(self, coarse: THBSplineSpace) -> npt.NDArray[np.float64]:
+        """Return the restriction matrix from this space to a coarsening ``coarse``.
+
+        ``self`` must be a refinement of ``coarse``.  The restriction is the algebraic
+        pseudo-inverse of the prolongation, ``R = pinv(P)`` with
+        ``P = coarse.prolongation_to(self)``.  It is assembly-free (no mass matrix) and
+        satisfies ``R @ P == I``, so restricting a prolonged coarse field recovers it
+        exactly; for a general fine field ``R @ u_fine`` is the least-squares
+        (coefficient-space) projection onto the coarse space.
+
+        Args:
+            coarse (THBSplineSpace): A coarsening of this space (``self`` is a
+                refinement of ``coarse``).
+
+        Returns:
+            npt.NDArray[np.float64]: Matrix ``R`` of shape
+            ``(coarse.num_active_functions, self.num_active_functions)``.
+
+        Raises:
+            TypeError: If ``coarse`` is not a :class:`THBSplineSpace`.
+            ValueError: If ``self`` is not a refinement of ``coarse``.
+        """
+        prolongation = coarse.prolongation_to(self)
+        restriction: npt.NDArray[np.float64] = np.asarray(
+            np.linalg.pinv(prolongation), dtype=np.float64
+        )
+        return restriction
 
     def __repr__(self) -> str:
         """Return a compact string representation.

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -953,6 +953,83 @@ class HierarchicalGrid(Grid):
         for lv in sorted(level_lo):
             self.refine(lv, level_lo[lv], level_hi[lv])
 
+    def coarsen(
+        self,
+        level: int,
+        lo: Sequence[int],
+        hi: Sequence[int],
+    ) -> None:
+        """Coarsen the rectangular region ``[lo, hi)`` at ``level`` (inverse of refine).
+
+        Reactivates the level-``level`` cells in ``[lo, hi)`` and removes their
+        level-``(level+1)`` children.  The region must be **fully refined to exactly
+        level ``level+1``**: every child cell in ``[lo*factor, hi*factor)`` must be an
+        active leaf at ``level+1`` (none further refined, none still a leaf at
+        ``level``).  Calling :meth:`coarsen` with the same arguments as a preceding
+        :meth:`refine` exactly restores the grid.
+
+        After the call all flat cell ids are **reassigned** (the BVH, cell tags, and
+        facet tags are invalidated).
+
+        Args:
+            level (int): Level whose cells are reactivated.  Must satisfy
+                ``0 <= level < max_level``.
+            lo (Sequence[int]): Per-direction start index (inclusive), in level-``level``
+                coordinates.
+            hi (Sequence[int]): Per-direction end index (exclusive), in level-``level``
+                coordinates.
+
+        Raises:
+            ValueError: If ``level`` is out of range, ``lo``/``hi`` have the wrong
+                length, any ``lo[k] >= hi[k]``, ``[lo, hi)`` is out of bounds, or the
+                region is not fully refined to exactly level ``level+1``.
+        """
+        ndim = self.ndim
+        if not (0 <= int(level) < self.max_level):
+            raise ValueError(f"level must be in [0, {self.max_level}); got {level!r}.")
+        lo_t = tuple(int(x) for x in lo)
+        hi_t = tuple(int(x) for x in hi)
+        if len(lo_t) != ndim or len(hi_t) != ndim:
+            raise ValueError(f"lo and hi must have length {ndim}; got {len(lo_t)} and {len(hi_t)}.")
+        if any(lo_k >= h for lo_k, h in zip(lo_t, hi_t, strict=False)):
+            raise ValueError(
+                f"lo must be strictly less than hi in every dimension; "
+                f"got lo={lo_t!r}, hi={hi_t!r}."
+            )
+        for k in range(ndim):
+            n_k = self._n_cells_at_level_k(level, k)
+            if lo_t[k] < 0 or hi_t[k] > n_k:
+                raise ValueError(
+                    f"[lo, hi) out of bounds at level {level}: "
+                    f"axis {k} needs [0, {n_k}), got [{lo_t[k]}, {hi_t[k]})."
+                )
+
+        child_lo = tuple(lo_t[k] * self._factor[k] for k in range(ndim))
+        child_hi = tuple(hi_t[k] * self._factor[k] for k in range(ndim))
+        child_size = _block_size(child_lo, child_hi)
+
+        # The children region must be fully tiled by active leaves at level+1.
+        covered = 0
+        new_finer: list[_Block] = []
+        for block_lo, block_hi in self._blocks[level + 1]:
+            inter = _rect_intersect(block_lo, block_hi, child_lo, child_hi)
+            if inter is None:
+                new_finer.append((block_lo, block_hi))
+                continue
+            covered += _block_size(*inter)
+            new_finer.extend(_peel(block_lo, block_hi, *inter))
+        if covered != child_size:
+            raise ValueError(
+                f"cannot coarsen [{lo_t}, {hi_t}) at level {level}: the region is not "
+                f"fully refined to exactly level {level + 1}."
+            )
+
+        self._blocks[level + 1] = _normalize_blocks(new_finer)
+        self._blocks[level] = _normalize_blocks([*self._blocks[level], (lo_t, hi_t)])
+        while len(self._blocks) > 1 and not self._blocks[-1]:
+            self._blocks.pop()
+        self._rebuild()
+
     # ------------------------------------------------------------------
     # Overrides for BVH efficiency
     # ------------------------------------------------------------------

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -611,3 +611,58 @@ class TestActiveSetAccessors:
         assert not g.is_active_leaf(1, (0,))  # wrong ndim (1D tuple on 2D grid)
         assert not g.is_active_leaf(0, (-1, 0))  # negative index
         assert not g.is_active_leaf(5, (0, 0))  # nonexistent level
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coarsening
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _grid_snapshot(g: HierarchicalGrid) -> tuple[object, ...]:
+    """Capture the full structural state of a hierarchical grid."""
+    return (g.num_cells, g.max_level, tuple(g.active_blocks(lv) for lv in range(g.max_level + 1)))
+
+
+class TestHierarchicalGridCoarsen:
+    """Tests for the coarsen method (inverse of refine)."""
+
+    def test_coarsen_inverts_refine_1d(self) -> None:
+        g = _grid_1d(4, 2)
+        before = _grid_snapshot(g)
+        g.refine(0, [1], [3])
+        g.coarsen(0, [1], [3])
+        assert _grid_snapshot(g) == before
+
+    def test_coarsen_inverts_refine_2d(self) -> None:
+        g = _grid_2d(4, 2)
+        before = _grid_snapshot(g)
+        g.refine(0, [1, 1], [3, 3])
+        g.coarsen(0, [1, 1], [3, 3])
+        assert _grid_snapshot(g) == before
+
+    def test_coarsen_drops_trailing_level(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [4])
+        assert g.max_level == 1
+        g.coarsen(0, [0], [4])
+        assert g.max_level == 0
+        assert g.num_cells == 4
+
+    def test_coarsen_one_of_two_levels(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        snap_one = _grid_snapshot(g)
+        g.refine(1, [0], [4])  # refine all level-1 cells to level 2
+        g.coarsen(1, [0], [4])  # undo just the level-1 refinement
+        assert _grid_snapshot(g) == snap_one
+
+    def test_coarsen_partial_region_raises(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [1])  # only cell 0 refined
+        with pytest.raises(ValueError, match="fully refined"):
+            g.coarsen(0, [0], [2])  # cell 1 has no children
+
+    def test_coarsen_level_out_of_range_raises(self) -> None:
+        g = _grid_1d(4, 2)  # max_level 0, no level 1 to coarsen from
+        with pytest.raises(ValueError, match="level"):
+            g.coarsen(0, [0], [1])

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -666,3 +666,21 @@ class TestHierarchicalGridCoarsen:
         g = _grid_1d(4, 2)  # max_level 0, no level 1 to coarsen from
         with pytest.raises(ValueError, match="level"):
             g.coarsen(0, [0], [1])
+
+    def test_coarsen_lo_ge_hi_raises(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [4])
+        with pytest.raises(ValueError, match="strictly less"):
+            g.coarsen(0, [2], [2])
+
+    def test_coarsen_out_of_bounds_raises(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [4])
+        with pytest.raises(ValueError, match="out of bounds"):
+            g.coarsen(0, [0], [5])  # hi=5 > 4 cells at level 0
+
+    def test_coarsen_wrong_ndim_raises(self) -> None:
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [4])
+        with pytest.raises(ValueError, match="length"):
+            g.coarsen(0, [0, 0], [4, 4])  # 1D grid, 2D lo/hi

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1070,3 +1070,111 @@ class TestProlongation:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(TypeError, match="THBSplineSpace"):
             coarse.prolongation_to(_grid_1d())  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coarsening / restriction
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _cells_at_level(thb: THBSplineSpace, level: int) -> list[int]:
+    """Return the flat ids of active cells at ``level``."""
+    return [c for c in range(thb.grid.num_cells) if thb.grid.cell_level(c) == level]
+
+
+def _active_indices(thb: THBSplineSpace) -> tuple[tuple[int, ...], ...]:
+    """Return the per-level active function indices as nested tuples."""
+    return tuple(tuple(thb.active_function_indices(lv).tolist()) for lv in range(thb.num_levels))
+
+
+class TestCoarsen:
+    """THBSplineSpace.coarsen reverses refinement and grades for admissibility."""
+
+    def test_coarsen_inverts_refine_1d(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0, 1])
+        back = fine.coarsen(_cells_at_level(fine, 1))
+        assert _active_indices(back) == _active_indices(coarse)
+
+    def test_coarsen_inverts_refine_2d(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0], admissible_class=None)
+        back = fine.coarsen(_cells_at_level(fine, 1), admissible_class=None)
+        assert _active_indices(back) == _active_indices(coarse)
+
+    def test_coarsen_partition_of_unity(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0])
+        back = fine.coarsen(_cells_at_level(fine, 1))
+        mat, _ = _collocation(back)
+        np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
+
+    def test_partial_children_not_coarsened(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine = coarse.refine([0])  # cell 0 -> children at level 1
+        children = _cells_at_level(fine, 1)
+        back = fine.coarsen([children[0]])  # only one of the two children marked
+        assert back.num_active_functions == fine.num_active_functions  # no-op
+
+    def test_root_cells_not_coarsened(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        back = coarse.coarsen([0])  # level-0 cell has no parent
+        assert back.num_active_functions == coarse.num_active_functions
+
+    def test_coarsen_out_of_range_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(IndexError):
+            coarse.coarsen([999])
+
+    def test_coarsen_admissible_class_below_two_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="admissible_class"):
+            coarse.coarsen([0], admissible_class=1)
+
+    def test_admissibility_blocks_unsafe_coarsening(self) -> None:
+        # Build a 3-level 1D mesh: refine [0, 0.5) to level 1, then [0, 0.25) to level 2.
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        f1 = coarse.refine([0, 1], admissible_class=None)  # level-1 over [0, 0.5)
+        deep = f1.refine(
+            _cells_at_level(f1, 1)[:2], admissible_class=None
+        )  # level-2 over [0, 0.25)
+        assert deep.num_levels == 3
+        # Coarsening the level-1 leaves back to level 0 would make a level-0 function
+        # span levels 0..2 (class 3); the class-2 guard must refuse what ungraded allows.
+        marked = _cells_at_level(deep, 1)
+        graded = deep.coarsen(marked, admissible_class=2)
+        ungraded = deep.coarsen(marked, admissible_class=None)
+        assert _nonzero_level_span(graded) <= 2
+        assert graded.num_active_functions != ungraded.num_active_functions
+
+
+class TestRestriction:
+    """The fine->coarse restriction is the pseudo-inverse of the prolongation."""
+
+    def _check(self, coarse: THBSplineSpace, fine: THBSplineSpace) -> None:
+        prolong = coarse.prolongation_to(fine)
+        restrict = fine.restriction_to(coarse)
+        assert restrict.shape == (coarse.num_active_functions, fine.num_active_functions)
+        np.testing.assert_allclose(
+            restrict @ prolong, np.eye(coarse.num_active_functions), atol=1e-9
+        )
+        u_coarse = np.random.default_rng(0).random(coarse.num_active_functions)
+        np.testing.assert_allclose(restrict @ (prolong @ u_coarse), u_coarse, atol=1e-9)
+
+    def test_restriction_1d_thb(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        self._check(coarse, coarse.refine([0, 1]))
+
+    def test_restriction_2d_thb(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        self._check(coarse, coarse.refine([0]))
+
+    def test_restriction_hb(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        self._check(coarse, coarse.refine([0, 1], admissible_class=None))
+
+    def test_restriction_non_refinement_raises(self) -> None:
+        fine = THBSplineSpace(_root_1d(), _grid_1d())
+        other = THBSplineSpace(_root_2d(), _grid_2d())
+        with pytest.raises(ValueError, match="refinement"):
+            fine.restriction_to(other)

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1054,6 +1054,13 @@ class TestProlongation:
         with pytest.raises(ValueError, match="refinement"):
             coarse.prolongation_to(other)
 
+    def test_dim_mismatch_raises(self) -> None:
+        # self.dim=2 > fine.dim=1: old code raised IndexError; now raises ValueError
+        coarse_2d = THBSplineSpace(_root_2d(), _grid_2d())
+        fine_1d = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError):
+            coarse_2d.prolongation_to(fine_1d)
+
     def test_truncate_mismatch_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())  # truncate=True (default)
         fine_hb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)


### PR DESCRIPTION
## Summary

PR5 of the THB-spline feature (#164): **adaptive coarsening** (the inverse of PR4's refinement) with admissible grading, plus the fine→coarse **restriction** operator.

### `pantr.grid`
- **`HierarchicalGrid.coarsen(level, lo, hi)`** — un-refines a rectangular region: reactivates the level-`level` cells in `[lo, hi)` and removes their level-`(level+1)` children (requiring the region to be fully refined to exactly `level+1`). Exact inverse of `refine` — `refine(level, lo, hi)` then `coarsen(level, lo, hi)` restores the grid — and drops trailing empty levels. Reuses the existing block helpers.

### `pantr.bspline`
- **`THBSplineSpace.coarsen(cell_ids, *, admissible_class=2) -> THBSplineSpace`** — non-mutating; mark active leaf cells, reactivate a parent only when **all** its children are marked (**Carraturo–Giannelli–Reali–Vázquez 2019, Alg. 5**). With `admissible_class=m`, a parent is reactivated only if its **coarsening neighborhood is empty** (Def. 3.5), keeping the mesh admissible of class `m`; `None` skips the guard.
- **`THBSplineSpace.restriction_to(coarse) -> ndarray`** `(coarse_dofs, fine_dofs)` — the **algebraic pseudo-inverse** of the prolongation, `R = pinv(coarse.prolongation_to(self))`. Assembly-free (no mass matrix — respects #152 Q0; L2 projection stays a PR8 test-only helper) and satisfies `R @ P == I`.
- Small fix to `prolongation_to`: guard the root-knot comparison on matching `dim` so a lower-dimensional argument raises a clean `ValueError` instead of `IndexError` (surfaced by the restriction tests).

## Test plan
- [x] Grid `coarsen`: exact inverse of `refine` (1D/2D, multi-level); drops trailing level; partial-region and out-of-range raise.
- [x] THB `coarsen`: `refine` then `coarsen` restores the space (active functions match); partition of unity preserved; partial-child and root-cell marks are no-ops; the **class-2 guard refuses an unsafe coarsening** that the ungraded pass performs (`_nonzero_level_span <= 2`).
- [x] `restriction_to`: `R @ P == I` and prolong→restrict round-trips to ~1e-15 (1D/2D, HB & THB); shape; non-refinement argument raises.
- [x] Full suite: `pytest --no-cov` — **2959 passed**. `ruff` / `ruff format` / `mypy` clean; docs build clean (`make docs -W`).

Tracking: #164 · builds on #165, #166, #167, #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
