### PR TITLE
feat(bspline): multi-level Bézier extraction for THBSplineSpace (PR6 of #164)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -20,6 +20,8 @@ This package consolidates the B-spline API:
   downstream ``@njit`` code.
 - :class:`THBSplineSpace`: hierarchical B-spline space (truncated /
   non-truncated) on a :class:`pantr.grid.HierarchicalGrid`.
+- :class:`MultiLevelExtraction`: per-element multi-level (Bézier) extraction
+  operators for a :class:`THBSplineSpace`.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -35,6 +37,7 @@ from ._bspline_space_factory import (
 )
 from ._bspline_space_nd import BsplineSpace
 from ._thb_spline_space import THBSplineSpace
+from .multilevel_extraction import MultiLevelExtraction
 from .spanwise_element_extraction import (
     ExtractionStructView,
     SpanwiseElementExtraction,
@@ -46,6 +49,7 @@ __all__ = [
     "BsplineSpace",
     "BsplineSpace1D",
     "ExtractionStructView",
+    "MultiLevelExtraction",
     "SpanwiseElementExtraction",
     "THBSplineSpace",
     "create_cardinal_knots",

--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -1,0 +1,370 @@
+r"""Multi-level Bézier extraction for truncated hierarchical B-spline spaces.
+
+This module provides :class:`MultiLevelExtraction`, the hierarchical counterpart of
+:class:`~pantr.bspline.SpanwiseElementExtraction`.  It exposes, per active cell, the
+*multi-level extraction operator* and the *multi-level Bézier extraction operator* of
+D'Angella et al. (2017) / D'Angella (2021, ch. 4), which flatten the (truncated)
+hierarchical basis on an element into a fixed single-level reference basis.
+
+On an active cell :math:`\epsilon` of level ``L`` the active hierarchical functions
+:math:`H^\epsilon` are a linear combination of the level-``L`` tensor-product B-splines
+:math:`N^{\epsilon,L}` with support on :math:`\epsilon` (the *multi-level extraction
+operator* :math:`M^\epsilon`), and composing with the standard per-element Bézier
+extraction :math:`E^\epsilon` gives the *multi-level Bézier extraction* :math:`C^\epsilon`:
+
+.. math::
+    H^\epsilon = M^\epsilon N^{\epsilon,L} = M^\epsilon E^\epsilon B = C^\epsilon B,
+
+mapping a fixed Bernstein reference basis ``B`` (on :math:`[0, 1]^d`) to the active
+hierarchical functions on the cell.
+
+Note:
+    :math:`M^\epsilon` is built from the space's already-truncated coefficients (the
+    Giannelli-Jüttler-Speleers truncation, which keeps and refines forward the passive
+    functions that straddle a refinement boundary), so it is correct on narrow refinement
+    bands.  It does **not** use the activeness-restricted local truncation of
+    D'Angella et al. (2017, §3.6.1), which drops such functions; see Eq. 4.7 of the 2021
+    thesis for the corrected predicate.
+
+Main exports:
+
+- :class:`MultiLevelExtraction`: per-element multi-level (Bézier) extraction operators.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, get_args
+
+import numpy as np
+
+from ._thb_spline_space import THBSplineSpace
+from .spanwise_element_extraction import SpanwiseElementExtraction, Target
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class MultiLevelExtraction:
+    r"""Per-element multi-level (Bézier) extraction for a :class:`THBSplineSpace`.
+
+    Mirrors :class:`~pantr.bspline.SpanwiseElementExtraction`: it is constructed from a
+    space and a ``target`` reference basis, caches the single-level per-level extractions,
+    and exposes per-element operators via :meth:`operator`.  Because hierarchical
+    refinement introduces a non-constant number of active functions per cell (and the
+    hierarchical basis is not of tensor-product structure), the operators are ragged
+    across cells; there is consequently no constant-shape ``tabulate`` / ``ops_1d``.
+
+    For a cell with ``K = active_basis(cid).size`` active functions, degree ``p``, and
+    dimension ``d`` (so ``n = (p + 1) ** d`` single-level functions on the cell):
+
+    - :meth:`multilevel_operator` returns :math:`M^\epsilon` of shape ``(K, n)`` mapping
+      the level-``L`` tensor-product B-splines on the cell to the active hierarchical
+      functions (independent of ``target``).
+    - :meth:`operator` returns :math:`C^\epsilon = M^\epsilon E^\epsilon` of shape
+      ``(K, n)`` mapping the ``target`` reference basis (Bernstein on :math:`[0, 1]^d`
+      for ``"bezier"``) to the active hierarchical functions.
+
+    The operators' rows are ordered as :meth:`active_basis` (sorted global dof).
+
+    Attributes:
+        _space (THBSplineSpace): The hierarchical space being extracted.
+        _target (Target): The single-level reference basis tag.
+        _oslo (tuple): Cached per-level, per-direction two-scale matrices.
+        _ext (dict[int, SpanwiseElementExtraction]): Cache of per-level single-level
+            extractions, built lazily.
+    """
+
+    __slots__ = ("_ext", "_oslo", "_space", "_target")
+
+    def __init__(self, space: THBSplineSpace, target: Target = "bezier") -> None:
+        """Create a multi-level extraction for a hierarchical space.
+
+        Args:
+            space (THBSplineSpace): The truncated (or non-truncated) hierarchical space.
+            target (Target): Single-level reference basis, one of ``"bezier"``,
+                ``"lagrange"``, ``"cardinal"``.  Defaults to ``"bezier"``.
+
+        Raises:
+            TypeError: If ``space`` is not a :class:`THBSplineSpace`.
+            ValueError: If ``target`` is not a recognized tag.
+        """
+        if not isinstance(space, THBSplineSpace):
+            raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
+        if target not in get_args(Target):
+            valid = ", ".join(repr(v) for v in get_args(Target))
+            raise ValueError(f"Unknown target {target!r}; expected one of {valid}.")
+        self._space = space
+        self._target = target
+        self._oslo = space._build_oslo_matrices()
+        self._ext: dict[int, SpanwiseElementExtraction] = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def space(self) -> THBSplineSpace:
+        """Get the underlying hierarchical space.
+
+        Returns:
+            THBSplineSpace: The space supplied at construction time.
+        """
+        return self._space
+
+    @property
+    def target(self) -> Target:
+        """Get the single-level reference basis tag.
+
+        Returns:
+            Target: One of ``"bezier"``, ``"lagrange"``, ``"cardinal"``.
+        """
+        return self._target
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension.
+
+        Returns:
+            int: Number of parametric directions.
+        """
+        return self._space.dim
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the floating-point dtype of the operators.
+
+        Returns:
+            npt.DTypeLike: ``numpy.float64``.
+        """
+        return np.float64
+
+    @property
+    def num_elements(self) -> int:
+        """Get the number of active cells (elements).
+
+        Returns:
+            int: ``space.grid.num_cells``.
+        """
+        return self._space.grid.num_cells
+
+    # ------------------------------------------------------------------
+    # Per-element operators
+    # ------------------------------------------------------------------
+
+    def active_basis(self, cid: int) -> npt.NDArray[np.int64]:
+        """Return the global dofs labelling the rows of the operators on cell ``cid``.
+
+        Args:
+            cid (int): Active cell flat id in ``[0, num_elements)``.
+
+        Returns:
+            npt.NDArray[np.int64]: Sorted global hierarchical-dof indices (the operator
+            rows), as returned by :meth:`THBSplineSpace.active_basis`.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        return self._space.active_basis(cid)
+
+    def multilevel_operator(
+        self,
+        cid: int,
+        *,
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        r"""Return the multi-level extraction operator :math:`M^\epsilon` on cell ``cid``.
+
+        :math:`M^\epsilon` (shape ``(K, n)``) maps the level-``L`` tensor-product
+        B-splines with support on the cell to the active hierarchical functions
+        (``H^\epsilon = M^\epsilon N^{\epsilon,L}``).  Rows follow :meth:`active_basis`;
+        columns are the ``(p + 1) ** d`` single-level functions on the cell in C-order.
+
+        Args:
+            cid (int): Active cell flat id in ``[0, num_elements)``.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(K, n)``.  Allocated when ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: The operator :math:`M^\epsilon`.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+            ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        space = self._space
+        grid = space.grid
+        level = grid.cell_level(cid)
+        cell_midx = grid.cell_multi_index(cid)
+        dim = space.dim
+        degrees = space.degrees
+        support = space._support[level]
+
+        contribs = space._cell_contributions(cid)
+        n_active = len(contribs)
+        first_basis = [int(support[d][0][cell_midx[d]]) for d in range(dim)]
+        n_per = tuple(degrees[d] + 1 for d in range(dim))
+        n_single = int(np.prod(n_per))
+
+        result = self._allocate_or_validate(out, (n_active, n_single))
+        result[...] = 0.0
+        for row, (_, origin_level, multi) in enumerate(contribs):
+            box_lo, coeffs = self._element_coeffs(origin_level, multi, level)
+            block = np.zeros(n_per, dtype=np.float64)
+            src_slices: list[slice] = []
+            dst_slices: list[slice] = []
+            covered = True
+            for d in range(dim):
+                offset = first_basis[d] - box_lo[d]
+                j0 = max(0, -offset)
+                j1 = min(n_per[d], coeffs.shape[d] - offset)
+                if j1 <= j0:
+                    covered = False
+                    break
+                dst_slices.append(slice(j0, j1))
+                src_slices.append(slice(offset + j0, offset + j1))
+            if covered:
+                block[tuple(dst_slices)] = coeffs[tuple(src_slices)]
+            result[row] = block.ravel()
+        return result
+
+    def operator(
+        self,
+        cid: int,
+        *,
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        r"""Return the multi-level Bézier extraction :math:`C^\epsilon` on cell ``cid``.
+
+        :math:`C^\epsilon = M^\epsilon E^\epsilon` (shape ``(K, n)``) maps the ``target``
+        reference basis on the cell to the active hierarchical functions
+        (``H^\epsilon = C^\epsilon B``).  For ``target="bezier"``, ``B`` is the Bernstein
+        basis on :math:`[0, 1]^d`.  Rows follow :meth:`active_basis`.
+
+        Args:
+            cid (int): Active cell flat id in ``[0, num_elements)``.
+            out (npt.NDArray[np.float64] | None): Optional output array of shape
+                ``(K, n)``.  Allocated when ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: The operator :math:`C^\epsilon`.
+
+        Raises:
+            IndexError: If ``cid`` is out of range.
+            ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        space = self._space
+        level = space.grid.cell_level(cid)
+        cell_midx = space.grid.cell_multi_index(cid)
+        multilevel = self.multilevel_operator(cid)
+        single_level = self._level_extraction(level).operator(cell_midx)
+        product: npt.NDArray[np.float64] = np.asarray(
+            multilevel @ np.asarray(single_level, dtype=np.float64), dtype=np.float64
+        )
+        result = self._allocate_or_validate(out, product.shape)
+        result[...] = product
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _level_extraction(self, level: int) -> SpanwiseElementExtraction:
+        """Return the cached single-level extraction for ``level``.
+
+        Args:
+            level (int): Hierarchy level.
+
+        Returns:
+            SpanwiseElementExtraction: Extraction of ``space.level_space(level)`` with
+            this object's ``target``.
+        """
+        ext = self._ext.get(level)
+        if ext is None:
+            ext = SpanwiseElementExtraction(self._space.level_space(level), self._target)
+            self._ext[level] = ext
+        return ext
+
+    def _element_coeffs(
+        self,
+        origin_level: int,
+        multi: tuple[int, ...],
+        target_level: int,
+    ) -> tuple[list[int], npt.NDArray[np.float64]]:
+        """Express a hierarchical function on a cell in the level-``target_level`` basis.
+
+        Refines the originating B-spline ``B^{origin_level}_multi`` from its origin level
+        up to ``target_level``, applying the (active-function) truncation at each finer
+        level when the space is truncated.  Truncations beyond ``target_level`` do not
+        affect values on a level-``target_level`` leaf cell, so this gives the function's
+        exact coefficients in the level-``target_level`` tensor-product basis over the
+        cell — even when the function's globally-stored representation lives at a finer
+        level than ``target_level``.
+
+        Args:
+            origin_level (int): Level the function originates at.
+            multi (tuple[int, ...]): Per-axis function index at ``origin_level``.
+            target_level (int): The cell's level; the basis the result is expressed in.
+
+        Returns:
+            tuple[list[int], npt.NDArray[np.float64]]: ``(box_lo, coeffs)`` over the
+            level-``target_level`` function box.
+        """
+        space = self._space
+        dim = space.dim
+        box_lo = [int(multi[d]) for d in range(dim)]
+        box_hi = [int(multi[d]) + 1 for d in range(dim)]
+        coeffs = np.ones((1,) * dim, dtype=np.float64)
+        for lvl in range(origin_level, target_level):
+            coeffs, box_lo, box_hi = THBSplineSpace._refine_box(
+                coeffs, box_lo, box_hi, self._oslo[lvl]
+            )
+            if space._truncate:
+                THBSplineSpace._truncate_box(
+                    coeffs,
+                    box_lo,
+                    box_hi,
+                    space._active_funcs[lvl + 1],
+                    space._level_spaces[lvl + 1].num_basis,
+                )
+        return box_lo, coeffs
+
+    @staticmethod
+    def _allocate_or_validate(
+        out: npt.NDArray[np.float64] | None,
+        shape: tuple[int, ...],
+    ) -> npt.NDArray[np.float64]:
+        """Allocate a fresh ``float64`` array or validate a provided ``out``.
+
+        Args:
+            out (npt.NDArray[np.float64] | None): Candidate output array, or ``None``.
+            shape (tuple[int, ...]): Required shape.
+
+        Returns:
+            npt.NDArray[np.float64]: ``out`` (validated) or a fresh array.
+
+        Raises:
+            ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
+        """
+        if out is None:
+            return np.empty(shape, dtype=np.float64)
+        if out.shape != shape:
+            raise ValueError(f"out must have shape {shape}; got {out.shape}.")
+        if out.dtype != np.float64:
+            raise ValueError(f"out must have dtype float64; got {out.dtype}.")
+        if not out.flags.writeable:
+            raise ValueError("out must be writeable.")
+        return out
+
+    def __repr__(self) -> str:
+        """Return a compact string representation.
+
+        Returns:
+            str: Shows dimension, target, and element count.
+        """
+        return (
+            f"MultiLevelExtraction(dim={self.dim}, target={self._target!r}, "
+            f"num_elements={self.num_elements})"
+        )

--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -33,15 +33,14 @@ Main exports:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, get_args
+from typing import cast, get_args
 
 import numpy as np
+import numpy.typing as npt
 
+from ..basis._basis_utils import _allocate_or_validate_out
 from ._thb_spline_space import THBSplineSpace
 from .spanwise_element_extraction import SpanwiseElementExtraction, Target
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 
 class MultiLevelExtraction:
@@ -69,7 +68,9 @@ class MultiLevelExtraction:
     Attributes:
         _space (THBSplineSpace): The hierarchical space being extracted.
         _target (Target): The single-level reference basis tag.
-        _oslo (tuple): Cached per-level, per-direction two-scale matrices.
+        _oslo (tuple[tuple[npt.NDArray[np.float64], ...], ...]): Cached per-level,
+            per-direction two-scale (Oslo) matrices; ``_oslo[m][k]`` maps level ``m``
+            to level ``m+1`` in direction ``k``.
         _ext (dict[int, SpanwiseElementExtraction]): Cache of per-level single-level
             extractions, built lazily.
     """
@@ -130,11 +131,12 @@ class MultiLevelExtraction:
         return self._space.dim
 
     @property
-    def dtype(self) -> npt.DTypeLike:
+    def dtype(self) -> type[np.float64]:
         """Get the floating-point dtype of the operators.
 
         Returns:
-            npt.DTypeLike: ``numpy.float64``.
+            type[np.float64]: Always ``numpy.float64``; Oslo matrices and all operators
+            are computed in double precision.
         """
         return np.float64
 
@@ -146,6 +148,14 @@ class MultiLevelExtraction:
             int: ``space.grid.num_cells``.
         """
         return self._space.grid.num_cells
+
+    def __len__(self) -> int:
+        """Return the number of active cells.
+
+        Returns:
+            int: ``num_elements``.
+        """
+        return self.num_elements
 
     # ------------------------------------------------------------------
     # Per-element operators
@@ -183,7 +193,8 @@ class MultiLevelExtraction:
         Args:
             cid (int): Active cell flat id in ``[0, num_elements)``.
             out (npt.NDArray[np.float64] | None): Optional output array of shape
-                ``(K, n)``.  Allocated when ``None``.
+                ``(K, n)`` where ``K = active_basis(cid).size`` and
+                ``n = (p + 1) ** d``.  Allocated when ``None``.
 
         Returns:
             npt.NDArray[np.float64]: The operator :math:`M^\epsilon`.
@@ -194,6 +205,7 @@ class MultiLevelExtraction:
             RuntimeError: If the grid has been modified since construction.
         """
         space = self._space
+        space._check_not_stale()
         grid = space.grid
         level = grid.cell_level(cid)
         cell_midx = grid.cell_multi_index(cid)
@@ -207,7 +219,10 @@ class MultiLevelExtraction:
         n_per = tuple(degrees[d] + 1 for d in range(dim))
         n_single = int(np.prod(n_per))
 
-        result = self._allocate_or_validate(out, (n_active, n_single))
+        result = cast(
+            npt.NDArray[np.float64],
+            _allocate_or_validate_out(out, (n_active, n_single), np.float64),
+        )
         result[...] = 0.0
         for row, (_, origin_level, multi) in enumerate(contribs):
             box_lo, coeffs = self._element_coeffs(origin_level, multi, level)
@@ -224,8 +239,14 @@ class MultiLevelExtraction:
                     break
                 dst_slices.append(slice(j0, j1))
                 src_slices.append(slice(offset + j0, offset + j1))
-            if covered:
-                block[tuple(dst_slices)] = coeffs[tuple(src_slices)]
+            if not covered:
+                raise RuntimeError(
+                    f"multilevel_operator: cell {cid} row {row} "
+                    f"(origin_level={origin_level}, multi={multi}) — refined coefficient "
+                    "box does not overlap the cell window. This is a bug; please report "
+                    "it with the space and grid configuration."
+                )
+            block[tuple(dst_slices)] = coeffs[tuple(src_slices)]
             result[row] = block.ravel()
         return result
 
@@ -245,7 +266,8 @@ class MultiLevelExtraction:
         Args:
             cid (int): Active cell flat id in ``[0, num_elements)``.
             out (npt.NDArray[np.float64] | None): Optional output array of shape
-                ``(K, n)``.  Allocated when ``None``.
+                ``(K, n)`` where ``K = active_basis(cid).size`` and
+                ``n = (p + 1) ** d``.  Allocated when ``None``.
 
         Returns:
             npt.NDArray[np.float64]: The operator :math:`C^\epsilon`.
@@ -256,15 +278,18 @@ class MultiLevelExtraction:
             RuntimeError: If the grid has been modified since construction.
         """
         space = self._space
+        space._check_not_stale()
         level = space.grid.cell_level(cid)
         cell_midx = space.grid.cell_multi_index(cid)
+        level_ext = self._level_extraction(level)
+        n_in = int(np.prod(level_ext.input_shape_per_dir))
         multilevel = self.multilevel_operator(cid)
-        single_level = self._level_extraction(level).operator(cell_midx)
-        product: npt.NDArray[np.float64] = np.asarray(
-            multilevel @ np.asarray(single_level, dtype=np.float64), dtype=np.float64
+        result = cast(
+            npt.NDArray[np.float64],
+            _allocate_or_validate_out(out, (multilevel.shape[0], n_in), np.float64),
         )
-        result = self._allocate_or_validate(out, product.shape)
-        result[...] = product
+        single_level_f64 = np.asarray(level_ext.operator(cell_midx), dtype=np.float64)
+        np.matmul(multilevel, single_level_f64, out=result)
         return result
 
     # ------------------------------------------------------------------
@@ -272,7 +297,7 @@ class MultiLevelExtraction:
     # ------------------------------------------------------------------
 
     def _level_extraction(self, level: int) -> SpanwiseElementExtraction:
-        """Return the cached single-level extraction for ``level``.
+        """Return (building and caching on first call) the single-level extraction for ``level``.
 
         Args:
             level (int): Hierarchy level.
@@ -296,12 +321,9 @@ class MultiLevelExtraction:
         """Express a hierarchical function on a cell in the level-``target_level`` basis.
 
         Refines the originating B-spline ``B^{origin_level}_multi`` from its origin level
-        up to ``target_level``, applying the (active-function) truncation at each finer
-        level when the space is truncated.  Truncations beyond ``target_level`` do not
-        affect values on a level-``target_level`` leaf cell, so this gives the function's
-        exact coefficients in the level-``target_level`` tensor-product basis over the
-        cell — even when the function's globally-stored representation lives at a finer
-        level than ``target_level``.
+        up to ``target_level``, applying the truncation at each intermediate level when the
+        space is truncated.  The result is the function's exact coefficients in the
+        level-``target_level`` tensor-product basis over the cell.
 
         Args:
             origin_level (int): Level the function originates at.
@@ -311,7 +333,14 @@ class MultiLevelExtraction:
         Returns:
             tuple[list[int], npt.NDArray[np.float64]]: ``(box_lo, coeffs)`` over the
             level-``target_level`` function box.
+
+        Raises:
+            ValueError: If ``origin_level > target_level``.
         """
+        if origin_level > target_level:
+            raise ValueError(
+                f"origin_level ({origin_level}) must be <= target_level ({target_level})."
+            )
         space = self._space
         dim = space.dim
         box_lo = [int(multi[d]) for d in range(dim)]
@@ -330,33 +359,6 @@ class MultiLevelExtraction:
                     space._level_spaces[lvl + 1].num_basis,
                 )
         return box_lo, coeffs
-
-    @staticmethod
-    def _allocate_or_validate(
-        out: npt.NDArray[np.float64] | None,
-        shape: tuple[int, ...],
-    ) -> npt.NDArray[np.float64]:
-        """Allocate a fresh ``float64`` array or validate a provided ``out``.
-
-        Args:
-            out (npt.NDArray[np.float64] | None): Candidate output array, or ``None``.
-            shape (tuple[int, ...]): Required shape.
-
-        Returns:
-            npt.NDArray[np.float64]: ``out`` (validated) or a fresh array.
-
-        Raises:
-            ValueError: If ``out`` has the wrong shape, dtype, or is not writeable.
-        """
-        if out is None:
-            return np.empty(shape, dtype=np.float64)
-        if out.shape != shape:
-            raise ValueError(f"out must have shape {shape}; got {out.shape}.")
-        if out.dtype != np.float64:
-            raise ValueError(f"out must have dtype float64; got {out.dtype}.")
-        if not out.flags.writeable:
-            raise ValueError("out must be writeable.")
-        return out
 
     def __repr__(self) -> str:
         """Return a compact string representation.

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -40,8 +40,8 @@ def _grid_2d() -> HierarchicalGrid:
     return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
 
 
-def _interior_points(thb: THBSplineSpace, cid: int) -> npt.NDArray[np.float64]:
-    """Reference points ξ ∈ (0,1)^d and their cell images, for one cell."""
+def _interior_points(thb: THBSplineSpace) -> npt.NDArray[np.float64]:
+    """Reference points ξ ∈ (0,1)^d in the cell interior (reference space)."""
     u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
     mesh = np.meshgrid(*[u] * thb.dim, indexing="ij")
     return np.stack([m.ravel() for m in mesh], axis=-1)
@@ -54,7 +54,7 @@ def _reproduction_error(thb: THBSplineSpace) -> float:
     err = 0.0
     for cid in range(thb.grid.num_cells):
         lo, hi = thb.grid.cell_bounds(cid)
-        xi = _interior_points(thb, cid)
+        xi = _interior_points(thb)
         x = lo + (hi - lo) * xi
         c_op = mle.operator(cid)
         bernstein = tabulate_bernstein(degrees, xi)
@@ -207,6 +207,21 @@ class TestMayerNarrowBand:
         assert _reproduction_error(thb) < 1e-12
         assert _pou_error(thb) < 1e-10
 
+    def test_narrow_band_no_zero_rows(self) -> None:
+        # If the §3.6.1 bug were present, the straddling passive function would be
+        # spuriously truncated to zero in Mᵉ.  Guard that no row is all zeros.
+        grid = _grid_1d()
+        grid.refine(0, [1], [2])
+        grid.refine(1, [2], [3])
+        thb = THBSplineSpace(_root_1d(), grid)
+        mle = MultiLevelExtraction(thb)
+        for cid in range(thb.grid.num_cells):
+            m_op = mle.multilevel_operator(cid)
+            assert not np.any(np.all(m_op == 0.0, axis=1)), (
+                f"cell {cid}: multilevel_operator has an all-zero row "
+                "(passive straddling function was spuriously dropped)"
+            )
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Operator shape / API / validation
@@ -243,6 +258,68 @@ class TestOperatorApi:
         with pytest.raises(ValueError, match="shape"):
             mle.operator(0, out=np.empty((1, 99)))
 
+    def test_out_bad_dtype_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        k = mle.active_basis(0).shape[0]
+        n = thb.degrees[0] + 1
+        with pytest.raises(ValueError, match="dtype"):
+            mle.operator(0, out=np.empty((k, n), dtype=np.float32))
+        with pytest.raises(ValueError, match="dtype"):
+            mle.multilevel_operator(0, out=np.empty((k, n), dtype=np.float32))
+
+    def test_out_not_writeable_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        k = mle.active_basis(0).shape[0]
+        n = thb.degrees[0] + 1
+        buf = np.empty((k, n), dtype=np.float64)
+        buf.flags.writeable = False
+        with pytest.raises(ValueError, match="writeable"):
+            mle.operator(0, out=buf)
+        with pytest.raises(ValueError, match="writeable"):
+            mle.multilevel_operator(0, out=buf)
+
+    def test_multilevel_operator_out_argument(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        k = mle.active_basis(0).shape[0]
+        out = np.empty((k, thb.degrees[0] + 1), dtype=np.float64)
+        ret = mle.multilevel_operator(0, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, mle.multilevel_operator(0))
+
+    def test_stale_grid_raises(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        mle = MultiLevelExtraction(thb)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            mle.operator(0)
+        with pytest.raises(RuntimeError, match="stale"):
+            mle.multilevel_operator(0)
+
+    def test_negative_cid_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        with pytest.raises(IndexError):
+            mle.operator(-1)
+        with pytest.raises(IndexError):
+            mle.multilevel_operator(-1)
+
+    def test_cardinal_target(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb, "cardinal")
+        assert mle.target == "cardinal"
+        for cid in range(thb.grid.num_cells):
+            mle.operator(cid)
+            mle.multilevel_operator(cid)
+
+    def test_len(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        assert len(mle) == mle.num_elements == thb.grid.num_cells
+
     def test_out_of_range_cid_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         mle = MultiLevelExtraction(thb)
@@ -261,4 +338,8 @@ class TestOperatorApi:
             np.testing.assert_allclose(
                 lagrange.multilevel_operator(cid), bezier.multilevel_operator(cid), atol=1e-12
             )
-            assert lagrange.operator(cid).shape == bezier.operator(cid).shape
+        # Cᵉ must differ between targets (target is actually threaded through to Eᵉ).
+        assert any(
+            not np.allclose(lagrange.operator(cid), bezier.operator(cid))
+            for cid in range(thb.grid.num_cells)
+        ), "lagrange and bezier operators should differ on at least one cell"

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -1,0 +1,264 @@
+"""Tests for pantr.bspline.MultiLevelExtraction (multi-level Bézier extraction)."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.basis import tabulate_bernstein
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    MultiLevelExtraction,
+    SpanwiseElementExtraction,
+    THBSplineSpace,
+)
+from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _root_1d() -> BsplineSpace:
+    return BsplineSpace([BsplineSpace1D(_KNOTS_DEG2_4, 2)])
+
+
+def _root_2d() -> BsplineSpace:
+    sp = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+    return BsplineSpace([sp, sp])
+
+
+def _grid_1d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+
+
+def _grid_2d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+
+
+def _interior_points(thb: THBSplineSpace, cid: int) -> npt.NDArray[np.float64]:
+    """Reference points ξ ∈ (0,1)^d and their cell images, for one cell."""
+    u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
+    mesh = np.meshgrid(*[u] * thb.dim, indexing="ij")
+    return np.stack([m.ravel() for m in mesh], axis=-1)
+
+
+def _reproduction_error(thb: THBSplineSpace) -> float:
+    """Max |operator·Bernstein - tabulate_basis| over all cells; also checks C == M·E."""
+    mle = MultiLevelExtraction(thb)
+    degrees = list(thb.degrees)
+    err = 0.0
+    for cid in range(thb.grid.num_cells):
+        lo, hi = thb.grid.cell_bounds(cid)
+        xi = _interior_points(thb, cid)
+        x = lo + (hi - lo) * xi
+        c_op = mle.operator(cid)
+        bernstein = tabulate_bernstein(degrees, xi)
+        from_extraction = (c_op @ bernstein.T).T
+        direct = thb.tabulate_basis(cid, x)
+        err = max(err, float(np.abs(from_extraction - direct).max()))
+        # C == M @ E by construction.
+        m_op = mle.multilevel_operator(cid)
+        e_op = mle._level_extraction(thb.grid.cell_level(cid)).operator(
+            thb.grid.cell_multi_index(cid)
+        )
+        err = max(err, float(np.abs(m_op @ e_op - c_op).max()))
+    return err
+
+
+def _pou_error(thb: THBSplineSpace) -> float:
+    """Max |column-sum - 1| of the Cᵉ and Mᵉ operators over all cells (THB only)."""
+    mle = MultiLevelExtraction(thb)
+    err = 0.0
+    for cid in range(thb.grid.num_cells):
+        for op in (mle.operator(cid), mle.multilevel_operator(cid)):
+            err = max(err, float(np.abs(op.sum(axis=0) - 1.0).max()))
+    return err
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Construction / properties
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestConstruction:
+    """Constructor validation and properties (mirroring SpanwiseElementExtraction)."""
+
+    def test_non_thb_space_raises(self) -> None:
+        with pytest.raises(TypeError, match="THBSplineSpace"):
+            MultiLevelExtraction(_root_1d())  # type: ignore[arg-type]
+
+    def test_bad_target_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="target"):
+            MultiLevelExtraction(thb, target="nope")  # type: ignore[arg-type]
+
+    def test_properties(self) -> None:
+        thb = THBSplineSpace(_root_2d(), _grid_2d())
+        mle = MultiLevelExtraction(thb)
+        assert mle.space is thb
+        assert mle.target == "bezier"
+        assert mle.dim == 2
+        assert mle.dtype == np.float64
+        assert mle.num_elements == thb.grid.num_cells
+        assert "MultiLevelExtraction" in repr(mle)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Reproduction (Cᵉ·B == tabulate_basis)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestReproduction:
+    """The extraction reproduces the hierarchical functions on every cell."""
+
+    def test_unrefined(self) -> None:
+        assert _reproduction_error(THBSplineSpace(_root_1d(), _grid_1d())) < 1e-12
+
+    def test_1d_two_levels(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        assert _reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-12
+
+    def test_1d_three_levels(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        assert _reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-12
+
+    def test_2d_corner(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        assert _reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-12
+
+    def test_2d_three_levels(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [3, 3])
+        grid.refine(1, [2, 2], [6, 6])
+        assert _reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-12
+
+    def test_hb(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        assert _reproduction_error(THBSplineSpace(_root_1d(), grid, truncate=False)) < 1e-12
+
+    def test_unrefined_equals_single_level_bezier(self) -> None:
+        # On an unrefined grid every cell has all (p+1)^d level-0 functions active, so
+        # Mᵉ is the identity and the operator equals the single-level Bézier extraction.
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        ext = SpanwiseElementExtraction(thb.root_space, "bezier")
+        mle = MultiLevelExtraction(thb)
+        n = thb.degrees[0] + 1
+        for cid in range(thb.grid.num_cells):
+            np.testing.assert_allclose(mle.multilevel_operator(cid), np.eye(n), atol=1e-12)
+            np.testing.assert_allclose(
+                mle.operator(cid), ext.operator(thb.grid.cell_multi_index(cid)), atol=1e-12
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Partition of unity through the operator
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestPartitionOfUnity:
+    """Column sums of Cᵉ and Mᵉ are 1 for THB (the operator-level PoU check)."""
+
+    def test_pou_1d(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        assert _pou_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
+
+    def test_pou_2d(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        assert _pou_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
+
+
+class TestMayerNarrowBand:
+    """Narrow single-element-wide multi-level bands (the D'Angella §3.6.1 bug trigger).
+
+    A passive level-l function straddling the band refines into the deeper region; the
+    buggy local truncation would drop it and break partition of unity. pantr keeps it,
+    so the extraction reproduces the basis and the column sums stay 1.
+    """
+
+    def test_narrow_band_1d(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [1], [2])  # single root cell -> level 1
+        grid.refine(1, [2], [3])  # single level-1 cell -> level 2
+        thb = THBSplineSpace(_root_1d(), grid)
+        assert thb.num_levels == 3
+        assert _reproduction_error(thb) < 1e-12
+        assert _pou_error(thb) < 1e-10
+
+    def test_narrow_band_2d(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [2, 2])  # single root cell -> level 1
+        grid.refine(1, [2, 2], [3, 3])  # single level-1 cell -> level 2
+        thb = THBSplineSpace(_root_2d(), grid)
+        assert thb.num_levels == 3
+        assert _reproduction_error(thb) < 1e-12
+        assert _pou_error(thb) < 1e-10
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Operator shape / API / validation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestOperatorApi:
+    """Shapes, row labelling, target plumbing, and ``out=`` validation."""
+
+    def test_shapes_and_active_basis(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        mle = MultiLevelExtraction(thb)
+        n_bernstein = thb.degrees[0] + 1
+        for cid in range(thb.grid.num_cells):
+            rows = mle.active_basis(cid)
+            assert mle.operator(cid).shape == (rows.shape[0], n_bernstein)
+            assert mle.multilevel_operator(cid).shape == (rows.shape[0], n_bernstein)
+            np.testing.assert_array_equal(rows, thb.active_basis(cid))
+
+    def test_out_argument(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        k = mle.active_basis(0).shape[0]
+        out = np.empty((k, thb.degrees[0] + 1), dtype=np.float64)
+        ret = mle.operator(0, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, mle.operator(0))
+
+    def test_out_bad_shape_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        with pytest.raises(ValueError, match="shape"):
+            mle.operator(0, out=np.empty((1, 99)))
+
+    def test_out_of_range_cid_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        mle = MultiLevelExtraction(thb)
+        with pytest.raises(IndexError):
+            mle.operator(999)
+
+    def test_lagrange_target(self) -> None:
+        # Mᵉ is target-independent; only Eᵉ (hence Cᵉ) changes with the target.
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        bezier = MultiLevelExtraction(thb, "bezier")
+        lagrange = MultiLevelExtraction(thb, "lagrange")
+        assert lagrange.target == "lagrange"
+        for cid in range(thb.grid.num_cells):
+            np.testing.assert_allclose(
+                lagrange.multilevel_operator(cid), bezier.multilevel_operator(cid), atol=1e-12
+            )
+            assert lagrange.operator(cid).shape == bezier.operator(cid).shape


### PR DESCRIPTION
## Summary

PR6 of the THB-splines feature (#164): export a `THBSplineSpace` to standard
element-based FEM data structures via **multi-level Bézier extraction**
(D'Angella thesis 2021, ch. 4).

New class `MultiLevelExtraction(space, target="bezier")` in `pantr.bspline`,
mirroring the tensor-product `SpanwiseElementExtraction` interface
(`space`/`target`/`dim`/`dtype`/`num_elements`, lazy per-level caching, `out=`):

- `multilevel_operator(cid)` → `Mᵉ` `(K, n)`: active THB functions ← level-`L`
  tensor-product B-splines on the cell (target-independent).
- `operator(cid)` → `Cᵉ = Mᵉ·Eᵉ` `(K, n)`: active THB functions ← the Bernstein
  reference basis on `[0,1]^d` (`Hᵉ = Cᵉ·B`).
- `active_basis(cid)` → global THB dofs labelling the operator rows.

Operators are ragged across cells (`K` varies — the hierarchical basis is not
tensor-product), so there is no constant-shape `tabulate()`; this is the only
departure from `SpanwiseElementExtraction`.

### Correctness (the D'Angella §3.6.1 bug)

The paper's local truncation predicate wrongly required the intermediate finer
function to be **active**, dropping passive straddling functions and breaking
partition of unity on narrow refinement bands. `Mᵉ` is instead built from the
space's already-truncated GJS coefficients (PR2), which keep and refine such
functions forward — matching the corrected thesis Eq. 4.7. A **Mayer narrow-band
regression test** guards this.

## Test plan
- [x] `Cᵉ·B == tabulate_basis` reproduction (1D/2D, HB/THB, multi-level) ~1e-12
- [x] `Cᵉ == Mᵉ·Eᵉ`; operator-level partition of unity (column sums == 1)
- [x] Mayer narrow-band regression (§3.6.1 bug guard)
- [x] unrefined identity; `target="lagrange"` smoke; `out=`/validation paths
- [x] full suite (2982 passed), ruff, ruff-format, mypy, docs (-W)

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)