### PR TITLE
feat(bspline): quasi-interpolation for B-spline and THB spaces (PR7 of #164)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,8 +144,8 @@ release = pantr.__version__
 nitpicky = True
 
 # Private NumPy typing internals are not exposed in the public inventory.
-# CellIndex and Target are Literal/Union type aliases; Sphinx resolves them as
-# py:class but they have no class inventory entry.
+# CellIndex, Target, and QIKind are Literal/Union type aliases; Sphinx resolves
+# them as py:class but they have no class inventory entry.
 nitpick_ignore = [
     ("py:class", "numpy._typing._array_like._Buffer"),
     ("py:class", "numpy._typing._array_like._SupportsArray"),
@@ -160,6 +160,7 @@ nitpick_ignore = [
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),
+    ("py:class", "QIKind"),
 ]
 
 # Short-form NumPy aliases used in type annotations (np.*, npt.*, numpy.*)

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -12,6 +12,8 @@ This package consolidates the B-spline API:
   utilities.
 - :func:`interpolate_bspline`, :func:`fit_bspline`,
   :func:`l2_project_bspline`: approximation functions.
+- :func:`quasi_interpolate_bspline`: Lee-Lyche-Mørken local quasi-interpolation
+  onto a tensor-product space.
 - :func:`create_from_bezier`: create a B-spline from a Bézier.
 - :class:`SpanwiseElementExtraction`: lazy tensor-product change-of-basis
   operator across B-spline elements (Bézier/Lagrange/cardinal targets).
@@ -22,10 +24,14 @@ This package consolidates the B-spline API:
   non-truncated) on a :class:`pantr.grid.HierarchicalGrid`.
 - :class:`MultiLevelExtraction`: per-element multi-level (Bézier) extraction
   operators for a :class:`THBSplineSpace`.
+- :class:`THBSpline`: an evaluable THB spline function (space + coefficients).
+- :func:`quasi_interpolate_thb_spline`: Speleers-Manni hierarchical
+  quasi-interpolation onto a :class:`THBSplineSpace`.
 """
 
 from ._bspline import Bspline, create_from_bezier
 from ._bspline_interpolate import fit_bspline, interpolate_bspline, l2_project_bspline
+from ._bspline_quasi_interpolation import quasi_interpolate_bspline
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_factory import (
     create_cardinal_knots,
@@ -36,6 +42,8 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace
+from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
+from ._thb_spline import THBSpline
 from ._thb_spline_space import THBSplineSpace
 from .multilevel_extraction import MultiLevelExtraction
 from .spanwise_element_extraction import (
@@ -51,6 +59,7 @@ __all__ = [
     "ExtractionStructView",
     "MultiLevelExtraction",
     "SpanwiseElementExtraction",
+    "THBSpline",
     "THBSplineSpace",
     "create_cardinal_knots",
     "create_from_bezier",
@@ -63,4 +72,6 @@ __all__ = [
     "interpolate_bspline",
     "l2_project_bspline",
     "make_struct_view",
+    "quasi_interpolate_bspline",
+    "quasi_interpolate_thb_spline",
 ]

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -1,0 +1,262 @@
+"""Quasi-interpolation onto tensor-product B-spline spaces (Lee-Lyche-Mørken).
+
+This module provides :func:`quasi_interpolate_bspline`, a local quasi-interpolant
+that maps a callable ``f`` to a :class:`~pantr.bspline.Bspline`.  It uses the
+Lee-Lyche-Mørken local-spline-interpolation construction: for each basis function
+``B_β`` the coefficient is a local, point-value functional
+``λ_β(f) = Σ_k a_{β,k} f(x_{β,k})`` obtained by inverting a small collocation
+matrix on one knot-interval cell inside ``supp(B_β)``.  On a single cell the
+``p+1`` (per direction) nonzero B-splines span the degree-``p`` polynomials, so the
+local interpolation recovers their exact coefficients and the operator is a
+projector onto the spline space (``Q B_β = B_β``).
+
+The same low-level helpers (:func:`_interval_interior_points`,
+:func:`_local_weight_row`, :func:`_tensor_point_grid`, :func:`_contract_weights`)
+back the hierarchical quasi-interpolant in ``_thb_quasi_interpolation``.
+
+Main exports:
+
+- :func:`quasi_interpolate_bspline`: quasi-interpolate a callable onto a
+  tensor-product :class:`~pantr.bspline.BsplineSpace`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, get_args
+
+import numpy as np
+from numpy import typing as npt
+
+from ._bspline import Bspline
+from ._bspline_space_factory import get_greville_abscissae
+from ._bspline_space_nd import BsplineSpace
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ._bspline_space_1d import BsplineSpace1D
+
+QIKind = Literal["llm"]
+"""Supported quasi-interpolation kinds (Lee-Lyche-Mørken local projector)."""
+
+
+# ---------------------------------------------------------------------------
+# Local Lee-Lyche-Mørken building blocks (shared with the hierarchical QI)
+# ---------------------------------------------------------------------------
+
+
+def _interval_interior_points(lo: float, hi: float, order: int) -> npt.NDArray[np.float64]:
+    """Return ``order`` equispaced interior points of ``[lo, hi]``.
+
+    Interior placement keeps the points off the knots, where the local collocation
+    block can become singular.
+
+    Args:
+        lo (float): Interval lower bound.
+        hi (float): Interval upper bound.
+        order (int): Number of points (``degree + 1``).
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(order,)`` strictly inside ``(lo, hi)``.
+    """
+    frac = np.arange(1, order + 1, dtype=np.float64) / (order + 1)
+    return np.asarray(lo + (hi - lo) * frac, dtype=np.float64)
+
+
+def _local_weight_row(
+    space1d: BsplineSpace1D,
+    points: npt.NDArray[np.float64],
+    target_index: int,
+) -> npt.NDArray[np.float64]:
+    """Return the local functional weights for one basis function on one interval.
+
+    ``points`` must all lie in a single knot interval where ``target_index`` is one
+    of the ``order`` nonzero B-splines.  The local collocation block is inverted so
+    that ``λ(f) = weights · f(points)`` recovers the coefficient of
+    ``B_{target_index}`` of the local degree-``p`` interpolant.
+
+    Args:
+        space1d (BsplineSpace1D): The 1D B-spline space.
+        points (npt.NDArray[np.float64]): ``order`` distinct points in one interval.
+        target_index (int): Global index of the target basis function.
+
+    Returns:
+        npt.NDArray[np.float64]: Weights of shape ``(order,)``.
+    """
+    basis, first_basis = space1d.tabulate_basis(points)
+    block = np.asarray(basis, dtype=np.float64)
+    inv = np.asarray(np.linalg.inv(block), dtype=np.float64)
+    local = target_index - int(first_basis[0])
+    return np.asarray(inv[local], dtype=np.float64)
+
+
+def _tensor_point_grid(per_dir_points: list[npt.NDArray[np.float64]]) -> npt.NDArray[np.float64]:
+    """Build the tensor-product point grid from per-direction point arrays.
+
+    Args:
+        per_dir_points (list[npt.NDArray[np.float64]]): One ``(order_k,)`` array per
+            direction.
+
+    Returns:
+        npt.NDArray[np.float64]: Points of shape ``(prod(order_k), dim)`` in C-order.
+    """
+    mesh = np.meshgrid(*per_dir_points, indexing="ij")
+    return np.stack([m.ravel() for m in mesh], axis=-1).astype(np.float64, copy=False)
+
+
+def _contract_weights(
+    weights: list[npt.NDArray[np.float64]],
+    values: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Contract a local value tensor with per-direction weight vectors.
+
+    Args:
+        weights (list[npt.NDArray[np.float64]]): One ``(order_k,)`` weight vector per
+            direction.
+        values (npt.NDArray[np.float64]): Local values of shape
+            ``(order_0, ..., order_{d-1}, rank)``.
+
+    Returns:
+        npt.NDArray[np.float64]: The coefficient of shape ``(rank,)``.
+    """
+    result = values
+    for w in weights:
+        result = np.tensordot(w, result, axes=([0], [0]))
+    return np.asarray(result, dtype=np.float64)
+
+
+def _llm_tp_direction_data(
+    space1d: BsplineSpace1D,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Precompute per-function local points and weights for a 1D space.
+
+    For each basis function the local interval is the knot span containing its
+    Greville abscissa (well inside the support, limiting extrapolation).
+
+    Args:
+        space1d (BsplineSpace1D): The 1D B-spline space.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(points, weights)``,
+        each of shape ``(num_basis, degree + 1)``.
+    """
+    order = space1d.degree + 1
+    n_basis = space1d.num_basis
+    greville = np.asarray(get_greville_abscissae(space1d), dtype=np.float64)
+    breakpoints, _ = space1d.get_unique_knots_and_multiplicity(in_domain=True)
+    breaks = np.asarray(breakpoints, dtype=np.float64)
+    n_intervals = breaks.shape[0] - 1
+
+    points = np.empty((n_basis, order), dtype=np.float64)
+    weights = np.empty((n_basis, order), dtype=np.float64)
+    for j in range(n_basis):
+        mu = int(np.searchsorted(breaks, greville[j], side="right")) - 1
+        mu = min(max(mu, 0), n_intervals - 1)
+        pts = _interval_interior_points(float(breaks[mu]), float(breaks[mu + 1]), order)
+        points[j] = pts
+        weights[j] = _local_weight_row(space1d, pts, j)
+    return points, weights
+
+
+# ---------------------------------------------------------------------------
+# Batched evaluation helper
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_func(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    points: npt.NDArray[np.float64],
+) -> tuple[npt.NDArray[np.float64], int, bool]:
+    """Evaluate ``func`` on a point array and normalize the output.
+
+    Args:
+        func (Callable): Called on ``(M, dim)`` points; returns ``(M,)`` or
+            ``(M, rank)``.
+        points (npt.NDArray[np.float64]): Points of shape ``(M, dim)``.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], int, bool]: ``(values, rank, scalar)`` with
+        ``values`` of shape ``(M, rank)``.
+
+    Raises:
+        ValueError: If the output leading dimension does not match ``M``.
+    """
+    values = np.asarray(func(np.ascontiguousarray(points, dtype=np.float64)), dtype=np.float64)
+    if values.shape[0] != points.shape[0]:
+        raise ValueError(f"func returned {values.shape[0]} values for {points.shape[0]} points.")
+    if values.ndim == 1:
+        return values.reshape(-1, 1), 1, True
+    return values, int(values.shape[1]), False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def quasi_interpolate_bspline(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    space: BsplineSpace,
+    *,
+    kind: QIKind = "llm",
+) -> Bspline:
+    """Quasi-interpolate a callable onto a tensor-product B-spline space.
+
+    Builds the Lee-Lyche-Mørken local projector: a local, point-value functional per
+    basis function whose weights come from inverting a small collocation block.  The
+    operator reproduces the spline space (``Q B_β = B_β``) and is local.
+
+    Args:
+        func (Callable): Function to quasi-interpolate.  Called once on an
+            ``(M, dim)`` point array and must return ``(M,)`` (scalar) or
+            ``(M, rank)`` (vector-valued).  Unlike the lattice-based
+            :func:`interpolate_bspline` / :func:`l2_project_bspline`, ``func``
+            receives a flat point array because the QI samples scattered local points.
+        space (BsplineSpace): The target tensor-product B-spline space.
+        kind (QIKind): Quasi-interpolant kind.  Only ``"llm"`` (Lee-Lyche-Mørken) is
+            currently supported.  Defaults to ``"llm"``.
+
+    Returns:
+        Bspline: A non-rational B-spline whose evaluation quasi-interpolates ``func``.
+
+    Raises:
+        TypeError: If ``space`` is not a :class:`~pantr.bspline.BsplineSpace`.
+        ValueError: If ``kind`` is not recognized.
+
+    Example:
+        >>> import numpy as np
+        >>> from pantr.bspline import create_uniform_space, quasi_interpolate_bspline
+        >>> space = create_uniform_space([2], [4])
+        >>> qi = quasi_interpolate_bspline(lambda p: p[:, 0] ** 2, space)
+        >>> bool(np.isclose(qi.evaluate(np.array([[0.3]]))[0, 0], 0.09))
+        True
+    """
+    if not isinstance(space, BsplineSpace):
+        raise TypeError(f"space must be a BsplineSpace; got {type(space).__name__!r}.")
+    if kind not in get_args(QIKind):
+        valid = ", ".join(repr(v) for v in get_args(QIKind))
+        raise ValueError(f"Unknown kind {kind!r}; expected one of {valid}.")
+
+    dim = space.dim
+    num_basis = tuple(space.num_basis)
+    dir_data = [_llm_tp_direction_data(space.spaces[k]) for k in range(dim)]
+
+    multi_indices = list(np.ndindex(*num_basis))
+    orders = tuple(d + 1 for d in space.degrees)
+    block = int(np.prod(orders))
+
+    all_points = np.empty((len(multi_indices) * block, dim), dtype=np.float64)
+    for f_idx, multi in enumerate(multi_indices):
+        per_dir = [dir_data[k][0][multi[k]] for k in range(dim)]
+        all_points[f_idx * block : (f_idx + 1) * block] = _tensor_point_grid(per_dir)
+
+    values, rank, scalar = _evaluate_func(func, all_points)
+    value_tensor = values.reshape(len(multi_indices), *orders, rank)
+
+    coeffs = np.empty((len(multi_indices), rank), dtype=np.float64)
+    for f_idx, multi in enumerate(multi_indices):
+        weights = [dir_data[k][1][multi[k]] for k in range(dim)]
+        coeffs[f_idx] = _contract_weights(weights, value_tensor[f_idx])
+
+    control_points = coeffs.reshape(*num_basis, rank).astype(space.dtype, copy=False)
+    return Bspline(space, control_points)

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -119,10 +119,10 @@ def _contract_weights(
     Returns:
         npt.NDArray[np.float64]: The coefficient of shape ``(rank,)``.
     """
-    result = values
+    result = np.asarray(values, dtype=np.float64)
     for w in weights:
-        result = np.tensordot(w, result, axes=([0], [0]))
-    return np.asarray(result, dtype=np.float64)
+        result = np.asarray(np.tensordot(w, result, axes=([0], [0])), dtype=np.float64)
+    return result
 
 
 def _llm_tp_direction_data(

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -11,8 +11,9 @@ local interpolation recovers their exact coefficients and the operator is a
 projector onto the spline space (``Q B_β = B_β``).
 
 The same low-level helpers (:func:`_interval_interior_points`,
-:func:`_local_weight_row`, :func:`_tensor_point_grid`, :func:`_contract_weights`)
-back the hierarchical quasi-interpolant in ``_thb_quasi_interpolation``.
+:func:`_local_weight_row`, :func:`_tensor_point_grid`, :func:`_contract_weights`,
+:func:`_evaluate_func`) and :data:`QIKind` back the hierarchical quasi-interpolant
+in ``_thb_quasi_interpolation``.
 
 Main exports:
 
@@ -78,14 +79,32 @@ def _local_weight_row(
     Args:
         space1d (BsplineSpace1D): The 1D B-spline space.
         points (npt.NDArray[np.float64]): ``order`` distinct points in one interval.
-        target_index (int): Global index of the target basis function.
+        target_index (int): Index of the target basis function within ``space1d``
+            (0-indexed within the 1D space, not a global hierarchical dof index).
 
     Returns:
         npt.NDArray[np.float64]: Weights of shape ``(order,)``.
+
+    Raises:
+        ValueError: If the local collocation matrix is singular or nearly singular
+            (non-finite inverse), which indicates degenerate knot intervals.
     """
     basis, first_basis = space1d.tabulate_basis(points)
     block = np.asarray(basis, dtype=np.float64)
-    inv = np.asarray(np.linalg.inv(block), dtype=np.float64)
+    try:
+        inv = np.asarray(np.linalg.inv(block), dtype=np.float64)
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(
+            f"Local collocation matrix for basis function {target_index} is singular. "
+            "This usually indicates repeated or degenerate knot intervals. "
+            f"Points: {points.tolist()}"
+        ) from exc
+    if not np.all(np.isfinite(inv)):
+        raise ValueError(
+            f"Local collocation matrix inversion for basis function {target_index} "
+            f"produced non-finite values (condition number too large). "
+            f"Points: {points.tolist()}"
+        )
     local = target_index - int(first_basis[0])
     return np.asarray(inv[local], dtype=np.float64)
 
@@ -179,9 +198,20 @@ def _evaluate_func(
         ``values`` of shape ``(M, rank)``.
 
     Raises:
-        ValueError: If the output leading dimension does not match ``M``.
+        ValueError: If the output is 0-D, has more than 2 dimensions, or its leading
+            dimension does not match ``M``.
     """
     values = np.asarray(func(np.ascontiguousarray(points, dtype=np.float64)), dtype=np.float64)
+    if values.ndim == 0:
+        raise ValueError(
+            f"func returned a 0-D scalar; expected shape ({points.shape[0]},) "
+            f"or ({points.shape[0]}, rank)."
+        )
+    if values.ndim > 2:  # noqa: PLR2004
+        raise ValueError(
+            f"func returned a {values.ndim}-D array of shape {values.shape!r}; "
+            f"expected shape ({points.shape[0]},) or ({points.shape[0]}, rank)."
+        )
     if values.shape[0] != points.shape[0]:
         raise ValueError(f"func returned {values.shape[0]} values for {points.shape[0]} points.")
     if values.ndim == 1:
@@ -221,7 +251,13 @@ def quasi_interpolate_bspline(
 
     Raises:
         TypeError: If ``space`` is not a :class:`~pantr.bspline.BsplineSpace`.
-        ValueError: If ``kind`` is not recognized.
+        ValueError: If ``kind`` is not recognized, or if ``func`` returns an output
+            with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
+
+    Note:
+        All internal computation uses ``float64``.  The returned control points are
+        cast to ``space.dtype`` at the end, so a ``float32`` space incurs a precision
+        loss on the final cast.
 
     Example:
         >>> import numpy as np

--- a/src/pantr/bspline/_thb_quasi_interpolation.py
+++ b/src/pantr/bspline/_thb_quasi_interpolation.py
@@ -73,7 +73,8 @@ def quasi_interpolate_thb_spline(
 
     Raises:
         TypeError: If ``space`` is not a :class:`~pantr.bspline.THBSplineSpace`.
-        ValueError: If ``kind`` is not recognized.
+        ValueError: If ``kind`` is not recognized, or if ``func`` returns an output
+            with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
         RuntimeError: If the grid has been modified since ``space`` was constructed,
             or an active dof has no leaf cell at its level (inconsistent space).
     """
@@ -140,6 +141,9 @@ def quasi_interpolate_thb_spline(
         for k in range(dim):
             pts = _interval_interior_points(float(lo[k]), float(hi[k]), orders[k])
             per_dir_points.append(pts)
+            # best_multi[k] is the per-direction index within the level-l
+            # tensor-product basis (not the global hierarchical dof index),
+            # which is what _local_weight_row expects.
             dof_weights[dof].append(_local_weight_row(level_space.spaces[k], pts, best_multi[k]))
         all_points[dof * block : (dof + 1) * block] = _tensor_point_grid(per_dir_points)
 

--- a/src/pantr/bspline/_thb_quasi_interpolation.py
+++ b/src/pantr/bspline/_thb_quasi_interpolation.py
@@ -1,0 +1,155 @@
+r"""Quasi-interpolation onto THB spline spaces (Speleers-Manni, effortless).
+
+This module provides :func:`quasi_interpolate_thb_spline`, the hierarchical
+counterpart of :func:`~pantr.bspline.quasi_interpolate_bspline`.  Following
+Speleers-Manni (2016), the hierarchical quasi-interpolant is assembled with no
+inter-level coupling: each active hierarchical dof receives the coefficient of a
+per-level tensor-product quasi-interpolant,
+
+.. math::
+    Q_H f = \sum_{\ell} \sum_{\beta \in A_\ell} \lambda^\ell_\beta(f)\,
+            \operatorname{trunc}(B^\ell_\beta),
+
+so ``c[d] = λ^{l}_β(f)`` for the active function ``(l, β)`` of global dof ``d``
+(truncation already lives in the basis).  The per-level functional is the
+Lee-Lyche-Mørken local projector, evaluated on a **level-l active leaf cell** inside
+``supp(B^l_β)``.  On such a cell, truncation zeros every coarser active function's
+component on the active ``B^l_β``, so ``λ^l_β(s) = c_β`` for any THB spline ``s`` and
+``Q_H`` reproduces the THB space exactly.
+
+Main exports:
+
+- :func:`quasi_interpolate_thb_spline`: quasi-interpolate a callable onto a
+  :class:`~pantr.bspline.THBSplineSpace`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, get_args
+
+import numpy as np
+from numpy import typing as npt
+
+from ._bspline_quasi_interpolation import (
+    QIKind,
+    _contract_weights,
+    _evaluate_func,
+    _interval_interior_points,
+    _local_weight_row,
+    _tensor_point_grid,
+)
+from ._bspline_space_factory import get_greville_abscissae
+from ._thb_spline import THBSpline
+from ._thb_spline_space import THBSplineSpace
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def quasi_interpolate_thb_spline(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    space: THBSplineSpace,
+    *,
+    kind: QIKind = "llm",
+) -> THBSpline:
+    """Quasi-interpolate a callable onto a THB spline space.
+
+    Assembles the Speleers-Manni hierarchical quasi-interpolant: every active dof gets
+    the coefficient of the per-level Lee-Lyche-Mørken local projector, sampled on a
+    level-``l`` active leaf cell inside the function's support.  For the truncated
+    (THB) basis this reproduces any THB spline exactly; for the non-truncated (HB)
+    basis it remains a valid local approximant but is not an exact projector.
+
+    Args:
+        func (Callable): Function to quasi-interpolate.  Called once on an
+            ``(M, dim)`` point array and must return ``(M,)`` (scalar) or
+            ``(M, rank)`` (vector-valued).
+        space (THBSplineSpace): The target hierarchical space.
+        kind (QIKind): Quasi-interpolant kind.  Only ``"llm"`` (Lee-Lyche-Mørken) is
+            currently supported.  Defaults to ``"llm"``.
+
+    Returns:
+        THBSpline: A THB spline whose evaluation quasi-interpolates ``func``.
+
+    Raises:
+        TypeError: If ``space`` is not a :class:`~pantr.bspline.THBSplineSpace`.
+        ValueError: If ``kind`` is not recognized.
+        RuntimeError: If the grid has been modified since ``space`` was constructed,
+            or an active dof has no leaf cell at its level (inconsistent space).
+    """
+    if not isinstance(space, THBSplineSpace):
+        raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
+    if kind not in get_args(QIKind):
+        valid = ", ".join(repr(v) for v in get_args(QIKind))
+        raise ValueError(f"Unknown kind {kind!r}; expected one of {valid}.")
+    space._check_not_stale()
+
+    grid = space.grid
+    dim = space.dim
+    num_active = space.num_active_functions
+    func_offset = space._func_offset
+
+    # Candidate leaf cells per dof: cells whose level equals the contributing
+    # function's level (i.e. level-l active leaf cells inside supp(B^l_β)).
+    candidates: dict[int, list[tuple[int, tuple[int, ...]]]] = {}
+    for cid in range(grid.num_cells):
+        cell_lvl = grid.cell_level(cid)
+        for dof, level, multi in space._cell_contributions(cid):
+            if level == cell_lvl:
+                candidates.setdefault(dof, []).append((cid, multi))
+
+    greville_cache: dict[tuple[int, int], npt.NDArray[np.float64]] = {}
+
+    def _greville(level: int, k: int) -> npt.NDArray[np.float64]:
+        key = (level, k)
+        cached = greville_cache.get(key)
+        if cached is None:
+            cached = np.asarray(
+                get_greville_abscissae(space.level_space(level).spaces[k]), dtype=np.float64
+            )
+            greville_cache[key] = cached
+        return cached
+
+    orders = tuple(d + 1 for d in space.degrees)
+    block = int(np.prod(orders))
+    all_points = np.empty((num_active * block, dim), dtype=np.float64)
+    dof_weights: list[list[npt.NDArray[np.float64]]] = [[] for _ in range(num_active)]
+
+    for dof in range(num_active):
+        cand = candidates.get(dof)
+        if not cand:
+            raise RuntimeError(
+                f"active dof {dof} has no leaf cell at its level; the THB space is inconsistent."
+            )
+        level = int(np.searchsorted(func_offset, dof, side="right")) - 1
+        multi = cand[0][1]
+        target = np.array([_greville(level, k)[multi[k]] for k in range(dim)], dtype=np.float64)
+
+        # Pick the candidate leaf cell whose centre is nearest the Greville point
+        # (any leaf cell is exact for splines; this limits the local extrapolation).
+        best_cid, best_multi = cand[0]
+        best_dist = np.inf
+        for cell_id, cell_multi in cand:
+            lo, hi = grid.cell_bounds(cell_id)
+            dist = float(np.linalg.norm(0.5 * (lo + hi) - target))
+            if dist < best_dist:
+                best_dist, best_cid, best_multi = dist, cell_id, cell_multi
+        lo, hi = grid.cell_bounds(best_cid)
+        level_space = space.level_space(level)
+        per_dir_points: list[npt.NDArray[np.float64]] = []
+        for k in range(dim):
+            pts = _interval_interior_points(float(lo[k]), float(hi[k]), orders[k])
+            per_dir_points.append(pts)
+            dof_weights[dof].append(_local_weight_row(level_space.spaces[k], pts, best_multi[k]))
+        all_points[dof * block : (dof + 1) * block] = _tensor_point_grid(per_dir_points)
+
+    values, rank, scalar = _evaluate_func(func, all_points)
+    value_tensor = values.reshape(num_active, *orders, rank)
+
+    coeffs = np.empty((num_active, rank), dtype=np.float64)
+    for dof in range(num_active):
+        coeffs[dof] = _contract_weights(dof_weights[dof], value_tensor[dof])
+
+    if scalar:
+        return THBSpline(space, coeffs[:, 0])
+    return THBSpline(space, coeffs)

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -1,0 +1,177 @@
+"""THB spline function: a :class:`THBSplineSpace` paired with coefficients.
+
+This module provides :class:`THBSpline`, the hierarchical analogue of
+:class:`~pantr.bspline.Bspline`.  It represents a function
+``f(u) = Σ_i c_i φ_i(u)`` where ``φ_i`` are the active (truncated) hierarchical
+basis functions of a :class:`~pantr.bspline.THBSplineSpace` and ``c_i`` the
+coefficients (one per active dof).  Evaluation locates each point's active leaf
+cell and combines the cell's active-basis values with the matching coefficients.
+
+Main exports:
+
+- :class:`THBSpline`: an evaluable hierarchical B-spline function.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import typing as npt
+
+from ._thb_spline_space import THBSplineSpace
+
+
+class THBSpline:
+    """An evaluable THB spline function ``f = Σ_i c_i φ_i``.
+
+    Pairs a :class:`~pantr.bspline.THBSplineSpace` with a coefficient per active
+    hierarchical dof.  Scalar (``coeffs`` shape ``(num_active,)``) and
+    vector-valued (``(num_active, rank)``) fields are both supported.
+
+    Attributes:
+        _space (THBSplineSpace): The hierarchical space.
+        _coeffs (npt.NDArray[np.float64]): Coefficients reshaped to
+            ``(num_active, rank)``.
+        _scalar (bool): Whether the field is scalar (``coeffs`` was 1-D).
+    """
+
+    __slots__ = ("_coeffs", "_scalar", "_space")
+
+    def __init__(self, space: THBSplineSpace, coeffs: npt.ArrayLike) -> None:
+        """Create a THB spline function.
+
+        Args:
+            space (THBSplineSpace): The hierarchical space.
+            coeffs (npt.ArrayLike): Coefficients of shape ``(num_active,)`` (scalar)
+                or ``(num_active, rank)`` (vector-valued), ordered by global dof.
+
+        Raises:
+            TypeError: If ``space`` is not a :class:`THBSplineSpace`.
+            ValueError: If ``coeffs`` is not 1-D/2-D or its leading dimension does
+                not equal ``space.num_active_functions``.
+        """
+        if not isinstance(space, THBSplineSpace):
+            raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
+        arr = np.asarray(coeffs, dtype=np.float64)
+        n = space.num_active_functions
+        if arr.ndim == 1:
+            scalar = True
+            if arr.shape[0] != n:
+                raise ValueError(f"coeffs must have length {n}; got {arr.shape[0]}.")
+            arr = arr.reshape(n, 1)
+        elif arr.ndim == 2:  # noqa: PLR2004
+            scalar = False
+            if arr.shape[0] != n:
+                raise ValueError(f"coeffs leading dimension must be {n}; got shape {arr.shape!r}.")
+        else:
+            raise ValueError(f"coeffs must be 1-D or 2-D; got {arr.ndim}-D.")
+        self._space = space
+        self._coeffs = np.ascontiguousarray(arr, dtype=np.float64)
+        self._scalar = scalar
+
+    @property
+    def space(self) -> THBSplineSpace:
+        """Get the underlying hierarchical space.
+
+        Returns:
+            THBSplineSpace: The space supplied at construction time.
+        """
+        return self._space
+
+    @property
+    def coeffs(self) -> npt.NDArray[np.float64]:
+        """Get the coefficients.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(num_active,)`` for a scalar field,
+            ``(num_active, rank)`` otherwise.
+        """
+        if self._scalar:
+            return self._coeffs[:, 0]
+        return self._coeffs
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension.
+
+        Returns:
+            int: Number of parametric directions.
+        """
+        return self._space.dim
+
+    @property
+    def rank(self) -> int:
+        """Get the output rank (number of value components).
+
+        Returns:
+            int: ``1`` for a scalar field; the number of components otherwise.
+        """
+        return int(self._coeffs.shape[1])
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the floating-point dtype of the coefficients.
+
+        Returns:
+            npt.DTypeLike: ``numpy.float64``.
+        """
+        return np.float64
+
+    def evaluate(self, pts: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        """Evaluate the THB spline at ``pts``.
+
+        Each point is located in its active leaf cell; the cell's active-basis
+        values (:meth:`THBSplineSpace.tabulate_basis`) are combined with the
+        matching coefficients.
+
+        Args:
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)``.
+
+        Returns:
+            npt.NDArray[np.float64]: Values of shape ``(...)`` for a scalar field
+            or ``(..., rank)`` for a vector-valued field.
+
+        Raises:
+            ValueError: If ``pts`` does not have trailing dimension ``dim`` or any
+                point lies outside the grid domain.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        self._space._check_not_stale()
+        arr = np.asarray(pts, dtype=np.float64)
+        if arr.ndim == 0 or arr.shape[-1] != self.dim:
+            raise ValueError(
+                f"pts must have trailing dimension {self.dim}; got shape {arr.shape!r}."
+            )
+        batch_shape = arr.shape[:-1]
+        flat = arr.reshape(-1, self.dim)
+        n_pts = flat.shape[0]
+        rank = self.rank
+        grid = self._space.grid
+
+        cids = np.empty(n_pts, dtype=np.int64)
+        for i in range(n_pts):
+            cid = grid.locate(flat[i])
+            if cid is None:
+                raise ValueError(f"point {flat[i].tolist()!r} lies outside the grid domain.")
+            cids[i] = cid
+
+        out = np.empty((n_pts, rank), dtype=np.float64)
+        for cid in np.unique(cids):
+            mask = cids == cid
+            dofs = self._space.active_basis(int(cid))
+            values = self._space.tabulate_basis(int(cid), flat[mask])
+            out[mask] = np.asarray(values, dtype=np.float64) @ self._coeffs[dofs]
+
+        if self._scalar:
+            return out[:, 0].reshape(batch_shape)
+        return out.reshape(*batch_shape, rank)
+
+    def __repr__(self) -> str:
+        """Return a concise representation.
+
+        Returns:
+            str: Summary with dimension, rank, and active-function count.
+        """
+        return (
+            f"THBSpline(dim={self.dim}, rank={self.rank}, "
+            f"num_active={self._space.num_active_functions})"
+        )

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -66,6 +66,11 @@ class THBSpline:
             raise ValueError(f"coeffs must be 1-D or 2-D; got {arr.ndim}-D.")
         self._space = space
         self._coeffs = np.ascontiguousarray(arr, dtype=np.float64)
+        # Ensure we own the data before marking read-only; ascontiguousarray may
+        # return a view of the input when it is already C-contiguous float64.
+        if not self._coeffs.flags.owndata:
+            self._coeffs = self._coeffs.copy()
+        self._coeffs.flags.writeable = False
         self._scalar = scalar
 
     @property
@@ -79,11 +84,12 @@ class THBSpline:
 
     @property
     def coeffs(self) -> npt.NDArray[np.float64]:
-        """Get the coefficients.
+        """Get the coefficients (read-only view).
 
         Returns:
             npt.NDArray[np.float64]: Shape ``(num_active,)`` for a scalar field,
-            ``(num_active, rank)`` otherwise.
+            ``(num_active, rank)`` otherwise.  The array is read-only; copy it
+            before modifying.
         """
         if self._scalar:
             return self._coeffs[:, 0]
@@ -108,13 +114,14 @@ class THBSpline:
         return int(self._coeffs.shape[1])
 
     @property
-    def dtype(self) -> npt.DTypeLike:
+    def dtype(self) -> np.dtype[np.float64]:
         """Get the floating-point dtype of the coefficients.
 
         Returns:
-            npt.DTypeLike: ``numpy.float64``.
+            np.dtype[np.float64]: Dtype of the stored coefficients, always
+            ``numpy.float64``.
         """
-        return np.float64
+        return self._coeffs.dtype
 
     def evaluate(self, pts: npt.ArrayLike) -> npt.NDArray[np.float64]:
         """Evaluate the THB spline at ``pts``.
@@ -133,7 +140,8 @@ class THBSpline:
         Raises:
             ValueError: If ``pts`` does not have trailing dimension ``dim`` or any
                 point lies outside the grid domain.
-            RuntimeError: If the grid has been modified since construction.
+            RuntimeError: If the grid has been modified since construction, or a cell
+                has no active basis functions (inconsistent space).
         """
         self._space._check_not_stale()
         arr = np.asarray(pts, dtype=np.float64)
@@ -158,6 +166,11 @@ class THBSpline:
         for cid in np.unique(cids):
             mask = cids == cid
             dofs = self._space.active_basis(int(cid))
+            if dofs.size == 0:
+                raise RuntimeError(
+                    f"cell {int(cid)} has no active basis functions; "
+                    "the THBSplineSpace may be inconsistent."
+                )
             values = self._space.tabulate_basis(int(cid), flat[mask])
             out[mask] = np.asarray(values, dtype=np.float64) @ self._coeffs[dofs]
 

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -107,6 +107,18 @@ class TestTensorProductQI:
         with pytest.raises(ValueError, match="kind"):
             quasi_interpolate_bspline(lambda p: p[:, 0], _root_1d(), kind="nope")  # type: ignore[arg-type]
 
+    def test_func_zero_d_raises(self) -> None:
+        with pytest.raises(ValueError, match="0-D"):
+            quasi_interpolate_bspline(lambda p: np.float64(1.0), _root_1d())
+
+    def test_func_3d_raises(self) -> None:
+        with pytest.raises(ValueError, match="3-D"):
+            quasi_interpolate_bspline(lambda p: np.zeros((p.shape[0], 2, 2)), _root_1d())
+
+    def test_func_wrong_count_raises(self) -> None:
+        with pytest.raises(ValueError, match="values"):
+            quasi_interpolate_bspline(lambda p: np.zeros(p.shape[0] + 1), _root_1d())
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Hierarchical quasi-interpolation — exact reproduction (THB)
@@ -187,6 +199,16 @@ class TestThbReproduction:
         assert recovered.rank == 2
         np.testing.assert_allclose(recovered.coeffs, coeffs, atol=1e-10)
 
+    def test_multiple_candidate_cells_selects_nearest(self) -> None:
+        # Refine two non-adjacent cells so a coarse dof whose support spans both
+        # refined regions has more than one leaf-cell candidate; exercises the
+        # nearest-Greville selection branch.
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(0, [3], [4])
+        thb = THBSplineSpace(_root_1d(), grid)
+        assert _thb_reproduction_error(thb) < 1e-10
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Convergence smoke + TP consistency
@@ -207,8 +229,8 @@ class TestConvergence:
             got = np.asarray(qi.evaluate(xs)).ravel()
             errs.append(np.abs(got - np.sin(2.0 * np.pi * xs)).max())
         orders = [np.log2(errs[i] / errs[i + 1]) for i in range(len(errs) - 1)]
-        # degree-2 LLM projector: expect order ≈ 3; assert comfortably super-quadratic.
-        assert min(orders) > 2.5
+        # degree-2 LLM projector: expect order ≈ 3.
+        assert min(orders) > 2.9
 
     def test_unrefined_thb_matches_tp(self) -> None:
         def f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
@@ -249,6 +271,18 @@ class TestHb:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="kind"):
             quasi_interpolate_thb_spline(lambda p: p[:, 0], thb, kind="nope")  # type: ignore[arg-type]
+
+    def test_func_wrong_count_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="values"):
+            quasi_interpolate_thb_spline(lambda p: np.zeros(p.shape[0] + 1), thb)
+
+    def test_stale_grid_raises_on_qi(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            quasi_interpolate_thb_spline(lambda p: p[:, 0], thb)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -312,3 +346,53 @@ class TestThbSpline:
         spline = THBSpline(thb, np.zeros(thb.num_active_functions))
         with pytest.raises(ValueError, match="trailing dimension"):
             spline.evaluate(np.array([[0.1]]))
+
+    def test_stale_grid_raises_on_evaluate(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            spline.evaluate(np.array([[0.5]]))
+
+    def test_bad_coeffs_ndim_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="1-D or 2-D"):
+            THBSpline(thb, np.zeros((thb.num_active_functions, 2, 2)))
+
+    def test_bad_coeffs_2d_leading_dim_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="leading dimension"):
+            THBSpline(thb, np.zeros((thb.num_active_functions + 1, 2)))
+
+    def test_coeffs_readonly(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.ones(thb.num_active_functions))
+        with pytest.raises(ValueError, match="read-only"):
+            spline.coeffs[:] = 0.0
+
+    def test_vector_coeffs_readonly(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.ones((thb.num_active_functions, 2)))
+        with pytest.raises(ValueError, match="read-only"):
+            spline.coeffs[:] = 0.0
+
+    def test_evaluate_vector_refined_2d(self) -> None:
+        # Vector-valued evaluate on a refined 2D grid exercises the full
+        # multi-level dofs → active_basis → tabulate_basis → matmul path.
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [3, 3])
+        thb = THBSplineSpace(_root_2d(), grid)
+        rng = np.random.default_rng(7)
+        coeffs = rng.standard_normal((thb.num_active_functions, 2))
+        spline = THBSpline(thb, coeffs)
+        pts = _sample(2, 5)
+        got = np.asarray(spline.evaluate(pts))
+        assert got.shape == (pts.shape[0], 2)
+        # Verify against manual assembly.
+        for i, p in enumerate(pts):
+            cid = thb.grid.locate(p)
+            assert cid is not None
+            dofs = thb.active_basis(cid)
+            expected = thb.tabulate_basis(cid, p.reshape(1, -1))[0] @ coeffs[dofs]
+            np.testing.assert_allclose(got[i], expected, atol=1e-13)

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -1,0 +1,314 @@
+"""Tests for B-spline and THB quasi-interpolation (Lee-Lyche-Mørken / Speleers-Manni)."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    THBSpline,
+    THBSplineSpace,
+    create_uniform_space,
+    quasi_interpolate_bspline,
+    quasi_interpolate_thb_spline,
+)
+from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _root_1d() -> BsplineSpace:
+    return BsplineSpace([BsplineSpace1D(_KNOTS_DEG2_4, 2)])
+
+
+def _root_2d() -> BsplineSpace:
+    sp = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+    return BsplineSpace([sp, sp])
+
+
+def _grid_1d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+
+
+def _grid_2d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+
+
+def _sample(dim: int, n: int = 9) -> npt.NDArray[np.float64]:
+    """Interior sample points in (0,1)^dim."""
+    u = np.linspace(0.05, 0.95, n)
+    mesh = np.meshgrid(*[u] * dim, indexing="ij")
+    return np.stack([m.ravel() for m in mesh], axis=-1)
+
+
+def _thb_reproduction_error(thb: THBSplineSpace, seed: int = 0) -> float:
+    """QI of a random THB spline recovers its coefficients."""
+    rng = np.random.default_rng(seed)
+    coeffs = rng.standard_normal(thb.num_active_functions)
+    f = THBSpline(thb, coeffs)
+    recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
+    return float(np.abs(recovered.coeffs - coeffs).max())
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tensor-product quasi-interpolation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestTensorProductQI:
+    """quasi_interpolate_bspline: polynomial reproduction and projector property."""
+
+    @pytest.mark.parametrize("power", [0, 1, 2])
+    def test_reproduces_monomials_1d(self, power: int) -> None:
+        sp = _root_1d()
+        qi = quasi_interpolate_bspline(lambda p: p[:, 0] ** power, sp)
+        xs = np.linspace(0.0, 1.0, 23)
+        got = np.asarray(qi.evaluate(xs)).ravel()
+        np.testing.assert_allclose(got, xs**power, atol=1e-12)
+
+    def test_reproduces_polynomial_2d(self) -> None:
+        sp = _root_2d()
+        qi = quasi_interpolate_bspline(lambda p: p[:, 0] ** 2 + p[:, 0] * p[:, 1], sp)
+        pts = _sample(2)
+        got = np.asarray(qi.evaluate(pts)).ravel()
+        np.testing.assert_allclose(got, pts[:, 0] ** 2 + pts[:, 0] * pts[:, 1], atol=1e-12)
+
+    def test_projector_reproduces_arbitrary_spline(self) -> None:
+        # Q B_j = B_j: a spline drawn from the space is reproduced exactly.
+        sp = _root_2d()
+        rng = np.random.default_rng(1)
+        cp = rng.standard_normal(sp.num_total_basis)
+        spline = Bspline(sp, cp.reshape(*sp.num_basis, 1).astype(sp.dtype))
+        qi = quasi_interpolate_bspline(lambda p: np.asarray(spline.evaluate(p)).ravel(), sp)
+        np.testing.assert_allclose(qi.control_points.ravel(), cp, atol=1e-11)
+
+    def test_vector_valued(self) -> None:
+        sp = _root_1d()
+        qi = quasi_interpolate_bspline(lambda p: np.stack([p[:, 0], p[:, 0] ** 2], axis=-1), sp)
+        assert qi.rank == 2
+        xs = np.linspace(0.0, 1.0, 11)
+        got = np.asarray(qi.evaluate(xs))
+        np.testing.assert_allclose(got[:, 0], xs, atol=1e-12)
+        np.testing.assert_allclose(got[:, 1], xs**2, atol=1e-12)
+
+    def test_bad_space_raises(self) -> None:
+        with pytest.raises(TypeError, match="BsplineSpace"):
+            quasi_interpolate_bspline(lambda p: p[:, 0], object())  # type: ignore[arg-type]
+
+    def test_bad_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="kind"):
+            quasi_interpolate_bspline(lambda p: p[:, 0], _root_1d(), kind="nope")  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Hierarchical quasi-interpolation — exact reproduction (THB)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestThbReproduction:
+    """Speleers-Manni: the THB QI reproduces any THB spline to machine precision."""
+
+    def test_unrefined(self) -> None:
+        assert _thb_reproduction_error(THBSplineSpace(_root_1d(), _grid_1d())) < 1e-10
+
+    def test_1d_two_levels(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        assert _thb_reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
+
+    def test_1d_three_levels(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        grid.refine(1, [0], [2])
+        assert _thb_reproduction_error(THBSplineSpace(_root_1d(), grid)) < 1e-10
+
+    def test_2d_corner(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        assert _thb_reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
+
+    def test_2d_three_levels(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [3, 3])
+        grid.refine(1, [2, 2], [6, 6])
+        assert _thb_reproduction_error(THBSplineSpace(_root_2d(), grid)) < 1e-10
+
+    def test_narrow_band_1d(self) -> None:
+        # Single-cell-wide multi-level band: exercises the leaf-cell / truncation path.
+        grid = _grid_1d()
+        grid.refine(0, [1], [2])
+        grid.refine(1, [2], [3])
+        thb = THBSplineSpace(_root_1d(), grid)
+        assert thb.num_levels == 3
+        assert _thb_reproduction_error(thb) < 1e-10
+
+    def test_narrow_band_2d(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [1, 1], [2, 2])
+        grid.refine(1, [2, 2], [3, 3])
+        thb = THBSplineSpace(_root_2d(), grid)
+        assert thb.num_levels == 3
+        assert _thb_reproduction_error(thb) < 1e-10
+
+    def test_reproduces_polynomials_1d(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        qi = quasi_interpolate_thb_spline(lambda p: 1.0 - 2.0 * p[:, 0] + 3.0 * p[:, 0] ** 2, thb)
+        xs = _sample(1)
+        exact = 1.0 - 2.0 * xs[:, 0] + 3.0 * xs[:, 0] ** 2
+        np.testing.assert_allclose(np.asarray(qi.evaluate(xs)).ravel(), exact, atol=1e-10)
+
+    def test_reproduces_polynomials_2d(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(_root_2d(), grid)
+        qi = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2 + p[:, 0] * p[:, 1] + 1.0, thb)
+        pts = _sample(2)
+        exact = pts[:, 0] ** 2 + pts[:, 0] * pts[:, 1] + 1.0
+        np.testing.assert_allclose(np.asarray(qi.evaluate(pts)).ravel(), exact, atol=1e-10)
+
+    def test_vector_valued(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        rng = np.random.default_rng(3)
+        coeffs = rng.standard_normal((thb.num_active_functions, 2))
+        f = THBSpline(thb, coeffs)
+        recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
+        assert recovered.rank == 2
+        np.testing.assert_allclose(recovered.coeffs, coeffs, atol=1e-10)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Convergence smoke + TP consistency
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestConvergence:
+    """Optimal approximation order on a smooth function; TP/THB consistency."""
+
+    def test_order_p_plus_one_1d(self) -> None:
+        def f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.sin(2.0 * np.pi * p[:, 0])
+
+        xs = np.linspace(0.0, 1.0, 401)
+        errs = []
+        for n in (8, 16, 32):
+            qi = quasi_interpolate_bspline(f, create_uniform_space([2], [n]))
+            got = np.asarray(qi.evaluate(xs)).ravel()
+            errs.append(np.abs(got - np.sin(2.0 * np.pi * xs)).max())
+        orders = [np.log2(errs[i] / errs[i + 1]) for i in range(len(errs) - 1)]
+        # degree-2 LLM projector: expect order ≈ 3; assert comfortably super-quadratic.
+        assert min(orders) > 2.5
+
+    def test_unrefined_thb_matches_tp(self) -> None:
+        def f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.cos(3.0 * p[:, 0])
+
+        root = _root_1d()
+        tp = quasi_interpolate_bspline(f, root)
+        thb = quasi_interpolate_thb_spline(f, THBSplineSpace(root, _grid_1d()))
+        np.testing.assert_allclose(thb.coeffs, tp.control_points.ravel(), atol=1e-12)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Non-truncated (HB) basis
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestHb:
+    """truncate=False: exact only on an unrefined grid; otherwise a valid local op."""
+
+    def test_unrefined_hb_equals_thb(self) -> None:
+        # With no finer levels HB == THB, so reproduction still holds.
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        assert _thb_reproduction_error(thb) < 1e-10
+
+    def test_refined_hb_runs(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        qi = quasi_interpolate_thb_spline(lambda p: np.sin(p[:, 0]), thb)
+        assert qi.coeffs.shape == (thb.num_active_functions,)
+        assert np.all(np.isfinite(qi.coeffs))
+
+    def test_bad_space_raises(self) -> None:
+        with pytest.raises(TypeError, match="THBSplineSpace"):
+            quasi_interpolate_thb_spline(lambda p: p[:, 0], _root_1d())  # type: ignore[arg-type]
+
+    def test_bad_kind_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="kind"):
+            quasi_interpolate_thb_spline(lambda p: p[:, 0], thb, kind="nope")  # type: ignore[arg-type]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# THBSpline wrapper
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestThbSpline:
+    """The evaluable THB spline function."""
+
+    def test_evaluate_matches_manual_assembly(self) -> None:
+        thb = THBSplineSpace(_root_2d(), _grid_2d())
+        rng = np.random.default_rng(5)
+        coeffs = rng.standard_normal(thb.num_active_functions)
+        spline = THBSpline(thb, coeffs)
+        pts = _sample(2, 5)
+        got = np.asarray(spline.evaluate(pts)).ravel()
+        manual = np.empty(pts.shape[0])
+        for i, p in enumerate(pts):
+            cid = thb.grid.locate(p)
+            assert cid is not None
+            dofs = thb.active_basis(cid)
+            manual[i] = thb.tabulate_basis(cid, p.reshape(1, -1))[0] @ coeffs[dofs]
+        np.testing.assert_allclose(got, manual, atol=1e-13)
+
+    def test_properties_and_repr(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        assert spline.space is thb
+        assert spline.dim == 1
+        assert spline.rank == 1
+        assert spline.dtype == np.float64
+        assert spline.coeffs.shape == (thb.num_active_functions,)
+        assert "THBSpline" in repr(spline)
+
+    def test_vector_coeffs_shape(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.zeros((thb.num_active_functions, 3)))
+        assert spline.rank == 3
+        assert spline.coeffs.shape == (thb.num_active_functions, 3)
+        xs = np.array([[0.1], [0.9]])
+        assert np.asarray(spline.evaluate(xs)).shape == (2, 3)
+
+    def test_non_thb_space_raises(self) -> None:
+        with pytest.raises(TypeError, match="THBSplineSpace"):
+            THBSpline(_root_1d(), np.zeros(9))  # type: ignore[arg-type]
+
+    def test_bad_coeffs_length_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(ValueError, match="length"):
+            THBSpline(thb, np.zeros(thb.num_active_functions + 1))
+
+    def test_out_of_domain_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        with pytest.raises(ValueError, match="outside"):
+            spline.evaluate(np.array([[2.0]]))
+
+    def test_wrong_trailing_dim_raises(self) -> None:
+        thb = THBSplineSpace(_root_2d(), _grid_2d())
+        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        with pytest.raises(ValueError, match="trailing dimension"):
+            spline.evaluate(np.array([[0.1]]))


### PR DESCRIPTION
## Summary

PR7 of the THB-splines feature (#164): **quasi-interpolation**, turning a callable
`f` into B-spline / THB coefficients, following Speleers–Manni 2016 ("Effortless
quasi-interpolation in hierarchical spaces").

New public API in `pantr.bspline`:

- **`quasi_interpolate_bspline(func, space, *, kind="llm") -> Bspline`** — a
  Lee–Lyche–Mørken local projector for tensor-product spaces: per basis function,
  a local point-value functional `λ_β(f)=Σ_k a_{β,k} f(x_{β,k})` from inverting a
  small collocation block. Reproduces the spline space (`Q B_β = B_β`); optimal
  order `p+1`.
- **`quasi_interpolate_thb_spline(func, space, *, kind="llm") -> THBSpline`** — the
  "effortless" hierarchical assembly: each active dof gets its per-level QI
  coefficient, sampled on a **level-`ℓ` active leaf cell** inside the function's
  support. On such a cell truncation zeros every coarser active function's
  component on the active `B^ℓ_β`, so for the truncated (THB) basis the QI
  **reproduces any THB spline exactly**.
- **`THBSpline(space, coeffs)`** — an evaluable THB spline function, the
  hierarchical analogue of `Bspline` (scalar and vector-valued).

`kind` is pluggable (only `"llm"` today). `func` is sampled on scattered local
points (a flat `(M, dim)` array), unlike the lattice-based
`interpolate_bspline`/`l2_project_bspline`.

## Test plan
- [x] TP: polynomial reproduction (1D/2D), projector `Q B_j = B_j`, vector-valued
- [x] THB exact reproduction of random THB splines — 1D/2D, multi-level, narrow
  single-cell band (the leaf-cell/truncation path) ~1e-10
- [x] THB polynomial reproduction; order-`p+1` convergence smoke; TP/THB consistency
- [x] `THBSpline.evaluate` vs manual assembly; out-of-domain / validation paths
- [x] full suite (3021 passed), ruff, ruff-format, mypy, docs (-W)

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)