### PR TITLE
test(bspline): paper-reproduction validation suite for THB-splines (PR8 of #164)

### DIFF
--- a/tests/_thb_assembly.py
+++ b/tests/_thb_assembly.py
@@ -48,7 +48,9 @@ def _assemble(
             ``(n_pts, dim)`` point array and returning ``(n_pts,)``.  If ``None``,
             the returned load vector is zero.
         n_quad (int | None): Gauss points per direction.  ``None`` uses
-            ``max(degrees) + 1`` (exact for the degree-``2p`` mass products).
+            ``max(degrees) + 1``, exact for the per-cell degree-``2p`` mass products
+            when all degrees are equal (each active function is degree ``p`` on a leaf
+            cell, so a ``p + 1``-point rule is exact to degree ``2p + 1``).
 
     Returns:
         tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(M, b)`` of shapes
@@ -83,7 +85,9 @@ def gram_matrix(thb: THBSplineSpace, *, n_quad: int | None = None) -> npt.NDArra
             ``max(degrees) + 1``.
 
     Returns:
-        npt.NDArray[np.float64]: SPD matrix of shape ``(num_active, num_active)``.
+        npt.NDArray[np.float64]: Symmetric matrix of shape ``(num_active, num_active)``;
+        positive definite for the linearly independent THB basis, only positive
+        semidefinite for a non-truncated HB basis.
     """
     return _assemble(thb, None, n_quad)[0]
 

--- a/tests/_thb_assembly.py
+++ b/tests/_thb_assembly.py
@@ -1,0 +1,148 @@
+"""Test-only THB assembly helpers for the paper-reproduction validation suite.
+
+This module is **not** part of the public ``pantr`` API and is intentionally
+underscore-prefixed so pytest does not collect it as a test module.  It provides the
+global cell-by-cell mass-matrix assembly and L2 projection that the THB validation
+suite needs.  The hierarchical basis is not tensor-product, so (unlike
+:func:`pantr.bspline.l2_project_bspline`, which is a pure Kronecker solve) the mass
+matrix has no separable structure and must be assembled by looping over the active
+leaf cells — the FEM-style assembly deliberately kept out of the library (#152 Q0).
+
+Functions:
+
+- :func:`gram_matrix`: the global mass/Gram matrix ``M[i,j] = ∫ φ_i φ_j``.
+- :func:`l2_project_thb`: the L2 best approximation of a callable as a
+  :class:`~pantr.bspline.THBSpline`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr.bspline import THBSpline, THBSplineSpace
+from pantr.grid import cell_quadrature
+from pantr.quad import gauss_legendre_quadrature
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _assemble(
+    thb: THBSplineSpace,
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike] | None,
+    n_quad: int | None,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Assemble the global mass matrix and (optionally) the load vector.
+
+    Loops over the active leaf cells, mapping a Gauss-Legendre rule onto each via
+    :func:`pantr.grid.cell_quadrature` (volume-scaled weights) and scattering the
+    local ``(K, K)`` block ``φᵀ W φ`` into the global matrix using the cell's
+    :meth:`~pantr.bspline.THBSplineSpace.active_basis` dofs.
+
+    Args:
+        thb (THBSplineSpace): The hierarchical space.
+        func (Callable | None): Scalar integrand for the load vector, called on an
+            ``(n_pts, dim)`` point array and returning ``(n_pts,)``.  If ``None``,
+            the returned load vector is zero.
+        n_quad (int | None): Gauss points per direction.  ``None`` uses
+            ``max(degrees) + 1`` (exact for the degree-``2p`` mass products).
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(M, b)`` of shapes
+        ``(num_active, num_active)`` and ``(num_active,)``.
+    """
+    dim = thb.dim
+    n = thb.num_active_functions
+    nq = max(thb.degrees) + 1 if n_quad is None else n_quad
+    rule = gauss_legendre_quadrature(dim, nq)
+    pts_all, wts_all = cell_quadrature(thb.grid, rule)
+
+    mass = np.zeros((n, n), dtype=np.float64)
+    load = np.zeros(n, dtype=np.float64)
+    for cid in range(thb.grid.num_cells):
+        pts = np.ascontiguousarray(pts_all[cid], dtype=np.float64)
+        wts = np.asarray(wts_all[cid], dtype=np.float64)
+        vals = np.asarray(thb.tabulate_basis(cid, pts), dtype=np.float64)
+        dofs = thb.active_basis(cid)
+        mass[np.ix_(dofs, dofs)] += vals.T @ (vals * wts[:, None])
+        if func is not None:
+            fvals = np.asarray(func(pts), dtype=np.float64).reshape(pts.shape[0])
+            load[dofs] += vals.T @ (wts * fvals)
+    return mass, load
+
+
+def gram_matrix(thb: THBSplineSpace, *, n_quad: int | None = None) -> npt.NDArray[np.float64]:
+    """Return the global Gram (mass) matrix ``M[i, j] = ∫ φ_i φ_j``.
+
+    Args:
+        thb (THBSplineSpace): The hierarchical space.
+        n_quad (int | None): Gauss points per direction.  Defaults to
+            ``max(degrees) + 1``.
+
+    Returns:
+        npt.NDArray[np.float64]: SPD matrix of shape ``(num_active, num_active)``.
+    """
+    return _assemble(thb, None, n_quad)[0]
+
+
+def l2_project_thb(
+    thb: THBSplineSpace,
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    *,
+    n_quad: int | None = None,
+) -> THBSpline:
+    """Return the L2 best approximation of ``func`` in the THB space.
+
+    Assembles the global mass matrix ``M`` and load ``b = ∫ f φ_i`` and solves
+    ``M c = b`` (numpy direct solve; ``M`` is SPD for the linearly independent THB
+    basis).
+
+    Args:
+        thb (THBSplineSpace): The hierarchical space.
+        func (Callable): Scalar function, called on an ``(n_pts, dim)`` point array
+            and returning ``(n_pts,)``.
+        n_quad (int | None): Gauss points per direction.  Defaults to
+            ``max(degrees) + 1``.
+
+    Returns:
+        THBSpline: The L2 projection of ``func``.
+    """
+    mass, load = _assemble(thb, func, n_quad)
+    coeffs = np.asarray(np.linalg.solve(mass, load), dtype=np.float64)
+    return THBSpline(thb, coeffs)
+
+
+def l2_error(
+    spline: THBSpline,
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    *,
+    n_quad: int | None = None,
+) -> float:
+    """Return the L2 error ``sqrt(∫ (func - spline)^2)`` over the hierarchical domain.
+
+    Args:
+        spline (THBSpline): The (scalar) approximation.
+        func (Callable): The exact function, called on an ``(n_pts, dim)`` point array
+            and returning ``(n_pts,)``.
+        n_quad (int | None): Gauss points per direction.  Defaults to
+            ``max(degrees) + 3`` (a few extra to resolve a smooth ``func``).
+
+    Returns:
+        float: The L2 error.
+    """
+    thb = spline.space
+    nq = max(thb.degrees) + 3 if n_quad is None else n_quad
+    rule = gauss_legendre_quadrature(thb.dim, nq)
+    pts_all, wts_all = cell_quadrature(thb.grid, rule)
+    err_sq = 0.0
+    for cid in range(thb.grid.num_cells):
+        pts = np.ascontiguousarray(pts_all[cid], dtype=np.float64)
+        wts = np.asarray(wts_all[cid], dtype=np.float64)
+        diff = np.asarray(func(pts), dtype=np.float64).reshape(pts.shape[0]) - np.asarray(
+            spline.evaluate(pts), dtype=np.float64
+        ).reshape(pts.shape[0])
+        err_sq += float(np.sum(wts * diff**2))
+    return float(np.sqrt(err_sq))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
-"""Pytest configuration to make `src` importable without installing the package."""
+"""Pytest configuration: make `src` and the repository root importable.
+
+`src` is added so the package resolves without installation; the repository root is
+added so test modules can import shared, non-collected helpers via the ``tests``
+namespace package (e.g. ``from tests._thb_assembly import ...``).
+"""
 
 from __future__ import annotations
 
@@ -6,12 +11,12 @@ import sys
 from pathlib import Path
 
 
-def _ensure_src_on_sys_path() -> None:
-    """Prepend the repository `src` directory to `sys.path` if missing."""
+def _ensure_on_sys_path() -> None:
+    """Prepend the repository `src` directory and the repository root to `sys.path`."""
     repo_root: Path = Path(__file__).resolve().parents[1]
-    src_path: Path = repo_root / "src"
-    if str(src_path) not in sys.path:
-        sys.path.insert(0, str(src_path))
+    for path in (str(repo_root / "src"), str(repo_root)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
 
 
-_ensure_src_on_sys_path()
+_ensure_on_sys_path()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 """Pytest configuration: make `src` and the repository root importable.
 
-`src` is added so the package resolves without installation; the repository root is
-added so test modules can import shared, non-collected helpers via the ``tests``
-namespace package (e.g. ``from tests._thb_assembly import ...``).
+`src` is added so the package resolves without installation.  The repository root is
+added so test modules can import shared, non-collected helpers from the regular
+``tests`` package (e.g. ``from tests._thb_assembly import ...``); under pytest this
+already resolves via ``rootdir``, so the addition is a belt-and-suspenders guard for
+direct (non-pytest) invocation.
 """
 
 from __future__ import annotations

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -132,7 +132,7 @@ class TestPreservationAndReproduction:
             return np.asarray(sum(pcoeffs[k] * p[:, 0] ** k for k in range(degree + 1)))
 
         proj = l2_project_thb(thb, poly)
-        xs = np.linspace(0.02, 0.98, 60).reshape(-1, 1)
+        xs = np.linspace(0.02, 0.98, 60).reshape(-1, 1).astype(np.float64)
         np.testing.assert_allclose(proj.evaluate(xs).ravel(), poly(xs), atol=1e-9)
 
     def test_qi_reproduces_polynomial_2d(self) -> None:

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -1,0 +1,149 @@
+"""Validation suite — group 1: THB basis properties (Giannelli-Jüttler-Speleers 2012).
+
+Reproduces the defining basis properties of the truncated hierarchical B-spline basis:
+nonnegativity, partition of unity, linear independence + strong stability (the Gram
+matrix is SPD with full rank and a condition number that stays bounded under refinement),
+and preservation of coefficients / coarse reproduction.  Properties are reproduced, not
+exact published magnitudes (#164, PR8).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    THBSplineSpace,
+    create_uniform_space,
+    quasi_interpolate_thb_spline,
+)
+from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
+from tests._thb_assembly import gram_matrix, l2_project_thb
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _root_1d() -> BsplineSpace:
+    return BsplineSpace([BsplineSpace1D(_KNOTS_DEG2_4, 2)])
+
+
+def _root_2d() -> BsplineSpace:
+    sp = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+    return BsplineSpace([sp, sp])
+
+
+def _grid_1d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+
+
+def _grid_2d() -> HierarchicalGrid:
+    return hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+
+
+def _cell_samples(thb: THBSplineSpace, n: int = 4) -> list[tuple[int, npt.NDArray[np.float64]]]:
+    """Interior sample points per active cell as ``(cid, pts)`` pairs."""
+    out: list[tuple[int, npt.NDArray[np.float64]]] = []
+    u = np.linspace(0.0, 1.0, n + 2)[1:-1]
+    for cid in range(thb.grid.num_cells):
+        lo, hi = thb.grid.cell_bounds(cid)
+        axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(thb.dim)]
+        mesh = np.meshgrid(*axes, indexing="ij")
+        out.append((cid, np.stack([m.ravel() for m in mesh], axis=-1)))
+    return out
+
+
+class TestNonnegativityAndPartitionOfUnity:
+    """THB functions are nonnegative and form a partition of unity."""
+
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_nonnegative(self, dim: int) -> None:
+        root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
+        grid.refine(0, [0] * dim, [2] * dim)
+        thb = THBSplineSpace(root, grid)
+        for cid, pts in _cell_samples(thb):
+            assert thb.tabulate_basis(cid, pts).min() >= -1e-13
+
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_partition_of_unity(self, dim: int) -> None:
+        root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
+        grid.refine(0, [0] * dim, [2] * dim)
+        thb = THBSplineSpace(root, grid)
+        for cid, pts in _cell_samples(thb):
+            np.testing.assert_allclose(thb.tabulate_basis(cid, pts).sum(axis=-1), 1.0, atol=1e-12)
+
+    def test_hb_is_not_partition_of_unity(self) -> None:
+        # Truncation is what restores PoU; the non-truncated basis over-counts.
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        hb = THBSplineSpace(_root_1d(), grid, truncate=False)
+        worst = 0.0
+        for cid, pts in _cell_samples(hb):
+            worst = max(worst, float(np.abs(hb.tabulate_basis(cid, pts).sum(axis=-1) - 1.0).max()))
+        assert worst > 1e-3
+
+
+class TestLinearIndependenceAndStability:
+    """The THB basis is linearly independent and strongly stable."""
+
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_gram_is_spd_full_rank(self, dim: int) -> None:
+        root, grid = (_root_1d(), _grid_1d()) if dim == 1 else (_root_2d(), _grid_2d())
+        grid.refine(0, [0] * dim, [2] * dim)
+        thb = THBSplineSpace(root, grid)
+        mass = gram_matrix(thb)
+        np.testing.assert_allclose(mass, mass.T, atol=1e-14)
+        eig = np.linalg.eigvalsh(mass)
+        # Strictly positive spectrum ⇒ linearly independent basis (full rank).
+        assert eig.min() > 0.0
+        assert np.linalg.matrix_rank(mass) == thb.num_active_functions
+
+    def test_condition_number_bounded_under_refinement(self) -> None:
+        # Strong stability: the mesh-normalized Gram condition number does not blow up
+        # as the hierarchy deepens.  Normalize by the diagonal (mass scales like the
+        # cell size) so the bound is level-independent.  Successively deeper central
+        # refinement bands.
+        grids = [_grid_1d(), _grid_1d(), _grid_1d()]
+        grids[1].refine(0, [1], [3])
+        grids[2].refine(0, [1], [3])
+        grids[2].refine(1, [3], [5])
+        conds: list[float] = []
+        for grid in grids:
+            mass = gram_matrix(THBSplineSpace(_root_1d(), grid))
+            d = np.sqrt(np.diag(mass))
+            conds.append(float(np.linalg.cond(mass / np.outer(d, d))))
+        assert max(conds) < 1e3
+
+
+class TestPreservationAndReproduction:
+    """Coarse reproduction: V_0 functions/polynomials are reproduced exactly."""
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_l2_reproduces_polynomials_1d(self, degree: int) -> None:
+        root = create_uniform_space([degree], [5])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 5), 2)
+        grid.refine(0, [1], [3])
+        thb = THBSplineSpace(root, grid)
+        pcoeffs = np.random.default_rng(degree).standard_normal(degree + 1)
+
+        def poly(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(sum(pcoeffs[k] * p[:, 0] ** k for k in range(degree + 1)))
+
+        proj = l2_project_thb(thb, poly)
+        xs = np.linspace(0.02, 0.98, 60).reshape(-1, 1)
+        np.testing.assert_allclose(proj.evaluate(xs).ravel(), poly(xs), atol=1e-9)
+
+    def test_qi_reproduces_polynomial_2d(self) -> None:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        thb = THBSplineSpace(_root_2d(), grid)
+
+        def poly(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(p[:, 0] ** 2 + p[:, 0] * p[:, 1] + 1.0)
+
+        qi = quasi_interpolate_thb_spline(poly, thb)
+        u = np.linspace(0.05, 0.95, 7)
+        pts = np.stack([m.ravel() for m in np.meshgrid(u, u, indexing="ij")], axis=-1)
+        np.testing.assert_allclose(qi.evaluate(pts).ravel(), poly(pts), atol=1e-10)

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -1,10 +1,18 @@
-"""Validation suite — group 1: THB basis properties (Giannelli-Jüttler-Speleers 2012).
+"""Validation suite — group 1: THB basis properties.
 
 Reproduces the defining basis properties of the truncated hierarchical B-spline basis:
-nonnegativity, partition of unity, linear independence + strong stability (the Gram
-matrix is SPD with full rank and a condition number that stays bounded under refinement),
-and preservation of coefficients / coarse reproduction.  Properties are reproduced, not
-exact published magnitudes (#164, PR8).
+
+- nonnegativity, partition of unity, and linear independence (Giannelli-Jüttler-Speleers
+  2012, Thms 6 and 10 — the truncated basis is a convex partition of unity and linearly
+  independent);
+- strong stability — the mesh-normalized Gram condition number stays bounded under
+  refinement.  GJS 2012 leaves a stability analysis to future work; the strong-stability
+  result is Giannelli-Jüttler-Speleers 2014, *Strongly stable bases for adaptively
+  refined multilevel spline spaces* (Adv. Comput. Math. 40);
+- coarse reproduction — a polynomial in the coarse space is reproduced exactly.
+
+Properties (orders/qualitative behaviour) are reproduced, not exact published magnitudes
+(#164, PR8).
 """
 
 from __future__ import annotations
@@ -101,20 +109,32 @@ class TestLinearIndependenceAndStability:
         assert np.linalg.matrix_rank(mass) == thb.num_active_functions
 
     def test_condition_number_bounded_under_refinement(self) -> None:
-        # Strong stability: the mesh-normalized Gram condition number does not blow up
-        # as the hierarchy deepens.  Normalize by the diagonal (mass scales like the
-        # cell size) so the bound is level-independent.  Successively deeper central
-        # refinement bands.
-        grids = [_grid_1d(), _grid_1d(), _grid_1d()]
-        grids[1].refine(0, [1], [3])
-        grids[2].refine(0, [1], [3])
-        grids[2].refine(1, [3], [5])
+        # Strong stability (GJS 2014, not 2012): the mesh-normalized Gram condition
+        # number stays bounded as the hierarchy deepens.  Normalize by the diagonal
+        # (a diagonal mass entry scales like the cell volume, h**dim) so the bound is
+        # level-independent.  Successively deeper nested central refinement bands.
+        refine_chains: list[list[tuple[int, list[int], list[int]]]] = [
+            [],
+            [(0, [1], [3])],
+            [(0, [1], [3]), (1, [3], [5])],
+            [(0, [1], [3]), (1, [3], [5]), (2, [7], [9])],
+            [(0, [1], [3]), (1, [3], [5]), (2, [7], [9]), (3, [15], [17])],
+        ]
         conds: list[float] = []
-        for grid in grids:
+        for chain in refine_chains:
+            grid = _grid_1d()
+            for level, lo, hi in chain:
+                grid.refine(level, lo, hi)
             mass = gram_matrix(THBSplineSpace(_root_1d(), grid))
             d = np.sqrt(np.diag(mass))
             conds.append(float(np.linalg.cond(mass / np.outer(d, d))))
-        assert max(conds) < 1e3
+        # Bounded (not merely finite): a regression that doubled the condition number
+        # per level would breach this within a few levels.
+        assert max(conds) < 50.0
+        # Plateauing: each added level contributes less than the previous one, i.e. the
+        # condition number converges rather than growing without bound.
+        increments = [conds[i + 1] - conds[i] for i in range(len(conds) - 1)]
+        assert all(increments[i + 1] < increments[i] for i in range(len(increments) - 1))
 
 
 class TestPreservationAndReproduction:
@@ -147,3 +167,34 @@ class TestPreservationAndReproduction:
         u = np.linspace(0.05, 0.95, 7)
         pts = np.stack([m.ravel() for m in np.meshgrid(u, u, indexing="ij")], axis=-1)
         np.testing.assert_allclose(qi.evaluate(pts).ravel(), poly(pts), atol=1e-10)
+
+
+class TestDerivativeReproduction:
+    """The truncated basis differentiates exactly.
+
+    The derivative of a reproduced polynomial matches the analytic derivative (exercises
+    ``tabulate_basis_derivatives`` on the truncated path).
+    """
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_first_derivative_of_polynomial_1d(self, degree: int) -> None:
+        root = create_uniform_space([degree], [6])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 6), 2)
+        grid.refine(0, [1], [4])  # partial refinement => truncated functions present
+        thb = THBSplineSpace(root, grid)
+        pcoeffs = np.random.default_rng(degree).standard_normal(degree + 1)
+
+        def poly(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(sum(pcoeffs[k] * p[:, 0] ** k for k in range(degree + 1)))
+
+        def dpoly(x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(sum(k * pcoeffs[k] * x ** (k - 1) for k in range(1, degree + 1)))
+
+        coeffs = l2_project_thb(thb, poly).coeffs
+        xi = np.linspace(0.1, 0.9, 5)
+        for cid in range(thb.grid.num_cells):
+            lo, hi = thb.grid.cell_bounds(cid)
+            x = (lo[0] + (hi[0] - lo[0]) * xi).reshape(-1, 1)
+            dofs = thb.active_basis(cid)
+            got = thb.tabulate_basis_derivatives(cid, x, 1) @ coeffs[dofs]
+            np.testing.assert_allclose(got, dpoly(x[:, 0]), atol=1e-11)

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -162,7 +162,7 @@ class TestCoarseningProjection:
 
         c_fine = l2_project_thb(fine, quad).coeffs
         c_back = fine.restriction_to(coarse) @ c_fine
-        xs = np.linspace(0.02, 0.98, 80).reshape(-1, 1)
+        xs = np.linspace(0.02, 0.98, 80).reshape(-1, 1).astype(np.float64)
         np.testing.assert_allclose(
             THBSpline(coarse, c_back).evaluate(xs).ravel(), quad(xs), atol=1e-8
         )

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -1,0 +1,140 @@
+"""Validation suite — group 4: cross-operator algebraic identities.
+
+End-to-end identities that tie several THB operators together (the per-operator
+identities themselves are covered in the feature-PR tests: ``test_thb_spline_space.py``
+for refinement/prolongation/coarsening, ``test_multilevel_extraction.py`` for Bézier
+extraction, ``test_quasi_interpolation.py`` for quasi-interpolation):
+
+- refinement **nesting** ``V_H ⊂ V_h``: a coarse THB field prolonged to a finer THB
+  space evaluates identically (via the public :class:`~pantr.bspline.THBSpline`);
+- **coarsening = exact left-inverse** of refinement: ``restriction ∘ prolongation == I``;
+- **Bézier reconstruction integrated with L2**: the per-cell multi-level extraction
+  reconstructs an L2-projected field from its Bernstein control values.
+
+(#164, PR8.)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr.basis import tabulate_bernstein
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    MultiLevelExtraction,
+    THBSpline,
+    THBSplineSpace,
+)
+from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from tests._thb_assembly import l2_project_thb
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _root_1d() -> BsplineSpace:
+    return BsplineSpace([BsplineSpace1D(_KNOTS_DEG2_4, 2)])
+
+
+def _root_2d() -> BsplineSpace:
+    sp = BsplineSpace1D(_KNOTS_DEG2_4, 2)
+    return BsplineSpace([sp, sp])
+
+
+class TestRefinementNesting:
+    """V_H ⊂ V_h: a coarse THB field is reproduced exactly on a finer THB space."""
+
+    def test_prolongation_reproduces_field(self) -> None:
+        coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        coarse_grid.refine(0, [1], [3])
+        coarse = THBSplineSpace(_root_1d(), coarse_grid)
+
+        fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        fine_grid.refine(0, [1], [3])
+        fine_grid.refine(1, [2], [6])
+        fine = THBSplineSpace(_root_1d(), fine_grid)
+
+        rng = np.random.default_rng(0)
+        c_coarse = rng.standard_normal(coarse.num_active_functions)
+        prolong = coarse.prolongation_to(fine)
+        c_fine = prolong @ c_coarse
+
+        xs = np.linspace(0.02, 0.98, 80).reshape(-1, 1)
+        got = THBSpline(fine, c_fine).evaluate(xs)
+        expected = THBSpline(coarse, c_coarse).evaluate(xs)
+        np.testing.assert_allclose(got, expected, atol=1e-10)
+
+
+class TestCoarseningExactInverse:
+    """restriction ∘ prolongation == I over a refinement chain."""
+
+    def test_restriction_left_inverse(self) -> None:
+        coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+        coarse_grid.refine(0, [0, 0], [2, 2])
+        coarse = THBSplineSpace(_root_2d(), coarse_grid)
+
+        fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+        fine_grid.refine(0, [0, 0], [2, 2])
+        fine_grid.refine(1, [0, 0], [4, 4])
+        fine = THBSplineSpace(_root_2d(), fine_grid)
+
+        prolong = coarse.prolongation_to(fine)
+        restrict = fine.restriction_to(coarse)
+        identity = restrict @ prolong
+        np.testing.assert_allclose(identity, np.eye(coarse.num_active_functions), atol=1e-9)
+
+
+class TestBezierReconstruction:
+    """Per-cell multi-level Bézier extraction reconstructs an L2-projected field."""
+
+    def _check(
+        self,
+        root: BsplineSpace,
+        grid_factory: Callable[[], HierarchicalGrid],
+        refines: list[tuple[int, list[int], list[int]]],
+    ) -> None:
+        grid = grid_factory()
+        for level, lo_box, hi_box in refines:
+            grid.refine(level, lo_box, hi_box)
+        thb = THBSplineSpace(root, grid)
+
+        def func(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(np.cos(2.0 * p[:, 0]) + (p[:, -1] if thb.dim > 1 else 0.0))
+
+        coeffs = l2_project_thb(thb, func).coeffs
+        spline = THBSpline(thb, coeffs)
+        ext = MultiLevelExtraction(thb)
+        degrees = list(thb.degrees)
+
+        u = np.linspace(0.1, 0.9, 4)
+        xi = np.stack([m.ravel() for m in np.meshgrid(*[u] * thb.dim, indexing="ij")], axis=-1)
+        bern = tabulate_bernstein(degrees, xi)  # (n_pts, n_bernstein)
+        for cid in range(thb.grid.num_cells):
+            dofs = thb.active_basis(cid)
+            # Field on the cell as a Bézier: control values g = Cᵉᵀ c[active].
+            control = ext.operator(cid).T @ coeffs[dofs]
+            from_bezier = bern @ control
+            lo, hi = thb.grid.cell_bounds(cid)
+            x = lo + (hi - lo) * xi
+            np.testing.assert_allclose(from_bezier, spline.evaluate(x), atol=1e-10)
+
+    def test_reconstruction_1d(self) -> None:
+        self._check(
+            _root_1d(),
+            lambda: hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2),
+            [(0, [0], [2]), (1, [0], [2])],
+        )
+
+    def test_reconstruction_2d(self) -> None:
+        self._check(
+            _root_2d(),
+            lambda: hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2),
+            [(0, [0, 0], [2, 2])],
+        )

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -6,20 +6,22 @@ for refinement/prolongation/coarsening, ``test_multilevel_extraction.py`` for B�
 extraction, ``test_quasi_interpolation.py`` for quasi-interpolation):
 
 - refinement **nesting** ``V_H ⊂ V_h``: a coarse THB field prolonged to a finer THB
-  space evaluates identically (via the public :class:`~pantr.bspline.THBSpline`);
-- **coarsening = exact left-inverse** of refinement: ``restriction ∘ prolongation == I``;
+  space evaluates identically (via the public :class:`~pantr.bspline.THBSpline`), and
+  prolongation is **transitive** across a multi-level chain;
+- **coarsening**: ``restriction ∘ prolongation == I`` plus the non-automatic projection
+  behaviour (restriction recovers a ``P``-independent coarse field; ``P ∘ R`` is a lossy
+  idempotent projector);
 - **Bézier reconstruction integrated with L2**: the per-cell multi-level extraction
-  reconstructs an L2-projected field from its Bernstein control values.
+  reconstructs an L2-projected field from its Bernstein control values (degrees 2 and 3).
 
 (#164, PR8.)
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import numpy.typing as npt
+import pytest
 
 from pantr.basis import tabulate_bernstein
 from pantr.bspline import (
@@ -28,12 +30,9 @@ from pantr.bspline import (
     MultiLevelExtraction,
     THBSpline,
     THBSplineSpace,
+    create_uniform_space,
 )
-from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
+from pantr.grid import hierarchical_grid, uniform_grid
 from tests._thb_assembly import l2_project_thb
 
 _KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
@@ -71,9 +70,30 @@ class TestRefinementNesting:
         expected = THBSpline(coarse, c_coarse).evaluate(xs)
         np.testing.assert_allclose(got, expected, atol=1e-10)
 
+    def test_prolongation_transitivity(self) -> None:
+        # P(coarse -> fine) == P(mid -> fine) @ P(coarse -> mid) over a 3-level chain.
+        def space(refines: list[tuple[int, list[int], list[int]]]) -> THBSplineSpace:
+            grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+            for level, lo, hi in refines:
+                grid.refine(level, lo, hi)
+            return THBSplineSpace(_root_1d(), grid)
+
+        coarse = space([(0, [1], [3])])
+        mid = space([(0, [1], [3]), (1, [2], [6])])
+        fine = space([(0, [1], [3]), (1, [2], [6]), (2, [6], [10])])
+
+        direct = coarse.prolongation_to(fine)
+        chained = mid.prolongation_to(fine) @ coarse.prolongation_to(mid)
+        np.testing.assert_allclose(direct, chained, atol=1e-9)
+
 
 class TestCoarseningExactInverse:
-    """restriction ∘ prolongation == I over a refinement chain."""
+    """restriction ∘ prolongation == I over a refinement chain.
+
+    Necessary but weak: ``R := pinv(P)`` left-inverts *any* full-rank ``P``, and the
+    same ``P`` cancels on both sides, so a wrong-but-full-rank prolongation would still
+    pass.  :class:`TestCoarseningProjection` covers the non-automatic behaviour.
+    """
 
     def test_restriction_left_inverse(self) -> None:
         coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
@@ -91,16 +111,105 @@ class TestCoarseningExactInverse:
         np.testing.assert_allclose(identity, np.eye(coarse.num_active_functions), atol=1e-9)
 
 
-class TestBezierReconstruction:
-    """Per-cell multi-level Bézier extraction reconstructs an L2-projected field."""
+class TestCoarseningProjection:
+    """Restriction's coarsening behaviour, beyond the (vacuous) ``R∘P == I`` identity.
 
-    def _check(
-        self,
-        root: BsplineSpace,
-        grid_factory: Callable[[], HierarchicalGrid],
-        refines: list[tuple[int, list[int], list[int]]],
-    ) -> None:
-        grid = grid_factory()
+    ``R := pinv(P)`` left-inverts any full-rank ``P``, so ``R∘P == I`` only exercises
+    numpy's pseudo-inverse — and since the same ``P`` appears on both sides, a faulty
+    prolongation cancels out and stays hidden.  These tests pin the genuinely
+    non-automatic behaviour:
+
+    - restriction recovers a coarse field whose fine representation is built
+      *independently* of ``P`` (L2-projected onto the fine space), so a wrong ``P`` is
+      no longer masked;
+    - ``P∘R`` is a non-trivial idempotent projector onto ``V_coarse ⊂ V_fine`` — i.e.
+      restriction truly discards fine-level detail rather than acting as an embedding.
+    """
+
+    @staticmethod
+    def _nested_1d() -> tuple[THBSplineSpace, THBSplineSpace]:
+        coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        coarse_grid.refine(0, [1], [3])
+        coarse = THBSplineSpace(_root_1d(), coarse_grid)
+
+        fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        fine_grid.refine(0, [1], [3])
+        fine_grid.refine(1, [2], [6])
+        fine = THBSplineSpace(_root_1d(), fine_grid)
+        return coarse, fine
+
+    @staticmethod
+    def _nested_2d() -> tuple[THBSplineSpace, THBSplineSpace]:
+        coarse_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+        coarse_grid.refine(0, [0, 0], [2, 2])
+        coarse = THBSplineSpace(_root_2d(), coarse_grid)
+
+        fine_grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+        fine_grid.refine(0, [0, 0], [2, 2])
+        fine_grid.refine(1, [0, 0], [4, 4])
+        fine = THBSplineSpace(_root_2d(), fine_grid)
+        return coarse, fine
+
+    def test_recovers_independently_built_coarse_field_1d(self) -> None:
+        # A quadratic lives in the (degree-2) coarse span. Build its FINE coefficients
+        # by L2 projection — never touching the prolongation — then coarsen: restriction
+        # must return coarse coefficients that reproduce the quadratic.  A wrong P (which
+        # R∘P == I cannot detect) breaks this, because the fine field is P-independent.
+        coarse, fine = self._nested_1d()
+
+        def quad(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(p[:, 0] ** 2 - 0.3 * p[:, 0] + 0.1)
+
+        c_fine = l2_project_thb(fine, quad).coeffs
+        c_back = fine.restriction_to(coarse) @ c_fine
+        xs = np.linspace(0.02, 0.98, 80).reshape(-1, 1)
+        np.testing.assert_allclose(
+            THBSpline(coarse, c_back).evaluate(xs).ravel(), quad(xs), atol=1e-8
+        )
+
+    def test_recovers_independently_built_coarse_field_2d(self) -> None:
+        coarse, fine = self._nested_2d()
+
+        def quad(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(p[:, 0] ** 2 + p[:, 0] * p[:, 1] - 0.5)
+
+        c_fine = l2_project_thb(fine, quad).coeffs
+        c_back = fine.restriction_to(coarse) @ c_fine
+        u = np.linspace(0.05, 0.95, 7)
+        pts = np.stack([m.ravel() for m in np.meshgrid(u, u, indexing="ij")], axis=-1)
+        np.testing.assert_allclose(
+            THBSpline(coarse, c_back).evaluate(pts).ravel(), quad(pts), atol=1e-8
+        )
+
+    def test_coarsening_is_a_lossy_idempotent_projector(self) -> None:
+        coarse, fine = self._nested_1d()
+        prolong = coarse.prolongation_to(fine)
+        restrict = fine.restriction_to(coarse)
+        proj = prolong @ restrict  # coarsen, then prolong back
+
+        rng = np.random.default_rng(0)
+        u = rng.standard_normal(fine.num_active_functions)
+        # Genuine coarsening: a generic fine field carries detail the coarse space
+        # cannot hold, so the round trip must change it (P∘R is not the identity).
+        assert np.linalg.norm(proj @ u - u) > 1e-2 * np.linalg.norm(u)
+        # ...yet it is an idempotent projection (re-applying it changes nothing)...
+        np.testing.assert_allclose(proj @ (proj @ u), proj @ u, atol=1e-9)
+        # ...onto exactly the coarse subspace.
+        assert np.linalg.matrix_rank(proj) == coarse.num_active_functions
+
+
+class TestBezierReconstruction:
+    """Per-cell multi-level Bézier extraction reconstructs an L2-projected field.
+
+    Cross-checks the extraction operator against the *independent* Bernstein basis
+    (:func:`~pantr.basis.tabulate_bernstein`): ``bern @ (Cᵉᵀ c)`` must equal the spline's
+    own evaluation on every active cell.  Covered for degrees 2 and 3, 1D and 2D.
+    """
+
+    @staticmethod
+    def _check(degree: int, dim: int, refines: list[tuple[int, list[int], list[int]]]) -> None:
+        root = create_uniform_space([degree] * dim, [4] * dim)
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, 4), 2)
         for level, lo_box, hi_box in refines:
             grid.refine(level, lo_box, hi_box)
         thb = THBSplineSpace(root, grid)
@@ -125,16 +234,10 @@ class TestBezierReconstruction:
             x = lo + (hi - lo) * xi
             np.testing.assert_allclose(from_bezier, spline.evaluate(x), atol=1e-10)
 
-    def test_reconstruction_1d(self) -> None:
-        self._check(
-            _root_1d(),
-            lambda: hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2),
-            [(0, [0], [2]), (1, [0], [2])],
-        )
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_reconstruction_1d(self, degree: int) -> None:
+        self._check(degree, 1, [(0, [0], [2]), (1, [0], [2])])
 
-    def test_reconstruction_2d(self) -> None:
-        self._check(
-            _root_2d(),
-            lambda: hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2),
-            [(0, [0, 0], [2, 2])],
-        )
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_reconstruction_2d(self, degree: int) -> None:
+        self._check(degree, 2, [(0, [0, 0], [2, 2])])

--- a/tests/test_thb_validation_l2.py
+++ b/tests/test_thb_validation_l2.py
@@ -1,0 +1,102 @@
+"""Validation suite — group 2: L2 approximation in THB spaces.
+
+Reproduces the L2-approximation behaviour of THB-splines (Giannelli-Jüttler-Speleers
+2012): exact reproduction of functions in the space, optimal order-``p+1`` convergence
+under uniform refinement, and the adaptivity payoff — refining toward a localized
+feature reaches a smaller error with fewer degrees of freedom than uniform refinement.
+
+The L2 projection is the test-only cell-assembly helper :func:`_thb_assembly.l2_project_thb`
+(no global assembler is added to the library; #152 Q0).  Convergence orders and the
+adaptive advantage are reproduced, not exact published magnitudes (#164, PR8).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    THBSpline,
+    THBSplineSpace,
+    create_uniform_space,
+)
+from pantr.grid import hierarchical_grid, uniform_grid
+from tests._thb_assembly import l2_error, l2_project_thb
+
+_KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+
+
+def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpace:
+    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh)."""
+    root = create_uniform_space([degree] * dim, [n] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
+    for level in range(depth):
+        n_at = n * (2**level)
+        grid.refine(level, [0] * dim, [n_at] * dim)
+    return THBSplineSpace(root, grid)
+
+
+def _observed_orders(errors: list[float]) -> list[float]:
+    return [float(np.log2(errors[i] / errors[i + 1])) for i in range(len(errors) - 1)]
+
+
+class TestL2Reproduction:
+    """L2 projection reproduces any spline already in the space."""
+
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_reproduces_thb_spline(self, dim: int) -> None:
+        knots = _KNOTS_DEG2_4
+        root = BsplineSpace([BsplineSpace1D(knots, 2) for _ in range(dim)])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, 4), 2)
+        grid.refine(0, [0] * dim, [2] * dim)
+        thb = THBSplineSpace(root, grid)
+        coeffs = np.random.default_rng(dim).standard_normal(thb.num_active_functions)
+        target = THBSpline(thb, coeffs)
+        proj = l2_project_thb(thb, lambda p: np.asarray(target.evaluate(p)))
+        np.testing.assert_allclose(proj.coeffs, coeffs, atol=1e-9)
+
+
+class TestL2Convergence:
+    """Order-``p+1`` L2 convergence on a smooth function under uniform refinement."""
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_order_1d(self, degree: int) -> None:
+        def f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            return np.asarray(np.sin(2.0 * np.pi * p[:, 0]))
+
+        errors = [
+            l2_error(l2_project_thb(_uniform_refined(degree, 4, d, 1), f), f) for d in (1, 2, 3)
+        ]
+        assert min(_observed_orders(errors)) > degree + 0.5
+
+
+class TestAdaptiveEfficiency:
+    """Adaptive refinement toward a localized feature beats uniform refinement."""
+
+    @staticmethod
+    def _bump(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return np.asarray(np.exp(-(((p[:, 0] - 0.5) / 0.04) ** 2)))
+
+    @staticmethod
+    def _space(refines: list[tuple[int, list[int], list[int]]]) -> THBSplineSpace:
+        root = create_uniform_space([2], [8])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 8), 2)
+        for level, lo, hi in refines:
+            grid.refine(level, lo, hi)
+        return THBSplineSpace(root, grid)
+
+    def test_adaptive_beats_uniform(self) -> None:
+        # Uniform: refine every cell once (resolution 16).
+        uniform = self._space([(0, [0], [8])])
+        # Adaptive: refine only the central band toward the bump, twice.
+        adaptive = self._space([(0, [3], [5]), (1, [7], [9])])
+
+        err_uniform = l2_error(l2_project_thb(uniform, self._bump), self._bump)
+        err_adaptive = l2_error(l2_project_thb(adaptive, self._bump), self._bump)
+
+        # Adaptive achieves a smaller error with fewer degrees of freedom.
+        assert adaptive.num_active_functions < uniform.num_active_functions
+        assert err_adaptive < err_uniform

--- a/tests/test_thb_validation_l2.py
+++ b/tests/test_thb_validation_l2.py
@@ -1,9 +1,16 @@
 """Validation suite — group 2: L2 approximation in THB spaces.
 
-Reproduces the L2-approximation behaviour of THB-splines (Giannelli-Jüttler-Speleers
-2012): exact reproduction of functions in the space, optimal order-``p+1`` convergence
-under uniform refinement, and the adaptivity payoff — refining toward a localized
-feature reaches a smaller error with fewer degrees of freedom than uniform refinement.
+Reproduces the L2-approximation behaviour of THB-splines:
+
+- exact reproduction of a function already in the space (a consequence of the
+  Giannelli-Jüttler-Speleers 2012 truncated basis spanning the hierarchical spline
+  space, Thm 9);
+- optimal order-``p+1`` convergence under refinement, and the adaptivity payoff —
+  refining toward a localized feature reaches a smaller error with fewer degrees of
+  freedom than uniform refinement.  The order-``p+1`` rate and the adaptive advantage
+  are THB *approximation* results (Speleers-Manni 2016 / Speleers 2017); GJS 2012 itself
+  reports a least-squares *fitting* study (L-infinity error, sparsity, conditioning), not
+  an L2 convergence-order analysis.
 
 The L2 projection is the test-only cell-assembly helper :func:`_thb_assembly.l2_project_thb`
 (no global assembler is added to the library; #152 Q0).  Convergence orders and the
@@ -30,12 +37,32 @@ _KNOTS_DEG2_4 = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
 
 
 def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpace:
-    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh)."""
+    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh).
+
+    Note: refining *every* cell deactivates all coarse functions, so this is a
+    single-level tensor-product space — it checks the tensor-product convergence base
+    case.  Use :func:`_graded_refined` to exercise the genuinely truncated path.
+    """
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
     for level in range(depth):
         n_at = n * (2**level)
         grid.refine(level, [0] * dim, [n_at] * dim)
+    return THBSplineSpace(root, grid)
+
+
+def _graded_refined(degree: int, depth: int, dim: int) -> THBSplineSpace:
+    """A genuinely truncated graded space (refine the left half only, doubling resolution).
+
+    Coarse functions stay active over the right (unrefined-further) half, so truncated
+    functions are present at every depth — unlike :func:`_uniform_refined`.  The global
+    mesh size halves with ``depth``, so a smooth function still converges at order
+    ``p+1`` (the error is dominated by the coarser half).
+    """
+    n = 4 * 2**depth
+    root = create_uniform_space([degree] * dim, [n] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
+    grid.refine(0, [0] * dim, [n // 2] * dim)
     return THBSplineSpace(root, grid)
 
 
@@ -60,15 +87,28 @@ class TestL2Reproduction:
 
 
 class TestL2Convergence:
-    """Order-``p+1`` L2 convergence on a smooth function under uniform refinement."""
+    """Order-``p+1`` L2 convergence on a smooth function under refinement."""
+
+    @staticmethod
+    def _f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return np.asarray(np.sin(2.0 * np.pi * p[:, 0]))
 
     @pytest.mark.parametrize("degree", [2, 3])
     def test_order_1d(self, degree: int) -> None:
-        def f(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-            return np.asarray(np.sin(2.0 * np.pi * p[:, 0]))
-
+        # Tensor-product base case (uniform refinement deactivates coarse functions).
         errors = [
-            l2_error(l2_project_thb(_uniform_refined(degree, 4, d, 1), f), f) for d in (1, 2, 3)
+            l2_error(l2_project_thb(_uniform_refined(degree, 4, d, 1), self._f), self._f)
+            for d in (1, 2, 3)
+        ]
+        assert min(_observed_orders(errors)) > degree + 0.5
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_order_1d_graded(self, degree: int) -> None:
+        # Genuinely truncated hierarchy: coarse functions remain active, so this
+        # exercises the THB path rather than a single-level tensor-product space.
+        errors = [
+            l2_error(l2_project_thb(_graded_refined(degree, d, 1), self._f), self._f)
+            for d in (1, 2, 3)
         ]
         assert min(_observed_orders(errors)) > degree + 0.5
 

--- a/tests/test_thb_validation_qi.py
+++ b/tests/test_thb_validation_qi.py
@@ -26,13 +26,33 @@ from tests._thb_assembly import l2_error
 
 
 def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpace:
-    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh)."""
+    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh).
+
+    Refining every cell deactivates all coarse functions, so this is a single-level
+    tensor-product space — the tensor-product convergence base case.  Use
+    :func:`_graded_refined` to exercise the genuinely truncated path.
+    """
     root = create_uniform_space([degree] * dim, [n] * dim)
     grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
     for level in range(depth):
         n_at = n * (2**level)
         grid.refine(level, [0] * dim, [n_at] * dim)
     return THBSplineSpace(root, grid)
+
+
+def _graded_refined(degree: int, depth: int, dim: int, *, truncate: bool = True) -> THBSplineSpace:
+    """A genuinely truncated graded space (refine the left half only, doubling resolution).
+
+    Coarse functions stay active over the right (unrefined-further) half, so truncated
+    functions are present at every depth.  The global mesh size halves with ``depth``, so
+    a smooth function still converges at order ``p+1``.  ``truncate=False`` builds the
+    non-truncated (HB) counterpart on the same mesh.
+    """
+    n = 4 * 2**depth
+    root = create_uniform_space([degree] * dim, [n] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
+    grid.refine(0, [0] * dim, [n // 2] * dim)
+    return THBSplineSpace(root, grid, truncate=truncate)
 
 
 def _observed_orders(errors: list[float]) -> list[float]:
@@ -48,12 +68,23 @@ def _f2(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
 
 
 class TestQIConvergence:
-    """Order-``p+1`` QI convergence under uniform refinement."""
+    """Order-``p+1`` QI convergence under refinement (Speleers-Manni 2016, Thm 6)."""
 
     @pytest.mark.parametrize("degree", [2, 3])
     def test_order_1d(self, degree: int) -> None:
+        # Tensor-product base case (uniform refinement deactivates coarse functions).
         errors = [
             l2_error(quasi_interpolate_thb_spline(_f1, _uniform_refined(degree, 4, d, 1)), _f1)
+            for d in (1, 2, 3)
+        ]
+        assert min(_observed_orders(errors)) > degree + 0.5
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_order_1d_graded(self, degree: int) -> None:
+        # Genuinely truncated hierarchy: the hierarchical QI sums per-level functionals
+        # over coexisting active levels, not a single-level collapse.
+        errors = [
+            l2_error(quasi_interpolate_thb_spline(_f1, _graded_refined(degree, d, 1)), _f1)
             for d in (1, 2, 3)
         ]
         assert min(_observed_orders(errors)) > degree + 0.5
@@ -62,9 +93,9 @@ class TestQIConvergence:
     def test_order_2d(self, degree: int) -> None:
         errors = [
             l2_error(quasi_interpolate_thb_spline(_f2, _uniform_refined(degree, 4, d, 2)), _f2)
-            for d in (1, 2)
+            for d in (1, 2, 3)
         ]
-        assert _observed_orders(errors)[0] > degree + 0.5
+        assert min(_observed_orders(errors)) > degree + 0.5
 
 
 class TestQIConsistency:
@@ -76,8 +107,38 @@ class TestQIConsistency:
         thb = THBSplineSpace(root, grid)
         thb_qi = quasi_interpolate_thb_spline(_f1, thb)
         tp_qi = quasi_interpolate_bspline(_f1, root)
-        # Identical coefficients ⇒ identical error.
+        # On an unrefined space the THB-QI coefficients equal the TP-QI control points
+        # (the hierarchical construction collapses to the single chosen level QI).
         np.testing.assert_allclose(thb_qi.coeffs, tp_qi.control_points.ravel(), atol=1e-12)
+
+
+class TestHBQuasiInterpolationDegraded:
+    """The non-truncated (HB) QI is a valid approximant but not an exact projector.
+
+    On a genuinely hierarchical mesh the truncated QI converges at order ``p+1``, while
+    the HB QI — whose basis is not a partition of unity, so it does not even reproduce
+    constants — converges at a sub-optimal rate.  The contrast confirms that truncation
+    is what restores the optimal approximation (docstring of
+    :func:`quasi_interpolate_thb_spline`).
+    """
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_hb_qi_converges_slower_than_thb(self, degree: int) -> None:
+        thb_errs = [
+            l2_error(quasi_interpolate_thb_spline(_f1, _graded_refined(degree, d, 1)), _f1)
+            for d in (1, 2, 3)
+        ]
+        hb_errs = [
+            l2_error(
+                quasi_interpolate_thb_spline(_f1, _graded_refined(degree, d, 1, truncate=False)),
+                _f1,
+            )
+            for d in (1, 2, 3)
+        ]
+        assert min(_observed_orders(thb_errs)) > degree + 0.5  # THB optimal (p+1)
+        assert min(_observed_orders(hb_errs)) < degree  # HB strictly sub-optimal
+        # HB error is larger at every refinement level, not only asymptotically.
+        assert all(h > t for h, t in zip(hb_errs, thb_errs, strict=True))
 
 
 class TestQIAdaptiveEfficiency:

--- a/tests/test_thb_validation_qi.py
+++ b/tests/test_thb_validation_qi.py
@@ -1,0 +1,104 @@
+"""Validation suite — group 3: quasi-interpolation convergence (Speleers-Manni 2016).
+
+Reproduces the approximation behaviour of the hierarchical quasi-interpolant: optimal
+order-``p+1`` convergence under uniform refinement (1D and 2D, degrees 2 and 3),
+consistency with the tensor-product QI on an unrefined space, and the adaptivity payoff
+on a localized feature.  This goes beyond PR7's single convergence smoke test.
+
+Orders and the adaptive advantage are reproduced, not exact published magnitudes
+(#164, PR8).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import (
+    THBSplineSpace,
+    create_uniform_space,
+    quasi_interpolate_bspline,
+    quasi_interpolate_thb_spline,
+)
+from pantr.grid import hierarchical_grid, uniform_grid
+from tests._thb_assembly import l2_error
+
+
+def _uniform_refined(degree: int, n: int, depth: int, dim: int) -> THBSplineSpace:
+    """A THB space whose every cell is refined ``depth`` times (a uniform fine mesh)."""
+    root = create_uniform_space([degree] * dim, [n] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
+    for level in range(depth):
+        n_at = n * (2**level)
+        grid.refine(level, [0] * dim, [n_at] * dim)
+    return THBSplineSpace(root, grid)
+
+
+def _observed_orders(errors: list[float]) -> list[float]:
+    return [float(np.log2(errors[i] / errors[i + 1])) for i in range(len(errors) - 1)]
+
+
+def _f1(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    return np.asarray(np.sin(2.0 * np.pi * p[:, 0]))
+
+
+def _f2(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    return np.asarray(np.sin(2.0 * np.pi * p[:, 0]) * np.cos(2.0 * np.pi * p[:, 1]))
+
+
+class TestQIConvergence:
+    """Order-``p+1`` QI convergence under uniform refinement."""
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_order_1d(self, degree: int) -> None:
+        errors = [
+            l2_error(quasi_interpolate_thb_spline(_f1, _uniform_refined(degree, 4, d, 1)), _f1)
+            for d in (1, 2, 3)
+        ]
+        assert min(_observed_orders(errors)) > degree + 0.5
+
+    @pytest.mark.parametrize("degree", [2, 3])
+    def test_order_2d(self, degree: int) -> None:
+        errors = [
+            l2_error(quasi_interpolate_thb_spline(_f2, _uniform_refined(degree, 4, d, 2)), _f2)
+            for d in (1, 2)
+        ]
+        assert _observed_orders(errors)[0] > degree + 0.5
+
+
+class TestQIConsistency:
+    """THB-QI on an unrefined space matches the tensor-product QI."""
+
+    def test_unrefined_matches_tp(self) -> None:
+        root = create_uniform_space([2], [8])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 8), 2)
+        thb = THBSplineSpace(root, grid)
+        thb_qi = quasi_interpolate_thb_spline(_f1, thb)
+        tp_qi = quasi_interpolate_bspline(_f1, root)
+        # Identical coefficients ⇒ identical error.
+        np.testing.assert_allclose(thb_qi.coeffs, tp_qi.control_points.ravel(), atol=1e-12)
+
+
+class TestQIAdaptiveEfficiency:
+    """Adaptive QI toward a localized feature beats uniform QI."""
+
+    @staticmethod
+    def _bump(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return np.asarray(np.exp(-(((p[:, 0] - 0.5) / 0.04) ** 2)))
+
+    @staticmethod
+    def _space(refines: list[tuple[int, list[int], list[int]]]) -> THBSplineSpace:
+        root = create_uniform_space([2], [8])
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 8), 2)
+        for level, lo, hi in refines:
+            grid.refine(level, lo, hi)
+        return THBSplineSpace(root, grid)
+
+    def test_adaptive_beats_uniform(self) -> None:
+        uniform = self._space([(0, [0], [8])])
+        adaptive = self._space([(0, [3], [5]), (1, [7], [9])])
+        err_uniform = l2_error(quasi_interpolate_thb_spline(self._bump, uniform), self._bump)
+        err_adaptive = l2_error(quasi_interpolate_thb_spline(self._bump, adaptive), self._bump)
+        assert adaptive.num_active_functions < uniform.num_active_functions
+        assert err_adaptive < err_uniform


### PR DESCRIPTION
## Summary

PR8 of the THB-splines feature (#164): a **test-only** validation suite that reproduces
published properties/results of the key references (Giannelli–Jüttler–Speleers 2012;
Speleers–Manni 2016) end-to-end. No solver/assembler is added to the library — the one
operator that needs writing (an L2 projection onto a `THBSplineSpace`) lives in a `tests/`
helper, since the THB mass matrix needs a global cell-by-cell assembly with no Kronecker
shortcut (the FEM-style assembly kept out of the API per #152-Q0).

Scope (user-locked): groups 1–3 + algebraic identities; G+Smo golden-file cross-check
skipped (no external reference data). Orders and properties are reproduced, not exact
published magnitudes.

New files (all under `tests/`, no `src/` changes):
- `tests/_thb_assembly.py` — test-only helper: global mass/Gram assembly via
  `cell_quadrature` + `tabulate_basis`, `l2_project_thb`, `l2_error`.
- `tests/test_thb_validation_basis.py` — **group 1**: nonnegativity, partition of unity,
  Gram SPD + full rank (linear independence) with bounded condition number under
  refinement (strong stability), coarse polynomial reproduction.
- `tests/test_thb_validation_l2.py` — **group 2**: L2 exact reproduction, order-`p+1`
  convergence, adaptive-beats-uniform on a localized feature.
- `tests/test_thb_validation_qi.py` — **group 3**: QI order-`p+1` convergence (1D/2D,
  degrees 2/3), TP/THB consistency, adaptive efficiency.
- `tests/test_thb_validation_identities.py` — **group 4**: refinement nesting via
  prolongation, `restriction ∘ prolongation == I`, and Bézier reconstruction of an
  L2-projected field (integrating PR6 + PR7).
- `tests/conftest.py` — expose the `tests` namespace so modules can import the shared helper.

## Test plan
- [x] 26 new validation tests pass
- [x] full suite (3059 passed), ruff, ruff-format, mypy, docs (-W)

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)