### PR TITLE
refactor(bspline): align THBSplineSpace/THBSpline with the TP B-spline API (PR9 of #164)

### DIFF
--- a/src/pantr/bspline/_thb_quasi_interpolation.py
+++ b/src/pantr/bspline/_thb_quasi_interpolation.py
@@ -87,7 +87,7 @@ def quasi_interpolate_thb_spline(
 
     grid = space.grid
     dim = space.dim
-    num_active = space.num_active_functions
+    num_active = space.num_total_basis
     func_offset = space._func_offset
 
     # Candidate leaf cells per dof: cells whose level equals the contributing

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -165,13 +165,12 @@ class THBSpline:
         out = np.empty((n_pts, rank), dtype=np.float64)
         for cid in np.unique(cids):
             mask = cids == cid
-            dofs = self._space.active_basis(int(cid))
+            values, dofs = self._space.tabulate_basis(int(cid), flat[mask])
             if dofs.size == 0:
                 raise RuntimeError(
                     f"cell {int(cid)} has no active basis functions; "
                     "the THBSplineSpace may be inconsistent."
                 )
-            values = self._space.tabulate_basis(int(cid), flat[mask])
             out[mask] = np.asarray(values, dtype=np.float64) @ self._coeffs[dofs]
 
         if self._scalar:

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -1,11 +1,11 @@
-"""THB spline function: a :class:`THBSplineSpace` paired with coefficients.
+"""THB spline function: a :class:`THBSplineSpace` paired with control points.
 
 This module provides :class:`THBSpline`, the hierarchical analogue of
 :class:`~pantr.bspline.Bspline`.  It represents a function
 ``f(u) = Σ_i c_i φ_i(u)`` where ``φ_i`` are the active (truncated) hierarchical
-basis functions of a :class:`~pantr.bspline.THBSplineSpace` and ``c_i`` the
-coefficients (one per active dof).  Evaluation locates each point's active leaf
-cell and combines the cell's active-basis values with the matching coefficients.
+basis functions of a :class:`~pantr.bspline.THBSplineSpace` and ``c_i`` the control
+points (one per active dof).  Evaluation locates each point's active leaf cell and
+combines the cell's active-basis values with the matching control points.
 
 Main exports:
 
@@ -14,63 +14,74 @@ Main exports:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from numpy import typing as npt
 
 from ._thb_spline_space import THBSplineSpace
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 class THBSpline:
     """An evaluable THB spline function ``f = Σ_i c_i φ_i``.
 
-    Pairs a :class:`~pantr.bspline.THBSplineSpace` with a coefficient per active
-    hierarchical dof.  Scalar (``coeffs`` shape ``(num_active,)``) and
-    vector-valued (``(num_active, rank)``) fields are both supported.
+    The hierarchical analogue of :class:`~pantr.bspline.Bspline`: it pairs a
+    :class:`~pantr.bspline.THBSplineSpace` with one control point per active
+    hierarchical dof.  Because the hierarchical basis is not of tensor-product
+    structure, the control points stay a flat ``(num_total_basis,)`` (scalar) or
+    ``(num_total_basis, rank)`` (vector-valued) array, rather than the
+    ``(*num_basis, rank)`` grid of :class:`~pantr.bspline.Bspline`.
 
     Attributes:
         _space (THBSplineSpace): The hierarchical space.
-        _coeffs (npt.NDArray[np.float64]): Coefficients reshaped to
-            ``(num_active, rank)``.
-        _scalar (bool): Whether the field is scalar (``coeffs`` was 1-D).
+        _control_points (npt.NDArray[np.float64]): Control points reshaped to
+            ``(num_total_basis, rank)`` (read-only).
+        _scalar (bool): Whether the field is scalar (``control_points`` was 1-D).
     """
 
-    __slots__ = ("_coeffs", "_scalar", "_space")
+    __slots__ = ("_control_points", "_scalar", "_space")
 
-    def __init__(self, space: THBSplineSpace, coeffs: npt.ArrayLike) -> None:
+    def __init__(self, space: THBSplineSpace, control_points: npt.ArrayLike) -> None:
         """Create a THB spline function.
 
         Args:
             space (THBSplineSpace): The hierarchical space.
-            coeffs (npt.ArrayLike): Coefficients of shape ``(num_active,)`` (scalar)
-                or ``(num_active, rank)`` (vector-valued), ordered by global dof.
+            control_points (npt.ArrayLike): Control points of shape
+                ``(num_total_basis,)`` (scalar) or ``(num_total_basis, rank)``
+                (vector-valued), ordered by global dof.
 
         Raises:
             TypeError: If ``space`` is not a :class:`THBSplineSpace`.
-            ValueError: If ``coeffs`` is not 1-D/2-D or its leading dimension does
-                not equal ``space.num_total_basis``.
+            ValueError: If ``control_points`` is not 1-D/2-D or its leading dimension
+                does not equal ``space.num_total_basis``.
         """
         if not isinstance(space, THBSplineSpace):
             raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
-        arr = np.asarray(coeffs, dtype=np.float64)
+        arr = np.asarray(control_points, dtype=np.float64)
         n = space.num_total_basis
         if arr.ndim == 1:
             scalar = True
             if arr.shape[0] != n:
-                raise ValueError(f"coeffs must have length {n}; got {arr.shape[0]}.")
+                raise ValueError(f"control_points must have length {n}; got {arr.shape[0]}.")
             arr = arr.reshape(n, 1)
         elif arr.ndim == 2:  # noqa: PLR2004
             scalar = False
             if arr.shape[0] != n:
-                raise ValueError(f"coeffs leading dimension must be {n}; got shape {arr.shape!r}.")
+                raise ValueError(
+                    f"control_points leading dimension must be {n}; got shape {arr.shape!r}."
+                )
         else:
-            raise ValueError(f"coeffs must be 1-D or 2-D; got {arr.ndim}-D.")
+            raise ValueError(f"control_points must be 1-D or 2-D; got {arr.ndim}-D.")
         self._space = space
-        self._coeffs = np.ascontiguousarray(arr, dtype=np.float64)
+        self._control_points = np.ascontiguousarray(arr, dtype=np.float64)
         # Ensure we own the data before marking read-only; ascontiguousarray may
         # return a view of the input when it is already C-contiguous float64.
-        if not self._coeffs.flags.owndata:
-            self._coeffs = self._coeffs.copy()
-        self._coeffs.flags.writeable = False
+        if not self._control_points.flags.owndata:
+            self._control_points = self._control_points.copy()
+        self._control_points.flags.writeable = False
         self._scalar = scalar
 
     @property
@@ -83,17 +94,17 @@ class THBSpline:
         return self._space
 
     @property
-    def coeffs(self) -> npt.NDArray[np.float64]:
-        """Get the coefficients (read-only view).
+    def control_points(self) -> npt.NDArray[np.float64]:
+        """Get the control points (read-only view).
 
         Returns:
-            npt.NDArray[np.float64]: Shape ``(num_active,)`` for a scalar field,
-            ``(num_active, rank)`` otherwise.  The array is read-only; copy it
+            npt.NDArray[np.float64]: Shape ``(num_total_basis,)`` for a scalar field,
+            ``(num_total_basis, rank)`` otherwise.  The array is read-only; copy it
             before modifying.
         """
         if self._scalar:
-            return self._coeffs[:, 0]
-        return self._coeffs
+            return self._control_points[:, 0]
+        return self._control_points
 
     @property
     def dim(self) -> int:
@@ -105,43 +116,120 @@ class THBSpline:
         return self._space.dim
 
     @property
+    def degree(self) -> tuple[int, ...]:
+        """Get the per-direction polynomial degrees.
+
+        Returns:
+            tuple[int, ...]: Degree per parametric direction (mirrors
+            :attr:`~pantr.bspline.Bspline.degree`).
+        """
+        return self._space.degrees
+
+    @property
     def rank(self) -> int:
         """Get the output rank (number of value components).
 
         Returns:
             int: ``1`` for a scalar field; the number of components otherwise.
         """
-        return int(self._coeffs.shape[1])
+        return int(self._control_points.shape[1])
 
     @property
     def dtype(self) -> np.dtype[np.float64]:
-        """Get the floating-point dtype of the coefficients.
+        """Get the floating-point dtype of the control points.
 
         Returns:
-            np.dtype[np.float64]: Dtype of the stored coefficients, always
+            np.dtype[np.float64]: Dtype of the stored control points, always
             ``numpy.float64``.
         """
-        return self._coeffs.dtype
+        return self._control_points.dtype
 
-    def evaluate(self, pts: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    def evaluate(
+        self,
+        pts: npt.ArrayLike,
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
         """Evaluate the THB spline at ``pts``.
 
-        Each point is located in its active leaf cell; the cell's active-basis
-        values (:meth:`THBSplineSpace.tabulate_basis`) are combined with the
-        matching coefficients.
+        Each point is located in its active leaf cell; the cell's active-basis values
+        (:meth:`THBSplineSpace.tabulate_basis`) are combined with the matching control
+        points.  Mirrors :meth:`~pantr.bspline.Bspline.evaluate`.
 
         Args:
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)``.
+            out (npt.NDArray[np.float64] | None): Optional output array of the result
+                shape (``(...)`` for a scalar field, ``(..., rank)`` otherwise).
+                Allocated when ``None``.
 
         Returns:
             npt.NDArray[np.float64]: Values of shape ``(...)`` for a scalar field
             or ``(..., rank)`` for a vector-valued field.
 
         Raises:
-            ValueError: If ``pts`` does not have trailing dimension ``dim`` or any
-                point lies outside the grid domain.
+            ValueError: If ``pts`` does not have trailing dimension ``dim``, any point
+                lies outside the grid domain, or ``out`` has the wrong shape/dtype or
+                is not writeable.
             RuntimeError: If the grid has been modified since construction, or a cell
                 has no active basis functions (inconsistent space).
+        """
+        return self._evaluate_orders(pts, (0,) * self.dim, out)
+
+    def evaluate_derivatives(
+        self,
+        pts: npt.ArrayLike,
+        orders: int | Sequence[int],
+        out: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        r"""Evaluate a mixed partial derivative of the THB spline at ``pts``.
+
+        Computes the single mixed partial :math:`\partial^{orders} f`, where
+        ``orders[k]`` is the derivative order in parametric direction ``k`` (with
+        respect to the parametric coordinates).  Mirrors
+        :meth:`~pantr.bspline.Bspline.evaluate_derivatives`.
+
+        Args:
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)``.
+            orders (int | Sequence[int]): Per-direction derivative orders.  A scalar is
+                broadcast to every direction.  Each entry must be ``>= 0``.
+            out (npt.NDArray[np.float64] | None): Optional output array of the result
+                shape.  Allocated when ``None``.
+
+        Returns:
+            npt.NDArray[np.float64]: Derivative values of shape ``(...)`` for a scalar
+            field or ``(..., rank)`` for a vector-valued field.
+
+        Raises:
+            ValueError: If ``orders`` has the wrong length or a negative entry, if
+                ``pts`` does not have trailing dimension ``dim``, any point lies
+                outside the grid domain, or ``out`` has the wrong shape/dtype or is
+                not writeable.
+            RuntimeError: If the grid has been modified since construction, or a cell
+                has no active basis functions (inconsistent space).
+        """
+        return self._evaluate_orders(pts, orders, out)
+
+    def _evaluate_orders(
+        self,
+        pts: npt.ArrayLike,
+        orders: int | Sequence[int],
+        out: npt.NDArray[np.float64] | None,
+    ) -> npt.NDArray[np.float64]:
+        """Shared evaluation of the ``orders`` mixed partial (values when all zero).
+
+        Args:
+            pts (npt.ArrayLike): Parametric points of shape ``(..., dim)``.
+            orders (int | Sequence[int]): Per-direction derivative orders (validated by
+                :meth:`THBSplineSpace.tabulate_basis_derivatives`).
+            out (npt.NDArray[np.float64] | None): Optional output array of the result
+                shape.
+
+        Returns:
+            npt.NDArray[np.float64]: Values of shape ``(...)`` / ``(..., rank)``.
+
+        Raises:
+            ValueError: If ``pts``/``orders``/``out`` are invalid (see the public
+                methods).
+            RuntimeError: If the grid is stale or a cell has no active functions.
         """
         self._space._check_not_stale()
         arr = np.asarray(pts, dtype=np.float64)
@@ -162,20 +250,28 @@ class THBSpline:
                 raise ValueError(f"point {flat[i].tolist()!r} lies outside the grid domain.")
             cids[i] = cid
 
-        out = np.empty((n_pts, rank), dtype=np.float64)
+        raw = np.empty((n_pts, rank), dtype=np.float64)
         for cid in np.unique(cids):
             mask = cids == cid
-            values, dofs = self._space.tabulate_basis(int(cid), flat[mask])
+            values, dofs = self._space.tabulate_basis_derivatives(int(cid), flat[mask], orders)
             if dofs.size == 0:
                 raise RuntimeError(
                     f"cell {int(cid)} has no active basis functions; "
                     "the THBSplineSpace may be inconsistent."
                 )
-            out[mask] = np.asarray(values, dtype=np.float64) @ self._coeffs[dofs]
+            raw[mask] = np.asarray(values, dtype=np.float64) @ self._control_points[dofs]
 
-        if self._scalar:
-            return out[:, 0].reshape(batch_shape)
-        return out.reshape(*batch_shape, rank)
+        result = raw[:, 0].reshape(batch_shape) if self._scalar else raw.reshape(*batch_shape, rank)
+        if out is None:
+            return result
+        if out.shape != result.shape:
+            raise ValueError(f"out must have shape {result.shape}; got {out.shape}.")
+        if out.dtype != np.float64:
+            raise ValueError(f"out must have dtype float64; got {out.dtype}.")
+        if not out.flags.writeable:
+            raise ValueError("out must be writeable.")
+        out[...] = result
+        return out
 
     def __repr__(self) -> str:
         """Return a concise representation.
@@ -184,5 +280,6 @@ class THBSpline:
             str: Summary with dimension, rank, and active-function count.
         """
         return (
-            f"THBSpline(dim={self.dim}, rank={self.rank}, num_active={self._space.num_total_basis})"
+            f"THBSpline(dim={self.dim}, rank={self.rank}, num_total_basis="
+            f"{self._space.num_total_basis})"
         )

--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -47,12 +47,12 @@ class THBSpline:
         Raises:
             TypeError: If ``space`` is not a :class:`THBSplineSpace`.
             ValueError: If ``coeffs`` is not 1-D/2-D or its leading dimension does
-                not equal ``space.num_active_functions``.
+                not equal ``space.num_total_basis``.
         """
         if not isinstance(space, THBSplineSpace):
             raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")
         arr = np.asarray(coeffs, dtype=np.float64)
-        n = space.num_active_functions
+        n = space.num_total_basis
         if arr.ndim == 1:
             scalar = True
             if arr.shape[0] != n:
@@ -185,6 +185,5 @@ class THBSpline:
             str: Summary with dimension, rank, and active-function count.
         """
         return (
-            f"THBSpline(dim={self.dim}, rank={self.rank}, "
-            f"num_active={self._space.num_active_functions})"
+            f"THBSpline(dim={self.dim}, rank={self.rank}, num_active={self._space.num_total_basis})"
         )

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -86,6 +86,31 @@ coefficient axes plus one for the point axis, leaving a safe ceiling of 24 dimen
 """
 
 
+def _check_out_array(
+    out: npt.NDArray[np.float64] | npt.NDArray[np.int64],
+    shape: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    name: str,
+) -> None:
+    """Validate an output array's shape, dtype, and writeability.
+
+    Args:
+        out (npt.NDArray[np.float64] | npt.NDArray[np.int64]): The output array.
+        shape (tuple[int, ...]): The required shape.
+        dtype (npt.DTypeLike): The required dtype.
+        name (str): The parameter name, used in error messages.
+
+    Raises:
+        ValueError: If ``out`` has the wrong shape or dtype, or is not writeable.
+    """
+    if out.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}; got {out.shape}.")
+    if out.dtype != dtype:
+        raise ValueError(f"{name} must have dtype {np.dtype(dtype).name}; got {out.dtype}.")
+    if not out.flags.writeable:
+        raise ValueError(f"{name} must be writeable.")
+
+
 def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
     """Compute the cell support of every B-spline function of a 1D space.
 
@@ -840,8 +865,9 @@ class THBSplineSpace:
         cid: int,
         pts: npt.ArrayLike,
         orders: tuple[int, ...],
-        out: npt.NDArray[np.float64] | None,
-    ) -> npt.NDArray[np.float64]:
+        out_basis: npt.NDArray[np.float64] | None,
+        out_dofs: npt.NDArray[np.int64] | None,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
         """Evaluate the active functions' ``orders`` mixed partial on cell ``cid``.
 
         Shared implementation for :meth:`tabulate_basis` (``orders`` all zero) and
@@ -853,22 +879,26 @@ class THBSplineSpace:
                 cell ``cid``.  A tolerance of ``1e-12`` is applied at the cell
                 boundary; points further outside raise :class:`ValueError`.
             orders (tuple[int, ...]): Per-direction derivative orders.
-            out (npt.NDArray[np.float64] | None): Optional output array of shape
+            out_basis (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
                 ``None``.
+            out_dofs (npt.NDArray[np.int64] | None): Optional output array of shape
+                ``(K,)`` for the global dofs.  Allocated when ``None``.
 
         Returns:
-            npt.NDArray[np.float64]: Values of shape ``(..., K)``.
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]: ``(values, dofs)``
+            of shapes ``(..., K)`` and ``(K,)``.
 
         Raises:
             IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
             ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
-                point lies outside cell ``cid``, or if ``out`` has the wrong shape,
-                dtype, or is not writeable.
+                point lies outside cell ``cid``, or if ``out_basis``/``out_dofs`` has
+                the wrong shape, dtype, or is not writeable.
             RuntimeError: If the grid has been modified since construction.
         """
         contribs = self._cell_contributions(cid)  # validates cid; raises if stale
         n_active = len(contribs)
+        dofs = np.array([gdof for gdof, _, _ in contribs], dtype=np.int64)
 
         pts_arr = np.asarray(pts, dtype=np.float64)
         if pts_arr.ndim == 0 or pts_arr.shape[-1] != self.dim:
@@ -888,16 +918,18 @@ class THBSplineSpace:
 
         out_shape = (*lead, n_active)
 
-        if out is None:
+        if out_basis is None:
             result = np.empty(out_shape, dtype=np.float64)
         else:
-            if out.shape != out_shape:
-                raise ValueError(f"out must have shape {out_shape}; got {out.shape}.")
-            if out.dtype != np.float64:
-                raise ValueError(f"out must have dtype float64; got {out.dtype}.")
-            if not out.flags.writeable:
-                raise ValueError("out must be writeable.")
-            result = out
+            _check_out_array(out_basis, out_shape, np.float64, "out_basis")
+            result = out_basis
+
+        if out_dofs is None:
+            dofs_result = dofs
+        else:
+            _check_out_array(out_dofs, (n_active,), np.int64, "out_dofs")
+            out_dofs[...] = dofs
+            dofs_result = out_dofs
 
         buffer = np.empty((num_pts, n_active), dtype=np.float64)
         eval_cache: _EvalCache = {}
@@ -920,50 +952,57 @@ class THBSplineSpace:
                 buffer[:, col] = self._truncated_column(entry, orders, flat_pts, eval_cache)
 
         result[...] = buffer.reshape(out_shape)
-        return result
+        return result, dofs_result
 
     def tabulate_basis(
         self,
         cid: int,
         pts: npt.ArrayLike,
-        out: npt.NDArray[np.float64] | None = None,
-    ) -> npt.NDArray[np.float64]:
+        out_basis: npt.NDArray[np.float64] | None = None,
+        out_dofs: npt.NDArray[np.int64] | None = None,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
         """Evaluate the active hierarchical functions on cell ``cid`` at ``pts``.
 
         Untruncated functions are a single tensor-product B-spline (the product of
         their 1D B-spline values).  Truncated functions are evaluated from their
         stored coefficients in the finest tensor-product basis their support reaches.
-        The returned columns are ordered as :meth:`active_basis` (sorted global dof);
-        a listed truncated function may evaluate to exactly zero on the cell.
+        The returned columns are ordered as ``dofs`` (the sorted global dofs, equal to
+        :meth:`active_basis`); a listed truncated function may evaluate to exactly zero
+        on the cell.  Mirrors the ``(basis, first_basis)`` two-return of
+        :meth:`~pantr.bspline.BsplineSpace.tabulate_basis`.
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
                 cell ``cid``.  Points outside the cell's bounds raise
                 :class:`ValueError`.
-            out (npt.NDArray[np.float64] | None): Optional output array of shape
+            out_basis (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
                 ``None``.
+            out_dofs (npt.NDArray[np.int64] | None): Optional output array of shape
+                ``(K,)`` for the dofs.  Allocated when ``None``.
 
         Returns:
-            npt.NDArray[np.float64]: Function values of shape ``(..., K)``.
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]: ``(values, dofs)`` of
+            shapes ``(..., K)`` and ``(K,)``.
 
         Raises:
             IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
             ValueError: If ``pts`` does not have trailing dimension ``dim``, if any
-                point lies outside the bounds of cell ``cid``, or if ``out`` has the
-                wrong shape, dtype, or is not writeable.
+                point lies outside the bounds of cell ``cid``, or if ``out_basis`` /
+                ``out_dofs`` has the wrong shape, dtype, or is not writeable.
             RuntimeError: If the grid has been modified since construction.
         """
-        return self._tabulate_orders(cid, pts, (0,) * self.dim, out)
+        return self._tabulate_orders(cid, pts, (0,) * self.dim, out_basis, out_dofs)
 
     def tabulate_basis_derivatives(
         self,
         cid: int,
         pts: npt.ArrayLike,
         orders: int | Sequence[int],
-        out: npt.NDArray[np.float64] | None = None,
-    ) -> npt.NDArray[np.float64]:
+        out_basis: npt.NDArray[np.float64] | None = None,
+        out_dofs: npt.NDArray[np.int64] | None = None,
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
         r"""Evaluate a mixed partial derivative of the active functions on cell ``cid``.
 
         Computes the single mixed partial :math:`\partial^{orders}` of each active
@@ -972,7 +1011,7 @@ class THBSplineSpace:
         coordinates).  Untruncated functions differentiate as a tensor product of 1D
         B-spline derivatives; truncated functions apply their stored coefficients to
         the B-spline derivatives at their representation level.  The returned columns
-        are ordered as :meth:`active_basis` (sorted global dof).
+        are ordered as ``dofs`` (the sorted global dofs, equal to :meth:`active_basis`).
 
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
@@ -982,19 +1021,22 @@ class THBSplineSpace:
             orders (int | Sequence[int]): Per-direction derivative orders.  A scalar
                 is broadcast to every direction.  Each entry must be ``>= 0``; orders
                 exceeding the degree yield zero.
-            out (npt.NDArray[np.float64] | None): Optional output array of shape
+            out_basis (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
                 ``None``.
+            out_dofs (npt.NDArray[np.int64] | None): Optional output array of shape
+                ``(K,)`` for the dofs.  Allocated when ``None``.
 
         Returns:
-            npt.NDArray[np.float64]: Derivative values of shape ``(..., K)``.
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]: ``(values, dofs)`` of
+            shapes ``(..., K)`` and ``(K,)``.
 
         Raises:
             IndexError: If ``cid`` is out of range ``[0, grid.num_cells)``.
             ValueError: If ``orders`` has the wrong length or a negative entry, if
                 ``pts`` does not have trailing dimension ``dim``, if any point lies
-                outside cell ``cid``, or if ``out`` has the wrong shape, dtype, or is
-                not writeable.
+                outside cell ``cid``, or if ``out_basis`` / ``out_dofs`` has the wrong
+                shape, dtype, or is not writeable.
             RuntimeError: If the grid has been modified since construction.
         """
         if isinstance(orders, int):
@@ -1008,7 +1050,7 @@ class THBSplineSpace:
                 )
         if any(o < 0 for o in orders_t):
             raise ValueError(f"orders must be non-negative; got {orders_t!r}.")
-        return self._tabulate_orders(cid, pts, orders_t, out)
+        return self._tabulate_orders(cid, pts, orders_t, out_basis, out_dofs)
 
     # ------------------------------------------------------------------
     # Refinement

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -632,8 +632,11 @@ class THBSplineSpace:
         return self._truncate
 
     @property
-    def num_active_functions(self) -> int:
-        """Get the total number of active hierarchical functions.
+    def num_total_basis(self) -> int:
+        """Get the total number of active hierarchical basis functions.
+
+        Mirrors :attr:`~pantr.bspline.BsplineSpace.num_total_basis` (the hierarchical
+        basis is not tensor-product, so there is no per-direction ``num_basis``).
 
         Returns:
             int: Total active-function count across all levels.
@@ -641,13 +644,41 @@ class THBSplineSpace:
         return self._num_active
 
     @property
-    def num_active_functions_per_level(self) -> tuple[int, ...]:
-        """Get the number of active functions at each level.
+    def num_basis_per_level(self) -> tuple[int, ...]:
+        """Get the number of active basis functions at each level.
 
         Returns:
             tuple[int, ...]: Active-function count per level.
         """
         return tuple(int(a.shape[0]) for a in self._active_funcs)
+
+    @property
+    def domain(self) -> npt.NDArray[np.float32 | np.float64]:
+        """Get the parametric domain bounds.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Shape ``(dim, 2)`` ``[lo, hi]`` per
+            direction (from the root space).
+        """
+        return self._root_space.domain
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """Get the floating-point dtype of the space.
+
+        Returns:
+            npt.DTypeLike: Always ``numpy.float64`` (THB evaluation is float64).
+        """
+        return np.float64
+
+    @property
+    def tolerance(self) -> float:
+        """Get the numerical tolerance.
+
+        Returns:
+            float: The root space's tolerance.
+        """
+        return self._root_space.tolerance
 
     # ------------------------------------------------------------------
     # Public API
@@ -1320,7 +1351,7 @@ class THBSplineSpace:
 
         Returns:
             npt.NDArray[np.float64]: Matrix ``P`` of shape
-            ``(fine.num_active_functions, self.num_active_functions)``.
+            ``(fine.num_total_basis, self.num_total_basis)``.
 
         Raises:
             TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
@@ -1368,8 +1399,8 @@ class THBSplineSpace:
             flats = np.ravel_multi_index([g.ravel() for g in mesh], num_basis_finest)
             return flats, coeffs.ravel()
 
-        coarse_cols = [column_flats(self, i) for i in range(self.num_active_functions)]
-        fine_cols = [column_flats(fine, j) for j in range(fine.num_active_functions)]
+        coarse_cols = [column_flats(self, i) for i in range(self.num_total_basis)]
+        fine_cols = [column_flats(fine, j) for j in range(fine.num_total_basis)]
 
         touched = sorted(
             {int(f) for flats, _ in (*coarse_cols, *fine_cols) for f in flats.tolist()}
@@ -1377,10 +1408,10 @@ class THBSplineSpace:
         touched_arr = np.array(touched, dtype=np.int64)
         n_rows = touched_arr.shape[0]
 
-        coarse_mat = np.zeros((n_rows, self.num_active_functions), dtype=np.float64)
+        coarse_mat = np.zeros((n_rows, self.num_total_basis), dtype=np.float64)
         for i, (flats, vals) in enumerate(coarse_cols):
             coarse_mat[np.searchsorted(touched_arr, flats), i] = vals
-        fine_mat = np.zeros((n_rows, fine.num_active_functions), dtype=np.float64)
+        fine_mat = np.zeros((n_rows, fine.num_total_basis), dtype=np.float64)
         for j, (flats, vals) in enumerate(fine_cols):
             fine_mat[np.searchsorted(touched_arr, flats), j] = vals
 
@@ -1410,7 +1441,7 @@ class THBSplineSpace:
 
         Returns:
             npt.NDArray[np.float64]: Matrix ``R`` of shape
-            ``(coarse.num_active_functions, self.num_active_functions)``.
+            ``(coarse.num_total_basis, self.num_total_basis)``.
 
         Raises:
             TypeError: If ``coarse`` is not a :class:`THBSplineSpace`.
@@ -1433,6 +1464,6 @@ class THBSplineSpace:
         """
         return (
             f"THBSplineSpace(dim={self.dim}, degrees={self.degrees}, "
-            f"num_levels={self.num_levels}, num_active_functions={self._num_active}, "
+            f"num_levels={self.num_levels}, num_total_basis={self._num_active}, "
             f"truncate={self._truncate})"
         )

--- a/tests/_thb_assembly.py
+++ b/tests/_thb_assembly.py
@@ -67,8 +67,8 @@ def _assemble(
     for cid in range(thb.grid.num_cells):
         pts = np.ascontiguousarray(pts_all[cid], dtype=np.float64)
         wts = np.asarray(wts_all[cid], dtype=np.float64)
-        vals = np.asarray(thb.tabulate_basis(cid, pts), dtype=np.float64)
-        dofs = thb.active_basis(cid)
+        vals_arr, dofs = thb.tabulate_basis(cid, pts)
+        vals = np.asarray(vals_arr, dtype=np.float64)
         mass[np.ix_(dofs, dofs)] += vals.T @ (vals * wts[:, None])
         if func is not None:
             fvals = np.asarray(func(pts), dtype=np.float64).reshape(pts.shape[0])

--- a/tests/_thb_assembly.py
+++ b/tests/_thb_assembly.py
@@ -57,7 +57,7 @@ def _assemble(
         ``(num_active, num_active)`` and ``(num_active,)``.
     """
     dim = thb.dim
-    n = thb.num_active_functions
+    n = thb.num_total_basis
     nq = max(thb.degrees) + 1 if n_quad is None else n_quad
     rule = gauss_legendre_quadrature(dim, nq)
     pts_all, wts_all = cell_quadrature(thb.grid, rule)

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -59,7 +59,7 @@ def _reproduction_error(thb: THBSplineSpace) -> float:
         c_op = mle.operator(cid)
         bernstein = tabulate_bernstein(degrees, xi)
         from_extraction = (c_op @ bernstein.T).T
-        direct = thb.tabulate_basis(cid, x)
+        direct, _ = thb.tabulate_basis(cid, x)
         err = max(err, float(np.abs(from_extraction - direct).max()))
         # C == M @ E by construction.
         m_op = mle.multilevel_operator(cid)

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -55,7 +55,7 @@ def _thb_reproduction_error(thb: THBSplineSpace, seed: int = 0) -> float:
     coeffs = rng.standard_normal(thb.num_total_basis)
     f = THBSpline(thb, coeffs)
     recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
-    return float(np.abs(recovered.coeffs - coeffs).max())
+    return float(np.abs(recovered.control_points - coeffs).max())
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -197,7 +197,7 @@ class TestThbReproduction:
         f = THBSpline(thb, coeffs)
         recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
         assert recovered.rank == 2
-        np.testing.assert_allclose(recovered.coeffs, coeffs, atol=1e-10)
+        np.testing.assert_allclose(recovered.control_points, coeffs, atol=1e-10)
 
     def test_multiple_candidate_cells_selects_nearest(self) -> None:
         # Refine two non-adjacent cells so a coarse dof whose support spans both
@@ -239,7 +239,7 @@ class TestConvergence:
         root = _root_1d()
         tp = quasi_interpolate_bspline(f, root)
         thb = quasi_interpolate_thb_spline(f, THBSplineSpace(root, _grid_1d()))
-        np.testing.assert_allclose(thb.coeffs, tp.control_points.ravel(), atol=1e-12)
+        np.testing.assert_allclose(thb.control_points, tp.control_points.ravel(), atol=1e-12)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -260,8 +260,8 @@ class TestHb:
         grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
         qi = quasi_interpolate_thb_spline(lambda p: np.sin(p[:, 0]), thb)
-        assert qi.coeffs.shape == (thb.num_total_basis,)
-        assert np.all(np.isfinite(qi.coeffs))
+        assert qi.control_points.shape == (thb.num_total_basis,)
+        assert np.all(np.isfinite(qi.control_points))
 
     def test_bad_space_raises(self) -> None:
         with pytest.raises(TypeError, match="THBSplineSpace"):
@@ -315,14 +315,14 @@ class TestThbSpline:
         assert spline.dim == 1
         assert spline.rank == 1
         assert spline.dtype == np.float64
-        assert spline.coeffs.shape == (thb.num_total_basis,)
+        assert spline.control_points.shape == (thb.num_total_basis,)
         assert "THBSpline" in repr(spline)
 
     def test_vector_coeffs_shape(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         spline = THBSpline(thb, np.zeros((thb.num_total_basis, 3)))
         assert spline.rank == 3
-        assert spline.coeffs.shape == (thb.num_total_basis, 3)
+        assert spline.control_points.shape == (thb.num_total_basis, 3)
         xs = np.array([[0.1], [0.9]])
         assert np.asarray(spline.evaluate(xs)).shape == (2, 3)
 
@@ -369,13 +369,13 @@ class TestThbSpline:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         spline = THBSpline(thb, np.ones(thb.num_total_basis))
         with pytest.raises(ValueError, match="read-only"):
-            spline.coeffs[:] = 0.0
+            spline.control_points[:] = 0.0
 
     def test_vector_coeffs_readonly(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         spline = THBSpline(thb, np.ones((thb.num_total_basis, 2)))
         with pytest.raises(ValueError, match="read-only"):
-            spline.coeffs[:] = 0.0
+            spline.control_points[:] = 0.0
 
     def test_evaluate_vector_refined_2d(self) -> None:
         # Vector-valued evaluate on a refined 2D grid exercises the full
@@ -396,3 +396,51 @@ class TestThbSpline:
             vals, dofs = thb.tabulate_basis(cid, p.reshape(1, -1))
             expected = vals[0] @ coeffs[dofs]
             np.testing.assert_allclose(got[i], expected, atol=1e-13)
+
+    def test_degree_property(self) -> None:
+        # Mirrors Bspline.degree.
+        thb = THBSplineSpace(_root_2d(), _grid_2d())
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
+        assert spline.degree == thb.degrees == (2, 2)
+
+    def test_evaluate_out_argument(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2, thb)
+        xs = _sample(1)
+        out = np.empty(xs.shape[0], dtype=np.float64)
+        ret = spline.evaluate(xs, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, spline.evaluate(xs))
+
+    def test_evaluate_out_bad_shape_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
+        with pytest.raises(ValueError, match="shape"):
+            spline.evaluate(np.array([[0.1], [0.2]]), out=np.empty(99))
+
+    def test_evaluate_derivatives_reproduces_polynomial_derivative(self) -> None:
+        # On a refined THB space, QI reproduces x^2 exactly; its derivative is 2x.
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        spline = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2, thb)
+        xs = _sample(1)
+        # Order 0 equals the values.
+        np.testing.assert_allclose(
+            np.asarray(spline.evaluate_derivatives(xs, 0)).ravel(),
+            np.asarray(spline.evaluate(xs)).ravel(),
+            atol=1e-12,
+        )
+        # First derivative of x^2 is 2x.
+        np.testing.assert_allclose(
+            np.asarray(spline.evaluate_derivatives(xs, 1)).ravel(), 2.0 * xs[:, 0], atol=1e-9
+        )
+
+    def test_evaluate_derivatives_out_argument(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d())
+        spline = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2, thb)
+        xs = _sample(1)
+        out = np.empty(xs.shape[0], dtype=np.float64)
+        ret = spline.evaluate_derivatives(xs, 1, out=out)
+        assert ret is out
+        np.testing.assert_allclose(out, spline.evaluate_derivatives(xs, 1))

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -52,7 +52,7 @@ def _sample(dim: int, n: int = 9) -> npt.NDArray[np.float64]:
 def _thb_reproduction_error(thb: THBSplineSpace, seed: int = 0) -> float:
     """QI of a random THB spline recovers its coefficients."""
     rng = np.random.default_rng(seed)
-    coeffs = rng.standard_normal(thb.num_active_functions)
+    coeffs = rng.standard_normal(thb.num_total_basis)
     f = THBSpline(thb, coeffs)
     recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
     return float(np.abs(recovered.coeffs - coeffs).max())
@@ -193,7 +193,7 @@ class TestThbReproduction:
         grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid)
         rng = np.random.default_rng(3)
-        coeffs = rng.standard_normal((thb.num_active_functions, 2))
+        coeffs = rng.standard_normal((thb.num_total_basis, 2))
         f = THBSpline(thb, coeffs)
         recovered = quasi_interpolate_thb_spline(f.evaluate, thb)
         assert recovered.rank == 2
@@ -260,7 +260,7 @@ class TestHb:
         grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
         qi = quasi_interpolate_thb_spline(lambda p: np.sin(p[:, 0]), thb)
-        assert qi.coeffs.shape == (thb.num_active_functions,)
+        assert qi.coeffs.shape == (thb.num_total_basis,)
         assert np.all(np.isfinite(qi.coeffs))
 
     def test_bad_space_raises(self) -> None:
@@ -296,7 +296,7 @@ class TestThbSpline:
     def test_evaluate_matches_manual_assembly(self) -> None:
         thb = THBSplineSpace(_root_2d(), _grid_2d())
         rng = np.random.default_rng(5)
-        coeffs = rng.standard_normal(thb.num_active_functions)
+        coeffs = rng.standard_normal(thb.num_total_basis)
         spline = THBSpline(thb, coeffs)
         pts = _sample(2, 5)
         got = np.asarray(spline.evaluate(pts)).ravel()
@@ -310,19 +310,19 @@ class TestThbSpline:
 
     def test_properties_and_repr(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
         assert spline.space is thb
         assert spline.dim == 1
         assert spline.rank == 1
         assert spline.dtype == np.float64
-        assert spline.coeffs.shape == (thb.num_active_functions,)
+        assert spline.coeffs.shape == (thb.num_total_basis,)
         assert "THBSpline" in repr(spline)
 
     def test_vector_coeffs_shape(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        spline = THBSpline(thb, np.zeros((thb.num_active_functions, 3)))
+        spline = THBSpline(thb, np.zeros((thb.num_total_basis, 3)))
         assert spline.rank == 3
-        assert spline.coeffs.shape == (thb.num_active_functions, 3)
+        assert spline.coeffs.shape == (thb.num_total_basis, 3)
         xs = np.array([[0.1], [0.9]])
         assert np.asarray(spline.evaluate(xs)).shape == (2, 3)
 
@@ -333,24 +333,24 @@ class TestThbSpline:
     def test_bad_coeffs_length_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="length"):
-            THBSpline(thb, np.zeros(thb.num_active_functions + 1))
+            THBSpline(thb, np.zeros(thb.num_total_basis + 1))
 
     def test_out_of_domain_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
         with pytest.raises(ValueError, match="outside"):
             spline.evaluate(np.array([[2.0]]))
 
     def test_wrong_trailing_dim_raises(self) -> None:
         thb = THBSplineSpace(_root_2d(), _grid_2d())
-        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
         with pytest.raises(ValueError, match="trailing dimension"):
             spline.evaluate(np.array([[0.1]]))
 
     def test_stale_grid_raises_on_evaluate(self) -> None:
         grid = _grid_1d()
         thb = THBSplineSpace(_root_1d(), grid)
-        spline = THBSpline(thb, np.zeros(thb.num_active_functions))
+        spline = THBSpline(thb, np.zeros(thb.num_total_basis))
         grid.refine(0, [0], [2])
         with pytest.raises(RuntimeError, match="stale"):
             spline.evaluate(np.array([[0.5]]))
@@ -358,22 +358,22 @@ class TestThbSpline:
     def test_bad_coeffs_ndim_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="1-D or 2-D"):
-            THBSpline(thb, np.zeros((thb.num_active_functions, 2, 2)))
+            THBSpline(thb, np.zeros((thb.num_total_basis, 2, 2)))
 
     def test_bad_coeffs_2d_leading_dim_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
         with pytest.raises(ValueError, match="leading dimension"):
-            THBSpline(thb, np.zeros((thb.num_active_functions + 1, 2)))
+            THBSpline(thb, np.zeros((thb.num_total_basis + 1, 2)))
 
     def test_coeffs_readonly(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        spline = THBSpline(thb, np.ones(thb.num_active_functions))
+        spline = THBSpline(thb, np.ones(thb.num_total_basis))
         with pytest.raises(ValueError, match="read-only"):
             spline.coeffs[:] = 0.0
 
     def test_vector_coeffs_readonly(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d())
-        spline = THBSpline(thb, np.ones((thb.num_active_functions, 2)))
+        spline = THBSpline(thb, np.ones((thb.num_total_basis, 2)))
         with pytest.raises(ValueError, match="read-only"):
             spline.coeffs[:] = 0.0
 
@@ -384,7 +384,7 @@ class TestThbSpline:
         grid.refine(0, [1, 1], [3, 3])
         thb = THBSplineSpace(_root_2d(), grid)
         rng = np.random.default_rng(7)
-        coeffs = rng.standard_normal((thb.num_active_functions, 2))
+        coeffs = rng.standard_normal((thb.num_total_basis, 2))
         spline = THBSpline(thb, coeffs)
         pts = _sample(2, 5)
         got = np.asarray(spline.evaluate(pts))

--- a/tests/test_quasi_interpolation.py
+++ b/tests/test_quasi_interpolation.py
@@ -304,8 +304,8 @@ class TestThbSpline:
         for i, p in enumerate(pts):
             cid = thb.grid.locate(p)
             assert cid is not None
-            dofs = thb.active_basis(cid)
-            manual[i] = thb.tabulate_basis(cid, p.reshape(1, -1))[0] @ coeffs[dofs]
+            vals, dofs = thb.tabulate_basis(cid, p.reshape(1, -1))
+            manual[i] = vals[0] @ coeffs[dofs]
         np.testing.assert_allclose(got, manual, atol=1e-13)
 
     def test_properties_and_repr(self) -> None:
@@ -393,6 +393,6 @@ class TestThbSpline:
         for i, p in enumerate(pts):
             cid = thb.grid.locate(p)
             assert cid is not None
-            dofs = thb.active_basis(cid)
-            expected = thb.tabulate_basis(cid, p.reshape(1, -1))[0] @ coeffs[dofs]
+            vals, dofs = thb.tabulate_basis(cid, p.reshape(1, -1))
+            expected = vals[0] @ coeffs[dofs]
             np.testing.assert_allclose(got[i], expected, atol=1e-13)

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -59,8 +59,7 @@ def _collocation(
         axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(dim)]
         mesh = np.meshgrid(*axes, indexing="ij")
         cell_pts = np.stack([m.ravel() for m in mesh], axis=-1)
-        active = thb.active_basis(cid)
-        values = thb.tabulate_basis(cid, cell_pts)
+        values, active = thb.tabulate_basis(cid, cell_pts)
         for i in range(cell_pts.shape[0]):
             row = np.zeros(n_active)
             row[active] = values[i]
@@ -292,8 +291,7 @@ class TestEvaluation:
         for cid in range(grid.num_cells):
             lo, hi = grid.cell_bounds(cid)
             mid = (0.5 * (lo + hi)).reshape(1, thb.dim)
-            active = thb.active_basis(cid)
-            values = thb.tabulate_basis(cid, mid)
+            values, active = thb.tabulate_basis(cid, mid)
             assert values.shape == (1, active.shape[0])
             # B-splines nonzero on the cell are strictly positive at its midpoint.
             assert np.all(values[0] > 0.0)
@@ -308,26 +306,35 @@ class TestEvaluation:
         mat, _ = _collocation(thb)
         assert mat.min() >= 0.0
 
-    def test_tabulate_basis_out_argument(self) -> None:
+    def test_tabulate_basis_out_arguments(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         pts = np.array([[0.1], [0.2]])
         k = thb.active_basis(0).shape[0]
-        out = np.empty((2, k), dtype=np.float64)
-        ret = thb.tabulate_basis(0, pts, out=out)
-        assert ret is out
-        np.testing.assert_allclose(out, thb.tabulate_basis(0, pts))
+        out_basis = np.empty((2, k), dtype=np.float64)
+        out_dofs = np.empty((k,), dtype=np.int64)
+        vals, dofs = thb.tabulate_basis(0, pts, out_basis=out_basis, out_dofs=out_dofs)
+        assert vals is out_basis
+        assert dofs is out_dofs
+        exp_vals, exp_dofs = thb.tabulate_basis(0, pts)
+        np.testing.assert_allclose(out_basis, exp_vals)
+        np.testing.assert_array_equal(out_dofs, exp_dofs)
 
     def test_tabulate_basis_bad_out_shape_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         with pytest.raises(ValueError, match="shape"):
-            thb.tabulate_basis(0, np.array([[0.1]]), out=np.empty((1, 99)))
+            thb.tabulate_basis(0, np.array([[0.1]]), out_basis=np.empty((1, 99)))
+
+    def test_tabulate_basis_bad_out_dofs_shape_raises(self) -> None:
+        thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(ValueError, match="out_dofs must have shape"):
+            thb.tabulate_basis(0, np.array([[0.1]]), out_dofs=np.empty((99,), dtype=np.int64))
 
     def test_tabulate_basis_bad_out_dtype_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         k = thb.active_basis(0).shape[0]
         out_bad = np.empty((1, k), dtype=np.float32)
         with pytest.raises(ValueError, match="dtype"):
-            thb.tabulate_basis(0, np.array([[0.1]]), out=out_bad)  # type: ignore[arg-type]
+            thb.tabulate_basis(0, np.array([[0.1]]), out_basis=out_bad)  # type: ignore[arg-type]
 
     def test_tabulate_basis_readonly_out_raises(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
@@ -335,7 +342,7 @@ class TestEvaluation:
         out = np.empty((1, k), dtype=np.float64)
         out.flags.writeable = False
         with pytest.raises(ValueError, match="writeable"):
-            thb.tabulate_basis(0, np.array([[0.1]]), out=out)
+            thb.tabulate_basis(0, np.array([[0.1]]), out_basis=out)
 
     def test_tabulate_basis_bad_point_dim_raises(self) -> None:
         thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
@@ -361,7 +368,7 @@ class TestEvaluation:
     def test_tabulate_basis_scalar_point(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
         # Shape (dim,) — single point without a leading batch dimension.
-        result = thb.tabulate_basis(0, np.array([0.1]))
+        result, _ = thb.tabulate_basis(0, np.array([0.1]))
         assert result.ndim == 1
         assert result.shape[0] == thb.active_basis(0).shape[0]
 
@@ -375,7 +382,7 @@ class TestEvaluation:
         assert cid is not None
         lo, hi = grid.cell_bounds(cid)
         mid = float(0.5 * (lo[0] + hi[0]))
-        total = thb.tabulate_basis(cid, np.array([[mid]])).sum()
+        total = thb.tabulate_basis(cid, np.array([[mid]]))[0].sum()
         # Functions from both level 0 and level 1 contribute; sum > 1.
         assert total > 1.0
 
@@ -525,7 +532,7 @@ class TestTruncation:
         pts = lo + (hi - lo) * np.linspace(0.1, 0.9, 5)[:, None]
         np.testing.assert_array_equal(thb.active_basis(cid), hb.active_basis(cid))
         np.testing.assert_allclose(
-            thb.tabulate_basis(cid, pts), hb.tabulate_basis(cid, pts), atol=1e-12
+            thb.tabulate_basis(cid, pts)[0], hb.tabulate_basis(cid, pts)[0], atol=1e-12
         )
 
     def test_truncation_restores_partition_of_unity_on_refined_cell(self) -> None:
@@ -538,8 +545,8 @@ class TestTruncation:
         cid = grid.locate([0.1])  # refined region
         assert cid is not None
         pt = np.array([[0.1]])
-        assert thb.tabulate_basis(cid, pt).sum() == pytest.approx(1.0, abs=1e-12)
-        assert hb.tabulate_basis(cid, pt).sum() > 1.0 + 1e-3
+        assert thb.tabulate_basis(cid, pt)[0].sum() == pytest.approx(1.0, abs=1e-12)
+        assert hb.tabulate_basis(cid, pt)[0].sum() > 1.0 + 1e-3
 
     def test_repr_truncate_true(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
@@ -552,10 +559,11 @@ class TestTruncation:
         active = thb.active_basis(cid)
         assert any(dof in thb._trunc for dof in active), "no truncated dof on this cell"
         pts = np.array([[0.1, 0.1]])
-        out = np.empty((1, active.shape[0]), dtype=np.float64)
-        ret = thb.tabulate_basis(cid, pts, out=out)
-        assert ret is out
-        np.testing.assert_allclose(out, thb.tabulate_basis(cid, pts))
+        out_basis = np.empty((1, active.shape[0]), dtype=np.float64)
+        vals, _ = thb.tabulate_basis(cid, pts, out_basis=out_basis)
+        assert vals is out_basis
+        exp, _ = thb.tabulate_basis(cid, pts)
+        np.testing.assert_allclose(out_basis, exp)
 
     def test_deepest_level_functions_not_in_trunc(self) -> None:
         # Active functions at the deepest level have no finer level below;
@@ -589,8 +597,8 @@ class TestTruncation:
         mid = (0.5 * (lo + hi)).reshape(1, -1)
         thb_active = thb.active_basis(cid)
         hb_active = hb.active_basis(cid)
-        thb_vals = thb.tabulate_basis(cid, mid)[0]
-        hb_vals = hb.tabulate_basis(cid, mid)[0]
+        thb_vals = thb.tabulate_basis(cid, mid)[0][0]
+        hb_vals = hb.tabulate_basis(cid, mid)[0][0]
         found_truncated = False
         for i, dof in enumerate(thb_active):
             if dof in thb._trunc:
@@ -620,9 +628,10 @@ class TestTruncation:
         ts = np.linspace(0.1, 0.9, 6)
         pts_flat = lo + (hi - lo) * ts[:, None]  # (6, 2)
         pts = pts_flat.reshape(2, 3, thb.dim)
-        result = thb.tabulate_basis(cid, pts)
+        result, dofs = thb.tabulate_basis(cid, pts)
         n_active = thb.active_basis(cid).shape[0]
         assert result.shape == (2, 3, n_active)
+        assert dofs.shape == (n_active,)
         np.testing.assert_allclose(result.sum(axis=-1), 1.0, atol=1e-10)
 
     def test_thb_and_hb_same_active_count(self) -> None:
@@ -697,8 +706,7 @@ def _collocation_derivatives(
         axes = [lo[k] + (hi[k] - lo[k]) * u for k in range(dim)]
         mesh = np.meshgrid(*axes, indexing="ij")
         cell_pts = np.stack([m.ravel() for m in mesh], axis=-1)
-        active = thb.active_basis(cid)
-        values = thb.tabulate_basis_derivatives(cid, cell_pts, orders)
+        values, active = thb.tabulate_basis_derivatives(cid, cell_pts, orders)
         for i in range(cell_pts.shape[0]):
             row = np.zeros(n_active)
             row[active] = values[i]
@@ -717,7 +725,7 @@ class TestDerivatives:
         lo, hi = thb.grid.cell_bounds(cid)
         pts = (lo + (hi - lo) * 0.5).reshape(1, thb.dim)
         np.testing.assert_allclose(
-            thb.tabulate_basis_derivatives(cid, pts, 0), thb.tabulate_basis(cid, pts)
+            thb.tabulate_basis_derivatives(cid, pts, 0)[0], thb.tabulate_basis(cid, pts)[0]
         )
 
     def test_order_zero_equals_values_hb(self) -> None:
@@ -730,7 +738,7 @@ class TestDerivatives:
         lo, hi = grid.cell_bounds(cid)
         pts = lo + (hi - lo) * np.array([0.25, 0.5, 0.75])[:, None]
         np.testing.assert_allclose(
-            hb.tabulate_basis_derivatives(cid, pts, 0), hb.tabulate_basis(cid, pts)
+            hb.tabulate_basis_derivatives(cid, pts, 0)[0], hb.tabulate_basis(cid, pts)[0]
         )
 
     def test_partition_of_unity_derivative_is_zero_1d(self) -> None:
@@ -774,10 +782,10 @@ class TestDerivatives:
             lo, hi = thb.grid.cell_bounds(cid)
             x = float(0.5 * (lo[0] + hi[0]))
             fd = (
-                thb.tabulate_basis(cid, np.array([[x + h]]))
-                - thb.tabulate_basis(cid, np.array([[x - h]]))
+                thb.tabulate_basis(cid, np.array([[x + h]]))[0]
+                - thb.tabulate_basis(cid, np.array([[x - h]]))[0]
             ) / (2.0 * h)
-            analytic = thb.tabulate_basis_derivatives(cid, np.array([[x]]), 1)
+            analytic = thb.tabulate_basis_derivatives(cid, np.array([[x]]), 1)[0]
             np.testing.assert_allclose(fd, analytic, atol=1e-6)
 
     def test_high_order_is_zero(self) -> None:
@@ -785,7 +793,7 @@ class TestDerivatives:
         thb = _refined_1d_three_levels()
         cid = thb.grid.locate([0.1])
         assert cid is not None
-        result = thb.tabulate_basis_derivatives(cid, np.array([[0.1]]), 3)
+        result, _ = thb.tabulate_basis_derivatives(cid, np.array([[0.1]]), 3)
         np.testing.assert_allclose(result, 0.0, atol=1e-12)
 
     def test_orders_length_mismatch_raises(self) -> None:
@@ -805,10 +813,11 @@ class TestDerivatives:
         lo, hi = thb.grid.cell_bounds(cid)
         pts = lo + (hi - lo) * np.array([0.3, 0.6])[:, None]
         k = thb.active_basis(cid).shape[0]
-        out = np.empty((2, k), dtype=np.float64)
-        ret = thb.tabulate_basis_derivatives(cid, pts, 1, out=out)
-        assert ret is out
-        np.testing.assert_allclose(out, thb.tabulate_basis_derivatives(cid, pts, 1))
+        out_basis = np.empty((2, k), dtype=np.float64)
+        vals, _ = thb.tabulate_basis_derivatives(cid, pts, 1, out_basis=out_basis)
+        assert vals is out_basis
+        exp, _ = thb.tabulate_basis_derivatives(cid, pts, 1)
+        np.testing.assert_allclose(out_basis, exp)
 
     def test_hb_derivative_reproduction(self) -> None:
         root = _root_1d()
@@ -845,8 +854,7 @@ def _nonzero_level_span(thb: THBSplineSpace) -> int:
         lo, hi = grid.cell_bounds(cid)
         mesh = np.meshgrid(*[lo[k] + (hi[k] - lo[k]) * u for k in range(thb.dim)], indexing="ij")
         pts = np.stack([m.ravel() for m in mesh], axis=-1)
-        active = thb.active_basis(cid)
-        vals = thb.tabulate_basis(cid, pts)
+        vals, active = thb.tabulate_basis(cid, pts)
         nonzero = active[np.abs(vals).max(axis=0) > 1e-12]
         if nonzero.size == 0:
             continue
@@ -859,8 +867,8 @@ def _field_at(
     thb: THBSplineSpace, coeffs: npt.NDArray[np.float64], cid: int, pts: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     """Evaluate the field ``sum coeffs[i] Phi_i`` at ``pts`` on cell ``cid``."""
-    active = thb.active_basis(cid)
-    result: npt.NDArray[np.float64] = thb.tabulate_basis(cid, pts) @ coeffs[active]
+    values, active = thb.tabulate_basis(cid, pts)
+    result: npt.NDArray[np.float64] = values @ coeffs[active]
     return result
 
 

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -49,7 +49,7 @@ def _collocation(
     """
     grid = thb.grid
     dim = thb.dim
-    n_active = thb.num_active_functions
+    n_active = thb.num_total_basis
     npa = (thb.degrees[0] + 3) if n_per_axis is None else n_per_axis
     u = np.linspace(0.0, 1.0, npa)[1:-1]
     rows: list[npt.NDArray[np.float64]] = []
@@ -154,13 +154,13 @@ class TestUnrefined:
     def test_active_count_equals_root_1d(self) -> None:
         root = _root_1d()
         thb = THBSplineSpace(root, _grid_1d(), truncate=False)
-        assert thb.num_active_functions == root.num_total_basis
-        assert thb.num_active_functions_per_level == (root.num_total_basis,)
+        assert thb.num_total_basis == root.num_total_basis
+        assert thb.num_basis_per_level == (root.num_total_basis,)
 
     def test_active_count_equals_root_2d(self) -> None:
         root = _root_2d()
         thb = THBSplineSpace(root, _grid_2d(), truncate=False)
-        assert thb.num_active_functions == root.num_total_basis
+        assert thb.num_total_basis == root.num_total_basis
 
     def test_partition_of_unity_when_unrefined(self) -> None:
         thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=False)
@@ -228,7 +228,7 @@ class TestSelection:
         grid = _grid_1d()
         grid.refine(0, [0], [2])
         thb = THBSplineSpace(_root_1d(), grid, truncate=False)
-        assert thb.num_active_functions_per_level == (4, 4)
+        assert thb.num_basis_per_level == (4, 4)
         np.testing.assert_array_equal(thb.active_function_indices(0), [2, 3, 4, 5])
         np.testing.assert_array_equal(thb.active_function_indices(1), [0, 1, 2, 3])
 
@@ -272,8 +272,8 @@ class TestSelection:
         grid = _grid_1d()
         grid.refine(0, [0], [4])
         thb = THBSplineSpace(root, grid, truncate=False)
-        assert thb.num_active_functions_per_level[0] == 0
-        assert thb.num_active_functions_per_level[1] > 0
+        assert thb.num_basis_per_level[0] == 0
+        assert thb.num_basis_per_level[1] > 0
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -445,7 +445,7 @@ class TestLevelSpaces:
         # Axis 0 subdivided (8 intervals), axis 1 unchanged (4 intervals).
         assert level1.num_intervals == (8, 4)
         assert level0.num_intervals == (4, 4)
-        assert thb.num_active_functions == sum(thb.num_active_functions_per_level)
+        assert thb.num_total_basis == sum(thb.num_basis_per_level)
         assert _max_reproduction_residual(thb, lambda p: p[:, 0] * p[:, 1]) < 1e-9
 
 
@@ -504,12 +504,12 @@ class TestTruncation:
     def test_some_functions_truncated(self) -> None:
         thb = _refined_2d_corner()
         n_truncated = len(thb._trunc)
-        assert 0 < n_truncated < thb.num_active_functions
+        assert 0 < n_truncated < thb.num_total_basis
 
     def test_no_truncation_when_unrefined(self) -> None:
         thb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=True)
         assert len(thb._trunc) == 0
-        assert thb.num_active_functions == _root_1d().num_total_basis
+        assert thb.num_total_basis == _root_1d().num_total_basis
 
     def test_truncation_identity_outside_refinement(self) -> None:
         # On a cell entirely outside the refined region, truncation changes nothing:
@@ -563,7 +563,7 @@ class TestTruncation:
         thb = _refined_1d_three_levels()
         deepest = thb.num_levels - 1
         offset = int(thb._func_offset[deepest])
-        count = int(thb.num_active_functions_per_level[deepest])
+        count = int(thb.num_basis_per_level[deepest])
         for i in range(count):
             assert offset + i not in thb._trunc
 
@@ -631,9 +631,9 @@ class TestTruncation:
         grid.refine(0, [0, 0], [2, 2])
         thb = THBSplineSpace(root, grid, truncate=True)
         hb = THBSplineSpace(root, grid, truncate=False)
-        assert thb.num_active_functions == hb.num_active_functions
-        assert thb.num_active_functions_per_level == hb.num_active_functions_per_level
-        assert thb.num_active_functions == sum(thb.num_active_functions_per_level)
+        assert thb.num_total_basis == hb.num_total_basis
+        assert thb.num_basis_per_level == hb.num_basis_per_level
+        assert thb.num_total_basis == sum(thb.num_basis_per_level)
 
     def test_active_basis_union_covers_all_dofs(self) -> None:
         # The union of active_basis(cid) over all cells must equal {0, …, N-1}.
@@ -641,7 +641,7 @@ class TestTruncation:
         seen: set[int] = set()
         for cid in range(thb.grid.num_cells):
             seen.update(thb.active_basis(cid).tolist())
-        assert seen == set(range(thb.num_active_functions))
+        assert seen == set(range(thb.num_total_basis))
 
     def test_partition_of_unity_factor3(self) -> None:
         # Verify that factor=3 (non-power-of-2) refinement still gives partition of unity.
@@ -672,7 +672,7 @@ class TestTruncation:
         grid2 = _grid_1d()
         grid2.refine(0, [0], [2])
         thb_seq = THBSplineSpace(root, grid2, truncate=True, regularity=[0])
-        assert thb_scalar.num_active_functions == thb_seq.num_active_functions
+        assert thb_scalar.num_total_basis == thb_seq.num_total_basis
         mat, _ = _collocation(thb_seq)
         np.testing.assert_allclose(mat.sum(axis=1), 1.0, atol=1e-10)
 
@@ -688,7 +688,7 @@ def _collocation_derivatives(
     """Like :func:`_collocation` but evaluates the ``orders`` mixed partial."""
     grid = thb.grid
     dim = thb.dim
-    n_active = thb.num_active_functions
+    n_active = thb.num_total_basis
     u = np.linspace(0.0, 1.0, thb.degrees[0] + 3)[1:-1]
     rows: list[npt.NDArray[np.float64]] = []
     pts: list[npt.NDArray[np.float64]] = []
@@ -876,11 +876,11 @@ class TestRefine:
 
     def test_returns_new_space_original_unchanged(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
-        n_cells, n_active = coarse.grid.num_cells, coarse.num_active_functions
+        n_cells, n_active = coarse.grid.num_cells, coarse.num_total_basis
         fine = coarse.refine([0, 1], admissible_class=None)
         assert fine is not coarse
         assert coarse.grid.num_cells == n_cells
-        assert coarse.num_active_functions == n_active
+        assert coarse.num_total_basis == n_active
         assert fine.grid.num_cells > n_cells
 
     def test_refine_preserves_partition_of_unity(self) -> None:
@@ -986,8 +986,8 @@ class TestProlongation:
         self, coarse: THBSplineSpace, fine: THBSplineSpace, rng: np.random.Generator
     ) -> None:
         p = coarse.prolongation_to(fine)
-        assert p.shape == (fine.num_active_functions, coarse.num_active_functions)
-        u_coarse = rng.random(coarse.num_active_functions)
+        assert p.shape == (fine.num_total_basis, coarse.num_total_basis)
+        u_coarse = rng.random(coarse.num_total_basis)
         u_fine = p @ u_coarse
         u_axis = np.linspace(0.1, 0.9, 3)
         err = 0.0
@@ -1029,13 +1029,13 @@ class TestProlongation:
     def test_identity_when_no_refinement(self) -> None:
         coarse = THBSplineSpace(_root_2d(), _grid_2d())
         p = coarse.prolongation_to(coarse)
-        np.testing.assert_allclose(p, np.eye(coarse.num_active_functions), atol=1e-10)
+        np.testing.assert_allclose(p, np.eye(coarse.num_total_basis), atol=1e-10)
 
     def test_columns_reproduce_basis_functions(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         fine = coarse.refine([0])
         p = coarse.prolongation_to(fine)
-        unit = np.zeros(coarse.num_active_functions)
+        unit = np.zeros(coarse.num_total_basis)
         unit[2] = 1.0  # a single coarse basis function
         col = p[:, 2]
         for cid in range(fine.grid.num_cells):
@@ -1121,12 +1121,12 @@ class TestCoarsen:
         fine = coarse.refine([0])  # cell 0 -> children at level 1
         children = _cells_at_level(fine, 1)
         back = fine.coarsen([children[0]])  # only one of the two children marked
-        assert back.num_active_functions == fine.num_active_functions  # no-op
+        assert back.num_total_basis == fine.num_total_basis  # no-op
 
     def test_root_cells_not_coarsened(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
         back = coarse.coarsen([0])  # level-0 cell has no parent
-        assert back.num_active_functions == coarse.num_active_functions
+        assert back.num_total_basis == coarse.num_total_basis
 
     def test_coarsen_out_of_range_raises(self) -> None:
         coarse = THBSplineSpace(_root_1d(), _grid_1d())
@@ -1152,7 +1152,7 @@ class TestCoarsen:
         graded = deep.coarsen(marked, admissible_class=2)
         ungraded = deep.coarsen(marked, admissible_class=None)
         assert _nonzero_level_span(graded) <= 2
-        assert graded.num_active_functions != ungraded.num_active_functions
+        assert graded.num_total_basis != ungraded.num_total_basis
 
 
 class TestRestriction:
@@ -1161,11 +1161,9 @@ class TestRestriction:
     def _check(self, coarse: THBSplineSpace, fine: THBSplineSpace) -> None:
         prolong = coarse.prolongation_to(fine)
         restrict = fine.restriction_to(coarse)
-        assert restrict.shape == (coarse.num_active_functions, fine.num_active_functions)
-        np.testing.assert_allclose(
-            restrict @ prolong, np.eye(coarse.num_active_functions), atol=1e-9
-        )
-        u_coarse = np.random.default_rng(0).random(coarse.num_active_functions)
+        assert restrict.shape == (coarse.num_total_basis, fine.num_total_basis)
+        np.testing.assert_allclose(restrict @ prolong, np.eye(coarse.num_total_basis), atol=1e-9)
+        u_coarse = np.random.default_rng(0).random(coarse.num_total_basis)
         np.testing.assert_allclose(restrict @ (prolong @ u_coarse), u_coarse, atol=1e-9)
 
     def test_restriction_1d_thb(self) -> None:

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -72,7 +72,7 @@ class TestNonnegativityAndPartitionOfUnity:
         grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         for cid, pts in _cell_samples(thb):
-            assert thb.tabulate_basis(cid, pts).min() >= -1e-13
+            assert thb.tabulate_basis(cid, pts)[0].min() >= -1e-13
 
     @pytest.mark.parametrize("dim", [1, 2])
     def test_partition_of_unity(self, dim: int) -> None:
@@ -80,7 +80,8 @@ class TestNonnegativityAndPartitionOfUnity:
         grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
         for cid, pts in _cell_samples(thb):
-            np.testing.assert_allclose(thb.tabulate_basis(cid, pts).sum(axis=-1), 1.0, atol=1e-12)
+            vals, _ = thb.tabulate_basis(cid, pts)
+            np.testing.assert_allclose(vals.sum(axis=-1), 1.0, atol=1e-12)
 
     def test_hb_is_not_partition_of_unity(self) -> None:
         # Truncation is what restores PoU; the non-truncated basis over-counts.
@@ -89,7 +90,8 @@ class TestNonnegativityAndPartitionOfUnity:
         hb = THBSplineSpace(_root_1d(), grid, truncate=False)
         worst = 0.0
         for cid, pts in _cell_samples(hb):
-            worst = max(worst, float(np.abs(hb.tabulate_basis(cid, pts).sum(axis=-1) - 1.0).max()))
+            vals, _ = hb.tabulate_basis(cid, pts)
+            worst = max(worst, float(np.abs(vals.sum(axis=-1) - 1.0).max()))
         assert worst > 1e-3
 
 
@@ -195,6 +197,6 @@ class TestDerivativeReproduction:
         for cid in range(thb.grid.num_cells):
             lo, hi = thb.grid.cell_bounds(cid)
             x = (lo[0] + (hi[0] - lo[0]) * xi).reshape(-1, 1)
-            dofs = thb.active_basis(cid)
-            got = thb.tabulate_basis_derivatives(cid, x, 1) @ coeffs[dofs]
+            vals, dofs = thb.tabulate_basis_derivatives(cid, x, 1)
+            got = vals @ coeffs[dofs]
             np.testing.assert_allclose(got, dpoly(x[:, 0]), atol=1e-11)

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -106,7 +106,7 @@ class TestLinearIndependenceAndStability:
         eig = np.linalg.eigvalsh(mass)
         # Strictly positive spectrum ⇒ linearly independent basis (full rank).
         assert eig.min() > 0.0
-        assert np.linalg.matrix_rank(mass) == thb.num_active_functions
+        assert np.linalg.matrix_rank(mass) == thb.num_total_basis
 
     def test_condition_number_bounded_under_refinement(self) -> None:
         # Strong stability (GJS 2014, not 2012): the mesh-normalized Gram condition

--- a/tests/test_thb_validation_basis.py
+++ b/tests/test_thb_validation_basis.py
@@ -192,7 +192,7 @@ class TestDerivativeReproduction:
         def dpoly(x: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
             return np.asarray(sum(k * pcoeffs[k] * x ** (k - 1) for k in range(1, degree + 1)))
 
-        coeffs = l2_project_thb(thb, poly).coeffs
+        coeffs = l2_project_thb(thb, poly).control_points
         xi = np.linspace(0.1, 0.9, 5)
         for cid in range(thb.grid.num_cells):
             lo, hi = thb.grid.cell_bounds(cid)

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -160,7 +160,7 @@ class TestCoarseningProjection:
         def quad(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
             return np.asarray(p[:, 0] ** 2 - 0.3 * p[:, 0] + 0.1)
 
-        c_fine = l2_project_thb(fine, quad).coeffs
+        c_fine = l2_project_thb(fine, quad).control_points
         c_back = fine.restriction_to(coarse) @ c_fine
         xs = np.linspace(0.02, 0.98, 80).reshape(-1, 1).astype(np.float64)
         np.testing.assert_allclose(
@@ -173,7 +173,7 @@ class TestCoarseningProjection:
         def quad(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
             return np.asarray(p[:, 0] ** 2 + p[:, 0] * p[:, 1] - 0.5)
 
-        c_fine = l2_project_thb(fine, quad).coeffs
+        c_fine = l2_project_thb(fine, quad).control_points
         c_back = fine.restriction_to(coarse) @ c_fine
         u = np.linspace(0.05, 0.95, 7)
         pts = np.stack([m.ravel() for m in np.meshgrid(u, u, indexing="ij")], axis=-1)
@@ -217,7 +217,7 @@ class TestBezierReconstruction:
         def func(p: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
             return np.asarray(np.cos(2.0 * p[:, 0]) + (p[:, -1] if thb.dim > 1 else 0.0))
 
-        coeffs = l2_project_thb(thb, func).coeffs
+        coeffs = l2_project_thb(thb, func).control_points
         spline = THBSpline(thb, coeffs)
         ext = MultiLevelExtraction(thb)
         degrees = list(thb.degrees)

--- a/tests/test_thb_validation_identities.py
+++ b/tests/test_thb_validation_identities.py
@@ -61,7 +61,7 @@ class TestRefinementNesting:
         fine = THBSplineSpace(_root_1d(), fine_grid)
 
         rng = np.random.default_rng(0)
-        c_coarse = rng.standard_normal(coarse.num_active_functions)
+        c_coarse = rng.standard_normal(coarse.num_total_basis)
         prolong = coarse.prolongation_to(fine)
         c_fine = prolong @ c_coarse
 
@@ -108,7 +108,7 @@ class TestCoarseningExactInverse:
         prolong = coarse.prolongation_to(fine)
         restrict = fine.restriction_to(coarse)
         identity = restrict @ prolong
-        np.testing.assert_allclose(identity, np.eye(coarse.num_active_functions), atol=1e-9)
+        np.testing.assert_allclose(identity, np.eye(coarse.num_total_basis), atol=1e-9)
 
 
 class TestCoarseningProjection:
@@ -188,14 +188,14 @@ class TestCoarseningProjection:
         proj = prolong @ restrict  # coarsen, then prolong back
 
         rng = np.random.default_rng(0)
-        u = rng.standard_normal(fine.num_active_functions)
+        u = rng.standard_normal(fine.num_total_basis)
         # Genuine coarsening: a generic fine field carries detail the coarse space
         # cannot hold, so the round trip must change it (P∘R is not the identity).
         assert np.linalg.norm(proj @ u - u) > 1e-2 * np.linalg.norm(u)
         # ...yet it is an idempotent projection (re-applying it changes nothing)...
         np.testing.assert_allclose(proj @ (proj @ u), proj @ u, atol=1e-9)
         # ...onto exactly the coarse subspace.
-        assert np.linalg.matrix_rank(proj) == coarse.num_active_functions
+        assert np.linalg.matrix_rank(proj) == coarse.num_total_basis
 
 
 class TestBezierReconstruction:

--- a/tests/test_thb_validation_l2.py
+++ b/tests/test_thb_validation_l2.py
@@ -83,7 +83,7 @@ class TestL2Reproduction:
         coeffs = np.random.default_rng(dim).standard_normal(thb.num_total_basis)
         target = THBSpline(thb, coeffs)
         proj = l2_project_thb(thb, lambda p: np.asarray(target.evaluate(p)))
-        np.testing.assert_allclose(proj.coeffs, coeffs, atol=1e-9)
+        np.testing.assert_allclose(proj.control_points, coeffs, atol=1e-9)
 
 
 class TestL2Convergence:

--- a/tests/test_thb_validation_l2.py
+++ b/tests/test_thb_validation_l2.py
@@ -80,7 +80,7 @@ class TestL2Reproduction:
         grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, 4), 2)
         grid.refine(0, [0] * dim, [2] * dim)
         thb = THBSplineSpace(root, grid)
-        coeffs = np.random.default_rng(dim).standard_normal(thb.num_active_functions)
+        coeffs = np.random.default_rng(dim).standard_normal(thb.num_total_basis)
         target = THBSpline(thb, coeffs)
         proj = l2_project_thb(thb, lambda p: np.asarray(target.evaluate(p)))
         np.testing.assert_allclose(proj.coeffs, coeffs, atol=1e-9)
@@ -138,5 +138,5 @@ class TestAdaptiveEfficiency:
         err_adaptive = l2_error(l2_project_thb(adaptive, self._bump), self._bump)
 
         # Adaptive achieves a smaller error with fewer degrees of freedom.
-        assert adaptive.num_active_functions < uniform.num_active_functions
+        assert adaptive.num_total_basis < uniform.num_total_basis
         assert err_adaptive < err_uniform

--- a/tests/test_thb_validation_qi.py
+++ b/tests/test_thb_validation_qi.py
@@ -109,7 +109,7 @@ class TestQIConsistency:
         tp_qi = quasi_interpolate_bspline(_f1, root)
         # On an unrefined space the THB-QI coefficients equal the TP-QI control points
         # (the hierarchical construction collapses to the single chosen level QI).
-        np.testing.assert_allclose(thb_qi.coeffs, tp_qi.control_points.ravel(), atol=1e-12)
+        np.testing.assert_allclose(thb_qi.control_points, tp_qi.control_points.ravel(), atol=1e-12)
 
 
 class TestHBQuasiInterpolationDegraded:

--- a/tests/test_thb_validation_qi.py
+++ b/tests/test_thb_validation_qi.py
@@ -161,5 +161,5 @@ class TestQIAdaptiveEfficiency:
         adaptive = self._space([(0, [3], [5]), (1, [7], [9])])
         err_uniform = l2_error(quasi_interpolate_thb_spline(self._bump, uniform), self._bump)
         err_adaptive = l2_error(quasi_interpolate_thb_spline(self._bump, adaptive), self._bump)
-        assert adaptive.num_active_functions < uniform.num_active_functions
+        assert adaptive.num_total_basis < uniform.num_total_basis
         assert err_adaptive < err_uniform


### PR DESCRIPTION
## Summary

PR9 of the THB-splines feature (#164): a breaking refactor that makes the hierarchical
classes mirror the tensor-product `BsplineSpace`/`Bspline` API as closely as possible, so
generic consumers and assembly code work uniformly across both. (Hard rename, no deprecation
aliases — pre-1.0, all callers internal + tests.)

**`THBSplineSpace`**
- `num_active_functions` → **`num_total_basis`** (mirrors TP's int property; the hierarchical
  basis is not tensor-product so there is no per-direction `num_basis`), `num_active_functions_per_level`
  → **`num_basis_per_level`**.
- new properties **`domain`**, **`dtype`**, **`tolerance`** (mirroring `BsplineSpace`).
- **`tabulate_basis`** / **`tabulate_basis_derivatives`** now return **`(values, dofs)`** — like
  TP's `(basis, first_basis)` — so callers get values + dof indices in one call instead of also
  calling `active_basis` (which recomputes `_cell_contributions`). `out` → `out_basis`, plus a new
  optional `out_dofs`. `active_basis` stays for index-only queries.

**`THBSpline`** (aligned with `Bspline`)
- `coeffs` → **`control_points`** (param + read-only property; stays flat since the basis is not TP).
- add **`degree`** property, an **`out=`** argument on `evaluate`, and **`evaluate_derivatives(pts, orders, out=None)`**.

TP-only members that are intrinsically tensor-product (`num_basis` tuple, `num_intervals`, `spaces`,
`knots`, knot-manipulation / `to_bezier` / `split` / geometry ops) are out of scope — meaningless
for a hierarchical basis.

## Test plan
- [x] All call sites swept (src + tests); two-return migrations dedupe `active_basis`
- [x] new coverage: `out_dofs`, `THBSpline.degree`, `evaluate(out=)`, `evaluate_derivatives`
- [x] full suite (3079 passed), ruff, ruff-format, mypy, docs (-W)

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)