### PR TITLE
perf(bspline): speed up THB evaluation (Numba kernel + vectorize + cache) (PR10 of #164)

### DIFF
--- a/benchmarks/bench_thb_eval.py
+++ b/benchmarks/bench_thb_eval.py
@@ -45,14 +45,14 @@ def _sweep(thb: THBSplineSpace, xi: np.ndarray, orders: tuple[int, ...] | None) 
             thb.tabulate_basis_derivatives(cid, pts, orders)
 
 
-def _best_ms(thb: THBSplineSpace, xi: np.ndarray, orders: tuple[int, ...] | None) -> float:
-    """Minimum wall time (ms) of the sweep over ``_N_REPEATS`` runs."""
+def _best_us(thb: THBSplineSpace, xi: np.ndarray, orders: tuple[int, ...] | None) -> float:
+    """Minimum wall time (µs) of the sweep over ``_N_REPEATS`` runs."""
     best = float("inf")
     for _ in range(_N_REPEATS):
         t0 = time.perf_counter()
         _sweep(thb, xi, orders)
         best = min(best, time.perf_counter() - t0)
-    return best * 1e3
+    return best * 1e6
 
 
 def main() -> None:
@@ -67,8 +67,8 @@ def main() -> None:
         deriv_orders = (1,) + (0,) * (dim - 1)
         _sweep(thb, xi, None)  # warm up the JIT / cache
         _sweep(thb, xi, deriv_orders)
-        values_us = _best_ms(thb, xi, None) * 1e3 / nc
-        deriv_us = _best_ms(thb, xi, deriv_orders) * 1e3 / nc
+        values_us = _best_us(thb, xi, None) / nc
+        deriv_us = _best_us(thb, xi, deriv_orders) / nc
         print(f"{f'{dim}D deg{degree} n{n}':>16}  {nc:>6}  {values_us:>10.1f}  {deriv_us:>10.1f}")
 
 

--- a/benchmarks/bench_thb_eval.py
+++ b/benchmarks/bench_thb_eval.py
@@ -1,0 +1,76 @@
+"""Benchmark: THBSplineSpace per-cell evaluation (FEM-assembly hot path).
+
+Usage::
+
+    conda run -n pantr python benchmarks/bench_thb_eval.py
+
+Builds refined 2D and 3D truncated-hierarchical spaces and times an assembly-like
+sweep — :meth:`THBSplineSpace.tabulate_basis` (and a first-derivative sweep) at a few
+points on every active cell — reporting microseconds per cell.  The 1D basis evaluation
+is Numba-jitted; this measures the THB combine/orchestration cost targeted by the
+``_combine_tp_values`` kernel, the vectorized truncated column, and the
+``_cell_contributions`` cache.  Run with ``NUMBA_DISABLE_JIT=1`` to see the pure-Python
+cost instead.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from pantr.bspline import THBSplineSpace, create_uniform_space
+from pantr.grid import hierarchical_grid, uniform_grid
+
+_N_REPEATS = 6
+
+
+def _build(dim: int, n: int, degree: int) -> THBSplineSpace:
+    """Build a two-band refined THB space: ``dim``-D, ``n`` root cells/axis, given degree."""
+    root = create_uniform_space([degree] * dim, [n] * dim)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]] * dim, n), 2)
+    grid.refine(0, [n // 4] * dim, [3 * n // 4] * dim)
+    grid.refine(1, [3 * n // 4] * dim, [5 * n // 4] * dim)
+    return THBSplineSpace(root, grid)
+
+
+def _sweep(thb: THBSplineSpace, xi: np.ndarray, orders: tuple[int, ...] | None) -> None:
+    """Evaluate ``tabulate_basis`` (or derivatives) at ``xi`` on every active cell."""
+    for cid in range(thb.grid.num_cells):
+        lo, hi = thb.grid.cell_bounds(cid)
+        pts = lo + (hi - lo) * xi
+        if orders is None:
+            thb.tabulate_basis(cid, pts)
+        else:
+            thb.tabulate_basis_derivatives(cid, pts, orders)
+
+
+def _best_ms(thb: THBSplineSpace, xi: np.ndarray, orders: tuple[int, ...] | None) -> float:
+    """Minimum wall time (ms) of the sweep over ``_N_REPEATS`` runs."""
+    best = float("inf")
+    for _ in range(_N_REPEATS):
+        t0 = time.perf_counter()
+        _sweep(thb, xi, orders)
+        best = min(best, time.perf_counter() - t0)
+    return best * 1e3
+
+
+def main() -> None:
+    """Run the benchmark and print a per-cell timing table."""
+    print(f"{'case':>16}  {'cells':>6}  {'values_us':>10}  {'deriv_us':>10}")
+    print("-" * 50)
+    for dim, n, degree in [(2, 16, 2), (2, 16, 3), (3, 8, 2)]:
+        thb = _build(dim, n, degree)
+        nc = thb.grid.num_cells
+        xi = np.full((4, dim), 0.3)
+        xi[1:] += np.linspace(0.1, 0.4, 3)[:, None]
+        deriv_orders = (1,) + (0,) * (dim - 1)
+        _sweep(thb, xi, None)  # warm up the JIT / cache
+        _sweep(thb, xi, deriv_orders)
+        values_us = _best_ms(thb, xi, None) * 1e3 / nc
+        deriv_us = _best_ms(thb, xi, deriv_orders) * 1e3 / nc
+        print(f"{f'{dim}D deg{degree} n{n}':>16}  {nc:>6}  {values_us:>10.1f}  {deriv_us:>10.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pantr/bspline/_thb_eval_core.py
+++ b/src/pantr/bspline/_thb_eval_core.py
@@ -1,0 +1,69 @@
+"""Numba kernels for THB-spline evaluation (Layer 3).
+
+Pure computation for the hierarchical-eval hot path, decorated with
+:func:`~pantr._numba_compat.nb_jit`.  The 1D B-spline basis values are produced by the
+existing jitted tabulation; this module only fuses the per-function tensor-product
+gather-and-product for the untruncated (common) functions on a cell, which otherwise
+incurs heavy NumPy temporary/dispatch overhead for the tiny per-cell arrays of FEM
+assembly (many cells, few points each).
+
+Main exports:
+
+- :func:`_combine_tp_values`: per-cell tensor-product combine of pre-tabulated 1D values.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit
+
+
+@nb_jit(nopython=True, cache=True)
+def _combine_tp_values(
+    vals: npt.NDArray[np.float64],
+    first_basis: npt.NDArray[np.int64],
+    multis: npt.NDArray[np.int64],
+    degrees: npt.NDArray[np.int64],
+) -> npt.NDArray[np.float64]:
+    """Combine pre-tabulated 1D values into untruncated tensor-product function values.
+
+    For each function ``f`` (a tensor-product B-spline with per-direction indices
+    ``multis[f]``) and point ``p``, computes the product over directions ``k`` of the
+    1D value ``vals[k, p, multis[f, k] - first_basis[k, p]]``; a factor is ``0`` when the
+    local index falls outside ``[0, degrees[k]]`` (the function is not supported at the
+    point in that direction).  This is the value of the mixed partial when ``vals`` holds
+    per-direction derivative values (the partial of a product factorizes per direction).
+
+    Args:
+        vals (npt.NDArray[np.float64]): Per-direction 1D values, shape
+            ``(dim, n_pts, max_order)``, zero-padded to ``max_order = max(degrees) + 1``.
+        first_basis (npt.NDArray[np.int64]): Per-direction first nonzero basis index per
+            point, shape ``(dim, n_pts)``.
+        multis (npt.NDArray[np.int64]): Per-function direction indices, shape
+            ``(n_funcs, dim)``.
+        degrees (npt.NDArray[np.int64]): Per-direction polynomial degrees, shape ``(dim,)``.
+
+    Returns:
+        npt.NDArray[np.float64]: Function values of shape ``(n_pts, n_funcs)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :meth:`~pantr.bspline.THBSplineSpace.tabulate_basis` instead.
+    """
+    dim = vals.shape[0]
+    n_pts = vals.shape[1]
+    n_funcs = multis.shape[0]
+    out = np.empty((n_pts, n_funcs), dtype=np.float64)
+    for f in range(n_funcs):
+        for p in range(n_pts):
+            product = 1.0
+            for k in range(dim):
+                local = multis[f, k] - first_basis[k, p]
+                if local < 0 or local > degrees[k]:
+                    product = 0.0
+                    break
+                product *= vals[k, p, local]
+            out[p, f] = product
+    return out

--- a/src/pantr/bspline/_thb_eval_core.py
+++ b/src/pantr/bspline/_thb_eval_core.py
@@ -33,8 +33,10 @@ def _combine_tp_values(
     ``multis[f]``) and point ``p``, computes the product over directions ``k`` of the
     1D value ``vals[k, p, multis[f, k] - first_basis[k, p]]``; a factor is ``0`` when the
     local index falls outside ``[0, degrees[k]]`` (the function is not supported at the
-    point in that direction).  This is the value of the mixed partial when ``vals`` holds
-    per-direction derivative values (the partial of a product factorizes per direction).
+    point in that direction); the inner ``k``-loop exits early on the first such direction
+    via ``break`` — remaining directions are not evaluated.  This is the value of the mixed
+    partial when ``vals`` holds per-direction derivative values (the partial of a product
+    factorizes per direction).
 
     Args:
         vals (npt.NDArray[np.float64]): Per-direction 1D values, shape

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -121,7 +121,8 @@ def _box_all_true(
 
     Each box ``b`` spans the half-open range ``[lo[b, d], hi[b, d])`` per axis ``d``.
     A summed-area table over ``~mask`` makes each box's all-``True`` test
-    (``mask[box].all()`` ⟺ no ``False`` cell in the box) an O(``2**ndim``) lookup.
+    (``mask[box].all()`` ⟺ no ``False`` cell in the box) an O(``2**ndim``) lookup per box.
+    Table construction is O(``N * ndim``) where ``N`` is the total cell count of ``mask``.
 
     Args:
         mask (npt.NDArray[np.bool_]): The ``ndim``-dimensional boolean mask.

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -111,6 +111,37 @@ def _check_out_array(
         raise ValueError(f"{name} must be writeable.")
 
 
+def _box_all_true(
+    mask: npt.NDArray[np.bool_],
+    lo: npt.NDArray[np.int64],
+    hi: npt.NDArray[np.int64],
+) -> npt.NDArray[np.bool_]:
+    """Test, for a batch of axis-aligned boxes, whether ``mask`` is all-``True`` inside.
+
+    Each box ``b`` spans the half-open range ``[lo[b, d], hi[b, d])`` per axis ``d``.
+    A summed-area table over ``~mask`` makes each box's all-``True`` test
+    (``mask[box].all()`` ⟺ no ``False`` cell in the box) an O(``2**ndim``) lookup.
+
+    Args:
+        mask (npt.NDArray[np.bool_]): The ``ndim``-dimensional boolean mask.
+        lo (npt.NDArray[np.int64]): Box lower corners, shape ``(n_boxes, ndim)``.
+        hi (npt.NDArray[np.int64]): Box upper corners (exclusive), shape ``(n_boxes, ndim)``.
+
+    Returns:
+        npt.NDArray[np.bool_]: Shape ``(n_boxes,)``; ``True`` where the box is all-``True``.
+    """
+    dim = mask.ndim
+    prefix = np.pad((~mask).astype(np.int64), [(1, 0)] * dim)
+    for ax in range(dim):
+        prefix = np.cumsum(prefix, axis=ax)
+    total = np.zeros(lo.shape[0], dtype=np.int64)
+    for corner in itertools.product((0, 1), repeat=dim):
+        idx = tuple(hi[:, d] if corner[d] else lo[:, d] for d in range(dim))
+        sign = (-1) ** (dim - sum(corner))
+        total = total + sign * prefix[idx]
+    return np.asarray(total == 0, dtype=np.bool_)
+
+
 def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
     """Compute the cell support of every B-spline function of a 1D space.
 
@@ -208,6 +239,7 @@ class THBSplineSpace:
 
     __slots__ = (
         "_active_funcs",
+        "_contrib_cache",
         "_func_offset",
         "_grid",
         "_grid_snapshot",
@@ -300,6 +332,9 @@ class THBSplineSpace:
         self._num_active = int(self._func_offset[-1])
         self._grid_snapshot = (grid.max_level, grid.num_cells)
         self._trunc = self._compute_truncated_coeffs() if truncate else {}
+        # Lazy per-cell cache of _cell_contributions (populated on first access). The
+        # space is an immutable construction-time snapshot, so cached results stay valid.
+        self._contrib_cache: dict[int, list[tuple[int, int, tuple[int, ...]]]] = {}
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -353,24 +388,28 @@ class THBSplineSpace:
             bbox_lo = true_coords.min(axis=0)
             bbox_hi = true_coords.max(axis=0) + 1
 
-            candidates_per_dir: list[list[int]] = []
+            candidates_per_dir: list[npt.NDArray[np.int64]] = []
             for k in range(dim):
                 _, first_cell, last_cell = support[k]
                 overlaps = (last_cell >= bbox_lo[k]) & (first_cell < bbox_hi[k])
-                candidates_per_dir.append(np.nonzero(overlaps)[0].tolist())
+                candidates_per_dir.append(np.nonzero(overlaps)[0].astype(np.int64))
 
-            selected: list[int] = []
-            for multi in itertools.product(*candidates_per_dir):
-                box = tuple(
-                    slice(int(support[k][1][multi[k]]), int(support[k][2][multi[k]]) + 1)
-                    for k in range(dim)
-                )
-                if not bool(subdomain[box].all()):
-                    continue
-                if bool(refined[box].all()):
-                    continue
-                selected.append(int(np.ravel_multi_index(multi, num_basis)))
-            active.append(np.array(sorted(selected), dtype=np.int64))
+            # Enumerate candidate multi-indices and batch the support-box all-checks via
+            # a summed-area table: selected iff the support box lies entirely in the
+            # subdomain (Ω_l) but not entirely in the further-refined region.
+            mesh = np.meshgrid(*candidates_per_dir, indexing="ij")
+            multis = np.stack([m.ravel() for m in mesh], axis=-1)  # (n_cand, dim)
+            box_lo = np.empty_like(multis)
+            box_hi = np.empty_like(multis)
+            for k in range(dim):
+                _, first_cell, last_cell = support[k]
+                box_lo[:, k] = first_cell[multis[:, k]]
+                box_hi[:, k] = last_cell[multis[:, k]] + 1
+            in_subdomain = _box_all_true(subdomain, box_lo, box_hi)
+            in_refined = _box_all_true(refined, box_lo, box_hi)
+            selected = multis[in_subdomain & ~in_refined]
+            flats = np.ravel_multi_index([selected[:, k] for k in range(dim)], num_basis)
+            active.append(np.sort(flats).astype(np.int64))
         return tuple(active)
 
     def _build_oslo_matrices(self) -> tuple[tuple[npt.NDArray[np.float64], ...], ...]:
@@ -570,8 +609,16 @@ class THBSplineSpace:
             list[tuple[int, int, tuple[int, ...]]]: ``(global_dof, level, multi)``
             triples sorted by ``global_dof``, where ``multi`` is the per-axis function
             index tuple (multi-index) in its level space.
+
+        Note:
+            Results are memoized per ``cid`` in ``self._contrib_cache`` (the space is an
+            immutable snapshot).  The returned list is the cached object; callers must
+            not mutate it.
         """
         self._check_not_stale()
+        cached = self._contrib_cache.get(cid)
+        if cached is not None:
+            return cached
         cell_level = self._grid.cell_level(cid)
         cell_midx = self._grid.cell_multi_index(cid)
         factor = self._grid.factor
@@ -595,6 +642,7 @@ class THBSplineSpace:
                 if pos < active_at_level.shape[0] and int(active_at_level[pos]) == flat:
                     contribs.append((offset + pos, level, multi))
         contribs.sort(key=lambda triple: triple[0])
+        self._contrib_cache[cid] = contribs
         return contribs
 
     # ------------------------------------------------------------------

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -25,6 +25,7 @@ import numpy as np
 from ..grid import HierarchicalGrid
 from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core
 from ._bspline_space_nd import BsplineSpace
+from ._thb_eval_core import _combine_tp_values
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -880,8 +881,6 @@ class THBSplineSpace:
         """
         rep_level, box_lo, coeffs = entry
         dim = self.dim
-        num_pts = flat_pts.shape[0]
-        point_index = np.arange(num_pts)
         if dim > _EINSUM_MAX_DIM:
             raise NotImplementedError(
                 f"_truncated_column uses single-letter einsum subscripts; "
@@ -894,12 +893,11 @@ class THBSplineSpace:
             )
             degree_k = self.degrees[k]
             width = coeffs.shape[k]
-            vmat = np.zeros((num_pts, width), dtype=np.float64)
-            for j in range(width):
-                local = (box_lo[k] + j) - first_basis
-                valid = (local >= 0) & (local <= degree_k)
-                vmat[:, j] = np.where(valid, values[point_index, np.clip(local, 0, degree_k)], 0.0)
-            value_mats.append(vmat)
+            # local[p, j] = (box_lo[k] + j) - first_basis[p]; gather + mask in one shot.
+            local = (box_lo[k] + np.arange(width))[None, :] - first_basis[:, None]
+            valid = (local >= 0) & (local <= degree_k)
+            gathered = np.take_along_axis(values, np.clip(local, 0, degree_k), axis=1)
+            value_mats.append(np.where(valid, gathered, 0.0))
 
         letters = string.ascii_lowercase
         func_subs = letters[:dim]
@@ -981,23 +979,34 @@ class THBSplineSpace:
 
         buffer = np.empty((num_pts, n_active), dtype=np.float64)
         eval_cache: _EvalCache = {}
-        point_index = np.arange(num_pts)
+        dim = self.dim
+        degrees_arr = np.asarray(self.degrees, dtype=np.int64)
+        max_order = int(degrees_arr.max()) + 1
+
+        # Truncated functions are evaluated individually (coefficient contraction);
+        # untruncated ones are grouped by level and combined in a single batched kernel
+        # call (the common, hot case).
+        untrunc_by_level: dict[int, tuple[list[int], list[tuple[int, ...]]]] = {}
         for col, (gdof, level, multi) in enumerate(contribs):
             entry = self._trunc.get(gdof)
             if entry is None:
-                column = np.ones(num_pts, dtype=np.float64)
-                for k in range(self.dim):
-                    values, first_basis = self._basis_1d_cached(
-                        level, k, orders[k], flat_pts, eval_cache
-                    )
-                    local = multi[k] - first_basis
-                    degree_k = self.degrees[k]
-                    valid = (local >= 0) & (local <= degree_k)
-                    gathered = values[point_index, np.clip(local, 0, degree_k)]
-                    column *= np.where(valid, gathered, 0.0)
-                buffer[:, col] = column
+                cols, multis = untrunc_by_level.setdefault(level, ([], []))
+                cols.append(col)
+                multis.append(multi)
             else:
                 buffer[:, col] = self._truncated_column(entry, orders, flat_pts, eval_cache)
+
+        for level, (cols, multis) in untrunc_by_level.items():
+            vals = np.zeros((dim, num_pts, max_order), dtype=np.float64)
+            first_basis = np.empty((dim, num_pts), dtype=np.int64)
+            for k in range(dim):
+                values_k, fb_k = self._basis_1d_cached(level, k, orders[k], flat_pts, eval_cache)
+                vals[k, :, : values_k.shape[1]] = values_k
+                first_basis[k] = fb_k
+            block = _combine_tp_values(
+                vals, first_basis, np.asarray(multis, dtype=np.int64), degrees_arr
+            )
+            buffer[:, cols] = block
 
         result[...] = buffer.reshape(out_shape)
         return result, dofs_result

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -9,7 +9,8 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
-from pantr.bspline._thb_spline_space import _func_support_1d
+from pantr.bspline._thb_eval_core import _combine_tp_values
+from pantr.bspline._thb_spline_space import _box_all_true, _func_support_1d
 from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -1191,3 +1192,177 @@ class TestRestriction:
         other = THBSplineSpace(_root_2d(), _grid_2d())
         with pytest.raises(ValueError, match="refinement"):
             fine.restriction_to(other)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _combine_tp_values kernel
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCombineTPValues:
+    """Direct unit tests for the _combine_tp_values Numba kernel."""
+
+    def test_in_support_1d(self) -> None:
+        # first_basis=1 → local indices [0,2] map to global [1,3].
+        # multi[0]=2: local = 2-1 = 1 → vals[0, 0, 1] = 0.5.
+        vals = np.array([[[0.3, 0.5, 0.2]]], dtype=np.float64)  # (1, 1, 3)
+        first_basis = np.array([[1]], dtype=np.int64)
+        multis = np.array([[2]], dtype=np.int64)
+        degrees = np.array([2], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        assert result.shape == (1, 1)
+        np.testing.assert_allclose(result[0, 0], 0.5)
+
+    def test_out_of_support_high_index_1d(self) -> None:
+        # multi[0]=5, first_basis=1: local = 4 > degree 2 → product = 0 (early break).
+        vals = np.array([[[0.3, 0.5, 0.2]]], dtype=np.float64)
+        first_basis = np.array([[1]], dtype=np.int64)
+        multis = np.array([[5]], dtype=np.int64)
+        degrees = np.array([2], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        np.testing.assert_allclose(result[0, 0], 0.0)
+
+    def test_out_of_support_low_index_1d(self) -> None:
+        # multi[0]=0, first_basis=2: local = -2 < 0 → product = 0 (early break).
+        vals = np.array([[[0.3, 0.5, 0.2]]], dtype=np.float64)
+        first_basis = np.array([[2]], dtype=np.int64)
+        multis = np.array([[0]], dtype=np.int64)
+        degrees = np.array([2], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        np.testing.assert_allclose(result[0, 0], 0.0)
+
+    def test_anisotropic_degrees_2d(self) -> None:
+        # degrees=(2,3) → max_order=4; direction 0 has only 3 valid entries.
+        # multi=(1,2), first_basis=(0,0): local=(1,2).
+        # dir 0: degree=2, local=1 → vals[0,0,1]=0.4; dir 1: degree=3, local=2 → vals[1,0,2]=0.4.
+        vals = np.zeros((2, 1, 4), dtype=np.float64)
+        vals[0, 0, :3] = [0.1, 0.4, 0.5]
+        vals[1, 0, :4] = [0.2, 0.3, 0.4, 0.1]
+        first_basis = np.zeros((2, 1), dtype=np.int64)
+        multis = np.array([[1, 2]], dtype=np.int64)
+        degrees = np.array([2, 3], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        np.testing.assert_allclose(result[0, 0], 0.4 * 0.4)
+
+    def test_anisotropic_out_of_support_second_direction(self) -> None:
+        # degrees=(2,3), multi=(1,5): dir 1 local=5 > 3 → early break → 0.
+        vals = np.zeros((2, 1, 4), dtype=np.float64)
+        vals[0, 0, :3] = [0.1, 0.4, 0.5]
+        vals[1, 0, :4] = [0.2, 0.3, 0.4, 0.1]
+        first_basis = np.zeros((2, 1), dtype=np.int64)
+        multis = np.array([[1, 5]], dtype=np.int64)
+        degrees = np.array([2, 3], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        np.testing.assert_allclose(result[0, 0], 0.0)
+
+    def test_anisotropic_in_support_dir0_out_dir1_differs_from_isotropic(self) -> None:
+        # Confirms degrees[k] (not max(degrees)) gates the out-of-support check.
+        # If the check used max(degrees)=3 instead of degrees[0]=2,
+        # local=3 would pass for dir 0 and return a nonzero product.
+        vals = np.zeros((2, 1, 4), dtype=np.float64)
+        vals[0, 0, :4] = [0.1, 0.2, 0.3, 0.9]  # index 3 is nonzero
+        vals[1, 0, :4] = [0.2, 0.3, 0.4, 0.1]
+        first_basis = np.zeros((2, 1), dtype=np.int64)
+        # local for dir 0 = 3; degree[0]=2 → out of support → 0.
+        multis = np.array([[3, 1]], dtype=np.int64)
+        degrees = np.array([2, 3], dtype=np.int64)
+        result = _combine_tp_values(vals, first_basis, multis, degrees)
+        np.testing.assert_allclose(result[0, 0], 0.0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _box_all_true SAT helper
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestBoxAllTrue:
+    """Direct unit tests for the _box_all_true summed-area-table helper."""
+
+    def test_all_true_2d(self) -> None:
+        mask = np.ones((5, 5), dtype=np.bool_)
+        lo = np.array([[1, 1]], dtype=np.int64)
+        hi = np.array([[4, 4]], dtype=np.int64)
+        assert bool(_box_all_true(mask, lo, hi)[0]) is True
+
+    def test_false_inside_box_2d(self) -> None:
+        mask = np.ones((5, 5), dtype=np.bool_)
+        mask[2, 2] = False
+        lo = np.array([[1, 1]], dtype=np.int64)
+        hi = np.array([[4, 4]], dtype=np.int64)
+        assert bool(_box_all_true(mask, lo, hi)[0]) is False
+
+    def test_false_outside_box_ignored_2d(self) -> None:
+        mask = np.ones((5, 5), dtype=np.bool_)
+        mask[0, 0] = False  # outside [1,4)x[1,4)
+        lo = np.array([[1, 1]], dtype=np.int64)
+        hi = np.array([[4, 4]], dtype=np.int64)
+        assert bool(_box_all_true(mask, lo, hi)[0]) is True
+
+    def test_single_cell_1d(self) -> None:
+        mask = np.array([True, False, True], dtype=np.bool_)
+        lo = np.array([[0], [1], [2]], dtype=np.int64)
+        hi = np.array([[1], [2], [3]], dtype=np.int64)
+        result = _box_all_true(mask, lo, hi)
+        assert [bool(r) for r in result] == [True, False, True]
+
+    def test_batch_1d_mixed(self) -> None:
+        # mask[3]=False; [0,3) is all-True; [2,4) contains the False.
+        mask = np.array([True, True, True, False, True, True], dtype=np.bool_)
+        lo = np.array([[0], [2]], dtype=np.int64)
+        hi = np.array([[3], [4]], dtype=np.int64)
+        result = _box_all_true(mask, lo, hi)
+        assert bool(result[0]) is True
+        assert bool(result[1]) is False
+
+    def test_full_mask_3d(self) -> None:
+        mask = np.ones((4, 4, 4), dtype=np.bool_)
+        lo = np.array([[0, 0, 0]], dtype=np.int64)
+        hi = np.array([[4, 4, 4]], dtype=np.int64)
+        assert bool(_box_all_true(mask, lo, hi)[0]) is True
+
+    def test_single_false_3d(self) -> None:
+        mask = np.ones((4, 4, 4), dtype=np.bool_)
+        mask[1, 2, 3] = False
+        lo = np.array([[0, 0, 0]], dtype=np.int64)
+        hi = np.array([[4, 4, 4]], dtype=np.int64)
+        assert bool(_box_all_true(mask, lo, hi)[0]) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _contrib_cache
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestContribCache:
+    """Tests for the lazy per-cell _cell_contributions cache."""
+
+    def test_second_call_returns_same_object(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        cid = grid.locate([0.1])
+        assert cid is not None
+        first = thb._cell_contributions(cid)
+        second = thb._cell_contributions(cid)
+        assert second is first
+
+    def test_cache_warm_stale_grid_still_raises(self) -> None:
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        _ = thb._cell_contributions(0)  # warm cache
+        assert 0 in thb._contrib_cache
+        grid.refine(0, [0], [2])  # mutate grid after cache is warm
+        with pytest.raises(RuntimeError, match="stale"):
+            thb._cell_contributions(0)
+
+    def test_different_cells_cached_independently(self) -> None:
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        c0 = grid.locate([0.1])
+        c1 = grid.locate([0.8])
+        assert c0 is not None and c1 is not None
+        r0 = thb._cell_contributions(c0)
+        r1 = thb._cell_contributions(c1)
+        assert thb._cell_contributions(c0) is r0
+        assert thb._cell_contributions(c1) is r1


### PR DESCRIPTION
## Summary

PR10 of the THB-splines feature (#164, the final planned PR): optimize the THB evaluation
hot path (FEM assembly — many cells, few points each). Purely additive and
correctness-preserving; results are identical under `NUMBA_DISABLE_JIT=1` (CI) and JIT-on.

- **Lazy `_cell_contributions` cache** — memoize per cell on first access (the space is an
  immutable snapshot), so repeated evals on a cell (values + derivatives, multi-sweep) don't
  recompute the active-function list. Lazy keeps the locked low-footprint mandate.
- **Numba combine kernel** (`_thb_eval_core._combine_tp_values`, Layer 3) — fuses the
  per-function tensor-product gather-and-product for untruncated functions into compiled
  scalar loops, avoiding the NumPy temporary/dispatch overhead that dominates for the tiny
  per-cell arrays. `_tabulate_orders` groups untruncated contributions by level and combines
  them in one kernel call.
- **Vectorize `_truncated_column`** — `take_along_axis` gather replacing the Python `for j` loop.
- **Vectorize `_select_active_functions`** (construction) — summed-area-table box-all checks
  (`_box_all_true`) replacing the `itertools.product` per-candidate `subdomain[box].all()` /
  `refined[box].all()`; exact Kraft semantics preserved.

## Benchmark (`benchmarks/bench_thb_eval.py`, JIT on)

| case | before | after | speedup |
|---|---|---|---|
| 2D deg2, 640 cells | 1504 µs/cell | 1162 µs/cell | 1.29× |
| 3D deg2, 1408 cells | 6537 µs/cell | 3246 µs/cell | 2.01× |

THB partition of unity stays exact under JIT (`max|Σφ−1| ≈ 2e-16`).

## Test plan
- [x] full suite (3079 passed) — identical results, kernel exercised as Python under JIT-off
- [x] JIT-on correctness spot check (PoU) + benchmark
- [x] ruff, ruff-format, mypy, docs (-W)

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)