### PR TITLE
feat(grid): add Grid.restrict for TensorProductGrid

### DIFF
--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -17,6 +17,8 @@ Main exports:
 - :class:`Grid`: abstract base class defining the grid contract and supplying
   axis-aligned box defaults for facets, neighbours, reference maps, batch point
   location, and spatial queries.
+- :class:`GridRestriction`: result of :meth:`Grid.restrict` -- a windowed
+  sub-grid plus local-to-global cell index maps.
 - :class:`TensorProductGrid`: concrete tensor-product grid of axis-aligned boxes
   with per-axis breakpoints and row-major (C-order) cell ids.
 - :class:`HierarchicalGrid`: hierarchical grid with a fixed per-direction
@@ -40,7 +42,7 @@ from __future__ import annotations
 
 from ._bvh import BVH
 from ._cell_quadrature import cell_quadrature
-from ._grid import Grid
+from ._grid import Grid, GridRestriction
 from ._hierarchical_grid import HierarchicalGrid, hierarchical_grid
 from ._overlay import overlay
 from ._tags import CellTags, FacetTags
@@ -51,6 +53,7 @@ __all__ = [
     "CellTags",
     "FacetTags",
     "Grid",
+    "GridRestriction",
     "HierarchicalGrid",
     "TensorProductGrid",
     "cell_quadrature",

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -42,7 +42,7 @@ per-cell tag footprint. Deciding *what* to tag is the consumer's job.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
@@ -258,6 +258,44 @@ class Grid(abc.ABC):
             if neighbor is not None:
                 result.append(neighbor)
         return result
+
+    # ------------------------------------------------------------------
+    # Restriction / windowing
+    # ------------------------------------------------------------------
+
+    def restrict(self, cell_ids: npt.ArrayLike) -> GridRestriction:
+        """Return the structured sub-grid spanning a subset of cells.
+
+        The sub-grid is the smallest grid of the same kind that contains every
+        requested cell -- for a tensor-product grid, the multi-index bounding box
+        of ``cell_ids``. Its breakpoints are *pure slices* of this grid's (never
+        re-clamped or re-based), so a B-spline or field built on the sub-grid
+        agrees pointwise with the global one over the shared cells.
+
+        The bounding box may contain cells that were not requested (when
+        ``cell_ids`` is non-convex); :attr:`GridRestriction.in_subset` flags, per
+        local cell, whether it was requested (``True``) or is bounding-box fill
+        (``False``).
+
+        Restriction is an *optional* grid capability: this base implementation
+        raises :class:`NotImplementedError`. Grids with structured windowing (for
+        example :class:`pantr.grid.TensorProductGrid`) override it.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat cell identifiers to span; duplicates
+                are ignored. Each must satisfy ``0 <= cid < num_cells``.
+
+        Returns:
+            GridRestriction: The windowed sub-grid, the ``local_to_global_cell``
+            map, and the ``in_subset`` mask.
+
+        Raises:
+            NotImplementedError: If this grid kind does not support restriction.
+            ValueError: If ``cell_ids`` is empty (in overriding implementations).
+            IndexError: If any cell id is out of range (in overriding
+                implementations).
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support restrict().")
 
     # ------------------------------------------------------------------
     # Facet accessors (axis-aligned box defaults)
@@ -555,4 +593,25 @@ class Grid(abc.ABC):
         return np.ascontiguousarray(arr)
 
 
-__all__ = ["Grid"]
+class GridRestriction(NamedTuple):
+    """Result of :meth:`Grid.restrict`: a windowed sub-grid plus index maps.
+
+    A :class:`typing.NamedTuple` returned by :meth:`Grid.restrict`:
+
+    - ``grid`` -- the windowed sub-grid: the smallest structured grid of the same
+      kind containing every requested cell, of the same concrete type as the grid
+      that produced it.
+    - ``local_to_global_cell`` -- shape ``(grid.num_cells,)`` map from each
+      sub-grid cell id to its id in the original grid, in the sub-grid's own
+      cell-id order.
+    - ``in_subset`` -- shape ``(grid.num_cells,)`` boolean mask: ``True`` for
+      cells that were in the requested ``cell_ids``, ``False`` for bounding-box
+      fill cells (present only when the request was non-convex).
+    """
+
+    grid: Grid
+    local_to_global_cell: npt.NDArray[np.int64]
+    in_subset: npt.NDArray[np.bool_]
+
+
+__all__ = ["Grid", "GridRestriction"]

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -598,18 +598,18 @@ class Grid(abc.ABC):
 class GridRestriction(NamedTuple):
     """Result of :meth:`Grid.restrict`: a windowed sub-grid plus index maps.
 
-    Attributes:
-        grid (Grid): The windowed sub-grid -- the smallest structured grid
-            containing every requested cell. For structured implementations
-            (e.g. :class:`TensorProductGrid`) this is the same concrete type
-            as the grid that produced it.
-        local_to_global_cell (npt.NDArray[np.int64]): Shape
-            ``(grid.num_cells,)`` map from each sub-grid cell id to its id in
-            the original grid, in the sub-grid's own cell-id order. Read-only.
-        in_subset (npt.NDArray[np.bool_]): Shape ``(grid.num_cells,)`` boolean
-            mask: ``True`` for cells that were in the requested ``cell_ids``,
-            ``False`` for bounding-box fill cells (present only when the request
-            was non-convex). Read-only.
+    A :class:`typing.NamedTuple` returned by :meth:`Grid.restrict`:
+
+    - ``grid`` -- the windowed sub-grid: the smallest structured grid containing
+      every requested cell. For structured implementations (e.g.
+      :class:`TensorProductGrid`) this is the same concrete type as the grid
+      that produced it.
+    - ``local_to_global_cell`` -- shape ``(grid.num_cells,)`` map from each
+      sub-grid cell id to its id in the original grid, in the sub-grid's own
+      cell-id order. Read-only.
+    - ``in_subset`` -- shape ``(grid.num_cells,)`` boolean mask: ``True`` for
+      cells that were in the requested ``cell_ids``, ``False`` for bounding-box
+      fill cells (present only when the request was non-convex). Read-only.
     """
 
     grid: Grid

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -294,6 +294,8 @@ class Grid(abc.ABC):
             ValueError: If ``cell_ids`` is empty (in overriding implementations).
             IndexError: If any cell id is out of range (in overriding
                 implementations).
+            TypeError: If ``cell_ids`` is not integer-valued (in overriding
+                implementations).
         """
         raise NotImplementedError(f"{type(self).__name__} does not support restrict().")
 
@@ -596,17 +598,18 @@ class Grid(abc.ABC):
 class GridRestriction(NamedTuple):
     """Result of :meth:`Grid.restrict`: a windowed sub-grid plus index maps.
 
-    A :class:`typing.NamedTuple` returned by :meth:`Grid.restrict`:
-
-    - ``grid`` -- the windowed sub-grid: the smallest structured grid of the same
-      kind containing every requested cell, of the same concrete type as the grid
-      that produced it.
-    - ``local_to_global_cell`` -- shape ``(grid.num_cells,)`` map from each
-      sub-grid cell id to its id in the original grid, in the sub-grid's own
-      cell-id order.
-    - ``in_subset`` -- shape ``(grid.num_cells,)`` boolean mask: ``True`` for
-      cells that were in the requested ``cell_ids``, ``False`` for bounding-box
-      fill cells (present only when the request was non-convex).
+    Attributes:
+        grid (Grid): The windowed sub-grid -- the smallest structured grid
+            containing every requested cell. For structured implementations
+            (e.g. :class:`TensorProductGrid`) this is the same concrete type
+            as the grid that produced it.
+        local_to_global_cell (npt.NDArray[np.int64]): Shape
+            ``(grid.num_cells,)`` map from each sub-grid cell id to its id in
+            the original grid, in the sub-grid's own cell-id order. Read-only.
+        in_subset (npt.NDArray[np.bool_]): Shape ``(grid.num_cells,)`` boolean
+            mask: ``True`` for cells that were in the requested ``cell_ids``,
+            ``False`` for bounding-box fill cells (present only when the request
+            was non-convex). Read-only.
     """
 
     grid: Grid

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Final
 import numpy as np
 
 from ._cell_index import c_order_strides, flat_to_multi, multi_to_flat
-from ._grid import Grid
+from ._grid import Grid, GridRestriction
 from ._grid_utils import _as_float64
 from ._locate_core import _locate_points_core
 
@@ -352,6 +352,55 @@ class TensorProductGrid(Grid):
             cell_lo[:, d] = lo_axes[d][flat_idx]
             cell_hi[:, d] = hi_axes[d][flat_idx]
         return cell_lo, cell_hi
+
+    def restrict(self, cell_ids: npt.ArrayLike) -> GridRestriction:
+        """Return the multi-index bounding-box sub-grid spanning ``cell_ids``.
+
+        The window is the axis-aligned bounding box of the requested cells in
+        multi-index space. Each axis of the sub-grid uses a pure slice of this
+        grid's breakpoints, ``breakpoints[d][imin_d : imax_d + 2]`` -- never
+        re-based or re-clamped -- so the sub-grid's cells coincide exactly with
+        the matching cells of this grid.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat cell identifiers to span; duplicates
+                are ignored. Each must satisfy ``0 <= cid < num_cells``.
+
+        Returns:
+            GridRestriction: The windowed :class:`TensorProductGrid`, its
+            ``local_to_global_cell`` map of shape ``(sub.num_cells,)``, and the
+            ``in_subset`` mask flagging requested versus bounding-box-fill cells.
+
+        Raises:
+            ValueError: If ``cell_ids`` is empty.
+            IndexError: If any cell id is out of range ``[0, num_cells)``.
+            TypeError: If ``cell_ids`` is not integer-valued.
+        """
+        ids = np.asarray(cell_ids).ravel()
+        if ids.size == 0:
+            raise ValueError("restrict: cell_ids must be non-empty.")
+        if not np.issubdtype(ids.dtype, np.integer):
+            raise TypeError(f"restrict: cell_ids must be integer-valued; got dtype {ids.dtype}.")
+        ids = ids.astype(np.int64, copy=False)
+        lo, hi = int(ids.min()), int(ids.max())
+        if lo < 0 or hi >= self._num_cells:
+            raise IndexError(
+                f"restrict: cell id out of range [0, {self._num_cells}); got [{lo}, {hi}]."
+            )
+        multi = np.unravel_index(ids, self._cells_per_axis)
+        imin = [int(m.min()) for m in multi]
+        imax = [int(m.max()) for m in multi]
+        sub_breakpoints = [self._breakpoints[d][imin[d] : imax[d] + 2] for d in range(self._ndim)]
+        sub_grid = TensorProductGrid(sub_breakpoints)
+        sub_cells_per_axis = [imax[d] - imin[d] + 1 for d in range(self._ndim)]
+        idx_grids = np.meshgrid(
+            *[np.arange(n, dtype=np.int64) for n in sub_cells_per_axis], indexing="ij"
+        )
+        local_to_global = np.zeros(int(math.prod(sub_cells_per_axis)), dtype=np.int64)
+        for d in range(self._ndim):
+            local_to_global += (idx_grids[d].ravel() + imin[d]) * int(self._strides[d])
+        in_subset = np.isin(local_to_global, ids)
+        return GridRestriction(sub_grid, local_to_global, in_subset)
 
     def __repr__(self) -> str:
         """Return a compact representation useful for debugging.

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -400,6 +400,8 @@ class TensorProductGrid(Grid):
         for d in range(self._ndim):
             local_to_global += (idx_grids[d].ravel() + imin[d]) * int(self._strides[d])
         in_subset = np.isin(local_to_global, ids)
+        local_to_global.flags.writeable = False
+        in_subset.flags.writeable = False
         return GridRestriction(sub_grid, local_to_global, in_subset)
 
     def __repr__(self) -> str:

--- a/tests/test_grid_abc.py
+++ b/tests/test_grid_abc.py
@@ -157,3 +157,10 @@ def test_locate_many_bad_shape_raises() -> None:
     plain = _PlainGrid(uniform_grid([[0.0, 2.0], [0.0, 2.0]], 2))
     with pytest.raises(ValueError, match="shape"):
         plain.locate_many(np.zeros((4, 3)))
+
+
+def test_default_restrict_not_implemented() -> None:
+    """The base Grid.restrict default raises NotImplementedError."""
+    plain = _PlainGrid(uniform_grid([[0.0, 3.0]], 3))
+    with pytest.raises(NotImplementedError, match="restrict"):
+        plain.restrict([0, 1])

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from pantr.geometry import AABB
-from pantr.grid import TensorProductGrid, tensor_product_grid, uniform_grid
+from pantr.grid import GridRestriction, TensorProductGrid, tensor_product_grid, uniform_grid
 from pantr.transform import AffineTransform
 
 
@@ -387,3 +387,140 @@ def test_uniform_grid_single_cell_per_axis() -> None:
     assert g.locate([5.1, 2.0]) is None
     out = g.locate_many(np.array([[2.5, 2.0], [-1.0, 2.0]]))
     assert out.tolist() == [0, -1]
+
+
+# ---------------------------------------------------------------- restrict
+
+
+def _assert_window_matches_global(g: TensorProductGrid, r: GridRestriction) -> None:
+    """Every sub-grid cell coincides with its global cell (bounds and locate)."""
+    for k in range(r.grid.num_cells):
+        gcid = int(r.local_to_global_cell[k])
+        lo_s, hi_s = r.grid.cell_bounds(k)
+        lo_g, hi_g = g.cell_bounds(gcid)
+        np.testing.assert_allclose(lo_s, lo_g)
+        np.testing.assert_allclose(hi_s, hi_g)
+        center = 0.5 * (lo_s + hi_s)
+        assert r.grid.locate(center) == k
+        assert g.locate(center) == gcid
+
+
+def test_restrict_convex_block_matches_global() -> None:
+    """A contiguous block restricts to a sub-grid coinciding with the window."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 4.0]], 4)
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 1), (1, 2), (2, 1), (2, 2)]]
+    r = g.restrict(cell_ids)
+    assert isinstance(r, GridRestriction)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (2, 2)
+    np.testing.assert_array_equal(r.local_to_global_cell, [5, 6, 9, 10])
+    assert bool(r.in_subset.all())
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_local_global_round_trip() -> None:
+    """local_to_global composes with the bbox offset; in_subset recovers the request."""
+    g = uniform_grid([[0.0, 5.0], [0.0, 4.0]], [5, 4])
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 1), (1, 2), (2, 1), (3, 2)]]
+    r = g.restrict(cell_ids)  # bbox rows 1..3, cols 1..2 -> offset (1, 1)
+    assert isinstance(r.grid, TensorProductGrid)
+    for k in range(r.grid.num_cells):
+        sm = r.grid.cell_multi_index(k)
+        assert g.flat_cell_index((sm[0] + 1, sm[1] + 1)) == int(r.local_to_global_cell[k])
+    assert {int(c) for c in r.local_to_global_cell[r.in_subset]} == set(cell_ids)
+
+
+def test_restrict_non_convex_flags_fill_cells() -> None:
+    """A non-convex request yields the full bbox with fill cells flagged False."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    corners = [g.flat_cell_index(m) for m in [(0, 0), (0, 2), (2, 0), (2, 2)]]
+    r = g.restrict(corners)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (3, 3)  # bbox spans the whole grid
+    np.testing.assert_array_equal(r.local_to_global_cell, np.arange(9))
+    expected_mask = np.zeros(9, dtype=bool)
+    expected_mask[corners] = True
+    np.testing.assert_array_equal(r.in_subset, expected_mask)
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_breakpoints_not_reclamped() -> None:
+    """Sub-grid breakpoints are pure slices of the parent (never re-based)."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 4.0]], 4)  # breakpoints 0,1,2,3,4 per axis
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 1), (1, 2), (2, 1), (2, 2)]]
+    sub = g.restrict(cell_ids).grid
+    assert isinstance(sub, TensorProductGrid)
+    np.testing.assert_allclose(sub.breakpoints[0], [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(sub.breakpoints[1], [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(sub.bounds, [[1.0, 3.0], [1.0, 3.0]])
+
+
+def test_restrict_full_grid_is_identity() -> None:
+    """Restricting to all cells reproduces the grid with an identity cell map."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0], [0.0, 2.0, 5.0, 6.0]])  # cells (2, 3)
+    r = g.restrict(list(range(g.num_cells)))
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == g.cells_per_axis
+    for d in range(g.ndim):
+        np.testing.assert_allclose(r.grid.breakpoints[d], g.breakpoints[d])
+    np.testing.assert_array_equal(r.local_to_global_cell, np.arange(g.num_cells))
+    assert bool(r.in_subset.all())
+
+
+def test_restrict_single_cell() -> None:
+    """Restricting one cell yields a single-cell grid mapping back to it."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 3.0]], 3)
+    cid = g.flat_cell_index((1, 2))
+    r = g.restrict([cid])
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (1, 1)
+    assert int(r.local_to_global_cell[0]) == cid
+    np.testing.assert_array_equal(r.in_subset, [True])
+    lo_s, hi_s = r.grid.cell_bounds(0)
+    lo_g, hi_g = g.cell_bounds(cid)
+    np.testing.assert_allclose(lo_s, lo_g)
+    np.testing.assert_allclose(hi_s, hi_g)
+
+
+def test_restrict_1d() -> None:
+    """Restriction works on a 1-D grid."""
+    g = uniform_grid([[0.0, 6.0]], 6)  # cells 0..5
+    r = g.restrict([2, 3, 4])
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (3,)
+    np.testing.assert_allclose(r.grid.breakpoints[0], [2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_equal(r.local_to_global_cell, [2, 3, 4])
+    assert bool(r.in_subset.all())
+
+
+def test_restrict_duplicates_ignored() -> None:
+    """Duplicate cell ids do not change the result."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 4.0]], 4)
+    ids = [g.flat_cell_index(m) for m in [(1, 1), (1, 2), (2, 1), (2, 2)]]
+    r_dup = g.restrict(ids + ids)
+    r = g.restrict(ids)
+    np.testing.assert_array_equal(r_dup.local_to_global_cell, r.local_to_global_cell)
+    np.testing.assert_array_equal(r_dup.in_subset, r.in_subset)
+
+
+def test_restrict_empty_raises() -> None:
+    """An empty cell_ids is rejected."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    with pytest.raises(ValueError, match="non-empty"):
+        g.restrict([])
+
+
+def test_restrict_out_of_range_raises() -> None:
+    """Out-of-range cell ids raise IndexError."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    with pytest.raises(IndexError):
+        g.restrict([0, 2])  # 2 == num_cells
+    with pytest.raises(IndexError):
+        g.restrict([-1, 0])
+
+
+def test_restrict_non_integer_raises() -> None:
+    """Non-integer cell ids raise TypeError."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    with pytest.raises(TypeError, match="integer"):
+        g.restrict([0.0, 1.0])

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -524,3 +524,65 @@ def test_restrict_non_integer_raises() -> None:
     g = uniform_grid([[0.0, 2.0]], 2)
     with pytest.raises(TypeError, match="integer"):
         g.restrict([0.0, 1.0])
+
+
+def test_restrict_non_square_grid_exact_local_to_global() -> None:
+    """On a non-square grid, local_to_global_cell uses the global strides."""
+    g = uniform_grid([[0.0, 3.0], [0.0, 5.0]], [3, 5])  # 3x5, strides (5, 1)
+    # rows 1-2, cols 1-3 -> local (0,0)..(1,2)
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3)]]
+    r = g.restrict(cell_ids)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (2, 3)
+    # global ids: row*5 + col for (1,1),(1,2),(1,3),(2,1),(2,2),(2,3) = 6,7,8,11,12,13
+    np.testing.assert_array_equal(r.local_to_global_cell, [6, 7, 8, 11, 12, 13])
+    assert bool(r.in_subset.all())
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_3d() -> None:
+    """Restriction works on a 3-D grid."""
+    g = uniform_grid([[0.0, 4.0], [0.0, 3.0], [0.0, 2.0]], [4, 3, 2])  # 4x3x2 = 24 cells
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 1, 0), (1, 1, 1), (2, 1, 0), (2, 1, 1)]]
+    r = g.restrict(cell_ids)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (2, 1, 2)
+    assert bool(r.in_subset.all())
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_non_convex_non_square_grid() -> None:
+    """Non-convex request in a non-square grid flags fill cells correctly."""
+    g = uniform_grid([[0.0, 2.0], [0.0, 3.0]], [2, 3])  # 2x3, strides (3, 1)
+    corners = [g.flat_cell_index((0, 0)), g.flat_cell_index((1, 2))]  # 0 and 5
+    r = g.restrict(corners)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (2, 3)
+    np.testing.assert_array_equal(r.local_to_global_cell, np.arange(6))
+    expected_mask = np.zeros(6, dtype=bool)
+    expected_mask[[0, 5]] = True
+    np.testing.assert_array_equal(r.in_subset, expected_mask)
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_non_uniform_breakpoints() -> None:
+    """Breakpoint slicing is correct for non-uniform spacing."""
+    g = TensorProductGrid([[0.0, 1.0, 3.0, 6.0, 10.0], [0.0, 5.0, 7.0]])  # 4x2 grid
+    cell_ids = [g.flat_cell_index(m) for m in [(1, 0), (2, 0)]]
+    r = g.restrict(cell_ids)
+    assert isinstance(r.grid, TensorProductGrid)
+    assert r.grid.cells_per_axis == (2, 1)
+    np.testing.assert_allclose(r.grid.breakpoints[0], [1.0, 3.0, 6.0])
+    np.testing.assert_allclose(r.grid.breakpoints[1], [0.0, 5.0])
+    assert bool(r.in_subset.all())
+    _assert_window_matches_global(g, r)
+
+
+def test_restrict_result_arrays_are_read_only() -> None:
+    """local_to_global_cell and in_subset are read-only."""
+    g = uniform_grid([[0.0, 2.0]], 2)
+    r = g.restrict([0, 1])
+    with pytest.raises(ValueError, match="read-only"):
+        r.local_to_global_cell[0] = 99
+    with pytest.raises(ValueError, match="read-only"):
+        r.in_subset[0] = False


### PR DESCRIPTION
## Summary
- Add an optional `Grid.restrict(cell_ids)` capability returning a `GridRestriction` NamedTuple: a windowed sub-grid, a `local_to_global_cell` map, and an `in_subset` mask.
- Implement it for `TensorProductGrid`: the window is the multi-index bounding box of the requested cells, built from pure per-axis breakpoint slices (never re-clamped), so the sub-grid's cells coincide pointwise with the parent's. A non-convex request has its bounding-box fill cells flagged `in_subset = False`.
- The base `Grid.restrict` raises `NotImplementedError` (an optional grid capability, like `cell_level`/`child_cells` defaults), so `HierarchicalGrid` is unaffected until its own override lands in a later PR.

This is **PR A1** of the MPI-distribution feature (#142) -- the serial grid-windowing primitive that `build_local` will sit on.

## Test plan
- [x] New tests in `tests/test_grid_tensor_product.py` (convex / non-convex / 1D / single-cell / full-grid windows; sub-grid cell_bounds and locate match the global grid; local-to-global round-trip; breakpoints never re-clamped; empty/out-of-range/non-integer errors) and `tests/test_grid_abc.py` (base raises NotImplementedError).
- [x] `pytest --no-cov` -- 3107 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)