### PR TITLE
feat(bspline): windowed BsplineSpace + local-global DOF map

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -5,6 +5,8 @@ This package consolidates the B-spline API:
 - :class:`Bspline`: parametric B-spline curves, surfaces, and volumes.
 - :class:`BsplineSpace1D`: 1D B-spline space (knot vector + degree).
 - :class:`BsplineSpace`: multi-dimensional tensor-product B-spline spaces.
+- :class:`BsplineSpaceRestriction`: result of :meth:`BsplineSpace.restrict` -- a
+  windowed sub-space plus its local-to-global DOF map.
 - :func:`create_uniform_open_knots`, :func:`create_uniform_periodic_knots`,
   :func:`create_cardinal_knots`: knot vector construction helpers.
 - :func:`create_uniform_space`: convenience factory for tensor-product spaces.
@@ -41,7 +43,7 @@ from ._bspline_space_factory import (
     create_uniform_space,
     get_greville_abscissae,
 )
-from ._bspline_space_nd import BsplineSpace
+from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
 from ._thb_spline_space import THBSplineSpace
@@ -56,6 +58,7 @@ __all__ = [
     "Bspline",
     "BsplineSpace",
     "BsplineSpace1D",
+    "BsplineSpaceRestriction",
     "ExtractionStructView",
     "MultiLevelExtraction",
     "SpanwiseElementExtraction",

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -682,3 +682,51 @@ class BsplineSpace1D:
             self._knots, self._degree, self._tol, n_subdivisions, eff_regularity
         )
         return self.insert_knots(new_knots)
+
+    def restrict(
+        self, interval_lo: int, interval_hi: int
+    ) -> tuple[BsplineSpace1D, npt.NDArray[np.int64]]:
+        """Return the windowed sub-space over the intervals ``[interval_lo, interval_hi)``.
+
+        The windowed knot vector is a pure slice of this space's knots (never
+        re-clamped), chosen so the windowed basis functions are exactly the global
+        basis functions supported on the windowed intervals; they therefore equal
+        the global basis pointwise over those intervals.
+
+        Args:
+            interval_lo (int): First interval (knot span) of the window, inclusive.
+            interval_hi (int): One past the last interval of the window, exclusive.
+                Must satisfy ``0 <= interval_lo < interval_hi <= num_intervals``.
+
+        Returns:
+            tuple[BsplineSpace1D, npt.NDArray[np.int64]]: The windowed space and a
+            read-only ``local_to_global_dof`` array of shape ``(num_basis_local,)``
+            mapping each windowed basis index to its index in this space.
+
+        Raises:
+            ValueError: If the space is periodic, or the interval range is invalid.
+        """
+        if self._periodic:
+            raise ValueError("restrict: periodic B-spline spaces are not supported.")
+        n_int = self.num_intervals
+        lo, hi = int(interval_lo), int(interval_hi)
+        if not 0 <= lo < hi <= n_int:
+            raise ValueError(
+                f"restrict: require 0 <= interval_lo < interval_hi <= {n_int}; got [{lo}, {hi})."
+            )
+        unique_knots, _ = self.get_unique_knots_and_multiplicity(in_domain=True)
+        mids = np.array(
+            [
+                0.5 * (unique_knots[lo] + unique_knots[lo + 1]),
+                0.5 * (unique_knots[hi - 1] + unique_knots[hi]),
+            ],
+            dtype=self._knots.dtype,
+        )
+        _, first_basis = self.tabulate_basis(mids)
+        j_lo = int(first_basis[0])
+        j_hi = int(first_basis[1]) + self._degree
+        windowed_knots = self._knots[j_lo : j_hi + self._degree + 2]
+        windowed = BsplineSpace1D(windowed_knots, self._degree, periodic=False, snap_knots=False)
+        local_to_global_dof = np.arange(j_lo, j_hi + 1, dtype=np.int64)
+        local_to_global_dof.flags.writeable = False
+        return windowed, local_to_global_dof

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -700,8 +700,9 @@ class BsplineSpace1D:
 
         Returns:
             tuple[BsplineSpace1D, npt.NDArray[np.int64]]: The windowed space and a
-            read-only ``local_to_global_dof`` array of shape ``(num_basis_local,)``
-            mapping each windowed basis index to its index in this space.
+            read-only ``local_to_global_dof`` array of shape
+            ``(windowed_space.num_basis,)`` mapping each windowed basis index to its
+            index in this space.
 
         Raises:
             ValueError: If the space is periodic, or the interval range is invalid.

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -276,14 +276,12 @@ class BsplineSpace:
 class BsplineSpaceRestriction(NamedTuple):
     """Result of :meth:`BsplineSpace.restrict`: a windowed space and its DOF map.
 
-    Attributes:
-        space (BsplineSpace): The windowed space; per axis a pure knot-vector slice
-            of the parent (never re-clamped), so its basis equals the parent's
-            pointwise over the windowed cells.
-        local_to_global_dof (npt.NDArray[np.int64]): Read-only array of shape
-            ``(space.num_total_basis,)`` mapping each windowed DOF (flat, C-order
-            over the windowed per-axis basis counts) to its flat index in the parent
-            space.
+    - ``space`` -- the windowed :class:`BsplineSpace`: per axis a pure knot-vector
+      slice of the parent (never re-clamped), so its basis equals the parent's
+      pointwise over the windowed cells.
+    - ``local_to_global_dof`` -- read-only, shape ``(space.num_total_basis,)``,
+      mapping each windowed DOF (flat, C-order over the windowed per-axis basis
+      counts) to its flat index in the parent space.
 
     Unlike :class:`pantr.grid.GridRestriction` there is no ``in_subset`` mask: every
     windowed DOF is a genuine parent DOF (a windowed space spans a box of cells, so

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -235,7 +235,7 @@ class BsplineSpace:
         Returns:
             BsplineSpaceRestriction: The windowed :class:`BsplineSpace` and the
             read-only ``local_to_global_dof`` map of shape
-            ``(space.num_total_basis,)``.
+            ``(windowed_space.num_total_basis,)``.
 
         Raises:
             ValueError: If ``cell_ids`` is empty or any axis is periodic.
@@ -276,14 +276,14 @@ class BsplineSpace:
 class BsplineSpaceRestriction(NamedTuple):
     """Result of :meth:`BsplineSpace.restrict`: a windowed space and its DOF map.
 
-    A :class:`typing.NamedTuple` returned by :meth:`BsplineSpace.restrict`:
-
-    - ``space`` -- the windowed :class:`BsplineSpace`: per axis a pure knot-vector
-      slice of the parent (never re-clamped), so its basis equals the parent's
-      pointwise over the windowed cells.
-    - ``local_to_global_dof`` -- read-only, shape ``(space.num_total_basis,)``, mapping
-      each windowed DOF (flat, C-order over the windowed per-axis basis counts) to its
-      flat index in the parent space.
+    Attributes:
+        space (BsplineSpace): The windowed space; per axis a pure knot-vector slice
+            of the parent (never re-clamped), so its basis equals the parent's
+            pointwise over the windowed cells.
+        local_to_global_dof (npt.NDArray[np.int64]): Read-only array of shape
+            ``(space.num_total_basis,)`` mapping each windowed DOF (flat, C-order
+            over the windowed per-axis basis counts) to its flat index in the parent
+            space.
 
     Unlike :class:`pantr.grid.GridRestriction` there is no ``in_subset`` mask: every
     windowed DOF is a genuine parent DOF (a windowed space spans a box of cells, so

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from numpy import typing as npt
@@ -217,3 +217,78 @@ class BsplineSpace:
         return _tabulate_Bspline_basis_impl(
             self, pts, out_basis=out_basis, out_first_basis=out_first_basis
         )
+
+    def restrict(self, cell_ids: npt.ArrayLike) -> BsplineSpaceRestriction:
+        """Return the bounding-box windowed sub-space spanning ``cell_ids``.
+
+        The window is the per-axis multi-index bounding box of the requested
+        knot-span cells (flat ids in C-order over :attr:`num_intervals`, the same
+        convention as :func:`pantr.grid.tensor_product_grid` and
+        :class:`SpanwiseElementExtraction`). Each axis is windowed by slicing its
+        knot vector (never re-clamped), so the windowed basis equals this space's
+        basis pointwise over the windowed cells.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat knot-span cell ids to span; duplicates
+                are ignored. Each must satisfy ``0 <= cid < num_total_intervals``.
+
+        Returns:
+            BsplineSpaceRestriction: The windowed :class:`BsplineSpace` and the
+            read-only ``local_to_global_dof`` map of shape
+            ``(space.num_total_basis,)``.
+
+        Raises:
+            ValueError: If ``cell_ids`` is empty or any axis is periodic.
+            IndexError: If any cell id is out of range ``[0, num_total_intervals)``.
+            TypeError: If ``cell_ids`` is not integer-valued.
+        """
+        if any(space.periodic for space in self._spaces):
+            raise ValueError("restrict: periodic B-spline spaces are not supported.")
+        ids = np.asarray(cell_ids).ravel()
+        if ids.size == 0:
+            raise ValueError("restrict: cell_ids must be non-empty.")
+        if not np.issubdtype(ids.dtype, np.integer):
+            raise TypeError(f"restrict: cell_ids must be integer-valued; got dtype {ids.dtype}.")
+        ids = ids.astype(np.int64, copy=False)
+        n_int = self.num_total_intervals
+        lo_id, hi_id = int(ids.min()), int(ids.max())
+        if lo_id < 0 or hi_id >= n_int:
+            raise IndexError(
+                f"restrict: cell id out of range [0, {n_int}); got [{lo_id}, {hi_id}]."
+            )
+
+        multi = np.unravel_index(ids, self.num_intervals)
+        windowed_1d: list[BsplineSpace1D] = []
+        dof_axes: list[npt.NDArray[np.int64]] = []
+        for d, space in enumerate(self._spaces):
+            w_space, dof_d = space.restrict(int(multi[d].min()), int(multi[d].max()) + 1)
+            windowed_1d.append(w_space)
+            dof_axes.append(dof_d)
+
+        mesh = np.meshgrid(*dof_axes, indexing="ij")
+        local_to_global_dof = np.ravel_multi_index(
+            tuple(m.ravel() for m in mesh), self.num_basis
+        ).astype(np.int64)
+        local_to_global_dof.flags.writeable = False
+        return BsplineSpaceRestriction(BsplineSpace(windowed_1d), local_to_global_dof)
+
+
+class BsplineSpaceRestriction(NamedTuple):
+    """Result of :meth:`BsplineSpace.restrict`: a windowed space and its DOF map.
+
+    A :class:`typing.NamedTuple` returned by :meth:`BsplineSpace.restrict`:
+
+    - ``space`` -- the windowed :class:`BsplineSpace`: per axis a pure knot-vector
+      slice of the parent (never re-clamped), so its basis equals the parent's
+      pointwise over the windowed cells.
+    - ``local_to_global_dof`` -- read-only, shape ``(space.num_total_basis,)``, mapping
+      each windowed DOF (flat, C-order over the windowed per-axis basis counts) to its
+      flat index in the parent space.
+
+    Unlike :class:`pantr.grid.GridRestriction` there is no ``in_subset`` mask: every
+    windowed DOF is a genuine parent DOF (a windowed space spans a box of cells, so
+    there are no fill DOFs).
+    """
+
+    space: BsplineSpace
+    local_to_global_dof: npt.NDArray[np.int64]

--- a/tests/test_bspline_space.py
+++ b/tests/test_bspline_space.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from pantr.bspline import BsplineSpace, BsplineSpace1D
+from pantr.bspline import BsplineSpace, BsplineSpace1D, BsplineSpaceRestriction
 from pantr.quad import PointsLattice
 
 
@@ -977,3 +977,117 @@ class TestOutParameter:
         np.testing.assert_array_equal(idx1, idx2)
         assert basis2 is out_basis
         assert idx2 is out_first
+
+
+def _open_uniform_space_1d(degree: int, n_int: int) -> BsplineSpace1D:
+    """Open-uniform 1D space: ``n_int`` unit intervals on ``[0, n_int]``, given degree."""
+    knots = (
+        [0.0] * (degree + 1) + [float(i) for i in range(1, n_int)] + [float(n_int)] * (degree + 1)
+    )
+    return BsplineSpace1D(knots, degree)
+
+
+def _check_restrict(space: BsplineSpace, cell_ids: list[int]) -> BsplineSpaceRestriction:
+    """Assert a space restriction reproduces the global basis and DOF map over the window."""
+    r = space.restrict(cell_ids)
+    sub, l2g = r.space, r.local_to_global_dof
+    assert isinstance(r, BsplineSpaceRestriction)
+    assert isinstance(sub, BsplineSpace)
+    assert not l2g.flags.writeable
+    assert l2g.shape == (sub.num_total_basis,)
+    assert len(set(l2g.tolist())) == sub.num_total_basis  # bijection into global DOFs
+
+    # Sample the tensor grid of windowed-cell midpoints (inside both windows).
+    axis_pts = [
+        0.5 * (uk[:-1] + uk[1:])
+        for uk in (
+            sub.spaces[d].get_unique_knots_and_multiplicity(in_domain=True)[0]
+            for d in range(space.dim)
+        )
+    ]
+    grids = np.meshgrid(*axis_pts, indexing="ij")
+    pts = np.stack([g.ravel() for g in grids], axis=-1).astype(np.float64)
+
+    gb, gfb = space.tabulate_basis(pts)
+    wb, wfb = sub.tabulate_basis(pts)
+    np.testing.assert_allclose(wb, gb, atol=1e-12)  # windowed basis == global basis pointwise
+
+    g_nb, w_nb, degs = space.num_basis, sub.num_basis, space.degrees
+    for i in range(pts.shape[0]):
+        g_axis = [gfb[i, d] + np.arange(degs[d] + 1) for d in range(space.dim)]
+        w_axis = [wfb[i, d] + np.arange(degs[d] + 1) for d in range(space.dim)]
+        g_flat = np.ravel_multi_index(
+            [m.ravel() for m in np.meshgrid(*g_axis, indexing="ij")], g_nb
+        )
+        w_flat = np.ravel_multi_index(
+            [m.ravel() for m in np.meshgrid(*w_axis, indexing="ij")], w_nb
+        )
+        np.testing.assert_array_equal(l2g[w_flat], g_flat)  # DOF-map ordering correct
+    return r
+
+
+class TestBsplineSpaceRestrict:
+    """Tests for BsplineSpace.restrict (windowed sub-space + DOF map)."""
+
+    def test_contiguous_block_2d(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(2, 3)])
+        # intervals [1,3) x [0,2); flat C-order over num_intervals (4,3): i*3 + j
+        cell_ids = [i * 3 + j for i in (1, 2) for j in (0, 1)]
+        r = _check_restrict(space, cell_ids)
+        assert r.space.num_intervals == (2, 2)
+
+    def test_full_space_is_bijection(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 3), _open_uniform_space_1d(1, 4)])
+        r = _check_restrict(space, list(range(space.num_total_intervals)))
+        assert r.space.num_intervals == space.num_intervals
+        assert r.space.num_total_basis == space.num_total_basis
+        assert set(r.local_to_global_dof.tolist()) == set(range(space.num_total_basis))
+
+    def test_non_convex_uses_bbox(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(2, 4)])
+        corners = [0, 3 * 4 + 3]  # (0,0) and (3,3) over num_intervals (4,4)
+        r = _check_restrict(space, corners)
+        assert r.space.num_intervals == (4, 4)  # bbox spans everything
+
+    def test_single_cell_1d(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(3, 5)])
+        r = _check_restrict(space, [2])
+        assert r.space.num_intervals == (1,)
+        assert r.space.num_total_basis == 4  # degree + 1 (Bezier-like window)
+
+    def test_dof_map_matches_global_indices(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 4)])  # num_basis 6, intervals 4
+        r = space.restrict([1, 2])  # intervals [1,3); first basis on interval 1 is index 1
+        np.testing.assert_array_equal(r.local_to_global_dof, [1, 2, 3, 4])
+
+    def test_returns_restriction_namedtuple(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 3), _open_uniform_space_1d(2, 3)])
+        r = space.restrict([0])
+        assert isinstance(r, BsplineSpaceRestriction)
+        assert isinstance(r.space, BsplineSpace)
+
+    def test_empty_raises(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 3)])
+        with pytest.raises(ValueError, match="non-empty"):
+            space.restrict([])
+
+    def test_out_of_range_raises(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 3)])
+        with pytest.raises(IndexError):
+            space.restrict([space.num_total_intervals])
+        with pytest.raises(IndexError):
+            space.restrict([-1])
+
+    def test_non_integer_raises(self) -> None:
+        space = BsplineSpace([_open_uniform_space_1d(2, 3)])
+        with pytest.raises(TypeError, match="integer"):
+            space.restrict([0.0])
+
+    def test_periodic_rejected(self) -> None:
+        from pantr.bspline import create_uniform_periodic_knots  # noqa: PLC0415
+
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+        per = BsplineSpace1D(knots, 2, periodic=True)
+        space = BsplineSpace([per])
+        with pytest.raises(ValueError, match="periodic"):
+            space.restrict([0])

--- a/tests/test_bspline_space.py
+++ b/tests/test_bspline_space.py
@@ -1060,6 +1060,16 @@ class TestBsplineSpaceRestrict:
         r = space.restrict([1, 2])  # intervals [1,3); first basis on interval 1 is index 1
         np.testing.assert_array_equal(r.local_to_global_dof, [1, 2, 3, 4])
 
+    def test_dof_map_explicit_2d(self) -> None:
+        # degree-(1,1) space, num_intervals=(3,2), num_basis=(4,3).
+        # Restrict to row 1 (all columns): cell_ids [1*2+0, 1*2+1] = [2,3].
+        # Per-axis windows: axis-0 -> [1,2), axis-1 -> [0,2) (full).
+        # Expected dof_0=[1,2], dof_1=[0,1,2]; meshgrid(ij) -> ravel over (4,3):
+        # [1*3+0, 1*3+1, 1*3+2, 2*3+0, 2*3+1, 2*3+2] = [3,4,5,6,7,8].
+        space = BsplineSpace([_open_uniform_space_1d(1, 3), _open_uniform_space_1d(1, 2)])
+        r = space.restrict([2, 3])
+        np.testing.assert_array_equal(r.local_to_global_dof, [3, 4, 5, 6, 7, 8])
+
     def test_returns_restriction_namedtuple(self) -> None:
         space = BsplineSpace([_open_uniform_space_1d(2, 3), _open_uniform_space_1d(2, 3)])
         r = space.restrict([0])

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2019,6 +2019,9 @@ class TestBsplineSpace1DRestrict:
     def test_interior_window(self) -> None:
         _check_restrict_1d(_open_uniform_1d(2, 5), 1, 4)
 
+    def test_left_boundary_window(self) -> None:
+        _check_restrict_1d(_open_uniform_1d(2, 5), 0, 3)
+
     def test_interior_window_cubic(self) -> None:
         _check_restrict_1d(_open_uniform_1d(3, 6), 2, 5)
 

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -1980,3 +1980,86 @@ class TestOutParameter:
 
         with pytest.raises(ValueError, match="Output array is not writeable"):
             spline.tabulate_cardinal_extraction_operators(out=out)
+
+
+def _open_uniform_1d(degree: int, n_int: int) -> BsplineSpace1D:
+    """Open-uniform 1D space: ``n_int`` unit intervals on ``[0, n_int]``."""
+    knots = (
+        [0.0] * (degree + 1) + [float(i) for i in range(1, n_int)] + [float(n_int)] * (degree + 1)
+    )
+    return BsplineSpace1D(knots, degree)
+
+
+def _check_restrict_1d(
+    space: BsplineSpace1D, lo: int, hi: int
+) -> tuple[BsplineSpace1D, npt.NDArray[np.int64]]:
+    """Assert a 1D restriction reproduces the global basis, derivatives, and DOF map."""
+    wspace, dof = space.restrict(lo, hi)
+    p = space.degree
+    assert not dof.flags.writeable
+    assert wspace.degree == p
+    assert wspace.num_intervals == hi - lo
+    assert wspace.num_basis == len(dof)
+    # Windowed knots are a pure slice of the global knots (never re-clamped).
+    j_lo, j_hi = int(dof[0]), int(dof[-1])
+    np.testing.assert_array_equal(wspace.knots, space.knots[j_lo : j_hi + p + 2])
+    # Windowed basis and all derivatives equal the global ones over the window cells.
+    uk, _ = wspace.get_unique_knots_and_multiplicity(in_domain=True)
+    mids = 0.5 * (uk[:-1] + uk[1:])
+    gd, gfb = space.tabulate_basis_derivatives(mids, p)
+    wd, wfb = wspace.tabulate_basis_derivatives(mids, p)
+    np.testing.assert_allclose(wd, gd, atol=1e-11)
+    np.testing.assert_array_equal(dof[wfb], gfb)  # windowed first-basis maps to global
+    return wspace, dof
+
+
+class TestBsplineSpace1DRestrict:
+    """Tests for BsplineSpace1D.restrict (windowed sub-space + DOF map)."""
+
+    def test_interior_window(self) -> None:
+        _check_restrict_1d(_open_uniform_1d(2, 5), 1, 4)
+
+    def test_interior_window_cubic(self) -> None:
+        _check_restrict_1d(_open_uniform_1d(3, 6), 2, 5)
+
+    def test_full_range_is_identity(self) -> None:
+        space = _open_uniform_1d(3, 4)
+        wspace, dof = _check_restrict_1d(space, 0, space.num_intervals)
+        np.testing.assert_array_equal(wspace.knots, space.knots)
+        np.testing.assert_array_equal(dof, np.arange(space.num_basis))
+
+    def test_single_interval(self) -> None:
+        space = _open_uniform_1d(2, 5)
+        wspace, _ = _check_restrict_1d(space, 2, 3)
+        assert wspace.num_intervals == 1
+        assert wspace.num_basis == space.degree + 1
+
+    def test_interior_window_not_reclamped(self) -> None:
+        wspace, _ = _open_uniform_1d(2, 5).restrict(1, 4)
+        # Interior window keeps the original (multiplicity-1) boundary knots.
+        assert not wspace.has_left_end_open()
+        assert not wspace.has_right_end_open()
+
+    def test_dof_range(self) -> None:
+        space = _open_uniform_1d(2, 4)  # knots [0,0,0,1,2,3,4,4,4], num_basis 6
+        _, dof = space.restrict(1, 3)
+        np.testing.assert_array_equal(dof, [1, 2, 3, 4])
+
+    def test_domain_matches_window(self) -> None:
+        wspace, _ = _open_uniform_1d(2, 5).restrict(1, 4)
+        np.testing.assert_allclose(wspace.domain, (1.0, 4.0))
+
+    def test_periodic_rejected(self) -> None:
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+        space = BsplineSpace1D(knots, 2, periodic=True)
+        with pytest.raises(ValueError, match="periodic"):
+            space.restrict(0, 2)
+
+    def test_invalid_range_raises(self) -> None:
+        space = _open_uniform_1d(2, 4)
+        with pytest.raises(ValueError, match="interval"):
+            space.restrict(2, 2)  # lo == hi
+        with pytest.raises(ValueError, match="interval"):
+            space.restrict(-1, 2)  # lo < 0
+        with pytest.raises(ValueError, match="interval"):
+            space.restrict(0, 5)  # hi > num_intervals


### PR DESCRIPTION
## Summary
The spline-space analogue of `Grid.restrict` (#175) -- an optional `restrict` that windows a B-spline space to a sub-range of knot-span cells, with **pure knot-vector slicing (never re-clamped)** so the windowed basis equals the parent basis pointwise over the window.

- `BsplineSpace1D.restrict(interval_lo, interval_hi) -> (BsplineSpace1D, NDArray[int64])`: windowed 1D space (knots are a slice `T[j_lo : j_hi+p+2]`) + read-only local-to-global DOF index array.
- `BsplineSpace.restrict(cell_ids) -> BsplineSpaceRestriction(space, local_to_global_dof)`: windows each axis over the multi-index bounding box of the requested flat knot-span cells (C-order, matching `tensor_product_grid` / `SpanwiseElementExtraction`); tensor-product DOF map, read-only.
- `BsplineSpaceRestriction` NamedTuple (exported). No `in_subset` field -- every windowed DOF is a genuine parent DOF (fill is a cell concept, handled by `GridRestriction`).
- Periodic spaces raise `ValueError` (windowing periodic knots is a deferred later pass).

This is **PR A3** of the MPI-distribution feature (#142). A4/A5 (`build_local`) compose this with the grid restriction.

## Test plan
- [x] New `TestBsplineSpaceRestrict` (nD) and `TestBsplineSpace1DRestrict` (1D): windowed basis **and derivatives** equal the global ones over the window; DOF-map ordering verified via `tabulate_basis`; knots are a pure slice / interior windows are not re-clamped; `num_intervals`/`domain`/DOF-range correctness; non-convex bbox; full-space bijection (not assuming id order); single-cell; errors (empty / out-of-range / non-integer / periodic).
- [x] `pytest --no-cov` -- 3131 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)