### PR TITLE
feat: Partition, support-closure halo, and DOF ownership (A4)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -29,6 +29,8 @@ This package consolidates the B-spline API:
 - :class:`THBSpline`: an evaluable THB spline function (space + coefficients).
 - :func:`quasi_interpolate_thb_spline`: Speleers-Manni hierarchical
   quasi-interpolation onto a :class:`THBSplineSpace`.
+- :func:`compute_halo`, :func:`dof_owner`: serial helpers for distributing a
+  B-spline space (support-closure halo and lex-first-active-cell DOF ownership).
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -44,6 +46,7 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
+from ._local_space import compute_halo, dof_owner
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
 from ._thb_spline_space import THBSplineSpace
@@ -64,12 +67,14 @@ __all__ = [
     "SpanwiseElementExtraction",
     "THBSpline",
     "THBSplineSpace",
+    "compute_halo",
     "create_cardinal_knots",
     "create_from_bezier",
     "create_greville_lattice",
     "create_uniform_open_knots",
     "create_uniform_periodic_knots",
     "create_uniform_space",
+    "dof_owner",
     "fit_bspline",
     "get_greville_abscissae",
     "interpolate_bspline",

--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -65,13 +65,23 @@ def compute_halo(space: BsplineSpace, owned_cells: npt.ArrayLike) -> npt.NDArray
 
     Raises:
         ValueError: If any axis is periodic.
+        TypeError: If ``owned_cells`` is not integer-valued.
         IndexError: If any owned cell id is out of range ``[0, num_total_intervals)``.
     """
     _reject_periodic(space)
     num_intervals = space.num_intervals
     n_cells = space.num_total_intervals
-    owned = np.asarray(owned_cells, dtype=np.int64).ravel()
-    if owned.size and (int(owned.min()) < 0 or int(owned.max()) >= n_cells):
+    owned = np.asarray(owned_cells).ravel()
+    if owned.size == 0:
+        result = np.empty(0, dtype=np.int64)
+        result.flags.writeable = False
+        return result
+    if not np.issubdtype(owned.dtype, np.integer):
+        raise TypeError(
+            f"compute_halo: owned_cells must be integer-valued; got dtype {owned.dtype}."
+        )
+    owned = owned.astype(np.int64, copy=False)
+    if int(owned.min()) < 0 or int(owned.max()) >= n_cells:
         raise IndexError(f"owned cell id out of range [0, {n_cells}).")
 
     # Per-axis interval -> inclusive support-cell range: functions non-zero on
@@ -114,8 +124,9 @@ def dof_owner(space: BsplineSpace, partition: Partition) -> npt.NDArray[np.int32
         ``-1`` for dead DOFs.
 
     Raises:
-        ValueError: If any axis is periodic, or ``partition`` does not match the
-            space's cell count.
+        ValueError: If any axis is periodic.
+        ValueError: If ``partition.cell_owner`` length does not match
+            ``space.num_total_intervals``.
     """
     _reject_periodic(space)
     cell_owner = partition.cell_owner

--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -1,0 +1,154 @@
+"""Serial windowing helpers for distributing a tensor-product B-spline space.
+
+These functions compute, without any MPI, pieces a distributed local space is built
+from:
+
+- :func:`compute_halo`: the function-support closure of a set of owned cells -- the
+  extra cells a rank must see so the B-spline functions touching its owned cells are
+  fully represented.
+- :func:`dof_owner`: the owner rank of every global DOF, by the
+  lex-first-active-cell-in-support rule.
+
+Both operate on the knot-span grid of a :class:`~pantr.bspline.BsplineSpace`: cells
+are flat-indexed in C-order over ``num_intervals`` and DOFs in C-order over
+``num_basis``, matching :func:`pantr.grid.tensor_product_grid` and
+:class:`~pantr.bspline.SpanwiseElementExtraction`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._thb_spline_space import _func_support_1d
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from ..grid import Partition
+    from ._bspline_space_nd import BsplineSpace
+
+
+def _reject_periodic(space: BsplineSpace) -> None:
+    """Raise if any direction of ``space`` is periodic.
+
+    Args:
+        space (BsplineSpace): Tensor-product B-spline space.
+
+    Raises:
+        ValueError: If any 1D direction is periodic.
+    """
+    if any(sp.periodic for sp in space.spaces):
+        raise ValueError("periodic B-spline spaces are not supported.")
+
+
+def compute_halo(space: BsplineSpace, owned_cells: npt.ArrayLike) -> npt.NDArray[np.int64]:
+    """Return the support-closure halo of ``owned_cells``.
+
+    The halo is the set of knot-span cells, **excluding** the owned cells, covered by
+    the support of any B-spline function non-zero on an owned cell. A rank owning
+    ``owned_cells`` needs exactly these extra cells so every function touching its
+    owned cells is fully represented over the union of the owned and halo cells. For
+    open/uniform knots this is the ``degree``-wide halo; general or repeated knots are
+    handled exactly via the per-direction support.
+
+    Args:
+        space (BsplineSpace): Tensor-product B-spline space (non-periodic). Its
+            knot-span grid has ``num_total_intervals`` cells.
+        owned_cells (npt.ArrayLike): Flat cell ids (C-order over ``num_intervals``)
+            owned by the rank. Duplicates are ignored.
+
+    Returns:
+        npt.NDArray[np.int64]: Sorted, read-only flat ids of the halo cells -- those
+        in the support closure but not in ``owned_cells``.
+
+    Raises:
+        ValueError: If any axis is periodic.
+        IndexError: If any owned cell id is out of range ``[0, num_total_intervals)``.
+    """
+    _reject_periodic(space)
+    num_intervals = space.num_intervals
+    n_cells = space.num_total_intervals
+    owned = np.asarray(owned_cells, dtype=np.int64).ravel()
+    if owned.size and (int(owned.min()) < 0 or int(owned.max()) >= n_cells):
+        raise IndexError(f"owned cell id out of range [0, {n_cells}).")
+
+    # Per-axis interval -> inclusive support-cell range: functions non-zero on
+    # interval c are [fb[c], fb[c] + degree]; their support is [fc[fb[c]], lc[fb[c]+p]].
+    lo_axes: list[npt.NDArray[np.int64]] = []
+    hi_axes: list[npt.NDArray[np.int64]] = []
+    for sp in space.spaces:
+        fb, fc, lc = _func_support_1d(sp)
+        lo_axes.append(fc[fb].astype(np.int64))
+        hi_axes.append(lc[fb + sp.degree].astype(np.int64))
+
+    mask = np.zeros(num_intervals, dtype=np.bool_)
+    owned_multi = np.unravel_index(owned, num_intervals)
+    for i in range(owned.size):
+        window = tuple(
+            slice(int(lo_axes[d][owned_multi[d][i]]), int(hi_axes[d][owned_multi[d][i]]) + 1)
+            for d in range(space.dim)
+        )
+        mask[window] = True
+    halo = np.setdiff1d(np.flatnonzero(mask.ravel()), owned).astype(np.int64, copy=False)
+    halo.flags.writeable = False
+    return halo
+
+
+def dof_owner(space: BsplineSpace, partition: Partition) -> npt.NDArray[np.int32]:
+    """Return the owner rank of every global DOF (lex-first-active-cell rule).
+
+    Each global B-spline DOF is owned by the rank that owns the active cell with the
+    smallest flat id in the DOF's support. A DOF whose support contains no active cell
+    (``cell_owner == -1`` throughout) is a dead DOF, assigned ``-1``.
+
+    Args:
+        space (BsplineSpace): Tensor-product B-spline space (non-periodic). DOFs are
+            flat-indexed in C-order over ``num_basis``.
+        partition (Partition): Owner of every knot-span cell; ``cell_owner`` must have
+            length ``space.num_total_intervals``.
+
+    Returns:
+        npt.NDArray[np.int32]: Read-only ``(num_total_basis,)`` owner rank per DOF;
+        ``-1`` for dead DOFs.
+
+    Raises:
+        ValueError: If any axis is periodic, or ``partition`` does not match the
+            space's cell count.
+    """
+    _reject_periodic(space)
+    cell_owner = partition.cell_owner
+    if cell_owner.shape[0] != space.num_total_intervals:
+        raise ValueError(
+            f"partition has {cell_owner.shape[0]} cells; "
+            f"expected {space.num_total_intervals} (space.num_total_intervals)."
+        )
+    num_intervals = space.num_intervals
+    num_basis = space.num_basis
+    dim = space.dim
+
+    fc_axes: list[npt.NDArray[np.int64]] = []
+    lc_axes: list[npt.NDArray[np.int64]] = []
+    for sp in space.spaces:
+        _, fc, lc = _func_support_1d(sp)
+        fc_axes.append(fc.astype(np.int64))
+        lc_axes.append(lc.astype(np.int64))
+
+    owners = np.full(space.num_total_basis, -1, dtype=np.int32)
+    dof_multi = np.unravel_index(np.arange(space.num_total_basis), num_basis)
+    for dof in range(space.num_total_basis):
+        axis_ranges = [
+            np.arange(fc_axes[d][dof_multi[d][dof]], lc_axes[d][dof_multi[d][dof]] + 1)
+            for d in range(dim)
+        ]
+        mesh = np.meshgrid(*axis_ranges, indexing="ij")
+        support_cells = np.ravel_multi_index(tuple(m.ravel() for m in mesh), num_intervals)
+        active = support_cells[cell_owner[support_cells] >= 0]
+        if active.size:
+            owners[dof] = cell_owner[int(active.min())]
+    owners.flags.writeable = False
+    return owners
+
+
+__all__ = ["compute_halo", "dof_owner"]

--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -36,6 +36,7 @@ Main exports:
   unit cube onto a grid's cells (per-cell points and weights).
 - :func:`overlay`: the coarsest :class:`TensorProductGrid` refining two input
   tensor-product grids (union of per-axis breakpoints on their domain overlap).
+- :class:`Partition`: a per-cell owner assignment for distributing a grid's cells.
 """
 
 from __future__ import annotations
@@ -45,6 +46,7 @@ from ._cell_quadrature import cell_quadrature
 from ._grid import Grid, GridRestriction
 from ._hierarchical_grid import HierarchicalGrid, hierarchical_grid
 from ._overlay import overlay
+from ._partition import Partition
 from ._tags import CellTags, FacetTags
 from ._tensor_product_grid import TensorProductGrid, tensor_product_grid, uniform_grid
 
@@ -55,6 +57,7 @@ __all__ = [
     "Grid",
     "GridRestriction",
     "HierarchicalGrid",
+    "Partition",
     "TensorProductGrid",
     "cell_quadrature",
     "hierarchical_grid",

--- a/src/pantr/grid/_partition.py
+++ b/src/pantr/grid/_partition.py
@@ -1,0 +1,113 @@
+"""Cell-ownership partition for distributing a structured grid.
+
+A :class:`Partition` records, for every cell of a grid (or the knot-span grid of a
+B-spline space), which rank owns it -- the serial, communication-free descriptor
+consumed by the distributed-space machinery. It is produced either by consuming an
+external partition (for example a dolfinx mesh) or by a native graph partitioner,
+and is intentionally space-agnostic: it stores only an integer owner per cell.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class Partition:
+    """A per-cell owner assignment over a grid's cells.
+
+    Records, for every cell, the rank that owns it -- or ``-1`` for an inactive cell
+    excluded from the partition (e.g. an exterior / trimmed cell). The owner array is
+    coerced to a read-only ``int32`` array on construction and the object is otherwise
+    immutable. Owners and counts are exposed through the :attr:`cell_owner`,
+    :attr:`n_parts`, :attr:`n_cells`, and :attr:`active_mask` properties.
+    """
+
+    __slots__ = ("_cell_owner", "_n_parts")
+
+    def __init__(self, cell_owner: npt.ArrayLike, n_parts: int) -> None:
+        """Build a partition from a per-cell owner array.
+
+        Args:
+            cell_owner (npt.ArrayLike): Per-cell owner ranks (``-1`` for inactive
+                cells); coerced to a read-only 1D ``int32`` array.
+            n_parts (int): Number of parts (ranks); must be ``>= 1``.
+
+        Raises:
+            ValueError: If ``n_parts < 1``, ``cell_owner`` is not 1D integer, or any
+                owner is outside ``[-1, n_parts)``.
+        """
+        if n_parts < 1:
+            raise ValueError(f"n_parts must be >= 1; got {n_parts}.")
+        owner = np.asarray(cell_owner)
+        if owner.ndim != 1 or not np.issubdtype(owner.dtype, np.integer):
+            raise ValueError("cell_owner must be a 1D integer array.")
+        owner = np.ascontiguousarray(owner, dtype=np.int32)
+        if owner.size and (int(owner.min()) < -1 or int(owner.max()) >= n_parts):
+            raise ValueError(
+                f"cell_owner values must lie in [-1, {n_parts}); "
+                f"got range [{int(owner.min())}, {int(owner.max())}]."
+            )
+        owner.flags.writeable = False
+        self._cell_owner = owner
+        self._n_parts = int(n_parts)
+
+    @property
+    def cell_owner(self) -> npt.NDArray[np.int32]:
+        """Get the read-only per-cell owner array.
+
+        Returns:
+            npt.NDArray[np.int32]: ``(n_cells,)`` owners; ``-1`` for inactive cells.
+        """
+        return self._cell_owner
+
+    @property
+    def n_parts(self) -> int:
+        """Get the number of parts (ranks).
+
+        Returns:
+            int: The part count (``>= 1``).
+        """
+        return self._n_parts
+
+    @property
+    def n_cells(self) -> int:
+        """Get the total number of cells (active and inactive).
+
+        Returns:
+            int: Length of :attr:`cell_owner`.
+        """
+        return int(self._cell_owner.shape[0])
+
+    @property
+    def active_mask(self) -> npt.NDArray[np.bool_]:
+        r"""Get a boolean mask of the active cells (owned by some rank).
+
+        Returns:
+            npt.NDArray[np.bool\_]: Fresh ``(n_cells,)`` mask; ``True`` where the cell
+            owner is not ``-1``.
+        """
+        return self._cell_owner >= 0
+
+    def owned_cells(self, rank: int) -> npt.NDArray[np.int64]:
+        """Return the flat ids of the cells owned by ``rank``, ascending.
+
+        Args:
+            rank (int): Owner rank in ``[0, n_parts)``.
+
+        Returns:
+            npt.NDArray[np.int64]: Sorted cell ids with ``cell_owner == rank``.
+
+        Raises:
+            ValueError: If ``rank`` is outside ``[0, n_parts)``.
+        """
+        if not 0 <= rank < self._n_parts:
+            raise ValueError(f"rank must be in [0, {self._n_parts}); got {rank}.")
+        return np.flatnonzero(self._cell_owner == rank).astype(np.int64)
+
+
+__all__ = ["Partition"]

--- a/tests/test_grid_partition.py
+++ b/tests/test_grid_partition.py
@@ -82,3 +82,8 @@ def test_empty_partition() -> None:
     p = Partition(np.array([], dtype=np.int32), n_parts=1)
     assert p.n_cells == 0
     assert p.owned_cells(0).size == 0
+
+
+def test_owned_cells_dtype() -> None:
+    p = Partition([0, 1, 0, 1], n_parts=2)
+    assert p.owned_cells(0).dtype == np.int64

--- a/tests/test_grid_partition.py
+++ b/tests/test_grid_partition.py
@@ -1,0 +1,84 @@
+"""Tests for pantr.grid.Partition."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.grid import Partition
+
+
+def test_construction_and_n_cells() -> None:
+    p = Partition(np.array([0, 1, 0, -1, 1], dtype=np.int32), n_parts=2)
+    assert p.n_cells == 5
+    assert p.n_parts == 2
+
+
+def test_cell_owner_is_readonly_int32() -> None:
+    p = Partition([0, 1, -1, 1], n_parts=2)
+    assert p.cell_owner.dtype == np.int32
+    assert not p.cell_owner.flags.writeable
+
+
+def test_active_mask() -> None:
+    p = Partition([0, -1, 1, -1, 0], n_parts=2)
+    np.testing.assert_array_equal(p.active_mask, [True, False, True, False, True])
+
+
+def test_owned_cells() -> None:
+    p = Partition([0, 1, 0, -1, 1, 0], n_parts=2)
+    np.testing.assert_array_equal(p.owned_cells(0), [0, 2, 5])
+    np.testing.assert_array_equal(p.owned_cells(1), [1, 4])
+
+
+def test_owned_cells_empty_for_unused_rank() -> None:
+    p = Partition([0, 0, -1], n_parts=3)
+    assert p.owned_cells(2).size == 0
+
+
+def test_owned_cells_bad_rank_raises() -> None:
+    p = Partition([0, 1], n_parts=2)
+    with pytest.raises(ValueError, match="rank"):
+        p.owned_cells(2)
+    with pytest.raises(ValueError, match="rank"):
+        p.owned_cells(-1)
+
+
+def test_accepts_list_input() -> None:
+    p = Partition([0, 1, -1], n_parts=2)
+    assert p.n_cells == 3
+    assert p.cell_owner.dtype == np.int32
+
+
+def test_invalid_n_parts_raises() -> None:
+    with pytest.raises(ValueError, match="n_parts"):
+        Partition([0, 0], n_parts=0)
+
+
+def test_non_1d_raises() -> None:
+    with pytest.raises(ValueError, match="1D integer"):
+        Partition(np.zeros((2, 2), dtype=np.int32), n_parts=1)
+
+
+def test_non_integer_raises() -> None:
+    with pytest.raises(ValueError, match="1D integer"):
+        Partition(np.array([0.0, 1.0]), n_parts=2)
+
+
+def test_owner_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match=r"\[-1, 2\)"):
+        Partition([0, 2], n_parts=2)  # 2 == n_parts
+    with pytest.raises(ValueError, match=r"\[-1, 2\)"):
+        Partition([-2, 0], n_parts=2)  # -2 < -1
+
+
+def test_frozen() -> None:
+    p = Partition([0, 1], n_parts=2)
+    with pytest.raises(AttributeError):
+        p.n_parts = 3  # type: ignore[misc]
+
+
+def test_empty_partition() -> None:
+    p = Partition(np.array([], dtype=np.int32), n_parts=1)
+    assert p.n_cells == 0
+    assert p.owned_cells(0).size == 0

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -114,6 +114,24 @@ def test_halo_out_of_range_raises() -> None:
         compute_halo(space, [space.num_total_intervals])
 
 
+def test_halo_out_of_range_negative() -> None:
+    space = _open_uniform_space([2], [5])
+    with pytest.raises(IndexError):
+        compute_halo(space, [-1])
+
+
+def test_halo_empty_owned() -> None:
+    space = _open_uniform_space([1], [4])
+    halo = compute_halo(space, [])
+    assert halo.size == 0
+
+
+def test_halo_non_integer_raises() -> None:
+    space = _open_uniform_space([1], [4])
+    with pytest.raises(TypeError, match="integer"):
+        compute_halo(space, [0.0, 1.0])
+
+
 # ------------------------------------------------------------------- dof_owner
 
 
@@ -165,3 +183,20 @@ def test_dof_owner_periodic_rejected() -> None:
     part = Partition(np.zeros(4, dtype=np.int32), n_parts=1)
     with pytest.raises(ValueError, match="periodic"):
         dof_owner(BsplineSpace([per]), part)
+
+
+def test_dof_owner_lex_first_active_degree2() -> None:
+    # degree 2, 5 cells => 7 DOFs; partition splits at cell 2
+    space = _open_uniform_space([2], [5])
+    part = Partition(np.array([0, 0, 1, 1, 1], dtype=np.int32), n_parts=2)
+    # B_0:[0]->0, B_1:[0,1]->0, B_2:[0,1,2]->0, B_3:[1,2,3]->cell1=rank0,
+    # B_4:[2,3,4]->cell2=rank1, B_5:[3,4]->rank1, B_6:[4]->rank1
+    np.testing.assert_array_equal(dof_owner(space, part), [0, 0, 0, 0, 1, 1, 1])
+
+
+def test_dof_owner_2d_multirank() -> None:
+    # degree (1,1), 2x2 cells => 3x3=9 DOFs; first two flat cells (row 0) -> rank 0, rest -> rank 1
+    space = _open_uniform_space([1, 1], [2, 2])
+    part = Partition(np.array([0, 0, 1, 1], dtype=np.int32), n_parts=2)
+    # DOFs in rows 0-1 (i<2) have lex-first support cell in row 0 -> rank 0; row 2 -> rank 1
+    np.testing.assert_array_equal(dof_owner(space, part), [0, 0, 0, 0, 0, 0, 1, 1, 1])

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -1,0 +1,167 @@
+"""Tests for pantr.bspline.compute_halo and dof_owner."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import BsplineSpace, BsplineSpace1D, compute_halo, dof_owner
+from pantr.grid import Partition
+
+
+def _open_uniform_space(degrees: list[int], n_ints: list[int]) -> BsplineSpace:
+    """Open-uniform tensor-product space: ``n_ints[d]`` unit intervals on each axis."""
+    spaces: list[BsplineSpace1D] = []
+    for p, n in zip(degrees, n_ints, strict=True):
+        knots = [0.0] * (p + 1) + [float(i) for i in range(1, n)] + [float(n)] * (p + 1)
+        spaces.append(BsplineSpace1D(knots, p))
+    return BsplineSpace(spaces)
+
+
+def _first_basis_per_axis(space: BsplineSpace) -> list[npt.NDArray[np.int64]]:
+    """Per axis, the first non-zero basis index on each interval (via midpoints)."""
+    fbs = []
+    for sp in space.spaces:
+        uk, _ = sp.get_unique_knots_and_multiplicity(in_domain=True)
+        _, fb = sp.tabulate_basis(0.5 * (uk[:-1] + uk[1:]))
+        fbs.append(np.asarray(fb, dtype=np.int64))
+    return fbs
+
+
+def _brute_closure(space: BsplineSpace, owned: list[int]) -> set[int]:
+    """Cells sharing a B-spline function with any owned cell (function-index overlap).
+
+    Independent cross-check of :func:`compute_halo`: cell ``c'`` is in the closure iff,
+    for every axis, the function-index range ``[fb[c'], fb[c']+p]`` overlaps that of an
+    owned cell.
+    """
+    fbs = _first_basis_per_axis(space)
+    degs = space.degrees
+    ni = space.num_intervals
+    owned_multi = [tuple(int(i) for i in np.unravel_index(c, ni)) for c in owned]
+    closure: set[int] = set()
+    for cflat in range(space.num_total_intervals):
+        cm = tuple(int(i) for i in np.unravel_index(cflat, ni))
+        for om in owned_multi:
+            if all(
+                max(int(fbs[d][cm[d]]), int(fbs[d][om[d]]))
+                <= min(int(fbs[d][cm[d]]), int(fbs[d][om[d]])) + degs[d]
+                for d in range(space.dim)
+            ):
+                closure.add(cflat)
+                break
+    return closure
+
+
+# ----------------------------------------------------------------- compute_halo
+
+
+def test_halo_open_uniform_1d() -> None:
+    space = _open_uniform_space([2], [7])
+    # Degree-2 open-uniform: the support closure of cell 3 is cells [1, 5].
+    np.testing.assert_array_equal(compute_halo(space, [3]), [1, 2, 4, 5])
+
+
+def test_halo_matches_brute_force_1d() -> None:
+    space = _open_uniform_space([3], [8])
+    owned = [2, 3, 4]
+    expected = sorted(_brute_closure(space, owned) - set(owned))
+    np.testing.assert_array_equal(compute_halo(space, owned), expected)
+
+
+def test_halo_matches_brute_force_2d_l_shape() -> None:
+    space = _open_uniform_space([2, 2], [4, 5])
+    owned = [1 * 5 + 1, 1 * 5 + 2, 2 * 5 + 1]  # non-convex L over num_intervals (4,5)
+    expected = sorted(_brute_closure(space, owned) - set(owned))
+    np.testing.assert_array_equal(compute_halo(space, owned), expected)
+
+
+def test_halo_matches_brute_force_anisotropic() -> None:
+    space = _open_uniform_space([1, 3], [5, 4])
+    owned = [2 * 4 + 1, 2 * 4 + 2]
+    expected = sorted(_brute_closure(space, owned) - set(owned))
+    np.testing.assert_array_equal(compute_halo(space, owned), expected)
+
+
+def test_halo_excludes_owned() -> None:
+    space = _open_uniform_space([2, 2], [5, 5])
+    owned = [12, 13]
+    assert set(compute_halo(space, owned).tolist()).isdisjoint(owned)
+
+
+def test_halo_is_readonly() -> None:
+    halo = compute_halo(_open_uniform_space([2], [6]), [3])
+    assert not halo.flags.writeable
+
+
+def test_halo_full_owned_is_empty() -> None:
+    space = _open_uniform_space([2], [5])
+    assert compute_halo(space, list(range(space.num_total_intervals))).size == 0
+
+
+def test_halo_periodic_rejected() -> None:
+    from pantr.bspline import create_uniform_periodic_knots  # noqa: PLC0415
+
+    per = BsplineSpace1D(create_uniform_periodic_knots(num_intervals=4, degree=2), 2, periodic=True)
+    with pytest.raises(ValueError, match="periodic"):
+        compute_halo(BsplineSpace([per]), [0])
+
+
+def test_halo_out_of_range_raises() -> None:
+    space = _open_uniform_space([2], [5])
+    with pytest.raises(IndexError):
+        compute_halo(space, [space.num_total_intervals])
+
+
+# ------------------------------------------------------------------- dof_owner
+
+
+def test_dof_owner_all_one_rank() -> None:
+    space = _open_uniform_space([1], [4])  # num_basis 5
+    part = Partition(np.zeros(space.num_total_intervals, dtype=np.int32), n_parts=1)
+    owners = dof_owner(space, part)
+    assert owners.shape == (space.num_total_basis,)
+    np.testing.assert_array_equal(owners, np.zeros(5, dtype=np.int32))
+
+
+def test_dof_owner_lex_first_active() -> None:
+    space = _open_uniform_space([1], [4])  # degree 1: B_j supports cells [j-1, j]
+    part = Partition(np.array([0, 0, 1, 1], dtype=np.int32), n_parts=2)
+    # B_0{0}->0, B_1{0,1}->0, B_2{1,2}->cell1=0, B_3{2,3}->cell2=1, B_4{3}->1
+    np.testing.assert_array_equal(dof_owner(space, part), [0, 0, 0, 1, 1])
+
+
+def test_dof_owner_dead_dof() -> None:
+    space = _open_uniform_space([1], [4])
+    part = Partition(np.array([0, -1, -1, -1], dtype=np.int32), n_parts=1)
+    # Only cell 0 active: DOFs whose support has no active cell are dead (-1).
+    np.testing.assert_array_equal(dof_owner(space, part), [0, 0, -1, -1, -1])
+
+
+def test_dof_owner_2d() -> None:
+    space = _open_uniform_space([1, 1], [2, 2])  # num_basis (3,3) = 9, cells 4
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=1)
+    np.testing.assert_array_equal(dof_owner(space, part), np.zeros(9, dtype=np.int32))
+
+
+def test_dof_owner_is_readonly() -> None:
+    space = _open_uniform_space([1], [4])
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=1)
+    assert not dof_owner(space, part).flags.writeable
+
+
+def test_dof_owner_cell_count_mismatch_raises() -> None:
+    space = _open_uniform_space([2], [5])
+    part = Partition(np.zeros(3, dtype=np.int32), n_parts=1)  # should be 5 cells
+    with pytest.raises(ValueError, match="cells"):
+        dof_owner(space, part)
+
+
+def test_dof_owner_periodic_rejected() -> None:
+    from pantr.bspline import create_uniform_periodic_knots  # noqa: PLC0415
+
+    per = BsplineSpace1D(create_uniform_periodic_knots(num_intervals=4, degree=2), 2, periodic=True)
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=1)
+    with pytest.raises(ValueError, match="periodic"):
+        dof_owner(BsplineSpace([per]), part)


### PR DESCRIPTION
## Summary
PR **A4** of the MPI-distribution feature (#142) -- the serial, MPI-free partition foundation that `build_local` (A5) will sit on. Two commits (grid + bspline):

- **`pantr.grid.Partition`** -- a per-cell owner descriptor: a read-only `int32` `cell_owner` array (`-1` = inactive) + `n_parts`, with `owned_cells(rank)` / `active_mask` / `n_cells`. Space-agnostic; flexible array-like input.
- **`pantr.bspline.compute_halo(space, owned_cells)`** -- the function-support closure of a rank's owned cells: the extra knot-span cells needed so every B-spline function touching an owned cell is fully represented over the owned + halo cells. Degree-wide for open/uniform knots; exact via the per-direction support for general/repeated knots.
- **`pantr.bspline.dof_owner(space, partition)`** -- the owner rank of every global DOF by the lex-first-active-cell-in-support rule; `-1` for dead DOFs (support contains no active cell).

Both helpers reuse the existing `_func_support_1d`, return read-only arrays, and reject periodic spaces. Standalone module functions.

## Test plan
- [x] `tests/test_grid_partition.py` -- construction/validation, int32 read-only coercion, `active_mask`, `owned_cells`, frozen, empty, out-of-range / bad-rank / non-integer.
- [x] `tests/test_local_space.py` -- `compute_halo` vs an independent function-overlap **brute force** (1D, non-convex 2D L-shape, anisotropic degrees), excludes-owned, read-only, full-owned-empty; `dof_owner` lex-first-active + dead-DOF `-1` + 2D + cell-count mismatch; periodic rejected for both.
- [x] `pytest --no-cov` -- 3177 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)