### PR TITLE
feat(bspline): build_local for tensor-product BsplineSpace (A5)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -31,6 +31,9 @@ This package consolidates the B-spline API:
   quasi-interpolation onto a :class:`THBSplineSpace`.
 - :func:`compute_halo`, :func:`dof_owner`: serial helpers for distributing a
   B-spline space (support-closure halo and lex-first-active-cell DOF ownership).
+- :func:`build_local`, :class:`LocalSpace`: build a rank's windowed local space
+  (cell/DOF maps and ownership masks) from a global space and a
+  :class:`pantr.grid.Partition`.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -46,7 +49,7 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
-from ._local_space import compute_halo, dof_owner
+from ._local_space import LocalSpace, build_local, compute_halo, dof_owner
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
 from ._thb_spline_space import THBSplineSpace
@@ -63,10 +66,12 @@ __all__ = [
     "BsplineSpace1D",
     "BsplineSpaceRestriction",
     "ExtractionStructView",
+    "LocalSpace",
     "MultiLevelExtraction",
     "SpanwiseElementExtraction",
     "THBSpline",
     "THBSplineSpace",
+    "build_local",
     "compute_halo",
     "create_cardinal_knots",
     "create_from_bezier",

--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -1,16 +1,19 @@
 """Serial windowing helpers for distributing a tensor-product B-spline space.
 
-These functions compute, without any MPI, pieces a distributed local space is built
-from:
+These functions compute, without any MPI, the pieces a distributed local space is
+built from:
 
 - :func:`compute_halo`: the function-support closure of a set of owned cells -- the
   extra cells a rank must see so the B-spline functions touching its owned cells are
   fully represented.
 - :func:`dof_owner`: the owner rank of every global DOF, by the
   lex-first-active-cell-in-support rule.
+- :func:`build_local`: compose the above into a rank-local :class:`LocalSpace` --
+  the complete windowed view a distributed solver needs.
+- :class:`LocalSpace`: NamedTuple returned by :func:`build_local`.
 
-Both operate on the knot-span grid of a :class:`~pantr.bspline.BsplineSpace`: cells
-are flat-indexed in C-order over ``num_intervals`` and DOFs in C-order over
+All functions operate on the knot-span grid of a :class:`~pantr.bspline.BsplineSpace`:
+cells are flat-indexed in C-order over ``num_intervals`` and DOFs in C-order over
 ``num_basis``, matching :func:`pantr.grid.tensor_product_grid` and
 :class:`~pantr.bspline.SpanwiseElementExtraction`.
 """
@@ -239,7 +242,12 @@ def build_local(global_space: BsplineSpace, partition: Partition, rank: int) -> 
     grid_restr = tensor_product_grid(global_space).restrict(window)
     local_to_global_cell = grid_restr.local_to_global_cell
     local_to_global_dof = restr.local_to_global_dof
-    assert local_to_global_cell.shape[0] == restr.space.num_total_intervals
+    if local_to_global_cell.shape[0] != restr.space.num_total_intervals:
+        raise RuntimeError(
+            f"Grid restriction ({local_to_global_cell.shape[0]} cells) and space restriction "
+            f"({restr.space.num_total_intervals} cells) disagree after restricting to the same "
+            f"window of {window.size} cells. This is a bug in restrict()."
+        )
 
     cell_owner = partition.cell_owner
     owned_cell_mask = cell_owner[local_to_global_cell] == rank

--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -17,7 +17,7 @@ are flat-indexed in C-order over ``num_intervals`` and DOFs in C-order over
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
@@ -162,4 +162,99 @@ def dof_owner(space: BsplineSpace, partition: Partition) -> npt.NDArray[np.int32
     return owners
 
 
-__all__ = ["compute_halo", "dof_owner"]
+class LocalSpace(NamedTuple):
+    """The rank-local windowed view of a distributed tensor-product B-spline space.
+
+    Produced by :func:`build_local`. A :class:`typing.NamedTuple` bundling a windowed
+    :class:`~pantr.bspline.BsplineSpace` with the maps and masks relating it to the
+    global space:
+
+    - ``space`` -- the windowed B-spline space over the bounding box of the rank's
+      owned cells and their support-closure halo; a real pantr object whose basis
+      equals the global basis pointwise over those cells.
+    - ``local_to_global_cell`` -- read-only ``(space.num_total_intervals,)`` map from
+      each local knot-span cell to its global cell id.
+    - ``local_to_global_dof`` -- read-only ``(space.num_total_basis,)`` map from each
+      local DOF to its global DOF id.
+    - ``owned_cell_mask`` -- read-only boolean ``(space.num_total_intervals,)`` mask;
+      ``True`` for the cells this rank owns (the rest are halo / bounding-box fill).
+    - ``owned_dof_mask`` -- read-only boolean ``(space.num_total_basis,)`` mask;
+      ``True`` for the DOFs this rank owns.
+    - ``n_global_cells`` -- total knot-span cells in the global space.
+    - ``n_global_dofs`` -- total basis functions in the global space.
+    """
+
+    space: BsplineSpace
+    local_to_global_cell: npt.NDArray[np.int64]
+    local_to_global_dof: npt.NDArray[np.int64]
+    owned_cell_mask: npt.NDArray[np.bool_]
+    owned_dof_mask: npt.NDArray[np.bool_]
+    n_global_cells: int
+    n_global_dofs: int
+
+
+def build_local(global_space: BsplineSpace, partition: Partition, rank: int) -> LocalSpace:
+    """Build the rank-local windowed space of a distributed tensor-product B-spline space.
+
+    Windows ``global_space`` to the bounding box of the cells owned by ``rank`` together
+    with their support-closure halo (:func:`compute_halo`), so the local basis equals the
+    global basis pointwise over those cells. Composes the grid restriction
+    (:meth:`pantr.grid.TensorProductGrid.restrict`) for the cell map and the space
+    restriction (:meth:`pantr.bspline.BsplineSpace.restrict`) for the windowed space and
+    DOF map, and marks owned cells/DOFs via :func:`dof_owner`.
+
+    Args:
+        global_space (BsplineSpace): The global tensor-product B-spline space
+            (non-periodic).
+        partition (Partition): Owner of every knot-span cell; ``cell_owner`` must have
+            length ``global_space.num_total_intervals``.
+        rank (int): The rank whose local space is built; must be in
+            ``[0, partition.n_parts)``.
+
+    Returns:
+        LocalSpace: The windowed space plus local-to-global cell/DOF maps and ownership
+        masks.
+
+    Raises:
+        ValueError: If ``global_space`` is periodic, ``rank`` is out of range,
+            ``partition`` does not match the space's cell count, or ``rank`` owns no
+            cells.
+    """
+    from ..grid import tensor_product_grid  # noqa: PLC0415
+
+    _reject_periodic(global_space)
+    if not 0 <= rank < partition.n_parts:
+        raise ValueError(f"rank must be in [0, {partition.n_parts}); got {rank}.")
+    if partition.n_cells != global_space.num_total_intervals:
+        raise ValueError(
+            f"partition has {partition.n_cells} cells; "
+            f"expected {global_space.num_total_intervals} (space.num_total_intervals)."
+        )
+    owned = partition.owned_cells(rank)
+    if owned.size == 0:
+        raise ValueError(f"rank {rank} owns no cells; cannot build a local space.")
+
+    window = np.union1d(owned, compute_halo(global_space, owned))
+    restr = global_space.restrict(window)
+    grid_restr = tensor_product_grid(global_space).restrict(window)
+    local_to_global_cell = grid_restr.local_to_global_cell
+    local_to_global_dof = restr.local_to_global_dof
+    assert local_to_global_cell.shape[0] == restr.space.num_total_intervals
+
+    cell_owner = partition.cell_owner
+    owned_cell_mask = cell_owner[local_to_global_cell] == rank
+    owned_dof_mask = dof_owner(global_space, partition)[local_to_global_dof] == rank
+    owned_cell_mask.flags.writeable = False
+    owned_dof_mask.flags.writeable = False
+    return LocalSpace(
+        space=restr.space,
+        local_to_global_cell=local_to_global_cell,
+        local_to_global_dof=local_to_global_dof,
+        owned_cell_mask=owned_cell_mask,
+        owned_dof_mask=owned_dof_mask,
+        n_global_cells=global_space.num_total_intervals,
+        n_global_dofs=global_space.num_total_basis,
+    )
+
+
+__all__ = ["LocalSpace", "build_local", "compute_halo", "dof_owner"]

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -1,4 +1,4 @@
-"""Tests for pantr.bspline.compute_halo and dof_owner."""
+"""Tests for pantr.bspline.compute_halo, dof_owner, build_local, and LocalSpace."""
 
 from __future__ import annotations
 
@@ -309,6 +309,9 @@ def test_build_local_includes_halo_cells() -> None:
     loc = build_local(space, Partition(owner, n_parts=2), 0)
     assert int(loc.owned_cell_mask.sum()) == 2  # only cells 3, 4 owned
     assert loc.space.num_total_intervals > 2  # halo / bbox-fill cells present
+    np.testing.assert_array_equal(
+        sorted(loc.local_to_global_cell[loc.owned_cell_mask].tolist()), [3, 4]
+    )
 
 
 def test_build_local_periodic_rejected() -> None:
@@ -325,6 +328,8 @@ def test_build_local_bad_rank_raises() -> None:
     part = Partition(np.zeros(4, dtype=np.int32), n_parts=2)
     with pytest.raises(ValueError, match="rank"):
         build_local(space, part, 2)
+    with pytest.raises(ValueError, match="rank"):
+        build_local(space, part, -1)
 
 
 def test_build_local_cell_count_mismatch_raises() -> None:
@@ -339,3 +344,17 @@ def test_build_local_rank_owns_nothing_raises() -> None:
     part = Partition(np.zeros(4, dtype=np.int32), n_parts=2)  # rank 1 owns nothing
     with pytest.raises(ValueError, match="owns no cells"):
         build_local(space, part, 1)
+
+
+def test_build_local_with_inactive_cells() -> None:
+    # Cells 1 and 3 are inactive (-1); rank 0 owns cells 0 and 2.
+    # Dead DOFs (no active cell in support) must appear with owned_dof_mask == False.
+    space = _open_uniform_space([1], [4])  # degree 1, 4 cells, 5 DOFs
+    owner = np.array([0, -1, 0, -1], dtype=np.int32)
+    part = Partition(owner, n_parts=1)
+    loc = build_local(space, part, 0)
+    global_owners = dof_owner(space, part)
+    expected_owned = global_owners[loc.local_to_global_dof] == 0
+    np.testing.assert_array_equal(loc.owned_dof_mask, expected_owned)
+    dead_local = np.flatnonzero(global_owners[loc.local_to_global_dof] == -1)
+    assert not loc.owned_dof_mask[dead_local].any()

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -6,7 +6,14 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import BsplineSpace, BsplineSpace1D, compute_halo, dof_owner
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    LocalSpace,
+    build_local,
+    compute_halo,
+    dof_owner,
+)
 from pantr.grid import Partition
 
 
@@ -200,3 +207,135 @@ def test_dof_owner_2d_multirank() -> None:
     part = Partition(np.array([0, 0, 1, 1], dtype=np.int32), n_parts=2)
     # DOFs in rows 0-1 (i<2) have lex-first support cell in row 0 -> rank 0; row 2 -> rank 1
     np.testing.assert_array_equal(dof_owner(space, part), [0, 0, 0, 0, 0, 0, 1, 1, 1])
+
+
+# ------------------------------------------------------------------ build_local
+
+
+def _round_robin(space: BsplineSpace, n_parts: int) -> Partition:
+    """Round-robin partition of all knot-span cells over ``n_parts`` ranks."""
+    return Partition(
+        np.arange(space.num_total_intervals, dtype=np.int32) % n_parts, n_parts=n_parts
+    )
+
+
+def _cell_midpoints(space: BsplineSpace, cells: npt.NDArray[np.int64]) -> npt.NDArray[np.float64]:
+    """Midpoints of the given flat (C-order) knot-span cells of ``space``."""
+    per_axis_uk = [sp.get_unique_knots_and_multiplicity(in_domain=True)[0] for sp in space.spaces]
+    multi = np.unravel_index(cells, space.num_intervals)
+    pts = np.empty((len(cells), space.dim), dtype=np.float64)
+    for d in range(space.dim):
+        uk = per_axis_uk[d]
+        pts[:, d] = 0.5 * (uk[multi[d]] + uk[multi[d] + 1])
+    return pts
+
+
+def test_build_local_partitions_cells_and_dofs() -> None:
+    # Over all ranks, build_local's owned cells/DOFs must exactly partition the active
+    # cells / non-dead DOFs (complete and disjoint).
+    space = _open_uniform_space([2, 2], [5, 4])
+    part = _round_robin(space, 3)
+    global_owner = dof_owner(space, part)
+
+    owned_cells: list[int] = []
+    owned_dofs: list[int] = []
+    for rank in range(part.n_parts):
+        loc = build_local(space, part, rank)
+        assert isinstance(loc, LocalSpace)
+        oc = loc.local_to_global_cell[loc.owned_cell_mask]
+        od = loc.local_to_global_dof[loc.owned_dof_mask]
+        np.testing.assert_array_equal(part.cell_owner[oc], rank)
+        np.testing.assert_array_equal(global_owner[od], rank)
+        owned_cells.extend(int(c) for c in oc)
+        owned_dofs.extend(int(d) for d in od)
+
+    assert sorted(owned_cells) == list(range(space.num_total_intervals))
+    assert len(owned_cells) == len(set(owned_cells))
+    assert sorted(owned_dofs) == sorted(int(d) for d in np.flatnonzero(global_owner >= 0))
+    assert len(owned_dofs) == len(set(owned_dofs))
+
+
+def test_build_local_reproduces_global_basis_on_owned_cells() -> None:
+    space = _open_uniform_space([2, 2], [5, 5])
+    part = _round_robin(space, 4)
+    g_nb = space.num_basis
+    degs = space.degrees
+    for rank in range(part.n_parts):
+        loc = build_local(space, part, rank)
+        sub = loc.space
+        owned_local = np.flatnonzero(loc.owned_cell_mask)
+        pts = _cell_midpoints(sub, owned_local)
+        gb, gfb = space.tabulate_basis(pts)
+        wb, wfb = sub.tabulate_basis(pts)
+        np.testing.assert_allclose(wb, gb, atol=1e-12)  # windowed basis == global on owned cells
+        w_nb = sub.num_basis
+        l2g = loc.local_to_global_dof
+        for i in range(pts.shape[0]):
+            w_axis = [wfb[i, d] + np.arange(degs[d] + 1) for d in range(space.dim)]
+            g_axis = [gfb[i, d] + np.arange(degs[d] + 1) for d in range(space.dim)]
+            w_flat = np.ravel_multi_index(
+                [m.ravel() for m in np.meshgrid(*w_axis, indexing="ij")], w_nb
+            )
+            g_flat = np.ravel_multi_index(
+                [m.ravel() for m in np.meshgrid(*g_axis, indexing="ij")], g_nb
+            )
+            np.testing.assert_array_equal(l2g[w_flat], g_flat)  # DOF map lines up
+
+
+def test_build_local_shapes_and_readonly() -> None:
+    space = _open_uniform_space([2, 2], [4, 4])
+    loc = build_local(space, _round_robin(space, 2), 0)
+    n_cells = loc.space.num_total_intervals
+    n_dofs = loc.space.num_total_basis
+    assert loc.local_to_global_cell.shape == (n_cells,)
+    assert loc.owned_cell_mask.shape == (n_cells,)
+    assert loc.local_to_global_dof.shape == (n_dofs,)
+    assert loc.owned_dof_mask.shape == (n_dofs,)
+    assert loc.n_global_cells == space.num_total_intervals
+    assert loc.n_global_dofs == space.num_total_basis
+    for arr in (
+        loc.local_to_global_cell,
+        loc.local_to_global_dof,
+        loc.owned_cell_mask,
+        loc.owned_dof_mask,
+    ):
+        assert not arr.flags.writeable
+
+
+def test_build_local_includes_halo_cells() -> None:
+    space = _open_uniform_space([2], [8])
+    owner = np.ones(8, dtype=np.int32)
+    owner[[3, 4]] = 0  # rank 0 owns an interior sub-block
+    loc = build_local(space, Partition(owner, n_parts=2), 0)
+    assert int(loc.owned_cell_mask.sum()) == 2  # only cells 3, 4 owned
+    assert loc.space.num_total_intervals > 2  # halo / bbox-fill cells present
+
+
+def test_build_local_periodic_rejected() -> None:
+    from pantr.bspline import create_uniform_periodic_knots  # noqa: PLC0415
+
+    per = BsplineSpace1D(create_uniform_periodic_knots(num_intervals=4, degree=2), 2, periodic=True)
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=1)
+    with pytest.raises(ValueError, match="periodic"):
+        build_local(BsplineSpace([per]), part, 0)
+
+
+def test_build_local_bad_rank_raises() -> None:
+    space = _open_uniform_space([1], [4])
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=2)
+    with pytest.raises(ValueError, match="rank"):
+        build_local(space, part, 2)
+
+
+def test_build_local_cell_count_mismatch_raises() -> None:
+    space = _open_uniform_space([2], [5])
+    part = Partition(np.zeros(3, dtype=np.int32), n_parts=1)
+    with pytest.raises(ValueError, match="cells"):
+        build_local(space, part, 0)
+
+
+def test_build_local_rank_owns_nothing_raises() -> None:
+    space = _open_uniform_space([1], [4])
+    part = Partition(np.zeros(4, dtype=np.int32), n_parts=2)  # rank 1 owns nothing
+    with pytest.raises(ValueError, match="owns no cells"):
+        build_local(space, part, 1)


### PR DESCRIPTION
## Summary
PR **A5** of the MPI-distribution feature (#142) -- composes the prior windowing PRs (A1 `Grid.restrict`, A3 `BsplineSpace.restrict`, A4 `Partition`/`compute_halo`/`dof_owner`) into a rank's local view of a distributed tensor-product B-spline space.

- **`LocalSpace`** (NamedTuple) -- the windowed `BsplineSpace` + read-only `local_to_global_cell` / `local_to_global_dof` maps + `owned_cell_mask` / `owned_dof_mask` + `n_global_cells` / `n_global_dofs`. No immersion state (per the design; immersion is the consumer's overlay).
- **`build_local(global_space, partition, rank)`** -- windows the space to the bounding box of the rank's owned cells **plus their support-closure halo** (`compute_halo`), pulling the windowed space + DOF map from `BsplineSpace.restrict` and the cell map from `TensorProductGrid.restrict`, then marks owned cells/DOFs via `dof_owner`. Rejects periodic spaces, out-of-range ranks, partition/cell-count mismatch, and ranks that own no cells (a documented v0 limitation).

Both exported from `pantr.bspline`.

## Test plan
- [x] **Ranks-in-process partition check** -- across all ranks, `local_to_global_cell[owned_cell_mask]` exactly partitions the active cells and `local_to_global_dof[owned_dof_mask]` exactly partitions the non-dead DOFs (complete + disjoint).
- [x] **Local == global basis on owned cells** -- the windowed-space `tabulate_basis` matches the global one at owned-cell midpoints, with `local_to_global_dof` mapping the active DOFs correctly (end-to-end composition check).
- [x] Halo inclusion (interior owner has halo/fill cells, `owned_cell_mask` False there); shapes + read-only; 1D + 2D; errors (periodic, bad rank, cell-count mismatch, rank-owns-nothing).
- [x] `pytest --no-cov` -- 3191 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)