### PR TITLE
feat(bspline): windowed THBSplineSpace construction (A6)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -24,6 +24,8 @@ This package consolidates the B-spline API:
   downstream ``@njit`` code.
 - :class:`THBSplineSpace`: hierarchical B-spline space (truncated /
   non-truncated) on a :class:`pantr.grid.HierarchicalGrid`.
+- :class:`THBSplineSpaceRestriction`: result of :meth:`THBSplineSpace.restrict` --
+  a windowed THB sub-space plus its local-to-global DOF map.
 - :class:`MultiLevelExtraction`: per-element multi-level (Bézier) extraction
   operators for a :class:`THBSplineSpace`.
 - :class:`THBSpline`: an evaluable THB spline function (space + coefficients).
@@ -52,7 +54,7 @@ from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
 from ._local_space import LocalSpace, build_local, compute_halo, dof_owner
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
-from ._thb_spline_space import THBSplineSpace
+from ._thb_spline_space import THBSplineSpace, THBSplineSpaceRestriction
 from .multilevel_extraction import MultiLevelExtraction
 from .spanwise_element_extraction import (
     ExtractionStructView,
@@ -71,6 +73,7 @@ __all__ = [
     "SpanwiseElementExtraction",
     "THBSpline",
     "THBSplineSpace",
+    "THBSplineSpaceRestriction",
     "build_local",
     "compute_halo",
     "create_cardinal_knots",

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -815,6 +815,87 @@ class THBSplineSpace:
         """
         return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
 
+    def restrict(self, cell_ids: npt.ArrayLike) -> THBSplineSpaceRestriction:
+        """Return the windowed sub-space over a subset of active cells.
+
+        Windows this space to the root-cell-aligned bounding box of ``cell_ids``: the
+        hierarchical grid is restricted (:meth:`pantr.grid.HierarchicalGrid.restrict`),
+        the root space is windowed (:meth:`pantr.bspline.BsplineSpace.restrict`), and a
+        new :class:`THBSplineSpace` is rebuilt on the sub-grid (re-running the Kraft
+        active-function selection and truncation).
+
+        Unlike the tensor-product :meth:`pantr.bspline.BsplineSpace.restrict`, the
+        windowed THB basis equals the global one only over the **interior** cells --
+        those whose entire (cross-level) function-support-closure lies inside the
+        window -- because Kraft selection and truncation depend on the subdomain near
+        the window boundary. Callers make the cells they care about interior by padding
+        ``cell_ids`` with a support-closure halo.
+
+        Args:
+            cell_ids (npt.ArrayLike): Active cell flat ids to span; duplicates ignored.
+
+        Returns:
+            THBSplineSpaceRestriction: The windowed :class:`THBSplineSpace` and a
+            read-only ``local_to_global_dof`` map; entry ``d`` is the global
+            hierarchical dof of local dof ``d`` when the local function matches a
+            globally-active function of the same level and multi-index, else ``-1``.
+
+        Raises:
+            ValueError: If ``cell_ids`` is empty.
+            TypeError: If ``cell_ids`` is not integer-valued.
+            IndexError: If any cell id is out of range ``[0, grid.num_cells)``.
+        """
+        grid_restr = self._grid.restrict(cell_ids)
+        sub_grid = grid_restr.grid
+        assert isinstance(sub_grid, HierarchicalGrid)
+        dim = self.dim
+        factor = self._grid.factor
+
+        # Root-cell bounding box of the window (the sub-grid's root spans it exactly).
+        r_lo = [
+            int(np.searchsorted(self._grid.root.breakpoints[k], sub_grid.root.breakpoints[k][0]))
+            for k in range(dim)
+        ]
+        r_hi = [r_lo[k] + sub_grid.root.cells_per_axis[k] for k in range(dim)]
+
+        # Window the root space to that box (A3) and rebuild the THB space on the sub-grid.
+        root_ni = self._root_space.num_intervals
+        box = [np.arange(r_lo[k], r_hi[k]) for k in range(dim)]
+        root_cells = np.ravel_multi_index(
+            tuple(m.ravel() for m in np.meshgrid(*box, indexing="ij")), root_ni
+        )
+        windowed_root = self._root_space.restrict(root_cells).space
+        sub_space = THBSplineSpace(
+            windowed_root, sub_grid, truncate=self._truncate, regularity=self._regularity
+        )
+
+        # Map each sub active function (level, sub_multi) to the global dof of the same
+        # (level, sub_multi + per-level window origin), or -1 if not globally active.
+        local_to_global_dof = np.full(sub_space.num_total_basis, -1, dtype=np.int64)
+        sub_offset = 0
+        for level in range(sub_space.num_levels):
+            origin = [
+                int(self._support[level][k][0][r_lo[k] * factor[k] ** level]) for k in range(dim)
+            ]
+            glob_num_basis = self._level_spaces[level].num_basis
+            glob_active = self._active_funcs[level]
+            glob_offset = int(self._func_offset[level])
+            sub_active = sub_space.active_function_indices(level)
+            sub_num_basis = sub_space.level_space(level).num_basis
+            for sub_pos, sub_flat in enumerate(sub_active.tolist()):
+                sub_multi = np.unravel_index(sub_flat, sub_num_basis)
+                glob_flat = int(
+                    np.ravel_multi_index(
+                        tuple(int(sub_multi[k]) + origin[k] for k in range(dim)), glob_num_basis
+                    )
+                )
+                gpos = int(np.searchsorted(glob_active, glob_flat))
+                if gpos < glob_active.shape[0] and int(glob_active[gpos]) == glob_flat:
+                    local_to_global_dof[sub_offset + sub_pos] = glob_offset + gpos
+            sub_offset += int(sub_active.shape[0])
+        local_to_global_dof.flags.writeable = False
+        return THBSplineSpaceRestriction(sub_space, local_to_global_dof)
+
     def _basis_1d_cached(
         self,
         level: int,
@@ -1567,3 +1648,19 @@ class THBSplineSpace:
             f"num_levels={self.num_levels}, num_total_basis={self._num_active}, "
             f"truncate={self._truncate})"
         )
+
+
+class THBSplineSpaceRestriction(NamedTuple):
+    """Result of :meth:`THBSplineSpace.restrict`: a windowed THB space and its DOF map.
+
+    - ``space`` -- the windowed :class:`THBSplineSpace` rebuilt on the restricted grid;
+      its basis equals the global basis pointwise over interior cells (those whose
+      function-support-closure lies inside the window).
+    - ``local_to_global_dof`` -- read-only ``(space.num_total_basis,)`` map; entry ``d``
+      is the global hierarchical dof of local dof ``d`` when the local function matches a
+      globally-active function of the same level and multi-index, else ``-1`` (a boundary
+      function with no global counterpart). Values are exact over interior cells.
+    """
+
+    space: THBSplineSpace
+    local_to_global_dof: npt.NDArray[np.int64]

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -839,15 +839,22 @@ class THBSplineSpace:
             read-only ``local_to_global_dof`` map; entry ``d`` is the global
             hierarchical dof of local dof ``d`` when the local function matches a
             globally-active function of the same level and multi-index, else ``-1``.
+            Values are exact over interior cells; functions near the window boundary
+            may map to ``-1``.
 
         Raises:
             ValueError: If ``cell_ids`` is empty.
             TypeError: If ``cell_ids`` is not integer-valued.
             IndexError: If any cell id is out of range ``[0, grid.num_cells)``.
         """
+        self._check_not_stale()
         grid_restr = self._grid.restrict(cell_ids)
         sub_grid = grid_restr.grid
-        assert isinstance(sub_grid, HierarchicalGrid)
+        if not isinstance(sub_grid, HierarchicalGrid):
+            raise RuntimeError(
+                f"restrict: expected HierarchicalGrid from grid.restrict; "
+                f"got {type(sub_grid).__name__!r}. This is a bug in HierarchicalGrid.restrict."
+            )
         dim = self.dim
         factor = self._grid.factor
 
@@ -858,7 +865,7 @@ class THBSplineSpace:
         ]
         r_hi = [r_lo[k] + sub_grid.root.cells_per_axis[k] for k in range(dim)]
 
-        # Window the root space to that box (A3) and rebuild the THB space on the sub-grid.
+        # Window the root space to that box and rebuild the THB space on the sub-grid.
         root_ni = self._root_space.num_intervals
         box = [np.arange(r_lo[k], r_hi[k]) for k in range(dim)]
         root_cells = np.ravel_multi_index(
@@ -893,6 +900,7 @@ class THBSplineSpace:
                 if gpos < glob_active.shape[0] and int(glob_active[gpos]) == glob_flat:
                     local_to_global_dof[sub_offset + sub_pos] = glob_offset + gpos
             sub_offset += int(sub_active.shape[0])
+        assert sub_offset == sub_space.num_total_basis
         local_to_global_dof.flags.writeable = False
         return THBSplineSpaceRestriction(sub_space, local_to_global_dof)
 
@@ -1658,8 +1666,10 @@ class THBSplineSpaceRestriction(NamedTuple):
       function-support-closure lies inside the window).
     - ``local_to_global_dof`` -- read-only ``(space.num_total_basis,)`` map; entry ``d``
       is the global hierarchical dof of local dof ``d`` when the local function matches a
-      globally-active function of the same level and multi-index, else ``-1`` (a boundary
-      function with no global counterpart). Values are exact over interior cells.
+      globally-active function of the same level and multi-index, else ``-1`` (local
+      function active in the sub-space but absent from the global active set -- arises
+      near the window boundary where Kraft selection may differ). Values are exact over
+      interior cells.
     """
 
     space: THBSplineSpace

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -8,7 +8,13 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
-from pantr.bspline import BsplineSpace, BsplineSpace1D, THBSplineSpace
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    MultiLevelExtraction,
+    THBSplineSpace,
+    THBSplineSpaceRestriction,
+)
 from pantr.bspline._thb_eval_core import _combine_tp_values
 from pantr.bspline._thb_spline_space import _box_all_true, _func_support_1d
 from pantr.grid import HierarchicalGrid, hierarchical_grid, uniform_grid
@@ -1366,3 +1372,121 @@ class TestContribCache:
         r1 = thb._cell_contributions(c1)
         assert thb._cell_contributions(c0) is r0
         assert thb._cell_contributions(c1) is r1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# restrict (windowed THB sub-space)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _refined_thb_2d(
+    n: int = 4, lo: tuple[int, int] = (1, 1), hi: tuple[int, int] = (3, 3), *, truncate: bool = True
+) -> THBSplineSpace:
+    """Degree-2 ``n x n`` THB space on [0, n]^2, refining ``[lo, hi)`` to level 1."""
+    knots = [0.0] * 3 + [float(i) for i in range(1, n)] + [float(n)] * 3
+    sp = BsplineSpace1D(knots, 2)
+    grid = hierarchical_grid(uniform_grid([[0.0, float(n)], [0.0, float(n)]], n), 2)
+    grid.refine(0, list(lo), list(hi))
+    return THBSplineSpace(BsplineSpace([sp, sp]), grid, truncate=truncate)
+
+
+def _cells_in_root_box(g: THBSplineSpace, lo: tuple[int, ...], hi: tuple[int, ...]) -> list[int]:
+    """Active cell ids whose root cell lies in the box ``[lo, hi)``."""
+    factor = g.grid.factor
+    out = []
+    for cid in range(g.grid.num_cells):
+        lv = g.grid.cell_level(cid)
+        m = g.grid.cell_multi_index(cid)
+        rc = [m[k] // factor[k] ** lv for k in range(g.dim)]
+        if all(lo[k] <= rc[k] < hi[k] for k in range(g.dim)):
+            out.append(cid)
+    return out
+
+
+def _check_restrict_interior(
+    g: THBSplineSpace, cell_ids: list[int]
+) -> tuple[int, THBSplineSpaceRestriction]:
+    """Assert windowed THB basis and extraction match the global ones on interior cells.
+
+    An interior cell is one whose active functions all map to a global dof.
+    """
+    r = g.restrict(cell_ids)
+    sub, l2g_dof = r.space, r.local_to_global_dof
+    assert isinstance(r, THBSplineSpaceRestriction)
+    assert isinstance(sub, THBSplineSpace)
+    assert not l2g_dof.flags.writeable
+    l2g_cell = g.grid.restrict(cell_ids).local_to_global_cell
+    ext_g, ext_s = MultiLevelExtraction(g), MultiLevelExtraction(sub)
+    n_interior = 0
+    for lcid in range(sub.grid.num_cells):
+        mapped = l2g_dof[sub.active_basis(lcid)]
+        if np.any(mapped < 0):
+            continue  # boundary cell: a touching function has no global counterpart
+        gcid = int(l2g_cell[lcid])
+        lo, hi = sub.grid.cell_bounds(lcid)
+        pt = (0.5 * (lo + hi)).reshape(1, -1)
+        vs, _ = sub.tabulate_basis(lcid, pt)
+        vg, dg = g.tabulate_basis(gcid, pt)
+        gval = {int(d): float(v) for d, v in zip(dg, vg[0], strict=True)}
+        assert {int(x) for x in mapped} == {int(d) for d in dg}
+        op_s, op_g = ext_s.operator(lcid), ext_g.operator(gcid)
+        grow = {int(d): op_g[j] for j, d in enumerate(g.active_basis(gcid))}
+        for i, gd in enumerate(mapped):
+            np.testing.assert_allclose(vs[0, i], gval[int(gd)], atol=1e-11)  # basis value
+            np.testing.assert_allclose(op_s[i], grow[int(gd)], atol=1e-10)  # extraction row
+        n_interior += 1
+    return n_interior, r
+
+
+def test_restrict_full_grid_2d() -> None:
+    g = _refined_thb_2d()
+    n_interior, r = _check_restrict_interior(g, list(range(g.grid.num_cells)))
+    assert n_interior == g.grid.num_cells  # full restrict: every cell is interior
+    np.testing.assert_array_equal(r.local_to_global_dof, np.arange(g.num_total_basis))
+
+
+def test_restrict_full_grid_1d() -> None:
+    knots = [0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0, 4.0]  # degree 2, 4 intervals
+    grid = hierarchical_grid(uniform_grid([[0.0, 4.0]], 4), 2)
+    grid.refine(0, [1], [3])
+    g = THBSplineSpace(BsplineSpace([BsplineSpace1D(knots, 2)]), grid)
+    n_interior, _ = _check_restrict_interior(g, list(range(g.grid.num_cells)))
+    assert n_interior == g.grid.num_cells
+
+
+def test_restrict_hb_full_grid() -> None:
+    g = _refined_thb_2d(truncate=False)
+    n_interior, r = _check_restrict_interior(g, list(range(g.grid.num_cells)))
+    assert n_interior == g.grid.num_cells
+    assert r.space.truncate is False
+
+
+def test_restrict_subset_has_interior_2d() -> None:
+    g = _refined_thb_2d(n=8, lo=(3, 3), hi=(5, 5))
+    cell_ids = _cells_in_root_box(g, (1, 1), (7, 7))
+    n_interior, _ = _check_restrict_interior(g, cell_ids)
+    assert n_interior > 0
+
+
+def test_restrict_dof_map_injective() -> None:
+    g = _refined_thb_2d(n=6, lo=(2, 2), hi=(4, 4))
+    l2g = g.restrict(_cells_in_root_box(g, (1, 1), (5, 5))).local_to_global_dof
+    valid = l2g[l2g >= 0]
+    assert np.all(valid < g.num_total_basis)
+    assert len(set(valid.tolist())) == valid.size  # injective on the mapped dofs
+
+
+def test_restrict_returns_namedtuple() -> None:
+    g = _refined_thb_2d()
+    r = g.restrict([0, 1, 2, 3])
+    assert isinstance(r, THBSplineSpaceRestriction)
+    assert isinstance(r.space, THBSplineSpace)
+    assert not r.local_to_global_dof.flags.writeable
+
+
+def test_restrict_errors() -> None:
+    g = _refined_thb_2d()
+    with pytest.raises(ValueError, match="non-empty"):
+        g.restrict([])
+    with pytest.raises(IndexError):
+        g.restrict([g.grid.num_cells])

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1490,3 +1490,5 @@ def test_restrict_errors() -> None:
         g.restrict([])
     with pytest.raises(IndexError):
         g.restrict([g.grid.num_cells])
+    with pytest.raises(TypeError):
+        g.restrict([0.5, 1.5])


### PR DESCRIPTION
## Summary
PR **A6** of the MPI-distribution feature (#142) -- the hierarchical analog of A3's `BsplineSpace.restrict`.

- **`THBSplineSpace.restrict(cell_ids) -> THBSplineSpaceRestriction(space, local_to_global_dof)`**: windows to the root-cell-aligned bounding box of `cell_ids` by restricting the `HierarchicalGrid` (A2), windowing the root space (A3), and **rebuilding** a `THBSplineSpace` on the sub-grid (re-running Kraft active-function selection + truncation).
- **`local_to_global_dof`** maps each sub active function `(level, sub_multi)` to the global hierarchical dof of the same `(level, sub_multi + per-level origin)`, or `-1` for a boundary function with no global counterpart.

**Key difference from the tensor-product case:** the windowed THB basis equals the global basis only over **interior** cells (those whose cross-level function-support-closure lies inside the window), because Kraft selection and truncation depend on the subdomain near the window boundary. Callers (A7 `build_local`) make owned cells interior via a support-closure halo. `local_to_global_dof` is value-exact over the interior; ghost functions that are genuine global functions still carry their global id (for cross-rank coupling), while spurious sub-only boundary functions get `-1`.

## Test plan
- [x] ⚠️ **Correctness on interior cells** -- for every interior cell, both `tabulate_basis` **and** `MultiLevelExtraction.operator` of the windowed space match the global space (matched via `local_to_global_dof`). Covered for full-grid restrict (1D + 2D), a proper sub-window (asserts interior cells exist), and the non-truncated HB basis.
- [x] Full-grid restrict is the identity DOF map (`arange`); DOF map is injective on mapped dofs and in range; returns the NamedTuple with a read-only map; empty / out-of-range errors.
- [x] `pytest --no-cov` -- 3199 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)