### PR TITLE
feat(bspline): build_local for THBSplineSpace (A7)

### DIFF
--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -1,21 +1,28 @@
-"""Serial windowing helpers for distributing a tensor-product B-spline space.
+"""Serial windowing helpers for distributing a B-spline or THB-spline space.
 
 These functions compute, without any MPI, the pieces a distributed local space is
 built from:
 
-- :func:`compute_halo`: the function-support closure of a set of owned cells -- the
-  extra cells a rank must see so the B-spline functions touching its owned cells are
-  fully represented.
+- :func:`compute_halo`: the function-support closure of a set of owned cells for a
+  tensor-product B-spline space.
 - :func:`dof_owner`: the owner rank of every global DOF, by the
-  lex-first-active-cell-in-support rule.
+  lex-first-active-cell-in-support rule (tensor-product path).
 - :func:`build_local`: compose the above into a rank-local :class:`LocalSpace` --
-  the complete windowed view a distributed solver needs.
+  the complete windowed view a distributed solver needs. Dispatches on space type:
+  tensor-product path for :class:`~pantr.bspline.BsplineSpace`, hierarchical path
+  (via :func:`_thb_halo` / :func:`_thb_dof_owner`) for
+  :class:`~pantr.bspline.THBSplineSpace`.
 - :class:`LocalSpace`: NamedTuple returned by :func:`build_local`.
 
-All functions operate on the knot-span grid of a :class:`~pantr.bspline.BsplineSpace`:
-cells are flat-indexed in C-order over ``num_intervals`` and DOFs in C-order over
-``num_basis``, matching :func:`pantr.grid.tensor_product_grid` and
+The tensor-product path operates on the knot-span grid of a
+:class:`~pantr.bspline.BsplineSpace`: cells are flat-indexed in C-order over
+``num_intervals`` and DOFs in C-order over ``num_basis``, matching
+:func:`pantr.grid.tensor_product_grid` and
 :class:`~pantr.bspline.SpanwiseElementExtraction`.
+
+The hierarchical path operates on the flat cell ids of
+:attr:`THBSplineSpace.grid <pantr.bspline.THBSplineSpace.grid>` and the global
+hierarchical DOF ids of the space.
 """
 
 from __future__ import annotations
@@ -221,9 +228,9 @@ def build_local(
         masks.
 
     Raises:
-        ValueError: If ``global_space`` is periodic, ``rank`` is out of range,
-            ``partition`` does not match the space's cell count, or ``rank`` owns no
-            cells.
+        ValueError: If ``global_space`` is a periodic :class:`~pantr.bspline.BsplineSpace`
+            (THB spaces have no periodicity); or if ``rank`` is out of range,
+            ``partition`` does not match the space's cell count, or ``rank`` owns no cells.
     """
     if isinstance(global_space, THBSplineSpace):
         return _build_local_thb(global_space, partition, rank)
@@ -280,10 +287,17 @@ def _thb_halo(thb: THBSplineSpace, owned_cells: npt.NDArray[np.int64]) -> npt.ND
 
     Args:
         thb (THBSplineSpace): The global hierarchical space.
-        owned_cells (npt.NDArray[np.int64]): Active cell ids owned by the rank.
+        owned_cells (npt.NDArray[np.int64]): Flat cell ids in ``[0, thb.grid.num_cells)``
+            owned by the rank.
 
     Returns:
-        npt.NDArray[np.int64]: Sorted, read-only halo cell ids (closure minus owned).
+        npt.NDArray[np.int64]: Sorted, read-only halo cell ids -- all cells that share an
+        active hierarchical function with any owned cell, excluding the owned cells
+        themselves. Empty if ``owned_cells`` is empty.
+
+    Raises:
+        IndexError: If any cell id in ``owned_cells`` is out of range
+            ``[0, thb.grid.num_cells)``.
     """
     owned = {int(c) for c in owned_cells}
     owned_funcs: set[int] = set()
@@ -311,10 +325,12 @@ def _thb_dof_owner(thb: THBSplineSpace, partition: Partition) -> npt.NDArray[np.
             ``thb.grid.num_cells``.
 
     Returns:
-        npt.NDArray[np.int32]: Read-only ``(num_total_basis,)`` owner rank per dof.
+        npt.NDArray[np.int32]: Read-only ``(thb.num_total_basis,)`` owner rank per dof;
+        ``-1`` for dead dofs.
 
     Raises:
-        ValueError: If ``partition`` does not match the grid's cell count.
+        ValueError: If ``partition.cell_owner`` length does not match
+            ``thb.grid.num_cells``.
     """
     cell_owner = partition.cell_owner
     if cell_owner.shape[0] != thb.grid.num_cells:
@@ -335,7 +351,32 @@ def _thb_dof_owner(thb: THBSplineSpace, partition: Partition) -> npt.NDArray[np.
 
 
 def _build_local_thb(thb: THBSplineSpace, partition: Partition, rank: int) -> LocalSpace:
-    """Build the rank-local windowed space of a distributed THB space (see build_local)."""
+    """Build the rank-local windowed space of a distributed THB space.
+
+    Validates inputs, computes the cross-level support-closure halo via
+    :func:`_thb_halo`, restricts both the THB space and its DOF/cell maps via
+    :meth:`THBSplineSpace.restrict`, and marks owned cells and DOFs via
+    :func:`_thb_dof_owner`.  Called by :func:`build_local` when ``global_space`` is a
+    :class:`THBSplineSpace`.
+
+    Args:
+        thb (THBSplineSpace): The global hierarchical space (non-periodic).
+        partition (Partition): Owner of every cell of ``thb.grid``; ``cell_owner`` must
+            have length ``thb.grid.num_cells``.
+        rank (int): The rank whose local space is built; must be in
+            ``[0, partition.n_parts)``.
+
+    Returns:
+        LocalSpace: The windowed THB space plus local-to-global cell/DOF maps and
+        ownership masks.
+
+    Raises:
+        ValueError: If ``rank`` is out of range ``[0, partition.n_parts)``,
+            ``partition.n_cells`` does not equal ``thb.grid.num_cells``, or ``rank``
+            owns no cells.
+        RuntimeError: If :meth:`THBSplineSpace.restrict` returns an inconsistent cell
+            count (indicates a bug in ``restrict``).
+    """
     if not 0 <= rank < partition.n_parts:
         raise ValueError(f"rank must be in [0, {partition.n_parts}); got {rank}.")
     if partition.n_cells != thb.grid.num_cells:
@@ -349,22 +390,33 @@ def _build_local_thb(thb: THBSplineSpace, partition: Partition, rank: int) -> Lo
 
     window = np.union1d(owned, _thb_halo(thb, owned))
     restr = thb.restrict(window)
-    grid_restr = thb.grid.restrict(window)
-    local_to_global_cell = grid_restr.local_to_global_cell
+    local_to_global_cell = restr.local_to_global_cell
     local_to_global_dof = restr.local_to_global_dof
     if local_to_global_cell.shape[0] != restr.space.grid.num_cells:
         raise RuntimeError(
-            f"Grid restriction ({local_to_global_cell.shape[0]} cells) and THB restriction "
-            f"({restr.space.grid.num_cells} cells) disagree after restricting to the same "
-            f"window of {window.size} cells. This is a bug in restrict()."
+            f"THBSplineSpace.restrict returned {local_to_global_cell.shape[0]} cells in "
+            f"local_to_global_cell but {restr.space.grid.num_cells} cells in space.grid "
+            f"for a window of {window.size} cells. This is a bug in restrict()."
+        )
+    if local_to_global_cell.size and int(local_to_global_cell.min()) < 0:
+        raise RuntimeError(
+            "THBSplineSpace.restrict returned a negative value in local_to_global_cell. "
+            "This is a bug in restrict()."
+        )
+    valid = local_to_global_dof >= 0
+    valid_dofs = local_to_global_dof[valid]
+    if valid_dofs.size and int(valid_dofs.max()) >= thb.num_total_basis:
+        raise RuntimeError(
+            f"THBSplineSpace.restrict returned a local_to_global_dof value "
+            f"{int(valid_dofs.max())} >= num_total_basis {thb.num_total_basis}. "
+            "This is a bug in restrict()."
         )
 
     cell_owner = partition.cell_owner
     owned_cell_mask = cell_owner[local_to_global_cell] == rank
     global_dof_owner = _thb_dof_owner(thb, partition)
     owned_dof_mask = np.zeros(local_to_global_dof.shape[0], dtype=np.bool_)
-    valid = local_to_global_dof >= 0
-    owned_dof_mask[valid] = global_dof_owner[local_to_global_dof[valid]] == rank
+    owned_dof_mask[valid] = global_dof_owner[valid_dofs] == rank
     owned_cell_mask.flags.writeable = False
     owned_dof_mask.flags.writeable = False
     return LocalSpace(

--- a/src/pantr/bspline/_local_space.py
+++ b/src/pantr/bspline/_local_space.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
-from ._thb_spline_space import _func_support_1d
+from ._thb_spline_space import THBSplineSpace, _func_support_1d
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -166,28 +166,29 @@ def dof_owner(space: BsplineSpace, partition: Partition) -> npt.NDArray[np.int32
 
 
 class LocalSpace(NamedTuple):
-    """The rank-local windowed view of a distributed tensor-product B-spline space.
+    """The rank-local windowed view of a distributed B-spline or THB space.
 
     Produced by :func:`build_local`. A :class:`typing.NamedTuple` bundling a windowed
-    :class:`~pantr.bspline.BsplineSpace` with the maps and masks relating it to the
-    global space:
+    :class:`~pantr.bspline.BsplineSpace` or :class:`~pantr.bspline.THBSplineSpace` with
+    the maps and masks relating it to the global space:
 
-    - ``space`` -- the windowed B-spline space over the bounding box of the rank's
-      owned cells and their support-closure halo; a real pantr object whose basis
-      equals the global basis pointwise over those cells.
-    - ``local_to_global_cell`` -- read-only ``(space.num_total_intervals,)`` map from
-      each local knot-span cell to its global cell id.
+    - ``space`` -- the windowed space over the bounding box of the rank's owned cells
+      and their support-closure halo; a real pantr object whose basis equals the global
+      basis pointwise over the rank's owned cells.
+    - ``local_to_global_cell`` -- read-only map (one entry per local cell) from each
+      local cell to its global cell id.
     - ``local_to_global_dof`` -- read-only ``(space.num_total_basis,)`` map from each
-      local DOF to its global DOF id.
-    - ``owned_cell_mask`` -- read-only boolean ``(space.num_total_intervals,)`` mask;
+      local DOF to its global DOF id (``-1`` for a THB boundary DOF with no global
+      counterpart).
+    - ``owned_cell_mask`` -- read-only boolean mask (one entry per local cell);
       ``True`` for the cells this rank owns (the rest are halo / bounding-box fill).
     - ``owned_dof_mask`` -- read-only boolean ``(space.num_total_basis,)`` mask;
       ``True`` for the DOFs this rank owns.
-    - ``n_global_cells`` -- total knot-span cells in the global space.
+    - ``n_global_cells`` -- total cells in the global space's grid.
     - ``n_global_dofs`` -- total basis functions in the global space.
     """
 
-    space: BsplineSpace
+    space: BsplineSpace | THBSplineSpace
     local_to_global_cell: npt.NDArray[np.int64]
     local_to_global_dof: npt.NDArray[np.int64]
     owned_cell_mask: npt.NDArray[np.bool_]
@@ -196,21 +197,22 @@ class LocalSpace(NamedTuple):
     n_global_dofs: int
 
 
-def build_local(global_space: BsplineSpace, partition: Partition, rank: int) -> LocalSpace:
-    """Build the rank-local windowed space of a distributed tensor-product B-spline space.
+def build_local(
+    global_space: BsplineSpace | THBSplineSpace, partition: Partition, rank: int
+) -> LocalSpace:
+    """Build the rank-local windowed space of a distributed B-spline or THB space.
 
-    Windows ``global_space`` to the bounding box of the cells owned by ``rank`` together
-    with their support-closure halo (:func:`compute_halo`), so the local basis equals the
-    global basis pointwise over those cells. Composes the grid restriction
-    (:meth:`pantr.grid.TensorProductGrid.restrict`) for the cell map and the space
-    restriction (:meth:`pantr.bspline.BsplineSpace.restrict`) for the windowed space and
-    DOF map, and marks owned cells/DOFs via :func:`dof_owner`.
+    Windows ``global_space`` to the cells owned by ``rank`` together with their
+    support-closure halo, so the local basis equals the global basis pointwise over the
+    rank's owned cells. Dispatches on the space type: a
+    :class:`~pantr.bspline.BsplineSpace` uses the tensor-product path
+    (:func:`compute_halo` / :func:`dof_owner`); a :class:`~pantr.bspline.THBSplineSpace`
+    uses the hierarchical path (cross-level support closure and ownership).
 
     Args:
-        global_space (BsplineSpace): The global tensor-product B-spline space
-            (non-periodic).
-        partition (Partition): Owner of every knot-span cell; ``cell_owner`` must have
-            length ``global_space.num_total_intervals``.
+        global_space (BsplineSpace | THBSplineSpace): The global space (non-periodic).
+        partition (Partition): Owner of every cell of the space's grid; ``cell_owner``
+            length must equal the global cell count.
         rank (int): The rank whose local space is built; must be in
             ``[0, partition.n_parts)``.
 
@@ -223,6 +225,9 @@ def build_local(global_space: BsplineSpace, partition: Partition, rank: int) -> 
             ``partition`` does not match the space's cell count, or ``rank`` owns no
             cells.
     """
+    if isinstance(global_space, THBSplineSpace):
+        return _build_local_thb(global_space, partition, rank)
+
     from ..grid import tensor_product_grid  # noqa: PLC0415
 
     _reject_periodic(global_space)
@@ -262,6 +267,114 @@ def build_local(global_space: BsplineSpace, partition: Partition, rank: int) -> 
         owned_dof_mask=owned_dof_mask,
         n_global_cells=global_space.num_total_intervals,
         n_global_dofs=global_space.num_total_basis,
+    )
+
+
+def _thb_halo(thb: THBSplineSpace, owned_cells: npt.NDArray[np.int64]) -> npt.NDArray[np.int64]:
+    """Return the cross-level support-closure halo of ``owned_cells`` for a THB space.
+
+    A cell is in the halo iff it shares an active hierarchical function with an owned
+    cell, so every function touching an owned cell has its full support inside the owned
+    cells plus this halo (making the owned cells interior for
+    :meth:`THBSplineSpace.restrict`).
+
+    Args:
+        thb (THBSplineSpace): The global hierarchical space.
+        owned_cells (npt.NDArray[np.int64]): Active cell ids owned by the rank.
+
+    Returns:
+        npt.NDArray[np.int64]: Sorted, read-only halo cell ids (closure minus owned).
+    """
+    owned = {int(c) for c in owned_cells}
+    owned_funcs: set[int] = set()
+    for c in owned:
+        owned_funcs.update(int(d) for d in thb.active_basis(c))
+    closure = [
+        c
+        for c in range(thb.grid.num_cells)
+        if any(int(d) in owned_funcs for d in thb.active_basis(c))
+    ]
+    halo = np.array(sorted(set(closure) - owned), dtype=np.int64)
+    halo.flags.writeable = False
+    return halo
+
+
+def _thb_dof_owner(thb: THBSplineSpace, partition: Partition) -> npt.NDArray[np.int32]:
+    """Return the owner rank of every global THB dof (lex-first-active-cell rule).
+
+    Each hierarchical dof is owned by the rank owning the active cell with the smallest
+    flat id in the dof's support; ``-1`` for a dead dof whose support has no active cell.
+
+    Args:
+        thb (THBSplineSpace): The global hierarchical space.
+        partition (Partition): Owner of every cell; ``cell_owner`` must have length
+            ``thb.grid.num_cells``.
+
+    Returns:
+        npt.NDArray[np.int32]: Read-only ``(num_total_basis,)`` owner rank per dof.
+
+    Raises:
+        ValueError: If ``partition`` does not match the grid's cell count.
+    """
+    cell_owner = partition.cell_owner
+    if cell_owner.shape[0] != thb.grid.num_cells:
+        raise ValueError(
+            f"partition has {cell_owner.shape[0]} cells; expected {thb.grid.num_cells} "
+            f"(grid.num_cells)."
+        )
+    owners = np.full(thb.num_total_basis, -1, dtype=np.int32)
+    for c in range(thb.grid.num_cells):  # ascending: the first active cell wins (lex-first)
+        rank_c = int(cell_owner[c])
+        if rank_c < 0:
+            continue
+        for dof in thb.active_basis(c):
+            if owners[int(dof)] < 0:
+                owners[int(dof)] = rank_c
+    owners.flags.writeable = False
+    return owners
+
+
+def _build_local_thb(thb: THBSplineSpace, partition: Partition, rank: int) -> LocalSpace:
+    """Build the rank-local windowed space of a distributed THB space (see build_local)."""
+    if not 0 <= rank < partition.n_parts:
+        raise ValueError(f"rank must be in [0, {partition.n_parts}); got {rank}.")
+    if partition.n_cells != thb.grid.num_cells:
+        raise ValueError(
+            f"partition has {partition.n_cells} cells; expected {thb.grid.num_cells} "
+            f"(grid.num_cells)."
+        )
+    owned = partition.owned_cells(rank)
+    if owned.size == 0:
+        raise ValueError(f"rank {rank} owns no cells; cannot build a local space.")
+
+    window = np.union1d(owned, _thb_halo(thb, owned))
+    restr = thb.restrict(window)
+    grid_restr = thb.grid.restrict(window)
+    local_to_global_cell = grid_restr.local_to_global_cell
+    local_to_global_dof = restr.local_to_global_dof
+    if local_to_global_cell.shape[0] != restr.space.grid.num_cells:
+        raise RuntimeError(
+            f"Grid restriction ({local_to_global_cell.shape[0]} cells) and THB restriction "
+            f"({restr.space.grid.num_cells} cells) disagree after restricting to the same "
+            f"window of {window.size} cells. This is a bug in restrict()."
+        )
+
+    cell_owner = partition.cell_owner
+    owned_cell_mask = cell_owner[local_to_global_cell] == rank
+    global_dof_owner = _thb_dof_owner(thb, partition)
+    owned_dof_mask = np.zeros(local_to_global_dof.shape[0], dtype=np.bool_)
+    valid = local_to_global_dof >= 0
+    owned_dof_mask[valid] = global_dof_owner[local_to_global_dof[valid]] == rank
+    owned_cell_mask.flags.writeable = False
+    owned_dof_mask.flags.writeable = False
+    return LocalSpace(
+        space=restr.space,
+        local_to_global_cell=local_to_global_cell,
+        local_to_global_dof=local_to_global_dof,
+        owned_cell_mask=owned_cell_mask,
+        owned_dof_mask=owned_dof_mask,
+        n_global_cells=thb.grid.num_cells,
+        n_global_dofs=thb.num_total_basis,
     )
 
 

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -902,7 +902,9 @@ class THBSplineSpace:
             sub_offset += int(sub_active.shape[0])
         assert sub_offset == sub_space.num_total_basis
         local_to_global_dof.flags.writeable = False
-        return THBSplineSpaceRestriction(sub_space, local_to_global_dof)
+        return THBSplineSpaceRestriction(
+            sub_space, local_to_global_dof, grid_restr.local_to_global_cell
+        )
 
     def _basis_1d_cached(
         self,
@@ -1659,7 +1661,7 @@ class THBSplineSpace:
 
 
 class THBSplineSpaceRestriction(NamedTuple):
-    """Result of :meth:`THBSplineSpace.restrict`: a windowed THB space and its DOF map.
+    """Result of :meth:`THBSplineSpace.restrict`: a windowed THB space with its maps.
 
     - ``space`` -- the windowed :class:`THBSplineSpace` rebuilt on the restricted grid;
       its basis equals the global basis pointwise over interior cells (those whose
@@ -1670,7 +1672,11 @@ class THBSplineSpaceRestriction(NamedTuple):
       function active in the sub-space but absent from the global active set -- arises
       near the window boundary where Kraft selection may differ). Values are exact over
       interior cells.
+    - ``local_to_global_cell`` -- read-only ``(space.grid.num_cells,)`` map; entry ``c``
+      is the global flat cell id of local cell ``c``. Same ordering as
+      :attr:`space.grid <THBSplineSpace.grid>`.
     """
 
     space: THBSplineSpace
     local_to_global_dof: npt.NDArray[np.int64]
+    local_to_global_cell: npt.NDArray[np.int64]

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -15,7 +15,7 @@ from pantr.bspline import (
     compute_halo,
     dof_owner,
 )
-from pantr.bspline._local_space import _thb_dof_owner
+from pantr.bspline._local_space import _thb_dof_owner, _thb_halo
 from pantr.grid import Partition, hierarchical_grid, uniform_grid
 
 
@@ -431,6 +431,10 @@ def test_build_local_thb_includes_halo() -> None:
     assert isinstance(loc.space, THBSplineSpace)
     assert int(loc.owned_cell_mask.sum()) == len(central)
     assert loc.space.grid.num_cells > len(central)  # halo / bbox-fill cells present
+    # Owned global cell ids must exactly match what we assigned to rank 0
+    np.testing.assert_array_equal(
+        sorted(loc.local_to_global_cell[loc.owned_cell_mask].tolist()), sorted(central)
+    )
 
 
 def test_build_local_thb_returns_thb_localspace() -> None:
@@ -468,3 +472,60 @@ def test_build_local_thb_bad_rank_raises() -> None:
     part = Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=2)
     with pytest.raises(ValueError, match="rank"):
         build_local(g, part, 2)
+
+
+def _corner_refined_thb() -> THBSplineSpace:
+    """Degree-2 6x6 THB space with [0,3)x[0,3) refined to level 1.
+
+    This produces globally-inactive level-0 functions (fully superseded by level-1
+    functions), so a window covering only a few level-1 cells yields ``local_to_global_dof
+    == -1`` entries — exercising the boundary-DOF path in ``_build_local_thb``.
+    """
+    knots = [0.0] * 3 + [float(i) for i in range(1, 6)] + [6.0] * 3
+    sp = BsplineSpace1D(knots, 2)
+    grid = hierarchical_grid(uniform_grid([[0.0, 6.0], [0.0, 6.0]], 6), 2)
+    grid.refine(0, [0, 0], [3, 3])
+    return THBSplineSpace(BsplineSpace([sp, sp]), grid)
+
+
+def test_build_local_thb_boundary_dofs_not_owned() -> None:
+    # Local DOFs mapping to -1 (window-boundary THB functions) must never be marked owned.
+    g = _corner_refined_thb()
+    l1 = [c for c in range(g.grid.num_cells) if g.grid.cell_level(c) == 1]
+    owner = np.ones(g.grid.num_cells, dtype=np.int32)
+    for c in l1[:4]:
+        owner[c] = 0  # rank 0 owns just 4 level-1 cells — ensures boundary DOFs exist
+    loc = build_local(g, Partition(owner, n_parts=2), 0)
+    boundary = loc.local_to_global_dof < 0
+    assert boundary.any(), "fixture produced no boundary DOFs; test is vacuous"
+    assert not loc.owned_dof_mask[boundary].any()
+
+
+def test_build_local_thb_full_owned_no_halo() -> None:
+    # All cells owned by one rank: halo is empty, owned_cell_mask is all True.
+    g = _refined_thb()
+    loc = build_local(g, Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=1), 0)
+    assert isinstance(loc.space, THBSplineSpace)
+    assert loc.owned_cell_mask.all()
+    assert loc.space.grid.num_cells == g.grid.num_cells
+    # _thb_halo with all cells owned should yield empty halo
+    all_cells = np.arange(g.grid.num_cells, dtype=np.int64)
+    assert _thb_halo(g, all_cells).size == 0
+
+
+def test_thb_dof_owner_all_one_rank() -> None:
+    # 1-rank partition: every non-dead DOF must be owned by rank 0.
+    g = _refined_thb()
+    part = Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=1)
+    owners = _thb_dof_owner(g, part)
+    assert owners.shape == (g.num_total_basis,)
+    assert not owners.flags.writeable
+    # With all cells active and owned by rank 0, no DOF should be dead.
+    np.testing.assert_array_equal(owners, np.zeros(g.num_total_basis, dtype=np.int32))
+
+
+def test_thb_dof_owner_cell_count_mismatch_raises() -> None:
+    g = _refined_thb()
+    part = Partition(np.zeros(g.grid.num_cells - 1, dtype=np.int32), n_parts=1)
+    with pytest.raises(ValueError, match="cells"):
+        _thb_dof_owner(g, part)

--- a/tests/test_local_space.py
+++ b/tests/test_local_space.py
@@ -10,11 +10,13 @@ from pantr.bspline import (
     BsplineSpace,
     BsplineSpace1D,
     LocalSpace,
+    THBSplineSpace,
     build_local,
     compute_halo,
     dof_owner,
 )
-from pantr.grid import Partition
+from pantr.bspline._local_space import _thb_dof_owner
+from pantr.grid import Partition, hierarchical_grid, uniform_grid
 
 
 def _open_uniform_space(degrees: list[int], n_ints: list[int]) -> BsplineSpace:
@@ -263,6 +265,7 @@ def test_build_local_reproduces_global_basis_on_owned_cells() -> None:
     for rank in range(part.n_parts):
         loc = build_local(space, part, rank)
         sub = loc.space
+        assert isinstance(sub, BsplineSpace)
         owned_local = np.flatnonzero(loc.owned_cell_mask)
         pts = _cell_midpoints(sub, owned_local)
         gb, gfb = space.tabulate_basis(pts)
@@ -285,8 +288,10 @@ def test_build_local_reproduces_global_basis_on_owned_cells() -> None:
 def test_build_local_shapes_and_readonly() -> None:
     space = _open_uniform_space([2, 2], [4, 4])
     loc = build_local(space, _round_robin(space, 2), 0)
-    n_cells = loc.space.num_total_intervals
-    n_dofs = loc.space.num_total_basis
+    sub = loc.space
+    assert isinstance(sub, BsplineSpace)
+    n_cells = sub.num_total_intervals
+    n_dofs = sub.num_total_basis
     assert loc.local_to_global_cell.shape == (n_cells,)
     assert loc.owned_cell_mask.shape == (n_cells,)
     assert loc.local_to_global_dof.shape == (n_dofs,)
@@ -307,6 +312,7 @@ def test_build_local_includes_halo_cells() -> None:
     owner = np.ones(8, dtype=np.int32)
     owner[[3, 4]] = 0  # rank 0 owns an interior sub-block
     loc = build_local(space, Partition(owner, n_parts=2), 0)
+    assert isinstance(loc.space, BsplineSpace)
     assert int(loc.owned_cell_mask.sum()) == 2  # only cells 3, 4 owned
     assert loc.space.num_total_intervals > 2  # halo / bbox-fill cells present
     np.testing.assert_array_equal(
@@ -358,3 +364,107 @@ def test_build_local_with_inactive_cells() -> None:
     np.testing.assert_array_equal(loc.owned_dof_mask, expected_owned)
     dead_local = np.flatnonzero(global_owners[loc.local_to_global_dof] == -1)
     assert not loc.owned_dof_mask[dead_local].any()
+
+
+# -------------------------------------------------------- build_local (THB dispatch)
+
+
+def _refined_thb(
+    n: int = 6, lo: tuple[int, int] = (2, 2), hi: tuple[int, int] = (4, 4)
+) -> THBSplineSpace:
+    """Degree-2 ``n x n`` THB space on [0, n]^2, refining ``[lo, hi)`` to level 1."""
+    knots = [0.0] * 3 + [float(i) for i in range(1, n)] + [float(n)] * 3
+    sp = BsplineSpace1D(knots, 2)
+    grid = hierarchical_grid(uniform_grid([[0.0, float(n)], [0.0, float(n)]], n), 2)
+    grid.refine(0, list(lo), list(hi))
+    return THBSplineSpace(BsplineSpace([sp, sp]), grid)
+
+
+def test_build_local_thb_partitions_cells_and_dofs() -> None:
+    g = _refined_thb()
+    part = Partition(np.arange(g.grid.num_cells, dtype=np.int32) % 3, n_parts=3)
+    global_owner = _thb_dof_owner(g, part)
+    owned_cells: list[int] = []
+    owned_dofs: list[int] = []
+    for rank in range(part.n_parts):
+        loc = build_local(g, part, rank)
+        assert isinstance(loc, LocalSpace)
+        assert isinstance(loc.space, THBSplineSpace)
+        oc = loc.local_to_global_cell[loc.owned_cell_mask]
+        od = loc.local_to_global_dof[loc.owned_dof_mask]
+        np.testing.assert_array_equal(part.cell_owner[oc], rank)
+        np.testing.assert_array_equal(global_owner[od], rank)
+        owned_cells.extend(int(c) for c in oc)
+        owned_dofs.extend(int(d) for d in od)
+    assert sorted(owned_cells) == list(range(g.grid.num_cells))
+    assert len(owned_cells) == len(set(owned_cells))
+    assert sorted(owned_dofs) == sorted(int(d) for d in np.flatnonzero(global_owner >= 0))
+    assert len(owned_dofs) == len(set(owned_dofs))
+
+
+def test_build_local_thb_basis_matches_on_owned_cells() -> None:
+    g = _refined_thb()
+    part = Partition(np.arange(g.grid.num_cells, dtype=np.int32) % 4, n_parts=4)
+    for rank in range(part.n_parts):
+        loc = build_local(g, part, rank)
+        sub = loc.space
+        assert isinstance(sub, THBSplineSpace)
+        for lcid in np.flatnonzero(loc.owned_cell_mask):
+            gcid = int(loc.local_to_global_cell[lcid])
+            lo, hi = sub.grid.cell_bounds(int(lcid))
+            pt = (0.5 * (lo + hi)).reshape(1, -1)
+            vs, ds = sub.tabulate_basis(int(lcid), pt)
+            vg, dg = g.tabulate_basis(gcid, pt)
+            mapped = loc.local_to_global_dof[ds]
+            assert np.all(mapped >= 0)  # owned cells are interior
+            gval = {int(d): float(v) for d, v in zip(dg, vg[0], strict=True)}
+            for i, gd in enumerate(mapped):
+                np.testing.assert_allclose(vs[0, i], gval[int(gd)], atol=1e-11)
+
+
+def test_build_local_thb_includes_halo() -> None:
+    g = _refined_thb()
+    owner = np.ones(g.grid.num_cells, dtype=np.int32)
+    central = [c for c in range(g.grid.num_cells) if g.grid.cell_level(c) == 1][:3]
+    owner[central] = 0
+    loc = build_local(g, Partition(owner, n_parts=2), 0)
+    assert isinstance(loc.space, THBSplineSpace)
+    assert int(loc.owned_cell_mask.sum()) == len(central)
+    assert loc.space.grid.num_cells > len(central)  # halo / bbox-fill cells present
+
+
+def test_build_local_thb_returns_thb_localspace() -> None:
+    g = _refined_thb()
+    loc = build_local(g, Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=1), 0)
+    assert isinstance(loc, LocalSpace)
+    assert isinstance(loc.space, THBSplineSpace)
+    assert loc.n_global_cells == g.grid.num_cells
+    assert loc.n_global_dofs == g.num_total_basis
+    for arr in (
+        loc.local_to_global_cell,
+        loc.local_to_global_dof,
+        loc.owned_cell_mask,
+        loc.owned_dof_mask,
+    ):
+        assert not arr.flags.writeable
+
+
+def test_build_local_thb_rank_owns_nothing_raises() -> None:
+    g = _refined_thb()
+    part = Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=2)  # rank 1 owns nothing
+    with pytest.raises(ValueError, match="owns no cells"):
+        build_local(g, part, 1)
+
+
+def test_build_local_thb_cell_count_mismatch_raises() -> None:
+    g = _refined_thb()
+    part = Partition(np.zeros(g.grid.num_cells - 1, dtype=np.int32), n_parts=1)
+    with pytest.raises(ValueError, match="cells"):
+        build_local(g, part, 0)
+
+
+def test_build_local_thb_bad_rank_raises() -> None:
+    g = _refined_thb()
+    part = Partition(np.zeros(g.grid.num_cells, dtype=np.int32), n_parts=2)
+    with pytest.raises(ValueError, match="rank"):
+        build_local(g, part, 2)


### PR DESCRIPTION
## Summary
PR **A7** of the MPI-distribution feature (#142) -- **completes Phase A**. Extends `build_local` to hierarchical spaces.

- **`build_local` dispatches on space type**: `BsplineSpace` -> the A5 tensor-product path; `THBSplineSpace` -> the new hierarchical path. `LocalSpace.space` is widened to `BsplineSpace | THBSplineSpace`.
- THB path (private helpers in `_local_space.py`):
  - **`_thb_halo`** -- cross-level support-closure halo: a cell joins the halo iff it shares an active hierarchical function with an owned cell, making owned cells *interior* for `THBSplineSpace.restrict` (A6).
  - **`_thb_dof_owner`** -- lex-first-active-cell-in-support owner per global THB dof (`-1` for dead dofs).
  - **`_build_local_thb`** -- composes `THBSplineSpace.restrict` (windowed space + DOF map) with `HierarchicalGrid.restrict` (cell map) and the THB ownership; `owned_dof_mask` skips the `-1` boundary DOFs of the windowed THB restriction.

## Test plan
- [x] **Ranks-in-process partition (THB)** -- across ranks, owned cells exactly partition the active cells and owned DOFs (via `local_to_global_dof`) exactly partition the non-dead global DOFs (complete + disjoint).
- [x] **Local == global basis on owned cells (THB)** -- the windowed THB `tabulate_basis` matches the global on every owned cell, with all owned-cell functions mapping to a global dof (validating the halo makes owned cells interior).
- [x] Halo inclusion; dispatch returns a `THBSplineSpace`-backed `LocalSpace`; errors (bad rank, cell-count mismatch, rank-owns-nothing). Existing TP tests narrowed for the widened `LocalSpace.space`.
- [x] `pytest --no-cov` -- 3206 passed
- [x] ruff, ruff format, mypy (strict) -- clean
- [x] docs build (`-W --keep-going`) -- clean

Generated with [Claude Code](https://claude.com/claude-code)