### PR TITLE
feat(mpi): pantr.mpi skeleton + PANTR_NO_MPI build flag (C1 of #142)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# pantr depends on mpi4py by default; the runners have no MPI toolchain and there
+# is no MPI code to exercise yet, so drop it at install time via the build flag.
+env:
+  PANTR_NO_MPI: "1"
+
 jobs:
   lint:
     name: Lint (Ruff)
@@ -64,6 +69,11 @@ jobs:
         run: |
           . .venv/bin/activate
           make ruff-format-check
+
+      - name: Import boundary check (import-linter)
+        run: |
+          . .venv/bin/activate
+          make import-lint
 
   type-check:
     name: Type check (mypy)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ NUMBA_DISABLE_JIT=1 pytest --cov=src/pantr --cov-report=xml         # coverage (
 ruff check .                                                         # lint
 ruff format .                                                        # format
 mypy --config-file mypy.ini src tests                               # type check
+lint-imports                                                        # import boundaries (core must not import pantr.mpi)
 NUMBA_DISABLE_JIT=1 make docs SPHINXOPTS="-W --keep-going -j auto"  # docs build (matches CI)
+PANTR_NO_MPI=1 pip install -e ".[dev]"                              # serial-only install (drop mpi4py)
 ```
 
 > Default pytest (via `pytest.ini`) adds `--cov`, which slows things down and requires ≥85% coverage. Always pass `--no-cov` during development.
@@ -59,6 +61,14 @@ The library is organized in three strict layers. Each layer has a well-defined r
 - Pure computation: Cox–de Boor, de Boor, Lagrange evaluation, etc.
 - Decorated with `@nb_jit(nopython=True, cache=True, parallel=True)` and `prange` for multi-core throughput
 - **No input validation whatsoever** — docstrings explicitly state this. All correctness guarantees come from Layer 2.
+
+### Optional MPI layer (`pantr.mpi`)
+
+`pantr.mpi` hosts the optional MPI-parallel distribution code (and the dolfinx bridge). It is kept strictly separate from the serial core:
+
+- **The serial core never imports `pantr.mpi`.** This is enforced by an import-linter contract (`make import-lint`, run in CI) and a grimp-based test. New core modules are covered automatically by the test.
+- **MPI imports are lazy.** `import pantr.mpi` succeeds even without `mpi4py`; only `pantr.mpi.require_mpi()` imports it (raising a clear error if absent).
+- **`mpi4py` is a default dependency**, injected by the hatchling metadata hook in `hatch_build.py`. Set `PANTR_NO_MPI=1` at build/install time for a serial-only, MPI-free install. Base runtime deps live in `[tool.pantr] base-dependencies` in `pyproject.toml` (the hook reads them, since `dependencies` is `dynamic`).
 
 Other private modules: `_numba_compat.py` (Numba shim), `_basis_utils.py` (shared validation helpers), `__init__.py` (async Numba warmup at import time).
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test coverage clean install ruff-lint ruff-format-check type-check before_push docs
+.PHONY: help test coverage clean install ruff-lint ruff-format-check type-check import-lint before_push docs
 
 help:
 	@echo "Commands:"
@@ -10,6 +10,7 @@ help:
 	@echo "  ruff-format : check Ruff formatting changing files."
 	@echo "  ruff-format-check : check Ruff formatting without changing files."
 	@echo "  type-check: run mypy static type checker."
+	@echo "  import-lint: check import boundaries (core must not import pantr.mpi)."
 	@echo "  docs      : build the documentation."
 	@echo "  befor-pr: run lint, format, format check, type check, tests, coverage, and docs."
 
@@ -46,9 +47,13 @@ ruff-format-check:
 type-check:
 	mypy --config-file mypy.ini src tests
 
+# Import boundary checks: serial core must not import pantr.mpi
+import-lint:
+	lint-imports
+
 # Build documentation
 docs:
 	$(MAKE) -C docs html SPHINXOPTS="$(SPHINXOPTS)"
 
 # Aggregate target to run all checks before creating a pull request
-pre-pull-request: ruff-lint ruff-format ruff-format-check type-check test coverage docs
+pre-pull-request: ruff-lint ruff-format ruff-format-check type-check import-lint test coverage docs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test coverage clean install ruff-lint ruff-format-check type-check import-lint before_push docs
+.PHONY: help test coverage clean install ruff-lint ruff-format-check type-check import-lint pre-pull-request docs
 
 help:
 	@echo "Commands:"
@@ -12,7 +12,7 @@ help:
 	@echo "  type-check: run mypy static type checker."
 	@echo "  import-lint: check import boundaries (core must not import pantr.mpi)."
 	@echo "  docs      : build the documentation."
-	@echo "  befor-pr: run lint, format, format check, type check, tests, coverage, and docs."
+	@echo "  before-pr: run lint, format, format check, type check, tests, coverage, and docs."
 
 # Run the test suite with Numba JIT enabled
 test:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ cd pantr
 pip install .
 ```
 
+By default PaNTr depends on `mpi4py` (for the optional `pantr.mpi` distribution
+layer), which requires an MPI library at build time. For a serial-only, MPI-free
+install, set `PANTR_NO_MPI` when building:
+
+```bash
+PANTR_NO_MPI=1 pip install .
+```
+
+The serial core (`pantr.grid`, `pantr.bspline`, ...) never imports `pantr.mpi`, so
+it works identically with or without MPI.
+
 ## Development
 
 ```bash

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -41,6 +41,11 @@ For transformations between these domains, the `pantr.change_basis` utilities ac
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: pantr.mpi
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: pantr.quad
    :members:
    :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,6 +155,9 @@ nitpick_ignore = [
     # Napoleon strips the npt. prefix from npt.ArrayLike / npt.DTypeLike
     ("py:class", "ArrayLike"),
     ("py:class", "DTypeLike"),
+    # types.ModuleType return annotation: stripped to a bare name by autodoc and
+    # not carried in the Python inventory under that short form.
+    ("py:class", "ModuleType"),
     # Private structural protocol; not in __all__ and not cross-referenceable
     ("py:class", "_AffineMap"),
     ("py:class", "CellIndex"),

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,48 @@
+"""Hatchling metadata hook for the env-var-conditional MPI dependency.
+
+PaNTr depends on ``mpi4py`` by default. Setting the ``PANTR_NO_MPI`` environment
+variable at build/install time drops that dependency, yielding a serial-only,
+MPI-free install. The always-on runtime dependencies live in
+``[tool.pantr] base-dependencies`` in ``pyproject.toml``; this hook reads them and
+appends ``mpi4py`` unless ``PANTR_NO_MPI`` is set in the build environment.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+_MPI_DEPENDENCY = "mpi4py>=3.1,<5"
+"""Optional MPI dependency, added unless the opt-out flag is set."""
+
+_OPT_OUT_ENV = "PANTR_NO_MPI"
+"""Environment variable that, when set to a non-empty value, drops ``mpi4py``."""
+
+
+class CustomMetadataHook(MetadataHookInterface):
+    """Inject ``mpi4py`` as a default dependency unless ``PANTR_NO_MPI`` is set."""
+
+    def update(self, metadata: dict[str, Any]) -> None:
+        """Set ``metadata['dependencies']`` to the base deps plus optional ``mpi4py``.
+
+        Args:
+            metadata: The project metadata mapping to mutate in place. Its
+                ``dependencies`` key is populated with the resolved dependency list.
+        """
+        pyproject = Path(self.root) / "pyproject.toml"
+        with pyproject.open("rb") as fh:
+            data = tomllib.load(fh)
+
+        deps: list[str] = list(data["tool"]["pantr"]["base-dependencies"])
+        if not os.environ.get(_OPT_OUT_ENV):
+            deps.append(_MPI_DEPENDENCY)
+        metadata["dependencies"] = deps

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -37,12 +37,25 @@ class CustomMetadataHook(MetadataHookInterface):
         Args:
             metadata: The project metadata mapping to mutate in place. Its
                 ``dependencies`` key is populated with the resolved dependency list.
+
+        Raises:
+            FileNotFoundError: If ``pyproject.toml`` is not found under ``self.root``.
+            RuntimeError: If ``[tool.pantr] base-dependencies`` is missing from
+                ``pyproject.toml``.
         """
         pyproject = Path(self.root) / "pyproject.toml"
         with pyproject.open("rb") as fh:
             data = tomllib.load(fh)
 
-        deps: list[str] = list(data["tool"]["pantr"]["base-dependencies"])
+        try:
+            deps: list[str] = list(data["tool"]["pantr"]["base-dependencies"])
+        except KeyError as exc:
+            raise RuntimeError(
+                f"hatch_build: could not read [tool.pantr] base-dependencies from "
+                f"{pyproject}: missing key {exc}. "
+                "Ensure pyproject.toml has a [tool.pantr] section with a "
+                "'base-dependencies' list."
+            ) from exc
         if not os.environ.get(_OPT_OUT_ENV):
             deps.append(_MPI_DEPENDENCY)
         metadata["dependencies"] = deps

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,10 @@ mypy_path = src
 disallow_untyped_defs = False
 disallow_untyped_decorators = False
 
+# hatch_build.py uses hatchling (no stubs) and tomli; tested via tests/test_hatch_build.py
+[mypy-hatch_build]
+ignore_errors = True
+
 [mypy-scipy.*]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.12.0"]
+requires = ["hatchling>=1.12.0", "tomli>=1.1.0; python_version < '3.11'"]
 build-backend = "hatchling.build"
 
 [project]
@@ -24,12 +24,11 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
-dependencies = [
-  "numpy>=1.26,<3",
-  "scipy>=1.11,<2",
-  "matplotlib>=3.8,<4",
-  "numba>=0.63",
-]
+# Runtime dependencies are resolved by the hatchling metadata hook in
+# `hatch_build.py`: the base list below plus `mpi4py` (unless the `PANTR_NO_MPI`
+# build-time environment variable is set). They are declared `dynamic` because a
+# PEP 621 field cannot be both static and hook-populated.
+dynamic = ["dependencies"]
 
 [project.optional-dependencies]
 dev = [
@@ -39,6 +38,7 @@ dev = [
   "mypy>=1.10,<2",
   "ruff>=0.12.0,<0.13",
   "pre-commit>=3.6,<4",
+  "import-linter>=2.0,<3",
 ]
 parallel = [
   "threadpoolctl>=3.0",
@@ -67,3 +67,37 @@ packages = ["src/pantr"]
 
 [tool.hatch.version]
 path = "src/pantr/__init__.py"
+
+# Resolve `dynamic = ["dependencies"]` via the CustomMetadataHook in hatch_build.py.
+[tool.hatch.metadata.hooks.custom]
+
+# Always-on runtime dependencies. `mpi4py` is appended by the metadata hook unless
+# the `PANTR_NO_MPI` build-time environment variable is set (see hatch_build.py).
+[tool.pantr]
+base-dependencies = [
+  "numpy>=1.26,<3",
+  "scipy>=1.11,<2",
+  "matplotlib>=3.8,<4",
+  "numba>=0.63",
+]
+
+[tool.importlinter]
+root_package = "pantr"
+
+[[tool.importlinter.contracts]]
+name = "Serial core must not import pantr.mpi"
+type = "forbidden"
+source_modules = [
+  "pantr.basis",
+  "pantr.bezier",
+  "pantr.bspline",
+  "pantr.cad",
+  "pantr.change_basis",
+  "pantr.geometry",
+  "pantr.grid",
+  "pantr.quad",
+  "pantr.tolerance",
+  "pantr.transform",
+  "pantr.viz",
+]
+forbidden_modules = ["pantr.mpi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "ruff>=0.12.0,<0.13",
   "pre-commit>=3.6,<4",
   "import-linter>=2.0,<3",
+  "hatchling>=1.12.0",
 ]
 parallel = [
   "threadpoolctl>=3.0",

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -1,0 +1,68 @@
+"""Optional MPI-parallel distribution layer for PaNTr.
+
+This subpackage hosts the MPI-dependent and dolfinx-bridge code for distributing
+B-spline and THB-spline spaces across ranks. Everything here is optional: the
+serial core (:mod:`pantr.grid`, :mod:`pantr.bspline`, ...) never imports it
+(enforced by an import-linter contract), and ``import pantr.mpi`` succeeds even
+when ``mpi4py`` is absent -- only helpers that genuinely need MPI raise at call
+time, via :func:`require_mpi`.
+
+The default ``pip install pantr`` pulls in ``mpi4py``. Build with the
+``PANTR_NO_MPI`` environment variable set to drop that dependency, yielding a
+serial-only, MPI-free install.
+
+Main exports:
+- :data:`HAS_MPI`: whether ``mpi4py`` is importable in the current environment.
+- :func:`mpi_available`: runtime check for ``mpi4py`` availability.
+- :func:`require_mpi`: lazily import and return the ``mpi4py.MPI`` module, or raise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from types import ModuleType
+from typing import Final
+
+
+def mpi_available() -> bool:
+    """Report whether ``mpi4py`` can be imported in this environment.
+
+    Uses :func:`importlib.util.find_spec`, so it never triggers an actual import
+    or MPI initialization.
+
+    Returns:
+        bool: ``True`` if ``mpi4py`` is installed and importable, ``False`` otherwise.
+    """
+    return importlib.util.find_spec("mpi4py") is not None
+
+
+HAS_MPI: Final[bool] = mpi_available()
+"""bool: Whether ``mpi4py`` is importable, evaluated once at import time."""
+
+
+def require_mpi() -> ModuleType:
+    """Lazily import and return the ``mpi4py.MPI`` module, or raise a clear error.
+
+    Call this from code paths that genuinely need MPI. Keeping the import lazy
+    lets the serial core and a bare ``import pantr.mpi`` work without ``mpi4py``.
+
+    Returns:
+        ModuleType: The imported ``mpi4py.MPI`` module.
+
+    Raises:
+        ImportError: If ``mpi4py`` is not installed, with guidance on how to obtain it.
+    """
+    if not mpi_available():
+        raise ImportError(
+            "pantr.mpi requires 'mpi4py', which is not installed. It ships by default "
+            "with pantr; reinstall without the PANTR_NO_MPI build flag, or run "
+            "'pip install mpi4py' in an environment with an MPI library."
+        )
+    return importlib.import_module("mpi4py.MPI")
+
+
+__all__ = [
+    "HAS_MPI",
+    "mpi_available",
+    "require_mpi",
+]

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -1,6 +1,6 @@
 """Optional MPI-parallel distribution layer for PaNTr.
 
-This subpackage hosts the MPI-dependent and dolfinx-bridge code for distributing
+This subpackage will host the MPI-dependent and dolfinx-bridge code for distributing
 B-spline and THB-spline spaces across ranks. Everything here is optional: the
 serial core (:mod:`pantr.grid`, :mod:`pantr.bspline`, ...) never imports it
 (enforced by an import-linter contract), and ``import pantr.mpi`` succeeds even
@@ -12,8 +12,8 @@ The default ``pip install pantr`` pulls in ``mpi4py``. Build with the
 serial-only, MPI-free install.
 
 Main exports:
-- :data:`HAS_MPI`: whether ``mpi4py`` is importable in the current environment.
-- :func:`mpi_available`: runtime check for ``mpi4py`` availability.
+- :data:`HAS_MPI`: whether ``mpi4py`` was importable at module load time.
+- :func:`mpi_available`: live runtime check for ``mpi4py`` availability.
 - :func:`require_mpi`: lazily import and return the ``mpi4py.MPI`` module, or raise.
 """
 
@@ -37,7 +37,13 @@ def mpi_available() -> bool:
 
 
 HAS_MPI: Final[bool] = mpi_available()
-"""bool: Whether ``mpi4py`` is importable, evaluated once at import time."""
+"""bool: Whether ``mpi4py`` was importable at module load time.
+
+This value is frozen at import and will not reflect environment changes made
+afterwards. Use :func:`mpi_available` for a live probe. In code paths that
+actually need MPI, always call :func:`require_mpi` — it checks freshly and
+raises a clear error if MPI is unavailable or broken.
+"""
 
 
 def require_mpi() -> ModuleType:
@@ -50,7 +56,8 @@ def require_mpi() -> ModuleType:
         ModuleType: The imported ``mpi4py.MPI`` module.
 
     Raises:
-        ImportError: If ``mpi4py`` is not installed, with guidance on how to obtain it.
+        ImportError: If ``mpi4py`` is not installed or fails to load (e.g. the
+            underlying MPI runtime library is missing or ABI-incompatible).
     """
     if not mpi_available():
         raise ImportError(
@@ -58,7 +65,16 @@ def require_mpi() -> ModuleType:
             "with pantr; reinstall without the PANTR_NO_MPI build flag, or run "
             "'pip install mpi4py' in an environment with an MPI library."
         )
-    return importlib.import_module("mpi4py.MPI")
+    try:
+        return importlib.import_module("mpi4py.MPI")
+    except Exception as exc:
+        raise ImportError(
+            "pantr.mpi found 'mpi4py' but failed to import 'mpi4py.MPI'. "
+            "This usually means the MPI runtime library (e.g. libmpi.so) is missing "
+            "or the mpi4py build is incompatible with the current environment. "
+            "Install an MPI library (e.g. 'conda install openmpi') or reinstall "
+            "pantr without MPI via 'PANTR_NO_MPI=1 pip install pantr'."
+        ) from exc
 
 
 __all__ = [

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -1,0 +1,63 @@
+"""Tests for the hatchling metadata hook in hatch_build.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hatch_build import _MPI_DEPENDENCY, _OPT_OUT_ENV, CustomMetadataHook
+
+
+def _make_hook(tmp_path: Path, base_deps: list[str] | None = None) -> CustomMetadataHook:
+    """Create a hook instance with a minimal pyproject.toml in tmp_path."""
+    deps = base_deps if base_deps is not None else ["numpy>=1.26,<3"]
+    (tmp_path / "pyproject.toml").write_text(f"[tool.pantr]\nbase-dependencies = {deps!r}\n")
+    return CustomMetadataHook(str(tmp_path), {})
+
+
+def test_mpi_injected_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``mpi4py`` is added to dependencies when ``PANTR_NO_MPI`` is not set."""
+    monkeypatch.delenv(_OPT_OUT_ENV, raising=False)
+    hook = _make_hook(tmp_path, ["numpy>=1.26,<3"])
+    meta: dict[str, Any] = {}
+    hook.update(meta)
+    assert _MPI_DEPENDENCY in meta["dependencies"]
+    assert "numpy>=1.26,<3" in meta["dependencies"]
+
+
+def test_mpi_not_injected_when_flag_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``mpi4py`` is omitted from dependencies when ``PANTR_NO_MPI`` is set."""
+    monkeypatch.setenv(_OPT_OUT_ENV, "1")
+    hook = _make_hook(tmp_path, ["numpy>=1.26,<3"])
+    meta: dict[str, Any] = {}
+    hook.update(meta)
+    assert _MPI_DEPENDENCY not in meta["dependencies"]
+    assert "numpy>=1.26,<3" in meta["dependencies"]
+
+
+def test_base_deps_always_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All base dependencies appear in the result regardless of the MPI flag."""
+    base = ["numpy>=1.26,<3", "scipy>=1.11,<2", "numba>=0.63"]
+    monkeypatch.setenv(_OPT_OUT_ENV, "1")
+    hook = _make_hook(tmp_path, base)
+    meta: dict[str, Any] = {}
+    hook.update(meta)
+    for dep in base:
+        assert dep in meta["dependencies"]
+
+
+def test_missing_base_dependencies_raises(tmp_path: Path) -> None:
+    """``RuntimeError`` is raised when ``[tool.pantr] base-dependencies`` is absent."""
+    (tmp_path / "pyproject.toml").write_text("[tool.other]\nfoo = 1\n")
+    hook = CustomMetadataHook(str(tmp_path), {})
+    with pytest.raises(RuntimeError, match="base-dependencies"):
+        hook.update({})
+
+
+def test_missing_pyproject_raises(tmp_path: Path) -> None:
+    """``FileNotFoundError`` is raised when ``pyproject.toml`` does not exist."""
+    hook = CustomMetadataHook(str(tmp_path), {})
+    with pytest.raises(FileNotFoundError):
+        hook.update({})

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
+import subprocess
+import sys
 
 import pytest
 
@@ -27,7 +30,7 @@ def test_mpi_available_matches_find_spec() -> None:
 def test_require_mpi_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     """`require_mpi()` raises an informative ImportError when mpi4py is absent."""
     monkeypatch.setattr(pantr.mpi, "mpi_available", lambda: False)
-    with pytest.raises(ImportError, match="mpi4py"):
+    with pytest.raises(ImportError, match="PANTR_NO_MPI"):
         pantr.mpi.require_mpi()
 
 
@@ -43,7 +46,20 @@ def test_require_mpi_imports_mpi4py_mpi(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(pantr.mpi, "mpi_available", lambda: True)
     monkeypatch.setattr(importlib, "import_module", fake_import)
     assert pantr.mpi.require_mpi() is sentinel
+    assert "name" in imported, "fake_import was never called — monkeypatch target may be wrong"
     assert imported["name"] == "mpi4py.MPI"
+
+
+def test_require_mpi_raises_on_broken_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`require_mpi()` wraps non-ImportError load failures as ImportError."""
+
+    def broken_import(name: str) -> object:
+        raise OSError("libmpi.so: cannot open shared object file")
+
+    monkeypatch.setattr(pantr.mpi, "mpi_available", lambda: True)
+    monkeypatch.setattr(importlib, "import_module", broken_import)
+    with pytest.raises(ImportError, match="mpi4py.MPI"):
+        pantr.mpi.require_mpi()
 
 
 def test_require_mpi_returns_module_when_available() -> None:
@@ -54,8 +70,27 @@ def test_require_mpi_returns_module_when_available() -> None:
     assert hasattr(mpi, "COMM_WORLD")
 
 
+def test_pantr_toplevel_does_not_import_mpi() -> None:
+    """``import pantr`` must not cause ``pantr.mpi`` to appear in ``sys.modules``."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import pantr, sys; assert 'pantr.mpi' not in sys.modules, list(sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_core_does_not_import_pantr_mpi() -> None:
-    """No serial-core module imports pantr.mpi (mirrors the import-linter contract)."""
+    """No serial-core module directly imports pantr.mpi (mirrors the import-linter contract).
+
+    Note: only direct (one-hop) imports are checked here. Transitive coverage is
+    provided by the import-linter contract in pyproject.toml (``make import-lint``).
+    """
     grimp = pytest.importorskip("grimp")
     graph = grimp.build_graph("pantr")
     mpi_modules = {m for m in graph.modules if m == "pantr.mpi" or m.startswith("pantr.mpi.")}

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,0 +1,71 @@
+"""Tests for the optional :mod:`pantr.mpi` package skeleton and import boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+import pantr.mpi
+
+
+def test_import_and_public_surface() -> None:
+    """`import pantr.mpi` works regardless of mpi4py, exposing the skeleton API."""
+    assert callable(pantr.mpi.mpi_available)
+    assert callable(pantr.mpi.require_mpi)
+    assert isinstance(pantr.mpi.HAS_MPI, bool)
+    assert set(pantr.mpi.__all__) == {"HAS_MPI", "mpi_available", "require_mpi"}
+
+
+def test_mpi_available_matches_find_spec() -> None:
+    """`mpi_available()` agrees with a direct find_spec probe and with `HAS_MPI`."""
+    expected = importlib.util.find_spec("mpi4py") is not None
+    assert pantr.mpi.mpi_available() is expected
+    assert pantr.mpi.HAS_MPI is expected
+
+
+def test_require_mpi_raises_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`require_mpi()` raises an informative ImportError when mpi4py is absent."""
+    monkeypatch.setattr(pantr.mpi, "mpi_available", lambda: False)
+    with pytest.raises(ImportError, match="mpi4py"):
+        pantr.mpi.require_mpi()
+
+
+def test_require_mpi_imports_mpi4py_mpi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When available, `require_mpi()` imports and returns exactly `mpi4py.MPI`."""
+    sentinel = object()
+    imported: dict[str, str] = {}
+
+    def fake_import(name: str) -> object:
+        imported["name"] = name
+        return sentinel
+
+    monkeypatch.setattr(pantr.mpi, "mpi_available", lambda: True)
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert pantr.mpi.require_mpi() is sentinel
+    assert imported["name"] == "mpi4py.MPI"
+
+
+def test_require_mpi_returns_module_when_available() -> None:
+    """Integration: with a real mpi4py installed, the returned module is usable."""
+    if not pantr.mpi.mpi_available():
+        pytest.skip("mpi4py not installed")
+    mpi = pantr.mpi.require_mpi()
+    assert hasattr(mpi, "COMM_WORLD")
+
+
+def test_core_does_not_import_pantr_mpi() -> None:
+    """No serial-core module imports pantr.mpi (mirrors the import-linter contract)."""
+    grimp = pytest.importorskip("grimp")
+    graph = grimp.build_graph("pantr")
+    mpi_modules = {m for m in graph.modules if m == "pantr.mpi" or m.startswith("pantr.mpi.")}
+    assert mpi_modules, "pantr.mpi not found in the import graph"
+
+    offenders: dict[str, list[str]] = {}
+    for module in graph.modules:
+        if module in mpi_modules:
+            continue
+        bad = sorted(graph.find_modules_directly_imported_by(module) & mpi_modules)
+        if bad:
+            offenders[module] = bad
+    assert not offenders, f"serial-core modules importing pantr.mpi: {offenders}"


### PR DESCRIPTION
## Summary

First PR of **Phase C** (pulled ahead of Phase B). Introduces the optional `pantr.mpi` package plus the packaging and import-boundary machinery the MPI distribution layer needs, so Phase B's MPI-bound partition backends and `from_dolfinx` have a home and a guarded boundary.

- **`pantr.mpi` skeleton** — lazy MPI guards (`mpi_available`, `require_mpi`, `HAS_MPI`). No eager `import mpi4py`: a bare `import pantr.mpi` works without MPI; only `require_mpi()` imports it (clear `ImportError` if absent). No `DistributedSpace` yet (that is C2).
- **Build flag** — `mpi4py` is a **default** dependency, injected by a hatchling metadata hook (`hatch_build.py`). Set `PANTR_NO_MPI=1` at build/install time for a serial-only, MPI-free install. Base deps move to `[tool.pantr] base-dependencies` (so `dependencies` becomes `dynamic`). Verified by inspecting wheel `Requires-Dist` with and without the flag.
- **Import boundary** — an import-linter contract (*serial core must not import `pantr.mpi`*) wired into the `Makefile` (`make import-lint`) and the CI lint job, plus a grimp-based test that covers every current and future module automatically.
- **CI** — sets `PANTR_NO_MPI=1` (runners have no MPI toolchain and there is no MPI code to exercise yet).
- **Docs / README / CLAUDE.md** — document the optional package and the build flag.

## Test plan

- [x] `pantr/mpi` tests: import works without `mpi4py`; `require_mpi()` raises clearly when absent and returns `mpi4py.MPI` when present; import boundary holds.
- [x] Build hook validated: default wheel lists `mpi4py<5,>=3.1`; `PANTR_NO_MPI=1` wheel drops it (base deps + extras intact).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy --config-file mypy.ini src tests` clean.
- [x] `lint-imports`: contract KEPT (1 kept, 0 broken).
- [x] Full suite: 3215 passed, 1 skipped.
- [x] Coverage: `pantr/mpi/__init__.py` 100%, TOTAL 95%.
- [x] Docs build with `-W` succeeds (`pantr.mpi` documented).

Generated with [Claude Code](https://claude.com/claude-code)