### PR TITLE
feat(grid): partition_grid with Cartesian block backend (B1 of #142)

### DIFF
--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -37,6 +37,8 @@ Main exports:
 - :func:`overlay`: the coarsest :class:`TensorProductGrid` refining two input
   tensor-product grids (union of per-axis breakpoints on their domain overlap).
 - :class:`Partition`: a per-cell owner assignment for distributing a grid's cells.
+- :func:`partition_grid`: split a grid into ``n_parts`` rank subdomains (native,
+  dependency-free; the ``"block"`` Cartesian backend).
 """
 
 from __future__ import annotations
@@ -47,6 +49,7 @@ from ._grid import Grid, GridRestriction
 from ._hierarchical_grid import HierarchicalGrid, hierarchical_grid
 from ._overlay import overlay
 from ._partition import Partition
+from ._partition_grid import partition_grid
 from ._tags import CellTags, FacetTags
 from ._tensor_product_grid import TensorProductGrid, tensor_product_grid, uniform_grid
 
@@ -62,6 +65,7 @@ __all__ = [
     "cell_quadrature",
     "hierarchical_grid",
     "overlay",
+    "partition_grid",
     "tensor_product_grid",
     "uniform_grid",
 ]

--- a/src/pantr/grid/_partition_grid.py
+++ b/src/pantr/grid/_partition_grid.py
@@ -1,0 +1,206 @@
+"""Native, dependency-free partitioning of a structured grid into rank subdomains.
+
+Produces a :class:`Partition` (per-cell owner assignment) without any external
+dependency or MPI -- the zero-dependency default for distributing a grid. The only
+backend here is ``"block"``: a Cartesian split of a :class:`TensorProductGrid` into
+contiguous, aspect-ratio-aware box subdomains, one per rank. It is ideal for uniform
+tensor-product grids whose part count factors reasonably across the axes. Weight- and
+activity-aware partitioning (the ``"rcb"`` backend) and external graph partitioners
+(ParMETIS / PT-Scotch) arrive in later work; ``"block"`` raises rather than silently
+producing empty ranks when a part count does not factor onto the grid.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+
+from ._partition import Partition
+from ._tensor_product_grid import TensorProductGrid
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from ._grid import Grid
+
+_VALID_BACKENDS = ("block",)
+"""Partitioning backends recognized by :func:`partition_grid`."""
+
+
+def partition_grid(grid: Grid, n_parts: int, *, backend: str = "block") -> Partition:
+    """Partition a grid's cells into ``n_parts`` contiguous rank subdomains.
+
+    The ``"block"`` backend splits a :class:`TensorProductGrid` into ``n_parts``
+    axis-aligned box subdomains: ``n_parts`` is factored across the axes
+    proportionally to the cell counts (so subdomains are as cube-like as possible),
+    and each axis is cut into contiguous, balanced cell ranges. Every cell is owned,
+    each rank owns one box, and every rank receives roughly ``num_cells / n_parts``
+    cells.
+
+    This is the serial, communication-free partitioner: it returns a
+    :class:`Partition` (a plain per-cell owner array) that the distributed-space
+    machinery consumes. No MPI is involved.
+
+    Args:
+        grid (Grid): The grid to partition. The ``"block"`` backend requires a
+            :class:`TensorProductGrid`.
+        n_parts (int): Number of parts (ranks); must be ``>= 1``.
+        backend (str): Partitioning strategy. Currently only ``"block"`` is
+            available. Defaults to ``"block"``.
+
+    Returns:
+        Partition: A per-cell owner assignment with ``n_parts`` parts. Every cell is
+        active, so :attr:`Partition.active_mask` is all ``True`` and the owner ids
+        cover ``range(n_parts)``.
+
+    Raises:
+        ValueError: If ``n_parts < 1``; if ``backend`` is not a recognized backend;
+            if the ``"block"`` backend is used on a non-:class:`TensorProductGrid`;
+            or if ``n_parts`` cannot be factored across the axes without leaving a
+            rank empty (e.g. a prime ``n_parts`` larger than every axis).
+
+    Example:
+        >>> from pantr.grid import partition_grid, uniform_grid
+        >>> grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+        >>> part = partition_grid(grid, 4)
+        >>> part.n_parts
+        4
+        >>> int(part.cell_owner.min()), int(part.cell_owner.max())
+        (0, 3)
+    """
+    if n_parts < 1:
+        raise ValueError(f"n_parts must be >= 1; got {n_parts}.")
+    if backend not in _VALID_BACKENDS:
+        valid = ", ".join(repr(b) for b in _VALID_BACKENDS)
+        raise ValueError(f"unknown backend {backend!r}; valid backends: {valid}.")
+    if not isinstance(grid, TensorProductGrid):
+        raise ValueError(
+            f"the {backend!r} backend requires a TensorProductGrid; got {type(grid).__name__}."
+        )
+    owner = _block_partition(grid, int(n_parts))
+    return Partition(owner, int(n_parts))
+
+
+def _block_partition(grid: TensorProductGrid, n_parts: int) -> npt.NDArray[np.int32]:
+    """Compute the per-cell owner array for the Cartesian ``"block"`` backend.
+
+    Factors ``n_parts`` into a per-axis block count (:func:`_factor_blocks`), then
+    maps each cell's multi-index to its block via a balanced contiguous split
+    ``block_d = cell_d * blocks_d // cells_d`` and flattens the block multi-index
+    (C-order, matching :class:`TensorProductGrid` cell ids) to the owner rank.
+
+    Args:
+        grid (TensorProductGrid): Grid to partition.
+        n_parts (int): Number of parts (``>= 1``).
+
+    Returns:
+        npt.NDArray[np.int32]: Shape ``(num_cells,)`` owner ranks in
+        ``range(n_parts)``, in C-order cell-id order.
+
+    Raises:
+        ValueError: If ``n_parts`` cannot be factored onto the grid's axes (see
+            :func:`_factor_blocks`).
+    """
+    cells_per_axis = grid.cells_per_axis
+    blocks_per_axis = _factor_blocks(cells_per_axis, n_parts)
+    cpa = np.asarray(cells_per_axis, dtype=np.int64)
+    bpa = np.asarray(blocks_per_axis, dtype=np.int64)
+    multi = np.stack(np.unravel_index(np.arange(grid.num_cells), cells_per_axis), axis=0)
+    block_multi = (multi * bpa[:, None]) // cpa[:, None]
+    owner = np.ravel_multi_index(block_multi, blocks_per_axis).astype(np.int32)
+    return cast("npt.NDArray[np.int32]", owner)
+
+
+def _factor_blocks(cells_per_axis: tuple[int, ...], n_parts: int) -> tuple[int, ...]:
+    """Factor ``n_parts`` into a per-axis block count proportional to cell counts.
+
+    Searches all factorizations of ``n_parts`` into ``len(cells_per_axis)`` ordered
+    factors with ``blocks[d] <= cells_per_axis[d]`` and returns the one whose block
+    extents ``cells_per_axis[d] / blocks[d]`` are the most uniform (minimizing the
+    variance of their logarithms), i.e. the most cube-like subdomains. The search is
+    exact, so it finds a valid factorization whenever one exists; the divisor count of
+    ``n_parts`` is small, so the enumeration is cheap.
+
+    Args:
+        cells_per_axis (tuple[int, ...]): Cell count along each axis (each ``>= 1``).
+        n_parts (int): Number of parts (``>= 1``).
+
+    Returns:
+        tuple[int, ...]: Block count per axis; the product equals ``n_parts`` and
+        every entry satisfies ``blocks[d] <= cells_per_axis[d]``.
+
+    Raises:
+        ValueError: If no such factorization exists -- ``n_parts`` is too large or
+            factors too coarsely for this grid, so some rank would get no cells.
+            Use a part count that divides the grid better, or the ``"rcb"`` backend.
+    """
+    ndim = len(cells_per_axis)
+    best: tuple[int, ...] | None = None
+    best_score = math.inf
+
+    def recurse(axis: int, remaining: int, acc: tuple[int, ...]) -> None:
+        nonlocal best, best_score
+        if axis == ndim - 1:
+            if remaining <= cells_per_axis[axis]:
+                blocks = (*acc, remaining)
+                score = _extent_imbalance(cells_per_axis, blocks)
+                if score < best_score:
+                    best_score, best = score, blocks
+            return
+        for divisor in _divisors(remaining):
+            if divisor <= cells_per_axis[axis]:
+                recurse(axis + 1, remaining // divisor, (*acc, divisor))
+
+    recurse(0, n_parts, ())
+    if best is None:
+        raise ValueError(
+            f"cannot factor n_parts={n_parts} across axes with "
+            f"cells_per_axis={cells_per_axis} without leaving a rank empty. "
+            f"Use a part count that divides the grid better, or the 'rcb' backend."
+        )
+    return best
+
+
+def _divisors(n: int) -> list[int]:
+    """Return all positive divisors of ``n``, ascending.
+
+    Args:
+        n (int): A positive integer.
+
+    Returns:
+        list[int]: Sorted divisors of ``n`` (includes ``1`` and ``n``).
+    """
+    small: list[int] = []
+    large: list[int] = []
+    i = 1
+    while i * i <= n:
+        if n % i == 0:
+            small.append(i)
+            if i != n // i:
+                large.append(n // i)
+        i += 1
+    return small + large[::-1]
+
+
+def _extent_imbalance(cells_per_axis: tuple[int, ...], blocks: tuple[int, ...]) -> float:
+    """Return the variance of the log block extents (lower is more cube-like).
+
+    The block extent along an axis is ``cells_per_axis[d] / blocks[d]`` (mean cells
+    per block along that axis). Using log extents makes the metric scale-invariant,
+    so the minimizer favors subdomains that are as cube-like as possible.
+
+    Args:
+        cells_per_axis (tuple[int, ...]): Cell count along each axis.
+        blocks (tuple[int, ...]): Candidate block count along each axis.
+
+    Returns:
+        float: Variance of ``log(cells_per_axis[d] / blocks[d])`` over the axes.
+    """
+    logs = [math.log(c / b) for c, b in zip(cells_per_axis, blocks, strict=True)]
+    mean = math.fsum(logs) / len(logs)
+    return math.fsum((x - mean) ** 2 for x in logs) / len(logs)
+
+
+__all__ = ["partition_grid"]

--- a/src/pantr/grid/_partition_grid.py
+++ b/src/pantr/grid/_partition_grid.py
@@ -109,7 +109,9 @@ def _block_partition(grid: TensorProductGrid, n_parts: int) -> npt.NDArray[np.in
     bpa = np.asarray(blocks_per_axis, dtype=np.int64)
     multi = np.stack(np.unravel_index(np.arange(grid.num_cells), cells_per_axis), axis=0)
     block_multi = (multi * bpa[:, None]) // cpa[:, None]
-    owner = np.ravel_multi_index(block_multi, blocks_per_axis).astype(np.int32)
+    owner = np.ravel_multi_index(
+        [block_multi[d] for d in range(len(cells_per_axis))], blocks_per_axis
+    ).astype(np.int32)
     return cast("npt.NDArray[np.int32]", owner)
 
 

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -20,11 +20,13 @@ from pantr.grid._partition_grid import _divisors, _factor_blocks
 def _cell_multi_indices(cells_per_axis: tuple[int, ...]) -> npt.NDArray[np.intp]:
     """Return the (num_cells, ndim) C-order multi-index of every cell."""
     n = int(np.prod(cells_per_axis))
-    multi = np.array(np.unravel_index(np.arange(n), cells_per_axis)).T
-    return cast("npt.NDArray[np.intp]", multi)
+    multi: npt.NDArray[np.intp] = np.array(
+        np.unravel_index(np.arange(n), cells_per_axis), dtype=np.intp
+    ).T
+    return multi
 
 
-def _assert_owner_boxes(owner: np.ndarray, cells_per_axis: tuple[int, ...]) -> None:
+def _assert_owner_boxes(owner: npt.NDArray[Any], cells_per_axis: tuple[int, ...]) -> None:
     """Assert each owner's cells form a solid axis-aligned box, tiling the grid."""
     multi = _cell_multi_indices(cells_per_axis)
     for rank in np.unique(owner):

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -1,0 +1,190 @@
+"""Tests for the native block partitioner :func:`pantr.grid.partition_grid`."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.grid import (
+    Partition,
+    hierarchical_grid,
+    partition_grid,
+    uniform_grid,
+)
+from pantr.grid._partition_grid import _divisors, _factor_blocks
+
+
+def _cell_multi_indices(cells_per_axis: tuple[int, ...]) -> npt.NDArray[np.intp]:
+    """Return the (num_cells, ndim) C-order multi-index of every cell."""
+    n = int(np.prod(cells_per_axis))
+    multi = np.array(np.unravel_index(np.arange(n), cells_per_axis)).T
+    return cast("npt.NDArray[np.intp]", multi)
+
+
+def _assert_owner_boxes(owner: np.ndarray, cells_per_axis: tuple[int, ...]) -> None:
+    """Assert each owner's cells form a solid axis-aligned box, tiling the grid."""
+    multi = _cell_multi_indices(cells_per_axis)
+    for rank in np.unique(owner):
+        cells = multi[owner == rank]
+        lo = cells.min(axis=0)
+        hi = cells.max(axis=0)
+        box_count = int(np.prod(hi - lo + 1))
+        assert cells.shape[0] == box_count, f"rank {rank} cells are not a full box"
+        in_box = np.all((multi >= lo) & (multi <= hi), axis=1)
+        assert np.all(owner[in_box] == rank), f"rank {rank} box overlaps another rank"
+
+
+# --------------------------------------------------------------------------- #
+# Invariants over a sweep of grids and part counts
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "cells_per_axis",
+    [(8,), (4, 4), (8, 2), (6, 4), (4, 3, 2), (3, 3, 3)],
+)
+@pytest.mark.parametrize("n_parts", [1, 2, 3, 4, 6, 8])
+def test_block_partition_invariants(cells_per_axis: tuple[int, ...], n_parts: int) -> None:
+    grid = uniform_grid([[0.0, 1.0]] * len(cells_per_axis), list(cells_per_axis))
+    num_cells = grid.num_cells
+    try:
+        part = partition_grid(grid, n_parts)
+    except ValueError:
+        # Infeasible factorization for this grid/part count; covered separately.
+        return
+
+    assert isinstance(part, Partition)
+    assert part.n_parts == n_parts
+    assert part.n_cells == num_cells
+    owner = part.cell_owner
+    assert owner.shape == (num_cells,)
+    assert np.all(part.active_mask), "block partition leaves every cell active"
+    assert owner.min() >= 0 and owner.max() < n_parts
+    # Every rank is used (no empty subdomain) and counts sum to num_cells.
+    assert set(owner.tolist()) == set(range(n_parts))
+    counts = np.bincount(owner, minlength=n_parts)
+    assert counts.sum() == num_cells
+    assert counts.min() >= 1
+    _assert_owner_boxes(owner, cells_per_axis)
+
+
+def test_block_partition_is_deterministic() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [6, 4])
+    a = partition_grid(grid, 6).cell_owner
+    b = partition_grid(grid, 6).cell_owner
+    np.testing.assert_array_equal(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# Exact, hand-computed cases
+# --------------------------------------------------------------------------- #
+
+
+def test_block_1d_even_split() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 8)
+    owner = partition_grid(grid, 4).cell_owner
+    np.testing.assert_array_equal(owner, [0, 0, 1, 1, 2, 2, 3, 3])
+
+
+def test_block_2d_four_parts() -> None:
+    # (4, 4) into 4 -> blocks (2, 2); owner = (i0 // 2) * 2 + (i1 // 2).
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+    owner = partition_grid(grid, 4).cell_owner
+    i0, i1 = np.unravel_index(np.arange(16), (4, 4))
+    expected = (i0 // 2) * 2 + (i1 // 2)
+    np.testing.assert_array_equal(owner, expected)
+
+
+def test_block_is_aspect_ratio_aware() -> None:
+    # (8, 2) into 4: cube-like blocks are (4, 1), so owner depends only on axis 0.
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [8, 2])
+    owner = partition_grid(grid, 4).cell_owner.reshape(8, 2)
+    # Constant across axis 1 (the short axis was not split)...
+    assert np.all(owner[:, 0] == owner[:, 1])
+    # ...and varies along axis 0 (the long axis was split into 4).
+    assert np.array_equal(owner[:, 0], np.repeat(np.arange(4), 2))
+
+
+def test_block_n_parts_one() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [5, 3])
+    part = partition_grid(grid, 1)
+    assert part.n_parts == 1
+    assert np.all(part.cell_owner == 0)
+
+
+def test_block_n_parts_equals_num_cells_is_bijection() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [3, 3])
+    owner = partition_grid(grid, 9).cell_owner
+    np.testing.assert_array_equal(np.sort(owner), np.arange(9))
+
+
+# --------------------------------------------------------------------------- #
+# Error handling
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("n_parts", [0, -1, -5])
+def test_invalid_n_parts_raises(n_parts: int) -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="n_parts must be >= 1"):
+        partition_grid(grid, n_parts)
+
+
+def test_unknown_backend_raises() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="unknown backend"):
+        partition_grid(grid, 2, backend="rcb")
+
+
+def test_block_on_non_tensor_product_grid_raises() -> None:
+    hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    with pytest.raises(ValueError, match="requires a TensorProductGrid"):
+        partition_grid(hgrid, 2)
+
+
+def test_infeasible_factorization_raises() -> None:
+    # 7 is prime and larger than every axis (4), so no non-empty box split exists.
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+    with pytest.raises(ValueError, match="cannot factor n_parts"):
+        partition_grid(grid, 7)
+
+
+# --------------------------------------------------------------------------- #
+# Factoring helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_divisors() -> None:
+    assert _divisors(1) == [1]
+    assert _divisors(12) == [1, 2, 3, 4, 6, 12]
+    assert _divisors(13) == [1, 13]
+    assert _divisors(36) == [1, 2, 3, 4, 6, 9, 12, 18, 36]
+
+
+@pytest.mark.parametrize(
+    ("cells_per_axis", "n_parts", "expected"),
+    [
+        ((8,), 4, (4,)),
+        ((4, 4), 4, (2, 2)),
+        ((8, 2), 4, (4, 1)),  # aspect-aware: cube-like blocks
+        ((4, 3), 12, (4, 3)),  # greedy-by-ratio would fail; exact search succeeds
+        ((3, 3, 3), 27, (3, 3, 3)),
+        ((10, 1), 2, (2, 1)),
+        ((6, 4), 1, (1, 1)),
+    ],
+)
+def test_factor_blocks(
+    cells_per_axis: tuple[int, ...], n_parts: int, expected: tuple[int, ...]
+) -> None:
+    blocks = _factor_blocks(cells_per_axis, n_parts)
+    assert blocks == expected
+    assert np.prod(blocks) == n_parts
+    assert all(b <= c for b, c in zip(blocks, cells_per_axis, strict=True))
+
+
+def test_factor_blocks_infeasible_raises() -> None:
+    with pytest.raises(ValueError, match="cannot factor"):
+        _factor_blocks((4, 4), 7)

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import numpy as np
@@ -80,6 +81,15 @@ def test_block_partition_is_deterministic() -> None:
     np.testing.assert_array_equal(a, b)
 
 
+def test_block_load_is_balanced() -> None:
+    # 1D uneven split: each rank gets floor or ceil of num_cells/n_parts.
+    grid = uniform_grid([[0.0, 1.0]], 7)
+    owner = partition_grid(grid, 3).cell_owner
+    counts = np.bincount(owner, minlength=3)
+    assert int(counts.min()) == 7 // 3
+    assert int(counts.max()) == math.ceil(7 / 3)
+
+
 # --------------------------------------------------------------------------- #
 # Exact, hand-computed cases
 # --------------------------------------------------------------------------- #
@@ -123,6 +133,13 @@ def test_block_n_parts_equals_num_cells_is_bijection() -> None:
     np.testing.assert_array_equal(np.sort(owner), np.arange(9))
 
 
+def test_block_single_cell_axis_concentrates_blocks() -> None:
+    # (1, 8) into 4: axis 0 has 1 cell so all blocks must go on axis 1.
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [1, 8])
+    owner = partition_grid(grid, 4).cell_owner
+    np.testing.assert_array_equal(owner, np.repeat(np.arange(4), 2))
+
+
 # --------------------------------------------------------------------------- #
 # Error handling
 # --------------------------------------------------------------------------- #
@@ -154,6 +171,13 @@ def test_infeasible_factorization_raises() -> None:
         partition_grid(grid, 7)
 
 
+def test_infeasible_1d_n_parts_exceeds_cells_raises() -> None:
+    # 1D: n_parts=7 > num_cells=4; the final-axis check rejects it.
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="cannot factor n_parts"):
+        partition_grid(grid, 7)
+
+
 # --------------------------------------------------------------------------- #
 # Factoring helpers
 # --------------------------------------------------------------------------- #
@@ -161,6 +185,8 @@ def test_infeasible_factorization_raises() -> None:
 
 def test_divisors() -> None:
     assert _divisors(1) == [1]
+    assert _divisors(4) == [1, 2, 4]  # perfect square: i == n//i branch
+    assert _divisors(9) == [1, 3, 9]  # perfect square: i == n//i branch
     assert _divisors(12) == [1, 2, 3, 4, 6, 12]
     assert _divisors(13) == [1, 13]
     assert _divisors(36) == [1, 2, 3, 4, 6, 9, 12, 18, 36]
@@ -174,6 +200,8 @@ def test_divisors() -> None:
         ((8, 2), 4, (4, 1)),  # aspect-aware: cube-like blocks
         ((4, 3), 12, (4, 3)),  # greedy-by-ratio would fail; exact search succeeds
         ((3, 3, 3), 27, (3, 3, 3)),
+        ((4, 4, 4), 8, (2, 2, 2)),  # 3D symmetric
+        ((6, 4, 2), 6, (3, 2, 1)),  # 3D asymmetric: extents (2,2,2) → var=0
         ((10, 1), 2, (2, 1)),
         ((6, 4), 1, (1, 1)),
     ],
@@ -185,6 +213,14 @@ def test_factor_blocks(
     assert blocks == expected
     assert np.prod(blocks) == n_parts
     assert all(b <= c for b, c in zip(blocks, cells_per_axis, strict=True))
+
+
+def test_factor_blocks_tie_only_contract() -> None:
+    # (3,3,3) into 9 has three equally optimal factorizations: (1,3,3), (3,1,3),
+    # (3,3,1). Test only the contract, not the specific tuple.
+    blocks = _factor_blocks((3, 3, 3), 9)
+    assert math.prod(blocks) == 9
+    assert all(b <= c for b, c in zip(blocks, (3, 3, 3), strict=True))
 
 
 def test_factor_blocks_infeasible_raises() -> None:


### PR DESCRIPTION
## Summary

First PR of **Phase B** (partition sources). Adds the native, dependency-free partitioner that turns a grid into a `Partition` (per-cell owner assignment) for distributing it — no MPI, no external graph partitioner.

- **`pantr.grid.partition_grid(grid, n_parts, *, backend="block")`** — returns a `Partition` with `n_parts` parts.
- **`block` backend** (Cartesian, aspect-ratio-aware): splits a `TensorProductGrid` into `n_parts` contiguous box subdomains. `n_parts` is factored across the axes proportionally to the cell counts via an exact search over divisor tuples (minimizing log-extent variance → cube-like blocks), and each axis is cut into balanced contiguous ranges (`block_d = cell_d * blocks_d // cells_d`). Every cell is owned; each rank gets ~`num_cells / n_parts` cells.
- **No silent surprises:** raises rather than producing empty ranks when `n_parts` can't factor onto the grid (the awkward/prime cases that the later `rcb` backend and `backend="auto"` will route around); rejects non-`TensorProductGrid` inputs and unknown backends; `n_parts < 1` raises.
- **Deferred to B2:** the `cell_weights` / `cell_active` immersion hooks — `block` is the uniform, all-active backend; weighting/activity belong to `rcb`. The signature stays additively compatible.

## Test plan

- [x] Invariant sweep (1D/2D/3D grids × several `n_parts`): `Partition` invariants, all cells active, owners cover `range(n_parts)`, no empty rank, and each owner's cells form a solid axis-aligned box tiling the grid.
- [x] Exact hand-computed cases (1D even split, 2D 4-part, `n_parts=1`, `n_parts=num_cells` bijection).
- [x] Aspect-awareness: `(8,2)` into 4 → blocks `(4,1)` (splits the long axis only).
- [x] `_factor_blocks` / `_divisors` unit tests, incl. `(4,3)`→12 = `(4,3)` (a case naive greedy-by-ratio would miss) and infeasible `(4,4)`→7.
- [x] Errors: bad `n_parts`, unknown backend, non-TP grid, infeasible factorization.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT; full suite 3279 passed (1 skipped); docs `-W` ok; `_partition_grid.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)