### PR TITLE
feat(grid): rcb backend + auto dispatch + immersion hooks (B2 of #142)

### DIFF
--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -38,7 +38,9 @@ Main exports:
   tensor-product grids (union of per-axis breakpoints on their domain overlap).
 - :class:`Partition`: a per-cell owner assignment for distributing a grid's cells.
 - :func:`partition_grid`: split a grid into ``n_parts`` rank subdomains (native,
-  dependency-free; the ``"block"`` Cartesian backend).
+  dependency-free): the ``"block"`` Cartesian backend, the ``"rcb"`` recursive
+  coordinate bisection backend (weight- and activity-aware), and an ``"auto"``
+  dispatch between them.
 """
 
 from __future__ import annotations

--- a/src/pantr/grid/_partition_grid.py
+++ b/src/pantr/grid/_partition_grid.py
@@ -1,13 +1,21 @@
 """Native, dependency-free partitioning of a structured grid into rank subdomains.
 
 Produces a :class:`Partition` (per-cell owner assignment) without any external
-dependency or MPI -- the zero-dependency default for distributing a grid. The only
-backend here is ``"block"``: a Cartesian split of a :class:`TensorProductGrid` into
-contiguous, aspect-ratio-aware box subdomains, one per rank. It is ideal for uniform
-tensor-product grids whose part count factors reasonably across the axes. Weight- and
-activity-aware partitioning (the ``"rcb"`` backend) and external graph partitioners
-(ParMETIS / PT-Scotch) arrive in later work; ``"block"`` raises rather than silently
-producing empty ranks when a part count does not factor onto the grid.
+dependency or MPI -- the zero-dependency default for distributing a grid. Two
+backends are provided, with an ``"auto"`` dispatch:
+
+- ``"block"`` -- a Cartesian split of a :class:`TensorProductGrid` into contiguous,
+  aspect-ratio-aware box subdomains. Ideal for tensor-product grids whose part count
+  factors reasonably across the axes; raises rather than producing empty ranks when
+  it does not. Ignores cell weights and activity.
+- ``"rcb"`` -- recursive coordinate bisection on cell centroids. Geometric and
+  grid-agnostic (works on any :class:`Grid`, hierarchical or immersed), weight-aware
+  (balances total cell cost, not cell count) and activity-aware (inactive cells get
+  owner ``-1`` and are excluded). Handles arbitrary part counts, including prime ones.
+- ``"auto"`` -- ``"block"`` when the grid is tensor-product, no weights/activity are
+  given, and the part count factors onto the axes; otherwise ``"rcb"``.
+
+External graph partitioners (ParMETIS / PT-Scotch) arrive in later work.
 """
 
 from __future__ import annotations
@@ -25,41 +33,56 @@ if TYPE_CHECKING:
 
     from ._grid import Grid
 
-_VALID_BACKENDS = ("block",)
+_VALID_BACKENDS = ("auto", "block", "rcb")
 """Partitioning backends recognized by :func:`partition_grid`."""
 
 
-def partition_grid(grid: Grid, n_parts: int, *, backend: str = "block") -> Partition:
-    """Partition a grid's cells into ``n_parts`` contiguous rank subdomains.
+def partition_grid(
+    grid: Grid,
+    n_parts: int,
+    *,
+    backend: str = "auto",
+    cell_weights: npt.ArrayLike | None = None,
+    cell_active: npt.ArrayLike | None = None,
+) -> Partition:
+    """Partition a grid's cells into ``n_parts`` rank subdomains.
 
-    The ``"block"`` backend splits a :class:`TensorProductGrid` into ``n_parts``
-    axis-aligned box subdomains: ``n_parts`` is factored across the axes
-    proportionally to the cell counts (so subdomains are as cube-like as possible),
-    and each axis is cut into contiguous, balanced cell ranges. Every cell is owned,
-    each rank owns one box, and every rank receives roughly ``num_cells / n_parts``
-    cells.
+    Returns a :class:`Partition` (a plain per-cell owner array) for the
+    serial, communication-free distribution of a grid -- no MPI is involved.
+    See the module docstring for the ``"block"``, ``"rcb"``, and ``"auto"``
+    backends.
 
-    This is the serial, communication-free partitioner: it returns a
-    :class:`Partition` (a plain per-cell owner array) that the distributed-space
-    machinery consumes. No MPI is involved.
+    The ``cell_weights`` and ``cell_active`` hooks let a consumer (e.g. an
+    immersed/unfitted code) drive the partition without pantr storing any
+    classification: per-cell assembly cost via ``cell_weights`` (the ``"rcb"``
+    backend balances total weight), and an active subset via ``cell_active``
+    (inactive cells get owner ``-1``). The ``"block"`` backend supports neither.
 
     Args:
         grid (Grid): The grid to partition. The ``"block"`` backend requires a
-            :class:`TensorProductGrid`.
+            :class:`TensorProductGrid`; ``"rcb"`` accepts any grid.
         n_parts (int): Number of parts (ranks); must be ``>= 1``.
-        backend (str): Partitioning strategy. Currently only ``"block"`` is
-            available. Defaults to ``"block"``.
+        backend (str): ``"auto"`` (default), ``"block"``, or ``"rcb"``.
+        cell_weights (npt.ArrayLike | None): Optional per-cell cost, shape
+            ``(num_cells,)``, finite and non-negative. ``None`` means uniform.
+            Used by ``"rcb"``; rejected by ``"block"``.
+        cell_active (npt.ArrayLike | None): Optional boolean mask, shape
+            ``(num_cells,)``; inactive cells get owner ``-1`` and are excluded
+            from partitioning. ``None`` means all active. Used by ``"rcb"``;
+            rejected by ``"block"``.
 
     Returns:
-        Partition: A per-cell owner assignment with ``n_parts`` parts. Every cell is
-        active, so :attr:`Partition.active_mask` is all ``True`` and the owner ids
-        cover ``range(n_parts)``.
+        Partition: A per-cell owner assignment with ``n_parts`` parts. Cells
+        excluded by ``cell_active`` have owner ``-1``; every active cell is
+        assigned a rank in ``range(n_parts)`` and no rank is left empty.
 
     Raises:
-        ValueError: If ``n_parts < 1``; if ``backend`` is not a recognized backend;
-            if the ``"block"`` backend is used on a non-:class:`TensorProductGrid`;
-            or if ``n_parts`` cannot be factored across the axes without leaving a
-            rank empty (e.g. a prime ``n_parts`` larger than every axis).
+        ValueError: If ``n_parts < 1``; if ``backend`` is unknown; if ``"block"``
+            is used on a non-:class:`TensorProductGrid` or with weights/activity;
+            if ``n_parts`` cannot be factored onto the axes (``"block"``); if
+            ``cell_weights`` / ``cell_active`` have the wrong shape or invalid
+            values; or if ``n_parts`` exceeds the number of active cells
+            (``"rcb"``).
 
     Example:
         >>> from pantr.grid import partition_grid, uniform_grid
@@ -75,12 +98,115 @@ def partition_grid(grid: Grid, n_parts: int, *, backend: str = "block") -> Parti
     if backend not in _VALID_BACKENDS:
         valid = ", ".join(repr(b) for b in _VALID_BACKENDS)
         raise ValueError(f"unknown backend {backend!r}; valid backends: {valid}.")
+
+    n_parts = int(n_parts)
+    weights = _validate_weights(cell_weights, grid.num_cells)
+    active = _validate_active(cell_active, grid.num_cells)
+
+    if backend == "block":
+        owner = _block_backend(grid, n_parts, weights, active)
+    elif backend == "rcb":
+        owner = _rcb_partition(grid, n_parts, weights, active)
+    elif isinstance(grid, TensorProductGrid) and weights is None and active is None:
+        # "auto": prefer the cheap Cartesian split; fall back to rcb when n_parts
+        # does not factor onto the axes (awkward / prime part counts).
+        try:
+            owner = _block_partition(grid, n_parts)
+        except ValueError:
+            owner = _rcb_partition(grid, n_parts, None, None)
+    else:
+        owner = _rcb_partition(grid, n_parts, weights, active)
+
+    return Partition(owner, n_parts)
+
+
+def _validate_weights(
+    cell_weights: npt.ArrayLike | None, n_cells: int
+) -> npt.NDArray[np.float64] | None:
+    """Validate and coerce ``cell_weights`` to a ``(n_cells,)`` ``float64`` array.
+
+    Args:
+        cell_weights (npt.ArrayLike | None): Candidate per-cell weights, or ``None``.
+        n_cells (int): Expected length.
+
+    Returns:
+        npt.NDArray[np.float64] | None: The coerced weights, or ``None`` if the
+        input was ``None``.
+
+    Raises:
+        ValueError: If the shape is not ``(n_cells,)`` or any entry is negative or
+            non-finite.
+    """
+    if cell_weights is None:
+        return None
+    weights = np.asarray(cell_weights, dtype=np.float64)
+    if weights.shape != (n_cells,):
+        raise ValueError(f"cell_weights must have shape ({n_cells},); got {weights.shape}.")
+    if not bool(np.all(np.isfinite(weights))) or bool(np.any(weights < 0.0)):
+        raise ValueError("cell_weights must be finite and non-negative.")
+    return weights
+
+
+def _validate_active(
+    cell_active: npt.ArrayLike | None, n_cells: int
+) -> npt.NDArray[np.bool_] | None:
+    """Validate and coerce ``cell_active`` to a ``(n_cells,)`` boolean array.
+
+    Args:
+        cell_active (npt.ArrayLike | None): Candidate activity mask, or ``None``.
+        n_cells (int): Expected length.
+
+    Returns:
+        npt.NDArray[np.bool_] | None: The coerced mask, or ``None`` if the input
+        was ``None``.
+
+    Raises:
+        ValueError: If the shape is not ``(n_cells,)`` or no cell is active.
+    """
+    if cell_active is None:
+        return None
+    active = np.asarray(cell_active)
+    if active.shape != (n_cells,):
+        raise ValueError(f"cell_active must have shape ({n_cells},); got {active.shape}.")
+    active = active.astype(bool)
+    if not bool(active.any()):
+        raise ValueError("cell_active must mark at least one cell active.")
+    return cast("npt.NDArray[np.bool_]", active)
+
+
+def _block_backend(
+    grid: Grid,
+    n_parts: int,
+    weights: npt.NDArray[np.float64] | None,
+    active: npt.NDArray[np.bool_] | None,
+) -> npt.NDArray[np.int32]:
+    """Run the ``"block"`` backend, rejecting unsupported grids and hooks.
+
+    Args:
+        grid (Grid): Grid to partition; must be a :class:`TensorProductGrid`.
+        n_parts (int): Number of parts (``>= 1``).
+        weights (npt.NDArray[np.float64] | None): Must be ``None`` (block ignores
+            weights).
+        active (npt.NDArray[np.bool_] | None): Must be ``None`` (block ignores
+            activity).
+
+    Returns:
+        npt.NDArray[np.int32]: Per-cell owner array (see :func:`_block_partition`).
+
+    Raises:
+        ValueError: If ``grid`` is not a :class:`TensorProductGrid`, or if weights
+            or activity are supplied.
+    """
     if not isinstance(grid, TensorProductGrid):
         raise ValueError(
-            f"the {backend!r} backend requires a TensorProductGrid; got {type(grid).__name__}."
+            f"the 'block' backend requires a TensorProductGrid; got {type(grid).__name__}."
         )
-    owner = _block_partition(grid, int(n_parts))
-    return Partition(owner, int(n_parts))
+    if weights is not None or active is not None:
+        raise ValueError(
+            "the 'block' backend does not support cell_weights or cell_active; "
+            "use backend='rcb' (or 'auto')."
+        )
+    return _block_partition(grid, n_parts)
 
 
 def _block_partition(grid: TensorProductGrid, n_parts: int) -> npt.NDArray[np.int32]:
@@ -112,6 +238,75 @@ def _block_partition(grid: TensorProductGrid, n_parts: int) -> npt.NDArray[np.in
     owner = np.ravel_multi_index(
         [block_multi[d] for d in range(len(cells_per_axis))], blocks_per_axis
     ).astype(np.int32)
+    return cast("npt.NDArray[np.int32]", owner)
+
+
+def _rcb_partition(
+    grid: Grid,
+    n_parts: int,
+    weights: npt.NDArray[np.float64] | None,
+    active: npt.NDArray[np.bool_] | None,
+) -> npt.NDArray[np.int32]:
+    """Partition a grid by recursive coordinate bisection of its active cells.
+
+    Operates on the centroids of the active cells (the midpoints of
+    :meth:`Grid.collect_cell_bounds`). It is geometric, so it works on any grid,
+    and balances total weight (uniform when ``weights is None``). Inactive cells
+    get owner ``-1``.
+
+    Args:
+        grid (Grid): Grid to partition.
+        n_parts (int): Number of parts (``>= 1``).
+        weights (npt.NDArray[np.float64] | None): Per-cell weights, or ``None`` for
+            uniform.
+        active (npt.NDArray[np.bool_] | None): Activity mask, or ``None`` for all
+            active.
+
+    Returns:
+        npt.NDArray[np.int32]: Shape ``(num_cells,)`` owner ranks; ``-1`` for
+        inactive cells, otherwise in ``range(n_parts)``.
+
+    Raises:
+        ValueError: If ``n_parts`` exceeds the number of active cells.
+    """
+    n_cells = grid.num_cells
+    active_idx = np.arange(n_cells) if active is None else np.flatnonzero(active)
+    n_active = int(active_idx.size)
+    if n_parts > n_active:
+        raise ValueError(
+            f"n_parts={n_parts} exceeds the number of active cells ({n_active}); "
+            f"cannot assign every rank a cell."
+        )
+
+    cell_lo, cell_hi = grid.collect_cell_bounds()
+    centroids = (0.5 * (cell_lo + cell_hi))[active_idx]
+    w_active = np.ones(n_active) if weights is None else weights[active_idx]
+
+    owner_active = np.empty(n_active, dtype=np.int32)
+
+    def bisect(idx: npt.NDArray[np.intp], part_lo: int, part_hi: int) -> None:
+        # Split cells `idx` into parts [part_lo, part_hi) by weight, cutting the
+        # longest-spread axis at the (clamped) weighted split point so that each
+        # side keeps at least as many cells as parts (no rank is left empty).
+        k = part_hi - part_lo
+        if k == 1:
+            owner_active[idx] = part_lo
+            return
+        coords = centroids[idx]
+        axis = int(np.argmax(coords.max(axis=0) - coords.min(axis=0)))
+        order = idx[np.argsort(coords[:, axis], kind="stable")]
+        cumw = np.cumsum(w_active[order])
+        k_left = k // 2
+        target = float(cumw[-1]) * k_left / k
+        split = int(np.searchsorted(cumw, target, side="left")) + 1
+        split = max(k_left, min(split, int(order.size) - (k - k_left)))
+        bisect(order[:split], part_lo, part_lo + k_left)
+        bisect(order[split:], part_lo + k_left, part_hi)
+
+    bisect(np.arange(n_active), 0, n_parts)
+
+    owner = np.full(n_cells, -1, dtype=np.int32)
+    owner[active_idx] = owner_active
     return cast("npt.NDArray[np.int32]", owner)
 
 

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -166,7 +166,7 @@ def test_rcb_2d_balances_count() -> None:
     part = partition_grid(grid, 4, backend="rcb")
     _assert_full_partition(part, 4, 100)
     counts = np.bincount(part.cell_owner, minlength=4)
-    assert counts.max() - counts.min() <= 1
+    assert counts.min() == 25 and counts.max() == 25
 
 
 def test_rcb_1d_parts_are_contiguous() -> None:
@@ -197,6 +197,41 @@ def test_rcb_respects_cell_active() -> None:
     assert set(owner[:5].tolist()) == {0, 1}
     np.testing.assert_array_equal(part.active_mask, active)
     _assert_full_partition(part, 2, 5)
+
+
+def test_rcb_non_contiguous_active_cells() -> None:
+    # Alternating active/inactive cells: exercises the active_idx scatter-back path.
+    grid = uniform_grid([[0.0, 1.0]], 10)
+    active = np.array([True, False, True, False, True, False, True, False, True, False])
+    part = partition_grid(grid, 2, backend="rcb", cell_active=active)
+    owner = part.cell_owner
+    np.testing.assert_array_equal(owner[1::2], -1)
+    assert set(owner[0::2].tolist()) == {0, 1}
+    np.testing.assert_array_equal(part.active_mask, active)
+    _assert_full_partition(part, 2, 5)
+
+
+def test_rcb_combined_weights_and_active() -> None:
+    # Cells 0-7 active (weights [1]*7+[7]); cells 8-9 inactive.
+    # rcb must slice weights to active cells and balance total weight (7+7=14).
+    grid = uniform_grid([[0.0, 1.0]], 10)
+    weights = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 7.0, 0.0, 0.0]
+    active = np.array([True] * 8 + [False, False])
+    part = partition_grid(grid, 2, backend="rcb", cell_weights=weights, cell_active=active)
+    owner = part.cell_owner
+    assert np.all(owner[8:] == -1)
+    w = np.asarray(weights)
+    part_weights = np.array([w[owner == r].sum() for r in range(2)])
+    np.testing.assert_allclose(part_weights, [7.0, 7.0])
+
+
+def test_rcb_n_parts_one_with_active() -> None:
+    # n_parts=1 hits the k==1 base case immediately; inactive cells must stay -1.
+    grid = uniform_grid([[0.0, 1.0]], 6)
+    active = np.array([True, False, True, False, True, False])
+    owner = partition_grid(grid, 1, backend="rcb", cell_active=active).cell_owner
+    np.testing.assert_array_equal(owner[1::2], -1)
+    np.testing.assert_array_equal(owner[0::2], 0)
 
 
 def test_rcb_on_hierarchical_grid() -> None:

--- a/tests/test_partition_grid.py
+++ b/tests/test_partition_grid.py
@@ -1,4 +1,4 @@
-"""Tests for the native block partitioner :func:`pantr.grid.partition_grid`."""
+"""Tests for :func:`pantr.grid.partition_grid` (block, rcb, and auto backends)."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ def _assert_owner_boxes(owner: npt.NDArray[Any], cells_per_axis: tuple[int, ...]
 
 
 # --------------------------------------------------------------------------- #
-# Invariants over a sweep of grids and part counts
+# block backend: invariants over a sweep of grids and part counts
 # --------------------------------------------------------------------------- #
 
 
@@ -54,7 +54,7 @@ def test_block_partition_invariants(cells_per_axis: tuple[int, ...], n_parts: in
     grid = uniform_grid([[0.0, 1.0]] * len(cells_per_axis), list(cells_per_axis))
     num_cells = grid.num_cells
     try:
-        part = partition_grid(grid, n_parts)
+        part = partition_grid(grid, n_parts, backend="block")
     except ValueError:
         # Infeasible factorization for this grid/part count; covered separately.
         return
@@ -76,35 +76,35 @@ def test_block_partition_invariants(cells_per_axis: tuple[int, ...], n_parts: in
 
 def test_block_partition_is_deterministic() -> None:
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [6, 4])
-    a = partition_grid(grid, 6).cell_owner
-    b = partition_grid(grid, 6).cell_owner
+    a = partition_grid(grid, 6, backend="block").cell_owner
+    b = partition_grid(grid, 6, backend="block").cell_owner
     np.testing.assert_array_equal(a, b)
 
 
 def test_block_load_is_balanced() -> None:
     # 1D uneven split: each rank gets floor or ceil of num_cells/n_parts.
     grid = uniform_grid([[0.0, 1.0]], 7)
-    owner = partition_grid(grid, 3).cell_owner
+    owner = partition_grid(grid, 3, backend="block").cell_owner
     counts = np.bincount(owner, minlength=3)
     assert int(counts.min()) == 7 // 3
     assert int(counts.max()) == math.ceil(7 / 3)
 
 
 # --------------------------------------------------------------------------- #
-# Exact, hand-computed cases
+# block backend: exact, hand-computed cases
 # --------------------------------------------------------------------------- #
 
 
 def test_block_1d_even_split() -> None:
     grid = uniform_grid([[0.0, 1.0]], 8)
-    owner = partition_grid(grid, 4).cell_owner
+    owner = partition_grid(grid, 4, backend="block").cell_owner
     np.testing.assert_array_equal(owner, [0, 0, 1, 1, 2, 2, 3, 3])
 
 
 def test_block_2d_four_parts() -> None:
     # (4, 4) into 4 -> blocks (2, 2); owner = (i0 // 2) * 2 + (i1 // 2).
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
-    owner = partition_grid(grid, 4).cell_owner
+    owner = partition_grid(grid, 4, backend="block").cell_owner
     i0, i1 = np.unravel_index(np.arange(16), (4, 4))
     expected = (i0 // 2) * 2 + (i1 // 2)
     np.testing.assert_array_equal(owner, expected)
@@ -113,7 +113,7 @@ def test_block_2d_four_parts() -> None:
 def test_block_is_aspect_ratio_aware() -> None:
     # (8, 2) into 4: cube-like blocks are (4, 1), so owner depends only on axis 0.
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [8, 2])
-    owner = partition_grid(grid, 4).cell_owner.reshape(8, 2)
+    owner = partition_grid(grid, 4, backend="block").cell_owner.reshape(8, 2)
     # Constant across axis 1 (the short axis was not split)...
     assert np.all(owner[:, 0] == owner[:, 1])
     # ...and varies along axis 0 (the long axis was split into 4).
@@ -122,26 +122,156 @@ def test_block_is_aspect_ratio_aware() -> None:
 
 def test_block_n_parts_one() -> None:
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [5, 3])
-    part = partition_grid(grid, 1)
+    part = partition_grid(grid, 1, backend="block")
     assert part.n_parts == 1
     assert np.all(part.cell_owner == 0)
 
 
 def test_block_n_parts_equals_num_cells_is_bijection() -> None:
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [3, 3])
-    owner = partition_grid(grid, 9).cell_owner
+    owner = partition_grid(grid, 9, backend="block").cell_owner
     np.testing.assert_array_equal(np.sort(owner), np.arange(9))
 
 
 def test_block_single_cell_axis_concentrates_blocks() -> None:
     # (1, 8) into 4: axis 0 has 1 cell so all blocks must go on axis 1.
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [1, 8])
-    owner = partition_grid(grid, 4).cell_owner
+    owner = partition_grid(grid, 4, backend="block").cell_owner
     np.testing.assert_array_equal(owner, np.repeat(np.arange(4), 2))
 
 
 # --------------------------------------------------------------------------- #
-# Error handling
+# rcb backend
+# --------------------------------------------------------------------------- #
+
+
+def _assert_full_partition(part: Partition, n_parts: int, n_active: int) -> None:
+    """Assert every active cell is assigned, all ranks used, no rank empty."""
+    owner = part.cell_owner
+    assert part.n_parts == n_parts
+    assert int(np.count_nonzero(owner >= 0)) == n_active
+    assert set(owner[owner >= 0].tolist()) == set(range(n_parts))
+
+
+def test_rcb_balances_count_when_uniform() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 100)
+    part = partition_grid(grid, 4, backend="rcb")
+    _assert_full_partition(part, 4, 100)
+    counts = np.bincount(part.cell_owner, minlength=4)
+    assert counts.min() == 25 and counts.max() == 25
+
+
+def test_rcb_2d_balances_count() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [10, 10])
+    part = partition_grid(grid, 4, backend="rcb")
+    _assert_full_partition(part, 4, 100)
+    counts = np.bincount(part.cell_owner, minlength=4)
+    assert counts.max() - counts.min() <= 1
+
+
+def test_rcb_1d_parts_are_contiguous() -> None:
+    # In 1D, rcb sorts by the single coordinate, so part ids are non-decreasing.
+    grid = uniform_grid([[0.0, 1.0]], 30)
+    owner = partition_grid(grid, 4, backend="rcb").cell_owner
+    assert np.all(np.diff(owner) >= 0)
+
+
+def test_rcb_balances_weight_not_count() -> None:
+    # One heavy cell: rcb balances total weight, so the heavy cell gets a part alone.
+    grid = uniform_grid([[0.0, 1.0]], 8)
+    weights = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 7.0]
+    owner = partition_grid(grid, 2, backend="rcb", cell_weights=weights).cell_owner
+    counts = np.bincount(owner, minlength=2)
+    w = np.asarray(weights)
+    part_weights = np.array([w[owner == r].sum() for r in range(2)])
+    np.testing.assert_allclose(part_weights, [7.0, 7.0])
+    assert sorted(counts.tolist()) == [1, 7]
+
+
+def test_rcb_respects_cell_active() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 10)
+    active = np.array([True] * 5 + [False] * 5)
+    part = partition_grid(grid, 2, backend="rcb", cell_active=active)
+    owner = part.cell_owner
+    assert np.all(owner[5:] == -1)
+    assert set(owner[:5].tolist()) == {0, 1}
+    np.testing.assert_array_equal(part.active_mask, active)
+    _assert_full_partition(part, 2, 5)
+
+
+def test_rcb_on_hierarchical_grid() -> None:
+    hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+    part = partition_grid(hgrid, 3, backend="rcb")
+    _assert_full_partition(part, 3, hgrid.num_cells)
+
+
+def test_rcb_n_parts_one() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+    owner = partition_grid(grid, 1, backend="rcb").cell_owner
+    assert np.all(owner == 0)
+
+
+def test_rcb_n_parts_equals_n_active_is_bijection() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 6)
+    owner = partition_grid(grid, 6, backend="rcb").cell_owner
+    np.testing.assert_array_equal(np.sort(owner), np.arange(6))
+
+
+def test_rcb_is_deterministic() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [7, 5])
+    a = partition_grid(grid, 5, backend="rcb").cell_owner
+    b = partition_grid(grid, 5, backend="rcb").cell_owner
+    np.testing.assert_array_equal(a, b)
+
+
+def test_rcb_n_parts_exceeds_active_raises() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="exceeds the number of active cells"):
+        partition_grid(grid, 5, backend="rcb")
+
+
+def test_rcb_n_parts_exceeds_active_with_mask_raises() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 10)
+    active = np.array([True] * 3 + [False] * 7)
+    with pytest.raises(ValueError, match="exceeds the number of active cells"):
+        partition_grid(grid, 4, backend="rcb", cell_active=active)
+
+
+# --------------------------------------------------------------------------- #
+# auto dispatch
+# --------------------------------------------------------------------------- #
+
+
+def test_auto_uses_block_for_tp_feasible() -> None:
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+    auto = partition_grid(grid, 4).cell_owner
+    block = partition_grid(grid, 4, backend="block").cell_owner
+    np.testing.assert_array_equal(auto, block)
+
+
+def test_auto_falls_back_to_rcb_for_prime_n() -> None:
+    # 7 cannot factor onto (4, 4); auto must fall back to rcb instead of raising.
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
+    part = partition_grid(grid, 7)  # default backend="auto"
+    _assert_full_partition(part, 7, 16)
+
+
+def test_auto_uses_rcb_when_weights_given() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 8)
+    weights = [1.0] * 7 + [7.0]
+    part = partition_grid(grid, 2, cell_weights=weights)
+    part_weights = np.array([np.asarray(weights)[part.cell_owner == r].sum() for r in range(2)])
+    np.testing.assert_allclose(part_weights, [7.0, 7.0])
+
+
+def test_auto_uses_rcb_for_hierarchical_grid() -> None:
+    hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    part = partition_grid(hgrid, 2)  # not tensor-product -> rcb
+    _assert_full_partition(part, 2, hgrid.num_cells)
+
+
+# --------------------------------------------------------------------------- #
+# Error handling and hook validation
 # --------------------------------------------------------------------------- #
 
 
@@ -155,27 +285,65 @@ def test_invalid_n_parts_raises(n_parts: int) -> None:
 def test_unknown_backend_raises() -> None:
     grid = uniform_grid([[0.0, 1.0]], 4)
     with pytest.raises(ValueError, match="unknown backend"):
-        partition_grid(grid, 2, backend="rcb")
+        partition_grid(grid, 2, backend="metis")
 
 
 def test_block_on_non_tensor_product_grid_raises() -> None:
     hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
     with pytest.raises(ValueError, match="requires a TensorProductGrid"):
-        partition_grid(hgrid, 2)
+        partition_grid(hgrid, 2, backend="block")
+
+
+def test_block_rejects_cell_weights() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="does not support cell_weights"):
+        partition_grid(grid, 2, backend="block", cell_weights=[1.0, 1.0, 1.0, 1.0])
+
+
+def test_block_rejects_cell_active() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="does not support cell_weights or cell_active"):
+        partition_grid(grid, 2, backend="block", cell_active=[True, True, True, False])
 
 
 def test_infeasible_factorization_raises() -> None:
-    # 7 is prime and larger than every axis (4), so no non-empty box split exists.
+    # 7 is prime and larger than every axis (4); block has no non-empty box split.
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4])
     with pytest.raises(ValueError, match="cannot factor n_parts"):
-        partition_grid(grid, 7)
+        partition_grid(grid, 7, backend="block")
 
 
 def test_infeasible_1d_n_parts_exceeds_cells_raises() -> None:
-    # 1D: n_parts=7 > num_cells=4; the final-axis check rejects it.
+    # 1D: n_parts=7 > num_cells=4; the block final-axis check rejects it.
     grid = uniform_grid([[0.0, 1.0]], 4)
     with pytest.raises(ValueError, match="cannot factor n_parts"):
-        partition_grid(grid, 7)
+        partition_grid(grid, 7, backend="block")
+
+
+@pytest.mark.parametrize("bad_weights", [[1.0, 2.0], [1.0, 2.0, 3.0, 4.0, 5.0]])
+def test_cell_weights_wrong_shape_raises(bad_weights: list[float]) -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="cell_weights must have shape"):
+        partition_grid(grid, 2, backend="rcb", cell_weights=bad_weights)
+
+
+@pytest.mark.parametrize("bad", [[1.0, -1.0, 1.0, 1.0], [1.0, np.inf, 1.0, 1.0]])
+def test_cell_weights_invalid_values_raise(bad: list[float]) -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        partition_grid(grid, 2, backend="rcb", cell_weights=bad)
+
+
+def test_cell_active_wrong_shape_raises() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="cell_active must have shape"):
+        partition_grid(grid, 2, backend="rcb", cell_active=[True, False])
+
+
+def test_cell_active_all_false_raises() -> None:
+    grid = uniform_grid([[0.0, 1.0]], 4)
+    with pytest.raises(ValueError, match="at least one cell active"):
+        partition_grid(grid, 2, backend="rcb", cell_active=[False, False, False, False])
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Second PR of **Phase B**. Extends `partition_grid` with the weight/activity-aware `rcb` backend, an `auto` dispatch, and the immersion hooks — completing the zero-dependency partitioner surface.

- **`rcb` backend** — recursive coordinate bisection over cell centroids (`Grid.collect_cell_bounds()` midpoints). **Geometric and grid-agnostic**: works on any `Grid` (incl. `HierarchicalGrid`), immersed or not. Bisects the part count `k → (k//2, k−k//2)`, cutting the longest-spread axis at the **weighted** split point; the split index is clamped to `[k_left, L−k_right]` so **no rank is ever empty**. Balances total weight (not cell count). Raises if `n_parts` exceeds the number of active cells.
- **`backend="auto"` (new default)** — picks `block` when the grid is tensor-product, no hooks are given, and `n_parts` factors onto the axes; otherwise `rcb`. So prime/awkward part counts that `block` rejects (e.g. `(4,4)`/7) now just succeed via `rcb`. `backend="block"` stays strict.
- **Immersion hooks** — `cell_weights` (per-cell cost; `rcb` balances total weight) and `cell_active` (boolean mask; inactive cells excluded with owner `-1`), validated in Layer 2. `block` rejects both. pantr stores no classification — the consumer drives weighting/activity.

Existing block-specific tests are pinned to `backend="block"` (the default changed from `"block"` to `"auto"`, and `"rcb"` is now a valid backend).

## Test plan

- [x] **rcb**: count balance (uniform), weight balance (heavy-cell case → weight-equal, count-unequal), 1D contiguity, activity (`-1` placement + active-subset partition + `active_mask`), runs on `HierarchicalGrid`, `n_parts=1`/`=n_active` bijection, determinism, `n_parts > #active` → raise (with and without mask).
- [x] **auto**: TP+feasible → equals `block`; TP+prime → `rcb` (no raise, full coverage); weights → `rcb`; hierarchical → `rcb`.
- [x] **hooks/errors**: `block` rejects weights/activity; weight shape/finiteness/sign; active shape/all-false; unknown backend; non-TP under `block`; infeasible factorization under `block`.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT; full suite 3308 passed (1 skipped); docs `-W` ok; `_partition_grid.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)