### PR TITLE
feat(bspline): cell-coupling graph for graph partitioning (B3 of #142)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -36,6 +36,9 @@ This package consolidates the B-spline API:
 - :func:`build_local`, :class:`LocalSpace`: build a rank's windowed local space
   (cell/DOF maps and ownership masks) from a global space and a
   :class:`pantr.grid.Partition`.
+- :func:`coupling_graph`, :class:`CouplingGraph`: cell-coupling (dual) graph of a
+  space -- cells sharing basis functions, weighted by the number shared -- in
+  METIS / Scotch CSR format, for graph-based partitioning.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -51,6 +54,7 @@ from ._bspline_space_factory import (
     get_greville_abscissae,
 )
 from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
+from ._coupling_graph import CouplingGraph, coupling_graph
 from ._local_space import LocalSpace, build_local, compute_halo, dof_owner
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
@@ -67,6 +71,7 @@ __all__ = [
     "BsplineSpace",
     "BsplineSpace1D",
     "BsplineSpaceRestriction",
+    "CouplingGraph",
     "ExtractionStructView",
     "LocalSpace",
     "MultiLevelExtraction",
@@ -76,6 +81,7 @@ __all__ = [
     "THBSplineSpaceRestriction",
     "build_local",
     "compute_halo",
+    "coupling_graph",
     "create_cardinal_knots",
     "create_from_bezier",
     "create_greville_lattice",

--- a/src/pantr/bspline/_coupling_graph.py
+++ b/src/pantr/bspline/_coupling_graph.py
@@ -225,6 +225,7 @@ def _validate_vertex_weights(
         ValueError: If the shape is not ``(n_cells,)`` or any entry is negative or
             non-finite.
     """
+    weights: npt.NDArray[np.float64]
     if cell_weights is None:
         weights = np.ones(n_cells, dtype=np.float64)
     else:
@@ -234,7 +235,7 @@ def _validate_vertex_weights(
         if not bool(np.all(np.isfinite(weights))) or bool(np.any(weights < 0.0)):
             raise ValueError("cell_weights must be finite and non-negative.")
     weights.flags.writeable = False
-    return cast("npt.NDArray[np.float64]", weights)
+    return weights
 
 
 __all__ = ["CouplingGraph", "coupling_graph"]

--- a/src/pantr/bspline/_coupling_graph.py
+++ b/src/pantr/bspline/_coupling_graph.py
@@ -32,22 +32,18 @@ class CouplingGraph(NamedTuple):
     """Cell-coupling graph of a space, in METIS / Scotch CSR adjacency format.
 
     A :class:`typing.NamedTuple` returned by :func:`coupling_graph`. The graph is
-    undirected (symmetric adjacency) and has no self-loops. All array fields are
-    read-only.
+    undirected (symmetric adjacency) and has no self-loops:
 
-    Attributes:
-        num_vertices (int): Number of cells (graph vertices).
-        xadj (npt.NDArray[np.int64]): CSR row pointers, shape ``(num_vertices + 1,)``;
-            the neighbors of cell ``c`` are ``adjncy[xadj[c]:xadj[c + 1]]``.
-            (METIS ``xadj``.)
-        adjncy (npt.NDArray[np.int64]): Concatenated neighbor cell ids, shape
-            ``(xadj[-1],)``. (METIS ``adjncy``.)
-        edge_weights (npt.NDArray[np.int64]): Per-adjacency-entry weight = number of
-            basis functions the two cells share, aligned with ``adjncy``.
-            (METIS ``adjwgt``.)
-        vertex_weights (npt.NDArray[np.float64]): Per-cell weight (assembly cost),
-            shape ``(num_vertices,)``; uniform ``1.0`` unless ``cell_weights`` was
-            given. (METIS ``vwgt``.)
+    - ``num_vertices`` -- number of cells (graph vertices).
+    - ``xadj`` -- CSR row pointers, shape ``(num_vertices + 1,)``; the neighbors of
+      cell ``c`` are ``adjncy[xadj[c]:xadj[c + 1]]``. (METIS ``xadj``.) Read-only.
+    - ``adjncy`` -- concatenated neighbor cell ids, shape ``(xadj[-1],)``. (METIS
+      ``adjncy``.) Read-only.
+    - ``edge_weights`` -- per-adjacency-entry weight = number of basis functions the
+      two cells share, aligned with ``adjncy``. (METIS ``adjwgt``.) Read-only.
+    - ``vertex_weights`` -- per-cell weight (assembly cost), shape
+      ``(num_vertices,)``; uniform ``1.0`` unless ``cell_weights`` was given. (METIS
+      ``vwgt``.) Read-only.
     """
 
     num_vertices: int

--- a/src/pantr/bspline/_coupling_graph.py
+++ b/src/pantr/bspline/_coupling_graph.py
@@ -1,0 +1,240 @@
+"""Cell-coupling (dual) graph of a B-spline or THB-spline space.
+
+Builds the graph whose vertices are the cells of a space's grid and whose edges
+join cells that share at least one basis function (DOF), weighted by the number
+of shared functions. This is the input a graph partitioner (METIS / Scotch)
+needs to minimize cross-rank DOF coupling; it is produced serially with no MPI
+and no external dependency, and consumed later by the optional graph-partition
+backends.
+
+The graph is emitted in the standard CSR adjacency format used by METIS and
+Scotch (``xadj`` / ``adjncy`` / ``adjwgt`` / ``vwgt``), so a backend can hand it
+to those libraries with no reshaping.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, cast
+
+import numpy as np
+from scipy import sparse
+
+from ._bspline_space_nd import BsplineSpace
+from ._local_space import _reject_periodic
+from ._thb_spline_space import THBSplineSpace, _func_support_1d
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class CouplingGraph(NamedTuple):
+    """Cell-coupling graph of a space, in METIS / Scotch CSR adjacency format.
+
+    A :class:`typing.NamedTuple` returned by :func:`coupling_graph`. The graph is
+    undirected (symmetric adjacency) and has no self-loops:
+
+    - ``num_vertices`` -- number of cells (graph vertices).
+    - ``xadj`` -- CSR row pointers, shape ``(num_vertices + 1,)``; the neighbors of
+      cell ``c`` are ``adjncy[xadj[c]:xadj[c + 1]]``. (METIS ``xadj``.) Read-only.
+    - ``adjncy`` -- concatenated neighbor cell ids, shape ``(xadj[-1],)``. (METIS
+      ``adjncy``.) Read-only.
+    - ``edge_weights`` -- per-adjacency-entry weight = number of basis functions the
+      two cells share, aligned with ``adjncy``. (METIS ``adjwgt``.) Read-only.
+    - ``vertex_weights`` -- per-cell weight (assembly cost), shape
+      ``(num_vertices,)``; uniform ``1.0`` unless ``cell_weights`` was given. (METIS
+      ``vwgt``.) Read-only.
+    """
+
+    num_vertices: int
+    xadj: npt.NDArray[np.int64]
+    adjncy: npt.NDArray[np.int64]
+    edge_weights: npt.NDArray[np.int64]
+    vertex_weights: npt.NDArray[np.float64]
+
+
+def coupling_graph(
+    space: BsplineSpace | THBSplineSpace,
+    *,
+    cell_weights: npt.ArrayLike | None = None,
+) -> CouplingGraph:
+    """Build the cell-coupling graph of a B-spline or THB-spline space.
+
+    Two cells are joined by an edge when they share at least one basis function;
+    the edge weight is the number of shared functions, and each vertex (cell)
+    carries an optional assembly-cost weight. The result is the dual graph a
+    graph partitioner uses to minimize cross-rank DOF coupling.
+
+    Args:
+        space (BsplineSpace | THBSplineSpace): The space whose cells to couple. A
+            :class:`BsplineSpace` must be non-periodic.
+        cell_weights (npt.ArrayLike | None): Optional per-cell assembly cost, shape
+            ``(num_cells,)``, finite and non-negative. ``None`` means uniform.
+
+    Returns:
+        CouplingGraph: The coupling graph in METIS / Scotch CSR adjacency format.
+
+    Raises:
+        TypeError: If ``space`` is neither a :class:`BsplineSpace` nor a
+            :class:`THBSplineSpace`.
+        ValueError: If ``space`` is a periodic :class:`BsplineSpace`, or if
+            ``cell_weights`` has the wrong shape or invalid values.
+
+    Example:
+        >>> from pantr.bspline import coupling_graph, create_uniform_space
+        >>> space = create_uniform_space(2, 4)
+        >>> graph = coupling_graph(space)
+        >>> graph.num_vertices
+        4
+        >>> int(graph.xadj[-1]) == graph.adjncy.size
+        True
+    """
+    if isinstance(space, THBSplineSpace):
+        n_cells = space.grid.num_cells
+        n_dofs = space.num_total_basis
+        rows, cols = _thb_incidence(space)
+    elif isinstance(space, BsplineSpace):
+        _reject_periodic(space)
+        n_cells = space.num_total_intervals
+        n_dofs = space.num_total_basis
+        rows, cols = _tp_incidence(space)
+    else:
+        raise TypeError(
+            f"coupling_graph expects a BsplineSpace or THBSplineSpace; got {type(space).__name__}."
+        )
+    vertex_weights = _validate_vertex_weights(cell_weights, n_cells)
+    return _dual_graph(rows, cols, n_cells, n_dofs, vertex_weights)
+
+
+def _tp_incidence(space: BsplineSpace) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    """Build the cell -> DOF incidence (row, col) pairs for a tensor-product space.
+
+    Cell ``c`` (multi-index ``i``) is supported by the tensor product of the per-axis
+    function ranges ``[fb_d[i_d], fb_d[i_d] + degree_d]``, where ``fb_d`` is the first
+    function non-zero on each cell along axis ``d``. Cells and DOFs are flat-indexed in
+    C-order over ``num_intervals`` and ``num_basis`` respectively.
+
+    Args:
+        space (BsplineSpace): Non-periodic tensor-product B-spline space.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ``(rows, cols)`` cell ids
+        and the global DOF ids they support, one entry per (cell, supported DOF).
+    """
+    num_intervals = space.num_intervals
+    num_basis = space.num_basis
+    n_cells = space.num_total_intervals
+    fb_axes = [_func_support_1d(sp)[0].astype(np.int64) for sp in space.spaces]
+
+    offset_grids = np.meshgrid(*[np.arange(sp.degree + 1) for sp in space.spaces], indexing="ij")
+    local_offsets = [grid.ravel() for grid in offset_grids]
+    cell_multi = np.unravel_index(np.arange(n_cells), num_intervals)
+    func_per_axis = [
+        fb_axes[d][cell_multi[d]][:, None] + local_offsets[d][None, :] for d in range(space.dim)
+    ]
+    dof_ids = np.ravel_multi_index(func_per_axis, num_basis)
+
+    k = dof_ids.shape[1]
+    rows = np.repeat(np.arange(n_cells, dtype=np.int64), k)
+    cols = dof_ids.ravel().astype(np.int64)
+    return rows, cols
+
+
+def _thb_incidence(space: THBSplineSpace) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    """Build the cell -> DOF incidence (row, col) pairs for a THB-spline space.
+
+    Uses :meth:`THBSplineSpace.active_basis` for the active global DOF ids on each cell.
+
+    Args:
+        space (THBSplineSpace): The hierarchical space.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ``(rows, cols)`` cell ids
+        and the global DOF ids they support, one entry per (cell, active DOF).
+    """
+    # A grid always has at least one cell, so the lists are never empty.
+    rows_list: list[npt.NDArray[np.int64]] = []
+    cols_list: list[npt.NDArray[np.int64]] = []
+    for cid in range(space.grid.num_cells):
+        dofs = np.asarray(space.active_basis(cid), dtype=np.int64)
+        rows_list.append(np.full(dofs.size, cid, dtype=np.int64))
+        cols_list.append(dofs)
+    return np.concatenate(rows_list), np.concatenate(cols_list)
+
+
+def _dual_graph(
+    rows: npt.NDArray[np.int64],
+    cols: npt.NDArray[np.int64],
+    n_cells: int,
+    n_dofs: int,
+    vertex_weights: npt.NDArray[np.float64],
+) -> CouplingGraph:
+    """Assemble the dual graph from a cell -> DOF incidence.
+
+    Forms the boolean cell-by-DOF incidence ``B`` and the symmetric product
+    ``B @ B.T``: its off-diagonal entry ``(i, j)`` counts the DOFs cells ``i`` and ``j``
+    share. The diagonal (self-coupling) is dropped, leaving the CSR adjacency.
+
+    Args:
+        rows (npt.NDArray[np.int64]): Cell ids of the incidence entries.
+        cols (npt.NDArray[np.int64]): Supported global DOF ids, aligned with ``rows``.
+        n_cells (int): Number of cells (graph vertices).
+        n_dofs (int): Number of global DOFs.
+        vertex_weights (npt.NDArray[np.float64]): Per-cell weights (already validated).
+
+    Returns:
+        CouplingGraph: The assembled coupling graph.
+    """
+    incidence = sparse.csr_matrix(
+        (np.ones(rows.size, dtype=np.int64), (rows, cols)),
+        shape=(n_cells, n_dofs),
+    )
+    coupling = (incidence @ incidence.T).tocsr()
+    coupling.setdiag(0)
+    coupling.eliminate_zeros()
+    coupling.sort_indices()
+
+    xadj = coupling.indptr.astype(np.int64)
+    adjncy = coupling.indices.astype(np.int64)
+    edge_weights = coupling.data.astype(np.int64)
+    for arr in (xadj, adjncy, edge_weights):
+        arr.flags.writeable = False
+    return CouplingGraph(
+        int(n_cells),
+        cast("npt.NDArray[np.int64]", xadj),
+        cast("npt.NDArray[np.int64]", adjncy),
+        cast("npt.NDArray[np.int64]", edge_weights),
+        vertex_weights,
+    )
+
+
+def _validate_vertex_weights(
+    cell_weights: npt.ArrayLike | None, n_cells: int
+) -> npt.NDArray[np.float64]:
+    """Validate and coerce ``cell_weights`` to a read-only ``(n_cells,)`` array.
+
+    Args:
+        cell_weights (npt.ArrayLike | None): Candidate per-cell weights, or ``None``
+            for uniform.
+        n_cells (int): Expected length.
+
+    Returns:
+        npt.NDArray[np.float64]: Read-only weights; uniform ``1.0`` if input was
+        ``None``.
+
+    Raises:
+        ValueError: If the shape is not ``(n_cells,)`` or any entry is negative or
+            non-finite.
+    """
+    if cell_weights is None:
+        weights = np.ones(n_cells, dtype=np.float64)
+    else:
+        weights = np.array(cell_weights, dtype=np.float64)
+        if weights.shape != (n_cells,):
+            raise ValueError(f"cell_weights must have shape ({n_cells},); got {weights.shape}.")
+        if not bool(np.all(np.isfinite(weights))) or bool(np.any(weights < 0.0)):
+            raise ValueError("cell_weights must be finite and non-negative.")
+    weights.flags.writeable = False
+    return cast("npt.NDArray[np.float64]", weights)
+
+
+__all__ = ["CouplingGraph", "coupling_graph"]

--- a/src/pantr/bspline/_coupling_graph.py
+++ b/src/pantr/bspline/_coupling_graph.py
@@ -8,7 +8,8 @@ and no external dependency, and consumed later by the optional graph-partition
 backends.
 
 The graph is emitted in the standard CSR adjacency format used by METIS and
-Scotch (``xadj`` / ``adjncy`` / ``adjwgt`` / ``vwgt``), so a backend can hand it
+Scotch (``xadj`` / ``adjncy`` / ``edge_weights`` / ``vertex_weights``, corresponding
+to METIS ``xadj`` / ``adjncy`` / ``adjwgt`` / ``vwgt``), so a backend can hand it
 to those libraries with no reshaping.
 """
 
@@ -31,18 +32,22 @@ class CouplingGraph(NamedTuple):
     """Cell-coupling graph of a space, in METIS / Scotch CSR adjacency format.
 
     A :class:`typing.NamedTuple` returned by :func:`coupling_graph`. The graph is
-    undirected (symmetric adjacency) and has no self-loops:
+    undirected (symmetric adjacency) and has no self-loops. All array fields are
+    read-only.
 
-    - ``num_vertices`` -- number of cells (graph vertices).
-    - ``xadj`` -- CSR row pointers, shape ``(num_vertices + 1,)``; the neighbors of
-      cell ``c`` are ``adjncy[xadj[c]:xadj[c + 1]]``. (METIS ``xadj``.) Read-only.
-    - ``adjncy`` -- concatenated neighbor cell ids, shape ``(xadj[-1],)``. (METIS
-      ``adjncy``.) Read-only.
-    - ``edge_weights`` -- per-adjacency-entry weight = number of basis functions the
-      two cells share, aligned with ``adjncy``. (METIS ``adjwgt``.) Read-only.
-    - ``vertex_weights`` -- per-cell weight (assembly cost), shape
-      ``(num_vertices,)``; uniform ``1.0`` unless ``cell_weights`` was given. (METIS
-      ``vwgt``.) Read-only.
+    Attributes:
+        num_vertices (int): Number of cells (graph vertices).
+        xadj (npt.NDArray[np.int64]): CSR row pointers, shape ``(num_vertices + 1,)``;
+            the neighbors of cell ``c`` are ``adjncy[xadj[c]:xadj[c + 1]]``.
+            (METIS ``xadj``.)
+        adjncy (npt.NDArray[np.int64]): Concatenated neighbor cell ids, shape
+            ``(xadj[-1],)``. (METIS ``adjncy``.)
+        edge_weights (npt.NDArray[np.int64]): Per-adjacency-entry weight = number of
+            basis functions the two cells share, aligned with ``adjncy``.
+            (METIS ``adjwgt``.)
+        vertex_weights (npt.NDArray[np.float64]): Per-cell weight (assembly cost),
+            shape ``(num_vertices,)``; uniform ``1.0`` unless ``cell_weights`` was
+            given. (METIS ``vwgt``.)
     """
 
     num_vertices: int
@@ -109,9 +114,10 @@ def _tp_incidence(space: BsplineSpace) -> tuple[npt.NDArray[np.int64], npt.NDArr
     """Build the cell -> DOF incidence (row, col) pairs for a tensor-product space.
 
     Cell ``c`` (multi-index ``i``) is supported by the tensor product of the per-axis
-    function ranges ``[fb_d[i_d], fb_d[i_d] + degree_d]``, where ``fb_d`` is the first
-    function non-zero on each cell along axis ``d``. Cells and DOFs are flat-indexed in
-    C-order over ``num_intervals`` and ``num_basis`` respectively.
+    function ranges ``fb_d[i_d], fb_d[i_d] + 1, ..., fb_d[i_d] + degree_d`` (that is,
+    ``degree_d + 1`` functions per axis), where ``fb_d`` is the first function non-zero
+    on each cell along axis ``d``. Cells and DOFs are flat-indexed in C-order over
+    ``num_intervals`` and ``num_basis`` respectively.
 
     Args:
         space (BsplineSpace): Non-periodic tensor-product B-spline space.
@@ -143,6 +149,9 @@ def _thb_incidence(space: THBSplineSpace) -> tuple[npt.NDArray[np.int64], npt.ND
     """Build the cell -> DOF incidence (row, col) pairs for a THB-spline space.
 
     Uses :meth:`THBSplineSpace.active_basis` for the active global DOF ids on each cell.
+    ``active_basis`` returns all functions whose untruncated support intersects the cell,
+    including truncated functions that may evaluate to zero there; edge weights therefore
+    count support-intersecting functions, not just non-zero ones.
 
     Args:
         space (THBSplineSpace): The hierarchical space.
@@ -151,7 +160,8 @@ def _thb_incidence(space: THBSplineSpace) -> tuple[npt.NDArray[np.int64], npt.ND
         tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ``(rows, cols)`` cell ids
         and the global DOF ids they support, one entry per (cell, active DOF).
     """
-    # A grid always has at least one cell, so the lists are never empty.
+    # grid.num_cells >= 1 is enforced by TensorProductGrid construction, so the loop
+    # always executes at least once and np.concatenate never receives an empty list.
     rows_list: list[npt.NDArray[np.int64]] = []
     cols_list: list[npt.NDArray[np.int64]] = []
     for cid in range(space.grid.num_cells):
@@ -170,9 +180,15 @@ def _dual_graph(
 ) -> CouplingGraph:
     """Assemble the dual graph from a cell -> DOF incidence.
 
-    Forms the boolean cell-by-DOF incidence ``B`` and the symmetric product
-    ``B @ B.T``: its off-diagonal entry ``(i, j)`` counts the DOFs cells ``i`` and ``j``
-    share. The diagonal (self-coupling) is dropped, leaving the CSR adjacency.
+    Forms the integer cell-by-DOF incidence ``B`` (entries are 1 for active
+    ``(cell, DOF)`` pairs) and the symmetric product ``B @ B.T``: its off-diagonal entry
+    ``(i, j)`` counts the DOFs cells ``i`` and ``j`` share. The diagonal (self-coupling)
+    is dropped, leaving the CSR adjacency.
+
+    Note:
+        ``rows`` / ``cols`` must be duplicate-free. ``scipy.sparse.csr_matrix`` sums
+        repeated ``(row, col)`` entries, so any duplicate ``(cell, DOF)`` pair would
+        silently inflate the edge weight for that cell pair.
 
     Args:
         rows (npt.NDArray[np.int64]): Cell ids of the incidence entries.

--- a/tests/test_coupling_graph.py
+++ b/tests/test_coupling_graph.py
@@ -1,0 +1,182 @@
+"""Tests for :func:`pantr.bspline.coupling_graph`."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import (
+    CouplingGraph,
+    THBSplineSpace,
+    coupling_graph,
+    create_uniform_space,
+)
+from pantr.grid import hierarchical_grid, uniform_grid
+
+
+def _dense(graph: CouplingGraph) -> npt.NDArray[np.int64]:
+    """Densify a CouplingGraph into a symmetric (n, n) edge-weight matrix."""
+    n = graph.num_vertices
+    mat: npt.NDArray[np.int64] = np.zeros((n, n), dtype=np.int64)
+    for c in range(n):
+        neighbors = graph.adjncy[graph.xadj[c] : graph.xadj[c + 1]]
+        weights = graph.edge_weights[graph.xadj[c] : graph.xadj[c + 1]]
+        mat[c, neighbors] = weights
+    return mat
+
+
+def _thb_two_level(*, truncate: bool = True) -> THBSplineSpace:
+    """A 1D two-level THB space: degree-2, 4 root cells, left half refined once."""
+    root = create_uniform_space(2, 4)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    grid.refine(0, [0], [2])
+    return THBSplineSpace(root, grid, truncate=truncate)
+
+
+# --------------------------------------------------------------------------- #
+# Tensor-product: closed-form coupling weights (independent of the impl)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("degree", [1, 2, 3])
+@pytest.mark.parametrize("n_cells", [4, 6, 7])
+def test_1d_coupling_closed_form(degree: int, n_cells: int) -> None:
+    # Open-uniform 1D B-splines: cells i, j share max(0, p + 1 - |i - j|) functions.
+    space = create_uniform_space(degree, n_cells)
+    graph = coupling_graph(space)
+    assert graph.num_vertices == n_cells
+
+    expected = np.zeros((n_cells, n_cells), dtype=np.int64)
+    for i in range(n_cells):
+        for j in range(n_cells):
+            if i != j:
+                expected[i, j] = max(0, degree + 1 - abs(i - j))
+    np.testing.assert_array_equal(_dense(graph), expected)
+
+
+@pytest.mark.parametrize(
+    ("degrees", "cells"),
+    [((1, 1), (3, 3)), ((2, 1), (3, 4)), ((2, 2), (4, 3))],
+)
+def test_2d_coupling_closed_form(degrees: tuple[int, int], cells: tuple[int, int]) -> None:
+    # Tensor product: shared functions = product of the per-axis shared counts.
+    space = create_uniform_space(list(degrees), list(cells))
+    graph = coupling_graph(space)
+    n = int(np.prod(cells))
+    assert graph.num_vertices == n
+
+    multi = np.array(np.unravel_index(np.arange(n), cells)).T
+    expected = np.zeros((n, n), dtype=np.int64)
+    for a in range(n):
+        for b in range(n):
+            if a != b:
+                weight = 1
+                for d in range(2):
+                    weight *= max(0, degrees[d] + 1 - abs(int(multi[a, d]) - int(multi[b, d])))
+                expected[a, b] = weight
+    np.testing.assert_array_equal(_dense(graph), expected)
+
+
+# --------------------------------------------------------------------------- #
+# THB: cross-check against active_basis intersections
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("truncate", [True, False])
+def test_thb_matches_active_basis_intersection(truncate: bool) -> None:
+    space = _thb_two_level(truncate=truncate)
+    graph = coupling_graph(space)
+    mat = _dense(graph)
+    n = space.grid.num_cells
+    dofs = [set(space.active_basis(c).tolist()) for c in range(n)]
+    for a in range(n):
+        for b in range(n):
+            shared = 0 if a == b else len(dofs[a] & dofs[b])
+            assert int(mat[a, b]) == shared
+
+
+# --------------------------------------------------------------------------- #
+# Structural invariants
+# --------------------------------------------------------------------------- #
+
+_INVARIANT_SPACES = [
+    create_uniform_space(2, 5),
+    create_uniform_space([2, 2], [3, 3]),
+    create_uniform_space([1, 2, 1], [2, 3, 2]),
+    _thb_two_level(),
+]
+_INVARIANT_IDS = ["tp_1d", "tp_2d", "tp_3d", "thb_2level"]
+
+
+@pytest.mark.parametrize("space", _INVARIANT_SPACES, ids=_INVARIANT_IDS)
+def test_graph_invariants(space: object) -> None:
+    graph = coupling_graph(space)  # type: ignore[arg-type]
+    n = graph.num_vertices
+
+    assert graph.xadj.shape == (n + 1,)
+    assert int(graph.xadj[0]) == 0
+    assert int(graph.xadj[-1]) == graph.adjncy.size
+    assert np.all(np.diff(graph.xadj) >= 0)
+    assert graph.edge_weights.shape == graph.adjncy.shape
+    if graph.adjncy.size:
+        assert int(graph.adjncy.min()) >= 0 and int(graph.adjncy.max()) < n
+        assert np.all(graph.edge_weights >= 1)
+
+    mat = _dense(graph)
+    assert np.array_equal(mat, mat.T), "coupling must be symmetric"
+    assert np.all(np.diag(mat) == 0), "no self-loops"
+
+    assert graph.vertex_weights.shape == (n,)
+    np.testing.assert_array_equal(graph.vertex_weights, 1.0)
+    for arr in (graph.xadj, graph.adjncy, graph.edge_weights, graph.vertex_weights):
+        assert not arr.flags.writeable
+
+
+def test_single_cell_has_no_edges() -> None:
+    space = create_uniform_space(2, 1)
+    graph = coupling_graph(space)
+    assert graph.num_vertices == 1
+    assert graph.adjncy.size == 0
+    assert graph.edge_weights.size == 0
+    np.testing.assert_array_equal(graph.xadj, [0, 0])
+
+
+# --------------------------------------------------------------------------- #
+# Vertex weights and error handling
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_cell_weights_passthrough() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4), cell_weights=[1.0, 2.0, 3.0, 4.0])
+    np.testing.assert_array_equal(graph.vertex_weights, [1.0, 2.0, 3.0, 4.0])
+    assert not graph.vertex_weights.flags.writeable
+
+
+def test_cell_weights_input_not_frozen() -> None:
+    weights = np.array([1.0, 2.0, 3.0, 4.0])
+    coupling_graph(create_uniform_space(2, 4), cell_weights=weights)
+    assert weights.flags.writeable, "the caller's array must not be frozen"
+
+
+@pytest.mark.parametrize("bad", [[1.0, 2.0], [1.0, 2.0, 3.0, 4.0, 5.0]])
+def test_cell_weights_wrong_shape_raises(bad: list[float]) -> None:
+    with pytest.raises(ValueError, match="cell_weights must have shape"):
+        coupling_graph(create_uniform_space(2, 4), cell_weights=bad)
+
+
+@pytest.mark.parametrize("bad", [[1.0, -1.0, 1.0, 1.0], [1.0, np.inf, 1.0, 1.0]])
+def test_cell_weights_invalid_values_raise(bad: list[float]) -> None:
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        coupling_graph(create_uniform_space(2, 4), cell_weights=bad)
+
+
+def test_periodic_space_raises() -> None:
+    space = create_uniform_space(2, 4, periodic=True)
+    with pytest.raises(ValueError, match="periodic"):
+        coupling_graph(space)
+
+
+def test_non_space_input_raises() -> None:
+    with pytest.raises(TypeError, match="BsplineSpace or THBSplineSpace"):
+        coupling_graph(uniform_grid([[0.0, 1.0]], 4))  # type: ignore[arg-type]

--- a/tests/test_coupling_graph.py
+++ b/tests/test_coupling_graph.py
@@ -39,7 +39,7 @@ def _thb_two_level(*, truncate: bool = True) -> THBSplineSpace:
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("degree", [1, 2, 3])
+@pytest.mark.parametrize("degree", [1, 2, 3, 4])
 @pytest.mark.parametrize("n_cells", [4, 6, 7])
 def test_1d_coupling_closed_form(degree: int, n_cells: int) -> None:
     # Open-uniform 1D B-splines: cells i, j share max(0, p + 1 - |i - j|) functions.
@@ -87,6 +87,7 @@ def test_2d_coupling_closed_form(degrees: tuple[int, int], cells: tuple[int, int
 def test_thb_matches_active_basis_intersection(truncate: bool) -> None:
     space = _thb_two_level(truncate=truncate)
     graph = coupling_graph(space)
+    assert graph.num_vertices == space.grid.num_cells
     mat = _dense(graph)
     n = space.grid.num_cells
     dofs = [set(space.active_basis(c).tolist()) for c in range(n)]
@@ -177,6 +178,33 @@ def test_periodic_space_raises() -> None:
         coupling_graph(space)
 
 
+def test_cell_weights_all_zero_accepted() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4), cell_weights=[0.0, 0.0, 0.0, 0.0])
+    np.testing.assert_array_equal(graph.vertex_weights, 0.0)
+    assert not graph.vertex_weights.flags.writeable
+
+
 def test_non_space_input_raises() -> None:
     with pytest.raises(TypeError, match="BsplineSpace or THBSplineSpace"):
         coupling_graph(uniform_grid([[0.0, 1.0]], 4))  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Reduced-continuity closed-form coupling
+# --------------------------------------------------------------------------- #
+
+
+def test_1d_coupling_reduced_continuity() -> None:
+    # C^0 (continuity=0) degree-2 space: adjacent cells share exactly 1 DOF,
+    # non-adjacent share 0 (vs max-continuity where adjacent cells share 2).
+    degree, n_cells = 2, 5
+    space = create_uniform_space(degree, n_cells, continuity=0)
+    graph = coupling_graph(space)
+    assert graph.num_vertices == n_cells
+
+    expected = np.zeros((n_cells, n_cells), dtype=np.int64)
+    for i in range(n_cells):
+        for j in range(n_cells):
+            if abs(i - j) == 1:
+                expected[i, j] = 1
+    np.testing.assert_array_equal(_dense(graph), expected)

--- a/tests/test_coupling_graph.py
+++ b/tests/test_coupling_graph.py
@@ -34,6 +34,23 @@ def _thb_two_level(*, truncate: bool = True) -> THBSplineSpace:
     return THBSplineSpace(root, grid, truncate=truncate)
 
 
+def _thb_two_level_2d() -> THBSplineSpace:
+    """A 2D two-level THB space: degree-(2,2), 4x4 root cells, lower-left quadrant refined."""
+    root = create_uniform_space([2, 2], [4, 4])
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+    grid.refine(0, [0, 0], [2, 2])
+    return THBSplineSpace(root, grid)
+
+
+def _thb_three_level() -> THBSplineSpace:
+    """A 1D three-level THB space: degree-2, 4 root cells, iterated left-half refinement."""
+    root = create_uniform_space(2, 4)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    grid.refine(0, [0], [2])
+    grid.refine(1, [0], [2])
+    return THBSplineSpace(root, grid)
+
+
 # --------------------------------------------------------------------------- #
 # Tensor-product: closed-form coupling weights (independent of the impl)
 # --------------------------------------------------------------------------- #
@@ -78,14 +95,37 @@ def test_2d_coupling_closed_form(degrees: tuple[int, int], cells: tuple[int, int
     np.testing.assert_array_equal(_dense(graph), expected)
 
 
+@pytest.mark.parametrize(
+    ("degrees", "cells"),
+    [((1, 2, 1), (2, 3, 2)), ((2, 2, 2), (3, 3, 3))],
+)
+def test_3d_coupling_closed_form(
+    degrees: tuple[int, int, int], cells: tuple[int, int, int]
+) -> None:
+    # Same closed-form as 2D generalised to 3 axes.
+    space = create_uniform_space(list(degrees), list(cells))
+    graph = coupling_graph(space)
+    n = int(np.prod(cells))
+    assert graph.num_vertices == n
+
+    multi = np.array(np.unravel_index(np.arange(n), cells)).T
+    expected = np.zeros((n, n), dtype=np.int64)
+    for a in range(n):
+        for b in range(n):
+            if a != b:
+                weight = 1
+                for d in range(3):
+                    weight *= max(0, degrees[d] + 1 - abs(int(multi[a, d]) - int(multi[b, d])))
+                expected[a, b] = weight
+    np.testing.assert_array_equal(_dense(graph), expected)
+
+
 # --------------------------------------------------------------------------- #
 # THB: cross-check against active_basis intersections
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("truncate", [True, False])
-def test_thb_matches_active_basis_intersection(truncate: bool) -> None:
-    space = _thb_two_level(truncate=truncate)
+def _assert_matches_active_basis(space: THBSplineSpace) -> None:
     graph = coupling_graph(space)
     assert graph.num_vertices == space.grid.num_cells
     mat = _dense(graph)
@@ -95,6 +135,19 @@ def test_thb_matches_active_basis_intersection(truncate: bool) -> None:
         for b in range(n):
             shared = 0 if a == b else len(dofs[a] & dofs[b])
             assert int(mat[a, b]) == shared
+
+
+@pytest.mark.parametrize("truncate", [True, False])
+def test_thb_matches_active_basis_intersection(truncate: bool) -> None:
+    _assert_matches_active_basis(_thb_two_level(truncate=truncate))
+
+
+def test_thb_2d_matches_active_basis_intersection() -> None:
+    _assert_matches_active_basis(_thb_two_level_2d())
+
+
+def test_thb_three_levels_matches_active_basis_intersection() -> None:
+    _assert_matches_active_basis(_thb_three_level())
 
 
 # --------------------------------------------------------------------------- #
@@ -166,7 +219,10 @@ def test_cell_weights_wrong_shape_raises(bad: list[float]) -> None:
         coupling_graph(create_uniform_space(2, 4), cell_weights=bad)
 
 
-@pytest.mark.parametrize("bad", [[1.0, -1.0, 1.0, 1.0], [1.0, np.inf, 1.0, 1.0]])
+@pytest.mark.parametrize(
+    "bad",
+    [[1.0, -1.0, 1.0, 1.0], [1.0, np.inf, 1.0, 1.0], [1.0, np.nan, 1.0, 1.0]],
+)
 def test_cell_weights_invalid_values_raise(bad: list[float]) -> None:
     with pytest.raises(ValueError, match="finite and non-negative"):
         coupling_graph(create_uniform_space(2, 4), cell_weights=bad)
@@ -174,6 +230,12 @@ def test_cell_weights_invalid_values_raise(bad: list[float]) -> None:
 
 def test_periodic_space_raises() -> None:
     space = create_uniform_space(2, 4, periodic=True)
+    with pytest.raises(ValueError, match="periodic"):
+        coupling_graph(space)
+
+
+def test_partially_periodic_2d_raises() -> None:
+    space = create_uniform_space([2, 2], [3, 3], periodic=[True, False])
     with pytest.raises(ValueError, match="periodic"):
         coupling_graph(space)
 


### PR DESCRIPTION
## Summary

Third PR of **Phase B**. Adds the cell-coupling (dual) graph that the graph-partition backends need — the pure-core, dependency-free prerequisite for ParMETIS/PT-Scotch, built and tested without either installed.

- **`pantr.bspline.coupling_graph(space, *, cell_weights=None) -> CouplingGraph`** — vertices are the space's cells; an edge joins two cells that share at least one basis function, weighted by the number shared; each vertex carries an optional assembly-cost weight.
- **`CouplingGraph`** — emitted directly in **METIS / Scotch CSR adjacency format** (`xadj` / `adjncy` / `adjwgt` / `vwgt`), so a backend hands it over with no reshaping. Symmetric, no self-loops, all arrays read-only.
- Works for **`BsplineSpace`** (tensor-product, via per-axis function support) and **`THBSplineSpace`** (via `active_basis`). Built from the cell→DOF incidence `B` as the symmetric product `B @ Bᵀ` (`scipy.sparse`), diagonal dropped.
- **Pure serial core** — no MPI, no external dependency. Consumed by the graph-partition backends in later work. `cell_weights` → per-vertex cost (default uniform); periodic `BsplineSpace` and non-space inputs are rejected.

This is decoupled from how the partitioner is *invoked* (the `partition_grid`-vs-`partition_space` API question is the next PR's call) — B3 just produces the graph.

## Test plan

- [x] **Independent closed-form checks** (no shared logic with the impl): 1D open-uniform coupling weight `max(0, p+1−|i−j|)` over degree×n_cells; 2D as the per-axis product.
- [x] **THB** cross-checked against `active_basis` set-intersections (truncated and non-truncated).
- [x] Structural invariants (TP 1D/2D/3D + THB): CSR validity, symmetry, no self-loops, edge weights ≥ 1, read-only arrays, default unit vertex weights; single-cell → no edges.
- [x] Vertex weights: pass-through, caller array not frozen, shape/finiteness/sign validation; periodic and non-space inputs raise.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT; full suite 3338 passed (1 skipped); docs `-W` ok; `_coupling_graph.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)