### PR TITLE
feat(bspline): spectral graph partitioner partition_graph (B4 of #142)

### DIFF
--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -39,6 +39,9 @@ This package consolidates the B-spline API:
 - :func:`coupling_graph`, :class:`CouplingGraph`: cell-coupling (dual) graph of a
   space -- cells sharing basis functions, weighted by the number shared -- in
   METIS / Scotch CSR format, for graph-based partitioning.
+- :func:`partition_graph`: partition a :class:`CouplingGraph` into ``n_parts`` rank
+  subdomains by spectral (Fiedler) bisection (weight- and activity-aware, dependency
+  free), minimizing cross-rank DOF coupling.
 """
 
 from ._bspline import Bspline, create_from_bezier
@@ -56,6 +59,7 @@ from ._bspline_space_factory import (
 from ._bspline_space_nd import BsplineSpace, BsplineSpaceRestriction
 from ._coupling_graph import CouplingGraph, coupling_graph
 from ._local_space import LocalSpace, build_local, compute_halo, dof_owner
+from ._partition_graph import partition_graph
 from ._thb_quasi_interpolation import quasi_interpolate_thb_spline
 from ._thb_spline import THBSpline
 from ._thb_spline_space import THBSplineSpace, THBSplineSpaceRestriction
@@ -94,6 +98,7 @@ __all__ = [
     "interpolate_bspline",
     "l2_project_bspline",
     "make_struct_view",
+    "partition_graph",
     "quasi_interpolate_bspline",
     "quasi_interpolate_thb_spline",
 ]

--- a/src/pantr/bspline/_partition_graph.py
+++ b/src/pantr/bspline/_partition_graph.py
@@ -1,0 +1,179 @@
+"""Spectral partitioning of a space's cell-coupling graph into rank subdomains.
+
+:func:`partition_graph` turns a :class:`~pantr.bspline.CouplingGraph` (built by
+:func:`~pantr.bspline.coupling_graph`) into a :class:`~pantr.grid.Partition` by
+recursive spectral (Fiedler) bisection, minimizing the cross-rank DOF coupling
+that geometric backends (``block`` / ``rcb`` in :func:`pantr.grid.partition_grid`)
+cannot see. It is the dependency-free, weight- and activity-aware graph backend:
+pure core, ``scipy`` only -- no MPI, no external graph library.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+from scipy import sparse
+from scipy.sparse import csgraph
+from scipy.sparse.linalg import ArpackError, eigsh
+
+from ..grid import Partition
+from ._coupling_graph import CouplingGraph
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+_DENSE_FIEDLER_MAX = 512
+"""Subgraphs with at most this many vertices use a dense eigensolver."""
+
+
+def partition_graph(
+    coupling: CouplingGraph,
+    n_parts: int,
+    *,
+    cell_active: npt.ArrayLike | None = None,
+) -> Partition:
+    """Partition a cell-coupling graph into ``n_parts`` rank subdomains.
+
+    Recursively bisects the graph, ordering each subgraph's vertices by its Fiedler
+    vector (the second eigenvector of the weighted graph Laplacian) and cutting at the
+    weighted split point. Balances :attr:`CouplingGraph.vertex_weights` and clamps the
+    cut so no rank is left empty. Disconnected subgraphs are split by connected
+    component first. The result minimizes cross-rank DOF coupling far better than a
+    geometric split for irregular or hierarchical meshes.
+
+    Args:
+        coupling (CouplingGraph): The cell-coupling graph (see
+            :func:`~pantr.bspline.coupling_graph`); its ``vertex_weights`` drive the
+            load balance.
+        n_parts (int): Number of parts (ranks); must be ``>= 1``.
+        cell_active (npt.ArrayLike | None): Optional boolean mask, shape
+            ``(coupling.num_vertices,)``; inactive cells get owner ``-1`` and are
+            excluded from the bisection. ``None`` means all active.
+
+    Returns:
+        Partition: A per-cell owner assignment with ``n_parts`` parts; ``-1`` for
+        inactive cells, otherwise a rank in ``range(n_parts)`` with no rank empty.
+
+    Raises:
+        TypeError: If ``coupling`` is not a :class:`CouplingGraph`.
+        ValueError: If ``n_parts < 1``; if ``cell_active`` has the wrong shape or marks
+            no cell active; or if ``n_parts`` exceeds the number of active cells.
+    """
+    if not isinstance(coupling, CouplingGraph):
+        raise TypeError(f"coupling must be a CouplingGraph; got {type(coupling).__name__}.")
+    if n_parts < 1:
+        raise ValueError(f"n_parts must be >= 1; got {n_parts}.")
+
+    n = coupling.num_vertices
+    active = _validate_active(cell_active, n)
+    active_idx = np.arange(n) if active is None else np.flatnonzero(active)
+    n_active = int(active_idx.size)
+    if n_parts > n_active:
+        raise ValueError(
+            f"n_parts={n_parts} exceeds the number of active cells ({n_active}); "
+            f"cannot assign every rank a cell."
+        )
+    n_parts = int(n_parts)
+
+    adjacency = sparse.csr_matrix(
+        (coupling.edge_weights.astype(np.float64), coupling.adjncy, coupling.xadj),
+        shape=(n, n),
+    )
+    if active is not None:
+        adjacency = adjacency[active_idx][:, active_idx]
+    weights = coupling.vertex_weights[active_idx]
+
+    owner_active = np.empty(n_active, dtype=np.int32)
+
+    def bisect(idx: npt.NDArray[np.intp], part_lo: int, part_hi: int) -> None:
+        # Split parts [part_lo, part_hi) by ordering this subgraph's vertices via its
+        # Fiedler vector, cutting at the (clamped) weighted split point so each side
+        # keeps at least as many cells as parts (no rank is left empty).
+        k = part_hi - part_lo
+        if k == 1:
+            owner_active[idx] = part_lo
+            return
+        ordered = idx[_spectral_order(adjacency[idx][:, idx])]
+        cumw = np.cumsum(weights[ordered])
+        k_left = k // 2
+        target = float(cumw[-1]) * k_left / k
+        split = int(np.searchsorted(cumw, target, side="left")) + 1
+        split = max(k_left, min(split, int(ordered.size) - (k - k_left)))
+        bisect(ordered[:split], part_lo, part_lo + k_left)
+        bisect(ordered[split:], part_lo + k_left, part_hi)
+
+    bisect(np.arange(n_active), 0, n_parts)
+
+    owner = np.full(n, -1, dtype=np.int32)
+    owner[active_idx] = owner_active
+    return Partition(owner, n_parts)
+
+
+def _spectral_order(sub_adjacency: object) -> npt.NDArray[np.intp]:
+    """Order a subgraph's vertices by its Fiedler vector (or by component).
+
+    For a connected subgraph, returns the permutation sorting vertices by the Fiedler
+    vector (second-smallest Laplacian eigenvector); the sign is canonicalized so the
+    ordering is deterministic. A disconnected subgraph is ordered by connected-component
+    label instead, which both avoids a singular Laplacian and keeps each component whole.
+
+    Args:
+        sub_adjacency (object): The ``(m, m)`` weighted adjacency (``scipy`` sparse
+            matrix) of the subgraph, with ``m >= 2``.
+
+    Returns:
+        npt.NDArray[np.intp]: A length-``m`` permutation of ``range(m)``.
+
+    Note:
+        Inputs are assumed valid (``m >= 2``); no validation is performed.
+    """
+    m = sub_adjacency.shape[0]  # type: ignore[attr-defined]
+    n_components, labels = csgraph.connected_components(sub_adjacency, directed=False)
+    if n_components > 1:
+        return np.argsort(labels, kind="stable")
+
+    laplacian = csgraph.laplacian(sub_adjacency, normed=False)
+    if m <= _DENSE_FIEDLER_MAX:
+        dense = laplacian.toarray() if sparse.issparse(laplacian) else np.asarray(laplacian)
+        _, vectors = np.linalg.eigh(dense)
+        fiedler = vectors[:, 1]
+    else:
+        v0 = np.arange(m, dtype=np.float64) - (m - 1) / 2.0
+        try:
+            values, vectors = eigsh(laplacian.tocsr().astype(np.float64), k=2, which="SA", v0=v0)
+            fiedler = vectors[:, int(np.argsort(values)[1])]
+        except ArpackError:
+            _, vectors = np.linalg.eigh(laplacian.toarray())
+            fiedler = vectors[:, 1]
+
+    # Canonicalize the sign (largest-magnitude entry positive) for determinism.
+    fiedler = fiedler * np.sign(fiedler[int(np.argmax(np.abs(fiedler)))])
+    return np.argsort(fiedler, kind="stable")
+
+
+def _validate_active(cell_active: npt.ArrayLike | None, n: int) -> npt.NDArray[np.bool_] | None:
+    """Validate and coerce ``cell_active`` to a ``(n,)`` boolean array.
+
+    Args:
+        cell_active (npt.ArrayLike | None): Candidate activity mask, or ``None``.
+        n (int): Expected length (number of graph vertices).
+
+    Returns:
+        npt.NDArray[np.bool_] | None: The coerced mask, or ``None`` if input was ``None``.
+
+    Raises:
+        ValueError: If the shape is not ``(n,)`` or no cell is active.
+    """
+    if cell_active is None:
+        return None
+    active = np.asarray(cell_active)
+    if active.shape != (n,):
+        raise ValueError(f"cell_active must have shape ({n},); got {active.shape}.")
+    active = active.astype(bool)
+    if not bool(active.any()):
+        raise ValueError("cell_active must mark at least one cell active.")
+    return cast("npt.NDArray[np.bool_]", active)
+
+
+__all__ = ["partition_graph"]

--- a/src/pantr/bspline/_partition_graph.py
+++ b/src/pantr/bspline/_partition_graph.py
@@ -6,6 +6,9 @@ recursive spectral (Fiedler) bisection, minimizing the cross-rank DOF coupling
 that geometric backends (``block`` / ``rcb`` in :func:`pantr.grid.partition_grid`)
 cannot see. It is the dependency-free, weight- and activity-aware graph backend:
 pure core, ``scipy`` only -- no MPI, no external graph library.
+
+Exports:
+    - :func:`partition_graph`
 """
 
 from __future__ import annotations
@@ -87,9 +90,12 @@ def partition_graph(
     owner_active = np.empty(n_active, dtype=np.int32)
 
     def bisect(idx: npt.NDArray[np.intp], part_lo: int, part_hi: int) -> None:
-        # Split parts [part_lo, part_hi) by ordering this subgraph's vertices via its
-        # Fiedler vector, cutting at the (clamped) weighted split point so each side
-        # keeps at least as many cells as parts (no rank is left empty).
+        """Assign parts ``[part_lo, part_hi)`` to vertices ``idx`` by spectral bisection.
+
+        Orders ``idx`` by the Fiedler vector of its induced subgraph, cuts at the
+        weighted split point, and recurses. The cut is clamped so each half receives at
+        least as many vertices as it has parts (no rank is left empty).
+        """
         k = part_hi - part_lo
         if k == 1:
             owner_active[idx] = part_lo
@@ -126,7 +132,8 @@ def _spectral_order(sub_adjacency: object) -> npt.NDArray[np.intp]:
         npt.NDArray[np.intp]: A length-``m`` permutation of ``range(m)``.
 
     Note:
-        Inputs are assumed valid (``m >= 2``); no validation is performed.
+        ``m >= 2`` is assumed; the caller (``bisect``) guarantees this via its
+        ``k == 1`` early-return.
     """
     m = sub_adjacency.shape[0]  # type: ignore[attr-defined]
     n_components, labels = csgraph.connected_components(sub_adjacency, directed=False)

--- a/tests/test_partition_graph.py
+++ b/tests/test_partition_graph.py
@@ -1,0 +1,224 @@
+"""Tests for :func:`pantr.bspline.partition_graph` (spectral graph bisection)."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from scipy import sparse
+from scipy.sparse.linalg import ArpackError
+
+from pantr.bspline import (
+    CouplingGraph,
+    THBSplineSpace,
+    coupling_graph,
+    create_uniform_space,
+    partition_graph,
+)
+from pantr.grid import hierarchical_grid, uniform_grid
+
+
+def _make_graph(
+    adjacency: npt.NDArray[np.int64], vertex_weights: npt.ArrayLike | None = None
+) -> CouplingGraph:
+    """Build a CouplingGraph from a dense symmetric integer adjacency matrix."""
+    n = adjacency.shape[0]
+    csr = sparse.csr_matrix(np.asarray(adjacency, dtype=np.int64))
+    csr.sort_indices()
+    vweights = (
+        np.ones(n) if vertex_weights is None else np.asarray(vertex_weights, dtype=np.float64)
+    )
+    return CouplingGraph(
+        n,
+        csr.indptr.astype(np.int64),
+        csr.indices.astype(np.int64),
+        csr.data.astype(np.int64),
+        vweights,
+    )
+
+
+def _cliques(clusters: list[list[int]], n: int, *, intra: int = 10) -> npt.NDArray[np.int64]:
+    """Dense adjacency with a strong clique on each cluster."""
+    adjacency = np.zeros((n, n), dtype=np.int64)
+    for cluster in clusters:
+        for i in cluster:
+            for j in cluster:
+                if i != j:
+                    adjacency[i, j] = intra
+    return adjacency
+
+
+# --------------------------------------------------------------------------- #
+# Hand-built graphs: the optimal cut is obvious (space-free correctness)
+# --------------------------------------------------------------------------- #
+
+
+def test_two_clusters_separated_by_weak_bridge() -> None:
+    adjacency = _cliques([[0, 1, 2], [3, 4, 5]], 6)
+    adjacency[2, 3] = adjacency[3, 2] = 1
+    owner = partition_graph(_make_graph(adjacency), 2).cell_owner
+    assert owner[0] == owner[1] == owner[2]
+    assert owner[3] == owner[4] == owner[5]
+    assert owner[0] != owner[3]
+
+
+def test_disconnected_components_separated() -> None:
+    # No bridge -> two connected components; exercises the component branch.
+    adjacency = _cliques([[0, 1, 2], [3, 4, 5]], 6)
+    owner = partition_graph(_make_graph(adjacency), 2).cell_owner
+    assert owner[0] == owner[1] == owner[2]
+    assert owner[3] == owner[4] == owner[5]
+    assert owner[0] != owner[3]
+
+
+def test_clique_chain_into_four_parts() -> None:
+    clusters = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]]
+    adjacency = _cliques(clusters, 12)
+    for i, j in [(2, 3), (5, 6), (8, 9)]:  # weak chain bridges
+        adjacency[i, j] = adjacency[j, i] = 1
+    owner = partition_graph(_make_graph(adjacency), 4).cell_owner
+    for cluster in clusters:
+        assert len(set(owner[cluster].tolist())) == 1, "each clique should be one part"
+    assert len(set(owner.tolist())) == 4
+
+
+def test_large_path_graph_single_cut() -> None:
+    # n > dense threshold exercises the sparse eigsh path; a path bisects with one cut.
+    n = 600
+    diag = np.ones(n - 1, dtype=np.int64)
+    csr = sparse.diags([diag, diag], [1, -1], format="csr", dtype=np.int64)
+    graph = CouplingGraph(
+        n,
+        csr.indptr.astype(np.int64),
+        csr.indices.astype(np.int64),
+        csr.data.astype(np.int64),
+        np.ones(n),
+    )
+    owner = partition_graph(graph, 2).cell_owner
+    assert set(owner.tolist()) == {0, 1}
+    assert int(np.sum(owner[:-1] != owner[1:])) == 1
+
+
+def test_eigsh_failure_falls_back_to_dense(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the sparse eigensolver to fail; the dense fallback must still partition.
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise ArpackError(-1)
+
+    monkeypatch.setattr("pantr.bspline._partition_graph.eigsh", _boom)
+    n = 600
+    diag = np.ones(n - 1, dtype=np.int64)
+    csr = sparse.diags([diag, diag], [1, -1], format="csr", dtype=np.int64)
+    graph = CouplingGraph(
+        n,
+        csr.indptr.astype(np.int64),
+        csr.indices.astype(np.int64),
+        csr.data.astype(np.int64),
+        np.ones(n),
+    )
+    owner = partition_graph(graph, 2).cell_owner
+    assert set(owner.tolist()) == {0, 1}
+
+
+# --------------------------------------------------------------------------- #
+# Real spaces
+# --------------------------------------------------------------------------- #
+
+
+def _assert_full_partition(owner: npt.NDArray[np.int32], n_parts: int, n_active: int) -> None:
+    assert int(np.count_nonzero(owner >= 0)) == n_active
+    assert set(owner[owner >= 0].tolist()) == set(range(n_parts))
+
+
+def test_real_space_partition_is_valid() -> None:
+    space = create_uniform_space([2, 2], [6, 6])
+    part = partition_graph(coupling_graph(space), 4)
+    assert part.n_parts == 4
+    _assert_full_partition(part.cell_owner, 4, 36)
+    assert np.bincount(part.cell_owner, minlength=4).min() >= 1
+
+
+def test_thb_space_partition_is_valid() -> None:
+    root = create_uniform_space(2, 4)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    grid.refine(0, [0], [2])
+    thb = THBSplineSpace(root, grid)
+    part = partition_graph(coupling_graph(thb), 2)
+    _assert_full_partition(part.cell_owner, 2, thb.grid.num_cells)
+
+
+def test_weight_balanced_not_count_balanced() -> None:
+    space = create_uniform_space(2, 8)
+    weights = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 7.0])
+    part = partition_graph(coupling_graph(space, cell_weights=weights), 2)
+    owner = part.cell_owner
+    part_weights = np.array([weights[owner == r].sum() for r in range(2)])
+    np.testing.assert_allclose(np.sort(part_weights), [7.0, 7.0])
+
+
+def test_is_deterministic() -> None:
+    graph = coupling_graph(create_uniform_space([2, 2], [5, 5]))
+    a = partition_graph(graph, 4).cell_owner
+    b = partition_graph(graph, 4).cell_owner
+    np.testing.assert_array_equal(a, b)
+
+
+def test_n_parts_one() -> None:
+    owner = partition_graph(coupling_graph(create_uniform_space(2, 4)), 1).cell_owner
+    assert np.all(owner == 0)
+
+
+def test_n_parts_equals_vertices_is_bijection() -> None:
+    owner = partition_graph(coupling_graph(create_uniform_space(2, 5)), 5).cell_owner
+    np.testing.assert_array_equal(np.sort(owner), np.arange(5))
+
+
+def test_respects_cell_active() -> None:
+    space = create_uniform_space(2, 8)
+    active = np.array([True] * 4 + [False] * 4)
+    part = partition_graph(coupling_graph(space), 2, cell_active=active)
+    owner = part.cell_owner
+    assert np.all(owner[4:] == -1)
+    assert set(owner[:4].tolist()) == {0, 1}
+    np.testing.assert_array_equal(part.active_mask, active)
+
+
+# --------------------------------------------------------------------------- #
+# Error handling
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("n_parts", [0, -1])
+def test_invalid_n_parts_raises(n_parts: int) -> None:
+    graph = coupling_graph(create_uniform_space(2, 4))
+    with pytest.raises(ValueError, match="n_parts must be >= 1"):
+        partition_graph(graph, n_parts)
+
+
+def test_n_parts_exceeds_active_raises() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4))
+    with pytest.raises(ValueError, match="exceeds the number of active cells"):
+        partition_graph(graph, 5)
+
+
+def test_n_parts_exceeds_active_with_mask_raises() -> None:
+    graph = coupling_graph(create_uniform_space(2, 8))
+    active = np.array([True] * 2 + [False] * 6)
+    with pytest.raises(ValueError, match="exceeds the number of active cells"):
+        partition_graph(graph, 3, cell_active=active)
+
+
+def test_non_coupling_graph_raises() -> None:
+    with pytest.raises(TypeError, match="CouplingGraph"):
+        partition_graph(np.zeros(3), 2)  # type: ignore[arg-type]
+
+
+def test_cell_active_wrong_shape_raises() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4))
+    with pytest.raises(ValueError, match="cell_active must have shape"):
+        partition_graph(graph, 2, cell_active=[True, False])
+
+
+def test_cell_active_all_false_raises() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4))
+    with pytest.raises(ValueError, match="at least one cell active"):
+        partition_graph(graph, 2, cell_active=[False, False, False, False])

--- a/tests/test_partition_graph.py
+++ b/tests/test_partition_graph.py
@@ -117,6 +117,34 @@ def test_eigsh_failure_falls_back_to_dense(monkeypatch: pytest.MonkeyPatch) -> N
     )
     owner = partition_graph(graph, 2).cell_owner
     assert set(owner.tolist()) == {0, 1}
+    assert int(np.sum(owner[:-1] != owner[1:])) == 1
+
+
+def test_clique_chain_into_three_parts() -> None:
+    clusters = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+    adjacency = _cliques(clusters, 9)
+    for i, j in [(2, 3), (5, 6)]:
+        adjacency[i, j] = adjacency[j, i] = 1
+    owner = partition_graph(_make_graph(adjacency), 3).cell_owner
+    for cluster in clusters:
+        assert len(set(owner[cluster].tolist())) == 1, "each clique should be one part"
+    assert len(set(owner.tolist())) == 3
+
+
+def test_dense_threshold_boundary() -> None:
+    # m=512 must use dense eigh (<=); m=513 must use sparse eigsh (>).
+    for n in (512, 513):
+        diag = np.ones(n - 1, dtype=np.int64)
+        csr = sparse.diags([diag, diag], [1, -1], format="csr", dtype=np.int64)
+        graph = CouplingGraph(
+            n,
+            csr.indptr.astype(np.int64),
+            csr.indices.astype(np.int64),
+            csr.data.astype(np.int64),
+            np.ones(n),
+        )
+        owner = partition_graph(graph, 2).cell_owner
+        assert int(np.sum(owner[:-1] != owner[1:])) == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -180,6 +208,17 @@ def test_respects_cell_active() -> None:
     assert np.all(owner[4:] == -1)
     assert set(owner[:4].tolist()) == {0, 1}
     np.testing.assert_array_equal(part.active_mask, active)
+
+
+def test_cell_active_int_coerced_to_bool() -> None:
+    graph = coupling_graph(create_uniform_space(2, 4))
+    part = partition_graph(graph, 2, cell_active=[1, 1, 0, 0])
+    assert np.all(part.cell_owner[2:] == -1)
+
+
+def test_cell_owner_is_read_only() -> None:
+    part = partition_graph(coupling_graph(create_uniform_space(2, 4)), 2)
+    assert not part.cell_owner.flags.writeable
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fourth PR of **Phase B** — the partitioner that consumes B3's coupling graph, as a **zero-dependency** spectral bisection (no METIS/Scotch, no MPI). This completes the native partitioner surface; external graph libraries become a future optional accelerator.

- **`pantr.bspline.partition_graph(coupling, n_parts, *, cell_active=None) -> Partition`** — recursive spectral (Fiedler) bisection of a `CouplingGraph`, minimizing the cross-rank DOF coupling that the geometric `block`/`rcb` backends can't see.
- **Algorithm:** bisect the part count `k → (k//2, k−k//2)`; order each subgraph's vertices by its **Fiedler vector** (2nd Laplacian eigenvector), cut at the weighted split point balancing `vertex_weights`, **clamped so no rank is empty**. Disconnected subgraphs split by connected component first (robust; avoids a singular Laplacian). Dense `eigh` for small subgraphs, sparse `eigsh` above a threshold with a dense fallback. Deterministic (fixed start vector, canonicalized Fiedler sign, stable sort).
- **`cell_active`** hook: inactive cells → owner `-1`, bisect the active induced subgraph; raises if `n_parts` exceeds the active count.
- **Layering:** lives in `pantr.bspline` (next to `CouplingGraph`); `block`/`rcb`/`auto` stay on `pantr.grid.partition_grid`. Routing the graph through `partition_grid` would have inverted the grid←bspline dependency — a separate `bspline` entry keeps it correct. Pure core, `scipy` only.

## Test plan

- [x] **Space-free correctness** on hand-built graphs: two clusters + weak bridge → separated; two disconnected components → separated (component branch); chain of 4 cliques → each clique its own part; 600-node path → exactly one contiguous cut (exercises the sparse `eigsh` path).
- [x] Forced `eigsh` failure → dense fallback still partitions (monkeypatched).
- [x] Real `BsplineSpace` and `THBSplineSpace` via `coupling_graph` → valid `Partition` (all active assigned, all ranks used, none empty).
- [x] Weight-balanced (heavy cell isolated), activity (`-1`), determinism, `n_parts=1`/`=n`/`>n_active`, wrong-type/shape/all-false validation.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT; full suite 3367 passed (1 skipped); docs `-W` ok; `_partition_graph.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)