### PR TITLE
feat(mpi): from_dolfinx -- Partition from a dolfinx mesh (B5 of #142)

### DIFF
--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -15,6 +15,7 @@ Main exports:
 - :data:`HAS_MPI`: whether ``mpi4py`` was importable at module load time.
 - :func:`mpi_available`: live runtime check for ``mpi4py`` availability.
 - :func:`require_mpi`: lazily import and return the ``mpi4py.MPI`` module, or raise.
+- :func:`from_dolfinx`: build a :class:`pantr.grid.Partition` from a dolfinx mesh.
 """
 
 from __future__ import annotations
@@ -22,6 +23,8 @@ from __future__ import annotations
 import importlib.util
 from types import ModuleType
 from typing import Final
+
+from ._from_dolfinx import from_dolfinx
 
 
 def mpi_available() -> bool:
@@ -79,6 +82,7 @@ def require_mpi() -> ModuleType:
 
 __all__ = [
     "HAS_MPI",
+    "from_dolfinx",
     "mpi_available",
     "require_mpi",
 ]

--- a/src/pantr/mpi/_from_dolfinx.py
+++ b/src/pantr/mpi/_from_dolfinx.py
@@ -8,6 +8,8 @@ consumers (e.g. qugar / tigarx).
 ``dolfinx`` is never imported here: the mesh (and its MPI communicator) are supplied by
 the caller, and only its attributes are read. This module therefore has no import-time
 dependency on ``dolfinx`` or ``mpi4py`` -- ``import pantr.mpi`` still works without them.
+At runtime, ``mesh.comm`` must behave as an ``mpi4py.MPI.Comm`` (providing ``size`` and
+``allgather``).
 """
 
 from __future__ import annotations
@@ -47,9 +49,9 @@ def from_dolfinx(
             ``dolfinx`` import): ``mesh.comm`` (an MPI communicator with ``size`` and
             ``allgather``), ``mesh.topology.dim``,
             ``mesh.topology.index_map(dim).size_local``, and
-            ``mesh.topology.original_cell_index``.
-        n_cells (int): Total number of cells in the pantr grid (e.g. ``grid.num_cells``
-            or ``space.num_total_intervals``); must be ``>= 1``.
+            ``mesh.topology.original_cell_index`` (must support integer-slice indexing).
+        n_cells (int): Total number of cells in the pantr grid (e.g.
+            ``grid.num_cells``); must be ``>= 1``.
         dolfinx_to_pantr (npt.ArrayLike | None): Optional integer map from a dolfinx
             *original global* cell index to a pantr cell id. ``None`` means identity (the
             mesh is in pantr C-order).
@@ -59,9 +61,12 @@ def from_dolfinx(
         pantr cells absent from the mesh.
 
     Raises:
-        ValueError: If ``n_cells < 1``; if ``dolfinx_to_pantr`` is not a 1D integer array
-            or an original index falls outside it; if a mapped cell id is outside
-            ``[0, n_cells)``; or if two ranks own the same cell (inconsistent mesh/map).
+        ValueError: If ``n_cells < 1``; if ``topology.index_map(dim).size_local`` is
+            negative; if ``dolfinx_to_pantr`` is not a 1D integer array, is not injective,
+            or an original index falls outside it; if any (original or mapped) pantr cell
+            id is outside ``[0, n_cells)``; if ``allgather`` returns an inconsistent number
+            of entries or a non-1D result for any rank; if any gathered cell id is out of
+            range; or if two ranks own the same cell (inconsistent mesh/map).
     """
     if n_cells < 1:
         raise ValueError(f"n_cells must be >= 1; got {n_cells}.")
@@ -69,23 +74,47 @@ def from_dolfinx(
     topology = mesh.topology
     tdim = int(topology.dim)
     size_local = int(topology.index_map(tdim).size_local)
+    if size_local < 0:
+        raise ValueError(
+            f"topology.index_map({tdim}).size_local returned {size_local}; "
+            "expected a non-negative count of locally-owned cells."
+        )
     original = np.asarray(topology.original_cell_index, dtype=np.int64)[:size_local]
     local_ids = _map_to_pantr(original, dolfinx_to_pantr, n_cells)
 
     gathered = mesh.comm.allgather(local_ids)
+    n_parts = int(mesh.comm.size)
+    if len(gathered) != n_parts:
+        raise ValueError(
+            f"allgather returned {len(gathered)} entries but mesh.comm.size is {n_parts}; "
+            "the communicator's allgather is inconsistent."
+        )
     cell_owner = np.full(n_cells, -1, dtype=np.int32)
     for owner_rank, ids in enumerate(gathered):
         ids_arr = np.asarray(ids, dtype=np.int64)
+        if ids_arr.ndim != 1:
+            raise ValueError(
+                f"allgather result for rank {owner_rank} is not a 1-D array "
+                f"(got shape {ids_arr.shape})."
+            )
         if ids_arr.size == 0:
             continue
-        if bool(np.any(cell_owner[ids_arr] != -1)):
+        if int(ids_arr.min()) < 0 or int(ids_arr.max()) >= n_cells:
             raise ValueError(
-                "inconsistent partition: a cell is owned by more than one rank "
-                f"(rank {owner_rank} re-claims an already-owned cell)."
+                f"gathered cell ids from rank {owner_rank} are outside [0, {n_cells}): "
+                f"got range [{int(ids_arr.min())}, {int(ids_arr.max())}]."
+            )
+        conflict_mask = cell_owner[ids_arr] != -1
+        if bool(np.any(conflict_mask)):
+            conflict_cell = int(ids_arr[conflict_mask][0])
+            prev_owner = int(cell_owner[conflict_cell])
+            raise ValueError(
+                f"inconsistent partition: cell {conflict_cell} is claimed by both "
+                f"rank {prev_owner} and rank {owner_rank}."
             )
         cell_owner[ids_arr] = owner_rank
 
-    return Partition(cell_owner, int(mesh.comm.size))
+    return Partition(cell_owner, n_parts)
 
 
 def _map_to_pantr(
@@ -106,21 +135,30 @@ def _map_to_pantr(
         npt.NDArray[np.int64]: Pantr cell ids of the owned cells.
 
     Raises:
-        ValueError: If the map is not a 1D integer array, an original index lies outside
-            the map, or a resulting pantr id lies outside ``[0, n_cells)``.
+        ValueError: If the map is not a 1D integer array, original indices are negative,
+            an original index lies outside the map, the map is not injective, or a
+            resulting pantr id lies outside ``[0, n_cells)``.
     """
     if dolfinx_to_pantr is None:
         ids = original
     else:
         mapping = np.asarray(dolfinx_to_pantr)
-        if mapping.ndim != 1 or not np.issubdtype(mapping.dtype, np.integer):
+        if mapping.ndim != 1 or mapping.dtype.kind not in ("i", "u"):
             raise ValueError("dolfinx_to_pantr must be a 1D integer array.")
+        if original.size and int(original.min()) < 0:
+            raise ValueError(
+                f"original cell indices must be non-negative; got {int(original.min())}."
+            )
         if original.size and int(original.max()) >= mapping.shape[0]:
             raise ValueError(
                 f"dolfinx_to_pantr has length {mapping.shape[0]} but an original cell "
                 f"index reaches {int(original.max())}."
             )
         ids = mapping[original].astype(np.int64)
+        if ids.size and np.unique(ids).size != ids.size:
+            raise ValueError(
+                "dolfinx_to_pantr is not injective: two dolfinx cells map to the same pantr id."
+            )
 
     if ids.size and (int(ids.min()) < 0 or int(ids.max()) >= n_cells):
         raise ValueError(

--- a/src/pantr/mpi/_from_dolfinx.py
+++ b/src/pantr/mpi/_from_dolfinx.py
@@ -1,0 +1,133 @@
+"""Build a :class:`~pantr.grid.Partition` from a dolfinx mesh's cell distribution.
+
+:func:`from_dolfinx` consumes the cell ownership of a (distributed) ``dolfinx`` mesh
+and returns the serial, redundant :class:`~pantr.grid.Partition` over a pantr grid's
+cells that the distributed-space machinery consumes -- the bridge for dolfinx-based
+consumers (e.g. qugar / tigarx).
+
+``dolfinx`` is never imported here: the mesh (and its MPI communicator) are supplied by
+the caller, and only its attributes are read. This module therefore has no import-time
+dependency on ``dolfinx`` or ``mpi4py`` -- ``import pantr.mpi`` still works without them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from ..grid import Partition
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+def from_dolfinx(
+    mesh: Any,  # noqa: ANN401 -- a dolfinx.mesh.Mesh; dolfinx is an optional, untyped dep
+    n_cells: int,
+    *,
+    dolfinx_to_pantr: npt.ArrayLike | None = None,
+) -> Partition:
+    """Build a cell :class:`~pantr.grid.Partition` from a dolfinx mesh.
+
+    Reads the locally-owned cells on every rank and MPI-allgathers their original
+    (input) global indices over ``mesh.comm`` to assemble one global, redundant per-cell
+    owner array -- the rank that owns each cell in dolfinx. The result is identical on
+    every rank. Pantr cells absent from the mesh (e.g. exterior / trimmed cells excluded
+    by an immersed consumer) get owner ``-1``.
+
+    The correspondence between a dolfinx cell and a pantr grid cell is its *original*
+    cell index (``mesh.topology.original_cell_index``): with ``dolfinx_to_pantr=None`` the
+    mesh is assumed to have been built in pantr's C-order cell numbering, so the original
+    index *is* the pantr flat cell id. Pass ``dolfinx_to_pantr`` to map the original
+    dolfinx global cell index to a pantr cell id explicitly.
+
+    Args:
+        mesh (Any): A ``dolfinx.mesh.Mesh``. The required interface is duck-typed (no
+            ``dolfinx`` import): ``mesh.comm`` (an MPI communicator with ``size`` and
+            ``allgather``), ``mesh.topology.dim``,
+            ``mesh.topology.index_map(dim).size_local``, and
+            ``mesh.topology.original_cell_index``.
+        n_cells (int): Total number of cells in the pantr grid (e.g. ``grid.num_cells``
+            or ``space.num_total_intervals``); must be ``>= 1``.
+        dolfinx_to_pantr (npt.ArrayLike | None): Optional integer map from a dolfinx
+            *original global* cell index to a pantr cell id. ``None`` means identity (the
+            mesh is in pantr C-order).
+
+    Returns:
+        Partition: A per-cell owner assignment with ``mesh.comm.size`` parts; ``-1`` for
+        pantr cells absent from the mesh.
+
+    Raises:
+        ValueError: If ``n_cells < 1``; if ``dolfinx_to_pantr`` is not a 1D integer array
+            or an original index falls outside it; if a mapped cell id is outside
+            ``[0, n_cells)``; or if two ranks own the same cell (inconsistent mesh/map).
+    """
+    if n_cells < 1:
+        raise ValueError(f"n_cells must be >= 1; got {n_cells}.")
+
+    topology = mesh.topology
+    tdim = int(topology.dim)
+    size_local = int(topology.index_map(tdim).size_local)
+    original = np.asarray(topology.original_cell_index, dtype=np.int64)[:size_local]
+    local_ids = _map_to_pantr(original, dolfinx_to_pantr, n_cells)
+
+    gathered = mesh.comm.allgather(local_ids)
+    cell_owner = np.full(n_cells, -1, dtype=np.int32)
+    for owner_rank, ids in enumerate(gathered):
+        ids_arr = np.asarray(ids, dtype=np.int64)
+        if ids_arr.size == 0:
+            continue
+        if bool(np.any(cell_owner[ids_arr] != -1)):
+            raise ValueError(
+                "inconsistent partition: a cell is owned by more than one rank "
+                f"(rank {owner_rank} re-claims an already-owned cell)."
+            )
+        cell_owner[ids_arr] = owner_rank
+
+    return Partition(cell_owner, int(mesh.comm.size))
+
+
+def _map_to_pantr(
+    original: npt.NDArray[np.int64],
+    dolfinx_to_pantr: npt.ArrayLike | None,
+    n_cells: int,
+) -> npt.NDArray[np.int64]:
+    """Map owned dolfinx original global cell indices to pantr cell ids.
+
+    Args:
+        original (npt.NDArray[np.int64]): Original global indices of the rank's owned
+            cells.
+        dolfinx_to_pantr (npt.ArrayLike | None): Optional dolfinx-global -> pantr-id map;
+            ``None`` for identity.
+        n_cells (int): Total pantr cell count, for range validation.
+
+    Returns:
+        npt.NDArray[np.int64]: Pantr cell ids of the owned cells.
+
+    Raises:
+        ValueError: If the map is not a 1D integer array, an original index lies outside
+            the map, or a resulting pantr id lies outside ``[0, n_cells)``.
+    """
+    if dolfinx_to_pantr is None:
+        ids = original
+    else:
+        mapping = np.asarray(dolfinx_to_pantr)
+        if mapping.ndim != 1 or not np.issubdtype(mapping.dtype, np.integer):
+            raise ValueError("dolfinx_to_pantr must be a 1D integer array.")
+        if original.size and int(original.max()) >= mapping.shape[0]:
+            raise ValueError(
+                f"dolfinx_to_pantr has length {mapping.shape[0]} but an original cell "
+                f"index reaches {int(original.max())}."
+            )
+        ids = mapping[original].astype(np.int64)
+
+    if ids.size and (int(ids.min()) < 0 or int(ids.max()) >= n_cells):
+        raise ValueError(
+            f"mapped pantr cell ids must lie in [0, {n_cells}); "
+            f"got range [{int(ids.min())}, {int(ids.max())}]."
+        )
+    return ids
+
+
+__all__ = ["from_dolfinx"]

--- a/tests/test_from_dolfinx.py
+++ b/tests/test_from_dolfinx.py
@@ -32,7 +32,7 @@ class _FakeComm:
         return self._size
 
     def allgather(self, sendobj: object) -> list[object]:
-        result: list[object] = [None] * self._size
+        result: list[object] = [np.array([], dtype=np.int64)] * self._size
         result[self._rank] = sendobj
         for rank, ids in self._others.items():
             result[rank] = np.asarray(ids, dtype=np.int64)
@@ -121,6 +121,7 @@ def test_consistent_across_ranks() -> None:
     rank0 = from_dolfinx(_mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]}), 6)
     rank1 = from_dolfinx(_mesh(1, 2, [3, 4, 5], others={0: [0, 1, 2]}), 6)
     np.testing.assert_array_equal(rank0.cell_owner, rank1.cell_owner)
+    np.testing.assert_array_equal(rank0.cell_owner, [0, 0, 0, 1, 1, 1])
 
 
 # --------------------------------------------------------------------------- #
@@ -131,8 +132,9 @@ def test_consistent_across_ranks() -> None:
 def test_explicit_map_reorders_ownership() -> None:
     # dolfinx global -> pantr id reversal: rank0 owns dolfinx {0,1} -> pantr {3,2},
     # rank1 owns dolfinx {2,3} -> pantr {1,0}.
+    # others carries rank 1's post-mapping pantr ids (allgather sends local_ids, not originals).
     mapping = [3, 2, 1, 0]
-    mesh = _mesh(0, 2, [0, 1], others={1: [1, 0]})  # others carry mapped pantr ids
+    mesh = _mesh(0, 2, [0, 1], others={1: [1, 0]})
     part = from_dolfinx(mesh, 4, dolfinx_to_pantr=mapping)
     np.testing.assert_array_equal(part.cell_owner, [1, 1, 0, 0])
 
@@ -143,6 +145,12 @@ def test_identity_map_matches_none() -> None:
     a = from_dolfinx(mesh_none, 6)
     b = from_dolfinx(mesh_id, 6, dolfinx_to_pantr=[0, 1, 2, 3, 4, 5])
     np.testing.assert_array_equal(a.cell_owner, b.cell_owner)
+
+
+def test_map_numpy_array_works() -> None:
+    mesh = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]})
+    part = from_dolfinx(mesh, 6, dolfinx_to_pantr=np.array([0, 1, 2, 3, 4, 5], dtype=np.int32))
+    np.testing.assert_array_equal(part.cell_owner, [0, 0, 0, 1, 1, 1])
 
 
 # --------------------------------------------------------------------------- #
@@ -159,7 +167,7 @@ def test_invalid_n_cells_raises(n_cells: int) -> None:
 
 def test_double_ownership_raises() -> None:
     mesh = _mesh(0, 2, [0, 1], others={1: [1, 2]})  # cell 1 claimed by both ranks
-    with pytest.raises(ValueError, match="more than one rank"):
+    with pytest.raises(ValueError, match="claimed by both"):
         from_dolfinx(mesh, 3)
 
 
@@ -169,13 +177,37 @@ def test_pantr_id_out_of_range_raises() -> None:
         from_dolfinx(mesh, 4)
 
 
+def test_map_negative_pantr_id_raises() -> None:
+    mesh = _mesh(0, 1, [0, 1])
+    with pytest.raises(ValueError, match="mapped pantr cell ids must lie"):
+        from_dolfinx(mesh, 4, dolfinx_to_pantr=[-1, 0, 1, 2])
+
+
 def test_map_not_1d_integer_raises() -> None:
     mesh = _mesh(0, 1, [0, 1])
     with pytest.raises(ValueError, match="1D integer array"):
         from_dolfinx(mesh, 4, dolfinx_to_pantr=[[0, 1], [2, 3]])
 
 
+def test_map_float_dtype_raises() -> None:
+    mesh = _mesh(0, 1, [0, 1])
+    with pytest.raises(ValueError, match="1D integer array"):
+        from_dolfinx(mesh, 4, dolfinx_to_pantr=[0.0, 1.0, 2.0, 3.0])
+
+
 def test_map_index_out_of_bounds_raises() -> None:
     mesh = _mesh(0, 1, [0, 5])  # original index 5 but map has length 4
     with pytest.raises(ValueError, match="dolfinx_to_pantr has length"):
         from_dolfinx(mesh, 6, dolfinx_to_pantr=[0, 1, 2, 3])
+
+
+def test_negative_original_index_raises() -> None:
+    mesh = _mesh(0, 1, [-1, 0])  # original_cell_index contains -1
+    with pytest.raises(ValueError, match="non-negative"):
+        from_dolfinx(mesh, 4, dolfinx_to_pantr=[0, 1, 2, 3])
+
+
+def test_non_injective_map_raises() -> None:
+    mesh = _mesh(0, 1, [0, 1])  # two dolfinx cells both mapping to pantr id 0
+    with pytest.raises(ValueError, match="not injective"):
+        from_dolfinx(mesh, 4, dolfinx_to_pantr=[0, 0, 2, 3])

--- a/tests/test_from_dolfinx.py
+++ b/tests/test_from_dolfinx.py
@@ -1,0 +1,181 @@
+"""Tests for :func:`pantr.mpi.from_dolfinx` (dolfinx mesh -> Partition bridge).
+
+dolfinx and MPI are not available in the test environment, so the dolfinx ``Mesh``
+and its communicator are duck-typed by the fakes below. ``_FakeComm.allgather``
+models ``mpi4py``'s collective: the calling rank contributes its own ``sendobj`` and
+the other ranks contribute preset owned-cell lists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+
+from pantr.grid import Partition
+from pantr.mpi import from_dolfinx
+
+
+class _FakeComm:
+    """Minimal stand-in for an mpi4py communicator."""
+
+    def __init__(
+        self, rank: int, size: int, others: dict[int, Sequence[int]] | None = None
+    ) -> None:
+        self._rank = rank
+        self._size = size
+        self._others = others or {}
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def allgather(self, sendobj: object) -> list[object]:
+        result: list[object] = [None] * self._size
+        result[self._rank] = sendobj
+        for rank, ids in self._others.items():
+            result[rank] = np.asarray(ids, dtype=np.int64)
+        return result
+
+
+class _FakeIndexMap:
+    def __init__(self, size_local: int) -> None:
+        self.size_local = size_local
+
+
+class _FakeTopology:
+    def __init__(self, dim: int, original: Sequence[int], size_local: int) -> None:
+        self.dim = dim
+        self.original_cell_index = np.asarray(original, dtype=np.int64)
+        self._index_map = _FakeIndexMap(size_local)
+
+    def index_map(self, dim: int) -> _FakeIndexMap:
+        return self._index_map
+
+
+class _FakeMesh:
+    def __init__(self, topology: _FakeTopology, comm: _FakeComm) -> None:
+        self.topology = topology
+        self.comm = comm
+
+
+def _mesh(
+    rank: int,
+    size: int,
+    owned: Sequence[int],
+    *,
+    others: dict[int, Sequence[int]] | None = None,
+    ghosts: Sequence[int] = (),
+) -> _FakeMesh:
+    """Build a fake dolfinx mesh: this rank owns ``owned`` (original global indices)."""
+    original = list(owned) + list(ghosts)
+    topology = _FakeTopology(2, original, len(owned))
+    return _FakeMesh(topology, _FakeComm(rank, size, others))
+
+
+# --------------------------------------------------------------------------- #
+# Core assembly
+# --------------------------------------------------------------------------- #
+
+
+def test_two_ranks_full_mesh() -> None:
+    mesh = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]})
+    part = from_dolfinx(mesh, 6)
+    assert isinstance(part, Partition)
+    assert part.n_parts == 2
+    np.testing.assert_array_equal(part.cell_owner, [0, 0, 0, 1, 1, 1])
+    assert np.all(part.active_mask)
+
+
+def test_ghost_cells_are_ignored() -> None:
+    # Owned cells are [0, 1, 2]; 3 and 4 are ghosts (beyond size_local) and dropped.
+    mesh = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]}, ghosts=[3, 4])
+    part = from_dolfinx(mesh, 6)
+    np.testing.assert_array_equal(part.cell_owner, [0, 0, 0, 1, 1, 1])
+
+
+def test_cells_absent_from_mesh_are_inactive() -> None:
+    mesh = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]})
+    part = from_dolfinx(mesh, 8)
+    np.testing.assert_array_equal(part.cell_owner, [0, 0, 0, 1, 1, 1, -1, -1])
+    np.testing.assert_array_equal(part.active_mask, [True] * 6 + [False] * 2)
+
+
+def test_serial_single_rank() -> None:
+    mesh = _mesh(0, 1, [0, 1, 2, 3])
+    part = from_dolfinx(mesh, 4)
+    assert part.n_parts == 1
+    assert np.all(part.cell_owner == 0)
+
+
+def test_empty_rank_is_allowed() -> None:
+    mesh = _mesh(0, 2, [0, 1, 2, 3], others={1: []})
+    part = from_dolfinx(mesh, 4)
+    assert part.n_parts == 2
+    np.testing.assert_array_equal(part.cell_owner, [0, 0, 0, 0])
+
+
+def test_consistent_across_ranks() -> None:
+    # Every rank assembles the same global partition.
+    rank0 = from_dolfinx(_mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]}), 6)
+    rank1 = from_dolfinx(_mesh(1, 2, [3, 4, 5], others={0: [0, 1, 2]}), 6)
+    np.testing.assert_array_equal(rank0.cell_owner, rank1.cell_owner)
+
+
+# --------------------------------------------------------------------------- #
+# Cell-index mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_explicit_map_reorders_ownership() -> None:
+    # dolfinx global -> pantr id reversal: rank0 owns dolfinx {0,1} -> pantr {3,2},
+    # rank1 owns dolfinx {2,3} -> pantr {1,0}.
+    mapping = [3, 2, 1, 0]
+    mesh = _mesh(0, 2, [0, 1], others={1: [1, 0]})  # others carry mapped pantr ids
+    part = from_dolfinx(mesh, 4, dolfinx_to_pantr=mapping)
+    np.testing.assert_array_equal(part.cell_owner, [1, 1, 0, 0])
+
+
+def test_identity_map_matches_none() -> None:
+    mesh_none = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]})
+    mesh_id = _mesh(0, 2, [0, 1, 2], others={1: [3, 4, 5]})
+    a = from_dolfinx(mesh_none, 6)
+    b = from_dolfinx(mesh_id, 6, dolfinx_to_pantr=[0, 1, 2, 3, 4, 5])
+    np.testing.assert_array_equal(a.cell_owner, b.cell_owner)
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("n_cells", [0, -1])
+def test_invalid_n_cells_raises(n_cells: int) -> None:
+    mesh = _mesh(0, 1, [0])
+    with pytest.raises(ValueError, match="n_cells must be >= 1"):
+        from_dolfinx(mesh, n_cells)
+
+
+def test_double_ownership_raises() -> None:
+    mesh = _mesh(0, 2, [0, 1], others={1: [1, 2]})  # cell 1 claimed by both ranks
+    with pytest.raises(ValueError, match="more than one rank"):
+        from_dolfinx(mesh, 3)
+
+
+def test_pantr_id_out_of_range_raises() -> None:
+    mesh = _mesh(0, 1, [0, 5])  # cell id 5 with n_cells=4
+    with pytest.raises(ValueError, match="mapped pantr cell ids must lie"):
+        from_dolfinx(mesh, 4)
+
+
+def test_map_not_1d_integer_raises() -> None:
+    mesh = _mesh(0, 1, [0, 1])
+    with pytest.raises(ValueError, match="1D integer array"):
+        from_dolfinx(mesh, 4, dolfinx_to_pantr=[[0, 1], [2, 3]])
+
+
+def test_map_index_out_of_bounds_raises() -> None:
+    mesh = _mesh(0, 1, [0, 5])  # original index 5 but map has length 4
+    with pytest.raises(ValueError, match="dolfinx_to_pantr has length"):
+        from_dolfinx(mesh, 6, dolfinx_to_pantr=[0, 1, 2, 3])

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -16,8 +16,9 @@ def test_import_and_public_surface() -> None:
     """`import pantr.mpi` works regardless of mpi4py, exposing the skeleton API."""
     assert callable(pantr.mpi.mpi_available)
     assert callable(pantr.mpi.require_mpi)
+    assert callable(pantr.mpi.from_dolfinx)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
-    assert set(pantr.mpi.__all__) == {"HAS_MPI", "mpi_available", "require_mpi"}
+    assert set(pantr.mpi.__all__) == {"HAS_MPI", "from_dolfinx", "mpi_available", "require_mpi"}
 
 
 def test_mpi_available_matches_find_spec() -> None:


### PR DESCRIPTION
## Summary

Fifth PR of **Phase B** — the second partition *source*: consume a dolfinx mesh's cell distribution into a pantr `Partition` (the qugar/tigarx bridge). With the native `partition_grid`/`partition_graph` (own-grown) and `from_dolfinx` (externally-driven), both partition sources from the #142 design now exist.

- **`pantr.mpi.from_dolfinx(mesh, n_cells, *, dolfinx_to_pantr=None) -> Partition`** — reads each rank's owned cells' original global indices, **MPI-allgathers** over `mesh.comm`, and assembles one global, redundant per-cell owner array (the rank that owns each cell in dolfinx). Identical on every rank.
- **Immersion-friendly:** pantr cells absent from the mesh (exterior/trimmed cells a consumer excluded) get owner `-1` automatically.
- **Cell correspondence** = dolfinx `original_cell_index`; `dolfinx_to_pantr=None` assumes the mesh was built in pantr C-order (original index == pantr id), else an explicit map is applied (as decided).
- **No hard dolfinx/MPI dependency:** the mesh and its communicator are supplied by the caller and only duck-typed attributes are read — `dolfinx` is never imported, so `import pantr.mpi` still works without `dolfinx`/`mpi4py`. This also makes it **fully unit-testable with fakes** (dolfinx isn't in CI).
- Validates `n_cells`, the map shape/range, mapped id ranges, and rejects a cell owned by more than one rank.

## Test plan

- [x] Core assembly (fake mesh + fake `allgather`): two-rank full mesh; ghost cells ignored (only `size_local` owned); cells absent from the mesh → `-1`; serial single rank; empty rank allowed; same global partition assembled on every rank.
- [x] Cell mapping: explicit `dolfinx_to_pantr` reorders ownership; identity map matches `None`.
- [x] Validation: bad `n_cells`, double ownership, mapped id out of range, non-1D/non-integer map, original index outside the map.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT (mpi -> grid only); full suite 3386 passed (1 skipped); docs `-W` ok; `_from_dolfinx.py` and `pantr/mpi/__init__.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)