### PR TITLE
feat(mpi): DistributedSpace -- per-rank handle to a distributed space (C2 of #142)

### DIFF
--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -16,6 +16,7 @@ Main exports:
 - :func:`mpi_available`: live runtime check for ``mpi4py`` availability.
 - :func:`require_mpi`: lazily import and return the ``mpi4py.MPI`` module, or raise.
 - :func:`from_dolfinx`: build a :class:`pantr.grid.Partition` from a dolfinx mesh.
+- :class:`DistributedSpace`: the per-rank handle to an MPI-distributed space.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ import importlib.util
 from types import ModuleType
 from typing import Final
 
+from ._distributed_space import DistributedSpace
 from ._from_dolfinx import from_dolfinx
 
 
@@ -82,6 +84,7 @@ def require_mpi() -> ModuleType:
 
 __all__ = [
     "HAS_MPI",
+    "DistributedSpace",
     "from_dolfinx",
     "mpi_available",
     "require_mpi",

--- a/src/pantr/mpi/_distributed_space.py
+++ b/src/pantr/mpi/_distributed_space.py
@@ -1,0 +1,184 @@
+"""Top-level MPI-distributed B-spline / THB-spline space.
+
+:class:`DistributedSpace` is the per-rank handle to a space distributed across an MPI
+communicator. Given the global space and a :class:`~pantr.grid.Partition` (identical on
+every rank), it builds *this rank's* windowed :class:`~pantr.bspline.LocalSpace` via
+:func:`~pantr.bspline.build_local`. Construction is purely local -- no MPI communication
+and no DOF exchange -- consistent with pantr's redundant per-rank storage model
+(cross-rank coupling is the consumer's job, e.g. via a PETSc ``PtAP``).
+
+``mpi4py`` is not imported: the communicator is supplied by the caller and only its
+``rank`` and ``size`` are read, so ``import pantr.mpi`` still works without MPI.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..bspline import THBSplineSpace, build_local
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+
+    from ..bspline import BsplineSpace, LocalSpace
+    from ..grid import Partition
+
+
+class DistributedSpace:
+    """A B-spline or THB-spline space distributed across an MPI communicator.
+
+    The per-rank, SPMD handle: every rank constructs its own ``DistributedSpace`` from
+    the same global space and partition, and holds only its own
+    :class:`~pantr.bspline.LocalSpace` (``local``). A rank that owns no cells (an
+    over-provisioned run, or a partition that excludes some ranks) has ``local`` set to
+    ``None`` and ``owns_cells`` ``False`` instead of failing.
+
+    Construction performs no MPI communication: the partition is assumed identical on
+    every rank (guaranteed by pantr's deterministic partitioners and by
+    :func:`~pantr.mpi.from_dolfinx`), so each rank can window the global space locally.
+
+    Attributes are exposed through the :attr:`comm`, :attr:`rank`, :attr:`n_parts`,
+    :attr:`global_space`, :attr:`partition`, :attr:`local`, :attr:`owns_cells`, and
+    :attr:`owned_cells` properties.
+    """
+
+    __slots__ = ("_comm", "_global_space", "_local", "_owned_cells", "_partition", "_rank")
+
+    def __init__(
+        self,
+        global_space: BsplineSpace | THBSplineSpace,
+        partition: Partition,
+        comm: Any,  # noqa: ANN401 -- an mpi4py.MPI.Comm; mpi4py is an optional, untyped dep
+    ) -> None:
+        """Build the distributed space, windowing the global space to this rank.
+
+        Args:
+            global_space (BsplineSpace | THBSplineSpace): The global (non-periodic)
+                space, identical on every rank.
+            partition (Partition): Owner of every cell of the space's grid, identical on
+                every rank. Its ``n_parts`` must equal ``comm.size``.
+            comm (Any): An MPI communicator (e.g. ``mpi4py.MPI.COMM_WORLD``). Only its
+                ``rank`` and ``size`` attributes are read.
+
+        Raises:
+            ValueError: If ``comm.size != partition.n_parts``; if ``partition`` does not
+                match the global space's cell count; if ``comm.rank`` is out of range; or
+                if ``global_space`` is a periodic :class:`~pantr.bspline.BsplineSpace`.
+        """
+        size = int(comm.size)
+        if size != partition.n_parts:
+            raise ValueError(
+                f"comm.size ({size}) must equal partition.n_parts ({partition.n_parts})."
+            )
+        n_global_cells = _global_cell_count(global_space)
+        if partition.n_cells != n_global_cells:
+            raise ValueError(
+                f"partition has {partition.n_cells} cells; "
+                f"expected {n_global_cells} (the global space's cell count)."
+            )
+
+        rank = int(comm.rank)
+        owned = partition.owned_cells(rank)  # validates rank in [0, n_parts)
+        owned.flags.writeable = False
+
+        self._comm = comm
+        self._global_space = global_space
+        self._partition = partition
+        self._rank = rank
+        self._owned_cells = owned
+        self._local: LocalSpace | None = (
+            build_local(global_space, partition, rank) if owned.size else None
+        )
+
+    @property
+    def comm(self) -> Any:  # noqa: ANN401 -- the caller-supplied MPI communicator
+        """Get the MPI communicator this space is distributed over.
+
+        Returns:
+            Any: The communicator passed at construction.
+        """
+        return self._comm
+
+    @property
+    def rank(self) -> int:
+        """Get this rank's id within the communicator.
+
+        Returns:
+            int: ``comm.rank``.
+        """
+        return self._rank
+
+    @property
+    def n_parts(self) -> int:
+        """Get the number of ranks (parts) the space is distributed over.
+
+        Returns:
+            int: ``comm.size`` (equal to ``partition.n_parts``).
+        """
+        return self._partition.n_parts
+
+    @property
+    def global_space(self) -> BsplineSpace | THBSplineSpace:
+        """Get the undistributed global space.
+
+        Returns:
+            BsplineSpace | THBSplineSpace: The global space passed at construction.
+        """
+        return self._global_space
+
+    @property
+    def partition(self) -> Partition:
+        """Get the cell-ownership partition.
+
+        Returns:
+            Partition: The partition passed at construction.
+        """
+        return self._partition
+
+    @property
+    def local(self) -> LocalSpace | None:
+        """Get this rank's local windowed space, or ``None`` if it owns no cells.
+
+        Returns:
+            LocalSpace | None: The rank-local space (windowed space plus local-to-global
+            cell/DOF maps and ownership masks), or ``None`` when ``owns_cells`` is
+            ``False``.
+        """
+        return self._local
+
+    @property
+    def owns_cells(self) -> bool:
+        """Report whether this rank owns at least one cell.
+
+        Returns:
+            bool: ``True`` iff :attr:`local` is not ``None``.
+        """
+        return self._local is not None
+
+    @property
+    def owned_cells(self) -> npt.NDArray[np.int64]:
+        """Get the global ids of the cells this rank owns.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only sorted global cell ids owned by this rank
+            (empty if the rank owns none).
+        """
+        return self._owned_cells
+
+
+def _global_cell_count(space: BsplineSpace | THBSplineSpace) -> int:
+    """Return the number of cells in a space's grid.
+
+    Args:
+        space (BsplineSpace | THBSplineSpace): The global space.
+
+    Returns:
+        int: ``grid.num_cells`` for a THB space, else ``num_total_intervals``.
+    """
+    if isinstance(space, THBSplineSpace):
+        return space.grid.num_cells
+    return space.num_total_intervals
+
+
+__all__ = ["DistributedSpace"]

--- a/src/pantr/mpi/_distributed_space.py
+++ b/src/pantr/mpi/_distributed_space.py
@@ -7,21 +7,21 @@ every rank), it builds *this rank's* windowed :class:`~pantr.bspline.LocalSpace`
 and no DOF exchange -- consistent with pantr's redundant per-rank storage model
 (cross-rank coupling is the consumer's job, e.g. via a PETSc ``PtAP``).
 
-``mpi4py`` is not imported: the communicator is supplied by the caller and only its
-``rank`` and ``size`` are read, so ``import pantr.mpi`` still works without MPI.
+``mpi4py`` is not imported by this module: the communicator is treated as an opaque object
+and only its ``rank`` and ``size`` attributes are read.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..bspline import THBSplineSpace, build_local
+from ..bspline import BsplineSpace, THBSplineSpace, build_local
 
 if TYPE_CHECKING:
     import numpy as np
     import numpy.typing as npt
 
-    from ..bspline import BsplineSpace, LocalSpace
+    from ..bspline import LocalSpace
     from ..grid import Partition
 
 
@@ -38,9 +38,16 @@ class DistributedSpace:
     every rank (guaranteed by pantr's deterministic partitioners and by
     :func:`~pantr.mpi.from_dolfinx`), so each rank can window the global space locally.
 
-    Attributes are exposed through the :attr:`comm`, :attr:`rank`, :attr:`n_parts`,
-    :attr:`global_space`, :attr:`partition`, :attr:`local`, :attr:`owns_cells`, and
-    :attr:`owned_cells` properties.
+    The public surface exposes:
+
+    - :attr:`comm` -- the MPI communicator passed at construction.
+    - :attr:`rank` -- this rank's id within the communicator.
+    - :attr:`n_parts` -- number of ranks the space is distributed over.
+    - :attr:`global_space` -- the undistributed global space.
+    - :attr:`partition` -- the cell-ownership partition.
+    - :attr:`local` -- this rank's windowed local space (``None`` if it owns no cells).
+    - :attr:`owns_cells` -- whether this rank owns at least one cell.
+    - :attr:`owned_cells` -- read-only sorted global cell ids owned by this rank.
     """
 
     __slots__ = ("_comm", "_global_space", "_local", "_owned_cells", "_partition", "_rank")
@@ -62,11 +69,22 @@ class DistributedSpace:
                 ``rank`` and ``size`` attributes are read.
 
         Raises:
-            ValueError: If ``comm.size != partition.n_parts``; if ``partition`` does not
-                match the global space's cell count; if ``comm.rank`` is out of range; or
-                if ``global_space`` is a periodic :class:`~pantr.bspline.BsplineSpace`.
+            ValueError: If ``global_space`` is a periodic
+                :class:`~pantr.bspline.BsplineSpace`; if ``comm.size != partition.n_parts``;
+                if ``partition`` does not match the global space's cell count; or if
+                ``comm.rank`` is outside ``[0, comm.size)`` (delegated to
+                :meth:`~pantr.grid.Partition.owned_cells`).
+
+        Note:
+            Unlike :func:`~pantr.bspline.build_local`, construction succeeds when this rank
+            owns no cells -- :attr:`local` is set to ``None`` and :attr:`owns_cells` to
+            ``False``.
         """
-        size = int(comm.size)
+        if isinstance(global_space, BsplineSpace) and any(
+            sp.periodic for sp in global_space.spaces
+        ):
+            raise ValueError("periodic B-spline spaces are not supported.")
+        size = int(comm.size)  # int() guards against mpi4py returning numpy.intp
         if size != partition.n_parts:
             raise ValueError(
                 f"comm.size ({size}) must equal partition.n_parts ({partition.n_parts})."
@@ -78,7 +96,7 @@ class DistributedSpace:
                 f"expected {n_global_cells} (the global space's cell count)."
             )
 
-        rank = int(comm.rank)
+        rank = int(comm.rank)  # int() guards against mpi4py returning numpy.intp
         owned = partition.owned_cells(rank)  # validates rank in [0, n_parts)
         owned.flags.writeable = False
 
@@ -87,6 +105,7 @@ class DistributedSpace:
         self._partition = partition
         self._rank = rank
         self._owned_cells = owned
+        # build_local raises if the rank owns no cells; guard here to support empty ranks.
         self._local: LocalSpace | None = (
             build_local(global_space, partition, rank) if owned.size else None
         )
@@ -114,7 +133,7 @@ class DistributedSpace:
         """Get the number of ranks (parts) the space is distributed over.
 
         Returns:
-            int: ``comm.size`` (equal to ``partition.n_parts``).
+            int: ``partition.n_parts`` (equal to ``comm.size`` at construction time).
         """
         return self._partition.n_parts
 
@@ -143,7 +162,12 @@ class DistributedSpace:
         Returns:
             LocalSpace | None: The rank-local space (windowed space plus local-to-global
             cell/DOF maps and ownership masks), or ``None`` when ``owns_cells`` is
-            ``False``.
+            ``False``. See :class:`~pantr.bspline.LocalSpace` for all fields.
+
+        Note:
+            Callers must narrow the type before use: ``assert ds.local is not None``
+            or ``if ds.local is not None``. :attr:`owns_cells` does not statically
+            narrow this property in mypy.
         """
         return self._local
 

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -11,6 +11,7 @@ import pytest
 
 from pantr.bspline import (
     BsplineSpace,
+    BsplineSpace1D,
     LocalSpace,
     THBSplineSpace,
     build_local,
@@ -58,6 +59,15 @@ def _tp_space_and_partition(n_parts: int) -> tuple[BsplineSpace, Partition]:
     return space, part
 
 
+def _thb_space_and_partition(n_parts: int) -> tuple[THBSplineSpace, Partition]:
+    root = create_uniform_space(2, 4)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    grid.refine(0, [0], [2])
+    thb = THBSplineSpace(root, grid)
+    part = partition_grid(thb.grid, n_parts)
+    return thb, part
+
+
 # --------------------------------------------------------------------------- #
 # Local space delegation
 # --------------------------------------------------------------------------- #
@@ -72,11 +82,7 @@ def test_local_matches_build_local_tp() -> None:
 
 
 def test_local_matches_build_local_thb() -> None:
-    root = create_uniform_space(2, 4)
-    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
-    grid.refine(0, [0], [2])
-    thb = THBSplineSpace(root, grid)
-    part = partition_grid(thb.grid, 2)
+    thb, part = _thb_space_and_partition(2)
     for rank in range(2):
         ds = DistributedSpace(thb, part, _FakeComm(rank, 2))
         assert ds.local is not None
@@ -98,6 +104,7 @@ def test_metadata() -> None:
     assert ds.global_space is space
     assert ds.partition is part
     assert ds.owns_cells is True
+    assert ds.n_parts == comm.size == ds.partition.n_parts
     np.testing.assert_array_equal(ds.owned_cells, part.owned_cells(2))
     assert not ds.owned_cells.flags.writeable
 
@@ -115,6 +122,14 @@ def test_owned_cells_partition_the_grid() -> None:
     np.testing.assert_array_equal(np.sort(owned), np.arange(space.num_total_intervals))
 
 
+def test_owned_cells_partition_the_grid_thb() -> None:
+    thb, part = _thb_space_and_partition(2)
+    owned = np.concatenate(
+        [DistributedSpace(thb, part, _FakeComm(r, 2)).owned_cells for r in range(2)]
+    )
+    np.testing.assert_array_equal(np.sort(owned), np.arange(thb.grid.num_cells))
+
+
 def test_owned_dofs_partition_the_global_space() -> None:
     space, part = _tp_space_and_partition(4)
     owned_dofs = []
@@ -124,6 +139,17 @@ def test_owned_dofs_partition_the_global_space() -> None:
         owned_dofs.append(local.local_to_global_dof[local.owned_dof_mask])
     allotted = np.concatenate(owned_dofs)
     np.testing.assert_array_equal(np.sort(allotted), np.arange(space.num_total_basis))
+
+
+def test_owned_dofs_partition_the_global_space_thb() -> None:
+    thb, part = _thb_space_and_partition(2)
+    owned_dofs = []
+    for rank in range(2):
+        local = DistributedSpace(thb, part, _FakeComm(rank, 2)).local
+        assert local is not None
+        owned_dofs.append(local.local_to_global_dof[local.owned_dof_mask])
+    allotted = np.concatenate(owned_dofs)
+    np.testing.assert_array_equal(np.sort(allotted), np.arange(thb.num_total_basis))
 
 
 # --------------------------------------------------------------------------- #
@@ -142,6 +168,7 @@ def test_empty_rank_has_no_local() -> None:
     assert empty.owns_cells is False
     assert empty.local is None
     assert empty.owned_cells.size == 0
+    assert not empty.owned_cells.flags.writeable
 
 
 # --------------------------------------------------------------------------- #
@@ -165,5 +192,22 @@ def test_partition_cell_count_mismatch_raises() -> None:
 def test_rank_out_of_range_raises() -> None:
     space, part = _tp_space_and_partition(4)
     # comm.size matches n_parts, but rank 4 is out of [0, 4).
-    with pytest.raises(ValueError, match="rank"):
+    with pytest.raises(ValueError, match=r"rank must be in \[0,"):
         DistributedSpace(space, part, _FakeComm(4, 4))
+
+
+def test_periodic_space_raises() -> None:
+    from pantr.bspline import create_uniform_periodic_knots  # noqa: PLC0415
+
+    # Periodic check must fire eagerly on every rank, including empty ones.
+    knots_p = create_uniform_periodic_knots(num_intervals=4, degree=2)
+    sp1d_periodic = BsplineSpace1D(knots_p, 2, periodic=True)
+    periodic_space = BsplineSpace([sp1d_periodic])
+    n_cells = periodic_space.num_total_intervals
+    part = Partition(np.zeros(n_cells, dtype=np.int64), 1)
+    with pytest.raises(ValueError, match="periodic"):
+        DistributedSpace(periodic_space, part, _FakeComm(0, 1))
+    # Empty rank (rank 1 owns nothing) must also raise without reaching build_local.
+    part2 = Partition(np.zeros(n_cells, dtype=np.int64), 2)
+    with pytest.raises(ValueError, match="periodic"):
+        DistributedSpace(periodic_space, part2, _FakeComm(1, 2))

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -1,0 +1,169 @@
+"""Tests for :class:`pantr.mpi.DistributedSpace`.
+
+MPI is not available in the test environment, so the communicator is duck-typed by
+``_FakeComm`` (exposing only ``rank`` and ``size``, which is all DistributedSpace reads).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.bspline import (
+    BsplineSpace,
+    LocalSpace,
+    THBSplineSpace,
+    build_local,
+    create_uniform_space,
+)
+from pantr.grid import (
+    Partition,
+    hierarchical_grid,
+    partition_grid,
+    tensor_product_grid,
+    uniform_grid,
+)
+from pantr.mpi import DistributedSpace
+
+
+class _FakeComm:
+    """Minimal stand-in for an mpi4py communicator (rank/size only)."""
+
+    def __init__(self, rank: int, size: int) -> None:
+        self._rank = rank
+        self._size = size
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+
+def _assert_local_equal(a: LocalSpace, b: LocalSpace) -> None:
+    np.testing.assert_array_equal(a.local_to_global_cell, b.local_to_global_cell)
+    np.testing.assert_array_equal(a.local_to_global_dof, b.local_to_global_dof)
+    np.testing.assert_array_equal(a.owned_cell_mask, b.owned_cell_mask)
+    np.testing.assert_array_equal(a.owned_dof_mask, b.owned_dof_mask)
+    assert a.n_global_cells == b.n_global_cells
+    assert a.n_global_dofs == b.n_global_dofs
+    assert a.space.num_total_basis == b.space.num_total_basis
+
+
+def _tp_space_and_partition(n_parts: int) -> tuple[BsplineSpace, Partition]:
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), n_parts)
+    return space, part
+
+
+# --------------------------------------------------------------------------- #
+# Local space delegation
+# --------------------------------------------------------------------------- #
+
+
+def test_local_matches_build_local_tp() -> None:
+    space, part = _tp_space_and_partition(4)
+    for rank in range(4):
+        ds = DistributedSpace(space, part, _FakeComm(rank, 4))
+        assert ds.local is not None
+        _assert_local_equal(ds.local, build_local(space, part, rank))
+
+
+def test_local_matches_build_local_thb() -> None:
+    root = create_uniform_space(2, 4)
+    grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+    grid.refine(0, [0], [2])
+    thb = THBSplineSpace(root, grid)
+    part = partition_grid(thb.grid, 2)
+    for rank in range(2):
+        ds = DistributedSpace(thb, part, _FakeComm(rank, 2))
+        assert ds.local is not None
+        _assert_local_equal(ds.local, build_local(thb, part, rank))
+
+
+# --------------------------------------------------------------------------- #
+# Metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_metadata() -> None:
+    space, part = _tp_space_and_partition(4)
+    comm = _FakeComm(2, 4)
+    ds = DistributedSpace(space, part, comm)
+    assert ds.comm is comm
+    assert ds.rank == 2
+    assert ds.n_parts == 4
+    assert ds.global_space is space
+    assert ds.partition is part
+    assert ds.owns_cells is True
+    np.testing.assert_array_equal(ds.owned_cells, part.owned_cells(2))
+    assert not ds.owned_cells.flags.writeable
+
+
+# --------------------------------------------------------------------------- #
+# Distributed correctness: owned cells / DOFs partition the globals exactly
+# --------------------------------------------------------------------------- #
+
+
+def test_owned_cells_partition_the_grid() -> None:
+    space, part = _tp_space_and_partition(4)
+    owned = np.concatenate(
+        [DistributedSpace(space, part, _FakeComm(r, 4)).owned_cells for r in range(4)]
+    )
+    np.testing.assert_array_equal(np.sort(owned), np.arange(space.num_total_intervals))
+
+
+def test_owned_dofs_partition_the_global_space() -> None:
+    space, part = _tp_space_and_partition(4)
+    owned_dofs = []
+    for rank in range(4):
+        local = DistributedSpace(space, part, _FakeComm(rank, 4)).local
+        assert local is not None
+        owned_dofs.append(local.local_to_global_dof[local.owned_dof_mask])
+    allotted = np.concatenate(owned_dofs)
+    np.testing.assert_array_equal(np.sort(allotted), np.arange(space.num_total_basis))
+
+
+# --------------------------------------------------------------------------- #
+# Empty ranks
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_rank_has_no_local() -> None:
+    space = create_uniform_space([2, 2], [4, 4])
+    # Rank 0 owns every cell; rank 1 owns none.
+    part = Partition(np.zeros(space.num_total_intervals, dtype=np.int64), 2)
+    full = DistributedSpace(space, part, _FakeComm(0, 2))
+    empty = DistributedSpace(space, part, _FakeComm(1, 2))
+    assert full.owns_cells is True
+    assert full.local is not None
+    assert empty.owns_cells is False
+    assert empty.local is None
+    assert empty.owned_cells.size == 0
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+def test_comm_size_mismatch_raises() -> None:
+    space, part = _tp_space_and_partition(4)
+    with pytest.raises(ValueError, match="must equal partition.n_parts"):
+        DistributedSpace(space, part, _FakeComm(0, 3))
+
+
+def test_partition_cell_count_mismatch_raises() -> None:
+    space = create_uniform_space([2, 2], [4, 4])  # 16 cells
+    part = Partition(np.zeros(10, dtype=np.int64), 1)  # wrong cell count
+    with pytest.raises(ValueError, match="the global space's cell count"):
+        DistributedSpace(space, part, _FakeComm(0, 1))
+
+
+def test_rank_out_of_range_raises() -> None:
+    space, part = _tp_space_and_partition(4)
+    # comm.size matches n_parts, but rank 4 is out of [0, 4).
+    with pytest.raises(ValueError, match="rank"):
+        DistributedSpace(space, part, _FakeComm(4, 4))

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -17,8 +17,15 @@ def test_import_and_public_surface() -> None:
     assert callable(pantr.mpi.mpi_available)
     assert callable(pantr.mpi.require_mpi)
     assert callable(pantr.mpi.from_dolfinx)
+    assert isinstance(pantr.mpi.DistributedSpace, type)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
-    assert set(pantr.mpi.__all__) == {"HAS_MPI", "from_dolfinx", "mpi_available", "require_mpi"}
+    assert set(pantr.mpi.__all__) == {
+        "DistributedSpace",
+        "HAS_MPI",
+        "from_dolfinx",
+        "mpi_available",
+        "require_mpi",
+    }
 
 
 def test_mpi_available_matches_find_spec() -> None:


### PR DESCRIPTION
## Summary

**Phase C2 — the capstone.** `pantr.mpi.DistributedSpace` ties the partition sources (Phase B) and the windowing core (Phase A) together into the top-level distributed-space object.

- **`DistributedSpace(global_space, partition, comm)`** — the per-rank, SPMD handle. Every rank constructs its own from the *same* global space + partition and holds only its own `LocalSpace`, built via the existing `build_local`.
- **No MPI communication at construction** — the partition is identical on every rank (guaranteed by the deterministic partitioners and by `from_dolfinx`), so each rank windows the global space locally. Consistent with pantr's redundant per-rank storage / no-DOF-exchange model.
- **Empty ranks are graceful** — a rank owning no cells (over-provisioned run, or a `from_dolfinx` partition that leaves a rank empty) gets `local=None` / `owns_cells=False` rather than raising, avoiding a one-rank failure mid-SPMD (a deadlock hazard).
- **Surface:** `comm`, `rank`, `n_parts`, `global_space`, `partition`, `local`, `owns_cells`, `owned_cells`. Local-to-global maps and ownership masks come through `.local` (the `LocalSpace`) — no duplication.
- **No hard MPI dependency:** `mpi4py` is never imported; the communicator is supplied by the caller and only its `rank`/`size` are read, so `import pantr.mpi` still works without MPI and the object is fully unit-testable with a fake comm.

Validates `comm.size == partition.n_parts` and that the partition matches the global space's cell count.

## Test plan

- [x] `local` matches `build_local(global_space, partition, rank)` for every rank — tensor-product **and** THB.
- [x] Distributed correctness: across ranks, the owned cells partition the grid exactly, and the owned DOFs partition the global space exactly (disjoint union == all).
- [x] Empty rank → `local is None`, `owns_cells is False`, `owned_cells` empty (rank 0 owns all, rank 1 none).
- [x] Metadata (`comm`/`rank`/`n_parts`/`global_space`/`partition`/`owned_cells` read-only).
- [x] Validation: `comm.size != n_parts`, partition/space cell-count mismatch, rank out of range.
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT (mpi -> core only); full suite 3400 passed (1 skipped); docs `-W` ok; `_distributed_space.py` + `pantr/mpi/__init__.py` 100% coverage (TOTAL 95%).

Generated with [Claude Code](https://claude.com/claude-code)