### PR TITLE
test(mpi): real-MPI smoke tests + dedicated mpiexec CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,3 +255,55 @@ jobs:
         run: |
           . .venv/bin/activate
           make docs SPHINXOPTS="-W --keep-going -j auto"
+
+  mpi-tests:
+    name: MPI tests (mpiexec)
+    needs: [lint, type-check]
+    runs-on: ubuntu-latest
+    # The only job that exercises the real distributed stack under multiple ranks, so
+    # unlike the rest it KEEPS the default mpi4py dependency (PANTR_NO_MPI unset) and
+    # builds mpi4py from source against the system OpenMPI -- the prebuilt wheels bundle
+    # MPICH, which would not match the `openmpi-bin` launcher. PANTR_RUN_MPI enables the
+    # otherwise-skipped tests under tests/mpi/.
+    env:
+      PANTR_NO_MPI: ""
+      PANTR_RUN_MPI: "1"
+      PIP_NO_BINARY: "mpi4py"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install OpenMPI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopenmpi-dev openmpi-bin
+
+      - name: Create venv and install (with mpi4py, built from source)
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify mpi4py matches the launcher
+        run: |
+          . .venv/bin/activate
+          mpiexec --oversubscribe -n 2 python -c "from mpi4py import MPI; assert MPI.COMM_WORLD.size == 2"
+
+      - name: Run MPI smoke tests (2 ranks)
+        run: |
+          . .venv/bin/activate
+          mpiexec --oversubscribe -n 2 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+
+      - name: Run MPI smoke tests (3 ranks)
+        run: |
+          . .venv/bin/activate
+          mpiexec --oversubscribe -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,12 @@ mypy --config-file mypy.ini src tests                               # type check
 lint-imports                                                        # import boundaries (core must not import pantr.mpi)
 NUMBA_DISABLE_JIT=1 make docs SPHINXOPTS="-W --keep-going -j auto"  # docs build (matches CI)
 PANTR_NO_MPI=1 pip install -e ".[dev]"                              # serial-only install (drop mpi4py)
+PANTR_RUN_MPI=1 mpiexec -n 2 python -m pytest tests/mpi/ --no-cov   # MPI smoke tests (needs mpi4py + MPI launcher)
 ```
+
+> `tests/mpi/` holds real-MPI smoke tests; they are **skipped** unless `PANTR_RUN_MPI` is set
+> (and run under `mpiexec`). The default `pytest` run collects and skips them. CI runs them in a
+> dedicated `mpi-tests` job (installs OpenMPI, builds `mpi4py` from source, `mpiexec -n {2,3}`).
 
 > Default pytest (via `pytest.ini`) adds `--cov`, which slows things down and requires ≥85% coverage. Always pass `--no-cov` during development.
 

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -1,0 +1,75 @@
+"""Real-MPI smoke tests for the distributed-space stack (run under ``mpiexec``).
+
+Skipped unless ``PANTR_RUN_MPI`` is set (and ``mpi4py`` is importable). The dedicated CI
+job runs them as ``PANTR_RUN_MPI=1 mpiexec -n {2,3} python -m pytest tests/mpi/``. Each
+test is collective: every rank executes the same code on ``MPI.COMM_WORLD``, so the
+partition and the global space are identical across ranks and the cross-rank invariants
+are checked with real ``allgather`` collectives.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from pantr.bspline import build_local, create_uniform_space
+from pantr.grid import partition_grid, tensor_product_grid
+from pantr.mpi import DistributedSpace, from_dolfinx
+
+MPI = pytest.importorskip("mpi4py.MPI")
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("PANTR_RUN_MPI"),
+    reason="MPI test: set PANTR_RUN_MPI=1 and run under mpiexec",
+)
+
+
+def test_distributed_space_partitions_globals_across_ranks() -> None:
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])  # identical on every rank
+    partition = partition_grid(tensor_product_grid(space), comm.size)  # deterministic
+    ds = DistributedSpace(space, partition, comm)
+
+    assert ds.rank == comm.rank
+    assert ds.n_parts == comm.size
+    assert ds.local is not None  # the block backend never leaves a rank empty
+
+    # This rank's local space equals the serial build for its rank.
+    ref = build_local(space, partition, comm.rank)
+    np.testing.assert_array_equal(ds.local.local_to_global_cell, ref.local_to_global_cell)
+    np.testing.assert_array_equal(ds.local.local_to_global_dof, ref.local_to_global_dof)
+
+    # Collective: owned DOFs and cells across ranks partition the globals exactly.
+    all_dofs = np.concatenate(comm.allgather(ds.local.local_to_global_dof[ds.local.owned_dof_mask]))
+    np.testing.assert_array_equal(np.sort(all_dofs), np.arange(space.num_total_basis))
+
+    all_cells = np.concatenate(comm.allgather(ds.owned_cells))
+    np.testing.assert_array_equal(np.sort(all_cells), np.arange(space.num_total_intervals))
+
+
+def _slice_mesh(comm: Any, owned: list[int]) -> SimpleNamespace:
+    """A dolfinx-mesh stand-in over the real communicator: this rank owns ``owned``."""
+    return SimpleNamespace(
+        comm=comm,
+        topology=SimpleNamespace(
+            dim=1,
+            original_cell_index=np.asarray(owned, dtype=np.int64),
+            index_map=lambda _dim: SimpleNamespace(size_local=len(owned)),
+        ),
+    )
+
+
+def test_from_dolfinx_assembles_global_partition_across_ranks() -> None:
+    comm = MPI.COMM_WORLD
+    per_rank = 4
+    n_cells = per_rank * comm.size
+    owned = list(range(comm.rank * per_rank, (comm.rank + 1) * per_rank))
+    partition = from_dolfinx(_slice_mesh(comm, owned), n_cells)  # real allgather collective
+
+    assert partition.n_parts == comm.size
+    expected = np.repeat(np.arange(comm.size), per_rank)
+    np.testing.assert_array_equal(partition.cell_owner, expected)


### PR DESCRIPTION
## Summary

Adds the first tests that exercise the distribution stack under **real MPI ranks** (everything so far was validated with fake comms / serial rank-loops), plus the CI job to run them — modeled on how dolfinx tests MPI, but scoped to a small collective suite rather than running the whole suite under `mpiexec`.

- **`tests/mpi/test_distributed_mpi.py`** — collective smoke tests on `MPI.COMM_WORLD`:
  - `DistributedSpace` across ranks: each rank's `.local` equals serial `build_local(space, partition, comm.rank)`, and `allgather` confirms the owned cells **and** DOFs partition the globals exactly.
  - `from_dolfinx`'s real `allgather` assembly — a fake mesh wrapping the real communicator, so the one genuine collective in the codebase runs under real MPI without needing dolfinx in CI.
- **Gated**: skipped unless `PANTR_RUN_MPI=1` (and `mpi4py` importable), so the default `pytest` run collects-and-skips them and stays green with no MPI. (`tests/mpi/` is *not* run under the main suite.)
- **`mpi-tests` CI job**: installs OpenMPI via apt; keeps the default `mpi4py` dependency (overrides the workflow-level `PANTR_NO_MPI`) and builds `mpi4py` **from source** against the system OpenMPI — prebuilt wheels bundle MPICH, which wouldn't match the `openmpi-bin` launcher; asserts `COMM_WORLD.size` (loud failure if a launcher/lib mismatch ever sneaks in); then runs `mpiexec --oversubscribe -n {2,3} python -m pytest tests/mpi/`. This is also the **one CI job that exercises the real default `mpi4py` install** (every other job uses `PANTR_NO_MPI=1`).

## Why not dolfinx's exact approach

dolfinx re-runs its *entire* unit suite under `mpiexec -np 3` because every test is collective by design. pantr's ~3400 tests are serial numerics, so only this small dedicated suite runs under MPI.

## Test plan

- [x] Validated locally under OpenMPI 5.0.9 at **`mpiexec -n 2` and `-n 3`** (both pass).
- [x] Default `pytest` (no `PANTR_RUN_MPI`): the two MPI tests skip cleanly (full suite 3404 passed, 2 skipped).
- [x] `ruff` / `ruff format` / `mypy` clean; `lint-imports` KEPT; docs `-W` ok.
- [ ] The new `mpi-tests` CI job runs on this PR (first real exercise on GitHub's runners).

Generated with [Claude Code](https://claude.com/claude-code)