### PR TITLE
fix(bezier): cap root-dedup merge radius and clamp batch root count

### DIFF
--- a/src/pantr/bezier/_batch_core.py
+++ b/src/pantr/bezier/_batch_core.py
@@ -16,8 +16,7 @@ import numpy as np
 from numpy import typing as npt
 
 from pantr._numba_compat import nb_jit, nb_prange
-from pantr.bezier._clipping_core import _clip_roots_core
-from pantr.bezier._root_finding_core import _DBL_EPSILON
+from pantr.bezier._clipping_core import _clip_roots_core, _dedup_roots_core
 from pantr.bezier._yuksel_core import (
     _solve_monotone_root_kernel,
     _yuksel_roots,
@@ -38,7 +37,7 @@ Duplicated from ``_find_roots.py`` -- keep in sync.
 
 
 @nb_jit(nopython=True, cache=True)
-def _dispatch_and_find(  # noqa: PLR0912
+def _dispatch_and_find(
     coeff: npt.NDArray[np.float32 | np.float64],
     param_tol: float,
     geom_tol: float,
@@ -98,31 +97,9 @@ def _dispatch_and_find(  # noqa: PLR0912
     if n_roots == 0:
         return raw_roots, 0
 
-    # Sort (simple insertion sort -- n_roots is small).
-    for i in range(1, n_roots):
-        key = raw_roots[i]
-        j = i - 1
-        while j >= 0 and raw_roots[j] > key:
-            raw_roots[j + 1] = raw_roots[j]
-            j -= 1
-        raw_roots[j + 1] = key
-
-    # Basic dedup.
-    coeff_scale = 0.0
-    for i in range(n + 1):
-        coeff_scale = max(coeff_scale, abs(coeff[i]))
-    zero_tol = max(coeff_scale * (n + 1) * 4.0 * _DBL_EPSILON, geom_tol)
-    dedup_tol = max(param_tol * 2.0, zero_tol * 4.0)
-
-    out = np.empty(n_roots, dtype=np.float64)
-    out[0] = raw_roots[0]
-    count = 1
-    for i in range(1, n_roots):
-        if raw_roots[i] - out[count - 1] > dedup_tol:
-            out[count] = raw_roots[i]
-            count += 1
-
-    return out, count
+    # Sort and deduplicate with the shared derivative-aware merge (capped for
+    # multiple roots), matching the single-polynomial path.
+    return _dedup_roots_core(raw_roots, n_roots, coeff, param_tol, geom_tol)
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
@@ -158,6 +135,9 @@ def _find_roots_batch_core(
     for i in nb_prange(n_polys):
         coeff_i = coeffs[i].copy()
         roots, count = _dispatch_and_find(coeff_i, param_tol, geom_tol)
+        # A degree-n polynomial has at most n roots; clamp as a memory-safety
+        # backstop so a dedup artifact can never overflow the output row.
+        count = min(count, out_roots.shape[1])
         out_counts[i] = count
         for j in range(count):
             out_roots[i, j] = roots[j]

--- a/src/pantr/bezier/_clipping_core.py
+++ b/src/pantr/bezier/_clipping_core.py
@@ -298,6 +298,83 @@ def _clip_roots_core(  # noqa: PLR0912, PLR0915
     return roots, n_roots
 
 
+@nb_jit(nopython=True, cache=True)
+def _dedup_roots_core(
+    raw_roots: npt.NDArray[np.float32 | np.float64],
+    n_roots: int,
+    coeff: npt.NDArray[np.float32 | np.float64],
+    param_tol: float,
+    geom_tol: float,
+) -> tuple[npt.NDArray[np.float64], int]:
+    """Sort and deduplicate raw root candidates with derivative-aware merging.
+
+    The same root can be reported from multiple converging intervals. The
+    maximum gap between duplicates is ``O(zero_tol / |f'(root)|)``, so the
+    dedup threshold is adaptive: for each candidate, the derivative is
+    evaluated and the local merge radius is computed.
+
+    At a multiple root ``f'(root) = 0`` and the linearized radius diverges, so
+    it is capped at ``zero_tol ** (1/3)`` -- an upper bound on the candidate
+    cluster width around roots of multiplicity up to three (``|f| <= zero_tol``
+    within ``O(zero_tol ** (1/m))`` of a multiplicity-``m`` root). Without the
+    cap, an exact multiple root would swallow every later candidate.
+
+    Args:
+        raw_roots (npt.NDArray[np.float32 | np.float64]): Unsorted array of root
+            candidates. Only the first ``n_roots`` entries are valid.
+        n_roots (int): Number of valid entries in ``raw_roots``.
+        coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein coefficients
+            (used for derivative evaluation during dedup).
+        param_tol (float): Parametric tolerance.
+        geom_tol (float): Geometric tolerance.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], int]: ``(roots, count)`` where only the
+            first ``count`` entries of ``roots`` are valid, sorted ascending.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bezier.find_roots` instead.
+    """
+    out = np.empty(max(n_roots, 1), dtype=np.float64)
+    if n_roots == 0:
+        return out, 0
+
+    n = len(coeff) - 1
+    coeff_scale = 0.0
+    for i in range(n + 1):
+        coeff_scale = max(coeff_scale, abs(float(coeff[i])))
+    zero_tol = max(coeff_scale * (n + 1) * 4.0 * _DBL_EPSILON, geom_tol)
+    base_dedup = max(param_tol * 2.0, zero_tol * 4.0)
+    radius_cap = zero_tol ** (1.0 / 3.0)
+
+    for i in range(n_roots):
+        out[i] = raw_roots[i]
+    # Insertion sort -- n_roots is small.
+    for i in range(1, n_roots):
+        key = out[i]
+        j = i - 1
+        while j >= 0 and out[j] > key:
+            out[j + 1] = out[j]
+            j -= 1
+        out[j + 1] = key
+
+    count = 1
+    for i in range(1, n_roots):
+        gap = out[i] - out[count - 1]
+        if gap <= base_dedup:
+            continue
+        # Derivative-aware merge, capped for (near-)multiple roots.
+        _, df = _de_casteljau_eval_and_deriv_scalar(coeff, out[count - 1])
+        local_tol = zero_tol / max(abs(df), _DBL_EPSILON)
+        if gap <= max(base_dedup, min(local_tol * 4.0, radius_cap)):
+            continue
+        out[count] = out[i]
+        count += 1
+
+    return out, count
+
+
 def _dedup_roots(
     raw_roots: npt.NDArray[np.float32 | np.float64],
     n_roots: int,
@@ -305,12 +382,10 @@ def _dedup_roots(
     param_tol: float,
     geom_tol: float,
 ) -> npt.NDArray[np.float64]:
-    """Sort and deduplicate raw root candidates with derivative-aware merging.
+    """Sort and deduplicate raw root candidates (plain-Python wrapper).
 
-    The same root can be reported from multiple converging intervals. The
-    maximum gap between duplicates is ``O(zero_tol / |f'(root)|)``, so the
-    dedup threshold is adaptive: for each candidate, the derivative is
-    evaluated and the local merge radius is computed.
+    Thin wrapper around :func:`_dedup_roots_core` returning only the valid
+    prefix; see that kernel for the merge-radius logic.
 
     Args:
         raw_roots (npt.NDArray[np.float32 | np.float64]): Unsorted array of root
@@ -326,26 +401,9 @@ def _dedup_roots(
     """
     if n_roots == 0:
         return np.empty(0, dtype=np.float64)
-
-    n = len(coeff) - 1
-    coeff_scale = float(np.max(np.abs(coeff)))
-    zero_tol = max(coeff_scale * (n + 1) * 4.0 * _DBL_EPSILON, geom_tol)
-    base_dedup = max(param_tol * 2.0, zero_tol * 4.0)
-
-    result = sorted(float(raw_roots[i]) for i in range(n_roots))
-    unique: list[float] = [result[0]]
-    for r in result[1:]:
-        gap = r - unique[-1]
-        if gap <= base_dedup:
-            continue
-        # Derivative-aware merge.
-        _, df = _de_casteljau_eval_and_deriv_scalar(coeff, unique[-1])
-        local_tol = zero_tol / max(abs(df), _DBL_EPSILON)
-        if gap <= max(base_dedup, local_tol * 4.0):
-            continue
-        unique.append(r)
-
-    return np.array(unique, dtype=np.float64)
+    out, count = _dedup_roots_core(raw_roots, n_roots, coeff, param_tol, geom_tol)
+    result: npt.NDArray[np.float64] = out[:count].copy()
+    return result
 
 
 def _warmup_numba_functions() -> None:
@@ -354,4 +412,5 @@ def _warmup_numba_functions() -> None:
     Called from the background warmup thread in ``pantr.__init__``.
     """
     dummy = np.array([1.0, -1.0, 0.5], dtype=np.float64)
-    _clip_roots_core(dummy, 1e-12, 1e-12)
+    raw, n_raw = _clip_roots_core(dummy, 1e-12, 1e-12)
+    _dedup_roots_core(raw, n_raw, dummy, 1e-12, 1e-12)

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -111,11 +111,6 @@ def _bernstein_degree6_from_roots(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="dedup merge radius zero_tol/|f'| is unbounded at a multiple root: an exact "
-    "double root at t=0 swallows every other root on the clipping path (degree >= 6)",
-)
 def test_find_roots_double_root_at_zero_keeps_other_roots() -> None:
     # f(t) = t^2 (t - 0.5) (t + 1) (t^2 + 1): roots in [0, 1] are 0 (double) and 0.5.
     coeffs = _bernstein_degree6_from_roots([0.0, 0.0, 0.5, -1.0], [1.0, 0.0, 1.0])
@@ -124,17 +119,6 @@ def test_find_roots_double_root_at_zero_keeps_other_roots() -> None:
     assert np.any(np.abs(roots) < 1e-6), f"root at 0 missing: {roots!r}"
 
 
-@pytest.mark.skipif(
-    not _JIT_DISABLED,
-    reason="the unclamped count overflows out_roots: an out-of-bounds write is "
-    "memory-unsafe under JIT (nopython kernels have no bounds checks)",
-)
-@pytest.mark.xfail(
-    strict=True,
-    reason="batch dedup does not clamp the root count to the polynomial degree: "
-    "candidates around several even-multiplicity roots overflow the (degree,)-wide "
-    "output row (IndexError with JIT disabled, memory corruption with JIT)",
-)
 def test_find_roots_batch_multiple_double_roots_within_degree() -> None:
     # f(t) = t^2 (t - 0.3)^2 (t - 0.7)^2, degree 6, three double roots.
     coeffs = _bernstein_degree6_from_roots([0.0, 0.0, 0.3, 0.3, 0.7, 0.7])
@@ -145,8 +129,8 @@ def test_find_roots_batch_multiple_double_roots_within_degree() -> None:
     for row in range(2):
         count = int(counts[row])
         assert count <= degree
-        row_roots = np.asarray(roots[row][:count], dtype=np.float64)
-        assert np.all((row_roots >= 0.0) & (row_roots <= 1.0))
+        row_roots = np.sort(np.asarray(roots[row][:count], dtype=np.float64))
+        np.testing.assert_allclose(row_roots, [0.0, 0.3, 0.7], atol=1e-6)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the two confirmed `find_roots` bugs from the review (stacked on #192; merge after it).

- **Multiple-root dedup swallowing real roots** — `_dedup_roots`'s derivative-aware merge radius `zero_tol/|f'|` diverges when the kept candidate is an exact multiple root (`f' = 0` → radius ≈ 18 ≫ domain). `find_roots` on `t²(t−0.5)(t+1)(t²+1)` returned `[0.]`. The radius is now capped at `zero_tol**(1/3)` — an upper bound on the candidate-cluster width around roots of multiplicity ≤ 3, far below any meaningful root separation.
- **Batch out-of-bounds write** — the batch path used a fixed ~1e-14 dedup with no count clamp; multiplicity clusters (e.g. `t²(t−0.3)²(t−0.7)²`) produced `count > degree` and overflowed the `(n_polys, degree)` output rows: `IndexError` with JIT disabled, silent memory corruption under `nopython`.

## Changes

- `_clipping_core.py`: new jitted `_dedup_roots_core` (sort + base dedup + capped derivative-aware merge); `_dedup_roots` becomes a thin plain-Python wrapper; warmup extended.
- `_batch_core.py`: `_dispatch_and_find` now calls the shared `_dedup_roots_core` (batch results match the single path); `_find_roots_batch_core` clamps the written count to the row width as a memory-safety backstop.
- `tests/test_review_regressions.py`: the two xfail regressions flip to plain tests; the batch test is strengthened to assert the deduplicated roots `[0, 0.3, 0.7]` and no longer needs the JIT skip.

## Test plan

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `pytest --no-cov` (3425 passed, 16 xfailed) and the root-finding files under `NUMBA_DISABLE_JIT=1`
- [x] Sphinx docs build with `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)