### PR TITLE
fix(grid): multi-level facet adjacency, mutation-counter staleness, NaN locate

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -233,8 +233,10 @@ class THBSplineSpace:
         _func_offset (npt.NDArray[np.int64]): Per-level global-dof base; length
             ``num_levels + 1`` (cumulative active-function counts).
         _num_active (int): Total number of active hierarchical functions.
-        _grid_snapshot (tuple[int, int]): ``(max_level, num_cells)`` captured at
-            construction; used to detect post-construction grid mutations.
+        _grid_snapshot (tuple[int, int, int]): ``(max_level, num_cells, version)``
+            captured at construction; used to detect post-construction grid
+            mutations (the grid's :attr:`~pantr.grid.HierarchicalGrid.version`
+            counter catches mutations the other two cannot distinguish).
         _trunc (dict): Map from global dof (``int``) to ``_TruncCoeffs``;
             only truncated functions appear (empty when ``truncate=False``).
     """
@@ -332,7 +334,7 @@ class THBSplineSpace:
             np.int64
         )
         self._num_active = int(self._func_offset[-1])
-        self._grid_snapshot = (grid.max_level, grid.num_cells)
+        self._grid_snapshot = (grid.max_level, grid.num_cells, grid.version)
         self._trunc = self._compute_truncated_coeffs() if truncate else {}
         # Lazy per-cell cache of _cell_contributions (populated on first access). The
         # space is an immutable construction-time snapshot, so cached results stay valid.
@@ -592,10 +594,11 @@ class THBSplineSpace:
         """Raise if the grid has been modified since this space was constructed.
 
         Raises:
-            RuntimeError: If the grid's ``max_level`` or ``num_cells`` differs from
-                the snapshot taken at construction.
+            RuntimeError: If the grid's ``max_level``, ``num_cells``, or mutation
+                ``version`` differs from the snapshot taken at construction.
         """
-        if (self._grid.max_level, self._grid.num_cells) != self._grid_snapshot:
+        current = (self._grid.max_level, self._grid.num_cells, self._grid.version)
+        if current != self._grid_snapshot:
             raise RuntimeError(
                 "THBSplineSpace is stale: the underlying HierarchicalGrid has been modified "
                 "after construction. Create a new THBSplineSpace from the updated grid."

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -17,8 +17,10 @@ already-refined area is silently correct: only the currently-active portion of
 the region is refined.  Since the children of newly-active cells are always
 disjoint from existing level blocks, no deduplication is needed.
 
-*Automatic single-level balance.*  A level-``l`` frame cell is always adjacent
-to level-``(l+1)`` cells (diff = 1).  No explicit balancing pass is needed.
+*No balance constraint.*  :meth:`refine` imposes no 2:1 grading: cells of any
+two levels may share a facet.  Facet adjacency (:meth:`neighbor_across_facet`,
+:meth:`hanging_neighbors`) walks as many levels up or down as the interface
+requires.
 
 Main exports:
 
@@ -30,6 +32,7 @@ Main exports:
 from __future__ import annotations
 
 import bisect
+import itertools
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -251,9 +254,11 @@ class HierarchicalGrid(Grid):
         _level_base (list[int]): ``_level_base[l]`` is the flat-id base of
             level ``l``; length ``max_level + 2`` (includes sentinel).
         _num_cells (int): Cached total active cell count.
+        _version (int): Monotonic mutation counter, incremented on every
+            structural change (see :attr:`version`).
     """
 
-    __slots__ = ("_blocks", "_factor", "_level_base", "_num_cells", "_root")
+    __slots__ = ("_blocks", "_factor", "_level_base", "_num_cells", "_root", "_version")
 
     def __init__(
         self,
@@ -298,6 +303,7 @@ class HierarchicalGrid(Grid):
         self._blocks: list[list[_Block]] = [[(lo0, hi0)]]
         self._level_base: list[int] = []
         self._num_cells: int = 0
+        self._version: int = 0
         self._rebuild()
 
     @classmethod
@@ -341,6 +347,7 @@ class HierarchicalGrid(Grid):
         self._blocks = normalized
         self._level_base = []
         self._num_cells = 0
+        self._version = 0
         self._rebuild()
         return self
 
@@ -394,6 +401,20 @@ class HierarchicalGrid(Grid):
         """
         return len(self._blocks) - 1
 
+    @property
+    def version(self) -> int:
+        """Get the monotonic mutation counter of this grid.
+
+        Incremented on every structural change (:meth:`refine`, :meth:`coarsen`).
+        Snapshot consumers (e.g. :class:`~pantr.bspline.THBSplineSpace`) compare
+        it to detect *any* post-construction mutation -- ``max_level`` and
+        ``num_cells`` alone cannot distinguish compensating refine/coarsen pairs.
+
+        Returns:
+            int: The current mutation count (``>= 1``).
+        """
+        return self._version
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -402,6 +423,9 @@ class HierarchicalGrid(Grid):
         """Recompute ``_level_base``, ``_num_cells``, and reset the BVH/tags.
 
         Called after every structural change (construction or refinement).
+        Bumps :attr:`version` so snapshot consumers can detect any mutation,
+        including compensating refine/coarsen pairs that leave ``max_level``
+        and ``num_cells`` unchanged.
         """
         base = 0
         level_base: list[int] = []
@@ -411,6 +435,7 @@ class HierarchicalGrid(Grid):
         level_base.append(base)  # sentinel for bisect_right
         self._level_base = level_base
         self._num_cells = base
+        self._version += 1
         self._bvh = None
         self._cell_tags = None
         self._facet_tags = None
@@ -608,21 +633,21 @@ class HierarchicalGrid(Grid):
 
         return None  # unreachable
 
-    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
-        """Return the cell across local facet ``lfid`` of ``cid``, or ``None``.
-
-        Handles hanging-node interfaces: when the neighbour is coarser (the
-        current cell is at a finer level), the coarse neighbour is returned.
-        When the neighbour is finer (the current cell is at a coarser level),
-        the first fine child touching the face (lowest C-order) is returned.
-        Use :meth:`hanging_neighbors` to retrieve *all* fine neighbours.
+    def _facet_neighbor_position(
+        self, cid: int, lfid: int
+    ) -> tuple[int, tuple[int, ...], int, int] | None:
+        """Resolve facet ``lfid`` of ``cid`` to its neighbour position.
 
         Args:
             cid (int): Cell identifier.
             lfid (int): Local facet identifier in ``[0, 2 * ndim)``.
 
         Returns:
-            int | None: Neighbouring cell id, or ``None`` on a boundary facet.
+            tuple[int, tuple[int, ...], int, int] | None:
+            ``(level, nbr_midx, axis, face_j)`` where ``(level, nbr_midx)`` is the
+            same-level position across the facet and ``face_j`` is the per-axis
+            child offset of descendants touching the shared facet plane, or
+            ``None`` when the facet lies on the grid outer boundary.
 
         Raises:
             IndexError: If ``cid`` or ``lfid`` is out of range.
@@ -638,39 +663,116 @@ class HierarchicalGrid(Grid):
             return None  # grid outer boundary
 
         nbr_midx = (*midx[:axis], new_ik, *midx[axis + 1 :])
+        face_j = self._factor[axis] - 1 if side == 0 else 0
+        return level, nbr_midx, axis, face_j
+
+    def _nearest_active_ancestor(self, level: int, midx: tuple[int, ...]) -> int | None:
+        """Return the active leaf covering ``(level, midx)`` at a strictly coarser level.
+
+        Args:
+            level (int): Level of the queried position.
+            midx (tuple[int, ...]): Per-axis index in level-``level`` coordinates.
+
+        Returns:
+            int | None: Flat id of the covering active leaf at the nearest coarser
+            level, or ``None`` when no ancestor is active (the position is either
+            an active leaf itself or subdivided into finer leaves).
+        """
+        anc = midx
+        for lvl in range(level - 1, -1, -1):
+            anc = tuple(i // f for i, f in zip(anc, self._factor, strict=False))
+            cid = self._encode_midx(lvl, anc)
+            if cid is not None:
+                return cid
+        return None
+
+    def _active_face_descendants(
+        self,
+        level: int,
+        midx: tuple[int, ...],
+        axis: int,
+        face_j: int,
+    ) -> list[int]:
+        """Collect the active leaves inside ``(level, midx)`` touching one of its faces.
+
+        Descends recursively through the subdivision tree, at each step keeping only
+        the children on the facet plane (child offset ``face_j`` on ``axis``) and
+        enumerating the remaining axes in C-order (depth-first), so the returned ids
+        are ordered by their position along the face.
+
+        Args:
+            level (int): Level of the starting position.
+            midx (tuple[int, ...]): Per-axis index in level-``level`` coordinates.
+            axis (int): Axis normal to the face.
+            face_j (int): Child offset on ``axis`` adjacent to the facet plane
+                (``factor[axis] - 1`` for the low side, ``0`` for the high side).
+
+        Returns:
+            list[int]: Flat ids of the active leaf descendants touching the face;
+            ``[cid]`` when ``(level, midx)`` is itself an active leaf.
+        """
+        cid = self._encode_midx(level, midx)
+        if cid is not None:
+            return [cid]
+        if level + 1 >= len(self._blocks):
+            return []
+        child_ranges = [
+            (face_j,) if k == axis else tuple(range(self._factor[k])) for k in range(self.ndim)
+        ]
+        result: list[int] = []
+        for offsets in itertools.product(*child_ranges):
+            child = tuple(m * f + o for m, f, o in zip(midx, self._factor, offsets, strict=False))
+            result.extend(self._active_face_descendants(level + 1, child, axis, face_j))
+        return result
+
+    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
+        """Return the cell across local facet ``lfid`` of ``cid``, or ``None``.
+
+        Handles hanging-node interfaces across **any** level difference (no 2:1
+        balance is enforced by :meth:`refine`): when the neighbour is coarser, the
+        active leaf covering the position -- however many levels up -- is returned.
+        When the neighbour side is finer, the first active leaf descendant touching
+        the face (lowest C-order along the face) is returned.  Use
+        :meth:`hanging_neighbors` to retrieve *all* fine neighbours.
+
+        Args:
+            cid (int): Cell identifier.
+            lfid (int): Local facet identifier in ``[0, 2 * ndim)``.
+
+        Returns:
+            int | None: Neighbouring cell id, or ``None`` on a boundary facet.
+
+        Raises:
+            IndexError: If ``cid`` or ``lfid`` is out of range.
+        """
+        position = self._facet_neighbor_position(cid, lfid)
+        if position is None:
+            return None  # grid outer boundary
+        level, nbr_midx, axis, face_j = position
 
         # Case 1: same-level active neighbour (conforming).
         ncid = self._encode_midx(level, nbr_midx)
         if ncid is not None:
             return ncid
 
-        # Case 2: coarser active neighbour — current cell is finer.
-        if level > 0:
-            parent_midx = tuple(i // f for i, f in zip(nbr_midx, self._factor, strict=False))
-            pcid = self._encode_midx(level - 1, parent_midx)
-            if pcid is not None:
-                return pcid
+        # Case 2: coarser active neighbour (any number of levels up).
+        pcid = self._nearest_active_ancestor(level, nbr_midx)
+        if pcid is not None:
+            return pcid
 
-        # Case 3: finer active neighbour — current cell is coarser.
-        # (level, nbr_midx) was created and then refined.  Return the first
-        # child of (level, nbr_midx) at level+1 that touches the face.
-        if level + 1 < len(self._blocks):
-            face_j = self._factor[axis] - 1 if side == 0 else 0
-            child_midx: list[int] = []
-            for k, (nk, fk) in enumerate(zip(nbr_midx, self._factor, strict=False)):
-                child_midx.append(nk * fk + (face_j if k == axis else 0))
-            ccid = self._encode_midx(level + 1, tuple(child_midx))
-            if ccid is not None:
-                return ccid
-
-        return None
+        # Case 3: finer active neighbours (any number of levels down) — return
+        # the first leaf touching the face.
+        descendants = self._active_face_descendants(level, nbr_midx, axis, face_j)
+        return descendants[0] if descendants else None
 
     def hanging_neighbors(self, cid: int, lfid: int) -> tuple[int, ...]:
         """Return all active neighbours across facet ``lfid`` of ``cid``.
 
-        Equivalent to :meth:`neighbor_across_facet` for conforming interfaces.
-        For a hanging (fine-to-coarse) interface, returns all
-        ``factor^(ndim-1)`` fine children that touch the face in C-order.
+        Equivalent to :meth:`neighbor_across_facet` for conforming and coarser
+        interfaces (a single neighbour, however many levels up).  For a hanging
+        (fine-side) interface, returns *all* active leaves touching the face,
+        descending as many levels as the interface requires, ordered depth-first
+        along the face (C-order over the non-``axis`` directions at each level).
 
         Args:
             cid (int): Cell identifier.
@@ -682,48 +784,21 @@ class HierarchicalGrid(Grid):
         Raises:
             IndexError: If ``cid`` or ``lfid`` is out of range.
         """
-        self._check_lfid(cid, lfid)
-        axis, side = divmod(int(lfid), 2)
-        level, midx = self._decode_flat_id(cid)
-
-        delta = -1 if side == 0 else 1
-        new_ik = midx[axis] + delta
-        n_k = self._n_cells_at_level_k(level, axis)
-        if new_ik < 0 or new_ik >= n_k:
-            return ()
-
-        nbr_midx = (*midx[:axis], new_ik, *midx[axis + 1 :])
+        position = self._facet_neighbor_position(cid, lfid)
+        if position is None:
+            return ()  # grid outer boundary
+        level, nbr_midx, axis, face_j = position
 
         # Conforming or coarser — at most one neighbour.
         ncid = self._encode_midx(level, nbr_midx)
         if ncid is not None:
             return (ncid,)
-        if level > 0:
-            parent_midx = tuple(i // f for i, f in zip(nbr_midx, self._factor, strict=False))
-            pcid = self._encode_midx(level - 1, parent_midx)
-            if pcid is not None:
-                return (pcid,)
+        pcid = self._nearest_active_ancestor(level, nbr_midx)
+        if pcid is not None:
+            return (pcid,)
 
-        # Finer side — collect all factor^(ndim-1) children touching the face.
-        if level + 1 >= len(self._blocks):
-            return ()
-
-        face_j = self._factor[axis] - 1 if side == 0 else 0
-        result: list[int] = []
-
-        import itertools  # noqa: PLC0415
-
-        other_ranges = [range(self._factor[k]) for k in range(self.ndim) if k != axis]
-        for other_js in itertools.product(*other_ranges):
-            it = iter(other_js)
-            child_midx: list[int] = []
-            for k, (nk, fk) in enumerate(zip(nbr_midx, self._factor, strict=False)):
-                j = face_j if k == axis else next(it)
-                child_midx.append(nk * fk + j)
-            ccid = self._encode_midx(level + 1, tuple(child_midx))
-            if ccid is not None:
-                result.append(ccid)
-        return tuple(result)
+        # Finer side — collect all active leaves touching the face.
+        return tuple(self._active_face_descendants(level, nbr_midx, axis, face_j))
 
     # ------------------------------------------------------------------
     # Restriction / windowing

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -253,7 +253,8 @@ class TensorProductGrid(Grid):
 
         A point exactly on an interior breakpoint is assigned to the
         lower-indexed cell sharing that face; a point on the outer boundary is
-        assigned to the adjacent boundary cell.
+        assigned to the adjacent boundary cell.  Non-finite coordinates
+        (NaN or infinity) are outside every cell.
 
         Args:
             pt (npt.ArrayLike): Length-``ndim`` point.
@@ -272,7 +273,8 @@ class TensorProductGrid(Grid):
         for d in range(self._ndim):
             bp = self._breakpoints[d]
             x = float(arr[d])
-            if x < bp[0] or x > bp[-1]:
+            # The negated chained comparison is NaN-safe (NaN fails both bounds).
+            if not bp[0] <= x <= bp[-1]:
                 return None
             idx = int(np.searchsorted(bp, x, side="left")) - 1
             idx = min(max(idx, 0), self._cells_per_axis[d] - 1)
@@ -288,7 +290,7 @@ class TensorProductGrid(Grid):
 
         Returns:
             npt.NDArray[np.int64]: Shape ``(npts,)`` cell ids; ``-1`` for points
-            outside the grid.
+            outside the grid (including points with NaN or infinite coordinates).
 
         Raises:
             ValueError: If the trailing axis of ``points`` is not ``ndim``.
@@ -301,6 +303,11 @@ class TensorProductGrid(Grid):
         cells_per_axis = np.array(self._cells_per_axis, dtype=np.int64)
         out = np.empty(pts.shape[0], dtype=np.int64)
         _locate_points_core(pts, knots_flat, knot_starts, cells_per_axis, self._strides, out)
+        # The kernel's binary search has no NaN handling (NaN comparisons are
+        # all False, silently landing in the first cell); mask them out here.
+        finite = np.isfinite(pts).all(axis=1)
+        if not finite.all():
+            out[~finite] = -1
         return out
 
     def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -176,12 +176,6 @@ def _two_level_jump_grid() -> tuple[HierarchicalGrid, int, int]:
     return grid, cid_coarse, cid_fine
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="neighbor_across_facet only probes +-1 level: a facet between level-0 and "
-    "level-2 cells (which plain refine() permits) reports no neighbor and the interior "
-    "facet is misclassified as a mesh boundary",
-)
 def test_hierarchical_neighbor_across_two_level_jump() -> None:
     grid, cid_coarse, cid_fine = _two_level_jump_grid()
     assert grid.neighbor_across_facet(cid_coarse, 1) == cid_fine
@@ -190,12 +184,44 @@ def test_hierarchical_neighbor_across_two_level_jump() -> None:
     assert grid.hanging_neighbors(cid_coarse, 1) == (cid_fine,)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the (max_level, num_cells) staleness snapshot is fooled by a compensating "
-    "refine+coarsen pair: the stale THB space then silently returns wrong dofs/values "
-    "instead of raising",
-)
+def test_hierarchical_hanging_neighbors_mixed_level_facet() -> None:
+    """A facet shared with level-1 AND level-2 cells must report all of them.
+
+    The brute-force oracle pairs every active cell whose face lies on the shared
+    plane and overlaps the coarse cell's extent.
+    """
+    grid = HierarchicalGrid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], [4, 4]), 2)
+    grid.refine(0, [1, 0], [2, 4])  # refine the x-index-1 column to level 1
+    grid.refine(1, [2, 2], [3, 3])  # refine one of its cells to level 2
+
+    coarse = next(
+        c
+        for c in range(grid.num_cells)
+        if grid.cell_level(c) == 0 and grid.cell_multi_index(c) == (0, 1)
+    )
+    lo_c, hi_c = grid.cell_bounds(coarse)
+    plane = float(hi_c[0])
+
+    def touches_facet(other: int) -> bool:
+        lo_o, hi_o = grid.cell_bounds(other)
+        on_plane = abs(float(lo_o[0]) - plane) < 1e-12
+        overlaps = float(lo_o[1]) < float(hi_c[1]) - 1e-12 and (
+            float(hi_o[1]) > float(lo_c[1]) + 1e-12
+        )
+        return on_plane and overlaps
+
+    expected = {c for c in range(grid.num_cells) if c != coarse and touches_facet(c)}
+    levels = {grid.cell_level(c) for c in expected}
+    assert levels == {1, 2}  # the configuration really mixes two finer levels
+
+    got = grid.hanging_neighbors(coarse, 1)
+    assert set(got) == expected
+    assert len(got) == len(expected)
+    assert grid.neighbor_across_facet(coarse, 1) in expected
+    for fine in expected:
+        assert grid.neighbor_across_facet(fine, 0) == coarse
+
+
 def test_thb_space_detects_compensating_refine_coarsen() -> None:
     root = BsplineSpace([_open_uniform_1d(2, 8)])
     grid = HierarchicalGrid(uniform_grid([[0.0, 1.0]], [8]), 2)
@@ -216,11 +242,6 @@ def test_thb_space_detects_compensating_refine_coarsen() -> None:
         space.tabulate_basis(2, pt)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="locate/locate_many accept NaN coordinates and return a valid cell id "
-    "(last cell on the scalar path, first cell on the batch path) instead of a miss",
-)
 def test_locate_nan_is_a_miss() -> None:
     grid = uniform_grid([[0.0, 1.0]], [4])
     assert grid.locate([float("nan")]) is None


### PR DESCRIPTION
## Summary

Fixes the three confirmed grid bugs from the review (stacked on #192; merge after it).

- **Facet adjacency across >1-level interfaces** — `refine()` enforces no 2:1 grading, but `neighbor_across_facet`/`hanging_neighbors` only probed ±1 level: across a level-0↔level-2 facet they returned `None`/`()` and `is_mesh_boundary_facet` reported an interior facet as boundary. The coarse side now walks to the nearest active ancestor (any number of levels up); the fine side recursively collects **all** active leaf descendants touching the face (depth-first C-order), so mixed-level facets (level-1 and level-2 neighbours on one facet) are complete. The module docstring's false *"automatic single-level balance"* claim is corrected.
- **THB staleness detection** — the `(max_level, num_cells)` snapshot was fooled by compensating refine+coarsen pairs; a stale `THBSplineSpace` then silently returned wrong dofs/values (cell ids are reassigned on every mutation). `HierarchicalGrid` now carries a monotonic `version` counter bumped in `_rebuild()` on every structural change, and the snapshot includes it — any mutation now raises `RuntimeError`.
- **NaN locate** — `locate` returned the last cell and `locate_many` the first cell for NaN coordinates (all comparisons false in the binary searches). The scalar path uses a NaN-safe chained bound check; the batch path masks non-finite points to `-1` after the kernel (Layer 2, kernel untouched).

## Tests

Three review xfail regressions flip to plain tests; one new test (`test_hierarchical_hanging_neighbors_mixed_level_facet`) checks a facet shared by level-1 **and** level-2 cells against a brute-force bounds oracle, both directions.

## Test plan

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `pytest --no-cov` (3427 passed, 14 xfailed)
- [x] Sphinx docs build with `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)