### PR TITLE
fix(quad,viz): chebyshev-gauss 2nd-kind rule, 3D F-order lattice, VTK orderings

### DIFF
--- a/src/pantr/basis/_basis_lagrange.py
+++ b/src/pantr/basis/_basis_lagrange.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
     from . import LagrangeVariant
 from ..quad import (
     get_chebyshev_gauss_1st_kind_1d,
-    get_chebyshev_gauss_2nd_kind_1d,
     get_gauss_legendre_1d,
     get_gauss_lobatto_legendre_1d,
+    get_modified_chebyshev_nodes_1d,
     get_trapezoidal_1d,
 )
 
@@ -55,7 +55,10 @@ def _get_lagrange_points(
     elif variant_value == "chebyshev_1st":
         return get_chebyshev_gauss_1st_kind_1d(n_pts, dtype)[0]
     else:  # "chebyshev_2nd"
-        return get_chebyshev_gauss_2nd_kind_1d(n_pts, dtype)[0]
+        # Chebyshev-Lobatto points (endpoints included) -- the documented
+        # LagrangeVariant.CHEBYSHEV_2ND interpolation nodes.  The quadrature
+        # function of the same name now returns interior Gauss-U nodes.
+        return get_modified_chebyshev_nodes_1d(n_pts, dtype)
 
 
 def _tabulate_lagrange_basis_1D_core(

--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -225,7 +225,15 @@ def get_modified_chebyshev_nodes_1d(
 def get_chebyshev_gauss_2nd_kind_1d(
     n_pts: int, dtype: npt.DTypeLike = np.float64
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
-    """Get Chebyshev-Gauss quadrature of the second kind on [0, 1] for the given number of points.
+    r"""Get Chebyshev-Gauss quadrature of the second kind on [0, 1] for the given number of points.
+
+    The rule integrates against the Chebyshev second-kind weight function
+    mapped to [0, 1]: :math:`\int_0^1 f(x) \sqrt{1 - (2x - 1)^2}\, dx \approx
+    \sum_k w_k f(x_k)`, exactly for polynomials of degree up to
+    ``2 * n_pts - 1``.  The nodes are the mapped roots of the Chebyshev
+    polynomial of the second kind :math:`U_{n_pts}` -- all interior (no
+    endpoints).  For endpoint-including Chebyshev-Lobatto *interpolation*
+    nodes, use :func:`get_modified_chebyshev_nodes_1d` instead.
 
     Args:
         n_pts (int): Number of quadrature points. Must be at least 2.
@@ -234,17 +242,18 @@ def get_chebyshev_gauss_2nd_kind_1d(
 
     Returns:
         tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
-            The nodes and weights.
+            The nodes (ascending, interior) and weights.
 
     Raises:
         ValueError: If n_pts is less than 2 or dtype is not float32 or float64.
     """
     _validate_n_pts_and_dtype(n_pts, dtype, min_pts=2)
 
-    cheb2_t = cast(Callable[[int], npt.NDArray[np.float64]], chebyshev.chebpts2)
-    nodes = cheb2_t(n_pts)
-    n_pts_plus_1 = float(n_pts + 1)
-    weights = np.pi / n_pts_plus_1 * (np.sin(np.arange(1, n_pts + 1) * np.pi / n_pts_plus_1) ** 2)
+    angles = np.arange(1, n_pts + 1, dtype=np.float64) * np.pi / float(n_pts + 1)
+    # Ascending Gauss-Chebyshev-U nodes on [-1, 1]; the weight formula is
+    # symmetric under k -> n_pts + 1 - k, so the pairing stays exact.
+    nodes = -np.cos(angles)
+    weights = np.pi / float(n_pts + 1) * np.sin(angles) ** 2
 
     return _scale_and_cast_nodes_and_weights(nodes, weights, dtype)
 
@@ -474,14 +483,18 @@ class PointsLattice:
             npt.NDArray[np.float32 | np.float64]: The dim-dimensional points
                 in the lattice. It has shape: (n_pts, dim).
         """
+        tp_coords = np.meshgrid(*self._pts_per_dir, indexing="ij")
         if order == "C":  # Last index varies fastest
-            tp_coords = np.meshgrid(*self._pts_per_dir, indexing="ij")
-        else:  # if order == "F": # First index varies fastest
-            tp_coords = np.meshgrid(*self._pts_per_dir, indexing="xy")
-
+            return cast(
+                npt.NDArray[np.float32 | np.float64],
+                np.array(tp_coords).reshape(self.dim, -1).T,  # (n_pts, dim)
+            )
+        # order == "F": first index varies fastest.  meshgrid(indexing="xy") only
+        # swaps the first two axes, so a Fortran-order ravel of each "ij"
+        # coordinate grid is required for dim >= 3.
         return cast(
             npt.NDArray[np.float32 | np.float64],
-            np.array(tp_coords).reshape(self.dim, -1).T,  # (n_pts, dim)
+            np.stack([c.ravel(order="F") for c in tp_coords], axis=-1),  # (n_pts, dim)
         )
 
 

--- a/src/pantr/viz/_vtk_ordering.py
+++ b/src/pantr/viz/_vtk_ordering.py
@@ -82,12 +82,17 @@ def vtk_ordering_quad(degree_u: int, degree_v: int) -> npt.NDArray[np.intp]:
         VTK vertex 2 → (degree_u, degree_v)
         VTK vertex 3 → (0, degree_v)
 
-    VTK quad edge ordering::
+    VTK quad edge ordering (interior nodes; per
+    ``vtkHigherOrderQuadrilateral::PointIndexFromIJK`` every run is in
+    **increasing** index order, including the top edge -- the high-order node
+    layout does not follow the linear cell's winding direction)::
 
-        Edge 0: (0,0)→(degree_u,0)        — bottom, increasing i, j=0
-        Edge 1: (degree_u,0)→(degree_u,degree_v) — right, i=degree_u, increasing j
-        Edge 2: (degree_u,degree_v)→(0,degree_v) — top, decreasing i, j=degree_v
-        Edge 3: (0,0)→(0,degree_v)         — left, i=0, increasing j
+        Edge 0: j=0        — increasing i
+        Edge 1: i=degree_u — increasing j
+        Edge 2: j=degree_v — increasing i
+        Edge 3: i=0        — increasing j
+
+    The face interior runs ``i`` fastest (``(i-1) + (degree_u-1)*(j-1)``).
 
     Args:
         degree_u: Polynomial degree in u direction (≥ 1).
@@ -113,16 +118,16 @@ def vtk_ordering_quad(degree_u: int, degree_v: int) -> npt.NDArray[np.intp]:
     # Edge 1: right (i=degree_u), j = 1..degree_v-1
     for j in range(1, degree_v):
         order.append(_tp_flat_index((degree_u, j), shape))
-    # Edge 2: top (j=degree_v), i = degree_u-1..1 (decreasing)
-    for i in range(degree_u - 1, 0, -1):
+    # Edge 2: top (j=degree_v), i = 1..degree_u-1 (increasing, per VTK)
+    for i in range(1, degree_u):
         order.append(_tp_flat_index((i, degree_v), shape))
     # Edge 3: left (i=0), j = 1..degree_v-1
     for j in range(1, degree_v):
         order.append(_tp_flat_index((0, j), shape))
 
-    # --- Face interior ---
-    for i in range(1, degree_u):
-        for j in range(1, degree_v):
+    # --- Face interior (i fastest, per VTK) ---
+    for j in range(1, degree_v):
+        for i in range(1, degree_u):
             order.append(_tp_flat_index((i, j), shape))
 
     return np.array(order, dtype=np.intp)
@@ -170,14 +175,19 @@ def vtk_ordering_hex(  # noqa: PLR0912
         Edge 10: vtx 2→6 — vertical, i=pu, j=pv, increasing k
         Edge 11: vtx 3→7 — vertical, i=0, j=pv, increasing k
 
-    VTK hex face ordering (6 faces, interior points only)::
+    VTK hex face ordering (6 faces, interior points only; per
+    ``vtkHigherOrderHexahedron::PointIndexFromIJK`` the i-normal face pair
+    comes first, then j-normal, then k-normal, with the lower face of each
+    pair first; the first in-face index varies fastest)::
 
-        Face 0: k=0    (bottom)  — ordered in local (i, j) increasing
-        Face 1: k=pw   (top)     — ordered in local (i, j) increasing
-        Face 2: j=0    (front)   — ordered in local (i, k) increasing
-        Face 3: i=pu   (right)   — ordered in local (j, k) increasing
-        Face 4: j=pv   (back)    — ordered in local (i, k) increasing
-        Face 5: i=0    (left)    — ordered in local (j, k) increasing
+        Face 0: i=0    (left)    — (j, k) interior, j fastest
+        Face 1: i=pu   (right)   — (j, k) interior, j fastest
+        Face 2: j=0    (front)   — (i, k) interior, i fastest
+        Face 3: j=pv   (back)    — (i, k) interior, i fastest
+        Face 4: k=0    (bottom)  — (i, j) interior, i fastest
+        Face 5: k=pw   (top)     — (i, j) interior, i fastest
+
+    The volume interior runs ``i`` fastest, then ``j``, then ``k``.
 
     Args:
         degree_u: Polynomial degree in u direction (≥ 1).
@@ -247,36 +257,36 @@ def vtk_ordering_hex(  # noqa: PLR0912
     for k in range(1, pw):
         order.append(flat(0, pv, k))
 
-    # --- 6 Faces (interior points only) ---
-    # Face 0: k=0 (bottom), interior (i, j) with i in 1..pu-1, j in 1..pv-1
-    for i in range(1, pu):
+    # --- 6 Faces (interior points only; i-pair, j-pair, k-pair, per VTK) ---
+    # Face 0: i=0 (left), interior (j, k), j fastest
+    for k in range(1, pw):
         for j in range(1, pv):
-            order.append(flat(i, j, 0))
-    # Face 1: k=pw (top)
-    for i in range(1, pu):
-        for j in range(1, pv):
-            order.append(flat(i, j, pw))
-    # Face 2: j=0 (front), interior (i, k)
-    for i in range(1, pu):
-        for k in range(1, pw):
-            order.append(flat(i, 0, k))
-    # Face 3: i=pu (right), interior (j, k)
-    for j in range(1, pv):
-        for k in range(1, pw):
-            order.append(flat(pu, j, k))
-    # Face 4: j=pv (back), interior (i, k)
-    for i in range(1, pu):
-        for k in range(1, pw):
-            order.append(flat(i, pv, k))
-    # Face 5: i=0 (left), interior (j, k)
-    for j in range(1, pv):
-        for k in range(1, pw):
             order.append(flat(0, j, k))
-
-    # --- Volume interior ---
-    for i in range(1, pu):
+    # Face 1: i=pu (right), interior (j, k), j fastest
+    for k in range(1, pw):
         for j in range(1, pv):
-            for k in range(1, pw):
+            order.append(flat(pu, j, k))
+    # Face 2: j=0 (front), interior (i, k), i fastest
+    for k in range(1, pw):
+        for i in range(1, pu):
+            order.append(flat(i, 0, k))
+    # Face 3: j=pv (back), interior (i, k), i fastest
+    for k in range(1, pw):
+        for i in range(1, pu):
+            order.append(flat(i, pv, k))
+    # Face 4: k=0 (bottom), interior (i, j), i fastest
+    for j in range(1, pv):
+        for i in range(1, pu):
+            order.append(flat(i, j, 0))
+    # Face 5: k=pw (top), interior (i, j), i fastest
+    for j in range(1, pv):
+        for i in range(1, pu):
+            order.append(flat(i, j, pw))
+
+    # --- Volume interior (i fastest, then j, then k, per VTK) ---
+    for k in range(1, pw):
+        for j in range(1, pv):
+            for i in range(1, pu):
                 order.append(flat(i, j, k))
 
     return np.array(order, dtype=np.intp)

--- a/tests/test_quad.py
+++ b/tests/test_quad.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from math import gamma
 from typing import Any, cast
 
 import numpy as np
@@ -195,16 +196,31 @@ class TestChebyshevGaussSecondKind:
 
     @pytest.mark.parametrize("n_pts", [2, 5, 9])
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-    def test_nodes_endpoints_and_total_weight(self, n_pts: int, dtype: npt.DTypeLike) -> None:
+    def test_nodes_interior_and_total_weight(self, n_pts: int, dtype: npt.DTypeLike) -> None:
         nodes, weights = get_chebyshev_gauss_2nd_kind_1d(n_pts, dtype)
-        # endpoints included for n>=2
-        nptest.assert_allclose(nodes[0], np.array(0.0, dtype=dtype))
-        nptest.assert_allclose(nodes[-1], np.array(1.0, dtype=dtype))
-        # weights sum to (integral of sqrt(1-x^2) over [0,1]) = pi/4 after scaling
+        # Gauss nodes are the mapped roots of U_{n_pts}: all interior, ascending.
+        assert np.all((nodes > 0.0) & (nodes < 1.0))
+        assert np.all(np.diff(nodes) > 0.0)
+        # weights sum to (integral of sqrt(1-(2x-1)^2) over [0,1]) = pi/4
         nptest.assert_allclose(
             np.sum(weights), np.array(np.pi / 4.0, dtype=dtype), rtol=get_strict(dtype)
         )
-        assert np.all((nodes >= 0.0) & (nodes <= 1.0))
+
+    @pytest.mark.parametrize("n_pts", [2, 5, 9])
+    def test_weighted_polynomial_exactness(self, n_pts: int) -> None:
+        """The rule must be exact for x^d * sqrt(1-(2x-1)^2) up to d = 2*n_pts - 1."""
+        nodes, weights = get_chebyshev_gauss_2nd_kind_1d(n_pts, np.float64)
+        u = 2.0 * np.asarray(nodes, dtype=np.float64) - 1.0
+        w = np.asarray(weights, dtype=np.float64)
+        # int_{-1}^{1} u^d sqrt(1-u^2) du = sqrt(pi)/2 * gamma((d+1)/2) / gamma(d/2+2)
+        # for even d (0 for odd d); the [0,1] mapping halves the value.
+        for d in range(2 * n_pts):
+            exact = (
+                0.5 * np.sqrt(np.pi) / 2.0 * gamma((d + 1) / 2.0) / gamma(d / 2.0 + 2.0)
+                if d % 2 == 0
+                else 0.0
+            )
+            nptest.assert_allclose(np.sum(w * u**d), exact, atol=1e-14)
 
 
 class TestPointsLattice:

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -378,11 +378,6 @@ def test_cm1_interior_knot_derivative_emits_no_warning() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="get_chebyshev_gauss_2nd_kind_1d pairs Chebyshev-Lobatto nodes with "
-    "Gauss-Chebyshev-U interior-node weights: the rule has no polynomial accuracy",
-)
 def test_chebyshev_gauss_2nd_kind_integrates_quadratic() -> None:
     pts, wts = get_chebyshev_gauss_2nd_kind_1d(5)
     x = np.asarray(pts, dtype=np.float64)
@@ -392,11 +387,6 @@ def test_chebyshev_gauss_2nd_kind_integrates_quadratic() -> None:
     assert abs(float(np.sum(w * mapped**2)) - pi / 16.0) < 1e-10
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="get_all_points(order='F') uses meshgrid(indexing='xy'), which only swaps "
-    "the first two axes: for dim >= 3 the first index does not vary fastest",
-)
 def test_points_lattice_f_order_first_axis_fastest_3d() -> None:
     lattice = PointsLattice(
         [np.array([0.0, 1.0]), np.array([10.0, 11.0]), np.array([20.0, 21.0, 22.0])]
@@ -407,12 +397,6 @@ def test_points_lattice_f_order_first_axis_fastest_3d() -> None:
     assert pts[2].tolist() == [0.0, 11.0, 20.0]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="VTK high-order quad ordering: edge 2 must run in increasing i and the "
-    "interior block i-fastest (vtkHigherOrderQuadrilateral); pantr reverses edge 2 and "
-    "emits the interior j-fastest, so cubic-and-higher quads render wrong",
-)
 def test_vtk_quad_ordering_matches_vtk_convention_cubic() -> None:
     perm = np.asarray(vtk_ordering_quad(3, 3), dtype=np.int64)
     ij = [divmod(int(flat), 4) for flat in perm]  # tp flat index is i-major
@@ -437,12 +421,6 @@ def test_vtk_quad_ordering_matches_vtk_convention_cubic() -> None:
     assert ij == expected
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="VTK high-order hex ordering: the six face blocks must come in the order "
-    "(i=0, i=pu, j=0, j=pv, k=0, k=pw) per vtkHigherOrderHexahedron; pantr emits "
-    "(k=0, k=pw, j=0, i=pu, j=pv, i=0), so every quadratic-and-higher hex renders wrong",
-)
 def test_vtk_hex_face_block_order_quadratic() -> None:
     perm = np.asarray(vtk_ordering_hex(2, 2, 2), dtype=np.int64)
     # Degree (2,2,2): 8 corners + 12 edge nodes, then the 6 face centres at
@@ -457,6 +435,100 @@ def test_vtk_hex_face_block_order_quadratic() -> None:
         1 * 9 + 1 * 3 + 2,  # k = pw -> (1,1,2) = 14
     ]
     assert face_centres == expected
+
+
+def _vtk_ref_quad_index(i: int, j: int, order: tuple[int, int]) -> int:
+    """``vtkHigherOrderQuadrilateral::PointIndexFromIJK`` transcribed verbatim."""
+    ibdy = i in (0, order[0])
+    jbdy = j in (0, order[1])
+    if ibdy and jbdy:  # corner
+        return (2 if j else 1) if i else (3 if j else 0)
+    offset = 4
+    if not ibdy:  # i-axis edge (j on a boundary)
+        return (i - 1) + (order[0] - 1 + order[1] - 1 if j else 0) + offset
+    if not jbdy:  # j-axis edge (i on a boundary)
+        return (j - 1) + (order[0] - 1 if i else 2 * (order[0] - 1) + order[1] - 1) + offset
+    raise AssertionError("unreachable")
+
+
+def _vtk_ref_quad_face_index(i: int, j: int, order: tuple[int, int]) -> int:
+    """Face-interior branch of the quad ``PointIndexFromIJK``."""
+    offset = 4 + 2 * (order[0] - 1 + order[1] - 1)
+    return offset + (i - 1) + (order[0] - 1) * (j - 1)
+
+
+def _vtk_ref_hex_index(  # noqa: PLR0911
+    i: int, j: int, k: int, order: tuple[int, int, int]
+) -> int:
+    """``vtkHigherOrderHexahedron::PointIndexFromIJK`` transcribed verbatim."""
+    o0, o1, o2 = order
+    ibdy = i in (0, o0)
+    jbdy = j in (0, o1)
+    kbdy = k in (0, o2)
+    nbdy = int(ibdy) + int(jbdy) + int(kbdy)
+    if nbdy == 3:  # corner
+        return ((2 if j else 1) if i else (3 if j else 0)) + (4 if k else 0)
+    offset = 8
+    if nbdy == 2:  # edge
+        if not ibdy:  # i-axis edge
+            return (
+                (i - 1)
+                + (o0 - 1 + o1 - 1 if j else 0)
+                + (2 * (o0 - 1 + o1 - 1) if k else 0)
+                + offset
+            )
+        if not jbdy:  # j-axis edge
+            return (
+                (j - 1)
+                + ((o0 - 1) if i else 2 * (o0 - 1) + o1 - 1)
+                + (2 * (o0 - 1 + o1 - 1) if k else 0)
+                + offset
+            )
+        # k-axis edge
+        offset += 4 * (o0 - 1) + 4 * (o1 - 1)
+        return (k - 1) + (o2 - 1) * ((2 if j else 1) if i else (3 if j else 0)) + offset
+    offset = 8 + 4 * (o0 - 1 + o1 - 1 + o2 - 1)
+    if nbdy == 1:  # face
+        if ibdy:
+            return (j - 1) + (o1 - 1) * (k - 1) + ((o1 - 1) * (o2 - 1) if i else 0) + offset
+        offset += 2 * (o1 - 1) * (o2 - 1)
+        if jbdy:
+            return (i - 1) + (o0 - 1) * (k - 1) + ((o2 - 1) * (o0 - 1) if j else 0) + offset
+        offset += 2 * (o2 - 1) * (o0 - 1)
+        return (i - 1) + (o0 - 1) * (j - 1) + ((o0 - 1) * (o1 - 1) if k else 0) + offset
+    # body
+    offset += 2 * ((o1 - 1) * (o2 - 1) + (o2 - 1) * (o0 - 1) + (o0 - 1) * (o1 - 1))
+    return offset + (i - 1) + (o0 - 1) * ((j - 1) + (o1 - 1) * (k - 1))
+
+
+@pytest.mark.parametrize("degrees", [(2, 2), (3, 3), (3, 4), (4, 2), (1, 3)])
+def test_vtk_quad_ordering_matches_pointindexfromijk(degrees: tuple[int, int]) -> None:
+    """The quad permutation must invert VTK's PointIndexFromIJK for every node."""
+    perm = np.asarray(vtk_ordering_quad(*degrees), dtype=np.int64)
+    nv = degrees[1] + 1
+    for i in range(degrees[0] + 1):
+        for j in range(nv):
+            ibdy = i in (0, degrees[0])
+            jbdy = j in (0, degrees[1])
+            if ibdy or jbdy:
+                vtk_pos = _vtk_ref_quad_index(i, j, degrees)
+            else:
+                vtk_pos = _vtk_ref_quad_face_index(i, j, degrees)
+            assert int(perm[vtk_pos]) == i * nv + j, (degrees, i, j)
+
+
+@pytest.mark.parametrize("degrees", [(2, 2, 2), (3, 3, 3), (3, 4, 2), (2, 1, 2)])
+def test_vtk_hex_ordering_matches_pointindexfromijk(
+    degrees: tuple[int, int, int],
+) -> None:
+    """The hex permutation must invert VTK's PointIndexFromIJK for every node."""
+    perm = np.asarray(vtk_ordering_hex(*degrees), dtype=np.int64)
+    nv, nw = degrees[1] + 1, degrees[2] + 1
+    for i in range(degrees[0] + 1):
+        for j in range(nv):
+            for k in range(nw):
+                vtk_pos = _vtk_ref_hex_index(i, j, k, degrees)
+                assert int(perm[vtk_pos]) == (i * nv + j) * nw + k, (degrees, i, j, k)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the quad/viz bugs from the review (stacked on #192; merge after it).

- **`get_chebyshev_gauss_2nd_kind_1d`** paired Chebyshev–Lobatto nodes (endpoints) with Gauss–Chebyshev-U interior-node weights — zero polynomial accuracy (∫x²·w was off by 67%). It now returns the true Gauss rule (mapped roots of `U_n`, weights `π/(n+1)·sin²(kπ/(n+1))`), exact to degree `2n−1` against the `√(1−(2x−1)²)` weight on `[0,1]`; weight mass π/4 is unchanged. The `LagrangeVariant.CHEBYSHEV_2ND` interpolation nodes keep their documented Lobatto values by switching the consumer to `get_modified_chebyshev_nodes_1d` (bit-identical nodes — no behavior change for Lagrange bases).
- **`PointsLattice.get_all_points(order="F")`** used `meshgrid(indexing="xy")`, which only swaps the first two axes: for dim ≥ 3 the first index did not vary fastest, silently mis-pairing points with the F-ordered basis combinator. Now each `"ij"` coordinate grid is raveled in Fortran order; dim ≤ 2 output is unchanged.
- **VTK high-order node orderings** deviated from `vtkHigherOrderQuadrilateral/Hexahedron::PointIndexFromIJK`: quad edge 2 reversed + interior j-fastest (wrong `.vtu` geometry for degree ≥ 3 quads); hex face blocks in the wrong order with transposed in-face layouts, body interior k-fastest (wrong for **every** degree ≥ 2 hex).

## Tests

- The four review xfail regressions flip to plain tests.
- New: full quad/hex permutations validated against a verbatim `PointIndexFromIJK` transcription for degrees `(2,2),(3,3),(3,4),(4,2),(1,3)` and `(2,2,2),(3,3,3),(3,4,2),(2,1,2)`.
- New: weighted-monomial exactness of the quadrature rule up to degree `2n−1` (closed-form moments); the old endpoint assertion (which pinned the broken pairing) is replaced.

## Test plan

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `pytest --no-cov` (3439 passed, 13 xfailed)
- [x] Sphinx docs build with `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)