### PR TITLE
fix(bspline): nine confirmed review findings

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -829,6 +829,18 @@ class Bspline:
         new_space = BsplineSpace(new_spaces)
 
         new_cp = _reverse_control_points(self._control_points, direction, in_place=in_place)
+        if old_space.periodic:
+            # The stored periodic points expand as full[j] = stored[j % n_stored];
+            # reversing the full sequence therefore needs a plain flip *plus* a
+            # cyclic shift by the ghost count n_full - n_stored.
+            n_stored = new_cp.shape[direction]
+            n_full = knots.shape[0] - old_space.degree - 1
+            shift = (n_full - n_stored) % n_stored
+            if shift:
+                if in_place:
+                    new_cp[:] = np.roll(new_cp, shift, axis=direction)
+                else:
+                    new_cp = np.roll(new_cp, shift, axis=direction)
 
         if in_place:
             self._space = new_space

--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -56,7 +56,12 @@ def _derivative_ctrl_1d(
     for _ in range(ctrl.ndim - 1):
         denom = denom[..., np.newaxis]
     diff = ctrl[1:] - ctrl[:-1]
-    return np.where(denom == 0.0, 0.0, degree * diff / denom)
+    # Masked division: a multiplicity-(degree+1) interior knot makes denom zero
+    # (C^-1 spline); np.where would still evaluate the division eagerly and emit
+    # a divide-by-zero warning (an error under warnings-as-errors test configs).
+    result = np.zeros(np.broadcast_shapes(diff.shape, denom.shape), dtype=diff.dtype)
+    np.divide(degree * diff, denom, out=result, where=denom != 0.0)
+    return result
 
 
 def _derivative_nonrational_1d(bspline: Bspline) -> Bspline:

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -24,6 +24,7 @@ from ._bspline_basis_core import (
     _compute_basis_deriv_nurbs_book_impl,
     _compute_basis_nurbs_book_impl,
 )
+from ._bspline_knots import _is_in_domain_impl
 
 if TYPE_CHECKING:
     from ..quad import PointsLattice
@@ -99,6 +100,30 @@ def _evaluate_Bspline_basis_combine_1D(  # noqa: PLR0913
     return out
 
 
+def _check_pts_in_domain_1d(
+    spline_1d: BsplineSpace1D,
+    pts: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Raise if any evaluation point lies outside the 1D space's domain.
+
+    Mirrors the validation of the nD tabulation path: without it, out-of-domain
+    points reach the Layer-3 kernels and produce silent garbage (negative span
+    indices wrap around the control-point array).
+
+    Args:
+        spline_1d (BsplineSpace1D): The 1D space whose domain bounds apply.
+        pts (npt.NDArray[np.float32 | np.float64]): Evaluation points.
+
+    Raises:
+        ValueError: If any point lies outside the knot-vector domain
+            (up to the space's tolerance).
+    """
+    if not np.all(_is_in_domain_impl(spline_1d.knots, spline_1d.degree, pts, spline_1d.tolerance)):
+        raise ValueError(
+            f"One or more values in pts are outside the knot vector domain {spline_1d.domain}"
+        )
+
+
 def _evaluate_Bspline_1D(
     spline: Bspline,
     pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
@@ -145,6 +170,9 @@ def _evaluate_Bspline_1D(
     if pts_array.dtype != spline.dtype:
         raise ValueError("Points dtype must match B-spline dtype")
 
+    spline_1D = spline.space.spaces[0]
+    _check_pts_in_domain_1d(spline_1D, pts_array)
+
     n_pts = pts_array.shape[0]
     expected_shape = (n_pts, spline.control_points.shape[-1])
     expected_dtype = spline.dtype
@@ -156,8 +184,6 @@ def _evaluate_Bspline_1D(
     else:
         _validate_out_array(out, expected_shape, expected_dtype)
         out_array = out
-
-    spline_1D = spline.space.spaces[0]
 
     _evaluate_Bspline_basis_combine_1D(
         spline.control_points,
@@ -495,6 +521,7 @@ def _evaluate_Bspline_deriv_1D(
         raise ValueError("Points dtype must match B-spline dtype")
 
     spline_1D = spline.space.spaces[0]
+    _check_pts_in_domain_1d(spline_1D, pts_array)
     if spline.is_rational:
         return _evaluate_Bspline_deriv_1D_rational(spline, spline_1D, pts_array, n_deriv, out)
     return _evaluate_Bspline_deriv_1D_non_rational(spline, spline_1D, pts_array, n_deriv, out)

--- a/src/pantr/bspline/_bspline_extraction.py
+++ b/src/pantr/bspline/_bspline_extraction.py
@@ -95,7 +95,7 @@ def _tabulate_Bspline_Bezier_1D_extraction_core(
                 alpha = (t - lcl_knots[k]) / (lcl_knots[k + degree - r] - lcl_knots[k])
                 C[:, k - 1] = alpha * C[:, k] + (one - alpha) * C[:, k - 1]
 
-    alphas = np.zeros(degree - 1, dtype=dtype)
+    alphas = np.zeros(max(degree - 1, 0), dtype=dtype)  # degree 0: no insertion coefficients
 
     knt_id = degree
     mult = 0

--- a/src/pantr/bspline/_bspline_interpolate.py
+++ b/src/pantr/bspline/_bspline_interpolate.py
@@ -7,6 +7,7 @@ Provides :func:`interpolate_bspline` (callable-based),
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -16,7 +17,7 @@ from numpy import typing as npt
 from .._interpolation_utils import resolve_svd_tolerance, split_components
 from ..quad import PointsLattice
 from ._bspline_space_1d import BsplineSpace1D
-from ._bspline_space_factory import create_greville_lattice, get_greville_abscissae
+from ._bspline_space_factory import create_greville_lattice
 from ._bspline_space_nd import BsplineSpace
 
 if TYPE_CHECKING:
@@ -881,7 +882,14 @@ def _l2_solve_components(  # noqa: PLR0913
 
         # Apply boundary interpolation to load vector.
         _apply_boundary_load(
-            func, space, quad_nodes_per_dir, bi_flags, load, comp_idx, n_components
+            func,
+            space,
+            quad_nodes_per_dir,
+            quad_weights_per_dir,
+            bi_flags,
+            load,
+            comp_idx,
+            n_components,
         )
 
         # Solve mass system per direction.
@@ -895,40 +903,66 @@ def _apply_boundary_load(  # noqa: PLR0913
     func: Callable[..., npt.ArrayLike],
     space: BsplineSpace,
     quad_nodes_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    quad_weights_per_dir: list[npt.NDArray[np.float32 | np.float64]],
     bi_flags: list[tuple[bool, bool]],
     load: npt.NDArray[np.floating[Any]],
     comp_idx: int,
     n_components: int,
 ) -> None:
-    """Apply boundary interpolation values to the load tensor in-place.
+    """Apply boundary-trace load values to the load tensor in-place.
+
+    The right-hand side of a Kronecker row is the tensor product of the
+    per-direction rows: a collocation row in every direction whose boundary row
+    was replaced, a mass row elsewhere.  An entry whose index sits on the
+    boundary of the directions in a set ``S`` must therefore hold the load
+    integrals over the directions **not** in ``S`` of the function restricted
+    to the boundary coordinates of ``S`` -- the boundary face traces, edge
+    traces, down to plain point values at corners where every direction is
+    collocated.  Subsets are processed by increasing size so the higher-order
+    intersections (edges, corners) overwrite the face values they sit on.
 
     Args:
         func (Callable): Function being projected.
         space (BsplineSpace): Target B-spline space.
         quad_nodes_per_dir (list[npt.NDArray]): Per-direction quadrature nodes.
+        quad_weights_per_dir (list[npt.NDArray]): Per-direction quadrature weights.
         bi_flags (list[tuple[bool, bool]]): Per-direction boundary flags.
         load (npt.NDArray): Load tensor to modify in-place.
         comp_idx (int): Which output component is being processed.
         n_components (int): Total number of output components.
     """
+    # Per direction, the flagged (slice_index, boundary_coordinate) sides.
+    sides_per_dir: dict[int, list[tuple[int, float]]] = {}
     for d, s1d in enumerate(space.spaces):
+        if s1d.periodic:
+            continue
         bi_left, bi_right = bi_flags[d]
-        if bi_left and not s1d.periodic:
-            a = s1d.domain[0]
-            boundary_val = _evaluate_func_at_boundary(
-                func, space, quad_nodes_per_dir, d, a, comp_idx, n_components
-            )
-            slices: list[int | slice] = [slice(None)] * load.ndim
-            slices[d] = 0
-            load[tuple(slices)] = boundary_val
-        if bi_right and not s1d.periodic:
-            b = s1d.domain[1]
-            boundary_val = _evaluate_func_at_boundary(
-                func, space, quad_nodes_per_dir, d, b, comp_idx, n_components
-            )
-            slices = [slice(None)] * load.ndim
-            slices[d] = -1
-            load[tuple(slices)] = boundary_val
+        sides: list[tuple[int, float]] = []
+        if bi_left:
+            sides.append((0, float(s1d.domain[0])))
+        if bi_right:
+            sides.append((-1, float(s1d.domain[1])))
+        if sides:
+            sides_per_dir[d] = sides
+
+    flagged_dirs = sorted(sides_per_dir)
+    for size in range(1, len(flagged_dirs) + 1):
+        for dirs in itertools.combinations(flagged_dirs, size):
+            for chosen in itertools.product(*(sides_per_dir[d] for d in dirs)):
+                fixed = {d: coord for d, (_, coord) in zip(dirs, chosen, strict=True)}
+                value = _boundary_trace_load(
+                    func,
+                    space,
+                    quad_nodes_per_dir,
+                    quad_weights_per_dir,
+                    fixed,
+                    comp_idx,
+                    n_components,
+                )
+                slices: list[int | slice] = [slice(None)] * load.ndim
+                for d, (idx, _) in zip(dirs, chosen, strict=True):
+                    slices[d] = idx
+                load[tuple(slices)] = value
 
 
 def _assemble_mass_and_quad_1d(
@@ -1033,54 +1067,41 @@ def _assemble_load_1d(
     return result
 
 
-def _evaluate_func_at_boundary(  # noqa: PLR0913
+def _boundary_trace_load(  # noqa: PLR0913
     func: Callable[..., npt.ArrayLike],
     space: BsplineSpace,
     quad_nodes_per_dir: list[npt.NDArray[np.float32 | np.float64]],
-    direction: int,
-    boundary_value: float | np.float32 | np.float64,
+    quad_weights_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    fixed: dict[int, float],
     comp_idx: int,
     n_components: int,
 ) -> npt.NDArray[np.floating[Any]] | np.floating[Any]:
-    """Evaluate a single component of the function at a boundary point (or hyperplane).
+    """Compute the load tensor of a boundary trace of ``func``.
 
-    For the boundary interpolation row in the Kronecker L2 projection, we
-    need the function value at the boundary. For 1D this is a scalar; for nD
-    it's a tensor over the other directions' Greville nodes.
+    Samples ``func`` on the lattice that pins the directions in ``fixed`` at
+    their boundary coordinates and uses quadrature nodes elsewhere, then
+    contracts every non-fixed direction with its weighted basis
+    (:func:`_assemble_load_1d`).  The result is the right-hand side matching a
+    Kronecker row that is collocated exactly in the ``fixed`` directions: the
+    load integrals of the trace ``func(.., fixed values, ..)`` -- a plain point
+    value when every direction is fixed (a corner).
 
     Args:
         func (Callable): Function to evaluate.
         space (BsplineSpace): Target B-spline space.
         quad_nodes_per_dir (list[npt.NDArray]): Quadrature nodes per direction.
-        direction (int): The direction of the boundary.
-        boundary_value: The boundary coordinate value.
+        quad_weights_per_dir (list[npt.NDArray]): Quadrature weights per direction.
+        fixed (dict[int, float]): Boundary coordinate per collocated direction.
         comp_idx (int): Which output component to extract.
         n_components (int): Total number of output components.
 
     Returns:
-        Value(s) at the boundary for insertion into the load tensor.
+        Trace load values shaped over the non-fixed directions' basis indices
+        (the fixed axes are squeezed out); a scalar when all axes are fixed.
     """
-    dtype = quad_nodes_per_dir[direction].dtype
-
-    if space.dim == 1:
-        # 1D: evaluate function at the single boundary point.
-        lattice = PointsLattice([np.array([boundary_value], dtype=dtype)])
-        raw = np.asarray(func(lattice))
-        if not np.issubdtype(raw.dtype, np.floating):
-            raw = raw.astype(np.float64)
-        flat = raw.ravel()
-        if n_components > 1:
-            # Vector-valued: extract the component.
-            val: np.floating[Any] = flat[comp_idx]
-            return val
-        val = flat[0]
-        return val
-
-    # nD: create a lattice with a single point in the boundary direction
-    # and Greville nodes in the other directions.
-    greville_nodes = [get_greville_abscissae(s) for s in space.spaces]
+    dtype = quad_nodes_per_dir[0].dtype
     boundary_nodes = [
-        np.array([boundary_value], dtype=dtype) if d == direction else greville_nodes[d]
+        np.array([fixed[d]], dtype=dtype) if d in fixed else quad_nodes_per_dir[d]
         for d in range(space.dim)
     ]
     lattice = PointsLattice(boundary_nodes)
@@ -1090,13 +1111,21 @@ def _evaluate_func_at_boundary(  # noqa: PLR0913
     if not np.issubdtype(raw.dtype, np.floating):
         raw = raw.astype(np.float64)
 
+    trace: npt.NDArray[np.floating[Any]]
     if n_components > 1:
         # Vector-valued: reshape to (*grid_shape, rank) and extract component.
-        values = raw.reshape(*grid_shape, n_components)
-        return values[..., comp_idx].squeeze(axis=direction)
+        trace = np.asarray(raw.reshape(*grid_shape, n_components)[..., comp_idx])
+    else:
+        trace = np.asarray(raw.reshape(grid_shape))
 
-    values = raw.reshape(grid_shape)
-    return values.squeeze(axis=direction)
+    for d, s1d in enumerate(space.spaces):
+        if d in fixed:
+            continue
+        trace = _assemble_load_1d(s1d, trace, quad_nodes_per_dir[d], quad_weights_per_dir[d], d)
+    squeezed = trace.squeeze(axis=tuple(sorted(fixed)))
+    if squeezed.ndim == 0:
+        return squeezed[()]
+    return squeezed
 
 
 def _resolve_boundary_interpolation(

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -281,12 +281,14 @@ def _to_open_bspline_1d_impl(
 
     # Trim external / ghost knots.  For both periodic (ghost knots) and
     # non-periodic unclamped (external support knots), there are
-    # ``p + 1 - m_bdy`` entries on each side that lie outside the domain and
-    # must be removed to obtain a clamped (open) knot vector.
-    n_trim = p + 1 - m_left
-    open_knots = new_knots[n_trim : len(new_knots) - n_trim] if n_trim else new_knots
+    # ``p + 1 - m_bdy`` entries outside the domain on each side -- counted with
+    # each side's own boundary multiplicity, which may differ.
+    n_trim_left = p + 1 - m_left
+    n_trim_right = p + 1 - m_right
+    end = len(new_knots) - n_trim_right
+    open_knots = new_knots[n_trim_left:end]
     n_open = len(open_knots) - p - 1
-    open_ctrl = new_ctrl[n_trim : n_trim + n_open] if n_trim else new_ctrl[:n_open]
+    open_ctrl = new_ctrl[n_trim_left : n_trim_left + n_open]
 
     return open_knots, open_ctrl
 

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -68,7 +68,12 @@ def _cached_unique_knots_and_multiplicity(
     dtype = np.dtype(dtype_str)
     knots = np.frombuffer(knots_bytes, dtype=dtype, count=size).copy()
     tol_value = dtype.type(tol)
-    return _get_unique_knots_and_multiplicity_impl(knots, degree, tol_value, in_domain)
+    unique, mults = _get_unique_knots_and_multiplicity_impl(knots, degree, tol_value, in_domain)
+    # The same arrays are returned to every caller; freeze them so a caller
+    # mutation cannot poison the cache.
+    unique.flags.writeable = False
+    mults.flags.writeable = False
+    return unique, mults
 
 
 class BsplineSpace1D:
@@ -114,9 +119,14 @@ class BsplineSpace1D:
         """
         BsplineSpace1D._validate_input(knots, degree, periodic)
 
-        self._knots = np.asarray(knots)
-        if np.issubdtype(self._knots.dtype, np.integer):
-            self._knots = self._knots.astype(np.float64)
+        knots_arr = np.asarray(knots)
+        if np.issubdtype(knots_arr.dtype, np.integer):
+            knots_arr = knots_arr.astype(np.float64)
+        else:
+            # Always own the storage: the vector is frozen read-only below, and
+            # freezing a caller-supplied array in place would mutate caller state.
+            knots_arr = knots_arr.copy()
+        self._knots = knots_arr
 
         self._tol = BsplineSpace1D._get_tolerance(self.dtype)
 
@@ -204,7 +214,10 @@ class BsplineSpace1D:
 
         snapped_knots = self._knots.copy()
         for val in unique_vals:
-            mask = np.isclose(rounded, val, atol=0)
+            # Exact match on the rounded values: knots are merged only when they
+            # round to the same tolerance-grid point.  (np.isclose would compare
+            # with its default rtol=1e-5 and merge far-apart knots.)
+            mask = rounded == val
             snapped_knots[mask] = np.mean(self._knots[mask], dtype=self.dtype)
         self._knots = snapped_knots
 

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -233,22 +233,12 @@ def test_locate_nan_is_a_miss() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="default knot snapping uses np.isclose with its default rtol=1e-5: knots "
-    "0.5 and 0.500001 are merged into one double knot, changing the space's continuity",
-)
 def test_snap_knots_does_not_merge_distant_knots() -> None:
     space = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 0.500001, 1.0, 1.0, 1.0]), 2)
     _, mults = space.get_unique_knots_and_multiplicity()
     assert np.asarray(mults).tolist() == [3, 1, 1, 3]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="reverse() of a periodic direction flips the stored control points without "
-    "the cyclic ghost shift, so the result is a parameter-shifted (wrong) reversal",
-)
 def test_periodic_reverse_is_pointwise_mirror() -> None:
     space = create_uniform_space(2, [4], periodic=True)
     n_basis = space.spaces[0].num_basis
@@ -262,11 +252,6 @@ def test_periodic_reverse_is_pointwise_mirror() -> None:
     np.testing.assert_allclose(values, mirrored, atol=1e-12)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the 1D evaluate path performs no domain check (the nD path does): "
-    "out-of-domain points reach the kernel and return silent garbage",
-)
 def test_bspline_evaluate_1d_rejects_out_of_domain() -> None:
     space = create_uniform_space(2, [4])
     n_basis = space.spaces[0].num_basis
@@ -275,11 +260,6 @@ def test_bspline_evaluate_1d_rejects_out_of_domain() -> None:
         spline.evaluate(np.array([-0.5]))
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="to_open_bspline trims p+1-m_left knots from BOTH ends: asymmetric boundary "
-    "multiplicities shrink the domain and change the function",
-)
 def test_to_open_preserves_asymmetric_unclamped_spline() -> None:
     space = BsplineSpace([BsplineSpace1D(np.array([-0.5, 0.0, 0.5, 1.0, 1.0]), 1)])
     n_basis = space.spaces[0].num_basis
@@ -298,12 +278,6 @@ def test_to_open_preserves_asymmetric_unclamped_spline() -> None:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="boundary_interpolation=True overwrites the boundary load slice with point "
-    "values while cross directions still apply mass solves: the 2D projection no longer "
-    "reproduces functions that lie exactly in the space",
-)
 def test_l2_project_boundary_interpolation_2d_reproduces_space_function() -> None:
     space = create_uniform_space(2, [5, 5])
 
@@ -319,11 +293,6 @@ def test_l2_project_boundary_interpolation_2d_reproduces_space_function() -> Non
     np.testing.assert_allclose(values, exact, atol=1e-8)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="get_unique_knots_and_multiplicity returns the writable lru-cached arrays: "
-    "a caller mutation poisons the cache for every later query of the same space",
-)
 def test_unique_knots_cache_is_not_corruptible() -> None:
     space = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]), 2)
     unique, _ = space.get_unique_knots_and_multiplicity()
@@ -334,22 +303,12 @@ def test_unique_knots_cache_is_not_corruptible() -> None:
     assert float(np.asarray(fresh)[0]) == 0.0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="BsplineSpace1D(snap_knots=False) freezes the caller's knot array in place "
-    "instead of copying before setting writeable=False",
-)
 def test_snap_knots_false_does_not_freeze_caller_array() -> None:
     knots = np.array([0.0, 0.0, 1.0, 1.0])
     BsplineSpace1D(knots, 1, snap_knots=False)
     assert knots.flags.writeable
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="degree-0 extraction allocates np.zeros(degree - 1) = np.zeros(-1): every "
-    "extraction entry point crashes for degree-0 spaces",
-)
 def test_degree0_extraction_operator() -> None:
     space = create_uniform_space(0, [4])
     extraction = SpanwiseElementExtraction(space, "bezier")
@@ -357,12 +316,6 @@ def test_degree0_extraction_operator() -> None:
     np.testing.assert_allclose(operator, np.ones((1, 1)))
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the derivative scaling evaluates degree*diff/denom eagerly inside np.where: "
-    "a C^-1 interior knot (multiplicity p+1) emits a divide-by-zero RuntimeWarning, "
-    "which the repo's warnings-as-errors pytest config turns into an error",
-)
 def test_cm1_interior_knot_derivative_emits_no_warning() -> None:
     knots = np.array([0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0])
     space = BsplineSpace([BsplineSpace1D(knots, 2)])


### PR DESCRIPTION
## Summary

Fixes the nine confirmed bspline bugs from the review (stacked on #192; merge after it).

| Fix | What was wrong |
|---|---|
| `snap_knots` exact grouping | `np.isclose(rounded, val, atol=0)` kept numpy's default `rtol=1e-5`, merging knots up to 1e-5 (relative) apart — `[0.5, 0.500001]` became one double knot, silently changing continuity. Grouping is now `rounded == val` (the original intent). |
| periodic `reverse()` | flipped the stored points without the cyclic ghost shift (`full[j] = stored[j % n_stored]`); reversal is now `roll(flip(·), n_full − n_stored)`, making `rev(a+b−t) == f(t)` exact. |
| 1D `evaluate`/`evaluate_derivatives` domain check | out-of-domain points reached the kernels (negative span indices wrap) and returned silent garbage; both paths now validate with `_is_in_domain_impl`, matching the nD error. |
| `to_open_bspline` asymmetric trim | trimmed `p+1−m_left` knots from **both** ends; each side now uses its own boundary multiplicity, preserving the domain of asymmetric unclamped splines. |
| `l2_project_bspline(boundary_interpolation=True)`, dim ≥ 2 | boundary load slices held point values while cross directions still apply mass solves (error 3.0 on an in-space function). Slices now hold the cross-direction **load integrals of the boundary trace**, assembled per boundary subset (faces → edges → corners) so each Kronecker row matches its collocation structure. Verified exact for in-space functions in 1D/2D/3D, scalar/vector, full and per-direction flags; a zero boundary trace now projects to exactly zero on the edge. |
| unique-knots cache | `get_unique_knots_and_multiplicity` returned the writable lru-cached arrays — caller mutation poisoned the cache. Cached arrays are frozen. |
| `snap_knots=False` constructor | froze the **caller's** knot array in place; the constructor now always owns (copies) its storage. |
| degree-0 extraction | `np.zeros(degree − 1)` crashed every extraction entry point for degree-0 spaces. |
| C⁻¹ derivative warning | `np.where(denom == 0, 0, x/denom)` evaluated the division eagerly → divide-by-zero `RuntimeWarning` (an error under the repo's warnings-as-errors pytest config). Masked `np.divide(..., where=)` instead. |

The nine review xfail regressions flip to plain tests.

## Test plan

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy --config-file mypy.ini src tests`
- [x] `pytest --no-cov` (3432 passed, 8 xfailed)
- [x] Sphinx docs build with `-W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)