### PR TITLE
perf(bspline): serial small-batch path for 1D basis tabulation

### DIFF
--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -16,6 +16,7 @@ The main modules are:
 - :mod:`pantr.bezier`: Bézier curves/surfaces and root finding for Bernstein polynomials.
 """
 
+import sys
 from typing import Final
 
 from . import (
@@ -113,10 +114,13 @@ if not TYPE_CHECKING:
             logger.debug("Finished Numba JIT warmup.")
         except Exception as exc:
             # During process teardown (e.g. short scripts), background Numba caching
-            # might fail due to unavailable module locators.  Log rather than swallow
-            # so that compilation errors (wrong type specialisation, cache corruption)
-            # are observable; the first affected call will still compile on demand.
-            logger.warning("Numba JIT warmup failed: %s", exc)
+            # fails because module locators become unavailable.  Distinguish teardown
+            # (DEBUG) from real compilation errors (WARNING) so that cache corruption
+            # or wrong type specialisations remain observable without noisy false alarms.
+            if sys.is_finalizing():
+                logger.debug("Numba JIT warmup skipped (process finalizing): %s", exc)
+            else:
+                logger.warning("Numba JIT warmup failed: %s", exc)
         finally:
             # Always signal completion so callers are never blocked indefinitely.
             _warmup_complete.set()

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -111,10 +111,12 @@ if not TYPE_CHECKING:
             _clipping_core._warmup_numba_functions()
             _batch_core._warmup_numba_functions()
             logger.debug("Finished Numba JIT warmup.")
-        except Exception:
+        except Exception as exc:
             # During process teardown (e.g. short scripts), background Numba caching
-            # might fail due to unavailable module locators. We silently ignore this.
-            pass
+            # might fail due to unavailable module locators.  Log rather than swallow
+            # so that compilation errors (wrong type specialisation, cache corruption)
+            # are observable; the first affected call will still compile on demand.
+            logger.warning("Numba JIT warmup failed: %s", exc)
         finally:
             # Always signal completion so callers are never blocked indefinitely.
             _warmup_complete.set()

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -15,7 +15,9 @@ import numpy.typing as npt
 
 from .._numba_compat import wait_for_jit_warmup
 from ._basis_core import (
+    _PARALLEL_MIN_NUM_PTS,
     _tabulate_Bernstein_basis_1D_core,
+    _tabulate_Bernstein_basis_1D_serial_core,
     _tabulate_cardinal_Bspline_basis_1D_core,
     _tabulate_Legendre_basis_1D_core,
 )
@@ -30,14 +32,19 @@ if TYPE_CHECKING:
     from . import LagrangeVariant
 
 
+_BasisCoreFunc = Callable[
+    [np.int32, npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
+    None,
+]
+"""Signature of a 1D basis tabulation core kernel: ``(degree, pts, out) -> None``."""
+
+
 def _tabulate_basis_1D_impl_helper(
     n: int,
     t: npt.ArrayLike,
-    core_func: Callable[
-        [np.int32, npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
-        None,
-    ],
+    core_func: _BasisCoreFunc,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
+    core_func_serial: _BasisCoreFunc | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Common implementation for tabulating 1D basis functions.
 
@@ -48,11 +55,14 @@ def _tabulate_basis_1D_impl_helper(
         n (int): Degree of the basis polynomials. Must be non-negative.
         t (npt.ArrayLike): Evaluation points. Can be a scalar, list, or numpy array.
             Types different from float32 or float64 are automatically converted to float64.
-        core_func: Core function to call for computation. Must accept
+        core_func (_BasisCoreFunc): Core function to call for computation. Must accept
             (np.int32, npt.NDArray[float32/float64], npt.NDArray[float32/float64]) -> None.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
             where the result will be stored. If None, a new array is allocated.
             Must have the correct shape and dtype if provided. Defaults to None.
+        core_func_serial (_BasisCoreFunc | None): Optional serial twin of ``core_func``,
+            used for batches smaller than ``_PARALLEL_MIN_NUM_PTS`` to avoid the
+            parallel launch overhead. Defaults to None (always use ``core_func``).
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Evaluated basis functions, with the same shape
@@ -93,7 +103,10 @@ def _tabulate_basis_1D_impl_helper(
 
     B_normalized = out.reshape(expected_normalized_shape)
 
-    core_func(np.int32(n), t, B_normalized)
+    if core_func_serial is not None and num_pts < _PARALLEL_MIN_NUM_PTS:
+        core_func_serial(np.int32(n), t, B_normalized)
+    else:
+        core_func(np.int32(n), t, B_normalized)
 
     return out
 
@@ -129,7 +142,13 @@ def _tabulate_Bernstein_basis_1D_impl(
                [0.0625, 0.375 , 0.5625],
                [0.    , 0.    , 1.    ]])
     """
-    return _tabulate_basis_1D_impl_helper(n, t, _tabulate_Bernstein_basis_1D_core, out)
+    return _tabulate_basis_1D_impl_helper(
+        n,
+        t,
+        _tabulate_Bernstein_basis_1D_core,
+        out,
+        core_func_serial=_tabulate_Bernstein_basis_1D_serial_core,
+    )
 
 
 def _tabulate_cardinal_Bspline_basis_1D_impl(

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -55,7 +55,8 @@ def _tabulate_basis_1D_impl_helper(
         n (int): Degree of the basis polynomials. Must be non-negative.
         t (npt.ArrayLike): Evaluation points. Can be a scalar, list, or numpy array.
             Types different from float32 or float64 are automatically converted to float64.
-        core_func (_BasisCoreFunc): Core function to call for computation. Must accept
+        core_func (_BasisCoreFunc): Parallel core function; used for batches of
+            ``_PARALLEL_MIN_NUM_PTS`` points or more. Must accept
             (np.int32, npt.NDArray[float32/float64], npt.NDArray[float32/float64]) -> None.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
             where the result will be stored. If None, a new array is allocated.

--- a/src/pantr/basis/_basis_core.py
+++ b/src/pantr/basis/_basis_core.py
@@ -11,6 +11,52 @@ import numpy.typing as npt
 
 from .._numba_compat import nb_jit, nb_prange
 
+_PARALLEL_MIN_NUM_PTS = 4096
+"""Minimum number of evaluation points for which the ``parallel=True`` kernels pay off.
+
+Below this threshold the fork/join overhead of a parallel Numba kernel launch
+(hundreds of microseconds) dwarfs the per-point work (tens of nanoseconds), so
+the Layer-2 tabulation helpers dispatch to the serial twin kernels instead.
+"""
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    inline="always",
+)
+def _bernstein_point(
+    n: np.int32,
+    u: np.float32 | np.float64,
+    out_row: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate all Bernstein basis polynomials of degree ``n`` at one point.
+
+    Recurrence: ``B_0,n(u) = (1-u)^n``; ``B_i,n = B_{i-1},n * ((n-i+1)/i) * (u/(1-u))``.
+    ``u == 1.0`` is special-cased (the recurrence would produce NaN).
+
+    Args:
+        n (np.int32): Degree of the Bernstein polynomials (>= 1).
+        u (np.float32 | np.float64): Evaluation point.
+        out_row (npt.NDArray[np.float32 | np.float64]): Output row of length ``n + 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    if u == 1.0:
+        # At t=1.0: only B_n,n(1) = 1, all others are 0
+        for i in range(out_row.shape[0]):
+            out_row[i] = 0.0
+        out_row[n] = 1.0
+    else:
+        # For t != 1.0, use recurrence relation
+        one_minus_u = 1.0 - u
+        out_row[0] = np.power(one_minus_u, n)
+        t_over_1mt = u / one_minus_u
+        for i in range(1, n + 1):
+            const_factor = (n - i + 1.0) / i
+            out_row[i] = out_row[i - 1] * const_factor * t_over_1mt
+
 
 @nb_jit(
     nopython=True,
@@ -28,16 +74,11 @@ def _tabulate_Bernstein_basis_1D_core(
     at each evaluation point in t. Writes the result to the provided output array,
     where out[j, i] contains the value of the i-th basis polynomial evaluated at point t_j.
 
-    The implementation uses a recurrence relation for efficient computation:
-    - Base case: B_0,n(t) = (1-t)^n
-    - Recurrence: B_i,n(t) = B_{i-1},n(t) * ((n-i+1)/i) * (t/(1-t))
-
-    Special handling is applied for points where t=1.0, where the recurrence
-    relation would produce NaN values. At t=1.0, only the last basis function
-    B_n,n(1) = 1, while all others are 0.
-
     Each evaluation point is independent, so the outer loop over points is
     parallelised with ``numba.prange`` for better throughput on large arrays.
+    For small batches (fewer than ``_PARALLEL_MIN_NUM_PTS`` points) prefer the
+    serial twin :func:`_tabulate_Bernstein_basis_1D_serial_core`, which avoids
+    the parallel launch overhead.
 
     Args:
         n (np.int32): Degree of the Bernstein polynomials. Must be non-negative.
@@ -64,21 +105,44 @@ def _tabulate_Bernstein_basis_1D_core(
 
     # Process each point — rows are independent, so use prange.
     for j in nb_prange(t.shape[0]):
-        u = t[j]
-        if u == 1.0:
-            # At t=1.0: only B_n,n(1) = 1, all others are 0
-            for i in range(out.shape[1]):
-                out[j, i] = 0.0
-            out[j, n] = 1.0
-        else:
-            # For t != 1.0, use recurrence relation
-            one_minus_u = 1.0 - u
-            out[j, 0] = np.power(one_minus_u, n)
-            if n > 0:
-                t_over_1mt = u / one_minus_u
-                for i in range(1, n + 1):
-                    const_factor = (n - i + 1.0) / i
-                    out[j, i] = out[j, i - 1] * const_factor * t_over_1mt
+        _bernstein_point(n, t[j], out[j, :])
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+)
+def _tabulate_Bernstein_basis_1D_serial_core(
+    n: np.int32,
+    t: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate Bernstein basis polynomials of degree n at points t (serial twin).
+
+    Identical to :func:`_tabulate_Bernstein_basis_1D_core` but compiled without
+    ``parallel=True``: no fork/join overhead, which makes it the faster choice
+    for small point batches.
+
+    Args:
+        n (np.int32): Degree of the Bernstein polynomials. Must be non-negative.
+        t (npt.NDArray[np.float32 | np.float64]): 1D array of
+            evaluation points. Must be a contiguous array of float32 or float64
+            values.
+        out (npt.NDArray[np.float32 | np.float64]): Output array
+            of shape (len(t), n+1) and dtype matching t. Must have the correct
+            shape and dtype (no validation performed).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call _tabulate_Bernstein_basis_1D_impl instead.
+    """
+    if n == 0:
+        for j in range(out.shape[0]):
+            out[j, 0] = 1.0
+        return
+
+    for j in range(t.shape[0]):
+        _bernstein_point(n, t[j], out[j, :])
 
 
 @nb_jit(
@@ -202,9 +266,108 @@ def _tabulate_Legendre_basis_1D_core(
 @nb_jit(
     nopython=True,
     cache=True,
+    inline="always",
+)
+def _bernstein_derivs_point(
+    n: np.int32,
+    s: np.float32 | np.float64,
+    n_deriv: int,
+    out_pt: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate all Bernstein basis derivatives at one point (A2.3 body, unit spans).
+
+    Inlined (``inline="always"``) into the batch kernels so the per-point
+    scratch allocations stay visible to Numba's parallel allocation hoisting.
+
+    Args:
+        n (np.int32): Degree of the Bernstein polynomials (>= 0).
+        s (np.float32 | np.float64): Evaluation point in [0, 1].
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        out_pt (npt.NDArray[np.float32 | np.float64]): Output block of shape
+            ``(n_deriv + 1, n + 1)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    order = int(n) + 1
+    dtype = out_pt.dtype
+    zero = dtype.type(0.0)
+    one = dtype.type(1.0)
+
+    # Zero out this point's output slice (thread-local write)
+    for k in range(n_deriv + 1):
+        for i in range(order):
+            out_pt[k, i] = zero
+
+    # --- Build ndu table for uniform knots on [0, 1] ---
+    # Upper triangle / diagonal: ndu[r, j] = B_{r, j}(s)  (r <= j)
+    # Lower triangle:            ndu[j, r] = 1             (r <  j)  ← knot differences
+    ndu = np.zeros((order, order), dtype=dtype)
+    a_arr = np.zeros((2, n_deriv + 1), dtype=dtype)
+
+    ndu[0, 0] = one
+    for j in range(1, order):
+        saved = zero
+        for r in range(j):
+            ndu[j, r] = one  # knot difference = 1 for uniform Bernstein knots
+            temp = ndu[r, j - 1]  # divide by ndu[j, r] = 1
+            ndu[r, j] = saved + (one - s) * temp
+            saved = s * temp
+        ndu[j, j] = saved
+
+    # 0th derivatives = Bernstein basis values
+    for j in range(order):
+        out_pt[0, j] = ndu[j, int(n)]
+
+    # --- k-th derivatives via triangular recursion (A2.3, unit knot spans) ---
+    for r in range(order):
+        s1 = 0
+        s2 = 1
+        a_arr[0, 0] = one
+
+        for k in range(1, n_deriv + 1):
+            d = zero
+            rk = r - k
+            pk = int(n) - k
+
+            if r >= k:
+                a_arr[s2, 0] = a_arr[s1, 0]  # divide by ndu[pk+1, rk] = 1
+                d = a_arr[s2, 0] * ndu[rk, pk]
+
+            j1 = 1 if rk >= -1 else -rk
+            j2 = k - 1 if (r - 1) <= pk else int(n) - r
+
+            for jj in range(j1, j2 + 1):
+                a_arr[s2, jj] = a_arr[s1, jj] - a_arr[s1, jj - 1]  # divide by 1
+                d += a_arr[s2, jj] * ndu[rk + jj, pk]
+
+            if r <= pk:
+                a_arr[s2, k] = -a_arr[s1, k - 1]  # divide by ndu[pk+1, r] = 1
+                d += a_arr[s2, k] * ndu[r, pk]
+
+            out_pt[k, r] = d
+
+            # Swap rows
+            tmp_s = s1
+            s1 = s2
+            s2 = tmp_s
+
+    # --- Factorial scaling: multiply k-th row by n! / (n-k)! ---
+    # When k > n, fac becomes 0, zeroing rows beyond the degree (the k-th
+    # derivative of a degree-n polynomial is identically zero for k > n).
+    fac = int(n)
+    for k in range(1, n_deriv + 1):
+        for j in range(order):
+            out_pt[k, j] *= fac
+        fac *= int(n) - k
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
     parallel=True,
 )
-def _tabulate_Bernstein_basis_deriv_1D_core(  # noqa: PLR0912
+def _tabulate_Bernstein_basis_deriv_1D_core(
     n: np.int32,
     t: npt.NDArray[np.float32 | np.float64],
     n_deriv: int,
@@ -214,7 +377,10 @@ def _tabulate_Bernstein_basis_deriv_1D_core(  # noqa: PLR0912
 
     Implements Algorithm A2.3 (DerBasisFuncs) from Piegl & Tiller specialised
     for Bernstein polynomials, where all knot differences equal one.  The outer
-    loop over points is parallelised with ``numba.prange``.
+    loop over points is parallelised with ``numba.prange``; for small batches
+    (fewer than ``_PARALLEL_MIN_NUM_PTS`` points) prefer the serial twin
+    :func:`_tabulate_Bernstein_basis_deriv_1D_serial_core`, which avoids the
+    parallel launch overhead.
 
     Args:
         n (np.int32): Degree of the Bernstein polynomials (>= 0).
@@ -235,79 +401,43 @@ def _tabulate_Bernstein_basis_deriv_1D_core(  # noqa: PLR0912
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
-    order = int(n) + 1
     n_pts = t.shape[0]
-    dtype = t.dtype
-    zero = dtype.type(0.0)
-    one = dtype.type(1.0)
-
     for pt_id in nb_prange(n_pts):
-        s = t[pt_id]
+        _bernstein_derivs_point(n, t[pt_id], n_deriv, out_deriv[pt_id, :, :])
 
-        # Zero out this point's output slice (thread-local write)
-        for k in range(n_deriv + 1):
-            for i in range(order):
-                out_deriv[pt_id, k, i] = zero
 
-        # --- Build ndu table for uniform knots on [0, 1] ---
-        # Upper triangle / diagonal: ndu[r, j] = B_{r, j}(s)  (r <= j)
-        # Lower triangle:            ndu[j, r] = 1             (r <  j)  ← knot differences
-        ndu = np.zeros((order, order), dtype=dtype)
-        a_arr = np.zeros((2, n_deriv + 1), dtype=dtype)
+@nb_jit(
+    nopython=True,
+    cache=True,
+)
+def _tabulate_Bernstein_basis_deriv_1D_serial_core(
+    n: np.int32,
+    t: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    out_deriv: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate Bernstein basis function derivatives on [0, 1] (serial twin).
 
-        ndu[0, 0] = one
-        for j in range(1, order):
-            saved = zero
-            for r in range(j):
-                ndu[j, r] = one  # knot difference = 1 for uniform Bernstein knots
-                temp = ndu[r, j - 1]  # divide by ndu[j, r] = 1
-                ndu[r, j] = saved + (one - s) * temp
-                saved = s * temp
-            ndu[j, j] = saved
+    Identical to :func:`_tabulate_Bernstein_basis_deriv_1D_core` but compiled
+    without ``parallel=True``: no fork/join overhead, which makes it the faster
+    choice for small point batches.
 
-        # 0th derivatives = Bernstein basis values
-        for j in range(order):
-            out_deriv[pt_id, 0, j] = ndu[j, int(n)]
+    Args:
+        n (np.int32): Degree of the Bernstein polynomials (>= 0).
+        t (npt.NDArray[np.float32 | np.float64]): 1D array of evaluation points
+            in [0, 1].
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        out_deriv (npt.NDArray[np.float32 | np.float64]): Output array of shape
+            ``(len(t), n_deriv+1, n+1)`` and dtype matching ``t``. Must have the
+            correct shape and dtype (no validation performed).
 
-        # --- k-th derivatives via triangular recursion (A2.3, unit knot spans) ---
-        for r in range(order):
-            s1 = 0
-            s2 = 1
-            a_arr[0, 0] = one
-
-            for k in range(1, n_deriv + 1):
-                d = zero
-                rk = r - k
-                pk = int(n) - k
-
-                if r >= k:
-                    a_arr[s2, 0] = a_arr[s1, 0]  # divide by ndu[pk+1, rk] = 1
-                    d = a_arr[s2, 0] * ndu[rk, pk]
-
-                j1 = 1 if rk >= -1 else -rk
-                j2 = k - 1 if (r - 1) <= pk else int(n) - r
-
-                for jj in range(j1, j2 + 1):
-                    a_arr[s2, jj] = a_arr[s1, jj] - a_arr[s1, jj - 1]  # divide by 1
-                    d += a_arr[s2, jj] * ndu[rk + jj, pk]
-
-                if r <= pk:
-                    a_arr[s2, k] = -a_arr[s1, k - 1]  # divide by ndu[pk+1, r] = 1
-                    d += a_arr[s2, k] * ndu[r, pk]
-
-                out_deriv[pt_id, k, r] = d
-
-                # Swap rows
-                tmp_s = s1
-                s1 = s2
-                s2 = tmp_s
-
-        # --- Factorial scaling: multiply k-th row by n! / (n-k)! ---
-        fac = int(n)
-        for k in range(1, n_deriv + 1):
-            for j in range(order):
-                out_deriv[pt_id, k, j] *= fac
-            fac *= int(n) - k
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
+    """
+    n_pts = t.shape[0]
+    for pt_id in range(n_pts):
+        _bernstein_derivs_point(n, t[pt_id], n_deriv, out_deriv[pt_id, :, :])
 
 
 def _warmup_numba_functions() -> None:
@@ -320,15 +450,19 @@ def _warmup_numba_functions() -> None:
     t_dummy = np.array([0.0, 0.5, 1.0], dtype=np.float64)
     out_dummy = np.empty((3, 2), dtype=np.float64)
 
-    # Warmup each core function with float64
+    # Warmup each core function with float64 (parallel and serial twins)
     _tabulate_Bernstein_basis_1D_core(np.int32(1), t_dummy, out_dummy)
+    _tabulate_Bernstein_basis_1D_serial_core(np.int32(1), t_dummy, out_dummy)
     _tabulate_cardinal_Bspline_basis_1D_core(np.int32(1), t_dummy, out_dummy)
     _tabulate_Legendre_basis_1D_core(np.int32(1), t_dummy, out_dummy)
 
-    # Warmup Bernstein derivative core with float64
+    # Warmup Bernstein derivative cores with float64 (parallel and serial twins)
     n_deriv_dummy = 2
     out_deriv_dummy = np.empty((3, n_deriv_dummy + 1, 2), dtype=np.float64)
     _tabulate_Bernstein_basis_deriv_1D_core(np.int32(1), t_dummy, n_deriv_dummy, out_deriv_dummy)
+    _tabulate_Bernstein_basis_deriv_1D_serial_core(
+        np.int32(1), t_dummy, n_deriv_dummy, out_deriv_dummy
+    )
 
 
 # Precompile numba functions on module import

--- a/src/pantr/basis/_basis_core.py
+++ b/src/pantr/basis/_basis_core.py
@@ -36,12 +36,13 @@ def _bernstein_point(
     ``u == 1.0`` is special-cased (the recurrence would produce NaN).
 
     Args:
-        n (np.int32): Degree of the Bernstein polynomials (>= 1).
+        n (np.int32): Degree of the Bernstein polynomials (>= 0).
         u (np.float32 | np.float64): Evaluation point.
         out_row (npt.NDArray[np.float32 | np.float64]): Output row of length ``n + 1``.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bernstein_basis_1D_impl` instead.
     """
     if u == 1.0:
         # At t=1.0: only B_n,n(1) = 1, all others are 0
@@ -92,10 +93,8 @@ def _tabulate_Bernstein_basis_1D_core(
             shape and dtype (no validation performed inside this numba-compiled function).
 
     Note:
-        This is a Numba-compiled function optimized for performance. It
-        expects pre-normalized inputs (1D contiguous arrays) and assumes the
-        output array has the correct shape and dtype. For general use,
-        call _tabulate_Bernstein_basis_1D_impl instead.
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bernstein_basis_1D_impl` instead.
     """
     if n == 0:
         # The basis is just B_0,0(pts) = 1
@@ -288,6 +287,7 @@ def _bernstein_derivs_point(
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = int(n) + 1
     dtype = out_pt.dtype

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -13,7 +13,11 @@ import numpy.typing as npt
 
 from .._numba_compat import nb_jit, nb_prange
 from ..basis._basis_1D import _tabulate_Bernstein_basis_1D_impl
-from ..basis._basis_core import _tabulate_Bernstein_basis_deriv_1D_core
+from ..basis._basis_core import (
+    _PARALLEL_MIN_NUM_PTS,
+    _tabulate_Bernstein_basis_deriv_1D_core,
+    _tabulate_Bernstein_basis_deriv_1D_serial_core,
+)
 from ..basis._basis_utils import (
     _compute_final_output_shape_1D,
     _compute_final_output_shape_1D_deriv,
@@ -28,14 +32,6 @@ from ._bspline_knots import (
 
 if TYPE_CHECKING:
     from ._bspline_space_1d import BsplineSpace1D
-
-_PARALLEL_MIN_NUM_PTS = 4096
-"""Minimum number of evaluation points for which the ``parallel=True`` kernels pay off.
-
-Below this threshold the fork/join overhead of a parallel Numba kernel launch
-(hundreds of microseconds) dwarfs the per-point work (tens of nanoseconds), so
-the Layer-2 tabulation helpers dispatch to the serial twin kernels instead.
-"""
 
 
 @nb_jit(
@@ -540,9 +536,12 @@ def _tabulate_Bspline_basis_Bernstein_like_deriv_1D(
     k0, k1 = spline.domain
     pts_normalized = (pts - k0) / (k1 - k0)  # map to [0, 1]
 
-    _tabulate_Bernstein_basis_deriv_1D_core(
-        np.int32(spline.degree), pts_normalized, n_deriv, out_deriv
+    deriv_core = (
+        _tabulate_Bernstein_basis_deriv_1D_core
+        if pts_normalized.shape[0] >= _PARALLEL_MIN_NUM_PTS
+        else _tabulate_Bernstein_basis_deriv_1D_serial_core
     )
+    deriv_core(np.int32(spline.degree), pts_normalized, n_deriv, out_deriv)
 
     # Chain-rule: d^k/dx^k f(x) = d^k/ds^k f(s) * (ds/dx)^k = d^k/ds^k f(s) * (1/(k1-k0))^k
     inv_span: float = 1.0 / float(k1 - k0)
@@ -559,6 +558,8 @@ def _tabulate_Bspline_basis_1D_impl(
     pts: npt.ArrayLike,
     out_basis: npt.NDArray[np.float32 | np.float64] | None = None,
     out_first_basis: npt.NDArray[np.int_] | None = None,
+    *,
+    validate: bool = True,
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
     """Evaluate B-spline basis functions at given points.
 
@@ -581,6 +582,10 @@ def _tabulate_Bspline_basis_1D_impl(
             first basis indices will be stored. If None, a new array is allocated. Must have
             the correct shape and dtype np.int_ if provided. This follows NumPy's style for
             output arrays. Defaults to None.
+        validate (bool): If True (default), check that every point lies inside the
+            spline domain. Pass False only when the caller guarantees in-domain
+            points (e.g. points generated inside a knot span); out-of-domain
+            points are then undefined behavior. Defaults to True.
 
     Returns:
         tuple[
@@ -597,8 +602,9 @@ def _tabulate_Bspline_basis_1D_impl(
               If `out_first_basis` was provided, returns the same array.
 
     Raises:
-        ValueError: If any evaluation points are outside the B-spline domain, or if `out_basis`
-            or `out_first_basis` is provided and has incorrect shape or dtype.
+        ValueError: If ``validate`` is True and any evaluation point is outside the
+            B-spline domain, or if `out_basis` or `out_first_basis` is provided and
+            has incorrect shape or dtype.
 
     Example:
         >>> bspline = BsplineSpace1D([0, 0, 0, 0.25, 0.7, 0.7, 1, 1, 1], 2)
@@ -612,7 +618,9 @@ def _tabulate_Bspline_basis_1D_impl(
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
 
-    if not np.all(_is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)):
+    if validate and not np.all(
+        _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)
+    ):
         raise ValueError(
             f"One or more values in pts are outside the knot vector domain {spline.domain}"
         )
@@ -656,12 +664,14 @@ def _tabulate_Bspline_basis_1D_impl(
     return out_basis, out_first_basis
 
 
-def _tabulate_Bspline_basis_deriv_1D_impl(
+def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
     spline: BsplineSpace1D,
     pts: npt.ArrayLike,
     n_deriv: int,
     out_deriv: npt.NDArray[np.float32 | np.float64] | None = None,
     out_first_basis: npt.NDArray[np.int_] | None = None,
+    *,
+    validate: bool = True,
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
     """Evaluate B-spline basis function derivatives at given points.
 
@@ -685,6 +695,10 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
         out_first_basis (npt.NDArray[np.int_] | None): Optional output array for first
             basis indices. If None, a new array is allocated. Must have shape ``pts_shape``
             and dtype ``np.int_`` if provided. Defaults to None.
+        validate (bool): If True (default), check that every point lies inside the
+            spline domain. Pass False only when the caller guarantees in-domain
+            points (e.g. points generated inside a knot span); out-of-domain
+            points are then undefined behavior. Defaults to True.
 
     Returns:
         tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Tuple of
@@ -693,8 +707,9 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
             function at each point.
 
     Raises:
-        ValueError: If ``n_deriv < 0``, any evaluation point is outside the domain, or
-            ``out_deriv`` / ``out_first_basis`` has incorrect shape or dtype.
+        ValueError: If ``n_deriv < 0``, if ``validate`` is True and any evaluation
+            point is outside the domain, or ``out_deriv`` / ``out_first_basis`` has
+            incorrect shape or dtype.
 
     Example:
         >>> bspline = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
@@ -708,7 +723,9 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
 
-    if not np.all(_is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)):
+    if validate and not np.all(
+        _is_in_domain_impl(spline.knots, spline.degree, pts, spline.tolerance)
+    ):
         raise ValueError(
             f"One or more values in pts are outside the knot vector domain {spline.domain}"
         )

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -29,6 +29,124 @@ from ._bspline_knots import (
 if TYPE_CHECKING:
     from ._bspline_space_1d import BsplineSpace1D
 
+_PARALLEL_MIN_NUM_PTS = 4096
+"""Minimum number of evaluation points for which the ``parallel=True`` kernels pay off.
+
+Below this threshold the fork/join overhead of a parallel Numba kernel launch
+(hundreds of microseconds) dwarfs the per-point work (tens of nanoseconds), so
+the Layer-2 tabulation helpers dispatch to the serial twin kernels instead.
+"""
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+)
+def _find_spans_and_first_basis(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    periodic: bool,
+    tol: float,
+    pts: npt.NDArray[np.float32 | np.float64],
+    out_first_basis: npt.NDArray[np.int_],
+) -> npt.NDArray[np.int_]:
+    """Compute clamped knot-span indices and fill the first-basis indices.
+
+    Shared preamble of the BasisFuncs / DerBasisFuncs kernels: locates each
+    point's knot span, clamps it to the last in-domain span, and derives the
+    index of the first nonzero basis function per point.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        periodic (bool): Whether the B-spline is periodic.
+        tol (float): Tolerance for numerical comparisons.
+        pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate at.
+        out_first_basis (npt.NDArray[np.int_]): Output array for first basis indices.
+            Must have shape (n_pts,) and dtype int.
+
+    Returns:
+        npt.NDArray[np.int_]: Clamped knot-span index per point, shape (n_pts,).
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
+
+    # Clamp knot span indices to the last in-domain span.  For non-open knot
+    # vectors the right domain endpoint knots[-degree-1] is not the last knot
+    # in the vector, so searchsorted can place a point in an out-of-domain
+    # span.  Clamping to knots.size - degree - 2 ensures the Cox-de Boor
+    # recurrence always uses an in-domain span.  For open knot vectors this
+    # subsumes the former ``knot_id == knots.size - 1`` special case.
+    max_knot_id = knots.size - degree - 2
+    knot_ids = np.minimum(knot_ids, max_knot_id)
+
+    # For non-periodic splines, clamp first_basis so the last (degree+1) basis
+    # functions are addressed by the final evaluation point.  For periodic
+    # splines, the unclamped index is needed: the evaluation loop wraps it via
+    # modulo to cycle through the periodic control points.
+    if periodic:
+        out_first_basis[:] = knot_ids - degree
+    else:
+        order = degree + 1
+        num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
+        out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
+
+    return knot_ids
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    inline="always",
+)
+def _basis_funcs_point(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    knot_id: int,
+    pt: np.float32 | np.float64,
+    N: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate the nonzero B-spline basis functions at one point (A2.2 body).
+
+    Inlined (``inline="always"``) into the batch kernels so the per-point
+    scratch allocations stay visible to Numba's parallel allocation hoisting.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        tol (float): Tolerance for numerical comparisons.
+        knot_id (int): Clamped knot-span index of ``pt``.
+        pt (np.float32 | np.float64): Evaluation point.
+        N (npt.NDArray[np.float32 | np.float64]): Output row of length ``degree + 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    order = degree + 1
+    dtype = knots.dtype
+    zero = dtype.type(0.0)
+    one = dtype.type(1.0)
+
+    left = np.zeros(order, dtype=dtype)
+    right = np.zeros(order, dtype=dtype)
+    N[0] = one
+
+    for j in range(1, order):
+        left[j] = pt - knots[knot_id + 1 - j]
+        right[j] = knots[knot_id + j] - pt
+        saved = zero
+
+        for r in range(j):
+            denom = right[r + 1] + left[j - r]  # always >= 0 (non-decreasing knots)
+            temp = zero if denom < tol else N[r] / denom
+            N[r] = saved + right[r + 1] * temp
+            saved = left[j - r] * temp
+
+        N[j] = saved
+
 
 @nb_jit(
     nopython=True,
@@ -48,7 +166,10 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
 
     This function implements Algorithm A2.2 from "The NURBS Book" by Piegl & Tiller.
     Results are written directly to the output arrays (C-style).  The outer loop
-    over evaluation points is parallelized via ``prange``.
+    over evaluation points is parallelized via ``prange``; for small batches
+    (fewer than `_PARALLEL_MIN_NUM_PTS` points) prefer the serial twin
+    :func:`_compute_basis_nurbs_book_serial_impl`, which avoids the parallel
+    launch overhead.
 
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
@@ -66,56 +187,153 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
         Inputs are assumed to be correct (no validation performed).
     """
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.2 (BasisFuncs)
-
-    order = degree + 1
     n_pts = pts.size
+    knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+
+    for pt_id in nb_prange(n_pts):
+        _basis_funcs_point(knots, degree, tol, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+)
+def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    periodic: bool,
+    tol: float,
+    pts: npt.NDArray[np.float32 | np.float64],
+    out_basis: npt.NDArray[np.float32 | np.float64],
+    out_first_basis: npt.NDArray[np.int_],
+) -> None:
+    """Evaluate B-spline basis functions using BasisFuncs (serial twin).
+
+    Identical to :func:`_compute_basis_nurbs_book_impl` but compiled without
+    ``parallel=True``: no fork/join overhead, which makes it the faster choice
+    for small point batches (FEM/IGA per-cell assembly).
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        periodic (bool): Whether the B-spline is periodic.
+        tol (float): Tolerance for numerical comparisons.
+        pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
+            functions at.
+        out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
+            Must have shape (n_pts, degree+1) and dtype matching the `knots` dtype.
+        out_first_basis (npt.NDArray[np.int_]): Output array for first basis indices.
+            Must have shape (n_pts,) and dtype int.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    n_pts = pts.size
+    knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+
+    for pt_id in range(n_pts):
+        _basis_funcs_point(knots, degree, tol, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    inline="always",
+)
+def _basis_derivs_point(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    tol: float,
+    n_deriv: int,
+    knot_id: int,
+    pt: np.float32 | np.float64,
+    out_pt: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate the nonzero B-spline basis derivatives at one point (A2.3 body).
+
+    Inlined (``inline="always"``) into the batch kernels so the per-point
+    scratch allocations stay visible to Numba's parallel allocation hoisting.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        tol (float): Tolerance for numerical comparisons.
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        knot_id (int): Clamped knot-span index of ``pt``.
+        pt (np.float32 | np.float64): Evaluation point.
+        out_pt (npt.NDArray[np.float32 | np.float64]): Output block of shape
+            ``(n_deriv + 1, degree + 1)``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    order = degree + 1
     dtype = knots.dtype
     zero = dtype.type(0.0)
     one = dtype.type(1.0)
 
-    knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
+    ndu = np.zeros((order, order), dtype=dtype)
+    left = np.zeros(order, dtype=dtype)
+    right = np.zeros(order, dtype=dtype)
+    a = np.zeros((2, n_deriv + 1), dtype=dtype)
 
-    # Clamp knot span indices to the last in-domain span.  For non-open knot
-    # vectors the right domain endpoint knots[-degree-1] is not the last knot
-    # in the vector, so searchsorted can place a point in an out-of-domain
-    # span.  Clamping to knots.size - degree - 2 ensures the Cox-de Boor
-    # recurrence always uses an in-domain span.  For open knot vectors this
-    # subsumes the former ``knot_id == knots.size - 1`` special case.
-    max_knot_id = knots.size - degree - 2
-    knot_ids = np.minimum(knot_ids, max_knot_id)
+    # --- Step 1: build ndu table (A2.2 extended to retain intermediate values) ---
+    ndu[0, 0] = one
+    for j in range(1, order):
+        left[j] = pt - knots[knot_id + 1 - j]
+        right[j] = knots[knot_id + j] - pt
+        saved = zero
+        for r in range(j):
+            ndu[j, r] = right[r + 1] + left[j - r]  # knot differences (lower triangle)
+            denom = ndu[j, r]
+            temp = zero if denom < tol else ndu[r, j - 1] / denom
+            ndu[r, j] = saved + right[r + 1] * temp  # basis values (upper triangle)
+            saved = left[j - r] * temp
+        ndu[j, j] = saved
 
-    # For non-periodic splines, clamp first_basis so the last (degree+1) basis
-    # functions are addressed by the final evaluation point.  For periodic
-    # splines, the unclamped index is needed: the evaluation loop wraps it via
-    # modulo to cycle through the periodic control points.
-    if periodic:
-        out_first_basis[:] = knot_ids - degree
-    else:
-        num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
-        out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
+    # Store 0th-order derivatives (basis values)
+    for j in range(order):
+        out_pt[0, j] = ndu[j, degree]
 
-    for pt_id in nb_prange(n_pts):
-        # Thread-local auxiliary arrays (allocated per iteration for safety).
-        left = np.zeros(order, dtype=dtype)
-        right = np.zeros(order, dtype=dtype)
+    # --- Step 2: compute kth derivatives via triangular recursion ---
+    for r in range(order):
+        s1 = 0
+        s2 = 1
+        a[0, 0] = one
 
-        knot_id = knot_ids[pt_id]
-        pt = pts[pt_id]
-        N = out_basis[pt_id, :]
-        N[0] = one
+        for k in range(1, n_deriv + 1):
+            d = zero
+            rk = r - k
+            pk = degree - k
 
-        for j in range(1, order):
-            left[j] = pt - knots[knot_id + 1 - j]
-            right[j] = knots[knot_id + j] - pt
-            saved = zero
+            if r >= k:
+                a[s2, 0] = a[s1, 0] / ndu[pk + 1, rk]
+                d = a[s2, 0] * ndu[rk, pk]
 
-            for r in range(j):
-                denom = right[r + 1] + left[j - r]  # always >= 0 (non-decreasing knots)
-                temp = zero if denom < tol else N[r] / denom
-                N[r] = saved + right[r + 1] * temp
-                saved = left[j - r] * temp
+            j1 = 1 if rk >= -1 else -rk
+            j2 = k - 1 if (r - 1) <= pk else degree - r
 
-            N[j] = saved
+            for j in range(j1, j2 + 1):
+                a[s2, j] = (a[s1, j] - a[s1, j - 1]) / ndu[pk + 1, rk + j]
+                d += a[s2, j] * ndu[rk + j, pk]
+
+            if r <= pk:
+                a[s2, k] = -a[s1, k - 1] / ndu[pk + 1, r]
+                d += a[s2, k] * ndu[r, pk]
+
+            out_pt[k, r] = d
+
+            # swap rows
+            j = s1
+            s1 = s2
+            s2 = j
+
+    # --- Step 3: apply degree factorial scaling factors ---
+    fac = degree
+    for k in range(1, n_deriv + 1):
+        for j in range(order):
+            out_pt[k, j] *= fac
+        fac *= degree - k
 
 
 @nb_jit(
@@ -123,7 +341,7 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     cache=True,
     parallel=True,
 )
-def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
+def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
     periodic: bool,
@@ -137,7 +355,10 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
 
     This function implements Algorithm A2.3 from "The NURBS Book" by Piegl & Tiller.
     Results are written directly to the output arrays (C-style).  The outer loop
-    over evaluation points is parallelized via ``prange``.
+    over evaluation points is parallelized via ``prange``; for small batches
+    (fewer than `_PARALLEL_MIN_NUM_PTS` points) prefer the serial twin
+    :func:`_compute_basis_deriv_nurbs_book_serial_impl`, which avoids the
+    parallel launch overhead.
 
     The 0th-order slice ``out_deriv[pt, 0, :]`` contains the plain basis values,
     identical to the output of ``_compute_basis_nurbs_book_impl``.  For
@@ -159,94 +380,57 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0912, PLR0913, PLR0915
         Inputs are assumed to be correct (no validation performed).
     """
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.3 (DerBasisFuncs)
-
-    order = degree + 1
     n_pts = pts.size
-    dtype = knots.dtype
-    zero = dtype.type(0.0)
-    one = dtype.type(1.0)
-
-    knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
-
-    # Clamp knot span indices to the last in-domain span (see comment in
-    # _compute_basis_nurbs_book_impl for rationale).
-    max_knot_id = knots.size - degree - 2
-    knot_ids = np.minimum(knot_ids, max_knot_id)
-
-    # See comment in _compute_basis_nurbs_book_impl for the periodic rationale.
-    if periodic:
-        out_first_basis[:] = knot_ids - degree
-    else:
-        num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
-        out_first_basis[:] = np.minimum(knot_ids - degree, num_basis - order)
+    knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
 
     for pt_id in nb_prange(n_pts):
-        # Thread-local auxiliary arrays (allocated per iteration for safety).
-        ndu = np.zeros((order, order), dtype=dtype)
-        left = np.zeros(order, dtype=dtype)
-        right = np.zeros(order, dtype=dtype)
-        a = np.zeros((2, n_deriv + 1), dtype=dtype)
+        _basis_derivs_point(
+            knots, degree, tol, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+        )
 
-        knot_id = knot_ids[pt_id]
-        pt = pts[pt_id]
 
-        # --- Step 1: build ndu table (A2.2 extended to retain intermediate values) ---
-        ndu[0, 0] = one
-        for j in range(1, order):
-            left[j] = pt - knots[knot_id + 1 - j]
-            right[j] = knots[knot_id + j] - pt
-            saved = zero
-            for r in range(j):
-                ndu[j, r] = right[r + 1] + left[j - r]  # knot differences (lower triangle)
-                denom = ndu[j, r]
-                temp = zero if denom < tol else ndu[r, j - 1] / denom
-                ndu[r, j] = saved + right[r + 1] * temp  # basis values (upper triangle)
-                saved = left[j - r] * temp
-            ndu[j, j] = saved
+@nb_jit(
+    nopython=True,
+    cache=True,
+)
+def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    periodic: bool,
+    tol: float,
+    n_deriv: int,
+    pts: npt.NDArray[np.float32 | np.float64],
+    out_deriv: npt.NDArray[np.float32 | np.float64],
+    out_first_basis: npt.NDArray[np.int_],
+) -> None:
+    """Evaluate B-spline basis function derivatives using DerBasisFuncs (serial twin).
 
-        # Store 0th-order derivatives (basis values)
-        for j in range(order):
-            out_deriv[pt_id, 0, j] = ndu[j, degree]
+    Identical to :func:`_compute_basis_deriv_nurbs_book_impl` but compiled
+    without ``parallel=True``: no fork/join overhead, which makes it the faster
+    choice for small point batches (FEM/IGA per-cell assembly).
 
-        # --- Step 2: compute kth derivatives via triangular recursion ---
-        for r in range(order):
-            s1 = 0
-            s2 = 1
-            a[0, 0] = one
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        degree (int): B-spline degree.
+        periodic (bool): Whether the B-spline is periodic.
+        tol (float): Tolerance for numerical comparisons.
+        n_deriv (int): Maximum derivative order to compute (>= 0).
+        pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
+        out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
+            Must have shape (n_pts, n_deriv+1, degree+1) and dtype matching ``knots``.
+        out_first_basis (npt.NDArray[np.int_]): Output array for first basis indices.
+            Must have shape (n_pts,) and dtype int.
 
-            for k in range(1, n_deriv + 1):
-                d = zero
-                rk = r - k
-                pk = degree - k
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    n_pts = pts.size
+    knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
 
-                if r >= k:
-                    a[s2, 0] = a[s1, 0] / ndu[pk + 1, rk]
-                    d = a[s2, 0] * ndu[rk, pk]
-
-                j1 = 1 if rk >= -1 else -rk
-                j2 = k - 1 if (r - 1) <= pk else degree - r
-
-                for j in range(j1, j2 + 1):
-                    a[s2, j] = (a[s1, j] - a[s1, j - 1]) / ndu[pk + 1, rk + j]
-                    d += a[s2, j] * ndu[rk + j, pk]
-
-                if r <= pk:
-                    a[s2, k] = -a[s1, k - 1] / ndu[pk + 1, r]
-                    d += a[s2, k] * ndu[r, pk]
-
-                out_deriv[pt_id, k, r] = d
-
-                # swap rows
-                j = s1
-                s1 = s2
-                s2 = j
-
-        # --- Step 3: apply degree factorial scaling factors ---
-        fac = degree
-        for k in range(1, n_deriv + 1):
-            for j in range(order):
-                out_deriv[pt_id, k, j] *= fac
-            fac *= degree - k
+    for pt_id in range(n_pts):
+        _basis_derivs_point(
+            knots, degree, tol, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+        )
 
 
 def _tabulate_Bspline_basis_Bernstein_like_1D(
@@ -438,7 +622,12 @@ def _tabulate_Bspline_basis_1D_impl(
             spline, pts, basis_normalized, first_indices_normalized
         )
     else:
-        _compute_basis_nurbs_book_impl(
+        kernel = (
+            _compute_basis_nurbs_book_impl
+            if num_pts >= _PARALLEL_MIN_NUM_PTS
+            else _compute_basis_nurbs_book_serial_impl
+        )
+        kernel(
             spline.knots,
             spline.degree,
             spline.periodic,
@@ -527,7 +716,12 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
             spline, pts, n_deriv, deriv_normalized, first_indices_normalized
         )
     else:
-        _compute_basis_deriv_nurbs_book_impl(
+        kernel = (
+            _compute_basis_deriv_nurbs_book_impl
+            if num_pts >= _PARALLEL_MIN_NUM_PTS
+            else _compute_basis_deriv_nurbs_book_serial_impl
+        )
+        kernel(
             spline.knots,
             spline.degree,
             spline.periodic,
@@ -556,15 +750,28 @@ def _warmup_numba_functions() -> None:
     basis_dummy = np.empty((n_pts_dummy, degree_dummy + 1), dtype=np.float64)
     first_basis_dummy = np.empty(n_pts_dummy, dtype=np.int_)
 
-    # Warmup BasisFuncs implementation with float64
+    # Warmup BasisFuncs implementation with float64 (parallel and serial twins)
     _compute_basis_nurbs_book_impl(
         knots_dummy, degree_dummy, False, tol_dummy, pts_dummy, basis_dummy, first_basis_dummy
     )
+    _compute_basis_nurbs_book_serial_impl(
+        knots_dummy, degree_dummy, False, tol_dummy, pts_dummy, basis_dummy, first_basis_dummy
+    )
 
-    # Warmup DerBasisFuncs implementation with float64
+    # Warmup DerBasisFuncs implementation with float64 (parallel and serial twins)
     n_deriv_dummy = 2
     deriv_dummy = np.empty((n_pts_dummy, n_deriv_dummy + 1, degree_dummy + 1), dtype=np.float64)
     _compute_basis_deriv_nurbs_book_impl(
+        knots_dummy,
+        degree_dummy,
+        False,
+        tol_dummy,
+        n_deriv_dummy,
+        pts_dummy,
+        deriv_dummy,
+        first_basis_dummy,
+    )
+    _compute_basis_deriv_nurbs_book_serial_impl(
         knots_dummy,
         degree_dummy,
         False,
@@ -588,7 +795,9 @@ def _warmup_numba_functions() -> None:
 
 __all__ = [
     "_compute_basis_deriv_nurbs_book_impl",
+    "_compute_basis_deriv_nurbs_book_serial_impl",
     "_compute_basis_nurbs_book_impl",
+    "_compute_basis_nurbs_book_serial_impl",
     "_tabulate_Bspline_basis_1D_impl",
     "_tabulate_Bspline_basis_Bernstein_like_1D",
     "_tabulate_Bspline_basis_Bernstein_like_deriv_1D",

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -6,7 +6,7 @@ using the BasisFuncs algorithm (Piegl & Tiller) and Bernstein-like evaluation.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -87,11 +87,13 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
     # recurrence always uses an in-domain span.  For open knot vectors this
     # subsumes the former ``knot_id == knots.size - 1`` special case.
     max_knot_id = knots.size - degree - 2
-    # Clamp both ends: upper bound prevents out-of-domain right-side points from
-    # landing in an invalid span; lower bound (`degree`) ensures knot_id + 1 - j >= 0
-    # for all j in range(1, degree+1), so _basis_funcs_point never wraps into
-    # negative knot indices for points left of the domain.
-    knot_ids = cast(npt.NDArray[np.int_], np.minimum(np.maximum(knot_ids, degree), max_knot_id))
+    # Clamp upper end (right-of-domain points → last valid span).
+    knot_ids = np.minimum(knot_ids, max_knot_id)
+    # Clamp lower end: ensures knot_id + 1 - j >= 0 for all j in range(1, degree+1),
+    # so _basis_funcs_point never wraps into negative knot indices for points left of
+    # the domain.  In-place boolean assignment avoids calling np.maximum (whose return
+    # type is Any on old py3.10 numpy stubs).
+    knot_ids[knot_ids < degree] = degree
 
     # For non-periodic splines, clamp first_basis so the last (degree+1) basis
     # functions are addressed by the final evaluation point.  For periodic

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -87,7 +87,11 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
     # recurrence always uses an in-domain span.  For open knot vectors this
     # subsumes the former ``knot_id == knots.size - 1`` special case.
     max_knot_id = knots.size - degree - 2
-    knot_ids = np.minimum(knot_ids, max_knot_id)
+    # Clamp both ends: upper bound prevents out-of-domain right-side points from
+    # landing in an invalid span; lower bound (`degree`) ensures knot_id + 1 - j >= 0
+    # for all j in range(1, degree+1), so _basis_funcs_point never wraps into
+    # negative knot indices for points left of the domain.
+    knot_ids = np.minimum(np.maximum(knot_ids, degree), max_knot_id)
 
     # For non-periodic splines, clamp first_basis so the last (degree+1) basis
     # functions are addressed by the final evaluation point.  For periodic
@@ -131,6 +135,7 @@ def _basis_funcs_point(  # noqa: PLR0913
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     order = degree + 1
     dtype = knots.dtype
@@ -234,6 +239,7 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
@@ -273,6 +279,7 @@ def _basis_derivs_point(  # noqa: PLR0913
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = degree + 1
     dtype = knots.dtype
@@ -433,6 +440,7 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -6,7 +6,7 @@ using the BasisFuncs algorithm (Piegl & Tiller) and Bernstein-like evaluation.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -91,7 +91,7 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
     # landing in an invalid span; lower bound (`degree`) ensures knot_id + 1 - j >= 0
     # for all j in range(1, degree+1), so _basis_funcs_point never wraps into
     # negative knot indices for points left of the domain.
-    knot_ids = np.minimum(np.maximum(knot_ids, degree), max_knot_id)
+    knot_ids = cast(npt.NDArray[np.int_], np.minimum(np.maximum(knot_ids, degree), max_knot_id))
 
     # For non-periodic splines, clamp first_basis so the last (degree+1) basis
     # functions are addressed by the final evaluation point.  For periodic

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -41,6 +41,7 @@ the Layer-2 tabulation helpers dispatch to the serial twin kernels instead.
 @nb_jit(
     nopython=True,
     cache=True,
+    parallel=False,
 )
 def _find_spans_and_first_basis(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
@@ -52,9 +53,18 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
 ) -> npt.NDArray[np.int_]:
     """Compute clamped knot-span indices and fill the first-basis indices.
 
-    Shared preamble of the BasisFuncs / DerBasisFuncs kernels: locates each
-    point's knot span, clamps it to the last in-domain span, and derives the
-    index of the first nonzero basis function per point.
+    Shared preamble of the BasisFuncs / DerBasisFuncs kernels.  Three steps:
+
+    1. Locate each point's raw knot span via binary search.
+    2. Clamp each span index to ``knots.size - degree - 2`` (the last in-domain
+       span).  Without clamping, a point at the right domain endpoint can be
+       placed in an out-of-domain span, causing Cox-de Boor to read knot values
+       beyond the last valid span.
+    3. Compute ``out_first_basis``: for non-periodic splines the index is
+       additionally clamped so the final evaluation point always addresses the
+       last ``degree + 1`` active basis functions; for periodic splines the raw
+       (unclamped) index is used so the evaluation loop can wrap it modulo the
+       number of control points.
 
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
@@ -70,6 +80,7 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
 
     Note:
         Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     knot_ids = _get_last_knot_smaller_equal_impl(knots, pts)
 
@@ -167,7 +178,7 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     This function implements Algorithm A2.2 from "The NURBS Book" by Piegl & Tiller.
     Results are written directly to the output arrays (C-style).  The outer loop
     over evaluation points is parallelized via ``prange``; for small batches
-    (fewer than `_PARALLEL_MIN_NUM_PTS` points) prefer the serial twin
+    (fewer than ``_PARALLEL_MIN_NUM_PTS`` points) prefer the serial twin
     :func:`_compute_basis_nurbs_book_serial_impl`, which avoids the parallel
     launch overhead.
 
@@ -329,6 +340,9 @@ def _basis_derivs_point(  # noqa: PLR0913
             s2 = j
 
     # --- Step 3: apply degree factorial scaling factors ---
+    # When k > degree, fac becomes 0 (degree - k ≤ 0), so rows beyond degree
+    # are zeroed out.  This is intentional: the k-th derivative of a degree-p
+    # polynomial is identically zero for k > p.
     fac = degree
     for k in range(1, n_deriv + 1):
         for j in range(order):
@@ -356,7 +370,7 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
     This function implements Algorithm A2.3 from "The NURBS Book" by Piegl & Tiller.
     Results are written directly to the output arrays (C-style).  The outer loop
     over evaluation points is parallelized via ``prange``; for small batches
-    (fewer than `_PARALLEL_MIN_NUM_PTS` points) prefer the serial twin
+    (fewer than ``_PARALLEL_MIN_NUM_PTS`` points) prefer the serial twin
     :func:`_compute_basis_deriv_nurbs_book_serial_impl`, which avoids the
     parallel launch overhead.
 
@@ -550,7 +564,9 @@ def _tabulate_Bspline_basis_1D_impl(
 
     This function automatically selects the most efficient evaluation method:
     - For Bézier-like knots: direct Bernstein evaluation
-    - For general knots: BasisFuncs (Piegl & Tiller A2.2)
+    - For general knots: BasisFuncs (Piegl & Tiller A2.2).  Batches smaller
+      than ``_PARALLEL_MIN_NUM_PTS`` use the serial (non-parallel) kernel to
+      avoid fork/join overhead; larger batches use the ``parallel=True`` kernel.
 
     In both cases it calls vectorized or numba implementations.
 
@@ -652,6 +668,8 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
     Implements Algorithm A2.3 (DerBasisFuncs) from Piegl & Tiller.  Uses a
     fast Bernstein path for Bézier-like knots (parallel kernel + chain-rule
     scaling) and falls back to the general DerBasisFuncs kernel otherwise.
+    For general knots, batches smaller than ``_PARALLEL_MIN_NUM_PTS`` use the
+    serial twin to avoid fork/join overhead.
     The 0th slice of the result is identical to the output of
     :func:`_tabulate_Bspline_basis_1D_impl`.  For ``n_deriv > degree`` all
     rows beyond ``degree`` are identically zero.
@@ -738,8 +756,9 @@ def _tabulate_Bspline_basis_deriv_1D_impl(
 def _warmup_numba_functions() -> None:
     """Precompile numba functions with float64 signatures for faster first call.
 
-    This function triggers compilation of the numba-decorated functions
-    with float64 arrays, ensuring they are cached and ready for use.
+    Triggers compilation of the parallel and serial twin kernels (BasisFuncs,
+    DerBasisFuncs) and the Bernstein derivative core with float64 arrays,
+    ensuring they are cached and ready for use.
     """
     # Small dummy arrays for warmup
     knots_dummy = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -89,9 +89,7 @@ def _local_weight_row(
         ValueError: If the local collocation matrix is singular or nearly singular
             (non-finite inverse), which indicates degenerate knot intervals.
     """
-    # Points are generated inside a single knot interval by the caller; skip
-    # the domain check.
-    basis, first_basis = space1d.tabulate_basis(points, validate=False)
+    basis, first_basis = space1d.tabulate_basis(points)
     block = np.asarray(basis, dtype=np.float64)
     try:
         inv = np.asarray(np.linalg.inv(block), dtype=np.float64)

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -89,7 +89,9 @@ def _local_weight_row(
         ValueError: If the local collocation matrix is singular or nearly singular
             (non-finite inverse), which indicates degenerate knot intervals.
     """
-    basis, first_basis = space1d.tabulate_basis(points)
+    # Points are generated inside a single knot interval by the caller; skip
+    # the domain check.
+    basis, first_basis = space1d.tabulate_basis(points, validate=False)
     block = np.asarray(basis, dtype=np.float64)
     try:
         inv = np.asarray(np.linalg.inv(block), dtype=np.float64)

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -473,6 +473,8 @@ class BsplineSpace1D:
         pts: npt.ArrayLike,
         out_basis: npt.NDArray[np.float32 | np.float64] | None = None,
         out_first_basis: npt.NDArray[np.int_] | None = None,
+        *,
+        validate: bool = True,
     ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
         """Evaluate the B-spline basis functions at the given points.
 
@@ -486,6 +488,10 @@ class BsplineSpace1D:
                 first basis indices will be stored. If None, a new array is allocated. Must have
                 the correct shape and dtype numpy.intp if provided. This follows NumPy's style for
                 output arrays. Defaults to None.
+            validate (bool): If True (default), check that every point lies inside
+                the spline domain. Pass False only when the caller guarantees
+                in-domain points; out-of-domain points are then undefined behavior.
+                Defaults to True.
 
         Returns:
             tuple[
@@ -502,8 +508,9 @@ class BsplineSpace1D:
                   of evaluation points. If `out_first_basis` was provided, returns the same array.
 
         Raises:
-            ValueError: If any evaluation points are outside the B-spline domain, or if `out_basis`
-                or `out_first_basis` is provided and has incorrect shape or dtype.
+            ValueError: If ``validate`` is True and any evaluation point is outside the
+                B-spline domain, or if `out_basis` or `out_first_basis` is provided and
+                has incorrect shape or dtype.
 
         Example:
             >>> bspline = BsplineSpace1D([0, 0, 0, 0.25, 0.7, 0.7, 1, 1, 1], 2)
@@ -515,7 +522,7 @@ class BsplineSpace1D:
              array([0, 1, 3, 3]))
         """
         return _tabulate_Bspline_basis_1D_impl(
-            self, pts, out_basis=out_basis, out_first_basis=out_first_basis
+            self, pts, out_basis=out_basis, out_first_basis=out_first_basis, validate=validate
         )
 
     def tabulate_basis_derivatives(
@@ -524,6 +531,8 @@ class BsplineSpace1D:
         n_deriv: int,
         out_deriv: npt.NDArray[np.float32 | np.float64] | None = None,
         out_first_basis: npt.NDArray[np.int_] | None = None,
+        *,
+        validate: bool = True,
     ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
         """Evaluate B-spline basis function derivatives at the given points.
 
@@ -543,6 +552,10 @@ class BsplineSpace1D:
                 for first basis indices. If None, a new array is allocated. Must have
                 shape ``pts_shape`` and dtype ``numpy.intp`` if provided.
                 Defaults to None.
+            validate (bool): If True (default), check that every point lies inside
+                the spline domain. Pass False only when the caller guarantees
+                in-domain points; out-of-domain points are then undefined behavior.
+                Defaults to True.
 
         Returns:
             tuple[
@@ -556,9 +569,9 @@ class BsplineSpace1D:
                   global index of the first nonzero basis function for each point.
 
         Raises:
-            ValueError: If ``n_deriv < 0``, any evaluation point is outside the
-                domain, or ``out_deriv`` / ``out_first_basis`` has incorrect shape
-                or dtype.
+            ValueError: If ``n_deriv < 0``, if ``validate`` is True and any evaluation
+                point is outside the domain, or ``out_deriv`` / ``out_first_basis``
+                has incorrect shape or dtype.
 
         Example:
             >>> bspline = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
@@ -569,7 +582,12 @@ class BsplineSpace1D:
             array([-1.,  0.,  1.])
         """
         return _tabulate_Bspline_basis_deriv_1D_impl(
-            self, pts, n_deriv, out_deriv=out_deriv, out_first_basis=out_first_basis
+            self,
+            pts,
+            n_deriv,
+            out_deriv=out_deriv,
+            out_first_basis=out_first_basis,
+            validate=validate,
         )
 
     def tabulate_Bezier_extraction_operators(

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -339,6 +339,48 @@ class BsplineSpace1D:
         i0, i1 = self._get_domain_indices()
         return (self._knots[i0], self._knots[i1])
 
+    @functools.cached_property
+    def _left_end_open(self) -> bool:
+        """Whether the left end is open (cached; knots are immutable).
+
+        Returns:
+            bool: True if the first ``degree + 1`` knots are equal.
+        """
+        if self.periodic:
+            return False
+
+        # Check if the first degree+1 knots are equal
+        # (we know that they are non-decreasing).
+        return bool(np.isclose(self._knots[0], self._knots[self._degree], atol=self._tol))
+
+    @functools.cached_property
+    def _right_end_open(self) -> bool:
+        """Whether the right end is open (cached; knots are immutable).
+
+        Returns:
+            bool: True if the last ``degree + 1`` knots are equal.
+        """
+        if self.periodic:
+            return False
+
+        # Check if the last degree+1 knots are equal
+        # (we know that they are non-decreasing).
+        return bool(np.isclose(self._knots[-self._degree - 1], self._knots[-1], atol=self._tol))
+
+    @functools.cached_property
+    def _bezier_like_knots(self) -> bool:
+        """Whether the knots are a Bézier-like configuration (cached; knots are immutable).
+
+        Returns:
+            bool: True if knots have open ends and only one non-zero span.
+        """
+        return (
+            (not self._periodic)
+            and self._left_end_open
+            and self._right_end_open
+            and self.num_basis == (self._degree + 1)
+        )
+
     def has_left_end_open(self) -> bool:
         """Check if the left end of the B-spline is open.
 
@@ -347,12 +389,7 @@ class BsplineSpace1D:
         Returns:
             bool: True if the left end is open, False otherwise.
         """
-        if self.periodic:
-            return False
-
-        # Check if the first degree+1 knots are equal
-        # (we know that they are non-decreasing).
-        return bool(np.isclose(self._knots[0], self._knots[self._degree], atol=self._tol))
+        return self._left_end_open
 
     def has_right_end_open(self) -> bool:
         """Check if the right end of the B-spline is open.
@@ -362,12 +399,7 @@ class BsplineSpace1D:
         Returns:
             bool: True if the right end is open, False otherwise.
         """
-        if self.periodic:
-            return False
-
-        # Check if the last degree+1 knots are equal
-        # (we know that they are non-decreasing).
-        return bool(np.isclose(self._knots[-self._degree - 1], self._knots[-1], atol=self._tol))
+        return self._right_end_open
 
     def has_open_knots(self) -> bool:
         """Check if the B-spline has open ends.
@@ -375,7 +407,7 @@ class BsplineSpace1D:
         Returns:
             bool: True if both ends are open, False otherwise.
         """
-        return self.has_left_end_open() and self.has_right_end_open()
+        return self._left_end_open and self._right_end_open
 
     def has_Bezier_like_knots(self) -> bool:
         """Check if the knot vector represents a Bézier-like configuration.
@@ -390,9 +422,7 @@ class BsplineSpace1D:
             >>> bspline.has_Bezier_like_knots()
             True
         """
-        return (
-            (not self._periodic) and self.has_open_knots() and self.num_basis == (self._degree + 1)
-        )
+        return self._bezier_like_knots
 
     def get_cardinal_intervals(
         self, out: npt.NDArray[np.bool_] | None = None

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -344,7 +344,8 @@ class BsplineSpace1D:
         """Whether the left end is open (cached; knots are immutable).
 
         Returns:
-            bool: True if the first ``degree + 1`` knots are equal.
+            bool: True if the first ``degree + 1`` knots are equal; always
+            False for periodic splines regardless of knot values.
         """
         if self.periodic:
             return False
@@ -358,7 +359,8 @@ class BsplineSpace1D:
         """Whether the right end is open (cached; knots are immutable).
 
         Returns:
-            bool: True if the last ``degree + 1`` knots are equal.
+            bool: True if the last ``degree + 1`` knots are equal; always
+            False for periodic splines regardless of knot values.
         """
         if self.periodic:
             return False
@@ -372,7 +374,8 @@ class BsplineSpace1D:
         """Whether the knots are a Bézier-like configuration (cached; knots are immutable).
 
         Returns:
-            bool: True if knots have open ends and only one non-zero span.
+            bool: True iff the spline is non-periodic, open on both ends, and
+            ``num_basis == degree + 1`` (i.e., exactly one non-zero span).
         """
         return (
             (not self._periodic)

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -937,8 +937,11 @@ class THBSplineSpace:
         if cached is None:
             sp1d = self._level_spaces[level].spaces[k]
             pts_k = np.ascontiguousarray(flat_pts[:, k])
-            # Points were already validated against the cell bounds (a subset of
-            # the level-space domain) in _tabulate_orders; skip the domain check.
+            # Safety: _tabulate_orders validated flat_pts against cell_lo/hi (one
+            # check per dimension via broadcasting) before calling here.  Cell bounds
+            # are a strict subset of each level-space's parametric domain, so pts_k
+            # is guaranteed in-domain.  Do NOT use validate=False from any other
+            # call site without re-verifying this invariant.
             if order == 0:
                 values, first_basis = sp1d.tabulate_basis(pts_k, validate=False)
                 deriv = np.asarray(values, dtype=np.float64)

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -937,11 +937,15 @@ class THBSplineSpace:
         if cached is None:
             sp1d = self._level_spaces[level].spaces[k]
             pts_k = np.ascontiguousarray(flat_pts[:, k])
+            # Points were already validated against the cell bounds (a subset of
+            # the level-space domain) in _tabulate_orders; skip the domain check.
             if order == 0:
-                values, first_basis = sp1d.tabulate_basis(pts_k)
+                values, first_basis = sp1d.tabulate_basis(pts_k, validate=False)
                 deriv = np.asarray(values, dtype=np.float64)
             else:
-                all_deriv, first_basis = sp1d.tabulate_basis_derivatives(pts_k, order)
+                all_deriv, first_basis = sp1d.tabulate_basis_derivatives(
+                    pts_k, order, validate=False
+                )
                 deriv = np.asarray(all_deriv, dtype=np.float64)[:, order, :]
             cached = _BasisEval1D(deriv, np.asarray(first_basis, dtype=np.int64))
             eval_cache[key] = cached

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2158,6 +2158,27 @@ class TestSerialParallelKernelTwins:
         np.testing.assert_array_equal(basis_ser, basis_par)
         np.testing.assert_array_equal(first_ser, first_par)
 
+    def test_float32_deriv_supported(self) -> None:
+        """Serial derivative twin compiles and agrees for float32 inputs."""
+        knots = np.array([0, 0, 0, 0.25, 0.5, 0.75, 1, 1, 1], dtype=np.float32)
+        sp = BsplineSpace1D(knots, 2)
+        pts = np.array([0.1, 0.4, 0.9], dtype=np.float32)
+        n_deriv = 2
+        order = sp.degree + 1
+
+        der_par = np.empty((3, n_deriv + 1, order), dtype=np.float32)
+        first_par = np.empty(3, dtype=np.int_)
+        _compute_basis_deriv_nurbs_book_impl(
+            sp.knots, sp.degree, sp.periodic, sp.tolerance, n_deriv, pts, der_par, first_par
+        )
+        der_ser = np.empty((3, n_deriv + 1, order), dtype=np.float32)
+        first_ser = np.empty(3, dtype=np.int_)
+        _compute_basis_deriv_nurbs_book_serial_impl(
+            sp.knots, sp.degree, sp.periodic, sp.tolerance, n_deriv, pts, der_ser, first_ser
+        )
+        np.testing.assert_array_equal(der_ser, der_par)
+        np.testing.assert_array_equal(first_ser, first_par)
+
     def test_layer2_dispatch_consistent_across_threshold(self) -> None:
         """Layer-2 tabulation gives identical results below and above the threshold."""
         knots = create_uniform_open_knots(num_intervals=16, degree=3)
@@ -2171,10 +2192,43 @@ class TestSerialParallelKernelTwins:
         np.testing.assert_array_equal(basis_small, basis_big[:8])
         np.testing.assert_array_equal(first_small, first_big[:8])
 
+        # n_deriv=2: standard case
         der_big, dfirst_big = _tabulate_Bspline_basis_deriv_1D_impl(sp, big, 2)
         der_small, dfirst_small = _tabulate_Bspline_basis_deriv_1D_impl(sp, small, 2)
         np.testing.assert_array_equal(der_small, der_big[:8])
         np.testing.assert_array_equal(dfirst_small, dfirst_big[:8])
+
+        # n_deriv=0: degenerate path — only 0th-order row is filled
+        der_big0, _ = _tabulate_Bspline_basis_deriv_1D_impl(sp, big, 0)
+        der_small0, _ = _tabulate_Bspline_basis_deriv_1D_impl(sp, small, 0)
+        np.testing.assert_array_equal(der_small0, der_big0[:8])
+
+    @pytest.mark.parametrize(
+        "num_pts", [_PARALLEL_MIN_NUM_PTS - 1, _PARALLEL_MIN_NUM_PTS, _PARALLEL_MIN_NUM_PTS + 1]
+    )
+    def test_layer2_dispatch_boundary(self, num_pts: int) -> None:
+        """Basis values are correct at, one below, and one above the dispatch threshold."""
+        knots = create_uniform_open_knots(num_intervals=16, degree=3)
+        sp = BsplineSpace1D(knots, 3)
+        rng = np.random.default_rng(42)
+        pts = rng.random(num_pts)
+        basis, _ = _tabulate_Bspline_basis_1D_impl(sp, pts)
+        np.testing.assert_allclose(basis.sum(axis=-1), np.ones(num_pts), atol=1e-13)
+
+    def test_layer2_dispatch_periodic_small_batch(self) -> None:
+        """Serial path is used for periodic spaces below the threshold."""
+        periodic_knots = create_uniform_periodic_knots(num_intervals=8, degree=3)
+        sp = BsplineSpace1D(periodic_knots, 3, periodic=True)
+        rng = np.random.default_rng(99)
+        lo, hi = float(sp.domain[0]), float(sp.domain[1])
+        pts_small = lo + (hi - lo) * rng.random(8)
+        pts_big = lo + (hi - lo) * rng.random(_PARALLEL_MIN_NUM_PTS + 64)
+
+        basis_small, _ = _tabulate_Bspline_basis_1D_impl(sp, pts_small)
+        np.testing.assert_allclose(basis_small.sum(axis=-1), np.ones(8), atol=1e-13)
+
+        basis_big, _ = _tabulate_Bspline_basis_1D_impl(sp, pts_big)
+        np.testing.assert_allclose(basis_big.sum(axis=-1), np.ones(len(pts_big)), atol=1e-13)
 
 
 class TestKnotPredicateCaching:
@@ -2204,4 +2258,12 @@ class TestKnotPredicateCaching:
         assert not sp.has_left_end_open()
         assert not sp.has_right_end_open()
         assert not sp.has_open_knots()
+        assert not sp.has_Bezier_like_knots()
+
+    def test_open_non_bezier_not_bezier_like(self) -> None:
+        """Open knots with multiple spans must not report Bézier-like."""
+        knots = create_uniform_open_knots(num_intervals=3, degree=2)
+        sp = BsplineSpace1D(knots, 2)
+        assert sp.has_open_knots()
+        assert sp.num_basis > sp.degree + 1
         assert not sp.has_Bezier_like_knots()

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -12,6 +12,13 @@ from pantr.basis import (
     tabulate_cardinal_bspline_1d,
     tabulate_lagrange_1d,
 )
+from pantr.basis._basis_core import (
+    _PARALLEL_MIN_NUM_PTS,
+    _tabulate_Bernstein_basis_1D_core,
+    _tabulate_Bernstein_basis_1D_serial_core,
+    _tabulate_Bernstein_basis_deriv_1D_core,
+    _tabulate_Bernstein_basis_deriv_1D_serial_core,
+)
 from pantr.bspline import (
     BsplineSpace1D,
     create_cardinal_knots,
@@ -19,7 +26,6 @@ from pantr.bspline import (
     create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_basis_core import (
-    _PARALLEL_MIN_NUM_PTS,
     _compute_basis_deriv_nurbs_book_impl,
     _compute_basis_deriv_nurbs_book_serial_impl,
     _compute_basis_nurbs_book_impl,
@@ -2267,3 +2273,84 @@ class TestKnotPredicateCaching:
         assert sp.has_open_knots()
         assert sp.num_basis > sp.degree + 1
         assert not sp.has_Bezier_like_knots()
+
+
+class TestBernsteinSerialParallelTwins:
+    """Bernstein serial twin cores must match the parallel cores exactly."""
+
+    @pytest.mark.parametrize("num_pts", [1, 3, 100, 5000])
+    @pytest.mark.parametrize("degree", [0, 1, 2, 4])
+    def test_values_match(self, num_pts: int, degree: int) -> None:
+        """Serial and parallel Bernstein value cores agree bitwise (incl. t=1)."""
+        rng = np.random.default_rng(19)
+        t = rng.random(num_pts)
+        t[0] = 1.0  # exercise the t == 1 special case
+
+        out_par = np.empty((num_pts, degree + 1), dtype=np.float64)
+        _tabulate_Bernstein_basis_1D_core(np.int32(degree), t, out_par)
+        out_ser = np.empty((num_pts, degree + 1), dtype=np.float64)
+        _tabulate_Bernstein_basis_1D_serial_core(np.int32(degree), t, out_ser)
+        np.testing.assert_array_equal(out_ser, out_par)
+
+    @pytest.mark.parametrize("num_pts", [1, 3, 100, 5000])
+    @pytest.mark.parametrize("degree", [0, 2, 3])
+    def test_derivs_match(self, num_pts: int, degree: int) -> None:
+        """Serial and parallel Bernstein derivative cores agree bitwise."""
+        rng = np.random.default_rng(23)
+        t = rng.random(num_pts)
+        t[-1] = 1.0
+        n_deriv = degree + 1
+
+        out_par = np.empty((num_pts, n_deriv + 1, degree + 1), dtype=np.float64)
+        _tabulate_Bernstein_basis_deriv_1D_core(np.int32(degree), t, n_deriv, out_par)
+        out_ser = np.empty((num_pts, n_deriv + 1, degree + 1), dtype=np.float64)
+        _tabulate_Bernstein_basis_deriv_1D_serial_core(np.int32(degree), t, n_deriv, out_ser)
+        np.testing.assert_array_equal(out_ser, out_par)
+
+    def test_bezier_like_layer2_dispatch_consistent(self) -> None:
+        """Layer-2 results on a Bézier-like space agree below and above the threshold."""
+        sp = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2)
+        rng = np.random.default_rng(29)
+        big = rng.random(_PARALLEL_MIN_NUM_PTS + 64)
+
+        basis_big, first_big = _tabulate_Bspline_basis_1D_impl(sp, big)
+        basis_small, first_small = _tabulate_Bspline_basis_1D_impl(sp, big[:8])
+        np.testing.assert_array_equal(basis_small, basis_big[:8])
+        np.testing.assert_array_equal(first_small, first_big[:8])
+
+        der_big, dfirst_big = _tabulate_Bspline_basis_deriv_1D_impl(sp, big, 2)
+        der_small, dfirst_small = _tabulate_Bspline_basis_deriv_1D_impl(sp, big[:8], 2)
+        np.testing.assert_array_equal(der_small, der_big[:8])
+        np.testing.assert_array_equal(dfirst_small, dfirst_big[:8])
+
+
+class TestTabulateValidateFlag:
+    """The validate flag skips only the domain check, never changes results."""
+
+    @staticmethod
+    def _space() -> BsplineSpace1D:
+        knots = create_uniform_open_knots(num_intervals=8, degree=3)
+        return BsplineSpace1D(knots, 3)
+
+    def test_values_identical_for_in_domain_points(self) -> None:
+        """validate=False returns bitwise-identical results for in-domain points."""
+        sp = self._space()
+        pts = np.random.default_rng(31).random(50)
+
+        b_val, f_val = sp.tabulate_basis(pts)
+        b_no, f_no = sp.tabulate_basis(pts, validate=False)
+        np.testing.assert_array_equal(b_no, b_val)
+        np.testing.assert_array_equal(f_no, f_val)
+
+        d_val, df_val = sp.tabulate_basis_derivatives(pts, 2)
+        d_no, df_no = sp.tabulate_basis_derivatives(pts, 2, validate=False)
+        np.testing.assert_array_equal(d_no, d_val)
+        np.testing.assert_array_equal(df_no, df_val)
+
+    def test_validate_true_still_raises_out_of_domain(self) -> None:
+        """The default validate=True keeps rejecting out-of-domain points."""
+        sp = self._space()
+        with pytest.raises(ValueError, match="outside"):
+            sp.tabulate_basis(np.array([-0.5]))
+        with pytest.raises(ValueError, match="outside"):
+            sp.tabulate_basis_derivatives(np.array([1.5]), 1)

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2354,3 +2354,21 @@ class TestTabulateValidateFlag:
             sp.tabulate_basis(np.array([-0.5]))
         with pytest.raises(ValueError, match="outside"):
             sp.tabulate_basis_derivatives(np.array([1.5]), 1)
+
+    def test_validate_false_does_not_raise_out_of_domain_derivatives(self) -> None:
+        """validate=False bypasses the domain check in tabulate_basis_derivatives."""
+        sp = self._space()
+        # Should not raise even though -0.5 is outside [0, 1].
+        sp.tabulate_basis_derivatives(np.array([-0.5]), 1, validate=False)
+
+    def test_validate_false_bezier_like_space(self) -> None:
+        """validate=False works on a Bézier-like (Bernstein fast-path) space."""
+        sp = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2)
+        rng = np.random.default_rng(41)
+        pts = rng.random(10)
+        b_val, f_val = sp.tabulate_basis(pts)
+        b_no, f_no = sp.tabulate_basis(pts, validate=False)
+        np.testing.assert_array_equal(b_no, b_val)
+        np.testing.assert_array_equal(f_no, f_val)
+        # validate=False should not raise for in-domain points on a Bézier-like space.
+        sp.tabulate_basis_derivatives(pts, 2, validate=False)

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -19,8 +19,14 @@ from pantr.bspline import (
     create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_basis_core import (
+    _PARALLEL_MIN_NUM_PTS,
+    _compute_basis_deriv_nurbs_book_impl,
+    _compute_basis_deriv_nurbs_book_serial_impl,
     _compute_basis_nurbs_book_impl,
+    _compute_basis_nurbs_book_serial_impl,
+    _tabulate_Bspline_basis_1D_impl,
     _tabulate_Bspline_basis_Bernstein_like_1D,
+    _tabulate_Bspline_basis_deriv_1D_impl,
 )
 from pantr.bspline._bspline_extraction import (
     _tabulate_Bspline_Bezier_1D_extraction_impl,
@@ -2066,3 +2072,136 @@ class TestBsplineSpace1DRestrict:
             space.restrict(-1, 2)  # lo < 0
         with pytest.raises(ValueError, match="interval"):
             space.restrict(0, 5)  # hi > num_intervals
+
+
+class TestSerialParallelKernelTwins:
+    """Serial twin kernels must match the parallel kernels exactly."""
+
+    @staticmethod
+    def _spaces() -> list[BsplineSpace1D]:
+        """Build a mix of open non-uniform and periodic spaces of varied degree."""
+        rng = np.random.default_rng(7)
+        spaces = []
+        for degree in (1, 2, 3, 4):
+            interior = np.sort(rng.random(6))
+            knots = np.concatenate([np.zeros(degree + 1), interior, np.ones(degree + 1)])
+            spaces.append(BsplineSpace1D(knots, degree))
+        periodic_knots = create_uniform_periodic_knots(num_intervals=6, degree=2)
+        spaces.append(BsplineSpace1D(periodic_knots, 2, periodic=True))
+        return spaces
+
+    @pytest.mark.parametrize("num_pts", [1, 3, 100, 5000])
+    def test_basis_values_match(self, num_pts: int) -> None:
+        """Serial and parallel BasisFuncs kernels agree bitwise on all paths."""
+        rng = np.random.default_rng(11)
+        for sp in self._spaces():
+            lo, hi = (float(sp.domain[0]), float(sp.domain[1]))
+            pts = lo + (hi - lo) * rng.random(num_pts)
+            order = sp.degree + 1
+
+            basis_par = np.empty((num_pts, order), dtype=np.float64)
+            first_par = np.empty(num_pts, dtype=np.int_)
+            _compute_basis_nurbs_book_impl(
+                sp.knots, sp.degree, sp.periodic, sp.tolerance, pts, basis_par, first_par
+            )
+
+            basis_ser = np.empty((num_pts, order), dtype=np.float64)
+            first_ser = np.empty(num_pts, dtype=np.int_)
+            _compute_basis_nurbs_book_serial_impl(
+                sp.knots, sp.degree, sp.periodic, sp.tolerance, pts, basis_ser, first_ser
+            )
+
+            np.testing.assert_array_equal(basis_ser, basis_par)
+            np.testing.assert_array_equal(first_ser, first_par)
+
+    @pytest.mark.parametrize("num_pts", [1, 3, 100, 5000])
+    def test_basis_derivs_match(self, num_pts: int) -> None:
+        """Serial and parallel DerBasisFuncs kernels agree bitwise on all paths."""
+        rng = np.random.default_rng(13)
+        for sp in self._spaces():
+            lo, hi = (float(sp.domain[0]), float(sp.domain[1]))
+            pts = lo + (hi - lo) * rng.random(num_pts)
+            order = sp.degree + 1
+            n_deriv = sp.degree + 1  # include the identically-zero row
+
+            der_par = np.empty((num_pts, n_deriv + 1, order), dtype=np.float64)
+            first_par = np.empty(num_pts, dtype=np.int_)
+            _compute_basis_deriv_nurbs_book_impl(
+                sp.knots, sp.degree, sp.periodic, sp.tolerance, n_deriv, pts, der_par, first_par
+            )
+
+            der_ser = np.empty((num_pts, n_deriv + 1, order), dtype=np.float64)
+            first_ser = np.empty(num_pts, dtype=np.int_)
+            _compute_basis_deriv_nurbs_book_serial_impl(
+                sp.knots, sp.degree, sp.periodic, sp.tolerance, n_deriv, pts, der_ser, first_ser
+            )
+
+            np.testing.assert_array_equal(der_ser, der_par)
+            np.testing.assert_array_equal(first_ser, first_par)
+
+    def test_float32_supported(self) -> None:
+        """Serial twins compile and agree for float32 inputs."""
+        knots = np.array([0, 0, 0, 0.25, 0.5, 0.75, 1, 1, 1], dtype=np.float32)
+        sp = BsplineSpace1D(knots, 2)
+        pts = np.array([0.1, 0.4, 0.9], dtype=np.float32)
+
+        basis_par = np.empty((3, 3), dtype=np.float32)
+        first_par = np.empty(3, dtype=np.int_)
+        _compute_basis_nurbs_book_impl(
+            sp.knots, sp.degree, sp.periodic, sp.tolerance, pts, basis_par, first_par
+        )
+        basis_ser = np.empty((3, 3), dtype=np.float32)
+        first_ser = np.empty(3, dtype=np.int_)
+        _compute_basis_nurbs_book_serial_impl(
+            sp.knots, sp.degree, sp.periodic, sp.tolerance, pts, basis_ser, first_ser
+        )
+        np.testing.assert_array_equal(basis_ser, basis_par)
+        np.testing.assert_array_equal(first_ser, first_par)
+
+    def test_layer2_dispatch_consistent_across_threshold(self) -> None:
+        """Layer-2 tabulation gives identical results below and above the threshold."""
+        knots = create_uniform_open_knots(num_intervals=16, degree=3)
+        sp = BsplineSpace1D(knots, 3)
+        rng = np.random.default_rng(17)
+        big = rng.random(_PARALLEL_MIN_NUM_PTS + 64)
+
+        basis_big, first_big = _tabulate_Bspline_basis_1D_impl(sp, big)
+        small = big[:8]
+        basis_small, first_small = _tabulate_Bspline_basis_1D_impl(sp, small)
+        np.testing.assert_array_equal(basis_small, basis_big[:8])
+        np.testing.assert_array_equal(first_small, first_big[:8])
+
+        der_big, dfirst_big = _tabulate_Bspline_basis_deriv_1D_impl(sp, big, 2)
+        der_small, dfirst_small = _tabulate_Bspline_basis_deriv_1D_impl(sp, small, 2)
+        np.testing.assert_array_equal(der_small, der_big[:8])
+        np.testing.assert_array_equal(dfirst_small, dfirst_big[:8])
+
+
+class TestKnotPredicateCaching:
+    """Knot-structure predicates are cached and stable on immutable knots."""
+
+    def test_predicates_stable_and_consistent(self) -> None:
+        """Repeated predicate calls return the same values as a fresh instance."""
+        knots = create_uniform_open_knots(num_intervals=4, degree=2)
+        sp = BsplineSpace1D(knots, 2)
+        fresh = BsplineSpace1D(knots.copy(), 2)
+        for _ in range(3):
+            assert sp.has_left_end_open() == fresh.has_left_end_open() is True
+            assert sp.has_right_end_open() == fresh.has_right_end_open() is True
+            assert sp.has_open_knots() == fresh.has_open_knots() is True
+            assert sp.has_Bezier_like_knots() == fresh.has_Bezier_like_knots() is False
+
+    def test_bezier_like_space(self) -> None:
+        """Single-span open space reports Bézier-like on every call."""
+        sp = BsplineSpace1D(np.array([1.0, 1.0, 1.0, 3.0, 3.0, 3.0]), 2)
+        assert sp.has_Bezier_like_knots()
+        assert sp.has_Bezier_like_knots()  # cached second call
+
+    def test_periodic_space_predicates(self) -> None:
+        """Periodic spaces report closed ends and non-Bézier-like knots."""
+        knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+        sp = BsplineSpace1D(knots, 2, periodic=True)
+        assert not sp.has_left_end_open()
+        assert not sp.has_right_end_open()
+        assert not sp.has_open_knots()
+        assert not sp.has_Bezier_like_knots()


### PR DESCRIPTION
## Summary

PR 1 of #197: cheap small-input path for 1D B-spline basis tabulation. Covers the full PR-1 scope from the issue: serial twin kernels + threshold dispatch, cached knot predicates, and the internal `validate=False` path.

- Factor the per-point BasisFuncs / DerBasisFuncs bodies (Piegl & Tiller A2.2 / A2.3) into `inline="always"` helpers shared by the batch kernels; same treatment for the Bernstein value/derivative cores in `basis/_basis_core.py`.
- Add serial twin kernels (`_compute_basis_nurbs_book_serial_impl`, `_compute_basis_deriv_nurbs_book_serial_impl`, `_tabulate_Bernstein_basis_1D_serial_core`, `_tabulate_Bernstein_basis_deriv_1D_serial_core`); Layer 2 dispatches on a shared `_PARALLEL_MIN_NUM_PTS = 4096` threshold (measured crossover ~2k points). The `parallel=True` kernels pay ~320 us of fork/join per launch, which dwarfs the per-point work (~70 ns) for the few-point batches of per-cell assembly. Both knot paths (general and Bezier-like) are covered.
- Cache the knot-structure predicates (`has_Bezier_like_knots`, `has_open_knots`, `has_left_end_open`, `has_right_end_open`) via private `cached_property`s — they re-ran `np.isclose` chains (~22 us) on every tabulate call; knots are frozen read-only.
- Add keyword-only `validate: bool = True` to `BsplineSpace1D.tabulate_basis` / `tabulate_basis_derivatives` (and the Layer-2 impls) to skip the domain check when the caller guarantees in-domain points; flipped in THB `_basis_1d_cached` (points already validated against cell bounds) and quasi-interpolation `_local_weight_row` (points constructed inside a knot interval).
- Warm all kernel twins.

Kernel names and signatures are unchanged for existing jit-to-jit callers (`_bspline_eval`); the only API change is the additive `validate` keyword.

## Profiling (before vs after, same machine, post-warmup)

| workload | before | after | speedup |
|----------|--------|-------|---------|
| 1D tabulate, 3 pts (degree 2, 258-basis space) | 347 us | 5.8 us | 60x |
| `has_Bezier_like_knots` per call | 21.6 us | 0.1 us | — |
| THB `tabulate_basis`, 17,152 cells x 9 Gauss pts | 13.70 s | 1.51 s | 9.0x |
| THB `tabulate_basis_derivatives`, same | 13.82 s | 1.53 s | 9.0x |
| `quasi_interpolate_thb_spline` (root 32x32, p2, 3 levels) | 15.23 s | 2.43 s | 6.3x |
| `THBSpline.evaluate`, 100k pts | 20.86 s | 10.67 s | 2.0x |
| bulk parallel kernel, 100k-1M pts | 69.9 ns/pt | 69.0 ns/pt | parity |

`THBSpline.evaluate` remainder is grid locate + point grouping (PRs 2 and 4 of #197).

An intermediate version of the helper refactor regressed the bulk parallel path by up to 28% (per-point scratch allocations no longer visible to Numba's parallel allocation hoisting); fixed with `inline="always"` and verified at 262k and 1M points.

## Test plan

- [x] All existing tests pass (3467 passed, 2 skipped)
- [x] New tests: bitwise serial/parallel twin agreement for NURBS-book and Bernstein kernels (values + derivatives; open non-uniform, periodic, float32, degrees 0-4, t=1 boundary), Layer-2 dispatch consistency across the threshold on both knot paths, predicate caching stability, `validate=False` bitwise equivalence + `validate=True` still rejecting out-of-domain points
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs, import-linter)

Generated with [Claude Code](https://claude.com/claude-code)
