### PR TITLE
perf(bspline): batched locate and argsort grouping in THBSpline evaluation

### DIFF
--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -243,23 +243,35 @@ class THBSpline:
         rank = self.rank
         grid = self._space.grid
 
-        cids = np.empty(n_pts, dtype=np.int64)
-        for i in range(n_pts):
-            cid = grid.locate(flat[i])
-            if cid is None:
-                raise ValueError(f"point {flat[i].tolist()!r} lies outside the grid domain.")
-            cids[i] = cid
+        cids = grid.locate_many(flat)
+        if n_pts > 0 and int(cids.min()) < 0:
+            i = int(np.argmax(cids < 0))
+            raise ValueError(f"point {flat[i].tolist()!r} lies outside the grid domain.")
+
+        # Group points by cell via a stable argsort: order[starts[g]:ends[g]]
+        # holds the point indices of the g-th occupied cell. Avoids the
+        # O(num_cells * num_pts) per-cell boolean masks.
+        order = np.argsort(cids, kind="stable")
+        sorted_cids = cids[order]
+        boundaries = np.flatnonzero(np.diff(sorted_cids)) + 1
+        if n_pts > 0:
+            starts = np.concatenate(([0], boundaries))
+            ends = np.concatenate((boundaries, [n_pts]))
+        else:
+            starts = np.empty(0, dtype=np.int64)
+            ends = np.empty(0, dtype=np.int64)
 
         raw = np.empty((n_pts, rank), dtype=np.float64)
-        for cid in np.unique(cids):
-            mask = cids == cid
-            values, dofs = self._space.tabulate_basis_derivatives(int(cid), flat[mask], orders)
+        for s, e in zip(starts, ends, strict=True):
+            cid = int(sorted_cids[s])
+            idx = order[s:e]
+            values, dofs = self._space.tabulate_basis_derivatives(cid, flat[idx], orders)
             if dofs.size == 0:
                 raise RuntimeError(
-                    f"cell {int(cid)} has no active basis functions; "
+                    f"cell {cid} has no active basis functions; "
                     "the THBSplineSpace may be inconsistent."
                 )
-            raw[mask] = np.asarray(values, dtype=np.float64) @ self._control_points[dofs]
+            raw[idx] = np.asarray(values, dtype=np.float64) @ self._control_points[dofs]
 
         result = raw[:, 0].reshape(batch_shape) if self._scalar else raw.reshape(*batch_shape, rank)
         if out is None:

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -12,6 +12,7 @@ from pantr.bspline import (
     BsplineSpace,
     BsplineSpace1D,
     MultiLevelExtraction,
+    THBSpline,
     THBSplineSpace,
     THBSplineSpaceRestriction,
 )
@@ -1492,3 +1493,88 @@ def test_restrict_errors() -> None:
         g.restrict([g.grid.num_cells])
     with pytest.raises(TypeError):
         g.restrict([0.5, 1.5])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# THBSpline.evaluate batched locate + argsort grouping (PR 4 of #197)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestTHBSplineEvaluateGrouping:
+    """The batched evaluate path matches per-point evaluation exactly."""
+
+    @staticmethod
+    def _spline(rank: int = 1) -> THBSpline:
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        grid.refine(1, [0, 0], [2, 2])
+        thb = THBSplineSpace(_root_2d(), grid)
+        rng = np.random.default_rng(31)
+        shape = (thb.num_total_basis,) if rank == 1 else (thb.num_total_basis, rank)
+        return THBSpline(thb, rng.random(shape))
+
+    def test_matches_per_point_evaluation(self) -> None:
+        """Shuffled multi-cell points (with duplicates) match per-point results."""
+        spline = self._spline()
+        rng = np.random.default_rng(7)
+        pts = rng.random((400, 2))
+        pts[100:120] = pts[:20]  # duplicated points
+        lo, hi = spline.space.grid.collect_cell_bounds()
+        pts[200:210] = lo[:: max(1, lo.shape[0] // 10)][:10]  # cell corners
+        got = spline.evaluate(pts)
+        cp = np.asarray(spline.control_points)
+        expected = []
+        for p in pts:
+            cid = spline.space.grid.locate(p)
+            assert cid is not None
+            values, dofs = spline.space.tabulate_basis(int(cid), p[None, :])
+            expected.append(float(np.asarray(values)[0] @ cp[dofs]))
+        # Grouped points share a BLAS matrix-vector product whose summation
+        # order differs from a single-point dot at the last ulp.
+        np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)
+
+    def test_vector_field_grouping(self) -> None:
+        """Vector-valued evaluation keeps point-to-result correspondence."""
+        spline = self._spline(rank=3)
+        rng = np.random.default_rng(13)
+        pts = rng.random((150, 2))
+        got = spline.evaluate(pts)
+        assert got.shape == (150, 3)
+        cp = np.asarray(spline.control_points)
+        for i in (0, 73, 149):
+            cid = spline.space.grid.locate(pts[i])
+            assert cid is not None
+            values, dofs = spline.space.tabulate_basis(int(cid), pts[i][None, :])
+            np.testing.assert_allclose(
+                got[i], np.asarray(values)[0] @ cp[dofs], rtol=1e-13, atol=0.0
+            )
+
+    def test_outside_point_raises(self) -> None:
+        """An outside point raises ValueError naming the offending point."""
+        spline = self._spline()
+        pts = np.array([[0.5, 0.5], [1.5, 0.5], [2.5, 0.5]])
+        with pytest.raises(ValueError, match="outside the grid domain"):
+            spline.evaluate(pts)
+
+    def test_empty_points(self) -> None:
+        """An empty point batch returns an empty result of the right shape."""
+        spline = self._spline()
+        got = spline.evaluate(np.empty((0, 2)))
+        assert got.shape == (0,)
+
+    def test_derivatives_grouping(self) -> None:
+        """evaluate_derivatives goes through the same grouping path."""
+        spline = self._spline()
+        rng = np.random.default_rng(19)
+        pts = rng.random((60, 2))
+        got = spline.evaluate_derivatives(pts, (1, 0))
+        cp = np.asarray(spline.control_points)
+        for i in (0, 30, 59):
+            cid = spline.space.grid.locate(pts[i])
+            assert cid is not None
+            values, dofs = spline.space.tabulate_basis_derivatives(
+                int(cid), pts[i][None, :], (1, 0)
+            )
+            np.testing.assert_allclose(
+                got[i], np.asarray(values)[0] @ cp[dofs], rtol=1e-12, atol=1e-12
+            )

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1534,26 +1534,27 @@ class TestTHBSplineEvaluateGrouping:
         np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)
 
     def test_vector_field_grouping(self) -> None:
-        """Vector-valued evaluation keeps point-to-result correspondence."""
+        """Vector-valued evaluation keeps point-to-result correspondence for all points."""
         spline = self._spline(rank=3)
         rng = np.random.default_rng(13)
         pts = rng.random((150, 2))
         got = spline.evaluate(pts)
         assert got.shape == (150, 3)
         cp = np.asarray(spline.control_points)
-        for i in (0, 73, 149):
-            cid = spline.space.grid.locate(pts[i])
+        expected = []
+        for p in pts:
+            cid = spline.space.grid.locate(p)
             assert cid is not None
-            values, dofs = spline.space.tabulate_basis(int(cid), pts[i][None, :])
-            np.testing.assert_allclose(
-                got[i], np.asarray(values)[0] @ cp[dofs], rtol=1e-13, atol=0.0
-            )
+            values, dofs = spline.space.tabulate_basis(int(cid), p[None, :])
+            expected.append(np.asarray(values)[0] @ cp[dofs])
+        np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)
 
     def test_outside_point_raises(self) -> None:
-        """An outside point raises ValueError naming the offending point."""
+        """An outside point raises ValueError naming the first offending point."""
         spline = self._spline()
+        # pts[0] is inside; pts[1] is the first outside point (x=1.5 > 1.0).
         pts = np.array([[0.5, 0.5], [1.5, 0.5], [2.5, 0.5]])
-        with pytest.raises(ValueError, match="outside the grid domain"):
+        with pytest.raises(ValueError, match=r"1\.5.*outside the grid domain"):
             spline.evaluate(pts)
 
     def test_empty_points(self) -> None:
@@ -1578,3 +1579,61 @@ class TestTHBSplineEvaluateGrouping:
             np.testing.assert_allclose(
                 got[i], np.asarray(values)[0] @ cp[dofs], rtol=1e-12, atol=1e-12
             )
+
+    def test_all_points_same_cell(self) -> None:
+        """All points in one cell form a single group (boundaries empty, one slice)."""
+        spline = self._spline()
+        # Level-0 cell [3,3] covers [0.75, 1.0]^2 and is never refined by _spline().
+        rng = np.random.default_rng(41)
+        pts = rng.random((30, 2)) * 0.2 + 0.78  # all within [0.78, 0.98]^2
+        got = spline.evaluate(pts)
+        cp = np.asarray(spline.control_points)
+        expected = []
+        for p in pts:
+            cid = spline.space.grid.locate(p)
+            assert cid is not None
+            values, dofs = spline.space.tabulate_basis(int(cid), p[None, :])
+            expected.append(float(np.asarray(values)[0] @ cp[dofs]))
+        # Verify all points landed in the same cell (single group, no splits).
+        cids = np.array([spline.space.grid.locate(p) for p in pts])
+        assert len(np.unique(cids)) == 1
+        np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)
+
+    def test_single_point_batch(self) -> None:
+        """A single-point batch (n_pts=1) forms one group and evaluates correctly."""
+        spline = self._spline()
+        pt = np.array([[0.6, 0.6]])
+        got = spline.evaluate(pt)
+        assert got.shape == (1,)
+        cp = np.asarray(spline.control_points)
+        cid = spline.space.grid.locate(pt[0])
+        assert cid is not None
+        values, dofs = spline.space.tabulate_basis(int(cid), pt)
+        np.testing.assert_allclose(
+            got[0], float(np.asarray(values)[0] @ cp[dofs]), rtol=1e-13, atol=0.0
+        )
+
+    @staticmethod
+    def _spline_1d() -> THBSpline:
+        """1D THBSpline fixture on [0, 1] with one level of refinement."""
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+        rng = np.random.default_rng(53)
+        return THBSpline(thb, rng.random(thb.num_total_basis))
+
+    def test_1d_evaluation(self) -> None:
+        """1D grouping path matches per-point scalar evaluation."""
+        spline = self._spline_1d()
+        rng = np.random.default_rng(61)
+        pts = rng.random((80, 1))
+        got = spline.evaluate(pts)
+        assert got.shape == (80,)
+        cp = np.asarray(spline.control_points)
+        expected = []
+        for p in pts:
+            cid = spline.space.grid.locate(p)
+            assert cid is not None
+            values, dofs = spline.space.tabulate_basis(int(cid), p[None, :])
+            expected.append(float(np.asarray(values)[0] @ cp[dofs]))
+        np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)


### PR DESCRIPTION
## Summary

PR 4 of #197: batched point location and linear-time grouping in `THBSpline` evaluation.

`THBSpline._evaluate_orders` had two scalability problems:

1. Every point was located with a per-point Python loop over `grid.locate`.
2. Points were grouped per cell with `mask = cids == cid` for every unique cell — an O(num_cells x num_pts) scan (640M boolean comparisons for 100k points on a 6.4k-cell space).

Both are replaced:

- `grid.locate_many(flat)` for the batch location. On current `main` this is the ABC loop (same speed); once #199 merges it runs through the hierarchical locate kernel with no further changes here. Outside points raise the same `ValueError`, naming the first offending point.
- A stable argsort with group boundaries (`np.diff` / `flatnonzero`) for the per-cell grouping — O(num_pts log num_pts), independent of the cell count.

No API changes. Branches from `main`; independent of (but compounding with) #198 and #199.

## Profiling (before vs after, same machine, post-warmup; 100k points, 17k-cell space)

| configuration | time | per point |
|---------------|------|-----------|
| baseline (main) | 20.9 s | 215 us |
| this PR standalone | 12.4 s | 124 us |
| this PR + #198 + #199 (local merge) | 1.17 s | 11.7 us |

The compound remainder is per-cell THB tabulation overhead (one `tabulate_basis_derivatives` call per occupied cell); a batched per-level tabulation would be the next lever and is out of scope here.

## Test plan

- [x] All existing tests pass
- [x] New tests: shuffled multi-cell points (with duplicates and cell corners) match per-point locate + tabulate within last-ulp BLAS tolerance, for scalar and vector fields and for derivatives; outside points raise; empty batch returns an empty result
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs, import-linter)

Generated with [Claude Code](https://claude.com/claude-code)
