### PR TITLE
perf(bspline): memoize multi-level extraction coefficients

### DIFF
--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -73,9 +73,16 @@ class MultiLevelExtraction:
             to level ``m+1`` in direction ``k``.
         _ext (dict[int, SpanwiseElementExtraction]): Cache of per-level single-level
             extractions, built lazily.
+        _coeffs_cache (dict[tuple[int, tuple[int, ...], int], tuple[tuple[int, ...],
+            npt.NDArray[np.float64]]]): Memoized ``_element_coeffs`` results keyed
+            by ``(origin_level, multi, target_level)``.  A hierarchical function's
+            coefficients in a finer level's basis are independent of the cell, but a
+            function's support covers up to ``(p + 1) ** d`` cells per level, so the
+            per-cell operators would otherwise recompute each entry many times.
+            Cached coefficient arrays are frozen read-only.
     """
 
-    __slots__ = ("_ext", "_oslo", "_space", "_target")
+    __slots__ = ("_coeffs_cache", "_ext", "_oslo", "_space", "_target")
 
     def __init__(self, space: THBSplineSpace, target: Target = "bezier") -> None:
         """Create a multi-level extraction for a hierarchical space.
@@ -98,6 +105,10 @@ class MultiLevelExtraction:
         self._target = target
         self._oslo = space._build_oslo_matrices()
         self._ext: dict[int, SpanwiseElementExtraction] = {}
+        self._coeffs_cache: dict[
+            tuple[int, tuple[int, ...], int],
+            tuple[tuple[int, ...], npt.NDArray[np.float64]],
+        ] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -317,7 +328,7 @@ class MultiLevelExtraction:
         origin_level: int,
         multi: tuple[int, ...],
         target_level: int,
-    ) -> tuple[list[int], npt.NDArray[np.float64]]:
+    ) -> tuple[tuple[int, ...], npt.NDArray[np.float64]]:
         """Express a hierarchical function on a cell in the level-``target_level`` basis.
 
         Refines the originating B-spline ``B^{origin_level}_multi`` from its origin level
@@ -325,14 +336,18 @@ class MultiLevelExtraction:
         space is truncated.  The result is the function's exact coefficients in the
         level-``target_level`` tensor-product basis over the cell.
 
+        The result depends only on the arguments — not on the cell — so it is
+        memoized on the instance (see ``_coeffs_cache``); the returned ``coeffs``
+        array is shared across calls and frozen read-only.
+
         Args:
             origin_level (int): Level the function originates at.
             multi (tuple[int, ...]): Per-axis function index at ``origin_level``.
             target_level (int): The cell's level; the basis the result is expressed in.
 
         Returns:
-            tuple[list[int], npt.NDArray[np.float64]]: ``(box_lo, coeffs)`` over the
-            level-``target_level`` function box.
+            tuple[tuple[int, ...], npt.NDArray[np.float64]]: ``(box_lo, coeffs)`` over
+            the level-``target_level`` function box.  ``coeffs`` is read-only.
 
         Raises:
             ValueError: If ``origin_level > target_level``.
@@ -341,6 +356,10 @@ class MultiLevelExtraction:
             raise ValueError(
                 f"origin_level ({origin_level}) must be <= target_level ({target_level})."
             )
+        key = (origin_level, multi, target_level)
+        cached = self._coeffs_cache.get(key)
+        if cached is not None:
+            return cached
         space = self._space
         dim = space.dim
         box_lo = [int(multi[d]) for d in range(dim)]
@@ -358,7 +377,10 @@ class MultiLevelExtraction:
                     space._active_funcs[lvl + 1],
                     space._level_spaces[lvl + 1].num_basis,
                 )
-        return box_lo, coeffs
+        coeffs.flags.writeable = False
+        entry = (tuple(box_lo), coeffs)
+        self._coeffs_cache[key] = entry
+        return entry
 
     def __repr__(self) -> str:
         """Return a compact string representation.

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -361,7 +361,7 @@ class TestElementCoeffsMemoization:
         return THBSplineSpace(_root_2d(), grid)
 
     def test_cache_returns_shared_readonly_entry(self) -> None:
-        """Repeated keys return the same frozen array object."""
+        """Repeated keys return the same frozen array; distinct keys return independent objects."""
         ext = MultiLevelExtraction(self._thb())
         box1, c1 = ext._element_coeffs(0, (0, 0), 2)
         box2, c2 = ext._element_coeffs(0, (0, 0), 2)
@@ -370,6 +370,9 @@ class TestElementCoeffsMemoization:
         assert not c1.flags.writeable
         with pytest.raises(ValueError, match="read-only|assignment"):
             c1[(0,) * c1.ndim] = 1.0
+        # Different target_level → independent cache entry (no key collision).
+        _, c_other = ext._element_coeffs(0, (0, 0), 1)
+        assert c_other is not c1
 
     def test_operators_match_fresh_instance(self) -> None:
         """Operators computed through a warm cache equal a fresh instance's."""
@@ -378,7 +381,7 @@ class TestElementCoeffsMemoization:
         for cid in range(thb.grid.num_cells):  # warm the cache over all cells
             warm.multilevel_operator(cid)
         fresh = MultiLevelExtraction(thb)
-        for cid in range(0, thb.grid.num_cells, 7):
+        for cid in range(thb.grid.num_cells):
             np.testing.assert_array_equal(
                 warm.multilevel_operator(cid), fresh.multilevel_operator(cid)
             )

--- a/tests/test_multilevel_extraction.py
+++ b/tests/test_multilevel_extraction.py
@@ -343,3 +343,55 @@ class TestOperatorApi:
             not np.allclose(lagrange.operator(cid), bezier.operator(cid))
             for cid in range(thb.grid.num_cells)
         ), "lagrange and bezier operators should differ on at least one cell"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coefficient memoization (PR 5 of #197)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestElementCoeffsMemoization:
+    """_element_coeffs is memoized per (origin_level, multi, target_level)."""
+
+    @staticmethod
+    def _thb() -> THBSplineSpace:
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+        grid.refine(0, [0, 0], [2, 2])
+        grid.refine(1, [0, 0], [2, 2])
+        return THBSplineSpace(_root_2d(), grid)
+
+    def test_cache_returns_shared_readonly_entry(self) -> None:
+        """Repeated keys return the same frozen array object."""
+        ext = MultiLevelExtraction(self._thb())
+        box1, c1 = ext._element_coeffs(0, (0, 0), 2)
+        box2, c2 = ext._element_coeffs(0, (0, 0), 2)
+        assert c1 is c2
+        assert box1 == box2
+        assert not c1.flags.writeable
+        with pytest.raises(ValueError, match="read-only|assignment"):
+            c1[(0,) * c1.ndim] = 1.0
+
+    def test_operators_match_fresh_instance(self) -> None:
+        """Operators computed through a warm cache equal a fresh instance's."""
+        thb = self._thb()
+        warm = MultiLevelExtraction(thb)
+        for cid in range(thb.grid.num_cells):  # warm the cache over all cells
+            warm.multilevel_operator(cid)
+        fresh = MultiLevelExtraction(thb)
+        for cid in range(0, thb.grid.num_cells, 7):
+            np.testing.assert_array_equal(
+                warm.multilevel_operator(cid), fresh.multilevel_operator(cid)
+            )
+            np.testing.assert_array_equal(warm.operator(cid), fresh.operator(cid))
+
+    def test_repeated_calls_identical(self) -> None:
+        """Two operator calls on the same cell are bitwise identical."""
+        ext = MultiLevelExtraction(self._thb())
+        cid = ext.num_elements - 1
+        np.testing.assert_array_equal(ext.operator(cid), ext.operator(cid))
+
+    def test_invalid_levels_still_raise(self) -> None:
+        """The origin > target validation fires before the cache."""
+        ext = MultiLevelExtraction(self._thb())
+        with pytest.raises(ValueError, match="must be <="):
+            ext._element_coeffs(2, (0, 0), 0)


### PR DESCRIPTION
## Summary

PR 5 of #197 (final item of the original checklist): memoize multi-level extraction coefficients.

`MultiLevelExtraction._element_coeffs` ran the `_refine_box` / `_truncate_box` cascade for every (cell, function) pair — 170k calls on a 17k-cell space — although the result depends only on `(origin_level, multi, target_level)`, and a function's support covers up to `(p + 1)^d` cells per level (~10x redundant recompute).

- Memoize on the `MultiLevelExtraction` instance, keyed by `(origin_level, multi, target_level)`.
- Cached coefficient arrays are frozen read-only and shared across calls; `multilevel_operator` only reads windows out of them. `box_lo` is returned as a tuple.
- Cache lifetime is the extraction object's; memory is bounded by one coefficient box per (active function, finer-level) pair — the same order as what the space itself stores for truncated functions.

No API changes (`_element_coeffs` is private with a single internal caller). Jitting `_refine_box` / `_truncate_box` remains a possible follow-up but is largely amortized by the cache.

## Profiling (before vs after, same machine, post-warmup)

| workload | before | after | speedup |
|----------|--------|-------|---------|
| `operator()` over all 17,152 cells | 5.19 s | 1.27 s | 4.1x |
| `MultiLevelExtraction` construction | 0.5 ms | 0.5 ms | unchanged |

The remainder is per-cell block assembly and the per-cell single-level operator matmul.

## Test plan

- [x] All existing tests pass
- [x] New tests: repeated keys return the same frozen read-only array; warm-cache operators equal a fresh instance's over all cells; repeated calls are bitwise identical; origin/target validation fires before the cache
- [x] Pre-PR checks pass (ruff, mypy, pytest, docs, import-linter)

Generated with [Claude Code](https://claude.com/claude-code)
