### PR TITLE
refactor(bezier,bspline): adopt shared flatten/unflatten array helpers

### DIFF
--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bezier_core import _degree_elevate_bezier_1d_core, _degree_reduce_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ def _degree_elevate_bezier(
     """Degree-elevate a Bézier in one or more parametric directions.
 
     For each direction with a positive increment, applies the Bézier degree
-    elevation kernel using the moveaxis/reshape pattern.
+    elevation kernel via the shared flatten/unflatten helpers.
 
     Args:
         bezier (~pantr.bezier.Bezier): The Bézier to elevate.
@@ -57,19 +58,9 @@ def _degree_elevate_bezier(
 
         p = degrees[d]
 
-        # Move target direction to axis 0, flatten the rest.
-        moved = np.moveaxis(ctrl, d, 0)
-        orig_shape = moved.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-        pts_2d = np.ascontiguousarray(pts_2d)
-
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
         new_pts_2d = _degree_elevate_bezier_1d_core(p, pts_2d, inc)
-
-        # Restore shape and move axis back.
-        new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-        new_moved = new_pts_2d.reshape(new_shape)
-        ctrl = np.moveaxis(new_moved, 0, d)
+        ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, d)
 
         # Update degrees for subsequent iterations.
         degrees = (*degrees[:d], p + inc, *degrees[d + 1 :])
@@ -84,7 +75,7 @@ def _degree_reduce_bezier(
     """Degree-reduce a Bézier in one or more parametric directions.
 
     For each direction with a positive decrement, applies the Bézier degree
-    reduction kernel using the moveaxis/reshape pattern.  The reduction is a
+    reduction kernel via the shared flatten/unflatten helpers.  The reduction is a
     least-squares approximation (not exact in general).
 
     Args:
@@ -112,19 +103,9 @@ def _degree_reduce_bezier(
 
         p = degrees[d]
 
-        # Move target direction to axis 0, flatten the rest.
-        moved = np.moveaxis(ctrl, d, 0)
-        orig_shape = moved.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-        pts_2d = np.ascontiguousarray(pts_2d)
-
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
         new_pts_2d = _degree_reduce_bezier_1d_core(p, pts_2d, dec)
-
-        # Restore shape and move axis back.
-        new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-        new_moved = new_pts_2d.reshape(new_shape)
-        ctrl = np.moveaxis(new_moved, 0, d)
+        ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, d)
 
         # Update degrees for subsequent iterations.
         degrees = (*degrees[:d], p - dec, *degrees[d + 1 :])
@@ -236,24 +217,14 @@ def _minimize_degree_bezier(
             degree = result.shape[dim] - 1
 
             # Reduce all rank components together along this dimension
-            moved = np.moveaxis(result, dim, 0)
-            shape_after = moved.shape
-            flat = moved.reshape(shape_after[0], -1)
-            flat = np.ascontiguousarray(flat)
+            flat, trailing_shape = _flatten_along_axis(result, dim)
             reduced_flat = _degree_reduce_bezier_1d_core(degree, flat, 1)
-            reduced = np.moveaxis(
-                reduced_flat.reshape(reduced_flat.shape[0], *shape_after[1:]), 0, dim
-            )
+            reduced = _unflatten_along_axis(reduced_flat, trailing_shape, dim)
 
             # Elevate back to original shape for error check
-            moved_r = np.moveaxis(reduced, dim, 0)
-            shape_r = moved_r.shape
-            flat_r: npt.NDArray[np.floating[Any]] = moved_r.reshape(shape_r[0], -1)
-            flat_r = np.ascontiguousarray(flat_r)
+            flat_r, trailing_r = _flatten_along_axis(reduced, dim)
             elevated_flat = _degree_elevate_bezier_1d_core(degree - 1, flat_r, 1)
-            elevated = np.moveaxis(
-                elevated_flat.reshape(elevated_flat.shape[0], *shape_r[1:]), 0, dim
-            )
+            elevated = _unflatten_along_axis(elevated_flat, trailing_r, dim)
 
             # Check L2 error summed across all rank components
             diff = elevated - result

--- a/src/pantr/bezier/_bezier_derivative.py
+++ b/src/pantr/bezier/_bezier_derivative.py
@@ -10,10 +10,12 @@ Works for non-rational and rational Bézier of any parametric dimension.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -91,7 +93,7 @@ def _derivative_ctrl_nd(
     """Compute the partial derivative of an N-D coefficient array along one axis.
 
     Applies :func:`_derivative_ctrl_1d` along dimension ``dim`` using the
-    moveaxis/reshape/restore pattern, reducing the size in that dimension
+    shared flatten/unflatten helpers, reducing the size in that dimension
     by 1.
 
     Args:
@@ -108,19 +110,16 @@ def _derivative_ctrl_nd(
         For general use, call :func:`_derivative_bezier` instead.
     """
     degree = coeffs.shape[dim] - 1
-    moved = np.moveaxis(coeffs, dim, 0)
-    orig_shape = moved.shape
-    flat = moved.reshape(orig_shape[0], -1)
-    result = _derivative_ctrl_1d(degree, flat)
-    new_shape = (result.shape[0], *orig_shape[1:])
-    return np.moveaxis(result.reshape(new_shape), 0, dim)
+    pts_2d, trailing_shape = _flatten_along_axis(coeffs, dim)
+    result = _derivative_ctrl_1d(degree, pts_2d)
+    return _unflatten_along_axis(result, trailing_shape, dim)
 
 
 def _derivative_nonrational(bezier: Bezier, direction: int) -> Bezier:
     """Compute the partial derivative of a non-rational Bézier.
 
     Applies the 1D derivative formula along the given parametric direction
-    using the moveaxis/reshape/restore pattern.
+    using the shared flatten/unflatten helpers.
 
     Args:
         bezier (~pantr.bezier.Bezier): A non-rational Bézier.
@@ -144,7 +143,7 @@ def _derivative_keep_degree_nonrational(bezier: Bezier, direction: int) -> Bezie
     """Compute the partial derivative of a non-rational Bézier, preserving degree.
 
     Fuses the derivative and degree elevation into a single operation along
-    the given direction using the moveaxis/reshape/restore pattern.
+    the given direction using the shared flatten/unflatten helpers.
 
     Args:
         bezier (~pantr.bezier.Bezier): A non-rational Bézier.
@@ -163,19 +162,9 @@ def _derivative_keep_degree_nonrational(bezier: Bezier, direction: int) -> Bezie
     p = bezier.degree[direction]
     ctrl = bezier.control_points
 
-    # Move target direction to axis 0, flatten the rest.
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
-
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
     new_pts_2d = _derivative_keep_degree_ctrl_1d(p, pts_2d)
-
-    # Restore shape and move axis back.
-    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-    new_moved = new_pts_2d.reshape(new_shape)
-    new_ctrl = np.moveaxis(new_moved, 0, direction)
+    new_ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, direction)
 
     return BezierCls(new_ctrl, is_rational=False)
 

--- a/src/pantr/bezier/_bezier_restrict.py
+++ b/src/pantr/bezier/_bezier_restrict.py
@@ -11,11 +11,11 @@ Bézier round-trip.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bezier_core import _restrict_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -28,9 +28,9 @@ def _restrict_bezier(
 ) -> Bezier:
     """Restrict a Bézier to a sub-region of ``[0, 1]^dim``.
 
-    Applies :func:`_restrict_bezier_1d_core` per parametric direction using the
-    standard moveaxis pattern. Directions with ``None`` bounds are left
-    unchanged.
+    Applies :func:`_restrict_bezier_1d_core` per parametric direction via the
+    shared :func:`_flatten_along_axis` / :func:`_unflatten_along_axis` helpers.
+    Directions with ``None`` bounds are left unchanged.
 
     Args:
         bezier (~pantr.bezier.Bezier): Input Bézier.
@@ -62,18 +62,10 @@ def _restrict_bezier(
 
         any_restricted = True
 
-        # Move target axis to position 0, flatten the rest.
-        moved = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-        pts_2d = np.ascontiguousarray(pts_2d)
-
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
         out = np.empty_like(pts_2d)
         _restrict_bezier_1d_core(pts_2d, lower, upper, out)
-
-        # Restore shape and move axis back.
-        ctrl = np.moveaxis(out.reshape(orig_shape), 0, i)
+        ctrl = _unflatten_along_axis(out, trailing_shape, i)
 
     if not any_restricted:
         raise ValueError("Bounds match the full domain; at least one direction must be restricted.")

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -12,11 +12,12 @@ last control point is returned directly in O(1).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis
 from ._bezier_core import _slice_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -56,12 +57,7 @@ def _slice_bezier(
 
     ctrl = bezier.control_points
 
-    # Move target axis to position 0, flatten the rest into a single axis.
-    moved = np.moveaxis(ctrl, axis, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, axis)
 
     # Apply 1D de Casteljau via Numba kernel.
     result_1d = np.empty(pts_2d.shape[1], dtype=pts_2d.dtype)
@@ -74,8 +70,7 @@ def _slice_bezier(
             return cast(npt.NDArray[np.float32 | np.float64], result_1d[:-1] / weight)
         return result_1d
 
-    # Restore shape: remove the sliced axis dimension.
-    new_shape = orig_shape[1:]
-    new_ctrl = result_1d.reshape(new_shape)
+    # Restore shape: the sliced axis is removed.
+    new_ctrl = result_1d.reshape(trailing_shape)
 
     return BezierCls(new_ctrl, is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_split.py
+++ b/src/pantr/bezier/_bezier_split.py
@@ -11,11 +11,11 @@ and right ``[value, 1]`` halves, each reparametrized to ``[0, 1]``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
-import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bezier_core import _split_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -53,22 +53,12 @@ def _split_bezier(
 
     ctrl = bezier.control_points
 
-    # Move target axis to position 0, flatten the rest into a single axis.
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
-
-    # Allocate outputs.
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
     out_left = np.empty_like(pts_2d)
     out_right = np.empty_like(pts_2d)
-
     _split_bezier_1d_core(pts_2d, value, out_left, out_right)
-
-    # Restore multi-dimensional shape and move axis back.
-    left_ctrl = np.moveaxis(out_left.reshape(orig_shape), 0, direction)
-    right_ctrl = np.moveaxis(out_right.reshape(orig_shape), 0, direction)
+    left_ctrl = _unflatten_along_axis(out_left, trailing_shape, direction)
+    right_ctrl = _unflatten_along_axis(out_right, trailing_shape, direction)
 
     return (
         BezierCls(left_ctrl, is_rational=bezier.is_rational),

--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -12,11 +12,12 @@ dimension, and correctly preserves per-direction boundary structure
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_nd import BsplineSpace
@@ -115,7 +116,7 @@ def _derivative_nonrational_nd(bspline: Bspline, direction: int) -> Bspline:
     """Compute the partial derivative of a non-rational nD B-spline.
 
     Applies the 1D derivative formula along the given parametric direction
-    using the moveaxis/reshape/restore pattern. Other directions are unchanged.
+    via the shared flatten/unflatten helpers. Other directions are unchanged.
 
     Args:
         bspline (~pantr.bspline.Bspline): A non-rational nD B-spline.
@@ -144,19 +145,11 @@ def _derivative_nonrational_nd(bspline: Bspline, direction: int) -> Bspline:
         indices = np.arange(n_full) % n_periodic
         ctrl = np.take(ctrl, indices, axis=direction)
 
-    # Move target direction to axis 0, flatten the rest.
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
 
     new_pts_2d = _derivative_ctrl_1d(knots, p, pts_2d)
 
-    # Restore shape and move axis back.
-    new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-    new_moved = new_pts_2d.reshape(new_shape)
-    new_ctrl = np.moveaxis(new_moved, 0, direction)
+    new_ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, direction)
 
     # For periodic: trim to periodic CP count.
     new_knots = knots[1:-1]
@@ -317,22 +310,14 @@ def _derivative_keep_degree_nonrational(bspline: Bspline, direction: int) -> Bsp
     knots = space_d.knots
     ctrl = bspline.control_points
 
-    # Move target direction to axis 0, flatten the rest.
-    moved = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
 
     # Derivative (degree p → p-1) + degree elevation (p-1 → p) on arrays.
     deriv_pts = _derivative_ctrl_1d(knots, p, pts_2d)
     deriv_knots = knots[1:-1]
     elevated_pts, elevated_knots = _degree_elevate_1d_core(p - 1, deriv_pts, deriv_knots, 1)
 
-    # Restore shape and move axis back.
-    new_shape = (elevated_pts.shape[0], *orig_shape[1:])
-    new_moved = elevated_pts.reshape(new_shape)
-    new_ctrl = np.moveaxis(new_moved, 0, direction)
+    new_ctrl = _unflatten_along_axis(elevated_pts, trailing_shape, direction)
 
     # Build new spaces: replace direction d, keep others unchanged.
     # Result is open in the differentiated direction.

--- a/src/pantr/bspline/_bspline_interpolate.py
+++ b/src/pantr/bspline/_bspline_interpolate.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from numpy import typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from .._interpolation_utils import resolve_svd_tolerance, split_components
 from ..quad import PointsLattice
 from ._bspline_space_1d import BsplineSpace1D
@@ -176,13 +177,9 @@ def _solve_kronecker(
     """
     result = rhs.copy()
     for d, mat in enumerate(matrices):
-        # Move axis d to position 0, solve, move back.
-        result = np.moveaxis(result, d, 0)
-        shape_rest = result.shape[1:]
-        result_2d = result.reshape(mat.shape[0], -1)
-        solved = _solve_1d(mat, result_2d, tol)
-        result = solved.reshape(mat.shape[1], *shape_rest)
-        result = np.moveaxis(result, 0, d)
+        pts_2d, trailing_shape = _flatten_along_axis(result, d)
+        solved = _solve_1d(mat, pts_2d, tol)
+        result = _unflatten_along_axis(solved, trailing_shape, d)
     return np.array(result, dtype=rhs.dtype)
 
 

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core, _insert_knots_1d_core
 from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
@@ -154,13 +155,7 @@ def _insert_knots_bspline(
 
         is_periodic = space_1d.periodic
 
-        # Move dimension i to the 0th axis.
-        moved_ctrl = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved_ctrl.shape
-
-        # Reshape remaining axes into a single column dimension.
-        pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-        pts_2d = np.ascontiguousarray(pts_2d)
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 
         if is_periodic:
             # Round-trip through open form to preserve periodicity.
@@ -192,12 +187,7 @@ def _insert_knots_bspline(
             )
             new_space_1d = BsplineSpace1D(refined_knots, space_1d.degree)
 
-        # Restore multi-dimensional shape.
-        new_shape = (new_pts_2d.shape[0], *orig_shape[1:])
-        new_moved_ctrl = new_pts_2d.reshape(new_shape)
-
-        # Move axis back to its original position.
-        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+        ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, i)
 
         new_spaces_1d.append(new_space_1d)
 
@@ -338,11 +328,7 @@ def _to_open_bspline_impl(bspline: Bspline) -> Bspline:
             new_spaces_1d.append(space_1d)
             continue
 
-        # Move dimension i to the 0th axis and flatten remaining axes.
-        moved_ctrl = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved_ctrl.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-        pts_2d = np.ascontiguousarray(pts_2d)
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 
         open_knots, open_pts_2d = _to_open_bspline_1d_impl(
             space_1d.knots,
@@ -352,12 +338,7 @@ def _to_open_bspline_impl(bspline: Bspline) -> Bspline:
             float(space_1d.tolerance),
         )
 
-        # Restore multi-dimensional shape.
-        new_shape = (open_pts_2d.shape[0], *orig_shape[1:])
-        new_moved_ctrl = open_pts_2d.reshape(new_shape)
-
-        # Move axis back to its original position.
-        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+        ctrl = _unflatten_along_axis(open_pts_2d, trailing_shape, i)
 
         new_spaces_1d.append(BsplineSpace1D(open_knots, space_1d.degree, periodic=False))
 
@@ -658,16 +639,11 @@ def _to_periodic_bspline_impl(
 
         knots_1d = space_1d.knots
         tol_1d = float(space_1d.tolerance)
-        moved_ctrl = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved_ctrl.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-        pts_2d = np.ascontiguousarray(pts_2d)
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 
         per_knots, per_pts_2d = _to_periodic_bspline_1d_impl(knots_1d, p, pts_2d, m_bdy, tol_1d)
 
-        new_shape = (per_pts_2d.shape[0], *orig_shape[1:])
-        new_moved_ctrl = per_pts_2d.reshape(new_shape)
-        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+        ctrl = _unflatten_along_axis(per_pts_2d, trailing_shape, i)
 
         new_spaces_1d.append(BsplineSpace1D(per_knots, p, periodic=True))
 

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -6,11 +6,12 @@ multi-dimensional orchestration that wrap the Layer 3 knot-removal kernel.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bspline_knot_removal_core import _remove_knot_1d_core
 from ._bspline_knots import _find_knot_index_and_multiplicity
 
@@ -123,13 +124,7 @@ def _remove_knots_bspline(
             new_spaces_1d.append(space_1d)
             continue
 
-        # Move dimension i to the 0th axis.
-        moved_ctrl = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved_ctrl.shape
-
-        # Flatten remaining axes into a single column dimension.
-        pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-        pts_2d = np.ascontiguousarray(pts_2d)
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 
         current_knots = space_1d.knots
         current_ctrl = pts_2d
@@ -146,12 +141,7 @@ def _remove_knots_bspline(
                 tol_deviation,
             )
 
-        # Restore multi-dimensional shape.
-        new_shape = (current_ctrl.shape[0], *orig_shape[1:])
-        new_moved_ctrl = current_ctrl.reshape(new_shape)
-
-        # Move axis back to its original position.
-        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+        ctrl = _unflatten_along_axis(current_ctrl, trailing_shape, i)
 
         new_spaces_1d.append(BsplineSpace1D(current_knots, space_1d.degree))
 

--- a/src/pantr/bspline/_bspline_product_nd.py
+++ b/src/pantr/bspline/_bspline_product_nd.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ..bezier._bezier_product import _bernstein_product_coefficients_nd
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl, _get_unique_knots_and_multiplicity_impl
 from ._bspline_product import (
@@ -131,14 +132,9 @@ def _project_to_optimal_nd(
         oslo_d = _compute_oslo_matrix_1d_core(
             degrees_sum[d], knots_opt_per_dir[d], knots_full_per_dir[d]
         )
-        # Move axis d to front, flatten the rest into a single trailing axis.
-        moved = np.moveaxis(ctrl, d, 0)
-        leading = moved.shape[0]
-        flat = moved.reshape(leading, -1)
+        flat, trailing_shape = _flatten_along_axis(ctrl, d)
         projected, *_ = np.linalg.lstsq(oslo_d, flat, rcond=None)
-        new_leading = projected.shape[0]
-        new_shape = (new_leading, *moved.shape[1:])
-        ctrl = np.moveaxis(projected.reshape(new_shape), 0, d).astype(dtype)
+        ctrl = _unflatten_along_axis(projected, trailing_shape, d).astype(dtype)
 
     return ctrl
 
@@ -392,11 +388,8 @@ def _convert_boundary_direction(  # noqa: PLR0913
     oslo2 = _compute_oslo_matrix_1d_core(r, t_per_open, h_knots_1d)
     oslo = oslo2 @ oslo1_trimmed
 
-    # Apply along the specified axis: move it to front, flatten the rest.
-    moved = np.moveaxis(ctrl, axis, 0)
-    leading = moved.shape[0]
-    rest_shape = moved.shape[1:]
-    flat = moved.reshape(leading, -1)
+    # Apply along the specified axis via the shared flatten/unflatten helpers.
+    flat, trailing_shape = _flatten_along_axis(ctrl, axis)
 
     if target_type == "periodic":
         n_full = len(t_ghost) - r - 1
@@ -412,9 +405,7 @@ def _convert_boundary_direction(  # noqa: PLR0913
         sol, *_ = np.linalg.lstsq(oslo, flat, rcond=None)
         new_space_1d = BsplineSpace1D(t_ghost, r)
 
-    new_leading = sol.shape[0]
-    new_shape = (new_leading, *rest_shape)
-    ctrl = np.moveaxis(sol.astype(dtype).reshape(new_shape), 0, axis)
+    ctrl = _unflatten_along_axis(sol.astype(dtype), trailing_shape, axis)
     return ctrl, new_space_1d
 
 

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -9,11 +9,12 @@ already-open domain endpoint.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bspline_knot_insertion import (
     _insert_knots_bspline_1d_impl,
     _to_open_bspline_1d_impl,
@@ -195,7 +196,7 @@ def _restrict_bspline_impl(
     """Restrict a B-spline to a sub-region of its parametric domain.
 
     Applies :func:`_restrict_bspline_1d_impl` per parametric direction using the
-    standard moveaxis pattern. Directions with ``None`` bounds are left unchanged.
+    shared flatten/unflatten helpers. Directions with ``None`` bounds are left unchanged.
 
     Args:
         bspline: Input B-spline.
@@ -229,11 +230,7 @@ def _restrict_bspline_impl(
             new_spaces_1d.append(space_1d)
             continue
 
-        # Move dimension i to the 0th axis and flatten remaining axes.
-        moved_ctrl = np.moveaxis(ctrl, i, 0)
-        orig_shape = moved_ctrl.shape
-        pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-        pts_2d = np.ascontiguousarray(pts_2d)
+        pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 
         restricted_knots, restricted_pts_2d = _restrict_bspline_1d_impl(
             space_1d.knots,
@@ -246,10 +243,7 @@ def _restrict_bspline_impl(
 
         any_restricted = True
 
-        # Restore multi-dimensional shape.
-        new_shape = (restricted_pts_2d.shape[0], *orig_shape[1:])
-        new_moved_ctrl = restricted_pts_2d.reshape(new_shape)
-        ctrl = np.moveaxis(new_moved_ctrl, 0, i)
+        ctrl = _unflatten_along_axis(restricted_pts_2d, trailing_shape, i)
 
         new_spaces_1d.append(
             BsplineSpace1D(restricted_knots, space_1d.degree, periodic=False, snap_knots=False)

--- a/src/pantr/bspline/_bspline_slice.py
+++ b/src/pantr/bspline/_bspline_slice.py
@@ -14,11 +14,12 @@ point lookup.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis
 from ._bspline_knots import _count_multiplicity, _find_span
 from ._bspline_space_nd import BsplineSpace
 
@@ -130,12 +131,7 @@ def _slice_bspline(
         indices = np.arange(n_full) % n_periodic
         ctrl = np.take(ctrl, indices, axis=axis)
 
-    # Move target axis to position 0, flatten the rest into a single axis.
-    moved = np.moveaxis(ctrl, axis, 0)
-    orig_shape = moved.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved.reshape(orig_shape[0], -1)
-
-    pts_2d = np.ascontiguousarray(pts_2d)
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, axis)
 
     # Apply 1D de Boor corner cutting.
     result_1d = _slice_bspline_1d(knots, p, tol, pts_2d, value)
@@ -148,14 +144,8 @@ def _slice_bspline(
             return cast(npt.NDArray[np.float32 | np.float64], result_1d[:-1] / weight)
         return result_1d
 
-    # Restore shape: remove the sliced axis dimension.
-    new_shape = orig_shape[1:]
-    result_nd = result_1d.reshape(new_shape)
-
-    # Move axis is not needed since we removed axis 0 entirely.
-    # The remaining shape is the original shape minus the sliced direction.
-    # result_nd already has shape (*other_dims, rank).
-    new_ctrl = result_nd
+    # Restore shape: the sliced axis is removed.
+    new_ctrl = result_1d.reshape(trailing_shape)
 
     # Build new spaces list: remove the sliced direction.
     new_spaces = [s for i, s in enumerate(bspline.space.spaces) if i != axis]

--- a/src/pantr/bspline/_bspline_split.py
+++ b/src/pantr/bspline/_bspline_split.py
@@ -8,11 +8,12 @@ sub-splines.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from ._bspline_knot_insertion import (
     _insert_knots_bspline_1d_impl,
     _to_open_bspline_1d_impl,
@@ -90,7 +91,7 @@ def _split_bspline_impl(
     """Split a B-spline into two at a parameter value in one direction.
 
     Applies :func:`_split_bspline_1d_impl` along the specified parametric
-    direction using the standard moveaxis pattern.
+    direction via the shared flatten/unflatten helpers.
 
     Args:
         bspline: Input B-spline.
@@ -107,11 +108,7 @@ def _split_bspline_impl(
     dim = bspline.dim
     ctrl = bspline.control_points
 
-    # Move the split direction to axis 0, flatten the rest.
-    moved_ctrl = np.moveaxis(ctrl, direction, 0)
-    orig_shape = moved_ctrl.shape
-    pts_2d: npt.NDArray[np.floating[Any]] = moved_ctrl.reshape(orig_shape[0], -1)
-    pts_2d = np.ascontiguousarray(pts_2d)
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
 
     space_1d = bspline.space.spaces[direction]
     (left_knots, left_pts_2d), (right_knots, right_pts_2d) = _split_bspline_1d_impl(
@@ -123,13 +120,8 @@ def _split_bspline_impl(
         value,
     )
 
-    # Build left B-spline.
-    left_shape = (left_pts_2d.shape[0], *orig_shape[1:])
-    left_ctrl = np.moveaxis(left_pts_2d.reshape(left_shape), 0, direction)
-
-    # Build right B-spline.
-    right_shape = (right_pts_2d.shape[0], *orig_shape[1:])
-    right_ctrl = np.moveaxis(right_pts_2d.reshape(right_shape), 0, direction)
+    left_ctrl = _unflatten_along_axis(left_pts_2d, trailing_shape, direction)
+    right_ctrl = _unflatten_along_axis(right_pts_2d, trailing_shape, direction)
 
     # Construct the spaces: replace the split direction, keep others.
     left_spaces: list[BsplineSpace1D] = []


### PR DESCRIPTION
## What

Replace the hand-rolled `moveaxis → reshape(n, -1) → ascontiguousarray → kernel → reshape → moveaxis-back` idiom with the existing `pantr._array_utils._flatten_along_axis` / `_unflatten_along_axis` helpers across **13 Layer-2 modules**.

These helpers already existed and were used by `_bspline_degree` and `_bspline_to_beziers`; this brings the rest of the bezier/bspline ops onto them:

- **bezier**: `_bezier_degree` (elevate/reduce/minimize), `_bezier_derivative`, `_bezier_restrict`, `_bezier_slice`, `_bezier_split`
- **bspline**: `_bspline_derivative`, `_bspline_interpolate` (`_solve_kronecker`), `_bspline_knot_insertion` (×3), `_bspline_knot_removal`, `_bspline_product_nd` (×2), `_bspline_restrict`, `_bspline_slice`, `_bspline_split`

Net **−148 lines**.

## Why

The same ~10-line reshape dance was copy-pasted ~20 times. The shared helpers are the single source of truth for the "apply a 1D-axis kernel to an N-D control-point array" pattern.

## Guarantees

- **Public API unchanged** — all edits are private Layer-2 helpers.
- **Performance unchanged** — pure reshape/moveaxis glue. The helper's `ascontiguousarray` is a no-op on the already-contiguous `moveaxis().reshape(n, -1)` result; no kernels touched. Sites that collapse the axis (`slice`) adopt only the `_flatten` half; sites with a trailing `.astype(dtype)` (`product_nd`) keep it.
- **Behavior identical** — tensordot/einsum contraction loops (eval, the `tensordot` path in `_boundary_trace_load`) were deliberately **not** converted; they are not the flatten idiom.

## Verification

- `ruff check` / `ruff format` — clean
- `mypy --strict` (src + tests) — clean
- `pytest --no-cov` — **3491 passed, 8 skipped** (run against this branch's source via `PYTHONPATH`)
- Docs build (`make docs SPHINXOPTS="-W"`) — **introduces zero new warnings** vs base.

First PR in a small internal-refactor series (adopting existing shared helpers / removing duplication; no API or perf changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)