### PR TITLE
refactor(basis,bspline): route out-array handling through _allocate_or_validate_out

### DIFF
--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -8,7 +8,7 @@ output array management.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -23,9 +23,9 @@ from ._basis_core import (
 )
 from ._basis_lagrange import _tabulate_lagrange_basis_1D_core
 from ._basis_utils import (
+    _allocate_or_validate_out,
     _compute_final_output_shape_1D,
     _normalize_points_1D,
-    _validate_out_array,
 )
 
 if TYPE_CHECKING:
@@ -97,10 +97,7 @@ def _tabulate_basis_1D_impl_helper(
     expected_normalized_shape = (num_pts, n_basis)
     expected_final_shape = _compute_final_output_shape_1D(input_shape, n_basis)
 
-    if out is None:
-        out = np.empty(expected_final_shape, dtype=t.dtype)
-    else:
-        _validate_out_array(out, expected_final_shape, cast(npt.DTypeLike, t.dtype))
+    out = _allocate_or_validate_out(out, expected_final_shape, t.dtype)
 
     B_normalized = out.reshape(expected_normalized_shape)
 

--- a/src/pantr/basis/_basis_multidim.py
+++ b/src/pantr/basis/_basis_multidim.py
@@ -14,8 +14,8 @@ import numpy.typing as npt
 
 from ..quad import PointsLattice
 from ._basis_utils import (
+    _allocate_or_validate_out,
     _compute_output_shape_multidimensional,
-    _validate_out_array,
 )
 
 
@@ -81,11 +81,7 @@ def _compute_basis_combinator_matrix_for_points_lattice(
     # Determine dtype from the points lattice
     expected_dtype = pts.dtype
 
-    # Validate or allocate output array
-    if out is None:
-        out = np.empty(expected_shape, dtype=expected_dtype)
-    else:
-        _validate_out_array(out, expected_shape, expected_dtype)
+    out = _allocate_or_validate_out(out, expected_shape, expected_dtype)
 
     # Same ordering (C or F) is used for both points and functions.
     op_str = "pi,qj->qpji" if order == "F" else "pi,qj->pqij"
@@ -181,11 +177,7 @@ def _compute_basis_combinator_matrix_for_points_array(
     expected_shape = _compute_output_shape_multidimensional(n_pts, n_basis_functions)
     expected_dtype = pts.dtype
 
-    # Validate or allocate output array
-    if out is None:
-        out = np.empty(expected_shape, dtype=expected_dtype)
-    else:
-        _validate_out_array(out, expected_shape, expected_dtype)
+    out = _allocate_or_validate_out(out, expected_shape, expected_dtype)
 
     # Handle the 1D case separately
     if dim == 1:

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy import typing as npt
 
 from .._numba_compat import nb_jit, nb_prange
-from ..basis._basis_utils import _validate_out_array
+from ..basis._basis_utils import _allocate_or_validate_out, _validate_out_array
 from ..quad import PointsLattice
 from ._bspline_basis_core import (
     _compute_basis_deriv_nurbs_book_impl,
@@ -177,13 +177,7 @@ def _evaluate_Bspline_1D(
     expected_shape = (n_pts, spline.control_points.shape[-1])
     expected_dtype = spline.dtype
 
-    # Allocate output array if not provided
-    out_array: npt.NDArray[np.float32 | np.float64]
-    if out is None:
-        out_array = np.empty(expected_shape, dtype=expected_dtype)
-    else:
-        _validate_out_array(out, expected_shape, expected_dtype)
-        out_array = out
+    out_array = _allocate_or_validate_out(out, expected_shape, expected_dtype)
 
     _evaluate_Bspline_basis_combine_1D(
         spline.control_points,
@@ -923,11 +917,7 @@ def _evaluate_Bspline_deriv_multi_dim_non_rational(
         return final_nd
 
     # Vector: out shape matches kernel output directly.
-    if out is None:
-        buf = np.empty(out_shape, dtype=dtype)
-    else:
-        _validate_out_array(out, out_shape, dtype)
-        buf = out
+    buf = _allocate_or_validate_out(out, out_shape, dtype)
     _call_kernel(buf)
     return buf
 
@@ -1216,11 +1206,7 @@ def _evaluate_Bspline_multi_dim(
 
         pts_grid_shape = tuple(int(p.shape[0]) for p in pts.pts_per_dir)
         expected_shape = (*pts_grid_shape, cp.shape[-1])
-        if out is None:
-            out_array = np.empty(expected_shape, dtype=dtype)
-        else:
-            _validate_out_array(out, expected_shape, dtype)
-            out_array = out
+        out_array = _allocate_or_validate_out(out, expected_shape, dtype)
 
         _evaluate_Bspline_multi_dim_lattice(cp, spline.space.spaces, pts, out_array)
 
@@ -1231,11 +1217,7 @@ def _evaluate_Bspline_multi_dim(
             raise ValueError("Points dtype must match B-spline dtype")
 
         expected_shape = (pts.shape[0], cp.shape[-1])
-        if out is None:
-            out_array = np.empty(expected_shape, dtype=dtype)
-        else:
-            _validate_out_array(out, expected_shape, dtype)
-            out_array = out
+        out_array = _allocate_or_validate_out(out, expected_shape, dtype)
 
         _evaluate_Bspline_multi_dim_pts_array(cp, spline.space.spaces, pts, out_array)
 


### PR DESCRIPTION
Part of #208 (item 1.2).

## What
Replace the inline `if out is None: np.empty(...) else: _validate_out_array(...)` alloc-or-validate pattern with the existing `pantr.basis._basis_utils._allocate_or_validate_out` helper in the float out-array paths:

- `basis/_basis_multidim.py` (×2)
- `basis/_basis_1D.py` (×1, also drops a now-unused `cast`)
- `bspline/_bspline_eval.py` (×4)

## Guarantees
- **Public API unchanged**, **perf unchanged** — `_allocate_or_validate_out` performs the identical `np.empty` allocation / `_validate_out_array` validation; not a kernel path.
- The bool out-array site in `_bspline_knots` is intentionally left on `_validate_out_array` (the helper is float-only, as its docstring states).

## Verification
- `ruff check` / `ruff format` / `mypy --strict` — clean
- `pytest --no-cov` — **3491 passed, 8 skipped** (worktree source via `PYTHONPATH`)
- Docs build — still exactly the 49 pre-existing warnings (Python-3.14 NamedTuple artifact), **zero from edited files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)