### PR TITLE
refactor: remove dead code and fix stale docstrings

### DIFF
--- a/src/pantr/_control_points_utils.py
+++ b/src/pantr/_control_points_utils.py
@@ -43,30 +43,21 @@ def _permute_control_points(
     ctrl: npt.NDArray[np.float32 | np.float64],
     permutation: Sequence[int],
     dim: int,
-    *,
-    in_place: bool,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Reorder control-point axes according to a permutation.
+
+    Transposing changes the array shape, so a new contiguous array is always
+    returned; callers performing an in-place permutation assign the result
+    back to their own buffer.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control point array with
             shape ``(*num_basis, rank)``.
         permutation (Sequence[int]): A permutation of ``range(dim)``.
         dim (int): Number of parametric dimensions (rank axis is ``dim``).
-        in_place (bool): If ``True``, store the result back into ``ctrl``
-            (requires a contiguous temporary). If ``False``, return a new
-            contiguous array.
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: The permuted control points
         (contiguous).
     """
-    axes = [*permutation, dim]
-    new_cp = np.ascontiguousarray(np.transpose(ctrl, axes))
-
-    if in_place:
-        # The shape changes, so we cannot write back into the same buffer.
-        # Replace the reference instead (caller must assign back).
-        return new_cp
-
-    return new_cp
+    return np.ascontiguousarray(np.transpose(ctrl, [*permutation, dim]))

--- a/src/pantr/bezier/_batch_core.py
+++ b/src/pantr/bezier/_batch_core.py
@@ -60,7 +60,7 @@ def _dispatch_and_find(
 
     Note:
         Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`pantr.bezier.find_roots_batch`
+        For general use, call :func:`pantr.bezier.find_roots`
         instead.
     """
     n = len(coeff) - 1
@@ -128,7 +128,7 @@ def _find_roots_batch_core(
 
     Note:
         Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`pantr.bezier.find_roots_batch`
+        For general use, call :func:`pantr.bezier.find_roots`
         instead.
     """
     n_polys = coeffs.shape[0]
@@ -166,7 +166,7 @@ def _solve_monotone_root_batch_core(
     Note:
         Inputs are assumed to be correct (no validation performed).
         For general use, call
-        :func:`pantr.bezier.solve_monotone_root_batch` instead.
+        :func:`pantr.bezier.find_monotone_root` instead.
     """
     n_polys = coeffs.shape[0]
     for i in nb_prange(n_polys):

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -536,7 +536,7 @@ class Bezier:
 
         from .._control_points_utils import _permute_control_points  # noqa: PLC0415
 
-        new_cp = _permute_control_points(self._control_points, perm, self.dim, in_place=in_place)
+        new_cp = _permute_control_points(self._control_points, perm, self.dim)
 
         if in_place:
             self._control_points = new_cp

--- a/src/pantr/bezier/_find_roots.py
+++ b/src/pantr/bezier/_find_roots.py
@@ -274,7 +274,7 @@ def _find_roots_batch_impl(
     *,
     tol: float | None = None,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]:
-    """L2 implementation for :func:`pantr.bezier.find_roots_batch`."""
+    """L2 implementation for :func:`pantr.bezier.find_roots`."""
     from pantr.bezier._batch_core import (  # noqa: PLC0415
         _find_roots_batch_core,
     )
@@ -319,7 +319,7 @@ def _solve_monotone_root_batch_impl(
     *,
     tol: float | None = None,
 ) -> npt.NDArray[np.float64]:
-    """L2 implementation for :func:`pantr.bezier.solve_monotone_root_batch`."""
+    """L2 implementation for :func:`pantr.bezier.find_monotone_root`."""
     from pantr.bezier._batch_core import (  # noqa: PLC0415
         _solve_monotone_root_batch_core,
     )

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -890,7 +890,7 @@ class Bspline:
         if sorted(perm) != list(range(self.dim)):
             raise ValueError(f"permutation must be a permutation of range({self.dim}), got {perm}.")
 
-        new_cp = _permute_control_points(self._control_points, perm, self.dim, in_place=in_place)
+        new_cp = _permute_control_points(self._control_points, perm, self.dim)
 
         # Reorder 1D spaces.
         old_spaces = self._space.spaces

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -9,7 +9,6 @@ geometric properties (domain, intervals, cardinality).
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy import typing as npt
@@ -34,9 +33,6 @@ from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 @functools.lru_cache(maxsize=128)
@@ -306,8 +302,8 @@ class BsplineSpace1D:
             int: Number of intervals.
 
         Example:
-            >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
-            >>> bspline.get_num_intervals
+            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+            >>> space.num_intervals
             2
         """
         unique_knots, _ = self.get_unique_knots_and_multiplicity(in_domain=True)

--- a/src/pantr/cad/_derived.py
+++ b/src/pantr/cad/_derived.py
@@ -45,15 +45,7 @@ def create_rectangle(
     # 5 control points: close the rectangle
     cp = np.array([c, c + dx, c + dx + dy, c + dy, c], dtype=np.float64)
 
-    # 4 spans, degree 1: knots [0,0, 0.25,0.25, 0.5,0.5, 0.75,0.75, 1,1]
-    n_spans = 4
-    knots: npt.NDArray[np.float64] = np.empty(2 * (n_spans + 1), dtype=np.float64)
-    knots[0] = 0.0
-    knots[-1] = 1.0
-    knots[1:-1] = np.linspace(0.0, 1.0, n_spans + 1).repeat(2)[1:-1]
-
-    # Actually for degree 1 with 5 CPs we need 7 knots: n + p + 1 = 5+1+1=7
-    # knots = [0, 0, 0.25, 0.5, 0.75, 1, 1]
+    # Degree 1 with 5 control points: n + p + 1 = 7 knots, 4 spans.
     knots = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0], dtype=np.float64)
 
     space = BsplineSpace([BsplineSpace1D(knots, degree=1)])

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -181,8 +181,8 @@ class TensorProductGrid(Grid):
         """Get whether every axis has uniform breakpoint spacing.
 
         Returns:
-            bool: ``True`` iff each axis's spacing is constant to within a
-            relative tolerance (``_UNIFORM_SPACING_RTOL``).
+            bool: ``True`` iff each axis's spacing is constant to within an
+            absolute tolerance (``_UNIFORM_SPACING_ATOL``).
         """
         return self._is_uniform
 

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -235,8 +235,8 @@ class TestBsplineSpace1DMethods:
         np.testing.assert_array_almost_equal(unique_knots, expected_unique)
         np.testing.assert_array_equal(multiplicities, expected_mults)
 
-    def test_get_num_intervals(self) -> None:
-        """Test get_num_intervals method."""
+    def test_num_intervals(self) -> None:
+        """Test num_intervals property."""
         num_intervals = 2
         degree = 2
         knots = create_uniform_open_knots(num_intervals, degree)


### PR DESCRIPTION
Part of #208 (item 3).

## Dead code
- **`cad.create_rectangle`** — dropped the knot-vector computation that was immediately overwritten by the hard-coded array on the next line (the old comments even flagged it as wrong), plus the orphaned `n_spans`.
- **`_control_points_utils._permute_control_points`** — dropped the vestigial keyword-only `in_place` parameter: both branches returned the same freshly-transposed array, so it never did anything. The two callers (`Bezier.permute_directions`, `Bspline.permute_directions`) keep their own `in_place` handling (which assigns the result back), so behaviour is identical.
- **`_bspline_space_1d`** — removed the empty `if TYPE_CHECKING: pass` block and the now-unused `TYPE_CHECKING` import.

## Stale docstrings
- `BsplineSpace1D.num_intervals` example called the nonexistent `get_num_intervals` → `num_intervals`.
- `TensorProductGrid.is_uniform` cited `_UNIFORM_SPACING_RTOL` / "relative tolerance"; the constant is `_UNIFORM_SPACING_ATOL` and the check is **absolute** (`np.ptp(np.diff(bp)) < _UNIFORM_SPACING_ATOL`).
- bezier root-finding docstrings referenced `pantr.bezier.find_roots_batch` / `solve_monotone_root_batch` (never public) → the actual public `find_roots` / `find_monotone_root`.

## Verification
- `ruff` / `mypy --strict` clean
- `pytest --no-cov` — **3503 passed, 11 skipped**
- Docs build — 49 pre-existing warnings unchanged, **zero from edited files**

No public API or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)