### PR TITLE
chore(pytest): resolve import pantr from the in-tree src via pythonpath

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 minversion = 7.4
 addopts = --strict-config --strict-markers
 testpaths = tests
+# Prepend the in-tree src/ to sys.path so `import pantr` resolves to THIS
+# checkout's source, independent of where the editable install points. Makes
+# tests run correctly from any git worktree without a per-worktree reinstall.
+pythonpath = src
 python_files = test_*.py
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
## What
Add `pythonpath = src` to `pytest.ini`.

## Why
With a src-layout + a shared editable install, `pytest` imports `pantr` from wherever the editable install points — which, when working in a git worktree, may be a *different* tree. `pythonpath = src` makes pytest prepend the checkout's own `src/` to `sys.path`, so `import pantr` always resolves to **this** tree. Tests then run correctly from any worktree with **no per-worktree `pip install -e .`** and no `PYTHONPATH=…` prefix.

Verified that `sys.path` prepend shadows the editable `.pth`: with the editable install pointing at a *different* worktree, `import pantr` (with `src` on `sys.path[0]`) still resolved to the local tree.

## Safety
- Standard src-layout config; **harmless in CI** — CI installs from the same checkout, so `src` and the install are the same files.
- Accepted under `--strict-config` (`pythonpath` is a core option since pytest 7.0; `minversion = 7.4` already requires it).

## Verification
`pytest --no-cov` → **3505 passed, 11 skipped**. (One test, `test_pantr_toplevel_does_not_import_mpi`, fails only under the local command-sandbox — it spawns a `python -c "import pantr"` subprocess that doesn't inherit pytest's `pythonpath` and hits a Numba-cache write outside the sandbox-writable root; it passes unsandboxed and in CI. Unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)