### PR TITLE
refactor(tier 4): batch Lagrange extraction matmul + consolidate homogeneous control-point helpers

### DIFF
--- a/src/pantr/_control_points_utils.py
+++ b/src/pantr/_control_points_utils.py
@@ -1,7 +1,7 @@
-"""Shared control-point manipulation helpers for reverse and permute operations.
+"""Shared control-point manipulation helpers (reverse, permute, homogeneous).
 
-These functions operate purely on control-point arrays and are used by both
-:class:`~pantr.bezier.Bezier` and :class:`~pantr.bspline.Bspline`.
+These functions operate purely on control-point arrays and are used across the
+:mod:`~pantr.bezier`, :mod:`~pantr.bspline`, and :mod:`~pantr.cad` packages.
 """
 
 from __future__ import annotations
@@ -61,3 +61,24 @@ def _permute_control_points(
         (contiguous).
     """
     return np.ascontiguousarray(np.transpose(ctrl, [*permutation, dim]))
+
+
+def _append_unit_weight_column(
+    control_points: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Append a trailing column of unit weights (homogeneous promotion).
+
+    Converts Euclidean control points of shape ``(*num_basis, rank)`` into
+    rational (homogeneous) control points of shape ``(*num_basis, rank + 1)``
+    whose weights are all ``1``.
+
+    Args:
+        control_points (npt.NDArray[np.float32 | np.float64]): Control points of
+            shape ``(*num_basis, rank)``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Control points with a trailing
+        unit-weight column, shape ``(*num_basis, rank + 1)``.
+    """
+    weights = np.ones((*control_points.shape[:-1], 1), dtype=control_points.dtype)
+    return np.concatenate([control_points, weights], axis=-1)

--- a/src/pantr/bezier/_bezier_eval.py
+++ b/src/pantr/bezier/_bezier_eval.py
@@ -100,15 +100,7 @@ def _evaluate_bezier_1d(
     out_raw = np.empty((n_pts, cp_size), dtype=dtype)
     _evaluate_bezier_1d_core(ctrl, pts_array, out_raw)
 
-    if bezier.is_rational:
-        out_raw[:, :-1] = out_raw[:, :-1] / out_raw[:, -1:]
-        result = out_raw[:, :-1]
-    else:
-        result = out_raw
-
-    # Squeeze scalar output
-    if result.shape[-1] == 1:
-        result = result[:, 0]
+    result = _project_rational(bezier, out_raw)
 
     if out is not None:
         _validate_out_array(out, result.shape, dtype)

--- a/src/pantr/bezier/_bezier_product.py
+++ b/src/pantr/bezier/_bezier_product.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._control_points_utils import _append_unit_weight_column
+
 if TYPE_CHECKING:
     from . import Bezier
 
@@ -260,5 +262,4 @@ def _ensure_rational_ctrl(
     ctrl = bezier.control_points
     if bezier.is_rational:
         return ctrl
-    weights = np.ones((*ctrl.shape[:-1], 1), dtype=ctrl.dtype)
-    return np.concatenate([ctrl, weights], axis=-1)
+    return _append_unit_weight_column(ctrl)

--- a/src/pantr/bspline/_bspline_extraction.py
+++ b/src/pantr/bspline/_bspline_extraction.py
@@ -283,13 +283,11 @@ def _tabulate_Bspline_Lagrange_1D_extraction_impl(
     # Compute Bezier extraction into out
     _tabulate_Bspline_Bezier_1D_extraction_impl(knots, degree, tol, out=out)
 
-    # Transform to Lagrange extraction in-place to avoid extra copy
-    # For every interval, right-multiply the Bezier-to-B-spline extraction by lagr_to_bzr in-place.
+    # Transform Bezier -> Lagrange extraction in-place: out[i] = out[i] @ lagr_to_bzr
+    # for every interval, as a single batched matmul (np.matmul broadcasts the
+    # (p+1, p+1) matrix over the leading interval axis), mirroring the cardinal path.
     lagr_to_bzr = _cached_lagrange_to_bernstein_matrix(degree, lagrange_variant, knots.dtype)
-    for i in range(out.shape[0]):
-        # Use out[i, :, :] = out[i, :, :] @ lagr_to_bzr, but perform in-place via np.matmul
-        # to avoid extra allocation.
-        np.matmul(out[i, :, :], lagr_to_bzr, out=out[i, :, :])
+    np.matmul(out, lagr_to_bzr, out=out)
 
     return out
 

--- a/src/pantr/bspline/_bspline_product.py
+++ b/src/pantr/bspline/_bspline_product.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._control_points_utils import _append_unit_weight_column
 from ..bezier._bezier_product import _bernstein_product_coefficients
 from ._bspline_knots import (
     _get_Bspline_num_basis_1D_impl,
@@ -476,9 +477,7 @@ def _to_rational(f: Bspline) -> Bspline:
         return f
     from . import Bspline  # noqa: PLC0415
 
-    n = f.control_points.shape[0]
-    weights = np.ones((n, 1), dtype=f.control_points.dtype)
-    new_ctrl = np.concatenate([f.control_points, weights], axis=-1)
+    new_ctrl = _append_unit_weight_column(f.control_points)
     return Bspline(f.space, new_ctrl, is_rational=True)
 
 

--- a/src/pantr/bspline/_bspline_product_nd.py
+++ b/src/pantr/bspline/_bspline_product_nd.py
@@ -20,6 +20,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from .._control_points_utils import _append_unit_weight_column
 from ..bezier._bezier_product import _bernstein_product_coefficients_nd
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl, _get_unique_knots_and_multiplicity_impl
 from ._bspline_product import (
@@ -264,9 +265,7 @@ def _to_rational_nd(f: Bspline) -> Bspline:
         return f
     from . import Bspline as BsplineCls  # noqa: PLC0415
 
-    cp = f.control_points
-    weights = np.ones((*cp.shape[:-1], 1), dtype=cp.dtype)
-    new_ctrl = np.concatenate([cp, weights], axis=-1)
+    new_ctrl = _append_unit_weight_column(f.control_points)
     return BsplineCls(f.space, new_ctrl, is_rational=True)
 
 

--- a/src/pantr/cad/_derived.py
+++ b/src/pantr/cad/_derived.py
@@ -94,9 +94,8 @@ def create_disk(
     inner_cp = np.zeros((n_cp, rank_full), dtype=np.float64)
     # Copy weights from outer arc
     inner_cp[:, _PHYSICAL_DIM] = outer.control_points[:, _PHYSICAL_DIM]
-    # Set weighted coordinates: w * center
-    for i in range(_PHYSICAL_DIM):
-        inner_cp[:, i] = inner_cp[:, _PHYSICAL_DIM] * c[i]
+    # Set weighted coordinates: w * center (broadcast the weight column over axes)
+    inner_cp[:, :_PHYSICAL_DIM] = inner_cp[:, _PHYSICAL_DIM : _PHYSICAL_DIM + 1] * c
 
     inner = Bspline(outer.space, inner_cp, is_rational=True)
     return create_ruled(inner, outer)

--- a/src/pantr/cad/_validation.py
+++ b/src/pantr/cad/_validation.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from .._control_points_utils import _append_unit_weight_column
+
 if TYPE_CHECKING:
     from numpy import typing as npt
 
@@ -56,7 +58,5 @@ def _promote_to_rational(bspline: Bspline) -> Bspline:
 
     from ..bspline import Bspline as BsplineCls  # noqa: PLC0415
 
-    cp = bspline.control_points
-    ones = np.ones((*cp.shape[:-1], 1), dtype=cp.dtype)
-    new_cp = np.concatenate([cp, ones], axis=-1)
+    new_cp = _append_unit_weight_column(bspline.control_points)
     return BsplineCls(bspline.space, new_cp, is_rational=True)

--- a/src/pantr/viz/_common.py
+++ b/src/pantr/viz/_common.py
@@ -29,3 +29,31 @@ def _pad_points_to_3d(
     pts_3d = np.zeros((coords.shape[0], _MAX_PHYSICAL_DIM), dtype=np.float64)
     pts_3d[:, :rank] = coords[:, :rank]
     return pts_3d
+
+
+def _project_homogeneous(
+    flat_cp: npt.NDArray[np.float32 | np.float64], is_rational: bool
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64] | None]:
+    """Split flat control points into Euclidean coords and homogeneous weights.
+
+    For rational geometries the leading columns are divided by the trailing
+    weight column; non-rational input is returned unchanged with ``None``
+    weights. Inputs are upcast to ``float64``.
+
+    Args:
+        flat_cp (npt.NDArray[np.float32 | np.float64]): Flattened control points
+            of shape ``(n_pts, rank)`` (non-rational) or ``(n_pts, rank + 1)``
+            (rational; last column is the homogeneous weight).
+        is_rational (bool): Whether the last column is a homogeneous weight.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64] | None]:
+        ``(coords, weights)`` — ``coords`` has shape ``(n_pts, rank)``; ``weights``
+        is ``(n_pts,)`` for rational input, else ``None``.
+    """
+    flat = flat_cp.astype(np.float64, copy=False)
+    if not is_rational:
+        return flat, None
+    weights = flat[:, -1].copy()
+    coords = flat[:, :-1] / weights[:, np.newaxis]
+    return coords, weights

--- a/src/pantr/viz/_common.py
+++ b/src/pantr/viz/_common.py
@@ -37,8 +37,8 @@ def _project_homogeneous(
     """Split flat control points into Euclidean coords and homogeneous weights.
 
     For rational geometries the leading columns are divided by the trailing
-    weight column; non-rational input is returned unchanged with ``None``
-    weights. Inputs are upcast to ``float64``.
+    weight column; non-rational input is returned without weight projection
+    (post-upcast) with ``None`` weights. Inputs are upcast to ``float64``.
 
     Args:
         flat_cp (npt.NDArray[np.float32 | np.float64]): Flattened control points

--- a/src/pantr/viz/_control_points.py
+++ b/src/pantr/viz/_control_points.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy import typing as npt
 
-from ._common import _pad_points_to_3d
+from ._common import _pad_points_to_3d, _project_homogeneous
 from ._lazy_import import _import_pyvista
 
 if TYPE_CHECKING:
@@ -45,14 +45,7 @@ def _get_euclidean_control_points(
     grid_shape = cp.shape[:-1]
     rank = geom.rank
     n_pts = int(np.prod(grid_shape))
-    flat = cp.reshape(n_pts, -1)
-
-    if geom.is_rational:
-        weights = flat[:, -1:]
-        coords = flat[:, :-1] / weights
-    else:
-        coords = flat
-
+    coords, _ = _project_homogeneous(cp.reshape(n_pts, -1), geom.is_rational)
     pts_3d = _pad_points_to_3d(coords, rank)
     return pts_3d, grid_shape, rank
 

--- a/src/pantr/viz/_vtk_cells.py
+++ b/src/pantr/viz/_vtk_cells.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from numpy import typing as npt
 
-from ._common import _MAX_PHYSICAL_DIM, _pad_points_to_3d
+from ._common import _MAX_PHYSICAL_DIM, _pad_points_to_3d, _project_homogeneous
 from ._lazy_import import _import_pyvista
 from ._vtk_ordering import vtk_ordering
 
@@ -96,13 +96,7 @@ def _flatten_and_project(
         and *weights* is ``(n_pts,)`` or ``None``.
     """
     n_pts = int(np.prod(cp.shape[:-1]))
-    flat_cp = cp.reshape(n_pts, -1).astype(np.float64)
-
-    if is_rational:
-        weights = flat_cp[:, -1].copy()
-        coords = flat_cp[:, :-1] / weights[:, np.newaxis]
-        return coords, weights
-    return flat_cp, None
+    return _project_homogeneous(cp.reshape(n_pts, -1), is_rational)
 
 
 def _embed_scalar_field(


### PR DESCRIPTION
Tier 4 of #208 (the "design + benchmark" tier). Three commits.

## 1. `perf(bspline)` — batch the Lagrange extraction matmul
Per-interval loop → single batched `np.matmul(out, M, out=out)` (mirrors the cardinal path). **Benchmarked 6–23× faster**; numerically identical (batched in-place == loop == non-aliased reference, incl. `n_elems=1`).

## 2. `refactor(viz)` — `_project_homogeneous`
Dedups the two identical viz divide-by-weight sites (`_get_euclidean_control_points`, `_flatten_and_project`) into `viz._common._project_homogeneous`.

## 3. `refactor` — finish the homogeneous control-point dedup
- `_control_points_utils._append_unit_weight_column` — promote-to-rational (append a unit-weight column); routes the **four** duplicates through it: cad `_promote_to_rational`, bspline `_to_rational` / `_to_rational_nd`, bezier `_ensure_rational_ctrl`. cad's exported `_promote_to_rational` keeps its signature/behaviour (only its body changes).
- bezier `_evaluate_bezier_1d` → calls its existing `_project_rational` instead of re-inlining divide-by-weight + scalar squeeze.
- cad `create_disk` → vectorized the per-axis weighted-coordinate loop.

## Intentionally left (design-pass conclusion)
- Unifying bezier's divide-by-weight with viz's `_project_homogeneous`: different operations (bezier's is **in-place, nD, on the eval hot path** and already its own `_project_rational`; viz's builds a new 2-D array + returns weights). Merging would change behaviour/perf.
- A `_split/_join_homogeneous` helper for `concatenate([num, den], axis=-1)`: it's a clear one-liner; a helper would not improve clarity.

## Verification
- `ruff` / `ruff format` / `mypy --strict` — clean (199 files)
- `pytest --no-cov` — **3505 passed, 11 skipped** (lone failure = the local-sandbox subprocess/Numba-cache artifact in `test_pantr_toplevel_does_not_import_mpi`; passes unsandboxed + in CI)
- Docs build — 49 pre-existing warnings unchanged, **zero from edited files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)