### PR TITLE
Prepare documentation and packaging for the first public release (v0.6.0)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs build configuration for PaNTr.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  # Match the CI docs build (`-W`): treat warnings as errors.
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "PaNTr: Polynomial and NURBS Toolkit"
+type: software
+authors:
+  - family-names: Antolin
+    given-names: Pablo
+    email: pablo.antolin@epfl.ch
+    affiliation: "École Polytechnique Fédérale de Lausanne (EPFL)"
+version: 0.6.0
+date-released: "2026-06-13"
+license: MIT
+repository-code: "https://github.com/pantolin/pantr"
+url: "https://github.com/pantolin/pantr"
+keywords:
+  - nurbs
+  - b-spline
+  - bezier
+  - isogeometric-analysis
+  - cad
+  - geometric-modeling
+  - scientific-computing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to PaNTr
+
+Thanks for your interest in contributing to PaNTr. This guide covers the
+development setup and the conventions the project follows.
+
+## Development setup
+
+PaNTr targets Python 3.10–3.14. Clone the repository and install the package
+with all development and optional-feature dependencies:
+
+```bash
+git clone https://github.com/pantolin/pantr.git
+cd pantr
+pip install -e ".[dev]"
+pre-commit install
+```
+
+The `dev` extra pulls in every optional feature (`mpi`, `metis`, `viz`, `docs`)
+so the full test suite runs with nothing silently skipped.
+
+## Running the checks
+
+All of the following must pass before a pull request is merged (CI enforces
+them):
+
+```bash
+ruff check .                             # lint
+ruff format --check .                    # formatting
+mypy --config-file mypy.ini src tests    # static types (strict)
+lint-imports                             # import-boundary contracts
+pytest --no-cov                          # tests (JIT enabled)
+```
+
+Build the documentation the same way CI does:
+
+```bash
+NUMBA_DISABLE_JIT=1 make docs SPHINXOPTS="-W --keep-going -j auto"
+```
+
+> The default `pytest` run adds coverage (`--cov`), which is slower and requires
+> ≥85% coverage. Pass `--no-cov` during development. To run the coverage gate
+> locally: `NUMBA_DISABLE_JIT=1 pytest --cov=src/pantr --cov-report=xml`.
+
+The optional MPI smoke tests under `tests/mpi/` are skipped unless
+`PANTR_RUN_MPI` is set and run under a launcher:
+
+```bash
+PANTR_RUN_MPI=1 mpiexec -n 2 python -m pytest tests/mpi/ --no-cov
+```
+
+## Code conventions
+
+- **Types**: strict mypy; all public and private functions must be fully typed.
+- **Docstrings**: Google-style, enforced by Ruff's `pydocstyle` rules. Private
+  functions are documented too; Numba kernels carry a `Note:` stating that no
+  input validation is performed.
+- **Style**: Ruff, line length 100, target Python 3.10.
+- **Layering**: the library is organized in three strict layers — public API,
+  implementation helpers (all input validation), and Numba kernels (no
+  validation). Review the architecture section of the documentation before
+  adding code.
+
+## Commits and branches
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <imperative summary>
+```
+
+- **Types**: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `perf`, `chore`.
+- **Scope**: the affected module (e.g. `bspline`, `bezier`, `grid`, `docs`).
+- One logical change per commit; branch names follow the same convention
+  (`<type>/<short-kebab-description>`).
+
+Changes are merged via pull requests, not direct pushes to `main`.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,18 +4,38 @@ Polynomial and NURBS Toolkit (**PaNTr**) is a pure Python 3.10–3.14 library fo
 
 ## Features
 
-- Precise polynomial and NURBS basis evaluation with strict type hints.
-- Vectorized implementations tailored for scientific computing workflows.
-- Comprehensive testing with `pytest`, coverage reporting, and type checking.
-- Documentation powered by **Sphinx**, **MyST**, and related tooling.
+- **B-spline & NURBS spaces** — univariate and tensor-product `BsplineSpace`,
+  exact rational (NURBS) geometry, evaluation and derivatives, knot
+  insertion/removal, degree elevation, and splitting.
+- **Bézier toolkit** — Bernstein/Bézier curves and patches, composition,
+  products, degree reduction, and Bernstein-polynomial root finding.
+- **Truncated hierarchical B-splines** — `THBSplineSpace` with local
+  refinement, mirroring the tensor-product API.
+- **Constructive geometry (`pantr.cad`)** — lines, circles and arcs, disks,
+  cylinders, extrude, revolve, sweep, ruled and Coons surfaces/volumes.
+- **Structured grids (`pantr.grid`)** — tensor-product and hierarchical grids,
+  BVH spatial queries, dolfinx-style cell/facet tags, and cell quadrature.
+- **Quadrature and change of basis** — Gauss–Legendre and tensor-product
+  rules, plus exact matrices between Bernstein, Lagrange, monomial, and
+  cardinal B-spline bases.
+- **Fast and typed** — Numba-JIT kernels parallelized over CPU cores, with
+  strict type hints across the public API.
+- **Optional MPI and visualization** — distribute spaces across ranks
+  (`pantr.mpi`) and render exact higher-order geometry through VTK
+  (`pantr.viz`).
 
 ## Installation
 
 ```bash
-# Install directly from GitHub
-pip install git+https://github.com/pantolin/pantr.git
+pip install pantr
+```
 
-# Or clone and install locally
+Requires Python 3.10–3.14. The serial core depends only on NumPy, SciPy,
+Numba, and threadpoolctl.
+
+To install the latest development version from source:
+
+```bash
 git clone https://github.com/pantolin/pantr.git
 cd pantr
 pip install .

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -60,4 +60,9 @@ For transformations between these domains, the `pantr.change_basis` utilities ac
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: pantr.viz
+   :members:
+   :undoc-members:
+   :show-inheritance:
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 (2026-06-13)
 
 ### Added
 - `pantr.mpi.configure_threads`: explicitly set the per-rank Numba thread count
-  for hybrid MPI + threads runs (optionally also limiting BLAS/LAPACK pools via
-  the optional `threadpoolctl` package). Calling it disables the default MPI
+  for hybrid MPI + threads runs (optionally also limiting BLAS/LAPACK thread
+  pools via `threadpoolctl`). Calling it disables the default MPI
   thread policy.
 
 ### Changed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,11 @@ autosummary_generate = True
 autodoc_typehints = "description"
 autodoc_member_order = "bysource"
 
+# Optional heavy dependencies are mocked so the docs build without installing
+# them. pantr imports them lazily at runtime, so autodoc can still import the
+# modules. `pyvista` backs `pantr.viz`; `mpi4py` / `pymetis` back `pantr.mpi`.
+autodoc_mock_imports = ["pyvista", "mpi4py", "pymetis"]
+
 myst_enable_extensions = [
     "colon_fence",
     "deflist",
@@ -126,7 +131,7 @@ html_theme_options = {
 
 html_context = {
     "display_github": True,
-    "github_user": "pablodroca",
+    "github_user": "pantolin",
     "github_repo": "pantr",
     "github_version": "main",
     "conf_py_path": "/docs/",
@@ -158,6 +163,8 @@ nitpick_ignore = [
     # types.ModuleType return annotation: stripped to a bare name by autodoc and
     # not carried in the Python inventory under that short form.
     ("py:class", "ModuleType"),
+    # pathlib.Path appears as a bare `Path` in pantr.viz.save's type annotation.
+    ("py:class", "Path"),
     # Private structural protocol; not in __all__ and not cross-referenceable
     ("py:class", "_AffineMap"),
     ("py:class", "CellIndex"),
@@ -175,6 +182,10 @@ nitpick_ignore_regex = [
     ("py:class", r"np\.\w+"),
     ("py:class", r"npt\.\w+"),
     ("py:class", r"numpy\.\w+"),
+    # pantr.viz annotations reference pyvista via the local alias `pv`; pyvista
+    # exposes no cross-referenceable inventory in this build.
+    ("py:class", r"pv\.\w+"),
+    ("py:class", r"pyvista\..*"),
 ]
 
 suppress_warnings: list[str] = []

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,15 +17,29 @@ pre-commit install
 
 ## Quick Example
 
-```python
-from __future__ import annotations
+Build a quadratic B-spline curve and evaluate it:
 
+```python
 import numpy as np
 
-import pantr
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 
-print(pantr.__version__)
+# Quadratic univariate space on the knot vector [0, 0, 0, 1, 2, 3, 3, 3]
+space = BsplineSpace([BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)])
+
+# Five 2-D control points
+control_points = np.array(
+    [[0.0, 0.0], [1.0, 2.0], [2.0, -1.0], [3.0, 1.0], [4.0, 0.0]]
+)
+curve = Bspline(space, control_points)
+
+# Evaluate at 50 parameters spanning the domain [0, 3]
+u = np.linspace(0.0, 3.0, 50)
+points = curve.evaluate(u)  # shape (50, 2)
 ```
+
+To render geometries interactively or export them to VTK, see
+[Visualization](visualization.md) (requires the `viz` extra).
 
 ## Building the Documentation
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-sphinx>=7.2,<8
-sphinx-rtd-theme>=1.3,<2
-sphinx-rtd-dark-mode>=1.3,<2
-breathe>=4.35,<5
-markdown>=3.5,<4
-myst-parser>=2.0,<3
-linkify-it-py>=2.0,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,31 @@
 [build-system]
-requires = ["hatchling>=1.12.0"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
 name = "pantr"
-version = "0.5.1"
 description = "Polynomial And NURBS Toolkit"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
-license = { text = "MIT License" }
+license = "MIT"
+license-files = ["LICENSE", "THIRD_PARTY_NOTICES"]
 authors = [{ name = "Pablo Antolin", email = "pablo.antolin@epfl.ch" }]
+keywords = [
+  "nurbs",
+  "b-spline",
+  "bezier",
+  "bernstein",
+  "spline",
+  "isogeometric-analysis",
+  "cad",
+  "geometric-modeling",
+  "quadrature",
+  "scientific-computing",
+]
+dynamic = ["version"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
@@ -47,11 +59,8 @@ docs = [
   "sphinx>=7.2,<8",
   "sphinx-rtd-theme>=1.3,<2",
   "sphinx-rtd-dark-mode>=1.3,<2",
-  "breathe>=4.35,<5",
-  "markdown>=3.5,<4",
   "myst-parser>=2.0,<3",
   "linkify-it-py>=2.0,<3",
-  "matplotlib>=3.8,<4",
 ]
 # `dev` pulls in every optional feature extra so a single
 # `pip install -e ".[dev]"` yields a complete contributor environment and CI runs
@@ -79,8 +88,13 @@ Issues = "https://github.com/pantolin/pantr/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pantr"]
 
+# Single source of truth for the version: `__version__` in the package __init__.
+# The explicit pattern is required because the assignment carries a type
+# annotation (`__version__: Final[str] = "..."`), which hatchling's default
+# regex does not match.
 [tool.hatch.version]
 path = "src/pantr/__init__.py"
+pattern = '^__version__[^=]*=\s*"(?P<version>[^"]+)"'
 
 [tool.importlinter]
 root_package = "pantr"

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -14,6 +14,8 @@ The main modules are:
 - :mod:`pantr.transform`: Affine transformations for geometric objects.
 - :mod:`pantr.cad`: Constructive geometry for B-spline curves, surfaces, and volumes.
 - :mod:`pantr.bezier`: Bézier curves/surfaces and root finding for Bernstein polynomials.
+- :mod:`pantr.mpi`: Optional MPI-distributed B-spline / THB-spline spaces (``mpi`` extra).
+- :mod:`pantr.viz`: Optional PyVista/VTK visualization of geometries (``viz`` extra).
 """
 
 import sys
@@ -35,7 +37,7 @@ from ._parallel import get_num_threads, num_threads, set_num_threads
 from .basis import _basis_utils  # noqa: F401
 
 # Package metadata
-__version__: Final[str] = "0.5.1"
+__version__: Final[str] = "0.6.0"
 __license__: Final[str] = "MIT"
 __author__: Final[str] = "Pablo Antolin <pablo.antolin@epfl.ch>"
 

--- a/src/pantr/viz/_grid.py
+++ b/src/pantr/viz/_grid.py
@@ -59,7 +59,7 @@ def grid_to_pyvista(grid: Grid) -> pv.UnstructuredGrid:
 
     Returns:
         pyvista.UnstructuredGrid: A grid of lines (1-D), quads (2-D), or
-        hexahedra (3-D), one cell per grid cell, in :meth:`Grid.iter_cells`
+        hexahedra (3-D), one cell per grid cell, in :meth:`~pantr.grid.Grid.iter_cells`
         order. Points are padded to 3-D (``z = 0``, and ``y = 0`` in 1-D).
 
     Raises:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,7 +36,7 @@ def test_package_all_exports() -> None:
 
 def test_package_metadata_values() -> None:
     """Validate the package metadata constants."""
-    assert pantr.__version__ == "0.5.1"
+    assert pantr.__version__ == "0.6.0"
     assert pantr.__license__ == "MIT"
     assert pantr.__author__ == "Pablo Antolin <pablo.antolin@epfl.ch>"
 
@@ -44,7 +44,7 @@ def test_package_metadata_values() -> None:
 def test_metadata_import_stability() -> None:
     """Verify metadata survives module reloads."""
     module = importlib.reload(pantr)
-    assert module.__version__ == "0.5.1"
+    assert module.__version__ == "0.6.0"
 
 
 def test_submodule_all_exports() -> None:


### PR DESCRIPTION
## Summary

Full pre-publish revision of PaNTr's documentation and packaging, ahead of the first PyPI/conda release. Cuts **v0.6.0 (Beta)**.

### Packaging (`pyproject.toml`)
- SPDX `license = "MIT"` + `license-files` → `LICENSE` and `THIRD_PARTY_NOTICES` now ship inside the wheel (`dist-info/licenses/`). Dropped the redundant `License ::` classifier (PEP 639); raised the hatchling build floor to 1.27.
- Single-sourced the version from `__init__.__version__` — the previous `[tool.hatch.version]` block was dead config (hatchling's default regex doesn't match the annotated `__version__: Final[str]`), so it silently fell back to the static field. Added an explicit pattern.
- Added `keywords`; bumped Development Status to `4 - Beta`.

### Version / changelog
- Cut `Unreleased` → `0.6.0 (2026-06-13)`; bumped `__version__` and the metadata-test pin.
- Corrected the changelog's `threadpoolctl` wording (it is a core dependency, not optional).

### Docs content
- **README**: real feature overview; `pip install pantr` as the primary install path (was GitHub-only).
- **getting-started**: replaced the `print(__version__)` stub with a runnable B-spline example.
- **API reference**: documented the optional `pantr.viz` module (with pyvista/mpi autodoc mocks + nitpick-ignores); fixed a stale `:meth:` cross-reference in `grid_to_pyvista`.
- **conf.py**: fixed the GitHub user (`pablodroca` → `pantolin`) so the "Edit on GitHub" / source links resolve.
- Removed `docs/requirements.txt`; docs deps now live solely in the `[docs]` extra (also dropped unused `breathe`/`markdown`/`matplotlib`).

### New files
- **`.readthedocs.yaml`** — the advertised `pantr.readthedocs.io` had no RTD config (RTD now requires one). Builds on Python 3.12, installs the `[docs]` extra, `fail_on_warning` for CI parity.
- **`CONTRIBUTING.md`**, **`CITATION.cff`** (basic; ORCID/DOI to follow).

### Testing
ruff, ruff-format, mypy (199 files), import-linter, full pytest (**3506 passed, 11 skipped**), and the Sphinx docs build all pass. The docs build is clean on CI's Python; the ~49 local warnings are pre-existing Python 3.14-only NamedTuple/ForwardRef noise.

### Deferred (per discussion)
- No PyPI publish workflow (manual release for now).
- CITATION.cff ORCID + Zenodo DOI to be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
