### PR TITLE
feat(demos): standalone demo gallery (PR2)

### DIFF
--- a/demos/01_visualization_basics.py
+++ b/demos/01_visualization_basics.py
@@ -1,0 +1,69 @@
+"""
+Visualization basics
+=====================
+
+PaNTr's :mod:`pantr.viz` module turns B-spline, Bézier, and THB-spline geometries
+into `PyVista <https://docs.pyvista.org>`_ meshes using native VTK Bézier cells, so
+curves and surfaces render *exactly* (no tessellation error). This first demo
+introduces the toolkit reused throughout the gallery:
+
+- :func:`~pantr.viz.plot` -- one-call interactive viewing,
+- :class:`~pantr.viz.Scene` -- compose several geometries with per-geometry options,
+- **control polygons** and **knot lines** overlaid on the geometry,
+- **scalar fields** drawn as a colour map or an elevation surface,
+- :func:`~pantr.viz.save` -- export to a ``.vtu`` file for ParaView.
+
+Requires the ``viz`` extra: ``pip install "pantr[viz]"``.
+"""
+
+import numpy as np
+
+from pantr import viz
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.cad import create_circle, create_disk
+
+# %%
+# A curve with its control polygon and knot lines
+# ------------------------------------------------
+# :func:`~pantr.cad.create_circle` builds an *exact* circle as a rational quadratic
+# (NURBS) curve. ``show_control_polygon`` draws the control net; ``show_knot_lines``
+# marks the images of the interior knots.
+arc = create_circle(radius=1.0, angle=(0.0, 1.5 * np.pi))
+viz.plot(arc, show_control_polygon=True, show_knot_lines=True)
+
+# %%
+# A surface, knot lines on the geometry
+# -------------------------------------
+# For a surface the knot lines become iso-parametric curves lying on the surface.
+disk = create_disk(radius_outer=1.0)
+viz.plot(disk, color="lightsteelblue", show_knot_lines=True)
+
+# %%
+# Scalar fields: colour map vs. elevation
+# ---------------------------------------
+# A rank-1 geometry is a *scalar field* ``f(u, v)``. By default it is drawn as a flat
+# colour map; ``elevation=True`` lifts the value into the third coordinate. Here we
+# build a biquadratic field whose coefficients sample ``sin(pi u) sin(pi v)``.
+space = BsplineSpace([BsplineSpace1D([0, 0, 0, 0.5, 1, 1, 1], 2) for _ in range(2)])
+greville = np.linspace(0.0, 1.0, space.num_basis[0])
+gu, gv = np.meshgrid(greville, greville, indexing="ij")
+coeffs = (np.sin(np.pi * gu) * np.sin(np.pi * gv))[..., np.newaxis]
+field = Bspline(space, coeffs)
+viz.plot(field, elevation=True, show_knot_lines=True)
+
+# %%
+# Composing a scene
+# -----------------
+# :class:`~pantr.viz.Scene` overlays several geometries, each with its own options.
+scene = viz.Scene()
+scene.add(disk, color="wheat", opacity=0.5)
+scene.add(arc, color="crimson", show_control_polygon=True)
+scene.show()
+
+# %%
+# Exporting to VTK
+# ----------------
+# :func:`~pantr.viz.save` writes a ``.vtu`` file that ParaView (>= 5.10) renders with
+# exact Bézier geometry -- handy for publication figures.
+viz.save(disk, "disk.vtu")
+print("wrote disk.vtu")

--- a/demos/01_visualization_basics.py
+++ b/demos/01_visualization_basics.py
@@ -19,7 +19,7 @@ Requires the ``viz`` extra: ``pip install "pantr[viz]"``.
 import numpy as np
 
 from pantr import viz
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, get_greville_abscissae
 from pantr.cad import create_circle, create_disk
 
 # %%
@@ -45,7 +45,7 @@ viz.plot(disk, color="lightsteelblue", show_knot_lines=True)
 # colour map; ``elevation=True`` lifts the value into the third coordinate. Here we
 # build a biquadratic field whose coefficients sample ``sin(pi u) sin(pi v)``.
 space = BsplineSpace([BsplineSpace1D([0, 0, 0, 0.5, 1, 1, 1], 2) for _ in range(2)])
-greville = np.linspace(0.0, 1.0, space.num_basis[0])
+greville = get_greville_abscissae(space.spaces[0])
 gu, gv = np.meshgrid(greville, greville, indexing="ij")
 coeffs = (np.sin(np.pi * gu) * np.sin(np.pi * gv))[..., np.newaxis]
 field = Bspline(space, coeffs)

--- a/demos/02_basis_gallery.py
+++ b/demos/02_basis_gallery.py
@@ -1,0 +1,73 @@
+"""
+Polynomial basis gallery
+=========================
+
+:mod:`pantr.basis` tabulates the common 1-D polynomial bases used to build
+splines and finite-element spaces. This demo plots them at a fixed degree and
+visualizes a change-of-basis matrix from :mod:`pantr.change_basis`.
+
+Each ``tabulate_*_1d`` call returns an ``(n_points, degree + 1)`` array whose
+columns are the individual basis functions sampled at the supplied points.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pantr.basis import (
+    LagrangeVariant,
+    tabulate_bernstein_1d,
+    tabulate_lagrange_1d,
+    tabulate_legendre_1d,
+)
+from pantr.change_basis import compute_bernstein_to_lagrange_1d
+
+DEGREE = 4
+x = np.linspace(0.0, 1.0, 200)
+
+# %%
+# Four bases at degree 4
+# ----------------------
+# Bernstein (non-negative, partition of unity), Lagrange on equispaced nodes
+# (interpolatory -- each function is 1 at its node, 0 at the others), Lagrange on
+# Gauss-Lobatto-Legendre nodes (clustered at the ends, much better conditioned),
+# and the Legendre polynomials (orthogonal on ``[0, 1]``).
+bases = {
+    "Bernstein": tabulate_bernstein_1d(DEGREE, x),
+    "Lagrange (equispaced)": tabulate_lagrange_1d(DEGREE, LagrangeVariant.EQUISPACES, x),
+    "Lagrange (Gauss-Lobatto)": tabulate_lagrange_1d(
+        DEGREE, LagrangeVariant.GAUSS_LOBATTO_LEGENDRE, x
+    ),
+    "Legendre": tabulate_legendre_1d(DEGREE, x),
+}
+
+fig, axes = plt.subplots(2, 2, figsize=(9, 6), constrained_layout=True)
+for ax, (name, table) in zip(axes.ravel(), bases.items(), strict=True):
+    ax.plot(x, table)
+    ax.set_title(name)
+    ax.axhline(0.0, color="0.7", lw=0.8)
+    ax.set_xlabel("x")
+fig.suptitle(f"1-D polynomial bases (degree {DEGREE})")
+plt.show()
+
+# %%
+# Change of basis
+# ---------------
+# :mod:`pantr.change_basis` builds the matrices that convert coefficients between
+# bases. ``compute_bernstein_to_lagrange_1d`` maps Bernstein coefficients to
+# Lagrange (nodal) values: row ``i`` is the Bernstein basis evaluated at node ``i``.
+matrix = np.asarray(compute_bernstein_to_lagrange_1d(DEGREE, LagrangeVariant.EQUISPACES))
+
+fig, ax = plt.subplots(figsize=(5, 4), constrained_layout=True)
+im = ax.imshow(matrix, cmap="RdBu_r", vmin=-abs(matrix).max(), vmax=abs(matrix).max())
+ax.set_title(f"Bernstein → Lagrange (degree {DEGREE})")
+ax.set_xlabel("Bernstein index")
+ax.set_ylabel("Lagrange node")
+fig.colorbar(im, ax=ax)
+plt.show()
+
+# %%
+# Partition of unity
+# ------------------
+# The Bernstein and (B-spline-like) bases sum to one at every point -- the
+# property that makes the convex-hull bound of a control polygon hold.
+print("max |sum of Bernstein - 1| =", float(np.abs(bases["Bernstein"].sum(axis=1) - 1.0).max()))

--- a/demos/02_basis_gallery.py
+++ b/demos/02_basis_gallery.py
@@ -68,6 +68,7 @@ plt.show()
 # %%
 # Partition of unity
 # ------------------
-# The Bernstein and (B-spline-like) bases sum to one at every point -- the
-# property that makes the convex-hull bound of a control polygon hold.
+# The Bernstein basis is non-negative and sums to one at every point -- the
+# property behind the convex-hull bound of a control polygon. (Lagrange bases also
+# sum to one but may be negative; Legendre polynomials do not sum to one.)
 print("max |sum of Bernstein - 1| =", float(np.abs(bases["Bernstein"].sum(axis=1) - 1.0).max()))

--- a/demos/03_bspline_geometry_tour.py
+++ b/demos/03_bspline_geometry_tour.py
@@ -65,7 +65,8 @@ viz.plot(surface, color="lightsteelblue", show_knot_lines=True, show_control_pol
 # An exact circle (NURBS)
 # -----------------------
 # A circle is not a polynomial, but it *is* a rational quadratic. The control
-# polygon is the classic triangle/square fan; the curve is exact to round-off.
+# points alternate between the circle and the corners of the circumscribed
+# square; the curve is exact to round-off.
 circle = create_circle(radius=1.0)
 print("circle is rational:", circle.is_rational)
 viz.plot(circle, color="crimson", show_control_polygon=True)

--- a/demos/03_bspline_geometry_tour.py
+++ b/demos/03_bspline_geometry_tour.py
@@ -1,0 +1,71 @@
+"""
+B-spline geometry tour
+=======================
+
+:class:`~pantr.bspline.Bspline` represents parametric curves, surfaces, and
+volumes (and rational NURBS) from a :class:`~pantr.bspline.BsplineSpace` plus a
+control-point array. This demo evaluates a curve and its derivative, marks the
+Greville abscissae, and renders a surface and an exact NURBS circle.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pantr import viz
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_uniform_space,
+    get_greville_abscissae,
+)
+from pantr.cad import create_circle
+
+# %%
+# A curve, its control polygon, Greville points, and tangents
+# -----------------------------------------------------------
+# The curve passes near (not through) its control points; the Greville abscissae
+# are the natural parameter values "attached" to each control point. The first
+# derivative is itself a B-spline, evaluated here to draw tangent vectors.
+space1d = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+control_points = np.array([[0.0, 0.0], [1.0, 2.0], [2.0, -1.0], [3.0, 1.5], [4.0, 0.0]])
+curve = Bspline(BsplineSpace([space1d]), control_points)
+
+u = np.linspace(0.0, 3.0, 200)
+pts = curve.evaluate(u)
+tangents = np.asarray(curve.derivative(0).evaluate(u))
+greville = get_greville_abscissae(space1d)
+gpts = curve.evaluate(np.asarray(greville, dtype=np.float64))
+
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+ax.plot(control_points[:, 0], control_points[:, 1], "o--", color="0.6", label="control polygon")
+ax.plot(pts[:, 0], pts[:, 1], color="navy", lw=2, label="curve")
+ax.plot(gpts[:, 0], gpts[:, 1], "s", color="crimson", label="Greville points")
+qi = np.linspace(0, len(u) - 1, 12).astype(int)
+ax.quiver(pts[qi, 0], pts[qi, 1], tangents[qi, 0], tangents[qi, 1], color="seagreen", alpha=0.6)
+ax.legend()
+ax.set_aspect("equal")
+ax.set_title("Quadratic B-spline curve with tangents")
+plt.show()
+
+# %%
+# A surface rendered with knot lines and control net
+# ---------------------------------------------------
+# A biquadratic surface over a 3x3 element grid; the control points are lifted by
+# a Gaussian bump. Knot lines show the element boundaries on the surface.
+space = create_uniform_space([2, 2], [3, 3])
+nu, nv = space.num_basis
+gu, gv = np.meshgrid(np.linspace(0, 1, nu), np.linspace(0, 1, nv), indexing="ij")
+bump = np.exp(-(((gu - 0.5) ** 2 + (gv - 0.5) ** 2) / 0.05))
+surface_cp = np.stack([gu, gv, 0.4 * bump], axis=-1)
+surface = Bspline(space, surface_cp)
+viz.plot(surface, color="lightsteelblue", show_knot_lines=True, show_control_polygon=True)
+
+# %%
+# An exact circle (NURBS)
+# -----------------------
+# A circle is not a polynomial, but it *is* a rational quadratic. The control
+# polygon is the classic triangle/square fan; the curve is exact to round-off.
+circle = create_circle(radius=1.0)
+print("circle is rational:", circle.is_rational)
+viz.plot(circle, color="crimson", show_control_polygon=True)

--- a/demos/04_knot_operations.py
+++ b/demos/04_knot_operations.py
@@ -1,0 +1,61 @@
+"""
+Knot operations and Bézier extraction
+======================================
+
+Knot insertion, degree elevation, and splitting all change a B-spline's
+*representation* without changing the curve it describes. This demo shows that
+invariance, then extracts the per-element Bézier pieces -- the representation
+finite-element assembly consumes.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pantr import viz
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+space1d = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+control_points = np.array([[0.0, 0.0], [1.0, 2.0], [2.0, -1.0], [3.0, 1.5], [4.0, 0.0]])
+curve = Bspline(BsplineSpace([space1d]), control_points)
+
+# %%
+# Knot insertion is geometry-preserving
+# -------------------------------------
+# Inserting knots adds control points and shrinks the control polygon toward the
+# curve, but the curve itself is unchanged (to round-off).
+refined = curve.insert_knots([0.5, 1.5, 2.5])
+u = np.linspace(0.0, 3.0, 200)
+err = np.max(np.abs(np.asarray(curve.evaluate(u)) - np.asarray(refined.evaluate(u))))
+print(f"max |curve - refined| after knot insertion = {err:.2e}")
+
+orig_cp = curve.control_points
+new_cp = refined.control_points
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+pts = curve.evaluate(u)
+ax.plot(pts[:, 0], pts[:, 1], color="navy", lw=2, label="curve (unchanged)")
+ax.plot(orig_cp[:, 0], orig_cp[:, 1], "o--", color="0.7", label="original control net")
+ax.plot(new_cp[:, 0], new_cp[:, 1], "s-", color="crimson", alpha=0.6, label="refined control net")
+ax.legend()
+ax.set_aspect("equal")
+ax.set_title("Knot insertion refines the net, not the curve")
+plt.show()
+
+# %%
+# Degree elevation is geometry-preserving too
+# -------------------------------------------
+elevated = curve.elevate_degree(1)  # quadratic -> cubic
+err = np.max(np.abs(np.asarray(curve.evaluate(u)) - np.asarray(elevated.evaluate(u))))
+print(f"degree {curve.degree} -> {elevated.degree}, max |curve - elevated| = {err:.2e}")
+
+# %%
+# Bézier extraction
+# -----------------
+# ``to_beziers`` decomposes the spline into one Bézier curve per knot span. We
+# render the elements in alternating colours -- this is the element-local view
+# used for isogeometric assembly.
+beziers = curve.to_beziers()
+scene = viz.Scene()
+for i, bez in enumerate(beziers.ravel()):
+    scene.add(bez, color=("crimson" if i % 2 else "navy"), show_control_polygon=True)
+scene.show()
+print(f"{beziers.size} Bézier elements")

--- a/demos/04_knot_operations.py
+++ b/demos/04_knot_operations.py
@@ -45,7 +45,7 @@ plt.show()
 # -------------------------------------------
 elevated = curve.elevate_degree(1)  # quadratic -> cubic
 err = np.max(np.abs(np.asarray(curve.evaluate(u)) - np.asarray(elevated.evaluate(u))))
-print(f"degree {curve.degree} -> {elevated.degree}, max |curve - elevated| = {err:.2e}")
+print(f"degree {curve.degree[0]} -> {elevated.degree[0]}, max |curve - elevated| = {err:.2e}")
 
 # %%
 # Bézier extraction

--- a/demos/05_approximation.py
+++ b/demos/05_approximation.py
@@ -1,0 +1,85 @@
+"""
+Approximation: interpolation, fitting, projection, quasi-interpolation
+======================================================================
+
+:mod:`pantr.bspline` offers several ways to approximate a function with a spline:
+:func:`~pantr.bspline.interpolate_bspline` (match the function at the Greville
+points), :func:`~pantr.bspline.l2_project_bspline` (best :math:`L^2` fit), and
+:func:`~pantr.bspline.quasi_interpolate_bspline` (a cheap local projector). This
+demo compares them and shows :math:`L^2` convergence under refinement.
+
+Note the calling conventions: ``interpolate_bspline`` and ``l2_project_bspline``
+call ``func(lattice)`` (a :class:`~pantr.quad.PointsLattice`, use
+``lattice.pts_per_dir``), while ``quasi_interpolate_bspline`` calls
+``func(points)`` with a flat ``(M, dim)`` array.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pantr.bspline import (
+    create_uniform_space,
+    interpolate_bspline,
+    l2_project_bspline,
+    quasi_interpolate_bspline,
+)
+
+
+def g(x):
+    """The 1-D target function on [0, 1]."""
+    return np.exp(np.sin(3.0 * np.pi * np.asarray(x)))
+
+
+# Adapters for the two calling conventions (1-D, so just the first axis).
+def on_lattice(lattice):
+    return g(lattice.pts_per_dir[0])
+
+
+def on_points(points):
+    return g(points[:, 0])
+
+
+# %%
+# Three approximations on the same space
+# --------------------------------------
+space = create_uniform_space([3], [8])  # cubic, 8 elements
+approx = {
+    "interpolation": interpolate_bspline(on_lattice, space),
+    "L2 projection": l2_project_bspline(on_lattice, space),
+    "quasi-interpolation": quasi_interpolate_bspline(on_points, space),
+}
+
+x = np.linspace(0.0, 1.0, 400)
+fx = g(x)
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+ax.plot(x, fx, "k", lw=2, label="target")
+for name, spline in approx.items():
+    ax.plot(x, np.asarray(spline.evaluate(x)).reshape(-1), "--", label=name)
+ax.legend()
+ax.set_title("Cubic approximations of exp(sin 3πx)")
+plt.show()
+
+
+# %%
+# L2 convergence under refinement
+# -------------------------------
+# Refining the mesh drives the L2 projection error down at the optimal rate for
+# the degree. We estimate the error by dense sampling.
+def l2_error(spline):
+    vals = np.asarray(spline.evaluate(x)).reshape(-1)
+    return float(np.sqrt(np.trapezoid((vals - fx) ** 2, x)))
+
+
+n_elements = [4, 8, 16, 32, 64]
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+for p in (2, 3, 4):
+    errors = [
+        l2_error(l2_project_bspline(on_lattice, create_uniform_space([p], [n]))) for n in n_elements
+    ]
+    ax.loglog(n_elements, errors, "o-", label=f"degree {p}")
+ax.set_xlabel("elements")
+ax.set_ylabel("L2 error")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+ax.set_title("L2 projection convergence")
+plt.show()

--- a/demos/05_approximation.py
+++ b/demos/05_approximation.py
@@ -4,7 +4,7 @@ Approximation: interpolation, fitting, projection, quasi-interpolation
 
 :mod:`pantr.bspline` offers several ways to approximate a function with a spline:
 :func:`~pantr.bspline.interpolate_bspline` (match the function at the Greville
-points), :func:`~pantr.bspline.l2_project_bspline` (best :math:`L^2` fit), and
+points by default), :func:`~pantr.bspline.l2_project_bspline` (best :math:`L^2` fit), and
 :func:`~pantr.bspline.quasi_interpolate_bspline` (a cheap local projector). This
 demo compares them and shows :math:`L^2` convergence under refinement.
 

--- a/demos/06_cad_modeling.py
+++ b/demos/06_cad_modeling.py
@@ -1,0 +1,56 @@
+"""
+Constructive CAD modeling
+=========================
+
+:mod:`pantr.cad` builds B-spline geometry the way a CAD kernel does: primitives
+(lines, circles, disks, cylinders) combined by operations (extrude, revolve,
+ruled surfaces, sweeps, Coons patches) and assembled with ``join``. This demo
+builds a few shapes and lays them out in one scene.
+"""
+
+from pantr import viz
+from pantr.cad import create_circle, create_cylinder, create_line, create_ruled, extrude, revolve
+from pantr.transform import AffineTransform
+
+# %%
+# Primitives
+# ----------
+# A cylinder is a rational surface; rendering uses exact Bézier cells.
+cylinder = create_cylinder(radius=0.5, height=1.5)
+viz.plot(cylinder, color="lightsteelblue", show_knot_lines=True)
+
+# %%
+# Extrude: sweep a profile along a vector
+# ---------------------------------------
+# Extruding a circle along +z produces a tube wall.
+tube = extrude(create_circle(radius=0.5), displacement=[0.0, 0.0, 1.2])
+viz.plot(tube, color="wheat", show_knot_lines=True)
+
+# %%
+# Revolve: spin a profile about an axis
+# -------------------------------------
+# Revolving a slanted line about the z-axis gives a cone-like surface of revolution.
+profile = create_line(p0=[0.2, 0.0, 0.0], p1=[0.6, 0.0, 1.0])
+surface_of_revolution = revolve(profile, point=[0.0, 0.0, 0.0], axis=2)
+viz.plot(surface_of_revolution, color="thistle", show_knot_lines=True)
+
+# %%
+# Ruled surface between two curves
+# --------------------------------
+# A ruled surface linearly interpolates between two curves -- here two circles of
+# different radius at different heights, giving a conical frustum.
+bottom = create_circle(radius=0.7, center=[0.0, 0.0, 0.0])
+top = create_circle(radius=0.3, center=[0.0, 0.0, 1.0])
+frustum = create_ruled(bottom, top)
+viz.plot(frustum, color="lightgreen", show_knot_lines=True)
+
+# %%
+# An assembled scene
+# ------------------
+# Lay the shapes side by side by translating each (see the transforms demo) and
+# adding them to one :class:`~pantr.viz.Scene`.
+scene = viz.Scene()
+for i, geom in enumerate([cylinder, tube, surface_of_revolution, frustum]):
+    placed = geom.transform(AffineTransform.translation([2.0 * i, 0.0, 0.0]))
+    scene.add(placed, show_knot_lines=True)
+scene.show()

--- a/demos/07_bezier_and_roots.py
+++ b/demos/07_bezier_and_roots.py
@@ -1,0 +1,66 @@
+"""
+Bézier geometry and Bernstein root finding
+===========================================
+
+:class:`~pantr.bezier.Bezier` stores a single polynomial patch in Bernstein form;
+its degree comes from the control-point shape. :func:`~pantr.bezier.find_roots`
+robustly finds all roots of a scalar 1-D Bézier in ``[0, 1]`` via Bézier
+clipping. This demo renders a Bézier surface and locates roots / intersections.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pantr import viz
+from pantr.bezier import Bezier, find_roots
+
+# %%
+# A Bézier surface
+# ----------------
+# A biquadratic patch defined by its 3x3 control net.
+cp = np.zeros((3, 3, 3))
+for i in range(3):
+    for j in range(3):
+        cp[i, j] = [0.5 * i, 0.5 * j, np.sin(np.pi * i / 2) * np.sin(np.pi * j / 2)]
+surface = Bezier(cp)
+viz.plot(surface, color="lightsteelblue", show_control_polygon=True)
+
+# %%
+# Roots of a Bernstein polynomial
+# -------------------------------
+# Build a scalar (rank-1) Bézier whose graph wiggles across zero, then locate
+# every root in ``[0, 1]``. ``find_roots`` returns them sorted.
+poly = Bezier(np.array([1.0, -3.0, 2.5, -2.0, 1.5])[:, np.newaxis])  # degree-4 scalar
+roots = find_roots(poly)
+
+t = np.linspace(0.0, 1.0, 300)
+vals = np.asarray(poly.evaluate(t)).reshape(-1)
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+ax.axhline(0.0, color="0.7")
+ax.plot(t, vals, color="navy", lw=2, label="Bernstein polynomial")
+ax.plot(roots, np.zeros_like(roots), "o", color="crimson", ms=9, label="roots")
+ax.legend()
+ax.set_xlabel("t")
+ax.set_title(f"Bézier clipping found {len(roots)} roots in [0, 1]")
+plt.show()
+print("roots:", np.round(roots, 6))
+
+# %%
+# Curve--line intersection via roots
+# ----------------------------------
+# Intersecting a Bézier curve ``C(t)`` with the line ``y = y0`` reduces to finding
+# the roots of the scalar polynomial ``C_y(t) - y0`` -- itself a Bézier.
+curve = Bezier(np.array([[0.0, 0.0], [0.3, 1.5], [0.7, -1.0], [1.0, 0.8]]))
+y0 = 0.4
+cp_y = curve.control_points[:, 1] - y0
+hits_t = find_roots(Bezier(cp_y[:, np.newaxis]))
+hits = np.asarray(curve.evaluate(hits_t))
+
+cvals = np.asarray(curve.evaluate(t))
+fig, ax = plt.subplots(figsize=(7, 4), constrained_layout=True)
+ax.plot(cvals[:, 0], cvals[:, 1], color="navy", lw=2, label="curve")
+ax.axhline(y0, color="seagreen", ls="--", label=f"y = {y0}")
+ax.plot(hits[:, 0], hits[:, 1], "o", color="crimson", ms=9, label="intersections")
+ax.legend()
+ax.set_title("Curve-line intersection as polynomial roots")
+plt.show()

--- a/demos/07_bezier_and_roots.py
+++ b/demos/07_bezier_and_roots.py
@@ -4,8 +4,9 @@ Bézier geometry and Bernstein root finding
 
 :class:`~pantr.bezier.Bezier` stores a single polynomial patch in Bernstein form;
 its degree comes from the control-point shape. :func:`~pantr.bezier.find_roots`
-robustly finds all roots of a scalar 1-D Bézier in ``[0, 1]`` via Bézier
-clipping. This demo renders a Bézier surface and locates roots / intersections.
+robustly finds all roots of a scalar 1-D Bézier in ``[0, 1]``, selecting its
+algorithm automatically (Bézier clipping at high degree, an exact derivative-based
+solver at low degree). This demo renders a Bézier surface and locates roots.
 """
 
 import matplotlib.pyplot as plt
@@ -41,7 +42,7 @@ ax.plot(t, vals, color="navy", lw=2, label="Bernstein polynomial")
 ax.plot(roots, np.zeros_like(roots), "o", color="crimson", ms=9, label="roots")
 ax.legend()
 ax.set_xlabel("t")
-ax.set_title(f"Bézier clipping found {len(roots)} roots in [0, 1]")
+ax.set_title(f"find_roots located {len(roots)} roots in [0, 1]")
 plt.show()
 print("roots:", np.round(roots, 6))
 

--- a/demos/08_thb_adaptive_refinement.py
+++ b/demos/08_thb_adaptive_refinement.py
@@ -1,0 +1,54 @@
+"""
+THB-splines: adaptive local refinement
+=======================================
+
+Truncated hierarchical B-splines (THB-splines) add resolution only where it is
+needed, keeping coarse basis functions elsewhere. This demo refines toward a
+localized feature, quasi-interpolates a peaked function onto the hierarchical
+space, and renders the field with its hierarchical mesh and per-level control
+net (see :mod:`pantr.viz`).
+"""
+
+import numpy as np
+
+from pantr import viz
+from pantr.bspline import THBSplineSpace, create_uniform_space, quasi_interpolate_thb_spline
+from pantr.grid import hierarchical_grid, uniform_grid
+
+# %%
+# Build a graded hierarchical space
+# ---------------------------------
+# Start from a biquadratic 8x8 grid and refine the lower-left block twice, so
+# fine cells cluster where a peak will sit.
+root = create_uniform_space([2, 2], [8, 8])
+grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 8), 2)
+grid.refine(0, [0, 0], [4, 4])  # level 0 -> 1 on the lower-left quarter
+grid.refine(1, [0, 0], [4, 4])  # level 1 -> 2 on the lower-left of that
+space = THBSplineSpace(root, grid)
+print(f"{space.num_levels} levels, {space.num_total_basis} active functions")
+
+
+# %%
+# Quasi-interpolate a peaked field
+# --------------------------------
+def peak(pts):
+    """A sharp Gaussian bump centred in the refined corner."""
+    x, y = pts[:, 0], pts[:, 1]
+    return np.exp(-(((x - 0.25) ** 2 + (y - 0.25) ** 2) / 0.004))
+
+
+field = quasi_interpolate_thb_spline(peak, space)
+
+# %%
+# Render the field, hierarchical mesh, and per-level control net
+# --------------------------------------------------------------
+# ``elevation=True`` lifts the scalar field into a surface; the knot lines are the
+# active-cell boundaries (denser in the refined corner); the control net is drawn
+# per level, coloured by level.
+viz.plot(field, elevation=True, show_knot_lines=True, show_control_polygon=True)
+
+# %%
+# Just the hierarchical mesh
+# --------------------------
+# The active cells alone make the octree-like refinement structure obvious.
+viz.plot(field, elevation=True, show_knot_lines=True, color="lightsteelblue")

--- a/demos/08_thb_adaptive_refinement.py
+++ b/demos/08_thb_adaptive_refinement.py
@@ -3,10 +3,12 @@ THB-splines: adaptive local refinement
 =======================================
 
 Truncated hierarchical B-splines (THB-splines) add resolution only where it is
-needed, keeping coarse basis functions elsewhere. This demo refines toward a
-localized feature, quasi-interpolates a peaked function onto the hierarchical
-space, and renders the field with its hierarchical mesh and per-level control
-net (see :mod:`pantr.viz`).
+needed, keeping coarse basis functions elsewhere. Refinement leaves the
+coefficients of functions that stay active at coarser levels unchanged
+(truncation preserves coefficients). This demo refines toward a localized
+feature, quasi-interpolates a peaked function onto the hierarchical space, and
+renders the field with its hierarchical mesh and per-level control net (see
+:mod:`pantr.viz`).
 """
 
 import numpy as np

--- a/demos/09_grids_and_quadrature.py
+++ b/demos/09_grids_and_quadrature.py
@@ -50,7 +50,7 @@ print(f"{len(hit_cells)} cells overlap {window.lo}-{window.hi}")
 # index just to show the per-cell data channel.
 ug = viz.grid_to_pyvista(grid)
 ug.cell_data["cell_id"] = np.arange(grid.num_cells)
-ug.plot(scalars="cell_id", show_edges=True, cpos="xy", off_screen=True)
+ug.plot(scalars="cell_id", show_edges=True, cpos="xy")
 
 # %%
 # A hierarchical grid
@@ -59,4 +59,4 @@ ug.plot(scalars="cell_id", show_edges=True, cpos="xy", off_screen=True)
 # the multi-level structure directly.
 hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
 hgrid.refine(0, [0, 0], [2, 2])
-viz.grid_to_pyvista(hgrid).plot(show_edges=True, cpos="xy", off_screen=True)
+viz.grid_to_pyvista(hgrid).plot(show_edges=True, cpos="xy")

--- a/demos/09_grids_and_quadrature.py
+++ b/demos/09_grids_and_quadrature.py
@@ -1,0 +1,62 @@
+"""
+Grids and quadrature
+=====================
+
+:mod:`pantr.grid` provides structured cell grids with implicit connectivity, a
+lazy BVH spatial index, and named cell/facet tags. :mod:`pantr.quad` supplies
+quadrature rules that :func:`~pantr.grid.cell_quadrature` maps onto a grid's
+cells. This demo integrates a function, queries the grid spatially, and renders
+both a tensor-product and a hierarchical grid.
+"""
+
+import numpy as np
+
+from pantr import viz
+from pantr.geometry import AABB
+from pantr.grid import cell_quadrature, hierarchical_grid, uniform_grid
+from pantr.quad import gauss_legendre_quadrature
+
+# %%
+# Integrate a function over a grid
+# --------------------------------
+# Map a 3-point Gauss-Legendre tensor rule onto every cell, then sum ``w * f`` over
+# all cells and quadrature points. The result matches the analytic integral.
+grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], 16)
+rule = gauss_legendre_quadrature(2, 3)
+points, weights = cell_quadrature(grid, rule)
+
+
+def f(xy):
+    return np.sin(np.pi * xy[..., 0]) * np.sin(np.pi * xy[..., 1])
+
+
+integral = float(np.sum(weights * f(points)))
+exact = (2.0 / np.pi) ** 2
+print(f"∫∫ sin(πx)sin(πy) = {integral:.6f}  (exact {exact:.6f})")
+
+# %%
+# Spatial query with the BVH
+# --------------------------
+# ``query_aabb`` returns the cells overlapping a box, backed by a lazily-built
+# bounding-volume hierarchy. Here we find the cells touching a small window.
+window = AABB(lo=[0.2, 0.2], hi=[0.35, 0.35])
+hit_cells = grid.query_aabb(window)
+print(f"{len(hit_cells)} cells overlap {window.lo}-{window.hi}")
+
+# %%
+# Render a tensor-product grid
+# ----------------------------
+# ``grid_to_pyvista`` turns any grid into a mesh; we colour cells by their column
+# index just to show the per-cell data channel.
+ug = viz.grid_to_pyvista(grid)
+ug.cell_data["cell_id"] = np.arange(grid.num_cells)
+ug.plot(scalars="cell_id", show_edges=True, cpos="xy", off_screen=True)
+
+# %%
+# A hierarchical grid
+# -------------------
+# The same export works for a refined hierarchical grid -- the active cells show
+# the multi-level structure directly.
+hgrid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 4), 2)
+hgrid.refine(0, [0, 0], [2, 2])
+viz.grid_to_pyvista(hgrid).plot(show_edges=True, cpos="xy", off_screen=True)

--- a/demos/10_transforms.py
+++ b/demos/10_transforms.py
@@ -1,0 +1,54 @@
+"""
+Affine transformations
+=======================
+
+:class:`~pantr.transform.AffineTransform` represents an affine map ``T(x) = A x + b``
+with factory methods for translation, scaling, rotation, mirroring, and shear.
+Transforms compose with ``@`` and apply to any geometry via ``geom.transform(T)``
+(operating on control points, so the result is exact). This demo builds a few
+transforms and applies them to a single base shape.
+"""
+
+import numpy as np
+
+from pantr import viz
+from pantr.cad import create_cylinder
+from pantr.transform import AffineTransform
+
+base = create_cylinder(radius=0.4, height=1.0)
+
+# %%
+# Individual transforms
+# ---------------------
+# Each transform produces a new, independent geometry; the original is untouched.
+rotated = base.transform(AffineTransform.rotation_3d(np.pi / 4, axis=0))  # tilt about x
+scaled = base.transform(AffineTransform.scaling([1.0, 1.0, 1.6]))  # stretch in z
+sheared = base.transform(AffineTransform.shear(dim=3, component=0, direction=2, factor=0.5))
+
+scene = viz.Scene()
+for i, geom in enumerate([base, rotated, scaled, sheared]):
+    placed = geom.transform(AffineTransform.translation([1.5 * i, 0.0, 0.0]))
+    scene.add(placed, color="lightsteelblue", show_knot_lines=True)
+scene.show()
+
+# %%
+# Composing transforms
+# --------------------
+# ``@`` composes transforms right-to-left, exactly like matrix multiplication:
+# ``(T2 @ T1)(x) == T2(T1(x))``. Here we rotate, then scale, then translate.
+combined = (
+    AffineTransform.translation([0.0, 0.0, 0.5])
+    @ AffineTransform.scaling([1.3, 1.3, 1.3])
+    @ AffineTransform.rotation_3d(np.pi / 3, axis=1)
+)
+viz.plot(base.transform(combined), color="thistle", show_knot_lines=True)
+
+# %%
+# Composition equals sequential application
+# -----------------------------------------
+t1 = AffineTransform.rotation_3d(0.7, axis=2)
+t2 = AffineTransform.translation([1.0, -0.5, 0.2])
+once = base.transform(t2 @ t1)
+twice = base.transform(t1).transform(t2)
+err = float(np.max(np.abs(once.control_points - twice.control_points)))
+print(f"max |(t2@t1) - t2∘t1| on control points = {err:.2e}")

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,32 @@
+# PaNTr demos
+
+Standalone, runnable scripts that illustrate the main features of PaNTr. Each is
+also a [Sphinx-Gallery](https://sphinx-gallery.github.io) source (reST header +
+``# %%`` cells), so the documentation build renders them as an interactive
+gallery — but they run on their own too:
+
+```bash
+pip install "pantr[viz]"            # the 3-D demos need the viz extra
+python demos/01_visualization_basics.py
+```
+
+The 3-D demos open an interactive PyVista window. The plotting demos use Numba
+kernels; if you hit a Numba background-warmup threading error on a fresh process,
+run with JIT disabled (the documentation build does this automatically):
+
+```bash
+NUMBA_DISABLE_JIT=1 python demos/05_approximation.py
+```
+
+| Demo | Shows | Modules |
+|---|---|---|
+| `01_visualization_basics` | `plot`/`Scene`, control polygon, knot lines, scalar fields, VTK export | `viz` |
+| `02_basis_gallery` | Bernstein / Lagrange / Legendre bases; change-of-basis matrix | `basis`, `change_basis` |
+| `03_bspline_geometry_tour` | curves/surfaces, derivatives, Greville points, NURBS circle | `bspline`, `cad` |
+| `04_knot_operations` | knot insertion, degree elevation, Bézier extraction | `bspline` |
+| `05_approximation` | interpolation / L2 projection / quasi-interpolation; convergence | `bspline` |
+| `06_cad_modeling` | primitives + extrude / revolve / ruled; assembly | `cad`, `transform` |
+| `07_bezier_and_roots` | Bézier surface; Bernstein root finding; curve–line intersection | `bezier` |
+| `08_thb_adaptive_refinement` | THB local refinement; hierarchical mesh + per-level control net | `bspline`, `grid`, `viz` |
+| `09_grids_and_quadrature` | grids, `cell_quadrature` integration, BVH query, grid rendering | `grid`, `quad`, `geometry` |
+| `10_transforms` | affine translation / rotation / scaling / shear; composition | `transform` |

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,3 +38,8 @@ convention = "google"
   "PLR2004",
 ]
 "docs/**/*.py" = ["D100", "D101", "D102", "D103", "D104", "D105"]
+# Demos are standalone teaching scripts (sphinx-gallery sources): keep real checks
+# (imports, bugs, numpy) but drop library-grade docstring/annotation/magic-value rules.
+# D205/D212/D415 are dropped because a gallery script's module docstring is a reST
+# title block ("Title\n=====\n\n..."), not a one-line-summary API docstring.
+"demos/**/*.py" = ["D101", "D102", "D103", "D105", "D205", "D212", "D415", "ANN", "PLR2004"]


### PR DESCRIPTION
## Summary

PR2 of the demos initiative: ten standalone, runnable scripts under `demos/` illustrating the main features of PaNTr. Each is **sphinx-gallery-compatible** (reST title header + `# %%` cells) so PR3 can render them as an interactive docs gallery with zero rework — but they all run on their own (`python demos/NN_*.py`).

- `01_visualization_basics` — `plot`/`Scene`, control polygon, knot lines, scalar fields, VTK export
- `02_basis_gallery` — Bernstein / Lagrange / Legendre bases + change-of-basis heatmap
- `03_bspline_geometry_tour` — curves/surfaces, derivatives, Greville points, NURBS circle
- `04_knot_operations` — knot insertion, degree elevation, Bézier extraction (geometry-invariant)
- `05_approximation` — interpolation / L2 projection / quasi-interpolation + L2 convergence
- `06_cad_modeling` — primitives + extrude / revolve / ruled, assembled scene
- `07_bezier_and_roots` — Bézier surface; Bernstein root finding; curve–line intersection
- `08_thb_adaptive_refinement` — THB local refinement; hierarchical mesh + per-level control net
- `09_grids_and_quadrature` — grids, `cell_quadrature` integration, BVH query, grid rendering
- `10_transforms` — affine translation / rotation / scaling / shear; composition

Also adds a `demos/**` ruff per-file-ignore (keeps real checks — imports, bugs, numpy — but drops library-grade docstring/annotation/magic-value rules that fight teaching style). **No library code changes.**

## Stacking
Targets **`feat/thb-viz` (#216)**, not `main`: demo 08 and the surface renders use that branch's THB visualization and mixed-degree elevation fix. Retarget to `main` once #216 merges.

## Test plan
- [x] All 10 demos run headless with JIT disabled (how the gallery executes them): zero errors, zero VTK warnings.
- [x] `ruff check .` and `ruff format --check .` clean across the repo.
- [x] No library code touched, so the existing suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)