### PR TITLE
fix(bspline): correct Bézier extraction for repeated interior knots

### DIFF
--- a/src/pantr/bspline/_bspline_to_beziers.py
+++ b/src/pantr/bspline/_bspline_to_beziers.py
@@ -26,12 +26,13 @@ from .._numba_compat import nb_jit, nb_prange
 from .spanwise_element_extraction import SpanwiseElementExtraction
 
 if TYPE_CHECKING:
-    from . import Bspline
+    from . import Bspline, BsplineSpace1D
 
 
 @nb_jit(nopython=True, cache=True, parallel=True)
 def _apply_bezier_extraction_1d_core(
     extraction_ops: npt.NDArray[Any],
+    first_basis: npt.NDArray[Any],
     ctrl: npt.NDArray[Any],
     out: npt.NDArray[Any],
 ) -> None:
@@ -39,11 +40,19 @@ def _apply_bezier_extraction_1d_core(
 
     For each element ``i``, computes the Bezier control points as
     ``C_i^T @ P_local`` where ``C_i`` is the extraction operator and
-    ``P_local = ctrl[i : i + order, :]`` are the local B-spline control points.
+    ``P_local = ctrl[first_basis[i] : first_basis[i] + order, :]`` are the local
+    B-spline control points — the ``order`` functions supported on element ``i``.
+
+    ``first_basis[i]`` (rather than ``i``) is required because the index of the
+    first function supported on an element equals the element index only when all
+    interior knots have multiplicity 1; with repeated interior knots the support
+    index advances faster than the element index.
 
     Args:
         extraction_ops (npt.NDArray[Any]): Bezier extraction operators of shape
             ``(n_elements, order, order)`` where ``order = degree + 1``.
+        first_basis (npt.NDArray[Any]): Index of the first B-spline function
+            supported on each element, shape ``(n_elements,)``.
         ctrl (npt.NDArray[Any]): B-spline control points of shape
             ``(n_basis, M)`` where ``M`` is the flattened trailing dimension.
             Must be C-contiguous.
@@ -61,12 +70,40 @@ def _apply_bezier_extraction_1d_core(
     for elem in nb_prange(n_elements):
         c_t = extraction_ops[elem].T
         out_start = elem * order
+        base = first_basis[elem]
         for i in range(order):
             for j in range(m):
                 val = c_t.dtype.type(0.0)
                 for k in range(order):
-                    val += c_t[i, k] * ctrl[elem + k, j]
+                    val += c_t[i, k] * ctrl[base + k, j]
                 out[out_start + i, j] = val
+
+
+def _first_basis_per_element(space_1d: BsplineSpace1D) -> npt.NDArray[np.intp]:
+    """Index of the first B-spline function supported on each element.
+
+    Computed by evaluating :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis`
+    at interval midpoints; its second return value is the index of the first
+    non-zero basis function at each point, which is exactly the per-element
+    support offset and is robust to knot multiplicities. For multiplicity-1
+    interior knots this is ``[0, 1, ..., n_elements - 1]``; each interior knot of
+    multiplicity ``> 1`` consumes an extra basis function, so the offset jumps by
+    more than 1 across that knot (``first_basis[i] >= i``, strict once any
+    preceding interior knot is repeated).
+
+    Args:
+        space_1d (BsplineSpace1D): A 1D B-spline space.
+
+    Returns:
+        npt.NDArray[np.intp]: First supported function index per element, shape
+        ``(num_intervals,)``.
+    """
+    unique_knots, _ = space_1d.get_unique_knots_and_multiplicity(in_domain=True)
+    unique_knots = np.asarray(unique_knots, dtype=np.float64)
+    midpoints = 0.5 * (unique_knots[:-1] + unique_knots[1:])
+    # Midpoints are interior to the domain by construction; skip the bounds check.
+    _, first_basis = space_1d.tabulate_basis(midpoints, validate=False)
+    return np.ascontiguousarray(first_basis, dtype=np.intp)
 
 
 def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
@@ -107,12 +144,13 @@ def _to_beziers_impl(bspline: Bspline) -> npt.NDArray[np.object_]:
         extraction_ops = extraction.ops_1d[d]
         n_el = num_intervals[d]
         order = degrees[d] + 1
+        first_basis = _first_basis_per_element(bspline.space.spaces[d])
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
 
         # Apply extraction: (n_basis, M) -> (n_el * order, M).
         out_2d = np.empty((n_el * order, pts_2d.shape[1]), dtype=pts_2d.dtype)
-        _apply_bezier_extraction_1d_core(extraction_ops, pts_2d, out_2d)
+        _apply_bezier_extraction_1d_core(extraction_ops, first_basis, pts_2d, out_2d)
 
         ctrl = _unflatten_along_axis(out_2d, trailing_shape, d)
 
@@ -149,9 +187,10 @@ def _warmup_numba_functions() -> None:
     with float64 arrays, ensuring they are cached and ready for use.
     """
     extraction_ops = np.eye(3, dtype=np.float64).reshape(1, 3, 3)
+    first_basis = np.zeros(1, dtype=np.intp)
     ctrl = np.zeros((3, 2), dtype=np.float64)
     out = np.zeros((3, 2), dtype=np.float64)
-    _apply_bezier_extraction_1d_core(extraction_ops, ctrl, out)
+    _apply_bezier_extraction_1d_core(extraction_ops, first_basis, ctrl, out)
 
 
 __all__ = [

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -15,6 +15,7 @@ from pantr.bspline import (
     create_uniform_periodic_knots,
 )
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
+from pantr.bspline._bspline_to_beziers import _first_basis_per_element
 from pantr.bspline.spanwise_element_extraction import SpanwiseElementExtraction
 
 # ---------------------------------------------------------------------------
@@ -888,7 +889,10 @@ class TestToBeziersSpanwiseParity:
         beziers[idx].control_points.reshape(N, rank) == M.T @ ctrl_local.reshape(N, rank)
 
     where ``M = extraction.operator(idx) = kron(C_0[i0], ..., C_{d-1}[i_{d-1}])`` and
-    ``ctrl_local = ctrl[i0:i0+order_0, ..., i_{d-1}:i_{d-1}+order_{d-1}, :]``.
+    ``ctrl_local`` is the support window of element ``idx`` — the ``order_d``
+    functions supported on the element per direction, starting at
+    ``first_basis_d[i_d]`` (the index of the first supported function, which only
+    equals ``i_d`` for multiplicity-1 interior knots).
 
     The ``.T`` arises because ``_apply_bezier_extraction_1d_core`` computes
     ``C_i^T @ P_local`` (column-convention operators matching the kernel at
@@ -923,8 +927,12 @@ class TestToBeziersSpanwiseParity:
             # Degree-3 space: exercises order=4 in the Numba kernel and higher-degree
             # extraction operators with non-trivial entries.
             ([BsplineSpace1D([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], 3)], 50),
+            # Repeated interior knots (multiplicity 2): the support offset advances
+            # faster than the element index, so this fails if ctrl_local is gathered
+            # by element index instead of first-supported-function index.
+            ([BsplineSpace1D([0.0, 0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.0], 2)], 60),
         ],
-        ids=["1d", "2d", "3d", "1d_single", "1d_deg3"],
+        ids=["1d", "2d", "3d", "1d_single", "1d_deg3", "1d_mult2"],
     )
     def test_element_cp_matches_operator_transpose(
         self, spaces: list[BsplineSpace1D], rng_seed: int
@@ -939,11 +947,15 @@ class TestToBeziersSpanwiseParity:
         extraction = SpanwiseElementExtraction(space, target="bezier")
         degrees = bs.degree
         orders = tuple(p + 1 for p in degrees)
+        first_basis_per_dir = [_first_basis_per_element(sp) for sp in space.spaces]
 
         for idx in np.ndindex(*space.num_intervals):
-            # Gather local B-spline control points for this element.
+            # Gather the support window: the order_d functions supported on this
+            # element per direction, starting at the first supported function
+            # (== element index only for multiplicity-1 interior knots).
             slices: tuple[slice | int, ...] = tuple(
-                slice(i, i + orders[d]) for d, i in enumerate(idx)
+                slice(start := int(first_basis_per_dir[d][i]), start + orders[d])
+                for d, i in enumerate(idx)
             )
             ctrl_local = bs.control_points[(*slices, slice(None))]
             n_in = int(np.prod(orders))

--- a/tests/test_to_beziers_multiplicity.py
+++ b/tests/test_to_beziers_multiplicity.py
@@ -1,0 +1,312 @@
+"""Correctness of :meth:`Bspline.to_beziers` across knot multiplicities.
+
+The governing property is **exact reproduction**: each Bézier patch, evaluated
+over its local ``[0, 1]^d``, must equal the parent B-spline evaluated over the
+corresponding knot span. The historical bug selected each element's local
+control points by element index (valid only for multiplicity-1 interior knots),
+so B-splines with repeated interior knots (multiplicity ``>= 2`` — as used by
+NURBS circles/disks) produced geometrically wrong patches.
+
+The suite exercises that property across degree, interior-knot multiplicity
+(including mixed and per-direction), dimension, rank, and rational/non-rational,
+and pins it down with evaluate-independent analytic oracles (the radius of a
+NURBS circle, hand-computed control points of a straight line) so a shared bug
+in ``evaluate`` cannot mask a bug in the extraction.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import Bezier
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_uniform_periodic_knots,
+)
+from pantr.cad import create_circle
+
+# ---------------------------------------------------------------------------
+# Builders and helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_knots(degree: int, n_elem: int, interior_mult: int = 1) -> list[float]:
+    """Open (clamped) knot vector with uniform interior multiplicity.
+
+    Interior knots ``1 .. n_elem-1`` each appear ``interior_mult`` times
+    (``1 <= interior_mult <= degree``).
+    """
+    knots = [0.0] * (degree + 1)
+    for i in range(1, n_elem):
+        knots += [float(i)] * interior_mult
+    knots += [float(n_elem)] * (degree + 1)
+    return knots
+
+
+def _make_bspline(  # noqa: PLR0913 -- distinct structural knobs, all needed
+    degrees: tuple[int, ...],
+    mults: tuple[int, ...],
+    n_elems: tuple[int, ...],
+    *,
+    rank: int,
+    rational: bool,
+    seed: int = 0,
+) -> Bspline:
+    """Build a tensor-product B-spline with the given per-direction structure.
+
+    Control points are deterministic pseudo-random; for rational splines the
+    last coordinate is a strictly-positive weight column.
+    """
+    spaces = [
+        BsplineSpace1D(_open_knots(p, n, m), p)
+        for p, m, n in zip(degrees, mults, n_elems, strict=True)
+    ]
+    space = BsplineSpace(spaces)
+    n_basis = space.num_basis  # tuple
+    n_coords = rank + 1 if rational else rank
+    rng = np.random.default_rng(seed)
+    cp = rng.standard_normal((*n_basis, n_coords))
+    if rational:
+        cp[..., -1] = rng.uniform(0.5, 1.5, size=n_basis)  # positive weights
+    return Bspline(space, cp, is_rational=rational)
+
+
+def _domain_knots(sp1d: BsplineSpace1D) -> npt.NDArray[np.float64]:
+    uk, _ = sp1d.get_unique_knots_and_multiplicity(in_domain=True)
+    return np.asarray(uk, dtype=np.float64)
+
+
+def _sample_local(dim: int, k: int = 4) -> npt.NDArray[np.float64]:
+    """Tensor grid of *interior* local samples in ``[0, 1]^dim``, shape ``(n, dim)``."""
+    s = np.linspace(0.13, 0.87, k)
+    grids = np.meshgrid(*([s] * dim), indexing="ij")
+    return np.stack([g.ravel() for g in grids], axis=-1)
+
+
+def _ev(obj: Bspline | Bezier, pts_nd: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Evaluate a Bspline/Bezier at ``(n, dim)`` points, handling the 1D signature."""
+    if obj.dim == 1:
+        return np.asarray(obj.evaluate(pts_nd[:, 0]))
+    return np.asarray(obj.evaluate(pts_nd))
+
+
+def assert_reproduces(bsp: Bspline, *, atol: float = 1e-10) -> None:
+    """Assert every Bézier patch reproduces the parent over its element span."""
+    beziers = bsp.to_beziers()
+    uks = [_domain_knots(sp) for sp in bsp.space.spaces]
+    dim = bsp.dim
+    loc = _sample_local(dim)
+    for idx in np.ndindex(*bsp.space.num_intervals):
+        patch = cast(Bezier, beziers[idx])
+        glob = np.empty_like(loc)
+        for d in range(dim):
+            t0, t1 = uks[d][idx[d]], uks[d][idx[d] + 1]
+            glob[:, d] = t0 + loc[:, d] * (t1 - t0)
+        pp = _ev(patch, loc)
+        pg = _ev(bsp, glob)
+        np.testing.assert_allclose(
+            pp, pg, atol=atol, rtol=0.0, err_msg=f"patch {idx} does not reproduce parent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. Exact-reproduction property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("degree", [1, 2, 3])
+@pytest.mark.parametrize("rational", [False, True])
+@pytest.mark.parametrize("rank", [2, 3])
+def test_reproduction_1d(degree: int, rational: bool, rank: int) -> None:
+    for mult in range(1, degree + 1):  # multiplicity 1 .. degree (C^{p-1} .. C^0)
+        bsp = _make_bspline((degree,), (mult,), (4,), rank=rank, rational=rational)
+        assert_reproduces(bsp)
+
+
+@pytest.mark.parametrize(
+    ("degrees", "mults", "n_elems"),
+    [
+        ((2, 2), (1, 1), (3, 3)),
+        ((2, 2), (2, 1), (3, 3)),  # repeated knots in u only
+        ((2, 2), (1, 2), (3, 3)),  # repeated knots in v only
+        ((2, 2), (2, 2), (3, 3)),  # repeated in both
+        ((3, 1), (2, 1), (4, 3)),  # anisotropic degree + repeated u
+        ((2, 3), (2, 3), (3, 3)),  # different multiplicity per direction
+    ],
+)
+@pytest.mark.parametrize("rational", [False, True])
+def test_reproduction_2d(
+    degrees: tuple[int, int], mults: tuple[int, int], n_elems: tuple[int, int], rational: bool
+) -> None:
+    bsp = _make_bspline(degrees, mults, n_elems, rank=3, rational=rational)
+    assert_reproduces(bsp)
+
+
+@pytest.mark.parametrize(
+    ("degrees", "mults"),
+    [((2, 2, 2), (2, 1, 2)), ((2, 1, 2), (1, 1, 2))],
+)
+@pytest.mark.parametrize("rational", [False, True])
+def test_reproduction_3d(
+    degrees: tuple[int, int, int], mults: tuple[int, int, int], rational: bool
+) -> None:
+    bsp = _make_bspline(degrees, mults, (3, 2, 3), rank=3, rational=rational)
+    assert_reproduces(bsp)
+
+
+@pytest.mark.parametrize("rational", [False, True])
+def test_reproduction_mixed_multiplicities_1d(rational: bool) -> None:
+    # degree 2; interior knots 1 (m=1), 2 (m=2), 3 (m=1): mixed multiplicities.
+    knots = [0, 0, 0, 1, 2, 2, 3, 4, 4, 4]
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    n = space.num_total_basis
+    rng = np.random.default_rng(1)
+    cp = rng.standard_normal((n, 3 if rational else 2))
+    if rational:
+        cp[:, -1] = rng.uniform(0.5, 1.5, size=n)
+    assert_reproduces(Bspline(space, cp, is_rational=rational))
+
+
+# ---------------------------------------------------------------------------
+# 2. Independent analytic oracles (no parent.evaluate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "angle",
+    [(0.0, 2.0 * np.pi), (0.0, 0.5 * np.pi), (0.25 * np.pi, 1.3 * np.pi)],
+)
+def test_circle_patches_have_unit_radius(angle: tuple[float, float]) -> None:
+    radius = 1.0
+    circ = create_circle(radius=radius, angle=angle)
+    s = np.linspace(0.0, 1.0, 11)
+    for i, patch in enumerate(circ.to_beziers().flat):
+        pts = np.asarray(cast(Bezier, patch).evaluate(s))
+        r = np.hypot(pts[:, 0], pts[:, 1])
+        np.testing.assert_allclose(
+            r, radius, atol=1e-10, rtol=0.0, err_msg=f"circle patch {i} off the circle"
+        )
+
+
+def test_extracted_control_points_match_expected_window() -> None:
+    # Evaluate-independent control-point oracle. With a C^0 interior knot
+    # (multiplicity == degree) and clamped ends, every element is already a Bézier
+    # segment, so extraction is the identity and each patch's control points are
+    # exactly the parent's support window: patch 0 == cp[0:3], patch 1 == cp[2:5].
+    # The historical element-indexed bug takes cp[1:4] for element 1, so this
+    # catches it directly without calling evaluate. The control points are
+    # intentionally non-collinear (collinear points stay collinear under any
+    # windowing, so a line cannot detect a wrong-window bug).
+    knots = [0, 0, 0, 1, 1, 2, 2, 2]  # degree 2, 2 elements, interior mult == degree
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    cp = np.array([[0.0, 0.0], [1.0, 3.0], [2.0, -1.0], [3.0, 2.0], [4.0, 0.0]])
+    patches = Bspline(space, cp).to_beziers()
+    p0 = cast(Bezier, patches.flat[0])
+    p1 = cast(Bezier, patches.flat[1])
+    np.testing.assert_allclose(np.asarray(p0.control_points), cp[0:3], atol=1e-12)
+    np.testing.assert_allclose(np.asarray(p1.control_points), cp[2:5], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 3. Targeted regression (fail on the buggy code)
+# ---------------------------------------------------------------------------
+
+
+def test_regression_nonrational_multiplicity_two() -> None:
+    knots = [0, 0, 0, 1, 1, 2, 2, 2]  # mult-2 interior knot, 2 elements
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    n = space.num_total_basis
+    cp = np.column_stack([np.linspace(0, 1, n), np.linspace(0, 1, n) ** 2])
+    assert_reproduces(Bspline(space, cp))
+
+
+def test_regression_full_circle_alternating_patches() -> None:
+    circ = create_circle(radius=1.0, angle=(0.0, 2.0 * np.pi))
+    s = np.linspace(0.0, 1.0, 9)
+    for i, patch in enumerate(circ.to_beziers().flat):
+        pts = np.asarray(cast(Bezier, patch).evaluate(s))
+        r = np.hypot(pts[:, 0], pts[:, 1])
+        np.testing.assert_allclose(r, 1.0, atol=1e-10, err_msg=f"patch {i} not on unit circle")
+
+
+# ---------------------------------------------------------------------------
+# 4. Structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_result_shape_matches_num_intervals() -> None:
+    bsp = _make_bspline((2, 3), (2, 2), (3, 4), rank=3, rational=True)
+    assert bsp.to_beziers().shape == bsp.space.num_intervals
+
+
+def test_patch_degrees_match_parent() -> None:
+    bsp = _make_bspline((2, 3), (2, 1), (3, 3), rank=3, rational=False)
+    for patch in bsp.to_beziers().flat:
+        assert cast(Bezier, patch).degree == bsp.degree
+
+
+def test_patch_control_points_readonly() -> None:
+    bsp = _make_bspline((2,), (2,), (3,), rank=2, rational=False)
+    for patch in bsp.to_beziers().flat:
+        assert not cast(Bezier, patch).control_points.flags.writeable
+
+
+def test_periodic_converts_then_reproduces() -> None:
+    knots = create_uniform_periodic_knots(5, 2)
+    sp1d = BsplineSpace1D(knots, 2, periodic=True)
+    space = BsplineSpace([sp1d])
+    n = space.num_total_basis
+    rng = np.random.default_rng(2)
+    bsp = Bspline(space, rng.standard_normal((n, 2)))
+    # to_beziers converts to open form; patches must reproduce that open spline.
+    opened = bsp.to_open_bspline()
+    beziers = bsp.to_beziers()
+    uks = _domain_knots(opened.space.spaces[0])
+    s = np.linspace(0.13, 0.87, 5)
+    for i, patch in enumerate(beziers.flat):
+        glob = uks[i] + s * (uks[i + 1] - uks[i])
+        np.testing.assert_allclose(
+            np.asarray(cast(Bezier, patch).evaluate(s)),
+            np.asarray(opened.evaluate(glob)),
+            atol=1e-10,
+            err_msg=f"periodic patch {i} mismatch",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_single_element() -> None:
+    bsp = _make_bspline((3,), (1,), (1,), rank=2, rational=False)
+    assert bsp.to_beziers().shape == (1,)
+    assert_reproduces(bsp)
+
+
+def test_interior_knot_full_multiplicity() -> None:
+    # Interior multiplicity == degree => C^0 joints; elements already near-Bézier.
+    for degree in (2, 3):
+        bsp = _make_bspline((degree,), (degree,), (3,), rank=2, rational=True)
+        assert_reproduces(bsp)
+
+
+def test_degree_one() -> None:
+    bsp = _make_bspline((1,), (1,), (4,), rank=2, rational=False)
+    assert_reproduces(bsp)
+
+
+def test_adjacent_repeated_knots_first_and_last_elements() -> None:
+    # Two interior repeated knots; checks first and last elements explicitly.
+    knots = [0, 0, 0, 1, 1, 2, 2, 3, 3, 3]  # degree 2, 3 elements, all interior mult 2
+    space = BsplineSpace([BsplineSpace1D(knots, 2)])
+    n = space.num_total_basis
+    rng = np.random.default_rng(3)
+    cp = np.column_stack([np.linspace(0, 1, n), rng.standard_normal(n)])
+    assert_reproduces(Bspline(space, cp))


### PR DESCRIPTION
## Summary

`Bspline.to_beziers()` produced **geometrically wrong Bézier patches** for any B-spline with **repeated interior knots** (multiplicity ≥ 2) — which includes every NURBS circle/disk and any C⁰ B-spline. Alternating elements were wrong: a quarter-circle element came out as a straight chord at radius √2.

**Root cause:** the extraction kernel `_apply_bezier_extraction_1d_core` selected each element's local control points as `ctrl[elem + k]`, assuming element `e` starts at control-point index `e`. That holds only for multiplicity-1 interior knots; with repeated interior knots the first supported function advances faster than the element index, so later elements read the wrong control points. The bug was masked because all prior tests/demos used multiplicity-1 knots.

**Fix:** pass a per-element `first_basis` offset — the index of the first B-spline function supported on the element, obtained from `tabulate_basis` at interval midpoints (robust to multiplicities) via the new `_first_basis_per_element` helper — and gather `ctrl[first_basis[elem] + k]`. Non-rational uniform splines are unaffected (offset == element index there).

This was discovered while debugging why rational surfaces (e.g. `create_disk`) rendered wrong in `pantr.viz`; the viz symptom is downstream of this core bug.

## Test plan

New `tests/test_to_beziers_multiplicity.py` certifies correctness via the **exact-reproduction property** (each patch over its element span equals the parent), parametrized over:
- interior knot multiplicity `1..degree` (incl. mixed and per-direction in 2D/3D)
- degrees 1–3, dim 1/2/3, rank 1 and >1, rational **and** non-rational
- ≥3 elements (exercises elements after a repeated knot)

Plus **evaluate-independent analytic oracles**:
- NURBS circle (full + partial arcs): every patch traces radius exactly `R`
- exact control-point window check at a C⁰ junction (`patch1 == cp[2:5]`, buggy code gives `cp[1:4]`)

Targeted regressions (`[0,0,0,1,1,2,2,2]` non-rational; full NURBS circle) fail on the old code. Existing parity test `TestToBeziersSpanwiseParity` updated to gather by support offset + a multiplicity-2 case.

- [x] New tests added; red on old code, green on the fix
- [x] Full suite passes (3650 passed)
- [x] ruff, ruff-format, mypy, import-linter pass
- [x] Two rounds of fresh-context Sonnet review; all Important findings addressed

Generated with [Claude Code](https://claude.com/claude-code)