### PR TITLE
docs: clarify optional backends + CAD naming, and switch theme to Furo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Polynomial and NURBS Toolkit (**PaNTr**) is a pure Python 3.11–3.14 library fo
 - **Truncated hierarchical B-splines** — `THBSplineSpace` with local
   refinement, mirroring the tensor-product API.
 - **Constructive geometry (`pantr.cad`)** — lines, circles and arcs, disks,
-  cylinders, extrude, revolve, sweep, ruled and Coons surfaces/volumes.
+  cylinders, extrusion, revolution, sweep, ruled and Coons surfaces/volumes.
 - **Structured grids (`pantr.grid`)** — tensor-product and hierarchical grids,
   BVH spatial queries, [dolfinx](https://github.com/FEniCS/dolfinx)-style
   cell/facet tags, and cell quadrature.
@@ -21,9 +21,11 @@ Polynomial and NURBS Toolkit (**PaNTr**) is a pure Python 3.11–3.14 library fo
   monomial, and cardinal B-spline bases.
 - **Fast and typed** — Numba-JIT kernels parallelized over CPU cores, with
   strict type hints across the public API.
-- **Optional MPI and visualization** — distribute spaces across ranks
-  (`pantr.mpi`) and render exact higher-order geometry through
-  [PyVista](https://docs.pyvista.org) and [VTK](https://vtk.org) (`pantr.viz`).
+- **Dependency-gated MPI and visualization** — `pantr.mpi` distributes spaces across
+  ranks once [`mpi4py`](https://github.com/mpi4py/mpi4py) is installed, and `pantr.viz`
+  renders exact higher-order geometry through [PyVista](https://docs.pyvista.org) /
+  [VTK](https://vtk.org) once PyVista is installed. Both modules ship with PaNTr; only
+  their backends are optional.
 
 ## Installation
 
@@ -44,23 +46,23 @@ pip install .
 
 ### Optional features
 
-The serial core (`pantr.grid`, `pantr.bspline`, ...) has no optional dependencies.
-Extra features are opt-in via extras:
+Every install of PaNTr includes **all** of its modules — `pantr.viz` and `pantr.mpi`
+among them. Those two stay dormant until their third-party backend is importable, and
+activate automatically once it is; until then, calling into them raises a clear,
+actionable error (nothing else is affected). The "extras" below add **no PaNTr code** —
+they are just a convenience that installs the backend for you, so `pip install
+"pantr[viz]"` and `pip install pyvista` are equivalent.
 
-| Extra | Enables | Pulls in |
-|---|---|---|
-| `mpi` | distributed spaces (`pantr.mpi`) | [`mpi4py`](https://github.com/mpi4py/mpi4py) (needs an MPI library) |
-| `metis` | [METIS](https://github.com/KarypisLab/METIS) graph partitioning backend | [`pymetis`](https://github.com/inducer/pymetis) |
-| `viz` | visualization (`pantr.viz`) | [`pyvista`](https://docs.pyvista.org) ([VTK](https://vtk.org)) |
-| `docs` | building the documentation | [Sphinx](https://www.sphinx-doc.org) stack |
+| Capability | Module | Backend it needs | Install (extra or direct) |
+|---|---|---|---|
+| Visualization & VTK export | `pantr.viz` | [`pyvista`](https://docs.pyvista.org) (+ [VTK](https://vtk.org)) | `pip install "pantr[viz]"` · or `pip install pyvista` |
+| Distributed (MPI) spaces | `pantr.mpi` | [`mpi4py`](https://github.com/mpi4py/mpi4py) (+ an MPI library) | `pip install "pantr[mpi]"` |
+| METIS partitioning backend | `pantr.bspline.partition_graph` | [`pymetis`](https://github.com/inducer/pymetis) | `pip install "pantr[metis]"` |
 
-```bash
-pip install "pantr[mpi]"        # e.g. distributed spaces
-pip install "pantr[mpi,viz]"    # several extras at once
-```
-
-The serial core never imports `pantr.mpi`, so it works identically with or without
-the `mpi` extra.
+The serial core (`pantr.grid`, `pantr.bspline`, …) never imports `pantr.mpi`, so a plain
+`pip install pantr` behaves identically with or without these backends. Contributors can
+grab everything — including the docs toolchain ([Sphinx](https://www.sphinx-doc.org)) —
+with `pip install -e ".[dev]"`.
 
 ## Development
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,12 +52,9 @@ extensions = [
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
     "pyvista.ext.viewer_directive",
-    "sphinx_rtd_dark_mode",
 ]
 
-OPTIONAL_EXTENSIONS: Final[list[str]] = [
-    "sphinx_rtd_dark_mode",
-]
+OPTIONAL_EXTENSIONS: Final[list[str]] = []
 
 for ext in OPTIONAL_EXTENSIONS:
     try:
@@ -167,32 +164,32 @@ myst_enable_extensions = [
     "smartquotes",
 ]
 
-html_theme = "sphinx_rtd_theme"
+# Furo: a clean theme that follows the reader's OS light/dark preference automatically
+# (a manual toggle is also available in the sidebar). Fall back to the built-in
+# 'alabaster' theme only if furo is not installed (it is pinned in the `docs` extra).
+html_theme = "furo"
 try:
-    if importlib.util.find_spec("sphinx_rtd_theme") is None:
+    if importlib.util.find_spec("furo") is None:
         raise ImportError
 except (ImportError, ModuleNotFoundError):
     warnings.warn(
-        "sphinx_rtd_theme not found. Falling back to 'alabaster'.",
+        "furo not found. Falling back to 'alabaster'.",
         stacklevel=1,
     )
     html_theme = "alabaster"
 html_static_path = ["_static"]
 html_show_sourcelink = True
 
-html_theme_options = {
-    "collapse_navigation": False,
-    "navigation_depth": 4,
-    "sticky_navigation": True,
-}
-
-html_context = {
-    "display_github": True,
-    "github_user": "pantolin",
-    "github_repo": "pantr",
-    "github_version": "main",
-    "conf_py_path": "/docs/",
-}
+# Furo provides light/dark automatically; these options drive its "Edit source" link.
+html_theme_options = (
+    {
+        "source_repository": "https://github.com/pantolin/pantr",
+        "source_branch": "main",
+        "source_directory": "docs/",
+    }
+    if html_theme == "furo"
+    else {}
+)
 
 html_logo = None
 html_favicon = None

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,21 +11,28 @@ pip install pantr
 
 ### Optional features
 
-Extra capabilities are opt-in via extras, so a plain install stays lightweight:
+A plain `pip install pantr` already includes **every** PaNTr module, including
+{mod}`pantr.viz` and {mod}`pantr.mpi`. These two don't do anything on their own — each
+needs a third-party *backend* library, and activates automatically as soon as that
+library is importable. Until then, calling into the module raises a clear error; nothing
+else is affected.
 
-| Extra | Enables | Pulls in |
-|---|---|---|
-| `viz` | visualization & VTK export ({mod}`pantr.viz`) | `pyvista` |
-| `mpi` | distributed spaces ({mod}`pantr.mpi`) | `mpi4py` (needs an MPI library) |
-| `metis` | METIS graph-partitioning backend | `pymetis` |
+The extras below install **no extra PaNTr code** — they are a convenience that pulls in
+the backend for you. Installing the backend yourself is exactly equivalent:
+
+| Capability | Module | Backend | Install (extra *or* direct) |
+|---|---|---|---|
+| Visualization & VTK export | {mod}`pantr.viz` | `pyvista` | `pip install "pantr[viz]"` · `pip install pyvista` |
+| Distributed (MPI) spaces | {mod}`pantr.mpi` | `mpi4py` (+ an MPI library) | `pip install "pantr[mpi]"` |
+| METIS partitioning backend | {func}`pantr.bspline.partition_graph` | `pymetis` | `pip install "pantr[metis]"` |
 
 ```bash
-pip install "pantr[viz]"        # e.g. to run the tutorials' 3-D scenes
-pip install "pantr[mpi,viz]"    # several extras at once
+pip install "pantr[viz]"        # enable visualization (installs pyvista)
+pip install "pantr[mpi,viz]"    # several backends at once
 ```
 
-The serial core never imports {mod}`pantr.mpi`, so it behaves identically with or
-without the `mpi` extra.
+The serial core never imports {mod}`pantr.mpi`, so a plain `pip install pantr` behaves
+identically whether or not these backends are present.
 
 ## Your first spline
 

--- a/docs/guide/cad.md
+++ b/docs/guide/cad.md
@@ -60,29 +60,29 @@ via {func}`~pantr.cad.create_ruled` between inner and outer circles.
 Operations create higher-dimensional objects from existing ones by adding
 a new parametric direction.
 
-### Extrude
+### Extrusion
 
 ```python
-from pantr.cad import create_circle, extrude
+from pantr.cad import create_circle, create_extrusion
 
-pipe = extrude(create_circle(), [0, 0, 2])   # circle -> cylindrical surface
+pipe = create_extrusion(create_circle(), [0, 0, 2])   # circle -> cylindrical surface
 ```
 
-{func}`~pantr.cad.extrude` translates a curve or surface along a displacement
+{func}`~pantr.cad.create_extrusion` translates a curve or surface along a displacement
 vector, appending a degree-1 parametric direction.
 
-### Revolve
+### Revolution
 
 ```python
-from pantr.cad import create_line, revolve
+from pantr.cad import create_line, create_revolution
 import numpy as np
 
-srf = revolve(create_line([1, 0, 0], [2, 0, 0]), point=0, axis=2)
-quarter = revolve(create_line([1, 0, 0], [1, 0, 3]), point=0, axis=2,
-                  angle=np.pi / 2)
+srf = create_revolution(create_line([1, 0, 0], [2, 0, 0]), point=0, axis=2)
+quarter = create_revolution(create_line([1, 0, 0], [1, 0, 3]), point=0, axis=2,
+                            angle=np.pi / 2)
 ```
 
-{func}`~pantr.cad.revolve` rotates a curve or surface around an axis.
+{func}`~pantr.cad.create_revolution` rotates a curve or surface around an axis.
 The angular direction inherits the same span structure as
 {func}`~pantr.cad.create_circle` (one span per 90 degrees, C0 at arc junctions).
 Supports coordinate axes (`axis=0, 1, 2`) and arbitrary axis vectors.
@@ -102,13 +102,13 @@ made compatible via {func}`~pantr.cad.make_compat`.
 ### Sweep
 
 ```python
-from pantr.cad import create_line, sweep
+from pantr.cad import create_line, create_sweep
 
-srf = sweep(create_line([0, 0, 0], [1, 0, 0]),    # section
-            create_line([0, 0, 0], [0, 0, 3]))     # trajectory
+srf = create_sweep(create_line([0, 0, 0], [1, 0, 0]),    # section
+                   create_line([0, 0, 0], [0, 0, 3]))     # trajectory
 ```
 
-{func}`~pantr.cad.sweep` creates a translational sweep:
+{func}`~pantr.cad.create_sweep` creates a translational sweep:
 $S(u, v) = \text{section}(u) + \text{trajectory}(v)$.
 
 ## Coons blending

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -131,13 +131,17 @@ Two specializations reuse the same model:
 
 The serial core ({mod}`pantr.bspline`, {mod}`pantr.bezier`, {mod}`pantr.basis`,
 {mod}`pantr.cad`, {mod}`pantr.grid`, {mod}`pantr.quad`, …) depends only on NumPy, SciPy,
-and Numba. Two heavier capabilities are **opt-in extras** and are never imported by the
-core:
+and Numba. Two further modules ship with every install but are **dependency-gated** —
+they need a third-party backend and activate automatically once it is importable (until
+then, using them raises a clear error). They are never imported by the core:
 
-- {mod}`pantr.viz` (the ``viz`` extra) — PyVista/VTK rendering and export
+- {mod}`pantr.viz` — PyVista/VTK rendering and export; needs `pyvista`
   ({doc}`/guide/visualization`).
-- {mod}`pantr.mpi` (the ``mpi`` extra) — MPI-distributed spaces
+- {mod}`pantr.mpi` — MPI-distributed spaces; needs `mpi4py`
   ({doc}`/guide/distributed`).
+
+The `viz` / `mpi` / `metis` install extras are just a convenience that pulls those
+backends in; installing the backend directly (e.g. `pip install pyvista`) is equivalent.
 
 Geometric predicates that need a floating-point tolerance (knot-multiplicity tests,
 endpoint detection) draw it from {mod}`pantr.tolerance`, so the whole library shares one

--- a/docs/guide/distributed.md
+++ b/docs/guide/distributed.md
@@ -93,8 +93,9 @@ partition = partition_graph(graph, comm.size)       # backend="spectral" (defaul
 
 ## Consuming an external partition (dolfinx)
 
-When a dolfinx-based consumer (e.g. qugar or tigarx) already partitioned a mesh,
-ingest *its* cell ownership instead of re-partitioning:
+When a dolfinx-based consumer (e.g. [QUGaR](https://github.com/pantolin/qugar) or
+[tIGArx](https://github.com/pantolin/tIGArx)) already partitioned a mesh, ingest *its*
+cell ownership instead of re-partitioning:
 
 ```python
 from pantr.mpi import from_dolfinx
@@ -155,7 +156,7 @@ partition = partition_grid(grid, comm.size, cell_weights=cost, cell_active=inter
 
 ## Consumer patterns
 
-**Native MPI (e.g. ocelat), no dolfinx.** Partition the grid (or coupling graph)
+**Native MPI (e.g. lepard), no dolfinx.** Partition the grid (or coupling graph)
 directly and build the distributed space:
 
 ```python
@@ -170,7 +171,8 @@ if ds.owns_cells:
     assemble_local(ds.local)        # your element loop over ds.local.space
 ```
 
-**dolfinx-driven (e.g. tigarx, qugar).** Let dolfinx own the partition and bridge
+**dolfinx-driven (e.g. [tIGArx](https://github.com/pantolin/tIGArx),
+[QUGaR](https://github.com/pantolin/qugar)).** Let dolfinx own the partition and bridge
 it in -- the immersed `cell_active` path falls out for free (trimmed cells become
 owner `-1`):
 

--- a/docs/guide/distributed.md
+++ b/docs/guide/distributed.md
@@ -5,7 +5,9 @@ hierarchical THB-spline space (`THBSplineSpace`) across MPI ranks for parallel
 assembly. The design keeps a clear separation:
 
 - a **serial windowing core** (in `pantr.grid` / `pantr.bspline`) that needs no MPI;
-- an **optional MPI layer** (`pantr.mpi`) that wraps it per rank.
+- the **MPI layer** (`pantr.mpi`) that wraps it per rank — it ships with PaNTr and
+  becomes usable once `mpi4py` is installed (the `mpi` extra is just a convenience for
+  that; see the Installation section below).
 
 Every rank holds a **redundant, self-contained** local space covering the cells it
 owns plus their support halo, so basis evaluation and element assembly are purely

--- a/docs/guide/parallelism.md
+++ b/docs/guide/parallelism.md
@@ -117,19 +117,25 @@ with concurrent.futures.ThreadPoolExecutor(4) as pool:
 ## Threading layer
 
 Numba supports several threading backends: **TBB**, **OpenMP**, and
-**workqueue** (the default).  TBB is the recommended choice for PaNTr because
-it handles nested and concurrent parallel regions safely.  To select it, set
-the environment variable before importing PaNTr:
+**workqueue**. With the default `NUMBA_THREADING_LAYER=default`, Numba selects
+the first that is installed, preferring **TBB → OpenMP → workqueue** — so a
+bare environment with neither TBB nor OpenMP available falls back to workqueue.
+
+**TBB is the recommended backend for PaNTr** because it handles nested and
+concurrent parallel regions safely — `workqueue` is *not* safe when several
+Python threads call PaNTr kernels concurrently (the *Usage patterns* above). The
+reliable way to get it is to **install the TBB backend**:
+
+```bash
+pip install tbb
+```
+
+Numba then selects it automatically (no env var needed). To *force* it — and get
+a clear error instead of a silent workqueue fallback if TBB is missing — set the
+environment variable before importing PaNTr (or any Numba code):
 
 ```bash
 export NUMBA_THREADING_LAYER=tbb
-```
-
-or, in Python before any Numba import:
-
-```python
-import os
-os.environ["NUMBA_THREADING_LAYER"] = "tbb"
 ```
 
 The maximum number of threads available to Numba is determined by
@@ -142,5 +148,5 @@ this maximum.
 | Variable | Default | Effect |
 |---|---|---|
 | `NUMBA_NUM_THREADS` | Number of logical cores | Maximum thread-pool size |
-| `NUMBA_THREADING_LAYER` | `workqueue` | Threading backend (`tbb`, `omp`, `workqueue`) |
+| `NUMBA_THREADING_LAYER` | `default` (picks `tbb`→`omp`→`workqueue` by availability) | Threading backend; install `tbb` to get TBB, or set this to force a specific layer |
 | `NUMBA_DISABLE_JIT` | `0` | Set to `1` to disable JIT entirely (useful for coverage) |

--- a/docs/guide/visualization.md
+++ b/docs/guide/visualization.md
@@ -1,15 +1,17 @@
 # Visualization
 
-PaNTr includes an optional visualization module (`pantr.viz`) built on
-[PyVista](https://docs.pyvista.org/) that renders B-spline and Bezier
-geometries using **native VTK higher-order Bezier cell types**.  This means
-exact polynomial geometry at any zoom level -- no tessellation to triangles.
+PaNTr ships with a visualization module (`pantr.viz`) built on
+[PyVista](https://docs.pyvista.org/) that renders B-spline and Bezier geometries
+using **native VTK higher-order Bezier cell types**. The cells store the *exact*
+polynomial geometry rather than a pre-baked triangle mesh, so a viewer can tessellate
+them as finely as needed and the geometry written to a file stays exact regardless of
+the display resolution.
 
 ## Installation
 
-`pantr.viz` requires [PyVista](https://docs.pyvista.org/), which is not
-included in a default `pantr` install.  You can make it available in two
-equivalent ways:
+`pantr.viz` ships with every PaNTr install but needs the third-party
+[PyVista](https://docs.pyvista.org/) library to do anything; PyVista is not pulled in by
+a default `pip install pantr`. Make it available in either equivalent way:
 
 ```bash
 pip install "pantr[viz]"   # let pantr pull in pyvista automatically
@@ -175,8 +177,9 @@ by default, configurable via `scalar_name`).
 ## Exporting to VTK files
 
 Export geometries to VTK files for visualization in
-[ParaView](https://www.paraview.org/) (version 5.10+ supports Bezier cells
-natively):
+[ParaView](https://www.paraview.org/) (5.10+ supports Bézier cells natively). ParaView
+tessellates each cell at its **Nonlinear Subdivision Level** -- raise that level for a
+closer fit to the curved geometry; the data stored in the file is exact regardless:
 
 ```python
 from pantr.viz import save

--- a/docs/guide/visualization.md
+++ b/docs/guide/visualization.md
@@ -2,10 +2,12 @@
 
 PaNTr ships with a visualization module (`pantr.viz`) built on
 [PyVista](https://docs.pyvista.org/) that renders B-spline and Bezier geometries
-using **native VTK higher-order Bezier cell types**. The cells store the *exact*
-polynomial geometry rather than a pre-baked triangle mesh, so a viewer can tessellate
-them as finely as needed and the geometry written to a file stays exact regardless of
-the display resolution.
+using **native VTK higher-order Bezier cell types**. Rather than baking the geometry
+into a fixed triangle mesh up front, each cell carries the *exact* polynomial map.
+To display it, a viewer still tessellates the cell into triangles -- but at a
+**subdivision level you choose**, so you trade resolution for cost and can refine as
+far as you like; the geometry stored in a file stays exact no matter how it is later
+tessellated.
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,13 +57,15 @@ Every module, class, and function, with full signatures.
   degree reduction, and Bernstein-polynomial root finding ({mod}`pantr.bezier`).
 - **Truncated hierarchical B-splines** — {class}`~pantr.bspline.THBSplineSpace` for
   adaptive local refinement, mirroring the tensor-product API.
-- **Constructive geometry** — lines, arcs, disks, cylinders, extrude, revolve, sweep,
-  ruled and Coons surfaces/volumes ({mod}`pantr.cad`).
+- **Constructive geometry** — lines, arcs, disks, cylinders, extrusion, revolution,
+  sweep, ruled and Coons surfaces/volumes ({mod}`pantr.cad`).
 - **Grids & quadrature** — tensor-product and hierarchical grids, BVH spatial queries,
   cell/facet tags, and quadrature rules ({mod}`pantr.grid`, {mod}`pantr.quad`).
-- **Optional MPI & visualization** — distribute spaces across ranks
-  ({mod}`pantr.mpi`) and render exact higher-order geometry through
-  [PyVista](https://docs.pyvista.org) and [VTK](https://vtk.org) ({mod}`pantr.viz`).
+- **Dependency-gated MPI & visualization** — {mod}`pantr.mpi` distributes spaces across
+  ranks (with [`mpi4py`](https://github.com/mpi4py/mpi4py)) and {mod}`pantr.viz` renders
+  exact higher-order geometry through [PyVista](https://docs.pyvista.org) /
+  [VTK](https://vtk.org) (with PyVista). Both ship with PaNTr; see
+  {doc}`getting-started` for how the optional backends are enabled.
 
 ```{toctree}
 :caption: Getting started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,12 @@ viz = [
 ]
 docs = [
   "sphinx>=7.2,<8",
-  "sphinx-rtd-theme>=1.3,<2",
-  "sphinx-rtd-dark-mode>=1.3,<2",
+  "furo>=2024.1",
   "myst-parser>=2.0,<3",
   "linkify-it-py>=2.0,<3",
+  # matplotlib is used only by the 2-D plots in the tutorial scripts (not by pantr
+  # itself, whose rendering is pyvista-based); pinned here so the gallery always builds.
+  "matplotlib>=3.7,<4",
   # Sphinx-Gallery executes the `tutorials/` scripts and embeds their output; pyvista
   # renders the 3-D scenes off-screen and the trame stack (+ nest_asyncio2)
   # exports them as interactive vtk.js widgets. On headless builders docs/conf.py

--- a/src/pantr/cad/__init__.py
+++ b/src/pantr/cad/__init__.py
@@ -8,8 +8,8 @@ B-spline geometric objects:
 - **Derived primitives**: :func:`create_rectangle`, :func:`create_disk`,
   :func:`create_cylinder`.
 - **Compatibility**: :func:`make_compat`.
-- **Operations**: :func:`extrude`, :func:`revolve`, :func:`create_ruled`,
-  :func:`sweep`.
+- **Operations**: :func:`create_extrusion`, :func:`create_revolution`,
+  :func:`create_ruled`, :func:`create_sweep`.
 - **Coons blending**: :func:`create_coons_surface`, :func:`create_coons_volume`.
 - **Assembly**: :func:`join`.
 """
@@ -18,7 +18,7 @@ from ._compat import make_compat
 from ._coons import create_coons_surface, create_coons_volume
 from ._derived import create_cylinder, create_disk, create_rectangle
 from ._join import join
-from ._operations import create_ruled, extrude, revolve, sweep
+from ._operations import create_extrusion, create_revolution, create_ruled, create_sweep
 from ._primitives import create_bilinear, create_circle, create_line, create_trilinear
 
 __all__ = [
@@ -28,13 +28,13 @@ __all__ = [
     "create_coons_volume",
     "create_cylinder",
     "create_disk",
+    "create_extrusion",
     "create_line",
     "create_rectangle",
+    "create_revolution",
     "create_ruled",
+    "create_sweep",
     "create_trilinear",
-    "extrude",
     "join",
     "make_compat",
-    "revolve",
-    "sweep",
 ]

--- a/src/pantr/cad/_derived.py
+++ b/src/pantr/cad/_derived.py
@@ -1,7 +1,8 @@
 """Derived primitives built from core operations.
 
 Provides higher-level geometric primitives constructed by composing
-:func:`create_circle`, :func:`extrude`, :func:`create_ruled`, and :func:`revolve`.
+:func:`create_circle`, :func:`create_extrusion`, :func:`create_ruled`, and
+:func:`create_revolution`.
 """
 
 from __future__ import annotations
@@ -10,7 +11,7 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
-from ._operations import create_ruled, extrude
+from ._operations import create_extrusion, create_ruled
 from ._primitives import create_circle
 from ._validation import _PHYSICAL_DIM, _pad_to_3d
 
@@ -125,4 +126,5 @@ def create_cylinder(
         >>> cyl.dim
         2
     """
-    return extrude(create_circle(radius=radius, center=center, angle=angle), [0, 0, height])
+    circle = create_circle(radius=radius, center=center, angle=angle)
+    return create_extrusion(circle, [0, 0, height])

--- a/src/pantr/cad/_operations.py
+++ b/src/pantr/cad/_operations.py
@@ -1,4 +1,4 @@
-"""Constructive operations: extrude, revolve, ruled, and sweep.
+"""Constructive operations: extrusion, revolution, ruled, and sweep.
 
 Provides functions that create higher-dimensional B-spline objects
 by combining existing ones: extrusion along a vector, revolution
@@ -20,7 +20,7 @@ _MAX_DIM_FOR_OPERATIONS = 2
 _NORM_TOL = 1e-14
 
 
-def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
+def create_extrusion(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
     """Extrude a B-spline curve or surface along a displacement vector.
 
     Creates a new B-spline with one additional parametric dimension by
@@ -39,13 +39,15 @@ def extrude(bspline: Bspline, displacement: npt.ArrayLike) -> Bspline:
         ValueError: If ``bspline.dim > 2``.
 
     Example:
-        >>> from pantr.cad import create_circle, extrude
-        >>> cyl = extrude(create_circle(), [0, 0, 1])
+        >>> from pantr.cad import create_circle, create_extrusion
+        >>> cyl = create_extrusion(create_circle(), [0, 0, 1])
         >>> cyl.dim
         2
     """
     if bspline.dim > _MAX_DIM_FOR_OPERATIONS:
-        raise ValueError(f"extrude requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}.")
+        raise ValueError(
+            f"create_extrusion requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}."
+        )
 
     disp = _pad_to_3d(displacement)
     cp = bspline.control_points
@@ -234,7 +236,7 @@ def _revolve_control_points(
     return qw
 
 
-def revolve(
+def create_revolution(
     bspline: Bspline,
     point: npt.ArrayLike,
     axis: int | npt.ArrayLike = 2,
@@ -267,9 +269,11 @@ def revolve(
         ValueError: If ``bspline.rank != 3``.
     """
     if bspline.dim > _MAX_DIM_FOR_OPERATIONS:
-        raise ValueError(f"revolve requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}.")
+        raise ValueError(
+            f"create_revolution requires dim <= {_MAX_DIM_FOR_OPERATIONS}, got {bspline.dim}."
+        )
     if bspline.rank != _PHYSICAL_DIM:
-        raise ValueError(f"revolve requires rank == {_PHYSICAL_DIM}, got {bspline.rank}.")
+        raise ValueError(f"create_revolution requires rank == {_PHYSICAL_DIM}, got {bspline.rank}.")
 
     pt = _pad_to_3d(point)
     v = _normalize_axis_vector(axis)
@@ -290,7 +294,7 @@ def revolve(
     return result_back
 
 
-def sweep(section: Bspline, trajectory: Bspline) -> Bspline:
+def create_sweep(section: Bspline, trajectory: Bspline) -> Bspline:
     """Construct the translational sweep of a section along a trajectory.
 
     Creates a new B-spline by summing the section and trajectory
@@ -315,10 +319,10 @@ def sweep(section: Bspline, trajectory: Bspline) -> Bspline:
     """
     if section.dim > _MAX_DIM_FOR_OPERATIONS:
         raise ValueError(
-            f"sweep requires section.dim <= {_MAX_DIM_FOR_OPERATIONS}, got {section.dim}."
+            f"create_sweep requires section.dim <= {_MAX_DIM_FOR_OPERATIONS}, got {section.dim}."
         )
     if trajectory.dim != 1:
-        raise ValueError(f"sweep requires trajectory.dim == 1, got {trajectory.dim}.")
+        raise ValueError(f"create_sweep requires trajectory.dim == 1, got {trajectory.dim}.")
 
     is_rational = section.is_rational or trajectory.is_rational
 

--- a/src/pantr/cad/_primitives.py
+++ b/src/pantr/cad/_primitives.py
@@ -5,7 +5,7 @@ Defines create_line, create_circle, create_bilinear, and create_trilinear.
 Provides functions to create basic B-spline objects from geometric
 descriptions (points, corners, radii, angles).  All primitives produce
 rank-3 (3D) output so they can be freely composed with higher-level
-operations such as ``extrude`` and ``revolve``.
+operations such as ``create_extrusion`` and ``create_revolution``.
 """
 
 from __future__ import annotations

--- a/src/pantr/grid/_cell_quadrature.py
+++ b/src/pantr/grid/_cell_quadrature.py
@@ -10,7 +10,7 @@ to that cell's volume and ``sum_i w_i f(x_i)`` approximates the integral of
 ``f`` over the cell.
 
 This is the uncut/background-cell quadrature bridge: a consumer (for example,
-ocelat) takes this rule for interior cells and substitutes its own cut-cell
+lepard) takes this rule for interior cells and substitutes its own cut-cell
 rule on cells flagged as cut.
 """
 

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -1,15 +1,15 @@
 """Optional MPI-parallel distribution layer for PaNTr.
 
-This subpackage will host the MPI-dependent and dolfinx-bridge code for distributing
-B-spline and THB-spline spaces across ranks. Everything here is optional: the
-serial core (:mod:`pantr.grid`, :mod:`pantr.bspline`, ...) never imports it
-(enforced by an import-linter contract), and ``import pantr.mpi`` succeeds even
-when ``mpi4py`` is absent -- only helpers that genuinely need MPI raise at call
-time, via :func:`require_mpi`.
+This subpackage hosts the MPI-dependent and dolfinx-bridge code for distributing
+B-spline and THB-spline spaces across ranks. It ships with every install of PaNTr but
+is **backend-gated**: the serial core (:mod:`pantr.grid`, :mod:`pantr.bspline`, ...)
+never imports it (enforced by an import-linter contract), and ``import pantr.mpi``
+succeeds even when ``mpi4py`` is absent -- only helpers that genuinely need MPI raise at
+call time, via :func:`require_mpi`.
 
-``mpi4py`` is an opt-in dependency: a plain ``pip install pantr`` is serial-only
-and MPI-free, while ``pip install "pantr[mpi]"`` adds ``mpi4py`` (and requires an
-MPI library).
+``mpi4py`` is the optional *backend*, not extra PaNTr code: a plain ``pip install pantr``
+is serial-only and MPI-free, while ``pip install "pantr[mpi]"`` simply installs ``mpi4py``
+for you (equivalently ``pip install mpi4py``; an MPI library is also required).
 
 Main exports:
 - :data:`HAS_MPI`: whether ``mpi4py`` was importable at module load time.

--- a/src/pantr/mpi/_from_dolfinx.py
+++ b/src/pantr/mpi/_from_dolfinx.py
@@ -3,7 +3,7 @@
 :func:`from_dolfinx` consumes the cell ownership of a (distributed) ``dolfinx`` mesh
 and returns the serial, redundant :class:`~pantr.grid.Partition` over a pantr grid's
 cells that the distributed-space machinery consumes -- the bridge for dolfinx-based
-consumers (e.g. qugar / tigarx).
+consumers (e.g. QUGaR / tIGArx).
 
 ``dolfinx`` is never imported here: the mesh (and its MPI communicator) are supplied by
 the caller, and only its attributes are read. This module therefore has no import-time

--- a/src/pantr/viz/__init__.py
+++ b/src/pantr/viz/__init__.py
@@ -1,4 +1,4 @@
-"""Optional visualization module for PaNTr using pyvista.
+"""Visualization module for PaNTr using pyvista.
 
 Provides conversion of B-spline, Bézier, and THB-spline geometries to pyvista
 ``UnstructuredGrid`` objects with native VTK Bézier cell types, interactive
@@ -6,9 +6,12 @@ visualization, and export to VTK file formats for ParaView. A
 :class:`~pantr.bspline.THBSpline` is decomposed into one VTK Bézier cell per
 active cell of its hierarchical grid.
 
-This module requires ``pyvista`` (optional dependency). Install with::
+This module ships with PaNTr but is **backend-gated**: it needs the third-party
+``pyvista`` library and activates as soon as ``pyvista`` is importable (otherwise its
+functions raise a clear error). The ``viz`` extra adds no PaNTr code -- it is just a
+convenience that installs ``pyvista`` for you::
 
-    pip install pantr[viz]
+    pip install "pantr[viz]"    # or, equivalently: pip install pyvista
 
 Main exports:
 

--- a/tests/test_aabb.py
+++ b/tests/test_aabb.py
@@ -1,6 +1,6 @@
 """Tests for :class:`pantr.geometry.AABB`.
 
-Ported from ocelat's AABB suite and extended for general ``ndim`` (PaNTr is not
+Ported from lepard's AABB suite and extended for general ``ndim`` (PaNTr is not
 restricted to 2-D/3-D) and PaNTr's standard-exception convention
 (:class:`ValueError` / :class:`TypeError` instead of a library-specific error
 type).
@@ -30,7 +30,7 @@ def test_aabb_rejects_mismatched_shapes() -> None:
 
 
 def test_aabb_allows_general_ndim() -> None:
-    # PaNTr is general-d: a 4-D box is valid (ocelat capped this at 2/3).
+    # PaNTr is general-d: a 4-D box is valid (lepard capped this at 2/3).
     b = AABB(lo=[0.0, 0.0, 0.0, 0.0], hi=[1.0, 1.0, 1.0, 1.0])
     assert b.ndim == 4
     assert not b.is_empty()
@@ -193,7 +193,7 @@ def test_aabb_unbounded() -> None:
 
 
 def test_aabb_unbounded_allows_high_ndim() -> None:
-    # General-d: unbounded works for ndim > 3 (ocelat rejected this).
+    # General-d: unbounded works for ndim > 3 (lepard rejected this).
     u = AABB.unbounded(5)
     assert u.ndim == 5
 

--- a/tests/test_cad_operations.py
+++ b/tests/test_cad_operations.py
@@ -1,4 +1,4 @@
-"""Tests for CAD operations: extrude and ruled."""
+"""Tests for CAD operations: create_extrusion and create_ruled."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pantr.cad import create_bilinear, create_circle, create_line, create_ruled, extrude
+from pantr.cad import create_bilinear, create_circle, create_extrusion, create_line, create_ruled
 
 _RANK_3D = 3
 
@@ -17,7 +17,7 @@ class TestExtrude:
     def test_line_to_surface(self) -> None:
         """Test extruding a line into a surface."""
         crv = create_line([0, 0, 0], [1, 0, 0])
-        srf = extrude(crv, [0, 0, 1])
+        srf = create_extrusion(crv, [0, 0, 1])
         assert srf.dim == 2
         assert srf.rank == _RANK_3D
         assert not srf.is_rational
@@ -25,13 +25,13 @@ class TestExtrude:
     def test_extrude_degree(self) -> None:
         """Test that the new direction has degree 1."""
         crv = create_line([0, 0, 0], [1, 0, 0])
-        srf = extrude(crv, [0, 1, 0])
+        srf = create_extrusion(crv, [0, 1, 0])
         assert srf.degree == (1, 1)
 
     def test_extrude_evaluate_corners(self) -> None:
         """Test evaluation at the four corners of an extruded line."""
         crv = create_line([0, 0, 0], [2, 0, 0])
-        srf = extrude(crv, [0, 3, 0])
+        srf = create_extrusion(crv, [0, 3, 0])
         pts = srf.evaluate(
             np.array(
                 [
@@ -50,7 +50,7 @@ class TestExtrude:
     def test_extrude_circle_to_cylinder(self) -> None:
         """Test extruding a circle produces a cylinder."""
         crv = create_circle(radius=2.0)
-        cyl = extrude(crv, [0, 0, 5])
+        cyl = create_extrusion(crv, [0, 0, 5])
         assert cyl.dim == 2
         assert cyl.is_rational
         # Evaluate on a grid and check all points lie on the cylinder
@@ -67,20 +67,20 @@ class TestExtrude:
     def test_extrude_surface_to_volume(self) -> None:
         """Test extruding a surface into a volume."""
         srf = create_bilinear()
-        vol = extrude(srf, [0, 0, 1])
+        vol = create_extrusion(srf, [0, 0, 1])
         assert vol.dim == _RANK_3D
         assert vol.degree == (1, 1, 1)
 
     def test_extrude_volume_raises(self) -> None:
         """Test that extruding a volume raises ValueError."""
-        vol = extrude(create_bilinear(), [0, 0, 1])
+        vol = create_extrusion(create_bilinear(), [0, 0, 1])
         with pytest.raises(ValueError, match="dim"):
-            extrude(vol, [0, 0, 1])
+            create_extrusion(vol, [0, 0, 1])
 
     def test_extrude_2d_displacement(self) -> None:
         """Test that 2D displacement is zero-padded to 3D."""
         crv = create_line([0, 0, 0], [1, 0, 0])
-        srf = extrude(crv, [0, 1])
+        srf = create_extrusion(crv, [0, 1])
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         assert_allclose(pt, [0.5, 1.0, 0.0], atol=1e-14)
 

--- a/tests/test_cad_revolve_sweep.py
+++ b/tests/test_cad_revolve_sweep.py
@@ -1,4 +1,4 @@
-"""Tests for CAD operations: revolve and sweep."""
+"""Tests for CAD operations: create_revolution and create_sweep."""
 
 from __future__ import annotations
 
@@ -7,7 +7,14 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
-from pantr.cad import create_bilinear, create_circle, create_line, extrude, revolve, sweep
+from pantr.cad import (
+    create_bilinear,
+    create_circle,
+    create_extrusion,
+    create_line,
+    create_revolution,
+    create_sweep,
+)
 
 _RANK_3D = 3
 
@@ -18,14 +25,14 @@ class TestRevolve:
     def test_line_to_annulus(self) -> None:
         """Test revolving a radial line produces a full annulus."""
         crv = create_line([1, 0, 0], [2, 0, 0])
-        srf = revolve(crv, point=0, axis=2)
+        srf = create_revolution(crv, point=0, axis=2)
         assert srf.dim == 2
         assert srf.is_rational
 
     def test_revolve_points_on_cylinder(self) -> None:
         """Test revolving a vertical line around Z produces a cylinder."""
         crv = create_line([1, 0, 0], [1, 0, 3])
-        srf = revolve(crv, point=0, axis=2)
+        srf = create_revolution(crv, point=0, axis=2)
         # Evaluate on a grid
         u = np.linspace(0, 1, 10)
         v = np.linspace(0, 1, 20)
@@ -37,7 +44,7 @@ class TestRevolve:
     def test_revolve_quarter_turn(self) -> None:
         """Test revolving a line by pi/2 around Z."""
         crv = create_line([1, 0, 0], [2, 0, 0])
-        srf = revolve(crv, point=0, axis=2, angle=np.pi / 2)
+        srf = create_revolution(crv, point=0, axis=2, angle=np.pi / 2)
         # At v=0 should be on +X axis, at v=1 on +Y axis
         pt_start = srf.evaluate(np.array([[0.5, 0.0]]))
         pt_end = srf.evaluate(np.array([[0.5, 1.0]]))
@@ -48,7 +55,7 @@ class TestRevolve:
     def test_revolve_around_y_axis(self) -> None:
         """Test revolving around the Y axis."""
         crv = create_line([1, 0, 0], [1, 0, 1])
-        srf = revolve(crv, point=0, axis=1, angle=np.pi / 2)
+        srf = create_revolution(crv, point=0, axis=1, angle=np.pi / 2)
         # At v=1, (x, z) should rotate to (z, -x) for Y-axis rotation
         pt = srf.evaluate(np.array([[0.0, 1.0]]))
         assert_allclose(pt, [0, 0, -1], atol=1e-12)
@@ -56,7 +63,7 @@ class TestRevolve:
     def test_revolve_with_center(self) -> None:
         """Test revolving around an offset point."""
         crv = create_line([3, 0, 0], [3, 0, 1])
-        srf = revolve(crv, point=[2, 0, 0], axis=2)
+        srf = create_revolution(crv, point=[2, 0, 0], axis=2)
         # At v=0, should be at original position
         pt = srf.evaluate(np.array([[0.0, 0.0]]))
         assert_allclose(pt, [3, 0, 0], atol=1e-12)
@@ -71,7 +78,7 @@ class TestRevolve:
     def test_revolve_negative_angle(self) -> None:
         """Test revolving with a negative angle (clockwise)."""
         crv = create_line([1, 0, 0], [2, 0, 0])
-        srf = revolve(crv, point=0, axis=2, angle=-np.pi / 2)
+        srf = create_revolution(crv, point=0, axis=2, angle=-np.pi / 2)
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         r = 1.5
         assert_allclose(pt, [0, -r, 0], atol=1e-12)
@@ -79,7 +86,7 @@ class TestRevolve:
     def test_revolve_angle_tuple(self) -> None:
         """Test revolving with (start, end) angle tuple."""
         crv = create_line([1, 0, 0], [2, 0, 0])
-        srf = revolve(crv, point=0, axis=2, angle=(np.pi / 2, np.pi))
+        srf = create_revolution(crv, point=0, axis=2, angle=(np.pi / 2, np.pi))
         # At v=0, should be at angle pi/2 (on +Y axis)
         pt0 = srf.evaluate(np.array([[0.5, 0.0]]))
         r = 1.5
@@ -90,9 +97,9 @@ class TestRevolve:
 
     def test_revolve_dim_too_large_raises(self) -> None:
         """Test that revolving a volume raises ValueError."""
-        vol = extrude(create_bilinear(), [0, 0, 1])
+        vol = create_extrusion(create_bilinear(), [0, 0, 1])
         with pytest.raises(ValueError, match="dim"):
-            revolve(vol, point=0, axis=2)
+            create_revolution(vol, point=0, axis=2)
 
     def test_revolve_wrong_rank_raises(self) -> None:
         """Test that rank != 3 raises ValueError."""
@@ -100,7 +107,7 @@ class TestRevolve:
         sp = BsplineSpace([BsplineSpace1D(knots, 1)])
         crv = Bspline(sp, np.array([[0.0, 0.0], [1.0, 1.0]]))
         with pytest.raises(ValueError, match="rank"):
-            revolve(crv, point=0, axis=2)
+            create_revolution(crv, point=0, axis=2)
 
 
 class TestSweep:
@@ -110,7 +117,7 @@ class TestSweep:
         """Test sweeping a line along a line produces a bilinear surface."""
         section = create_line([0, 0, 0], [1, 0, 0])
         trajectory = create_line([0, 0, 0], [0, 1, 0])
-        srf = sweep(section, trajectory)
+        srf = create_sweep(section, trajectory)
         assert srf.dim == 2
         assert srf.rank == _RANK_3D
         # Evaluate corners
@@ -133,7 +140,7 @@ class TestSweep:
         """Test that at trajectory start the section geometry is preserved."""
         section = create_circle(radius=2.0, angle=np.pi / 2)
         trajectory = create_line([0, 0, 0], [0, 0, 5])
-        srf = sweep(section, trajectory)
+        srf = create_sweep(section, trajectory)
         # At v=0 (trajectory start), should match the section
         u = np.linspace(0, 1, 20)
         params_v0 = np.column_stack([u, np.zeros_like(u)])
@@ -145,20 +152,20 @@ class TestSweep:
         """Test that the trajectory adds an offset."""
         section = create_line([0, 0, 0], [1, 0, 0])
         trajectory = create_line([0, 0, 0], [0, 0, 3])
-        srf = sweep(section, trajectory)
+        srf = create_sweep(section, trajectory)
         pt = srf.evaluate(np.array([[0.5, 1.0]]))
         assert_allclose(pt, [0.5, 0, 3], atol=1e-14)
 
     def test_sweep_section_dim2_raises_for_dim3(self) -> None:
         """Test that section dim > 2 raises ValueError."""
-        vol = extrude(create_bilinear(), [0, 0, 1])
+        vol = create_extrusion(create_bilinear(), [0, 0, 1])
         traj = create_line([0, 0, 0], [1, 0, 0])
         with pytest.raises(ValueError, match=r"section\.dim"):
-            sweep(vol, traj)
+            create_sweep(vol, traj)
 
     def test_sweep_trajectory_dim2_raises(self) -> None:
         """Test that trajectory dim != 1 raises ValueError."""
         sec = create_line([0, 0, 0], [1, 0, 0])
         traj = create_bilinear()
         with pytest.raises(ValueError, match=r"trajectory\.dim"):
-            sweep(sec, traj)
+            create_sweep(sec, traj)

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -61,7 +61,7 @@ def test_overlay_refines_both_inputs() -> None:
 
 
 def test_overlay_high_dimension() -> None:
-    """Overlay is defined for ndim > 3 (generalized beyond ocelat's 2/3-D cap)."""
+    """Overlay is defined for ndim > 3 (generalized beyond lepard's 2/3-D cap)."""
     a = uniform_grid([[0.0, 1.0]] * 4, 2)
     b = uniform_grid([[0.0, 1.0]] * 4, 3)
     result = overlay(a, b)

--- a/tutorials/02_visualization.py
+++ b/tutorials/02_visualization.py
@@ -6,8 +6,9 @@ Now that you can build a geometry (:doc:`/tutorials/01_first_bspline`), this tut
 shows how to *see* it. PaNTr's :mod:`pantr.viz` module turns B-spline, Bézier, and
 THB-spline geometries into `PyVista <https://docs.pyvista.org>`_ meshes backed by
 native VTK Bézier cells that store the *exact* polynomial geometry. The interactive
-viewer below subdivides those cells for display, while a ``.vtu`` opened in ParaView
-(>= 5.10) renders them exactly. The toolkit is reused throughout the rest of the
+viewer below subdivides those cells for display, and a ``.vtu`` opened in ParaView
+(>= 5.10) renders them as exact Bézier cells, tessellated at ParaView's chosen
+*Nonlinear Subdivision Level*. The toolkit is reused throughout the rest of the
 tutorials:
 
 - :func:`~pantr.viz.plot` -- one-call interactive viewing,

--- a/tutorials/04_cad_modeling.py
+++ b/tutorials/04_cad_modeling.py
@@ -4,7 +4,7 @@ Constructive CAD modeling
 
 Hand-authoring control points (as in :doc:`/tutorials/01_first_bspline`) does not
 scale. :mod:`pantr.cad` builds B-spline geometry the way a CAD kernel does: primitives
-(lines, circles, disks, cylinders) combined by operations (extrude, revolve, ruled
+(lines, circles, disks, cylinders) combined by operations (extrusion, revolution, ruled
 surfaces, sweeps, Coons patches) and assembled with ``join``. Every result is an
 ordinary :class:`~pantr.bspline.Bspline`, so it supports evaluation, derivatives, and
 the knot operations from the previous tutorial.
@@ -14,7 +14,14 @@ This tutorial builds a few shapes and lays them out in one scene; the
 """
 
 from pantr import viz
-from pantr.cad import create_circle, create_cylinder, create_line, create_ruled, extrude, revolve
+from pantr.cad import (
+    create_circle,
+    create_cylinder,
+    create_extrusion,
+    create_line,
+    create_revolution,
+    create_ruled,
+)
 from pantr.transform import AffineTransform
 
 # %%
@@ -25,18 +32,18 @@ cylinder = create_cylinder(radius=0.5, height=1.5)
 viz.plot(cylinder, color="lightsteelblue", show_knot_lines=True)
 
 # %%
-# Extrude: sweep a profile along a vector
-# ---------------------------------------
+# Extrusion: sweep a profile along a vector
+# -----------------------------------------
 # Extruding a circle along +z produces a tube wall.
-tube = extrude(create_circle(radius=0.5), displacement=[0.0, 0.0, 1.2])
+tube = create_extrusion(create_circle(radius=0.5), displacement=[0.0, 0.0, 1.2])
 viz.plot(tube, color="wheat", show_knot_lines=True)
 
 # %%
-# Revolve: spin a profile about an axis
-# -------------------------------------
+# Revolution: spin a profile about an axis
+# -----------------------------------------
 # Revolving a slanted line about the z-axis gives a cone-like surface of revolution.
 profile = create_line(p0=[0.2, 0.0, 0.0], p1=[0.6, 0.0, 1.0])
-surface_of_revolution = revolve(profile, point=[0.0, 0.0, 0.0], axis=2)
+surface_of_revolution = create_revolution(profile, point=[0.0, 0.0, 0.0], axis=2)
 viz.plot(surface_of_revolution, color="thistle", show_knot_lines=True)
 
 # %%

--- a/tutorials/05_approximation.py
+++ b/tutorials/05_approximation.py
@@ -2,9 +2,10 @@
 Approximation: interpolation, fitting, projection, quasi-interpolation
 ======================================================================
 
-So far we have *prescribed* control points. Often the geometry is the unknown: given a
-function (or sampled data), find the spline that best represents it. :mod:`pantr.bspline`
-offers several routes, trading cost against accuracy:
+So far the control points have come from geometry we built directly -- placed by hand or
+produced by the CAD module. Often the geometry is the *unknown* instead: given a function
+(or sampled data), find the spline that best represents it. :mod:`pantr.bspline` offers
+several routes, trading cost against accuracy:
 :func:`~pantr.bspline.interpolate_bspline` (match the function at the Greville points by
 default), :func:`~pantr.bspline.l2_project_bspline` (best :math:`L^2` fit), and
 :func:`~pantr.bspline.quasi_interpolate_bspline` (a cheap, purely local projector). This

--- a/tutorials/06_polynomial_bases.py
+++ b/tutorials/06_polynomial_bases.py
@@ -2,8 +2,8 @@
 Polynomial bases and change of basis
 ====================================
 
-Underneath every spline is a *basis*. :mod:`pantr.basis` tabulates the common 1-D
-polynomial bases used to build spline and finite-element spaces, and
+Every spline is a linear combination of *basis functions*. :mod:`pantr.basis` tabulates
+the common 1-D polynomial bases used to build spline and finite-element spaces, and
 :mod:`pantr.change_basis` provides the exact matrices that convert coefficients between
 them. This tutorial plots the bases at a fixed degree and visualizes one such
 change-of-basis matrix.

--- a/tutorials/GALLERY_HEADER.rst
+++ b/tutorials/GALLERY_HEADER.rst
@@ -13,8 +13,13 @@ rest of the User Guide for the conceptual reference behind each step.
 
 Running them yourself::
 
-    pip install "pantr[viz]"          # the 3-D tutorials need the viz extra
+    pip install "pantr[viz]" matplotlib    # 3-D scenes need PyVista; 2-D plots use matplotlib
     python tutorials/01_first_bspline.py
+
+The 2-D plots are drawn with `matplotlib <https://matplotlib.org>`_ and the interactive
+3-D scenes with `PyVista <https://docs.pyvista.org>`_. Neither is a dependency of PaNTr
+itself -- they are used only by these tutorial scripts (PaNTr's own rendering lives in
+:mod:`pantr.viz`, which needs only PyVista).
 
 The 3-D scenes are interactive -- drag to rotate, scroll to zoom. The plotting scripts
 use Numba kernels; on a fresh process you may hit a Numba background-warmup threading
@@ -31,8 +36,8 @@ The path, in order:
    scalar fields, VTK export (:mod:`pantr.viz`).
 #. **Knot operations & Bézier extraction** -- knot insertion, degree elevation, and the
    element-local Bézier pieces (:mod:`pantr.bspline`).
-#. **Constructive CAD modeling** -- primitives plus extrude / revolve / ruled, assembled
-   (:mod:`pantr.cad`).
+#. **Constructive CAD modeling** -- primitives plus extrusion / revolution / ruled,
+   assembled (:mod:`pantr.cad`).
 #. **Approximation** -- interpolation, L2 projection, quasi-interpolation, and
    convergence (:mod:`pantr.bspline`).
 #. **Polynomial bases & change of basis** -- Bernstein / Lagrange / Legendre and the


### PR DESCRIPTION
Follow-up to #225, addressing review feedback on the new docs.

## 1. Optional extras are backend-enablers, not extra PaNTr code
The biggest fix. `pantr.viz` and `pantr.mpi` **always ship** with PaNTr; they're inert until their third-party backend (`pyvista` / `mpi4py`) is importable, then activate automatically (otherwise they raise a clear error). The `viz`/`mpi`/`metis` extras add **no PaNTr code** — they're a convenience that pip-installs the backend, equivalent to installing it yourself (`pip install pyvista`). Reworded everywhere: README, `getting-started`, `index`, `guide/concepts`, `guide/visualization`, `guide/distributed`, and the `pantr.viz` / `pantr.mpi` module docstrings.

## 2. CAD operations renamed to the `create_*` convention (breaking)
`extrude`/`revolve`/`sweep` → **`create_extrusion`/`create_revolution`/`create_sweep`**, so every function returning a new geometry is `create_<noun>` (matching `create_ruled`, `create_coons_*`). `join`/`make_compat` (assembly/utility) keep their names. Hard rename, no aliases — done now, before the first public release. Propagated through code, tests, docs, and tutorials.

## 3. matplotlib treated as a tutorial-only tool
It was undeclared (riding in transitively via pyvista) yet used by the tutorials' 2-D plots. Added to the `docs` extra and noted in the tutorials that matplotlib/PyVista are illustration tools, not PaNTr dependencies (PaNTr's own rendering is `pantr.viz`).

## 4. ParaView wording
"renders them exactly" → ParaView tessellates Bézier cells at the chosen **Nonlinear Subdivision Level** (the *stored* geometry is exact; the rendered fit depends on that level). Fixed in `tutorial 02` and `guide/visualization`.

## 5. Tutorial corrections
- Tut 05: dropped the false "so far we have *prescribed* control points" — the CAD tutorial already constructs geometry. Reworded to "built directly, by hand or with the CAD module".
- Tut 06: "Underneath every spline is a basis" → the precise "Every spline is a linear combination of *basis functions*" (the statement was true; this is just exact).

## 6. Theme → Furo
Swapped `sphinx-rtd-theme` + `sphinx-rtd-dark-mode` for **Furo**, which follows the reader's OS light/dark preference automatically (with a manual toggle) — so RTD gets both styles cleanly, no forced-dark default.

## Verification
ruff · ruff format · mypy · lint-imports · `pytest --no-cov` (3660 passed, 7 skipped) · clean `-W` docs build with Furo (**0 warnings**; the py3.14 ForwardRef ones stay suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)