### PR TITLE
docs: link Read the Docs site from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # PaNTr
 
+[![Documentation Status](https://readthedocs.org/projects/pantr/badge/?version=latest)](https://pantr.readthedocs.io/en/latest/?badge=latest)
+
 Polynomial and NURBS Toolkit (**PaNTr**) is a pure Python 3.11–3.14 library for geometric modeling and numerical analysis using [NumPy](https://numpy.org), [SciPy](https://scipy.org), and [Numba](https://numba.pydata.org).
+
+**Documentation:** [pantr.readthedocs.io](https://pantr.readthedocs.io)
 
 ## Features
 


### PR DESCRIPTION
Now that the hosted docs are live at https://pantr.readthedocs.io, surface them from the README:

- Add a Read the Docs status badge under the title.
- Add an explicit **Documentation** link.

The PyPI sidebar link (`[project.urls] Documentation`) was already set; this covers the GitHub-facing entry point.

## Checks
- ruff lint / format: pass
- mypy: pass
- pytest: pass (3660 passed, 7 skipped)
- docs build (`-W`): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)