### PR TITLE
docs: add THB-spline algorithm references (Speleers, Garau, D'Angella)

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -54,6 +54,40 @@
   doi     = {10.1016/j.cagd.2012.03.025}
 }
 
+@article{speleers2016quasi,
+  author  = {Speleers, Hendrik and Manni, Carla},
+  title   = {Effortless quasi-interpolation in hierarchical spaces},
+  journal = {Numerische Mathematik},
+  volume  = {132},
+  number  = {1},
+  pages   = {155--184},
+  year    = {2016},
+  doi     = {10.1007/s00211-015-0711-z}
+}
+
+@article{garau2018algorithms,
+  author  = {Garau, Eduardo M. and V{\'a}zquez, Rafael},
+  title   = {Algorithms for the implementation of adaptive isogeometric methods
+             using hierarchical {B}-splines},
+  journal = {Applied Numerical Mathematics},
+  volume  = {123},
+  pages   = {58--87},
+  year    = {2018},
+  doi     = {10.1016/j.apnum.2017.08.006}
+}
+
+@article{dangella2018multilevel,
+  author  = {D'Angella, Davide and Kollmannsberger, Stefan and Rank, Ernst
+             and Reali, Alessandro},
+  title   = {Multi-level {B}{\'e}zier extraction for hierarchical local
+             refinement of isogeometric analysis},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  volume  = {328},
+  pages   = {147--174},
+  year    = {2018},
+  doi     = {10.1016/j.cma.2017.08.017}
+}
+
 % --- Foundational books -----------------------------------------------------
 
 @book{piegl1997nurbs,

--- a/src/pantr/bspline/_thb_quasi_interpolation.py
+++ b/src/pantr/bspline/_thb_quasi_interpolation.py
@@ -77,6 +77,10 @@ def quasi_interpolate_thb_spline(
             with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
         RuntimeError: If the grid has been modified since ``space`` was constructed,
             or an active dof has no leaf cell at its level (inconsistent space).
+
+    References:
+        Hierarchical quasi-interpolation in truncated hierarchical spaces
+        :cite:p:`speleers2016quasi`.
     """
     if not isinstance(space, THBSplineSpace):
         raise TypeError(f"space must be a THBSplineSpace; got {type(space).__name__!r}.")

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -216,6 +216,13 @@ class THBSplineSpace:
         cell.  :meth:`tabulate_basis` always returns the correct (possibly zero)
         values.
 
+    References:
+        Adaptive isogeometric algorithms for hierarchical splines
+        :cite:p:`garau2018algorithms`.  Per-element multi-level Bézier extraction
+        (used for element assembly and visualization) is provided by
+        :class:`~pantr.bspline.MultiLevelExtraction`, following
+        :cite:t:`dangella2018multilevel`.
+
     Attributes:
         _root_space (BsplineSpace): The level-0 tensor-product space.
         _grid (HierarchicalGrid): The active-cell hierarchy (snapshot reference).

--- a/src/pantr/bspline/multilevel_extraction.py
+++ b/src/pantr/bspline/multilevel_extraction.py
@@ -65,6 +65,10 @@ class MultiLevelExtraction:
 
     The operators' rows are ordered as :meth:`active_basis` (sorted global dof).
 
+    References:
+        Multi-level Bézier extraction for hierarchical local refinement
+        :cite:p:`dangella2018multilevel`.
+
     Attributes:
         _space (THBSplineSpace): The hierarchical space being extracted.
         _target (Target): The single-level reference basis tag.

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1183,6 +1183,10 @@ class HierarchicalGrid(Grid):
             ValueError: If ``level`` is out of range, ``lo``/``hi`` have the
                 wrong length, any ``lo[k] >= hi[k]``, or ``[lo, hi)`` falls
                 entirely outside the level-``level`` domain.
+
+        References:
+            Refinement and coarsening algorithms for adaptive hierarchical-spline
+            meshes :cite:p:`garau2018algorithms`.
         """
         ndim = self.ndim
         if not (0 <= int(level) <= self.max_level):
@@ -1295,6 +1299,10 @@ class HierarchicalGrid(Grid):
             ValueError: If ``level`` is out of range, ``lo``/``hi`` have the wrong
                 length, any ``lo[k] >= hi[k]``, ``[lo, hi)`` is out of bounds, or the
                 region is not fully refined to exactly level ``level+1``.
+
+        References:
+            Coarsening algorithms for adaptive hierarchical-spline meshes
+            :cite:p:`garau2018algorithms`.
         """
         ndim = self.ndim
         if not (0 <= int(level) < self.max_level):


### PR DESCRIPTION
Follow-up to #229. That PR was squash-merged at an earlier point on the branch, so the THB-spline algorithm references added afterward never reached `main`. This restores them (57 insertions across 5 files; bibliography 14 → 17 entries).

## References added
- **Speleers & Manni (2016)**, *Effortless quasi-interpolation in hierarchical spaces* (Numer. Math. 132:155–184) → `quasi_interpolate_thb_spline`
- **Garau & Vázquez (2018)**, *Algorithms for adaptive IGA with hierarchical B-splines* (Appl. Numer. Math. 123:58–87) → `HierarchicalGrid.refine`/`.coarsen`, `THBSplineSpace`
- **D'Angella et al. (2018)**, *Multi-level Bézier extraction for hierarchical local refinement of IGA* (CMAME 328:147–174) → `MultiLevelExtraction` (the class that implements THB Bézier extraction, used by THB visualization), cross-linked from `THBSplineSpace`

All three verified against Crossref/publisher records; all 17 bib entries are cited at least once.

## Checks
- ruff lint / format: pass
- mypy: pass
- pytest: 3659 passed, 7 skipped (the lone subprocess-test failure is the pre-existing local-env artifact, green in CI)
- docs build (`-W`): pass, 17 entries parsed, no citation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)