### PR TITLE
chore(ci): cache OpenMPI apt install and mpi-tests venv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,11 +159,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-numba-${{ steps.setup-python.outputs.python-version }}-
 
-      - name: Install OpenMPI (needed by mpi4py installed via [dev])
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y libopenmpi-dev openmpi-bin
-
       - name: Create venv and install dev deps (on cache miss)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -260,18 +255,18 @@ jobs:
     name: MPI tests (mpiexec)
     needs: [lint, type-check]
     runs-on: ubuntu-latest
-    # The only job that exercises the real distributed stack under multiple ranks. It
-    # builds mpi4py from source against the system OpenMPI -- the prebuilt wheels bundle
-    # MPICH, which would not match the `openmpi-bin` launcher. PANTR_RUN_MPI enables the
+    # The only job that exercises the real distributed stack under multiple ranks.
+    # Uses the system MPICH launcher together with the prebuilt mpi4py wheel (which
+    # bundles MPICH), so no source build is needed. PANTR_RUN_MPI enables the
     # otherwise-skipped tests under tests/mpi/.
     env:
       PANTR_RUN_MPI: "1"
-      PIP_NO_BINARY: "mpi4py"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -279,12 +274,22 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install OpenMPI
+      - name: Install MPICH
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libopenmpi-dev openmpi-bin
+          sudo apt-get update -q
+          sudo apt-get install -y libmpich-dev mpich
 
-      - name: Create venv and install (with mpi4py, built from source)
+      - name: Cache virtualenv
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-mpi-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-mpi-
+
+      - name: Create venv and install dev deps (on cache miss)
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
           . .venv/bin/activate
@@ -294,14 +299,14 @@ jobs:
       - name: Verify mpi4py matches the launcher
         run: |
           . .venv/bin/activate
-          mpiexec --oversubscribe -n 2 python -c "from mpi4py import MPI; assert MPI.COMM_WORLD.size == 2"
+          mpiexec -n 2 python -c "from mpi4py import MPI; assert MPI.COMM_WORLD.size == 2"
 
       - name: Run MPI smoke tests (2 ranks)
         run: |
           . .venv/bin/activate
-          mpiexec --oversubscribe -n 2 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+          mpiexec -n 2 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
 
       - name: Run MPI smoke tests (3 ranks)
         run: |
           . .venv/bin/activate
-          mpiexec --oversubscribe -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+          mpiexec -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,11 +159,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-numba-${{ steps.setup-python.outputs.python-version }}-
 
-      - name: Install OpenMPI (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libopenmpi-dev openmpi-bin
-          version: 1.0
+      - name: Install OpenMPI
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y libopenmpi-dev openmpi-bin
 
       - name: Create venv and install dev deps (on cache miss)
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -281,11 +280,10 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install OpenMPI (cached)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libopenmpi-dev openmpi-bin
-          version: 1.0
+      - name: Install OpenMPI
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y libopenmpi-dev openmpi-bin
 
       - name: Cache virtualenv
         id: cache-venv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,10 +274,11 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install MPICH
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y libmpich-dev mpich
+      - name: Install MPICH (cached)
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libmpich-dev mpich
+          version: 1.0
 
       - name: Cache virtualenv
         id: cache-venv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-numba-${{ steps.setup-python.outputs.python-version }}-
 
+      - name: Install OpenMPI (cached)
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libopenmpi-dev openmpi-bin
+          version: 1.0
+
       - name: Create venv and install dev deps (on cache miss)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -255,12 +261,13 @@ jobs:
     name: MPI tests (mpiexec)
     needs: [lint, type-check]
     runs-on: ubuntu-latest
-    # The only job that exercises the real distributed stack under multiple ranks.
-    # Uses the system MPICH launcher together with the prebuilt mpi4py wheel (which
-    # bundles MPICH), so no source build is needed. PANTR_RUN_MPI enables the
+    # The only job that exercises the real distributed stack under multiple ranks. It
+    # builds mpi4py from source against the system OpenMPI -- the prebuilt wheels are not
+    # guaranteed to match the system launcher's wire protocol. PANTR_RUN_MPI enables the
     # otherwise-skipped tests under tests/mpi/.
     env:
       PANTR_RUN_MPI: "1"
+      PIP_NO_BINARY: "mpi4py"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -274,10 +281,10 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
 
-      - name: Install MPICH (cached)
+      - name: Install OpenMPI (cached)
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libmpich-dev mpich
+          packages: libopenmpi-dev openmpi-bin
           version: 1.0
 
       - name: Cache virtualenv
@@ -289,7 +296,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-mpi-
 
-      - name: Create venv and install dev deps (on cache miss)
+      - name: Create venv and install (with mpi4py built from source, on cache miss)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
@@ -300,14 +307,14 @@ jobs:
       - name: Verify mpi4py matches the launcher
         run: |
           . .venv/bin/activate
-          mpiexec -n 2 python -c "from mpi4py import MPI; assert MPI.COMM_WORLD.size == 2"
+          mpiexec --oversubscribe -n 2 python -c "from mpi4py import MPI; assert MPI.COMM_WORLD.size == 2"
 
       - name: Run MPI smoke tests (2 ranks)
         run: |
           . .venv/bin/activate
-          mpiexec -n 2 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+          mpiexec --oversubscribe -n 2 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
 
       - name: Run MPI smoke tests (3 ranks)
         run: |
           . .venv/bin/activate
-          mpiexec -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+          mpiexec --oversubscribe -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider


### PR DESCRIPTION
## Summary

- Cache OpenMPI apt packages via `awalsh128/cache-apt-pkgs-action` in both `tests` and `mpi-tests` jobs (fast restore on cache hit vs. ~30–60s apt download every run)
- Add a venv cache to `mpi-tests` (was the only job without one) so mpi4py is only built from source when `pyproject.toml` changes

After these changes, on a typical PR that doesn't touch `pyproject.toml`:
- OpenMPI: fast cache restore (~5s)
- mpi4py: not rebuilt at all in either job

## Test plan

- [ ] All existing tests pass
- [ ] Pre-PR checks pass (ruff, mypy, pytest, docs)
- [ ] `mpi-tests` job passes with cached OpenMPI + cached venv

Generated with [Claude Code](https://claude.com/claude-code)