### PR TITLE
feat(thb): refine a THBSpline function (value-preserving)

### DIFF
--- a/src/pantr/bspline/_thb_spline.py
+++ b/src/pantr/bspline/_thb_spline.py
@@ -285,6 +285,83 @@ class THBSpline:
         out[...] = result
         return out
 
+    def refine(self, cell_ids: npt.ArrayLike, *, admissible_class: int | None = 2) -> THBSpline:
+        """Return the same function on a space with the marked cells refined.
+
+        Refines the underlying :class:`THBSplineSpace` (see
+        :meth:`THBSplineSpace.refine`) and prolongs the control points onto it, so the
+        returned spline represents the **same function** -- hierarchical refinement is
+        exact (the spaces are nested).  This does not mutate ``self``.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat ids of active cells to refine.
+            admissible_class (int | None): Admissibility class ``m >= 2`` to maintain
+                (graded refinement), or ``None`` for ungraded refinement.  Defaults
+                to ``2``.  See :meth:`THBSplineSpace.refine`.
+
+        Returns:
+            THBSpline: A new spline on the refined space, equal to ``self`` as a
+            function.
+
+        Raises:
+            IndexError: If any id is outside ``[0, grid.num_cells)``.
+            ValueError: If ``admissible_class`` is an integer ``< 2``.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        fine = self._space.refine(cell_ids, admissible_class=admissible_class)
+        return self._prolong_to(fine)
+
+    def refine_region(
+        self,
+        level: int,
+        lo: Sequence[int],
+        hi: Sequence[int],
+        *,
+        admissible_class: int | None = 2,
+    ) -> THBSpline:
+        """Return the same function on a space with a rectangular region refined.
+
+        Refines the underlying :class:`THBSplineSpace` (see
+        :meth:`THBSplineSpace.refine_region`) and prolongs the control points onto it,
+        so the returned spline represents the **same function**.  This does not mutate
+        ``self``.
+
+        Args:
+            level (int): Level at which the box lives.  Must satisfy
+                ``0 <= level <= grid.max_level``.
+            lo (Sequence[int]): Per-direction start index (inclusive), in
+                level-``level`` coordinates.
+            hi (Sequence[int]): Per-direction end index (exclusive), in
+                level-``level`` coordinates.
+            admissible_class (int | None): Admissibility class ``m >= 2`` to maintain,
+                or ``None`` for ungraded refinement.  Defaults to ``2``.  See
+                :meth:`THBSplineSpace.refine_region`.
+
+        Returns:
+            THBSpline: A new spline on the refined space, equal to ``self`` as a
+            function.
+
+        Raises:
+            ValueError: If ``admissible_class`` is an integer ``< 2``, ``level`` is
+                out of range, ``lo``/``hi`` have the wrong length, any
+                ``lo[k] >= hi[k]``, or ``[lo, hi)`` lies outside the level domain.
+            RuntimeError: If the grid has been modified since construction.
+        """
+        fine = self._space.refine_region(level, lo, hi, admissible_class=admissible_class)
+        return self._prolong_to(fine)
+
+    def _prolong_to(self, fine: THBSplineSpace) -> THBSpline:
+        """Prolong the control points onto a refinement ``fine`` (value-preserving).
+
+        Args:
+            fine (THBSplineSpace): A refinement of this spline's space.
+
+        Returns:
+            THBSpline: A new spline on ``fine`` equal to ``self`` as a function.
+        """
+        prolongation = self._space.prolongation_to(fine)
+        return THBSpline(fine, prolongation @ self.control_points)
+
     def __repr__(self) -> str:
         """Return a concise representation.
 

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -16,6 +16,7 @@ from pantr.bspline import (
     THBSplineSpace,
     THBSplineSpaceRestriction,
     create_thb_space,
+    create_uniform_space,
 )
 from pantr.bspline._thb_eval_core import _combine_tp_values
 from pantr.bspline._thb_spline_space import _box_all_true, _func_support_1d
@@ -1792,3 +1793,76 @@ class TestTHBSplineEvaluateGrouping:
             values, dofs = spline.space.tabulate_basis(int(cid), p[None, :])
             expected.append(float(np.asarray(values)[0] @ cp[dofs]))
         np.testing.assert_allclose(got, np.asarray(expected), rtol=1e-13, atol=0.0)
+
+
+class TestTHBSplineRefine:
+    """THBSpline.refine / refine_region refine a function, preserving its values."""
+
+    @staticmethod
+    def _field(rng: np.random.Generator, truncate: bool = True, rank: int = 1) -> THBSpline:
+        thb = create_thb_space(create_uniform_space([2, 2], [8, 8]), truncate=truncate)
+        shape = (thb.num_total_basis,) if rank == 1 else (thb.num_total_basis, rank)
+        return THBSpline(thb, rng.standard_normal(shape))
+
+    def test_refine_region_preserves_values(self) -> None:
+        rng = np.random.default_rng(0)
+        f = self._field(rng)
+        g = f.refine_region(0, [0, 0], [4, 4])
+        pts = rng.random((50, 2))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+        assert g.space.num_total_basis > f.space.num_total_basis
+
+    def test_refine_by_ids_preserves_values(self) -> None:
+        rng = np.random.default_rng(1)
+        f = self._field(rng)
+        g = f.refine([0, 1, 8, 9])
+        pts = rng.random((50, 2))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
+    def test_vector_field_preserves_values(self) -> None:
+        rng = np.random.default_rng(2)
+        f = self._field(rng, rank=3)
+        g = f.refine_region(0, [0, 0], [4, 4])
+        pts = rng.random((30, 2))
+        assert g.rank == 3
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
+    def test_scalar_stays_scalar(self) -> None:
+        rng = np.random.default_rng(3)
+        f = self._field(rng)
+        g = f.refine_region(0, [0, 0], [2, 2])
+        assert g.control_points.ndim == 1  # scalar field stays scalar
+
+    def test_hb_preserves_values(self) -> None:
+        rng = np.random.default_rng(4)
+        f = self._field(rng, truncate=False)
+        g = f.refine([0, 1], admissible_class=None)
+        pts = rng.random((40, 2))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
+    def test_chained_refinement_preserves_values(self) -> None:
+        rng = np.random.default_rng(5)
+        f = self._field(rng)
+        g = f.refine_region(0, [0, 0], [4, 4]).refine_region(1, [0, 0], [4, 4])
+        assert g.space.num_levels == 3
+        pts = rng.random((50, 2))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
+    def test_does_not_mutate_original(self) -> None:
+        rng = np.random.default_rng(6)
+        f = self._field(rng)
+        n_before = f.space.num_total_basis
+        cp_before = np.array(f.control_points)
+        f.refine_region(0, [0, 0], [4, 4])
+        assert f.space.num_total_basis == n_before
+        np.testing.assert_array_equal(f.control_points, cp_before)
+
+    def test_invalid_admissible_class_raises(self) -> None:
+        f = self._field(np.random.default_rng(7))
+        with pytest.raises(ValueError, match="admissible_class"):
+            f.refine([0], admissible_class=1)
+
+    def test_region_out_of_range_raises(self) -> None:
+        f = self._field(np.random.default_rng(8))
+        with pytest.raises(ValueError, match="level must be in"):
+            f.refine_region(9, [0, 0], [1, 1])

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1819,6 +1819,21 @@ class TestTHBSplineRefine:
         pts = rng.random((50, 2))
         np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
 
+    def test_preserves_values_1d(self) -> None:
+        rng = np.random.default_rng(9)
+        thb = create_thb_space(create_uniform_space(2, 8))  # 1D, degree 2
+        f = THBSpline(thb, rng.standard_normal(thb.num_total_basis))
+        g = f.refine_region(0, [0], [4])
+        pts = rng.random((50, 1))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
+    def test_ungraded_region_preserves_values(self) -> None:
+        rng = np.random.default_rng(10)
+        f = self._field(rng)
+        g = f.refine_region(0, [0, 0], [4, 4], admissible_class=None)
+        pts = rng.random((50, 2))
+        np.testing.assert_allclose(g.evaluate(pts), f.evaluate(pts), atol=1e-10)
+
     def test_vector_field_preserves_values(self) -> None:
         rng = np.random.default_rng(2)
         f = self._field(rng, rank=3)
@@ -1853,9 +1868,12 @@ class TestTHBSplineRefine:
         f = self._field(rng)
         n_before = f.space.num_total_basis
         cp_before = np.array(f.control_points)
-        f.refine_region(0, [0, 0], [4, 4])
+        g = f.refine_region(0, [0, 0], [4, 4])
         assert f.space.num_total_basis == n_before
         np.testing.assert_array_equal(f.control_points, cp_before)
+        # The read-only contract holds for both the original and the refined spline.
+        assert not f.control_points.flags.writeable
+        assert not g.control_points.flags.writeable
 
     def test_invalid_admissible_class_raises(self) -> None:
         f = self._field(np.random.default_rng(7))


### PR DESCRIPTION
## Summary
Adds function-level refinement to `THBSpline` (a `THBSplineSpace` + control points), the missing piece for adaptive loops — previously only the *space* could be refined.

- **`THBSpline.refine(cell_ids, *, admissible_class=2)`**
- **`THBSpline.refine_region(level, lo, hi, *, admissible_class=2)`**

Each refines the underlying space (`THBSplineSpace.refine` / `refine_region`) and prolongs the control points onto it via `prolongation_to`, returning a new `THBSpline` that represents the **same function** — hierarchical refinement is exact because the spaces are nested. Immutable and chainable, mirroring the space-level API; scalar and vector fields are both preserved.

```python
f = THBSpline(thb, coeffs)
g = f.refine_region(0, [0, 0], [4, 4])   # same function, richer space
# g.evaluate(pts) == f.evaluate(pts)
```

## Notes
- Builds on `prolongation_to`; once #234 (sparse prolongation) merges, this path is automatically fast. Independent of #234 — works with either prolongation implementation.
- Coarsening is intentionally **not** added here: unlike refinement it is a lossy projection, not value-preserving.

## Test plan
- [x] `TestTHBSplineRefine`: value preservation (1D/2D, scalar & rank-3 vector, graded & ungraded, HB, chained), scalar-stays-scalar, immutability of the original + read-only invariant on both splines, and error propagation.
- [x] Full suite green (3690 passed); ruff/format/mypy clean; docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)