### PR TITLE
feat(mpi): create_distributed_space — build a distributed space from a space

### DIFF
--- a/docs/guide/distributed.md
+++ b/docs/guide/distributed.md
@@ -139,6 +139,26 @@ that leaves a rank empty) gets `ds.local is None` and `ds.owns_cells is False`
 rather than failing -- guard with `if ds.owns_cells:` before assembling.
 ```
 
+### One-call shortcut
+
+When you don't need to hold the grid or partition yourself,
+`pantr.mpi.create_distributed_space(global_space, comm, *, method="grid", backend=None,
+cell_weights=None, cell_active=None)` derives the grid, partitions it, and builds the
+`DistributedSpace` in one call:
+
+```python
+from pantr.mpi import create_distributed_space
+
+ds = create_distributed_space(space, comm)                  # geometric (partition_grid)
+ds = create_distributed_space(space, comm, method="graph")  # coupling-graph (partition_graph)
+```
+
+`method="grid"` (default) partitions geometrically; `method="graph"` minimizes
+cross-rank DOF coupling. `backend=None` picks each method's default (`"auto"` /
+`"spectral"`), and `cell_weights` / `cell_active` are forwarded to the chosen
+partitioner. The explicit three-step flow above stays available when you need the grid
+or partition as separate objects.
+
 ## Immersion hooks
 
 PaNTr stores **no** geometric classification (interior / cut / exterior). An

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -17,6 +17,7 @@ Main exports:
 - :func:`require_mpi`: lazily import and return the ``mpi4py.MPI`` module, or raise.
 - :func:`from_dolfinx`: build a :class:`pantr.grid.Partition` from a dolfinx mesh.
 - :class:`DistributedSpace`: the per-rank handle to an MPI-distributed space.
+- :func:`create_distributed_space`: build a :class:`DistributedSpace` from a space.
 - :func:`configure_threads`: explicitly set this rank's Numba thread count.
 
 A process-level thread policy coordinates MPI with PaNTr's Numba parallelism: the
@@ -34,6 +35,7 @@ import importlib.util
 from types import ModuleType
 from typing import Final
 
+from ._create import create_distributed_space
 from ._distributed_space import DistributedSpace
 from ._from_dolfinx import from_dolfinx
 from ._thread_policy import configure_threads
@@ -96,6 +98,7 @@ __all__ = [
     "HAS_MPI",
     "DistributedSpace",
     "configure_threads",
+    "create_distributed_space",
     "from_dolfinx",
     "mpi_available",
     "require_mpi",

--- a/src/pantr/mpi/_create.py
+++ b/src/pantr/mpi/_create.py
@@ -1,0 +1,112 @@
+"""Convenience factory for building an MPI-distributed space directly from a space.
+
+Provides :func:`create_distributed_space`, the one-call counterpart to the explicit
+``partition -> DistributedSpace`` flow: it derives the grid, partitions it, and wraps
+the result, so a caller need not assemble the grid and :class:`~pantr.grid.Partition`
+by hand.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..bspline import BsplineSpace, THBSplineSpace, coupling_graph, partition_graph
+from ..grid import partition_grid, tensor_product_grid
+from ._distributed_space import DistributedSpace
+from ._thread_policy import _ensure_default_thread_policy
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from ..grid import Grid
+
+
+def create_distributed_space(  # noqa: PLR0913 -- public factory mirrors the partitioner args
+    global_space: BsplineSpace | THBSplineSpace,
+    comm: Any,  # noqa: ANN401 -- an mpi4py.MPI.Comm; mpi4py is an optional, untyped dep
+    *,
+    method: str = "grid",
+    backend: str | None = None,
+    cell_weights: npt.ArrayLike | None = None,
+    cell_active: npt.ArrayLike | None = None,
+) -> DistributedSpace:
+    """Build an MPI-distributed space directly from a global space.
+
+    Convenience wrapper over the explicit flow (derive grid -> partition ->
+    :class:`DistributedSpace`).  It derives the space's cell grid
+    (:func:`~pantr.grid.tensor_product_grid` for a :class:`~pantr.bspline.BsplineSpace`,
+    or :attr:`THBSplineSpace.grid <pantr.bspline.THBSplineSpace.grid>` for a hierarchical
+    space), partitions it across ``comm.size`` ranks, and returns the per-rank handle.
+    The partition is deterministic, so every rank computes the same one without
+    communication.
+
+    The explicit three-step flow remains available for full control; this factory just
+    removes the boilerplate for the common case.
+
+    Args:
+        global_space (BsplineSpace | THBSplineSpace): The global space to distribute,
+            identical on every rank.  A ``BsplineSpace`` must be non-periodic.
+        comm (Any): An MPI communicator (e.g. ``mpi4py.MPI.COMM_WORLD``).  Only its
+            ``rank`` and ``size`` are read; it is duck-typed.
+        method (str): Partitioning strategy.  ``"grid"`` (default) splits the cell grid
+            geometrically via :func:`~pantr.grid.partition_grid`; ``"graph"`` partitions
+            the cell-coupling graph (:func:`~pantr.bspline.coupling_graph` +
+            :func:`~pantr.bspline.partition_graph`) to minimize cross-rank DOF coupling.
+        backend (str | None): Partitioner backend.  ``None`` (default) selects each
+            method's default -- ``"auto"`` for ``"grid"`` (``"block"`` or ``"rcb"``),
+            ``"spectral"`` for ``"graph"`` (or ``"metis"``, needing the ``metis`` extra).
+        cell_weights (npt.ArrayLike | None): Per-cell assembly-cost weights.  For
+            ``"grid"`` they balance the geometric split; for ``"graph"`` they become the
+            coupling graph's vertex weights.  Defaults to ``None`` (uniform).
+        cell_active (npt.ArrayLike | None): Boolean per-cell activity mask; inactive
+            cells get owner ``-1`` and drop out of the partition.  Defaults to ``None``
+            (all active).
+
+    Returns:
+        DistributedSpace: The per-rank distributed-space handle.
+
+    Raises:
+        TypeError: If ``method="grid"`` and ``global_space`` is neither a
+            ``BsplineSpace`` nor a ``THBSplineSpace``.
+        ValueError: If ``method`` is not ``"grid"`` or ``"graph"``; if ``backend`` is
+            invalid for the chosen method; or if the derived partition is incompatible
+            with ``comm`` (e.g. ``comm.size`` mismatch), as raised downstream.
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP
+        >>> space = create_uniform_space([2, 2], [8, 8])  # doctest: +SKIP
+        >>> ds = create_distributed_space(space, MPI.COMM_WORLD)  # doctest: +SKIP
+    """
+    _ensure_default_thread_policy()
+    n_parts = int(comm.size)
+    if method == "grid":
+        grid: Grid
+        if isinstance(global_space, THBSplineSpace):
+            grid = global_space.grid
+        elif isinstance(global_space, BsplineSpace):
+            grid = tensor_product_grid(global_space)
+        else:
+            raise TypeError(
+                f"global_space must be a BsplineSpace or THBSplineSpace; "
+                f"got {type(global_space).__name__!r}."
+            )
+        partition = partition_grid(
+            grid,
+            n_parts,
+            backend="auto" if backend is None else backend,
+            cell_weights=cell_weights,
+            cell_active=cell_active,
+        )
+    elif method == "graph":
+        graph = coupling_graph(global_space, cell_weights=cell_weights)
+        partition = partition_graph(
+            graph,
+            n_parts,
+            backend="spectral" if backend is None else backend,
+            cell_active=cell_active,
+        )
+    else:
+        raise ValueError(f"method must be 'grid' or 'graph'; got {method!r}.")
+    return DistributedSpace(global_space, partition, comm)

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -18,7 +18,7 @@ import pytest
 
 from pantr.bspline import build_local, create_uniform_space
 from pantr.grid import partition_grid, tensor_product_grid
-from pantr.mpi import DistributedSpace, from_dolfinx
+from pantr.mpi import DistributedSpace, create_distributed_space, from_dolfinx
 
 MPI = pytest.importorskip("mpi4py.MPI")
 
@@ -49,6 +49,27 @@ def test_distributed_space_partitions_globals_across_ranks() -> None:
 
     all_cells = np.concatenate(comm.allgather(ds.owned_cells))
     np.testing.assert_array_equal(np.sort(all_cells), np.arange(space.num_total_intervals))
+
+
+def test_create_distributed_space_matches_explicit_across_ranks() -> None:
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])
+
+    ds = create_distributed_space(space, comm)  # one-call factory
+    ref = DistributedSpace(space, partition_grid(tensor_product_grid(space), comm.size), comm)
+
+    assert ds.rank == comm.rank and ds.n_parts == comm.size
+    np.testing.assert_array_equal(ds.owned_cells, ref.owned_cells)
+    if ds.local is not None:
+        assert ref.local is not None
+        np.testing.assert_array_equal(ds.local.local_to_global_dof, ref.local.local_to_global_dof)
+
+    # Collective: the factory's partition still tiles the globals exactly.
+    owned = (
+        ds.local.local_to_global_dof[ds.local.owned_dof_mask] if ds.local else np.empty(0, np.int64)
+    )
+    all_dofs = np.concatenate(comm.allgather(owned))
+    np.testing.assert_array_equal(np.sort(all_dofs), np.arange(space.num_total_basis))
 
 
 def _slice_mesh(comm: Any, owned: list[int]) -> SimpleNamespace:

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -276,7 +276,18 @@ class TestCreateDistributedSpace:
         got = create_distributed_space(space, _FakeComm(0, 2), cell_active=active)
         np.testing.assert_array_equal(got.partition.cell_owner, part.cell_owner)
 
+    def test_cell_weights_passthrough_graph(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        weights = np.arange(1, space.num_total_intervals + 1, dtype=np.float64)
+        part = partition_graph(coupling_graph(space, cell_weights=weights), 3)
+        got = create_distributed_space(space, _FakeComm(0, 3), method="graph", cell_weights=weights)
+        np.testing.assert_array_equal(got.partition.cell_owner, part.cell_owner)
+
     def test_invalid_method_raises(self) -> None:
         space = create_uniform_space([2, 2], [4, 4])
         with pytest.raises(ValueError, match="method must be"):
             create_distributed_space(space, _FakeComm(0, 4), method="bogus")
+
+    def test_grid_method_invalid_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="BsplineSpace or THBSplineSpace"):
+            create_distributed_space(object(), _FakeComm(0, 2))  # type: ignore[arg-type]

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -15,7 +15,9 @@ from pantr.bspline import (
     LocalSpace,
     THBSplineSpace,
     build_local,
+    coupling_graph,
     create_uniform_space,
+    partition_graph,
 )
 from pantr.grid import (
     Partition,
@@ -24,7 +26,7 @@ from pantr.grid import (
     tensor_product_grid,
     uniform_grid,
 )
-from pantr.mpi import DistributedSpace
+from pantr.mpi import DistributedSpace, create_distributed_space
 
 
 class _FakeComm:
@@ -211,3 +213,70 @@ def test_periodic_space_raises() -> None:
     part2 = Partition(np.zeros(n_cells, dtype=np.int64), 2)
     with pytest.raises(ValueError, match="periodic"):
         DistributedSpace(periodic_space, part2, _FakeComm(1, 2))
+
+
+# --------------------------------------------------------------------------- #
+# create_distributed_space convenience factory
+# --------------------------------------------------------------------------- #
+
+
+class TestCreateDistributedSpace:
+    """create_distributed_space mirrors the explicit grid/graph -> DistributedSpace flow."""
+
+    def test_grid_method_matches_explicit_tp(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        part = partition_grid(tensor_product_grid(space), 4)
+        for rank in range(4):
+            comm = _FakeComm(rank, 4)
+            got = create_distributed_space(space, comm)  # method="grid" default
+            ref = DistributedSpace(space, part, comm)
+            if got.local is not None:
+                assert ref.local is not None
+                _assert_local_equal(got.local, ref.local)
+            np.testing.assert_array_equal(got.owned_cells, ref.owned_cells)
+
+    def test_grid_method_matches_explicit_thb(self) -> None:
+        root = create_uniform_space(2, 4)
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2)
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(root, grid)
+        part = partition_grid(thb.grid, 2)
+        for rank in range(2):
+            comm = _FakeComm(rank, 2)
+            got = create_distributed_space(thb, comm)
+            ref = DistributedSpace(thb, part, comm)
+            if got.local is not None:
+                assert ref.local is not None
+                _assert_local_equal(got.local, ref.local)
+            np.testing.assert_array_equal(got.owned_cells, ref.owned_cells)
+
+    def test_graph_method_matches_explicit(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        part = partition_graph(coupling_graph(space), 3)
+        for rank in range(3):
+            comm = _FakeComm(rank, 3)
+            got = create_distributed_space(space, comm, method="graph")
+            ref = DistributedSpace(space, part, comm)
+            if got.local is not None:
+                assert ref.local is not None
+                _assert_local_equal(got.local, ref.local)
+            np.testing.assert_array_equal(got.owned_cells, ref.owned_cells)
+
+    def test_grid_backend_passthrough(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        part = partition_grid(tensor_product_grid(space), 4, backend="rcb")
+        got = create_distributed_space(space, _FakeComm(0, 4), backend="rcb")
+        np.testing.assert_array_equal(got.partition.cell_owner, part.cell_owner)
+
+    def test_cell_active_passthrough_grid(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        active = np.ones(space.num_total_intervals, dtype=bool)
+        active[:2] = False  # exclude two cells
+        part = partition_grid(tensor_product_grid(space), 2, cell_active=active)
+        got = create_distributed_space(space, _FakeComm(0, 2), cell_active=active)
+        np.testing.assert_array_equal(got.partition.cell_owner, part.cell_owner)
+
+    def test_invalid_method_raises(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        with pytest.raises(ValueError, match="method must be"):
+            create_distributed_space(space, _FakeComm(0, 4), method="bogus")

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -18,12 +18,14 @@ def test_import_and_public_surface() -> None:
     assert callable(pantr.mpi.require_mpi)
     assert callable(pantr.mpi.from_dolfinx)
     assert callable(pantr.mpi.configure_threads)
+    assert callable(pantr.mpi.create_distributed_space)
     assert isinstance(pantr.mpi.DistributedSpace, type)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
     assert set(pantr.mpi.__all__) == {
         "DistributedSpace",
         "HAS_MPI",
         "configure_threads",
+        "create_distributed_space",
         "from_dolfinx",
         "mpi_available",
         "require_mpi",


### PR DESCRIPTION
## Summary
Adds a one-call factory so you can go straight from a space to a distributed space, without assembling the grid and `Partition` by hand — while keeping the explicit 3-step flow fully intact.

```python
from pantr.mpi import create_distributed_space

ds = create_distributed_space(space, comm)                  # geometric (partition_grid)
ds = create_distributed_space(space, comm, method="graph")  # coupling-graph (partition_graph)
```

`create_distributed_space(global_space, comm, *, method="grid", backend=None, cell_weights=None, cell_active=None)`:
- **`method="grid"`** (default) — derives the cell grid (`tensor_product_grid` for `BsplineSpace`, `.grid` for `THBSplineSpace`) and partitions it geometrically via `partition_grid`.
- **`method="graph"`** — partitions the cell-coupling graph (`coupling_graph` + `partition_graph`) to minimize cross-rank DOF coupling.
- `backend=None` resolves each method's default (`"auto"` / `"spectral"`); `cell_weights` / `cell_active` are forwarded to the right call for each path.

It's a module-level factory (mirroring `create_thb_space` / `create_uniform_space`), lives in `pantr.mpi` (no core→mpi import; import-linter contract still **kept**), and calls `_ensure_default_thread_policy()` first per the MPI entry-point contract.

The explicit flow stays available unchanged:
```python
ds = DistributedSpace(space, partition_grid(tensor_product_grid(space), comm.size), comm)
```

## Test plan
- [x] Serial (`_FakeComm`) equivalence to the explicit flow — grid (B-spline + THB), graph; backend / `cell_active` / `cell_weights` passthrough; `method` ValueError; `TypeError` on bad space type.
- [x] Real-MPI smoke test in `tests/mpi/` (passes under `mpiexec -n 3`).
- [x] `pantr.mpi` public-surface test updated.
- [x] Full suite green; ruff/format/mypy clean; import-lint contract kept; docs build clean under `-W` (guide section added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)