### PR TITLE
feat(mpi): distribute functions (DistributedSpace.localize + DistributedFunction)

### DIFF
--- a/docs/guide/distributed.md
+++ b/docs/guide/distributed.md
@@ -159,6 +159,30 @@ cross-rank DOF coupling. `backend=None` picks each method's default (`"auto"` /
 partitioner. The explicit three-step flow above stays available when you need the grid
 or partition as separate objects.
 
+## Distributing a function
+
+To distribute a *function* (space **+** control points), not just a space, use
+`DistributedSpace.localize(control_points)` to slice a global coefficient field to this
+rank's local function, or `pantr.mpi.create_distributed_function(global_function, comm,
+...)` for the one-call path (same `method` / `backend` / `cell_weights` / `cell_active`
+options as `create_distributed_space`):
+
+```python
+from pantr.mpi import create_distributed_function
+
+df = create_distributed_function(global_function, comm)
+local_f = df.local            # this rank's windowed Bspline / THBSpline (or None)
+
+# Or localize many fields on one distributed space (solver loop):
+ds = create_distributed_space(space, comm)
+local_u = ds.localize(u)      # u, residual, ... are global coefficient vectors
+```
+
+The global control points are identical on every rank (the SPMD model); "distributing"
+windows the space and slices the coefficients to this rank's DOFs. `df.local` equals the
+global function pointwise over the rank's owned cells, and is `None` on a rank that owns
+no cells.
+
 ## Immersion hooks
 
 PaNTr stores **no** geometric classification (interior / cut / exterior). An

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -18,6 +18,8 @@ Main exports:
 - :func:`from_dolfinx`: build a :class:`pantr.grid.Partition` from a dolfinx mesh.
 - :class:`DistributedSpace`: the per-rank handle to an MPI-distributed space.
 - :func:`create_distributed_space`: build a :class:`DistributedSpace` from a space.
+- :class:`DistributedFunction`: the per-rank handle to an MPI-distributed function.
+- :func:`create_distributed_function`: build a :class:`DistributedFunction` from a function.
 - :func:`configure_threads`: explicitly set this rank's Numba thread count.
 
 A process-level thread policy coordinates MPI with PaNTr's Numba parallelism: the
@@ -36,6 +38,7 @@ from types import ModuleType
 from typing import Final
 
 from ._create import create_distributed_space
+from ._distributed_function import DistributedFunction, create_distributed_function
 from ._distributed_space import DistributedSpace
 from ._from_dolfinx import from_dolfinx
 from ._thread_policy import configure_threads
@@ -96,8 +99,10 @@ def require_mpi() -> ModuleType:
 
 __all__ = [
     "HAS_MPI",
+    "DistributedFunction",
     "DistributedSpace",
     "configure_threads",
+    "create_distributed_function",
     "create_distributed_space",
     "from_dolfinx",
     "mpi_available",

--- a/src/pantr/mpi/_distributed_function.py
+++ b/src/pantr/mpi/_distributed_function.py
@@ -1,0 +1,204 @@
+"""Per-rank handle for an MPI-distributed spline function (space + control points).
+
+Provides :class:`DistributedFunction`, the function-level counterpart of
+:class:`~pantr.mpi.DistributedSpace`, and the :func:`create_distributed_function`
+factory.  A distributed function pairs a :class:`~pantr.mpi.DistributedSpace` with a
+global coefficient field and exposes this rank's local
+:class:`~pantr.bspline.Bspline` / :class:`~pantr.bspline.THBSpline`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from ..bspline import Bspline, THBSpline
+from ._create import create_distributed_space
+from ._distributed_space import DistributedSpace
+from ._thread_policy import _ensure_default_thread_policy
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+def _dof_coeffs(function: Bspline | THBSpline) -> npt.NDArray[np.float64]:
+    """Return a function's control points indexed by global DOF.
+
+    A :class:`~pantr.bspline.THBSpline` already stores its coefficients per active DOF;
+    a :class:`~pantr.bspline.Bspline` stores them tensor-product reshaped
+    (``(*num_basis, rank)``), so they are flattened to ``(num_total_basis, rank)`` in the
+    C-order DOF numbering used by the windowing maps.
+
+    Args:
+        function (Bspline | THBSpline): The global function.
+
+    Returns:
+        npt.NDArray[np.float64]: Control points shaped ``(num_total_basis,)`` or
+        ``(num_total_basis, rank)``, indexed by global DOF.
+    """
+    cp = np.asarray(function.control_points, dtype=np.float64)
+    if isinstance(function, Bspline):
+        return cp.reshape(function.space.num_total_basis, -1)
+    return cp
+
+
+class DistributedFunction:
+    """Per-rank handle to an MPI-distributed spline function.
+
+    Pairs a :class:`~pantr.mpi.DistributedSpace` with a global control-point field and
+    holds this rank's local function -- the windowed space's
+    :class:`~pantr.bspline.Bspline` / :class:`~pantr.bspline.THBSpline` whose control
+    points are the global field sliced to the rank's local DOFs.  The local function
+    equals the global one pointwise over the rank's owned cells.  Construction performs
+    no MPI communication (it reuses the distributed space's windowing).
+
+    Attributes:
+        _global_function (Bspline | THBSpline): The undistributed global function.
+        _distributed_space (DistributedSpace): The distributed space it is defined on.
+        _local (Bspline | THBSpline | None): This rank's local function, or ``None``.
+    """
+
+    __slots__ = ("_distributed_space", "_global_function", "_local")
+
+    def __init__(
+        self,
+        global_function: Bspline | THBSpline,
+        distributed_space: DistributedSpace,
+    ) -> None:
+        """Build the distributed function by localizing the global control points.
+
+        Args:
+            global_function (Bspline | THBSpline): The global function, identical on
+                every rank.  Its space must be the one ``distributed_space`` distributes.
+            distributed_space (DistributedSpace): The distributed space whose
+                ``global_space`` is exactly ``global_function.space``.
+
+        Raises:
+            ValueError: If ``global_function.space`` is not the distributed space's
+                ``global_space``.
+        """
+        if global_function.space is not distributed_space.global_space:
+            raise ValueError(
+                "global_function.space must be the distributed_space's global_space; "
+                "build the DistributedSpace from this function's space."
+            )
+        self._global_function = global_function
+        self._distributed_space = distributed_space
+        self._local: Bspline | THBSpline | None = distributed_space.localize(
+            _dof_coeffs(global_function)
+        )
+
+    @property
+    def global_function(self) -> Bspline | THBSpline:
+        """Get the undistributed global function.
+
+        Returns:
+            Bspline | THBSpline: The global function passed at construction.
+        """
+        return self._global_function
+
+    @property
+    def distributed_space(self) -> DistributedSpace:
+        """Get the distributed space this function is defined on.
+
+        Returns:
+            DistributedSpace: The underlying distributed space.
+        """
+        return self._distributed_space
+
+    @property
+    def local(self) -> Bspline | THBSpline | None:
+        """Get this rank's local function, or ``None`` if it owns no cells.
+
+        Returns:
+            Bspline | THBSpline | None: The rank-local function on the windowed space
+            (control points sliced to local DOFs), or ``None`` when
+            :attr:`owns_cells` is ``False``.  Scalar vs. vector kind is preserved.
+        """
+        return self._local
+
+    @property
+    def rank(self) -> int:
+        """Get this rank's id within the communicator.
+
+        Returns:
+            int: The rank id (``== distributed_space.rank``).
+        """
+        return self._distributed_space.rank
+
+    @property
+    def n_parts(self) -> int:
+        """Get the number of ranks.
+
+        Returns:
+            int: The number of parts (``== distributed_space.n_parts``).
+        """
+        return self._distributed_space.n_parts
+
+    @property
+    def owns_cells(self) -> bool:
+        """Report whether this rank owns at least one cell.
+
+        Returns:
+            bool: ``True`` iff :attr:`local` is not ``None``.
+        """
+        return self._local is not None
+
+
+def create_distributed_function(  # noqa: PLR0913 -- public factory mirrors the partitioner args
+    global_function: Bspline | THBSpline,
+    comm: Any,  # noqa: ANN401 -- an mpi4py.MPI.Comm; mpi4py is an optional, untyped dep
+    *,
+    method: str = "grid",
+    backend: str | None = None,
+    cell_weights: npt.ArrayLike | None = None,
+    cell_active: npt.ArrayLike | None = None,
+) -> DistributedFunction:
+    """Build an MPI-distributed function directly from a global function.
+
+    The function-level counterpart of :func:`~pantr.mpi.create_distributed_space`:
+    distributes the function's space across ``comm`` and slices the control points to
+    each rank, returning a :class:`DistributedFunction` whose :attr:`~DistributedFunction.local`
+    is this rank's :class:`~pantr.bspline.Bspline` / :class:`~pantr.bspline.THBSpline`.
+
+    Args:
+        global_function (Bspline | THBSpline): The global function to distribute,
+            identical on every rank.
+        comm (Any): An MPI communicator (e.g. ``mpi4py.MPI.COMM_WORLD``); only its
+            ``rank`` and ``size`` are read.
+        method (str): Partitioning strategy, ``"grid"`` (default) or ``"graph"``.  See
+            :func:`~pantr.mpi.create_distributed_space`.
+        backend (str | None): Partitioner backend; ``None`` selects each method's
+            default.  See :func:`~pantr.mpi.create_distributed_space`.
+        cell_weights (npt.ArrayLike | None): Per-cell assembly-cost weights.  Defaults
+            to ``None``.
+        cell_active (npt.ArrayLike | None): Boolean per-cell activity mask.  Defaults to
+            ``None``.
+
+    Returns:
+        DistributedFunction: The per-rank distributed-function handle.
+
+    Raises:
+        ValueError: If ``method``/``backend`` are invalid, or the derived partition is
+            incompatible with ``comm`` (as raised downstream).
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> from pantr.bspline import Bspline, create_uniform_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_function  # doctest: +SKIP
+        >>> space = create_uniform_space([2, 2], [8, 8])  # doctest: +SKIP
+        >>> f = Bspline(space, coeffs)  # doctest: +SKIP
+        >>> df = create_distributed_function(f, MPI.COMM_WORLD)  # doctest: +SKIP
+        >>> local_f = df.local  # this rank's windowed function  # doctest: +SKIP
+    """
+    _ensure_default_thread_policy()
+    distributed_space = create_distributed_space(
+        global_function.space,
+        comm,
+        method=method,
+        backend=backend,
+        cell_weights=cell_weights,
+        cell_active=cell_active,
+    )
+    return DistributedFunction(global_function, distributed_space)

--- a/src/pantr/mpi/_distributed_function.py
+++ b/src/pantr/mpi/_distributed_function.py
@@ -22,22 +22,22 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
 
-def _dof_coeffs(function: Bspline | THBSpline) -> npt.NDArray[np.float64]:
+def _dof_coeffs(function: Bspline | THBSpline) -> npt.NDArray[np.float32 | np.float64]:
     """Return a function's control points indexed by global DOF.
 
     A :class:`~pantr.bspline.THBSpline` already stores its coefficients per active DOF;
     a :class:`~pantr.bspline.Bspline` stores them tensor-product reshaped
     (``(*num_basis, rank)``), so they are flattened to ``(num_total_basis, rank)`` in the
-    C-order DOF numbering used by the windowing maps.
+    C-order DOF numbering used by the windowing maps.  The function's dtype is preserved.
 
     Args:
         function (Bspline | THBSpline): The global function.
 
     Returns:
-        npt.NDArray[np.float64]: Control points shaped ``(num_total_basis,)`` or
-        ``(num_total_basis, rank)``, indexed by global DOF.
+        npt.NDArray[np.float32 | np.float64]: Control points shaped
+        ``(num_total_basis,)`` or ``(num_total_basis, rank)``, indexed by global DOF.
     """
-    cp = np.asarray(function.control_points, dtype=np.float64)
+    cp = np.asarray(function.control_points)
     if isinstance(function, Bspline):
         return cp.reshape(function.space.num_total_basis, -1)
     return cp

--- a/src/pantr/mpi/_distributed_space.py
+++ b/src/pantr/mpi/_distributed_space.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..bspline import BsplineSpace, THBSplineSpace, build_local
+import numpy as np
+
+from ..bspline import Bspline, BsplineSpace, THBSpline, THBSplineSpace, build_local
 from ._thread_policy import _ensure_default_thread_policy
 
 if TYPE_CHECKING:
-    import numpy as np
     import numpy.typing as npt
 
     from ..bspline import LocalSpace
@@ -196,6 +197,46 @@ class DistributedSpace:
             (empty if the rank owns none).
         """
         return self._owned_cells
+
+    def localize(self, control_points: npt.ArrayLike) -> Bspline | THBSpline | None:
+        """Restrict a global coefficient field to this rank's local function.
+
+        Slices the *global* control points (identical on every rank, one per global DOF)
+        down to this rank's local DOFs via :attr:`local`'s ``local_to_global_dof`` map,
+        and wraps them on the windowed :attr:`local` space.  The returned function equals
+        the global one pointwise over the rank's owned cells, so per-element evaluation
+        and assembly are local.  Reuse a single distributed space to localize many fields
+        (right-hand side, solution, residual, ...).
+
+        Args:
+            control_points (npt.ArrayLike): Global control points, shape
+                ``(n_global_dofs,)`` for a scalar field or ``(n_global_dofs, rank)`` for a
+                vector field, where ``n_global_dofs == global_space.num_total_basis``.
+
+        Returns:
+            Bspline | THBSpline | None: This rank's local function (a
+            :class:`~pantr.bspline.Bspline` for a tensor-product space, a
+            :class:`~pantr.bspline.THBSpline` for a hierarchical one), or ``None`` if the
+            rank owns no cells.  Scalar vs. vector kind is preserved.
+
+        Raises:
+            ValueError: If ``control_points``'s leading dimension is not
+                ``global_space.num_total_basis``.
+        """
+        local = self._local
+        if local is None:
+            return None
+        cp = np.asarray(control_points, dtype=np.float64)
+        n_global = self._global_space.num_total_basis
+        if cp.shape[0] != n_global:
+            raise ValueError(
+                f"control_points leading dimension must be {n_global} "
+                f"(global_space.num_total_basis); got {cp.shape[0]}."
+            )
+        local_cp = cp[local.local_to_global_dof]
+        if isinstance(local.space, THBSplineSpace):
+            return THBSpline(local.space, local_cp)
+        return Bspline(local.space, local_cp)
 
 
 def _global_cell_count(space: BsplineSpace | THBSplineSpace) -> int:

--- a/src/pantr/mpi/_distributed_space.py
+++ b/src/pantr/mpi/_distributed_space.py
@@ -226,7 +226,7 @@ class DistributedSpace:
         local = self._local
         if local is None:
             return None
-        cp = np.asarray(control_points, dtype=np.float64)
+        cp = np.asarray(control_points, dtype=self._global_space.dtype)
         n_global = self._global_space.num_total_basis
         if cp.shape[0] != n_global:
             raise ValueError(

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -16,9 +16,14 @@ from typing import Any
 import numpy as np
 import pytest
 
-from pantr.bspline import build_local, create_uniform_space
+from pantr.bspline import Bspline, build_local, create_uniform_space
 from pantr.grid import partition_grid, tensor_product_grid
-from pantr.mpi import DistributedSpace, create_distributed_space, from_dolfinx
+from pantr.mpi import (
+    DistributedSpace,
+    create_distributed_function,
+    create_distributed_space,
+    from_dolfinx,
+)
 
 MPI = pytest.importorskip("mpi4py.MPI")
 
@@ -70,6 +75,43 @@ def test_create_distributed_space_matches_explicit_across_ranks() -> None:
     )
     all_dofs = np.concatenate(comm.allgather(owned))
     np.testing.assert_array_equal(np.sort(all_dofs), np.arange(space.num_total_basis))
+
+
+def test_create_distributed_function_reproduces_serial_field() -> None:
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])
+    # Identical global field on every rank (same seed), then distribute it.
+    cp = np.arange(space.num_total_basis, dtype=np.float64)  # deterministic, same on all ranks
+    global_fn = Bspline(space, cp)
+    dfn = create_distributed_function(global_fn, comm)
+
+    assert dfn.rank == comm.rank and dfn.n_parts == comm.size
+    assert dfn.owns_cells == (dfn.local is not None)
+
+    # Each rank evaluates its local field at the midpoints of its owned cells; the
+    # gathered (cell, value) pairs must reproduce the serial field over every cell.
+    cells: list[int] = []
+    vals: list[float] = []
+    if dfn.local is not None:
+        assert isinstance(dfn.local, Bspline)
+        local = dfn.distributed_space.local
+        assert local is not None
+        lgrid = tensor_product_grid(dfn.local.space)
+        for lc in np.flatnonzero(local.owned_cell_mask):
+            lo, hi = lgrid.cell_bounds(int(lc))
+            mid = (0.5 * (lo + hi))[None]
+            cells.append(int(local.local_to_global_cell[lc]))
+            vals.append(float(np.asarray(dfn.local.evaluate(mid)).reshape(-1)[0]))
+
+    all_cells = np.concatenate(comm.allgather(np.asarray(cells, dtype=np.int64)))
+    all_vals = np.concatenate(comm.allgather(np.asarray(vals, dtype=np.float64)))
+    order = np.argsort(all_cells)
+    np.testing.assert_array_equal(all_cells[order], np.arange(space.num_total_intervals))
+
+    grid = tensor_product_grid(space)
+    lo, hi = grid.collect_cell_bounds()
+    serial = np.asarray(global_fn.evaluate(0.5 * (lo + hi))).reshape(-1)
+    np.testing.assert_allclose(all_vals[order], serial, atol=1e-10)
 
 
 def _slice_mesh(comm: Any, owned: list[int]) -> SimpleNamespace:

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -409,6 +409,39 @@ class TestDistributedFunction:
                 assert ref is not None
                 np.testing.assert_array_equal(dfn.local.control_points, ref.control_points)
 
+    def test_vector_bspline_value_preserving(self) -> None:
+        # Exercises _dof_coeffs flattening of a vector Bspline (*num_basis, rank).
+        space = create_uniform_space([2, 2], [4, 4])
+        cp = np.random.default_rng(10).standard_normal((space.num_total_basis, 2))
+        gfn = Bspline(space, cp)
+        for rank in range(4):
+            dfn = create_distributed_function(gfn, _FakeComm(rank, 4))
+            if dfn.local is None:
+                continue
+            assert isinstance(dfn.local, Bspline) and dfn.local.control_points.shape[-1] == 2
+            local = dfn.distributed_space.local
+            assert local is not None
+            grid = tensor_product_grid(dfn.local.space)
+            for lc in np.flatnonzero(local.owned_cell_mask):
+                lo, hi = grid.cell_bounds(int(lc))
+                mid = (0.5 * (lo + hi))[None]
+                np.testing.assert_allclose(dfn.local.evaluate(mid), gfn.evaluate(mid), atol=1e-10)
+
+    def test_empty_rank_owns_nothing(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        part = Partition(np.zeros(space.num_total_intervals, dtype=np.int64), 2)  # rank 1 empty
+        fn = Bspline(space, np.zeros(space.num_total_basis))
+        dfn = DistributedFunction(fn, DistributedSpace(space, part, _FakeComm(1, 2)))
+        assert dfn.local is None
+        assert dfn.owns_cells is False
+
+    def test_float32_bspline(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4], dtype=np.float32)
+        cp = np.random.default_rng(11).standard_normal(space.num_total_basis).astype(np.float32)
+        dfn = create_distributed_function(Bspline(space, cp), _FakeComm(0, 2))
+        assert dfn.local is not None
+        assert dfn.local.control_points.dtype == np.float32
+
     def test_graph_method_thb(self) -> None:
         thb = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(
             0, [0, 0], [4, 4]

--- a/tests/test_distributed_space.py
+++ b/tests/test_distributed_space.py
@@ -10,12 +10,15 @@ import numpy as np
 import pytest
 
 from pantr.bspline import (
+    Bspline,
     BsplineSpace,
     BsplineSpace1D,
     LocalSpace,
+    THBSpline,
     THBSplineSpace,
     build_local,
     coupling_graph,
+    create_thb_space,
     create_uniform_space,
     partition_graph,
 )
@@ -26,7 +29,12 @@ from pantr.grid import (
     tensor_product_grid,
     uniform_grid,
 )
-from pantr.mpi import DistributedSpace, create_distributed_space
+from pantr.mpi import (
+    DistributedFunction,
+    DistributedSpace,
+    create_distributed_function,
+    create_distributed_space,
+)
 
 
 class _FakeComm:
@@ -291,3 +299,130 @@ class TestCreateDistributedSpace:
     def test_grid_method_invalid_type_raises(self) -> None:
         with pytest.raises(TypeError, match="BsplineSpace or THBSplineSpace"):
             create_distributed_space(object(), _FakeComm(0, 2))  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# DistributedSpace.localize and DistributedFunction
+# --------------------------------------------------------------------------- #
+
+
+def _assert_local_field_matches_global(
+    local_fn: Bspline | THBSpline,
+    global_fn: Bspline | THBSpline,
+    local: LocalSpace,
+    grid: object,
+) -> None:
+    """Local function reproduces the global one at every owned cell's midpoint."""
+    for lc in np.flatnonzero(local.owned_cell_mask):
+        lo, hi = grid.cell_bounds(int(lc))  # type: ignore[attr-defined]
+        mid = (0.5 * (lo + hi))[None]
+        np.testing.assert_allclose(local_fn.evaluate(mid), global_fn.evaluate(mid), atol=1e-10)
+
+
+class TestLocalize:
+    """DistributedSpace.localize slices a global field to this rank's local function."""
+
+    def test_matches_manual_slice_thb(self) -> None:
+        # THBSpline keeps control points flat per DOF, so the slice is direct.
+        thb = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(
+            0, [0, 0], [4, 4]
+        )
+        cp = np.random.default_rng(0).standard_normal(thb.num_total_basis)
+        part = partition_grid(thb.grid, 3)
+        for rank in range(3):
+            ds = DistributedSpace(thb, part, _FakeComm(rank, 3))
+            local_fn = ds.localize(cp)
+            if local_fn is None:
+                continue
+            assert ds.local is not None
+            np.testing.assert_array_equal(local_fn.control_points, cp[ds.local.local_to_global_dof])
+
+    def test_value_preserving_bspline(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        cp = np.random.default_rng(1).standard_normal((space.num_total_basis, 2))  # vector
+        gfn = Bspline(space, cp)
+        part = partition_grid(tensor_product_grid(space), 4)
+        for rank in range(4):
+            ds = DistributedSpace(space, part, _FakeComm(rank, 4))
+            lf = ds.localize(cp)
+            if lf is None:
+                continue
+            assert ds.local is not None
+            assert isinstance(lf, Bspline)
+            _assert_local_field_matches_global(lf, gfn, ds.local, tensor_product_grid(lf.space))
+
+    def test_value_preserving_thb(self) -> None:
+        thb = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(
+            0, [0, 0], [4, 4]
+        )
+        cp = np.random.default_rng(2).standard_normal(thb.num_total_basis)
+        gfn = THBSpline(thb, cp)
+        part = partition_grid(thb.grid, 3)
+        for rank in range(3):
+            ds = DistributedSpace(thb, part, _FakeComm(rank, 3))
+            lf = ds.localize(cp)
+            if lf is None:
+                continue
+            assert ds.local is not None
+            assert isinstance(lf, THBSpline)
+            _assert_local_field_matches_global(lf, gfn, ds.local, lf.space.grid)
+
+    def test_scalar_thb_stays_scalar(self) -> None:
+        thb = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(
+            0, [0, 0], [4, 4]
+        )
+        cp = np.random.default_rng(3).standard_normal(thb.num_total_basis)  # scalar (1-D)
+        ds = DistributedSpace(thb, partition_grid(thb.grid, 2), _FakeComm(0, 2))
+        lf = ds.localize(cp)
+        assert lf is not None and lf.control_points.ndim == 1
+
+    def test_empty_rank_returns_none(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        n_cells = space.num_total_intervals
+        part = Partition(np.zeros(n_cells, dtype=np.int64), 2)  # rank 1 owns nothing
+        cp = np.zeros(space.num_total_basis)
+        assert DistributedSpace(space, part, _FakeComm(1, 2)).localize(cp) is None
+
+    def test_wrong_size_raises(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        ds = DistributedSpace(space, partition_grid(tensor_product_grid(space), 2), _FakeComm(0, 2))
+        with pytest.raises(ValueError, match="leading dimension must be"):
+            ds.localize(np.zeros(space.num_total_basis + 1))
+
+
+class TestDistributedFunction:
+    """create_distributed_function / DistributedFunction wrap a distributed field."""
+
+    def test_local_matches_localize(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        cp = np.random.default_rng(4).standard_normal(space.num_total_basis)
+        fn = Bspline(space, cp)
+        for rank in range(4):
+            comm = _FakeComm(rank, 4)
+            dfn = create_distributed_function(fn, comm)
+            ref = create_distributed_space(space, comm).localize(cp)
+            assert dfn.rank == rank and dfn.n_parts == 4
+            assert dfn.owns_cells == (dfn.local is not None)
+            if dfn.local is None:
+                assert ref is None
+            else:
+                assert ref is not None
+                np.testing.assert_array_equal(dfn.local.control_points, ref.control_points)
+
+    def test_graph_method_thb(self) -> None:
+        thb = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(
+            0, [0, 0], [4, 4]
+        )
+        fn = THBSpline(thb, np.random.default_rng(5).standard_normal(thb.num_total_basis))
+        dfn = create_distributed_function(fn, _FakeComm(0, 2), method="graph")
+        assert isinstance(dfn.local, THBSpline)
+        assert dfn.global_function is fn
+        assert dfn.distributed_space.global_space is thb
+
+    def test_space_mismatch_raises(self) -> None:
+        space = create_uniform_space([2, 2], [4, 4])
+        other = create_uniform_space([2, 2], [4, 4])  # equal but a different object
+        fn = Bspline(space, np.zeros(space.num_total_basis))
+        ds = create_distributed_space(other, _FakeComm(0, 2))
+        with pytest.raises(ValueError, match="global_space"):
+            DistributedFunction(fn, ds)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -19,12 +19,16 @@ def test_import_and_public_surface() -> None:
     assert callable(pantr.mpi.from_dolfinx)
     assert callable(pantr.mpi.configure_threads)
     assert callable(pantr.mpi.create_distributed_space)
+    assert callable(pantr.mpi.create_distributed_function)
     assert isinstance(pantr.mpi.DistributedSpace, type)
+    assert isinstance(pantr.mpi.DistributedFunction, type)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
     assert set(pantr.mpi.__all__) == {
+        "DistributedFunction",
         "DistributedSpace",
         "HAS_MPI",
         "configure_threads",
+        "create_distributed_function",
         "create_distributed_space",
         "from_dolfinx",
         "mpi_available",


### PR DESCRIPTION
## Summary
Completes the distributed API by distributing a *function* (space **+** control points), not just a space — the function-level counterpart of `DistributedSpace` / `create_distributed_space`.

- **`DistributedSpace.localize(control_points)`** — slice a global coefficient field (indexed by global DOF, `(n_global,)` or `(n_global, rank)`) to this rank's local `Bspline`/`THBSpline` on the windowed space; `None` if the rank owns no cells. Reuse one distributed space to localize many fields (rhs, solution, residual, …).
- **`DistributedFunction`** + **`create_distributed_function(global_function, comm, *, method, backend, cell_weights, cell_active)`** — per-rank handle mirroring `DistributedSpace`: `.local`, `.rank`, `.n_parts`, `.owns_cells`, `.distributed_space`, `.global_function`. The factory distributes the space (via `create_distributed_space`) and localizes.

```python
df = create_distributed_function(global_function, comm)
local_f = df.local            # this rank's windowed Bspline / THBSpline (or None)

# or, reuse one distributed space for many fields:
ds = create_distributed_space(space, comm)
local_u = ds.localize(u)
```

The local function equals the global one pointwise over the rank's owned cells (SPMD: global coefficients identical on every rank, then windowed + sliced). `Bspline` control points (tensor-product reshaped) are flattened to C-order DOF numbering before slicing — verified to match `build_local`'s `local_to_global_dof`; `THBSpline` coefficients are already per-DOF. Scalar/vector kind and dtype (float32/float64) preserved.

## Test plan
- [x] Serial (`_FakeComm`): `localize` manual-slice (THB), value-preservation at owned-cell midpoints (B-spline vector + THB scalar), scalar-stays-scalar, empty-rank→None, wrong-size→ValueError; `DistributedFunction` local-matches-localize, vector B-spline value-preservation, empty-rank handle, float32, graph method, space-mismatch→ValueError.
- [x] Real-MPI smoke test (`mpiexec -n {2,3}`): distributed field reproduces the serial field over all cells across ranks.
- [x] Public-surface test updated; full suite green (3714 passed); ruff/format/mypy clean; import-lint contract kept; docs build clean under `-W` (guide section added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)