### PR TITLE
docs(tutorials): modernize THB tutorial with create_thb_space + adaptive loop

### DIFF
--- a/tutorials/08_thb_adaptive_refinement.py
+++ b/tutorials/08_thb_adaptive_refinement.py
@@ -11,27 +11,32 @@ coarser levels unchanged (truncation preserves coefficients). The API mirrors th
 tensor-product one: a :class:`~pantr.bspline.THBSplineSpace` plays the role of
 :class:`~pantr.bspline.BsplineSpace`.
 
-This tutorial refines toward a localized feature, quasi-interpolates a peaked function
-onto the hierarchical space, and renders the field with its hierarchical mesh and
-per-level control net (:doc:`/guide/visualization`).
+This tutorial builds a hierarchical space with the ergonomic
+:func:`~pantr.bspline.create_thb_space` /
+:meth:`~pantr.bspline.THBSplineSpace.refine_region` API, runs an *error-driven adaptive
+loop* that refines the space where the approximation is poor, and shows that refining a
+*function* (:meth:`~pantr.bspline.THBSpline.refine_region`) carries its coefficients
+exactly. Fields are rendered with their hierarchical mesh and per-level control net
+(:doc:`/guide/visualization`).
 """
 
 import numpy as np
 
 from pantr import viz
-from pantr.bspline import THBSplineSpace, create_uniform_space, quasi_interpolate_thb_spline
-from pantr.grid import hierarchical_grid, uniform_grid
+from pantr.bspline import create_thb_space, create_uniform_space, quasi_interpolate_thb_spline
 
 # %%
-# Build a graded hierarchical space
-# ---------------------------------
-# Start from a biquadratic 8x8 grid and refine the lower-left block twice, so
-# fine cells cluster where a peak will sit.
-root = create_uniform_space([2, 2], [8, 8])
-grid = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 8), 2)
-grid.refine(0, [0, 0], [4, 4])  # level 0 -> 1 on the lower-left quarter
-grid.refine(1, [0, 0], [4, 4])  # level 1 -> 2 on the lower-left of that
-space = THBSplineSpace(root, grid)
+# Build a hierarchical space
+# --------------------------
+# :func:`~pantr.bspline.create_thb_space` lifts a tensor-product
+# :class:`~pantr.bspline.BsplineSpace` into a single-level THB space;
+# :meth:`~pantr.bspline.THBSplineSpace.refine_region` refines a rectangular block of
+# active cells and returns a **new** space (immutable, chainable). Here we cluster fine
+# cells in the lower-left corner where a peak will sit.
+root = create_uniform_space([2, 2], [8, 8])  # biquadratic, 8x8 elements
+space = create_thb_space(root)
+space = space.refine_region(0, [0, 0], [4, 4])  # level 0 -> 1 on the lower-left quarter
+space = space.refine_region(1, [0, 0], [4, 4])  # level 1 -> 2 on the lower-left of that
 print(f"{space.num_levels} levels, {space.num_total_basis} active functions")
 
 
@@ -55,7 +60,45 @@ field = quasi_interpolate_thb_spline(peak, space)
 viz.plot(field, elevation=True, show_knot_lines=True, show_control_polygon=True)
 
 # %%
-# Just the hierarchical mesh
-# --------------------------
-# The active cells alone make the octree-like refinement structure obvious.
-viz.plot(field, elevation=True, show_knot_lines=True, color="lightsteelblue")
+# Adaptive refinement loop
+# ------------------------
+# Rather than refine a fixed block, let the *approximation error* drive refinement.
+# Each pass estimates a per-cell error (the peak vs. the current field at cell
+# midpoints), marks the worst cells, refines the space there with
+# :meth:`~pantr.bspline.THBSplineSpace.refine` (graded and immutable, so it returns a
+# new space), and re-quasi-interpolates. The mesh concentrates on the peak on its own.
+adaptive = create_thb_space(root)
+approx = quasi_interpolate_thb_spline(peak, adaptive)
+for it in range(4):
+    cell_lo, cell_hi = adaptive.grid.collect_cell_bounds()
+    midpoints = 0.5 * (cell_lo + cell_hi)
+    cell_error = np.abs(peak(midpoints) - np.asarray(approx.evaluate(midpoints)))
+    marked = np.flatnonzero(cell_error > 0.05 * cell_error.max())
+    if marked.size == 0:
+        break
+    adaptive = adaptive.refine(marked)  # mark -> refine -> new space
+    approx = quasi_interpolate_thb_spline(peak, adaptive)
+    print(f"pass {it}: {adaptive.num_total_basis} dofs, max cell error {cell_error.max():.2e}")
+
+# %%
+# The adapted mesh
+# ----------------
+# The active cells alone make the error-driven refinement structure obvious -- fine
+# cells track the peak without the rest of the domain paying for it.
+viz.plot(approx, elevation=True, show_knot_lines=True, color="lightsteelblue")
+
+# %%
+# Refining a function is exact
+# ----------------------------
+# :meth:`~pantr.bspline.THBSpline.refine` / ``refine_region`` refine the *function*
+# (space **and** coefficients): they return the **same field** on a finer space.
+# Hierarchical spaces are nested, so the prolongation is exact -- this is the lossless
+# field transfer used to carry a solution to a finer mesh inside an adaptive solver.
+finer = field.refine_region(0, [0, 0], [8, 8])  # refine the remaining coarse cells
+sample = np.random.default_rng(0).random((200, 2))
+max_diff = np.abs(finer.evaluate(sample) - field.evaluate(sample)).max()
+assert np.allclose(finer.evaluate(sample), field.evaluate(sample))
+print(
+    f"prolonged {field.space.num_total_basis} -> {finer.space.num_total_basis} dofs; "
+    f"field unchanged (max diff {max_diff:.2e})"
+)


### PR DESCRIPTION
## Summary
Brings `tutorials/08_thb_adaptive_refinement.py` up to the ergonomic THB API added in #233/#235 — it was still using the pre-#233 verbose construction and demonstrated none of the new entry points.

- **Build** via `create_thb_space(root)` + chained `refine_region(level, lo, hi)` (was `hierarchical_grid(uniform_grid(...), 2)` + `grid.refine(...)` + `THBSplineSpace(root, grid)`).
- **New "Adaptive refinement loop" section** — error-driven refinement: estimate a per-cell error (peak vs. field at cell midpoints), mark the worst cells, `space = space.refine(marked)` (graded, immutable), re-quasi-interpolate. The mesh concentrates on the peak on its own (max cell error 1.3e-1 → 3.7e-3 over 4 passes).
- **New "Refining a function is exact" section** — `THBSpline.refine_region` carries the field's coefficients losslessly (prolongation is exact; max diff ~1e-15), the value-preserving field transfer for adaptive solvers.

This is the only doc gap the THB/MPI PR series (#233–#237) left: the distribution work (#234/#236/#237) is already covered in `docs/guide/distributed.md`, and the API reference auto-documents the new symbols via `automodule`.

## Test plan
- [x] Tutorial executes end-to-end (computational flow validated locally sans viz: construction, adaptive loop, exact prolongation).
- [x] ruff / ruff-format / mypy clean; docs build clean under `-W`.
- [x] The `Build documentation` CI job runs the tutorial under Sphinx-Gallery (with a virtual display) — exercises the `viz.plot` render calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)