### PR TITLE
feat(mpi): quasi_interpolate_thb_spline_distributed for DistributedSpace

### DIFF
--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -22,6 +22,7 @@ Main exports:
 - :func:`create_distributed_function`: build a :class:`DistributedFunction` from a function.
 - :func:`configure_threads`: explicitly set this rank's Numba thread count.
 - :func:`quasi_interpolate_bspline_distributed`: distributed B-spline quasi-interpolation.
+- :func:`quasi_interpolate_thb_spline_distributed`: distributed THB-spline quasi-interpolation.
 
 A process-level thread policy coordinates MPI with PaNTr's Numba parallelism: the
 first use of any MPI-engaging entry point limits this process to **one Numba thread
@@ -43,6 +44,7 @@ from ._distributed_function import DistributedFunction, create_distributed_funct
 from ._distributed_space import DistributedSpace
 from ._from_dolfinx import from_dolfinx
 from ._qi import quasi_interpolate_bspline_distributed
+from ._thb_qi import quasi_interpolate_thb_spline_distributed
 from ._thread_policy import configure_threads
 
 
@@ -109,5 +111,6 @@ __all__ = [
     "from_dolfinx",
     "mpi_available",
     "quasi_interpolate_bspline_distributed",
+    "quasi_interpolate_thb_spline_distributed",
     "require_mpi",
 ]

--- a/src/pantr/mpi/_thb_qi.py
+++ b/src/pantr/mpi/_thb_qi.py
@@ -4,7 +4,8 @@ Provides :func:`quasi_interpolate_thb_spline_distributed`, the MPI-parallel coun
 of :func:`~pantr.bspline.quasi_interpolate_thb_spline`.  Each rank runs the serial
 Speleers-Manni hierarchical quasi-interpolant on its *windowed* local space -- which
 covers every owned active DOF's full support, including the level-``l`` active leaf cell
-the per-level functional samples -- then keeps only its *owned* DOFs' coefficients.  A
+on which the per-level functional samples ``func`` -- then keeps only its *owned* DOFs'
+coefficients.  A
 single ``allgather`` collective assembles the full global coefficient field.  The result
 is a :class:`~pantr.mpi.DistributedFunction` whose
 :attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial quasi-interpolant
@@ -75,11 +76,11 @@ def quasi_interpolate_thb_spline_distributed(
             with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
 
     Note:
-        All computation uses ``float64``.  Scalar vs. vector kind is preserved (a scalar
-        ``func`` yields a scalar :class:`~pantr.bspline.THBSpline`).  Like the serial
+        Scalar vs. vector kind is preserved (a scalar ``func`` yields a scalar
+        :class:`~pantr.bspline.THBSpline`).  Like the serial
         :func:`~pantr.bspline.quasi_interpolate_thb_spline`, the result is always
-        ``float64`` -- :class:`~pantr.bspline.THBSpline` stores ``float64`` coefficients
-        regardless of ``global_space.dtype``.
+        ``float64``: :class:`~pantr.bspline.THBSpline` coerces its coefficients to
+        ``float64`` on construction, regardless of ``global_space.dtype``.
 
     Example:
         >>> from mpi4py import MPI  # doctest: +SKIP
@@ -118,11 +119,11 @@ def quasi_interpolate_thb_spline_distributed(
         # (num_total_basis, rank) vector.  Preserve that rank so scalar funcs stay
         # scalar, matching the serial quasi-interpolant exactly.
         local_thb = quasi_interpolate_thb_spline(func, local.space, kind=kind)
-        coeffs = np.asarray(local_thb.control_points, dtype=np.float64)
+        cp = np.asarray(local_thb.control_points, dtype=np.float64)
         # Restrict to owned DOFs and record their global indices.
         owned_mask = local.owned_dof_mask
         owned_global_dofs: npt.NDArray[np.int64] = local.local_to_global_dof[owned_mask]
-        owned_coeffs: npt.NDArray[np.float64] = coeffs[owned_mask]
+        owned_coeffs: npt.NDArray[np.float64] = cp[owned_mask]
     else:
         owned_global_dofs = np.empty(0, dtype=np.int64)
         owned_coeffs = np.empty(0, dtype=np.float64)
@@ -133,7 +134,8 @@ def quasi_interpolate_thb_spline_distributed(
     )
 
     # Detect scalar vs. vector (and its rank) from the first non-empty contribution.
-    # At least one rank owns cells, so a non-empty contribution always exists.
+    # Every global DOF is owned by exactly one rank, so for any non-empty space at
+    # least one rank contributes a non-empty array (the loop always breaks).
     scalar = True
     rank_dim = 1
     for _, coeffs in gathered:

--- a/src/pantr/mpi/_thb_qi.py
+++ b/src/pantr/mpi/_thb_qi.py
@@ -1,0 +1,163 @@
+"""Distributed quasi-interpolation onto THB-spline spaces.
+
+Provides :func:`quasi_interpolate_thb_spline_distributed`, the MPI-parallel counterpart
+of :func:`~pantr.bspline.quasi_interpolate_thb_spline`.  Each rank runs the serial
+Speleers-Manni hierarchical quasi-interpolant on its *windowed* local space -- which
+covers every owned active DOF's full support, including the level-``l`` active leaf cell
+the per-level functional samples -- then keeps only its *owned* DOFs' coefficients.  A
+single ``allgather`` collective assembles the full global coefficient field.  The result
+is a :class:`~pantr.mpi.DistributedFunction` whose
+:attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial quasi-interpolant
+exactly over the rank's owned cells.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, get_args
+
+import numpy as np
+
+from ..bspline import THBSpline, THBSplineSpace
+from ..bspline._bspline_quasi_interpolation import QIKind
+from ..bspline._thb_quasi_interpolation import quasi_interpolate_thb_spline
+from ._distributed_function import DistributedFunction
+from ._distributed_space import DistributedSpace
+from ._thread_policy import _ensure_default_thread_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy.typing as npt
+
+
+def quasi_interpolate_thb_spline_distributed(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    distributed_space: DistributedSpace,
+    *,
+    kind: QIKind = "llm",
+) -> DistributedFunction:
+    """Quasi-interpolate a callable onto a distributed THB-spline space.
+
+    The MPI-parallel counterpart of
+    :func:`~pantr.bspline.quasi_interpolate_thb_spline`.  Each rank runs the serial
+    Speleers-Manni hierarchical quasi-interpolant on its windowed local space and keeps
+    only its *owned* DOFs' coefficients; a single ``allgather`` at the end assembles the
+    global coefficient field.  The returned
+    :class:`~pantr.mpi.DistributedFunction` agrees with the serial quasi-interpolant
+    pointwise over every owned cell.
+
+    The windowed local space covers the support closure of every owned DOF, so the
+    per-level functional's level-``l`` active leaf cell -- the one the serial routine
+    samples ``func`` on -- always lies inside the rank's windowed parametric domain.  No
+    rank ever evaluates ``func`` outside that domain.  Construction requires one MPI
+    collective (``comm.allgather``) after the local computation.
+
+    Args:
+        func (Callable): Function to quasi-interpolate.  Called on a flat
+            ``(M, dim)`` point array; must return ``(M,)`` (scalar) or ``(M, rank)``
+            (vector-valued).
+        distributed_space (DistributedSpace): The distributed space to interpolate onto.
+            Its ``global_space`` must be a :class:`~pantr.bspline.THBSplineSpace`.
+        kind (QIKind): Quasi-interpolant kind.  Only ``"llm"`` (Lee-Lyche-Mørken) is
+            currently supported.  Defaults to ``"llm"``.
+
+    Returns:
+        DistributedFunction: A distributed function whose
+        :attr:`~pantr.mpi.DistributedFunction.local` quasi-interpolates ``func`` over
+        this rank's owned cells, and whose
+        :attr:`~pantr.mpi.DistributedFunction.global_function` holds the full assembled
+        global coefficient field (identical on every rank after the ``allgather``).
+
+    Raises:
+        TypeError: If ``distributed_space.global_space`` is not a
+            :class:`~pantr.bspline.THBSplineSpace`.
+        ValueError: If ``kind`` is not recognized, or if ``func`` returns an output
+            with an invalid shape (0-D, more than 2-D, or wrong leading dimension).
+
+    Note:
+        All computation uses ``float64``.  Scalar vs. vector kind is preserved (a scalar
+        ``func`` yields a scalar :class:`~pantr.bspline.THBSpline`).  Like the serial
+        :func:`~pantr.bspline.quasi_interpolate_thb_spline`, the result is always
+        ``float64`` -- :class:`~pantr.bspline.THBSpline` stores ``float64`` coefficients
+        regardless of ``global_space.dtype``.
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> import numpy as np  # doctest: +SKIP
+        >>> from pantr.bspline import create_uniform_space, create_thb_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP
+        >>> from pantr.mpi import quasi_interpolate_thb_spline_distributed  # doctest: +SKIP
+        >>> thb = create_thb_space(create_uniform_space([2, 2], [8, 8]))  # doctest: +SKIP
+        >>> thb = thb.refine_region(0, [0, 0], [4, 4])  # doctest: +SKIP
+        >>> ds = create_distributed_space(thb, MPI.COMM_WORLD)  # doctest: +SKIP
+        >>> dfn = quasi_interpolate_thb_spline_distributed(  # doctest: +SKIP
+        ...     lambda p: np.sin(p[:, 0]) * np.cos(p[:, 1]), ds
+        ... )
+        >>> local = dfn.local  # rank-local THBSpline on the windowed space  # doctest: +SKIP
+    """
+    _ensure_default_thread_policy()
+
+    global_space = distributed_space.global_space
+    if not isinstance(global_space, THBSplineSpace):
+        raise TypeError(
+            f"distributed_space.global_space must be a THBSplineSpace; "
+            f"got {type(global_space).__name__!r}."
+        )
+    if kind not in get_args(QIKind):
+        valid = ", ".join(repr(v) for v in get_args(QIKind))
+        raise ValueError(f"Unknown kind {kind!r}; expected one of {valid}.")
+
+    comm = distributed_space.comm
+    local = distributed_space.local
+
+    if local is not None:
+        # local.space is THBSplineSpace because global_space is (checked above).
+        assert isinstance(local.space, THBSplineSpace)
+        # Run serial Speleers-Manni QI on the windowed local space.  THBSpline stores
+        # coefficients per active dof already: (num_total_basis,) scalar or
+        # (num_total_basis, rank) vector.  Preserve that rank so scalar funcs stay
+        # scalar, matching the serial quasi-interpolant exactly.
+        local_thb = quasi_interpolate_thb_spline(func, local.space, kind=kind)
+        coeffs = np.asarray(local_thb.control_points, dtype=np.float64)
+        # Restrict to owned DOFs and record their global indices.
+        owned_mask = local.owned_dof_mask
+        owned_global_dofs: npt.NDArray[np.int64] = local.local_to_global_dof[owned_mask]
+        owned_coeffs: npt.NDArray[np.float64] = coeffs[owned_mask]
+    else:
+        owned_global_dofs = np.empty(0, dtype=np.int64)
+        owned_coeffs = np.empty(0, dtype=np.float64)
+
+    # Single MPI collective: each rank contributes its owned-DOF (index, coefficient) pairs.
+    gathered: list[tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]] = list(
+        comm.allgather((owned_global_dofs, owned_coeffs))
+    )
+
+    # Detect scalar vs. vector (and its rank) from the first non-empty contribution.
+    # At least one rank owns cells, so a non-empty contribution always exists.
+    scalar = True
+    rank_dim = 1
+    for _, coeffs in gathered:
+        c = np.asarray(coeffs)
+        if c.shape[0] == 0:
+            continue
+        scalar = c.ndim == 1
+        rank_dim = 1 if scalar else int(c.shape[1])
+        break
+
+    # Assemble the global coefficient field.  THBSpline always stores float64, so the
+    # global control points are float64 regardless of global_space.dtype (consistent
+    # with the serial quasi-interpolant).
+    n_global = global_space.num_total_basis
+    shape: tuple[int, ...] = (n_global,) if scalar else (n_global, rank_dim)
+    global_cp = np.empty(shape, dtype=np.float64)
+    for gdofs, coeffs in gathered:
+        gdofs_arr = np.asarray(gdofs, dtype=np.int64)
+        if gdofs_arr.size == 0:
+            continue
+        global_cp[gdofs_arr] = np.asarray(coeffs, dtype=np.float64)
+
+    global_thb = THBSpline(global_space, global_cp)
+    return DistributedFunction(global_thb, distributed_space)
+
+
+__all__ = ["quasi_interpolate_thb_spline_distributed"]

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -19,9 +19,12 @@ import pytest
 from pantr.bspline import (
     Bspline,
     BsplineSpace,
+    THBSpline,
     build_local,
+    create_thb_space,
     create_uniform_space,
     quasi_interpolate_bspline,
+    quasi_interpolate_thb_spline,
 )
 from pantr.grid import partition_grid, tensor_product_grid
 from pantr.mpi import (
@@ -30,6 +33,7 @@ from pantr.mpi import (
     create_distributed_space,
     from_dolfinx,
     quasi_interpolate_bspline_distributed,
+    quasi_interpolate_thb_spline_distributed,
 )
 
 MPI = pytest.importorskip("mpi4py.MPI")
@@ -191,6 +195,59 @@ def test_quasi_interpolate_bspline_distributed_vector_func() -> None:
     ds = create_distributed_space(space, comm)
     dfn = quasi_interpolate_bspline_distributed(func, ds)
     serial = quasi_interpolate_bspline(func, space)
+
+    np.testing.assert_allclose(
+        dfn.global_function.control_points, serial.control_points, atol=1e-10
+    )
+
+
+def test_quasi_interpolate_thb_spline_distributed_matches_serial() -> None:
+    """Distributed THB QI reproduces the serial hierarchical quasi-interpolant.
+
+    On a two-level THB space (lower-left quadrant refined), the test verifies:
+    1. The global function is identical on every rank (allgather correctness).
+    2. Each rank's local function agrees with the serial QI at its owned cell midpoints.
+    """
+    comm = MPI.COMM_WORLD
+    space = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(0, [0, 0], [4, 4])
+    func = lambda p: np.sin(np.pi * p[:, 0]) * np.cos(np.pi * p[:, 1])  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = quasi_interpolate_thb_spline_distributed(func, ds)
+    serial = quasi_interpolate_thb_spline(func, space)
+
+    # 1. Global function must be identical on all ranks.
+    all_global_cp = comm.allgather(np.asarray(dfn.global_function.control_points))
+    for rank_cp in all_global_cp:
+        np.testing.assert_allclose(rank_cp, serial.control_points, atol=1e-10)
+
+    # 2. Local function reproduces serial QI at owned cell midpoints.  Evaluate at all
+    # midpoints in a single call (one parallel kernel launch, not one per cell).
+    if dfn.local is None:
+        return
+    assert ds.local is not None
+    assert isinstance(dfn.local, THBSpline)
+    grid = dfn.local.space.grid
+    mids = np.empty((0, space.dim))
+    for lc in np.flatnonzero(ds.local.owned_cell_mask):
+        lo, hi = grid.cell_bounds(int(lc))
+        mids = np.vstack([mids, 0.5 * (lo + hi)])
+    np.testing.assert_allclose(
+        dfn.local.evaluate(mids),
+        serial.evaluate(mids),
+        atol=1e-10,
+    )
+
+
+def test_quasi_interpolate_thb_spline_distributed_vector_func() -> None:
+    """Vector-valued func (rank=2) distributes correctly over a THB space."""
+    comm = MPI.COMM_WORLD
+    space = create_thb_space(create_uniform_space([2, 2], [8, 8])).refine_region(0, [0, 0], [4, 4])
+    func = lambda p: np.stack([p[:, 0], 1.0 - p[:, 1]], axis=-1)  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = quasi_interpolate_thb_spline_distributed(func, ds)
+    serial = quasi_interpolate_thb_spline(func, space)
 
     np.testing.assert_allclose(
         dfn.global_function.control_points, serial.control_points, atol=1e-10

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -24,6 +24,7 @@ def test_import_and_public_surface() -> None:
     assert isinstance(pantr.mpi.DistributedFunction, type)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
     assert callable(pantr.mpi.quasi_interpolate_bspline_distributed)
+    assert callable(pantr.mpi.quasi_interpolate_thb_spline_distributed)
     assert set(pantr.mpi.__all__) == {
         "DistributedFunction",
         "DistributedSpace",
@@ -34,6 +35,7 @@ def test_import_and_public_surface() -> None:
         "from_dolfinx",
         "mpi_available",
         "quasi_interpolate_bspline_distributed",
+        "quasi_interpolate_thb_spline_distributed",
         "require_mpi",
     }
 

--- a/tests/test_mpi_thb_qi.py
+++ b/tests/test_mpi_thb_qi.py
@@ -1,0 +1,360 @@
+"""Tests for :func:`pantr.mpi.quasi_interpolate_thb_spline_distributed`.
+
+MPI is not available in the test environment, so the communicator is duck-typed by
+``_FakeComm``, which adds ``allgather`` support (needed by this function) on top of
+the basic rank/size interface used elsewhere.
+
+The multi-rank equivalence test (distributed result == serial result) lives in
+``tests/mpi/test_distributed_mpi.py`` and runs under ``mpiexec``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import pantr.mpi as _pantr_mpi
+from pantr.bspline import (
+    THBSpline,
+    THBSplineSpace,
+    create_thb_space,
+    create_uniform_space,
+    quasi_interpolate_thb_spline,
+)
+from pantr.bspline._bspline_quasi_interpolation import QIKind
+from pantr.grid import Partition, partition_grid
+from pantr.mpi import (
+    DistributedFunction,
+    DistributedSpace,
+    quasi_interpolate_thb_spline_distributed,
+)
+
+# ---------------------------------------------------------------------------
+# Fake communicator with allgather
+# ---------------------------------------------------------------------------
+
+
+class _FakeComm:
+    """Minimal stand-in for an mpi4py communicator.
+
+    Supports ``rank``, ``size``, and a single-rank ``allgather`` (returns
+    ``[data]``).  For multi-rank simulations pass ``allgather_results`` to
+    set the value returned regardless of local data.
+    """
+
+    def __init__(
+        self,
+        rank: int,
+        size: int,
+        allgather_results: list[Any] | None = None,
+    ) -> None:
+        self._rank = rank
+        self._size = size
+        self._allgather_results = allgather_results
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def allgather(self, data: Any) -> list[Any]:
+        if self._allgather_results is not None:
+            return self._allgather_results
+        assert self._size == 1, (
+            "Multi-rank allgather requires pre-set allgather_results; "
+            "use _simulate_distributed_qi() for multi-rank tests."
+        )
+        return [data]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _refined_thb_space() -> THBSplineSpace:
+    """Return a two-level THB space (lower-left quadrant refined)."""
+    thb = create_thb_space(create_uniform_space([2, 2], [8, 8]))
+    return thb.refine_region(0, [0, 0], [4, 4])
+
+
+def _simulate_distributed_qi(
+    func: Any,
+    space: THBSplineSpace,
+    n_parts: int,
+    *,
+    kind: QIKind = "llm",
+) -> list[DistributedFunction]:
+    """Simulate quasi_interpolate_thb_spline_distributed across n_parts ranks in one process.
+
+    Runs the QI for each rank sequentially, collecting per-rank contributions
+    first, then replays the allgather so each rank assembles the correct global field.
+    """
+    part = partition_grid(space.grid, n_parts)
+
+    # Pass 1: collect what each rank would contribute to the allgather.
+    contributions: list[tuple[Any, Any]] = []
+    for rank in range(n_parts):
+        ds = DistributedSpace(space, part, _FakeComm(rank, n_parts))
+        local = ds.local
+        if local is not None:
+            assert isinstance(local.space, THBSplineSpace)
+            local_thb = quasi_interpolate_thb_spline(func, local.space, kind=kind)
+            coeffs = np.asarray(local_thb.control_points, dtype=np.float64)
+            owned_mask = local.owned_dof_mask
+            owned_global_dofs = local.local_to_global_dof[owned_mask]
+            owned_coeffs = coeffs[owned_mask]
+        else:
+            owned_global_dofs = np.empty(0, dtype=np.int64)
+            owned_coeffs = np.empty(0, dtype=np.float64)
+        contributions.append((owned_global_dofs, owned_coeffs))
+
+    # Pass 2: run the distributed QI for each rank with the pre-known allgather.
+    results: list[DistributedFunction] = []
+    for rank in range(n_parts):
+        comm = _FakeComm(rank, n_parts, allgather_results=contributions)
+        ds = DistributedSpace(space, part, comm)
+        dfn = quasi_interpolate_thb_spline_distributed(func, ds, kind=kind)
+        results.append(dfn)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_surface() -> None:
+    """quasi_interpolate_thb_spline_distributed is exported from pantr.mpi."""
+    assert callable(_pantr_mpi.quasi_interpolate_thb_spline_distributed)
+    assert "quasi_interpolate_thb_spline_distributed" in _pantr_mpi.__all__
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+
+
+def test_returns_distributed_function() -> None:
+    """Returns a DistributedFunction on the given distributed space."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0] ** 2, ds)
+    assert isinstance(dfn, DistributedFunction)
+    assert dfn.distributed_space is ds
+    assert dfn.global_function.space is space
+
+
+def test_local_is_thb_spline_on_local_space() -> None:
+    """Local is a THBSpline on the rank's windowed space when it owns cells."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0] + p[:, 1], ds)
+    assert dfn.local is not None
+    assert isinstance(dfn.local, THBSpline)
+    assert dfn.local.space is ds.local.space  # type: ignore[union-attr]
+
+
+def test_empty_rank_has_none_local() -> None:
+    """A rank owning no cells has local=None; still participates and returns a valid result."""
+    space = _refined_thb_space()
+    n_cells = space.grid.num_cells
+    # Rank 0 owns everything; rank 1 is empty.
+    part = Partition(np.zeros(n_cells, dtype=np.int64), 2)
+
+    # Rank 1 (empty) contributes nothing; allgather from rank 0 provides the full field.
+    ds0 = DistributedSpace(space, part, _FakeComm(0, 2))
+    local0 = ds0.local
+    assert local0 is not None
+    assert isinstance(local0.space, THBSplineSpace)
+    local_thb = quasi_interpolate_thb_spline(lambda p: p[:, 0], local0.space)
+    coeffs = np.asarray(local_thb.control_points, dtype=np.float64)
+    owned_mask = local0.owned_dof_mask
+    contrib0 = (local0.local_to_global_dof[owned_mask], coeffs[owned_mask])
+    contrib1 = (np.empty(0, dtype=np.int64), np.empty(0, dtype=np.float64))
+    allgather_data = [contrib0, contrib1]
+
+    for rank in range(2):
+        comm = _FakeComm(rank, 2, allgather_results=allgather_data)
+        ds = DistributedSpace(space, part, comm)
+        dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0], ds)
+        if rank == 0:
+            assert dfn.local is not None
+        else:
+            assert dfn.local is None
+
+
+# ---------------------------------------------------------------------------
+# Scalar and vector functions
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_function() -> None:
+    """Scalar func → scalar THBSpline (1-D control points), matching the serial kind."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0] ** 2, ds)
+    assert dfn.global_function.control_points.ndim == 1
+    assert dfn.global_function.control_points.shape == (space.num_total_basis,)
+
+
+def test_vector_function() -> None:
+    """Vector func (rank=2) → control points have shape (num_total_basis, 2)."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = quasi_interpolate_thb_spline_distributed(
+        lambda p: np.stack([p[:, 0], p[:, 0] ** 2], axis=-1), ds
+    )
+    assert dfn.global_function.control_points.shape[-1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Single-rank equivalence: distributed == serial
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRankEquivalence:
+    """With n_parts=1 the distributed result must equal the serial result exactly."""
+
+    def _check(self, func: Any, space: THBSplineSpace) -> None:
+        part = partition_grid(space.grid, 1)
+        ds = DistributedSpace(space, part, _FakeComm(0, 1))
+        dfn = quasi_interpolate_thb_spline_distributed(func, ds)
+        serial = quasi_interpolate_thb_spline(func, space)
+        np.testing.assert_array_equal(
+            dfn.global_function.control_points,
+            serial.control_points,
+        )
+
+    def test_polynomial(self) -> None:
+        self._check(lambda p: p[:, 0] ** 2 + p[:, 0] * p[:, 1], _refined_thb_space())
+
+    def test_vector(self) -> None:
+        self._check(
+            lambda p: np.stack([p[:, 0], p[:, 1]], axis=-1),
+            _refined_thb_space(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-rank equivalence: distributed == serial (simulated in one process)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRankEquivalence:
+    """Distributed QI across N simulated ranks must reproduce the serial result."""
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_scalar_polynomial(self, n_parts: int) -> None:
+        func = lambda p: p[:, 0] ** 2 + p[:, 1] ** 2  # noqa: E731
+        space = _refined_thb_space()
+        results = _simulate_distributed_qi(func, space, n_parts)
+        serial = quasi_interpolate_thb_spline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-12,
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_vector_function(self, n_parts: int) -> None:
+        func = lambda p: np.stack([p[:, 0], 1.0 - p[:, 1]], axis=-1)  # noqa: E731
+        space = _refined_thb_space()
+        results = _simulate_distributed_qi(func, space, n_parts)
+        serial = quasi_interpolate_thb_spline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-12,
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_local_evaluates_correctly_on_owned_cells(self, n_parts: int) -> None:
+        """Each rank's local function reproduces the serial QI at owned cell midpoints."""
+        func = lambda p: np.sin(np.pi * p[:, 0]) * np.cos(np.pi * p[:, 1])  # noqa: E731
+        space = _refined_thb_space()
+        serial = quasi_interpolate_thb_spline(func, space)
+        results = _simulate_distributed_qi(func, space, n_parts)
+
+        for dfn in results:
+            local = dfn.distributed_space.local
+            if local is None:
+                continue
+            assert dfn.local is not None
+            assert isinstance(dfn.local, THBSpline)
+            grid = local.space.grid
+            for lc in np.flatnonzero(local.owned_cell_mask):
+                lo, hi = grid.cell_bounds(int(lc))
+                mid = (0.5 * (lo + hi))[None]
+                np.testing.assert_allclose(
+                    dfn.local.evaluate(mid),
+                    serial.evaluate(mid),
+                    atol=1e-10,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_bspline_space_raises_type_error() -> None:
+    """TypeError when global_space is BsplineSpace (not THBSplineSpace)."""
+    space = create_uniform_space([2, 2], [4, 4])
+    from pantr.grid import tensor_product_grid
+
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    with pytest.raises(TypeError, match="THBSplineSpace"):
+        quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0], ds)
+
+
+def test_unknown_kind_raises() -> None:
+    """ValueError for unsupported kind."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    with pytest.raises(ValueError, match="Unknown kind"):
+        quasi_interpolate_thb_spline_distributed(
+            lambda p: p[:, 0],
+            ds,
+            kind="nope",  # type: ignore[arg-type]
+        )
+
+
+def test_func_shape_error_propagates() -> None:
+    """Shape errors from func propagate from the underlying serial QI."""
+    space = _refined_thb_space()
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    with pytest.raises(ValueError):
+        quasi_interpolate_thb_spline_distributed(lambda p: np.zeros(p.shape[0] + 1), ds)
+
+
+# ---------------------------------------------------------------------------
+# dtype: THBSpline coefficients are always float64 (matches serial)
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_float64_for_float32_space() -> None:
+    """A float32 THB space still yields float64 coefficients, exactly as the serial QI."""
+    thb = create_thb_space(create_uniform_space([2, 2], [8, 8], dtype=np.float32))
+    space = thb.refine_region(0, [0, 0], [4, 4])
+    part = partition_grid(space.grid, 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0] ** 2, ds)
+    serial = quasi_interpolate_thb_spline(lambda p: p[:, 0] ** 2, space)
+    assert dfn.global_function.control_points.dtype == np.float64
+    assert serial.control_points.dtype == np.float64
+    np.testing.assert_array_equal(dfn.global_function.control_points, serial.control_points)

--- a/tests/test_mpi_thb_qi.py
+++ b/tests/test_mpi_thb_qi.py
@@ -181,10 +181,15 @@ def test_empty_rank_has_none_local() -> None:
     contrib1 = (np.empty(0, dtype=np.int64), np.empty(0, dtype=np.float64))
     allgather_data = [contrib0, contrib1]
 
+    serial = quasi_interpolate_thb_spline(lambda p: p[:, 0], space)
     for rank in range(2):
         comm = _FakeComm(rank, 2, allgather_results=allgather_data)
         ds = DistributedSpace(space, part, comm)
         dfn = quasi_interpolate_thb_spline_distributed(lambda p: p[:, 0], ds)
+        # The empty rank contributes nothing, yet both ranks assemble the full field.
+        np.testing.assert_allclose(
+            dfn.global_function.control_points, serial.control_points, atol=1e-12
+        )
         if rank == 0:
             assert dfn.local is not None
         else:
@@ -303,6 +308,45 @@ class TestMultiRankEquivalence:
                     serial.evaluate(mid),
                     atol=1e-10,
                 )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_1d_multi_rank_matches_serial(self, n_parts: int) -> None:
+        """1D two-level THB QI matches the serial result across multiple ranks."""
+        func = lambda p: np.sin(np.pi * p[:, 0])  # noqa: E731
+        space = create_thb_space(create_uniform_space([3], [8])).refine_region(0, [0], [4])
+        results = _simulate_distributed_qi(func, space, n_parts)
+        serial = quasi_interpolate_thb_spline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-10,
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_three_level_hierarchy_matches_serial(self, n_parts: int) -> None:
+        """A 3-level THB space distributes correctly.
+
+        Exercises the per-level leaf-cell selection (issue #240, I2): ranks straddling
+        a level-2 refinement must window in active DOFs from all three levels, and the
+        Speleers-Manni functional's level-``l`` leaf cell must still resolve inside each
+        rank's windowed parametric sub-domain.
+        """
+        func = lambda p: np.sin(np.pi * p[:, 0]) * np.cos(np.pi * p[:, 1])  # noqa: E731
+        space = (
+            create_thb_space(create_uniform_space([2, 2], [8, 8]))
+            .refine_region(0, [0, 0], [4, 4])
+            .refine_region(1, [0, 0], [4, 4])
+        )
+        assert space.num_levels == 3
+        results = _simulate_distributed_qi(func, space, n_parts)
+        serial = quasi_interpolate_thb_spline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-10,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mpi_thb_qi.py
+++ b/tests/test_mpi_thb_qi.py
@@ -24,7 +24,7 @@ from pantr.bspline import (
     quasi_interpolate_thb_spline,
 )
 from pantr.bspline._bspline_quasi_interpolation import QIKind
-from pantr.grid import Partition, partition_grid
+from pantr.grid import Partition, partition_grid, tensor_product_grid
 from pantr.mpi import (
     DistributedFunction,
     DistributedSpace,
@@ -293,6 +293,7 @@ class TestMultiRankEquivalence:
                 continue
             assert dfn.local is not None
             assert isinstance(dfn.local, THBSpline)
+            assert isinstance(local.space, THBSplineSpace)
             grid = local.space.grid
             for lc in np.flatnonzero(local.owned_cell_mask):
                 lo, hi = grid.cell_bounds(int(lc))
@@ -312,8 +313,6 @@ class TestMultiRankEquivalence:
 def test_bspline_space_raises_type_error() -> None:
     """TypeError when global_space is BsplineSpace (not THBSplineSpace)."""
     space = create_uniform_space([2, 2], [4, 4])
-    from pantr.grid import tensor_product_grid
-
     part = partition_grid(tensor_product_grid(space), 1)
     ds = DistributedSpace(space, part, _FakeComm(0, 1))
     with pytest.raises(TypeError, match="THBSplineSpace"):


### PR DESCRIPTION
## Summary

- Adds `quasi_interpolate_thb_spline_distributed` to `pantr.mpi`: the MPI-parallel counterpart of `quasi_interpolate_thb_spline` (Speleers-Manni hierarchical quasi-interpolation). Implements **I2** of #240.
- Each rank runs the serial hierarchical QI on its *windowed* local space and keeps only its *owned* DOFs' coefficients; a single `allgather` assembles the global coefficient field. The windowed space covers every owned DOF's support closure, so the per-level functional's level-`l` active leaf cell always resolves inside the rank's parametric sub-domain (the correctness point flagged in the issue).
- Mirrors the merged I1 (`quasi_interpolate_bspline_distributed`, #241). Two THB-specific differences are handled explicitly: `THBSpline` always stores `float64`, and (unlike `Bspline`) it does **not** collapse a trailing dim-1 — so scalar vs. vector kind is preserved deliberately (scalar `func` → scalar `THBSpline`, matching the serial result).
- Supports scalar and vector-valued functions; returns a `DistributedFunction` whose `local` reproduces the serial quasi-interpolant pointwise over every owned cell.

## Implementation

- `src/pantr/mpi/_thb_qi.py` — new module with `quasi_interpolate_thb_spline_distributed`
- `src/pantr/mpi/__init__.py` — exports + `__all__` + docstring bullet
- `tests/test_mpi_thb_qi.py` — in-process tests via `_FakeComm` (no real MPI): single-/multi-rank (n_parts=2,4) equivalence to serial, scalar/vector kind preservation, owned-cell pointwise agreement, empty-rank path (with global-field correctness), 1D and 3-level hierarchy equivalence, float64-only coefficients, validation errors
- `tests/mpi/test_distributed_mpi.py` — real-MPI smoke tests (`mpiexec -n {2,3}`): global function identical on all ranks, local agrees with serial at owned cell midpoints, vector-valued variant
- `tests/test_mpi.py` — export-surface assertion

## Test plan

- [x] `pytest tests/test_mpi_thb_qi.py --no-cov` — 22 tests pass
- [x] Full suite — 3757 passed, 13 skipped (the lone local failure, `test_pantr_toplevel_does_not_import_mpi`, is a stale-editable-install artifact in this dev env; passes in CI which `pip install -e .`)
- [x] Real-MPI smoke tests `mpiexec -n {2,3}` — pass (repeated runs, no flakes)
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini src tests` — no errors (208 source files)
- [x] Docs build (`-W`) — clean
- [ ] Real-MPI smoke tests in CI (`mpi-tests` job)

## Review notes

Fresh-context review (Sonnet) across code / tests / comments; all Critical/Important findings addressed (variable shadowing, docstring grammar, float64 Note precision, empty-rank global-field assert, added 1D + 3-level hierarchy tests). Re-review clean. Deliberately not changed for I1 parity: the `(M, rank)` shape wording in the docstring and the `np.empty((0, 0))`-vs-`np.empty(0)` empty-rank sentinel (both harmless; empty contributions are skipped during assembly).

Note: distributed THB smoke tests batch all owned-cell midpoints into a single `evaluate` call — a per-cell evaluate loop intermittently tripped a Numba `parallel=True` thread-safety race under `mpiexec` (the serial code, not this PR).

Closes part of #240 (I2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
