### PR TITLE
feat(mpi): l2_project_bspline_distributed for DistributedSpace

### DIFF
--- a/src/pantr/bspline/_bspline_interpolate.py
+++ b/src/pantr/bspline/_bspline_interpolate.py
@@ -709,6 +709,93 @@ def _build_nd_collocation_matrix(
 # ---------------------------------------------------------------------------
 
 
+def _build_l2_mass_and_quad(
+    space: BsplineSpace,
+    n_quad: int | Sequence[int] | None,
+    quadrature: Literal["gauss-legendre", "gauss-lobatto"],
+    boundary_interpolation: bool | Sequence[tuple[bool, bool]],
+) -> tuple[
+    list[npt.NDArray[np.float32 | np.float64]],
+    list[npt.NDArray[np.float32 | np.float64]],
+    list[npt.NDArray[np.float32 | np.float64]],
+    list[tuple[bool, bool]],
+    tuple[int, ...],
+]:
+    """Build the per-direction L2 mass matrices and global quadrature nodes/weights.
+
+    Resolves ``n_quad`` and ``boundary_interpolation`` per direction, assembles each 1D
+    mass matrix via per-element quadrature, and replaces the first/last mass row with a
+    collocation (interpolation) row where requested.  Shared by the serial
+    :func:`l2_project_bspline` and its MPI-distributed counterpart; the result depends
+    only on ``space`` and the quadrature settings, never on any partition, so every rank
+    builds it identically.
+
+    Args:
+        space (BsplineSpace): The target B-spline space.
+        n_quad (int | Sequence[int] | None): Quadrature points per element per direction.
+            ``None`` defaults to ``degree + 1`` per direction.
+        quadrature (Literal["gauss-legendre", "gauss-lobatto"]): Quadrature rule type.
+        boundary_interpolation (bool | Sequence[tuple[bool, bool]]): Boundary
+            interpolation flags (see :func:`l2_project_bspline`).
+
+    Returns:
+        tuple: ``(mass_matrices, quad_nodes_per_dir, quad_weights_per_dir, bi_flags,
+        n_quads)`` -- per-direction mass matrices (boundary rows applied), global
+        quadrature nodes and weights, the resolved per-direction ``(left, right)``
+        boundary flags, and the resolved per-direction quadrature-point counts.
+
+    Raises:
+        ValueError: If ``n_quad`` or ``boundary_interpolation`` is inconsistent with
+            ``space``.
+    """
+    from ..quad import get_gauss_legendre_1d, get_gauss_lobatto_legendre_1d  # noqa: PLC0415
+
+    ndim = space.dim
+
+    # Resolve n_quad per direction.
+    if n_quad is None:
+        n_quads = tuple(s.degree + 1 for s in space.spaces)
+    elif isinstance(n_quad, int):
+        n_quads = tuple(n_quad for _ in range(ndim))
+    else:
+        n_quads = tuple(n_quad)
+        if len(n_quads) != ndim:
+            raise ValueError(f"n_quad has length {len(n_quads)}, expected {ndim}")
+
+    # Resolve boundary interpolation flags.
+    bi_flags = _resolve_boundary_interpolation(boundary_interpolation, space)
+
+    mass_matrices: list[npt.NDArray[np.float32 | np.float64]] = []
+    quad_nodes_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
+    quad_weights_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
+
+    quad_func = (
+        get_gauss_legendre_1d if quadrature == "gauss-legendre" else get_gauss_lobatto_legendre_1d
+    )
+
+    for d, s1d in enumerate(space.spaces):
+        nq = n_quads[d]
+        mass, q_nodes, q_weights = _assemble_mass_and_quad_1d(s1d, nq, quad_func)
+
+        # Apply boundary interpolation if requested.
+        bi_left, bi_right = bi_flags[d]
+        if bi_left and not s1d.periodic:
+            a = s1d.domain[0]
+            colloc_row = _build_collocation_matrix_1d(s1d, np.array([a], dtype=s1d.dtype))
+            mass[0, :] = colloc_row[0, :]
+
+        if bi_right and not s1d.periodic:
+            b = s1d.domain[1]
+            colloc_row = _build_collocation_matrix_1d(s1d, np.array([b], dtype=s1d.dtype))
+            mass[-1, :] = colloc_row[0, :]
+
+        mass_matrices.append(mass)
+        quad_nodes_per_dir.append(q_nodes)
+        quad_weights_per_dir.append(q_weights)
+
+    return mass_matrices, quad_nodes_per_dir, quad_weights_per_dir, bi_flags, n_quads
+
+
 def l2_project_bspline(  # noqa: PLR0913
     func: Callable[..., npt.ArrayLike],
     space: BsplineSpace,
@@ -764,55 +851,16 @@ def l2_project_bspline(  # noqa: PLR0913
         ...     lambda lat: lat.pts_per_dir[0] ** 2, space
         ... )
     """
-    from ..quad import get_gauss_legendre_1d, get_gauss_lobatto_legendre_1d  # noqa: PLC0415
     from ._bspline import Bspline  # noqa: PLC0415
 
     if not isinstance(space, BsplineSpace):
         raise TypeError(f"Expected BsplineSpace, got {type(space).__name__}")
 
-    ndim = space.dim
-
-    # Resolve n_quad per direction.
-    if n_quad is None:
-        n_quads = tuple(s.degree + 1 for s in space.spaces)
-    elif isinstance(n_quad, int):
-        n_quads = tuple(n_quad for _ in range(ndim))
-    else:
-        n_quads = tuple(n_quad)
-        if len(n_quads) != ndim:
-            raise ValueError(f"n_quad has length {len(n_quads)}, expected {ndim}")
-
-    # Resolve boundary interpolation flags.
-    bi_flags = _resolve_boundary_interpolation(boundary_interpolation, space)
-
-    # Build per-direction mass matrices and quadrature-sampled nodes.
-    mass_matrices: list[npt.NDArray[np.float32 | np.float64]] = []
-    quad_nodes_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
-    quad_weights_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
-
-    quad_func = (
-        get_gauss_legendre_1d if quadrature == "gauss-legendre" else get_gauss_lobatto_legendre_1d
+    # Build per-direction mass matrices (with boundary-interpolation rows applied),
+    # global quadrature nodes/weights, and the normalized n_quad / boundary flags.
+    mass_matrices, quad_nodes_per_dir, quad_weights_per_dir, bi_flags, _n_quads = (
+        _build_l2_mass_and_quad(space, n_quad, quadrature, boundary_interpolation)
     )
-
-    for d, s1d in enumerate(space.spaces):
-        nq = n_quads[d]
-        mass, q_nodes, q_weights = _assemble_mass_and_quad_1d(s1d, nq, quad_func)
-
-        # Apply boundary interpolation if requested.
-        bi_left, bi_right = bi_flags[d]
-        if bi_left and not s1d.periodic:
-            a = s1d.domain[0]
-            colloc_row = _build_collocation_matrix_1d(s1d, np.array([a], dtype=s1d.dtype))
-            mass[0, :] = colloc_row[0, :]
-
-        if bi_right and not s1d.periodic:
-            b = s1d.domain[1]
-            colloc_row = _build_collocation_matrix_1d(s1d, np.array([b], dtype=s1d.dtype))
-            mass[-1, :] = colloc_row[0, :]
-
-        mass_matrices.append(mass)
-        quad_nodes_per_dir.append(q_nodes)
-        quad_weights_per_dir.append(q_weights)
 
     # Build quadrature lattice and evaluate function.
     quad_lattice = PointsLattice(quad_nodes_per_dir)

--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -21,6 +21,7 @@ Main exports:
 - :class:`DistributedFunction`: the per-rank handle to an MPI-distributed function.
 - :func:`create_distributed_function`: build a :class:`DistributedFunction` from a function.
 - :func:`configure_threads`: explicitly set this rank's Numba thread count.
+- :func:`l2_project_bspline_distributed`: distributed B-spline L2 projection.
 - :func:`quasi_interpolate_bspline_distributed`: distributed B-spline quasi-interpolation.
 - :func:`quasi_interpolate_thb_spline_distributed`: distributed THB-spline quasi-interpolation.
 
@@ -43,6 +44,7 @@ from ._create import create_distributed_space
 from ._distributed_function import DistributedFunction, create_distributed_function
 from ._distributed_space import DistributedSpace
 from ._from_dolfinx import from_dolfinx
+from ._l2 import l2_project_bspline_distributed
 from ._qi import quasi_interpolate_bspline_distributed
 from ._thb_qi import quasi_interpolate_thb_spline_distributed
 from ._thread_policy import configure_threads
@@ -109,6 +111,7 @@ __all__ = [
     "create_distributed_function",
     "create_distributed_space",
     "from_dolfinx",
+    "l2_project_bspline_distributed",
     "mpi_available",
     "quasi_interpolate_bspline_distributed",
     "quasi_interpolate_thb_spline_distributed",

--- a/src/pantr/mpi/_l2.py
+++ b/src/pantr/mpi/_l2.py
@@ -1,0 +1,267 @@
+"""Distributed L2 projection onto tensor-product B-spline spaces.
+
+Provides :func:`l2_project_bspline_distributed`, the MPI-parallel counterpart of
+:func:`~pantr.bspline.l2_project_bspline`.  L2 assembly is per-element, mapping directly
+onto the cell partition: each rank evaluates ``func`` only on the quadrature points of
+its *owned* cells and contracts them into a per-direction load tensor, a single
+``allreduce`` sums the global load across ranks, and the (replicated) Kronecker solve
+recovers the global coefficients.  The per-direction mass matrices are
+partition-independent and built identically on every rank, so only the load is
+communicated.  The result is a :class:`~pantr.mpi.DistributedFunction` whose
+:attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial L2 projection exactly
+over the rank's owned cells.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import numpy as np
+
+from ..bspline import Bspline, BsplineSpace
+from ..bspline._bspline_interpolate import (
+    _apply_boundary_load,
+    _assemble_load_1d,
+    _build_l2_mass_and_quad,
+    _evaluate_func_on_lattice,
+    _solve_kronecker,
+)
+from ..quad import PointsLattice
+from ._distributed_function import DistributedFunction
+from ._distributed_space import DistributedSpace
+from ._thread_policy import _ensure_default_thread_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import numpy.typing as npt
+
+
+def _owned_quad_cell_mask(
+    space: BsplineSpace,
+    cell_owner: npt.NDArray[np.int32],
+    rank: int,
+    n_quads: tuple[int, ...],
+    quad_grid_shape: tuple[int, ...],
+) -> npt.NDArray[np.bool_]:
+    """Build the boolean mask of quadrature points lying in this rank's owned cells.
+
+    The global quadrature nodes are concatenated per element in each direction, so the
+    ``n_quad`` consecutive nodes of direction-``d`` element ``e`` map to interval ``e``.
+    A quadrature point's owning cell is the C-order flat id (over ``num_intervals``) of
+    its per-direction element tuple; the point is owned iff ``cell_owner`` assigns that
+    cell to ``rank``.
+
+    Args:
+        space (BsplineSpace): The target B-spline space.
+        cell_owner (npt.NDArray[np.int32]): Owner rank of every global cell, C-order over
+            ``num_intervals``.
+        rank (int): This rank's id.
+        n_quads (tuple[int, ...]): Quadrature points per element per direction.
+        quad_grid_shape (tuple[int, ...]): Shape of the global quadrature grid
+            (``num_intervals[d] * n_quads[d]`` per direction).
+
+    Returns:
+        npt.NDArray[np.bool_]: Boolean mask of shape ``quad_grid_shape``; ``True`` at
+        quadrature points whose owning cell belongs to ``rank``.
+    """
+    num_intervals = space.num_intervals
+    elem_idx_per_dir = [
+        np.repeat(np.arange(num_intervals[d], dtype=np.int64), n_quads[d]) for d in range(space.dim)
+    ]
+    mesh = np.meshgrid(*elem_idx_per_dir, indexing="ij")
+    cell_flat = np.ravel_multi_index(tuple(mesh), num_intervals)
+    return np.asarray(cell_owner[cell_flat] == rank).reshape(quad_grid_shape)
+
+
+def _assemble_owned_load(  # noqa: PLR0913
+    space: BsplineSpace,
+    components: list[npt.NDArray[np.floating[Any]]],
+    owned_mask: npt.NDArray[np.bool_],
+    out_dtype: np.dtype[np.float32] | np.dtype[np.float64],
+    quad_nodes_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+    quad_weights_per_dir: list[npt.NDArray[np.float32 | np.float64]],
+) -> list[npt.NDArray[np.floating[Any]]]:
+    """Contract the owned-cell function values into a per-component load tensor.
+
+    Each component's quadrature values are masked to this rank's owned cells (others set
+    to zero), then contracted direction by direction with the weighted basis.  Because
+    the contraction is linear in the function values and every quadrature point belongs
+    to exactly one cell, summing these per-rank loads over all ranks reproduces the full
+    serial L2 load exactly.
+
+    Args:
+        space (BsplineSpace): The target B-spline space.
+        components (list[npt.NDArray[np.floating[Any]]]): Per-component quadrature values,
+            each of shape ``quad_grid_shape``.
+        owned_mask (npt.NDArray[np.bool_]): Owned-quadrature-point mask of shape
+            ``quad_grid_shape``.
+        out_dtype (np.dtype[np.float32] | np.dtype[np.float64]): Output floating dtype.
+        quad_nodes_per_dir (list[npt.NDArray[np.float32 | np.float64]]): Per-direction
+            global quadrature nodes.
+        quad_weights_per_dir (list[npt.NDArray[np.float32 | np.float64]]): Per-direction
+            global quadrature weights.
+
+    Returns:
+        list[npt.NDArray[np.floating[Any]]]: Per-component load tensors of shape
+        ``num_basis``.
+    """
+    loads: list[npt.NDArray[np.floating[Any]]] = []
+    for comp in components:
+        load: npt.NDArray[np.floating[Any]] = np.where(owned_mask, comp, 0.0).astype(out_dtype)
+        for d, s1d in enumerate(space.spaces):
+            load = _assemble_load_1d(s1d, load, quad_nodes_per_dir[d], quad_weights_per_dir[d], d)
+        loads.append(load)
+    return loads
+
+
+def l2_project_bspline_distributed(  # noqa: PLR0913
+    func: Callable[..., npt.ArrayLike],
+    distributed_space: DistributedSpace,
+    *,
+    n_quad: int | Sequence[int] | None = None,
+    quadrature: Literal["gauss-legendre", "gauss-lobatto"] = "gauss-legendre",
+    boundary_interpolation: bool | Sequence[tuple[bool, bool]] = False,
+    tol: float | None = None,
+) -> DistributedFunction:
+    """L2-project a callable onto a distributed tensor-product B-spline space.
+
+    The MPI-parallel counterpart of :func:`~pantr.bspline.l2_project_bspline`.  L2
+    assembly is per-element and maps directly onto the cell partition: each rank
+    evaluates ``func`` only on the quadrature points of its *owned* cells and contracts
+    them into a per-direction load tensor; a single ``allreduce`` sums the global load
+    across ranks; and the replicated Kronecker solve recovers the global coefficients.
+    The returned :class:`~pantr.mpi.DistributedFunction` agrees with the serial L2
+    projection pointwise over every owned cell.
+
+    The per-direction mass matrices are partition-independent and built identically on
+    every rank (cheap ``n_dofs_i x n_dofs_i`` systems), so only the load is communicated.
+    ``boundary_interpolation`` rows are handled after the reduce: each boundary trace is
+    partition-independent, so every rank recomputes the same boundary row (equivalent to
+    only the rank owning the boundary cell contributing it).  Construction requires one
+    MPI collective (``comm.allreduce``) after the local assembly.
+
+    Args:
+        func (Callable[..., npt.ArrayLike]): Function to project.  Called as
+            ``func(lattice)`` where ``lattice`` is a :class:`~pantr.quad.PointsLattice`
+            of quadrature points (the serial convention); must return an array of shape
+            ``(n_total,)`` for scalar or ``(n_total, rank)`` for vector-valued functions.
+        distributed_space (DistributedSpace): The distributed space to project onto.  Its
+            ``global_space`` must be a :class:`~pantr.bspline.BsplineSpace`.
+        n_quad (int | Sequence[int] | None): Quadrature points per element per direction.
+            Defaults to ``degree + 1``.
+        quadrature (Literal["gauss-legendre", "gauss-lobatto"]): Quadrature rule type.
+            Defaults to ``"gauss-legendre"``.
+        boundary_interpolation (bool | Sequence[tuple[bool, bool]]): Replace boundary rows
+            with interpolation conditions.  ``False`` (default) is a pure L2 projection,
+            ``True`` interpolates at all non-periodic boundaries, and a sequence of
+            ``(left, right)`` pairs sets per-direction flags.
+        tol (float | None): SVD truncation tolerance for the per-direction solves.  If
+            ``None``, defaults to ``100 * machine_epsilon``.
+
+    Returns:
+        DistributedFunction: A distributed function whose
+        :attr:`~pantr.mpi.DistributedFunction.local` L2-projects ``func`` over this
+        rank's owned cells, and whose
+        :attr:`~pantr.mpi.DistributedFunction.global_function` holds the full assembled
+        global coefficient field (identical on every rank after the ``allreduce``).
+
+    Raises:
+        TypeError: If ``distributed_space.global_space`` is not a
+            :class:`~pantr.bspline.BsplineSpace`.
+        ValueError: If ``n_quad`` or ``boundary_interpolation`` is inconsistent with the
+            global space, or if ``func`` returns an output with an invalid shape.
+
+    Note:
+        The output dtype is inferred from the return value of ``func`` (as in the serial
+        :func:`~pantr.bspline.l2_project_bspline`) and the global control points are cast
+        to ``global_space.dtype`` before assembly.
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> import numpy as np  # doctest: +SKIP
+        >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP
+        >>> from pantr.mpi import l2_project_bspline_distributed  # doctest: +SKIP
+        >>> space = create_uniform_space([2, 2], [8, 8])  # doctest: +SKIP
+        >>> ds = create_distributed_space(space, MPI.COMM_WORLD)  # doctest: +SKIP
+        >>> dfn = l2_project_bspline_distributed(  # doctest: +SKIP
+        ...     lambda lat: np.sin(lat.pts_per_dir[0]), ds
+        ... )
+        >>> local = dfn.local  # rank-local Bspline on the windowed space  # doctest: +SKIP
+    """
+    _ensure_default_thread_policy()
+
+    global_space = distributed_space.global_space
+    if not isinstance(global_space, BsplineSpace):
+        raise TypeError(
+            f"distributed_space.global_space must be a BsplineSpace; "
+            f"got {type(global_space).__name__!r}."
+        )
+
+    comm = distributed_space.comm
+    rank = distributed_space.rank
+
+    # Mass matrices, global quadrature nodes/weights, and resolved settings are
+    # partition-independent: every rank builds them identically.
+    mass_matrices, quad_nodes_per_dir, quad_weights_per_dir, bi_flags, n_quads = (
+        _build_l2_mass_and_quad(global_space, n_quad, quadrature, boundary_interpolation)
+    )
+
+    # Evaluate func on the global quadrature lattice, restricted (by masking) to this
+    # rank's owned cells, and contract into a per-component load tensor.
+    quad_lattice = PointsLattice(quad_nodes_per_dir)
+    quad_grid_shape = tuple(a.shape[0] for a in quad_nodes_per_dir)
+    components, out_dtype = _evaluate_func_on_lattice(func, quad_lattice, quad_grid_shape)
+    n_components = len(components)
+
+    owned_mask = _owned_quad_cell_mask(
+        global_space,
+        distributed_space.partition.cell_owner,
+        rank,
+        n_quads,
+        quad_grid_shape,
+    )
+    local_loads = _assemble_owned_load(
+        global_space,
+        components,
+        owned_mask,
+        out_dtype,
+        quad_nodes_per_dir,
+        quad_weights_per_dir,
+    )
+
+    # Stack components into a single tensor for one allreduce: (*num_basis, n_components).
+    num_basis = tuple(global_space.num_basis)
+    local_load = np.stack(local_loads, axis=-1).astype(out_dtype, copy=False)
+    global_load = cast(
+        "npt.NDArray[np.floating[Any]]",
+        np.asarray(comm.allreduce(local_load), dtype=out_dtype),
+    )
+
+    # Apply boundary-interpolation rows on the reduced (global) load, replicated on every
+    # rank.  Each boundary trace is partition-independent, matching the serial result.
+    ctrl_components: list[npt.NDArray[np.floating[Any]]] = []
+    for comp_idx in range(n_components):
+        load: npt.NDArray[np.floating[Any]] = global_load[..., comp_idx].copy()
+        _apply_boundary_load(
+            func,
+            global_space,
+            quad_nodes_per_dir,
+            quad_weights_per_dir,
+            bi_flags,
+            load,
+            comp_idx,
+            n_components,
+        )
+        coeffs = _solve_kronecker(mass_matrices, load, tol)
+        ctrl_components.append(coeffs)
+
+    ctrl = np.stack(ctrl_components, axis=-1).astype(global_space.dtype, copy=False)
+    global_cp = ctrl.reshape(*num_basis, n_components)
+
+    global_bspline = Bspline(global_space, global_cp)
+    return DistributedFunction(global_bspline, distributed_space)
+
+
+__all__ = ["l2_project_bspline_distributed"]

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -23,6 +23,7 @@ from pantr.bspline import (
     build_local,
     create_thb_space,
     create_uniform_space,
+    l2_project_bspline,
     quasi_interpolate_bspline,
     quasi_interpolate_thb_spline,
 )
@@ -32,6 +33,7 @@ from pantr.mpi import (
     create_distributed_function,
     create_distributed_space,
     from_dolfinx,
+    l2_project_bspline_distributed,
     quasi_interpolate_bspline_distributed,
     quasi_interpolate_thb_spline_distributed,
 )
@@ -248,6 +250,68 @@ def test_quasi_interpolate_thb_spline_distributed_vector_func() -> None:
     ds = create_distributed_space(space, comm)
     dfn = quasi_interpolate_thb_spline_distributed(func, ds)
     serial = quasi_interpolate_thb_spline(func, space)
+
+    np.testing.assert_allclose(
+        dfn.global_function.control_points, serial.control_points, atol=1e-10
+    )
+
+
+def _grid_mesh(lat: Any) -> tuple[np.ndarray, ...]:
+    """Return the C-order, flattened meshgrid of a PointsLattice's per-direction nodes.
+
+    Mirrors the serial ``func(lattice)`` convention: each returned array is the flat
+    ``(n_total,)`` coordinate vector for one parametric direction.
+    """
+    return tuple(g.reshape(-1) for g in np.meshgrid(*list(lat.pts_per_dir), indexing="ij"))
+
+
+def test_l2_project_bspline_distributed_matches_serial() -> None:
+    """Distributed L2 projection reproduces the serial result over every cell.
+
+    Each rank assembles the load over its owned cells only; a single allreduce sums the
+    global load and the replicated Kronecker solve recovers the coefficients.  The test
+    verifies:
+    1. The global function is identical on every rank (allreduce correctness).
+    2. Each rank's local function agrees with the serial L2 at its owned cell midpoints.
+    """
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [8, 8])
+    func = lambda lat: np.sin(np.pi * _grid_mesh(lat)[0]) * np.cos(np.pi * _grid_mesh(lat)[1])  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = l2_project_bspline_distributed(func, ds)
+    serial = l2_project_bspline(func, space)
+
+    # 1. Global function must be identical on all ranks.
+    all_global_cp = comm.allgather(np.asarray(dfn.global_function.control_points))
+    for rank_cp in all_global_cp:
+        np.testing.assert_allclose(rank_cp, serial.control_points, atol=1e-10)
+
+    # 2. Local function reproduces serial L2 at owned cell midpoints.
+    if dfn.local is None:
+        return
+    assert ds.local is not None
+    assert isinstance(dfn.local.space, BsplineSpace)
+    grid = tensor_product_grid(dfn.local.space)
+    for lc in np.flatnonzero(ds.local.owned_cell_mask):
+        lo, hi = grid.cell_bounds(int(lc))
+        mid = (0.5 * (lo + hi))[None]
+        np.testing.assert_allclose(
+            dfn.local.evaluate(mid),
+            serial.evaluate(mid),
+            atol=1e-10,
+        )
+
+
+def test_l2_project_bspline_distributed_boundary_interpolation() -> None:
+    """Distributed L2 with boundary_interpolation matches the serial result."""
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([3, 3], [6, 6])
+    func = lambda lat: np.cos(_grid_mesh(lat)[0]) * _grid_mesh(lat)[1] ** 2  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = l2_project_bspline_distributed(func, ds, boundary_interpolation=True)
+    serial = l2_project_bspline(func, space, boundary_interpolation=True)
 
     np.testing.assert_allclose(
         dfn.global_function.control_points, serial.control_points, atol=1e-10

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -23,6 +23,7 @@ def test_import_and_public_surface() -> None:
     assert isinstance(pantr.mpi.DistributedSpace, type)
     assert isinstance(pantr.mpi.DistributedFunction, type)
     assert isinstance(pantr.mpi.HAS_MPI, bool)
+    assert callable(pantr.mpi.l2_project_bspline_distributed)
     assert callable(pantr.mpi.quasi_interpolate_bspline_distributed)
     assert callable(pantr.mpi.quasi_interpolate_thb_spline_distributed)
     assert set(pantr.mpi.__all__) == {
@@ -33,6 +34,7 @@ def test_import_and_public_surface() -> None:
         "create_distributed_function",
         "create_distributed_space",
         "from_dolfinx",
+        "l2_project_bspline_distributed",
         "mpi_available",
         "quasi_interpolate_bspline_distributed",
         "quasi_interpolate_thb_spline_distributed",

--- a/tests/test_mpi_l2.py
+++ b/tests/test_mpi_l2.py
@@ -1,0 +1,432 @@
+"""Tests for :func:`pantr.mpi.l2_project_bspline_distributed`.
+
+MPI is not available in the test environment, so the communicator is duck-typed by
+``_FakeComm``, which adds ``allreduce`` support (needed by this function) on top of the
+basic rank/size interface used elsewhere.  Multi-rank runs are simulated in one process:
+each rank's owned-cell load is assembled, then the ``allreduce`` is replayed so every
+rank sees the summed global load.
+
+The real-MPI equivalence test (collective over ``MPI.COMM_WORLD``) lives in
+``tests/mpi/test_distributed_mpi.py`` and runs under ``mpiexec``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import pantr.mpi as _pantr_mpi
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    create_thb_space,
+    create_uniform_space,
+    l2_project_bspline,
+)
+from pantr.grid import Partition, partition_grid, tensor_product_grid
+from pantr.mpi import (
+    DistributedFunction,
+    DistributedSpace,
+    l2_project_bspline_distributed,
+)
+
+# ---------------------------------------------------------------------------
+# Fake communicator with allreduce
+# ---------------------------------------------------------------------------
+
+
+class _FakeComm:
+    """Minimal stand-in for an mpi4py communicator.
+
+    Supports ``rank``, ``size``, and a single-rank ``allreduce`` (returns its argument).
+    For multi-rank simulations pass ``allreduce_result`` to set the summed value returned
+    regardless of local data.
+    """
+
+    def __init__(
+        self,
+        rank: int,
+        size: int,
+        allreduce_result: Any = None,
+    ) -> None:
+        self._rank = rank
+        self._size = size
+        self._allreduce_result = allreduce_result
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def allreduce(self, data: Any) -> Any:
+        if self._allreduce_result is not None:
+            return self._allreduce_result
+        assert self._size == 1, (
+            "Multi-rank allreduce requires pre-set allreduce_result; "
+            "use _simulate_distributed_l2() for multi-rank tests."
+        )
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _grid(lat: Any) -> tuple[np.ndarray, ...]:
+    """Return the C-order, flattened meshgrid of a PointsLattice's per-direction nodes.
+
+    Mirrors the serial ``func(lattice)`` convention: each returned array is the flat
+    ``(n_total,)`` coordinate vector for one parametric direction, so an expression like
+    ``_grid(lat)[0] ** 2`` yields the expected ``(n_total,)`` output.
+    """
+    return tuple(g.reshape(-1) for g in np.meshgrid(*list(lat.pts_per_dir), indexing="ij"))
+
+
+def _simulate_distributed_l2(
+    func: Any,
+    space: BsplineSpace,
+    n_parts: int,
+    **kwargs: Any,
+) -> list[DistributedFunction]:
+    """Simulate l2_project_bspline_distributed across n_parts ranks in one process.
+
+    Pass 1 runs each rank up to its local load contribution and sums them (the
+    ``allreduce``).  Pass 2 runs the distributed projection for every rank with the
+    pre-summed global load, so each rank assembles the identical global field.
+    """
+    from pantr.bspline._bspline_interpolate import (  # noqa: PLC0415
+        _build_l2_mass_and_quad,
+        _evaluate_func_on_lattice,
+    )
+    from pantr.mpi._l2 import _assemble_owned_load, _owned_quad_cell_mask  # noqa: PLC0415
+    from pantr.quad import PointsLattice  # noqa: PLC0415
+
+    part = partition_grid(tensor_product_grid(space), n_parts)
+    n_quad = kwargs.get("n_quad")
+    quadrature = kwargs.get("quadrature", "gauss-legendre")
+    boundary_interpolation = kwargs.get("boundary_interpolation", False)
+
+    _, q_nodes, q_weights, _, n_quads = _build_l2_mass_and_quad(
+        space, n_quad, quadrature, boundary_interpolation
+    )
+    lattice = PointsLattice(q_nodes)
+    quad_grid_shape = tuple(a.shape[0] for a in q_nodes)
+    components, out_dtype = _evaluate_func_on_lattice(func, lattice, quad_grid_shape)
+
+    total: np.ndarray | None = None
+    for rank in range(n_parts):
+        mask = _owned_quad_cell_mask(space, part.cell_owner, rank, n_quads, quad_grid_shape)
+        loads = _assemble_owned_load(space, components, mask, out_dtype, q_nodes, q_weights)
+        local_load = np.stack(loads, axis=-1).astype(out_dtype, copy=False)
+        total = local_load if total is None else total + local_load
+
+    results: list[DistributedFunction] = []
+    for rank in range(n_parts):
+        comm = _FakeComm(rank, n_parts, allreduce_result=total)
+        ds = DistributedSpace(space, part, comm)
+        dfn = l2_project_bspline_distributed(func, ds, **kwargs)
+        results.append(dfn)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_surface() -> None:
+    """l2_project_bspline_distributed is exported from pantr.mpi."""
+    assert callable(_pantr_mpi.l2_project_bspline_distributed)
+    assert "l2_project_bspline_distributed" in _pantr_mpi.__all__
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+
+
+def test_returns_distributed_function() -> None:
+    """Returns a DistributedFunction on the given distributed space."""
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = l2_project_bspline_distributed(lambda lat: _grid(lat)[0] ** 2, ds)
+    assert isinstance(dfn, DistributedFunction)
+    assert dfn.distributed_space is ds
+    assert dfn.global_function.space is space
+
+
+def test_local_is_bspline_on_local_space() -> None:
+    """Local is a Bspline on the rank's windowed space when it owns cells."""
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = l2_project_bspline_distributed(lambda lat: _grid(lat)[0] + _grid(lat)[1], ds)
+    assert dfn.local is not None
+    assert isinstance(dfn.local, Bspline)
+    assert dfn.local.space is ds.local.space  # type: ignore[union-attr]
+
+
+def test_empty_rank_has_none_local() -> None:
+    """A rank owning no cells has local=None; still participates and returns a result."""
+    space = create_uniform_space([2, 2], [4, 4])
+    n_cells = space.num_total_intervals
+    # Rank 0 owns everything; rank 1 is empty.
+    part = Partition(np.zeros(n_cells, dtype=np.int64), 2)
+    func = lambda lat: _grid(lat)[0]  # noqa: E731
+
+    # Build the global load (only rank 0 contributes) and replay the allreduce.
+    from pantr.bspline._bspline_interpolate import (  # noqa: PLC0415
+        _build_l2_mass_and_quad,
+        _evaluate_func_on_lattice,
+    )
+    from pantr.mpi._l2 import _assemble_owned_load, _owned_quad_cell_mask  # noqa: PLC0415
+    from pantr.quad import PointsLattice  # noqa: PLC0415
+
+    _, q_nodes, q_weights, _, n_quads = _build_l2_mass_and_quad(
+        space, None, "gauss-legendre", False
+    )
+    lattice = PointsLattice(q_nodes)
+    quad_grid_shape = tuple(a.shape[0] for a in q_nodes)
+    components, out_dtype = _evaluate_func_on_lattice(func, lattice, quad_grid_shape)
+    mask0 = _owned_quad_cell_mask(space, part.cell_owner, 0, n_quads, quad_grid_shape)
+    loads0 = _assemble_owned_load(space, components, mask0, out_dtype, q_nodes, q_weights)
+    total = np.stack(loads0, axis=-1).astype(out_dtype, copy=False)
+
+    for rank in range(2):
+        comm = _FakeComm(rank, 2, allreduce_result=total)
+        ds = DistributedSpace(space, part, comm)
+        dfn = l2_project_bspline_distributed(func, ds)
+        if rank == 0:
+            assert dfn.local is not None
+        else:
+            assert dfn.local is None
+
+
+# ---------------------------------------------------------------------------
+# Scalar and vector functions
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_function() -> None:
+    """Scalar func -> control points have shape (*num_basis, 1)."""
+    space = create_uniform_space([2], [4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = l2_project_bspline_distributed(lambda lat: _grid(lat)[0] ** 2, ds)
+    assert dfn.global_function.control_points.shape[-1] == 1
+
+
+def test_vector_function() -> None:
+    """Vector func (rank=2) -> control points have shape (*num_basis, 2)."""
+    space = create_uniform_space([2], [4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    func = lambda lat: np.stack(  # noqa: E731
+        [_grid(lat)[0].reshape(-1), (_grid(lat)[0] ** 2).reshape(-1)], axis=-1
+    )
+    dfn = l2_project_bspline_distributed(func, ds)
+    assert dfn.global_function.control_points.shape[-1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Single-rank equivalence: distributed == serial
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRankEquivalence:
+    """With n_parts=1 the distributed result must equal the serial result exactly."""
+
+    def _check(self, func: Any, space: BsplineSpace, **kwargs: Any) -> None:
+        part = partition_grid(tensor_product_grid(space), 1)
+        ds = DistributedSpace(space, part, _FakeComm(0, 1))
+        dfn = l2_project_bspline_distributed(func, ds, **kwargs)
+        serial = l2_project_bspline(func, space, **kwargs)
+        np.testing.assert_allclose(
+            dfn.global_function.control_points,
+            serial.control_points,
+            atol=1e-13,
+        )
+
+    def test_polynomial_1d(self) -> None:
+        self._check(lambda lat: _grid(lat)[0] ** 2, create_uniform_space([2], [5]))
+
+    def test_polynomial_2d(self) -> None:
+        self._check(
+            lambda lat: _grid(lat)[0] ** 2 + _grid(lat)[0] * _grid(lat)[1],
+            create_uniform_space([2, 2], [4, 4]),
+        )
+
+    def test_boundary_interpolation(self) -> None:
+        self._check(
+            lambda lat: np.sin(_grid(lat)[0]) + _grid(lat)[1] ** 2,
+            create_uniform_space([2, 2], [4, 4]),
+            boundary_interpolation=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-rank equivalence: distributed == serial (simulated in one process)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRankEquivalence:
+    """Distributed L2 across N simulated ranks must reproduce the serial result."""
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_scalar_polynomial(self, n_parts: int) -> None:
+        func = lambda lat: np.sin(_grid(lat)[0]) + 0.5 * _grid(lat)[1] ** 2  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        results = _simulate_distributed_l2(func, space, n_parts)
+        serial = l2_project_bspline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-12,
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_vector_function(self, n_parts: int) -> None:
+        func = lambda lat: np.stack(  # noqa: E731
+            [_grid(lat)[0].reshape(-1), (1.0 - _grid(lat)[1]).reshape(-1)], axis=-1
+        )
+        space = create_uniform_space([2, 2], [4, 4])
+        results = _simulate_distributed_l2(func, space, n_parts)
+        serial = l2_project_bspline(func, space)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points,
+                serial.control_points,
+                atol=1e-12,
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_boundary_interpolation(self, n_parts: int) -> None:
+        func = lambda lat: np.cos(_grid(lat)[0]) * _grid(lat)[1]  # noqa: E731
+        space = create_uniform_space([3, 3], [6, 6])
+        for bi in (True, [(True, False), (False, True)]):
+            results = _simulate_distributed_l2(func, space, n_parts, boundary_interpolation=bi)
+            serial = l2_project_bspline(func, space, boundary_interpolation=bi)
+            for dfn in results:
+                np.testing.assert_allclose(
+                    dfn.global_function.control_points,
+                    serial.control_points,
+                    atol=1e-12,
+                )
+
+    @pytest.mark.parametrize("n_parts", [2, 3, 4])
+    def test_partition_independent(self, n_parts: int) -> None:
+        """Different partitions all give the serial output (so identical to each other)."""
+        func = lambda lat: np.exp(-_grid(lat)[0]) + _grid(lat)[1]  # noqa: E731
+        space = create_uniform_space([2, 2], [6, 6])
+        serial = l2_project_bspline(func, space)
+        results = _simulate_distributed_l2(func, space, n_parts)
+        for dfn in results:
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_local_evaluates_correctly_on_owned_cells(self, n_parts: int) -> None:
+        """Each rank's local function reproduces the serial L2 at owned cell midpoints."""
+        func = lambda lat: np.sin(np.pi * _grid(lat)[0]) * np.cos(np.pi * _grid(lat)[1])  # noqa: E731
+        space = create_uniform_space([3, 3], [8, 8])
+        serial = l2_project_bspline(func, space)
+        results = _simulate_distributed_l2(func, space, n_parts)
+        part = partition_grid(tensor_product_grid(space), n_parts)
+        for rank, dfn in enumerate(results):
+            ds = DistributedSpace(space, part, _FakeComm(rank, n_parts))
+            local = ds.local
+            if local is None:
+                continue
+            assert dfn.local is not None
+            assert isinstance(dfn.local.space, BsplineSpace)
+            grid = tensor_product_grid(dfn.local.space)
+            for lc in np.flatnonzero(local.owned_cell_mask):
+                lo, hi = grid.cell_bounds(int(lc))
+                mid = (0.5 * (lo + hi))[None]
+                np.testing.assert_allclose(
+                    dfn.local.evaluate(mid),
+                    serial.evaluate(mid),
+                    atol=1e-10,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_thb_space_raises_type_error() -> None:
+    """TypeError when global_space is THBSplineSpace (not BsplineSpace)."""
+    thb = create_thb_space(create_uniform_space([2, 2], [4, 4]))
+    part = partition_grid(thb.grid, 1)
+    ds = DistributedSpace(thb, part, _FakeComm(0, 1))
+    with pytest.raises(TypeError, match="BsplineSpace"):
+        l2_project_bspline_distributed(lambda lat: _grid(lat)[0], ds)
+
+
+def test_bad_n_quad_raises() -> None:
+    """ValueError when n_quad length mismatches the space dimension."""
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    with pytest.raises(ValueError, match="n_quad"):
+        l2_project_bspline_distributed(lambda lat: _grid(lat)[0], ds, n_quad=[2, 2, 2])
+
+
+# ---------------------------------------------------------------------------
+# dtype propagation
+# ---------------------------------------------------------------------------
+
+
+def test_float32_space_preserves_dtype() -> None:
+    """Global control points retain float32 dtype when the space uses float32."""
+    space = create_uniform_space([2], [4], dtype=np.float32)
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = l2_project_bspline_distributed(lambda lat: (_grid(lat)[0] ** 2).astype(np.float32), ds)
+    assert dfn.global_function.control_points.dtype == np.float32
+
+
+@pytest.mark.parametrize("n_parts", [2, 4])
+def test_float32_multi_rank_matches_serial(n_parts: int) -> None:
+    """float32 distributed L2 matches the serial result within float32 tolerance."""
+    space = create_uniform_space([2, 2], [4, 4], dtype=np.float32)
+    func = lambda lat: (_grid(lat)[0] ** 2 + _grid(lat)[1]).astype(np.float32)  # noqa: E731
+    results = _simulate_distributed_l2(func, space, n_parts)
+    serial = l2_project_bspline(func, space)
+    for dfn in results:
+        assert dfn.global_function.control_points.dtype == np.float32
+        np.testing.assert_allclose(
+            dfn.global_function.control_points.astype(np.float64),
+            serial.control_points.astype(np.float64),
+            atol=1e-4,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1D multi-rank
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_parts", [2, 4])
+def test_1d_multi_rank_matches_serial(n_parts: int) -> None:
+    """1D distributed L2 matches the serial result across multiple ranks."""
+    func = lambda lat: np.sin(np.pi * _grid(lat)[0])  # noqa: E731
+    space = create_uniform_space([3], [8])
+    results = _simulate_distributed_l2(func, space, n_parts)
+    serial = l2_project_bspline(func, space)
+    for dfn in results:
+        np.testing.assert_allclose(
+            dfn.global_function.control_points,
+            serial.control_points,
+            atol=1e-12,
+        )


### PR DESCRIPTION
## Summary

PR **I3** of #240 — `feat(mpi): l2_project_bspline_distributed for DistributedSpace`.
Deps: I1 (#241, merged).

Ports the serial `l2_project_bspline` to an MPI-distributed variant that accepts a
`DistributedSpace` and returns a `DistributedFunction`, mirroring the established
pattern of `quasi_interpolate_bspline_distributed` (#241) and
`quasi_interpolate_thb_spline_distributed` (#242).

## Algorithm

L2 assembly is per-element and maps directly onto the cell partition:

1. **Mass matrices** are partition-independent (the standard tensor-product 1D mass
   over *all* elements) — built identically and replicated on every rank, no reduce.
2. **Load vector**: each rank evaluates `func` only on the quadrature points of its
   *owned* cells (others masked to zero) and contracts them per-direction into a load
   tensor. A single `comm.allreduce` sums the global load across ranks. Because the
   contraction is linear in the function values and every quadrature point belongs to
   exactly one cell, the summed per-rank loads reproduce the full serial load exactly,
   for an arbitrary partition.
3. The **Kronecker solve** runs replicated on each rank (small `n_dofs_i × n_dofs_i`
   systems).
4. **`boundary_interpolation`** rows are applied on the reduced (global) load,
   replicated post-reduce: each boundary trace is partition-independent, so every rank
   recomputes the same boundary row (equivalent to only the rank owning the boundary
   cell contributing it).
5. Wrap the global coefficients in a `DistributedFunction`.

Every MPI entry point calls `_ensure_default_thread_policy()` first; `global_space` is
validated to be a `BsplineSpace` (`TypeError` otherwise).

## Serial refactor (additive)

Extracted `_build_l2_mass_and_quad` from `l2_project_bspline` so the serial path and the
new `pantr.mpi._l2` module share the mass/quad construction (with boundary-interpolation
rows applied) instead of duplicating it. Pure code motion — the extracted body is
verbatim, no serial behavior change (full serial L2 test suite still green). The new
module imports *from* `pantr.bspline`, the allowed direction; the import-linter contract
(serial core must not import `pantr.mpi`) stays **KEPT**.

## Files

- **added** `src/pantr/mpi/_l2.py` — `l2_project_bspline_distributed` + the
  `_owned_quad_cell_mask` / `_assemble_owned_load` helpers.
- **added** `tests/test_mpi_l2.py` — in-process unit tests (duck-typed `_FakeComm` with
  `allreduce`).
- **changed** `src/pantr/mpi/__init__.py` — export the new function (import, "Main
  exports" bullet, sorted `__all__`).
- **changed** `src/pantr/bspline/_bspline_interpolate.py` — extract
  `_build_l2_mass_and_quad`.
- **changed** `tests/mpi/test_distributed_mpi.py` — two real-MPI smoke tests.
- **changed** `tests/test_mpi.py` — register the new export in the public-surface
  assertion.

## Tests

In-process unit tests (counted toward the coverage gate) assert: distributed result ==
serial `l2_project_bspline` for owned DOFs and the full assembled field; multiple
partitions (`n_parts ∈ {2,3,4}`) all reproduce the serial output (so identical to each
other); each rank's local function matches the serial L2 at owned-cell midpoints; the
`boundary_interpolation` special case (`True` and per-direction pairs); scalar/vector
funcs; `float32` dtype propagation; 1D; and the empty-rank case.

Real-MPI smoke tests (`tests/mpi/`, run under `mpiexec`) verify the same over
`MPI.COMM_WORLD`, with a dedicated `boundary_interpolation` case.

## Checks (exit-code verified)

| Check | Result |
|---|---|
| `ruff check .` | ✅ pass |
| `ruff format --check .` | ✅ pass |
| `mypy --config-file mypy.ini src tests` | ✅ pass (210 files) |
| `lint-imports` | ✅ pass (1 contract kept, 0 broken) |
| `pytest --no-cov` (JIT) | ✅ 3789 passed, 15 skipped¹ |
| docs build (`-W --keep-going`) | ✅ build succeeded |
| `mpiexec -n 2` / `-n 3` smoke tests | ✅ 12 passed each |

¹ The default local run (without `pantr` pip-installed) shows 2 pre-existing failures in
`tests/test_mpi.py` whose subprocess `python -c "import pantr"` can't find the package;
with `pantr` importable (as in CI's `pip install -e`) the full suite is green
(3789 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
