### PR TITLE
feat(mpi): interpolate_bspline / fit_bspline for DistributedSpace

### DIFF
--- a/src/pantr/mpi/__init__.py
+++ b/src/pantr/mpi/__init__.py
@@ -21,6 +21,8 @@ Main exports:
 - :class:`DistributedFunction`: the per-rank handle to an MPI-distributed function.
 - :func:`create_distributed_function`: build a :class:`DistributedFunction` from a function.
 - :func:`configure_threads`: explicitly set this rank's Numba thread count.
+- :func:`interpolate_bspline_distributed`: distributed B-spline collocation interpolation.
+- :func:`fit_bspline_distributed`: distributed B-spline fit from pre-evaluated values.
 - :func:`quasi_interpolate_bspline_distributed`: distributed B-spline quasi-interpolation.
 - :func:`quasi_interpolate_thb_spline_distributed`: distributed THB-spline quasi-interpolation.
 
@@ -39,6 +41,7 @@ import importlib.util
 from types import ModuleType
 from typing import Final
 
+from ._collocation import fit_bspline_distributed, interpolate_bspline_distributed
 from ._create import create_distributed_space
 from ._distributed_function import DistributedFunction, create_distributed_function
 from ._distributed_space import DistributedSpace
@@ -108,7 +111,9 @@ __all__ = [
     "configure_threads",
     "create_distributed_function",
     "create_distributed_space",
+    "fit_bspline_distributed",
     "from_dolfinx",
+    "interpolate_bspline_distributed",
     "mpi_available",
     "quasi_interpolate_bspline_distributed",
     "quasi_interpolate_thb_spline_distributed",

--- a/src/pantr/mpi/_collocation.py
+++ b/src/pantr/mpi/_collocation.py
@@ -1,0 +1,418 @@
+"""Distributed collocation interpolation / fitting onto tensor-product B-spline spaces.
+
+Provides :func:`interpolate_bspline_distributed` and :func:`fit_bspline_distributed`, the
+MPI-parallel counterparts of :func:`~pantr.bspline.interpolate_bspline` and
+:func:`~pantr.bspline.fit_bspline`.  The collocation solve itself is a cheap sequence of
+1D SVD solves on small ``n_dofs_i x n_dofs_i`` systems; the bottleneck that motivates
+parallelism is evaluating ``func`` on the tensor-product Greville-node grid (whose size is
+the global DOF count).  Each rank therefore evaluates ``func`` on its block-assigned chunk
+of the flattened grid, a single ``allgather`` assembles the full value field, and the
+Kronecker solve runs **replicated** on every rank.  The result is a
+:class:`~pantr.mpi.DistributedFunction` whose global coefficient field equals the serial
+:func:`~pantr.bspline.interpolate_bspline` result bit-for-bit (and whose
+:attr:`~pantr.mpi.DistributedFunction.local` reproduces it over the rank's owned cells).
+
+Both entry points operate on tensor-product (lattice / Greville) nodes -- the case the
+distributed algorithm parallelizes.  Scattered-node inputs fall back to a fully replicated
+evaluation on every rank (no parallel speedup, but a correct result); this is documented
+per function.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+
+from .._interpolation_utils import split_components
+from ..bspline import Bspline, BsplineSpace, fit_bspline
+from ..bspline._bspline_interpolate import (
+    _apply_boundary_deriv_rhs,
+    _build_collocation_matrices,
+    _is_scattered_nodes,
+    _resolve_nodes,
+    _solve_kronecker,
+)
+from ..quad import PointsLattice
+from ._distributed_function import DistributedFunction
+from ._distributed_space import DistributedSpace
+from ._thread_policy import _ensure_default_thread_policy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import numpy.typing as npt
+
+
+def _block_bounds(n_total: int, n_parts: int, rank: int) -> tuple[int, int]:
+    """Return this rank's half-open block ``[start, stop)`` of a contiguous range.
+
+    Splits ``range(n_total)`` into ``n_parts`` contiguous blocks as evenly as possible:
+    the first ``n_total % n_parts`` blocks get one extra element.  An empty range (or a
+    rank beyond the populated blocks) yields a degenerate ``[start, start)`` slice.
+
+    Args:
+        n_total (int): Length of the range being split.
+        n_parts (int): Number of blocks (ranks).
+        rank (int): The rank whose block is requested; assumed in ``[0, n_parts)``.
+
+    Returns:
+        tuple[int, int]: The ``(start, stop)`` half-open bounds of this rank's block.
+
+    Note:
+        No input validation is performed.
+    """
+    base, extra = divmod(n_total, n_parts)
+    start = rank * base + min(rank, extra)
+    stop = start + base + (1 if rank < extra else 0)
+    return start, stop
+
+
+def _evaluate_block(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    all_points: npt.NDArray[np.float64],
+    start: int,
+    stop: int,
+) -> npt.NDArray[np.float64]:
+    """Evaluate ``func`` on a contiguous block of the flattened grid points.
+
+    Args:
+        func (Callable): Function called on a flat ``(M, dim)`` point array; must return
+            ``(M,)`` (scalar) or ``(M, rank)`` (vector-valued).
+        all_points (npt.NDArray[np.float64]): The full ``(n_total, dim)`` flattened grid.
+        start (int): Inclusive start index of this rank's block.
+        stop (int): Exclusive stop index of this rank's block.
+
+    Returns:
+        npt.NDArray[np.float64]: This rank's values, shape ``(stop - start,)`` (scalar) or
+        ``(stop - start, rank)`` (vector); always ``float64`` and C-contiguous.
+
+    Note:
+        No input validation is performed; ``func``'s return shape is checked downstream by
+        the replicated Kronecker solve.
+    """
+    block = np.ascontiguousarray(all_points[start:stop])
+    values = np.asarray(func(block), dtype=np.float64)
+    return np.ascontiguousarray(values)
+
+
+def _assemble_full_values(
+    blocks: list[npt.NDArray[np.float64]],
+    n_total: int,
+) -> npt.NDArray[np.float64]:
+    """Concatenate per-rank value blocks into the full flattened value field.
+
+    Args:
+        blocks (list[npt.NDArray[np.float64]]): Per-rank value blocks in rank order, each
+            shaped ``(block_len,)`` (scalar) or ``(block_len, rank)`` (vector); empty
+            blocks may be ``(0,)`` or ``(0, rank)``.
+        n_total (int): Expected total number of grid points (sum of block lengths).
+
+    Returns:
+        npt.NDArray[np.float64]: The full value field, shape ``(n_total,)`` (scalar) or
+        ``(n_total, rank)`` (vector).
+
+    Note:
+        No input validation is performed.  The rank dimension is inferred from the first
+        non-empty 2D block; if every block is empty the field is treated as scalar.
+    """
+    scalar = True
+    rank_dim = 1
+    for b in blocks:
+        if b.shape[0] == 0:
+            continue
+        scalar = b.ndim == 1
+        rank_dim = 1 if scalar else int(b.shape[1])
+        break
+
+    shape: tuple[int, ...] = (n_total,) if scalar else (n_total, rank_dim)
+    full = np.empty(shape, dtype=np.float64)
+    offset = 0
+    for b in blocks:
+        m = b.shape[0]
+        if m == 0:
+            continue
+        full[offset : offset + m] = b if scalar else b.reshape(m, rank_dim)
+        offset += m
+    return full
+
+
+def _solve_replicated(
+    space: BsplineSpace,
+    node_arrays: list[npt.NDArray[np.float32 | np.float64]],
+    full_values: npt.NDArray[np.float64],
+    boundary_derivatives: Sequence[tuple[int, ...] | None] | None,
+    tol: float | None,
+) -> Bspline:
+    """Run the replicated tensor-product collocation solve from a full value field.
+
+    Mirrors the serial :func:`~pantr.bspline.interpolate_bspline` solve: build the
+    per-direction collocation matrices, reshape the flattened values to the grid, apply
+    any boundary-derivative right-hand-side zeros, and solve each component via the
+    Kronecker structure.  Every rank runs this identically on the gathered value field.
+
+    Args:
+        space (BsplineSpace): The global target space.
+        node_arrays (list[npt.NDArray]): Per-direction node arrays (the Greville or custom
+            tensor-product nodes).
+        full_values (npt.NDArray[np.float64]): The full flattened value field, shape
+            ``(n_total,)`` (scalar) or ``(n_total, rank)`` (vector), C-ordered to match the
+            grid (last grid index varies fastest).
+        boundary_derivatives (Sequence[tuple[int, ...] | None] | None): Per-direction
+            ``(n_left, n_right)`` boundary-derivative constraints, or ``None``.
+        tol (float | None): SVD truncation tolerance forwarded to the 1D solves.
+
+    Returns:
+        Bspline: The fitted global B-spline (control points cast to ``space.dtype``).
+
+    Note:
+        No input validation is performed.  ``full_values`` must already be shaped
+        consistently with ``node_arrays``.
+    """
+    grid_shape = tuple(a.shape[0] for a in node_arrays)
+    if full_values.ndim == 1:
+        gridded: npt.NDArray[np.float64] = full_values.reshape(grid_shape)
+    else:
+        gridded = full_values.reshape(*grid_shape, full_values.shape[1])
+
+    components = split_components(gridded, grid_shape)
+    if boundary_derivatives is not None:
+        components = _apply_boundary_deriv_rhs(space, components, boundary_derivatives)
+
+    matrices = _build_collocation_matrices(space, node_arrays, boundary_derivatives)
+    out_dtype = space.dtype
+    ctrl_components = [
+        _solve_kronecker(matrices, comp.astype(out_dtype), tol) for comp in components
+    ]
+    ctrl = np.stack(ctrl_components, axis=-1)
+    return Bspline(space, ctrl)
+
+
+def interpolate_bspline_distributed(
+    func: Callable[[npt.NDArray[np.float64]], npt.ArrayLike],
+    distributed_space: DistributedSpace,
+    *,
+    nodes: (
+        Literal["greville"]
+        | PointsLattice
+        | npt.NDArray[np.floating[Any]]
+        | Sequence[npt.NDArray[np.floating[Any]]]
+        | None
+    ) = None,
+    boundary_derivatives: Sequence[tuple[int, ...] | None] | None = None,
+    tol: float | None = None,
+) -> DistributedFunction:
+    """Interpolate a callable onto a distributed tensor-product B-spline space.
+
+    The MPI-parallel counterpart of :func:`~pantr.bspline.interpolate_bspline`.  The
+    collocation solve is a cheap sequence of small 1D SVD solves; the cost that motivates
+    parallelism is evaluating ``func`` on the tensor-product node grid (whose size is the
+    global DOF count).  Each rank evaluates ``func`` on its block-assigned chunk of the
+    flattened grid, a single ``allgather`` assembles the full value field, and the
+    Kronecker solve runs **replicated** on every rank.  The returned
+    :class:`~pantr.mpi.DistributedFunction` carries the global coefficient field (identical
+    on every rank, equal to the serial result) and its
+    :attr:`~pantr.mpi.DistributedFunction.local` reproduces the serial interpolant over the
+    rank's owned cells.
+
+    Unlike serial :func:`~pantr.bspline.interpolate_bspline`, whose ``func`` receives a
+    :class:`~pantr.quad.PointsLattice`, here ``func`` receives a **flat** ``(M, dim)`` point
+    array -- a contiguous chunk of the grid is not itself a tensor product, so a flat array
+    is the natural distributed convention (and matches the distributed quasi-interpolants).
+
+    Construction requires one MPI collective (``comm.allgather``) after each rank's local
+    evaluation.
+
+    Args:
+        func (Callable): Function to interpolate.  Called on a flat ``(M, dim)`` point
+            array; must return ``(M,)`` (scalar) or ``(M, rank)`` (vector-valued).
+        distributed_space (DistributedSpace): The distributed space to interpolate onto.
+            Its ``global_space`` must be a :class:`~pantr.bspline.BsplineSpace`.
+        nodes: Interpolation node selection, identical to
+            :func:`~pantr.bspline.interpolate_bspline`.
+
+            - ``None`` or ``"greville"`` (default): Greville abscissae.
+            - A :class:`~pantr.quad.PointsLattice`: custom tensor-product grid.
+            - A 1D ``ndarray``: custom nodes for a 1D space.
+            - A sequence of 1D ``ndarray`` values: per-direction custom nodes.
+        boundary_derivatives (Sequence[tuple[int, ...] | None] | None): Per-direction
+            ``(n_left, n_right)`` boundary-derivative constraints (set to zero), or
+            ``None``.  Defaults to ``None``.
+        tol (float | None): SVD truncation tolerance for the collocation solve.  If
+            ``None``, defaults to ``100 * machine_epsilon``.  Defaults to ``None``.
+
+    Returns:
+        DistributedFunction: A distributed function whose
+        :attr:`~pantr.mpi.DistributedFunction.global_function` holds the full assembled
+        global coefficient field (identical on every rank), and whose
+        :attr:`~pantr.mpi.DistributedFunction.local` interpolates ``func`` over this rank's
+        owned cells.
+
+    Raises:
+        TypeError: If ``distributed_space.global_space`` is not a
+            :class:`~pantr.bspline.BsplineSpace`.
+        ValueError: If ``nodes`` is inconsistent with the space, or ``func`` returns an
+            output with an invalid shape.
+
+    Note:
+        Tensor-product (lattice / Greville) nodes are the parallelized path.  All internal
+        computation uses ``float64``; the global control points are cast to
+        ``global_space.dtype`` before assembly, consistent with serial
+        :func:`~pantr.bspline.interpolate_bspline`.
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> import numpy as np  # doctest: +SKIP
+        >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP
+        >>> from pantr.mpi import interpolate_bspline_distributed  # doctest: +SKIP
+        >>> space = create_uniform_space([2, 2], [8, 8])  # doctest: +SKIP
+        >>> ds = create_distributed_space(space, MPI.COMM_WORLD)  # doctest: +SKIP
+        >>> dfn = interpolate_bspline_distributed(  # doctest: +SKIP
+        ...     lambda p: np.sin(p[:, 0]) * np.cos(p[:, 1]), ds
+        ... )
+    """
+    _ensure_default_thread_policy()
+
+    global_space = distributed_space.global_space
+    if not isinstance(global_space, BsplineSpace):
+        raise TypeError(
+            f"distributed_space.global_space must be a BsplineSpace; "
+            f"got {type(global_space).__name__!r}."
+        )
+
+    node_arrays = _resolve_nodes(global_space, nodes)
+    lattice = PointsLattice(node_arrays)
+
+    comm = distributed_space.comm
+    n_parts = int(comm.size)
+    rank = int(comm.rank)
+
+    all_points = np.ascontiguousarray(lattice.get_all_points(order="C"), dtype=np.float64)
+    n_total = all_points.shape[0]
+    start, stop = _block_bounds(n_total, n_parts, rank)
+    local_values = _evaluate_block(func, all_points, start, stop)
+
+    blocks: list[npt.NDArray[np.float64]] = list(comm.allgather(local_values))
+    full_values = _assemble_full_values(blocks, n_total)
+
+    global_bspline = _solve_replicated(
+        global_space, node_arrays, full_values, boundary_derivatives, tol
+    )
+    return DistributedFunction(global_bspline, distributed_space)
+
+
+def fit_bspline_distributed(
+    values: npt.ArrayLike,
+    nodes: (
+        PointsLattice | npt.NDArray[np.floating[Any]] | Sequence[npt.NDArray[np.floating[Any]]]
+    ),
+    distributed_space: DistributedSpace,
+    *,
+    values_distributed: bool = False,
+    tol: float | None = None,
+) -> DistributedFunction:
+    """Construct a distributed B-spline from pre-evaluated sample values at known nodes.
+
+    The MPI-parallel counterpart of :func:`~pantr.bspline.fit_bspline`.  The collocation
+    solve is cheap (small 1D SVD solves); for tensor-product nodes the value field is the
+    only large object, so this function supports values that **arrive already distributed**
+    (one contiguous block of the flattened grid per rank), gathered with a single
+    ``allgather`` before the replicated Kronecker solve.
+
+    Two value layouts are supported via ``values_distributed``:
+
+    - ``values_distributed=False`` (default, *replicated*): every rank passes the full
+      value field (shape ``(*n_pts_per_dir)`` or ``(*n_pts_per_dir, rank)``), exactly as
+      serial :func:`~pantr.bspline.fit_bspline`.  No ``allgather`` is needed; each rank
+      solves locally.
+    - ``values_distributed=True`` (*pre-distributed*): each rank passes only its
+      block-assigned chunk of the **C-flattened** grid values, shape ``(block_len,)`` or
+      ``(block_len, rank)``.  The blocks are concatenated (one ``allgather``) into the full
+      field before the solve.  The per-rank split must match
+      :func:`interpolate_bspline_distributed` (contiguous blocks of the C-order flattened
+      grid, the first ``n_total % n_parts`` blocks one element longer).
+
+    Args:
+        values (npt.ArrayLike): Sample values.  Full tensor-product field when
+            ``values_distributed`` is ``False``; this rank's flattened block when ``True``.
+        nodes: Tensor-product interpolation nodes (identical on every rank).
+
+            - A :class:`~pantr.quad.PointsLattice`: tensor-product grid.
+            - A 1D ``ndarray``: 1D tensor-product (single direction).
+            - A sequence of 1D ``ndarray`` values: N-D tensor-product.
+        distributed_space (DistributedSpace): The distributed space to fit onto.  Its
+            ``global_space`` must be a :class:`~pantr.bspline.BsplineSpace`.
+        values_distributed (bool): Whether ``values`` is this rank's flattened block
+            (``True``) or the full replicated field (``False``).  Defaults to ``False``.
+        tol (float | None): SVD truncation tolerance.  If ``None``, defaults to
+            ``100 * machine_epsilon``.  Defaults to ``None``.
+
+    Returns:
+        DistributedFunction: A distributed function whose
+        :attr:`~pantr.mpi.DistributedFunction.global_function` holds the full assembled
+        global coefficient field (identical on every rank), and whose
+        :attr:`~pantr.mpi.DistributedFunction.local` reproduces the fit over the rank's
+        owned cells.
+
+    Raises:
+        TypeError: If ``distributed_space.global_space`` is not a
+            :class:`~pantr.bspline.BsplineSpace`.
+        ValueError: If ``nodes`` are scattered (a 2D ``ndarray``) while
+            ``values_distributed`` is ``True`` (scattered points have no tensor-product
+            block layout), or if ``nodes`` / ``values`` are inconsistent with the space.
+
+    Note:
+        Scattered nodes (a 2D ``ndarray`` of shape ``(n_pts, dim)``) are only supported in
+        the replicated path (``values_distributed=False``); they fall back to the serial
+        :func:`~pantr.bspline.fit_bspline` solve run identically on every rank (correct,
+        but with no parallel speedup).  The output dtype follows
+        ``global_space.dtype``.
+
+    Example:
+        >>> from mpi4py import MPI  # doctest: +SKIP
+        >>> from pantr.bspline import create_greville_lattice  # doctest: +SKIP
+        >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
+        >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP
+        >>> from pantr.mpi import fit_bspline_distributed  # doctest: +SKIP
+        >>> space = create_uniform_space([2, 2], [8, 8])  # doctest: +SKIP
+        >>> ds = create_distributed_space(space, MPI.COMM_WORLD)  # doctest: +SKIP
+        >>> lat = create_greville_lattice(space)  # doctest: +SKIP
+        >>> vals = (lat.get_all_points()[:, 0] ** 2)  # full field on every rank  # doctest: +SKIP
+        >>> dfn = fit_bspline_distributed(vals, lat, ds)  # doctest: +SKIP
+    """
+    _ensure_default_thread_policy()
+
+    global_space = distributed_space.global_space
+    if not isinstance(global_space, BsplineSpace):
+        raise TypeError(
+            f"distributed_space.global_space must be a BsplineSpace; "
+            f"got {type(global_space).__name__!r}."
+        )
+
+    if not values_distributed:
+        # Replicated path: every rank holds the full field; delegate to the serial solve.
+        global_bspline = fit_bspline(values, nodes, global_space, tol=tol)
+        return DistributedFunction(global_bspline, distributed_space)
+
+    if _is_scattered_nodes(nodes):
+        raise ValueError(
+            "values_distributed=True is only supported for tensor-product nodes; "
+            "scattered (2D ndarray) nodes have no block layout. Pass the full value "
+            "field with values_distributed=False instead."
+        )
+
+    node_arrays = _resolve_nodes(global_space, nodes)
+    n_total = int(np.prod([a.shape[0] for a in node_arrays]))
+
+    local_block = np.asarray(values, dtype=np.float64)
+    blocks: list[npt.NDArray[np.float64]] = list(
+        distributed_space.comm.allgather(np.ascontiguousarray(local_block))
+    )
+    full_values = _assemble_full_values(blocks, n_total)
+
+    global_bspline = _solve_replicated(global_space, node_arrays, full_values, None, tol)
+    return DistributedFunction(global_bspline, distributed_space)
+
+
+__all__ = ["fit_bspline_distributed", "interpolate_bspline_distributed"]

--- a/tests/mpi/test_distributed_mpi.py
+++ b/tests/mpi/test_distributed_mpi.py
@@ -21,8 +21,11 @@ from pantr.bspline import (
     BsplineSpace,
     THBSpline,
     build_local,
+    create_greville_lattice,
     create_thb_space,
     create_uniform_space,
+    fit_bspline,
+    interpolate_bspline,
     quasi_interpolate_bspline,
     quasi_interpolate_thb_spline,
 )
@@ -31,7 +34,9 @@ from pantr.mpi import (
     DistributedSpace,
     create_distributed_function,
     create_distributed_space,
+    fit_bspline_distributed,
     from_dolfinx,
+    interpolate_bspline_distributed,
     quasi_interpolate_bspline_distributed,
     quasi_interpolate_thb_spline_distributed,
 )
@@ -248,6 +253,105 @@ def test_quasi_interpolate_thb_spline_distributed_vector_func() -> None:
     ds = create_distributed_space(space, comm)
     dfn = quasi_interpolate_thb_spline_distributed(func, ds)
     serial = quasi_interpolate_thb_spline(func, space)
+
+    np.testing.assert_allclose(
+        dfn.global_function.control_points, serial.control_points, atol=1e-10
+    )
+
+
+def test_interpolate_bspline_distributed_matches_serial() -> None:
+    """Distributed collocation interpolation reproduces the serial interpolant.
+
+    Each rank evaluates func only on its block of the flattened Greville grid; a single
+    allgather assembles the full value field before the replicated Kronecker solve.  The
+    test verifies the global function is identical on every rank and equals the serial
+    interpolant, and that the local function agrees with serial at owned cell midpoints.
+    """
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [8, 8])
+    # The distributed func takes a flat (M, dim) array; serial takes a PointsLattice.
+    flat: Any = lambda p: np.sin(np.pi * p[:, 0]) * np.cos(np.pi * p[:, 1])  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = interpolate_bspline_distributed(flat, ds)
+    serial = interpolate_bspline(lambda lat: flat(lat.get_all_points(order="C")), space)
+
+    # 1. Global function must be identical on all ranks and equal to serial.
+    all_global_cp = comm.allgather(np.asarray(dfn.global_function.control_points))
+    for rank_cp in all_global_cp:
+        np.testing.assert_allclose(rank_cp, serial.control_points, atol=1e-10)
+
+    # 2. Local function reproduces serial at owned cell midpoints.
+    if dfn.local is None:
+        return
+    assert ds.local is not None
+    assert isinstance(dfn.local.space, BsplineSpace)
+    grid = tensor_product_grid(dfn.local.space)
+    for lc in np.flatnonzero(ds.local.owned_cell_mask):
+        lo, hi = grid.cell_bounds(int(lc))
+        mid = (0.5 * (lo + hi))[None]
+        np.testing.assert_allclose(dfn.local.evaluate(mid), serial.evaluate(mid), atol=1e-10)
+
+
+def test_interpolate_bspline_distributed_vector_func() -> None:
+    """Vector-valued func (rank=2) distributes correctly via collocation."""
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])
+    flat: Any = lambda p: np.stack([p[:, 0], 1.0 - p[:, 1]], axis=-1)  # noqa: E731
+
+    ds = create_distributed_space(space, comm)
+    dfn = interpolate_bspline_distributed(flat, ds)
+    serial = interpolate_bspline(lambda lat: flat(lat.get_all_points(order="C")), space)
+
+    np.testing.assert_allclose(
+        dfn.global_function.control_points, serial.control_points, atol=1e-10
+    )
+
+
+def test_fit_bspline_distributed_predistributed_values_matches_serial() -> None:
+    """Distributed fit with pre-distributed value blocks reproduces the serial fit.
+
+    Every rank evaluates only its block of the flattened Greville grid, passes it with
+    ``values_distributed=True``, and a single allgather assembles the full field before
+    the replicated solve.  The block split must match the routine's contiguous C-order
+    blocks (``divmod`` even split, first remainder ranks one longer).
+    """
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [8, 8])
+    lattice = create_greville_lattice(space)
+    pts = lattice.get_all_points(order="C")
+    n_total = pts.shape[0]
+    flat: Any = lambda p: p[:, 0] ** 2 + p[:, 1]  # noqa: E731
+
+    base, extra = divmod(n_total, comm.size)
+    start = comm.rank * base + min(comm.rank, extra)
+    stop = start + base + (1 if comm.rank < extra else 0)
+    block = np.ascontiguousarray(flat(pts[start:stop]))
+
+    ds = create_distributed_space(space, comm)
+    dfn = fit_bspline_distributed(block, lattice, ds, values_distributed=True)
+
+    # Reference serial fit on the full value field.
+    grid_shape = tuple(a.shape[0] for a in lattice.pts_per_dir)
+    serial = fit_bspline(flat(pts).reshape(grid_shape), lattice, space)
+
+    all_global_cp = comm.allgather(np.asarray(dfn.global_function.control_points))
+    for rank_cp in all_global_cp:
+        np.testing.assert_allclose(rank_cp, serial.control_points, atol=1e-10)
+
+
+def test_fit_bspline_distributed_replicated_values_matches_serial() -> None:
+    """Distributed fit with replicated values (full field on every rank) matches serial."""
+    comm = MPI.COMM_WORLD
+    space = create_uniform_space([2, 2], [6, 6])
+    lattice = create_greville_lattice(space)
+    pts = lattice.get_all_points(order="C")
+    grid_shape = tuple(a.shape[0] for a in lattice.pts_per_dir)
+    vals = (pts[:, 0] ** 2 + pts[:, 1]).reshape(grid_shape)
+
+    ds = create_distributed_space(space, comm)
+    dfn = fit_bspline_distributed(vals, lattice, ds)
+    serial = fit_bspline(vals, lattice, space)
 
     np.testing.assert_allclose(
         dfn.global_function.control_points, serial.control_points, atol=1e-10

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -25,6 +25,8 @@ def test_import_and_public_surface() -> None:
     assert isinstance(pantr.mpi.HAS_MPI, bool)
     assert callable(pantr.mpi.quasi_interpolate_bspline_distributed)
     assert callable(pantr.mpi.quasi_interpolate_thb_spline_distributed)
+    assert callable(pantr.mpi.interpolate_bspline_distributed)
+    assert callable(pantr.mpi.fit_bspline_distributed)
     assert set(pantr.mpi.__all__) == {
         "DistributedFunction",
         "DistributedSpace",
@@ -32,7 +34,9 @@ def test_import_and_public_surface() -> None:
         "configure_threads",
         "create_distributed_function",
         "create_distributed_space",
+        "fit_bspline_distributed",
         "from_dolfinx",
+        "interpolate_bspline_distributed",
         "mpi_available",
         "quasi_interpolate_bspline_distributed",
         "quasi_interpolate_thb_spline_distributed",

--- a/tests/test_mpi_collocation.py
+++ b/tests/test_mpi_collocation.py
@@ -1,0 +1,434 @@
+"""Tests for distributed B-spline collocation interpolation / fitting.
+
+Covers :func:`pantr.mpi.interpolate_bspline_distributed` and
+:func:`pantr.mpi.fit_bspline_distributed`.  MPI is not available in the default test
+environment, so the communicator is duck-typed by ``_FakeComm``, which adds the
+``allgather`` collective these functions need.
+
+Multi-rank runs are simulated in a single process: each rank's contribution to the
+``allgather`` is collected first, then the distributed routine is replayed per rank with
+the full gather pre-set.  The matching real-MPI smoke tests live in
+``tests/mpi/test_distributed_mpi.py`` and run under ``mpiexec``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import pantr.mpi as _pantr_mpi
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    create_greville_lattice,
+    create_thb_space,
+    create_uniform_space,
+    fit_bspline,
+    interpolate_bspline,
+)
+from pantr.grid import partition_grid, tensor_product_grid
+from pantr.mpi import (
+    DistributedFunction,
+    DistributedSpace,
+    fit_bspline_distributed,
+    interpolate_bspline_distributed,
+)
+from pantr.mpi._collocation import _block_bounds
+
+# ---------------------------------------------------------------------------
+# Fake communicator with allgather
+# ---------------------------------------------------------------------------
+
+
+class _FakeComm:
+    """Minimal stand-in for an mpi4py communicator.
+
+    Supports ``rank``, ``size``, and ``allgather``.  For a single rank, ``allgather``
+    returns ``[data]``.  For multi-rank simulations pass ``allgather_results`` to set the
+    value returned regardless of local data.
+    """
+
+    def __init__(
+        self,
+        rank: int,
+        size: int,
+        allgather_results: list[Any] | None = None,
+    ) -> None:
+        self._rank = rank
+        self._size = size
+        self._allgather_results = allgather_results
+
+    @property
+    def rank(self) -> int:
+        return self._rank
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def allgather(self, data: Any) -> list[Any]:
+        if self._allgather_results is not None:
+            return self._allgather_results
+        assert self._size == 1, "multi-rank allgather requires pre-set allgather_results"
+        return [data]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_lattice_func(flat_func: Any) -> Any:
+    """Adapt a flat-``(M, dim)`` func to the serial PointsLattice calling convention.
+
+    Serial :func:`interpolate_bspline` / :func:`fit_bspline` call ``func(lattice)``; the
+    distributed routines call ``func(points)`` on a flat array.  This wrapper lets one
+    flat func drive both so equivalence is checked on identical values.
+    """
+    return lambda lattice: flat_func(lattice.get_all_points(order="C"))
+
+
+def _simulate_interpolate(
+    func: Any,
+    space: BsplineSpace,
+    n_parts: int,
+    **kwargs: Any,
+) -> list[DistributedFunction]:
+    """Simulate interpolate_bspline_distributed across n_parts ranks in one process.
+
+    Each rank evaluates only its block of the flattened grid; the pre-collected blocks
+    play the role of the allgather, so every rank assembles the identical full field.
+    """
+    part = partition_grid(tensor_product_grid(space), n_parts)
+    pts = create_greville_lattice(space).get_all_points(order="C")
+    n_total = pts.shape[0]
+
+    blocks: list[Any] = []
+    for rank in range(n_parts):
+        start, stop = _block_bounds(n_total, n_parts, rank)
+        blocks.append(np.asarray(func(pts[start:stop]), dtype=np.float64))
+
+    results: list[DistributedFunction] = []
+    for rank in range(n_parts):
+        ds = DistributedSpace(space, part, _FakeComm(rank, n_parts, allgather_results=blocks))
+        results.append(interpolate_bspline_distributed(func, ds, **kwargs))
+    return results
+
+
+def _simulate_fit_distributed_values(
+    func: Any,
+    space: BsplineSpace,
+    n_parts: int,
+    **kwargs: Any,
+) -> list[DistributedFunction]:
+    """Simulate fit_bspline_distributed with values_distributed=True across n_parts ranks."""
+    part = partition_grid(tensor_product_grid(space), n_parts)
+    lattice = create_greville_lattice(space)
+    pts = lattice.get_all_points(order="C")
+    n_total = pts.shape[0]
+    full_vals = np.asarray(func(pts), dtype=np.float64)
+
+    blocks: list[Any] = []
+    for rank in range(n_parts):
+        start, stop = _block_bounds(n_total, n_parts, rank)
+        blocks.append(np.ascontiguousarray(full_vals[start:stop]))
+
+    results: list[DistributedFunction] = []
+    for rank in range(n_parts):
+        ds = DistributedSpace(space, part, _FakeComm(rank, n_parts, allgather_results=blocks))
+        results.append(
+            fit_bspline_distributed(blocks[rank], lattice, ds, values_distributed=True, **kwargs)
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_surface() -> None:
+    """Both functions are exported from pantr.mpi."""
+    assert callable(_pantr_mpi.interpolate_bspline_distributed)
+    assert callable(_pantr_mpi.fit_bspline_distributed)
+    assert "interpolate_bspline_distributed" in _pantr_mpi.__all__
+    assert "fit_bspline_distributed" in _pantr_mpi.__all__
+
+
+def test_block_bounds_partition() -> None:
+    """_block_bounds tiles [0, n_total) into contiguous, non-overlapping blocks."""
+    for n_total in (0, 1, 7, 16, 17):
+        for n_parts in (1, 2, 3, 4):
+            bounds = [_block_bounds(n_total, n_parts, r) for r in range(n_parts)]
+            # Contiguous and covering.
+            assert bounds[0][0] == 0
+            assert bounds[-1][1] == n_total
+            for r in range(1, n_parts):
+                assert bounds[r][0] == bounds[r - 1][1]
+            # Block sizes differ by at most 1.
+            sizes = [hi - lo for lo, hi in bounds]
+            assert max(sizes) - min(sizes) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_returns_distributed_function() -> None:
+    """Interpolation returns a DistributedFunction on the given distributed space."""
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = interpolate_bspline_distributed(lambda p: p[:, 0] ** 2, ds)
+    assert isinstance(dfn, DistributedFunction)
+    assert dfn.distributed_space is ds
+    assert dfn.global_function.space is space
+    assert isinstance(dfn.local, Bspline)
+
+
+def test_fit_returns_distributed_function() -> None:
+    """Fitting returns a DistributedFunction on the given distributed space."""
+    space = create_uniform_space([2, 2], [4, 4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    lattice = create_greville_lattice(space)
+    vals = lattice.get_all_points(order="C")[:, 0] ** 2
+    grid_shape = tuple(a.shape[0] for a in lattice.pts_per_dir)
+    dfn = fit_bspline_distributed(vals.reshape(grid_shape), lattice, ds)
+    assert isinstance(dfn, DistributedFunction)
+    assert dfn.global_function.space is space
+
+
+# ---------------------------------------------------------------------------
+# Single-rank equivalence: distributed == serial
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateSingleRankEquivalence:
+    """With n_parts=1 the distributed interpolant must equal the serial one exactly."""
+
+    def _check(self, func: Any, space: BsplineSpace, **kwargs: Any) -> None:
+        part = partition_grid(tensor_product_grid(space), 1)
+        ds = DistributedSpace(space, part, _FakeComm(0, 1))
+        dfn = interpolate_bspline_distributed(func, ds, **kwargs)
+        serial = interpolate_bspline(_as_lattice_func(func), space, **kwargs)
+        np.testing.assert_array_equal(dfn.global_function.control_points, serial.control_points)
+
+    def test_polynomial_1d(self) -> None:
+        self._check(lambda p: p[:, 0] ** 2, create_uniform_space([2], [5]))
+
+    def test_polynomial_2d(self) -> None:
+        self._check(
+            lambda p: p[:, 0] ** 2 + p[:, 0] * p[:, 1],
+            create_uniform_space([2, 2], [4, 4]),
+        )
+
+    def test_vector_2d(self) -> None:
+        self._check(
+            lambda p: np.stack([p[:, 0], p[:, 1]], axis=-1),
+            create_uniform_space([2, 2], [4, 4]),
+        )
+
+    def test_boundary_derivatives(self) -> None:
+        self._check(
+            lambda p: np.sin(np.pi * p[:, 0]),
+            create_uniform_space([3], [6]),
+            boundary_derivatives=[(1, 1)],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-rank equivalence: distributed == serial (simulated in one process)
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateMultiRankEquivalence:
+    """Distributed interpolation across N simulated ranks must reproduce serial."""
+
+    @pytest.mark.parametrize("n_parts", [1, 2, 3, 4])
+    def test_scalar_polynomial(self, n_parts: int) -> None:
+        func = lambda p: p[:, 0] ** 2 + p[:, 1] ** 2  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        serial = interpolate_bspline(_as_lattice_func(func), space)
+        for dfn in _simulate_interpolate(func, space, n_parts):
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_vector_function(self, n_parts: int) -> None:
+        func = lambda p: np.stack([p[:, 0], 1.0 - p[:, 1]], axis=-1)  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        serial = interpolate_bspline(_as_lattice_func(func), space)
+        for dfn in _simulate_interpolate(func, space, n_parts):
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 3])
+    def test_1d_transcendental(self, n_parts: int) -> None:
+        func = lambda p: np.sin(np.pi * p[:, 0])  # noqa: E731
+        space = create_uniform_space([3], [8])
+        serial = interpolate_bspline(_as_lattice_func(func), space)
+        for dfn in _simulate_interpolate(func, space, n_parts):
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_different_partitions_identical(self, n_parts: int) -> None:
+        """Every rank assembles the identical global field, independent of partition."""
+        func = lambda p: np.cos(np.pi * p[:, 0]) * p[:, 1]  # noqa: E731
+        space = create_uniform_space([2, 2], [6, 6])
+        results = _simulate_interpolate(func, space, n_parts)
+        ref = results[0].global_function.control_points
+        for dfn in results[1:]:
+            np.testing.assert_array_equal(dfn.global_function.control_points, ref)
+
+
+# ---------------------------------------------------------------------------
+# fit: distributed == serial, both replicated and pre-distributed value paths
+# ---------------------------------------------------------------------------
+
+
+class TestFitEquivalence:
+    """fit_bspline_distributed matches serial fit_bspline in both value layouts."""
+
+    def _serial(self, func: Any, space: BsplineSpace) -> Bspline:
+        lattice = create_greville_lattice(space)
+        grid_shape = tuple(a.shape[0] for a in lattice.pts_per_dir)
+        vals = np.asarray(func(lattice.get_all_points(order="C")), dtype=np.float64)
+        if vals.ndim == 1:
+            vals = vals.reshape(grid_shape)
+        else:
+            vals = vals.reshape(*grid_shape, vals.shape[1])
+        return fit_bspline(vals, lattice, space)
+
+    @pytest.mark.parametrize("n_parts", [1, 2, 4])
+    def test_replicated_values(self, n_parts: int) -> None:
+        """values_distributed=False: every rank holds the full field."""
+        func: Any = lambda p: p[:, 0] ** 2 + p[:, 1]  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        serial = self._serial(func, space)
+
+        lattice = create_greville_lattice(space)
+        grid_shape = tuple(a.shape[0] for a in lattice.pts_per_dir)
+        vals = np.asarray(func(lattice.get_all_points(order="C")), dtype=np.float64)
+        vals = vals.reshape(grid_shape)
+
+        part = partition_grid(tensor_product_grid(space), n_parts)
+        for rank in range(n_parts):
+            ds = DistributedSpace(space, part, _FakeComm(rank, n_parts))
+            dfn = fit_bspline_distributed(vals, lattice, ds)
+            np.testing.assert_array_equal(dfn.global_function.control_points, serial.control_points)
+
+    @pytest.mark.parametrize("n_parts", [1, 2, 3, 4])
+    def test_pre_distributed_values(self, n_parts: int) -> None:
+        """values_distributed=True: each rank holds only its flattened block."""
+        func = lambda p: p[:, 0] ** 2 + p[:, 1]  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        serial = self._serial(func, space)
+        for dfn in _simulate_fit_distributed_values(func, space, n_parts):
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    @pytest.mark.parametrize("n_parts", [2, 4])
+    def test_pre_distributed_vector_values(self, n_parts: int) -> None:
+        """Vector-valued pre-distributed blocks reproduce the serial fit."""
+        func = lambda p: np.stack([p[:, 0], 1.0 - p[:, 1]], axis=-1)  # noqa: E731
+        space = create_uniform_space([2, 2], [4, 4])
+        serial = self._serial(func, space)
+        for dfn in _simulate_fit_distributed_values(func, space, n_parts):
+            np.testing.assert_allclose(
+                dfn.global_function.control_points, serial.control_points, atol=1e-12
+            )
+
+    def test_interpolate_matches_fit_distributed(self) -> None:
+        """Distributed interpolate == distributed fit on the same Greville values."""
+        func = lambda p: np.sin(np.pi * p[:, 0]) * p[:, 1]  # noqa: E731
+        space = create_uniform_space([3, 2], [6, 5])
+        interp = _simulate_interpolate(func, space, 3)[0]
+        fitted = _simulate_fit_distributed_values(func, space, 3)[0]
+        np.testing.assert_allclose(
+            interp.global_function.control_points,
+            fitted.global_function.control_points,
+            atol=1e-12,
+        )
+
+
+# ---------------------------------------------------------------------------
+# dtype propagation
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_float32_preserves_dtype() -> None:
+    """Global control points retain float32 dtype when the space uses float32."""
+    space = create_uniform_space([2], [4], dtype=np.float32)
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    dfn = interpolate_bspline_distributed(lambda p: (p[:, 0] ** 2).astype(np.float32), ds)
+    assert dfn.global_function.control_points.dtype == np.float32
+
+
+@pytest.mark.parametrize("n_parts", [2, 4])
+def test_interpolate_float32_matches_serial(n_parts: int) -> None:
+    """float32 distributed interpolation matches serial within float32 tolerance."""
+    space = create_uniform_space([2, 2], [4, 4], dtype=np.float32)
+    func = lambda p: (p[:, 0] ** 2 + p[:, 1]).astype(np.float32)  # noqa: E731
+    serial = interpolate_bspline(_as_lattice_func(func), space)
+    for dfn in _simulate_interpolate(func, space, n_parts):
+        assert dfn.global_function.control_points.dtype == np.float32
+        np.testing.assert_allclose(
+            dfn.global_function.control_points.astype(np.float64),
+            serial.control_points.astype(np.float64),
+            atol=1e-5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_thb_space_raises_type_error() -> None:
+    """TypeError when global_space is a THBSplineSpace."""
+    thb = create_thb_space(create_uniform_space([2, 2], [4, 4]))
+    part = partition_grid(thb.grid, 1)
+    ds = DistributedSpace(thb, part, _FakeComm(0, 1))
+    with pytest.raises(TypeError, match="BsplineSpace"):
+        interpolate_bspline_distributed(lambda p: p[:, 0], ds)
+
+
+def test_fit_thb_space_raises_type_error() -> None:
+    """TypeError when global_space is a THBSplineSpace (checked before nodes are used)."""
+    thb = create_thb_space(create_uniform_space([2, 2], [4, 4]))
+    part = partition_grid(thb.grid, 1)
+    ds = DistributedSpace(thb, part, _FakeComm(0, 1))
+    with pytest.raises(TypeError, match="BsplineSpace"):
+        fit_bspline_distributed(np.zeros((5, 5)), [np.linspace(0, 1, 5)], ds)
+
+
+def test_fit_distributed_scattered_raises() -> None:
+    """values_distributed=True with scattered nodes raises ValueError."""
+    space = create_uniform_space([2], [4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    scattered = np.linspace(0, 1, 10).reshape(-1, 1)
+    with pytest.raises(ValueError, match="tensor-product"):
+        fit_bspline_distributed(np.zeros(10), scattered, ds, values_distributed=True)
+
+
+def test_fit_scattered_replicated_falls_back() -> None:
+    """Scattered nodes work in the replicated path (serial fallback)."""
+    space = create_uniform_space([2], [4])
+    part = partition_grid(tensor_product_grid(space), 1)
+    ds = DistributedSpace(space, part, _FakeComm(0, 1))
+    nodes = np.linspace(0, 1, 20).reshape(-1, 1)
+    vals = np.sin(np.pi * nodes[:, 0])
+    dfn = fit_bspline_distributed(vals, nodes, ds)
+    serial = fit_bspline(vals, nodes, space)
+    np.testing.assert_array_equal(dfn.global_function.control_points, serial.control_points)


### PR DESCRIPTION
## Summary

PR **I4** of #240. Adds MPI-distributed collocation interpolation and fitting onto
tensor-product B-spline spaces, the parallel counterparts of the serial
`interpolate_bspline` / `fit_bspline`.

The Kronecker solve itself is cheap (small sequential 1D SVD solves); the cost that
motivates parallelism is evaluating `func` on the Greville-node tensor-product grid (size =
global DOF count). Each rank evaluates its **block-assigned** chunk of the flattened grid, a
single `allgather` assembles the full value field, and the Kronecker solve runs
**replicated** on every rank. The result is a `DistributedFunction` whose global coefficient
field matches the serial result bit-for-bit (float64).

## What's added

New module `pantr.mpi._collocation`:

- **`interpolate_bspline_distributed(func, distributed_space, *, nodes, boundary_derivatives, tol)`** —
  `func` is called on a flat `(M, dim)` point array (the natural distributed convention,
  matching the distributed quasi-interpolants; serial takes a `PointsLattice` because it
  always has the full lattice, but a per-rank chunk is not a tensor product).
- **`fit_bspline_distributed(values, nodes, distributed_space, *, values_distributed, tol)`** —
  pre-evaluated values, two layouts:
  - `values_distributed=False` (default, replicated): full field on every rank → delegates
    to serial `fit_bspline`.
  - `values_distributed=True` (pre-distributed): each rank passes only its contiguous
    C-order block of the flattened grid; a single `allgather` assembles the field before the
    solve. Scattered nodes are rejected on this path.
  - Scattered nodes are supported on the replicated path (serial fallback).

Both entry points call `_ensure_default_thread_policy()` first and validate
`global_space` is a `BsplineSpace` (`TypeError` otherwise), following `_qi.py` / `_thb_qi.py`.

Exported from `pantr.mpi` (imports, module-docstring "Main exports", sorted `__all__`).

**No serial code was changed** — the implementation reuses the existing serial helpers
(`_resolve_nodes`, `_build_collocation_matrices`, `_solve_kronecker`,
`_apply_boundary_deriv_rhs`, `split_components`); purely additive, so the serial path cannot
regress.

## Tests

- **`tests/test_mpi_collocation.py`** (in-process, counts toward the coverage gate): asserts
  distributed == serial for `interpolate` (1D/2D, scalar/vector, boundary derivatives) and
  for `fit` in both value layouts; identical output across different partitions
  (`n_parts` 1–4); float32 dtype propagation; and the validation errors (THB → `TypeError`,
  scattered + `values_distributed=True` → `ValueError`, scattered replicated fallback).
- **`tests/mpi/test_distributed_mpi.py`**: real-MPI smoke tests over `MPI.COMM_WORLD` with a
  real `allgather` (interpolate matches serial, vector func, fit pre-distributed and
  replicated paths).
- **`tests/test_mpi.py`**: updated the pinned `pantr.mpi` public-surface set.

## Checks (exit-code verified)

- `ruff check .` — pass
- `ruff format --check .` — pass
- `mypy --config-file mypy.ini src tests` — pass (no issues, 210 files)
- `lint-imports` — pass (serial core does not import `pantr.mpi`)
- `pytest --no-cov` — pass (3797 passed, 17 skipped)
- docs build — clean (`build succeeded`, 0 warnings) once intersphinx inventories are
  reachable; the local sandbox blocks the inventory hosts and lacks an offscreen GL context
  for the pyvista gallery, both unrelated to this change
- real-MPI smoke tests — pass under `mpiexec -n 2` and `-n 3`

## Dependencies

Builds on I1/#241 (merged) and the THB distributed QI #242. No other branches touched.

Closes part of #240 (I4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
