### PR TITLE
ci(release): add tag-driven PyPI/TestPyPI trusted-publishing pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,26 +34,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Verify tag matches package version
-        if: github.event_name == 'push'
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          version=$(python -c "import re, pathlib; \
-            text = pathlib.Path('src/pantr/__init__.py').read_text(); \
-            print(re.search(r'__version__.*=\\s*\"([^\"]+)\"', text).group(1))")
-          echo "Package version: $version"
-          echo "Git tag:         $TAG"
-          if [ "$TAG" != "v$version" ]; then
-            echo "::error::Tag '$TAG' does not match package version 'v$version'"
-            exit 1
-          fi
-
       - name: Build sdist and wheel
         run: |
           python -m pip install --upgrade pip build twine
           python -m build
           python -m twine check dist/*
+
+      - name: Verify built version matches tag
+        # On a tag push the wheel that ships MUST carry the tagged version, so we
+        # check the actual built artifact rather than re-parsing the source. The
+        # rehearsal (workflow_dispatch) skips this on purpose: it may build from
+        # an untagged branch and only ever reaches TestPyPI.
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version=$(basename dist/*.whl | cut -d- -f2)
+          echo "Built version: $version"
+          echo "Git tag:       $TAG"
+          if [ "$TAG" != "v$version" ]; then
+            echo "::error::Tag '$TAG' does not match built package version 'v$version'"
+            exit 1
+          fi
 
       - name: Upload distributions
         uses: actions/upload-artifact@v7
@@ -79,7 +82,9 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to the release/v1 commit SHA (third-party action handling an OIDC
+        # token that can publish to PyPI). Bump deliberately; @release/v1 is mutable.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 @ 2026-02-18
         with:
           repository-url: https://test.pypi.org/legacy/
           # Re-running a tag (or a dispatch on the same version) must not fail
@@ -105,7 +110,8 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to the release/v1 commit SHA; see the TestPyPI step above.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 @ 2026-02-18
 
   github-release:
     name: Create GitHub Release
@@ -130,9 +136,13 @@ jobs:
         run: |
           python - "$TAG" <<'PY'
           import pathlib
+          import re
           import sys
 
           version = sys.argv[1].lstrip("v")
+          # Match the exact version header (e.g. "## 0.6.0 (date)"), not a prefix,
+          # so v0.6 / v0.6.0 / v0.6.0-rc1 never collide.
+          header = re.compile(rf"^{re.escape(version)}(?:\s|$)")
           lines = pathlib.Path("docs/changelog.md").read_text().splitlines()
           section: list[str] = []
           capturing = False
@@ -140,7 +150,7 @@ jobs:
               if line.startswith("## "):
                   if capturing:
                       break
-                  capturing = line[3:].strip().startswith(version)
+                  capturing = bool(header.match(line[3:].strip()))
                   continue
               if capturing:
                   section.append(line)
@@ -156,12 +166,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           if [ -s release-notes.md ]; then
             notes=(--notes-file release-notes.md)
           else
             notes=(--generate-notes)
           fi
-          gh release create "$TAG" dist/* \
-            --title "$TAG" \
-            --verify-tag \
-            "${notes[@]}"
+          # Idempotent: a re-run after the release already exists uploads/refreshes
+          # assets instead of failing.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; refreshing assets."
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --title "$TAG" \
+              --verify-tag \
+              "${notes[@]}"
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,167 @@
+name: Release
+
+# Release automation for PaNTr.
+#
+# Triggers:
+#   * Pushing a `v*` tag  -> build, publish to TestPyPI, then PyPI, then cut a
+#     GitHub Release. This is the real release path.
+#   * Manual `workflow_dispatch` -> build and publish to TestPyPI only. A safe
+#     end-to-end rehearsal that never touches the real index.
+#
+# Publishing uses PyPA Trusted Publishing (OIDC): no API tokens are stored. The
+# `testpypi` / `pypi` GitHub environments and matching "pending publishers" on
+# test.pypi.org / pypi.org authorize the upload from this workflow.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version=$(python -c "import re, pathlib; \
+            text = pathlib.Path('src/pantr/__init__.py').read_text(); \
+            print(re.search(r'__version__.*=\\s*\"([^\"]+)\"', text).group(1))")
+          echo "Package version: $version"
+          echo "Git tag:         $TAG"
+          if [ "$TAG" != "v$version" ]; then
+            echo "::error::Tag '$TAG' does not match package version 'v$version'"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  testpypi:
+    name: Publish to TestPyPI (rehearsal)
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/pantr/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          # Re-running a tag (or a dispatch on the same version) must not fail
+          # because the files already exist on TestPyPI.
+          skip-existing: true
+
+  pypi:
+    name: Publish to PyPI
+    needs: [testpypi]
+    # Only real tag pushes reach the production index; dispatch stops at TestPyPI.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pantr/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: [pypi]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract changelog section
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          python - "$TAG" <<'PY'
+          import pathlib
+          import sys
+
+          version = sys.argv[1].lstrip("v")
+          lines = pathlib.Path("docs/changelog.md").read_text().splitlines()
+          section: list[str] = []
+          capturing = False
+          for line in lines:
+              if line.startswith("## "):
+                  if capturing:
+                      break
+                  capturing = line[3:].strip().startswith(version)
+                  continue
+              if capturing:
+                  section.append(line)
+          body = "\n".join(section).strip()
+          pathlib.Path("release-notes.md").write_text(body + "\n" if body else "")
+          PY
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog section found; GitHub will auto-generate notes."
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [ -s release-notes.md ]; then
+            notes=(--notes-file release-notes.md)
+          else
+            notes=(--generate-notes)
+          fi
+          gh release create "$TAG" dist/* \
+            --title "$TAG" \
+            --verify-tag \
+            "${notes[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,13 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 Changes are merged via pull requests, not direct pushes to `main`.
 
+## Releasing
+
+Releases are automated: pushing a `v*` tag publishes to PyPI (via trusted
+publishing) and cuts a GitHub Release. The full maintainer runbook — version
+bump, changelog, tagging, and the one-time PyPI / Read the Docs setup — is in
+[`RELEASING.md`](RELEASING.md).
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,104 @@
+# Releasing PaNTr
+
+Maintainer runbook for cutting a release. Publishing is automated by
+[`.github/workflows/release.yaml`](.github/workflows/release.yaml): pushing a
+`v*` tag builds the distributions and publishes them to TestPyPI and then PyPI
+via [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC —
+no API tokens are stored anywhere), then cuts a GitHub Release.
+
+The version is single-sourced from `__version__` in `src/pantr/__init__.py`
+(hatchling reads it as the package version). **The git tag must be
+`v<version>`** — the pipeline rebuilds the wheel and fails the release if the
+built version does not match the tag.
+
+## One-time setup
+
+These are dashboard actions, done once for the project. They cannot be committed
+to the repository.
+
+### PyPI and TestPyPI trusted publishers
+
+On both [pypi.org](https://pypi.org/manage/account/publishing/) **and**
+[test.pypi.org](https://test.pypi.org/manage/account/publishing/) (enable 2FA on
+each account first), add a *pending publisher*:
+
+| Field             | Value          |
+| ----------------- | -------------- |
+| PyPI Project Name | `pantr`        |
+| Owner             | `FELIGN`       |
+| Repository name   | `pantr`        |
+| Workflow name     | `release.yaml` |
+| Environment name  | `pypi` on pypi.org, `testpypi` on test.pypi.org |
+
+The first successful publish creates the project; the pending publisher then
+becomes a regular trusted publisher.
+
+### GitHub environments
+
+In *Settings → Environments*, create two environments named `pypi` and
+`testpypi` (the names must match the pending publishers above). Add yourself as a
+*required reviewer* on each so a tag push pauses for a one-click approval before
+anything is uploaded.
+
+### Read the Docs
+
+Confirm the GitHub webhook is connected (RTD → *Admin → Integrations*; a recent
+delivery should show `200`). RTD reads `.readthedocs.yaml` from the repo, so no
+other configuration is needed. Optionally add an *Automation Rule* matching the
+`v*` tag pattern to **activate** the new version and **set it as default** — with
+that rule in place the per-release RTD steps below become automatic.
+
+## Cutting a release
+
+1. **Land all changes on `main`** with CI green.
+2. **Bump the version** in `src/pantr/__init__.py` (`__version__`).
+3. **Update the changelog**: add the new `## <version> (<date>)` section to
+   `docs/changelog.md` (Keep a Changelog style — `### Added` / `### Changed` /
+   …). This exact section becomes the GitHub Release notes.
+4. Open a PR with the bump + changelog, run the checks, and merge it.
+5. *(Optional) Rehearse.* Trigger the workflow manually from *Actions → Release →
+   Run workflow*. This builds and publishes to **TestPyPI only** — production
+   PyPI is never touched on a manual run. Verify the install:
+
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ "pantr==<version>"
+   ```
+
+6. **Tag and push** from `main`:
+
+   ```bash
+   git checkout main && git pull
+   git tag v<version>
+   git push origin v<version>
+   ```
+
+7. **Approve** the `testpypi` and then `pypi` environments when the run pauses
+   (*Actions* tab). The pipeline then publishes to PyPI and cuts the GitHub
+   Release.
+8. **On Read the Docs** (unless an Automation Rule handles it): *Versions* →
+   activate `v<version>`; *Admin → Settings* → set it as the default version.
+
+## Verify
+
+- PyPI project page shows the new version, and `pip install "pantr==<version>"`
+  works from a clean environment.
+- The GitHub Release exists with the changelog section as its notes and the
+  sdist + wheel attached.
+- `https://pantr.readthedocs.io` serves the new version's docs.
+
+## How the pipeline is wired
+
+`release.yaml` runs four jobs:
+
+- **build** — `python -m build` (sdist + wheel) and `twine check`; on a tag,
+  asserts the built version equals the tag.
+- **testpypi** — publishes to TestPyPI (`skip-existing`, so re-runs are safe).
+  Runs on both a tag push and a manual dispatch.
+- **pypi** — publishes to PyPI. Gated to tag pushes only.
+- **github-release** — creates the GitHub Release with notes extracted from the
+  matching section of `docs/changelog.md`.
+
+Permissions are least-privilege: the publish jobs request only the OIDC
+`id-token` they need, and the third-party publish action is pinned to a commit
+SHA.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yaml`, automating releases for current and future versions. No `src/` changes — CI/packaging only.

**On a `v*` tag push:**
1. `build` — `python -m build` (sdist + wheel) + `twine check`, then verify the built wheel's version matches the tag (`set -euo pipefail`, fail-closed).
2. `testpypi` — publish to TestPyPI via PyPA **Trusted Publishing** (OIDC, no stored tokens), `skip-existing: true`. Environment `testpypi`.
3. `pypi` — publish to PyPI via OIDC. Environment `pypi`. Gated on `github.event_name == 'push'`.
4. `github-release` — `gh release create` with notes extracted from the matching section of `docs/changelog.md` (falls back to `--generate-notes`); idempotent on re-run.

**On `workflow_dispatch`:** runs `build` + `testpypi` only — a safe end-to-end rehearsal that never touches production PyPI.

Least-privilege `permissions` (top-level `contents: read`; per-job `id-token: write` for publish, `contents: write` for the release). All `${{ github.ref_name }}` flow through `env:` → shell vars (no script injection). `pypa/gh-action-pypi-publish` pinned to the `release/v1` commit SHA.

## Out-of-band setup required before the first release (dashboards, not code)

- **PyPI** + **TestPyPI**: add a *pending publisher* on each (owner `FELIGN`, repo `pantr`, workflow `release.yaml`, environments `pypi` / `testpypi`).
- **GitHub**: create environments `pypi` and `testpypi` (add a required reviewer for protection).
- **RTD**: confirm webhook connected; activate the `v0.6.0` version after tagging.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean; import-linter contract kept
- [x] `pytest --no-cov`: 3826 passed, 19 skipped (one subprocess test needs `PYTHONPATH=src` in the worktree; passes in CI/installed envs)
- [x] Local `python -m build` + `twine check` PASSED both sdist & wheel; all 7 subpackages present in wheel; metadata (MIT, license files, classifiers, URLs) correct
- [x] Embedded version-guard and changelog-extraction snippets validated against the real files
- [x] `release.yaml` parses as valid YAML
- [ ] CI green on this PR

## Review notes (from automated review; not blocking)
- **S1 (declare `contents: read` on publish jobs):** not applied — a job-level `permissions:` block sets unlisted scopes to `none`, and `download-artifact` needs no `contents`, so the publish jobs are already tightest.
- **S2 (dispatch skips version guard):** intentional (rehearsal builds from untagged branches); documented with an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)