### PR TITLE
refactor(bezier): re-derive L2 norm and Bernstein interpolation clean-room

### DIFF
--- a/src/pantr/bezier/_bezier_collapse.py
+++ b/src/pantr/bezier/_bezier_collapse.py
@@ -6,8 +6,7 @@ univariate Bézier along the remaining direction.
 
 The algorithm evaluates the Bernstein basis in each collapsed direction at the
 given parameter value, then contracts the control point tensor against these
-basis vectors using :func:`numpy.tensordot`.  This mirrors the single-pass
-tensor contraction strategy used in algoim's ``collapseAlongAxis``.
+basis vectors using :func:`numpy.tensordot`.
 """
 
 from __future__ import annotations

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -22,7 +22,23 @@ if TYPE_CHECKING:
     from . import Bezier
 
 _AUTO_REDUCTION_TOL_FACTOR: float = 1.0e3
-"""Factor multiplied by machine epsilon for automatic degree reduction."""
+"""Default relative tolerance for automatic degree reduction, in units of eps.
+
+When :func:`_minimize_degree_bezier` is called without an explicit ``tol``, a
+degree-1 reduction is accepted whenever the round-trip (reduce then re-elevate)
+relative :math:`L^2` error stays below ``_AUTO_REDUCTION_TOL_FACTOR * eps``,
+where ``eps`` is the machine epsilon of the control-point dtype.
+
+The factor of ``1e3`` gives roughly three decimal digits of headroom above the
+unit-roundoff floor. The least-squares reduction and the subsequent
+re-elevation each accumulate ``O(p)`` floating-point operations, so a curve that
+is exactly reducible (for instance a degree-elevated lower-degree curve)
+produces a round-trip error of a small multiple of ``eps`` rather than exactly
+zero. A threshold at the bare ``eps`` level would spuriously reject such curves;
+``1e3 * eps`` (``~2.2e-13`` for ``float64``) comfortably accepts genuine
+reductions while still rejecting curves whose true degree cannot be lowered
+without visible geometric error.
+"""
 
 
 def _degree_elevate_bezier(
@@ -113,64 +129,72 @@ def _degree_reduce_bezier(
     return BezierCls(ctrl, is_rational=bezier.is_rational)
 
 
-def _squared_l2_norm(
-    coeffs: npt.NDArray[np.floating[Any]],
-) -> float:
-    r"""Compute the squared L2 norm of a Bernstein polynomial.
+def _bernstein_gram_matrix_1d(degree: int) -> npt.NDArray[np.float64]:
+    r"""Build the degree-``n`` univariate Bernstein mass (Gram) matrix on :math:`[0, 1]`.
 
-    Uses the Bernstein inner product formula:
+    The entries are the exact inner products of the Bernstein basis functions,
+    given by the closed form of Farouki & Rajan (*Computer Aided Geometric
+    Design* 5, 1988):
 
     .. math::
 
-        \int_0^1 B_{i,n}(x) B_{j,n}(x)\,dx
-        = \frac{1}{2n+1} \frac{\binom{n}{i} \binom{n}{j}}{\binom{2n}{i+j}}
+        G_{ij} = \int_0^1 B_{i,n}(x) B_{j,n}(x)\,dx
+        = \frac{1}{2n+1}\,
+          \frac{\binom{n}{i}\binom{n}{j}}{\binom{2n}{i+j}},
+        \qquad 0 \le i, j \le n .
 
-    extended to tensor products for multivariate polynomials.
+    Args:
+        degree (int): Polynomial degree ``n`` (``>= 0``).
+
+    Returns:
+        npt.NDArray[np.float64]: Symmetric ``(n + 1, n + 1)`` Gram matrix.
+    """
+    n = degree
+    binom_n = np.array([math.comb(n, i) for i in range(n + 1)], dtype=np.float64)
+    binom_2n = np.array([math.comb(2 * n, k) for k in range(2 * n + 1)], dtype=np.float64)
+
+    idx = np.arange(n + 1)
+    numerator = np.outer(binom_n, binom_n)
+    denominator = binom_2n[idx[:, None] + idx[None, :]]
+    gram: npt.NDArray[np.float64] = numerator / denominator / (2.0 * n + 1.0)
+    return gram
+
+
+def _squared_l2_norm(
+    coeffs: npt.NDArray[np.floating[Any]],
+) -> float:
+    r"""Compute the squared :math:`L^2` norm of a Bernstein polynomial on :math:`[0, 1]^d`.
+
+    A polynomial with Bernstein coefficients ``c`` has squared norm equal to the
+    Bernstein-Gram quadratic form :math:`\lVert p\rVert_2^2 = c^\top G\, c`,
+    where :math:`G` is the Bernstein mass matrix.  For a tensor-product basis the
+    mass matrix factorises as a Kronecker product of the univariate Gram matrices
+    :math:`G = G^{(0)} \otimes \cdots \otimes G^{(d-1)}`, so the quadratic form is
+    evaluated by contracting each univariate :math:`G^{(k)}` against the
+    coefficient tensor along its axis and taking the final inner product with the
+    coefficients.
+
+    The closed-form univariate Gram entries are due to Farouki & Rajan (*Computer
+    Aided Geometric Design* 5, 1988); see :func:`_bernstein_gram_matrix_1d`.
 
     Args:
         coeffs (npt.NDArray[np.floating[Any]]): Bernstein coefficients
             (any shape).
 
     Returns:
-        float: The squared L2 norm ``||p||_2^2``.
-
-    Note:
-        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
+        float: The squared :math:`L^2` norm ``||p||_2^2``.
     """
-    ndim = coeffs.ndim
-    shape = coeffs.shape
+    c = coeffs.astype(np.float64, copy=False)
 
-    # Precompute binomial rows and Gram factors per dimension
-    binom_rows = []
-    binom_double = []
-    for d in range(ndim):
-        n = shape[d] - 1
-        brow = np.array([math.comb(n, i) for i in range(n + 1)], dtype=np.float64)
-        bdbl = np.array([math.comb(2 * n, k) for k in range(2 * n + 1)], dtype=np.float64)
-        binom_rows.append(brow)
-        binom_double.append(bdbl)
+    # Apply G = G^(0) (x) ... (x) G^(d-1) by contracting one axis at a time.
+    g_c = c
+    for axis in range(c.ndim):
+        gram = _bernstein_gram_matrix_1d(c.shape[axis] - 1)
+        g_c = np.moveaxis(np.tensordot(gram, g_c, axes=([1], [axis])), 0, axis)
 
-    # Flatten and compute all pairwise products with Gram weights
-    flat = coeffs.ravel().astype(np.float64)
-    indices = np.array(np.unravel_index(np.arange(flat.size), shape)).T  # (size, ndim)
-
-    # For each pair (i, j): gram_weight = product over dims of binom(n_d, i_d)*binom(n_d, j_d) /
-    #                                      binom(2*n_d, i_d + j_d)
-    # This is O(size^2) but polynomials are small in practice.
-    delta = 0.0
-    for idx_i in range(flat.size):
-        for idx_j in range(flat.size):
-            g = 1.0
-            for d in range(ndim):
-                ii = indices[idx_i, d]
-                jj = indices[idx_j, d]
-                g *= (binom_rows[d][ii] * binom_rows[d][jj]) / binom_double[d][ii + jj]
-            delta += flat[idx_i] * flat[idx_j] * g
-
-    for d in range(ndim):
-        delta /= 2.0 * shape[d] - 1.0
-
-    return abs(delta)
+    # Quadratic form c^T (G c); the analytic value is non-negative, so guard
+    # against a small negative result from floating-point round-off.
+    return abs(float(np.sum(c * g_c)))
 
 
 def _minimize_degree_bezier(
@@ -179,10 +203,16 @@ def _minimize_degree_bezier(
 ) -> Bezier:
     """Automatically reduce the degree of a Bézier while maintaining accuracy.
 
-    Iterates over each parametric direction and repeatedly tries to reduce
-    the degree by 1.  A reduction is accepted when the round-trip
-    (reduce then elevate) relative L2 error stays below ``tol``.  For
-    vector-valued Bézier, all rank components are checked simultaneously.
+    Greedy, direction-by-direction degree reduction.  For each parametric
+    direction the degree is lowered by one as long as the candidate reduction is
+    accurate enough: the trial curve is degree-reduced (least squares) and then
+    re-elevated back to the current degree, and the round-trip relative
+    :math:`L^2` error is compared against ``tol``.  The first rejected trial in a
+    direction stops further reduction in that direction (the error is
+    monotonically non-decreasing as the degree drops, so there is nothing to gain
+    by continuing).  For vector-valued Bézier all rank components are combined
+    into a single error measure, so a reduction is accepted only when every
+    component is preserved.
 
     Args:
         bezier (~pantr.bezier.Bezier): The Bézier to simplify.
@@ -194,53 +224,55 @@ def _minimize_degree_bezier(
         ~pantr.bezier.Bezier: A new Bézier with the lowest degree that
         preserves accuracy within ``tol``.  If no reduction is possible,
         returns a copy of the input.
-
-    Note:
-        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 
     ctrl: npt.NDArray[np.floating[Any]] = bezier.control_points  # (*orders, rank)
-    n_param = bezier.dim
-    eps = float(np.finfo(ctrl.dtype).eps)
+    rank = ctrl.shape[-1]
+
     if tol is None:
-        tol = _AUTO_REDUCTION_TOL_FACTOR * eps
+        tol = _AUTO_REDUCTION_TOL_FACTOR * float(np.finfo(ctrl.dtype).eps)
 
     if tol <= 0.0:
         return BezierCls(ctrl.copy(), is_rational=bezier.is_rational)
 
+    def total_squared_norm(arr: npt.NDArray[np.floating[Any]]) -> float:
+        """Sum the squared L2 norms of every rank component of *arr*."""
+        return float(sum(_squared_l2_norm(arr[..., r]) for r in range(rank)))
+
     result = ctrl
     changed = False
 
-    for dim in range(n_param):
+    for dim in range(bezier.dim):
+        # Each direction shrinks until a reduction is rejected.
         while result.shape[dim] >= 2:  # noqa: PLR2004
             degree = result.shape[dim] - 1
 
-            # Reduce all rank components together along this dimension
-            flat, trailing_shape = _flatten_along_axis(result, dim)
-            reduced_flat = _degree_reduce_bezier_1d_core(degree, flat, 1)
-            reduced = _unflatten_along_axis(reduced_flat, trailing_shape, dim)
+            # Reduce by one along `dim` (all rank components together) ...
+            flat, trailing = _flatten_along_axis(result, dim)
+            reduced = _unflatten_along_axis(
+                _degree_reduce_bezier_1d_core(degree, flat, 1), trailing, dim
+            )
 
-            # Elevate back to original shape for error check
-            flat_r, trailing_r = _flatten_along_axis(reduced, dim)
-            elevated_flat = _degree_elevate_bezier_1d_core(degree - 1, flat_r, 1)
-            elevated = _unflatten_along_axis(elevated_flat, trailing_r, dim)
+            # ... then re-elevate so the trial can be compared to `result`.
+            flat_reduced, trailing_reduced = _flatten_along_axis(reduced, dim)
+            elevated = _unflatten_along_axis(
+                _degree_elevate_bezier_1d_core(degree - 1, flat_reduced, 1),
+                trailing_reduced,
+                dim,
+            )
 
-            # Check L2 error summed across all rank components
-            diff = elevated - result
-            diff_norm = sum(_squared_l2_norm(diff[..., r]) for r in range(result.shape[-1]))
-            orig_norm = sum(_squared_l2_norm(result[..., r]) for r in range(result.shape[-1]))
+            # Relative round-trip L2 error across all components.
+            diff_norm2 = total_squared_norm(elevated - result)
+            orig_norm2 = total_squared_norm(result)
+            rel_error = math.sqrt(diff_norm2)
+            if orig_norm2 > 0.0:
+                rel_error /= math.sqrt(orig_norm2)
 
-            if orig_norm > 0.0:
-                rel_error = math.sqrt(abs(diff_norm)) / math.sqrt(abs(orig_norm))
-            else:
-                rel_error = math.sqrt(abs(diff_norm))
-
-            if rel_error < tol:
-                result = reduced
-                changed = True
-            else:
+            if rel_error >= tol:
                 break
+            result = reduced
+            changed = True
 
     if not changed:
         return BezierCls(ctrl.copy(), is_rational=bezier.is_rational)

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -19,9 +19,8 @@ Supporting utilities (used internally and by the resultant pipeline):
 
 - :func:`_bernstein_vandermonde_svd` — SVD of the Bernstein Vandermonde
   matrix at modified Chebyshev nodes.
-- :func:`_bernstein_interpolate_1d` — 1D SVD-based interpolation from
-  node values to Bernstein coefficients.
-- :func:`_bernstein_interpolate` — Tensor-product extension to N-D.
+- :func:`_bernstein_interpolate` — tensor-product interpolation from node
+  values on a modified-Chebyshev grid to Bernstein coefficients.
 """
 
 from __future__ import annotations
@@ -51,8 +50,11 @@ def _bernstein_vandermonde_svd(
     """Compute the SVD of the Bernstein Vandermonde matrix at modified Chebyshev nodes.
 
     The Vandermonde matrix ``V`` has entries ``V[i, j] = B_{j,n-1}(x_i)``
-    where ``x_i`` are the modified Chebyshev nodes and ``B_{j,n-1}`` is the
-    ``j``-th Bernstein basis function of degree ``n - 1``.
+    where ``x_i`` are the ``n`` modified Chebyshev-Lobatto nodes on ``[0, 1]``
+    and ``B_{j,n-1}`` is the ``j``-th Bernstein basis function of degree
+    ``n - 1``.  ``V`` is square (``n`` nodes, ``n`` coefficients), so its SVD
+    underlies the truncated pseudo-inverse used to invert the (ill-conditioned
+    at high degree) interpolation system.
 
     Args:
         n (int): Number of nodes/coefficients (degree + 1). Must be >= 1.
@@ -64,64 +66,30 @@ def _bernstein_vandermonde_svd(
     """
     nodes = get_modified_chebyshev_nodes_1d(max(n, 2), dtype)[:n]
     V = _tabulate_bernstein_1d_fast(n - 1, nodes, dtype)
-    U, sigma, Vt = np.linalg.svd(V, full_matrices=True)
+    U, sigma, Vt = np.linalg.svd(V, full_matrices=False)
     return U, sigma, Vt
-
-
-def _bernstein_interpolate_1d(
-    f: npt.NDArray[np.floating[Any]],
-    tol: float | None = None,
-) -> npt.NDArray[np.floating[Any]]:
-    """Interpolate values at modified Chebyshev nodes to 1D Bernstein coefficients.
-
-    Given function values ``f[i]`` sampled at the modified Chebyshev nodes
-    of order ``len(f)``, compute the Bernstein coefficients of the
-    interpolating polynomial via truncated SVD.
-
-    Args:
-        f (npt.NDArray[np.floating[Any]]): Function values at modified
-            Chebyshev nodes.  Shape ``(n,)`` where ``n >= 1``.
-        tol (float | None): SVD truncation tolerance (relative to the
-            largest singular value).  If *None*, uses
-            ``100 * eps`` where ``eps`` is machine epsilon.
-
-    Returns:
-        npt.NDArray[np.floating[Any]]: Bernstein coefficients, shape ``(n,)``.
-
-    Note:
-        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
-    """
-    n = f.shape[0]
-    dtype = f.dtype
-
-    if n == 1:
-        return np.array(f)
-
-    tol = resolve_svd_tolerance(dtype, tol)
-
-    U, sigma, Vt = _bernstein_vandermonde_svd(n, dtype)
-
-    # Apply U^T to f
-    tmp = U.T @ f
-
-    # Truncated pseudo-inverse: zero out small singular values
-    min_sigma = tol * sigma[0]
-    inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
-    tmp *= inv_sigma
-
-    # Apply V to get coefficients
-    out = Vt.T @ tmp
-    return np.array(out, dtype=dtype)
 
 
 def _bernstein_interpolate(
     f: npt.NDArray[np.floating[Any]],
     tol: float | None = None,
 ) -> npt.NDArray[np.floating[Any]]:
-    """Interpolate tensor-product values at modified Chebyshev nodes to Bernstein coefficients.
+    r"""Interpolate tensor-product values at modified Chebyshev nodes to Bernstein coefficients.
 
-    Applies :func:`_bernstein_interpolate_1d` sequentially along each
-    dimension of the input array.
+    Given values of a degree-``(n_0 - 1, ..., n_{N-1} - 1)`` polynomial sampled
+    on the tensor product of modified Chebyshev-Lobatto node sets, recover its
+    Bernstein coefficients.  Because the interpolation operator separates over a
+    tensor-product grid, the inverse is applied one axis at a time: along axis
+    ``k`` the values are mapped through the truncated-SVD pseudo-inverse of the
+    univariate Bernstein Vandermonde matrix ``V^{(k)}``.
+
+    For each axis with ``V = U \Sigma V^\top`` the pseudo-inverse is
+    :math:`V^{+} = V \Sigma^{+} U^\top`, where :math:`\Sigma^{+}` inverts only
+    the singular values above ``tol * sigma_max`` and zeroes the rest.  This
+    truncated SVD (standard regularised least squares; see Golub & Van Loan,
+    *Matrix Computations*) keeps the recovery stable even when ``V`` becomes
+    ill-conditioned at high degree.  Size-1 axes (degree 0) are passed through
+    unchanged.
 
     Args:
         f (npt.NDArray[np.floating[Any]]): Function values at the tensor
@@ -133,33 +101,26 @@ def _bernstein_interpolate(
     Returns:
         npt.NDArray[np.floating[Any]]: Bernstein coefficients with the same
         shape as ``f``.
-
-    Note:
-        Implementation follows algoim (Saye, J. Comput. Phys. 448, 2022).
     """
-    result = f.copy()
-    ndim = f.ndim
-    actual_tol = resolve_svd_tolerance(f.dtype, tol)
+    dtype = f.dtype
+    actual_tol = resolve_svd_tolerance(dtype, tol)
 
-    for dim in range(ndim):
-        n = result.shape[dim]
+    result = np.asarray(f, dtype=dtype)
+    for axis in range(result.ndim):
+        n = result.shape[axis]
         if n == 1:
             continue
 
-        U, sigma, Vt = _bernstein_vandermonde_svd(n, f.dtype)
+        U, sigma, Vt = _bernstein_vandermonde_svd(n, dtype)
 
-        min_sigma = actual_tol * sigma[0]
-        inv_sigma = np.where(sigma >= min_sigma, 1.0 / sigma, 0.0)
-
-        # Pseudoinverse matrix: V @ diag(1/sigma) @ U^T
+        # Truncated pseudo-inverse V^+ = V @ diag(sigma^+) @ U^T.
+        inv_sigma = np.where(sigma >= actual_tol * sigma[0], 1.0 / sigma, 0.0)
         pinv = (Vt.T * inv_sigma[np.newaxis, :]) @ U.T
 
-        # Apply along dimension `dim`
-        result = np.tensordot(pinv, result, axes=([1], [dim]))
-        # tensordot puts the result dimension first; move it back to `dim`
-        result = np.moveaxis(result, 0, dim)
+        # Apply V^+ along `axis`; tensordot puts the new axis first, so move it back.
+        result = np.moveaxis(np.tensordot(pinv, result, axes=([1], [axis])), 0, axis)
 
-    return np.array(result, dtype=f.dtype)
+    return np.asarray(result, dtype=dtype)
 
 
 def _resolve_nodes(

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -10,7 +10,96 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import fit_bezier, interpolate_bezier
-from pantr.quad import PointsLattice
+from pantr.bezier._bezier_interpolate import _bernstein_interpolate
+from pantr.bezier._bezier_utils import _tabulate_bernstein_1d_fast
+from pantr.quad import PointsLattice, get_modified_chebyshev_nodes_1d
+
+
+def _eval_bernstein_on_modified_chebyshev_grid(
+    coeffs: npt.NDArray[np.floating[Any]],
+) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate a Bernstein polynomial on the modified-Chebyshev tensor grid.
+
+    Given Bernstein coefficients of shape ``(n_0, ..., n_{N-1})``, evaluates the
+    polynomial at the tensor product of modified Chebyshev-Lobatto nodes (the
+    nodes :func:`_bernstein_interpolate` interpolates from), returning the value
+    array with the same shape.
+
+    Args:
+        coeffs (npt.NDArray[np.floating[Any]]): Bernstein coefficients.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Sampled values, same shape as *coeffs*.
+    """
+    result = coeffs
+    for dim in range(coeffs.ndim):
+        n = coeffs.shape[dim]
+        if n == 1:
+            continue
+        nodes = get_modified_chebyshev_nodes_1d(n, np.float64)
+        bern = _tabulate_bernstein_1d_fast(n - 1, nodes, np.float64)
+        result = np.tensordot(bern, result, axes=([1], [dim]))
+        result = np.moveaxis(result, 0, dim)
+    return np.asarray(result, dtype=np.float64)
+
+
+class TestBernsteinInterpolateRoundTrip:
+    """Round-trip tests for the N-D ``_bernstein_interpolate`` helper.
+
+    This private helper is consumed across the package boundary by ocelat, so it
+    needs its own coverage: build a known polynomial in Bernstein form, evaluate
+    it on the modified-Chebyshev grid, interpolate, and check the recovered
+    coefficients reproduce the original polynomial.
+    """
+
+    def test_roundtrip_1d(self) -> None:
+        """A 1D Bernstein polynomial round-trips to its original coefficients."""
+        rng = np.random.default_rng(0)
+        coeffs = rng.standard_normal(7)
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-11)
+
+    def test_roundtrip_2d(self) -> None:
+        """A 2D tensor-product Bernstein polynomial round-trips exactly."""
+        rng = np.random.default_rng(1)
+        coeffs = rng.standard_normal((4, 5))
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-11)
+
+    def test_roundtrip_3d(self) -> None:
+        """A 3D tensor-product Bernstein polynomial round-trips exactly."""
+        rng = np.random.default_rng(2)
+        coeffs = rng.standard_normal((3, 4, 2))
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-11)
+
+    def test_recovers_monomial_x_squared(self) -> None:
+        """Interpolating x^2 (degree-2 Bernstein form) recovers known coefficients."""
+        # x^2 in Bernstein form of degree 2 has coefficients [0, 0, 1].
+        coeffs = np.array([0.0, 0.0, 1.0])
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        nptest.assert_allclose(recovered, coeffs, atol=1e-12)
+
+    def test_singleton_dimension_passthrough(self) -> None:
+        """A size-1 axis is left untouched (degree-0 in that direction)."""
+        rng = np.random.default_rng(3)
+        coeffs = rng.standard_normal((1, 3, 1))
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs)
+        recovered = _bernstein_interpolate(vals)
+        assert recovered.shape == coeffs.shape
+        nptest.assert_allclose(recovered, coeffs, atol=1e-12)
+
+    def test_preserves_float32_dtype(self) -> None:
+        """The output dtype matches the input dtype."""
+        coeffs = np.array([0.0, 1.0, 0.5], dtype=np.float32)
+        vals = _eval_bernstein_on_modified_chebyshev_grid(coeffs).astype(np.float32)
+        recovered = _bernstein_interpolate(vals)
+        assert recovered.dtype == np.float32
+
 
 # ---------------------------------------------------------------------------
 # 1D scalar interpolation


### PR DESCRIPTION
## Summary

PR3 of the algoim-removal effort. Replaces the remaining algoim-derived **code expression** in the `pantr.bezier` package with independent implementations re-derived from public references, and removes every remaining `Note: Implementation follows algoim ...` docstring in these files. No behavior change — verified numerically equivalent to the prior implementation.

Touched files only: `_bezier_degree.py`, `_bezier_interpolate.py`, `_bezier_collapse.py`, and `tests/test_bezier_interpolate.py`. Does **not** touch `docs/changelog.md` (reserved for the final PR4) nor the reduction kernels in `_bezier_core.py` (PR2).

## Changes

- **`_squared_l2_norm`** — re-derived as the Bernstein-Gram quadratic form `c^T G c`. Adds a `_bernstein_gram_matrix_1d` helper that builds the closed-form univariate Bernstein mass matrix (Farouki & Rajan, *CAGD* 5, 1988); the tensor-product norm is evaluated by contracting each per-axis Gram against the coefficient tensor. Keeps the `abs()` round-off guard. (Replaces the previous O(size²) pairwise double loop — strictly faster.)
- **`_minimize_degree_bezier`** — rewrote the greedy *reduce → re-elevate → relative-L2-error → accept* loop independently. The `_AUTO_REDUCTION_TOL_FACTOR` default (`1e3 * eps`) is **unchanged** but now carries a documented rationale instead of being an unexplained algoim default.
- **`_bernstein_interpolate`** — rewrote as a standard truncated-SVD least-squares solve applied one axis at a time (Golub & Van Loan, *Matrix Computations*; modified Chebyshev-Lobatto nodes). This private helper is consumed across the package boundary by ocelat, so **1D/2D/3D round-trip tests were added first** (`TestBernsteinInterpolateRoundTrip`) as a safety net. The rewrite is bit-identical to the prior output on the baseline grid.
- **`_bernstein_vandermonde_svd`** — `full_matrices=False` (identical result for the always-square Vandermonde) and an independent docstring.
- **Deleted `_bernstein_interpolate_1d`** — dead code, no callers in pantr or lepard (lepard defines its own unrelated 3-argument variant locally).
- **`_bezier_collapse.py`** — removed the algoim sentence from the module docstring; the code is generic `tensordot` (no code change).

## Verification

- ruff check / ruff format --check / mypy (`--strict`) — all pass
- `pytest --no-cov` — 3833 passed, 19 skipped; targeted `test_degree_reduction.py`, `test_bezier_interpolate.py`, `test_bezier_collapse.py` all pass
- docs build (`-W --keep-going`) — passes (with OpenGL access for the visualization tutorial gallery)
- Numerical equivalence vs. the pre-refactor baseline: `_bernstein_interpolate` max error `0.0`; `_squared_l2_norm` max relative error `~1.8e-15`; `_minimize_degree_bezier` identical output degrees and control points
- **ocelat guard** (cross-package consumer): `tests/test_algoim.py` + `tests/test_autofit.py` run against this branch's pantr — **146 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
