### PR TITLE
chore: rebrand lingering ocelat references to lepard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,7 +83,7 @@
 - `pantr.transform.AffineTransform`: stricter input validation (reject
   zero / non-finite scaling factors; validate rotation-axis and mirror-normal
   finiteness and the `center` shape), a cached `inverse`, and C-contiguous
-  stored arrays (#154). Enables ocelat to adopt pantr's `AffineTransform` and
+  stored arrays (#154). Enables lepard to adopt pantr's `AffineTransform` and
   drop its local copy.
 
 ## 0.3.0 (2026-05-06)
@@ -130,7 +130,7 @@
 - `bezier`: `_gauss_legendre_01` now delegates to `pantr.quad` (#133).
 - Layer 2 validation helpers consolidated and shared across `bezier` / `bspline`
   (#138, #139).
-- `bezier.implicit`: legacy algoim engine moved out into `ocelat.algoim`,
+- `bezier.implicit`: legacy algoim engine moved out into `lepard.algoim`,
   and dead algoim-era modules dropped (#136, #137).
 
 ### Documentation

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -46,7 +46,7 @@ def _eval_bernstein_on_modified_chebyshev_grid(
 class TestBernsteinInterpolateRoundTrip:
     """Round-trip tests for the N-D ``_bernstein_interpolate`` helper.
 
-    This private helper is consumed across the package boundary by ocelat, so it
+    This private helper is consumed across the package boundary by lepard, so it
     needs its own coverage: build a known polynomial in Bernstein form, evaluate
     it on the modified-Chebyshev grid, interpolate, and check the recovered
     coefficients reproduce the original polynomial.

--- a/tests/test_quad_tanh_sinh.py
+++ b/tests/test_quad_tanh_sinh.py
@@ -17,8 +17,8 @@ from pantr.tolerance import get_conservative
 # the pre-refactor implementation on ``main`` (commit 71ede9a, the original
 # algoim-derived rule) by calling ``get_tanh_sinh_1d(n)`` for each ``n`` below.
 # Regenerate by checking out that commit and re-running the same calls. The
-# public rule is consumed verbatim by the ocelat project
-# (``ocelat.implicit.algoim._implicit_quad``), so this guard pins the values the
+# public rule is consumed verbatim by the lepard project
+# (``lepard.implicit.algoim._implicit_quad``), so this guard pins the values the
 # clean-room reimplementation must reproduce — it is NOT generated from the new
 # code, so it genuinely tests backward compatibility.
 _GOLDEN_PATH = Path(__file__).parent / "data" / "tanh_sinh_golden.npz"
@@ -210,9 +210,9 @@ class TestTanhSinhOddEven:
 
 
 class TestTanhSinhGoldenValues:
-    """Golden-value regression guarding the ocelat consumer contract.
+    """Golden-value regression guarding the lepard consumer contract.
 
-    ``pantr.quad.get_tanh_sinh_1d`` is imported by the ocelat project, which
+    ``pantr.quad.get_tanh_sinh_1d`` is imported by the lepard project, which
     feeds the returned nodes/weights straight into its implicit-quadrature
     kernels. The values must therefore stay numerically identical across
     refactors. These tests pin the node/weight arrays (and the effective node


### PR DESCRIPTION
## What

Rebrand the consumer project references `ocelat → lepard` in pantr — the 7 remaining mentions:

- `tests/test_quad_tanh_sinh.py` (4): golden-test provenance comment + class docstring, including the `lepard.implicit.algoim._implicit_quad` import-path reference.
- `tests/test_bezier_interpolate.py` (1): `_bernstein_interpolate` cross-package consumer docstring.
- `docs/changelog.md` (2): historical entries ("Enables lepard to adopt …", "moved out into `lepard.algoim`").

After this, `grep -in ocelat` over the repo is empty.

## Why a separate PR

These edits were first pushed as follow-up commits on the algoim-removal branches (#248/#249/#250/#251) — but those PRs had **already squash-merged** before the follow-ups, so the rebrand never reached `main`. This PR applies it to `main` directly (cherry-picked off the merged state).

## Checks

ruff ✓ · ruff-format ✓ · mypy (strict) ✓ · full pytest **3860 passed, 19 skipped** · docs build ✓.
(The lone `test_pantr_toplevel_does_not_import_mpi` failure is the pre-existing editable-install env artifact, identical on `main`.)

Note: comment/docstring/changelog-only — no code logic, public API, or numerical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
