### PR TITLE
docs(changelog): finalize 0.6.0 (date + fold unreleased notes)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,18 +1,6 @@
 # Changelog
 
-## Unreleased
-
-### Removed
-- Dropped the `THIRD_PARTY_NOTICES` file and its `pyproject.toml` `license-files`
-  entry. The routines that previously followed algoim — Bézier/B-spline degree
-  reduction, Bernstein interpolation, the Bernstein L2 norm and degree
-  minimization, and the tanh–sinh rule with its Lambert W step — were
-  reimplemented clean-room from public references (The NURBS Book; Farouki &
-  Rajan, *CAGD* 1988; Golub & Van Loan; Takahasi & Mori 1974; SciPy), with no
-  change in public API or numerical results, so the third-party attribution is
-  no longer required.
-
-## 0.6.0 (2026-06-13)
+## 0.6.0 (2026-06-24)
 
 ### Added
 - `pantr.mpi.configure_threads`: explicitly set the per-rank Numba thread count
@@ -29,6 +17,16 @@
   `pantr.set_num_threads`, `pantr.num_threads`, or
   `pantr.mpi.configure_threads`), and the policy is applied at most once per
   process, so raising the count afterwards sticks.
+
+### Removed
+- Dropped the `THIRD_PARTY_NOTICES` file and its `pyproject.toml` `license-files`
+  entry. The routines that previously followed algoim — Bézier/B-spline degree
+  reduction, Bernstein interpolation, the Bernstein L2 norm and degree
+  minimization, and the tanh–sinh rule with its Lambert W step — were
+  reimplemented clean-room from public references (The NURBS Book; Farouki &
+  Rajan, *CAGD* 1988; Golub & Van Loan; Takahasi & Mori 1974; SciPy), with no
+  change in public API or numerical results, so the third-party attribution is
+  no longer required.
 
 ## 0.5.1 (2026-06-03)
 


### PR DESCRIPTION
## Summary
Prepares the changelog for the v0.6.0 release tag:
- Set the 0.6.0 heading date to the release day: `2026-06-13` → `2026-06-24`.
- Fold the `Unreleased` section (the `THIRD_PARTY_NOTICES` removal from the clean-room algoim work) into `0.6.0` as `### Removed`.

Those changes are already on `main` and will ship in 0.6.0, so they belong in that section — and the release workflow extracts this exact section for the GitHub Release notes. Verified the extractor now yields Added / Changed / Removed and stops before 0.5.1.

## Test plan
- [x] `docs/changelog.md` renders as before (only a date change + section move; CI docs build covers it)
- [x] Release-notes extraction (from the merged `release.yaml`) captures the full 0.6.0 section
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)