### PR TITLE
fix(basis): scale-invariant Cox-de Boor denominator guard

### DIFF
--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -139,13 +139,16 @@ def _basis_funcs_point(
         non-decreasing knot vector; it is treated as zero (and the corresponding
         term dropped) exactly when ``denom == 0`` (Piegl & Tiller A2.2's textbook
         guard). Because IEEE-754 subtraction is antisymmetric, ``denom`` is exactly
-        ``0.0`` whenever the two knots it comes from are stored bitwise identical --
-        which is guaranteed for knots meant to be equal, since
-        :class:`~pantr.bspline.BsplineSpace1D` snaps near-duplicate knots (within
-        tolerance) to a single bitwise value at construction time (see
-        ``BsplineSpace1D._snap_knots``). No tolerance parameter is needed here: the
-        exact-zero test is scale-invariant by construction, so this guard is
-        unaffected by the knot vector's parametric span (shift or scale).
+        ``0.0`` whenever the two knots it comes from are stored bitwise identical.
+        This holds for knots meant to be equal when the space was constructed with
+        the default ``snap_knots=True``, which snaps near-duplicate knots (within
+        tolerance) to a single bitwise value (see ``BsplineSpace1D._snap_knots``);
+        callers that build a knot vector with ``snap_knots=False`` (or bypass
+        :class:`~pantr.bspline.BsplineSpace1D` and call this kernel directly) are
+        responsible for the knot vector's own consistency. No tolerance parameter
+        is needed here regardless: the exact-zero test is scale-invariant by
+        construction, so this guard is unaffected by the knot vector's parametric
+        span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     order = degree + 1
@@ -198,10 +201,13 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
-            for periodic multiplicity detection (see
-            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
-            itself needs no tolerance; see :func:`_basis_funcs_point`.
+        tol (float): Absolute per-dtype tolerance, threaded through to
+            :func:`_find_spans_and_first_basis` for interface consistency with the
+            space's other tolerance-based conventions (e.g.
+            :func:`_get_Bspline_num_basis_1D_impl`'s periodic-regularity path); it
+            does not affect this function's own behavior. The Cox-de Boor
+            denominator guard itself needs no tolerance; see
+            :func:`_basis_funcs_point`.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -243,10 +249,13 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
-            for periodic multiplicity detection (see
-            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
-            itself needs no tolerance; see :func:`_basis_funcs_point`.
+        tol (float): Absolute per-dtype tolerance, threaded through to
+            :func:`_find_spans_and_first_basis` for interface consistency with the
+            space's other tolerance-based conventions (e.g.
+            :func:`_get_Bspline_num_basis_1D_impl`'s periodic-regularity path); it
+            does not affect this function's own behavior. The Cox-de Boor
+            denominator guard itself needs no tolerance; see
+            :func:`_basis_funcs_point`.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -299,12 +308,15 @@ def _basis_derivs_point(  # noqa: PLR0913
         corresponding term dropped) exactly when ``denom == 0`` (Piegl & Tiller
         A2.3's textbook guard). Because IEEE-754 subtraction is antisymmetric,
         ``denom`` is exactly ``0.0`` whenever the two knots it comes from are
-        stored bitwise identical -- which is guaranteed for knots meant to be
-        equal, since :class:`~pantr.bspline.BsplineSpace1D` snaps near-duplicate
-        knots (within tolerance) to a single bitwise value at construction time
-        (see ``BsplineSpace1D._snap_knots``). No tolerance parameter is needed
-        here: the exact-zero test is scale-invariant by construction, so this
-        guard is unaffected by the knot vector's parametric span (shift or scale).
+        stored bitwise identical. This holds for knots meant to be equal when the
+        space was constructed with the default ``snap_knots=True``, which snaps
+        near-duplicate knots (within tolerance) to a single bitwise value (see
+        ``BsplineSpace1D._snap_knots``); callers that build a knot vector with
+        ``snap_knots=False`` (or bypass :class:`~pantr.bspline.BsplineSpace1D` and
+        call this kernel directly) are responsible for the knot vector's own
+        consistency. No tolerance parameter is needed here regardless: the
+        exact-zero test is scale-invariant by construction, so this guard is
+        unaffected by the knot vector's parametric span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = degree + 1
@@ -411,10 +423,13 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
-            for periodic multiplicity detection (see
-            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
-            itself needs no tolerance; see :func:`_basis_derivs_point`.
+        tol (float): Absolute per-dtype tolerance, threaded through to
+            :func:`_find_spans_and_first_basis` for interface consistency with the
+            space's other tolerance-based conventions (e.g.
+            :func:`_get_Bspline_num_basis_1D_impl`'s periodic-regularity path); it
+            does not affect this function's own behavior. The Cox-de Boor
+            denominator guard itself needs no tolerance; see
+            :func:`_basis_derivs_point`.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
@@ -459,10 +474,13 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
-            for periodic multiplicity detection (see
-            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
-            itself needs no tolerance; see :func:`_basis_derivs_point`.
+        tol (float): Absolute per-dtype tolerance, threaded through to
+            :func:`_find_spans_and_first_basis` for interface consistency with the
+            space's other tolerance-based conventions (e.g.
+            :func:`_get_Bspline_num_basis_1D_impl`'s periodic-regularity path); it
+            does not affect this function's own behavior. The Cox-de Boor
+            denominator guard itself needs no tolerance; see
+            :func:`_basis_derivs_point`.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -37,6 +37,41 @@ if TYPE_CHECKING:
 @nb_jit(
     nopython=True,
     cache=True,
+    inline="always",
+)
+def _scaled_denom_tol(
+    knots: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+) -> float:
+    """Scale an absolute tolerance by the knot vector's parametric span.
+
+    The Cox-de Boor recurrence denominator is itself a knot difference, so
+    comparing it against a plain absolute ``tol`` makes the guard in
+    :func:`_basis_funcs_point` / :func:`_basis_derivs_point` scale-dependent:
+    the same relative knot structure evaluates differently depending on the
+    domain's parametric span. Scaling ``tol`` by ``knots[-1] - knots[0]`` (the
+    full span of the knot vector) restores affine invariance under shift and
+    scale, since knot *differences* do not depend on the shift and grow/shrink
+    linearly with the scale.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
+        tol (float): Absolute per-dtype tolerance (e.g. ``spline.tolerance``).
+
+    Returns:
+        float: ``tol`` scaled by the knot vector span, ``tol * (knots[-1] - knots[0])``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed). Callers
+        compute this once per batch, outside the per-point loop, so it adds no
+        per-iteration cost to the hot Cox-de Boor kernels.
+    """
+    return float(tol * (knots[knots.size - 1] - knots[0]))
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
     parallel=False,
 )
 def _find_spans_and_first_basis(  # noqa: PLR0913
@@ -117,7 +152,7 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
 def _basis_funcs_point(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
-    tol: float,
+    tol_rel: float,
     knot_id: int,
     pt: np.float32 | np.float64,
     N: npt.NDArray[np.float32 | np.float64],
@@ -130,13 +165,26 @@ def _basis_funcs_point(  # noqa: PLR0913
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
-        tol (float): Tolerance for numerical comparisons.
+        tol_rel (float): Denominator guard threshold, already scaled by the knot
+            vector's parametric span (``tol * (knots[-1] - knots[0])``; see
+            :func:`_scaled_denom_tol`). Using the pre-scaled threshold instead of a
+            plain absolute ``tol`` keeps the guard invariant under affine
+            reparametrization of the knots (shift and scale).
         knot_id (int): Clamped knot-span index of ``pt``.
         pt (np.float32 | np.float64): Evaluation point.
         N (npt.NDArray[np.float32 | np.float64]): Output row of length ``degree + 1``.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The recurrence
+        denominator is a sum of two knot differences and is always ``>= 0`` for a
+        non-decreasing knot vector; it is treated as zero (and the corresponding
+        term dropped) whenever it is at or below ``tol_rel`` (``denom <= tol_rel``).
+        For knots stored bitwise identical (the case for exactly repeated knots,
+        since IEEE-754 subtraction is antisymmetric) the denominator is exactly
+        ``0.0`` and this rule reduces to the textbook exact-zero test regardless of
+        ``tol_rel`` -- including the degenerate case ``tol_rel == 0`` (a zero-width
+        knot-vector span), where the ``<=`` comparison still catches ``denom == 0``
+        and avoids a division by zero.
         For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     order = degree + 1
@@ -155,7 +203,7 @@ def _basis_funcs_point(  # noqa: PLR0913
 
         for r in range(j):
             denom = right[r + 1] + left[j - r]  # always >= 0 (non-decreasing knots)
-            temp = zero if denom < tol else N[r] / denom
+            temp = zero if denom <= tol_rel else N[r] / denom
             N[r] = saved + right[r + 1] * temp
             saved = left[j - r] * temp
 
@@ -189,7 +237,10 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Tolerance for numerical comparisons.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
+            directly for periodic multiplicity detection; scaled by the knot
+            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
+            denominator guard, so the guard stays affine-invariant.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -203,9 +254,10 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.2 (BasisFuncs)
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in nb_prange(n_pts):
-        _basis_funcs_point(knots, degree, tol, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+        _basis_funcs_point(knots, degree, tol_rel, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
 
 
 @nb_jit(
@@ -231,7 +283,10 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Tolerance for numerical comparisons.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
+            directly for periodic multiplicity detection; scaled by the knot
+            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
+            denominator guard, so the guard stays affine-invariant.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -245,9 +300,10 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in range(n_pts):
-        _basis_funcs_point(knots, degree, tol, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+        _basis_funcs_point(knots, degree, tol_rel, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
 
 
 @nb_jit(
@@ -258,7 +314,7 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
 def _basis_derivs_point(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
-    tol: float,
+    tol_rel: float,
     n_deriv: int,
     knot_id: int,
     pt: np.float32 | np.float64,
@@ -272,7 +328,11 @@ def _basis_derivs_point(  # noqa: PLR0913
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
-        tol (float): Tolerance for numerical comparisons.
+        tol_rel (float): Denominator guard threshold, already scaled by the knot
+            vector's parametric span (``tol * (knots[-1] - knots[0])``; see
+            :func:`_scaled_denom_tol`). Using the pre-scaled threshold instead of a
+            plain absolute ``tol`` keeps the guard invariant under affine
+            reparametrization of the knots (shift and scale).
         n_deriv (int): Maximum derivative order to compute (>= 0).
         knot_id (int): Clamped knot-span index of ``pt``.
         pt (np.float32 | np.float64): Evaluation point.
@@ -280,7 +340,16 @@ def _basis_derivs_point(  # noqa: PLR0913
             ``(n_deriv + 1, degree + 1)``.
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Inputs are assumed to be correct (no validation performed). The recurrence
+        denominator ``ndu[j, r]`` is a sum of two knot differences and is always
+        ``>= 0`` for a non-decreasing knot vector; it is treated as zero (and the
+        corresponding term dropped) whenever it is at or below ``tol_rel``
+        (``denom <= tol_rel``). For knots stored bitwise identical (the case for
+        exactly repeated knots, since IEEE-754 subtraction is antisymmetric) the
+        denominator is exactly ``0.0`` and this rule reduces to the textbook
+        exact-zero test regardless of ``tol_rel`` -- including the degenerate case
+        ``tol_rel == 0`` (a zero-width knot-vector span), where the ``<=``
+        comparison still catches ``denom == 0`` and avoids a division by zero.
         For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = degree + 1
@@ -302,7 +371,7 @@ def _basis_derivs_point(  # noqa: PLR0913
         for r in range(j):
             ndu[j, r] = right[r + 1] + left[j - r]  # knot differences (lower triangle)
             denom = ndu[j, r]
-            temp = zero if denom < tol else ndu[r, j - 1] / denom
+            temp = zero if denom <= tol_rel else ndu[r, j - 1] / denom
             ndu[r, j] = saved + right[r + 1] * temp  # basis values (upper triangle)
             saved = left[j - r] * temp
         ndu[j, j] = saved
@@ -387,7 +456,10 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Tolerance for numerical comparisons.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
+            directly for periodic multiplicity detection; scaled by the knot
+            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
+            denominator guard, so the guard stays affine-invariant.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
@@ -401,10 +473,11 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.3 (DerBasisFuncs)
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in nb_prange(n_pts):
         _basis_derivs_point(
-            knots, degree, tol, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+            knots, degree, tol_rel, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
         )
 
 
@@ -432,7 +505,10 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Tolerance for numerical comparisons.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
+            directly for periodic multiplicity detection; scaled by the knot
+            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
+            denominator guard, so the guard stays affine-invariant.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
@@ -446,10 +522,11 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
+    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in range(n_pts):
         _basis_derivs_point(
-            knots, degree, tol, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+            knots, degree, tol_rel, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
         )
 
 

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -37,41 +37,6 @@ if TYPE_CHECKING:
 @nb_jit(
     nopython=True,
     cache=True,
-    inline="always",
-)
-def _scaled_denom_tol(
-    knots: npt.NDArray[np.float32 | np.float64],
-    tol: float,
-) -> float:
-    """Scale an absolute tolerance by the knot vector's parametric span.
-
-    The Cox-de Boor recurrence denominator is itself a knot difference, so
-    comparing it against a plain absolute ``tol`` makes the guard in
-    :func:`_basis_funcs_point` / :func:`_basis_derivs_point` scale-dependent:
-    the same relative knot structure evaluates differently depending on the
-    domain's parametric span. Scaling ``tol`` by ``knots[-1] - knots[0]`` (the
-    full span of the knot vector) restores affine invariance under shift and
-    scale, since knot *differences* do not depend on the shift and grow/shrink
-    linearly with the scale.
-
-    Args:
-        knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
-        tol (float): Absolute per-dtype tolerance (e.g. ``spline.tolerance``).
-
-    Returns:
-        float: ``tol`` scaled by the knot vector span, ``tol * (knots[-1] - knots[0])``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed). Callers
-        compute this once per batch, outside the per-point loop, so it adds no
-        per-iteration cost to the hot Cox-de Boor kernels.
-    """
-    return float(tol * (knots[knots.size - 1] - knots[0]))
-
-
-@nb_jit(
-    nopython=True,
-    cache=True,
     parallel=False,
 )
 def _find_spans_and_first_basis(  # noqa: PLR0913
@@ -149,10 +114,9 @@ def _find_spans_and_first_basis(  # noqa: PLR0913
     cache=True,
     inline="always",
 )
-def _basis_funcs_point(  # noqa: PLR0913
+def _basis_funcs_point(
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
-    tol_rel: float,
     knot_id: int,
     pt: np.float32 | np.float64,
     N: npt.NDArray[np.float32 | np.float64],
@@ -165,11 +129,6 @@ def _basis_funcs_point(  # noqa: PLR0913
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
-        tol_rel (float): Denominator guard threshold, already scaled by the knot
-            vector's parametric span (``tol * (knots[-1] - knots[0])``; see
-            :func:`_scaled_denom_tol`). Using the pre-scaled threshold instead of a
-            plain absolute ``tol`` keeps the guard invariant under affine
-            reparametrization of the knots (shift and scale).
         knot_id (int): Clamped knot-span index of ``pt``.
         pt (np.float32 | np.float64): Evaluation point.
         N (npt.NDArray[np.float32 | np.float64]): Output row of length ``degree + 1``.
@@ -178,13 +137,15 @@ def _basis_funcs_point(  # noqa: PLR0913
         Inputs are assumed to be correct (no validation performed). The recurrence
         denominator is a sum of two knot differences and is always ``>= 0`` for a
         non-decreasing knot vector; it is treated as zero (and the corresponding
-        term dropped) whenever it is at or below ``tol_rel`` (``denom <= tol_rel``).
-        For knots stored bitwise identical (the case for exactly repeated knots,
-        since IEEE-754 subtraction is antisymmetric) the denominator is exactly
-        ``0.0`` and this rule reduces to the textbook exact-zero test regardless of
-        ``tol_rel`` -- including the degenerate case ``tol_rel == 0`` (a zero-width
-        knot-vector span), where the ``<=`` comparison still catches ``denom == 0``
-        and avoids a division by zero.
+        term dropped) exactly when ``denom == 0`` (Piegl & Tiller A2.2's textbook
+        guard). Because IEEE-754 subtraction is antisymmetric, ``denom`` is exactly
+        ``0.0`` whenever the two knots it comes from are stored bitwise identical --
+        which is guaranteed for knots meant to be equal, since
+        :class:`~pantr.bspline.BsplineSpace1D` snaps near-duplicate knots (within
+        tolerance) to a single bitwise value at construction time (see
+        ``BsplineSpace1D._snap_knots``). No tolerance parameter is needed here: the
+        exact-zero test is scale-invariant by construction, so this guard is
+        unaffected by the knot vector's parametric span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
     order = degree + 1
@@ -203,7 +164,7 @@ def _basis_funcs_point(  # noqa: PLR0913
 
         for r in range(j):
             denom = right[r + 1] + left[j - r]  # always >= 0 (non-decreasing knots)
-            temp = zero if denom <= tol_rel else N[r] / denom
+            temp = zero if denom == zero else N[r] / denom
             N[r] = saved + right[r + 1] * temp
             saved = left[j - r] * temp
 
@@ -237,10 +198,10 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
-            directly for periodic multiplicity detection; scaled by the knot
-            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
-            denominator guard, so the guard stays affine-invariant.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
+            for periodic multiplicity detection (see
+            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
+            itself needs no tolerance; see :func:`_basis_funcs_point`.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -254,10 +215,9 @@ def _compute_basis_nurbs_book_impl(  # noqa: PLR0913
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.2 (BasisFuncs)
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
-    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in nb_prange(n_pts):
-        _basis_funcs_point(knots, degree, tol_rel, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+        _basis_funcs_point(knots, degree, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
 
 
 @nb_jit(
@@ -283,10 +243,10 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
-            directly for periodic multiplicity detection; scaled by the knot
-            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
-            denominator guard, so the guard stays affine-invariant.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
+            for periodic multiplicity detection (see
+            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
+            itself needs no tolerance; see :func:`_basis_funcs_point`.
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate basis
             functions at.
         out_basis (npt.NDArray[np.float32 | np.float64]): Output array for basis values.
@@ -300,10 +260,9 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
-    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in range(n_pts):
-        _basis_funcs_point(knots, degree, tol_rel, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
+        _basis_funcs_point(knots, degree, knot_ids[pt_id], pts[pt_id], out_basis[pt_id, :])
 
 
 @nb_jit(
@@ -314,7 +273,6 @@ def _compute_basis_nurbs_book_serial_impl(  # noqa: PLR0913
 def _basis_derivs_point(  # noqa: PLR0913
     knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
-    tol_rel: float,
     n_deriv: int,
     knot_id: int,
     pt: np.float32 | np.float64,
@@ -328,11 +286,6 @@ def _basis_derivs_point(  # noqa: PLR0913
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
-        tol_rel (float): Denominator guard threshold, already scaled by the knot
-            vector's parametric span (``tol * (knots[-1] - knots[0])``; see
-            :func:`_scaled_denom_tol`). Using the pre-scaled threshold instead of a
-            plain absolute ``tol`` keeps the guard invariant under affine
-            reparametrization of the knots (shift and scale).
         n_deriv (int): Maximum derivative order to compute (>= 0).
         knot_id (int): Clamped knot-span index of ``pt``.
         pt (np.float32 | np.float64): Evaluation point.
@@ -343,13 +296,15 @@ def _basis_derivs_point(  # noqa: PLR0913
         Inputs are assumed to be correct (no validation performed). The recurrence
         denominator ``ndu[j, r]`` is a sum of two knot differences and is always
         ``>= 0`` for a non-decreasing knot vector; it is treated as zero (and the
-        corresponding term dropped) whenever it is at or below ``tol_rel``
-        (``denom <= tol_rel``). For knots stored bitwise identical (the case for
-        exactly repeated knots, since IEEE-754 subtraction is antisymmetric) the
-        denominator is exactly ``0.0`` and this rule reduces to the textbook
-        exact-zero test regardless of ``tol_rel`` -- including the degenerate case
-        ``tol_rel == 0`` (a zero-width knot-vector span), where the ``<=``
-        comparison still catches ``denom == 0`` and avoids a division by zero.
+        corresponding term dropped) exactly when ``denom == 0`` (Piegl & Tiller
+        A2.3's textbook guard). Because IEEE-754 subtraction is antisymmetric,
+        ``denom`` is exactly ``0.0`` whenever the two knots it comes from are
+        stored bitwise identical -- which is guaranteed for knots meant to be
+        equal, since :class:`~pantr.bspline.BsplineSpace1D` snaps near-duplicate
+        knots (within tolerance) to a single bitwise value at construction time
+        (see ``BsplineSpace1D._snap_knots``). No tolerance parameter is needed
+        here: the exact-zero test is scale-invariant by construction, so this
+        guard is unaffected by the knot vector's parametric span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = degree + 1
@@ -371,7 +326,7 @@ def _basis_derivs_point(  # noqa: PLR0913
         for r in range(j):
             ndu[j, r] = right[r + 1] + left[j - r]  # knot differences (lower triangle)
             denom = ndu[j, r]
-            temp = zero if denom <= tol_rel else ndu[r, j - 1] / denom
+            temp = zero if denom == zero else ndu[r, j - 1] / denom
             ndu[r, j] = saved + right[r + 1] * temp  # basis values (upper triangle)
             saved = left[j - r] * temp
         ndu[j, j] = saved
@@ -456,10 +411,10 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
-            directly for periodic multiplicity detection; scaled by the knot
-            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
-            denominator guard, so the guard stays affine-invariant.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
+            for periodic multiplicity detection (see
+            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
+            itself needs no tolerance; see :func:`_basis_derivs_point`.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
@@ -473,11 +428,10 @@ def _compute_basis_deriv_nurbs_book_impl(  # noqa: PLR0913
     # See The NURBS Book, by Piegl & Tiller. Algorithm A2.3 (DerBasisFuncs)
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
-    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in nb_prange(n_pts):
         _basis_derivs_point(
-            knots, degree, tol_rel, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+            knots, degree, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
         )
 
 
@@ -505,10 +459,10 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
         periodic (bool): Whether the B-spline is periodic.
-        tol (float): Absolute per-dtype tolerance for numerical comparisons. Used
-            directly for periodic multiplicity detection; scaled by the knot
-            vector's span (:func:`_scaled_denom_tol`) for the Cox-de Boor
-            denominator guard, so the guard stays affine-invariant.
+        tol (float): Absolute per-dtype tolerance for numerical comparisons, used
+            for periodic multiplicity detection (see
+            :func:`_find_spans_and_first_basis`). The Cox-de Boor denominator guard
+            itself needs no tolerance; see :func:`_basis_derivs_point`.
         n_deriv (int): Maximum derivative order to compute (>= 0).
         pts (npt.NDArray[np.float32 | np.float64]): Points (1D array) to evaluate.
         out_deriv (npt.NDArray[np.float32 | np.float64]): Output array for derivative values.
@@ -522,11 +476,10 @@ def _compute_basis_deriv_nurbs_book_serial_impl(  # noqa: PLR0913
     """
     n_pts = pts.size
     knot_ids = _find_spans_and_first_basis(knots, degree, periodic, tol, pts, out_first_basis)
-    tol_rel = _scaled_denom_tol(knots, tol)
 
     for pt_id in range(n_pts):
         _basis_derivs_point(
-            knots, degree, tol_rel, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
+            knots, degree, n_deriv, knot_ids[pt_id], pts[pt_id], out_deriv[pt_id, :, :]
         )
 
 

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -9,7 +9,7 @@ knots to a single bitwise value at construction time
 (``BsplineSpace1D._snap_knots``).
 
 Kernels that compare a *difference of two knots* against zero -- e.g. the Cox-de
-Boor recurrence denominator guard in :mod:`pantr.bspline._bspline_basis_core`
+Boor recurrence denominator guard in ``pantr.bspline._bspline_basis_core``
 (``_basis_funcs_point``, ``_basis_derivs_point``) -- do **not** take a tolerance
 at all: they use an exact ``denom == 0.0`` test. This is safe (and scale-invariant
 by construction, unlike a tolerance-based guard) precisely because construction-time

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -11,10 +11,13 @@ knots to a single bitwise value at construction time
 Kernels that compare a *difference of two knots* against zero -- e.g. the Cox-de
 Boor recurrence denominator guard in ``pantr.bspline._bspline_basis_core``
 (``_basis_funcs_point``, ``_basis_derivs_point``) -- do **not** take a tolerance
-at all: they use an exact ``denom == 0.0`` test. This is safe (and scale-invariant
-by construction, unlike a tolerance-based guard) precisely because construction-time
-snapping already guarantees that any two knots meant to be equal are stored bitwise
-identical, so IEEE-754 subtraction makes their difference exactly zero.
+at all: they use an exact ``denom == 0.0`` test, which is scale-invariant by
+construction (unlike a tolerance-based guard). This is safe whenever any two knots
+meant to be equal are stored bitwise identical, so IEEE-754 subtraction makes their
+difference exactly zero -- the default ``snap_knots=True`` construction path
+guarantees this by snapping near-duplicate knots together; callers that opt out of
+snapping (``snap_knots=False``) or call the kernels directly are responsible for
+the knot vector's own consistency.
 """
 
 from __future__ import annotations

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -2,16 +2,19 @@
 
 The presets returned here (:func:`get_default`, :func:`get_strict`,
 :func:`get_conservative`) are **absolute** tolerances: a fixed value per dtype,
-independent of the magnitude of the values being compared. This is appropriate for
-comparisons made directly against parametric coordinates on an assumed-reasonable
-(O(1)) domain, such as knot-multiplicity detection.
+independent of the magnitude of the values being compared. This is used for
+knot-multiplicity detection (grouping near-duplicate knot values, e.g.
+``_get_unique_knots_and_multiplicity_impl``) and for canonicalizing near-duplicate
+knots to a single bitwise value at construction time
+(``BsplineSpace1D._snap_knots``).
 
-Kernels that compare a *difference of two knots* against tolerance (e.g. the
-Cox-de Boor recurrence denominator guard in
-:mod:`pantr.bspline._bspline_basis_core`) additionally scale the absolute preset by
-the knot vector's parametric span before comparing, so the guard stays invariant
-under affine reparametrization (shift and scale) of the knots. See
-``_scaled_denom_tol`` in that module for the exact rule.
+Kernels that compare a *difference of two knots* against zero -- e.g. the Cox-de
+Boor recurrence denominator guard in :mod:`pantr.bspline._bspline_basis_core`
+(``_basis_funcs_point``, ``_basis_derivs_point``) -- do **not** take a tolerance
+at all: they use an exact ``denom == 0.0`` test. This is safe (and scale-invariant
+by construction, unlike a tolerance-based guard) precisely because construction-time
+snapping already guarantees that any two knots meant to be equal are stored bitwise
+identical, so IEEE-754 subtraction makes their difference exactly zero.
 """
 
 from __future__ import annotations

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -1,4 +1,18 @@
-"""Tolerance utilities for floating-point comparisons in IGA applications."""
+"""Tolerance utilities for floating-point comparisons in IGA applications.
+
+The presets returned here (:func:`get_default`, :func:`get_strict`,
+:func:`get_conservative`) are **absolute** tolerances: a fixed value per dtype,
+independent of the magnitude of the values being compared. This is appropriate for
+comparisons made directly against parametric coordinates on an assumed-reasonable
+(O(1)) domain, such as knot-multiplicity detection.
+
+Kernels that compare a *difference of two knots* against tolerance (e.g. the
+Cox-de Boor recurrence denominator guard in
+:mod:`pantr.bspline._bspline_basis_core`) additionally scale the absolute preset by
+the knot vector's parametric span before comparing, so the guard stays invariant
+under affine reparametrization (shift and scale) of the knots. See
+``_scaled_denom_tol`` in that module for the exact rule.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_bspline_basis_tol_guard_scale.py
+++ b/tests/test_bspline_basis_tol_guard_scale.py
@@ -1,0 +1,49 @@
+"""Regression tests for the Cox-de Boor denominator guard (issue #257).
+
+The ``BasisFuncs``/``DerBasisFuncs`` kernels in ``_bspline_basis_core.py`` guard the
+Cox-de Boor recurrence denominator with ``denom < tol`` where ``tol`` is an absolute,
+per-dtype preset (see ``pantr.tolerance``) and ``denom`` is a knot difference. Because
+``tol`` does not scale with the knot vector's parametric span, the guard is not
+invariant under affine reparametrization of the knots: a genuinely nonzero knot span
+on a tiny domain can be smaller than ``tol`` and get incorrectly zeroed, breaking the
+partition of unity.
+
+The xfail test below isolates this behavior at the kernel level (bypassing
+:class:`~pantr.bspline.BsplineSpace1D`'s construction-time knot snapping, which is a
+separate concern) with a knot vector whose domain is small enough that a genuine,
+nonzero local knot difference falls below the absolute tolerance.
+"""
+
+import numpy as np
+import pytest
+
+from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_serial_impl
+
+
+class TestScaleDependentDenominatorGuard:
+    """Known-bug regression: absolute tol guard is not affine-invariant."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="issue #257: absolute tol guard zeroes genuine tiny-domain knot spans",
+    )
+    def test_tiny_domain_partition_of_unity(self) -> None:
+        """A tiny-but-nonzero domain must still satisfy the partition of unity.
+
+        Knot spans are scaled down to ``1e-16`` while ``tol`` stays at the float64
+        strict preset (``1e-15``, see :func:`pantr.tolerance.get_strict`). Every local
+        knot span is then well below ``tol`` even though it is not zero, so the
+        current absolute-tolerance guard incorrectly collapses every Cox-de Boor
+        contribution and the basis functions no longer sum to one.
+        """
+        scale = 1e-16
+        knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=np.float64) * scale
+        degree = 2
+        tol = 1e-15  # spline.tolerance for float64 (strict preset)
+        pts = np.array([0.4 * scale], dtype=np.float64)
+
+        basis = np.empty((1, degree + 1), dtype=np.float64)
+        first_basis = np.empty(1, dtype=np.int_)
+        _compute_basis_nurbs_book_serial_impl(knots, degree, False, tol, pts, basis, first_basis)
+
+        np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-13)

--- a/tests/test_bspline_basis_tol_guard_scale.py
+++ b/tests/test_bspline_basis_tol_guard_scale.py
@@ -49,9 +49,10 @@ class TestScaleDependentDenominatorGuard:
         strict preset (``1e-15``, see :func:`pantr.tolerance.get_strict`). Every
         local knot span is well below ``tol`` even though it is not zero; before the
         fix this made the guard incorrectly collapse every Cox-de Boor contribution,
-        so the basis functions no longer summed to one. ``tol`` is still passed to
-        the kernel (it is used for periodic multiplicity detection) but no longer
-        affects the denominator guard, which is now an exact ``denom == 0.0`` test.
+        so the basis functions no longer summed to one. ``tol`` is still a required
+        argument of the kernel (unrelated interface reasons, see
+        ``_find_spans_and_first_basis``) but no longer affects the denominator
+        guard, which is now an exact ``denom == 0.0`` test.
         """
         scale = 1e-16
         knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=np.float64) * scale
@@ -292,3 +293,26 @@ class TestConsistencyWithMultiplicity:
 
         assert np.all(np.isfinite(basis))
         np.testing.assert_allclose(basis.sum(axis=-1), 1.0, atol=1e-13)
+
+    def test_snap_knots_false_near_duplicate_not_worse_than_absolute_tol(self) -> None:
+        """With snapping disabled, a near-duplicate knot pair must not be zeroed.
+
+        ``BsplineSpace1D(..., snap_knots=False)`` opts out of the construction-time
+        canonicalization the exact-zero guard otherwise relies on, so this pair
+        (one float64 ULP apart) stays genuinely distinct, not bitwise-identical.
+        Found in review: the previous absolute-tolerance guard (``denom < tol``)
+        zeroed every contribution at the smaller of the two knots (an all-zero,
+        partition-of-unity-violating row); the exact-zero guard does not, since it
+        only special-cases a *literal* zero denominator and otherwise evaluates the
+        (numerically well-defined, if poorly conditioned) division normally.
+        """
+        a = 0.5
+        b = np.nextafter(a, -np.inf)
+        knots = np.array([0.0, 0.0, 0.0, 0.0, b, a, a, a, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
+        space = BsplineSpace1D(knots, 3, snap_knots=False)
+        assert space.knots[4] != space.knots[5]  # genuinely distinct, not snapped
+
+        basis, _ = space.tabulate_basis(np.array([b], dtype=np.float64))
+
+        assert np.all(np.isfinite(basis))
+        np.testing.assert_allclose(basis.sum(axis=-1), 1.0, atol=1e-12)

--- a/tests/test_bspline_basis_tol_guard_scale.py
+++ b/tests/test_bspline_basis_tol_guard_scale.py
@@ -1,45 +1,45 @@
 """Regression tests for the Cox-de Boor denominator guard (issue #257).
 
 The ``BasisFuncs``/``DerBasisFuncs`` kernels in ``_bspline_basis_core.py`` guard the
-Cox-de Boor recurrence denominator with ``denom < tol`` where ``tol`` is an absolute,
-per-dtype preset (see ``pantr.tolerance``) and ``denom`` is a knot difference. Because
-``tol`` does not scale with the knot vector's parametric span, the guard is not
-invariant under affine reparametrization of the knots: a genuinely nonzero knot span
-on a tiny domain can be smaller than ``tol`` and get incorrectly zeroed, breaking the
-partition of unity.
+Cox-de Boor recurrence denominator against near-zero knot differences. The guard now
+compares the denominator to ``tol`` scaled by the knot vector's parametric span
+(``_scaled_denom_tol``), so it is invariant under affine reparametrization (shift and
+scale) of the knot vector, matching the fact that B-spline basis functions themselves
+are affine-invariant.
 
-The xfail test below isolates this behavior at the kernel level (bypassing
-:class:`~pantr.bspline.BsplineSpace1D`'s construction-time knot snapping, which is a
-separate concern) with a knot vector whose domain is small enough that a genuine,
-nonzero local knot difference falls below the absolute tolerance.
+Note on the (scale, shift) grid below: combining the smallest scale (``1e-12``) with
+the largest shift (``1e3``) is deliberately *not* tested as a single combination.
+At that combination the knot span (``~1e-12``) is only a few float64 ULPs wide at
+magnitude ``1e3`` (ULP there is ``~2.2e-13``), so the knot *values* themselves cannot
+be represented distinctly -- a float64 representability limit, not a property of the
+guard being tested here. Scale and shift invariance are therefore each tested at a
+grid where the other axis does not erode representability.
 """
 
 import numpy as np
 import pytest
 
+from pantr.bspline import BsplineSpace1D
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_serial_impl
+from pantr.tolerance import get_strict
 
 
 class TestScaleDependentDenominatorGuard:
-    """Known-bug regression: absolute tol guard is not affine-invariant."""
+    """Former known-bug regression (issue #257): the guard is now affine-invariant."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="issue #257: absolute tol guard zeroes genuine tiny-domain knot spans",
-    )
     def test_tiny_domain_partition_of_unity(self) -> None:
         """A tiny-but-nonzero domain must still satisfy the partition of unity.
 
         Knot spans are scaled down to ``1e-16`` while ``tol`` stays at the float64
-        strict preset (``1e-15``, see :func:`pantr.tolerance.get_strict`). Every local
-        knot span is then well below ``tol`` even though it is not zero, so the
-        current absolute-tolerance guard incorrectly collapses every Cox-de Boor
-        contribution and the basis functions no longer sum to one.
+        strict preset (``1e-15``, see :func:`pantr.tolerance.get_strict`). Every
+        local knot span is well below the *unscaled* ``tol`` even though it is not
+        zero; before the fix this made the guard incorrectly collapse every
+        Cox-de Boor contribution, so the basis functions no longer summed to one.
         """
         scale = 1e-16
         knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=np.float64) * scale
         degree = 2
-        tol = 1e-15  # spline.tolerance for float64 (strict preset)
+        tol = get_strict(np.float64)
         pts = np.array([0.4 * scale], dtype=np.float64)
 
         basis = np.empty((1, degree + 1), dtype=np.float64)
@@ -47,3 +47,180 @@ class TestScaleDependentDenominatorGuard:
         _compute_basis_nurbs_book_serial_impl(knots, degree, False, tol, pts, basis, first_basis)
 
         np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-13)
+
+
+# ---------------------------------------------------------------------------
+# Shared reference knot structures
+# ---------------------------------------------------------------------------
+
+# Degree-3 open knot vector with interior double knots at 0.2 and 0.8 (drops
+# continuity from C^2 to C^1 there): exercises the general (non-Bezier-like)
+# Cox-de Boor kernel.
+_REF_DEGREE = 3
+_REF_KNOTS = np.array(
+    [0.0, 0.0, 0.0, 0.0, 0.2, 0.2, 0.4, 0.6, 0.8, 0.8, 1.0, 1.0, 1.0, 1.0],
+    dtype=np.float64,
+)
+_REF_PTS = np.array(
+    [
+        0.0,
+        0.05,
+        0.1,
+        0.15,
+        0.2,
+        0.25,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.65,
+        0.7,
+        0.75,
+        0.8,
+        0.85,
+        0.9,
+        0.95,
+        1.0,
+    ],
+    dtype=np.float64,
+)
+
+# Degree-3 open uniform, single-span knot vector: triggers the Bézier-like fast
+# path (Bernstein evaluation), which never had the "denom < tol" pattern but is
+# required to stay affine-invariant too.
+_BEZIER_KNOTS = np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
+_BEZIER_PTS = np.linspace(0.0, 1.0, 11, dtype=np.float64)
+
+_SCALES = [1e-12, 1e-6, 1.0, 1e6, 1e12]
+
+
+class TestAffineInvarianceBasis:
+    """`tabulate_basis` values must be invariant under affine reparametrization."""
+
+    @pytest.mark.parametrize("scale", _SCALES)
+    def test_scale_invariance_general_kernel(self, scale: float) -> None:
+        """Basis values agree across five orders of magnitude of domain scale."""
+        ref = BsplineSpace1D(_REF_KNOTS, _REF_DEGREE)
+        basis_ref, first_ref = ref.tabulate_basis(_REF_PTS)
+
+        scaled = BsplineSpace1D(_REF_KNOTS * scale, _REF_DEGREE)
+        basis, first = scaled.tabulate_basis(_REF_PTS * scale)
+
+        np.testing.assert_array_equal(first, first_ref)
+        np.testing.assert_allclose(basis, basis_ref, rtol=1e-11, atol=1e-11)
+
+    @pytest.mark.parametrize("shift", [0.0, 1e3])
+    @pytest.mark.parametrize("scale", [1.0, 1e6])
+    def test_shift_invariance_general_kernel(self, scale: float, shift: float) -> None:
+        """Basis values are unaffected by translating the knot vector's origin."""
+        ref = BsplineSpace1D(_REF_KNOTS, _REF_DEGREE)
+        basis_ref, first_ref = ref.tabulate_basis(_REF_PTS)
+
+        shifted = BsplineSpace1D(_REF_KNOTS * scale + shift, _REF_DEGREE)
+        basis, first = shifted.tabulate_basis(_REF_PTS * scale + shift)
+
+        np.testing.assert_array_equal(first, first_ref)
+        np.testing.assert_allclose(basis, basis_ref, rtol=1e-11, atol=1e-11)
+
+    @pytest.mark.parametrize("scale", _SCALES)
+    def test_scale_invariance_bezier_like_fast_path(self, scale: float) -> None:
+        """The Bernstein fast path (Bézier-like knots) is also affine-invariant."""
+        ref = BsplineSpace1D(_BEZIER_KNOTS, _REF_DEGREE)
+        basis_ref, first_ref = ref.tabulate_basis(_BEZIER_PTS)
+
+        scaled = BsplineSpace1D(_BEZIER_KNOTS * scale, _REF_DEGREE)
+        assert scaled.has_Bezier_like_knots()
+        basis, first = scaled.tabulate_basis(_BEZIER_PTS * scale)
+
+        np.testing.assert_array_equal(first, first_ref)
+        np.testing.assert_allclose(basis, basis_ref, rtol=1e-12, atol=1e-12)
+
+    def test_repeated_knots_unchanged(self) -> None:
+        """Exact multiplicities on an O(1) domain reproduce known closed-form values.
+
+        Locks down the guard-change requirement that bitwise-repeated knots (the
+        common, already-correct case) must not move at all: a degree-2 open
+        uniform knot vector reduces to the quadratic Bernstein basis, whose
+        values at these points are well-known closed forms.
+        """
+        space = BsplineSpace1D([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 2)
+        pts = np.array([0.0, 0.25, 0.5, 0.75, 1.0], dtype=np.float64)
+        basis, _ = space.tabulate_basis(pts)
+
+        t = pts
+        expected = np.stack([(1 - t) ** 2, 2 * t * (1 - t), t**2], axis=-1)
+        np.testing.assert_allclose(basis, expected, atol=1e-14)
+
+
+class TestAffineInvarianceDerivatives:
+    """`tabulate_basis_derivatives` must be affine-invariant under reparametrization.
+
+    Invariance holds once the chain-rule scaling factor ``(1/scale)^k`` is divided
+    back out of the k-th derivative slice.
+    """
+
+    @pytest.mark.parametrize("n_deriv", [0, 1, 2, 3])
+    @pytest.mark.parametrize("scale", _SCALES)
+    def test_scale_invariance_general_kernel(self, scale: float, n_deriv: int) -> None:
+        """d^k/dx^k agrees across scales after undoing the (1/scale)^k chain-rule factor."""
+        ref = BsplineSpace1D(_REF_KNOTS, _REF_DEGREE)
+        deriv_ref, first_ref = ref.tabulate_basis_derivatives(_REF_PTS, n_deriv)
+
+        scaled = BsplineSpace1D(_REF_KNOTS * scale, _REF_DEGREE)
+        deriv, first = scaled.tabulate_basis_derivatives(_REF_PTS * scale, n_deriv)
+
+        # d^k/dx^k f(scale*u) = scale^k * d^k/du^k f(u): divide the scale factor
+        # back out before comparing to the reference (scale=1) derivatives.
+        corrected = deriv * (scale ** np.arange(n_deriv + 1))[None, :, None]
+
+        np.testing.assert_array_equal(first, first_ref)
+        np.testing.assert_allclose(corrected, deriv_ref, rtol=1e-9, atol=1e-9)
+
+    @pytest.mark.parametrize("n_deriv", [0, 1, 2, 3])
+    @pytest.mark.parametrize("scale", _SCALES)
+    def test_scale_invariance_bezier_like_fast_path(self, scale: float, n_deriv: int) -> None:
+        """Same chain-rule-corrected invariance check for the Bernstein fast path."""
+        ref = BsplineSpace1D(_BEZIER_KNOTS, _REF_DEGREE)
+        deriv_ref, first_ref = ref.tabulate_basis_derivatives(_BEZIER_PTS, n_deriv)
+
+        scaled = BsplineSpace1D(_BEZIER_KNOTS * scale, _REF_DEGREE)
+        assert scaled.has_Bezier_like_knots()
+        deriv, first = scaled.tabulate_basis_derivatives(_BEZIER_PTS * scale, n_deriv)
+
+        corrected = deriv * (scale ** np.arange(n_deriv + 1))[None, :, None]
+
+        np.testing.assert_array_equal(first, first_ref)
+        np.testing.assert_allclose(corrected, deriv_ref, rtol=1e-9, atol=1e-9)
+
+
+class TestConsistencyWithMultiplicity:
+    """The kernel guard must agree with the space's own multiplicity computation."""
+
+    def test_near_duplicate_knot_pair_matches_space_multiplicity(self) -> None:
+        """Two knots 0.5*tol apart: snapping merges them, so the kernel must too.
+
+        With an interior knot pair separated by half the (float64, strict) merge
+        tolerance, :meth:`BsplineSpace1D.get_unique_knots_and_multiplicity` groups
+        them into a single knot of multiplicity 2 (construction-time snapping
+        makes them bitwise identical). Basis evaluation must then be fully
+        consistent with that: no NaN/Inf, and the partition of unity holds at and
+        around the (now doubled) knot.
+        """
+        tol = get_strict(np.float64)
+        degree = 2
+        knots = np.array(
+            [0.0, 0.0, 0.0, 0.5, 0.5 + 0.5 * tol, 0.75, 1.0, 1.0, 1.0], dtype=np.float64
+        )
+        space = BsplineSpace1D(knots, degree)
+
+        unique_knots, mult = space.get_unique_knots_and_multiplicity()
+        idx = int(np.argmin(np.abs(unique_knots - 0.5)))
+        expected_multiplicity = 2
+        assert mult[idx] == expected_multiplicity
+        assert space.knots[3] == space.knots[4]  # snapped to bitwise-identical
+
+        pts = np.array([0.4, 0.5, 0.5 + 0.25 * tol, 0.5 + 0.5 * tol, 0.6], dtype=np.float64)
+        basis, _ = space.tabulate_basis(pts)
+
+        assert np.all(np.isfinite(basis))
+        np.testing.assert_allclose(basis.sum(axis=-1), 1.0, atol=1e-13)

--- a/tests/test_bspline_basis_tol_guard_scale.py
+++ b/tests/test_bspline_basis_tol_guard_scale.py
@@ -1,19 +1,34 @@
 """Regression tests for the Cox-de Boor denominator guard (issue #257).
 
-The ``BasisFuncs``/``DerBasisFuncs`` kernels in ``_bspline_basis_core.py`` guard the
-Cox-de Boor recurrence denominator against near-zero knot differences. The guard now
-compares the denominator to ``tol`` scaled by the knot vector's parametric span
-(``_scaled_denom_tol``), so it is invariant under affine reparametrization (shift and
-scale) of the knot vector, matching the fact that B-spline basis functions themselves
-are affine-invariant.
+The ``BasisFuncs``/``DerBasisFuncs`` kernels in ``_bspline_basis_core.py`` used to
+guard the Cox-de Boor recurrence denominator with ``denom < tol`` (an absolute
+per-dtype tolerance): scale-dependent, since a genuinely nonzero knot span on a tiny
+domain can be smaller than ``tol`` and get zeroed, breaking the partition of unity.
 
-Note on the (scale, shift) grid below: combining the smallest scale (``1e-12``) with
-the largest shift (``1e3``) is deliberately *not* tested as a single combination.
-At that combination the knot span (``~1e-12``) is only a few float64 ULPs wide at
-magnitude ``1e3`` (ULP there is ``~2.2e-13``), so the knot *values* themselves cannot
-be represented distinctly -- a float64 representability limit, not a property of the
-guard being tested here. Scale and shift invariance are therefore each tested at a
-grid where the other axis does not erode representability.
+An initial fix scaled ``tol`` by the knot vector's *global* span before comparing.
+That was itself wrong: it made the guard fire on genuinely distinct, non-repeated
+local knot gaps whenever the domain was large relative to local spacing (an
+ordinary graded/refined knot vector), incorrectly zeroing basis contributions that
+:meth:`~pantr.bspline.BsplineSpace1D.get_unique_knots_and_multiplicity` reports as
+distinct. ``TestGradedKnotVectorLocalSpacing`` below locks in a regression test for
+that specific failure mode.
+
+The final fix drops the tolerance from the guard entirely and uses the textbook
+exact-zero test (``denom == 0.0``, Piegl & Tiller A2.2/A2.3), which is scale-invariant
+by construction. This is safe because
+:class:`~pantr.bspline.BsplineSpace1D` already snaps near-duplicate knots (within
+tolerance) to a single bitwise value at construction time
+(``BsplineSpace1D._snap_knots``), so two knots meant to be equal always produce an
+exactly-zero Cox-de Boor denominator (IEEE-754 subtraction is antisymmetric).
+
+Note on the (scale, shift) grid in the affine-invariance tests below: combining the
+smallest scale (``1e-12``) with the largest shift (``1e3``) is deliberately *not*
+tested as a single combination. At that combination the knot span (``~1e-12``) is
+only a few float64 ULPs wide at magnitude ``1e3`` (ULP there is ``~2.2e-13``), so the
+knot *values* themselves cannot be represented distinctly -- a float64
+representability limit, not a property of the guard being tested here. Scale and
+shift invariance are therefore each tested at a grid where the other axis does not
+erode representability.
 """
 
 import numpy as np
@@ -25,16 +40,18 @@ from pantr.tolerance import get_strict
 
 
 class TestScaleDependentDenominatorGuard:
-    """Former known-bug regression (issue #257): the guard is now affine-invariant."""
+    """Former known-bug regression (issue #257): guard no longer depends on tol at all."""
 
     def test_tiny_domain_partition_of_unity(self) -> None:
         """A tiny-but-nonzero domain must still satisfy the partition of unity.
 
         Knot spans are scaled down to ``1e-16`` while ``tol`` stays at the float64
         strict preset (``1e-15``, see :func:`pantr.tolerance.get_strict`). Every
-        local knot span is well below the *unscaled* ``tol`` even though it is not
-        zero; before the fix this made the guard incorrectly collapse every
-        Cox-de Boor contribution, so the basis functions no longer summed to one.
+        local knot span is well below ``tol`` even though it is not zero; before the
+        fix this made the guard incorrectly collapse every Cox-de Boor contribution,
+        so the basis functions no longer summed to one. ``tol`` is still passed to
+        the kernel (it is used for periodic multiplicity detection) but no longer
+        affects the denominator guard, which is now an exact ``denom == 0.0`` test.
         """
         scale = 1e-16
         knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=np.float64) * scale
@@ -47,6 +64,57 @@ class TestScaleDependentDenominatorGuard:
         _compute_basis_nurbs_book_serial_impl(knots, degree, False, tol, pts, basis, first_basis)
 
         np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-13)
+
+
+class TestGradedKnotVectorLocalSpacing:
+    """Regression guard for the global-span-scaling failure mode found in review.
+
+    An earlier version of this fix scaled ``tol`` by the knot vector's *global*
+    span (``knots[-1] - knots[0]``) instead of using an exact-zero test. That
+    incorrectly zeroed genuinely distinct, non-repeated local knot gaps whenever
+    the domain was large relative to local spacing -- an entirely ordinary
+    graded/refined knot vector, not an extreme edge case. These tests pin down
+    that the final (exact-zero) guard does not reintroduce that regression.
+    """
+
+    def test_large_domain_small_local_gap_float64(self) -> None:
+        """A non-repeated, locally tiny knot gap on a huge domain must not be zeroed.
+
+        Domain ``[0, 1e12]`` with an interior knot pair ``5e11`` apart from
+        ``5e11`` by only ``5e-4`` (ratio to the domain ``~5e-16``): the pair is
+        *not* repeated, and :meth:`BsplineSpace1D.get_unique_knots_and_multiplicity`
+        agrees (multiplicity 1 each), so the guard must not collapse it.
+        """
+        knots = np.array([0.0, 0.0, 0.0, 5e11, 5e11 + 5e-4, 1e12, 1e12, 1e12], dtype=np.float64)
+        space = BsplineSpace1D(knots, 2)
+
+        # Endpoints are open (multiplicity degree+1 = 3); the two interior knots
+        # (5e11 and 5e11 + 5e-4) are genuinely distinct, multiplicity 1 each.
+        _, mult = space.get_unique_knots_and_multiplicity()
+        np.testing.assert_array_equal(mult, [3, 1, 1, 3])
+
+        basis, _ = space.tabulate_basis(np.array([5e11 + 2.5e-4], dtype=np.float64))
+        assert np.all(np.isfinite(basis))
+        np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-9)
+
+    def test_ordinary_domain_graded_refinement_float32(self) -> None:
+        """A routine float32 grading ratio on an unremarkable domain must not be zeroed.
+
+        Domain ``[0, 1000]`` (nothing extreme) with an interior gap of ``~9.15e-5``
+        (grading ratio ``~1e-7`` relative to the domain), well within ordinary
+        adaptive-refinement territory for float32.
+        """
+        knots = np.array(
+            [0.0, 0.0, 0.0, 500.0, 500.0 + 9.15e-5, 1000.0, 1000.0, 1000.0], dtype=np.float32
+        )
+        space = BsplineSpace1D(knots, 2)
+
+        _, mult = space.get_unique_knots_and_multiplicity()
+        np.testing.assert_array_equal(mult, [3, 1, 1, 3])
+
+        basis, _ = space.tabulate_basis(np.array([500.0 + 4.6e-5], dtype=np.float32))
+        assert np.all(np.isfinite(basis))
+        np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #257: the Cox-de Boor recurrence denominator guard in `_basis_funcs_point`/`_basis_derivs_point` (`src/pantr/bspline/_bspline_basis_core.py`) used to compare a knot difference against an absolute per-dtype tolerance (`denom < tol`), which is scale-dependent — a genuinely nonzero knot span on a tiny domain could be smaller than `tol` and get zeroed, breaking the partition of unity.
- **Option chosen: A (exact-zero test)**, not a scaled tolerance. `denom == 0.0` (Piegl & Tiller's textbook A2.2/A2.3 guard) is both correct and scale-invariant by construction, because `BsplineSpace1D` already snaps near-duplicate knots to a single bitwise value at construction time (`_snap_knots`, unchanged, default `snap_knots=True`) — so two knots meant to be equal always produce an exactly-zero Cox-de Boor denominator (IEEE-754 subtraction is antisymmetric). No tolerance parameter is needed in the kernel at all.
- An earlier attempt (scaling `tol` by the knot vector's *global* span) was caught by review: it incorrectly zeroed genuinely distinct, non-repeated local knot gaps whenever the domain was large relative to local spacing — an ordinary graded/refined knot vector, reproducible even at an unremarkable float32 domain of `[0, 1000]`. That approach was dropped in favor of Option A, which cannot exhibit this failure mode since it never scales anything.
- `src/pantr/tolerance.py`: docstring-only update documenting the convention (absolute presets for multiplicity/snapping; kernels compare against exact zero, relying on construction-time snapping).
- New tests in `tests/test_bspline_basis_tol_guard_scale.py`: the issue's regression case (now passing, not xfail), affine-invariance sweeps (scale {1e-12…1e12}, shift {0, 1e3}) for both the general kernel and the Bézier-like fast path, derivatives orders 0-3, a repeated-knots-unchanged closed-form check, a knot-multiplicity-consistency check, and two regression tests locking in the graded-knot-vector failure mode found in review.

## Test plan

- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --config-file mypy.ini src tests` — clean
- [x] `lint-imports` — contract kept (serial core does not import `pantr.mpi`)
- [x] `pytest --no-cov` — 3920 passed, 19 skipped, 0 new failures
- [x] `NUMBA_DISABLE_JIT=1 pytest --cov=src/pantr --cov-report=xml` — 3920 passed, 19 skipped, 0 new failures
- [x] `make docs SPHINXOPTS="-W --keep-going -j auto"` — build succeeded, no warnings
- [x] Benchmark (1 thread, 10^7 points, cubic degree): basis 512.78ms vs. pre-fix baseline 522.36ms; derivative 1340.58ms vs. baseline 1352.15ms — within noise, under the 2% gate (the fix is marginally cheaper, since the guard no longer takes or scales a tolerance parameter)

## Review notes

Two independent fresh-context review rounds were run (`pr-review-toolkit:code-reviewer`, plus `type-design-analyzer` on round 1):
- Round 1 caught a critical regression in the initial (global-span-scaled tolerance) approach, described above — fixed by switching to Option A.
- Round 2 found two documentation-accuracy issues (an inaccurate claim that `tol` is "used for periodic multiplicity detection" in a call path where it's actually inert, and an overclaimed "safe by construction" guarantee that didn't mention the `snap_knots=False` path used internally by `_bspline_split.py`/`_bspline_restrict.py`) — both corrected, plus a new regression test added for the `snap_knots=False` near-duplicate-knot case the reviewer surfaced (confirmed: the new guard handles it correctly; the old absolute-tolerance guard did not).

One pre-existing, unrelated local-environment test failure was observed throughout (`tests/test_mpi.py::test_pantr_toplevel_does_not_import_mpi`), caused by a stale editable pip-install pointer to a deleted worktree on this machine; confirmed to fail identically on `main` with no changes, and not something CI (which does a clean install) would hit.

Generated with [Claude Code](https://claude.com/claude-code)