### PR TITLE
fix(basis): mirror Bernstein recurrence near u=1

### DIFF
--- a/src/pantr/basis/_basis_core.py
+++ b/src/pantr/basis/_basis_core.py
@@ -32,8 +32,24 @@ def _bernstein_point(
 ) -> None:
     """Evaluate all Bernstein basis polynomials of degree ``n`` at one point.
 
-    Recurrence: ``B_0,n(u) = (1-u)^n``; ``B_i,n = B_{i-1},n * ((n-i+1)/i) * (u/(1-u))``.
-    ``u == 1.0`` is special-cased (the recurrence would produce NaN).
+    Uses the O(n) ratio recurrence, run from whichever endpoint keeps the seed
+    term bounded away from underflow, exploiting the symmetry
+    ``B_i,n(u) = B_{n-i},n(1-u)``:
+
+    - ``u <= 0.5``: forward recurrence from ``u = 0``:
+      ``B_0,n(u) = (1-u)^n``; ``B_i,n = B_{i-1},n * ((n-i+1)/i) * (u/(1-u))``.
+    - ``u > 0.5``: mirrored recurrence from ``u = 1``:
+      ``B_n,n(u) = u^n``; ``B_{i-1},n = B_i,n * (i/(n-i+1)) * ((1-u)/u)``.
+
+    Branching on the midpoint bounds the seed (``(1-u)^n`` or ``u^n``) below
+    by ``0.5^n``, so it never underflows for any representable degree ``n``.
+    Without the branch, the forward seed ``(1-u)^n`` underflows to exact
+    ``0.0`` once ``u`` is close enough to 1 at high degree, and every
+    subsequent term (a positive multiple of the previous one) stays zero —
+    including ``B_n,n``, whose true value is near 1 — silently breaking
+    partition of unity. ``u == 1.0`` needs no special-casing: the mirrored
+    branch handles it exactly (``u^n == 1.0``, then every step multiplies by
+    ``(1-u)/u == 0.0``).
 
     Args:
         n (np.int32): Degree of the Bernstein polynomials (>= 0).
@@ -44,13 +60,19 @@ def _bernstein_point(
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_tabulate_Bernstein_basis_1D_impl` instead.
     """
-    if u == 1.0:
-        # At t=1.0: only B_n,n(1) = 1, all others are 0
-        for i in range(out_row.shape[0]):
-            out_row[i] = 0.0
-        out_row[n] = 1.0
+    if u > 0.5:
+        # Mirrored recurrence from u=1: seed B_n,n(u) = u^n is >= 0.5^n, so it
+        # never underflows. Low-index entries may legitimately underflow to
+        # exact 0.0 (their true value is negligible near u=1).
+        one_minus_u = 1.0 - u
+        out_row[n] = np.power(u, n)
+        one_minus_u_over_u = one_minus_u / u
+        for i in range(n, 0, -1):
+            const_factor = i / (n - i + 1.0)
+            out_row[i - 1] = out_row[i] * const_factor * one_minus_u_over_u
     else:
-        # For t != 1.0, use recurrence relation
+        # Forward recurrence from u=0: seed B_0,n(u) = (1-u)^n is >= 0.5^n, so
+        # it never underflows.
         one_minus_u = 1.0 - u
         out_row[0] = np.power(one_minus_u, n)
         t_over_1mt = u / one_minus_u

--- a/src/pantr/basis/_basis_core.py
+++ b/src/pantr/basis/_basis_core.py
@@ -593,6 +593,17 @@ def _warmup_numba_functions() -> None:
 
     This function triggers compilation of the numba-decorated core functions
     with float64 arrays, ensuring they are cached and ready for use.
+
+    Note:
+        Unlike its siblings in other modules, this function is not invoked
+        from `pantr/__init__.py`'s background async-warmup thread: this
+        module's kernels are ``parallel=True``, and compiling them from a
+        background thread while the main thread may also call them
+        concurrently is a known Numba crash (see the warmup-thread comment
+        in `pantr/__init__.py`). They compile lazily on first user call
+        instead, always from the calling (main) thread, avoiding the race.
+        This function is kept for potential future use (e.g. an explicit,
+        single-threaded warmup call site) but is currently dead code.
     """
     # Small dummy arrays for warmup
     t_dummy = np.array([0.0, 0.5, 1.0], dtype=np.float64)

--- a/src/pantr/basis/_basis_core.py
+++ b/src/pantr/basis/_basis_core.py
@@ -19,6 +19,41 @@ Below this threshold the fork/join overhead of a parallel Numba kernel launch
 the Layer-2 tabulation helpers dispatch to the serial twin kernels instead.
 """
 
+_MIRROR_THRESHOLD = 0.5
+"""Midpoint used to pick the Bernstein ratio-recurrence branch in `_bernstein_point`.
+
+Bounds the recurrence seed (``(1-u)^n`` or ``u^n``) below by ``0.5^n``, so it
+never underflows regardless of degree.
+"""
+
+_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64 = 20
+"""Largest float64 degree for which the plain (unmirrored) forward recurrence
+cannot underflow for *any* representable ``u``.
+
+The smallest positive ``1 - u`` for a representable float64 ``u < 1`` is half
+a ULP below 1, i.e. ``2**-53`` (attained at ``u = np.nextafter(1.0, 0.0)``).
+``(2**-53)**n`` first underflows to exactly ``0.0`` (below the smallest
+float64 subnormal, ``2**-1074``) once ``53 * n > 1074``, i.e. at ``n = 21``.
+Verified empirically: partition of unity holds within ``8*n*eps`` at that
+worst-case ``u`` for every ``n`` up to 20, and fails at ``n = 21``. Used by
+the tabulation kernels to dispatch to :func:`_bernstein_point_no_mirror`
+(bit-identical to the pre-fix recurrence) instead of the mirrored
+:func:`_bernstein_point`, avoiding the mirror branch's overhead entirely for
+degrees where it can provably never be needed.
+"""
+
+_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32 = 6
+"""Float32 analogue of `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64`.
+
+The smallest positive ``1 - u`` for representable float32 ``u < 1`` is
+``2**-24``; the smallest float32 subnormal is ``2**-149``. Underflow to exact
+``0.0`` first occurs once ``24 * n > 149``, i.e. at ``n = 7``. Verified
+empirically (see `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64`): safe up to ``n = 6``.
+"""
+
+_FLOAT64_ITEMSIZE = 8
+"""Byte width of a float64 element, used to pick the safe-degree threshold by dtype."""
+
 
 @nb_jit(
     nopython=True,
@@ -36,10 +71,16 @@ def _bernstein_point(
     term bounded away from underflow, exploiting the symmetry
     ``B_i,n(u) = B_{n-i},n(1-u)``:
 
-    - ``u <= 0.5``: forward recurrence from ``u = 0``:
+    - ``u <= 0.5``: forward recurrence from ``u = 0``, written directly into
+      ``out_row`` in ascending order:
       ``B_0,n(u) = (1-u)^n``; ``B_i,n = B_{i-1},n * ((n-i+1)/i) * (u/(1-u))``.
-    - ``u > 0.5``: mirrored recurrence from ``u = 1``:
-      ``B_n,n(u) = u^n``; ``B_{i-1},n = B_i,n * (i/(n-i+1)) * ((1-u)/u)``.
+    - ``u > 0.5``: the same forward recurrence run on ``1-u`` in place of
+      ``u`` (seed ``u^n``, ratio ``(1-u)/u``) — which by the symmetry above
+      computes ``B_i,n(1-u) = B_{n-i},n(u)`` into ``out_row[i]`` — followed by
+      an in-place reversal of ``out_row`` to restore ``B_i,n(u)`` at index
+      ``i``. Reusing the *ascending* loop (rather than accumulating directly
+      into descending indices) avoids a measured slowdown from the
+      decreasing-index store pattern a naive mirrored loop would produce.
 
     Branching on the midpoint bounds the seed (``(1-u)^n`` or ``u^n``) below
     by ``0.5^n``, so it never underflows for any representable degree ``n``.
@@ -49,7 +90,8 @@ def _bernstein_point(
     including ``B_n,n``, whose true value is near 1 — silently breaking
     partition of unity. ``u == 1.0`` needs no special-casing: the mirrored
     branch handles it exactly (``u^n == 1.0``, then every step multiplies by
-    ``(1-u)/u == 0.0``).
+    ``(1-u)/u == 0.0``, and the reversal is a no-op on the resulting
+    ``[1.0, 0.0, ..., 0.0]`` row read backwards).
 
     Args:
         n (np.int32): Degree of the Bernstein polynomials (>= 0).
@@ -60,19 +102,76 @@ def _bernstein_point(
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_tabulate_Bernstein_basis_1D_impl` instead.
     """
-    if u > 0.5:
-        # Mirrored recurrence from u=1: seed B_n,n(u) = u^n is >= 0.5^n, so it
-        # never underflows. Low-index entries may legitimately underflow to
-        # exact 0.0 (their true value is negligible near u=1).
+    if u > _MIRROR_THRESHOLD:
+        # Mirrored recurrence from u=1, computed as the forward recurrence on
+        # 1-u (seed u^n >= 0.5^n never underflows) written ascending into
+        # out_row, then reversed in place to land B_i,n(u) at index i.
         one_minus_u = 1.0 - u
-        out_row[n] = np.power(u, n)
+        out_row[0] = np.power(u, n)
         one_minus_u_over_u = one_minus_u / u
-        for i in range(n, 0, -1):
-            const_factor = i / (n - i + 1.0)
-            out_row[i - 1] = out_row[i] * const_factor * one_minus_u_over_u
+        for i in range(1, n + 1):
+            const_factor = (n - i + 1.0) / i
+            out_row[i] = out_row[i - 1] * const_factor * one_minus_u_over_u
+        lo = 0
+        hi = n
+        while lo < hi:
+            tmp = out_row[lo]
+            out_row[lo] = out_row[hi]
+            out_row[hi] = tmp
+            lo += 1
+            hi -= 1
     else:
         # Forward recurrence from u=0: seed B_0,n(u) = (1-u)^n is >= 0.5^n, so
         # it never underflows.
+        one_minus_u = 1.0 - u
+        out_row[0] = np.power(one_minus_u, n)
+        t_over_1mt = u / one_minus_u
+        for i in range(1, n + 1):
+            const_factor = (n - i + 1.0) / i
+            out_row[i] = out_row[i - 1] * const_factor * t_over_1mt
+
+
+@nb_jit(
+    nopython=True,
+    cache=True,
+    inline="always",
+)
+def _bernstein_point_no_mirror(
+    n: np.int32,
+    u: np.float32 | np.float64,
+    out_row: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate Bernstein basis polynomials at one point via the plain forward recurrence.
+
+    Bit-identical to the pre-issue-#258 recurrence: ``B_0,n(u) = (1-u)^n``,
+    ``B_i,n = B_{i-1},n * ((n-i+1)/i) * (u/(1-u))``, with ``u == 1.0``
+    special-cased directly. Callers must only use this for degrees at or
+    below `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64` (float64) or
+    `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32` (float32), where the seed
+    ``(1-u)^n`` is proven to never underflow — this function has none of
+    :func:`_bernstein_point`'s mirroring, so it is unsafe for higher degrees.
+    Kept as a byte-for-byte-unbranched fast path purely for performance: the
+    tabulation kernels dispatch to it once per batch (not per point) so that
+    low-degree callers, which can never hit the underflow this issue fixes,
+    pay zero overhead for the mirror-branch machinery.
+
+    Args:
+        n (np.int32): Degree of the Bernstein polynomials (>= 0), at or below
+            the relevant `_MAX_SAFE_DEGREE_NO_MIRROR_*` bound for ``u``'s dtype.
+        u (np.float32 | np.float64): Evaluation point.
+        out_row (npt.NDArray[np.float32 | np.float64]): Output row of length ``n + 1``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed), including
+        the degree bound above: this is a private performance fast path, not
+        a general-purpose entry point.
+        For general use, call :func:`_tabulate_Bernstein_basis_1D_impl` instead.
+    """
+    if u == 1.0:
+        for i in range(out_row.shape[0]):
+            out_row[i] = 0.0
+        out_row[n] = 1.0
+    else:
         one_minus_u = 1.0 - u
         out_row[0] = np.power(one_minus_u, n)
         t_over_1mt = u / one_minus_u
@@ -103,6 +202,13 @@ def _tabulate_Bernstein_basis_1D_core(
     serial twin :func:`_tabulate_Bernstein_basis_1D_serial_core`, which avoids
     the parallel launch overhead.
 
+    The degree/dtype check against `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64` /
+    `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32` happens once per call (not once per
+    point), then dispatches every point to the branch-free
+    :func:`_bernstein_point_no_mirror` when safe, or the mirrored
+    :func:`_bernstein_point` otherwise — this keeps the (measured) mirror
+    branch's overhead confined to the rare degrees that actually need it.
+
     Args:
         n (np.int32): Degree of the Bernstein polynomials. Must be non-negative.
         t (npt.NDArray[np.float32 | np.float64]): 1D array of
@@ -124,9 +230,18 @@ def _tabulate_Bernstein_basis_1D_core(
             out[j, 0] = 1.0
         return
 
+    max_safe_degree = (
+        _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64
+        if t.itemsize == _FLOAT64_ITEMSIZE
+        else _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32
+    )
     # Process each point — rows are independent, so use prange.
-    for j in nb_prange(t.shape[0]):
-        _bernstein_point(n, t[j], out[j, :])
+    if n <= max_safe_degree:
+        for j in nb_prange(t.shape[0]):
+            _bernstein_point_no_mirror(n, t[j], out[j, :])
+    else:
+        for j in nb_prange(t.shape[0]):
+            _bernstein_point(n, t[j], out[j, :])
 
 
 @nb_jit(
@@ -142,7 +257,9 @@ def _tabulate_Bernstein_basis_1D_serial_core(
 
     Identical to :func:`_tabulate_Bernstein_basis_1D_core` but compiled without
     ``parallel=True``: no fork/join overhead, which makes it the faster choice
-    for small point batches.
+    for small point batches. Dispatches to the branch-free
+    :func:`_bernstein_point_no_mirror` or the mirrored :func:`_bernstein_point`
+    exactly as described there.
 
     Args:
         n (np.int32): Degree of the Bernstein polynomials. Must be non-negative.
@@ -162,8 +279,17 @@ def _tabulate_Bernstein_basis_1D_serial_core(
             out[j, 0] = 1.0
         return
 
-    for j in range(t.shape[0]):
-        _bernstein_point(n, t[j], out[j, :])
+    max_safe_degree = (
+        _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64
+        if t.itemsize == _FLOAT64_ITEMSIZE
+        else _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32
+    )
+    if n <= max_safe_degree:
+        for j in range(t.shape[0]):
+            _bernstein_point_no_mirror(n, t[j], out[j, :])
+    else:
+        for j in range(t.shape[0]):
+            _bernstein_point(n, t[j], out[j, :])
 
 
 @nb_jit(
@@ -477,6 +603,17 @@ def _warmup_numba_functions() -> None:
     _tabulate_Bernstein_basis_1D_serial_core(np.int32(1), t_dummy, out_dummy)
     _tabulate_cardinal_Bspline_basis_1D_core(np.int32(1), t_dummy, out_dummy)
     _tabulate_Legendre_basis_1D_core(np.int32(1), t_dummy, out_dummy)
+
+    # The Bernstein tabulation kernels dispatch on degree (see
+    # `_MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64`): the n=1 warmup above only compiles
+    # the branch-free `_bernstein_point_no_mirror` fast path, so warm up the
+    # mirrored `_bernstein_point` path too with a degree above the threshold.
+    n_mirrored_dummy = _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64 + 1
+    out_mirrored_dummy = np.empty((3, n_mirrored_dummy + 1), dtype=np.float64)
+    _tabulate_Bernstein_basis_1D_core(np.int32(n_mirrored_dummy), t_dummy, out_mirrored_dummy)
+    _tabulate_Bernstein_basis_1D_serial_core(
+        np.int32(n_mirrored_dummy), t_dummy, out_mirrored_dummy
+    )
 
     # Warmup Bernstein derivative cores with float64 (parallel and serial twins)
     n_deriv_dummy = 2

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -18,13 +18,20 @@ import numpy.typing as npt
 from .._numba_compat import nb_jit, nb_prange
 from ..bspline._bspline_degree_core import _bincoeff
 
+_MIRROR_THRESHOLD = 0.5
+"""Midpoint used to pick the Bernstein ratio-recurrence branch in `_evaluate_bezier_1d_core`.
+
+Bounds the recurrence seed (``(1-u)^p`` or ``u^p``) below by ``0.5^p``, so it
+never underflows regardless of degree. Matches ``_basis_core._MIRROR_THRESHOLD``.
+"""
+
 
 @nb_jit(
     nopython=True,
     cache=True,
     parallel=True,
 )
-def _evaluate_bezier_1d_core(
+def _evaluate_bezier_1d_core(  # noqa: PLR0912
     ctrl: npt.NDArray[np.float32 | np.float64],
     pts: npt.NDArray[np.float32 | np.float64],
     out: npt.NDArray[np.float32 | np.float64],
@@ -37,12 +44,26 @@ def _evaluate_bezier_1d_core(
     points, avoiding allocation of a full ``(n_pts, p+1)`` basis matrix.
 
     As in :func:`_bernstein_point` (``_basis_core.py``), the recurrence is run
-    from whichever endpoint keeps its seed term bounded away from underflow:
-    forward from ``u = 0`` (seed ``(1-u)^p``) when ``u <= 0.5``, mirrored from
-    ``u = 1`` (seed ``u^p``) when ``u > 0.5``, using the symmetry
-    ``B_i,p(u) = B_{p-i},p(1-u)``. Without this branch, the forward seed
-    underflows to exact ``0.0`` for ``u`` close enough to 1 at high degree,
-    silently zeroing the whole evaluation.
+    from whichever endpoint keeps its seed term bounded away from underflow,
+    using the symmetry ``B_i,p(u) = B_{p-i},p(1-u)``:
+
+    - ``u <= 0.5``: forward recurrence (seed ``(1-u)^p``), contracted with
+      ``ctrl`` in ascending order.
+    - ``u > 0.5``: the same forward recurrence run on ``1-u`` in place of
+      ``u`` (seed ``u^p``, ratio ``(1-u)/u``), contracted with ``ctrl`` in
+      *descending* order (``ctrl[p - i, :]`` at loop step ``i``) so that the
+      ``i``-th term of the ascending recurrence — which equals
+      ``B_i,p(1-u) = B_{p-i},p(u)`` — pairs with its matching control point.
+      Reusing the ascending loop (rather than accumulating via a genuinely
+      descending recurrence) avoids a measured slowdown from the
+      decreasing-index store pattern a naive mirrored loop would produce; here
+      the running scalar ``b_curr`` accumulates into the same fixed ``rank``
+      output slots every iteration, so reading ``ctrl`` in reverse carries no
+      such penalty.
+
+    Without this branch, the forward seed underflows to exact ``0.0`` for
+    ``u`` close enough to 1 at high degree, silently zeroing the whole
+    evaluation.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
@@ -69,20 +90,21 @@ def _evaluate_bezier_1d_core(
         elif u == 1.0:
             for r in range(rank):
                 out[pt_id, r] = ctrl[p, r]
-        elif u > 0.5:
+        elif u > _MIRROR_THRESHOLD:
             one_minus_u = 1.0 - u
-            # B_p = u^p
+            # b_curr = B_0,p(1-u) = u^p = B_p,p(u); pairs with ctrl[p]
             b_curr = np.power(u, p)
 
-            # Accumulate: start with basis[p] * ctrl[p]
             for r in range(rank):
                 out[pt_id, r] = b_curr * ctrl[p, r]
 
             one_minus_u_over_u = one_minus_u / u
-            for i in range(p, 0, -1):
-                b_curr = b_curr * (i / (p - i + 1.0)) * one_minus_u_over_u
+            for i in range(1, p + 1):
+                const_factor = (p - i + 1.0) / i
+                b_curr = b_curr * const_factor * one_minus_u_over_u
+                # b_curr = B_i,p(1-u) = B_{p-i},p(u); pairs with ctrl[p - i]
                 for r in range(rank):
-                    out[pt_id, r] += b_curr * ctrl[i - 1, r]
+                    out[pt_id, r] += b_curr * ctrl[p - i, r]
         else:
             one_minus_u = 1.0 - u
             # B_0 = (1 - u)^p

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -33,8 +33,16 @@ def _evaluate_bezier_1d_core(
 
     Fuses Bernstein basis evaluation with control point contraction: for each
     evaluation point the ``(p+1)`` Bernstein basis values are computed via the
-    recurrence relation and immediately multiplied with the corresponding
-    control points, avoiding allocation of a full ``(n_pts, p+1)`` basis matrix.
+    ratio recurrence and immediately multiplied with the corresponding control
+    points, avoiding allocation of a full ``(n_pts, p+1)`` basis matrix.
+
+    As in :func:`_bernstein_point` (``_basis_core.py``), the recurrence is run
+    from whichever endpoint keeps its seed term bounded away from underflow:
+    forward from ``u = 0`` (seed ``(1-u)^p``) when ``u <= 0.5``, mirrored from
+    ``u = 1`` (seed ``u^p``) when ``u > 0.5``, using the symmetry
+    ``B_i,p(u) = B_{p-i},p(1-u)``. Without this branch, the forward seed
+    underflows to exact ``0.0`` for ``u`` close enough to 1 at high degree,
+    silently zeroing the whole evaluation.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
@@ -61,6 +69,20 @@ def _evaluate_bezier_1d_core(
         elif u == 1.0:
             for r in range(rank):
                 out[pt_id, r] = ctrl[p, r]
+        elif u > 0.5:
+            one_minus_u = 1.0 - u
+            # B_p = u^p
+            b_curr = np.power(u, p)
+
+            # Accumulate: start with basis[p] * ctrl[p]
+            for r in range(rank):
+                out[pt_id, r] = b_curr * ctrl[p, r]
+
+            one_minus_u_over_u = one_minus_u / u
+            for i in range(p, 0, -1):
+                b_curr = b_curr * (i / (p - i + 1.0)) * one_minus_u_over_u
+                for r in range(rank):
+                    out[pt_id, r] += b_curr * ctrl[i - 1, r]
         else:
             one_minus_u = 1.0 - u
             # B_0 = (1 - u)^p
@@ -70,13 +92,12 @@ def _evaluate_bezier_1d_core(
             for r in range(rank):
                 out[pt_id, r] = b_prev * ctrl[0, r]
 
-            if p > 0:
-                t_over_1mt = u / one_minus_u
-                for i in range(1, p + 1):
-                    b_curr = b_prev * ((p - i + 1.0) / i) * t_over_1mt
-                    for r in range(rank):
-                        out[pt_id, r] += b_curr * ctrl[i, r]
-                    b_prev = b_curr
+            t_over_1mt = u / one_minus_u
+            for i in range(1, p + 1):
+                b_curr = b_prev * ((p - i + 1.0) / i) * t_over_1mt
+                for r in range(rank):
+                    out[pt_id, r] += b_curr * ctrl[i, r]
+                b_prev = b_curr
 
 
 @nb_jit(

--- a/tests/test_bernstein_underflow.py
+++ b/tests/test_bernstein_underflow.py
@@ -27,6 +27,7 @@ This module covers:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -34,7 +35,15 @@ import numpy.typing as npt
 import pytest
 
 from pantr._numba_compat import wait_for_jit_warmup
-from pantr.basis._basis_core import _bernstein_derivs_point, _bernstein_point
+from pantr.basis._basis_core import (
+    _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32,
+    _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64,
+    _bernstein_derivs_point,
+    _bernstein_point,
+    _bernstein_point_no_mirror,
+    _tabulate_Bernstein_basis_1D_core,
+    _tabulate_Bernstein_basis_1D_serial_core,
+)
 from pantr.bezier._bezier_core import _evaluate_bezier_1d_core, _slice_bezier_1d_core
 
 # This module calls parallel=True Numba kernels directly (bypassing the
@@ -63,6 +72,11 @@ Narrower than `npt.DTypeLike`: calling the type directly (e.g. ``dtype(u)``)
 gives mypy a single concrete overload instead of the ambiguous ``np.void``
 fallback that ``np.dtype(some_DTypeLike).type(...)`` resolves to.
 """
+
+_TabulateFn = Callable[
+    [np.int32, npt.NDArray[np.floating[Any]], npt.NDArray[np.floating[Any]]], None
+]
+"""Shared signature of `_tabulate_Bernstein_basis_1D_core` and its serial twin."""
 
 
 def _eval_bernstein_row(n: int, u: float, dtype: _Float32Or64) -> npt.NDArray[np.floating[Any]]:
@@ -214,3 +228,144 @@ class TestFusedBezierKernel:
         _slice_bezier_1d_core(ctrl, u, out_ref)
 
         np.testing.assert_allclose(out_fused[0], out_ref, rtol=1e-10, atol=1e-10)
+
+    def test_batch_of_mixed_points_matches_de_casteljau(self) -> None:
+        """A single batched call mixing both branches matches de Casteljau per point.
+
+        `_evaluate_bezier_1d_core` is a ``parallel=True``/``prange`` kernel: a
+        batch with more than one point, spanning the forward branch, the
+        mirrored branch, and the shared boundary, guards against any
+        cross-iteration state-sharing bug the branch could introduce (each
+        point's ``b_curr`` must stay independent of every other point's).
+        """
+        degree = 30
+        rank = 3
+        pts = np.array([0.0, 0.1, 0.25, 0.5, 0.5 + _EPS64, 0.75, 1.0 - 1e-12, 1.0 - 1e-16, 1.0])
+        rng = np.random.default_rng(7)
+        ctrl = rng.normal(size=(degree + 1, rank))
+
+        out_fused = np.empty((pts.size, rank), dtype=np.float64)
+        _evaluate_bezier_1d_core(ctrl, pts, out_fused)
+
+        for k, u in enumerate(pts):
+            out_ref = np.empty(rank, dtype=np.float64)
+            _slice_bezier_1d_core(ctrl, float(u), out_ref)
+            np.testing.assert_allclose(out_fused[k], out_ref, rtol=1e-10, atol=1e-10)
+
+
+class TestBernsteinPointNoMirror:
+    """Pin the fast path's "bit-identical to the pre-issue-#258 recurrence" contract."""
+
+    @pytest.mark.parametrize("u", [u for u in _U64 if u <= 0.5] + [1.0], ids=lambda u: f"{u:.17g}")
+    @pytest.mark.parametrize("degree", [0, 1, 2, 5, 10, _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64])
+    def test_bitwise_identical_where_both_take_the_same_code_path(
+        self, degree: int, u: float
+    ) -> None:
+        """`_bernstein_point_no_mirror` is bit-identical to `_bernstein_point`.
+
+        Only where they run the *textually identical* code: `_bernstein_point`
+        takes its own forward branch (unbranched, matching
+        `_bernstein_point_no_mirror` line for line) for ``u <= 0.5``, and both
+        functions special-case ``u == 1.0`` identically. This is the
+        "byte-for-byte-unbranched fast path" contract from
+        `_bernstein_point_no_mirror`'s docstring.
+        """
+        out_no_mirror = np.empty(degree + 1, dtype=np.float64)
+        _bernstein_point_no_mirror(np.int32(degree), np.float64(u), out_no_mirror)
+
+        out_mirrored = _eval_bernstein_row(degree, u, np.float64)
+
+        np.testing.assert_array_equal(out_no_mirror, out_mirrored)
+
+    @pytest.mark.parametrize("u", [u for u in _U64 if 0.5 < u < 1.0], ids=lambda u: f"{u:.17g}")
+    @pytest.mark.parametrize("degree", [2, 5, 10, _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64])
+    def test_matches_mirrored_kernel_within_a_few_ulp_for_u_above_half(
+        self, degree: int, u: float
+    ) -> None:
+        """For ``u > 0.5`` (excluding 1.0) the two paths take different code.
+
+        `_bernstein_point` mirrors (forward recurrence on ``1-u`` then
+        reversed) while `_bernstein_point_no_mirror` always runs forward on
+        ``u`` directly. Both are mathematically correct at these safe
+        degrees, but accumulate the same value through different sequences
+        of floating-point operations, so they are compared within a few ULPs
+        rather than bit-for-bit (same rationale as
+        `TestForwardMirroredSymmetry`).
+        """
+        out_no_mirror = np.empty(degree + 1, dtype=np.float64)
+        _bernstein_point_no_mirror(np.int32(degree), np.float64(u), out_no_mirror)
+
+        out_mirrored = _eval_bernstein_row(degree, u, np.float64)
+
+        np.testing.assert_allclose(
+            out_no_mirror, out_mirrored, rtol=degree * _EPS64, atol=degree * _EPS64
+        )
+
+    def test_partition_of_unity_at_max_safe_degree(self) -> None:
+        """The fast path holds partition of unity at its own proven degree bound.
+
+        Uses the exact worst-case point (`np.nextafter(1.0, 0.0)`, the
+        representable float64 closest to 1) that the docstring's underflow
+        analysis is based on.
+        """
+        degree = _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64
+        u = np.nextafter(1.0, 0.0)
+        out_row = np.empty(degree + 1, dtype=np.float64)
+        _bernstein_point_no_mirror(np.int32(degree), u, out_row)
+        assert abs(float(out_row.sum()) - 1.0) <= 8 * degree * _EPS64
+
+
+class TestDegreeGateDispatch:
+    """The batch tabulation kernels must dispatch correctly at the safe-degree boundary."""
+
+    @pytest.mark.parametrize(
+        ("dtype", "max_safe_degree", "eps", "worst_case_u"),
+        [
+            pytest.param(
+                np.float64,
+                _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT64,
+                _EPS64,
+                np.nextafter(np.float64(1.0), np.float64(0.0)),
+                id="float64",
+            ),
+            pytest.param(
+                np.float32,
+                _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32,
+                _EPS32,
+                np.nextafter(np.float32(1.0), np.float32(0.0)),
+                id="float32",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "tabulate_fn",
+        [_tabulate_Bernstein_basis_1D_core, _tabulate_Bernstein_basis_1D_serial_core],
+        ids=["parallel", "serial"],
+    )
+    def test_partition_of_unity_across_the_boundary(
+        self,
+        tabulate_fn: _TabulateFn,
+        dtype: _Float32Or64,
+        max_safe_degree: int,
+        eps: float,
+        worst_case_u: np.floating[Any],
+    ) -> None:
+        """Both the branch-free fast path and the mirrored path stay correct.
+
+        Degree ``max_safe_degree`` must take the fast (branch-free) dispatch
+        path; degree ``max_safe_degree + 1`` is the first degree where the
+        fast path would fail, so it must take the mirrored path instead —
+        this is the regression guard that the dispatch boundary itself
+        doesn't reintroduce issue #258 right where it matters. Runs both the
+        parallel (`_tabulate_Bernstein_basis_1D_core`) and serial
+        (`_tabulate_Bernstein_basis_1D_serial_core`) twins, since the dispatch
+        logic is duplicated between them.
+        """
+        t: npt.NDArray[np.floating[Any]] = np.array([worst_case_u], dtype=dtype)
+        for degree in (max_safe_degree, max_safe_degree + 1):
+            out: npt.NDArray[np.floating[Any]] = np.empty((1, degree + 1), dtype=dtype)
+            tabulate_fn(np.int32(degree), t, out)
+            total = float(out[0].sum())
+            assert abs(total - 1.0) <= 8 * degree * eps, (
+                f"degree={degree} (max_safe_degree={max_safe_degree}) sum={total}"
+            )

--- a/tests/test_bernstein_underflow.py
+++ b/tests/test_bernstein_underflow.py
@@ -314,6 +314,14 @@ class TestBernsteinPointNoMirror:
         _bernstein_point_no_mirror(np.int32(degree), u, out_row)
         assert abs(float(out_row.sum()) - 1.0) <= 8 * degree * _EPS64
 
+    def test_partition_of_unity_at_max_safe_degree_float32(self) -> None:
+        """Float32 analogue of `test_partition_of_unity_at_max_safe_degree`."""
+        degree = _MAX_SAFE_DEGREE_NO_MIRROR_FLOAT32
+        u = np.nextafter(np.float32(1.0), np.float32(0.0))
+        out_row = np.empty(degree + 1, dtype=np.float32)
+        _bernstein_point_no_mirror(np.int32(degree), u, out_row)
+        assert abs(float(out_row.sum()) - 1.0) <= 8 * degree * _EPS32
+
 
 class TestDegreeGateDispatch:
     """The batch tabulation kernels must dispatch correctly at the safe-degree boundary."""

--- a/tests/test_bernstein_underflow.py
+++ b/tests/test_bernstein_underflow.py
@@ -33,8 +33,17 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._numba_compat import wait_for_jit_warmup
 from pantr.basis._basis_core import _bernstein_derivs_point, _bernstein_point
 from pantr.bezier._bezier_core import _evaluate_bezier_1d_core, _slice_bezier_1d_core
+
+# This module calls parallel=True Numba kernels directly (bypassing the
+# public API) very early in the test session. Numba's default threading
+# layer cannot safely compile the same kernel concurrently from two threads,
+# so wait for pantr's background warmup thread to finish first — otherwise it
+# can race with these direct calls and crash the interpreter (see
+# `pantr/__init__.py`'s `_async_warmup` and `_numba_compat.wait_for_jit_warmup`).
+wait_for_jit_warmup()
 
 DEGREES = [2, 5, 10, 20, 30, 64]
 
@@ -47,16 +56,24 @@ _U64 = [0.0, 1e-17, 0.25, 0.5 - _EPS64, 0.5, 0.5 + _EPS64, 0.75, 1.0 - 1e-8, 1.0
 _U32 = [0.0, 1e-7, 0.25, 0.5 - _EPS32, 0.5, 0.5 + _EPS32, 0.75, 1.0 - 1e-4, 1.0 - _EPS32, 1.0]
 
 
-def _eval_bernstein_row(n: int, u: float, dtype: npt.DTypeLike) -> npt.NDArray[np.floating[Any]]:
+_Float32Or64 = type[np.float32] | type[np.float64]
+"""Concrete float scalar types accepted by this module's test helpers.
+
+Narrower than `npt.DTypeLike`: calling the type directly (e.g. ``dtype(u)``)
+gives mypy a single concrete overload instead of the ambiguous ``np.void``
+fallback that ``np.dtype(some_DTypeLike).type(...)`` resolves to.
+"""
+
+
+def _eval_bernstein_row(n: int, u: float, dtype: _Float32Or64) -> npt.NDArray[np.floating[Any]]:
     """Evaluate the Layer-3 kernel `_bernstein_point` at one point."""
-    dt = np.dtype(dtype)
-    out_row = np.empty(n + 1, dtype=dt)
-    _bernstein_point(np.int32(n), dt.type(u), out_row)
+    out_row = np.empty(n + 1, dtype=dtype)
+    _bernstein_point(np.int32(n), dtype(u), out_row)
     return out_row
 
 
 def _all_bernstein_reference(
-    n: int, u: float, dtype: npt.DTypeLike = np.float64
+    n: int, u: float, dtype: _Float32Or64 = np.float64
 ) -> npt.NDArray[np.floating[Any]]:
     """Evaluate all degree-n Bernstein basis functions via corner-cutting (A1.3).
 
@@ -66,15 +83,14 @@ def _all_bernstein_reference(
     blow-up and hence no risk of the total-flush failure mode this module
     guards against.
     """
-    dt = np.dtype(dtype)
-    one = dt.type(1.0)
-    uu = dt.type(u)
+    one = dtype(1.0)
+    uu = dtype(u)
     u1 = one - uu
 
-    row = np.zeros(n + 1, dtype=dt)
+    row = np.zeros(n + 1, dtype=dtype)
     row[0] = one
     for j in range(1, n + 1):
-        saved = dt.type(0.0)
+        saved = dtype(0.0)
         for k in range(j):
             temp = row[k]
             row[k] = saved + u1 * temp
@@ -147,8 +163,8 @@ class TestForwardMirroredSymmetry:
         # u < 0.5 strictly, so `u` takes the forward branch and `1 - u` (> 0.5)
         # takes the mirrored branch.
         us = np.concatenate([rng.uniform(0.0, 0.5, size=20), [1e-17, 0.25]])
-        for u in us:
-            u = float(u)
+        for u_raw in us:
+            u = float(u_raw)
             row_forward = _eval_bernstein_row(degree, u, np.float64)
             row_mirrored = _eval_bernstein_row(degree, 1.0 - u, np.float64)
             np.testing.assert_allclose(

--- a/tests/test_bernstein_underflow.py
+++ b/tests/test_bernstein_underflow.py
@@ -1,31 +1,200 @@
 """Regression tests for Bernstein ratio-recurrence underflow near u=1 (issue #258).
 
-The O(p) ratio recurrence in ``_bernstein_point`` seeds the forward pass from
-``B_0 = (1 - u)^p``, which underflows to exact zero for ``u`` close enough to
-1 at high degree. Once the seed flushes, every subsequent term (a positive
-multiple of the previous one) stays zero, so ``sum_i B_i(u)`` collapses to 0
-instead of 1: partition of unity is silently broken.
+The O(p) ratio recurrence in ``_bernstein_point`` and the fused kernel
+``_evaluate_bezier_1d_core`` now branches on ``u > 0.5`` and runs from
+whichever endpoint keeps the seed term (``(1-u)^p`` or ``u^p``) bounded below
+by ``0.5^p``, using the symmetry ``B_i,p(u) = B_{p-i},p(1-u)``. Before the
+fix, the forward-only recurrence seeded from ``(1-u)^p`` underflowed to exact
+zero for ``u`` close enough to 1 at high degree, and every subsequent term (a
+positive multiple of the previous one) stayed zero: ``sum_i B_i(u)`` collapsed
+to 0 instead of 1.
+
+This module covers:
+    - Partition of unity across degrees and points spanning both recurrence
+      branches and their shared midpoint (float32 and float64).
+    - Agreement with an independent O(p^2) reference (corner-cutting
+      "AllBernstein", Piegl & Tiller A1.3), which never underflows because
+      every intermediate value is a convex combination weighted by ``u`` and
+      ``1-u`` rather than a ratio that can blow up.
+    - Symmetry between the forward branch (evaluated at ``u <= 0.5``) and the
+      mirrored branch (evaluated at ``1-u > 0.5``).
+    - Consistency between the 0th row of the derivative kernel
+      (``_bernstein_derivs_point``, an unaffected O(p^2) ``ndu``-table
+      recurrence) and the fixed value kernel.
+    - An end-to-end guard for the fused Bezier-evaluation kernel
+      (``_evaluate_bezier_1d_core``) against de Casteljau evaluation.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 import pytest
 
-from pantr.basis._basis_core import _bernstein_point
+from pantr.basis._basis_core import _bernstein_derivs_point, _bernstein_point
+from pantr.bezier._bezier_core import _evaluate_bezier_1d_core, _slice_bezier_1d_core
+
+DEGREES = [2, 5, 10, 20, 30, 64]
+
+_EPS64 = float(np.finfo(np.float64).eps)
+_EPS32 = float(np.finfo(np.float32).eps)
+
+# Points spanning both recurrence branches and their shared midpoint, plus the
+# near-1 region where the pre-fix forward recurrence underflows.
+_U64 = [0.0, 1e-17, 0.25, 0.5 - _EPS64, 0.5, 0.5 + _EPS64, 0.75, 1.0 - 1e-8, 1.0 - 1e-16, 1.0]
+_U32 = [0.0, 1e-7, 0.25, 0.5 - _EPS32, 0.5, 0.5 + _EPS32, 0.75, 1.0 - 1e-4, 1.0 - _EPS32, 1.0]
 
 
-@pytest.mark.xfail(
-    reason="issue #258: forward recurrence seed (1-u)**p underflows to exact 0.0 "
-    "for u this close to 1 at degree 30, so sum(B_i) collapses to 0 instead of 1",
-    strict=True,
-)
-def test_partition_of_unity_degree30_near_u1_regression() -> None:
-    """Partition of unity fails for degree 30 at u = 1 - 1e-16 (pre-fix)."""
-    degree = 30
-    u = 1.0 - 1e-16
-    out_row = np.empty(degree + 1, dtype=np.float64)
-    _bernstein_point(np.int32(degree), np.float64(u), out_row)
+def _eval_bernstein_row(n: int, u: float, dtype: npt.DTypeLike) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate the Layer-3 kernel `_bernstein_point` at one point."""
+    dt = np.dtype(dtype)
+    out_row = np.empty(n + 1, dtype=dt)
+    _bernstein_point(np.int32(n), dt.type(u), out_row)
+    return out_row
 
-    eps = np.finfo(np.float64).eps
-    assert abs(out_row.sum() - 1.0) <= 8 * degree * eps
+
+def _all_bernstein_reference(
+    n: int, u: float, dtype: npt.DTypeLike = np.float64
+) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate all degree-n Bernstein basis functions via corner-cutting (A1.3).
+
+    Independent O(n^2) reference (Piegl & Tiller, "AllBernstein"): every
+    intermediate value is a convex combination of already-computed entries
+    weighted by ``u`` and ``1 - u``, both in ``[0, 1]``, so there is no ratio
+    blow-up and hence no risk of the total-flush failure mode this module
+    guards against.
+    """
+    dt = np.dtype(dtype)
+    one = dt.type(1.0)
+    uu = dt.type(u)
+    u1 = one - uu
+
+    row = np.zeros(n + 1, dtype=dt)
+    row[0] = one
+    for j in range(1, n + 1):
+        saved = dt.type(0.0)
+        for k in range(j):
+            temp = row[k]
+            row[k] = saved + u1 * temp
+            saved = uu * temp
+        row[j] = saved
+    return row
+
+
+class TestPartitionOfUnity:
+    """Partition of unity must hold across both recurrence branches."""
+
+    @pytest.mark.parametrize("u", _U64, ids=lambda u: f"{u:.17g}")
+    @pytest.mark.parametrize("degree", DEGREES)
+    def test_float64(self, degree: int, u: float) -> None:
+        """Sum of Bernstein basis values stays within 8*p*eps of 1 (float64).
+
+        This is the fixed version of the regression covered by issue #258:
+        the (degree=30, u=1-1e-16) cell used to fail before the mirrored
+        recurrence was introduced.
+        """
+        row = _eval_bernstein_row(degree, u, np.float64)
+        assert abs(float(row.sum()) - 1.0) <= 8 * degree * _EPS64
+
+    @pytest.mark.parametrize("u", _U32, ids=lambda u: f"{u:.9g}")
+    @pytest.mark.parametrize("degree", DEGREES)
+    def test_float32(self, degree: int, u: float) -> None:
+        """Sum of Bernstein basis values stays within 8*p*eps of 1 (float32)."""
+        row = _eval_bernstein_row(degree, u, np.float32)
+        assert abs(float(row.sum()) - 1.0) <= 8 * degree * _EPS32
+
+
+class TestReferenceCrossCheck:
+    """Compare against the independent O(p^2) AllBernstein reference."""
+
+    @pytest.mark.parametrize("degree", DEGREES)
+    def test_matches_all_bernstein_reference(self, degree: int) -> None:
+        """Kernel values match the reference over a grid biased toward u=1.
+
+        The grid mixes uniform random points with a geometric sequence
+        approaching both endpoints, since uniform sampling in [0, 1] almost
+        never lands within the underflow-prone region near u=1 that this fix
+        targets.
+        """
+        rng = np.random.default_rng(1000 + degree)
+        uniform_pts = rng.uniform(0.0, 1.0, size=64)
+        near_boundary = np.concatenate(
+            [1.0 - np.geomspace(1e-16, 1e-2, 15), np.geomspace(1e-16, 1e-2, 15)]
+        )
+        pts = np.concatenate([uniform_pts, near_boundary, [0.0, 0.5, 1.0]])
+
+        for u in pts:
+            row = _eval_bernstein_row(degree, float(u), np.float64)
+            ref = _all_bernstein_reference(degree, float(u))
+            np.testing.assert_allclose(row, ref, rtol=1e-14, atol=1e-14)
+
+
+class TestForwardMirroredSymmetry:
+    """Forward branch at u must match the mirrored branch at 1-u, reversed."""
+
+    @pytest.mark.parametrize("degree", DEGREES)
+    def test_symmetry(self, degree: int) -> None:
+        """B_i(u) (forward branch) equals B_{p-i}(1-u) (mirrored branch).
+
+        Values are compared within ``p*eps``, not bitwise: the two branches
+        accumulate the same mathematical quantity through different sequences
+        of floating-point multiplications, so rounding differs by up to a few
+        ULPs per step.
+        """
+        rng = np.random.default_rng(2000 + degree)
+        # u < 0.5 strictly, so `u` takes the forward branch and `1 - u` (> 0.5)
+        # takes the mirrored branch.
+        us = np.concatenate([rng.uniform(0.0, 0.5, size=20), [1e-17, 0.25]])
+        for u in us:
+            u = float(u)
+            row_forward = _eval_bernstein_row(degree, u, np.float64)
+            row_mirrored = _eval_bernstein_row(degree, 1.0 - u, np.float64)
+            np.testing.assert_allclose(
+                row_forward,
+                row_mirrored[::-1],
+                rtol=degree * _EPS64,
+                atol=degree * _EPS64,
+            )
+
+
+class TestDerivativeConsistency:
+    """The unaffected O(p^2) derivative kernel must agree with the fixed kernel."""
+
+    @pytest.mark.parametrize("u", _U64, ids=lambda u: f"{u:.17g}")
+    @pytest.mark.parametrize("degree", DEGREES)
+    def test_row0_matches_value_kernel(self, degree: int, u: float) -> None:
+        """Row 0 of `_bernstein_derivs_point` (ndu table) matches `_bernstein_point`."""
+        row = _eval_bernstein_row(degree, u, np.float64)
+
+        n_deriv = 2
+        out_pt = np.empty((n_deriv + 1, degree + 1), dtype=np.float64)
+        _bernstein_derivs_point(np.int32(degree), np.float64(u), n_deriv, out_pt)
+
+        np.testing.assert_allclose(out_pt[0, :], row, rtol=1e-13, atol=1e-13)
+
+
+class TestFusedBezierKernel:
+    """End-to-end guard for the fused evaluation kernel `_evaluate_bezier_1d_core`."""
+
+    def test_degree_30_near_u1_matches_de_casteljau(self) -> None:
+        """Random-control-point degree-30 Bezier at u=1-1e-16 matches de Casteljau.
+
+        `_slice_bezier_1d_core` is a stable de Casteljau triangular reduction
+        (no ratio recurrence, hence no underflow risk) used here as the
+        reference for the fused kernel under test.
+        """
+        degree = 30
+        rank = 4
+        u = 1.0 - 1e-16
+        rng = np.random.default_rng(42)
+        ctrl = rng.normal(size=(degree + 1, rank))
+
+        out_fused = np.empty((1, rank), dtype=np.float64)
+        _evaluate_bezier_1d_core(ctrl, np.array([u]), out_fused)
+
+        out_ref = np.empty(rank, dtype=np.float64)
+        _slice_bezier_1d_core(ctrl, u, out_ref)
+
+        np.testing.assert_allclose(out_fused[0], out_ref, rtol=1e-10, atol=1e-10)

--- a/tests/test_bernstein_underflow.py
+++ b/tests/test_bernstein_underflow.py
@@ -1,0 +1,31 @@
+"""Regression tests for Bernstein ratio-recurrence underflow near u=1 (issue #258).
+
+The O(p) ratio recurrence in ``_bernstein_point`` seeds the forward pass from
+``B_0 = (1 - u)^p``, which underflows to exact zero for ``u`` close enough to
+1 at high degree. Once the seed flushes, every subsequent term (a positive
+multiple of the previous one) stays zero, so ``sum_i B_i(u)`` collapses to 0
+instead of 1: partition of unity is silently broken.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.basis._basis_core import _bernstein_point
+
+
+@pytest.mark.xfail(
+    reason="issue #258: forward recurrence seed (1-u)**p underflows to exact 0.0 "
+    "for u this close to 1 at degree 30, so sum(B_i) collapses to 0 instead of 1",
+    strict=True,
+)
+def test_partition_of_unity_degree30_near_u1_regression() -> None:
+    """Partition of unity fails for degree 30 at u = 1 - 1e-16 (pre-fix)."""
+    degree = 30
+    u = 1.0 - 1e-16
+    out_row = np.empty(degree + 1, dtype=np.float64)
+    _bernstein_point(np.int32(degree), np.float64(u), out_row)
+
+    eps = np.finfo(np.float64).eps
+    assert abs(out_row.sum() - 1.0) <= 8 * degree * eps


### PR DESCRIPTION
## Summary

- Fixes #258: the O(p) Bernstein ratio recurrence in `_bernstein_point` (`src/pantr/basis/_basis_core.py`) seeded from `(1-u)^p`, which underflows to exact `0.0` for `u` close enough to 1 at high degree (`p >= 21` at `u = 1 - 1e-16`). Once the seed flushes, every subsequent term (a positive multiple of the previous one) stays zero, so `sum_i B_i(u)` collapses to 0 instead of 1 — partition of unity silently breaks.
- Fix: branch on `u > 0.5` and run the recurrence from whichever endpoint keeps the seed (`(1-u)^p` or `u^p`) bounded below by `0.5^p`, using the symmetry `B_i,p(u) = B_{p-i,p}(1-u)`. The mirrored branch reuses the *ascending* forward-style loop (seed `u^p`, ratio `(1-u)/u`) rather than a genuinely descending one, then reverses the row in place — a literal descending-write implementation measured 20-45% slower under this Numba/LLVM version (decreasing-index stores don't vectorize the same way).
- Same fix applied to the fused kernel `_evaluate_bezier_1d_core` (`src/pantr/bezier/_bezier_core.py`), which contracts Bernstein values with control points in one pass. There the mirrored branch avoids the reversal entirely by contracting each ascending term with a *reverse-indexed* control point (`ctrl[p - i, :]`), since the value is consumed immediately rather than stored.
- **Performance-critical addition**: introducing any per-point branch measurably regressed the explicitly benchmark-gated kernel `_tabulate_Bernstein_basis_1D_core` at the realistic degrees (p=3, p=10) where the original bug can never actually occur (proved analytically and empirically: float64 is safe up to degree 20, float32 up to degree 6). Added `_bernstein_point_no_mirror` — bit-identical to the pre-fix recurrence — and a one-time-per-batch-call (not per-point) degree/dtype dispatch in `_tabulate_Bernstein_basis_1D_core` / `_tabulate_Bernstein_basis_1D_serial_core`, so degrees below the proven-safe bound pay zero overhead for the mirror-branch machinery.
- `u == 1.0` no longer needs its own special case in `_bernstein_point`: the mirrored branch resolves it exactly (`u^p == 1.0`, then every step multiplies by `(1-u)/u == 0.0`).

## Test plan

- [x] `tests/test_bernstein_underflow.py` (new): partition of unity across degrees {2,5,10,20,30,64} × u spanning both branches and the near-1 underflow region (float32 + float64); cross-check against an independent O(p²) "AllBernstein" corner-cutting reference; forward/mirrored symmetry; consistency with the unaffected O(p²) derivative kernel; fused-Bezier-kernel end-to-end guard (single point and a multi-point batch mixing both branches) against de Casteljau evaluation; direct pin of `_bernstein_point_no_mirror`'s bit-identical/near-ULP contract; boundary test for the degree-gate dispatch (at and one above the safe-degree bound, through both the parallel and serial tabulate kernels, for both dtypes).
- [x] First commit added the (degree=30, u=1-1e-16) case as an `xfail(strict=True)` regression before any fix, per repo convention; later folded into the full parametrized suite once fixed.
- [x] Full existing suite passes unchanged: `pytest --no-cov` → 4112 passed, 19 skipped, 1 failed. The 1 failure (`test_mpi.py::test_pantr_toplevel_does_not_import_mpi`) is pre-existing and unrelated — confirmed by reproducing it identically on a completely fresh, unmodified scratch clone of `main` (subprocess-based test fails because `pantr` isn't pip-installed for subprocess use in this sandbox).
- [x] `ruff check`, `ruff format --check`, `mypy --config-file mypy.ini src tests`, `lint-imports` all clean.
- [x] Coverage run (`NUMBA_DISABLE_JIT=1 pytest --cov`) passes with the same pre-existing failure only; `coverage.xml` generated.
- [x] Docs build: `make docs SPHINXOPTS="-W --keep-going -j auto"` hits a pre-existing sandboxed-environment VTK/OpenGL segfault when Sphinx-Gallery executes the tutorial scripts (confirmed reproducing identically on a pristine, unmodified `main` clone — not caused by this change). With gallery execution skipped (`-D plot_gallery=0`, isolating the actual docstring/API-reference content this PR touches from that unrelated tutorial-rendering issue), the build succeeds with **0 warnings**.
- [x] Benchmark gate: `_tabulate_Bernstein_basis_1D_core`, 10⁷ points, p=3 and p=10, 1 thread, after `wait_for_jit_warmup()`, min-of-N, measured via interleaved A/B against `main` to control for sandbox noise (system load varied run-to-run by up to ~20%) — consistently within ~0-3% of baseline once the degree-gate dispatch was added (a naive always-mirrored implementation regressed ~20% before that fix).

## Review notes

Two rounds of automated review (`code-reviewer` + `pr-test-analyzer`) were run against the diff and all Critical/Important findings were fixed:
- Round 1: mypy ambiguous-overload issue, ruff `PLR2004`/`PLR0912`/`PLW2901` — all fixed.
- Round 2: a genuine bug in a test I'd written (asserted bit-identity between the mirrored and no-mirror paths even where they take different code paths for `u > 0.5`, which are only equal to within a few ULPs, not bitwise) — fixed by splitting into a bitwise-exact assertion where the code paths are textually identical and a ULP-tolerant one where they aren't; also flagged that `_basis_core._warmup_numba_functions()` is dead code (never invoked from `pantr/__init__.py`) — confirmed this is pre-existing and intentional (that module's `parallel=True` kernels are deliberately excluded from the background warmup thread to avoid a known Numba concurrent-compilation crash), documented rather than "fixed" since wiring it in would reintroduce that exact crash risk.

No unaddressed Suggestions remain from either round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)