### PR TITLE
feat(change_basis): legendre-cardinal pair and cardinal-dual Legendre coefficients

### DIFF
--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -20,7 +20,12 @@ from math import comb
 import numpy as np
 import numpy.typing as npt
 
-from .basis import LagrangeVariant, tabulate_bernstein_1d, tabulate_cardinal_bspline_1d
+from .basis import (
+    LagrangeVariant,
+    tabulate_bernstein_1d,
+    tabulate_cardinal_bspline_1d,
+    tabulate_legendre_1d,
+)
 from .basis._basis_lagrange import _get_lagrange_points
 from .basis._basis_utils import (
     _allocate_or_validate_out,
@@ -288,6 +293,190 @@ def compute_cardinal_to_bernstein_1d(
     )
 
 
+def compute_legendre_to_cardinal_1d(
+    degree: int,
+    dtype: npt.DTypeLike = np.float64,
+    out: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Create transformation matrix from orthonormal shifted Legendre to cardinal B-spline basis.
+
+    The Legendre basis is the orthonormal shifted Legendre basis on ``[0, 1]``
+    (see :func:`~pantr.basis.tabulate_legendre_1d`), so row ``j`` of the result
+    holds the coefficients of the ``j``-th cardinal B-spline in that basis.
+
+    The quadrature is exact: ``degree + 1`` Gauss-Legendre points integrate
+    polynomials up to degree ``2 * degree + 1`` exactly, while every inner
+    product formed here is between two polynomials of degree ``degree`` and so
+    has degree ``2 * degree``. Consequently the Legendre Gram matrix is the
+    identity up to round-off, and the returned matrix carries no quadrature
+    error beyond floating-point round-off.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative.
+        dtype (npt.DTypeLike): Floating point type for the output matrix.
+            Defaults to np.float64.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
+            where the result will be stored. If None, a new array is allocated.
+            Must have shape (degree+1, degree+1) and dtype matching the `dtype` parameter
+            if provided. This follows NumPy's style for output arrays. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix A such
+            that ``A @ [Legendre values] = [cardinal values]``. If `out` was provided,
+            returns the same array.
+
+    Raises:
+        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
+            provided and has incorrect shape or dtype.
+
+    Example:
+        >>> import numpy as np
+        >>> A = compute_legendre_to_cardinal_1d(1)
+        >>> np.allclose(A, [[0.5, -0.28867513], [0.5, 0.28867513]])
+        True
+    """
+    if degree < 0:
+        raise ValueError("Degree must be non-negative")
+    out = _prepare_square_out(degree, dtype, out)
+
+    return _compute_change_basis_1D(
+        new_basis_eval=functools.partial(tabulate_legendre_1d, degree),
+        old_basis_eval=functools.partial(tabulate_cardinal_bspline_1d, degree),
+        n_quad_pts=degree + 1,
+        dtype=dtype,
+        out=out,
+    )
+
+
+def compute_cardinal_to_legendre_1d(
+    degree: int,
+    dtype: npt.DTypeLike = np.float64,
+    out: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Create transformation matrix from cardinal B-spline to orthonormal shifted Legendre basis.
+
+    The inverse direction of :func:`compute_legendre_to_cardinal_1d`: with ``A``
+    from that function, this returns ``W`` solving ``A @ W = I``, computed by one
+    LU solve against the identity (:func:`numpy.linalg.solve`). No explicit
+    inverse is formed.
+
+    Note:
+        A second Gram projection -- swapping the two evaluators and solving with
+        the *cardinal* Gram matrix -- is the obvious alternative and is the wrong
+        one. It is equivalent in exact arithmetic, but the cardinal Gram matrix
+        satisfies $\kappa(G) = \kappa(A)^2$ (verified numerically to three digits
+        for degrees 0-7; at degree 8 it saturates against $1/\varepsilon$), so it
+        loses twice as many digits. Measured round-trip error at degree 8 in
+        float64: ``5e-6`` via the Gram projection against ``5e-10`` here. The
+        forward direction does not face this because *its* Gram matrix is the
+        Legendre one, which is the identity.
+
+    Warning:
+        The cardinal-to-Legendre map is intrinsically ill-conditioned at high
+        degree -- $\kappa(A)$ is ``1.1e3`` at degree 4 and ``3.0e8`` at degree 8
+        -- so the attainable accuracy of ``W``, by any algorithm, is bounded by
+        roughly $\kappa(A)\varepsilon$. In float64 the round trip holds to about
+        ``1e-13`` through degree 6 and degrades to ``5e-10`` at degree 8; in
+        float32 it is meaningless beyond degree 4. This is a property of the
+        bases, not of the implementation.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative.
+        dtype (npt.DTypeLike): Floating point type for the output matrix.
+            Defaults to np.float64.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
+            where the result will be stored. If None, a new array is allocated.
+            Must have shape (degree+1, degree+1) and dtype matching the `dtype` parameter
+            if provided. This follows NumPy's style for output arrays. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix W such
+            that ``W @ [cardinal values] = [Legendre values]``. If `out` was provided,
+            returns the same array.
+
+    Raises:
+        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
+            provided and has incorrect shape or dtype.
+
+    Example:
+        >>> import numpy as np
+        >>> A = compute_legendre_to_cardinal_1d(3)
+        >>> W = compute_cardinal_to_legendre_1d(3)
+        >>> np.allclose(W @ A, np.eye(4), atol=1e-13)
+        True
+    """
+    if degree < 0:
+        raise ValueError("Degree must be non-negative")
+    out = _prepare_square_out(degree, dtype, out)
+
+    forward = compute_legendre_to_cardinal_1d(degree, dtype)
+    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
+    return out
+
+
+def compute_cardinal_dual_legendre_coeffs_1d(
+    degree: int,
+    dtype: npt.DTypeLike = np.float64,
+    out: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> npt.NDArray[np.float32 | np.float64]:
+    r"""Create the cardinal-dual $L^2$ functionals, expressed in the Legendre basis.
+
+    Row ``i`` holds the coefficients, in the orthonormal shifted Legendre basis,
+    of the dual function $D_i$ biorthogonal to the cardinal B-spline basis:
+
+    \[
+    \int_0^1 D_i(x) B_{p,j}(x) \, dx = \delta_{ij}
+    \]
+
+    Derivation: write the cardinal basis in the Legendre basis as
+    ``cardinal = A @ legendre`` with ``A`` from
+    :func:`compute_legendre_to_cardinal_1d`, and let $D_i = \sum_k T_{ik}
+    \tilde{p}_k$. Because the Legendre basis is orthonormal,
+    $\int D_i B_j = \sum_k T_{ik} A_{jk} = (A T^\mathsf{T})_{ji}$, so
+    biorthogonality holds exactly when $T^\mathsf{T} = A^{-1}$, i.e.
+    $T = A^{-\mathsf{T}}$. No inverse is formed: since
+    :func:`compute_cardinal_to_legendre_1d` returns ``W`` with ``W @ A = I`` from
+    an LU solve, the result is simply ``W.T``.
+
+    Warning:
+        Biorthogonality is limited by the same conditioning that bounds ``W`` --
+        see the warning on :func:`compute_cardinal_to_legendre_1d`. In float64
+        $\int D_i B_j = \delta_{ij}$ holds to about ``1e-13`` through degree 6 and
+        to ``5e-10`` at degree 8.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative.
+        dtype (npt.DTypeLike): Floating point type for the output matrix.
+            Defaults to np.float64.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
+            where the result will be stored. If None, a new array is allocated.
+            Must have shape (degree+1, degree+1) and dtype matching the `dtype` parameter
+            if provided. This follows NumPy's style for output arrays. Defaults to None.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) matrix whose row ``i``
+            holds the Legendre coefficients of the dual function $D_i$. If `out` was
+            provided, returns the same array.
+
+    Raises:
+        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
+            provided and has incorrect shape or dtype.
+
+    Example:
+        >>> import numpy as np
+        >>> D = compute_cardinal_dual_legendre_coeffs_1d(2)
+        >>> W = compute_cardinal_to_legendre_1d(2)
+        >>> np.allclose(D, W.T)
+        True
+    """
+    if degree < 0:
+        raise ValueError("Degree must be non-negative")
+    out = _prepare_square_out(degree, dtype, out)
+
+    out[:] = compute_cardinal_to_legendre_1d(degree, dtype).T
+    return out
+
+
 def compute_monomial_to_bernstein_1d(
     degree: int,
     dtype: npt.DTypeLike = np.float64,
@@ -398,10 +587,73 @@ def _cached_cardinal_to_bernstein_matrix(
     return mat
 
 
+@functools.lru_cache(maxsize=64)
+def _cached_legendre_to_cardinal_matrix(
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return a cached, read-only Legendre-to-cardinal-B-spline change-of-basis matrix.
+
+    This is the hot-path counterpart of
+    :func:`compute_legendre_to_cardinal_1d`.  Because the matrix depends only on
+    ``(degree, dtype)`` — never on the knot vector — it is safe to share a
+    single immutable copy across all calls with matching arguments.
+
+    The returned array has ``writeable=False`` to guard the cached copy against
+    accidental in-place mutation.  NumPy's ``matmul`` and ``@`` operator accept
+    read-only arrays as non-output arguments, so callers can use the matrix
+    directly with :func:`numpy.matmul`.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (np.dtype): Floating-point dtype (``float32`` or ``float64``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Read-only ``(degree+1, degree+1)``
+            transformation matrix such that ``A @ legendre_values = cardinal_values``.
+    """
+    mat = compute_legendre_to_cardinal_1d(degree, dtype)
+    mat.flags.writeable = False
+    return mat
+
+
+@functools.lru_cache(maxsize=64)
+def _cached_cardinal_to_legendre_matrix(
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Return a cached, read-only cardinal-B-spline-to-Legendre change-of-basis matrix.
+
+    This is the hot-path counterpart of
+    :func:`compute_cardinal_to_legendre_1d`.  Because the matrix depends only on
+    ``(degree, dtype)`` — never on the knot vector — it is safe to share a
+    single immutable copy across all calls with matching arguments.
+
+    The returned array has ``writeable=False`` to guard the cached copy against
+    accidental in-place mutation.  NumPy's ``matmul`` and ``@`` operator accept
+    read-only arrays as non-output arguments, so callers can use the matrix
+    directly with :func:`numpy.matmul`.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (np.dtype): Floating-point dtype (``float32`` or ``float64``).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Read-only ``(degree+1, degree+1)``
+            transformation matrix such that ``W @ cardinal_values = legendre_values``.
+    """
+    mat = compute_cardinal_to_legendre_1d(degree, dtype)
+    mat.flags.writeable = False
+    return mat
+
+
 __all__ = [
     "compute_bernstein_to_cardinal_1d",
     "compute_bernstein_to_lagrange_1d",
+    "compute_cardinal_dual_legendre_coeffs_1d",
     "compute_cardinal_to_bernstein_1d",
+    "compute_cardinal_to_legendre_1d",
     "compute_lagrange_to_bernstein_1d",
+    "compute_legendre_to_cardinal_1d",
     "compute_monomial_to_bernstein_1d",
 ]

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -6,9 +6,11 @@ bases.
 
 Architecturally, this module serves as the **bridge between different basis types**,
 providing pure mathematical functions to compute the exact $(degree+1, degree+1)$
-transformation matrices (e.g., $M$ such that $new\\_basis(x) = M @ old\\_basis(x)$)
-without tying the dense numerical quadrature logic directly into the core Spline
-space objects.
+transformation matrices without tying the dense numerical quadrature logic directly
+into the core Spline space objects.
+
+Every public builder is named ``compute_A_to_B_1d`` and returns the matrix $M$ with
+$M \\, [A\\ values](x) = [B\\ values](x)$.
 """
 
 import functools
@@ -151,7 +153,12 @@ def _compute_change_basis_1D(
     """Create a change of basis operator using numerical quadrature.
 
     This function computes the transformation matrix M that satisfies:
-        new_basis(x) = M @ old_basis(x)
+        old_basis(x) = M @ new_basis(x)
+
+    That is, row ``i`` of ``M`` holds the coefficients of the ``i``-th *old* basis
+    function expanded in the *new* basis. Note the direction: the public
+    ``compute_A_to_B_1d`` wrappers document ``M @ [A values] = [B values]`` and
+    therefore pass ``new_basis_eval=A``, ``old_basis_eval=B``.
 
     The matrix is computed by solving the system C = G M^T where:
     - G is the Gram matrix of the new basis

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -1,6 +1,7 @@
 """Tests for change_basis_1D module."""
 
 import functools
+from collections.abc import Callable
 
 import numpy as np
 import numpy.typing as npt
@@ -11,17 +12,80 @@ from pantr.basis import (
     tabulate_bernstein_1d,
     tabulate_cardinal_bspline_1d,
     tabulate_lagrange_1d,
+    tabulate_legendre_1d,
 )
 from pantr.change_basis import (
     _cached_cardinal_to_bernstein_matrix,
+    _cached_cardinal_to_legendre_matrix,
     _cached_lagrange_to_bernstein_matrix,
+    _cached_legendre_to_cardinal_matrix,
     _compute_change_basis_1D,
     compute_bernstein_to_cardinal_1d,
     compute_bernstein_to_lagrange_1d,
+    compute_cardinal_dual_legendre_coeffs_1d,
     compute_cardinal_to_bernstein_1d,
+    compute_cardinal_to_legendre_1d,
     compute_lagrange_to_bernstein_1d,
+    compute_legendre_to_cardinal_1d,
     compute_monomial_to_bernstein_1d,
 )
+from pantr.quad import get_gauss_legendre_1d
+from pantr.tolerance import get_machine_epsilon
+
+_COND_SAFETY_FACTOR = 64
+"""
+Safety factor multiplying the first-order error bound ``cond(A) * eps``.
+
+The bound itself is the standard one for a linear solve. The factor covers what it
+does not model: the biorthogonality check contracts the duals against a quadrature
+rule, so its error accumulates over ``2 * degree + 2`` points on top of the solve.
+Measured margins with this factor range from 6x (degree 8, biorthogonality) to
+several hundred (low degrees), i.e. it is never looser than needed by more than two
+orders and never tighter than the phenomenon.
+"""
+
+_ROUNDOFF_FACTOR = 64
+"""
+Multiple of machine epsilon for quantities that carry no conditioning penalty.
+
+Applies to the well-conditioned direction (Legendre to cardinal) and to the
+partition-of-unity identity, both of which are built on the Legendre Gram matrix,
+which is the identity. Measured errors are flat in degree at 2-4 ulp, so a fixed
+multiple of epsilon is the right form; 64 leaves ~32x margin.
+"""
+
+_COMPOSED_ROUNDOFF_FACTOR = 256
+"""
+Multiple of machine epsilon for an identity chaining two changes of basis.
+
+Used by the consistency check against the Bernstein pair, whose right-hand side is a
+product of two separately-computed matrices. Measured error grows to 2.7e-15 at
+degree 8, so the single-map factor of 64 would leave only 5x; 256 restores ~21x.
+"""
+
+
+def _conditioning_atol(degree: int, dtype: npt.DTypeLike = np.float64) -> float:
+    """Return the attainable accuracy for inverting the Legendre-to-cardinal map.
+
+    The cardinal-to-Legendre direction requires solving with a matrix whose
+    condition number grows steeply with degree (``1.1e3`` at degree 4, ``3.0e8`` at
+    degree 8), so no algorithm can do better than roughly ``cond(A) * eps``. Tests
+    of that direction, of the duals built from it, and of biorthogonality are all
+    bounded by this quantity rather than by a flat tolerance.
+
+    The condition number is always taken from the float64 matrix: it is a property
+    of the two bases, not of the dtype the result is stored in.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Dtype whose machine epsilon sets the noise floor.
+            Defaults to np.float64.
+
+    Returns:
+        float: Absolute tolerance for identities involving the inverse map.
+    """
+    cond = float(np.linalg.cond(compute_legendre_to_cardinal_1d(degree)))
+    return _COND_SAFETY_FACTOR * cond * get_machine_epsilon(dtype)
 
 
 class TestLagrangeToBernsteinBasisOperator:
@@ -620,3 +684,211 @@ class TestMonomialToBernsteinBasisOperator:
         p_bern = tabulate_bernstein_1d(degree, tt) @ bern_coeffs
 
         np.testing.assert_array_almost_equal(p_bern, p_mono)
+
+
+class TestLegendreCardinalBasisOperators:
+    """Test the Legendre<->cardinal pair and the cardinal-dual Legendre coefficients."""
+
+    def test_degree_one_closed_form(self) -> None:
+        """Degree 1 matches the closed form obtained by integrating by hand.
+
+        With ``B_0 = 1 - x``, ``B_1 = x`` and the orthonormal shifted Legendre pair
+        ``p0 = 1``, ``p1 = sqrt(3) (2x - 1)``, the coefficient of ``p1`` in ``B_0``
+        is ``int_0^1 (1-x) sqrt(3) (2x-1) dx = -sqrt(3)/6 = -1/(2 sqrt(3))``.
+        """
+        expected = np.array(
+            [
+                [0.5, -1.0 / (2.0 * np.sqrt(3.0))],
+                [0.5, 1.0 / (2.0 * np.sqrt(3.0))],
+            ]
+        )
+        np.testing.assert_allclose(compute_legendre_to_cardinal_1d(1), expected, atol=1e-15)
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_forward_map_reproduces_cardinal_basis(self, degree: int) -> None:
+        """``A @ legendre(x)`` must equal ``cardinal(x)`` at arbitrary points, not just nodes.
+
+        This is the property the matrix is defined by, checked away from the
+        quadrature points used to build it, so a rule that happened to be exact only
+        at its own nodes would not pass.
+        """
+        rng = np.random.default_rng(20260813 + degree)
+        pts = rng.random(50)
+
+        result = compute_legendre_to_cardinal_1d(degree) @ tabulate_legendre_1d(degree, pts).T
+
+        np.testing.assert_allclose(
+            result,
+            tabulate_cardinal_bspline_1d(degree, pts).T,
+            atol=_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
+        )
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_roundtrip(self, degree: int) -> None:
+        """Both products of the pair must be the identity, to the attainable accuracy.
+
+        The tolerance is derived rather than flat: the inverse direction cannot beat
+        ``cond(A) * eps``, which spans ten orders of magnitude across these degrees.
+        """
+        forward = compute_legendre_to_cardinal_1d(degree)
+        inverse = compute_cardinal_to_legendre_1d(degree)
+        identity = np.eye(degree + 1)
+        atol = _conditioning_atol(degree)
+
+        np.testing.assert_allclose(inverse @ forward, identity, atol=atol)
+        np.testing.assert_allclose(forward @ inverse, identity, atol=atol)
+
+    @pytest.mark.parametrize("degree", range(5))
+    def test_roundtrip_float32(self, degree: int) -> None:
+        """The pair round-trips in float32 over the degrees where the bound is meaningful.
+
+        Beyond degree 5 the derived bound ``cond(A) * eps32`` exceeds 0.1 and the
+        assertion would be vacuous, so those degrees are deliberately not claimed.
+        """
+        forward = compute_legendre_to_cardinal_1d(degree, dtype=np.float32)
+        inverse = compute_cardinal_to_legendre_1d(degree, dtype=np.float32)
+        assert forward.dtype == np.float32
+        assert inverse.dtype == np.float32
+
+        np.testing.assert_allclose(
+            inverse @ forward,
+            np.eye(degree + 1, dtype=np.float32),
+            atol=_conditioning_atol(degree, np.float32),
+        )
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_partition_of_unity(self, degree: int) -> None:
+        """Column sums of ``A`` must be ``[1, 0, ..., 0]``.
+
+        The cardinal basis sums to 1, which is exactly the first orthonormal
+        Legendre polynomial, so every higher coefficient must cancel across the
+        rows. This direction carries no conditioning penalty.
+        """
+        expected = np.zeros(degree + 1)
+        expected[0] = 1.0
+
+        np.testing.assert_allclose(
+            compute_legendre_to_cardinal_1d(degree).sum(axis=0),
+            expected,
+            atol=_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
+        )
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_dual_biorthogonality(self, degree: int) -> None:
+        """The duals must satisfy ``int D_i B_j = delta_ij``, by independent quadrature.
+
+        Integrated with a ``2 * degree + 2`` point Gauss-Legendre rule, which is
+        exact for the degree-``2 * degree`` products and is not the rule used to
+        build the matrices.
+        """
+        duals = compute_cardinal_dual_legendre_coeffs_1d(degree)
+        pts, weights = get_gauss_legendre_1d(2 * degree + 2)
+        cardinal = tabulate_cardinal_bspline_1d(degree, pts)
+        legendre = tabulate_legendre_1d(degree, pts)
+
+        gram = (duals @ (legendre.T * weights)) @ cardinal
+
+        np.testing.assert_allclose(gram, np.eye(degree + 1), atol=_conditioning_atol(degree))
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_dual_integrates_to_one(self, degree: int) -> None:
+        """Every dual must integrate to 1 over the unit interval.
+
+        Summing biorthogonality over ``j`` gives ``int D_i (sum_j B_j) = 1``, and the
+        cardinal basis is a partition of unity, so ``int D_i = 1``. Because the
+        Legendre basis is orthonormal that integral is the ``p0`` coefficient, i.e.
+        the first column, which must therefore be all ones.
+        """
+        duals = compute_cardinal_dual_legendre_coeffs_1d(degree)
+
+        np.testing.assert_allclose(
+            duals[:, 0], np.ones(degree + 1), atol=_conditioning_atol(degree)
+        )
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_dual_equals_inverse_transpose(self, degree: int) -> None:
+        """The duals must be exactly the transpose of the cardinal-to-Legendre matrix."""
+        np.testing.assert_array_equal(
+            compute_cardinal_dual_legendre_coeffs_1d(degree),
+            compute_cardinal_to_legendre_1d(degree).T,
+        )
+
+    @pytest.mark.parametrize("degree", range(9))
+    def test_consistency_with_bernstein_pair(self, degree: int) -> None:
+        """``A_lc`` must equal ``A_bc @ M_lb``, routing through the Bernstein basis.
+
+        An independent construction of the same matrix: going Legendre to Bernstein
+        to cardinal must land where going Legendre to cardinal directly does.
+        """
+        legendre_to_bernstein = _compute_change_basis_1D(
+            new_basis_eval=functools.partial(tabulate_legendre_1d, degree),
+            old_basis_eval=functools.partial(tabulate_bernstein_1d, degree),
+            n_quad_pts=degree + 1,
+        )
+
+        np.testing.assert_allclose(
+            compute_legendre_to_cardinal_1d(degree),
+            compute_bernstein_to_cardinal_1d(degree) @ legendre_to_bernstein,
+            atol=_COMPOSED_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
+        )
+
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            compute_legendre_to_cardinal_1d,
+            compute_cardinal_to_legendre_1d,
+            compute_cardinal_dual_legendre_coeffs_1d,
+        ],
+    )
+    def test_negative_degree_error(
+        self,
+        builder: Callable[..., npt.NDArray[np.float32 | np.float64]],
+    ) -> None:
+        """Degree 0 is allowed but a negative degree is rejected."""
+        assert builder(0).shape == (1, 1)
+        with pytest.raises(ValueError, match="Degree must be non-negative"):
+            builder(-1)
+
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            compute_legendre_to_cardinal_1d,
+            compute_cardinal_to_legendre_1d,
+            compute_cardinal_dual_legendre_coeffs_1d,
+        ],
+    )
+    def test_out_and_dtype_validation(
+        self,
+        builder: Callable[..., npt.NDArray[np.float32 | np.float64]],
+    ) -> None:
+        """A provided ``out`` is returned and filled; a bad one is rejected."""
+        degree = 3
+        out = np.empty((degree + 1, degree + 1), dtype=np.float64)
+        result = builder(degree, np.float64, out)
+        assert result is out
+        np.testing.assert_allclose(result, builder(degree))
+
+        with pytest.raises(ValueError, match="dtype must be float32 or float64"):
+            builder(degree, np.int32)
+        with pytest.raises(ValueError):
+            builder(degree, np.float64, np.empty((degree, degree), dtype=np.float64))
+        with pytest.raises(ValueError):
+            builder(degree, np.float64, np.empty((degree + 1, degree + 1), dtype=np.float32))
+
+        readonly = np.empty((degree + 1, degree + 1), dtype=np.float64)
+        readonly.flags.writeable = False
+        with pytest.raises(ValueError):
+            builder(degree, np.float64, readonly)
+
+    def test_cached_variants_are_frozen_and_shared(self) -> None:
+        """The cached matrices are read-only, shared per key, and equal to the builders."""
+        for cached, builder in (
+            (_cached_legendre_to_cardinal_matrix, compute_legendre_to_cardinal_1d),
+            (_cached_cardinal_to_legendre_matrix, compute_cardinal_to_legendre_1d),
+        ):
+            first = cached(3, np.dtype(np.float64))
+            assert first is cached(3, np.dtype(np.float64))
+            assert not first.flags.writeable
+            np.testing.assert_array_equal(first, builder(3))
+            with pytest.raises(ValueError):
+                first[0, 0] = 0.0


### PR DESCRIPTION
## Summary

Adds the Legendre↔cardinal change-of-basis pair and the cardinal-dual Legendre
coefficients that tigarx v2 needs for its basix custom element, plus the two cached
read-only variants mirroring the existing Bernstein pair. Purely additive.

- `compute_legendre_to_cardinal_1d` → `A` with `A @ legendre = cardinal`
- `compute_cardinal_to_legendre_1d` → `W` with `W @ A = I`
- `compute_cardinal_dual_legendre_coeffs_1d` → duals with `∫ D_i B_j = δ_ij`, as `W.T`

## Deviation from the ticket

**The ticket's prescribed method and its promised tolerances are incompatible, so I
changed the method.** Flagging it explicitly because it is a deliberate departure.

The ticket asked for the inverse direction to be a second Gram projection with the
evaluators swapped, and promised a round trip accurate to `1e-13` across degrees 0–8.
Measured, `cond(G_cardinal) = cond(A)²` — exactly, to three digits, for degrees 0–7;
at degree 8 `cond(G)` hits `8.4e16` and saturates against `1/ε`. Solving with that
Gram matrix loses twice as many digits as solving with `A` directly:

| degree | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|
| Gram projection (ticket) | 8.4e-13 | 1.7e-10 | 1.8e-09 | 1.5e-06 | 5.3e-06 |
| LU solve on `A` (here) | 1.9e-14 | 1.1e-13 | 2.6e-13 | 1.5e-11 | 4.9e-10 |

The forward direction is unaffected either way — flat at `2e-16` for every degree —
because *its* Gram matrix is the Legendre one, which is the identity. That asymmetry
is the whole story, and it is now documented on the functions themselves.

`np.linalg.solve(A, I)` is still a solve, so the ticket's "never an explicit `inv`"
constraint is honored.

**Second point, and the less comfortable one:** even with the better route, `1e-13` is
unreachable at degrees 7–8 *by any algorithm*. `cond(A)` is `3.0e8` at degree 8, so the
inverse is not determined to that accuracy in float64 at all. The ticket's "second
exact projection" is exact in exact arithmetic and not in floating point. Rather than
claim a bound they cannot hold, the functions document the attainable accuracy per
degree and warn that float32 is meaningless past degree 4.

## Tolerances

Tests derive their tolerances from `cond(A) · eps` rather than asserting a flat number,
with a fixed safety factor of 64 documented at its definition (measured margins: 6× at
degree 8 biorthogonality, several hundred at low degrees). The well-conditioned
identities keep a flat multiple of epsilon, since their measured error is flat in degree
at 2–4 ulp.

## Test plan

75 new cases, all passing:

- [x] Degree 1 against a closed form integrated by hand (`∫₀¹(1-x)√3(2x-1)dx = -1/(2√3)`)
- [x] `A @ legendre(x) = cardinal(x)` at 50 random points — deliberately away from the
      construction nodes, so a rule exact only at its own nodes would fail
- [x] Both round trips, degrees 0–8, derived tolerance
- [x] float32 round trip, degrees 0–4 (beyond that the derived bound exceeds 0.1 and the
      assertion would be vacuous — those degrees are deliberately not claimed)
- [x] Partition of unity: `A.sum(axis=0) == [1, 0, …, 0]`
- [x] Biorthogonality by an independent `2·degree+2` point rule, not the one used to build
- [x] Every dual integrates to 1 — follows from biorthogonality *and* partition of unity,
      so it breaks if either does
- [x] Agreement with an independent construction routed through the Bernstein basis
- [x] `out`/dtype/readonly validation and `degree=-1`, over all three builders
- [x] Cached variants: frozen, shared per key, equal to the builders
- [x] The three docstring examples run as doctests

Full suite: 4278 passed, 19 skipped. ruff, ruff-format, mypy (214 files), import-lint and
the `-W` docs build all pass. One pre-existing local failure,
`test_pantr_toplevel_does_not_import_mpi`, is unrelated to this branch and is fixed by
#274 — it comes from the subprocess resolving the installed package rather than the
checkout.

## Also

Separate commit: `_compute_change_basis_1D`'s docstring (and the module header) stated
the transposed convention — `new_basis(x) = M @ old_basis(x)` where the function returns
`old_basis(x) = M @ new_basis(x)`. Refuted by measurement at degree 3: the documented
identity is off by `8.3e-1`, the corrected one by `4.4e-16`. Every public wrapper already
documented the correct direction, so only the private helper's own docs were wrong.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
