### PR TITLE
feat(bspline): per-cell factors() accessor on SpanwiseElementExtraction

### DIFF
--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -97,6 +97,11 @@ class SpanwiseElementExtraction:
     - *Dense* (:attr:`ops_1d`): the full ``(n_elements_k, n_out_k, n_in_k)``
       layout, reconstructed lazily from compact storage on first access.
 
+    For one element at a time, :meth:`factors` returns the per-direction
+    ``(is_identity, operator)`` pairs without allocating anything, which is what
+    a consumer serializing the 1D factors should use; ``__getitem__`` is the
+    convenience form that materializes an explicit identity matrix instead.
+
     Attributes:
         _space (BsplineSpace): Underlying multi-dimensional B-spline space.
         _target (Target): Target basis tag.
@@ -418,6 +423,58 @@ class SpanwiseElementExtraction:
         return tuple(
             bool(mask[i]) for mask, i in zip(self._is_identity_mask_1d, multi, strict=True)
         )
+
+    def factors(
+        self, cell_idx: CellIndex
+    ) -> tuple[tuple[bool, npt.NDArray[np.float32 | np.float64] | None], ...]:
+        """Return the per-direction 1D factors of one element's operator.
+
+        The element operator is ``kron(F_0, …, F_{d-1})`` where ``F_k`` is the
+        returned direction-``k`` operator, or the identity where the flag is set.
+        This is the same factorization :meth:`operator` and ``__getitem__``
+        use, exposed without materializing anything: identity directions yield
+        ``None`` rather than an identity matrix, and non-identity directions yield
+        a read-only view into :attr:`compact_ops_1d` rather than a copy. Elements
+        sharing a compact row therefore share its memory -- the view object itself
+        is new on each call, as numpy basic indexing always builds one, but no
+        operator data is copied.
+
+        Args:
+            cell_idx (CellIndex): Element index (flat or per-direction).
+
+        Returns:
+            tuple[tuple[bool, npt.NDArray[np.float32 | np.float64] | None], ...]:
+            Length-``d`` tuple whose entry ``k`` is ``(is_identity_k, op_k)``.
+            ``op_k`` is ``None`` exactly when ``is_identity_k`` is ``True``;
+            otherwise it is a read-only ``(n_out_k, n_in_k)`` view.
+
+        Raises:
+            IndexError: If a flat index is out of range, or a per-direction entry
+                is out of range for its direction.
+            ValueError: If a per-direction index has the wrong length.
+            TypeError: If ``cell_idx`` is not an ``int`` or sequence of ``int``.
+
+        Example:
+            >>> import numpy as np
+            >>> from pantr.bspline import BsplineSpace, BsplineSpace1D
+            >>> space = BsplineSpace([BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 4, 4], 2)])
+            >>> ext = SpanwiseElementExtraction(space, "cardinal")
+            >>> ext.factors(1)
+            ((True, None),)
+            >>> flag, op = ext.factors(0)[0]
+            >>> flag, op.shape, op.flags.writeable
+            (False, (3, 3), False)
+        """
+        multi = self._normalize_cell_idx(cell_idx)
+        factors: list[tuple[bool, npt.NDArray[np.float32 | np.float64] | None]] = []
+        for compact, idx_map, mask, i in zip(
+            self._compact_ops_1d, self._idx_maps_1d, self._is_identity_mask_1d, multi, strict=True
+        ):
+            if bool(mask[i]):
+                factors.append((True, None))
+            else:
+                factors.append((False, compact[int(idx_map[i])]))
+        return tuple(factors)
 
     # ---------------------------------------------------------------- per-cell applies
 

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -1471,3 +1471,130 @@ def test_struct_view_float32_is_numba_callable() -> None:
     _njit_apply_many_2d_via_view(view, cell_indices, v, out, scratch)
     expected = ext.apply_many(v, cell_indices)
     np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------- factors()
+
+
+def _space_for_degrees(degrees: tuple[int, ...]) -> BsplineSpace:
+    """Build an open-knot space with the given per-direction degrees.
+
+    Interior knots are single so the interior intervals are non-identity, while the
+    boundary intervals are, giving every direction a mix of both cases.
+    """
+    spaces = [
+        BsplineSpace1D([0.0] * (d + 1) + [1.0, 2.0, 3.0] + [4.0] * (d + 1), d) for d in degrees
+    ]
+    return BsplineSpace(spaces)
+
+
+def _kron_from_factors(
+    ext: SpanwiseElementExtraction, cell_idx: int
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Reassemble a cell's dense operator from :meth:`factors`, substituting eye for None."""
+    mats = []
+    for k, (is_identity, op) in enumerate(ext.factors(cell_idx)):
+        compact = ext.compact_ops_1d[k]
+        if is_identity:
+            mats.append(np.eye(compact.shape[1], compact.shape[2], dtype=compact.dtype))
+        else:
+            assert op is not None
+            mats.append(op)
+    result = mats[0]
+    for mat in mats[1:]:
+        result = np.kron(result, mat)
+    return result
+
+
+def test_factors_identity_directions_are_none() -> None:
+    """``None`` appears exactly where the identity flag is set, and flags agree."""
+    sp1 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 4, 4], 2)
+    sp2 = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp1, sp2]), "cardinal")
+
+    for cell in range(ext.num_total_intervals):
+        factors = ext.factors(cell)
+        flags = ext.per_direction_identity_flags(cell)
+        assert tuple(flag for flag, _ in factors) == flags
+        for is_identity, op in factors:
+            assert (op is None) == is_identity
+
+
+def test_factors_identity_cell_is_all_none() -> None:
+    """A wholly identity element yields ``(True, None)`` in every direction."""
+    sp = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 4, 4], 2)
+    ext = SpanwiseElementExtraction(BsplineSpace([sp, sp]), "cardinal")
+
+    identity_cells = [cell for cell in range(ext.num_total_intervals) if ext.is_identity_at(cell)]
+    assert identity_cells, "expected at least one fully-identity element"
+    for cell in identity_cells:
+        assert ext.factors(cell) == ((True, None), (True, None))
+
+
+def test_factors_zero_copy_and_readonly() -> None:
+    """Non-identity entries are read-only views sharing memory with compact storage.
+
+    The view object is necessarily new on each call -- numpy basic indexing always
+    builds one -- so the property that matters is shared memory, not identity.
+    """
+    ext = SpanwiseElementExtraction(_space_for_degrees((2, 3)), "cardinal")
+
+    saw_non_identity = False
+    for cell in range(ext.num_total_intervals):
+        for k, (is_identity, op) in enumerate(ext.factors(cell)):
+            if is_identity:
+                continue
+            saw_non_identity = True
+            assert op is not None
+            assert not op.flags.writeable
+            assert np.shares_memory(op, ext.compact_ops_1d[k])
+            with pytest.raises(ValueError):
+                op[0, 0] = 0.0
+    assert saw_non_identity, "expected at least one non-identity direction"
+
+
+@pytest.mark.parametrize("degrees", [(2,), (2, 3), (1, 2, 2)])
+@pytest.mark.parametrize("target", ["bezier", "cardinal"])
+def test_factors_kron_matches_operator(degrees: tuple[int, ...], target: str) -> None:
+    """The Kronecker product of the factors equals the dense per-cell operator, exactly.
+
+    Both go through the same arithmetic path, so this is an exact comparison rather
+    than a tolerance check.
+    """
+    ext = SpanwiseElementExtraction(_space_for_degrees(degrees), target)  # type: ignore[arg-type]
+
+    for cell in range(ext.num_total_intervals):
+        assert np.array_equal(_kron_from_factors(ext, cell), ext.operator(cell))
+
+
+def test_factors_flat_and_multi_index_agree() -> None:
+    """A flat index and its unravelled per-direction form give the same factors."""
+    ext = SpanwiseElementExtraction(_space_for_degrees((2, 3)), "cardinal")
+
+    for flat in range(ext.num_total_intervals):
+        multi = tuple(int(i) for i in np.unravel_index(flat, ext.num_intervals))
+        by_flat = ext.factors(flat)
+        by_multi = ext.factors(multi)
+        assert tuple(flag for flag, _ in by_flat) == tuple(flag for flag, _ in by_multi)
+        for (_, left), (_, right) in zip(by_flat, by_multi, strict=True):
+            if left is None:
+                assert right is None
+            else:
+                assert right is not None
+                assert np.array_equal(left, right)
+
+
+def test_factors_validation() -> None:
+    """Bad cell indices raise the same errors as the rest of the per-cell API."""
+    ext = SpanwiseElementExtraction(_space_for_degrees((2, 3)), "cardinal")
+
+    with pytest.raises(IndexError, match="out of range"):
+        ext.factors(ext.num_total_intervals)
+    with pytest.raises(IndexError, match="out of range"):
+        ext.factors(-1)
+    with pytest.raises(IndexError, match="direction"):
+        ext.factors((0, ext.num_intervals[1]))
+    with pytest.raises(ValueError, match="length"):
+        ext.factors((0,))
+    with pytest.raises(TypeError, match="must be int or sequence"):
+        ext.factors("0")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Adds `SpanwiseElementExtraction.factors(cell_idx)`, returning the per-direction
`(is_identity, operator)` pairs for one element so a consumer can serialize the 1D
factors of `C_e = C⁽⁰⁾ ⊗ … ⊗ C⁽ᵈ⁻¹⁾` while walking the whole grid.

`__getitem__` cannot serve that purpose: it builds a fresh `np.eye` for every identity
direction, which is precisely the allocation a payload builder iterating all cells must
avoid. `factors` allocates nothing — identity directions yield `None`, and the rest yield
read-only views into the frozen compact storage, so no operator data is copied either.

Index handling and validation reuse the existing `_normalize_cell_idx`. The accessor is
O(1) lookups into eagerly built storage, so there is nothing to cache. Shapes come from
`compact_ops_1d` rather than `degree + 1` literals, preserving the class's documented
non-square-operator generality. Purely additive: `operator`, `__getitem__` and the
kernels are untouched.

## One correction to the ticket

The ticket's expected-behavior snippet asserts:

```python
f[1][1] is ext.factors((2, 0))[1][1]   # True — same compact row, zero-copy
```

**This is False.** Numpy basic indexing builds a new view object on every call, so what
two elements sharing a compact row share is that row's *memory*, not the object. Measured:
`is` → `False`, `np.shares_memory` → `True`, `op.base is _compact_ops_1d[k]` → `True`.

The zero-copy intent behind the assertion holds; only the way it was phrased does not. The
tests assert `np.shares_memory` and the docstring says so explicitly, so the next reader
does not re-derive it.

## Test plan

11 new cases, all passing:

- [x] `None` appears exactly where the identity flag is set, and the flags agree with
      `per_direction_identity_flags` for every cell
- [x] A wholly identity element gives `((True, None), (True, None))`, cross-checked against
      `is_identity_at`
- [x] Non-identity entries are read-only (writing raises), share memory with
      `compact_ops_1d`, and are views rather than copies
- [x] **The load-bearing one:** for degrees `(2,)`, `(2, 3)`, `(1, 2, 2)` × targets
      `bezier`, `cardinal`, substituting the identity where flagged and taking the
      Kronecker product reproduces `operator(cell)` for every cell — `np.array_equal`, no
      tolerance, since both paths do the same arithmetic
- [x] Flat and per-direction indices agree
- [x] Validation: out-of-range flat (both ends) → `IndexError`, out-of-range per-direction
      → `IndexError`, wrong tuple length → `ValueError`, non-integer → `TypeError`
- [x] The docstring example runs as a doctest

Checked the exactness comparison is not vacuous: those six configurations carry **350
non-identity directions** between them, so it is not comparing identities to identities.

Full suite: 4213 passed, 19 skipped. ruff, ruff-format, mypy (214 files), import-lint and
the `-W` docs build all pass. The one pre-existing local failure,
`test_pantr_toplevel_does_not_import_mpi`, is environmental and fixed by #274.

The docs build initially failed on this branch: `:meth:` cross-references to
`__getitem__` do not resolve, since dunders are not in the autodoc index and `-W` turns
that warning into an error. Now written as literal code instead.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
