### PR TITLE
feat(multipatch): Interface/MultiPatch topology, detect_interfaces, match_face_cps

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -15,6 +15,7 @@ for worked examples; this page is the exhaustive contract.
 | {mod}`pantr.cad` | constructive geometry: primitives + operations | {doc}`/guide/cad` |
 | {mod}`pantr.transform` | affine transforms acting exactly on control points | {doc}`/tutorials/10_transforms` |
 | {mod}`pantr.geometry` | the {class}`~pantr.geometry.AABB` box primitive | {doc}`/guide/concepts` |
+| {mod}`pantr.multipatch` | how separate patches meet: interfaces and matched control points | {doc}`/guide/concepts` |
 | {mod}`pantr.grid` | structured / hierarchical cell grids, BVH, tags | {doc}`/tutorials/09_grids_and_quadrature` |
 | {mod}`pantr.quad` | quadrature rules and point lattices | {doc}`/tutorials/09_grids_and_quadrature` |
 | {mod}`pantr.tolerance` | shared floating-point tolerance policy | {doc}`/guide/concepts` |
@@ -53,6 +54,10 @@ for worked examples; this page is the exhaustive contract.
    :show-inheritance:
 
 .. automodule:: pantr.geometry
+   :members:
+   :show-inheritance:
+
+.. automodule:: pantr.multipatch
    :members:
    :show-inheritance:
 ```

--- a/src/pantr/multipatch/__init__.py
+++ b/src/pantr/multipatch/__init__.py
@@ -1,0 +1,29 @@
+"""Multipatch topology and geometry for B-spline patches.
+
+Describes how separate :class:`~pantr.bspline.Bspline` patches meet, which is the
+spline-side knowledge a solver needs before it can unify degrees of freedom across
+patch boundaries. Purely parametric and geometric: nothing here knows about
+assembly, dof numbering, or parallel distribution.
+
+Main exports:
+
+- :class:`Interface`: an immutable record of one conforming face-to-face contact,
+  carrying the tangential axis correspondence and orientations.
+- :class:`MultiPatch`: a validated collection of patches with their interfaces,
+  detected automatically when not supplied.
+- :func:`detect_interfaces`: find the conforming interfaces among a set of patches.
+- :func:`match_face_cps`: pair the flat control-point ids of two faces under a
+  given axis correspondence (index arithmetic only).
+"""
+
+from ._detect import detect_interfaces
+from ._interface import Interface
+from ._match import match_face_cps
+from ._multi_patch import MultiPatch
+
+__all__ = [
+    "Interface",
+    "MultiPatch",
+    "detect_interfaces",
+    "match_face_cps",
+]

--- a/src/pantr/multipatch/_detect.py
+++ b/src/pantr/multipatch/_detect.py
@@ -1,0 +1,374 @@
+"""Detection of conforming interfaces among a set of B-spline patches.
+
+Defines :func:`detect_interfaces`, which finds every pair of patch faces that
+coincide geometrically *and* carry compatible tangential knot vectors, together
+with the axis correspondence relating them.
+
+Only conforming interfaces are recognized. Two faces that occupy the same region
+of space but disagree in degree or interior knots are rejected rather than
+approximated: accepting a nested refinement on one side needs a projection the
+caller has to opt into, and silently pairing them would produce control-point
+matches that are simply wrong.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+
+from ._interface import Interface, face_axis_side, tangential_axes
+from ._match import match_face_cps
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..bspline import Bspline
+
+
+class _Face(NamedTuple):
+    """One side of a candidate interface: a patch and one of its faces.
+
+    Attributes:
+        patch (Bspline): The patch.
+        face (int): Face id on that patch.
+    """
+
+    patch: Bspline
+    face: int
+
+
+class _Orientation(NamedTuple):
+    """A candidate correspondence between the tangential axes of two faces.
+
+    Attributes:
+        axis_map (tuple[int, ...]): Patch-``b`` axis per tangential axis of face a.
+        flips (tuple[bool, ...]): Whether each of those axis pairs runs opposed.
+    """
+
+    axis_map: tuple[int, ...]
+    flips: tuple[bool, ...]
+
+
+class _Tolerances(NamedTuple):
+    """The three tolerances an interface check needs, kept dimensionally separate.
+
+    Comparing all three quantities against one number is the classic silent error
+    here: a patch measured in millimetres would accept weight differences a metre
+    apart, and a knot vector normalized to ``[0, 1]`` has no length scale at all.
+
+    Attributes:
+        geometric (float): For control-point coordinates. The relative tolerance
+            scaled by the joint bounding-box diagonal, so it tracks problem size.
+        parametric (float): For knot vectors already normalized to ``[0, 1]``.
+            Dimensionless, so it is the bare relative tolerance.
+        weight (float): For rational weights. Scaled by the largest weight in play
+            rather than by any length.
+    """
+
+    geometric: float
+    parametric: float
+    weight: float
+
+
+def _joint_tolerances(patch_a: Bspline, patch_b: Bspline, tol: float | None) -> _Tolerances:
+    """Derive the geometric, parametric and weight tolerances for a patch pair.
+
+    Args:
+        patch_a (Bspline): First patch.
+        patch_b (Bspline): Second patch.
+        tol (float | None): Relative tolerance override, or ``None`` to take the
+            larger of the two spaces' own tolerances.
+
+    Returns:
+        _Tolerances: The three derived absolute tolerances.
+    """
+    relative = max(patch_a.space.tolerance, patch_b.space.tolerance) if tol is None else float(tol)
+    rank = patch_a.rank
+    coords = np.concatenate(
+        [
+            patch_a.control_points.reshape(-1, patch_a.control_points.shape[-1])[:, :rank],
+            patch_b.control_points.reshape(-1, patch_b.control_points.shape[-1])[:, :rank],
+        ]
+    )
+    extent = np.asarray(coords.max(axis=0) - coords.min(axis=0), dtype=np.float64)
+    diagonal = float(np.linalg.norm(extent))
+    # A degenerate joint bounding box (both patches a single point) leaves no scale
+    # to borrow, so fall back to the bare relative tolerance rather than to zero.
+    geometric = relative * diagonal if diagonal > 0.0 else relative
+
+    weight_scale = 1.0
+    if patch_a.is_rational or patch_b.is_rational:
+        weights = [
+            np.abs(patch.control_points[..., -1]).max()
+            for patch in (patch_a, patch_b)
+            if patch.is_rational
+        ]
+        weight_scale = max(1.0, float(max(weights)))
+    return _Tolerances(geometric=geometric, parametric=relative, weight=relative * weight_scale)
+
+
+def _normalized_knots(
+    space_1d_knots: npt.NDArray[np.floating], flip: bool
+) -> npt.NDArray[np.float64]:
+    """Affinely map a knot vector onto ``[0, 1]``, optionally reversing it.
+
+    Args:
+        space_1d_knots (npt.NDArray[np.floating]): Knot vector.
+        flip (bool): Whether to reverse the parametrization.
+
+    Returns:
+        npt.NDArray[np.float64]: The normalized (and possibly reversed) knots,
+        ascending in both cases.
+    """
+    knots = np.asarray(space_1d_knots, dtype=np.float64)
+    span = knots[-1] - knots[0]
+    normalized = (knots - knots[0]) / span if span > 0.0 else np.zeros_like(knots)
+    if flip:
+        normalized = 1.0 - normalized[::-1]
+    return normalized
+
+
+def _face_corner_coords(patch: Bspline, face: int) -> npt.NDArray[np.float64]:
+    """Return the geometric coordinates of a face's corner control points.
+
+    Args:
+        patch (Bspline): The patch.
+        face (int): Face id.
+
+    Returns:
+        npt.NDArray[np.float64]: Array of shape ``(2 ** (dim - 1), rank)``, in an
+        unspecified order -- callers compare corner *sets*.
+    """
+    axis, side = face_axis_side(face)
+    num_basis = patch.space.num_basis
+    slab = 0 if side == 0 else num_basis[axis] - 1
+    coords = patch.control_points[..., : patch.rank]
+    corners = []
+    tangential = tangential_axes(face, patch.dim)
+    for combo in itertools.product(*[(0, num_basis[k] - 1) for k in tangential]):
+        index: list[int] = [0] * patch.dim
+        index[axis] = slab
+        for k, axis_t in enumerate(tangential):
+            index[axis_t] = combo[k]
+        corners.append(coords[tuple(index)])
+    return np.asarray(corners, dtype=np.float64)
+
+
+def _corner_sets_match(side_a: _Face, side_b: _Face, tol: float) -> bool:
+    """Check whether two faces have the same corner control points, as a set.
+
+    A cheap pre-filter before the full verification: it rejects the vast majority
+    of face pairs without touching the interior control points, and it deliberately
+    ignores ordering, since the ordering is what the orientation search determines.
+
+    Args:
+        side_a (_Face): First side.
+        side_b (_Face): Second side.
+        tol (float): Absolute geometric tolerance.
+
+    Returns:
+        bool: ``True`` if the two corner sets coincide within ``tol``.
+    """
+    corners_a = _face_corner_coords(side_a.patch, side_a.face)
+    corners_b = _face_corner_coords(side_b.patch, side_b.face)
+    if corners_a.shape != corners_b.shape:
+        return False
+    distances = np.linalg.norm(corners_a[:, None, :] - corners_b[None, :, :], axis=-1)
+    # Every corner of each face must have a partner on the other; a bijection is not
+    # required here because coincident corners are legitimate on degenerate patches.
+    return bool((distances.min(axis=1) <= tol).all() and (distances.min(axis=0) <= tol).all())
+
+
+def _knots_agree(side_a: _Face, side_b: _Face, orientation: _Orientation, tol: float) -> bool:
+    """Check that the tangential knot vectors agree under the given correspondence.
+
+    Args:
+        side_a (_Face): First side.
+        side_b (_Face): Second side.
+        orientation (_Orientation): Candidate axis correspondence.
+        tol (float): Dimensionless tolerance for knots normalized to ``[0, 1]``.
+
+    Returns:
+        bool: ``True`` if every matched direction agrees in degree and in
+        normalized knot vector.
+    """
+    space_a, space_b = side_a.patch.space, side_b.patch.space
+    for k, axis_a in enumerate(tangential_axes(side_a.face, space_a.dim)):
+        one_d_a = space_a.spaces[axis_a]
+        one_d_b = space_b.spaces[orientation.axis_map[k]]
+        if one_d_a.degree != one_d_b.degree:
+            return False
+        knots_a = _normalized_knots(one_d_a.knots, flip=False)
+        knots_b = _normalized_knots(one_d_b.knots, flip=orientation.flips[k])
+        if knots_a.shape != knots_b.shape:
+            return False
+        if not bool(np.all(np.abs(knots_a - knots_b) <= tol)):
+            return False
+    return True
+
+
+def _cps_agree(
+    side_a: _Face, side_b: _Face, orientation: _Orientation, tolerances: _Tolerances
+) -> bool:
+    """Check that every matched control point pair coincides, weights included.
+
+    The pairing comes from :func:`~pantr.multipatch.match_face_cps`, so this cannot
+    drift from the index arithmetic a caller will later use to unify dofs.
+
+    Args:
+        side_a (_Face): First side.
+        side_b (_Face): Second side.
+        orientation (_Orientation): Candidate axis correspondence.
+        tolerances (_Tolerances): Geometric and weight tolerances.
+
+    Returns:
+        bool: ``True`` if all matched coordinates agree within the geometric
+        tolerance and all matched weights within the weight tolerance.
+    """
+    patch_a, patch_b = side_a.patch, side_b.patch
+    try:
+        cps_a, cps_b = match_face_cps(
+            patch_a.space,
+            side_a.face,
+            patch_b.space,
+            side_b.face,
+            orientation.axis_map,
+            orientation.flips,
+        )
+    except ValueError:
+        return False
+
+    rank = patch_a.rank
+    flat_a = patch_a.control_points.reshape(-1, patch_a.control_points.shape[-1])
+    flat_b = patch_b.control_points.reshape(-1, patch_b.control_points.shape[-1])
+    if not bool(
+        np.all(np.abs(flat_a[cps_a, :rank] - flat_b[cps_b, :rank]) <= tolerances.geometric)
+    ):
+        return False
+    if patch_a.is_rational:
+        return bool(np.all(np.abs(flat_a[cps_a, -1] - flat_b[cps_b, -1]) <= tolerances.weight))
+    return True
+
+
+def _orientation_candidates(face_b: int, dim: int) -> list[_Orientation]:
+    """Enumerate every axis correspondence a face pair could have.
+
+    There are ``(dim - 1)! * 2 ** (dim - 1)`` of them: 1 in 1D, 2 in 2D, 8 in 3D.
+    Enumerating and verifying is what makes detection robust on symmetric faces,
+    where the corner correspondence alone does not determine the orientation.
+
+    Args:
+        face_b (int): Face id on the second patch.
+        dim (int): Parametric dimension.
+
+    Returns:
+        list[_Orientation]: Every candidate correspondence, cheapest-first in the
+        sense that the identity permutation without flips comes first.
+    """
+    tangential_b = tangential_axes(face_b, dim)
+    return [
+        _Orientation(axis_map=permutation, flips=flips)
+        for permutation in itertools.permutations(tangential_b)
+        for flips in itertools.product([False, True], repeat=len(tangential_b))
+    ]
+
+
+def verify_interface(
+    patches: Sequence[Bspline], interface: Interface, *, tol: float | None = None
+) -> bool:
+    """Check that an interface actually holds for a set of patches.
+
+    Applies the same two conditions detection requires: every matched control point
+    pair coincides, and the tangential knot vectors agree after normalization.
+
+    Args:
+        patches (Sequence[Bspline]): The patches the interface refers to.
+        interface (Interface): The interface to verify.
+        tol (float | None): Relative tolerance override. Defaults to the larger of
+            the two spaces' own tolerances.
+
+    Returns:
+        bool: ``True`` if the interface holds.
+
+    Raises:
+        IndexError: If the interface refers to a patch index that does not exist.
+    """
+    side_a = _Face(patches[interface.patch_a], interface.face_a)
+    side_b = _Face(patches[interface.patch_b], interface.face_b)
+    orientation = _Orientation(interface.axis_map, interface.flips)
+    tolerances = _joint_tolerances(side_a.patch, side_b.patch, tol)
+    if not _knots_agree(side_a, side_b, orientation, tolerances.parametric):
+        return False
+    return _cps_agree(side_a, side_b, orientation, tolerances)
+
+
+def detect_interfaces(
+    patches: Sequence[Bspline], *, tol: float | None = None
+) -> tuple[Interface, ...]:
+    """Find the conforming interfaces among a set of patches.
+
+    Every pair of faces in canonical order is considered, including two faces of the
+    same patch, which is how a closed ring is found. A pair becomes an interface
+    only when both conditions hold: all matched control points coincide, and the
+    matched tangential knot vectors agree after affine normalization to ``[0, 1]``.
+    A face pair that occupies the same space but disagrees in degree or interior
+    knots is *not* an interface here.
+
+    Args:
+        patches (Sequence[Bspline]): The patches to inspect. All must share the same
+            parametric dimension.
+        tol (float | None): Relative tolerance override. Defaults, per pair, to the
+            larger of the two spaces' own tolerances; it is scaled by the joint
+            bounding-box diagonal for coordinates and used bare for knots.
+
+    Returns:
+        tuple[Interface, ...]: The interfaces found, sorted by
+        ``(patch_a, face_a, patch_b, face_b)``.
+
+    Raises:
+        ValueError: If the patches do not all share the same parametric dimension.
+
+    Example:
+        >>> import numpy as np
+        >>> from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+        >>> space = BsplineSpace([BsplineSpace1D([0, 0, 1, 1], 1)] * 2)
+        >>> left = Bspline(space, np.array([[0.0, 0], [0, 1], [1, 0], [1, 1]]))
+        >>> right = Bspline(space, np.array([[1.0, 0], [1, 1], [2, 0], [2, 1]]))
+        >>> detect_interfaces([left, right])
+        (Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),)
+    """
+    if not patches:
+        return ()
+    dims = {patch.dim for patch in patches}
+    if len(dims) != 1:
+        raise ValueError(f"All patches must share one parametric dimension; got {sorted(dims)}")
+    dim = dims.pop()
+
+    sides = [(p, f) for p in range(len(patches)) for f in range(2 * dim)]
+    found: list[Interface] = []
+    for (patch_a, face_a), (patch_b, face_b) in itertools.combinations(sides, 2):
+        side_a = _Face(patches[patch_a], face_a)
+        side_b = _Face(patches[patch_b], face_b)
+        tolerances = _joint_tolerances(side_a.patch, side_b.patch, tol)
+        if not _corner_sets_match(side_a, side_b, tolerances.geometric):
+            continue
+        for orientation in _orientation_candidates(face_b, dim):
+            if not _knots_agree(side_a, side_b, orientation, tolerances.parametric):
+                continue
+            if not _cps_agree(side_a, side_b, orientation, tolerances):
+                continue
+            found.append(
+                Interface(
+                    patch_a=patch_a,
+                    face_a=face_a,
+                    patch_b=patch_b,
+                    face_b=face_b,
+                    axis_map=tuple(orientation.axis_map),
+                    flips=tuple(orientation.flips),
+                )
+            )
+            break
+    return tuple(sorted(found, key=lambda i: (i.patch_a, i.face_a, i.patch_b, i.face_b)))

--- a/src/pantr/multipatch/_interface.py
+++ b/src/pantr/multipatch/_interface.py
@@ -1,0 +1,122 @@
+"""Interface record between two B-spline patch faces.
+
+Defines :class:`Interface`, the immutable description of one conforming contact
+between two patch faces: which faces meet, how their tangential axes correspond,
+and which of those axes run in opposite directions.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+def face_axis_side(face: int) -> tuple[int, int]:
+    """Split a face id into its parametric axis and side.
+
+    Faces are numbered ``2 * axis + side`` with ``side == 0`` the low-parameter
+    face and ``side == 1`` the high one, matching
+    :meth:`pantr.grid.Grid.local_facet_axis_side`.
+
+    Args:
+        face (int): Face id.
+
+    Returns:
+        tuple[int, int]: ``(axis, side)``.
+    """
+    return divmod(face, 2)
+
+
+def tangential_axes(face: int, dim: int) -> tuple[int, ...]:
+    """Return the patch axes tangential to a face, in increasing order.
+
+    Args:
+        face (int): Face id.
+        dim (int): Parametric dimension of the patch.
+
+    Returns:
+        tuple[int, ...]: The ``dim - 1`` axes other than the face's own axis.
+    """
+    axis, _ = face_axis_side(face)
+    return tuple(k for k in range(dim) if k != axis)
+
+
+@dataclasses.dataclass(frozen=True)
+class Interface:
+    """A conforming contact between two B-spline patch faces.
+
+    Frozen, so instances are hashable and usable as dictionary keys, and ordered
+    canonically: ``(patch_a, face_a)`` is lexicographically smaller than
+    ``(patch_b, face_b)``. A patch may meet itself on two different faces, which
+    is how a closed ring is expressed.
+
+    ``axis_map`` and ``flips`` describe the reparametrization between the two
+    faces. Entry ``k`` refers to the ``k``-th tangential axis of ``face_a`` taken
+    in increasing-axis order; ``axis_map[k]`` is the *patch axis of* ``patch_b``
+    it corresponds to, and ``flips[k]`` says whether the two run in opposite
+    directions.
+
+    Attributes:
+        patch_a (int): Index of the first patch.
+        face_a (int): Face id on ``patch_a``, as ``2 * axis + side``.
+        patch_b (int): Index of the second patch.
+        face_b (int): Face id on ``patch_b``.
+        axis_map (tuple[int, ...]): Length ``dim - 1``; the patch-``b`` axis
+            corresponding to each tangential axis of ``face_a``. A permutation of
+            the tangential axes of ``face_b``.
+        flips (tuple[bool, ...]): Length ``dim - 1``; ``True`` where that
+            tangential axis of ``face_a`` runs against its partner's direction.
+    """
+
+    patch_a: int
+    face_a: int
+    patch_b: int
+    face_b: int
+    axis_map: tuple[int, ...]
+    flips: tuple[bool, ...]
+
+    def __post_init__(self) -> None:
+        """Validate the face ids, the axis permutation, and the canonical order.
+
+        Raises:
+            ValueError: If the interface joins a face to itself, a face id is out
+                of range for the implied dimension, ``axis_map`` is not a
+                permutation of ``face_b``'s tangential axes, ``flips`` has a
+                different length, or the two sides are not in canonical order.
+        """
+        dim = len(self.axis_map) + 1
+        if len(self.flips) != len(self.axis_map):
+            raise ValueError(
+                f"flips and axis_map must have equal length; "
+                f"got {len(self.flips)} and {len(self.axis_map)}"
+            )
+        for name, face in (("face_a", self.face_a), ("face_b", self.face_b)):
+            if not 0 <= face < 2 * dim:
+                raise ValueError(
+                    f"{name}={face} out of range for dim={dim}; expected 0 <= face < {2 * dim}"
+                )
+        if self.patch_a == self.patch_b and self.face_a == self.face_b:
+            raise ValueError(
+                f"An interface cannot join a face to itself "
+                f"(patch {self.patch_a}, face {self.face_a})"
+            )
+        expected = set(tangential_axes(self.face_b, dim))
+        if set(self.axis_map) != expected or len(set(self.axis_map)) != len(self.axis_map):
+            raise ValueError(
+                f"axis_map={self.axis_map} must be a permutation of the tangential axes "
+                f"{tuple(sorted(expected))} of face_b={self.face_b}"
+            )
+        if (self.patch_a, self.face_a) >= (self.patch_b, self.face_b):
+            raise ValueError(
+                f"Interface sides must be in canonical order: "
+                f"({self.patch_a}, {self.face_a}) must be lexicographically smaller than "
+                f"({self.patch_b}, {self.face_b})"
+            )
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension of the patches this interface joins.
+
+        Returns:
+            int: ``len(axis_map) + 1``.
+        """
+        return len(self.axis_map) + 1

--- a/src/pantr/multipatch/_match.py
+++ b/src/pantr/multipatch/_match.py
@@ -1,0 +1,169 @@
+"""Control-point index arithmetic across a pair of patch faces.
+
+Defines :func:`match_face_cps`, which pairs the flat control-point ids on two
+faces under a given axis correspondence. Pure index arithmetic: no geometry is
+read, so it says nothing about whether the two faces actually coincide in space.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from ._interface import face_axis_side, tangential_axes
+
+if TYPE_CHECKING:
+    from ..bspline import BsplineSpace
+
+
+def _face_slab_index(num_basis: tuple[int, ...], face: int) -> int:
+    """Return the index along a face's own axis that the face occupies.
+
+    Args:
+        num_basis (tuple[int, ...]): Per-direction basis counts of the patch.
+        face (int): Face id.
+
+    Returns:
+        int: ``0`` for a low face, ``num_basis[axis] - 1`` for a high one.
+    """
+    axis, side = face_axis_side(face)
+    return 0 if side == 0 else num_basis[axis] - 1
+
+
+def _validate_face(space: BsplineSpace, face: int, name: str) -> None:
+    """Check that a face id is in range for a space.
+
+    Args:
+        space (BsplineSpace): The patch space.
+        face (int): Face id.
+        name (str): Argument name, for the error message.
+
+    Raises:
+        ValueError: If the face id is out of range.
+    """
+    if not 0 <= face < 2 * space.dim:
+        raise ValueError(
+            f"{name}={face} out of range for a {space.dim}D space; "
+            f"expected 0 <= {name} < {2 * space.dim}"
+        )
+
+
+def face_index_grids(space: BsplineSpace, face: int) -> tuple[npt.NDArray[np.int64], ...]:
+    """Build the per-tangential-axis index grids of a face, in C-order.
+
+    Args:
+        space (BsplineSpace): The patch space.
+        face (int): Face id.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], ...]: One array per tangential axis, each of
+        the face's tangential shape, holding that axis's index. Empty for a 1D
+        patch, whose faces are single points.
+    """
+    num_basis = space.num_basis
+    tangential = tangential_axes(face, space.dim)
+    ranges = [np.arange(num_basis[axis], dtype=np.int64) for axis in tangential]
+    if not ranges:
+        return ()
+    return tuple(np.meshgrid(*ranges, indexing="ij"))
+
+
+def match_face_cps(  # noqa: PLR0913
+    space_a: BsplineSpace,
+    face_a: int,
+    space_b: BsplineSpace,
+    face_b: int,
+    axis_map: tuple[int, ...],
+    flips: tuple[bool, ...],
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    """Pair the flat control-point ids of two faces under an axis correspondence.
+
+    Flat ids are C-order over :attr:`~pantr.bspline.BsplineSpace.num_basis`. The
+    ``k``-th tangential axis of ``face_a``, in increasing-axis order, is taken to
+    correspond to patch axis ``axis_map[k]`` of ``space_b``, running backwards
+    when ``flips[k]``.
+
+    This is index arithmetic only. It does not check that the two faces coincide
+    geometrically; :func:`~pantr.multipatch.detect_interfaces` is what establishes
+    that.
+
+    Args:
+        space_a (BsplineSpace): First patch space.
+        face_a (int): Face id on ``space_a``.
+        space_b (BsplineSpace): Second patch space.
+        face_b (int): Face id on ``space_b``.
+        axis_map (tuple[int, ...]): Patch-``b`` axis per tangential axis of
+            ``face_a``; a permutation of ``face_b``'s tangential axes.
+        flips (tuple[bool, ...]): Whether each of those axis pairs runs opposed.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ``(cps_a, cps_b)``,
+        equal-length read-only arrays of flat ids. ``cps_a`` is sorted ascending
+        and ``cps_b[i]`` is the id matched to ``cps_a[i]``.
+
+    Raises:
+        ValueError: If a face id is out of range, the two spaces differ in
+            dimension, ``axis_map`` is not a permutation of ``face_b``'s
+            tangential axes, ``flips`` has a different length, or the matched
+            tangential directions hold different numbers of basis functions.
+
+    Example:
+        >>> import numpy as np
+        >>> from pantr.bspline import BsplineSpace, BsplineSpace1D
+        >>> space = BsplineSpace([BsplineSpace1D([0, 0, 1, 1], 1)] * 2)
+        >>> a, b = match_face_cps(space, 1, space, 0, (1,), (False,))
+        >>> a, b
+        (array([2, 3]), array([0, 1]))
+    """
+    if space_a.dim != space_b.dim:
+        raise ValueError(
+            f"Both spaces must have the same parametric dimension; "
+            f"got {space_a.dim} and {space_b.dim}"
+        )
+    _validate_face(space_a, face_a, "face_a")
+    _validate_face(space_b, face_b, "face_b")
+
+    dim = space_a.dim
+    tang_a = tangential_axes(face_a, dim)
+    expected = set(tangential_axes(face_b, dim))
+    if len(flips) != len(axis_map):
+        raise ValueError(
+            f"flips and axis_map must have equal length; got {len(flips)} and {len(axis_map)}"
+        )
+    if len(axis_map) != dim - 1:
+        raise ValueError(f"axis_map must have length {dim - 1} for a {dim}D space")
+    if set(axis_map) != expected or len(set(axis_map)) != len(axis_map):
+        raise ValueError(
+            f"axis_map={axis_map} must be a permutation of the tangential axes "
+            f"{tuple(sorted(expected))} of face_b={face_b}"
+        )
+
+    n_a, n_b = space_a.num_basis, space_b.num_basis
+    for k, axis_a in enumerate(tang_a):
+        if n_a[axis_a] != n_b[axis_map[k]]:
+            raise ValueError(
+                f"Matched tangential directions hold different numbers of basis functions: "
+                f"axis {axis_a} of space_a has {n_a[axis_a]}, "
+                f"axis {axis_map[k]} of space_b has {n_b[axis_map[k]]}"
+            )
+
+    axis_a_own, _ = face_axis_side(face_a)
+    axis_b_own, _ = face_axis_side(face_b)
+    grids = face_index_grids(space_a, face_a)
+
+    idx_a: list[npt.NDArray[np.int64] | int] = [0] * dim
+    idx_b: list[npt.NDArray[np.int64] | int] = [0] * dim
+    idx_a[axis_a_own] = _face_slab_index(n_a, face_a)
+    idx_b[axis_b_own] = _face_slab_index(n_b, face_b)
+    for k, axis_a in enumerate(tang_a):
+        axis_b = axis_map[k]
+        idx_a[axis_a] = grids[k]
+        idx_b[axis_b] = (n_b[axis_b] - 1 - grids[k]) if flips[k] else grids[k]
+
+    cps_a = np.ravel_multi_index(tuple(idx_a), n_a).ravel().astype(np.int64)
+    cps_b = np.ravel_multi_index(tuple(idx_b), n_b).ravel().astype(np.int64)
+    cps_a.flags.writeable = False
+    cps_b.flags.writeable = False
+    return cps_a, cps_b

--- a/src/pantr/multipatch/_multi_patch.py
+++ b/src/pantr/multipatch/_multi_patch.py
@@ -1,0 +1,129 @@
+"""A validated collection of B-spline patches and the interfaces joining them."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._detect import detect_interfaces, verify_interface
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..bspline import Bspline
+    from ._interface import Interface
+
+
+class MultiPatch:
+    """A set of B-spline patches together with their conforming interfaces.
+
+    The patches must agree on everything that would make joining them meaningless
+    otherwise: parametric dimension, physical rank, dtype, and whether they are
+    rational. Interfaces are detected on construction unless supplied, and supplied
+    ones are verified rather than trusted.
+
+    Attributes:
+        _patches (tuple[Bspline, ...]): The patches, in the order given.
+        _interfaces (tuple[Interface, ...]): The interfaces joining them.
+    """
+
+    _patches: tuple[Bspline, ...]
+    _interfaces: tuple[Interface, ...]
+
+    def __init__(
+        self,
+        patches: Sequence[Bspline],
+        interfaces: tuple[Interface, ...] | None = None,
+        *,
+        tol: float | None = None,
+    ) -> None:
+        """Validate the patches and establish the interfaces.
+
+        Args:
+            patches (Sequence[Bspline]): At least one patch. All must share
+                parametric dimension, physical rank, dtype and ``is_rational``.
+            interfaces (tuple[Interface, ...] | None): Interfaces to use. Each is
+                verified against the geometry. Detected automatically when ``None``.
+            tol (float | None): Relative tolerance override for detection and
+                verification. Defaults to the larger of each pair's own tolerances.
+
+        Raises:
+            ValueError: If no patches are given, the patches disagree on dimension,
+                rank, dtype or rationality, an interface refers to a patch that does
+                not exist, or a supplied interface does not hold for the geometry.
+        """
+        if not patches:
+            raise ValueError("A MultiPatch needs at least one patch")
+
+        first = patches[0]
+        for index, patch in enumerate(patches[1:], start=1):
+            for attribute in ("dim", "rank", "is_rational"):
+                expected, actual = getattr(first, attribute), getattr(patch, attribute)
+                if expected != actual:
+                    raise ValueError(
+                        f"All patches must share {attribute}; patch 0 has {expected!r} "
+                        f"but patch {index} has {actual!r}"
+                    )
+            if patch.dtype != first.dtype:
+                raise ValueError(
+                    f"All patches must share dtype; patch 0 has {first.dtype} "
+                    f"but patch {index} has {patch.dtype}"
+                )
+
+        self._patches = tuple(patches)
+
+        if interfaces is None:
+            self._interfaces = detect_interfaces(self._patches, tol=tol)
+            return
+
+        n_patches = len(self._patches)
+        for interface in interfaces:
+            for side, index in (("patch_a", interface.patch_a), ("patch_b", interface.patch_b)):
+                if not 0 <= index < n_patches:
+                    raise ValueError(
+                        f"Interface {side}={index} is out of range for {n_patches} patches"
+                    )
+            if interface.dim != first.dim:
+                raise ValueError(
+                    f"Interface implies dim={interface.dim} but the patches are {first.dim}D"
+                )
+            if not verify_interface(self._patches, interface, tol=tol):
+                raise ValueError(
+                    f"Interface does not hold for the given geometry: {interface}. "
+                    "The matched control points or the tangential knot vectors disagree."
+                )
+        self._interfaces = tuple(interfaces)
+
+    @property
+    def patches(self) -> tuple[Bspline, ...]:
+        """Get the patches.
+
+        Returns:
+            tuple[Bspline, ...]: The patches, in the order given at construction.
+        """
+        return self._patches
+
+    @property
+    def interfaces(self) -> tuple[Interface, ...]:
+        """Get the interfaces joining the patches.
+
+        Returns:
+            tuple[Interface, ...]: The supplied or detected interfaces.
+        """
+        return self._interfaces
+
+    @property
+    def dim(self) -> int:
+        """Get the shared parametric dimension of the patches.
+
+        Returns:
+            int: Parametric dimension.
+        """
+        return self._patches[0].dim
+
+    def __len__(self) -> int:
+        """Return the number of patches.
+
+        Returns:
+            int: Patch count.
+        """
+        return len(self._patches)

--- a/tests/test_multipatch.py
+++ b/tests/test_multipatch.py
@@ -1,0 +1,503 @@
+"""Tests for the :mod:`pantr.multipatch` topology and detection code."""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.multipatch import Interface, MultiPatch, detect_interfaces, match_face_cps
+from pantr.multipatch._interface import tangential_axes
+
+
+def _open_space_1d(degree: int, n_interior: int) -> BsplineSpace1D:
+    """Build an open 1D space on ``[0, 1]`` with ``n_interior`` single interior knots."""
+    interior = [(i + 1) / (n_interior + 1) for i in range(n_interior)]
+    return BsplineSpace1D([0.0] * (degree + 1) + interior + [1.0] * (degree + 1), degree)
+
+
+def _lattice_patch(space: BsplineSpace, offset: npt.ArrayLike | None = None) -> Bspline:
+    """Build a patch whose control points form a regular lattice on the unit box.
+
+    The lattice is deliberately anisotropic in index count, so a wrong axis
+    correspondence produces a shape mismatch or a coordinate mismatch rather than
+    silently working.
+    """
+    num_basis = space.num_basis
+    grids = np.meshgrid(*[np.linspace(0.0, 1.0, n) for n in num_basis], indexing="ij")
+    cps = np.stack(grids, axis=-1)
+    if offset is not None:
+        cps = cps + np.asarray(offset, dtype=cps.dtype)
+    return Bspline(space, cps.copy())
+
+
+def _anisotropic_space_2d() -> BsplineSpace:
+    """A 2D space with different basis counts per direction."""
+    return BsplineSpace([_open_space_1d(2, 1), _open_space_1d(2, 0)])
+
+
+def _anisotropic_space_3d() -> BsplineSpace:
+    """A 3D space with three different basis counts."""
+    return BsplineSpace([_open_space_1d(1, 0), _open_space_1d(2, 0), _open_space_1d(2, 1)])
+
+
+# ---------------------------------------------------------------- Interface record
+
+
+def test_interface_is_frozen_and_hashable() -> None:
+    """Interfaces are immutable, comparable and usable as dict keys."""
+    iface = Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,))
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        iface.patch_a = 5  # type: ignore[misc]
+    assert iface == Interface(0, 1, 1, 0, (1,), (False,))
+    assert {iface: "value"}[Interface(0, 1, 1, 0, (1,), (False,))] == "value"
+    assert iface.dim == 2
+
+
+def test_interface_rejects_self_face() -> None:
+    """A face cannot be joined to itself."""
+    with pytest.raises(ValueError, match="cannot join a face to itself"):
+        Interface(patch_a=0, face_a=1, patch_b=0, face_b=1, axis_map=(1,), flips=(False,))
+
+
+def test_interface_rejects_out_of_range_face() -> None:
+    """Face ids must be in range for the dimension implied by ``axis_map``."""
+    with pytest.raises(ValueError, match="out of range for dim=2"):
+        Interface(patch_a=0, face_a=4, patch_b=1, face_b=0, axis_map=(1,), flips=(False,))
+
+
+def test_interface_rejects_bad_axis_map() -> None:
+    """``axis_map`` must be a permutation of ``face_b``'s tangential axes."""
+    with pytest.raises(ValueError, match="must be a permutation"):
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(0,), flips=(False,))
+    with pytest.raises(ValueError, match="must be a permutation"):
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1, 1), flips=(False, False))
+
+
+def test_interface_rejects_flips_length_mismatch() -> None:
+    """``flips`` must have the same length as ``axis_map``."""
+    with pytest.raises(ValueError, match="equal length"):
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=())
+
+
+def test_interface_requires_canonical_order() -> None:
+    """The two sides must be given in canonical order."""
+    with pytest.raises(ValueError, match="canonical order"):
+        Interface(patch_a=1, face_a=0, patch_b=0, face_b=1, axis_map=(1,), flips=(False,))
+
+
+# ---------------------------------------------------------------- match_face_cps
+
+
+def _brute_force_match(  # noqa: PLR0913
+    space_a: BsplineSpace,
+    face_a: int,
+    space_b: BsplineSpace,
+    face_b: int,
+    axis_map: tuple[int, ...],
+    flips: tuple[bool, ...],
+) -> tuple[list[int], list[int]]:
+    """Pair face control points with explicit nested loops, as an independent oracle.
+
+    Deliberately written without any of the vectorized machinery under test: it walks
+    the face's tangential index space in C-order and computes both flat ids by hand.
+    """
+    dim = space_a.dim
+    n_a, n_b = space_a.num_basis, space_b.num_basis
+    axis_a, side_a = divmod(face_a, 2)
+    axis_b, side_b = divmod(face_b, 2)
+    tang_a = tangential_axes(face_a, dim)
+    slab_a = 0 if side_a == 0 else n_a[axis_a] - 1
+    slab_b = 0 if side_b == 0 else n_b[axis_b] - 1
+
+    ids_a: list[int] = []
+    ids_b: list[int] = []
+    for combo in itertools.product(*[range(n_a[axis]) for axis in tang_a]):
+        index_a = [0] * dim
+        index_b = [0] * dim
+        index_a[axis_a] = slab_a
+        index_b[axis_b] = slab_b
+        for k, axis in enumerate(tang_a):
+            index_a[axis] = combo[k]
+            target = axis_map[k]
+            index_b[target] = n_b[target] - 1 - combo[k] if flips[k] else combo[k]
+        flat_a = 0
+        for axis in range(dim):
+            flat_a = flat_a * n_a[axis] + index_a[axis]
+        flat_b = 0
+        for axis in range(dim):
+            flat_b = flat_b * n_b[axis] + index_b[axis]
+        ids_a.append(flat_a)
+        ids_b.append(flat_b)
+    return ids_a, ids_b
+
+
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_match_face_cps_matches_brute_force(dim: int) -> None:
+    """Every face pair and orientation agrees with an independent nested-loop oracle."""
+    degrees = [1, 2, 2][:dim]
+    interior = [0, 1, 2][:dim]
+    space = BsplineSpace([_open_space_1d(d, n) for d, n in zip(degrees, interior, strict=True)])
+
+    for face_a, face_b in itertools.product(range(2 * dim), repeat=2):
+        tang_b = tangential_axes(face_b, dim)
+        for axis_map in itertools.permutations(tang_b):
+            for flips in itertools.product([False, True], repeat=len(tang_b)):
+                sizes_a = [space.num_basis[a] for a in tangential_axes(face_a, dim)]
+                sizes_b = [space.num_basis[a] for a in axis_map]
+                if sizes_a != sizes_b:
+                    with pytest.raises(ValueError, match="different numbers of basis functions"):
+                        match_face_cps(space, face_a, space, face_b, axis_map, flips)
+                    continue
+                cps_a, cps_b = match_face_cps(space, face_a, space, face_b, axis_map, flips)
+                expected_a, expected_b = _brute_force_match(
+                    space, face_a, space, face_b, axis_map, flips
+                )
+                assert cps_a.tolist() == expected_a
+                assert cps_b.tolist() == expected_b
+
+
+def test_match_face_cps_is_sorted_and_readonly() -> None:
+    """``cps_a`` comes back sorted ascending, and both outputs are frozen."""
+    space = _anisotropic_space_3d()
+    cps_a, cps_b = match_face_cps(space, 1, space, 0, (1, 2), (False, False))
+
+    assert np.all(np.diff(cps_a) > 0)
+    assert not cps_a.flags.writeable
+    assert not cps_b.flags.writeable
+    assert cps_a.shape == cps_b.shape
+
+
+def test_match_face_cps_validation() -> None:
+    """Out-of-range faces, bad permutations and length mismatches are rejected."""
+    space = _anisotropic_space_2d()
+
+    with pytest.raises(ValueError, match="face_a=4 out of range"):
+        match_face_cps(space, 4, space, 0, (1,), (False,))
+    with pytest.raises(ValueError, match="face_b=-1 out of range"):
+        match_face_cps(space, 0, space, -1, (1,), (False,))
+    with pytest.raises(ValueError, match="must be a permutation"):
+        match_face_cps(space, 1, space, 0, (0,), (False,))
+    with pytest.raises(ValueError, match="equal length"):
+        match_face_cps(space, 1, space, 0, (1,), (False, False))
+    with pytest.raises(ValueError, match="same parametric dimension"):
+        match_face_cps(space, 1, _anisotropic_space_3d(), 0, (1,), (False,))
+
+
+# ---------------------------------------------------------------- detection
+
+
+def test_detect_translated_1d() -> None:
+    """Two 1D patches meeting at a point give one interface with empty axis data."""
+    space = BsplineSpace([_open_space_1d(2, 1)])
+    left = _lattice_patch(space)
+    right = _lattice_patch(space, offset=[1.0])
+
+    assert detect_interfaces([left, right]) == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(), flips=()),
+    )
+
+
+def test_detect_translated_2d() -> None:
+    """Side-by-side 2D patches give the interface stated in the specification."""
+    space = _anisotropic_space_2d()
+    left = _lattice_patch(space)
+    right = _lattice_patch(space, offset=[1.0, 0.0])
+
+    assert detect_interfaces([left, right]) == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_detect_translated_3d_all_axes(axis: int) -> None:
+    """Translating along each axis exercises all six 3D faces."""
+    space = _anisotropic_space_3d()
+    first = _lattice_patch(space)
+    offset = np.zeros(3)
+    offset[axis] = 1.0
+    second = _lattice_patch(space, offset=offset)
+
+    expected_tangential = tuple(k for k in range(3) if k != axis)
+    assert detect_interfaces([first, second]) == (
+        Interface(
+            patch_a=0,
+            face_a=2 * axis + 1,
+            patch_b=1,
+            face_b=2 * axis,
+            axis_map=expected_tangential,
+            flips=(False, False),
+        ),
+    )
+
+
+def test_detect_recovers_permuted_axes_2d() -> None:
+    """A patch whose axes were swapped is still matched, with the axis map recording it."""
+    space = _anisotropic_space_2d()
+    first = _lattice_patch(space)
+    second = _lattice_patch(space, offset=[1.0, 0.0]).permute_directions([1, 0])
+    assert second is not None
+
+    interfaces = detect_interfaces([first, second])
+
+    assert interfaces == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=2, axis_map=(0,), flips=(False,)),
+    )
+
+
+def test_detect_recovers_flipped_axis_2d() -> None:
+    """Reversing the tangential direction of the neighbour is recorded as a flip."""
+    space = _anisotropic_space_2d()
+    first = _lattice_patch(space)
+    swapped = _lattice_patch(space, offset=[1.0, 0.0]).permute_directions([1, 0])
+    assert swapped is not None
+    second = swapped.reverse(0)
+    assert second is not None
+
+    interfaces = detect_interfaces([first, second])
+
+    assert interfaces == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=2, axis_map=(0,), flips=(True,)),
+    )
+
+
+def test_detected_matches_coincide_geometrically() -> None:
+    """The control points a detected interface pairs really do coincide in space.
+
+    Guards the whole chain rather than the record alone: a wrong ``axis_map`` or
+    ``flips`` would still produce a plausible-looking Interface, but the paired
+    coordinates would not agree.
+    """
+    space = _anisotropic_space_2d()
+    first = _lattice_patch(space)
+    swapped = _lattice_patch(space, offset=[1.0, 0.0]).permute_directions([1, 0])
+    assert swapped is not None
+    second = swapped.reverse(0)
+    assert second is not None
+
+    (interface,) = detect_interfaces([first, second])
+    cps_a, cps_b = match_face_cps(
+        first.space,
+        interface.face_a,
+        second.space,
+        interface.face_b,
+        interface.axis_map,
+        interface.flips,
+    )
+    coords_a = first.control_points.reshape(-1, first.rank)[cps_a]
+    coords_b = second.control_points.reshape(-1, second.rank)[cps_b]
+
+    assert cps_a.size > 1, "a degenerate one-point match would make this vacuous"
+    np.testing.assert_allclose(coords_a, coords_b, atol=first.space.tolerance)
+
+
+def test_detect_corner_only_no_interface() -> None:
+    """Patches touching at a single corner share no face."""
+    space = _anisotropic_space_2d()
+    first = _lattice_patch(space)
+    diagonal = _lattice_patch(space, offset=[1.0, 1.0])
+
+    assert detect_interfaces([first, diagonal]) == ()
+
+
+def test_detect_disjoint_no_interface() -> None:
+    """Patches that do not touch share no face."""
+    space = _anisotropic_space_2d()
+    first = _lattice_patch(space)
+    far = _lattice_patch(space, offset=[5.0, 0.0])
+
+    assert detect_interfaces([first, far]) == ()
+
+
+def test_detect_rejects_refined_face_knots() -> None:
+    """Equal geometry but a refined knot vector on the shared face is not conforming."""
+    coarse = _anisotropic_space_2d()
+    refined = BsplineSpace([_open_space_1d(2, 1), _open_space_1d(2, 1)])
+    first = _lattice_patch(coarse)
+    second = _lattice_patch(refined, offset=[1.0, 0.0])
+
+    assert detect_interfaces([first, second]) == ()
+
+
+def test_detect_rejects_degree_mismatch() -> None:
+    """A different degree along the shared face is not conforming either."""
+    first = _lattice_patch(_anisotropic_space_2d())
+    other = BsplineSpace([_open_space_1d(2, 1), _open_space_1d(1, 0)])
+    second = _lattice_patch(other, offset=[1.0, 0.0])
+
+    assert detect_interfaces([first, second]) == ()
+
+
+def _rational_pair(weight_perturbation: float = 0.0) -> tuple[Bspline, Bspline]:
+    """Build two rational patches sharing a face, optionally breaking one weight.
+
+    The neighbour's shared column is copied from the first patch, weights included,
+    so the pair matches exactly regardless of how homogeneous coordinates are stored.
+    """
+    space = BsplineSpace([_open_space_1d(2, 0), _open_space_1d(2, 0)])
+    num_basis = space.num_basis
+    grids = np.meshgrid(*[np.linspace(0.0, 1.0, n) for n in num_basis], indexing="ij")
+    weights = 1.0 + 0.5 * grids[1]
+    first_cps = np.stack([*grids, weights], axis=-1)
+
+    second_cps = first_cps.copy()
+    second_cps[..., 0] += 1.0
+    # The shared column: patch b's low face must equal patch a's high face exactly.
+    second_cps[0, ...] = first_cps[-1, ...]
+    if weight_perturbation:
+        second_cps[0, 0, -1] += weight_perturbation
+
+    return (
+        Bspline(space, first_cps, is_rational=True),
+        Bspline(space, second_cps, is_rational=True),
+    )
+
+
+def test_detect_rational_matching_weights() -> None:
+    """Two rational patches whose shared face agrees in weights are matched."""
+    first, second = _rational_pair()
+
+    assert detect_interfaces([first, second]) == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),
+    )
+
+
+def test_detect_rational_weight_mismatch_rejected() -> None:
+    """Identical coordinates but a differing weight breaks the match."""
+    first, second = _rational_pair(weight_perturbation=0.25)
+
+    assert detect_interfaces([first, second]) == ()
+
+
+def test_detect_self_interface() -> None:
+    """A patch whose two opposite faces coincide yields a self-interface."""
+    space = BsplineSpace([_open_space_1d(1, 0), _open_space_1d(1, 0)])
+    # Degenerate in the first direction: both faces of axis 0 sit on the same edge.
+    cps = np.array([[[0.0, 0.0], [0.0, 1.0]], [[0.0, 0.0], [0.0, 1.0]]])
+    patch = Bspline(space, cps)
+
+    interfaces = detect_interfaces([patch])
+
+    assert interfaces == (
+        Interface(patch_a=0, face_a=0, patch_b=0, face_b=1, axis_map=(1,), flips=(False,)),
+    )
+
+
+def test_detect_l_shape_has_two_interfaces() -> None:
+    """Three patches in an L share exactly two faces."""
+    space = BsplineSpace([_open_space_1d(2, 0), _open_space_1d(2, 0)])
+    corner = _lattice_patch(space)
+    right = _lattice_patch(space, offset=[1.0, 0.0])
+    above = _lattice_patch(space, offset=[0.0, 1.0])
+
+    interfaces = detect_interfaces([corner, right, above])
+
+    assert len(interfaces) == 2
+    assert {(i.patch_a, i.patch_b) for i in interfaces} == {(0, 1), (0, 2)}
+
+
+def test_detect_scale_invariance() -> None:
+    """Detection survives a large uniform rescaling of the geometry.
+
+    The geometric tolerance is scaled by the joint bounding-box diagonal, so a
+    problem measured in different units must give the same topology. An absolute
+    epsilon would quietly stop matching here.
+    """
+    space = _anisotropic_space_2d()
+    for scale in (1e-4, 1.0, 1e5):
+        first = Bspline(space, _lattice_patch(space).control_points * scale)
+        second = Bspline(space, _lattice_patch(space, offset=[1.0, 0.0]).control_points * scale)
+        assert detect_interfaces([first, second]) == (
+            Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),
+        ), f"failed at scale {scale}"
+
+
+def test_detect_requires_common_dim() -> None:
+    """Mixing parametric dimensions is an error, not an empty result."""
+    flat = _lattice_patch(_anisotropic_space_2d())
+    solid = _lattice_patch(_anisotropic_space_3d())
+
+    with pytest.raises(ValueError, match="must share one parametric dimension"):
+        detect_interfaces([flat, solid])
+
+
+# ---------------------------------------------------------------- MultiPatch
+
+
+def test_multipatch_detects_by_default() -> None:
+    """Interfaces are detected when none are supplied."""
+    space = _anisotropic_space_2d()
+    mp = MultiPatch([_lattice_patch(space), _lattice_patch(space, offset=[1.0, 0.0])])
+
+    assert len(mp) == 2
+    assert mp.dim == 2
+    assert mp.interfaces == (
+        Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),
+    )
+    assert mp.patches[0].control_points.shape == (*space.num_basis, 2)
+
+
+def test_multipatch_accepts_valid_supplied_interfaces() -> None:
+    """A correct supplied interface is kept as given."""
+    space = _anisotropic_space_2d()
+    supplied = (Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),)
+    mp = MultiPatch([_lattice_patch(space), _lattice_patch(space, offset=[1.0, 0.0])], supplied)
+
+    assert mp.interfaces == supplied
+
+
+def test_multipatch_rejects_false_interface() -> None:
+    """A supplied interface that does not hold geometrically is rejected."""
+    space = _anisotropic_space_2d()
+    wrong = (Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(True,)),)
+
+    with pytest.raises(ValueError, match="does not hold for the given geometry"):
+        MultiPatch([_lattice_patch(space), _lattice_patch(space, offset=[1.0, 0.0])], wrong)
+
+
+def test_multipatch_rejects_out_of_range_patch_index() -> None:
+    """An interface naming a patch that does not exist is rejected."""
+    space = _anisotropic_space_2d()
+    bad = (Interface(patch_a=0, face_a=1, patch_b=7, face_b=0, axis_map=(1,), flips=(False,)),)
+
+    with pytest.raises(ValueError, match="out of range"):
+        MultiPatch([_lattice_patch(space), _lattice_patch(space, offset=[1.0, 0.0])], bad)
+
+
+def test_multipatch_requires_a_patch() -> None:
+    """An empty patch list is an error."""
+    with pytest.raises(ValueError, match="at least one patch"):
+        MultiPatch([])
+
+
+def test_multipatch_rejects_mixed_dim() -> None:
+    """Patches of different parametric dimension cannot be combined."""
+    with pytest.raises(ValueError, match="must share dim"):
+        MultiPatch(
+            [_lattice_patch(_anisotropic_space_2d()), _lattice_patch(_anisotropic_space_3d())]
+        )
+
+
+def test_multipatch_rejects_mixed_rationality() -> None:
+    """A rational and a polynomial patch cannot be combined."""
+    rational, _ = _rational_pair()
+    polynomial = _lattice_patch(BsplineSpace([_open_space_1d(2, 0), _open_space_1d(2, 0)]))
+
+    with pytest.raises(ValueError, match="must share is_rational"):
+        MultiPatch([rational, polynomial])
+
+
+def test_multipatch_rejects_mixed_rank() -> None:
+    """Patches embedded in different physical dimensions cannot be combined."""
+    space = BsplineSpace([_open_space_1d(2, 0), _open_space_1d(2, 0)])
+    planar = _lattice_patch(space)
+    num_basis = space.num_basis
+    spatial = Bspline(space, np.zeros((*num_basis, 3)))
+
+    with pytest.raises(ValueError, match="must share rank"):
+        MultiPatch([planar, spatial])


### PR DESCRIPTION
## Summary

New `pantr.multipatch` subpackage: the spline-side answer to how separate patches meet —
which faces coincide, how their tangential axes correspond, and which control-point pairs
are the same point. That is what a solver needs before it can unify dofs across a patch
boundary, and it is pure spline knowledge, so it belongs here rather than in the consumer.

- **`Interface`** — frozen dataclass, hashable and canonically ordered, carrying
  `axis_map`/`flips`. Validates face ids, that `axis_map` is a permutation of face b's
  tangential axes, and the canonical order.
- **`MultiPatch`** — validated patch collection; detects interfaces when none are given,
  and *verifies* rather than trusts the ones that are.
- **`detect_interfaces`** — conforming detection: corner pre-filter, then full verification
  of both control points and tangential knot vectors.
- **`match_face_cps`** — vectorized index arithmetic pairing two faces' flat CP ids.

No dolfinx, no `pantr.mpi`, no scipy. `cad.join` is untouched — it concatenates two
B-splines into a single patch, a different operation entirely.

## Two deliberate departures from the ticket

**1. Orientation search instead of corner-derived orientation.** The ticket derives
`axis_map`/`flips` from the corner correspondence and notes that symmetric corner sets make
this ambiguous. Rather than resolve that ambiguity, detection enumerates all
`(dim-1)! · 2^(dim-1)` orientations — 1 in 1D, 2 in 2D, 8 in 3D — and accepts the first
that verifies. Corners remain the cheap pre-filter they are genuinely good for. At 8
candidates worst case, each an O(face size) comparison, robustness costs nothing here, and
the ambiguous case stops being a special case at all.

**2. Three tolerances, not one.** The ticket asks for one tolerance scaled by the joint
bounding-box diagonal. Applied to all three comparisons that is a dimensional error:

- knot vectors are normalized to `[0, 1]` and carry **no length scale**;
- NURBS weights are **not lengths** either.

A patch measured in millimetres would accept weight differences a metre apart — which is
the ticket's own "weight mismatch must break a match" requirement failing silently. So
coordinates use the diagonal-scaled tolerance, knots the bare relative one, and weights one
scaled by the largest weight in play. The `_Tolerances` named tuple documents each and why.

**Note on `axis_map`:** entries are patch axes of B, not positions within B's tangential
list. The ticket is ambiguous, but its own example (`axis_map=(1,)` at `dim=2`) only parses
that way — with `dim=2` the tangential list has length 1, so position `1` could not exist.

## Test plan

37 new cases, all passing:

- [x] Translated patches in 1D, 2D and 3D, the 3D case parametrized over all three axes so
      **all six faces** are exercised; expected `Interface` compared exactly
- [x] Neighbour with permuted axes → `axis_map` recovers it; additionally reversed along the
      tangential axis → `flips=(True,)` recovered
- [x] **The paired control points are checked to coincide geometrically**, not just the
      record — a plausible-looking but wrong `axis_map` would produce a valid-looking
      `Interface` and fail here. Guarded against vacuity (`cps_a.size > 1`)
- [x] Rejections: corner-only contact, disjoint patches, refined face knots, degree
      mismatch, and identical coordinates with one differing weight
- [x] Rational pair with matching weights is accepted (the neighbour's shared column is
      copied from the first patch, so the test holds regardless of how homogeneous
      coordinates are stored)
- [x] Self-interface on a degenerate patch whose two opposite faces coincide
- [x] Three-patch L-shape → exactly 2 interfaces
- [x] **Scale invariance** over 10⁻⁴ … 10⁵: the same topology at every scale, which an
      absolute epsilon would quietly fail
- [x] `match_face_cps` against an **independent nested-loop oracle** over every face pair
      and every orientation in 1D/2D/3D, including the `ValueError` on incompatible
      tangential sizes; sorted `cps_a`; frozen outputs
- [x] `Interface` immutability, hash/eq, canonical ordering, and every `__post_init__`
      rejection
- [x] `MultiPatch` validation: false interface, out-of-range patch index, empty list, mixed
      dim / rank / rationality
- [x] The two docstring examples run as doctests

Full suite: 4239 passed, 19 skipped. ruff, ruff-format, mypy (220 files) and the `-W` docs
build all pass. **import-lint contract kept** — the new core modules do not reach
`pantr.mpi`, which the grimp test also covers automatically. The one pre-existing local
failure, `test_pantr_toplevel_does_not_import_mpi`, is environmental and fixed by #274.

Also adds `pantr.multipatch` to the docs module map and API reference, since a new public
subpackage absent from the reference is invisible.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
