### PR TITLE
feat(bspline): public cached first_basis_per_interval and cell_supports

### DIFF
--- a/src/pantr/bspline/_bspline_cell_supports.py
+++ b/src/pantr/bspline/_bspline_cell_supports.py
@@ -1,0 +1,76 @@
+"""Per-cell control-point support of a tensor-product B-spline space.
+
+Layer-2 helper behind :meth:`~pantr.bspline.BsplineSpace.cell_supports`: it does all
+the validation and the vectorized index arithmetic, so the Layer-1 method stays a
+thin delegation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from ._bspline_space_nd import BsplineSpace
+
+
+def _cell_supports_impl(space: BsplineSpace, cell_ids: npt.ArrayLike) -> npt.NDArray[np.int64]:
+    """Return the control points supported on each of the given cells.
+
+    Args:
+        space (BsplineSpace): The tensor-product space.
+        cell_ids (npt.ArrayLike): Flat cell ids, C-order over
+            :attr:`~pantr.bspline.BsplineSpace.num_intervals`.
+
+    Returns:
+        npt.NDArray[np.int64]: Array of shape ``(n, W)`` with
+        ``W = prod(degree + 1)``. Column ``k`` corresponds to the local offset whose
+        C-order index within ``degrees + 1`` is ``k``, and holds the flat C-order
+        control-point id.
+
+    Raises:
+        ValueError: If any direction is periodic, ``cell_ids`` is not of integer
+            dtype, is not one-dimensional, or holds an id outside
+            ``[0, num_total_intervals)``.
+    """
+    periodic = [k for k, one_d in enumerate(space.spaces) if one_d.periodic]
+    if periodic:
+        raise ValueError(
+            f"cell_supports: periodic B-spline spaces are not supported; "
+            f"direction(s) {periodic} are periodic."
+        )
+
+    ids = np.asarray(cell_ids)
+    if ids.ndim == 0:
+        ids = ids.reshape(1)
+    if ids.ndim != 1:
+        raise ValueError(f"cell_ids must be one-dimensional; got shape {ids.shape}")
+    if ids.size and not np.issubdtype(ids.dtype, np.integer):
+        raise ValueError(f"cell_ids must have an integer dtype; got {ids.dtype}")
+
+    num_intervals = space.num_intervals
+    num_basis = space.num_basis
+    degrees = space.degrees
+    width = int(np.prod([degree + 1 for degree in degrees]))
+
+    if ids.size == 0:
+        return np.empty((0, width), dtype=np.int64)
+
+    total = space.num_total_intervals
+    if int(ids.min()) < 0 or int(ids.max()) >= total:
+        raise ValueError(
+            f"cell_ids must lie in [0, {total}); got range [{int(ids.min())}, {int(ids.max())}]"
+        )
+
+    multi = np.unravel_index(ids.astype(np.int64), num_intervals)
+    # One (width,) offset vector per direction, C-order over degrees + 1, so that
+    # column k of the result always means the same local offset.
+    offset_grids = np.meshgrid(*[np.arange(degree + 1) for degree in degrees], indexing="ij")
+    per_direction = tuple(
+        space.spaces[direction].first_basis_per_interval()[multi[direction]][:, None]
+        + offset_grids[direction].reshape(1, width)
+        for direction in range(space.dim)
+    )
+    return np.ravel_multi_index(per_direction, num_basis).astype(np.int64)

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -309,6 +309,60 @@ class BsplineSpace1D:
         unique_knots, _ = self.get_unique_knots_and_multiplicity(in_domain=True)
         return len(unique_knots) - 1
 
+    @functools.cached_property
+    def _first_basis_per_interval_cached(self) -> npt.NDArray[np.int64]:
+        """Compute and freeze the first supported basis index of each interval.
+
+        Cached because the knot vector is immutable, and frozen because the cached
+        array is handed out directly.
+
+        The index is exact integer arithmetic, no basis evaluation: the functions
+        non-zero on the span starting at knot index ``k`` are ``k - degree`` through
+        ``k``, so the first one is ``k - degree``, where ``k`` is the *last* position
+        at which that unique knot occurs. Selecting the unique knots whose last
+        position lies in ``[degree, num_basis)`` picks out exactly the knots that
+        start an in-domain interval, which makes the first interval no different from
+        the rest and needs no special case for a non-clamped knot vector.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only array of shape ``(num_intervals,)``.
+        """
+        _, multiplicities = self.get_unique_knots_and_multiplicity(in_domain=False)
+        last_position = np.cumsum(np.asarray(multiplicities, dtype=np.int64)) - 1
+        starts_an_interval = (last_position >= self._degree) & (last_position < self.num_basis)
+        first_basis = (last_position[starts_an_interval] - self._degree).astype(np.int64)
+        first_basis.flags.writeable = False
+        return first_basis
+
+    def first_basis_per_interval(self) -> npt.NDArray[np.int64]:
+        """Get the index of the first B-spline function supported on each interval.
+
+        Entry ``j`` is the smallest global function index ``i`` whose function is
+        non-zero on the open interval between in-domain unique knots ``j`` and
+        ``j + 1``. The functions non-zero there are exactly ``i`` through
+        ``i + degree``, so this one index describes the whole support of the interval.
+
+        The result is cached and read-only: repeated calls return the same array.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only ``int64`` array of shape
+            ``(num_intervals,)``, non-decreasing, whose successive differences are
+            the interior knot multiplicities.
+
+        Raises:
+            ValueError: If the space is periodic.
+
+        Example:
+            >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2)
+            >>> space.first_basis_per_interval()
+            array([0, 1, 3])
+        """
+        if self._periodic:
+            raise ValueError(
+                "first_basis_per_interval: periodic B-spline spaces are not supported."
+            )
+        return self._first_basis_per_interval_cached
+
     def _get_domain_indices(self) -> tuple[int, int]:
         """Get the domain boundary indices of the knot vector.
 

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -16,6 +16,7 @@ import numpy as np
 from numpy import typing as npt
 
 from ._bspline_basis_multidim import _tabulate_Bspline_basis_impl
+from ._bspline_cell_supports import _cell_supports_impl
 
 if TYPE_CHECKING:
     from ..quad import PointsLattice
@@ -217,6 +218,42 @@ class BsplineSpace:
         return _tabulate_Bspline_basis_impl(
             self, pts, out_basis=out_basis, out_first_basis=out_first_basis
         )
+
+    def cell_supports(self, cell_ids: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        """Return the control points supported on each of the given cells.
+
+        Every cell of a tensor-product space is supported by exactly
+        ``prod(degree + 1)`` control points, contiguous per direction, so the result
+        is a dense ``(n, W)`` table rather than a ragged structure. Column ``k``
+        always means the same local offset: the one whose C-order index within
+        ``degrees + 1`` is ``k``.
+
+        Args:
+            cell_ids (npt.ArrayLike): Flat knot-span cell ids in C-order over
+                :attr:`num_intervals`, the same convention as
+                :func:`pantr.grid.tensor_product_grid` and
+                :class:`SpanwiseElementExtraction`. Each must satisfy
+                ``0 <= cid < num_total_intervals``.
+
+        Returns:
+            npt.NDArray[np.int64]: Array of shape ``(n, prod(degree + 1))`` of flat
+            C-order control-point ids. Empty input gives shape ``(0, W)``.
+
+        Raises:
+            ValueError: If any direction is periodic, ``cell_ids`` is not integral or
+                one-dimensional, or an id is out of range.
+
+        Example:
+            >>> from pantr.bspline import BsplineSpace, BsplineSpace1D
+            >>> first = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+            >>> second = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
+            >>> space = BsplineSpace([first, second])
+            >>> space.num_basis
+            (5, 3)
+            >>> space.cell_supports([0])
+            array([[0, 1, 2, 3, 4, 5, 6, 7, 8]])
+        """
+        return _cell_supports_impl(self, cell_ids)
 
     def restrict(self, cell_ids: npt.ArrayLike) -> BsplineSpaceRestriction:
         """Return the bounding-box windowed sub-space spanning ``cell_ids``.

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -147,11 +147,10 @@ def _box_all_true(
 def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
     """Compute the cell support of every B-spline function of a 1D space.
 
-    The first non-zero function index per interval is obtained from
-    :meth:`~pantr.bspline.BsplineSpace1D.tabulate_basis` evaluated at interval
-    midpoints (robust to knot multiplicities), then inverted to give, for each
-    function ``i``, the inclusive interval (cell) range ``[first_cell, last_cell]``
-    it is supported on.
+    The first non-zero function index per interval comes from
+    :meth:`~pantr.bspline.BsplineSpace1D.first_basis_per_interval`, which is then
+    inverted to give, for each function ``i``, the inclusive interval (cell) range
+    ``[first_cell, last_cell]`` it is supported on.
 
     Args:
         space (BsplineSpace1D): The 1D B-spline space.
@@ -161,10 +160,7 @@ def _func_support_1d(space: BsplineSpace1D) -> _Support1D:
         has length ``num_intervals`` and ``first_cell`` / ``last_cell`` have length
         ``num_basis``.
     """
-    unique_knots, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
-    midpoints = 0.5 * (unique_knots[:-1] + unique_knots[1:])
-    _, first_basis_per_pt = space.tabulate_basis(midpoints)
-    first_basis = np.asarray(first_basis_per_pt, dtype=np.int64)
+    first_basis = space.first_basis_per_interval()
 
     degree = space.degree
     n_basis = space.num_basis

--- a/tests/test_bspline_space.py
+++ b/tests/test_bspline_space.py
@@ -1,9 +1,16 @@
 """Tests for bspline_space module."""
 
+import itertools
+
 import numpy as np
 import pytest
 
-from pantr.bspline import BsplineSpace, BsplineSpace1D, BsplineSpaceRestriction
+from pantr.bspline import (
+    BsplineSpace,
+    BsplineSpace1D,
+    BsplineSpaceRestriction,
+    create_uniform_periodic_knots,
+)
 from pantr.quad import PointsLattice
 
 
@@ -1101,3 +1108,112 @@ class TestBsplineSpaceRestrict:
         space = BsplineSpace([per])
         with pytest.raises(ValueError, match="periodic"):
             space.restrict([0])
+
+
+# ---------------------------------------------------------------- cell_supports
+
+
+def _cell_support_by_tabulation(space: BsplineSpace, cell_id: int) -> list[int]:
+    """Reference row of `cell_supports`, built by tabulating the basis per direction.
+
+    An independent oracle: it finds each direction's first supported function by
+    evaluating the basis at the cell midpoint, then forms the flat ids with an explicit
+    Python loop, sharing none of the vectorized index arithmetic under test.
+    """
+    multi = np.unravel_index(cell_id, space.num_intervals)
+    firsts = []
+    for direction, one_d in enumerate(space.spaces):
+        unique_knots, _ = one_d.get_unique_knots_and_multiplicity(in_domain=True)
+        index = int(multi[direction])
+        midpoint = np.array([0.5 * (unique_knots[index] + unique_knots[index + 1])])
+        _, first_basis = one_d.tabulate_basis(midpoint)
+        firsts.append(int(first_basis[0]))
+
+    row = []
+    for offsets in itertools.product(*[range(degree + 1) for degree in space.degrees]):
+        indices = tuple(first + offset for first, offset in zip(firsts, offsets, strict=True))
+        row.append(int(np.ravel_multi_index(indices, space.num_basis)))
+    return row
+
+
+@pytest.mark.parametrize(
+    "degrees",
+    [(2,), (2, 1), (1, 3), (3, 4, 2)],
+)
+def test_cell_supports_matches_tabulation(degrees: tuple[int, ...]) -> None:
+    """Every row equals an independent per-direction tabulation reference, exactly."""
+    space = BsplineSpace([_open_uniform_space_1d(degree, degree + 1) for degree in degrees])
+    cell_ids = np.arange(space.num_total_intervals)
+
+    supports = space.cell_supports(cell_ids)
+
+    expected_width = int(np.prod([degree + 1 for degree in degrees]))
+    assert supports.shape == (space.num_total_intervals, expected_width)
+    assert supports.dtype == np.int64
+    for cell_id in cell_ids:
+        assert supports[cell_id].tolist() == _cell_support_by_tabulation(space, int(cell_id))
+
+
+def test_cell_supports_with_repeated_interior_knots() -> None:
+    """Repeated interior knots shift the supports, and the reference agrees."""
+    space = BsplineSpace(
+        [
+            BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2),
+            BsplineSpace1D([0, 0, 1, 1], 1),
+        ]
+    )
+    cell_ids = np.arange(space.num_total_intervals)
+
+    supports = space.cell_supports(cell_ids)
+
+    for cell_id in cell_ids:
+        assert supports[cell_id].tolist() == _cell_support_by_tabulation(space, int(cell_id))
+
+
+def test_cell_supports_documented_example() -> None:
+    """The 2D example from the specification reproduces exactly."""
+    space = BsplineSpace(
+        [
+            BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2),
+            BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2),
+        ]
+    )
+    assert space.num_basis == (5, 4)
+
+    flat = int(np.ravel_multi_index((0, 1), space.num_intervals))
+
+    assert space.cell_supports([flat]).tolist() == [[1, 2, 3, 5, 6, 7, 9, 10, 11]]
+
+
+def test_cell_supports_empty_input() -> None:
+    """An empty id list gives an empty table of the right width."""
+    space = BsplineSpace([_open_uniform_space_1d(2, 3), _open_uniform_space_1d(1, 2)])
+
+    supports = space.cell_supports([])
+
+    assert supports.shape == (0, 6)
+    assert supports.dtype == np.int64
+
+
+def test_cell_supports_validation() -> None:
+    """Out-of-range, non-integer and non-1D inputs are rejected."""
+    space = BsplineSpace([_open_uniform_space_1d(2, 3), _open_uniform_space_1d(1, 2)])
+    total = space.num_total_intervals
+
+    with pytest.raises(ValueError, match=r"must lie in \[0, "):
+        space.cell_supports([total])
+    with pytest.raises(ValueError, match=r"must lie in \[0, "):
+        space.cell_supports([-1])
+    with pytest.raises(ValueError, match="integer dtype"):
+        space.cell_supports([0.5])
+    with pytest.raises(ValueError, match="one-dimensional"):
+        space.cell_supports([[0, 1], [2, 3]])
+
+
+def test_cell_supports_rejects_periodic() -> None:
+    """Periodic directions are rejected, as for restrict."""
+    knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+    space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+
+    with pytest.raises(ValueError, match="periodic"):
+        space.cell_supports([0])

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -2591,3 +2591,119 @@ class TestTabulateValidateFlag:
         np.testing.assert_array_equal(f_no, f_val)
         # validate=False should not raise for in-domain points on a Bézier-like space.
         sp.tabulate_basis_derivatives(pts, 2, validate=False)
+
+
+# ---------------------------------------------------------------- first_basis_per_interval
+
+
+def _first_basis_by_tabulation(space: BsplineSpace1D) -> npt.NDArray[np.int64]:
+    """Reference first-supported-function index, via basis tabulation at midpoints.
+
+    The independent oracle for `first_basis_per_interval`, which uses exact integer
+    arithmetic instead. Midpoints never coincide with a knot, so this route is robust
+    to interior multiplicities up to `degree + 1`.
+    """
+    unique_knots, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
+    midpoints = 0.5 * (unique_knots[:-1] + unique_knots[1:])
+    _, first_basis = space.tabulate_basis(midpoints)
+    return np.asarray(first_basis, dtype=np.int64)
+
+
+@pytest.mark.parametrize("degree", [1, 2, 3, 4])
+def test_first_basis_per_interval_uniform_open(degree: int) -> None:
+    """On uniform open knots the first index advances by one per interval."""
+    n_intervals = 5
+    knots = [0.0] * (degree + 1) + [float(j) for j in range(1, n_intervals)]
+    knots += [float(n_intervals)] * (degree + 1)
+    space = BsplineSpace1D(knots, degree)
+
+    first = space.first_basis_per_interval()
+
+    assert first.dtype == np.int64
+    assert first.shape == (space.num_intervals,)
+    np.testing.assert_array_equal(first, np.arange(n_intervals, dtype=np.int64))
+    assert int(first[0]) == 0
+    assert int(first[-1]) == space.num_basis - degree - 1
+
+
+def test_first_basis_per_interval_interior_multiplicity() -> None:
+    """A repeated interior knot makes the index jump by that multiplicity."""
+    doubled = BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2)
+    np.testing.assert_array_equal(
+        doubled.first_basis_per_interval(), np.array([0, 1, 3], dtype=np.int64)
+    )
+
+    single = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+    np.testing.assert_array_equal(
+        single.first_basis_per_interval(), np.array([0, 1, 2], dtype=np.int64)
+    )
+
+
+@pytest.mark.parametrize("multiplicity", [1, 2, 3])
+def test_first_basis_per_interval_c0_and_discontinuous(multiplicity: int) -> None:
+    """Interior multiplicity up to ``degree + 1`` (C^0 and C^-1) is handled exactly."""
+    degree = 2
+    knots = [0.0] * (degree + 1) + [1.0] * multiplicity + [2.0] * (degree + 1)
+    space = BsplineSpace1D(knots, degree)
+
+    first = space.first_basis_per_interval()
+
+    np.testing.assert_array_equal(first, _first_basis_by_tabulation(space))
+    assert int(first[1]) - int(first[0]) == multiplicity
+
+
+def test_first_basis_per_interval_matches_tabulation_property() -> None:
+    """Over many random knot vectors the exact route equals basis tabulation.
+
+    This is what licenses the exact integer arithmetic: it never evaluates the basis,
+    so a wrong derivation would not show up as a tolerance failure but as a plainly
+    wrong index, and only a comparison against the evaluating route catches it.
+    """
+    rng = np.random.default_rng(20260813)
+    checked = 0
+    for _ in range(300):
+        degree = int(rng.integers(0, 5))
+        n_intervals = int(rng.integers(1, 7))
+        interior: list[float] = []
+        for j in range(1, n_intervals):
+            interior += [float(j)] * int(rng.integers(1, degree + 2))
+        knots = [0.0] * (degree + 1) + interior + [float(n_intervals)] * (degree + 1)
+        space = BsplineSpace1D(knots, degree)
+
+        np.testing.assert_array_equal(
+            space.first_basis_per_interval(), _first_basis_by_tabulation(space)
+        )
+        checked += 1
+    assert checked == 300
+
+
+def test_first_basis_per_interval_is_non_decreasing() -> None:
+    """The index never decreases, and its steps are the interior multiplicities."""
+    space = BsplineSpace1D([0, 0, 0, 1, 1, 2, 3, 3, 4, 4, 4], 2)
+
+    first = space.first_basis_per_interval()
+    _, multiplicities = space.get_unique_knots_and_multiplicity(in_domain=True)
+
+    assert np.all(np.diff(first) > 0)
+    np.testing.assert_array_equal(np.diff(first), np.asarray(multiplicities[1:-1]))
+
+
+def test_first_basis_per_interval_cached_and_frozen() -> None:
+    """The same read-only array comes back on every call."""
+    space = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+
+    first = space.first_basis_per_interval()
+
+    assert first is space.first_basis_per_interval()
+    assert not first.flags.writeable
+    with pytest.raises(ValueError):
+        first[0] = 7
+
+
+def test_first_basis_per_interval_rejects_periodic() -> None:
+    """Periodic spaces are rejected, as elsewhere in the 1D API."""
+    knots = create_uniform_periodic_knots(num_intervals=3, degree=2, domain=(0.0, 1.0))
+    space = BsplineSpace1D(knots, 2, periodic=True)
+
+    with pytest.raises(ValueError, match="periodic B-spline spaces are not supported"):
+        space.first_basis_per_interval()


### PR DESCRIPTION
## Summary

Both parts of the ticket, one commit each.

**`BsplineSpace1D.first_basis_per_interval()`** — promotes the first-supported-function
index per interval from a private helper in the THB module to a public cached accessor on
the 1D space, where a generic property of a 1D space belongs. A consumer building a dofmap
needs it per direction and should not have to reach into
`_thb_spline_space._func_support_1d`.

**`BsplineSpace.cell_supports(cell_ids)`** — the tensor-product counterpart: the
`prod(degree + 1)` control points supported on each of the given cells, as a dense `(n, W)`
table. Column `k` always means the same local offset (C-order within `degrees + 1`).

## Exact integer arithmetic instead of tabulation

The ticket allowed either the midpoint-tabulation route or an exact-integer one, requiring
a cross-check if the latter was chosen. It was, in a slightly different form than the ticket
sketched:

> `first[j] = last_position(u_j) - degree`

The functions non-zero on the span starting at knot index `k` are `k - degree` through `k`,
so the first is `k - degree`, where `k` is the **last** position at which that unique knot
occurs. Selecting the unique knots whose last position lies in `[degree, num_basis)` picks
out exactly the knots that start an in-domain interval — which makes the first interval no
different from the rest, so there is no special case even for a knot vector that is not
clamped. No floating point and no basis evaluation at all.

**Cross-check done, and kept in the suite:** the exact route and midpoint tabulation agree
*exactly* on 300 random knot vectors with interior multiplicities up to `degree + 1`, and on
both worked examples in the ticket. That property test earns its place — a wrong derivation
here would surface as a plainly wrong integer, not as a tolerance failure, and only the
evaluating route catches it.

## Behaviour preserved for existing consumers

`_func_support_1d` now consumes the new accessor for its first stage. The **398 existing
THB, halo, dof_owner and local-space tests pass untouched**, so `compute_halo` and
`dof_owner` inherit the change for free, as the ticket expected.

For `cell_supports`, validation and the vectorized body live in a new Layer-2 module
(`_bspline_cell_supports._cell_supports_impl`), mirroring how `tabulate_basis` delegates to
`_bspline_basis_multidim`; the Layer-1 method is a thin delegation. Broadcast index
arithmetic, no per-cell Python loop.

## Test plan

23 new cases, all passing:

- [x] Uniform open knots, degrees 1–4: index advances by one per interval; `first[0] == 0`
      and `first[-1] == num_basis - degree - 1`; dtype, shape
- [x] Repeated interior knot: both ticket examples exactly (`[0, 1, 3]` and `[0, 1, 2]`)
- [x] Interior multiplicity 1, 2 and 3 at degree 2 (through C⁻¹), against tabulation
- [x] **Property test over 300 random knot vectors** against the tabulation oracle
- [x] Non-decreasing, with steps equal to the interior multiplicities
- [x] Cached (same object) and frozen (write raises); periodic raises
- [x] `cell_supports` against an **independent oracle** (midpoint tabulation + explicit
      Python loop, sharing none of the machinery under test) for degrees `(2,)`, `(2,1)`,
      `(1,3)`, `(3,4,2)` and for a space with a repeated interior knot — exact integer
      equality over every cell
- [x] The ticket's 2D worked example reproduces exactly: `[[1, 2, 3, 5, 6, 7, 9, 10, 11]]`
- [x] Empty input → `(0, W)`; out-of-range, non-integer and 2D inputs rejected; periodic
      rejected
- [x] Both new docstring examples run as doctests

Full suite: 4223 passed, 19 skipped. ruff, ruff-format, mypy (215 files), import-lint and
the `-W` docs build all pass. The one pre-existing local failure,
`test_pantr_toplevel_does_not_import_mpi`, is environmental and fixed by #274.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
