### PR TITLE
feat(bspline): BsplineSpace.boundary_dofs for boundary-slab control points

### DIFF
--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -255,6 +255,82 @@ class BsplineSpace:
         """
         return _cell_supports_impl(self, cell_ids)
 
+    def boundary_dofs(
+        self,
+        direction: int,
+        side: int,
+        layers: int = 1,
+    ) -> npt.NDArray[np.int64]:
+        """Return the control points of a boundary slab, as flat C-order ids.
+
+        The slab holds the control points whose index along ``direction`` lies in the
+        first (``side == 0``) or last (``side == 1``) ``layers`` positions, and every
+        index on the remaining axes. For an open knot vector, ``layers == 1`` selects
+        exactly the basis functions with non-zero trace on that face, which is what a
+        strong Dirichlet condition needs; a thicker slab serves a clamped or
+        :math:`C^1` condition.
+
+        The result holds **control-point** ids over :attr:`num_basis`, never cell ids
+        over :attr:`num_intervals`. Interior knot multiplicities do not affect it: a
+        boundary slab is a notion in index space.
+
+        Args:
+            direction (int): Axis of the face, in ``[0, dim)``.
+            side (int): ``0`` for the low face, ``1`` for the high face. Together with
+                ``direction`` this is the ``lfid = 2 * direction + side`` encoding of
+                :meth:`pantr.grid.Grid.local_facet_axis_side`.
+            layers (int): Slab thickness in control-point indices, in
+                ``[1, num_basis[direction]]``. Defaults to 1.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only, strictly ascending flat C-order
+            control-point ids, of shape
+            ``(layers * num_total_basis // num_basis[direction],)``.
+
+        Raises:
+            ValueError: If ``direction``, ``side`` or ``layers`` is out of range, or if
+                any direction is periodic -- a periodic direction has no boundary.
+
+        Example:
+            >>> from pantr.bspline import BsplineSpace, BsplineSpace1D
+            >>> first = BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2)
+            >>> second = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
+            >>> space = BsplineSpace([first, second])
+            >>> space.num_basis
+            (5, 4)
+            >>> space.boundary_dofs(0, 0)
+            array([0, 1, 2, 3])
+            >>> space.boundary_dofs(1, 0)
+            array([ 0,  4,  8, 12, 16])
+            >>> space.boundary_dofs(1, 1, layers=2)
+            array([ 2,  3,  6,  7, 10, 11, 14, 15, 18, 19])
+        """
+        if any(space.periodic for space in self._spaces):
+            raise ValueError("boundary_dofs: periodic B-spline spaces are not supported.")
+        if not 0 <= direction < self.dim:
+            raise ValueError(
+                f"boundary_dofs: direction must lie in [0, {self.dim}); got {direction}."
+            )
+        if side not in (0, 1):
+            raise ValueError(f"boundary_dofs: side must be 0 (low) or 1 (high); got {side}.")
+        num_basis_dir = self.num_basis[direction]
+        if not 1 <= layers <= num_basis_dir:
+            raise ValueError(
+                f"boundary_dofs: layers must lie in [1, {num_basis_dir}]; got {layers}."
+            )
+
+        first = 0 if side == 0 else num_basis_dir - layers
+        axes = [np.arange(n, dtype=np.int64) for n in self.num_basis]
+        axes[direction] = np.arange(first, first + layers, dtype=np.int64)
+
+        # Each axis range is ascending and the C-order flat id is monotone in the
+        # lexicographic order of the multi-index, so the slab comes out sorted and
+        # unique without an explicit sort.
+        mesh = np.meshgrid(*axes, indexing="ij")
+        dofs = np.ravel_multi_index(tuple(m.ravel() for m in mesh), self.num_basis).astype(np.int64)
+        dofs.flags.writeable = False
+        return dofs
+
     def restrict(self, cell_ids: npt.ArrayLike) -> BsplineSpaceRestriction:
         """Return the bounding-box windowed sub-space spanning ``cell_ids``.
 

--- a/tests/test_bspline_space.py
+++ b/tests/test_bspline_space.py
@@ -1217,3 +1217,161 @@ def test_cell_supports_rejects_periodic() -> None:
 
     with pytest.raises(ValueError, match="periodic"):
         space.cell_supports([0])
+
+
+# --------------------------------------------------------------- boundary_dofs
+
+
+def _boundary_dofs_bruteforce(
+    space: BsplineSpace, direction: int, side: int, layers: int
+) -> list[int]:
+    """Reference row of `boundary_dofs`, by filtering every dof on its unraveled index.
+
+    An independent oracle: it walks all dofs with `unravel_index` and keeps the ones
+    inside the slab, sharing none of the vectorized `ravel_multi_index` arithmetic
+    under test.
+    """
+    num_basis_dir = space.num_basis[direction]
+    first = 0 if side == 0 else num_basis_dir - layers
+    return [
+        flat
+        for flat in range(space.num_total_basis)
+        if first <= int(np.unravel_index(flat, space.num_basis)[direction]) < first + layers
+    ]
+
+
+def test_boundary_dofs_2d_known_values() -> None:
+    """The documented 2D slabs reproduce exactly, flat ids being ``i0 * 4 + i1``."""
+    space = BsplineSpace(
+        [
+            BsplineSpace1D([0, 0, 0, 1, 2, 3, 3, 3], 2),
+            BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2),
+        ]
+    )
+    assert space.num_basis == (5, 4)
+
+    assert space.boundary_dofs(0, 0).tolist() == [0, 1, 2, 3]
+    assert space.boundary_dofs(0, 1).tolist() == [16, 17, 18, 19]
+    assert space.boundary_dofs(1, 0).tolist() == [0, 4, 8, 12, 16]
+    assert space.boundary_dofs(1, 1, layers=2).tolist() == [2, 3, 6, 7, 10, 11, 14, 15, 18, 19]
+    assert space.boundary_dofs(0, 0, layers=5).tolist() == list(range(20))
+
+
+def test_boundary_dofs_3d_known_values() -> None:
+    """A 3D tangential slab holds ``num_basis[0] * num_basis[2]`` ids of the form i0*20+i2."""
+    space = BsplineSpace(
+        [
+            BsplineSpace1D([0, 0, 0, 1, 1, 1], 2),
+            _open_uniform_space_1d(2, 2),
+            _open_uniform_space_1d(2, 3),
+        ]
+    )
+    assert space.num_basis == (3, 4, 5)
+
+    dofs = space.boundary_dofs(1, 0)
+
+    assert dofs.tolist() == [i0 * 20 + i2 for i0 in range(3) for i2 in range(5)]
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        BsplineSpace([_open_uniform_space_1d(2, 4)]),
+        BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(1, 3)]),
+        BsplineSpace(
+            [
+                _open_uniform_space_1d(3, 2),
+                _open_uniform_space_1d(4, 2),
+                _open_uniform_space_1d(2, 3),
+            ]
+        ),
+        BsplineSpace(
+            [BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2), _open_uniform_space_1d(1, 3)]
+        ),
+    ],
+    ids=["1d_p2", "2d_aniso_p21", "3d_aniso_p342", "repeated_interior_knots"],
+)
+def test_boundary_dofs_matches_bruteforce(space: BsplineSpace) -> None:
+    """Every face, side and thickness equals the brute-force filter, exactly."""
+    for direction in range(space.dim):
+        num_basis_dir = space.num_basis[direction]
+        for side in (0, 1):
+            for layers in range(1, min(3, num_basis_dir) + 1):
+                dofs = space.boundary_dofs(direction, side, layers)
+
+                assert dofs.tolist() == _boundary_dofs_bruteforce(space, direction, side, layers)
+                assert dofs.dtype == np.int64
+                assert not dofs.flags.writeable
+                assert dofs.shape == (layers * space.num_total_basis // num_basis_dir,)
+                # unique() both sorts and deduplicates, so equality proves the slab is
+                # emitted strictly ascending with no repeats and needs no sort.
+                np.testing.assert_array_equal(np.unique(dofs), dofs)
+
+
+def test_boundary_dofs_trace_property() -> None:
+    """With open knots, ``layers=1`` is exactly the set with non-zero trace on the face."""
+    space = BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(3, 3)])
+
+    for direction in range(space.dim):
+        one_d = space.spaces[direction]
+        for side in (0, 1):
+            endpoint = np.array([one_d.domain[side]], dtype=np.float64)
+            values, first_basis = one_d.tabulate_basis(endpoint)
+            on_face = {
+                int(first_basis[0]) + local
+                for local in range(one_d.degree + 1)
+                if abs(float(values[0, local])) > space.tolerance
+            }
+            # The clamped end leaves a single function alive on the face; if that ever
+            # stopped holding, layers=1 would no longer mean "non-zero trace".
+            assert len(on_face) == 1
+
+            axis_indices = [set(range(n)) for n in space.num_basis]
+            axis_indices[direction] = on_face
+            expected = sorted(
+                int(np.ravel_multi_index(multi, space.num_basis))
+                for multi in itertools.product(*axis_indices)
+            )
+
+            assert space.boundary_dofs(direction, side).tolist() == expected
+
+
+def test_boundary_dofs_layers_nested() -> None:
+    """A thicker slab strictly contains a thinner one, and the full thickness is every dof."""
+    space = BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(2, 3)])
+
+    for direction in range(space.dim):
+        num_basis_dir = space.num_basis[direction]
+        for side in (0, 1):
+            for layers in range(1, num_basis_dir):
+                thin = set(space.boundary_dofs(direction, side, layers).tolist())
+                thick = set(space.boundary_dofs(direction, side, layers + 1).tolist())
+                assert thin < thick
+
+            full = space.boundary_dofs(direction, side, num_basis_dir)
+            assert full.tolist() == list(range(space.num_total_basis))
+
+
+def test_boundary_dofs_validation() -> None:
+    """Out-of-range direction, side and layers are rejected."""
+    space = BsplineSpace([_open_uniform_space_1d(2, 4), _open_uniform_space_1d(1, 3)])
+
+    with pytest.raises(ValueError, match=r"direction must lie in \[0, 2\)"):
+        space.boundary_dofs(2, 0)
+    with pytest.raises(ValueError, match="direction must lie"):
+        space.boundary_dofs(-1, 0)
+    with pytest.raises(ValueError, match="side must be 0"):
+        space.boundary_dofs(0, 2)
+    with pytest.raises(ValueError, match="layers must lie"):
+        space.boundary_dofs(0, 0, layers=0)
+    with pytest.raises(ValueError, match="layers must lie"):
+        space.boundary_dofs(0, 0, layers=space.num_basis[0] + 1)
+
+
+def test_boundary_dofs_rejects_periodic() -> None:
+    """Periodic directions are rejected: a periodic direction has no boundary."""
+    knots = create_uniform_periodic_knots(num_intervals=4, degree=2)
+    space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+
+    with pytest.raises(ValueError, match="periodic"):
+        space.boundary_dofs(0, 0)


### PR DESCRIPTION
## Summary

Adds `BsplineSpace.boundary_dofs(direction, side, layers=1)`, returning the control
points of a boundary slab as flat C-order ids: the first (`side=0`) or last (`side=1`)
`layers` indices along `direction`, and every index on the remaining axes. `side`
follows the `lfid = 2 * direction + side` encoding of `Grid.local_facet_axis_side`, so
tigarx can address a face the same way in both libraries.

Vectorized per-axis `arange` + `ravel_multi_index`, no Python loop over dofs. The
result is read-only `int64`, matching `dof_owner` and `compute_halo`.

**No sort is needed, and the tests prove it rather than assume it.** Each axis range
is ascending, and a C-order flat id is monotone in the lexicographic order of its
multi-index, so the product comes out strictly ascending and duplicate-free. The
brute-force test asserts `np.unique(dofs) == dofs`, which pins sortedness and
uniqueness together.

## Two departures from the ticket

**Validation stays in Layer 1, and this is not the drift it looks like.** The ticket
points at `BsplineSpace.restrict` as precedent, and `restrict` does validate in Layer 1
against `CLAUDE.md`'s "validation lives exclusively in Layer 2". But the rule's own
carve-out is trivial scalar preconditions, and that is all there is here: three ints
with range checks, no array shape, dtype or writability to verify. A Layer 2 helper
would hold four `raise`s and eight lines of index arithmetic with nothing to validate.

**The optional `BsplineSpace1D.boundary_dofs` mirror is not implemented.** A 1D
`BsplineSpace` already answers the question through this method, so the mirror would be
a second spelling of `arange(layers)`. The ticket marks it "not required by tigarx",
and every symbol added now is surface the C++ port has to carry and keep in parity.

## Test plan

`tests/test_bspline_space.py`, 10 new cases:

- [x] `test_boundary_dofs_2d_known_values` — the five documented `num_basis=(5, 4)`
      slabs, exact equality
- [x] `test_boundary_dofs_3d_known_values` — the ticket's `num_basis=(3, 4, 5)`
      tangential slab: 15 ids of the form `i0 * 20 + i2`
- [x] `test_boundary_dofs_matches_bruteforce` — every direction, side and thickness
      1..3 on four spaces (1D; 2D anisotropic `(2, 1)`; 3D anisotropic `(3, 4, 2)`;
      repeated interior knots) equals an independent `unravel_index` filter. Also
      checks dtype, read-only, shape and the ascending-unique property
- [x] `test_boundary_dofs_trace_property` — `layers=1` equals the set of functions with
      non-zero trace on the face, by tabulating the 1D basis at the domain endpoint. It
      asserts the face carries **exactly one** live function, so the test fails if that
      ever stops holding instead of passing vacuously
- [x] `test_boundary_dofs_layers_nested` — `layers=k` is a strict subset of `k+1`;
      `layers=n_d` returns every dof once
- [x] `test_boundary_dofs_validation` / `test_boundary_dofs_rejects_periodic` — bad
      `direction`, `side`, `layers` and any periodic axis raise `ValueError`

Full suite: 4364 passed, 19 skipped. Coverage 96% overall, `_bspline_space_nd.py` at
100%. ruff, ruff-format, mypy (222 files), import-lint and the `-W` docs build all pass.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
