### PR TITLE
feat(grid,bspline): boundary_facets, export_cells and max_active_per_cell

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -243,6 +243,8 @@ class THBSplineSpace:
             counter catches mutations the other two cannot distinguish).
         _trunc (dict): Map from global dof (``int``) to ``_TruncCoeffs``;
             only truncated functions appear (empty when ``truncate=False``).
+        _max_active_per_cell (int | None): Memoized :meth:`max_active_per_cell`
+            result; ``None`` until first requested.
     """
 
     __slots__ = (
@@ -252,6 +254,7 @@ class THBSplineSpace:
         "_grid",
         "_grid_snapshot",
         "_level_spaces",
+        "_max_active_per_cell",
         "_num_active",
         "_regularity",
         "_root_space",
@@ -343,6 +346,7 @@ class THBSplineSpace:
         # Lazy per-cell cache of _cell_contributions (populated on first access). The
         # space is an immutable construction-time snapshot, so cached results stay valid.
         self._contrib_cache: dict[int, list[tuple[int, int, tuple[int, ...]]]] = {}
+        self._max_active_per_cell: int | None = None
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -821,6 +825,40 @@ class THBSplineSpace:
             RuntimeError: If the grid has been modified since construction.
         """
         return np.array([dof for dof, _, _ in self._cell_contributions(cid)], dtype=np.int64)
+
+    def max_active_per_cell(self) -> int:
+        """Return the largest number of active functions on any single cell.
+
+        The width a fixed-size dofmap needs: ``max(active_basis(cid).size)`` over every
+        active cell. On an unrefined space this is ``prod(degree + 1)``; near a level
+        interface a cell also sees the coarser functions overlapping it, so the count
+        grows there.
+
+        Computed once and cached, since the space is a construction-time snapshot.
+
+        Returns:
+            int: Maximum active-function count over all cells (``>= 1``).
+
+        Raises:
+            RuntimeError: If the grid has been modified since construction.
+
+        Note:
+            Counts exactly what :meth:`active_basis` returns, which selects on
+            tensor-product support. Truncation can only annihilate a function on a cell
+            it supports, never add one, so with ``truncate=True`` this is an upper bound
+            on the number of *non-zero* functions -- which is what a fixed-width dofmap
+            wants. The value is therefore the same for the THB and HB bases.
+
+            Visits every cell, so the first call populates the per-cell contribution
+            cache for the whole grid -- the same cache :meth:`active_basis` fills lazily,
+            but warmed in full.
+        """
+        self._check_not_stale()
+        if self._max_active_per_cell is None:
+            self._max_active_per_cell = max(
+                len(self._cell_contributions(cid)) for cid in range(self._grid.num_cells)
+            )
+        return self._max_active_per_cell
 
     def restrict(self, cell_ids: npt.ArrayLike) -> THBSplineSpaceRestriction:
         """Return the windowed sub-space over a subset of active cells.

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -388,6 +388,35 @@ class Grid(abc.ABC):
         """
         return self.neighbor_across_facet(cid, lfid) is None
 
+    def boundary_facets(self) -> npt.NDArray[np.int64]:
+        """Return every facet on the grid's outer boundary as ``(cid, lfid)`` rows.
+
+        Only the outer (domain) boundary: a facet shared with any neighbouring cell
+        is excluded, whether that neighbour is conforming, coarser, or finer. For a
+        hierarchical grid this means level interfaces are **not** boundary facets,
+        even though the leaf-cell mesh makes them topologically exterior (hanging
+        vertices) and so a consumer searching that mesh over-reports them.
+
+        The default enumerates :meth:`is_mesh_boundary_facet` over every cell and
+        local facet, costing ``O(num_cells * 2 * ndim)`` neighbour queries.
+        Subclasses with exploitable structure should override it.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only array of shape ``(n, 2)`` whose rows are
+            ``(cid, lfid)`` with ``lfid = 2 * axis + side`` (see
+            :meth:`local_facet_axis_side`), sorted lexicographically by
+            ``(cid, lfid)``.
+        """
+        rows = [
+            (cid, lfid)
+            for cid in self.iter_cells()
+            for lfid in range(self.num_local_facets(cid))
+            if self.is_mesh_boundary_facet(cid, lfid)
+        ]
+        out = np.array(rows, dtype=np.int64).reshape(len(rows), 2)
+        out.flags.writeable = False
+        return out
+
     def hanging_neighbors(self, cid: int, lfid: int) -> tuple[int, ...]:
         """Return all active cells sharing facet ``lfid`` of ``cid``.
 

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -899,6 +899,64 @@ class HierarchicalGrid(Grid):
         # Finer side — collect all active leaves touching the face.
         return tuple(self._active_face_descendants(level, nbr_midx, axis, face_j))
 
+    def boundary_facets(self) -> npt.NDArray[np.int64]:
+        """Return every facet on the grid's outer boundary as ``(cid, lfid)`` rows.
+
+        Same semantics as :meth:`pantr.grid.Grid.boundary_facets` -- the outer
+        boundary only, so level interfaces are excluded -- computed from the packed
+        active blocks instead of one neighbour query per facet.
+
+        A level-``l`` cell's facet ``(axis, side)`` is on the outer boundary iff its
+        level-``l`` index along ``axis`` is ``0`` (side 0) or
+        ``level_cells_per_axis(l)[axis] - 1`` (side 1), which is exactly the
+        out-of-range test in ``_facet_neighbor_position``. Since a block is a
+        rectangle of contiguous indices, that condition is decided **once per block
+        face** rather than per cell, and the whole face is emitted vectorized. Cost is
+        ``O(total boundary facets + num_blocks * 2 * ndim)``.
+
+        Returns:
+            npt.NDArray[np.int64]: Read-only array of shape ``(n, 2)`` whose rows are
+            ``(cid, lfid)`` with ``lfid = 2 * axis + side``, sorted lexicographically
+            by ``(cid, lfid)``.
+        """
+        ndim = self.ndim
+        chunks: list[npt.NDArray[np.int64]] = []
+        for level in range(len(self._blocks)):
+            cells_per_axis = [self._n_cells_at_level_k(level, k) for k in range(ndim)]
+            first_block = int(self._packed_level_start[level])
+            last_block = int(self._packed_level_start[level + 1])
+            for b in range(first_block, last_block):
+                block_lo = self._packed_block_lo[b]
+                block_hi = self._packed_block_hi[b]
+                base = int(self._packed_block_base[b])
+                shape = tuple(int(block_hi[k] - block_lo[k]) for k in range(ndim))
+                for axis in range(ndim):
+                    for side in (0, 1):
+                        touches = (
+                            int(block_lo[axis]) == 0
+                            if side == 0
+                            else int(block_hi[axis]) == cells_per_axis[axis]
+                        )
+                        if not touches:
+                            continue
+                        # Fix the normal axis at the block's boundary layer; span the rest.
+                        face = [np.arange(extent, dtype=np.int64) for extent in shape]
+                        face[axis] = np.array([0 if side == 0 else shape[axis] - 1], dtype=np.int64)
+                        grids = np.meshgrid(*face, indexing="ij")
+                        offsets = np.ravel_multi_index([g.ravel() for g in grids], shape)
+                        chunk = np.empty((offsets.size, 2), dtype=np.int64)
+                        chunk[:, 0] = base + offsets
+                        chunk[:, 1] = 2 * axis + side
+                        chunks.append(chunk)
+
+        if chunks:
+            rows = np.concatenate(chunks)
+            out = rows[np.lexsort((rows[:, 1], rows[:, 0]))]
+        else:
+            out = np.empty((0, 2), dtype=np.int64)
+        out.flags.writeable = False
+        return out
+
     # ------------------------------------------------------------------
     # Restriction / windowing
     # ------------------------------------------------------------------
@@ -1382,6 +1440,117 @@ class HierarchicalGrid(Grid):
             cell_hi,
         )
         return cell_lo, cell_hi
+
+    def _lattice_to_coords(self, lattice: npt.NDArray[np.int64]) -> npt.NDArray[np.float64]:
+        """Map finest-level integer lattice coordinates to parametric coordinates.
+
+        The lattice has ``factor[k] ** max_level`` steps per root cell on axis ``k``, so
+        every active-leaf corner at every level lands on an integer node. One formula
+        serves all of them, which is what makes coincident corners map to *identical*
+        floats and lets :meth:`export_cells` deduplicate without a tolerance.
+
+        Args:
+            lattice (npt.NDArray[np.int64]): ``(n, ndim)`` integer lattice coordinates,
+                each in ``[0, factor[k] ** max_level * root.cells_per_axis[k]]``.
+
+        Returns:
+            npt.NDArray[np.float64]: ``(n, ndim)`` fresh, writeable parametric
+            coordinates.
+        """
+        points = np.empty(lattice.shape, dtype=np.float64)
+        for k in range(self.ndim):
+            breakpoints = np.asarray(self._root.breakpoints[k], dtype=np.float64)
+            num_root_cells = int(self._root.cells_per_axis[k])
+            steps = self._factor[k] ** self.max_level
+            coord = lattice[:, k]
+            # Clamp so the domain's far edge borrows the last root cell; the exact
+            # breakpoint is written back below rather than reconstructed by arithmetic.
+            root_cell = np.minimum(coord // steps, num_root_cells - 1)
+            offset = coord - root_cell * steps
+            widths = breakpoints[root_cell + 1] - breakpoints[root_cell]
+            points[:, k] = breakpoints[root_cell] + offset * (widths / steps)
+            points[coord == steps * num_root_cells, k] = breakpoints[num_root_cells]
+        return points
+
+    def export_cells(self) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
+        """Return deduplicated leaf-cell vertices and their connectivity.
+
+        The mesh a dolfinx-style consumer needs: one vertex per distinct corner of the
+        active leaves, shared exactly between the cells that meet there, including
+        corners shared across levels (a hanging vertex appears once).
+
+        Deduplication is **exact and tolerance-free**: corners are identified on the
+        finest-level integer lattice, where a level-``l`` cell at ``midx`` contributes
+        ``(midx[k] + bit[k]) * factor[k] ** (max_level - l)``. Equal corners are equal
+        integers, and ``_lattice_to_coords`` then maps each distinct integer node
+        through one formula, so coincident corners come out bitwise identical.
+
+        Corner order within a row is the tensor-product (basix/dolfinx) convention:
+        corner ``c`` takes the ``hi`` bound on axis ``k`` iff bit ``k`` of ``c`` is set,
+        with axis 0 the least-significant bit. In 2D that is
+        ``[(lo0, lo1), (hi0, lo1), (lo0, hi1), (hi0, hi1)]``. This is a *corner*
+        convention and is deliberately unlike pantr's C-order flat cell and dof ids,
+        where the **last** axis varies fastest.
+
+        Returns:
+            tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]: ``(points, conn)``,
+            both read-only. ``points`` has shape ``(num_vertices, ndim)``, sorted
+            lexicographically by integer lattice coordinate; ``conn`` has shape
+            ``(num_cells, 2 ** ndim)`` and indexes ``points``, one row per active leaf
+            in flat cell-id order.
+
+        Note:
+            ``points[conn[cid]]`` reproduces the corners of :meth:`cell_bounds` to
+            within ``8 * eps * |coordinate|`` (about 4 ulp), and bitwise whenever every
+            intermediate is exactly representable -- a dyadic ``factor`` on dyadic root
+            breakpoints, which covers the usual unit-domain power-of-two case.
+
+            Bitwise agreement in general is not merely unimplemented, it is
+            unattainable. :meth:`cell_bounds` scales a root cell's width by
+            ``factor ** level``, so for a corner shared between two levels it evaluates
+            a *different* expression on each side and can return two floats one ulp
+            apart; no single deduplicated vertex can equal both. The bound follows from
+            three roundings per side (one division, one integer-scaled multiply, one
+            addition, plus one more for a ``hi`` corner) against a coordinate that
+            dominates its own offset.
+
+        Warning:
+            Materializes ``O(num_cells * 2 ** ndim * ndim)`` integers before
+            deduplication, so a large 3D hierarchy costs several times ``conn`` in peak
+            memory.
+        """
+        ndim = self.ndim
+        num_corners = 1 << ndim
+        corner_bits = (
+            np.arange(num_corners, dtype=np.int64)[:, None] >> np.arange(ndim, dtype=np.int64)
+        ) & 1
+
+        lattice = np.empty((self._num_cells, num_corners, ndim), dtype=np.int64)
+        for level in range(len(self._blocks)):
+            scale = np.array(
+                [self._factor[k] ** (self.max_level - level) for k in range(ndim)], dtype=np.int64
+            )
+            first_block = int(self._packed_level_start[level])
+            last_block = int(self._packed_level_start[level + 1])
+            for b in range(first_block, last_block):
+                block_lo = self._packed_block_lo[b]
+                block_hi = self._packed_block_hi[b]
+                base = int(self._packed_block_base[b])
+                shape = tuple(int(block_hi[k] - block_lo[k]) for k in range(ndim))
+                axes = [int(block_lo[k]) + np.arange(shape[k], dtype=np.int64) for k in range(ndim)]
+                grids = np.meshgrid(*axes, indexing="ij")
+                # C-order within the block, matching how flat ids are assigned.
+                cell_midx = np.stack([g.ravel() for g in grids], axis=1)
+                stop = base + cell_midx.shape[0]
+                for corner in range(num_corners):
+                    lattice[base:stop, corner, :] = (cell_midx + corner_bits[corner]) * scale
+
+        unique_nodes, inverse = np.unique(lattice.reshape(-1, ndim), axis=0, return_inverse=True)
+        conn = np.asarray(inverse, dtype=np.int64).reshape(self._num_cells, num_corners)
+        points = self._lattice_to_coords(unique_nodes)
+        points.flags.writeable = False
+        conn.flags.writeable = False
+        return points, conn
 
     # ------------------------------------------------------------------
     # Representation

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -8,6 +8,7 @@ import pytest
 
 from pantr.geometry import AABB
 from pantr.grid import (
+    Grid,
     GridRestriction,
     HierarchicalGrid,
     TensorProductGrid,
@@ -1007,3 +1008,208 @@ class TestHierKernelEquivalence:
             lo, hi = g.cell_bounds(cid)
             np_testing.assert_array_equal(lo_all[cid], lo)
             np_testing.assert_array_equal(hi_all[cid], hi)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Boundary facets
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _boundary_facets_bruteforce(grid: HierarchicalGrid) -> list[list[int]]:
+    """Reference enumeration: one `is_mesh_boundary_facet` query per cell and facet.
+
+    Independent of the block-vectorized implementation under test, which decides a
+    whole block face at once and never queries a neighbour.
+    """
+    return [
+        [cid, lfid]
+        for cid in range(grid.num_cells)
+        for lfid in range(grid.num_local_facets(cid))
+        if grid.is_mesh_boundary_facet(cid, lfid)
+    ]
+
+
+def _refined_corner_grid() -> HierarchicalGrid:
+    """2x2 unit grid with the low corner root cell refined once: 3 coarse + 4 fine."""
+    g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2), 2)
+    g.refine(0, (0, 0), (1, 1))
+    return g
+
+
+class TestBoundaryFacets:
+    """boundary_facets enumerates the outer boundary only, and agrees with the predicate."""
+
+    @pytest.mark.parametrize(
+        ("ndim", "factor"), [(1, 2), (2, 2), (2, (2, 3)), (3, 2), (1, 3), (2, 3)]
+    )
+    def test_matches_predicate(self, ndim: int, factor: int | tuple[int, ...]) -> None:
+        """The block-vectorized enumeration equals the per-facet predicate, exactly."""
+        g = _irregular_grid(ndim, factor)
+        rows = g.boundary_facets()
+
+        assert rows.tolist() == _boundary_facets_bruteforce(g)
+        assert rows.shape[0] > 0  # not vacuously empty
+        assert rows.dtype == np.int64
+        assert rows.shape[1] == 2
+        assert not rows.flags.writeable
+        # Lexicographic in (cid, lfid).
+        np_testing.assert_array_equal(rows[np.lexsort((rows[:, 1], rows[:, 0]))], rows)
+
+    @pytest.mark.parametrize(("ndim", "factor"), [(1, 2), (2, 2), (3, 2)])
+    def test_override_agrees_with_abc_default(
+        self, ndim: int, factor: int | tuple[int, ...]
+    ) -> None:
+        """The specialized override returns exactly what the inherited default would."""
+        g = _irregular_grid(ndim, factor)
+        np_testing.assert_array_equal(g.boundary_facets(), Grid.boundary_facets(g))
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3])
+    def test_unrefined_count_is_analytic(self, ndim: int) -> None:
+        """A flat n^ndim grid has 2 * ndim * n^(ndim-1) boundary facets."""
+        n = 3
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0]] * ndim, n), 2)
+        assert g.boundary_facets().shape[0] == 2 * ndim * n ** (ndim - 1)
+
+    def test_excludes_level_interfaces(self) -> None:
+        """Level-interface facets are excluded, and the outer count is the analytic one."""
+        g = _refined_corner_grid()
+        rows = g.boundary_facets()
+        assert g.num_cells == 7
+
+        # 4 sides x 2 root cells = 8 coarse facets; the refined quadrant touches 2 of
+        # those sides and on each *replaces* its coarse facet by 2 fine ones: 8 - 2 + 4.
+        assert rows.shape[0] == 10
+
+        # Every reported facet has no neighbour at all — a stricter check than the
+        # predicate, since it would also catch a facet with hanging fine neighbours.
+        for cid, lfid in rows.tolist():
+            assert g.hanging_neighbors(cid, lfid) == ()
+
+        # And the level interface, which does exist here, is entirely absent.
+        interface = {
+            (cid, lfid)
+            for cid in range(g.num_cells)
+            for lfid in range(g.num_local_facets(cid))
+            for nbrs in [g.hanging_neighbors(cid, lfid)]
+            if nbrs and any(g.cell_level(n) != g.cell_level(cid) for n in nbrs)
+        }
+        assert interface
+        assert not interface & {tuple(row) for row in rows.tolist()}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Leaf-cell mesh export
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CORNER_RTOL = 8.0 * np.finfo(np.float64).eps
+"""Bound on ``|export_cells corner - cell_bounds corner|`` relative to the coordinate.
+
+`cell_bounds` builds a corner as ``bp + s * (width / factor**level)``, with one more
+addition for a ``hi`` corner; `export_cells` builds the same value as
+``bp + o * (width / factor**max_level)``. Same quantity, different expression, so up to
+four correctly-rounded operations per side, each at most ``eps/2`` relative to a
+coordinate that dominates its own offset: ``<= 7 * eps / 2``, i.e. under ``4 * eps``.
+Measured worst case over the cases below is 1 ulp; the 8 leaves a 2x margin.
+"""
+
+
+def _cell_corners(grid: HierarchicalGrid, cid: int) -> list[np.ndarray]:
+    """Corners of `cell_bounds(cid)` in the export corner order (axis 0 = LSB)."""
+    lo, hi = grid.cell_bounds(cid)
+    return [
+        np.array(
+            [hi[k] if (corner >> k) & 1 else lo[k] for k in range(grid.ndim)], dtype=np.float64
+        )
+        for corner in range(1 << grid.ndim)
+    ]
+
+
+class TestExportCells:
+    """export_cells deduplicates leaf corners exactly and reproduces the cell bounds."""
+
+    @pytest.mark.parametrize(("ndim", "factor"), [(1, 2), (2, 2), (2, (2, 3)), (3, 2), (2, 3)])
+    def test_roundtrip_matches_cell_bounds(self, ndim: int, factor: int | tuple[int, ...]) -> None:
+        """points[conn[cid]] reproduces every cell's corners within the derived bound."""
+        g = _irregular_grid(ndim, factor)
+        points, conn = g.export_cells()
+
+        assert conn.shape == (g.num_cells, 1 << ndim)
+        assert points.shape[1] == ndim
+        assert points.dtype == np.float64
+        assert conn.dtype == np.int64
+        assert not points.flags.writeable
+        assert not conn.flags.writeable
+        assert int(conn.min()) >= 0
+        assert int(conn.max()) == points.shape[0] - 1
+
+        for cid in range(g.num_cells):
+            for corner, want in enumerate(_cell_corners(g, cid)):
+                np_testing.assert_allclose(
+                    points[conn[cid, corner]], want, rtol=_CORNER_RTOL, atol=0.0
+                )
+
+    def test_roundtrip_exact_on_dyadic_grid(self) -> None:
+        """With dyadic breakpoints and a dyadic factor every corner agrees bitwise."""
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2), 2)
+        g.refine(0, (0, 0), (1, 1))
+        g.refine(1, (0, 0), (2, 2))
+        points, conn = g.export_cells()
+
+        for cid in range(g.num_cells):
+            for corner, want in enumerate(_cell_corners(g, cid)):
+                np_testing.assert_array_equal(points[conn[cid, corner]], want)
+
+    def test_dedup_exact_with_hanging_vertices(self) -> None:
+        """The refined-corner example: 14 distinct vertices, hanging ones counted once."""
+        g = _refined_corner_grid()
+        points, conn = g.export_cells()
+
+        assert conn.shape == (7, 4)
+        # The 9 root corners of the 2x2 grid, plus the 5 level-1 nodes inside the
+        # refined quadrant: 2 on the domain boundary, the quadrant centre, and the 2
+        # hanging nodes on the level interface.
+        assert points.shape == (14, 2)
+        got = {tuple(p) for p in points.tolist()}
+        assert len(got) == 14
+        assert got == {
+            (0.0, 0.0), (0.0, 0.25), (0.0, 0.5), (0.0, 1.0),
+            (0.25, 0.0), (0.25, 0.25), (0.25, 0.5),
+            (0.5, 0.0), (0.5, 0.25), (0.5, 0.5), (0.5, 1.0),
+            (1.0, 0.0), (1.0, 0.5), (1.0, 1.0),
+        }  # fmt: skip
+
+    def test_dedup_exact_with_non_uniform_breakpoints(self) -> None:
+        """Non-uniform root breakpoints deduplicate exactly as well."""
+        g = hierarchical_grid(TensorProductGrid([np.array([0.0, 0.3, 1.0])] * 2), 2)
+        g.refine(0, (0, 0), (1, 1))
+        points, _ = g.export_cells()
+
+        assert points.shape == (14, 2)
+        assert len({tuple(p) for p in points.tolist()}) == 14
+        # 0.15 is the level-1 node inside [0, 0.3]; it must appear exactly once.
+        assert [tuple(p) for p in points.tolist()].count((0.15, 0.0)) == 1
+
+    def test_shared_vertex_referenced_by_every_touching_cell(self) -> None:
+        """An interior vertex is one index, referenced once per cell that touches it."""
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], 2), 2)
+        points, conn = g.export_cells()
+
+        centre = int(np.flatnonzero((points == 0.5).all(axis=1))[0])
+        assert int((conn == centre).sum()) == 4  # all four root cells meet there
+
+    def test_corner_order_convention(self) -> None:
+        """Corner c takes the hi bound on axis k iff bit k of c is set (axis 0 = LSB)."""
+        # Deliberately anisotropic bounds, so a transposed convention cannot pass.
+        g = hierarchical_grid(TensorProductGrid([np.array([0.0, 1.0]), np.array([0.0, 2.0])]), 2)
+        points, conn = g.export_cells()
+
+        assert points[conn[0]].tolist() == [[0.0, 0.0], [1.0, 0.0], [0.0, 2.0], [1.0, 2.0]]
+
+    def test_unrefined_grid_matches_tensor_product_lattice(self) -> None:
+        """On a flat n^ndim grid the vertex set is the full (n+1)^ndim breakpoint lattice."""
+        n = 3
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0]] * 3, n), 2)
+        points, conn = g.export_cells()
+
+        assert points.shape == ((n + 1) ** 3, 3)
+        assert conn.shape == (n**3, 8)

--- a/tests/test_grid_tensor_product.py
+++ b/tests/test_grid_tensor_product.py
@@ -586,3 +586,26 @@ def test_restrict_result_arrays_are_read_only() -> None:
         r.local_to_global_cell[0] = 99
     with pytest.raises(ValueError, match="read-only"):
         r.in_subset[0] = False
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_boundary_facets_inherited_default(ndim: int) -> None:
+    """The inherited Grid.boundary_facets enumerates a flat grid's outer boundary."""
+    n = 3
+    g = uniform_grid([[0.0, 1.0]] * ndim, n)
+    rows = g.boundary_facets()
+
+    assert rows.shape == (2 * ndim * n ** (ndim - 1), 2)
+    assert rows.dtype == np.int64
+    assert not rows.flags.writeable
+    # Every row is a boundary facet, and no interior facet is reported.
+    reported = {tuple(row) for row in rows.tolist()}
+    for cid in range(g.num_cells):
+        for lfid in range(g.num_local_facets(cid)):
+            assert ((cid, lfid) in reported) == g.is_mesh_boundary_facet(cid, lfid)
+
+
+def test_boundary_facets_single_cell() -> None:
+    """A one-cell grid has every facet on the boundary."""
+    g = uniform_grid([[0.0, 1.0], [0.0, 1.0]], 1)
+    assert g.boundary_facets().tolist() == [[0, 0], [0, 1], [0, 2], [0, 3]]

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1572,6 +1572,78 @@ class TestContribCache:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# max_active_per_cell (fixed-width dofmap size)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestMaxActivePerCell:
+    """max_active_per_cell is the max over cells of the active_basis size."""
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    def test_unrefined_is_product_of_orders(self, truncate: bool) -> None:
+        """An unrefined space sees exactly prod(degree + 1) functions on every cell."""
+        thb = THBSplineSpace(_root_2d(), _grid_2d(), truncate=truncate)
+        assert thb.grid.max_level == 0
+
+        expected = int(np.prod([d + 1 for d in thb.degrees]))
+        assert thb.max_active_per_cell() == expected
+        assert {thb.active_basis(cid).size for cid in range(thb.grid.num_cells)} == {expected}
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    @pytest.mark.parametrize("rounds", [1, 2])
+    def test_refined_matches_python_loop(self, truncate: bool, rounds: int) -> None:
+        """The cached value equals an explicit loop over active_basis, and exceeds the flat one."""
+        grid = _grid_2d()
+        for level in range(rounds):
+            grid.refine(level, [0, 0], [2 * 2**level, 2 * 2**level])
+        thb = THBSplineSpace(_root_2d(), grid, truncate=truncate)
+
+        loop_max = max(thb.active_basis(cid).size for cid in range(grid.num_cells))
+        assert thb.max_active_per_cell() == loop_max
+        # A level interface makes some cell see more than the tensor-product count.
+        assert loop_max > int(np.prod([d + 1 for d in thb.degrees]))
+
+    def test_thb_and_hb_agree(self) -> None:
+        """Truncation changes coefficients, not the active set, so the count is the same."""
+        grid = _grid_2d()
+        grid.refine(0, [0, 0], [2, 2])
+        root = _root_2d()
+
+        thb = THBSplineSpace(root, grid, truncate=True)
+        hb = THBSplineSpace(root, grid, truncate=False)
+        assert thb.max_active_per_cell() == hb.max_active_per_cell()
+
+    def test_cached_across_calls(self) -> None:
+        """The result is memoized: a second call recomputes nothing."""
+        grid = _grid_1d()
+        grid.refine(0, [0], [2])
+        thb = THBSplineSpace(_root_1d(), grid)
+
+        first = thb.max_active_per_cell()
+        # Recomputing would have to walk every cell and refill this cache.
+        thb._contrib_cache.clear()
+        assert thb.max_active_per_cell() == first
+        assert thb._contrib_cache == {}
+
+    def test_stale_grid_raises(self) -> None:
+        """A grid mutated after construction is rejected, as for active_basis."""
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            thb.max_active_per_cell()
+
+    def test_stale_grid_raises_after_caching(self) -> None:
+        """Staleness is detected even once the value has been cached."""
+        grid = _grid_1d()
+        thb = THBSplineSpace(_root_1d(), grid)
+        _ = thb.max_active_per_cell()
+        grid.refine(0, [0], [2])
+        with pytest.raises(RuntimeError, match="stale"):
+            thb.max_active_per_cell()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # restrict (windowed THB sub-space)
 # ──────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Three additions a dolfinx-style consumer of the leaf-cell mesh needs, all pure numpy.

**`Grid.boundary_facets()`** returns the outer-boundary facets as sorted `(cid, lfid)`
rows. The ABC default enumerates `is_mesh_boundary_facet`, so `TensorProductGrid` gets
it for free; `HierarchicalGrid` overrides it with a block-vectorized pass. A facet is on
the outer boundary exactly when its per-axis index sits at the end of the level extent
— the out-of-range test already in `_facet_neighbor_position` — and a block is a
rectangle of contiguous indices, so that is decided **once per block face** and the face
emitted vectorized. Level interfaces are excluded, which is the whole point: in the
leaf-cell mesh they are topologically exterior and a consumer searching that mesh
over-reports them.

**`HierarchicalGrid.export_cells()`** returns deduplicated vertices and per-leaf
connectivity. Corners are identified on the finest-level integer lattice, so dedup is
exact with no tolerance, and one shared formula maps each distinct node to floats. Corner
order is the tensor-product (basix) convention: corner `c` takes the `hi` bound on axis
`k` iff bit `k` of `c` is set, axis 0 the least-significant bit.

**`THBSplineSpace.max_active_per_cell()`** returns the fixed dofmap width, cached.

## Three specified numbers that measurement refuted

The code follows the measurement; each is pinned by a test.

**The 2×2/refine-one example has 14 vertices, not 13.** The refined quadrant contributes
**five** new level-1 nodes, not four: two on the domain boundary, its centre, and two
hanging on the level interface. Enumerated:

```
(0,0) (0,0.25) (0,0.5) (0,1) | (0.25,0) (0.25,0.25) (0.25,0.5)
(0.5,0) (0.5,0.25) (0.5,0.5) (0.5,1) | (1,0) (1,0.5) (1,1)
```

**That example has 10 boundary facets, not 12.** The refined quadrant's 2 fine facets
*replace* the coarse facet on each of the 2 sides it touches rather than adding to it:
`8 - 2 + 4 = 10`. Cross-checked against the per-facet predicate on every case below.

**A bitwise roundtrip against `cell_bounds` was specified and no implementation can
deliver it.** `cell_bounds` scales a root cell's width by `factor ** level`, so for a
corner shared between two levels it evaluates a *different* expression on each side. With
factor 3 that returns two floats one ulp apart for one and the same corner
(`0.3333333333333333` vs `0.33333333333333337`, 19 such vertices in a 2-round case), and
no single deduplicated vertex can equal both. Deduplication is what the consumer needs, so
the exactness claim is the part that gives way:

- **bitwise** where every intermediate is representable — dyadic factor on dyadic
  breakpoints, the usual unit-domain case — asserted with `assert_array_equal`;
- **within `8 * eps * |coordinate|`** otherwise, derived from at most four correctly-rounded
  operations per side against a coordinate that dominates its own offset (`≤ 7 * eps / 2`),
  with the derivation written down at the constant. Measured worst case 1 ulp.

A related trap this surfaced, worth knowing independently of this PR: a 3×3 root grid on
`[0, 1]` is **not** dyadic (widths of 1/3), so factor 2 alone does not buy exactness. My
first pass claimed it did; the 3×3 case refuted it.

## Note on the THB count

The ticket expects THB and HB to differ here. They cannot: the count is over the *active
set*, which Kraft selection fixes identically for both, and truncation changes
coefficients rather than membership. So with `truncate=True` the value is an upper bound
on the non-zero functions, which is exactly what a fixed-width dofmap wants. Documented,
and pinned by `test_thb_and_hb_agree`.

## Test plan

`tests/test_grid_hierarchical.py` (24 cases), `tests/test_grid_tensor_product.py` (4),
`tests/test_thb_spline_space.py` (7):

- [x] `boundary_facets` equals a brute-force `is_mesh_boundary_facet` enumeration over
      1D/2D/3D, factors 2, 3 and `(2, 3)`, three refinement levels with disjoint refined
      regions — and equals what the inherited ABC default returns
- [x] Analytic count `2 * ndim * n**(ndim-1)` on flat grids; the refined-corner count of 10
- [x] Level interfaces excluded, checked two ways: every reported facet has **no**
      neighbour at all (`hanging_neighbors == ()`, stricter than the predicate, so a facet
      with hanging fine neighbours could not slip through), and the interface set — which
      is non-empty in that example — is disjoint from the result
- [x] `export_cells` roundtrip against `cell_bounds` within the derived bound on five
      grid/factor combinations; bitwise on the dyadic grid
- [x] Dedup exact: 14 known vertices for the hanging case, 14 with non-uniform
      breakpoints `[0, 0.3, 1]`, and a shared interior vertex referenced by all four
      cells that touch it
- [x] Corner order on anisotropic bounds (`[0,1] × [0,2]`), so a transposed convention
      fails
- [x] `max_active_per_cell`: `prod(degree + 1)` unrefined; equals a Python loop over
      `active_basis` for THB and HB at 1 and 2 refinement rounds, and exceeds the flat
      count; stale grid raises before *and* after caching; memoization proved by clearing
      the contribution cache and checking a second call does not refill it

Full suite: 4392 passed, 19 skipped. Coverage 96% (`_hierarchical_grid.py` and `_grid.py`
at 99%). ruff, ruff-format, mypy (222 files), import-lint and a **clean** `-W` docs build
all pass.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)
