### PR TITLE
feat(bspline): sparse CSR variant of THBSplineSpace.prolongation_to

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -21,6 +21,7 @@ import string
 from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
+from scipy import sparse
 
 from ..grid import HierarchicalGrid, hierarchical_grid, tensor_product_grid
 from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core
@@ -28,7 +29,7 @@ from ._bspline_space_nd import BsplineSpace
 from ._thb_eval_core import _combine_tp_values
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     import numpy.typing as npt
 
@@ -1704,6 +1705,11 @@ class THBSplineSpace:
         refinement yield trivial (identity) columns, so cost and sparsity follow the
         refined region.
 
+        For a large refinement prefer :meth:`prolongation_to_sparse`, which computes the
+        same entries with the same arithmetic but stores only the non-zeros: this dense
+        variant allocates ``n_fine * n_coarse`` float64 regardless of how few columns the
+        refinement actually touches.
+
         Args:
             fine (THBSplineSpace): A refinement of this space (same ``root_space``,
                 ``factor``, ``regularity``, and ``truncate``; more levels / refined
@@ -1718,6 +1724,58 @@ class THBSplineSpace:
             ValueError: If ``fine`` is not a refinement of this space (mismatched
                 root/factor/regularity/truncation, fewer levels, or the prolongation
                 residual is non-negligible).
+        """
+        self._check_is_refinement(fine)
+        return self._assemble_prolongation(fine)
+
+    def prolongation_to_sparse(self, fine: THBSplineSpace) -> sparse.csr_array:
+        """Return the prolongation to a refinement ``fine`` in sparse CSR form.
+
+        The same matrix :meth:`prolongation_to` returns, entry for entry: the columns come
+        from the same local two-scale solves in the same order, so ``toarray()`` is
+        **bitwise equal** to the dense result. Only the storage differs.
+
+        That storage is the whole point at scale. The dense variant is
+        ``O(n_fine * n_coarse)`` -- for ``1e5`` fine by ``9e4`` coarse dofs, some 72 GB --
+        while the matrix has only a handful of entries per column: a coarse function is
+        matched against the fine functions overlapping its support, and away from the
+        refined region that is one entry of value ``1.0``. Sparse storage is ``O(nnz)``.
+
+        Entries are stored exactly as solved, including any that happen to be zero, since
+        they are the two-scale coefficients rather than a thresholded approximation. Call
+        ``eliminate_zeros()`` on the result if a caller wants them dropped.
+
+        Args:
+            fine (THBSplineSpace): A refinement of this space, on the same terms as
+                :meth:`prolongation_to`.
+
+        Returns:
+            scipy.sparse.csr_array: Matrix ``P`` of shape
+            ``(fine.num_total_basis, self.num_total_basis)``, ``float64``.
+
+        Raises:
+            TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
+            ValueError: If ``fine`` is not a refinement of this space -- the same
+                mismatches and residual check as :meth:`prolongation_to`.
+        """
+        self._check_is_refinement(fine)
+        return self._assemble_prolongation_sparse(fine)
+
+    def _check_is_refinement(self, fine: THBSplineSpace) -> None:
+        """Raise unless ``fine`` is a structurally compatible refinement of ``self``.
+
+        Checks everything decidable without assembling: type, dimension, truncation mode,
+        subdivision factor, regularity, level count, and root knot vectors. The remaining
+        condition -- that the coarse basis is actually reproducible in the fine one -- is
+        a residual check during assembly.
+
+        Args:
+            fine (THBSplineSpace): Candidate refinement.
+
+        Raises:
+            TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
+            ValueError: If any structural property disagrees; the message lists every
+                mismatch found, not just the first.
         """
         if not isinstance(fine, THBSplineSpace):
             raise TypeError(f"fine must be a THBSplineSpace; got {type(fine).__name__!r}.")
@@ -1746,30 +1804,38 @@ class THBSplineSpace:
                 + "."
             )
 
-        return self._assemble_prolongation(fine)
+    def _prolongation_columns(
+        self, fine: THBSplineSpace
+    ) -> Iterator[tuple[int, npt.NDArray[np.int64], npt.NDArray[np.float64]]]:
+        """Yield the prolongation one column at a time, as ``(column, rows, values)``.
 
-    def _assemble_prolongation(self, fine: THBSplineSpace) -> npt.NDArray[np.float64]:
-        """Build the prolongation column-by-column from local two-scale data.
+        The shared driver behind both :meth:`prolongation_to` and
+        :meth:`prolongation_to_sparse`, so the two cannot drift: each coarse function is
+        represented by only the fine functions over its support, expressed in a common
+        *local* tensor-product level (the deepest present there) rather than the global
+        finest level.  Functions far from the refinement stay at their own level (a trivial
+        solve, often the identity), so the cost follows the refined region rather than the
+        whole finest grid.  This is the local two-scale view of the change of basis (Garau
+        & Vazquez 2018; D'Angella et al. 2018): coarse functions expanded by the refinement
+        mask and matched against the active fine (truncated) basis.
 
-        Each coarse function is represented by only the fine functions over its
-        support, expressed in a common *local* tensor-product level (the deepest
-        present there) rather than the global finest level.  Functions far from the
-        refinement stay at their own level (a trivial solve, often the identity), so
-        the cost follows the refined region rather than the whole finest grid.  This
-        is the local two-scale view of the change of basis (Garau & Vazquez 2018;
-        D'Angella et al. 2018): coarse functions expanded by the refinement mask and
-        matched against the active fine (truncated) basis.
+        Columns with no candidate fine functions are skipped rather than yielded empty.
 
         Args:
             fine (THBSplineSpace): A validated refinement of ``self``.
 
-        Returns:
-            npt.NDArray[np.float64]: Prolongation ``P`` of shape
-            ``(fine.num_total_basis, self.num_total_basis)``.
+        Yields:
+            tuple[int, npt.NDArray[np.int64], npt.NDArray[np.float64]]: The coarse dof
+            index, the fine dof indices its column occupies, and the values there.
 
         Raises:
-            ValueError: If a column cannot reproduce its coarse function (residual
+            ValueError: If some column cannot reproduce its coarse function (residual
                 above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+
+        Note:
+            The residual is only known once every column has been solved, so the check
+            runs after the last one. A consumer that abandons the iterator early therefore
+            skips it; both callers here exhaust it.
         """
         oslo = fine._build_oslo_matrices()
         root_cells = self._grid.level_cells_per_axis(0)
@@ -1782,7 +1848,6 @@ class THBSplineSpace:
             for cell in self._cells_in_box(lo, hi, root_cells):
                 cell_to_fine.setdefault(cell, []).append(j)
 
-        prolongation: npt.NDArray[np.float64] = np.zeros((n_fine, n_coarse), dtype=np.float64)
         max_residual = 0.0
         max_coarse_val = 0.0
         for i in range(n_coarse):
@@ -1796,7 +1861,7 @@ class THBSplineSpace:
             )
             sol, residual, coarse_val = self._prolong_column(fine, oslo, i, candidates, fine_box)
             if sol is not None:
-                prolongation[np.array(candidates), i] = sol
+                yield i, np.array(candidates, dtype=np.int64), sol
             max_residual = max(max_residual, residual)
             max_coarse_val = max(max_coarse_val, coarse_val)
 
@@ -1805,7 +1870,65 @@ class THBSplineSpace:
                 f"fine is not a refinement of this space (prolongation residual "
                 f"{max_residual:.2e})."
             )
+
+    def _assemble_prolongation(self, fine: THBSplineSpace) -> npt.NDArray[np.float64]:
+        """Scatter the prolongation columns into a dense matrix.
+
+        Args:
+            fine (THBSplineSpace): A validated refinement of ``self``.
+
+        Returns:
+            npt.NDArray[np.float64]: Prolongation ``P`` of shape
+            ``(fine.num_total_basis, self.num_total_basis)``.
+
+        Raises:
+            ValueError: If a column cannot reproduce its coarse function (residual
+                above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+        """
+        shape = (fine.num_total_basis, self.num_total_basis)
+        prolongation: npt.NDArray[np.float64] = np.zeros(shape, dtype=np.float64)
+        for column, rows, values in self._prolongation_columns(fine):
+            prolongation[rows, column] = values
         return prolongation
+
+    def _assemble_prolongation_sparse(self, fine: THBSplineSpace) -> sparse.csr_array:
+        """Gather the prolongation columns into a CSR array.
+
+        Args:
+            fine (THBSplineSpace): A validated refinement of ``self``.
+
+        Returns:
+            scipy.sparse.csr_array: Prolongation ``P`` of shape
+            ``(fine.num_total_basis, self.num_total_basis)``, ``float64``.
+
+        Raises:
+            ValueError: If a column cannot reproduce its coarse function (residual
+                above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+
+        Note:
+            Assembled through COO, whose duplicate summation never fires: each column is
+            emitted exactly once and its rows are distinct, so the stored values are the
+            solved ones unaltered.
+        """
+        shape = (fine.num_total_basis, self.num_total_basis)
+        all_rows: list[npt.NDArray[np.int64]] = []
+        all_cols: list[npt.NDArray[np.int64]] = []
+        all_values: list[npt.NDArray[np.float64]] = []
+        for column, rows, values in self._prolongation_columns(fine):
+            all_rows.append(rows)
+            all_cols.append(np.full(rows.shape[0], column, dtype=np.int64))
+            all_values.append(values)
+
+        if not all_values:
+            return sparse.csr_array(shape, dtype=np.float64)
+        coo = sparse.coo_array(
+            (
+                np.concatenate(all_values),
+                (np.concatenate(all_rows), np.concatenate(all_cols)),
+            ),
+            shape=shape,
+        )
+        return coo.tocsr()
 
     def _prolong_column(
         self,

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1291,6 +1291,210 @@ class TestProlongation:
             coarse.prolongation_to(_grid_1d())  # type: ignore[arg-type]
 
 
+def _assert_same_field(
+    coarse: THBSplineSpace,
+    fine: THBSplineSpace,
+    u_coarse: npt.NDArray[np.float64],
+    u_fine: npt.NDArray[np.float64],
+) -> None:
+    """Assert the two coefficient vectors describe the same function, cell by cell."""
+    u_axis = np.linspace(0.1, 0.9, 3)
+    err = 0.0
+    for cid in range(fine.grid.num_cells):
+        lo, hi = fine.grid.cell_bounds(cid)
+        mesh = np.meshgrid(
+            *[lo[k] + (hi[k] - lo[k]) * u_axis for k in range(fine.dim)], indexing="ij"
+        )
+        pts = np.stack([m.ravel() for m in mesh], axis=-1)
+        coarse_cid = coarse.grid.locate(pts[0])
+        assert coarse_cid is not None
+        err = max(
+            err,
+            float(
+                np.abs(
+                    _field_at(fine, u_fine, cid, pts) - _field_at(coarse, u_coarse, coarse_cid, pts)
+                ).max()
+            ),
+        )
+    assert err < 1e-12
+
+
+_MATVEC_ATOL = 64.0 * float(np.finfo(np.float64).eps)
+"""Bound on the gap between a CSR matvec and a dense BLAS matvec of the same matrix.
+
+The two matrices are bitwise identical, but a matrix-vector product is not: scipy sums a
+row in stored-index order while BLAS blocks and reorders, and floating-point addition is
+not associative. A row here holds at most a few dozen entries of order one, so the gap is
+bounded by roughly ``2 * row_length * eps / 2``; 64 ulp covers that with margin. Compare
+the *matrices* bitwise and their *products* within this bound, never the other way round.
+"""
+
+
+class TestProlongationSparse:
+    """prolongation_to_sparse stores exactly the matrix the dense variant computes."""
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    def test_equals_dense_1d(self, truncate: bool) -> None:
+        """Bitwise equality, not an approximation: the same solves in the same order."""
+        coarse = THBSplineSpace(_root_1d(), _grid_1d(), truncate=truncate)
+        fine = coarse.refine([0, 1], admissible_class=None)
+
+        sparse_p = coarse.prolongation_to_sparse(fine)
+        dense = coarse.prolongation_to(fine)
+
+        assert sparse_p.shape == (fine.num_total_basis, coarse.num_total_basis)
+        assert sparse_p.dtype == np.float64
+        assert np.array_equal(sparse_p.toarray(), dense)
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    def test_equals_dense_2d_multi_level(self, truncate: bool) -> None:
+        """Two refinement rounds, so columns resolve at several local levels."""
+        coarse = THBSplineSpace(_root_2d(), _grid_2d(), truncate=truncate)
+        f1 = coarse.refine([0], admissible_class=None)
+        f2 = f1.refine([_locate(f1.grid, [0.05, 0.05])], admissible_class=None)
+        assert f2.num_levels >= 3
+
+        assert np.array_equal(
+            coarse.prolongation_to_sparse(f2).toarray(), coarse.prolongation_to(f2)
+        )
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    def test_equals_dense_anisotropic_degrees(self, truncate: bool) -> None:
+        """Anisotropic degrees (2, 3) and factor (2, 3)."""
+        coarse = create_thb_space(
+            create_uniform_space([2, 3], [6, 9]), factor=[2, 3], truncate=truncate
+        )
+        fine = coarse.refine_region(0, [0, 0], [3, 3], admissible_class=None)
+
+        assert np.array_equal(
+            coarse.prolongation_to_sparse(fine).toarray(), coarse.prolongation_to(fine)
+        )
+
+    def test_identity_when_no_refinement(self) -> None:
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        p = coarse.prolongation_to_sparse(coarse)
+        np.testing.assert_allclose(p.toarray(), np.eye(coarse.num_total_basis), atol=1e-10)
+
+    def test_unit_columns_need_eliminate_zeros(self) -> None:
+        """A coarse function away from the refinement has one non-zero, of value 1.0.
+
+        The *stored* count is larger. Every fine function overlapping the coarse support
+        enters the local solve, and its coefficient is kept even when it solves to exactly
+        zero, because these are two-scale coefficients rather than a thresholded
+        approximation. So the unit-column property holds after ``eliminate_zeros()``, and
+        this test pins both halves of that.
+        """
+        coarse = create_thb_space(create_uniform_space([2, 2], [16, 16]))
+        fine = coarse.refine_region(0, [0, 0], [2, 2])
+
+        p = coarse.prolongation_to_sparse(fine)
+        stored_per_column = np.diff(p.tocsc().indptr)
+        pruned = p.copy()
+        pruned.eliminate_zeros()
+        nonzeros_per_column = np.diff(pruned.tocsc().indptr)
+
+        unit_columns = np.flatnonzero(nonzeros_per_column == 1)
+        assert unit_columns.size > coarse.num_total_basis // 2
+        values = p.toarray()[:, unit_columns]
+        np.testing.assert_array_equal(values[values != 0.0], np.ones(unit_columns.size))
+        # Explicit zeros really are stored, which is why the property needs the pruning.
+        assert int(stored_per_column.sum()) > int(nonzeros_per_column.sum())
+
+    def test_storage_grows_with_dofs_not_their_square(self) -> None:
+        """Storage follows nnz, so it grows like the dof count, not like its square.
+
+        This needs two sizes to say anything: at one small size the constant factor
+        (entries per column) dominates and sparse storage is merely a fraction of dense,
+        which would pass a threshold test for the wrong reason. Measured here, the coarse
+        dof count grows 11.6x, sparse storage 13x, dense storage 121x.
+        """
+        measured = []
+        for cells in (8, 32):
+            coarse = create_thb_space(create_uniform_space([2, 2], [cells, cells]))
+            fine = coarse.refine_region(0, [0, 0], [2, 2])
+            p = coarse.prolongation_to_sparse(fine)
+            measured.append((coarse.num_total_basis, fine.num_total_basis, p.nnz))
+        (n_coarse_0, n_fine_0, nnz_0), (n_coarse_1, n_fine_1, nnz_1) = measured
+        dof_growth = n_coarse_1 / n_coarse_0
+
+        # Entries per column stay bounded: a coarse function only ever meets the fine
+        # functions overlapping its own support, however large the space grows.
+        assert nnz_1 / n_coarse_1 < 1.5 * (nnz_0 / n_coarse_0)
+        # Hence sparse storage grows like the dof count...
+        assert nnz_1 / nnz_0 < 3.0 * dof_growth
+        # ...while dense storage grows like its square.
+        assert (n_fine_1 * n_coarse_1) / (n_fine_0 * n_coarse_0) > 5.0 * dof_growth
+
+    def test_partition_of_unity_thb(self) -> None:
+        """For THB, prolonging the constant 1 yields the fine constant 1."""
+        coarse = THBSplineSpace(_root_2d(), _grid_2d())
+        fine = coarse.refine([0])
+
+        got = coarse.prolongation_to_sparse(fine) @ np.ones(coarse.num_total_basis)
+
+        np.testing.assert_allclose(got, np.ones(fine.num_total_basis), atol=1e-12)
+
+    def test_partition_of_unity_must_not_hold_for_hb(self) -> None:
+        """``P @ 1 == 1`` is a THB identity only, and the sparse path must not fake it.
+
+        A refined HB basis is not a partition of unity -- it sums to more than one over the
+        refined region, which is precisely why truncation exists -- so the coefficients of
+        the constant 1 in the fine HB basis are not all ones. The function is still
+        transferred exactly; ``test_transfer_roundtrip`` is what checks that. Asserting the
+        deviation here keeps anyone from "repairing" it into the THB identity.
+        """
+        coarse = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        fine = coarse.refine([0, 1], admissible_class=None)
+        ones = np.ones(coarse.num_total_basis)
+
+        got = coarse.prolongation_to_sparse(fine) @ ones
+
+        assert float(np.abs(got - 1.0).max()) > 0.1
+        # The refined HB basis over-counts: its own all-ones field is not the constant 1.
+        refined_cid = _locate(fine.grid, [0.05])
+        hb_sum = _field_at(fine, np.ones(fine.num_total_basis), refined_cid, np.array([[0.05]]))
+        assert float(hb_sum[0]) > 1.0 + 1e-6
+        # Same deviation from the dense operator, to matvec precision (see _MATVEC_ATOL).
+        np.testing.assert_allclose(
+            got, coarse.prolongation_to(fine) @ ones, rtol=0.0, atol=_MATVEC_ATOL
+        )
+
+    @pytest.mark.parametrize("truncate", [True, False])
+    def test_transfer_roundtrip(self, truncate: bool) -> None:
+        """Random coefficients transfer to the same function through the sparse operator."""
+        coarse = THBSplineSpace(_root_2d(), _grid_2d(), truncate=truncate)
+        fine = coarse.refine([0], admissible_class=None)
+        rng = np.random.default_rng(11)
+        u_coarse = rng.random(coarse.num_total_basis)
+
+        u_fine = coarse.prolongation_to_sparse(fine) @ u_coarse
+
+        _assert_same_field(coarse, fine, u_coarse, u_fine)
+
+    def test_validation_message_matches_dense(self) -> None:
+        """The sparse entry point rejects what the dense one rejects, with the same text."""
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        other = THBSplineSpace(_root_2d(), _grid_2d())
+
+        with pytest.raises(ValueError, match="refinement") as sparse_err:
+            coarse.prolongation_to_sparse(other)
+        with pytest.raises(ValueError, match="refinement") as dense_err:
+            coarse.prolongation_to(other)
+
+        assert str(sparse_err.value) == str(dense_err.value)
+
+    def test_truncate_mismatch_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        fine_hb = THBSplineSpace(_root_1d(), _grid_1d(), truncate=False)
+        with pytest.raises(ValueError, match="truncate"):
+            coarse.prolongation_to_sparse(fine_hb)
+
+    def test_non_thb_argument_raises(self) -> None:
+        coarse = THBSplineSpace(_root_1d(), _grid_1d())
+        with pytest.raises(TypeError, match="THBSplineSpace"):
+            coarse.prolongation_to_sparse(_grid_1d())  # type: ignore[arg-type]
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Coarsening / restriction
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
> Touches `_thb_spline_space.py`, as #281 does. No semantic dependency, but merge #281
> first and this rebases cleanly; the reverse order needs a two-line manual resolution.

## Summary

`prolongation_to_sparse` returns the same operator as `prolongation_to`, as a
`scipy.sparse.csr_array`. The dense variant allocates `n_fine * n_coarse` float64 however
few columns the refinement actually touches (72 GB at `1e5 × 9e4` dofs), while the matrix
holds a handful of entries per column and exactly one of value `1.0` away from the refined
region.

The per-column two-scale solves now live in a `_prolongation_columns` generator that both
paths consume, so the two cannot drift: the dense assembler scatters columns into the
preallocated array exactly as before, the sparse one gathers them through COO. Validation
is shared too, extracted into `_check_is_refinement`, so the sparse entry point raises the
same messages — asserted by comparing the exception text of both paths.

`toarray()` is **bitwise equal** to the dense result, over 1D/2D, anisotropic degrees
`(2, 3)` with factor `(2, 3)`, multi-level refinements, and both bases.

Measured storage, `p=(2,2)`, corner refinement, coarse dofs growing 11.6×:

| root cells | coarse dofs | nnz | sparse | dense | sparse/dense |
|---|---|---|---|---|---|
| 8² | 100 | 2 083 | 33 KB | 88 KB | 0.38 |
| 16² | 324 | 7 203 | 115 KB | 851 KB | 0.14 |
| 32² | 1 156 | 27 043 | 432 KB | 10.3 MB | 0.041 |

Sparse storage grows 12.9×, dense 120.6×. `nnz / n_coarse` stays ≈ 21–23, which is the
actual invariant: entries per column are bounded by the fine functions overlapping one
coarse support, so the test asserts that rather than a single-size threshold. (My first
attempt did assert a single-size threshold and failed at 13.5% of dense — a fraction, not
an asymptotic.)

## Two specified properties that measurement corrected

**Untouched columns have one *non-zero*, not one stored entry.** The ticket asks for no
thresholding and for `nnz == 1` on those columns; both cannot hold. Measured on a 10-column
1D case, stored per column is `[5, 6, 7, 6, 5, 5, 5, 5, 4, 3]` while non-zeros per column
is `[2, 3, 7, 6, 5, 1, 1, 1, 1, 1]`. Every fine function overlapping the coarse support
enters the local solve and its coefficient is kept even when it solves to exactly zero,
because these are two-scale coefficients rather than an approximation. No thresholding is
the right call, so the property is stated and tested after `eliminate_zeros()`, and the
docstring says so.

**Partition of unity holds for THB only.** The ticket claims `P @ 1 == 1` to `1e-12` for
both bases, "THB and HB with the appropriate coefficient of 1". For HB it is off by
**0.75**, and dense `prolongation_to` gives the identical deviation, so this is the basis,
not the implementation. The reason, measured: evaluating the all-ones coefficient field in
the refined basis gives

- THB: min 1.0000, max 1.0000 — a partition of unity;
- HB: min 1.0000, max **1.5814** — not one.

That over-counting in the overlap region is exactly why truncation exists. The coefficients
of the constant 1 in a fine HB basis are therefore not all ones, so `P @ 1 ≠ 1` is the
correct answer. The suite now asserts PU for THB, asserts the deviation for HB so nobody
"repairs" it into the THB identity, and pins the invariant that does hold for both bases:
the prolonged coefficients describe the same function (checked by evaluation, `< 1e-12`).

## One trap worth keeping

The two matrices are bitwise equal; their **matrix-vector products are not**. scipy sums a
CSR row in stored-index order, BLAS blocks and reorders, and floating-point addition is not
associative — 1 ulp apart on 2 of 8 entries in the HB case. My first version of that test
demanded `assert_array_equal` on `P @ ones` and failed for this reason. Compare matrices
bitwise and products within a derived bound (`_MATVEC_ATOL`, 64 ulp, from the row length);
never the other way round.

## Test plan

`tests/test_thb_spline_space.py`, 16 new cases in `TestProlongationSparse`:

- [x] `toarray()` bitwise equals dense — 1D, 2D multi-level (≥ 3 levels), anisotropic
      degrees/factors, each for `truncate=True` and `False`
- [x] Identity operator when `fine is self`
- [x] Unit columns after `eliminate_zeros()`, plus the assertion that stored > non-zero, so
      the explicit-zero behavior is pinned rather than incidental
- [x] Storage grows with the dof count, not its square (two sizes, as above)
- [x] PU for THB; the HB deviation, its cause, and agreement with dense
- [x] Transfer roundtrip by evaluation on every fine cell, both bases
- [x] Validation: identical `ValueError` text to dense, `truncate` mismatch, `TypeError`
- [x] The 15 pre-existing dense prolongation and restriction tests pass untouched, which is
      the regression guard on the refactor

Full suite: 4370 passed, 19 skipped. Coverage 96%, `_thb_spline_space.py` 97%. ruff,
ruff-format, mypy (222 files), import-lint and the `-W` docs build all pass.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
