### PR TITLE
feat(bspline): Bspline.locate for physical-to-parametric point inversion

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -25,6 +25,7 @@ from ._bspline_knot_insertion import (
     _to_periodic_bspline_impl,
 )
 from ._bspline_knot_removal import _remove_knots_bspline
+from ._bspline_locate import _locate_impl
 from ._bspline_restrict import _restrict_bspline_impl
 from ._bspline_slice import _slice_bspline
 from ._bspline_split import _split_bspline_impl
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     from ..bezier import Bezier
     from ..quad import PointsLattice
     from ..transform import AffineTransform
+    from ._bspline_locate import _LocateContext
     from ._bspline_space_nd import BsplineSpace
 
 
@@ -51,6 +53,9 @@ class Bspline:
         _is_rational (bool): Whether the B-spline is rational (NURBS).
         _beziers_cache (``npt.NDArray[np.object_] | None``): Cached Bézier
             decomposition, or ``None`` if not yet computed.
+        _locate_cache (``_LocateContext | None``): Cached point-inversion state
+            (see :meth:`locate`), or ``None`` if not yet computed. Invalidated
+            alongside ``_beziers_cache`` by the in-place mutators.
     """
 
     _control_points: npt.NDArray[np.float32 | np.float64]
@@ -93,6 +98,7 @@ class Bspline:
 
         self._is_rational = is_rational
         self._beziers_cache: npt.NDArray[np.object_] | None = None
+        self._locate_cache: _LocateContext | None = None
 
         if self.rank <= 0:
             raise ValueError(f"The B-spline must have at least rank one. Got rank {self.rank}")
@@ -250,6 +256,78 @@ class Bspline:
         """
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_Bspline_deriv(self, pts, orders_seq, out)
+
+    def locate(
+        self,
+        points: npt.ArrayLike,
+        *,
+        tol: float | None = None,
+        max_iter: int = 30,
+    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]:
+        """Invert the mapping: find the parametric coordinates of physical points.
+
+        The inverse of :meth:`evaluate`. Candidate knot-span cells come from a cached
+        hierarchy over the per-cell control-point boxes (the convex-hull property), and
+        each candidate is refined by Newton's method on ``F(xi) - x = 0``. The
+        hierarchy is built on the first call and reused afterwards.
+
+        Only square mappings are inverted (``rank == dim``), which covers planar and
+        volumetric geometry maps. For a rational B-spline every weight must be
+        strictly positive: the candidate search relies on the projected control points
+        bounding the cell's image, which is false for a non-positive weight.
+
+        Args:
+            points (npt.ArrayLike): Physical points, shape ``(n, rank)``. A 1-D input is
+                one point of ``rank`` coordinates, except when ``rank == 1``, where it is
+                ``n`` scalar coordinates.
+            tol (float | None): Convergence threshold on ``||F(xi) - x||_2``, as an
+                absolute distance in physical units. ``None`` (default) uses
+                :func:`pantr.tolerance.get_default` for this B-spline's dtype, scaled by
+                the geometry's own size: the larger of its control-point bounding-box
+                diagonal and its largest coordinate magnitude. Defaults to None.
+            max_iter (int): Maximum number of Newton steps per candidate cell.
+                Defaults to 30.
+
+        Returns:
+            tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]: ``(cell_ids,
+            ref_coords)``, both read-only. ``cell_ids`` has shape ``(n,)`` and holds
+            flat knot-span cell ids in C-order over ``space.num_intervals`` -- the
+            convention of :func:`pantr.grid.tensor_product_grid` and
+            :class:`SpanwiseElementExtraction`. ``ref_coords`` has shape ``(n, dim)``
+            and holds *parametric* (not cell-local) coordinates satisfying
+            ``evaluate(ref_coords[i]) == points[i]`` within ``tol``. A point not on the
+            mapping's image gets ``cell_ids[i] = -1`` and ``ref_coords[i] = nan``.
+
+        Raises:
+            NotImplementedError: If ``rank > dim`` (an embedded curve or surface, which
+                needs a Gauss-Newton closest-point solve).
+            ValueError: If ``rank < dim``, any direction is periodic, a rational
+                B-spline has a non-positive weight, ``points`` has the wrong shape or a
+                non-finite entry, ``max_iter < 1``, or ``tol`` is not positive and
+                finite.
+
+        Note:
+            What is guaranteed is that ``evaluate(ref_coords[i])`` reproduces
+            ``points[i]``, not that ``ref_coords[i]`` is a particular preimage. A
+            mapping that folds (its Jacobian determinant changes sign) sends several
+            parametric points to the same physical point, and any of them is a correct
+            answer; only for an injective mapping does :meth:`locate` invert
+            :meth:`evaluate` back to the coordinates it was called with.
+
+            A point on an interior knot line legitimately belongs to either adjacent
+            cell; ``ref_coords`` is unique but the reported ``cell_ids`` entry is
+            whichever cell :meth:`pantr.grid.TensorProductGrid.locate_many` assigns.
+
+            The inversion always runs in ``float64``: a ``float32`` B-spline is promoted
+            to an exact ``float64`` copy, since a ``float32`` residual cannot be resolved
+            below the ``float32`` tolerance preset. Evaluating the returned coordinates
+            on the original ``float32`` B-spline therefore reproduces the query point to
+            ``float32`` accuracy only.
+
+        Example:
+            >>> cell_ids, ref_coords = surface.locate(surface.evaluate(pts))
+        """
+        return _locate_impl(self, points, tol, max_iter)
 
     def derivative(self, direction: int = 0, *, keep_degree: bool = False) -> Bspline:
         """Return a B-spline representing the first derivative in the given direction.
@@ -857,6 +935,7 @@ class Bspline:
         if in_place:
             self._space = new_space
             self._beziers_cache = None
+            self._locate_cache = None
             return None
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
@@ -913,6 +992,7 @@ class Bspline:
             self._control_points = new_cp
             self._space = new_space
             self._beziers_cache = None
+            self._locate_cache = None
             return None
         return Bspline(new_space, new_cp, is_rational=self._is_rational)
 
@@ -968,6 +1048,7 @@ class Bspline:
         )
         if in_place:
             self._beziers_cache = None
+            self._locate_cache = None
             return None
         return Bspline(self._space, new_cp, is_rational=self._is_rational)
 

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -1,0 +1,519 @@
+"""Physical-to-parametric point inversion for :class:`~pantr.bspline.Bspline`.
+
+Layer 2 implementation behind :meth:`pantr.bspline.Bspline.locate`: given physical
+points, recover the parametric coordinates whose image they are, together with the
+knot-span cell that contains them.
+
+The inversion has two stages:
+
+1. **Candidate cells.** The image of a knot-span cell lies inside the axis-aligned box
+   of the control points supporting that cell -- the convex-hull property of the
+   B-spline basis, which for a NURBS holds for the *projected* control points provided
+   every weight is positive. Those per-cell boxes are indexed by a
+   :class:`pantr.grid.BVH`, so the cells that can contain a query point are found by a
+   tree descent instead of by trying Newton on every cell.
+2. **Newton.** Per candidate cell, Newton's method on ``F(xi) - x = 0`` starting from
+   the cell's parametric midpoint, with the Jacobian assembled column by column from
+   :meth:`~pantr.bspline.Bspline.evaluate_derivatives` (already rational-aware through
+   the generalized quotient rule). Iterates are clamped to the parametric domain box,
+   so an iterate may migrate out of its candidate cell: the candidate box is a superset
+   test, never a constraint on the solution.
+
+Newton runs on the whole batch of points at once: one candidate slot per round, and
+within a round one evaluator call per Jacobian column for all still-active points
+together. The number of Python-level calls into the evaluators is therefore
+``O(rounds * max_iter * dim)``, independent of the number of query points.
+
+What is guaranteed is ``F(ref_coords[i]) == points[i]`` within the tolerance, and *not*
+that ``ref_coords[i]`` is any particular preimage. A mapping whose Jacobian determinant
+changes sign folds, and a folded mapping sends several parametric points to the same
+physical point; every one of them is a correct answer, and which one comes back depends on
+the candidate order and on the Newton path. Only for an injective mapping does inverting
+``evaluate`` return the coordinates it was called with.
+
+Precision contract: the inversion always runs in ``float64``, promoting a ``float32``
+spline to an exact ``float64`` copy first -- casting float32 coefficients to float64 is
+exact, so the promoted spline is the same mapping. The reason is margin, not
+impossibility: the residual of a ``float32`` evaluation cannot be resolved below
+``1 - 3 * eps32 * scale`` (measured over supports from 6 to 125 control points), while
+:func:`pantr.tolerance.get_default` for ``float32`` is ``1e-6``, i.e. ``8.4 * eps32``.
+That is under one decade of headroom, against roughly ``2e3`` for ``float64``, and
+iterating in float32 would additionally quantize the parametric iterate at ``eps32``.
+Promotion removes both for the price of one exact cast. The returned coordinates invert
+the promoted mapping to float64 accuracy; evaluating them on the original ``float32``
+spline reproduces the query point to float32 accuracy only.
+
+v1 inverts square maps only (``rank == dim``): planar and volumetric geometry maps. An
+embedded curve or surface (``rank > dim``) needs a Gauss-Newton closest-point solve,
+which is a documented follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+
+from ..geometry import AABB
+from ..grid import BVH, tensor_product_grid
+from ..tolerance import get_default
+
+if TYPE_CHECKING:
+    from numpy import typing as npt
+
+    from ._bspline import Bspline
+    from ._bspline_space_nd import BsplineSpace
+
+_JACOBIAN_RANK_REL_TOL: float = float(np.finfo(np.float64).eps)
+"""
+Relative threshold at which a Newton Jacobian counts as rank-deficient.
+
+A candidate is abandoned when ``sigma_min <= dim * _JACOBIAN_RANK_REL_TOL * sigma_max``,
+which is the rule and the magnitude :func:`numpy.linalg.matrix_rank` uses by default
+(``max(M, N) * eps * sigma_max``): below it the null direction is indistinguishable from
+rounding noise and the solve returns an arbitrary step. The test is a ratio, so it is
+invariant under scaling the geometry or the parametrization. It is deliberately
+permissive -- it only rejects a Jacobian whose condition number reaches ``1 / (dim *
+eps)`` -- because a merely ill-conditioned Jacobian still gives a usable step, and the
+clamp to the parametric domain box already bounds an overlong one.
+"""
+
+
+class _LocateContext(NamedTuple):
+    """Per-:class:`~pantr.bspline.Bspline` state reused across :meth:`locate` calls.
+
+    Cached on the B-spline instance and invalidated by the in-place mutators, exactly
+    like the Bézier decomposition cache: none of these three depends on the query
+    points, and the BVH costs ``O(num_cells)`` to build.
+
+    Attributes:
+        spline (Bspline): The spline to invert, in ``float64``. The original instance
+            when it is already ``float64``, otherwise an exact promoted copy.
+        bvh (BVH): Hierarchy over the per-cell physical control-point boxes, with cell
+            ids flat in C-order over ``space.num_intervals``.
+        scale (float): The geometric scale the default tolerance is expressed in; see
+            :func:`_geometric_scale`.
+    """
+
+    spline: Bspline
+    bvh: BVH
+    scale: float
+
+
+def _physical_control_points(spline: Bspline) -> npt.NDArray[np.float64]:
+    """Return the projected control points of ``spline`` as ``float64``.
+
+    Args:
+        spline (Bspline): The spline whose control points are wanted. A rational spline
+            must have strictly positive weights, which the caller has checked.
+
+    Returns:
+        npt.NDArray[np.float64]: Array of shape ``(*num_basis, rank)``: the control
+        points a non-rational spline stores directly, or ``P_i / w_i`` for a NURBS.
+    """
+    cp = np.asarray(spline.control_points, dtype=np.float64)
+    if not spline.is_rational:
+        return cp
+    return np.asarray(cp[..., :-1] / cp[..., -1:], dtype=np.float64)
+
+
+def _promote_to_float64(spline: Bspline) -> Bspline:
+    """Return an exact ``float64`` copy of ``spline``, or ``spline`` if already so.
+
+    Casting ``float32`` knots and control points to ``float64`` is exact, so the copy
+    represents the same mapping. Knots that a ``float32`` construction snapped together
+    stay bitwise equal under the cast, so the promoted knot vector has the same
+    multiplicity structure.
+
+    Args:
+        spline (Bspline): The spline to promote.
+
+    Returns:
+        Bspline: ``spline`` when its dtype is already ``float64``, else a new
+        :class:`~pantr.bspline.Bspline` over ``float64`` knots and control points.
+    """
+    if np.dtype(spline.dtype) == np.float64:
+        return spline
+
+    from ._bspline import Bspline as BsplineCls  # noqa: PLC0415 -- breaks an import cycle
+    from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415 -- breaks an import cycle
+    from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415 -- breaks an import cycle
+
+    spaces_64 = [
+        BsplineSpace1D(np.asarray(sub.knots, dtype=np.float64), sub.degree, periodic=sub.periodic)
+        for sub in spline.space.spaces
+    ]
+    return BsplineCls(
+        BsplineSpace(spaces_64),
+        np.asarray(spline.control_points, dtype=np.float64),
+        is_rational=spline.is_rational,
+    )
+
+
+def _cell_physical_bounds(
+    spline: Bspline,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return the physical AABB of every knot-span cell's supporting control points.
+
+    Reduces one parametric axis at a time rather than gathering the full
+    ``prod(degree + 1)`` support of each cell: the support is a contiguous window per
+    axis, so a running min/max over ``degree + 1`` shifted takes gives the same result
+    in ``O(num_cells * sum(degree + 1))`` work and without ever materializing the
+    per-cell support table.
+
+    Args:
+        spline (Bspline): The spline whose cell boxes are wanted, in ``float64``, with
+            no periodic direction and (if rational) positive weights.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(lo, hi)``, both of
+        shape ``(num_total_intervals, rank)``, indexed by flat cell id in C-order over
+        ``space.num_intervals``.
+    """
+    lo = _physical_control_points(spline)
+    hi = lo
+    for axis, sub in enumerate(spline.space.spaces):
+        first = sub.first_basis_per_interval()
+        acc_lo = np.take(lo, first, axis=axis)
+        acc_hi = np.take(hi, first, axis=axis)
+        for offset in range(1, sub.degree + 1):
+            np.minimum(acc_lo, np.take(lo, first + offset, axis=axis), out=acc_lo)
+            np.maximum(acc_hi, np.take(hi, first + offset, axis=axis), out=acc_hi)
+        lo, hi = acc_lo, acc_hi
+    n_cells = spline.space.num_total_intervals
+    rank = spline.rank
+    return lo.reshape(n_cells, rank), hi.reshape(n_cells, rank)
+
+
+def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -> float:
+    """Return the length the default convergence tolerance is a multiple of.
+
+    Two lengths matter and the larger one has to win:
+
+    - the **diagonal** of the geometry's bounding box, which is what makes a residual
+      threshold a *relative* accuracy statement about the mapping; and
+    - the largest coordinate **magnitude** present, because the computed residual
+      ``F(xi) - x`` cannot be resolved below ``~C * eps * max|coordinate|`` (the de Boor
+      sum accumulates ``C`` roundings, of the order of ``prod(degree + 1)``), whatever
+      the box's extent is.
+
+    Using the diagonal alone silently makes the tolerance unreachable for a geometry far
+    from the origin -- a patch of diameter 1 sitting at ``x = 1e6`` has a residual floor
+    around ``1e-10`` while ``1e-12 * 1`` would be demanded -- so the scale is the
+    maximum of the two. With :func:`pantr.tolerance.get_default` for ``float64``
+    (``1e-12``, i.e. ``4.5e3 * eps``) the resulting threshold sits about two orders of
+    magnitude above that floor.
+
+    A geometry with no length at all (every control point identical, at the origin)
+    falls back to ``1.0``: there is no scale to read off it, and the tolerance must stay
+    positive.
+
+    Args:
+        lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
+            ``(n_cells, rank)``.
+        hi (npt.NDArray[np.float64]): Per-cell box upper corners, same shape.
+
+    Returns:
+        float: The geometric scale, strictly positive.
+    """
+    box_lo = lo.min(axis=0)
+    box_hi = hi.max(axis=0)
+    diagonal = float(np.linalg.norm(box_hi - box_lo))
+    magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
+    return max(diagonal, magnitude, 1.0)
+
+
+def _build_context(spline: Bspline) -> _LocateContext:
+    """Build the cached inversion state of ``spline``.
+
+    Args:
+        spline (Bspline): The spline to invert; already validated by
+            :func:`_locate_impl`.
+
+    Returns:
+        _LocateContext: The promoted spline, the BVH over its per-cell physical boxes,
+        and the geometric scale.
+    """
+    spline_64 = _promote_to_float64(spline)
+    lo, hi = _cell_physical_bounds(spline_64)
+    return _LocateContext(
+        spline=spline_64, bvh=BVH.from_cell_bounds(lo, hi), scale=_geometric_scale(lo, hi)
+    )
+
+
+def _cell_midpoints(
+    space: BsplineSpace, cell_ids: npt.NDArray[np.int64]
+) -> npt.NDArray[np.float64]:
+    """Return the parametric midpoint of each of the given knot-span cells.
+
+    Args:
+        space (BsplineSpace): The space the cells belong to, with no periodic direction.
+        cell_ids (npt.NDArray[np.int64]): Flat cell ids in C-order over
+            ``space.num_intervals``, shape ``(n,)``.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(n, space.dim)`` parametric midpoints.
+    """
+    multi = np.unravel_index(cell_ids, space.num_intervals)
+    out = np.empty((cell_ids.shape[0], space.dim), dtype=np.float64)
+    for axis, sub in enumerate(space.spaces):
+        breakpoints = np.asarray(
+            sub.get_unique_knots_and_multiplicity(in_domain=True)[0], dtype=np.float64
+        )
+        index = multi[axis]
+        out[:, axis] = 0.5 * (breakpoints[index] + breakpoints[index + 1])
+    return out
+
+
+def _eval_map(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Evaluate the mapping at parametric points, in the batched shape Newton wants.
+
+    Args:
+        spline (Bspline): A ``float64`` spline with ``rank == dim``.
+        xi (npt.NDArray[np.float64]): Parametric points, shape ``(n, dim)``, inside the
+            domain.
+
+    Returns:
+        npt.NDArray[np.float64]: Physical points, shape ``(n, rank)``. The reshape also
+        undoes the ``squeeze()`` the 1-D evaluation path applies to scalar output.
+    """
+    pts = np.ascontiguousarray(xi[:, 0] if spline.dim == 1 else xi)
+    values = spline.evaluate(pts)
+    return np.asarray(values, dtype=np.float64).reshape(xi.shape[0], spline.rank)
+
+
+def _eval_jacobian(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Evaluate the Jacobian of the mapping at parametric points.
+
+    Column ``d`` is the first partial derivative in parametric direction ``d``, taken
+    from :meth:`~pantr.bspline.Bspline.evaluate_derivatives`, which returns derivatives
+    of the projected mapping for a NURBS.
+
+    Args:
+        spline (Bspline): A ``float64`` spline with ``rank == dim``.
+        xi (npt.NDArray[np.float64]): Parametric points, shape ``(n, dim)``, inside the
+            domain.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(n, rank, dim)`` Jacobians.
+    """
+    n_pts, dim = xi.shape
+    rank = spline.rank
+    pts = np.ascontiguousarray(xi[:, 0] if dim == 1 else xi)
+    out = np.empty((n_pts, rank, dim), dtype=np.float64)
+    for axis in range(dim):
+        orders = [0] * dim
+        orders[axis] = 1
+        column = spline.evaluate_derivatives(pts, orders)
+        out[:, :, axis] = np.asarray(column, dtype=np.float64).reshape(n_pts, rank)
+    return out
+
+
+def _newton_refine(
+    spline: Bspline,
+    targets: npt.NDArray[np.float64],
+    xi_start: npt.NDArray[np.float64],
+    tol_phys: float,
+    max_iter: int,
+) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
+    """Run a batched Newton inversion, one starting guess per target point.
+
+    Every point is iterated independently but evaluated collectively: each round drops
+    the points that have converged and the points whose Jacobian has become
+    rank-deficient, then takes one Newton step for the rest. Iterates are clamped to the
+    parametric domain box, which both keeps them inside the evaluators' legal input
+    range and bounds an overlong step from an ill-conditioned Jacobian.
+
+    Args:
+        spline (Bspline): A ``float64`` spline with ``rank == dim``, non-periodic.
+        targets (npt.NDArray[np.float64]): Physical query points, shape ``(n, rank)``.
+        xi_start (npt.NDArray[np.float64]): Starting parametric guesses, shape
+            ``(n, dim)``.
+        tol_phys (float): Convergence threshold on ``||F(xi) - x||_2``, a distance in
+            physical units.
+        max_iter (int): Maximum number of Newton steps. The residual is tested once more
+            after the last step, so a point converging on step ``max_iter`` is reported.
+
+    Returns:
+        tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]: ``(converged, xi)``.
+        ``converged`` has shape ``(n,)``; ``xi`` has shape ``(n, dim)`` and is only
+        meaningful where ``converged`` is True.
+    """
+    dim = xi_start.shape[1]
+    domain = np.asarray(spline.space.domain, dtype=np.float64)
+    lo, hi = domain[:, 0], domain[:, 1]
+
+    xi = np.clip(xi_start, lo, hi)
+    converged = np.zeros(xi.shape[0], dtype=np.bool_)
+    active = np.arange(xi.shape[0], dtype=np.int64)
+
+    for step in range(max_iter + 1):
+        xi_active = xi[active]
+        residual = _eval_map(spline, xi_active) - targets[active]
+        done = np.linalg.norm(residual, axis=1) <= tol_phys
+        converged[active[done]] = True
+        active, xi_active, residual = active[~done], xi_active[~done], residual[~done]
+        if step == max_iter or active.size == 0:
+            break
+
+        jacobian = _eval_jacobian(spline, xi_active)
+        singular_values = np.asarray(np.linalg.svd(jacobian, compute_uv=False), dtype=np.float64)
+        healthy = singular_values[:, -1] > (dim * _JACOBIAN_RANK_REL_TOL * singular_values[:, 0])
+        active = active[healthy]
+        if active.size == 0:
+            break
+        delta = np.asarray(
+            np.linalg.solve(jacobian[healthy], residual[healthy][..., np.newaxis]),
+            dtype=np.float64,
+        )[..., 0]
+        xi[active] = np.clip(xi_active[healthy] - delta, lo, hi)
+
+    return converged, xi
+
+
+def _validate_points(points: npt.ArrayLike, rank: int) -> npt.NDArray[np.float64]:
+    """Normalize the query points to a finite ``(n, rank)`` ``float64`` array.
+
+    A 1-D input is read as a single point of ``rank`` coordinates, except for ``rank ==
+    1`` where it is read as ``n`` scalar coordinates -- the convention
+    :meth:`~pantr.bspline.Bspline.evaluate` already uses for a 1-D spline.
+
+    Args:
+        points (npt.ArrayLike): The query points.
+        rank (int): The spline's physical rank.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(n, rank)`` array of query points.
+
+    Raises:
+        ValueError: If the shape is not ``(n, rank)`` (after the 1-D readings above) or
+            any coordinate is not finite.
+    """
+    pts = np.asarray(points, dtype=np.float64)
+    if pts.ndim == 1:
+        pts = pts.reshape(-1, 1) if rank == 1 else pts.reshape(1, -1)
+    if pts.ndim != 2 or pts.shape[1] != rank:  # noqa: PLR2004 -- (n, rank) is 2-D
+        raise ValueError(
+            f"locate: points must have shape (n, {rank}) for a rank-{rank} B-spline; "
+            f"got shape {np.asarray(points).shape}."
+        )
+    if not bool(np.all(np.isfinite(pts))):
+        raise ValueError("locate: points must be finite; got a NaN or infinite coordinate.")
+    return np.ascontiguousarray(pts)
+
+
+def _locate_impl(
+    spline: Bspline,
+    points: npt.ArrayLike,
+    tol: float | None,
+    max_iter: int,
+) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]:
+    """Invert the mapping of ``spline`` at the given physical points.
+
+    Args:
+        spline (Bspline): The spline to invert. Must be square (``rank == dim``) and
+            non-periodic, and, if rational, have strictly positive weights.
+        points (npt.ArrayLike): Physical query points; see :func:`_validate_points`.
+        tol (float | None): Convergence threshold on ``||F(xi) - x||_2`` as an absolute
+            distance in physical units, or ``None`` for
+            ``pantr.tolerance.get_default(spline.dtype) * scale``, with ``scale`` from
+            :func:`_geometric_scale`.
+        max_iter (int): Maximum number of Newton steps per candidate cell.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]: ``(cell_ids,
+        ref_coords)``, both read-only. ``cell_ids`` has shape ``(n,)`` and holds flat
+        knot-span cell ids in C-order over ``space.num_intervals``, or ``-1`` where the
+        point was not found; ``ref_coords`` has shape ``(n, dim)`` and holds parametric
+        coordinates, or ``nan`` where the point was not found.
+
+    Raises:
+        NotImplementedError: If ``rank > dim`` (an embedded curve or surface).
+        ValueError: If ``rank < dim``, any direction is periodic, a rational spline has
+            a non-positive weight, ``points`` has a bad shape or a non-finite entry,
+            ``max_iter < 1``, or ``tol`` is given and is not positive and finite.
+    """
+    dim, rank = spline.dim, spline.rank
+    if rank > dim:
+        raise NotImplementedError(
+            f"locate: embedded geometries (rank {rank} > dim {dim}) need a Gauss-Newton "
+            "closest-point solve, which is not implemented; only square maps "
+            "(rank == dim) can be inverted."
+        )
+    if rank < dim:
+        raise ValueError(
+            f"locate: a B-spline mapping cannot be inverted with fewer physical "
+            f"coordinates than parametric directions; got rank {rank} < dim {dim}."
+        )
+    for axis, sub in enumerate(spline.space.spaces):
+        if sub.periodic:
+            raise ValueError(f"locate: periodic B-spline spaces are not supported (axis {axis}).")
+    if spline.is_rational and not bool(
+        np.all(np.asarray(spline.control_points[..., -1], dtype=np.float64) > 0.0)
+    ):
+        raise ValueError(
+            "locate: every NURBS weight must be strictly positive; the convex-hull "
+            "property the candidate search relies on does not hold otherwise."
+        )
+    if max_iter < 1:
+        raise ValueError(f"locate: max_iter must be >= 1; got {max_iter}.")
+    if tol is not None and not (float(tol) > 0.0 and np.isfinite(tol)):
+        raise ValueError(f"locate: tol must be positive and finite; got {tol}.")
+
+    pts = _validate_points(points, rank)
+    context = _locate_context(spline)
+    tol_phys = float(tol) if tol is not None else get_default(spline.dtype) * context.scale
+
+    n_pts = pts.shape[0]
+    cell_ids = np.full(n_pts, -1, dtype=np.int64)
+    ref_coords = np.full((n_pts, dim), np.nan, dtype=np.float64)
+
+    # Candidates per point, in ascending cell id: the order the rounds below try them in.
+    candidates = [np.sort(context.bvh.query_aabb(AABB(x, x).pad(tol_phys))) for x in pts]
+    pending = [i for i, cand in enumerate(candidates) if cand.size > 0]
+    found: list[int] = []
+    slot = 0
+    while pending:
+        batch = [i for i in pending if candidates[i].size > slot]
+        if not batch:
+            break
+        index = np.asarray(batch, dtype=np.int64)
+        starts = _cell_midpoints(
+            context.spline.space, np.asarray([candidates[i][slot] for i in batch], dtype=np.int64)
+        )
+        converged, xi = _newton_refine(context.spline, pts[index], starts, tol_phys, max_iter)
+        hits = index[converged]
+        ref_coords[hits] = xi[converged]
+        found.extend(int(i) for i in hits)
+        resolved = set(found)
+        pending = [i for i in pending if i not in resolved]
+        slot += 1
+
+    if found:
+        rows = np.asarray(sorted(found), dtype=np.int64)
+        grid = tensor_product_grid(context.spline.space)
+        cell_ids[rows] = grid.locate_many(ref_coords[rows])
+
+    cell_ids.flags.writeable = False
+    ref_coords.flags.writeable = False
+    return cell_ids, ref_coords
+
+
+def _locate_context(spline: Bspline) -> _LocateContext:
+    """Return the cached inversion state of ``spline``, building it on first use.
+
+    Args:
+        spline (Bspline): The spline to invert; already validated by
+            :func:`_locate_impl`.
+
+    Returns:
+        _LocateContext: The cached context. Invalidated by the in-place mutators of
+        :class:`~pantr.bspline.Bspline`, which reset the cache attribute to ``None``.
+    """
+    # Layer 2 owns this cache slot; Layer 1 only declares and invalidates it.
+    if spline._locate_cache is None:
+        spline._locate_cache = _build_context(spline)
+    return spline._locate_cache
+
+
+__all__ = ["_locate_impl"]

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -1,0 +1,748 @@
+"""Tests for physical-to-parametric point inversion (``Bspline.locate``)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline_locate import (
+    _cell_physical_bounds,
+    _geometric_scale,
+    _LocateContext,
+)
+from pantr.transform import AffineTransform
+
+_XI_REL_ATOL: float = 1e-10
+"""
+Absolute tolerance on a recovered parametric coordinate, as a multiple of the geometry's
+scale (the larger of its control-point bounding-box diagonal and its largest coordinate
+magnitude).
+
+The inversion stops when ``||F(xi) - x||_2 <= 1e-12 * scale``, so the coordinate error is
+that residual divided by the smallest singular value of the Jacobian:
+``1e-12 * scale / sigma_min``. Every geometry below has ``sigma_min`` of order one, and
+the measured worst case over them is ``2.8e-12`` on a geometry of scale ``2.83``, i.e.
+``1e-12 * scale`` exactly as predicted. The ``1e-10`` factor leaves two decades of margin
+for a less favourable Jacobian.
+"""
+
+_XI_ATOL_FLOAT32: float = 1e-4
+"""
+Absolute tolerance on a recovered parametric coordinate for a ``float32`` B-spline.
+
+The convergence threshold is :func:`pantr.tolerance.get_default` for ``float32``
+(``1e-6``) times the geometric scale, so the coordinate error is four orders of magnitude
+larger than in the ``float64`` case. Measured worst case over the cases below:
+``5.2e-6``; the ``1e-4`` leaves a factor of 19.
+"""
+
+
+def _quarter_annulus(
+    r_in: float = 1.0,
+    r_out: float = 2.0,
+    shift: tuple[float, float] = (0.0, 0.0),
+    dtype: npt.DTypeLike = np.float64,
+) -> Bspline:
+    """Return the exact quarter annulus: a degree-2 rational arc times a linear radius.
+
+    The angular direction is the standard degree-2 NURBS quarter circle (three control
+    points, middle weight ``sqrt(2) / 2``), so ``|F(u, v) - shift| == r_in + v *
+    (r_out - r_in)`` holds exactly, not approximately.
+    """
+    weight = np.sqrt(2.0) / 2.0
+    arc = np.array([[1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    weights = np.array([1.0, weight, 1.0])
+    radii = np.array([r_in, r_out])
+    cp = np.empty((3, 2, 3), dtype=np.float64)
+    for i in range(3):
+        for j in range(2):
+            cp[i, j, :2] = weights[i] * (radii[j] * arc[i] + np.asarray(shift))
+            cp[i, j, 2] = weights[i]
+    angular = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=dtype), 2)
+    radial = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype), 1)
+    return Bspline(BsplineSpace([angular, radial]), cp.astype(dtype), is_rational=True)
+
+
+def _greville_abscissae(space: BsplineSpace1D) -> npt.NDArray[np.float64]:
+    """Return the Greville abscissae of a 1-D space, one per basis function."""
+    knots = np.asarray(space.knots, dtype=np.float64)
+    degree = space.degree
+    return np.array(
+        [knots[i + 1 : i + degree + 1].mean() for i in range(space.num_basis)], dtype=np.float64
+    )
+
+
+def _identity_map(
+    knots: npt.ArrayLike, degree: int, dim: int, dtype: npt.DTypeLike = np.float64
+) -> Bspline:
+    """Return the identity mapping of the knot vector's box, from Greville abscissae."""
+    spaces = [BsplineSpace1D(np.asarray(knots, dtype=dtype), degree) for _ in range(dim)]
+    mesh = np.meshgrid(*[_greville_abscissae(sub) for sub in spaces], indexing="ij")
+    cp = np.stack(mesh, axis=-1) if dim > 1 else mesh[0][:, np.newaxis]
+    return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp.astype(dtype)))
+
+
+def _perturbed_patch(
+    degree: int, n_cells: int, dim: int, seed: int, dtype: npt.DTypeLike = np.float64
+) -> Bspline:
+    """Return an injective patch: the identity map plus a bounded random perturbation.
+
+    The perturbation (``0.12`` of a unit cell) is small enough to keep the Jacobian
+    determinant positive, which the tests that compare recovered coordinates assert
+    directly rather than assume.
+    """
+    rng = np.random.default_rng(seed)
+    knots = np.concatenate(
+        [np.zeros(degree + 1), np.arange(1.0, n_cells), np.full(degree + 1, float(n_cells))]
+    )
+    spaces = [BsplineSpace1D(knots.astype(dtype), degree) for _ in range(dim)]
+    mesh = np.meshgrid(*[_greville_abscissae(sub) for sub in spaces], indexing="ij")
+    cp = np.stack(mesh, axis=-1) if dim > 1 else mesh[0][:, np.newaxis]
+    cp = cp + 0.12 * rng.uniform(-1.0, 1.0, size=cp.shape)
+    return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp.astype(dtype)))
+
+
+def _folded_patch() -> Bspline:
+    """Return a patch whose Jacobian determinant changes sign, so it is not injective."""
+    knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+    sub = BsplineSpace1D(knots, 2)
+    space = BsplineSpace([sub, sub])
+    u_grev, v_grev = (np.linspace(0.0, 1.0, n) for n in space.num_basis)
+    u_mesh, v_mesh = np.meshgrid(u_grev, v_grev, indexing="ij")
+    cp = np.stack([u_mesh + 0.9 * v_mesh, v_mesh + 0.9 * np.sin(3.0 * u_mesh)], axis=-1)
+    return Bspline(space, np.ascontiguousarray(cp))
+
+
+def _stretched_patch() -> Bspline:
+    """Return an injective sheared patch whose per-cell physical boxes overlap heavily."""
+    knots = np.array([0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0])
+    sub = BsplineSpace1D(knots, 2)
+    space = BsplineSpace([sub, sub])
+    u_grev, v_grev = (np.linspace(0.0, 1.0, n) for n in space.num_basis)
+    u_mesh, v_mesh = np.meshgrid(u_grev, v_grev, indexing="ij")
+    cp = np.stack([u_mesh + 0.9 * v_mesh, v_mesh + 0.25 * np.sin(3.0 * u_mesh)], axis=-1)
+    return Bspline(space, np.ascontiguousarray(cp))
+
+
+def _collapsed_edge_patch() -> Bspline:
+    """Return the bilinear patch ``F(u, v) = (u * v, v)``, whose ``v == 0`` edge collapses.
+
+    Its Jacobian ``[[v, u], [0, 1]]`` is singular along that edge, and its image is the
+    triangle ``0 <= x <= y <= 1`` rather than the full control-point box.
+    """
+    cp = np.array([[[0.0, 0.0], [0.0, 1.0]], [[0.0, 0.0], [1.0, 1.0]]], dtype=np.float64)
+    sub = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+    return Bspline(BsplineSpace([sub, sub]), cp)
+
+
+def _scale_of(spline: Bspline) -> float:
+    """Return the geometric scale the default tolerance is expressed in."""
+    return _geometric_scale(*_cell_physical_bounds(spline))
+
+
+def _cache_of(spline: Bspline) -> _LocateContext | None:
+    """Return the point-inversion cache attribute of ``spline``.
+
+    Read through a function rather than inline: an inline ``assert spline._locate_cache is
+    None`` narrows the attribute's type for the rest of the test, and mypy then calls the
+    later assertions unreachable. A call expression is not narrowed.
+    """
+    return spline._locate_cache
+
+
+def _sample_parametric(
+    spline: Bspline, n_pts: int, seed: int, margin: float = 0.02
+) -> npt.NDArray[np.float64]:
+    """Return ``n_pts`` random parametric points, kept ``margin`` away from the boundary."""
+    domain = np.asarray(spline.space.domain, dtype=np.float64)
+    lo, hi = domain[:, 0], domain[:, 1]
+    rng = np.random.default_rng(seed)
+    unit = rng.uniform(margin, 1.0 - margin, size=(n_pts, spline.dim))
+    return lo + (hi - lo) * unit
+
+
+def _evaluate_at(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Evaluate ``spline`` at ``(n, dim)`` parametric points, always returning ``(n, rank)``."""
+    pts = np.ascontiguousarray((xi[:, 0] if spline.dim == 1 else xi).astype(spline.dtype))
+    values = spline.evaluate(pts)
+    return np.asarray(values, dtype=np.float64).reshape(xi.shape[0], spline.rank)
+
+
+def _jacobian_determinants(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Return ``det J`` at each parametric point, for an injectivity guard."""
+    pts = np.ascontiguousarray((xi[:, 0] if spline.dim == 1 else xi).astype(spline.dtype))
+    columns = []
+    for axis in range(spline.dim):
+        orders = [0] * spline.dim
+        orders[axis] = 1
+        column = spline.evaluate_derivatives(pts, orders)
+        columns.append(np.asarray(column, dtype=np.float64).reshape(xi.shape[0], spline.rank))
+    return np.asarray(np.linalg.det(np.stack(columns, axis=-1)), dtype=np.float64)
+
+
+def _assert_cell_contains(
+    spline: Bspline,
+    cell_ids: npt.NDArray[np.int64],
+    ref_coords: npt.NDArray[np.float64],
+) -> None:
+    """Assert every reported cell's parametric box contains its reported coordinates.
+
+    An independent check of the ``cell_ids`` half of the result: it reads the per-axis
+    breakpoints straight off the knot vectors instead of asking the grid again, which is
+    what produced the ids.
+    """
+    multi = np.unravel_index(cell_ids, spline.space.num_intervals)
+    for axis, sub in enumerate(spline.space.spaces):
+        breakpoints = np.asarray(
+            sub.get_unique_knots_and_multiplicity(in_domain=True)[0], dtype=np.float64
+        )
+        index = multi[axis]
+        assert np.all(breakpoints[index] <= ref_coords[:, axis])
+        assert np.all(ref_coords[:, axis] <= breakpoints[index + 1])
+
+
+class TestRoundtrip:
+    """Inverting ``evaluate`` recovers the parametric coordinates it was called with."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_perturbed_identity(self, degree: int, dim: int) -> None:
+        """A perturbed identity patch inverts to the generating coordinates."""
+        spline = _perturbed_patch(degree, 4, dim, seed=100 * degree + dim)
+        xi_true = _sample_parametric(spline, 200, seed=1)
+        assert np.all(_jacobian_determinants(spline, xi_true) > 0.0), "patch must be injective"
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        atol = _XI_REL_ATOL * _scale_of(spline)
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(ref_coords, xi_true, atol=atol, rtol=0.0)
+        np.testing.assert_allclose(_evaluate_at(spline, ref_coords), points, atol=atol, rtol=0.0)
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_three_dimensional(self) -> None:
+        """A 3-D perturbed identity volume inverts to the generating coordinates."""
+        spline = _perturbed_patch(2, 3, 3, seed=77)
+        xi_true = _sample_parametric(spline, 200, seed=2)
+        assert np.all(_jacobian_determinants(spline, xi_true) > 0.0)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_repeated_interior_knots(self) -> None:
+        """A knot vector with a repeated interior knot (a C0 line) inverts correctly."""
+        knots = np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0])
+        spline = _identity_map(knots, 3, 2)
+        xi_true = _sample_parametric(spline, 200, seed=3)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_one_dimensional_input_is_a_list_of_scalars(self) -> None:
+        """For ``rank == 1`` a 1-D input is read as ``n`` points, matching ``evaluate``."""
+        spline = _perturbed_patch(3, 4, 1, seed=5)
+        xi_true = _sample_parametric(spline, 20, seed=4)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points[:, 0])
+
+        assert cell_ids.shape == (20,)
+        assert ref_coords.shape == (20, 1)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+
+    def test_single_point_as_a_flat_array(self) -> None:
+        """A flat array of ``rank`` coordinates is read as one point."""
+        spline = _perturbed_patch(2, 3, 2, seed=6)
+        xi_true = _sample_parametric(spline, 1, seed=7)
+        point = _evaluate_at(spline, xi_true)[0]
+
+        cell_ids, ref_coords = spline.locate(point)
+
+        assert cell_ids.shape == (1,)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+
+    def test_empty_input(self) -> None:
+        """An empty batch returns empty results rather than raising."""
+        spline = _perturbed_patch(2, 2, 2, seed=8)
+        cell_ids, ref_coords = spline.locate(np.zeros((0, 2)))
+        assert cell_ids.shape == (0,)
+        assert ref_coords.shape == (0, 2)
+
+    def test_outputs_are_read_only(self) -> None:
+        """Both returned arrays are frozen, like the rest of pantr's exposed arrays."""
+        spline = _perturbed_patch(2, 2, 2, seed=9)
+        points = _evaluate_at(spline, _sample_parametric(spline, 5, seed=10))
+        cell_ids, ref_coords = spline.locate(points)
+        assert not cell_ids.flags.writeable
+        assert not ref_coords.flags.writeable
+
+
+class TestRationalAnnulus:
+    """Inversion of an exact NURBS quarter annulus, interior and boundary."""
+
+    def test_geometry_is_the_exact_annulus(self) -> None:
+        """Guard on the fixture: the radius is exactly affine in ``v``."""
+        annulus = _quarter_annulus()
+        xi = _sample_parametric(annulus, 100, seed=11)
+        radii = np.linalg.norm(_evaluate_at(annulus, xi), axis=1)
+        np.testing.assert_allclose(radii, 1.0 + xi[:, 1], atol=1e-15, rtol=0.0)
+
+    def test_interior_points(self) -> None:
+        """Interior points invert to the generating coordinates."""
+        annulus = _quarter_annulus()
+        xi_true = _sample_parametric(annulus, 200, seed=11)
+        points = _evaluate_at(annulus, xi_true)
+
+        cell_ids, ref_coords = annulus.locate(points)
+
+        assert np.all(cell_ids == 0), "a single-cell patch has only cell 0"
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(annulus), rtol=0.0
+        )
+
+    def test_boundary_and_corner_points(self) -> None:
+        """Points on the domain boundary, including corners, are found."""
+        annulus = _quarter_annulus()
+        xi_true = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [0.0, 0.5],
+                [1.0, 0.5],
+                [0.5, 0.0],
+                [0.5, 1.0],
+            ]
+        )
+        points = _evaluate_at(annulus, xi_true)
+
+        cell_ids, ref_coords = annulus.locate(points)
+
+        assert np.all(cell_ids == 0)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(annulus), rtol=0.0
+        )
+
+    def test_float32_spline(self) -> None:
+        """A ``float32`` annulus inverts to ``float32``-limited accuracy."""
+        annulus32 = _quarter_annulus(dtype=np.float32)
+        xi_true = _sample_parametric(annulus32, 200, seed=12)
+        points = _evaluate_at(annulus32, xi_true)
+
+        cell_ids, ref_coords = annulus32.locate(points)
+
+        assert ref_coords.dtype == np.float64
+        assert np.all(cell_ids == 0)
+        np.testing.assert_allclose(ref_coords, xi_true, atol=_XI_ATOL_FLOAT32, rtol=0.0)
+
+
+class TestOutsidePoints:
+    """Points that are not on the mapping's image report ``-1`` and ``nan``."""
+
+    def test_outside_the_bounding_box(self) -> None:
+        """A point far from the geometry is reported as not found."""
+        annulus = _quarter_annulus()
+        cell_ids, ref_coords = annulus.locate(np.array([[10.0, 10.0], [-3.0, 0.5]]))
+        assert cell_ids.tolist() == [-1, -1]
+        assert bool(np.all(np.isnan(ref_coords)))
+
+    def test_inside_the_bounding_box_but_off_the_domain(self) -> None:
+        """The annulus hole is inside the control-point box yet off the geometry."""
+        annulus = _quarter_annulus()
+        holes = np.array([[0.0, 0.0], [0.2, 0.2], [0.5, 0.5], [1.9, 1.9]])
+        cell_ids, ref_coords = annulus.locate(holes)
+        assert cell_ids.tolist() == [-1, -1, -1, -1]
+        assert bool(np.all(np.isnan(ref_coords)))
+
+    def test_mixed_batch_keeps_the_found_points(self) -> None:
+        """A batch mixing found and unfound points resolves each independently."""
+        annulus = _quarter_annulus()
+        xi_true = np.array([[0.3, 0.7], [0.8, 0.1]])
+        points = np.vstack([_evaluate_at(annulus, xi_true), np.array([[0.0, 0.0], [9.0, 9.0]])])
+
+        cell_ids, ref_coords = annulus.locate(points)
+
+        assert cell_ids.tolist() == [0, 0, -1, -1]
+        np.testing.assert_allclose(
+            ref_coords[:2], xi_true, atol=_XI_REL_ATOL * _scale_of(annulus), rtol=0.0
+        )
+        assert bool(np.all(np.isnan(ref_coords[2:])))
+
+
+class TestCandidateCells:
+    """Behaviour when several cells' physical boxes contain the query point."""
+
+    def test_stretched_patch_with_overlapping_boxes(self) -> None:
+        """A sheared patch whose cell boxes overlap still resolves every point."""
+        from pantr.bspline._bspline_locate import _locate_context  # noqa: PLC0415
+        from pantr.geometry import AABB  # noqa: PLC0415
+
+        spline = _stretched_patch()
+        xi_true = _sample_parametric(spline, 300, seed=13, margin=0.01)
+        assert np.all(_jacobian_determinants(spline, xi_true) > 0.0)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        # The premise of the test: the AABB test really is ambiguous here.
+        context = _locate_context(spline)
+        tol_phys = 1e-12 * context.scale
+        counts = np.array([context.bvh.query_aabb(AABB(x, x).pad(tol_phys)).size for x in points])
+        assert counts.mean() > 2.0, "expected genuinely ambiguous candidate boxes"
+
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_folded_patch_returns_a_valid_preimage(self) -> None:
+        """A non-injective mapping is inverted to *some* preimage, not a specified one.
+
+        This pins the documented contract: what holds is ``F(ref_coords) == points``, not
+        ``ref_coords == the coordinates evaluate was called with``.
+        """
+        spline = _folded_patch()
+        xi_true = _sample_parametric(spline, 300, seed=14, margin=0.01)
+        determinants = _jacobian_determinants(spline, xi_true)
+        assert determinants.min() < 0.0 < determinants.max(), "fixture must actually fold"
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        atol = _XI_REL_ATOL * _scale_of(spline)
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(_evaluate_at(spline, ref_coords), points, atol=atol, rtol=0.0)
+        assert np.abs(ref_coords - xi_true).max() > atol, (
+            "a folded mapping is expected to return a different preimage for some points"
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_collapsed_edge_patch(self) -> None:
+        """A patch with a collapsed edge (singular Jacobian there) still inverts."""
+        spline = _collapsed_edge_patch()
+        # F(u, v) = (u * v, v): the whole v == 0 edge collapses onto the origin, so the
+        # last query has a whole family of preimages and any of them is correct.
+        points = np.array([[0.25, 0.5], [0.5, 0.75], [0.0, 0.0]])
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        assert np.all(cell_ids == 0)
+        np.testing.assert_allclose(
+            _evaluate_at(spline, ref_coords), points, atol=_XI_REL_ATOL, rtol=0.0
+        )
+
+    def test_singular_jacobian_abandons_the_candidate(self) -> None:
+        """A query that drives the iterate onto a singular Jacobian is reported unfound.
+
+        The image of ``F(u, v) = (u * v, v)`` is the triangle ``0 <= x <= y <= 1``, so
+        ``(0.5, 0)`` lies outside it while still inside the control-point box. Newton is
+        pushed onto the collapsed ``v == 0`` edge, where the smallest singular value of
+        the Jacobian is exactly zero (measured), and the candidate is abandoned instead of
+        an arbitrary step being taken from a rank-deficient solve.
+        """
+        spline = _collapsed_edge_patch()
+
+        cell_ids, ref_coords = spline.locate(np.array([[0.5, 0.0]]))
+
+        assert cell_ids.tolist() == [-1]
+        assert bool(np.all(np.isnan(ref_coords)))
+
+    def test_off_image_query_exhausts_the_iteration_budget(self) -> None:
+        """The other way a candidate fails: a healthy Jacobian that never converges.
+
+        ``(0.75, 0.25)`` is also outside the triangle, but the iterate settles at
+        ``(1, 0.25)`` with a well-conditioned Jacobian, so it is the iteration budget that
+        ends the attempt rather than the rank guard.
+        """
+        spline = _collapsed_edge_patch()
+
+        cell_ids, ref_coords = spline.locate(np.array([[0.75, 0.25]]))
+
+        assert cell_ids.tolist() == [-1]
+        assert bool(np.all(np.isnan(ref_coords)))
+
+    def test_fully_degenerate_patch_reports_unfound_instead_of_raising(self) -> None:
+        """A patch that collapses onto a line is handled, not crashed on.
+
+        ``F(u, v) = (u + v, u + v)`` has ``J = [[1, 1], [1, 1]]`` everywhere, and
+        ``numpy.linalg.solve`` raises ``LinAlgError`` on it (verified). The rank guard is
+        what turns that into a plain "not found". A query that happens to lie on the
+        image is still answered, since the residual test runs before the Jacobian.
+        """
+        sub = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+        cp = np.array([[[0.0, 0.0], [1.0, 1.0]], [[1.0, 1.0], [2.0, 2.0]]], dtype=np.float64)
+        flat = Bspline(BsplineSpace([sub, sub]), cp)
+
+        cell_ids, ref_coords = flat.locate(np.array([[0.3, 0.9], [1.0, 1.0]]))
+
+        assert cell_ids.tolist() == [-1, 0]
+        assert bool(np.all(np.isnan(ref_coords[0])))
+        np.testing.assert_allclose(
+            _evaluate_at(flat, ref_coords[1:]), np.array([[1.0, 1.0]]), atol=1e-15, rtol=0.0
+        )
+
+
+class TestIdentityMap:
+    """The identity mapping inverts in one Newton step, to machine precision."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_machine_precision_but_not_bitwise(self, degree: int) -> None:
+        """Recovery is exact to a few ulp of the domain, which is all that is available.
+
+        The control points are the Greville abscissae, so the mapping is the identity
+        mathematically but not in floating point: ``F(xi)`` already differs from ``xi`` by
+        up to ``1.3e-15`` on a domain of length 3 (measured, degrees 1-4). A bitwise
+        round trip is therefore unattainable by any implementation, and the reachable
+        statement is a few ulp.
+        """
+        knots = np.concatenate([np.zeros(degree + 1), [1.0, 2.0], np.full(degree + 1, 3.0)])
+        spline = _identity_map(knots, degree, 2)
+        xi_true = _sample_parametric(spline, 200, seed=15)
+
+        forward_error = np.abs(_evaluate_at(spline, xi_true) - xi_true).max()
+        cell_ids, ref_coords = spline.locate(xi_true)
+
+        assert np.all(cell_ids >= 0)
+        # 8 ulp of the domain length: measured worst case is 1.8e-15, i.e. under 3 ulp.
+        atol = 8.0 * float(np.finfo(np.float64).eps) * 3.0
+        np.testing.assert_allclose(ref_coords, xi_true, atol=atol, rtol=0.0)
+        assert forward_error > 0.0, "the discrete identity is not exact in floating point"
+
+    def test_converges_in_a_single_newton_step(self) -> None:
+        """One step suffices: the mapping is affine, so the Jacobian is constant."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0])
+        spline = _identity_map(knots, 2, 2)
+        xi_true = _sample_parametric(spline, 100, seed=16)
+
+        cell_ids, _ = spline.locate(xi_true, max_iter=1)
+
+        assert np.all(cell_ids >= 0)
+
+
+class TestToleranceScaling:
+    """The default tolerance follows the geometry's own size, offset included."""
+
+    def test_scale_uses_the_coordinate_magnitude_not_only_the_diagonal(self) -> None:
+        """Translating a geometry leaves its diagonal alone but raises its scale."""
+        centered = _quarter_annulus()
+        shifted = _quarter_annulus(shift=(1.0e6, 1.0e6))
+        assert _scale_of(centered) == pytest.approx(2.8284271247461903)
+        # The diagonal is translation invariant; the scale must not be.
+        assert _scale_of(shifted) > 1.0e6
+
+    @pytest.mark.parametrize("shift", [1.0e3, 1.0e6, 1.0e9])
+    def test_offset_geometry_still_inverts(self, shift: float) -> None:
+        """A geometry far from the origin is fully recovered with the default tolerance.
+
+        A tolerance taken from the bounding-box diagonal alone would be below the
+        residual's own arithmetic floor here (measured: 113 of 200 points lost at a
+        ``1e6`` offset), because the floor scales with the coordinate magnitude and the
+        diagonal does not.
+        """
+        spline = _quarter_annulus(shift=(shift, shift))
+        xi_true = _sample_parametric(spline, 200, seed=17)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        assert np.all(cell_ids == 0)
+        np.testing.assert_allclose(
+            ref_coords, xi_true, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+
+    def test_explicit_tolerance_is_an_absolute_distance(self) -> None:
+        """A slack ``tol`` accepts a point that is merely near the geometry.
+
+        The image of a square mapping is a full-dimensional region, so "near but not on"
+        only exists outside it: the point below sits ``1e-3`` inside the annulus hole,
+        just off the ``v == 0`` boundary.
+        """
+        annulus = _quarter_annulus()
+        direction = np.array([[np.cos(0.7), np.sin(0.7)]])
+        nearby = (1.0 - 1.0e-3) * direction
+
+        assert annulus.locate(nearby)[0].tolist() == [-1]
+        assert annulus.locate(nearby, tol=1.0e-2)[0].tolist() == [0]
+
+    def test_max_iter_is_honoured(self) -> None:
+        """Too small an iteration budget reports "not found" instead of a wrong answer.
+
+        The annulus needs 5 Newton steps from a cell midpoint (measured); with a budget
+        of 1 the residual test simply never passes.
+        """
+        annulus = _quarter_annulus()
+        points = _evaluate_at(annulus, np.array([[0.05, 0.95], [0.95, 0.05]]))
+
+        assert annulus.locate(points, max_iter=1)[0].tolist() == [-1, -1]
+        assert annulus.locate(points, max_iter=30)[0].tolist() == [0, 0]
+
+
+class TestCellPhysicalBounds:
+    """The per-cell physical boxes match an independent brute-force oracle."""
+
+    @pytest.mark.parametrize(
+        "spline_factory",
+        [
+            lambda: _quarter_annulus(),
+            lambda: _quarter_annulus().subdivide(3),
+            lambda: _perturbed_patch(3, 4, 2, seed=18),
+            lambda: _identity_map(
+                np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0, 3.0]), 3, 2
+            ),
+            lambda: _perturbed_patch(2, 2, 3, seed=19),
+        ],
+    )
+    def test_matches_cell_supports_oracle(self, spline_factory: Callable[[], Bspline]) -> None:
+        """A running min/max per axis equals a gather over the full per-cell support.
+
+        Bitwise equality is the right assertion here: both routes take the minimum and
+        maximum of the same finite set of floats, with no arithmetic in between.
+        """
+        spline = spline_factory()
+        space = spline.space
+        lo, hi = _cell_physical_bounds(spline)
+
+        supports = space.cell_supports(np.arange(space.num_total_intervals))
+        cp = np.asarray(spline.control_points, dtype=np.float64).reshape(space.num_total_basis, -1)
+        physical = cp[:, :-1] / cp[:, -1:] if spline.is_rational else cp
+        boxes = physical[supports]
+
+        assert np.array_equal(lo, boxes.min(axis=1))
+        assert np.array_equal(hi, boxes.max(axis=1))
+
+
+class TestCaching:
+    """The inversion state is cached, and the in-place mutators invalidate it."""
+
+    def test_second_call_reuses_the_context(self) -> None:
+        """The hierarchy is built once per B-spline."""
+        spline = _quarter_annulus()
+        assert _cache_of(spline) is None
+        spline.locate(np.array([[1.2, 0.3]]))
+        first = _cache_of(spline)
+        assert first is not None
+        spline.locate(np.array([[0.3, 1.2]]))
+        second = _cache_of(spline)
+        assert second is first
+        assert second is not None
+        assert second.bvh is first.bvh
+
+    @pytest.mark.parametrize("mutate", ["reverse", "permute_directions", "transform"])
+    def test_in_place_mutation_invalidates_the_context(self, mutate: str) -> None:
+        """Every in-place mutator drops the cache, as it does the Bézier cache.
+
+        Without this a stale hierarchy would survive a mutation that moves the geometry,
+        and the next call would silently report points as not found.
+        """
+        spline = _perturbed_patch(2, 2, 2, seed=20)
+        xi_true = _sample_parametric(spline, 20, seed=21)
+        spline.locate(_evaluate_at(spline, xi_true))
+        assert _cache_of(spline) is not None
+
+        if mutate == "reverse":
+            spline.reverse(0, in_place=True)
+        elif mutate == "permute_directions":
+            spline.permute_directions([1, 0], in_place=True)
+        else:
+            spline.transform(AffineTransform.translation([100.0, 100.0]), in_place=True)
+
+        assert _cache_of(spline) is None
+        # And the mutated geometry inverts correctly, which a stale cache would break.
+        moved = _sample_parametric(spline, 20, seed=22)
+        cell_ids, ref_coords = spline.locate(_evaluate_at(spline, moved))
+        assert np.all(cell_ids >= 0)
+        np.testing.assert_allclose(
+            ref_coords, moved, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+
+
+class TestValidation:
+    """Rejected inputs, each with the exception the contract promises."""
+
+    def test_embedded_geometry_is_not_implemented(self) -> None:
+        """A curve in the plane (``rank > dim``) needs a closest-point solve."""
+        sub = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2)
+        curve = Bspline(BsplineSpace([sub]), np.array([[0.0, 0.0], [1.0, 2.0], [2.0, 0.0]]))
+        with pytest.raises(NotImplementedError, match="rank 2 > dim 1"):
+            curve.locate(np.array([[1.0, 1.0]]))
+
+    def test_rank_below_dim_is_rejected(self) -> None:
+        """A scalar field over a surface cannot be inverted at all."""
+        sub = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+        space = BsplineSpace([sub, sub])
+        field = Bspline(space, np.arange(4.0).reshape(2, 2, 1))
+        with pytest.raises(ValueError, match="rank 1 < dim 2"):
+            field.locate(np.array([[1.0]]))
+
+    def test_periodic_space_is_rejected(self) -> None:
+        """Periodic directions have no bounded knot-span grid to report cells from."""
+        knots = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        periodic = BsplineSpace1D(knots, 2, periodic=True)
+        space = BsplineSpace([periodic, periodic])
+        n_0, n_1 = space.num_basis
+        rng = np.random.default_rng(23)
+        spline = Bspline(space, rng.uniform(size=(n_0, n_1, 2)))
+        with pytest.raises(ValueError, match="periodic"):
+            spline.locate(np.array([[0.5, 0.5]]))
+
+    def test_non_positive_weight_is_rejected(self) -> None:
+        """The convex-hull property behind the candidate search needs positive weights."""
+        annulus = _quarter_annulus()
+        cp = np.array(annulus.control_points, dtype=np.float64)
+        cp[1, 0, 2] = -cp[1, 0, 2]
+        broken = Bspline(annulus.space, cp, is_rational=True)
+        with pytest.raises(ValueError, match="weight must be strictly positive"):
+            broken.locate(np.array([[1.2, 0.3]]))
+
+    @pytest.mark.parametrize(
+        "bad_points",
+        [
+            np.zeros((3, 3)),
+            np.zeros((3, 1)),
+            np.zeros((2, 2, 2)),
+            np.array([np.nan, 0.5]),
+            np.array([[0.5, np.inf]]),
+        ],
+    )
+    def test_bad_points_are_rejected(self, bad_points: npt.NDArray[np.float64]) -> None:
+        """Wrong trailing dimension, wrong rank, or a non-finite coordinate."""
+        annulus = _quarter_annulus()
+        with pytest.raises(ValueError):
+            annulus.locate(bad_points)
+
+    @pytest.mark.parametrize("max_iter", [0, -1])
+    def test_max_iter_must_be_positive(self, max_iter: int) -> None:
+        """A budget of zero steps is a caller mistake, not a silent empty result."""
+        annulus = _quarter_annulus()
+        with pytest.raises(ValueError, match="max_iter"):
+            annulus.locate(np.array([[1.2, 0.3]]), max_iter=max_iter)
+
+    @pytest.mark.parametrize("tol", [0.0, -1e-6, np.nan, np.inf])
+    def test_tol_must_be_positive_and_finite(self, tol: float) -> None:
+        """An explicit tolerance is an absolute distance, so it must be usable as one."""
+        annulus = _quarter_annulus()
+        with pytest.raises(ValueError, match="tol"):
+            annulus.locate(np.array([[1.2, 0.3]]), tol=tol)


### PR DESCRIPTION
Closes #273.

## What this adds

`Bspline.locate(points, *, tol=None, max_iter=30) -> (cell_ids, ref_coords)`: the inverse of
`Bspline.evaluate`. Layer 1 method delegating to a new Layer 2 module
`src/pantr/bspline/_bspline_locate.py`.

1. **Candidate cells** — a cached BVH over the per-cell *physical* control-point boxes. The
   convex-hull property puts a cell's image inside the box of its supporting control points
   (for a NURBS, the projected points, provided every weight is positive). Query per point
   with a degenerate `AABB` padded by the tolerance.
2. **Newton** — from each candidate cell's parametric midpoint, iterating
   `xi <- xi - J(xi)^-1 (F(xi) - x)` with the Jacobian assembled from
   `evaluate_derivatives` (already rational-aware). Iterates are clamped to the parametric
   domain box, so a solution in a different cell is still found; the candidate box is a
   superset test, not a constraint. The cell id is resolved from the converged `xi`.
3. Points not on the image get `cell_ids = -1` and `ref_coords = nan`.

Newton runs **over the whole batch at once** — one candidate slot per round, one evaluator
call per Jacobian column per round — so the number of Python-level calls into the
evaluators is `O(rounds * max_iter * dim)`, independent of the point count. 1e4 points on a
64-cell NURBS annulus: **0.25 s** (0.14 s of it in the per-point BVH queries), against the
issue's "seconds" target.

Square maps only (`rank == dim`). `rank > dim` raises `NotImplementedError`, `rank < dim`
`ValueError`.

## What the issue got wrong

As with the previous eight tickets in this sweep, the numbers needed measuring.

**1. The default tolerance cannot come from the bounding-box diagonal alone.** The issue
specifies `get_default(dtype)` "scaled by the control-point bounding-box diagonal". The
diagonal is translation invariant, but the *residual's own arithmetic floor* is not: the de
Boor sum and the subtraction `F(xi) - x` cannot resolve below `~C * eps * max|coordinate|`.
Translating the test annulus (diagonal 2.83) away from the origin and keeping the
diagonal-only tolerance:

| offset | found, tol from the diagonal | found, tol from `max(diagonal, magnitude)` |
|---|---|---|
| 0 | 200/200 | 200/200 |
| 1e3 | 200/200 | 200/200 |
| **1e6** | **87/200** | 200/200 |
| **1e9** | **183/200** | 200/200 |

The failure is silent: the lost points come back as "not found", not as an error. The scale
is therefore `max(bbox diagonal, largest coordinate magnitude, 1.0)`, which is identical to
the issue's rule for a geometry near the origin and floor-safe otherwise. With
`get_default(float64) = 1e-12 = 4.5e3 * eps` the threshold then sits ~2 decades above the
floor. Recovered-coordinate accuracy degrades in proportion to the magnitude
(`7.8e-7` at a 1e6 offset), which is inherent and now documented rather than hidden.

**2. "computation in float64" is not reachable through the public evaluators**, since
`evaluate` requires `pts.dtype == spline.dtype`. Resolved by promoting a float32 spline to
an exact float64 copy (the cast is exact) and inverting that. Note the *stated* reason for
promotion in an early draft of this PR was wrong and measurement refuted it: a
float32-arithmetic Newton would in fact converge. The measured float32 evaluation floor is
only `1-3 * eps32 * scale` across supports from 6 to 125 control points, against a
`8.4 * eps32` threshold. The honest justification is **margin** — under one decade, against
~2e3 for float64 — plus not having to quantize the parametric iterate at `eps32`.

**3. `xi == pts exactly` for the identity map is unattainable.** The identity built from
Greville abscissae is not the identity in floating point: `|F(xi) - xi|` is already up to
`1.3e-15` on a domain of length 3 (degrees 1-4). No implementation can return `pts`
bitwise. The reachable statement, which the test asserts, is a few ulp of the domain
(measured worst case 1.8e-15, under 3 ulp). One Newton step does suffice, as the issue says.

**4. The issue's cell-agreement check is vacuous as written.** "cell agreement with
`locate_many(xi)`" compares the result against the very call that produced it. Replaced by a
property check that reads the per-axis breakpoints off the knot vectors: the reported
cell's parametric box must contain the reported coordinates.

**5. A contract the issue does not state: `locate` returns *a* preimage, not *the*
preimage.** A mapping whose Jacobian determinant changes sign folds, and a folded mapping
sends several parametric points to one physical point. Measured on a folded patch: all 500
points invert with residual `<= 2.4e-12`, but 143 of them come back at a different `xi`
than the one they were generated from. Documented on both the module and the method, and
pinned by a test — otherwise the natural round-trip assertion looks like a bug.

**6. `cached_property` on the BVH is not safe for the reason given.** The issue says
"safe: control points are immutable on `Bspline`". They are not: `reverse`,
`permute_directions` and `transform` all have an `in_place=True` path that replaces
`_control_points` or `_space`, which is exactly why `_beziers_cache` is invalidated in all
three. The inversion state follows the same pattern (`_locate_cache`, reset in the same
three places), with a test per mutator that a stale hierarchy would fail.

## Also worth noting

- **The rank guard earns its place.** `numpy.linalg.solve` raises `LinAlgError` on a patch
  that collapses onto a line (verified), which would crash `locate` on degenerate CAD
  input. The guard turns it into a plain "not found". Threshold
  `sigma_min <= dim * eps * sigma_max`, the same rule and magnitude as
  `numpy.linalg.matrix_rank`'s default, so it is scale-free and rejects only a Jacobian
  whose condition number reaches `1 / (dim * eps)`.
- **Per-cell boxes without the support table.** The support is a contiguous window per
  axis, so a running min/max over `degree + 1` shifted takes gives the boxes in
  `O(num_cells * sum(degree + 1))` and allocates `O(num_cells)` instead of gathering the
  full `prod(degree + 1)` table. It matches a `cell_supports`-based oracle **bitwise** in
  all five test geometries (min/max of the same floats, no arithmetic), and that oracle is
  the test.
- Iteration counts, measured: 1 step for the identity map, 5 for the annulus (offset or
  not). The issue's `max_iter=30` default is kept and is generous.
- No changelog entry, matching the other PRs in this sweep.

## Tests

New `tests/test_bspline_locate.py`, 62 tests: round trips in 1-D/2-D/3-D over degrees 1-4
with non-uniform and repeated interior knots, the exact NURBS quarter annulus (interior,
boundary and corner points, plus a float32 variant), off-image points including the annulus
hole, overlapping candidate boxes, the folded and collapsed-edge patches, the fully
degenerate patch, the identity map, tolerance scaling under translation, `max_iter`
honouring, the per-cell box oracle, caching and its invalidation, and the validation
matrix. 100% line coverage of the new module.

## Checks

`ruff check` · `ruff format --check` · `mypy` · `import-lint` · full suite (4413 passed, 19
skipped) · coverage 96% total · clean docs build with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
