### PR TITLE
refactor(bspline): exact integer _bincoeff and binary span search in the blossom kernel

### DIFF
--- a/src/pantr/bspline/_bspline_blossom_core.py
+++ b/src/pantr/bspline/_bspline_blossom_core.py
@@ -21,6 +21,41 @@ from .._numba_compat import nb_jit
 
 
 @nb_jit(nopython=True, cache=True)
+def _blossom_span(knots: npt.NDArray[Any], u_last: float, n: int) -> int:
+    """Return the knot span the blossom's de Boor recurrence starts from.
+
+    The span index is the position of the last knot not exceeding ``u_last``, found by
+    binary search. For a value inside a non-empty span this is exactly what a scan for
+    the first ``idx`` with ``knots[idx] <= u_last < knots[idx + 1]`` returns, repeated
+    knots included, because that first match is the last occurrence of the span's left
+    knot.
+
+    Args:
+        knots (npt.NDArray[Any]): Non-decreasing knot vector.
+        u_last (float): Largest of the blossom's parameter values.
+        n (int): Index of the last control point (``control_points.shape[0] - 1``).
+
+    Returns:
+        int: Span index in ``[0, n]``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+
+        Both out-of-span cases return the rightmost span ``n``, which is what the linear
+        scan this replaced also returned for ``u_last`` at or beyond the last knot and
+        for ``u_last`` below the first knot. Layer 2 (``_evaluate_blossom_1d``) accepts
+        parameters up to its tolerance outside the domain, so the second case is
+        reachable and its behaviour is preserved deliberately. The clamp additionally
+        keeps the index in range for a parameter past the domain of a non-clamped knot
+        vector, where the scan could return an index that reads past the control points.
+    """
+    span = int(np.searchsorted(knots, u_last, side="right")) - 1
+    if span < 0 or span > n:
+        return n
+    return span
+
+
+@nb_jit(nopython=True, cache=True)
 def _evaluate_blossom_1d_core(
     knots: npt.NDArray[Any],
     degree: int,
@@ -66,11 +101,7 @@ def _evaluate_blossom_1d_core(
     # Find knot span for the largest u value (u_values[-1]).
     u_last = u_values[degree - 1]
     n = control_points.shape[0] - 1
-    k = n  # default: rightmost span
-    for idx in range(n + degree):
-        if knots[idx] <= u_last < knots[idx + 1]:
-            k = idx
-            break
+    k = _blossom_span(knots, u_last, n)
 
     # Local copy of control points d[j] = P[k-p+j] for j in 0..p.
     d = np.empty((degree + 1, rank), dtype=control_points.dtype)
@@ -108,4 +139,4 @@ def _warmup_numba_functions() -> None:
     _evaluate_blossom_1d_core(knots, 2, ctrl, u_vals)
 
 
-__all__ = ["_evaluate_blossom_1d_core"]
+__all__ = ["_blossom_span", "_evaluate_blossom_1d_core"]

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -11,7 +11,6 @@ Note:
     ``_degree_reduce_bspline`` instead.
 """
 
-import math
 from typing import Any
 
 import numpy as np
@@ -22,14 +21,50 @@ from .._numba_compat import nb_jit
 
 @nb_jit(nopython=True, cache=True)
 def _bincoeff(n: int, k: int) -> float:
-    """Compute binomial coefficient (n choose k)."""
+    """Compute the binomial coefficient ``C(n, k)`` in exact integer arithmetic.
+
+    Runs the multiplicative recurrence ``C(m, i) = C(m - 1, i - 1) * m // i`` over the
+    smaller of ``k`` and ``n - k``. The running product after step ``i`` is exactly
+    ``C(n - kk + i, i)``, an integer, so every division is exact and the result carries
+    no rounding at all.
+
+    Args:
+        n (int): Upper index.
+        k (int): Lower index.
+
+    Returns:
+        float: ``C(n, k)``, or ``0.0`` when ``k`` lies outside ``[0, n]``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+
+        Exactness envelope, measured against :func:`math.comb`. The largest intermediate
+        is ``C(n, k) * min(k, n - k)``, so the integer arithmetic is exact while that
+        fits in ``int64``: every ``k`` up to ``n = 61``. From ``n = 62`` an intermediate
+        wraps silently (Numba does not trap integer overflow) and the result is outside
+        the contract. Independently, the ``float`` return is lossless only while
+        ``C(n, k) <= 2**53``, i.e. every ``k`` up to ``n = 56`` (``C(57, 28)`` is the
+        first coefficient past it); between 57 and 61 the exact integer is computed and
+        then correctly rounded, which is the most a float return can carry. Call sites
+        pass ``p + t`` (degree elevation) and ``p + q`` (Bernstein product), so the
+        envelope covers every numerically meaningful degree.
+
+        The previous route, ``floor(0.5 + exp(lgamma(n + 1) - lgamma(k + 1) -
+        lgamma(n - k + 1)))``, was silently wrong well inside both limits: it is off by
+        380 at ``(57, 28)`` and by 5600 at ``(60, 30)``, since a value above ``2**53``
+        cannot be recovered from logarithms. Where exactly it starts failing depends on
+        the ``libm`` in use -- compiled here it already differed from ``(48, 25)`` on,
+        while CPython's own ``lgamma`` still agreed there -- which is the other reason to
+        prefer integer arithmetic: the envelope becomes a property of the algorithm
+        rather than of the platform.
+    """
     if k < 0 or k > n:
         return 0.0
-    if k in (0, n):
-        return 1.0
-    return math.floor(
-        0.5 + math.exp(math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1))
-    )
+    kk = min(k, n - k)
+    result = np.int64(1)
+    for i in range(1, kk + 1):
+        result = result * np.int64(n - kk + i) // np.int64(i)
+    return float(result)
 
 
 @nb_jit(nopython=True, cache=True)

--- a/tests/test_bspline_bincoeff.py
+++ b/tests/test_bspline_bincoeff.py
@@ -1,0 +1,99 @@
+"""Tests for the exact binomial-coefficient kernel (``_bincoeff``)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pantr.bspline._bspline_degree_core import _bincoeff
+
+_EXACT_UP_TO: int = 61
+"""
+Largest ``n`` for which ``_bincoeff(n, k)`` is exact for every ``k``.
+
+The multiplicative recurrence's largest intermediate is ``C(n, k) * min(k, n - k)``, and
+``max_k C(61, k) * min(k, 61 - k) = 6.98e18`` still fits in ``int64`` while the ``n = 62``
+value ``1.44e19`` does not. :func:`test_the_envelope_boundary_is_where_int64_ends` pins
+both halves of that statement, so this constant cannot drift away from its derivation.
+"""
+
+_FLOAT_EXACT_UP_TO: int = 56
+"""
+Largest ``n`` for which every ``C(n, k)`` is representable in ``float64``.
+
+``C(56, 28) = 7.65e15`` is below ``2**53 = 9.01e15`` and ``C(57, 28) = 1.50e16`` is above
+it. Past this point the kernel still computes the exact integer, but the ``float`` return
+carries only its correctly-rounded value.
+"""
+
+
+class TestBincoeffExactness:
+    """The kernel agrees with :func:`math.comb` everywhere inside its envelope."""
+
+    def test_exhaustive_up_to_the_envelope(self) -> None:
+        """Every ``(n, k)`` with ``n <= 61`` matches ``math.comb`` exactly."""
+        mismatches = [
+            (n, k)
+            for n in range(_EXACT_UP_TO + 1)
+            for k in range(n + 1)
+            if _bincoeff(n, k) != float(math.comb(n, k))
+        ]
+        assert mismatches == []
+
+    @pytest.mark.parametrize(
+        ("n", "k", "expected"),
+        [
+            (48, 25, 30957699535776),
+            (57, 28, 15033633249770520),
+            (60, 30, 118264581564861424),
+            (61, 30, 232714176627630544),
+        ],
+    )
+    def test_values_the_lgamma_route_got_wrong(self, n: int, k: int, expected: int) -> None:
+        """Hardcoded witnesses of the bug this kernel replaced.
+
+        The previous ``floor(0.5 + exp(lgamma ...))`` formula returned values too large by
+        380 at ``(57, 28)``, 5600 at ``(60, 30)`` and 1136 at ``(61, 30)``; compiled on
+        this platform it already differed at ``(48, 25)``, where CPython's own ``lgamma``
+        still agreed. Reverting to any logarithm-based route fails this test.
+        """
+        assert _bincoeff(n, k) == float(expected)
+
+    def test_the_envelope_boundary_is_where_int64_ends(self) -> None:
+        """``_EXACT_UP_TO`` is exactly where the recurrence's intermediates stop fitting."""
+        int64_max = 2**63 - 1
+
+        def worst_intermediate(n: int) -> int:
+            return max(math.comb(n, k) * min(k, n - k) for k in range(n + 1))
+
+        assert worst_intermediate(_EXACT_UP_TO) <= int64_max
+        assert worst_intermediate(_EXACT_UP_TO + 1) > int64_max
+
+    def test_the_float_return_boundary(self) -> None:
+        """``_FLOAT_EXACT_UP_TO`` is exactly where ``float64`` stops holding the integer."""
+        assert max(math.comb(_FLOAT_EXACT_UP_TO, k) for k in range(_FLOAT_EXACT_UP_TO + 1)) <= 2**53
+        assert math.comb(_FLOAT_EXACT_UP_TO + 1, 28) > 2**53
+
+    @pytest.mark.parametrize("n", [0, 1, 5, 12, 30, 61])
+    def test_symmetry(self, n: int) -> None:
+        """``C(n, k) == C(n, n - k)``, which is also the branch the recurrence picks."""
+        for k in range(n + 1):
+            assert _bincoeff(n, k) == _bincoeff(n, n - k)
+
+    @pytest.mark.parametrize(("n", "k"), [(5, -1), (5, 6), (0, 1), (10, 11), (3, -7)])
+    def test_out_of_range_k_is_zero(self, n: int, k: int) -> None:
+        """``k`` outside ``[0, n]`` gives ``0.0``, as the elevation tables rely on."""
+        assert _bincoeff(n, k) == 0.0
+
+    @pytest.mark.parametrize("n", [0, 1, 7, 40])
+    def test_edges_are_one(self, n: int) -> None:
+        """``C(n, 0) == C(n, n) == 1``."""
+        assert _bincoeff(n, 0) == 1.0
+        assert _bincoeff(n, n) == 1.0
+
+    def test_returns_a_float(self) -> None:
+        """The return type stays ``float`` so the call sites are untouched."""
+        value = _bincoeff(10, 4)
+        assert isinstance(value, float)
+        assert value == 210.0

--- a/tests/test_bspline_blossom.py
+++ b/tests/test_bspline_blossom.py
@@ -10,6 +10,7 @@ import pytest
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_blossom import _evaluate_blossom_1d
+from pantr.bspline._bspline_blossom_core import _blossom_span
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -202,4 +203,123 @@ class TestBlossomValidation:
                 ctrl,
                 u,
                 1e-12,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Knot-span search: the binary search must reproduce the linear scan
+# ---------------------------------------------------------------------------
+
+
+def _linear_scan_span(knots: npt.NDArray[Any], u_last: float, n: int, degree: int) -> int:
+    """The ``O(n)`` scan ``_blossom_span`` replaced, kept here as the reference oracle.
+
+    Verbatim from the kernel before the change, including its ``k = n`` fall-through when
+    no half-open span contains ``u_last``.
+    """
+    k = n
+    for idx in range(n + degree):
+        if knots[idx] <= u_last < knots[idx + 1]:
+            k = idx
+            break
+    return k
+
+
+def _random_open_knots(
+    degree: int, n_interior: int, seed: int, *, repeat_first: bool = False
+) -> npt.NDArray[np.float64]:
+    """Return a clamped knot vector on ``[0, 1]`` with random interior knots."""
+    rng = np.random.default_rng(seed)
+    interior = np.sort(rng.uniform(0.0, 1.0, size=n_interior))
+    if repeat_first and n_interior > 1:
+        interior[1] = interior[0]
+    return np.concatenate([np.zeros(degree + 1), interior, np.ones(degree + 1)]).astype(np.float64)
+
+
+class TestBlossomSpan:
+    """The binary span search agrees with the linear scan on every valid input."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize("n_interior", [0, 1, 2, 5])
+    @pytest.mark.parametrize("repeat_first", [False, True])
+    def test_matches_the_linear_scan(
+        self, degree: int, n_interior: int, repeat_first: bool
+    ) -> None:
+        """Identical span indices, interior multiplicities and endpoints included.
+
+        The probe set covers the interior, both domain endpoints, every interior knot
+        exactly, and the band just outside the domain that Layer 2 still accepts within
+        its tolerance.
+        """
+        knots = _random_open_knots(
+            degree, n_interior, seed=100 * degree + n_interior, repeat_first=repeat_first
+        )
+        n = knots.shape[0] - degree - 2
+        interior = knots[degree + 1 : knots.shape[0] - degree - 1]
+        rng = np.random.default_rng(7)
+        probes = [
+            *rng.uniform(0.0, 1.0, size=30).tolist(),
+            0.0,
+            1.0,
+            *interior.tolist(),
+            -1e-12,
+            1.0 + 1e-12,
+        ]
+        for u in probes:
+            assert int(_blossom_span(knots, float(u), n)) == _linear_scan_span(
+                knots, float(u), n, degree
+            ), f"degree={degree} u={u!r} knots={knots.tolist()}"
+
+    def test_below_the_first_knot_gives_the_rightmost_span(self) -> None:
+        """Preserved behaviour: an under-range parameter falls through to span ``n``.
+
+        Reachable through Layer 2, which accepts parameters up to its tolerance below the
+        domain start. The scan returned ``n`` here because no span matched; the binary
+        search would give ``-1`` without the guard.
+        """
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        n = knots.shape[0] - 4
+        assert int(_blossom_span(knots, -1e-9, n)) == n
+        assert _linear_scan_span(knots, -1e-9, n, 2) == n
+
+    def test_at_and_beyond_the_last_knot_clamps(self) -> None:
+        """The right domain endpoint and anything past it both give span ``n``."""
+        knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        n = knots.shape[0] - 4
+        assert int(_blossom_span(knots, 1.0, n)) == n
+        assert int(_blossom_span(knots, 2.0, n)) == n
+
+    def test_non_clamped_knots_stay_in_range(self) -> None:
+        """On a non-clamped vector a parameter past the domain still yields a valid index.
+
+        Here the linear scan matched a span above ``n`` and the caller then read past the
+        control points; the clamp removes that. Inputs like this are outside the Layer 2
+        contract either way.
+        """
+        knots = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        n = knots.shape[0] - 4  # degree 2 => 3 control points
+        assert int(_blossom_span(knots, 4.5, n)) == n
+        assert _linear_scan_span(knots, 4.5, n, 2) > n
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5])
+    def test_diagonal_property_with_interior_multiplicities(self, degree: int) -> None:
+        """``f[t, ..., t] == f(t)`` on knots with a repeated interior knot.
+
+        The end-to-end guard on the span change: degrees 1 to 5, a non-uniform knot vector
+        carrying an interior multiplicity, and ``t`` at both endpoints, exactly on every
+        interior knot, and in between.
+        """
+        knots = _random_open_knots(degree, 4, seed=degree, repeat_first=True)
+        space = BsplineSpace1D(knots, degree)
+        rng = np.random.default_rng(degree + 50)
+        ctrl = rng.uniform(-1.0, 1.0, size=(space.num_basis, 2))
+        curve = Bspline(BsplineSpace([space]), np.ascontiguousarray(ctrl))
+        interior = knots[degree + 1 : knots.shape[0] - degree - 1]
+        tol = 64.0 * float(np.finfo(np.float64).eps)
+
+        for t in [0.0, 1.0, *interior.tolist(), *rng.uniform(0.0, 1.0, size=10).tolist()]:
+            blossom = _evaluate_blossom_1d(knots, degree, ctrl, np.full(degree, float(t)), tol)
+            direct = np.asarray(curve.evaluate(np.array([float(t)]))).reshape(2)
+            np.testing.assert_allclose(
+                np.asarray(blossom).reshape(2), direct, atol=tol, rtol=0.0, err_msg=f"t={t}"
             )


### PR DESCRIPTION
Closes #259.

Two independent Layer 3 fixes, one commit each.

## 1. `_bincoeff` by exact integer recurrence

`floor(0.5 + exp(lgamma(n+1) - lgamma(k+1) - lgamma(n-k+1)))` replaced by the
multiplicative recurrence `C(m, i) = C(m-1, i-1) * m // i` over `min(k, n-k)`. The running
product after step `i` is exactly `C(n-kk+i, i)`, an integer, so every division is exact.

**What the old route actually got wrong** (measured against `math.comb`):

| `(n, k)` | exact | `lgamma` route | error |
|---|---|---|---|
| (57, 28) | 15033633249770520 | 15033633249770900 | +380 |
| (60, 30) | 118264581564861424 | 118264581564867024 | +5600 |
| (61, 30) | 232714176627630544 | 232714176627631680 | +1136 |

**Two corrections to the issue's numbers.**

*The envelope of the proposed recurrence is `n <= 61`, not `n <= 62`.* The issue's criterion
was "exact while the *result* fits int64". The binding constraint is the *intermediate*:
before the division at step `i` the value is `C(n-kk+i, i) * i`, so the largest is
`C(n, k) * min(k, n-k)`. At `n = 62` that is `1.44e19 > 9.22e18` and the int64 arithmetic
wraps — silently, since Numba does not trap integer overflow. Measured first mismatch:
`(62, 28)`. A test pins both sides of the boundary so the constant cannot drift from its
derivation.

*The `lgamma` route fails earlier than stated, and where it fails is platform-dependent.*
The issue put it at "roughly n ≈ 50–56". Compiled here it already differs from
`math.comb` at **(48, 25)** — a value of `3.1e13`, far below `2^53` — while CPython's own
`lgamma` still agreed at that pair. The failure point is a property of the `libm`, which is
the second reason to use integer arithmetic: the envelope becomes a property of the
algorithm instead.

A third boundary the issue does not mention: the `float` return type is itself lossless only
while `C(n, k) <= 2**53`, i.e. up to `n = 56` (`C(57, 28)` is the first past it). Between 57
and 61 the exact integer is computed and then correctly rounded, which is the most a float
return can carry. All three limits are in the docstring, all three are tested.

Call sites pass `p + t` (elevation) and `p + q` (Bernstein product), so the envelope covers
any degree that is numerically meaningful — but note that nothing *enforces* it: above
`n = 61` the kernel returns a wrapped value and Layer 2 does not check. A degree guard where
those sums are formed would close that, and is worth its own issue rather than being
smuggled into a refactor.

**Timing, as the issue's DoD asks:** per elevation 0.090 / 0.091 / 0.062 ms (degree 3, 6,
10) against 0.087 / 0.090 / 0.062 ms before — run-to-run noise. Per call the recurrence is
comparable up to `n = 30` (0.13-0.17 µs) and 2x slower at `n = 60` (0.34 vs 0.16 µs), which
never shows up at real degrees.

## 2. Binary knot-span search in the blossom kernel

The linear scan is replaced by `searchsorted(..., side="right") - 1`, extracted as
`_blossom_span` so the equivalence can be tested directly rather than only through
evaluation.

**Why they agree.** For a parameter inside a non-empty span, the first index satisfying
`knots[i] <= u < knots[i+1]` *is* the last occurrence of that span's left knot, which is
what "position of the last knot not exceeding `u`" returns. Repeated knots included.

**The fall-through is preserved, and it is reachable.** The issue asks to keep the scan's
`k = n` default for `u < knots[0]`, treating it as an out-of-contract case. It is not quite
that: Layer 2 (`_evaluate_blossom_1d`) accepts parameters up to `tol` *below* the domain
start, so a parameter in that band reaches the kernel and gets the rightmost span. Preserved
deliberately, tested, and documented. (Evaluating the rightmost span for a parameter at the
left edge is a latent sharp edge in that tolerance band, but it predates this change and
altering it is not this PR's business.)

The clamp to `n` additionally keeps the index in range for a parameter past the domain of a
**non-clamped** knot vector, where the scan could return an index above `n` and the caller
then read past the control points. Also tested.

## Tests

- New `tests/test_bspline_bincoeff.py` (23 tests): exhaustive agreement with `math.comb` for
  every `0 <= k <= n <= 61`; the two envelope boundaries derived and asserted; hardcoded
  witnesses at the four `(n, k)` pairs the old route got wrong, so a revert fails; symmetry,
  out-of-range `k`, edges, return type.
- `tests/test_bspline_blossom.py` (+35 tests): `_blossom_span` against the old scan, kept in
  the test file as the reference oracle, over degrees 1-5 x interior-knot counts 0/1/2/5 x
  with and without an interior multiplicity, probing the interior, both endpoints, every
  interior knot exactly, and the tolerance band; the clamping cases; and the diagonal
  property `f[t,...,t] == f(t)` end to end for degrees 1-5 on knots with a repeated interior
  knot (worst error 2.2e-16).
- `_blossom_span` is fully covered; the file's only remaining gap is the pre-existing
  `degree == 0` branch.

## Checks

`ruff check` · `ruff format --check` · `mypy` · `import-lint` · full suite (4489 passed, 19
skipped) · coverage 96% total · clean docs build with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
