### PR TITLE
feat(bspline): Mørken-Reimers spline root finder by knot insertion

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -177,6 +177,18 @@
   doi     = {10.1145/3543865}
 }
 
+@article{morken2007zeros,
+  author  = {M{\o}rken, Knut and Reimers, Martin},
+  title   = {An unconditionally convergent method for computing zeros of
+             splines and polynomials},
+  journal = {Mathematics of Computation},
+  volume  = {76},
+  number  = {258},
+  pages   = {845--865},
+  year    = {2007},
+  doi     = {10.1090/S0025-5718-07-01923-0}
+}
+
 % --- Gauss quadrature -------------------------------------------------------
 
 @article{golub1969gauss,

--- a/src/pantr/__init__.py
+++ b/src/pantr/__init__.py
@@ -96,9 +96,10 @@ if not TYPE_CHECKING:
             _bspline_knot_insertion_core._warmup_numba_functions()
             _bspline_knot_removal_core._warmup_numba_functions()
             _bspline_knots._warmup_numba_functions()
-            from .bspline import _bspline_blossom_core  # noqa: PLC0415
+            from .bspline import _bspline_blossom_core, _bspline_roots_core  # noqa: PLC0415
 
             _bspline_blossom_core._warmup_numba_functions()
+            _bspline_roots_core._warmup_numba_functions()
             from .bezier import _bezier_core  # noqa: PLC0415
 
             _bezier_core._warmup_numba_functions()

--- a/src/pantr/bspline/__init__.py
+++ b/src/pantr/bspline/__init__.py
@@ -14,6 +14,8 @@ This package consolidates the B-spline API:
   utilities.
 - :func:`interpolate_bspline`, :func:`fit_bspline`,
   :func:`l2_project_bspline`: approximation functions.
+- :func:`find_roots`: zeros of a scalar univariate B-spline, by repeated knot
+  insertion at the zeros of the control polygon (Mørken-Reimers).
 - :func:`quasi_interpolate_bspline`: Lee-Lyche-Mørken local quasi-interpolation
   onto a tensor-product space.
 - :func:`create_from_bezier`: create a B-spline from a Bézier.
@@ -50,6 +52,7 @@ This package consolidates the B-spline API:
 from ._bspline import Bspline, create_from_bezier
 from ._bspline_interpolate import fit_bspline, interpolate_bspline, l2_project_bspline
 from ._bspline_quasi_interpolation import quasi_interpolate_bspline
+from ._bspline_roots import find_roots
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_factory import (
     create_cardinal_knots,
@@ -104,6 +107,7 @@ __all__ = [
     "create_uniform_space",
     "dof_owner",
     "dof_owner_windowed",
+    "find_roots",
     "fit_bspline",
     "get_greville_abscissae",
     "interpolate_bspline",

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -1,0 +1,401 @@
+"""Root finding for scalar B-splines by the Mørken-Reimers method.
+
+Holds the public :func:`find_roots` (Layer 1) and its validation and tolerance
+layer (Layer 2). All computation is delegated to the Numba kernels in
+:mod:`_bspline_roots_core`.
+
+The method computes the zeros of a scalar spline on the spline's own knot vector
+by repeatedly inserting the zero of the control polygon as a new knot
+:cite:p:`morken2007zeros`. Compared with extracting the Bézier segments and
+solving each of them (:func:`pantr.bezier.find_roots`), it needs no extraction
+and no stitching of roots at segment boundaries, zeros sitting exactly on a knot
+need no special case, and convergence is unconditional rather than heuristically
+controlled.
+
+**Precision contract.** Knots and coefficients are promoted to float64 before
+the iteration, which is exact for a float32 spline, so the arithmetic is float64
+throughout regardless of the input dtype. The tolerances, however, are resolved
+from the *input* dtype: a float32 spline carries float32-level information, and
+a residual below that level cannot be distinguished from zero no matter how the
+iteration is carried out.
+
+**What is found.** Every zero where the spline changes sign is found; that is
+the guarantee the control polygon supports, since a spline whose coefficients
+have no sign change has no zeros at all. A zero of even multiplicity does not
+change the sign of the spline, so the sign changes that bracket it disappear
+under refinement and it cannot be certified from the polygon alone. Those are
+reported through a residual test instead (``|f(x)| <= zero_tol``), which is the
+same test that decides the two domain endpoints.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy import typing as npt
+
+from pantr._numba_compat import wait_for_jit_warmup
+from pantr.bspline._bspline_roots_core import _merge_roots, _morken_reimers_roots
+from pantr.tolerance import get_machine_epsilon, get_strict
+
+if TYPE_CHECKING:
+    from pantr.bspline._bspline import Bspline
+
+_INSERTIONS_BASE: int = 64
+"""Insertion budget for the linear phase of a single zero.
+
+A zero of multiplicity greater than one is approached linearly, and the observed
+ratio is one half (measured on an exact double zero), so exhausting the 53-bit
+significand takes ``log2(1 / eps) = 53`` insertions. Rounded up to 64, matching
+``_MAX_NEWTON_ITER`` in ``pantr.bezier._yuksel_core``, which bounds the same
+bisection-grade phase for the Bernstein solver.
+"""
+
+_INSERTIONS_PER_DEGREE: int = 8
+"""Extra insertions granted per unit of degree.
+
+The error is quadratic once per ``degree - 1`` insertions and not once per
+insertion (Mørken-Reimers, Theorem 22), so a simple zero needs roughly six
+quadratic steps of ``degree - 1`` insertions each to reach machine precision.
+Eight per degree leaves a margin over the worst case measured on random splines
+(173 insertions at degree 25, against a budget of 256).
+"""
+
+_CURVATURE_DEGREE: int = 2
+"""Lowest degree whose splines have a second derivative, hence a curvature merge radius."""
+
+_ZERO_TOL_SAFETY: float = 4.0
+"""Safety factor on the evaluation-error bound used as the residual threshold.
+
+Matches the factor applied to the de Casteljau bound in
+``pantr.bezier._clipping_core``; de Boor's algorithm combines the same
+``degree + 1`` coefficients through the same number of convex-combination
+levels, so the bound has the same shape.
+"""
+
+
+def _max_insertions(degree: int) -> int:
+    """Compute the insertion budget for one zero at a given degree.
+
+    Args:
+        degree (int): Polynomial degree of the spline.
+
+    Returns:
+        int: Maximum number of knot insertions spent on a single zero.
+    """
+    return _INSERTIONS_BASE + _INSERTIONS_PER_DEGREE * (degree - 1)
+
+
+def _validate_bspline_for_roots(bspline: object) -> Bspline:
+    """Validate that an object is a scalar univariate B-spline with positive weights.
+
+    Args:
+        bspline (object): Input to validate.
+
+    Returns:
+        Bspline: The validated B-spline, converted to an open (clamped),
+        non-periodic representation when it is not already one.
+
+    Raises:
+        TypeError: If ``bspline`` is not a :class:`~pantr.bspline.Bspline`.
+        ValueError: If it is not univariate (``dim != 1``), not scalar-valued
+            (``rank != 1``), of degree zero, or rational with a non-positive
+            weight.
+    """
+    from pantr.bspline._bspline import Bspline as BsplineCls  # noqa: PLC0415
+
+    if not isinstance(bspline, BsplineCls):
+        msg = f"Expected a Bspline instance, got {type(bspline).__name__}"
+        raise TypeError(msg)
+    if bspline.dim != 1:
+        msg = f"Bspline must be univariate (dim == 1), got dim={bspline.dim}"
+        raise ValueError(msg)
+    if bspline.rank != 1:
+        msg = f"Bspline must be scalar valued (rank == 1), got rank={bspline.rank}"
+        raise ValueError(msg)
+    if bspline.degree[0] < 1:
+        msg = (
+            "Root finding needs degree >= 1: a degree-zero spline is piecewise "
+            "constant, so its zero set is a union of knot intervals, not a set of points"
+        )
+        raise ValueError(msg)
+    if bspline.is_rational:
+        weights = np.asarray(bspline.control_points[..., -1], dtype=np.float64)
+        if not bool(np.all(weights > 0.0)):
+            msg = (
+                "Rational B-splines must have strictly positive weights, so that the "
+                f"zeros of the numerator are the zeros of the mapping. Got min weight "
+                f"{float(weights.min())}"
+            )
+            raise ValueError(msg)
+
+    if not bspline.space.spaces[0].has_open_knots():
+        return bspline.to_open_bspline()
+    return bspline
+
+
+def _check_connected(
+    coeffs: npt.NDArray[np.float64],
+    knots: npt.NDArray[np.float64],
+    degree: int,
+    zero_tol: float,
+) -> None:
+    """Reject a spline that vanishes identically on a knot interval.
+
+    Such a spline is *disconnected* in the sense of Mørken and Reimers: on that
+    interval every zero is a zero of the spline, so there is no set of isolated
+    roots to report and the variation-diminishing bound that the method rests on
+    no longer holds. The paper assumes connectedness throughout and notes that
+    the degeneracy is easy to detect, which is what this does.
+
+    Args:
+        coeffs (npt.NDArray[np.float64]): Scalar B-spline coefficients.
+        knots (npt.NDArray[np.float64]): Open knot vector.
+        degree (int): Polynomial degree.
+        zero_tol (float): Residual below which a coefficient counts as zero.
+
+    Raises:
+        ValueError: If every coefficient active on some non-empty knot interval
+            is zero to within ``zero_tol``.
+    """
+    num_coeffs = coeffs.shape[0]
+    windows = np.lib.stride_tricks.sliding_window_view(np.abs(coeffs), degree + 1)
+    window_max = np.asarray(windows.max(axis=1), dtype=np.float64)
+
+    spans = np.arange(degree, num_coeffs)
+    non_empty = knots[spans] < knots[spans + 1]
+    vanishing = non_empty & (window_max[spans - degree] <= zero_tol)
+    if bool(np.any(vanishing)):
+        first = int(spans[vanishing][0])
+        msg = (
+            f"The spline vanishes identically on the knot interval "
+            f"[{knots[first]}, {knots[first + 1]}], so its zero set is not a set of "
+            "isolated points. Split the spline to exclude that interval."
+        )
+        raise ValueError(msg)
+
+
+def _merge_radii(  # noqa: PLR0913
+    numerator: Bspline,
+    roots: npt.NDArray[np.float64],
+    *,
+    zero_tol: float,
+    coeff_scale: float,
+    domain_length: float,
+    tol: float,
+) -> npt.NDArray[np.float64]:
+    """Compute the per-root radius within which two reports are the same zero.
+
+    Around a zero of multiplicity ``m`` the set where ``|f| <= zero_tol`` has
+    half-width ``(m! * zero_tol / |f^(m)|) ** (1 / m)``, from the first
+    non-vanishing term of the Taylor expansion. The two cases that are computed
+    are ``m = 1`` and ``m = 2``; every one of them is a length, so all of them
+    transform correctly under a change of parametric scale.
+
+    The result is floored at the parametric resolution
+    ``tol * max(|x|, domain_length)`` and capped at
+    ``domain_length * (degree! * zero_tol / coeff_scale) ** (1 / degree)``, which
+    is that same half-width for the highest multiplicity the spline space admits,
+    evaluated where ``f^(degree)`` has its natural magnitude
+    ``coeff_scale / domain_length ** degree``. The cap is what covers a zero of
+    multiplicity three or more, where the two computed derivatives both vanish
+    and their radii would otherwise be dominated by rounding; without a cap at
+    all, such a zero would merge every later root into itself.
+
+    Args:
+        numerator (Bspline): Scalar, non-rational spline whose zeros are sought.
+        roots (npt.NDArray[np.float64]): Ascending root candidates.
+        zero_tol (float): Residual below which a value counts as zero.
+        coeff_scale (float): Largest absolute coefficient of the spline.
+        domain_length (float): Length of the parametric domain.
+        tol (float): Relative parametric tolerance.
+
+    Returns:
+        npt.NDArray[np.float64]: Merge radius for each root.
+    """
+    degree = numerator.degree[0]
+    infinite = np.full(roots.shape, np.inf, dtype=np.float64)
+
+    first = np.abs(np.asarray(numerator.evaluate_derivatives(roots, [1]), dtype=np.float64))
+    first = first.reshape(-1)
+    radius = np.divide(zero_tol, first, out=infinite.copy(), where=first > 0.0)
+
+    if degree >= _CURVATURE_DEGREE:
+        second = np.abs(np.asarray(numerator.evaluate_derivatives(roots, [2]), dtype=np.float64))
+        second = second.reshape(-1)
+        curved = np.sqrt(np.divide(2.0 * zero_tol, second, out=infinite.copy(), where=second > 0.0))
+        radius = np.minimum(radius, curved)
+
+    cap = domain_length * (math.factorial(degree) * zero_tol / coeff_scale) ** (1.0 / degree)
+    floor = tol * np.maximum(np.abs(roots), domain_length)
+    return np.asarray(np.maximum(np.minimum(radius, cap), floor), dtype=np.float64)
+
+
+def _find_roots_impl(
+    bspline: Bspline,
+    *,
+    tol: float | None = None,
+) -> npt.NDArray[np.float64]:
+    """Layer 2 implementation for :func:`find_roots`.
+
+    Args:
+        bspline (Bspline): Scalar univariate B-spline.
+        tol (float | None): Relative parametric tolerance, or ``None`` for the
+            dtype default.
+
+    Returns:
+        npt.NDArray[np.float64]: Sorted, read-only array of roots.
+
+    Raises:
+        TypeError: If ``bspline`` is not a :class:`~pantr.bspline.Bspline`.
+        ValueError: If the spline is not scalar and univariate, has degree zero,
+            has a non-positive weight, vanishes identically on a knot interval,
+            or if ``tol`` is not positive.
+    """
+    spline = _validate_bspline_for_roots(bspline)
+    if tol is not None and tol <= 0.0:
+        msg = f"tol must be positive, got {tol}"
+        raise ValueError(msg)
+
+    dtype = spline.dtype
+    resolved_tol = get_strict(dtype) if tol is None else tol
+    epsilon = get_machine_epsilon(dtype)
+
+    space = spline.space.spaces[0]
+    degree = int(space.degree)
+    knots = np.ascontiguousarray(space.knots, dtype=np.float64)
+    coeffs = np.ascontiguousarray(spline.control_points[..., 0], dtype=np.float64)
+
+    coeff_scale = float(np.abs(coeffs).max())
+    if coeff_scale == 0.0:
+        msg = "The spline is identically zero, so every point of its domain is a root"
+        raise ValueError(msg)
+    zero_tol = coeff_scale * max((degree + 1) * _ZERO_TOL_SAFETY * epsilon, resolved_tol)
+    _check_connected(coeffs, knots, degree, zero_tol)
+
+    wait_for_jit_warmup()
+    raw, count, truncated = _morken_reimers_roots(
+        knots, degree, coeffs, resolved_tol, zero_tol, _max_insertions(degree)
+    )
+    if truncated > 0:
+        warnings.warn(
+            f"{truncated} of {count} roots exhausted their insertion budget of "
+            f"{_max_insertions(degree)} before the iterates stagnated; they are "
+            "reported at the last iterate reached",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+    roots = np.ascontiguousarray(raw[:count])
+    if count > 1:
+        numerator = _scalar_numerator(spline, knots, coeffs)
+        radii = _merge_radii(
+            numerator,
+            roots,
+            zero_tol=zero_tol,
+            coeff_scale=coeff_scale,
+            domain_length=float(knots[coeffs.shape[0]] - knots[degree]),
+            tol=resolved_tol,
+        )
+        merged, n_merged = _merge_roots(roots, radii)
+        roots = np.ascontiguousarray(merged[:n_merged])
+
+    roots.flags.writeable = False
+    return roots
+
+
+def _scalar_numerator(
+    spline: Bspline,
+    knots: npt.NDArray[np.float64],
+    coeffs: npt.NDArray[np.float64],
+) -> Bspline:
+    """Build the float64, non-rational spline whose zeros are being reported.
+
+    For a rational spline the zeros of the mapping are the zeros of its
+    numerator, the weights being strictly positive, so the numerator is what the
+    derivatives used by :func:`_merge_radii` must be taken of.
+
+    Args:
+        spline (Bspline): The validated input spline.
+        knots (npt.NDArray[np.float64]): Its knot vector, as float64.
+        coeffs (npt.NDArray[np.float64]): Its scalar coefficients, as float64.
+
+    Returns:
+        Bspline: A non-rational float64 spline with the same zeros.
+    """
+    from pantr.bspline._bspline import Bspline as BsplineCls  # noqa: PLC0415
+    from pantr.bspline._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
+    from pantr.bspline._bspline_space_nd import BsplineSpace  # noqa: PLC0415
+
+    degree = int(spline.space.spaces[0].degree)
+    space = BsplineSpace([BsplineSpace1D(knots, degree, snap_knots=False)])
+    return BsplineCls(space, coeffs.reshape(-1, 1))
+
+
+def find_roots(
+    bspline: Bspline,
+    *,
+    tol: float | None = None,
+) -> npt.NDArray[np.float64]:
+    """Find every zero of a scalar univariate B-spline.
+
+    Uses the Mørken-Reimers method: the zero of the control polygon is inserted
+    as a new knot, over and over, until the iterates stagnate. The iteration
+    needs no starting value, converges for any spline, and reaches a simple zero
+    quadratically -- once per ``degree - 1`` insertions, not once per insertion.
+
+    Args:
+        bspline (Bspline): A univariate (``dim == 1``), scalar-valued
+            (``rank == 1``) B-spline. Periodic or unclamped splines are
+            converted to an open representation first. For rational splines the
+            zeros are those of the numerator, which are the zeros of the
+            mapping because the weights are positive.
+        tol (float | None): Relative parametric tolerance. The iteration stops
+            when the spread of the last ``degree`` iterates falls to
+            ``tol * max(|t_a|, |t_{a+degree}|, domain_length)``, so that it
+            transforms correctly when the parametric domain is scaled or moved
+            away from the origin. Defaults to
+            ``tolerance.get_strict(bspline.dtype)``.
+
+    Returns:
+        npt.NDArray[np.float64]: Sorted, read-only array of roots, always
+        float64. Empty if the spline has no zero.
+
+    Raises:
+        TypeError: If ``bspline`` is not a :class:`~pantr.bspline.Bspline`.
+        ValueError: If ``bspline`` is not univariate and scalar valued, has
+            degree zero, is rational with a non-positive weight, vanishes
+            identically on a knot interval, or if ``tol`` is not positive.
+
+    Warns:
+        RuntimeWarning: If a zero exhausted its insertion budget before the
+            iterates stagnated. The last iterate reached is reported.
+
+    Note:
+        Zeros where the spline changes sign are always found. A zero of even
+        multiplicity does not change the sign of the spline, so the sign changes
+        of the control polygon that bracket it vanish under refinement and it
+        cannot be certified from the polygon; it is reported only when the
+        residual there satisfies ``|f(x)| <= zero_tol``, with ``zero_tol`` the
+        de Boor evaluation-error bound of the spline.
+
+    Example:
+        >>> import numpy as np
+        >>> from pantr.bspline import BsplineSpace, BsplineSpace1D, Bspline, find_roots
+        >>> knots = np.array([0.0, 0.0, 1.0, 2.0, 2.0])
+        >>> space = BsplineSpace([BsplineSpace1D(knots, 1)])
+        >>> spline = Bspline(space, np.array([[-1.0], [1.0], [3.0]]))
+        >>> find_roots(spline)
+        array([0.5])
+
+    References:
+        The unconditionally convergent knot-insertion method of Mørken and
+        Reimers :cite:p:`morken2007zeros`.
+    """
+    return _find_roots_impl(bspline, tol=tol)
+
+
+__all__ = ["find_roots"]

--- a/src/pantr/bspline/_bspline_roots_core.py
+++ b/src/pantr/bspline/_bspline_roots_core.py
@@ -1,0 +1,621 @@
+"""Numba kernels for spline root finding by the Mørken-Reimers method.
+
+Computes the zeros of a scalar B-spline directly on its own knot vector, by
+repeatedly inserting the zero of the control polygon as a new knot
+:cite:p:`morken2007zeros`. Every arithmetic operation is a convex combination
+(Boehm knot insertion), the iteration needs no starting value, and it converges
+for any spline: the control polygon of a spline with a zero always has a sign
+change, and the variation-diminishing property keeps the sign-change count from
+growing under refinement.
+
+The kernels refine one working copy of the whole knot vector in place. Reporting
+a zero splits the spline there, raising the zero to knot multiplicity
+``degree + 1``, and everything to its left is then dropped: what is left is again
+an open (clamped) knot vector, this time on ``[zero, end]``. That is what bounds
+the memory, since the insertions spent on one zero are discarded when the next
+one is reported, and it is what keeps every span search inside the buffer.
+
+Note:
+    Inputs are assumed to be correct (no validation performed).
+    For general use, call :func:`pantr.bspline.find_roots` instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from .._numba_compat import nb_jit
+
+_STATUS_CONVERGED: int = 1
+"""The iterates stagnated, or repeated exactly, at a zero of the spline."""
+
+_STATUS_CANDIDATE: int = 2
+"""The sign change vanished; the last iterate is a tangential-zero candidate."""
+
+_STATUS_BUDGET: int = 3
+"""The insertion budget ran out before the iterates stagnated."""
+
+
+@nb_jit(nopython=True, cache=True)
+def _knot_average(knots: npt.NDArray[Any], degree: int, index: int) -> float:
+    """Compute the Greville abscissa ``(t[index+1] + ... + t[index+degree]) / degree``.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot vector.
+        degree (int): Polynomial degree, at least 1.
+        index (int): Coefficient index whose knot average is requested.
+
+    Returns:
+        float: The knot average (Greville abscissa) of coefficient ``index``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    total = 0.0
+    for j in range(index + 1, index + degree + 1):
+        total += knots[j]
+    return total / degree
+
+
+@nb_jit(nopython=True, cache=True)
+def _zero_index(coeffs: npt.NDArray[Any], num_coeffs: int, start: int) -> int:
+    """Find the smallest zero index of the control polygon at or after ``start``.
+
+    Following Mørken and Reimers, ``a`` is a zero index when ``coeffs[a - 1]`` is
+    non-zero and ``coeffs[a - 1] * coeffs[a] <= 0``; the non-zero requirement is
+    what keeps the secant denominator ``coeffs[a] - coeffs[a - 1]`` away from
+    zero across a run of vanishing coefficients.
+
+    Args:
+        coeffs (npt.NDArray[Any]): B-spline coefficients.
+        num_coeffs (int): Number of valid entries in ``coeffs``.
+        start (int): First index to test; clamped to 1 from below.
+
+    Returns:
+        int: The zero index, or ``-1`` if the polygon has no sign change left.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    index = start if start > 1 else 1
+    while index < num_coeffs:
+        previous = coeffs[index - 1]
+        if previous != 0.0 and previous * coeffs[index] <= 0.0:
+            return index
+        index += 1
+    return -1
+
+
+@nb_jit(nopython=True, cache=True)
+def _is_zero_index(coeffs: npt.NDArray[Any], num_coeffs: int, index: int) -> bool:
+    """Check whether ``index`` is a zero index of the control polygon.
+
+    Args:
+        coeffs (npt.NDArray[Any]): B-spline coefficients.
+        num_coeffs (int): Number of valid entries in ``coeffs``.
+        index (int): Index to test.
+
+    Returns:
+        bool: True if ``coeffs[index - 1]`` is non-zero and the product
+        ``coeffs[index - 1] * coeffs[index]`` is non-positive.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    if index < 1 or index >= num_coeffs:
+        return False
+    previous = coeffs[index - 1]
+    return bool(previous != 0.0 and previous * coeffs[index] <= 0.0)
+
+
+@nb_jit(nopython=True, cache=True)
+def _deboor_point(  # noqa: PLR0913
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    degree: int,
+    point: float,
+    span: int,
+    work: npt.NDArray[Any],
+) -> float:
+    """Evaluate a scalar spline at one point with de Boor's algorithm.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot vector.
+        coeffs (npt.NDArray[Any]): B-spline coefficients.
+        degree (int): Polynomial degree.
+        point (float): Evaluation point, inside ``[knots[span], knots[span+1]]``.
+        span (int): Knot span index of ``point``.
+        work (npt.NDArray[Any]): Scratch buffer of at least ``degree + 1`` entries.
+
+    Returns:
+        float: The value of the spline at ``point``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    for i in range(degree + 1):
+        work[i] = coeffs[span - degree + i]
+    for level in range(1, degree + 1):
+        for i in range(degree, level - 1, -1):
+            left = span - degree + i
+            denominator = knots[left + degree - level + 1] - knots[left]
+            alpha = (point - knots[left]) / denominator if denominator > 0.0 else 0.0
+            work[i] = (1.0 - alpha) * work[i - 1] + alpha * work[i]
+    return float(work[degree])
+
+
+@nb_jit(nopython=True, cache=True)
+def _insert_knot(  # noqa: PLR0913
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    point: float,
+    span: int,
+) -> None:
+    """Insert one knot in place by Boehm's algorithm, growing both buffers by one.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot buffer holding ``num_coeffs + degree + 1``
+            valid entries, with room for one more.
+        coeffs (npt.NDArray[Any]): Coefficient buffer holding ``num_coeffs``
+            valid entries, with room for one more.
+        num_coeffs (int): Number of valid coefficients before the insertion.
+        degree (int): Polynomial degree.
+        point (float): Knot value to insert.
+        span (int): Knot span index of ``point``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    for i in range(num_coeffs, span, -1):
+        coeffs[i] = coeffs[i - 1]
+    for i in range(span, span - degree, -1):
+        alpha = (point - knots[i]) / (knots[i + degree] - knots[i])
+        coeffs[i] = (1.0 - alpha) * coeffs[i - 1] + alpha * coeffs[i]
+
+    for i in range(num_coeffs + degree + 1, span + 1, -1):
+        knots[i] = knots[i - 1]
+    knots[span + 1] = point
+
+
+@nb_jit(nopython=True, cache=True)
+def _split_at_root(  # noqa: PLR0913
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    point: float,
+    zero_tol: float,
+) -> tuple[int, int]:
+    """Raise ``point`` to multiplicity ``degree + 1`` and pin its coefficient to zero.
+
+    Splitting the spline at a zero that has already been reported is what keeps
+    the next sign change from drifting back onto it: a tracked sequence converges
+    to *a* zero of the spline inside ``[t[a], t[a+degree]]``, not necessarily to
+    the one its own Greville interval brackets, so an already-reported zero has
+    to be removed from that bracket first. Mørken and Reimers prescribe exactly
+    this, splitting the spline at each zero before looking for the next one.
+
+    Multiplicity ``degree + 1`` is what makes the split a genuine one: the two
+    sides then share no basis function, and dropping the left side leaves an
+    open (clamped) knot vector on ``[point, end]``, so every later span search
+    and every later Boehm insertion sees the same structure as the original
+    input. Multiplicity ``degree`` would leave one knot of the old spline
+    hanging to the left of the new domain, and a span search starting from a
+    coefficient index would then be free to run off the front of the buffer.
+
+    The first coefficient of that clamped remainder is ``f(point)``, which is
+    zero because ``point`` is a zero of the spline, so pinning it to exactly zero
+    removes the rounding left by the insertions and makes it a barrier:
+    :func:`_zero_index` never reports an index whose left neighbour is exactly
+    zero.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot vector, refined in place.
+        coeffs (npt.NDArray[Any]): Coefficients, refined in place.
+        num_coeffs (int): Number of valid entries in ``coeffs``.
+        degree (int): Polynomial degree.
+        point (float): Zero of the spline, below the end of the domain.
+        zero_tol (float): Residual below which a coefficient counts as zero.
+
+    Returns:
+        tuple[int, int]: ``(num_coeffs, offset)`` with the updated coefficient
+        count and the index at which the remainder begins, that is the first
+        index of the knot run carrying ``point``. Both arrays are to be shifted
+        down by ``offset``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    # Count only the run that ends at this span: the same value may well appear
+    # elsewhere in the knot vector, and it is this run that has to be raised.
+    span = 0
+    while point >= knots[span + 1]:
+        span += 1
+    multiplicity = 0
+    index = span
+    while index >= 0 and knots[index] == point:
+        multiplicity += 1
+        index -= 1
+
+    while multiplicity <= degree and num_coeffs < coeffs.shape[0]:
+        _insert_knot(knots, coeffs, num_coeffs, degree, point, span)
+        num_coeffs += 1
+        multiplicity += 1
+        span += 1
+
+    offset = span
+    while offset > 0 and knots[offset - 1] == point:
+        offset -= 1
+
+    coeffs[offset] = 0.0
+    # The coefficients just right of the barrier average knots that are all the
+    # split point, so they carry f(point) = 0 up to rounding. Left as they are,
+    # their arbitrary sign seeds a sign change that tracks straight back to the
+    # split point; pinning them extends the barrier.
+    i = offset + 1
+    while i < num_coeffs and abs(coeffs[i]) <= zero_tol:
+        coeffs[i] = 0.0
+        i += 1
+    return num_coeffs, offset
+
+
+@nb_jit(nopython=True, cache=True)
+def _track_zero(  # noqa: PLR0913
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    index: int,
+    tol: float,
+    domain_length: float,
+    max_insertions: int,
+    iterates: npt.NDArray[Any],
+    work: npt.NDArray[Any],
+) -> tuple[float, int, float, int, int]:
+    """Track one sign change of the control polygon to a zero of the spline.
+
+    Runs Algorithm 2 of Mørken and Reimers on the window buffers: the zero of
+    the control polygon is inserted as a new knot, and the tracked index follows
+    the same sign change, which after the insertion sits at ``index`` or at
+    ``index + 1`` and nowhere else. Both buffers are refined in place.
+
+    The stopping rule is the paper's: the spread of the last ``degree`` iterates,
+    measured relative to ``max(|knots[index]|, |knots[index+degree]|,
+    domain_length)``. That window spans exactly one quadratic step, since the
+    error is quadratic per ``degree - 1`` insertions and not per insertion.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot window, refined in place.
+        coeffs (npt.NDArray[Any]): Coefficient window, refined in place.
+        num_coeffs (int): Number of valid entries in ``coeffs``.
+        degree (int): Polynomial degree, at least 1.
+        index (int): Zero index to track, inside the window. The caller
+            guarantees that :func:`_is_zero_index` holds for it.
+        tol (float): Relative stagnation tolerance.
+        domain_length (float): Length of the spline's parametric domain, used as
+            a floor for the tolerance scale.
+        max_insertions (int): Insertion budget for this zero.
+        iterates (npt.NDArray[Any]): Ring buffer of at least ``degree`` entries.
+        work (npt.NDArray[Any]): Scratch buffer of at least ``degree + 1`` entries.
+
+    Returns:
+        tuple[float, int, float, int, int]: ``(x, status, residual, num_coeffs,
+        index)``. ``status`` is one of ``_STATUS_CONVERGED``,
+        ``_STATUS_CANDIDATE`` or ``_STATUS_BUDGET``, ``x`` is the last polygon
+        zero computed, ``residual`` is ``|f(x)|`` when the status is
+        ``_STATUS_CANDIDATE`` and ``0.0`` otherwise, and the last two are the
+        coefficient count and tracked index left behind in the refined window.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    num_iterates = 0
+    previous_x = 0.0
+    x = 0.0
+
+    # Never write past the working buffers: the budget is whichever runs out
+    # first, the insertions allowed for this zero or the room left in the
+    # arrays, keeping `degree + 1` slots for the split that follows a reported
+    # zero.
+    budget = min(max_insertions, coeffs.shape[0] - degree - 1 - num_coeffs)
+    inserted = 0
+
+    while True:
+        left_value = coeffs[index - 1]
+        right_value = coeffs[index]
+        left_abscissa = _knot_average(knots, degree, index - 1)
+        right_abscissa = _knot_average(knots, degree, index)
+
+        # Zero of the segment joining (left_abscissa, left_value) and
+        # (right_abscissa, right_value), as a clamped convex combination: the
+        # two values straddle zero, so the parameter is in [0, 1] up to rounding.
+        lam = -left_value / (right_value - left_value)
+        lam = min(max(lam, 0.0), 1.0)
+        x = left_abscissa + lam * (right_abscissa - left_abscissa)
+        x = min(max(x, left_abscissa), right_abscissa)
+
+        # A knot average is a sum of `degree` terms divided by `degree`, so it
+        # carries a relative error of a few ulp and can land below its own
+        # smallest term once the knots have piled up to within that much. The
+        # theory places every iterate in `[t[index], t[index+degree]]`, and the
+        # span search below only ever walks right from `index`, so restore the
+        # left end rather than let the search return a span that does not
+        # bracket x.
+        x = max(x, knots[index])
+
+        # A repeated iterate is a fixed point of the iteration, hence a zero of
+        # the spline (Morken-Reimers, Lemma 13 and Corollary 14).
+        if num_iterates > 0 and x == previous_x:
+            return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+
+        # The spline is disconnected at x, so f(x) = 0 exactly (their Lemma 3).
+        if x >= knots[index + degree]:
+            return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+
+        iterates[num_iterates % degree] = x
+        previous_x = x
+        num_iterates += 1
+
+        if num_iterates >= degree:
+            lowest = iterates[0]
+            highest = iterates[0]
+            for i in range(1, degree):
+                lowest = min(lowest, iterates[i])
+                highest = max(highest, iterates[i])
+            scale = max(abs(knots[index]), abs(knots[index + degree]))
+            scale = max(scale, domain_length)
+            if highest - lowest <= tol * scale:
+                return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+
+        if inserted >= budget:
+            return x, _STATUS_BUDGET, 0.0, num_coeffs, index
+
+        span = index
+        while x >= knots[span + 1]:
+            span += 1
+        _insert_knot(knots, coeffs, num_coeffs, degree, x, span)
+        num_coeffs += 1
+        inserted += 1
+
+        # Their Algorithm 2, step 3: the tracked sign change is now at `index`
+        # or at `index + 1`; if it is at neither, it has vanished.
+        if not _is_zero_index(coeffs, num_coeffs, index):
+            index += 1
+            if not _is_zero_index(coeffs, num_coeffs, index):
+                span = 0
+                while x >= knots[span + 1]:
+                    span += 1
+                residual = _deboor_point(knots, coeffs, degree, x, span, work)
+                return x, _STATUS_CANDIDATE, abs(residual), num_coeffs, index
+
+
+@nb_jit(nopython=True, cache=True)
+def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
+    knots: npt.NDArray[Any],
+    degree: int,
+    coeffs: npt.NDArray[Any],
+    tol: float,
+    zero_tol: float,
+    max_insertions: int,
+) -> tuple[npt.NDArray[np.float64], int, int]:
+    """Compute every zero of a scalar spline by the Mørken-Reimers method.
+
+    Scans the control polygon left to right and tracks each sign change to a
+    zero of the spline. A sign change that disappears under refinement is a
+    false warning of the variation-diminishing bound, unless the spline is
+    tangent to the axis there: those are separated by testing the residual
+    ``|f(x)| <= zero_tol``, which is also how the two domain endpoints are
+    tested. Zeros of even multiplicity have no sign change in the limit and
+    cannot be certified by the polygon alone, so they are reported through that
+    residual test only.
+
+    Args:
+        knots (npt.NDArray[Any]): Open (clamped) knot vector of shape
+            ``(num_coeffs + degree + 1,)``.
+        degree (int): Polynomial degree, at least 1.
+        coeffs (npt.NDArray[Any]): B-spline coefficients of the scalar spline.
+        tol (float): Relative stagnation tolerance for the iterates.
+        zero_tol (float): Absolute residual below which a value counts as zero.
+        max_insertions (int): Insertion budget per zero.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], int, int]: ``(roots, count, truncated)``
+        where only the first ``count`` entries of ``roots`` are valid, sorted
+        ascending, and ``truncated`` counts the zeros whose insertion budget ran
+        out before the iterates stagnated.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    num_coeffs = coeffs.shape[0]
+    # A connected spline has at most `num_coeffs - 1` sign changes in its control
+    # polygon and therefore at most that many interior zeros, plus the two
+    # endpoints. The extra slot is what lets the loop below stop on a full array
+    # instead of writing past it, which nothing would catch inside a kernel.
+    roots = np.empty(num_coeffs + 2, dtype=np.float64)
+    count = 0
+    truncated = 0
+
+    start = float(knots[degree])
+    end = float(knots[num_coeffs])
+    domain_length = end - start
+
+    # The working arrays hold the spline from the zero reported last to the end
+    # of the domain, refined in place. They only ever grow by insertions between
+    # two reported zeros, because reporting one compacts everything behind it.
+    capacity = num_coeffs + degree + 2 + 4 * max_insertions
+    live_coeffs = np.empty(capacity, dtype=np.float64)
+    live_knots = np.empty(capacity + degree + 1, dtype=np.float64)
+    iterates = np.empty(max(degree, 1), dtype=np.float64)
+    work = np.empty(degree + 1, dtype=np.float64)
+
+    for i in range(num_coeffs):
+        live_coeffs[i] = coeffs[i]
+    for i in range(num_coeffs + degree + 1):
+        live_knots[i] = knots[i]
+    num_live = num_coeffs
+
+    # An open knot vector interpolates its first and last coefficient, so an
+    # endpoint zero is read straight off the coefficients (their pseudo code).
+    previous_root = start - domain_length - 1.0
+    if abs(coeffs[0]) <= zero_tol:
+        roots[count] = start
+        count += 1
+        previous_root = start
+
+    scan_from = 1
+    while count + 1 < roots.shape[0]:
+        index = _zero_index(live_coeffs, num_live, scan_from)
+        if index < 0:
+            break
+
+        # Stop while a full tracking and the split that may follow it still fit.
+        # Reaching this means the insertions between two reported zeros outran
+        # the room the compaction reclaims, which the capacity below is sized to
+        # prevent; the count of unfinished zeros is what tells the caller.
+        if num_live + max_insertions + 2 * (degree + 1) > capacity:
+            truncated += 1
+            break
+
+        x, status, residual, num_live, index = _track_zero(
+            live_knots,
+            live_coeffs,
+            num_live,
+            degree,
+            index,
+            tol,
+            domain_length,
+            max_insertions,
+            iterates,
+            work,
+        )
+
+        if status == _STATUS_BUDGET:
+            truncated += 1
+
+        # A polygon that lost its sign change is at a zero of even multiplicity if
+        # the spline vanishes there, and at a false warning of the
+        # variation-diminishing bound otherwise.
+        accepted = residual <= zero_tol if status == _STATUS_CANDIDATE else True
+
+        # The sweep is strictly left to right, so an iterate that did not pass
+        # the zero reported last is that same zero seen again through another
+        # sign change of the polygon, not a new one.
+        if accepted and previous_root < x <= end:
+            roots[count] = x
+            count += 1
+            previous_root = x
+            scan_from = index + 1
+            if x < live_knots[num_live]:
+                # Split at the zero just reported so that the next sign change
+                # cannot drift back onto it, then drop everything left of the
+                # split: it is behind the sweep for good, and dropping it is
+                # what keeps the working arrays from growing with each zero and
+                # what leaves an open knot vector on the rest of the domain.
+                num_live, offset = _split_at_root(
+                    live_knots, live_coeffs, num_live, degree, x, zero_tol
+                )
+                for i in range(num_live - offset):
+                    live_coeffs[i] = live_coeffs[i + offset]
+                for i in range(num_live - offset + degree + 1):
+                    live_knots[i] = live_knots[i + offset]
+                num_live -= offset
+                scan_from = 1
+        else:
+            # One index past the sign change just rejected, and no further: the
+            # refinement left by the tracking can leave a second sign change of
+            # its own immediately to the right, and that one may well bracket
+            # the next zero. Stepping over the knot run instead would skip it.
+            # This is what makes the sweep terminate, the index returned by
+            # `_track_zero` being at least the one the scan handed it.
+            scan_from = index + 1
+
+    if abs(coeffs[num_coeffs - 1]) <= zero_tol:
+        roots[count] = end
+        count += 1
+
+    return roots, count, truncated
+
+
+@nb_jit(nopython=True, cache=True)
+def _merge_roots(
+    roots: npt.NDArray[np.float64],
+    radii: npt.NDArray[np.float64],
+) -> tuple[npt.NDArray[np.float64], int]:
+    """Merge runs of ascending roots that lie within their own merge radii.
+
+    The scan reports one root per sign change of the control polygon, and a zero
+    of even multiplicity is bracketed by two of them, so consecutive reports have
+    to be collapsed. Two neighbours join the same run when their separation does
+    not exceed the larger of the two radii; each run is replaced by its midpoint,
+    which for a bracketed tangential zero is the better estimate of the two.
+
+    Args:
+        roots (npt.NDArray[np.float64]): Ascending root candidates.
+        radii (npt.NDArray[np.float64]): Per-root merge radius, same length.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], int]: ``(merged, n_merged)`` where only
+        the first ``n_merged`` entries are valid.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    count = roots.shape[0]
+    merged = np.empty(max(count, 1), dtype=np.float64)
+    if count == 0:
+        return merged, 0
+
+    n_merged = 0
+    run_start = roots[0]
+    run_end = roots[0]
+    for i in range(1, count):
+        if roots[i] - run_end <= max(radii[i], radii[i - 1]):
+            run_end = roots[i]
+        else:
+            merged[n_merged] = 0.5 * (run_start + run_end)
+            n_merged += 1
+            run_start = roots[i]
+            run_end = roots[i]
+    merged[n_merged] = 0.5 * (run_start + run_end)
+    n_merged += 1
+    return merged, n_merged
+
+
+def _warmup_numba_functions() -> None:
+    """Precompile the root-finding kernels with float64 signatures.
+
+    Compiles the whole call tree through :func:`_morken_reimers_roots` on a
+    cubic spline with one interior knot and a single sign change.
+    """
+    knots = np.array([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
+    coeffs = np.array([-1.0, -0.5, 0.5, 1.0, 2.0], dtype=np.float64)
+    roots, count, _ = _morken_reimers_roots(knots, 3, coeffs, 1e-15, 1e-14, 64)
+    _merge_roots(roots[:count], np.full(count, 1e-15, dtype=np.float64))
+
+
+__all__ = [
+    "_deboor_point",
+    "_insert_knot",
+    "_is_zero_index",
+    "_knot_average",
+    "_merge_roots",
+    "_morken_reimers_roots",
+    "_split_at_root",
+    "_track_zero",
+    "_zero_index",
+]

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -1,0 +1,826 @@
+"""Tests for Mørken-Reimers B-spline root finding (``pantr.bspline.find_roots``)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.bezier import find_roots as bezier_find_roots
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, _bspline_roots, find_roots
+from pantr.bspline._bspline_roots import _max_insertions
+from pantr.bspline._bspline_roots_core import (
+    _insert_knot,
+    _is_zero_index,
+    _knot_average,
+    _merge_roots,
+    _morken_reimers_roots,
+    _split_at_root,
+    _zero_index,
+)
+from pantr.tolerance import get_strict
+
+_EPS: float = float(np.finfo(np.float64).eps)
+"""Machine epsilon of ``float64``, the precision every tolerance below derives from."""
+
+_STRICT_TOL: float = get_strict(np.float64)
+"""
+The default relative parametric tolerance of :func:`find_roots`, ``1e-15``, or 4.5 ulp.
+
+It is what sets the accuracy of a reported root, so it is what the residual bound scales
+with; machine epsilon alone understates that by the factor between the two.
+"""
+
+_ROOT_ULPS: float = 64.0
+"""
+Accuracy of a simple root, in ulp of the coordinate scale.
+
+A root is a parametric coordinate, so its accuracy floor is one ulp of its own
+magnitude; the iteration adds the evaluation error of the control polygon, which is
+``degree + 1`` convex combinations. The worst error measured over the analytic cases
+below is ``2.3e-13`` at degree 5 on a domain around ``1e3``, that is two ulp of the
+coordinate, so 64 ulp leaves a factor of 32.
+"""
+
+_PARITY_RTOL: float = 1e-10
+"""
+Agreement required between this method and extraction plus Bernstein root finding.
+
+The assertion is that the two routes report the *same set* of zeros, not that either is
+accurate: the Bézier route maps each segment root back with ``lo + t * (hi - lo)`` and so
+carries the segment's own rounding, which is not the object under test. Accuracy is
+asserted separately, against analytic polynomials and against the residual bound. The
+worst disagreement measured over 700 random splines is ``5.6e-16`` on a unit domain, so
+this leaves five decades of margin.
+"""
+
+
+def _open_knots(
+    degree: int,
+    breaks: npt.ArrayLike,
+    multiplicities: npt.NDArray[np.int_] | None = None,
+) -> npt.NDArray[np.float64]:
+    """Build an open (clamped) knot vector from breakpoints and interior multiplicities."""
+    inner = np.asarray(breaks, dtype=np.float64)
+    interior = inner[1:-1] if multiplicities is None else np.repeat(inner[1:-1], multiplicities)
+    return np.concatenate(([inner[0]] * (degree + 1), interior, [inner[-1]] * (degree + 1)))
+
+
+def _spline(
+    knots: npt.NDArray[np.float64],
+    coeffs: npt.ArrayLike,
+    degree: int,
+    dtype: npt.DTypeLike = np.float64,
+) -> Bspline:
+    """Build the scalar univariate B-spline with the given knots and coefficients."""
+    space = BsplineSpace([BsplineSpace1D(knots.astype(dtype), degree, snap_knots=False)])
+    return Bspline(space, np.asarray(coeffs, dtype=dtype).reshape(-1, 1))
+
+
+def _polynomial_coefficients(
+    knots: npt.NDArray[np.float64],
+    degree: int,
+    roots: tuple[float, ...],
+) -> npt.NDArray[np.float64]:
+    """Return the B-spline coefficients of ``prod(x - r)`` through its blossom.
+
+    The blossom of ``x ** k`` at ``u_1, ..., u_p`` is ``e_k(u) / C(p, k)``, with ``e_k``
+    the elementary symmetric polynomial, so the coefficient ``c_j``, which is the blossom
+    evaluated on the knot window ``t[j+1 .. j+p]``, follows from the power-basis
+    coefficients of the polynomial. This is an oracle independent of any root finder: the
+    roots are put in, the coefficients come out.
+
+    Build the polynomial on a domain around the origin and move it by scaling the *knots*
+    afterwards. Building it directly on a domain around ``1e3`` instead loses it entirely,
+    the power basis then cancelling terms of order ``1e15`` down to a result of order
+    ``1e-5``.
+    """
+    power = np.poly(np.asarray(roots, dtype=np.float64))[::-1]
+    binomials = np.array([math.comb(degree, k) for k in range(degree + 1)], dtype=np.float64)
+    out = np.empty(len(knots) - degree - 1, dtype=np.float64)
+    for j in range(out.shape[0]):
+        window = np.asarray(knots[j + 1 : j + degree + 1], dtype=np.float64)
+        # np.poly(window)[i] is the coefficient of x ** (p - i) in prod(x - u), which is
+        # (-1) ** i * e_i, so the sign alternation recovers e_i itself.
+        signs = np.array([(-1.0) ** i for i in range(degree + 1)])
+        out[j] = float(np.dot(power, np.poly(window) * signs / binomials))
+    return out
+
+
+def _bezier_reference_roots(
+    spline: Bspline,
+    knots: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Return the zeros found by extracting Bézier segments and solving each of them.
+
+    An independent route to the same answer: it converts to the Bernstein basis and runs
+    the clipping solver of :func:`pantr.bezier.find_roots` on every segment, then stitches
+    and deduplicates. Nothing of the knot-insertion method is reused.
+    """
+    unique = np.unique(knots)
+    found: list[float] = []
+    for segment, bezier in enumerate(spline.to_beziers().ravel()):
+        low, high = unique[segment], unique[segment + 1]
+        found.extend(low + bezier_find_roots(bezier) * (high - low))
+    out = np.sort(np.asarray(found, dtype=np.float64))
+    if out.size:
+        length = unique[-1] - unique[0]
+        out = out[np.concatenate(([True], np.diff(out) > 1e-9 * length))]
+    return out
+
+
+def _zero_tol(coeffs: npt.NDArray[np.float64], degree: int) -> float:
+    """Return the residual threshold ``find_roots`` derives for these coefficients."""
+    return float(np.abs(coeffs).max()) * max((degree + 1) * 4.0 * _EPS, 1e-15)
+
+
+# --- Analytic cases -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("degree", "roots"),
+    [
+        (1, (0.5,)),
+        (2, (0.25, 0.8)),
+        (3, (0.2, 0.5, 0.9)),
+        (4, (0.15, 0.4, 0.6, 0.85)),
+        (5, (0.1, 0.3, 0.55, 0.8, 0.95)),
+    ],
+)
+def test_polynomial_roots_are_found_to_a_few_ulp(degree: int, roots: tuple[float, ...]) -> None:
+    """A polynomial in B-spline form gives back exactly the roots it was built from."""
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, roots)
+
+    found = find_roots(_spline(knots, coeffs, degree))
+
+    assert found.shape == (len(roots),)
+    np.testing.assert_allclose(found, np.array(roots), rtol=0.0, atol=_ROOT_ULPS * _EPS)
+
+
+@pytest.mark.parametrize(
+    ("origin", "span"),
+    [(0.0, 1.0), (1.0e3, 1.0), (1.0e6, 1.0), (-5.0, 7.0), (0.0, 1.0e-3)],
+)
+def test_roots_follow_an_affine_reparametrization(origin: float, span: float) -> None:
+    """Moving and scaling the knots moves and scales the roots, to the coordinate's ulp.
+
+    A B-spline whose knots are mapped affinely, with the coefficients left alone, *is* the
+    affinely reparametrized function, so the exact answer is known at every scale. This is
+    what shows the tolerances are scale-covariant rather than tuned to the unit interval.
+    """
+    degree = 3
+    unit_knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    unit_roots = (0.2, 0.5, 0.9)
+    coeffs = _polynomial_coefficients(unit_knots, degree, unit_roots)
+
+    found = find_roots(_spline(origin + span * unit_knots, coeffs, degree))
+
+    expected = np.array([origin + span * r for r in unit_roots])
+    scale = max(abs(origin), span)
+    np.testing.assert_allclose(found, expected, rtol=0.0, atol=_ROOT_ULPS * _EPS * scale)
+
+
+@pytest.mark.parametrize("multiplicity", [2, 3, 4])
+def test_a_multiple_root_is_reported_once(multiplicity: int) -> None:
+    """A zero of multiplicity ``m`` collapses to one root, accurate to ``zero_tol ** (1/m)``.
+
+    That exponent is not a safety factor but the accuracy the problem allows: around a zero
+    of multiplicity ``m`` the spline only reaches ``zero_tol`` at a distance
+    ``(m! * zero_tol / |f^(m)|) ** (1 / m)``, and for ``(x - 1/2) ** m`` the ``m``-th
+    derivative is exactly ``m!``. A zero of even multiplicity has no sign change at all, so
+    it is reported through the residual test rather than through the control polygon.
+    """
+    knots = _open_knots(multiplicity, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, multiplicity, (0.5,) * multiplicity)
+
+    found = find_roots(_spline(knots, coeffs, multiplicity))
+
+    assert found.shape == (1,)
+    assert abs(found[0] - 0.5) <= _zero_tol(coeffs, multiplicity) ** (1.0 / multiplicity)
+
+
+def test_a_simple_and_a_double_root_stay_separate() -> None:
+    """Merging collapses a repeated report of one zero, never two distinct zeros."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.25, 0.5, 0.5))
+
+    found = find_roots(_spline(knots, coeffs, degree))
+
+    assert found.shape == (2,)
+    assert abs(found[0] - 0.25) <= _ROOT_ULPS * _EPS
+    assert abs(found[1] - 0.5) <= _zero_tol(coeffs, degree) ** 0.5
+
+
+def test_a_root_sitting_exactly_on_an_interior_knot() -> None:
+    """A zero at a knot needs no special case: it is where the method inserts anyway."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.4, 0.8))
+
+    found = find_roots(_spline(knots, coeffs, degree))
+
+    np.testing.assert_allclose(found, [0.2, 0.4, 0.8], rtol=0.0, atol=_ROOT_ULPS * _EPS)
+
+
+def test_roots_at_both_domain_endpoints() -> None:
+    """An open knot vector interpolates its end coefficients, so an endpoint zero shows up."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+    coeffs = _polynomial_coefficients(knots, degree, (0.0, 1.0))
+
+    found = find_roots(_spline(knots, coeffs, degree))
+
+    np.testing.assert_allclose(found, [0.0, 1.0], rtol=0.0, atol=_ROOT_ULPS * _EPS)
+
+
+def test_no_roots_when_the_spline_is_strictly_positive() -> None:
+    """A control polygon without a sign change means no zeros at all."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coefficients = np.full(len(knots) - degree - 1, 2.0)
+
+    found = find_roots(_spline(knots, coefficients, degree))
+
+    assert found.shape == (0,)
+
+
+# --- Agreement with an independent route ----------------------------------------------
+
+
+@pytest.mark.parametrize("degree", [1, 2, 3, 4, 5, 6, 7])
+def test_matches_the_bezier_route_on_random_splines(degree: int) -> None:
+    """Random splines with repeated interior knots give the same zero set as extraction.
+
+    Repeated interior knots are where the two defects this module was fixed for both live:
+    with simple knots the two routes agreed on every one of 160 trials, while the failures
+    appeared at about one per cent once multiplicities were drawn as well.
+    """
+    rng = np.random.default_rng(20260814 + degree)
+    for _ in range(50):
+        n_elements = int(rng.integers(2, 20))
+        breaks = np.unique(np.concatenate(([0.0, 1.0], rng.uniform(0.0, 1.0, n_elements - 1))))
+        multiplicities = rng.integers(1, degree + 1, size=max(breaks.size - 2, 0))
+        knots = _open_knots(degree, breaks, multiplicities)
+        coeffs = rng.normal(size=len(knots) - degree - 1)
+        spline = _spline(knots, coeffs, degree)
+
+        found = find_roots(spline)
+        expected = _bezier_reference_roots(spline, knots)
+
+        assert found.shape == expected.shape
+        if found.size:
+            np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+@pytest.mark.parametrize(
+    ("origin", "span"),
+    [(0.0, 1.0), (1.0e3, 1.0), (1.0e6, 1.0), (0.0, 1.0e-3)],
+)
+def test_residual_at_every_root_is_within_the_evaluation_bound(origin: float, span: float) -> None:
+    """``|f(x)|`` at a reported root stays under the error of evaluating ``f`` there.
+
+    The bound has two terms and needs both. The first is the de Boor evaluation error,
+    ``coeff_scale * (degree + 1) * 4 * eps``. The second is ``|f'| * 2 * tol * max(|x|, L)``,
+    the value the spline takes at the parametric resolution the iteration actually stops at:
+    the rule is a spread of the last ``degree`` iterates below ``tol * max(|x|, L)``, so the
+    root carries that much slack and one further step. Writing ``eps`` there instead of
+    ``tol`` understates it by the factor between them, which is 4.5 for the default
+    ``get_strict(float64)``; that goes unnoticed on the unit domain, where the first term
+    dominates, and fails by 6.8 times on a domain around ``1e6``, where the second does.
+    """
+    rng = np.random.default_rng(613)
+    worst = 0.0
+    for degree in (2, 3, 5, 7):
+        for _ in range(15):
+            n_elements = int(rng.integers(2, 15))
+            breaks = np.unique(np.concatenate(([0.0, 1.0], rng.uniform(0.0, 1.0, n_elements - 1))))
+            knots = origin + span * _open_knots(degree, breaks)
+            coeffs = rng.normal(size=len(knots) - degree - 1)
+            spline = _spline(knots, coeffs, degree)
+
+            roots = find_roots(spline)
+            if roots.size == 0:
+                continue
+            values = np.abs(np.asarray(spline.evaluate(roots), dtype=np.float64).reshape(-1))
+            slopes = np.abs(
+                np.asarray(spline.evaluate_derivatives(roots, [1]), dtype=np.float64).reshape(-1)
+            )
+            bound = _zero_tol(coeffs, degree) + slopes * 2.0 * _STRICT_TOL * np.maximum(
+                np.abs(roots), span
+            )
+            worst = max(worst, float((values / bound).max()))
+    assert worst <= 1.0
+
+
+# --- Regression cases, with the data that triggered them -------------------------------
+
+_DIVISION_DEGREE = 7
+"""Degree of the spline that used to make the Boehm insertion divide by zero."""
+
+_DIVISION_BREAKS = np.array(
+    [
+        0.024892404472518503,
+        0.03354892843448798,
+        0.10136056366541846,
+        0.1122190513796808,
+        0.1464272974472447,
+        0.4624100974100952,
+        0.5109112536781879,
+        0.6235078061995366,
+        0.6378198461841913,
+        0.729584735215864,
+        0.7697545067745368,
+        0.7715103674467213,
+        0.8530564246522064,
+        0.9409084808000586,
+        0.9485109253452616,
+    ]
+)
+"""Interior breakpoints of the division-by-zero case."""
+
+_DIVISION_MULTS = np.array([4, 6, 1, 5, 6, 2, 6, 7, 1, 2, 6, 3, 7, 6, 3])
+"""Interior knot multiplicities of the division-by-zero case."""
+
+_DIVISION_COEFFS = np.array(
+    [
+        0.9437459682550059,
+        -1.7619232704479926,
+        -1.769325337044876,
+        -0.18024728004294954,
+        0.041247632747591106,
+        -0.3994308994247353,
+        -0.516022669178932,
+        0.18100580447818726,
+        0.4993511564441196,
+        0.5321707345411638,
+        0.4660851995749392,
+        0.7410879736380998,
+        -0.38089957480056474,
+        1.3631888996881332,
+        -0.5494494669227896,
+        -1.0452973037922395,
+        0.3203141999627478,
+        0.1757283130970403,
+        -0.5007916818951128,
+        0.11060288310608378,
+        -1.5937131347903954,
+        -0.8313734056944073,
+        0.24133882168833876,
+        0.7983299714590487,
+        0.8765505820977094,
+        -0.12259583863913351,
+        -0.009193873407048046,
+        1.5711360452267944,
+        -1.9321387632151084,
+        -1.3190257696414207,
+        -0.2844767117704297,
+        -1.1990518322779973,
+        0.51671830294839,
+        0.2624975354984742,
+        -0.9803343820777106,
+        1.5654425190301766,
+        0.015287705067431509,
+        0.05394948182127942,
+        1.3959184688042012,
+        -0.7235266585844332,
+        -0.8978583025676149,
+        2.828565592337862,
+        -1.886413481161058,
+        0.2974819653205911,
+        -0.08995063875416641,
+        -0.9172722203772358,
+        -0.9587210338847852,
+        -0.5818281363389338,
+        1.5514175764178706,
+        -1.195103342222694,
+        -0.14838726266626737,
+        -0.384981200717065,
+        1.6790678865844157,
+        0.6536032708161893,
+        0.09219390150258462,
+        -0.6454490385078762,
+        1.0916575980237546,
+        1.0695505549977262,
+        1.130009070519936,
+        -0.28799879294347763,
+        -0.7013417360350601,
+        -0.9074097956738512,
+        -0.1007157586601924,
+        -1.2357574762970038,
+        0.9824577648202112,
+        2.1521157661220105,
+        -0.26550142696010753,
+        -1.36185989740396,
+        0.3919810001338171,
+        -0.481357556584237,
+        -0.0985054408304594,
+        0.09376462814118997,
+        1.1837644094770001,
+    ]
+)
+"""Coefficients of the division-by-zero case."""
+
+_MISSED_DEGREE = 3
+"""Degree of the spline that used to lose a root."""
+
+_MISSED_BREAKS = np.array(
+    [
+        0.05686473281359683,
+        0.08537928894568714,
+        0.13343296683579242,
+        0.2689055644096665,
+        0.389738489622555,
+        0.4083831147882375,
+        0.5487495352562979,
+        0.5596814072327488,
+        0.5877034964862079,
+        0.5948584020096005,
+        0.6785788110950385,
+        0.7229176228671199,
+        0.7299050172882676,
+        0.7351085418280764,
+        0.898802239121968,
+        0.93445666115023,
+        0.9393359179619315,
+    ]
+)
+"""Interior breakpoints of the lost-root case."""
+
+_MISSED_MULTS = np.array([1, 1, 3, 2, 1, 1, 1, 2, 3, 1, 3, 3, 1, 3, 2, 1, 3])
+"""Interior knot multiplicities of the lost-root case."""
+
+_MISSED_COEFFS = np.array(
+    [
+        -1.0006117751615216,
+        0.10262535130347963,
+        -0.48647873649939866,
+        0.46005458592952936,
+        0.4281128136333478,
+        -0.8192377984112155,
+        0.13140957712401866,
+        0.18713602388592093,
+        -0.12555552301405867,
+        0.2942570898257234,
+        1.3492740850774352,
+        0.5886224136013747,
+        -0.2619988438521604,
+        0.23047441055342363,
+        1.9599383087338076,
+        -0.6097700812684572,
+        1.1006657532543598,
+        -0.6559691195441099,
+        -1.5714860195424816,
+        -0.6787185365612848,
+        0.332880561443392,
+        -0.23357475164202018,
+        -0.6903722447753305,
+        -0.7720728746968911,
+        -0.9478203174394234,
+        -1.0478317575078717,
+        -0.6009049657319299,
+        -2.4532962394326048,
+        0.4157017527144879,
+        0.2762701458252833,
+        0.08991282869754379,
+        0.8858012047756563,
+        -0.5933233317599033,
+        -0.01809771231938426,
+        -2.566961781300906,
+        0.1730469906173836,
+    ]
+)
+"""Coefficients of the lost-root case."""
+
+_MISSED_ROOT = 0.611347358111781
+"""The zero the lost-root case used to drop, located by the Bézier route."""
+
+
+def test_regression_repeated_knots_do_not_divide_by_zero() -> None:
+    """Knots piled to within an ulp used to send a span search off the front of the buffer.
+
+    Splitting at a reported zero raised it to multiplicity ``degree`` and dropped everything
+    strictly left of the run, which left one knot of the old spline hanging below the new
+    domain: the remainder was no longer an open knot vector. A Greville abscissa is an
+    average of ``degree`` knots and can round below its own smallest term once they have
+    piled up, and the span search, which walks right from the tracked coefficient index,
+    then returned a span smaller than ``degree``. Boehm's loop indexed backwards past zero
+    from there, read uninitialized memory, and divided by a difference of two equal knots.
+    """
+    knots = _open_knots(
+        _DIVISION_DEGREE,
+        np.concatenate(([0.0], _DIVISION_BREAKS, [1.0])),
+        _DIVISION_MULTS,
+    )
+    spline = _spline(knots, _DIVISION_COEFFS, _DIVISION_DEGREE)
+
+    found = find_roots(spline)
+
+    expected = _bezier_reference_roots(spline, knots)
+    assert found.shape == expected.shape
+    np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+def test_regression_no_root_is_lost_after_a_rejected_sign_change() -> None:
+    """A sign change rejected as already reported used to take its right neighbour with it.
+
+    Splitting leaves the coefficient at the zero pinned, but the next one along is only zero
+    to within the rounding of a hundred knot insertions, which is coarser than the residual
+    threshold; so a spurious sign change survives beside the barrier and tracks straight back
+    to the zero just reported. Rejecting it used to advance the scan past the whole knot run,
+    and the genuine sign change bracketing the next zero sits inside that run.
+    """
+    knots = _open_knots(
+        _MISSED_DEGREE, np.concatenate(([0.0], _MISSED_BREAKS, [1.0])), _MISSED_MULTS
+    )
+    spline = _spline(knots, _MISSED_COEFFS, _MISSED_DEGREE)
+
+    found = find_roots(spline)
+
+    assert float(np.abs(found - _MISSED_ROOT).min()) <= _PARITY_RTOL
+    expected = _bezier_reference_roots(spline, knots)
+    assert found.shape == expected.shape
+    np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+# --- Kernels --------------------------------------------------------------------------
+
+
+def test_knot_average_is_the_greville_abscissa() -> None:
+    """``_knot_average`` averages the ``degree`` knots that follow its coefficient index."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+
+    for index in range(len(knots) - degree - 1):
+        expected = float(np.mean(knots[index + 1 : index + degree + 1]))
+        assert _knot_average(knots, degree, index) == pytest.approx(expected, abs=_EPS)
+
+
+def test_zero_index_needs_a_non_zero_left_neighbour() -> None:
+    """A pinned coefficient is a barrier: no sign change is reported across it."""
+    coeffs = np.array([0.0, -1.0, 1.0, 1.0, -1.0])
+
+    assert _zero_index(coeffs, coeffs.shape[0], 1) == 2
+    assert _zero_index(coeffs, coeffs.shape[0], 3) == 4
+    assert _zero_index(np.array([0.0, 0.0, 1.0]), 3, 1) == -1
+
+
+def test_insert_knot_leaves_the_spline_unchanged() -> None:
+    """Boehm insertion refines the representation without moving the function."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+    num_coeffs = len(knots) - degree - 1
+    coeffs = np.linspace(-1.0, 2.0, num_coeffs) ** 2 - 0.5
+    sample = np.linspace(0.0, 1.0, 37)
+    before = np.asarray(_spline(knots, coeffs, degree).evaluate(sample)).reshape(-1)
+
+    buffer_knots = np.empty(knots.shape[0] + 1)
+    buffer_knots[: knots.shape[0]] = knots
+    buffer_coeffs = np.empty(num_coeffs + 1)
+    buffer_coeffs[:num_coeffs] = coeffs
+    point = 0.375
+    span = int(np.searchsorted(knots, point, side="right") - 1)
+    _insert_knot(buffer_knots, buffer_coeffs, num_coeffs, degree, point, span)
+
+    after = np.asarray(
+        _spline(buffer_knots, buffer_coeffs, degree).evaluate(sample), dtype=np.float64
+    ).reshape(-1)
+    np.testing.assert_allclose(after, before, rtol=0.0, atol=16 * _EPS)
+
+
+def test_split_at_root_leaves_an_open_knot_vector() -> None:
+    """The split raises the zero to multiplicity ``degree + 1`` and clamps the remainder.
+
+    This is the invariant that keeps every later span search inside the buffer: after the
+    caller shifts both arrays down by ``offset``, the knot vector is open again, this time
+    on ``[root, end]``, exactly as the original input was.
+    """
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+    num_coeffs = coeffs.shape[0]
+    capacity = num_coeffs + 4 * (degree + 1)
+    buffer_coeffs = np.empty(capacity)
+    buffer_coeffs[:num_coeffs] = coeffs
+    buffer_knots = np.empty(capacity + degree + 1)
+    buffer_knots[: knots.shape[0]] = knots
+
+    root = 0.5
+    num_live, offset = _split_at_root(
+        buffer_knots, buffer_coeffs, num_coeffs, degree, root, _zero_tol(coeffs, degree)
+    )
+
+    assert np.all(buffer_knots[offset : offset + degree + 1] == root)
+    assert buffer_knots[offset - 1] < root
+    assert buffer_coeffs[offset] == 0.0
+    assert num_live == num_coeffs + degree + 1  # 0.5 is not a breakpoint here
+
+
+def test_is_zero_index_rejects_an_index_outside_the_polygon() -> None:
+    """The tracker steps its index past the end, so the bound check has to hold there."""
+    coeffs = np.array([-1.0, 1.0, 2.0])
+
+    assert _is_zero_index(coeffs, 3, 1)
+    assert not _is_zero_index(coeffs, 3, 0)
+    assert not _is_zero_index(coeffs, 3, 3)
+
+
+def test_merge_roots_on_an_empty_input() -> None:
+    """No roots in, no roots out, and a buffer that is still safe to index."""
+    merged, count = _merge_roots(np.empty(0), np.empty(0))
+
+    assert count == 0
+    assert merged.shape == (1,)
+
+
+def test_merge_roots_collapses_a_run_but_not_a_gap() -> None:
+    """Neighbours within the larger of their two radii become one root, at the midpoint."""
+    roots = np.array([0.1, 0.1 + 1e-9, 0.5, 0.9])
+    radii = np.array([1e-8, 1e-8, 1e-12, 1e-12])
+
+    merged, count = _merge_roots(roots, radii)
+
+    assert count == 3
+    np.testing.assert_allclose(merged[:count], [0.1 + 0.5e-9, 0.5, 0.9], rtol=0.0, atol=1e-15)
+
+
+def test_kernel_reports_a_zero_whose_budget_ran_out() -> None:
+    """Cutting the insertion budget to one is reported rather than silently accepted."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+
+    _, _, truncated = _morken_reimers_roots(
+        knots, degree, coeffs, 1e-15, _zero_tol(coeffs, degree), 1
+    )
+
+    assert truncated > 0
+
+
+def test_budget_exhaustion_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Layer 2 turns an exhausted budget into a warning naming how many zeros it hit."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+    monkeypatch.setattr(_bspline_roots, "_max_insertions", lambda _degree: 1)
+
+    with pytest.warns(RuntimeWarning, match="insertion budget"):
+        find_roots(_spline(knots, coeffs, degree))
+
+
+def test_insertion_budget_grows_with_degree() -> None:
+    """The budget is degree-aware: convergence is quadratic per ``degree - 1`` insertions."""
+    assert _max_insertions(1) == 64
+    assert _max_insertions(25) > 4 * _max_insertions(1) // 2
+    assert _max_insertions(5) > _max_insertions(3) > _max_insertions(1)
+
+
+# --- Public surface -------------------------------------------------------------------
+
+
+def test_returned_roots_are_sorted_read_only_float64() -> None:
+    """The result follows the same contract as every other array pantr hands out."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+
+    found = find_roots(_spline(knots, coeffs, degree))
+
+    assert found.dtype == np.float64
+    assert not found.flags.writeable
+    assert np.all(np.diff(found) > 0.0)
+
+
+def test_rational_spline_reports_the_zeros_of_its_numerator() -> None:
+    """With positive weights the zeros of the mapping are the zeros of the numerator."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+    numerator = _polynomial_coefficients(knots, degree, (0.3, 0.7))
+    weights = np.linspace(1.0, 3.0, numerator.shape[0])
+    # Control points are homogeneous, so the first slot holds the numerator spline itself:
+    # the mapping is that spline over the weight spline, and the weights being positive its
+    # zeros are the numerator's.
+    control = np.stack((numerator, weights), axis=1)
+    space = BsplineSpace([BsplineSpace1D(knots, degree, snap_knots=False)])
+
+    found = find_roots(Bspline(space, control, is_rational=True))
+
+    np.testing.assert_allclose(found, [0.3, 0.7], rtol=0.0, atol=_ROOT_ULPS * _EPS)
+
+
+def test_float32_spline_is_solved_in_float64() -> None:
+    """A float32 spline is promoted exactly; only the tolerances stay at float32 level."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.25, 0.5, 0.75))
+
+    found = find_roots(_spline(knots, coeffs, degree, dtype=np.float32))
+
+    assert found.dtype == np.float64
+    np.testing.assert_allclose(found, [0.25, 0.5, 0.75], rtol=0.0, atol=1e-6)
+
+
+def test_a_looser_tolerance_still_finds_every_root() -> None:
+    """``tol`` trades parametric accuracy for insertions, never a root."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+
+    found = find_roots(_spline(knots, coeffs, degree), tol=1e-8)
+
+    np.testing.assert_allclose(found, [0.2, 0.5, 0.9], rtol=0.0, atol=1e-7)
+
+
+def test_unclamped_spline_is_converted_before_solving() -> None:
+    """The method needs an open knot vector; a uniform one is converted, not rejected."""
+    degree = 2
+    knots = np.linspace(-0.4, 1.4, 10)
+    coeffs = np.array([1.0, 0.6, -0.4, -0.8, 0.2, 1.0, 1.4])
+    spline = _spline(knots, coeffs, degree)
+
+    found = find_roots(spline)
+
+    values = np.abs(np.asarray(spline.evaluate(found), dtype=np.float64).reshape(-1))
+    assert found.size > 0
+    assert float(values.max()) <= 1e-12
+
+
+# --- Validation -----------------------------------------------------------------------
+
+
+def test_rejects_a_non_bspline() -> None:
+    """The argument has to be a B-spline, and the message says what arrived instead."""
+    with pytest.raises(TypeError, match="Expected a Bspline"):
+        find_roots(np.array([1.0, -1.0]))  # type: ignore[arg-type]
+
+
+def test_rejects_a_multivariate_spline() -> None:
+    """Root finding is one-dimensional: a surface has a zero set, not a set of roots."""
+    space = BsplineSpace([BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)] * 2)
+    spline = Bspline(space, np.arange(4.0).reshape(2, 2, 1) - 1.5)
+
+    with pytest.raises(ValueError, match="univariate"):
+        find_roots(spline)
+
+
+def test_rejects_a_vector_valued_spline() -> None:
+    """A curve in the plane has no zeros in this sense; the caller must pick a component."""
+    space = BsplineSpace([BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)])
+    spline = Bspline(space, np.array([[-1.0, 1.0], [1.0, 2.0]]))
+
+    with pytest.raises(ValueError, match="scalar valued"):
+        find_roots(spline)
+
+
+def test_rejects_a_degree_zero_spline() -> None:
+    """A piecewise constant vanishes on whole intervals or nowhere, never at points."""
+    space = BsplineSpace([BsplineSpace1D(np.array([0.0, 0.5, 1.0]), 0)])
+    spline = Bspline(space, np.array([[-1.0], [1.0]]))
+
+    with pytest.raises(ValueError, match="degree >= 1"):
+        find_roots(spline)
+
+
+def test_rejects_a_non_positive_weight() -> None:
+    """Only positive weights make the numerator's zeros the mapping's zeros."""
+    degree = 1
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 3))
+    control = np.array([[-1.0, 1.0], [0.5, 0.0], [1.0, 2.0]])
+    space = BsplineSpace([BsplineSpace1D(knots, degree, snap_knots=False)])
+
+    with pytest.raises(ValueError, match="strictly positive weights"):
+        find_roots(Bspline(space, control, is_rational=True))
+
+
+def test_rejects_an_identically_zero_spline() -> None:
+    """Every point of the domain would be a root, so there is nothing to report."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 4))
+
+    with pytest.raises(ValueError, match="identically zero"):
+        find_roots(_spline(knots, np.zeros(len(knots) - degree - 1), degree))
+
+
+def test_rejects_a_spline_that_vanishes_on_a_knot_interval() -> None:
+    """A disconnected spline breaks the variation-diminishing bound the method rests on."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 8))
+    coeffs = np.zeros(len(knots) - degree - 1)
+    coeffs[-2:] = [1.0, 2.0]
+
+    with pytest.raises(ValueError, match="vanishes identically"):
+        find_roots(_spline(knots, coeffs, degree))
+
+
+@pytest.mark.parametrize("tol", [0.0, -1e-12])
+def test_rejects_a_non_positive_tolerance(tol: float) -> None:
+    """A tolerance that is not positive would make the stopping rule unreachable."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 4))
+    coeffs = _polynomial_coefficients(knots, degree, (0.3, 0.7))
+
+    with pytest.raises(ValueError, match="tol must be positive"):
+        find_roots(_spline(knots, coeffs, degree), tol=tol)

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -44,6 +44,18 @@ below is ``2.3e-13`` at degree 5 on a domain around ``1e3``, that is two ulp of 
 coordinate, so 64 ulp leaves a factor of 32.
 """
 
+_MULTIPLE_ROOT_SAFETY: float = 2.0
+"""
+Safety factor on the half-width of the interval a multiple root cannot be located inside.
+
+That half-width is the physical limit, not an estimate, so asserting against it bare leaves
+no margin at all and the assertion turns on where the iteration happens to stop. It stops
+somewhere different on every build: the same double root lands at ``2.3e-8`` under one numpy
+and at ``3.1e-8`` under another, a 40 % spread with no bug behind it. Two absorbs that, and
+still fails on anything an order of magnitude out. Measured margins with it: 16 times at
+multiplicities two and three, 9.5 at four, 3.3 for a double root beside a simple one.
+"""
+
 _PARITY_RTOL: float = 1e-10
 """
 Agreement required between this method and extraction plus Bernstein root finding.
@@ -198,21 +210,30 @@ def test_a_multiple_root_is_reported_once(multiplicity: int) -> None:
 
     found = find_roots(_spline(knots, coeffs, multiplicity))
 
+    half_width = _zero_tol(coeffs, multiplicity) ** (1.0 / multiplicity)
     assert found.shape == (1,)
-    assert abs(found[0] - 0.5) <= _zero_tol(coeffs, multiplicity) ** (1.0 / multiplicity)
+    assert abs(found[0] - 0.5) <= _MULTIPLE_ROOT_SAFETY * half_width
 
 
 def test_a_simple_and_a_double_root_stay_separate() -> None:
-    """Merging collapses a repeated report of one zero, never two distinct zeros."""
+    """Merging collapses a repeated report of one zero, never two distinct zeros.
+
+    The double root's accuracy comes from its own curvature, not from a generic one: for
+    ``(x - 1/4) (x - 1/2) ** 2`` the second derivative at ``1/2`` is ``2 * (1/2 - 1/4)``,
+    so the interval where the spline is indistinguishable from zero has half-width
+    ``sqrt(2 * zero_tol / 0.5)``, four times wider than for ``(x - 1/2) ** 2``.
+    """
     degree = 3
     knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
     coeffs = _polynomial_coefficients(knots, degree, (0.25, 0.5, 0.5))
 
     found = find_roots(_spline(knots, coeffs, degree))
 
+    second_derivative = 2.0 * (0.5 - 0.25)
+    half_width = math.sqrt(2.0 * _zero_tol(coeffs, degree) / second_derivative)
     assert found.shape == (2,)
     assert abs(found[0] - 0.25) <= _ROOT_ULPS * _EPS
-    assert abs(found[1] - 0.5) <= _zero_tol(coeffs, degree) ** 0.5
+    assert abs(found[1] - 0.5) <= _MULTIPLE_ROOT_SAFETY * half_width
 
 
 def test_a_root_sitting_exactly_on_an_interior_knot() -> None:


### PR DESCRIPTION
## Context

`pantr.bspline.find_roots(bspline, *, tol=None)` returns every zero of a scalar univariate
B-spline, working on the spline's own knot vector: the zero of the control polygon is
inserted as a new knot, over and over, until the iterates stagnate. Every arithmetic
operation is a convex combination (Boehm insertion), the iteration needs no starting value,
and it converges for any spline. Compared with `to_beziers()` plus `pantr.bezier.find_roots`
there is no extraction, no stitching of roots at segment boundaries, and a zero sitting
exactly on a knot needs no special case.

Named to match the sibling package, which already gives root finding the bare name
(`pantr.bezier.find_roots`) while its approximation functions carry a `_bezier` suffix.

Layering as elsewhere: `find_roots` (Layer 1), validation and tolerance derivation in
`_bspline_roots.py` (Layer 2), Numba kernels in `_bspline_roots_core.py` (Layer 3).

## What the ticket got wrong

Nine claims, measured before implementing. As with the ten tickets before it, the
specification was precise and the numbers in it were not.

1. **"Asymptotically quadratic" is per `degree - 1` insertions, not per insertion**
   (Mørken–Reimers, Theorem 22). Sampling the error every `d - 1` insertions gives an order
   of **2.14** and **2.03**; per single insertion it oscillates around `2 ** (1/(d-1))`,
   measured **1.19** at degree 5. This is what sets the insertion budget.

2. **The prescribed stopping rule `|x_{k+1} - x_k| <= tol` is absolute, so on a domain
   around 1e6 it sits below one ulp (1.2e-10) and can never fire**; the iteration then runs
   until the knot interval collapses. The paper's rule is relative. Implemented as
   `spread(last degree iterates) <= tol * max(|t_a|, |t_{a+degree}|, domain_length)`. The
   domain-length floor is added here: without it a fine knot vector near the origin makes
   the criterion unreachable in the other direction.

3. **The ticket's alternative rule, "the bracketing knot interval has width <= tol",
   can never fire either.** Measured, the active knot bracket converges to a *positive*
   limit (**0.700** at degrees 3 and 5), because one endpoint freezes at `t_+` while the
   rest pile up at the zero (their Lemmas 8 and 16). The Greville gap likewise converges to
   `(t_+ - t_-) / degree`, not to zero.

4. **The prescribed cap of 64 insertions is degree-blind and too small.** One simple zero at
   degree 25 needs **103** insertions, and the worst over random splines was **173**. The
   budget is `64 + 8 * (degree - 1)`, that is 256 at degree 25: a 53-insertion
   bisection-grade linear phase plus six quadratic steps of `degree - 1` insertions each.

5. **The prescribed residual bound `coeff_scale * (p + 1) * 8 * eps` is violated**, measured
   **1.5e-13** against a bound of **7.1e-15** on a domain at 1e3. It omits the term that
   dominates away from the origin. The bound that holds, and that the tests assert, is
   `coeff_scale * (degree + 1) * 4 * eps + |f'| * 2 * tol * max(|x|, L)`: a root is located
   only to the parametric resolution the stopping rule stops at. Writing `eps` there instead
   of `tol` understates it by the factor between them (4.5 for the default
   `get_strict(float64)`), which goes unnoticed on the unit domain and **fails by 6.8 times
   on a domain around 1e6**. Worst ratio against the corrected bound, over five scales:
   **0.91**.

6. **"A run of `>= p+1` zero coefficients" is not the disconnectedness test.** What matters
   is a run of `degree + 1` zeros *aligned with a non-empty knot interval*. Implemented that
   way; a spline that vanishes identically on an interval is rejected, since its zero set is
   not a set of isolated points.

7. **Zeros of even multiplicity cannot be certified from the control polygon at all** — they
   have no sign change in the limit — so they are reported through the residual test only.
   `pantr.bezier.find_roots` does report them (measured), so parity with the sibling API
   required implementing this rather than declaring them out of scope.

8. Also measured: **`pantr.bezier.find_roots` reports a double root twice**
   (`0.5` and `0.499999995786` for `(x - 1/2)^2 (x - 3/4)`), so its deduplication leaks.
   Pre-existing and out of scope here; worth its own look.

9. `lepard` has its own `find_roots` in `lepard.implicit.algoim._roots_core`. Different
   namespace, **no collision** with `pantr.bspline.find_roots`.

## Two defects found and fixed while validating

Both appear only with repeated interior knots, which is why the paper's own examples and a
first pass over simple knot vectors miss them: with simple interior knots the two routes
agreed on 160 of 160 random splines, while multiplicities brought failures at about one per
cent. Both carry a regression test with the exact spline that triggered them.

- **A division by zero inside Boehm insertion.** Splitting at a reported zero raised it to
  multiplicity `degree` and dropped everything strictly left of the run, which left one knot
  of the old spline hanging below the new domain: the remainder was no longer an open knot
  vector. A Greville abscissa is an average of `degree` knots and can round below its own
  smallest term once they have piled up to within a few ulp, and the span search, which
  walks right from the tracked coefficient index, then returned a span below `degree`.
  Boehm's loop indexed backwards past zero from there and read uninitialized memory. The
  split now raises the zero to multiplicity **`degree + 1`**, so the remainder is clamped and
  every later span search is structurally inside the buffer; the iterate is also clamped
  into the bracket the theory places it in.

- **A lost root after a rejected sign change.** Splitting pins the coefficient at the zero,
  but its right neighbour is only zero to within the rounding of a hundred knot insertions,
  which is coarser than the residual threshold (measured **2.6e-14** against a threshold of
  9.1e-15). So a spurious sign change survives beside the barrier and tracks straight back to
  the zero just reported. Rejecting it used to advance the scan past the whole knot run, and
  the genuine sign change bracketing the next zero sits inside that run. The scan now
  advances by exactly one index, which is already enough for the sweep to terminate.

- One more, found by the tests: **a zero of multiplicity three or more was reported twice.**
  The merge radius was capped at the value for multiplicity two, `L * sqrt(zero_tol /
  coeff_scale)`, while a zero of multiplicity `m` has half-width `(m! * zero_tol /
  |f^(m)|) ** (1/m)`. The cap now uses the highest multiplicity the space admits,
  `L * (degree! * zero_tol / coeff_scale) ** (1/degree)`. A triple root came back as
  `0.499997` and `0.500001` before, and as one root after.

## Verification

- **4300 random splines** with repeated interior knots, degrees 1 to 9, on domains at the
  origin and at 1e3, 1e6, `[-5, 2]` and 1e-3: the same zero set as extraction plus the
  Bernstein solver, every time. Worst positional disagreement `5.6e-16` on a unit domain.
- **Polynomials with analytically known roots**, built through their blossom from elementary
  symmetric polynomials (an oracle that shares nothing with the method under test): degrees
  1 to 5, recovered to within 2 ulp of the coordinate scale.
- Multiplicities 2, 3 and 4 each collapse to one root, accurate to `zero_tol ** (1/m)`,
  which is the accuracy the problem allows rather than a safety factor.
- Residual bound above, at five scales.
- Working buffers reach **29 %** of their capacity in the worst case measured, so the
  insertion budget rather than the memory is what binds.
- Coverage of the two new modules: **100 %** and **99 %**; the one uncovered branch is the
  buffer backstop, which the capacity is sized to make unreachable.
- Benchmark, cubic with 1000 elements and 101 zeros: **1.1 ms** against **9.3 ms** for
  extraction plus the Bernstein solver, so **8x**.

## Notes

- A polynomial with roots away from the origin cannot be built in the power basis at all:
  at degree 5 on a domain around 1e3 the construction cancels terms of order 1e15 down to a
  result of order 1e-5 and loses every root. The tests build on the unit domain and move the
  *knots*, which is exact.
- No changelog entry, matching the ten merged PRs of this sweep; the public additions
  (`boundary_dofs`, `Bspline.locate`, `prolongation_to_sparse`, `find_roots`) are worth
  batching into one entry before the next release.

Closes #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
