### PR TITLE
feat(bezier,bspline): L2-optimal degree reduction with endpoint interpolation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `Bezier.degree_reduction_error`: the exact $L^2$ norm of the error
+  `Bezier.reduce_degree` would introduce, computed through the Bernstein mass
+  matrix rather than by sampling.
+
+### Changed
+- `Bezier.reduce_degree` and `Bspline.reduce_degree` now interpolate the
+  endpoints of every segment: among the lower-degree polynomials that reproduce
+  the original at both ends of the parametric domain, the result is the closest
+  in $L^2$. Reduced control points therefore differ from previous releases on
+  any reduction that is not exact. In exchange, adjacent B-spline segments meet
+  at breakpoints bit for bit and the previous averaging of the shared control
+  point — which moved *both* segments off their own optima — is gone. Without
+  the endpoint conditions the $L^2$ error would be a factor 1.1 (degree 16) to
+  4.5 (reduction to a straight line) smaller. Reduction to degree 0 keeps no
+  endpoint condition and still returns the mean of the control points.
+
+### Fixed
+- `Bspline.reduce_degree` wrote past the end of its output buffers whenever the
+  reduced Bézier form needed more control points than `len(knots)` allowed —
+  from 13 elements on at degree 4, 8 at degree 5, 5 at degree 8, on the open,
+  periodic and tensor-product paths alike. Unchecked under `nopython`, it
+  surfaced as a control-point/basis-count mismatch from the `Bspline`
+  constructor.
+
 ## 0.6.0 (2026-06-24)
 
 ### Added

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -14,6 +14,7 @@ from ._bezier_compose import _compose_bezier
 from ._bezier_degree import (
     _degree_elevate_bezier,
     _degree_reduce_bezier,
+    _degree_reduction_l2_error,
     _minimize_degree_bezier,
 )
 from ._bezier_derivative import _derivative_bezier
@@ -310,15 +311,26 @@ class Bezier:
     # ------------------------------------------------------------------
 
     def reduce_degree(self, degree_decrements: int | Sequence[int]) -> Bezier:
-        """Reduce the polynomial degree of the Bézier via least-squares approximation.
+        r"""Reduce the polynomial degree of the Bézier, interpolating the endpoints.
 
         Creates a new Bézier whose degree is lower by the requested amount in
-        each parametric direction.  The reduction minimises the squared error
-        under the Bernstein degree-elevation matrix using QR factorisation with
-        Givens rotations.
+        each parametric direction.  Among the polynomials of the lower degree
+        that reproduce this one at the ends of the parametric domain, the result
+        is the one closest in :math:`L^2([0, 1]^{\dim})`; the endpoint values are
+        reproduced exactly, bit for bit.
 
         Unlike :meth:`elevate_degree`, this operation is **not exact** in
-        general: the result is an approximation of the original mapping.
+        general: the result is an approximation of the original mapping.  Use
+        :meth:`degree_reduction_error` to find out how close it is before
+        committing to it.
+
+        The endpoint conditions cost accuracy in the interior — dropping them
+        would lower the :math:`L^2` error by a factor between 1.1 (degree 16) and
+        4.5 (reduction to a straight line) — and buy an approximation that joins
+        its neighbours exactly, which is what makes the B-spline case work.  A
+        reduction to degree 0 cannot honour two conditions with one coefficient
+        and returns the plain :math:`L^2` projection, the mean of the control
+        points.
 
         Args:
             degree_decrements (int | Sequence[int]): Number of degrees to
@@ -328,6 +340,65 @@ class Bezier:
 
         Returns:
             Bezier: A new Bézier with reduced degrees.
+
+        Raises:
+            ValueError: If any degree decrement is negative.
+            ValueError: If all degree decrements are zero.
+            ValueError: If the number of decrements does not match the dimension.
+            ValueError: If any decrement exceeds the current degree in that
+                direction.
+        """
+        return _degree_reduce_bezier(self, self._checked_decrements(degree_decrements))
+
+    def degree_reduction_error(self, degree_decrements: int | Sequence[int]) -> float:
+        r"""Compute the :math:`L^2` error that :meth:`reduce_degree` would introduce.
+
+        The value is exact rather than an estimate: it is
+        :math:`\lVert f - g \rVert_{L^2}` for the reduction *g* this Bézier would
+        produce, obtained from the Bernstein mass matrix rather than by sampling.
+        Rank components are combined in the Euclidean sense, and for a rational
+        Bézier the norm is taken over the homogeneous coefficients, not over the
+        projected mapping.
+
+        The convex-hull bound on the coefficient residual is deliberately not
+        offered instead: measured against the true supremum of the error it runs
+        from 1.3 to 1600 times too large, the ratio growing with degree, so it is
+        of little use as a stopping criterion.
+
+        Args:
+            degree_decrements (int | Sequence[int]): Number of degrees to
+                reduce, as in :meth:`reduce_degree`.
+
+        Returns:
+            float: The :math:`L^2` norm of the error, in the units of the
+            control points.
+
+        Raises:
+            ValueError: If any degree decrement is negative.
+            ValueError: If all degree decrements are zero.
+            ValueError: If the number of decrements does not match the dimension.
+            ValueError: If any decrement exceeds the current degree in that
+                direction.
+
+        Example:
+            >>> import numpy as np
+            >>> from pantr.bezier import Bezier
+            >>> bezier = Bezier(np.array([[0.0], [1.0], [0.0], [1.0]]))
+            >>> round(bezier.degree_reduction_error(1), 6)
+            0.138013
+        """
+        decrements = self._checked_decrements(degree_decrements)
+        return _degree_reduction_l2_error(self, decrements)
+
+    def _checked_decrements(self, degree_decrements: int | Sequence[int]) -> tuple[int, ...]:
+        """Normalise and validate a degree-decrement argument.
+
+        Args:
+            degree_decrements (int | Sequence[int]): Decrement for every
+                direction, or one per direction.
+
+        Returns:
+            tuple[int, ...]: One decrement per parametric direction.
 
         Raises:
             ValueError: If any degree decrement is negative.
@@ -360,7 +431,7 @@ class Bezier:
                     f"current degree ({self.degree[d]})."
                 )
 
-        return _degree_reduce_bezier(self, decrements)
+        return decrements
 
     def minimize_degree(self, tol: float | None = None) -> Bezier:
         """Find the lowest degree that preserves accuracy within tolerance.

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -1,8 +1,8 @@
 """Numba-compiled kernels for Bézier operations.
 
 Provides fused evaluation kernels that compute Bernstein basis values and
-contract them with control points in a single pass, plus degree elevation
-and degree reduction kernels.
+contract them with control points in a single pass, plus a degree elevation
+kernel.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
@@ -304,136 +304,6 @@ def _degree_elevate_bezier_1d_core(
     return new_ctrl
 
 
-@nb_jit(nopython=True, cache=True)
-def _degree_reduce_bezier_1d_core(
-    degree: int,
-    ctrl: npt.NDArray[np.float32 | np.float64],
-    degree_decrement: int,
-) -> npt.NDArray[np.float32 | np.float64]:
-    r"""Degree-reduce a single Bézier segment via least-squares approximation.
-
-    Bernstein degree elevation from degree ``P-1`` to ``P`` maps the ``P``
-    control points :math:`q_0,\dots,q_{P-1}` to ``P+1`` control points via
-
-    .. math::
-
-        c_k = \frac{k}{P}\,q_{k-1} + \Bigl(1 - \frac{k}{P}\Bigr)\,q_k,
-        \qquad k = 0,\dots,P,
-
-    (with the out-of-range terms dropped at the endpoints).  In matrix form
-    :math:`c = M q` where :math:`M` is the ``(P+1) x P`` lower-bidiagonal
-    elevation matrix with diagonal :math:`M_{kk} = 1 - k/P` and sub-diagonal
-    :math:`M_{k+1,k} = (k+1)/P`.  Degree reduction recovers ``q`` as the
-    least-squares solution of the overdetermined system :math:`M q = c`.
-
-    The solve follows the standard bidiagonal QR scheme (Golub & Van Loan,
-    *Matrix Computations*, 4th ed., sections 5.1-5.2): a sweep of Givens rotations
-    ``G_0, ..., G_{P-1}`` annihilates the sub-diagonal one column at a time,
-    yielding an upper-bidiagonal :math:`R` (the same rotations are applied to
-    the right-hand side), after which back-substitution returns ``q``.  Each
-    rotation introduces a single fill-in entry on the super-diagonal.  The
-    cost is :math:`O(P)` per right-hand side (rank component).
-
-    When ``degree_decrement > 1``, the single-step reduction is applied
-    iteratively.
-
-    Args:
-        degree (int): Current polynomial degree (``p >= 1``).
-        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
-            ``(p+1, rank)``.
-        degree_decrement (int): Number of degrees to remove (``1 <= t <= p``).
-
-    Returns:
-        npt.NDArray[np.float32 | np.float64]: Reduced control points of shape
-        ``(p - t + 1, rank)``.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_bezier_degree._degree_reduce_bezier`
-        instead.
-    """
-    rank = ctrl.shape[1]
-    cur = np.empty((ctrl.shape[0], rank), dtype=ctrl.dtype)
-    for i in range(ctrl.shape[0]):
-        for r in range(rank):
-            cur[i, r] = ctrl[i, r]
-
-    cur_deg = degree
-
-    for _step in range(degree_decrement):
-        p = cur_deg  # reduce from degree p (P+1 points) to degree p-1 (p points)
-
-        nxt = np.empty((p, rank), dtype=ctrl.dtype)
-
-        # Triangular factor R of the QR factorisation of the elevation matrix
-        # M (size (p+1) x p).  R is upper bidiagonal: r_diag is its main
-        # diagonal, r_super the fill-in super-diagonal produced by the Givens
-        # sweep.  cos/sin store each rotation so the same orthogonal transform
-        # can be replayed on every right-hand side.
-        r_diag = np.empty(p, dtype=np.float64)
-        r_super = np.empty(p, dtype=np.float64)  # r_super[p-1] is never read
-        cos = np.empty(p, dtype=np.float64)
-        sin = np.empty(p, dtype=np.float64)
-        rhs = np.empty(p + 1, dtype=np.float64)
-
-        inv_p = 1.0 / np.float64(p)
-
-        # --- QR sweep on M (independent of the right-hand side) ---------------
-        # Column k holds M[k, k] = 1 - k/p (carried in `head`, mutated by the
-        # previous rotation) and M[k+1, k] = (k+1)/p (`tail`, the entry G_k
-        # annihilates).  `tail` is always > 0, so the magnitude-scaled Givens
-        # of G&VL Alg. 5.1.3 reduces to two branches (no `tail == 0` case).
-        next_diag = 1.0  # M[0, 0]
-        for k in range(p):
-            head = next_diag
-            tail = np.float64(k + 1) * inv_p
-
-            if abs(tail) > abs(head):
-                ratio = head / tail
-                sn = 1.0 / np.sqrt(1.0 + ratio * ratio)
-                cs = ratio * sn
-                rho = tail / sn
-            else:
-                ratio = tail / head
-                cs = 1.0 / np.sqrt(1.0 + ratio * ratio)
-                sn = ratio * cs
-                rho = head / cs
-
-            cos[k] = cs
-            sin[k] = sn
-            r_diag[k] = rho
-
-            if k + 1 < p:
-                # The rotation spreads M[k+1, k+1] = 1 - (k+1)/p onto the
-                # super-diagonal of R and into the diagonal carried to column k+1.
-                below = 1.0 - np.float64(k + 1) * inv_p
-                r_super[k] = sn * below
-                next_diag = cs * below
-
-        # --- Apply Q^T to each right-hand side and back-substitute -----------
-        for r in range(rank):
-            for i in range(p + 1):
-                rhs[i] = np.float64(cur[i, r])
-
-            for k in range(p):
-                cs = cos[k]
-                sn = sin[k]
-                top = rhs[k]
-                bot = rhs[k + 1]
-                rhs[k] = cs * top + sn * bot
-                rhs[k + 1] = -sn * top + cs * bot
-
-            nxt[p - 1, r] = ctrl.dtype.type(rhs[p - 1] / r_diag[p - 1])
-            for k in range(p - 2, -1, -1):
-                solved = (rhs[k] - r_super[k] * np.float64(nxt[k + 1, r])) / r_diag[k]
-                nxt[k, r] = ctrl.dtype.type(solved)
-
-        cur = nxt
-        cur_deg = p - 1
-
-    return cur
-
-
 @nb_jit(
     nopython=True,
     cache=True,
@@ -690,7 +560,6 @@ def _warmup_numba_functions() -> None:
     _evaluate_bezier_1d_core(ctrl_dummy, pts_dummy, out_eval_dummy)
     _evaluate_bezier_deriv_1d_core(ctrl_dummy, pts_dummy, 0, out_deriv_dummy)
     _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1)
-    _degree_reduce_bezier_1d_core(2, ctrl_dummy, 1)
     _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)
     _split_bezier_1d_core(ctrl_dummy, 0.5, out_split_dummy, out_split_dummy.copy())
     _restrict_bezier_1d_core(ctrl_dummy, 0.2, 0.8, out_split_dummy)

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -2,24 +2,37 @@
 
 This module provides :func:`_degree_elevate_bezier`, which raises the polynomial
 degree of a Bézier in one or more parametric directions while preserving the
-same geometric mapping, :func:`_degree_reduce_bezier`, which computes a
-least-squares degree-reduced approximation, and :func:`_minimize_degree_bezier`,
-which automatically finds the lowest degree that preserves accuracy.
+same geometric mapping, :func:`_degree_reduce_bezier`, which computes the
+:math:`L^2`-optimal degree-reduced approximation that interpolates the segment
+endpoints, and :func:`_minimize_degree_bezier`, which automatically finds the
+lowest degree that preserves accuracy.
+
+Reduction is driven by a *reduction operator* :math:`R`, a dense
+``(q + 1) x (p + 1)`` matrix depending only on the degree pair, so that the
+reduced control points are ``R @ ctrl``.  The operator is assembled in exact
+rational arithmetic and rounded to ``float64`` once; see
+:func:`_interpolating_reduction_operator` for why.
 """
 
 from __future__ import annotations
 
+import functools
 import math
+from fractions import Fraction
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bezier_core import _degree_elevate_bezier_1d_core, _degree_reduce_bezier_1d_core
+from ..bspline._bspline_degree_core import _apply_reduction_operator
+from ._bezier_core import _degree_elevate_bezier_1d_core
 
 if TYPE_CHECKING:
     from . import Bezier
+
+_ExactMatrix = list[list[Fraction]]
+"""A matrix of exact rationals, used to assemble reduction operators."""
 
 _AUTO_REDUCTION_TOL_FACTOR: float = 1.0e3
 """Default relative tolerance for automatic degree reduction, in units of eps.
@@ -84,15 +97,244 @@ def _degree_elevate_bezier(
     return BezierCls(ctrl, is_rational=bezier.is_rational)
 
 
+def _bernstein_gram_exact(degree: int) -> _ExactMatrix:
+    r"""Build the degree-``n`` Bernstein Gram matrix as exact rationals.
+
+    Same closed form as :func:`_bernstein_gram_matrix_1d`, evaluated over
+    :class:`~fractions.Fraction` so that the assembly of a reduction operator
+    carries no rounding at all.
+
+    Args:
+        degree (int): Polynomial degree ``n`` (``>= 0``).
+
+    Returns:
+        _ExactMatrix: Symmetric ``(n + 1, n + 1)`` matrix of exact rationals.
+    """
+    n = degree
+    return [
+        [
+            Fraction(
+                math.comb(n, i) * math.comb(n, j),
+                math.comb(2 * n, i + j) * (2 * n + 1),
+            )
+            for j in range(n + 1)
+        ]
+        for i in range(n + 1)
+    ]
+
+
+def _elevation_matrix_exact(degree: int, increment: int) -> _ExactMatrix:
+    r"""Build the degree-elevation matrix as exact rationals.
+
+    Elevation from degree :math:`q` to :math:`p = q + t` maps Bernstein
+    coefficients by :math:`c = M \hat q` with
+
+    .. math::
+
+        M_{ij} = \frac{\binom{q}{j}\binom{t}{i-j}}{\binom{p}{i}},
+        \qquad \max(0, i - t) \le j \le \min(q, i),
+
+    and zero elsewhere.  This is the closed form of the ``bezalfs`` coefficients
+    that :func:`~pantr.bezier._bezier_core._degree_elevate_bezier_1d_core`
+    computes, assembled here as a matrix rather than applied.
+
+    Args:
+        degree (int): Starting degree ``q`` (``>= 0``).
+        increment (int): Number of degrees to add, ``t >= 1``.
+
+    Returns:
+        _ExactMatrix: ``(q + t + 1, q + 1)`` matrix of exact rationals.
+    """
+    q = degree
+    t = increment
+    p = q + t
+    return [
+        [
+            Fraction(math.comb(q, j) * math.comb(t, i - j), math.comb(p, i))
+            if max(0, i - t) <= j <= min(q, i)
+            else Fraction(0)
+            for j in range(q + 1)
+        ]
+        for i in range(p + 1)
+    ]
+
+
+def _solve_exact(matrix: _ExactMatrix, rhs: _ExactMatrix) -> _ExactMatrix:
+    """Solve ``matrix @ x = rhs`` in exact rational arithmetic.
+
+    Gauss-Jordan elimination with partial pivoting.  Pivoting is not needed for
+    stability here — the arithmetic is exact — only to step over a zero pivot.
+
+    Args:
+        matrix (_ExactMatrix): Square ``(n, n)`` non-singular matrix.
+        rhs (_ExactMatrix): Right-hand sides, ``(n, k)``.
+
+    Returns:
+        _ExactMatrix: The solution ``(n, k)``.
+    """
+    n = len(matrix)
+    aug = [list(matrix[i]) + list(rhs[i]) for i in range(n)]
+
+    for col in range(n):
+        pivot_row = max(range(col, n), key=lambda row: abs(aug[row][col]))
+        aug[col], aug[pivot_row] = aug[pivot_row], aug[col]
+        inv_pivot = 1 / aug[col][col]
+        aug[col] = [value * inv_pivot for value in aug[col]]
+        for row in range(n):
+            if row != col and aug[row][col]:
+                factor = aug[row][col]
+                aug[row] = [a - factor * b for a, b in zip(aug[row], aug[col], strict=True)]
+
+    return [row[n:] for row in aug]
+
+
+@functools.lru_cache(maxsize=64)
+def _l2_reduction_operator(degree: int, decrement: int) -> npt.NDArray[np.float64]:
+    r"""Return the cached, read-only :math:`L^2` projection onto the lower degree.
+
+    The reduced coefficients :math:`\hat q = R c` minimise the true
+    :math:`L^2[0, 1]` distance :math:`\lVert \sum_j c_j B_{j,p} - \sum_i \hat q_i
+    B_{i,q} \rVert` with no constraints, i.e. they solve the normal equations
+    :math:`M^\top G_p M \hat q = M^\top G_p c`.  The system matrix is exactly the
+    degree-:math:`q` Gram matrix, since :math:`M \hat q` and :math:`\hat q`
+    describe the same polynomial: :math:`M^\top G_p M = G_q`.
+
+    Note that this is *not* a new approximation: minimising the Euclidean norm of
+    the Bernstein coefficient residual gives the same polynomial (Lutterkort,
+    Peters & Reif, *Computer Aided Geometric Design* 16, 1999), which is what the
+    bidiagonal least-squares route used before computed.
+
+    Args:
+        degree (int): Original degree ``p`` (``>= 1``).
+        decrement (int): Degrees to remove, ``1 <= t <= p``.
+
+    Returns:
+        npt.NDArray[np.float64]: Read-only ``(p - t + 1, p + 1)`` operator.
+    """
+    p = degree
+    q = p - decrement
+    elevation = _elevation_matrix_exact(q, decrement)
+    gram_p = _bernstein_gram_exact(p)
+
+    projected = [
+        [
+            sum((elevation[k][i] * gram_p[k][j] for k in range(p + 1)), Fraction(0))
+            for j in range(p + 1)
+        ]
+        for i in range(q + 1)
+    ]
+    rows = _solve_exact(_bernstein_gram_exact(q), projected)
+
+    operator = np.array([[float(value) for value in row] for row in rows], dtype=np.float64)
+    operator.flags.writeable = False
+    return operator
+
+
+@functools.lru_cache(maxsize=64)
+def _interpolating_reduction_operator(degree: int, decrement: int) -> npt.NDArray[np.float64]:
+    r"""Return the cached, read-only endpoint-interpolating reduction operator.
+
+    Minimises the same :math:`L^2` distance as :func:`_l2_reduction_operator`
+    subject to :math:`\hat q_0 = c_0` and :math:`\hat q_q = c_p`, so the reduced
+    polynomial agrees with the original at both ends of the segment.  Splitting
+    the columns of :math:`M` into the two constrained ones and the free block
+    :math:`M_f` leaves the symmetric positive-definite system
+
+    .. math::
+
+        (M_f^\top G_p M_f)\, \hat q_f
+        = \bigl(M^\top G_p c\bigr)_{1:q} - (G_q)_{1:q,0}\, c_0
+          - (G_q)_{1:q,q}\, c_p ,
+
+    whose matrix is the interior block of the degree-:math:`q` Gram matrix.  A
+    degree-0 target cannot honour two interpolation conditions with a single
+    coefficient, so ``decrement == degree`` falls back to
+    :func:`_l2_reduction_operator`, whose degree-0 answer is the mean of ``c``.
+
+    The assembly runs in exact rational arithmetic and rounds once, which is what
+    makes the operator usable at high degree: that interior Gram block has
+    condition number ``5.4e10`` at ``q = 19`` (it depends on ``q`` alone, not on
+    ``p`` or ``t``), so a ``float64`` normal-equation solve loses eleven digits
+    and a round trip through elevation then reduction comes back with an error of
+    ``2.6e-11`` instead of ``4e-16``.  Solving exactly moves that cost to a cached
+    one-off — 3 ms at degree 10, 32 ms at degree 21 — and the operator entries
+    themselves are benign (``max |R| <= 2.5`` over that range), so applying it is
+    accurate.  It also makes the operator bit-identical across platforms and BLAS
+    versions.
+
+    Args:
+        degree (int): Original degree ``p`` (``>= 1``).
+        decrement (int): Degrees to remove, ``1 <= t <= p``.
+
+    Returns:
+        npt.NDArray[np.float64]: Read-only ``(p - t + 1, p + 1)`` operator.
+    """
+    p = degree
+    q = p - decrement
+    if q == 0:
+        return _l2_reduction_operator(degree, decrement)
+
+    elevation = _elevation_matrix_exact(q, decrement)
+    gram_p = _bernstein_gram_exact(p)
+    gram_q = _bernstein_gram_exact(q)
+
+    rows: _ExactMatrix = [[Fraction(0)] * (p + 1) for _ in range(q + 1)]
+    rows[0][0] = Fraction(1)
+    rows[q][p] = Fraction(1)
+
+    if q >= 2:  # noqa: PLR2004
+        interior = [row[1:q] for row in gram_q[1:q]]
+        right = [
+            [
+                sum((elevation[k][i] * gram_p[k][j] for k in range(p + 1)), Fraction(0))
+                for j in range(p + 1)
+            ]
+            for i in range(1, q)
+        ]
+        for i in range(q - 1):
+            right[i][0] -= gram_q[1 + i][0]
+            right[i][p] -= gram_q[1 + i][q]
+        rows[1:q] = _solve_exact(interior, right)
+
+    operator = np.array([[float(value) for value in row] for row in rows], dtype=np.float64)
+    operator.flags.writeable = False
+    return operator
+
+
+def _reduce_along_axis(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    axis: int,
+    operator: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Apply a reduction operator along one axis of a control-point array.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(*orders, rank)``.
+        axis (int): Parametric direction to reduce.
+        operator (npt.NDArray[np.float64]): Reduction operator of shape
+            ``(new_order, ctrl.shape[axis])``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Control points with ``axis``
+        reduced, same dtype as *ctrl*.
+    """
+    pts_2d, trailing_shape = _flatten_along_axis(ctrl, axis)
+    reduced = np.empty((operator.shape[0], pts_2d.shape[1]), dtype=pts_2d.dtype)
+    _apply_reduction_operator(operator, np.ascontiguousarray(pts_2d), reduced)
+    return _unflatten_along_axis(reduced, trailing_shape, axis)
+
+
 def _degree_reduce_bezier(
     bezier: Bezier,
     decrements: tuple[int, ...],
 ) -> Bezier:
     """Degree-reduce a Bézier in one or more parametric directions.
 
-    For each direction with a positive decrement, applies the Bézier degree
-    reduction kernel via the shared flatten/unflatten helpers.  The reduction is a
-    least-squares approximation (not exact in general).
+    For each direction with a positive decrement, applies the
+    endpoint-interpolating :math:`L^2`-optimal reduction operator.  The result is
+    an approximation (not exact in general), but it reproduces the original
+    exactly at the boundary of the parametric domain.
 
     Args:
         bezier (~pantr.bezier.Bezier): The Bézier to reduce.
@@ -110,21 +352,14 @@ def _degree_reduce_bezier(
     from . import Bezier as BezierCls  # noqa: PLC0415
 
     ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
-    degrees = bezier.degree
 
     for d in range(bezier.dim):
         dec = decrements[d]
         if dec == 0:
             continue
 
-        p = degrees[d]
-
-        pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
-        new_pts_2d = _degree_reduce_bezier_1d_core(p, pts_2d, dec)
-        ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, d)
-
-        # Update degrees for subsequent iterations.
-        degrees = (*degrees[:d], p - dec, *degrees[d + 1 :])
+        operator = _interpolating_reduction_operator(bezier.degree[d], dec)
+        ctrl = _reduce_along_axis(ctrl, d, operator)
 
     return BezierCls(ctrl, is_rational=bezier.is_rational)
 
@@ -197,6 +432,33 @@ def _squared_l2_norm(
     return abs(float(np.sum(c * g_c)))
 
 
+def _degree_reduction_l2_error(bezier: Bezier, decrements: tuple[int, ...]) -> float:
+    r"""Compute the exact :math:`L^2` error of a degree reduction.
+
+    Reduces, elevates the result back to the original degrees (an exact
+    operation) and takes the :math:`L^2` norm of the coefficient difference
+    through the Bernstein Gram matrix, so the value is the true
+    :math:`\lVert f - g \rVert_{L^2([0,1]^d)}` rather than an estimate.  Rank
+    components are combined in the Euclidean sense.
+
+    Args:
+        bezier (~pantr.bezier.Bezier): The Bézier that would be reduced.
+        decrements (tuple[int, ...]): Degree decrement per direction.
+
+    Returns:
+        float: The :math:`L^2` norm of the error the reduction would introduce.
+
+    Note:
+        Inputs are assumed to be validated by the caller (Layer 1).
+    """
+    reduced = _degree_reduce_bezier(bezier, decrements)
+    restored = _degree_elevate_bezier(reduced, decrements)
+
+    diff = restored.control_points - bezier.control_points
+    rank = diff.shape[-1]
+    return math.sqrt(sum(_squared_l2_norm(diff[..., r]) for r in range(rank)))
+
+
 def _minimize_degree_bezier(
     bezier: Bezier,
     tol: float | None = None,
@@ -249,10 +511,7 @@ def _minimize_degree_bezier(
             degree = result.shape[dim] - 1
 
             # Reduce by one along `dim` (all rank components together) ...
-            flat, trailing = _flatten_along_axis(result, dim)
-            reduced = _unflatten_along_axis(
-                _degree_reduce_bezier_1d_core(degree, flat, 1), trailing, dim
-            )
+            reduced = _reduce_along_axis(result, dim, _interpolating_reduction_operator(degree, 1))
 
             # ... then re-elevate so the trial can be compared to `result`.
             flat_reduced, trailing_reduced = _flatten_along_axis(reduced, dim)

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -421,14 +421,23 @@ class Bspline:
         return _degree_elevate_bspline(self, increments)
 
     def reduce_degree(self, degree_decrements: int | Sequence[int]) -> Bspline:
-        """Reduce the polynomial degree of the B-spline via least-squares approximation.
+        r"""Reduce the polynomial degree of the B-spline.
 
-        Decomposes to Bézier segments, reduces each segment using bidiagonal
-        least-squares (Givens QR), and coarsens the knot vector to restore
-        the original continuity structure.
+        Decomposes to Bézier segments, reduces each segment, and coarsens the
+        knot vector to restore the original continuity structure.
 
         Unlike :meth:`elevate_degree`, this operation is **not exact** in
         general: the result is an approximation of the original mapping.
+
+        Each Bézier segment is reduced on its own, to the closest lower-degree
+        polynomial in :math:`L^2` among those reproducing the segment's endpoint
+        values.  Adjacent segments therefore agree at every breakpoint bit for
+        bit and the stitch is exactly C0, with neither side moved off its own
+        optimum.  Knots are then removed to restore the original continuity
+        structure, and that step, not the reduction, is what sets the final
+        error: it is a forced removal with no deviation bound, so the exact
+        per-segment figure :meth:`~pantr.bezier.Bezier.degree_reduction_error`
+        reports does not carry over to the assembled spline.
 
         Args:
             degree_decrements (int | Sequence[int]): Number of degrees to

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -161,6 +161,10 @@ def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...])
     Returns:
         Bspline: New B-spline with reduced degrees.
     """
+    # Deferred to break the import cycle: pantr.bezier._bezier_core imports
+    # _bincoeff from this package's Layer 3.
+    from ..bezier._bezier_degree import _interpolating_reduction_operator  # noqa: PLC0415
+
     dim = bspline.dim
     ctrl = bspline.control_points
 
@@ -190,6 +194,7 @@ def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...])
                 interior_mults = np.empty(0, dtype=orig_mults.dtype)
 
             pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
+            operator = _interpolating_reduction_operator(space_1d.degree, dec)
 
             if is_periodic:
                 m_bdy = int(orig_mults[0])
@@ -199,7 +204,7 @@ def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...])
                 )
 
                 new_pts_2d, new_knots = _degree_reduce_1d_core(
-                    space_1d.degree, open_pts_2d, open_knots, dec
+                    space_1d.degree, open_pts_2d, open_knots, dec, operator
                 )
 
                 new_degree = space_1d.degree - dec
@@ -224,7 +229,7 @@ def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...])
                 new_space_1d = BsplineSpace1D(per_knots, new_degree, periodic=True)
             else:
                 new_pts_2d, new_knots = _degree_reduce_1d_core(
-                    space_1d.degree, pts_2d, space_1d.knots, dec
+                    space_1d.degree, pts_2d, space_1d.knots, dec, operator
                 )
                 new_degree = space_1d.degree - dec
 

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -411,10 +411,22 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
     alfs = np.zeros(d, dtype=np.float64)
     rbpts = np.empty((new_deg + 1, rank), dtype=ctrl.dtype)
 
-    # Over-allocate output arrays (same pattern as elevation kernel).
-    max_new_knots = len(knots) + len(knots)
-    oc = np.empty((n_pts + len(knots), rank), dtype=ctrl.dtype)
-    ok = np.empty(max_new_knots, dtype=np.float64)
+    # Size the output arrays from the number of Bézier segments the sweep below
+    # will produce, counted with that sweep's own advance rule.  The reduced
+    # spline is in Bézier form, so it has exactly ``n_seg * new_deg + 1`` control
+    # points and ``n_seg * new_deg + new_deg + 2`` knots.  (A bound expressed in
+    # terms of ``len(knots)`` alone is not an upper bound: it fails from 8
+    # elements on at degree 5, and the kernel then writes past the end.)
+    n_seg = 0
+    scan = d + 1
+    while scan < m:
+        while scan < m and knots[scan] == knots[scan + 1]:
+            scan += 1
+        n_seg += 1
+        scan += 1
+
+    oc = np.empty((n_seg * new_deg + 1, rank), dtype=ctrl.dtype)
+    ok = np.empty(n_seg * new_deg + new_deg + 2, dtype=np.float64)
 
     # Initialise: first boundary knots and first Bézier segment.
     ua = knots[0]

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -1,9 +1,9 @@
 """Numba kernels for B-spline degree elevation and reduction.
 
 Elevation follows The NURBS Book (Piegl & Tiller, Algorithm A5.9) / MATLAB
-NURBS Toolbox layer.  Reduction solves the Bernstein degree-elevation system
-in the least-squares sense via bidiagonal QR (Golub & Van Loan, *Matrix
-Computations*, 4th ed., sections 5.1-5.2).
+NURBS Toolbox layer.  Reduction decomposes the spline into Bézier segments and
+applies a precomputed reduction operator to each; the operator itself is
+assembled in :mod:`pantr.bezier._bezier_degree`.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
@@ -254,118 +254,46 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
 
 
 @nb_jit(nopython=True, cache=True)
-def _reduce_bezier_segment(  # noqa: PLR0912
-    degree: int,
-    bpts: npt.NDArray[Any],
-    degree_decrement: int,
+def _apply_reduction_operator(
+    operator: npt.NDArray[np.float64],
+    ctrl: npt.NDArray[Any],
     out: npt.NDArray[Any],
 ) -> None:
-    r"""Degree-reduce a single Bézier segment into a pre-allocated output.
+    r"""Apply a degree-reduction operator to one set of Bézier control points.
 
-    Solves the Bernstein degree-elevation system in the least-squares sense,
-    the same bidiagonal QR scheme used by
-    :func:`~pantr.bezier._bezier_core._degree_reduce_bezier_1d_core` (Golub &
-    Van Loan, *Matrix Computations*, 4th ed., sections 5.1-5.2).  Elevation from degree
-    ``p-1`` to ``p`` is the ``(p+1) x p`` lower-bidiagonal matrix ``M`` with
-    diagonal :math:`1 - k/p` and sub-diagonal :math:`(k+1)/p`; a Givens sweep
-    factors ``M = Q R`` with ``R`` upper bidiagonal, and back-substitution on
-    ``R`` recovers the reduced control points.
+    Computes :math:`\hat q = R\, c` for the dense operator ``R`` assembled by
+    :func:`~pantr.bezier._bezier_degree._interpolating_reduction_operator` (or
+    its unconstrained sibling), accumulating in ``float64`` regardless of the
+    control-point dtype and rounding once on the write.
 
-    The kernel is duplicated here (rather than importing the Bézier version)
-    because ``_bezier_core`` already imports ``_bincoeff`` from this module, so
-    calling back into it would create a circular import.
+    Rows of ``R`` that pin an endpoint are unit vectors, so the corresponding
+    output values reproduce their inputs bit for bit.
+
+    This kernel lives here rather than in ``pantr.bezier`` because
+    ``_bezier_core`` already imports ``_bincoeff`` from this module; the reverse
+    import would close a cycle.
 
     Args:
-        degree (int): Current polynomial degree (``p >= 1``).
-        bpts (npt.NDArray[Any]): Input Bézier control points of shape
-            ``(p + 1, rank)``.
-        degree_decrement (int): Number of degrees to reduce (``1 <= t <= p``).
-        out (npt.NDArray[Any]): Pre-allocated output of shape
-            ``(p - t + 1, rank)``.
+        operator (npt.NDArray[np.float64]): Reduction operator of shape
+            ``(q + 1, p + 1)``.
+        ctrl (npt.NDArray[Any]): Control points of shape ``(p + 1, rank)``.
+        out (npt.NDArray[Any]): Pre-allocated output of shape ``(q + 1, rank)``.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
-        For general use, call :func:`_degree_reduce_bspline` instead.
+        For general use, call :func:`_degree_reduce_bspline` or
+        :func:`~pantr.bezier._bezier_degree._degree_reduce_bezier` instead.
     """
-    rank = bpts.shape[1]
+    n_out = operator.shape[0]
+    n_in = operator.shape[1]
+    rank = ctrl.shape[1]
 
-    # Scratch sized for the first (largest) step; later steps reuse a prefix.
-    # r_diag / r_super: main and super-diagonal of the upper-bidiagonal R.
-    # cos / sin: the Givens rotations, replayed on every right-hand side.
-    r_diag = np.empty(degree, dtype=np.float64)
-    r_super = np.empty(degree, dtype=np.float64)
-    cos = np.empty(degree, dtype=np.float64)
-    sin = np.empty(degree, dtype=np.float64)
-    rhs = np.empty(degree + 1, dtype=np.float64)
-
-    cur = np.empty((degree + 1, rank), dtype=bpts.dtype)
-    for i in range(degree + 1):
+    for i in range(n_out):
         for r in range(rank):
-            cur[i, r] = bpts[i, r]
-
-    cur_deg = degree
-
-    for _step in range(degree_decrement):
-        p = cur_deg  # reduce degree p (p+1 points) to degree p-1 (p points)
-
-        nxt = np.empty((p, rank), dtype=bpts.dtype)
-
-        inv_p = 1.0 / np.float64(p)
-
-        # --- QR sweep on the elevation matrix M (right-hand-side free) -------
-        # Column k carries M[k, k] = 1 - k/p (`head`, mutated by the previous
-        # rotation) and M[k+1, k] = (k+1)/p (`tail`, the entry G_k zeros).
-        # `tail` is always > 0, so the Givens of G&VL Alg. 5.1.3 needs only two
-        # branches.  G_k also spreads M[k+1, k+1] onto the super-diagonal of R.
-        next_diag = 1.0  # M[0, 0]
-        for k in range(p):
-            head = next_diag
-            tail = np.float64(k + 1) * inv_p
-
-            if abs(tail) > abs(head):
-                ratio = head / tail
-                sn = 1.0 / np.sqrt(1.0 + ratio * ratio)
-                cs = ratio * sn
-                rho = tail / sn
-            else:
-                ratio = tail / head
-                cs = 1.0 / np.sqrt(1.0 + ratio * ratio)
-                sn = ratio * cs
-                rho = head / cs
-
-            cos[k] = cs
-            sin[k] = sn
-            r_diag[k] = rho
-
-            if k + 1 < p:
-                below = 1.0 - np.float64(k + 1) * inv_p  # M[k+1, k+1]
-                r_super[k] = sn * below
-                next_diag = cs * below
-
-        # --- Apply Q^T to each right-hand side and back-substitute -----------
-        for r in range(rank):
-            for i in range(p + 1):
-                rhs[i] = np.float64(cur[i, r])
-
-            for k in range(p):
-                cs = cos[k]
-                sn = sin[k]
-                top = rhs[k]
-                bot = rhs[k + 1]
-                rhs[k] = cs * top + sn * bot
-                rhs[k + 1] = -sn * top + cs * bot
-
-            nxt[p - 1, r] = bpts.dtype.type(rhs[p - 1] / r_diag[p - 1])
-            for k in range(p - 2, -1, -1):
-                solved = (rhs[k] - r_super[k] * np.float64(nxt[k + 1, r])) / r_diag[k]
-                nxt[k, r] = bpts.dtype.type(solved)
-
-        cur = nxt
-        cur_deg = p - 1
-
-    for i in range(out.shape[0]):
-        for r in range(rank):
-            out[i, r] = cur[i, r]
+            acc = 0.0
+            for j in range(n_in):
+                acc += operator[i, j] * np.float64(ctrl[j, r])
+            out[i, r] = out.dtype.type(acc)
 
 
 @nb_jit(nopython=True, cache=True)
@@ -374,19 +302,29 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
     ctrl: npt.NDArray[Any],
     knots: npt.NDArray[Any],
     degree_decrement: int,
+    reduction_operator: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any]]:
     """Degree reduce a B-spline curve by ``degree_decrement``.
 
     Decomposes the B-spline into Bézier segments by iterating through knot
-    spans (same alpha-blending as the elevation kernel), reduces each segment
-    via bidiagonal least-squares, and stitches the results into a B-spline in
-    Bézier form (C0 at every interior breakpoint).
+    spans (same alpha-blending as the elevation kernel), applies the reduction
+    operator to each segment, and stitches the results into a B-spline in Bézier
+    form (C0 at every interior breakpoint).
+
+    Because the operator interpolates the segment endpoints, the last control
+    point of one reduced segment and the first of the next are both the shared
+    breakpoint value of the *original* spline, bit for bit.  The junction is
+    therefore written once and the stitch is exactly C0; no averaging of the two
+    sides is involved, and neither segment is perturbed away from its own
+    optimum.
 
     Args:
         degree (int): Original degree.
         ctrl (npt.NDArray[Any]): Control points of shape ``(n_pts, rank)``.
         knots (npt.NDArray[Any]): Knot vector of shape ``(n_knots,)``.
         degree_decrement (int): Number of degrees to reduce (``1 <= t <= degree``).
+        reduction_operator (npt.NDArray[np.float64]): Operator of shape
+            ``(degree - t + 1, degree + 1)`` for this degree pair.
 
     Returns:
         tuple[npt.NDArray[Any], npt.NDArray[Any]]: ``(reduced_ctrl, reduced_knots)``
@@ -471,26 +409,16 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
                     Nextbpts[save, ii] = bpts[d, ii]
 
         # --- Reduce the current Bézier segment ---
-        _reduce_bezier_segment(d, bpts, t, rbpts)
+        _apply_reduction_operator(reduction_operator, bpts, rbpts)
 
-        # If this is the very first segment, write all control points.
-        # Otherwise, average the shared boundary point with the previous
-        # segment's last point, then write the interior + end points.
-        if cind == 0:
-            # First segment: write all new_deg + 1 points.
-            for j in range(new_deg + 1):
-                for ii in range(rank):
-                    oc[cind, ii] = rbpts[j, ii]
-                cind += 1
-        else:
-            # Average the shared boundary point.
+        # The first segment contributes all of its control points; every later
+        # one skips its first, which the previous segment already wrote with the
+        # identical value.
+        start = 0 if cind == 0 else 1
+        for j in range(start, new_deg + 1):
             for ii in range(rank):
-                oc[cind - 1, ii] = (oc[cind - 1, ii] + rbpts[0, ii]) * 0.5
-            # Write interior and end points.
-            for j in range(1, new_deg + 1):
-                for ii in range(rank):
-                    oc[cind, ii] = rbpts[j, ii]
-                cind += 1
+                oc[cind, ii] = rbpts[j, ii]
+            cind += 1
 
         # Write interior breakpoint knots (multiplicity = new_deg for C0).
         if a != d:

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -2,17 +2,62 @@
 
 from __future__ import annotations
 
+import itertools
+import math
+
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from pantr.bezier import Bezier
+from pantr.bezier._bezier_degree import (
+    _elevation_matrix_exact,
+    _interpolating_reduction_operator,
+    _l2_reduction_operator,
+    _squared_l2_norm,
+)
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_degree_core import _degree_reduce_1d_core
+
+_EPS = float(np.finfo(np.float64).eps)
+
+_ROUND_TRIP_FACTOR = 8.0
+"""Safety factor on the round-trip bound ``(p + 1) * eps * max|ctrl|``.
+
+Reduction applies a dense operator, so each output coefficient is a dot product
+of ``p + 1`` terms and carries the classic forward error ``(p + 1) * u *
+sum_j |R_ij| |c_j|``.  The operator entries stay near unity over the whole
+tested range (``max |R| = 1.52`` at degree 30), so a factor of 8 covers the row
+sums with room to spare.  Measured worst over degrees 1 to 22 and decrements 1
+to 3: ``1.3e-15``, that is 55 times inside the bound.
+"""
+
+_MAX_INTERPOLATION_PRICE = 5.0
+"""Largest admissible ratio of interpolating to unconstrained :math:`L^2` error.
+
+Endpoint interpolation removes two degrees of freedom, so it can only make the
+:math:`L^2` error larger; the ratio is 1 exactly when the unconstrained optimum
+already interpolates.  Measured over degrees 1 to 20 and every decrement, the
+ratio stays in ``[1.002, 4.547]``, the worst cases being reductions to a
+straight line.  A regression that dropped the constraints, or one that solved
+the wrong system, would leave this window immediately.
+"""
 
 
 def _make_bezier_1d(ctrl: list[list[float]], rational: bool = False) -> Bezier:
     """Create a 1D Bézier from a list of control points."""
     return Bezier(np.array(ctrl), is_rational=rational)
+
+
+def _l2_norm_squared(bezier: Bezier) -> float:
+    """Sum the squared L2 norms of every rank component of a Bézier."""
+    ctrl = bezier.control_points
+    return float(sum(_squared_l2_norm(ctrl[..., r]) for r in range(ctrl.shape[-1])))
+
+
+def _difference(left: Bezier, right: Bezier) -> Bezier:
+    """Coefficient-wise difference of two Béziers of equal degree."""
+    return Bezier(left.control_points - right.control_points)
 
 
 # ---------------------------------------------------------------------------
@@ -99,14 +144,12 @@ class TestBezierReduceDegreeApproximate:
         assert np.max(np.abs(vals_orig - vals_red)) < max_err_tol
 
     def test_endpoints_preserved(self) -> None:
-        """After reduction, endpoints should be close to the original."""
+        """After reduction, the endpoints are reproduced exactly."""
         b = _make_bezier_1d([[0.0, 0.0], [0.3, 1.5], [0.7, -0.5], [1.0, 1.0]])
         reduced = b.reduce_degree(1)
 
         pts = np.array([0.0, 1.0])
-        vals_orig = b.evaluate(pts)
-        vals_red = reduced.evaluate(pts)
-        np.testing.assert_allclose(vals_red, vals_orig, atol=0.5)
+        assert np.array_equal(reduced.evaluate(pts), b.evaluate(pts))
 
     def test_reduce_degree_result_type(self) -> None:
         """Reduced Bézier has correct degree and dtype."""
@@ -125,6 +168,291 @@ class TestBezierReduceDegreeApproximate:
         # The constant is the least-squares fit: average of endpoints
         expected = np.array([[1.0, 2.0]])
         np.testing.assert_allclose(reduced.control_points, expected, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# The reduction operator and what makes it optimal
+# ---------------------------------------------------------------------------
+
+
+class TestReductionOperator:
+    """The cached operators that drive every reduction."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 5, 8, 12, 16, 20])
+    @pytest.mark.parametrize("increment", [1, 2, 5])
+    def test_exact_elevation_matrix_matches_the_elevation_kernel(
+        self, degree: int, increment: int
+    ) -> None:
+        """The rational elevation matrix reproduces the compiled elevation kernel."""
+        rng = np.random.default_rng(degree * 100 + increment)
+        ctrl = rng.standard_normal((degree + 1, 2))
+
+        from_kernel = Bezier(ctrl).elevate_degree(increment).control_points
+        matrix = np.array(
+            [[float(v) for v in row] for row in _elevation_matrix_exact(degree, increment)]
+        )
+
+        # Both routes sum O(degree) products, so compare against the magnitude
+        # of the result rather than entry by entry: a coefficient near zero is
+        # the difference of larger terms and has no relative accuracy.
+        scale = float(np.max(np.abs(from_kernel)))
+        assert float(np.max(np.abs(matrix @ ctrl - from_kernel))) <= 8.0 * _EPS * scale
+
+    @pytest.mark.parametrize("degree,decrement", [(1, 1), (4, 1), (7, 3), (12, 2)])
+    def test_operator_is_shared_and_read_only(self, degree: int, decrement: int) -> None:
+        """Repeated calls hand back the same immutable array."""
+        first = _interpolating_reduction_operator(degree, decrement)
+        second = _interpolating_reduction_operator(degree, decrement)
+
+        assert first is second
+        assert not first.flags.writeable
+        assert first.shape == (degree - decrement + 1, degree + 1)
+
+    def test_reduction_to_a_constant_is_the_mean(self) -> None:
+        """Two endpoint conditions cannot hold with one coefficient; the mean does."""
+        operator = _interpolating_reduction_operator(3, 3)
+
+        np.testing.assert_allclose(operator, np.full((1, 4), 0.25), rtol=0.0, atol=_EPS)
+
+    def test_the_two_operators_differ(self) -> None:
+        """The interpolating operator is not the plain projection."""
+        interpolating = _interpolating_reduction_operator(5, 1)
+        unconstrained = _l2_reduction_operator(5, 1)
+
+        assert not np.allclose(interpolating, unconstrained)
+
+
+def _bernstein_values(degree: int, points: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Tabulate the degree-``n`` Bernstein basis by evaluating the unit Béziers.
+
+    Goes through the public evaluator, so it shares nothing with the assembly of
+    the reduction operator.
+
+    Args:
+        degree (int): Polynomial degree.
+        points (npt.NDArray[np.float64]): Evaluation points in ``[0, 1]``.
+
+    Returns:
+        npt.NDArray[np.float64]: ``(len(points), degree + 1)`` basis values.
+    """
+    return np.column_stack(
+        [np.ravel(Bezier(np.eye(degree + 1)[:, [i]]).evaluate(points)) for i in range(degree + 1)]
+    )
+
+
+def _reference_reduction(ctrl: npt.NDArray[np.float64], decrement: int) -> npt.NDArray[np.float64]:
+    """Solve the endpoint-constrained L2 fit by Gauss-Legendre quadrature.
+
+    An ``n``-node Gauss-Legendre rule integrates polynomials of degree
+    ``2n - 1`` exactly, so with ``n = degree + 2`` nodes the discrete weighted
+    least-squares problem *is* the continuous one, not an approximation of it.
+    The endpoint conditions are imposed by substitution and the remaining
+    overdetermined system goes through :func:`numpy.linalg.lstsq`, so the
+    reference shares no algebra with the implementation.
+
+    Args:
+        ctrl (npt.NDArray[np.float64]): Control points of shape ``(p + 1, rank)``.
+        decrement (int): Degrees to remove.
+
+    Returns:
+        npt.NDArray[np.float64]: Reference reduced control points.
+    """
+    degree = ctrl.shape[0] - 1
+    target = degree - decrement
+
+    nodes, weights = np.polynomial.legendre.leggauss(degree + 2)
+    nodes = 0.5 * (nodes + 1.0)
+    root_weights = np.sqrt(0.5 * weights)[:, None]
+
+    high = _bernstein_values(degree, nodes) * root_weights
+    low = _bernstein_values(target, nodes) * root_weights
+
+    residual = high @ ctrl - np.outer(low[:, 0], ctrl[0]) - np.outer(low[:, target], ctrl[-1])
+    reduced = np.empty((target + 1, ctrl.shape[1]))
+    reduced[0] = ctrl[0]
+    reduced[target] = ctrl[-1]
+    if target >= 2:
+        reduced[1:target] = np.linalg.lstsq(low[:, 1:target], residual, rcond=None)[0]
+    return reduced
+
+
+class TestBezierReductionOptimality:
+    """Optimality against an independent oracle, and variationally."""
+
+    @pytest.mark.parametrize("degree", [3, 4, 5, 8, 10])
+    @pytest.mark.parametrize("decrement", [1, 2, 3])
+    def test_matches_a_quadrature_reference(self, degree: int, decrement: int) -> None:
+        """The reduction agrees with a Gauss-Legendre constrained least-squares fit."""
+        if decrement >= degree:
+            pytest.skip("a reduction to a constant keeps no endpoint condition")
+
+        rng = np.random.default_rng(degree * 10 + decrement)
+        ctrl = rng.standard_normal((degree + 1, 2))
+
+        reduced = Bezier(ctrl).reduce_degree(decrement).control_points
+        reference = _reference_reduction(ctrl, decrement)
+
+        # The reference solves the same problem through a design matrix whose
+        # condition number is the square root of the Gram's; over these degrees
+        # that is at most ~2e2, so half a dozen digits of head-room is plenty.
+        scale = float(np.max(np.abs(reference)))
+        assert float(np.max(np.abs(reduced - reference))) <= 1e-9 * scale
+
+    @pytest.mark.parametrize("degree", [3, 5, 8, 12])
+    def test_moving_off_the_optimum_costs_error_in_every_direction(self, degree: int) -> None:
+        """Any admissible move increases the L2 error, at every interior coefficient."""
+        rng = np.random.default_rng(degree * 3)
+        bezier = Bezier(rng.standard_normal((degree + 1, 1)))
+        reduced = bezier.reduce_degree(1)
+        best = _l2_norm_squared(_difference(reduced.elevate_degree(1), bezier))
+
+        for index in range(1, degree - 1):
+            for step in (-1e-3, 1e-3):
+                moved = reduced.control_points.copy()
+                moved[index] += step
+                perturbed = _l2_norm_squared(_difference(Bezier(moved).elevate_degree(1), bezier))
+                assert perturbed > best
+
+    @pytest.mark.parametrize("degree", [2, 3, 5, 8, 12, 16])
+    def test_endpoint_conditions_cost_a_bounded_factor(self, degree: int) -> None:
+        """Interpolating is never better than projecting, and never much worse."""
+        rng = np.random.default_rng(degree + 500)
+        for decrement in range(1, degree):
+            target = degree - decrement
+            for _ in range(3):
+                ctrl = rng.standard_normal((degree + 1, 1))
+                bezier = Bezier(ctrl)
+
+                interpolating = Bezier(_interpolating_reduction_operator(degree, decrement) @ ctrl)
+                unconstrained = Bezier(_l2_reduction_operator(degree, decrement) @ ctrl)
+                assert interpolating.degree == (target,)
+
+                error_i = math.sqrt(
+                    _l2_norm_squared(_difference(interpolating.elevate_degree(decrement), bezier))
+                )
+                error_u = math.sqrt(
+                    _l2_norm_squared(_difference(unconstrained.elevate_degree(decrement), bezier))
+                )
+
+                assert error_u <= error_i * (1.0 + 1e-12)
+                assert error_i <= _MAX_INTERPOLATION_PRICE * error_u
+
+
+class TestBezierEndpointInterpolation:
+    """The endpoint values survive reduction untouched."""
+
+    @pytest.mark.parametrize("degree", [1, 2, 3, 5, 8, 12, 16, 20])
+    @pytest.mark.parametrize("rank", [1, 3])
+    def test_endpoints_are_reproduced_bit_for_bit(self, degree: int, rank: int) -> None:
+        """Every decrement short of a constant leaves both ends exactly where they were."""
+        rng = np.random.default_rng(degree * 7 + rank)
+        ctrl = rng.standard_normal((degree + 1, rank))
+
+        for decrement in range(1, degree):
+            reduced = Bezier(ctrl).reduce_degree(decrement).control_points
+            assert np.array_equal(reduced[0], ctrl[0])
+            assert np.array_equal(reduced[-1], ctrl[-1])
+
+    @pytest.mark.parametrize(
+        "target,increment", [(1, 1), (2, 3), (5, 2), (12, 1), (16, 2), (20, 2)]
+    )
+    def test_elevated_data_round_trips(self, target: int, increment: int) -> None:
+        """Reduction inverts elevation to the accuracy of applying one dense operator."""
+        rng = np.random.default_rng(target * 13 + increment)
+        ctrl = rng.standard_normal((target + 1, 3))
+        degree = target + increment
+
+        back = Bezier(ctrl).elevate_degree(increment).reduce_degree(increment).control_points
+
+        bound = _ROUND_TRIP_FACTOR * (degree + 1) * _EPS * float(np.max(np.abs(ctrl)))
+        assert float(np.max(np.abs(back - ctrl))) <= bound
+
+    def test_float32_stays_float32(self) -> None:
+        """A float32 Bézier round trips within single-precision rounding."""
+        rng = np.random.default_rng(4)
+        ctrl = rng.standard_normal((6, 2)).astype(np.float32)
+
+        back = Bezier(ctrl).elevate_degree(2).reduce_degree(2).control_points
+
+        assert back.dtype == np.float32
+        eps32 = float(np.finfo(np.float32).eps)
+        assert float(np.max(np.abs(back - ctrl))) <= 8.0 * eps32 * float(np.max(np.abs(ctrl)))
+
+
+class TestBezierDegreeReductionError:
+    """The exact L2 error reported alongside a reduction."""
+
+    @pytest.mark.parametrize("degree,decrement", [(3, 1), (5, 1), (5, 2), (8, 3)])
+    def test_matches_numerical_quadrature(self, degree: int, decrement: int) -> None:
+        """The reported norm matches a fine trapezoidal integration of the error."""
+        rng = np.random.default_rng(degree * 3 + decrement)
+        bezier = Bezier(rng.standard_normal((degree + 1, 1)))
+
+        reported = bezier.degree_reduction_error(decrement)
+
+        samples = np.linspace(0.0, 1.0, 200001)
+        diff = np.ravel(bezier.evaluate(samples)) - np.ravel(
+            bezier.reduce_degree(decrement).evaluate(samples)
+        )
+        quadrature = float(np.sqrt(np.trapezoid(diff**2, samples)))
+
+        # The composite trapezoidal rule converges as h^2; at 2e5 intervals that
+        # leaves well under six digits for a smooth integrand.
+        assert reported == pytest.approx(quadrature, rel=1e-6)
+
+    def test_vanishes_for_exactly_reducible_input(self) -> None:
+        """An elevated curve can be reduced back for free."""
+        rng = np.random.default_rng(11)
+        bezier = Bezier(rng.standard_normal((4, 2))).elevate_degree(2)
+
+        reported = bezier.degree_reduction_error(2)
+
+        scale = float(np.max(np.abs(bezier.control_points)))
+        assert reported <= _ROUND_TRIP_FACTOR * (bezier.degree[0] + 1) * _EPS * scale
+
+    def test_grows_with_the_decrement(self) -> None:
+        """Removing more degrees cannot reduce the error, while a target degree remains.
+
+        The interpolating targets are nested — a degree-``q`` polynomial through
+        both endpoints is also a degree-``q+1`` one — so the optimum over the
+        smaller set cannot be closer.  The chain stops short of a constant,
+        which is not in that family (see the companion test).
+        """
+        rng = np.random.default_rng(12)
+        bezier = Bezier(rng.standard_normal((7, 1)))
+
+        errors = [bezier.degree_reduction_error(dec) for dec in range(1, 6)]
+
+        assert errors == sorted(errors)
+
+    def test_reduction_to_a_constant_breaks_the_monotone_chain(self) -> None:
+        """Dropping to degree 0 can beat degree 1, because it stops interpolating.
+
+        Degree 1 is pinned to the chord between the endpoints; degree 0 keeps no
+        endpoint condition at all and is free to sit at the mean, which for this
+        curve is closer.  Worth pinning: it is the visible edge of the
+        interpolating family, not an accident of the arithmetic.
+        """
+        rng = np.random.default_rng(12)
+        bezier = Bezier(rng.standard_normal((7, 1)))
+
+        to_line = bezier.degree_reduction_error(5)
+        to_constant = bezier.degree_reduction_error(6)
+
+        assert to_constant < to_line
+
+    def test_rejects_the_same_arguments_reduce_degree_does(self) -> None:
+        """Validation is shared with :meth:`Bezier.reduce_degree`."""
+        bezier = _make_bezier_1d([[0.0], [1.0], [2.0]])
+
+        with pytest.raises(ValueError, match=r"exceeds current degree"):
+            bezier.degree_reduction_error(3)
+        with pytest.raises(ValueError, match=r"non-negative"):
+            bezier.degree_reduction_error(-1)
+        with pytest.raises(ValueError, match=r"(?i)at least one"):
+            bezier.degree_reduction_error(0)
+        with pytest.raises(ValueError, match=r"must match dimension"):
+            bezier.degree_reduction_error((1, 1))
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +685,11 @@ class TestBsplineReduceDegreeOutputSizing:
         space_1d = bsp.space.spaces[0]
 
         new_ctrl, new_knots = _degree_reduce_1d_core(
-            degree, bsp.control_points, space_1d.knots, dec
+            degree,
+            bsp.control_points,
+            space_1d.knots,
+            dec,
+            _interpolating_reduction_operator(degree, dec),
         )
 
         new_degree = degree - dec
@@ -396,6 +728,56 @@ class TestBsplineReduceDegreeOutputSizing:
 
         assert reduced.degree == (4, 2)
         assert reduced.control_points.shape[:2] == reduced.space.num_basis
+
+
+class TestBsplineSegmentStitching:
+    """Reduced segments meet exactly, so nothing has to be averaged."""
+
+    @pytest.mark.parametrize("degree,n_el", [(3, 5), (4, 7), (5, 8), (6, 4)])
+    def test_neighbouring_segments_agree_bit_for_bit(self, degree: int, n_el: int) -> None:
+        """Independently reduced segments share their junction control point exactly.
+
+        This is what removes the averaging step: the old kernel replaced both
+        sides with their mean, moving each segment off its own optimum to buy a
+        C0 join that endpoint interpolation now provides for free.
+        """
+        bsp = _open_uniform_bspline(degree, n_el, rank=2, seed=degree * 3 + n_el)
+        operator = _interpolating_reduction_operator(degree, 1)
+
+        segments = [bezier.control_points for bezier in bsp.to_beziers().ravel()]
+        reduced = [operator @ segment for segment in segments]
+
+        assert len(reduced) == n_el
+        for left, right in itertools.pairwise(reduced):
+            assert np.array_equal(left[-1], right[0])
+
+    @pytest.mark.parametrize("degree,n_el", [(3, 4), (4, 6)])
+    def test_the_stitched_spline_interpolates_the_breakpoints(self, degree: int, n_el: int) -> None:
+        """Before knot coarsening, the reduced spline meets the original at every breakpoint."""
+        bsp = _open_uniform_bspline(degree, n_el, rank=2, seed=degree + n_el)
+        space_1d = bsp.space.spaces[0]
+
+        new_ctrl, new_knots = _degree_reduce_1d_core(
+            degree,
+            bsp.control_points,
+            space_1d.knots,
+            1,
+            _interpolating_reduction_operator(degree, 1),
+        )
+        bezier_form = Bspline(
+            BsplineSpace([BsplineSpace1D(new_knots, degree - 1)]),
+            new_ctrl,
+        )
+
+        breakpoints = np.linspace(0.0, 1.0, n_el + 1)
+        # Bézier form: the value at a breakpoint is a control point, and the
+        # reduction pinned it to the original segment's endpoint.
+        np.testing.assert_allclose(
+            bezier_form.evaluate(breakpoints),
+            bsp.evaluate(breakpoints),
+            rtol=0.0,
+            atol=8.0 * _EPS * float(np.max(np.abs(bsp.control_points))),
+        )
 
 
 class TestBsplineReduceDegreePeriodic:

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -7,6 +7,7 @@ import pytest
 
 from pantr.bezier import Bezier
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
+from pantr.bspline._bspline_degree_core import _degree_reduce_1d_core
 
 
 def _make_bezier_1d(ctrl: list[list[float]], rational: bool = False) -> Bezier:
@@ -306,6 +307,95 @@ class TestBsplineReduceDegreeRoundTrip:
 
         pts = np.linspace(0, 1, 20)
         np.testing.assert_allclose(bsp.evaluate(pts), reduced.evaluate(pts), atol=1e-12)
+
+
+def _open_uniform_bspline(degree: int, n_el: int, rank: int = 2, seed: int = 0) -> Bspline:
+    """Create an open B-spline with ``n_el`` uniform elements and random control points."""
+    knots = np.concatenate([np.zeros(degree), np.linspace(0.0, 1.0, n_el + 1), np.ones(degree)])
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    rng = np.random.default_rng(seed)
+    return Bspline(space, rng.random((space.num_total_basis, rank)))
+
+
+class TestBsplineReduceDegreeOutputSizing:
+    """Regression: the kernel sized its output buffers from ``len(knots)``.
+
+    The reduced spline is in Bézier form, so it holds ``n_seg * new_degree + 1``
+    control points, a count that grows with the number of elements while
+    ``len(knots)`` grows more slowly.  Past the crossover the kernel wrote beyond
+    the end of both output arrays: unchecked under ``nopython``, and surfacing
+    downstream as a control-point/basis-count mismatch.
+    """
+
+    @pytest.mark.parametrize(
+        "degree,n_el,dec",
+        [
+            (5, 8, 1),  # the smallest failing case at degree 5
+            (4, 13, 1),
+            (6, 7, 1),
+            (7, 6, 1),
+            (8, 5, 1),
+            (5, 16, 2),
+            (7, 11, 3),
+            (8, 13, 4),
+        ],
+    )
+    def test_reduction_fills_a_consistent_spline(self, degree: int, n_el: int, dec: int) -> None:
+        """Reducing an open uniform B-spline yields a well-formed spline."""
+        bsp = _open_uniform_bspline(degree, n_el)
+        reduced = bsp.reduce_degree(dec)
+
+        assert reduced.degree == (degree - dec,)
+        space_1d = reduced.space.spaces[0]
+        assert len(space_1d.knots) == space_1d.num_basis + space_1d.degree + 1
+        assert reduced.control_points.shape[0] == space_1d.num_basis
+
+    def test_kernel_output_matches_the_bezier_form_count(self) -> None:
+        """The kernel returns exactly ``n_seg * new_degree + 1`` control points."""
+        degree, n_el, dec = 5, 8, 1
+        bsp = _open_uniform_bspline(degree, n_el, rank=1)
+        space_1d = bsp.space.spaces[0]
+
+        new_ctrl, new_knots = _degree_reduce_1d_core(
+            degree, bsp.control_points, space_1d.knots, dec
+        )
+
+        new_degree = degree - dec
+        assert new_ctrl.shape[0] == n_el * new_degree + 1
+        assert new_knots.shape[0] == new_ctrl.shape[0] + new_degree + 1
+
+    def test_round_trip_on_the_triggering_configuration(self) -> None:
+        """Degree 5 with 8 elements: elevate then reduce recovers the geometry."""
+        bsp = _open_uniform_bspline(4, 8, rank=2, seed=3)
+        reduced = bsp.elevate_degree(1).reduce_degree(1)
+
+        pts = np.linspace(0.0, 1.0, 100)
+        np.testing.assert_allclose(reduced.evaluate(pts), bsp.evaluate(pts), atol=1e-12)
+
+    def test_periodic_spline_of_the_same_size(self) -> None:
+        """The periodic path reaches the same kernel."""
+        knots = create_uniform_periodic_knots(num_intervals=8, degree=4)
+        space = BsplineSpace([BsplineSpace1D(knots, 4, periodic=True)])
+        rng = np.random.default_rng(1)
+        bsp = Bspline(space, rng.random((space.num_total_basis, 2)))
+
+        reduced = bsp.elevate_degree(1).reduce_degree(1)
+
+        assert reduced.degree == (4,)
+        assert reduced.space.spaces[0].periodic
+
+    def test_surface_direction_of_the_same_size(self) -> None:
+        """A 2D surface reduced along one direction only."""
+        knots_x = np.concatenate([np.zeros(5), np.linspace(0.0, 1.0, 9), np.ones(5)])
+        knots_y = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots_x, 5), BsplineSpace1D(knots_y, 2)])
+        rng = np.random.default_rng(2)
+        bsp = Bspline(space, rng.random((*space.num_basis, 3)))
+
+        reduced = bsp.reduce_degree((1, 0))
+
+        assert reduced.degree == (4, 2)
+        assert reduced.control_points.shape[:2] == reduced.space.num_basis
 
 
 class TestBsplineReduceDegreePeriodic:


### PR DESCRIPTION
## Context

Degree reduction now returns, for every Bézier segment, the closest lower-degree
polynomial in $L^2$ **among those that reproduce the segment's endpoint values**. The
endpoints come back bit for bit, so adjacent B-spline segments meet exactly and the
averaging of the shared control point — which moved *both* segments off their own optima to
buy a C0 join — is gone. `Bezier.degree_reduction_error` reports the exact $L^2$ error of a
reduction before you commit to it.

The reduction is driven by a dense operator `R` of shape `(q+1, p+1)`, cached per degree
pair and applied as `out = R @ ctrl` by a single kernel shared by both packages.

Layering as elsewhere: operator assembly and caching in Layer 2 (`_bezier_degree.py`),
validation-free application in Layer 3 (`_bspline_degree_core.py`).

## What the ticket got wrong

Ten claims, measured before implementing. The premise of the ticket is one of them.

1. **"ℓ2 in coefficient space ≠ L2 in function space — the result is not the best
   degree-reduced approximation in any function norm." False.** The bidiagonal-QR
   reduction already in the repository returns the **exact $L^2$ optimum**. Checked against
   an oracle in exact rational arithmetic (`fractions.Fraction`, Gauss-Jordan on the exact
   Bernstein Gram matrix, dyadic control points, no rounding anywhere): agreement to
   **6.1e-15** relative and an $L^2$ error ratio of **1.0000000000** across fifteen
   (degree, decrement) combinations up to degree 16, single and multi-step alike. This is
   the Lutterkort–Peters–Reif theorem, which the ticket cites by title and then contradicts
   in its own annotation ("the equivalence holds in the *Legendre*-transformed
   coefficients, not raw Bernstein ones").

2. **"Sequential single-step LS is not the t-step optimum." False**, for the unconstrained
   problem *and* the constrained one. Orthogonal projection onto nested subspaces composes,
   and the interpolating targets are nested too, so `t` single steps land on the `t`-step
   optimum exactly. Verified in exact arithmetic: **identical, bit for bit**, for every
   `(p, t)` tested. A single operator is a performance choice, not a correctness one.

3. **The prescribed system matrix is not a new object.** $M^\top G_p M = G_q$ **exactly**
   (measured to 0.8 eps), the degree-$q$ Bernstein Gram matrix, because $M\hat q$ and
   $\hat q$ describe the same polynomial. So its conditioning depends on $q$ alone — not on
   $p$ and $t$, as the ticket's conditioning note has it. Measured for the interior block:
   **37** at $q=4$, **5.4e4** at $q=9$, **5.4e10** at $q=19$.

4. **"For the supported range (p ≤ 20) float64 normal equations lose ≤ ~half the digits."
   They lose eleven.** Round trip through elevation then reduction at $p = 21$:
   **2.6e-11** via the prescribed Cholesky-on-normal-equations, against **4.4e-16** for the
   QR route it was to replace. The ticket's own acceptance criterion (`1e-13` round trip
   over degrees 3–15) **fails on the ticket's own algorithm** from degree 13 on
   (1.0e-13 measured at degree 15). Squaring the conditioning is the same trap #266 hit.

   Fixed by assembling the operator in **exact rational arithmetic** and rounding once:
   round-trip error at most **4.7e-16** at every degree up to 22, since `max |R| <= 2.5` and
   all the trouble was in *building* the operator, never in applying it. The cost is a
   cached one-off — **2.4 ms** at degree 10, **26 ms** at 20, **107 ms** at 30 — and the
   operator becomes bit-identical across platforms and BLAS versions, which matters for a
   library that promises reproducibility within a derived bound. The ticket's "Legendre
   route is the natural upgrade path" is moot: there is nothing left to upgrade.

5. **"The returned error bound is within 10x of the measured max error." False**, by two
   orders of magnitude. The convex-hull bound on the coefficient residual runs from
   **1.3x** to **1630x** too large, the ratio growing with degree (115x at degree 8, 1630x
   at degree 12, both at decrement 1). It is not offered. `degree_reduction_error` returns
   the **exact** $L^2$ error instead, matching a 200 001-point trapezoidal quadrature to
   eight significant digits.

6. **"Operator caching should make it faster for multi-segment splines." Not measurably.**
   The B-spline path is dominated by the Bézier-decomposition sweep and the knot removal,
   not by the per-segment solve. Degree 3, 1000 elements, rank 3: **57.8 ms** after against
   **57.2 ms** before. A single degree-15 Bézier is 15% faster (9.2 µs against 10.8 µs).

7. **Endpoint interpolation is not a free improvement; it is a trade.** In $L^2$ the
   constrained optimum is strictly worse than the unconstrained one, by a measured factor
   in **[1.002, 4.547]** over degrees 1–20 and every decrement (worst at reduction to a
   straight line, mildest at high degree). What it buys is the exact join, which is what
   the B-spline path needs. Documented in both public docstrings and pinned by a test.

8. **`t = p` is not merely a degenerate case to test, it is unsatisfiable.** Two
   interpolation conditions cannot hold with one coefficient, so reduction to degree 0
   keeps neither and returns the plain $L^2$ projection — the mean of the control points,
   which is also what the previous implementation returned, so that case is unchanged.

9. **The $L^2$ error is monotone in the decrement only while a degree ≥ 1 target remains.**
   Reducing to a constant can beat reducing to a line (measured **0.49** against **0.75**),
   because the line is pinned to the chord while the constant is free. Pinned by a test so
   it is not later "fixed".

10. **`constrained: bool = True` and `return_error: bool = False` are not implemented as
    booleans.** A boolean that selects behaviour is two functions: `_l2_reduction_operator`
    and `_interpolating_reduction_operator`. The error is its own method rather than a flag
    that changes the return type. The public surface grows by one method, which is what the
    coming port has to carry.

## A bug met on the way (`B1`, own commit)

`_degree_reduce_1d_core` sized its two output buffers as `n_pts + len(knots)` and
`2 * len(knots)`. **Neither is an upper bound.** The reduced spline is in Bézier form, so it
holds `n_seg * new_degree + 1` control points, a count that grows with the element count
while `len(knots)` grows more slowly. Past the crossover the kernel wrote **past the end of
both arrays** — unchecked under `nopython` — after which `oc[:cind]` silently clamped to the
short buffer and the user met an unrelated "the number of control points must be a multiple
of the number of basis functions" from the `Bspline` constructor.

Measured over degrees 1–8, 1–20 elements and every decrement: **141 combinations overflow**,
from **13 elements on at degree 4**, **8 at degree 5**, **5 at degree 8**. The periodic and
tensor-product paths reach the same kernel and fail with it. The elevation kernel is *not*
affected — its formula carries the `t` factor that makes it a genuine bound.

Both buffers are now sized exactly, from a pre-pass counting segments with the same advance
rule the main sweep uses. Regression tests cover the smallest failing case per degree, the
kernel-level count invariant, and the periodic and surface paths.

## Verification

- **An independent oracle for optimality**: a Gauss–Legendre constrained least-squares fit
  built in the test from the *public* evaluator, with `degree + 2` nodes so the rule is
  exact for the integrand and the discrete problem **is** the continuous one. Agreement to
  1e-9 relative over degrees 3–10 and decrements 1–3.
- **A variational check** that no admissible move improves the result: perturbing any
  interior coefficient in either direction raises the $L^2$ error, at every degree tested.
- **The exact rational oracle** above, for the claims about what the previous
  implementation computed.
- Endpoint interpolation is **bitwise**: 25 of 25 reductions reproduce both ends exactly,
  and neighbouring reduced segments share their junction control point bit for bit.
- Round trips up to degree 22 within `8 * (p+1) * eps * scale`, measured worst 1.3e-15
  (55x inside the bound); float32 stays float32 and round trips within single precision.
- The exact elevation matrix reproduces the compiled elevation kernel to **1 eps**.
- Full suite: 4654 passed, 20 skipped; coverage 96% overall against a floor of 85%; docs
  build clean under `-W`.

## Not fixed, and not a regression: periodic reduction

Reducing a **genuine** (not degree-elevated) periodic B-spline fails, on `main` and on this
branch alike. On `main` the open-form endpoints no longer agree after an approximate
reduction ("Function values do not match at the domain endpoints", deviation 2.9e-3 to
1.3e-2); endpoint interpolation fixes exactly that check, and the *next* one now fires
instead — the seam continuity residual, 5.6e-2 to 1.3e-1. The cause is the same underneath:
reduction happens in the open form and an approximate result does not carry the wrapped
continuity a periodic space demands. Fixing it means reducing in the periodic space, or
adding seam constraints; that is a different algorithm, not a bounded change, so it is left
alone here. The existing periodic tests pass because they elevate first, which makes the
reduction exact.

## Notes

- `lepard` has its own `_degree_reduce_1d` and `_squared_l2_norm_1d` under
  `implicit.algoim._bernstein_core` and imports neither of the kernels removed here.
- The bidiagonal-QR kernels are gone from both packages (130 lines in `_bezier_core.py`,
  113 in `_bspline_degree_core.py`), replaced by one shared `_apply_reduction_operator`.
  It stays serial: the sizes are tiny, and the repository already documents why compiled
  `parallel=True` kernels must not join paths the warmup thread can enter.
- Changelog entry added under `Unreleased` — the first of this sweep, since this is the
  first change to alter numbers a released API already returned.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
