### PR TITLE
perf(bspline): banded row-wise Oslo knot insertion

### DIFF
--- a/src/pantr/bspline/_bspline_knot_insertion_core.py
+++ b/src/pantr/bspline/_bspline_knot_insertion_core.py
@@ -1,8 +1,18 @@
 """Numba kernels for B-spline knot insertion via the Oslo algorithm.
 
-Implements the discrete B-spline recurrence from Cohen, Lyche, Riesenfeld (1980)
-to compute a refinement matrix that maps old control points to new ones in a
-single pass.
+Implements the discrete B-spline recurrence from Cohen, Lyche & Riesenfeld
+(1980), which maps old control points to new ones in a single pass.
+
+The recurrence is run **row by row over a band of ``degree + 1`` entries**
+(Lyche & Mørken, *Spline Methods*, section 4.2.3), not over a dense matrix: row
+``i`` of the refinement matrix is a discrete B-spline supported on the columns
+``[mu(i) - degree, mu(i)]``, so everything a dense sweep computes outside that
+window is exactly zero.  One row costs ``O(degree^2)`` instead of
+``O(n * degree)``.
+
+Both forms are available.  :func:`_insert_knots_1d_core` never materialises the
+matrix, while :func:`_compute_oslo_matrix_1d_core` scatters the bands into the
+dense array its callers expect.
 
 Note:
     Inputs are assumed to be correct (no validation performed).
@@ -20,6 +30,97 @@ from .._numba_compat import nb_jit
 
 
 @nb_jit(nopython=True, cache=True)
+def _compute_oslo_rows_1d_core(
+    degree: int,
+    old_knots: npt.NDArray[Any],
+    new_knots: npt.NDArray[Any],
+) -> tuple[npt.NDArray[Any], npt.NDArray[np.int64]]:
+    r"""Compute the Oslo refinement matrix one banded row at a time.
+
+    Row ``i`` of the refinement matrix holds the discrete B-splines
+    :math:`\alpha_{j,p+1}(i)`, which vanish outside ``j`` in
+    ``[mu(i) - degree, mu(i)]`` where ``mu(i)`` is the old-knot span containing
+    ``new_knots[i]``.  Only that window is computed, by the recurrence
+
+    .. math::
+
+        \alpha_j^{(k+1)}
+        = \frac{x_k - t_j}{t_{j+k} - t_j}\,\alpha_j^{(k)}
+        + \frac{t_{j+k+1} - x_k}{t_{j+k+1} - t_{j+1}}\,\alpha_{j+1}^{(k)},
+        \qquad x_k = \tau_{i+k},
+
+    run for ``k = 1 .. degree`` from the seed ``alpha_mu = 1``.  A term whose
+    denominator vanishes is dropped, and since the two terms that consume
+    :math:`\alpha_j^{(k)}` share the denominator :math:`t_{j+k} - t_j`, one test
+    per entry settles both — which is what lets the level be run in place with a
+    single carried value.
+
+    Unlike the Cox-de Boor triangle for basis functions, the evaluation point
+    changes with the level (:math:`x_k = \tau_{i+k}`), so no knot differences can
+    be reused across levels.
+
+    Args:
+        degree (int): Polynomial degree of the B-spline.
+        old_knots (npt.NDArray[Any]): Original knot vector of shape
+            ``(n + degree + 2,)``.
+        new_knots (npt.NDArray[Any]): Refined (merged) knot vector of shape
+            ``(m + degree + 2,)``.  Must be a superset of ``old_knots``.
+
+    Returns:
+        tuple[npt.NDArray[Any], npt.NDArray[np.int64]]: ``(alphas, first_col)``
+        where ``alphas`` has shape ``(m + 1, degree + 1)`` and ``first_col`` has
+        shape ``(m + 1,)``.  Entry ``alphas[i, l]`` is the coefficient of old
+        control point ``first_col[i] + l``.  ``first_col[i]`` is negative when
+        the span sits within the first ``degree`` knots, which happens on
+        non-clamped (periodic) knot vectors; the corresponding leading entries
+        are meaningless and callers must skip columns outside ``[0, n]``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call the Layer 2 helper ``_insert_knots_bspline_1d_impl``
+        instead.
+    """
+    p = degree
+    n = old_knots.shape[0] - p - 2  # num old control points - 1
+    m = new_knots.shape[0] - p - 2  # num new control points - 1
+
+    alphas = np.zeros((m + 1, p + 1), dtype=old_knots.dtype)
+    first_col = np.empty(m + 1, dtype=np.int64)
+
+    for i in range(m + 1):
+        # Span of the old knot vector containing new_knots[i].  The right
+        # endpoint lands past the last span and is clamped back onto it.
+        mu = np.searchsorted(old_knots, new_knots[i], side="right") - 1
+        mu = min(mu, n)
+        mu = max(mu, 0)
+        first_col[i] = mu - p
+
+        band = alphas[i]
+        band[p] = 1.0
+
+        for k in range(1, p + 1):
+            x = new_knots[i + k]
+            saved = 0.0
+            # The band grows one entry to the left per level; entries left of
+            # column 0 only ever feed columns further left, so they are skipped.
+            l_start = max(p - k + 1, p - mu)
+            for level_index in range(l_start, p + 1):
+                j = mu - p + level_index
+                denom = old_knots[j + k] - old_knots[j]
+                if denom > 0.0:
+                    to_left = (old_knots[j + k] - x) / denom * band[level_index]
+                    to_right = (x - old_knots[j]) / denom * band[level_index]
+                else:
+                    to_left = 0.0
+                    to_right = 0.0
+                band[level_index - 1] = saved + to_left
+                saved = to_right
+            band[p] = saved
+
+    return alphas, first_col
+
+
+@nb_jit(nopython=True, cache=True)
 def _compute_oslo_matrix_1d_core(
     degree: int,
     old_knots: npt.NDArray[Any],
@@ -29,6 +130,9 @@ def _compute_oslo_matrix_1d_core(
 
     Returns the matrix ``alpha`` of shape ``(m+1, n+1)`` such that the new
     control points ``Q = alpha @ P`` reproduce the original geometry exactly.
+    Assembled by scattering the banded rows of
+    :func:`_compute_oslo_rows_1d_core`, which reproduces the dense recurrence
+    entry for entry: outside the band the dense sweep computes exact zeros.
 
     Args:
         degree (int): Polynomial degree of the B-spline.
@@ -48,52 +152,15 @@ def _compute_oslo_matrix_1d_core(
     n = old_knots.shape[0] - degree - 2  # num old control points - 1
     m = new_knots.shape[0] - degree - 2  # num new control points - 1
 
-    # Two (m+1) x (n+2) buffers: column n+1 is a permanent ghost column of zeros,
-    # used so that the recurrence can safely access alpha[i, j+1] when j == n.
-    alpha_prev = np.zeros((m + 1, n + 2), dtype=old_knots.dtype)
-    alpha_curr = np.zeros((m + 1, n + 2), dtype=old_knots.dtype)
+    alphas, first_col = _compute_oslo_rows_1d_core(degree, old_knots, new_knots)
 
-    # Base case (order 1): alpha[i, j] = 1 if old_knots[j] <= new_knots[i] < old_knots[j+1].
-    # For the right endpoint (new_knots[i] == old_knots[-1]) searchsorted returns an
-    # index beyond n, which we clamp to n.
-    for i in range(m + 1):
-        si = new_knots[i]
-        j = np.searchsorted(old_knots, si, side="right") - 1
-        j = min(j, n)
-        j = max(j, 0)
-        alpha_prev[i, j] = 1.0
-
-    # Recurrence: build up from order 1 to order degree+1.
-    for k in range(2, degree + 2):
-        # Clear current buffer.
-        for i in range(m + 1):
-            for jj in range(n + 2):
-                alpha_curr[i, jj] = 0.0
-
-        for i in range(m + 1):
-            sik = new_knots[i + k - 1]  # s_{i+k-1} in the Oslo notation
-            for j in range(n + 1):
-                val = 0.0
-                # First term: (sik - t_j) / (t_{j+k-1} - t_j)
-                denom1 = old_knots[j + k - 1] - old_knots[j]
-                if denom1 > 0.0:
-                    val += (sik - old_knots[j]) / denom1 * alpha_prev[i, j]
-                # Second term: (t_{j+k} - sik) / (t_{j+k} - t_{j+1})
-                denom2 = old_knots[j + k] - old_knots[j + 1]
-                if denom2 > 0.0:
-                    val += (old_knots[j + k] - sik) / denom2 * alpha_prev[i, j + 1]
-                alpha_curr[i, j] = val
-
-        # Swap buffers.
-        for i in range(m + 1):
-            for jj in range(n + 2):
-                alpha_prev[i, jj] = alpha_curr[i, jj]
-
-    # Extract the (m+1, n+1) block (drop ghost column).
     result = np.zeros((m + 1, n + 1), dtype=old_knots.dtype)
     for i in range(m + 1):
-        for j in range(n + 1):
-            result[i, j] = alpha_prev[i, j]
+        base = first_col[i]
+        for level_index in range(degree + 1):
+            col = base + level_index
+            if 0 <= col <= n:
+                result[i, col] = alphas[i, level_index]
     return result
 
 
@@ -121,9 +188,27 @@ def _insert_knots_1d_core(
         Inputs are assumed to be correct (no validation performed).
         For general use, call the Layer 2 helper ``_insert_knots_bspline_1d_impl``
         instead.
+
+        The refinement matrix is never materialised: each new control point is
+        the combination of the ``degree + 1`` old ones its band selects.  The
+        summation order therefore differs from the dense matrix product this
+        replaced, so results may move in the last bits.
     """
-    oslo = _compute_oslo_matrix_1d_core(degree, old_knots, new_knots)
-    result: npt.NDArray[Any] = oslo @ ctrl
+    n = old_knots.shape[0] - degree - 2
+    m = new_knots.shape[0] - degree - 2
+    rank = ctrl.shape[1]
+
+    alphas, first_col = _compute_oslo_rows_1d_core(degree, old_knots, new_knots)
+
+    result = np.zeros((m + 1, rank), dtype=ctrl.dtype)
+    for i in range(m + 1):
+        base = first_col[i]
+        for level_index in range(degree + 1):
+            col = base + level_index
+            if 0 <= col <= n:
+                weight = alphas[i, level_index]
+                for r in range(rank):
+                    result[i, r] += weight * ctrl[col, r]
     return result
 
 
@@ -138,11 +223,13 @@ def _warmup_numba_functions() -> None:
     ctrl = np.array([[0.0, 0.0], [0.5, 1.0], [1.0, 0.0]], dtype=np.float64)
     degree = 2
 
+    _compute_oslo_rows_1d_core(degree, old_knots, new_knots)
     _compute_oslo_matrix_1d_core(degree, old_knots, new_knots)
     _insert_knots_1d_core(degree, old_knots, ctrl, new_knots)
 
 
 __all__ = [
     "_compute_oslo_matrix_1d_core",
+    "_compute_oslo_rows_1d_core",
     "_insert_knots_1d_core",
 ]

--- a/tests/test_knot_insertion.py
+++ b/tests/test_knot_insertion.py
@@ -7,6 +7,11 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
+from pantr.bspline._bspline_knot_insertion_core import (
+    _compute_oslo_matrix_1d_core,
+    _compute_oslo_rows_1d_core,
+    _insert_knots_1d_core,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -678,3 +683,257 @@ class TestPeriodicBsplineSubdivide:
         orig = bsp.to_open_bspline().evaluate(pts)
         sub = subdivided.to_open_bspline().evaluate(pts)
         np.testing.assert_allclose(orig, sub, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Banded Oslo rows
+# ---------------------------------------------------------------------------
+
+_EPS = float(np.finfo(np.float64).eps)
+
+_OSLO_ATOL_FACTOR = 8.0
+"""Safety factor on the agreement between the banded and dense Oslo sweeps.
+
+The two run the same recurrence over the same knot differences in the same
+order — the banded one simply skips the entries the dense one computes as exact
+zeros — so they agree bit for bit whenever the compiler emits the same
+instructions, which is what is observed here. The bound is written in eps rather
+than as an equality because the assertion crosses a compilation boundary: the
+reference is interpreted NumPy while the kernel is compiled, and a fused
+multiply-add contracted by one and not the other moves the last bit without
+anything being wrong. Eight eps is the classic forward bound for the three
+roundings per entry, with room for that contraction.
+"""
+
+
+def _dense_oslo_reference(
+    degree: int,
+    old_knots: npt.NDArray[np.float64],
+    new_knots: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Build the Oslo matrix by the dense sweep the banded kernel replaced.
+
+    Kept here as an oracle: it walks every column at every order, so it makes no
+    assumption about where the discrete B-splines are supported.
+
+    Args:
+        degree (int): Polynomial degree.
+        old_knots (npt.NDArray[np.float64]): Original knot vector.
+        new_knots (npt.NDArray[np.float64]): Refined knot vector.
+
+    Returns:
+        npt.NDArray[np.float64]: Dense refinement matrix of shape ``(m+1, n+1)``.
+    """
+    n = old_knots.shape[0] - degree - 2
+    m = new_knots.shape[0] - degree - 2
+
+    previous = np.zeros((m + 1, n + 2))
+    current = np.zeros((m + 1, n + 2))
+
+    for i in range(m + 1):
+        j = int(np.searchsorted(old_knots, new_knots[i], side="right")) - 1
+        previous[i, min(max(j, 0), n)] = 1.0
+
+    for k in range(2, degree + 2):
+        current[:] = 0.0
+        for i in range(m + 1):
+            sik = new_knots[i + k - 1]
+            for j in range(n + 1):
+                value = 0.0
+                denom1 = old_knots[j + k - 1] - old_knots[j]
+                if denom1 > 0.0:
+                    value += (sik - old_knots[j]) / denom1 * previous[i, j]
+                denom2 = old_knots[j + k] - old_knots[j + 1]
+                if denom2 > 0.0:
+                    value += (old_knots[j + k] - sik) / denom2 * previous[i, j + 1]
+                current[i, j] = value
+        previous[:] = current
+
+    return previous[:, : n + 1].copy()
+
+
+def _scatter_oslo_rows(
+    alphas: npt.NDArray[np.float64], first_col: npt.NDArray[np.int64], n_cols: int
+) -> npt.NDArray[np.float64]:
+    """Place banded rows into a dense matrix, dropping columns outside the space.
+
+    Args:
+        alphas (npt.NDArray[np.float64]): Bands of shape ``(m+1, degree+1)``.
+        first_col (npt.NDArray[np.int64]): Global column of each band's first entry.
+        n_cols (int): Number of old control points.
+
+    Returns:
+        npt.NDArray[np.float64]: Dense matrix of shape ``(m+1, n_cols)``.
+    """
+    dense = np.zeros((alphas.shape[0], n_cols))
+    for i in range(alphas.shape[0]):
+        for offset in range(alphas.shape[1]):
+            col = int(first_col[i]) + offset
+            if 0 <= col < n_cols:
+                dense[i, col] = alphas[i, offset]
+    return dense
+
+
+def _oslo_case(
+    degree: int, kind: str, seed: int
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Build an (old, refined) knot-vector pair of the requested shape.
+
+    Args:
+        degree (int): Polynomial degree.
+        kind (str): One of ``uniform``, ``non_uniform``, ``multiple``,
+            ``single_knot``, ``re_insert``, ``many``.
+        seed (int): Seed for the random parts.
+
+    Returns:
+        tuple: ``(old_knots, new_knots)`` with ``new_knots`` a superset.
+    """
+    rng = np.random.default_rng(seed)
+    if kind == "non_uniform":
+        interior = np.sort(rng.random(5))
+    elif kind == "multiple":
+        # Interior knots repeated up to multiplicity `degree`.
+        interior = np.repeat(np.array([0.25, 0.5, 0.75]), max(1, degree))
+    else:
+        interior = np.linspace(0.0, 1.0, 6)[1:-1]
+
+    old = np.concatenate([np.zeros(degree + 1), interior, np.ones(degree + 1)])
+
+    if kind == "single_knot":
+        inserted = np.array([0.37])
+    elif kind == "re_insert":
+        # Raise the multiplicity of knots that are already there.
+        existing = np.unique(old[degree + 1 : old.shape[0] - degree - 1])
+        inserted = np.repeat(existing, max(1, degree - 1)) if existing.size else np.array([0.5])
+    elif kind == "many":
+        inserted = np.sort(rng.random(37))
+    else:
+        inserted = np.sort(rng.random(4))
+
+    return old, np.sort(np.concatenate([old, inserted]))
+
+
+_OSLO_KINDS = ["uniform", "non_uniform", "multiple", "single_knot", "re_insert", "many"]
+
+
+class TestOsloBandedRows:
+    """The banded row recurrence against the dense sweep it replaced."""
+
+    @pytest.mark.parametrize("degree", range(9))
+    @pytest.mark.parametrize("kind", _OSLO_KINDS)
+    def test_banded_rows_reproduce_the_dense_sweep(self, degree: int, kind: str) -> None:
+        """Scattering the bands gives back the dense refinement matrix."""
+        old, new = _oslo_case(degree, kind, seed=degree * 10 + len(kind))
+        reference = _dense_oslo_reference(degree, old, new)
+
+        alphas, first_col = _compute_oslo_rows_1d_core(degree, old, new)
+        scattered = _scatter_oslo_rows(alphas, first_col, reference.shape[1])
+
+        assert alphas.shape == (reference.shape[0], degree + 1)
+        assert first_col.shape == (reference.shape[0],)
+        np.testing.assert_allclose(scattered, reference, rtol=0.0, atol=_OSLO_ATOL_FACTOR * _EPS)
+
+    @pytest.mark.parametrize("degree", range(9))
+    @pytest.mark.parametrize("kind", _OSLO_KINDS)
+    def test_dense_wrapper_is_unchanged(self, degree: int, kind: str) -> None:
+        """The public dense kernel still returns what the dense sweep returned."""
+        old, new = _oslo_case(degree, kind, seed=degree + 3)
+
+        np.testing.assert_allclose(
+            _compute_oslo_matrix_1d_core(degree, old, new),
+            _dense_oslo_reference(degree, old, new),
+            rtol=0.0,
+            atol=_OSLO_ATOL_FACTOR * _EPS,
+        )
+
+    @pytest.mark.parametrize("degree", range(1, 7))
+    @pytest.mark.parametrize("kind", _OSLO_KINDS)
+    def test_the_dense_matrix_has_no_nonzeros_outside_the_band(
+        self, degree: int, kind: str
+    ) -> None:
+        """Everything the dense sweep computes outside the band is exactly zero.
+
+        This is the claim the whole change rests on, so it is checked against the
+        dense oracle rather than against the banded kernel.
+        """
+        old, new = _oslo_case(degree, kind, seed=degree * 7 + 1)
+        reference = _dense_oslo_reference(degree, old, new)
+        _, first_col = _compute_oslo_rows_1d_core(degree, old, new)
+
+        for i in range(reference.shape[0]):
+            nonzero = np.flatnonzero(reference[i] != 0.0)
+            if nonzero.size:
+                assert nonzero.min() >= first_col[i]
+                assert nonzero.max() <= first_col[i] + degree
+
+    @pytest.mark.parametrize("degree", range(9))
+    @pytest.mark.parametrize("kind", _OSLO_KINDS)
+    def test_rows_sum_to_one(self, degree: int, kind: str) -> None:
+        """Discrete B-splines form a partition of unity on every row."""
+        old, new = _oslo_case(degree, kind, seed=degree * 5 + 2)
+        alphas, first_col = _compute_oslo_rows_1d_core(degree, old, new)
+        n_cols = old.shape[0] - degree - 1
+
+        sums = _scatter_oslo_rows(alphas, first_col, n_cols).sum(axis=1)
+
+        np.testing.assert_allclose(sums, 1.0, rtol=0.0, atol=_OSLO_ATOL_FACTOR * _EPS)
+
+    @pytest.mark.parametrize("degree", [2, 3, 4, 5])
+    def test_periodic_knot_vectors_push_the_band_left_of_the_space(self, degree: int) -> None:
+        """A non-clamped knot vector produces bands that start before column 0.
+
+        The clipping in the kernel's consumers is therefore load-bearing, not
+        defensive: on these vectors some spans sit inside the first ``degree``
+        knots.
+        """
+        periodic = np.asarray(
+            create_uniform_periodic_knots(num_intervals=6, degree=degree), dtype=np.float64
+        )
+        refined = np.sort(np.concatenate([periodic, np.array([0.05, 0.55])]))
+
+        alphas, first_col = _compute_oslo_rows_1d_core(degree, periodic, refined)
+        n_cols = periodic.shape[0] - degree - 1
+
+        assert (first_col < 0).any()
+        reference = _dense_oslo_reference(degree, periodic, refined)
+        np.testing.assert_allclose(
+            _scatter_oslo_rows(alphas, first_col, n_cols),
+            reference,
+            rtol=0.0,
+            atol=_OSLO_ATOL_FACTOR * _EPS,
+        )
+
+    @pytest.mark.parametrize("degree", range(1, 7))
+    @pytest.mark.parametrize("kind", _OSLO_KINDS)
+    def test_insertion_matches_the_dense_matrix_product(self, degree: int, kind: str) -> None:
+        """Applying the bands agrees with multiplying by the dense matrix.
+
+        The two sum the same products in a different order, so they are compared
+        within the forward bound of a dot product of ``degree + 1`` terms rather
+        than by equality.
+        """
+        rng = np.random.default_rng(degree * 11 + len(kind))
+        old, new = _oslo_case(degree, kind, seed=degree + 17)
+        ctrl = rng.standard_normal((old.shape[0] - degree - 1, 3))
+
+        banded = _insert_knots_1d_core(degree, old, ctrl, new)
+        dense = _dense_oslo_reference(degree, old, new) @ ctrl
+
+        atol = (degree + 1) * _EPS * float(np.max(np.abs(ctrl)))
+        np.testing.assert_allclose(banded, dense, rtol=0.0, atol=atol)
+
+    @pytest.mark.parametrize("degree", range(1, 7))
+    @pytest.mark.parametrize("rational", [False, True])
+    def test_geometry_is_preserved(self, degree: int, rational: bool) -> None:
+        """Refinement leaves the mapping unchanged at a thousand random points."""
+        rng = np.random.default_rng(degree * 3 + int(rational))
+        knots = np.concatenate([np.zeros(degree), np.linspace(0.0, 1.0, 7), np.ones(degree)])
+        space = BsplineSpace([BsplineSpace1D(knots, degree)])
+        ctrl = rng.random((space.num_total_basis, 4)) + 1.0
+        bsp = Bspline(space, ctrl, is_rational=rational)
+
+        refined = bsp.insert_knots(np.sort(rng.random(23)))
+
+        pts = np.sort(rng.random(1000))
+        atol = 64.0 * _EPS * float(np.max(np.abs(bsp.evaluate(pts))))
+        np.testing.assert_allclose(refined.evaluate(pts), bsp.evaluate(pts), rtol=0.0, atol=atol)


### PR DESCRIPTION
## Context

Row `i` of the Oslo refinement matrix is a discrete B-spline supported on the `degree + 1`
columns `[mu(i) - degree, mu(i)]`. Everything the dense sweep computed outside that window
was an exact zero it spent `O(n)` per row to produce. The recurrence now runs over the band
alone, one row at a time, in `O(degree²)` (Lyche & Mørken, *Spline Methods*, section 4.2.3).

- `_compute_oslo_rows_1d_core(degree, old_knots, new_knots) -> (alphas, first_col)` is the
  new kernel: `alphas` is `(m+1, degree+1)`, `first_col[i]` the global column of
  `alphas[i, 0]`.
- `_insert_knots_1d_core` never materialises the matrix — each new control point is the
  combination of the `degree + 1` old ones its band selects.
- `_compute_oslo_matrix_1d_core` keeps its exact signature and dense return for the THB,
  spline-product and periodic-conversion callers, now assembled by scattering the bands.

## Benchmark

Min of five, after JIT warm-up, against the dense sweep kept verbatim as the reference.
"rows only" is the banded kernel without building any dense array.

| case | matrix, old | matrix, new | rows only | insert, old | insert, new | insert speed-up |
|---|---|---|---|---|---|---|
| `p=3 n=20 +5` | 0.004 ms | 0.002 ms | 0.002 ms | 0.005 ms | 0.002 ms | **2.2x** |
| `p=3 n=10³ +10³` | 10.20 ms | 0.24 ms | 0.12 ms | 10.76 ms | 0.145 ms | **74x** |
| `p=3 n=10³ +10⁴` | 66.7 ms | 4.75 ms | 0.67 ms | 69.3 ms | 0.77 ms | **90x** |
| `p=3 n=10⁴ dyadic` | 1367 ms | 102 ms | 1.60 ms | 1432 ms | 1.86 ms | **768x** |
| `p=8 n=2·10³ +2·10³` | 114.6 ms | 3.36 ms | 0.46 ms | 116.9 ms | 0.54 ms | **215x** |

The small case is 2.2x *faster*, not slower, so the parallel-launch concern the ticket
raises does not arise — see claim 2 below.

## What the ticket got wrong

Eleven tickets in, this is the first whose mathematics is right as written: the recurrence
in the ticket is the existing dense one under the index shift `k_ticket = k_dense − 1`, and
the support claim is exactly true (measured: **zero** rows, over degrees 0–8 and six knot
configurations, have a dense nonzero outside the band). Three things do not survive
measurement.

1. **"Expected ≥ 50x on the build" — not reached, and it cannot be.** The dense wrapper
   comes out at **13.4x** on the ticket's own dyadic case and 14.0x on the large one. The
   ticket names the reason itself and then does not carry it into the estimate: the wrapper
   still allocates and zero-fills an `(m+1) × (n+1)` array, which is `O(m·n)` and now
   dominates everything else it does. The recurrence itself is **856x** faster there. The
   hard gate (≥ 10x) is met in every case; the ≥ 50x figure only holds where `n` is small
   enough for the zero-fill not to dominate (42x at `n = 10³`, 34x at degree 8). Callers
   that want the full win must take the banded rows, which is what `_insert_knots_1d_core`
   now does and what a follow-up would do for the THB and product paths.

2. **`prange` over rows is prescribed, and is the wrong call here.** Not used. The serial
   kernel already returns 768x on the ticket's own large case, and pantr deliberately keeps
   compiled `parallel=True` kernels **out** of the warmup path: the Numba workqueue
   threading layer is not threadsafe against the async warmup thread, which is the process
   abort documented in `pantr/__init__.py` and re-measured in #270. The ticket asks in the
   same breath for `prange` *and* for the kernel to join `_warmup_numba_functions()`; those
   two cannot both happen. Serial satisfies both, at no measured cost.

3. **"With the clamping of step 1 these entries are provably zero, but clip defensively" —
   the clip is not defensive, it is load-bearing.** `first_col[i]` really does go negative:
   on a non-clamped (periodic) knot vector, `mu < degree` for 2 of 8 rows at degree 2, 3 of
   9 at degree 3 and 4 of 10 at degree 4. The *values* dropped are indeed exactly zero
   (measured, no exception found), so the ticket's parenthesis is right about the
   arithmetic; but a consumer that computes `ctrl[first_col[i] + l]` without the range test
   indexes with a negative number, which under `nopython` silently wraps to the end of the
   control-point array. Both consumers test the range, and the docstring says why.

## Verification

- **Against the dense sweep**, kept in the test module as an oracle that walks every column
  at every order and so assumes nothing about the support: degrees **0 to 8** × six knot
  configurations (uniform, non-uniform, interior multiplicities up to `degree`, a single
  inserted knot, re-inserting existing knots, 37 knots at once), for the banded rows, for
  the dense wrapper, and for the insertion path.
- **The support claim itself** is checked against that oracle rather than against the new
  kernel: no row has a nonzero outside its band.
- **Row sums are 1** to 8 eps (partition of unity of the discrete B-splines), on every case.
- **Non-clamped knot vectors** get their own test, asserting that `first_col` goes negative
  and that the scattered result still matches the oracle.
- **Geometry**: degrees 1–6, rational and polynomial, 23 knots inserted, compared at 1000
  random points.
- The dense matrix is **bitwise identical** to before on every benchmark case, so the THB,
  product and periodic-conversion callers are numerically untouched. The insertion path
  sums the same products in a different order and moves by at most **0.8 eps** relative,
  which is why its test asserts a forward bound rather than equality.
- Full suite: 4855 passed, 19 skipped. Existing knot-insertion, THB and product tests pass
  unchanged.

## Notes

- `lepard` imports neither Oslo kernel (checked); no external consumer to keep in step.
- Not migrated in this PR, as the ticket asks: the THB two-scale relation, the spline
  products and the periodic conversions still consume the dense matrix. They are where the
  remaining `O(m·n)` sits, and each needs its own reasoning about what it does with the
  matrix afterwards.

Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
