### PR TITLE
fix(bspline,grid): close eight Layer-2 validation gaps and the np.isclose tolerance leak

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,6 +76,42 @@
   endpoint condition and still returns the mean of the control points.
 
 ### Fixed
+- Knot comparisons went through `np.isclose(a, b, atol=tol)` at 26 sites across
+  seven modules. Setting `atol` does not clear `rtol`, which stays at NumPy's
+  default `1e-5`, so the effective test was `|a - b| <= tol + 1e-5 * |b|`: on a
+  domain of length 1 placed at `1e6` the tolerance was 10, not the `1e-15` the
+  space reports. The consequences were a periodic space reporting the wrong
+  number of basis functions, the in-domain gate admitting points ten domain
+  lengths outside, `remove_knots` removing a different knot than the one asked
+  for, `split` and `restrict` returning a piece that no longer interpolated its
+  own end control point, and the exact extraction operator being discarded in
+  favour of the identity on a knot vector that was near-uniform but not uniform.
+  On a *translated* periodic domain it was also memory-unsafe: degree elevation
+  indexed out of bounds, unchecked under `nopython`. All 26 now compare
+  absolutely.
+- Degree operations had no upper bound, while the exact-integer binomial
+  recurrence they rely on overflows `int64` at `n = 62` — silently, since
+  `nopython` does not trap it. `Bspline.elevate_degree`, `Bezier.elevate_degree`
+  and Bézier composition returned corrupted control points from that degree on,
+  where degree elevation must leave the curve pointwise unchanged. Two paths
+  nobody would associate with degree elevation reach the same recurrence and are
+  now capped too: `Bspline.derivative` on a rational spline, and
+  `Bezier.minimize_degree`.
+- Evaluating a 1D `Bspline` at points shaped `(n, 1)` — the shape the
+  `(n_pts, dim)` convention implies, and the one this project's own docstring
+  example uses — raised a Numba typing error from inside the kernel instead of
+  being accepted. Points are now normalised before they reach any kernel, on all
+  four entry points, and array-likes are coerced rather than failing on a
+  missing `dtype` attribute.
+- `SpanwiseElementExtraction.apply` and `apply_transpose` accepted an `out=`
+  array aliasing their input and returned a silently wrong result; the alias
+  check existed only for the two bilateral op kinds. `idx_map` was checked
+  against its upper bound only, and only for non-identity entries, so a negative
+  index reached the kernel and read out of bounds.
+- `get_cardinal_intervals` on a degree-0 space read past the end of an empty
+  array. `BVH` accepted node arrays deeper than the fixed traversal stack its own
+  query kernels assume, and node arrays whose leaf markers and child pointers
+  disagreed; both are rejected at construction now.
 - `Bspline.reduce_degree` wrote past the end of its output buffers whenever the
   reduced Bézier form needed more control points than `len(knots)` allowed —
   from 13 elements on at degree 4, 8 at degree 5, 5 at degree 8, on the open,

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from ..bspline._bspline_degree_core import _check_bincoeff_envelope
 from ._bezier_core import _scalar_bernstein_product_1d_core
 from ._bezier_product import _bernstein_product_coefficients_nd
 
@@ -46,6 +47,9 @@ def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
         TypeError: If either operand is rational.
         ValueError: If ``inner.rank != outer.dim``.
         ValueError: If the operands have different dtypes.
+        ValueError: If a 1D inner Bézier would drive the composed degree past the
+            exactness envelope of the binomial-coefficient kernel (see
+            :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
     """
     if outer.is_rational:
         raise TypeError("Composition is not supported for rational Béziers (outer is rational).")
@@ -58,6 +62,32 @@ def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
         )
     if outer.dtype != inner.dtype:
         raise ValueError(f"Operands must have the same dtype. Got {outer.dtype} and {inner.dtype}.")
+
+    # A 1D inner reparametrization routes the Bernstein products through
+    # ``_scalar_bernstein_product_1d_core``, whose ``C(r, k)`` with ``r = p + q``
+    # reaches the largest product degree formed.  That is the full composed degree
+    # ``sum(outer.degree) * inner.degree[0]``: the per-direction power ladder in
+    # ``_compute_scalar_powers`` climbs to ``outer.degree[d] * inner.degree[0]``, and
+    # the cross-direction accumulation in ``_compose_impl`` then multiplies the
+    # per-direction bases together.  The envelope is therefore *multiplicative* in the
+    # operands and binds at far lower input degrees than degree elevation's additive
+    # one: an outer of degree 6 composed with an inner of degree 11 already asks for
+    # ``C(66, k)``, and was measured off by 30.4 composing the identity with itself.
+    #
+    # Two configurations are exposure-free and deliberately left uncapped:
+    #   * an nD inner, which takes ``_bernstein_product_coefficients_nd`` instead --
+    #     built on arbitrary-precision ``math.comb``, so it cannot wrap;
+    #   * a *1D* outer of degree <= 1, for which no product is formed at all (the power
+    #     ladder needs degree >= 2 and there is no second direction to multiply into),
+    #     so ``_bincoeff`` is never called. Verified: a degree-1 outer composed with a
+    #     degree-70 inner reproduces the identity to 1.0e-15.
+    # A degree-(1, 1) *2D* outer is not exempt: the cross-direction product runs, and
+    # it was measured off by 2.019 at a composed degree of 62.
+    if inner.dim == 1 and (outer.dim > 1 or outer.degree[0] > 1):
+        composed = sum(outer.degree) * inner.degree[0]
+        _check_bincoeff_envelope(
+            composed, f"Composition to degree {composed} with a 1D inner Bézier"
+        )
 
     return _compose_impl(outer, inner)
 

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -25,7 +25,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ..bspline._bspline_degree_core import _apply_reduction_operator
+from ..bspline._bspline_degree_core import _apply_reduction_operator, _check_bincoeff_envelope
 from ._bezier_core import _degree_elevate_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -72,6 +72,11 @@ def _degree_elevate_bezier(
         ~pantr.bezier.Bezier: New Bézier with elevated degrees and updated
         control points.
 
+    Raises:
+        ValueError: If an elevated degree would exceed the exactness envelope of the
+            binomial-coefficient kernel (see
+            :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
+
     Note:
         Inputs are assumed to be validated by the caller (Layer 1).
     """
@@ -79,6 +84,15 @@ def _degree_elevate_bezier(
 
     ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
     degrees = bezier.degree
+
+    # ``_degree_elevate_bezier_1d_core`` builds its coefficient table from
+    # ``C(p + inc, i)``, so the elevated degree is what has to stay in range.
+    for d in range(bezier.dim):
+        if increments[d] > 0:
+            elevated = degrees[d] + increments[d]
+            _check_bincoeff_envelope(
+                elevated, f"Degree elevation to degree {elevated} in direction {d}"
+            )
 
     for d in range(bezier.dim):
         inc = increments[d]
@@ -486,8 +500,21 @@ def _minimize_degree_bezier(
         ~pantr.bezier.Bezier: A new Bézier with the lowest degree that
         preserves accuracy within ``tol``.  If no reduction is possible,
         returns a copy of the input.
+
+    Raises:
+        ValueError: If a direction's degree exceeds the exactness envelope of the
+            binomial-coefficient kernel (see
+            :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
+
+    # Each trial re-elevates from ``degree - 1`` back to ``degree``, starting at the
+    # direction's own degree, so that degree bounds the coefficients needed.  Corrupted
+    # coefficients would not merely lose accuracy here: they feed the round-trip error
+    # measure, and so the accept/reject verdict itself.
+    for d, p in enumerate(bezier.degree):
+        if p >= 1:
+            _check_bincoeff_envelope(p, f"Degree minimization of a degree-{p} direction {d}")
 
     ctrl: npt.NDArray[np.floating[Any]] = bezier.control_points  # (*orders, rank)
     rank = ctrl.shape[-1]

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -184,7 +184,7 @@ class Bspline:
         """Evaluate the B-spline at the given points.
 
         Args:
-            pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
+            pts (npt.ArrayLike | PointsLattice): The
                 parametric points at which to evaluate the B-spline, shaped
                 ``(n_pts, dim)`` or, for a 1D B-spline, either ``(n_pts,)`` or
                 ``(n_pts, 1)``. Array-likes are converted; the dtype must match
@@ -219,7 +219,7 @@ class Bspline:
         the returned values are derivatives of the projected mapping.
 
         Args:
-            pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
+            pts (npt.ArrayLike | PointsLattice): The
                 parametric points at which to evaluate. For 1D B-splines, an
                 array of shape ``(n_pts,)`` or ``(n_pts, 1)``, or a 1D
                 :class:`~pantr.quad.PointsLattice`. For multi-dimensional

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -178,14 +178,17 @@ class Bspline:
 
     def evaluate(
         self,
-        pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+        pts: npt.ArrayLike | PointsLattice,
         out: npt.NDArray[np.float32 | np.float64] | None = None,
     ) -> npt.NDArray[np.float32 | np.float64]:
         """Evaluate the B-spline at the given points.
 
         Args:
             pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
-                parametric points at which to evaluate the B-spline.
+                parametric points at which to evaluate the B-spline, shaped
+                ``(n_pts, dim)`` or, for a 1D B-spline, either ``(n_pts,)`` or
+                ``(n_pts, 1)``. Array-likes are converted; the dtype must match
+                the B-spline's.
             out (npt.NDArray[np.float32 | np.float64] | None): Optional output
                 array where the result will be stored. If None, a new array is
                 allocated. This follows NumPy's style for output arrays.
@@ -196,14 +199,15 @@ class Bspline:
             points.
 
         Raises:
-            ValueError: If the points dtype does not match the B-spline dtype,
-                or if `out` has incorrect shape or dtype.
+            ValueError: If the points have an unusable shape, if their dtype does
+                not match the B-spline dtype, or if `out` has incorrect shape or
+                dtype.
         """
         return _evaluate_Bspline(self, pts, out)
 
     def evaluate_derivatives(
         self,
-        pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+        pts: npt.ArrayLike | PointsLattice,
         orders: int | Sequence[int],
         out: npt.NDArray[np.float32 | np.float64] | None = None,
     ) -> npt.NDArray[np.float32 | np.float64]:
@@ -216,12 +220,12 @@ class Bspline:
 
         Args:
             pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The
-                parametric points at which to evaluate. For 1D B-splines, must
-                be a 1D array of shape ``(n_pts,)`` or a 1D
+                parametric points at which to evaluate. For 1D B-splines, an
+                array of shape ``(n_pts,)`` or ``(n_pts, 1)``, or a 1D
                 :class:`~pantr.quad.PointsLattice`. For multi-dimensional
-                B-splines, must be a 2D array of shape ``(n_pts, dim)`` or a
+                B-splines, a 2D array of shape ``(n_pts, dim)`` or a
                 :class:`~pantr.quad.PointsLattice` with matching dimension.
-                The dtype must match the B-spline dtype.
+                Array-likes are converted; the dtype must match the B-spline's.
             orders (int | Sequence[int]): Derivative order(s). A single
                 ``int`` is broadcast to all ``self.dim`` directions. A sequence
                 must contain one non-negative integer per parametric direction

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -13,7 +13,11 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bspline_degree_core import _degree_elevate_1d_core, _degree_reduce_1d_core
+from ._bspline_degree_core import (
+    _check_bincoeff_envelope,
+    _degree_elevate_1d_core,
+    _degree_reduce_1d_core,
+)
 from ._bspline_knot_insertion import _to_open_bspline_1d_impl, _to_periodic_bspline_1d_impl
 from ._bspline_knot_removal import _remove_knot_bspline_1d_impl
 from ._bspline_knots import _get_unique_knots_and_multiplicity_impl
@@ -33,9 +37,23 @@ def _degree_elevate_bspline(bspline: Bspline, degree_increments: tuple[int, ...]
 
     Returns:
         Bspline: New B-spline with elevated degrees.
+
+    Raises:
+        ValueError: If an elevated degree would exceed the exactness envelope of the
+            binomial-coefficient kernel (see
+            :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
     """
     dim = bspline.dim
     ctrl = bspline.control_points
+
+    # ``_degree_elevate_1d_core`` builds its Bezier coefficient table from
+    # ``C(degree + inc, i)``, so the elevated degree is what has to stay in range.
+    for i in range(dim):
+        if degree_increments[i] > 0:
+            elevated = bspline.space.spaces[i].degree + degree_increments[i]
+            _check_bincoeff_envelope(
+                elevated, f"Degree elevation to degree {elevated} in direction {i}"
+            )
 
     # Bspline variables
     orig_is_rational = bspline.is_rational

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -18,6 +18,49 @@ import numpy.typing as npt
 
 from .._numba_compat import nb_jit
 
+_BINCOEFF_MAX_N: int = 61
+"""Largest ``n`` for which :func:`_bincoeff` honours its contract.
+
+The exact-integer recurrence is safe while its largest intermediate,
+``C(n, k) * min(k, n - k)``, fits in ``int64``: ``6.98e18`` at ``n = 61`` against an
+``int64`` ceiling of ``9.22e18``, and ``1.44e19`` at ``n = 62``. Numba does not trap
+integer overflow, so from ``n = 62`` an intermediate wraps and the returned value is
+silently wrong (negative, at ``(62, 31)``).
+
+This is the *integer* limit, deliberately, and not the tighter ``n = 56`` beyond which
+the ``float`` return can no longer hold ``C(n, k)`` exactly. Every caller in the
+library consumes ``_bincoeff`` only inside a floating-point **ratio** of binomial
+coefficients -- ``C(d, j) * C(t, i - j) / C(ph, i)`` in degree elevation,
+``C(p, i) * C(q, j) / C(r, k)`` in the Bernstein product -- so those ratios are formed
+in floating point regardless and a correctly rounded operand is all they can use. For
+``57 <= n <= 61`` that is exactly what :func:`_bincoeff` delivers: the integer is exact
+and the cast rounds once. Capping at 56 instead would reject usable degrees for no
+gain in the accuracy of any result the library actually computes.
+"""
+
+
+def _check_bincoeff_envelope(n: int, what: str) -> None:
+    """Raise if ``n`` exceeds the exactness envelope of :func:`_bincoeff`.
+
+    A Layer-2 validator: it lives beside the kernel whose contract it enforces so the
+    two cannot drift apart, but it is plain Python and is never called from inside a
+    kernel. Layer-3 kernels here still validate nothing.
+
+    Args:
+        n (int): Largest upper index the caller will pass to :func:`_bincoeff`.
+        what (str): Description of the requested operation, used in the error message.
+
+    Raises:
+        ValueError: If ``n`` exceeds :data:`_BINCOEFF_MAX_N`.
+    """
+    if n > _BINCOEFF_MAX_N:
+        raise ValueError(
+            f"{what} needs binomial coefficients up to C({n}, k), beyond the largest "
+            f"upper index {_BINCOEFF_MAX_N} that pantr's exact-integer binomial kernel "
+            f"can compute without an int64 overflow. Past that the coefficients wrap "
+            f"silently and the result is corrupted rather than merely inaccurate."
+        )
+
 
 @nb_jit(nopython=True, cache=True)
 def _bincoeff(n: int, k: int) -> float:

--- a/src/pantr/bspline/_bspline_derivative.py
+++ b/src/pantr/bspline/_bspline_derivative.py
@@ -292,15 +292,29 @@ def _derivative_keep_degree_nonrational(bspline: Bspline, direction: int) -> Bsp
         input.  Periodic directions in the differentiated axis are converted
         to open representation (degree elevation does not support periodic).
 
+    Raises:
+        ValueError: If the direction's degree exceeds the exactness envelope of the
+            binomial-coefficient kernel (see
+            :data:`~pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`).
+
     Note:
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_derivative_bspline` instead.
     """
     from . import Bspline as BsplineCls  # noqa: PLC0415
-    from ._bspline_degree_core import _degree_elevate_1d_core  # noqa: PLC0415
+    from ._bspline_degree_core import (  # noqa: PLC0415
+        _check_bincoeff_envelope,
+        _degree_elevate_1d_core,
+    )
 
     space_d = bspline.space.spaces[direction]
     p = space_d.degree
+
+    # Re-elevating from ``p - 1`` back to ``p`` builds the Bezier table from
+    # ``C(p, i)``.  This is the only degree-elevating path a caller can reach without
+    # asking for elevation: every derivative of a *rational* B-spline routes here,
+    # ``keep_degree`` or not.
+    _check_bincoeff_envelope(p, f"Degree-preserving derivative of a degree-{p} B-spline")
 
     # Degree elevation requires open knot vectors. For periodic B-splines,
     # convert to open representation first, then recurse.

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -193,7 +193,7 @@ def _evaluate_Bspline_1D(
     Args:
         spline (Bspline): A 1D B-spline object containing space, control points,
             and rational flag.
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+        pts (npt.ArrayLike | PointsLattice): Evaluation
             points. If a PointsLattice, must be 1D. Otherwise an array-like of
             shape (n_pts,) or (n_pts, 1), with dtype matching the B-spline's.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
@@ -533,7 +533,7 @@ def _evaluate_Bspline_deriv_1D(
     Args:
         spline (Bspline): A 1D B-spline object containing space, control points,
             and rational flag.
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+        pts (npt.ArrayLike | PointsLattice): Evaluation
             points. If a :class:`~pantr.quad.PointsLattice`, must be 1D. Otherwise
             an array-like of shape ``(n_pts,)`` or ``(n_pts, 1)``, with dtype
             matching the B-spline's.
@@ -986,7 +986,7 @@ def _evaluate_Bspline_deriv_multi_dim(
 
     Args:
         spline (Bspline): A multi-dimensional B-spline (``dim >= 2``).
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+        pts (npt.ArrayLike | PointsLattice): Evaluation
             points. Either a 2-D array of shape ``(n_pts, dim)`` or a
             :class:`~pantr.quad.PointsLattice`.
         orders (Sequence[int]): One non-negative integer per parametric direction.
@@ -1051,7 +1051,7 @@ def _evaluate_Bspline_deriv(
 
     Args:
         spline (Bspline): The B-spline object.
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+        pts (npt.ArrayLike | PointsLattice): Evaluation
             points.
         orders (Sequence[int]): One non-negative derivative order per parametric
             direction. ``len(orders)`` must equal ``spline.dim``.
@@ -1217,7 +1217,7 @@ def _evaluate_Bspline_multi_dim(
 
     Args:
         spline (Bspline): A multi-dimensional B-spline object (``dim >= 2``).
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
+        pts (npt.ArrayLike | PointsLattice): Evaluation
             points. Either a :class:`~pantr.quad.PointsLattice` (one 1D array
             per parametric direction) or a 2D array of shape
             ``(n_pts, spline.dim)`` containing row-wise parameter coordinates.
@@ -1285,7 +1285,7 @@ def _evaluate_Bspline(
 
     Args:
         spline (Bspline): The B-spline object.
-        pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): The points at which
+        pts (npt.ArrayLike | PointsLattice): The points at which
             to evaluate the B-spline.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated output
             array. Defaults to None.

--- a/src/pantr/bspline/_bspline_eval.py
+++ b/src/pantr/bspline/_bspline_eval.py
@@ -100,6 +100,62 @@ def _evaluate_Bspline_basis_combine_1D(  # noqa: PLR0913
     return out
 
 
+def _normalize_eval_points(
+    pts: npt.ArrayLike,
+    dim: int,
+    dtype: npt.DTypeLike,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Coerce and validate a user-supplied array of evaluation points.
+
+    Establishes the shape and dtype the Layer-3 evaluation kernels assume. Without
+    it, a ``(n_pts, 1)`` array reached the Cox-de Boor kernel and failed there with a
+    ``numba.core.errors.TypingError`` (``int()`` of a length-1 array in
+    :func:`~pantr.bspline._bspline_basis_core._find_span_and_first_basis_point`), and
+    an array-like such as a plain list failed even earlier on a missing ``.dtype``
+    attribute, before reaching any validation at all.
+
+    For ``dim == 1`` both ``(n_pts,)`` and ``(n_pts, 1)`` are accepted and normalized
+    to ``(n_pts,)``. A column of points is what the general ``(n_pts, dim)``
+    convention degenerates to at ``dim == 1``, and it is the shape the library's own
+    documented example uses, so it is normalized rather than rejected.
+
+    Args:
+        pts (npt.ArrayLike): Evaluation points, or anything ``np.asarray`` accepts.
+        dim (int): Parametric dimension of the B-spline.
+        dtype (npt.DTypeLike): Required dtype, i.e. the B-spline's own.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: C-contiguous array of shape
+        ``(n_pts,)`` when ``dim == 1`` and ``(n_pts, dim)`` otherwise. The input is
+        returned unchanged when it already satisfies both, so the common path copies
+        nothing.
+
+    Raises:
+        ValueError: If ``pts`` cannot be converted to an array, if its shape is not
+            one of the accepted forms, or if its dtype differs from ``dtype``.
+    """
+    try:
+        arr = np.asarray(pts)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"pts could not be converted to an array: {exc}") from exc
+
+    if dim == 1:
+        if arr.ndim == 2 and arr.shape[1] == 1:  # noqa: PLR2004
+            arr = np.ascontiguousarray(arr).reshape(-1)
+        elif arr.ndim != 1:
+            raise ValueError(
+                f"pts must have shape (n_pts,) or (n_pts, 1) for a 1D B-spline; "
+                f"got shape {arr.shape}"
+            )
+    elif arr.ndim != 2 or arr.shape[1] != dim:  # noqa: PLR2004
+        raise ValueError(f"pts must be a 2D array with {dim} columns; got shape {arr.shape}")
+
+    if arr.dtype != dtype:
+        raise ValueError("Points dtype must match B-spline dtype")
+
+    return np.ascontiguousarray(arr)
+
+
 def _check_pts_in_domain_1d(
     spline_1d: BsplineSpace1D,
     pts: npt.NDArray[np.float32 | np.float64],
@@ -126,7 +182,7 @@ def _check_pts_in_domain_1d(
 
 def _evaluate_Bspline_1D(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Evaluate the 1D B-spline at the given points.
@@ -138,8 +194,8 @@ def _evaluate_Bspline_1D(
         spline (Bspline): A 1D B-spline object containing space, control points,
             and rational flag.
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
-            points. If a PointsLattice, must be 1D. Otherwise must be a 1D array
-            of shape (n_pts,) matching the B-spline's dtype.
+            points. If a PointsLattice, must be 1D. Otherwise an array-like of
+            shape (n_pts,) or (n_pts, 1), with dtype matching the B-spline's.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
             where the result will be stored. If None, a new array is allocated.
             Must have shape (n_pts, rank) and dtype matching the B-spline.
@@ -153,7 +209,8 @@ def _evaluate_Bspline_1D(
 
     Raises:
         ValueError: If the B-spline is not 1D, if the points lattice is not 1D,
-            or if the points dtype does not match the B-spline dtype.
+            or if the points have an unusable shape or a dtype that does not match
+            the B-spline dtype.
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
@@ -165,10 +222,7 @@ def _evaluate_Bspline_1D(
             raise ValueError("Points lattice must be 1D")
         pts_array = pts._pts_per_dir[0]
     else:
-        pts_array = pts
-
-    if pts_array.dtype != spline.dtype:
-        raise ValueError("Points dtype must match B-spline dtype")
+        pts_array = _normalize_eval_points(pts, 1, spline.dtype)
 
     spline_1D = spline.space.spaces[0]
     _check_pts_in_domain_1d(spline_1D, pts_array)
@@ -466,7 +520,7 @@ def _evaluate_Bspline_deriv_1D_non_rational(
 
 def _evaluate_Bspline_deriv_1D(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     n_deriv: int,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
@@ -481,7 +535,8 @@ def _evaluate_Bspline_deriv_1D(
             and rational flag.
         pts (npt.NDArray[np.float32 | np.float64] | PointsLattice): Evaluation
             points. If a :class:`~pantr.quad.PointsLattice`, must be 1D. Otherwise
-            must be a 1D array of shape ``(n_pts,)`` matching the B-spline's dtype.
+            an array-like of shape ``(n_pts,)`` or ``(n_pts, 1)``, with dtype
+            matching the B-spline's.
         n_deriv (int): The derivative order to return. Must be >= 0.
         out (npt.NDArray[np.float32 | np.float64] | None): Optional pre-allocated
             output array with shape ``(n_pts,)`` for scalar or ``(n_pts, rank)``
@@ -495,8 +550,8 @@ def _evaluate_Bspline_deriv_1D(
 
     Raises:
         ValueError: If the B-spline is not 1D, if ``n_deriv < 0``, if the
-            points lattice is not 1D, or if the points dtype does not match the
-            B-spline dtype.
+            points lattice is not 1D, or if the points have an unusable shape or a
+            dtype that does not match the B-spline dtype.
     """
     if spline.dim != 1:
         raise ValueError("B-spline must be 1D")
@@ -509,10 +564,7 @@ def _evaluate_Bspline_deriv_1D(
             raise ValueError("Points lattice must be 1D")
         pts_array = pts._pts_per_dir[0]
     else:
-        pts_array = pts
-
-    if pts_array.dtype != spline.dtype:
-        raise ValueError("Points dtype must match B-spline dtype")
+        pts_array = _normalize_eval_points(pts, 1, spline.dtype)
 
     spline_1D = spline.space.spaces[0]
     _check_pts_in_domain_1d(spline_1D, pts_array)
@@ -924,7 +976,7 @@ def _evaluate_Bspline_deriv_multi_dim_non_rational(
 
 def _evaluate_Bspline_deriv_multi_dim(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
@@ -966,6 +1018,7 @@ def _evaluate_Bspline_deriv_multi_dim(
 
     dtype = spline.dtype
     pts_base_shape: tuple[int, ...]
+    pts_arg: npt.NDArray[np.float32 | np.float64] | PointsLattice
     if isinstance(pts, PointsLattice):
         if pts.dim != dim:
             raise ValueError(
@@ -974,25 +1027,23 @@ def _evaluate_Bspline_deriv_multi_dim(
         if pts.dtype != dtype:
             raise ValueError("Points dtype must match B-spline dtype")
         pts_base_shape = tuple(int(p.shape[0]) for p in pts.pts_per_dir)
+        pts_arg = pts
     else:
-        if pts.ndim != 2 or pts.shape[1] != dim:  # noqa: PLR2004
-            raise ValueError(f"pts must be a 2D array with {dim} columns")
-        if pts.dtype != dtype:
-            raise ValueError("Points dtype must match B-spline dtype")
-        pts_base_shape = (pts.shape[0],)
+        pts_arg = _normalize_eval_points(pts, dim, dtype)
+        pts_base_shape = (pts_arg.shape[0],)
 
     if spline.is_rational:
         return _evaluate_Bspline_deriv_multi_dim_rational(
-            spline, pts, orders_tuple, pts_base_shape, out
+            spline, pts_arg, orders_tuple, pts_base_shape, out
         )
     return _evaluate_Bspline_deriv_multi_dim_non_rational(
-        spline, pts, orders_tuple, pts_base_shape, out
+        spline, pts_arg, orders_tuple, pts_base_shape, out
     )
 
 
 def _evaluate_Bspline_deriv(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     orders: Sequence[int],
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
@@ -1155,7 +1206,7 @@ def _evaluate_Bspline_multi_dim_pts_array(
 
 def _evaluate_Bspline_multi_dim(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Evaluate a multi-dimensional B-spline at the given points.
@@ -1211,15 +1262,12 @@ def _evaluate_Bspline_multi_dim(
         _evaluate_Bspline_multi_dim_lattice(cp, spline.space.spaces, pts, out_array)
 
     else:
-        if pts.ndim != 2 or pts.shape[1] != dim:  # noqa: PLR2004
-            raise ValueError(f"pts must be a 2D array with {dim} columns")
-        if pts.dtype != dtype:
-            raise ValueError("Points dtype must match B-spline dtype")
+        pts_array = _normalize_eval_points(pts, dim, dtype)
 
-        expected_shape = (pts.shape[0], cp.shape[-1])
+        expected_shape = (pts_array.shape[0], cp.shape[-1])
         out_array = _allocate_or_validate_out(out, expected_shape, dtype)
 
-        _evaluate_Bspline_multi_dim_pts_array(cp, spline.space.spaces, pts, out_array)
+        _evaluate_Bspline_multi_dim_pts_array(cp, spline.space.spaces, pts_array, out_array)
 
     if spline.is_rational:
         out_array[..., :-1] = out_array[..., :-1] / out_array[..., -1:]
@@ -1230,7 +1278,7 @@ def _evaluate_Bspline_multi_dim(
 
 def _evaluate_Bspline(
     spline: Bspline,
-    pts: npt.NDArray[np.float32 | np.float64] | PointsLattice,
+    pts: npt.ArrayLike | PointsLattice,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Evaluate the B-spline at the given points, dispatching on parametric dimension.

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -239,8 +239,8 @@ def _to_open_bspline_1d_impl(
     a = float(knots[p])
     b = float(knots[-p - 1])
 
-    m_left = int(np.sum(np.isclose(knots[: p + 1], a, atol=tol)))
-    m_right = int(np.sum(np.isclose(knots[-p - 1 :], b, atol=tol)))
+    m_left = int(np.sum(np.abs(knots[: p + 1] - a) <= tol))
+    m_right = int(np.sum(np.abs(knots[-p - 1 :] - b) <= tol))
 
     if m_left == p + 1 and m_right == p + 1 and not periodic:
         raise ValueError(
@@ -475,8 +475,8 @@ def _to_periodic_bspline_1d_impl(
     b = float(open_knots[-p - 1])
 
     # --- Quick C^0 check when knots are clamped (P_0 = f(a), P_{n-1} = f(b)) ---
-    m_left = int(np.sum(np.isclose(open_knots[: p + 1], a, atol=tol)))
-    m_right = int(np.sum(np.isclose(open_knots[-p - 1 :], b, atol=tol)))
+    m_left = int(np.sum(np.abs(open_knots[: p + 1] - a) <= tol))
+    m_right = int(np.sum(np.abs(open_knots[-p - 1 :] - b) <= tol))
     is_clamped = m_left == p + 1 and m_right == p + 1
     if is_clamped:
         eps = float(np.finfo(np.float64).eps)

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -64,7 +64,11 @@ def _remove_knot_bspline_1d_impl(  # noqa: PLR0913
     if abs(float(knot_value) - domain_hi) <= tol_space:
         raise ValueError(f"Cannot remove boundary knot {knot_value} (domain end).")
 
-    # Cap at the actual multiplicity (and at degree per the algorithm).
+    # Cap at the actual multiplicity (and at degree per the algorithm).  This clamp is
+    # load-bearing for memory safety, not just a sanity bound: `_remove_knot_1d_core`
+    # sizes its scratch buffer for `2 * num <= degree + s` and writes outside it past
+    # that, silently.  `min(s, degree)` implies that bound, so the clamp has to stay,
+    # including when the caller supplied `num` explicitly.
     max_removals = min(s, degree)
     num = max_removals if num is None else min(num, max_removals)
 

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -59,9 +59,9 @@ def _remove_knot_bspline_1d_impl(  # noqa: PLR0913
     # Boundary knots of open splines cannot be removed.
     domain_lo = float(knots[degree])
     domain_hi = float(knots[-degree - 1])
-    if np.isclose(knot_value, domain_lo, atol=tol_space):
+    if abs(float(knot_value) - domain_lo) <= tol_space:
         raise ValueError(f"Cannot remove boundary knot {knot_value} (domain start).")
-    if np.isclose(knot_value, domain_hi, atol=tol_space):
+    if abs(float(knot_value) - domain_hi) <= tol_space:
         raise ValueError(f"Cannot remove boundary knot {knot_value} (domain end).")
 
     # Cap at the actual multiplicity (and at degree per the algorithm).

--- a/src/pantr/bspline/_bspline_knot_removal_core.py
+++ b/src/pantr/bspline/_bspline_knot_removal_core.py
@@ -45,7 +45,8 @@ def _remove_knot_1d_core(  # noqa: PLR0912, PLR0913, PLR0915
         knot_index (int): Index *r* such that ``knots[r] == knot_value`` and
             ``knots[r] != knots[r + 1]`` (i.e. the last occurrence).
         multiplicity (int): Current multiplicity *s* of *knot_value*.
-        num (int): Maximum number of removals to attempt.
+        num (int): Maximum number of removals to attempt. **Load-bearing for
+            memory safety**; see the precondition in the notes below.
         tol (float): Maximum allowed Euclidean distance between the two
             intermediate control-point approximations.
 
@@ -57,6 +58,27 @@ def _remove_knot_1d_core(  # noqa: PLR0912, PLR0913, PLR0915
     Note:
         Inputs are assumed to be correct (no validation performed).
         For general use, call ``_remove_knot_bspline_1d_impl`` instead.
+
+        **Precondition on** ``num`` **-- memory safety, not merely correctness:**
+        ``2 * num <= degree + multiplicity``.
+
+        The scratch buffer ``temp`` is sized ``(2 * degree + 1, rank)`` once, before
+        the removal loop. Pass ``t`` writes up to row ``last + 1 - off`` with
+        ``off = first - 1``; since ``first`` decreases and ``last`` increases by one
+        per pass, that highest row is ``degree - s + 2 * t + 2``, growing by two each
+        time. Keeping it within ``2 * degree`` gives ``t <= (degree + s - 2) / 2`` for
+        the final pass ``t = num - 1``, which is the bound above. Past it the kernel
+        writes outside ``temp`` -- silently, since Numba compiles without bounds
+        checking by default, and as undefined behaviour once ported. Confirmed under
+        ``NUMBA_BOUNDSCHECK=1``: that bound is exactly where ``IndexError`` begins,
+        for every ``(degree, multiplicity)`` pair with ``degree <= 4``.
+
+        The Layer-2 caller ``_remove_knot_bspline_1d_impl`` establishes this today by
+        capping ``num`` at ``min(multiplicity, degree)``, which implies the bound and
+        is one removal conservative for some pairs (``degree = 4``,
+        ``multiplicity = 2`` would admit ``num = 3``). Any other caller must establish
+        it itself -- in particular a future C ABI, where the Python-side cap stops
+        being an implicit guarantee.
     """
     n = ctrl.shape[0] - 1  # last control point index
     rank = ctrl.shape[1]

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -260,6 +260,10 @@ def _get_Bspline_cardinal_intervals_1D_core(
     In the case of open knot vectors, this definition automatically
     discards the first degree-1 and the last degree-1 intervals.
 
+    At ``degree == 0`` there are no neighbouring intervals to compare against and
+    every interval is cardinal; see the in-body comment for why that is also the
+    geometrically correct answer.
+
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
@@ -289,10 +293,19 @@ def _get_Bspline_cardinal_intervals_1D_core(
     # This would require to compute knot_id differently.
     for elem_id in range(num_intervals):
         if mult[elem_id] == 1 and mult[elem_id + 1] == 1:
-            local_knots = knots[knot_id - degree + 1 : knot_id + degree + 1]
-            lengths = np.diff(local_knots)
-            if np.all(np.isclose(lengths, lengths[degree - 1], atol=tol)):
+            if degree == 0:
+                # The comparison window below spans ``2 * degree - 1`` knot intervals
+                # and its reference is the centre entry ``degree - 1``; at degree 0 the
+                # window is empty and that index addressed a zero-length array.  There
+                # is nothing to compare: a degree-0 space has one basis function per
+                # interval and its cardinal extraction operator is the 1x1 identity
+                # everywhere, so every interval is cardinal.
                 out[elem_id] = np.True_
+            else:
+                local_knots = knots[knot_id - degree + 1 : knot_id + degree + 1]
+                lengths = np.diff(local_knots)
+                if np.all(np.isclose(lengths, lengths[degree - 1], atol=tol)):
+                    out[elem_id] = np.True_
 
         knot_id += mult[elem_id + 1]
 

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -168,14 +168,24 @@ def _is_in_domain_impl(
         Inputs are assumed to be correct (no validation performed).
     """
     knot_begin, knot_end = knots[degree], knots[-degree - 1]
-    # ``tol`` is an absolute tolerance, so widen the domain by exactly ``tol`` at each
-    # end.  ``np.isclose`` would carry its default ``rtol=1e-5`` and, since the rtol
-    # leg attaches to the second operand, accept an overshoot of ``1e-5 * |knot_end|``
-    # at the right end while rejecting ``tol``-sized undershoot at a left end sitting
-    # at zero -- an asymmetry that is an accident of argument order.
+    # ``tol`` is an absolute tolerance, so the admitted band is exactly ``tol`` wide at
+    # each end.  ``np.isclose`` would carry its default ``rtol=1e-5`` and, since the
+    # rtol leg attaches to the second operand, accept an overshoot of
+    # ``1e-5 * |knot_end|`` at the right end while rejecting ``tol``-sized undershoot
+    # at a left end sitting at zero -- an asymmetry that is an accident of argument
+    # order.
+    #
+    # The difference is formed first and only then compared against ``tol``.  Shifting
+    # the bound instead (``pts <= knot_end + tol``) reads more directly but is not the
+    # same predicate in floating point: ``knot_end + tol`` rounds to the nearest
+    # representable value, so once ``tol`` drops below ``ulp(knot_end)`` the effective
+    # tolerance becomes ``ulp(knot_end)`` rather than ``tol`` -- 1.16e-10 instead of a
+    # requested 1e-10 on a domain ending at 1e6.  Subtracting first is exact here
+    # (Sterbenz, for the nearby points that decide the boundary), so the band stays
+    # ``tol`` wide at every scale.
     return np.logical_and(  # type: ignore[no-any-return]
-        pts >= knot_begin - tol,
-        pts <= knot_end + tol,
+        (knot_begin < pts) | (np.abs(knot_begin - pts) <= tol),
+        (pts < knot_end) | (np.abs(pts - knot_end) <= tol),
     )
 
 

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -72,7 +72,7 @@ def _get_multiplicity_of_first_knot_in_domain_impl(
         Inputs are assumed to be correct (no validation performed).
     """
     first_knot = knots[degree]
-    return int(np.sum(np.isclose(knots[: degree + 1], first_knot, atol=tol)))
+    return int(np.sum(np.abs(knots[: degree + 1] - first_knot) <= tol))
 
 
 @nb_jit(
@@ -168,9 +168,14 @@ def _is_in_domain_impl(
         Inputs are assumed to be correct (no validation performed).
     """
     knot_begin, knot_end = knots[degree], knots[-degree - 1]
+    # ``tol`` is an absolute tolerance, so widen the domain by exactly ``tol`` at each
+    # end.  ``np.isclose`` would carry its default ``rtol=1e-5`` and, since the rtol
+    # leg attaches to the second operand, accept an overshoot of ``1e-5 * |knot_end|``
+    # at the right end while rejecting ``tol``-sized undershoot at a left end sitting
+    # at zero -- an asymmetry that is an accident of argument order.
     return np.logical_and(  # type: ignore[no-any-return]
-        (knot_begin < pts) | np.isclose(knot_begin, pts, atol=tol),
-        (pts < knot_end) | np.isclose(pts, knot_end, atol=tol),
+        pts >= knot_begin - tol,
+        pts <= knot_end + tol,
     )
 
 
@@ -304,7 +309,7 @@ def _get_Bspline_cardinal_intervals_1D_core(
             else:
                 local_knots = knots[knot_id - degree + 1 : knot_id + degree + 1]
                 lengths = np.diff(local_knots)
-                if np.all(np.isclose(lengths, lengths[degree - 1], atol=tol)):
+                if np.all(np.abs(lengths - lengths[degree - 1]) <= tol):
                     out[elem_id] = np.True_
 
         knot_id += mult[elem_id + 1]
@@ -615,8 +620,11 @@ def _find_knot_index_and_multiplicity(
         knots, degree, tol, in_domain=False
     )
 
-    # Find the matching unique knot.
-    matches = np.where(np.isclose(unique_knots, knot_value, atol=tol))[0]
+    # Find the matching unique knot.  The comparison is absolute: ``np.isclose`` would
+    # keep its default ``rtol=1e-5`` and match a knot up to ``1e-5 * |knot_value|``
+    # away, so a removal request would silently target a different knot (10.0 away at
+    # a knot value of 1e6).
+    matches = np.where(np.abs(unique_knots - knot_value) <= tol)[0]
     if len(matches) == 0:
         raise ValueError(f"Knot value {knot_value} not found in knot vector (tolerance={tol}).")
 

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -275,9 +275,10 @@ def _get_Bspline_cardinal_intervals_1D_core(
     In the case of open knot vectors, this definition automatically
     discards the first degree-1 and the last degree-1 intervals.
 
-    At ``degree == 0`` there are no neighbouring intervals to compare against and
-    every interval is cardinal; see the in-body comment for why that is also the
-    geometrically correct answer.
+    At ``degree == 0`` there are no neighbouring intervals to compare against, so the
+    equal-length condition holds vacuously and only the multiplicity gate below
+    decides the answer; see the in-body comment for why that is consistent with the
+    geometry.
 
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
@@ -312,9 +313,12 @@ def _get_Bspline_cardinal_intervals_1D_core(
                 # The comparison window below spans ``2 * degree - 1`` knot intervals
                 # and its reference is the centre entry ``degree - 1``; at degree 0 the
                 # window is empty and that index addressed a zero-length array.  There
-                # is nothing to compare: a degree-0 space has one basis function per
-                # interval and its cardinal extraction operator is the 1x1 identity
-                # everywhere, so every interval is cardinal.
+                # is nothing to compare, so the length condition holds vacuously and
+                # this interval is cardinal -- it already passed the multiplicity gate
+                # above, which still applies at degree 0.  Consistent with the geometry
+                # either way: a degree-0 space has one basis function per interval, so
+                # its cardinal extraction operator is the 1x1 identity on every
+                # interval whatever this flag says.
                 out[elem_id] = np.True_
             else:
                 local_knots = knots[knot_id - degree + 1 : knot_id + degree + 1]

--- a/src/pantr/bspline/_bspline_product.py
+++ b/src/pantr/bspline/_bspline_product.py
@@ -263,8 +263,8 @@ def _get_boundary_mults(
     p = space_1d.degree
     a = float(knots[p])
     b = float(knots[-p - 1])
-    m_left = int(np.sum(np.isclose(knots[: p + 1], a, atol=tol)))
-    m_right = int(np.sum(np.isclose(knots[-p - 1 :], b, atol=tol)))
+    m_left = int(np.sum(np.abs(knots[: p + 1] - a) <= tol))
+    m_right = int(np.sum(np.abs(knots[-p - 1 :] - b) <= tol))
     return m_left, m_right
 
 

--- a/src/pantr/bspline/_bspline_quasi_interpolation.py
+++ b/src/pantr/bspline/_bspline_quasi_interpolation.py
@@ -263,7 +263,7 @@ def quasi_interpolate_bspline(
         >>> from pantr.bspline import create_uniform_space, quasi_interpolate_bspline
         >>> space = create_uniform_space([2], [4])
         >>> qi = quasi_interpolate_bspline(lambda p: p[:, 0] ** 2, space)
-        >>> bool(np.isclose(qi.evaluate(np.array([[0.3]]))[0, 0], 0.09))
+        >>> bool(np.isclose(qi.evaluate(np.array([[0.3]])), 0.09))
         True
     """
     if not isinstance(space, BsplineSpace):

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -52,15 +52,15 @@ def _validate_restrict_bounds(
     if a_new >= b_new:
         raise ValueError(f"Lower bound ({a_new}) must be strictly less than upper bound ({b_new}).")
 
-    if a_new < a and not np.isclose(a_new, a, atol=tol):
+    if a_new < a and abs(a_new - a) > tol:
         raise ValueError(f"Lower bound ({a_new}) is below the domain start ({a}).")
-    if b_new > b and not np.isclose(b_new, b, atol=tol):
+    if b_new > b and abs(b_new - b) > tol:
         raise ValueError(f"Upper bound ({b_new}) is above the domain end ({b}).")
 
     # Snap bounds to domain endpoints if within tolerance.
-    if np.isclose(a_new, a, atol=tol):
+    if abs(a_new - a) <= tol:
         a_new = a
-    if np.isclose(b_new, b, atol=tol):
+    if abs(b_new - b) <= tol:
         b_new = b
 
     return a_new, b_new
@@ -96,10 +96,10 @@ def _compute_boundary_knots_to_insert(
     a = float(knots[p])
     b = float(knots[-p - 1])
 
-    left_at_domain = np.isclose(a_new, a, atol=tol)
-    right_at_domain = np.isclose(b_new, b, atol=tol)
-    left_open = bool(np.isclose(knots[0], knots[p], atol=tol))
-    right_open = bool(np.isclose(knots[-p - 1], knots[-1], atol=tol))
+    left_at_domain = abs(a_new - a) <= tol
+    right_at_domain = abs(b_new - b) <= tol
+    left_open = abs(float(knots[0]) - float(knots[p])) <= tol
+    right_open = abs(float(knots[-p - 1]) - float(knots[-1])) <= tol
 
     if left_at_domain and right_at_domain and left_open and right_open:
         raise ValueError("Bounds match the full domain and the direction is already open.")
@@ -107,13 +107,13 @@ def _compute_boundary_knots_to_insert(
     knots_list: list[float] = []
 
     if not (left_at_domain and left_open):
-        m_left = int(np.sum(np.isclose(knots, a_new, atol=tol)))
+        m_left = int(np.sum(np.abs(knots - a_new) <= tol))
         deficit = p + 1 - m_left
         if deficit > 0:
             knots_list.extend([a_new] * deficit)
 
     if not (right_at_domain and right_open):
-        m_right = int(np.sum(np.isclose(knots, b_new, atol=tol)))
+        m_right = int(np.sum(np.abs(knots - b_new) <= tol))
         deficit = p + 1 - m_right
         if deficit > 0:
             knots_list.extend([b_new] * deficit)

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -494,11 +494,14 @@ class BsplineSpace1D:
         In the case of open knot vectors, this definition automatically
         discards the first degree-1 and the last degree-1 intervals.
 
-        At ``degree == 0`` the condition ranges over an empty set of neighbouring
-        intervals, so every interval is cardinal irrespective of the knot spacing.
-        That is the geometrically correct answer as well: a degree-0 space carries
-        one basis function per interval and its cardinal extraction operator is the
-        1x1 identity everywhere.
+        At ``degree == 0`` the equal-length condition ranges over an empty set of
+        neighbouring intervals, so it holds vacuously and the knot spacing does not
+        affect the answer. What remains is the multiplicity gate that applies at every
+        degree: an interval is reported cardinal unless one of the two knots bounding
+        it is repeated. Either way this is consistent with the geometry, since a
+        degree-0 space carries one basis function per interval and its cardinal
+        extraction operator is the 1x1 identity on every interval regardless of the
+        flag.
 
         Args:
             out (npt.NDArray[bool] | None): Optional output array where the result will be

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -401,8 +401,11 @@ class BsplineSpace1D:
             return False
 
         # Check if the first degree+1 knots are equal
-        # (we know that they are non-decreasing).
-        return bool(np.isclose(self._knots[0], self._knots[self._degree], atol=self._tol))
+        # (we know that they are non-decreasing).  The comparison is absolute, as
+        # ``_snap_knots`` already notes: ``np.isclose`` keeps its default
+        # ``rtol=1e-5``, which would read a gap of up to ``1e-5 * |knots[degree]|``
+        # as clamped (half the domain, on a knot vector based at 1e6).
+        return bool(abs(float(self._knots[0]) - float(self._knots[self._degree])) <= self._tol)
 
     @functools.cached_property
     def _right_end_open(self) -> bool:
@@ -416,8 +419,11 @@ class BsplineSpace1D:
             return False
 
         # Check if the last degree+1 knots are equal
-        # (we know that they are non-decreasing).
-        return bool(np.isclose(self._knots[-self._degree - 1], self._knots[-1], atol=self._tol))
+        # (we know that they are non-decreasing).  Absolute comparison, as in
+        # :attr:`_left_end_open`.
+        return bool(
+            abs(float(self._knots[-self._degree - 1]) - float(self._knots[-1])) <= self._tol
+        )
 
     @functools.cached_property
     def _bezier_like_knots(self) -> bool:

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -488,6 +488,12 @@ class BsplineSpace1D:
         In the case of open knot vectors, this definition automatically
         discards the first degree-1 and the last degree-1 intervals.
 
+        At ``degree == 0`` the condition ranges over an empty set of neighbouring
+        intervals, so every interval is cardinal irrespective of the knot spacing.
+        That is the geometrically correct answer as well: a degree-0 space carries
+        one basis function per interval and its cardinal extraction operator is the
+        1x1 identity everywhere.
+
         Args:
             out (npt.NDArray[bool] | None): Optional output array where the result will be
                 stored. If None, a new array is allocated. Must have the correct shape and dtype

--- a/src/pantr/bspline/_bspline_split.py
+++ b/src/pantr/bspline/_bspline_split.py
@@ -63,7 +63,7 @@ def _split_bspline_1d_impl(  # noqa: PLR0913
         knots, ctrl_2d = _to_open_bspline_1d_impl(knots, p, ctrl_2d, periodic, tol)
 
     # Compute current multiplicity of the split value.
-    m_current = int(np.sum(np.isclose(knots, value, atol=tol)))
+    m_current = int(np.sum(np.abs(knots - value) <= tol))
     deficit = p + 1 - m_current
     if deficit > 0:
         knots_to_insert = np.full(deficit, value, dtype=knots.dtype)

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -440,16 +440,17 @@ def _prepare_apply_call(  # noqa: PLR0913 -- each arg reflects a distinct kernel
     )
     _validate_operand(operand, expected_in_shape, dtype)
     out = _allocate_or_validate_out(out, expected_out_shape, dtype)
-    # When every direction is identity the bilateral kernel is a pure copy, so
-    # aliasing out=K is safe.  Only raise for the general (non-identity) case.
-    if (
-        op_kind in ("MT_K_M", "M_K_MT")
-        and not all(is_identity_per_dir)
-        and np.shares_memory(operand, out)
-    ):
+    # No op kind may alias its operand: every kernel reads and writes overlapping
+    # memory.  The guard is uniform on purpose.  Whether a particular contraction
+    # survives aliasing depends on the parametric dimension and on which directions
+    # happen to be identity -- an in-place ``apply`` is corrupted in 1D (measured up
+    # to 1.1 absolute on a degree-3 Bezier target) yet survives in 2D, where the
+    # intermediate lands in the scratch buffer.  That is not a contract a caller can
+    # reason about, so it is not one to offer.  The one exemption is the all-identity
+    # case, where every kernel degenerates to a straight copy.
+    if not all(is_identity_per_dir) and np.shares_memory(operand, out):
         raise ValueError(
-            "out must not alias the operand (K) for bilateral operations; "
-            "the kernel reads and writes overlapping memory"
+            "out must not alias the operand; the kernel reads and writes overlapping memory"
         )
 
     scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)
@@ -641,14 +642,14 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913, PLR0915
     expected_out_shape = (n_cells, *per_cell_out)
     _validate_operand(operand, expected_operand, dtype)
     out = _allocate_or_validate_out(out, expected_out_shape, dtype)
-    if op_kind in ("MT_K_M", "M_K_MT") and np.shares_memory(operand, out):
+    # Uniform across op kinds, for the reason given in ``_prepare_apply_call``.
+    if np.shares_memory(operand, out):
         all_identity = n_cells == 0 or all(
             bool(is_identity_masks[k][cell_indices[:, k]].all()) for k in range(d)
         )
         if not all_identity:
             raise ValueError(
-                "out must not alias the operand (K) for bilateral operations; "
-                "the kernel reads and writes overlapping memory"
+                "out must not alias the operand; the kernel reads and writes overlapping memory"
             )
 
     scratch_size = _required_scratch_size(input_shape_per_dir, output_shape_per_dir, op_kind)

--- a/src/pantr/bspline/_extraction_helpers.py
+++ b/src/pantr/bspline/_extraction_helpers.py
@@ -543,9 +543,12 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913, PLR0915
             containing only non-identity rows. Length must equal ``d``.
         idx_maps_1d (tuple[npt.NDArray[np.intp], ...]): Per-direction compact
             index maps of shape ``(n_el_k,)``; ``idx_maps_1d[k][e]`` is the row
-            index into ``ops_1d[k]`` for element ``e`` (0 for identity elements,
-            unused; the kernel short-circuits on ``is_identity_masks``). Length
-            must equal ``d``.
+            index into ``ops_1d[k]`` for element ``e``, conventionally 0 for
+            identity elements. Every entry must lie in ``[0, n_compact_k)``,
+            including the identity ones: the batch kernels fetch
+            ``ops_1d[k][idx_maps_1d[k][e]]`` as an argument, so the row is read
+            before ``is_identity_masks`` can short-circuit on it. Length must
+            equal ``d``.
         is_identity_masks (tuple[npt.NDArray[np.bool_], ...]): Full per-direction
             identity mask arrays of shape ``(n_el_k,)``. Length must equal ``d``.
         cell_indices (npt.NDArray[np.intp]): Per-direction element indices,
@@ -601,12 +604,21 @@ def _prepare_apply_many_call(  # noqa: PLR0912, PLR0913, PLR0915
                 f"idx_maps_1d[{k}] has length {idx_map.shape[0]}, "
                 f"expected {n_el_k} to match is_identity_masks[{k}]"
             )
-        non_id_vals = idx_map[~mask]
-        if len(non_id_vals) > 0 and int(non_id_vals.max()) >= int(op.shape[0]):
-            raise ValueError(
-                f"idx_maps_1d[{k}] contains out-of-range values for ops_1d[{k}]: "
-                f"max value {int(non_id_vals.max())} >= n_compact_{k}={int(op.shape[0])}"
-            )
+        # Both bounds, and over *every* entry rather than only the non-identity ones.
+        # The batch kernels index the operator stack before the identity mask can
+        # short-circuit anything -- ``apply_kron_apply_many_1d`` evaluates
+        # ``ops_0[idx_map_0[i0]]`` as an argument to ``apply_kron_1d``, so the row is
+        # fetched whatever ``is_id_0[i0]`` says -- and a negative index is legal in
+        # NumPy but reads outside the array in a kernel compiled without bounds
+        # checking. This mirrors the ``cell_indices`` check below.
+        if idx_map.shape[0] > 0:
+            lo, hi = int(idx_map.min()), int(idx_map.max())
+            n_compact_k = int(op.shape[0])
+            if lo < 0 or hi >= n_compact_k:
+                raise ValueError(
+                    f"idx_maps_1d[{k}] contains values outside [0, {n_compact_k}) "
+                    f"for ops_1d[{k}]: range is [{lo}, {hi}]"
+                )
 
     if cell_indices.ndim != 2:  # noqa: PLR2004
         raise ValueError(f"cell_indices must be 2D; got ndim={cell_indices.ndim}")

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -306,9 +306,17 @@ class THBSplineSpace:
                 f"grid root cells_per_axis {tuple(grid.root.cells_per_axis)!r} must match "
                 f"root_space.num_intervals {tuple(root_space.num_intervals)!r}."
             )
-        if not np.allclose(
-            np.asarray(grid.root.bounds, dtype=np.float64),
-            np.asarray(root_space.domain, dtype=np.float64),
+        # Absolute comparison against the space's own knot tolerance.  Bare
+        # ``np.allclose`` would apply numpy's defaults (``rtol=1e-5``, ``atol=1e-8``),
+        # which accept a 3e-6 relative domain mismatch at every scale and, through the
+        # atol leg, pass ``[0, 1e-9]`` against ``[0, 2e-9]`` -- a factor-of-two wrong
+        # domain.
+        if not np.all(
+            np.abs(
+                np.asarray(grid.root.bounds, dtype=np.float64)
+                - np.asarray(root_space.domain, dtype=np.float64)
+            )
+            <= root_space.tolerance
         ):
             raise ValueError("grid root bounds must match root_space domain.")
 

--- a/src/pantr/bspline/spanwise_element_extraction.py
+++ b/src/pantr/bspline/spanwise_element_extraction.py
@@ -496,7 +496,8 @@ class SpanwiseElementExtraction:
                 ``(prod(input_shape_per_dir),)``.
             cell_idx (CellIndex): Element index (flat or per-direction).
             out (npt.NDArray[np.float32 | np.float64] | None): Optional output
-                array of shape ``(prod(output_shape_per_dir),)``. Allocated
+                array of shape ``(prod(output_shape_per_dir),)``. Must not
+                alias ``v``. Allocated
                 if ``None``.
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
                 scratch buffer. Allocated if ``None``.
@@ -526,7 +527,8 @@ class SpanwiseElementExtraction:
                 ``(prod(output_shape_per_dir),)``.
             cell_idx (CellIndex): Element index.
             out (npt.NDArray[np.float32 | np.float64] | None): Optional output
-                array of shape ``(prod(input_shape_per_dir),)``.
+                array of shape ``(prod(input_shape_per_dir),)``. Must not
+                alias ``w``.
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
                 scratch buffer.
 
@@ -870,7 +872,8 @@ class SpanwiseElementExtraction:
                 shape ``(n_cells,)`` or per-direction 2-D array of shape
                 ``(n_cells, d)``.
             out (npt.NDArray[np.float32 | np.float64] | None): Optional output
-                array of shape ``(n_cells, N_out)``. Allocated if ``None``.
+                array of shape ``(n_cells, N_out)``. Must not alias ``v``.
+                Allocated if ``None``.
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
                 per-cell scratch array of shape ``(n_cells, s)`` with
                 ``s >= scratch_size_per_cell``. Allocated if ``None``.
@@ -900,7 +903,8 @@ class SpanwiseElementExtraction:
                 ``N_out = prod(output_shape_per_dir)``.
             cell_indices (CellIndicesBatch): Cell indices — flat or per-direction.
             out (npt.NDArray[np.float32 | np.float64] | None): Optional output
-                array of shape ``(n_cells, N_in)``. Allocated if ``None``.
+                array of shape ``(n_cells, N_in)``. Must not alias ``w``.
+                Allocated if ``None``.
             scratch (npt.NDArray[np.float32 | np.float64] | None): Optional
                 per-cell scratch array. Allocated if ``None``.
 

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -53,6 +53,58 @@ if TYPE_CHECKING:
     from ..geometry import AABB
 
 
+def _check_tree_structure(
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+    n_nodes: int,
+    n_cells: int,
+) -> None:
+    """Check that the node arrays encode a tree the traversal kernels can walk.
+
+    The kernels in :mod:`pantr.grid._bvh_core` decide "leaf or internal" from
+    ``node_cell`` alone (``node_cell[i] < 0`` means internal) and then push
+    ``node_left[i]`` and ``node_right[i]`` unconditionally, without testing either
+    against ``-1``. So the two encodings of leafness have to agree, and an internal
+    node's children have to be real indices: a child left at ``-1``, or any other
+    negative value, wraps to the end of the node array rather than raising, and
+    silently corrupts the query result.
+
+    Args:
+        node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on leaves.
+        node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on leaves.
+        node_cell (npt.NDArray[np.int64]): Leaf cell ids; ``-1`` on internal nodes.
+        n_nodes (int): Number of nodes, i.e. the valid child-index range.
+        n_cells (int): Number of indexed cells, i.e. the valid cell-id range.
+
+    Raises:
+        ValueError: If ``node_cell`` and the child pointers disagree about which
+            nodes are leaves, if an internal node's child index lies outside
+            ``[0, n_nodes)``, or if a leaf's cell id lies outside ``[0, n_cells)``.
+    """
+    is_leaf = node_cell >= 0
+    if not np.array_equal(is_leaf, (node_left == -1) & (node_right == -1)):
+        raise ValueError(
+            "BVH: node_cell and the child pointers disagree about which nodes are "
+            "leaves. A node is a leaf iff node_cell >= 0, and exactly then must "
+            "node_left and node_right both be -1."
+        )
+    internal = ~is_leaf
+    for arr, name in ((node_left, "node_left"), (node_right, "node_right")):
+        child = arr[internal]
+        if child.size > 0 and (int(child.min()) < 0 or int(child.max()) >= n_nodes):
+            raise ValueError(
+                f"BVH: {name} contains values outside [0, {n_nodes}) on internal nodes: "
+                f"range is [{int(child.min())}, {int(child.max())}]."
+            )
+    leaf_cells = node_cell[is_leaf]
+    if leaf_cells.size > 0 and int(leaf_cells.max()) >= n_cells:
+        raise ValueError(
+            f"BVH: node_cell contains values outside [0, {n_cells}) on leaves: "
+            f"maximum is {int(leaf_cells.max())}."
+        )
+
+
 def _max_tree_depth(
     node_left: npt.NDArray[np.int64],
     node_right: npt.NDArray[np.int64],
@@ -161,9 +213,11 @@ class BVH:
         Raises:
             TypeError: If any array has the wrong dtype.
             ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``,
-                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``), or
-                the tree's root-to-leaf depth exceeds the traversal kernels'
-                stack depth (``_BVH_STACK_DEPTH``).
+                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``), if
+                ``node_cell`` and the child pointers disagree about which nodes are
+                leaves, if an internal node's children or a leaf's cell id are out of
+                range, or if the tree's root-to-leaf depth exceeds the traversal
+                kernels' stack depth (``_BVH_STACK_DEPTH``).
         """
         if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
             raise TypeError(
@@ -194,6 +248,9 @@ class BVH:
                 f"BVH: n_cells={n_cells_int} implies n_nodes={expected_nodes}; "
                 f"got node arrays with {n_nodes} rows."
             )
+        # Runs before the depth walk below, which indexes the children itself.
+        _check_tree_structure(node_left, node_right, node_cell, n_nodes, n_cells_int)
+
         # Guard the fixed-depth traversal stack in :mod:`pantr.grid._bvh_core`, whose
         # kernels push unconditionally.  Unlike from_cell_bounds -- whose median split
         # keeps the tree balanced, so depth follows from n_cells -- this constructor

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -53,6 +53,54 @@ if TYPE_CHECKING:
     from ..geometry import AABB
 
 
+def _max_tree_depth(
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    limit: int,
+) -> int:
+    """Measure a BVH node array's maximum root-to-leaf depth, capped at ``limit``.
+
+    Walks from the root (node ``0``) with an explicit Python ``list`` as the
+    traversal stack. That list has to be unbounded: the depth is precisely the
+    unknown quantity being checked, so a fixed-size buffer would reproduce the very
+    bug this function exists to catch.
+
+    The walk stops as soon as it finds a path deeper than ``limit``, which is all the
+    caller needs to know and which also makes it terminate on a node array that is
+    not a tree. A cyclic child pointer would otherwise grow the stack without bound,
+    and a validator that hangs is worse than the out-of-bounds write it replaces.
+
+    Args:
+        node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on
+            leaves. Shape ``(n_nodes,)``.
+        node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on
+            leaves. Shape ``(n_nodes,)``.
+        limit (int): Depth beyond which the exact value no longer matters.
+
+    Returns:
+        int: Number of nodes on the longest root-to-leaf path, the root counting as
+        depth ``1``; ``0`` for empty node arrays. A returned value greater than
+        ``limit`` means only "deeper than ``limit``", not the true maximum.
+    """
+    n_nodes = node_left.shape[0]
+    if n_nodes == 0:
+        return 0
+    stack: list[tuple[int, int]] = [(0, 1)]
+    max_depth = 0
+    while stack:
+        node, depth = stack.pop()
+        max_depth = max(max_depth, depth)
+        if max_depth > limit:
+            return max_depth
+        left = int(node_left[node])
+        right = int(node_right[node])
+        if left != -1:
+            stack.append((left, depth + 1))
+        if right != -1:
+            stack.append((right, depth + 1))
+    return max_depth
+
+
 class BVH:
     """Bounding-volume hierarchy indexing a fixed collection of AABBs.
 
@@ -112,8 +160,10 @@ class BVH:
 
         Raises:
             TypeError: If any array has the wrong dtype.
-            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, or
-                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``).
+            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``,
+                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``), or
+                the tree's root-to-leaf depth exceeds the traversal kernels'
+                stack depth (``_BVH_STACK_DEPTH``).
         """
         if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
             raise TypeError(
@@ -143,6 +193,20 @@ class BVH:
             raise ValueError(
                 f"BVH: n_cells={n_cells_int} implies n_nodes={expected_nodes}; "
                 f"got node arrays with {n_nodes} rows."
+            )
+        # Guard the fixed-depth traversal stack in :mod:`pantr.grid._bvh_core`, whose
+        # kernels push unconditionally.  Unlike from_cell_bounds -- whose median split
+        # keeps the tree balanced, so depth follows from n_cells -- this constructor
+        # takes arbitrary node arrays, and an unbalanced one overflows that stack with
+        # an out-of-bounds write on the first query.  A depth-d traversal occupies at
+        # most d slots, so depth == _BVH_STACK_DEPTH still fits.
+        tree_depth = _max_tree_depth(node_left, node_right, _BVH_STACK_DEPTH)
+        if tree_depth > _BVH_STACK_DEPTH:
+            raise ValueError(
+                f"BVH: the given node arrays encode a tree of depth {tree_depth} or more, "
+                f"exceeding the stack depth {_BVH_STACK_DEPTH} that the traversal kernels "
+                f"allow. Build the tree more evenly, or use BVH.from_cell_bounds, whose "
+                f"median split keeps the depth logarithmic in the cell count."
             )
         self._node_lo = np.ascontiguousarray(node_lo, dtype=np.float64)
         self._node_hi = np.ascontiguousarray(node_hi, dtype=np.float64)

--- a/tests/test_bincoeff_envelope.py
+++ b/tests/test_bincoeff_envelope.py
@@ -1,0 +1,300 @@
+"""Public paths must not walk off ``_bincoeff``'s exactness envelope.
+
+``_bincoeff`` runs an exact-integer multiplicative recurrence whose largest
+intermediate is ``C(n, k) * min(k, n - k)``. That fits in ``int64`` for every ``k``
+up to ``n = 61`` (6.98e18 against a ceiling of 9.22e18) and overflows from
+``n = 62`` (1.44e19). Numba does not trap integer overflow, so past the envelope a
+coefficient wraps silently: ``_bincoeff(62, 31)`` returned ``-1.296e17`` where the
+exact value is ``4.654e17``.
+
+The kernel documented that envelope and asserted callers stayed inside it, but
+nothing enforced it, and five public entry points reached it uncapped. Degree
+elevation and composition are *value-preserving* operations, so the corruption
+showed up as silent geometry corruption rather than as an error.
+
+Two of the five reach the envelope without the caller asking for any degree change
+at all:
+
+* every derivative of a **rational** B-spline re-elevates internally, so a
+  degree-62 NURBS was corrupted by ``derivative()`` alone;
+* ``Bezier.minimize_degree`` re-elevates each trial to score it, so a degree-62
+  Bézier scored its own round-trip against corrupted coefficients.
+
+And ``Bezier.compose`` has a **multiplicative** envelope, ``sum(outer.degree) *
+inner.degree[0]``, which binds at far lower operand degrees than the additive one:
+an outer of degree 6 with an inner of degree 11 already asks for ``C(66, k)``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from numpy import typing as npt
+
+from pantr.bezier import Bezier
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline_degree_core import _BINCOEFF_MAX_N, _bincoeff
+
+# One inside the envelope, one outside. Both are exercised at every entry point so a
+# test cannot pass by rejecting everything.
+INSIDE = _BINCOEFF_MAX_N
+OUTSIDE = _BINCOEFF_MAX_N + 1
+
+ENVELOPE_MSG = "beyond the largest upper index"
+
+
+def _bernstein_line(degree: int) -> npt.NDArray[np.float64]:
+    """Control points of the identity map ``f(x) = x`` in the degree-``n`` Bernstein basis."""
+    return (np.arange(degree + 1, dtype=np.float64) / degree).reshape(-1, 1)
+
+
+class TestKernelEnvelope:
+    """The envelope constant must match where the kernel actually breaks."""
+
+    def test_exact_up_to_the_declared_bound(self) -> None:
+        """``_bincoeff`` agrees with ``math.comb`` for every ``k`` at the bound."""
+        for k in range(_BINCOEFF_MAX_N + 1):
+            assert _bincoeff(_BINCOEFF_MAX_N, k) == float(math.comb(_BINCOEFF_MAX_N, k))
+
+    def test_wraps_one_past_the_declared_bound(self) -> None:
+        """One past the bound a coefficient wraps, and does so negative.
+
+        This is what makes the envelope load-bearing rather than cosmetic: the
+        failure is a sign flip, not a rounding error, so it propagates as gross
+        geometry corruption.
+
+        The ``errstate`` is deliberate and is itself part of the point: with
+        ``NUMBA_DISABLE_JIT=1`` the recurrence runs on numpy scalars, which do warn on
+        overflow, but the compiled kernel this test exists for wraps in silence.
+        """
+        with np.errstate(over="ignore"):
+            wrapped = _bincoeff(OUTSIDE, OUTSIDE // 2)
+
+        assert wrapped < 0.0
+        assert wrapped != float(math.comb(OUTSIDE, OUTSIDE // 2))
+
+    def test_bound_is_the_int64_limit_not_the_float_limit(self) -> None:
+        """The declared bound is the exact-integer limit (61), not the float one (56).
+
+        Callers only ever consume ``_bincoeff`` inside floating-point *ratios*, so a
+        correctly rounded operand is all they can use; capping at the float-lossless
+        limit would reject usable degrees for no gain.
+        """
+        int64_max = 2**63 - 1
+        worst = max(
+            math.comb(_BINCOEFF_MAX_N, k) * min(k, _BINCOEFF_MAX_N - k)
+            for k in range(_BINCOEFF_MAX_N + 1)
+        )
+        worst_past = max(math.comb(OUTSIDE, k) * min(k, OUTSIDE - k) for k in range(OUTSIDE + 1))
+
+        assert worst <= int64_max
+        assert worst_past > int64_max
+        # And the bound is genuinely past the float-lossless limit of 56.
+        assert max(math.comb(_BINCOEFF_MAX_N, k) for k in range(_BINCOEFF_MAX_N + 1)) > 2**53
+
+
+class TestBsplineElevateDegree:
+    """``Bspline.elevate_degree`` must be value-preserving or refuse."""
+
+    @staticmethod
+    def _quadratic() -> Bspline:
+        """Degree-2 Bézier-like B-spline, so elevation has a closed-form check."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        ctrl = np.array([[0.0], [0.5], [1.0]])
+        return Bspline(BsplineSpace([BsplineSpace1D(knots, 2)]), ctrl)
+
+    def test_elevation_inside_the_envelope_preserves_values(self) -> None:
+        """Elevating to the envelope bound must not move the curve."""
+        curve = self._quadratic()
+        pts = np.array([0.3, 0.5, 0.7])
+
+        elevated = curve.elevate_degree((INSIDE - 2,))
+
+        assert elevated.degree == (INSIDE,)
+        np.testing.assert_allclose(
+            np.asarray(elevated.evaluate(pts)), np.asarray(curve.evaluate(pts)), atol=1e-13
+        )
+
+    def test_elevation_past_the_envelope_raises(self) -> None:
+        """One increment further silently corrupted the curve by O(1); now it raises.
+
+        Measured before the cap: elevating a degree-2 curve to degree 62 moved its
+        values at ``[0.3, 0.5, 0.7]`` by 1.023, on a curve whose whole range is
+        ``[0, 1]``.
+        """
+        curve = self._quadratic()
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            curve.elevate_degree((OUTSIDE - 2,))
+
+    def test_the_cap_names_the_offending_direction(self) -> None:
+        """A 2D spline reports which direction overflowed."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 2), BsplineSpace1D(knots, 2)])
+        surface = Bspline(space, np.zeros((3, 3, 1)))
+
+        with pytest.raises(ValueError, match="direction 1"):
+            surface.elevate_degree((0, OUTSIDE - 2))
+
+
+class TestRationalDerivative:
+    """A rational B-spline's derivative re-elevates internally, with no opt-in."""
+
+    @staticmethod
+    def _rational_line(degree: int) -> Bspline:
+        """Degree-``n`` rational B-spline with unit weights, representing ``f(x) = x``."""
+        knots = np.concatenate([np.zeros(degree + 1), np.ones(degree + 1)])
+        coords = np.arange(degree + 1, dtype=np.float64) / degree
+        ctrl = np.stack([coords, np.ones(degree + 1)], axis=1)
+        return Bspline(BsplineSpace([BsplineSpace1D(knots, degree)]), ctrl, is_rational=True)
+
+    def test_derivative_inside_the_envelope_is_correct(self) -> None:
+        """The derivative of the identity map is 1 everywhere."""
+        curve = self._rational_line(INSIDE)
+
+        deriv = curve.derivative(0)
+
+        np.testing.assert_allclose(
+            np.asarray(deriv.evaluate(np.array([0.3, 0.5, 0.7]))), 1.0, atol=1e-8
+        )
+
+    def test_derivative_past_the_envelope_raises(self) -> None:
+        """``derivative()`` on a degree-62 NURBS asked for corrupted coefficients.
+
+        No ``keep_degree`` and no elevation requested: being rational is enough to
+        route through the degree-elevation kernel.
+        """
+        curve = self._rational_line(OUTSIDE)
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            curve.derivative(0)
+
+    def test_nonrational_derivative_is_unaffected(self) -> None:
+        """A non-rational derivative lowers the degree and needs no coefficients."""
+        knots = np.concatenate([np.zeros(OUTSIDE + 1), np.ones(OUTSIDE + 1)])
+        ctrl = _bernstein_line(OUTSIDE)
+        curve = Bspline(BsplineSpace([BsplineSpace1D(knots, OUTSIDE)]), ctrl)
+
+        deriv = curve.derivative(0)
+
+        assert deriv.degree == (OUTSIDE - 1,)
+
+
+class TestBezierElevateDegree:
+    """``Bezier.elevate_degree`` shares the elevation envelope."""
+
+    def test_elevation_inside_the_envelope_preserves_values(self) -> None:
+        """Elevating the identity map to the bound leaves it the identity."""
+        curve = Bezier(np.array([[0.0], [1.0]]))
+        pts = np.array([0.3, 0.5, 0.7])
+
+        elevated = curve.elevate_degree((INSIDE - 1,))
+
+        assert elevated.degree == (INSIDE,)
+        np.testing.assert_allclose(np.asarray(elevated.evaluate(pts)), pts, atol=1e-13)
+
+    def test_elevation_past_the_envelope_raises(self) -> None:
+        """Measured before the cap: an error of 1.023 on a curve of range ``[0, 1]``."""
+        curve = Bezier(np.array([[0.0], [1.0]]))
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            curve.elevate_degree((OUTSIDE - 1,))
+
+
+class TestBezierMinimizeDegree:
+    """``Bezier.minimize_degree`` re-elevates each trial to score it."""
+
+    def test_minimization_inside_the_envelope_reduces_a_line(self) -> None:
+        """A degree-61 representation of a straight line reduces to degree 1."""
+        curve = Bezier(_bernstein_line(INSIDE))
+
+        assert curve.minimize_degree().degree == (1,)
+
+    def test_minimization_past_the_envelope_raises(self) -> None:
+        """Before the cap this silently failed to reduce at all.
+
+        The round-trip error measure was computed from wrapped coefficients, so the
+        exact reduction of a straight line was rejected and degree 62 came back
+        unchanged. The verdict itself was untrustworthy, not merely conservative,
+        which is why this raises rather than degrading quietly.
+        """
+        curve = Bezier(_bernstein_line(OUTSIDE))
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            curve.minimize_degree()
+
+
+class TestBezierCompose:
+    """``Bezier.compose``'s envelope is multiplicative, not additive."""
+
+    @staticmethod
+    def _identity(degree: int) -> Bezier:
+        """Identity map ``t -> t`` as a degree-``n`` Bézier."""
+        return Bezier(_bernstein_line(degree))
+
+    @pytest.mark.parametrize(
+        ("outer_degree", "inner_degree"),
+        [(INSIDE, 1), (2, 30), (3, 20)],
+    )
+    def test_composition_inside_the_envelope_is_the_identity(
+        self, outer_degree: int, inner_degree: int
+    ) -> None:
+        """Identity composed with identity is the identity, exactly."""
+        pts = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+
+        composed = self._identity(outer_degree).compose(self._identity(inner_degree))
+
+        assert composed.degree == (outer_degree * inner_degree,)
+        np.testing.assert_allclose(np.asarray(composed.evaluate(pts)), pts, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("outer_degree", "inner_degree", "measured_error"),
+        [(2, 31, 1.010), (3, 21, 2.898), (6, 11, 30.4), (OUTSIDE, 1, 1.010)],
+    )
+    def test_composition_past_the_envelope_raises(
+        self, outer_degree: int, inner_degree: int, measured_error: float
+    ) -> None:
+        """The product of the degrees is what binds, not either degree alone.
+
+        ``(2, 31)``, ``(3, 21)`` and ``(6, 11)`` all have small operand degrees and all
+        exceed the envelope. ``measured_error`` records what the uncapped code produced
+        composing the identity with the identity, on a curve whose range is ``[0, 1]``.
+        """
+        assert measured_error > 1.0  # documents the magnitude; not itself computed here
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            self._identity(outer_degree).compose(self._identity(inner_degree))
+
+    @pytest.mark.parametrize("inner_degree", [INSIDE, OUTSIDE, 70])
+    def test_a_degree_one_1d_outer_is_never_capped(self, inner_degree: int) -> None:
+        """A 1D outer of degree 1 forms no Bernstein product, so it needs no cap.
+
+        The power ladder in ``_compute_scalar_powers`` only multiplies from degree 2 up,
+        and with a single direction there is no cross-direction product either, so
+        ``_bincoeff`` is never called however large the inner degree is. Verified
+        against the uncapped code: degree 1 composed with degree 70 reproduced the
+        identity to 1.0e-15. Capping this would reject a correct operation.
+        """
+        pts = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+
+        composed = self._identity(1).compose(self._identity(inner_degree))
+
+        assert composed.degree == (inner_degree,)
+        np.testing.assert_allclose(np.asarray(composed.evaluate(pts)), pts, atol=1e-12)
+
+    def test_a_degree_one_2d_outer_is_capped(self) -> None:
+        """A degree-(1, 1) *2D* outer is not exempt: the cross-direction product runs.
+
+        Measured off by 2.019 at a composed degree of 62, against an exact answer of
+        ``2t``, so the exemption above is genuinely about a missing product rather than
+        about the operand degree being small.
+        """
+        u = np.arange(2, dtype=np.float64)
+        outer = Bezier((u[:, None] + u[None, :])[..., None])
+        coords = np.arange(32, dtype=np.float64) / 31
+        inner = Bezier(np.stack([coords, coords], axis=1))
+
+        with pytest.raises(ValueError, match=ENVELOPE_MSG):
+            outer.compose(inner)

--- a/tests/test_bspline_eval_point_shapes.py
+++ b/tests/test_bspline_eval_point_shapes.py
@@ -1,0 +1,245 @@
+"""No illegal point argument may escape Layer 2 into a Numba kernel.
+
+The 1D ``Bspline`` evaluation path coerced nothing and checked no rank, so two
+classes of bad input got past validation entirely:
+
+* a ``(n_pts, 1)`` array reached the Cox-de Boor kernel and died inside it, with
+  ``numba.core.errors.TypingError: No implementation of function Function(<class
+  'int'>) found for signature: >>> int(array(int64, 1d, C))`` raised from
+  ``_bspline_basis_core.py`` where the kernel does
+  ``int(np.searchsorted(knots, pt, side="right")) - 1`` on what it assumes is a
+  scalar. With the JIT disabled the same input surfaced as ``TypeError: only
+  0-dimensional arrays can be converted to Python scalars``;
+* an array-like such as a plain Python list failed even earlier, on
+  ``AttributeError: 'list' object has no attribute 'dtype'`` (1D) or ``'ndim'``
+  (nD) -- before reaching any validation at all, so not even a bad-input message.
+
+``(n_pts, 1)`` is *accepted*, not rejected: it is what the general ``(n_pts, dim)``
+convention degenerates to at ``dim == 1``, ``Bspline.locate`` and ``Grid`` already
+take it, and the library's own documented example in
+``_bspline_quasi_interpolation`` passes it. ``Bezier`` was the sibling that already
+got this right, calling ``np.asarray`` at all four of its entry points.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy import typing as npt
+
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+
+# A quadratic arc, so evaluation at an interior point is not degenerate.
+_KNOTS = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0])
+_PARAMS = np.array([0.3, 0.5, 0.7])
+
+
+def _curve_1d(dtype: npt.DTypeLike = np.float64) -> Bspline:
+    """Degree-2, rank-1 B-spline on ``[0, 1]``."""
+    space = BsplineSpace([BsplineSpace1D(_KNOTS.astype(dtype), 2)])
+    return Bspline(space, np.array([[0.0], [1.0], [0.0]], dtype=dtype))
+
+
+def _curve_1d_rank2() -> Bspline:
+    """Degree-2, rank-2 B-spline, to cover the vector-valued output shape."""
+    space = BsplineSpace([BsplineSpace1D(_KNOTS, 2)])
+    return Bspline(space, np.array([[0.0, 1.0], [1.0, 0.0], [0.0, 1.0]]))
+
+
+def _surface_2d() -> Bspline:
+    """Degree-(2, 2), rank-1 B-spline on ``[0, 1]^2``."""
+    space = BsplineSpace([BsplineSpace1D(_KNOTS, 2), BsplineSpace1D(_KNOTS, 2)])
+    return Bspline(space, np.arange(9, dtype=np.float64).reshape(3, 3, 1))
+
+
+class TestColumnShapeAccepted:
+    """``(n_pts, 1)`` is the same request as ``(n_pts,)`` for a 1D B-spline."""
+
+    @pytest.mark.parametrize("n_pts", [1, 3])
+    def test_evaluate_column_matches_flat(self, n_pts: int) -> None:
+        """A column of points must give bit-identical values to the flat form.
+
+        Not merely close: the normalization is a reshape, so the kernel sees the
+        same buffer and must produce the same floats.
+        """
+        curve = _curve_1d()
+        flat = _PARAMS[:n_pts]
+
+        from_flat = np.asarray(curve.evaluate(flat))
+        from_column = np.asarray(curve.evaluate(flat.reshape(-1, 1)))
+
+        assert from_column.shape == from_flat.shape
+        np.testing.assert_array_equal(from_column, from_flat)
+
+    @pytest.mark.parametrize("order", [0, 1, 2])
+    def test_evaluate_derivatives_column_matches_flat(self, order: int) -> None:
+        """The derivative sibling had the identical gap and must behave identically."""
+        curve = _curve_1d()
+
+        from_flat = np.asarray(curve.evaluate_derivatives(_PARAMS, order))
+        from_column = np.asarray(curve.evaluate_derivatives(_PARAMS.reshape(-1, 1), order))
+
+        assert from_column.shape == from_flat.shape
+        np.testing.assert_array_equal(from_column, from_flat)
+
+    def test_column_works_for_vector_valued_output(self) -> None:
+        """Rank > 1 keeps its trailing axis; only the point axis is normalized."""
+        curve = _curve_1d_rank2()
+
+        from_flat = np.asarray(curve.evaluate(_PARAMS))
+        from_column = np.asarray(curve.evaluate(_PARAMS.reshape(-1, 1)))
+
+        assert from_column.shape == (3, 2)
+        np.testing.assert_array_equal(from_column, from_flat)
+
+    def test_the_documented_quasi_interpolation_example_runs(self) -> None:
+        """The library's own docstring example passes ``(1, 1)`` and used to fail.
+
+        ``_bspline_quasi_interpolation`` documents ``qi.evaluate(np.array([[0.3]]))``,
+        which is the shape this fix accepts; the doctest raised the TypingError above.
+        """
+        from pantr.bspline import (  # noqa: PLC0415
+            create_uniform_space,
+            quasi_interpolate_bspline,
+        )
+
+        qi = quasi_interpolate_bspline(lambda p: p[:, 0] ** 2, create_uniform_space([2], [4]))
+
+        assert float(np.asarray(qi.evaluate(np.array([[0.3]])))) == pytest.approx(0.09)
+
+
+class TestArrayLikesCoerced:
+    """An array-like must be converted, not met with an ``AttributeError``."""
+
+    @pytest.mark.parametrize(
+        "pts",
+        [
+            [0.3, 0.5, 0.7],
+            [[0.3], [0.5], [0.7]],
+            (0.3, 0.5, 0.7),
+        ],
+    )
+    def test_evaluate_accepts_array_likes(self, pts: Any) -> None:
+        """Lists and tuples, flat or as a column, give the ndarray answer."""
+        curve = _curve_1d()
+
+        np.testing.assert_array_equal(
+            np.asarray(curve.evaluate(pts)), np.asarray(curve.evaluate(_PARAMS))
+        )
+
+    def test_evaluate_derivatives_accepts_array_likes(self) -> None:
+        """The derivative path coerces too."""
+        curve = _curve_1d()
+
+        np.testing.assert_array_equal(
+            np.asarray(curve.evaluate_derivatives([0.3, 0.5, 0.7], 1)),
+            np.asarray(curve.evaluate_derivatives(_PARAMS, 1)),
+        )
+
+    def test_nd_evaluate_accepts_array_likes(self) -> None:
+        """The nD path raised ``AttributeError: 'list' object has no attribute 'ndim'``."""
+        surface = _surface_2d()
+        pts = [[0.3, 0.4], [0.5, 0.6]]
+
+        np.testing.assert_array_equal(
+            np.asarray(surface.evaluate(pts)),
+            np.asarray(surface.evaluate(np.asarray(pts, dtype=np.float64))),
+        )
+
+    def test_a_list_of_the_wrong_rank_gives_a_shape_error(self) -> None:
+        """Coercion must not swallow a genuinely wrong shape."""
+        surface = _surface_2d()
+
+        with pytest.raises(ValueError, match="must be a 2D array with 2 columns"):
+            surface.evaluate([0.3, 0.4])
+
+
+class TestIllegalShapesRejectedInLayer2:
+    """Every rejection must be a ``ValueError`` from Layer 2, never a kernel error."""
+
+    @pytest.mark.parametrize(
+        "pts",
+        [
+            np.array([[0.3, 0.4], [0.5, 0.6]]),  # (2, 2): trailing axis is not 1
+            np.array([[[0.3]]]),  # (1, 1, 1): rank 3
+            np.array(0.3),  # 0-d
+        ],
+    )
+    @pytest.mark.parametrize("method", ["evaluate", "evaluate_derivatives"])
+    def test_1d_rejects_unusable_shapes(self, pts: npt.NDArray[np.float64], method: str) -> None:
+        """These are exactly the shapes that used to reach the kernel and fail there."""
+        curve = _curve_1d()
+        args = (1,) if method == "evaluate_derivatives" else ()
+
+        with pytest.raises(ValueError, match=r"shape \(n_pts,\) or \(n_pts, 1\)"):
+            getattr(curve, method)(pts, *args)
+
+    @pytest.mark.parametrize("method", ["evaluate", "evaluate_derivatives"])
+    def test_dtype_mismatch_is_still_rejected(self, method: str) -> None:
+        """Coercion must not silently promote a mismatched dtype.
+
+        Points are validated against the B-spline's dtype rather than cast, so a
+        float32 array against a float64 spline stays an error. Widening the
+        *accepted shapes* must not widen the accepted dtypes.
+        """
+        curve = _curve_1d()
+        args = (1,) if method == "evaluate_derivatives" else ()
+
+        with pytest.raises(ValueError, match="Points dtype must match B-spline dtype"):
+            getattr(curve, method)(_PARAMS.astype(np.float32), *args)
+
+    def test_integer_points_are_still_rejected(self) -> None:
+        """An integer array is a dtype mismatch, before and after this change."""
+        curve = _curve_1d()
+
+        with pytest.raises(ValueError, match="Points dtype must match B-spline dtype"):
+            curve.evaluate(np.array([0, 1]))
+
+    def test_float32_spline_takes_float32_points_in_both_shapes(self) -> None:
+        """The normalization is dtype-agnostic: a float32 space still works."""
+        curve = _curve_1d(np.float32)
+        pts = _PARAMS.astype(np.float32)
+
+        np.testing.assert_array_equal(
+            np.asarray(curve.evaluate(pts.reshape(-1, 1))), np.asarray(curve.evaluate(pts))
+        )
+
+
+class TestNoKernelErrorEscapes:
+    """The acceptance criterion, stated directly."""
+
+    @pytest.mark.parametrize(
+        "pts",
+        [
+            [0.3],
+            (0.3,),
+            np.array([0.3]),
+            np.array([[0.3]]),
+            np.array([[0.3], [0.5]]),
+            np.array([0]),
+            np.array([0.3], dtype=np.float32),
+            np.array(0.3),
+            np.array([[0.3, 0.4]]),
+            np.array([[[0.3]]]),
+            np.empty((0,)),
+            np.empty((0, 1)),
+        ],
+    )
+    def test_no_input_produces_a_numba_or_attribute_error(self, pts: Any) -> None:
+        """Whatever the input, the outcome is a result or a ``ValueError``.
+
+        In particular never a ``numba.core.errors.TypingError``, never the
+        ``TypeError: only 0-dimensional arrays can be converted to Python scalars``
+        it degrades to with the JIT disabled, and never an ``AttributeError`` from
+        Layer 2 poking at an attribute the input does not have.
+        """
+        curve = _curve_1d()
+
+        try:
+            curve.evaluate(pts)
+        except ValueError:
+            pass  # a validated rejection is the acceptable failure
+        except Exception as exc:
+            pytest.fail(f"{type(exc).__name__} escaped Layer 2 for pts={pts!r}: {exc}")

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -335,14 +335,13 @@ class TestBsplineSpace1DMethods:
         ],
     )
     def test_get_cardinal_intervals_degree_zero(self, knots: list[float]) -> None:
-        """Degree 0: every interval is cardinal and nothing is read out of bounds.
+        """Degree 0 with simple knots: all cardinal, and nothing read out of bounds.
 
         The comparison window inside the kernel spans ``2 * degree - 1`` knot
         intervals, so at ``degree == 0`` it is empty and its centre index
-        ``degree - 1 == -1`` addressed a zero-length array. A degree-0 space
-        carries one basis function per interval and its cardinal extraction
-        operator is the 1x1 identity everywhere, so the answer is all-``True``
-        regardless of the knot spacing.
+        ``degree - 1 == -1`` addressed a zero-length array. With the window empty
+        the equal-length condition holds vacuously, so knot spacing does not enter
+        and both a uniform and a deliberately non-uniform vector answer all-``True``.
         """
         spline = BsplineSpace1D(knots, 0)
         result = spline.get_cardinal_intervals()
@@ -350,12 +349,42 @@ class TestBsplineSpace1DMethods:
         assert result.shape == (len(knots) - 1,)
         np.testing.assert_array_equal(result, np.ones(len(knots) - 1, dtype=np.bool_))
 
-    def test_tabulate_cardinal_extraction_operators_degree_zero(self) -> None:
-        """Degree-0 cardinal extraction operators are 1x1 identities."""
-        spline = BsplineSpace1D([0.0, 0.25, 0.5, 0.75, 1.0], 0)
+    def test_get_cardinal_intervals_degree_zero_repeated_knot(self) -> None:
+        """Degree 0 is still subject to the multiplicity gate, at every degree.
+
+        "The length condition is vacuous at degree 0" does not mean "every interval
+        is cardinal": the pre-existing gate requiring both bounding knots to be
+        simple still applies, so the two intervals touching a repeated interior knot
+        are reported non-cardinal. Pins that distinction, which is easy to overstate
+        in prose.
+        """
+        spline = BsplineSpace1D([0.0, 0.25, 0.25, 0.5, 1.0], 0, snap_knots=False)
+
+        np.testing.assert_array_equal(spline.get_cardinal_intervals(), [False, False, True])
+
+    @pytest.mark.parametrize(
+        ("knots", "n_intervals"),
+        [
+            ([0.0, 0.25, 0.5, 0.75, 1.0], 4),
+            # Repeated interior knot: some cardinal flags come back False, and the
+            # zero-length span it creates is collapsed, so there are 3 intervals.
+            ([0.0, 0.25, 0.25, 0.5, 1.0], 3),
+        ],
+    )
+    def test_tabulate_cardinal_extraction_operators_degree_zero(
+        self, knots: list[float], n_intervals: int
+    ) -> None:
+        """Degree-0 cardinal extraction operators are 1x1 identities either way.
+
+        Whatever the cardinal flags say, a degree-0 space has one basis function per
+        interval, so the operator has no freedom. That is what makes the flag's
+        treatment of repeated knots harmless in practice.
+        """
+        spline = BsplineSpace1D(knots, 0, snap_knots=False)
         ops = spline.tabulate_cardinal_extraction_operators()
 
-        np.testing.assert_array_equal(ops, np.ones((4, 1, 1)))
+        assert spline.get_cardinal_intervals().shape == (n_intervals,)
+        np.testing.assert_array_equal(ops, np.ones((n_intervals, 1, 1)))
 
 
 class TestBsplineSpace1DWithKnotGenerators:

--- a/tests/test_bspline_space_1D.py
+++ b/tests/test_bspline_space_1D.py
@@ -327,6 +327,36 @@ class TestBsplineSpace1DMethods:
         expected = np.array([False, True, True, False])
         np.testing.assert_array_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "knots",
+        [
+            [0.0, 0.25, 0.5, 0.75, 1.0],  # uniform
+            [0.0, 0.1, 0.5, 0.9, 1.0],  # deliberately non-uniform
+        ],
+    )
+    def test_get_cardinal_intervals_degree_zero(self, knots: list[float]) -> None:
+        """Degree 0: every interval is cardinal and nothing is read out of bounds.
+
+        The comparison window inside the kernel spans ``2 * degree - 1`` knot
+        intervals, so at ``degree == 0`` it is empty and its centre index
+        ``degree - 1 == -1`` addressed a zero-length array. A degree-0 space
+        carries one basis function per interval and its cardinal extraction
+        operator is the 1x1 identity everywhere, so the answer is all-``True``
+        regardless of the knot spacing.
+        """
+        spline = BsplineSpace1D(knots, 0)
+        result = spline.get_cardinal_intervals()
+
+        assert result.shape == (len(knots) - 1,)
+        np.testing.assert_array_equal(result, np.ones(len(knots) - 1, dtype=np.bool_))
+
+    def test_tabulate_cardinal_extraction_operators_degree_zero(self) -> None:
+        """Degree-0 cardinal extraction operators are 1x1 identities."""
+        spline = BsplineSpace1D([0.0, 0.25, 0.5, 0.75, 1.0], 0)
+        ops = spline.tabulate_cardinal_extraction_operators()
+
+        np.testing.assert_array_equal(ops, np.ones((4, 1, 1)))
+
 
 class TestBsplineSpace1DWithKnotGenerators:
     """Test BsplineSpace1D with knot vector generators."""

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -320,6 +320,109 @@ def test_ctor_rejects_a_cyclic_node_graph_without_hanging() -> None:
         BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=4)
 
 
+def _three_leaf_arrays() -> tuple[
+    npt.NDArray[np.float64],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+]:
+    """Raw node arrays of a valid 3-leaf BVH, taken from ``from_cell_bounds`` itself."""
+    lo = np.array([[0.0], [1.0], [2.0]])
+    hi = np.array([[1.0], [2.0], [3.0]])
+    ref = BVH.from_cell_bounds(lo, hi)
+    return (
+        np.array(ref.node_lo, dtype=np.float64),
+        np.array(ref.node_hi, dtype=np.float64),
+        np.array(ref.node_left, dtype=np.int64),
+        np.array(ref.node_right, dtype=np.int64),
+        np.array(ref.node_cell, dtype=np.int64),
+    )
+
+
+def test_ctor_accepts_a_well_formed_hand_built_tree() -> None:
+    """The consistency checks must not reject a tree the library itself produced."""
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+
+    bvh = BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=3)
+
+    assert sorted(int(c) for c in bvh.query_aabb(AABB([0.5], [0.6]))) == [0]
+
+
+def test_ctor_rejects_internal_node_with_a_missing_child() -> None:
+    """An "internal" node whose child is -1 must be rejected at construction.
+
+    The traversal kernels decide leaf-vs-internal from ``node_cell`` alone and then
+    push both children without checking either against -1, so a -1 child index wraps
+    to the last row of the node array. Before this check the tree constructed
+    cleanly and the query silently returned the wrong cells: this arrangement gave
+    ``[]`` where the correct answer is ``[0]``.
+
+    With only *one* child cleared the node still does not look like a leaf, so the
+    leaf-consistency check passes it on and the child-range check is what rejects
+    it. Either is fine; what matters is that it no longer constructs.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+    internal = int(np.where(node_cell < 0)[0][0])
+    node_left[internal] = -1
+
+    with pytest.raises(ValueError, match=r"node_left contains values outside"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=3)
+
+
+def test_ctor_rejects_leaf_marked_internal() -> None:
+    """The mirror case: a node with children but a non-negative ``node_cell``."""
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+    leaf = int(np.where(node_cell >= 0)[0][0])
+    node_cell[leaf] = -1
+
+    with pytest.raises(ValueError, match="disagree about which nodes are leaves"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=3)
+
+
+def test_ctor_rejects_out_of_range_child_index() -> None:
+    """A child index outside ``[0, n_nodes)`` must be rejected, negatives included.
+
+    A negative other than -1 passes the leaf-consistency check (the node still does
+    not look like a leaf) but still wraps when the kernel indexes with it.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+    internal = int(np.where(node_cell < 0)[0][0])
+    node_right[internal] = -5
+
+    with pytest.raises(ValueError, match=r"node_right contains values outside"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=3)
+
+
+def test_ctor_rejects_out_of_range_leaf_cell_id() -> None:
+    """A leaf naming a cell id beyond ``n_cells`` must be rejected."""
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+    leaf = int(np.where(node_cell >= 0)[0][0])
+    node_cell[leaf] = 42
+
+    with pytest.raises(ValueError, match=r"node_cell contains values outside"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=3)
+
+
+def test_from_cell_bounds_always_satisfies_the_consistency_invariant() -> None:
+    """Every tree the builder produces must pass the new checks, at every size.
+
+    Guards the checks against being stricter than the library's own producer.
+    """
+    for n in range(1, 60):
+        lo = np.arange(n, dtype=np.float64).reshape(-1, 1)
+        tree = BVH.from_cell_bounds(lo, lo + 1.0)
+        # Round-tripping the raw arrays back through __init__ runs every check.
+        BVH(
+            np.array(tree.node_lo, dtype=np.float64),
+            np.array(tree.node_hi, dtype=np.float64),
+            np.array(tree.node_left, dtype=np.int64),
+            np.array(tree.node_right, dtype=np.int64),
+            np.array(tree.node_cell, dtype=np.int64),
+            n_cells=n,
+        )
+
+
 def test_stack_overflow_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     """from_cell_bounds raises when the tree depth would overflow the kernel stack."""
     import pantr.grid._bvh as _bvh_mod  # noqa: PLC0415

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -220,6 +220,106 @@ def test_from_cell_bounds_rejects_nan_inf() -> None:
         BVH.from_cell_bounds(lo, hi_inf)
 
 
+def _chain_bvh_arrays(
+    n_leaves: int,
+) -> tuple[
+    npt.NDArray[np.float64],
+    npt.NDArray[np.float64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+]:
+    """Build raw node arrays for a maximally unbalanced (linear-chain) 1-D BVH.
+
+    Leaf ``k`` covers the unit cell ``[k, k+1]``. Node ``i`` for
+    ``i < n_leaves - 1`` is internal, with left child = leaf ``i`` and right
+    child = the next internal node (the last internal node's right child is
+    leaf ``n_leaves - 1`` instead). Every internal node's AABB is the honest
+    union of its subtree, so a correctly-pruning query still answers right.
+    This chain is the deepest possible tree over ``n_leaves`` leaves: the
+    longest root-to-leaf path has exactly ``n_leaves`` nodes.
+    """
+    n_internal = n_leaves - 1
+    n_nodes = 2 * n_leaves - 1
+    node_lo = np.zeros((n_nodes, 1), dtype=np.float64)
+    node_hi = np.zeros((n_nodes, 1), dtype=np.float64)
+    node_left = np.full(n_nodes, -1, dtype=np.int64)
+    node_right = np.full(n_nodes, -1, dtype=np.int64)
+    node_cell = np.full(n_nodes, -1, dtype=np.int64)
+    for i in range(n_internal):
+        node_lo[i, 0] = float(i)
+        node_hi[i, 0] = float(n_leaves)
+        node_left[i] = n_internal + i
+        node_right[i] = i + 1 if i < n_internal - 1 else n_internal + i + 1
+    for k in range(n_leaves):
+        leaf = n_internal + k
+        node_lo[leaf, 0] = float(k)
+        node_hi[leaf, 0] = float(k + 1)
+        node_cell[leaf] = k
+    return node_lo, node_hi, node_left, node_right, node_cell
+
+
+def test_ctor_unbalanced_chain_raises_at_construction() -> None:
+    """A hand-built 148-leaf linear-chain tree exceeds the kernel stack depth.
+
+    148 leaves force a chain of depth 148, past the traversal kernels' fixed
+    stack depth (``_BVH_STACK_DEPTH == 128`` in ``_bvh_core.py``). Unlike
+    ``from_cell_bounds``, the raw constructor accepts arbitrary node arrays, so
+    this depth cannot be inferred from ``n_cells`` alone; ``BVH.__init__`` must
+    reject it before any query touches the fixed-size kernel stack.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _chain_bvh_arrays(148)
+    with pytest.raises(ValueError, match="stack depth"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=148)
+
+
+def test_ctor_unbalanced_chain_at_the_limit_constructs_and_queries() -> None:
+    """A 128-leaf chain sits exactly on the limit and must still be accepted.
+
+    A depth-``d`` DFS occupies at most ``d`` stack slots: the root takes one, then
+    each of the ``d - 1`` internal expansions along the deepest path pops one entry
+    and pushes two, a net ``+1``. So ``d == _BVH_STACK_DEPTH == 128`` fits exactly
+    while ``d == 129`` does not, which is what makes the guard's strict ``>`` the
+    right comparison. Confirmed against the kernel under ``NUMBA_BOUNDSCHECK=1``
+    with the guard lifted: a depth-128 chain queries correctly, and a depth-129
+    chain raises ``IndexError`` from inside the compiled traversal.
+
+    So this is the exact boundary, and it also shows the guard cannot pass merely
+    by rejecting everything.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _chain_bvh_arrays(128)
+    bvh = BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=128)
+    result = sorted(int(c) for c in bvh.query_aabb(AABB([50.5], [52.5])))
+    assert result == [50, 51, 52]
+
+
+def test_ctor_unbalanced_chain_one_past_the_limit_raises() -> None:
+    """A 129-leaf chain is the smallest chain that overflows, and must be rejected.
+
+    Pins the other side of the boundary above: without the guard this constructs
+    cleanly and then writes one slot past the kernel's 128-entry stack on the very
+    first query.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _chain_bvh_arrays(129)
+    with pytest.raises(ValueError, match="stack depth"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=129)
+
+
+def test_ctor_rejects_a_cyclic_node_graph_without_hanging() -> None:
+    """A node array that is not a tree must be rejected, not walked forever.
+
+    The depth walk stops as soon as the bound is exceeded, so a self-referential
+    or cyclic child pointer terminates instead of growing the traversal stack
+    without limit. A validator that hangs would be worse than the out-of-bounds
+    write it replaces.
+    """
+    node_lo, node_hi, node_left, node_right, node_cell = _chain_bvh_arrays(4)
+    node_right[0] = 0  # root points back at itself
+
+    with pytest.raises(ValueError, match="stack depth"):
+        BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=4)
+
+
 def test_stack_overflow_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     """from_cell_bounds raises when the tree depth would overflow the kernel stack."""
     import pantr.grid._bvh as _bvh_mod  # noqa: PLC0415

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -305,3 +305,76 @@ class TestToleranceRejection:
         knots = result.space.spaces[0].knots
         count = np.sum(np.isclose(knots, 0.5, atol=1e-14))
         assert count == 1
+
+
+class TestRemoveKnotKernelPrecondition:
+    """The Layer-2 cap on ``num`` is what keeps the kernel's scratch buffer in bounds.
+
+    ``_remove_knot_1d_core`` sizes ``temp`` as ``(2 * degree + 1, rank)`` once, and
+    each removal pass writes two rows further out, so it stays in bounds only while
+    ``2 * num <= degree + multiplicity``. Nothing inside the kernel enforces that --
+    Layer 3 validates nothing by contract -- and Numba compiles without bounds
+    checking, so exceeding it corrupts memory silently rather than raising.
+
+    ``_remove_knot_bspline_1d_impl`` establishes the precondition by clamping ``num``
+    to ``min(multiplicity, degree)``, which implies it. These tests pin that clamp:
+    if it were dropped, a caller-supplied ``num`` would reach the kernel unbounded.
+    """
+
+    @staticmethod
+    def _curve_with_multiplicity(degree: int, s: int, n_int: int = 6) -> Bspline:
+        """Open degree-``p`` curve on ``[0, n_int]`` carrying knot 3.0 at multiplicity ``s``."""
+        interior: list[float] = []
+        for x in range(1, n_int):
+            interior += [float(x)] * (s if x == 3 else 1)
+        knots = np.concatenate(
+            [
+                np.zeros(degree + 1),
+                np.array(interior, dtype=float),
+                np.full(degree + 1, float(n_int)),
+            ]
+        )
+        space = BsplineSpace([BsplineSpace1D(knots, degree)])
+        n_basis = space.spaces[0].num_basis
+        ctrl = np.stack(
+            [np.linspace(0.0, 1.0, n_basis), np.linspace(0.0, 1.0, n_basis) ** 2], axis=1
+        )
+        return Bspline(space, ctrl)
+
+    @pytest.mark.parametrize(
+        ("degree", "s"),
+        [(2, 1), (2, 2), (3, 1), (3, 2), (3, 3), (4, 1), (4, 2), (4, 3)],
+    )
+    @pytest.mark.parametrize("requested_num", [1, 5, 100])
+    def test_public_removal_never_exceeds_the_kernel_bound(
+        self, degree: int, s: int, requested_num: int
+    ) -> None:
+        """However large a ``num`` the caller asks for, the kernel stays in bounds.
+
+        The removals actually performed must satisfy ``2 * removals <= degree + s``.
+        Verified under ``NUMBA_BOUNDSCHECK=1`` that this is exactly where the kernel
+        starts writing out of bounds when called directly: e.g. degree 2 with
+        ``s == 1`` raises at ``num == 2``, and degree 4 with ``s == 2`` at ``num == 4``.
+        """
+        curve = self._curve_with_multiplicity(degree, s)
+        before = int(np.sum(np.abs(np.asarray(curve.space.spaces[0].knots) - 3.0) <= 1e-14))
+
+        result = curve.remove_knots(3.0, num=requested_num, tol=1e30)
+
+        after = int(np.sum(np.abs(np.asarray(result.space.spaces[0].knots) - 3.0) <= 1e-14))
+        removals = before - after
+        assert 0 <= removals <= min(s, degree)
+        assert 2 * removals <= degree + s
+
+    def test_removal_still_reaches_the_full_multiplicity(self) -> None:
+        """The cap must not be so tight that a legitimate full removal is blocked.
+
+        Guards against "fixing" the precondition by clamping ``num`` to something
+        smaller: with ``tol`` wide open, all ``s`` copies must still come out.
+        """
+        curve = self._curve_with_multiplicity(degree=3, s=3)
+
+        result = curve.remove_knots(3.0, tol=1e30)
+
+        knots = np.asarray(result.space.spaces[0].knots)
+        assert int(np.sum(np.abs(knots - 3.0) <= 1e-14)) == 0

--- a/tests/test_knot_tolerance_absolute.py
+++ b/tests/test_knot_tolerance_absolute.py
@@ -156,6 +156,34 @@ class TestDomainGate:
         np.testing.assert_array_equal(_is_in_domain_impl(knots, 2, just_in, tol), [True, True])
         np.testing.assert_array_equal(_is_in_domain_impl(knots, 2, just_out, tol), [False, False])
 
+    def test_band_stays_tol_wide_when_tol_falls_below_one_ulp(self) -> None:
+        """The admitted band must be ``tol`` wide even where ``tol < ulp(knot_end)``.
+
+        The obvious way to write an absolute gate is to shift the bound,
+        ``pts <= knot_end + tol``. In floating point that is a *different* predicate:
+        ``knot_end + tol`` rounds to the nearest representable value, so once ``tol``
+        falls below ``ulp(knot_end)`` the effective tolerance silently becomes
+        ``ulp(knot_end)``. On a domain ending at 1e6 that ulp is 1.164e-10, so a
+        requested ``tol`` of 1e-10 would admit points 1.164e-10 past the end.
+
+        Forming the difference first and only then comparing against ``tol`` avoids
+        it; the subtraction is exact for the nearby points that decide the boundary.
+        This is the same shape of defect as the leak the rest of this module fixes --
+        a tolerance quietly becoming something other than what was asked for -- at one
+        ulp instead of 1e-5 relative.
+        """
+        hi = 1e6
+        tol = 1e-10
+        knots = np.array([0.0, 0.0, 0.0, hi, hi, hi], dtype=np.float64)
+        assert np.spacing(hi) > tol, "construction requires tol below one ulp of hi"
+
+        # One ulp past the end: admitted by the shifted-bound form, outside the true
+        # tol-wide band.
+        just_past = np.array([np.nextafter(hi, np.inf)])
+        assert float(just_past[0]) - hi > tol
+
+        assert not bool(_is_in_domain_impl(knots, 2, just_past, tol)[0])
+
     @pytest.mark.parametrize("hi", SCALES)
     def test_evaluate_rejects_an_out_of_domain_point(self, hi: float) -> None:
         """The public evaluation path inherits the tightened gate."""

--- a/tests/test_knot_tolerance_absolute.py
+++ b/tests/test_knot_tolerance_absolute.py
@@ -1,0 +1,423 @@
+"""Knot-layer predicates must use an absolute tolerance, not ``np.isclose``.
+
+Every tolerance in :mod:`pantr.tolerance` is documented as **absolute**: a fixed
+value per dtype, independent of the magnitude of the values compared. But
+``np.isclose(a, b, atol=tol)`` keeps numpy's default ``rtol=1e-5``, so the test it
+actually performs is ``|a - b| <= tol + 1e-5 * |b|``. Every knot-layer predicate
+written that way therefore widened by ``1e-5`` times the operand magnitude, which
+is harmless on a unit domain and catastrophic on a large one.
+
+Two further properties of the leak are worth pinning, because they are what makes
+it hard to spot:
+
+* the ``rtol`` leg attaches to the **second** operand only, so the predicate is
+  asymmetric in its arguments, and a comparison against an operand that happens to
+  be ``0.0`` shows no leak at all;
+* the widening is *relative*, so a test on a ``[0, 1]`` domain cannot see it.
+
+Each test below therefore drives the same construction at two or three coordinate
+scales and asserts the verdict is scale-invariant. The perturbations are hardcoded
+at ``1e-6`` and ``1e-7`` relative, i.e. inside the leaked ``1e-5`` window and far
+outside the strict float64 tolerance of ``1e-15``, so a leaky predicate answers
+the perturbed case exactly as it answers the exact one.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+from numpy import typing as npt
+
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    THBSplineSpace,
+    create_uniform_space,
+)
+from pantr.bspline._bspline_knots import (
+    _find_knot_index_and_multiplicity,
+    _is_in_domain_impl,
+)
+from pantr.bspline._bspline_product import _get_boundary_mults
+from pantr.bspline._bspline_restrict import (
+    _compute_boundary_knots_to_insert,
+    _validate_restrict_bounds,
+)
+from pantr.grid import hierarchical_grid, uniform_grid
+
+# Coordinate scales exercised throughout. 1.0 is the regime where the leak is
+# invisible; 1e6 is where a 1e-5 relative window is 10.0 wide in absolute terms.
+SCALES = (1.0, 100.0, 1e6)
+
+# Relative perturbation sitting strictly inside the leaked ``rtol=1e-5`` window and
+# far outside the strict float64 knot tolerance (1e-15).
+INSIDE_LEAK = 1e-6
+
+
+class TestMultiplicityCounting:
+    """Knot-multiplicity counts must not absorb a near-but-distinct knot."""
+
+    @pytest.mark.parametrize("base", [1.0, 1e6])
+    def test_periodic_num_basis_ignores_near_first_knot(self, base: float) -> None:
+        """A periodic space's ``num_basis`` must not depend on a ``1e-6``-relative gap.
+
+        ``_get_multiplicity_of_first_knot_in_domain_impl`` counts how many of
+        ``knots[:degree+1]`` equal ``knots[degree]``. The leak made two knots a
+        relative ``1e-6`` below it count as equal, raising the multiplicity from 1
+        to 3, driving the periodic regularity correction from ``degree - 1 == 1``
+        to ``-1``, and reporting ``num_basis == 8`` instead of 6.
+        """
+        knots = np.array([1.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]) * base
+        gap = INSIDE_LEAK * base
+        knots[0] -= gap
+        knots[1] -= gap
+
+        space = BsplineSpace1D(knots, 2, periodic=True, snap_knots=False)
+
+        # len(knots) - degree - 1 == 8 raw, minus (regularity + 1) == 2.
+        assert space.num_basis == 6
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_has_open_knots_rejects_a_near_clamped_vector(self, base: float) -> None:
+        """A knot vector that is not clamped must not read as clamped at any scale.
+
+        At base 1e6 the leaked window is 10.0 wide, so gaps of a full unit read as
+        "the first ``degree + 1`` knots are equal" -- and at a gap of ``0.5 * base``
+        it would have accepted half the domain length.
+        """
+        knots = np.array([1.0, 1.0, 1.0, 1.5, 2.0, 2.0, 2.0]) * base
+        knots[0] -= INSIDE_LEAK * base
+
+        space = BsplineSpace1D(knots, 2, snap_knots=False)
+
+        assert space.has_open_knots() is False
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_has_open_knots_accepts_an_exactly_clamped_vector(self, base: float) -> None:
+        """The tightened predicate must still accept a genuinely clamped vector."""
+        knots = np.array([1.0, 1.0, 1.0, 1.5, 2.0, 2.0, 2.0]) * base
+
+        space = BsplineSpace1D(knots, 2, snap_knots=False)
+
+        assert space.has_open_knots() is True
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_boundary_multiplicities_ignore_a_near_boundary_knot(self, base: float) -> None:
+        """``_get_boundary_mults`` must report the true multiplicity at any scale.
+
+        Shared by the product-space knot construction and, through the same
+        pattern, by ``to_open_bspline`` / ``to_periodic``.
+        """
+        knots = np.array([1.0, 1.0, 1.0, 1.5, 2.0, 2.0, 2.0]) * base
+        knots[0] -= INSIDE_LEAK * base
+        knots[-1] += INSIDE_LEAK * base
+        space = BsplineSpace1D(knots, 2, snap_knots=False)
+
+        m_left, m_right = _get_boundary_mults(space, space.tolerance)
+
+        assert (m_left, m_right) == (2, 2)
+
+
+class TestDomainGate:
+    """The in-domain gate must be an absolute, argument-order-independent window."""
+
+    @pytest.mark.parametrize("hi", SCALES)
+    def test_overshoot_inside_the_leaked_window_is_rejected(self, hi: float) -> None:
+        """A point overshooting the domain end must be rejected at any scale.
+
+        The leak attached ``rtol`` to the second operand, which was ``knot_end`` at
+        the right end, so overshoot of ``1e-5 * knot_end`` was accepted: 1.0e-5 on
+        ``[0, 1]``, 1.0e-3 on ``[0, 100]`` and 10.0 on ``[0, 1e6]``.
+        """
+        knots = np.array([0.0, 0.0, 0.0, hi, hi, hi], dtype=np.float64)
+        tol = 1e-10
+        pts = np.array([hi + INSIDE_LEAK * hi, hi + 10.0])
+
+        assert not np.any(_is_in_domain_impl(knots, 2, pts, tol))
+
+    @pytest.mark.parametrize("hi", SCALES)
+    def test_gate_is_symmetric_in_undershoot_and_overshoot(self, hi: float) -> None:
+        """The window must be exactly ``tol`` wide at both ends.
+
+        The old asymmetry was an accident of argument order: the left end compared
+        ``knot_begin`` against ``pts`` and the right end ``pts`` against
+        ``knot_end``, so undershoot at a domain starting at 0 was judged on a bare
+        ``atol`` while overshoot at the far end got the full relative window.
+        """
+        knots = np.array([0.0, 0.0, 0.0, hi, hi, hi], dtype=np.float64)
+        tol = 1e-10
+
+        just_in = np.array([-0.5 * tol, hi + 0.5 * tol])
+        just_out = np.array([-2.0 * tol, hi + 2.0 * tol])
+
+        np.testing.assert_array_equal(_is_in_domain_impl(knots, 2, just_in, tol), [True, True])
+        np.testing.assert_array_equal(_is_in_domain_impl(knots, 2, just_out, tol), [False, False])
+
+    @pytest.mark.parametrize("hi", SCALES)
+    def test_evaluate_rejects_an_out_of_domain_point(self, hi: float) -> None:
+        """The public evaluation path inherits the tightened gate."""
+        knots = np.array([0.0, 0.0, 0.0, hi, hi, hi], dtype=np.float64)
+        spline = Bspline(
+            BsplineSpace([BsplineSpace1D(knots, 2)]),
+            np.array([[0.0], [1.0], [0.0]]),
+        )
+
+        with pytest.raises(ValueError, match="outside the knot vector domain"):
+            spline.evaluate(np.array([hi + INSIDE_LEAK * hi]))
+
+
+class TestCardinalClassification:
+    """A near-uniform knot vector is not a uniform one."""
+
+    # ``knots[9]`` is moved. The kernel judges interval ``k`` (0-based, over the
+    # 8 in-domain intervals of the vector below) on the ``2 * degree - 1 == 5``
+    # knot-interval window ``knots[1 + k : 7 + k]``, which contains index 9 exactly
+    # for ``k >= 3``. So the first three intervals stay cardinal and the rest do not
+    # -- a localized pattern, which a blanket all-``True`` or all-``False`` answer
+    # cannot imitate.
+    EXPECTED: ClassVar[list[bool]] = [True, True, True, False, False, False, False, False]
+
+    @staticmethod
+    def _perturbed_uniform(rel: float) -> BsplineSpace1D:
+        """Degree-3 uniform space on ``[3, 11]`` with ``knots[9]`` moved by ``rel``."""
+        knots = np.arange(0.0, 15.0)
+        knots[9] += rel
+        return BsplineSpace1D(knots, 3, snap_knots=False)
+
+    def test_uniform_knots_are_all_cardinal(self) -> None:
+        """Baseline: the unperturbed uniform vector really is cardinal throughout."""
+        space = self._perturbed_uniform(0.0)
+
+        np.testing.assert_array_equal(space.get_cardinal_intervals(), [True] * 8)
+
+    @pytest.mark.parametrize("rel", [1e-7, INSIDE_LEAK, 3e-6])
+    def test_near_uniform_knots_are_not_cardinal(self, rel: float) -> None:
+        """Moving one knot by ``rel`` must un-cardinal every window that sees it.
+
+        The leak compared ``lengths`` against a reference of magnitude 1, so the
+        leaked window was ``1e-5`` wide and every ``rel`` here was absorbed: all
+        eight intervals came back cardinal.
+        """
+        space = self._perturbed_uniform(rel)
+
+        np.testing.assert_array_equal(space.get_cardinal_intervals(), self.EXPECTED)
+
+    @pytest.mark.parametrize("rel", [1e-7, INSIDE_LEAK, 3e-6])
+    def test_near_uniform_operators_are_not_replaced_by_the_identity(self, rel: float) -> None:
+        """A misclassified interval had its exact operator discarded for ``np.eye``.
+
+        ``_tabulate_Bspline_cardinal_1D_extraction_impl`` computes the exact
+        operator and then overwrites it with the identity on every interval flagged
+        cardinal, so a misclassification did not merely mislabel: it substituted a
+        wrong operator for a correct one that had already been computed two lines
+        earlier.
+        """
+        space = self._perturbed_uniform(rel)
+        ops = space.tabulate_cardinal_extraction_operators()
+        identity = np.eye(4)
+
+        is_identity = [bool(np.array_equal(ops[i], identity)) for i in range(ops.shape[0])]
+        assert is_identity == self.EXPECTED
+
+    def test_uniform_operators_are_the_identity(self) -> None:
+        """Baseline: a genuinely cardinal interval does get the identity."""
+        space = self._perturbed_uniform(0.0)
+        ops = space.tabulate_cardinal_extraction_operators()
+
+        for i in range(ops.shape[0]):
+            np.testing.assert_array_equal(ops[i], np.eye(4))
+
+
+class TestKnotLookup:
+    """Locating a knot by value must not silently pick a neighbour."""
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_near_miss_is_not_matched(self, base: float) -> None:
+        """A query a relative ``1e-6`` away from every knot must not be found.
+
+        The leak matched a knot up to ``1e-5 * |knot_value|`` away, so
+        ``remove_knots(v)`` removed a *different* knot than requested: up to
+        1.0e-5 away at a knot of 1.0, and 10.0 away at a knot of 1e6.
+        """
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0]) * base
+        query = 1.0 * base + INSIDE_LEAK * base
+
+        with pytest.raises(ValueError, match="not found in knot vector"):
+            _find_knot_index_and_multiplicity(knots, 2, query, 1e-15)
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_exact_hit_is_matched(self, base: float) -> None:
+        """The tightened lookup must still find the knot it is given exactly."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0]) * base
+
+        r, s = _find_knot_index_and_multiplicity(knots, 2, 1.0 * base, 1e-15)
+
+        assert (r, s) == (3, 1)
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_remove_knots_rejects_a_near_miss(self, base: float) -> None:
+        """Public ``remove_knots`` surfaces the tightened lookup as an error."""
+        knots = np.array([0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 3.0, 3.0]) * base
+        space = BsplineSpace1D(knots, 2, snap_knots=False)
+        n = space.num_basis
+        ctrl = np.stack([np.linspace(0.0, 1.0, n), np.linspace(0.0, 1.0, n) ** 2], axis=1)
+        spline = Bspline(BsplineSpace([space]), ctrl)
+
+        with pytest.raises(ValueError, match="not found in knot vector"):
+            spline.remove_knots(1.0 * base + INSIDE_LEAK * base)
+
+
+class TestSplitMultiplicity:
+    """``Bspline.split`` must clamp the two pieces at the split value."""
+
+    @staticmethod
+    def _curve(offset: float, degree: int = 2, n_int: int = 6) -> Bspline:
+        """Degree-2 curve on ``[offset, offset + n_int]`` with unit knot spacing."""
+        knots = np.concatenate(
+            [
+                np.full(degree + 1, offset),
+                np.arange(1.0, n_int) + offset,
+                np.full(degree + 1, offset + n_int),
+            ]
+        )
+        space = BsplineSpace1D(knots, degree)
+        n = space.num_basis
+        ctrl = np.stack([np.linspace(0.0, 1.0, n), np.linspace(0.0, 1.0, n) ** 2], axis=1)
+        return Bspline(BsplineSpace([space]), ctrl)
+
+    @pytest.mark.parametrize("offset", [0.0, 1e5, 1e6])
+    def test_left_piece_interpolates_its_last_control_point(self, offset: float) -> None:
+        """The left piece must end exactly at its own last control point.
+
+        ``_split_bspline_1d_impl`` counts the split value's current multiplicity to
+        decide how many knots to insert. The leak inflated that count -- measured 3
+        instead of 1 at offset 1e5, 18 at 1e6 and 45 at 1e8 -- so the deficit
+        collapsed to zero, no knots were inserted, and the split point kept
+        multiplicity 1 instead of ``degree + 1``. The left piece was then not
+        clamped there, and stopped interpolating its own last control point (a
+        measured 1.22e-2 discrepancy at offset 1e5).
+        """
+        spline = self._curve(offset)
+        value = float(spline.space.spaces[0].domain[0]) + 5.0
+
+        left, _ = spline.split(0, value)
+
+        np.testing.assert_allclose(
+            np.asarray(left.evaluate(np.array([value]))),
+            np.asarray(left.control_points)[-1],
+            atol=1e-12,
+            rtol=0.0,
+        )
+
+    @pytest.mark.parametrize("offset", [0.0, 1e5, 1e6])
+    def test_split_point_reaches_full_multiplicity(self, offset: float) -> None:
+        """The split value must end up clamped in both pieces."""
+        spline = self._curve(offset)
+        value = float(spline.space.spaces[0].domain[0]) + 5.0
+
+        left, right = spline.split(0, value)
+
+        assert left.space.spaces[0].has_open_knots() is True
+        assert right.space.spaces[0].has_open_knots() is True
+
+
+class TestRestrictBounds:
+    """Restriction bounds must be snapped and validated absolutely.
+
+    These exercise the Layer-2 helpers rather than ``Bspline.restrict`` itself: the
+    public method is independently broken for any bound above roughly 8 in
+    magnitude by an unrelated defect at ``_bspline_restrict.py:183-184``, where an
+    absolute ``+/- tol`` nudge fed to ``np.searchsorted`` underflows below one ulp
+    and the wrong end of a repeated-knot block is selected. That defect predates
+    this fix and is untouched by it.
+    """
+
+    @staticmethod
+    def _knots(base: float) -> npt.NDArray[np.float64]:
+        """Clamped degree-2 knot vector on ``[base, 3 * base]``."""
+        return np.array([1.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0]) * base
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_a_bound_inside_the_domain_is_not_snapped_to_the_end(self, base: float) -> None:
+        """A bound a relative ``1e-6`` inside the domain must stay where it is.
+
+        The leak read such a bound as coinciding with the domain endpoint, which
+        both snapped it to the wrong value and -- when both bounds snapped -- made
+        ``restrict`` raise "Bounds match the full domain and the direction is
+        already open" for a perfectly valid request.
+        """
+        knots = self._knots(base)
+        a, b = float(knots[2]), float(knots[-3])
+        a_new = a + INSIDE_LEAK * base
+        b_new = b - INSIDE_LEAK * base
+
+        snapped_a, snapped_b = _validate_restrict_bounds(knots, 2, 1e-15, a_new, b_new)
+
+        assert snapped_a == a_new
+        assert snapped_b == b_new
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_a_bound_at_the_domain_end_is_still_snapped(self, base: float) -> None:
+        """The tightened snap must still fire on an exact endpoint."""
+        knots = self._knots(base)
+        a, b = float(knots[2]), float(knots[-3])
+
+        snapped_a, snapped_b = _validate_restrict_bounds(knots, 2, 1e-15, a, b)
+
+        assert (snapped_a, snapped_b) == (a, b)
+
+    @pytest.mark.parametrize("base", SCALES)
+    def test_interior_bounds_still_require_boundary_knots(self, base: float) -> None:
+        """Bounds a relative ``1e-6`` inside the domain still need clamping knots.
+
+        With the leak, both bounds were taken to be at the domain ends of an
+        already-open vector, so no knots were queued and the caller raised instead.
+        """
+        knots = self._knots(base)
+        a, b = float(knots[2]), float(knots[-3])
+        a_new = a + INSIDE_LEAK * base
+        b_new = b - INSIDE_LEAK * base
+
+        to_insert = _compute_boundary_knots_to_insert(knots, 2, 1e-15, a_new, b_new)
+
+        # Neither bound coincides with an existing knot, so each needs degree + 1.
+        assert to_insert.size == 6
+        np.testing.assert_array_equal(to_insert[:3], [a_new] * 3)
+        np.testing.assert_array_equal(to_insert[3:], [b_new] * 3)
+
+
+class TestTHBRootBounds:
+    """The THB grid/space domain-consistency check needs a real tolerance."""
+
+    def test_mismatched_root_bounds_are_rejected(self) -> None:
+        """A factor-of-two wrong domain must be rejected.
+
+        ``np.allclose`` with no tolerance argument at all applies numpy's defaults
+        (``rtol=1e-5``, ``atol=1e-8``). Through the ``atol`` leg, ``[0, 1e-9]``
+        against ``[0, 2e-9]`` -- twice the domain -- compared equal.
+        """
+        root = create_uniform_space(2, 4, domain=(0.0, 1e-9))
+        grid = hierarchical_grid(uniform_grid([[0.0, 2e-9]], 4), 2)
+
+        with pytest.raises(ValueError, match="grid root bounds must match"):
+            THBSplineSpace(root, grid)
+
+    def test_relatively_mismatched_root_bounds_are_rejected(self) -> None:
+        """A 3e-6 relative domain mismatch must be rejected, at any scale."""
+        root = create_uniform_space(2, 4, domain=(0.0, 1.0))
+        grid = hierarchical_grid(uniform_grid([[0.0, 1.0 + 3e-6]], 4), 2)
+
+        with pytest.raises(ValueError, match="grid root bounds must match"):
+            THBSplineSpace(root, grid)
+
+    def test_matching_root_bounds_are_accepted(self) -> None:
+        """The tightened check must still accept a consistent pair."""
+        root = create_uniform_space(2, 4, domain=(0.0, 1e-9))
+        grid = hierarchical_grid(uniform_grid([[0.0, 1e-9]], 4), 2)
+
+        space = THBSplineSpace(root, grid)
+
+        assert space.dim == 1

--- a/tests/test_knot_tolerance_absolute.py
+++ b/tests/test_knot_tolerance_absolute.py
@@ -146,9 +146,16 @@ class TestDomainGate:
         ``knot_begin`` against ``pts`` and the right end ``pts`` against
         ``knot_end``, so undershoot at a domain starting at 0 was judged on a bare
         ``atol`` while overshoot at the far end got the full relative window.
+
+        ``tol`` is scaled with ``hi`` so the probes stay representable. With a fixed
+        ``tol = 1e-10``, ``hi + 0.5 * tol`` rounds back to exactly ``hi`` once
+        ``hi = 1e6`` (half a ulp there is 5.8e-11), and the "just inside" probe would
+        silently degenerate into an exact-boundary check at the very scale this
+        module is about.
         """
         knots = np.array([0.0, 0.0, 0.0, hi, hi, hi], dtype=np.float64)
-        tol = 1e-10
+        tol = 1e-10 * hi
+        assert hi + 0.5 * tol != hi, "probe must be representable at this scale"
 
         just_in = np.array([-0.5 * tol, hi + 0.5 * tol])
         just_out = np.array([-2.0 * tol, hi + 2.0 * tol])

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -949,6 +949,72 @@ def test_batch_apply_bilateral_aliasing_raises() -> None:
         ext.apply_M_K_MT_many(K2, flat, out=K2)
 
 
+def _space_1d_square() -> BsplineSpace:
+    """Degree-3 1D space on 4 intervals, where ``N_in == N_out == 4``.
+
+    Equal input and output sizes are what make an in-place ``apply`` shape-legal in
+    the first place, so this is the configuration where aliasing can actually occur.
+    """
+    degree, n_int = 3, 4
+    knots = np.concatenate(
+        [np.zeros(degree + 1), np.arange(1.0, n_int), np.full(degree + 1, float(n_int))]
+    )
+    return BsplineSpace([BsplineSpace1D(knots, degree)])
+
+
+def test_apply_aliasing_raises() -> None:
+    """``out`` aliasing the operand must raise for ``apply``/``apply_T`` too.
+
+    The guard existed only for the bilateral kinds, so an in-place ``apply``
+    silently returned wrong numbers: on this degree-3 Bezier target the result
+    differed from the correct one by up to 1.13 in absolute value, and the
+    corruption is data-dependent -- cell 0's operator is the identity there, so that
+    cell happened to agree and a test looking only at it would have seen nothing.
+    """
+    ext = SpanwiseElementExtraction(_space_1d_square(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    assert n_in == int(np.prod(ext.output_shape_per_dir))
+
+    v = RNG.standard_normal(n_in)
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply(v, 1, out=v)
+
+    w = RNG.standard_normal(n_in)
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply_transpose(w, 1, out=w)
+
+
+def test_batch_apply_aliasing_raises() -> None:
+    """The batch ``apply_many``/``apply_transpose_many`` share the gap and the fix."""
+    ext = SpanwiseElementExtraction(_space_1d_square(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    flat = np.arange(3)
+
+    V = RNG.standard_normal((3, n_in))
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply_many(V, flat, out=V)
+
+    W = RNG.standard_normal((3, n_in))
+    with pytest.raises(ValueError, match="alias"):
+        ext.apply_transpose_many(W, flat, out=W)
+
+
+def test_apply_with_distinct_out_still_works() -> None:
+    """A non-aliasing ``out`` must still be accepted and give the allocating answer.
+
+    Guards against the widened check rejecting the ordinary ``out=`` usage.
+    """
+    ext = SpanwiseElementExtraction(_space_1d_square(), "bezier")
+    n_in = int(np.prod(ext.input_shape_per_dir))
+    n_out = int(np.prod(ext.output_shape_per_dir))
+    v = RNG.standard_normal(n_in)
+
+    buf = np.empty(n_out)
+    got = ext.apply(v, 1, out=buf)
+
+    np.testing.assert_array_equal(np.asarray(got), np.asarray(ext.apply(v, 1)))
+
+
 def test_batch_apply_wrong_out_shape_raises() -> None:
     """Wrong ``out`` shape raises ValueError."""
     ext = SpanwiseElementExtraction(_space_2d(), "bezier")

--- a/tests/test_spanwise_element_extraction.py
+++ b/tests/test_spanwise_element_extraction.py
@@ -1224,6 +1224,71 @@ def test_idx_maps_1d_validation_in_prepare_many_call() -> None:
         )
 
 
+def _one_dir_apply_many_args(
+    idx_map: npt.NDArray[np.intp],
+    is_identity: npt.NDArray[np.bool_],
+) -> tuple[Any, ...]:
+    """Build a minimal 1-direction ``_prepare_apply_many_call`` argument tuple.
+
+    A 2-row operator stack over 3 elements, so the only valid ``idx_map`` entries
+    are 0 and 1. Two cells, both addressing element 2 -- the element whose
+    ``idx_map`` entry the tests below poison.
+    """
+    ops_1d = (np.zeros((2, 3, 3), dtype=np.float64),)
+    cell_indices = np.array([[2], [2]], dtype=np.intp)
+    operand = np.zeros((2, 3), dtype=np.float64)
+    return (ops_1d, (idx_map,), (is_identity,), cell_indices, operand, None, None, "apply")
+
+
+def test_idx_map_negative_value_rejected() -> None:
+    """A negative ``idx_map`` entry must be rejected, even on an identity element.
+
+    ``idx_map = [0, 1, -5]`` against a 2-operator stack: the old check looked only
+    at the *upper* bound and only at the non-identity entries, so a negative value
+    on an identity-flagged element passed validation entirely. It then reached the
+    kernel, which raised ``IndexError`` with the JIT disabled and read out of bounds
+    under real JIT -- a negative index is legal in NumPy but not in a kernel
+    compiled without bounds checking, and will be undefined behaviour once ported.
+
+    The entry is on an identity element deliberately: the batch kernels fetch
+    ``ops_0[idx_map_0[i0]]`` as an *argument* to ``apply_kron_1d``, so the row is
+    read before the identity mask can short-circuit on it.
+    """
+    idx_map = np.array([0, 1, -5], dtype=np.intp)
+    is_identity = np.array([False, False, True])
+
+    with pytest.raises(ValueError, match=r"outside \[0, 2\)"):
+        _prepare_apply_many_call(*_one_dir_apply_many_args(idx_map, is_identity))
+
+
+def test_idx_map_too_large_value_on_identity_element_rejected() -> None:
+    """An over-range entry on an identity element must be rejected too.
+
+    The old upper-bound check filtered by ``~mask`` first, so this slipped through
+    for the same reason as the negative case above.
+    """
+    idx_map = np.array([0, 1, 7], dtype=np.intp)
+    is_identity = np.array([False, False, True])
+
+    with pytest.raises(ValueError, match=r"outside \[0, 2\)"):
+        _prepare_apply_many_call(*_one_dir_apply_many_args(idx_map, is_identity))
+
+
+def test_idx_map_in_range_values_accepted() -> None:
+    """Valid entries must still pass, identity-flagged or not.
+
+    Guards against the tightened check simply rejecting everything, and pins the
+    convention that identity elements carry 0.
+    """
+    idx_map = np.array([0, 1, 0], dtype=np.intp)
+    is_identity = np.array([False, False, True])
+
+    kernel, args, out = _prepare_apply_many_call(*_one_dir_apply_many_args(idx_map, is_identity))
+
+    assert out.shape == (2, 3)
+    kernel(*args)
+
+
 # ---------------------------------------------------------------- struct view
 
 


### PR DESCRIPTION
Eight confirmed defects, all of one shape: a Layer-2 function does not establish a
precondition its Layer-3 kernel assumes. Because `nopython` kernels have no bounds
checking and no integer-overflow trap, every one of them failed silently.

Each fix lands with the regression test that would have caught it, carrying the exact
triggering data. No pre-existing test was moved or loosened.

## The tolerance leak, 26 sites across seven modules

`np.isclose(a, b, atol=tol)` keeps NumPy's default `rtol=1e-5`, so the test was really
`|a - b| <= tol + 1e-5 * |b|`. On a domain of length 1 placed at `1e6` that is a
tolerance of 10 where the space reports `1e-15`. Measured consequences:

| site | consequence |
|---|---|
| `_get_multiplicity_of_first_knot_in_domain_impl` | a periodic space reports 8 basis functions where it has 6 |
| `_is_in_domain_impl` | admits points 10.0 outside a domain of length 1 at `1e6`, while rejecting `1e-12` of undershoot at the other end — the asymmetry follows the argument order, since `rtol` attaches to the second operand |
| `_find_knot_index_and_multiplicity` | `remove_knots(v)` removes a different knot, up to `1e-5·|v|` away |
| `_get_Bspline_cardinal_intervals_1D_impl` | a near-uniform knot vector is classified cardinal and the exact extraction operator is replaced by the identity |
| `Bspline.split` / `restrict` | the returned piece stops interpolating its own end control point (1.22e-2 at offset `1e5`) |

It is also **memory-unsafe on a translated domain**: `elevate_degree` on a periodic
space over `[1e6, 1e6+1]` indexes out of bounds at degrees 1, 2 and 3. Varying only the
domain isolates it to translation rather than magnitude — `[0, 1e6]` is fine.

## The `_bincoeff` envelope

The exact-integer recurrence overflows `int64` at `n = 62` and wraps untrapped: at
combined degree 62 a degree-2 curve moves by 1.023 under an operation that must leave it
pointwise unchanged. The kernel documented the envelope and asserted its callers stayed
inside it; nothing enforced that. Now checked at five call sites, including two that do
not look like degree elevation at all — `Bspline.derivative` on a rational spline, and
`Bezier.minimize_degree`.

## The rest

- 1D `Bspline.evaluate` and `evaluate_derivatives` rejected points shaped `(n, 1)` with a
  Numba typing error rather than accepting them. That shape is what the `(n_pts, dim)`
  convention implies and what this repository's own docstring example passes, so it is now
  accepted; array-likes are coerced instead of failing on a missing `dtype` attribute.
- `SpanwiseElementExtraction.apply` / `apply_transpose` accepted an `out=` aliasing their
  input and returned a silently wrong result; the guard existed only for the two bilateral
  op kinds. `idx_map` was checked on its upper bound only, and only for non-identity
  entries.
- `get_cardinal_intervals` read past the end of an empty array at degree 0.
- `BVH` accepted node arrays deeper than the fixed traversal stack its query kernels
  assume, and arrays whose leaf markers and child pointers disagree.
- `_remove_knot_1d_core`'s scratch buffer is safe only under a caller-side cap; the exact
  bound is now derived and stated where the kernel and the cap both live.

## Verification

`ruff check`, `ruff format --check`, `mypy`, `import-lint`, `pytest` and the docs build
under `-W`, all green. **5119 passed, 20 skipped** against a baseline of 4958, so +161
tests. The whole suite also runs clean under `NUMBA_BOUNDSCHECK=1` with a fresh Numba
cache, which is the configuration that actually detects this class of defect — the flag is
silently ignored for `cache=True` kernels when a stale cache is present.

Checked against the downstream consumer: it imports none of the symbols changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
