### PR TITLE
test(tools): sweep the public API adversarially under bounds checking and pin what it finds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,3 +316,50 @@ jobs:
         run: |
           . .venv/bin/activate
           mpiexec --oversubscribe -n 3 python -m pytest tests/mpi/ --no-cov -p no:cacheprovider
+
+  adversarial-sweep:
+    name: Adversarial sweep (Numba bounds check)
+    needs: [lint, type-check]
+    runs-on: ubuntu-latest
+    # The only job that compiles the Layer-3 kernels with bounds checking on. It needs a
+    # job of its own because NUMBA_BOUNDSCHECK is not part of the Numba cache key, so it is
+    # silently ignored for a cache=True kernel that was already compiled without it -- and
+    # every pantr kernel is cache=True. The test hands the sweep a fresh cache directory
+    # per run, which means recompiling everything it touches, hence the separate job rather
+    # than a step in `tests`. PANTR_RUN_SWEEP enables the otherwise-skipped test.
+    env:
+      PANTR_RUN_SWEEP: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Cache virtualenv
+        id: cache-venv
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-sweep-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-sweep-
+
+      - name: Create venv and install (on cache miss)
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run the bounds-checked smoke sweep
+        run: |
+          . .venv/bin/activate
+          python -m pytest tests/test_adversarial_sweep.py -v --no-cov -p no:cacheprovider

--- a/tests/test_adversarial_sweep.py
+++ b/tests/test_adversarial_sweep.py
@@ -1,0 +1,146 @@
+"""Keep the bounds-checked adversarial sweep alive as a test.
+
+The sweep proper lives in ``tools/adversarial_sweep/`` and exists because pantr's Layer-3
+kernels run under Numba ``nopython=True``: there is no bounds check, a negative index
+wraps, and int64 overflows untrapped. The whole suite already runs clean under
+``NUMBA_BOUNDSCHECK=1``, so everything the sweep finds comes from inputs the suite does
+not contain. This test runs the sweep's bounded ``smoke`` profile and fails when it finds
+something that is not already pinned by a regression test.
+
+Three things force the shape of this test:
+
+* **It must be a subprocess.** ``NUMBA_BOUNDSCHECK`` is read when Numba is imported and
+  applied when a kernel is compiled, so it cannot be turned on from inside a pytest
+  process that has already imported pantr.
+* **It needs a fresh Numba cache.** The bounds-check flag is *not* part of the cache key,
+  so a ``cache=True`` kernel compiled earlier without it is silently reused and the run
+  returns a false clean. Every pantr kernel is ``cache=True``. The test therefore hands
+  the child a per-run ``NUMBA_CACHE_DIR`` under pytest's ``tmp_path``.
+* **It is opt-in.** A fresh cache means recompiling every kernel the sweep touches, which
+  costs minutes rather than the seconds a suite run should. Following the precedent of
+  ``tests/mpi/``, it is gated on an environment variable and marked ``slow``, so the
+  default suite pays nothing and CI runs it in a step of its own.
+
+Run it with::
+
+    PANTR_RUN_SWEEP=1 pytest tests/test_adversarial_sweep.py
+
+The sweep's own canary is what makes a clean result meaningful: it compiles two
+deliberately out-of-range ``cache=True`` kernels and requires both to raise before any
+case runs. This test asserts the canary line is present, because a sweep that cannot
+detect the bug it hunts is worse than no sweep.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_LAUNCHER = _ROOT / "tools" / "sweep.py"
+
+_ENV_FLAG = "PANTR_RUN_SWEEP"
+"""Set it to run the sweep. Absent, the test skips and the suite costs nothing."""
+
+_MIN_CASES = 400
+"""Floor on the smoke profile's case count.
+
+Guards the failure mode a verdict-based assertion cannot see: a probe module that stops
+yielding cases (an import error swallowed by a generator, a profile guard inverted) makes
+the sweep pass by running almost nothing. The smoke profile yields a little over 500
+cases; this floor leaves room to prune without becoming a maintenance chore.
+"""
+
+_KNOWN_FINDINGS = frozenset(
+    {
+        # Degree-0 cardinal extraction reads out of bounds in
+        # `_get_Bspline_cardinal_intervals_1D_core` (`_bspline_knots.py:294`,
+        # `lengths[degree - 1]` on an empty array). Logged before this sweep.
+        "cardinal_intervals_d0_m1_float64",
+        "extraction_build_d0_m1_float64_cardinal",
+        # `_degree_elevate_1d_core` returns a knot vector and a control-point array that
+        # disagree once an interior knot reaches multiplicity degree + 1. Pinned by
+        # `test_sweep_regressions.py::test_degree_elevation_outputs_are_mutually_consistent`.
+        "elevate_degree_d0_m1_float64_random",
+        "elevate_degree_d1_m2_float64_random",
+        # `_de_casteljau_eval_scalar` reads `coeff[0]` with no guard, so an empty
+        # coefficient array reads out of bounds. Layer 3 documents that it validates
+        # nothing, and no public path reaches it with an empty array, so this is a port
+        # note rather than a live bug: in C++ the same read is undefined behavior.
+        "de_casteljau_len0_float64",
+    }
+)
+"""Findings the smoke profile is expected to reproduce.
+
+The assertion is containment, not equality: a **new** finding fails the test, while fixing
+a known one merely shrinks the set. Each entry is either pinned by an ``xfail(strict=True)``
+test in ``test_sweep_regressions.py``, which is what fails when the bug is fixed, or
+recorded above as a deliberate contract-boundary probe.
+"""
+
+
+def _run_sweep(cache_dir: pathlib.Path, journal: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    """Run the smoke profile in a child process with a fresh Numba cache.
+
+    Args:
+        cache_dir (pathlib.Path): Directory for the child's Numba cache. Must not already
+            hold a compilation of these kernels, or the bounds check is silently skipped.
+        journal (pathlib.Path): File to receive the per-case JSONL records.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The finished process, with output captured.
+    """
+    env = dict(os.environ)
+    env["NUMBA_BOUNDSCHECK"] = "1"
+    env["NUMBA_CACHE_DIR"] = str(cache_dir)
+    # The coverage run sets this globally, and with the JIT off nothing is compiled and
+    # the bounds check grades nothing. The sweep's canary refuses to start in that state,
+    # so clear it rather than let an inherited value turn the run into a false clean.
+    env.pop("NUMBA_DISABLE_JIT", None)
+    # Fixed argv, no shell, in-repo launcher.
+    return subprocess.run(
+        [sys.executable, str(_LAUNCHER), "--profile", "smoke", "--journal", str(journal)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.environ.get(_ENV_FLAG) != "1",
+    reason=f"set {_ENV_FLAG}=1 to run the bounds-checked adversarial sweep",
+)
+def test_smoke_sweep_finds_nothing_new(tmp_path: pathlib.Path) -> None:
+    cache_dir = tmp_path / "numba-cache"
+    cache_dir.mkdir()
+    journal = tmp_path / "sweep.jsonl"
+
+    result = _run_sweep(cache_dir, journal)
+
+    # 0 is clean, 1 is findings, 3 is "the harness is unusable" and anything else is a
+    # crash or a signal. Only the first two may be interpreted, and the canary line has to
+    # be there: a sweep that cannot detect an out-of-bounds access proves nothing.
+    assert result.returncode in (0, 1), (
+        f"the sweep did not complete (exit {result.returncode}):\n"
+        f"{result.stdout[-2000:]}\n{result.stderr[-4000:]}"
+    )
+    assert "canary OK" in result.stderr, f"the canary did not report:\n{result.stderr[-4000:]}"
+
+    records = [json.loads(line) for line in journal.read_text(encoding="utf-8").splitlines()]
+    assert len(records) >= _MIN_CASES, f"only {len(records)} cases ran, expected >= {_MIN_CASES}"
+
+    found = {r["label"] for r in records if r["verdict"] == "BUG"}
+    new = found - _KNOWN_FINDINGS
+    details = "\n".join(
+        f"  {r['group']}/{r['label']} [{r['kind']}]\n    {r['detail'].splitlines()[0]}"
+        for r in records
+        if r["verdict"] == "BUG" and r["label"] in new
+    )
+    assert not new, f"the sweep found {len(new)} finding(s) not in _KNOWN_FINDINGS:\n{details}"

--- a/tests/test_adversarial_sweep.py
+++ b/tests/test_adversarial_sweep.py
@@ -58,16 +58,22 @@ cases; this floor leaves room to prune without becoming a maintenance chore.
 
 _KNOWN_FINDINGS = frozenset(
     {
-        # Degree-0 cardinal extraction reads out of bounds in
-        # `_get_Bspline_cardinal_intervals_1D_core` (`_bspline_knots.py:294`,
-        # `lengths[degree - 1]` on an empty array). Logged before this sweep.
-        "cardinal_intervals_d0_m1_float64",
-        "extraction_build_d0_m1_float64_cardinal",
         # `_degree_elevate_1d_core` returns a knot vector and a control-point array that
         # disagree once an interior knot reaches multiplicity degree + 1. Pinned by
         # `test_sweep_regressions.py::test_degree_elevation_outputs_are_mutually_consistent`.
         "elevate_degree_d0_m1_float64_random",
         "elevate_degree_d1_m2_float64_random",
+        # `num_intervals=0` is documented as legal by two knot-vector factories and
+        # rejected by a third; neither accepting factory returns a usable vector -- the
+        # periodic one returns NaN and inf, the open one returns one interval instead of
+        # none. Pinned by
+        # `test_sweep_regressions.py::test_knot_factories_agree_on_zero_intervals`.
+        "create_uniform_open_knots_d0_float64_[0,1]_n0",
+        "create_uniform_open_knots_d1_float64_[0,1]_n0",
+        "create_uniform_open_knots_d3_float64_[0,1]_n0",
+        "create_uniform_periodic_knots_d0_float64_[0,1]_n0",
+        "create_uniform_periodic_knots_d1_float64_[0,1]_n0",
+        "create_uniform_periodic_knots_d3_float64_[0,1]_n0",
         # `_de_casteljau_eval_scalar` reads `coeff[0]` with no guard, so an empty
         # coefficient array reads out of bounds. Layer 3 documents that it validates
         # nothing, and no public path reaches it with an empty array, so this is a port
@@ -78,9 +84,17 @@ _KNOWN_FINDINGS = frozenset(
 """Findings the smoke profile is expected to reproduce.
 
 The assertion is containment, not equality: a **new** finding fails the test, while fixing
-a known one merely shrinks the set. Each entry is either pinned by an ``xfail(strict=True)``
-test in ``test_sweep_regressions.py``, which is what fails when the bug is fixed, or
-recorded above as a deliberate contract-boundary probe.
+a known one merely shrinks the set. Every entry must be *tracked*, not merely *seen* --
+each is either pinned by an ``xfail(strict=True)`` test in ``test_sweep_regressions.py``,
+which is what fails when the bug is fixed, or recorded above as a deliberate
+contract-boundary probe. An entry with neither would make this list a way to silence a
+finding, which is the one thing it must not become.
+
+Two entries were removed when ``fix(bspline,grid): … (#289)`` landed: the degree-0
+cardinal extraction reads out of bounds no longer occur, so the sweep stopped reporting
+``cardinal_intervals_d0_m1_float64`` and ``extraction_build_d0_m1_float64_cardinal``.
+Containment would have tolerated leaving them, but a stale entry misdescribes the state of
+the code.
 """
 
 

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -1,11 +1,14 @@
 """Known-bug regressions from the adversarial parameter sweep (August 2026).
 
-Every test here is an ``xfail(strict=True)`` reproduction of a bug the sweep in
-``tools/adversarial_sweep/`` found on inputs the rest of the suite does not contain. When
-a bug is fixed the corresponding test starts passing, pytest reports a strict XPASS
-failure, and the marker should be removed, promoting the test to a permanent guard. That
-is the same convention ``tests/test_review_regressions.py`` follows for the June 2026
-review, whose markers have all since been removed.
+Each test here reproduces a bug the sweep in ``tools/adversarial_sweep/`` found on inputs
+the rest of the suite does not contain. A bug that is still open carries
+``xfail(strict=True)``; when it is fixed the test starts passing, pytest reports a strict
+XPASS failure, and the marker comes off, promoting the test to a permanent guard on the
+same data. That is the convention ``tests/test_review_regressions.py`` follows for the
+June 2026 review, whose markers have all since been removed.
+
+One marker has already come off here: the domain-membership test, closed by the
+``np.isclose`` tolerance-leak fix in #289. Eight remain open.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -172,50 +175,49 @@ def test_degree_elevation_preserves_float32() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="domain membership is tested with np.isclose(..., atol=tol), which keeps the "
-    "default rtol=1e-5, so the effective tolerance is 1e-5 * |knot| instead of tol",
-)
 def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
-    # `_is_in_domain` (`_bspline_knots.py:172-173`) accepts a point when
-    # `np.isclose(knot_end, pt, atol=tol)`. Setting `atol` does not clear `rtol`, which
-    # stays at numpy's default 1e-5, so the test is really
-    # `|pt - knot_end| <= tol + 1e-5 * |knot_end|`. On a domain of length 1 placed at 1e6
-    # that admits points up to 10.00001 outside -- ten domain lengths -- while the space's
-    # stated tolerance is 1e-15.
+    # FIXED in `fix(bspline,grid): close eight Layer-2 validation gaps and the np.isclose
+    # tolerance leak (#289)`, which converted all 26 sites to absolute comparisons. Kept as
+    # a regression guard with its original triggering data, per this repository's
+    # convention that the fix PR un-xfails the tests it closes.
     #
-    # This is one root cause with 26 sites: every `np.isclose(..., atol=tol)` in
+    # What it was: `_is_in_domain` (`_bspline_knots.py:172-173`) accepted a point when
+    # `np.isclose(knot_end, pt, atol=tol)`. Setting `atol` does not clear `rtol`, which
+    # stayed at numpy's default 1e-5, so the test was really
+    # `|pt - knot_end| <= tol + 1e-5 * |knot_end|`. On a domain of length 1 placed at 1e6
+    # that admitted points up to 10.00001 outside -- ten domain lengths -- while the
+    # space's stated tolerance is 1e-15.
+    #
+    # It was one root cause with 26 sites: every `np.isclose(..., atol=tol)` in
     # `pantr.bspline` leaves `rtol` at its default, across `_bspline_restrict.py` (10),
     # `_bspline_knots.py` (5), `_bspline_knot_insertion.py` (4),
     # `_bspline_knot_removal.py` (2), `_bspline_product.py` (2),
-    # `_bspline_space_1d.py` (2) and `_bspline_split.py` (1) -- not one of them passes
+    # `_bspline_space_1d.py` (2) and `_bspline_split.py` (1) -- not one of them passed
     # `rtol`. (A 27th call, in `_bspline_quasi_interpolation.py`, is inside a doctest and
-    # so not a library site.) Consequences already
-    # measured, all at |knot| ~ 1e6: `tabulate_basis` accepts a point 10 units outside a
-    # unit-length domain and returns a polynomial extrapolation (max|B| = 640 at degree 2,
-    # 4.3e43 at degree 62) instead of raising; `remove_knots` refuses to remove the
-    # interior knot 1000000.3125, calling it the domain start; `insert_knots` reports a
-    # false multiplicity clash between knots 0.0625 apart.
+    # so not a library site.) Consequences measured at the time, all at |knot| ~ 1e6:
+    # `tabulate_basis` accepted a point 10 units outside a unit-length domain and returned
+    # a polynomial extrapolation (max|B| = 640 at degree 2, 4.3e43 at degree 62) instead of
+    # raising; `remove_knots` refused to remove the interior knot 1000000.3125, calling it
+    # the domain start; `insert_knots` reported a false multiplicity clash between knots
+    # 0.0625 apart.
     #
-    # It is also **memory-unsafe**, which is what lifts it above a wrong-answer bug. On a
+    # It was also **memory-unsafe**, which is what lifted it above a wrong-answer bug. On a
     # *periodic* space over the same translated domain, `elevate_degree` and
-    # `reduce_degree` make a genuine out-of-bounds access -- `IndexError: index is out of
+    # `reduce_degree` made a genuine out-of-bounds access -- `IndexError: index is out of
     # bounds` under NUMBA_BOUNDSCHECK=1, at degrees 1, 2 and 3 in both dtypes. The
-    # boundary multiplicity is counted with the same leaky comparison
-    # (`_bspline_knot_insertion.py:242-243`), the false count is then used as an index,
-    # and with the bounds check off that read is silent. Varying only the domain isolates
+    # boundary multiplicity was counted with the same leaky comparison
+    # (`_bspline_knot_insertion.py:242-243`), the false count was then used as an index,
+    # and with the bounds check off that read was silent. Varying only the domain isolated
     # it:
     #
     #   [0, 1]  [0, 5]  [0, 100]  [0, 1e6]  [1e3, 1e3+1]  [1e4, 1e4+1]  ->  fine
     #   [1e6, 1e6+1]                                                    ->  IndexError
     #
-    # So it is not magnitude but *translation*: the offset sets the effective tolerance
-    # (1e-5 * 1e6 = 10) while the span it must resolve stays 1. In C++ that read is
-    # undefined behaviour, which makes this the finding the port most needs fixed.
+    # So it was not magnitude but *translation*: the offset set the effective tolerance
+    # (1e-5 * 1e6 = 10) while the span it had to resolve stayed 1.
     #
     # The author knew the trap -- `_snap_knots` (`_bspline_space_1d.py:211-215`) carries a
-    # comment warning about exactly it -- and avoided it in that one place.
+    # comment warning about exactly it -- and had avoided it in that one place.
     lo, hi = 1e6, 1e6 + 1.0
     knots = np.concatenate([np.full(3, lo), [lo + 0.5], np.full(3, hi)])
     space = BsplineSpace1D(knots, 2)
@@ -224,6 +226,14 @@ def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
     with pytest.raises(ValueError, match="outside the knot vector domain"):
         # 10 domain lengths past the right end.
         space.tabulate_basis(np.array([hi + 10.0]))
+
+    # Guard the other side too, which the original xfail did not: the fix must not
+    # over-correct into rejecting points that are legitimately inside. A tolerance that
+    # went fully absolute at 1e-15 would fail here, because the endpoint itself is only
+    # representable to about 1.2e-10 at this magnitude (one ulp of 1e6).
+    inside = np.array([lo, lo + 0.5, hi], dtype=np.float64)
+    basis, _ = space.tabulate_basis(inside)
+    assert np.all(np.isfinite(basis)), "in-domain points must still be accepted"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -23,7 +23,13 @@ import numpy as np
 import pytest
 
 from pantr.basis import LagrangeVariant, tabulate_lagrange_1d
-from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
+)
 from pantr.bspline._bspline_degree_core import _degree_elevate_1d_core
 from pantr.quad import get_tanh_sinh_1d
 from pantr.tolerance import get_machine_epsilon
@@ -47,14 +53,19 @@ def _scalar_spline(knots: np.ndarray, degree: int, values: list[float]) -> Bspli
 )
 def test_degree_elevation_outputs_are_mutually_consistent() -> None:
     # `_degree_elevate_1d_core` returns (control_points, knots), which are only usable
-    # together when `control_points.shape[0] == knots.size - new_degree - 1`. The counters
-    # `cind` and `kind` that produce them (`_bspline_degree_core.py:253`) are maintained
-    # independently through Piegl-Tiller A5.9, whose Bezier-segment walk assumes adjacent
-    # segments *share* an endpoint. At interior multiplicity degree + 1 the spline is
-    # discontinuous and they share nothing, so one control point per such knot is lost.
+    # together when `control_points.shape[0] == knots.size - new_degree - 1`. Those two
+    # come from counters `cind` and `kind` maintained independently through the
+    # Piegl-Tiller A5.9 walk and combined in a single return
+    # (`_bspline_degree_core.py:253`), and they diverge.
     #
-    # The deficit equals the number of C^-1 interior knots (measured: 1, 2 and 3 such
-    # knots give deficit 1, 2, 3) and does not grow with the increment.
+    # **Measured**: the deficit equals the number of interior knots at multiplicity
+    # degree + 1 (1, 2 and 3 such knots give deficit 1, 2, 3) and does not grow with the
+    # increment (an increment of 2 still gives deficit 1).
+    # **Inferred, not verified against the published algorithm**: A5.9 walks Bezier
+    # segments joined at interior knots of multiplicity at most `degree`, so adjacent
+    # segments share an endpoint; at multiplicity degree + 1 they share nothing and the
+    # shared point is subtracted anyway. Anyone fixing this should trace the `lbz`/`rbz`
+    # bookkeeping rather than take that sentence on trust.
     #
     # Two faces, one cause:
     #   * degree >= 1 -- the knot vector is right and the points are short, so
@@ -91,6 +102,54 @@ def test_degree_elevation_outputs_are_mutually_consistent() -> None:
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="_degree_elevate_1d_core allocates its knot output as float64 regardless of "
+    "the input dtype, so degree elevation is unusable in float32",
+)
+def test_degree_elevation_preserves_float32() -> None:
+    # `_bspline_degree_core.py:136-137` allocates the two outputs with different dtypes:
+    # `ik = np.zeros(max_new_knots, dtype=np.float64)` is hardcoded, while
+    # `ic = np.zeros(..., dtype=ctrl.dtype)` follows the input. The knot vector therefore
+    # comes back float64 while the control points stay float32, and the two faces of that
+    # are:
+    #   * clamped -- `Bspline.__init__` rejects the pair, so `elevate_degree` raises for
+    #     **every** float32 spline, at every degree and every knot count. Measured on
+    #     degrees 1-3 with 3, 4 and 6 breakpoints: nine for nine.
+    #   * periodic -- the round trip through open form converts the control points too, so
+    #     both come back float64 and the call *succeeds*, silently discarding the
+    #     caller's choice of precision.
+    #
+    # The second face is what makes this worth a test rather than a bug report: a silent
+    # dtype promotion is invisible until something downstream compares dtypes, and it
+    # doubles memory and halves throughput without a word.
+    knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float32)
+    clamped = _scalar_spline(knots, 2, [1.0, 2.0, 3.0, 4.0])
+    assert np.dtype(clamped.dtype) == np.float32, "precondition: the spline is float32"
+
+    # Face one: it does not work at all.
+    try:
+        elevated = clamped.elevate_degree(1)
+    except ValueError as exc:
+        pytest.fail(f"degree elevation of a clamped float32 spline raised: {exc}")
+    assert np.dtype(elevated.dtype) == np.float32, (
+        f"degree elevation changed the dtype from float32 to {np.dtype(elevated.dtype).name}"
+    )
+
+    # Face two: on a periodic space it succeeds and silently promotes. Kept in the same
+    # test because it is the same allocation, and separating them would imply two fixes.
+    periodic_knots = (np.arange(-2, 6, dtype=np.float64) / 3.0).astype(np.float32)
+    periodic = Bspline(
+        BsplineSpace([BsplineSpace1D(periodic_knots, 2, periodic=True)]),
+        np.arange(5, dtype=np.float32).reshape(5, 1),
+    )
+    promoted = periodic.elevate_degree(1)
+    assert np.dtype(promoted.dtype) == np.float32, (
+        f"degree elevation silently promoted a periodic float32 spline to "
+        f"{np.dtype(promoted.dtype).name}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tolerance policy: np.isclose keeps its default rtol
 # ---------------------------------------------------------------------------
@@ -109,11 +168,13 @@ def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
     # that admits points up to 10.00001 outside -- ten domain lengths -- while the space's
     # stated tolerance is 1e-15.
     #
-    # This is one root cause with 27 sites: every `np.isclose(..., atol=tol)` in
+    # This is one root cause with 26 sites: every `np.isclose(..., atol=tol)` in
     # `pantr.bspline` leaves `rtol` at its default, across `_bspline_restrict.py` (10),
     # `_bspline_knots.py` (5), `_bspline_knot_insertion.py` (4),
-    # `_bspline_space_1d.py` (3), `_bspline_product.py` (2),
-    # `_bspline_knot_removal.py` (2) and `_bspline_split.py` (1). Consequences already
+    # `_bspline_knot_removal.py` (2), `_bspline_product.py` (2),
+    # `_bspline_space_1d.py` (2) and `_bspline_split.py` (1) -- not one of them passes
+    # `rtol`. (A 27th call, in `_bspline_quasi_interpolation.py`, is inside a doctest and
+    # so not a library site.) Consequences already
     # measured, all at |knot| ~ 1e6: `tabulate_basis` accepts a point 10 units outside a
     # unit-length domain and returns a polynomial extrapolation (max|B| = 640 at degree 2,
     # 4.3e43 at degree 62) instead of raising; `remove_knots` refuses to remove the
@@ -145,14 +206,18 @@ def test_snapping_preserves_a_run_of_identical_knots() -> None:
     # `_snap_knots` (`_bspline_space_1d.py:215`) replaces every group of knots that round
     # to the same grid point by `np.mean(group, dtype=self.dtype)`. For a clamped end the
     # group is `degree + 1` copies of one value, so the mean must be that value exactly.
-    # It is not: numpy's pairwise summation of 63 copies loses the low bits once
-    # `(degree + 1) * |knot|` passes the format's exact-integer range (2^24 for float32,
-    # 2^53 for float64), and the knot moves by 0.125.
+    # It is not: the summation loses the low bits once `(degree + 1) * |knot|` passes the
+    # format's exact-integer range (2^24 for float32, 2^53 for float64), and the knot
+    # moves by 0.125. The consequence is that the space's *reported domain* differs from
+    # the one the caller asked for, silently.
     #
-    # The consequence is that the space's *reported domain* differs from the one the
-    # caller asked for, silently: float32 at |knot| ~ 1e6 and float64 at |knot| ~ 1e15,
-    # both at degree 62. Degree <= 15 is unaffected at those magnitudes, because numpy
-    # sums a run of 16 or fewer terms exactly.
+    # Which run lengths survive is **not** a clean rule, and it is worth not pretending
+    # otherwise: it falls out of NumPy's pairwise-summation blocking interacting with the
+    # value's own bit pattern. Measured for float64 at 1e15 + 1, runs of 11, 13, 14, 15,
+    # 18-23 and 26-31 copies are already inexact while 12, 16, 17, 24, 25 and 32 are
+    # exact. So this bites from **degree 10** in float64 at that magnitude, and the two
+    # degrees asserted below are simply the ones the sweep happened to visit -- do not
+    # read them as a threshold.
     for dtype, base in ((np.float32, 1e6), (np.float64, 1e15)):
         degree = 62
         hi = np.asarray(base + 1.0, dtype=dtype)
@@ -293,4 +358,47 @@ def test_tanh_sinh_nodes_are_interior_and_distinct() -> None:
         )
         assert np.unique(nodes).size == nodes.size, (
             f"n_pts {n_pts}: {nodes.size - np.unique(nodes).size} duplicated nodes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Zero intervals is documented as legal and produces a malformed knot vector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="num_intervals=0 is documented as legal but the knot-vector factories either "
+    "return NaN and inf or silently produce one interval instead of none",
+)
+def test_knot_factories_agree_on_zero_intervals() -> None:
+    # `create_uniform_open_knots` and `create_uniform_periodic_knots` both document
+    # `num_intervals` as "must be non-negative" and both validate only `>= 0`, so zero is
+    # inside their stated contract. `create_cardinal_knots` rejects it with
+    # "num_intervals must be at least 1". Three factories in one module, two answers to
+    # whether the input is legal, and neither of the accepting two returns a usable vector:
+    #
+    #   create_uniform_periodic_knots(0, 1) -> [nan, 0.0, inf]
+    #   create_uniform_periodic_knots(0, 3) -> [nan, nan, nan, 0.0, inf, inf, inf]
+    #   create_uniform_open_knots(0, 3)     -> [0,0,0,0, 1,1,1,1]   (one interval, not zero)
+    #
+    # The periodic case comes from `np.linspace` over a zero-length span with a division by
+    # the interval count; it emits only `RuntimeWarning: invalid value encountered in add`,
+    # which nothing raises on, and the caller receives a knot vector full of NaN and inf.
+    # `BsplineSpace1D` then rejects it for the wrong reason ("at least 2*degree+2
+    # elements"), so the origin of the NaN is never reported.
+    #
+    # Either answer would be defensible -- reject zero as the cardinal factory does, or
+    # return an empty-domain vector -- but the three must agree, and none may return NaN.
+    for degree in (1, 2, 3):
+        periodic = np.asarray(create_uniform_periodic_knots(0, degree))
+        assert np.all(np.isfinite(periodic)), (
+            f"create_uniform_periodic_knots(0, {degree}) returned non-finite knots: "
+            f"{periodic.tolist()}"
+        )
+        open_knots = np.asarray(create_uniform_open_knots(0, degree))
+        spans = int(np.unique(open_knots).size) - 1
+        assert spans == 0, (
+            f"create_uniform_open_knots(0, {degree}) returned {spans} interval(s): "
+            f"{open_knots.tolist()}"
         )

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -19,6 +19,9 @@ about this exact input and nothing else.
 
 from __future__ import annotations
 
+import signal
+from types import FrameType
+
 import numpy as np
 import pytest
 
@@ -39,6 +42,20 @@ def _scalar_spline(knots: np.ndarray, degree: int, values: list[float]) -> Bspli
     """Build a scalar 1D B-spline on the given knot vector."""
     space = BsplineSpace([BsplineSpace1D(knots, degree)])
     return Bspline(space, np.asarray(values, dtype=knots.dtype).reshape(-1, 1))
+
+
+class _CallTimeout(RuntimeError):
+    """Raised by :func:`_deadline` when the guarded call does not return in time."""
+
+
+_HANG_BUDGET_SECONDS = 2.0
+"""Budget for a call that must terminate promptly.
+
+Derived from the working case rather than picked: the same reduction on the *clamped*
+equivalent of the knot vector below returns in 0.003 s, so this is 600 times the observed
+cost and cannot fire on a slow machine. It is the price the suite pays while the bug is
+open; once fixed the call returns in milliseconds and the budget is never reached.
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -402,3 +419,59 @@ def test_knot_factories_agree_on_zero_intervals() -> None:
             f"create_uniform_open_knots(0, {degree}) returned {spans} interval(s): "
             f"{open_knots.tolist()}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Degree reduction never returns on a periodic linear spline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="needs SIGALRM to bound the call")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Bspline.reduce_degree(1) does not terminate on a degree-1 periodic spline",
+)
+def test_reduce_degree_terminates_on_a_periodic_linear_spline() -> None:
+    # Found by the sweep the hard way: it stalled a 25952-case run indefinitely, which is
+    # why the harness now bounds every case (`_core.CASE_TIMEOUT_SECONDS`).
+    #
+    # The trigger is exact and narrow -- periodic **and** degree 1 **and** `reduce_degree`:
+    #
+    #   degree 1, periodic,   2 / 3 / 4 / 8 intervals    -> never returns
+    #   degree 1, same knots, periodic=False             -> returns in 0.003 s
+    #   degree 1, periodic,   domain [0, 1e-6] or [0, 1] -> never returns (scale is not it)
+    #   degree 0, periodic                               -> documented ValueError (the
+    #                                                       decrement exceeds the degree)
+    #   degree 2 and 3, periodic                         -> documented ValueError (residual
+    #                                                       exceeds tolerance)
+    #
+    # So it is not a slow path, and not a tolerance loop that eventually gives up: the
+    # degrees on either side terminate, and only the periodic form of degree 1 spins. A
+    # non-terminating public call is the worst outcome in this codebase's own triage, and
+    # for the C++ port an infinite loop in a numerical routine is unrecoverable.
+    knots = np.asarray(create_uniform_periodic_knots(4, 1), dtype=np.float64)
+    space = BsplineSpace1D(knots, 1, periodic=True)
+    spline = Bspline(
+        BsplineSpace([space]),
+        np.linspace(-1.0, 1.0, 2 * space.num_basis).reshape(space.num_basis, 2),
+    )
+
+    def _expire(signum: int, frame: FrameType | None) -> None:
+        del signum, frame
+        raise _CallTimeout
+
+    previous = signal.signal(signal.SIGALRM, _expire)
+    signal.setitimer(signal.ITIMER_REAL, _HANG_BUDGET_SECONDS)
+    try:
+        spline.reduce_degree(1)
+    except _CallTimeout:
+        pytest.fail(
+            f"reduce_degree(1) on a degree-1 periodic spline did not return within "
+            f"{_HANG_BUDGET_SECONDS} s; the clamped equivalent takes 0.003 s"
+        )
+    except ValueError:
+        # A clean refusal would be a fix, not a failure: the point is that it terminates.
+        pass
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0.0)
+        signal.signal(signal.SIGALRM, previous)

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -196,9 +196,26 @@ def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
     # unit-length domain and returns a polynomial extrapolation (max|B| = 640 at degree 2,
     # 4.3e43 at degree 62) instead of raising; `remove_knots` refuses to remove the
     # interior knot 1000000.3125, calling it the domain start; `insert_knots` reports a
-    # false multiplicity clash between knots 0.0625 apart. The author knew the trap --
-    # `_snap_knots` (`_bspline_space_1d.py:211-215`) carries a comment warning about
-    # exactly it -- and avoided it in that one place.
+    # false multiplicity clash between knots 0.0625 apart.
+    #
+    # It is also **memory-unsafe**, which is what lifts it above a wrong-answer bug. On a
+    # *periodic* space over the same translated domain, `elevate_degree` and
+    # `reduce_degree` make a genuine out-of-bounds access -- `IndexError: index is out of
+    # bounds` under NUMBA_BOUNDSCHECK=1, at degrees 1, 2 and 3 in both dtypes. The
+    # boundary multiplicity is counted with the same leaky comparison
+    # (`_bspline_knot_insertion.py:242-243`), the false count is then used as an index,
+    # and with the bounds check off that read is silent. Varying only the domain isolates
+    # it:
+    #
+    #   [0, 1]  [0, 5]  [0, 100]  [0, 1e6]  [1e3, 1e3+1]  [1e4, 1e4+1]  ->  fine
+    #   [1e6, 1e6+1]                                                    ->  IndexError
+    #
+    # So it is not magnitude but *translation*: the offset sets the effective tolerance
+    # (1e-5 * 1e6 = 10) while the span it must resolve stays 1. In C++ that read is
+    # undefined behaviour, which makes this the finding the port most needs fixed.
+    #
+    # The author knew the trap -- `_snap_knots` (`_bspline_space_1d.py:211-215`) carries a
+    # comment warning about exactly it -- and avoided it in that one place.
     lo, hi = 1e6, 1e6 + 1.0
     knots = np.concatenate([np.full(3, lo), [lo + 0.5], np.full(3, hi)])
     space = BsplineSpace1D(knots, 2)

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -1,0 +1,296 @@
+"""Known-bug regressions from the adversarial parameter sweep (August 2026).
+
+Every test here is an ``xfail(strict=True)`` reproduction of a bug the sweep in
+``tools/adversarial_sweep/`` found on inputs the rest of the suite does not contain. When
+a bug is fixed the corresponding test starts passing, pytest reports a strict XPASS
+failure, and the marker should be removed, promoting the test to a permanent guard. That
+is the same convention ``tests/test_review_regressions.py`` follows for the June 2026
+review, whose markers have all since been removed.
+
+One test per **root cause**, not per symptom: several of these root causes have many
+triggering combinations, and each test names them in a comment rather than repeating
+itself. Regenerate the findings with::
+
+    conda run -n pantr python tools/sweep.py --profile full
+
+The triggering data is hardcoded rather than swept, so a test failure here is a statement
+about this exact input and nothing else.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pantr.basis import LagrangeVariant, tabulate_lagrange_1d
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline_degree_core import _degree_elevate_1d_core
+from pantr.quad import get_tanh_sinh_1d
+from pantr.tolerance import get_machine_epsilon
+
+
+def _scalar_spline(knots: np.ndarray, degree: int, values: list[float]) -> Bspline:
+    """Build a scalar 1D B-spline on the given knot vector."""
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    return Bspline(space, np.asarray(values, dtype=knots.dtype).reshape(-1, 1))
+
+
+# ---------------------------------------------------------------------------
+# Degree elevation: the kernel's two returns disagree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_degree_elevate_1d_core returns a knot vector and control points that "
+    "disagree once any interior knot has multiplicity degree + 1",
+)
+def test_degree_elevation_outputs_are_mutually_consistent() -> None:
+    # `_degree_elevate_1d_core` returns (control_points, knots), which are only usable
+    # together when `control_points.shape[0] == knots.size - new_degree - 1`. The counters
+    # `cind` and `kind` that produce them (`_bspline_degree_core.py:253`) are maintained
+    # independently through Piegl-Tiller A5.9, whose Bezier-segment walk assumes adjacent
+    # segments *share* an endpoint. At interior multiplicity degree + 1 the spline is
+    # discontinuous and they share nothing, so one control point per such knot is lost.
+    #
+    # The deficit equals the number of C^-1 interior knots (measured: 1, 2 and 3 such
+    # knots give deficit 1, 2, 3) and does not grow with the increment.
+    #
+    # Two faces, one cause:
+    #   * degree >= 1 -- the knot vector is right and the points are short, so
+    #     `Bspline.__init__` rejects the result with a message about the *caller's*
+    #     control-point count.
+    #   * degree 0 -- every interior knot has multiplicity 1 = degree + 1, so the whole
+    #     vector is pathological, both outputs come out short, the sizes agree by
+    #     accident, and the wrong answer is returned silently (see the second half).
+    for degree, mult in ((1, 2), (2, 3), (3, 4), (0, 1)):
+        knots = np.concatenate(
+            [np.full(degree + 1, 0.0), np.full(mult, 0.5), [0.75], np.full(degree + 1, 1.0)]
+        )
+        n_basis = knots.size - degree - 1
+        control = np.arange(2 * n_basis, dtype=np.float64).reshape(n_basis, 2)
+        new_control, new_knots = _degree_elevate_1d_core(degree, control, knots, 1)
+        implied = new_knots.size - (degree + 1) - 1
+        assert new_control.shape[0] == implied, (
+            f"degree {degree}, interior multiplicity {mult}: kernel wrote "
+            f"{new_control.shape[0]} control points but its own knot vector "
+            f"({new_knots.size} knots at degree {degree + 1}) implies {implied}"
+        )
+        assert np.all(np.diff(new_knots) >= 0.0), (
+            f"degree {degree}, interior multiplicity {mult}: returned knot vector is not "
+            f"non-decreasing: {new_knots.tolist()}"
+        )
+
+    # The silent face, entirely through public API: a degree-0 spline on [0, 1] with two
+    # control points comes back with a collapsed domain and a duplicated control point.
+    spline = _scalar_spline(np.array([0.0, 0.5, 1.0]), 0, [1.0, 2.0])
+    elevated = spline.elevate_degree(1)
+    elevated_knots = np.asarray(elevated.space.spaces[0].knots)
+    assert elevated_knots[-1] > elevated_knots[0], (
+        f"degree elevation collapsed the domain to a point: {elevated_knots.tolist()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tolerance policy: np.isclose keeps its default rtol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="domain membership is tested with np.isclose(..., atol=tol), which keeps the "
+    "default rtol=1e-5, so the effective tolerance is 1e-5 * |knot| instead of tol",
+)
+def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
+    # `_is_in_domain` (`_bspline_knots.py:172-173`) accepts a point when
+    # `np.isclose(knot_end, pt, atol=tol)`. Setting `atol` does not clear `rtol`, which
+    # stays at numpy's default 1e-5, so the test is really
+    # `|pt - knot_end| <= tol + 1e-5 * |knot_end|`. On a domain of length 1 placed at 1e6
+    # that admits points up to 10.00001 outside -- ten domain lengths -- while the space's
+    # stated tolerance is 1e-15.
+    #
+    # This is one root cause with 27 sites: every `np.isclose(..., atol=tol)` in
+    # `pantr.bspline` leaves `rtol` at its default, across `_bspline_restrict.py` (10),
+    # `_bspline_knots.py` (5), `_bspline_knot_insertion.py` (4),
+    # `_bspline_space_1d.py` (3), `_bspline_product.py` (2),
+    # `_bspline_knot_removal.py` (2) and `_bspline_split.py` (1). Consequences already
+    # measured, all at |knot| ~ 1e6: `tabulate_basis` accepts a point 10 units outside a
+    # unit-length domain and returns a polynomial extrapolation (max|B| = 640 at degree 2,
+    # 4.3e43 at degree 62) instead of raising; `remove_knots` refuses to remove the
+    # interior knot 1000000.3125, calling it the domain start; `insert_knots` reports a
+    # false multiplicity clash between knots 0.0625 apart. The author knew the trap --
+    # `_snap_knots` (`_bspline_space_1d.py:211-215`) carries a comment warning about
+    # exactly it -- and avoided it in that one place.
+    lo, hi = 1e6, 1e6 + 1.0
+    knots = np.concatenate([np.full(3, lo), [lo + 0.5], np.full(3, hi)])
+    space = BsplineSpace1D(knots, 2)
+    assert float(space.tolerance) < 1e-9, "precondition: the space carries a strict tolerance"
+
+    with pytest.raises(ValueError, match="outside the knot vector domain"):
+        # 10 domain lengths past the right end.
+        space.tabulate_basis(np.array([hi + 10.0]))
+
+
+# ---------------------------------------------------------------------------
+# Knot snapping: two independent defects in one method
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_snap_knots averages each group of equal knots, and np.mean over a run of "
+    "degree + 1 identical knots is not the identity at large coordinate magnitude",
+)
+def test_snapping_preserves_a_run_of_identical_knots() -> None:
+    # `_snap_knots` (`_bspline_space_1d.py:215`) replaces every group of knots that round
+    # to the same grid point by `np.mean(group, dtype=self.dtype)`. For a clamped end the
+    # group is `degree + 1` copies of one value, so the mean must be that value exactly.
+    # It is not: numpy's pairwise summation of 63 copies loses the low bits once
+    # `(degree + 1) * |knot|` passes the format's exact-integer range (2^24 for float32,
+    # 2^53 for float64), and the knot moves by 0.125.
+    #
+    # The consequence is that the space's *reported domain* differs from the one the
+    # caller asked for, silently: float32 at |knot| ~ 1e6 and float64 at |knot| ~ 1e15,
+    # both at degree 62. Degree <= 15 is unaffected at those magnitudes, because numpy
+    # sums a run of 16 or fewer terms exactly.
+    for dtype, base in ((np.float32, 1e6), (np.float64, 1e15)):
+        degree = 62
+        hi = np.asarray(base + 1.0, dtype=dtype)
+        raw = np.concatenate(
+            [
+                np.full(degree + 1, base, dtype=dtype),
+                [np.asarray(base + 0.5, dtype=dtype)],
+                np.full(degree + 1, hi, dtype=dtype),
+            ]
+        )
+        stored = np.asarray(BsplineSpace1D(raw, degree).knots)
+        assert stored[-1] == hi, (
+            f"{np.dtype(dtype).name}: snapping moved a run of {degree + 1} identical "
+            f"knots from {float(hi)!r} to {float(stored[-1])!r}"
+        )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="the knot-snapping grid is an absolute tolerance, so on a small domain it "
+    "merges knots the format resolves easily and the space silently loses intervals",
+)
+def test_snapping_keeps_knots_the_format_can_resolve() -> None:
+    # `_snap_knots` rounds onto a grid of width `tolerance`, which is absolute
+    # (`get_strict(float32) = 1e-7`, `get_strict(float64) = 1e-15`) while the quantity it
+    # grades -- a gap between knots -- carries the domain's scale. On `[0, 1e-6]` with 20
+    # equal intervals the spacing is 5e-8, below the float32 grid, so half the knots are
+    # merged and the space reports 10 intervals instead of 20. The float32 ulp at 1e-6 is
+    # 6e-14, so the format resolves those knots with six orders to spare: nothing about
+    # the input is unrepresentable.
+    #
+    # This is the small-domain face of an already-recorded tolerance-policy defect whose
+    # large-domain face is that from |knot| ~ 5 upward the same grid merges nothing at all.
+    # Further consequences measured at degree 62 on `[0, 1e-6]` in float32, where a
+    # periodic knot vector of 63 intervals collapses to 10: zero-length spans make
+    # `tabulate_Bezier_extraction_operators` raise a bare `ZeroDivisionError`, and the
+    # basis sums to 0 instead of 1 at the right endpoint.
+    n_intervals = 20
+    hi = 1e-6
+    breaks = np.linspace(0.0, hi, n_intervals + 1, dtype=np.float32)
+    raw = np.concatenate([np.array([0.0], dtype=np.float32), breaks, np.array([hi], np.float32)])
+    space = BsplineSpace1D(raw, 1)
+    assert space.num_intervals == n_intervals, (
+        f"asked for {n_intervals} intervals of width {hi / n_intervals:.2e} "
+        f"(float32 ulp there is {float(np.spacing(np.float32(hi))):.2e}), got "
+        f"{space.num_intervals}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lagrange tabulation is not reproducible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="tabulate_lagrange_1d builds a scipy BarycentricInterpolator without the rng "
+    "argument, so an unseeded global RNG permutes the nodes and the result changes "
+    "between calls",
+)
+def test_lagrange_tabulation_is_reproducible() -> None:
+    # `_basis_lagrange.py:104` constructs `BarycentricInterpolator(nodes_sorted, y_sorted)`
+    # with no `rng`. scipy then draws from the unseeded global `numpy.random` state and
+    # applies `rng.permutation(n)` to the nodes before computing the barycentric weights
+    # (`scipy/interpolate/_polyint.py:708-734`); its own documentation says "Specify `rng`
+    # for repeatable interpolation".
+    #
+    # So the same call returns different values in different processes. This is not
+    # floating-point nondeterminism with a bound one could derive -- it is an unseeded
+    # RNG, and the spread grows with degree: about 1 ulp at degree 3-5, 4.18 absolute on a
+    # value scale of 3.75e7 at degree 62 (relative 1.1e-7), and `inf` versus 1e16 across
+    # separate processes at degree 62 evaluated outside [0, 1]. Everything downstream
+    # inherits it: `tabulate_lagrange`, `compute_lagrange_to_bernstein_1d`,
+    # `tabulate_Lagrange_extraction_operators`, and `SpanwiseElementExtraction` with the
+    # Lagrange target.
+    #
+    # Reseeding the global state is what makes the failure deterministic here; in
+    # production the seeds differ because nobody set one.
+    pts = np.array([0.1, 0.5, 0.9])
+
+    # The legacy global state is the point: it is what scipy draws from.
+    np.random.seed(0)  # noqa: NPY002 -- scipy reads the legacy global state, not a Generator
+    first = np.asarray(tabulate_lagrange_1d(5, LagrangeVariant.EQUISPACES, pts), dtype=np.float64)
+    np.random.seed(12345)  # noqa: NPY002 -- see above
+    second = np.asarray(tabulate_lagrange_1d(5, LagrangeVariant.EQUISPACES, pts), dtype=np.float64)
+    assert np.array_equal(first, second), (
+        f"degree 5 differs between calls by up to {np.max(np.abs(first - second)):.3e}"
+    )
+
+    np.random.seed(0)  # noqa: NPY002 -- see above
+    high_first = np.asarray(
+        tabulate_lagrange_1d(62, LagrangeVariant.EQUISPACES, pts), dtype=np.float64
+    )
+    np.random.seed(12345)  # noqa: NPY002 -- see above
+    high_second = np.asarray(
+        tabulate_lagrange_1d(62, LagrangeVariant.EQUISPACES, pts), dtype=np.float64
+    )
+    # Even granting rounding, two evaluations of one basis at one point may differ by no
+    # more than the barycentric formula's own error: degree + 1 terms, each carrying at
+    # most eps relative, on values of this magnitude.
+    scale = float(np.max(np.abs(high_first)))
+    bound = 63.0 * get_machine_epsilon(np.float64) * scale
+    spread = float(np.max(np.abs(high_first - high_second)))
+    assert spread <= bound, (
+        f"degree 62 differs between calls by {spread:.3e}, bound {bound:.3e} "
+        f"(value scale {scale:.3e})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# tanh-sinh places nodes on the endpoints it exists to avoid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="get_tanh_sinh_1d snaps near-endpoint nodes onto 0 and 1 but keeps them, with "
+    "a nonzero weight and sometimes duplicated, so the rule evaluates at the endpoints",
+)
+def test_tanh_sinh_nodes_are_interior_and_distinct() -> None:
+    # A double-exponential rule exists to avoid evaluating at the endpoints:
+    # `get_tanh_sinh_1d`'s own docstring (`quad.py:370-372`) advertises it as "well suited
+    # for integrands with endpoint singularities". Nodes that underflow to the boundary
+    # are snapped there, which the docstring records only as making the returned count
+    # smaller (`:373-375`) -- but the snapped node is *kept*, with a nonzero weight
+    # (6.5e-17 at n_pts = 110), and from n_pts = 53 a second node snaps onto the same
+    # boundary and is returned twice.
+    #
+    # Consequence: for f(x) = 1/sqrt(x), the advertised use case, the rule returns `inf`
+    # rather than 2.0 at every n_pts >= 45. Weights still sum to 1 throughout, so the
+    # module's own doctest cannot see it.
+    for n_pts in (45, 53, 110, 129):
+        nodes, weights = get_tanh_sinh_1d(n_pts)
+        interior = np.count_nonzero((nodes <= 0.0) | (nodes >= 1.0))
+        assert interior == 0, (
+            f"n_pts {n_pts}: {interior} of {nodes.size} nodes sit on the boundary "
+            f"(weights {weights[(nodes <= 0.0) | (nodes >= 1.0)].tolist()})"
+        )
+        assert np.unique(nodes).size == nodes.size, (
+            f"n_pts {n_pts}: {nodes.size - np.unique(nodes).size} duplicated nodes"
+        )

--- a/tools/adversarial_sweep/__init__.py
+++ b/tools/adversarial_sweep/__init__.py
@@ -1,0 +1,79 @@
+"""Adversarial parameter sweep over pantr's public entry points.
+
+The sweep exists because pantr's Layer-3 kernels run under Numba ``nopython=True``,
+where there is no bounds checking: an out-of-range write silently corrupts memory, a
+negative index wraps to the end of the array, and int64 arithmetic overflows
+untrapped. The test suite runs clean under ``NUMBA_BOUNDSCHECK=1``, so the gap is
+inputs the suite does not contain. This tool generates them.
+
+Main pieces:
+
+* :mod:`adversarial_sweep._axes` -- the parameter axes and the hostile input families.
+* :mod:`adversarial_sweep._core` -- the case model, the four-way verdict rule, the
+  runner, and :func:`adversarial_sweep._core.assert_boundscheck_active`, the canary
+  that proves the harness could have caught an overrun.
+* :mod:`adversarial_sweep._registry` -- group name to case generator.
+* ``adversarial_sweep._probes_*`` -- one module per area under test.
+
+Run it through ``tools/sweep.py``, which puts ``src`` and ``tools`` on the path and
+configures the bounds check::
+
+    conda run -n pantr python tools/sweep.py --profile smoke
+    conda run -n pantr python tools/sweep.py --profile full --journal sweep.jsonl
+
+The sweep is also the input generator for the C++ port's parity oracle: every case
+carries its axis values in the JSONL journal, and ``--dump-npz DIR`` persists the
+input arrays of the cases that declare them.
+
+Coverage
+--------
+
+What the ``full`` profile actually crosses, so the claim can be read off rather than
+guessed. Case counts are from the first complete run.
+
+======================  =====  =========================================================
+group                   cases  covered
+======================  =====  =========================================================
+``geometry``              352  ``AABB`` and ``AffineTransform``: construction, degenerate
+                               and inverted boxes, set operations, transform enclosure and
+                               inverse round trip, dimensions 1-4, every domain.
+``grid``                  518  ``TensorProductGrid``, ``HierarchicalGrid``, ``BVH``,
+                               ``Partition``/``partition_grid`` (three backends),
+                               ``overlay``, tags, ``cell_quadrature``; refinement depth to
+                               20, anisotropic factors, degenerate BVH configurations.
+``quad``                  282  all seven 1D rules, ``PointsLattice``, ``QuadratureRule``,
+                               ``tensor_product_quadrature``, ``gauss_legendre_quadrature``;
+                               point counts 1-1000, both dtypes, exactness against exact
+                               rational moments.
+``basis``                1192  every ``tabulate_*`` and every ``change_basis`` builder,
+                               degrees 0-62, both dtypes, conditioning-derived round trips.
+``bspline``             13341  the multiplicity ladder crossed with degree, dtype and
+                               domain, then **every** operation that takes a spline pushed
+                               through each fixture; plus nD spaces to dimension 4,
+                               extraction for three targets, the knot-vector factories,
+                               interpolation, and THB spaces truncated and not.
+``bezier``                  -  see ``_probes_bezier``; curve, surface and volume Bezier
+                               operations, root finding, and the two named private kernels.
+======================  =====  =========================================================
+
+Axes crossed: interior knot multiplicity 1 to ``degree + 1``; degree 0, 1, 2, 3, 15, 62;
+domains ``[0,1]``, ``[0,1e-6]``, ``[0,5]``, ``[0,100]``, ``[0,1e6]`` and ``[1e6,1e6+1]``;
+clamped, graded, periodic, unclamped, one-end-clamped, over-clamped, minimal and malformed
+knot vectors; float32 and float64; dimensions 1-4; control points random, identical,
+collinear, zero and at the library's own zero threshold; query points interior, at a knot,
+at either endpoint, just outside, far outside, ``NaN``, ``inf``, empty and single; counts at
+zero, one and the minimum legal size.
+
+**Not covered, deliberately.** ``pantr.viz``, ``pantr.cad`` and ``pantr.mpi`` are deferred
+by the port plan and get no probes. Within ``pantr.bspline`` the multi-patch, coupling-graph
+and distributed local-space exports are unswept, and THB coverage is shallow (creation, one
+refinement, tabulation, prolongation) rather than a hierarchy sweep. The crossing is
+factorized rather than exhaustive: the full multiplicity ladder is crossed with degree and
+dtype on the unit domain and only its ``degree + 1`` corner is repeated on every other
+domain, so a bug needing (say) multiplicity 2 *and* a translated domain *and* float32
+together would be missed. Degree is sampled at six values, not swept. Interior multiplicity
+above degree 4 uses the corners ``{1, 2, degree-1, degree, degree+1}`` rather than the whole
+ladder.
+"""
+
+from __future__ import annotations

--- a/tools/adversarial_sweep/__main__.py
+++ b/tools/adversarial_sweep/__main__.py
@@ -1,0 +1,234 @@
+"""Command-line entry point for the adversarial parameter sweep.
+
+The sweep must run with Numba's bounds check enabled *and* a cache directory that
+does not already hold an unchecked compilation of the kernels, because
+``NUMBA_BOUNDSCHECK=1`` is silently ignored when a stale cache entry exists (the
+cache key does not include the flag) and every pantr kernel is ``cache=True``. Rather
+than rely on the caller getting that right, :func:`main` re-executes itself once with
+a fresh temporary cache directory when the environment is not already configured.
+
+Run it through the launcher, which puts ``src`` and ``tools`` on the path::
+
+    conda run -n pantr python tools/sweep.py --profile smoke
+    conda run -n pantr python tools/sweep.py --profile full --journal sweep.jsonl
+
+Exit codes: ``0`` no bugs found, ``1`` bugs found, ``3`` the harness itself is
+unusable (the bounds-check canary did not fire).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+import tempfile
+from typing import TYPE_CHECKING, Final, TextIO
+
+if TYPE_CHECKING:
+    from ._core import Summary
+
+_REEXEC_FLAG: Final = "PANTR_SWEEP_CONFIGURED"
+"""Environment marker set on re-exec so the fix-up can never loop."""
+
+EXIT_CLEAN: Final = 0
+EXIT_FINDINGS: Final = 1
+EXIT_HARNESS_UNUSABLE: Final = 3
+
+
+def _launcher_path() -> pathlib.Path:
+    """Locate ``tools/sweep.py``, the script a re-exec must invoke.
+
+    Returns:
+        pathlib.Path: Absolute path to the launcher.
+    """
+    return pathlib.Path(__file__).resolve().parents[1] / "sweep.py"
+
+
+def _reexec_with_boundscheck() -> None:
+    """Re-execute this process with the bounds check on and a fresh Numba cache.
+
+    Does nothing when the environment is already configured, or when the marker
+    shows this process is itself the result of a re-exec.
+    """
+    if os.environ.get(_REEXEC_FLAG) == "1":
+        return
+    env = dict(os.environ)
+    env[_REEXEC_FLAG] = "1"
+    env["NUMBA_BOUNDSCHECK"] = "1"
+    if not env.get("NUMBA_CACHE_DIR"):
+        env["NUMBA_CACHE_DIR"] = tempfile.mkdtemp(prefix="pantr-sweep-nbcache-")
+    print(
+        f"[sweep] re-exec with NUMBA_BOUNDSCHECK=1 NUMBA_CACHE_DIR={env['NUMBA_CACHE_DIR']}",
+        file=sys.stderr,
+        flush=True,
+    )
+    launcher = str(_launcher_path())
+    os.execve(sys.executable, [sys.executable, launcher, *sys.argv[1:]], env)
+
+
+def _build_parser(group_names: tuple[str, ...]) -> argparse.ArgumentParser:
+    """Build the command-line parser.
+
+    Args:
+        group_names (tuple[str, ...]): Registered sweep group names.
+
+    Returns:
+        argparse.ArgumentParser: The parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="sweep.py",
+        description="Adversarial parameter sweep over pantr's public entry points.",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=("smoke", "full"),
+        default="full",
+        help="Sweep width: 'smoke' is the bounded CI subset, 'full' the whole space.",
+    )
+    parser.add_argument(
+        "--group",
+        action="append",
+        choices=group_names,
+        metavar="NAME",
+        help="Restrict to one group; repeatable. Defaults to every group.",
+    )
+    parser.add_argument("--list-groups", action="store_true", help="Print the groups and exit.")
+    parser.add_argument(
+        "--journal",
+        type=pathlib.Path,
+        default=None,
+        help="Write the per-case JSONL records here instead of stdout.",
+    )
+    parser.add_argument(
+        "--dump-npz",
+        type=pathlib.Path,
+        default=None,
+        help="Persist each case's declared input arrays as .npz parity fixtures.",
+    )
+    parser.add_argument(
+        "--start-index",
+        type=int,
+        default=0,
+        help="Skip cases before this index, to resume past a hang or a hard crash.",
+    )
+    parser.add_argument(
+        "--max-cases", type=int, default=None, help="Stop after this many executed cases."
+    )
+    parser.add_argument(
+        "--count-only",
+        action="store_true",
+        help="Enumerate the selected cases and report how many there are, running none.",
+    )
+    return parser
+
+
+def _report(summary: Summary, stream: TextIO) -> None:
+    """Print the human-readable summary and every finding.
+
+    Args:
+        summary (Summary): Aggregate sweep result.
+        stream (TextIO): Text stream to print to.
+    """
+    print(f"\n{'=' * 78}", file=stream)
+    print(f"cases run: {summary.total}", file=stream)
+    for name, count in summary.counts.items():
+        print(f"  {name:24s} {count}", file=stream)
+
+    if summary.warned:
+        print(
+            f"\n--- WARNED WHILE RETURNING ({len(summary.warned)}): NumPy reports int64 "
+            "overflow and invalid operations this way ---",
+            file=stream,
+        )
+        for outcome in summary.warned:
+            print(
+                f"  [{outcome.index}] {outcome.case.group}/{outcome.case.label}"
+                f"  {','.join(outcome.warnings)}",
+                file=stream,
+            )
+
+    if summary.suspected:
+        print(
+            f"\n--- SUSPECTED ({len(summary.suspected)}): "
+            "ValueError/TypeError not listed in the entry point's Raises: section ---",
+            file=stream,
+        )
+        for outcome in summary.suspected:
+            print(
+                f"  [{outcome.index}] {outcome.case.group}/{outcome.case.label}\n"
+                f"      {outcome.detail}",
+                file=stream,
+            )
+
+    if summary.findings:
+        print(f"\n--- BUGS ({len(summary.findings)}) ---", file=stream)
+        for outcome in summary.findings:
+            print(
+                f"  [{outcome.index}] {outcome.case.group}/{outcome.case.label}\n"
+                f"      kind: {outcome.kind}\n"
+                f"      {outcome.detail}",
+                file=stream,
+            )
+    else:
+        print("\nno bugs found", file=stream)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sweep.
+
+    Args:
+        argv (list[str] | None): Command-line arguments. Defaults to ``sys.argv[1:]``.
+
+    Returns:
+        int: Process exit code.
+    """
+    _reexec_with_boundscheck()
+
+    from ._axes import Profile  # noqa: PLC0415 -- deferred until the env is fixed up
+    from ._core import CanaryError, Verdict, assert_boundscheck_active, run_sweep  # noqa: PLC0415
+    from ._registry import GROUPS, iter_cases  # noqa: PLC0415
+
+    parser = _build_parser(tuple(GROUPS))
+    args = parser.parse_args(argv)
+
+    if args.list_groups:
+        for name in GROUPS:
+            print(name)
+        return EXIT_CLEAN
+
+    try:
+        print(f"[sweep] {assert_boundscheck_active()}", file=sys.stderr, flush=True)
+    except CanaryError as exc:
+        print(f"[sweep] CANARY FAILED: {exc}", file=sys.stderr, flush=True)
+        return EXIT_HARNESS_UNUSABLE
+
+    profile = Profile.SMOKE if args.profile == "smoke" else Profile.FULL
+    groups = tuple(args.group) if args.group else tuple(GROUPS)
+    print(f"[sweep] profile={profile.name} groups={','.join(groups)}", file=sys.stderr, flush=True)
+
+    if args.count_only:
+        total = sum(1 for _ in iter_cases(profile, groups))
+        print(f"cases: {total}")
+        return EXIT_CLEAN
+
+    journal = args.journal.open("w", encoding="utf-8") if args.journal else sys.stdout
+    try:
+        summary = run_sweep(
+            iter_cases(profile, groups),
+            journal=journal,
+            progress=sys.stderr,
+            start_index=args.start_index,
+            max_cases=args.max_cases,
+            dump_dir=args.dump_npz,
+        )
+    finally:
+        if journal is not sys.stdout:
+            journal.close()
+
+    _report(summary, sys.stderr)
+    return EXIT_FINDINGS if summary.counts[Verdict.BUG.name] else EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/adversarial_sweep/__main__.py
+++ b/tools/adversarial_sweep/__main__.py
@@ -27,6 +27,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import time
 from typing import TYPE_CHECKING, Final, TextIO
 
 if TYPE_CHECKING:
@@ -128,6 +129,30 @@ def _build_parser(group_names: tuple[str, ...]) -> argparse.ArgumentParser:
     return parser
 
 
+def _pay_jit_compilation() -> None:
+    """Compile pantr's kernels before the timed loop starts, not inside a case.
+
+    pantr compiles its kernels on a background thread at import and exposes a barrier to
+    wait on. Waiting here moves that cost outside every case's budget, so the first case
+    to touch a kernel is not charged for it -- which under ``NUMBA_BOUNDSCHECK=1`` on a
+    fresh cache is the difference between milliseconds and tens of seconds.
+
+    This is a mitigation, not the fix: the warmup covers only the kernels it touches, and
+    any other still pays on first use. :func:`adversarial_sweep._core._call_with_budget`
+    is what actually keeps a slow compile from being reported as a hang.
+    """
+    from pantr._numba_compat import wait_for_jit_warmup  # noqa: PLC0415 -- after the re-exec
+
+    start = time.perf_counter()
+    wait_for_jit_warmup()
+    print(
+        f"[sweep] pantr JIT warmup complete in {time.perf_counter() - start:.1f} s "
+        "(paid outside every case budget)",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def _report(summary: Summary, stream: TextIO) -> None:
     """Print the human-readable summary and every finding.
 
@@ -214,6 +239,8 @@ def main(argv: list[str] | None = None) -> int:
     except CanaryError as exc:
         print(f"[sweep] CANARY FAILED: {exc}", file=sys.stderr, flush=True)
         return EXIT_HARNESS_UNUSABLE
+
+    _pay_jit_compilation()
 
     profile = Profile.SMOKE if args.profile == "smoke" else Profile.FULL
     groups = tuple(args.group) if args.group else tuple(GROUPS)

--- a/tools/adversarial_sweep/__main__.py
+++ b/tools/adversarial_sweep/__main__.py
@@ -13,7 +13,11 @@ Run it through the launcher, which puts ``src`` and ``tools`` on the path::
     conda run -n pantr python tools/sweep.py --profile full --journal sweep.jsonl
 
 Exit codes: ``0`` no bugs found, ``1`` bugs found, ``3`` the harness itself is
-unusable (the bounds-check canary did not fire).
+unusable (the bounds-check canary did not fire), ``4`` the run did not complete
+because a probe generator raised while building a case. ``4`` is deliberately
+distinct from ``1``: an incomplete run's counts mean nothing, and reading a
+truncation as "some findings, run finished" is the one mistake that would make a
+clean report untrustworthy.
 """
 
 from __future__ import annotations
@@ -34,6 +38,7 @@ _REEXEC_FLAG: Final = "PANTR_SWEEP_CONFIGURED"
 EXIT_CLEAN: Final = 0
 EXIT_FINDINGS: Final = 1
 EXIT_HARNESS_UNUSABLE: Final = 3
+EXIT_INCOMPLETE: Final = 4
 
 
 def _launcher_path() -> pathlib.Path:
@@ -131,6 +136,13 @@ def _report(summary: Summary, stream: TextIO) -> None:
         stream (TextIO): Text stream to print to.
     """
     print(f"\n{'=' * 78}", file=stream)
+    if summary.aborted is not None:
+        print(
+            f"RUN INCOMPLETE: {summary.aborted}\n"
+            "The counts below cover only the cases built before the failure and mean "
+            "nothing as a coverage claim.",
+            file=stream,
+        )
     print(f"cases run: {summary.total}", file=stream)
     for name, count in summary.counts.items():
         print(f"  {name:24s} {count}", file=stream)
@@ -227,6 +239,8 @@ def main(argv: list[str] | None = None) -> int:
             journal.close()
 
     _report(summary, sys.stderr)
+    if summary.aborted is not None:
+        return EXIT_INCOMPLETE
     return EXIT_FINDINGS if summary.counts[Verdict.BUG.name] else EXIT_CLEAN
 
 

--- a/tools/adversarial_sweep/_axes.py
+++ b/tools/adversarial_sweep/_axes.py
@@ -1,0 +1,485 @@
+"""The parameter axes the sweep crosses, and the hostile input families per axis.
+
+Everything the probe modules cross lives here, so the swept space is stated in one
+place and the coverage claim in the report can be read off it. Every family leans on
+the corners rather than the middle: degree 0 and a high degree where binomials bite,
+knot multiplicities up to ``degree + 1``, non-clamped and periodic knot vectors,
+translated domains, empty and single-element inputs, and ``NaN``/``inf``.
+
+Two profiles are provided. ``FULL`` is the sweep proper; ``SMOKE`` is the bounded
+subset the CI test runs, small enough that recompiling every kernel into a fresh
+Numba cache stays affordable.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING, Final, NamedTuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class Profile(enum.IntEnum):
+    """How wide to open each axis."""
+
+    SMOKE = 0
+    """Bounded subset for CI: the corners only, one domain, one dtype per axis."""
+
+    FULL = 1
+    """The whole space."""
+
+
+SEED: Final = 20260814
+"""Fixed seed so every random family is reproducible across runs and machines."""
+
+_DEGREES_SMOKE: Final = (0, 1, 3)
+_DEGREES_FULL: Final = (0, 1, 2, 3, 15, 62)
+"""Degree axis. 0-3 are the corners; 15 is high enough for binomial and Vandermonde
+conditioning to bite; 62 is the exact cliff where ``_bincoeff``'s integer recurrence
+wraps int64 (``_bspline_degree_core.py:22-67``), so any operation whose combined degree
+reaches it is a candidate for silent corruption."""
+
+_DOMAIN_UNIT: Final = (0.0, 1.0)
+_DOMAINS_FULL: Final = (
+    _DOMAIN_UNIT,
+    (0.0, 1e-6),
+    (0.0, 5.0),
+    (0.0, 100.0),
+    (0.0, 1e6),
+    (1e6, 1e6 + 1.0),
+)
+"""Scale and position axis, doubling as the knot-magnitude axis: an interior knot lands
+at ``lo + 0.5 * span``, so these domains put one at 0.5, 5e-7, 2.5, 50 and 5e5, plus the
+translated case. Magnitude matters because ``BsplineSpace1D``'s knot-snapping tolerance is
+*absolute* (``get_strict(float64) = 1e-15``) while the gap it grades scales with the knot,
+so from |knot| ~ 5 upward it merges nothing. The translated domain is the one that bites
+elsewhere: a tolerance derived from a bounding-box diagonal is translation invariant, an
+arithmetic floor is not."""
+
+
+class KnotSpec(NamedTuple):
+    """One knot-vector family instance.
+
+    Attributes:
+        name (str): Family identifier, used in the case label.
+        knots (npt.NDArray[np.float32 | np.float64]): The knot vector.
+        periodic (bool): Value to pass as ``BsplineSpace1D(periodic=...)``.
+    """
+
+    name: str
+    knots: npt.NDArray[np.float32 | np.float64]
+    periodic: bool
+
+
+class PointSpec(NamedTuple):
+    """One evaluation-point family instance.
+
+    Attributes:
+        name (str): Family identifier, used in the case label.
+        pts (npt.NDArray[np.float32 | np.float64]): The points, shape ``(n,)``.
+        finite (bool): ``False`` when the family deliberately contains ``NaN``/``inf``,
+            which switches off the automatic finiteness check on the result.
+    """
+
+    name: str
+    pts: npt.NDArray[np.float32 | np.float64]
+    finite: bool
+
+
+class CoeffSpec(NamedTuple):
+    """One coefficient / control-point family instance.
+
+    Attributes:
+        name (str): Family identifier, used in the case label.
+        values (npt.NDArray[np.float32 | np.float64]): The coefficient array.
+    """
+
+    name: str
+    values: npt.NDArray[np.float32 | np.float64]
+
+
+def degrees(profile: Profile) -> tuple[int, ...]:
+    """List the polynomial degrees to sweep.
+
+    Degree 0 is included deliberately: it has been a defect source in this codebase.
+    The high degrees are where factorials, binomials and the Bernstein recurrence
+    lose precision or overflow.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[int, ...]: Degrees, ascending.
+    """
+    return _DEGREES_SMOKE if profile is Profile.SMOKE else _DEGREES_FULL
+
+
+def dtypes(profile: Profile) -> tuple[np.dtype[np.float32 | np.float64], ...]:
+    """List the working precisions to sweep.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[np.dtype[np.float32 | np.float64], ...]: ``float64`` alone for the smoke
+            profile, both precisions for the full sweep.
+    """
+    if profile is Profile.SMOKE:
+        return (np.dtype(np.float64),)
+    return (np.dtype(np.float64), np.dtype(np.float32))
+
+
+def domains(profile: Profile) -> tuple[tuple[float, float], ...]:
+    """List the parametric/physical domains to sweep.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[tuple[float, float], ...]: ``(lo, hi)`` pairs covering unit, tiny, huge
+            and translated domains.
+    """
+    return (_DOMAIN_UNIT,) if profile is Profile.SMOKE else _DOMAINS_FULL
+
+
+def dims(profile: Profile, *, max_dim: int = 3) -> tuple[int, ...]:
+    """List the parametric dimensions to sweep.
+
+    Args:
+        profile (Profile): Sweep width.
+        max_dim (int): Highest dimension the entry point admits. Pass 4 to probe
+            ``n ** dim`` overflow where the API allows it. Defaults to 3.
+
+    Returns:
+        tuple[int, ...]: Dimensions, ascending.
+    """
+    top = min(max_dim, 2 if profile is Profile.SMOKE else max_dim)
+    return tuple(range(1, top + 1))
+
+
+def rng(offset: int = 0) -> np.random.Generator:
+    """Build a reproducible random generator.
+
+    Args:
+        offset (int): Stream offset so distinct families draw distinct values while
+            staying reproducible. Defaults to 0.
+
+    Returns:
+        np.random.Generator: Seeded generator.
+    """
+    return np.random.default_rng(SEED + offset)
+
+
+# ---------------------------------------------------------------------------
+# Knot vector families
+# ---------------------------------------------------------------------------
+
+
+def open_uniform_knots(
+    degree: int,
+    n_intervals: int,
+    domain: tuple[float, float],
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a clamped uniform knot vector.
+
+    Args:
+        degree (int): Polynomial degree.
+        n_intervals (int): Number of non-empty knot spans.
+        domain (tuple[float, float]): ``(lo, hi)`` parametric interval.
+        dtype (np.dtype[np.float32 | np.float64]): Knot precision.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Knot vector of length
+            ``n_intervals + 2 * degree + 1``.
+    """
+    lo, hi = domain
+    breaks = np.linspace(lo, hi, n_intervals + 1, dtype=dtype)
+    return np.concatenate(
+        [np.full(degree, lo, dtype=dtype), breaks, np.full(degree, hi, dtype=dtype)]
+    )
+
+
+_LADDER_MAX_DEGREE: Final = 4
+"""Highest degree whose multiplicity ladder is swept exhaustively rather than by corners."""
+
+
+def interior_multiplicities(degree: int, profile: Profile) -> tuple[int, ...]:
+    """List the interior knot multiplicities to sweep for one degree.
+
+    Multiplicity ``degree + 1`` is the prime suspect on every operation that takes a
+    spline: it makes the spline discontinuous (C^-1), which
+    :meth:`pantr.bspline.BsplineSpace1D.subdivide` produces as a documented public
+    feature with ``regularity=-1``, and which several algorithms silently assume away.
+    The whole ladder is swept up to degree ``_LADDER_MAX_DEGREE``; above it only the
+    corners are, since the interior of the ladder repeats one continuity class per step
+    and the case count is multiplied by every other axis.
+
+    Args:
+        degree (int): Polynomial degree.
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[int, ...]: Multiplicities, ascending, each in ``[1, degree + 1]``.
+    """
+    if profile is not Profile.FULL:
+        return tuple(sorted({1, min(2, degree + 1)}))
+    if degree <= _LADDER_MAX_DEGREE:
+        return tuple(range(1, degree + 2))
+    return tuple(sorted({1, 2, degree - 1, degree, degree + 1}))
+
+
+def knot_specs(
+    degree: int,
+    domain: tuple[float, float],
+    dtype: np.dtype[np.float32 | np.float64],
+    profile: Profile,
+) -> tuple[KnotSpec, ...]:
+    """Build the hostile knot-vector families for one ``(degree, domain, dtype)``.
+
+    Covers, in order: clamped uniform; clamped non-uniform (graded spans); the interior
+    multiplicities of :func:`interior_multiplicities`; a periodic/unclamped vector; the
+    minimal legal clamped vector (one Bezier span); the minimal legal unclamped one; a
+    non-clamped uniform vector; each end clamped alone; an over-clamped end; a knot run
+    a hair inside the left boundary; and three malformed vectors (unsorted, ``NaN``,
+    all-equal) which the sweep expects to be *rejected*, not accepted.
+
+    Args:
+        degree (int): Polynomial degree.
+        domain (tuple[float, float]): ``(lo, hi)`` parametric interval.
+        dtype (np.dtype[np.float32 | np.float64]): Knot precision.
+        profile (Profile): Sweep width; ``SMOKE`` drops the multiplicity ladder above
+            2 and the malformed vectors.
+
+    Returns:
+        tuple[KnotSpec, ...]: The families.
+    """
+    lo, hi = domain
+    span = hi - lo
+    full = profile is Profile.FULL
+    specs: list[KnotSpec] = [
+        KnotSpec("open_uniform", open_uniform_knots(degree, 4, domain, dtype), False),
+    ]
+
+    # Clamped, non-uniform: geometrically graded interior spans.
+    graded = lo + span * np.array([0.1, 0.3, 0.7], dtype=dtype)
+    specs.append(
+        KnotSpec(
+            "open_graded",
+            np.concatenate(
+                [
+                    np.full(degree + 1, lo, dtype=dtype),
+                    graded,
+                    np.full(degree + 1, hi, dtype=dtype),
+                ]
+            ),
+            False,
+        )
+    )
+
+    for mult in interior_multiplicities(degree, profile):
+        interior = np.concatenate(
+            [
+                np.full(mult, lo + 0.5 * span, dtype=dtype),
+                np.array([lo + 0.75 * span], dtype=dtype),
+            ]
+        )
+        specs.append(
+            KnotSpec(
+                f"interior_mult{mult}",
+                np.concatenate(
+                    [
+                        np.full(degree + 1, lo, dtype=dtype),
+                        interior,
+                        np.full(degree + 1, hi, dtype=dtype),
+                    ]
+                ),
+                False,
+            )
+        )
+
+    # Periodic / unclamped: uniform knots covering degree extra spans on each side.
+    n_per = max(2, degree + 1)
+    step = span / n_per
+    periodic = np.arange(-degree, n_per + degree + 1, dtype=np.float64) * step + lo
+    specs.append(KnotSpec("periodic_uniform", periodic.astype(dtype), True))
+    specs.append(KnotSpec("unclamped_uniform", periodic.astype(dtype), False))
+
+    # Minimal legal lengths: one Bezier span clamped, one span unclamped.
+    specs.append(
+        KnotSpec(
+            "minimal_clamped",
+            np.concatenate(
+                [np.full(degree + 1, lo, dtype=dtype), np.full(degree + 1, hi, dtype=dtype)]
+            ),
+            False,
+        )
+    )
+    minimal_unclamped = lo + span * np.linspace(-degree, degree + 1, 2 * degree + 2, dtype=dtype)
+    specs.append(KnotSpec("minimal_unclamped", minimal_unclamped, False))
+
+    # One end clamped only.
+    tail = lo + span * np.arange(1, degree + 2, dtype=dtype) / (degree + 1)
+    specs.append(
+        KnotSpec(
+            "left_clamped_only",
+            np.concatenate([np.full(degree + 1, lo, dtype=dtype), tail]),
+            False,
+        )
+    )
+    head = lo - span * np.arange(degree + 1, 0, -1, dtype=dtype) / (degree + 1)
+    specs.append(
+        KnotSpec(
+            "right_clamped_only",
+            np.concatenate([head, np.full(degree + 1, hi, dtype=dtype)]),
+            False,
+        )
+    )
+
+    if not full:
+        return tuple(specs)
+
+    # Over-clamped left end: multiplicity degree + 2 at the domain start.
+    specs.append(
+        KnotSpec(
+            "over_clamped_left",
+            np.concatenate(
+                [
+                    np.full(degree + 2, lo, dtype=dtype),
+                    np.array([lo + 0.5 * span], dtype=dtype),
+                    np.full(degree + 1, hi, dtype=dtype),
+                ]
+            ),
+            False,
+        )
+    )
+
+    # A knot run a hair inside the left boundary: spans far below any snap tolerance.
+    hair = lo + span * np.full(degree, 1e-13, dtype=dtype)
+    specs.append(
+        KnotSpec(
+            "hair_run_at_left",
+            np.concatenate(
+                [
+                    np.full(degree + 1, lo, dtype=dtype),
+                    hair,
+                    np.full(degree + 1, hi, dtype=dtype),
+                ]
+            ),
+            False,
+        )
+    )
+
+    # Malformed vectors: these must be rejected, and a rejection is not a finding.
+    # `open_uniform_knots(degree, 4, ...)` always has 2 * degree + 5 entries, so the
+    # swap below is unconditional.
+    unsorted = open_uniform_knots(degree, 4, domain, dtype).copy()
+    mid = unsorted.size // 2
+    unsorted[mid], unsorted[mid - 1] = unsorted[mid - 1], unsorted[mid] + span
+    specs.append(KnotSpec("unsorted", unsorted, False))
+
+    with_nan = open_uniform_knots(degree, 4, domain, dtype).copy()
+    with_nan[with_nan.size // 2] = np.nan
+    specs.append(KnotSpec("with_nan", with_nan, False))
+
+    specs.append(KnotSpec("all_equal", np.full(2 * degree + 2, lo, dtype=dtype), False))
+    specs.append(KnotSpec("too_short", np.full(degree + 1, lo, dtype=dtype), False))
+
+    return tuple(specs)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation point families
+# ---------------------------------------------------------------------------
+
+
+def point_specs(
+    domain: tuple[float, float],
+    dtype: np.dtype[np.float32 | np.float64],
+    profile: Profile,
+    *,
+    breakpoints: npt.NDArray[np.float32 | np.float64] | None = None,
+) -> tuple[PointSpec, ...]:
+    """Build the hostile evaluation-point families for one domain.
+
+    Args:
+        domain (tuple[float, float]): ``(lo, hi)`` parametric interval.
+        dtype (np.dtype[np.float32 | np.float64]): Point precision.
+        profile (Profile): Sweep width.
+        breakpoints (npt.NDArray[np.float32 | np.float64] | None): Interior knot
+            values to hit exactly. When ``None`` the interior-knot family is skipped.
+
+    Returns:
+        tuple[PointSpec, ...]: The families.
+    """
+    lo, hi = domain
+    span = hi - lo
+    step = np.spacing(np.float64(max(abs(lo), abs(hi), 1.0))).astype(np.float64)
+
+    specs: list[PointSpec] = [
+        PointSpec("interior", np.array([lo + 0.31 * span, lo + 0.77 * span], dtype=dtype), True),
+        PointSpec("right_endpoint", np.array([hi], dtype=dtype), True),
+        PointSpec("left_endpoint", np.array([lo], dtype=dtype), True),
+    ]
+    if profile is Profile.FULL:
+        specs += [
+            PointSpec("just_outside_right", np.array([hi + 8.0 * step], dtype=dtype), True),
+            PointSpec("just_outside_left", np.array([lo - 8.0 * step], dtype=dtype), True),
+            PointSpec("far_outside", np.array([lo - span, hi + span], dtype=dtype), True),
+            PointSpec("empty", np.zeros(0, dtype=dtype), True),
+            PointSpec("single", np.array([lo + 0.5 * span], dtype=dtype), True),
+            PointSpec("nan_inf", np.array([np.nan, np.inf, -np.inf], dtype=dtype), False),
+        ]
+    else:
+        specs.append(PointSpec("empty", np.zeros(0, dtype=dtype), True))
+    if breakpoints is not None and breakpoints.size:
+        specs.append(PointSpec("at_knots", np.unique(breakpoints).astype(dtype), True))
+    return tuple(specs)
+
+
+# ---------------------------------------------------------------------------
+# Coefficient / control point families
+# ---------------------------------------------------------------------------
+
+
+def coeff_specs(
+    shape: tuple[int, ...],
+    dtype: np.dtype[np.float32 | np.float64],
+    profile: Profile,
+    *,
+    offset: int = 0,
+) -> tuple[CoeffSpec, ...]:
+    """Build the hostile coefficient families for a given array shape.
+
+    Covers random, all-identical (collapsed geometry), collinear, identically zero,
+    and a value sitting exactly on the library's own default zero threshold.
+
+    Args:
+        shape (tuple[int, ...]): Shape of the coefficient array.
+        dtype (np.dtype[np.float32 | np.float64]): Coefficient precision.
+        profile (Profile): Sweep width.
+        offset (int): Random-stream offset. Defaults to 0.
+
+    Returns:
+        tuple[CoeffSpec, ...]: The families.
+    """
+    from pantr.tolerance import get_default  # noqa: PLC0415 -- keeps import cost off module load
+
+    generator = rng(offset)
+    specs: list[CoeffSpec] = [
+        CoeffSpec("random", generator.uniform(-1.0, 1.0, shape).astype(dtype)),
+        CoeffSpec("identical", np.full(shape, 0.5, dtype=dtype)),
+    ]
+    if profile is Profile.FULL:
+        n = int(np.prod(shape)) if shape else 1
+        ramp = np.linspace(0.0, 1.0, max(n, 1), dtype=dtype).reshape(shape) if shape else None
+        if ramp is not None:
+            specs.append(CoeffSpec("collinear", ramp))
+        specs += [
+            CoeffSpec("zeros", np.zeros(shape, dtype=dtype)),
+            CoeffSpec("at_zero_threshold", np.full(shape, get_default(dtype), dtype=dtype)),
+        ]
+    return tuple(specs)

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -1,0 +1,682 @@
+"""Case model, outcome classification and the runner for the adversarial sweep.
+
+A *case* is one call of one public pantr entry point with one hostile input
+combination. The runner executes it, catches everything it throws, and reduces the
+outcome to a single :class:`Verdict`:
+
+``OK``
+    The call returned and every invariant the case declared held.
+``DOCUMENTED_REJECTION``
+    The call raised an exception type that the entry point's own docstring lists
+    under ``Raises:``. Correct behavior, not a finding.
+``UNDOCUMENTED_REJECTION``
+    The call raised ``ValueError`` or ``TypeError`` -- the library's validation
+    idiom -- but the entry point's ``Raises:`` section does not list it. This is
+    almost always a nested Layer-2 validator firing, so it is reported as
+    *suspected* rather than as a bug.
+``BUG``
+    Everything else: an ``IndexError`` from Numba's bounds check, any other
+    exception type, a non-finite result from finite inputs, or a declared
+    invariant that failed. Also *any* exception at all on a case flagged
+    :attr:`Case.must_succeed`, which is how a documented exception type raised for
+    an undocumented reason stops passing for a correct rejection.
+
+Only ``BUG`` makes the runner exit non-zero.
+
+The module also owns :func:`assert_boundscheck_active`, the canary that proves the
+harness *could* have caught an out-of-bounds access before any result is trusted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+import re
+import sys
+import traceback
+import warnings
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, TextIO
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import numpy.typing as npt
+
+
+class Verdict(enum.IntEnum):
+    """Outcome classification of a single swept case, ordered by severity."""
+
+    OK = 0
+    """Returned, and every declared invariant held."""
+
+    DOCUMENTED_REJECTION = 1
+    """Raised an exception type listed in the entry point's ``Raises:`` section."""
+
+    UNDOCUMENTED_REJECTION = 2
+    """Raised ``ValueError``/``TypeError`` that the ``Raises:`` section omits."""
+
+    BUG = 3
+    """A finding: bounds-check hit, unexpected exception, or broken invariant."""
+
+
+NUMBA_OOB_MESSAGE: Final = "index is out of bounds"
+"""Exact ``IndexError`` message Numba's bounds check raises (verified on numba 0.65.1).
+
+NumPy's own out-of-range ``IndexError`` messages always name the offending index and
+the axis size, so an exact match on this string separates a Numba kernel overrun --
+which is silent memory corruption when the bounds check is off -- from an ordinary
+Python-level indexing error.
+"""
+
+_RAISES_HEADER: Final = re.compile(r"^\s*Raises:\s*$")
+_RAISES_ENTRY: Final = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_.]*)\s*:")
+_SECTION_HEADER: Final = re.compile(
+    r"^\s*(Args|Returns|Yields|Note|Notes|Example|Examples|"
+    r"Attributes|Warning|Warns|See Also|References):\s*$"
+)
+
+
+class InvariantResult(NamedTuple):
+    """Outcome of one invariant check.
+
+    Attributes:
+        name (str): Invariant identifier, reported verbatim on failure.
+        failure (str | None): ``None`` when the invariant held, otherwise a short
+            message describing the violation.
+    """
+
+    name: str
+    failure: str | None
+
+
+Invariant = Callable[[Any], InvariantResult]
+"""A check applied to a case's return value; returns :class:`InvariantResult`."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Case:
+    """One hostile call of one entry point.
+
+    Attributes:
+        group (str): Sweep group the case belongs to (selectable on the CLI).
+        label (str): Human-readable identity, unique within the group.
+        entry (Callable[..., Any]): The public symbol under test. Its docstring's
+            ``Raises:`` section defines which exceptions count as documented
+            rejections; for a class, ``__init__`` is consulted first.
+        run (Callable[[], Any]): Thunk performing the call and returning its result.
+        params (Mapping[str, Any]): Axis values recorded verbatim in the JSONL
+            journal. This is a serialized record payload, not an options bag.
+        invariants (tuple[Invariant, ...]): Checks applied to the return value.
+        must_succeed (bool): Set it when the input is legal *by construction* -- built
+            from a space that constructed cleanly, a point inside the domain, a degree
+            increment the docstring accepts. Then **any** exception is a finding,
+            whatever the ``Raises:`` section says. Without it, a docstring-driven rule
+            cannot see the failure mode where an entry point raises a documented
+            exception *type* for an undocumented *reason*: it reads as a correct
+            rejection and the sweep says nothing. That is not hypothetical -- it hid an
+            internal control-point/knot-vector inconsistency in degree elevation behind
+            the ``ValueError`` that documents a negative increment.
+        finite_inputs (bool): Whether every input is finite. When ``False`` the
+            automatic finiteness check on the result is skipped.
+        arrays (Mapping[str, npt.NDArray[Any]]): Input arrays to persist under
+            ``--dump-npz`` so the C++ port can replay the case as a parity oracle.
+            Empty when the case's inputs are fully determined by ``params``.
+    """
+
+    group: str
+    label: str
+    entry: Callable[..., Any]
+    run: Callable[[], Any]
+    params: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+    invariants: tuple[Invariant, ...] = ()
+    must_succeed: bool = False
+    finite_inputs: bool = True
+    arrays: Mapping[str, npt.NDArray[Any]] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Outcome:
+    """Classified result of running one :class:`Case`.
+
+    Attributes:
+        index (int): Position of the case in the sweep, for ``--start-index``.
+        case (Case): The case that produced this outcome.
+        verdict (Verdict): Severity classification.
+        kind (str): Short machine-readable reason (e.g. ``"numba-oob"``).
+        detail (str): One-line human explanation.
+        warnings (tuple[str, ...]): Warning categories raised during the call.
+    """
+
+    index: int
+    case: Case
+    verdict: Verdict
+    kind: str
+    detail: str
+    warnings: tuple[str, ...] = ()
+
+    def as_record(self) -> dict[str, Any]:
+        """Build the JSONL journal record for this outcome.
+
+        Returns:
+            dict[str, Any]: JSON-serializable summary of the case and its verdict.
+        """
+        return {
+            "index": self.index,
+            "group": self.case.group,
+            "label": self.case.label,
+            "entry": _entry_name(self.case.entry),
+            "verdict": self.verdict.name,
+            "kind": self.kind,
+            "detail": self.detail,
+            "params": {k: _jsonable(v) for k, v in self.case.params.items()},
+            "warnings": list(self.warnings),
+        }
+
+
+class Summary(NamedTuple):
+    """Aggregate result of a sweep run.
+
+    Attributes:
+        counts (dict[str, int]): Number of cases per :class:`Verdict` name.
+        findings (tuple[Outcome, ...]): Every ``BUG`` outcome, in order.
+        suspected (tuple[Outcome, ...]): Every ``UNDOCUMENTED_REJECTION`` outcome.
+        warned (tuple[Outcome, ...]): Every outcome that emitted a warning while
+            *returning* normally. NumPy reports int64 overflow, division by zero and
+            invalid operations as ``RuntimeWarning``, so an ``OK`` case that warned is
+            the cheapest available lead on a silent numerical fault.
+    """
+
+    counts: dict[str, int]
+    findings: tuple[Outcome, ...]
+    suspected: tuple[Outcome, ...]
+    warned: tuple[Outcome, ...] = ()
+
+    @property
+    def total(self) -> int:
+        """Total number of cases run.
+
+        Returns:
+            int: Sum of all per-verdict counts.
+        """
+        return sum(self.counts.values())
+
+
+# ---------------------------------------------------------------------------
+# Canary: prove the bounds check is live before trusting any clean result
+# ---------------------------------------------------------------------------
+
+
+class CanaryError(RuntimeError):
+    """Raised when the bounds-check canary fails to fire."""
+
+
+def assert_boundscheck_active() -> str:
+    """Verify that Numba's bounds check is live for a ``cache=True`` kernel.
+
+    ``NUMBA_BOUNDSCHECK=1`` is silently ignored when a stale on-disk cache entry
+    exists, because the cache key does not include the flag. Every pantr kernel is
+    ``cache=True``, so a sweep run against a warm cache returns a false clean. This
+    compiles two deliberately out-of-range ``cache=True`` kernels and requires both
+    to raise.
+
+    It also refuses to run with ``NUMBA_DISABLE_JIT=1``, and that check is not
+    ceremony: with the JIT off, ``njit`` is a no-op, the two probe kernels run as
+    plain Python, and NumPy raises ``IndexError`` on its own. The canary would pass
+    while nothing had been compiled at all -- the exact false clean it exists to
+    prevent. The repository's coverage run does set that variable, so the
+    configuration is reachable by accident.
+
+    Returns:
+        str: One-line description of the verified configuration.
+
+    Raises:
+        CanaryError: If the bounds check is off, if the JIT is disabled, or if either
+            deliberate out-of-bounds access fails to raise ``IndexError``.
+    """
+    import numba  # noqa: PLC0415  -- deferred so the env can be fixed up first
+
+    if not numba.config.BOUNDSCHECK:
+        raise CanaryError(
+            "numba.config.BOUNDSCHECK is off; run with NUMBA_BOUNDSCHECK=1 and a "
+            "fresh NUMBA_CACHE_DIR (see the module docstring for the invocation)."
+        )
+    if numba.config.DISABLE_JIT:
+        raise CanaryError(
+            "NUMBA_DISABLE_JIT is set, so no kernel is compiled and the bounds check "
+            "grades nothing; the canary below would pass on plain NumPy indexing. "
+            "Unset it: this sweep exists to exercise compiled kernels."
+        )
+
+    @numba.njit(cache=True)  # type: ignore[misc]
+    def _read_past_end(a: npt.NDArray[np.float64]) -> float:
+        """Read three elements past the end of ``a``."""
+        acc = 0.0
+        for i in range(a.size + 3):
+            acc += a[i]
+        return acc
+
+    @numba.njit(cache=True)  # type: ignore[misc]
+    def _read_before_start(a: npt.NDArray[np.float64]) -> float:
+        """Index ``a`` with a negative index that wraps past the front."""
+        return float(a[-a.size - 2])
+
+    probe = np.ones(4, dtype=np.float64)
+    for name, kernel in (("read-past-end", _read_past_end), ("negative-wrap", _read_before_start)):
+        try:
+            value = kernel(probe)
+        except IndexError:
+            continue
+        raise CanaryError(
+            f"canary {name!r} did not raise: returned {value!r}. The bounds check is "
+            "not active for cache=True kernels -- most likely a stale Numba cache. "
+            "A sweep that cannot detect an out-of-bounds access is worthless."
+        )
+
+    return (
+        f"canary OK: numba {numba.__version__}, BOUNDSCHECK="
+        f"{numba.config.BOUNDSCHECK}, JIT enabled, both deliberate overruns raised IndexError"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Documented-rejection lookup
+# ---------------------------------------------------------------------------
+
+
+def documented_exceptions(entry: Callable[..., Any]) -> frozenset[str]:
+    """Collect the exception type names listed in an entry point's ``Raises:`` section.
+
+    Google-style docstrings are mandatory in this repository, so the ``Raises:``
+    section is the machine-readable contract for which inputs may legitimately be
+    refused. For a class, ``__init__``'s docstring is consulted first and the class
+    docstring second.
+
+    Args:
+        entry (Callable[..., Any]): The public symbol under test.
+
+    Returns:
+        frozenset[str]: Bare exception type names, e.g. ``{"ValueError", "TypeError"}``.
+    """
+    docs: list[str] = []
+    init = getattr(entry, "__init__", None)
+    if isinstance(entry, type) and init is not None and init.__doc__:
+        docs.append(init.__doc__)
+    if entry.__doc__:
+        docs.append(entry.__doc__)
+
+    names: set[str] = set()
+    for doc in docs:
+        names |= _parse_raises(doc)
+    return frozenset(names)
+
+
+def _parse_raises(doc: str) -> set[str]:
+    """Extract exception names from the ``Raises:`` section of a Google docstring.
+
+    Args:
+        doc (str): Docstring text.
+
+    Returns:
+        set[str]: Bare exception type names found in the section.
+    """
+    names: set[str] = set()
+    in_section = False
+    for line in doc.splitlines():
+        if _RAISES_HEADER.match(line):
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if _SECTION_HEADER.match(line):
+            break
+        match = _RAISES_ENTRY.match(line)
+        if match is not None:
+            names.add(match.group(1).rsplit(".", maxsplit=1)[-1])
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Invariant factories
+# ---------------------------------------------------------------------------
+
+
+def finite_result() -> Invariant:
+    """Build an invariant requiring every floating-point output to be finite.
+
+    Returns:
+        Invariant: Check reporting the first non-finite array found.
+    """
+
+    def check(result: Any) -> InvariantResult:  # noqa: ANN401 -- classifies any return value
+        for path, arr in _iter_float_arrays(result):
+            if arr.size and not np.all(np.isfinite(arr)):
+                bad = int(np.count_nonzero(~np.isfinite(arr)))
+                return InvariantResult("finite", f"{bad}/{arr.size} non-finite in {path}")
+        return InvariantResult("finite", None)
+
+    return check
+
+
+def partition_of_unity(degree: int, dtype: npt.DTypeLike, *, axis: int = -1) -> Invariant:
+    """Build an invariant requiring basis values to sum to one along ``axis``.
+
+    The tolerance is derived rather than tuned. Summing ``n = degree + 1``
+    non-negative values whose exact total is one carries a forward error of at most
+    ``(n - 1) * eps``; each value itself comes out of a recurrence of depth
+    ``degree``, contributing at most ``O(degree) * eps`` more. Their product bounds
+    the total by ``(degree + 1) ** 2 * eps``, and an explicit safety factor of 4
+    absorbs the recurrence's unmodelled constant. A genuine partition-of-unity
+    failure is gross (zero, ``NaN``, or a value like 1.58 from summing a
+    non-truncated hierarchical basis), so a conservative bound costs no sensitivity.
+
+    Args:
+        degree (int): Polynomial degree of the basis, which sets the term count.
+        dtype (npt.DTypeLike): Working precision, which sets machine epsilon.
+        axis (int): Axis holding the basis functions. Defaults to ``-1``.
+
+    Returns:
+        Invariant: Check reporting the worst deviation from one.
+    """
+    from pantr.tolerance import get_machine_epsilon  # noqa: PLC0415  -- avoids import cycle
+
+    tol = 4.0 * (degree + 1) ** 2 * get_machine_epsilon(dtype)
+
+    def check(result: Any) -> InvariantResult:  # noqa: ANN401 -- classifies any return value
+        arr = np.asarray(result)
+        if arr.size == 0:
+            return InvariantResult("partition-of-unity", None)
+        sums = np.sum(arr, axis=axis)
+        worst = float(np.max(np.abs(sums - 1.0)))
+        if not np.isfinite(worst) or worst > tol:
+            return InvariantResult("partition-of-unity", f"max|sum-1| = {worst:.3e} > {tol:.3e}")
+        return InvariantResult("partition-of-unity", None)
+
+    return check
+
+
+def expected_shape(shape: tuple[int, ...]) -> Invariant:
+    """Build an invariant requiring the result to have an exact shape.
+
+    Args:
+        shape (tuple[int, ...]): The shape the entry point's own contract promises.
+
+    Returns:
+        Invariant: Check reporting the mismatch.
+    """
+
+    def check(result: Any) -> InvariantResult:  # noqa: ANN401 -- classifies any return value
+        got = np.shape(result)
+        if tuple(got) != shape:
+            return InvariantResult("shape", f"got {tuple(got)}, contract says {shape}")
+        return InvariantResult("shape", None)
+
+    return check
+
+
+def custom(name: str, predicate: Callable[[Any], str | None]) -> Invariant:
+    """Wrap a bespoke predicate as an invariant.
+
+    Args:
+        name (str): Invariant identifier reported on failure.
+        predicate (Callable[[Any], str | None]): Returns ``None`` when the property
+            holds, otherwise a short failure message.
+
+    Returns:
+        Invariant: The wrapped check.
+    """
+
+    def check(result: Any) -> InvariantResult:  # noqa: ANN401 -- classifies any return value
+        return InvariantResult(name, predicate(result))
+
+    return check
+
+
+def _iter_float_arrays(
+    result: Any,  # noqa: ANN401 -- walks an arbitrary return value
+    path: str = "result",
+) -> Iterator[tuple[str, npt.NDArray[np.floating[Any]]]]:
+    """Walk a return value yielding every floating-point array it contains.
+
+    Args:
+        result (Any): Value returned by an entry point.
+        path (str): Dotted path used in failure messages. Defaults to ``"result"``.
+
+    Yields:
+        tuple[str, npt.NDArray[np.floating[Any]]]: Path and array, for each float array
+            reached.
+    """
+    if isinstance(result, np.ndarray):
+        if result.dtype.kind == "f":
+            yield path, result
+        return
+    if isinstance(result, str | bytes):
+        return
+    if isinstance(result, Mapping):
+        for key, value in result.items():
+            yield from _iter_float_arrays(value, f"{path}[{key!r}]")
+        return
+    if isinstance(result, Sequence):
+        for i, value in enumerate(result):
+            yield from _iter_float_arrays(value, f"{path}[{i}]")
+        return
+    if isinstance(result, float):
+        yield path, np.asarray(result, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def classify(case: Case, exc: Exception) -> tuple[Verdict, str, str]:
+    """Classify an exception thrown by a case.
+
+    Args:
+        case (Case): The case that raised.
+        exc (Exception): The exception it raised.
+
+    Returns:
+        tuple[Verdict, str, str]: Verdict, machine-readable kind, and detail line.
+    """
+    name = type(exc).__name__
+    message = str(exc).strip()
+
+    if isinstance(exc, IndexError) and message == NUMBA_OOB_MESSAGE:
+        return Verdict.BUG, "numba-oob", "Numba bounds check: out-of-range access in a kernel"
+
+    if case.must_succeed:
+        return (
+            Verdict.BUG,
+            f"must-succeed:{name}",
+            f"{name} on input that is legal by construction: {message}",
+        )
+
+    documented = documented_exceptions(case.entry)
+    if name in documented:
+        return Verdict.DOCUMENTED_REJECTION, f"documented:{name}", message
+
+    if isinstance(exc, ValueError | TypeError):
+        listed = ", ".join(sorted(documented)) or "nothing"
+        return (
+            Verdict.UNDOCUMENTED_REJECTION,
+            f"undocumented:{name}",
+            f"{name}: {message} (Raises: lists {listed})",
+        )
+
+    return Verdict.BUG, f"unexpected:{name}", f"{name}: {message}"
+
+
+def run_case(index: int, case: Case) -> Outcome:
+    """Execute one case and classify the outcome.
+
+    Args:
+        index (int): Position of the case in the sweep.
+        case (Case): The case to run.
+
+    Returns:
+        Outcome: The classified result.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            result = case.run()
+        except Exception as exc:  # a sweep classifies whatever comes out, by design
+            verdict, kind, detail = classify(case, exc)
+            if verdict is Verdict.BUG:
+                detail = f"{detail}\n{_short_traceback(exc)}"
+            return Outcome(index, case, verdict, kind, detail, _warning_names(caught))
+        checks = [*case.invariants]
+        if case.finite_inputs:
+            checks.append(finite_result())
+        for check in checks:
+            outcome = check(result)
+            if outcome.failure is not None:
+                return Outcome(
+                    index,
+                    case,
+                    Verdict.BUG,
+                    f"invariant:{outcome.name}",
+                    outcome.failure,
+                    _warning_names(caught),
+                )
+        return Outcome(index, case, Verdict.OK, "ok", "", _warning_names(caught))
+
+
+def run_sweep(  # noqa: PLR0913 -- five keyword-only knobs, each one CLI flag
+    cases: Iterable[Case],
+    *,
+    journal: TextIO = sys.stdout,
+    progress: TextIO = sys.stderr,
+    start_index: int = 0,
+    max_cases: int | None = None,
+    dump_dir: Path | None = None,
+) -> Summary:
+    """Run a sequence of cases, journaling each one before it executes.
+
+    Each case's identity is written to ``progress`` and flushed *before* the call,
+    so a hang or a hard crash (which an unchecked Numba kernel can produce) still
+    identifies the case that caused it.
+
+    Args:
+        cases (Iterable[Case]): The cases to run, in order.
+        journal (TextIO): Text stream receiving one JSON record per case.
+        progress (TextIO): Text stream receiving human-readable progress.
+        start_index (int): Skip cases before this index, to resume past a crash.
+        max_cases (int | None): Stop after this many executed cases.
+        dump_dir (Path | None): When set, persist each case's declared input arrays
+            plus its float outputs as ``.npz`` for reuse as parity fixtures.
+
+    Returns:
+        Summary: Per-verdict counts and the findings.
+    """
+    counts: dict[str, int] = {verdict.name: 0 for verdict in Verdict}
+    findings: list[Outcome] = []
+    suspected: list[Outcome] = []
+    warned: list[Outcome] = []
+    executed = 0
+
+    for index, case in enumerate(cases):
+        if index < start_index:
+            continue
+        if max_cases is not None and executed >= max_cases:
+            break
+        print(f"[{index}] {case.group}/{case.label}", file=progress, flush=True)
+        outcome = run_case(index, case)
+        executed += 1
+        counts[outcome.verdict.name] += 1
+        if outcome.verdict is Verdict.BUG:
+            findings.append(outcome)
+        elif outcome.verdict is Verdict.UNDOCUMENTED_REJECTION:
+            suspected.append(outcome)
+        if outcome.verdict is Verdict.OK and outcome.warnings:
+            warned.append(outcome)
+        print(json.dumps(outcome.as_record()), file=journal, flush=True)
+        if dump_dir is not None and case.arrays:
+            _dump_case(dump_dir, outcome)
+
+    return Summary(counts, tuple(findings), tuple(suspected), tuple(warned))
+
+
+def _dump_case(dump_dir: Path, outcome: Outcome) -> None:
+    """Persist a case's input arrays and float outputs as a parity fixture.
+
+    Args:
+        dump_dir (Path): Directory to write into; created if absent.
+        outcome (Outcome): The executed case.
+    """
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", f"{outcome.case.group}-{outcome.case.label}")
+    payload = {f"in_{k}": np.asarray(v) for k, v in outcome.case.arrays.items()}
+    np.savez_compressed(dump_dir / f"{outcome.index:06d}-{safe}.npz", **payload)
+
+
+def _warning_names(caught: Sequence[warnings.WarningMessage]) -> tuple[str, ...]:
+    """Reduce captured warnings to their unique category names.
+
+    Args:
+        caught (Sequence[warnings.WarningMessage]): Warnings recorded during a call.
+
+    Returns:
+        tuple[str, ...]: Sorted unique category names.
+    """
+    return tuple(sorted({w.category.__name__ for w in caught}))
+
+
+def _short_traceback(exc: Exception, depth: int = 3) -> str:
+    """Format the innermost frames of an exception's traceback.
+
+    Args:
+        exc (Exception): The exception to format.
+        depth (int): Number of innermost frames to keep. Defaults to 3.
+
+    Returns:
+        str: Indented traceback tail.
+    """
+    frames = traceback.format_tb(exc.__traceback__)[-depth:]
+    return "".join(frames).rstrip()
+
+
+def _entry_name(entry: Callable[..., Any]) -> str:
+    """Build a stable dotted name for an entry point.
+
+    Args:
+        entry (Callable[..., Any]): The symbol under test.
+
+    Returns:
+        str: ``module.qualname``, or ``repr`` when either is unavailable.
+    """
+    module = getattr(entry, "__module__", "?")
+    qualname = getattr(entry, "__qualname__", None) or repr(entry)
+    return f"{module}.{qualname}"
+
+
+def _jsonable(  # noqa: PLR0911 -- a flat type-dispatch chain, one return per case
+    value: Any,  # noqa: ANN401 -- any axis value may be recorded
+) -> Any:  # noqa: ANN401
+    """Coerce a parameter value into something ``json.dumps`` accepts.
+
+    Args:
+        value (Any): Recorded axis value.
+
+    Returns:
+        Any: JSON-serializable equivalent.
+    """
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.dtype):
+        return value.name
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, enum.Enum):
+        return value.name
+    if isinstance(value, str | int | float | bool | None):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_jsonable(v) for v in value]
+    return repr(value)

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -544,14 +544,18 @@ class CaseTimeout(RuntimeError):
 
 
 CASE_TIMEOUT_SECONDS: Final = 30.0
-"""Wall-clock budget for one case, after which it is reported as a hang.
+"""Wall-clock budget for **one attempt** at a case; two expiries make it a hang.
 
 Non-termination is one of the outcomes this sweep hunts, and it needs a budget because
-the alternative is that the *sweep* hangs and nobody runs it again. Thirty seconds is far
-above what any case here legitimately needs -- the slowest, a degree-62 tabulation, is
-milliseconds -- so a case that trips it is not slow, it is stuck. That is not
+the alternative is that the *sweep* hangs and nobody runs it again. That is not
 hypothetical: ``Bspline.reduce_degree(1)`` never returns on a degree-1 *periodic* spline,
-which stalled a 25952-case run indefinitely.
+and stalled a 25952-case run indefinitely.
+
+The value is deliberately **not** load-bearing, because it cannot be: a budget that
+separates "slow" from "stuck" by magnitude alone has to be tuned to a machine, and the
+first call into any kernel pays LLVM codegen that is far larger than the work itself
+(16.6 s against 0.000 s here). :func:`_call_with_budget` does the separating instead, by
+retrying once; thirty seconds is then merely a generous allowance for one compile.
 
 **Limitation, stated because it matters for the port:** the alarm is delivered at a Python
 bytecode boundary, so it interrupts a hang in a Layer-2 Python loop but **not** one inside
@@ -593,6 +597,43 @@ def _timeout_guard(seconds: float) -> AbstractContextManager[None]:
     return guard()
 
 
+def _call_with_budget(case: Case) -> Any:  # noqa: ANN401 -- returns whatever the entry point does
+    """Run a case's thunk under the timeout, retrying once if the first attempt expires.
+
+    The retry is what makes the budget's absolute value stop mattering, and it is not an
+    optimization -- without it the harness reports a *hang* that is really a slow compile.
+    The first call into any Numba kernel pays LLVM codegen, and under
+    ``NUMBA_BOUNDSCHECK=1`` on a fresh cache that is expensive: measured at **16.6 s** for
+    the first ``tabulate_bernstein_1d`` call on the development machine against **0.000 s**
+    for the second, a ratio of 8.7e5. Whichever case happens to reach a kernel first is
+    charged the whole of it, so on a machine slower at codegen a perfectly healthy case
+    blows any fixed budget -- which is exactly what happened on CI, where a degree-0
+    Bernstein tabulation was reported as a 30 s hang.
+
+    Retrying separates the two by observation rather than by a constant tuned to one
+    machine: compilation is paid once, so the second attempt is fast, while a genuine
+    non-termination expires again. The cost is that a real hang takes
+    ``2 * CASE_TIMEOUT_SECONDS`` to report, which is the right trade -- hangs are rare and
+    a false one is far more expensive than a slow one.
+
+    Args:
+        case (Case): The case to run.
+
+    Returns:
+        Any: Whatever the entry point returned.
+
+    Raises:
+        CaseTimeout: If the call expires twice, i.e. it genuinely does not terminate.
+    """
+    try:
+        with _timeout_guard(CASE_TIMEOUT_SECONDS):
+            return case.run()
+    except CaseTimeout:
+        pass
+    with _timeout_guard(CASE_TIMEOUT_SECONDS):
+        return case.run()
+
+
 def run_case(index: int, case: Case) -> Outcome:
     """Execute one case and classify the outcome.
 
@@ -601,7 +642,8 @@ def run_case(index: int, case: Case) -> Outcome:
     surrounding machinery is that no single case can end the run, and an uncaught
     exception here would do exactly that: the remaining cases never execute and the
     process exit status is indistinguishable from "findings were reported". A case that
-    does not return within :data:`CASE_TIMEOUT_SECONDS` is reported the same way.
+    does not terminate is reported the same way, on the terms
+    :func:`_call_with_budget` sets.
 
     Args:
         index (int): Position of the case in the sweep.
@@ -613,15 +655,14 @@ def run_case(index: int, case: Case) -> Outcome:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         try:
-            with _timeout_guard(CASE_TIMEOUT_SECONDS):
-                result = case.run()
+            result = _call_with_budget(case)
         except CaseTimeout as exc:
             return Outcome(
                 index,
                 case,
                 Verdict.BUG,
                 "timeout",
-                f"the call did not terminate: {exc}",
+                f"the call did not terminate, on two attempts: {exc}",
                 _warning_names(caught),
             )
         except Exception as exc:  # a sweep classifies whatever comes out, by design

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -120,6 +120,12 @@ class Case:
             rejection and the sweep says nothing. That is not hypothetical -- it hid an
             internal control-point/knot-vector inconsistency in degree elevation behind
             the ``ValueError`` that documents a negative increment.
+        must_reject (bool): The mirror image, for a case built to be *refused* -- a
+            malformed knot vector, a negative point count, a coordinate outside the unit
+            cube. Then *returning* is the finding. Without it such a case is graded only
+            on whether the result is finite, so an entry point that silently started
+            accepting nonsense and producing a plausible number would read as ``OK``:
+            the input family's intent lives in a comment and nothing checks it.
         finite_inputs (bool): Whether every input is finite. When ``False`` the
             automatic finiteness check on the result is skipped.
         arrays (Mapping[str, npt.NDArray[Any]]): Input arrays to persist under
@@ -134,8 +140,20 @@ class Case:
     params: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     invariants: tuple[Invariant, ...] = ()
     must_succeed: bool = False
+    must_reject: bool = False
     finite_inputs: bool = True
     arrays: Mapping[str, npt.NDArray[Any]] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject a case that claims its input is both legal and illegal.
+
+        Raises:
+            ValueError: If both ``must_succeed`` and ``must_reject`` are set.
+        """
+        if self.must_succeed and self.must_reject:
+            raise ValueError(
+                f"case {self.group}/{self.label} sets both must_succeed and must_reject"
+            )
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -188,12 +206,18 @@ class Summary(NamedTuple):
             *returning* normally. NumPy reports int64 overflow, division by zero and
             invalid operations as ``RuntimeWarning``, so an ``OK`` case that warned is
             the cheapest available lead on a silent numerical fault.
+        aborted (str | None): Set when *enumeration* failed, i.e. a probe generator
+            raised while building a case rather than while running one. The cases after
+            it never execute, so the run is incomplete and its counts mean nothing --
+            which is why it gets its own exit code instead of being folded into the
+            findings.
     """
 
     counts: dict[str, int]
     findings: tuple[Outcome, ...]
     suspected: tuple[Outcome, ...]
     warned: tuple[Outcome, ...] = ()
+    aborted: str | None = None
 
     @property
     def total(self) -> int:
@@ -513,6 +537,12 @@ def classify(case: Case, exc: Exception) -> tuple[Verdict, str, str]:
 def run_case(index: int, case: Case) -> Outcome:
     """Execute one case and classify the outcome.
 
+    An invariant that *raises* is caught and reported, not allowed to propagate. A
+    predicate usually raises because the probe is wrong, but the whole point of the
+    surrounding machinery is that no single case can end the run, and an uncaught
+    exception here would do exactly that: the remaining cases never execute and the
+    process exit status is indistinguishable from "findings were reported".
+
     Args:
         index (int): Position of the case in the sweep.
         case (Case): The case to run.
@@ -529,11 +559,31 @@ def run_case(index: int, case: Case) -> Outcome:
             if verdict is Verdict.BUG:
                 detail = f"{detail}\n{_short_traceback(exc)}"
             return Outcome(index, case, verdict, kind, detail, _warning_names(caught))
+        if case.must_reject:
+            return Outcome(
+                index,
+                case,
+                Verdict.BUG,
+                "must-reject:returned",
+                f"input built to be refused was accepted, returning {type(result).__name__}",
+                _warning_names(caught),
+            )
         checks = [*case.invariants]
         if case.finite_inputs:
             checks.append(finite_result())
         for check in checks:
-            outcome = check(result)
+            try:
+                outcome = check(result)
+            except Exception as exc:  # a predicate must never end the run
+                return Outcome(
+                    index,
+                    case,
+                    Verdict.BUG,
+                    f"invariant-raised:{type(exc).__name__}",
+                    f"an invariant raised instead of returning a verdict: {exc}\n"
+                    f"{_short_traceback(exc)}",
+                    _warning_names(caught),
+                )
             if outcome.failure is not None:
                 return Outcome(
                     index,
@@ -561,6 +611,14 @@ def run_sweep(  # noqa: PLR0913 -- five keyword-only knobs, each one CLI flag
     so a hang or a hard crash (which an unchecked Numba kernel can produce) still
     identifies the case that caused it.
 
+    Failures while *building* a case are caught too, and reported through
+    :attr:`Summary.aborted`. A probe generator that raises cannot be resumed -- Python
+    closes it -- so the run genuinely ends there; what must not happen is that it ends
+    with a bare traceback and an exit status a caller cannot tell apart from "findings
+    were reported". This is not hypothetical: an invariant factory that evaluated its
+    reference eagerly, at build time rather than in the returned closure, truncated a
+    13341-case run silently.
+
     Args:
         cases (Iterable[Case]): The cases to run, in order.
         journal (TextIO): Text stream receiving one JSON record per case.
@@ -571,15 +629,29 @@ def run_sweep(  # noqa: PLR0913 -- five keyword-only knobs, each one CLI flag
             plus its float outputs as ``.npz`` for reuse as parity fixtures.
 
     Returns:
-        Summary: Per-verdict counts and the findings.
+        Summary: Per-verdict counts, the findings, and the abort reason if enumeration
+            failed.
     """
     counts: dict[str, int] = {verdict.name: 0 for verdict in Verdict}
     findings: list[Outcome] = []
     suspected: list[Outcome] = []
     warned: list[Outcome] = []
     executed = 0
+    aborted: str | None = None
 
-    for index, case in enumerate(cases):
+    iterator = iter(cases)
+    index = -1
+    while True:
+        index += 1
+        try:
+            case = next(iterator)
+        except StopIteration:
+            break
+        except Exception as exc:  # a probe generator must not end the run silently
+            aborted = f"{type(exc).__name__} while building case {index}: {exc}"
+            print(f"[sweep] ENUMERATION ABORTED: {aborted}", file=progress, flush=True)
+            print(f"{_short_traceback(exc, depth=6)}", file=progress, flush=True)
+            break
         if index < start_index:
             continue
         if max_cases is not None and executed >= max_cases:
@@ -598,7 +670,7 @@ def run_sweep(  # noqa: PLR0913 -- five keyword-only knobs, each one CLI flag
         if dump_dir is not None and case.arrays:
             _dump_case(dump_dir, outcome)
 
-    return Summary(counts, tuple(findings), tuple(suspected), tuple(warned))
+    return Summary(counts, tuple(findings), tuple(suspected), tuple(warned), aborted)
 
 
 def _dump_case(dump_dir: Path, outcome: Outcome) -> None:

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -29,15 +29,20 @@ harness *could* have caught an out-of-bounds access before any result is trusted
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import enum
 import json
 import re
+import signal
 import sys
 import traceback
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, TextIO
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
 
 import numpy as np
 
@@ -534,6 +539,60 @@ def classify(case: Case, exc: Exception) -> tuple[Verdict, str, str]:
     return Verdict.BUG, f"unexpected:{name}", f"{name}: {message}"
 
 
+class CaseTimeout(RuntimeError):
+    """Raised when a case exceeds :data:`CASE_TIMEOUT_SECONDS`."""
+
+
+CASE_TIMEOUT_SECONDS: Final = 30.0
+"""Wall-clock budget for one case, after which it is reported as a hang.
+
+Non-termination is one of the outcomes this sweep hunts, and it needs a budget because
+the alternative is that the *sweep* hangs and nobody runs it again. Thirty seconds is far
+above what any case here legitimately needs -- the slowest, a degree-62 tabulation, is
+milliseconds -- so a case that trips it is not slow, it is stuck. That is not
+hypothetical: ``Bspline.reduce_degree(1)`` never returns on a degree-1 *periodic* spline,
+which stalled a 25952-case run indefinitely.
+
+**Limitation, stated because it matters for the port:** the alarm is delivered at a Python
+bytecode boundary, so it interrupts a hang in a Layer-2 Python loop but **not** one inside
+a compiled ``nopython`` kernel, which does not return to the interpreter. A kernel that
+spins forever still hangs the sweep, and the progress line printed before each case is
+what identifies it.
+"""
+
+
+def _timeout_guard(seconds: float) -> AbstractContextManager[None]:
+    """Build a context manager that raises :class:`CaseTimeout` after ``seconds``.
+
+    Falls back to doing nothing where ``SIGALRM`` is unavailable (Windows), since a sweep
+    without the guard is still worth running.
+
+    Args:
+        seconds (float): Wall-clock budget.
+
+    Returns:
+        AbstractContextManager[None]: The guard.
+    """
+    if not hasattr(signal, "SIGALRM"):
+        return contextlib.nullcontext()
+
+    @contextlib.contextmanager
+    def guard() -> Iterator[None]:
+        def on_alarm(signum: int, frame: object) -> None:
+            del signum, frame
+            raise CaseTimeout(f"no return after {seconds:g} s")
+
+        previous = signal.signal(signal.SIGALRM, on_alarm)
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        try:
+            yield
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0.0)
+            signal.signal(signal.SIGALRM, previous)
+
+    return guard()
+
+
 def run_case(index: int, case: Case) -> Outcome:
     """Execute one case and classify the outcome.
 
@@ -541,7 +600,8 @@ def run_case(index: int, case: Case) -> Outcome:
     predicate usually raises because the probe is wrong, but the whole point of the
     surrounding machinery is that no single case can end the run, and an uncaught
     exception here would do exactly that: the remaining cases never execute and the
-    process exit status is indistinguishable from "findings were reported".
+    process exit status is indistinguishable from "findings were reported". A case that
+    does not return within :data:`CASE_TIMEOUT_SECONDS` is reported the same way.
 
     Args:
         index (int): Position of the case in the sweep.
@@ -553,7 +613,17 @@ def run_case(index: int, case: Case) -> Outcome:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         try:
-            result = case.run()
+            with _timeout_guard(CASE_TIMEOUT_SECONDS):
+                result = case.run()
+        except CaseTimeout as exc:
+            return Outcome(
+                index,
+                case,
+                Verdict.BUG,
+                "timeout",
+                f"the call did not terminate: {exc}",
+                _warning_names(caught),
+            )
         except Exception as exc:  # a sweep classifies whatever comes out, by design
             verdict, kind, detail = classify(case, exc)
             if verdict is Verdict.BUG:

--- a/tools/adversarial_sweep/_probes_basis.py
+++ b/tools/adversarial_sweep/_probes_basis.py
@@ -1,0 +1,1006 @@
+"""Probes for :mod:`pantr.basis` and :mod:`pantr.change_basis`.
+
+The 1D tabulators (Bernstein, cardinal B-spline, Lagrange, Legendre) and their
+tensor-product ``nD`` wrappers are pure NumPy dispatchers over Numba kernels, so
+the yield here is contract violations -- a wrong shape, a broken partition of
+unity, a `Lagrange` basis that fails to reproduce the identity at its own
+nodes, a change-of-basis round trip that drifts beyond what the matrix's own
+conditioning allows -- rather than raw memory corruption (that lives in the
+`bspline`/`bezier` groups' knot-span kernels). Degree is swept at its corners
+(0, the smallest legal value and a frequent defect source in this codebase, and
+62, the exact cliff where ``_bincoeff``'s integer recurrence wraps int64), and
+every evaluation-point family from :func:`~_axes.point_specs` is exercised,
+including the ones that deliberately sit outside ``[0, 1]`` or carry ``NaN``.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING, Any, Final
+
+import numpy as np
+
+from pantr.basis import (
+    LagrangeVariant,
+    tabulate_bernstein,
+    tabulate_bernstein_1d,
+    tabulate_cardinal_bspline,
+    tabulate_cardinal_bspline_1d,
+    tabulate_lagrange,
+    tabulate_lagrange_1d,
+    tabulate_legendre_1d,
+)
+from pantr.basis._basis_lagrange import _get_lagrange_points
+from pantr.change_basis import (
+    compute_bernstein_to_cardinal_1d,
+    compute_bernstein_to_lagrange_1d,
+    compute_cardinal_dual_legendre_coeffs_1d,
+    compute_cardinal_to_bernstein_1d,
+    compute_cardinal_to_legendre_1d,
+    compute_lagrange_to_bernstein_1d,
+    compute_legendre_to_cardinal_1d,
+    compute_monomial_to_bernstein_1d,
+)
+from pantr.quad import PointsLattice
+
+from ._axes import Profile, degrees, dtypes, point_specs, rng
+from ._core import Case, custom, expected_shape, partition_of_unity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy.typing as npt
+
+    from ._core import Invariant
+
+GROUP = "basis"
+"""Registry name of this probe group."""
+
+_UNIT_DOMAIN: Final = (0.0, 1.0)
+"""Bernstein, Lagrange and Legendre are all defined on the unit interval."""
+
+# Point families for which a partition-of-unity or non-negativity claim is
+# actually meaningful: strictly inside [0, 1], including the endpoints. The
+# out-of-domain and NaN/inf families are still exercised for shape and crash
+# safety (via the automatic finiteness check), but the algebraic identity
+# `sum(Bernstein) == 1` -- true for *every* real x -- is not asserted there,
+# since floating-point cancellation genuinely grows with |x| and that growth
+# is not the claim under test.
+_DOMAIN_ELIGIBLE_POINT_FAMILIES: Final = frozenset({"interior", "right_endpoint", "left_endpoint"})
+
+
+def _capped(seq: tuple[Any, ...], n: int, profile: Profile) -> tuple[Any, ...]:
+    """Cap a sequence to its first ``n`` entries for the smoke profile only.
+
+    The SMOKE profile is meant to stay small enough for a CI test to recompile
+    every kernel into a fresh Numba cache; several entry points in this group
+    multiply degree, dtype and point-family axes together, so smoke needs an
+    extra cap beyond what those shared axes already provide on their own. FULL
+    is returned unchanged.
+
+    Args:
+        seq (tuple[Any, ...]): The full sequence, in the order the shared axis
+            helper returns it (corners first).
+        n (int): Number of leading entries to keep for SMOKE.
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[Any, ...]: ``seq`` unchanged for FULL, ``seq[:n]`` for SMOKE.
+    """
+    return seq if profile is Profile.FULL else seq[:n]
+
+
+def _bernstein_nonneg() -> Invariant:
+    """Build an invariant requiring every Bernstein value to be non-negative.
+
+    Bernstein polynomials are products of non-negative factors
+    (``x`` and ``1 - x`` on ``[0, 1]``, times a positive binomial coefficient),
+    so the basis is exactly non-negative by construction: no tolerance is
+    applied, and any negative value is a genuine violation.
+
+    Returns:
+        Invariant: Check reporting the most negative value found.
+    """
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        arr = np.asarray(result)
+        if arr.size == 0:
+            return None
+        worst = float(np.min(arr))
+        if worst < 0.0:
+            return f"most negative Bernstein value {worst!r} < 0"
+        return None
+
+    return custom("bernstein-nonneg", predicate)
+
+
+def _tabulate_1d_cases(
+    name: str,
+    func: Callable[..., Any],
+    profile: Profile,
+    *,
+    claims_partition: bool,
+    claims_nonneg: bool,
+) -> Iterator[Case]:
+    """Yield hostile ``(degree, points)`` cases for one 1D tabulator.
+
+    Args:
+        name (str): Short identifier used in case labels.
+        func (Callable[..., Any]): The ``tabulate_*_1d`` entry point, called as
+            ``func(degree, pts)``.
+        profile (Profile): Sweep width.
+        claims_partition (bool): Whether to assert partition of unity on
+            in-domain point families.
+        claims_nonneg (bool): Whether to assert non-negativity on in-domain
+            point families.
+
+    Yields:
+        Case: One hostile ``(degree, dtype, point family)`` combination.
+    """
+    for degree in _capped(degrees(profile), 2, profile):
+        for dtype in dtypes(profile):
+            specs = _capped(point_specs(_UNIT_DOMAIN, dtype, profile), 1, profile)
+            for spec in specs:
+                invariants: list[Invariant] = [expected_shape((*spec.pts.shape, degree + 1))]
+                if spec.name in _DOMAIN_ELIGIBLE_POINT_FAMILIES:
+                    if claims_partition:
+                        invariants.append(partition_of_unity(degree, dtype))
+                    if claims_nonneg:
+                        invariants.append(_bernstein_nonneg())
+                yield Case(
+                    GROUP,
+                    f"{name}_1d_deg{degree}_{spec.name}_{np.dtype(dtype).name}",
+                    func,
+                    lambda func=func, degree=degree, pts=spec.pts: func(degree, pts),
+                    {"degree": degree, "dtype": dtype, "points": spec.name},
+                    invariants=tuple(invariants),
+                    finite_inputs=spec.finite,
+                )
+
+
+def _tabulate_1d_extra_cases(
+    name: str, func: Callable[..., Any], profile: Profile
+) -> Iterator[Case]:
+    """Yield the corner hostile inputs common to every 1D tabulator.
+
+    Args:
+        name (str): Short identifier used in case labels.
+        func (Callable[..., Any]): The ``tabulate_*_1d`` entry point.
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile call outside the ``(degree, point-family)`` grid.
+    """
+    yield Case(
+        GROUP,
+        f"{name}_1d_degree_negative",
+        func,
+        lambda func=func: func(-1, [0.2, 0.5]),
+        {"degree": -1, "kind": "invalid-degree"},
+    )
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP,
+        f"{name}_1d_scalar_point",
+        func,
+        lambda func=func: func(2, 0.4),
+        {"degree": 2, "kind": "scalar-point"},
+        invariants=(expected_shape((3,)),),
+    )
+    yield Case(
+        GROUP,
+        f"{name}_1d_shape_1x1_points",
+        func,
+        lambda func=func: func(2, np.array([[0.4]])),
+        {"degree": 2, "kind": "shape-1x1-points"},
+        invariants=(expected_shape((1, 1, 3)),),
+    )
+    yield Case(
+        GROUP,
+        f"{name}_1d_int_points_auto_cast",
+        func,
+        lambda func=func: func(2, np.array([0, 1], dtype=np.int64)),
+        {"degree": 2, "kind": "int-points-auto-cast"},
+        invariants=(expected_shape((2, 3)),),
+    )
+
+
+_LAGRANGE_VARIANT_MIN_NPTS: Final[dict[LagrangeVariant, int]] = {
+    LagrangeVariant.EQUISPACES: 1,
+    LagrangeVariant.GAUSS_LEGENDRE: 1,
+    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: 2,
+    LagrangeVariant.CHEBYSHEV_1ST: 1,
+    LagrangeVariant.CHEBYSHEV_2ND: 2,
+}
+"""Minimum ``degree + 1`` (node count) each Lagrange variant's underlying
+quadrature rule accepts (`_basis_lagrange.py:31-32`)."""
+
+
+def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
+    """Yield hostile ``(degree, variant, points)`` cases for ``tabulate_lagrange_1d``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile combination.
+    """
+    variants = tuple(LagrangeVariant) if profile is Profile.FULL else (LagrangeVariant.EQUISPACES,)
+    for degree in _capped(degrees(profile), 2, profile):
+        for variant in variants:
+            if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+                continue
+            for dtype in dtypes(profile):
+                specs = _capped(point_specs(_UNIT_DOMAIN, dtype, profile), 1, profile)
+                for spec in specs:
+                    yield Case(
+                        GROUP,
+                        f"lagrange_1d_deg{degree}_{variant.value}_{spec.name}_"
+                        f"{np.dtype(dtype).name}",
+                        tabulate_lagrange_1d,
+                        lambda degree=degree, variant=variant, pts=spec.pts: tabulate_lagrange_1d(
+                            degree, variant, pts
+                        ),
+                        {"degree": degree, "variant": variant, "dtype": dtype, "points": spec.name},
+                        invariants=(expected_shape((*spec.pts.shape, degree + 1)),),
+                        finite_inputs=spec.finite,
+                    )
+    yield Case(
+        GROUP,
+        "lagrange_1d_degree_negative",
+        tabulate_lagrange_1d,
+        lambda: tabulate_lagrange_1d(-1, LagrangeVariant.EQUISPACES, [0.2, 0.5]),
+        {"degree": -1, "kind": "invalid-degree"},
+    )
+
+
+def _lagrange_cardinality_invariant(degree: int, dtype: npt.DTypeLike) -> Invariant:
+    """Build an invariant requiring a Lagrange basis to be the identity at its own nodes.
+
+    Barycentric evaluation of ``L_i`` at its defining node ``x_j`` is a sum of
+    ``degree + 1`` rational terms: the diagonal term collapses to exactly one
+    (a nonzero float divided by itself), and every off-diagonal term contains
+    an exactly-zero factor, so the identity is exact in real arithmetic. In
+    floating point this carries rounding from the barycentric weights and the
+    summation, bounded by ``O(degree + 1)`` machine epsilons; an explicit
+    factor of 16 absorbs the recurrence's unmodelled constant (matching the
+    module's own snap-to-delta window, ``_basis_lagrange.py`` around
+    lines 109-115, which exists for exactly this reason).
+
+    Args:
+        degree (int): Polynomial degree, which sets the term count.
+        dtype (npt.DTypeLike): Working precision, which sets machine epsilon.
+
+    Returns:
+        Invariant: Check reporting the worst deviation from the identity.
+    """
+    from pantr.tolerance import get_machine_epsilon  # noqa: PLC0415 -- avoids import cycle
+
+    tol = 16.0 * (degree + 1) * get_machine_epsilon(dtype)
+    identity = np.eye(degree + 1, dtype=np.float64)
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        arr = np.asarray(result, dtype=np.float64)
+        worst = float(np.max(np.abs(arr - identity)))
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|L(nodes) - I| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return custom("lagrange-cardinality", predicate)
+
+
+def _lagrange_cardinality_cases(profile: Profile) -> Iterator[Case]:
+    """Yield cases checking a Lagrange basis is the identity at its own nodes.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(degree, variant, dtype)`` combination.
+    """
+    variants = tuple(LagrangeVariant) if profile is Profile.FULL else (LagrangeVariant.EQUISPACES,)
+    for degree in _capped(degrees(profile), 2, profile):
+        for variant in variants:
+            if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+                continue
+            for dtype in dtypes(profile):
+                nodes = _get_lagrange_points(variant, degree + 1, dtype)
+                yield Case(
+                    GROUP,
+                    f"lagrange_cardinality_deg{degree}_{variant.value}_{np.dtype(dtype).name}",
+                    tabulate_lagrange_1d,
+                    lambda degree=degree, variant=variant, nodes=nodes: tabulate_lagrange_1d(
+                        degree, variant, nodes
+                    ),
+                    {"degree": degree, "variant": variant, "dtype": dtype, "kind": "cardinality"},
+                    invariants=(_lagrange_cardinality_invariant(degree, dtype),),
+                )
+
+
+def _nd_degree_tuples(profile: Profile) -> tuple[tuple[int, ...], ...]:
+    """List the hostile per-direction degree tuples for the nD wrappers.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[tuple[int, ...], ...]: Degree tuples covering degree-0 axes, a
+        mixed pair, the int64-wraparound corner, and (for FULL) a 3D tuple.
+    """
+    if profile is Profile.FULL:
+        return ((0, 0), (1, 3), (62, 62), (2, 5, 15))
+    return ((0, 0), (1, 3))
+
+
+def _scattered_points(
+    dim: int, dtype: npt.DTypeLike, generator: np.random.Generator
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a small scattered point set covering the unit cube's corners and interior.
+
+    Args:
+        dim (int): Spatial dimension.
+        dtype (npt.DTypeLike): Point precision.
+        generator (np.random.Generator): Seeded source of interior points.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: ``(6 + 2**dim, dim)`` array: 6
+        random interior points followed by every corner of ``[0, 1]^dim``.
+    """
+    interior = generator.uniform(0.0, 1.0, size=(6, dim)).astype(dtype)
+    corners = np.array(list(itertools.product([0.0, 1.0], repeat=dim)), dtype=dtype)
+    return np.concatenate([interior, corners], axis=0)
+
+
+def _call_bernstein(
+    degrees_tuple: tuple[int, ...],
+    pts: Any,  # noqa: ANN401
+    funcs_order: str = "C",
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Adapt :func:`~pantr.basis.tabulate_bernstein` to the shared nD case shape.
+
+    Args:
+        degrees_tuple (tuple[int, ...]): Per-direction degrees.
+        pts (Any): Points, either a ``(n, dim)`` array or a
+            :class:`~pantr.quad.PointsLattice`.
+        funcs_order (str): Basis function ordering. Defaults to ``"C"``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The tabulated basis.
+    """
+    return tabulate_bernstein(degrees_tuple, pts, funcs_order)  # type: ignore[arg-type]
+
+
+def _call_cardinal_bspline(
+    degrees_tuple: tuple[int, ...],
+    pts: Any,  # noqa: ANN401
+    funcs_order: str = "C",
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Adapt :func:`~pantr.basis.tabulate_cardinal_bspline` to the shared nD case shape.
+
+    Args:
+        degrees_tuple (tuple[int, ...]): Per-direction degrees.
+        pts (Any): Points, either a ``(n, dim)`` array or a
+            :class:`~pantr.quad.PointsLattice`.
+        funcs_order (str): Basis function ordering. Defaults to ``"C"``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The tabulated basis.
+    """
+    return tabulate_cardinal_bspline(degrees_tuple, pts, funcs_order)  # type: ignore[arg-type]
+
+
+def _call_lagrange(
+    degrees_tuple: tuple[int, ...],
+    pts: Any,  # noqa: ANN401
+    funcs_order: str = "C",
+    variant: LagrangeVariant = LagrangeVariant.EQUISPACES,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Adapt :func:`~pantr.basis.tabulate_lagrange` to the shared nD case shape.
+
+    Args:
+        degrees_tuple (tuple[int, ...]): Per-direction degrees.
+        pts (Any): Points, either a ``(n, dim)`` array or a
+            :class:`~pantr.quad.PointsLattice`.
+        funcs_order (str): Basis function ordering. Defaults to ``"C"``.
+        variant (LagrangeVariant): Lagrange node variant. Defaults to
+            ``LagrangeVariant.EQUISPACES``.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The tabulated basis.
+    """
+    return tabulate_lagrange(degrees_tuple, variant, pts, funcs_order)  # type: ignore[arg-type]
+
+
+def _nd_wrapper_cases(
+    name: str,
+    call: Callable[..., Any],
+    profile: Profile,
+    *,
+    claims_partition: bool,
+    claims_nonneg: bool,
+) -> Iterator[Case]:
+    """Yield hostile cases for one tensor-product ``nD`` tabulator wrapper.
+
+    Args:
+        name (str): Short identifier used in case labels.
+        call (Callable[..., Any]): Adapter with signature
+            ``call(degrees_tuple, pts, funcs_order="C")``.
+        profile (Profile): Sweep width.
+        claims_partition (bool): Whether to assert partition of unity.
+        claims_nonneg (bool): Whether to assert non-negativity.
+
+    Yields:
+        Case: One hostile ``nD`` tabulation call.
+    """
+    generator = rng(41)
+    for degrees_tuple in _nd_degree_tuples(profile):
+        dim = len(degrees_tuple)
+        n_basis = int(np.prod([d + 1 for d in degrees_tuple]))
+        for dtype in dtypes(profile):
+            pts = _scattered_points(dim, dtype, generator)
+            invariants: list[Invariant] = [expected_shape((pts.shape[0], n_basis))]
+            if claims_partition:
+                # The tensor-product basis sums n_basis terms in total (not
+                # degrees_tuple[-1] + 1), so the term count that sets the
+                # tolerance is n_basis - 1 passed as the "degree" argument.
+                invariants.append(partition_of_unity(n_basis - 1, dtype))
+            if claims_nonneg:
+                invariants.append(_bernstein_nonneg())
+            yield Case(
+                GROUP,
+                f"{name}_nd_deg{degrees_tuple}_{np.dtype(dtype).name}",
+                call,
+                lambda call=call, degrees_tuple=degrees_tuple, pts=pts: call(degrees_tuple, pts),
+                {"degrees": degrees_tuple, "dtype": dtype},
+                invariants=tuple(invariants),
+            )
+
+    if profile is not Profile.FULL:
+        return
+
+    dtype = np.dtype(np.float64)
+    degrees_tuple = (2, 3)
+    n_basis = 3 * 4
+    pts = _scattered_points(2, dtype, generator)
+
+    empty_pts = np.zeros((3, 0), dtype=dtype)
+    yield Case(
+        GROUP,
+        f"{name}_nd_empty_degrees",
+        call,
+        lambda call=call, empty_pts=empty_pts: call((), empty_pts),
+        {"degrees": (), "kind": "empty-degrees"},
+    )
+    yield Case(
+        GROUP,
+        f"{name}_nd_funcs_order_F",
+        call,
+        lambda call=call, degrees_tuple=degrees_tuple, pts=pts: call(
+            degrees_tuple, pts, funcs_order="F"
+        ),
+        {"degrees": degrees_tuple, "kind": "funcs-order-F"},
+        invariants=(expected_shape((pts.shape[0], n_basis)),),
+    )
+    lattice = PointsLattice(
+        [np.array([0.2, 0.8], dtype=dtype), np.array([0.3, 0.6, 0.9], dtype=dtype)]
+    )
+    yield Case(
+        GROUP,
+        f"{name}_nd_points_lattice",
+        call,
+        lambda call=call, degrees_tuple=degrees_tuple, lattice=lattice: call(
+            degrees_tuple, lattice
+        ),
+        {"degrees": degrees_tuple, "kind": "points-lattice"},
+        invariants=(expected_shape((6, n_basis)),),
+    )
+    mismatched_pts = _scattered_points(3, dtype, generator)
+    yield Case(
+        GROUP,
+        f"{name}_nd_dim_mismatch",
+        call,
+        lambda call=call, degrees_tuple=degrees_tuple, mismatched_pts=mismatched_pts: call(
+            degrees_tuple, mismatched_pts
+        ),
+        {"degrees": degrees_tuple, "kind": "dim-mismatch"},
+    )
+    yield Case(
+        GROUP,
+        f"{name}_nd_negative_degree",
+        call,
+        lambda call=call, pts=pts: call((-1, 2), pts),
+        {"degrees": (-1, 2), "kind": "negative-degree"},
+    )
+
+
+def _lagrange_nd_variant_cases(profile: Profile) -> Iterator[Case]:
+    """Yield a small cross of Lagrange variants for the ``nD`` wrapper.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One ``(variant, degrees)`` combination.
+    """
+    if profile is not Profile.FULL:
+        return
+    generator = rng(42)
+    degrees_tuple = (3, 4)
+    pts = _scattered_points(2, np.dtype(np.float64), generator)
+    n_basis = 4 * 5
+    for variant in LagrangeVariant:
+        yield Case(
+            GROUP,
+            f"lagrange_nd_variant_{variant.value}",
+            _call_lagrange,
+            lambda degrees_tuple=degrees_tuple, pts=pts, variant=variant: _call_lagrange(
+                degrees_tuple, pts, variant=variant
+            ),
+            {"degrees": degrees_tuple, "variant": variant},
+            invariants=(expected_shape((pts.shape[0], n_basis)),),
+        )
+
+
+_SquareBuilder = tuple[str, "Callable[..., Any]"]
+_SQUARE_BUILDERS: Final[tuple[_SquareBuilder, ...]] = (
+    ("bernstein_to_cardinal", compute_bernstein_to_cardinal_1d),
+    ("cardinal_to_bernstein", compute_cardinal_to_bernstein_1d),
+    ("legendre_to_cardinal", compute_legendre_to_cardinal_1d),
+    ("cardinal_to_legendre", compute_cardinal_to_legendre_1d),
+    ("cardinal_dual_legendre", compute_cardinal_dual_legendre_coeffs_1d),
+    ("monomial_to_bernstein", compute_monomial_to_bernstein_1d),
+)
+"""The six ``compute_*_1d`` change-of-basis builders that take ``degree >= 0``
+and no ``LagrangeVariant`` argument."""
+
+
+def _change_basis_square_cases(profile: Profile) -> Iterator[Case]:
+    """Yield hostile ``(degree, dtype)`` cases for the six plain square builders.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile call per builder.
+    """
+    for name, func in _SQUARE_BUILDERS:
+        for degree in _capped(degrees(profile), 2, profile):
+            for dtype in dtypes(profile):
+                yield Case(
+                    GROUP,
+                    f"{name}_deg{degree}_{np.dtype(dtype).name}",
+                    func,
+                    lambda func=func, degree=degree, dtype=dtype: func(degree, dtype),
+                    {"degree": degree, "dtype": dtype},
+                    invariants=(expected_shape((degree + 1, degree + 1)),),
+                )
+        yield Case(
+            GROUP,
+            f"{name}_degree_negative",
+            func,
+            lambda func=func: func(-1),
+            {"degree": -1, "kind": "invalid-degree"},
+        )
+        if profile is Profile.FULL:
+            yield Case(
+                GROUP,
+                f"{name}_bad_dtype_int64",
+                func,
+                lambda func=func: func(3, np.int64),
+                {"degree": 3, "kind": "bad-dtype-int64"},
+            )
+
+
+_LagrangePairBuilder = tuple[str, "Callable[..., Any]"]
+_LAGRANGE_PAIR_BUILDERS: Final[tuple[_LagrangePairBuilder, ...]] = (
+    ("lagrange_to_bernstein", compute_lagrange_to_bernstein_1d),
+    ("bernstein_to_lagrange", compute_bernstein_to_lagrange_1d),
+)
+
+
+def _change_basis_lagrange_pair_cases(profile: Profile) -> Iterator[Case]:
+    """Yield hostile cases for the two Lagrange-variant change-of-basis builders.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(degree, variant, dtype)`` combination, plus the
+        degree-0 and degree-negative rejections (both documented: these two
+        builders require ``degree >= 1``).
+    """
+    variants = tuple(LagrangeVariant) if profile is Profile.FULL else (LagrangeVariant.EQUISPACES,)
+    for name, func in _LAGRANGE_PAIR_BUILDERS:
+        for degree in _capped(degrees(profile), 2, profile):
+            for variant in variants:
+                if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+                    continue
+                for dtype in dtypes(profile):
+                    yield Case(
+                        GROUP,
+                        f"{name}_deg{degree}_{variant.value}_{np.dtype(dtype).name}",
+                        func,
+                        lambda func=func, degree=degree, variant=variant, dtype=dtype: func(
+                            degree, variant, dtype
+                        ),
+                        {"degree": degree, "variant": variant, "dtype": dtype},
+                        invariants=(expected_shape((degree + 1, degree + 1)),),
+                    )
+        yield Case(
+            GROUP,
+            f"{name}_degree_negative",
+            func,
+            lambda func=func: func(-1),
+            {"degree": -1, "kind": "invalid-degree"},
+        )
+
+
+def _lagrange_to_bernstein_default(degree: int, dtype: npt.DTypeLike) -> npt.NDArray[Any]:
+    """Adapt :func:`~pantr.change_basis.compute_lagrange_to_bernstein_1d` to ``(degree, dtype)``.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Working precision.
+
+    Returns:
+        npt.NDArray[Any]: The change-of-basis matrix.
+    """
+    return compute_lagrange_to_bernstein_1d(degree, LagrangeVariant.EQUISPACES, dtype)
+
+
+def _bernstein_to_lagrange_default(degree: int, dtype: npt.DTypeLike) -> npt.NDArray[Any]:
+    """Adapt :func:`~pantr.change_basis.compute_bernstein_to_lagrange_1d` to ``(degree, dtype)``.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Working precision.
+
+    Returns:
+        npt.NDArray[Any]: The change-of-basis matrix.
+    """
+    return compute_bernstein_to_lagrange_1d(degree, LagrangeVariant.EQUISPACES, dtype)
+
+
+def _round_trip_case(
+    label: str,
+    forward: Callable[[int, npt.DTypeLike], npt.NDArray[Any]],
+    backward: Callable[[int, npt.DTypeLike], npt.NDArray[Any]],
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+) -> Case:
+    """Build one round-trip identity case for a change-of-basis pair.
+
+    The tolerance is derived from the condition number of the matrix actually
+    being inverted (measured with :func:`numpy.linalg.cond`, an oracle
+    independent of the algorithm under test), matching the conditioning
+    documented at ``change_basis.py:376-381`` (``cond ~ 1.1e3`` at degree 4,
+    ``3.0e8`` at degree 8, for the cardinal/Legendre pair): a bare literal
+    tolerance would be meaningless across that six-orders-of-magnitude range.
+    An explicit factor of ``16 * (degree + 1)`` covers the round trip's own
+    matrix product on top of the conditioning bound.
+
+    Args:
+        label (str): Short identifier for the pair, used in the case label.
+        forward (Callable[[int, npt.DTypeLike], npt.NDArray[Any]]): Builds the
+            matrix whose conditioning sets the tolerance.
+        backward (Callable[[int, npt.DTypeLike], npt.NDArray[Any]]): Builds the
+            matrix applied second in the round trip.
+        degree (int): Polynomial degree.
+        dtype (np.dtype[np.float32 | np.float64]): Working precision.
+
+    Returns:
+        Case: The round-trip case.
+    """
+    from pantr.tolerance import get_machine_epsilon  # noqa: PLC0415 -- avoids import cycle
+
+    matrix_a = np.asarray(forward(degree, dtype), dtype=np.float64)
+    cond = float(np.linalg.cond(matrix_a))
+    eps = get_machine_epsilon(dtype)
+    tol = 16.0 * (degree + 1) * cond * eps
+    identity = np.eye(degree + 1, dtype=np.float64)
+
+    def run() -> npt.NDArray[Any]:
+        return backward(degree, dtype) @ forward(degree, dtype)
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        arr = np.asarray(result, dtype=np.float64)
+        worst = float(np.max(np.abs(arr - identity)))
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|BA - I| = {worst:.3e} > {tol:.3e} (cond={cond:.3e})"
+        return None
+
+    # Once cond(A) * eps reaches 1, the classical backward-error bound for
+    # solving a linear system guarantees zero correct digits: no factor in
+    # front of it turns a vacuous bound into a meaningful one (an attainable-
+    # accuracy limit needs margin, not a claim placed exactly at the cliff
+    # where accuracy is already gone). At that point the round trip is
+    # still executed -- so a crash or a non-finite result is still a
+    # BUG via the automatic finiteness check -- but the numerical-identity
+    # claim itself is dropped rather than asserted with a tolerance that
+    # cannot fail informatively.
+    invariants: tuple[Invariant, ...] = (
+        () if cond * eps >= 1.0 else (custom("round-trip-identity", predicate),)
+    )
+
+    return Case(
+        GROUP,
+        f"roundtrip_{label}_deg{degree}_{np.dtype(dtype).name}",
+        backward,
+        run,
+        {"degree": degree, "dtype": dtype, "kind": "round-trip", "cond": cond},
+        invariants=invariants,
+    )
+
+
+def _round_trip_cases(profile: Profile) -> Iterator[Case]:
+    """Yield round-trip identity cases for the three change-of-basis pairs.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One round-trip case per ``(pair, degree, dtype)``.
+    """
+    for degree in _capped(degrees(profile), 2, profile):
+        for dtype in dtypes(profile):
+            yield _round_trip_case(
+                "cardinal_bernstein",
+                compute_bernstein_to_cardinal_1d,
+                compute_cardinal_to_bernstein_1d,
+                degree,
+                dtype,
+            )
+            yield _round_trip_case(
+                "cardinal_legendre",
+                compute_legendre_to_cardinal_1d,
+                compute_cardinal_to_legendre_1d,
+                degree,
+                dtype,
+            )
+            if degree >= 1:
+                yield _round_trip_case(
+                    "bernstein_lagrange",
+                    _lagrange_to_bernstein_default,
+                    _bernstein_to_lagrange_default,
+                    degree,
+                    dtype,
+                )
+
+
+def _out_same_array(expected: npt.NDArray[Any]) -> Invariant:
+    """Build an invariant requiring the result to be the caller-provided ``out`` array.
+
+    Args:
+        expected (npt.NDArray[Any]): The array passed as ``out``.
+
+    Returns:
+        Invariant: Check failing when a different object is returned.
+    """
+    return custom(
+        "out-is-same-array",
+        lambda r: None if r is expected else f"returned {type(r).__name__}, not the out array",
+    )
+
+
+def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile) -> Iterator[Case]:
+    """Yield ``out=`` handling cases for a ``tabulate_*_1d`` function.
+
+    Args:
+        name (str): Short identifier used in case labels.
+        func (Callable[..., Any]): The entry point, called as ``func(degree, pts, out=out)``.
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One correct, wrong-shape, wrong-dtype, or non-writable ``out`` case.
+    """
+    if profile is not Profile.FULL:
+        return
+    degree = 3
+    dtype = np.float64
+    pts = np.array([0.2, 0.6, 0.9], dtype=dtype)
+    n_basis = degree + 1
+
+    good_out = np.empty((pts.shape[0], n_basis), dtype=dtype)
+    yield Case(
+        GROUP,
+        f"{name}_1d_out_correct",
+        func,
+        lambda func=func, pts=pts, good_out=good_out: func(degree, pts, out=good_out),
+        {"degree": degree, "kind": "out-correct"},
+        invariants=(_out_same_array(good_out),),
+    )
+    wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=dtype)
+    yield Case(
+        GROUP,
+        f"{name}_1d_out_wrong_shape",
+        func,
+        lambda func=func, pts=pts, wrong_shape=wrong_shape: func(degree, pts, out=wrong_shape),
+        {"degree": degree, "kind": "out-wrong-shape"},
+    )
+    wrong_dtype = np.empty((pts.shape[0], n_basis), dtype=np.float32)
+    yield Case(
+        GROUP,
+        f"{name}_1d_out_wrong_dtype",
+        func,
+        lambda func=func, pts=pts, wrong_dtype=wrong_dtype: func(degree, pts, out=wrong_dtype),
+        {"degree": degree, "kind": "out-wrong-dtype"},
+    )
+    non_writable = np.empty((pts.shape[0], n_basis), dtype=dtype)
+    non_writable.flags.writeable = False
+    yield Case(
+        GROUP,
+        f"{name}_1d_out_non_writable",
+        func,
+        lambda func=func, pts=pts, non_writable=non_writable: func(degree, pts, out=non_writable),
+        {"degree": degree, "kind": "out-non-writable"},
+    )
+
+
+def _lagrange_1d_out_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``out=`` handling cases for ``tabulate_lagrange_1d``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One correct, wrong-shape, wrong-dtype, or non-writable ``out`` case.
+    """
+    if profile is not Profile.FULL:
+        return
+    degree = 3
+    variant = LagrangeVariant.EQUISPACES
+    dtype = np.float64
+    pts = np.array([0.2, 0.6, 0.9], dtype=dtype)
+    n_basis = degree + 1
+
+    good_out = np.empty((pts.shape[0], n_basis), dtype=dtype)
+    yield Case(
+        GROUP,
+        "lagrange_1d_out_correct",
+        tabulate_lagrange_1d,
+        lambda good_out=good_out: tabulate_lagrange_1d(degree, variant, pts, out=good_out),
+        {"degree": degree, "kind": "out-correct"},
+        invariants=(_out_same_array(good_out),),
+    )
+    wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=dtype)
+    yield Case(
+        GROUP,
+        "lagrange_1d_out_wrong_shape",
+        tabulate_lagrange_1d,
+        lambda wrong_shape=wrong_shape: tabulate_lagrange_1d(degree, variant, pts, out=wrong_shape),
+        {"degree": degree, "kind": "out-wrong-shape"},
+    )
+    non_writable = np.empty((pts.shape[0], n_basis), dtype=dtype)
+    non_writable.flags.writeable = False
+    yield Case(
+        GROUP,
+        "lagrange_1d_out_non_writable",
+        tabulate_lagrange_1d,
+        lambda non_writable=non_writable: tabulate_lagrange_1d(
+            degree, variant, pts, out=non_writable
+        ),
+        {"degree": degree, "kind": "out-non-writable"},
+    )
+
+
+def _monomial_to_bernstein_out_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``out=`` handling cases for ``compute_monomial_to_bernstein_1d``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One correct and one wrong-shape ``out`` case.
+    """
+    if profile is not Profile.FULL:
+        return
+    degree = 4
+    dtype = np.float64
+    good_out = np.empty((degree + 1, degree + 1), dtype=dtype)
+    yield Case(
+        GROUP,
+        "monomial_to_bernstein_out_correct",
+        compute_monomial_to_bernstein_1d,
+        lambda good_out=good_out: compute_monomial_to_bernstein_1d(degree, dtype, out=good_out),
+        {"degree": degree, "kind": "out-correct"},
+        invariants=(_out_same_array(good_out),),
+    )
+    wrong_shape = np.empty((degree, degree + 1), dtype=dtype)
+    yield Case(
+        GROUP,
+        "monomial_to_bernstein_out_wrong_shape",
+        compute_monomial_to_bernstein_1d,
+        lambda wrong_shape=wrong_shape: compute_monomial_to_bernstein_1d(
+            degree, dtype, out=wrong_shape
+        ),
+        {"degree": degree, "kind": "out-wrong-shape"},
+    )
+
+
+def _bernstein_nd_out_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``out=`` handling cases for ``tabulate_bernstein`` (the ``nD`` wrapper).
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One correct and one wrong-shape ``out`` case.
+    """
+    if profile is not Profile.FULL:
+        return
+    degrees_tuple = (2, 3)
+    pts = np.array([[0.2, 0.3], [0.6, 0.7]], dtype=np.float64)
+    n_basis = 3 * 4
+    good_out = np.empty((pts.shape[0], n_basis), dtype=np.float64)
+    yield Case(
+        GROUP,
+        "bernstein_nd_out_correct",
+        tabulate_bernstein,
+        lambda good_out=good_out: tabulate_bernstein(degrees_tuple, pts, out=good_out),
+        {"degrees": degrees_tuple, "kind": "out-correct"},
+        invariants=(_out_same_array(good_out),),
+    )
+    wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=np.float64)
+    yield Case(
+        GROUP,
+        "bernstein_nd_out_wrong_shape",
+        tabulate_bernstein,
+        lambda wrong_shape=wrong_shape: tabulate_bernstein(degrees_tuple, pts, out=wrong_shape),
+        {"degrees": degrees_tuple, "kind": "out-wrong-shape"},
+    )
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _tabulate_1d_cases(
+        "bernstein", tabulate_bernstein_1d, profile, claims_partition=True, claims_nonneg=True
+    )
+    yield from _tabulate_1d_extra_cases("bernstein", tabulate_bernstein_1d, profile)
+    yield from _tabulate_1d_cases(
+        "cardinal_bspline",
+        tabulate_cardinal_bspline_1d,
+        profile,
+        claims_partition=False,
+        claims_nonneg=False,
+    )
+    yield from _tabulate_1d_extra_cases("cardinal_bspline", tabulate_cardinal_bspline_1d, profile)
+    yield from _tabulate_1d_cases(
+        "legendre", tabulate_legendre_1d, profile, claims_partition=False, claims_nonneg=False
+    )
+    yield from _tabulate_1d_extra_cases("legendre", tabulate_legendre_1d, profile)
+    yield from _lagrange_1d_cases(profile)
+    yield from _lagrange_cardinality_cases(profile)
+
+    yield from _nd_wrapper_cases(
+        "bernstein", _call_bernstein, profile, claims_partition=True, claims_nonneg=True
+    )
+    yield from _nd_wrapper_cases(
+        "cardinal_bspline",
+        _call_cardinal_bspline,
+        profile,
+        claims_partition=False,
+        claims_nonneg=False,
+    )
+    yield from _nd_wrapper_cases(
+        "lagrange", _call_lagrange, profile, claims_partition=False, claims_nonneg=False
+    )
+    yield from _lagrange_nd_variant_cases(profile)
+
+    yield from _change_basis_square_cases(profile)
+    yield from _change_basis_lagrange_pair_cases(profile)
+    yield from _round_trip_cases(profile)
+
+    yield from _tabulate_1d_out_cases("bernstein", tabulate_bernstein_1d, profile)
+    yield from _tabulate_1d_out_cases("cardinal_bspline", tabulate_cardinal_bspline_1d, profile)
+    yield from _tabulate_1d_out_cases("legendre", tabulate_legendre_1d, profile)
+    yield from _lagrange_1d_out_cases(profile)
+    yield from _monomial_to_bernstein_out_cases(profile)
+    yield from _bernstein_nd_out_cases(profile)

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -1,0 +1,2647 @@
+"""Probes for :mod:`pantr.bezier`: the Bezier surface, root finder and interpolation.
+
+Bezier is fixed on the parametric domain ``[0, 1]^rank``, so unlike the B-spline
+probes the *domain* axis from ``_axes`` does not apply here -- there is no knot
+vector to translate. The analogous hostile axis is control-point **magnitude**:
+:func:`_magnitude_variants` sweeps unit-scale, tiny, huge, and *translated*
+control-point clouds (``1e6 + O(1)``), which is the one that catches a tolerance
+derived from a coordinate's own magnitude rather than from the control polygon's
+diagonal -- such a tolerance is not translation invariant.
+
+Two Numba/NumPy kernels are probed directly rather than only through the public
+``Bezier`` surface, because they are imported by a private, non-public consumer
+and are the sharpest boundscheck targets in the package:
+
+- ``pantr.bezier._root_finding_core._de_casteljau_eval_scalar`` -- a
+  ``nopython=True`` kernel with *no* input validation whatsoever.
+- ``pantr.bezier._bezier_interpolate._bernstein_interpolate`` -- a pure-NumPy
+  Layer 2 helper (truncated-SVD pseudo-inverse), also unvalidated.
+
+Every invariant here is a genuinely claimed property quoted from the docstrings
+(degree elevation is exact, degree reduction reproduces the endpoints bit for
+bit, split/compose/multiply/derivative agree with their defining identities,
+root finding returns bounded genuine roots), never a mirror of the algorithm
+under test. Tolerances are derived in-line from machine epsilon, degree, and
+coefficient magnitude -- see each helper's docstring for the derivation.
+"""
+
+from __future__ import annotations
+
+import math
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any, Final
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr.bezier import (
+    Bezier,
+    create_from_bspline,
+    find_monotone_root,
+    find_roots,
+    fit_bezier,
+    interpolate_bezier,
+)
+from pantr.bezier._bezier_interpolate import _bernstein_interpolate
+from pantr.bezier._root_finding_core import _de_casteljau_eval_scalar
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.quad import PointsLattice
+from pantr.tolerance import get_default, get_machine_epsilon
+from pantr.transform import AffineTransform
+
+from ._axes import Profile, coeff_specs, degrees, dtypes, point_specs, rng
+from ._core import Case, custom, expected_shape
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from ._core import Invariant
+
+GROUP = "bezier"
+"""Registry name of this probe group."""
+
+_RANK_DIM_FULL: Final = (
+    (1, 1),  # scalar curve
+    (2, 1),  # planar curve
+    (3, 1),  # space curve
+    (4, 1),  # curve into R^4, admitted purely because the constructor allows it
+    (1, 2),  # scalar surface
+    (2, 2),  # planar surface
+    (1, 3),  # scalar volume
+    (3, 3),  # solid (typical NURBS volume)
+)
+"""``(rank, dim)`` combinations swept, deliberately including mismatched-but-legal
+pairs (a space curve, a scalar surface) rather than only the square ones."""
+
+_RANK_DIM_SMOKE: Final = ((1, 1), (1, 2))
+
+
+def _rank_dim_combos(profile: Profile) -> tuple[tuple[int, int], ...]:
+    """List the ``(rank, dim)`` combinations to sweep.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[tuple[int, int], ...]: ``(rank, dim)`` pairs.
+    """
+    return _RANK_DIM_SMOKE if profile is Profile.SMOKE else _RANK_DIM_FULL
+
+
+_EXTRAPOLATION_POINT_FAMILIES: Final = frozenset(
+    {"just_outside_right", "just_outside_left", "far_outside", "just_outside"}
+)
+"""Point families that deliberately evaluate outside ``[0, 1]``.
+
+Bernstein basis functions extrapolate like ``O(t ** n)``, so at a fixed
+off-domain parameter a high enough degree overflows even before any
+implementation defect is involved; these families are excluded from the
+automatic finiteness check rather than asserted finite at every degree.
+"""
+
+
+_MAGNITUDE_FULL: Final = (
+    ("scale1", 1.0, 0.0),
+    ("scale1e-6", 1e-6, 0.0),
+    ("scale1e6", 1e6, 0.0),
+    ("translated1e6", 1.0, 1e6),
+)
+"""Control-point magnitude/translation families: ``value = scale * u + translate``
+for ``u`` uniform on ``[-1, 1]``. The translated family is the one that bites a
+tolerance derived from a coordinate's own magnitude instead of the control
+polygon's diagonal."""
+
+_MAGNITUDE_SMOKE: Final = (("scale1", 1.0, 0.0),)
+
+
+def _magnitude_variants(profile: Profile) -> tuple[tuple[str, float, float], ...]:
+    """List the control-point magnitude/translation families to sweep.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[tuple[str, float, float], ...]: ``(name, scale, translate)`` triples.
+    """
+    return _MAGNITUDE_SMOKE if profile is Profile.SMOKE else _MAGNITUDE_FULL
+
+
+def _random_control_points(  # noqa: PLR0913 -- one axis value per keyword, all needed by callers
+    rank: int,
+    dim: int,
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+    offset: int,
+    *,
+    rational: bool = False,
+    scale: float = 1.0,
+    translate: float = 0.0,
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a random control-point array for one ``(rank, dim, degree)`` case.
+
+    Args:
+        rank (int): Geometric output rank (excluding the rational weight).
+        dim (int): Parametric dimension.
+        degree (int): Polynomial degree, same in every direction.
+        dtype (np.dtype[np.float32 | np.float64]): Control-point precision.
+        offset (int): Random-stream offset, for reproducible but distinct draws.
+        rational (bool): Whether to append a positive weight column. Defaults
+            to ``False``.
+        scale (float): Multiplicative magnitude factor. Defaults to 1.0.
+        translate (float): Additive translation applied after scaling. Defaults
+            to 0.0.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Control points, shape
+        ``(*(degree + 1,) * dim, rank + (1 if rational else 0))``.
+    """
+    generator = rng(offset)
+    shape = (*((degree + 1,) * dim), rank + (1 if rational else 0))
+    cp = (generator.uniform(-1.0, 1.0, shape) * scale + translate).astype(dtype)
+    if rational:
+        weights = generator.uniform(0.5, 1.5, shape[:-1]).astype(dtype)
+        cp[..., -1] = weights
+    return cp
+
+
+def _eps(dtype: npt.DTypeLike) -> float:
+    """Fetch machine epsilon for a dtype, as a bare float.
+
+    Args:
+        dtype (npt.DTypeLike): Floating dtype.
+
+    Returns:
+        float: Machine epsilon.
+    """
+    return get_machine_epsilon(dtype)
+
+
+def _magnitude(cp: npt.NDArray[np.floating[Any]]) -> float:
+    """Compute the coefficient-magnitude scale used to size a tolerance.
+
+    Args:
+        cp (npt.NDArray[np.floating[Any]]): Control points or coefficients.
+
+    Returns:
+        float: ``max(|cp|, 1.0)`` -- floored at 1 so a near-zero cloud does not
+        collapse the tolerance to zero.
+    """
+    return float(max(np.max(np.abs(cp)), 1.0)) if cp.size else 1.0
+
+
+def _convex_combination_tol(
+    degree_total: int, dtype: npt.DTypeLike, cp: npt.NDArray[np.floating[Any]]
+) -> float:
+    """Bound the error of an operation whose outputs are convex combinations of inputs.
+
+    Degree elevation, splitting, and restriction all produce each output
+    coefficient as a weighted sum of at most ``degree_total + 1`` input
+    coefficients with non-negative weights summing to one (elevation: binomial
+    weights; splitting/restriction: repeated de Casteljau lerps). Summing
+    ``degree_total + 1`` such terms carries a forward error of at most
+    ``(degree_total + 1) * eps`` relative to the largest coefficient magnitude.
+    An explicit factor of 8 absorbs the recurrence depth of the underlying
+    algorithm (de Casteljau/elevation run in ``O(degree)`` sequential steps,
+    each contributing its own rounding).
+
+    Args:
+        degree_total (int): Combined polynomial degree driving the term count.
+        dtype (npt.DTypeLike): Working precision.
+        cp (npt.NDArray[np.floating[Any]]): Control points, for the magnitude scale.
+
+    Returns:
+        float: Absolute tolerance.
+    """
+    return 8.0 * (degree_total + 1) * _eps(dtype) * _magnitude(cp)
+
+
+def _fd_step_and_tol(
+    dtype: npt.DTypeLike, cp: npt.NDArray[np.floating[Any]], degree: int
+) -> tuple[float, float]:
+    """Compute the central-difference step and noise floor for a derivative check.
+
+    A central difference has truncation error ``O(h**2)`` and rounding error
+    ``O(eps / h)``; the standard balance sets ``h = eps ** (1/3)``, which
+    equalises both at ``eps ** (2/3)``. The truncation term is ``(h**2 / 6) *
+    f'''(xi)``, and the Markov brothers' inequality bounds a degree-``n``
+    polynomial's ``k``-th derivative sup-norm by a factor of order ``n**(2k)``
+    relative to the polynomial's own sup-norm -- so the third-derivative term
+    can grow with degree far faster than the flat ``O(eps**(2/3))`` estimate
+    admits. A random Bernstein polynomial is nowhere near that Chebyshev-sharp
+    extremal case, so ``(degree + 1) ** 2`` is used as a deliberately modest
+    (not the sharp ``n**6``) headroom factor, on top of an explicit constant
+    of 8 for the unmodelled recurrence depth.
+
+    Args:
+        dtype (npt.DTypeLike): Working precision.
+        cp (npt.NDArray[np.floating[Any]]): Control points, for the magnitude scale.
+        degree (int): Polynomial degree, which sets the derivative-growth headroom.
+
+    Returns:
+        tuple[float, float]: ``(h, tol)`` -- the finite-difference step and the
+        absolute tolerance on the derivative residual.
+    """
+    eps = _eps(dtype)
+    h = eps ** (1.0 / 3.0)
+    tol = 8.0 * (degree + 1) ** 2 * eps ** (2.0 / 3.0) * _magnitude(cp)
+    return h, tol
+
+
+def _product_tol(
+    p_degree: int,
+    q_degree: int,
+    dtype: npt.DTypeLike,
+    magnitude: float,
+    *,
+    chain_depth: int = 1,
+) -> float:
+    """Bound the error of a Bernstein product (``multiply`` or ``compose``).
+
+    Each product coefficient sums ``O(p + q)`` cross terms with binomial
+    weights that telescope to one, so the relative error accumulates like the
+    combined degree relative to the *result's own* magnitude -- callers must
+    pass that magnitude explicitly, since it is not always the operands'
+    magnitude (a pointwise product's natural scale is the product of both
+    factors' magnitudes, not their max). ``chain_depth`` covers a caller that
+    builds its result through several *sequential* Bernstein products (e.g.
+    ``compose`` computing successive powers ``g, g**2, ..., g**n`` of a
+    reparametrization): each of the ``chain_depth`` steps contributes its own
+    single-product error, which then also propagates through the remaining
+    steps, so the total is bounded by ``chain_depth`` times a single step's
+    bound. An explicit factor of 8 covers the unmodelled recurrence constant.
+
+    Args:
+        p_degree (int): Degree of the first factor.
+        q_degree (int): Degree of the second factor.
+        dtype (npt.DTypeLike): Working precision.
+        magnitude (float): Magnitude scale of the *result* being checked.
+        chain_depth (int): Number of sequential Bernstein products chained to
+            build the result. Defaults to 1 (a single product).
+
+    Returns:
+        float: Absolute tolerance.
+    """
+    return 8.0 * (p_degree + q_degree + 1) * _eps(dtype) * magnitude * max(chain_depth, 1)
+
+
+def _delta_failure(
+    name: str, got: npt.NDArray[Any], expected: npt.NDArray[Any], tol: float
+) -> str | None:
+    """Report the worst absolute deviation between two arrays, if it exceeds a tolerance.
+
+    Shared by every invariant that compares one Bezier evaluation to another
+    (or to an analytic oracle), to keep each call site to one line.
+
+    Args:
+        name (str): Short label for the quantities being compared, used only
+            in the failure message.
+        got (npt.NDArray[Any]): The value under test.
+        expected (npt.NDArray[Any]): The reference value.
+        tol (float): Absolute tolerance.
+
+    Returns:
+        str | None: ``None`` when within tolerance, else a short message.
+    """
+    worst = float(np.max(np.abs(np.asarray(got) - np.asarray(expected))))
+    if worst > tol:
+        return f"{name}: max|delta| = {worst:.3e} > {tol:.3e}"
+    return None
+
+
+def _bernstein_eval_noise(
+    degree: int, dtype: npt.DTypeLike, cp: npt.NDArray[np.floating[Any]]
+) -> float:
+    """Bound the rounding noise of evaluating a degree-``n`` Bernstein polynomial.
+
+    The de Casteljau recurrence runs ``degree`` sequential lerp stages, each
+    contributing ``O(eps)`` relative to the running coefficient magnitude; an
+    explicit factor of 8 covers the unmodelled constant.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Working precision.
+        cp (npt.NDArray[np.floating[Any]]): Coefficients, for the magnitude scale.
+
+    Returns:
+        float: Absolute tolerance on ``|f(t)|`` for an alleged root ``t``.
+    """
+    return 8.0 * (degree + 1) * _eps(dtype) * _magnitude(cp)
+
+
+def _double_op_identity_invariant(original_cp: npt.NDArray[np.floating[Any]]) -> Invariant:
+    """Build an invariant asserting a bitwise round trip back to the original.
+
+    ``reverse`` and ``permute_directions`` are pure permutations of the control
+    point array, so applying the inverse operation must reproduce the original
+    exactly -- ``==``, not a tolerance.
+
+    Args:
+        original_cp (npt.NDArray[np.floating[Any]]): The control points before
+            the round trip.
+
+    Returns:
+        Invariant: Check reporting any bitwise mismatch.
+    """
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bezier):
+            return f"expected Bezier, got {type(result).__name__}"
+        if not np.array_equal(result.control_points, original_cp):
+            return "round trip is not bit-identical to the original control points"
+        return None
+
+    return custom("double-op-identity", predicate)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def _construct_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`~pantr.bezier.Bezier` construction cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile construction.
+    """
+    corner_degrees = (0, 1, 3, 15, 62) if profile is Profile.FULL else (0, 1)
+    combos = _rank_dim_combos(profile) if profile is Profile.FULL else _rank_dim_combos(profile)[:1]
+    for dtype in dtypes(profile):
+        for rank, dim in combos:
+            for degree in corner_degrees:
+                for rational in (False, True) if profile is Profile.FULL else (False,):
+                    cp = _random_control_points(
+                        rank, dim, degree, dtype, offset=1000 + degree, rational=rational
+                    )
+                    tag = f"r{rank}d{dim}p{degree}_{dtype}_{'rat' if rational else 'nonrat'}"
+                    yield Case(
+                        GROUP,
+                        f"construct_{tag}",
+                        Bezier,
+                        lambda cp=cp, rational=rational: Bezier(cp, is_rational=rational),
+                        {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
+                        invariants=(
+                            custom(
+                                "shape-matches-request",
+                                lambda r, rank=rank, dim=dim, degree=degree: None
+                                if (r.rank == rank and r.dim == dim and r.degree == (degree,) * dim)
+                                else f"got rank={r.rank} dim={r.dim} degree={r.degree}",
+                            ),
+                        ),
+                        arrays={"control_points": cp},
+                    )
+
+    # Malformed / edge-case constructions: documented rejections or corners.
+    yield Case(
+        GROUP,
+        "construct_empty_cp",
+        Bezier,
+        lambda: Bezier(np.zeros((0, 2), dtype=np.float64)),
+        {"kind": "empty"},
+    )
+    yield Case(
+        GROUP,
+        "construct_scalar_cp",
+        Bezier,
+        lambda: Bezier(np.float64(1.0)),
+        {"kind": "0d-scalar"},
+    )
+    yield Case(
+        GROUP,
+        "construct_rank_zero",
+        Bezier,
+        lambda: Bezier(np.zeros((3, 0), dtype=np.float64)),
+        {"kind": "rank-zero"},
+    )
+    yield Case(
+        GROUP,
+        "construct_1d_list_reshape",
+        Bezier,
+        lambda: Bezier([0.0, 1.0, 2.0]),
+        {"kind": "1d-list"},
+        invariants=(expected_shape(()),),
+        finite_inputs=False,  # predicate below checks rank/dim, not the raw result
+    )
+    yield Case(
+        GROUP,
+        "construct_integer_cp_cast",
+        Bezier,
+        lambda: Bezier(np.array([[0, 0], [1, 1], [2, 0]], dtype=np.int64)),
+        {"kind": "integer-cast"},
+        invariants=(
+            custom(
+                "cast-to-float64",
+                lambda r: None if r.dtype == np.float64 else f"got dtype {r.dtype}",
+            ),
+        ),
+    )
+    float32_cp = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]], dtype=np.float32)
+    yield Case(
+        GROUP,
+        "construct_float32_untouched",
+        Bezier,
+        lambda: Bezier(float32_cp),
+        {"kind": "float32-passthrough"},
+        invariants=(
+            custom(
+                "float32-preserved",
+                lambda r: None if r.dtype == np.float32 else f"got dtype {r.dtype}",
+            ),
+        ),
+        arrays={"control_points": float32_cp},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def _nd_point_families(
+    dim: int, dtype: np.dtype[np.float32 | np.float64], profile: Profile
+) -> list[tuple[str, npt.NDArray[np.float32 | np.float64], bool]]:
+    """Build hostile evaluation-point families for a ``dim >= 2`` Bezier.
+
+    :func:`~._axes.point_specs` only builds 1D coordinate arrays; this mirrors
+    its corner families (interior, both corners, out-of-range, empty) for a
+    genuinely multi-dimensional parametric point. Each point repeats the same
+    coordinate across every direction rather than crossing per-direction
+    values -- a deliberate simplification to keep the case count bounded.
+
+    Args:
+        dim (int): Parametric dimension, ``>= 2``.
+        dtype (np.dtype[np.float32 | np.float64]): Point precision.
+        profile (Profile): Sweep width.
+
+    Returns:
+        list[tuple[str, npt.NDArray[np.float32 | np.float64], bool]]: ``(name,
+        pts, finite)`` triples, ``pts`` of shape ``(n, dim)``.
+    """
+    families: list[tuple[str, npt.NDArray[np.float32 | np.float64], bool]] = [
+        ("interior", np.tile(np.array([[0.31], [0.77]], dtype=dtype), (1, dim)), True),
+        ("corner_zero", np.zeros((1, dim), dtype=dtype), True),
+        ("corner_one", np.ones((1, dim), dtype=dtype), True),
+        (
+            "mixed_corner",
+            np.array([[0.0 if d % 2 == 0 else 1.0 for d in range(dim)]], dtype=dtype),
+            True,
+        ),
+        ("empty", np.zeros((0, dim), dtype=dtype), True),
+    ]
+    if profile is Profile.FULL:
+        families += [
+            ("just_outside", np.full((1, dim), -1.0e-3, dtype=dtype), True),
+            ("far_outside", np.full((1, dim), 5.0, dtype=dtype), True),
+            ("nan_inf", np.array([[np.nan, *([0.5] * (dim - 1))]], dtype=dtype), False),
+        ]
+    return families
+
+
+def _evaluate_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.evaluate` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile evaluation.
+    """
+    eval_degrees = degrees(profile) if profile is Profile.FULL else degrees(profile)[:1]
+    # Explicit, dimension-diverse subset -- `_RANK_DIM_FULL[:4]` would pick four
+    # dim=1 combos back to back and never cross the point-family axis with a
+    # surface or volume at all.
+    combos = (
+        ((1, 1), (3, 1), (1, 2), (3, 3))
+        if profile is Profile.FULL
+        else _rank_dim_combos(profile)[:1]
+    )
+    for dtype in dtypes(profile):
+        for rank, dim in combos:
+            for degree in eval_degrees:
+                cp = _random_control_points(rank, dim, degree, dtype, offset=2000 + degree)
+                bezier = Bezier(cp)
+                tag = f"r{rank}d{dim}p{degree}_{dtype}"
+
+                if dim == 1:
+                    pt_families = [
+                        (spec.name, spec.pts, spec.finite)
+                        for spec in point_specs((0.0, 1.0), dtype, profile)
+                    ]
+                else:
+                    pt_families = _nd_point_families(dim, dtype, profile)
+
+                for name, pts, finite in pt_families:
+                    # Bernstein extrapolation is mathematically unbounded: at a
+                    # fixed off-domain parameter, B_i^n(t) grows like O(t**n),
+                    # so a high enough degree genuinely overflows float32 (and
+                    # eventually float64) well before any implementation error
+                    # is involved -- nothing in `evaluate`'s contract promises
+                    # a finite answer for these families at every degree.
+                    finite_expected = finite and name not in _EXTRAPOLATION_POINT_FAMILIES
+                    yield Case(
+                        GROUP,
+                        f"evaluate_{tag}_{name}",
+                        Bezier.evaluate,
+                        lambda bezier=bezier, pts=pts: bezier.evaluate(pts),
+                        {
+                            "rank": rank,
+                            "dim": dim,
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "points": name,
+                        },
+                        finite_inputs=finite_expected,
+                        arrays={"control_points": cp, "pts": pts},
+                    )
+
+                if profile is Profile.FULL:
+                    # Rationality crosses degree/dim/dtype separately, at a
+                    # single interior point, rather than multiplying into the
+                    # point-family sweep above (which is about domain geometry,
+                    # not rationality).
+                    cp_rat = _random_control_points(
+                        rank, dim, degree, dtype, offset=2000 + degree, rational=True
+                    )
+                    bezier_rat = Bezier(cp_rat, is_rational=True)
+                    interior_pts = (
+                        np.array([0.31, 0.77], dtype=dtype)
+                        if dim == 1
+                        else np.tile(np.array([[0.31], [0.77]], dtype=dtype), (1, dim))
+                    )
+                    yield Case(
+                        GROUP,
+                        f"evaluate_{tag}_rational_interior",
+                        Bezier.evaluate,
+                        lambda bezier_rat=bezier_rat,
+                        interior_pts=interior_pts: bezier_rat.evaluate(interior_pts),
+                        {
+                            "rank": rank,
+                            "dim": dim,
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "rational": True,
+                        },
+                        arrays={"control_points": cp_rat, "pts": interior_pts},
+                    )
+
+    # Dtype-mismatch and out-of-range direction: documented rejections.
+    bezier64 = Bezier(_random_control_points(1, 1, 3, np.dtype(np.float64), offset=2900))
+    pts32 = np.array([0.5], dtype=np.float32)
+    yield Case(
+        GROUP,
+        "evaluate_dtype_mismatch",
+        Bezier.evaluate,
+        lambda: bezier64.evaluate(pts32),
+        {"kind": "dtype-mismatch"},
+    )
+
+    # out= round trip: correct shape/dtype accepted and filled bit-identically.
+    bezier_out = Bezier(_random_control_points(2, 1, 3, np.dtype(np.float64), offset=2901))
+    pts_out = np.array([0.2, 0.6], dtype=np.float64)
+    expected = bezier_out.evaluate(pts_out)
+    out_buf = np.empty_like(expected)
+    yield Case(
+        GROUP,
+        "evaluate_out_roundtrip",
+        Bezier.evaluate,
+        lambda: bezier_out.evaluate(pts_out, out=out_buf),
+        {"kind": "out-roundtrip"},
+        invariants=(
+            custom(
+                "out-matches-return",
+                lambda r, expected=expected: None
+                if np.array_equal(r, expected)
+                else "out= result differs from the freshly-allocated result",
+            ),
+        ),
+    )
+    bad_out = np.empty((3, 7), dtype=np.float64)
+    yield Case(
+        GROUP,
+        "evaluate_out_wrong_shape",
+        Bezier.evaluate,
+        lambda: bezier_out.evaluate(pts_out, out=bad_out),
+        {"kind": "out-wrong-shape"},
+    )
+
+
+def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.evaluate_derivatives` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile derivative evaluation.
+    """
+    deriv_degrees = degrees(profile) if profile is Profile.FULL else degrees(profile)[:1]
+    for dtype in dtypes(profile):
+        for degree in deriv_degrees:
+            for rational in (False, True) if profile is Profile.FULL else (False,):
+                cp = _random_control_points(
+                    2, 1, degree, dtype, offset=3000 + degree, rational=rational
+                )
+                bezier = Bezier(cp, is_rational=rational)
+                pts = np.array([0.1, 0.5, 0.9], dtype=dtype)
+                # `sorted(set(...))` avoids a duplicate order (e.g. degree == 0
+                # collides 0 and degree) producing two cases with the same label.
+                orders = sorted({0, 1, degree, degree + 3})
+                for order in orders:
+                    if order == 0 and degree == 0:
+                        continue
+                    tag = f"p{degree}_{dtype}_{'rat' if rational else 'nonrat'}_o{order}"
+                    yield Case(
+                        GROUP,
+                        f"evaluate_derivatives_{tag}",
+                        Bezier.evaluate_derivatives,
+                        lambda bezier=bezier, pts=pts, order=order: bezier.evaluate_derivatives(
+                            pts, order
+                        ),
+                        {
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "rational": rational,
+                            "order": order,
+                        },
+                        arrays={"control_points": cp},
+                    )
+
+    # Mismatched orders length and negative order: documented rejections.
+    cp_bad = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=3900)
+    bezier_bad = Bezier(cp_bad)
+    pts_bad = np.array([[0.2, 0.3]], dtype=np.float64)
+    yield Case(
+        GROUP,
+        "evaluate_derivatives_orders_length_mismatch",
+        Bezier.evaluate_derivatives,
+        lambda: bezier_bad.evaluate_derivatives(pts_bad, [1, 2, 3]),
+        {"kind": "orders-length-mismatch"},
+    )
+    yield Case(
+        GROUP,
+        "evaluate_derivatives_negative_order",
+        Bezier.evaluate_derivatives,
+        lambda: bezier_bad.evaluate_derivatives(pts_bad, [-1, 0]),
+        {"kind": "negative-order"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Degree elevation, reduction, and minimization
+# ---------------------------------------------------------------------------
+
+
+def _elevate_degree_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.elevate_degree` cases.
+
+    Invariant 1: elevation leaves the curve pointwise unchanged (the elevated
+    control points are convex combinations of the originals).
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile elevation.
+    """
+    elevate_degrees = (0, 1, 3, 15) if profile is Profile.FULL else (0, 1)
+    for dtype in dtypes(profile):
+        for degree in elevate_degrees:
+            for inc in (1, 5) if profile is Profile.FULL else (1,):
+                for mag_name, scale, translate in _magnitude_variants(profile):
+                    cp = _random_control_points(
+                        2,
+                        1,
+                        degree,
+                        dtype,
+                        offset=4000 + degree + inc,
+                        scale=scale,
+                        translate=translate,
+                    )
+                    bezier = Bezier(cp)
+                    test_pts = np.array([0.0, 0.13, 0.5, 0.87, 1.0], dtype=dtype)
+                    expected = bezier.evaluate(test_pts)
+                    tol = _convex_combination_tol(degree + inc, dtype, cp)
+                    yield Case(
+                        GROUP,
+                        f"elevate_p{degree}_inc{inc}_{dtype}_{mag_name}",
+                        Bezier.elevate_degree,
+                        lambda bezier=bezier, inc=inc: bezier.elevate_degree(inc),
+                        {
+                            "degree": degree,
+                            "increment": inc,
+                            "dtype": str(dtype),
+                            "magnitude": mag_name,
+                        },
+                        invariants=(
+                            custom(
+                                "elevate-preserves-values",
+                                lambda r, test_pts=test_pts, expected=expected, tol=tol: (
+                                    _delta_failure("elevate", r.evaluate(test_pts), expected, tol)
+                                ),
+                            ),
+                        ),
+                        arrays={"control_points": cp},
+                    )
+
+    # Documented rejections: negative increment, all-zero increments, length mismatch.
+    cp_nd = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=4900)
+    bezier_nd = Bezier(cp_nd)
+    yield Case(
+        GROUP,
+        "elevate_negative_increment",
+        Bezier.elevate_degree,
+        lambda: bezier_nd.elevate_degree(-1),
+        {"kind": "negative-increment"},
+    )
+    yield Case(
+        GROUP,
+        "elevate_all_zero_increments",
+        Bezier.elevate_degree,
+        lambda: bezier_nd.elevate_degree([0, 0]),
+        {"kind": "all-zero-increments"},
+    )
+    yield Case(
+        GROUP,
+        "elevate_length_mismatch",
+        Bezier.elevate_degree,
+        lambda: bezier_nd.elevate_degree([1, 1, 1]),
+        {"kind": "length-mismatch"},
+    )
+
+
+def _reduce_degree_invariant(
+    endpoints: npt.NDArray[np.floating[Any]],
+    expected_ends: npt.NDArray[np.floating[Any]],
+    *,
+    to_degree_zero: bool,
+    mean_cp: npt.NDArray[np.floating[Any]] | None = None,
+    mean_tol: float = 0.0,
+) -> Invariant:
+    """Build the reduce_degree correctness invariant for one case.
+
+    The endpoint-bit-exactness claim (``_bezier.py:319-320``) is explicit about
+    one carve-out: "A reduction to degree 0 cannot honour two conditions with
+    one coefficient and returns the plain L2 projection, the mean of the
+    control points." So a reduction whose *target* degree is 0 is checked
+    against the mean instead of the (inapplicable) bit-exact endpoints.
+
+    Args:
+        endpoints (npt.NDArray[np.floating[Any]]): ``[0.0, 1.0]`` in the
+            operand's dtype.
+        expected_ends (npt.NDArray[np.floating[Any]]): The original curve
+            evaluated at the endpoints.
+        to_degree_zero (bool): Whether this reduction's target degree is 0.
+        mean_cp (npt.NDArray[np.floating[Any]] | None): The mean of the
+            original control points, required when ``to_degree_zero``.
+        mean_tol (float): Absolute tolerance for the degree-0 mean-projection
+            check.
+
+    Returns:
+        Invariant: The check appropriate to this reduction's target degree.
+    """
+    if to_degree_zero:
+
+        def predicate_mean(result: Bezier) -> str | None:
+            got = np.asarray(result.control_points[0], dtype=np.float64)
+            return _delta_failure("reduce-to-degree-0-mean", got, mean_cp, mean_tol)
+
+        return custom("reduce-degree-zero-is-mean-projection", predicate_mean)
+
+    def predicate_endpoints(result: Bezier) -> str | None:
+        got = result.evaluate(endpoints)
+        if np.array_equal(got, expected_ends):
+            return None
+        return f"endpoints differ: got {got}, expected {expected_ends}"
+
+    return custom("reduce-endpoints-bit-exact", predicate_endpoints)
+
+
+def _reduce_degree_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.reduce_degree` cases.
+
+    Invariant 2: reduction reproduces the endpoint values bit for bit
+    (``_bezier.py`` states this exactly) -- except when the *target* degree is
+    0, where the same docstring documents a different exact property (the mean
+    of the control points).
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile reduction.
+    """
+    reduce_degrees = (1, 2, 3, 15, 62) if profile is Profile.FULL else (1, 2)
+    for dtype in dtypes(profile):
+        for degree in reduce_degrees:
+            for dec in (1, degree) if profile is Profile.FULL else (1,):
+                for mag_name, scale, translate in _magnitude_variants(profile):
+                    cp = _random_control_points(
+                        2,
+                        1,
+                        degree,
+                        dtype,
+                        offset=5000 + degree + dec,
+                        scale=scale,
+                        translate=translate,
+                    )
+                    bezier = Bezier(cp)
+                    endpoints = np.array([0.0, 1.0], dtype=dtype)
+                    expected_ends = bezier.evaluate(endpoints)
+                    to_zero = degree - dec == 0
+                    mean_cp = np.mean(cp, axis=0, dtype=np.float64) if to_zero else None
+                    # Averaging `degree + 1` coefficients carries O(degree) * eps
+                    # of rounding relative to their magnitude; factor 8 as elsewhere.
+                    mean_tol = _convex_combination_tol(degree, dtype, cp) if to_zero else 0.0
+                    invariant = _reduce_degree_invariant(
+                        endpoints,
+                        expected_ends,
+                        to_degree_zero=to_zero,
+                        mean_cp=mean_cp,
+                        mean_tol=mean_tol,
+                    )
+                    yield Case(
+                        GROUP,
+                        f"reduce_p{degree}_dec{dec}_{dtype}_{mag_name}",
+                        Bezier.reduce_degree,
+                        lambda bezier=bezier, dec=dec: bezier.reduce_degree(dec),
+                        {
+                            "degree": degree,
+                            "decrement": dec,
+                            "dtype": str(dtype),
+                            "magnitude": mag_name,
+                        },
+                        invariants=(invariant,),
+                        arrays={"control_points": cp},
+                    )
+
+    # Documented rejections: decrement exceeds degree, negative, all-zero.
+    cp = _random_control_points(1, 1, 3, np.dtype(np.float64), offset=5900)
+    bezier = Bezier(cp)
+    yield Case(
+        GROUP,
+        "reduce_decrement_exceeds_degree",
+        Bezier.reduce_degree,
+        lambda: bezier.reduce_degree(4),
+        {"kind": "decrement-exceeds-degree"},
+    )
+    yield Case(
+        GROUP,
+        "reduce_negative_decrement",
+        Bezier.reduce_degree,
+        lambda: bezier.reduce_degree(-1),
+        {"kind": "negative-decrement"},
+    )
+    yield Case(
+        GROUP,
+        "reduce_all_zero_decrements",
+        Bezier.reduce_degree,
+        lambda: bezier.reduce_degree(0),
+        {"kind": "all-zero-decrement"},
+    )
+
+
+def _degree_reduction_error_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.degree_reduction_error` cases.
+
+    Invariant 11: the value is the exact ``L2`` error, so it must be finite,
+    non-negative always, and at the rounding floor when the curve genuinely has
+    lower degree (built here by elevating a lower-degree curve by one).
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile error computation.
+    """
+    error_degrees = (1, 2, 3, 15) if profile is Profile.FULL else (1, 2)
+    for dtype in dtypes(profile):
+        eps = _eps(dtype)
+        for degree in error_degrees:
+            base_cp = _random_control_points(1, 1, degree, dtype, offset=6000 + degree)
+            base = Bezier(base_cp)
+            elevated = base.elevate_degree(1)
+            tol = 100.0 * eps * _magnitude(base_cp)
+            yield Case(
+                GROUP,
+                f"reduction_error_exact_p{degree}_{dtype}",
+                Bezier.degree_reduction_error,
+                lambda b=elevated: b.degree_reduction_error(1),
+                {"degree": degree, "dtype": str(dtype), "kind": "exactly-reducible"},
+                invariants=(
+                    custom(
+                        "error-at-rounding-floor",
+                        lambda r, tol=tol: None
+                        if (np.isfinite(r) and 0.0 <= r <= tol)
+                        else f"error {r!r} not in [0, {tol:.3e}]",
+                    ),
+                ),
+            )
+            generic_decs = range(1, degree + 1) if profile is Profile.FULL else (1,)
+            for dec in generic_decs:
+                generic_cp = _random_control_points(1, 1, degree, dtype, offset=6100 + degree + dec)
+                generic = Bezier(generic_cp)
+                yield Case(
+                    GROUP,
+                    f"reduction_error_generic_p{degree}_dec{dec}_{dtype}",
+                    Bezier.degree_reduction_error,
+                    lambda b=generic, dec=dec: b.degree_reduction_error(dec),
+                    {"degree": degree, "decrement": dec, "dtype": str(dtype)},
+                    invariants=(
+                        custom(
+                            "error-finite-nonneg",
+                            lambda r: None if (np.isfinite(r) and r >= 0.0) else f"got {r!r}",
+                        ),
+                    ),
+                )
+
+
+def _minimize_degree_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.minimize_degree` cases.
+
+    The only genuinely claimed property without re-implementing the algorithm
+    is that the result's degree never exceeds the original's.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile minimization.
+    """
+    for dtype in dtypes(profile):
+        for degree in degrees(profile):
+            if degree == 0:
+                continue
+            cp = _random_control_points(1, 1, degree, dtype, offset=7000 + degree)
+            bezier = Bezier(cp)
+            yield Case(
+                GROUP,
+                f"minimize_random_p{degree}_{dtype}",
+                Bezier.minimize_degree,
+                lambda bezier=bezier: bezier.minimize_degree(),
+                {"degree": degree, "dtype": str(dtype), "kind": "random"},
+                invariants=(
+                    custom(
+                        "degree-not-increased",
+                        lambda r, degree=degree: None
+                        if r.degree[0] <= degree
+                        else f"got degree {r.degree[0]} > original {degree}",
+                    ),
+                ),
+                arrays={"control_points": cp},
+            )
+            if profile is Profile.FULL:
+                # A genuinely reducible curve: a straight line elevated to `degree`.
+                line_cp = np.linspace(0.0, 1.0, degree + 1, dtype=dtype).reshape(-1, 1)
+                line = Bezier(line_cp)
+                yield Case(
+                    GROUP,
+                    f"minimize_reducible_p{degree}_{dtype}",
+                    Bezier.minimize_degree,
+                    lambda line=line: line.minimize_degree(),
+                    {"degree": degree, "dtype": str(dtype), "kind": "reducible-line"},
+                    invariants=(
+                        custom(
+                            "degree-reduced",
+                            lambda r, degree=degree: None
+                            if r.degree[0] <= degree
+                            else f"got degree {r.degree[0]} > original {degree}",
+                        ),
+                    ),
+                )
+    yield Case(
+        GROUP,
+        "minimize_explicit_tol",
+        Bezier.minimize_degree,
+        lambda: Bezier(np.linspace(0.0, 1.0, 16, dtype=np.float64).reshape(-1, 1)).minimize_degree(
+            tol=1e-3
+        ),
+        {"kind": "explicit-tol"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Split and restrict
+# ---------------------------------------------------------------------------
+
+
+def _split_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.split` cases.
+
+    Invariant 3: both halves, reparametrized, reproduce the original.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile split.
+    """
+    split_degrees = (1, 2, 3, 15, 62) if profile is Profile.FULL else (1, 3)
+    split_values = (0.5, 0.1, 0.9, 1e-6) if profile is Profile.FULL else (0.5,)
+    for dtype in dtypes(profile):
+        for degree in split_degrees:
+            for value in split_values:
+                for mag_name, scale, translate in _magnitude_variants(profile):
+                    cp = _random_control_points(
+                        2, 1, degree, dtype, offset=8000 + degree, scale=scale, translate=translate
+                    )
+                    bezier = Bezier(cp)
+                    tol = _convex_combination_tol(degree, dtype, cp)
+                    left_pts = np.array([0.1, 0.5, 0.9], dtype=dtype)
+                    right_pts = np.array([0.1, 0.5, 0.9], dtype=dtype)
+                    expected_left = bezier.evaluate((left_pts * value).astype(dtype))
+                    expected_right = bezier.evaluate(
+                        (value + right_pts * (1.0 - value)).astype(dtype)
+                    )
+                    yield Case(
+                        GROUP,
+                        f"split_p{degree}_v{value:g}_{dtype}_{mag_name}",
+                        Bezier.split,
+                        lambda bezier=bezier, value=value: bezier.split(0, value),
+                        {
+                            "degree": degree,
+                            "value": value,
+                            "dtype": str(dtype),
+                            "magnitude": mag_name,
+                        },
+                        invariants=(
+                            custom(
+                                "split-reproduces-original",
+                                lambda r,
+                                left_pts=left_pts,
+                                right_pts=right_pts,
+                                expected_left=expected_left,
+                                expected_right=expected_right,
+                                tol=tol: _split_failure(
+                                    r, left_pts, right_pts, expected_left, expected_right, tol
+                                ),
+                            ),
+                        ),
+                        arrays={"control_points": cp},
+                    )
+
+    cp_1d = _random_control_points(1, 1, 3, np.dtype(np.float64), offset=8900)
+    bezier_1d = Bezier(cp_1d)
+    for boundary_value, tag in ((0.0, "left"), (1.0, "right")):
+        yield Case(
+            GROUP,
+            f"split_at_boundary_{tag}",
+            Bezier.split,
+            lambda bezier_1d=bezier_1d, boundary_value=boundary_value: bezier_1d.split(
+                0, boundary_value
+            ),
+            {"kind": f"boundary-{tag}", "value": boundary_value},
+        )
+    yield Case(
+        GROUP,
+        "split_direction_out_of_range",
+        Bezier.split,
+        lambda: bezier_1d.split(1, 0.5),
+        {"kind": "direction-out-of-range"},
+    )
+
+
+def _split_failure(  # noqa: PLR0913 -- two halves each need points and expected values, plus tol
+    result: tuple[Bezier, Bezier],
+    left_pts: npt.NDArray[np.floating[Any]],
+    right_pts: npt.NDArray[np.floating[Any]],
+    expected_left: npt.NDArray[np.floating[Any]],
+    expected_right: npt.NDArray[np.floating[Any]],
+    tol: float,
+) -> str | None:
+    """Check that both halves of a split reproduce the original mapping.
+
+    Args:
+        result (tuple[Bezier, Bezier]): The ``(left, right)`` pair returned by ``split``.
+        left_pts (npt.NDArray[np.floating[Any]]): Test parameters on the left half.
+        right_pts (npt.NDArray[np.floating[Any]]): Test parameters on the right half.
+        expected_left (npt.NDArray[np.floating[Any]]): Original evaluated at the
+            mapped left parameters.
+        expected_right (npt.NDArray[np.floating[Any]]): Original evaluated at the
+            mapped right parameters.
+        tol (float): Absolute tolerance.
+
+    Returns:
+        str | None: ``None`` when both halves match, else a short message.
+    """
+    left, right = result
+    got_left = left.evaluate(left_pts)
+    got_right = right.evaluate(right_pts)
+    worst_left = float(np.max(np.abs(got_left - expected_left)))
+    worst_right = float(np.max(np.abs(got_right - expected_right)))
+    worst = max(worst_left, worst_right)
+    if worst > tol:
+        return (
+            f"max|delta| = {worst:.3e} > {tol:.3e} (left={worst_left:.3e}, right={worst_right:.3e})"
+        )
+    return None
+
+
+def _restrict_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.restrict` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile restriction.
+    """
+    for dtype in dtypes(profile):
+        for degree in (1, 3, 15) if profile is Profile.FULL else (1,):
+            cp = _random_control_points(2, 1, degree, dtype, offset=9000 + degree)
+            bezier = Bezier(cp)
+            bounds = (0.2, 0.8)
+            test_pts = np.array([0.0, 0.5, 1.0], dtype=dtype)
+            expected = bezier.evaluate(
+                (bounds[0] + test_pts * (bounds[1] - bounds[0])).astype(dtype)
+            )
+            tol = _convex_combination_tol(degree, dtype, cp)
+            yield Case(
+                GROUP,
+                f"restrict_p{degree}_{dtype}",
+                Bezier.restrict,
+                lambda bezier=bezier, bounds=bounds: bezier.restrict(bounds),
+                {"degree": degree, "dtype": str(dtype), "bounds": bounds},
+                invariants=(
+                    custom(
+                        "restrict-reproduces-subinterval",
+                        lambda r, test_pts=test_pts, expected=expected, tol=tol: _delta_failure(
+                            "restrict", r.evaluate(test_pts), expected, tol
+                        ),
+                    ),
+                ),
+                arrays={"control_points": cp},
+            )
+
+    cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=9900)
+    bezier_1d = Bezier(cp_1d)
+    yield Case(
+        GROUP,
+        "restrict_zero_width",
+        Bezier.restrict,
+        lambda: bezier_1d.restrict((0.4, 0.4)),
+        {"kind": "zero-width"},
+    )
+    yield Case(
+        GROUP,
+        "restrict_out_of_domain",
+        Bezier.restrict,
+        lambda: bezier_1d.restrict((-0.1, 0.5)),
+        {"kind": "out-of-domain"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compose
+# ---------------------------------------------------------------------------
+
+
+def _compose_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.compose` cases.
+
+    Invariant 4: ``outer.compose(inner).evaluate(t) == outer.evaluate(inner.evaluate(t))``.
+    Combined degree is kept below 62 in the main crossing -- 62 is the known
+    ``_bincoeff`` int64 overflow cliff reached through this path
+    (``_bezier_compose.py``) -- except for one labelled case documenting the
+    boundary at the combined degree 61, one step below the cliff.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile composition.
+    """
+    for dtype in dtypes(profile):
+        # 1-D outer, 1-D inner: the common case, uses the 1D bincoeff kernel.
+        for p, q in ((1, 3), (3, 1), (2, 5)) if profile is Profile.FULL else ((1, 2),):
+            outer_cp = _random_control_points(1, 1, p, dtype, offset=10000 + p)
+            inner_cp = np.linspace(0.0, 1.0, q + 1, dtype=dtype).reshape(-1, 1)
+            outer = Bezier(outer_cp)
+            inner = Bezier(inner_cp)
+            ts = np.array([0.1, 0.4, 0.6, 0.9], dtype=dtype)
+            expected = outer.evaluate(inner.evaluate(ts))
+            magnitude = max(_magnitude(outer_cp), _magnitude(inner_cp))
+            tol = _product_tol(p, q, dtype, magnitude, chain_depth=p)
+            yield Case(
+                GROUP,
+                f"compose_1d1d_p{p}q{q}_{dtype}",
+                Bezier.compose,
+                lambda outer=outer, inner=inner: outer.compose(inner),
+                {"outer_degree": p, "inner_degree": q, "dtype": str(dtype), "kind": "1d-inner"},
+                invariants=(_compose_invariant(ts, expected, tol),),
+                arrays={"outer_control_points": outer_cp, "inner_control_points": inner_cp},
+            )
+
+        if profile is Profile.FULL:
+            # A different route to high combined degree: multi-D inner uses the
+            # NumPy nD product path (`_bernstein_product_coefficients_nd`,
+            # `math.comb`-based), not the Numba 1D bincoeff kernel -- so this is
+            # a genuinely different mechanism, not the known cliff.
+            outer_cp_nd = _random_control_points(1, 1, 30, dtype, offset=10100)
+            inner_cp_nd = _random_control_points(1, 2, 3, dtype, offset=10101)
+            outer_nd = Bezier(outer_cp_nd)
+            inner_nd = Bezier(inner_cp_nd)
+            ts_nd = np.array([[0.2, 0.3], [0.6, 0.8]], dtype=dtype)
+            expected_nd = outer_nd.evaluate(inner_nd.evaluate(ts_nd))
+            magnitude_nd = max(_magnitude(outer_cp_nd), _magnitude(inner_cp_nd))
+            tol_nd = _product_tol(30, 3, dtype, magnitude_nd, chain_depth=30)
+            yield Case(
+                GROUP,
+                f"compose_1d_nd_inner_{dtype}",
+                Bezier.compose,
+                lambda outer_nd=outer_nd, inner_nd=inner_nd: outer_nd.compose(inner_nd),
+                {"outer_degree": 30, "inner_degree": 3, "dtype": str(dtype), "kind": "nd-inner"},
+                invariants=(_compose_invariant(ts_nd, expected_nd, tol_nd),),
+                arrays={"outer_control_points": outer_cp_nd, "inner_control_points": inner_cp_nd},
+            )
+
+            # Boundary marker: combined degree exactly 61, one below the known
+            # `_bincoeff` int64-overflow cliff at 62 -- documents that the cliff
+            # is sharp, without re-triggering the already-logged bug.
+            outer_boundary_cp = _random_control_points(1, 1, 1, dtype, offset=10200)
+            inner_boundary_cp = np.linspace(0.0, 1.0, 62, dtype=dtype).reshape(-1, 1)
+            outer_boundary = Bezier(outer_boundary_cp)
+            inner_boundary = Bezier(inner_boundary_cp)
+            ts_boundary = np.array([0.3, 0.7], dtype=dtype)
+            expected_boundary = outer_boundary.evaluate(inner_boundary.evaluate(ts_boundary))
+            magnitude_boundary = max(_magnitude(outer_boundary_cp), _magnitude(inner_boundary_cp))
+            tol_boundary = _product_tol(1, 61, dtype, magnitude_boundary, chain_depth=1)
+            yield Case(
+                GROUP,
+                f"compose_boundary_combined_degree_61_{dtype}",
+                Bezier.compose,
+                lambda outer_boundary=outer_boundary, inner_boundary=inner_boundary: (
+                    outer_boundary.compose(inner_boundary)
+                ),
+                {"combined_degree": 61, "dtype": str(dtype), "kind": "cliff-boundary"},
+                invariants=(_compose_invariant(ts_boundary, expected_boundary, tol_boundary),),
+                arrays={
+                    "outer_control_points": outer_boundary_cp,
+                    "inner_control_points": inner_boundary_cp,
+                },
+            )
+
+    # Documented rejections.
+    outer_rat_cp = _random_control_points(
+        1, 1, 2, np.dtype(np.float64), offset=10900, rational=True
+    )
+    inner_plain_cp = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=10901)
+    outer_rat = Bezier(outer_rat_cp, is_rational=True)
+    inner_plain = Bezier(inner_plain_cp)
+    yield Case(
+        GROUP,
+        "compose_rational_outer_rejected",
+        Bezier.compose,
+        lambda: outer_rat.compose(inner_plain),
+        {"kind": "rational-outer"},
+    )
+    outer_plain = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=10902))
+    inner_rank_mismatch = Bezier(
+        _random_control_points(2, 1, 2, np.dtype(np.float64), offset=10903)
+    )
+    yield Case(
+        GROUP,
+        "compose_rank_mismatch",
+        Bezier.compose,
+        lambda: outer_plain.compose(inner_rank_mismatch),
+        {"kind": "rank-mismatch"},
+    )
+    outer_f32 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float32), offset=10904))
+    inner_f64 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=10905))
+    yield Case(
+        GROUP,
+        "compose_dtype_mismatch",
+        Bezier.compose,
+        lambda: outer_f32.compose(inner_f64),
+        {"kind": "dtype-mismatch"},
+    )
+
+
+def _compose_invariant(
+    ts: npt.NDArray[np.floating[Any]], expected: npt.NDArray[np.floating[Any]], tol: float
+) -> Invariant:
+    """Build the compose-matches-evaluation invariant for one case.
+
+    Args:
+        ts (npt.NDArray[np.floating[Any]]): Test parameters, in the inner's
+            parametric space.
+        expected (npt.NDArray[np.floating[Any]]): ``outer.evaluate(inner.evaluate(ts))``.
+        tol (float): Absolute tolerance.
+
+    Returns:
+        Invariant: Check comparing the composed Bezier's own evaluation to
+        ``expected``.
+    """
+
+    def predicate(result: Bezier) -> str | None:
+        return _delta_failure("compose-vs-eval-through-inner", result.evaluate(ts), expected, tol)
+
+    return custom("compose-matches-eval", predicate)
+
+
+# ---------------------------------------------------------------------------
+# Multiply
+# ---------------------------------------------------------------------------
+
+
+def _multiply_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.multiply` cases.
+
+    Invariant 5: ``(f * g).evaluate(t) == f.evaluate(t) * g.evaluate(t)``.
+    Multiply uses ``math.comb`` (arbitrary-precision Python ints), not the
+    Numba ``_bincoeff`` kernel, so it is not subject to the known int64 cliff;
+    degrees here are kept moderate to avoid unrelated float64 conditioning noise.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile product.
+    """
+    degree_pairs = ((1, 1), (3, 5), (15, 15)) if profile is Profile.FULL else ((1, 1),)
+    for dtype in dtypes(profile):
+        for p, q in degree_pairs:
+            for mag_name, scale, translate in _magnitude_variants(profile):
+                cp_f = _random_control_points(
+                    1, 1, p, dtype, offset=11000 + p, scale=scale, translate=translate
+                )
+                cp_g = _random_control_points(
+                    1, 1, q, dtype, offset=11000 + q + 1, scale=scale, translate=translate
+                )
+                f = Bezier(cp_f)
+                g = Bezier(cp_g)
+                ts = np.array([0.05, 0.3, 0.6, 0.95], dtype=dtype)
+                expected = f.evaluate(ts) * g.evaluate(ts)
+                # A pointwise product's own magnitude is the *product* of both
+                # factors' magnitudes, not their max -- passing the max badly
+                # underestimates the tolerance once either factor is scaled up.
+                tol = _product_tol(p, q, dtype, _magnitude(cp_f) * _magnitude(cp_g))
+                yield Case(
+                    GROUP,
+                    f"multiply_p{p}q{q}_{dtype}_{mag_name}",
+                    Bezier.multiply,
+                    lambda f=f, g=g: f.multiply(g),
+                    {"p": p, "q": q, "dtype": str(dtype), "magnitude": mag_name},
+                    invariants=(
+                        custom(
+                            "multiply-matches-pointwise-product",
+                            lambda r, ts=ts, expected=expected, tol=tol: _delta_failure(
+                                "multiply", r.evaluate(ts), expected, tol
+                            ),
+                        ),
+                    ),
+                    arrays={"f_control_points": cp_f, "g_control_points": cp_g},
+                )
+
+    f_operator = Bezier.__mul__
+    f64 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=11900))
+    g64 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=11901))
+    ts_op = np.array([0.3, 0.7], dtype=np.float64)
+    expected_op = f64.evaluate(ts_op) * g64.evaluate(ts_op)
+    tol_op = _product_tol(
+        2, 2, np.dtype(np.float64), _magnitude(f64.control_points) * _magnitude(g64.control_points)
+    )
+    yield Case(
+        GROUP,
+        "multiply_operator",
+        f_operator,
+        lambda: f64 * g64,
+        {"kind": "dunder-mul"},
+        invariants=(
+            custom(
+                "operator-matches-product",
+                lambda r, ts_op=ts_op, expected_op=expected_op, tol_op=tol_op: _delta_failure(
+                    "operator", r.evaluate(ts_op), expected_op, tol_op
+                ),
+            ),
+        ),
+    )
+
+    rank_mismatch = Bezier(_random_control_points(2, 1, 2, np.dtype(np.float64), offset=11902))
+    yield Case(
+        GROUP,
+        "multiply_rank_mismatch",
+        Bezier.multiply,
+        lambda: f64.multiply(rank_mismatch),
+        {"kind": "rank-mismatch"},
+    )
+    f32 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float32), offset=11903))
+    yield Case(
+        GROUP,
+        "multiply_dtype_mismatch",
+        Bezier.multiply,
+        lambda: f64.multiply(f32),
+        {"kind": "dtype-mismatch"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivative
+# ---------------------------------------------------------------------------
+
+
+def _derivative_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.derivative` cases.
+
+    Invariant 6: the returned hodograph agrees with a central difference on
+    ``evaluate``, to the finite-difference noise floor.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile derivative.
+    """
+    derivative_degrees = (1, 2, 3, 15) if profile is Profile.FULL else (1, 2)
+    for dtype in dtypes(profile):
+        for degree in derivative_degrees:
+            for rational in (False, True) if profile is Profile.FULL else (False,):
+                for keep_degree in (False, True) if profile is Profile.FULL else (False,):
+                    for mag_name, scale, translate in _magnitude_variants(profile):
+                        cp = _random_control_points(
+                            1,
+                            1,
+                            degree,
+                            dtype,
+                            offset=12000 + degree,
+                            rational=rational,
+                            scale=scale,
+                            translate=translate,
+                        )
+                        bezier = Bezier(cp, is_rational=rational)
+                        h, tol = _fd_step_and_tol(dtype, cp, degree)
+                        ts = np.array([0.2, 0.5, 0.8], dtype=dtype)
+                        ts_safe = np.clip(ts, h, 1.0 - h).astype(dtype)
+                        central = (
+                            bezier.evaluate((ts_safe + h).astype(dtype))
+                            - bezier.evaluate((ts_safe - h).astype(dtype))
+                        ) / (2.0 * h)
+                        tag = (
+                            f"p{degree}_{dtype}_{'rat' if rational else 'nonrat'}"
+                            f"_{'keepdeg' if keep_degree else 'lower'}_{mag_name}"
+                        )
+                        yield Case(
+                            GROUP,
+                            f"derivative_{tag}",
+                            Bezier.derivative,
+                            lambda bezier=bezier, keep_degree=keep_degree: bezier.derivative(
+                                keep_degree=keep_degree
+                            ),
+                            {
+                                "degree": degree,
+                                "dtype": str(dtype),
+                                "rational": rational,
+                                "keep_degree": keep_degree,
+                                "magnitude": mag_name,
+                            },
+                            invariants=(
+                                custom(
+                                    "derivative-matches-central-difference",
+                                    lambda r, ts_safe=ts_safe, central=central, tol=tol: (
+                                        _delta_failure(
+                                            "derivative", r.evaluate(ts_safe), central, tol
+                                        )
+                                    ),
+                                ),
+                            ),
+                            arrays={"control_points": cp},
+                        )
+
+    cp_const = _random_control_points(1, 2, 0, np.dtype(np.float64), offset=12900)
+    bezier_const = Bezier(cp_const)
+    yield Case(
+        GROUP,
+        "derivative_degree_zero_rejected",
+        Bezier.derivative,
+        lambda: bezier_const.derivative(direction=0),
+        {"kind": "degree-zero-direction"},
+    )
+    yield Case(
+        GROUP,
+        "derivative_direction_out_of_range",
+        Bezier.derivative,
+        lambda: bezier_const.derivative(direction=5),
+        {"kind": "direction-out-of-range"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Root finding
+# ---------------------------------------------------------------------------
+
+
+def _exact_bernstein_from_roots(
+    roots: Sequence[Fraction], dtype: np.dtype[np.float32 | np.float64]
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build exact Bernstein coefficients for a polynomial with known roots.
+
+    Expands ``prod_i (t - r_i)`` into power-basis coefficients using exact
+    rational arithmetic, converts to the Bernstein basis of the same degree via
+    the standard power-to-Bernstein change of basis (``b_j = sum_{i<=j}
+    C(j,i)/C(n,i) * a_i``, Farouki & Rajan 2012), and rounds to ``dtype`` once.
+    The algorithm under test never sees this derivation, so the resulting
+    coefficients are an independent root-finding oracle.
+
+    Args:
+        roots (Sequence[Fraction]): Distinct exact roots in ``(0, 1)``.
+        dtype (np.dtype[np.float32 | np.float64]): Target floating dtype.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Bernstein coefficients, shape
+        ``(len(roots) + 1,)``.
+    """
+    n = len(roots)
+    poly: list[Fraction] = [Fraction(1)]
+    for r in roots:
+        new_poly = [Fraction(0)] * (len(poly) + 1)
+        for i, c in enumerate(poly):
+            new_poly[i] += c * (-r)
+            new_poly[i + 1] += c
+        poly = new_poly
+
+    bernstein: list[Fraction] = []
+    for j in range(n + 1):
+        acc = Fraction(0)
+        for i in range(j + 1):
+            acc += Fraction(math.comb(j, i), math.comb(n, i)) * poly[i]
+        bernstein.append(acc)
+
+    return np.array([float(v) for v in bernstein], dtype=dtype)
+
+
+def _well_separated_roots(n: int) -> list[Fraction]:
+    """Build ``n`` roots evenly spaced in ``(0, 1)``, well separated.
+
+    Args:
+        n (int): Number of roots.
+
+    Returns:
+        list[Fraction]: Exact roots ``k / (n + 1)`` for ``k = 1, ..., n``.
+    """
+    return [Fraction(k, n + 1) for k in range(1, n + 1)]
+
+
+def _clustered_roots(n: int) -> list[Fraction]:
+    """Build ``n`` roots with one nearly-duplicate pair (a known dedup edge case).
+
+    Args:
+        n (int): Number of roots, ``>= 2``.
+
+    Returns:
+        list[Fraction]: Exact roots, mostly well separated but with two
+        roots ``1e-6`` apart.
+    """
+    roots = _well_separated_roots(n)
+    roots[-1] = roots[-2] + Fraction(1, 1_000_000)
+    return roots
+
+
+def _monotone_control_points(
+    degree: int, dtype: np.dtype[np.float32 | np.float64], *, sign_change: bool
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build control points for a Bezier certified monotone by construction.
+
+    Strictly increasing control points guarantee a monotone Bezier: the
+    hodograph's control points are positive multiples of the (all-positive)
+    forward differences, so the derivative never changes sign. This is an
+    independent sufficient condition, not the algorithm's own logic.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (np.dtype[np.float32 | np.float64]): Target floating dtype.
+        sign_change (bool): If ``True``, the ramp crosses zero (root exists);
+            if ``False``, it stays strictly positive (no root).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Control points, shape ``(degree + 1, 1)``.
+    """
+    lo, hi = (-1.0, 1.0) if sign_change else (0.2, 1.0)
+    return np.linspace(lo, hi, degree + 1, dtype=dtype).reshape(-1, 1)
+
+
+def _roots_bounded_invariant(bezier: Bezier) -> Invariant:
+    """Build the invariant that ``find_roots`` returns bounded, genuine roots.
+
+    Args:
+        bezier (Bezier): The curve whose roots are being found.
+
+    Returns:
+        Invariant: Check enforcing the count bound, containment, and residual.
+    """
+    degree = bezier.degree[0]
+    cp = bezier.control_points[:, 0]
+    bound = _bernstein_eval_noise(degree, bezier.dtype, cp)
+
+    def predicate(result: object) -> str | None:
+        roots = np.asarray(result)
+        if roots.ndim != 1:
+            return f"expected a 1D roots array, got shape {roots.shape}"
+        if roots.size > max(degree, 1):
+            return f"found {roots.size} roots but degree is {degree}"
+        if roots.size and (np.any(roots < 0.0) or np.any(roots > 1.0)):
+            return f"root outside [0, 1]: {roots}"
+        if roots.size:
+            vals = np.atleast_1d(bezier.evaluate(roots.astype(bezier.dtype)))
+            worst = float(np.max(np.abs(vals)))
+            if worst > bound:
+                return f"max|f(root)| = {worst:.3e} > {bound:.3e}"
+        return None
+
+    return custom("roots-bounded-and-genuine", predicate)
+
+
+def _root_finding_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`~pantr.bezier.find_roots` and :func:`~pantr.bezier.find_monotone_root` cases.
+
+    Invariant 7: at most ``degree`` roots, each in ``[0, 1]``, each a genuine
+    root to the derived noise floor. Invariant 8: on a monotone sign-changing
+    curve, a bounded root; on a non-crossing one, the documented ``NaN`` sentinel.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile root-finding call.
+    """
+    root_degrees = (3, 5, 8, 15, 61) if profile is Profile.FULL else (3,)
+    for dtype in dtypes(profile):
+        for n in root_degrees:
+            coeff = _exact_bernstein_from_roots(_well_separated_roots(n), dtype)
+            bezier = Bezier(coeff.reshape(-1, 1))
+            yield Case(
+                GROUP,
+                f"find_roots_well_separated_n{n}_{dtype}",
+                find_roots,
+                lambda bezier=bezier: find_roots(bezier),
+                {"n_roots": n, "dtype": str(dtype), "kind": "well-separated"},
+                invariants=(_roots_bounded_invariant(bezier),),
+                arrays={"coefficients": coeff},
+            )
+
+        if profile is Profile.FULL:
+            for n in (5, 8):
+                coeff = _exact_bernstein_from_roots(_clustered_roots(n), dtype)
+                bezier = Bezier(coeff.reshape(-1, 1))
+                yield Case(
+                    GROUP,
+                    f"find_roots_clustered_n{n}_{dtype}",
+                    find_roots,
+                    lambda bezier=bezier: find_roots(bezier),
+                    {"n_roots": n, "dtype": str(dtype), "kind": "clustered-known-dedup-edge-case"},
+                    invariants=(_roots_bounded_invariant(bezier),),
+                    arrays={"coefficients": coeff},
+                )
+
+        # Degenerate: identically zero (every point is a root).
+        zero_cp = np.zeros((5, 1), dtype=dtype)
+        zero_bezier = Bezier(zero_cp)
+        yield Case(
+            GROUP,
+            f"find_roots_identically_zero_{dtype}",
+            find_roots,
+            lambda zero_bezier=zero_bezier: find_roots(zero_bezier),
+            {"dtype": str(dtype), "kind": "identically-zero"},
+        )
+
+        for degree in (3, 15) if profile is Profile.FULL else (3,):
+            mono_cp = _monotone_control_points(degree, dtype, sign_change=True)
+            mono_bezier = Bezier(mono_cp)
+            bound = _bernstein_eval_noise(degree, dtype, mono_cp[:, 0])
+            yield Case(
+                GROUP,
+                f"find_monotone_root_crossing_p{degree}_{dtype}",
+                find_monotone_root,
+                lambda mono_bezier=mono_bezier: find_monotone_root(mono_bezier),
+                {"degree": degree, "dtype": str(dtype), "kind": "sign-change"},
+                invariants=(
+                    custom(
+                        "monotone-root-bounded",
+                        lambda r, mono_bezier=mono_bezier, bound=bound: _monotone_root_failure(
+                            r, mono_bezier, bound, expect_root=True
+                        ),
+                    ),
+                ),
+                arrays={"control_points": mono_cp},
+            )
+
+            no_cross_cp = _monotone_control_points(degree, dtype, sign_change=False)
+            no_cross_bezier = Bezier(no_cross_cp)
+            yield Case(
+                GROUP,
+                f"find_monotone_root_no_crossing_p{degree}_{dtype}",
+                find_monotone_root,
+                lambda no_cross_bezier=no_cross_bezier: find_monotone_root(no_cross_bezier),
+                {"degree": degree, "dtype": str(dtype), "kind": "no-sign-change"},
+                invariants=(
+                    custom(
+                        "monotone-root-nan-sentinel",
+                        lambda r, no_cross_bezier=no_cross_bezier: _monotone_root_failure(
+                            r, no_cross_bezier, 0.0, expect_root=False
+                        ),
+                    ),
+                ),
+                finite_inputs=False,
+                arrays={"control_points": no_cross_cp},
+            )
+
+        if profile is Profile.FULL:
+            # Batch mode: same-degree sequence.
+            batch = [
+                Bezier(_exact_bernstein_from_roots(_well_separated_roots(4), dtype).reshape(-1, 1))
+                for _ in range(3)
+            ]
+            yield Case(
+                GROUP,
+                f"find_roots_batch_{dtype}",
+                find_roots,
+                lambda batch=batch: find_roots(batch),
+                {"n_polys": len(batch), "dtype": str(dtype), "kind": "batch"},
+                invariants=(
+                    custom(
+                        "batch-roots-bounded",
+                        lambda r, batch=batch: _batch_roots_failure(r, batch),
+                    ),
+                ),
+            )
+            mono_batch = [
+                Bezier(_monotone_control_points(4, dtype, sign_change=True)) for _ in range(3)
+            ]
+            yield Case(
+                GROUP,
+                f"find_monotone_root_batch_{dtype}",
+                find_monotone_root,
+                lambda mono_batch=mono_batch: find_monotone_root(mono_batch),
+                {"n_polys": len(mono_batch), "dtype": str(dtype), "kind": "batch"},
+                invariants=(expected_shape((len(mono_batch),)),),
+            )
+
+    # Documented rejections.
+    yield Case(
+        GROUP,
+        "find_roots_wrong_type",
+        find_roots,
+        lambda: find_roots(42),
+        {"kind": "not-a-bezier"},
+    )
+    surface = Bezier(_random_control_points(1, 2, 2, np.dtype(np.float64), offset=13900))
+    yield Case(
+        GROUP,
+        "find_roots_wrong_dim",
+        find_roots,
+        lambda: find_roots(surface),
+        {"kind": "dim-not-1"},
+    )
+    vector_curve = Bezier(_random_control_points(2, 1, 2, np.dtype(np.float64), offset=13901))
+    yield Case(
+        GROUP,
+        "find_roots_wrong_rank",
+        find_roots,
+        lambda: find_roots(vector_curve),
+        {"kind": "rank-not-1"},
+    )
+    scalar_curve = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=13902))
+    yield Case(
+        GROUP,
+        "find_roots_nonpositive_tol",
+        find_roots,
+        lambda: find_roots(scalar_curve, tol=0.0),
+        {"kind": "nonpositive-tol"},
+    )
+    uneven_batch = [
+        Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=13903)),
+        Bezier(_random_control_points(1, 1, 3, np.dtype(np.float64), offset=13904)),
+    ]
+    yield Case(
+        GROUP,
+        "find_roots_batch_uneven_degree",
+        find_roots,
+        lambda: find_roots(uneven_batch),
+        {"kind": "uneven-batch-degree"},
+    )
+
+
+def _monotone_root_failure(
+    result: object, bezier: Bezier, bound: float, *, expect_root: bool
+) -> str | None:
+    """Check a monotone-root result against its expected sentinel/bounded-root behavior.
+
+    Args:
+        result (object): The value returned by ``find_monotone_root``.
+        bezier (Bezier): The curve the root was sought on.
+        bound (float): Residual bound (ignored when ``expect_root`` is ``False``).
+        expect_root (bool): Whether a genuine root is expected.
+
+    Returns:
+        str | None: ``None`` when the result matches expectations, else a message.
+    """
+    if not expect_root:
+        if isinstance(result, float) and math.isnan(result):
+            return None
+        return f"expected NaN, got {result!r}"
+    if not isinstance(result, float) or not (0.0 <= result <= 1.0):
+        return f"root {result!r} not a float in [0, 1]"
+    val = float(np.atleast_1d(bezier.evaluate(np.array([result], dtype=bezier.dtype)))[0])
+    if abs(val) > bound:
+        return f"|f(root)| = {abs(val):.3e} > {bound:.3e}"
+    return None
+
+
+def _batch_roots_failure(
+    result: tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]], batch: Sequence[Bezier]
+) -> str | None:
+    """Check the batch ``find_roots`` result against the count/containment/residual invariant.
+
+    Args:
+        result (tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]): The
+            ``(roots, counts)`` pair returned in batch mode.
+        batch (Sequence[Bezier]): The curves that were searched.
+
+    Returns:
+        str | None: ``None`` when every curve's roots are bounded and genuine,
+        else the first failure message.
+    """
+    roots, counts = result
+    for i, bezier in enumerate(batch):
+        degree = bezier.degree[0]
+        count = int(counts[i])
+        if count > degree:
+            return f"poly {i}: found {count} roots but degree is {degree}"
+        row = roots[i, :count]
+        if count and (np.any(row < 0.0) or np.any(row > 1.0)):
+            return f"poly {i}: root outside [0, 1]: {row}"
+        if count:
+            bound = _bernstein_eval_noise(degree, bezier.dtype, bezier.control_points[:, 0])
+            vals = np.atleast_1d(bezier.evaluate(row.astype(bezier.dtype)))
+            worst = float(np.max(np.abs(vals)))
+            if worst > bound:
+                return f"poly {i}: max|f(root)| = {worst:.3e} > {bound:.3e}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Reverse, permute, transform
+# ---------------------------------------------------------------------------
+
+
+def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.reverse`, ``permute_directions``, and ``transform`` cases.
+
+    Invariant 9: applying ``reverse``/``permute_directions`` twice (with the
+    inverse permutation) reproduces the original control points bit for bit.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile reverse/permute/transform.
+    """
+    combos = _rank_dim_combos(profile)[:3] if profile is Profile.FULL else ((1, 2),)
+    for dtype in dtypes(profile):
+        for rank, dim in combos:
+            for degree in (1, 3) if profile is Profile.FULL else (1,):
+                cp = _random_control_points(rank, dim, degree, dtype, offset=14000 + degree)
+                bezier = Bezier(cp)
+                directions = range(dim) if profile is Profile.FULL else (0,)
+                for direction in directions:
+                    yield Case(
+                        GROUP,
+                        f"reverse_twice_r{rank}d{dim}p{degree}_{dtype}_dir{direction}",
+                        Bezier.reverse,
+                        lambda bezier=bezier, direction=direction: bezier.reverse(
+                            direction
+                        ).reverse(direction),
+                        {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
+                        invariants=(_double_op_identity_invariant(cp),),
+                        arrays={"control_points": cp},
+                    )
+                    fresh = Bezier(cp.copy())
+                    yield Case(
+                        GROUP,
+                        f"reverse_in_place_returns_none_r{rank}d{dim}_{dtype}_dir{direction}",
+                        Bezier.reverse,
+                        lambda fresh=fresh, direction=direction: fresh.reverse(
+                            direction, in_place=True
+                        ),
+                        {"rank": rank, "dim": dim, "direction": direction, "kind": "in-place"},
+                        invariants=(
+                            custom(
+                                "in-place-returns-none",
+                                lambda r: None if r is None else f"expected None, got {r!r}",
+                            ),
+                        ),
+                    )
+
+                if dim >= 2:  # noqa: PLR2004
+                    perm = list(range(dim))
+                    perm[0], perm[-1] = perm[-1], perm[0]
+                    yield Case(
+                        GROUP,
+                        f"permute_twice_r{rank}d{dim}p{degree}_{dtype}",
+                        Bezier.permute_directions,
+                        lambda bezier=bezier, perm=perm: bezier.permute_directions(
+                            perm
+                        ).permute_directions(perm),
+                        {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
+                        invariants=(_double_op_identity_invariant(cp),),
+                        arrays={"control_points": cp},
+                    )
+                    fresh_perm = Bezier(cp.copy())
+                    yield Case(
+                        GROUP,
+                        f"permute_in_place_returns_none_r{rank}d{dim}_{dtype}",
+                        Bezier.permute_directions,
+                        lambda fresh_perm=fresh_perm, perm=perm: fresh_perm.permute_directions(
+                            perm, in_place=True
+                        ),
+                        {"rank": rank, "dim": dim, "kind": "in-place"},
+                        invariants=(
+                            custom(
+                                "in-place-returns-none",
+                                lambda r: None if r is None else f"expected None, got {r!r}",
+                            ),
+                        ),
+                    )
+
+                identity = AffineTransform.identity(rank)
+                yield Case(
+                    GROUP,
+                    f"transform_identity_r{rank}d{dim}p{degree}_{dtype}",
+                    Bezier.transform,
+                    lambda bezier=bezier, identity=identity: bezier.transform(identity),
+                    {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
+                    invariants=(
+                        custom(
+                            "identity-transform-is-noop",
+                            lambda r, cp=cp: None
+                            if np.array_equal(r.control_points, cp)
+                            else "identity transform changed the control points",
+                        ),
+                    ),
+                    arrays={"control_points": cp},
+                )
+                fresh_transform = Bezier(cp.copy())
+                yield Case(
+                    GROUP,
+                    f"transform_in_place_returns_none_r{rank}d{dim}_{dtype}",
+                    Bezier.transform,
+                    lambda fresh_transform=fresh_transform, identity=identity: (
+                        fresh_transform.transform(identity, in_place=True)
+                    ),
+                    {"rank": rank, "dim": dim, "kind": "in-place"},
+                    invariants=(
+                        custom(
+                            "in-place-returns-none",
+                            lambda r: None if r is None else f"expected None, got {r!r}",
+                        ),
+                    ),
+                )
+
+                if profile is Profile.FULL:
+                    singular = AffineTransform(np.zeros((rank, rank)), np.zeros(rank))
+                    yield Case(
+                        GROUP,
+                        f"transform_singular_matrix_r{rank}d{dim}_{dtype}",
+                        Bezier.transform,
+                        lambda bezier=bezier, singular=singular: bezier.transform(singular),
+                        {"rank": rank, "dim": dim, "kind": "singular-matrix"},
+                        arrays={"control_points": cp},
+                    )
+
+    cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=14900)
+    bezier_1d = Bezier(cp_1d)
+    yield Case(
+        GROUP,
+        "reverse_direction_out_of_range",
+        Bezier.reverse,
+        lambda: bezier_1d.reverse(3),
+        {"kind": "direction-out-of-range"},
+    )
+    cp_2d = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=14901)
+    bezier_2d = Bezier(cp_2d)
+    yield Case(
+        GROUP,
+        "permute_invalid_permutation",
+        Bezier.permute_directions,
+        lambda: bezier_2d.permute_directions([0, 0]),
+        {"kind": "invalid-permutation"},
+    )
+    yield Case(
+        GROUP,
+        "transform_dimension_mismatch",
+        Bezier.transform,
+        lambda: bezier_2d.transform(AffineTransform.identity(3)),
+        {"kind": "dimension-mismatch"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice, boundary, collapse
+# ---------------------------------------------------------------------------
+
+
+def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.slice` and ``boundary`` cases.
+
+    Invariant 10: ``boundary(axis, side)`` agrees with ``slice(axis, 0.0 or 1.0)``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile slice/boundary.
+    """
+    for dtype in dtypes(profile):
+        for rank, dim in ((1, 2), (2, 2), (1, 3)) if profile is Profile.FULL else ((1, 2),):
+            for degree in (2, 15) if profile is Profile.FULL else (2,):
+                cp = _random_control_points(rank, dim, degree, dtype, offset=15000 + degree)
+                bezier = Bezier(cp)
+                slice_values = (0.0, 0.5, 1.0) if profile is Profile.FULL else (0.5,)
+                for value in slice_values:
+                    yield Case(
+                        GROUP,
+                        f"slice_r{rank}d{dim}p{degree}_{dtype}_v{value:g}",
+                        Bezier.slice,
+                        lambda bezier=bezier, value=value: bezier.slice(0, value),
+                        {
+                            "rank": rank,
+                            "dim": dim,
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "value": value,
+                        },
+                        arrays={"control_points": cp},
+                    )
+                for side in (0, 1):
+                    yield Case(
+                        GROUP,
+                        f"boundary_matches_slice_r{rank}d{dim}p{degree}_{dtype}_s{side}",
+                        Bezier.boundary,
+                        lambda bezier=bezier, side=side: bezier.boundary(0, side),
+                        {
+                            "rank": rank,
+                            "dim": dim,
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "side": side,
+                        },
+                        invariants=(
+                            custom(
+                                "boundary-matches-slice",
+                                lambda r, bezier=bezier, side=side: _boundary_matches_slice(
+                                    r, bezier, side
+                                ),
+                            ),
+                        ),
+                        arrays={"control_points": cp},
+                    )
+
+    cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=15900)
+    bezier_1d = Bezier(cp_1d)
+    yield Case(
+        GROUP,
+        "slice_value_out_of_range",
+        Bezier.slice,
+        lambda: bezier_1d.slice(0, 1.5),
+        {"kind": "value-out-of-range"},
+    )
+    yield Case(
+        GROUP,
+        "slice_axis_out_of_range",
+        Bezier.slice,
+        lambda: bezier_1d.slice(2, 0.5),
+        {"kind": "axis-out-of-range"},
+    )
+    yield Case(
+        GROUP,
+        "boundary_invalid_side",
+        Bezier.boundary,
+        lambda: bezier_1d.boundary(0, 2),
+        {"kind": "invalid-side"},
+    )
+
+
+def _boundary_matches_slice(result: object, bezier: Bezier, side: int) -> str | None:
+    """Check that ``boundary`` and the corresponding ``slice`` agree.
+
+    Args:
+        result (object): The value returned by ``boundary(axis, side)``.
+        bezier (Bezier): The Bezier the boundary was extracted from.
+        side (int): ``0`` or ``1``, the domain end that was extracted.
+
+    Returns:
+        str | None: ``None`` when they agree exactly, else a message.
+    """
+    reference = bezier.slice(0, float(side))
+    if isinstance(result, Bezier) and isinstance(reference, Bezier):
+        if np.array_equal(result.control_points, reference.control_points):
+            return None
+        return "boundary(axis, side) differs from slice(axis, 0.0 or 1.0)"
+    if isinstance(result, np.ndarray) and isinstance(reference, np.ndarray):
+        if np.array_equal(result, reference):
+            return None
+        return "boundary(axis, side) differs from slice(axis, 0.0 or 1.0)"
+    return f"boundary/slice returned mismatched types: {type(result)} vs {type(reference)}"
+
+
+def _collapse_along_axis_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.collapse_along_axis` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile collapse.
+    """
+    for dtype in dtypes(profile):
+        for rank, dim in ((1, 2), (2, 3)) if profile is Profile.FULL else ((1, 2),):
+            for degree in (2, 15) if profile is Profile.FULL else (2,):
+                cp = _random_control_points(rank, dim, degree, dtype, offset=16000 + degree)
+                bezier = Bezier(cp)
+                value_families = (
+                    ([0.0] * (dim - 1), [1.0] * (dim - 1), [0.5] * (dim - 1))
+                    if profile is Profile.FULL
+                    else ([0.5] * (dim - 1),)
+                )
+                for values in value_families:
+                    tag = "_".join(f"{v:g}" for v in values)
+                    yield Case(
+                        GROUP,
+                        f"collapse_r{rank}d{dim}p{degree}_{dtype}_v{tag}",
+                        Bezier.collapse_along_axis,
+                        lambda bezier=bezier, values=values: bezier.collapse_along_axis(0, values),
+                        {
+                            "rank": rank,
+                            "dim": dim,
+                            "degree": degree,
+                            "dtype": str(dtype),
+                            "values": values,
+                        },
+                        invariants=(
+                            custom(
+                                "collapse-degree-preserved",
+                                lambda r, degree=degree: None
+                                if r.degree == (degree,)
+                                else f"got degree {r.degree}, expected {(degree,)}",
+                            ),
+                        ),
+                        arrays={"control_points": cp},
+                    )
+
+    cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=16900)
+    bezier_1d = Bezier(cp_1d)
+    yield Case(
+        GROUP,
+        "collapse_requires_dim_2",
+        Bezier.collapse_along_axis,
+        lambda: bezier_1d.collapse_along_axis(0, []),
+        {"kind": "dim-less-than-2"},
+    )
+    cp_2d = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=16901)
+    bezier_2d = Bezier(cp_2d)
+    yield Case(
+        GROUP,
+        "collapse_values_length_mismatch",
+        Bezier.collapse_along_axis,
+        lambda: bezier_2d.collapse_along_axis(0, [0.2, 0.3]),
+        {"kind": "values-length-mismatch"},
+    )
+    yield Case(
+        GROUP,
+        "collapse_value_out_of_range",
+        Bezier.collapse_along_axis,
+        lambda: bezier_2d.collapse_along_axis(0, [1.5]),
+        {"kind": "value-out-of-range"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# B-spline round trip
+# ---------------------------------------------------------------------------
+
+
+def _to_bspline_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`~pantr.bezier.Bezier.to_bspline` / ``create_from_bspline`` round trips.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile round trip.
+    """
+    combos = (
+        _rank_dim_combos(profile)[:3] if profile is Profile.FULL else _rank_dim_combos(profile)[:1]
+    )
+    for dtype in dtypes(profile):
+        for rank, dim in combos:
+            for degree in (0, 1, 3) if profile is Profile.FULL else (1,):
+                cp = _random_control_points(rank, dim, degree, dtype, offset=17000 + degree)
+                bezier = Bezier(cp)
+                yield Case(
+                    GROUP,
+                    f"to_bspline_roundtrip_r{rank}d{dim}p{degree}_{dtype}",
+                    Bezier.to_bspline,
+                    lambda bezier=bezier: create_from_bspline(bezier.to_bspline()),
+                    {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
+                    invariants=(
+                        custom(
+                            "roundtrip-bit-exact",
+                            lambda r, cp=cp: None
+                            if np.array_equal(r.control_points, cp)
+                            else "to_bspline/create_from_bspline round trip is not bit-identical",
+                        ),
+                    ),
+                    arrays={"control_points": cp},
+                )
+
+    non_bezier_space = BsplineSpace(
+        [BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float64), 2)]
+    )
+    non_bezier_bspline = Bspline(
+        non_bezier_space, np.linspace(0.0, 1.0, 4, dtype=np.float64).reshape(-1, 1)
+    )
+    yield Case(
+        GROUP,
+        "create_from_bspline_not_bezier_like",
+        create_from_bspline,
+        lambda: create_from_bspline(non_bezier_bspline),
+        {"kind": "not-bezier-like-knots"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interpolation and fitting
+# ---------------------------------------------------------------------------
+
+
+def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`~pantr.bezier.interpolate_bezier` and :func:`~pantr.bezier.fit_bezier` cases.
+
+    The oracle is a known low-degree polynomial (``t**k``), evaluated directly
+    by NumPy at the interpolation nodes -- an independent construction, not a
+    mirror of the interpolation algorithm. Exact reproduction is expected
+    whenever ``degree >= k``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile interpolation or fit.
+    """
+    for dtype_name in ("float64",) if profile is not Profile.FULL else ("float64", "float32"):
+        for n_pts in (1, 2, 5, 16) if profile is Profile.FULL else (5,):
+            k = min(2, n_pts - 1)
+
+            def func(lattice: PointsLattice, k: int = k) -> npt.NDArray[np.floating[Any]]:
+                pts = lattice.get_all_points()[:, 0]
+                return np.asarray(pts, dtype=np.float64) ** k
+
+            yield Case(
+                GROUP,
+                f"interpolate_exact_monomial_n{n_pts}_k{k}_{dtype_name}",
+                interpolate_bezier,
+                lambda n_pts=n_pts: interpolate_bezier(func, n_pts),
+                {"n_pts": n_pts, "k": k, "dtype": dtype_name},
+                invariants=(
+                    custom(
+                        "interpolate-reproduces-monomial",
+                        lambda r, k=k: _monomial_reproduction_failure(r, k),
+                    ),
+                ),
+            )
+
+            if profile is Profile.FULL and n_pts >= 3:  # noqa: PLR2004
+                low_degree = max(n_pts - 2, 0)
+                yield Case(
+                    GROUP,
+                    f"interpolate_least_squares_n{n_pts}_deg{low_degree}",
+                    interpolate_bezier,
+                    lambda n_pts=n_pts, low_degree=low_degree: interpolate_bezier(
+                        func, n_pts, degree=low_degree
+                    ),
+                    {"n_pts": n_pts, "degree": low_degree, "kind": "least-squares"},
+                )
+
+    monomial_invariant_k2 = custom(
+        "fit-reproduces-monomial", lambda r: _monomial_reproduction_failure(r, 2)
+    )
+    for nodes_kind in ("chebyshev", "uniform") if profile is Profile.FULL else ("chebyshev",):
+        n_pts = 6
+        node_arr = np.linspace(0.0, 1.0, n_pts, dtype=np.float64)
+        values = node_arr**2
+        yield Case(
+            GROUP,
+            f"fit_bezier_tensor_product_{nodes_kind}",
+            fit_bezier,
+            lambda values=values, node_arr=node_arr: fit_bezier(values, node_arr),
+            {"n_pts": n_pts, "nodes": nodes_kind},
+            invariants=(monomial_invariant_k2,),
+        )
+
+    generator = rng(18000)
+    scattered_pts = generator.uniform(0.0, 1.0, (12, 1))
+    scattered_values = scattered_pts[:, 0] ** 2
+    yield Case(
+        GROUP,
+        "fit_bezier_scattered",
+        fit_bezier,
+        lambda: fit_bezier(scattered_values, scattered_pts, degree=3),
+        {"n_pts": 12, "degree": 3, "kind": "scattered"},
+        invariants=(monomial_invariant_k2,),
+        arrays={"pts": scattered_pts, "values": scattered_values},
+    )
+
+    yield Case(
+        GROUP,
+        "fit_bezier_scattered_missing_degree",
+        fit_bezier,
+        lambda: fit_bezier(scattered_values, scattered_pts),
+        {"kind": "scattered-missing-degree"},
+    )
+    yield Case(
+        GROUP,
+        "interpolate_degree_exceeds_npts",
+        interpolate_bezier,
+        lambda: interpolate_bezier(func, 4, degree=5),
+        {"kind": "degree-exceeds-n_pts"},
+    )
+    yield Case(
+        GROUP,
+        "interpolate_bad_return_shape",
+        interpolate_bezier,
+        lambda: interpolate_bezier(lambda lattice: np.zeros(3), 5),
+        {"kind": "bad-return-shape"},
+    )
+
+
+def _monomial_reproduction_failure(result: object, k: int) -> str | None:
+    """Check that an interpolated/fitted Bezier reproduces ``t**k`` exactly.
+
+    Args:
+        result (object): The Bezier returned by ``interpolate_bezier``/``fit_bezier``.
+        k (int): The monomial power the sample values were drawn from.
+
+    Returns:
+        str | None: ``None`` when the reproduction is within the SVD/rounding
+        floor, else a message.
+    """
+    if not isinstance(result, Bezier):
+        return f"expected Bezier, got {type(result).__name__}"
+    if result.degree[0] < k:
+        return None  # least-squares path: exact reproduction is not expected
+    ts = np.array([0.1, 0.4, 0.6, 0.9], dtype=result.dtype)
+    expected = ts.astype(np.float64) ** k
+    got = np.asarray(result.evaluate(ts), dtype=np.float64)
+    eps = get_machine_epsilon(result.dtype)
+    # Truncated-SVD recovery accumulates O(degree) rounding on top of the
+    # conditioning of the Bernstein Vandermonde system; a generous factor of
+    # 1e3 covers both without masking a genuine failure to reproduce.
+    tol = 1.0e3 * eps * max(float(np.max(np.abs(expected))), 1.0)
+    worst = float(np.max(np.abs(got - expected)))
+    if worst > tol:
+        return f"max|delta| = {worst:.3e} > {tol:.3e}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Direct kernel/helper probes
+# ---------------------------------------------------------------------------
+
+
+def _de_casteljau_kernel_cases(profile: Profile) -> Iterator[Case]:
+    """Yield direct probes of ``_de_casteljau_eval_scalar``.
+
+    This Numba kernel performs no input validation whatsoever, per its own
+    docstring. A length-0 ``coeff`` is the sharpest boundscheck target: the
+    algorithm reads ``coeff[0]`` unconditionally.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile kernel call.
+    """
+    for dtype in dtypes(profile):
+        for length, name in ((0, "len0"), (1, "len1"), (63, "len63")):
+            coeff = np.linspace(-1.0, 1.0, length, dtype=dtype)
+            yield Case(
+                GROUP,
+                f"de_casteljau_{name}_{dtype}",
+                _de_casteljau_eval_scalar,
+                lambda coeff=coeff: _de_casteljau_eval_scalar(coeff, 0.5),
+                {"length": length, "dtype": str(dtype), "t": 0.5},
+                arrays={"coeff": coeff},
+            )
+
+        coeff5 = np.linspace(-1.0, 1.0, 5, dtype=dtype)
+        for t, finite in ((-5.0, True), (5.0, True), (float("nan"), False), (float("inf"), False)):
+            yield Case(
+                GROUP,
+                f"de_casteljau_t{t}_{dtype}",
+                _de_casteljau_eval_scalar,
+                lambda coeff5=coeff5, t=t: _de_casteljau_eval_scalar(coeff5, t),
+                {"t": t, "dtype": str(dtype)},
+                finite_inputs=finite,
+                arrays={"coeff": coeff5},
+            )
+
+
+def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
+    """Yield direct probes of ``_bernstein_interpolate``.
+
+    This Layer 2 helper performs no input validation either; it is exercised
+    here with the shapes and value families the module docstring flags.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile kernel call.
+    """
+    for dtype in dtypes(profile):
+        shapes = (
+            (((1,), "shape1"), ((2,), "shape2"), ((63,), "shape63"))
+            if profile is Profile.FULL
+            else (((1,), "shape1"), ((2,), "shape2"))
+        )
+        for shape, name in shapes:
+            f = np.linspace(0.1, 1.0, shape[0], dtype=dtype)
+            yield Case(
+                GROUP,
+                f"bernstein_interpolate_{name}_{dtype}",
+                _bernstein_interpolate,
+                lambda f=f: _bernstein_interpolate(f),
+                {"shape": shape, "dtype": str(dtype)},
+                arrays={"f": f},
+            )
+
+        zeros = np.zeros(8, dtype=dtype)
+        yield Case(
+            GROUP,
+            f"bernstein_interpolate_zeros_{dtype}",
+            _bernstein_interpolate,
+            lambda zeros=zeros: _bernstein_interpolate(zeros),
+            {"kind": "all-zeros", "dtype": str(dtype)},
+        )
+
+        if profile is Profile.FULL:
+            outlier = np.full(8, 1e-3, dtype=dtype)
+            outlier[3] = 1e9
+            yield Case(
+                GROUP,
+                f"bernstein_interpolate_outlier_{dtype}",
+                _bernstein_interpolate,
+                lambda outlier=outlier: _bernstein_interpolate(outlier),
+                {"kind": "huge-outlier-among-tiny", "dtype": str(dtype)},
+                arrays={"f": outlier},
+            )
+
+        nan_f = np.linspace(0.0, 1.0, 8, dtype=dtype)
+        nan_f[4] = np.nan
+        yield Case(
+            GROUP,
+            f"bernstein_interpolate_nan_{dtype}",
+            _bernstein_interpolate,
+            lambda nan_f=nan_f: _bernstein_interpolate(nan_f),
+            {"kind": "nan", "dtype": str(dtype)},
+            finite_inputs=False,
+            arrays={"f": nan_f},
+        )
+
+        f_2d = rng(19000).uniform(0.0, 1.0, (5, 4)).astype(dtype)
+        yield Case(
+            GROUP,
+            f"bernstein_interpolate_2d_{dtype}",
+            _bernstein_interpolate,
+            lambda f_2d=f_2d: _bernstein_interpolate(f_2d),
+            {"shape": (5, 4), "dtype": str(dtype)},
+            arrays={"f": f_2d},
+        )
+
+        if profile is Profile.FULL:
+            f_3d = rng(19001).uniform(0.0, 1.0, (3, 3, 3)).astype(dtype)
+            yield Case(
+                GROUP,
+                f"bernstein_interpolate_3d_{dtype}",
+                _bernstein_interpolate,
+                lambda f_3d=f_3d: _bernstein_interpolate(f_3d),
+                {"shape": (3, 3, 3), "dtype": str(dtype)},
+                arrays={"f": f_3d},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Coefficient-family sanity crossing (partition-independent construction/eval)
+# ---------------------------------------------------------------------------
+
+
+def _coeff_family_cases(profile: Profile) -> Iterator[Case]:
+    """Yield evaluate cases crossed with :func:`~._axes.coeff_specs` control-point families.
+
+    Covers random, all-identical (degenerate/collapsed geometry), collinear,
+    all-zero, and at-the-zero-threshold control points -- families the rest of
+    this module does not otherwise exercise, since they are built from
+    ``coeff_specs`` rather than :func:`_random_control_points`.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile evaluate call.
+    """
+    for dtype in dtypes(profile):
+        for degree in (1, 3, 15) if profile is Profile.FULL else (1,):
+            shape = (degree + 1, 2)
+            for spec in coeff_specs(shape, dtype, profile, offset=20000 + degree):
+                bezier = Bezier(spec.values)
+                pts = np.array([0.0, 0.3, 0.7, 1.0], dtype=dtype)
+                yield Case(
+                    GROUP,
+                    f"coeff_family_{spec.name}_p{degree}_{dtype}",
+                    Bezier.evaluate,
+                    lambda bezier=bezier, pts=pts: bezier.evaluate(pts),
+                    {"degree": degree, "dtype": str(dtype), "family": spec.name},
+                    arrays={"control_points": spec.values},
+                )
+
+
+# ---------------------------------------------------------------------------
+# Rational-specific edge cases
+# ---------------------------------------------------------------------------
+
+
+def _rational_weight_cases(profile: Profile) -> Iterator[Case]:
+    """Yield evaluate cases probing degenerate rational weights.
+
+    A zero, negative, or near-threshold weight is neither validated by the
+    constructor nor documented as rejected by ``evaluate`` -- so whatever
+    happens (a rejection, a finite answer, or an ``inf``/``NaN``) is worth
+    recording rather than assuming.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile rational evaluation.
+    """
+    for dtype in dtypes(profile):
+        degree = 3
+        base = rng(21000).uniform(-1.0, 1.0, (degree + 1, 2)).astype(dtype)
+        pts = np.array([0.2, 0.5, 0.8], dtype=dtype)
+
+        for weight_name, weight_value in (
+            ("zero", 0.0),
+            ("negative", -1.0),
+            ("near_threshold", get_default(dtype)),
+        ):
+            cp = np.concatenate([base, np.ones((degree + 1, 1), dtype=dtype)], axis=-1)
+            cp[1, -1] = dtype.type(weight_value)
+            bezier = Bezier(cp, is_rational=True)
+            yield Case(
+                GROUP,
+                f"rational_weight_{weight_name}_{dtype}",
+                Bezier.evaluate,
+                lambda bezier=bezier, pts=pts: bezier.evaluate(pts),
+                {"weight": weight_name, "dtype": str(dtype)},
+                finite_inputs=False,
+                arrays={"control_points": cp},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _construct_cases(profile)
+    yield from _evaluate_cases(profile)
+    yield from _evaluate_derivatives_cases(profile)
+    yield from _elevate_degree_cases(profile)
+    yield from _reduce_degree_cases(profile)
+    yield from _degree_reduction_error_cases(profile)
+    yield from _minimize_degree_cases(profile)
+    yield from _split_cases(profile)
+    yield from _restrict_cases(profile)
+    yield from _compose_cases(profile)
+    yield from _multiply_cases(profile)
+    yield from _derivative_cases(profile)
+    yield from _root_finding_cases(profile)
+    yield from _reverse_permute_transform_cases(profile)
+    yield from _slice_boundary_cases(profile)
+    yield from _collapse_along_axis_cases(profile)
+    yield from _to_bspline_cases(profile)
+    yield from _interpolate_fit_cases(profile)
+    yield from _de_casteljau_kernel_cases(profile)
+    yield from _bernstein_interpolate_kernel_cases(profile)
+    yield from _coeff_family_cases(profile)
+    yield from _rational_weight_cases(profile)

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -103,6 +103,17 @@ the values being compared and the check would assert nothing.
 _PAIR: Final = 2
 """Length of the ``(basis, first_basis)`` and ``(left, right)`` two-returns checked here."""
 
+_ILLEGAL_KNOT_FAMILIES: Final = frozenset({"unsorted", "with_nan", "too_short"})
+"""Knot families from :func:`adversarial_sweep._axes.knot_specs` that must be refused.
+
+Each violates a stated precondition: not non-decreasing, not finite, or shorter than
+``2 * degree + 2``. They are flagged ``must_reject`` so that an entry point which quietly
+started *accepting* one would be a finding rather than an ``OK``. ``all_equal`` is
+deliberately absent: a knot vector of identical values is non-decreasing and long enough,
+so it is legal, and it builds a degenerate space with an empty domain. So is
+``over_clamped_left``, which merely exceeds the usual boundary multiplicity.
+"""
+
 _BINCOEFF_SAFE_DEGREE: Final = 61
 """Highest combined degree at which ``_bincoeff``'s exact-integer recurrence is sound.
 
@@ -362,6 +373,13 @@ def _reproduces(
 ) -> Predicate:
     """Build a predicate requiring a derived spline to reproduce a reference pointwise.
 
+    The reference is evaluated **inside** the predicate, not here. Evaluating it at
+    build time puts a pantr call in a generator body, where an exception aborts
+    enumeration instead of being classified -- which is exactly what happened while this
+    module was being written: a periodic float32 spline whose degree elevation silently
+    returned float64 made the reference reject the float32 sample points and truncated a
+    13341-case run.
+
     Args:
         reference (Bspline): The spline whose values the result must reproduce.
         pts (npt.NDArray[np.floating[Any]]): Parameters at which to compare.
@@ -370,11 +388,16 @@ def _reproduces(
     Returns:
         Predicate: Check for :func:`adversarial_sweep._core.custom`.
     """
-    expected = np.asarray(reference.evaluate(pts), dtype=np.float64)
 
     def predicate(result: object) -> str | None:
         if not isinstance(result, Bspline | Bezier):
             return f"expected a spline, got {type(result).__name__}"
+        if np.dtype(result.dtype) != np.dtype(reference.dtype):
+            return (
+                f"dtype changed: reference is {np.dtype(reference.dtype).name}, "
+                f"result is {np.dtype(result.dtype).name}"
+            )
+        expected = np.asarray(reference.evaluate(pts), dtype=np.float64)
         got = np.asarray(result.evaluate(pts.astype(result.dtype)), dtype=np.float64)
         if got.shape != expected.shape:
             return f"shape {got.shape} != reference {expected.shape}"
@@ -722,14 +745,16 @@ def _product_agreement(
     Returns:
         Predicate: Check for :func:`adversarial_sweep._core.custom`.
     """
-    values = np.asarray(scalar.evaluate(pts), dtype=np.float64)
-    expected = values * values
-    scale = max(float(np.max(np.abs(values))) if values.size else 1.0, 1.0)
-    tol = _fixture_tolerance(fixture, scale) * scale
 
     def predicate(result: object) -> str | None:
         if not isinstance(result, Bspline):
             return f"expected a Bspline, got {type(result).__name__}"
+        # Evaluated here rather than at build time, so a factor that refuses to evaluate
+        # is classified as a finding instead of aborting enumeration.
+        values = np.asarray(scalar.evaluate(pts), dtype=np.float64)
+        expected = values * values
+        scale = max(float(np.max(np.abs(values))) if values.size else 1.0, 1.0)
+        tol = _fixture_tolerance(fixture, scale) * scale
         got = np.asarray(result.evaluate(pts.astype(result.dtype)), dtype=np.float64)
         if got.shape != expected.shape:
             return f"shape {got.shape} != pointwise product {expected.shape}"
@@ -764,6 +789,41 @@ def _bitwise_control_points(expected: npt.NDArray[np.floating[Any]]) -> Predicat
         if not np.array_equal(got, expected):
             worst = float(np.max(np.abs(got.astype(np.float64) - expected.astype(np.float64))))
             return f"control points not restored bitwise, max|diff| = {worst:.3e}"
+        return None
+
+    return predicate
+
+
+def _interval_count(expected: int, degree: int) -> Predicate:
+    """Build a predicate requiring a knot vector to carry the requested interval count.
+
+    Counted **inside the domain** ``[knots[degree], knots[-degree-1]]``, which is the only
+    definition that fits all three factories: a periodic or cardinal vector deliberately
+    extends ``degree`` further spans beyond each end, so counting spans across the whole
+    array would report ``1 + 2 * degree`` for a one-interval request and flag correct
+    behavior. This is the weakest reading of what the factories promise, and it is the one
+    that separates them at ``n = 0``.
+
+    Args:
+        expected (int): Number of intervals requested.
+        degree (int): Polynomial degree, which locates the domain within the vector.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+
+    def predicate(result: object) -> str | None:
+        knots = np.asarray(result, dtype=np.float64).ravel()
+        if not np.all(np.isfinite(knots)):
+            bad = int(np.count_nonzero(~np.isfinite(knots)))
+            return f"{bad}/{knots.size} non-finite knots: {knots.tolist()}"
+        if knots.size < 2 * degree + 2:
+            return f"{knots.size} knots is below the minimum {2 * degree + 2}: {knots.tolist()}"
+        lo, hi = knots[degree], knots[knots.size - degree - 1]
+        inside = np.unique(knots[(knots >= lo) & (knots <= hi)])
+        got = int(inside.size) - 1
+        if got != expected:
+            return f"asked for {expected} intervals, domain has {got}: {knots.tolist()}"
         return None
 
     return predicate
@@ -1069,6 +1129,7 @@ def _construction_cases(profile: Profile) -> Iterator[Case]:
                         "dtype": dtype,
                         "domain": list(domain),
                     }
+                    illegal = spec.name in _ILLEGAL_KNOT_FAMILIES
                     yield Case(
                         GROUP,
                         f"space1d_{spec.name}_{tag}",
@@ -1077,6 +1138,7 @@ def _construction_cases(profile: Profile) -> Iterator[Case]:
                             spec.knots, degree, periodic=spec.periodic
                         ),
                         params,
+                        must_reject=illegal,
                         arrays={"knots": np.asarray(spec.knots)},
                     )
                     if profile is not Profile.FULL:
@@ -1091,6 +1153,7 @@ def _construction_cases(profile: Profile) -> Iterator[Case]:
                             spec.knots, degree, periodic=spec.periodic, snap_knots=False
                         ),
                         {**params, "snap_knots": False},
+                        must_reject=illegal,
                     )
 
 
@@ -1837,18 +1900,32 @@ def _factory_cases(profile: Profile) -> Iterator[Case]:
                     params,
                     invariants=(custom("knots-non-decreasing", _non_decreasing),),
                 )
-                # Zero and one interval: the count corners the factories must either
-                # accept cleanly or reject.
-                for n_intervals in (0, 1):
-                    yield Case(
-                        GROUP,
-                        f"uniform_open_knots_{tag}_n{n_intervals}",
-                        create_uniform_open_knots,
-                        lambda degree=degree, n=n_intervals, domain=domain, dtype=dtype: (
-                            create_uniform_open_knots(n, degree, domain=domain, dtype=dtype)
-                        ),
-                        {**params, "n_intervals": n_intervals},
-                    )
+                # The count corners. `must_reject` is deliberately *not* used for zero:
+                # `create_uniform_open_knots` documents `num_intervals` as "must be
+                # non-negative", so refusing it is not the contract. What is asserted
+                # instead is that whatever comes back is a usable knot vector with the
+                # requested number of intervals -- which is where the three factories
+                # part company (see `_interval_count`).
+                for factory in (
+                    create_uniform_open_knots,
+                    create_uniform_periodic_knots,
+                    create_cardinal_knots,
+                ):
+                    for n_intervals in (0, 1):
+                        yield Case(
+                            GROUP,
+                            f"{factory.__name__}_{tag}_n{n_intervals}",
+                            factory,
+                            lambda factory=factory, degree=degree, n=n_intervals, dtype=dtype: (
+                                factory(n, degree, dtype=dtype)
+                            ),
+                            {**params, "n_intervals": n_intervals, "factory": factory.__name__},
+                            invariants=(
+                                custom("knots-non-decreasing", _non_decreasing),
+                                custom("interval-count", _interval_count(n_intervals, degree)),
+                            ),
+                            must_succeed=n_intervals == 1,
+                        )
 
     if profile is not Profile.FULL:
         return
@@ -1982,6 +2059,7 @@ def _thb_cases(profile: Profile) -> Iterator[Case]:
                     type(space).refine,
                     lambda space=space: space.refine([space.grid.num_cells]),
                     params,
+                    must_reject=True,
                 )
 
 

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -1,0 +1,2004 @@
+"""Probes for the B-spline space, spline, extraction and THB-spline surface.
+
+This is the group the sweep weights heaviest, for one reason: **an interior knot at
+multiplicity ``degree + 1``** -- a discontinuous, C^-1 spline -- is a documented public
+construction (``BsplineSpace1D.subdivide(n, regularity=-1)``) that several algorithms in
+this package silently assume away. So the shape of this module is deliberately not
+"one crossing per entry point": it builds a compact set of *spline fixtures* spanning
+the multiplicity ladder, the degree corners, both dtypes and the domain-magnitude axis,
+and then pushes **every** operation that takes a spline through each of them. An
+operation that only breaks on a C^-1 operand is invisible to a per-operation sweep and
+obvious to this one.
+
+The other axes are folded in where they bite:
+
+* **degree** 0 (a repeated defect source here), 1, 2, 3, 15, and 62 -- the exact point
+  where ``_bincoeff``'s integer recurrence wraps int64.
+* **knot magnitude**, through the domain axis: ``BsplineSpace1D``'s knot-snapping
+  tolerance is *absolute*, so from ``|knot| ~ 5`` upward it merges nothing and the space
+  can silently carry the wrong continuity.
+* **periodic and non-clamped** knot vectors, which have already produced a genuinely
+  negative index and a span search running off the front of the array.
+* **dtype**, because several kernels hardwire a double epsilon while accepting float32.
+
+Invariants asserted here are only ones the code or its docstrings actually claim:
+degree elevation and knot insertion leave the map pointwise unchanged, splitting and
+restriction reproduce the original on their subdomain, ``reduce_degree`` reproduces the
+endpoints *bit for bit* (``_bspline.py:433-436``), a value at an in-domain point lies in
+the convex hull of the control points, the local basis sums to one, ``first_basis`` is a
+valid index, and ``first_basis_per_interval`` is non-decreasing with successive
+differences equal to the interior knot multiplicities (``_bspline_space_1d.py:348-350``).
+
+One trap worth naming: a **non-truncated** hierarchical basis is *not* a partition of
+unity -- only the truncated one is (``_thb_spline_space.py:196-202``) -- so the THB
+probes assert it for ``truncate=True`` alone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import numpy as np
+
+from pantr.bezier import Bezier
+from pantr.bspline import (
+    Bspline,
+    BsplineSpace,
+    BsplineSpace1D,
+    SpanwiseElementExtraction,
+    THBSplineSpace,
+    create_cardinal_knots,
+    create_thb_space,
+    create_uniform_open_knots,
+    create_uniform_periodic_knots,
+    create_uniform_space,
+    find_roots,
+    get_greville_abscissae,
+    interpolate_bspline,
+    quasi_interpolate_bspline,
+)
+from pantr.tolerance import get_machine_epsilon
+
+from ._axes import (
+    Profile,
+    coeff_specs,
+    degrees,
+    dims,
+    domains,
+    dtypes,
+    interior_multiplicities,
+    knot_specs,
+    point_specs,
+    rng,
+)
+from ._core import Case, custom, expected_shape
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy.typing as npt
+
+    Predicate = Callable[[object], str | None]
+    """A bare invariant predicate, before :func:`adversarial_sweep._core.custom` wraps it."""
+
+GROUP = "bspline"
+"""Registry name of this probe group."""
+
+_ERROR_SAFETY_FACTOR: Final = 8.0
+"""Explicit safety factor absorbing the unmodelled constants of de Boor's recurrence.
+
+Every bound below is derived from first principles (see :func:`_eval_tolerance`) and then
+multiplied by this one stated factor. It is fixed and acknowledged rather than tuned per
+call site, so a bound that fails is failing by orders of magnitude, not by a constant.
+"""
+
+_GRAM_CONDITIONED_DEGREE: Final = 6
+"""Highest degree at which the exactly-reducible recovery check is not vacuous.
+
+The Bernstein Gram matrix's condition number grows like ``4 ** degree``, so the honest
+bound on a degree-reduction round trip grows with it; past this degree the bound exceeds
+the values being compared and the check would assert nothing.
+"""
+
+_PAIR: Final = 2
+"""Length of the ``(basis, first_basis)`` and ``(left, right)`` two-returns checked here."""
+
+_BINCOEFF_SAFE_DEGREE: Final = 61
+"""Highest combined degree at which ``_bincoeff``'s exact-integer recurrence is sound.
+
+``_bspline_degree_core.py:22-67`` wraps int64 from ``n = 62``. That overflow is already
+confirmed and logged for ``Bspline.elevate_degree``, ``Bezier.elevate_degree`` and
+``_compose_bezier``, so the degree-elevation probes stay at or below this bound: their
+job is to find something *else*, and a case that only rediscovered the known overflow
+would drown it.
+"""
+
+
+class _Fixture(NamedTuple):
+    """One 1D B-spline space plus the axis values that produced it.
+
+    Attributes:
+        label (str): Identity of the fixture, embedded in every case label built on it.
+        space (BsplineSpace1D): The space itself.
+        degree (int): Polynomial degree.
+        mult (int): Interior knot multiplicity, or ``0`` when the family has no single
+            interior multiplicity (uniform, periodic, minimal).
+        domain (tuple[float, float]): The ``(lo, hi)`` the knots were built on.
+        dtype (np.dtype[np.float32 | np.float64]): Knot precision.
+        params (dict[str, Any]): The axis values, recorded in the journal.
+    """
+
+    label: str
+    space: BsplineSpace1D
+    degree: int
+    mult: int
+    domain: tuple[float, float]
+    dtype: np.dtype[np.float32 | np.float64]
+    params: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Derived tolerances
+# ---------------------------------------------------------------------------
+
+
+def _min_nonzero_span(space: BsplineSpace1D) -> float:
+    """Measure the shortest non-empty knot span of a space.
+
+    Args:
+        space (BsplineSpace1D): The space.
+
+    Returns:
+        float: The shortest positive difference between consecutive knots, or the whole
+            knot range when every span is empty.
+    """
+    knots = np.asarray(space.knots, dtype=np.float64)
+    gaps = np.diff(knots)
+    positive = gaps[gaps > 0.0]
+    if positive.size == 0:
+        return float(abs(knots[-1] - knots[0])) or 1.0
+    return float(np.min(positive))
+
+
+def _eval_tolerance(
+    degree: int,
+    dtype: npt.DTypeLike,
+    value_scale: float,
+    *,
+    coord_scale: float = 1.0,
+    span: float = 1.0,
+) -> float:
+    """Derive the bound on the difference between two evaluations of the same map.
+
+    De Boor's recurrence forms the value as a convex combination through ``degree``
+    stages. Each stage rounds its two products and their sum, so the value carries at
+    most ``3 * degree * eps * value_scale`` of rounding error, and comparing *two*
+    representations of the same map doubles that.
+
+    On top of that sits the conditioning of the parametrization. The stage weights are
+    ``(x - t_i) / (t_j - t_i)``, and two representations of one map (before and after
+    degree elevation, say) hold knots that differ by the rounding of their own
+    construction, about ``eps * coord_scale``. That perturbs each weight by
+    ``eps * coord_scale / span``, which is why a domain translated to ``1e6`` with spans
+    of order one has six orders of magnitude less accuracy available than the unit
+    domain -- an honest statement about the input, not slack for the algorithm.
+
+    Args:
+        degree (int): Polynomial degree, which sets the number of recurrence stages.
+        dtype (npt.DTypeLike): Working precision, which sets machine epsilon. Passing
+            the *actual* dtype matters: a kernel that hardwires a double epsilon while
+            accepting float32 is exactly what this sweep is looking for.
+        value_scale (float): Magnitude of the control points, which the error scales
+            with.
+        coord_scale (float): Magnitude of the parametric coordinates. Defaults to 1.
+        span (float): Shortest non-empty knot span. Defaults to 1.
+
+    Returns:
+        float: The bound.
+    """
+    eps = get_machine_epsilon(dtype)
+    conditioning = max(1.0, abs(coord_scale) / span) if span > 0.0 else 1.0
+    return _ERROR_SAFETY_FACTOR * (degree + 1) * eps * max(value_scale, 1.0) * conditioning
+
+
+def _fixture_tolerance(fixture: _Fixture, value_scale: float) -> float:
+    """Derive the evaluation tolerance for one fixture.
+
+    Args:
+        fixture (_Fixture): The fixture, supplying degree, dtype, domain and spans.
+        value_scale (float): Magnitude of the control points.
+
+    Returns:
+        float: The bound, per :func:`_eval_tolerance`.
+    """
+    lo, hi = fixture.domain
+    return _eval_tolerance(
+        fixture.degree,
+        fixture.dtype,
+        value_scale,
+        coord_scale=max(abs(lo), abs(hi)),
+        span=_min_nonzero_span(fixture.space),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant predicates
+# ---------------------------------------------------------------------------
+
+
+def _basis_of(result: object) -> npt.NDArray[np.floating[Any]] | None:
+    """Extract the basis-value array from a ``(basis, first_basis)`` two-return.
+
+    Args:
+        result (object): Whatever the entry point returned.
+
+    Returns:
+        npt.NDArray[np.floating[Any]] | None: The first element when the result is a
+            pair, else ``None``.
+    """
+    if isinstance(result, tuple) and len(result) == _PAIR:
+        return np.asarray(result[0], dtype=np.float64)
+    return None
+
+
+def _local_partition_of_unity(degree: int, dtype: npt.DTypeLike) -> Predicate:
+    """Build a predicate requiring the local basis values to sum to one.
+
+    Cox-de Boor forms each value as a convex combination, so the ``degree + 1`` locally
+    supported functions sum to one exactly in real arithmetic wherever the point lies in
+    the domain -- for *any* valid knot vector, clamped or not, since the property is
+    local to the span. Summing ``degree + 1`` non-negative values whose exact total is
+    one carries at most ``degree * eps``; each value comes out of a recurrence of depth
+    ``degree``, contributing ``O(degree) * eps`` more, so the product bounds the total by
+    ``(degree + 1) ** 2 * eps``.
+
+    Args:
+        degree (int): Polynomial degree, which sets the term count.
+        dtype (npt.DTypeLike): Working precision, which sets machine epsilon.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    tol = _ERROR_SAFETY_FACTOR * (degree + 1) ** 2 * get_machine_epsilon(dtype)
+
+    def predicate(result: object) -> str | None:
+        basis = _basis_of(result)
+        if basis is None:
+            return f"expected a (basis, first_basis) pair, got {type(result).__name__}"
+        if basis.size == 0:
+            return None
+        sums = np.sum(basis, axis=-1)
+        worst = float(np.max(np.abs(sums - 1.0)))
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|sum(N) - 1| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _first_basis_in_range(num_basis: int, degree: int, *, periodic: bool) -> Predicate:
+    """Build a predicate requiring every returned ``first_basis`` index to be usable.
+
+    ``first_basis`` is what a caller scatters the local block with, so an index that
+    leaves no room for the block means the caller writes out of bounds -- silently, in a
+    Numba kernel. Checking it here is cheaper than discovering it in the port.
+
+    The admissible range differs by knot family. On a clamped or unclamped space the
+    block ``first_basis .. first_basis + degree`` must fit, so the index stops at
+    ``num_basis - degree - 1``. On a **periodic** space the block wraps modulo
+    ``num_basis`` by construction, so any index in ``[0, num_basis - 1]`` is valid and
+    the tighter bound would flag correct behavior.
+
+    Args:
+        num_basis (int): Number of basis functions in the space.
+        degree (int): Polynomial degree, which sets the local block width.
+        periodic (bool): Whether the space wraps.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    limit = num_basis - 1 if periodic else num_basis - degree - 1
+
+    def predicate(result: object) -> str | None:
+        if not (isinstance(result, tuple) and len(result) == _PAIR):
+            return f"expected a (basis, first_basis) pair, got {type(result).__name__}"
+        first = np.asarray(result[1])
+        if first.size == 0:
+            return None
+        lowest = int(np.min(first))
+        highest = int(np.max(first))
+        if lowest < 0 or highest > limit:
+            return f"first_basis in [{lowest}, {highest}], must be within [0, {limit}]"
+        return None
+
+    return predicate
+
+
+def _within_convex_hull(
+    control_points: npt.NDArray[np.floating[Any]], degree: int, dtype: npt.DTypeLike
+) -> Predicate:
+    """Build a predicate requiring in-domain values to lie in the control hull.
+
+    A B-spline value is a convex combination of at most ``degree + 1`` control points, so
+    it cannot leave their componentwise range. Rounding lets it out by at most
+    ``3 * degree * eps * max|control point|``: a perturbed stage weight that rounds
+    slightly outside ``[0, 1]`` is the only escape, and it is bounded by one epsilon per
+    stage. This is the cheapest available detector of silent garbage -- a wrong index or
+    a wrong span gives a value far outside the hull, not a slightly wrong one.
+
+    Args:
+        control_points (npt.NDArray[np.floating[Any]]): The control points.
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Working precision.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    flat = np.asarray(control_points, dtype=np.float64).reshape(-1, control_points.shape[-1])
+    lo = flat.min(axis=0)
+    hi = flat.max(axis=0)
+    scale = float(np.max(np.abs(flat))) if flat.size else 1.0
+    slack = _ERROR_SAFETY_FACTOR * (degree + 1) * get_machine_epsilon(dtype) * max(scale, 1.0)
+
+    def predicate(result: object) -> str | None:
+        values = np.asarray(result, dtype=np.float64)
+        if values.size == 0:
+            return None
+        flat_values = values.reshape(-1, lo.size)
+        below = float(np.max(lo - flat_values.min(axis=0)))
+        above = float(np.max(flat_values.max(axis=0) - hi))
+        worst = max(below, above)
+        if not np.isfinite(worst) or worst > slack:
+            return f"value escapes the control hull by {worst:.3e} > {slack:.3e}"
+        return None
+
+    return predicate
+
+
+def _reproduces(
+    reference: Bspline,
+    pts: npt.NDArray[np.floating[Any]],
+    tol: float,
+) -> Predicate:
+    """Build a predicate requiring a derived spline to reproduce a reference pointwise.
+
+    Args:
+        reference (Bspline): The spline whose values the result must reproduce.
+        pts (npt.NDArray[np.floating[Any]]): Parameters at which to compare.
+        tol (float): Bound on the difference, derived by :func:`_eval_tolerance`.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    expected = np.asarray(reference.evaluate(pts), dtype=np.float64)
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline | Bezier):
+            return f"expected a spline, got {type(result).__name__}"
+        got = np.asarray(result.evaluate(pts.astype(result.dtype)), dtype=np.float64)
+        if got.shape != expected.shape:
+            return f"shape {got.shape} != reference {expected.shape}"
+        worst = float(np.max(np.abs(got - expected))) if got.size else 0.0
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|f - f_ref| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _has_degrees(expected: tuple[int, ...]) -> Predicate:
+    """Build a predicate requiring a returned spline to carry the expected degrees.
+
+    This is deliberately weak, and the reason is worth recording. ``Bspline.reduce_degree``
+    states outright that it is **not exact** (``_bspline.py:429-430``), and that the knot
+    removal following the per-segment reduction "is a forced removal with no deviation
+    bound" (``:437-440``) -- so no accuracy invariant is available on an arbitrary curve.
+    Its bit-exactness sentence ("adjacent segments therefore agree at every breakpoint bit
+    for bit") is about the *intermediate* Bézier segments before that removal, not about
+    reproducing the original's endpoints, and asserting the latter would be inventing a
+    claim. The exactly-reducible case is probed separately, where the claim does bite.
+
+    Args:
+        expected (tuple[int, ...]): Degree per parametric direction.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline):
+            return f"expected a Bspline, got {type(result).__name__}"
+        got = tuple(result.degree)
+        if got != expected:
+            return f"degrees {got} != expected {expected}"
+        return None
+
+    return predicate
+
+
+def _nd_partition_of_unity(degrees_per_dir: tuple[int, ...], dtype: npt.DTypeLike) -> Predicate:
+    """Build a predicate for the tensor-product local partition of unity.
+
+    ``BsplineSpace.tabulate_basis`` returns basis values of shape
+    ``(num_pts, order[0], ..., order[d-1])`` -- a tensor per point, not a flat vector -- so
+    the sum runs over every trailing axis. The term count is the product of the orders, and
+    each value is a product of ``d`` univariate values each from a recurrence of depth
+    ``degree``, giving a bound of ``(prod(order) + sum(degree)) * eps``.
+
+    Args:
+        degrees_per_dir (tuple[int, ...]): Degree in each parametric direction.
+        dtype (npt.DTypeLike): Working precision.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    terms = int(np.prod([d + 1 for d in degrees_per_dir]))
+    depth = int(sum(degrees_per_dir))
+    tol = _ERROR_SAFETY_FACTOR * (terms + depth) * get_machine_epsilon(dtype)
+
+    def predicate(result: object) -> str | None:
+        basis = _basis_of(result)
+        if basis is None:
+            return f"expected a (basis, first_basis) pair, got {type(result).__name__}"
+        if basis.size == 0:
+            return None
+        axes = tuple(range(basis.ndim - len(degrees_per_dir), basis.ndim))
+        sums = np.sum(basis, axis=axes)
+        worst = float(np.max(np.abs(sums - 1.0)))
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|sum(N) - 1| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _nd_first_basis_in_range(
+    num_basis_per_dir: tuple[int, ...], degrees_per_dir: tuple[int, ...]
+) -> Predicate:
+    """Build a predicate requiring every per-direction ``first_basis`` index to be usable.
+
+    The nD two-return carries ``first_basis`` of shape ``(..., dim)``, one index per
+    direction, and each must leave room for that direction's local block.
+
+    Args:
+        num_basis_per_dir (tuple[int, ...]): Basis count per direction.
+        degrees_per_dir (tuple[int, ...]): Degree per direction.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    limits = tuple(n - p - 1 for n, p in zip(num_basis_per_dir, degrees_per_dir, strict=True))
+
+    def predicate(result: object) -> str | None:
+        if not (isinstance(result, tuple) and len(result) == _PAIR):
+            return f"expected a (basis, first_basis) pair, got {type(result).__name__}"
+        first = np.asarray(result[1]).reshape(-1, len(limits))
+        if first.size == 0:
+            return None
+        for direction, limit in enumerate(limits):
+            column = first[:, direction]
+            lowest = int(np.min(column))
+            highest = int(np.max(column))
+            if lowest < 0 or highest > limit:
+                return (
+                    f"direction {direction}: first_basis in [{lowest}, {highest}], "
+                    f"must be within [0, {limit}]"
+                )
+        return None
+
+    return predicate
+
+
+def _monotone_index_ladder(space: BsplineSpace1D) -> Predicate:
+    """Build a predicate for the ``first_basis_per_interval`` contract.
+
+    ``_bspline_space_1d.py:348-350`` states the result is non-decreasing and that its
+    successive differences are the interior knot multiplicities. Both halves are exact
+    integer claims, so both are asserted exactly.
+
+    Args:
+        space (BsplineSpace1D): The space whose interior multiplicities are the oracle.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    unique, mult = space.get_unique_knots_and_multiplicity(in_domain=True)
+    interior = (
+        np.asarray(mult, dtype=np.int64)[1:-1]
+        if unique.size >= _PAIR
+        else np.zeros(0, dtype=np.int64)
+    )
+
+    def predicate(result: object) -> str | None:
+        first = np.asarray(result, dtype=np.int64)
+        if first.size == 0:
+            return None
+        diffs = np.diff(first)
+        if np.any(diffs < 0):
+            return f"not non-decreasing: {first.tolist()}"
+        if diffs.size != interior.size:
+            return f"{diffs.size} successive differences for {interior.size} interior knots"
+        if not np.array_equal(diffs, interior):
+            return f"differences {diffs.tolist()} != interior multiplicities {interior.tolist()}"
+        return None
+
+    return predicate
+
+
+def _root_quality(spline: Bspline, degree: int, dtype: npt.DTypeLike) -> Predicate:
+    """Build a predicate for the three things a root list must satisfy.
+
+    A degree-``n`` polynomial has at most ``n`` roots per interval, and a spline with
+    ``k`` intervals therefore at most ``degree * k``; more than that is a defect no
+    conditioning argument excuses. Each root must lie in the domain, and each must be an
+    actual root: de Boor evaluation of a degree-``n`` spline with coefficients of
+    magnitude ``cs`` carries about ``n * eps * cs`` of noise, so the residual is checked
+    against that and nothing tighter.
+
+    Args:
+        spline (Bspline): The spline whose roots were requested.
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Working precision.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    space = spline.space.spaces[0]
+    knots = np.asarray(space.knots, dtype=np.float64)
+    lo = float(knots[degree])
+    hi = float(knots[knots.size - degree - 1])
+    limit = degree * space.num_intervals
+    scale = float(np.max(np.abs(np.asarray(spline.control_points, dtype=np.float64))))
+    residual_tol = (
+        _ERROR_SAFETY_FACTOR * (degree + 1) * get_machine_epsilon(dtype) * max(scale, 1.0)
+    )
+
+    def predicate(result: object) -> str | None:
+        roots = np.asarray(result, dtype=np.float64).ravel()
+        if roots.size > limit:
+            return f"{roots.size} roots for degree {degree} on {space.num_intervals} intervals"
+        if roots.size == 0:
+            return None
+        if float(np.min(roots)) < lo or float(np.max(roots)) > hi:
+            return f"roots outside the domain [{lo:g}, {hi:g}]: {roots.tolist()}"
+        values = np.asarray(spline.evaluate(roots.astype(spline.dtype)), dtype=np.float64)
+        worst = float(np.max(np.abs(values)))
+        if worst > residual_tol:
+            return f"max|f(root)| = {worst:.3e} > {residual_tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _derivative_agreement(
+    curve: Bspline,
+    pts: npt.NDArray[np.floating[Any]],
+    fixture: _Fixture,
+    value_scale: float,
+) -> Predicate:
+    """Build a predicate comparing an analytic derivative to a central difference.
+
+    The central difference has truncation error ``O(h ** 2)`` and rounding error
+    ``O(eps / h)``; balancing them gives ``h = eps ** (1/3)`` and a floor of
+    ``eps ** (2/3)`` on the *relative* accuracy. Scaling by the value magnitude over the
+    parametric span converts that into the derivative's own units. Anything tighter would
+    report the finite difference's own noise as a defect.
+
+    Args:
+        curve (Bspline): The spline whose derivative is under test.
+        pts (npt.NDArray[np.floating[Any]]): Parameters strictly inside knot intervals,
+            since a C^-1 spline has no derivative at a knot.
+        fixture (_Fixture): Supplies dtype, degree and the parametric scale.
+        value_scale (float): Magnitude of the control points.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    eps = get_machine_epsilon(fixture.dtype)
+    span = _min_nonzero_span(fixture.space)
+    step = float(eps ** (1.0 / 3.0)) * span
+    tol = (
+        _ERROR_SAFETY_FACTOR
+        * (fixture.degree + 1)
+        * eps ** (2.0 / 3.0)
+        * max(value_scale, 1.0)
+        / span
+    )
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline):
+            return f"expected a Bspline, got {type(result).__name__}"
+        if pts.size == 0:
+            return None
+        forward = np.asarray(curve.evaluate((pts + step).astype(curve.dtype)), dtype=np.float64)
+        backward = np.asarray(curve.evaluate((pts - step).astype(curve.dtype)), dtype=np.float64)
+        approx = (forward - backward) / (2.0 * step)
+        exact = np.asarray(result.evaluate(pts.astype(result.dtype)), dtype=np.float64)
+        if exact.shape != approx.shape:
+            return f"derivative shape {exact.shape} != finite difference {approx.shape}"
+        worst = float(np.max(np.abs(exact - approx))) if exact.size else 0.0
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|f' - FD| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _split_agreement(curve: Bspline, fixture: _Fixture, tol: float) -> Predicate:
+    """Build a predicate requiring both halves of a split to reproduce the original.
+
+    The samples exclude both ends of each half. The split point is a knot, and a spline
+    whose interior multiplicity is ``degree + 1`` is genuinely discontinuous there: the
+    original and the two halves each pick a one-sided value by their own span convention,
+    and neither is wrong. Comparing *at* the breakpoint would report the discontinuity as
+    a defect, which is the one thing this probe must not do.
+
+    Args:
+        curve (Bspline): The spline before splitting.
+        fixture (_Fixture): Supplies the domain and dtype.
+        tol (float): Bound from :func:`_eval_tolerance`.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    lo, hi = _domain_of(fixture)
+    mid = lo + 0.5 * (hi - lo)
+    inner = np.array([0.13, 0.37, 0.61, 0.83])
+    left_pts = (lo + (mid - lo) * inner).astype(fixture.dtype)
+    right_pts = (mid + (hi - mid) * inner).astype(fixture.dtype)
+
+    def predicate(result: object) -> str | None:
+        if not (isinstance(result, tuple) and len(result) == _PAIR):
+            return f"expected two halves, got {type(result).__name__}"
+        for name, half, sample in (("left", result[0], left_pts), ("right", result[1], right_pts)):
+            expected = np.asarray(curve.evaluate(sample), dtype=np.float64)
+            got = np.asarray(half.evaluate(sample), dtype=np.float64)
+            worst = float(np.max(np.abs(got - expected))) if got.size else 0.0
+            if not np.isfinite(worst) or worst > tol:
+                return f"{name} half: max|f - f_ref| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _bezier_agreement(curve: Bspline, fixture: _Fixture, tol: float) -> Predicate:
+    """Build a predicate requiring each extracted Bézier to reproduce its own interval.
+
+    The local parameters stay strictly inside ``(0, 1)`` for the same reason
+    :func:`_split_agreement` avoids the split point: a patch's endpoint is a knot, and at
+    an interior knot of multiplicity ``degree + 1`` the spline has two values, so the
+    patch and the spline legitimately disagree there.
+
+    Args:
+        curve (Bspline): The spline that was decomposed.
+        fixture (_Fixture): Supplies the degree and dtype.
+        tol (float): Bound from :func:`_eval_tolerance`.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    knots = np.asarray(curve.space.spaces[0].knots, dtype=np.float64)
+    degree = fixture.degree
+    breaks = np.unique(knots[degree : knots.size - degree])
+    local = np.array([0.13, 0.37, 0.61, 0.83], dtype=fixture.dtype)
+
+    def predicate(result: object) -> str | None:
+        patches = np.asarray(result, dtype=object).ravel()
+        if patches.size == 0:
+            return "no Bézier patches returned"
+        if patches.size != breaks.size - 1:
+            return f"{patches.size} patches for {breaks.size - 1} intervals"
+        for index, patch in enumerate(patches):
+            left = float(breaks[index])
+            width = float(breaks[index + 1]) - left
+            if width <= 0.0:
+                continue
+            global_pts = (left + width * local.astype(np.float64)).astype(fixture.dtype)
+            expected = np.asarray(curve.evaluate(global_pts), dtype=np.float64)
+            got = np.asarray(patch.evaluate(local), dtype=np.float64)
+            worst = float(np.max(np.abs(got - expected))) if got.size else 0.0
+            if not np.isfinite(worst) or worst > tol:
+                return f"patch {index}: max|B - f| = {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _product_agreement(
+    scalar: Bspline, pts: npt.NDArray[np.floating[Any]], fixture: _Fixture
+) -> Predicate:
+    """Build a predicate requiring a spline product to equal the pointwise product.
+
+    ``_bspline_product.py``'s module docstring claims the product is *exact* in the
+    product space of degree ``p + q``. The comparison's own error is each factor's
+    evaluation error times the other factor's magnitude, so the bound is the evaluation
+    tolerance scaled by the value magnitude once more.
+
+    Args:
+        scalar (Bspline): The scalar spline being squared.
+        pts (npt.NDArray[np.floating[Any]]): Comparison parameters.
+        fixture (_Fixture): Supplies degree and dtype.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    values = np.asarray(scalar.evaluate(pts), dtype=np.float64)
+    expected = values * values
+    scale = max(float(np.max(np.abs(values))) if values.size else 1.0, 1.0)
+    tol = _fixture_tolerance(fixture, scale) * scale
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline):
+            return f"expected a Bspline, got {type(result).__name__}"
+        got = np.asarray(result.evaluate(pts.astype(result.dtype)), dtype=np.float64)
+        if got.shape != expected.shape:
+            return f"shape {got.shape} != pointwise product {expected.shape}"
+        worst = float(np.max(np.abs(got - expected))) if got.size else 0.0
+        reference = max(float(np.max(np.abs(expected))), 1.0) if expected.size else 1.0
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|fg - f*g| = {worst:.3e} > {tol:.3e} (relative {worst / reference:.3e})"
+        return None
+
+    return predicate
+
+
+def _bitwise_control_points(expected: npt.NDArray[np.floating[Any]]) -> Predicate:
+    """Build a predicate requiring a spline's control points to match bit for bit.
+
+    Reversal is a pure permutation of the control points, so applying it twice must
+    restore them exactly. No tolerance applies to a permutation.
+
+    Args:
+        expected (npt.NDArray[np.floating[Any]]): The original control points.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline):
+            return f"expected a Bspline, got {type(result).__name__}"
+        got = np.asarray(result.control_points)
+        if got.shape != expected.shape:
+            return f"shape {got.shape} != original {expected.shape}"
+        if not np.array_equal(got, expected):
+            worst = float(np.max(np.abs(got.astype(np.float64) - expected.astype(np.float64))))
+            return f"control points not restored bitwise, max|diff| = {worst:.3e}"
+        return None
+
+    return predicate
+
+
+def _non_decreasing(result: object) -> str | None:
+    """Check that a returned knot vector is non-decreasing.
+
+    Every knot-vector factory documents a valid knot vector, and non-decreasing is the
+    defining property of one.
+
+    Args:
+        result (object): The returned knot vector.
+
+    Returns:
+        str | None: ``None`` when it holds, otherwise the violation.
+    """
+    knots = np.asarray(result, dtype=np.float64).ravel()
+    if knots.size < _PAIR:
+        return None
+    gaps = np.diff(knots)
+    if np.any(gaps < 0.0):
+        worst = int(np.argmin(gaps))
+        return f"knots decrease at index {worst}: {knots[worst]:.17g} > {knots[worst + 1]:.17g}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixture construction
+# ---------------------------------------------------------------------------
+
+
+def _interior_mult_of(name: str) -> int:
+    """Read the interior multiplicity out of a knot-family name.
+
+    Args:
+        name (str): Family name from :func:`adversarial_sweep._axes.knot_specs`.
+
+    Returns:
+        int: The multiplicity, or ``0`` when the family does not encode one.
+    """
+    prefix = "interior_mult"
+    return int(name[len(prefix) :]) if name.startswith(prefix) else 0
+
+
+def _try_space(
+    knots: npt.NDArray[np.floating[Any]], degree: int, *, periodic: bool
+) -> BsplineSpace1D | None:
+    """Build a space, returning ``None`` when the knot family is not a legal one.
+
+    Fixture enumeration must not raise: an illegal knot vector is covered as a
+    *construction* case elsewhere, and here it simply yields no fixture.
+
+    Args:
+        knots (npt.NDArray[np.floating[Any]]): The knot vector.
+        degree (int): Polynomial degree.
+        periodic (bool): Whether to build a periodic space.
+
+    Returns:
+        BsplineSpace1D | None: The space, or ``None`` if it could not be built.
+    """
+    try:
+        return BsplineSpace1D(knots, degree, periodic=periodic)
+    except (ValueError, TypeError):
+        return None
+
+
+def _mult_knots(
+    degree: int,
+    mult: int,
+    domain: tuple[float, float],
+    dtype: np.dtype[np.float32 | np.float64],
+) -> npt.NDArray[np.floating[Any]]:
+    """Build a clamped knot vector with one interior knot at a chosen multiplicity.
+
+    Two interior breakpoints are used, one carrying the swept multiplicity and one
+    simple, so that operations special-casing the first or the last interval still see a
+    neighbour.
+
+    Args:
+        degree (int): Polynomial degree.
+        mult (int): Multiplicity of the first interior knot, in ``[1, degree + 1]``.
+        domain (tuple[float, float]): ``(lo, hi)`` parametric interval.
+        dtype (np.dtype[np.float32 | np.float64]): Knot precision.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The knot vector.
+    """
+    lo, hi = domain
+    span = hi - lo
+    return np.concatenate(
+        [
+            np.full(degree + 1, lo, dtype=dtype),
+            np.full(mult, lo + 0.5 * span, dtype=dtype),
+            np.array([lo + 0.75 * span], dtype=dtype),
+            np.full(degree + 1, hi, dtype=dtype),
+        ]
+    )
+
+
+def _fixtures(profile: Profile) -> Iterator[_Fixture]:
+    """Yield the 1D space fixtures every operation probe is run against.
+
+    The crossing is factorized rather than exhaustive, on the sweep's own principle of
+    corners over middles: the full multiplicity ladder is crossed with degree and dtype
+    on the unit domain, and the ``degree + 1`` corner -- the discontinuous case -- is
+    then repeated on every other domain, together with the uniform and periodic families
+    that give a continuity baseline to compare it against.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        _Fixture: One usable space plus its axis values.
+    """
+    unit = domains(Profile.SMOKE)[0]
+    for degree in degrees(profile):
+        for dtype in dtypes(profile):
+            for mult in interior_multiplicities(degree, profile):
+                space = _try_space(_mult_knots(degree, mult, unit, dtype), degree, periodic=False)
+                if space is not None:
+                    yield _Fixture(
+                        f"d{degree}_m{mult}_{dtype.name}",
+                        space,
+                        degree,
+                        mult,
+                        unit,
+                        dtype,
+                        {"degree": degree, "mult": mult, "dtype": dtype, "domain": "unit"},
+                    )
+            if profile is not Profile.FULL:
+                continue
+            wanted = ("open_uniform", "periodic_uniform", f"interior_mult{degree + 1}")
+            for domain in domains(profile)[1:]:
+                for spec in knot_specs(degree, domain, dtype, profile):
+                    if spec.name not in wanted:
+                        continue
+                    space = _try_space(spec.knots, degree, periodic=spec.periodic)
+                    if space is None:
+                        continue
+                    yield _Fixture(
+                        f"d{degree}_{spec.name}_{dtype.name}_[{domain[0]:g},{domain[1]:g}]",
+                        space,
+                        degree,
+                        _interior_mult_of(spec.name),
+                        domain,
+                        dtype,
+                        {
+                            "degree": degree,
+                            "knots": spec.name,
+                            "dtype": dtype,
+                            "domain": list(domain),
+                        },
+                    )
+
+
+def _domain_of(fixture: _Fixture) -> tuple[float, float]:
+    """Read a fixture's actual parametric domain from its knot vector.
+
+    The nominal ``(lo, hi)`` of the axis is not the domain for an unclamped or periodic
+    knot family, where the domain is the inner ``[knots[degree], knots[-degree-1]]``.
+    Evaluating outside it is a different probe, so operations must use this.
+
+    Args:
+        fixture (_Fixture): The fixture.
+
+    Returns:
+        tuple[float, float]: The domain endpoints.
+    """
+    knots = np.asarray(fixture.space.knots, dtype=np.float64)
+    return float(knots[fixture.degree]), float(knots[knots.size - fixture.degree - 1])
+
+
+def _sample_points(
+    fixture: _Fixture, *, avoid_knots: bool = False
+) -> npt.NDArray[np.floating[Any]]:
+    """Build in-domain sample parameters for a fixture.
+
+    Args:
+        fixture (_Fixture): The fixture whose domain to sample.
+        avoid_knots (bool): When ``True``, keep the samples strictly inside the knot
+            intervals. A C^-1 spline has no derivative *at* a knot, so a
+            finite-difference comparison must not straddle one.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Sample parameters.
+    """
+    lo, hi = _domain_of(fixture)
+    if not avoid_knots:
+        fractions = np.array([0.0, 0.13, 0.37, 0.5, 0.61, 0.87, 1.0])
+        return (lo + (hi - lo) * fractions).astype(fixture.dtype)
+    knots = np.asarray(fixture.space.knots, dtype=np.float64)
+    breaks = np.unique(knots[(knots >= lo) & (knots <= hi)])
+    mids = 0.5 * (breaks[:-1] + breaks[1:]) if breaks.size >= _PAIR else np.array([0.5 * (lo + hi)])
+    return mids.astype(fixture.dtype)
+
+
+def _curve(fixture: _Fixture, dim: int, *, kind: str = "random", offset: int = 0) -> Bspline:
+    """Build a spline on a fixture's space with control points from a chosen family.
+
+    Args:
+        fixture (_Fixture): The space to build on.
+        dim (int): Number of physical components.
+        kind (str): Control-point family name from
+            :func:`adversarial_sweep._axes.coeff_specs`. Defaults to ``"random"``.
+        offset (int): Random-stream offset. Defaults to 0.
+
+    Returns:
+        Bspline: The spline.
+    """
+    shape = (fixture.space.num_basis, dim)
+    specs = {
+        spec.name: spec for spec in coeff_specs(shape, fixture.dtype, Profile.FULL, offset=offset)
+    }
+    values = specs[kind].values if kind in specs else specs["random"].values
+    return Bspline(BsplineSpace([fixture.space]), values)
+
+
+def _try_elevate(curve: Bspline) -> Bspline | None:
+    """Elevate a curve's degree by one, returning ``None`` when the call refuses.
+
+    A generator body must not raise -- an exception here aborts the whole sweep instead of
+    being classified -- and degree elevation is currently *unable* to handle a
+    discontinuous spline. The refusal is itself covered as a ``must_succeed`` case, so
+    swallowing it here loses nothing.
+
+    Args:
+        curve (Bspline): The curve to elevate.
+
+    Returns:
+        Bspline | None: The elevated curve, or ``None``.
+    """
+    try:
+        return curve.elevate_degree(1)
+    except (ValueError, TypeError, IndexError):
+        return None
+
+
+def _sign_alternating_curve(fixture: _Fixture) -> Bspline:
+    """Build a scalar spline whose control points alternate in sign.
+
+    Alternating signs guarantee sign changes for the root finder to find, and spread the
+    roots roughly one per interval rather than clustering them -- a *clustered* root set
+    is already known to defeat the deduplication radius, so a count violation there would
+    only rediscover that.
+
+    Args:
+        fixture (_Fixture): The space to build on.
+
+    Returns:
+        Bspline: The scalar spline.
+    """
+    n = fixture.space.num_basis
+    values = np.where(np.arange(n) % 2 == 0, 1.0, -1.0).astype(fixture.dtype).reshape(n, 1)
+    return Bspline(BsplineSpace([fixture.space]), values)
+
+
+def _locate_round_trip(fixture: _Fixture) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]:
+    """Invert a monotone scalar spline at its own sampled values.
+
+    Args:
+        fixture (_Fixture): The space to build the monotone spline on.
+
+    Returns:
+        tuple[npt.NDArray[np.int64], npt.NDArray[np.float64]]: Whatever
+            :meth:`pantr.bspline.Bspline.locate` returns for the sampled images.
+    """
+    n = fixture.space.num_basis
+    values = np.linspace(0.0, 1.0, n, dtype=fixture.dtype).reshape(n, 1)
+    curve = Bspline(BsplineSpace([fixture.space]), values)
+    images = np.asarray(curve.evaluate(_sample_points(fixture, avoid_knots=True)))
+    return curve.locate(images)
+
+
+# ---------------------------------------------------------------------------
+# Case groups
+# ---------------------------------------------------------------------------
+
+
+def _construction_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`pantr.bspline.BsplineSpace1D` construction cases.
+
+    This is the one exhaustive crossing in the module -- every degree, dtype, domain and
+    knot family -- because a constructor call is cheap and because construction is where
+    a malformed knot vector must be *rejected*, which the verdict rule can only judge
+    against the docstring's own ``Raises:`` list.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One construction attempt.
+    """
+    for degree in degrees(profile):
+        for dtype in dtypes(profile):
+            for domain in domains(profile):
+                tag = f"d{degree}_{dtype.name}_[{domain[0]:g},{domain[1]:g}]"
+                for spec in knot_specs(degree, domain, dtype, profile):
+                    params = {
+                        "degree": degree,
+                        "knots": spec.name,
+                        "periodic": spec.periodic,
+                        "dtype": dtype,
+                        "domain": list(domain),
+                    }
+                    yield Case(
+                        GROUP,
+                        f"space1d_{spec.name}_{tag}",
+                        BsplineSpace1D,
+                        lambda spec=spec, degree=degree: BsplineSpace1D(
+                            spec.knots, degree, periodic=spec.periodic
+                        ),
+                        params,
+                        arrays={"knots": np.asarray(spec.knots)},
+                    )
+                    if profile is not Profile.FULL:
+                        continue
+                    # snap_knots=False is the documented escape hatch from the absolute
+                    # snapping tolerance; the space it builds must still be usable.
+                    yield Case(
+                        GROUP,
+                        f"space1d_nosnap_{spec.name}_{tag}",
+                        BsplineSpace1D,
+                        lambda spec=spec, degree=degree: BsplineSpace1D(
+                            spec.knots, degree, periodic=spec.periodic, snap_knots=False
+                        ),
+                        {**params, "snap_knots": False},
+                    )
+
+
+def _tabulation_cases(profile: Profile) -> Iterator[Case]:
+    """Yield basis-tabulation cases over every fixture and point family.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One tabulation call.
+    """
+    in_domain_families = ("interior", "left_endpoint", "right_endpoint", "at_knots", "single")
+    for fixture in _fixtures(profile):
+        space = fixture.space
+        knots = np.asarray(space.knots, dtype=np.float64)
+        interior = knots[fixture.degree + 1 : knots.size - fixture.degree - 1]
+        pou = custom(
+            "local-partition-of-unity", _local_partition_of_unity(fixture.degree, fixture.dtype)
+        )
+        index = custom(
+            "first-basis-in-range",
+            _first_basis_in_range(space.num_basis, fixture.degree, periodic=space.periodic),
+        )
+        for pts in point_specs(_domain_of(fixture), fixture.dtype, profile, breakpoints=interior):
+            in_domain = pts.name in in_domain_families
+            yield Case(
+                GROUP,
+                f"tabulate_basis_{fixture.label}_{pts.name}",
+                BsplineSpace1D.tabulate_basis,
+                lambda space=space, pts=pts: space.tabulate_basis(pts.pts),
+                {**fixture.params, "pts": pts.name},
+                invariants=(pou, index) if in_domain else (index,),
+                must_succeed=in_domain,
+                finite_inputs=pts.finite,
+                arrays={"knots": np.asarray(space.knots), "pts": np.asarray(pts.pts)},
+            )
+            if profile is not Profile.FULL:
+                continue
+            n_deriv = min(fixture.degree + 1, 3)
+            yield Case(
+                GROUP,
+                f"tabulate_derivs_{fixture.label}_{pts.name}",
+                BsplineSpace1D.tabulate_basis_derivatives,
+                lambda space=space, pts=pts, n_deriv=n_deriv: space.tabulate_basis_derivatives(
+                    pts.pts, n_deriv
+                ),
+                {**fixture.params, "pts": pts.name, "n_deriv": n_deriv},
+                invariants=(index,),
+                must_succeed=in_domain,
+                finite_inputs=pts.finite,
+            )
+            # validate=False is the documented escape hatch: out-of-domain points are
+            # then undefined behavior by contract, which is exactly what the bounds check
+            # is here to catch.
+            yield Case(
+                GROUP,
+                f"tabulate_novalidate_{fixture.label}_{pts.name}",
+                BsplineSpace1D.tabulate_basis,
+                lambda space=space, pts=pts: space.tabulate_basis(pts.pts, validate=False),
+                {**fixture.params, "pts": pts.name, "validate": False},
+                invariants=(index,),
+                finite_inputs=pts.finite,
+            )
+
+
+def _space_operation_cases(profile: Profile) -> Iterator[Case]:
+    """Yield cases for the operations :class:`BsplineSpace1D` offers on itself.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One space-level operation.
+    """
+    for fixture in _fixtures(profile):
+        space = fixture.space
+        degree = fixture.degree
+        legal = not space.periodic
+        lo, hi = _domain_of(fixture)
+        yield Case(
+            GROUP,
+            f"first_basis_per_interval_{fixture.label}",
+            BsplineSpace1D.first_basis_per_interval,
+            space.first_basis_per_interval,
+            dict(fixture.params),
+            invariants=(custom("index-ladder", _monotone_index_ladder(space)),),
+            must_succeed=legal,
+        )
+        yield Case(
+            GROUP,
+            f"cardinal_intervals_{fixture.label}",
+            BsplineSpace1D.get_cardinal_intervals,
+            space.get_cardinal_intervals,
+            dict(fixture.params),
+            invariants=(expected_shape((space.num_intervals,)),),
+            must_succeed=legal,
+        )
+        yield Case(
+            GROUP,
+            f"greville_{fixture.label}",
+            get_greville_abscissae,
+            lambda space=space: get_greville_abscissae(space),
+            dict(fixture.params),
+            must_succeed=legal,
+        )
+        for regularity in sorted({-1, 0, degree - 1}):
+            if not -1 <= regularity <= degree - 1:
+                continue
+            yield Case(
+                GROUP,
+                f"subdivide_space_{fixture.label}_reg{regularity}",
+                BsplineSpace1D.subdivide,
+                lambda space=space, regularity=regularity: space.subdivide(
+                    3, regularity=regularity
+                ),
+                {**fixture.params, "regularity": regularity},
+                must_succeed=legal,
+            )
+        if profile is not Profile.FULL:
+            continue
+        yield Case(
+            GROUP,
+            f"bezier_extraction_{fixture.label}",
+            BsplineSpace1D.tabulate_Bezier_extraction_operators,
+            space.tabulate_Bezier_extraction_operators,
+            dict(fixture.params),
+            invariants=(expected_shape((space.num_intervals, degree + 1, degree + 1)),),
+            must_succeed=legal,
+        )
+        yield Case(
+            GROUP,
+            f"cardinal_extraction_{fixture.label}",
+            BsplineSpace1D.tabulate_cardinal_extraction_operators,
+            space.tabulate_cardinal_extraction_operators,
+            dict(fixture.params),
+            must_succeed=legal,
+        )
+        yield Case(
+            GROUP,
+            f"lagrange_extraction_{fixture.label}",
+            BsplineSpace1D.tabulate_Lagrange_extraction_operators,
+            space.tabulate_Lagrange_extraction_operators,
+            dict(fixture.params),
+            must_succeed=legal,
+        )
+        # Insert at a coordinate that is not a midpoint of the existing knots, so
+        # snapping cannot hide a mis-merge.
+        inserted = np.array([lo + (hi - lo) * 0.3125], dtype=fixture.dtype)
+        yield Case(
+            GROUP,
+            f"insert_knots_space_{fixture.label}",
+            BsplineSpace1D.insert_knots,
+            lambda space=space, inserted=inserted: space.insert_knots(inserted),
+            dict(fixture.params),
+        )
+        yield Case(
+            GROUP,
+            f"restrict_space_{fixture.label}",
+            BsplineSpace1D.restrict,
+            lambda space=space: space.restrict(0, max(1, space.num_intervals - 1)),
+            dict(fixture.params),
+        )
+        yield Case(
+            GROUP,
+            f"has_open_knots_{fixture.label}",
+            BsplineSpace1D.has_open_knots,
+            space.has_open_knots,
+            dict(fixture.params),
+        )
+
+
+def _curve_operation_cases(profile: Profile) -> Iterator[Case]:
+    """Yield the operation matrix every fixture's spline is pushed through.
+
+    This is the core of the group: one spline per fixture and control-point family, then
+    every operation that takes a spline, each with the strongest invariant its own
+    contract supports.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One spline operation.
+    """
+    kinds = ("random", "identical") if profile is Profile.FULL else ("random",)
+    for fixture in _fixtures(profile):
+        for kind in kinds:
+            yield from _one_curve_cases(fixture, kind, profile)
+
+
+def _one_curve_cases(fixture: _Fixture, kind: str, profile: Profile) -> Iterator[Case]:
+    """Yield every operation case for one fixture and one control-point family.
+
+    Args:
+        fixture (_Fixture): The space to build the spline on.
+        kind (str): Control-point family name.
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One spline operation.
+    """
+    degree = fixture.degree
+    dtype = fixture.dtype
+    # Every operation below is legal on a clamped space by construction, so any exception
+    # is a finding. A periodic space is different: most of these document a ValueError for
+    # a periodic direction, and that rejection is correct.
+    legal = not fixture.space.periodic
+    lo, hi = _domain_of(fixture)
+    mid = lo + 0.5 * (hi - lo)
+    curve = _curve(fixture, 2, kind=kind)
+    scalar = _curve(fixture, 1, kind=kind, offset=3)
+    tag = f"{fixture.label}_{kind}"
+    pts = _sample_points(fixture)
+    smooth_pts = _sample_points(fixture, avoid_knots=True)
+    value_scale = float(np.max(np.abs(np.asarray(curve.control_points, dtype=np.float64))))
+    tol = _fixture_tolerance(fixture, value_scale)
+    inserted = np.array([lo + (hi - lo) * 0.3125], dtype=dtype)
+    in_domain_families = ("interior", "left_endpoint", "right_endpoint", "single")
+
+    for family in point_specs((lo, hi), dtype, profile):
+        yield Case(
+            GROUP,
+            f"evaluate_{tag}_{family.name}",
+            Bspline.evaluate,
+            lambda curve=curve, family=family: curve.evaluate(family.pts),
+            {**fixture.params, "cp": kind, "pts": family.name},
+            invariants=(
+                (
+                    custom(
+                        "in-control-hull",
+                        _within_convex_hull(curve.control_points, degree, dtype),
+                    ),
+                )
+                if family.name in in_domain_families
+                else ()
+            ),
+            must_succeed=legal and family.name in in_domain_families,
+            finite_inputs=family.finite,
+            arrays={
+                "control_points": np.asarray(curve.control_points),
+                "pts": np.asarray(family.pts),
+            },
+        )
+
+    orders = min(degree, 2)
+    yield Case(
+        GROUP,
+        f"evaluate_derivatives_{tag}",
+        Bspline.evaluate_derivatives,
+        lambda curve=curve, pts=pts, orders=orders: curve.evaluate_derivatives(pts, orders),
+        {**fixture.params, "cp": kind, "orders": orders},
+        must_succeed=legal,
+    )
+
+    if degree >= 1:
+        yield Case(
+            GROUP,
+            f"derivative_{tag}",
+            Bspline.derivative,
+            lambda curve=curve: curve.derivative(0),
+            {**fixture.params, "cp": kind},
+            invariants=(
+                custom(
+                    "derivative-matches-central-difference",
+                    _derivative_agreement(curve, smooth_pts, fixture, value_scale),
+                ),
+            ),
+            must_succeed=legal,
+        )
+        yield Case(
+            GROUP,
+            f"reduce_degree_{tag}",
+            Bspline.reduce_degree,
+            lambda curve=curve: curve.reduce_degree(1),
+            {**fixture.params, "cp": kind, "decrement": 1},
+            invariants=(custom("reduced-degree", _has_degrees((degree - 1,))),),
+            must_succeed=legal,
+        )
+        lifted = _try_elevate(_curve(fixture, 2, kind=kind, offset=7))
+        if degree <= _GRAM_CONDITIONED_DEGREE and lifted is not None:
+            # An exactly-reducible spline is the one case where reduction *must* be
+            # accurate: the L2-optimal lower-degree approximation of a curve that already
+            # lies in the lower-degree space is the curve itself. The attainable accuracy
+            # is set by the Bernstein Gram matrix, whose condition number grows like
+            # 4 ** degree, which is also why the case stops at a modest degree: past it
+            # the honest bound exceeds the values being compared and the check is vacuous.
+            recovery_tol = tol * 4.0**degree
+            yield Case(
+                GROUP,
+                f"reduce_degree_exact_recovery_{tag}",
+                Bspline.reduce_degree,
+                lambda lifted=lifted: lifted.reduce_degree(1),
+                {**fixture.params, "cp": kind, "kind": "exactly-reducible"},
+                invariants=(
+                    custom(
+                        "recovers-the-reducible-curve",
+                        _reproduces(lifted, pts, recovery_tol),
+                    ),
+                ),
+                must_succeed=legal,
+            )
+
+    if degree + 1 <= _BINCOEFF_SAFE_DEGREE:
+        yield Case(
+            GROUP,
+            f"elevate_degree_{tag}",
+            Bspline.elevate_degree,
+            lambda curve=curve: curve.elevate_degree(1),
+            {**fixture.params, "cp": kind, "increment": 1},
+            invariants=(custom("elevation-is-exact", _reproduces(curve, pts, tol)),),
+            must_succeed=legal,
+        )
+
+    yield Case(
+        GROUP,
+        f"insert_knots_{tag}",
+        Bspline.insert_knots,
+        lambda curve=curve, inserted=inserted: curve.insert_knots(inserted),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("insertion-is-exact", _reproduces(curve, pts, tol)),),
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"subdivide_{tag}",
+        Bspline.subdivide,
+        lambda curve=curve: curve.subdivide(2),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("subdivision-is-exact", _reproduces(curve, pts, tol)),),
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"split_{tag}",
+        Bspline.split,
+        lambda curve=curve, mid=mid: curve.split(0, mid),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("halves-reproduce-original", _split_agreement(curve, fixture, tol)),),
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"to_beziers_{tag}",
+        Bspline.to_beziers,
+        curve.to_beziers,
+        {**fixture.params, "cp": kind},
+        invariants=(custom("beziers-reproduce-original", _bezier_agreement(curve, fixture, tol)),),
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"reverse_roundtrip_{tag}",
+        Bspline.reverse,
+        lambda curve=curve: curve.reverse(0).reverse(0),
+        {**fixture.params, "cp": kind},
+        invariants=(
+            custom(
+                "reverse-twice-is-identity",
+                _bitwise_control_points(np.asarray(curve.control_points)),
+            ),
+        ),
+        must_succeed=legal,
+    )
+
+    if profile is not Profile.FULL:
+        return
+
+    yield Case(
+        GROUP,
+        f"multiply_{tag}",
+        Bspline.multiply,
+        lambda scalar=scalar: scalar.multiply(scalar),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("product-is-pointwise", _product_agreement(scalar, pts, fixture)),),
+        must_succeed=legal,
+    )
+
+    window = (lo + 0.25 * (hi - lo), lo + 0.75 * (hi - lo))
+    yield Case(
+        GROUP,
+        f"restrict_{tag}",
+        Bspline.restrict,
+        lambda curve=curve, window=window: curve.restrict(window),
+        {**fixture.params, "cp": kind},
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"slice_{tag}",
+        Bspline.slice,
+        lambda curve=curve, mid=mid: curve.slice(0, mid),
+        {**fixture.params, "cp": kind},
+        must_succeed=legal,
+    )
+
+    yield Case(
+        GROUP,
+        f"boundary_{tag}",
+        Bspline.boundary,
+        lambda curve=curve: curve.boundary(0, 1),
+        {**fixture.params, "cp": kind},
+        must_succeed=legal,
+    )
+
+    # No must_succeed here: `to_open_bspline` documents a ValueError when the spline is
+    # already open in every direction, which is the case for every clamped fixture.
+    yield Case(
+        GROUP,
+        f"to_open_{tag}",
+        Bspline.to_open_bspline,
+        lambda curve=curve: curve.to_open_bspline(),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("open-form-is-exact", _reproduces(curve, pts, tol)),),
+    )
+
+    yield Case(
+        GROUP,
+        f"remove_inserted_knot_{tag}",
+        Bspline.remove_knots,
+        lambda curve=curve, inserted=inserted: curve.insert_knots(inserted).remove_knots(inserted),
+        {**fixture.params, "cp": kind},
+        invariants=(custom("removal-restores-original", _reproduces(curve, pts, tol)),),
+        must_succeed=legal,
+    )
+
+    if degree >= 1:
+        signed = _sign_alternating_curve(fixture)
+        yield Case(
+            GROUP,
+            f"find_roots_{tag}",
+            find_roots,
+            lambda signed=signed: find_roots(signed),
+            {**fixture.params, "cp": "sign-alternating"},
+            invariants=(custom("root-quality", _root_quality(signed, degree, dtype)),),
+            must_succeed=legal,
+            arrays={"control_points": np.asarray(signed.control_points)},
+        )
+        yield Case(
+            GROUP,
+            f"locate_{tag}",
+            Bspline.locate,
+            lambda fixture=fixture: _locate_round_trip(fixture),
+            {**fixture.params, "cp": "monotone"},
+            must_succeed=legal,
+        )
+
+
+def _try_nd_space(
+    dim: int, degree: int, dtype: np.dtype[np.float32 | np.float64]
+) -> BsplineSpace | None:
+    """Build a small nD space, returning ``None`` if the combination is rejected.
+
+    Args:
+        dim (int): Parametric dimension.
+        degree (int): Degree in every direction.
+        dtype (np.dtype[np.float32 | np.float64]): Knot precision.
+
+    Returns:
+        BsplineSpace | None: The space, or ``None``.
+    """
+    try:
+        return create_uniform_space([degree] * dim, [2] * dim, dtype=dtype)
+    except (ValueError, TypeError):
+        return None
+
+
+def _nd_cases(profile: Profile) -> Iterator[Case]:
+    """Yield multi-dimensional space and spline cases.
+
+    Dimension 4 is included deliberately: the space and grid layers enforce only
+    ``dim >= 1``, so ``n ** dim`` growth is reachable, and the repo has four different
+    answers to "what is the maximum dimension?" in four modules.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One multi-dimensional case.
+    """
+    generator = rng(21)
+    if profile is Profile.FULL:
+        # The nD point convention is (n_pts, dim), which on a *1D* space means (n, 1).
+        # That shape is already logged as leaking a raw Numba TypingError out of
+        # `_evaluate_Bspline_1D`, so it gets exactly one labelled case here rather than
+        # firing on every 1-D crossing: the port needs the case, the findings list does
+        # not need it eleven times.
+        space_1d = create_uniform_space([2], [3])
+        curve_1d = Bspline(
+            space_1d, np.asarray(generator.uniform(-1.0, 1.0, (space_1d.num_total_basis, 1)))
+        )
+        column_pts = np.asarray(generator.uniform(0.1, 0.9, (4, 1)))
+        yield Case(
+            GROUP,
+            "evaluate_1d_with_column_points",
+            Bspline.evaluate,
+            lambda curve_1d=curve_1d, column_pts=column_pts: curve_1d.evaluate(column_pts),
+            {"dim": 1, "degree": 2, "pts_shape": "(n, 1)"},
+            arrays={"pts": column_pts},
+        )
+        # The same 1D/nD asymmetry in `restrict`: a 1D spline takes the bare
+        # `(lower, upper)` pair, the nD convention is one pair per direction. Writing the
+        # nD form on a 1D spline gives a bare `IndexError: list index out of range` from
+        # `_validate_restrict_bounds` instead of the documented `ValueError`. One case, for
+        # the same reason as above.
+        yield Case(
+            GROUP,
+            "restrict_1d_with_nested_bounds",
+            Bspline.restrict,
+            lambda curve_1d=curve_1d: curve_1d.restrict([(0.25, 0.75)]),
+            {"dim": 1, "degree": 2, "bounds_shape": "nD form on a 1D spline"},
+        )
+    for dim in dims(profile, max_dim=4)[1:]:
+        for degree in (0, 1, 3) if profile is Profile.FULL else (1,):
+            for dtype in dtypes(profile):
+                tag = f"dim{dim}_d{degree}_{dtype.name}"
+                params: dict[str, Any] = {"dim": dim, "degree": degree, "dtype": dtype}
+                yield Case(
+                    GROUP,
+                    f"create_uniform_space_{tag}",
+                    create_uniform_space,
+                    lambda dim=dim, degree=degree, dtype=dtype: create_uniform_space(
+                        [degree] * dim, [2] * dim, dtype=dtype
+                    ),
+                    params,
+                )
+                space = _try_nd_space(dim, degree, dtype)
+                if space is None:
+                    continue
+                pts = np.asarray(generator.uniform(0.0, 1.0, (5, dim)), dtype=dtype)
+                yield Case(
+                    GROUP,
+                    f"nd_tabulate_basis_{tag}",
+                    BsplineSpace.tabulate_basis,
+                    lambda space=space, pts=pts: space.tabulate_basis(pts),
+                    params,
+                    invariants=(
+                        custom(
+                            "local-partition-of-unity",
+                            _nd_partition_of_unity(tuple(space.degrees), dtype),
+                        ),
+                        custom(
+                            "first-basis-in-range",
+                            _nd_first_basis_in_range(tuple(space.num_basis), tuple(space.degrees)),
+                        ),
+                    ),
+                )
+                control = np.asarray(
+                    generator.uniform(-1.0, 1.0, (space.num_total_basis, dim)), dtype=dtype
+                )
+                curve = Bspline(space, control)
+                yield Case(
+                    GROUP,
+                    f"nd_evaluate_{tag}",
+                    Bspline.evaluate,
+                    lambda curve=curve, pts=pts: curve.evaluate(pts),
+                    params,
+                    invariants=(
+                        custom(
+                            "in-control-hull",
+                            _within_convex_hull(curve.control_points, degree, dtype),
+                        ),
+                    ),
+                    arrays={"control_points": control, "pts": pts},
+                )
+                if profile is not Profile.FULL:
+                    continue
+                yield Case(
+                    GROUP,
+                    f"nd_cell_supports_{tag}",
+                    BsplineSpace.cell_supports,
+                    lambda space=space: space.cell_supports(np.arange(space.num_total_intervals)),
+                    params,
+                )
+                yield Case(
+                    GROUP,
+                    f"nd_boundary_dofs_{tag}",
+                    BsplineSpace.boundary_dofs,
+                    lambda space=space, dim=dim: space.boundary_dofs(dim - 1, 1),
+                    params,
+                )
+                orders = [min(degree, 1)] * dim
+                yield Case(
+                    GROUP,
+                    f"nd_evaluate_derivatives_{tag}",
+                    Bspline.evaluate_derivatives,
+                    lambda curve=curve, pts=pts, orders=orders: (
+                        curve.evaluate_derivatives(pts, orders)
+                    ),
+                    params,
+                )
+                if dim >= _PAIR:
+                    yield Case(
+                        GROUP,
+                        f"nd_permute_{tag}",
+                        Bspline.permute_directions,
+                        lambda curve=curve, dim=dim: curve.permute_directions([*range(1, dim), 0]),
+                        params,
+                    )
+
+
+def _try_extraction(fixture: _Fixture, target: str) -> SpanwiseElementExtraction | None:
+    """Build an extraction, returning ``None`` when the combination is rejected.
+
+    Args:
+        fixture (_Fixture): The space to build on.
+        target (str): Extraction target name.
+
+    Returns:
+        SpanwiseElementExtraction | None: The extraction, or ``None``.
+    """
+    try:
+        return SpanwiseElementExtraction(BsplineSpace([fixture.space]), target)
+    except (ValueError, TypeError, NotImplementedError, IndexError):
+        return None
+
+
+def _extraction_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`SpanwiseElementExtraction` cases across targets and fixtures.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One extraction case.
+    """
+    generator = rng(31)
+    for fixture in _fixtures(profile):
+        if fixture.space.periodic:
+            continue
+        for target in ("bezier", "cardinal", "lagrange"):
+            tag = f"{fixture.label}_{target}"
+            params = {**fixture.params, "target": target}
+            yield Case(
+                GROUP,
+                f"extraction_build_{tag}",
+                SpanwiseElementExtraction,
+                lambda fixture=fixture, target=target: SpanwiseElementExtraction(
+                    BsplineSpace([fixture.space]), target
+                ),
+                params,
+            )
+            extraction = _try_extraction(fixture, target)
+            if extraction is None:
+                continue
+            n_in = int(np.prod(extraction.input_shape_per_dir))
+            n_out = int(np.prod(extraction.output_shape_per_dir))
+            operand = np.asarray(generator.uniform(-1.0, 1.0, n_in), dtype=fixture.dtype)
+            yield Case(
+                GROUP,
+                f"extraction_apply_{tag}",
+                SpanwiseElementExtraction.apply,
+                lambda extraction=extraction, operand=operand: extraction.apply(operand, 0),
+                params,
+                invariants=(expected_shape((n_out,)),),
+                arrays={"operand": operand},
+            )
+            if profile is not Profile.FULL:
+                continue
+            yield Case(
+                GROUP,
+                f"extraction_tabulate_{tag}",
+                SpanwiseElementExtraction.tabulate,
+                extraction.tabulate,
+                params,
+            )
+            yield Case(
+                GROUP,
+                f"extraction_operator_last_{tag}",
+                SpanwiseElementExtraction.operator,
+                lambda extraction=extraction: extraction.operator(
+                    extraction.num_total_intervals - 1
+                ),
+                params,
+            )
+            yield Case(
+                GROUP,
+                f"extraction_apply_many_{tag}",
+                SpanwiseElementExtraction.apply_many,
+                lambda extraction=extraction, operand=operand: extraction.apply_many(
+                    np.broadcast_to(operand, (extraction.num_total_intervals, operand.size)).copy(),
+                    np.arange(extraction.num_total_intervals),
+                ),
+                params,
+            )
+
+
+def _factory_cases(profile: Profile) -> Iterator[Case]:
+    """Yield knot-vector factory, interpolation and quasi-interpolation cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One factory or fitting case.
+    """
+    swept_domains = domains(profile) if profile is Profile.FULL else (domains(profile)[0],)
+    for degree in degrees(profile):
+        for dtype in dtypes(profile):
+            for domain in swept_domains:
+                tag = f"d{degree}_{dtype.name}_[{domain[0]:g},{domain[1]:g}]"
+                params: dict[str, Any] = {
+                    "degree": degree,
+                    "dtype": dtype,
+                    "domain": list(domain),
+                }
+                for continuity in sorted({-1, 0, degree - 1}):
+                    if not -1 <= continuity <= degree - 1:
+                        continue
+                    yield Case(
+                        GROUP,
+                        f"uniform_open_knots_{tag}_c{continuity}",
+                        create_uniform_open_knots,
+                        lambda degree=degree, continuity=continuity, domain=domain, dtype=dtype: (
+                            create_uniform_open_knots(
+                                3, degree, continuity, domain=domain, dtype=dtype
+                            )
+                        ),
+                        {**params, "continuity": continuity},
+                        invariants=(custom("knots-non-decreasing", _non_decreasing),),
+                    )
+                yield Case(
+                    GROUP,
+                    f"uniform_periodic_knots_{tag}",
+                    create_uniform_periodic_knots,
+                    lambda degree=degree, domain=domain, dtype=dtype: (
+                        create_uniform_periodic_knots(3, degree, domain=domain, dtype=dtype)
+                    ),
+                    params,
+                    invariants=(custom("knots-non-decreasing", _non_decreasing),),
+                )
+                yield Case(
+                    GROUP,
+                    f"cardinal_knots_{tag}",
+                    create_cardinal_knots,
+                    lambda degree=degree, dtype=dtype: create_cardinal_knots(
+                        3, degree, dtype=dtype
+                    ),
+                    params,
+                    invariants=(custom("knots-non-decreasing", _non_decreasing),),
+                )
+                # Zero and one interval: the count corners the factories must either
+                # accept cleanly or reject.
+                for n_intervals in (0, 1):
+                    yield Case(
+                        GROUP,
+                        f"uniform_open_knots_{tag}_n{n_intervals}",
+                        create_uniform_open_knots,
+                        lambda degree=degree, n=n_intervals, domain=domain, dtype=dtype: (
+                            create_uniform_open_knots(n, degree, domain=domain, dtype=dtype)
+                        ),
+                        {**params, "n_intervals": n_intervals},
+                    )
+
+    if profile is not Profile.FULL:
+        return
+
+    for degree in (1, 2, 3):
+        for dtype in dtypes(profile):
+            space = create_uniform_space([degree], [4], dtype=dtype)
+            params = {"degree": degree, "dtype": dtype}
+            yield Case(
+                GROUP,
+                f"interpolate_bspline_d{degree}_{dtype.name}",
+                interpolate_bspline,
+                lambda space=space: interpolate_bspline(np.sin, space),
+                params,
+            )
+            yield Case(
+                GROUP,
+                f"quasi_interpolate_bspline_d{degree}_{dtype.name}",
+                quasi_interpolate_bspline,
+                lambda space=space: quasi_interpolate_bspline(np.cos, space),
+                params,
+            )
+
+
+def _try_thb(root: BsplineSpace, truncate: bool) -> THBSplineSpace | None:
+    """Build a THB space, returning ``None`` when the combination is rejected.
+
+    Args:
+        root (BsplineSpace): The level-0 space.
+        truncate (bool): Whether to truncate.
+
+    Returns:
+        THBSplineSpace | None: The space, or ``None``.
+    """
+    try:
+        return create_thb_space(root, 2, truncate=truncate)
+    except (ValueError, TypeError, NotImplementedError):
+        return None
+
+
+def _thb_cell_points(
+    space: THBSplineSpace, cid: int, generator: np.random.Generator
+) -> npt.NDArray[np.float64]:
+    """Sample points strictly inside one cell of a THB space's grid.
+
+    ``THBSplineSpace.tabulate_basis`` rejects points outside the named cell, so the
+    samples must come from that cell's own bounds.
+
+    Args:
+        space (THBSplineSpace): The THB space.
+        cid (int): Flat cell id.
+        generator (np.random.Generator): Seeded generator.
+
+    Returns:
+        npt.NDArray[np.float64]: Points of shape ``(3, dim)``.
+    """
+    lo, hi = space.grid.cell_bounds(cid)
+    lo = np.asarray(lo, dtype=np.float64)
+    hi = np.asarray(hi, dtype=np.float64)
+    unit = np.asarray(generator.uniform(0.2, 0.8, (3, lo.size)))
+    return lo + unit * (hi - lo)
+
+
+def _thb_cases(profile: Profile) -> Iterator[Case]:
+    """Yield THB-spline space cases, truncated and not.
+
+    Only the *truncated* basis is a partition of unity: the non-truncated hierarchical
+    basis genuinely is not (``_thb_spline_space.py:196-202``), so asserting it there
+    would manufacture findings. The refinement depth is kept shallow on purpose -- the
+    ``factor ** level`` int64 overflow in the hierarchical grid past level 63 is already
+    logged and is not this group's target.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One THB case.
+    """
+    generator = rng(41)
+    for dim in dims(profile, max_dim=2):
+        for degree in (1, 2, 3) if profile is Profile.FULL else (2,):
+            for truncate in (True, False):
+                tag = f"dim{dim}_d{degree}_trunc{int(truncate)}"
+                params = {"dim": dim, "degree": degree, "truncate": truncate}
+                root = create_uniform_space([degree] * dim, [4] * dim)
+                yield Case(
+                    GROUP,
+                    f"thb_create_{tag}",
+                    create_thb_space,
+                    lambda root=root, truncate=truncate: create_thb_space(
+                        root, 2, truncate=truncate
+                    ),
+                    params,
+                )
+                space = _try_thb(root, truncate)
+                if space is None:
+                    continue
+                refined = space.refine([0])
+                for level_name, current in (("level0", space), ("level1", refined)):
+                    cid = current.grid.num_cells - 1
+                    pts = _thb_cell_points(current, cid, generator)
+                    yield Case(
+                        GROUP,
+                        f"thb_tabulate_{tag}_{level_name}",
+                        type(current).tabulate_basis,
+                        lambda current=current, cid=cid, pts=pts: current.tabulate_basis(cid, pts),
+                        {**params, "level": level_name, "cid": cid},
+                        invariants=(
+                            (
+                                custom(
+                                    "thb-partition-of-unity",
+                                    _local_partition_of_unity(degree * dim, np.float64),
+                                ),
+                            )
+                            if truncate
+                            else ()
+                        ),
+                    )
+                if profile is not Profile.FULL:
+                    continue
+                yield Case(
+                    GROUP,
+                    f"thb_prolongation_{tag}",
+                    type(space).prolongation_to,
+                    lambda space=space, refined=refined: space.prolongation_to(refined),
+                    params,
+                )
+                yield Case(
+                    GROUP,
+                    f"thb_refine_out_of_range_{tag}",
+                    type(space).refine,
+                    lambda space=space: space.refine([space.grid.num_cells]),
+                    params,
+                )
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _construction_cases(profile)
+    yield from _tabulation_cases(profile)
+    yield from _space_operation_cases(profile)
+    yield from _curve_operation_cases(profile)
+    yield from _nd_cases(profile)
+    yield from _extraction_cases(profile)
+    yield from _factory_cases(profile)
+    yield from _thb_cases(profile)

--- a/tools/adversarial_sweep/_probes_geometry.py
+++ b/tools/adversarial_sweep/_probes_geometry.py
@@ -1,0 +1,401 @@
+"""Probes for :mod:`pantr.geometry` and :mod:`pantr.transform`.
+
+Both are pure NumPy, so the yield here is contract violations and translation
+sensitivity rather than Numba overruns: the bounding-box invariants that matter are
+that a transformed box still encloses the images of every corner, and that
+``union``/``intersect``/``pad`` keep their set relations at a domain translated to
+``[1e6, 1e6 + 1]`` as well as on the unit box.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pantr.geometry import AABB
+from pantr.transform import AffineTransform
+
+from ._axes import Profile, dims, domains, rng
+from ._core import Case, custom
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+GROUP = "geometry"
+"""Registry name of this probe group."""
+
+
+def _corners(lo: np.ndarray, hi: np.ndarray) -> np.ndarray:
+    """Enumerate the corners of an axis-aligned box.
+
+    Args:
+        lo (np.ndarray): Lower corner, shape ``(ndim,)``.
+        hi (np.ndarray): Upper corner, shape ``(ndim,)``.
+
+    Returns:
+        np.ndarray: Corners, shape ``(2 ** ndim, ndim)``.
+    """
+    return np.array(list(itertools.product(*zip(lo, hi, strict=True))), dtype=np.float64)
+
+
+def _encloses_transformed_corners(
+    lo: np.ndarray, hi: np.ndarray, affine: AffineTransform
+) -> object:
+    """Build a predicate asserting the transformed AABB encloses every mapped corner.
+
+    Args:
+        lo (np.ndarray): Lower corner of the source box.
+        hi (np.ndarray): Upper corner of the source box.
+        affine (AffineTransform): The map applied to the box.
+
+    Returns:
+        object: Predicate suitable for :func:`pantr_sweep._core.custom`.
+    """
+    mapped = affine(_corners(lo, hi))
+    scale = float(max(np.max(np.abs(mapped)), 1.0))
+    # The bound must hold up to the rounding of the matrix-vector product itself:
+    # ndim fused multiply-adds on values of magnitude `scale` carry at most
+    # ndim * eps * scale of error, and the enclosure is computed by the same product.
+    slack = mapped.shape[1] * float(np.finfo(np.float64).eps) * scale * 4.0
+
+    def predicate(result: object) -> str | None:
+        box = result
+        if not isinstance(box, AABB):
+            return f"expected AABB, got {type(box).__name__}"
+        below = float(np.max(box.lo - mapped.min(axis=0)))
+        above = float(np.max(mapped.max(axis=0) - box.hi))
+        worst = max(below, above)
+        if worst > slack:
+            return f"transformed box misses a corner by {worst:.3e} > {slack:.3e}"
+        return None
+
+    return predicate
+
+
+def _aabb_cases(profile: Profile) -> Iterator[Case]:
+    """Yield the :class:`pantr.geometry.AABB` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile construction or operation.
+    """
+    generator = rng(11)
+    for ndim in dims(profile, max_dim=4):
+        for lo_val, hi_val in domains(profile):
+            lo = np.full(ndim, lo_val)
+            hi = np.full(ndim, hi_val)
+            tag = f"d{ndim}_[{lo_val:g},{hi_val:g}]"
+
+            yield Case(
+                GROUP,
+                f"aabb_construct_{tag}",
+                AABB,
+                lambda lo=lo, hi=hi: AABB(lo, hi),
+                {"ndim": ndim, "lo": lo_val, "hi": hi_val},
+                arrays={"lo": lo, "hi": hi},
+            )
+            yield Case(
+                GROUP,
+                f"aabb_degenerate_{tag}",
+                AABB,
+                lambda lo=lo: AABB(lo, lo),
+                {"ndim": ndim, "lo": lo_val, "kind": "collapsed"},
+            )
+            yield Case(
+                GROUP,
+                f"aabb_inverted_{tag}",
+                AABB,
+                lambda lo=lo, hi=hi: AABB(hi, lo),
+                {"ndim": ndim, "kind": "inverted"},
+            )
+
+            box = AABB(lo, hi)
+            other = AABB(lo + 0.5 * (hi - lo), hi + 0.5 * (hi - lo))
+
+            yield Case(
+                GROUP,
+                f"aabb_contains_center_{tag}",
+                AABB.contains_point,
+                lambda box=box, lo=lo, hi=hi: box.contains_point(0.5 * (lo + hi)),
+                {"ndim": ndim, "lo": lo_val, "hi": hi_val},
+                invariants=(
+                    custom("center-inside", lambda r: None if r else "center reported out"),
+                ),
+            )
+            yield Case(
+                GROUP,
+                f"aabb_union_encloses_{tag}",
+                AABB.union,
+                lambda box=box, other=other: box.union(other),
+                {"ndim": ndim, "lo": lo_val, "hi": hi_val},
+                invariants=(
+                    custom(
+                        "union-encloses",
+                        lambda r, box=box, other=other: None
+                        if (
+                            np.all(r.lo <= box.lo)
+                            and np.all(r.lo <= other.lo)
+                            and np.all(r.hi >= box.hi)
+                            and np.all(r.hi >= other.hi)
+                        )
+                        else f"union {r} does not enclose both inputs",
+                    ),
+                ),
+            )
+            yield Case(
+                GROUP,
+                f"aabb_intersect_contained_{tag}",
+                AABB.intersect,
+                lambda box=box, other=other: box.intersect(other),
+                {"ndim": ndim, "lo": lo_val, "hi": hi_val},
+                invariants=(
+                    custom(
+                        "intersect-contained",
+                        lambda r, box=box, other=other: None
+                        if r is None
+                        or (
+                            np.all(r.lo >= np.minimum(box.lo, other.lo))
+                            and np.all(r.hi <= np.maximum(box.hi, other.hi))
+                        )
+                        else f"intersection {r} escapes both inputs",
+                    ),
+                ),
+            )
+            yield Case(
+                GROUP,
+                f"aabb_pad_negative_{tag}",
+                AABB.pad,
+                lambda box=box, lo=lo, hi=hi: box.pad(-0.75 * float(np.max(hi - lo))),
+                {"ndim": ndim, "kind": "pad-collapses-box"},
+            )
+
+            if profile is Profile.FULL:
+                nan_lo = lo.copy()
+                nan_lo[0] = np.nan
+                yield Case(
+                    GROUP,
+                    f"aabb_nan_lo_{tag}",
+                    AABB,
+                    lambda nan_lo=nan_lo, hi=hi: AABB(nan_lo, hi),
+                    {"ndim": ndim, "kind": "nan"},
+                    finite_inputs=False,
+                )
+                inf_hi = hi.copy()
+                inf_hi[0] = np.inf
+                yield Case(
+                    GROUP,
+                    f"aabb_inf_hi_{tag}",
+                    AABB,
+                    lambda lo=lo, inf_hi=inf_hi: AABB(lo, inf_hi),
+                    {"ndim": ndim, "kind": "inf"},
+                    finite_inputs=False,
+                )
+                yield Case(
+                    GROUP,
+                    f"aabb_shape_mismatch_{tag}",
+                    AABB,
+                    lambda lo=lo, ndim=ndim: AABB(lo, np.zeros(ndim + 1)),
+                    {"ndim": ndim, "kind": "shape-mismatch"},
+                )
+                yield Case(
+                    GROUP,
+                    f"aabb_from_bounds_{tag}",
+                    AABB.from_bounds,
+                    lambda box=box: AABB.from_bounds(box.as_bounds()),
+                    {"ndim": ndim, "kind": "round-trip"},
+                    invariants=(
+                        custom(
+                            "as_bounds-round-trip",
+                            lambda r, box=box: None
+                            if r == box
+                            else f"from_bounds(as_bounds()) != original: {r} vs {box}",
+                        ),
+                    ),
+                )
+
+                # Transformed enclosure: the invariant a translated domain breaks first.
+                matrix = np.asarray(generator.uniform(-1.5, 1.5, (ndim, ndim)))
+                matrix += ndim * np.eye(ndim)  # keep it comfortably non-singular
+                affine = AffineTransform(matrix, np.full(ndim, 0.25 * (hi_val - lo_val)))
+                yield Case(
+                    GROUP,
+                    f"aabb_transform_{tag}",
+                    AABB.transform,
+                    lambda box=box, affine=affine: box.transform(affine),
+                    {"ndim": ndim, "lo": lo_val, "hi": hi_val, "kind": "affine"},
+                    invariants=(
+                        custom("encloses-corners", _encloses_transformed_corners(lo, hi, affine)),
+                    ),
+                    arrays={"lo": lo, "hi": hi, "matrix": matrix, "offset": affine.offset},
+                )
+                singular = np.zeros((ndim, ndim))
+                yield Case(
+                    GROUP,
+                    f"aabb_transform_singular_{tag}",
+                    AABB.transform,
+                    lambda box=box, singular=singular, ndim=ndim: box.transform(
+                        AffineTransform(singular, np.zeros(ndim))
+                    ),
+                    {"ndim": ndim, "kind": "singular-matrix"},
+                )
+
+    for ndim in (0, -1):
+        yield Case(
+            GROUP,
+            f"aabb_unbounded_ndim{ndim}",
+            AABB.unbounded,
+            lambda ndim=ndim: AABB.unbounded(ndim),
+            {"ndim": ndim},
+            finite_inputs=False,
+        )
+        yield Case(
+            GROUP,
+            f"aabb_empty_ndim{ndim}",
+            AABB.empty,
+            lambda ndim=ndim: AABB.empty(ndim),
+            {"ndim": ndim},
+            finite_inputs=False,
+        )
+
+
+def _transform_cases(profile: Profile) -> Iterator[Case]:
+    """Yield the :class:`pantr.transform.AffineTransform` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile construction or operation.
+    """
+    generator = rng(12)
+    for ndim in dims(profile, max_dim=4):
+        eye = np.eye(ndim)
+        yield Case(
+            GROUP,
+            f"affine_identity_d{ndim}",
+            AffineTransform.identity,
+            lambda ndim=ndim: AffineTransform.identity(ndim),
+            {"ndim": ndim},
+        )
+        yield Case(
+            GROUP,
+            f"affine_singular_inverse_d{ndim}",
+            AffineTransform.inverse,
+            lambda ndim=ndim: AffineTransform(np.zeros((ndim, ndim))).inverse,
+            {"ndim": ndim, "kind": "singular"},
+        )
+        yield Case(
+            GROUP,
+            f"affine_nonsquare_d{ndim}",
+            AffineTransform,
+            lambda ndim=ndim: AffineTransform(np.zeros((ndim, ndim + 1))),
+            {"ndim": ndim, "kind": "non-square"},
+        )
+        yield Case(
+            GROUP,
+            f"affine_zero_scaling_d{ndim}",
+            AffineTransform.scaling,
+            lambda ndim=ndim: AffineTransform.scaling(np.zeros(ndim)),
+            {"ndim": ndim, "kind": "zero-factor"},
+        )
+        yield Case(
+            GROUP,
+            f"affine_nan_translation_d{ndim}",
+            AffineTransform,
+            lambda eye=eye, ndim=ndim: AffineTransform(eye, np.full(ndim, np.nan)),
+            {"ndim": ndim, "kind": "nan-translation"},
+            finite_inputs=False,
+        )
+
+        if profile is not Profile.FULL:
+            continue
+
+        matrix = np.asarray(generator.uniform(-1.0, 1.0, (ndim, ndim))) + ndim * eye
+        for offset_scale in (1.0, 1e6):
+            offset = offset_scale * np.asarray(generator.uniform(-1.0, 1.0, ndim))
+            affine = AffineTransform(matrix, offset)
+            yield Case(
+                GROUP,
+                f"affine_inverse_round_trip_d{ndim}_off{offset_scale:g}",
+                AffineTransform.inverse,
+                lambda affine=affine: affine.inverse.compose(affine),
+                {"ndim": ndim, "kind": "round-trip", "offset_scale": offset_scale},
+                invariants=(
+                    custom(
+                        "inverse-composes-to-identity",
+                        lambda r, ndim=ndim, matrix=matrix, offset=offset: _identity_failure(
+                            r, ndim, matrix, offset
+                        ),
+                    ),
+                ),
+                arrays={"matrix": matrix, "offset": offset},
+            )
+        yield Case(
+            GROUP,
+            f"affine_rotation_nan_d{ndim}",
+            AffineTransform.rotation_2d,
+            lambda: AffineTransform.rotation_2d(np.nan),
+            {"kind": "nan-angle"},
+            finite_inputs=False,
+        )
+        yield Case(
+            GROUP,
+            f"affine_mirror_zero_normal_d{ndim}",
+            AffineTransform.mirror,
+            lambda ndim=ndim: AffineTransform.mirror(np.zeros(ndim)),
+            {"ndim": ndim, "kind": "zero-normal"},
+        )
+
+
+def _identity_failure(
+    result: object, ndim: int, matrix: np.ndarray, offset: np.ndarray
+) -> str | None:
+    """Check that a composed inverse is the identity to a conditioning-scaled bound.
+
+    Both parts are checked, because they fail differently: the linear part is bounded
+    by ``cond(A) * eps``, while the translation part carries the *offset's own*
+    magnitude through ``-A^-1 b``, so a domain translated to ``1e6`` moves its
+    attainable accuracy up by six orders. Checking only the matrix would call a
+    translated round trip clean no matter how badly the offset cancelled.
+
+    Args:
+        result (object): The composed transform.
+        ndim (int): Dimension.
+        matrix (np.ndarray): The matrix that was inverted, whose condition number sets
+            the attainable accuracy.
+        offset (np.ndarray): The translation, whose magnitude scales the residual.
+
+    Returns:
+        str | None: ``None`` when the identity holds, otherwise the deviation.
+    """
+    if not isinstance(result, AffineTransform):
+        return f"expected AffineTransform, got {type(result).__name__}"
+    eps = float(np.finfo(np.float64).eps)
+    cond = float(np.linalg.cond(matrix))
+    tol = 16.0 * ndim * cond * eps
+    worst = float(np.max(np.abs(result.matrix - np.eye(ndim))))
+    if worst > tol:
+        return f"max|A^-1 A - I| = {worst:.3e} > {tol:.3e} (cond = {cond:.3e})"
+    scale = max(float(np.max(np.abs(offset))), 1.0)
+    tol_offset = tol * scale
+    worst_offset = float(np.max(np.abs(result.offset)))
+    if worst_offset > tol_offset:
+        return f"max|A^-1 b + b'| = {worst_offset:.3e} > {tol_offset:.3e} (scale {scale:.1e})"
+    return None
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _aabb_cases(profile)
+    yield from _transform_cases(profile)

--- a/tools/adversarial_sweep/_probes_grid.py
+++ b/tools/adversarial_sweep/_probes_grid.py
@@ -1,0 +1,2170 @@
+"""Probes for :mod:`pantr.grid`.
+
+``pantr.grid`` is Tier-1 surface for the C++ port: :class:`~pantr.grid.TensorProductGrid`
+and :class:`~pantr.grid.HierarchicalGrid` back ``locate_many`` with Numba kernels (per-axis
+search and top-down hierarchy descent), and :class:`~pantr.grid.BVH` backs ``query_aabb``
+with an iterative stack-based traversal -- both run under ``nopython=True`` with no bounds
+checking, so an off-by-one span or a stack overrun corrupts memory silently rather than
+raising. The pure-Python arithmetic (cell indexing, facet/neighbour resolution, block
+bookkeeping) is lower Numba risk but still worth hostile inputs: it feeds the kernels their
+descriptor arrays, and a bug there produces the same silently-wrong cell ids.
+
+Every invariant here is checked against an *independent* oracle -- brute-force overlap
+tests via :class:`pantr.geometry.AABB`, geometric adjacency from ``cell_bounds``, or a
+closed-form volume/tiling formula -- never a second call into the same algorithm.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from pantr.bspline import BsplineSpace, BsplineSpace1D
+from pantr.geometry import AABB
+from pantr.grid import (
+    BVH,
+    CellTags,
+    FacetTags,
+    HierarchicalGrid,
+    Partition,
+    TensorProductGrid,
+    cell_quadrature,
+    hierarchical_grid,
+    overlay,
+    partition_grid,
+    tensor_product_grid,
+    uniform_grid,
+)
+from pantr.quad import gauss_legendre_quadrature
+from pantr.tolerance import get_default
+
+from ._axes import Profile, dims, domains
+from ._core import Case, custom, expected_shape
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy.typing as npt
+
+GROUP = "grid"
+"""Registry name of this probe group."""
+
+_EPS64 = float(np.finfo(np.float64).eps)
+"""``float64`` machine epsilon; every derived tolerance below is a multiple of this."""
+
+_UNIFORM_SPACING_ATOL = 1e-10
+"""Mirrors ``TensorProductGrid._UNIFORM_SPACING_ATOL`` (`_tensor_product_grid.py:53`), the
+absolute tolerance ``is_uniform`` compares spacing differences against. Needed here only to
+derive a perturbation guaranteed to sit well above it; not a probe tolerance itself."""
+
+# Deepest level probed for HierarchicalGrid refinement. `factor ** level` overflowing
+# int64 in `_hier_collect_cell_bounds_core` (`_hier_core.py:328-334`) is already logged
+# for level ~63+; capping here at 20 keeps this sweep from re-reporting that known issue.
+_MAX_PROBED_LEVEL = 20
+
+
+# ---------------------------------------------------------------------------
+# Shared builders
+# ---------------------------------------------------------------------------
+
+
+def _grid_tag(ndim: int, domain: tuple[float, float]) -> str:
+    """Build a short case-label tag from a dimension and a domain.
+
+    Args:
+        ndim (int): Spatial dimension.
+        domain (tuple[float, float]): ``(lo, hi)`` domain.
+
+    Returns:
+        str: ``"d{ndim}_[{lo},{hi}]"``.
+    """
+    lo, hi = domain
+    return f"d{ndim}_[{lo:g},{hi:g}]"
+
+
+def _uniform_breakpoints(
+    ndim: int, domain: tuple[float, float], n_per_axis: int
+) -> list[npt.NDArray[np.float64]]:
+    """Build identical uniform per-axis breakpoint arrays.
+
+    Args:
+        ndim (int): Spatial dimension.
+        domain (tuple[float, float]): ``(lo, hi)`` domain, shared by every axis.
+        n_per_axis (int): Number of cells per axis.
+
+    Returns:
+        list[npt.NDArray[np.float64]]: One ``n_per_axis + 1``-length array per axis.
+    """
+    lo, hi = domain
+    return [np.linspace(lo, hi, n_per_axis + 1, dtype=np.float64) for _ in range(ndim)]
+
+
+def _tp_grid(ndim: int, domain: tuple[float, float], n_per_axis: int = 3) -> TensorProductGrid:
+    """Build a uniform :class:`TensorProductGrid`.
+
+    Args:
+        ndim (int): Spatial dimension.
+        domain (tuple[float, float]): ``(lo, hi)`` domain, shared by every axis.
+        n_per_axis (int): Number of cells per axis. Defaults to 3.
+
+    Returns:
+        TensorProductGrid: The constructed grid.
+    """
+    return TensorProductGrid(_uniform_breakpoints(ndim, domain, n_per_axis))
+
+
+def _volume(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Compute per-row axis-aligned box volumes.
+
+    Args:
+        lo (npt.NDArray[np.float64]): Lower corners, shape ``(n, ndim)``.
+        hi (npt.NDArray[np.float64]): Upper corners, shape ``(n, ndim)``.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(n,)`` volumes.
+    """
+    return np.prod(hi - lo, axis=1)
+
+
+# ---------------------------------------------------------------------------
+# Invariant factories shared across TensorProductGrid and HierarchicalGrid
+# ---------------------------------------------------------------------------
+
+
+def _collect_vs_percell_predicate(
+    grid: TensorProductGrid | HierarchicalGrid,
+    *,
+    exact: bool,
+    tol: float = 0.0,
+) -> Callable[[object], str | None]:
+    """Build a predicate comparing ``collect_cell_bounds()`` to per-cell ``cell_bounds``.
+
+    ``HierarchicalGrid.collect_cell_bounds`` documents *exact* agreement with
+    per-cell ``cell_bounds`` (`_hierarchical_grid.py:1420-1421`), so callers pass
+    ``exact=True`` and get a bitwise (``np.array_equal``) check.
+    ``TensorProductGrid.collect_cell_bounds`` makes no such claim -- its result is a
+    vectorized re-derivation from the same breakpoint arrays -- so callers pass a
+    derived ``tol`` instead.
+
+    Args:
+        grid (TensorProductGrid | HierarchicalGrid): The grid whose per-cell
+            ``cell_bounds`` is the oracle.
+        exact (bool): Require bitwise equality rather than a tolerance.
+        tol (float): Absolute tolerance when ``exact`` is ``False``.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``(cell_lo, cell_hi)`` result
+        of ``collect_cell_bounds()``, reporting the worst mismatching cell.
+    """
+
+    def predicate(result: object) -> str | None:
+        cell_lo, cell_hi = result  # type: ignore[misc]
+        worst = 0.0
+        worst_cid = -1
+        for cid in range(grid.num_cells):
+            lo, hi = grid.cell_bounds(cid)
+            diff_lo = float(np.max(np.abs(lo - cell_lo[cid])))
+            diff_hi = float(np.max(np.abs(hi - cell_hi[cid])))
+            diff = max(diff_lo, diff_hi)
+            if diff > worst:
+                worst, worst_cid = diff, cid
+        limit = 0.0 if exact else tol
+        if worst > limit:
+            kind = "bitwise" if exact else f"tol {tol:.3e}"
+            return (
+                f"collect_cell_bounds vs cell_bounds mismatch at cid={worst_cid}: "
+                f"{worst:.3e} ({kind})"
+            )
+        return None
+
+    return predicate
+
+
+def _tiling_predicate(
+    dom_lo: npt.NDArray[np.float64],
+    dom_hi: npt.NDArray[np.float64],
+    num_cells: int,
+) -> Callable[[object], str | None]:
+    """Build a predicate asserting cell bounds tile the domain exactly.
+
+    Volume: summing ``num_cells`` per-cell volumes (each an ``ndim``-fold product)
+    carries at most ``O(ndim * eps)`` relative rounding per product plus
+    ``O(num_cells * eps)`` from the summation; an explicit factor of 8 covers both
+    constants. Coverage: the cell union's own extreme corners must not escape the
+    domain by more than the same bound.
+
+    Args:
+        dom_lo (npt.NDArray[np.float64]): Domain lower corner, shape ``(ndim,)``.
+        dom_hi (npt.NDArray[np.float64]): Domain upper corner, shape ``(ndim,)``.
+        num_cells (int): Total cell count (sets the summation error).
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``(cell_lo, cell_hi)``
+        result of ``collect_cell_bounds()``.
+    """
+    ndim = dom_lo.shape[0]
+    domain_vol = float(np.prod(dom_hi - dom_lo))
+    scale = max(abs(domain_vol), 1.0)
+    tol = 8.0 * num_cells * ndim * _EPS64 * scale
+
+    def predicate(result: object) -> str | None:
+        cell_lo, cell_hi = result  # type: ignore[misc]
+        volumes = _volume(cell_lo, cell_hi)
+        total = float(np.sum(volumes))
+        if abs(total - domain_vol) > tol:
+            return (
+                f"cell volumes sum to {total:.6e}, domain volume is {domain_vol:.6e} "
+                f"(tol {tol:.3e})"
+            )
+        escape_lo = float(np.max(dom_lo - cell_lo.min(axis=0)))
+        escape_hi = float(np.max(cell_hi.max(axis=0) - dom_hi))
+        worst = max(escape_lo, escape_hi)
+        if worst > tol:
+            return f"cell bounds escape the domain by {worst:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _locate_roundtrip_case(
+    group_tag: str,
+    grid: TensorProductGrid | HierarchicalGrid,
+    *,
+    params: dict[str, Any],
+    profile: Profile,
+) -> Iterator[Case]:
+    """Yield the ``locate`` / ``locate_many`` round-trip cases for one grid.
+
+    Every cell's centroid (from ``collect_cell_bounds``, not from ``locate`` itself)
+    must locate back to its own cell id, singly and in a batch; a point far outside
+    the domain and non-finite coordinates must locate to nothing. The individual
+    ``nan``-only and ``inf``-only single-point cases are ``FULL``-only; the smoke
+    profile keeps only the roundtrip, the far-outside point, and the combined
+    nan/inf batch (which already exercises both non-finite kinds together).
+
+    Args:
+        group_tag (str): Label prefix identifying the grid under test.
+        grid (TensorProductGrid | HierarchicalGrid): The grid to probe.
+        params (dict[str, Any]): Axis values recorded in the case.
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The round-trip and outside/non-finite cases.
+    """
+
+    def run_roundtrip() -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        cell_lo, cell_hi = grid.collect_cell_bounds()
+        centroids = 0.5 * (cell_lo + cell_hi)
+        single = np.array(
+            [-1 if (c := grid.locate(centroids[i])) is None else c for i in range(grid.num_cells)],
+            dtype=np.int64,
+        )
+        batch = grid.locate_many(centroids)
+        return single, batch
+
+    def check_roundtrip(result: object) -> str | None:
+        single, batch = result  # type: ignore[misc]
+        expected = np.arange(grid.num_cells, dtype=np.int64)
+        if not np.array_equal(single, expected):
+            bad = np.flatnonzero(single != expected)
+            return f"locate(centroid) mismatch at cids {bad[:5].tolist()}"
+        if not np.array_equal(batch, expected):
+            bad = np.flatnonzero(batch != expected)
+            return f"locate_many mismatch at cids {bad[:5].tolist()}"
+        return None
+
+    yield Case(
+        GROUP,
+        f"{group_tag}_locate_roundtrip",
+        grid.locate,
+        run_roundtrip,
+        params,
+        invariants=(custom("locate-roundtrip", check_roundtrip),),
+    )
+
+    # The domain's own lower corner, not an arbitrary cell's bounds: after refinement
+    # flat cell id 0 need not sit at the domain corner (ids are reassigned level by
+    # level, and the coarsest surviving block can be anywhere), so `cell_bounds(0)`
+    # is not a reliable "near the corner" reference once the grid has been refined.
+    if grid.num_cells:
+        cell_lo_all, _ = grid.collect_cell_bounds()
+        dom_lo = cell_lo_all.min(axis=0)
+    else:
+        dom_lo = np.zeros(grid.ndim)
+    ndim = grid.ndim
+    outside = dom_lo - 10.0 - np.arange(ndim, dtype=np.float64)
+
+    def check_none(result: object) -> str | None:
+        return None if result is None else f"expected None outside the domain; got {result!r}"
+
+    yield Case(
+        GROUP,
+        f"{group_tag}_locate_outside",
+        grid.locate,
+        lambda outside=outside: grid.locate(outside),
+        {**params, "kind": "far-outside"},
+        invariants=(custom("outside-is-none", check_none),),
+    )
+
+    if profile is Profile.FULL:
+        nan_pt = np.full(ndim, np.nan)
+        inf_pt = np.full(ndim, np.inf)
+        for name, pt in (("nan", nan_pt), ("inf", inf_pt)):
+            yield Case(
+                GROUP,
+                f"{group_tag}_locate_{name}",
+                grid.locate,
+                lambda pt=pt: grid.locate(pt),
+                {**params, "kind": name},
+                invariants=(custom(f"{name}-is-none", check_none),),
+                finite_inputs=False,
+            )
+
+    def check_all_outside(result: object) -> str | None:
+        arr = np.asarray(result)
+        if np.any(arr != -1):
+            return f"locate_many should report -1 for every non-finite row; got {arr.tolist()}"
+        return None
+
+    yield Case(
+        GROUP,
+        f"{group_tag}_locate_many_nonfinite",
+        grid.locate_many,
+        lambda ndim=ndim: grid.locate_many(
+            np.array([[np.nan] * ndim, [np.inf] * ndim, [-np.inf] * ndim])
+        ),
+        {**params, "kind": "nan-inf-batch"},
+        invariants=(custom("nonfinite-is-minus-one", check_all_outside),),
+        finite_inputs=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TensorProductGrid: construction, uniformity, tiling, locate, restrict
+# ---------------------------------------------------------------------------
+
+
+def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`TensorProductGrid` construction cases across dimension and domain.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One construction, one tiling check, and one collect-vs-percell check
+        per ``(ndim, domain)``.
+    """
+    ndims = dims(profile, max_dim=4) if profile is Profile.FULL else (2,)
+    for ndim in ndims:
+        for domain in domains(profile):
+            tag = _grid_tag(ndim, domain)
+            n_per_axis = 2 if ndim >= 4 else 3  # noqa: PLR2004 -- keep n**4 cheap
+            grid = _tp_grid(ndim, domain, n_per_axis)
+            params = {"ndim": ndim, "domain": domain, "n_per_axis": n_per_axis}
+
+            yield Case(
+                GROUP,
+                f"tp_construct_{tag}",
+                TensorProductGrid,
+                lambda ndim=ndim, domain=domain, n=n_per_axis: _tp_grid(ndim, domain, n),
+                params,
+                invariants=(
+                    custom(
+                        "cell-count",
+                        lambda r, n=n_per_axis, ndim=ndim: None
+                        if r.num_cells == n**ndim
+                        else f"num_cells={r.num_cells}, expected {n**ndim}",
+                    ),
+                ),
+            )
+
+            dom_lo, dom_hi = grid.bounds[:, 0].copy(), grid.bounds[:, 1].copy()
+            yield Case(
+                GROUP,
+                f"tp_tiling_{tag}",
+                TensorProductGrid.collect_cell_bounds,
+                grid.collect_cell_bounds,
+                params,
+                invariants=(
+                    custom("cell-tiling", _tiling_predicate(dom_lo, dom_hi, grid.num_cells)),
+                ),
+            )
+            yield Case(
+                GROUP,
+                f"tp_collect_vs_percell_{tag}",
+                TensorProductGrid.collect_cell_bounds,
+                grid.collect_cell_bounds,
+                params,
+                # Not an exactness claim in the docstring (see the predicate's own
+                # docstring): a broadcast re-derivation from the same breakpoints
+                # carries at most one rounding per axis beyond the direct read.
+                invariants=(
+                    custom(
+                        "collect-vs-percell",
+                        _collect_vs_percell_predicate(
+                            grid, exact=False, tol=4.0 * _EPS64 * max(abs(dom_hi).max(), 1.0)
+                        ),
+                    ),
+                ),
+            )
+
+    if profile is not Profile.FULL:
+        return
+
+    # Malformed constructions: each must be a documented rejection, not a finding.
+    yield Case(GROUP, "tp_empty_breakpoints", TensorProductGrid, lambda: TensorProductGrid([]), {})
+    yield Case(
+        GROUP,
+        "tp_too_short_axis",
+        TensorProductGrid,
+        lambda: TensorProductGrid([np.array([0.0])]),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "tp_nonfinite_axis",
+        TensorProductGrid,
+        lambda: TensorProductGrid([np.array([0.0, np.nan, 1.0])]),
+        {},
+        finite_inputs=False,
+    )
+    yield Case(
+        GROUP,
+        "tp_non_increasing_axis",
+        TensorProductGrid,
+        lambda: TensorProductGrid([np.array([0.0, 1.0, 0.5])]),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "tp_flat_axis",
+        TensorProductGrid,
+        lambda: TensorProductGrid([np.array([0.0, 0.0, 1.0])]),
+        {},
+    )
+
+
+def _tp_uniformity_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``is_uniform`` corner cases across every domain magnitude.
+
+    An exactly-uniform grid must report ``True`` on every domain, including the
+    translated ``[1e6, 1e6 + 1]`` one, and a grid perturbed by a *relative* amount
+    well above ``_UNIFORM_SPACING_ATOL`` (``1e-10``) must report ``False`` even at
+    that scale -- the tolerance is absolute, so this is where a translated domain
+    would silently flip the verdict if it were derived from the coordinates instead.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One ``True``-expected and one ``False``-expected case per domain.
+    """
+    for domain in domains(profile):
+        tag = _grid_tag(2, domain)
+        breakpoints = _uniform_breakpoints(2, domain, 4)
+        exact_grid = TensorProductGrid(breakpoints)
+        yield Case(
+            GROUP,
+            f"tp_is_uniform_true_{tag}",
+            TensorProductGrid.is_uniform.fget,  # type: ignore[attr-defined]
+            lambda g=exact_grid: g.is_uniform,
+            {"domain": domain, "kind": "exact"},
+            invariants=(
+                custom(
+                    "expected-uniform",
+                    lambda r: None if r else "exactly-spaced grid reported non-uniform",
+                ),
+            ),
+        )
+
+        span = domain[1] - domain[0]
+        perturbed = [bp.copy() for bp in breakpoints]
+        spacing = span / 4.0
+        # `spacing * 1e-7` is the relative perturbation the domain-scale axis is meant
+        # to probe, but on the tiny `[0, 1e-6]` domain that relative amount (~2.5e-14)
+        # falls *below* the absolute `_UNIFORM_SPACING_ATOL = 1e-10` and would register
+        # as uniform -- correctly, since it genuinely is uniform to that tolerance, not
+        # a probe finding. Flooring at `100 * _UNIFORM_SPACING_ATOL` keeps the
+        # perturbation two orders of magnitude above the code's own absolute tolerance
+        # on every domain, while staying well under `spacing` so the breakpoints stay
+        # strictly increasing.
+        perturbation = max(spacing * 1e-7, 100.0 * _UNIFORM_SPACING_ATOL)
+        perturbed[0][2] += perturbation
+        perturbed_grid = TensorProductGrid(perturbed)
+        yield Case(
+            GROUP,
+            f"tp_is_uniform_false_{tag}",
+            TensorProductGrid.is_uniform.fget,  # type: ignore[attr-defined]
+            lambda g=perturbed_grid: g.is_uniform,
+            {"domain": domain, "kind": "perturbed"},
+            invariants=(
+                custom(
+                    "expected-nonuniform",
+                    lambda r: None if not r else "spacing-perturbed grid reported uniform",
+                ),
+            ),
+            arrays={"breakpoints_axis0": perturbed[0]},
+        )
+
+
+def _tp_locate_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`TensorProductGrid.locate` round-trip cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: See :func:`_locate_roundtrip_case`.
+    """
+    ndims = dims(profile, max_dim=4) if profile is Profile.FULL else (2,)
+    for ndim in ndims:
+        for domain in domains(profile):
+            n_per_axis = 2 if ndim >= 4 else 3  # noqa: PLR2004 -- keep n**4 cheap
+            grid = _tp_grid(ndim, domain, n_per_axis)
+            yield from _locate_roundtrip_case(
+                f"tp_{_grid_tag(ndim, domain)}",
+                grid,
+                params={"ndim": ndim, "domain": domain, "n_per_axis": n_per_axis},
+                profile=profile,
+            )
+
+
+def _tp_neighbor_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`TensorProductGrid.neighbor_across_facet` symmetry cases.
+
+    For every interior facet, crossing to the neighbour and back across the
+    opposite local facet must return the original cell -- a self-consistency
+    property that a bug in the per-axis arithmetic (an off-by-one at a domain
+    edge, most likely) would break asymmetrically.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One symmetry check per ``(ndim, domain)``, plus a boundary check.
+    """
+    ndims = dims(profile, max_dim=3) if profile is Profile.FULL else (2,)
+    for ndim in ndims:
+        for domain in domains(profile):
+            grid = _tp_grid(ndim, domain, 3)
+            tag = _grid_tag(ndim, domain)
+
+            def check_symmetry(_: object, grid: TensorProductGrid = grid) -> str | None:
+                for cid in range(grid.num_cells):
+                    for lfid in range(grid.num_local_facets(cid)):
+                        nbr = grid.neighbor_across_facet(cid, lfid)
+                        if nbr is None:
+                            continue
+                        axis, side = grid.local_facet_axis_side(cid, lfid)
+                        opposite = 2 * axis + (1 - side)
+                        back = grid.neighbor_across_facet(nbr, opposite)
+                        if back != cid:
+                            return (
+                                f"cell {cid} facet {lfid} -> {nbr}, but {nbr}'s opposite facet "
+                                f"{opposite} -> {back} (expected {cid})"
+                            )
+                return None
+
+            yield Case(
+                GROUP,
+                f"tp_neighbor_symmetry_{tag}",
+                TensorProductGrid.neighbor_across_facet,
+                lambda: None,
+                {"ndim": ndim, "domain": domain},
+                invariants=(custom("neighbor-symmetry", check_symmetry),),
+            )
+
+    if profile is not Profile.FULL:
+        return
+    grid = _tp_grid(2, (0.0, 1.0), 2)
+    yield Case(
+        GROUP,
+        "tp_neighbor_lfid_out_of_range",
+        TensorProductGrid.neighbor_across_facet,
+        lambda: grid.neighbor_across_facet(0, 4),
+        {"kind": "lfid-oob"},
+    )
+    yield Case(
+        GROUP,
+        "tp_neighbor_cid_out_of_range",
+        TensorProductGrid.neighbor_across_facet,
+        lambda: grid.neighbor_across_facet(grid.num_cells, 0),
+        {"kind": "cid-oob"},
+    )
+
+
+def _tp_restrict_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`TensorProductGrid.restrict` cases.
+
+    The docstring's exactness claim ("never re-based or re-clamped") licenses a
+    bitwise comparison between the sub-grid's cell bounds and the original grid's,
+    reached through ``local_to_global_cell``.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Corner selections plus the malformed-input rejections.
+    """
+    grid = _tp_grid(3, (0.0, 5.0), 4)
+
+    def check_exact_slice(result: object) -> str | None:
+        restriction = result
+        for local_cid in range(restriction.grid.num_cells):  # type: ignore[attr-defined]
+            global_cid = int(restriction.local_to_global_cell[local_cid])  # type: ignore[attr-defined]
+            lo_sub, hi_sub = restriction.grid.cell_bounds(local_cid)  # type: ignore[attr-defined]
+            lo_glob, hi_glob = grid.cell_bounds(global_cid)
+            if not (np.array_equal(lo_sub, lo_glob) and np.array_equal(hi_sub, hi_glob)):
+                return (
+                    f"restrict cell {local_cid} (-> global {global_cid}) bounds "
+                    "are not a pure slice"
+                )
+        return None
+
+    selectors = {
+        "single_corner": np.array([0]),
+        "all_cells": np.arange(grid.num_cells),
+    }
+    if profile is Profile.FULL:
+        selectors["single_center"] = np.array([grid.num_cells // 2])
+        selectors["two_opposite_corners"] = np.array([0, grid.num_cells - 1])
+    for name, ids in selectors.items():
+        yield Case(
+            GROUP,
+            f"tp_restrict_{name}",
+            TensorProductGrid.restrict,
+            lambda ids=ids: grid.restrict(ids),
+            {"kind": name, "n_ids": int(ids.size)},
+            invariants=(custom("restrict-is-pure-slice", check_exact_slice),),
+        )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP, "tp_restrict_empty", TensorProductGrid.restrict, lambda: grid.restrict([]), {}
+    )
+    yield Case(
+        GROUP,
+        "tp_restrict_out_of_range",
+        TensorProductGrid.restrict,
+        lambda: grid.restrict([grid.num_cells]),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "tp_restrict_non_integer",
+        TensorProductGrid.restrict,
+        lambda: grid.restrict(np.array([0.5])),
+        {},
+    )
+
+
+def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`pantr.grid.uniform_grid` factory corner cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One-cell-per-axis, anisotropic counts, and malformed-input rejections.
+    """
+    for ndim in dims(profile, max_dim=4):
+        bounds = np.array([[0.0, 1.0 + d] for d in range(ndim)])
+        yield Case(
+            GROUP,
+            f"uniform_grid_single_cell_d{ndim}",
+            uniform_grid,
+            lambda bounds=bounds, ndim=ndim: uniform_grid(bounds, 1),
+            {"ndim": ndim, "cells": 1},
+            invariants=(
+                custom(
+                    "single-cell",
+                    lambda r: None if r.num_cells == 1 else f"num_cells={r.num_cells}, expected 1",
+                ),
+            ),
+        )
+        if profile is Profile.FULL and ndim > 1:
+            anisotropic = tuple(range(2, 2 + ndim))
+            yield Case(
+                GROUP,
+                f"uniform_grid_anisotropic_d{ndim}",
+                uniform_grid,
+                lambda bounds=bounds, anisotropic=anisotropic: uniform_grid(bounds, anisotropic),
+                {"ndim": ndim, "cells": anisotropic},
+                invariants=(
+                    custom(
+                        "cells-per-axis-matches",
+                        lambda r, anisotropic=anisotropic: None
+                        if r.cells_per_axis == anisotropic
+                        else f"cells_per_axis={r.cells_per_axis}, expected {anisotropic}",
+                    ),
+                ),
+            )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP, "uniform_grid_zero_cells", uniform_grid, lambda: uniform_grid([[0.0, 1.0]], 0), {}
+    )
+    yield Case(
+        GROUP,
+        "uniform_grid_degenerate_bounds",
+        uniform_grid,
+        lambda: uniform_grid([[1.0, 1.0]], 2),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "uniform_grid_inverted_bounds",
+        uniform_grid,
+        lambda: uniform_grid([[1.0, 0.0]], 2),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "uniform_grid_cells_wrong_length",
+        uniform_grid,
+        lambda: uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2, 2]),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "uniform_grid_bad_shape",
+        uniform_grid,
+        lambda: uniform_grid(np.zeros((2, 3)), 2),
+        {},
+    )
+
+
+def _tensor_product_from_space_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`pantr.grid.tensor_product_grid` cases built from a B-spline space.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: A clamped-space success and the documented periodic rejection.
+    """
+    if profile is not Profile.FULL:
+        return
+    clamped = BsplineSpace1D(np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]), 2)
+    space = BsplineSpace([clamped, clamped])
+    yield Case(
+        GROUP,
+        "tensor_product_grid_from_clamped_space",
+        tensor_product_grid,
+        lambda space=space: tensor_product_grid(space),
+        {"kind": "clamped"},
+    )
+    periodic_knots = np.arange(-2, 6, dtype=np.float64)
+    periodic = BsplineSpace1D(periodic_knots, 2, periodic=True)
+    periodic_space = BsplineSpace([clamped, periodic])
+    yield Case(
+        GROUP,
+        "tensor_product_grid_from_periodic_space",
+        tensor_product_grid,
+        lambda periodic_space=periodic_space: tensor_product_grid(periodic_space),
+        {"kind": "periodic-axis"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# HierarchicalGrid: construction, refinement, bounds, locate, masks
+# ---------------------------------------------------------------------------
+
+
+def _deep_refine_chain(grid: HierarchicalGrid, target_level: int) -> None:
+    """Refine a hierarchical grid's origin cell down to ``target_level``.
+
+    Repeatedly refines only the single active cell at multi-index ``(0, ..., 0)``,
+    so the total active-cell count grows linearly in ``target_level`` rather than
+    exponentially.
+
+    Args:
+        grid (HierarchicalGrid): Grid to mutate in place.
+        target_level (int): Deepest level to reach.
+    """
+    ndim = grid.ndim
+    origin_lo = tuple(0 for _ in range(ndim))
+    origin_hi = tuple(1 for _ in range(ndim))
+    for level in range(target_level):
+        grid.refine(level, origin_lo, origin_hi)
+
+
+def _hier_construction_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`HierarchicalGrid` construction cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One construction per ``(ndim, factor)`` plus malformed-input rejections.
+    """
+    factors: tuple[int | tuple[int, ...], ...] = (2, 3) if profile is Profile.FULL else (2,)
+    for ndim in dims(profile, max_dim=4):
+        root = _tp_grid(ndim, (0.0, 1.0), 2)
+        for factor in factors:
+            yield Case(
+                GROUP,
+                f"hier_construct_d{ndim}_f{factor}",
+                HierarchicalGrid,
+                lambda root=root, factor=factor: HierarchicalGrid(root, factor),
+                {"ndim": ndim, "factor": factor},
+                invariants=(
+                    custom(
+                        "starts-at-root",
+                        lambda r, root=root: None
+                        if r.num_cells == root.num_cells
+                        else f"num_cells={r.num_cells}, expected {root.num_cells}",
+                    ),
+                ),
+            )
+        if profile is Profile.FULL and ndim >= 2:  # noqa: PLR2004 -- anisotropic factor needs 2 axes
+            # Alternate 2/1 per axis so every ndim gets a genuinely mixed factor
+            # (a factor of 1 means "no subdivision on that axis", which is legal).
+            anisotropic = tuple(2 if k % 2 == 0 else 1 for k in range(ndim))
+            yield Case(
+                GROUP,
+                f"hier_construct_anisotropic_d{ndim}",
+                HierarchicalGrid,
+                lambda root=root, anisotropic=anisotropic: HierarchicalGrid(root, anisotropic),
+                {"ndim": ndim, "factor": anisotropic},
+            )
+
+    if profile is not Profile.FULL:
+        return
+    root2 = _tp_grid(2, (0.0, 1.0), 2)
+    yield Case(
+        GROUP, "hier_bad_root_type", HierarchicalGrid, lambda: HierarchicalGrid(object(), 2), {}
+    )
+    yield Case(
+        GROUP,
+        "hier_factor_wrong_length",
+        HierarchicalGrid,
+        lambda: HierarchicalGrid(root2, (2, 2, 2)),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "hier_factor_below_one",
+        HierarchicalGrid,
+        lambda: HierarchicalGrid(root2, 0),
+        {},
+    )
+
+
+def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
+    """Yield refine/refine_cells/coarsen depth and no-op/inverse cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Depth ladder (1, 2, 3, capped-deep), a no-op refine, an exact
+        coarsen-undoes-refine round trip, and malformed-input rejections.
+    """
+    levels = (1, 2, 3, _MAX_PROBED_LEVEL) if profile is Profile.FULL else (1, 2)
+    for target_level in levels:
+        root = _tp_grid(2, (0.0, 1.0), 2)
+        grid = HierarchicalGrid(root, 2)
+
+        def build(
+            grid: HierarchicalGrid = grid, target_level: int = target_level
+        ) -> HierarchicalGrid:
+            _deep_refine_chain(grid, target_level)
+            return grid
+
+        yield Case(
+            GROUP,
+            f"hier_refine_depth_{target_level}",
+            HierarchicalGrid.refine,
+            build,
+            {"target_level": target_level},
+            invariants=(
+                custom(
+                    "reaches-target-level",
+                    lambda r, target_level=target_level: None
+                    if r.max_level == target_level
+                    else f"max_level={r.max_level}, expected {target_level}",
+                ),
+            ),
+        )
+
+    if profile is not Profile.FULL:
+        return
+
+    # Union semantics: refining a region with no active cells there is a no-op.
+    root = _tp_grid(2, (0.0, 1.0), 4)
+    grid = HierarchicalGrid(root, 2)
+    grid.refine(0, (0, 0), (1, 1))
+
+    def refine_noop() -> tuple[int, int]:
+        before = grid.num_cells
+        grid.refine(0, (0, 0), (1, 1))  # already fully refined away at level 0
+        return before, grid.num_cells
+
+    yield Case(
+        GROUP,
+        "hier_refine_noop_on_refined_region",
+        HierarchicalGrid.refine,
+        refine_noop,
+        {"kind": "noop"},
+        invariants=(
+            custom(
+                "unchanged",
+                lambda r: None
+                if r[0] == r[1]
+                else f"num_cells changed {r[0]} -> {r[1]} on a no-op refine",
+            ),
+        ),
+    )
+
+    # Coarsen exactly undoes a matching refine.
+    root2 = _tp_grid(2, (0.0, 1.0), 3)
+    grid2 = HierarchicalGrid(root2, 3)
+
+    def refine_then_coarsen() -> tuple[int, int]:
+        before = grid2.num_cells
+        grid2.refine(0, (1, 1), (2, 2))
+        grid2.coarsen(0, (1, 1), (2, 2))
+        return before, grid2.num_cells
+
+    yield Case(
+        GROUP,
+        "hier_coarsen_undoes_refine",
+        HierarchicalGrid.coarsen,
+        refine_then_coarsen,
+        {"kind": "round-trip"},
+        invariants=(
+            custom(
+                "restored",
+                lambda r: None
+                if r[0] == r[1]
+                else f"num_cells {r[0]} -> refine -> coarsen -> {r[1]}",
+            ),
+        ),
+    )
+
+    root3 = _tp_grid(2, (0.0, 1.0), 2)
+    grid3 = HierarchicalGrid(root3, 2)
+    yield Case(
+        GROUP,
+        "hier_refine_level_out_of_range",
+        HierarchicalGrid.refine,
+        lambda: grid3.refine(5, (0, 0), (1, 1)),
+        {"kind": "level-oob"},
+    )
+    yield Case(
+        GROUP,
+        "hier_refine_lo_ge_hi",
+        HierarchicalGrid.refine,
+        lambda: grid3.refine(0, (1, 1), (1, 1)),
+        {"kind": "lo-ge-hi"},
+    )
+    yield Case(
+        GROUP,
+        "hier_coarsen_partial_region",
+        HierarchicalGrid.coarsen,
+        lambda: (grid3.refine(0, (0, 0), (1, 1)), grid3.coarsen(0, (0, 0), (2, 2)))[-1],
+        {"kind": "partially-refined-region"},
+    )
+    yield Case(
+        GROUP,
+        "hier_refine_cells_out_of_range",
+        HierarchicalGrid.refine_cells,
+        lambda: grid3.refine_cells([grid3.num_cells]),
+        {"kind": "cid-oob"},
+    )
+
+
+def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``collect_cell_bounds`` / ``export_cells`` / tiling cases for a refined hierarchy.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The exact ``collect_cell_bounds`` check, the ``export_cells`` bound
+        check, and the tiling check, for each dimension and refinement depth.
+    """
+    for ndim in dims(profile, max_dim=4):
+        for target_level in (2,) if profile is not Profile.FULL else (1, 2, 3):
+            root = _tp_grid(ndim, (0.0, 1.0), 2)
+            grid = HierarchicalGrid(root, 2)
+            _deep_refine_chain(grid, target_level)
+            tag = f"d{ndim}_l{target_level}"
+            params = {"ndim": ndim, "target_level": target_level}
+
+            # `collect_cell_bounds` docstring claims exact agreement with `cell_bounds`
+            # (`_hierarchical_grid.py:1420-1421`): bitwise check.
+            yield Case(
+                GROUP,
+                f"hier_collect_vs_percell_{tag}",
+                HierarchicalGrid.collect_cell_bounds,
+                grid.collect_cell_bounds,
+                params,
+                invariants=(
+                    custom(
+                        "collect-vs-percell-exact",
+                        _collect_vs_percell_predicate(grid, exact=True),
+                    ),
+                ),
+            )
+
+            dom_lo, dom_hi = root.bounds[:, 0].copy(), root.bounds[:, 1].copy()
+            yield Case(
+                GROUP,
+                f"hier_tiling_{tag}",
+                HierarchicalGrid.collect_cell_bounds,
+                grid.collect_cell_bounds,
+                params,
+                invariants=(
+                    custom("cell-tiling", _tiling_predicate(dom_lo, dom_hi, grid.num_cells)),
+                ),
+            )
+
+            # `export_cells` docstring (`_hierarchical_grid.py:1502-1516`) claims only
+            # `8 * eps * |coordinate|` agreement, and says bitwise agreement is
+            # unattainable in general -- do not tighten this to exact equality.
+            yield Case(
+                GROUP,
+                f"hier_export_cells_bound_{tag}",
+                HierarchicalGrid.export_cells,
+                grid.export_cells,
+                params,
+                invariants=(custom("export-cells-bound", _export_cells_predicate(grid)),),
+            )
+
+
+def _export_cells_predicate(grid: HierarchicalGrid) -> Callable[[object], str | None]:
+    """Build a predicate checking ``export_cells`` against the docstring's own bound.
+
+    Recomputes each cell's expected corners directly from ``cell_bounds`` (never
+    from ``export_cells``'s own lattice-deduplication code path), so this is an
+    independent oracle, not a mirror.
+
+    Args:
+        grid (HierarchicalGrid): The grid whose ``cell_bounds`` is the oracle.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``(points, conn)`` result.
+    """
+    ndim = grid.ndim
+
+    def predicate(result: object) -> str | None:
+        points, conn = result  # type: ignore[misc]
+        worst_violation = 0.0
+        worst_cid = -1
+        for cid in range(grid.num_cells):
+            lo, hi = grid.cell_bounds(cid)
+            corners = points[conn[cid]]
+            for corner_id in range(corners.shape[0]):
+                expected = np.where(
+                    [(corner_id >> k) & 1 for k in range(ndim)],
+                    hi,
+                    lo,
+                )
+                tol = 8.0 * _EPS64 * np.maximum(np.abs(expected), 1.0)
+                violation = float(np.max(np.abs(corners[corner_id] - expected) - tol))
+                if violation > worst_violation:
+                    worst_violation, worst_cid = violation, cid
+        if worst_violation > 0.0:
+            return (
+                f"export_cells corner exceeds the docstring's 8*eps*|coordinate| bound "
+                f"by {worst_violation:.3e} at cid={worst_cid}"
+            )
+        return None
+
+    return predicate
+
+
+def _hier_locate_cases(profile: Profile) -> Iterator[Case]:
+    """Yield locate round-trip cases for a refined hierarchical grid.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: See :func:`_locate_roundtrip_case`.
+    """
+    for ndim in dims(profile, max_dim=3):
+        for domain in domains(profile):
+            root = _tp_grid(ndim, domain, 2)
+            grid = HierarchicalGrid(root, 2)
+            _deep_refine_chain(grid, 2)
+            yield from _locate_roundtrip_case(
+                f"hier_{_grid_tag(ndim, domain)}",
+                grid,
+                profile=profile,
+                params={"ndim": ndim, "domain": domain, "target_level": 2},
+            )
+
+
+def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``active_leaf_mask`` / ``subdomain_mask`` / ``level_cells_per_axis`` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Mask-shape and content checks, plus malformed-level rejections.
+    """
+    root = _tp_grid(2, (0.0, 1.0), 2)
+    grid = HierarchicalGrid(root, 2)
+    _deep_refine_chain(grid, 3)
+
+    levels = range(grid.max_level + 1) if profile is Profile.FULL else (0, grid.max_level)
+    for level in levels:
+        yield Case(
+            GROUP,
+            f"hier_active_leaf_mask_l{level}",
+            HierarchicalGrid.active_leaf_mask,
+            lambda level=level: grid.active_leaf_mask(level),
+            {"level": level},
+            invariants=(expected_shape(grid.level_cells_per_axis(level)),),
+        )
+        yield Case(
+            GROUP,
+            f"hier_subdomain_mask_l{level}",
+            HierarchicalGrid.subdomain_mask,
+            lambda level=level: grid.subdomain_mask(level),
+            {"level": level},
+            invariants=(expected_shape(grid.level_cells_per_axis(level)),),
+        )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP,
+        "hier_level_cells_per_axis_above_max",
+        HierarchicalGrid.level_cells_per_axis,
+        lambda: grid.level_cells_per_axis(grid.max_level + 5),
+        {"kind": "above-max-level"},
+    )
+    yield Case(
+        GROUP,
+        "hier_level_cells_per_axis_negative",
+        HierarchicalGrid.level_cells_per_axis,
+        lambda: grid.level_cells_per_axis(-1),
+        {"kind": "negative-level"},
+    )
+    yield Case(
+        GROUP,
+        "hier_active_leaf_mask_above_max",
+        HierarchicalGrid.active_leaf_mask,
+        lambda: grid.active_leaf_mask(grid.max_level + 1),
+        {"kind": "above-max-level"},
+    )
+
+
+def _hier_hanging_neighbor_cases(profile: Profile) -> Iterator[Case]:
+    """Yield ``hanging_neighbors`` geometric-adjacency cases at a level interface.
+
+    The oracle recomputes touching from ``cell_bounds`` (independent of
+    ``hanging_neighbors``'s own block-descent code path): a returned neighbour must
+    share the queried facet's plane and overlap its extent on every other axis.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One adjacency check over every cell/facet of a once-refined grid.
+    """
+    root = _tp_grid(2, (0.0, 1.0), 2)
+    grid = HierarchicalGrid(root, 2)
+    grid.refine(0, (0, 0), (1, 1))  # refine one root cell; leaves a hanging interface
+
+    def check_touching(_: object) -> str | None:
+        for cid in range(grid.num_cells):
+            lo, hi = grid.cell_bounds(cid)
+            for lfid in range(grid.num_local_facets(cid)):
+                axis, side = grid.local_facet_axis_side(cid, lfid)
+                plane = hi[axis] if side == 1 else lo[axis]
+                for nbr in grid.hanging_neighbors(cid, lfid):
+                    n_lo, n_hi = grid.cell_bounds(nbr)
+                    n_plane = n_lo[axis] if side == 1 else n_hi[axis]
+                    if abs(n_plane - plane) > 8.0 * _EPS64 * max(abs(plane), 1.0):
+                        return (
+                            f"cell {cid} facet {lfid}: neighbor {nbr} does not touch "
+                            "the facet plane"
+                        )
+                    other_axes = [k for k in range(grid.ndim) if k != axis]
+                    overlap_lo = np.maximum(lo[other_axes], n_lo[other_axes])
+                    overlap_hi = np.minimum(hi[other_axes], n_hi[other_axes])
+                    if np.any(overlap_lo > overlap_hi):
+                        return (
+                            f"cell {cid} facet {lfid}: neighbor {nbr} does not overlap "
+                            "the facet extent"
+                        )
+        return None
+
+    yield Case(
+        GROUP,
+        "hier_hanging_neighbors_touch",
+        HierarchicalGrid.hanging_neighbors,
+        lambda: None,
+        {"kind": "geometric-adjacency"},
+        invariants=(custom("hanging-neighbors-touch", check_touching),),
+    )
+
+
+def _hier_restrict_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`HierarchicalGrid.restrict` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Corner selections plus the malformed-input rejections.
+    """
+    root = _tp_grid(2, (0.0, 1.0), 3)
+    grid = HierarchicalGrid(root, 2)
+    grid.refine(0, (1, 1), (2, 2))
+
+    selectors = {
+        "single_leaf": np.array([0]),
+        "all_leaves": np.arange(grid.num_cells),
+    }
+    if profile is Profile.FULL:
+        selectors["deep_leaf"] = np.array([grid.num_cells - 1])
+    for name, ids in selectors.items():
+        yield Case(
+            GROUP,
+            f"hier_restrict_{name}",
+            HierarchicalGrid.restrict,
+            lambda ids=ids: grid.restrict(ids),
+            {"kind": name, "n_ids": int(ids.size)},
+            invariants=(
+                custom(
+                    "restrict-returns-hierarchical-grid",
+                    lambda r: None
+                    if isinstance(r.grid, HierarchicalGrid)  # type: ignore[attr-defined]
+                    else f"expected HierarchicalGrid, got {type(r.grid).__name__}",  # type: ignore[attr-defined]
+                ),
+            ),
+        )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP, "hier_restrict_empty", HierarchicalGrid.restrict, lambda: grid.restrict([]), {}
+    )
+    yield Case(
+        GROUP,
+        "hier_restrict_out_of_range",
+        HierarchicalGrid.restrict,
+        lambda: grid.restrict([grid.num_cells]),
+        {},
+    )
+
+
+def _hierarchical_grid_factory_case(profile: Profile) -> Iterator[Case]:
+    """Yield a case exercising the standalone :func:`hierarchical_grid` factory.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: A single factory-equivalence check.
+    """
+    if profile is not Profile.FULL:
+        return
+    root = _tp_grid(2, (0.0, 1.0), 2)
+    yield Case(
+        GROUP,
+        "hierarchical_grid_factory",
+        hierarchical_grid,
+        lambda root=root: hierarchical_grid(root, 2),
+        {"kind": "factory"},
+        invariants=(
+            custom(
+                "matches-constructor",
+                lambda r, root=root: None
+                if r.num_cells == root.num_cells
+                else f"num_cells={r.num_cells}, expected {root.num_cells}",
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# BVH: construction, degenerate configurations, query completeness
+# ---------------------------------------------------------------------------
+
+
+def _bvh_query_predicate(
+    cell_lo: npt.NDArray[np.float64],
+    cell_hi: npt.NDArray[np.float64],
+    query_box: AABB,
+) -> Callable[[object], str | None]:
+    """Build a predicate comparing ``query_aabb`` to a brute-force overlap scan.
+
+    The brute-force oracle calls :meth:`pantr.geometry.AABB.overlaps` (an
+    elementwise NumPy comparison), an entirely different code path from the BVH's
+    iterative stack traversal.
+
+    Args:
+        cell_lo (npt.NDArray[np.float64]): Per-cell lower corners, shape ``(n, ndim)``.
+        cell_hi (npt.NDArray[np.float64]): Per-cell upper corners, shape ``(n, ndim)``.
+        query_box (AABB): The query box.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``query_aabb`` result.
+    """
+
+    def predicate(result: object) -> str | None:
+        brute = {
+            cid
+            for cid in range(cell_lo.shape[0])
+            if AABB(cell_lo[cid], cell_hi[cid]).overlaps(query_box)
+        }
+        got = {int(c) for c in result}  # type: ignore[attr-defined]
+        if got != brute:
+            missing = sorted(brute - got)[:5]
+            extra = sorted(got - brute)[:5]
+            return f"query_aabb mismatch vs brute force: missing={missing} extra={extra}"
+        return None
+
+    return predicate
+
+
+def _bvh_from_grid_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`Grid.query_aabb` completeness cases over a small tensor-product grid.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Whole-domain, single-cell, shared-face, degenerate, outside, and
+        unbounded query boxes, each checked against the brute-force oracle.
+    """
+    grid = _tp_grid(2, (0.0, 1.0), 4)
+    cell_lo, cell_hi = grid.collect_cell_bounds()
+    domain_lo, domain_hi = grid.bounds[:, 0], grid.bounds[:, 1]
+
+    # A box spanning a single interior shared face (zero thickness on one axis):
+    # touching counts as overlapping, so both cells across the face must be hit.
+    face_box = AABB(np.array([0.25, 0.0]), np.array([0.25, 1.0]))
+    boxes = {
+        "whole_domain": AABB(domain_lo, domain_hi),
+        "single_cell": AABB(cell_lo[0], cell_hi[0]),
+        # AABB rejects NaN bounds at construction (`geometry.py:147-151`), so a
+        # literal NaN query box cannot be built; an unbounded (inf) box is the
+        # closest hostile substitute and exercises the same inf-arithmetic path
+        # in the BVH's overlap test.
+        "unbounded": AABB.unbounded(2),
+    }
+    if profile is Profile.FULL:
+        boxes["shared_face"] = face_box
+        boxes["zero_volume_point"] = AABB(cell_lo[0], cell_lo[0])
+        boxes["entirely_outside"] = AABB(domain_lo - 10.0, domain_lo - 5.0)
+    for name, box in boxes.items():
+        yield Case(
+            GROUP,
+            f"bvh_query_{name}",
+            grid.query_aabb,
+            lambda box=box: grid.query_aabb(box),
+            {"kind": name},
+            invariants=(custom("query-completeness", _bvh_query_predicate(cell_lo, cell_hi, box)),),
+        )
+
+
+def _bvh_direct_construction_cases(profile: Profile) -> Iterator[Case]:
+    """Yield direct :class:`BVH` constructor cases (dtype/shape strictness).
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Wrong dtype, mismatched shapes, and ``n_nodes`` mismatch rejections.
+    """
+    if profile is not Profile.FULL:
+        return
+    lo = np.zeros((1, 2), dtype=np.float64)
+    hi = np.ones((1, 2), dtype=np.float64)
+    idx = np.array([-1], dtype=np.int64)
+    cell = np.array([0], dtype=np.int64)
+    yield Case(
+        GROUP,
+        "bvh_direct_wrong_dtype",
+        BVH,
+        lambda: BVH(lo.astype(np.float32), hi, idx, idx, cell, n_cells=1),
+        {"kind": "wrong-dtype"},
+    )
+    yield Case(
+        GROUP,
+        "bvh_direct_shape_mismatch",
+        BVH,
+        lambda: BVH(lo, np.ones((2, 2)), idx, idx, cell, n_cells=1),
+        {"kind": "shape-mismatch"},
+    )
+    yield Case(
+        GROUP,
+        "bvh_direct_n_nodes_mismatch",
+        BVH,
+        lambda: BVH(lo, hi, idx, idx, cell, n_cells=2),
+        {"kind": "n-nodes-mismatch"},
+    )
+
+
+def _bvh_n_nodes_predicate(n_cells: int) -> Callable[[object], str | None]:
+    """Build a predicate asserting ``BVH.n_nodes == 2 * n_cells - 1`` (0 when empty).
+
+    Args:
+        n_cells (int): Number of cells the tree was built over.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the resulting :class:`BVH`.
+    """
+    expected = 2 * n_cells - 1 if n_cells > 0 else 0
+
+    def predicate(result: object) -> str | None:
+        got = result.n_nodes  # type: ignore[attr-defined]
+        if got != expected:
+            return f"n_nodes={got}, expected {expected}"
+        return None
+
+    return predicate
+
+
+def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :meth:`BVH.from_cell_bounds` cases over degenerate cell configurations.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Zero cells, one cell, all-identical boxes, all-collapsed points, a
+        line arrangement, and touching-face boxes, each checked against the
+        brute-force overlap oracle.
+    """
+    configs: dict[str, tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {
+        "zero_cells": (np.zeros((0, 2)), np.zeros((0, 2))),
+        "one_cell": (np.zeros((1, 2)), np.ones((1, 2))),
+        # Touching-face pair: two boxes sharing exactly the x=1 face.
+        "touching_faces": (
+            np.array([[0.0, 0.0], [1.0, 0.0]]),
+            np.array([[1.0, 1.0], [2.0, 1.0]]),
+        ),
+    }
+    if profile is Profile.FULL:
+        configs["all_identical"] = (np.zeros((5, 2)), np.ones((5, 2)))
+        configs["all_collapsed_to_point"] = (np.full((5, 2), 0.5), np.full((5, 2), 0.5))
+        n_line = 6
+        line_lo = np.stack([np.arange(n_line, dtype=np.float64), np.zeros(n_line)], axis=1)
+        line_hi = line_lo + np.array([1.0, 1.0])
+        configs["line_arrangement"] = (line_lo, line_hi)
+
+    query = AABB(np.array([0.4, 0.4]), np.array([0.6, 0.6]))
+    for name, (lo, hi) in configs.items():
+        yield Case(
+            GROUP,
+            f"bvh_degenerate_{name}",
+            BVH.from_cell_bounds,
+            lambda lo=lo, hi=hi: BVH.from_cell_bounds(lo, hi),
+            {"kind": name, "n_cells": int(lo.shape[0])},
+            invariants=(
+                custom(
+                    "n-nodes-formula",
+                    _bvh_n_nodes_predicate(int(lo.shape[0])),
+                ),
+            ),
+        )
+        if lo.shape[0] > 0:
+            yield Case(
+                GROUP,
+                f"bvh_degenerate_query_{name}",
+                BVH.query_aabb,
+                lambda lo=lo, hi=hi: BVH.from_cell_bounds(lo, hi).query_aabb(query),
+                {"kind": name, "n_cells": int(lo.shape[0])},
+                invariants=(custom("query-completeness", _bvh_query_predicate(lo, hi, query)),),
+            )
+
+    if profile is not Profile.FULL:
+        return
+    bad_hi = np.array([[0.5, 0.5]])
+    bad_lo = np.array([[1.0, 1.0]])
+    yield Case(
+        GROUP,
+        "bvh_from_cell_bounds_hi_below_lo",
+        BVH.from_cell_bounds,
+        lambda: BVH.from_cell_bounds(bad_lo, bad_hi),
+        {"kind": "hi-below-lo"},
+    )
+    yield Case(
+        GROUP,
+        "bvh_from_cell_bounds_nonfinite",
+        BVH.from_cell_bounds,
+        lambda: BVH.from_cell_bounds(np.array([[np.nan, 0.0]]), np.array([[1.0, 1.0]])),
+        {"kind": "nan"},
+        finite_inputs=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partition / partition_grid
+# ---------------------------------------------------------------------------
+
+
+def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
+    """Yield direct :class:`Partition` constructor and accessor cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: ``n_parts == 1``, ``n_parts == n_cells``, and malformed-input
+        rejections.
+    """
+    yield Case(
+        GROUP,
+        "partition_direct_single_rank",
+        Partition,
+        lambda: Partition(np.zeros(5, dtype=np.int32), 1),
+        {"kind": "n_parts=1"},
+        invariants=(
+            custom(
+                "owns-everything",
+                lambda r: None
+                if np.array_equal(r.owned_cells(0), np.arange(5))
+                else "rank 0 does not own every cell",
+            ),
+        ),
+    )
+    owner_one_each = np.arange(5, dtype=np.int32)
+    yield Case(
+        GROUP,
+        "partition_direct_one_cell_per_rank",
+        Partition,
+        lambda: Partition(owner_one_each, 5),
+        {"kind": "n_parts=n_cells"},
+        invariants=(
+            custom(
+                "every-rank-owns-one",
+                lambda r: None
+                if all(r.owned_cells(rank).size == 1 for rank in range(5))
+                else "some rank does not own exactly one cell",
+            ),
+        ),
+    )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP,
+        "partition_direct_zero_parts",
+        Partition,
+        lambda: Partition(np.zeros(3, dtype=np.int32), 0),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "partition_direct_owner_out_of_range",
+        Partition,
+        lambda: Partition(np.array([0, 1, 2], dtype=np.int32), 2),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "partition_direct_non_integer",
+        Partition,
+        lambda: Partition(np.array([0.0, 1.0]), 2),
+        {},
+    )
+    part = Partition(np.array([0, 1], dtype=np.int32), 2)
+    yield Case(
+        GROUP,
+        "partition_direct_owned_cells_bad_rank",
+        Partition.owned_cells,
+        lambda: part.owned_cells(5),
+        {"kind": "rank-oob"},
+    )
+
+
+def _partition_active_predicate(
+    n_parts: int, active_mask: npt.NDArray[np.bool_] | None
+) -> Callable[[object], str | None]:
+    """Build a predicate asserting owners exactly partition the active set.
+
+    Args:
+        n_parts (int): Requested part count.
+        active_mask (npt.NDArray[np.bool_] | None): Activity mask, or ``None`` when
+            every cell is active.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the resulting
+        :class:`Partition`.
+    """
+
+    def predicate(result: object) -> str | None:
+        owner = result.cell_owner  # type: ignore[attr-defined]
+        if active_mask is not None and np.any(owner[~active_mask] != -1):
+            return "an inactive cell was assigned an owner"
+        active_owner = owner if active_mask is None else owner[active_mask]
+        out_of_range = active_owner.size and (
+            int(active_owner.min()) < 0 or int(active_owner.max()) >= n_parts
+        )
+        if out_of_range:
+            return f"an active cell owner falls outside [0, {n_parts})"
+        return None
+
+    return predicate
+
+
+def _every_rank_nonempty_predicate(n_parts: int) -> Callable[[object], str | None]:
+    """Build a predicate asserting every rank owns at least one cell.
+
+    Args:
+        n_parts (int): Requested part count.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the resulting
+        :class:`Partition`.
+    """
+
+    def predicate(result: object) -> str | None:
+        for rank in range(n_parts):
+            if result.owned_cells(rank).size == 0:  # type: ignore[attr-defined]
+                return f"rank {rank} owns zero cells"
+        return None
+
+    return predicate
+
+
+def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`pantr.grid.partition_grid` corner cases across backends.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: ``n_parts == n_cells``, ``n_parts == 1``, an all-but-one-inactive
+        selection, and malformed-input rejections.
+    """
+    grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [3, 3])
+    backends = ("block", "rcb", "auto") if profile is Profile.FULL else ("auto",)
+    for backend in backends:
+        yield Case(
+            GROUP,
+            f"partition_grid_n_parts_eq_n_cells_{backend}",
+            partition_grid,
+            lambda backend=backend: partition_grid(grid, grid.num_cells, backend=backend),
+            {"backend": backend, "n_parts": grid.num_cells},
+            invariants=(
+                custom("every-rank-nonempty", _every_rank_nonempty_predicate(grid.num_cells)),
+                custom("partitions-active-set", _partition_active_predicate(grid.num_cells, None)),
+            ),
+        )
+        yield Case(
+            GROUP,
+            f"partition_grid_single_rank_{backend}",
+            partition_grid,
+            lambda backend=backend: partition_grid(grid, 1, backend=backend),
+            {"backend": backend, "n_parts": 1},
+            invariants=(
+                custom("every-rank-nonempty", _every_rank_nonempty_predicate(1)),
+                custom("partitions-active-set", _partition_active_predicate(1, None)),
+            ),
+        )
+
+    if profile is not Profile.FULL:
+        return
+
+    active = np.zeros(grid.num_cells, dtype=bool)
+    active[0] = True
+    yield Case(
+        GROUP,
+        "partition_grid_all_but_one_inactive",
+        partition_grid,
+        lambda: partition_grid(grid, 1, backend="rcb", cell_active=active),
+        {"backend": "rcb", "n_parts": 1, "kind": "all-but-one-inactive"},
+        invariants=(custom("partitions-active-set", _partition_active_predicate(1, active)),),
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_zero_parts",
+        partition_grid,
+        lambda: partition_grid(grid, 0),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_unknown_backend",
+        partition_grid,
+        lambda: partition_grid(grid, 2, backend="nope"),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_block_rejects_weights",
+        partition_grid,
+        lambda: partition_grid(grid, 3, backend="block", cell_weights=np.ones(grid.num_cells)),
+        {},
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_block_unfactorable",
+        partition_grid,
+        lambda: partition_grid(grid, 5, backend="block"),
+        {"kind": "prime-part-count"},
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_n_parts_exceeds_active",
+        partition_grid,
+        lambda: partition_grid(grid, grid.num_cells + 1, backend="rcb"),
+        {"kind": "n_parts-too-large"},
+    )
+    yield Case(
+        GROUP,
+        "partition_grid_rcb_on_hierarchical",
+        partition_grid,
+        lambda: partition_grid(HierarchicalGrid(grid, 2), 3, backend="rcb"),
+        {"kind": "non-tensor-product"},
+        invariants=(
+            custom(
+                "every-rank-nonempty",
+                _every_rank_nonempty_predicate(3),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# overlay
+# ---------------------------------------------------------------------------
+
+
+def _overlay_symmetry_predicate() -> Callable[[object], str | None]:
+    """Build a predicate asserting ``overlay(a, b)`` and ``overlay(b, a)`` agree.
+
+    Args:
+        None
+
+    Returns:
+        Callable[[object], str | None]: Predicate over a ``(overlay_ab, overlay_ba)``
+        tuple.
+    """
+    atol = get_default(np.float64)
+    # The merge itself tolerates `atol`-close breakpoints; comparing two
+    # independent merges of the same data allows the same slack again, times 2
+    # for the two roundings (one per merge direction).
+    tol = 2.0 * atol
+
+    def predicate(result: object) -> str | None:
+        overlay_ab, overlay_ba = result  # type: ignore[misc]
+        for d in range(overlay_ab.ndim):
+            bp_ab, bp_ba = overlay_ab.breakpoints[d], overlay_ba.breakpoints[d]
+            if bp_ab.shape != bp_ba.shape:
+                return (
+                    f"axis {d}: overlay(a,b) has {bp_ab.shape[0]} breakpoints, "
+                    f"overlay(b,a) has {bp_ba.shape[0]}"
+                )
+            diff = float(np.max(np.abs(bp_ab - bp_ba)))
+            if diff > tol:
+                return f"axis {d}: overlay(a,b) vs overlay(b,a) differ by {diff:.3e} > {tol:.3e}"
+        return None
+
+    return predicate
+
+
+def _overlay_containment_predicate(
+    grid_a: TensorProductGrid, grid_b: TensorProductGrid
+) -> Callable[[object], str | None]:
+    """Build a predicate asserting every overlay cell lies inside one cell of each input.
+
+    Args:
+        grid_a (TensorProductGrid): First input grid.
+        grid_b (TensorProductGrid): Second input grid.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over a ``(overlay_ab, overlay_ba)``
+        tuple (only ``overlay_ab`` is checked; symmetric by construction).
+    """
+
+    def predicate(result: object) -> str | None:
+        overlay_ab, _ = result  # type: ignore[misc]
+        cell_lo, cell_hi = overlay_ab.collect_cell_bounds()
+        centroids = 0.5 * (cell_lo + cell_hi)
+        if np.any(grid_a.locate_many(centroids) < 0):
+            return "an overlay cell centroid falls outside grid_a"
+        if np.any(grid_b.locate_many(centroids) < 0):
+            return "an overlay cell centroid falls outside grid_b"
+        return None
+
+    return predicate
+
+
+def _overlay_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`pantr.grid.overlay` cases across dimension and domain.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Symmetry and containment checks per ``(ndim, domain)``, plus the
+        malformed-input rejections.
+    """
+    ndims = dims(profile, max_dim=3) if profile is Profile.FULL else (2,)
+    for ndim in ndims:
+        for domain in domains(profile):
+            grid_a = _tp_grid(ndim, domain, 3)
+            grid_b = _tp_grid(ndim, domain, 4)
+            tag = _grid_tag(ndim, domain)
+
+            def run(
+                grid_a: TensorProductGrid = grid_a, grid_b: TensorProductGrid = grid_b
+            ) -> tuple[TensorProductGrid, TensorProductGrid]:
+                return overlay(grid_a, grid_b), overlay(grid_b, grid_a)
+
+            yield Case(
+                GROUP,
+                f"overlay_symmetry_{tag}",
+                overlay,
+                run,
+                {"ndim": ndim, "domain": domain},
+                invariants=(custom("overlay-symmetric", _overlay_symmetry_predicate()),),
+            )
+            yield Case(
+                GROUP,
+                f"overlay_containment_{tag}",
+                overlay,
+                run,
+                {"ndim": ndim, "domain": domain},
+                invariants=(
+                    custom(
+                        "overlay-contained",
+                        _overlay_containment_predicate(grid_a, grid_b),
+                    ),
+                ),
+            )
+
+    if profile is not Profile.FULL:
+        return
+    a = _tp_grid(2, (0.0, 1.0), 2)
+    b = _tp_grid(2, (2.0, 3.0), 2)
+    yield Case(
+        GROUP, "overlay_disjoint_domains", overlay, lambda: overlay(a, b), {"kind": "disjoint"}
+    )
+    c = _tp_grid(3, (0.0, 1.0), 2)
+    yield Case(
+        GROUP, "overlay_ndim_mismatch", overlay, lambda: overlay(a, c), {"kind": "ndim-mismatch"}
+    )
+    yield Case(
+        GROUP, "overlay_wrong_type", overlay, lambda: overlay(a, object()), {"kind": "wrong-type"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# CellTags / FacetTags
+# ---------------------------------------------------------------------------
+
+
+def _tags_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`CellTags` / :class:`FacetTags` round-trip and overflow cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: A set/getitem/to_dense round trip, the documented ``to_dense``
+        overflow, and malformed-input rejections.
+    """
+    num_cells = 6
+
+    def cell_round_trip() -> npt.NDArray[np.int64]:
+        tags = CellTags(num_cells)
+        tags.set("labels", np.array([1, 3, 5]), np.array([10, 30, 50]))
+        return tags.to_dense("labels", fill=-1)
+
+    def check_cell_round_trip(result: object) -> str | None:
+        expected = np.array([-1, 10, -1, 30, -1, 50])
+        if np.array_equal(result, expected):
+            return None
+        return f"to_dense() = {result}, expected {expected}"
+
+    yield Case(
+        GROUP,
+        "cell_tags_round_trip",
+        CellTags.to_dense,
+        cell_round_trip,
+        {"kind": "round-trip"},
+        invariants=(custom("round-trip-values", check_cell_round_trip),),
+    )
+
+    def cell_overflow() -> npt.NDArray[Any]:
+        tags = CellTags(num_cells)
+        tags.set("big", np.array([0]), np.array([1000]))
+        return tags.to_dense("big", dtype=np.int8)
+
+    yield Case(
+        GROUP,
+        "cell_tags_to_dense_overflow",
+        CellTags.to_dense,
+        cell_overflow,
+        {"kind": "int8-overflow"},
+    )
+
+    facets_per_cell = 4
+    num_facet_cells = 3
+    tagged_value_a = 7
+    tagged_value_b = 9
+
+    def facet_round_trip() -> npt.NDArray[np.int64]:
+        tags = FacetTags(num_facet_cells, facets_per_cell)
+        tags.set("bc", np.array([[0, 1], [2, 3]]), np.array([tagged_value_a, tagged_value_b]))
+        return tags.to_dense("bc", fill=-1)
+
+    def check_facet_round_trip(result: object) -> str | None:
+        arr = np.asarray(result)
+        if arr[0, 1] != tagged_value_a or arr[2, 3] != tagged_value_b:
+            return f"facet round trip landed wrong: {arr}"
+        return None
+
+    yield Case(
+        GROUP,
+        "facet_tags_round_trip",
+        FacetTags.to_dense,
+        facet_round_trip,
+        {"kind": "round-trip"},
+        invariants=(custom("round-trip-values", check_facet_round_trip),),
+    )
+
+    def facet_overflow() -> npt.NDArray[Any]:
+        tags = FacetTags(num_facet_cells, facets_per_cell)
+        tags.set("big", np.array([[0, 0]]), np.array([1000]))
+        return tags.to_dense("big", dtype=np.int8)
+
+    yield Case(
+        GROUP,
+        "facet_tags_to_dense_overflow",
+        FacetTags.to_dense,
+        facet_overflow,
+        {"kind": "int8-overflow"},
+    )
+
+    if profile is not Profile.FULL:
+        return
+    yield Case(
+        GROUP,
+        "cell_tags_duplicate_ids",
+        CellTags.set,
+        lambda: CellTags(num_cells).set("dup", np.array([1, 1]), np.array([1, 2])),
+        {"kind": "duplicate-ids"},
+    )
+    yield Case(
+        GROUP,
+        "cell_tags_id_out_of_range",
+        CellTags.set,
+        lambda: CellTags(num_cells).set("oob", np.array([num_cells]), np.array([1])),
+        {"kind": "id-oob"},
+    )
+    yield Case(
+        GROUP,
+        "facet_tags_lfid_out_of_range",
+        FacetTags.set,
+        lambda: FacetTags(num_facet_cells, facets_per_cell).set(
+            "oob", np.array([[0, facets_per_cell]]), np.array([1])
+        ),
+        {"kind": "lfid-oob"},
+    )
+    yield Case(
+        GROUP,
+        "facet_tags_duplicate_keys",
+        FacetTags.set,
+        lambda: FacetTags(num_facet_cells, facets_per_cell).set(
+            "dup", np.array([[0, 0], [0, 0]]), np.array([1, 2])
+        ),
+        {"kind": "duplicate-keys"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# cell_quadrature
+# ---------------------------------------------------------------------------
+
+
+def _quadrature_weight_sum_predicate(
+    cell_lo: npt.NDArray[np.float64], cell_hi: npt.NDArray[np.float64], num_points: int
+) -> Callable[[object], str | None]:
+    """Build a predicate asserting per-cell weights sum to the cell volume.
+
+    Only valid for a rule whose reference weights sum to 1
+    (``gauss_legendre_quadrature`` does); the docstring's claim
+    (`_cell_quadrature.py:8-10`) is conditioned on exactly that.
+
+    Args:
+        cell_lo (npt.NDArray[np.float64]): Selected cells' lower corners.
+        cell_hi (npt.NDArray[np.float64]): Selected cells' upper corners.
+        num_points (int): Quadrature point count per cell.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``(points, weights)``
+        result.
+    """
+    volumes = _volume(cell_lo, cell_hi)
+    ndim = cell_lo.shape[1]
+    # Each cell's weight sum is `num_points` reference weights (summing to 1 up to
+    # their own O(num_points * eps) rounding) scaled by a volume computed as an
+    # `ndim`-fold product (one rounding per factor). Factor 8 covers both constants.
+    scale = np.maximum(np.abs(volumes), 1.0)
+    tol = 8.0 * num_points * ndim * _EPS64 * scale
+
+    def predicate(result: object) -> str | None:
+        _, weights = result  # type: ignore[misc]
+        sums = np.sum(weights, axis=1)
+        bad = np.abs(sums - volumes) > tol
+        if np.any(bad):
+            cid = int(np.argmax(np.abs(sums - volumes) - tol))
+            return (
+                f"cell {cid}: weight sum {sums[cid]:.6e} vs volume {volumes[cid]:.6e} "
+                f"(tol {tol[cid]:.3e})"
+            )
+        return None
+
+    return predicate
+
+
+def _quadrature_points_shape_predicate(shape: tuple[int, ...]) -> Callable[[object], str | None]:
+    """Build a predicate checking the ``points`` half of a ``cell_quadrature`` result.
+
+    ``expected_shape`` (`_core.py`) shapes its check for a single array; ``cell_quadrature``
+    returns a ``(points, weights)`` pair, so this checks ``result[0]`` directly instead of
+    feeding the whole tuple to ``np.shape``.
+
+    Args:
+        shape (tuple[int, ...]): Expected ``points`` shape.
+
+    Returns:
+        Callable[[object], str | None]: Predicate over the ``(points, weights)`` result.
+    """
+
+    def predicate(result: object) -> str | None:
+        points, _ = result  # type: ignore[misc]
+        got = tuple(points.shape)
+        if got != shape:
+            return f"points.shape={got}, expected {shape}"
+        return None
+
+    return predicate
+
+
+def _cell_quadrature_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`pantr.grid.cell_quadrature` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: Weight-sum-to-volume checks over several cell selections, plus the
+        malformed-input rejections.
+    """
+    ndims = dims(profile, max_dim=3) if profile is Profile.FULL else (2,)
+    for ndim in ndims:
+        grid = _tp_grid(ndim, (0.0, 5.0), 3)
+        rule = gauss_legendre_quadrature(ndim, 3)
+        cell_lo_all, cell_hi_all = grid.collect_cell_bounds()
+
+        selectors: dict[str, npt.NDArray[np.int64] | None] = {
+            "all_cells": None,
+            "single_cell": np.array([0]),
+            "empty_selection": np.zeros(0, dtype=np.int64),
+        }
+        for name, ids in selectors.items():
+            expected_lo = cell_lo_all if ids is None else cell_lo_all[ids]
+            expected_hi = cell_hi_all if ids is None else cell_hi_all[ids]
+            yield Case(
+                GROUP,
+                f"cell_quadrature_{name}_d{ndim}",
+                cell_quadrature,
+                lambda grid=grid, rule=rule, ids=ids: cell_quadrature(grid, rule, ids),
+                {"ndim": ndim, "kind": name},
+                invariants=(
+                    custom(
+                        "weight-sums-to-volume",
+                        _quadrature_weight_sum_predicate(expected_lo, expected_hi, rule.num_points),
+                    ),
+                    custom(
+                        "points-shape",
+                        _quadrature_points_shape_predicate(
+                            (expected_lo.shape[0], rule.num_points, ndim)
+                        ),
+                    ),
+                )
+                if name != "empty_selection"
+                else (),
+            )
+
+    if profile is not Profile.FULL:
+        return
+    grid2 = _tp_grid(2, (0.0, 1.0), 2)
+    rule3 = gauss_legendre_quadrature(3, 2)
+    yield Case(
+        GROUP,
+        "cell_quadrature_ndim_mismatch",
+        cell_quadrature,
+        lambda: cell_quadrature(grid2, rule3),
+        {"kind": "ndim-mismatch"},
+    )
+    yield Case(
+        GROUP,
+        "cell_quadrature_cell_out_of_range",
+        cell_quadrature,
+        lambda: cell_quadrature(
+            grid2, gauss_legendre_quadrature(2, 2), np.array([grid2.num_cells])
+        ),
+        {"kind": "cell-oob"},
+    )
+    yield Case(
+        GROUP,
+        "cell_quadrature_non_integer_cells",
+        cell_quadrature,
+        lambda: cell_quadrature(grid2, gauss_legendre_quadrature(2, 2), np.array([0.5])),
+        {"kind": "non-integer-cells"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry entry point
+# ---------------------------------------------------------------------------
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _tp_construction_cases(profile)
+    yield from _tp_uniformity_cases(profile)
+    yield from _tp_locate_cases(profile)
+    yield from _tp_neighbor_cases(profile)
+    yield from _tp_restrict_cases(profile)
+    yield from _uniform_grid_factory_cases(profile)
+    yield from _tensor_product_from_space_cases(profile)
+
+    yield from _hier_construction_cases(profile)
+    yield from _hier_refine_coarsen_cases(profile)
+    yield from _hier_bounds_cases(profile)
+    yield from _hier_locate_cases(profile)
+    yield from _hier_mask_cases(profile)
+    yield from _hier_hanging_neighbor_cases(profile)
+    yield from _hier_restrict_cases(profile)
+    yield from _hierarchical_grid_factory_case(profile)
+
+    yield from _bvh_from_grid_cases(profile)
+    yield from _bvh_direct_construction_cases(profile)
+    yield from _bvh_degenerate_cases(profile)
+
+    yield from _partition_direct_cases(profile)
+    yield from _partition_grid_cases(profile)
+
+    yield from _overlay_cases(profile)
+
+    yield from _tags_cases(profile)
+
+    yield from _cell_quadrature_cases(profile)

--- a/tools/adversarial_sweep/_probes_quad.py
+++ b/tools/adversarial_sweep/_probes_quad.py
@@ -1,0 +1,677 @@
+"""Probes for :mod:`pantr.quad`: the 1-D rules, the lattices, and the tensor products.
+
+Every 1-D rule returns nodes (and, except for the modified-Chebyshev factory,
+weights) on ``[0, 1]``; the invariants checked here are exactly the claims each
+docstring makes -- nodes inside the unit interval, strictly ascending order where
+documented, weights summing to one where documented, and (for Gauss-Legendre)
+polynomial exactness up to degree ``2 * n_pts - 1`` -- plus the two structural
+claims of :class:`~pantr.quad.QuadratureRule` and
+:func:`~pantr.quad.tensor_product_quadrature`: read-only storage and row-major
+("last axis varies fastest") point ordering. The ``n_pts`` axis is swept at its
+corners (0 and -1, which must be rejected, then 1, 2, 3, 4, 5, 17, 64, 200, 1000)
+rather than its middle, since off-by-one and int64-wraparound defects live at the
+edges of a count, not in its interior.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any, Final
+
+import numpy as np
+
+from pantr.basis import LagrangeVariant
+from pantr.quad import (
+    PointsLattice,
+    QuadratureRule,
+    create_lagrange_points_lattice,
+    gauss_legendre_quadrature,
+    get_chebyshev_gauss_1st_kind_1d,
+    get_chebyshev_gauss_2nd_kind_1d,
+    get_gauss_legendre_1d,
+    get_gauss_lobatto_legendre_1d,
+    get_modified_chebyshev_nodes_1d,
+    get_tanh_sinh_1d,
+    get_trapezoidal_1d,
+    tensor_product_quadrature,
+)
+
+from ._axes import Profile, dims, dtypes
+from ._core import Case, custom
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy.typing as npt
+
+    from ._core import Invariant
+
+GROUP = "quad"
+"""Registry name of this probe group."""
+
+_N_PTS_FULL: Final = (0, -1, 1, 2, 3, 4, 5, 17, 64, 200, 1000)
+"""``n_pts`` corners: 0 and -1 must be rejected; the rest span from the smallest
+legal rule up to a count large enough to stress the double-exponential and
+Chebyshev root finders."""
+_N_PTS_SMOKE: Final = (0, -1, 1, 5)
+
+_GL_EXACTNESS_MAX_N: Final = 20
+"""Above this ``n_pts`` the moment ``1 / (m + 1)`` for ``m`` near ``2n - 1`` is so
+close to the float64 relative-error floor that the exactness check loses power;
+below it, the check is a genuine, independent oracle on the rule's own claim."""
+
+# One entry per 1D rule: (case name, factory, minimum legal n_pts, nodes-only
+# return value, weights claimed to sum to one, ascending order documented).
+# Ascending order is asserted only for the two rules whose docstring actually
+# claims it (get_chebyshev_gauss_2nd_kind_1d:245 "ascending";
+# get_modified_chebyshev_nodes_1d:212 "starting at 0 and ending at 1"): the
+# other rules are not documented as sorted, and get_tanh_sinh_1d in particular
+# emits its central node first and then symmetric pairs outward from it, so it
+# is *not* ascending even in the well-behaved case -- asserting it there would
+# be a probe defect, not a finding.
+_RuleSpec = tuple[str, "Callable[..., Any]", int, bool, bool, bool]
+_RULES: Final[tuple[_RuleSpec, ...]] = (
+    ("trapezoidal", get_trapezoidal_1d, 1, False, True, False),
+    ("gauss_legendre", get_gauss_legendre_1d, 1, False, True, False),
+    ("gauss_lobatto_legendre", get_gauss_lobatto_legendre_1d, 2, False, True, False),
+    ("chebyshev_1st", get_chebyshev_gauss_1st_kind_1d, 1, False, False, False),
+    ("modified_chebyshev_nodes", get_modified_chebyshev_nodes_1d, 2, True, False, True),
+    ("chebyshev_2nd", get_chebyshev_gauss_2nd_kind_1d, 2, False, False, True),
+    ("tanh_sinh", get_tanh_sinh_1d, 1, False, True, False),
+)
+
+
+def _n_pts_values(profile: Profile) -> tuple[int, ...]:
+    """List the ``n_pts`` corners to sweep for the 1D rules.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Returns:
+        tuple[int, ...]: The corner values for this profile.
+    """
+    return _N_PTS_SMOKE if profile is Profile.SMOKE else _N_PTS_FULL
+
+
+def _extract_nodes(result: Any) -> np.ndarray:  # noqa: ANN401 -- dispatches on return shape
+    """Pull the nodes array out of a 1D rule's return value.
+
+    Args:
+        result (Any): Either a ``(nodes, weights)`` pair or a bare nodes array
+            (:func:`~pantr.quad.get_modified_chebyshev_nodes_1d`).
+
+    Returns:
+        np.ndarray: The nodes, as a plain array.
+    """
+    if isinstance(result, tuple):
+        return np.asarray(result[0])
+    return np.asarray(result)
+
+
+def _nodes_in_unit_interval() -> Invariant:
+    """Build an invariant requiring every node to lie in the closed unit interval.
+
+    Returns:
+        Invariant: Check reporting the offending min/max when violated.
+    """
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        nodes = _extract_nodes(result)
+        if nodes.size == 0:
+            return None
+        lo, hi = float(np.min(nodes)), float(np.max(nodes))
+        if lo < 0.0 or hi > 1.0:
+            return f"nodes escape [0, 1]: min={lo!r}, max={hi!r}"
+        return None
+
+    return custom("nodes-in-unit-interval", predicate)
+
+
+def _nodes_strictly_ascending() -> Invariant:
+    """Build an invariant requiring nodes to be strictly increasing.
+
+    Every one of these rules is either explicitly documented as ascending
+    (:func:`~pantr.quad.get_chebyshev_gauss_2nd_kind_1d`,
+    :func:`~pantr.quad.get_modified_chebyshev_nodes_1d`) or produces sorted nodes
+    by construction (linspace, root-finder output already sorted); a repeated or
+    out-of-order node pairs a weight with the wrong location and is a genuine
+    finding regardless of which rule produced it.
+
+    Returns:
+        Invariant: Check reporting the first non-increasing pair found.
+    """
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        nodes = _extract_nodes(result).astype(np.float64)
+        if nodes.size < 2:  # noqa: PLR2004 -- trivially ascending
+            return None
+        diffs = np.diff(nodes)
+        bad = np.flatnonzero(diffs <= 0.0)
+        if bad.size:
+            i = int(bad[0])
+            return f"nodes[{i}]={nodes[i]!r} >= nodes[{i + 1}]={nodes[i + 1]!r}"
+        return None
+
+    return custom("nodes-strictly-ascending", predicate)
+
+
+def _weights_sum_to_one(n_terms: int, dtype: npt.DTypeLike) -> Invariant:
+    """Build an invariant requiring quadrature weights to sum to one.
+
+    Summing ``n_terms`` positive values whose exact total is one carries a
+    forward error of at most ``(n_terms - 1) * eps`` (Higham, *Accuracy and
+    Stability of Numerical Algorithms*, Sec. 4.2); an explicit factor of 8
+    absorbs the extra rounding of computing each weight itself (a closed form or
+    a short recurrence) before the sum.
+
+    Args:
+        n_terms (int): Number of weights summed, which sets the term count.
+        dtype (npt.DTypeLike): Working precision, which sets machine epsilon.
+
+    Returns:
+        Invariant: Check reporting the deviation from one.
+    """
+    from pantr.tolerance import get_machine_epsilon  # noqa: PLC0415 -- avoids import cycle
+
+    tol = 8.0 * max(n_terms, 1) * get_machine_epsilon(dtype)
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        weights = result.weights if isinstance(result, QuadratureRule) else result[1]
+        total = float(np.sum(np.asarray(weights, dtype=np.float64)))
+        if not np.isfinite(total) or abs(total - 1.0) > tol:
+            return f"sum(weights) = {total!r}, |sum - 1| > {tol:.3e}"
+        return None
+
+    return custom("weights-sum-to-one", predicate)
+
+
+def _gauss_legendre_exactness(n_pts: int) -> Invariant:
+    """Build an invariant checking Gauss-Legendre exactness against an exact oracle.
+
+    ``get_gauss_legendre_1d(n_pts)`` is documented (``quad.py:706-707``) to
+    integrate ``x**m`` exactly on ``[0, 1]`` for ``m <= 2 * n_pts - 1``. The exact
+    moment ``1 / (m + 1)`` is built with :class:`fractions.Fraction`, an oracle
+    independent of the rule's own construction. Terms in the weighted sum are
+    positive and bounded by ``max(weight) * 1`` (nodes lie in ``[0, 1]``), so
+    summing ``n_pts`` of them plus evaluating ``nodes ** m`` carries forward
+    error bounded by an explicit factor of 16 times ``n_pts`` times machine
+    epsilon, relative to the larger of the exact value and the largest term.
+
+    Args:
+        n_pts (int): Number of quadrature points, which sets both the exactness
+            degree and the term count.
+
+    Returns:
+        Invariant: Check reporting the first moment that violates the bound.
+    """
+    from pantr.tolerance import get_machine_epsilon  # noqa: PLC0415 -- avoids import cycle
+
+    eps = get_machine_epsilon(np.float64)
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        nodes, weights = result
+        nodes = np.asarray(nodes, dtype=np.float64)
+        weights = np.asarray(weights, dtype=np.float64)
+        max_w = float(np.max(weights)) if weights.size else 0.0
+        for m in range(2 * n_pts):  # m <= 2 * n_pts - 1
+            exact = float(Fraction(1, m + 1))
+            approx = float(np.sum(weights * nodes**m))
+            tol = 16.0 * n_pts * eps * max(abs(exact), max_w, 1.0)
+            err = abs(approx - exact)
+            if err > tol:
+                return f"m={m}: got {approx!r}, exact {exact!r}, err={err:.3e} > {tol:.3e}"
+        return None
+
+    return custom("gauss-legendre-exactness", predicate)
+
+
+def _rule_1d_cases(profile: Profile) -> Iterator[Case]:
+    """Yield the corner cases for every 1D quadrature rule factory.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(n_pts, dtype)`` call per rule.
+    """
+    for name, func, min_pts, nodes_only, sum_to_one, ascending_claimed in _RULES:
+        for n_pts in _n_pts_values(profile):
+            for dtype in dtypes(profile):
+                invariants: list[Invariant] = [_nodes_in_unit_interval()]
+                if ascending_claimed:
+                    invariants.append(_nodes_strictly_ascending())
+                if sum_to_one and n_pts >= min_pts:
+                    invariants.append(_weights_sum_to_one(n_pts, dtype))
+                if (
+                    name == "gauss_legendre"
+                    and dtype == np.dtype(np.float64)
+                    and min_pts <= n_pts <= _GL_EXACTNESS_MAX_N
+                ):
+                    invariants.append(_gauss_legendre_exactness(n_pts))
+                yield Case(
+                    GROUP,
+                    f"{name}_n{n_pts}_{np.dtype(dtype).name}",
+                    func,
+                    lambda func=func, n_pts=n_pts, dtype=dtype: func(n_pts, dtype=dtype),
+                    {"rule": name, "n_pts": n_pts, "dtype": dtype, "nodes_only": nodes_only},
+                    invariants=tuple(invariants),
+                )
+
+
+def _bad_dtype_cases(profile: Profile) -> Iterator[Case]:
+    """Yield calls with a dtype that must be rejected, for every 1D rule.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One rejected-dtype call per rule.
+    """
+    if profile is not Profile.FULL:
+        return
+    for name, func, min_pts, _, _, _ in _RULES:
+        n_pts = max(min_pts, 5)
+        for bad_dtype in (np.dtype(np.int32), np.dtype(np.float16)):
+            yield Case(
+                GROUP,
+                f"{name}_bad_dtype_{bad_dtype.name}",
+                func,
+                lambda func=func, n_pts=n_pts, bad_dtype=bad_dtype: func(n_pts, dtype=bad_dtype),
+                {"rule": name, "n_pts": n_pts, "dtype": bad_dtype},
+            )
+
+
+def _lattice_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`~pantr.quad.PointsLattice` construction and ordering cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile lattice construction or query.
+    """
+    for dtype in dtypes(profile):
+        name = np.dtype(dtype).name
+        single = [np.array([0.3], dtype=dtype), np.array([0.7], dtype=dtype)]
+        yield Case(
+            GROUP,
+            f"lattice_single_point_per_axis_{name}",
+            PointsLattice,
+            lambda single=single: PointsLattice(single),
+            {"kind": "single-point-per-axis", "dtype": dtype},
+        )
+        yield Case(
+            GROUP,
+            f"lattice_get_all_points_order_F_{name}",
+            PointsLattice.get_all_points,
+            lambda single=single: PointsLattice(single).get_all_points(order="F"),
+            {"kind": "order-F", "dtype": dtype},
+        )
+        empty_axis = [np.array([0.3], dtype=dtype), np.zeros(0, dtype=dtype)]
+        yield Case(
+            GROUP,
+            f"lattice_empty_axis_{name}",
+            PointsLattice,
+            lambda empty_axis=empty_axis: PointsLattice(empty_axis),
+            {"kind": "empty-axis", "dtype": dtype},
+        )
+
+    if profile is not Profile.FULL:
+        return
+
+    mixed = [np.array([0.1, 0.9], dtype=np.float64), np.array([0.2, 0.8], dtype=np.float32)]
+    yield Case(
+        GROUP,
+        "lattice_mismatched_dtypes",
+        PointsLattice,
+        lambda mixed=mixed: PointsLattice(mixed),
+        {"kind": "mismatched-dtypes"},
+    )
+    four_axes = [np.array([0.2, 0.8]) for _ in range(4)]
+    yield Case(
+        GROUP,
+        "lattice_four_axes",
+        PointsLattice.get_all_points,
+        lambda four_axes=four_axes: PointsLattice(four_axes).get_all_points(),
+        {"ndim": 4, "kind": "four-axes"},
+        invariants=(
+            custom(
+                "shape",
+                lambda r: None if r.shape == (16, 4) else f"got shape {r.shape}, expected (16, 4)",
+            ),
+        ),
+    )
+
+
+_LAGRANGE_LATTICE_N_PTS_FULL: Final = (0, 1, 2, 5, 17)
+_LAGRANGE_LATTICE_N_PTS_SMOKE: Final = (1, 2, 5)
+
+
+def _lagrange_lattice_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`~pantr.quad.create_lagrange_points_lattice` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(variant, n_pts_per_dir)`` combination.
+    """
+    full = profile is Profile.FULL
+    n_pts_values = _LAGRANGE_LATTICE_N_PTS_FULL if full else _LAGRANGE_LATTICE_N_PTS_SMOKE
+    variants = (
+        tuple(LagrangeVariant)
+        if full
+        else (LagrangeVariant.EQUISPACES, LagrangeVariant.GAUSS_LOBATTO_LEGENDRE)
+    )
+    for variant in variants:
+        for n_pts in n_pts_values:
+            for dim in dims(profile, max_dim=3):
+                n_pts_per_dir = (n_pts,) * dim
+                yield Case(
+                    GROUP,
+                    f"lagrange_lattice_{variant.value}_n{n_pts}_d{dim}",
+                    create_lagrange_points_lattice,
+                    lambda variant=variant,
+                    n_pts_per_dir=n_pts_per_dir: create_lagrange_points_lattice(
+                        variant, n_pts_per_dir
+                    ),
+                    {"variant": variant, "n_pts": n_pts, "dim": dim},
+                )
+
+
+def _quadrature_rule_shape_readonly(num_points: int, ndim: int) -> Invariant:
+    """Build an invariant checking a :class:`~pantr.quad.QuadratureRule`'s contract.
+
+    Args:
+        num_points (int): Expected ``num_points``.
+        ndim (int): Expected ``ndim``.
+
+    Returns:
+        Invariant: Check reporting a shape mismatch or a writeable stored array.
+    """
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        if not isinstance(result, QuadratureRule):
+            return f"expected QuadratureRule, got {type(result).__name__}"
+        if result.points.shape != (num_points, ndim):
+            return f"points shape {result.points.shape} != {(num_points, ndim)}"
+        if result.weights.shape != (num_points,):
+            return f"weights shape {result.weights.shape} != {(num_points,)}"
+        if result.points.flags.writeable or result.weights.flags.writeable:
+            return "points/weights are writeable; contract promises read-only storage"
+        return None
+
+    return custom("quadrule-shape-readonly", predicate)
+
+
+def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :class:`~pantr.quad.QuadratureRule` construction cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(points, weights)`` construction.
+    """
+    del profile  # every construction below is a corner; nothing to widen further
+    step = float(np.spacing(np.float64(1.0)))
+
+    yield Case(
+        GROUP,
+        "quadrule_endpoints_0_1",
+        QuadratureRule,
+        lambda: QuadratureRule([[0.0], [1.0]], [0.5, 0.5]),
+        {"kind": "endpoints"},
+        invariants=(_quadrature_rule_shape_readonly(2, 1),),
+        arrays={"points": np.array([[0.0], [1.0]]), "weights": np.array([0.5, 0.5])},
+    )
+    yield Case(
+        GROUP,
+        "quadrule_negative_weight",
+        QuadratureRule,
+        lambda: QuadratureRule([[0.5]], [-1.0]),
+        {"kind": "negative-weight"},
+        invariants=(_quadrature_rule_shape_readonly(1, 1),),
+        arrays={"points": np.array([[0.5]]), "weights": np.array([-1.0])},
+    )
+    yield Case(
+        GROUP,
+        "quadrule_just_outside_left",
+        QuadratureRule,
+        lambda step=step: QuadratureRule([[-8.0 * step]], [1.0]),
+        {"kind": "just-outside-left"},
+    )
+    yield Case(
+        GROUP,
+        "quadrule_just_outside_right",
+        QuadratureRule,
+        lambda step=step: QuadratureRule([[1.0 + 8.0 * step]], [1.0]),
+        {"kind": "just-outside-right"},
+    )
+    yield Case(
+        GROUP,
+        "quadrule_nan_point",
+        QuadratureRule,
+        lambda: QuadratureRule([[np.nan]], [1.0]),
+        {"kind": "nan-point"},
+        finite_inputs=False,
+    )
+    yield Case(
+        GROUP,
+        "quadrule_inf_weight",
+        QuadratureRule,
+        lambda: QuadratureRule([[0.5]], [np.inf]),
+        {"kind": "inf-weight"},
+        finite_inputs=False,
+    )
+    yield Case(
+        GROUP,
+        "quadrule_zero_length",
+        QuadratureRule,
+        lambda: QuadratureRule(np.zeros((0, 1)), np.zeros(0)),
+        {"kind": "zero-length"},
+    )
+    yield Case(
+        GROUP,
+        "quadrule_wrong_ndim_points",
+        QuadratureRule,
+        lambda: QuadratureRule([0.1, 0.5, 0.9], [1.0, 1.0, 1.0]),
+        {"kind": "wrong-ndim-points"},
+    )
+
+
+def _tensor_product_ordering(nodes_per_axis: list[np.ndarray]) -> Invariant:
+    """Build an invariant checking the "last axis varies fastest" ordering claim.
+
+    Reconstructs the expected row at each flat index with
+    :func:`numpy.unravel_index` against the per-axis node arrays directly --
+    an oracle independent of :func:`~pantr.quad.tensor_product_quadrature`'s own
+    ``meshgrid``-based construction -- and compares every row, so a
+    transposition of two axes with distinct lengths cannot hide.
+
+    Args:
+        nodes_per_axis (list[np.ndarray]): The per-axis node arrays used to
+            build the rule under test.
+
+    Returns:
+        Invariant: Check reporting the first row that disagrees.
+    """
+    shape = tuple(len(n) for n in nodes_per_axis)
+    total = int(np.prod(shape))
+
+    def predicate(result: Any) -> str | None:  # noqa: ANN401 -- classifies any return value
+        if not isinstance(result, QuadratureRule):
+            return f"expected QuadratureRule, got {type(result).__name__}"
+        pts = result.points
+        if pts.shape[0] != total:
+            return f"num_points {pts.shape[0]} != prod(shape) {total}"
+        for k in range(total):
+            idx = np.unravel_index(k, shape)
+            expected = np.array([nodes_per_axis[d][idx[d]] for d in range(len(shape))])
+            if not np.array_equal(pts[k], expected):
+                return (
+                    f"row {k}: got {pts[k].tolist()!r}, expected {expected.tolist()!r} "
+                    "(last axis should vary fastest)"
+                )
+        return None
+
+    return custom("tensor-product-c-order", predicate)
+
+
+def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`~pantr.quad.tensor_product_quadrature` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile combination of per-axis rules.
+    """
+    nodes_a = np.array([0.1, 0.9])
+    weights_a = np.array([0.5, 0.5])
+    nodes_b = np.array([0.2, 0.5, 0.8])
+    weights_b = np.full(3, 1.0 / 3.0)
+    rules_2d = [(nodes_a, weights_a), (nodes_b, weights_b)]
+    yield Case(
+        GROUP,
+        "tpq_ordering_2axis_distinct_lengths",
+        tensor_product_quadrature,
+        lambda rules_2d=rules_2d: tensor_product_quadrature(rules_2d),
+        {"kind": "ordering", "shape": (2, 3)},
+        invariants=(_tensor_product_ordering([nodes_a, nodes_b]),),
+        arrays={"nodes_a": nodes_a, "nodes_b": nodes_b},
+    )
+
+    nodes_c = np.array([0.15, 0.55, 0.65, 0.95])
+    weights_c = np.full(4, 0.25)
+    rules_3d = [(nodes_a, weights_a), (nodes_b, weights_b), (nodes_c, weights_c)]
+    yield Case(
+        GROUP,
+        "tpq_ordering_3axis_distinct_lengths",
+        tensor_product_quadrature,
+        lambda rules_3d=rules_3d: tensor_product_quadrature(rules_3d),
+        {"kind": "ordering", "shape": (2, 3, 4)},
+        invariants=(_tensor_product_ordering([nodes_a, nodes_b, nodes_c]),),
+        arrays={"nodes_a": nodes_a, "nodes_b": nodes_b, "nodes_c": nodes_c},
+    )
+
+    yield Case(
+        GROUP,
+        "tpq_empty_rules",
+        tensor_product_quadrature,
+        lambda: tensor_product_quadrature([]),
+        {"kind": "empty"},
+    )
+
+    if profile is not Profile.FULL:
+        return
+
+    mismatched = [(np.array([0.1, 0.5, 0.9]), np.array([0.3, 0.3]))]
+    yield Case(
+        GROUP,
+        "tpq_mismatched_axis_lengths",
+        tensor_product_quadrature,
+        lambda mismatched=mismatched: tensor_product_quadrature(mismatched),
+        {"kind": "mismatched-lengths"},
+    )
+
+
+_GLQ_NPTS_FULL: Final = (1, 2, 5, 17)
+_GLQ_NPTS_SMOKE: Final = (1, 2)
+
+
+def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
+    """Yield :func:`~pantr.quad.gauss_legendre_quadrature` cases.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: One hostile ``(ndim, npts)`` combination.
+    """
+    npts_values = _GLQ_NPTS_FULL if profile is Profile.FULL else _GLQ_NPTS_SMOKE
+    for ndim in dims(profile, max_dim=3):
+        for npts in npts_values:
+            yield Case(
+                GROUP,
+                f"glq_scalar_d{ndim}_n{npts}",
+                gauss_legendre_quadrature,
+                lambda ndim=ndim, npts=npts: gauss_legendre_quadrature(ndim, npts),
+                {"ndim": ndim, "npts": npts, "kind": "scalar"},
+                invariants=(_weights_sum_to_one(npts**ndim, np.dtype(np.float64)),),
+            )
+
+    if profile is not Profile.FULL:
+        return
+
+    yield Case(
+        GROUP,
+        "glq_sequence_d3_mixed_counts",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(3, (2, 3, 4)),
+        {"ndim": 3, "npts": (2, 3, 4), "kind": "sequence"},
+        invariants=(_weights_sum_to_one(2 * 3 * 4, np.dtype(np.float64)),),
+    )
+    # A 4-D case to probe n ** dim growth, as the entry point allows ndim >= 1
+    # with no explicit upper bound.
+    yield Case(
+        GROUP,
+        "glq_growth_d4_n17",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(4, 17),
+        {"ndim": 4, "npts": 17, "kind": "growth"},
+        invariants=(_weights_sum_to_one(17**4, np.dtype(np.float64)),),
+    )
+    yield Case(
+        GROUP,
+        "glq_ndim_zero",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(0, 3),
+        {"ndim": 0, "kind": "invalid-ndim"},
+    )
+    yield Case(
+        GROUP,
+        "glq_ndim_negative",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(-1, 3),
+        {"ndim": -1, "kind": "invalid-ndim"},
+    )
+    yield Case(
+        GROUP,
+        "glq_sequence_wrong_length",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(3, (2, 3)),
+        {"ndim": 3, "npts": (2, 3), "kind": "wrong-length"},
+    )
+    yield Case(
+        GROUP,
+        "glq_count_zero",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(2, 0),
+        {"ndim": 2, "npts": 0, "kind": "invalid-count"},
+    )
+    yield Case(
+        GROUP,
+        "glq_count_negative",
+        gauss_legendre_quadrature,
+        lambda: gauss_legendre_quadrature(2, -1),
+        {"ndim": 2, "npts": -1, "kind": "invalid-count"},
+    )
+
+
+def cases(profile: Profile) -> Iterator[Case]:
+    """Yield every case in this group.
+
+    Args:
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases.
+    """
+    yield from _rule_1d_cases(profile)
+    yield from _bad_dtype_cases(profile)
+    yield from _lattice_cases(profile)
+    yield from _lagrange_lattice_cases(profile)
+    yield from _quadrature_rule_cases(profile)
+    yield from _tensor_product_cases(profile)
+    yield from _gauss_legendre_nd_cases(profile)

--- a/tools/adversarial_sweep/_registry.py
+++ b/tools/adversarial_sweep/_registry.py
@@ -1,0 +1,57 @@
+"""Registry mapping sweep group names to their case generators.
+
+Adding a probe module means importing it here and adding one entry to
+:data:`GROUPS`; the CLI's ``--group`` choices and ``--list-groups`` output are
+derived from it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from . import (
+    _probes_basis,
+    _probes_bezier,
+    _probes_bspline,
+    _probes_geometry,
+    _probes_grid,
+    _probes_quad,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+    from ._axes import Profile
+    from ._core import Case
+
+GROUPS: Final[dict[str, Callable[[Profile], Iterator[Case]]]] = {
+    _probes_geometry.GROUP: _probes_geometry.cases,
+    _probes_quad.GROUP: _probes_quad.cases,
+    _probes_basis.GROUP: _probes_basis.cases,
+    _probes_bspline.GROUP: _probes_bspline.cases,
+    _probes_bezier.GROUP: _probes_bezier.cases,
+    _probes_grid.GROUP: _probes_grid.cases,
+}
+"""Group name to case generator. Iteration order fixes the sweep's case indices."""
+
+
+def iter_cases(profile: Profile, groups: Iterable[str]) -> Iterator[Case]:
+    """Yield the cases of the selected groups, in registry order.
+
+    Args:
+        profile (Profile): Sweep width.
+        groups (Iterable[str]): Group names to include.
+
+    Yields:
+        Case: The selected cases.
+
+    Raises:
+        KeyError: If a name is not a registered group.
+    """
+    wanted = set(groups)
+    unknown = wanted - set(GROUPS)
+    if unknown:
+        raise KeyError(f"unknown sweep groups: {sorted(unknown)}")
+    for name, generator in GROUPS.items():
+        if name in wanted:
+            yield from generator(profile)

--- a/tools/adversarial_sweep/_registry.py
+++ b/tools/adversarial_sweep/_registry.py
@@ -3,6 +3,16 @@
 Adding a probe module means importing it here and adding one entry to
 :data:`GROUPS`; the CLI's ``--group`` choices and ``--list-groups`` output are
 derived from it.
+
+Enumeration is guarded per group. A probe generator builds its cases lazily, so a
+pantr call in a generator *body* -- constructing a fixture, evaluating a reference
+for an invariant -- raises during iteration rather than inside a case, where the
+runner would classify it. Unguarded, that ends the whole sweep: the remaining groups
+never run and the exit status looks like an ordinary findings report. So
+:func:`iter_cases` converts such a failure into one synthetic case that re-raises when
+run, which the runner then reports as a finding with its traceback, and carries on with
+the next group. The cases after the failure *within* that group are still lost --
+Python closes a generator that raises -- but five groups out of six are not.
 """
 
 from __future__ import annotations
@@ -17,12 +27,12 @@ from . import (
     _probes_grid,
     _probes_quad,
 )
+from ._core import Case
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
 
     from ._axes import Profile
-    from ._core import Case
 
 GROUPS: Final[dict[str, Callable[[Profile], Iterator[Case]]]] = {
     _probes_geometry.GROUP: _probes_geometry.cases,
@@ -33,6 +43,49 @@ GROUPS: Final[dict[str, Callable[[Profile], Iterator[Case]]]] = {
     _probes_grid.GROUP: _probes_grid.cases,
 }
 """Group name to case generator. Iteration order fixes the sweep's case indices."""
+
+
+def _enumeration_failure(group: str, exc: Exception) -> Case:
+    """Wrap an enumeration failure as a case that reports it.
+
+    Args:
+        group (str): The group whose generator raised.
+        exc (Exception): What it raised.
+
+    Returns:
+        Case: A case whose thunk re-raises, so the runner classifies and journals it.
+    """
+
+    def reraise() -> None:
+        raise exc
+
+    return Case(
+        group,
+        "__enumeration_failed__",
+        reraise,
+        reraise,
+        {"error": type(exc).__name__, "message": str(exc)},
+        must_succeed=True,
+    )
+
+
+def _guarded(
+    group: str, generator: Callable[[Profile], Iterator[Case]], profile: Profile
+) -> Iterator[Case]:
+    """Yield a group's cases, turning an enumeration failure into a reported case.
+
+    Args:
+        group (str): Group name, for the synthetic case's label.
+        generator (Callable[[Profile], Iterator[Case]]): The group's case generator.
+        profile (Profile): Sweep width.
+
+    Yields:
+        Case: The group's cases, followed by one synthetic case if enumeration failed.
+    """
+    try:
+        yield from generator(profile)
+    except Exception as exc:  # one bad group must not end the sweep
+        yield _enumeration_failure(group, exc)
 
 
 def iter_cases(profile: Profile, groups: Iterable[str]) -> Iterator[Case]:
@@ -54,4 +107,4 @@ def iter_cases(profile: Profile, groups: Iterable[str]) -> Iterator[Case]:
         raise KeyError(f"unknown sweep groups: {sorted(unknown)}")
     for name, generator in GROUPS.items():
         if name in wanted:
-            yield from generator(profile)
+            yield from _guarded(name, generator, profile)

--- a/tools/sweep.py
+++ b/tools/sweep.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""Launcher for the adversarial parameter sweep.
+
+Puts this checkout's ``src`` and ``tools`` on ``sys.path`` -- so the sweep always
+exercises the worktree's own source, never whatever an editable install points at --
+and hands over to :mod:`adversarial_sweep.__main__`, which configures Numba's bounds
+check before importing anything compiled.
+
+Usage::
+
+    conda run -n pantr python tools/sweep.py --profile smoke
+    conda run -n pantr python tools/sweep.py --profile full --journal sweep.jsonl
+    conda run -n pantr python tools/sweep.py --list-groups
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "tools"))
+sys.path.insert(0, str(_ROOT / "src"))
+
+from adversarial_sweep.__main__ import main  # noqa: E402  -- needs the path set up first
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The test suite is about to become the parity oracle for a C++ port, so what it does *not*
exercise matters as much as what it does. This adds an adversarial sweep over the public
API, pins the root causes it found, and gates it in CI.

## The sweep

`tools/adversarial_sweep/` plus a `tools/sweep.py` launcher: **29 858 cases** across
geometry, quad, basis, bezier, grid and bspline, crossing degree, knot multiplicity up to
`degree + 1`, domain scale and translation, periodic and non-clamped vectors, dtype,
degenerate counts, and query points at knots, at domain ends, outside, and non-finite.

It runs under `NUMBA_BOUNDSCHECK=1` with a fresh Numba cache **arranged by the launcher**,
because the flag is silently ignored for `cache=True` kernels when a stale cache exists —
every pantr kernel is `cache=True`, so a naive invocation returns a false clean. A canary
kernel with a deliberate overrun must raise before any run is believed.

`--dump-npz` persists the input arrays, so the same cases can be replayed against the port.

## What it found

Nine root causes, each pinned as one `xfail(strict=True)` in
`tests/test_sweep_regressions.py` with the exact data hardcoded, and each verified to fail
*for its stated reason*. The four with the widest blast radius:

- `elevate_degree` allocates its knot output as `float64` regardless of the input dtype, so
  it **raises for every clamped float32 spline** (9 of 9 across degrees 1-3) and, on a
  periodic space, succeeds while silently promoting the caller's precision.
- `_degree_elevate_1d_core` returns a knot vector and control points from two counters
  maintained independently; the deficit equals the number of interior knots at multiplicity
  `degree + 1`. **Silent at degree 0**, where the domain collapses to a point, a control
  point is duplicated, and evaluation returns zeros with no exception.
- `Bspline.reduce_degree(1)` **does not return** on a degree-1 periodic spline, at any
  interval count and any scale; the clamped equivalent takes 0.003 s and degrees 2 and 3
  raise cleanly in milliseconds.
- `tabulate_lagrange_1d` builds SciPy's `BarycentricInterpolator` without `rng`, so an
  unseeded global RNG permutes the nodes and **the same call returns different values in
  different processes** — 1 ulp at degree 3, 4.18 absolute at degree 62. Everything
  downstream inherits it.

Also pinned: knot snapping averaging a run of identical knots (the reported domain moves),
the snapping grid being absolute (20 requested intervals become 10 on a small float32
domain), tanh-sinh keeping snapped endpoint nodes so it returns `inf` for the
endpoint-singular integrands it advertises, and `num_intervals=0` documented legal by two
factories and rejected by a third.

Three previously known bugs were reproduced by the harness as a validation that it can
detect what it is looking for.

## CI

`tests/test_adversarial_sweep.py` and a dedicated `adversarial-sweep` job, `slow`- and
`PANTR_RUN_SWEEP`-gated, following the `tests/mpi/` precedent. Cost to the default suite:
one skip.

## Honest coverage limits

- The `must_succeed` / `must_reject` verdict flags are fully applied only in the `bspline`
  group; the other four still grade a legal-input exception against the docstring alone, so
  their near-clean results are weaker than they look.
- The complete run's second half produced roughly 80 further findings, recorded with their
  parameters but **not triaged or pinned** — including a second hang, in `Bspline.multiply`
  at degree 62 periodic.
- The crossing is factorized, not exhaustive: a defect needing multiplicity *and*
  translation *and* float32 simultaneously would be missed. `viz`, `cad` and MPI are
  unswept by design.
- The per-case timeout uses `SIGALRM`, which cannot interrupt a spin inside a compiled
  kernel.

## Verification

`ruff check`, `ruff format --check`, `mypy`, `import-lint` and the docs build under `-W`
all clean; **4958 passed, 21 skipped, 9 xfailed**.

No changelog entry: this is internal tooling and a CI job, not public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
