### PR TITLE
fix(bspline,quad,basis): close five confirmed defects, from a fabricated root to a non-terminating reduction

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -145,6 +145,25 @@
   `0.61721778`. The lemma's hypothesis is now tested on the knot vector, which
   needs no tolerance, and a jump is rejected by the same residual test that
   already separates a tangential zero from a false sign change.
+- `get_tanh_sinh_1d` returned `inf` for `1/sqrt(x)` — the integrand a
+  double-exponential rule exists for — at every `n_pts >= 45`, and raising the
+  point count therefore turned a correct answer into `inf`. A node whose
+  distance to the endpoint had underflowed was moved *onto* the endpoint and
+  kept, with a nonzero weight, and from `n_pts = 53` a second node landed on the
+  same boundary and was returned twice. The rule is now truncated there instead:
+  generation stops at the last node whose gap survives the mapping onto `[0, 1]`
+  in the requested dtype, which is one machine epsilon. The discarded weight is
+  at most `pi * cosh(t) * gap`, measured at `8.2e-15` against a weight sum of
+  `2`, so a smooth integrand is unchanged; a singular one now converges to the
+  truncation floor, `2e-8` for `x**-0.5` and `4e-15` for `log(x)`, both stated
+  in the docstring. Returning fewer nodes than requested was already documented.
+  In `float32` the cast onto `[0, 1]` collapsed a node onto `1.0` from
+  `n_pts = 19`, which the dtype-aware threshold also closes.
+- `QuadratureRule` claimed its factory-built rules integrate the constant `1`
+  exactly. They do not, and cannot: dividing by a computed sum leaves the
+  rescaled weights summing to `1` only up to rounding. Measured over Gauss-
+  Legendre rules of 1 to 40 points per direction, `|sum - 1|` reaches 2 ulp in
+  1D, 3 ulp in 2D and 4 ulp in 3D. The docstring now says that.
 
 ## 0.6.0 (2026-06-24)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -177,6 +177,16 @@
   a Lagrange target all inherited it. The permutation is now seeded from a
   recorded constant, which also makes the `degree + 1` cardinal functions share
   one set of weights instead of drawing their own.
+- `Bspline.elevate_degree` and `Bspline.reduce_degree` were unusable on every
+  float32 spline. Both kernels allocated the two halves of their return with
+  different dtypes: the control points followed the input while the knot vector
+  was hardcoded float64. On a clamped space the `Bspline` constructor then
+  rejected the mismatched pair with a message about the *caller's* control
+  points, at every degree and every knot count; on a periodic space the round
+  trip through open form converted the control points as well, so the call
+  succeeded and silently discarded the caller's choice of precision, doubling
+  memory and halving throughput without a word. Both knot outputs now follow the
+  input knot vector's dtype.
 
 ## 0.6.0 (2026-06-24)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -164,6 +164,19 @@
   rescaled weights summing to `1` only up to rounding. Measured over Gauss-
   Legendre rules of 1 to 40 points per direction, `|sum - 1|` reaches 2 ulp in
   1D, 3 ulp in 2D and 4 ulp in 3D. The docstring now says that.
+- Lagrange tabulation was not reproducible between processes. SciPy's
+  `BarycentricInterpolator` permutes the nodes before forming the barycentric
+  weights, which is Berrut and Trefethen's remedy against the product over- or
+  underflowing, and it was built without the `rng` argument, so the permutation
+  came from the unseeded global NumPy state. Two runs of the same call differed
+  by 1.6e-16 to 1.5e-15 relative at degrees 3 to 12, by 4.18 absolute on a value
+  scale of 3.75e7 at degree 62, and by `inf` against 1e16 evaluated outside
+  `[0, 1]`. That is an unseeded generator, not floating-point nondeterminism
+  with a bound. `tabulate_lagrange`, `compute_lagrange_to_bernstein_1d`,
+  `tabulate_Lagrange_extraction_operators` and `SpanwiseElementExtraction` with
+  a Lagrange target all inherited it. The permutation is now seeded from a
+  recorded constant, which also makes the `degree + 1` cardinal functions share
+  one set of weights instead of drawing their own.
 
 ## 0.6.0 (2026-06-24)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -187,6 +187,21 @@
   succeeded and silently discarded the caller's choice of precision, doubling
   memory and halving throughput without a word. Both knot outputs now follow the
   input knot vector's dtype.
+- `Bspline.reduce_degree` never returned on a degree-1 periodic spline. Degree
+  reduction hands the periodic conversion `m_bdy - decrement` as the target
+  boundary multiplicity, and a maximally smooth periodic space has `m_bdy = 1`,
+  so the argument is 0 at every degree; the conversion documents
+  `1 <= m_bdy <= degree` and nothing checked it. The ghost-knot builder then had
+  a per-period tile of total multiplicity 0 and its right-hand loop, which
+  appends until it has enough ghost knots, could append nothing and incremented
+  its shift forever. Degrees 2 and 3 escaped only because the C^0 seam check a
+  few lines earlier rejected them first, so the trigger's narrowness was an
+  accident of check ordering rather than anything about degree 1. The
+  precondition is now enforced, so every degree refuses in under 10 ms with a
+  message naming the actual problem; the loop's termination argument is written
+  down beside it. Reducing a periodic spline to degree 0 has no answer in this
+  representation, an empty `[1, degree]` meaning no ghost knots and nothing to
+  wrap; `to_open_bspline().reduce_degree(1)` does it in the open form.
 
 ## 0.6.0 (2026-06-24)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,12 @@
   matrix rather than by sampling.
 
 ### Changed
+- The minimum supported SciPy is now 1.15, raised from 1.11. Lagrange tabulation
+  seeds the node permutation SciPy's `BarycentricInterpolator` applies, and the
+  `rng` argument that makes that possible arrived in 1.15. Earlier versions
+  cannot be made reproducible through that class at all — 1.11 accepts neither a
+  seed nor precomputed weights — so the previous floor was already untrue for
+  this function rather than merely untested.
 - Knot insertion runs the Oslo recurrence over the `degree + 1` band each row is
   supported on, instead of over the full row. Refining a spline with 10⁴ control
   points dyadically takes 1.9 ms where it took 1432 ms. The refinement matrix

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -130,6 +130,21 @@
   partition of unity. The guard now tests against exact zero, which is
   scale-invariant by construction because knot vectors already snap
   near-duplicate knots to one bitwise value.
+- `find_roots` reported a root at every interior knot of multiplicity
+  `degree + 1` whose two straddling coefficients change sign, where the spline
+  is C^-1 and jumps across the axis without ever reaching it. The tracking cited
+  Mørken-Reimers Lemma 3, whose conclusion `c[a] = 0` rests on the iterate lying
+  in the half-open interval between two consecutive Greville abscissae, and that
+  interval is empty at precisely that multiplicity: the secant through the two
+  coefficients is vertical there, so its zero is the knot for every `lambda` and
+  nothing forces the coefficient to vanish. The fabricated root then took a real
+  one with it, since reporting it split the spline at the jump and pinned the
+  coefficient on the far side to zero as the split barrier, destroying the sign
+  change that bracketed the next zero. On a quadratic split once at C^-1 the
+  reported set was `[0.40269975, 0.5]` where the zeros are `0.40269975` and
+  `0.61721778`. The lemma's hypothesis is now tested on the knot vector, which
+  needs no tolerance, and a jump is rejected by the same residual test that
+  already separates a tangential zero from a false sign change.
 
 ## 0.6.0 (2026-06-24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 # visualization) live in `[project.optional-dependencies]` and are opt-in.
 dependencies = [
   "numpy>=1.26,<3",
-  "scipy>=1.11,<2",
+  "scipy>=1.15,<2",  # 1.15 added BarycentricInterpolator's `rng`, which Lagrange tabulation needs to be reproducible
   "numba>=0.63,<0.66",  # 0.66.0 broke mypy's view of get_num_threads/config.NUMBA_NUM_THREADS
   "threadpoolctl>=3.0",
 ]

--- a/src/pantr/basis/_basis_lagrange.py
+++ b/src/pantr/basis/_basis_lagrange.py
@@ -22,6 +22,38 @@ from ..quad import (
     get_trapezoidal_1d,
 )
 
+_BARYCENTRIC_SEED: int = 0
+"""Seed for the node permutation SciPy uses to build the barycentric weights.
+
+:class:`scipy.interpolate.BarycentricInterpolator` multiplies the node differences in a
+random order, which is Berrut and Trefethen's remedy (2004, p. 510) for the product
+over- or underflowing at high degree. Left unseeded it draws from the *global* NumPy
+state, so the tabulated basis changed from one process to the next: measured relative
+spreads of 1.6e-16 at degree 3 to 1.5e-15 at degree 12, growing to 4.18 absolute on a
+value scale of 3.75e7 at degree 62, and to ``inf`` against 1e16 evaluated outside
+``[0, 1]``. That is not floating-point nondeterminism with a bound one could derive; it
+is an unseeded generator, so no bound exists.
+
+The integer itself is arbitrary. What matters is that it is *fixed and recorded*: a
+different seed orders the same product differently and so rounds differently, which is a
+choice about reproducibility rather than about accuracy. Every consumer inherits it --
+:func:`~pantr.basis.tabulate_lagrange`,
+:func:`~pantr.change_basis.compute_lagrange_to_bernstein_1d`, the Lagrange extraction
+operators.
+
+What it pins, precisely: two calls in one environment agree bit for bit. It does *not*
+pin the bits across a NumPy or SciPy upgrade, since the permutation comes from their
+generator, nor across a reimplementation in another language, which would have to
+reproduce that generator's stream to match. A reimplementation reproduces the same
+polynomial to the accuracy of the barycentric formula and freezes a choice of its own;
+that is the contract, and bit-exactness across implementations is not part of it.
+
+Passing a seed rather than a :class:`~numpy.random.Generator` is deliberate: SciPy builds
+a fresh generator from an integer, so the ``n + 1`` cardinal functions below are all built
+on one permutation and therefore on one set of weights. A ``Generator`` instance would
+advance between them and give every column weights of its own.
+"""
+
 
 def _get_lagrange_points(
     variant: LagrangeVariant, n_pts: int, dtype: npt.DTypeLike = np.float64
@@ -101,7 +133,7 @@ def _tabulate_lagrange_basis_1D_core(
         y_sorted = np.zeros(n_pts, dtype=t.dtype)
         y_sorted[inv_perm[j]] = 1.0
 
-        interpolator = BarycentricInterpolator(nodes_sorted, y_sorted)
+        interpolator = BarycentricInterpolator(nodes_sorted, y_sorted, rng=_BARYCENTRIC_SEED)
 
         # SciPy may upcast internally; ensure we preserve input dtype.
         B_normalized[:, j] = np.asarray(interpolator(t), dtype=t.dtype)

--- a/src/pantr/basis/_basis_lagrange.py
+++ b/src/pantr/basis/_basis_lagrange.py
@@ -52,6 +52,16 @@ Passing a seed rather than a :class:`~numpy.random.Generator` is deliberate: Sci
 a fresh generator from an integer, so the ``n + 1`` cardinal functions below are all built
 on one permutation and therefore on one set of weights. A ``Generator`` instance would
 advance between them and give every column weights of its own.
+
+**Open: this needs SciPy 1.15 or newer, while ``pyproject.toml`` still declares
+``scipy>=1.11,<2``.** Read at the release tags: 1.11 takes no seeding argument at all and
+permutes with the global ``np.random.permutation``; 1.12 through 1.14 take
+``random_state``; ``rng`` arrives in 1.15, where ``random_state`` still works but warns,
+and this project turns warnings into errors under pytest. So the call below raises
+``TypeError`` on 1.11 through 1.14. Neither closing the gap by raising the declared floor
+nor closing it by selecting the keyword at import time is this module's decision to make;
+until it is made, the effective floor is 1.15. Note that 1.11 cannot be made reproducible
+through this class at all -- it accepts neither a seed nor precomputed ``wi`` weights.
 """
 
 

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -174,9 +174,11 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
     cind = 1
     ua = knots[0]
 
-    # We allocate more than enough space for the new arrays
+    # We allocate more than enough space for the new arrays.  Both outputs follow
+    # their own input's dtype: a caller who asked for float32 gets a float32 spline
+    # back, and the two halves of the return stay usable together.
     max_new_knots = len(knots) + t * len(knots)
-    ik = np.zeros(max_new_knots, dtype=np.float64)
+    ik = np.zeros(max_new_knots, dtype=knots.dtype)
     ic = np.zeros((n_pts + t * len(knots), rank), dtype=ctrl.dtype)
 
     for ii in range(rank):
@@ -406,8 +408,9 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
         n_seg += 1
         scan += 1
 
+    # Both outputs follow their own input's dtype, as in the elevation kernel.
     oc = np.empty((n_seg * new_deg + 1, rank), dtype=ctrl.dtype)
-    ok = np.empty(n_seg * new_deg + new_deg + 2, dtype=np.float64)
+    ok = np.empty(n_seg * new_deg + new_deg + 2, dtype=knots.dtype)
 
     # Initialise: first boundary knots and first Bézier segment.
     ua = knots[0]

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -430,11 +430,14 @@ def _build_periodic_knot_vector(
     # We create a long enough sequence and slice to n_ghost entries.
     # Right ghosts: interior breakpoints + period, then a + 2*period, etc.
     #
-    # The loop terminates because `bp_mults` sums to at least `m_bdy >= 1`, which the
-    # caller enforces: every pass from `shift = 2` on appends at least that many
-    # entries, so `n_ghost` is reached in at most `n_ghost + 1` passes. At `m_bdy = 0`
-    # and with no interior breakpoint there is nothing to append and it never ends,
-    # which is why the caller checks rather than assumes.
+    # Both loops below terminate for the same reason, and only for that reason:
+    # `bp_mults` sums to at least `m_bdy`, which `_check_boundary_multiplicity` has
+    # already put at 1 or more. Each pass then appends at least one entry -- the right
+    # loop from `shift = 2` on, since its `shift == 1` pass skips the seam entry, and
+    # the left loop from its first -- so `n_ghost` is reached in at most `n_ghost + 1`
+    # passes. At `m_bdy = 0` with no interior breakpoint the tile is empty, neither
+    # loop can append anything, and both spin forever. That is why the caller checks
+    # rather than assumes, and why weakening that one check reintroduces a hang here.
     right_entries: list[np.floating[Any]] = []
     shift = 1
     while len(right_entries) < n_ghost:
@@ -500,7 +503,10 @@ def _to_periodic_bspline_1d_impl(
             not periodic (C^0 check at seam or residual exceeds tolerance).
 
     Note:
-        Inputs are assumed to be correct (no validation performed).
+        Layer 2, so it does validate, and the boilerplate that used to stand here
+        claiming otherwise was never true of it: the C^0 seam test below predates
+        this docstring and :func:`_check_boundary_multiplicity` joins it. What is
+        *not* checked is shapes and dtypes, which the caller owns.
         For general use, call :meth:`~pantr.bspline.Bspline.to_periodic` instead.
     """
     p = degree

--- a/src/pantr/bspline/_bspline_knot_insertion.py
+++ b/src/pantr/bspline/_bspline_knot_insertion.py
@@ -346,6 +346,35 @@ def _to_open_bspline_impl(bspline: Bspline) -> Bspline:
     return Bspline(new_space, ctrl, is_rational=bspline.is_rational)
 
 
+def _check_boundary_multiplicity(m_bdy: int, degree: int) -> None:
+    """Raise if a target boundary multiplicity is outside ``[1, degree]``.
+
+    The precondition of :func:`_to_periodic_bspline_1d_impl`, enforced rather than
+    assumed because :func:`_build_periodic_knot_vector` cannot survive its violation:
+    with ``m_bdy = 0`` the per-period tile it replicates has total multiplicity 0 at the
+    seam, so its right-hand loop appends nothing and increments its shift forever.
+
+    Every caller but one derives ``m_bdy`` from a range that already satisfies this:
+    ``to_periodic`` computes ``degree - continuity`` with a validated continuity, and
+    knot insertion and degree elevation carry a multiplicity forward from an existing
+    periodic space. Degree reduction computes ``m_bdy - decrement``, which reaches 0.
+
+    Args:
+        m_bdy (int): Target boundary multiplicity of the periodic knot vector.
+        degree (int): Polynomial degree of the periodic space.
+
+    Raises:
+        ValueError: If ``m_bdy`` is outside ``[1, degree]``.
+    """
+    if not 1 <= m_bdy <= degree:
+        raise ValueError(
+            f"A periodic knot vector needs a boundary multiplicity in [1, degree] = "
+            f"[1, {degree}], got {m_bdy}. At degree 0 that range is empty: with no ghost "
+            f"knots there is nothing to wrap, and the periodic form of a piecewise "
+            f"constant is its open form. Work in the open representation instead."
+        )
+
+
 def _build_periodic_knot_vector(
     open_knots: npt.NDArray[np.float32 | np.float64],
     degree: int,
@@ -400,6 +429,12 @@ def _build_periodic_knot_vector(
     # Build ghost knots by generating shifted copies of the tile breakpoints.
     # We create a long enough sequence and slice to n_ghost entries.
     # Right ghosts: interior breakpoints + period, then a + 2*period, etc.
+    #
+    # The loop terminates because `bp_mults` sums to at least `m_bdy >= 1`, which the
+    # caller enforces: every pass from `shift = 2` on appends at least that many
+    # entries, so `n_ghost` is reached in at most `n_ghost + 1` passes. At `m_bdy = 0`
+    # and with no interior breakpoint there is nothing to append and it never ends,
+    # which is why the caller checks rather than assumes.
     right_entries: list[np.floating[Any]] = []
     shift = 1
     while len(right_entries) < n_ghost:
@@ -461,8 +496,8 @@ def _to_periodic_bspline_1d_impl(
         ``(n_periodic, rank)``.
 
     Raises:
-        ValueError: If the function is not periodic (C^0 check at seam or
-            residual exceeds tolerance).
+        ValueError: If ``m_bdy`` is outside ``[1, degree]``, or if the function is
+            not periodic (C^0 check at seam or residual exceeds tolerance).
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -470,6 +505,8 @@ def _to_periodic_bspline_1d_impl(
     """
     p = degree
     dtype = open_knots.dtype
+
+    _check_boundary_multiplicity(m_bdy, p)
 
     a = float(open_knots[p])
     b = float(open_knots[-p - 1])

--- a/src/pantr/bspline/_bspline_roots_core.py
+++ b/src/pantr/bspline/_bspline_roots_core.py
@@ -33,7 +33,13 @@ _STATUS_CONVERGED: int = 1
 """The iterates stagnated, or repeated exactly, at a zero of the spline."""
 
 _STATUS_CANDIDATE: int = 2
-"""The sign change vanished; the last iterate is a tangential-zero candidate."""
+"""The polygon cannot certify the last iterate; its residual decides.
+
+Reached when the tracked sign change vanished under refinement, which is either a
+tangential zero or a false warning of the variation-diminishing bound, and when the
+iterate reached a knot of multiplicity ``degree + 1``, where the spline jumps and the
+sign change need not bracket a zero at all.
+"""
 
 _STATUS_BUDGET: int = 3
 """The insertion budget ran out before the iterates stagnated."""
@@ -278,6 +284,7 @@ def _track_zero(  # noqa: PLR0913
     degree: int,
     index: int,
     tol: float,
+    zero_tol: float,
     domain_length: float,
     max_insertions: int,
     iterates: npt.NDArray[Any],
@@ -303,6 +310,8 @@ def _track_zero(  # noqa: PLR0913
         index (int): Zero index to track, inside the window. The caller
             guarantees that :func:`_is_zero_index` holds for it.
         tol (float): Relative stagnation tolerance.
+        zero_tol (float): Absolute residual below which a coefficient counts as
+            zero.
         domain_length (float): Length of the spline's parametric domain, used as
             a floor for the tolerance scale.
         max_insertions (int): Insertion budget for this zero.
@@ -360,9 +369,32 @@ def _track_zero(  # noqa: PLR0913
         if num_iterates > 0 and x == previous_x:
             return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
 
-        # The spline is disconnected at x, so f(x) = 0 exactly (their Lemma 3).
+        # Their Lemma 3: an iterate that reaches the right end of its Greville
+        # interval carries `coeffs[index] = 0`, hence f(x) = 0.
+        #
+        # The lemma places x in `(knot_average(index - 1), knot_average(index)]`,
+        # and that interval is empty exactly when the two abscissae coincide,
+        # which happens exactly when `knots[index] == knots[index + degree]`,
+        # that is when the knot run at x carries multiplicity `degree + 1` and
+        # the spline is C^-1 there. The hypothesis is therefore a property of the
+        # knot vector alone: the test below is structural and needs no tolerance,
+        # and it leaves every other spline on the path it already took.
+        #
+        # In that one excluded case the secant through the two coefficients is
+        # vertical, its zero is x for every `lam`, and nothing forces
+        # `coeffs[index]` to vanish; the sign change is then the spline jumping
+        # across the axis rather than meeting it. So test the lemma's conclusion
+        # instead of assuming it. At an exact C^-1 knot `coeffs[index]` is the
+        # value of the spline immediately to the right of the run, with no
+        # positional error to inflate it, so comparing it against the residual
+        # threshold is dimensionally sound.
         if x >= knots[index + degree]:
-            return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+            if knots[index] < knots[index + degree] or abs(coeffs[index]) <= zero_tol:
+                return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+            # Hand the jump to the caller's residual test, which rejects it.
+            # Refining instead would insert a knot into a run the method keeps at
+            # multiplicity at most `degree`, and divide by a zero-length span.
+            return x, _STATUS_CANDIDATE, abs(coeffs[index]), num_coeffs, index
 
         iterates[num_iterates % degree] = x
         previous_x = x
@@ -419,7 +451,9 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
     ``|f(x)| <= zero_tol``, which is also how the two domain endpoints are
     tested. Zeros of even multiplicity have no sign change in the limit and
     cannot be certified by the polygon alone, so they are reported through that
-    residual test only.
+    residual test only. A sign change across a knot of multiplicity
+    ``degree + 1``, where the spline is C^-1 and jumps across the axis without
+    reaching it, is rejected by that same test.
 
     Args:
         knots (npt.NDArray[Any]): Open (clamped) knot vector of shape
@@ -497,6 +531,7 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
             degree,
             index,
             tol,
+            zero_tol,
             domain_length,
             max_insertions,
             iterates,
@@ -508,7 +543,9 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
 
         # A polygon that lost its sign change is at a zero of even multiplicity if
         # the spline vanishes there, and at a false warning of the
-        # variation-diminishing bound otherwise.
+        # variation-diminishing bound otherwise. A sign change straddling a knot
+        # of multiplicity `degree + 1` arrives here as well, and the same test
+        # rejects it: the spline jumps across the axis without ever reaching it.
         accepted = residual <= zero_tol if status == _STATUS_CANDIDATE else True
 
         # The sweep is strictly left to right, so an iterate that did not pass

--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -21,6 +21,7 @@ import numpy.typing as npt
 from numpy.polynomial import chebyshev, legendre
 
 from ._array_utils import _validate_float_dtype
+from .tolerance import get_machine_epsilon
 
 if TYPE_CHECKING:
     from .basis import LagrangeVariant
@@ -268,7 +269,46 @@ _TANH_SINH_DECAY_FACTOR: float = 0.6
 """Decay-rate factor selecting the uniform step ``h`` in transform space."""
 
 
-def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
+def _tanh_sinh_min_gap(dtype: npt.DTypeLike) -> float:
+    """Get the smallest endpoint gap ``1 - |x|`` a tanh-sinh node may carry on [-1, 1].
+
+    A double-exponential rule is what it is because no node ever reaches an
+    endpoint; that is what makes an endpoint singularity integrable, and it is
+    the property :func:`get_tanh_sinh_1d` advertises.  The gap falls
+    double-exponentially along the transform axis, so the rule has to stop
+    somewhere, and the place to stop is where the gap stops being representable
+    *in the frame the rule is returned in*.
+
+    :func:`get_tanh_sinh_1d` maps ``[-1, 1]`` onto ``[0, 1]`` by ``(x + 1) / 2``
+    and casts to *dtype*, so the node near the right end is computed as
+    ``(2 - gap) / 2``.  The halving is exact; the subtraction is not, and
+    ``2 - gap`` rounds to ``2`` as soon as ``gap <= eps / 2``, which sends the
+    node onto ``1``.  Returning ``eps`` keeps one bit of margin over that
+    boundary.  For ``float32`` the same threshold governs the final cast, since
+    ``1 - gap / 2`` rounds to ``1.0f`` once ``gap / 2`` falls below half a
+    ``float32`` ulp.
+
+    Truncating there costs nothing.  With ``gap = 1 - tanh(omega)`` one has
+    ``cosh(omega)**-2 = gap * (2 - gap)``, so the discarded weight is
+    ``w = (pi / 2) * cosh(t) * gap * (2 - gap) <= pi * cosh(t) * gap``.  In
+    float64 the threshold puts ``omega`` at ``18.4`` and ``cosh(t)`` at ``11.8``,
+    giving ``w <= 8.3e-15`` against a weight sum of ``2`` (largest measured over
+    ``n`` from 2 to 400: ``8.19e-15``).  That is below the rounding of the sum
+    the weight would have joined, and the rescaling in
+    :func:`_generate_tanh_sinh` restores that sum.
+
+    Args:
+        dtype (npt.DTypeLike): Floating-point dtype the rule will be returned in.
+
+    Returns:
+        float: The smallest admissible gap, one machine epsilon of *dtype*.
+    """
+    return get_machine_epsilon(dtype)
+
+
+def _generate_tanh_sinh(
+    n: int, dtype: npt.DTypeLike = np.float64
+) -> tuple[npt.NDArray[np.float64], int]:
     r"""Generate tanh-sinh quadrature nodes and weights on [-1, 1].
 
     Builds an *n*-point double-exponential (tanh-sinh) scheme.  Under the
@@ -282,14 +322,18 @@ def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
     truncation balance solved via the Lambert W function (see
     :data:`_TANH_SINH_DECAY_FACTOR`).
 
-    Nodes so close to :math:`\pm 1` that ``1 - |x|`` underflows to ``0`` in
-    float64 are snapped to the boundary and their weights accumulated onto the
-    shared endpoint pair, so the effective number of nodes *m* may be less than
-    *n*.  The weights are finally rescaled to sum to ``2`` (the measure of
-    ``[-1, 1]``).
+    Generation stops at the last node whose distance to the endpoint is still
+    representable once the rule is mapped onto ``[0, 1]`` in *dtype* (see
+    :func:`_tanh_sinh_min_gap`), so the effective number of nodes *m* may be less
+    than *n* and no node ever sits on an endpoint.  The weights are finally
+    rescaled onto the measure ``2`` of ``[-1, 1]``, up to the rounding of their
+    own sum.
 
     Args:
         n (int): Requested number of quadrature points (must be >= 1).
+        dtype (npt.DTypeLike): Floating-point dtype the rule will be returned in.
+            It sets the truncation point and nothing else; the returned data is
+            float64 either way.  Defaults to ``np.float64``.
 
     Returns:
         tuple[npt.NDArray[np.float64], int]: A pair ``(data, m)`` where
@@ -312,6 +356,7 @@ def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
     decay_arg = 2.0 * _TANH_SINH_DECAY_FACTOR * half_pi * (n - 1)
     h = 2.0 * float(lambertw(decay_arg).real) / n
 
+    min_gap = _tanh_sinh_min_gap(dtype)
     buf = np.empty((n, 2), dtype=np.float64)  # worst case: n nodes
     count = 0
 
@@ -321,8 +366,6 @@ def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
         buf[count] = [0.0, half_pi]
         count += 1
 
-    endpoint_snapped = False
-
     for i in range(n // 2):
         # Odd n samples t = h, 2h, ...; even n offsets by half a step.
         t = (i + 1) * h if odd else (i + 0.5) * h
@@ -330,33 +373,28 @@ def _generate_tanh_sinh(n: int) -> tuple[npt.NDArray[np.float64], int]:
         w = half_pi * np.cosh(t) / np.cosh(omega) ** 2
         # gap = 1 - tanh(omega), the node's distance from the +1 endpoint,
         # via the algebraically equal form 2 / (1 + e^{2 omega}).  This keeps
-        # gap a small but nonzero float right up to the underflow boundary,
+        # gap a small but nonzero float right up to the resolution limit,
         # whereas 1 - np.tanh(omega) saturates to 0 a step too early and would
-        # snap nodes prematurely.
+        # truncate the rule prematurely.
         gap = 2.0 / (1.0 + np.exp(2.0 * omega))
 
-        if (np.float64(1.0) - np.float64(gap)) == np.float64(1.0):
-            # gap underflowed: the node is numerically at the boundary.
-            if endpoint_snapped:
-                buf[count - 2, 1] += w
-                buf[count - 1, 1] += w
-            else:
-                buf[count] = [-1.0, w]
-                count += 1
-                buf[count] = [1.0, w]
-                count += 1
-                endpoint_snapped = True
-        else:
-            # Symmetric pair at -(1 - gap) and +(1 - gap); writing both from
-            # gap keeps the coordinates exact negatives of each other.
-            buf[count] = [-(1.0 - gap), w]
-            count += 1
-            buf[count] = [1.0 - gap, w]
-            count += 1
+        # gap decreases monotonically in t, so the first node whose distance to
+        # the endpoint no longer survives the mapping onto [0, 1] ends the rule.
+        if gap < min_gap:
+            break
+
+        # Symmetric pair at -(1 - gap) and +(1 - gap); writing both from
+        # gap keeps the coordinates exact negatives of each other.
+        buf[count] = [-(1.0 - gap), w]
+        count += 1
+        buf[count] = [1.0 - gap, w]
+        count += 1
 
     data = buf[:count].copy()
 
-    # Rescale weights to integrate the constant 1 exactly over [-1, 1].
+    # Rescale the weights onto the measure 2 of [-1, 1].  The sum of the rescaled
+    # weights is 2 only up to the rounding of that sum: dividing by a computed sum
+    # cannot make a floating-point sum exact.
     data[:, 1] *= 2.0 / np.sum(data[:, 1])
 
     return data, count
@@ -370,9 +408,12 @@ def get_tanh_sinh_1d(
     Tanh-sinh (double-exponential) quadrature clusters nodes near the
     endpoints of the interval, making it well suited for integrands with
     endpoint singularities or steep boundary layers.  The scheme is
-    symmetric and nodes near the endpoints that are indistinguishable from
-    0 or 1 in floating-point arithmetic are snapped to the boundary, so
-    the effective number of returned nodes may be less than *n_pts*.
+    symmetric, and every returned node lies strictly inside ``(0, 1)``: a node
+    that would sit closer to an endpoint than *dtype* can resolve ends the rule
+    instead of being moved onto the boundary, so the number of returned nodes
+    may be less than *n_pts*, and fewer in ``float32`` than in ``float64``.
+    Placing a node *on* the boundary would defeat the purpose of the rule, an
+    endpoint singularity being exactly what it is meant to integrate.
 
     Args:
         n_pts (int): Requested number of quadrature points.  Must be at
@@ -383,22 +424,34 @@ def get_tanh_sinh_1d(
     Returns:
         tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
             ``(nodes, weights)`` on ``[0, 1]``.  Both arrays have the same
-            length, which may be less than *n_pts* due to endpoint
-            snapping.  Weights sum to 1.
+            length, which may be less than *n_pts* because the rule is
+            truncated where the endpoint gap stops being resolvable.  Weights
+            sum to 1 up to the rounding of that sum.
 
     Raises:
         ValueError: If *n_pts* < 1 or *dtype* is not ``float32``/``float64``.
 
+    Note:
+        Truncation puts a floor on what a singular integrand can reach, and
+        raising *n_pts* past it buys nothing.  The rule covers
+        ``[delta, 1 - delta]`` with ``delta`` of order ``eps / 2``, so the error
+        is the integral over the two neglected tails.  For ``x**-0.5`` that is
+        ``2 * sqrt(delta) = 2e-8`` (measured 2.0e-8 from *n_pts* 49 on) and for
+        ``log(x)`` it is ``delta * (log(delta) - 1) = 4e-15`` (measured 3.9e-15).
+        A smooth integrand is unaffected and converges to machine precision.
+
     Example:
         >>> nodes, weights = get_tanh_sinh_1d(5)
         >>> nodes.shape[0] <= 5
+        True
+        >>> bool(((nodes > 0.0) & (nodes < 1.0)).all())
         True
         >>> abs(weights.sum() - 1.0) < 1e-14
         True
     """
     _validate_n_pts_and_dtype(n_pts, dtype)
 
-    data, _ = _generate_tanh_sinh(n_pts)
+    data, _ = _generate_tanh_sinh(n_pts, dtype)
     return _scale_and_cast_nodes_and_weights(data[:, 0], data[:, 1], dtype)
 
 
@@ -547,8 +600,12 @@ class QuadratureRule:
     :func:`pantr.grid.cell_quadrature` affinely maps onto each cell of a grid.
     Points lie in the closed unit cube; the factory-built rules
     (:func:`tensor_product_quadrature`, :func:`gauss_legendre_quadrature`) have
-    weights summing to ``1`` (the measure of the unit cube), so the rule
-    integrates the constant ``1`` exactly. The stored arrays are read-only.
+    weights summing to ``1``, the measure of the unit cube, so the rule
+    integrates the constant ``1`` to within the rounding of that sum and not
+    exactly: a ``ndim``-fold product of rounded 1D weights, summed over
+    ``num_points`` terms, cannot land on ``1.0`` bitwise. Measured over Gauss-
+    Legendre rules of 1 to 40 points per direction, the largest ``|sum - 1|`` is
+    2 ulp in 1D, 3 ulp in 2D and 4 ulp in 3D. The stored arrays are read-only.
     """
 
     __slots__ = ("_ndim", "_num_points", "_points", "_weights")

--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -280,13 +280,26 @@ def _tanh_sinh_min_gap(dtype: npt.DTypeLike) -> float:
     *in the frame the rule is returned in*.
 
     :func:`get_tanh_sinh_1d` maps ``[-1, 1]`` onto ``[0, 1]`` by ``(x + 1) / 2``
-    and casts to *dtype*, so the node near the right end is computed as
-    ``(2 - gap) / 2``.  The halving is exact; the subtraction is not, and
-    ``2 - gap`` rounds to ``2`` as soon as ``gap <= eps / 2``, which sends the
-    node onto ``1``.  Returning ``eps`` keeps one bit of margin over that
-    boundary.  For ``float32`` the same threshold governs the final cast, since
-    ``1 - gap / 2`` rounds to ``1.0f`` once ``gap / 2`` falls below half a
-    ``float32`` ulp.
+    and casts to *dtype*, so the node near the right end is reached as
+    ``((1 - gap) + 1) / 2``, and it is that whole expression, not any one step of
+    it, that has to land strictly below ``1``.  Two of the three steps round.
+    Writing ``u = eps / 2`` for the spacing just below ``1``:
+
+    * ``1 - gap`` rounds to ``1 - u`` while ``gap < 1.5 u``, and to ``1 - 2u``
+      from there on;
+    * ``+ 1`` maps ``1 - u`` to ``2 - u``, the midpoint of ``[2 - 2u, 2]``, which
+      ties to even and so becomes ``2``; it maps ``1 - 2u`` to ``2 - 2u`` exactly;
+    * the halving is exact.
+
+    So the node collapses onto ``1`` exactly when ``gap < 1.5 u = 0.75 eps``, and
+    returning ``eps`` clears that by one representable step of ``gap``, a factor
+    ``4 / 3``.  Bisecting on ``gap`` puts the crossing at ``0.75 eps`` to fifty
+    digits in ``float64`` and in ``float32`` alike, the argument being about the
+    binade boundary at ``1`` and not about the width of the format.
+
+    Note that reasoning about a single step gives the wrong answer here: ``2 -
+    gap`` alone survives down to ``gap > eps / 2``, a factor 1.5 below the true
+    threshold, because it ignores the rounding of ``1 - gap`` that precedes it.
 
     Truncating there costs nothing.  With ``gap = 1 - tanh(omega)`` one has
     ``cosh(omega)**-2 = gap * (2 - gap)``, so the discarded weight is
@@ -296,6 +309,13 @@ def _tanh_sinh_min_gap(dtype: npt.DTypeLike) -> float:
     ``n`` from 2 to 400: ``8.19e-15``).  That is below the rounding of the sum
     the weight would have joined, and the rescaling in
     :func:`_generate_tanh_sinh` restores that sum.
+
+    What this bound does *not* claim is that the returned nodes are all distinct.
+    Two consecutive samples can both clear the threshold and still round onto one
+    representable coordinate, first at ``n_pts = 544`` in ``float64`` and
+    ``n_pts = 324`` in ``float32``, both at ``1 - eps``.  That is the format
+    running out of coordinates rather than a node reaching the endpoint, and the
+    two weights, ``2.9e-16`` together at ``n_pts = 544``, land where they belong.
 
     Args:
         dtype (npt.DTypeLike): Floating-point dtype the rule will be returned in.

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -519,6 +519,27 @@ _MISSED_COEFFS = np.array(
 _MISSED_ROOT = 0.611347358111781
 """The zero the lost-root case used to drop, located by the Bézier route."""
 
+_JUMP_KNOTS = np.array([0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0])
+"""Knot vector of the C^-1 case: ``BsplineSpace1D(_open_knots(2, [0, 1])).subdivide(2, -1)``.
+
+The interior knot carries multiplicity ``degree + 1``, which is the only multiplicity at
+which the two Greville abscissae ``t[index-1]`` and ``t[index]`` coincide.
+"""
+
+_JUMP_COEFFS = np.array([-1.0, -0.5, 0.3, -0.4, 0.5, 1.0])
+"""Coefficients of the C^-1 case: the pair straddling the break changes sign, 0.3 to -0.4."""
+
+_JUMP_ROOTS = np.array(
+    [0.5 * (math.sqrt(2.2) - 1.0) / 0.6, 0.5 + 0.5 * (9.0 - math.sqrt(65.0)) / 4.0]
+)
+"""The two zeros of the C^-1 case in closed form, 0.40269975 and 0.61721778.
+
+Each Bézier piece is a quadratic that can be solved by hand, which is what makes this an
+independent oracle rather than a second run of the method. Left piece, in ``u = 2t``:
+``0.3u^2 + u - 1``, so ``u = (sqrt(2.2) - 1) / 0.6``. Right piece, in ``v = 2t - 1``:
+``-0.4v^2 + 1.8v - 0.4``, so ``v = (9 - sqrt(65)) / 4``. Both are the root inside ``[0, 1]``.
+"""
+
 
 def test_regression_repeated_knots_do_not_divide_by_zero() -> None:
     """Knots piled to within an ulp used to send a span search off the front of the buffer.
@@ -565,6 +586,38 @@ def test_regression_no_root_is_lost_after_a_rejected_sign_change() -> None:
     expected = _bezier_reference_roots(spline, knots)
     assert found.shape == expected.shape
     np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+def test_regression_a_jump_across_the_axis_is_not_a_root() -> None:
+    """A C^-1 knot used to be reported as a zero, and to swallow the next genuine one.
+
+    The tracking stopped and declared ``f(x) = 0`` whenever an iterate reached the right end
+    of its Greville interval, citing Mørken-Reimers Lemma 3. The lemma places its ``x`` in
+    the half-open interval ``(t[index-1], t[index]]``, which is empty when the two abscissae
+    coincide, and they coincide exactly when the knot run at ``x`` has multiplicity
+    ``degree + 1``. There the secant through the two coefficients is vertical, its zero is
+    ``x`` for every ``lambda``, and nothing forces the coefficient to vanish.
+
+    So on the spline below the break at 0.5 was reported as a root although the spline jumps
+    from ``+0.3`` to ``-0.4`` there. Reporting it then split the spline at 0.5 and pinned the
+    coefficient ``-0.4`` to zero as the split barrier, which destroyed the sign change
+    bracketing the genuine zero at 0.61721778 and lost it. One fabricated root and one lost
+    root, from one cause, which is why both halves are asserted here.
+    """
+    space = BsplineSpace1D(_JUMP_KNOTS, 2)
+    spline = _spline(_JUMP_KNOTS, _JUMP_COEFFS, 2)
+
+    # Precondition: the interior knot is C^-1, the only case the lemma does not cover.
+    unique, mults = space.get_unique_knots_and_multiplicity(in_domain=True)
+    assert int(mults[np.searchsorted(unique, 0.5)]) == space.degree + 1
+
+    # Precondition: the spline really does jump across the axis at the break.
+    jump = spline.evaluate(np.array([[0.5 - 1e-9], [0.5 + 1e-9]])).reshape(-1)
+    assert jump[0] > 0.0 > jump[1]
+
+    found = find_roots(spline)
+
+    np.testing.assert_allclose(found, _JUMP_ROOTS, rtol=0.0, atol=_ROOT_ULPS * _EPS)
 
 
 # --- Kernels --------------------------------------------------------------------------

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -619,6 +619,13 @@ def test_regression_a_jump_across_the_axis_is_not_a_root() -> None:
 
     np.testing.assert_allclose(found, _JUMP_ROOTS, rtol=0.0, atol=_ROOT_ULPS * _EPS)
 
+    # The Bézier route as well, as the two regression tests above do: it solves each
+    # segment on its own, so a C^-1 break is simply where one segment ends, and it has no
+    # opportunity to invent a root there.
+    expected = _bezier_reference_roots(spline, _JUMP_KNOTS)
+    assert found.shape == expected.shape
+    np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
 
 # --- Kernels --------------------------------------------------------------------------
 

--- a/tests/test_lagrange_1D.py
+++ b/tests/test_lagrange_1D.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from fractions import Fraction
 from typing import Any, cast
 
 import numpy as np
@@ -12,6 +13,7 @@ import pytest
 from numpy.polynomial import chebyshev, legendre
 
 from pantr.basis import LagrangeVariant, tabulate_lagrange_1d
+from pantr.basis._basis_lagrange import _get_lagrange_points
 from pantr.tolerance import get_default
 
 
@@ -118,6 +120,108 @@ def test_partition_of_unity(variant: LagrangeVariant, dtype: npt.DTypeLike) -> N
     sums = np.sum(res, axis=-1)
     rtol = get_default(dtype)
     nptest.assert_allclose(sums, 1.0, rtol=rtol, atol=0.0)
+
+
+_SNAP_CLEARANCE: float = 1e-5
+"""Minimum distance from an evaluation point to the nearest node, for the test below.
+
+``_tabulate_lagrange_basis_1D_core`` replaces any row within ``16 * eps`` of a node by a
+hardcoded identity row, so a test meant to see the interpolator has to stay outside that
+window. ``16 * eps`` is 3.6e-15; this leaves ten orders of magnitude. The tightest
+approach the fixed points make is 1e-4, from ``0.5001`` against the node at ``0.5``
+that every symmetric variant carries at even degree, so this is a guard against a later
+edit moving a point onto a node, not a constraint the current data is near.
+"""
+
+_BARYCENTRIC_SAFETY: float = 4.0
+"""Safety factor on the barycentric evaluation-error bound used below.
+
+The bound itself is ``(degree + 1) * eps``, one relative rounding per term of the
+barycentric quotient, applied to the largest cardinal value in the row so that it is a
+bound on a value of that scale rather than on an absolute number. Measured against exact
+rational arithmetic over the five variants at degrees 1 to 12, the worst relative error
+is 1.55e-15 (equispaced, degree 12) against a bare bound of 2.89e-15 there, a margin of
+only 1.9. Four takes that to 7.4 while still failing by twelve orders of magnitude on
+anything that changes the polynomial rather than its rounding.
+"""
+
+
+def _exact_cardinal_row(nodes: npt.NDArray[np.floating[Any]], point: float) -> list[Fraction]:
+    """Evaluate the cardinal basis of ``nodes`` at ``point`` in exact rational arithmetic.
+
+    A float64 is itself a rational, so :class:`~fractions.Fraction` reproduces the
+    interpolation nodes the implementation actually uses with no error at all, and the
+    product form ``prod_{k != j} (t - x_k) / (x_j - x_k)`` is then evaluated exactly.
+    This is an independent oracle rather than a mirror: it is the defining formula of the
+    basis, not the barycentric quotient the implementation evaluates.
+
+    Args:
+        nodes (npt.NDArray[np.floating[Any]]): Interpolation nodes, in any order.
+        point (float): Evaluation point.
+
+    Returns:
+        list[Fraction]: One exact cardinal value per node, in the order given.
+    """
+    xs = [Fraction(float(v)) for v in nodes]
+    t = Fraction(float(point))
+    row: list[Fraction] = []
+    for j, xj in enumerate(xs):
+        value = Fraction(1)
+        for k, xk in enumerate(xs):
+            if k != j:
+                value *= (t - xk) / (xj - xk)
+        row.append(value)
+    return row
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        LagrangeVariant.EQUISPACES,
+        LagrangeVariant.GAUSS_LEGENDRE,
+        LagrangeVariant.GAUSS_LOBATTO_LEGENDRE,
+        LagrangeVariant.CHEBYSHEV_1ST,
+        LagrangeVariant.CHEBYSHEV_2ND,
+    ],
+)
+@pytest.mark.parametrize("degree", [1, 2, 3, 5, 8, 12])
+def test_matches_exact_rational_arithmetic_away_from_the_nodes(
+    variant: LagrangeVariant, degree: int
+) -> None:
+    """Off-node values match the defining product formula computed in exact arithmetic.
+
+    The delta and partition-of-unity tests above cannot see the interpolator at all:
+    ``_tabulate_lagrange_basis_1D_core`` overwrites any row within ``16 * eps`` of a node
+    with a hardcoded identity row, so the first is satisfied by that snap, and the second
+    is satisfied by any basis that sums to one, which a wrong-degree interpolant still
+    does. A mutation that lowered the interpolator's degree left both of them green.
+    Evaluating away from every node is what pins the polynomial itself.
+    """
+    points = np.array([0.13, 0.37, 0.5001, 0.86])
+    # The implementation's own nodes, not the independent reconstruction
+    # `_lagrange_nodes` builds: a cardinal basis is *defined* by its nodes, so an oracle
+    # for the interpolator has to be given the same ones. The two differ by an ulp for
+    # Gauss-Legendre (`leggauss` against `legroots`), and an ulp of node position moves
+    # the exact cardinal value by more than the interpolator's own error budget.
+    # Column j is the cardinal function of node j in this order, whatever that order is.
+    nodes = _get_lagrange_points(variant, degree + 1, np.float64)
+    clearance = float(np.min(np.abs(points[:, None] - nodes[None, :])))
+    assert clearance > _SNAP_CLEARANCE, (
+        f"the evaluation points must stay clear of the snap window around every node; "
+        f"closest approach is {clearance:.3e}"
+    )
+
+    values = np.asarray(tabulate_lagrange_1d(degree, variant, points), dtype=np.float64)
+
+    for i, point in enumerate(points):
+        exact = _exact_cardinal_row(nodes, float(point))
+        scale = max(abs(float(value)) for value in exact)
+        bound = _BARYCENTRIC_SAFETY * (degree + 1) * float(np.finfo(np.float64).eps) * scale
+        for j, value in enumerate(exact):
+            assert abs(values[i, j] - float(value)) <= bound, (
+                f"{variant.value} degree {degree}: cardinal {j} at {point} is "
+                f"{values[i, j]!r}, exact {float(value)!r}, bound {bound:.3e}"
+            )
 
 
 def test_scalar_and_nd_shape_preservation() -> None:

--- a/tests/test_quad_tanh_sinh.py
+++ b/tests/test_quad_tanh_sinh.py
@@ -11,7 +11,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.quad import get_tanh_sinh_1d
-from pantr.tolerance import get_conservative
+from pantr.tolerance import get_conservative, get_machine_epsilon
 
 # Golden node/weight values for ``get_tanh_sinh_1d``. Provenance: captured from
 # the pre-refactor implementation on ``main`` (commit 71ede9a, the original
@@ -209,23 +209,53 @@ class TestTanhSinhOddEven:
         assert not np.any(np.isclose(nodes, 0.5, atol=1e-14))
 
 
+def _resolvable(golden_nodes: npt.NDArray[np.float64]) -> npt.NDArray[np.bool_]:
+    """Select the golden nodes whose distance to an endpoint survives float64.
+
+    The reference rule moved a node onto the boundary once its endpoint gap
+    underflowed, and the affine map onto ``[0, 1]`` collapsed a few more onto
+    ``1.0`` on its own. Those are exactly the nodes the current rule declines to
+    emit, so this predicate turns the golden arrays into the expected answer.
+
+    Args:
+        golden_nodes (npt.NDArray[np.float64]): Golden nodes on ``[0, 1]``.
+
+    Returns:
+        npt.NDArray[np.bool_]: True where ``min(x, 1 - x)`` is at least half an
+        ``eps``, the smallest gap ``1 - x`` can carry and stay below ``1``.
+    """
+    gap = np.minimum(golden_nodes, 1.0 - golden_nodes)
+    return np.asarray(gap >= 0.5 * get_machine_epsilon(np.float64))
+
+
 class TestTanhSinhGoldenValues:
     """Golden-value regression guarding the lepard consumer contract.
 
     ``pantr.quad.get_tanh_sinh_1d`` is imported by the lepard project, which
     feeds the returned nodes/weights straight into its implicit-quadrature
     kernels. The values must therefore stay numerically identical across
-    refactors. These tests pin the node/weight arrays (and the effective node
-    count after endpoint snapping) for a representative range of ``n_pts``.
+    refactors. These tests pin the node/weight arrays and the effective node
+    count for a representative range of ``n_pts``.
+
+    One deliberate divergence from the reference rule is asserted rather than
+    excused. The reference snapped a node onto ``0`` or ``1`` once its endpoint
+    gap underflowed and kept it, with a nonzero weight and sometimes duplicated,
+    which made ``1/sqrt(x)`` -- the integrand the rule exists for -- come back as
+    ``inf`` from ``n_pts = 45`` on. The rule now stops there instead. Everything
+    the reference placed legitimately is still reproduced, and
+    :func:`_resolvable` says exactly which entries went: at the fourteen point
+    counts below, the current nodes and weights equal the golden arrays
+    restricted by that predicate, to 2.2e-16 and 1.1e-16 respectively.
     """
 
     @pytest.mark.parametrize("n_pts", _GOLDEN_N_PTS)
     def test_nodes_weights_match_golden(self, n_pts: int) -> None:
-        """Nodes and weights reproduce the captured golden arrays to tolerance."""
+        """Nodes and weights reproduce the resolvable part of the golden arrays."""
         golden = np.load(_GOLDEN_PATH)
         nodes, weights = get_tanh_sinh_1d(n_pts)
-        golden_nodes = golden[f"nodes_{n_pts}"]
-        golden_weights = golden[f"weights_{n_pts}"]
+        keep = _resolvable(golden[f"nodes_{n_pts}"])
+        golden_nodes = golden[f"nodes_{n_pts}"][keep]
+        golden_weights = golden[f"weights_{n_pts}"][keep]
         assert nodes.shape == golden_nodes.shape
         assert weights.shape == golden_weights.shape
         nptest.assert_allclose(nodes, golden_nodes, rtol=0.0, atol=5e-15)
@@ -233,7 +263,10 @@ class TestTanhSinhGoldenValues:
 
     @pytest.mark.parametrize("n_pts", _GOLDEN_N_PTS)
     def test_effective_node_count_matches_golden(self, n_pts: int) -> None:
-        """Endpoint snapping yields the same effective node count as the reference."""
+        """Truncation drops the reference's unresolvable nodes and nothing else."""
         golden = np.load(_GOLDEN_PATH)
         nodes, _ = get_tanh_sinh_1d(n_pts)
-        assert nodes.shape[0] == golden[f"nodes_{n_pts}"].shape[0]
+        golden_nodes = golden[f"nodes_{n_pts}"]
+        assert nodes.shape[0] == int(np.count_nonzero(_resolvable(golden_nodes)))
+        # 2, 3 and 4 entries go at n_pts 50, 100 and 200; none at any smaller count.
+        assert nodes.shape[0] == golden_nodes.shape[0] or n_pts in (50, 100, 200)

--- a/tests/test_quad_tanh_sinh.py
+++ b/tests/test_quad_tanh_sinh.py
@@ -246,6 +246,12 @@ class TestTanhSinhGoldenValues:
     :func:`_resolvable` says exactly which entries went: at the fourteen point
     counts below, the current nodes and weights equal the golden arrays
     restricted by that predicate, to 2.2e-16 and 1.1e-16 respectively.
+
+    All fourteen counts are unaffected by a separate limit that starts well
+    above them: from ``n_pts = 544`` in float64 two consecutive samples round
+    onto one representable coordinate, so the returned nodes stop being
+    pairwise distinct. That is the format running out of coordinates, not a node
+    reaching an endpoint, and it is out of this test's range.
     """
 
     @pytest.mark.parametrize("n_pts", _GOLDEN_N_PTS)
@@ -268,5 +274,5 @@ class TestTanhSinhGoldenValues:
         nodes, _ = get_tanh_sinh_1d(n_pts)
         golden_nodes = golden[f"nodes_{n_pts}"]
         assert nodes.shape[0] == int(np.count_nonzero(_resolvable(golden_nodes)))
-        # 2, 3 and 4 entries go at n_pts 50, 100 and 200; none at any smaller count.
+        # 2, 2 and 4 entries go at n_pts 50, 100 and 200; none at any smaller count.
         assert nodes.shape[0] == golden_nodes.shape[0] or n_pts in (50, 100, 200)

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -191,11 +191,13 @@ def test_degree_elevation_preserves_float32() -> None:
     # xfail is satisfied by *any* failure, so the marker hid the fact that this half was
     # never exercising the bug. The knot vector is the original one; only the count
     # changes, and the precondition below now pins it.
+    periodic_degree = 2
     periodic_knots = (np.arange(-2, 6, dtype=np.float64) / 3.0).astype(np.float32)
-    periodic_space = BsplineSpace1D(periodic_knots, 2, periodic=True)
-    assert periodic_space.num_basis == periodic_knots.size - 2 * 2 - 1, (
-        f"precondition: 8 knots at degree 2 give 8 - 2 * 2 - 1 = 3 periodic basis "
-        f"functions, got {periodic_space.num_basis}"
+    periodic_space = BsplineSpace1D(periodic_knots, periodic_degree, periodic=True)
+    assert periodic_space.num_basis == periodic_knots.size - 2 * periodic_degree - 1, (
+        f"precondition: {periodic_knots.size} knots at degree {periodic_degree} give "
+        f"{periodic_knots.size - 2 * periodic_degree - 1} periodic basis functions, got "
+        f"{periodic_space.num_basis}"
     )
     periodic = Bspline(
         BsplineSpace([periodic_space]),
@@ -217,10 +219,15 @@ def test_degree_elevation_preserves_float32() -> None:
     sample = np.linspace(0.0, 1.0, 17, dtype=np.float32).reshape(-1, 1)
     before = np.asarray(clamped.evaluate(sample), dtype=np.float64)
     after = np.asarray(reduced.evaluate(sample), dtype=np.float64)
-    # Elevating then reducing is exact in exact arithmetic, so the only error is float32
-    # rounding through the two kernels: `degree + 1` convex combinations each way, on
-    # values up to 4.
-    tolerance = 2.0 * (2 + 1) * get_machine_epsilon(np.float32) * float(np.abs(before).max())
+    # Elevating then reducing is exact in exact arithmetic -- the reduction operator
+    # interpolates the endpoints and is an exact left-inverse of elevation on the
+    # elevated subspace -- so the only error is float32 rounding through the two kernels:
+    # `degree + 1` convex combinations each way, on values up to 4. Checked rather than
+    # assumed: the same round trip in float64 leaves a residual of 0 to 3.6 eps relative
+    # over degrees 1 to 4 and 3, 4 and 6 breakpoints, which is rounding and not method
+    # error.
+    degree = int(clamped.degree[0])
+    tolerance = 2.0 * (degree + 1) * get_machine_epsilon(np.float32) * float(np.abs(before).max())
     assert float(np.max(np.abs(before - after))) <= tolerance
 
 

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,8 +7,9 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-One marker has already come off here: the domain-membership test, closed by the
-``np.isclose`` tolerance-leak fix in #289. Eight remain open.
+Two markers have already come off here: the domain-membership test, closed by the
+``np.isclose`` tolerance-leak fix in #289, and the tanh-sinh endpoint test, closed by
+truncating the rule where the endpoint gap stops being resolvable. Seven remain open.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -22,6 +23,7 @@ about this exact input and nothing else.
 
 from __future__ import annotations
 
+import math
 import signal
 from types import FrameType
 
@@ -50,6 +52,22 @@ def _scalar_spline(knots: np.ndarray, degree: int, values: list[float]) -> Bspli
 class _CallTimeout(RuntimeError):
     """Raised by :func:`_deadline` when the guarded call does not return in time."""
 
+
+_TANH_SINH_TAIL: float = 8.0 * math.sqrt(get_machine_epsilon(np.float64))
+"""Accuracy floor of a tanh-sinh rule on ``x**-0.5``, from its truncation gap.
+
+The rule is truncated where the distance from a node to the endpoint stops being
+representable, so it covers ``[delta, 1 - delta]`` and misses the tail
+``int_0^delta x**-0.5 dx = 2 * sqrt(delta)``. The truncation guarantees only
+``delta >= eps / 2``; the last node kept sits wherever the step ``h`` puts it, so
+``delta`` is a few times that and the floor is a few times ``sqrt(2 * eps) = 2.1e-8``.
+Measured over ``n_pts`` from 45 to 400, the error runs from 4.1e-9 to 4.8e-8, the
+largest corresponding to ``delta = 5.3 * eps / 2``.
+
+``8 * sqrt(eps) = 1.2e-7`` therefore leaves a factor 2.5 over the worst case measured,
+while still failing by six orders of magnitude on the bug this pins, which returned
+``inf``.
+"""
 
 _HANG_BUDGET_SECONDS = 2.0
 """Budget for a call that must terminate promptly.
@@ -376,23 +394,23 @@ def test_lagrange_tabulation_is_reproducible() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="get_tanh_sinh_1d snaps near-endpoint nodes onto 0 and 1 but keeps them, with "
-    "a nonzero weight and sometimes duplicated, so the rule evaluates at the endpoints",
-)
 def test_tanh_sinh_nodes_are_interior_and_distinct() -> None:
-    # A double-exponential rule exists to avoid evaluating at the endpoints:
-    # `get_tanh_sinh_1d`'s own docstring (`quad.py:370-372`) advertises it as "well suited
-    # for integrands with endpoint singularities". Nodes that underflow to the boundary
-    # are snapped there, which the docstring records only as making the returned count
-    # smaller (`:373-375`) -- but the snapped node is *kept*, with a nonzero weight
-    # (6.5e-17 at n_pts = 110), and from n_pts = 53 a second node snaps onto the same
-    # boundary and is returned twice.
+    # FIXED by truncating the rule where the endpoint gap stops being resolvable, instead
+    # of snapping the node onto the boundary and keeping it. Kept as a regression guard
+    # with its original triggering data, per this repository's convention that the fix PR
+    # un-xfails the tests it closes.
     #
-    # Consequence: for f(x) = 1/sqrt(x), the advertised use case, the rule returns `inf`
-    # rather than 2.0 at every n_pts >= 45. Weights still sum to 1 throughout, so the
-    # module's own doctest cannot see it.
+    # What it was: a double-exponential rule exists to avoid evaluating at the endpoints,
+    # and `get_tanh_sinh_1d`'s own docstring advertises it as "well suited for integrands
+    # with endpoint singularities". Nodes that underflowed to the boundary were snapped
+    # there, which the docstring recorded only as making the returned count smaller -- but
+    # the snapped node was *kept*, with a nonzero weight (6.5e-17 at n_pts = 110), and from
+    # n_pts = 53 a second node snapped onto the same boundary and was returned twice.
+    #
+    # Consequence: for f(x) = 1/sqrt(x), the advertised use case, the rule returned `inf`
+    # rather than 2.0 at every n_pts >= 45. Weights still summed to 1 throughout, so the
+    # module's own doctest could not see it. Raising the point count turned a correct
+    # answer into `inf`: n_pts = 33 gave 2.0, n_pts = 49 and 129 gave `inf`.
     for n_pts in (45, 53, 110, 129):
         nodes, weights = get_tanh_sinh_1d(n_pts)
         interior = np.count_nonzero((nodes <= 0.0) | (nodes >= 1.0))
@@ -402,6 +420,13 @@ def test_tanh_sinh_nodes_are_interior_and_distinct() -> None:
         )
         assert np.unique(nodes).size == nodes.size, (
             f"n_pts {n_pts}: {nodes.size - np.unique(nodes).size} duplicated nodes"
+        )
+        # The consequence, asserted directly: the advertised integrand is finite and
+        # correct. The floor is the neglected tail `2 * sqrt(delta)` with `delta ~ eps / 2`
+        # the truncation gap, which is 2.1e-8 and is what the rule can reach in float64.
+        singular = float(np.sum(weights / np.sqrt(nodes)))
+        assert abs(singular - 2.0) <= _TANH_SINH_TAIL, (
+            f"n_pts {n_pts}: integral of x**-0.5 is {singular}, not 2.0"
         )
 
 

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,9 +7,11 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Two markers have already come off here: the domain-membership test, closed by the
-``np.isclose`` tolerance-leak fix in #289, and the tanh-sinh endpoint test, closed by
-truncating the rule where the endpoint gap stops being resolvable. Seven remain open.
+Three markers have already come off here: the domain-membership test, closed by the
+``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
+truncating the rule where the endpoint gap stops being resolvable; and the Lagrange
+reproducibility test, closed by seeding the barycentric node permutation. Six remain
+open.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -334,30 +336,31 @@ def test_snapping_keeps_knots_the_format_can_resolve() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="tabulate_lagrange_1d builds a scipy BarycentricInterpolator without the rng "
-    "argument, so an unseeded global RNG permutes the nodes and the result changes "
-    "between calls",
-)
 def test_lagrange_tabulation_is_reproducible() -> None:
-    # `_basis_lagrange.py:104` constructs `BarycentricInterpolator(nodes_sorted, y_sorted)`
-    # with no `rng`. scipy then draws from the unseeded global `numpy.random` state and
-    # applies `rng.permutation(n)` to the nodes before computing the barycentric weights
-    # (`scipy/interpolate/_polyint.py:708-734`); its own documentation says "Specify `rng`
-    # for repeatable interpolation".
+    # FIXED by passing a fixed seed to the scipy interpolator
+    # (`_basis_lagrange._BARYCENTRIC_SEED`). Kept as a regression guard with its original
+    # triggering data, per this repository's convention that the fix PR un-xfails the
+    # tests it closes.
     #
-    # So the same call returns different values in different processes. This is not
-    # floating-point nondeterminism with a bound one could derive -- it is an unseeded
-    # RNG, and the spread grows with degree: about 1 ulp at degree 3-5, 4.18 absolute on a
+    # What it was: `_tabulate_lagrange_basis_1D_core` constructed
+    # `BarycentricInterpolator(nodes_sorted, y_sorted)` with no `rng`. scipy then drew
+    # from the unseeded global `numpy.random` state and applied `rng.permutation(n)` to
+    # the nodes before computing the barycentric weights; its own documentation says
+    # "Specify `rng` for repeatable interpolation".
+    #
+    # So the same call returned different values in different processes. This was not
+    # floating-point nondeterminism with a bound one could derive -- it was an unseeded
+    # RNG, and the spread grew with degree: about 1 ulp at degree 3-5, 4.18 absolute on a
     # value scale of 3.75e7 at degree 62 (relative 1.1e-7), and `inf` versus 1e16 across
     # separate processes at degree 62 evaluated outside [0, 1]. Everything downstream
-    # inherits it: `tabulate_lagrange`, `compute_lagrange_to_bernstein_1d`,
+    # inherited it: `tabulate_lagrange`, `compute_lagrange_to_bernstein_1d`,
     # `tabulate_Lagrange_extraction_operators`, and `SpanwiseElementExtraction` with the
     # Lagrange target.
     #
-    # Reseeding the global state is what makes the failure deterministic here; in
-    # production the seeds differ because nobody set one.
+    # Reseeding the global state is what made the failure deterministic here; in
+    # production the seeds differed because nobody set one. The assertions are kept as
+    # they were, including the derived bound at degree 62, but the result is now bitwise
+    # identical and the bound has ceased to be the binding constraint.
     pts = np.array([0.1, 0.5, 0.9])
 
     # The legacy global state is the point: it is what scipy draws from.

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,12 +7,13 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Four markers have already come off here: the domain-membership test, closed by the
+Five markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
 truncating the rule where the endpoint gap stops being resolvable; the Lagrange
-reproducibility test, closed by seeding the barycentric node permutation; and the float32
-degree-elevation test, closed by allocating the kernels' knot output in the input's dtype.
-Five remain open.
+reproducibility test, closed by seeding the barycentric node permutation; the float32
+degree-elevation test, closed by allocating the kernels' knot output in the input's dtype;
+and the periodic degree-reduction hang, closed by enforcing the periodic conversion's own
+boundary-multiplicity precondition. Four remain open.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -515,28 +516,46 @@ def test_knot_factories_agree_on_zero_intervals() -> None:
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="needs SIGALRM to bound the call")
-@pytest.mark.xfail(
-    strict=True,
-    reason="Bspline.reduce_degree(1) does not terminate on a degree-1 periodic spline",
-)
 def test_reduce_degree_terminates_on_a_periodic_linear_spline() -> None:
+    # FIXED by enforcing `_to_periodic_bspline_1d_impl`'s own documented precondition,
+    # `1 <= m_bdy <= degree`. Kept as a regression guard with its original triggering
+    # data, per this repository's convention that the fix PR un-xfails the tests it
+    # closes.
+    #
     # Found by the sweep the hard way: it stalled a 25952-case run indefinitely, which is
     # why the harness now bounds every case (`_core.CASE_TIMEOUT_SECONDS`).
     #
-    # The trigger is exact and narrow -- periodic **and** degree 1 **and** `reduce_degree`:
+    # The trigger was exact and narrow -- periodic **and** degree 1 **and**
+    # `reduce_degree`:
     #
-    #   degree 1, periodic,   2 / 3 / 4 / 8 intervals    -> never returns
-    #   degree 1, same knots, periodic=False             -> returns in 0.003 s
-    #   degree 1, periodic,   domain [0, 1e-6] or [0, 1] -> never returns (scale is not it)
+    #   degree 1, periodic,   2 / 3 / 4 / 8 intervals    -> never returned
+    #   degree 1, same knots, periodic=False             -> returned in 0.003 s
+    #   degree 1, periodic,   domain [0, 1e-6] or [0, 1] -> never returned (scale was not
+    #                                                       it)
     #   degree 0, periodic                               -> documented ValueError (the
     #                                                       decrement exceeds the degree)
     #   degree 2 and 3, periodic                         -> documented ValueError (residual
     #                                                       exceeds tolerance)
     #
-    # So it is not a slow path, and not a tolerance loop that eventually gives up: the
-    # degrees on either side terminate, and only the periodic form of degree 1 spins. A
-    # non-terminating public call is the worst outcome in this codebase's own triage, and
-    # for the C++ port an infinite loop in a numerical routine is unrecoverable.
+    # The mechanism: `_degree_reduce_bspline` passes `m_bdy_new = m_bdy - decrement` to
+    # `_to_periodic_bspline_1d_impl`, and a maximally smooth periodic space has
+    # `m_bdy = 1`, so the argument is 0 at **every** degree. That violates the documented
+    # `1 <= m_bdy <= degree`, which nothing checked. `_build_periodic_knot_vector` then
+    # builds its per-period tile with multiplicity 0 at the seam, and its right-ghost
+    # `while` loop has nothing to append: it increments `shift` forever.
+    #
+    # Degrees 2 and 3 escaped only by accident -- the C^0 seam check a few lines earlier
+    # rejected them first -- so the narrowness of the trigger was a coincidence of check
+    # ordering, not a property of degree 1. Degree 1 is the one case where nothing rejects
+    # it first, because reducing it leaves a single control point and the seam check
+    # compares that point with itself.
+    #
+    # A clean refusal is the right outcome here rather than a working reduction: the
+    # result would be degree 0, and the periodic representation this library uses needs
+    # `1 <= m_bdy <= degree`, a range that is empty at degree 0. With no ghost knots there
+    # is nothing to wrap, and the periodic form of a piecewise constant is its open form.
+    # `spline.to_open_bspline().reduce_degree(1)` does the reduction and returns in
+    # milliseconds.
     knots = np.asarray(create_uniform_periodic_knots(4, 1), dtype=np.float64)
     space = BsplineSpace1D(knots, 1, periodic=True)
     spline = Bspline(
@@ -551,15 +570,21 @@ def test_reduce_degree_terminates_on_a_periodic_linear_spline() -> None:
     previous = signal.signal(signal.SIGALRM, _expire)
     signal.setitimer(signal.ITIMER_REAL, _HANG_BUDGET_SECONDS)
     try:
-        spline.reduce_degree(1)
+        # Terminating is the point, so the timeout is what this test really guards; the
+        # message is asserted as well so that a *different* refusal cannot pass for the
+        # fix, which is what the bare `except ValueError` of the xfail version allowed.
+        with pytest.raises(ValueError, match=r"boundary multiplicity in \[1, degree\]"):
+            spline.reduce_degree(1)
     except _CallTimeout:
         pytest.fail(
             f"reduce_degree(1) on a degree-1 periodic spline did not return within "
             f"{_HANG_BUDGET_SECONDS} s; the clamped equivalent takes 0.003 s"
         )
-    except ValueError:
-        # A clean refusal would be a fix, not a failure: the point is that it terminates.
-        pass
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0.0)
         signal.signal(signal.SIGALRM, previous)
+
+    # The escape route the message names, on the same data.
+    reduced = spline.to_open_bspline().reduce_degree(1)
+    assert reduced.degree[0] == 0
+    assert not reduced.space.spaces[0].periodic

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,11 +7,12 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Three markers have already come off here: the domain-membership test, closed by the
+Four markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
-truncating the rule where the endpoint gap stops being resolvable; and the Lagrange
-reproducibility test, closed by seeding the barycentric node permutation. Six remain
-open.
+truncating the rule where the endpoint gap stops being resolvable; the Lagrange
+reproducibility test, closed by seeding the barycentric node permutation; and the float32
+degree-elevation test, closed by allocating the kernels' knot output in the input's dtype.
+Five remain open.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -142,27 +143,31 @@ def test_degree_elevation_outputs_are_mutually_consistent() -> None:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_degree_elevate_1d_core allocates its knot output as float64 regardless of "
-    "the input dtype, so degree elevation is unusable in float32",
-)
 def test_degree_elevation_preserves_float32() -> None:
-    # `_bspline_degree_core.py:136-137` allocates the two outputs with different dtypes:
-    # `ik = np.zeros(max_new_knots, dtype=np.float64)` is hardcoded, while
-    # `ic = np.zeros(..., dtype=ctrl.dtype)` follows the input. The knot vector therefore
-    # comes back float64 while the control points stay float32, and the two faces of that
-    # are:
-    #   * clamped -- `Bspline.__init__` rejects the pair, so `elevate_degree` raises for
+    # FIXED by allocating the kernel's knot output in the knot vector's own dtype, in both
+    # `_degree_elevate_1d_core` and `_degree_reduce_1d_core`. Kept as a regression guard
+    # with its original triggering data, per this repository's convention that the fix PR
+    # un-xfails the tests it closes.
+    #
+    # What it was: the elevation kernel allocated its two outputs with different dtypes,
+    # `ik = np.zeros(max_new_knots, dtype=np.float64)` hardcoded while
+    # `ic = np.zeros(..., dtype=ctrl.dtype)` followed the input. The knot vector therefore
+    # came back float64 while the control points stayed float32, and the two faces of that
+    # were:
+    #   * clamped -- `Bspline.__init__` rejected the pair, so `elevate_degree` raised for
     #     **every** float32 spline, at every degree and every knot count. Measured on
-    #     degrees 1-3 with 3, 4 and 6 breakpoints: nine for nine.
-    #   * periodic -- the round trip through open form converts the control points too, so
-    #     both come back float64 and the call *succeeds*, silently discarding the
+    #     degrees 1-3 with 3, 4 and 6 breakpoints: nine for nine. The message blamed the
+    #     caller's control points for the kernel's own hardcoded dtype.
+    #   * periodic -- the round trip through open form converted the control points too, so
+    #     both came back float64 and the call *succeeded*, silently discarding the
     #     caller's choice of precision.
     #
-    # The second face is what makes this worth a test rather than a bug report: a silent
+    # The second face is what made this worth a test rather than a bug report: a silent
     # dtype promotion is invisible until something downstream compares dtypes, and it
     # doubles memory and halves throughput without a word.
+    #
+    # `_degree_reduce_1d_core` carried the identical hardcoded allocation and raised the
+    # identical error, so the third assertion below covers the round trip.
     knots = np.array([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], dtype=np.float32)
     clamped = _scalar_spline(knots, 2, [1.0, 2.0, 3.0, 4.0])
     assert np.dtype(clamped.dtype) == np.float32, "precondition: the spline is float32"
@@ -178,16 +183,44 @@ def test_degree_elevation_preserves_float32() -> None:
 
     # Face two: on a periodic space it succeeds and silently promotes. Kept in the same
     # test because it is the same allocation, and separating them would imply two fixes.
+    #
+    # The control-point count is corrected here: as written when the marker went on, this
+    # half built five control points on a space that has three basis functions, so it
+    # raised from the `Bspline` constructor before reaching any dtype at all. A strict
+    # xfail is satisfied by *any* failure, so the marker hid the fact that this half was
+    # never exercising the bug. The knot vector is the original one; only the count
+    # changes, and the precondition below now pins it.
     periodic_knots = (np.arange(-2, 6, dtype=np.float64) / 3.0).astype(np.float32)
+    periodic_space = BsplineSpace1D(periodic_knots, 2, periodic=True)
+    assert periodic_space.num_basis == periodic_knots.size - 2 * 2 - 1, (
+        f"precondition: 8 knots at degree 2 give 8 - 2 * 2 - 1 = 3 periodic basis "
+        f"functions, got {periodic_space.num_basis}"
+    )
     periodic = Bspline(
-        BsplineSpace([BsplineSpace1D(periodic_knots, 2, periodic=True)]),
-        np.arange(5, dtype=np.float32).reshape(5, 1),
+        BsplineSpace([periodic_space]),
+        np.arange(periodic_space.num_basis, dtype=np.float32).reshape(-1, 1),
     )
     promoted = periodic.elevate_degree(1)
     assert np.dtype(promoted.dtype) == np.float32, (
         f"degree elevation silently promoted a periodic float32 spline to "
         f"{np.dtype(promoted.dtype).name}"
     )
+
+    # The sibling kernel had the same hardcoded allocation, so the round trip back down
+    # is what shows both are fixed. Elevation followed by reduction returns the original
+    # spline, so the values are asserted too and not only the dtype.
+    reduced = elevated.reduce_degree(1)
+    assert np.dtype(reduced.dtype) == np.float32, (
+        f"degree reduction changed the dtype from float32 to {np.dtype(reduced.dtype).name}"
+    )
+    sample = np.linspace(0.0, 1.0, 17, dtype=np.float32).reshape(-1, 1)
+    before = np.asarray(clamped.evaluate(sample), dtype=np.float64)
+    after = np.asarray(reduced.evaluate(sample), dtype=np.float64)
+    # Elevating then reducing is exact in exact arithmetic, so the only error is float32
+    # rounding through the two kernels: `degree + 1` convex combinations each way, on
+    # values up to 4.
+    tolerance = 2.0 * (2 + 1) * get_machine_epsilon(np.float32) * float(np.abs(before).max())
+    assert float(np.max(np.abs(before - after))) <= tolerance
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Five confirmed defects, each reproduced independently twice before being touched. Four
had their bug pinned as an `xfail(strict=True)` by #290; those tests are now ordinary
passing regression tests, keeping their triggering data. The xfail count drops from 8 to
exactly 4.

## `find_roots` reported a root where the spline jumps, and lost a real one

`_bspline_roots_core.py` treated a disconnection as `f(x) = 0` exactly, citing Mørken &
Reimers' Lemma 3. Read at the source, that lemma places `x` in a **half-open interval
that is empty precisely when the interior multiplicity reaches `degree + 1`** — the C⁻¹
case, and only that case. With coincident Greville abscissae the secant is vertical, its
zero lands at the same point for every `λ`, and the conclusion no longer follows.

On the documented `subdivide(n, regularity=-1)` path this reported `0.5` — where the
spline jumps from `0.3` to `-0.4` — while never reporting the genuine root at
`0.61721778`. One fabricated and one lost, from one cause.

The hypothesis is **structural**, so it is now tested structurally: `knots[index] <
knots[index + degree]` is exactly "the Greville interval is non-empty", needs no
tolerance, and leaves every other spline on the path it already took. A residual test
applies only in the excluded case. Over 96 C⁻¹ configurations at degrees 1-4, checked
against a scan-and-bisect oracle: **54 disagreed before, 0 after**.

## tanh-sinh returned `inf` once you asked for enough points

The rule's defining property is that no node reaches an endpoint, which is what makes an
endpoint singularity integrable. On underflow the code snapped the node *onto* the
endpoint and kept its weight, so from 49 points `∫₀¹ x^(-1/2)` returned `inf` where 33
points gave `2.000000`. Smooth integrands were unaffected, which is why nothing caught
it. Nodes are now truncated instead: the dropped weight is below the round-off of the sum
it would have joined, and the existing renormalisation keeps constants exact. The
threshold is one epsilon of the **requested** dtype, since the float32 cast collapsed a
node onto `1.0` from 19 points.

Also corrected `QuadratureRule`'s claim to integrate the constant `1` *exactly* — it is
2, 3 and 4 ulp out in 1D, 2D and 3D, because rescaling cannot make a float sum exact.

## Lagrange tabulation was not reproducible between processes

`BarycentricInterpolator` was built without `rng`, so an unseeded global RNG permuted the
nodes and the same call returned different values in different processes. Not
floating-point noise with a derivable bound — an unseeded RNG, so no bound exists — and
everything downstream inherited it. The seed is now fixed and recorded, with what it does
and does not pin.

This is why the minimum SciPy moves to 1.15: `rng` arrived there, and 1.11 accepts
neither a seed nor precomputed weights, so the previous floor was already untrue for this
function rather than merely untested.

The existing Lagrange tests could not have caught any of this: an identity snap
overwrites whatever the interpolator computed at node points, and an interpolator built
with one node too few leaves both of them green. A test at **non-node** points against an
exact `Fraction` oracle now pins the interpolator itself.

## Degree operations were unusable in float32

One output buffer was allocated `float64` regardless of input while its sibling followed
the dtype, so every clamped float32 spline raised — with a message blaming the caller's
control points — and every periodic one silently promoted the caller's precision.
`_degree_reduce_1d_core` had the identical line, so both are fixed together and the test
covers the elevate-then-reduce round trip.

## `reduce_degree` hung forever on a periodic linear spline

Root cause: the caller passes `m_bdy - decrement`, and a maximally smooth periodic space
has `m_bdy = 1`, so the argument is **0 at every degree**, violating a documented
precondition nothing checked. The ghost-knot loop then advances on a tile of total
multiplicity zero and never terminates. Degrees 2 and 3 escaped only because a
continuity check a few lines earlier rejected them first — the narrow trigger was check
ordering, not degree.

It now raises, and that is argued rather than assumed: the result would be degree 0, where
the valid multiplicity range is empty and there are no ghost knots to build.
`to_open_bspline().reduce_degree(1)` is the working route and the test exercises it.

## Verification

`ruff`, `ruff format`, `mypy`, `import-lint` and the docs build under `-W` all clean.
**5155 passed, 21 skipped, 4 xfailed**, against a baseline of 5120 / 21 / 8. The whole
suite also runs clean under `NUMBA_BOUNDSCHECK=1` with a fresh Numba cache. The
adversarial sweep introduces **zero** new findings and loses two, both being the Lagrange
reproducibility cases this PR closes.

Downstream consumer: only the quadrature change has one. Its highest point count sits
inside the affected regime, where the rule previously returned a node exactly at an
endpoint; the new behaviour returns 54 interior nodes instead of 58 with two on the
boundary, costs one ulp on a smooth integrand, and turns `inf` into the right answer on a
singular one. Worth re-running that project's high-curvature quadrature test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
