### PR TITLE
fix(bspline): give products and degree changes the multiplicity the smoothness rule requires

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -237,6 +237,14 @@
   is a single knot, so the last segment and the closing knots were never written
   and the elevated spline came back on a domain collapsed to a point, without an
   error.
+- `Bspline.derivative(direction, keep_degree=True)` raised
+  `ValueError: The number of control points must be a multiple of the number of
+  basis functions` for every spline with a C⁰ interior knot, which is the
+  ordinary Bézier-element mesh rather than an exotic input. It differentiates to
+  `degree - 1` and elevates back, so a knot of multiplicity `degree` becomes one
+  of multiplicity `(degree - 1) + 1` in the space handed to the elevation kernel:
+  the discontinuous case fixed above. It now returns the derivative, which is
+  itself discontinuous there, carrying multiplicity `degree + 1`.
 - `Bspline.reduce_degree` fitted a discontinuous knot into a C^0 space. Reduction
   preserves smoothness, so multiplicity `m` becomes `m - t`; the target was
   clamped at `new_degree`, one short of the `new_degree + 1` a jump needs, and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -208,6 +208,52 @@
   down beside it. Reducing a periodic spline to degree 0 has no answer in this
   representation, an empty `[1, degree]` meaning no ghost knots and nothing to
   wrap; `to_open_bspline().reduce_degree(1)` does it in the open form.
+- `Bspline.multiply` built the product space from `max(m_f + q, m_g + p)` at a
+  breakpoint both operands share and from a hardcoded `p + q` at one only a
+  single operand carries. The second form assumes the present operand has
+  multiplicity `p`, a hypothesis the module never stated, and it is wrong in both
+  directions. Against a discontinuous operand (multiplicity `degree + 1`, which
+  `subdivide(n, regularity=-1)` produces) the knot vector came out one knot
+  short, the intermediate Bézier space did not contain the product, and the
+  underdetermined Oslo system returned a least-squares vector unrelated to it:
+  multiplying such a spline by the constant 1 gave a different function.
+  Exhaustive over `p, q <= 3` with multiplicities up to `degree + 1`, 45 of 81
+  configurations were wrong, every one of them with a discontinuous operand.
+  Below multiplicity `p` the same line asked for up to `p - m_f` knots more than
+  the product needs, so the ordinary continuous case now yields a smaller space
+  as well: degree 4 times degree 1 across a C^3 knot builds 8 control points
+  where it built 11. The rule that replaces both, minimal by Curry-Schoenberg, is
+  `(p + q) - min(s_f, s_g)` with `s = degree - m` the smoothness of an operand
+  there and `s = +inf` where it has no knot at all. It now lives in one function
+  that the 1D and tensor-product paths both call.
+- `Bspline.elevate_degree` returned control points and a knot vector that
+  disagreed on how many basis functions the elevated space has, by one per
+  interior knot of multiplicity `degree + 1`. Piegl-Tiller A5.9 starts each
+  segment at its second elevated coefficient because the segment before it
+  already wrote the shared junction value; where the spline is discontinuous the
+  two segments share nothing and that coefficient was dropped. At degree 0 a
+  second cause compounded it: the segment sweep relied on the closing block of
+  `degree + 1` equal knots to reach the end of the knot vector, which at degree 0
+  is a single knot, so the last segment and the closing knots were never written
+  and the elevated spline came back on a domain collapsed to a point, without an
+  error.
+- `Bspline.reduce_degree` fitted a discontinuous knot into a C^0 space. Reduction
+  preserves smoothness, so multiplicity `m` becomes `m - t`; the target was
+  clamped at `new_degree`, one short of the `new_degree + 1` a jump needs, and
+  the kernel underneath merged the two sides of every junction into one control
+  point on the strength of an endpoint-interpolation argument that holds only
+  where the original spline is continuous. On input built to be exactly
+  reducible, the reduced curve now reproduces it to 4.4e-16 or better at degrees
+  2 to 4, where the errors were 5.7e-01, 1.0e+00 and 4.9e-01.
+- `Bspline.reduce_degree` on a maximally smooth periodic spline asked the
+  periodic conversion for a seam multiplicity of `m_bdy - decrement`, which is 0,
+  while interior breakpoints three lines away were already floored at 1. It now
+  uses the same floor, which asks for less smoothness than the seam already has
+  and is therefore always representable, and a maximally smooth periodic
+  quadratic reduces to degree 1. From degree 3 the call still fails, because the
+  segment-wise reduction does not preserve C^1 across the seam, but on the
+  residual test that says so rather than on the knot vector. The degree-0
+  rejection above is unaffected and now fires only where its reasoning applies.
 
 ## 0.6.0 (2026-06-24)
 

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -128,11 +128,17 @@ def _coarsen_knots_after_reduction(  # noqa: PLR0913
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
     """Remove excess knots from a Bézier-form B-spline after degree reduction.
 
-    After degree reduction the output is in Bézier form (all interior
-    breakpoints have multiplicity ``new_degree``).  This function removes
-    excess copies of each interior knot so that the final multiplicity is
-    ``max(1, m_i - t)`` where ``m_i`` is the original multiplicity and ``t``
-    is the degree decrement, restoring the original continuity structure.
+    After degree reduction the output is in Bézier form: every interior
+    breakpoint has multiplicity ``new_degree``, or ``new_degree + 1`` where the
+    original spline was discontinuous.  This function removes excess copies of
+    each interior knot so that the final multiplicity is ``max(1, m_i - t)``,
+    with ``m_i`` the original multiplicity and ``t`` the degree decrement, which
+    restores the original continuity ``C^{p - m_i} = C^{(p - t) - (m_i - t)}``.
+
+    A discontinuous breakpoint (``m_i = p + 1``) therefore keeps multiplicity
+    ``new_degree + 1`` and nothing is removed there.  Clamping the target at
+    ``new_degree`` instead would ask for a C0 space where the function jumps, and
+    the reduction would silently stop being exact on curves that reduce exactly.
 
     Args:
         knots: Knot vector of the Bézier-form reduced B-spline.
@@ -147,12 +153,15 @@ def _coarsen_knots_after_reduction(  # noqa: PLR0913
     Returns:
         tuple: ``(coarsened_knots, coarsened_ctrl)``.
     """
+    orig_degree = new_degree + degree_decrement
     for idx in range(len(orig_unique_knots)):
         knot_val = float(orig_unique_knots[idx])
         m_orig = int(orig_mults[idx])
         target_mult = max(1, m_orig - degree_decrement)
-        # Current multiplicity in the Bézier form is new_degree.
-        num_to_remove = new_degree - target_mult
+        # Multiplicity in the Bézier form: new_degree, or new_degree + 1 at a knot
+        # the original spline was discontinuous at.
+        bezier_mult = new_degree + 1 if m_orig > orig_degree else new_degree
+        num_to_remove = bezier_mult - target_mult
         if num_to_remove <= 0:
             continue
         # Use a large tolerance for deviation since reduction is approximate.

--- a/src/pantr/bspline/_bspline_degree.py
+++ b/src/pantr/bspline/_bspline_degree.py
@@ -248,7 +248,14 @@ def _degree_reduce_bspline(bspline: Bspline, degree_decrements: tuple[int, ...])
                         tol,
                     )
 
-                m_bdy_new = m_bdy - dec
+                # Same floor as the interior breakpoints in
+                # ``_coarsen_knots_after_reduction``: a breakpoint that has to be
+                # present cannot drop below multiplicity 1, and the smoothness the
+                # subtraction asks for there (C^{new_degree} or better) is already
+                # implied by multiplicity 1.  Without it the seam of a maximally
+                # smooth periodic spline (``m_bdy = 1``) asks for multiplicity 0 and
+                # the reduction fails on a knot vector it never had to build.
+                m_bdy_new = max(1, m_bdy - dec)
                 per_knots, new_pts_2d = _to_periodic_bspline_1d_impl(
                     new_knots, new_degree, new_pts_2d, m_bdy_new, tol
                 )

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -125,9 +125,11 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
     Elevation preserves smoothness: a breakpoint where the spline is
     :math:`C^{s}` stays :math:`C^{s}`, so its multiplicity goes from ``m`` to
     ``m + t``, which is what the knot-writing step emits.  That includes
-    ``m = degree + 1``, a :math:`C^{-1}` breakpoint, where the two adjacent
-    Bézier segments share no control point and the segment after it therefore
-    contributes all ``degree + t + 1`` of its coefficients.
+    ``m = degree + 1``, a :math:`C^{-1}` breakpoint: the two adjacent Bézier
+    segments share no control point there, so the segment after it starts
+    contributing at its own coefficient 0 rather than at 1.  How many of its
+    coefficients that pass writes still depends on the breakpoint that *closes*
+    the segment, through ``rbz``, exactly as in the published algorithm.
 
     Args:
         degree (int): Original degree.

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -122,6 +122,13 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
     Implements a robust version of Piegl & Tiller Algorithm A5.9
     (Degree elevate a B-spline curve).
 
+    Elevation preserves smoothness: a breakpoint where the spline is
+    :math:`C^{s}` stays :math:`C^{s}`, so its multiplicity goes from ``m`` to
+    ``m + t``, which is what the knot-writing step emits.  That includes
+    ``m = degree + 1``, a :math:`C^{-1}` breakpoint, where the two adjacent
+    Bézier segments share no control point and the segment after it therefore
+    contributes all ``degree + t + 1`` of its coefficients.
+
     Args:
         degree (int): Original degree.
         ctrl (np.ndarray): Control points of shape (n_pts, rank).
@@ -191,7 +198,15 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
         for ii in range(rank):
             bpts[i, ii] = ctrl[i, ii]
 
-    while b < m:
+    # ``b <= m`` rather than A5.9's ``b < m``: the loop body runs once per segment,
+    # indexed by the last knot of the run that closes it, so the final segment needs
+    # ``b == m``.  For ``d >= 1`` the closing block holds ``d + 1`` equal knots and the
+    # inner run scan reaches ``m`` on its own, which is why A5.9 gets away with the
+    # strict bound; at ``d == 0`` that block is a single knot, the scan cannot advance,
+    # and the strict bound drops the last segment together with the closing knots,
+    # leaving a knot vector whose tail is still zero and a domain collapsed to a point.
+    # The ``break`` below is what the strict bound used to provide.
+    while b <= m:
         i = b
         while b < m and knots[b] == knots[b + 1]:
             b += 1
@@ -201,7 +216,20 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
         oldr = r
         r = d - mul
 
-        lbz = (oldr + 2) // 2 if oldr > 0 else 1
+        # First elevated Bezier coefficient this segment contributes.  A5.9 assumes
+        # interior knots of multiplicity at most d, where consecutive segments meet
+        # C^0 and the junction coefficient has already been written, so it starts at
+        # 1.  A knot of multiplicity d + 1 leaves oldr = -1: the spline is C^-1
+        # there, the segments share nothing, and skipping index 0 would drop a
+        # control point (the returned array would then be one shorter than the knot
+        # vector calls for).  The first pass through the loop also has oldr = -1 but
+        # a == d, and its index 0 really was written, before the loop.
+        if oldr > 0:
+            lbz = (oldr + 2) // 2
+        elif oldr < 0 and a != d:
+            lbz = 0
+        else:
+            lbz = 1
 
         rbz = ph - (r + 1) // 2 if r > 0 else ph
 
@@ -294,6 +322,7 @@ def _degree_elevate_1d_core(  # noqa: PLR0912, PLR0915
         else:
             for i in range(ph + 1):
                 ik[kind + i] = ub
+            break
 
     return ic[:cind].copy(), ik[: kind + ph + 1].copy()
 

--- a/src/pantr/bspline/_bspline_degree_core.py
+++ b/src/pantr/bspline/_bspline_degree_core.py
@@ -383,7 +383,7 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
     Decomposes the B-spline into Bézier segments by iterating through knot
     spans (same alpha-blending as the elevation kernel), applies the reduction
     operator to each segment, and stitches the results into a B-spline in Bézier
-    form (C0 at every interior breakpoint).
+    form.
 
     Because the operator interpolates the segment endpoints, the last control
     point of one reduced segment and the first of the next are both the shared
@@ -391,6 +391,13 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
     therefore written once and the stitch is exactly C0; no averaging of the two
     sides is involved, and neither segment is perturbed away from its own
     optimum.
+
+    That argument needs a breakpoint the original spline is continuous at.  Where
+    it is not — an interior knot of multiplicity ``degree + 1`` — the two segments
+    have different endpoint values, both are kept, and the breakpoint carries
+    multiplicity ``new_degree + 1`` so that the reduced spline jumps where the
+    original does.  Reduction preserves smoothness, exactly as elevation does:
+    ``C^{degree - m} = C^{new_degree - (m - t)}``.
 
     Args:
         degree (int): Original degree.
@@ -402,8 +409,8 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
 
     Returns:
         tuple[npt.NDArray[Any], npt.NDArray[Any]]: ``(reduced_ctrl, reduced_knots)``
-        in Bézier form — all interior breakpoints have multiplicity ``new_degree``
-        (C0 continuity).
+        in Bézier form — every interior breakpoint has multiplicity ``new_degree``,
+        or ``new_degree + 1`` where the input was discontinuous.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -425,21 +432,28 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
 
     # Size the output arrays from the number of Bézier segments the sweep below
     # will produce, counted with that sweep's own advance rule.  The reduced
-    # spline is in Bézier form, so it has exactly ``n_seg * new_deg + 1`` control
-    # points and ``n_seg * new_deg + new_deg + 2`` knots.  (A bound expressed in
-    # terms of ``len(knots)`` alone is not an upper bound: it fails from 8
-    # elements on at degree 5, and the kernel then writes past the end.)
+    # spline is in Bézier form, so it has ``n_seg * new_deg + 1`` control points
+    # and ``n_seg * new_deg + new_deg + 2`` knots, plus one of each per interior
+    # breakpoint of multiplicity ``d + 1``: there the reduced spline is
+    # discontinuous, the junction is not shared, and the breakpoint carries
+    # ``new_deg + 1`` knots.  (A bound expressed in terms of ``len(knots)`` alone
+    # is not an upper bound: it fails from 8 elements on at degree 5, and the
+    # kernel then writes past the end.)
     n_seg = 0
+    n_jump = 0
     scan = d + 1
     while scan < m:
+        run_start = scan
         while scan < m and knots[scan] == knots[scan + 1]:
             scan += 1
+        if scan < m and scan - run_start + 1 > d:
+            n_jump += 1
         n_seg += 1
         scan += 1
 
     # Both outputs follow their own input's dtype, as in the elevation kernel.
-    oc = np.empty((n_seg * new_deg + 1, rank), dtype=ctrl.dtype)
-    ok = np.empty(n_seg * new_deg + new_deg + 2, dtype=knots.dtype)
+    oc = np.empty((n_seg * new_deg + 1 + n_jump, rank), dtype=ctrl.dtype)
+    ok = np.empty(n_seg * new_deg + new_deg + 2 + n_jump, dtype=knots.dtype)
 
     # Initialise: first boundary knots and first Bézier segment.
     ua = knots[0]
@@ -463,7 +477,7 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
             b += 1
         mul = b - i + 1
         ub = knots[b]
-        oldr = r  # noqa: F841
+        oldr = r
         r = d - mul
 
         # Extract Bézier control points for the current span.
@@ -486,18 +500,22 @@ def _degree_reduce_1d_core(  # noqa: PLR0912, PLR0915
         # --- Reduce the current Bézier segment ---
         _apply_reduction_operator(reduction_operator, bpts, rbpts)
 
-        # The first segment contributes all of its control points; every later
-        # one skips its first, which the previous segment already wrote with the
-        # identical value.
-        start = 0 if cind == 0 else 1
+        # The first segment contributes all of its control points; every later one
+        # skips its first, which the previous segment already wrote with the
+        # identical value.  ``oldr < 0`` says the previous breakpoint had
+        # multiplicity ``d + 1``, so there is no shared value to skip: the two
+        # sides of a jump are different numbers and both belong in the output.
+        start = 0 if (cind == 0 or oldr < 0) else 1
         for j in range(start, new_deg + 1):
             for ii in range(rank):
                 oc[cind, ii] = rbpts[j, ii]
             cind += 1
 
-        # Write interior breakpoint knots (multiplicity = new_deg for C0).
+        # Write the previous interior breakpoint: multiplicity new_deg for a C0
+        # junction, new_deg + 1 where the spline jumps.
         if a != d:
-            for _i in range(new_deg):
+            n_write = new_deg + 1 if oldr < 0 else new_deg
+            for _i in range(n_write):
                 ok[kind] = ua
                 kind += 1
 

--- a/src/pantr/bspline/_bspline_product.py
+++ b/src/pantr/bspline/_bspline_product.py
@@ -668,8 +668,9 @@ def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
     space_full = BsplineSpace([BsplineSpace1D(T_full, r)])
     h_full = Bspline(space_full, ctrl_h_bezier, is_rational=False)
 
-    # Nothing to remove when the product is already no smoother than C^0 everywhere.
-    if all_bp.size == 0 or np.array_equal(product_mults, bezier_mults_h):
+    # Nothing to remove when the product is already no smoother than C^0 everywhere
+    # (which includes the single-element case, where both arrays are empty).
+    if np.array_equal(product_mults, bezier_mults_h):
         return h_full
 
     T_opt = _build_product_knot_vector(domain, all_bp, product_mults, r, dtype)

--- a/src/pantr/bspline/_bspline_product.py
+++ b/src/pantr/bspline/_bspline_product.py
@@ -1,11 +1,39 @@
-"""B-spline pointwise product for 1D splines.
+r"""B-spline pointwise product for 1D splines.
 
 This module provides :func:`_multiply_bspline_1d`, which computes the exact
 pointwise product of two 1D B-splines via Bézier extraction and the Bernstein
-product formula.  The result lives in the product space of degree ``p + q``
-with **optimal continuity**: each interior knot's multiplicity equals
-``max(m1 + q, m2 + p)`` where ``m1``, ``m2`` are the individual multiplicities
-and ``p``, ``q`` are the respective degrees.
+product formula.  The result lives in the product space of degree ``r = p + q``
+with the **minimal** multiplicity at every breakpoint, computed once by
+:func:`_product_multiplicities`.
+
+**Smoothness of a product.**  Write ``s_f(ξ) = p - m_f(ξ)`` for the smoothness of
+``f`` at a breakpoint ``ξ`` (so ``f`` is :math:`C^{s_f}` there), with
+``s_f(ξ) = +∞`` when ``ξ`` is not a knot of ``f`` at all, and likewise for ``g``.
+Then ``h = f g`` is :math:`C^{\min(s_f, s_g)}` at ``ξ``, so
+
+.. math::
+
+    m_h(\xi) = r - \min(s_f(\xi), s_g(\xi))
+             = \max \{\, m_f(\xi) + q \;:\; \xi \in T_f \,\}
+                \cup \{\, m_g(\xi) + p \;:\; \xi \in T_g \,\},
+
+the maximum being taken over the operands that actually have a knot at ``ξ``.  A
+breakpoint carried by one operand alone therefore gets ``m_f(ξ) + q``, *not*
+``p + q``: the two agree only when ``m_f(ξ) = p``, and the product space is
+strictly larger than it needs to be whenever ``m_f(ξ) < p``.
+
+The identity follows from the Curry-Schoenberg theorem (Curry & Schoenberg,
+*J. Analyse Math.* **17**, 1966, 71-107), which identifies the spline space on a
+knot vector with the space of piecewise polynomials of matching smoothness; see
+Lyche & Mørken, *Spline Methods*, Thm 3.25, or Lyche, Manni & Speleers, CIME
+2017, Thm 13.  Because that identification is an equality of spaces rather than
+an inclusion, the multiplicity above is not merely sufficient but minimal: for
+generic coefficients ``h`` is not smoother than :math:`C^{\min(s_f, s_g)}`.  The
+hypotheses are mild — the end knots need not be clamped, and ``m = p + 1``
+(a :math:`C^{-1}`, discontinuous, spline, which
+:meth:`~pantr.bspline.BsplineSpace1D.subdivide` admits through
+``regularity=-1``) is inside the range, not at its edge.  ``m_h`` is capped at
+``r + 1`` because ``m_f ≤ p + 1`` and ``m_g ≤ q + 1``.
 
 Works for both non-rational and rational (NURBS) splines.
 """
@@ -13,7 +41,7 @@ Works for both non-rational and rational (NURBS) splines.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -95,91 +123,177 @@ def _lookup_mults_in_space(
     return result
 
 
-def _merge_interior_breakpoints(  # noqa: PLR0913
+def _merge_interior_breakpoints(
     bp_f: npt.NDArray[np.float32 | np.float64],
-    mf: npt.NDArray[np.int_],
     bp_g: npt.NDArray[np.float32 | np.float64],
-    mg: npt.NDArray[np.int_],
-    p: int,
-    q: int,
     tol: float,
-) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
-    """Merge two sorted interior breakpoint arrays with optimal product multiplicities.
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Merge two sorted interior breakpoint arrays into their union.
 
-    Uses a two-pointer scan to compute the union of interior breakpoints from
-    both spaces and assigns each breakpoint the correct multiplicity in the
-    product space of degree ``p + q``.
-
-    The product multiplicity at a shared breakpoint follows the formula::
-
-        m_h(ξ) = max(m_f(ξ) + q, m_g(ξ) + p)
-
-    This ensures the product spline has continuity ``C^{min(p-m_f, q-m_g)}`` at
-    ``ξ``, which is the correct smoothness of the pointwise product of two splines.
-    A breakpoint absent from one operand contributes ``m=0`` for that operand.
+    Uses a two-pointer scan.  Two breakpoints closer than ``tol`` are treated as
+    one and replaced by their midpoint.
 
     Args:
         bp_f (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
-            of the first space (degree ``p``).
-        mf (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp_f``.
+            of the first space.
         bp_g (npt.NDArray[np.float32 | np.float64]): Sorted interior breakpoints
-            of the second space (degree ``q``).
-        mg (npt.NDArray[np.int_]): Multiplicities corresponding to ``bp_g``.
-        p (int): Degree of the first operand.
-        q (int): Degree of the second operand.
+            of the second space.
         tol (float): Tolerance for coincidence tests.
 
     Returns:
-        tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Merged
-        ``(all_bp, product_mults)`` arrays in ascending order.
+        npt.NDArray[np.float32 | np.float64]: The merged breakpoints in ascending
+        order.
     """
     n1, n2 = len(bp_f), len(bp_g)
     i, j = 0, 0
     all_bp_list: list[float] = []
-    mults_list: list[int] = []
 
     while i < n1 and j < n2:
         if abs(float(bp_f[i]) - float(bp_g[j])) <= tol:
             all_bp_list.append(float(bp_f[i] + bp_g[j]) / 2.0)
-            mults_list.append(max(int(mf[i]) + q, int(mg[j]) + p))
             i += 1
             j += 1
         elif float(bp_f[i]) < float(bp_g[j]):
             all_bp_list.append(float(bp_f[i]))
-            mults_list.append(p + q)  # m_g=0 → max(mf+q, p+q)=p+q
             i += 1
         else:
             all_bp_list.append(float(bp_g[j]))
-            mults_list.append(p + q)  # m_f=0 → max(p+q, mg+p)=p+q
             j += 1
 
-    if i < n1:
-        all_bp_list.extend(float(x) for x in bp_f[i:])
-        mults_list.extend([p + q] * (n1 - i))
-    if j < n2:
-        all_bp_list.extend(float(x) for x in bp_g[j:])
-        mults_list.extend([p + q] * (n2 - j))
+    all_bp_list.extend(float(x) for x in bp_f[i:])
+    all_bp_list.extend(float(x) for x in bp_g[j:])
 
     dtype = bp_f.dtype if bp_f.size > 0 else bp_g.dtype
-    if len(all_bp_list) == 0:
-        return np.empty(0, dtype=dtype), np.empty(0, dtype=np.int_)
-    return (
-        np.array(all_bp_list, dtype=dtype),
-        np.array(mults_list, dtype=np.int_),
-    )
+    return np.array(all_bp_list, dtype=dtype)
+
+
+def _product_multiplicities(
+    mults_f: npt.NDArray[np.int_],
+    mults_g: npt.NDArray[np.int_],
+    p: int,
+    q: int,
+) -> npt.NDArray[np.int_]:
+    r"""Compute the minimal product-space multiplicity at each merged breakpoint.
+
+    Takes the largest of ``m_f(ξ) + q`` and ``m_g(ξ) + p`` over the operands that
+    carry a knot at ``ξ``; see the module docstring for the derivation and its
+    hypotheses.  An operand whose multiplicity is 0 has no knot there and
+    contributes nothing; at least one operand must contribute, which holds for
+    every breakpoint of the union.
+
+    Writing ``max(m_f + q, p + q)`` for a breakpoint carried by ``f`` alone is
+    *not* the same thing: that form silently assumes ``m_f ≤ p``, so it is one
+    knot short of what a :math:`C^{-1}` operand (``m_f = p + 1``) needs, and up
+    to ``p - m_f`` knots more than the product actually requires otherwise.
+
+    Args:
+        mults_f (npt.NDArray[np.int_]): Multiplicity in the first space at each
+            merged breakpoint (``0`` where the breakpoint is absent).
+        mults_g (npt.NDArray[np.int_]): Multiplicity in the second space, likewise.
+        p (int): Degree of the first operand.
+        q (int): Degree of the second operand.
+
+    Returns:
+        npt.NDArray[np.int_]: Product multiplicity per breakpoint, in ``[1, p+q+1]``.
+    """
+    from_f = np.where(mults_f > 0, mults_f + q, 0)
+    from_g = np.where(mults_g > 0, mults_g + p, 0)
+    return np.maximum(from_f, from_g).astype(np.int_)
+
+
+class _ProductMesh(NamedTuple):
+    """The breakpoint structure shared by two operands and by their product.
+
+    Attributes:
+        breakpoints (npt.NDArray[np.float32 | np.float64]): Union of the interior
+            breakpoints of the two operands, ascending.
+        mults_f (npt.NDArray[np.int_]): Multiplicity of each breakpoint in the
+            first operand's knot vector (``0`` when absent).
+        mults_g (npt.NDArray[np.int_]): Same for the second operand.
+        product_mults (npt.NDArray[np.int_]): Minimal multiplicity of each
+            breakpoint in the product space, from :func:`_product_multiplicities`.
+    """
+
+    breakpoints: npt.NDArray[np.float32 | np.float64]
+    mults_f: npt.NDArray[np.int_]
+    mults_g: npt.NDArray[np.int_]
+    product_mults: npt.NDArray[np.int_]
+
+
+def _build_product_mesh(
+    space_f: BsplineSpace1D,
+    space_g: BsplineSpace1D,
+    tol: float,
+) -> _ProductMesh:
+    """Collect the interior breakpoints of two 1D spaces and their product multiplicities.
+
+    Args:
+        space_f (BsplineSpace1D): First operand's 1D space, of degree ``p``.
+        space_g (BsplineSpace1D): Second operand's 1D space, of degree ``q``.
+        tol (float): Tolerance for grouping nearby knots.
+
+    Returns:
+        _ProductMesh: The merged breakpoints with per-operand and product
+        multiplicities.
+    """
+    bp_f, mf = _get_interior_breakpoints_and_mults(space_f, tol)
+    bp_g, mg = _get_interior_breakpoints_and_mults(space_g, tol)
+    all_bp = _merge_interior_breakpoints(bp_f, bp_g, tol)
+    mults_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
+    mults_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
+    product_mults = _product_multiplicities(mults_f, mults_g, space_f.degree, space_g.degree)
+    return _ProductMesh(all_bp, mults_f, mults_g, product_mults)
+
+
+def _bezier_mults(degree: int, mults: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+    """Raise interior multiplicities to Bézier form without ever lowering one.
+
+    A Bézier (element-by-element) representation needs multiplicity ``degree`` at
+    every interior breakpoint, except where the spline is already discontinuous:
+    a knot of multiplicity ``degree + 1`` stays where it is, since removing it
+    would change the function.
+
+    Args:
+        degree (int): Degree of the space being brought to Bézier form.
+        mults (npt.NDArray[np.int_]): Current multiplicity per breakpoint
+            (``0`` where the breakpoint is absent).
+
+    Returns:
+        npt.NDArray[np.int_]: Multiplicity per breakpoint in Bézier form.
+    """
+    return np.maximum(degree, mults).astype(np.int_)
+
+
+def _bezier_element_offsets(bezier_mults: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+    """Index of each element's first control point in a Bézier-form spline.
+
+    Element ``e`` owns the ``degree + 1`` control points starting at entry ``e``
+    of the returned array.  Consecutive elements overlap in their shared
+    endpoint where the breakpoint between them has multiplicity ``degree``, and
+    are disjoint where it has multiplicity ``degree + 1``.
+
+    Args:
+        bezier_mults (npt.NDArray[np.int_]): Interior multiplicities of the
+            Bézier-form knot vector, from :func:`_bezier_mults`.
+
+    Returns:
+        npt.NDArray[np.int_]: Offsets of shape ``(len(bezier_mults) + 1,)``,
+        starting at 0.
+    """
+    return np.concatenate([np.zeros(1, dtype=np.int_), np.cumsum(bezier_mults, dtype=np.int_)])
 
 
 def _knots_for_full_bezier(
     space_1d: BsplineSpace1D,
     all_bp: npt.NDArray[np.float32 | np.float64],
     mults_in_space: npt.NDArray[np.int_],
-    tol: float,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Compute the additional knots needed to bring a space to full-Bézier form.
 
     For each breakpoint ``ξ`` with existing multiplicity ``m`` in ``space_1d``,
-    inserts ``degree - m`` copies of ``ξ`` so that every interior breakpoint
-    reaches multiplicity ``degree`` (full-Bézier / C^0).
+    inserts enough copies of ``ξ`` to reach :func:`_bezier_mults`, i.e.
+    ``degree - m`` copies at an ordinary breakpoint and none at a
+    :math:`C^{-1}` one, which is already isolated.
 
     Args:
         space_1d (BsplineSpace1D): The 1D B-spline space to refine.
@@ -187,22 +301,13 @@ def _knots_for_full_bezier(
             breakpoints (sorted ascending).
         mults_in_space (npt.NDArray[np.int_]): Multiplicity of each entry of
             ``all_bp`` in ``space_1d`` (0 if absent).
-        tol (float): Tolerance (unused here, kept for API symmetry).
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Flat sorted array of knot values
         to insert, possibly empty.
     """
-    degree = space_1d.degree
-    dtype = space_1d.knots.dtype
-    knots_to_insert: list[float] = []
-    for xi, m in zip(all_bp, mults_in_space, strict=True):
-        n_to_insert = degree - int(m)
-        if n_to_insert > 0:
-            knots_to_insert.extend([float(xi)] * n_to_insert)
-    if len(knots_to_insert) == 0:
-        return np.empty(0, dtype=dtype)
-    return np.array(knots_to_insert, dtype=dtype)
+    deficits = _bezier_mults(space_1d.degree, mults_in_space) - mults_in_space
+    return np.repeat(all_bp, deficits).astype(space_1d.knots.dtype)
 
 
 def _build_product_knot_vector(
@@ -212,7 +317,7 @@ def _build_product_knot_vector(
     degree_sum: int,
     dtype: npt.DTypeLike,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Build the product B-spline knot vector with optimal continuity.
+    """Build a clamped product knot vector from prescribed interior multiplicities.
 
     Assembles a clamped knot vector with:
 
@@ -220,8 +325,10 @@ def _build_product_knot_vector(
     - For each interior breakpoint ``ξ``: ``product_mults[k]`` copies
     - ``degree_sum + 1`` copies of the right endpoint ``b``
 
-    The interior multiplicities from ``product_mults`` encode the optimal
-    continuity: ``C^{degree_sum - product_mults[k]}`` at breakpoint ``ξ_k``.
+    The interior multiplicities encode the continuity
+    ``C^{degree_sum - product_mults[k]}`` at breakpoint ``ξ_k``.  Callers pass
+    either the minimal multiplicities of :func:`_product_multiplicities` or their
+    Bézier-form counterparts from :func:`_bezier_mults`.
 
     Args:
         domain (tuple[np.float32 | np.float64, np.float32 | np.float64]): Domain
@@ -482,17 +589,22 @@ def _to_rational(f: Bspline) -> Bspline:
 
 
 def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
-    """Multiply two non-rational 1D B-splines with optimal-continuity output.
+    r"""Multiply two non-rational 1D B-splines with minimal-multiplicity output.
 
-    Refines both operands to full-Bézier form (C^0 at every interior
-    breakpoint), applies the Bernstein product formula element by element to
-    obtain control points in a full-Bézier representation, then assembles the
-    result using an optimal-continuity knot vector.
+    Refines both operands to Bézier form, applies the Bernstein product formula
+    element by element to obtain control points in a Bézier representation of the
+    product, then re-expresses those in the minimal product space.
 
-    The product knot vector uses interior multiplicities
-    ``max(m_f(ξ) + q, m_g(ξ) + p)`` at each breakpoint ``ξ``, which is the
-    minimum multiplicity required to represent the product exactly while
-    achieving the maximum possible continuity.
+    Bézier form means multiplicity ``degree`` at every interior breakpoint, so
+    that each element carries its own ``degree + 1`` control points and adjacent
+    elements share exactly their junction — except at a :math:`C^{-1}` knot,
+    where the multiplicity is already ``degree + 1``, the elements share nothing,
+    and :func:`_bezier_element_offsets` is what keeps the read and write windows
+    aligned.  The intermediate product representation follows the same rule, so
+    it contains the product even when the product is discontinuous.
+
+    The final knot vector uses the minimal multiplicities of
+    :func:`_product_multiplicities`; see the module docstring for the formula.
 
     This function does not perform input validation; use :func:`_multiply_bspline_1d`
     for the validated public entry point.
@@ -515,82 +627,65 @@ def _multiply_nonrational_1d(f: Bspline, g: Bspline) -> Bspline:
     space_g = g.space.spaces[0]
     p = space_f.degree
     q = space_g.degree
+    r = p + q
     tol = max(float(space_f.tolerance), float(space_g.tolerance))
 
-    # --- Step 1: gather interior breakpoints from both operands ---
-    bp_f, mf = _get_interior_breakpoints_and_mults(space_f, tol)
-    bp_g, mg = _get_interior_breakpoints_and_mults(space_g, tol)
-
-    # --- Step 2: compute union of breakpoints with optimal product multiplicities ---
-    all_bp, product_mults = _merge_interior_breakpoints(bp_f, mf, bp_g, mg, p, q, tol)
+    # --- Step 1: union of the interior breakpoints, with the product multiplicities ---
+    mesh = _build_product_mesh(space_f, space_g, tol)
+    all_bp = mesh.breakpoints
+    product_mults = mesh.product_mults
     n_elements = int(all_bp.size) + 1
 
-    # --- Step 3: compute per-space multiplicities at union breakpoints ---
-    mults_in_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
-    mults_in_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
-
-    # --- Step 4: refine both operands to full-Bézier ---
-    knots_f_ins = _knots_for_full_bezier(space_f, all_bp, mults_in_f, tol)
-    knots_g_ins = _knots_for_full_bezier(space_g, all_bp, mults_in_g, tol)
+    # --- Step 2: refine both operands to Bézier form ---
+    knots_f_ins = _knots_for_full_bezier(space_f, all_bp, mesh.mults_f)
+    knots_g_ins = _knots_for_full_bezier(space_g, all_bp, mesh.mults_g)
 
     f_bezier: Bspline = f.insert_knots(knots_f_ins) if knots_f_ins.size > 0 else f
     g_bezier: Bspline = g.insert_knots(knots_g_ins) if knots_g_ins.size > 0 else g
 
-    # --- Step 5: assemble product control points (full-Bézier representation) ---
+    # --- Step 3: assemble the product control points, element by element ---
+    # A C^-1 breakpoint keeps its multiplicity degree+1 in Bézier form, so the
+    # element windows are cumulative rather than a fixed stride.
+    offsets_f = _bezier_element_offsets(_bezier_mults(p, mesh.mults_f))
+    offsets_g = _bezier_element_offsets(_bezier_mults(q, mesh.mults_g))
+    bezier_mults_h = _bezier_mults(r, product_mults)
+    offsets_h = _bezier_element_offsets(bezier_mults_h)
+
     rank = int(f.control_points.shape[-1])
-    ctrl_h_bezier = np.empty((n_elements * (p + q) + 1, rank), dtype=f.control_points.dtype)
+    ctrl_h_bezier = np.empty((int(offsets_h[-1]) + r + 1, rank), dtype=f.control_points.dtype)
 
     for e in range(n_elements):
-        b_f_e = f_bezier.control_points[e * p : e * p + p + 1]
-        b_g_e = g_bezier.control_points[e * q : e * q + q + 1]
-        ctrl_h_bezier[e * (p + q) : e * (p + q) + p + q + 1] = _bernstein_product_coefficients(
-            b_f_e, b_g_e
-        )
+        i_f, i_g, i_h = int(offsets_f[e]), int(offsets_g[e]), int(offsets_h[e])
+        b_f_e = f_bezier.control_points[i_f : i_f + p + 1]
+        b_g_e = g_bezier.control_points[i_g : i_g + q + 1]
+        ctrl_h_bezier[i_h : i_h + r + 1] = _bernstein_product_coefficients(b_f_e, b_g_e)
 
-    # --- Step 6: build product knot vector with optimal continuity ---
-    # The control points are in full-Bézier form; the product knot vector uses
-    # optimal multiplicities (max(m_f+q, m_g+p)), which may be less than p+q.
-    # To transition from the full-Bézier representation to the optimal one, we
-    # apply knot removal: a knot at ξ can be removed (product_mults[k]) times
-    # from its full-Bézier multiplicity (p+q).  The control points are updated
-    # accordingly via the Oslo algorithm in reverse (knot removal).
+    # --- Step 4: re-express the Bézier control points in the minimal product space ---
     domain = space_f.domain
     dtype = f.control_points.dtype
 
-    # Build the full-Bézier product B-spline first.
-    all_bp_arr = all_bp  # already ndarray
-    full_mults = np.full(all_bp.size, p + q, dtype=np.int_)
-    T_full = _build_product_knot_vector(domain, all_bp_arr, full_mults, p + q, dtype)
-    space_full = BsplineSpace([BsplineSpace1D(T_full, p + q)])
+    T_full = _build_product_knot_vector(domain, all_bp, bezier_mults_h, r, dtype)
+    space_full = BsplineSpace([BsplineSpace1D(T_full, r)])
     h_full = Bspline(space_full, ctrl_h_bezier, is_rational=False)
 
-    # If all product multiplicities equal p+q (e.g. all breakpoints are C^0),
-    # return the full-Bézier spline directly.
-    if all_bp.size == 0 or np.all(product_mults == p + q):
+    # Nothing to remove when the product is already no smoother than C^0 everywhere.
+    if all_bp.size == 0 or np.array_equal(product_mults, bezier_mults_h):
         return h_full
 
-    # Determine how many knots to remove at each breakpoint.
-    # At each breakpoint ξ_k with full-Bezier mult (p+q), we want to reduce to
-    # product_mults[k].  Use knot removal via inverse Oslo: project the
-    # full-Bézier control points onto the subspace with reduced knots.
-    # The simplest approach: use the Oslo matrix to re-express the full-Bézier
-    # control points in the optimal knot vector space.
-    T_opt = _build_product_knot_vector(domain, all_bp_arr, product_mults, p + q, dtype)
+    T_opt = _build_product_knot_vector(domain, all_bp, product_mults, r, dtype)
 
-    # Compute the Oslo matrix mapping optimal → full-Bézier, then solve for
-    # optimal control points.  Since the product B-spline lives exactly in the
-    # optimal space, the Oslo matrix should have a (numerically) unique
-    # least-squares solution that recovers the optimal control points.
+    # Re-express the Bézier control points on the minimal knot vector.  T_opt is a
+    # subsequence of T_full, so the Oslo matrix has full column rank and the
+    # least-squares solve is an exact change of representation, not a fit.
     from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core  # noqa: PLC0415
 
-    # oslo[i,j]: coefficient of old CP j in new CP i (old=optimal, new=full-Bezier)
-    oslo = _compute_oslo_matrix_1d_core(p + q, T_opt, T_full)
+    # oslo[i,j]: coefficient of old CP j in new CP i (old=minimal, new=Bézier)
+    oslo = _compute_oslo_matrix_1d_core(r, T_opt, T_full)
 
-    # Solve oslo @ ctrl_opt = ctrl_h_bezier (least-squares, should be exact).
     ctrl_opt, _res, _rank_ls, _sv = np.linalg.lstsq(oslo, ctrl_h_bezier, rcond=None)
     ctrl_opt = ctrl_opt.astype(dtype)
 
-    space_opt = BsplineSpace([BsplineSpace1D(T_opt, p + q)])
+    space_opt = BsplineSpace([BsplineSpace1D(T_opt, r)])
     return Bspline(space_opt, ctrl_opt, is_rational=False)
 
 
@@ -635,9 +730,12 @@ def _multiply_bspline_1d(f: Bspline, g: Bspline) -> Bspline:  # noqa: PLR0912
 
     Given B-splines ``f`` and ``g`` over the same 1D parametric domain, returns
     a new B-spline ``h`` such that ``h(t) = f(t) * g(t)`` for all ``t`` in the
-    domain.  The result lives in the product space of degree ``p + q`` with
-    optimal continuity: interior knot multiplicities equal
-    ``max(m_f(ξ) + q, m_g(ξ) + p)``.
+    domain.  The result lives in the smallest space that contains the product:
+    degree ``p + q``, with the interior multiplicities of
+    :func:`_product_multiplicities` — the maximum of ``m_f(ξ) + q`` and
+    ``m_g(ξ) + p`` over the operands that have a knot at ``ξ``.  Discontinuous
+    (:math:`C^{-1}`) operands are included: the product is then discontinuous
+    too, at multiplicity ``p + q + 1``.
 
     Rational operands are handled via homogeneous-coordinate decomposition.  A
     non-rational operand is silently promoted to rational (unit weights) when the

--- a/src/pantr/bspline/_bspline_product_nd.py
+++ b/src/pantr/bspline/_bspline_product_nd.py
@@ -3,11 +3,14 @@
 This module provides :func:`_multiply_bspline_nd`, which computes the exact
 pointwise product of two N-dimensional tensor-product B-splines via Bézier
 extraction and the Bernstein product formula.  The result lives in the product
-space of degree ``p_d + q_d`` per direction *d* with **optimal continuity**:
-each interior knot's multiplicity equals ``max(m_f(ξ) + q_d, m_g(ξ) + p_d)``.
+space of degree ``p_d + q_d`` per direction *d*, with the **minimal** interior
+multiplicities computed direction by direction by
+:func:`~pantr.bspline._bspline_product._product_multiplicities`; that module's
+docstring carries the formula, its derivation and its hypotheses.
 
 Works for non-rational and rational (NURBS) splines of any parametric
-dimension, and correctly preserves per-direction boundary structure
+dimension, including operands that are :math:`C^{-1}` in one or more
+directions, and correctly preserves per-direction boundary structure
 (open / periodic / non-open).
 """
 
@@ -24,12 +27,13 @@ from .._control_points_utils import _append_unit_weight_column
 from ..bezier._bezier_product import _bernstein_product_coefficients_nd
 from ._bspline_knots import _get_Bspline_num_basis_1D_impl, _get_unique_knots_and_multiplicity_impl
 from ._bspline_product import (
+    _bezier_element_offsets,
+    _bezier_mults,
     _build_product_knot_vector,
+    _build_product_mesh,
     _get_boundary_mults,
-    _get_interior_breakpoints_and_mults,
     _knots_for_full_bezier,
-    _lookup_mults_in_space,
-    _merge_interior_breakpoints,
+    _ProductMesh,
 )
 from ._bspline_space_1d import BsplineSpace1D
 from ._bspline_space_nd import BsplineSpace
@@ -38,63 +42,40 @@ if TYPE_CHECKING:
     from . import Bspline
 
 
-def _extract_bezier_patch(
-    ctrl: npt.NDArray[np.float32 | np.float64],
+def _bezier_patch_slices(
     element_idx: tuple[int, ...],
     degrees: tuple[int, ...],
-) -> npt.NDArray[np.float32 | np.float64]:
-    """Extract Bézier patch control points for a given element multi-index.
+    offsets: list[npt.NDArray[np.int_]],
+) -> tuple[slice, ...]:
+    """Index the control points of one element in a Bézier-form tensor-product spline.
 
-    In a full-Bézier representation, each direction *d* has control points
-    laid out as ``n_elements_d * degree_d + 1`` entries.  Element ``e_d``
-    occupies indices ``[e_d * degree_d, e_d * degree_d + degree_d + 1)``.
+    Element ``e_d`` of direction *d* owns ``degree_d + 1`` consecutive control
+    points starting at ``offsets[d][e_d]``.  The offsets are cumulative rather
+    than a fixed ``e_d * degree_d`` stride, because a :math:`C^{-1}` breakpoint
+    keeps multiplicity ``degree_d + 1`` in Bézier form and its two elements then
+    share no control point.
+
+    The same slices index the operands' control points for reading and the
+    product's for writing.  Where two elements do share a control point the two
+    writes carry the same value, so overwriting is safe.
 
     Args:
-        ctrl (npt.NDArray[np.float32 | np.float64]): Full-Bézier control
-            point array of shape ``(n_0, ..., n_{D-1}, rank)``.
         element_idx (tuple[int, ...]): Per-direction element index.
         degrees (tuple[int, ...]): Per-direction polynomial degrees.
+        offsets (list[npt.NDArray[np.int_]]): Per-direction element offsets, from
+            :func:`~pantr.bspline._bspline_product._bezier_element_offsets`.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Bézier patch control points
-        of shape ``(degree_0+1, ..., degree_{D-1}+1, rank)``.
+        tuple[slice, ...]: One slice per parametric direction; the trailing rank
+        axis is left untouched.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
     """
-    slices = tuple(
-        slice(e * deg, e * deg + deg + 1) for e, deg in zip(element_idx, degrees, strict=True)
+    return tuple(
+        slice(int(offsets[d][e]), int(offsets[d][e]) + deg + 1)
+        for d, (e, deg) in enumerate(zip(element_idx, degrees, strict=True))
     )
-    return ctrl[slices]
-
-
-def _place_bezier_patch(
-    ctrl_out: npt.NDArray[np.float32 | np.float64],
-    patch: npt.NDArray[np.float32 | np.float64],
-    element_idx: tuple[int, ...],
-    degrees: tuple[int, ...],
-) -> None:
-    """Place product Bézier patch into the full-Bézier control point array.
-
-    Writes the patch control points into the correct location.  At shared
-    boundaries between adjacent elements, the values are identical, so
-    overwriting is safe.
-
-    Args:
-        ctrl_out (npt.NDArray[np.float32 | np.float64]): Output full-Bézier
-            control point array (modified in-place).
-        patch (npt.NDArray[np.float32 | np.float64]): Bézier patch control
-            points to place.
-        element_idx (tuple[int, ...]): Per-direction element index.
-        degrees (tuple[int, ...]): Per-direction product degrees.
-
-    Note:
-        Inputs are assumed to be correct (no validation performed).
-    """
-    slices = tuple(
-        slice(e * deg, e * deg + deg + 1) for e, deg in zip(element_idx, degrees, strict=True)
-    )
-    ctrl_out[slices] = patch
 
 
 def _project_to_optimal_nd(
@@ -103,18 +84,18 @@ def _project_to_optimal_nd(
     knots_opt_per_dir: list[npt.NDArray[np.float32 | np.float64]],
     degrees_sum: tuple[int, ...],
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Project full-Bézier control points to optimal-continuity space per direction.
+    """Re-express Bézier-form control points on the minimal knot vectors, per direction.
 
-    Applies the Oslo-based least-squares projection direction by direction.
-    For each direction *d*, the Oslo matrix mapping optimal → full-Bézier is
-    computed, and the inverse (least-squares) solve reduces the control point
-    count along that axis.
+    Applies the Oslo-based solve direction by direction.  For each direction *d*
+    the Oslo matrix mapping minimal → Bézier is computed; since the minimal knot
+    vector is a subsequence of the Bézier one, that matrix has full column rank
+    and the least-squares solve is an exact change of representation.
 
     Args:
-        ctrl_full (npt.NDArray[np.float32 | np.float64]): Full-Bézier control
+        ctrl_full (npt.NDArray[np.float32 | np.float64]): Bézier-form control
             points of shape ``(n_full_0, ..., n_full_{D-1}, rank)``.
-        knots_full_per_dir (list[npt.NDArray]): Full-Bézier knot vector per direction.
-        knots_opt_per_dir (list[npt.NDArray]): Optimal knot vector per direction.
+        knots_full_per_dir (list[npt.NDArray]): Bézier-form knot vector per direction.
+        knots_opt_per_dir (list[npt.NDArray]): Minimal knot vector per direction.
         degrees_sum (tuple[int, ...]): Product degree per direction.
 
     Returns:
@@ -141,11 +122,11 @@ def _project_to_optimal_nd(
 
 
 def _multiply_nonrational_nd(f: Bspline, g: Bspline) -> Bspline:  # noqa: PLR0915
-    """Multiply two non-rational nD B-splines with optimal-continuity output.
+    """Multiply two non-rational nD B-splines with minimal-multiplicity output.
 
-    Refines both operands to full-Bézier form in all directions, applies the
-    nD Bernstein product formula element by element, then projects the result
-    to optimal continuity via per-direction Oslo solves.
+    Refines both operands to Bézier form in all directions, applies the nD
+    Bernstein product formula element by element, then re-expresses the result on
+    the minimal knot vectors via per-direction Oslo solves.
 
     Args:
         f (~pantr.bspline.Bspline): First non-rational nD B-spline operand.
@@ -173,65 +154,66 @@ def _multiply_nonrational_nd(f: Bspline, g: Bspline) -> Bspline:  # noqa: PLR091
     tol = max(float(s.tolerance) for s in (*spaces_f, *spaces_g))
 
     # --- Per-direction breakpoint analysis ---
-    all_bp_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
-    product_mults_per_dir: list[npt.NDArray[np.int_]] = []
+    meshes: list[_ProductMesh] = []
+    bezier_mults_h_per_dir: list[npt.NDArray[np.int_]] = []
+    offsets_f_per_dir: list[npt.NDArray[np.int_]] = []
+    offsets_g_per_dir: list[npt.NDArray[np.int_]] = []
+    offsets_h_per_dir: list[npt.NDArray[np.int_]] = []
     knots_f_ins_per_dir: list[npt.NDArray[np.float32 | np.float64] | None] = []
     knots_g_ins_per_dir: list[npt.NDArray[np.float32 | np.float64] | None] = []
 
     for d in range(ndim):
-        bp_f, mf = _get_interior_breakpoints_and_mults(spaces_f[d], tol)
-        bp_g, mg = _get_interior_breakpoints_and_mults(spaces_g[d], tol)
+        mesh = _build_product_mesh(spaces_f[d], spaces_g[d], tol)
+        meshes.append(mesh)
 
-        all_bp, product_mults = _merge_interior_breakpoints(
-            bp_f, mf, bp_g, mg, degrees_f[d], degrees_g[d], tol
-        )
-        all_bp_per_dir.append(all_bp)
-        product_mults_per_dir.append(product_mults)
+        bezier_mults_h = _bezier_mults(degrees_sum[d], mesh.product_mults)
+        bezier_mults_h_per_dir.append(bezier_mults_h)
+        offsets_f_per_dir.append(_bezier_element_offsets(_bezier_mults(degrees_f[d], mesh.mults_f)))
+        offsets_g_per_dir.append(_bezier_element_offsets(_bezier_mults(degrees_g[d], mesh.mults_g)))
+        offsets_h_per_dir.append(_bezier_element_offsets(bezier_mults_h))
 
-        mults_in_f = _lookup_mults_in_space(all_bp, bp_f, mf, tol)
-        mults_in_g = _lookup_mults_in_space(all_bp, bp_g, mg, tol)
-
-        knots_f_d = _knots_for_full_bezier(spaces_f[d], all_bp, mults_in_f, tol)
-        knots_g_d = _knots_for_full_bezier(spaces_g[d], all_bp, mults_in_g, tol)
+        knots_f_d = _knots_for_full_bezier(spaces_f[d], mesh.breakpoints, mesh.mults_f)
+        knots_g_d = _knots_for_full_bezier(spaces_g[d], mesh.breakpoints, mesh.mults_g)
         knots_f_ins_per_dir.append(knots_f_d if knots_f_d.size > 0 else None)
         knots_g_ins_per_dir.append(knots_g_d if knots_g_d.size > 0 else None)
 
-    # --- Refine both operands to full-Bézier ---
+    # --- Refine both operands to Bézier form ---
     if any(k is not None for k in knots_f_ins_per_dir):
         f = f.insert_knots(knots_f_ins_per_dir)
     if any(k is not None for k in knots_g_ins_per_dir):
         g = g.insert_knots(knots_g_ins_per_dir)
 
     # --- Element-wise nD Bernstein product ---
-    n_elements_per_dir = tuple(int(bp.size) + 1 for bp in all_bp_per_dir)
+    n_elements_per_dir = tuple(int(mesh.breakpoints.size) + 1 for mesh in meshes)
     rank = f.control_points.shape[-1]
-    full_shape = tuple(ne * rd + 1 for ne, rd in zip(n_elements_per_dir, degrees_sum, strict=True))
+    full_shape = tuple(
+        int(off[-1]) + rd + 1 for off, rd in zip(offsets_h_per_dir, degrees_sum, strict=True)
+    )
     ctrl_h_bezier = np.empty((*full_shape, rank), dtype=dtype)
 
     for elem_idx in itertools.product(*(range(ne) for ne in n_elements_per_dir)):
-        patch_f = _extract_bezier_patch(f.control_points, elem_idx, degrees_f)
-        patch_g = _extract_bezier_patch(g.control_points, elem_idx, degrees_g)
-        product_patch = _bernstein_product_coefficients_nd(patch_f, patch_g)
-        _place_bezier_patch(ctrl_h_bezier, product_patch, elem_idx, degrees_sum)
+        patch_f = f.control_points[_bezier_patch_slices(elem_idx, degrees_f, offsets_f_per_dir)]
+        patch_g = g.control_points[_bezier_patch_slices(elem_idx, degrees_g, offsets_g_per_dir)]
+        slices_h = _bezier_patch_slices(elem_idx, degrees_sum, offsets_h_per_dir)
+        ctrl_h_bezier[slices_h] = _bernstein_product_coefficients_nd(patch_f, patch_g)
 
-    # --- Build product knot vectors (full-Bézier and optimal) ---
+    # --- Build the product knot vectors (Bézier form and minimal) ---
     knots_full_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
     knots_opt_per_dir: list[npt.NDArray[np.float32 | np.float64]] = []
     needs_projection = False
 
     for d in range(ndim):
         domain_d = spaces_f[d].domain
-        full_mults_d = np.full(all_bp_per_dir[d].size, degrees_sum[d], dtype=np.int_)
         t_full_d = _build_product_knot_vector(
-            domain_d, all_bp_per_dir[d], full_mults_d, degrees_sum[d], dtype
+            domain_d, meshes[d].breakpoints, bezier_mults_h_per_dir[d], degrees_sum[d], dtype
         )
         t_opt_d = _build_product_knot_vector(
-            domain_d, all_bp_per_dir[d], product_mults_per_dir[d], degrees_sum[d], dtype
+            domain_d, meshes[d].breakpoints, meshes[d].product_mults, degrees_sum[d], dtype
         )
         knots_full_per_dir.append(t_full_d)
         knots_opt_per_dir.append(t_opt_d)
 
-        if all_bp_per_dir[d].size > 0 and not np.all(product_mults_per_dir[d] == degrees_sum[d]):
+        if not np.array_equal(meshes[d].product_mults, bezier_mults_h_per_dir[d]):
             needs_projection = True
 
     # --- Project to optimal continuity if needed ---

--- a/tests/test_bspline_derivative.py
+++ b/tests/test_bspline_derivative.py
@@ -464,6 +464,35 @@ class TestKeepDegreeNonRational:
         pts = eval_pts()
         np.testing.assert_allclose(d_keep.evaluate(pts), d_ref.evaluate(pts), atol=1e-12)
 
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4])
+    def test_1d_with_a_c0_interior_knot(self, degree: int) -> None:
+        """A C^0 interior knot is the ordinary case, and it used to raise.
+
+        ``keep_degree=True`` differentiates to ``degree - 1`` and elevates back,
+        so a knot of multiplicity ``degree`` in the original space is a knot of
+        multiplicity ``(degree - 1) + 1`` in the space handed to the elevation
+        kernel: exactly the discontinuous case that kernel mishandled, which made
+        this raise for every C^0-knotted spline. The derivative of a C^0 function
+        jumps, so the result must carry multiplicity ``degree + 1`` there.
+        """
+        knots = [0.0] * (degree + 1) + [0.5] * degree + [1.0] * (degree + 1)
+        rng = np.random.default_rng(degree)
+        n_basis = len(knots) - degree - 1
+        f = make_bspline_1d(knots, degree, rng.standard_normal((n_basis, 2)).tolist())
+
+        f_prime = f.derivative(keep_degree=True)
+
+        space_d = f_prime.space.spaces[0]
+        assert space_d.degree == degree
+        assert f_prime.control_points.shape[0] == space_d.num_basis
+        assert int(np.count_nonzero(np.abs(np.asarray(space_d.knots) - 0.5) <= 1e-12)) == degree + 1
+
+        # Off the jump, it is still the derivative.
+        pts = np.array([0.07, 0.23, 0.4999, 0.5001, 0.71, 0.93])
+        np.testing.assert_allclose(
+            f_prime.evaluate(pts), f.evaluate_derivatives(pts, 1), atol=1e-11
+        )
+
     def test_vector_valued(self) -> None:
         """Vector-valued B-spline with keep_degree."""
         knots = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -717,6 +717,26 @@ class TestProductMultiplicityRule:
             h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), rtol=1e-11, atol=1e-11
         )
 
+    def test_float32_keeps_the_rule_and_the_dtype(self) -> None:
+        """The multiplicity rule is integer arithmetic; float32 changes only the values."""
+        f = make_bspline(
+            _open_knots(2, [(0.5, 3)]),
+            2,
+            [[1.0], [2.0], [3.0], [-1.0], [0.5], [2.0]],
+            dtype=np.float32,
+        )
+        g = make_bspline(_open_knots(1, [(0.5, 1)]), 1, [[1.0], [2.0], [0.5]], dtype=np.float32)
+
+        h = f.multiply(g)
+
+        assert np.dtype(h.dtype) == np.float32
+        assert _interior_mult(h, 0.5) == 4
+
+        pts = eval_pts()[1:-1].astype(np.float32) + np.float32(1.0e-5)
+        np.testing.assert_allclose(
+            h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), rtol=1e-5, atol=1e-5
+        )
+
     def test_rational_operands_with_a_jump(self) -> None:
         """The homogeneous-coordinate path carries a C^-1 operand through as well."""
         f = make_bspline(
@@ -741,6 +761,33 @@ class TestProductMultiplicityRule:
         np.testing.assert_allclose(
             h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), rtol=1e-11, atol=1e-11
         )
+
+    def test_degree_zero_operands_on_different_meshes(self) -> None:
+        """Every breakpoint of a degree-0 spline is C^-1, and it may miss the other's.
+
+        The element windows are cumulative offsets over the Bézier multiplicities,
+        which at degree 0 are 1 where the operand has a knot and 0 where it does
+        not: an operand that is constant across a breakpoint the other introduces
+        contributes the same coefficient to both elements.
+        """
+        f = make_bspline([0.0, 0.25, 0.6, 1.0], 0, [[2.0], [-3.0], [5.0]])
+        g = make_bspline([0.0, 0.4, 1.0], 0, [[7.0], [-1.0]])
+
+        h = f.multiply(g)
+
+        assert h.degree == (0,)
+        # The breakpoints come back within an ulp rather than exactly: the unique-knot
+        # helper returns the value rounded onto its 1/tolerance grouping grid, not the
+        # knot it grouped. That is a separate, pre-existing defect; what this test pins
+        # is the element structure and the products.
+        np.testing.assert_allclose(
+            h.space.spaces[0].knots,
+            [0.0, 0.25, 0.4, 0.6, 1.0],
+            rtol=8.0 * float(np.finfo(np.float64).eps),
+            atol=0.0,
+        )
+        # Piecewise constant products: 2*7, -3*7, -3*-1, 5*-1.
+        np.testing.assert_array_equal(h.control_points, np.array([[14.0], [-21.0], [3.0], [-5.0]]))
 
     def test_product_multiplicities_formula(self) -> None:
         """Unit-test the rule itself, including the absent-operand convention."""

--- a/tests/test_bspline_product.py
+++ b/tests/test_bspline_product.py
@@ -9,6 +9,7 @@ import pytest
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 from pantr.bspline._bspline_knots import _get_unique_knots_and_multiplicity_impl
+from pantr.bspline._bspline_product import _product_multiplicities
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -586,3 +587,167 @@ class TestNonOpenProduct:
         pts = eval_pts()[1:-1]
         expected = f.evaluate(pts) * g.evaluate(pts)
         np.testing.assert_allclose(h.evaluate(pts), expected, atol=1e-11)
+
+
+# ---------------------------------------------------------------------------
+# Product multiplicity rule (shared, unshared and discontinuous breakpoints)
+# ---------------------------------------------------------------------------
+
+
+def _interior_mult(spline: Bspline, xi: float) -> int:
+    """Return the multiplicity of interior breakpoint ``xi`` in a 1D spline."""
+    space_1d = spline.space.spaces[0]
+    unique, mults = _get_unique_knots_and_multiplicity_impl(
+        space_1d.knots, space_1d.degree, float(space_1d.tolerance), in_domain=True
+    )
+    matches = np.flatnonzero(np.abs(unique - xi) <= float(space_1d.tolerance))
+    assert matches.size == 1, f"breakpoint {xi} not found in {unique}"
+    return int(mults[matches[0]])
+
+
+def _open_knots(degree: int, interior: list[tuple[float, int]]) -> list[float]:
+    """Build a clamped knot vector on ``[0, 1]`` from interior (value, multiplicity) pairs."""
+    knots = [0.0] * (degree + 1)
+    for xi, mult in interior:
+        knots.extend([xi] * mult)
+    knots.extend([1.0] * (degree + 1))
+    return knots
+
+
+class TestProductMultiplicityRule:
+    """The interior multiplicity of the product follows the smoothness rule.
+
+    The product of splines of smoothness ``s_f`` and ``s_g`` at a breakpoint is
+    ``C^{min(s_f, s_g)}`` there, so its multiplicity is
+    ``(p + q) - min(s_f, s_g)``, with ``s = degree - m`` and ``s = +inf`` for an
+    operand that has no knot at that breakpoint.  Discontinuous (``m = p + 1``)
+    operands are inside that rule, not an exception to it.
+    """
+
+    def test_multiplying_by_the_constant_one_returns_the_operand(self) -> None:
+        """``f * 1`` must be ``f``, including across a C^-1 jump.
+
+        ``f`` is the degree-1 spline that jumps from 2 to 3 at 0.5; ``g`` is the
+        constant 1.  Reading the unshared breakpoint 0.5 as ``p + q`` instead of
+        ``m_f + q`` builds multiplicity 2 where 3 is needed, and the product then
+        interpolates across the jump instead of reproducing it.
+        """
+        f = make_bspline([0.0, 0.0, 0.5, 0.5, 1.0, 1.0], 1, [[1.0], [2.0], [3.0], [4.0]])
+        g = make_bspline([0.0, 0.0, 1.0, 1.0], 1, [[1.0], [1.0]])
+
+        h = f.multiply(g)
+
+        assert h.degree == (2,)
+        assert _interior_mult(h, 0.5) == 3
+
+        # f is 1 + 2x on [0, 0.5) and 2 + 2x on (0.5, 1]; the product is exact and
+        # every control point is dyadic, so it is reproduced bit for bit.
+        np.testing.assert_array_equal(
+            h.control_points, np.array([[1.0], [1.5], [2.0], [3.0], [3.5], [4.0]])
+        )
+        pts = np.array([0.1, 0.25, 0.4999, 0.5001, 0.6, 0.9])
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts), atol=1e-15)
+
+    def test_product_of_discontinuous_operands_keeps_the_jump(self) -> None:
+        """A C^-1 operand gives a C^-1 product with the same one-sided limits."""
+        f = make_bspline(_open_knots(2, [(0.5, 3)]), 2, [[1.0], [2.0], [3.0], [-1.0], [0.5], [2.0]])
+        g = make_bspline(_open_knots(1, [(0.5, 1)]), 1, [[1.0], [2.0], [0.5]])
+
+        h = f.multiply(g)
+
+        assert h.degree == (3,)
+        assert _interior_mult(h, 0.5) == 4  # p + q + 1: the product jumps too
+
+        # One-sided limits: f jumps 3 -> -1 and g is continuous with g(0.5) = 2.
+        eps = 1e-9
+        pts = np.array([0.5 - eps, 0.5 + eps])
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+        np.testing.assert_allclose(h.evaluate(pts).ravel(), [6.0, -2.0], atol=1e-7)
+
+    def test_unshared_breakpoint_uses_the_minimal_multiplicity(self) -> None:
+        """A breakpoint carried by one operand alone gets ``m_f + q``, not ``p + q``.
+
+        ``f`` is C^3 at 0.5 (degree 4, multiplicity 1) and ``g`` has no knot
+        there, so the product is C^3 as well: multiplicity ``1 + 1 = 2`` in the
+        degree-5 product space, giving 8 control points rather than the 11 a
+        ``p + q`` multiplicity would need.
+        """
+        f = make_bspline(_open_knots(4, [(0.5, 1)]), 4, [[1.0], [2.0], [-1.0], [3.0], [0.5], [2.5]])
+        g = make_bspline(_open_knots(1, []), 1, [[2.0], [-1.0]])
+
+        h = f.multiply(g)
+
+        assert h.degree == (5,)
+        assert _interior_mult(h, 0.5) == 2
+        assert h.space.num_total_basis == 8
+
+        pts = eval_pts()
+        np.testing.assert_allclose(h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), atol=1e-11)
+
+    @pytest.mark.parametrize("degree_f", [1, 2, 3])
+    @pytest.mark.parametrize("degree_g", [1, 2, 3])
+    @pytest.mark.parametrize("shift_f", [0, 1])
+    @pytest.mark.parametrize("shift_g", [0, 1])
+    def test_multiplicity_and_values_over_the_smoothness_range(
+        self, degree_f: int, degree_g: int, shift_f: int, shift_g: int
+    ) -> None:
+        """Sweep the two most-singular multiplicities of each operand, C^0 and C^-1."""
+        mult_f = degree_f + shift_f
+        mult_g = degree_g + shift_g
+        rng = np.random.default_rng(1234 + 100 * degree_f + 10 * degree_g + shift_f)
+
+        knots_f = _open_knots(degree_f, [(0.5, mult_f)])
+        knots_g = _open_knots(degree_g, [(0.5, mult_g)])
+        ctrl_f = rng.standard_normal((len(knots_f) - degree_f - 1, 1)).tolist()
+        ctrl_g = rng.standard_normal((len(knots_g) - degree_g - 1, 1)).tolist()
+        f = make_bspline(knots_f, degree_f, ctrl_f)
+        g = make_bspline(knots_g, degree_g, ctrl_g)
+
+        h = f.multiply(g)
+
+        degree_h = degree_f + degree_g
+        expected = degree_h - min(degree_f - mult_f, degree_g - mult_g)
+        assert h.degree == (degree_h,)
+        assert _interior_mult(h, 0.5) == expected
+
+        # Stay off the breakpoint: the value of a C^-1 spline exactly at its jump
+        # is a one-sided convention, not a property the product has to match.
+        pts = eval_pts()[1:-1] + 1.0e-7
+        np.testing.assert_allclose(
+            h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), rtol=1e-11, atol=1e-11
+        )
+
+    def test_rational_operands_with_a_jump(self) -> None:
+        """The homogeneous-coordinate path carries a C^-1 operand through as well."""
+        f = make_bspline(
+            _open_knots(2, [(0.5, 3)]),
+            2,
+            [[1.0, 1.0], [2.0, 2.0], [3.0, 1.5], [-1.0, 1.0], [0.5, 2.0], [2.0, 1.0]],
+            is_rational=True,
+        )
+        g = make_bspline(
+            _open_knots(1, [(0.5, 1)]),
+            1,
+            [[1.0, 2.0], [2.0, 1.0], [0.5, 3.0]],
+            is_rational=True,
+        )
+
+        h = f.multiply(g)
+
+        assert h.is_rational
+        assert _interior_mult(h, 0.5) == 4
+
+        pts = eval_pts()[1:-1] + 1.0e-7
+        np.testing.assert_allclose(
+            h.evaluate(pts), f.evaluate(pts) * g.evaluate(pts), rtol=1e-11, atol=1e-11
+        )
+
+    def test_product_multiplicities_formula(self) -> None:
+        """Unit-test the rule itself, including the absent-operand convention."""
+        # p = 4, q = 1.  Columns: shared C^0, f-only C^3, g-only C^0, both C^-1.
+        mults_f = np.array([4, 1, 0, 5], dtype=np.int_)
+        mults_g = np.array([1, 0, 1, 2], dtype=np.int_)
+        np.testing.assert_array_equal(
+            _product_multiplicities(mults_f, mults_g, 4, 1),
+            np.array([5, 2, 5, 6], dtype=np.int_),
+        )

--- a/tests/test_bspline_product_nd.py
+++ b/tests/test_bspline_product_nd.py
@@ -71,6 +71,27 @@ def _eval_2d_product(f: Bspline, g: Bspline, h: Bspline, n: int = 21, atol: floa
     np.testing.assert_allclose(h_vals, f_vals * g_vals, atol=atol)
 
 
+def _eval_2d_product_off_breakpoints(
+    f: Bspline, g: Bspline, h: Bspline, breakpoint_value: float, n: int = 21
+) -> None:
+    """Assert h == f*g on a 2D lattice that avoids a discontinuity.
+
+    The value of a C^-1 spline *at* its jump is a one-sided convention, not a
+    property the product has to reproduce: ``f * g`` and ``h`` live on knot
+    vectors of different degrees and need not resolve the same side there.
+    """
+    axes = []
+    for direction in range(2):
+        dom = f.space.spaces[direction].domain
+        pts = _eval_lattice_pts(n, float(dom[0]), float(dom[1]))[1:-1]
+        axes.append(pts[np.abs(pts - breakpoint_value) > 1e-9])
+    lattice = PointsLattice(axes)
+
+    np.testing.assert_allclose(
+        h.evaluate(lattice), f.evaluate(lattice) * g.evaluate(lattice), atol=1e-10
+    )
+
+
 def _eval_3d_product(f: Bspline, g: Bspline, h: Bspline, n: int = 11, atol: float = 1e-10) -> None:
     """Assert h == f*g by evaluating on a 3D lattice at interior points.
 
@@ -479,6 +500,57 @@ class TestOptimalContinuity2D:
         assert h.space.num_basis == (8, 8)
 
         _eval_2d_product(f, g, h)
+
+
+class TestDiscontinuousOperand2D:
+    """A C^-1 operand in one or both directions of a tensor-product product.
+
+    The per-element windows into the control points run over cumulative offsets
+    rather than a fixed ``degree`` stride, because a C^-1 breakpoint keeps
+    multiplicity ``degree + 1`` in Bézier form and its two elements then share no
+    control point.  That is a per-direction property, so it has to hold when only
+    one direction is discontinuous as well as when both are.
+    """
+
+    def test_c_minus_one_in_one_direction(self) -> None:
+        """Direction u is C^-1 at 0.5 and v is smooth: only u reaches p + q + 1."""
+        knots_u = [0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0]  # degree 2, mult 3
+        knots_v = [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]  # degree 2, mult 1
+        s_u, s_v = _make_space_1d(knots_u, 2), _make_space_1d(knots_v, 2)
+        s_g = _make_space_1d([0.0, 0.0, 0.5, 1.0, 1.0], 1)  # degree 1, mult 1
+
+        rng = np.random.default_rng(60)
+        f = _make_2d_bspline(s_u, s_v, rng.standard_normal((s_u.num_basis, s_v.num_basis, 1)))
+        g = _make_2d_bspline(s_g, s_v, rng.standard_normal((s_g.num_basis, s_v.num_basis, 1)))
+
+        h = f * g
+        assert h.degree == (3, 4)
+
+        bp_u, mults_u = _get_interior_mults(h.space.spaces[0])
+        np.testing.assert_allclose(bp_u, [0.5], atol=1e-12)
+        assert int(mults_u[0]) == 4  # max(3 + 1, 1 + 2) = p + q + 1: the product jumps
+        bp_v, mults_v = _get_interior_mults(h.space.spaces[1])
+        np.testing.assert_allclose(bp_v, [0.5], atol=1e-12)
+        assert int(mults_v[0]) == 3  # max(1 + 2, 1 + 2)
+
+        _eval_2d_product_off_breakpoints(f, g, h, 0.5)
+
+    def test_c_minus_one_in_both_directions(self) -> None:
+        """Both directions discontinuous, with a different degree in each operand."""
+        s_f = _make_space_1d([0.0, 0.0, 0.5, 0.5, 1.0, 1.0], 1)  # degree 1, mult 2
+        s_g = _make_space_1d([0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0], 2)
+
+        rng = np.random.default_rng(61)
+        f = _make_2d_bspline(s_f, s_f, rng.standard_normal((s_f.num_basis, s_f.num_basis, 1)))
+        g = _make_2d_bspline(s_g, s_g, rng.standard_normal((s_g.num_basis, s_g.num_basis, 1)))
+
+        h = f * g
+        assert h.degree == (3, 3)
+        for direction in range(2):
+            _, mults = _get_interior_mults(h.space.spaces[direction])
+            assert int(mults[0]) == 4  # max(2 + 2, 3 + 1)
+
+        _eval_2d_product_off_breakpoints(f, g, h, 0.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_degree_elevation.py
+++ b/tests/test_degree_elevation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
@@ -239,3 +240,100 @@ class TestPeriodicBsplineElevateDegree:
         orig = bsp.to_open_bspline().evaluate(pts)
         elev = elevated.to_open_bspline().evaluate(pts)
         np.testing.assert_allclose(orig, elev, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Discontinuous (C^-1) knots: elevation preserves smoothness, so m -> m + t
+# ---------------------------------------------------------------------------
+
+
+def _open_knots(degree: int, interior: list[tuple[float, int]]) -> npt.NDArray[np.float64]:
+    """Build a clamped knot vector on ``[0, 1]`` from interior (value, multiplicity) pairs."""
+    parts = [np.zeros(degree + 1)]
+    for xi, mult in interior:
+        parts.append(np.full(mult, xi))
+    parts.append(np.ones(degree + 1))
+    return np.concatenate(parts)
+
+
+def _random_bspline(degree: int, interior: list[tuple[float, int]], seed: int) -> Bspline:
+    """Create an open 1D B-spline on the given breakpoint structure."""
+    knots = _open_knots(degree, interior)
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    rng = np.random.default_rng(seed)
+    return Bspline(space, rng.standard_normal((space.num_total_basis, 1)))
+
+
+def _multiplicity(spline: Bspline, xi: float) -> int:
+    """Multiplicity of the breakpoint ``xi`` in a 1D spline's knot vector."""
+    knots = spline.space.spaces[0].knots
+    return int(np.count_nonzero(np.abs(knots - xi) <= 1.0e-12))
+
+
+class TestElevateDegreeDiscontinuous:
+    """Elevation preserves smoothness, including where the spline has none.
+
+    A breakpoint of multiplicity ``m`` carries smoothness ``C^{p-m}``, and the
+    elevated spline is the same function, so its multiplicity must become
+    ``m + t``.  At ``m = p + 1`` the two Bézier segments meeting there share no
+    control point, which is what Piegl & Tiller A5.9's bookkeeping assumed away;
+    at degree 0 *every* interior breakpoint is of that kind.
+    """
+
+    @pytest.mark.parametrize("degree", [0, 1, 2, 3, 4])
+    @pytest.mark.parametrize("increment", [1, 2])
+    @pytest.mark.parametrize("n_jumps", [1, 2, 3])
+    def test_multiplicity_and_geometry(self, degree: int, increment: int, n_jumps: int) -> None:
+        """Every C^-1 breakpoint goes to ``degree + 1 + increment``, the curve is unchanged."""
+        breaks = [(round(0.2 + 0.2 * k, 10), degree + 1) for k in range(n_jumps)]
+        bsp = _random_bspline(degree, breaks, seed=11 * degree + increment + n_jumps)
+
+        elevated = bsp.elevate_degree(increment)
+
+        assert elevated.degree == (degree + increment,)
+        for xi, mult in breaks:
+            assert _multiplicity(elevated, xi) == mult + increment
+
+        space_1d = elevated.space.spaces[0]
+        assert elevated.control_points.shape[0] == space_1d.num_basis
+
+        # Stay off the jumps: the value there is a one-sided convention.
+        pts = np.linspace(0.0, 1.0, 97)[1:-1] + 1.0e-7
+        np.testing.assert_allclose(elevated.evaluate(pts), bsp.evaluate(pts), atol=1e-12)
+
+    def test_degree_zero_keeps_its_domain(self) -> None:
+        """A piecewise constant elevates to the same step function, not to a point.
+
+        The kernel used to leave the closing knots of a degree-0 knot vector
+        unwritten, collapsing the domain to ``(0, 0)`` with no error raised.
+        """
+        knots = np.array([0.0, 0.25, 0.6, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots, 0)])
+        bsp = Bspline(space, np.array([[2.0], [-1.0], [3.0]]))
+
+        elevated = bsp.elevate_degree(2)
+
+        space_1d = elevated.space.spaces[0]
+        assert elevated.degree == (2,)
+        assert (float(space_1d.domain[0]), float(space_1d.domain[1])) == (0.0, 1.0)
+        np.testing.assert_allclose(
+            space_1d.knots,
+            [0.0, 0.0, 0.0, 0.25, 0.25, 0.25, 0.6, 0.6, 0.6, 1.0, 1.0, 1.0],
+        )
+        # Elevating a constant repeats its value on every coefficient of the segment.
+        np.testing.assert_array_equal(
+            elevated.control_points,
+            np.array([[2.0], [2.0], [2.0], [-1.0], [-1.0], [-1.0], [3.0], [3.0], [3.0]]),
+        )
+
+    def test_mixed_multiplicities(self) -> None:
+        """Smooth, C^0 and C^-1 breakpoints in one spline all shift by the increment."""
+        breaks = [(0.25, 1), (0.5, 4), (0.75, 3)]
+        bsp = _random_bspline(3, breaks, seed=7)
+
+        elevated = bsp.elevate_degree(2)
+
+        for xi, mult in breaks:
+            assert _multiplicity(elevated, xi) == mult + 2
+        pts = np.linspace(0.0, 1.0, 97)[1:-1] + 1.0e-7
+        np.testing.assert_allclose(elevated.evaluate(pts), bsp.evaluate(pts), atol=1e-12)

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -582,6 +582,12 @@ def _make_bspline_1d(knots: list[float], degree: int, ctrl: list[list[float]]) -
     return Bspline(space, np.array(ctrl))
 
 
+def _bspline_multiplicity(spline: Bspline, xi: float) -> int:
+    """Multiplicity of the breakpoint ``xi`` in a 1D spline's knot vector."""
+    knots = spline.space.spaces[0].knots
+    return int(np.count_nonzero(np.abs(knots - xi) <= 1.0e-12))
+
+
 class TestBsplineReduceDegreeRoundTrip:
     """Elevate by t then reduce by t should recover the original geometry."""
 
@@ -837,6 +843,88 @@ class TestBsplineReduceDegreePeriodic:
         orig = bsp.to_open_bspline().evaluate(pts)
         red = reduced.to_open_bspline().evaluate(pts)
         np.testing.assert_allclose(orig, red, atol=1e-11)
+
+
+class TestBsplineReduceDegreeDiscontinuous:
+    """Reduction preserves smoothness, so a C^-1 knot stays C^-1.
+
+    A breakpoint of multiplicity ``m`` is ``C^{p-m}``, and ``C^{p-m} =
+    C^{(p-t)-(m-t)}``, so the reduced multiplicity is ``m - t``.  At ``m = p + 1``
+    that is ``new_degree + 1``: clamping it at ``new_degree`` asks for a C0 space
+    where the function jumps, and the reduction stops being exact on curves that
+    reduce exactly.
+    """
+
+    @pytest.mark.parametrize("degree", [2, 3, 4, 5])
+    def test_exactly_reducible_curve_with_a_jump(self, degree: int) -> None:
+        """A degree-elevated C^-1 spline reduces back to itself, not to a C0 fit."""
+        knots = np.concatenate([np.zeros(degree), np.full(degree, 0.5), np.ones(degree)]).tolist()
+        rng = np.random.default_rng(degree)
+        base = _make_bspline_1d(knots, degree - 1, rng.standard_normal((2 * degree, 1)).tolist())
+        assert _bspline_multiplicity(base, 0.5) == degree  # (degree - 1) + 1: C^-1
+
+        elevated = base.elevate_degree(1)
+        reduced = elevated.reduce_degree(1)
+
+        assert reduced.degree == (degree - 1,)
+        assert _bspline_multiplicity(reduced, 0.5) == degree
+
+        pts = np.linspace(0.0, 1.0, 97)[1:-1] + 1.0e-7
+        scale = float(np.max(np.abs(base.control_points)))
+        np.testing.assert_allclose(
+            reduced.evaluate(pts),
+            base.evaluate(pts),
+            rtol=0.0,
+            atol=_ROUND_TRIP_FACTOR * (degree + 1) * _EPS * scale,
+        )
+
+    def test_mixed_multiplicities_keep_their_continuity(self) -> None:
+        """A C^-1 knot alongside smooth and C^0 ones: each loses exactly the decrement."""
+        degree = 4
+        knots = np.concatenate(
+            [
+                np.zeros(degree + 1),
+                [0.25],
+                np.full(degree + 1, 0.5),
+                np.full(degree, 0.75),
+                np.ones(degree + 1),
+            ]
+        ).tolist()
+        rng = np.random.default_rng(4321)
+        n_basis = len(knots) - degree - 1
+        bsp = _make_bspline_1d(knots, degree, rng.standard_normal((n_basis, 2)).tolist())
+
+        reduced = bsp.reduce_degree(1)
+
+        assert reduced.degree == (3,)
+        assert _bspline_multiplicity(reduced, 0.25) == 1
+        assert _bspline_multiplicity(reduced, 0.5) == 4  # new_degree + 1: still a jump
+        assert _bspline_multiplicity(reduced, 0.75) == 3
+        space_1d = reduced.space.spaces[0]
+        assert reduced.control_points.shape[0] == space_1d.num_basis
+
+    def test_kernel_output_sizing_accounts_for_the_jumps(self) -> None:
+        """The Bézier form holds one extra control point and knot per C^-1 breakpoint."""
+        degree, dec = 3, 1
+        knots = np.concatenate(
+            [np.zeros(degree + 1), np.full(4, 0.3), [0.6], np.full(4, 0.8), np.ones(degree + 1)]
+        )
+        rng = np.random.default_rng(99)
+        n_basis = len(knots) - degree - 1
+        bsp = _make_bspline_1d(knots.tolist(), degree, rng.standard_normal((n_basis, 1)).tolist())
+
+        new_ctrl, new_knots = _degree_reduce_1d_core(
+            degree,
+            bsp.control_points,
+            bsp.space.spaces[0].knots,
+            dec,
+            _interpolating_reduction_operator(degree, dec),
+        )
+
+        new_degree = degree - dec
+        n_seg, n_jump = 4, 2
+        assert new_ctrl.shape[0] == n_seg * new_degree + 1 + n_jump
+        assert new_knots.shape[0] == new_ctrl.shape[0] + new_degree + 1
 
 
 class TestBsplineReduceDegreeErrors:

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -927,6 +927,39 @@ class TestBsplineReduceDegreeDiscontinuous:
         assert new_knots.shape[0] == new_ctrl.shape[0] + new_degree + 1
 
 
+class TestBsplineReduceDegreePeriodicSeam:
+    """The seam multiplicity is floored at 1, exactly as interior knots are."""
+
+    def test_maximally_smooth_periodic_spline_reduces(self) -> None:
+        """``m_bdy = 1`` used to ask for multiplicity 0 and fail on the knot vector.
+
+        The subtraction ``m_bdy - dec`` reaches 0 for a maximally smooth periodic
+        spline; multiplicity 0 means "no breakpoint at the seam", which the
+        periodic knot-vector builder cannot express.  Flooring at 1 asks for less
+        smoothness than the seam already has, which is always representable.
+        """
+        knots = create_uniform_periodic_knots(num_intervals=6, degree=2)
+        space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
+        rng = np.random.default_rng(14)
+        bsp = Bspline(space, rng.standard_normal((space.num_total_basis, 1)))
+
+        reduced = bsp.reduce_degree(1)
+
+        assert reduced.degree == (1,)
+        assert reduced.space.spaces[0].periodic
+        assert reduced.control_points.shape[0] == reduced.space.spaces[0].num_basis
+
+    def test_degree_one_still_rejects_the_degree_zero_periodic_result(self) -> None:
+        """Reducing to degree 0 stays rejected: no ghost knots, no periodic form."""
+        knots = create_uniform_periodic_knots(num_intervals=6, degree=1)
+        space = BsplineSpace([BsplineSpace1D(knots, 1, periodic=True)])
+        rng = np.random.default_rng(15)
+        bsp = Bspline(space, rng.standard_normal((space.num_total_basis, 1)))
+
+        with pytest.raises(ValueError, match=r"boundary multiplicity in \[1, degree\]"):
+            bsp.reduce_degree(1)
+
+
 class TestBsplineReduceDegreeErrors:
     """Test that invalid inputs raise appropriate errors."""
 

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -942,12 +942,21 @@ class TestBsplineReduceDegreePeriodicSeam:
         space = BsplineSpace([BsplineSpace1D(knots, 2, periodic=True)])
         rng = np.random.default_rng(14)
         bsp = Bspline(space, rng.standard_normal((space.num_total_basis, 1)))
+        assert _bspline_multiplicity(bsp, 0.0) == 1  # precondition: maximally smooth seam
 
         reduced = bsp.reduce_degree(1)
 
         assert reduced.degree == (1,)
         assert reduced.space.spaces[0].periodic
         assert reduced.control_points.shape[0] == reduced.space.spaces[0].num_basis
+        assert _bspline_multiplicity(reduced, 0.0) == 1  # floored, not 1 - 1 = 0
+        assert reduced.space.spaces[0].num_basis == 6
+
+        # It is an approximation, but a periodic one that stays near the original.
+        pts = np.linspace(0.01, 0.99, 61)
+        original = bsp.to_open_bspline().evaluate(pts)
+        got = reduced.to_open_bspline().evaluate(pts)
+        assert float(np.max(np.abs(got - original))) < 0.5 * float(np.max(np.abs(original)))
 
     def test_degree_one_still_rejects_the_degree_zero_periodic_result(self) -> None:
         """Reducing to degree 0 stays rejected: no ghost knots, no periodic form."""

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,13 +7,16 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Five markers have already come off here: the domain-membership test, closed by the
+Six markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
 truncating the rule where the endpoint gap stops being resolvable; the Lagrange
 reproducibility test, closed by seeding the barycentric node permutation; the float32
 degree-elevation test, closed by allocating the kernels' knot output in the input's dtype;
-and the periodic degree-reduction hang, closed by enforcing the periodic conversion's own
-boundary-multiplicity precondition. Four remain open.
+the periodic degree-reduction hang, closed by enforcing the periodic conversion's own
+boundary-multiplicity precondition; and the degree-elevation counter mismatch, closed by
+emitting the unshared Bézier coefficient at a C^-1 knot and by letting the segment sweep
+reach the final span of a degree-0 knot vector. Three remain open, all in the tolerance
+workstream.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -88,34 +91,32 @@ open; once fixed the call returns in milliseconds and the budget is never reache
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_degree_elevate_1d_core returns a knot vector and control points that "
-    "disagree once any interior knot has multiplicity degree + 1",
-)
 def test_degree_elevation_outputs_are_mutually_consistent() -> None:
-    # `_degree_elevate_1d_core` returns (control_points, knots), which are only usable
-    # together when `control_points.shape[0] == knots.size - new_degree - 1`. Those two
+    # FIXED, and kept as a regression guard with its original triggering data per this
+    # repository's convention that the fix PR un-xfails the tests it closes. It took two
+    # changes, not one: what looked like a single defect with two faces is two defects
+    # that happened to share a symptom.
+    #
+    # What it was: `_degree_elevate_1d_core` returns (control_points, knots), usable
+    # together only when `control_points.shape[0] == knots.size - new_degree - 1`. Those
     # come from counters `cind` and `kind` maintained independently through the
-    # Piegl-Tiller A5.9 walk and combined in a single return
-    # (`_bspline_degree_core.py:253`), and they diverge.
+    # Piegl-Tiller A5.9 walk, and they diverged by the number of interior knots at
+    # multiplicity degree + 1 (1, 2 and 3 such knots gave deficit 1, 2, 3, and raising the
+    # increment did not change it).
     #
-    # **Measured**: the deficit equals the number of interior knots at multiplicity
-    # degree + 1 (1, 2 and 3 such knots give deficit 1, 2, 3) and does not grow with the
-    # increment (an increment of 2 still gives deficit 1).
-    # **Inferred, not verified against the published algorithm**: A5.9 walks Bezier
-    # segments joined at interior knots of multiplicity at most `degree`, so adjacent
-    # segments share an endpoint; at multiplicity degree + 1 they share nothing and the
-    # shared point is subtracted anyway. Anyone fixing this should trace the `lbz`/`rbz`
-    # bookkeeping rather than take that sentence on trust.
+    # The mechanism the original note recorded as *inferred* is now traced and confirmed,
+    # for degree >= 1: `lbz` is the index of the first elevated Bezier coefficient a
+    # segment contributes, and it started at 1 because A5.9 assumes the previous segment
+    # already wrote the shared junction coefficient. At multiplicity degree + 1 the two
+    # segments share nothing, so coefficient 0 was dropped -- one control point per jump,
+    # while the knot writer emitted the correct `mul + t` knots.
     #
-    # Two faces, one cause:
-    #   * degree >= 1 -- the knot vector is right and the points are short, so
-    #     `Bspline.__init__` rejects the result with a message about the *caller's*
-    #     control-point count.
-    #   * degree 0 -- every interior knot has multiplicity 1 = degree + 1, so the whole
-    #     vector is pathological, both outputs come out short, the sizes agree by
-    #     accident, and the wrong answer is returned silently (see the second half).
+    # Degree 0 had a *second*, independent cause that the deficit arithmetic hid: the
+    # sweep ran `while b < m`, and for degree >= 1 the closing block of `degree + 1` equal
+    # knots lets the inner run scan reach `m` by itself. At degree 0 that block is a
+    # single knot, the scan cannot advance, and the last segment was never processed nor
+    # the closing knots written -- so the knot vector kept its trailing zeros and the
+    # domain collapsed to a point. Both halves below pin both fixes.
     for degree, mult in ((1, 2), (2, 3), (3, 4), (0, 1)):
         knots = np.concatenate(
             [np.full(degree + 1, 0.0), np.full(mult, 0.5), [0.75], np.full(degree + 1, 1.0)]
@@ -135,12 +136,17 @@ def test_degree_elevation_outputs_are_mutually_consistent() -> None:
         )
 
     # The silent face, entirely through public API: a degree-0 spline on [0, 1] with two
-    # control points comes back with a collapsed domain and a duplicated control point.
+    # control points came back with a collapsed domain and a duplicated control point.
     spline = _scalar_spline(np.array([0.0, 0.5, 1.0]), 0, [1.0, 2.0])
     elevated = spline.elevate_degree(1)
     elevated_knots = np.asarray(elevated.space.spaces[0].knots)
     assert elevated_knots[-1] > elevated_knots[0], (
         f"degree elevation collapsed the domain to a point: {elevated_knots.tolist()}"
+    )
+    # ... and it is still the same step function, off the jump.
+    pts = np.array([0.1, 0.4999, 0.5001, 0.9])
+    np.testing.assert_array_equal(
+        np.asarray(elevated.evaluate(pts)).ravel(), np.array([1.0, 1.0, 2.0, 2.0])
     )
 
 


### PR DESCRIPTION
Several operations that build a **new space of a different degree** computed its interior
multiplicities with a formula whose `≤ degree` assumption was never written down, so they
were silently wrong on a discontinuous (C⁻¹) spline — an interior knot at multiplicity
`degree + 1`, which `subdivide(n, regularity=-1)` produces as a documented feature.

The rule they all needed is one theorem, proved from Curry & Schoenberg (*J. Analyse
Math.* **17**, 1966; checked against Lyche & Mørken Thm 3.25 and Lyche–Manni–Speleers
Thm 13). With `s_f = p − m_f`, `+∞` when the breakpoint is absent from that operand:

```
h = f·g is C^{min(s_f, s_g)} at ξ,  and  m_h(ξ) = max{ m_f + q , m_g + p }
```

over the **present** operands only. It now lives in one place and is called per direction
by both the 1D and tensor-product paths.

## The one-line refutation this closes

```python
f = degree 1, knots [0,0,0.5,0.5,1,1], cp [1,2,3,4]   # C⁻¹ at 0.5
g = degree 1, knots [0,0,1,1],         cp [1,1]       # g == 1 identically
f.multiply(g)   #  differed from f by exactly 1.0 — the size of f's jump
```

The product space was built C⁰ where the function jumps, so it could not represent it and
continued the left branch instead. The knot vector now carries multiplicity 3 where the
theorem requires it, the control points come back exact, and `f · 1 == f`.

The same defect reached rational operands and the tensor-product path.

## Also fixed, and wider than the C⁻¹ case

**`derivative(keep_degree=True)` was broken for every C⁰-knotted spline** — the ordinary
Bézier-element mesh, not a corner case. It differentiates to `degree − 1` and elevates
back, so a standard multiplicity-`degree` knot is a multiplicity-`(degree−1)+1` knot in
the space the elevation kernel sees, and the kernel's two output counters diverge there.
On `main` this raises `ValueError` at degrees 2, 3 and 4; it now returns the derivative,
matching `evaluate_derivatives` to 1e-11. **This is the widest consequence of the branch
and nothing in the audit that produced it had noticed** — the existing fixtures all come
from maximally smooth knot factories, so no test built a C⁰ mesh and asked to keep the
degree.

**Degree elevation at degree 0** had a second, independent cause the deficit arithmetic
hid: the sweep relied on a closing block of `degree + 1` equal knots to terminate, and at
degree 0 that block is one knot, so the last segment and the closing knots were never
written. Silent, and it collapsed the domain to a point.

**Degree reduction** clamped the target multiplicity to `new_degree`, giving a C⁰ target
space where the function jumps; and the periodic seam multiplicity was not floored the way
the interior three lines away already was.

## Minimality — a measurable win in the ordinary continuous case

The old formula was not only wrong at C⁻¹, it was **not minimal** anywhere the operands sit
on different meshes. Control-point count now drops **20-45%** there (degree 4 × 1 with 32
and 8 elements: 161 → 89; 5 × 2: 218 → 122), and by 0% when the operands share a knot
vector, exactly as the formula predicts.

## Measured against the sweep

The repository's adversarial sweep, full profile, before from a clean checkout of the base
commit:

| | before | after |
|---|---|---|
| total findings | 771 | **496** |
| `multiply` | 194 | **56** |
| `elevate_degree` | 156 | **18** |

**276 labels went from BUG to non-BUG with zero regressions.** `reduce_degree` rises from 3
to 4 because the elevation fix *unlocks 72 cases the probe could not previously generate*
(it only builds a reducible curve when the elevation succeeds); 71 of the 72 pass.

34 `multiply` findings remain, all root-caused to a single pre-existing line outside this
change's scope — unique-knot detection returns tolerance-grid-rounded values rather than
the knots themselves, so a product breakpoint lands 1 ulp from its operand's and the two
resolve opposite sides of a jump. Changing it takes those 34 to 2, but it is a shared
Layer-3 kernel with 29 call sites and the balance is +61 fixed / −8 new, so it belongs to
the tolerance work rather than here.

## Verification

`ruff`, `ruff format`, `mypy`, `import-lint`, the docs build under `-W`, and the gated
adversarial sweep on a cold Numba cache: all clean. **5245 passed, 21 skipped, 3 xfailed**
against a baseline of 5155 / 21 / 4. Both reviewers independently re-derived the output
sizing of the two rewritten kernels and swept them under `NUMBA_BOUNDSCHECK=1` at degrees
0-5 with up to three jumps: no out-of-bounds.

The downstream consumer imports none of the symbols touched here and uses none of these
entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
