### PR TITLE
test(tools): triage the sweep into twelve mechanisms, and make its verdicts mean the same thing everywhere

### DIFF
--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -52,6 +52,7 @@ from pantr.bspline import (
     find_roots,
 )
 from pantr.bspline._bspline_degree_core import _degree_elevate_1d_core
+from pantr.change_basis import compute_cardinal_to_bernstein_1d
 from pantr.quad import get_tanh_sinh_1d
 from pantr.tolerance import get_machine_epsilon
 
@@ -811,3 +812,65 @@ def test_lagrange_extraction_handles_a_degree_zero_space() -> None:
         f"degree-0 Lagrange extraction returned shape {lagrange.shape}, expected one "
         f"1x1 identity per element"
     )
+
+
+# ---------------------------------------------------------------------------
+# The cardinal change of basis raises a bare LinAlgError on a legal degree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="the cardinal change-of-basis builders raise numpy's LinAlgError on a legal "
+    "(degree, dtype) pair, an exception type none of them documents and which the caller "
+    "cannot tell apart from an illegal argument",
+)
+def test_cardinal_change_of_basis_reports_its_own_conditioning_limit() -> None:
+    # Found only because the August 2026 triage completed the sweep's verdict flags: with
+    # no `must_succeed`, this read as an UNDOCUMENTED_REJECTION -- a suspicion nobody had
+    # looked at -- because `numpy.linalg.LinAlgError` subclasses `ValueError` and the
+    # runner's `Raises:`-driven rule cannot see that the *reason* is undocumented. Five
+    # `basis` cases and fifteen `bspline` extraction cases are this one cause.
+    #
+    # The numerics are not in dispute. The cardinal-to-Bernstein matrix's condition number
+    # grows like 4 ** degree; measured with `numpy.linalg.cond` on the returned matrix it
+    # is 15 at degree 3, 3.5e10 at degree 10, 1.2e21 at degree 20 and 5.2e32 at degree 30,
+    # while float32 can resolve at most 1 / eps = 8.4e6. So at high degree in float32 the
+    # inverse genuinely cannot be formed, and refusing is right.
+    #
+    # What is wrong is the contract. Every one of these builders documents exactly one
+    # exception -- "ValueError: If degree is negative, dtype is not float32 or float64, or
+    # if `out` is provided and has incorrect shape or dtype" -- and then, for a degree that
+    # is not negative and a dtype that is float32, raises `LinAlgError: Singular matrix`
+    # from three frames down. The caller is told nothing about a degree limit, cannot
+    # discover one from the signature, and gets a message that describes an internal matrix
+    # rather than the argument that caused it. Either the limit belongs in the docstring
+    # with a `ValueError` that names it, or `LinAlgError` belongs in `Raises:`.
+    #
+    # The threshold measured on this machine, for `compute_cardinal_to_bernstein_1d`:
+    #
+    #   float32   degree 3, 10, 15, 20, 25, 30 -> returns    degree 40, 62 -> LinAlgError
+    #   float64   degree 3 ... 62              -> returns
+    #
+    # so the assertion below uses float32 at degree 62, well past the cliff, and pins
+    # float64 alongside it to keep the failure attributable to precision rather than to
+    # degree alone.
+    degree = 62
+
+    # float64 handles the same degree, so this is a precision limit and not a degree one.
+    reference = np.asarray(compute_cardinal_to_bernstein_1d(degree, np.float64))
+    assert reference.shape == (degree + 1, degree + 1)
+
+    try:
+        matrix = compute_cardinal_to_bernstein_1d(degree, np.float32)
+    except ValueError as exc:
+        # `LinAlgError` is a `ValueError` subclass, so this catches both. The distinction
+        # the test insists on is the one the caller has to make: a message naming the
+        # argument at fault, not numpy's internal one.
+        assert "Singular matrix" not in str(exc), (
+            f"compute_cardinal_to_bernstein_1d({degree}, float32) raised numpy's "
+            f"{type(exc).__name__}: {exc} -- the documented ValueError should name the "
+            f"degree or the precision, and `Raises:` should list whatever is thrown"
+        )
+        raise
+    assert np.asarray(matrix).shape == (degree + 1, degree + 1)

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -15,8 +15,13 @@ degree-elevation test, closed by allocating the kernels' knot output in the inpu
 the periodic degree-reduction hang, closed by enforcing the periodic conversion's own
 boundary-multiplicity precondition; and the degree-elevation counter mismatch, closed by
 emitting the unshared Bézier coefficient at a C^-1 knot and by letting the segment sweep
-reach the final span of a degree-0 knot vector. Three remain open, all in the tolerance
-workstream.
+reach the final span of a degree-0 knot vector.
+
+Six remain open. Three are the tolerance workstream's. The other three come from the
+August 2026 triage of the full profile's 496 findings, which collapsed them into a
+handful of mechanisms: a root finder that returns a value that is not a root, a
+restriction that silently returns a shorter domain than it was asked for, and a Lagrange
+extraction that cannot be built on a degree-0 space its two sibling extractions handle.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -44,6 +49,7 @@ from pantr.bspline import (
     BsplineSpace1D,
     create_uniform_open_knots,
     create_uniform_periodic_knots,
+    find_roots,
 )
 from pantr.bspline._bspline_degree_core import _degree_elevate_1d_core
 from pantr.quad import get_tanh_sinh_1d
@@ -601,3 +607,207 @@ def test_reduce_degree_terminates_on_a_periodic_linear_spline() -> None:
     reduced = spline.to_open_bspline().reduce_degree(1)
     assert reduced.degree[0] == 0
     assert not reduced.space.spaces[0].periodic
+
+
+# ---------------------------------------------------------------------------
+# The root finder certifies a value that is not a root
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="find_roots accepts a _STATUS_CONVERGED iterate without ever checking its "
+    "residual, so a coincidentally-near-zero intermediate coefficient is certified as a "
+    "root",
+)
+def test_find_roots_returns_only_genuine_roots() -> None:
+    # The most serious finding of the August 2026 triage: `find_roots` returns a
+    # parameter at which the spline is not zero, silently, through the public API, on a
+    # perfectly ordinary clamped cubic on the unit domain. Nothing warns.
+    #
+    # The data below is a degree-3 clamped uniform spline on [0, 1] with four intervals
+    # and control points alternating +1/-1. It has exactly six sign changes. `find_roots`
+    # returns six values; four of them are roots to 1e-16, and two -- 0.375 and 0.625 --
+    # are not roots at all. The true zeros nearest them are at 0.369 and 0.630995, so the
+    # returned values are off by about 0.006 in the parameter and leave a residual of
+    # 0.0208 on a curve whose values are bounded by 1.
+    #
+    # The mechanism, traced through a line-for-line pure-Python mirror of
+    # `_bspline_roots_core.py` that reproduces the same wrong roots bit for bit:
+    # `_track_zero` treats a repeated iterate (`x == previous_x`) as a certificate of
+    # convergence, per Morken-Reimers Lemma 13/Corollary 14, and `_morken_reimers_roots`
+    # then gates acceptance on
+    #
+    #     accepted = residual <= zero_tol if status == _STATUS_CANDIDATE else True
+    #
+    # so for `_STATUS_CONVERGED` the residual is hard-coded to 0.0 and never compared
+    # against the actual function value. Here the first secant estimate lands on 0.375, a
+    # single Boehm insertion there produces a control coefficient that is exactly 0.0 for
+    # an algebraic reason (the symmetric alternating coefficients on exact rational
+    # Greville abscissae), the next iterate is therefore 0.375 again, and the fixed-point
+    # test fires after one step -- far from convergence. That is a theorem valid in exact
+    # arithmetic applied to a floating-point iteration where a coefficient can reach zero
+    # for reasons unrelated to being near a root.
+    #
+    # Distinct from the fabricated root closed in #291, which guarded the
+    # `x >= knots[index + degree]` branch at a C^-1 knot of multiplicity degree + 1. This
+    # knot vector has only simple interior knots and never reaches that branch.
+    #
+    # It is not a tolerance artifact and does not scale away: the same construction on
+    # [0, 5] returns 3.125 with the same residual 0.0208 against a true zero at
+    # 3.154997195131751.
+    degree = 3
+    knots = np.array([0.0, 0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0])
+    spline = _scalar_spline(knots, degree, [1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0])
+
+    roots = np.asarray(find_roots(spline), dtype=np.float64).ravel()
+    assert roots.size, "precondition: the sign-alternating spline has roots to find"
+
+    # The bound is the two terms a returned root may legitimately carry, and nothing
+    # else. Evaluation: de Boor over `degree + 1` stages on coefficients of magnitude 1,
+    # so `4 * eps`. Location: `find_roots` documents `tol` as a *parametric* tolerance
+    # defaulting to `get_strict(float64) = 1e-15`, and a root located to `dt` leaves
+    # `|f'| * dt`; the hodograph bounds `|f'|` by `degree * max|delta c| / h_min`
+    # = 3 * 2 / 0.25 = 24, and the documented stopping scale here is the domain length 1.
+    # A safety factor of 8 covers the unmodelled constants of both, as elsewhere in this
+    # suite. The result is 3.1e-13, against an observed residual of 2.1e-2 -- eleven
+    # orders of magnitude, so no reasonable sharpening of this bound changes the verdict.
+    eps = get_machine_epsilon(np.float64)
+    slope_bound = degree * 2.0 / 0.25
+    bound = 8.0 * ((degree + 1) * eps + slope_bound * 1e-15)
+    residuals = np.abs(np.asarray(spline.evaluate(roots), dtype=np.float64).ravel())
+    worst = float(np.max(residuals))
+    assert worst <= bound, (
+        f"find_roots returned {roots.tolist()}; |f| there is {residuals.tolist()}, "
+        f"and the largest exceeds the derived bound {bound:.3e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Restriction silently returns a shorter domain than it was asked for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="restrict adds an absolute 1e-15 to the upper bound to step past its last "
+    "copy, and that addition is a no-op once the bound reaches 16, so searchsorted "
+    "lands one clamp too early and the top of the window is cut off",
+)
+def test_restrict_spans_the_requested_window() -> None:
+    # A silent wrong answer through the public API, and the reason it stayed hidden is
+    # worth as much as the bug: `Bspline.restrict` carried no invariant in the sweep, so
+    # the case was graded only on whether it raised.
+    #
+    # `_restrict_bspline_impl` (`_bspline_restrict.py`, the extraction step) locates the
+    # end of the restricted knot vector with
+    #
+    #     i_end = int(np.searchsorted(refined_knots, b_new + tol)) - 1
+    #
+    # The `+ tol` exists to step past the last of the `degree + 1` copies of `b_new` that
+    # the preceding insertion produced. But `tol` is the space's *absolute* tolerance,
+    # `get_strict(float64) = 1e-15`, and `b_new + 1e-15 == b_new` exactly once half an ulp
+    # of `b_new` exceeds 1e-15 -- which is at `|b_new| = 16`, since ulp(x) is 1.78e-15 on
+    # [8, 16) and 3.55e-15 on [16, 32). Past that the search finds the *first* copy
+    # instead of one past the last, and `degree + 1` knots are dropped from the top.
+    #
+    # The threshold is exact and was bisected: on [0, span] with four intervals and the
+    # window at 25%/75%, span 20 (upper bound 15) is correct and span 24 (upper bound 18)
+    # is not.
+    #
+    # Two faces, and only the loud one was visible before:
+    #   * few intervals  -- the truncated vector falls below `2 * degree + 2` and
+    #     `BsplineSpace1D` raises "knots must have at least 2*degree+2 elements", blaming
+    #     the knot count for an index computed one place too low. 30 sweep findings.
+    #   * many intervals -- enough knots survive, and the call *returns a spline over the
+    #     wrong domain*. This is the half the test pins first.
+    #
+    # Attribution: this is the absolute-tolerance-versus-coordinate-magnitude family that
+    # already owns two open tests in this file, so the fix belongs with that workstream.
+    # It is recorded separately because the site and the failure mode are different --
+    # index arithmetic on a knot search, not a snapping merge -- and because a correction
+    # to `_snap_knots` would not touch it.
+    degree = 2
+    span = 100.0
+    n_intervals = 20
+    breaks = np.linspace(0.0, span, n_intervals + 1)
+    knots = np.concatenate([np.full(degree, 0.0), breaks, np.full(degree, span)])
+    space = BsplineSpace1D(knots, degree)
+    n_basis = space.num_basis
+    curve = Bspline(
+        BsplineSpace([space]), np.linspace(0.0, 1.0, n_basis, dtype=np.float64).reshape(-1, 1)
+    )
+
+    lower, upper = 0.25 * span, 0.75 * span
+    assert upper > 16.0, "precondition: the upper bound is past the 16.0 threshold"
+
+    restricted = curve.restrict((lower, upper))
+    restricted_knots = np.asarray(restricted.space.spaces[0].knots, dtype=np.float64)
+    got_upper = float(restricted_knots[restricted_knots.size - degree - 1])
+    # The endpoints are exactly representable here (25.0 and 75.0 are dyadic), so this is
+    # an equality, not a tolerance.
+    assert got_upper == upper, (
+        f"restrict((({lower}, {upper}))) returned a domain ending at {got_upper}, "
+        f"{upper - got_upper} short of the window that was asked for"
+    )
+
+    # The loud face, on the same mechanism with fewer intervals: the truncated vector is
+    # too short and the constructor blames the caller's knot count.
+    coarse_breaks = np.linspace(0.0, span, 5)
+    coarse_knots = np.concatenate([np.full(degree, 0.0), coarse_breaks, np.full(degree, span)])
+    coarse_space = BsplineSpace1D(coarse_knots, degree)
+    coarse_n = coarse_space.num_basis
+    coarse = Bspline(
+        BsplineSpace([coarse_space]),
+        np.linspace(0.0, 1.0, coarse_n, dtype=np.float64).reshape(-1, 1),
+    )
+    coarse_restricted = coarse.restrict((lower, upper))
+    assert coarse_restricted.space.spaces[0].num_basis > 0
+
+
+# ---------------------------------------------------------------------------
+# Lagrange extraction is the only one of the three that a degree-0 space defeats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="tabulate_Lagrange_extraction_operators reaches a change-of-basis builder "
+    "that requires degree >= 1, while the Bezier and cardinal extractions of the same "
+    "degree-0 space both succeed",
+)
+def test_lagrange_extraction_handles_a_degree_zero_space() -> None:
+    # A degree-0 `BsplineSpace1D` is legal -- the constructor accepts it, and it is what
+    # `subdivide(n, regularity=-1)` produces -- and two of its three extraction operators
+    # are perfectly happy with it. The third is not: it reaches
+    # `compute_lagrange_to_bernstein_1d`, whose documented precondition is "Must be at
+    # least 1", and the `ValueError` that surfaces ("Degree must at least 1", the
+    # message's own grammar) names a degree the caller never passed.
+    #
+    # This is a contract inconsistency rather than a numerical defect: the extraction of
+    # a piecewise-constant space is well defined -- the Lagrange basis of degree 0 is the
+    # single constant function 1, so every element operator is the 1x1 identity -- and
+    # nothing about the mathematics forces a refusal. Either the operator should be that
+    # identity, or `tabulate_Lagrange_extraction_operators` should document a degree
+    # floor its two siblings do not have. It does neither.
+    #
+    # 22 of the sweep's findings are this, spread across both dtypes and every domain, and
+    # they are all one cause: `degree == 0`. (A 23rd finding on the same entry point at
+    # degree 62 in float32 is *not* this mechanism -- it is the float32 knot-collapse
+    # already pinned by `test_snapping_keeps_knots_the_format_can_resolve` -- which is why
+    # the assertion below is at degree 0 only.)
+    space = BsplineSpace1D(np.array([0.0, 0.25, 0.5, 0.75, 1.0]), 0)
+    assert space.num_intervals == 4, "precondition: four piecewise-constant elements"
+
+    # The two that work, asserted first so a regression in them cannot be mistaken for
+    # this bug.
+    bezier = np.asarray(space.tabulate_Bezier_extraction_operators())
+    assert bezier.shape == (4, 1, 1)
+    cardinal = np.asarray(space.tabulate_cardinal_extraction_operators())
+    assert cardinal.shape[0] == 4
+
+    lagrange = np.asarray(space.tabulate_Lagrange_extraction_operators())
+    assert lagrange.shape == (4, 1, 1), (
+        f"degree-0 Lagrange extraction returned shape {lagrange.shape}, expected one "
+        f"1x1 identity per element"
+    )

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -17,11 +17,13 @@ boundary-multiplicity precondition; and the degree-elevation counter mismatch, c
 emitting the unshared Bézier coefficient at a C^-1 knot and by letting the segment sweep
 reach the final span of a degree-0 knot vector.
 
-Six remain open. Three are the tolerance workstream's. The other three come from the
-August 2026 triage of the full profile's 496 findings, which collapsed them into a
-handful of mechanisms: a root finder that returns a value that is not a root, a
-restriction that silently returns a shorter domain than it was asked for, and a Lagrange
-extraction that cannot be built on a degree-0 space its two sibling extractions handle.
+Eight remain open. Three are the tolerance workstream's. The other five come from the
+August 2026 triage of the full profile's 496 findings, which collapsed them into a dozen
+mechanisms: a root finder that certifies a value that is not a root, a restriction that
+silently returns a shorter domain than it was asked for, a Lagrange extraction that cannot
+be built on a degree-0 space its two sibling extractions handle, a change of basis that
+reports numpy's `LinAlgError` for a legal degree, and a unique-knot accessor that returns
+knots the space does not contain.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -671,8 +673,8 @@ def test_find_roots_returns_only_genuine_roots() -> None:
     # `|f'| * dt`; the hodograph bounds `|f'|` by `degree * max|delta c| / h_min`
     # = 3 * 2 / 0.25 = 24, and the documented stopping scale here is the domain length 1.
     # A safety factor of 8 covers the unmodelled constants of both, as elsewhere in this
-    # suite. The result is 3.1e-13, against an observed residual of 2.1e-2 -- eleven
-    # orders of magnitude, so no reasonable sharpening of this bound changes the verdict.
+    # suite. The result is 1.99e-13, against an observed residual of 2.1e-2 -- a factor of
+    # 1.05e11, so no reasonable sharpening of this bound changes the verdict.
     eps = get_machine_epsilon(np.float64)
     slope_bound = degree * 2.0 / 0.25
     bound = 8.0 * ((degree + 1) * eps + slope_bound * 1e-15)
@@ -874,3 +876,74 @@ def test_cardinal_change_of_basis_reports_its_own_conditioning_limit() -> None:
         )
         raise
     assert np.asarray(matrix).shape == (degree + 1, degree + 1)
+
+
+# ---------------------------------------------------------------------------
+# The unique-knot accessor returns knots the space does not contain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_get_unique_knots_and_multiplicity_impl returns the tolerance-grid-rounded "
+    "knots instead of the originals it already indexed, so a breakpoint is relocated "
+    "whenever the absolute grid is coarse relative to the knot spacing",
+)
+def test_unique_knots_are_knots_of_the_space() -> None:
+    # `get_unique_knots_and_multiplicity` is meant to *report* the distinct knots of a
+    # space. It reports different numbers. On a float32 space over [0, 1e-6] whose stored
+    # interior knots are 2.5e-7, 5.0e-7 and 7.5e-7, the accessor answers 2.0e-7, 5.0e-7
+    # and 8.0e-7 -- each moved by 20% of its own value, to a knot the space does not have.
+    #
+    # `_get_unique_knots_and_multiplicity_impl` (`_bspline_knots.py:107-110, 138`) rounds
+    # onto a grid of width `tol` to decide which knots are the same,
+    #
+    #     scale = dtype.type(1.0 / tol)
+    #     rounded_knots = np.round(knots * scale) / scale
+    #
+    # and then returns `rounded_knots[unique_rounded_knots_ids]` -- the rounded values --
+    # although `unique_rounded_knots_ids` already indexes the *original* array and
+    # `knots[...]` would have returned the knots themselves. Its sibling `_snap_knots`
+    # (`_bspline_space_1d.py:207-218`) does the same grouping and deliberately does not
+    # make this mistake: it writes back `np.mean(self._knots[mask])`, with a comment about
+    # the care being taken. The two helpers implement one idea and disagree.
+    #
+    # `tol` here is the space's absolute tolerance (`get_strict(float32) = 1e-7`), so the
+    # grid is coarse compared with a 2.5e-7 spacing and 2.5 rounds to 2 while 7.5 rounds
+    # to 8. Nothing about the input is unrepresentable: the float32 ulp at 2.5e-7 is
+    # 1.7e-14, seven orders of magnitude finer than the movement.
+    #
+    # The float64 face is milder and still wrong: 2.5e-07 comes back as
+    # 2.5000000000000004e-07, because `round(x * scale) / scale` is not the identity even
+    # when the grouping changes nothing. The accessor never returns the array it was
+    # given.
+    #
+    # Consequences, and why this outranks a reporting nuisance. The helper feeds
+    # `to_beziers`, knot insertion and removal, quasi-interpolation, and the product's
+    # breakpoint mesh. The last is what the sweep found: `Bspline.multiply` builds the
+    # product knot vector from these relocated breakpoints, so squaring a degree-2 float32
+    # spline on [0, 1e-6] returns a curve whose interior knots sit at 0.2/0.5/0.8 of the
+    # domain instead of 0.25/0.5/0.75, and which is wrong by 8.0e-2 *relative* at points
+    # nowhere near a knot. Silent, through the public API. The same operands in float64,
+    # and the same float32 operands on the unit domain, are exact to rounding -- so this
+    # is the absolute-tolerance-versus-coordinate-magnitude family, and belongs with that
+    # workstream rather than being fixed here.
+    #
+    # Found only after the probe's product invariant stopped sampling at the C^-1
+    # breakpoint: the 8% error had been sitting underneath a 15-40% artifact.
+    hi = 1e-6
+    knots = np.array([0.0, 0.0, 0.0, 0.25 * hi, 0.5 * hi, 0.75 * hi, hi, hi, hi], dtype=np.float32)
+    space = BsplineSpace1D(knots, 2)
+    stored = np.asarray(space.knots, dtype=np.float64)
+    assert np.array_equal(np.asarray(space.knots), knots), (
+        "precondition: construction leaves these knots alone -- they do not share a "
+        "snapping cell, so this is not the already-pinned `_snap_knots` merge"
+    )
+
+    unique, _ = space.get_unique_knots_and_multiplicity(in_domain=True)
+    reported = np.asarray(unique, dtype=np.float64)
+    missing = [float(x) for x in reported if not np.any(stored == np.float32(x))]
+    assert not missing, (
+        f"get_unique_knots_and_multiplicity reported {reported.tolist()}, which contains "
+        f"{missing} -- values that are not knots of the space {np.unique(stored).tolist()}"
+    )

--- a/tools/adversarial_sweep/_axes.py
+++ b/tools/adversarial_sweep/_axes.py
@@ -18,8 +18,27 @@ from typing import TYPE_CHECKING, Final, NamedTuple
 
 import numpy as np
 
+from pantr.basis import LagrangeVariant
+
 if TYPE_CHECKING:
     import numpy.typing as npt
+
+
+LAGRANGE_MIN_NODES: Final[dict[LagrangeVariant, int]] = {
+    LagrangeVariant.EQUISPACES: 1,
+    LagrangeVariant.GAUSS_LEGENDRE: 1,
+    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: 2,
+    LagrangeVariant.CHEBYSHEV_1ST: 1,
+    LagrangeVariant.CHEBYSHEV_2ND: 2,
+}
+"""Smallest node count each Lagrange variant's underlying quadrature rule accepts.
+
+The floor is the ``min_pts`` of the rule ``_basis_lagrange._get_lagrange_points``
+(``_basis_lagrange.py:90-103``) dispatches to, and it is a *library* fact rather than a
+swept axis, which is why it lives here rather than in one probe module: both the
+``basis`` and ``quad`` groups need it to decide whether a given node count is legal, and
+two copies of a contract table drift.
+"""
 
 
 class Profile(enum.IntEnum):

--- a/tools/adversarial_sweep/_axes.py
+++ b/tools/adversarial_sweep/_axes.py
@@ -41,6 +41,24 @@ two copies of a contract table drift.
 """
 
 
+EXTRAPOLATION_POINT_FAMILIES: Final = frozenset(
+    {"just_outside_right", "just_outside_left", "far_outside", "just_outside"}
+)
+"""Point families from :func:`point_specs` that deliberately sit outside the domain.
+
+Every polynomial basis in this library extrapolates rather than refusing or clamping, and
+a Bernstein or Cox-de Boor value grows like ``O(t ** degree)`` off the domain, so at a
+fixed out-of-domain parameter a high enough degree overflows the format before any
+implementation defect is involved -- ``float32`` at degree 62 does, and that is arithmetic,
+not a bug. So the automatic finiteness check is switched off for these families rather than
+asserted and then explained away. Shape and crash safety are still graded, and every
+invariant a docstring actually claims still applies.
+
+The families are named rather than derived because ``PointSpec.finite`` says something
+different -- whether the *input* contains ``NaN``/``inf`` -- and conflating the two would
+switch off the check for the wrong cases."""
+
+
 class Profile(enum.IntEnum):
     """How wide to open each axis."""
 

--- a/tools/adversarial_sweep/_core.py
+++ b/tools/adversarial_sweep/_core.py
@@ -562,6 +562,16 @@ bytecode boundary, so it interrupts a hang in a Layer-2 Python loop but **not** 
 a compiled ``nopython`` kernel, which does not return to the interpreter. A kernel that
 spins forever still hangs the sweep, and the progress line printed before each case is
 what identifies it.
+
+**The same limitation makes a slow *library* call indistinguishable from a hang, and a
+reader must not read a timeout as non-termination.** A long-running call into LAPACK or any
+other C extension does not return to the interpreter either, so both attempts run to
+completion and the retry that separates "slow" from "stuck" everywhere else cannot separate
+them here. Measured: ``Bspline.multiply`` on a degree-62 periodic spline reaches a dense
+``numpy.linalg.lstsq`` over the product space at degree 124 and **returns after 78 s**,
+having been reported as "did not terminate, on two attempts". It is slow, not stuck. Before
+recording a timeout as a hang, re-run the case with a generous budget and a
+``faulthandler`` traceback and see where it actually sits.
 """
 
 

--- a/tools/adversarial_sweep/_probes_basis.py
+++ b/tools/adversarial_sweep/_probes_basis.py
@@ -11,6 +11,17 @@ conditioning allows -- rather than raw memory corruption (that lives in the
 62, the exact cliff where ``_bincoeff``'s integer recurrence wraps int64), and
 every evaluation-point family from :func:`~_axes.point_specs` is exercised,
 including the ones that deliberately sit outside ``[0, 1]`` or carry ``NaN``.
+
+**Verdict flags.** Every case carries ``must_succeed`` or ``must_reject`` unless the
+contract genuinely admits both, and the exceptions say why at the site. The decision is
+easy for this group and worth stating once: the only precondition any tabulator states is
+``degree >= 0`` (plus a valid ``out``), and **no entry point here documents a domain for
+its evaluation points at all** -- Layer 1 is silent, and the one Layer-3 kernel that does
+make a domain claim, ``_tabulate_cardinal_Bspline_basis_1D_core``'s "Values are zero
+outside [0, 1]" (``_basis_core.py:309-310``), is contradicted by the kernel itself, which
+extrapolates. So an out-of-domain or ``NaN`` point is not an illegal input, it is an
+unspecified one: the call must still *return*, and what it returns is graded by the
+finiteness check and nothing stronger.
 """
 
 from __future__ import annotations
@@ -43,7 +54,7 @@ from pantr.change_basis import (
 )
 from pantr.quad import PointsLattice
 
-from ._axes import Profile, degrees, dtypes, point_specs, rng
+from ._axes import LAGRANGE_MIN_NODES, Profile, degrees, dtypes, point_specs, rng
 from ._core import Case, custom, expected_shape, partition_of_unity
 
 if TYPE_CHECKING:
@@ -147,6 +158,11 @@ def _tabulate_1d_cases(
                         invariants.append(partition_of_unity(degree, dtype))
                     if claims_nonneg:
                         invariants.append(_bernstein_nonneg())
+                # `degree >= 0` is the only precondition stated, and the swept degrees
+                # are all non-negative. The point family does not change the verdict:
+                # no tabulator documents a domain for `pts`, so an out-of-domain or
+                # `NaN` point is unspecified rather than illegal, and refusing one
+                # would be an undocumented rejection. See the module docstring.
                 yield Case(
                     GROUP,
                     f"{name}_1d_deg{degree}_{spec.name}_{np.dtype(dtype).name}",
@@ -155,6 +171,7 @@ def _tabulate_1d_cases(
                     {"degree": degree, "dtype": dtype, "points": spec.name},
                     invariants=tuple(invariants),
                     finite_inputs=spec.finite,
+                    must_succeed=True,
                 )
 
 
@@ -171,15 +188,20 @@ def _tabulate_1d_extra_cases(
     Yields:
         Case: One hostile call outside the ``(degree, point-family)`` grid.
     """
+    # "Must be non-negative", with a matching `Raises: ValueError` on every tabulator.
     yield Case(
         GROUP,
         f"{name}_1d_degree_negative",
         func,
         lambda func=func: func(-1, [0.2, 0.5]),
         {"degree": -1, "kind": "invalid-degree"},
+        must_reject=True,
     )
     if profile is not Profile.FULL:
         return
+    # All three below are shapes the `pts` docstring explicitly admits: "Can be a
+    # scalar, list, or numpy array" and "Types different from float32 or float64 are
+    # automatically converted to float64".
     yield Case(
         GROUP,
         f"{name}_1d_scalar_point",
@@ -187,6 +209,7 @@ def _tabulate_1d_extra_cases(
         lambda func=func: func(2, 0.4),
         {"degree": 2, "kind": "scalar-point"},
         invariants=(expected_shape((3,)),),
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -195,6 +218,7 @@ def _tabulate_1d_extra_cases(
         lambda func=func: func(2, np.array([[0.4]])),
         {"degree": 2, "kind": "shape-1x1-points"},
         invariants=(expected_shape((1, 1, 3)),),
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -203,18 +227,8 @@ def _tabulate_1d_extra_cases(
         lambda func=func: func(2, np.array([0, 1], dtype=np.int64)),
         {"degree": 2, "kind": "int-points-auto-cast"},
         invariants=(expected_shape((2, 3)),),
+        must_succeed=True,
     )
-
-
-_LAGRANGE_VARIANT_MIN_NPTS: Final[dict[LagrangeVariant, int]] = {
-    LagrangeVariant.EQUISPACES: 1,
-    LagrangeVariant.GAUSS_LEGENDRE: 1,
-    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: 2,
-    LagrangeVariant.CHEBYSHEV_1ST: 1,
-    LagrangeVariant.CHEBYSHEV_2ND: 2,
-}
-"""Minimum ``degree + 1`` (node count) each Lagrange variant's underlying
-quadrature rule accepts (`_basis_lagrange.py:31-32`)."""
 
 
 def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
@@ -229,7 +243,7 @@ def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
     variants = tuple(LagrangeVariant) if profile is Profile.FULL else (LagrangeVariant.EQUISPACES,)
     for degree in _capped(degrees(profile), 2, profile):
         for variant in variants:
-            if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+            if degree + 1 < LAGRANGE_MIN_NODES[variant]:
                 continue
             for dtype in dtypes(profile):
                 specs = _capped(point_specs(_UNIT_DOMAIN, dtype, profile), 1, profile)
@@ -245,6 +259,7 @@ def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
                         {"degree": degree, "variant": variant, "dtype": dtype, "points": spec.name},
                         invariants=(expected_shape((*spec.pts.shape, degree + 1)),),
                         finite_inputs=spec.finite,
+                        must_succeed=True,
                     )
     yield Case(
         GROUP,
@@ -252,6 +267,7 @@ def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
         tabulate_lagrange_1d,
         lambda: tabulate_lagrange_1d(-1, LagrangeVariant.EQUISPACES, [0.2, 0.5]),
         {"degree": -1, "kind": "invalid-degree"},
+        must_reject=True,
     )
 
 
@@ -302,7 +318,10 @@ def _lagrange_cardinality_cases(profile: Profile) -> Iterator[Case]:
     variants = tuple(LagrangeVariant) if profile is Profile.FULL else (LagrangeVariant.EQUISPACES,)
     for degree in _capped(degrees(profile), 2, profile):
         for variant in variants:
-            if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+            # Not merely a filter: `_get_lagrange_points` runs in this generator
+            # *body*, so a variant below its own node floor would raise during
+            # enumeration and truncate the run rather than being classified.
+            if degree + 1 < LAGRANGE_MIN_NODES[variant]:
                 continue
             for dtype in dtypes(profile):
                 nodes = _get_lagrange_points(variant, degree + 1, dtype)
@@ -315,6 +334,9 @@ def _lagrange_cardinality_cases(profile: Profile) -> Iterator[Case]:
                     ),
                     {"degree": degree, "variant": variant, "dtype": dtype, "kind": "cardinality"},
                     invariants=(_lagrange_cardinality_invariant(degree, dtype),),
+                    # The nodes came out of `_get_lagrange_points` for this very
+                    # variant and count, so they are in-domain by construction.
+                    must_succeed=True,
                 )
 
 
@@ -447,6 +469,8 @@ def _nd_wrapper_cases(
                 invariants.append(partition_of_unity(n_basis - 1, dtype))
             if claims_nonneg:
                 invariants.append(_bernstein_nonneg())
+            # Non-negative degrees, one per direction, and points of matching
+            # dimension inside the unit cube: every stated precondition is met.
             yield Case(
                 GROUP,
                 f"{name}_nd_deg{degrees_tuple}_{np.dtype(dtype).name}",
@@ -454,6 +478,7 @@ def _nd_wrapper_cases(
                 lambda call=call, degrees_tuple=degrees_tuple, pts=pts: call(degrees_tuple, pts),
                 {"degrees": degrees_tuple, "dtype": dtype},
                 invariants=tuple(invariants),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
@@ -465,6 +490,14 @@ def _nd_wrapper_cases(
     pts = _scattered_points(2, dtype, generator)
 
     empty_pts = np.zeros((3, 0), dtype=dtype)
+    # Deliberately unflagged: a zero-dimensional tabulation is a genuine contract
+    # boundary. No docstring in this module says whether an empty `degrees` is legal,
+    # and there is a defensible answer either way -- the empty tensor product is the
+    # single constant function 1, or a basis needs at least one direction. What the
+    # code does is reject it from Layer 2 ("The dimension of the points must be at
+    # least 1", `_basis_multidim.py:161`) with a `ValueError` the Layer-1 `Raises:`
+    # does not list, so the sweep reports it as a *suspected* undocumented rejection,
+    # which is exactly the right strength of claim until the contract says.
     yield Case(
         GROUP,
         f"{name}_nd_empty_degrees",
@@ -481,6 +514,7 @@ def _nd_wrapper_cases(
         ),
         {"degrees": degrees_tuple, "kind": "funcs-order-F"},
         invariants=(expected_shape((pts.shape[0], n_basis)),),
+        must_succeed=True,
     )
     lattice = PointsLattice(
         [np.array([0.2, 0.8], dtype=dtype), np.array([0.3, 0.6, 0.9], dtype=dtype)]
@@ -494,8 +528,14 @@ def _nd_wrapper_cases(
         ),
         {"degrees": degrees_tuple, "kind": "points-lattice"},
         invariants=(expected_shape((6, n_basis)),),
+        must_succeed=True,
     )
     mismatched_pts = _scattered_points(3, dtype, generator)
+    # Two degrees against three-dimensional points: the `degrees`/`pts` pairing is
+    # per-direction by definition, so there is no basis to tabulate and *returning*
+    # something would be the finding. (The `ValueError` it raises comes from Layer 2
+    # and is absent from the Layer-1 `Raises:` list -- a documentation gap, not a
+    # reason to call the input legal.)
     yield Case(
         GROUP,
         f"{name}_nd_dim_mismatch",
@@ -504,6 +544,7 @@ def _nd_wrapper_cases(
             degrees_tuple, mismatched_pts
         ),
         {"degrees": degrees_tuple, "kind": "dim-mismatch"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -511,6 +552,7 @@ def _nd_wrapper_cases(
         call,
         lambda call=call, pts=pts: call((-1, 2), pts),
         {"degrees": (-1, 2), "kind": "negative-degree"},
+        must_reject=True,  # "If any degree is negative"
     )
 
 
@@ -539,6 +581,8 @@ def _lagrange_nd_variant_cases(profile: Profile) -> Iterator[Case]:
             ),
             {"degrees": degrees_tuple, "variant": variant},
             invariants=(expected_shape((pts.shape[0], n_basis)),),
+            # Degrees 3 and 4 give 4 and 5 nodes, above every variant's floor.
+            must_succeed=True,
         )
 
 
@@ -564,6 +608,8 @@ def _change_basis_square_cases(profile: Profile) -> Iterator[Case]:
     Yields:
         Case: One hostile call per builder.
     """
+    # All six document exactly two preconditions -- "Must be non-negative" and a
+    # float32/float64 dtype -- with a matching `Raises: ValueError` naming both.
     for name, func in _SQUARE_BUILDERS:
         for degree in _capped(degrees(profile), 2, profile):
             for dtype in dtypes(profile):
@@ -574,6 +620,7 @@ def _change_basis_square_cases(profile: Profile) -> Iterator[Case]:
                     lambda func=func, degree=degree, dtype=dtype: func(degree, dtype),
                     {"degree": degree, "dtype": dtype},
                     invariants=(expected_shape((degree + 1, degree + 1)),),
+                    must_succeed=True,
                 )
         yield Case(
             GROUP,
@@ -581,6 +628,7 @@ def _change_basis_square_cases(profile: Profile) -> Iterator[Case]:
             func,
             lambda func=func: func(-1),
             {"degree": -1, "kind": "invalid-degree"},
+            must_reject=True,
         )
         if profile is Profile.FULL:
             yield Case(
@@ -589,6 +637,7 @@ def _change_basis_square_cases(profile: Profile) -> Iterator[Case]:
                 func,
                 lambda func=func: func(3, np.int64),
                 {"degree": 3, "kind": "bad-dtype-int64"},
+                must_reject=True,
             )
 
 
@@ -614,7 +663,7 @@ def _change_basis_lagrange_pair_cases(profile: Profile) -> Iterator[Case]:
     for name, func in _LAGRANGE_PAIR_BUILDERS:
         for degree in _capped(degrees(profile), 2, profile):
             for variant in variants:
-                if degree + 1 < _LAGRANGE_VARIANT_MIN_NPTS[variant]:
+                if degree + 1 < LAGRANGE_MIN_NODES[variant]:
                     continue
                 for dtype in dtypes(profile):
                     yield Case(
@@ -626,6 +675,10 @@ def _change_basis_lagrange_pair_cases(profile: Profile) -> Iterator[Case]:
                         ),
                         {"degree": degree, "variant": variant, "dtype": dtype},
                         invariants=(expected_shape((degree + 1, degree + 1)),),
+                        # These two builders document "Must be at least 1", so the
+                        # swept degree 0 is a documented refusal, not a success.
+                        must_succeed=degree >= 1,
+                        must_reject=degree < 1,
                     )
         yield Case(
             GROUP,
@@ -633,6 +686,7 @@ def _change_basis_lagrange_pair_cases(profile: Profile) -> Iterator[Case]:
             func,
             lambda func=func: func(-1),
             {"degree": -1, "kind": "invalid-degree"},
+            must_reject=True,
         )
 
 
@@ -730,6 +784,9 @@ def _round_trip_case(
         run,
         {"degree": degree, "dtype": dtype, "kind": "round-trip", "cond": cond},
         invariants=invariants,
+        # Both matrices are built at a degree and dtype each builder accepts, so
+        # neither call may refuse; ill-conditioning is not grounds for an exception.
+        must_succeed=True,
     )
 
 
@@ -801,6 +858,11 @@ def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile
     pts = np.array([0.2, 0.6, 0.9], dtype=dtype)
     n_basis = degree + 1
 
+    # The `out` contract is stated identically everywhere: "Must have the correct
+    # shape and dtype if provided", with a matching `Raises: ValueError`. So a
+    # correct `out` must be used and returned, and each of the three malformed ones
+    # must be refused -- for the non-writable case because accepting it means writing
+    # through a read-only view, which is the finding, not the rejection.
     good_out = np.empty((pts.shape[0], n_basis), dtype=dtype)
     yield Case(
         GROUP,
@@ -809,6 +871,7 @@ def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile
         lambda func=func, pts=pts, good_out=good_out: func(degree, pts, out=good_out),
         {"degree": degree, "kind": "out-correct"},
         invariants=(_out_same_array(good_out),),
+        must_succeed=True,
     )
     wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=dtype)
     yield Case(
@@ -817,6 +880,7 @@ def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile
         func,
         lambda func=func, pts=pts, wrong_shape=wrong_shape: func(degree, pts, out=wrong_shape),
         {"degree": degree, "kind": "out-wrong-shape"},
+        must_reject=True,
     )
     wrong_dtype = np.empty((pts.shape[0], n_basis), dtype=np.float32)
     yield Case(
@@ -825,6 +889,7 @@ def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile
         func,
         lambda func=func, pts=pts, wrong_dtype=wrong_dtype: func(degree, pts, out=wrong_dtype),
         {"degree": degree, "kind": "out-wrong-dtype"},
+        must_reject=True,
     )
     non_writable = np.empty((pts.shape[0], n_basis), dtype=dtype)
     non_writable.flags.writeable = False
@@ -834,6 +899,7 @@ def _tabulate_1d_out_cases(name: str, func: Callable[..., Any], profile: Profile
         func,
         lambda func=func, pts=pts, non_writable=non_writable: func(degree, pts, out=non_writable),
         {"degree": degree, "kind": "out-non-writable"},
+        must_reject=True,
     )
 
 
@@ -862,6 +928,7 @@ def _lagrange_1d_out_cases(profile: Profile) -> Iterator[Case]:
         lambda good_out=good_out: tabulate_lagrange_1d(degree, variant, pts, out=good_out),
         {"degree": degree, "kind": "out-correct"},
         invariants=(_out_same_array(good_out),),
+        must_succeed=True,
     )
     wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=dtype)
     yield Case(
@@ -870,6 +937,7 @@ def _lagrange_1d_out_cases(profile: Profile) -> Iterator[Case]:
         tabulate_lagrange_1d,
         lambda wrong_shape=wrong_shape: tabulate_lagrange_1d(degree, variant, pts, out=wrong_shape),
         {"degree": degree, "kind": "out-wrong-shape"},
+        must_reject=True,
     )
     non_writable = np.empty((pts.shape[0], n_basis), dtype=dtype)
     non_writable.flags.writeable = False
@@ -881,6 +949,7 @@ def _lagrange_1d_out_cases(profile: Profile) -> Iterator[Case]:
             degree, variant, pts, out=non_writable
         ),
         {"degree": degree, "kind": "out-non-writable"},
+        must_reject=True,
     )
 
 
@@ -905,6 +974,7 @@ def _monomial_to_bernstein_out_cases(profile: Profile) -> Iterator[Case]:
         lambda good_out=good_out: compute_monomial_to_bernstein_1d(degree, dtype, out=good_out),
         {"degree": degree, "kind": "out-correct"},
         invariants=(_out_same_array(good_out),),
+        must_succeed=True,
     )
     wrong_shape = np.empty((degree, degree + 1), dtype=dtype)
     yield Case(
@@ -915,6 +985,7 @@ def _monomial_to_bernstein_out_cases(profile: Profile) -> Iterator[Case]:
             degree, dtype, out=wrong_shape
         ),
         {"degree": degree, "kind": "out-wrong-shape"},
+        must_reject=True,
     )
 
 
@@ -940,6 +1011,7 @@ def _bernstein_nd_out_cases(profile: Profile) -> Iterator[Case]:
         lambda good_out=good_out: tabulate_bernstein(degrees_tuple, pts, out=good_out),
         {"degrees": degrees_tuple, "kind": "out-correct"},
         invariants=(_out_same_array(good_out),),
+        must_succeed=True,
     )
     wrong_shape = np.empty((pts.shape[0] + 1, n_basis), dtype=np.float64)
     yield Case(
@@ -948,6 +1020,7 @@ def _bernstein_nd_out_cases(profile: Profile) -> Iterator[Case]:
         tabulate_bernstein,
         lambda wrong_shape=wrong_shape: tabulate_bernstein(degrees_tuple, pts, out=wrong_shape),
         {"degrees": degrees_tuple, "kind": "out-wrong-shape"},
+        must_reject=True,
     )
 
 

--- a/tools/adversarial_sweep/_probes_basis.py
+++ b/tools/adversarial_sweep/_probes_basis.py
@@ -54,7 +54,15 @@ from pantr.change_basis import (
 )
 from pantr.quad import PointsLattice
 
-from ._axes import LAGRANGE_MIN_NODES, Profile, degrees, dtypes, point_specs, rng
+from ._axes import (
+    EXTRAPOLATION_POINT_FAMILIES,
+    LAGRANGE_MIN_NODES,
+    Profile,
+    degrees,
+    dtypes,
+    point_specs,
+    rng,
+)
 from ._core import Case, custom, expected_shape, partition_of_unity
 
 if TYPE_CHECKING:
@@ -170,7 +178,10 @@ def _tabulate_1d_cases(
                     lambda func=func, degree=degree, pts=spec.pts: func(degree, pts),
                     {"degree": degree, "dtype": dtype, "points": spec.name},
                     invariants=tuple(invariants),
-                    finite_inputs=spec.finite,
+                    # A point outside [0, 1] is extrapolated, not refused, and at
+                    # degree 62 in float32 the extrapolated value overflows the format
+                    # -- arithmetic, not a defect. See EXTRAPOLATION_POINT_FAMILIES.
+                    finite_inputs=spec.finite and spec.name not in EXTRAPOLATION_POINT_FAMILIES,
                     must_succeed=True,
                 )
 
@@ -258,7 +269,7 @@ def _lagrange_1d_cases(profile: Profile) -> Iterator[Case]:
                         ),
                         {"degree": degree, "variant": variant, "dtype": dtype, "points": spec.name},
                         invariants=(expected_shape((*spec.pts.shape, degree + 1)),),
-                        finite_inputs=spec.finite,
+                        finite_inputs=spec.finite and spec.name not in EXTRAPOLATION_POINT_FAMILIES,
                         must_succeed=True,
                     )
     yield Case(

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -662,6 +662,44 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
     )
 
 
+def _derivative_overflows(
+    dtype: np.dtype[np.float32 | np.float64], order: int, *, rational: bool
+) -> bool:
+    """Decide whether a derivative of this order must overflow the format.
+
+    A *rational* Bezier's ``k``-th derivative comes out of the quotient rule applied ``k``
+    times, so it carries a ``k!`` factor from the repeated differentiation of ``1 / w``,
+    and its magnitude therefore grows at least factorially in the order regardless of how
+    tame the control points are. Once ``k!`` passes the format's largest finite value the
+    true answer is unrepresentable and ``inf`` is the correct result, not a defect: at
+    degree 62, order 62, the float64 computation of the very same derivative peaks at
+    **6.5e149** against a float32 maximum of 3.4e38.
+
+    That threshold is why only the rational cases fail. A *polynomial* Bezier's ``k``-th
+    derivative is a finite difference scaled by ``n! / (n - k)!``, which vanishes
+    identically past ``k = n``; measured at degree 62, order 62 it peaks at 7.1e36, inside
+    float32's range, and the non-rational cases are all finite.
+
+    The threshold is derived rather than tuned: it is the smallest ``k`` whose factorial
+    the format cannot hold. For ``float32`` that is 35, since ``34! = 3.0e38`` still fits
+    under the maximum 3.4e38 and ``35! = 1.0e40`` does not; for ``float64`` it is 171,
+    beyond any order this module sweeps, so ``float64`` is never exempted. The comparison
+    is computed rather than written down, so the boundary cannot drift.
+
+    Args:
+        dtype (np.dtype[np.float32 | np.float64]): Working precision.
+        order (int): Derivative order requested.
+        rational (bool): Whether the Bezier is rational.
+
+    Returns:
+        bool: ``True`` when a non-finite result is arithmetic rather than a finding.
+    """
+    if not rational:
+        return False
+    largest = float(np.finfo(dtype).max)
+    return math.factorial(order) > largest
+
+
 def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
     """Yield :meth:`~pantr.bezier.Bezier.evaluate_derivatives` cases.
 
@@ -707,6 +745,7 @@ def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
                             "order": order,
                         },
                         arrays={"control_points": cp},
+                        finite_inputs=not _derivative_overflows(dtype, order, rational=rational),
                         must_succeed=True,
                     )
 

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -113,6 +113,17 @@ polygon's diagonal."""
 
 _MAGNITUDE_SMOKE: Final = (("scale1", 1.0, 0.0),)
 
+_BINCOEFF_MAX_DEGREE: Final = 61
+"""Highest degree at which ``_bincoeff``'s exact-integer recurrence is sound.
+
+Mirrors ``_BINCOEFF_MAX_N`` (``_bspline_degree_core.py:21``), which is what
+``_check_bincoeff_envelope`` grades against. Three ``Bezier`` operations enforce it --
+``elevate_degree`` (on the *elevated* degree), ``minimize_degree`` (on the operand's own
+degree) and ``compose`` (on the combined degree) -- and none of the three mentions it in
+its public ``Raises:`` section, so the verdict flags have to know it independently.
+``reduce_degree``, ``multiply``, ``derivative``, ``evaluate``, ``split``, ``restrict`` and
+``slice`` do not use ``_bincoeff`` at all and carry no such ceiling."""
+
 
 def _magnitude_variants(profile: Profile) -> tuple[tuple[str, float, float], ...]:
     """List the control-point magnitude/translation families to sweep.
@@ -392,15 +403,23 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
                             ),
                         ),
                         arrays={"control_points": cp},
+                        # `_random_control_points` builds `(*(degree + 1,) * dim, rank)`
+                        # with rank >= 1 and every direction non-empty, which is the whole
+                        # of the constructor's stated contract. No maximum degree is
+                        # documented anywhere on `Bezier`, so degree 62 is legal too.
+                        must_succeed=True,
                     )
 
-    # Malformed / edge-case constructions: documented rejections or corners.
+    # Malformed / edge-case constructions. The first three violate one of the two
+    # documented `Raises:` clauses -- "fewer than 1 entry in any parametric direction"
+    # and "rank smaller than 1" -- so returning would be the finding.
     yield Case(
         GROUP,
         "construct_empty_cp",
         Bezier,
         lambda: Bezier(np.zeros((0, 2), dtype=np.float64)),
         {"kind": "empty"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -408,6 +427,7 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
         Bezier,
         lambda: Bezier(np.float64(1.0)),
         {"kind": "0d-scalar"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -415,7 +435,11 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
         Bezier,
         lambda: Bezier(np.zeros((3, 0), dtype=np.float64)),
         {"kind": "rank-zero"},
+        must_reject=True,
     )
+    # The remaining three are conveniences the `control_points` docstring promises
+    # outright: "A 1D input of shape (n,) is reshaped to (n, 1) (scalar field). Integer
+    # arrays are cast to float64" -- and, by omission, float32 is left alone.
     yield Case(
         GROUP,
         "construct_1d_list_reshape",
@@ -424,6 +448,7 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
         {"kind": "1d-list"},
         invariants=(expected_shape(()),),
         finite_inputs=False,  # predicate below checks rank/dim, not the raw result
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -437,6 +462,7 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
                 lambda r: None if r.dtype == np.float64 else f"got dtype {r.dtype}",
             ),
         ),
+        must_succeed=True,
     )
     float32_cp = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]], dtype=np.float32)
     yield Case(
@@ -452,6 +478,7 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
             ),
         ),
         arrays={"control_points": float32_cp},
+        must_succeed=True,
     )
 
 
@@ -541,6 +568,11 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
                     # is involved -- nothing in `evaluate`'s contract promises
                     # a finite answer for these families at every degree.
                     finite_expected = finite and name not in _EXTRAPOLATION_POINT_FAMILIES
+                    # Every family here has the shape and dtype `evaluate` asks for, and
+                    # `evaluate` states no domain at all for `pts` -- there is no
+                    # rejection clause an out-of-domain, empty or `NaN` point could
+                    # trip. So the call must *return*; whether the value it returns is
+                    # finite is a separate question, settled by `finite_inputs` above.
                     yield Case(
                         GROUP,
                         f"evaluate_{tag}_{name}",
@@ -555,6 +587,7 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
                         },
                         finite_inputs=finite_expected,
                         arrays={"control_points": cp, "pts": pts},
+                        must_succeed=True,
                     )
 
                 if profile is Profile.FULL:
@@ -585,9 +618,11 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
                             "rational": True,
                         },
                         arrays={"control_points": cp_rat, "pts": interior_pts},
+                        must_succeed=True,
                     )
 
-    # Dtype-mismatch and out-of-range direction: documented rejections.
+    # Dtype-mismatch: documented rejection, "If the points dtype does not match the
+    # Bézier dtype".
     bezier64 = Bezier(_random_control_points(1, 1, 3, np.dtype(np.float64), offset=2900))
     pts32 = np.array([0.5], dtype=np.float32)
     yield Case(
@@ -596,6 +631,7 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
         Bezier.evaluate,
         lambda: bezier64.evaluate(pts32),
         {"kind": "dtype-mismatch"},
+        must_reject=True,
     )
 
     # out= round trip: correct shape/dtype accepted and filled bit-identically.
@@ -617,6 +653,7 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
                 else "out= result differs from the freshly-allocated result",
             ),
         ),
+        must_succeed=True,
     )
     bad_out = np.empty((3, 7), dtype=np.float64)
     yield Case(
@@ -625,6 +662,7 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
         Bezier.evaluate,
         lambda: bezier_out.evaluate(pts_out, out=bad_out),
         {"kind": "out-wrong-shape"},
+        must_reject=True,  # "or if out has incorrect shape or dtype"
     )
 
 
@@ -653,6 +691,12 @@ def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
                     if order == 0 and degree == 0:
                         continue
                     tag = f"p{degree}_{dtype}_{'rat' if rational else 'nonrat'}_o{order}"
+                    # `orders` reaches `degree + 3` deliberately. That is legal: the
+                    # only stated precondition is "one non-negative integer per
+                    # parametric direction", with no cap relative to the degree, so an
+                    # order past the degree must return the zero derivative rather than
+                    # refuse. Unlike `derivative`, which *does* document a refusal at
+                    # degree 0, this method documents none.
                     yield Case(
                         GROUP,
                         f"evaluate_derivatives_{tag}",
@@ -667,9 +711,11 @@ def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
                             "order": order,
                         },
                         arrays={"control_points": cp},
+                        must_succeed=True,
                     )
 
-    # Mismatched orders length and negative order: documented rejections.
+    # Mismatched orders length and negative order: documented rejections, "If
+    # len(orders) != self.dim, if any order is negative, ...".
     cp_bad = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=3900)
     bezier_bad = Bezier(cp_bad)
     pts_bad = np.array([[0.2, 0.3]], dtype=np.float64)
@@ -679,6 +725,7 @@ def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
         Bezier.evaluate_derivatives,
         lambda: bezier_bad.evaluate_derivatives(pts_bad, [1, 2, 3]),
         {"kind": "orders-length-mismatch"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -686,6 +733,7 @@ def _evaluate_derivatives_cases(profile: Profile) -> Iterator[Case]:
         Bezier.evaluate_derivatives,
         lambda: bezier_bad.evaluate_derivatives(pts_bad, [-1, 0]),
         {"kind": "negative-order"},
+        must_reject=True,
     )
 
 
@@ -744,9 +792,17 @@ def _elevate_degree_cases(profile: Profile) -> Iterator[Case]:
                             ),
                         ),
                         arrays={"control_points": cp},
+                        # The swept degrees stop at 15 and the increments at 5, so the
+                        # highest elevated degree is 20 -- well inside the exactness
+                        # envelope of the binomial-coefficient kernel
+                        # (`_BINCOEFF_MAX_N = 61`, `_bspline_degree_core.py:21`), which
+                        # is the only ceiling `elevate_degree` has. Nothing here may
+                        # therefore refuse.
+                        must_succeed=True,
                     )
 
-    # Documented rejections: negative increment, all-zero increments, length mismatch.
+    # Documented rejections: "If any degree increment is negative", "If all degree
+    # increments are zero", "If the number of increments does not match the dimension".
     cp_nd = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=4900)
     bezier_nd = Bezier(cp_nd)
     yield Case(
@@ -755,6 +811,7 @@ def _elevate_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.elevate_degree,
         lambda: bezier_nd.elevate_degree(-1),
         {"kind": "negative-increment"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -762,6 +819,7 @@ def _elevate_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.elevate_degree,
         lambda: bezier_nd.elevate_degree([0, 0]),
         {"kind": "all-zero-increments"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -769,6 +827,7 @@ def _elevate_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.elevate_degree,
         lambda: bezier_nd.elevate_degree([1, 1, 1]),
         {"kind": "length-mismatch"},
+        must_reject=True,
     )
 
 
@@ -875,9 +934,18 @@ def _reduce_degree_cases(profile: Profile) -> Iterator[Case]:
                         },
                         invariants=(invariant,),
                         arrays={"control_points": cp},
+                        # `dec` never exceeds `degree` and is never zero or negative, so
+                        # none of the four documented refusals applies. Degree 62 is
+                        # legal here even though it is not for `elevate_degree`:
+                        # `_degree_reduce_bezier` is built from exact `Fraction` and
+                        # `math.comb` arithmetic and never touches `_bincoeff`, so it
+                        # carries no envelope check. Verified: degree 62 reduces, while
+                        # elevating a degree-61 curve raises.
+                        must_succeed=True,
                     )
 
-    # Documented rejections: decrement exceeds degree, negative, all-zero.
+    # Documented rejections: "If any decrement exceeds the current degree in that
+    # direction", "If any degree decrement is negative", "If all decrements are zero".
     cp = _random_control_points(1, 1, 3, np.dtype(np.float64), offset=5900)
     bezier = Bezier(cp)
     yield Case(
@@ -886,6 +954,7 @@ def _reduce_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.reduce_degree,
         lambda: bezier.reduce_degree(4),
         {"kind": "decrement-exceeds-degree"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -893,6 +962,7 @@ def _reduce_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.reduce_degree,
         lambda: bezier.reduce_degree(-1),
         {"kind": "negative-decrement"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -900,6 +970,7 @@ def _reduce_degree_cases(profile: Profile) -> Iterator[Case]:
         Bezier.reduce_degree,
         lambda: bezier.reduce_degree(0),
         {"kind": "all-zero-decrement"},
+        must_reject=True,
     )
 
 
@@ -938,6 +1009,11 @@ def _degree_reduction_error_cases(profile: Profile) -> Iterator[Case]:
                         else f"error {r!r} not in [0, {tol:.3e}]",
                     ),
                 ),
+                # `error_degrees` stops at 15, so the internal re-elevation back to the
+                # original degree stays inside the binomial envelope. It would not at
+                # degree 62: `degree_reduction_error` re-elevates, and elevating a
+                # degree-61 curve already raises. Keep the cap if this sweep widens.
+                must_succeed=True,
             )
             generic_decs = range(1, degree + 1) if profile is Profile.FULL else (1,)
             for dec in generic_decs:
@@ -955,6 +1031,7 @@ def _degree_reduction_error_cases(profile: Profile) -> Iterator[Case]:
                             lambda r: None if (np.isfinite(r) and r >= 0.0) else f"got {r!r}",
                         ),
                     ),
+                    must_succeed=True,  # `dec <= degree <= 15`, as above
                 )
 
 
@@ -974,6 +1051,18 @@ def _minimize_degree_cases(profile: Profile) -> Iterator[Case]:
         for degree in degrees(profile):
             if degree == 0:
                 continue
+            # `minimize_degree` checks every direction against the binomial-coefficient
+            # envelope before doing anything (`_bezier_degree.py:515-517`), so a
+            # degree-62 operand is refused outright -- verified: degree 61 minimizes,
+            # degree 62 raises. That refusal is correct (past 61 `_bincoeff` wraps
+            # int64 and the answer would be silently wrong), which is why it is graded
+            # `must_reject` rather than left unflagged. What is *missing* is the
+            # documentation: `Bezier.minimize_degree` has no `Raises:` section at all,
+            # while the Layer-2 function it calls documents this exact `ValueError`. So
+            # the sweep will report the refusal as an undocumented rejection -- a
+            # suspicion, not a bug -- which is the right strength of claim for a
+            # docstring gap, while a *return* at degree 62 would be graded a bug.
+            over_envelope = degree > _BINCOEFF_MAX_DEGREE
             cp = _random_control_points(1, 1, degree, dtype, offset=7000 + degree)
             bezier = Bezier(cp)
             yield Case(
@@ -991,6 +1080,8 @@ def _minimize_degree_cases(profile: Profile) -> Iterator[Case]:
                     ),
                 ),
                 arrays={"control_points": cp},
+                must_succeed=not over_envelope,
+                must_reject=over_envelope,
             )
             if profile is Profile.FULL:
                 # A genuinely reducible curve: a straight line elevated to `degree`.
@@ -1010,6 +1101,8 @@ def _minimize_degree_cases(profile: Profile) -> Iterator[Case]:
                             else f"got degree {r.degree[0]} > original {degree}",
                         ),
                     ),
+                    must_succeed=not over_envelope,
+                    must_reject=over_envelope,
                 )
     yield Case(
         GROUP,
@@ -1019,6 +1112,7 @@ def _minimize_degree_cases(profile: Profile) -> Iterator[Case]:
             tol=1e-3
         ),
         {"kind": "explicit-tol"},
+        must_succeed=True,  # degree 15, and `tol` has no documented range
     )
 
 
@@ -1080,10 +1174,17 @@ def _split_cases(profile: Profile) -> Iterator[Case]:
                             ),
                         ),
                         arrays={"control_points": cp},
+                        # Every swept value is strictly inside (0, 1) and the direction
+                        # is 0 on a 1-D Bézier, which is the whole of `split`'s stated
+                        # contract. Degree 0 is not swept here, but it would be legal
+                        # too: splitting a constant returns the same constant twice.
+                        must_succeed=True,
                     )
 
     cp_1d = _random_control_points(1, 1, 3, np.dtype(np.float64), offset=8900)
     bezier_1d = Bezier(cp_1d)
+    # "Must lie strictly inside (0, 1)", so both endpoints are documented refusals --
+    # the one place in this module where a *closed* bound would be wrong.
     for boundary_value, tag in ((0.0, "left"), (1.0, "right")):
         yield Case(
             GROUP,
@@ -1093,6 +1194,7 @@ def _split_cases(profile: Profile) -> Iterator[Case]:
                 0, boundary_value
             ),
             {"kind": f"boundary-{tag}", "value": boundary_value},
+            must_reject=True,
         )
     yield Case(
         GROUP,
@@ -1100,6 +1202,7 @@ def _split_cases(profile: Profile) -> Iterator[Case]:
         Bezier.split,
         lambda: bezier_1d.split(1, 0.5),
         {"kind": "direction-out-of-range"},
+        must_reject=True,  # "If direction is out of range [0, dim)"
     )
 
 
@@ -1173,6 +1276,9 @@ def _restrict_cases(profile: Profile) -> Iterator[Case]:
                     ),
                 ),
                 arrays={"control_points": cp},
+                # (0.2, 0.8) is inside [0, 1] with lower < upper and genuinely
+                # restricts, so none of the four documented refusals applies.
+                must_succeed=True,
             )
 
     cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=9900)
@@ -1183,6 +1289,7 @@ def _restrict_cases(profile: Profile) -> Iterator[Case]:
         Bezier.restrict,
         lambda: bezier_1d.restrict((0.4, 0.4)),
         {"kind": "zero-width"},
+        must_reject=True,  # "lower >= upper"
     )
     yield Case(
         GROUP,
@@ -1190,6 +1297,7 @@ def _restrict_cases(profile: Profile) -> Iterator[Case]:
         Bezier.restrict,
         lambda: bezier_1d.restrict((-0.1, 0.5)),
         {"kind": "out-of-domain"},
+        must_reject=True,  # "bounds outside [0, 1]"
     )
 
 
@@ -1232,6 +1340,10 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
                 {"outer_degree": p, "inner_degree": q, "dtype": str(dtype), "kind": "1d-inner"},
                 invariants=(_compose_invariant(ts, expected, tol),),
                 arrays={"outer_control_points": outer_cp, "inner_control_points": inner_cp},
+                # Non-rational, matching dtypes, and `inner.rank == outer.dim == 1`:
+                # all three documented refusals are avoided. The combined degree `p * q`
+                # peaks at 10 here, far inside the binomial envelope.
+                must_succeed=True,
             )
 
         if profile is Profile.FULL:
@@ -1255,6 +1367,11 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
                 {"outer_degree": 30, "inner_degree": 3, "dtype": str(dtype), "kind": "nd-inner"},
                 invariants=(_compose_invariant(ts_nd, expected_nd, tol_nd),),
                 arrays={"outer_control_points": outer_cp_nd, "inner_control_points": inner_cp_nd},
+                # Combined degree 90 and still `must_succeed`: the envelope guard is
+                # conditioned on `inner.dim == 1` (`_bezier_compose.py:86-90`), and this
+                # inner is 2-D, so the composition takes the `math.comb` nD path, which
+                # is exact at any degree and carries no ceiling.
+                must_succeed=True,
             )
 
             # Boundary marker: combined degree exactly 61, one below the known
@@ -1281,9 +1398,17 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
                     "outer_control_points": outer_boundary_cp,
                     "inner_control_points": inner_boundary_cp,
                 },
+                # Worth being precise about what this case does and does not prove: the
+                # combined degree is 61, but a degree-1 1-D outer is *exempt* from the
+                # envelope check altogether (`_bezier_compose.py:86-90` requires
+                # `outer.dim > 1 or outer.degree[0] > 1`), so this never reaches the
+                # guard. It documents that a degree-1 outer composes with an arbitrarily
+                # high-degree inner, not that the cliff is at 62.
+                must_succeed=True,
             )
 
-    # Documented rejections.
+    # Documented rejections: "TypeError: If either Bézier is rational", "ValueError: If
+    # inner.rank != self.dim", "ValueError: If the operands have different dtypes".
     outer_rat_cp = _random_control_points(
         1, 1, 2, np.dtype(np.float64), offset=10900, rational=True
     )
@@ -1296,6 +1421,7 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
         Bezier.compose,
         lambda: outer_rat.compose(inner_plain),
         {"kind": "rational-outer"},
+        must_reject=True,
     )
     outer_plain = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=10902))
     inner_rank_mismatch = Bezier(
@@ -1307,6 +1433,7 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
         Bezier.compose,
         lambda: outer_plain.compose(inner_rank_mismatch),
         {"kind": "rank-mismatch"},
+        must_reject=True,
     )
     outer_f32 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float32), offset=10904))
     inner_f64 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=10905))
@@ -1316,6 +1443,7 @@ def _compose_cases(profile: Profile) -> Iterator[Case]:
         Bezier.compose,
         lambda: outer_f32.compose(inner_f64),
         {"kind": "dtype-mismatch"},
+        must_reject=True,
     )
 
 
@@ -1393,6 +1521,10 @@ def _multiply_cases(profile: Profile) -> Iterator[Case]:
                         ),
                     ),
                     arrays={"f_control_points": cp_f, "g_control_points": cp_g},
+                    # Matching dtype, dim and rank, which is the whole of `multiply`'s
+                    # contract. No degree ceiling applies: the product is an exact
+                    # `math.comb` convolution and never touches `_bincoeff`.
+                    must_succeed=True,
                 )
 
     f_operator = Bezier.__mul__
@@ -1417,6 +1549,7 @@ def _multiply_cases(profile: Profile) -> Iterator[Case]:
                 ),
             ),
         ),
+        must_succeed=True,
     )
 
     rank_mismatch = Bezier(_random_control_points(2, 1, 2, np.dtype(np.float64), offset=11902))
@@ -1426,6 +1559,7 @@ def _multiply_cases(profile: Profile) -> Iterator[Case]:
         Bezier.multiply,
         lambda: f64.multiply(rank_mismatch),
         {"kind": "rank-mismatch"},
+        must_reject=True,  # "different dimensions, dtypes, or ranks"
     )
     f32 = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float32), offset=11903))
     yield Case(
@@ -1434,6 +1568,7 @@ def _multiply_cases(profile: Profile) -> Iterator[Case]:
         Bezier.multiply,
         lambda: f64.multiply(f32),
         {"kind": "dtype-mismatch"},
+        must_reject=True,
     )
 
 
@@ -1507,6 +1642,10 @@ def _derivative_cases(profile: Profile) -> Iterator[Case]:
                                 ),
                             ),
                             arrays={"control_points": cp},
+                            # `derivative` documents exactly two refusals -- an
+                            # out-of-range direction and a degree-0 direction -- and
+                            # `derivative_degrees` starts at 1, so neither applies.
+                            must_succeed=True,
                         )
 
     cp_const = _random_control_points(1, 2, 0, np.dtype(np.float64), offset=12900)
@@ -1517,6 +1656,10 @@ def _derivative_cases(profile: Profile) -> Iterator[Case]:
         Bezier.derivative,
         lambda: bezier_const.derivative(direction=0),
         {"kind": "degree-zero-direction"},
+        # "ValueError: If the degree in the given direction is 0." `derivative` is the
+        # only operation in this module with a documented degree-0 refusal, which is why
+        # degree 0 is `must_succeed` everywhere else and `must_reject` here.
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1524,6 +1667,7 @@ def _derivative_cases(profile: Profile) -> Iterator[Case]:
         Bezier.derivative,
         lambda: bezier_const.derivative(direction=5),
         {"kind": "direction-out-of-range"},
+        must_reject=True,  # "If direction is out of range [0, dim)"
     )
 
 
@@ -1678,6 +1822,11 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                 {"n_roots": n, "dtype": str(dtype), "kind": "well-separated"},
                 invariants=(_roots_bounded_invariant(bezier),),
                 arrays={"coefficients": coeff},
+                # `find_roots` refuses exactly four things: a non-Bezier, `dim != 1`,
+                # `rank != 1`, and a non-positive `tol` (plus uneven degrees in batch
+                # mode). Every crossing in this function is a scalar 1-D curve at the
+                # default `tol`, so none applies and any exception is a finding.
+                must_succeed=True,
             )
 
         if profile is Profile.FULL:
@@ -1692,6 +1841,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                     {"n_roots": n, "dtype": str(dtype), "kind": "clustered-known-dedup-edge-case"},
                     invariants=(_roots_bounded_invariant(bezier),),
                     arrays={"coefficients": coeff},
+                    must_succeed=True,
                 )
 
         # Degenerate: identically zero (every point is a root).
@@ -1703,6 +1853,11 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
             find_roots,
             lambda zero_bezier=zero_bezier: find_roots(zero_bezier),
             {"dtype": str(dtype), "kind": "identically-zero"},
+            # An identically-zero polynomial is a legal scalar 1-D curve, so the call
+            # must return. *What* it should return is genuinely unspecified -- every
+            # point is a root, and the docstring says only "Empty if no roots exist" --
+            # so no invariant is asserted, deliberately.
+            must_succeed=True,
         )
 
         for degree in (3, 15) if profile is Profile.FULL else (3,):
@@ -1724,6 +1879,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                     ),
                 ),
                 arrays={"control_points": mono_cp},
+                must_succeed=True,
             )
 
             no_cross_cp = _monotone_control_points(degree, dtype, sign_change=False)
@@ -1743,7 +1899,10 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                     ),
                 ),
                 finite_inputs=False,
+                # `NaN` is the documented *return* for "no sign change across the
+                # interval", not a refusal, so this must succeed too.
                 arrays={"control_points": no_cross_cp},
+                must_succeed=True,
             )
 
         if profile is Profile.FULL:
@@ -1764,6 +1923,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                         lambda r, batch=batch: _batch_roots_failure(r, batch),
                     ),
                 ),
+                must_succeed=True,  # a uniform-degree batch, which batch mode requires
             )
             mono_batch = [
                 Bezier(_monotone_control_points(4, dtype, sign_change=True)) for _ in range(3)
@@ -1775,15 +1935,19 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
                 lambda mono_batch=mono_batch: find_monotone_root(mono_batch),
                 {"n_polys": len(mono_batch), "dtype": str(dtype), "kind": "batch"},
                 invariants=(expected_shape((len(mono_batch),)),),
+                must_succeed=True,
             )
 
-    # Documented rejections.
+    # Documented rejections: "TypeError: If bezier is not a Bezier instance (or sequence
+    # thereof)" and "ValueError: If any Bezier has dim != 1 or rank != 1, or tol is not
+    # positive. In batch mode, also raised if degrees are not uniform."
     yield Case(
         GROUP,
         "find_roots_wrong_type",
         find_roots,
         lambda: find_roots(42),
         {"kind": "not-a-bezier"},
+        must_reject=True,
     )
     surface = Bezier(_random_control_points(1, 2, 2, np.dtype(np.float64), offset=13900))
     yield Case(
@@ -1792,6 +1956,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
         find_roots,
         lambda: find_roots(surface),
         {"kind": "dim-not-1"},
+        must_reject=True,
     )
     vector_curve = Bezier(_random_control_points(2, 1, 2, np.dtype(np.float64), offset=13901))
     yield Case(
@@ -1800,6 +1965,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
         find_roots,
         lambda: find_roots(vector_curve),
         {"kind": "rank-not-1"},
+        must_reject=True,
     )
     scalar_curve = Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=13902))
     yield Case(
@@ -1808,6 +1974,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
         find_roots,
         lambda: find_roots(scalar_curve, tol=0.0),
         {"kind": "nonpositive-tol"},
+        must_reject=True,
     )
     uneven_batch = [
         Bezier(_random_control_points(1, 1, 2, np.dtype(np.float64), offset=13903)),
@@ -1819,6 +1986,7 @@ def _root_finding_cases(profile: Profile) -> Iterator[Case]:
         find_roots,
         lambda: find_roots(uneven_batch),
         {"kind": "uneven-batch-degree"},
+        must_reject=True,
     )
 
 
@@ -1915,6 +2083,9 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                         {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
                         invariants=(_double_op_identity_invariant(cp),),
                         arrays={"control_points": cp},
+                        # `reverse` refuses only an out-of-range direction, and
+                        # `direction` runs over `range(dim)`.
+                        must_succeed=True,
                     )
                     fresh = Bezier(cp.copy())
                     yield Case(
@@ -1931,6 +2102,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                                 lambda r: None if r is None else f"expected None, got {r!r}",
                             ),
                         ),
+                        must_succeed=True,
                     )
 
                 if dim >= 2:  # noqa: PLR2004
@@ -1946,6 +2118,9 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                         {"rank": rank, "dim": dim, "degree": degree, "dtype": str(dtype)},
                         invariants=(_double_op_identity_invariant(cp),),
                         arrays={"control_points": cp},
+                        # A transposition of two directions is a valid permutation of
+                        # `range(dim)`, the only thing `permute_directions` checks.
+                        must_succeed=True,
                     )
                     fresh_perm = Bezier(cp.copy())
                     yield Case(
@@ -1962,6 +2137,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                                 lambda r: None if r is None else f"expected None, got {r!r}",
                             ),
                         ),
+                        must_succeed=True,
                     )
 
                 identity = AffineTransform.identity(rank)
@@ -1980,6 +2156,9 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                         ),
                     ),
                     arrays={"control_points": cp},
+                    # Built at the Bézier's own geometric rank, the only thing
+                    # `transform` checks.
+                    must_succeed=True,
                 )
                 fresh_transform = Bezier(cp.copy())
                 yield Case(
@@ -1996,6 +2175,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                             lambda r: None if r is None else f"expected None, got {r!r}",
                         ),
                     ),
+                    must_succeed=True,
                 )
 
                 if profile is Profile.FULL:
@@ -2007,6 +2187,11 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
                         lambda bezier=bezier, singular=singular: bezier.transform(singular),
                         {"rank": rank, "dim": dim, "kind": "singular-matrix"},
                         arrays={"control_points": cp},
+                        # A singular affine map is legal and undocumented as special:
+                        # `transform` checks only the matrix's shape and never its
+                        # rank, so collapsing the geometry onto a lower-dimensional
+                        # subspace is an ordinary result, not a refusal.
+                        must_succeed=True,
                     )
 
     cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=14900)
@@ -2017,6 +2202,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
         Bezier.reverse,
         lambda: bezier_1d.reverse(3),
         {"kind": "direction-out-of-range"},
+        must_reject=True,  # "If direction is out of range [0, dim)"
     )
     cp_2d = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=14901)
     bezier_2d = Bezier(cp_2d)
@@ -2026,6 +2212,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
         Bezier.permute_directions,
         lambda: bezier_2d.permute_directions([0, 0]),
         {"kind": "invalid-permutation"},
+        must_reject=True,  # "If permutation is not a valid permutation of range(dim)"
     )
     yield Case(
         GROUP,
@@ -2033,6 +2220,7 @@ def _reverse_permute_transform_cases(profile: Profile) -> Iterator[Case]:
         Bezier.transform,
         lambda: bezier_2d.transform(AffineTransform.identity(3)),
         {"kind": "dimension-mismatch"},
+        must_reject=True,  # "If the transform dimension does not match the geometric rank"
     )
 
 
@@ -2072,6 +2260,9 @@ def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
                             "value": value,
                         },
                         arrays={"control_points": cp},
+                        # `slice` documents a *closed* bound, "Must lie within [0, 1]",
+                        # unlike `split`'s open one, so 0.0 and 1.0 are legal here.
+                        must_succeed=True,
                     )
                 for side in (0, 1):
                     yield Case(
@@ -2095,6 +2286,7 @@ def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
                             ),
                         ),
                         arrays={"control_points": cp},
+                        must_succeed=True,  # axis 0 < dim, side in {0, 1}
                     )
 
     cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=15900)
@@ -2105,6 +2297,7 @@ def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
         Bezier.slice,
         lambda: bezier_1d.slice(0, 1.5),
         {"kind": "value-out-of-range"},
+        must_reject=True,  # "If value is outside [0, 1]"
     )
     yield Case(
         GROUP,
@@ -2112,6 +2305,7 @@ def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
         Bezier.slice,
         lambda: bezier_1d.slice(2, 0.5),
         {"kind": "axis-out-of-range"},
+        must_reject=True,  # "If axis is out of range"
     )
     yield Case(
         GROUP,
@@ -2119,6 +2313,7 @@ def _slice_boundary_cases(profile: Profile) -> Iterator[Case]:
         Bezier.boundary,
         lambda: bezier_1d.boundary(0, 2),
         {"kind": "invalid-side"},
+        must_reject=True,  # "If side is not 0 or 1"
     )
 
 
@@ -2187,6 +2382,9 @@ def _collapse_along_axis_cases(profile: Profile) -> Iterator[Case]:
                             ),
                         ),
                         arrays={"control_points": cp},
+                        # `dim >= 2`, `axis` in range, `len(values) == dim - 1`, and
+                        # every value in [0, 1]: all four documented refusals avoided.
+                        must_succeed=True,
                     )
 
     cp_1d = _random_control_points(1, 1, 2, np.dtype(np.float64), offset=16900)
@@ -2197,6 +2395,7 @@ def _collapse_along_axis_cases(profile: Profile) -> Iterator[Case]:
         Bezier.collapse_along_axis,
         lambda: bezier_1d.collapse_along_axis(0, []),
         {"kind": "dim-less-than-2"},
+        must_reject=True,  # "collapse_along_axis requires dim >= 2"
     )
     cp_2d = _random_control_points(1, 2, 2, np.dtype(np.float64), offset=16901)
     bezier_2d = Bezier(cp_2d)
@@ -2206,6 +2405,7 @@ def _collapse_along_axis_cases(profile: Profile) -> Iterator[Case]:
         Bezier.collapse_along_axis,
         lambda: bezier_2d.collapse_along_axis(0, [0.2, 0.3]),
         {"kind": "values-length-mismatch"},
+        must_reject=True,  # "values must have length dim - 1"
     )
     yield Case(
         GROUP,
@@ -2213,6 +2413,7 @@ def _collapse_along_axis_cases(profile: Profile) -> Iterator[Case]:
         Bezier.collapse_along_axis,
         lambda: bezier_2d.collapse_along_axis(0, [1.5]),
         {"kind": "value-out-of-range"},
+        must_reject=True,  # "All values must be in [0, 1]"
     )
 
 
@@ -2253,6 +2454,10 @@ def _to_bspline_cases(profile: Profile) -> Iterator[Case]:
                         ),
                     ),
                     arrays={"control_points": cp},
+                    # `to_bspline` documents no refusal at all, and the vector it builds
+                    # is Bézier-like by construction, which is the one thing
+                    # `create_from_bspline` checks. Degree 0 is swept and is legal.
+                    must_succeed=True,
                 )
 
     non_bezier_space = BsplineSpace(
@@ -2267,6 +2472,7 @@ def _to_bspline_cases(profile: Profile) -> Iterator[Case]:
         create_from_bspline,
         lambda: create_from_bspline(non_bezier_bspline),
         {"kind": "not-bezier-like-knots"},
+        must_reject=True,  # "If the B-spline does not have Bezier-like knots"
     )
 
 
@@ -2309,6 +2515,10 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
                         lambda r, k=k: _monomial_reproduction_failure(r, k),
                     ),
                 ),
+                # `degree` defaults to `n_pts - 1`, so `degree < n_pts` holds for every
+                # swept count including 1, the callable returns the documented shape,
+                # and the nodes are consistent -- all three refusals avoided.
+                must_succeed=True,
             )
 
             if profile is Profile.FULL and n_pts >= 3:  # noqa: PLR2004
@@ -2321,6 +2531,7 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
                         func, n_pts, degree=low_degree
                     ),
                     {"n_pts": n_pts, "degree": low_degree, "kind": "least-squares"},
+                    must_succeed=True,  # `low_degree = n_pts - 2 < n_pts`
                 )
 
     monomial_invariant_k2 = custom(
@@ -2337,6 +2548,7 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
             lambda values=values, node_arr=node_arr: fit_bezier(values, node_arr),
             {"n_pts": n_pts, "nodes": nodes_kind},
             invariants=(monomial_invariant_k2,),
+            must_succeed=True,  # tensor-product nodes, so `degree` is optional
         )
 
     generator = rng(18000)
@@ -2350,6 +2562,9 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
         {"n_pts": 12, "degree": 3, "kind": "scattered"},
         invariants=(monomial_invariant_k2,),
         arrays={"pts": scattered_pts, "values": scattered_values},
+        # Scattered nodes with an explicit `degree`, and 4 coefficients for 12 samples,
+        # so the system is overdetermined rather than underdetermined.
+        must_succeed=True,
     )
 
     yield Case(
@@ -2358,6 +2573,7 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
         fit_bezier,
         lambda: fit_bezier(scattered_values, scattered_pts),
         {"kind": "scattered-missing-degree"},
+        must_reject=True,  # "degree is required for scattered (non-tensor-product) nodes"
     )
     yield Case(
         GROUP,
@@ -2365,6 +2581,7 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
         interpolate_bezier,
         lambda: interpolate_bezier(func, 4, degree=5),
         {"kind": "degree-exceeds-n_pts"},
+        must_reject=True,  # "degree >= n_pts"
     )
     yield Case(
         GROUP,
@@ -2372,6 +2589,7 @@ def _interpolate_fit_cases(profile: Profile) -> Iterator[Case]:
         interpolate_bezier,
         lambda: interpolate_bezier(lambda lattice: np.zeros(3), 5),
         {"kind": "bad-return-shape"},
+        must_reject=True,  # "the callable returns an unexpected shape"
     )
 
 
@@ -2432,6 +2650,17 @@ def _de_casteljau_kernel_cases(profile: Profile) -> Iterator[Case]:
                 lambda coeff=coeff: _de_casteljau_eval_scalar(coeff, 0.5),
                 {"length": length, "dtype": str(dtype), "t": 0.5},
                 arrays={"coeff": coeff},
+                # `length == 0` is the one case in this module that is deliberately
+                # *outside* the contract and so carries neither flag. This is a Layer-3
+                # kernel whose docstring says "Inputs are assumed to be correct (no
+                # validation performed)", so it owes a zero-length array nothing: the
+                # bounds-check hit it produces is the sweep proving the harness is live
+                # on a real pantr kernel, and a record for the port that this call site
+                # needs its own guard -- not a defect in the kernel. Flagging it either
+                # way would be a false claim, and neither flag could change the verdict
+                # anyway: `_core.classify` reports a Numba out-of-bounds access before
+                # it consults them. The other lengths are in contract.
+                must_succeed=length > 0,
             )
 
         coeff5 = np.linspace(-1.0, 1.0, 5, dtype=dtype)
@@ -2444,6 +2673,10 @@ def _de_casteljau_kernel_cases(profile: Profile) -> Iterator[Case]:
                 {"t": t, "dtype": str(dtype)},
                 finite_inputs=finite,
                 arrays={"coeff": coeff5},
+                # The kernel restricts `t` to nothing at all -- de Casteljau is a
+                # polynomial evaluation valid for any real parameter -- so an
+                # out-of-domain or non-finite `t` must still return.
+                must_succeed=True,
             )
 
 
@@ -2474,6 +2707,9 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
                 lambda f=f: _bernstein_interpolate(f),
                 {"shape": shape, "dtype": str(dtype)},
                 arrays={"f": f},
+                # Well-formed 1-D sample arrays: `_bernstein_interpolate` validates
+                # nothing, but nothing here violates its implicit shape contract either.
+                must_succeed=True,
             )
 
         zeros = np.zeros(8, dtype=dtype)
@@ -2483,6 +2719,7 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
             _bernstein_interpolate,
             lambda zeros=zeros: _bernstein_interpolate(zeros),
             {"kind": "all-zeros", "dtype": str(dtype)},
+            must_succeed=True,
         )
 
         if profile is Profile.FULL:
@@ -2495,6 +2732,7 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
                 lambda outlier=outlier: _bernstein_interpolate(outlier),
                 {"kind": "huge-outlier-among-tiny", "dtype": str(dtype)},
                 arrays={"f": outlier},
+                must_succeed=True,
             )
 
         nan_f = np.linspace(0.0, 1.0, 8, dtype=dtype)
@@ -2507,6 +2745,10 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
             {"kind": "nan", "dtype": str(dtype)},
             finite_inputs=False,
             arrays={"f": nan_f},
+            # No finiteness precondition is stated anywhere on this helper, so a `NaN`
+            # sample is unspecified rather than illegal: it must return, and what it
+            # returns is not graded (`finite_inputs=False`).
+            must_succeed=True,
         )
 
         f_2d = rng(19000).uniform(0.0, 1.0, (5, 4)).astype(dtype)
@@ -2517,6 +2759,7 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
             lambda f_2d=f_2d: _bernstein_interpolate(f_2d),
             {"shape": (5, 4), "dtype": str(dtype)},
             arrays={"f": f_2d},
+            must_succeed=True,
         )
 
         if profile is Profile.FULL:
@@ -2528,6 +2771,7 @@ def _bernstein_interpolate_kernel_cases(profile: Profile) -> Iterator[Case]:
                 lambda f_3d=f_3d: _bernstein_interpolate(f_3d),
                 {"shape": (3, 3, 3), "dtype": str(dtype)},
                 arrays={"f": f_3d},
+                must_succeed=True,
             )
 
 
@@ -2563,6 +2807,11 @@ def _coeff_family_cases(profile: Profile) -> Iterator[Case]:
                     lambda bezier=bezier, pts=pts: bezier.evaluate(pts),
                     {"degree": degree, "dtype": str(dtype), "family": spec.name},
                     arrays={"control_points": spec.values},
+                    # Degenerate *geometry* is not an illegal input: a collapsed,
+                    # collinear or identically-zero control polygon is a well-formed
+                    # array of the right shape and dtype, and `evaluate` states no
+                    # condition on the values. Every family here must return.
+                    must_succeed=True,
                 )
 
 
@@ -2606,6 +2855,13 @@ def _rational_weight_cases(profile: Profile) -> Iterator[Case]:
                 {"weight": weight_name, "dtype": str(dtype)},
                 finite_inputs=False,
                 arrays={"control_points": cp},
+                # Deliberately unflagged, and the docstring above says why: a zero,
+                # negative or near-threshold weight is neither validated by the
+                # constructor nor documented as rejected by `evaluate`, so both a
+                # refusal and a returned `inf` are defensible. Asserting either would
+                # be inventing the contract rather than grading against it. The one
+                # thing that would settle it is a `Raises:` entry or a stated
+                # positivity precondition on the weights; neither exists.
             )
 
 

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -49,7 +49,15 @@ from pantr.quad import PointsLattice
 from pantr.tolerance import get_default, get_machine_epsilon
 from pantr.transform import AffineTransform
 
-from ._axes import Profile, coeff_specs, degrees, dtypes, point_specs, rng
+from ._axes import (
+    EXTRAPOLATION_POINT_FAMILIES,
+    Profile,
+    coeff_specs,
+    degrees,
+    dtypes,
+    point_specs,
+    rng,
+)
 from ._core import Case, custom, expected_shape
 
 if TYPE_CHECKING:
@@ -86,18 +94,6 @@ def _rank_dim_combos(profile: Profile) -> tuple[tuple[int, int], ...]:
         tuple[tuple[int, int], ...]: ``(rank, dim)`` pairs.
     """
     return _RANK_DIM_SMOKE if profile is Profile.SMOKE else _RANK_DIM_FULL
-
-
-_EXTRAPOLATION_POINT_FAMILIES: Final = frozenset(
-    {"just_outside_right", "just_outside_left", "far_outside", "just_outside"}
-)
-"""Point families that deliberately evaluate outside ``[0, 1]``.
-
-Bernstein basis functions extrapolate like ``O(t ** n)``, so at a fixed
-off-domain parameter a high enough degree overflows even before any
-implementation defect is involved; these families are excluded from the
-automatic finiteness check rather than asserted finite at every degree.
-"""
 
 
 _MAGNITUDE_FULL: Final = (
@@ -567,7 +563,7 @@ def _evaluate_cases(profile: Profile) -> Iterator[Case]:
                     # eventually float64) well before any implementation error
                     # is involved -- nothing in `evaluate`'s contract promises
                     # a finite answer for these families at every degree.
-                    finite_expected = finite and name not in _EXTRAPOLATION_POINT_FAMILIES
+                    finite_expected = finite and name not in EXTRAPOLATION_POINT_FAMILIES
                     # Every family here has the shape and dtype `evaluate` asks for, and
                     # `evaluate` states no domain at all for `pts` -- there is no
                     # rejection clause an out-of-domain, empty or `NaN` point could

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -60,6 +60,7 @@ from pantr.bspline import (
 from pantr.tolerance import get_machine_epsilon
 
 from ._axes import (
+    EXTRAPOLATION_POINT_FAMILIES,
     Profile,
     coeff_specs,
     degrees,
@@ -554,9 +555,24 @@ def _root_quality(spline: Bspline, degree: int, dtype: npt.DTypeLike) -> Predica
     A degree-``n`` polynomial has at most ``n`` roots per interval, and a spline with
     ``k`` intervals therefore at most ``degree * k``; more than that is a defect no
     conditioning argument excuses. Each root must lie in the domain, and each must be an
-    actual root: de Boor evaluation of a degree-``n`` spline with coefficients of
-    magnitude ``cs`` carries about ``n * eps * cs`` of noise, so the residual is checked
-    against that and nothing tighter.
+    actual root.
+
+    "An actual root" needs two terms, not one. The first is the evaluation noise: de Boor
+    evaluation of a degree-``n`` spline with coefficients of magnitude ``cs`` carries about
+    ``n * eps * cs``. The second is the root finder's own stopping criterion, which the
+    original bound omitted. ``find_roots`` documents ``tol`` as a *parametric* tolerance --
+    the iteration stops when the spread of the last ``degree`` iterates falls to
+    ``tol * max(|t_a|, |t_{a+degree}|, domain_length)`` -- so a root located to ``dt`` in
+    the parameter leaves a residual of about ``|f'| * dt``, about which the evaluation
+    noise says nothing. Bounding the derivative by ``degree * max|delta c| / h_min``, the
+    standard Lipschitz bound read off the hodograph's control points, closes the gap.
+
+    Both terms are needed and neither is slack. With only the first, a genuine root located
+    to a few ulps of parametric precision was reported as a defect at degree 62 -- residual
+    1.7e-13 against a bound of 1.1e-13, where the corrected bound is 6.1e-13. With the
+    second added the check still refutes what it should: a returned value with no zero
+    anywhere near it, off by 0.03 in the parameter, exceeds the corrected bound by a factor
+    of 6.7e11.
 
     Args:
         spline (Bspline): The spline whose roots were requested.
@@ -571,10 +587,19 @@ def _root_quality(spline: Bspline, degree: int, dtype: npt.DTypeLike) -> Predica
     lo = float(knots[degree])
     hi = float(knots[knots.size - degree - 1])
     limit = degree * space.num_intervals
-    scale = float(np.max(np.abs(np.asarray(spline.control_points, dtype=np.float64))))
-    residual_tol = (
-        _ERROR_SAFETY_FACTOR * (degree + 1) * get_machine_epsilon(dtype) * max(scale, 1.0)
+    control = np.asarray(spline.control_points, dtype=np.float64)
+    scale = float(np.max(np.abs(control)))
+    eps = get_machine_epsilon(dtype)
+    evaluation_noise = _ERROR_SAFETY_FACTOR * (degree + 1) * eps * max(scale, 1.0)
+    # `find_roots` defaults `tol` to `get_strict(dtype)`, which is `eps` to within the
+    # safety factor this bound already carries, times the scale its docstring names.
+    parametric_tol = eps * max(abs(lo), abs(hi), hi - lo)
+    slope_bound = (
+        degree * float(np.max(np.abs(np.diff(control, axis=0)))) / _min_nonzero_span(space)
+        if degree > 0 and control.shape[0] > 1
+        else 0.0
     )
+    residual_tol = evaluation_noise + _ERROR_SAFETY_FACTOR * slope_bound * parametric_tol
 
     def predicate(result: object) -> str | None:
         roots = np.asarray(result, dtype=np.float64).ravel()
@@ -607,6 +632,16 @@ def _derivative_agreement(
     parametric span converts that into the derivative's own units. Anything tighter would
     report the finite difference's own noise as a defect.
 
+    That derivation assumes ``h`` is represented exactly, which it is on the unit domain
+    and is not on a translated one. Forming ``t +/- h`` rounds the *sum* to one ulp of
+    ``|t|``, so the step actually taken differs from ``h`` by up to ``eps * |t|``, and the
+    quotient inherits a relative error of ``eps * |t| / h`` -- six orders of magnitude on a
+    domain at ``1e6`` with spans of order one. Ignoring that reported 32 findings, all but
+    two of them on the translated domain; the worst was ``4.2e-6`` against a bound of
+    ``2.3e-9``, while the corrected bound below is ``3.7e-5`` there and comfortably
+    holds. This is an honest statement about what a finite difference can resolve at that
+    coordinate magnitude, not slack granted to the derivative.
+
     Args:
         curve (Bspline): The spline whose derivative is under test.
         pts (npt.NDArray[np.floating[Any]]): Parameters strictly inside knot intervals,
@@ -620,12 +655,19 @@ def _derivative_agreement(
     eps = get_machine_epsilon(fixture.dtype)
     span = _min_nonzero_span(fixture.space)
     step = float(eps ** (1.0 / 3.0)) * span
+    lo, hi = fixture.domain
+    coord_scale = max(abs(lo), abs(hi), 1.0)
+    # Two independent floors, added rather than maximized: the finite difference's own
+    # truncation/rounding balance, and the error inherited from a step that cannot be
+    # represented exactly at this coordinate magnitude. On the unit domain the second
+    # term is negligible and this reduces to the original bound.
+    fd_floor = eps ** (2.0 / 3.0) / span
+    step_representation = eps * coord_scale / (step * span) if step > 0.0 else 0.0
     tol = (
         _ERROR_SAFETY_FACTOR
         * (fixture.degree + 1)
-        * eps ** (2.0 / 3.0)
+        * (fd_floor + step_representation)
         * max(value_scale, 1.0)
-        / span
     )
 
     def predicate(result: object) -> str | None:
@@ -684,6 +726,64 @@ def _split_agreement(curve: Bspline, fixture: _Fixture, tol: float) -> Predicate
     return predicate
 
 
+def _restriction_agreement(curve: Bspline, window: tuple[float, float], tol: float) -> Predicate:
+    """Build a predicate requiring a restriction to span its window and reproduce there.
+
+    ``Bspline.restrict`` carried no invariant at all, which is how it came to be the one
+    entry point in this sweep whose worst failure was invisible: on a domain whose upper
+    bound exceeds 16 in float64 it can return a spline over a *shorter* window than the
+    caller asked for, silently. Whether that surfaces at all was an accident of the
+    fixture -- with four intervals the truncated knot vector is too short and the
+    constructor raises, so it read as a loud ``must_succeed`` failure, but with twenty
+    intervals enough knots survive and the call simply returns the wrong curve. Grading
+    only "did it raise" cannot tell those apart.
+
+    So both halves are checked: the returned domain must be the requested window, and the
+    restricted spline must reproduce the original inside it. The samples stay strictly
+    inside the window, since its ends are knots and a C^-1 spline has two values there --
+    the same reason :func:`_split_agreement` avoids the split point.
+
+    Args:
+        curve (Bspline): The spline before restriction.
+        window (tuple[float, float]): The ``(lower, upper)`` bounds requested.
+        tol (float): Bound from :func:`_eval_tolerance`.
+
+    Returns:
+        Predicate: Check for :func:`adversarial_sweep._core.custom`.
+    """
+    lower, upper = window
+    inner = np.array([0.13, 0.37, 0.61, 0.83])
+    sample = lower + (upper - lower) * inner
+
+    def predicate(result: object) -> str | None:
+        if not isinstance(result, Bspline):
+            return f"expected a Bspline, got {type(result).__name__}"
+        space = result.space.spaces[0]
+        degree = int(space.degree)
+        knots = np.asarray(space.knots, dtype=np.float64)
+        got_lo = float(knots[degree])
+        got_hi = float(knots[knots.size - degree - 1])
+        # The window's own scale sets what "the same endpoint" can mean: at |t| ~ 1e6 the
+        # endpoints are representable to about one ulp there, not to an absolute epsilon.
+        endpoint_tol = 8.0 * get_machine_epsilon(result.dtype) * max(abs(lower), abs(upper), 1.0)
+        if abs(got_lo - lower) > endpoint_tol or abs(got_hi - upper) > endpoint_tol:
+            return (
+                f"restricted domain is [{got_lo:.17g}, {got_hi:.17g}], "
+                f"asked for [{lower:.17g}, {upper:.17g}]"
+            )
+        pts = sample.astype(result.dtype)
+        expected = np.asarray(curve.evaluate(pts), dtype=np.float64)
+        got = np.asarray(result.evaluate(pts), dtype=np.float64)
+        if got.shape != expected.shape:
+            return f"shape {got.shape} != original {expected.shape}"
+        worst = float(np.max(np.abs(got - expected))) if got.size else 0.0
+        if not np.isfinite(worst) or worst > tol:
+            return f"max|f - f_ref| = {worst:.3e} > {tol:.3e} inside the window"
+        return None
+
+    return predicate
+
+
 def _bezier_agreement(curve: Bspline, fixture: _Fixture, tol: float) -> Predicate:
     """Build a predicate requiring each extracted Bézier to reproduce its own interval.
 
@@ -737,9 +837,22 @@ def _product_agreement(
     evaluation error times the other factor's magnitude, so the bound is the evaluation
     tolerance scaled by the value magnitude once more.
 
+    The comparison parameters must avoid the knots, for the same reason
+    :func:`_split_agreement` and :func:`_bezier_agreement` say so in their own
+    docstrings: at an interior knot of multiplicity ``degree + 1`` the spline has two
+    values, and the product's own representation is free to pick the other one. Passing
+    the shared ``_sample_points(fixture)`` here -- which lands on ``0.5``, an interior
+    knot of every ``_mult_knots`` fixture -- reported that discontinuity as a defect on
+    34 cases. Measured on the unit domain with the swept fixtures: at the fractions the
+    shared sampler uses, ``max|fg - f*g|`` is 1.5e-1 at degree 0, 3.9e-1 at degree 1,
+    1.1e-1 at degree 2 and 1.7e-1 at degree 3; at the interval midpoints of the very
+    same splines it is 0, 1.1e-16, 1.7e-16 and 1.5e-16. The product is exact, and the
+    probe was measuring the jump.
+
     Args:
         scalar (Bspline): The scalar spline being squared.
-        pts (npt.NDArray[np.floating[Any]]): Comparison parameters.
+        pts (npt.NDArray[np.floating[Any]]): Comparison parameters. Must lie strictly
+            inside the knot intervals; pass ``_sample_points(fixture, avoid_knots=True)``.
         fixture (_Fixture): Supplies degree and dtype.
 
     Returns:
@@ -1216,7 +1329,14 @@ def _tabulation_cases(profile: Profile) -> Iterator[Case]:
                 lambda space=space, pts=pts: space.tabulate_basis(pts.pts, validate=False),
                 {**fixture.params, "pts": pts.name, "validate": False},
                 invariants=(index,),
-                finite_inputs=pts.finite,
+                # This is the one tabulation case that actually *evaluates* off the
+                # domain -- the two above reject an out-of-domain point before any
+                # arithmetic -- so it is also the only one that can legitimately
+                # overflow. Cox-de Boor extrapolates like O(t ** degree), and at
+                # degree 62 in float32 the result is `inf` for arithmetic reasons.
+                # That produced 18 findings, every one of them float32 at degree 62 on
+                # the `far_outside` family. See EXTRAPOLATION_POINT_FAMILIES.
+                finite_inputs=pts.finite and pts.name not in EXTRAPOLATION_POINT_FAMILIES,
             )
 
 
@@ -1532,7 +1652,9 @@ def _one_curve_cases(fixture: _Fixture, kind: str, profile: Profile) -> Iterator
         Bspline.multiply,
         lambda scalar=scalar: scalar.multiply(scalar),
         {**fixture.params, "cp": kind},
-        invariants=(custom("product-is-pointwise", _product_agreement(scalar, pts, fixture)),),
+        invariants=(
+            custom("product-is-pointwise", _product_agreement(scalar, smooth_pts, fixture)),
+        ),
         must_succeed=legal,
     )
 
@@ -1543,6 +1665,9 @@ def _one_curve_cases(fixture: _Fixture, kind: str, profile: Profile) -> Iterator
         Bspline.restrict,
         lambda curve=curve, window=window: curve.restrict(window),
         {**fixture.params, "cp": kind},
+        invariants=(
+            custom("restriction-spans-the-window", _restriction_agreement(curve, window, tol)),
+        ),
         must_succeed=legal,
     )
 

--- a/tools/adversarial_sweep/_probes_geometry.py
+++ b/tools/adversarial_sweep/_probes_geometry.py
@@ -1,5 +1,13 @@
 """Probes for :mod:`pantr.geometry` and :mod:`pantr.transform`.
 
+Every case carries ``must_succeed`` or ``must_reject``: both classes state closed
+``Raises:`` lists, so each input is on one side of a stated clause or the other, and
+nothing here is a genuine contract boundary. Two verdicts are worth stating up front
+because they read as errors and are not: an **inverted** box (``hi < lo``) is legal and
+is how :class:`~pantr.geometry.AABB` represents the empty set, and an **infinite** corner
+is legal too, since the constructor documents its arguments as "array-like of
+finite-or-infinite floats" and rejects only ``NaN``.
+
 Both are pure NumPy, so the yield here is contract violations and translation
 sensitivity rather than Numba overruns: the bounding-box invariants that matter are
 that a transformed box still encloses the images of every corner, and that
@@ -97,6 +105,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                 lambda lo=lo, hi=hi: AABB(lo, hi),
                 {"ndim": ndim, "lo": lo_val, "hi": hi_val},
                 arrays={"lo": lo, "hi": hi},
+                must_succeed=True,
             )
             yield Case(
                 GROUP,
@@ -104,6 +113,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                 AABB,
                 lambda lo=lo: AABB(lo, lo),
                 {"ndim": ndim, "lo": lo_val, "kind": "collapsed"},
+                must_succeed=True,  # a zero-volume box is a box
             )
             yield Case(
                 GROUP,
@@ -111,6 +121,10 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                 AABB,
                 lambda lo=lo, hi=hi: AABB(hi, lo),
                 {"ndim": ndim, "kind": "inverted"},
+                # Legal, and deliberately so: the `Raises:` list covers shape mismatch,
+                # `NaN` and `ndim < 1` and says nothing about ordering, because an
+                # inverted box is how `is_empty()` reports the empty set.
+                must_succeed=True,
             )
 
             box = AABB(lo, hi)
@@ -125,6 +139,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                 invariants=(
                     custom("center-inside", lambda r: None if r else "center reported out"),
                 ),
+                must_succeed=True,  # a length-`ndim`, NaN-free point
             )
             yield Case(
                 GROUP,
@@ -145,6 +160,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                         else f"union {r} does not enclose both inputs",
                     ),
                 ),
+                must_succeed=True,  # matching `ndim`, the only thing `union` checks
             )
             yield Case(
                 GROUP,
@@ -164,6 +180,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                         else f"intersection {r} escapes both inputs",
                     ),
                 ),
+                must_succeed=True,  # matching `ndim`, as above
             )
             yield Case(
                 GROUP,
@@ -171,6 +188,9 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                 AABB.pad,
                 lambda box=box, lo=lo, hi=hi: box.pad(-0.75 * float(np.max(hi - lo))),
                 {"ndim": ndim, "kind": "pad-collapses-box"},
+                # Padding a box out of existence yields an inverted box, which is legal
+                # (see the `aabb_inverted` note above), not a refusal.
+                must_succeed=True,
             )
 
             if profile is Profile.FULL:
@@ -183,6 +203,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                     lambda nan_lo=nan_lo, hi=hi: AABB(nan_lo, hi),
                     {"ndim": ndim, "kind": "nan"},
                     finite_inputs=False,
+                    must_reject=True,  # "If the shapes mismatch, contain a NaN, ..."
                 )
                 inf_hi = hi.copy()
                 inf_hi[0] = np.inf
@@ -193,6 +214,10 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                     lambda lo=lo, inf_hi=inf_hi: AABB(lo, inf_hi),
                     {"ndim": ndim, "kind": "inf"},
                     finite_inputs=False,
+                    # An infinite corner is legal: the constructor documents
+                    # "finite-or-infinite floats" and rejects only `NaN`. This is the
+                    # case that makes `AABB.unbounded` expressible.
+                    must_succeed=True,
                 )
                 yield Case(
                     GROUP,
@@ -200,6 +225,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                     AABB,
                     lambda lo=lo, ndim=ndim: AABB(lo, np.zeros(ndim + 1)),
                     {"ndim": ndim, "kind": "shape-mismatch"},
+                    must_reject=True,  # "If the shapes mismatch, ..."
                 )
                 yield Case(
                     GROUP,
@@ -215,6 +241,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                             else f"from_bounds(as_bounds()) != original: {r} vs {box}",
                         ),
                     ),
+                    must_succeed=True,
                 )
 
                 # Transformed enclosure: the invariant a translated domain breaks first.
@@ -231,6 +258,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                         custom("encloses-corners", _encloses_transformed_corners(lo, hi, affine)),
                     ),
                     arrays={"lo": lo, "hi": hi, "matrix": matrix, "offset": affine.offset},
+                    must_succeed=True,
                 )
                 singular = np.zeros((ndim, ndim))
                 yield Case(
@@ -241,6 +269,9 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
                         AffineTransform(singular, np.zeros(ndim))
                     ),
                     {"ndim": ndim, "kind": "singular-matrix"},
+                    # Transforming *by* a singular map is legal -- nothing inverts it --
+                    # unlike `AffineTransform.inverse`, which documents a refusal.
+                    must_succeed=True,
                 )
 
     for ndim in (0, -1):
@@ -251,6 +282,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
             lambda ndim=ndim: AABB.unbounded(ndim),
             {"ndim": ndim},
             finite_inputs=False,
+            must_reject=True,  # "... or the implied ndim is less than 1"
         )
         yield Case(
             GROUP,
@@ -259,6 +291,7 @@ def _aabb_cases(profile: Profile) -> Iterator[Case]:
             lambda ndim=ndim: AABB.empty(ndim),
             {"ndim": ndim},
             finite_inputs=False,
+            must_reject=True,  # as above
         )
 
 
@@ -280,6 +313,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             AffineTransform.identity,
             lambda ndim=ndim: AffineTransform.identity(ndim),
             {"ndim": ndim},
+            must_succeed=True,
         )
         yield Case(
             GROUP,
@@ -287,6 +321,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             AffineTransform.inverse,
             lambda ndim=ndim: AffineTransform(np.zeros((ndim, ndim))).inverse,
             {"ndim": ndim, "kind": "singular"},
+            must_reject=True,  # "ValueError: If the matrix is singular."
         )
         yield Case(
             GROUP,
@@ -294,6 +329,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             AffineTransform,
             lambda ndim=ndim: AffineTransform(np.zeros((ndim, ndim + 1))),
             {"ndim": ndim, "kind": "non-square"},
+            must_reject=True,  # "If *matrix* is not 2-D or not square."
         )
         yield Case(
             GROUP,
@@ -301,6 +337,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             AffineTransform.scaling,
             lambda ndim=ndim: AffineTransform.scaling(np.zeros(ndim)),
             {"ndim": ndim, "kind": "zero-factor"},
+            must_reject=True,  # "If any factor is non-finite or zero (singular transform)."
         )
         yield Case(
             GROUP,
@@ -309,6 +346,12 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             lambda eye=eye, ndim=ndim: AffineTransform(eye, np.full(ndim, np.nan)),
             {"ndim": ndim, "kind": "nan-translation"},
             finite_inputs=False,
+            # `__init__` refuses only a non-square matrix and a translation of the wrong
+            # length; a non-finite translation is unspecified, not illegal. Note the
+            # asymmetry with `rotation_2d` and `scaling`, which *do* document a
+            # finiteness refusal -- one more reason to grade each entry point from its
+            # own docstring rather than from a class-wide habit.
+            must_succeed=True,
         )
 
         if profile is not Profile.FULL:
@@ -333,6 +376,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
                     ),
                 ),
                 arrays={"matrix": matrix, "offset": offset},
+                must_succeed=True,  # `matrix` is diagonally dominant, so not singular
             )
         yield Case(
             GROUP,
@@ -341,6 +385,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             lambda: AffineTransform.rotation_2d(np.nan),
             {"kind": "nan-angle"},
             finite_inputs=False,
+            must_reject=True,  # "ValueError: If *angle* is non-finite."
         )
         yield Case(
             GROUP,
@@ -348,6 +393,7 @@ def _transform_cases(profile: Profile) -> Iterator[Case]:
             AffineTransform.mirror,
             lambda ndim=ndim: AffineTransform.mirror(np.zeros(ndim)),
             {"ndim": ndim, "kind": "zero-normal"},
+            must_reject=True,  # "ValueError: If *normal* is zero or non-finite."
         )
 
 

--- a/tools/adversarial_sweep/_probes_grid.py
+++ b/tools/adversarial_sweep/_probes_grid.py
@@ -274,6 +274,12 @@ def _locate_roundtrip_case(
             return f"locate_many mismatch at cids {bad[:5].tolist()}"
         return None
 
+    # Being outside the grid is a documented *return value*, not a refusal:
+    # `locate` documents "Non-finite coordinates (NaN or infinity) are outside
+    # every cell" and returns None, and `locate_many` documents "-1 for points
+    # outside the grid (including points with NaN or infinite coordinates)". So
+    # every case in this helper must return; the returned value is what the
+    # invariants grade.
     yield Case(
         GROUP,
         f"{group_tag}_locate_roundtrip",
@@ -281,6 +287,7 @@ def _locate_roundtrip_case(
         run_roundtrip,
         params,
         invariants=(custom("locate-roundtrip", check_roundtrip),),
+        must_succeed=True,
     )
 
     # The domain's own lower corner, not an arbitrary cell's bounds: after refinement
@@ -305,6 +312,7 @@ def _locate_roundtrip_case(
         lambda outside=outside: grid.locate(outside),
         {**params, "kind": "far-outside"},
         invariants=(custom("outside-is-none", check_none),),
+        must_succeed=True,
     )
 
     if profile is Profile.FULL:
@@ -319,6 +327,7 @@ def _locate_roundtrip_case(
                 {**params, "kind": name},
                 invariants=(custom(f"{name}-is-none", check_none),),
                 finite_inputs=False,
+                must_succeed=True,
             )
 
     def check_all_outside(result: object) -> str | None:
@@ -337,6 +346,7 @@ def _locate_roundtrip_case(
         {**params, "kind": "nan-inf-batch"},
         invariants=(custom("nonfinite-is-minus-one", check_all_outside),),
         finite_inputs=False,
+        must_succeed=True,
     )
 
 
@@ -363,6 +373,10 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
             grid = _tp_grid(ndim, domain, n_per_axis)
             params = {"ndim": ndim, "domain": domain, "n_per_axis": n_per_axis}
 
+            # Uniform breakpoints from np.linspace are strictly increasing, finite,
+            # and have >= 2 entries per axis -- every precondition __init__ states --
+            # and collect_cell_bounds documents no Raises: at all, so all three below
+            # are legal by construction.
             yield Case(
                 GROUP,
                 f"tp_construct_{tag}",
@@ -377,6 +391,7 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
                         else f"num_cells={r.num_cells}, expected {n**ndim}",
                     ),
                 ),
+                must_succeed=True,
             )
 
             dom_lo, dom_hi = grid.bounds[:, 0].copy(), grid.bounds[:, 1].copy()
@@ -389,6 +404,7 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
                 invariants=(
                     custom("cell-tiling", _tiling_predicate(dom_lo, dom_hi, grid.num_cells)),
                 ),
+                must_succeed=True,
             )
             yield Case(
                 GROUP,
@@ -407,19 +423,32 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
                         ),
                     ),
                 ),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
 
-    # Malformed constructions: each must be a documented rejection, not a finding.
-    yield Case(GROUP, "tp_empty_breakpoints", TensorProductGrid, lambda: TensorProductGrid([]), {})
+    # Malformed constructions: each is a documented rejection ("ValueError: If
+    # breakpoints is empty, any axis has fewer than two entries, or any axis is
+    # non-finite or not strictly increasing.", `_tensor_product_grid.py:86-89`).
+    # tp_flat_axis ([0, 0, 1]) is caught by the same strictly-increasing clause,
+    # not a separate one.
+    yield Case(
+        GROUP,
+        "tp_empty_breakpoints",
+        TensorProductGrid,
+        lambda: TensorProductGrid([]),
+        {},
+        must_reject=True,
+    )
     yield Case(
         GROUP,
         "tp_too_short_axis",
         TensorProductGrid,
         lambda: TensorProductGrid([np.array([0.0])]),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -428,6 +457,7 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
         lambda: TensorProductGrid([np.array([0.0, np.nan, 1.0])]),
         {},
         finite_inputs=False,
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -435,6 +465,7 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
         TensorProductGrid,
         lambda: TensorProductGrid([np.array([0.0, 1.0, 0.5])]),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -442,6 +473,7 @@ def _tp_construction_cases(profile: Profile) -> Iterator[Case]:
         TensorProductGrid,
         lambda: TensorProductGrid([np.array([0.0, 0.0, 1.0])]),
         {},
+        must_reject=True,
     )
 
 
@@ -464,6 +496,9 @@ def _tp_uniformity_cases(profile: Profile) -> Iterator[Case]:
         tag = _grid_tag(2, domain)
         breakpoints = _uniform_breakpoints(2, domain, 4)
         exact_grid = TensorProductGrid(breakpoints)
+        # Both grids below are validly constructed and `is_uniform` is a property
+        # with no `Raises:`; the True/False verdict is graded by the invariant,
+        # not by the flag.
         yield Case(
             GROUP,
             f"tp_is_uniform_true_{tag}",
@@ -476,6 +511,7 @@ def _tp_uniformity_cases(profile: Profile) -> Iterator[Case]:
                     lambda r: None if r else "exactly-spaced grid reported non-uniform",
                 ),
             ),
+            must_succeed=True,
         )
 
         span = domain[1] - domain[0]
@@ -505,6 +541,7 @@ def _tp_uniformity_cases(profile: Profile) -> Iterator[Case]:
                 ),
             ),
             arrays={"breakpoints_axis0": perturbed[0]},
+            must_succeed=True,
         )
 
 
@@ -566,6 +603,9 @@ def _tp_neighbor_cases(profile: Profile) -> Iterator[Case]:
                             )
                 return None
 
+            # The thunk is a placeholder (`lambda: None`); the real calls happen
+            # inside the invariant, so `must_succeed` guards this case against a
+            # future refactor rather than grading anything today.
             yield Case(
                 GROUP,
                 f"tp_neighbor_symmetry_{tag}",
@@ -573,17 +613,20 @@ def _tp_neighbor_cases(profile: Profile) -> Iterator[Case]:
                 lambda: None,
                 {"ndim": ndim, "domain": domain},
                 invariants=(custom("neighbor-symmetry", check_symmetry),),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
     grid = _tp_grid(2, (0.0, 1.0), 2)
+    # "IndexError: If cid or lfid is out of range."
     yield Case(
         GROUP,
         "tp_neighbor_lfid_out_of_range",
         TensorProductGrid.neighbor_across_facet,
         lambda: grid.neighbor_across_facet(0, 4),
         {"kind": "lfid-oob"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -591,6 +634,7 @@ def _tp_neighbor_cases(profile: Profile) -> Iterator[Case]:
         TensorProductGrid.neighbor_across_facet,
         lambda: grid.neighbor_across_facet(grid.num_cells, 0),
         {"kind": "cid-oob"},
+        must_reject=True,
     )
 
 
@@ -629,6 +673,7 @@ def _tp_restrict_cases(profile: Profile) -> Iterator[Case]:
     if profile is Profile.FULL:
         selectors["single_center"] = np.array([grid.num_cells // 2])
         selectors["two_opposite_corners"] = np.array([0, grid.num_cells - 1])
+    # All ids below are in [0, num_cells).
     for name, ids in selectors.items():
         yield Case(
             GROUP,
@@ -637,12 +682,18 @@ def _tp_restrict_cases(profile: Profile) -> Iterator[Case]:
             lambda ids=ids: grid.restrict(ids),
             {"kind": name, "n_ids": int(ids.size)},
             invariants=(custom("restrict-is-pure-slice", check_exact_slice),),
+            must_succeed=True,
         )
 
     if profile is not Profile.FULL:
         return
     yield Case(
-        GROUP, "tp_restrict_empty", TensorProductGrid.restrict, lambda: grid.restrict([]), {}
+        GROUP,
+        "tp_restrict_empty",
+        TensorProductGrid.restrict,
+        lambda: grid.restrict([]),
+        {},
+        must_reject=True,  # "ValueError: If cell_ids is empty."
     )
     yield Case(
         GROUP,
@@ -650,6 +701,8 @@ def _tp_restrict_cases(profile: Profile) -> Iterator[Case]:
         TensorProductGrid.restrict,
         lambda: grid.restrict([grid.num_cells]),
         {},
+        # "IndexError: If any cell id is out of range [0, num_cells)."
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -657,6 +710,7 @@ def _tp_restrict_cases(profile: Profile) -> Iterator[Case]:
         TensorProductGrid.restrict,
         lambda: grid.restrict(np.array([0.5])),
         {},
+        must_reject=True,  # "TypeError: If cell_ids is not integer-valued."
     )
 
 
@@ -683,6 +737,7 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
                     lambda r: None if r.num_cells == 1 else f"num_cells={r.num_cells}, expected 1",
                 ),
             ),
+            must_succeed=True,
         )
         if profile is Profile.FULL and ndim > 1:
             anisotropic = tuple(range(2, 2 + ndim))
@@ -700,12 +755,21 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
                         else f"cells_per_axis={r.cells_per_axis}, expected {anisotropic}",
                     ),
                 ),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
+    # "ValueError: If bounds does not have shape (ndim, 2), any axis has lo >= hi,
+    # cells has the wrong length, or any count is < 1." The degenerate and
+    # inverted cases below are both caught by the single `lo >= hi` clause.
     yield Case(
-        GROUP, "uniform_grid_zero_cells", uniform_grid, lambda: uniform_grid([[0.0, 1.0]], 0), {}
+        GROUP,
+        "uniform_grid_zero_cells",
+        uniform_grid,
+        lambda: uniform_grid([[0.0, 1.0]], 0),
+        {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -713,6 +777,7 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
         uniform_grid,
         lambda: uniform_grid([[1.0, 1.0]], 2),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -720,6 +785,7 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
         uniform_grid,
         lambda: uniform_grid([[1.0, 0.0]], 2),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -727,6 +793,7 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
         uniform_grid,
         lambda: uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2, 2]),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -734,6 +801,7 @@ def _uniform_grid_factory_cases(profile: Profile) -> Iterator[Case]:
         uniform_grid,
         lambda: uniform_grid(np.zeros((2, 3)), 2),
         {},
+        must_reject=True,
     )
 
 
@@ -756,6 +824,7 @@ def _tensor_product_from_space_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_grid,
         lambda space=space: tensor_product_grid(space),
         {"kind": "clamped"},
+        must_succeed=True,
     )
     periodic_knots = np.arange(-2, 6, dtype=np.float64)
     periodic = BsplineSpace1D(periodic_knots, 2, periodic=True)
@@ -766,6 +835,7 @@ def _tensor_product_from_space_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_grid,
         lambda periodic_space=periodic_space: tensor_product_grid(periodic_space),
         {"kind": "periodic-axis"},
+        must_reject=True,  # "ValueError: If any direction of space is periodic."
     )
 
 
@@ -819,10 +889,12 @@ def _hier_construction_cases(profile: Profile) -> Iterator[Case]:
                         else f"num_cells={r.num_cells}, expected {root.num_cells}",
                     ),
                 ),
+                must_succeed=True,
             )
         if profile is Profile.FULL and ndim >= 2:  # noqa: PLR2004 -- anisotropic factor needs 2 axes
             # Alternate 2/1 per axis so every ndim gets a genuinely mixed factor
-            # (a factor of 1 means "no subdivision on that axis", which is legal).
+            # (a factor of 1 on an axis prevents subdivision in that direction,
+            # which is explicitly legal).
             anisotropic = tuple(2 if k % 2 == 0 else 1 for k in range(ndim))
             yield Case(
                 GROUP,
@@ -830,20 +902,28 @@ def _hier_construction_cases(profile: Profile) -> Iterator[Case]:
                 HierarchicalGrid,
                 lambda root=root, anisotropic=anisotropic: HierarchicalGrid(root, anisotropic),
                 {"ndim": ndim, "factor": anisotropic},
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
     root2 = _tp_grid(2, (0.0, 1.0), 2)
     yield Case(
-        GROUP, "hier_bad_root_type", HierarchicalGrid, lambda: HierarchicalGrid(object(), 2), {}
+        GROUP,
+        "hier_bad_root_type",
+        HierarchicalGrid,
+        lambda: HierarchicalGrid(object(), 2),
+        {},
+        must_reject=True,  # "TypeError: If root is not a TensorProductGrid."
     )
+    # "ValueError: If factor has the wrong length or any entry is < 1."
     yield Case(
         GROUP,
         "hier_factor_wrong_length",
         HierarchicalGrid,
         lambda: HierarchicalGrid(root2, (2, 2, 2)),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -851,6 +931,7 @@ def _hier_construction_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid,
         lambda: HierarchicalGrid(root2, 0),
         {},
+        must_reject=True,
     )
 
 
@@ -889,6 +970,9 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
                     else f"max_level={r.max_level}, expected {target_level}",
                 ),
             ),
+            # Each step refines an existing level with lo < hi inside the level's
+            # domain.
+            must_succeed=True,
         )
 
     if profile is not Profile.FULL:
@@ -918,6 +1002,9 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
                 else f"num_cells changed {r[0]} -> {r[1]} on a no-op refine",
             ),
         ),
+        # "If the intersection with active blocks at level is empty, the call is
+        # a silent no-op."
+        must_succeed=True,
     )
 
     # Coarsen exactly undoes a matching refine.
@@ -944,16 +1031,20 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
                 else f"num_cells {r[0]} -> refine -> coarsen -> {r[1]}",
             ),
         ),
+        must_succeed=True,
     )
 
     root3 = _tp_grid(2, (0.0, 1.0), 2)
     grid3 = HierarchicalGrid(root3, 2)
+    # "ValueError: If level is out of range, lo/hi have the wrong length, any
+    # lo[k] >= hi[k], or [lo, hi) falls entirely outside the level-level domain."
     yield Case(
         GROUP,
         "hier_refine_level_out_of_range",
         HierarchicalGrid.refine,
         lambda: grid3.refine(5, (0, 0), (1, 1)),
         {"kind": "level-oob"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -961,6 +1052,7 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.refine,
         lambda: grid3.refine(0, (1, 1), (1, 1)),
         {"kind": "lo-ge-hi"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -968,6 +1060,8 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.coarsen,
         lambda: (grid3.refine(0, (0, 0), (1, 1)), grid3.coarsen(0, (0, 0), (2, 2)))[-1],
         {"kind": "partially-refined-region"},
+        # "...or the region is not fully refined to exactly level level+1."
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -975,6 +1069,7 @@ def _hier_refine_coarsen_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.refine_cells,
         lambda: grid3.refine_cells([grid3.num_cells]),
         {"kind": "cid-oob"},
+        must_reject=True,  # "IndexError: If any id in cell_ids is out of range."
     )
 
 
@@ -997,7 +1092,9 @@ def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
             params = {"ndim": ndim, "target_level": target_level}
 
             # `collect_cell_bounds` docstring claims exact agreement with `cell_bounds`
-            # (`_hierarchical_grid.py:1420-1421`): bitwise check.
+            # (`_hierarchical_grid.py:1420-1421`): bitwise check. All three cases below
+            # run on a validly refined grid and none of the three methods documents a
+            # `Raises:` section.
             yield Case(
                 GROUP,
                 f"hier_collect_vs_percell_{tag}",
@@ -1010,6 +1107,7 @@ def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
                         _collect_vs_percell_predicate(grid, exact=True),
                     ),
                 ),
+                must_succeed=True,
             )
 
             dom_lo, dom_hi = root.bounds[:, 0].copy(), root.bounds[:, 1].copy()
@@ -1022,6 +1120,7 @@ def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
                 invariants=(
                     custom("cell-tiling", _tiling_predicate(dom_lo, dom_hi, grid.num_cells)),
                 ),
+                must_succeed=True,
             )
 
             # `export_cells` docstring (`_hierarchical_grid.py:1502-1516`) claims only
@@ -1034,6 +1133,7 @@ def _hier_bounds_cases(profile: Profile) -> Iterator[Case]:
                 grid.export_cells,
                 params,
                 invariants=(custom("export-cells-bound", _export_cells_predicate(grid)),),
+                must_succeed=True,
             )
 
 
@@ -1123,6 +1223,7 @@ def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
             lambda level=level: grid.active_leaf_mask(level),
             {"level": level},
             invariants=(expected_shape(grid.level_cells_per_axis(level)),),
+            must_succeed=True,
         )
         yield Case(
             GROUP,
@@ -1131,16 +1232,24 @@ def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
             lambda level=level: grid.subdomain_mask(level),
             {"level": level},
             invariants=(expected_shape(grid.level_cells_per_axis(level)),),
+            must_succeed=True,
         )
 
     if profile is not Profile.FULL:
         return
+    # This looks like an out-of-range case and is not: `level_cells_per_axis`
+    # documents "Must be >= 0; values above max_level are accepted and return
+    # the geometrically valid count", and its only `Raises:` is "ValueError: If
+    # level < 0". So `must_succeed`, in deliberate contrast with
+    # `active_leaf_mask`/`subdomain_mask` right below, which DO require
+    # level <= max_level.
     yield Case(
         GROUP,
         "hier_level_cells_per_axis_above_max",
         HierarchicalGrid.level_cells_per_axis,
         lambda: grid.level_cells_per_axis(grid.max_level + 5),
         {"kind": "above-max-level"},
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -1148,6 +1257,7 @@ def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.level_cells_per_axis,
         lambda: grid.level_cells_per_axis(-1),
         {"kind": "negative-level"},
+        must_reject=True,  # "ValueError: If level < 0."
     )
     yield Case(
         GROUP,
@@ -1155,6 +1265,7 @@ def _hier_mask_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.active_leaf_mask,
         lambda: grid.active_leaf_mask(grid.max_level + 1),
         {"kind": "above-max-level"},
+        must_reject=True,  # "ValueError: If level is outside [0, max_level]."
     )
 
 
@@ -1199,6 +1310,9 @@ def _hier_hanging_neighbor_cases(profile: Profile) -> Iterator[Case]:
                         )
         return None
 
+    # The thunk is a placeholder (`lambda: None`); the real calls happen inside
+    # the invariant, so `must_succeed` guards this case against a future
+    # refactor rather than grading anything today.
     yield Case(
         GROUP,
         "hier_hanging_neighbors_touch",
@@ -1206,6 +1320,7 @@ def _hier_hanging_neighbor_cases(profile: Profile) -> Iterator[Case]:
         lambda: None,
         {"kind": "geometric-adjacency"},
         invariants=(custom("hanging-neighbors-touch", check_touching),),
+        must_succeed=True,
     )
 
 
@@ -1243,12 +1358,19 @@ def _hier_restrict_cases(profile: Profile) -> Iterator[Case]:
                     else f"expected HierarchicalGrid, got {type(r.grid).__name__}",  # type: ignore[attr-defined]
                 ),
             ),
+            must_succeed=True,
         )
 
     if profile is not Profile.FULL:
         return
+    # Same documented clauses as TensorProductGrid.restrict.
     yield Case(
-        GROUP, "hier_restrict_empty", HierarchicalGrid.restrict, lambda: grid.restrict([]), {}
+        GROUP,
+        "hier_restrict_empty",
+        HierarchicalGrid.restrict,
+        lambda: grid.restrict([]),
+        {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1256,6 +1378,7 @@ def _hier_restrict_cases(profile: Profile) -> Iterator[Case]:
         HierarchicalGrid.restrict,
         lambda: grid.restrict([grid.num_cells]),
         {},
+        must_reject=True,
     )
 
 
@@ -1285,6 +1408,7 @@ def _hierarchical_grid_factory_case(profile: Profile) -> Iterator[Case]:
                 else f"num_cells={r.num_cells}, expected {root.num_cells}",
             ),
         ),
+        must_succeed=True,
     )
 
 
@@ -1359,6 +1483,9 @@ def _bvh_from_grid_cases(profile: Profile) -> Iterator[Case]:
         boxes["shared_face"] = face_box
         boxes["zero_volume_point"] = AABB(cell_lo[0], cell_lo[0])
         boxes["entirely_outside"] = AABB(domain_lo - 10.0, domain_lo - 5.0)
+    # `query_aabb`'s only documented `Raises:` is "ValueError: If aabb.ndim !=
+    # self.ndim", and every box here is built at the grid's own ndim. An
+    # unbounded (inf) box is a legal AABB.
     for name, box in boxes.items():
         yield Case(
             GROUP,
@@ -1367,6 +1494,7 @@ def _bvh_from_grid_cases(profile: Profile) -> Iterator[Case]:
             lambda box=box: grid.query_aabb(box),
             {"kind": name},
             invariants=(custom("query-completeness", _bvh_query_predicate(cell_lo, cell_hi, box)),),
+            must_succeed=True,
         )
 
 
@@ -1391,13 +1519,16 @@ def _bvh_direct_construction_cases(profile: Profile) -> Iterator[Case]:
         BVH,
         lambda: BVH(lo.astype(np.float32), hi, idx, idx, cell, n_cells=1),
         {"kind": "wrong-dtype"},
+        must_reject=True,  # "TypeError: If any array has the wrong dtype."
     )
+    # "ValueError: If shapes are inconsistent, ... n_nodes != 2 * n_cells - 1 ..."
     yield Case(
         GROUP,
         "bvh_direct_shape_mismatch",
         BVH,
         lambda: BVH(lo, np.ones((2, 2)), idx, idx, cell, n_cells=1),
         {"kind": "shape-mismatch"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1405,6 +1536,7 @@ def _bvh_direct_construction_cases(profile: Profile) -> Iterator[Case]:
         BVH,
         lambda: BVH(lo, hi, idx, idx, cell, n_cells=2),
         {"kind": "n-nodes-mismatch"},
+        must_reject=True,
     )
 
 
@@ -1457,6 +1589,8 @@ def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
         configs["line_arrangement"] = (line_lo, line_hi)
 
     query = AABB(np.array([0.4, 0.4]), np.array([0.6, 0.6]))
+    # Every config here satisfies hi >= lo, is finite, and has ndim >= 1;
+    # `n_cells == 0` is explicitly legal and returns an empty tree.
     for name, (lo, hi) in configs.items():
         yield Case(
             GROUP,
@@ -1470,6 +1604,7 @@ def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
                     _bvh_n_nodes_predicate(int(lo.shape[0])),
                 ),
             ),
+            must_succeed=True,
         )
         if lo.shape[0] > 0:
             yield Case(
@@ -1479,6 +1614,7 @@ def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
                 lambda lo=lo, hi=hi: BVH.from_cell_bounds(lo, hi).query_aabb(query),
                 {"kind": name, "n_cells": int(lo.shape[0])},
                 invariants=(custom("query-completeness", _bvh_query_predicate(lo, hi, query)),),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
@@ -1491,7 +1627,15 @@ def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
         BVH.from_cell_bounds,
         lambda: BVH.from_cell_bounds(bad_lo, bad_hi),
         {"kind": "hi-below-lo"},
+        # "ValueError: If shapes are inconsistent, ndim is < 1, any cell has
+        # hi < lo, ..."
+        must_reject=True,
     )
+    # Still `must_reject`, though the code rejects non-finite corners at
+    # `_bvh.py:322-326` while `from_cell_bounds`'s `Raises:` section does not
+    # list non-finiteness. A NaN corner is not a box, so refusing it is right
+    # and returning would be the finding -- what is missing is the `Raises:`
+    # entry, a documentation gap rather than a reason to withhold the flag.
     yield Case(
         GROUP,
         "bvh_from_cell_bounds_nonfinite",
@@ -1499,6 +1643,7 @@ def _bvh_degenerate_cases(profile: Profile) -> Iterator[Case]:
         lambda: BVH.from_cell_bounds(np.array([[np.nan, 0.0]]), np.array([[1.0, 1.0]])),
         {"kind": "nan"},
         finite_inputs=False,
+        must_reject=True,
     )
 
 
@@ -1531,6 +1676,7 @@ def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
                 else "rank 0 does not own every cell",
             ),
         ),
+        must_succeed=True,
     )
     owner_one_each = np.arange(5, dtype=np.int32)
     yield Case(
@@ -1547,16 +1693,20 @@ def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
                 else "some rank does not own exactly one cell",
             ),
         ),
+        must_succeed=True,
     )
 
     if profile is not Profile.FULL:
         return
+    # "ValueError: If n_parts < 1, cell_owner is not 1D integer, or any owner is
+    # outside [-1, n_parts)."
     yield Case(
         GROUP,
         "partition_direct_zero_parts",
         Partition,
         lambda: Partition(np.zeros(3, dtype=np.int32), 0),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1564,6 +1714,7 @@ def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
         Partition,
         lambda: Partition(np.array([0, 1, 2], dtype=np.int32), 2),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1571,6 +1722,7 @@ def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
         Partition,
         lambda: Partition(np.array([0.0, 1.0]), 2),
         {},
+        must_reject=True,
     )
     part = Partition(np.array([0, 1], dtype=np.int32), 2)
     yield Case(
@@ -1579,6 +1731,7 @@ def _partition_direct_cases(profile: Profile) -> Iterator[Case]:
         Partition.owned_cells,
         lambda: part.owned_cells(5),
         {"kind": "rank-oob"},
+        must_reject=True,  # "ValueError: If rank is outside [0, n_parts)."
     )
 
 
@@ -1645,6 +1798,8 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
     grid = uniform_grid([[0.0, 1.0], [0.0, 1.0]], [3, 3])
     backends = ("block", "rcb", "auto") if profile is Profile.FULL else ("auto",)
     for backend in backends:
+        # The grid is 3x3 = 9 cells and 9 = 3 * 3 factors onto the two axes, so
+        # even the "block" backend is satisfiable here.
         yield Case(
             GROUP,
             f"partition_grid_n_parts_eq_n_cells_{backend}",
@@ -1655,6 +1810,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
                 custom("every-rank-nonempty", _every_rank_nonempty_predicate(grid.num_cells)),
                 custom("partitions-active-set", _partition_active_predicate(grid.num_cells, None)),
             ),
+            must_succeed=True,
         )
         yield Case(
             GROUP,
@@ -1666,6 +1822,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
                 custom("every-rank-nonempty", _every_rank_nonempty_predicate(1)),
                 custom("partitions-active-set", _partition_active_predicate(1, None)),
             ),
+            must_succeed=True,
         )
 
     if profile is not Profile.FULL:
@@ -1680,13 +1837,19 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
         lambda: partition_grid(grid, 1, backend="rcb", cell_active=active),
         {"backend": "rcb", "n_parts": 1, "kind": "all-but-one-inactive"},
         invariants=(custom("partitions-active-set", _partition_active_predicate(1, active)),),
+        must_succeed=True,
     )
+    # "ValueError: If n_parts < 1; if backend is unknown; if 'block' is used on
+    # a non-TensorProductGrid or with weights/activity; if n_parts cannot be
+    # factored onto the axes ('block'); ... or if n_parts exceeds the number of
+    # active cells ('rcb')."
     yield Case(
         GROUP,
         "partition_grid_zero_parts",
         partition_grid,
         lambda: partition_grid(grid, 0),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1694,6 +1857,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
         partition_grid,
         lambda: partition_grid(grid, 2, backend="nope"),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1701,6 +1865,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
         partition_grid,
         lambda: partition_grid(grid, 3, backend="block", cell_weights=np.ones(grid.num_cells)),
         {},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1708,6 +1873,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
         partition_grid,
         lambda: partition_grid(grid, 5, backend="block"),
         {"kind": "prime-part-count"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1715,6 +1881,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
         partition_grid,
         lambda: partition_grid(grid, grid.num_cells + 1, backend="rcb"),
         {"kind": "n_parts-too-large"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1728,6 +1895,7 @@ def _partition_grid_cases(profile: Profile) -> Iterator[Case]:
                 _every_rank_nonempty_predicate(3),
             ),
         ),
+        must_succeed=True,  # "'rcb' accepts any grid."
     )
 
 
@@ -1818,6 +1986,8 @@ def _overlay_cases(profile: Profile) -> Iterator[Case]:
             ) -> tuple[TensorProductGrid, TensorProductGrid]:
                 return overlay(grid_a, grid_b), overlay(grid_b, grid_a)
 
+            # Both grids share ndim and the identical domain, so the per-axis
+            # intersection is the whole domain.
             yield Case(
                 GROUP,
                 f"overlay_symmetry_{tag}",
@@ -1825,6 +1995,7 @@ def _overlay_cases(profile: Profile) -> Iterator[Case]:
                 run,
                 {"ndim": ndim, "domain": domain},
                 invariants=(custom("overlay-symmetric", _overlay_symmetry_predicate()),),
+                must_succeed=True,
             )
             yield Case(
                 GROUP,
@@ -1838,21 +2009,39 @@ def _overlay_cases(profile: Profile) -> Iterator[Case]:
                         _overlay_containment_predicate(grid_a, grid_b),
                     ),
                 ),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
     a = _tp_grid(2, (0.0, 1.0), 2)
     b = _tp_grid(2, (2.0, 3.0), 2)
+    # "ValueError: If the grids have different ndim, or if their domains do not
+    # overlap on some axis"
     yield Case(
-        GROUP, "overlay_disjoint_domains", overlay, lambda: overlay(a, b), {"kind": "disjoint"}
+        GROUP,
+        "overlay_disjoint_domains",
+        overlay,
+        lambda: overlay(a, b),
+        {"kind": "disjoint"},
+        must_reject=True,
     )
     c = _tp_grid(3, (0.0, 1.0), 2)
     yield Case(
-        GROUP, "overlay_ndim_mismatch", overlay, lambda: overlay(a, c), {"kind": "ndim-mismatch"}
+        GROUP,
+        "overlay_ndim_mismatch",
+        overlay,
+        lambda: overlay(a, c),
+        {"kind": "ndim-mismatch"},
+        must_reject=True,
     )
     yield Case(
-        GROUP, "overlay_wrong_type", overlay, lambda: overlay(a, object()), {"kind": "wrong-type"}
+        GROUP,
+        "overlay_wrong_type",
+        overlay,
+        lambda: overlay(a, object()),
+        {"kind": "wrong-type"},
+        must_reject=True,  # "TypeError: If either argument is not a TensorProductGrid."
     )
 
 
@@ -1891,6 +2080,7 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
         cell_round_trip,
         {"kind": "round-trip"},
         invariants=(custom("round-trip-values", check_cell_round_trip),),
+        must_succeed=True,
     )
 
     def cell_overflow() -> npt.NDArray[Any]:
@@ -1898,12 +2088,17 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
         tags.set("big", np.array([0]), np.array([1000]))
         return tags.to_dense("big", dtype=np.int8)
 
+    # "OverflowError: If any stored value cannot be represented exactly in
+    # dtype". `must_reject` is still the right flag for a non-ValueError
+    # rejection: it grades *returning*, and silently truncating 1000 to an
+    # int8 is exactly the finding.
     yield Case(
         GROUP,
         "cell_tags_to_dense_overflow",
         CellTags.to_dense,
         cell_overflow,
         {"kind": "int8-overflow"},
+        must_reject=True,
     )
 
     facets_per_cell = 4
@@ -1929,6 +2124,7 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
         facet_round_trip,
         {"kind": "round-trip"},
         invariants=(custom("round-trip-values", check_facet_round_trip),),
+        must_succeed=True,
     )
 
     def facet_overflow() -> npt.NDArray[Any]:
@@ -1942,16 +2138,20 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
         FacetTags.to_dense,
         facet_overflow,
         {"kind": "int8-overflow"},
+        must_reject=True,
     )
 
     if profile is not Profile.FULL:
         return
+    # "ValueError: If ids is not 1-D, contains duplicates, or has an id out of
+    # range"
     yield Case(
         GROUP,
         "cell_tags_duplicate_ids",
         CellTags.set,
         lambda: CellTags(num_cells).set("dup", np.array([1, 1]), np.array([1, 2])),
         {"kind": "duplicate-ids"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1959,7 +2159,10 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
         CellTags.set,
         lambda: CellTags(num_cells).set("oob", np.array([num_cells]), np.array([1])),
         {"kind": "id-oob"},
+        must_reject=True,
     )
+    # "ValueError: If keys does not have shape (M, 2), contains a duplicate or
+    # out-of-range key, ..."
     yield Case(
         GROUP,
         "facet_tags_lfid_out_of_range",
@@ -1968,6 +2171,7 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
             "oob", np.array([[0, facets_per_cell]]), np.array([1])
         ),
         {"kind": "lfid-oob"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -1977,6 +2181,7 @@ def _tags_cases(profile: Profile) -> Iterator[Case]:
             "dup", np.array([[0, 0], [0, 0]]), np.array([1, 2])
         ),
         {"kind": "duplicate-keys"},
+        must_reject=True,
     )
 
 
@@ -2071,6 +2276,9 @@ def _cell_quadrature_cases(profile: Profile) -> Iterator[Case]:
             "single_cell": np.array([0]),
             "empty_selection": np.zeros(0, dtype=np.int64),
         }
+        # The empty selection is an explicitly-typed empty int64 array, which
+        # vacuously satisfies "each in [0, num_cells)"; all three below are
+        # legal.
         for name, ids in selectors.items():
             expected_lo = cell_lo_all if ids is None else cell_lo_all[ids]
             expected_hi = cell_hi_all if ids is None else cell_hi_all[ids]
@@ -2094,18 +2302,22 @@ def _cell_quadrature_cases(profile: Profile) -> Iterator[Case]:
                 )
                 if name != "empty_selection"
                 else (),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
         return
     grid2 = _tp_grid(2, (0.0, 1.0), 2)
     rule3 = gauss_legendre_quadrature(3, 2)
+    # "ValueError: If rule.ndim != grid.ndim, cells is not a 1D integer
+    # array-like, or any id is outside [0, num_cells)."
     yield Case(
         GROUP,
         "cell_quadrature_ndim_mismatch",
         cell_quadrature,
         lambda: cell_quadrature(grid2, rule3),
         {"kind": "ndim-mismatch"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -2115,6 +2327,7 @@ def _cell_quadrature_cases(profile: Profile) -> Iterator[Case]:
             grid2, gauss_legendre_quadrature(2, 2), np.array([grid2.num_cells])
         ),
         {"kind": "cell-oob"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -2122,6 +2335,7 @@ def _cell_quadrature_cases(profile: Profile) -> Iterator[Case]:
         cell_quadrature,
         lambda: cell_quadrature(grid2, gauss_legendre_quadrature(2, 2), np.array([0.5])),
         {"kind": "non-integer-cells"},
+        must_reject=True,
     )
 
 

--- a/tools/adversarial_sweep/_probes_quad.py
+++ b/tools/adversarial_sweep/_probes_quad.py
@@ -11,6 +11,16 @@ claims of :class:`~pantr.quad.QuadratureRule` and
 corners (0 and -1, which must be rejected, then 1, 2, 3, 4, 5, 17, 64, 200, 1000)
 rather than its middle, since off-by-one and int64-wraparound defects live at the
 edges of a count, not in its interior.
+
+**Verdict flags.** Every case here carries ``must_succeed`` or ``must_reject``
+unless the entry point's contract genuinely admits both, and the few that carry
+neither say why at the site. Without them a legal-input failure is graded against
+the ``Raises:`` section alone, which cannot see the two failure modes that matter
+most: a documented exception type raised for an *undocumented reason* reads as a
+correct rejection, and an entry point that silently starts accepting nonsense
+reads as ``OK``. The flags are decided from the docstrings quoted at each site,
+not from what the code happens to do -- the point is to grade the code against its
+contract, so a site where the two disagree is left unflagged and named.
 """
 
 from __future__ import annotations
@@ -36,7 +46,7 @@ from pantr.quad import (
     tensor_product_quadrature,
 )
 
-from ._axes import Profile, dims, dtypes
+from ._axes import LAGRANGE_MIN_NODES, Profile, dims, dtypes
 from ._core import Case, custom
 
 if TYPE_CHECKING:
@@ -248,6 +258,16 @@ def _rule_1d_cases(profile: Profile) -> Iterator[Case]:
                     and min_pts <= n_pts <= _GL_EXACTNESS_MAX_N
                 ):
                     invariants.append(_gauss_legendre_exactness(n_pts))
+                # `min_pts` is each factory's own documented floor ("Must be at
+                # least N", with a matching `Raises: ValueError`), so it decides
+                # the verdict outright: below it the call must be refused, at or
+                # above it -- with a float64/float32 dtype, which is the only other
+                # stated precondition -- there is nothing left for the rule to
+                # object to and any exception is a finding. `get_tanh_sinh_1d` is
+                # still `must_succeed` at large `n_pts` even though it returns
+                # *fewer* nodes than requested: that truncation is documented
+                # (`quad.py:433-434`), and returning fewer points is a return, not
+                # a refusal.
                 yield Case(
                     GROUP,
                     f"{name}_n{n_pts}_{np.dtype(dtype).name}",
@@ -255,6 +275,8 @@ def _rule_1d_cases(profile: Profile) -> Iterator[Case]:
                     lambda func=func, n_pts=n_pts, dtype=dtype: func(n_pts, dtype=dtype),
                     {"rule": name, "n_pts": n_pts, "dtype": dtype, "nodes_only": nodes_only},
                     invariants=tuple(invariants),
+                    must_succeed=n_pts >= min_pts,
+                    must_reject=n_pts < min_pts,
                 )
 
 
@@ -272,12 +294,16 @@ def _bad_dtype_cases(profile: Profile) -> Iterator[Case]:
     for name, func, min_pts, _, _, _ in _RULES:
         n_pts = max(min_pts, 5)
         for bad_dtype in (np.dtype(np.int32), np.dtype(np.float16)):
+            # Every factory's `Raises:` says "or dtype is not float32 or float64",
+            # and the shared validator names these two exact dtypes as the
+            # rejected examples (`_array_utils.py:31`), so refusal is the contract.
             yield Case(
                 GROUP,
                 f"{name}_bad_dtype_{bad_dtype.name}",
                 func,
                 lambda func=func, n_pts=n_pts, bad_dtype=bad_dtype: func(n_pts, dtype=bad_dtype),
                 {"rule": name, "n_pts": n_pts, "dtype": bad_dtype},
+                must_reject=True,
             )
 
 
@@ -293,41 +319,56 @@ def _lattice_cases(profile: Profile) -> Iterator[Case]:
     for dtype in dtypes(profile):
         name = np.dtype(dtype).name
         single = [np.array([0.3], dtype=dtype), np.array([0.7], dtype=dtype)]
+        # Two axes, one point each, one shared dtype, both 1D and non-empty: every
+        # condition `_validate_pts_per_dir` states (`quad.py:507-520`) is met, so
+        # the lattice is legal by construction.
         yield Case(
             GROUP,
             f"lattice_single_point_per_axis_{name}",
             PointsLattice,
             lambda single=single: PointsLattice(single),
             {"kind": "single-point-per-axis", "dtype": dtype},
+            must_succeed=True,
         )
+        # `order` is a documented `Literal["C", "F"]` with no `Raises:` at all
+        # (`quad.py:551-563`), so "F" on a legal lattice cannot legitimately fail.
         yield Case(
             GROUP,
             f"lattice_get_all_points_order_F_{name}",
             PointsLattice.get_all_points,
             lambda single=single: PointsLattice(single).get_all_points(order="F"),
             {"kind": "order-F", "dtype": dtype},
+            must_succeed=True,
         )
         empty_axis = [np.array([0.3], dtype=dtype), np.zeros(0, dtype=dtype)]
+        # "All points must have at least 1 point" (`quad.py:519-520`).
         yield Case(
             GROUP,
             f"lattice_empty_axis_{name}",
             PointsLattice,
             lambda empty_axis=empty_axis: PointsLattice(empty_axis),
             {"kind": "empty-axis", "dtype": dtype},
+            must_reject=True,
         )
 
     if profile is not Profile.FULL:
         return
 
     mixed = [np.array([0.1, 0.9], dtype=np.float64), np.array([0.2, 0.8], dtype=np.float32)]
+    # "All points must have the same dtype" -- stated in `__init__`'s own `Raises:`
+    # (`quad.py:498-499`) as well as the validator's.
     yield Case(
         GROUP,
         "lattice_mismatched_dtypes",
         PointsLattice,
         lambda mixed=mixed: PointsLattice(mixed),
         {"kind": "mismatched-dtypes"},
+        must_reject=True,
     )
     four_axes = [np.array([0.2, 0.8]) for _ in range(4)]
+    # No maximum dimension is stated anywhere in `PointsLattice`, so four axes are
+    # as legal as two and the `n ** dim` growth is the caller's problem, not a
+    # refusal the class is entitled to make.
     yield Case(
         GROUP,
         "lattice_four_axes",
@@ -340,6 +381,7 @@ def _lattice_cases(profile: Profile) -> Iterator[Case]:
                 lambda r: None if r.shape == (16, 4) else f"got shape {r.shape}, expected (16, 4)",
             ),
         ),
+        must_succeed=True,
     )
 
 
@@ -367,6 +409,22 @@ def _lagrange_lattice_cases(profile: Profile) -> Iterator[Case]:
         for n_pts in n_pts_values:
             for dim in dims(profile, max_dim=3):
                 n_pts_per_dir = (n_pts,) * dim
+                # `create_lagrange_points_lattice` documents "Each value must be at
+                # least 1" and enforces exactly that (`quad.py:592-593, 607-608`), so
+                # zero is a documented refusal and anything at or above each variant's
+                # own floor is legal. The gap between the two is a genuine contract
+                # boundary and stays unflagged: at `n_pts == 1` the *stated* contract
+                # accepts every variant, but GAUSS_LOBATTO_LEGENDRE and CHEBYSHEV_2ND
+                # are refused two calls deeper, by the rule this function dispatches to
+                # (`_basis_lagrange.py:90-103` -> `quad.py:148` / `quad.py:218`), whose
+                # own docstring does state the "at least 2" caveat that this one omits.
+                # One of the two docstrings is wrong; which is the caller's decision, so
+                # neither verdict is asserted here rather than guessing and manufacturing
+                # a finding. Because the deeper refusal is a `ValueError`, and this
+                # function's `Raises:` lists `ValueError`, the sweep currently grades it
+                # a documented rejection and says nothing -- which is why it needs saying
+                # here.
+                legal_everywhere = n_pts >= LAGRANGE_MIN_NODES[variant]
                 yield Case(
                     GROUP,
                     f"lagrange_lattice_{variant.value}_n{n_pts}_d{dim}",
@@ -376,6 +434,8 @@ def _lagrange_lattice_cases(profile: Profile) -> Iterator[Case]:
                         variant, n_pts_per_dir
                     ),
                     {"variant": variant, "n_pts": n_pts, "dim": dim},
+                    must_succeed=legal_everywhere,
+                    must_reject=n_pts < 1,
                 )
 
 
@@ -416,6 +476,9 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
     del profile  # every construction below is a corner; nothing to widen further
     step = float(np.spacing(np.float64(1.0)))
 
+    # The constructor's `Raises:` (`quad.py:641-644`) is a closed list: not 2D, weights
+    # not 1D, lengths disagree, either empty, non-finite, or a point outside [0, 1].
+    # Every case below is on one side or the other of exactly that list.
     yield Case(
         GROUP,
         "quadrule_endpoints_0_1",
@@ -424,7 +487,13 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         {"kind": "endpoints"},
         invariants=(_quadrature_rule_shape_readonly(2, 1),),
         arrays={"points": np.array([[0.0], [1.0]]), "weights": np.array([0.5, 0.5])},
+        must_succeed=True,
     )
+    # A negative weight is legal by construction, and deliberately so: the class
+    # docstring's "weights sum to one" language (`quad.py:622-628`) is scoped to the two
+    # factories, and `__init__` neither documents nor checks weight sign or sum. Refusing
+    # this input would be the finding, not accepting it -- several legitimate rules
+    # (Newton-Cotes past degree 8, moment-fitted rules) carry negative weights.
     yield Case(
         GROUP,
         "quadrule_negative_weight",
@@ -433,6 +502,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         {"kind": "negative-weight"},
         invariants=(_quadrature_rule_shape_readonly(1, 1),),
         arrays={"points": np.array([[0.5]]), "weights": np.array([-1.0])},
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -440,6 +510,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         QuadratureRule,
         lambda step=step: QuadratureRule([[-8.0 * step]], [1.0]),
         {"kind": "just-outside-left"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -447,6 +518,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         QuadratureRule,
         lambda step=step: QuadratureRule([[1.0 + 8.0 * step]], [1.0]),
         {"kind": "just-outside-right"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -455,6 +527,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         lambda: QuadratureRule([[np.nan]], [1.0]),
         {"kind": "nan-point"},
         finite_inputs=False,
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -463,6 +536,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         lambda: QuadratureRule([[0.5]], [np.inf]),
         {"kind": "inf-weight"},
         finite_inputs=False,
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -470,6 +544,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         QuadratureRule,
         lambda: QuadratureRule(np.zeros((0, 1)), np.zeros(0)),
         {"kind": "zero-length"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -477,6 +552,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         QuadratureRule,
         lambda: QuadratureRule([0.1, 0.5, 0.9], [1.0, 1.0, 1.0]),
         {"kind": "wrong-ndim-points"},
+        must_reject=True,
     )
 
 
@@ -532,6 +608,9 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
     nodes_b = np.array([0.2, 0.5, 0.8])
     weights_b = np.full(3, 1.0 / 3.0)
     rules_2d = [(nodes_a, weights_a), (nodes_b, weights_b)]
+    # Matching non-empty 1D pairs with nodes inside [0, 1] satisfy every precondition
+    # the docstring states (`quad.py:731-734`), including the `[0, 1]` bound it defers
+    # to `QuadratureRule`.
     yield Case(
         GROUP,
         "tpq_ordering_2axis_distinct_lengths",
@@ -540,6 +619,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         {"kind": "ordering", "shape": (2, 3)},
         invariants=(_tensor_product_ordering([nodes_a, nodes_b]),),
         arrays={"nodes_a": nodes_a, "nodes_b": nodes_b},
+        must_succeed=True,
     )
 
     nodes_c = np.array([0.15, 0.55, 0.65, 0.95])
@@ -553,6 +633,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         {"kind": "ordering", "shape": (2, 3, 4)},
         invariants=(_tensor_product_ordering([nodes_a, nodes_b, nodes_c]),),
         arrays={"nodes_a": nodes_a, "nodes_b": nodes_b, "nodes_c": nodes_c},
+        must_succeed=True,
     )
 
     yield Case(
@@ -561,6 +642,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_quadrature,
         lambda: tensor_product_quadrature([]),
         {"kind": "empty"},
+        must_reject=True,  # "If ``rules`` is empty" (quad.py:741-744)
     )
 
     if profile is not Profile.FULL:
@@ -573,6 +655,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_quadrature,
         lambda mismatched=mismatched: tensor_product_quadrature(mismatched),
         {"kind": "mismatched-lengths"},
+        must_reject=True,  # "not a matching pair of ... 1D arrays" (quad.py:741-744)
     )
 
 
@@ -590,6 +673,9 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         Case: One hostile ``(ndim, npts)`` combination.
     """
     npts_values = _GLQ_NPTS_FULL if profile is Profile.FULL else _GLQ_NPTS_SMOKE
+    # The docstring states three preconditions and no more (`quad.py:776-779`):
+    # `ndim >= 1`, a sequence of length `ndim` if not a scalar, and every count
+    # `>= 1`. Each case below satisfies all three or violates exactly one.
     for ndim in dims(profile, max_dim=3):
         for npts in npts_values:
             yield Case(
@@ -599,6 +685,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
                 lambda ndim=ndim, npts=npts: gauss_legendre_quadrature(ndim, npts),
                 {"ndim": ndim, "npts": npts, "kind": "scalar"},
                 invariants=(_weights_sum_to_one(npts**ndim, np.dtype(np.float64)),),
+                must_succeed=True,
             )
 
     if profile is not Profile.FULL:
@@ -611,9 +698,11 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         lambda: gauss_legendre_quadrature(3, (2, 3, 4)),
         {"ndim": 3, "npts": (2, 3, 4), "kind": "sequence"},
         invariants=(_weights_sum_to_one(2 * 3 * 4, np.dtype(np.float64)),),
+        must_succeed=True,
     )
     # A 4-D case to probe n ** dim growth, as the entry point allows ndim >= 1
-    # with no explicit upper bound.
+    # with no explicit upper bound. No upper bound stated means no refusal is
+    # licensed: 83521 points is the caller's choice, so `must_succeed` holds.
     yield Case(
         GROUP,
         "glq_growth_d4_n17",
@@ -621,6 +710,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         lambda: gauss_legendre_quadrature(4, 17),
         {"ndim": 4, "npts": 17, "kind": "growth"},
         invariants=(_weights_sum_to_one(17**4, np.dtype(np.float64)),),
+        must_succeed=True,
     )
     yield Case(
         GROUP,
@@ -628,6 +718,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         gauss_legendre_quadrature,
         lambda: gauss_legendre_quadrature(0, 3),
         {"ndim": 0, "kind": "invalid-ndim"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -635,6 +726,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         gauss_legendre_quadrature,
         lambda: gauss_legendre_quadrature(-1, 3),
         {"ndim": -1, "kind": "invalid-ndim"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -642,6 +734,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         gauss_legendre_quadrature,
         lambda: gauss_legendre_quadrature(3, (2, 3)),
         {"ndim": 3, "npts": (2, 3), "kind": "wrong-length"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -649,6 +742,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         gauss_legendre_quadrature,
         lambda: gauss_legendre_quadrature(2, 0),
         {"ndim": 2, "npts": 0, "kind": "invalid-count"},
+        must_reject=True,
     )
     yield Case(
         GROUP,
@@ -656,6 +750,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         gauss_legendre_quadrature,
         lambda: gauss_legendre_quadrature(2, -1),
         {"ndim": 2, "npts": -1, "kind": "invalid-count"},
+        must_reject=True,
     )
 
 


### PR DESCRIPTION
The adversarial sweep reported roughly 500 findings and nobody had read most of them. This
classifies every one, corrects the probes that were measuring the wrong thing, and completes
the verdict flags so that the five probe groups' numbers mean the same thing.

**It fixes no bugs.** A fix changes what the sweep reports and would have invalidated the
measurement. Confirmed new causes are pinned as strict xfails instead.

## 496 labels collapse into 12 mechanisms

Four already known and tracked by an existing test, **five new root causes**, one deliberate
contract boundary, one unresolved, and **five probe defects accounting for 105 findings**.

## Read the count change carefully

| | cases | findings |
|---|---|---|
| before | 30072 | 496 |
| after | 30072 | 441 |

That is **not 55 fewer bugs**. It is **105 false positives removed and 50 real findings newly
exposed** — 46 of them a silent `restrict` defect the sweep had been grading `OK` because no
probe asserted anything about it.

## The five new causes

**`find_roots` certifies a value that is not a root.** The worst of the set, because nothing
about the input is unusual: an ordinary clamped cubic **on the unit domain**, control points
`[1,-1,1,-1,1,-1,1]`. Six values come back; four are genuine roots at 1e-16, and `0.375` and
`0.625` carry a residual of **2.08e-2** while the true zeros sit at `0.369` and `0.631`. A
repeated iterate is taken as a convergence certificate, and the caller then hard-codes
`residual = 0.0` for that status without ever comparing it against the function value. Distinct
from the fabricated-root defect closed earlier — a different branch, and this knot vector has
only simple interior knots.

**`restrict` silently returns a shorter domain than requested.** `b_new + tol == b_new` once
half an ulp exceeds the absolute tolerance, which happens at exactly `|b_new| = 16` (bisected).
Asking for `[25, 75]` on a domain of `[0, 96]` returns `[25, 57.6]`. With few intervals it
instead raises a `ValueError` blaming the knot count. **The silent face had been invisible
because no probe asserted anything about `restrict` at all.**

**Degree-0 Lagrange extraction is refused** while Bézier and cardinal extraction on the same
space both succeed, and the message names a degree the caller never passed. The mathematics does
not force the restriction; the degree-0 operator is the 1×1 identity.

**Cardinal change of basis raises a bare `LinAlgError`** on legal input. Refusing is right —
measured conditioning is `~4**degree`, past float32's reach by degree 10 — but the contract says
nothing. **This surfaced only because the verdict flags were completed**: `LinAlgError` subclasses
`ValueError`, so it had been grading as an unread "suspected".

**`get_unique_knots_and_multiplicity` returns knots the space does not contain.** It rounds onto
the tolerance grid to *group*, then returns the rounded values although the indices already point
at the originals. On a float32 `[0, 1e-6]` domain it reports `2.0e-7 / 5.0e-7 / 8.0e-7` for stored
knots `2.5e-7 / 5.0e-7 / 7.5e-7`. `Bspline.multiply` builds its mesh from this accessor, so the
product is wrong by **8% relative** away from any knot. The sibling `_snap_knots` does the same
grouping and deliberately avoids the trap.

## The five probe defects, each corrected with its reasoning in the code

The product invariant sampled **at** a C⁻¹ breakpoint, where the two sides legitimately differ
(34 findings; at interval midpoints of the same splines the error is 0 to 1.7e-16). A
finite-difference bound that ignored coordinate magnitude (32). A root residual compared without
the finder's parametric tolerance (52). Off-domain extrapolation asserted finite (19). A rational
order-62 derivative asserted finite (2) whose true value is 6.5e149 against a float32 maximum of
3.4e38.

## The two open questions this answers

**The second "hang" is not a hang.** `Bspline.multiply` at degree 62 periodic returns in 78.3 s,
inside `np.linalg.lstsq` — a dense SVD over the degree-124 product space. The earlier
`reduce_degree` hang was a genuine infinite loop. The harness cannot distinguish them because
`SIGALRM` cannot interrupt LAPACK either, which is now documented at the timeout. Worth noting
that the comment above that call states the matrix has full column rank and the solve is an exact
change of representation, which makes an SVD solver the wrong tool.

**The control-hull escape is already tracked**, not new: the same float32 snapping cause named
verbatim in an existing test's comment.

## Verdict flags

Completed for `geometry`, `quad`, `basis`, `bezier` and `grid`. `quad`, `grid` and `geometry`
still report zero — but that zero now means something, where before it meant only that no
docstring had been contradicted. `basis` was hiding four. The 17 cases left unflagged are
deliberate, each with the contract disagreement named at the site rather than a guessed flag.

## Verification

`ruff`, `ruff format`, `mypy`, `import-lint`, the docs build under `-W`, and the gated sweep on a
cold Numba cache: all clean. **5245 passed, 21 skipped, 8 xfailed** — the test count is unchanged
and the xfail count rises by exactly the five new mechanisms, which is what a classifying pass
should do.

## Named, not done

93 `warned-while-returning` cases (50 in Lagrange tabulation, 42 in root finding) remain unread —
the harness calls these the cheapest lead on a silent numerical fault. Twelve
`elevation-is-exact` findings at degree 15 are unresolved and deliberately not "fixed" by
loosening a bound nobody has derived. The `bspline` group's own flags are only partly complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
