### PR TITLE
fix(bspline): certify every value find_roots returns against its own residual

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -82,6 +82,24 @@
   endpoint condition and still returns the mean of the control points.
 
 ### Fixed
+- `pantr.bspline.find_roots` returned values that are not roots, silently, on
+  ordinary input: a clamped cubic on `[0, 1]` with control points alternating
+  `+1, -1` gave back `0.375` and `0.625`, where the spline is `0.0208` rather
+  than zero. Its residual test only ever ran on one of the four ways the
+  tracking of a sign change can stop; on the other three the residual was
+  hard-coded to zero and the value accepted unconditionally, and those are the
+  branches that fire when the iteration is in trouble. Every exit now evaluates
+  `|f(x)|` and the same test decides all of them, so a status records how the
+  iteration stopped and never whether the value may be reported. Two further
+  changes were needed to keep that from costing genuine roots. The stop on a
+  repeated iterate now tests the hypothesis Mørken and Reimers actually state in
+  their Corollary 14 — `degree - 1` active knots collapsed onto the iterate —
+  rather than the bare repetition, which is also what a nearly horizontal
+  control-polygon secant produces at a shallow non-zero minimum. And the
+  threshold a tracked iterate is tested against now carries the term the
+  parametric tolerance itself allows, `|f'| * 2 * tol * scale`, alongside the
+  evaluation error: testing the evaluation error alone rejects the correctly
+  located zeros of a steep spline.
 - Knot comparisons went through `np.isclose(a, b, atol=tol)` at 26 sites across
   seven modules. Setting `atol` does not clear `rtol`, which stays at NumPy's
   default `1e-5`, so the effective test was `|a - b| <= tol + 1e-5 * |b|`: on a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -100,6 +100,17 @@
   parametric tolerance itself allows, `|f'| * 2 * tol * scale`, alongside the
   evaluation error: testing the evaluation error alone rejects the correctly
   located zeros of a steep spline.
+- The merge that collapses several reports of one zero could return a point
+  between two distinct zeros. Reports are joined into a run on the *larger* of
+  two merge radii, and the radius is capped at
+  `domain_length * (degree! * zero_tol / coeff_scale) ** (1 / degree)`, which
+  *grows* with degree — 0.114 at degree 9, 0.767 at 15, past the whole domain
+  from 17 — so at high degree one radius joined every later root into its run.
+  On a degree-15 spline with a C⁰ interior knot the three zeros found, each with
+  a residual of 1e-17, came back as their midpoint alone, where the spline is
+  `-0.64`. A merged midpoint is a value nobody tracked, so it now takes the same
+  residual test as the reports it replaces, and a run whose midpoint fails is
+  left as the separate roots it was. The radius policy itself is unchanged.
 - Knot comparisons went through `np.isclose(a, b, atol=tol)` at 26 sites across
   seven modules. Setting `atol` does not clear `rtol`, which stays at NumPy's
   default `1e-5`, so the effective test was `|a - b| <= tol + 1e-5 * |b|`: on a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -99,7 +99,10 @@
   threshold a tracked iterate is tested against now carries the term the
   parametric tolerance itself allows, `|f'| * 2 * tol * scale`, alongside the
   evaluation error: testing the evaluation error alone rejects the correctly
-  located zeros of a steep spline.
+  located zeros of a steep spline. A side effect worth knowing: from degree 20 a
+  double root came back as the two sign changes bracketing it, so a caller
+  counting zeros got two where the answer is one. One of the pair was an
+  uncertified budget-limited iterate and is now dropped, leaving the count right.
 - The merge that collapses several reports of one zero could return a point
   between two distinct zeros. Reports are joined into a run on the *larger* of
   two merge radii, and the radius is capped at

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -294,6 +294,45 @@ def _merge_radii(  # noqa: PLR0913
     return np.asarray(np.maximum(np.minimum(radius, cap), floor), dtype=np.float64)
 
 
+def _merge_certified(
+    numerator: Bspline,
+    roots: npt.NDArray[np.float64],
+    radii: npt.NDArray[np.float64],
+    *,
+    root_tol: float,
+) -> npt.NDArray[np.float64]:
+    """Collapse repeated reports of one zero, keeping only the merges that are zeros.
+
+    The midpoint of a run is a value nobody tracked, so it inherits no certificate from
+    the reports it replaces and takes the same residual test they did. Where it fails,
+    the run was not one zero seen several times: the reports are kept as they were, each
+    already certified on its own.
+
+    Without that test a single over-wide radius is enough to return a value that is not a
+    root, which is what happens at high degree: the cap ``domain_length * (degree! *
+    zero_tol / coeff_scale) ** (1 / degree)`` grows with degree and passes the whole
+    domain around degree 17, and runs are joined on the *larger* of two radii, so one
+    such radius joins every later root into its own run.
+
+    Args:
+        numerator (Bspline): Scalar, non-rational spline whose zeros are sought.
+        roots (npt.NDArray[np.float64]): Ascending root candidates.
+        radii (npt.NDArray[np.float64]): Per-root merge radius, same length.
+        root_tol (float): Residual below which a value counts as a zero.
+
+    Returns:
+        npt.NDArray[np.float64]: Ascending roots, with every certified run collapsed to
+        its midpoint and every other run left as it was.
+    """
+    merged, labels, n_merged = _merge_roots(roots, radii)
+    merged = merged[:n_merged]
+    residuals = np.abs(np.asarray(numerator.evaluate(merged), dtype=np.float64).reshape(-1))
+    certified = residuals <= root_tol
+    if bool(np.all(certified)):
+        return np.ascontiguousarray(merged)
+    return np.sort(np.concatenate((merged[certified], roots[~certified[labels]])))
+
+
 def _find_roots_impl(
     bspline: Bspline,
     *,
@@ -383,8 +422,7 @@ def _find_roots_impl(
             domain_length=domain_length,
             tol=resolved_tol,
         )
-        merged, n_merged = _merge_roots(roots, radii)
-        roots = np.ascontiguousarray(merged[:n_merged])
+        roots = _merge_certified(numerator, roots, radii, root_tol=root_tol)
 
     roots.flags.writeable = False
     return roots

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -92,12 +92,16 @@ levels, so the bound has the same shape.
 _STOP_SLACK: float = 2.0
 """How far a reported zero may sit from the true one, in units of the stopping spread.
 
-The tracking stops when the last ``degree`` iterates span less than ``tol * scale``,
-so the last iterate is within that spread of the limit, plus at most one further step
-of the same size. Two of them is therefore the parametric error a reported zero carries
-by construction, and it is the factor
-``test_residual_at_every_root_is_within_the_evaluation_bound`` already measures the
-residual against.
+The tracking stops when the last ``degree`` iterates span less than ``tol * scale``.
+Mørken and Reimers bound the *convergence rate* but not the distance from the last
+iterate to the limit at an arbitrary stopping point, so this is **observed, not
+proved**: the spread bounds how far the iterates still move, and one further step of
+the same size covers the tail. Two is what
+``test_residual_at_every_root_is_within_the_evaluation_bound`` measures the residual
+against over 240 random splines at four parametric scales, and what
+``test_no_returned_value_escapes_the_residual_certificate`` clears by a factor of five
+on the families that break this method. Being an estimate, it is used with the safety
+factors those tests carry rather than as a bound in its own right.
 """
 
 
@@ -218,7 +222,17 @@ def _slope_bound(
     only at a knot of multiplicity ``degree + 1``, where the spline jumps and no finite
     slope describes it; an infinite bound there would turn the residual test into an
     unconditional accept, which is the defect this whole threshold exists to prevent, and
-    the jump itself is rejected on its own residual.
+    the jump itself is rejected on its own residual. At least one denominator is always
+    positive: an open knot vector carries exactly ``degree + 1`` copies of the start, so
+    ``knots[degree + 1] > knots[1]``.
+
+    The bound is over the whole domain, where the threshold it feeds is applied at one
+    zero at a time. A spline with one steep region therefore gets a threshold as loose
+    everywhere as that region needs, which errs towards accepting rather than towards
+    rejecting a genuine zero. Sharpening it to the knot span holding the zero is a
+    tolerance-policy question and is *not* a matter of computing the same quantity on the
+    working window: after a hundred insertions the local knot gaps there are degenerate
+    and the same formula returns a bound larger than the spline's own range.
 
     Args:
         coeffs (npt.NDArray[np.float64]): Scalar B-spline coefficients.
@@ -226,14 +240,12 @@ def _slope_bound(
         degree (int): Polynomial degree, at least 1.
 
     Returns:
-        float: An upper bound on ``|f'|`` over the domain, or ``0.0`` for a spline whose
-        coefficients are all equal.
+        float: An upper bound on ``|f'|`` over the domain. Zero for a spline whose
+        coefficients are all equal, which is the correct bound for a constant.
     """
     num_coeffs = coeffs.shape[0]
     gaps = knots[degree + 1 : num_coeffs + degree] - knots[1:num_coeffs]
     usable = gaps > 0.0
-    if not bool(np.any(usable)):
-        return 0.0
     quotients = np.abs(np.diff(coeffs))[usable] / gaps[usable]
     return float(degree * quotients.max())
 
@@ -510,6 +522,14 @@ def find_roots(
         a zero of even multiplicity is reported, since it does not change the
         sign of the spline and the sign changes bracketing it vanish under
         refinement.
+
+        At a knot of multiplicity ``degree + 1`` the spline is discontinuous, and
+        a zero of the piece on either side is reported at the knot. Evaluating
+        there returns the *right* limit, so such a root can show a residual as
+        large as the jump when the zero belongs to the left piece. Extracting the
+        Bézier segments and solving each of them
+        (:func:`pantr.bezier.find_roots`) reports the same knot for the same
+        reason.
 
     Example:
         >>> import numpy as np

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -19,13 +19,19 @@ from the *input* dtype: a float32 spline carries float32-level information, and
 a residual below that level cannot be distinguished from zero no matter how the
 iteration is carried out.
 
-**What is found.** Every zero where the spline changes sign is found; that is
-the guarantee the control polygon supports, since a spline whose coefficients
-have no sign change has no zeros at all. A zero of even multiplicity does not
-change the sign of the spline, so the sign changes that bracket it disappear
-under refinement and it cannot be certified from the polygon alone. Those are
-reported through a residual test instead (``|f(x)| <= zero_tol``), which is the
-same test that decides the two domain endpoints.
+**What is found.** The control polygon says where to look: a spline whose
+coefficients have no sign change has no zeros at all, so every zero where the
+spline changes sign is bracketed by a sign change and is searched for. What it
+does not do is certify. The tracking of a sign change stops for three different
+reasons, and none of them implies that the point it stopped at is a zero, so a
+value reaches the result only when its residual ``|f(x)|`` is within what a zero
+may legitimately leave behind: the error of evaluating the spline, plus the value
+the spline reaches at the parametric resolution the iteration stops at,
+``|f'| * 2 * tol * scale``. That residual test is the only way a zero of even
+multiplicity can be reported at all, since the sign changes bracketing it
+disappear under refinement. The two domain endpoints are decided on the
+evaluation error alone, being read straight off a coefficient with no location
+error to allow for.
 """
 
 from __future__ import annotations
@@ -58,10 +64,17 @@ _INSERTIONS_PER_DEGREE: int = 8
 """Extra insertions granted per unit of degree.
 
 The error is quadratic once per ``degree - 1`` insertions and not once per
-insertion (Mørken-Reimers, Theorem 22), so a simple zero needs roughly six
-quadratic steps of ``degree - 1`` insertions each to reach machine precision.
-Eight per degree leaves a margin over the worst case measured on random splines
-(173 insertions at degree 25, against a budget of 256).
+insertion (Mørken-Reimers, Theorem 22), so a zero the theorem covers needs
+roughly six quadratic steps of ``degree - 1`` insertions each to reach machine
+precision. Eight per degree leaves a margin over the worst case measured on
+random splines (173 insertions at degree 25, against a budget of 256).
+
+The theorem's hypotheses are ``f'(z) != 0`` **and** ``f''(z) != 0``, not simplicity
+alone: a simple zero with a vanishing second derivative is outside it, and so is
+every multiple zero. Nothing rests on the hypotheses holding, since the budget is
+soft -- exhausting it stops the tracking with ``_STATUS_BUDGET`` and leaves the
+residual to decide -- but the quadratic-step count that sizes the budget is only
+justified where they do.
 """
 
 _CURVATURE_DEGREE: int = 2
@@ -74,6 +87,17 @@ Matches the factor applied to the de Casteljau bound in
 ``pantr.bezier._clipping_core``; de Boor's algorithm combines the same
 ``degree + 1`` coefficients through the same number of convex-combination
 levels, so the bound has the same shape.
+"""
+
+_STOP_SLACK: float = 2.0
+"""How far a reported zero may sit from the true one, in units of the stopping spread.
+
+The tracking stops when the last ``degree`` iterates span less than ``tol * scale``,
+so the last iterate is within that spread of the limit, plus at most one further step
+of the same size. Two of them is therefore the parametric error a reported zero carries
+by construction, and it is the factor
+``test_residual_at_every_root_is_within_the_evaluation_bound`` already measures the
+residual against.
 """
 
 
@@ -178,6 +202,42 @@ def _check_connected(
         raise ValueError(msg)
 
 
+def _slope_bound(
+    coeffs: npt.NDArray[np.float64],
+    knots: npt.NDArray[np.float64],
+    degree: int,
+) -> float:
+    """Bound ``|f'|`` over the whole parametric domain, from the hodograph.
+
+    The derivative of a spline is the spline of degree ``degree - 1`` whose
+    coefficients are ``degree * (c[i] - c[i-1]) / (t[i+degree] - t[i])``, and a spline
+    never leaves the range of its own coefficients, so the largest of those difference
+    quotients bounds ``|f'|`` everywhere.
+
+    A zero-length denominator is skipped rather than read as an infinite slope. It occurs
+    only at a knot of multiplicity ``degree + 1``, where the spline jumps and no finite
+    slope describes it; an infinite bound there would turn the residual test into an
+    unconditional accept, which is the defect this whole threshold exists to prevent, and
+    the jump itself is rejected on its own residual.
+
+    Args:
+        coeffs (npt.NDArray[np.float64]): Scalar B-spline coefficients.
+        knots (npt.NDArray[np.float64]): Open knot vector.
+        degree (int): Polynomial degree, at least 1.
+
+    Returns:
+        float: An upper bound on ``|f'|`` over the domain, or ``0.0`` for a spline whose
+        coefficients are all equal.
+    """
+    num_coeffs = coeffs.shape[0]
+    gaps = knots[degree + 1 : num_coeffs + degree] - knots[1:num_coeffs]
+    usable = gaps > 0.0
+    if not bool(np.any(usable)):
+        return 0.0
+    quotients = np.abs(np.diff(coeffs))[usable] / gaps[usable]
+    return float(degree * quotients.max())
+
+
 def _merge_radii(  # noqa: PLR0913
     numerator: Bspline,
     roots: npt.NDArray[np.float64],
@@ -276,15 +336,38 @@ def _find_roots_impl(
     zero_tol = coeff_scale * max((degree + 1) * _ZERO_TOL_SAFETY * epsilon, resolved_tol)
     _check_connected(coeffs, knots, degree, zero_tol)
 
-    wait_for_jit_warmup()
-    raw, count, truncated = _morken_reimers_roots(
-        knots, degree, coeffs, resolved_tol, zero_tol, _max_insertions(degree)
+    # What a *tracked* iterate may leave behind, as opposed to a value read straight off
+    # a coefficient. `zero_tol` is the error of evaluating the spline, and on its own it
+    # rejects the genuine zeros of a steep one: the iteration stops at a parametric
+    # resolution of `_STOP_SLACK * tol * scale`, and a zero located to that much leaves
+    # `|f'|` times it behind however exactly the spline is then evaluated. Both terms are
+    # values of the spline, so the sum transforms correctly under a change of either
+    # scale: the second is a slope times a length.
+    domain_length = float(knots[coeffs.shape[0]] - knots[degree])
+    parametric_scale = max(abs(float(knots[degree])), abs(float(knots[coeffs.shape[0]])))
+    parametric_scale = max(parametric_scale, domain_length)
+    root_tol = zero_tol + _STOP_SLACK * _slope_bound(coeffs, knots, degree) * (
+        resolved_tol * parametric_scale
     )
+
+    wait_for_jit_warmup()
+    raw, count, truncated, abandoned = _morken_reimers_roots(
+        knots, degree, coeffs, resolved_tol, zero_tol, root_tol, _max_insertions(degree)
+    )
+    budget = _max_insertions(degree)
     if truncated > 0:
         warnings.warn(
             f"{truncated} of {count} roots exhausted their insertion budget of "
-            f"{_max_insertions(degree)} before the iterates stagnated; they are "
-            "reported at the last iterate reached",
+            f"{budget} before the iterates stagnated; they are reported at the last "
+            "iterate reached, so they may be less accurate than tol asks for",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    if abandoned > 0:
+        warnings.warn(
+            f"{abandoned} sign changes exhausted their insertion budget of {budget} "
+            f"without the residual ever falling to {root_tol:.3e}, so they are not "
+            "reported; the result may be missing a root",
             RuntimeWarning,
             stacklevel=3,
         )
@@ -297,7 +380,7 @@ def _find_roots_impl(
             roots,
             zero_tol=zero_tol,
             coeff_scale=coeff_scale,
-            domain_length=float(knots[coeffs.shape[0]] - knots[degree]),
+            domain_length=domain_length,
             tol=resolved_tol,
         )
         merged, n_merged = _merge_roots(roots, radii)
@@ -372,15 +455,23 @@ def find_roots(
 
     Warns:
         RuntimeWarning: If a zero exhausted its insertion budget before the
-            iterates stagnated. The last iterate reached is reported.
+            iterates stagnated, in which case the last iterate reached is
+            reported and may be less accurate than ``tol`` asks for; and,
+            separately, if a sign change exhausted that budget without its
+            residual ever certifying it, in which case it is not reported at all
+            and the result may be missing a root.
 
     Note:
-        Zeros where the spline changes sign are always found. A zero of even
-        multiplicity does not change the sign of the spline, so the sign changes
-        of the control polygon that bracket it vanish under refinement and it
-        cannot be certified from the polygon; it is reported only when the
-        residual there satisfies ``|f(x)| <= zero_tol``, with ``zero_tol`` the
-        de Boor evaluation-error bound of the spline.
+        A value is reported only when the residual there is within what a zero
+        may legitimately leave behind: the de Boor evaluation-error bound of the
+        spline, plus ``|f'| * 2 * tol * scale``, the value the spline reaches at
+        the parametric resolution the iteration stops at. The control polygon
+        says where to look and never certifies on its own: the tracking of a sign
+        change stops for three different reasons, and none of them implies that
+        the point it stopped at is a zero. The residual test is also the only way
+        a zero of even multiplicity is reported, since it does not change the
+        sign of the spline and the sign changes bracketing it vanish under
+        refinement.
 
     Example:
         >>> import numpy as np

--- a/src/pantr/bspline/_bspline_roots_core.py
+++ b/src/pantr/bspline/_bspline_roots_core.py
@@ -15,6 +15,14 @@ an open (clamped) knot vector, this time on ``[zero, end]``. That is what bounds
 the memory, since the insertions spent on one zero are discarded when the next
 one is reported, and it is what keeps every span search inside the buffer.
 
+Nothing here is reported on the strength of the branch that produced it. The
+paper's certificates -- a repeated iterate, an iterate at the end of its Greville
+interval -- are theorems of exact arithmetic, and a floating-point iteration can
+satisfy their conclusions' *tests* without being anywhere near a zero. So
+:func:`_track_zero` hands back ``|f(x)|`` on every exit, its status says only how
+the iteration stopped, and :func:`_morken_reimers_roots` reports an iterate if and
+only if that residual is within ``root_tol``.
+
 Note:
     Inputs are assumed to be correct (no validation performed).
     For general use, call :func:`pantr.bspline.find_roots` instead.
@@ -29,20 +37,30 @@ import numpy.typing as npt
 
 from .._numba_compat import nb_jit
 
-_STATUS_CONVERGED: int = 1
-"""The iterates stagnated, or repeated exactly, at a zero of the spline."""
+_STATUS_STAGNATED: int = 1
+"""The iteration reached a point it will not leave.
 
-_STATUS_CANDIDATE: int = 2
-"""The polygon cannot certify the last iterate; its residual decides.
+Covers the three stopping rules: an iterate repeated exactly, the last ``degree``
+iterates spanned less than ``tol``, and an iterate reached the right end of its
+Greville interval, where every value of ``lam`` gives the same point.
+"""
 
-Reached when the tracked sign change vanished under refinement, which is either a
-tangential zero or a false warning of the variation-diminishing bound, and when the
-iterate reached a knot of multiplicity ``degree + 1``, where the spline jumps and the
-sign change need not bracket a zero at all.
+_STATUS_VANISHED: int = 2
+"""The tracked sign change disappeared under refinement.
+
+Either a tangential zero, where the two sign changes bracketing it collapse, or a
+false warning of the variation-diminishing bound.
 """
 
 _STATUS_BUDGET: int = 3
-"""The insertion budget ran out before the iterates stagnated."""
+"""The insertion budget ran out before the iteration stopped."""
+
+_COROLLARY_14_DEGREE: int = 2
+"""Lowest degree at which Corollary 14 of Mørken-Reimers asks for a collapsed knot run.
+
+The corollary needs ``degree - 1`` active knots collapsed onto the iterate, so at
+degree 1 it asks for none and a repeated iterate satisfies it on its own.
+"""
 
 
 @nb_jit(nopython=True, cache=True)
@@ -155,6 +173,72 @@ def _deboor_point(  # noqa: PLR0913
             alpha = (point - knots[left]) / denominator if denominator > 0.0 else 0.0
             work[i] = (1.0 - alpha) * work[i - 1] + alpha * work[i]
     return float(work[degree])
+
+
+@nb_jit(nopython=True, cache=True)
+def _span_at(
+    knots: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    point: float,
+) -> int:
+    """Locate the knot span of ``point`` in an open (clamped) knot window.
+
+    The search is bounded above by ``num_coeffs - 1``, the last span of an open
+    knot vector, so that a point at the end of the domain is handled from the
+    left instead of walking off the end of the buffer.
+
+    Args:
+        knots (npt.NDArray[Any]): Open (clamped) knot window.
+        num_coeffs (int): Number of valid coefficients in the window.
+        degree (int): Polynomial degree.
+        point (float): Point inside the window's domain.
+
+    Returns:
+        int: Span index in ``[degree, num_coeffs - 1]``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    span = degree
+    while span + 1 < num_coeffs and point >= knots[span + 1]:
+        span += 1
+    return span
+
+
+@nb_jit(nopython=True, cache=True)
+def _residual_at(  # noqa: PLR0913
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    point: float,
+    work: npt.NDArray[Any],
+) -> float:
+    """Evaluate ``|f(point)|`` on a refined window.
+
+    This is the certificate every reported zero has to produce, so it is computed
+    from the window as it stands rather than assumed from the branch that reached
+    it.
+
+    Args:
+        knots (npt.NDArray[Any]): Open (clamped) knot window.
+        coeffs (npt.NDArray[Any]): Coefficient window.
+        num_coeffs (int): Number of valid entries in ``coeffs``.
+        degree (int): Polynomial degree.
+        point (float): Evaluation point, inside the window's domain.
+        work (npt.NDArray[Any]): Scratch buffer of at least ``degree + 1`` entries.
+
+    Returns:
+        float: ``|f(point)|``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    span = _span_at(knots, num_coeffs, degree, point)
+    return abs(_deboor_point(knots, coeffs, degree, point, span, work))
 
 
 @nb_jit(nopython=True, cache=True)
@@ -277,6 +361,38 @@ def _split_at_root(  # noqa: PLR0913
 
 
 @nb_jit(nopython=True, cache=True)
+def _drop_window_head(
+    knots: npt.NDArray[Any],
+    coeffs: npt.NDArray[Any],
+    num_coeffs: int,
+    degree: int,
+    offset: int,
+) -> int:
+    """Discard the first ``offset`` coefficients of the window, shifting the rest down.
+
+    Args:
+        knots (npt.NDArray[Any]): Knot window, shifted in place.
+        coeffs (npt.NDArray[Any]): Coefficient window, shifted in place.
+        num_coeffs (int): Number of valid entries in ``coeffs`` before the shift.
+        degree (int): Polynomial degree.
+        offset (int): Number of leading coefficients to drop.
+
+    Returns:
+        int: The coefficient count after the shift, ``num_coeffs - offset``.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`pantr.bspline.find_roots` instead.
+    """
+    remaining = num_coeffs - offset
+    for i in range(remaining):
+        coeffs[i] = coeffs[i + offset]
+    for i in range(remaining + degree + 1):
+        knots[i] = knots[i + offset]
+    return remaining
+
+
+@nb_jit(nopython=True, cache=True)
 def _track_zero(  # noqa: PLR0913
     knots: npt.NDArray[Any],
     coeffs: npt.NDArray[Any],
@@ -284,7 +400,6 @@ def _track_zero(  # noqa: PLR0913
     degree: int,
     index: int,
     tol: float,
-    zero_tol: float,
     domain_length: float,
     max_insertions: int,
     iterates: npt.NDArray[Any],
@@ -310,8 +425,6 @@ def _track_zero(  # noqa: PLR0913
         index (int): Zero index to track, inside the window. The caller
             guarantees that :func:`_is_zero_index` holds for it.
         tol (float): Relative stagnation tolerance.
-        zero_tol (float): Absolute residual below which a coefficient counts as
-            zero.
         domain_length (float): Length of the spline's parametric domain, used as
             a floor for the tolerance scale.
         max_insertions (int): Insertion budget for this zero.
@@ -320,11 +433,13 @@ def _track_zero(  # noqa: PLR0913
 
     Returns:
         tuple[float, int, float, int, int]: ``(x, status, residual, num_coeffs,
-        index)``. ``status`` is one of ``_STATUS_CONVERGED``,
-        ``_STATUS_CANDIDATE`` or ``_STATUS_BUDGET``, ``x`` is the last polygon
-        zero computed, ``residual`` is ``|f(x)|`` when the status is
-        ``_STATUS_CANDIDATE`` and ``0.0`` otherwise, and the last two are the
-        coefficient count and tracked index left behind in the refined window.
+        index)``. ``x`` is the last polygon zero computed and ``residual`` is
+        ``|f(x)|``, evaluated on the refined window on *every* exit: the status
+        records how the iteration stopped, never whether ``x`` may be reported,
+        which is the caller's residual test alone. ``status`` is one of
+        ``_STATUS_STAGNATED``, ``_STATUS_VANISHED`` or ``_STATUS_BUDGET``, and
+        the last two are the coefficient count and tracked index left behind in
+        the refined window.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -365,9 +480,32 @@ def _track_zero(  # noqa: PLR0913
         x = max(x, knots[index])
 
         # A repeated iterate is a fixed point of the iteration, hence a zero of
-        # the spline (Morken-Reimers, Lemma 13 and Corollary 14).
+        # the spline (Morken-Reimers, Lemma 13 and Corollary 14). The corollary
+        # is a statement about exact arithmetic, so what it licenses is stopping
+        # here, not the value being a zero: the residual is what says that.
+        #
+        # Its hypothesis is that the tracked sign change has `degree - 1` of its
+        # active knots collapsed onto the iterate, `t[index + 1] = ... =
+        # t[index + degree - 1] = x`, and the knots being ascending the two ends
+        # of that run decide it. Repetition alone is a much weaker signal: it is
+        # also what a secant that is nearly horizontal in the control polygon
+        # produces, once the correction it asks for falls below an ulp of the
+        # Greville abscissa, and that happens at a shallow non-zero minimum just
+        # as readily as at a zero. Testing repetition alone stops the iteration
+        # early, wherever precision runs out first, which at degree 3 is after
+        # one collapsed knot of the two the corollary needs.
+        #
+        # Falling through instead inserts x again, which collapses one more knot
+        # onto it, so the hypothesis is reached in at most `degree - 1` further
+        # insertions and the budget bounds the rest. For degree 1 the run is
+        # empty and the corollary asks for nothing.
         if num_iterates > 0 and x == previous_x:
-            return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+            collapsed = degree < _COROLLARY_14_DEGREE or (
+                knots[index + 1] == x and knots[index + degree - 1] == x
+            )
+            if collapsed:
+                residual = _residual_at(knots, coeffs, num_coeffs, degree, x, work)
+                return x, _STATUS_STAGNATED, residual, num_coeffs, index
 
         # Their Lemma 3: an iterate that reaches the right end of its Greville
         # interval carries `coeffs[index] = 0`, hence f(x) = 0.
@@ -376,25 +514,20 @@ def _track_zero(  # noqa: PLR0913
         # and that interval is empty exactly when the two abscissae coincide,
         # which happens exactly when `knots[index] == knots[index + degree]`,
         # that is when the knot run at x carries multiplicity `degree + 1` and
-        # the spline is C^-1 there. The hypothesis is therefore a property of the
-        # knot vector alone: the test below is structural and needs no tolerance,
-        # and it leaves every other spline on the path it already took.
+        # the spline is C^-1 there. In that one excluded case the secant through
+        # the two coefficients is vertical, its zero is x for every `lam`, and
+        # nothing forces `coeffs[index]` to vanish; the sign change is then the
+        # spline jumping across the axis rather than meeting it.
         #
-        # In that one excluded case the secant through the two coefficients is
-        # vertical, its zero is x for every `lam`, and nothing forces
-        # `coeffs[index]` to vanish; the sign change is then the spline jumping
-        # across the axis rather than meeting it. So test the lemma's conclusion
-        # instead of assuming it. At an exact C^-1 knot `coeffs[index]` is the
-        # value of the spline immediately to the right of the run, with no
-        # positional error to inflate it, so comparing it against the residual
-        # threshold is dimensionally sound.
+        # Either way the conclusion is tested rather than assumed, so the two
+        # cases need no separating: reaching this branch means the knot run at x
+        # has multiplicity at least `degree`, and `coeffs[index]` is then exactly
+        # the value of the spline immediately to the right of the run, with no
+        # positional error to inflate it. Refining instead would insert a knot
+        # into a run the method keeps at multiplicity at most `degree`, and
+        # divide by a zero-length span.
         if x >= knots[index + degree]:
-            if knots[index] < knots[index + degree] or abs(coeffs[index]) <= zero_tol:
-                return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
-            # Hand the jump to the caller's residual test, which rejects it.
-            # Refining instead would insert a knot into a run the method keeps at
-            # multiplicity at most `degree`, and divide by a zero-length span.
-            return x, _STATUS_CANDIDATE, abs(coeffs[index]), num_coeffs, index
+            return x, _STATUS_STAGNATED, abs(coeffs[index]), num_coeffs, index
 
         iterates[num_iterates % degree] = x
         previous_x = x
@@ -409,10 +542,12 @@ def _track_zero(  # noqa: PLR0913
             scale = max(abs(knots[index]), abs(knots[index + degree]))
             scale = max(scale, domain_length)
             if highest - lowest <= tol * scale:
-                return x, _STATUS_CONVERGED, 0.0, num_coeffs, index
+                residual = _residual_at(knots, coeffs, num_coeffs, degree, x, work)
+                return x, _STATUS_STAGNATED, residual, num_coeffs, index
 
         if inserted >= budget:
-            return x, _STATUS_BUDGET, 0.0, num_coeffs, index
+            residual = _residual_at(knots, coeffs, num_coeffs, degree, x, work)
+            return x, _STATUS_BUDGET, residual, num_coeffs, index
 
         span = index
         while x >= knots[span + 1]:
@@ -426,34 +561,37 @@ def _track_zero(  # noqa: PLR0913
         if not _is_zero_index(coeffs, num_coeffs, index):
             index += 1
             if not _is_zero_index(coeffs, num_coeffs, index):
-                span = 0
-                while x >= knots[span + 1]:
-                    span += 1
-                residual = _deboor_point(knots, coeffs, degree, x, span, work)
-                return x, _STATUS_CANDIDATE, abs(residual), num_coeffs, index
+                residual = _residual_at(knots, coeffs, num_coeffs, degree, x, work)
+                return x, _STATUS_VANISHED, residual, num_coeffs, index
 
 
 @nb_jit(nopython=True, cache=True)
-def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
+def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
     knots: npt.NDArray[Any],
     degree: int,
     coeffs: npt.NDArray[Any],
     tol: float,
     zero_tol: float,
+    root_tol: float,
     max_insertions: int,
-) -> tuple[npt.NDArray[np.float64], int, int]:
+) -> tuple[npt.NDArray[np.float64], int, int, int]:
     """Compute every zero of a scalar spline by the Mørken-Reimers method.
 
-    Scans the control polygon left to right and tracks each sign change to a
-    zero of the spline. A sign change that disappears under refinement is a
-    false warning of the variation-diminishing bound, unless the spline is
-    tangent to the axis there: those are separated by testing the residual
-    ``|f(x)| <= zero_tol``, which is also how the two domain endpoints are
-    tested. Zeros of even multiplicity have no sign change in the limit and
-    cannot be certified by the polygon alone, so they are reported through that
-    residual test only. A sign change across a knot of multiplicity
-    ``degree + 1``, where the spline is C^-1 and jumps across the axis without
-    reaching it, is rejected by that same test.
+    Scans the control polygon left to right and tracks each sign change. What
+    the polygon supplies is a *place to look*, never a certificate: the
+    tracking stops for three different reasons, none of which implies that the
+    point it stopped at is a zero, so every iterate is reported only when
+    ``|f(x)| <= root_tol``. It is what separates a tangential zero, where the
+    two sign changes bracketing it collapse, from a false warning of the
+    variation-diminishing bound; what rejects a sign change across a knot of
+    multiplicity ``degree + 1``, where the spline is C^-1 and jumps across the
+    axis without reaching it; and what rejects an iteration that stopped moving
+    somewhere other than a zero.
+
+    The two domain endpoints are decided by ``zero_tol`` instead, on the
+    coefficient an open knot vector interpolates there: that is the value of the
+    spline, carrying no location error at all, so only the evaluation term
+    applies.
 
     Args:
         knots (npt.NDArray[Any]): Open (clamped) knot vector of shape
@@ -461,14 +599,22 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
         degree (int): Polynomial degree, at least 1.
         coeffs (npt.NDArray[Any]): B-spline coefficients of the scalar spline.
         tol (float): Relative stagnation tolerance for the iterates.
-        zero_tol (float): Absolute residual below which a value counts as zero.
+        zero_tol (float): Absolute residual below which an exactly located value
+            counts as zero, that is the error of evaluating the spline.
+        root_tol (float): Absolute residual below which a *tracked* iterate
+            counts as a zero. Larger than ``zero_tol`` by what the parametric
+            tolerance the iteration stops at leaves behind, and derived in
+            :func:`pantr.bspline._bspline_roots._find_roots_impl`.
         max_insertions (int): Insertion budget per zero.
 
     Returns:
-        tuple[npt.NDArray[np.float64], int, int]: ``(roots, count, truncated)``
-        where only the first ``count`` entries of ``roots`` are valid, sorted
-        ascending, and ``truncated`` counts the zeros whose insertion budget ran
-        out before the iterates stagnated.
+        tuple[npt.NDArray[np.float64], int, int, int]: ``(roots, count,
+        truncated, abandoned)`` where only the first ``count`` entries of
+        ``roots`` are valid, sorted ascending. ``truncated`` counts the reported
+        zeros whose insertion budget ran out first, so that they sit at the last
+        iterate reached rather than at a stagnated one; ``abandoned`` counts the
+        sign changes whose budget ran out without the residual ever certifying
+        them, each of which may be a zero this call does not report.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -482,6 +628,7 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
     roots = np.empty(num_coeffs + 2, dtype=np.float64)
     count = 0
     truncated = 0
+    abandoned = 0
 
     start = float(knots[degree])
     end = float(knots[num_coeffs])
@@ -519,9 +666,11 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
         # Stop while a full tracking and the split that may follow it still fit.
         # Reaching this means the insertions between two reported zeros outran
         # the room the compaction reclaims, which the capacity below is sized to
-        # prevent; the count of unfinished zeros is what tells the caller.
+        # prevent; the count of unfinished zeros is what tells the caller. This
+        # sign change is never tracked at all, so it is abandoned rather than
+        # truncated.
         if num_live + max_insertions + 2 * (degree + 1) > capacity:
-            truncated += 1
+            abandoned += 1
             break
 
         x, status, residual, num_live, index = _track_zero(
@@ -531,27 +680,38 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
             degree,
             index,
             tol,
-            zero_tol,
             domain_length,
             max_insertions,
             iterates,
             work,
         )
 
-        if status == _STATUS_BUDGET:
-            truncated += 1
+        # The residual, and nothing else, is what makes an iterate a zero. The
+        # three ways the tracking can stop are three provenances, not three
+        # entitlements: the polygon lost its sign change, the iteration stopped
+        # moving, or the budget ran out, and each of them can stop at a point
+        # where the spline does not vanish. The theory that says otherwise holds
+        # in exact arithmetic, where a coefficient reaches zero only near a zero
+        # of the spline; in floating point it can reach zero for reasons of its
+        # own, so the conclusion is tested rather than inherited.
+        #
+        # `root_tol` rather than `zero_tol`, because the iteration stops at a
+        # *parametric* resolution: a zero located to that much leaves `|f'|`
+        # times it behind however exactly f is then evaluated, and testing the
+        # evaluation error alone would reject the genuine zeros of a steep
+        # spline.
+        certified = residual <= root_tol
 
-        # A polygon that lost its sign change is at a zero of even multiplicity if
-        # the spline vanishes there, and at a false warning of the
-        # variation-diminishing bound otherwise. A sign change straddling a knot
-        # of multiplicity `degree + 1` arrives here as well, and the same test
-        # rejects it: the spline jumps across the axis without ever reaching it.
-        accepted = residual <= zero_tol if status == _STATUS_CANDIDATE else True
+        if status == _STATUS_BUDGET:
+            if certified:
+                truncated += 1
+            else:
+                abandoned += 1
 
         # The sweep is strictly left to right, so an iterate that did not pass
         # the zero reported last is that same zero seen again through another
         # sign change of the polygon, not a new one.
-        if accepted and previous_root < x <= end:
+        if certified and previous_root < x <= end:
             roots[count] = x
             count += 1
             previous_root = x
@@ -565,11 +725,7 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
                 num_live, offset = _split_at_root(
                     live_knots, live_coeffs, num_live, degree, x, zero_tol
                 )
-                for i in range(num_live - offset):
-                    live_coeffs[i] = live_coeffs[i + offset]
-                for i in range(num_live - offset + degree + 1):
-                    live_knots[i] = live_knots[i + offset]
-                num_live -= offset
+                num_live = _drop_window_head(live_knots, live_coeffs, num_live, degree, offset)
                 scan_from = 1
         else:
             # One index past the sign change just rejected, and no further: the
@@ -584,7 +740,7 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913
         roots[count] = end
         count += 1
 
-    return roots, count, truncated
+    return roots, count, truncated, abandoned
 
 
 @nb_jit(nopython=True, cache=True)
@@ -641,17 +797,20 @@ def _warmup_numba_functions() -> None:
     """
     knots = np.array([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
     coeffs = np.array([-1.0, -0.5, 0.5, 1.0, 2.0], dtype=np.float64)
-    roots, count, _ = _morken_reimers_roots(knots, 3, coeffs, 1e-15, 1e-14, 64)
+    roots, count, _, _ = _morken_reimers_roots(knots, 3, coeffs, 1e-15, 1e-14, 1e-13, 64)
     _merge_roots(roots[:count], np.full(count, 1e-15, dtype=np.float64))
 
 
 __all__ = [
     "_deboor_point",
+    "_drop_window_head",
     "_insert_knot",
     "_is_zero_index",
     "_knot_average",
     "_merge_roots",
     "_morken_reimers_roots",
+    "_residual_at",
+    "_span_at",
     "_split_at_root",
     "_track_zero",
     "_zero_index",

--- a/src/pantr/bspline/_bspline_roots_core.py
+++ b/src/pantr/bspline/_bspline_roots_core.py
@@ -40,9 +40,10 @@ from .._numba_compat import nb_jit
 _STATUS_STAGNATED: int = 1
 """The iteration reached a point it will not leave.
 
-Covers the three stopping rules: an iterate repeated exactly, the last ``degree``
-iterates spanned less than ``tol``, and an iterate reached the right end of its
-Greville interval, where every value of ``lam`` gives the same point.
+Covers the three stopping rules: an iterate repeated exactly with Corollary 14's
+collapsed knot run behind it, the last ``degree`` iterates spanned less than ``tol``,
+and an iterate reached the right end of its Greville interval, where every value of
+``lam`` gives the same point.
 """
 
 _STATUS_VANISHED: int = 2
@@ -520,12 +521,24 @@ def _track_zero(  # noqa: PLR0913
         # spline jumping across the axis rather than meeting it.
         #
         # Either way the conclusion is tested rather than assumed, so the two
-        # cases need no separating: reaching this branch means the knot run at x
-        # has multiplicity at least `degree`, and `coeffs[index]` is then exactly
-        # the value of the spline immediately to the right of the run, with no
-        # positional error to inflate it. Refining instead would insert a knot
-        # into a run the method keeps at multiplicity at most `degree`, and
-        # divide by a zero-length span.
+        # cases need no separating. Reaching this branch means `x` is exactly the
+        # knot `knots[index + degree]` and the run ending there has multiplicity
+        # at least `degree`, so exactly one basis function is non-zero at x on
+        # the side the tracking came from and `coeffs[index]` is the value of the
+        # spline there: the right limit when the run reaches back to `index`, the
+        # left limit when it starts past it, and both at once where the spline is
+        # continuous. Refining instead would insert a knot into a run the method
+        # keeps at multiplicity at most `degree`, and divide by a zero-length
+        # span.
+        #
+        # It is a coefficient rather than an evaluation, but that does not make
+        # it exact and it gets the same threshold as every other exit. The window
+        # it belongs to was refined by up to a few hundred Boehm insertions whose
+        # alphas are differences of knots, so it carries the coordinate's own
+        # resolution: on the unit domain moved to 1e6 the coefficient at a zero
+        # sitting on a knot comes out at 2e-11, eleven thousand times `zero_tol`
+        # and comfortably inside what the parametric tolerance allows. Only the
+        # two domain endpoints, read off the *unrefined* input, are free of it.
         if x >= knots[index + degree]:
             return x, _STATUS_STAGNATED, abs(coeffs[index]), num_coeffs, index
 
@@ -578,20 +591,20 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
     """Compute every zero of a scalar spline by the Mørken-Reimers method.
 
     Scans the control polygon left to right and tracks each sign change. What
-    the polygon supplies is a *place to look*, never a certificate: the
-    tracking stops for three different reasons, none of which implies that the
-    point it stopped at is a zero, so every iterate is reported only when
-    ``|f(x)| <= root_tol``. It is what separates a tangential zero, where the
-    two sign changes bracketing it collapse, from a false warning of the
+    the polygon supplies is a *place to look*, never a certificate: the tracking
+    stops for three different reasons, none of which implies that the point it
+    stopped at is a zero, so every iterate is reported only when
+    ``|f(x)| <= root_tol``. That test is what separates a tangential zero, where
+    the two sign changes bracketing it collapse, from a false warning of the
     variation-diminishing bound; what rejects a sign change across a knot of
     multiplicity ``degree + 1``, where the spline is C^-1 and jumps across the
     axis without reaching it; and what rejects an iteration that stopped moving
     somewhere other than a zero.
 
-    The two domain endpoints are decided by ``zero_tol`` instead, on the
-    coefficient an open knot vector interpolates there: that is the value of the
-    spline, carrying no location error at all, so only the evaluation term
-    applies.
+    The two domain endpoints are decided by the tighter ``zero_tol`` instead, on
+    the coefficient an open knot vector interpolates there. That coefficient
+    comes from the input untouched, so unlike everything the tracking produces it
+    carries no positional error at all and only the evaluation term applies.
 
     Args:
         knots (npt.NDArray[Any]): Open (clamped) knot vector of shape
@@ -599,12 +612,13 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
         degree (int): Polynomial degree, at least 1.
         coeffs (npt.NDArray[Any]): B-spline coefficients of the scalar spline.
         tol (float): Relative stagnation tolerance for the iterates.
-        zero_tol (float): Absolute residual below which an exactly located value
-            counts as zero, that is the error of evaluating the spline.
-        root_tol (float): Absolute residual below which a *tracked* iterate
-            counts as a zero. Larger than ``zero_tol`` by what the parametric
-            tolerance the iteration stops at leaves behind, and derived in
-            :func:`pantr.bspline._bspline_roots._find_roots_impl`.
+        zero_tol (float): Absolute residual below which a value taken from the
+            unrefined input counts as zero, that is the error of evaluating the
+            spline. Used for the two domain endpoints and for the split barrier.
+        root_tol (float): Absolute residual below which an iterate the tracking
+            produced counts as a zero. Larger than ``zero_tol`` by what the
+            parametric tolerance the iteration stops at leaves behind, and
+            derived in :func:`pantr.bspline._bspline_roots._find_roots_impl`.
         max_insertions (int): Insertion budget per zero.
 
     Returns:
@@ -613,8 +627,10 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
         ``roots`` are valid, sorted ascending. ``truncated`` counts the reported
         zeros whose insertion budget ran out first, so that they sit at the last
         iterate reached rather than at a stagnated one; ``abandoned`` counts the
-        sign changes whose budget ran out without the residual ever certifying
-        them, each of which may be a zero this call does not report.
+        sign changes left without a zero to show for them, whether because the
+        budget ran out before the residual certified one or because the working
+        arrays had no room to track them, each of which may be a zero this call
+        does not report.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -688,18 +704,21 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
 
         # The residual, and nothing else, is what makes an iterate a zero. The
         # three ways the tracking can stop are three provenances, not three
-        # entitlements: the polygon lost its sign change, the iteration stopped
-        # moving, or the budget ran out, and each of them can stop at a point
-        # where the spline does not vanish. The theory that says otherwise holds
-        # in exact arithmetic, where a coefficient reaches zero only near a zero
-        # of the spline; in floating point it can reach zero for reasons of its
-        # own, so the conclusion is tested rather than inherited.
+        # entitlements: the iteration stopped moving, the polygon lost its sign
+        # change, or the budget ran out, and each of them can stop where the
+        # spline does not vanish. The theory that says otherwise holds in exact
+        # arithmetic, where a coefficient reaches zero only near a zero of the
+        # spline; in floating point it can reach zero for reasons of its own, so
+        # the conclusion is tested rather than inherited.
         #
-        # `root_tol` rather than `zero_tol`, because the iteration stops at a
-        # *parametric* resolution: a zero located to that much leaves `|f'|`
-        # times it behind however exactly f is then evaluated, and testing the
-        # evaluation error alone would reject the genuine zeros of a steep
-        # spline.
+        # `root_tol` and not `zero_tol`, for every one of them alike. The
+        # iteration stops at a *parametric* resolution, so a correctly located
+        # zero leaves `|f'|` times that behind however exactly f is then
+        # evaluated, and the same is true of a residual read off a coefficient of
+        # the refined window, since the insertions that produced it take
+        # differences of knots and so carry the coordinate's resolution too. Only
+        # the two domain endpoints below, taken from the unrefined input, are
+        # free of it.
         certified = residual <= root_tol
 
         if status == _STATUS_BUDGET:

--- a/src/pantr/bspline/_bspline_roots_core.py
+++ b/src/pantr/bspline/_bspline_roots_core.py
@@ -747,7 +747,7 @@ def _morken_reimers_roots(  # noqa: PLR0912, PLR0913, PLR0915
 def _merge_roots(
     roots: npt.NDArray[np.float64],
     radii: npt.NDArray[np.float64],
-) -> tuple[npt.NDArray[np.float64], int]:
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], int]:
     """Merge runs of ascending roots that lie within their own merge radii.
 
     The scan reports one root per sign change of the control polygon, and a zero
@@ -756,13 +756,20 @@ def _merge_roots(
     not exceed the larger of the two radii; each run is replaced by its midpoint,
     which for a bracketed tangential zero is the better estimate of the two.
 
+    A midpoint is a value nobody tracked, so the run each input joined is
+    reported alongside it: the caller cannot certify the midpoint from here, and
+    without the labels it could not put a run back the way it found it when the
+    certificate fails.
+
     Args:
         roots (npt.NDArray[np.float64]): Ascending root candidates.
         radii (npt.NDArray[np.float64]): Per-root merge radius, same length.
 
     Returns:
-        tuple[npt.NDArray[np.float64], int]: ``(merged, n_merged)`` where only
-        the first ``n_merged`` entries are valid.
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], int]: ``(merged,
+        labels, n_merged)`` where only the first ``n_merged`` entries of
+        ``merged`` are valid, and ``labels[i]`` is the index in ``merged`` of the
+        run that ``roots[i]`` joined.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -770,12 +777,14 @@ def _merge_roots(
     """
     count = roots.shape[0]
     merged = np.empty(max(count, 1), dtype=np.float64)
+    labels = np.empty(count, dtype=np.int64)
     if count == 0:
-        return merged, 0
+        return merged, labels, 0
 
     n_merged = 0
     run_start = roots[0]
     run_end = roots[0]
+    labels[0] = 0
     for i in range(1, count):
         if roots[i] - run_end <= max(radii[i], radii[i - 1]):
             run_end = roots[i]
@@ -784,9 +793,10 @@ def _merge_roots(
             n_merged += 1
             run_start = roots[i]
             run_end = roots[i]
+        labels[i] = n_merged
     merged[n_merged] = 0.5 * (run_start + run_end)
     n_merged += 1
-    return merged, n_merged
+    return merged, labels, n_merged
 
 
 def _warmup_numba_functions() -> None:
@@ -798,7 +808,7 @@ def _warmup_numba_functions() -> None:
     knots = np.array([0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0], dtype=np.float64)
     coeffs = np.array([-1.0, -0.5, 0.5, 1.0, 2.0], dtype=np.float64)
     roots, count, _, _ = _morken_reimers_roots(knots, 3, coeffs, 1e-15, 1e-14, 1e-13, 64)
-    _merge_roots(roots[:count], np.full(count, 1e-15, dtype=np.float64))
+    _merge_roots(np.ascontiguousarray(roots[:count]), np.full(count, 1e-15, dtype=np.float64))
 
 
 __all__ = [

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -70,6 +70,22 @@ own root-quality invariant applies to the same two terms. It buys nothing agains
 this guards, which exceeds the bound by eleven orders of magnitude.
 """
 
+_SLOPE_SAMPLES: int = 4001
+"""Grid points used to estimate ``max |f'|`` independently of the implementation.
+
+The estimate only has to be within the safety factor of the true supremum, and it is
+taken on top of every knot and both sides of it, which is where a spline's slope peaks.
+Four thousand points on the families it is used with put it within 1 % of the hodograph
+bound.
+"""
+
+_SLOPE_SAMPLE_NUDGE: float = 1.0e-9
+"""Offset, relative to the coordinate scale, at which the slope is sampled beside a knot.
+
+Small enough to sit inside the smallest knot interval used here (``1 / 8`` of the
+domain), large enough to survive the rounding of adding it to a coordinate at ``1e6``.
+"""
+
 _PARITY_RTOL: float = 1e-10
 """
 Agreement required between this method and extraction plus Bernstein root finding.
@@ -122,8 +138,12 @@ def _polynomial_coefficients(
     afterwards. Building it directly on a domain around ``1e3`` instead loses it entirely,
     the power basis then cancelling terms of order ``1e15`` down to a result of order
     ``1e-5``.
+
+    Fewer roots than ``degree`` is allowed and puts a polynomial of lower degree in the
+    space, its leading power coefficients being zero.
     """
     power = np.poly(np.asarray(roots, dtype=np.float64))[::-1]
+    power = np.concatenate((power, np.zeros(degree + 1 - power.size, dtype=np.float64)))
     binomials = np.array([math.comb(degree, k) for k in range(degree + 1)], dtype=np.float64)
     out = np.empty(len(knots) - degree - 1, dtype=np.float64)
     for j in range(out.shape[0]):
@@ -157,22 +177,37 @@ def _bezier_reference_roots(
     return out
 
 
-def _hodograph_slope_bound(
-    coeffs: npt.NDArray[np.float64],
-    knots: npt.NDArray[np.float64],
-    degree: int,
-) -> float:
-    """Bound ``|f'|`` over the whole domain from the hodograph coefficients.
+def _sampled_slope(spline: Bspline, knots: npt.NDArray[np.float64], degree: int) -> float:
+    """Estimate ``max |f'|`` over the domain by sampling the derivative.
 
-    The derivative of a spline is the spline whose coefficients are
-    ``degree * (c[i] - c[i-1]) / (t[i+degree] - t[i])``, and a spline never leaves the
-    range of its own coefficients, so the largest such difference quotient bounds ``|f'|``
-    everywhere. A zero-length denominator is a C^-1 knot, where the spline jumps and no
-    finite slope describes it, and is skipped.
+    Deliberately *not* the hodograph difference quotient the implementation derives its
+    own threshold from: a bound recomputed by the same formula would move with a bug in
+    it, and the tolerance it feeds would then stretch to cover the very defect the
+    assertion is meant to catch. This goes through :meth:`Bspline.evaluate_derivatives`
+    instead, which reaches the derivative by a different route.
+
+    Sampling gives a lower estimate of the supremum, so the bound built on it is if
+    anything too tight; the sample includes every knot and both sides of it, which is
+    where a spline's slope peaks, and the tests using it carry ``_RESIDUAL_SAFETY``.
     """
-    gaps = knots[degree + 1 : coeffs.shape[0] + degree] - knots[1 : coeffs.shape[0]]
-    quotients = np.abs(np.diff(coeffs))[gaps > 0.0] / gaps[gaps > 0.0]
-    return float(degree * quotients.max()) if quotients.size else 0.0
+    unique = np.unique(knots)
+    nudge = _SLOPE_SAMPLE_NUDGE * max(float(unique[-1] - unique[0]), float(np.abs(knots).max()))
+    points = np.unique(
+        np.clip(
+            np.concatenate(
+                (
+                    np.linspace(unique[0], unique[-1], _SLOPE_SAMPLES),
+                    unique,
+                    unique + nudge,
+                    unique - nudge,
+                )
+            ),
+            unique[0],
+            unique[-1],
+        )
+    )
+    values = np.asarray(spline.evaluate_derivatives(points, [1]), dtype=np.float64)
+    return float(np.abs(values).max())
 
 
 def _zero_tol(coeffs: npt.NDArray[np.float64], degree: int) -> float:
@@ -180,21 +215,20 @@ def _zero_tol(coeffs: npt.NDArray[np.float64], degree: int) -> float:
     return float(np.abs(coeffs).max()) * max((degree + 1) * 4.0 * _EPS, 1e-15)
 
 
-def _root_tol(
-    coeffs: npt.NDArray[np.float64],
-    knots: npt.NDArray[np.float64],
-    degree: int,
-) -> float:
-    """Return the residual threshold ``find_roots`` allows a *tracked* iterate.
+def _root_tol(spline: Bspline, coeffs: npt.NDArray[np.float64], degree: int) -> float:
+    """Return the residual threshold ``find_roots`` allows a *located* iterate.
 
     Larger than :func:`_zero_tol` by the value the spline reaches at the parametric
-    resolution the iteration stops at, ``|f'| * 2 * tol * scale``.
+    resolution the iteration stops at, ``|f'| * 2 * tol * scale``, with ``|f'|`` taken
+    from :func:`_sampled_slope` rather than from the implementation's own formula.
     """
+    knots = np.asarray(spline.space.spaces[0].knots, dtype=np.float64)
     num_coeffs = coeffs.shape[0]
     scale = max(abs(float(knots[degree])), abs(float(knots[num_coeffs])))
     scale = max(scale, float(knots[num_coeffs] - knots[degree]))
-    slope = _hodograph_slope_bound(coeffs, knots, degree)
-    return _zero_tol(coeffs, degree) + 2.0 * slope * _STRICT_TOL * scale
+    return _zero_tol(coeffs, degree) + 2.0 * _sampled_slope(spline, knots, degree) * (
+        _STRICT_TOL * scale
+    )
 
 
 # --- Analytic cases -------------------------------------------------------------------
@@ -426,13 +460,15 @@ def test_no_returned_value_escapes_the_residual_certificate() -> None:
     de Boor evaluation error, ``coeff_scale * (degree + 1) * 4 * eps``. The second is the
     value the spline reaches at the parametric resolution the iteration stops at: ``tol``
     is documented as a *relative parametric* tolerance on ``max(|x|, L)``, and a zero
-    located to ``dt`` leaves ``|f'| * dt``. ``|f'|`` is bounded from the hodograph of the
-    input rather than read back out of the solver, and the residual is evaluated through
-    the public :meth:`Bspline.evaluate`, so neither side of the comparison comes from the
-    kernel under test. The safety factor is the eight used elsewhere in this file.
+    located to ``dt`` leaves ``|f'| * dt``. Neither side of the comparison is computed the
+    way the solver computes it: the residual goes through the public
+    :meth:`Bspline.evaluate`, and ``|f'|`` through :func:`_sampled_slope`, which samples
+    :meth:`Bspline.evaluate_derivatives` rather than re-deriving the hodograph difference
+    quotient the threshold inside ``find_roots`` is built from. The safety factor is the
+    eight used elsewhere in this file.
 
     Against the defect it pins, the margin is not marginal: the worst value the old code
-    returned here leaves ``2.08e-2`` against a bound of ``1.99e-13``.
+    returned here leaves ``2.08e-2`` against a bound of ``1.99e-13``, a factor of 6.2e11.
     """
     worst = 0.0
     for degree in (1, 2, 3, 5, 8, 15):
@@ -454,7 +490,7 @@ def test_no_returned_value_escapes_the_residual_certificate() -> None:
                         continue
 
                     values = np.abs(np.asarray(spline.evaluate(roots), dtype=np.float64))
-                    slope = _hodograph_slope_bound(coeffs, knots, degree)
+                    slope = _sampled_slope(spline, knots, degree)
                     bound = _zero_tol(coeffs, degree) + slope * _STRICT_TOL * np.maximum(
                         np.abs(roots), span
                     )
@@ -788,7 +824,78 @@ def test_regression_merging_never_invents_a_root_between_two_real_ones() -> None
 
     residuals = np.abs(np.asarray(spline.evaluate(found), dtype=np.float64).reshape(-1))
     assert found.shape == (3,)
-    assert float(residuals.max()) <= _RESIDUAL_SAFETY * _root_tol(coeffs, knots, degree)
+    assert float(residuals.max()) <= _RESIDUAL_SAFETY * _root_tol(spline, coeffs, degree)
+
+
+def test_a_one_sided_zero_at_a_jump_is_reported_at_the_knot() -> None:
+    """A zero of the left piece at a C^-1 knot is a root, though evaluating gives the jump.
+
+    The counterpart of ``test_regression_a_jump_across_the_axis_is_not_a_root``: there the
+    spline crossed the axis without touching it and the knot is not a zero; here the left
+    piece *reaches* zero at the knot before the spline jumps to -2, so the knot is a zero
+    of that piece and is reported. The documented consequence, which this pins, is that
+    :meth:`Bspline.evaluate` at such a root returns the right limit, so its residual is the
+    whole jump. Both routes agree, which is what says the report is the convention and not
+    an accident of this method: the Bézier route sees a segment whose last Bernstein
+    coefficient is exactly zero.
+
+    The data is the worst residual over 960 random splines with interior multiplicities
+    drawn up to ``degree + 1``, and it behaves identically before and after the certificate
+    work.
+    """
+    degree = 5
+    knots = _open_knots(
+        degree,
+        np.array([0.0, 0.123541192295, 0.338252602594, 0.477533677605, 1.0]),
+        np.array([1, degree + 1, 3]),
+    )
+    coeffs = np.array(
+        [1.0, 0.5, -1.0, 1.5, -0.5, 2.0, 0.0, -2.0, -1.5, -1.5, -0.5, 0.5, -0.0, 1.0, -1.0, -3.0]
+    )
+    spline = _spline(knots, coeffs, degree)
+    jump_knot = 0.338252602594
+
+    # Preconditions: the knot is C^-1, the left piece reaches zero there, and the right
+    # piece does not.
+    assert int(np.sum(knots == jump_knot)) == degree + 1
+    sides = np.asarray(spline.evaluate(np.array([jump_knot - 1e-13, jump_knot]))).reshape(-1)
+    assert abs(float(sides[0])) < 1e-11
+    assert float(sides[1]) == pytest.approx(-2.0)
+
+    found = find_roots(spline)
+
+    assert float(np.abs(found - jump_knot).min()) <= _ROOT_ULPS * _EPS
+    expected = _bezier_reference_roots(spline, knots)
+    assert found.shape == expected.shape
+    np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+@pytest.mark.parametrize("degree", [20, 25])
+def test_regression_a_double_root_at_high_degree_is_one_root_not_two(degree: int) -> None:
+    """A caller counting the zeros of ``(x - 1/2) ** 2`` used to get two of them.
+
+    At degree 20 and above the two sign changes bracketing the double root were both
+    reported, at ``0.49999992`` and ``0.50000008`` for degree 20 and ``0.49999985`` and
+    ``0.50000015`` for degree 25, so the count was wrong where the positions were not:
+    the pair straddles the zero and each is inside the half-width the problem allows.
+
+    One of the two came from a tracking that had run out of insertions, and used to be
+    accepted without its residual ever being looked at. Certifying it removes it, which
+    leaves the other -- itself a genuine report -- alone. The count is what this pins,
+    since the positions were never the complaint.
+    """
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.5, 0.5))
+    spline = _spline(knots, coeffs, degree)
+
+    # The remaining sign change of the pair does not converge inside the budget either,
+    # and saying so is the honest report: the zero is found, its twin is not certified.
+    with pytest.warns(RuntimeWarning, match="may be missing a root"):
+        found = find_roots(spline)
+
+    assert found.shape == (1,)
+    half_width = math.sqrt(2.0 * _zero_tol(coeffs, degree) / 2.0)
+    assert abs(float(found[0]) - 0.5) <= _MULTIPLE_ROOT_SAFETY * half_width
 
 
 # --- Kernels --------------------------------------------------------------------------
@@ -931,10 +1038,16 @@ def test_kernel_reports_a_zero_whose_budget_ran_out() -> None:
     degree = 3
     knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
     coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
-    zero_tol = _zero_tol(coeffs, degree)
+    spline = _spline(knots, coeffs, degree)
 
     _, _, truncated, abandoned = _morken_reimers_roots(
-        knots, degree, coeffs, 1e-15, zero_tol, _root_tol(coeffs, knots, degree), 1
+        knots,
+        degree,
+        coeffs,
+        1e-15,
+        _zero_tol(coeffs, degree),
+        _root_tol(spline, coeffs, degree),
+        1,
     )
 
     assert truncated + abandoned > 0

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 import numpy.typing as npt
@@ -56,6 +57,17 @@ somewhere different on every build: the same double root lands at ``2.3e-8`` und
 and at ``3.1e-8`` under another, a 40 % spread with no bug behind it. Two absorbs that, and
 still fails on anything an order of magnitude out. Measured margins with it: 16 times at
 multiplicities two and three, 9.5 at four, 3.3 for a double root beside a simple one.
+"""
+
+_RESIDUAL_SAFETY: float = 8.0
+"""
+Safety factor on the residual a returned root may carry, over the derived two-term bound.
+
+Both terms are order-of-magnitude statements: the evaluation term counts convex-combination
+levels without their constants, and the location term uses a Lipschitz bound on ``|f'|`` in
+place of its value at the root. Eight covers what neither models, and is what the sweep's
+own root-quality invariant applies to the same two terms. It buys nothing against the defect
+this guards, which exceeds the bound by eleven orders of magnitude.
 """
 
 _PARITY_RTOL: float = 1e-10
@@ -400,6 +412,56 @@ def test_residual_at_every_root_is_within_the_evaluation_bound(origin: float, sp
     assert worst <= 1.0
 
 
+def test_no_returned_value_escapes_the_residual_certificate() -> None:
+    """The soundness property: a value is returned only if the spline vanishes there.
+
+    This is the invariant the method rests on, and the one that used to hold on a single
+    branch of the tracking while three others bypassed it. It is asserted here over the
+    families that broke it rather than over the random splines the bound test above uses:
+    coefficients alternating ``+1, -1``, which put one sign change in every interval and
+    are what the August 2026 sweep found the failure with; interior knots repeated up to
+    ``degree + 1``, where the spline is C^-1; and three parametric scales.
+
+    The bound has the two terms a returned root may legitimately carry. The first is the
+    de Boor evaluation error, ``coeff_scale * (degree + 1) * 4 * eps``. The second is the
+    value the spline reaches at the parametric resolution the iteration stops at: ``tol``
+    is documented as a *relative parametric* tolerance on ``max(|x|, L)``, and a zero
+    located to ``dt`` leaves ``|f'| * dt``. ``|f'|`` is bounded from the hodograph of the
+    input rather than read back out of the solver, and the residual is evaluated through
+    the public :meth:`Bspline.evaluate`, so neither side of the comparison comes from the
+    kernel under test. The safety factor is the eight used elsewhere in this file.
+
+    Against the defect it pins, the margin is not marginal: the worst value the old code
+    returned here leaves ``2.08e-2`` against a bound of ``1.99e-13``.
+    """
+    worst = 0.0
+    for degree in (1, 2, 3, 5, 8, 15):
+        for n_intervals in (2, 5):
+            for mult in {1, degree, degree + 1}:
+                for origin, span in ((0.0, 1.0), (0.0, 1.0e-6), (1.0e6, 1.0)):
+                    breaks = np.linspace(0.0, 1.0, n_intervals + 1)
+                    mults = np.full(max(breaks.size - 2, 0), mult, dtype=np.int_)
+                    knots = origin + span * _open_knots(degree, breaks, mults)
+                    coeffs = np.where(np.arange(len(knots) - degree - 1) % 2, -1.0, 1.0)
+                    spline = _spline(knots, coeffs, degree)
+
+                    # The budget warning is about a root's accuracy, not its soundness,
+                    # and this test is about soundness; it has its own test below.
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", RuntimeWarning)
+                        roots = find_roots(spline)
+                    if roots.size == 0:
+                        continue
+
+                    values = np.abs(np.asarray(spline.evaluate(roots), dtype=np.float64))
+                    slope = _hodograph_slope_bound(coeffs, knots, degree)
+                    bound = _zero_tol(coeffs, degree) + slope * _STRICT_TOL * np.maximum(
+                        np.abs(roots), span
+                    )
+                    worst = max(worst, float((values.reshape(-1) / bound).max()))
+    assert worst <= _RESIDUAL_SAFETY
+
+
 # --- Regression cases, with the data that triggered them -------------------------------
 
 _DIVISION_DEGREE = 7
@@ -690,6 +752,45 @@ def test_regression_a_jump_across_the_axis_is_not_a_root() -> None:
     np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
 
 
+def test_regression_merging_never_invents_a_root_between_two_real_ones() -> None:
+    """An over-wide merge radius used to collapse separated zeros onto a point between them.
+
+    Two zeros are the same zero seen twice only if everything between them is also a zero,
+    and the merge radius is a proxy for that. At high degree the proxy fails outright: the
+    cap ``domain_length * (degree! * zero_tol / coeff_scale) ** (1 / degree)`` *grows* with
+    degree -- 0.114 at 9, 0.767 at 15, and past the whole domain from 17 -- and a run is
+    joined on the *larger* of two radii, so one such radius joins every root after it.
+
+    On the spline below, a clamped degree-15 spline whose single interior knot is C^0 and
+    whose coefficients alternate, the kernel reports three zeros with residuals of 1e-17
+    and the merge used to return their midpoint 0.49279338 alone, where the spline is
+    -0.6448. Certifying the midpoint the way the reports themselves are certified is what
+    keeps them apart; the radius policy is untouched.
+    """
+    degree = 15
+    knots = _open_knots(degree, np.array([0.0, 0.5, 1.0]), np.full(1, degree, dtype=np.int_))
+    coeffs = np.where(np.arange(len(knots) - degree - 1) % 2, -1.0, 1.0)
+    spline = _spline(knots, coeffs, degree)
+
+    # Precondition: the cap really is wider than the gaps between the zeros it must not
+    # merge, so this pins the certificate and not a radius that happens to be small.
+    domain_length = float(knots[-1] - knots[0])
+    coeff_scale = float(np.abs(coeffs).max())
+    cap = domain_length * (math.factorial(degree) * _zero_tol(coeffs, degree) / coeff_scale) ** (
+        1.0 / degree
+    )
+    assert cap > 0.5 * domain_length
+
+    # Two of the five sign changes of this polygon do not converge inside the insertion
+    # budget, which is a separate matter from the merge and is what the warning is for.
+    with pytest.warns(RuntimeWarning, match="may be missing a root"):
+        found = find_roots(spline)
+
+    residuals = np.abs(np.asarray(spline.evaluate(found), dtype=np.float64).reshape(-1))
+    assert found.shape == (3,)
+    assert float(residuals.max()) <= _RESIDUAL_SAFETY * _root_tol(coeffs, knots, degree)
+
+
 # --- Kernels --------------------------------------------------------------------------
 
 
@@ -804,10 +905,11 @@ def test_is_zero_index_rejects_an_index_outside_the_polygon() -> None:
 
 def test_merge_roots_on_an_empty_input() -> None:
     """No roots in, no roots out, and a buffer that is still safe to index."""
-    merged, count = _merge_roots(np.empty(0), np.empty(0))
+    merged, labels, count = _merge_roots(np.empty(0), np.empty(0))
 
     assert count == 0
     assert merged.shape == (1,)
+    assert labels.shape == (0,)
 
 
 def test_merge_roots_collapses_a_run_but_not_a_gap() -> None:
@@ -815,10 +917,13 @@ def test_merge_roots_collapses_a_run_but_not_a_gap() -> None:
     roots = np.array([0.1, 0.1 + 1e-9, 0.5, 0.9])
     radii = np.array([1e-8, 1e-8, 1e-12, 1e-12])
 
-    merged, count = _merge_roots(roots, radii)
+    merged, labels, count = _merge_roots(roots, radii)
 
     assert count == 3
     np.testing.assert_allclose(merged[:count], [0.1 + 0.5e-9, 0.5, 0.9], rtol=0.0, atol=1e-15)
+    # Every input names the run it joined, so a caller can put a run back the way it
+    # found it when the midpoint turns out not to be a zero.
+    np.testing.assert_array_equal(labels, [0, 0, 1, 2])
 
 
 def test_kernel_reports_a_zero_whose_budget_ran_out() -> None:

--- a/tests/test_bspline_roots.py
+++ b/tests/test_bspline_roots.py
@@ -17,6 +17,8 @@ from pantr.bspline._bspline_roots_core import (
     _knot_average,
     _merge_roots,
     _morken_reimers_roots,
+    _residual_at,
+    _span_at,
     _split_at_root,
     _zero_index,
 )
@@ -143,9 +145,44 @@ def _bezier_reference_roots(
     return out
 
 
+def _hodograph_slope_bound(
+    coeffs: npt.NDArray[np.float64],
+    knots: npt.NDArray[np.float64],
+    degree: int,
+) -> float:
+    """Bound ``|f'|`` over the whole domain from the hodograph coefficients.
+
+    The derivative of a spline is the spline whose coefficients are
+    ``degree * (c[i] - c[i-1]) / (t[i+degree] - t[i])``, and a spline never leaves the
+    range of its own coefficients, so the largest such difference quotient bounds ``|f'|``
+    everywhere. A zero-length denominator is a C^-1 knot, where the spline jumps and no
+    finite slope describes it, and is skipped.
+    """
+    gaps = knots[degree + 1 : coeffs.shape[0] + degree] - knots[1 : coeffs.shape[0]]
+    quotients = np.abs(np.diff(coeffs))[gaps > 0.0] / gaps[gaps > 0.0]
+    return float(degree * quotients.max()) if quotients.size else 0.0
+
+
 def _zero_tol(coeffs: npt.NDArray[np.float64], degree: int) -> float:
     """Return the residual threshold ``find_roots`` derives for these coefficients."""
     return float(np.abs(coeffs).max()) * max((degree + 1) * 4.0 * _EPS, 1e-15)
+
+
+def _root_tol(
+    coeffs: npt.NDArray[np.float64],
+    knots: npt.NDArray[np.float64],
+    degree: int,
+) -> float:
+    """Return the residual threshold ``find_roots`` allows a *tracked* iterate.
+
+    Larger than :func:`_zero_tol` by the value the spline reaches at the parametric
+    resolution the iteration stops at, ``|f'| * 2 * tol * scale``.
+    """
+    num_coeffs = coeffs.shape[0]
+    scale = max(abs(float(knots[degree])), abs(float(knots[num_coeffs])))
+    scale = max(scale, float(knots[num_coeffs] - knots[degree]))
+    slope = _hodograph_slope_bound(coeffs, knots, degree)
+    return _zero_tol(coeffs, degree) + 2.0 * slope * _STRICT_TOL * scale
 
 
 # --- Analytic cases -------------------------------------------------------------------
@@ -295,6 +332,32 @@ def test_matches_the_bezier_route_on_random_splines(degree: int) -> None:
         assert found.shape == expected.shape
         if found.size:
             np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
+
+
+@pytest.mark.parametrize("degree", [1, 2, 3, 4, 5, 6, 7])
+def test_sign_alternating_splines_agree_with_the_bezier_route(degree: int) -> None:
+    """Coefficients alternating ``+1, -1`` give the same zero set as extraction.
+
+    The family the August 2026 sweep found the certificate defect with, and the one the
+    residual test has to be careful not to over-reject: one sign change per interval, so
+    every zero the polygon can bracket is present, and a slope steep enough that the
+    evaluation error alone is not what a correctly located zero leaves behind.
+
+    Two intervals are excluded. There the outer zeros are near-tangential and both routes
+    place them only to ``zero_tol ** (1 / m)``, which at degree 7 is ``1.8e-3``: a real
+    accuracy limit of the problem, asserted by ``test_a_multiple_root_is_reported_once``
+    on data built for it, and not what this test is about.
+    """
+    for n_intervals in (3, 4, 5, 8):
+        knots = _open_knots(degree, np.linspace(0.0, 1.0, n_intervals + 1))
+        coeffs = np.where(np.arange(len(knots) - degree - 1) % 2, -1.0, 1.0)
+        spline = _spline(knots, coeffs, degree)
+
+        found = find_roots(spline)
+        expected = _bezier_reference_roots(spline, knots)
+
+        assert found.shape == expected.shape, f"{n_intervals} intervals"
+        np.testing.assert_allclose(found, expected, rtol=0.0, atol=_PARITY_RTOL)
 
 
 @pytest.mark.parametrize(
@@ -640,6 +703,36 @@ def test_knot_average_is_the_greville_abscissa() -> None:
         assert _knot_average(knots, degree, index) == pytest.approx(expected, abs=_EPS)
 
 
+def test_span_at_stays_inside_the_last_span_of_the_domain() -> None:
+    """The span search brackets every point, and treats the end of the domain from the left."""
+    degree = 2
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+    num_coeffs = len(knots) - degree - 1
+
+    for point, expected in ((0.0, 2), (0.1, 2), (0.25, 3), (0.6, 4), (0.99, 5)):
+        assert _span_at(knots, num_coeffs, degree, point) == expected
+        assert knots[expected] <= point < knots[expected + 1]
+
+    # The one point no bracket contains: an open knot vector's last span is half open, so
+    # the search stops at it rather than walking into the clamped tail.
+    assert _span_at(knots, num_coeffs, degree, 1.0) == num_coeffs - 1
+
+
+def test_residual_at_evaluates_the_spline_it_is_given() -> None:
+    """``_residual_at`` is ``|f|``, and agrees with the public evaluator that certifies it."""
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 5))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+    num_coeffs = coeffs.shape[0]
+    work = np.empty(degree + 1, dtype=np.float64)
+    points = np.array([0.0, 0.2, 0.37, 0.5, 0.75, 0.9, 1.0])
+
+    expected = np.abs(np.asarray(_spline(knots, coeffs, degree).evaluate(points)).reshape(-1))
+    got = [_residual_at(knots, coeffs, num_coeffs, degree, float(p), work) for p in points]
+
+    np.testing.assert_allclose(got, expected, rtol=0.0, atol=(degree + 1) * _EPS)
+
+
 def test_zero_index_needs_a_non_zero_left_neighbour() -> None:
     """A pinned coefficient is a barrier: no sign change is reported across it."""
     coeffs = np.array([0.0, -1.0, 1.0, 1.0, -1.0])
@@ -733,23 +826,54 @@ def test_kernel_reports_a_zero_whose_budget_ran_out() -> None:
     degree = 3
     knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
     coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+    zero_tol = _zero_tol(coeffs, degree)
 
-    _, _, truncated = _morken_reimers_roots(
-        knots, degree, coeffs, 1e-15, _zero_tol(coeffs, degree), 1
+    _, _, truncated, abandoned = _morken_reimers_roots(
+        knots, degree, coeffs, 1e-15, zero_tol, _root_tol(coeffs, knots, degree), 1
     )
 
-    assert truncated > 0
+    assert truncated + abandoned > 0
 
 
 def test_budget_exhaustion_warns(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Layer 2 turns an exhausted budget into a warning naming how many zeros it hit."""
+    """A zero reported at an unconverged iterate says so: it may be less accurate than tol.
+
+    A budget of eight is enough for the residual to certify all three zeros of this
+    spline but not for the iterates of the first to stagnate, which is the case the
+    warning is for. It has to be measured rather than reasoned: the budget at which the
+    two stop coinciding is a property of this spline.
+    """
+    degree = 3
+    knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
+    coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
+    monkeypatch.setattr(_bspline_roots, "_max_insertions", lambda _degree: 8)
+
+    with pytest.warns(RuntimeWarning, match="reported at the last iterate reached"):
+        found = find_roots(_spline(knots, coeffs, degree))
+
+    assert found.shape == (3,)
+
+
+def test_a_sign_change_the_budget_never_certified_is_not_silently_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rejecting an uncertified iterate loses a zero, and losing one silently is not allowed.
+
+    Uniform residual testing is what keeps a non-root out of the result, and the price is
+    that a sign change whose tracking never converges is dropped rather than reported at
+    whatever it reached. That is the sound direction, but it is a *missing* root, so it is
+    the one rejection the caller is told about. A budget of one exhausts before any of the
+    three zeros below is located at all.
+    """
     degree = 3
     knots = _open_knots(degree, np.linspace(0.0, 1.0, 6))
     coeffs = _polynomial_coefficients(knots, degree, (0.2, 0.5, 0.9))
     monkeypatch.setattr(_bspline_roots, "_max_insertions", lambda _degree: 1)
 
-    with pytest.warns(RuntimeWarning, match="insertion budget"):
-        find_roots(_spline(knots, coeffs, degree))
+    with pytest.warns(RuntimeWarning, match="may be missing a root"):
+        found = find_roots(_spline(knots, coeffs, degree))
+
+    assert found.shape == (0,)
 
 
 def test_insertion_budget_grows_with_degree() -> None:

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,23 +7,24 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Six markers have already come off here: the domain-membership test, closed by the
+Seven markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
 truncating the rule where the endpoint gap stops being resolvable; the Lagrange
 reproducibility test, closed by seeding the barycentric node permutation; the float32
 degree-elevation test, closed by allocating the kernels' knot output in the input's dtype;
 the periodic degree-reduction hang, closed by enforcing the periodic conversion's own
-boundary-multiplicity precondition; and the degree-elevation counter mismatch, closed by
+boundary-multiplicity precondition; the degree-elevation counter mismatch, closed by
 emitting the unshared Bézier coefficient at a C^-1 knot and by letting the segment sweep
-reach the final span of a degree-0 knot vector.
+reach the final span of a degree-0 knot vector; and the root finder that certified a value
+that is not a root, closed by evaluating the residual on every exit of the tracking and by
+holding the repeated-iterate stop to Corollary 14's actual hypothesis.
 
-Eight remain open. Three are the tolerance workstream's. The other five come from the
+Seven remain open. Three are the tolerance workstream's. The other four come from the
 August 2026 triage of the full profile's 496 findings, which collapsed them into a dozen
-mechanisms: a root finder that certifies a value that is not a root, a restriction that
-silently returns a shorter domain than it was asked for, a Lagrange extraction that cannot
-be built on a degree-0 space its two sibling extractions handle, a change of basis that
-reports numpy's `LinAlgError` for a legal degree, and a unique-knot accessor that returns
-knots the space does not contain.
+mechanisms: a restriction that silently returns a shorter domain than it was asked for, a
+Lagrange extraction that cannot be built on a degree-0 space its two sibling extractions
+handle, a change of basis that reports numpy's `LinAlgError` for a legal degree, and a
+unique-knot accessor that returns knots the space does not contain.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -617,47 +618,54 @@ def test_reduce_degree_terminates_on_a_periodic_linear_spline() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="find_roots accepts a _STATUS_CONVERGED iterate without ever checking its "
-    "residual, so a coincidentally-near-zero intermediate coefficient is certified as a "
-    "root",
-)
 def test_find_roots_returns_only_genuine_roots() -> None:
-    # The most serious finding of the August 2026 triage: `find_roots` returns a
-    # parameter at which the spline is not zero, silently, through the public API, on a
-    # perfectly ordinary clamped cubic on the unit domain. Nothing warns.
+    # FIXED, and kept as a regression guard with its original triggering data per this
+    # repository's convention that the fix PR un-xfails the tests it closes. It took two
+    # changes, and the second is what keeps the first from being a cure worse than the
+    # disease.
+    #
+    # What it was, the most serious finding of the August 2026 triage: `find_roots`
+    # returned a parameter at which the spline is not zero, silently, through the public
+    # API, on a perfectly ordinary clamped cubic on the unit domain. Nothing warned.
     #
     # The data below is a degree-3 clamped uniform spline on [0, 1] with four intervals
     # and control points alternating +1/-1. It has exactly six sign changes. `find_roots`
-    # returns six values; four of them are roots to 1e-16, and two -- 0.375 and 0.625 --
-    # are not roots at all. The true zeros nearest them are at 0.369 and 0.630995, so the
-    # returned values are off by about 0.006 in the parameter and leave a residual of
+    # returned six values; four of them were roots to 1e-16, and two -- 0.375 and 0.625 --
+    # were not roots at all. The true zeros nearest them are at 0.369 and 0.630995, so the
+    # returned values were off by about 0.006 in the parameter and left a residual of
     # 0.0208 on a curve whose values are bounded by 1.
     #
     # The mechanism, traced through a line-for-line pure-Python mirror of
-    # `_bspline_roots_core.py` that reproduces the same wrong roots bit for bit:
-    # `_track_zero` treats a repeated iterate (`x == previous_x`) as a certificate of
+    # `_bspline_roots_core.py` that reproduced the same wrong roots bit for bit:
+    # `_track_zero` treated a repeated iterate (`x == previous_x`) as a certificate of
     # convergence, per Morken-Reimers Lemma 13/Corollary 14, and `_morken_reimers_roots`
-    # then gates acceptance on
+    # then gated acceptance on
     #
     #     accepted = residual <= zero_tol if status == _STATUS_CANDIDATE else True
     #
-    # so for `_STATUS_CONVERGED` the residual is hard-coded to 0.0 and never compared
+    # so for `_STATUS_CONVERGED` the residual was hard-coded to 0.0 and never compared
     # against the actual function value. Here the first secant estimate lands on 0.375, a
     # single Boehm insertion there produces a control coefficient that is exactly 0.0 for
     # an algebraic reason (the symmetric alternating coefficients on exact rational
     # Greville abscissae), the next iterate is therefore 0.375 again, and the fixed-point
-    # test fires after one step -- far from convergence. That is a theorem valid in exact
+    # test fired after one step -- far from convergence. That is a theorem valid in exact
     # arithmetic applied to a floating-point iteration where a coefficient can reach zero
     # for reasons unrelated to being near a root.
+    #
+    # The fix makes every exit of `_track_zero` hand back `|f(x)|` and gates acceptance on
+    # that residual uniformly, so a status records how the iteration stopped and never
+    # whether the value may be reported. On its own that only makes the answer sound: it
+    # drops 0.375 and 0.625 and reports four roots where there are six. The second change
+    # restores the two: the repeated-iterate stop now tests Corollary 14's actual
+    # hypothesis, `degree - 1` active knots collapsed onto the iterate, rather than the
+    # bare repetition that a nearly horizontal control-polygon secant also produces.
     #
     # Distinct from the fabricated root closed in #291, which guarded the
     # `x >= knots[index + degree]` branch at a C^-1 knot of multiplicity degree + 1. This
     # knot vector has only simple interior knots and never reaches that branch.
     #
-    # It is not a tolerance artifact and does not scale away: the same construction on
-    # [0, 5] returns 3.125 with the same residual 0.0208 against a true zero at
+    # It was not a tolerance artifact and did not scale away: the same construction on
+    # [0, 5] returned 3.125 with the same residual 0.0208 against a true zero at
     # 3.154997195131751.
     degree = 3
     knots = np.array([0.0, 0.0, 0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0])
@@ -684,6 +692,23 @@ def test_find_roots_returns_only_genuine_roots() -> None:
         f"find_roots returned {roots.tolist()}; |f| there is {residuals.tolist()}, "
         f"and the largest exceeds the derived bound {bound:.3e}"
     )
+
+    # Guard the other side too, which the original xfail did not: an xfail is satisfied by
+    # *any* failure, so returning four roots instead of six would have satisfied it while
+    # losing two genuine zeros. The six below were obtained independently of this method,
+    # by a two-million-point sign scan of the spline followed by bisection to convergence;
+    # `1e-15` is the parametric tolerance `find_roots` documents, and the domain length is
+    # 1, so a root is placed to that much and the comparison needs no safety factor beyond
+    # the eight this suite uses elsewhere.
+    expected = [
+        0.06279438346444505,
+        0.200641357614461,
+        0.36900056097364975,
+        0.6309994390263503,
+        0.799358642385539,
+        0.9372056165355549,
+    ]
+    np.testing.assert_allclose(roots, expected, rtol=0.0, atol=8.0 * 1e-15)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`find_roots` returned values that are not roots, silently, on the most ordinary input a spline
root finder can be given — an unremarkable clamped cubic on the unit domain:

```python
knots = [0,0,0,0, .25,.5,.75, 1,1,1,1];  control points [1,-1,1,-1,1,-1,1]
# returned  0.375       and 0.625        with |f| = 2.08e-2
# true      0.36900056  and 0.63099944
```

The residual certificate existed on **one** of four exit paths; the other three hard-coded
`residual = 0.0` and were accepted unconditionally — and those are the paths that fire when the
iteration is in trouble. The verdict was therefore not monotone in distance from zero: which exit
fired decided it, not any tolerance.

Now every exit evaluates `|f(x)|` on its refined window and the gate is uniform. The two wrong
values above become the two true zeros, at 1.7e-17 and 6.9e-18.

## The status tiers say how, not whether

`_STATUS_CANDIDATE` / `_STATUS_CONVERGED` are now `_STATUS_VANISHED` / `_STATUS_STAGNATED`: a tier
records **how** a value was obtained, and whether it is returned follows from the residual,
uniformly.

The repeated-iterate stop tested `x == previous_x`, which is **degree-blind**, where Mørken &
Reimers' Corollary 14 requires `degree − 1` collapsed active knots — it fired with 1 of 2 needed at
degree 3 and 1 of 4 at degree 5, so it was detecting precision exhaustion rather than the
corollary's hypothesis. It now tests that hypothesis structurally. Theorem 22's hypotheses are also
corrected in the docstring: it needs `f''(z) ≠ 0` as well as `f'(z) ≠ 0`.

## A second tolerance term, which is not optional

Applying the residual test uniformly with `zero_tol` alone **drops genuine roots**: `zero_tol`
bounds *evaluation* error, but the iteration stops at a *parametric* resolution, so a correctly
located zero of a steep spline still carries `|f'|·2·tol·scale`. Measured before it was added: 3 of
12 roots lost on one random degree-1 spline, and the Bézier-parity test red at every degree 1 to 7.

The threshold is now `root_tol = zero_tol + 2·slope_bound·tol·scale`, with the slope bound derived
in Layer 2 from the hodograph. Scale covariance checked over six decades of coordinate scale and
eight of value scale: identical root counts, drift under one ulp.

## Dropped, not flagged — and the warning channel split in two

No API change. The docstring already promised a value is reported *only* when its residual passes,
and the one branch that had the test already dropped; this enforces the stated contract rather than
altering it. What the caller needs to know is served by splitting the warning:

- **truncated** — reported, but possibly less accurate than the requested tolerance.
- **abandoned** — **not** reported, so the result may be missing a root.

A dropped root is precisely the outcome a caller must not learn about silently. On a degree-15
example the old code warned "reported at the last iterate reached" and handed back two uncertified
values; it now says the residual never fell far enough, withholds them, and says a root may be
missing.

## The merge midpoint was returning a non-root

The merge-radius cap grows with degree — `0.767·L` at degree 15, past the whole domain by degree 17
— and runs join on the **larger** of two radii, so one oversized radius chains a whole run. On a
degree-15 clamped spline with a C⁰ interior knot, three zeros at 1e-17 were merged into a midpoint
at `0.49279338` where the spline is **−0.6448**. That midpoint is now residual-tested, falling back
to the un-merged roots when it fails.

**The radius policy itself is untouched and still wrong at high degree.** Switching the join from
`max` to `min` fixes this case at the criterion level, but that is a policy change and it is not
made here.

Fixed as a side effect: a genuine double root at degrees 20 and 25 was returned as two simple roots,
one of each pair an uncertified budget-limited iterate.

## The 42 unread warnings

All 42 `warned-while-returning` cases in root finding turned out to be the same insertion-budget
warning — no second mechanism. Afterwards there are 68: the same 42, plus 26 that **used to be
silent wrong answers** and now carry the "may be missing a root" warning. Reading them cleared a
suspicion rather than finding a bug, which is worth recording.

## Verification

Sweep, full profile, baseline re-run from a pristine export of the base commit: `find_roots`
**48 findings → 0**, and the whole-sweep total 435 → 387, i.e. exactly those 48 with nothing else
moved. The new tests were checked to fail against the baseline export rather than assumed to: by
6.2e11 on soundness, by count on the merge, by position on Bézier parity. 960 random splines,
degrees 1-15, multiplicities to `degree + 1`: no NaN, no non-termination.

`ruff`, `ruff format`, `mypy`, `import-lint` and the docs build under `-W` all clean.
**5261 passed, 21 skipped, 7 xfailed** against a baseline of 5245 / 21 / 8.

The downstream consumer has its own Bernstein root finder and imports none of the symbols touched.

## Left open, deliberately

The slope bound is **global** where its derivation is local, so one steep region loosens the
threshold everywhere. The obvious local version does not work — computing the same hodograph bound
on the working window returns a value larger than the spline's own range once the local knot gaps
degenerate, and that attempt is how the merge defect above was found. A correct local version must
index the original knot vector by parametric position. Tolerance-workstream shaped, and no live
false positive could be constructed for it across 948 random splines and 376 sweep cases.

Also pre-existing and unchanged: a zero of the *left* piece at a C⁻¹ knot is reported at the knot
while `evaluate` returns the right limit, so its residual is the whole jump. The Bézier route agrees,
so it is a convention rather than a fault — now documented and pinned, and it means the soundness
property holds modulo that convention. Whether `find_roots` should report one-sided zeros at all is
worth a ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
