### PR TITLE
refactor(tolerance): make a tolerance mean one thing, and scale with what it grades

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -71,8 +71,8 @@
   doubled for one extra rounding upstream, scaled by the parametric magnitude every
   comparison in the B-spline layer is relative to. Previously it was the bare
   per-dtype constant, so the same absolute band meant four ulp on a unit domain,
-  nothing at all from `|knot| ≈ 5` upward, and the whole domain on `[0, 1e-6]` in
-  float32. Everything downstream that takes `space.tolerance` — domain membership,
+  nothing at all from `|knot| ≈ 5` upward, and half the breakpoints of a
+  twenty-interval float32 mesh on `[0, 1e-6]`, which then reported ten. Everything downstream that takes `space.tolerance` — domain membership,
   knot matching, cardinal interval lengths, knot insertion and removal, products,
   degree changes — becomes scale-covariant with it. `detect_interfaces` is the one
   caller that wanted the dimensionless factor instead and now takes it from

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,22 @@
   matrix rather than by sampling.
 
 ### Changed
+- **`pantr.tolerance`'s presets are now dimensionless relative tolerances.**
+  `get_strict`, `get_default` and `get_conservative` return `K * eps(dtype)` with
+  `K` equal to 4, 64 and 4096 — an acknowledged safety factor, stated, a power of
+  two, and the *same* in every precision. The previous table was a fixed value per
+  dtype, and in units of that dtype's own epsilon it was neither constant nor
+  ordered the same way: strict was 0.10 eps in float16, 0.84 in float32 and 4.5 in
+  float64, so `get_strict` demanded bitwise equality in the two smaller formats
+  while allowing four roundings in the largest. The module docstring called the
+  presets absolute while `Bspline.locate` and both root finders were already
+  multiplying them by a magnitude; that ambiguity is what this change removes. A
+  preset is now unusable on its own — multiply it by the magnitude of the quantity
+  being compared, and name that magnitude at the call site. Numerically:
+  `get_default(float64)` moves from 1e-12 to 1.42e-14 and `get_conservative`
+  from 1e-10 to 9.09e-13, while `get_strict(float32)` moves from 1e-7 to 4.77e-7.
+  The per-dtype table and its platform branch on whether `longdouble` aliases
+  `float64` are gone: reading the epsilon from the platform makes both unnecessary.
 - `pantr.grid.overlay` merges breakpoints closer than the default *relative*
   tolerance times the axis's own magnitude -- the intersection window and the
   coordinates bounding it -- instead of against a bare `float64` constant. A

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -66,6 +66,18 @@
   from 1e-10 to 9.09e-13, while `get_strict(float32)` moves from 1e-7 to 4.77e-7.
   The per-dtype table and its platform branch on whether `longdouble` aliases
   `float64` are gone: reading the epsilon from the platform makes both unnecessary.
+- **`BsplineSpace1D.tolerance` now carries the knot vector's own magnitude.** It is
+  `8 * eps(dtype) * max(span, |knots[0]|, |knots[-1]|)` — the strict preset,
+  doubled for one extra rounding upstream, scaled by the parametric magnitude every
+  comparison in the B-spline layer is relative to. Previously it was the bare
+  per-dtype constant, so the same absolute band meant four ulp on a unit domain,
+  nothing at all from `|knot| ≈ 5` upward, and the whole domain on `[0, 1e-6]` in
+  float32. Everything downstream that takes `space.tolerance` — domain membership,
+  knot matching, cardinal interval lengths, knot insertion and removal, products,
+  degree changes — becomes scale-covariant with it. `detect_interfaces` is the one
+  caller that wanted the dimensionless factor instead and now takes it from
+  `pantr.tolerance` directly, since none of the three quantities it compares is a
+  parametric coordinate of a single patch.
 - `pantr.grid.overlay` merges breakpoints closer than the default *relative*
   tolerance times the axis's own magnitude -- the intersection window and the
   coordinates bounding it -- instead of against a bare `float64` constant. A
@@ -104,6 +116,32 @@
   endpoint condition and still returns the mean of the control points.
 
 ### Fixed
+- Knot snapping merged the wrong knots, and from `|knot| ≈ 5` upward merged none
+  at all. `BsplineSpace1D._snap_knots` rounded onto a grid of width `tolerance`,
+  which was an absolute per-dtype constant: at knot 1.0 the grid was 4.5 ulp wide
+  and it narrowed relative to the knots as they grew, so two knots one ulp apart
+  stopped merging at base 5 and the detected multiplicity dropped — a cubic asked
+  for multiplicity 2 (C¹) silently became C². A rounding *grid* is also wrong in
+  principle: two values one ulp apart can straddle a grid line and never merge,
+  for any spacing. Knots are now grouped by relative gap — a class ends where the
+  step to the next knot exceeds `8 * eps * max(span, |knots[0]|, |knots[-1]|)`,
+  three roundings of an affine map of the span with 2.7x over it — and every
+  member of a class takes the class's *first* knot. Choosing rather than averaging
+  makes snapping idempotent and keeps the stored values ones the caller supplied;
+  `np.mean` over `degree + 1` identical copies is not even the identity at large
+  magnitude, and it was moving the reported domain (`1000001.0` came back as
+  `1000000.875` in float32).
+- `get_unique_knots_and_multiplicity` reported knots the space does not contain.
+  The helper behind it rounded the knots onto the tolerance grid to decide which
+  were the same and then returned the *rounded* values, although the indices it
+  had built already pointed at the originals. On a float32 space over `[0, 1e-6]`
+  with interior knots at 2.5e-7, 5.0e-7 and 7.5e-7 it answered 2.0e-7, 5.0e-7 and
+  8.0e-7. `Bspline.multiply` builds the product's breakpoint mesh from this
+  accessor, so squaring such a spline returned a curve wrong by 8% relative at
+  points nowhere near a knot; `to_beziers`, knot insertion and removal and
+  quasi-interpolation all read the same helper. The accessor now returns stored
+  knots, and `_snap_knots` is implemented on top of it, so the space and its own
+  accessor can no longer disagree about which knots are the same knot.
 - `pantr.bspline.find_roots` returned values that are not roots, silently, on
   ordinary input: a clamped cubic on `[0, 1]` with control points alternating
   `+1, -1` gave back `0.375` and `0.625`, where the spline is `0.0208` rather
@@ -188,8 +226,14 @@
   absolute tolerance, which is scale-dependent: on a small enough domain a
   genuinely non-empty knot span fell below it and was zeroed, breaking the
   partition of unity. The guard now tests against exact zero, which is
-  scale-invariant by construction because knot vectors already snap
-  near-duplicate knots to one bitwise value.
+  scale-invariant by construction. What makes the exact test safe is the shape of
+  the recurrence, not the knot vector: the denominator is the sum of the two
+  non-negative terms the step then multiplies the quotient by, so the two weights
+  are a convex combination and a tiny denominator cancels against an equally tiny
+  numerator. (An earlier version of this entry justified it by claiming that knot
+  snapping stores equal knots bitwise identical. Snapping does that, but the guard
+  never needed it: with snapping off and two interior knots separated by 0 to
+  64 ulp, `max|N|` is 1.0 exactly and the partition of unity holds to 6.7e-16.)
 - `find_roots` reported a root at every interior knot of multiplicity
   `degree + 1` whose two straddling coefficients change sign, where the spline
   is C^-1 and jumps across the axis without ever reaching it. The tracking cited

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,12 @@
   matrix rather than by sampling.
 
 ### Changed
+- `pantr.grid.overlay` merges breakpoints closer than the default *relative*
+  tolerance times the axis's own magnitude -- the intersection window and the
+  coordinates bounding it -- instead of against a bare `float64` constant. A
+  window of length 1 sitting at 1e6 resolves its breakpoints no better than
+  `eps * 1e6` however short it is, and the merge verdict is now the same on
+  `[0, 1]` as on any rescaling of it.
 - The minimum supported SciPy is now 1.15, raised from 1.11. Lagrange tabulation
   seeds the node permutation SciPy's `BarycentricInterpolator` applies, and the
   `rng` argument that makes that possible arrived in 1.15. Earlier versions

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,24 @@
   `Bezier.reduce_degree` would introduce, computed through the Bernstein mass
   matrix rather than by sampling.
 
+### Rejected where it used to be accepted
+- **A knot vector whose spacing is finer than its dtype resolves at its own coordinate
+  magnitude is now refused at construction**, where it used to be accepted and then
+  silently behave as if it had no intervals. `BsplineSpace1D` raises a `ValueError`
+  naming the dtype, the coordinate magnitude, the merge tolerance in ulp and the closest
+  pair of knots you supplied, and suggesting float64, a domain nearer the origin, or a
+  coarser mesh. Concretely: float32 on `[1e6, 1e6 + 1]` with more than one interval. The
+  ulp there is 0.0625, so a four-interval mesh spaces breakpoints 0.25 apart while
+  telling two knots apart at that magnitude needs 0.48 — an interior knot computed by any
+  route is uncertain by 6% of the window, and no tolerance both keeps the mesh and merges
+  two routes to the same knot. The previous release kept the mesh only by never merging
+  anything (its tolerance there was 1.6e-6 ulp), so the knots it stored were noise.
+  Reachable in float64 too, but only from `|offset| / span ≈ 1.4e14` at four intervals,
+  where the window is 8 ulp wide. Two things are deliberately *not* refused: a knot vector
+  that was already a single repeated value, which is what the caller asked for and comes
+  back untouched, and anything built with `snap_knots=False`, which bypasses the merging
+  and the check together.
+
 ### Changed
 - **`pantr.tolerance`'s presets are now dimensionless relative tolerances.**
   `get_strict`, `get_default` and `get_conservative` return `K * eps(dtype)` with

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -197,16 +197,25 @@ def _basis_funcs_point(
         denominator is a sum of two knot differences and is always ``>= 0`` for a
         non-decreasing knot vector; it is treated as zero (and the corresponding
         term dropped) exactly when ``denom == 0`` (Piegl & Tiller A2.2's textbook
-        guard). Because IEEE-754 subtraction is antisymmetric, ``denom`` is exactly
-        ``0.0`` whenever the two knots it comes from are stored bitwise identical.
-        This holds for knots meant to be equal when the space was constructed with
-        the default ``snap_knots=True``, which snaps near-duplicate knots (within
-        tolerance) to a single bitwise value (see ``BsplineSpace1D._snap_knots``);
-        callers that build a knot vector with ``snap_knots=False`` (or bypass
-        :class:`~pantr.bspline.BsplineSpace1D` and call this kernel directly) are
-        responsible for the knot vector's own consistency. No tolerance parameter
-        is needed here regardless: the exact-zero test is scale-invariant by
-        construction, so this guard is unaffected by the knot vector's parametric
+        guard). No tolerance is needed, and -- contrary to what this note used to
+        claim -- the guard does **not** rest on knots meant to be equal being
+        stored bitwise identical.
+
+        What makes it sound is the shape of the step. ``denom`` is
+        ``right[r + 1] + left[j - r]``, the sum of the two non-negative terms the
+        step then multiplies ``temp = N[r] / denom`` by, so the two contributions
+        carry weights ``right[r + 1] / denom`` and ``left[j - r] / denom``, which
+        are non-negative and add to one up to a single rounding. A denominator
+        small enough to make ``temp`` large is multiplied straight back by factors
+        no larger than itself, so each contribution stays bounded by ``N[r]``.
+        Near-duplicate knots cost accuracy in that ratio, not boundedness.
+        Measured with ``snap_knots=False`` and two interior knots separated by 0 to
+        64 ulp, at degrees 1 to 5 and knot bases 1.0 and 1e6: ``max|N|`` is 1.0
+        exactly and the partition of unity holds to 6.7e-16.
+
+        ``denom == 0`` is reached only when both terms are exactly zero, which is
+        what an empty knot span is, and the test is scale-invariant by
+        construction, so the guard is unaffected by the knot vector's parametric
         span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_1D_impl` instead.
     """
@@ -375,17 +384,15 @@ def _basis_derivs_point(  # noqa: PLR0913
         denominator ``ndu[j, r]`` is a sum of two knot differences and is always
         ``>= 0`` for a non-decreasing knot vector; it is treated as zero (and the
         corresponding term dropped) exactly when ``denom == 0`` (Piegl & Tiller
-        A2.3's textbook guard). Because IEEE-754 subtraction is antisymmetric,
-        ``denom`` is exactly ``0.0`` whenever the two knots it comes from are
-        stored bitwise identical. This holds for knots meant to be equal when the
-        space was constructed with the default ``snap_knots=True``, which snaps
-        near-duplicate knots (within tolerance) to a single bitwise value (see
-        ``BsplineSpace1D._snap_knots``); callers that build a knot vector with
-        ``snap_knots=False`` (or bypass :class:`~pantr.bspline.BsplineSpace1D` and
-        call this kernel directly) are responsible for the knot vector's own
-        consistency. No tolerance parameter is needed here regardless: the
-        exact-zero test is scale-invariant by construction, so this guard is
-        unaffected by the knot vector's parametric span (shift or scale).
+        A2.3's textbook guard). No tolerance is needed, and the guard does **not**
+        rest on knots meant to be equal being stored bitwise identical: as in
+        :func:`_basis_funcs_point`, each ``ndu[j, r]`` divides a quantity that is
+        then multiplied by two non-negative terms summing to that same denominator,
+        so a small denominator cancels against an equally small numerator and the
+        term stays bounded. ``denom == 0`` is reached only when both terms are
+        exactly zero, which is what an empty knot span is, and the exact-zero test
+        is scale-invariant by construction, so this guard is unaffected by the knot
+        vector's parametric span (shift or scale).
         For general use, call :func:`_tabulate_Bspline_basis_deriv_1D_impl` instead.
     """
     order = degree + 1

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -25,14 +25,30 @@ from ..tolerance import get_strict
 _KNOT_MERGE_SAFETY: Final[float] = 2.0
 """Extra factor on the strict tier for deciding that two knots are the same knot.
 
-Two knots a caller means to be equal but obtains by different routes -- a uniform
-``a + i * h`` against a barycentric ``(a * (n - i) + b * i) / n``, a refinement, a
-reparametrization, a Bezier split -- are each an affine map ``a + t * (b - a)`` of
-the knot span evaluated in at most three operations, so they differ by at most
-``3 * eps * scale`` with ``scale`` the magnitude :func:`_knot_scale` returns.
-:func:`~pantr.tolerance.get_strict` covers four roundings; doubling it to eight
-leaves about 2.7x over that bound for an FMA contraction, a different vector
-width, and one extra rounding upstream.
+The quantity to cover is how far apart two knots a caller *means* to be equal can
+land when they are obtained by different routes -- a uniform ``a + i * (b - a) / n``
+against a barycentric ``(a * (n - i) + b * i) / n``, a refinement, a
+reparametrization, a Bezier split. Write ``u = eps / 2`` for the unit roundoff and
+``scale`` for what :func:`_knot_scale` returns.
+
+Each route is four floating-point operations and neither amplifies. The uniform
+one: ``b - a`` carries an absolute error at most ``u * |b - a| <= u * scale``; the
+division and the multiplication each add ``u`` relative on a quantity bounded by
+``scale``; the final sum adds ``u * scale``. Four terms of ``u * scale``, so the
+computed knot is within ``4u * scale = 2 * eps * scale`` of the exact one. The
+barycentric one is the same count and comes out slightly smaller, because the two
+products are divided by ``n`` after being added. By the triangle inequality two
+routes differ by at most ``4 * eps * scale``.
+
+Eight is that bound doubled, and the doubling buys the things the count does not
+see: an FMA contraction (which removes a rounding but changes the value), a
+different vector width, and one further rounding upstream of the two routes.
+:func:`~pantr.tolerance.get_strict` is four epsilons, so the factor here is two.
+
+The bound is not tight, which is the intent. Measured over 200000 random
+``(a, b, n, i)`` with ``|a|`` and the span drawn across 1e-3 to 1e7, the largest
+observed ``|route_A - route_B| / (eps * scale)`` is 1.74, against the derived 4 and
+the applied 8.
 """
 
 

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -97,6 +97,64 @@ def _knot_tolerance(knots: npt.NDArray[np.float32 | np.float64]) -> float:
     return _KNOT_MERGE_SAFETY * get_strict(knots.dtype) * _knot_scale(knots)
 
 
+def _check_snapping_kept_an_interval(
+    raw: npt.NDArray[np.float32 | np.float64],
+    snapped: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+) -> None:
+    """Reject a knot vector that snapping collapsed onto a single point.
+
+    A caller who passes a genuinely degenerate vector -- every knot already the same
+    value -- gets it back untouched and no error, because that is what was asked for.
+    What is refused is the case the caller cannot see coming: the knots *were*
+    distinct, and the merge rule found none of them distinguishable at their own
+    magnitude, so the space would carry no interval and every operation on it would
+    fail on an empty domain with a message about something else.
+
+    This is reachable, and the arithmetic that makes it so is not a defect. Two knots
+    obtained by different routes differ by up to ``4 * eps * scale``, so telling them
+    apart needs a tolerance at least that wide; a mesh of ``n`` intervals over a span
+    ``s`` at offset ``x`` survives only while ``s / n > 8 * eps * max(s, |x|)``. When
+    ``|x|`` dominates, that fails once ``|x| / s`` reaches ``1 / (8 * eps * n)`` --
+    about ``5.2e5 / n`` in float32 and ``5.6e14 / n`` in float64. Past it no threshold
+    satisfies both requirements at once, because an interior knot is then uncertain by
+    a sizeable fraction of the span. Saying so is the only honest answer.
+
+    Args:
+        raw (npt.NDArray[np.float32 | np.float64]): The knot vector as supplied,
+            non-decreasing, before snapping.
+        snapped (npt.NDArray[np.float32 | np.float64]): The same vector afterwards.
+        tol (float): The absolute tolerance snapping used, from :func:`_knot_tolerance`.
+
+    Raises:
+        ValueError: If ``raw`` held more than one distinct knot while ``snapped``
+            holds only one.
+    """
+    # Both vectors are non-decreasing, so "all knots identical" is exactly
+    # "first equals last", tested bitwise and needing no tolerance of its own.
+    if raw[0] == raw[-1] or snapped[0] != snapped[-1]:
+        return
+
+    name = raw.dtype.name
+    scale = _knot_scale(raw)
+    ulp = float(np.spacing(raw.dtype.type(scale)))
+    gaps = np.diff(np.asarray(raw, dtype=np.float64))
+    closest = float(gaps[gaps > 0.0].min())
+    # Widening the format is only a remedy if there is a wider one to move to.
+    remedy = (
+        "Use float64, move the domain nearer the origin, or coarsen the mesh."
+        if raw.dtype.type is np.float32
+        else "Move the domain nearer the origin, or coarsen the mesh."
+    )
+    raise ValueError(
+        f"knot snapping collapsed every knot onto {float(snapped[0])!r}: in {name} at "
+        f"|coordinate| ~ {scale:.3g} two knots are the same knot unless they differ by "
+        f"more than {tol:.3g} ({tol / ulp:.0f} ulp there), and the closest pair in "
+        f"[{float(raw[0])!r}, {float(raw[-1])!r}] is {closest:.3g} apart. This mesh is "
+        f"finer than {name} resolves at that magnitude. {remedy}"
+    )
+
+
 @nb_jit(
     nopython=True,
     cache=True,
@@ -782,6 +840,7 @@ def _warmup_numba_functions() -> None:
 
 
 __all__ = [
+    "_check_snapping_kept_an_interval",
     "_check_spline_info",
     "_count_multiplicity",
     "_find_knot_index_and_multiplicity",
@@ -793,5 +852,7 @@ __all__ = [
     "_get_multiplicity_of_first_knot_in_domain_impl",
     "_get_unique_knots_and_multiplicity_impl",
     "_is_in_domain_impl",
+    "_knot_scale",
+    "_knot_tolerance",
     "_validate_knot_input",
 ]

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -3,17 +3,82 @@
 This module provides functions for validating, analyzing, and querying
 B-spline knot vectors including multiplicity computation, domain checks,
 cardinal interval identification, and knot vector generation utilities.
+
+Every ``tol`` argument in this module is an **absolute** parametric length, in the
+units of the knot vector itself. :func:`_knot_tolerance` is what turns the
+dimensionless presets of :mod:`pantr.tolerance` into one, by multiplying by the
+knot vector's own magnitude; :class:`~pantr.bspline.BsplineSpace1D` calls it once
+at construction and hands the result to everything below.
 """
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import numpy as np
 import numpy.typing as npt
 
 from .._numba_compat import nb_jit
 from ..basis._basis_utils import _validate_float_dtype, _validate_out_array
+from ..tolerance import get_strict
+
+_KNOT_MERGE_SAFETY: Final[float] = 2.0
+"""Extra factor on the strict tier for deciding that two knots are the same knot.
+
+Two knots a caller means to be equal but obtains by different routes -- a uniform
+``a + i * h`` against a barycentric ``(a * (n - i) + b * i) / n``, a refinement, a
+reparametrization, a Bezier split -- are each an affine map ``a + t * (b - a)`` of
+the knot span evaluated in at most three operations, so they differ by at most
+``3 * eps * scale`` with ``scale`` the magnitude :func:`_knot_scale` returns.
+:func:`~pantr.tolerance.get_strict` covers four roundings; doubling it to eight
+leaves about 2.7x over that bound for an FMA contraction, a different vector
+width, and one extra rounding upstream.
+"""
+
+
+def _knot_scale(knots: npt.NDArray[np.float32 | np.float64]) -> float:
+    """Get the magnitude a parametric comparison on a knot vector is relative to.
+
+    The span alone is not enough: on a knot vector based at 1e6 a knot difference
+    is formed from two coordinates of that size, so it carries an absolute error
+    of ``eps * 1e6`` however short the span is. The coordinate magnitudes are
+    therefore taken alongside the span, and the largest wins.
+
+    No floor is applied. A floor of 1.0 would be a physical choice this module is
+    not entitled to make, and it would destroy scale covariance on a domain
+    smaller than one unit -- exactly the case (``[0, 1e-6]``) where the previous
+    absolute tolerance merged every knot in the vector.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Non-decreasing knot vector.
+
+    Returns:
+        float: ``max(span, |knots[0]|, |knots[-1]|)``, zero only for a knot vector
+        that is identically zero.
+    """
+    lo, hi = float(knots[0]), float(knots[-1])
+    return max(hi - lo, abs(lo), abs(hi))
+
+
+def _knot_tolerance(knots: npt.NDArray[np.float32 | np.float64]) -> float:
+    """Get the absolute tolerance for comparing parametric coordinates of a knot vector.
+
+    ``_KNOT_MERGE_SAFETY * get_strict(dtype) * _knot_scale(knots)``, i.e.
+    ``8 * eps * scale``. Every parametric comparison the B-spline layer makes --
+    are these two knots one knot, is this point inside the domain, are these two
+    knot intervals the same length -- is a comparison of quantities of that
+    magnitude, so they all share this one number.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): Non-decreasing knot vector.
+
+    Returns:
+        float: Absolute parametric tolerance, in the units of ``knots``.
+
+    Raises:
+        ValueError: If the knot dtype is not a supported floating-point type.
+    """
+    return _KNOT_MERGE_SAFETY * get_strict(knots.dtype) * _knot_scale(knots)
 
 
 @nb_jit(
@@ -88,10 +153,32 @@ def _get_unique_knots_and_multiplicity_impl(
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]:
     """Get unique knots and their multiplicities.
 
+    Knots are grouped by *gap*: the vector is non-decreasing, so one pass suffices,
+    and a class ends where the step to the next knot exceeds ``tol``. Every member
+    of a class is represented by the class's **first** knot, chosen rather than
+    averaged, so the values returned are knots the vector actually contains and
+    the grouping is idempotent -- regrouping the represented vector reproduces it.
+    An average would be a fresh rounding, and could place two adjacent classes'
+    representatives a single ulp apart.
+
+    Grouping by gap rather than by a rounding grid is what makes the answer depend
+    on the knots and not on where they sit relative to an origin: two values one
+    ulp apart can straddle a grid line and never merge, for any grid spacing.
+
+    The cost of the gap rule is chaining -- ``n`` knots each within ``tol`` of the
+    next collapse into one class however far apart the ends are. That is accepted
+    rather than capped: a class-width cap would break the idempotence above, since
+    a class split by the cap leaves two representatives that may be within ``tol``
+    of each other and would merge on the next pass. Chaining needs every step of
+    the chain to sit at the format's noise floor, which is a mesh that has already
+    stopped being resolvable.
+
     Args:
         knots (npt.NDArray[np.float32 | np.float64]): B-spline knot vector.
         degree (int): B-spline degree.
-        tol (float): Tolerance for numerical comparisons.
+        tol (float): **Absolute** parametric tolerance: consecutive knots closer
+            than this are one knot. See :func:`_knot_tolerance` for how it is
+            derived from the knot vector's own magnitude.
         in_domain (bool): If True, only consider knots in the domain.
             Defaults to False.
 
@@ -99,45 +186,41 @@ def _get_unique_knots_and_multiplicity_impl(
         tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.int_]]: Tuple of
             (unique_knots, multiplicities) where unique_knots contains the distinct knot values
             and multiplicities contains the corresponding multiplicity counts. Both arrays have
-            the same length.
+            the same length. With ``in_domain=False`` the multiplicities sum to
+            ``knots.size``, so ``np.repeat(unique_knots, multiplicities)`` rebuilds
+            the whole vector with each class collapsed onto its representative.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
     """
-    # Round to tolerance precision for grouping
-    dtype = knots.dtype
-    scale = dtype.type(1.0 / tol)
-    rounded_knots = np.round(knots * scale) / scale
-
     n = knots.size
-    # unique_rounded_knots = np.empty(n, dtype=rounded_knots.dtype)
-    unique_rounded_knots_ids = np.empty(n, dtype=np.int_)
+    # Index of the first knot of each class, and how many knots the class holds.
+    first_ids = np.empty(n, dtype=np.int_)
     mult = np.zeros(n, dtype=np.int_)
 
-    if in_domain:
-        rknot_0, rknot_1 = rounded_knots[degree], rounded_knots[-degree - 1]
-    else:
-        rknot_0, rknot_1 = rounded_knots[0], rounded_knots[-1]
+    # The class containing the first and the last knot of the domain. Their whole
+    # class is reported, clamped copies outside the domain included, which is what
+    # the multiplicity of a boundary knot means.
+    lo_index, hi_index = degree, n - degree - 1
+    lo_class, hi_class = 0, 0
 
-    j = -1
-    last_rknot = np.nan
-
-    for i, rknot in enumerate(rounded_knots):
-        if rknot < rknot_0:
-            continue
-        elif rknot > rknot_1:
-            break
-
-        if rknot == last_rknot:
-            mult[j] += 1
-        else:
+    j = 0
+    first_ids[0] = 0
+    mult[0] = 1
+    for i in range(1, n):
+        if knots[i] - knots[i - 1] > tol:
             j += 1
-            last_rknot = rknot
-            unique_rounded_knots_ids[j] = i
-            mult[j] = 1
+            first_ids[j] = i
+        mult[j] += 1
+        if i == lo_index:
+            lo_class = j
+        if i == hi_index:
+            hi_class = j
 
-    unique_knots = rounded_knots[unique_rounded_knots_ids[: j + 1]]
-    mults = mult[: j + 1]
+    lo, hi = (lo_class, hi_class) if in_domain else (0, j)
+
+    unique_knots = knots[first_ids[lo : hi + 1]]
+    mults = mult[lo : hi + 1]
     return unique_knots, mults
 
 

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -36,12 +36,14 @@ spline to an exact ``float64`` copy first -- casting float32 coefficients to flo
 exact, so the promoted spline is the same mapping. The reason is margin, not
 impossibility: the residual of a ``float32`` evaluation cannot be resolved below
 ``1 - 3 * eps32 * scale`` (measured over supports from 6 to 125 control points), while
-:func:`pantr.tolerance.get_default` for ``float32`` is ``1e-6``, i.e. ``8.4 * eps32``.
-That is under one decade of headroom, against roughly ``2e3`` for ``float64``, and
-iterating in float32 would additionally quantize the parametric iterate at ``eps32``.
-Promotion removes both for the price of one exact cast. The returned coordinates invert
-the promoted mapping to float64 accuracy; evaluating them on the original ``float32``
-spline reproduces the query point to float32 accuracy only.
+:func:`pantr.tolerance.get_default` is ``64 * eps`` in every format. Iterating in
+float32 would therefore leave between one and two decades of headroom, and would
+additionally quantize the parametric iterate at ``eps32``. Promotion removes both for
+the price of one exact cast: the arithmetic floor becomes ``1 - 3 * eps64 * scale``,
+which for a float32 caller is eight orders below the threshold it asks for, so what
+limits the answer is the precision the caller's data carries and not the solver. The
+returned coordinates invert the promoted mapping to float64 accuracy; evaluating them
+on the original ``float32`` spline reproduces the query point to float32 accuracy only.
 
 v1 inverts square maps only (``rank == dim``): planar and volumetric geometry maps. An
 embedded curve or surface (``rank > dim``) needs a Gauss-Newton closest-point solve,
@@ -199,10 +201,18 @@ def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -
 
     Using the diagonal alone silently makes the tolerance unreachable for a geometry far
     from the origin -- a patch of diameter 1 sitting at ``x = 1e6`` has a residual floor
-    around ``1e-10`` while ``1e-12 * 1`` would be demanded -- so the scale is the
-    maximum of the two. With :func:`pantr.tolerance.get_default` for ``float64``
-    (``1e-12``, i.e. ``4.5e3 * eps``) the resulting threshold sits about two orders of
-    magnitude above that floor.
+    around ``1e-10`` while ``eps * 1`` would be demanded -- so the scale is the maximum
+    of the two.
+
+    The margin that leaves is thin and worth stating rather than assuming.
+    :func:`pantr.tolerance.get_default` is ``64 * eps``, so the threshold is
+    ``64 * eps * scale`` while the floor above is ``C * eps * max|coordinate|`` with
+    ``C`` of the order of ``prod(degree + 1)``. Measured on warped tensor-product maps in
+    1 to 3 directions at degrees 1 to 5, with the geometry translated to ``x = 1e6``: the
+    worst residual over 40 query points reaches ``60 * eps * scale``, against a threshold
+    of ``64``. Every point is still located -- ``C`` is a pessimistic count, since the de
+    Boor sum is a convex combination and its roundings do not all add -- but a caller with
+    a worse-conditioned map should pass ``tol`` explicitly rather than rely on 6 percent.
 
     A geometry with no length at all (every control point identical, at the origin)
     falls back to ``1.0``: there is no scale to read off it, and the tolerance must stay

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -28,6 +28,7 @@ from ._bspline_knot_insertion import (
     _compute_uniform_subdivision_knots,
 )
 from ._bspline_knots import (
+    _check_snapping_kept_an_interval,
     _get_Bspline_cardinal_intervals_1D_impl,
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
@@ -115,8 +116,13 @@ class BsplineSpace1D:
                 Defaults to True.
 
         Raises:
-            ValueError: If degree is negative, knots are insufficient, or
-                knots are not non-decreasing.
+            ValueError: If degree is negative, knots are insufficient, or knots are
+                not non-decreasing; or if ``snap_knots`` is set and snapping
+                collapses a knot vector that had more than one distinct knot onto a
+                single point, which means the requested spacing is finer than the
+                dtype resolves at that coordinate magnitude. A vector that was
+                already degenerate is accepted unchanged, and ``snap_knots=False``
+                bypasses both the merging and this check.
             TypeError: If knots cannot be converted to a numpy array.
         """
         BsplineSpace1D._validate_input(knots, degree, periodic)
@@ -140,6 +146,7 @@ class BsplineSpace1D:
 
         if snap_knots:
             self._snap_knots()
+            _check_snapping_kept_an_interval(knots_arr, self._knots, self._tol)
 
         self._knots.flags.writeable = False
 

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -84,7 +84,7 @@ class BsplineSpace1D:
     Attributes:
         _tol (float): Absolute tolerance for parametric comparisons on this space,
             in the units of its knots. Derived once at construction by
-            :func:`~pantr.bspline._bspline_knots._knot_tolerance` as
+            ``_bspline_knots._knot_tolerance`` as
             ``8 * eps(dtype) * max(span, |knots[0]|, |knots[-1]|)``, so it tracks
             the knot vector's own magnitude instead of being a per-dtype constant.
         _knots (npt.NDArray[np.float32 | np.float64]): Knot vector defining the B-spline.
@@ -204,7 +204,9 @@ class BsplineSpace1D:
         a fresh rounding: over ``degree + 1`` identical copies at large magnitude
         ``np.mean`` is not even the identity, so it moved the reported domain.
 
-        It modifies the knot vector in place.
+        It replaces :attr:`_knots` with the collapsed vector, of the same length,
+        dtype and ordering. Called once from ``__init__``, before the array is
+        frozen read-only.
         """
         unique, mult = _get_unique_knots_and_multiplicity_impl(
             self._knots, self._degree, self._tol, False

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -14,7 +14,6 @@ import numpy as np
 from numpy import typing as npt
 
 from ..basis import LagrangeVariant
-from ..tolerance import get_strict
 from ._bspline_basis_core import (
     _tabulate_Bspline_basis_1D_impl,
     _tabulate_Bspline_basis_deriv_1D_impl,
@@ -32,6 +31,7 @@ from ._bspline_knots import (
     _get_Bspline_cardinal_intervals_1D_impl,
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
+    _knot_tolerance,
 )
 
 
@@ -63,8 +63,10 @@ def _cached_unique_knots_and_multiplicity(
     knots_bytes, dtype_str, size = knots_repr
     dtype = np.dtype(dtype_str)
     knots = np.frombuffer(knots_bytes, dtype=dtype, count=size).copy()
-    tol_value = dtype.type(tol)
-    unique, mults = _get_unique_knots_and_multiplicity_impl(knots, degree, tol_value, in_domain)
+    # ``tol`` goes in unrounded, exactly as ``BsplineSpace1D._snap_knots`` passes it, so
+    # the space and its own accessor apply one predicate rather than two that differ in
+    # the last bits of the threshold.
+    unique, mults = _get_unique_knots_and_multiplicity_impl(knots, degree, tol, in_domain)
     # The same arrays are returned to every caller; freeze them so a caller
     # mutation cannot poison the cache.
     unique.flags.writeable = False
@@ -80,7 +82,11 @@ class BsplineSpace1D:
     and access various properties of the B-spline.
 
     Attributes:
-        _tol (np.float32 | np.float64): Tolerance value for numerical comparisons.
+        _tol (float): Absolute tolerance for parametric comparisons on this space,
+            in the units of its knots. Derived once at construction by
+            :func:`~pantr.bspline._bspline_knots._knot_tolerance` as
+            ``8 * eps(dtype) * max(span, |knots[0]|, |knots[-1]|)``, so it tracks
+            the knot vector's own magnitude instead of being a per-dtype constant.
         _knots (npt.NDArray[np.float32 | np.float64]): Knot vector defining the B-spline.
         _degree (int): Polynomial degree of the B-spline.
         _periodic (bool): Whether the B-spline is periodic.
@@ -124,7 +130,10 @@ class BsplineSpace1D:
             knots_arr = knots_arr.copy()
         self._knots = knots_arr
 
-        self._tol = BsplineSpace1D._get_tolerance(self.dtype)
+        # Derived from the knots, not from the dtype alone: the presets in
+        # ``pantr.tolerance`` are dimensionless, and the magnitude a parametric
+        # comparison on this space is relative to is the knot vector's own extent.
+        self._tol = _knot_tolerance(self._knots)
 
         self._degree = int(degree)
         self._periodic = bool(periodic)
@@ -163,9 +172,6 @@ class BsplineSpace1D:
         if np.issubdtype(knots.dtype, np.integer):
             knots = knots.astype(np.float64)
 
-        dtype = knots.dtype
-        tol = BsplineSpace1D._get_tolerance(dtype)
-
         if not isinstance(knots, np.ndarray) or knots.ndim != 1:
             raise TypeError("knots must be a 1D numpy array or Python list")
 
@@ -178,44 +184,32 @@ class BsplineSpace1D:
         if not np.all(np.diff(knots) >= 0):
             raise ValueError("knots must be non-decreasing")
 
+        # Derived only here, after the shape and ordering checks: the tolerance
+        # reads the endpoints, so it needs a vector that has them.
+        tol = _knot_tolerance(knots)
         num_basis = _get_Bspline_num_basis_1D_impl(knots, degree, periodic, tol)
         if num_basis < (degree + 1):
             raise ValueError("Not enough knots for the specified degree")
 
-    @staticmethod
-    def _get_tolerance(dtype: npt.DTypeLike) -> float:
-        """Create tolerance value based on data type.
-
-        Right now, strict tolerance is used.
-
-        Args:
-            dtype (np.dtype): NumPy data type.
-
-        Returns:
-            float: Tolerance value appropriate for the given data type.
-        """
-        return float(get_strict(dtype))
-
     def _snap_knots(self) -> None:
-        """Snap knots within tolerance to avoid numerical precision issues.
+        """Collapse each group of knots meant to be one knot onto a single stored value.
 
-        This method rounds knots to a precision determined by the stored tolerance
-        and then averages any knots that are close together.
+        The grouping is delegated to :func:`_get_unique_knots_and_multiplicity_impl`
+        and the vector rebuilt from the classes it reports, so the space and its own
+        accessor cannot disagree about which knots are the same knot -- two
+        implementations of one idea is how they came to disagree before.
+
+        The representative is the class's *first* knot, chosen and not averaged, so
+        snapping returns values the caller supplied and is idempotent. Averaging is
+        a fresh rounding: over ``degree + 1`` identical copies at large magnitude
+        ``np.mean`` is not even the identity, so it moved the reported domain.
 
         It modifies the knot vector in place.
         """
-        scale = 1.0 / self._tol
-        rounded = np.round(self._knots * scale) / scale
-        unique_vals = np.unique(rounded)
-
-        snapped_knots = self._knots.copy()
-        for val in unique_vals:
-            # Exact match on the rounded values: knots are merged only when they
-            # round to the same tolerance-grid point.  (np.isclose would compare
-            # with its default rtol=1e-5 and merge far-apart knots.)
-            mask = rounded == val
-            snapped_knots[mask] = np.mean(self._knots[mask], dtype=self.dtype)
-        self._knots = snapped_knots
+        unique, mult = _get_unique_knots_and_multiplicity_impl(
+            self._knots, self._degree, self._tol, False
+        )
+        self._knots = np.repeat(unique, mult)
 
     @property
     def degree(self) -> int:
@@ -246,10 +240,22 @@ class BsplineSpace1D:
 
     @property
     def tolerance(self) -> float:
-        """Get the tolerance value used for numerical comparisons.
+        """Get the absolute tolerance used for parametric comparisons on this space.
+
+        It is in the units of the knot vector, being the dimensionless strict
+        preset of :mod:`pantr.tolerance` scaled by the knot vector's own magnitude
+        (``max(span, |knots[0]|, |knots[-1]|)``) and doubled for one extra rounding
+        upstream. Two knots closer than this are the same knot, a point within this
+        of an end is inside the domain, and two knot intervals differing by less
+        than this are the same length.
+
+        Being an absolute parametric length, it is *not* the factor to scale a
+        physical coordinate or a spline coefficient by; take the dimensionless
+        preset from :mod:`pantr.tolerance` for those and scale it by the magnitude
+        that applies.
 
         Returns:
-            float: The tolerance value.
+            float: The absolute parametric tolerance.
         """
         return self._tol
 

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -84,12 +84,15 @@ class BsplineSpace:
 
     @functools.cached_property
     def tolerance(self) -> float:
-        """Get the tolerance value used for numerical comparisons.
+        """Get the absolute tolerance used for parametric comparisons on this space.
 
-        It is the maximum tolerance of the B-spline spaces.
+        The largest of the univariate spaces' tolerances, each of which already
+        carries its own direction's knot magnitude (see
+        :attr:`~pantr.bspline.BsplineSpace1D.tolerance`). Taking the largest is the
+        conservative choice when the directions are scaled differently.
 
         Returns:
-            float: The tolerance value.
+            float: The absolute parametric tolerance.
         """
         return max(space.tolerance for space in self._spaces)
 

--- a/src/pantr/grid/_overlay.py
+++ b/src/pantr/grid/_overlay.py
@@ -35,9 +35,11 @@ def overlay(grid_a: TensorProductGrid, grid_b: TensorProductGrid) -> TensorProdu
 
     The overlay's per-axis breakpoints are the sorted union of both inputs'
     breakpoint arrays restricted to the intersection of their domains.
-    Breakpoints closer than the default ``float64`` tolerance
-    (:func:`pantr.tolerance.get_default`) are merged into one. The result is the
-    coarsest :class:`TensorProductGrid` that refines both inputs.
+    Breakpoints closer than the default *relative* tolerance
+    (:func:`pantr.tolerance.get_default`) times the axis's own magnitude -- the
+    intersection window and the coordinates bounding it -- are merged into one, so
+    the merge behaves the same on ``[0, 1]`` as on ``[1e6, 1e6 + 1]``. The result
+    is the coarsest :class:`TensorProductGrid` that refines both inputs.
 
     Args:
         grid_a (TensorProductGrid): First input grid.
@@ -71,13 +73,18 @@ def overlay(grid_a: TensorProductGrid, grid_b: TensorProductGrid) -> TensorProdu
         )
     if grid_a.ndim != grid_b.ndim:
         raise ValueError(f"overlay(): grids must share ndim; got {grid_a.ndim} vs {grid_b.ndim}.")
-    atol = get_default(np.float64)
+    relative = get_default(np.float64)
     merged: list[npt.NDArray[np.float64]] = []
     for d in range(grid_a.ndim):
         ba = grid_a.breakpoints[d]
         bb = grid_b.breakpoints[d]
         lo = max(float(ba[0]), float(bb[0]))
         hi = min(float(ba[-1]), float(bb[-1]))
+        # ``relative`` is dimensionless; the magnitude a breakpoint comparison on this
+        # axis is relative to is the intersection window, taken together with the
+        # coordinates bounding it -- a window of length 1 sitting at 1e6 resolves its
+        # breakpoints no better than ``eps * 1e6``, however short the window is.
+        atol = relative * max(hi - lo, abs(lo), abs(hi))
         if hi - lo <= atol:
             raise ValueError(
                 f"overlay(): domains do not overlap on axis {d}; grid_a extent "

--- a/src/pantr/multipatch/_detect.py
+++ b/src/pantr/multipatch/_detect.py
@@ -90,7 +90,9 @@ def _joint_tolerances(patch_a: Bspline, patch_b: Bspline, tol: float | None) -> 
     # patch's own knot magnitude, and none of the three quantities compared here is
     # a parametric coordinate of a single patch. What is wanted is the bare
     # dimensionless factor, which each leg below scales by the magnitude that
-    # applies to it.
+    # applies to it. The strict tier is what ``space.tolerance`` was built from
+    # before, so this keeps the tier the interface check has always used and only
+    # stops it travelling through a quantity that has since acquired units.
     relative = (
         max(get_strict(patch_a.space.dtype), get_strict(patch_b.space.dtype))
         if tol is None

--- a/src/pantr/multipatch/_detect.py
+++ b/src/pantr/multipatch/_detect.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 import numpy.typing as npt
 
+from ..tolerance import get_strict
 from ._interface import Interface, face_axis_side, tangential_axes
 from ._match import match_face_cps
 
@@ -79,13 +80,22 @@ def _joint_tolerances(patch_a: Bspline, patch_b: Bspline, tol: float | None) -> 
     Args:
         patch_a (Bspline): First patch.
         patch_b (Bspline): Second patch.
-        tol (float | None): Relative tolerance override, or ``None`` to take the
-            larger of the two spaces' own tolerances.
+        tol (float | None): Dimensionless relative tolerance override, or ``None``
+            for the strict preset of the patches' own dtypes.
 
     Returns:
         _Tolerances: The three derived absolute tolerances.
     """
-    relative = max(patch_a.space.tolerance, patch_b.space.tolerance) if tol is None else float(tol)
+    # Not ``space.tolerance``: that is an *absolute* parametric length carrying the
+    # patch's own knot magnitude, and none of the three quantities compared here is
+    # a parametric coordinate of a single patch. What is wanted is the bare
+    # dimensionless factor, which each leg below scales by the magnitude that
+    # applies to it.
+    relative = (
+        max(get_strict(patch_a.space.dtype), get_strict(patch_b.space.dtype))
+        if tol is None
+        else float(tol)
+    )
     rank = patch_a.rank
     coords = np.concatenate(
         [
@@ -287,8 +297,8 @@ def verify_interface(
     Args:
         patches (Sequence[Bspline]): The patches the interface refers to.
         interface (Interface): The interface to verify.
-        tol (float | None): Relative tolerance override. Defaults to the larger of
-            the two spaces' own tolerances.
+        tol (float | None): Dimensionless relative tolerance override. Defaults to
+            the strict preset of the two patches' dtypes.
 
     Returns:
         bool: ``True`` if the interface holds.
@@ -320,8 +330,8 @@ def detect_interfaces(
     Args:
         patches (Sequence[Bspline]): The patches to inspect. All must share the same
             parametric dimension.
-        tol (float | None): Relative tolerance override. Defaults, per pair, to the
-            larger of the two spaces' own tolerances; it is scaled by the joint
+        tol (float | None): Dimensionless relative tolerance override. Defaults, per
+            pair, to the strict preset of the two dtypes; it is scaled by the joint
             bounding-box diagonal for coordinates and used bare for knots.
 
     Returns:

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -17,17 +17,17 @@ Each preset is ``K * eps(dtype)``. ``K`` is an acknowledged safety factor, state
 rather than tuned, and a power of two so that it is exact in every format and
 carries no decimal literal to mistranscribe:
 
-======================  ======  ==========================================
+======================  ======  =============================================
 preset                  ``K``   what it pays for
-======================  ======  ==========================================
-:func:`get_strict`           4  a handful of roundings: one comparison, one
-                                subtraction, one convex combination
-:func:`get_default`         64  a short algorithm (about 16 operations) plus
+======================  ======  =============================================
+``get_strict``               4  a handful of roundings: one subtraction and
+                                one convex combination, then a difference
+``get_default``             64  a short algorithm (about 16 operations) plus
                                 build slack: FMA contraction, vector width,
                                 libm
-:func:`get_conservative`  4096  a long accumulation, or a condition number up
-                                to about 1e3, with headroom
-======================  ======  ==========================================
+``get_conservative``      4096  a long accumulation, or a condition number
+                                up to about 1e3, with headroom
+======================  ======  =============================================
 
 ``K`` being constant across dtypes is what makes the three presets mean the same
 thing in every precision: ``get_strict`` is four roundings whether the roundings
@@ -103,9 +103,11 @@ def _ensure_float_dtype(dtype: npt.DTypeLike) -> np.dtype[np.floating[Any]]:
 _STRICT_EPS_FACTOR: Final[float] = 4.0
 """Machine epsilons a :func:`get_strict` comparison allows for.
 
-A handful of roundings and nothing more: one comparison, one subtraction, one
-convex combination. Three roundings bound the error of an affine map evaluated in
-the obvious way, and four is that rounded up to a power of two.
+A handful of roundings and nothing more. Four is the count for the shape this tier
+is meant for: a value reached by one convex combination -- a subtract, a multiply
+and an add, three roundings -- and then differenced against another such value,
+which is the fourth. (The comparison itself is exact in IEEE-754 and costs
+nothing.) Four is also already a power of two, so nothing is rounded up here.
 """
 
 _DEFAULT_EPS_FACTOR: Final[float] = 64.0
@@ -163,10 +165,10 @@ def get_default(dtype: npt.DTypeLike) -> float:
         ValueError: If dtype is not a supported floating-point type.
 
     Example:
-        >>> get_default(np.float32) / float(np.finfo(np.float32).eps)
-        64.0
         >>> get_default("float64")
         1.4210854715202004e-14
+        >>> get_default(np.float32) / float(np.finfo(np.float32).eps)
+        64.0
     """
     return _relative_tolerance(dtype, _DEFAULT_EPS_FACTOR)
 
@@ -191,6 +193,8 @@ def get_strict(dtype: npt.DTypeLike) -> float:
     Example:
         >>> get_strict("float64")
         8.881784197001252e-16
+        >>> get_strict(np.float32) / float(np.finfo(np.float32).eps)
+        4.0
     """
     return _relative_tolerance(dtype, _STRICT_EPS_FACTOR)
 
@@ -215,6 +219,8 @@ def get_conservative(dtype: npt.DTypeLike) -> float:
     Example:
         >>> get_conservative("float64")
         9.094947017729282e-13
+        >>> get_conservative(np.float32) / float(np.finfo(np.float32).eps)
+        4096.0
     """
     return _relative_tolerance(dtype, _CONSERVATIVE_EPS_FACTOR)
 

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -1,29 +1,63 @@
-"""Tolerance utilities for floating-point comparisons in IGA applications.
+"""Relative tolerances for floating-point comparisons in IGA applications.
 
-The presets returned here (:func:`get_default`, :func:`get_strict`,
-:func:`get_conservative`) are **absolute** tolerances: a fixed value per dtype,
-independent of the magnitude of the values being compared. This is used for
-knot-multiplicity detection (grouping near-duplicate knot values, e.g.
-``_get_unique_knots_and_multiplicity_impl``) and for canonicalizing near-duplicate
-knots to a single bitwise value at construction time
-(``BsplineSpace1D._snap_knots``).
+The presets returned here (:func:`get_strict`, :func:`get_default`,
+:func:`get_conservative`) are **dimensionless relative** tolerances: a number of
+machine epsilons, the *same* number for every dtype. They carry no units and no
+scale of their own, so none of them is usable as a comparison on its own.
 
-Kernels that compare a *difference of two knots* against zero -- e.g. the Cox-de
-Boor recurrence denominator guard in ``pantr.bspline._bspline_basis_core``
-(``_basis_funcs_point``, ``_basis_derivs_point``) -- do **not** take a tolerance
-at all: they use an exact ``denom == 0.0`` test, which is scale-invariant by
-construction (unlike a tolerance-based guard). This is safe whenever any two knots
-meant to be equal are stored bitwise identical, so IEEE-754 subtraction makes their
-difference exactly zero -- the default ``snap_knots=True`` construction path
-guarantees this by snapping near-duplicate knots together; callers that opt out of
-snapping (``snap_knots=False``) or call the kernels directly are responsible for
-the knot vector's own consistency.
+A call site turns one into a comparison by multiplying it by the magnitude of the
+quantity it is actually comparing, and by naming that magnitude where it does so:
+``max(|a|, |b|)`` for two values, ``knots[-1] - knots[0]`` for a knot gap, the
+bounding-box diagonal for a physical coordinate, ``max|c|`` for a spline
+coefficient. The floor near zero is that same product -- a relative test can never
+accept ``a = 0`` against a tiny ``b``, so a floor is genuinely needed, but the
+problem supplies its scale, never the dtype.
+
+Each preset is ``K * eps(dtype)``. ``K`` is an acknowledged safety factor, stated
+rather than tuned, and a power of two so that it is exact in every format and
+carries no decimal literal to mistranscribe:
+
+======================  ======  ==========================================
+preset                  ``K``   what it pays for
+======================  ======  ==========================================
+:func:`get_strict`           4  a handful of roundings: one comparison, one
+                                subtraction, one convex combination
+:func:`get_default`         64  a short algorithm (about 16 operations) plus
+                                build slack: FMA contraction, vector width,
+                                libm
+:func:`get_conservative`  4096  a long accumulation, or a condition number up
+                                to about 1e3, with headroom
+======================  ======  ==========================================
+
+``K`` being constant across dtypes is what makes the three presets mean the same
+thing in every precision: ``get_strict`` is four roundings whether the roundings
+are float32's or float64's.
+
+The one place that uniformity has a visible edge is ``float16``, which carries 11
+significant bits and therefore cannot absorb 4096 roundings at all:
+``get_conservative(np.float16)`` is 4.0, a relative tolerance above one, which
+accepts everything. That is the honest answer -- a long accumulation in half
+precision retains no digits -- and it is reported rather than clipped. Nothing in
+pantr reaches it: the B-spline layer accepts only float32 and float64
+(``BsplineSpace1D`` rejects the rest at construction).
+
+Kernels that compare a *difference of two knots* against zero -- the Cox-de Boor
+recurrence denominator guard in ``pantr.bspline._bspline_basis_core``
+(``_basis_funcs_point``, ``_basis_derivs_point``) -- take no tolerance at all and
+use an exact ``denom == 0.0`` test. What makes that sound is the shape of the
+recurrence, not the knot vector: ``denom`` is the sum of the two non-negative
+terms the step then divides by, so the two weights ``right / denom`` and
+``left / denom`` are non-negative and sum to one up to a single rounding. A
+denominator small enough to make the quotient large is multiplied straight back by
+factors no larger than itself, and the term stays bounded by the basis value it
+came from. Near-duplicate knots therefore cost accuracy in that ratio, not
+boundedness, and the guard needs no tolerance and no bitwise-identical knots.
 """
 
 from __future__ import annotations
 
 from functools import cache
-from typing import Any, NamedTuple, TypedDict
+from typing import Any, Final, TypedDict
 
 import numpy as np
 from numpy import typing as npt
@@ -66,118 +100,123 @@ def _ensure_float_dtype(dtype: npt.DTypeLike) -> np.dtype[np.floating[Any]]:
     return _ensure_float_dtype_by_name(dtype_obj.name)
 
 
-class _TolerancePreset(NamedTuple):
-    """A named tuple to hold tolerance values for different floating-point types."""
+_STRICT_EPS_FACTOR: Final[float] = 4.0
+"""Machine epsilons a :func:`get_strict` comparison allows for.
 
-    float16: float
-    float32: float
-    float64: float
-    longdouble: float
+A handful of roundings and nothing more: one comparison, one subtraction, one
+convex combination. Three roundings bound the error of an affine map evaluated in
+the obvious way, and four is that rounded up to a power of two.
+"""
+
+_DEFAULT_EPS_FACTOR: Final[float] = 64.0
+"""Machine epsilons a :func:`get_default` comparison allows for.
+
+A short algorithm -- on the order of 16 operations, whose worst-case accumulation
+is ``16 * eps`` -- plus build slack: an FMA contraction, a different vector width
+and a different libm each move the last bits without changing the algorithm.
+Four times the accumulation bound covers that, and 64 is the power of two it
+lands on.
+"""
+
+_CONSERVATIVE_EPS_FACTOR: Final[float] = 4096.0
+"""Machine epsilons a :func:`get_conservative` comparison allows for.
+
+A long accumulation, or a problem whose condition number reaches about 1e3: the
+error is then ``cond * eps`` rather than an operation count times ``eps``, and
+4096 leaves a factor of four over that on top of the same build slack the default
+tier allows. Past this the tolerance stops being a safety factor and starts
+hiding the answer, so a site that needs more needs a derivation of its own.
+"""
 
 
-# This is platform dependent.
-if np.dtype(np.longdouble) == np.dtype(np.float64):
-    _TOLERANCE_PRESETS = {
-        "default": _TolerancePreset(1e-3, 1e-6, 1e-12, 1e-12),
-        "strict": _TolerancePreset(1e-4, 1e-7, 1e-15, 1e-15),
-        "conservative": _TolerancePreset(1e-2, 1e-5, 1e-10, 1e-10),
-    }
-else:
-    _TOLERANCE_PRESETS = {
-        "default": _TolerancePreset(1e-3, 1e-6, 1e-12, 1e-15),
-        "strict": _TolerancePreset(1e-4, 1e-7, 1e-15, 1e-18),
-        "conservative": _TolerancePreset(1e-2, 1e-5, 1e-10, 1e-12),
-    }
-
-
-def _get_tolerance(
-    dtype: npt.DTypeLike,
-    preset: _TolerancePreset,
-) -> float:
-    """Get the tolerance value for a specific dtype from a preset.
+def _relative_tolerance(dtype: npt.DTypeLike, eps_factor: float) -> float:
+    """Scale a dimensionless safety factor by a dtype's machine epsilon.
 
     Args:
         dtype (npt.DTypeLike): NumPy floating-point data type.
-        preset (_TolerancePreset): A named tuple containing tolerance values.
+        eps_factor (float): Number of machine epsilons the tolerance allows for.
 
     Returns:
-        float: Tolerance value for the given dtype.
+        float: The dimensionless relative tolerance ``eps_factor * eps(dtype)``.
 
     Raises:
         ValueError: If dtype is not a supported floating-point type.
     """
-    dtype_obj = _ensure_float_dtype(dtype)
-
-    # Respect an explicit request for np.longdouble even on platforms where it
-    # aliases float64 (e.g., macOS, Windows). The tests expect semantic intent,
-    # not platform aliasing.
-    if dtype is np.longdouble or (
-        isinstance(dtype, str) and dtype.lower().replace(" ", "") == "longdouble"
-    ):
-        return preset.longdouble
-
-    if dtype_obj.type == np.float16:
-        return preset.float16
-    elif dtype_obj.type == np.float32:
-        return preset.float32
-    elif dtype_obj.type == np.float64:
-        return preset.float64
-    else:  # if dtype_obj.type == np.longdouble:
-        return preset.longdouble
+    return eps_factor * float(np.finfo(_ensure_float_dtype(dtype)).eps)
 
 
 def get_default(dtype: npt.DTypeLike) -> float:
-    """Get a reasonable default tolerance for floating-point comparisons.
+    """Get the default relative tolerance for floating-point comparisons.
+
+    ``_DEFAULT_EPS_FACTOR * eps(dtype)``: the tier for a short algorithm plus build
+    slack. Dimensionless -- multiply it by the magnitude of the quantity being
+    compared, and name that magnitude at the call site.
 
     Args:
         dtype (npt.DTypeLike): NumPy floating-point data type or numpy scalar
             type.
 
     Returns:
-        float: Recommended tolerance value for the given dtype.
+        float: Relative tolerance for the given dtype.
 
     Raises:
         ValueError: If dtype is not a supported floating-point type.
 
     Example:
-        >>> get_default(np.float32)
-        1e-06
+        >>> get_default(np.float32) / float(np.finfo(np.float32).eps)
+        64.0
         >>> get_default("float64")
-        1e-12
+        1.4210854715202004e-14
     """
-    return _get_tolerance(dtype, _TOLERANCE_PRESETS["default"])
+    return _relative_tolerance(dtype, _DEFAULT_EPS_FACTOR)
 
 
 def get_strict(dtype: npt.DTypeLike) -> float:
-    """Get a strict tolerance for high-precision floating-point comparisons.
+    """Get the strict relative tolerance for high-precision comparisons.
+
+    ``_STRICT_EPS_FACTOR * eps(dtype)``: the tier for a handful of roundings, used
+    where a quantity is expected to agree to within the format's own noise.
+    Dimensionless -- multiply it by the magnitude of the quantity being compared,
+    and name that magnitude at the call site.
 
     Args:
         dtype (npt.DTypeLike): NumPy floating-point data type.
 
     Returns:
-        float: Strict tolerance value for the given dtype. Typically used for
-            parametric coordinates requiring high precision.
+        float: Relative tolerance for the given dtype.
 
     Raises:
         ValueError: If dtype is not a supported floating-point type.
+
+    Example:
+        >>> get_strict("float64")
+        8.881784197001252e-16
     """
-    return _get_tolerance(dtype, _TOLERANCE_PRESETS["strict"])
+    return _relative_tolerance(dtype, _STRICT_EPS_FACTOR)
 
 
 def get_conservative(dtype: npt.DTypeLike) -> float:
-    """Get a conservative tolerance for robust floating-point comparisons.
+    """Get the conservative relative tolerance for robust comparisons.
+
+    ``_CONSERVATIVE_EPS_FACTOR * eps(dtype)``: the tier for a long accumulation or
+    a moderately ill-conditioned step, used where robustness matters more than
+    resolving power. Dimensionless -- multiply it by the magnitude of the quantity
+    being compared, and name that magnitude at the call site.
 
     Args:
         dtype (npt.DTypeLike): NumPy floating-point data type.
 
     Returns:
-        float: Conservative tolerance value for the given dtype. Used when
-            robustness is more important than precision.
+        float: Relative tolerance for the given dtype.
 
     Raises:
         ValueError: If dtype is not a supported floating-point type.
+
+    Example:
+        >>> get_conservative("float64")
+        9.094947017729282e-13
     """
-    return _get_tolerance(dtype, _TOLERANCE_PRESETS["conservative"])
+    return _relative_tolerance(dtype, _CONSERVATIVE_EPS_FACTOR)
 
 
 def get_machine_epsilon(dtype: npt.DTypeLike) -> float:
@@ -202,7 +241,11 @@ def get_machine_epsilon(dtype: npt.DTypeLike) -> float:
 
 
 class ToleranceInfo(TypedDict):
-    """A TypedDict holding comprehensive tolerance and precision information."""
+    """A TypedDict holding comprehensive tolerance and precision information.
+
+    The three tolerance entries are the **dimensionless relative** presets, not
+    absolute bounds; see the module docstring.
+    """
 
     dtype: npt.DTypeLike
     machine_epsilon: float
@@ -226,8 +269,8 @@ def get_info(
 
     Returns:
         ToleranceInfo: Dictionary containing tolerance information including
-            machine epsilon, default/strict/conservative tolerances, precision
-            bits, and min/max values for the dtype.
+            machine epsilon, the default/strict/conservative *relative*
+            tolerances, precision bits, and min/max values for the dtype.
 
     Raises:
         ValueError: If dtype is not a supported floating-point type.

--- a/tests/test_bspline_basis_tol_guard_scale.py
+++ b/tests/test_bspline_basis_tol_guard_scale.py
@@ -15,11 +15,14 @@ that specific failure mode.
 
 The final fix drops the tolerance from the guard entirely and uses the textbook
 exact-zero test (``denom == 0.0``, Piegl & Tiller A2.2/A2.3), which is scale-invariant
-by construction. This is safe because
-:class:`~pantr.bspline.BsplineSpace1D` already snaps near-duplicate knots (within
-tolerance) to a single bitwise value at construction time
-(``BsplineSpace1D._snap_knots``), so two knots meant to be equal always produce an
-exactly-zero Cox-de Boor denominator (IEEE-754 subtraction is antisymmetric).
+by construction. It is safe for a reason that has nothing to do with knot snapping:
+the denominator is the sum of the two non-negative terms the recurrence then
+multiplies the quotient by, so those two weights form a convex combination and a
+tiny denominator cancels against an equally tiny numerator. Verified directly with
+``snap_knots=False`` and interior knots 0 to 64 ulp apart; see the note on
+``_basis_funcs_point``. (This paragraph used to justify the guard by claiming that
+snapping stores equal knots bitwise identical. It does, but the guard never rested
+on it.)
 
 Note on the (scale, shift) grid in the affine-invariance tests below: combining the
 smallest scale (``1e-12``) with the largest shift (``1e3``) is deliberately *not*
@@ -71,51 +74,105 @@ class TestGradedKnotVectorLocalSpacing:
     """Regression guard for the global-span-scaling failure mode found in review.
 
     An earlier version of this fix scaled ``tol`` by the knot vector's *global*
-    span (``knots[-1] - knots[0]``) instead of using an exact-zero test. That
-    incorrectly zeroed genuinely distinct, non-repeated local knot gaps whenever
-    the domain was large relative to local spacing -- an entirely ordinary
-    graded/refined knot vector, not an extreme edge case. These tests pin down
-    that the final (exact-zero) guard does not reintroduce that regression.
+    span (``knots[-1] - knots[0]``) inside the Cox-de Boor guard instead of using
+    an exact-zero test. That incorrectly zeroed genuinely distinct, non-repeated
+    local knot gaps on a domain large relative to the local spacing. What made it
+    a defect was the *disagreement* it created: the guard dropped the contribution
+    of a span that :meth:`BsplineSpace1D.get_unique_knots_and_multiplicity` was
+    still reporting as non-empty, so the basis lost mass on a space that claimed
+    to have an interval there.
+
+    Two things are pinned below, and the distinction between them is the point.
+
+    * A gap the format resolves must survive, both in the reported multiplicity
+      and in the basis. That is the original regression, and it is asserted at a
+      gap comfortably above the merge threshold.
+    * A gap *below* the threshold is merged at construction, and everything then
+      agrees about it -- the stored knots, the multiplicity, and the basis. The two
+      fixtures this class originally used sat at 8.2 and 3.0 ulp of the knot they
+      straddled, which is inside the noise of computing that knot at all; they are
+      kept here with their expectations re-derived, as the merged-and-consistent
+      case.
     """
 
-    def test_large_domain_small_local_gap_float64(self) -> None:
-        """A non-repeated, locally tiny knot gap on a huge domain must not be zeroed.
+    def test_resolvable_gap_on_a_huge_domain_survives_float64(self) -> None:
+        """A local gap the format resolves must not be collapsed, however large the domain.
 
-        Domain ``[0, 1e12]`` with an interior knot pair ``5e11`` apart from
-        ``5e11`` by only ``5e-4`` (ratio to the domain ``~5e-16``): the pair is
-        *not* repeated, and :meth:`BsplineSpace1D.get_unique_knots_and_multiplicity`
-        agrees (multiplicity 1 each), so the guard must not collapse it.
+        Domain ``[0, 1e12]``; the interior pair straddles ``5e11`` with a gap of
+        ``1e-2``. The float64 ulp at ``5e11`` is 6.1e-5, so that is 164 ulp, and it
+        is 5.6x the ``8 * eps * span = 1.78e-3`` merge threshold. A grading ratio of
+        1e-14 against the domain: far past anything a real adaptive mesh reaches,
+        which is the point -- the threshold does not eat ordinary refinement.
         """
-        knots = np.array([0.0, 0.0, 0.0, 5e11, 5e11 + 5e-4, 1e12, 1e12, 1e12], dtype=np.float64)
+        knots = np.array([0.0, 0.0, 0.0, 5e11, 5e11 + 1e-2, 1e12, 1e12, 1e12], dtype=np.float64)
         space = BsplineSpace1D(knots, 2)
 
-        # Endpoints are open (multiplicity degree+1 = 3); the two interior knots
-        # (5e11 and 5e11 + 5e-4) are genuinely distinct, multiplicity 1 each.
+        assert np.array_equal(np.asarray(space.knots), knots), "the pair must stay distinct"
         _, mult = space.get_unique_knots_and_multiplicity()
         np.testing.assert_array_equal(mult, [3, 1, 1, 3])
 
-        basis, _ = space.tabulate_basis(np.array([5e11 + 2.5e-4], dtype=np.float64))
+        basis, _ = space.tabulate_basis(np.array([5e11 + 5e-3], dtype=np.float64))
         assert np.all(np.isfinite(basis))
         np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-9)
 
-    def test_ordinary_domain_graded_refinement_float32(self) -> None:
-        """A routine float32 grading ratio on an unremarkable domain must not be zeroed.
+    def test_resolvable_gap_on_an_ordinary_domain_survives_float32(self) -> None:
+        """The same, in float32 on an unremarkable domain.
 
-        Domain ``[0, 1000]`` (nothing extreme) with an interior gap of ``~9.15e-5``
-        (grading ratio ``~1e-7`` relative to the domain), well within ordinary
-        adaptive-refinement territory for float32.
+        Domain ``[0, 1000]`` with an interior gap of ``1e-2`` at ``500``: 328 ulp
+        there, and 10.5x the ``8 * eps * span = 9.54e-4`` threshold.
         """
         knots = np.array(
-            [0.0, 0.0, 0.0, 500.0, 500.0 + 9.15e-5, 1000.0, 1000.0, 1000.0], dtype=np.float32
+            [0.0, 0.0, 0.0, 500.0, 500.0 + 1e-2, 1000.0, 1000.0, 1000.0], dtype=np.float32
         )
         space = BsplineSpace1D(knots, 2)
 
+        assert np.array_equal(np.asarray(space.knots), knots), "the pair must stay distinct"
         _, mult = space.get_unique_knots_and_multiplicity()
         np.testing.assert_array_equal(mult, [3, 1, 1, 3])
 
-        basis, _ = space.tabulate_basis(np.array([500.0 + 4.6e-5], dtype=np.float32))
+        basis, _ = space.tabulate_basis(np.array([500.0 + 5e-3], dtype=np.float32))
         assert np.all(np.isfinite(basis))
         np.testing.assert_allclose(basis.sum(axis=-1), 1.0, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        ("dtype", "domain", "knot", "gap", "gap_in_ulp"),
+        [
+            (np.float64, 1e12, 5e11, 5e-4, 8.2),
+            (np.float32, 1000.0, 500.0, 9.15e-5, 3.0),
+        ],
+    )
+    def test_a_gap_below_the_threshold_merges_consistently(
+        self, dtype: type[np.floating], domain: float, knot: float, gap: float, gap_in_ulp: float
+    ) -> None:
+        """A sub-threshold gap becomes one knot everywhere at once, not just in the guard.
+
+        These are the two fixtures this class used to assert stayed distinct. At
+        8.2 and 3.0 ulp of the knot they straddle they are inside the rounding of
+        computing that knot by any route, so the construction-time grouping merges
+        them. What matters -- and what the rejected in-guard scaling got wrong -- is
+        that nothing is left disagreeing afterwards: the stored knot vector, the
+        reported multiplicity and the basis all describe the same space.
+        """
+        knots = np.array([0.0, 0.0, 0.0, knot, knot + gap, domain, domain, domain], dtype=dtype)
+        eps = float(np.finfo(dtype).eps)
+        assert gap < 8.0 * eps * domain, "precondition: the gap is below the merge threshold"
+        assert gap / float(np.spacing(dtype(knot))) == pytest.approx(gap_in_ulp, rel=0.05)
+
+        space = BsplineSpace1D(knots, 2)
+
+        stored = np.asarray(space.knots)
+        assert stored[3] == stored[4] == dtype(knot), "merged onto the first of the pair"
+
+        unique, mult = space.get_unique_knots_and_multiplicity()
+        np.testing.assert_array_equal(mult, [3, 2, 3])
+        assert np.all(np.isin(np.asarray(unique), stored)), "reported knots are stored knots"
+        assert np.repeat(np.asarray(unique), mult).tolist() == stored.tolist()
+
+        basis, _ = space.tabulate_basis(np.array([knot + 0.25 * domain], dtype=dtype))
+        assert np.all(np.isfinite(basis))
+        np.testing.assert_allclose(
+            basis.sum(axis=-1), 1.0, rtol=1e-9 if dtype is np.float64 else 1e-4
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cardinal_bspline_1D.py
+++ b/tests/test_cardinal_bspline_1D.py
@@ -8,7 +8,7 @@ import numpy.typing as npt
 import pytest
 
 from pantr.basis import tabulate_cardinal_bspline_1d
-from pantr.tolerance import get_default
+from pantr.tolerance import get_default, get_strict
 
 
 class TestCardinalBspline:
@@ -43,27 +43,43 @@ class TestCardinalBspline:
         assert np.all(res >= -get_default(res.dtype))
 
     def test_outside_span(self) -> None:
+        """Points off the central span extrapolate the cubic polynomials, they are not clamped.
+
+        Checked against the closed form of the four uniform cubic B-splines on the
+        central span rather than against frozen digits, which is an independent
+        oracle (the kernel runs a de Boor recurrence) and does not move when a
+        tolerance preset does. Two of the sampled points sit ``get_default`` outside
+        the span -- dimensionally sound here because the span is ``[0, 1]``, so the
+        dimensionless preset is already in the units of the parameter.
+        """
         tol = get_default(np.float64)
-        pts = np.array(
-            [
-                -0.5,
-                -tol,
-                1.0 + tol,
-                2.0,
-            ],
-            dtype=np.float64,
-        )
+        pts = np.array([-0.5, -tol, 1.0 + tol, 2.0], dtype=np.float64)
         res = tabulate_cardinal_bspline_1d(3, pts)
-        exp = np.array(
-            [
-                [5.62500000e-01, 3.54166667e-01, 1.04166667e-01, -2.08333333e-02],
-                [1.66666667e-01, 6.66666667e-01, 1.66666667e-01, -1.66674107e-37],
-                [-1.66711121e-37, 1.66666667e-01, 6.66666667e-01, 1.66666667e-01],
-                [-1.66666667e-01, 6.66666667e-01, -8.33333333e-01, 1.33333333e00],
-            ],
-            dtype=np.float64,
+
+        u = pts
+        exp = (
+            np.stack(
+                [
+                    (1.0 - u) ** 3,
+                    3.0 * u**3 - 6.0 * u**2 + 4.0,
+                    -3.0 * u**3 + 3.0 * u**2 + 3.0 * u + 1.0,
+                    u**3,
+                ],
+                axis=-1,
+            )
+            / 6.0
         )
-        nptest.assert_allclose(res, exp)
+
+        # The basis values are O(1) and reach the output through `degree + 1` levels
+        # of convex combination, so the strict preset -- four roundings -- times that
+        # magnitude is the bound. It is an absolute bound because the two entries
+        # nearest the span ends are ~1e-43, far below the noise of an O(1)
+        # computation, and pinning their digits would be pinning noise.
+        nptest.assert_allclose(res, exp, rtol=get_strict(np.float64), atol=get_strict(np.float64))
+
+        # Extrapolation, not clamping: outside the span the polynomials leave [0, 1].
+        assert res[0].min() < 0.0
+        assert res[3].max() > 1.0
 
     def test_dtype_preservation(self) -> None:
         pts32 = np.array([0.0, 0.25, 0.5], dtype=np.float32)

--- a/tests/test_cardinal_bspline_1D.py
+++ b/tests/test_cardinal_bspline_1D.py
@@ -77,6 +77,25 @@ class TestCardinalBspline:
         # computation, and pinning their digits would be pinning noise.
         nptest.assert_allclose(res, exp, rtol=get_strict(np.float64), atol=get_strict(np.float64))
 
+        # That `atol` is twenty-one orders above the two entries at the span ends, so
+        # it says nothing about them. They are the whole reason for sampling at
+        # `+/- tol`: the point is *outside*, so the outermost basis function must be
+        # small, negative -- and not clamped to zero, which is what treating the point
+        # as the boundary would produce. Checked relatively, against `-tol**3 / 6`,
+        # which both of them are: at `-tol` the last basis function is `u**3 / 6` and
+        # at `1 + tol` the first is `(1 - u)**3 / 6`.
+        #
+        # 5% is as tight as this can be, and the reason is worth stating: a value of
+        # order `tol**3` is being produced by a recurrence whose inputs are O(1), so
+        # its relative accuracy is limited by how exactly those inputs reproduce `u`,
+        # not by the recurrence. The measured deviation is 1/64 at `-tol` and nothing
+        # at `1 + tol`. That is still four orders of margin over what this is for --
+        # separating a cubic extrapolation from a clamp to zero.
+        for row, col in ((1, 3), (2, 0)):
+            outside = float(res[row, col])
+            assert outside < 0.0, f"row {row} was clamped to {outside!r} instead of extrapolating"
+            nptest.assert_allclose(outside, -(tol**3) / 6.0, rtol=0.05)
+
         # Extrapolation, not clamping: outside the span the polynomials leave [0, 1].
         assert res[0].min() < 0.0
         assert res[3].max() > 1.0

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -121,6 +121,34 @@ def test_overlay_merge_verdict_is_scale_covariant(lam: float) -> None:
     assert far.breakpoints[0].shape[0] == 4
 
 
+def test_overlay_tolerance_follows_the_offset_not_only_the_window() -> None:
+    """A short window far from the origin is graded on the coordinates, not its length.
+
+    The other covariance test rescales both the window and its position together, so
+    the window always dominates ``max(hi - lo, |lo|, |hi|)``. This is the other branch:
+    a window of 400 ulp sitting at 1e10, where the *offset* sets the tolerance
+    (``get_default(float64) * 1e10 = 1.42e-4``, about 75 ulp there). An interior
+    breakpoint further than that from both ends survives; one closer to an end than
+    that is folded into it, which is what merging means and not a loss -- the end is
+    emitted regardless.
+    """
+    lo = 1e10
+    ulp = float(np.spacing(lo))
+    hi = lo + 400.0 * ulp
+    plain = TensorProductGrid([[lo, hi]])
+
+    kept = overlay(TensorProductGrid([[lo, lo + 200.0 * ulp, hi]]), plain)
+    assert kept.breakpoints[0].shape[0] == 3, (
+        "a breakpoint 200 ulp from both ends is outside the ~75 ulp tolerance and must survive"
+    )
+
+    folded = overlay(TensorProductGrid([[lo, lo + 30.0 * ulp, hi]]), plain)
+    assert folded.breakpoints[0].shape[0] == 2, (
+        "a breakpoint 30 ulp from the lower end is inside the tolerance and must fold into it"
+    )
+    nptest.assert_array_equal(folded.breakpoints[0], [lo, hi])
+
+
 def test_overlay_ndim_mismatch_raises() -> None:
     """Mismatched ndim is a ValueError."""
     with pytest.raises(ValueError, match="share ndim"):

--- a/tests/test_grid_overlay.py
+++ b/tests/test_grid_overlay.py
@@ -79,9 +79,14 @@ def test_overlay_restricts_to_domain_intersection() -> None:
 
 
 def test_overlay_merges_near_coincident_breakpoints() -> None:
-    """Breakpoints closer than the float64 tolerance collapse into one."""
+    """Breakpoints closer than the tolerance collapse into one.
+
+    The merge tolerance is ``get_default(float64) * window = 1.42e-14`` here, so
+    the separation below is well inside it (9 ulp at 0.5) while remaining a
+    perfectly representable pair.
+    """
     a = TensorProductGrid([[0.0, 0.5, 1.0]])
-    b = TensorProductGrid([[0.0, 0.5 + 1e-13, 1.0]])
+    b = TensorProductGrid([[0.0, 0.5 + 1e-15, 1.0]])
     result = overlay(a, b)
     nptest.assert_allclose(result.breakpoints[0], [0.0, 0.5, 1.0])
 
@@ -92,6 +97,28 @@ def test_overlay_keeps_distinct_close_breakpoints() -> None:
     b = TensorProductGrid([[0.0, 0.5 + 1e-3, 1.0]])
     result = overlay(a, b)
     assert result.breakpoints[0].shape[0] == 4
+
+
+@pytest.mark.parametrize("lam", [1e-6, 1.0, 1e6])
+def test_overlay_merge_verdict_is_scale_covariant(lam: float) -> None:
+    """The same breakpoints in units of ``lam`` get the same verdict at every ``lam``.
+
+    The tolerance is relative to the axis's own magnitude, so a separation of
+    ``1e-15 * lam`` merges and one of ``1e-3 * lam`` does not, whatever ``lam`` is.
+    An absolute tolerance merged everything at ``lam = 1e-6`` and nothing at
+    ``lam = 1e6``.
+    """
+    near = overlay(
+        TensorProductGrid([[0.0, 0.5 * lam, 1.0 * lam]]),
+        TensorProductGrid([[0.0, 0.5 * lam + 1e-15 * lam, 1.0 * lam]]),
+    )
+    assert near.breakpoints[0].shape[0] == 3
+
+    far = overlay(
+        TensorProductGrid([[0.0, 0.5 * lam, 1.0 * lam]]),
+        TensorProductGrid([[0.0, 0.5 * lam + 1e-3 * lam, 1.0 * lam]]),
+    )
+    assert far.breakpoints[0].shape[0] == 4
 
 
 def test_overlay_ndim_mismatch_raises() -> None:

--- a/tests/test_knot_tolerance_absolute.py
+++ b/tests/test_knot_tolerance_absolute.py
@@ -1,11 +1,19 @@
 """Knot-layer predicates must use an absolute tolerance, not ``np.isclose``.
 
-Every tolerance in :mod:`pantr.tolerance` is documented as **absolute**: a fixed
-value per dtype, independent of the magnitude of the values compared. But
-``np.isclose(a, b, atol=tol)`` keeps numpy's default ``rtol=1e-5``, so the test it
-actually performs is ``|a - b| <= tol + 1e-5 * |b|``. Every knot-layer predicate
-written that way therefore widened by ``1e-5`` times the operand magnitude, which
-is harmless on a unit domain and catastrophic on a large one.
+Every knot-layer predicate grades a parametric length against
+:attr:`~pantr.bspline.BsplineSpace1D.tolerance`, which is **absolute**: it already
+carries the knot vector's own magnitude, so the comparison must be a plain
+``|a - b| <= tol`` and nothing else. But ``np.isclose(a, b, atol=tol)`` keeps
+numpy's default ``rtol=1e-5``, so the test it actually performs is
+``|a - b| <= tol + 1e-5 * |b|``. Every predicate written that way therefore widened
+by ``1e-5`` times the operand magnitude -- a second, undeclared relative term on top
+of the derived one -- which is harmless on a unit domain and catastrophic on a large
+one.
+
+(The presets in :mod:`pantr.tolerance` are dimensionless relative factors; it is
+``_bspline_knots._knot_tolerance`` that turns one into the absolute length this file
+is about. ``TestDerivedKnotTolerance`` at the end pins that derivation and the
+properties the knot layer rests on.)
 
 Two further properties of the leak are worth pinning, because they are what makes
 it hard to spot:
@@ -39,6 +47,7 @@ from pantr.bspline import (
 )
 from pantr.bspline._bspline_knots import (
     _find_knot_index_and_multiplicity,
+    _get_unique_knots_and_multiplicity_impl,
     _is_in_domain_impl,
 )
 from pantr.bspline._bspline_product import _get_boundary_mults
@@ -456,3 +465,135 @@ class TestTHBRootBounds:
         space = THBSplineSpace(root, grid)
 
         assert space.dim == 1
+
+
+class TestDerivedKnotTolerance:
+    """The absolute knot tolerance itself: its formula, and what rests on it.
+
+    Everything above tests a *consequence* of ``BsplineSpace1D.tolerance``. These
+    test the quantity, so that a one-line slip in the formula -- dropping the
+    coordinate-magnitude term, taking a ``min`` where a ``max`` belongs -- surfaces
+    here rather than several steps downstream as a puzzling merge verdict.
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("dtype", "knots", "expected_scale", "why"),
+        [
+            (np.float64, [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0], 2.0, "span wins"),
+            (np.float64, [-3.0, -3.0, -3.0, -2.0, -1.0, -1.0, -1.0], 3.0, "|knots[0]| wins"),
+            (
+                np.float64,
+                [1e6, 1e6, 1e6, 1e6 + 0.5, 1e6 + 1, 1e6 + 1, 1e6 + 1],
+                1e6 + 1.0,
+                "|knots[-1]| wins over a span of 1",
+            ),
+            (np.float32, [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 1.0, "the same in float32"),
+        ],
+    )
+    def test_tolerance_is_eight_epsilons_of_the_knot_magnitude(
+        dtype: type[np.floating], knots: list[float], expected_scale: float, why: str
+    ) -> None:
+        """``tolerance == 8 * eps(dtype) * max(span, |knots[0]|, |knots[-1]|)``.
+
+        ``expected_scale`` is written out per case rather than computed by the
+        helper under test, so the two cannot agree by sharing a bug.
+        """
+        space = BsplineSpace1D(np.asarray(knots, dtype=dtype), 2)
+        eps = float(np.finfo(dtype).eps)
+        assert space.tolerance == 8.0 * eps * expected_scale, why
+
+    @staticmethod
+    @pytest.mark.parametrize("lam", [1e-6, 1.0, 1e6])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_merge_verdict_is_scale_covariant(dtype: type[np.floating], lam: float) -> None:
+        """The same gap-to-domain ratio gets the same verdict at every scale.
+
+        This is the central claim of the derived tolerance, and it is the one the
+        previous absolute constant failed: it merged every knot of this fixture at
+        ``lam = 1e-6`` and none of them at ``lam = 1e6``.
+        """
+        for ratio, want in ((1e-15, [3, 2, 3]), (1e-3, [3, 1, 1, 3])):
+            mid = dtype(0.5 * lam)
+            knots = np.asarray(
+                [0.0, 0.0, 0.0, mid, dtype(float(mid) * (1.0 + ratio)), lam, lam, lam],
+                dtype=dtype,
+            )
+            space = BsplineSpace1D(knots, 2)
+            _, mult = space.get_unique_knots_and_multiplicity()
+            assert mult.tolist() == want, (
+                f"gap ratio {ratio:g} at lam={lam:g} in {np.dtype(dtype).name} gave "
+                f"multiplicities {mult.tolist()}, expected {want}"
+            )
+
+    @staticmethod
+    def test_snapping_is_idempotent() -> None:
+        """Snapping a snapped vector must not move it again, bit for bit.
+
+        The exact ``denom == 0.0`` Cox-de Boor guard wants a knot vector that is a
+        fixed point of the grouping, and electing each class's first knot rather
+        than its mean is what delivers one. An average would be a fresh rounding
+        and could place two neighbouring representatives back within tolerance.
+        """
+        base = 1000.0
+        eps = float(np.finfo(np.float64).eps)
+        near = 8.0 * eps * base * 0.25  # a quarter of the merge tolerance
+        raw = np.array(
+            [
+                0.0,
+                0.0,
+                0.0,
+                250.0,
+                250.0 + near,
+                250.0 + 2 * near,
+                500.0,
+                750.0 - near,
+                750.0,
+                base,
+                base,
+                base,
+            ],
+            dtype=np.float64,
+        )
+        once = np.asarray(BsplineSpace1D(raw, 2).knots)
+        assert not np.array_equal(once, raw), "precondition: the fixture must actually merge"
+
+        twice = np.asarray(BsplineSpace1D(once, 2).knots)
+        assert np.array_equal(once, twice), (
+            f"snapping moved an already-snapped vector: {once.tolist()} -> {twice.tolist()}"
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_classes_partition_the_knot_vector(dtype: type[np.floating]) -> None:
+        """``np.repeat(unique, mults)`` rebuilds the whole vector, which ``_snap_knots`` needs.
+
+        ``BsplineSpace1D._snap_knots`` *is* that ``np.repeat``, so if the
+        multiplicities stopped summing to ``knots.size`` the space would silently
+        change length. Checked directly on the kernel, with ``in_domain=False``.
+        """
+        raw = np.asarray([0.0, 0.0, 0.0, 0.25, 0.5, 0.5, 0.75, 1.0, 1.0, 1.0], dtype=dtype)
+        space = BsplineSpace1D(raw, 2)
+        knots = np.asarray(space.knots)
+        unique, mults = _get_unique_knots_and_multiplicity_impl(
+            knots, space.degree, space.tolerance, False
+        )
+        assert int(mults.sum()) == knots.size
+        assert np.array_equal(np.repeat(np.asarray(unique), mults), knots)
+        assert np.all(np.isin(np.asarray(unique), knots)), "reported knots must be stored knots"
+
+    @staticmethod
+    def test_a_knot_vector_with_no_scale_compares_exactly() -> None:
+        """An identically-zero knot vector leaves no magnitude to be relative to.
+
+        ``_knot_scale`` returns 0.0 and the tolerance with it, so grouping falls back
+        to exact equality. That is the only defensible answer -- there is no scale to
+        read off the input -- and the vector is all one knot either way. Pinned
+        because a zero tolerance is the kind of degenerate value that invites a
+        well-meaning floor.
+        """
+        space = BsplineSpace1D(np.zeros(8, dtype=np.float64), 3)
+        assert space.tolerance == 0.0
+        unique, mults = space.get_unique_knots_and_multiplicity()
+        assert unique.tolist() == [0.0]
+        assert mults.tolist() == [8]

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -391,38 +391,62 @@ def test_snapping_preserves_a_run_of_identical_knots() -> None:
         )
 
 
-def test_a_domain_below_its_own_resolution_collapses() -> None:
-    """A knot vector whose span is inside its own coordinate noise becomes one knot.
+def test_a_domain_below_its_own_resolution_is_refused() -> None:
+    """A knot vector whose spacing is inside its own coordinate noise is rejected.
 
-    Not a defect but the contract, recorded because it is the one thing the merge rule
-    takes away. The tolerance is ``8 * eps * max(span, |knots[0]|, |knots[-1]|)``, so the
-    span itself is swallowed once ``offset / span`` exceeds ``1 / (8 * eps)`` -- about
-    5.2e5 in float32 and 5.6e14 in float64.
+    Not a defect but the contract, and the one thing the merge rule takes away. The
+    tolerance is ``8 * eps * max(span, |knots[0]|, |knots[-1]|)``, so a mesh of ``n``
+    intervals over a span ``s`` at offset ``x`` survives only while
+    ``s / n > 8 * eps * max(s, |x|)``; once ``|x|`` dominates that fails at
+    ``|x| / s = 1 / (8 * eps * n)``, about ``5.2e5 / n`` in float32.
 
-    ``[1e6, 1e6 + 1]`` in float32 is past that: the ulp there is 0.0625, so the whole
-    domain holds 16 representable coordinates and an interior knot computed by any route
-    is uncertain by ``eps * 1e6 = 0.06``, six percent of the span. There is no mesh to
-    resolve, and the space says so by collapsing rather than by pretending the knots are
-    distinct. The same vector in float64 keeps every knot, which is the point: what
+    ``[1e6, 1e6 + 1]`` in float32 is past it: the ulp there is 0.0625, so the whole
+    window holds 16 representable coordinates and an interior knot computed by any route
+    is uncertain by ``eps * 1e6 = 0.06``, six percent of the span. No threshold keeps
+    such a mesh *and* merges two routes to one knot, so the space cannot be built, and
+    saying so beats collapsing silently -- which is what an earlier version of this
+    change did, and what turned 525 sweep cases into opaque failures deep in the
+    kernels. The same vector in float64 keeps every knot, which is the point: what
     decides is the format's resolution at that magnitude, not the magnitude.
     """
     degree = 2
     lo, hi = 1e6, 1e6 + 1.0
     raw = [lo] * (degree + 1) + [lo + 0.5] + [hi] * (degree + 1)
 
-    collapsed = BsplineSpace1D(np.asarray(raw, dtype=np.float32), degree)
-    stored32 = np.asarray(collapsed.knots)
-    assert np.all(stored32 == np.float32(lo)), (
-        f"float32 [{lo}, {hi}] spans {(hi - lo) / float(np.spacing(np.float32(hi))):.0f} "
-        f"ulp, below the {8 * float(np.finfo(np.float32).eps) * hi:.3g} merge tolerance, "
-        f"so it must collapse; got {stored32.tolist()}"
-    )
+    with pytest.raises(ValueError, match="collapsed every knot") as excinfo:
+        BsplineSpace1D(np.asarray(raw, dtype=np.float32), degree)
+    message = str(excinfo.value)
+    # The message has to let the reader act without opening our source.
+    assert "float32" in message, message
+    assert "0.5 apart" in message, message
+    assert "Use float64" in message, message
 
     resolved = BsplineSpace1D(np.asarray(raw, dtype=np.float64), degree)
     assert np.array_equal(np.asarray(resolved.knots), np.asarray(raw, dtype=np.float64)), (
         "the same vector in float64 resolves easily and must be left alone"
     )
     assert resolved.num_intervals == 2
+
+
+def test_an_already_degenerate_knot_vector_is_still_accepted() -> None:
+    """The refusal fires only when *snapping* destroyed the mesh, not when it arrived flat.
+
+    A caller who passes a knot vector that is already a single repeated value asked for
+    exactly that and gets it, at any magnitude and in either dtype. Distinguishing the
+    two is what keeps the new rejection from being a general ban on degenerate spaces:
+    the case worth refusing is the one the caller could not see coming.
+    """
+    for dtype in (np.float32, np.float64):
+        for value in (0.0, 1.0, 1e6, -3.5):
+            space = BsplineSpace1D(np.full(8, value, dtype=dtype), 3)
+            assert space.num_intervals == 0
+            assert np.all(np.asarray(space.knots) == dtype(value))
+
+    # And `snap_knots=False` bypasses merging and the check together, as documented.
+    lo, hi = 1e6, 1e6 + 1.0
+    raw = np.asarray([lo, lo, lo, lo + 0.5, hi, hi, hi], dtype=np.float32)
+    kept = BsplineSpace1D(raw, 2, snap_knots=False)
+    assert np.array_equal(np.asarray(kept.knots), raw)
 
 
 def test_snapping_keeps_knots_the_format_can_resolve() -> None:

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,7 +7,7 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Seven markers have already come off here: the domain-membership test, closed by the
+Eleven markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
 truncating the rule where the endpoint gap stops being resolvable; the Lagrange
 reproducibility test, closed by seeding the barycentric node permutation; the float32
@@ -17,14 +17,16 @@ boundary-multiplicity precondition; the degree-elevation counter mismatch, close
 emitting the unshared Bézier coefficient at a C^-1 knot and by letting the segment sweep
 reach the final span of a degree-0 knot vector; and the root finder that certified a value
 that is not a root, closed by evaluating the residual on every exit of the tracking and by
-holding the repeated-iterate stop to Corollary 14's actual hypothesis.
+holding the repeated-iterate stop to Corollary 14's actual hypothesis; and four closed
+together by the tolerance-semantics pass -- the two knot-snapping tests and the unique-knot
+accessor directly, and the restriction that returned a shorter domain than asked for as a
+consequence, since its ``b_new + tol`` step ceased to be a no-op once ``tol`` carried the
+knot vector's magnitude.
 
-Seven remain open. Three are the tolerance workstream's. The other four come from the
-August 2026 triage of the full profile's 496 findings, which collapsed them into a dozen
-mechanisms: a restriction that silently returns a shorter domain than it was asked for, a
-Lagrange extraction that cannot be built on a degree-0 space its two sibling extractions
-handle, a change of basis that reports numpy's `LinAlgError` for a legal degree, and a
-unique-knot accessor that returns knots the space does not contain.
+Three remain open, all from the August 2026 triage of the full profile: knot-vector
+factories that disagree with their own documentation at zero intervals, a Lagrange
+extraction that cannot be built on a degree-0 space its two sibling extractions handle, and
+a change of basis that reports numpy's `LinAlgError` for a legal degree.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -298,7 +300,18 @@ def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
     lo, hi = 1e6, 1e6 + 1.0
     knots = np.concatenate([np.full(3, lo), [lo + 0.5], np.full(3, hi)])
     space = BsplineSpace1D(knots, 2)
-    assert float(space.tolerance) < 1e-9, "precondition: the space carries a strict tolerance"
+    # Two-sided, and stating it that way is what makes it survive a change in how the
+    # tolerance is derived: it must be at least one ulp of the endpoint (below that the
+    # endpoint is not resolvable and legitimate in-domain points get rejected) and far
+    # below the domain length (above that the rejection this test asks for stops
+    # happening). It used to read `< 1e-9`, which was the old per-dtype constant seen
+    # through this fixture rather than a property of it.
+    endpoint_ulp = float(np.spacing(hi))
+    assert endpoint_ulp <= float(space.tolerance) < 1e-3 * (hi - lo), (
+        f"precondition: the tolerance ({float(space.tolerance):.3e}) must resolve the "
+        f"endpoint (ulp {endpoint_ulp:.3e}) without approaching the domain length "
+        f"({hi - lo:g})"
+    )
 
     with pytest.raises(ValueError, match="outside the knot vector domain"):
         # 10 domain lengths past the right end.
@@ -318,18 +331,19 @@ def test_out_of_domain_points_are_rejected_at_large_knot_magnitude() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_snap_knots averages each group of equal knots, and np.mean over a run of "
-    "degree + 1 identical knots is not the identity at large coordinate magnitude",
-)
 def test_snapping_preserves_a_run_of_identical_knots() -> None:
-    # `_snap_knots` (`_bspline_space_1d.py:215`) replaces every group of knots that round
-    # to the same grid point by `np.mean(group, dtype=self.dtype)`. For a clamped end the
-    # group is `degree + 1` copies of one value, so the mean must be that value exactly.
-    # It is not: the summation loses the low bits once `(degree + 1) * |knot|` passes the
+    # FIXED by electing each group's *first* knot as its representative instead of the
+    # group's mean (`BsplineSpace1D._snap_knots`). Kept as a regression guard with its
+    # original triggering data, per this repository's convention that the fix PR un-xfails
+    # the tests it closes. Choosing rather than averaging is also what makes snapping
+    # idempotent, which is the property the exact `denom == 0.0` Cox-de Boor guard wants.
+    #
+    # What it was: `_snap_knots` replaced every group of knots that round to the same grid
+    # point by `np.mean(group, dtype=self.dtype)`. For a clamped end the group is
+    # `degree + 1` copies of one value, so the mean must be that value exactly.
+    # It was not: the summation loses the low bits once `(degree + 1) * |knot|` passes the
     # format's exact-integer range (2^24 for float32, 2^53 for float64), and the knot
-    # moves by 0.125. The consequence is that the space's *reported domain* differs from
+    # moved by 0.125. The consequence was that the space's *reported domain* differed from
     # the one the caller asked for, silently.
     #
     # Which run lengths survive is **not** a clean rule, and it is worth not pretending
@@ -339,43 +353,103 @@ def test_snapping_preserves_a_run_of_identical_knots() -> None:
     # exact. So this bites from **degree 10** in float64 at that magnitude, and the two
     # degrees asserted below are simply the ones the sweep happened to visit -- do not
     # read them as a threshold.
-    for dtype, base in ((np.float32, 1e6), (np.float64, 1e15)):
+    #
+    # One thing moved when the fix landed, and only one: the domain's *lower* end. The
+    # original fixture ran from `base` to `base + 1`, which the merge tolerance now
+    # (correctly) swallows whole -- at float32 a span of 1 sitting at 1e6 is 16 ulp wide,
+    # so every knot in it is within `8 * eps * 1e6 = 0.95` of every other and the whole
+    # vector is one knot. That is a different phenomenon and it is asserted separately in
+    # `test_a_domain_below_its_own_resolution_collapses`. The run values that trigger
+    # *this* bug -- 1000001.0 and 1000000000000001.0, whose means over 63 copies are
+    # 1000000.875 and 1000000000000000.9 -- are unchanged; the lower end simply moves to
+    # zero so the span is resolvable and the knots stay distinct.
+    cases: tuple[tuple[type[np.floating], float], ...] = ((np.float32, 1e6), (np.float64, 1e15))
+    for dtype, base in cases:
         degree = 62
         hi = np.asarray(base + 1.0, dtype=dtype)
+        mid = np.asarray(0.5 * float(hi), dtype=dtype)
         raw = np.concatenate(
             [
-                np.full(degree + 1, base, dtype=dtype),
-                [np.asarray(base + 0.5, dtype=dtype)],
+                np.full(degree + 1, 0.0, dtype=dtype),
+                [mid],
                 np.full(degree + 1, hi, dtype=dtype),
             ]
+        )
+        run = np.full(degree + 1, hi, dtype=dtype)
+        assert float(np.mean(run, dtype=dtype)) != float(hi), (
+            f"{np.dtype(dtype).name}: precondition -- averaging the run must still be "
+            f"inexact, or this fixture no longer reaches the bug"
         )
         stored = np.asarray(BsplineSpace1D(raw, degree).knots)
         assert stored[-1] == hi, (
             f"{np.dtype(dtype).name}: snapping moved a run of {degree + 1} identical "
             f"knots from {float(hi)!r} to {float(stored[-1])!r}"
         )
+        assert stored[degree + 1] == mid, (
+            f"{np.dtype(dtype).name}: the interior knot must stay where it was, at "
+            f"{float(mid)!r}, not {float(stored[degree + 1])!r}"
+        )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the knot-snapping grid is an absolute tolerance, so on a small domain it "
-    "merges knots the format resolves easily and the space silently loses intervals",
-)
+def test_a_domain_below_its_own_resolution_collapses() -> None:
+    """A knot vector whose span is inside its own coordinate noise becomes one knot.
+
+    Not a defect but the contract, recorded because it is the one thing the merge rule
+    takes away. The tolerance is ``8 * eps * max(span, |knots[0]|, |knots[-1]|)``, so the
+    span itself is swallowed once ``offset / span`` exceeds ``1 / (8 * eps)`` -- about
+    5.2e5 in float32 and 5.6e14 in float64.
+
+    ``[1e6, 1e6 + 1]`` in float32 is past that: the ulp there is 0.0625, so the whole
+    domain holds 16 representable coordinates and an interior knot computed by any route
+    is uncertain by ``eps * 1e6 = 0.06``, six percent of the span. There is no mesh to
+    resolve, and the space says so by collapsing rather than by pretending the knots are
+    distinct. The same vector in float64 keeps every knot, which is the point: what
+    decides is the format's resolution at that magnitude, not the magnitude.
+    """
+    degree = 2
+    lo, hi = 1e6, 1e6 + 1.0
+    raw = [lo] * (degree + 1) + [lo + 0.5] + [hi] * (degree + 1)
+
+    collapsed = BsplineSpace1D(np.asarray(raw, dtype=np.float32), degree)
+    stored32 = np.asarray(collapsed.knots)
+    assert np.all(stored32 == np.float32(lo)), (
+        f"float32 [{lo}, {hi}] spans {(hi - lo) / float(np.spacing(np.float32(hi))):.0f} "
+        f"ulp, below the {8 * float(np.finfo(np.float32).eps) * hi:.3g} merge tolerance, "
+        f"so it must collapse; got {stored32.tolist()}"
+    )
+
+    resolved = BsplineSpace1D(np.asarray(raw, dtype=np.float64), degree)
+    assert np.array_equal(np.asarray(resolved.knots), np.asarray(raw, dtype=np.float64)), (
+        "the same vector in float64 resolves easily and must be left alone"
+    )
+    assert resolved.num_intervals == 2
+
+
 def test_snapping_keeps_knots_the_format_can_resolve() -> None:
-    # `_snap_knots` rounds onto a grid of width `tolerance`, which is absolute
-    # (`get_strict(float32) = 1e-7`, `get_strict(float64) = 1e-15`) while the quantity it
-    # grades -- a gap between knots -- carries the domain's scale. On `[0, 1e-6]` with 20
-    # equal intervals the spacing is 5e-8, below the float32 grid, so half the knots are
-    # merged and the space reports 10 intervals instead of 20. The float32 ulp at 1e-6 is
-    # 6e-14, so the format resolves those knots with six orders to spare: nothing about
-    # the input is unrepresentable.
+    # FIXED by deriving the snapping tolerance from the knot vector's own magnitude
+    # instead of from the dtype alone (`_bspline_knots._knot_tolerance`), and by grouping
+    # knots by relative gap rather than by rounding them onto a grid. Kept as a regression
+    # guard with its original triggering data, per this repository's convention that the
+    # fix PR un-xfails the tests it closes.
     #
-    # This is the small-domain face of an already-recorded tolerance-policy defect whose
-    # large-domain face is that from |knot| ~ 5 upward the same grid merges nothing at all.
-    # Further consequences measured at degree 62 on `[0, 1e-6]` in float32, where a
-    # periodic knot vector of 63 intervals collapses to 10: zero-length spans make
+    # What it was: `_snap_knots` rounded onto a grid of width `tolerance`, which was
+    # absolute (`get_strict(float32) = 1e-7`, `get_strict(float64) = 1e-15`) while the
+    # quantity it grades -- a gap between knots -- carries the domain's scale. On
+    # `[0, 1e-6]` with 20 equal intervals the spacing is 5e-8, below the float32 grid, so
+    # half the knots were merged and the space reported 10 intervals instead of 20. The
+    # float32 ulp at 1e-6 is 6e-14, so the format resolves those knots with six orders to
+    # spare: nothing about the input is unrepresentable.
+    #
+    # It was the small-domain face of one defect whose large-domain face was that from
+    # |knot| ~ 5 upward the same grid merged nothing at all, not even a 1-ulp discrepancy.
+    # The tolerance is now `8 * eps * max(span, |knots[0]|, |knots[-1]|)`, which here is
+    # 7.6e-12 against a spacing of 5e-8, so the intervals survive with four orders to
+    # spare and would survive equally at any other domain scale.
+    #
+    # Further consequences that were measured at degree 62 on `[0, 1e-6]` in float32,
+    # where a periodic knot vector of 63 intervals collapsed to 10: zero-length spans made
     # `tabulate_Bezier_extraction_operators` raise a bare `ZeroDivisionError`, and the
-    # basis sums to 0 instead of 1 at the right endpoint.
+    # basis summed to 0 instead of 1 at the right endpoint.
     n_intervals = 20
     hi = 1e-6
     breaks = np.linspace(0.0, hi, n_intervals + 1, dtype=np.float32)
@@ -716,13 +790,20 @@ def test_find_roots_returns_only_genuine_roots() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="restrict adds an absolute 1e-15 to the upper bound to step past its last "
-    "copy, and that addition is a no-op once the bound reaches 16, so searchsorted "
-    "lands one clamp too early and the top of the window is cut off",
-)
 def test_restrict_spans_the_requested_window() -> None:
+    # FIXED, though not at this site: `tol` here is `space.tolerance`, which now carries
+    # the knot vector's own magnitude (`8 * eps * max(span, |knots[0]|, |knots[-1]|)`)
+    # instead of a per-dtype constant. Since one ulp of any coordinate in the vector is at
+    # most `eps * scale`, the addition below now always moves the bound by at least eight
+    # ulp and can no longer be a no-op at any magnitude -- which is the whole mechanism
+    # this test pinned. It also steps no further than intended, because distinct knots are
+    # now separated by more than that same tolerance by construction. Kept as a regression
+    # guard with its original triggering data, per this repository's convention that the
+    # fix PR un-xfails the tests it closes.
+    #
+    # The site's own tolerance policy was not otherwise revisited, so if `restrict` grows
+    # a tolerance of its own this guard is what will catch a return of the mechanism.
+    #
     # A silent wrong answer through the public API, and the reason it stayed hidden is
     # worth as much as the bug: `Bspline.restrict` carried no invariant in the sweep, so
     # the case was graded only on whether it raised.
@@ -908,40 +989,41 @@ def test_cardinal_change_of_basis_reports_its_own_conditioning_limit() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_get_unique_knots_and_multiplicity_impl returns the tolerance-grid-rounded "
-    "knots instead of the originals it already indexed, so a breakpoint is relocated "
-    "whenever the absolute grid is coarse relative to the knot spacing",
-)
 def test_unique_knots_are_knots_of_the_space() -> None:
-    # `get_unique_knots_and_multiplicity` is meant to *report* the distinct knots of a
-    # space. It reports different numbers. On a float32 space over [0, 1e-6] whose stored
-    # interior knots are 2.5e-7, 5.0e-7 and 7.5e-7, the accessor answers 2.0e-7, 5.0e-7
-    # and 8.0e-7 -- each moved by 20% of its own value, to a knot the space does not have.
+    # FIXED by grouping knots by relative gap and returning the class's first *stored*
+    # knot, and by rebuilding `_snap_knots` on top of the same helper so the two can no
+    # longer disagree. Kept as a regression guard with its original triggering data, per
+    # this repository's convention that the fix PR un-xfails the tests it closes.
     #
-    # `_get_unique_knots_and_multiplicity_impl` (`_bspline_knots.py:107-110, 138`) rounds
+    # What it was: `get_unique_knots_and_multiplicity` is meant to *report* the distinct
+    # knots of a space, and it reported different numbers. On a float32 space over
+    # [0, 1e-6] whose stored interior knots are 2.5e-7, 5.0e-7 and 7.5e-7, the accessor
+    # answered 2.0e-7, 5.0e-7 and 8.0e-7 -- each moved by 20% of its own value, to a knot
+    # the space does not have.
+    #
+    # `_get_unique_knots_and_multiplicity_impl` rounded
     # onto a grid of width `tol` to decide which knots are the same,
     #
     #     scale = dtype.type(1.0 / tol)
     #     rounded_knots = np.round(knots * scale) / scale
     #
-    # and then returns `rounded_knots[unique_rounded_knots_ids]` -- the rounded values --
-    # although `unique_rounded_knots_ids` already indexes the *original* array and
+    # and then returned `rounded_knots[unique_rounded_knots_ids]` -- the rounded values --
+    # although `unique_rounded_knots_ids` already indexed the *original* array and
     # `knots[...]` would have returned the knots themselves. Its sibling `_snap_knots`
-    # (`_bspline_space_1d.py:207-218`) does the same grouping and deliberately does not
-    # make this mistake: it writes back `np.mean(self._knots[mask])`, with a comment about
-    # the care being taken. The two helpers implement one idea and disagree.
+    # did the same grouping and deliberately did not make this mistake: it wrote back
+    # `np.mean(self._knots[mask])`, with a comment about the care being taken. Two
+    # implementations of one idea, disagreeing. There is now one: `_snap_knots` calls this
+    # helper and repeats its classes, so the space and its accessor cannot diverge.
     #
-    # `tol` here is the space's absolute tolerance (`get_strict(float32) = 1e-7`), so the
-    # grid is coarse compared with a 2.5e-7 spacing and 2.5 rounds to 2 while 7.5 rounds
-    # to 8. Nothing about the input is unrepresentable: the float32 ulp at 2.5e-7 is
-    # 1.7e-14, seven orders of magnitude finer than the movement.
+    # `tol` was the space's absolute tolerance (`get_strict(float32) = 1e-7`), so the
+    # grid was coarse compared with a 2.5e-7 spacing and 2.5 rounded to 2 while 7.5
+    # rounded to 8. Nothing about the input is unrepresentable: the float32 ulp at 2.5e-7
+    # is 1.7e-14, seven orders of magnitude finer than the movement.
     #
-    # The float64 face is milder and still wrong: 2.5e-07 comes back as
+    # The float64 face was milder and still wrong: 2.5e-07 came back as
     # 2.5000000000000004e-07, because `round(x * scale) / scale` is not the identity even
-    # when the grouping changes nothing. The accessor never returns the array it was
-    # given.
+    # when the grouping changes nothing. The accessor never returned the array it was
+    # given; it now returns entries of it.
     #
     # Consequences, and why this outranks a reporting nuisance. The helper feeds
     # `to_beziers`, knot insertion and removal, quasi-interpolation, and the product's
@@ -950,9 +1032,9 @@ def test_unique_knots_are_knots_of_the_space() -> None:
     # spline on [0, 1e-6] returns a curve whose interior knots sit at 0.2/0.5/0.8 of the
     # domain instead of 0.25/0.5/0.75, and which is wrong by 8.0e-2 *relative* at points
     # nowhere near a knot. Silent, through the public API. The same operands in float64,
-    # and the same float32 operands on the unit domain, are exact to rounding -- so this
-    # is the absolute-tolerance-versus-coordinate-magnitude family, and belongs with that
-    # workstream rather than being fixed here.
+    # and the same float32 operands on the unit domain, were exact to rounding -- which is
+    # what identified it as the absolute-tolerance-versus-coordinate-magnitude family it
+    # was fixed with.
     #
     # Found only after the probe's product invariant stopped sampling at the C^-1
     # breakpoint: the 8% error had been sitting underneath a 15-40% artifact.

--- a/tests/test_tolerance.py
+++ b/tests/test_tolerance.py
@@ -1,15 +1,21 @@
-"""Tests for tolerance utilities."""
+"""Tests for tolerance utilities.
+
+The presets are **dimensionless relative** tolerances, ``K * eps(dtype)`` with a
+safety factor ``K`` that is the same in every precision. The tests below pin that
+shape rather than a table of twelve numbers: the constancy of ``K`` across dtypes,
+the ordering of the three tiers, ``K`` being an exact power of two, and every
+preset being at least one epsilon (the defect the previous table had -- its strict
+float16 and float32 entries were *below* one ulp at 1.0, so they asked for bitwise
+equality). The two dtypes the library actually uses are additionally pinned to
+their literal values, so a silent drift in ``K`` is caught.
+"""
 
 from __future__ import annotations
 
-import importlib
-import sys
-import types
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 import pytest
-from numpy import typing as npt
 
 from pantr.tolerance import (
     get_conservative,
@@ -19,76 +25,114 @@ from pantr.tolerance import (
     get_strict,
 )
 
-tol_mod = sys.modules["pantr.tolerance"]
+DTYPES: tuple[Any, ...] = (np.float16, np.float32, np.float64, np.longdouble)
+"""Every floating dtype the tolerance module accepts."""
 
-NO_LONGDOUBLE = np.dtype(np.longdouble) == np.dtype(np.float64)
+PRESETS: tuple[tuple[str, Any, float], ...] = (
+    ("strict", get_strict, 4.0),
+    ("default", get_default, 64.0),
+    ("conservative", get_conservative, 4096.0),
+)
+"""Each preset with the number of machine epsilons its docstring claims."""
 
-DEFAULT_TOL_F32: float = 1e-6
-DEFAULT_TOL_F64: float = 1e-12
-DEFAULT_TOL_LD: float = DEFAULT_TOL_F64 if NO_LONGDOUBLE else 1e-15
+STRICT_TOL_F32: float = 4.76837158203125e-07
+"""``4 * eps(float32)``, written out so a change to the factor is visible here."""
 
-STRICT_TOL_F64: float = 1e-15
-STRICT_TOL_LD: float = STRICT_TOL_F64 if NO_LONGDOUBLE else 1e-18
+STRICT_TOL_F64: float = 8.881784197001252e-16
+"""``4 * eps(float64)``."""
 
-CONSERVATIVE_TOL_F64: float = 1e-10
-CONSERVATIVE_TOL_LD: float = CONSERVATIVE_TOL_F64 if NO_LONGDOUBLE else 1e-12
+DEFAULT_TOL_F32: float = 7.62939453125e-06
+"""``64 * eps(float32)``."""
+
+DEFAULT_TOL_F64: float = 1.4210854715202004e-14
+"""``64 * eps(float64)``."""
+
+CONSERVATIVE_TOL_F32: float = 0.00048828125
+"""``4096 * eps(float32)``."""
+
+CONSERVATIVE_TOL_F64: float = 9.094947017729282e-13
+"""``4096 * eps(float64)``."""
 
 
 class TestTolerance:
     """Test suite for tolerance utilities."""
 
     @pytest.mark.parametrize(
-        ("dtype", "expected"),
+        ("getter", "dtype", "expected"),
         [
-            (np.float16, 1e-3),
-            (np.float32, 1e-6),
-            ("float64", 1e-12),
-            (np.longdouble, 1e-12 if NO_LONGDOUBLE else 1e-15),
+            (get_strict, np.float32, STRICT_TOL_F32),
+            (get_strict, "float64", STRICT_TOL_F64),
+            (get_default, np.float32, DEFAULT_TOL_F32),
+            (get_default, "float64", DEFAULT_TOL_F64),
+            (get_conservative, np.float32, CONSERVATIVE_TOL_F32),
+            (get_conservative, "float64", CONSERVATIVE_TOL_F64),
         ],
     )
-    def test_get_default_tolerance(
-        self, dtype: np.dtype[np.floating[Any]] | type[np.floating[Any]], expected: float
+    def test_preset_values_for_the_supported_dtypes(
+        self, getter: Any, dtype: Any, expected: float
     ) -> None:
-        """Test get_default with various dtypes."""
-        assert get_default(dtype) == expected
+        """The two dtypes the library uses resolve to their pinned literal values."""
+        assert getter(dtype) == expected
 
-    @pytest.mark.parametrize(
-        ("dtype", "expected"),
-        [
-            (np.float16, 1e-4),
-            (np.float32, 1e-7),
-            ("float64", 1e-15),
-            (np.longdouble, 1e-15 if NO_LONGDOUBLE else 1e-18),
-        ],
-    )
-    def test_get_strict_tolerance(
-        self, dtype: np.dtype[np.floating[Any]] | type[np.floating[Any]], expected: float
+    @pytest.mark.parametrize(("name", "getter", "eps_factor"), PRESETS)
+    def test_preset_is_a_constant_number_of_epsilons(
+        self, name: str, getter: Any, eps_factor: float
     ) -> None:
-        """Test get_strict with various dtypes."""
-        assert get_strict(dtype) == expected
+        """Every dtype gets the *same* safety factor -- the property the old table lacked.
 
-    @pytest.mark.parametrize(
-        ("dtype", "expected"),
-        [
-            (np.float16, 1e-2),
-            (np.float32, 1e-5),
-            ("float64", 1e-10),
-            (np.longdouble, 1e-10 if NO_LONGDOUBLE else 1e-12),
-        ],
-    )
-    def test_get_conservative_tolerance(
-        self, dtype: np.dtype[np.floating[Any]] | type[np.floating[Any]], expected: float
-    ) -> None:
-        """Test get_conservative with various dtypes."""
-        assert get_conservative(dtype) == expected
+        The shipped table was 0.10/0.84/4.50 epsilons of strict for float16/float32/
+        float64, so "strict" meant something different in each precision and two of the
+        three were below one rounding.
+        """
+        for dtype in DTYPES:
+            eps = float(np.finfo(dtype).eps)
+            assert getter(dtype) == eps_factor * eps, (
+                f"{name}({np.dtype(dtype).name}) is "
+                f"{getter(dtype) / eps:g} epsilons, not {eps_factor:g}"
+            )
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [np.float16, np.float32, "float64", np.longdouble],
-    )
-    def test_get_machine_epsilon(
-        self, dtype: np.dtype[np.floating[Any]] | type[np.floating[Any]]
+    @pytest.mark.parametrize(("name", "getter", "eps_factor"), PRESETS)
+    def test_safety_factor_is_an_exact_power_of_two(
+        self, name: str, getter: Any, eps_factor: float
     ) -> None:
+        """``K`` is a power of two, so it is exact in every format and in C++."""
+        assert eps_factor == 2.0 ** round(np.log2(eps_factor)), name
+        for dtype in DTYPES:
+            ratio = getter(dtype) / float(np.finfo(dtype).eps)
+            assert ratio == eps_factor
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_every_preset_admits_at_least_one_rounding(self, dtype: Any) -> None:
+        """No preset may fall below one ulp at 1.0, which would demand bitwise equality."""
+        eps = float(np.finfo(dtype).eps)
+        for name, getter, _ in PRESETS:
+            assert getter(dtype) >= eps, (
+                f"{name}({np.dtype(dtype).name}) = {getter(dtype):g} is below one "
+                f"epsilon ({eps:g}): it asks for bitwise equality, not a tolerance"
+            )
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_the_three_tiers_are_ordered(self, dtype: Any) -> None:
+        """Strict is tighter than default, which is tighter than conservative."""
+        assert get_strict(dtype) < get_default(dtype) < get_conservative(dtype)
+
+    def test_longdouble_needs_no_platform_branch(self) -> None:
+        """``longdouble`` follows the same formula whether or not it aliases float64.
+
+        The previous table carried a separate longdouble column and an import-time
+        branch on ``np.dtype(np.longdouble) == np.dtype(np.float64)``. Reading the
+        epsilon from the platform removes both: where longdouble *is* float64 the two
+        answers coincide because the two epsilons do.
+        """
+        eps = float(np.finfo(np.longdouble).eps)
+        assert get_strict(np.longdouble) == 4.0 * eps
+        assert get_strict(np.dtype(np.longdouble)) == 4.0 * eps
+        assert get_strict("longdouble") == 4.0 * eps
+        if np.dtype(np.longdouble) == np.dtype(np.float64):
+            assert get_strict(np.longdouble) == get_strict(np.float64)
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_get_machine_epsilon(self, dtype: Any) -> None:
         """Test get_machine_epsilon against np.finfo."""
         assert get_machine_epsilon(dtype) == np.finfo(dtype).eps
 
@@ -104,7 +148,7 @@ class TestTolerance:
             get_machine_epsilon(np.uint8)
 
     def test_get_tolerance_info(self) -> None:
-        """Test the get_info dictionary."""
+        """Test get_info returns the expected structure and values."""
         dtype = np.float64
         info = get_info(dtype)
 
@@ -120,17 +164,17 @@ class TestTolerance:
         assert info["min_value"] == np.finfo(dtype).tiny
 
     def test_get_tolerance_info_string_dtype(self) -> None:
-        """Test get_info with a string dtype."""
+        """Test get_info with a string dtype preserves the original representation."""
         dtype_str = "float32"
-        info = get_info(dtype_str)
         finfo = np.finfo(dtype_str)
+        info = get_info(dtype_str)
 
         assert info["dtype"] == dtype_str
         assert info["machine_epsilon"] == finfo.eps
         assert info["default_tolerance"] == DEFAULT_TOL_F32
 
     def test_tolerance_info_keys(self) -> None:
-        """Test that get_info returns all expected keys."""
+        """Test that get_info returns exactly the documented keys."""
         info = get_info(np.float32)
         expected_keys = {
             "dtype",
@@ -146,94 +190,12 @@ class TestTolerance:
         }
         assert set(info.keys()) == expected_keys
 
-    def test_longdouble_else_branch_with_dtype_object(self) -> None:
-        """Ensure the np.dtype(np.longdouble) path hits the else-branch."""
-        dt = np.dtype(np.longdouble)
-        assert get_default(dt) == DEFAULT_TOL_LD
-        assert get_strict(dt) == STRICT_TOL_LD
-        assert get_conservative(dt) == CONSERVATIVE_TOL_LD
+    def test_half_precision_conservative_tier_saturates(self) -> None:
+        """float16 cannot absorb 4096 roundings, and the module says so rather than clipping.
 
-    def test_import_non_alias_longdouble_branch_executes(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Force the import-time non-alias branch to execute to improve coverage.
-
-        This replaces the 'numpy' module temporarily with a minimal stub so that
-        dtype(np.longdouble) != dtype(np.float64) holds during module reload.
+        11 significant bits give ``eps = 9.77e-4``, so the conservative tier is 4.0 -- a
+        relative tolerance above one, which accepts everything. Asserted here so the
+        documented edge cannot drift into a silent clamp.
         """
-        # Save original numpy
-        real_numpy = sys.modules.get("numpy")
-
-        # Build a minimal fake numpy module sufficient for the import-time check
-        fake_numpy = types.ModuleType("numpy")
-
-        class _FakeDType:
-            def __init__(self, token: object) -> None:
-                self._token = token
-
-            def __eq__(self, other: object) -> bool:
-                return isinstance(other, _FakeDType) and self._token is other._token
-
-            def __hash__(self) -> int:
-                return hash(self._token)
-
-        class _FakeFloating:
-            @classmethod
-            def __class_getitem__(cls: type[_FakeFloating], _item: object) -> type[_FakeFloating]:
-                return cls
-
-        class _FakeDTypeClass:
-            def __call__(self, x: object) -> _FakeDType:
-                return _FakeDType(x)
-
-            @classmethod
-            def __class_getitem__(
-                cls: type[_FakeDTypeClass], _item: object
-            ) -> type[_FakeDTypeClass]:
-                return cls
-
-        # distinct tokens so dtype(longdouble) != dtype(float64)
-        fake_numpy.float16 = object()  # type: ignore[attr-defined]
-        fake_numpy.float32 = object()  # type: ignore[attr-defined]
-        fake_numpy.float64 = object()  # type: ignore[attr-defined]
-        fake_numpy.longdouble = object()  # type: ignore[attr-defined]
-        fake_numpy.floating = _FakeFloating  # type: ignore[attr-defined]
-
-        def _fake_dtype(x: object) -> _FakeDType:
-            return _FakeDType(x)
-
-        fake_numpy.dtype = _FakeDTypeClass()  # type: ignore[attr-defined]
-        # Provide attribute used by "from numpy import typing as npt"
-        fake_numpy.typing = types.SimpleNamespace()  # type: ignore[attr-defined]
-
-        # Install fake numpy and reload tolerance to execute the else-branch
-        sys.modules["numpy"] = fake_numpy
-
-        try:
-            importlib.reload(tol_mod)
-            # Sanity check that module loaded and presets exist
-            assert hasattr(tol_mod, "_TOLERANCE_PRESETS")
-        finally:
-            # Restore real numpy and reload the module back to normal
-            if real_numpy is not None:
-                sys.modules["numpy"] = real_numpy
-            importlib.reload(tol_mod)
-
-    def test_get_tolerance_else_branch_via_monkeypatch(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Hit the fallback longdouble branch in _get_tolerance to cover line 92."""
-
-        class _FakeEnsuredDType:
-            # A fake ensured dtype whose .type won't match float16/32/64
-            def __init__(self) -> None:
-                self.type = object()
-
-        monkeypatch.setattr(tol_mod, "_ensure_float_dtype", lambda _d: _FakeEnsuredDType())
-
-        # Pass a non-string, non-longdouble sentinel so special-casing is skipped
-        sentinel = cast(npt.DTypeLike, object())
-        result = get_default(sentinel)
-        # Should equal the longdouble tolerance for the default preset
-        expected = DEFAULT_TOL_LD
-        assert result == expected
+        assert get_conservative(np.float16) == 4.0
+        assert get_default(np.float16) < 1.0

--- a/tests/test_tolerance.py
+++ b/tests/test_tolerance.py
@@ -95,10 +95,17 @@ class TestTolerance:
     def test_safety_factor_is_an_exact_power_of_two(
         self, name: str, getter: Any, eps_factor: float
     ) -> None:
-        """``K`` is a power of two, so it is exact in every format and in C++."""
-        assert eps_factor == 2.0 ** round(np.log2(eps_factor)), name
+        """``K`` is a power of two, so it is exact in every format and in C++.
+
+        Read back out of the module rather than checked against the table above, so
+        the assertion is about what ``pantr.tolerance`` returns and not about this
+        file's own literals.
+        """
         for dtype in DTYPES:
             ratio = getter(dtype) / float(np.finfo(dtype).eps)
+            assert ratio == 2.0 ** round(np.log2(ratio)), (
+                f"{name}({np.dtype(dtype).name}) is {ratio:g} epsilons, not a power of two"
+            )
             assert ratio == eps_factor
 
     @pytest.mark.parametrize("dtype", DTYPES)

--- a/tools/adversarial_sweep/_probes_bspline.py
+++ b/tools/adversarial_sweep/_probes_bspline.py
@@ -990,6 +990,17 @@ def _try_space(
     Fixture enumeration must not raise: an illegal knot vector is covered as a
     *construction* case elsewhere, and here it simply yields no fixture.
 
+    One family leaves the sweep through this door rather than being graded, and it is
+    worth naming so the drop in case count is not read as coverage lost by accident. On
+    a float32 domain ``[1e6, 1e6 + 1]`` the ulp is 0.0625, so any mesh of more than one
+    interval spaces its breakpoints under 0.5 apart, while telling two knots apart at
+    that magnitude needs 0.48 -- ``BsplineSpace1D`` refuses such a vector rather than
+    build a space with no resolvable interval. The refusal itself is still swept, as a
+    ``space1d_*`` construction case that grades ``DOCUMENTED_REJECTION`` off the
+    constructor's own ``Raises:`` section; what is not swept is the operations that
+    would have run on the space, because there is no space. Single-interval members of
+    the same family do still build, which is why this cannot be a per-domain exclusion.
+
     Args:
         knots (npt.NDArray[np.floating[Any]]): The knot vector.
         degree (int): Polynomial degree.
@@ -1243,6 +1254,19 @@ def _construction_cases(profile: Profile) -> Iterator[Case]:
                         "domain": list(domain),
                     }
                     illegal = spec.name in _ILLEGAL_KNOT_FAMILIES
+                    # Deliberately neither flag beyond `illegal`. A legal knot vector
+                    # here has *two* admissible outcomes and which one applies depends
+                    # on the vector, not on the family: it builds, or -- when the mesh
+                    # is finer than the dtype resolves at that coordinate magnitude,
+                    # which on float32 `[1e6, 1e6 + 1]` is every mesh past a single
+                    # interval -- the constructor refuses it. That refusal is a
+                    # contract boundary, not a finding, and the docstring-driven rule
+                    # grades it `DOCUMENTED_REJECTION` off the constructor's own
+                    # `Raises:` section. `must_succeed` would call the refusal a bug
+                    # and `must_reject` would call the successful build one, so both
+                    # are wrong; asserting either per-family would need this file to
+                    # recompute the merge rule, which is the mirror the sweep exists
+                    # to avoid.
                     yield Case(
                         GROUP,
                         f"space1d_{spec.name}_{tag}",


### PR DESCRIPTION
This is the semantic half of a tolerance overhaul: it fixes what a tolerance *means* here, so
that the site-by-site derivations in the next pass have something true to derive from. It is
also the change the C++ port cannot postpone, because the port freezes whichever reading the
transcriber happens to hold.

## The defect: the preset table contradicted its own docstring

`tolerance.py` declared its presets **absolute** — "a fixed value per dtype, independent of the
magnitude of the values being compared" — while `_bspline_locate.py` used the same value as a
**dimensionless relative factor**. One table was asked to be a physical length, a parametric
length and a ratio at once.

Measured in units of each dtype's own epsilon, the table had four dtypes and four different
patterns, with no constant number of epsilons anywhere. `get_strict` for float32 was **0.84 eps**
— below one ulp at 1.0, i.e. bitwise equality — and it was the default tolerance of both root
finders.

The table is now `K · eps(dtype)` with `K` = 4 / 64 / 4096, a stated power of two, constant per
tier across dtypes, and each carrying its derivation. Reading eps from the platform deleted the
per-dtype table, the longdouble-aliasing branch and the explicit-longdouble case, all dead under
the formula.

## Knot identity by relative gap, and snapping made idempotent

Snapping used a rounding grid at `1/tolerance`. Because the tolerance was absolute, **from
|knot| ≈ 5 it merged nothing at all**, not even a 1-ulp discrepancy — and knots computed as
`a + i*h` versus `(a*(n−i) + b*i)/n` differ by an ulp routinely, so the detected multiplicity
dropped and the space silently carried the wrong continuity. A rounding grid is also wrong in
principle: two values one ulp apart can straddle a line and never merge, for any spacing.

Knot identity is now a relative gap against the vector's own scale,
`8 · eps · max(span, |k₀|, |k_N|)`, with the derivation stated: each of the two routes to a knot
is four roundings on quantities bounded by the scale, so they differ by at most `4·eps·scale`, and
8 doubles that for FMA contraction, vector width and one upstream rounding. Measured over 200 000
random `(a, b, n, i)` across scales 1e-3 to 1e7: worst observed 1.74 eps·scale.

Grouping elects each class's **first stored knot** rather than averaging. Averaging is a fresh
rounding that can place adjacent representatives one ulp apart, and `np.mean` over `degree+1`
identical copies is not even the identity at large magnitude. Electing makes snapping
**idempotent**, which is the property the exact `denom == 0.0` Cox–de Boor guard actually needs.

Rather than multiply by a magnitude at some forty consumers, `BsplineSpace1D`'s stored tolerance
*is* the derived absolute length, so every downstream parametric comparison becomes
scale-covariant at one site.

## Scale covariance, measured

29 rows — merge verdicts at 1/4/8/16/64/4096 ulp across both dtypes, tolerance-over-eps, domain
membership, overlay merge, multiplicity survival, product accuracy — under `x → λx` for
λ = 1e-6, 1, 1e6.

**Before: 25 of 29 scale-dependent. After: 0.** `tolerance/(eps·λ)` is exactly 8.000 at every λ in
both dtypes. The product of a float32 spline on `[0, 1e-6]` goes from 1.6e-2 relative error to
1.6e-7.

## A knot vector that snapping would destroy is now refused

In float32 at 1e6 an interior knot is uncertain by 6 % of a unit window: merging two routes to one
knot needs a tolerance above 0.477, keeping a 0.25 spacing needs one below it. **No threshold
satisfies both.** The old code "worked" only by never merging anything — its tolerance was
1.6e-6 ulp there.

Collapsing is the honest verdict, but silence is not, so `BsplineSpace1D` raises when snapping
removes every interval from a vector that had more than one distinct knot. The message names the
dtype, the magnitude, the merge threshold in ulp, the closest pair the caller actually passed, and
a dtype-aware remedy. A vector the caller passed already degenerate is still accepted — only
snapping's own destruction is refused. Verified over 40 domain × interval-count × dtype
combinations: the only refusals are the intended family, and single-interval vectors there still
build.

In float64 this is reachable only past an offset of roughly `1e13`–`1e15` times the domain's own
length, where the window is a handful of ulp wide; predicted and measured thresholds agree.

## Also

The Cox–de Boor exact-zero guard's justification was **false** — it claimed snapping stores equal
knots bitwise identical. The guard is sound for a different reason: the two weights sum to exactly
the denominator, so they form a convex combination and a tiny denominator cancels against an
equally tiny numerator. Verified with snapping off, gaps 0 to 64 ulp, bases 1.0 and 1e6:
`max|N| = 1.0` exactly, partition of unity ≤ 6.7e-16. Both docstrings and the changelog entry that
repeated the false justification are corrected.

The unique-knot accessor returned tolerance-grid values although its indices already pointed at
the originals, which made `Bspline.multiply` wrong by 8 % away from any knot. It returns the stored
knots, and `_snap_knots` is now `np.repeat` over that same accessor, which is what structurally
prevents the two from disagreeing again.

`restrict`'s silent truncation disappeared **without `restrict` being touched**: its
`searchsorted(knots, b + tol)` was a no-op once half an ulp of `b` exceeded the absolute tolerance,
and one ulp of any coordinate is now at most `eps·scale`, so the bound always moves by at least
8 ulp. Structural, not fixture luck.

## Sweep

| | cases | findings |
|---|---:|---:|
| base | 30 072 | 393 |
| branch | 28 234 | **217** |

1 829 cases leave because their fixtures can no longer be built. Whole mechanisms close: the
restriction-window invariant (49), the accessor (12), `must-succeed:ValueError` (50),
`numba-oob` 4 → 0.

One measurement caveat stated plainly: a `multiply` case at degree 62 sits ~70 s inside LAPACK
where the sweep's alarm cannot reach it, so the totals were computed from the enumerated case set
plus prior verdicts and then **validated against the 81 % of cases the live run did complete** —
exactly the 55 predicted verdict changes, no others, identical BUG counts. That case is 67.1 s on
base and 71.7 s here, same product space: slow, not regressed.

## Tests whose expectations were re-derived

Every one is listed in the commits with its reasoning; the two worth a reviewer's eye are
`test_tolerance.py`, rewritten from twelve literals to assert the *shape* the old table lacked, and
`TestGradedKnotVectorLocalSpacing`, whose fixtures existed to guard against a rejected earlier fix
and whose gaps (8.2 and 3.0 ulp of the knot they straddle) are inside the rounding of computing
that knot at all. The regression is kept at gaps the format resolves, and the old fixtures are kept
as the merged case asserting what the rejected fix actually got wrong — the *disagreement* between
stored knots, multiplicity and basis, not the merge.

## Verification

`ruff`, `ruff format`, `mypy`, `import-lint` and a from-scratch docs build under `-W` all clean.
**5294 passed, 21 skipped, 3 xfailed** against a baseline of 5261 / 21 / 7; four strict xfails
removed. The downstream consumer's affected test files were run per file against base and head:
identical, and its one failure is pre-existing in the same frame on both.

## Not in this pass, recorded for the next

`restrict`'s own tolerance policy, the THB refinement gate, the THB cell-membership `1e-12`,
`cad/_coons.py`'s corner check, `remove_knots`'s `1e-10` default, the rational knot-removal
pullback, and `_bspline_roots.py`'s global slope bound. Also: `Bspline.locate` now runs on 6 %
headroom (worst residual `60·eps·scale` against a `64·eps·scale` threshold) and wants a tier
choice; `multipatch`'s geometric tolerance ignores coordinate magnitude; `get_conservative` has
zero call sites in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
