### PR TITLE
fix(bspline,cad): derive every remaining site tolerance from what it grades

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -146,11 +146,17 @@
   absolute `1e-10`, a geometric budget wearing no units: the same exactly-removable knot
   came out at geometry scale 1e-6, 1 and 1e3 and was silently refused at 1e6 and 1e9. It
   now means *remove only what is exact to round-off*, `8 * (degree + 1) * eps *
-  max(bbox diagonal, largest |P_i|)`, which is the one default needing no arbitrary
-  constant. Measured over 105 cases (degrees 1–7, ranks 1–3, geometry scales 1e-6 to 1e9)
-  by bisecting for the smallest budget that still removes a just-inserted knot: the
-  largest distance observed is 0.84 eps × scale, and the tightest margin anywhere in the
-  set is a factor of 48. **This is a behaviour change** — a knot whose removal costs up to
+  max(bbox diagonal, largest |P_i|) * sqrt(n)`, which is the one default needing no
+  arbitrary constant. Measured over 105 cases (degrees 1–7, ranks 1–3, geometry scales
+  1e-6 to 1e9) by bisecting for the smallest budget that still removes a just-inserted
+  knot: the largest distance observed is 0.84 eps × scale, and the tightest margin
+  anywhere in the set is a factor of 48. The `sqrt(n)` is what the *other* directions
+  add: on a surface or a volume the removal test is handed a slice with every other
+  direction's control points flattened into it, so its single Euclidean distance spans
+  `n` control points rather than one, and stacking `n` blocks each of norm at most `e`
+  reaches `sqrt(n) · e`. Without that term the default silently refuses an exactly
+  redundant knot once `n` is large enough — measured on a degree-3 volume, from
+  `n = 124609` upward. **This is a behaviour change** — a knot whose removal costs up to
   1e-10 of geometry used to come out and no longer does. Trading geometry for a shorter
   knot vector is a price only the caller can set, so it has to be asked for.
 - **A rational knot-removal budget is converted before it reaches the kernel.** The kernel

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -96,6 +96,73 @@
   caller that wanted the dimensionless factor instead and now takes it from
   `pantr.tolerance` directly, since none of the three quantities it compares is a
   parametric coordinate of a single patch.
+- **The individual sites that still carried a bare constant now derive one.** The
+  presets above made a tolerance mean something; these are the places that could not be
+  re-derived until it did. Each grades a named quantity, scales by that quantity's own
+  magnitude, and states its safety factor in an attribute docstring:
+  - **The THB refinement gate** certified a candidate whenever the worst prolongation
+    residual stayed under `1e-8 * (1 + max_coarse_value)`. The shape was right — the
+    residual is compared against the size of the coarse column it reproduces — but the
+    constant was wrong by seven decades, so an impostor whose residual landed anywhere in
+    `[1e-14, 1e-8]` was certified and `prolongation_to` returned a matrix that does not
+    prolong. It is now `4096 * eps * (1 + max_coarse_value)`, the conservative tier
+    standing in for the backward-stability constant of the `gelsd` least-squares solve,
+    which has no closed form. Measured over 132 configurations (1D/2D/3D, degrees 2–5,
+    truncated and not, one and two refinement levels, three domain scales) the worst
+    residual is 18.5 eps, so the gate keeps a safety factor of 443 while tightening
+    1.1e4-fold. A `sqrt(M)` growth term was tried and dropped on measurement: `M` spans
+    13 to 19683 with no trend in the residual.
+  - **THB cell membership** allowed a fixed `1e-12` of slack at a cell boundary, which
+    rejected a point one ulp outside once the parametric domain reached 1e6 and accepted
+    some 9000 ulp of slop on `[0, 1]`. It is now `8 * eps * max(|lo|, |hi|, hi - lo)` per
+    axis: the same rule, and the same number, the knot layer uses for the same question.
+  - **The Coons corner check** decided a `ValueError` with `atol=1e-12, rtol=0`. Across
+    twelve decades that rejects a one-ulp corner mismatch at model size 1e6 — a
+    micron-unit model of a metre-scale part failing on a geometrically perfect patch —
+    while accepting a 1e-9 *relative* gap at 1e-6. It is now `4096 * eps` times the
+    largest absolute coordinate over **all eight** corner values, so the verdict does not
+    depend on which corner sits at the origin.
+  - **`Bspline.locate`'s geometric scale** no longer floors at 1.0. The floor held a
+    millimetre-scale part to a thousand times the relative accuracy of a metre-scale one;
+    the fallback to 1.0 now fires only for a geometry with no extent *at the origin*,
+    which is the one case with no scale to read. The docstring's account of the default
+    tier is corrected with it: the `60 * eps * scale` it cited as a six percent margin was
+    a censored measurement, since the iteration stops at the threshold. Re-measured at six
+    thresholds from 2 to 4096 epsilons over 9480 query points, the achieved residual
+    tracks whatever threshold is set and nothing is lost even at `4 * eps * scale`, so the
+    threshold is an accuracy contract rather than a safety margin, and loosening the tier
+    would cost accuracy one for one.
+  - **`multipatch`'s joint geometric tolerance** was `relative * diagonal`, which tracks
+    how big the geometry is but not where it sits: two unit patches meeting at 1e6 were
+    graded at 2.5e-18, eight orders below their own noise floor. It now takes
+    `max(diagonal, largest |coordinate|)`.
+  - **`Bspline.restrict`** gains no constant, which is its policy and is now written
+    down: every comparison it makes is a knot-identity question that
+    `BsplineSpace1D.tolerance` already answers, and the module docstring records the three
+    properties making one number enough — insertion preserves the endpoints, the
+    extraction offsets widen away from the interval, and the snapping invariant stops the
+    widening over-collecting.
+- **`Bspline.remove_knots` is now lossless by default.** `tol=None` used to mean an
+  absolute `1e-10`, a geometric budget wearing no units: the same exactly-removable knot
+  came out at geometry scale 1e-6, 1 and 1e3 and was silently refused at 1e6 and 1e9. It
+  now means *remove only what is exact to round-off*, `8 * (degree + 1) * eps *
+  max(bbox diagonal, largest |P_i|)`, which is the one default needing no arbitrary
+  constant. Measured over 105 cases (degrees 1–7, ranks 1–3, geometry scales 1e-6 to 1e9)
+  by bisecting for the smallest budget that still removes a just-inserted knot: the
+  largest distance observed is 0.84 eps × scale, and the tightest margin anywhere in the
+  set is a factor of 48. **This is a behaviour change** — a knot whose removal costs up to
+  1e-10 of geometry used to come out and no longer does. Trading geometry for a shorter
+  knot vector is a price only the caller can set, so it has to be asked for.
+- **A rational knot-removal budget is converted before it reaches the kernel.** The kernel
+  measures a Euclidean distance over every column of the array it is given, which for a
+  NURBS is the homogeneous `[w·x, w·y, w·z, w]`, while the caller's budget is a distance
+  in projected space. Eq. (5.30) of Piegl & Tiller (2nd ed., 1997, p. 185),
+  `TOL = d · w_min / (1 + |P|_max)`, is now applied. Without it a deviation carried by the
+  **weight** column is graded as though it were a coordinate: sweeping a weight
+  perturbation over sixteen decades with the coordinates at 1e6, the worst projected
+  deviation an accepted removal produced was 7.4e5 times the requested budget; with the
+  conversion, 0.32. A circle cannot show this, its weights being structurally tied to its
+  coordinates, so the tests vary weights and coordinates independently.
 - `pantr.grid.overlay` merges breakpoints closer than the default *relative*
   tolerance times the axis's own magnitude -- the intersection window and the
   coordinates bounding it -- instead of against a bare `float64` constant. A

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -546,6 +546,11 @@ class Bspline:
         possible when ``num=None``), provided the geometric deviation stays
         within *tol*.
 
+        With no ``tol`` the operation is **lossless**: only knots the spline does not
+        actually need are removed, to within the round-off of the reconstruction that
+        decides it. Removing a knot at the cost of a geometric error is a trade only
+        the caller can price, so it has to be asked for by passing a ``tol``.
+
         Args:
             knot_values (float | npt.ArrayLike | Sequence[npt.ArrayLike | None]):
                 For a 1D B-spline, a single float or a 1D array-like of
@@ -560,7 +565,9 @@ class Bspline:
             tol (float | None): Maximum allowed geometric deviation for each
                 removal step, as a distance in the B-spline's own physical units
                 (projected coordinates, for a rational B-spline). ``None`` (default)
-                uses ``1e-10``.
+                derives the round-off floor ``8 * (degree + 1) * eps * scale``, with
+                ``scale = max(control-net bounding-box diagonal, largest ||P_i||)``,
+                so a knot is removed only when doing so is exact to the arithmetic.
 
         Returns:
             Bspline: New B-spline with the same geometry (within tolerance)

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -558,7 +558,9 @@ class Bspline:
                 value. ``None`` (default) removes as many as possible (up to
                 the current multiplicity, capped at the degree).
             tol (float | None): Maximum allowed geometric deviation for each
-                removal step. ``None`` (default) uses ``1e-10``.
+                removal step, as a distance in the B-spline's own physical units
+                (projected coordinates, for a rational B-spline). ``None`` (default)
+                uses ``1e-10``.
 
         Returns:
             Bspline: New B-spline with the same geometry (within tolerance)

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -565,9 +565,12 @@ class Bspline:
             tol (float | None): Maximum allowed geometric deviation for each
                 removal step, as a distance in the B-spline's own physical units
                 (projected coordinates, for a rational B-spline). ``None`` (default)
-                derives the round-off floor ``8 * (degree + 1) * eps * scale``, with
-                ``scale = max(control-net bounding-box diagonal, largest ||P_i||)``,
-                so a knot is removed only when doing so is exact to the arithmetic.
+                derives the round-off floor ``8 * (degree + 1) * eps * scale *
+                sqrt(n)``, with ``scale = max(control-net bounding-box diagonal, largest
+                ||P_i||)`` and ``n`` the number of control points the removal test spans
+                at once (one for a curve, the product of the other directions' basis
+                counts for a surface or a volume), so a knot is removed only when doing
+                so is exact to the arithmetic.
 
         Returns:
             Bspline: New B-spline with the same geometry (within tolerance)

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -15,6 +15,7 @@ this module is where they are reconciled: see
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
@@ -53,6 +54,9 @@ for the smallest budget that still removes it: the largest observed distance is
 whole set is a factor of 48. There is no trend with degree (the worst case is at
 degree 4), so the ``degree + 1`` is headroom the derivation asks for rather than a
 term fitted to the data.
+
+All of that describes **one** control point, which is what a curve has per index. See
+:func:`_roundoff_deviation_floor` for the ``sqrt`` that a surface or a volume adds.
 """
 
 
@@ -83,12 +87,15 @@ def _control_point_scale(ctrl: npt.NDArray[np.float32 | np.float64]) -> float:
     return max(diagonal, magnitude)
 
 
-def _roundoff_deviation_floor(ctrl: npt.NDArray[np.float32 | np.float64], degree: int) -> float:
+def _roundoff_deviation_floor(
+    ctrl: npt.NDArray[np.float32 | np.float64], degree: int, num_stacked: int
+) -> float:
     """Get the deviation budget that admits exactly the removals round-off allows.
 
-    ``_REMOVAL_FLOOR_SAFETY * get_strict(dtype) * (degree + 1) * scale``, i.e.
-    ``8 * (degree + 1) * eps`` times :func:`_control_point_scale`; the derivation and
-    the measurement are in :data:`_REMOVAL_FLOOR_SAFETY`.
+    ``_REMOVAL_FLOOR_SAFETY * get_strict(dtype) * (degree + 1) * sqrt(num_stacked) *
+    scale``: ``8 * (degree + 1) * eps`` times :func:`_control_point_scale` for one
+    control point (derivation and measurement in :data:`_REMOVAL_FLOOR_SAFETY`), times
+    a ``sqrt`` for how many control points the kernel grades at once.
 
     This is the default budget, and it is deliberately *not* a geometric one. A knot
     that a spline does not actually need is removable exactly, and the only thing
@@ -98,6 +105,27 @@ def _roundoff_deviation_floor(ctrl: npt.NDArray[np.float32 | np.float64], degree
     arbitrary constant. Anything looser is a statement about how much geometry the
     caller is willing to lose, which only the caller can make.
 
+    **Why ``sqrt(num_stacked)``.** For a curve the kernel compares one control point
+    against one control point. For a surface or a volume it does not:
+    :func:`~pantr._array_utils._flatten_along_axis` collapses every *other* direction
+    into the trailing axis first, so the single Euclidean distance A5.8 computes runs
+    over ``num_stacked`` control points at once. Stacking is exactly what a 2-norm
+    aggregates -- ``|| (d_1, ..., d_n) || = sqrt(sum ||d_k||^2) <= sqrt(n) * max_k
+    ||d_k||`` -- so a slice whose every point is at its own per-point floor lands at
+    ``sqrt(num_stacked)`` times that floor. This is a bound, not a statistical estimate:
+    it holds however the per-point errors are correlated. Without it the default is too
+    tight by that factor on anything but a curve, and it *silently* refuses an exactly
+    redundant knot: measured on a degree-3 volume with 5 elements in the removal
+    direction, a just-inserted knot came out up to ``num_stacked = 91809`` and was
+    refused from ``124609`` upward, with no error and no warning.
+
+    What the aggregate cannot see is *which* point moved. A slice could in principle
+    spend the whole budget on one control point, which would then sit
+    ``sqrt(num_stacked)`` above its own floor. Grading per point instead would need the
+    kernel to return a per-point distance rather than one scalar. In practice the
+    reconstructions share their weights and run on data of one magnitude, so the error
+    is spread across the slice rather than concentrated.
+
     It is expressed in the units the kernel measures in, so for a rational spline it is
     a homogeneous distance and does **not** go through
     :func:`_homogeneous_deviation_tolerance`: a floor is a statement about the
@@ -105,14 +133,18 @@ def _roundoff_deviation_floor(ctrl: npt.NDArray[np.float32 | np.float64], degree
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Control points as the kernel will
-            see them, homogeneous for a rational spline.
+            see them, homogeneous for a rational spline, with the coordinate axis last.
         degree (int): Polynomial degree in the direction being reduced.
+        num_stacked (int): How many control points the kernel's distance spans, i.e. the
+            product of the basis counts of every direction *except* the one being
+            reduced. One for a curve.
 
     Returns:
         float: Absolute deviation budget, in the units of ``ctrl``.
     """
     scale = _control_point_scale(ctrl)
-    return _REMOVAL_FLOOR_SAFETY * get_strict(ctrl.dtype) * (degree + 1) * scale
+    per_point = _REMOVAL_FLOOR_SAFETY * get_strict(ctrl.dtype) * (degree + 1) * scale
+    return per_point * math.sqrt(num_stacked)
 
 
 def _homogeneous_deviation_tolerance(
@@ -141,6 +173,9 @@ def _homogeneous_deviation_tolerance(
     show this, because its weights are structurally tied to its coordinates.
 
     Two honest caveats.
+
+    ``w_min = min_i w_i``, and weights are required strictly positive (see ``Raises``),
+    so it is a minimum and not a minimum of absolute values.
 
     The bound is **tight for a weight-carried perturbation and conservative for a purely
     geometric one**, by up to a factor ``1 + |P|_max``. Splitting ``D`` optimally between
@@ -183,10 +218,24 @@ def _homogeneous_deviation_tolerance(
 
     Returns:
         float: The equivalent budget on homogeneous control points.
+
+    Raises:
+        ValueError: If any weight is non-positive. The conversion divides by the weights
+            to recover ``|P|_max``, and a zero weight has no projected point to convert
+            to; the same precondition is checked by
+            :func:`~pantr.bspline._bspline_locate._locate_impl` and
+            :func:`~pantr.bspline.find_roots`, and stating it here is what keeps a
+            degenerate weight from silently producing ``TOL = 0`` and refusing every
+            removal in the direction.
     """
     flat = np.asarray(ctrl, dtype=np.float64).reshape(-1, ctrl.shape[-1])
     weights = flat[:, -1]
-    w_min = float(np.abs(weights).min())
+    w_min = float(weights.min())
+    if w_min <= 0.0:
+        raise ValueError(
+            f"Knot removal with an explicit tolerance needs strictly positive weights to "
+            f"convert the tolerance into homogeneous coordinates; the smallest is {w_min}."
+        )
     projected = flat[:, :-1] / weights[:, None]
     p_max = float(np.linalg.norm(projected, axis=1).max())
     return tol_euclidean * w_min / (1.0 + p_max)
@@ -303,12 +352,19 @@ def _remove_knots_bspline(
             new_spaces_1d.append(space_1d)
             continue
 
-        # Resolved per direction, from the control points as they stand: the degree and
-        # the control-point scale both differ between directions, and `ctrl` is carried
-        # forward from the previous one.
+        # Resolved per direction, from the control points as they stand: the degree, the
+        # control-point scale and the number of stacked points all differ between
+        # directions, and `ctrl` is carried forward from the previous one.
         if tol is None:
-            tol_deviation = _roundoff_deviation_floor(ctrl, space_1d.degree)
+            # How many control points the kernel's one Euclidean distance will span:
+            # every direction but this one. See `_roundoff_deviation_floor`.
+            num_stacked = int(np.prod(ctrl.shape[:-1])) // ctrl.shape[i]
+            tol_deviation = _roundoff_deviation_floor(ctrl, space_1d.degree, num_stacked)
         elif bspline.is_rational:
+            # Not scaled by `num_stacked`: an explicit budget is a promise about each
+            # control point, and widening the aggregate would let one point absorb the
+            # whole of it. Grading the stacked distance against the per-point budget is
+            # conservative, which is the sound direction for a caller's own bound.
             tol_deviation = _homogeneous_deviation_tolerance(ctrl, tol)
         else:
             tol_deviation = tol

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -15,17 +15,104 @@ this module is where they are reconciled: see
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from ..tolerance import get_strict
 from ._bspline_knot_removal_core import _remove_knot_1d_core
 from ._bspline_knots import _find_knot_index_and_multiplicity
 
 if TYPE_CHECKING:
     from . import Bspline, BsplineSpace1D
+
+_REMOVAL_FLOOR_SAFETY: Final[float] = 2.0
+"""Extra factor on the strict tier for the round-off floor of an exact removal.
+
+With :func:`~pantr.tolerance.get_strict` this is ``8 * eps``, and it is applied per
+step of the reconstruction chain: the floor is
+``8 * (degree + 1) * eps * control-point scale``.
+
+**Shape.** Removing a knot once runs Algorithm A5.8's two one-sided reconstructions
+towards each other, at most ``degree + 1`` control points from each side, and reads
+off how far apart they land. Each step is one divided difference of the previous
+result, so an ``eps``-sized error enters at every one of the ``degree + 1`` of them
+and the largest quantity any of them handles is the control-point scale. The steps
+are *not* convex combinations -- the ``1 / alpha`` in the recurrence can amplify --
+so this is an operation count and not a proved bound; the eight epsilons per step are
+the same doubling of the strict tier that
+:data:`~pantr.bspline._bspline_knots._KNOT_MERGE_SAFETY` applies, covering an FMA
+contraction and a differing summation order on top of the count.
+
+**Measured**, over 105 cases (degrees 1 to 7, ranks 1 to 3, geometry scales ``1e-6``
+to ``1e9``), taking an exactly removable knot -- one just inserted -- and bisecting
+for the smallest budget that still removes it: the largest observed distance is
+``0.84 * eps * scale``, and the tightest margin against ``8 * (degree + 1)`` over the
+whole set is a factor of 48. There is no trend with degree (the worst case is at
+degree 4), so the ``degree + 1`` is headroom the derivation asks for rather than a
+term fitted to the data.
+"""
+
+
+def _control_point_scale(ctrl: npt.NDArray[np.float32 | np.float64]) -> float:
+    """Get the magnitude a control-point distance is relative to.
+
+    ``max(bounding-box diagonal, largest ||P_i||)`` over the rows of ``ctrl``, the same
+    pairing of extent and coordinate magnitude that
+    :func:`~pantr.bspline._bspline_knots._knot_scale` makes in parametric space and
+    :func:`~pantr.bspline._bspline_locate._geometric_scale` in physical space. The
+    extent alone is not enough: a small part sitting at ``x = 1e6`` has control points
+    whose differences carry an absolute error of ``eps * 1e6`` however small the part
+    is.
+
+    Computed on the array as given, so for a rational spline it is the scale of the
+    *homogeneous* control points, which is the space the kernel measures in.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points, of any shape whose
+            last axis is the coordinate axis.
+
+    Returns:
+        float: The scale, zero only for a control net that is identically zero.
+    """
+    flat = np.asarray(ctrl, dtype=np.float64).reshape(-1, ctrl.shape[-1])
+    diagonal = float(np.linalg.norm(flat.max(axis=0) - flat.min(axis=0)))
+    magnitude = float(np.linalg.norm(flat, axis=1).max())
+    return max(diagonal, magnitude)
+
+
+def _roundoff_deviation_floor(ctrl: npt.NDArray[np.float32 | np.float64], degree: int) -> float:
+    """Get the deviation budget that admits exactly the removals round-off allows.
+
+    ``_REMOVAL_FLOOR_SAFETY * get_strict(dtype) * (degree + 1) * scale``, i.e.
+    ``8 * (degree + 1) * eps`` times :func:`_control_point_scale`; the derivation and
+    the measurement are in :data:`_REMOVAL_FLOOR_SAFETY`.
+
+    This is the default budget, and it is deliberately *not* a geometric one. A knot
+    that a spline does not actually need is removable exactly, and the only thing
+    standing between it and a bit-for-bit reconstruction is the round-off of the
+    reconstruction itself. A budget at that level therefore means "remove what is
+    genuinely redundant and nothing else", which is the one default that needs no
+    arbitrary constant. Anything looser is a statement about how much geometry the
+    caller is willing to lose, which only the caller can make.
+
+    It is expressed in the units the kernel measures in, so for a rational spline it is
+    a homogeneous distance and does **not** go through
+    :func:`_homogeneous_deviation_tolerance`: a floor is a statement about the
+    arithmetic, and the arithmetic happens in homogeneous coordinates.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points as the kernel will
+            see them, homogeneous for a rational spline.
+        degree (int): Polynomial degree in the direction being reduced.
+
+    Returns:
+        float: Absolute deviation budget, in the units of ``ctrl``.
+    """
+    scale = _control_point_scale(ctrl)
+    return _REMOVAL_FLOOR_SAFETY * get_strict(ctrl.dtype) * (degree + 1) * scale
 
 
 def _homogeneous_deviation_tolerance(
@@ -174,7 +261,8 @@ def _remove_knots_bspline(
         num (int | None): Maximum removals per knot value. ``None`` removes
             as many as possible.
         tol (float | None): Deviation tolerance, a distance in **projected** space.
-            ``None`` uses a default of ``1e-10``.
+            ``None`` uses the round-off floor of :func:`_roundoff_deviation_floor`,
+            which removes what is redundant to within the arithmetic and nothing more.
 
     Returns:
         Bspline: New B-spline with reduced knot vectors.
@@ -194,12 +282,15 @@ def _remove_knots_bspline(
             new_spaces_1d.append(space_1d)
             continue
 
-        # Resolved per direction, from the control points as they stand: `ctrl` is
-        # carried forward from the previous direction.
-        requested = 1e-10 if tol is None else tol
-        tol_deviation = (
-            _homogeneous_deviation_tolerance(ctrl, requested) if bspline.is_rational else requested
-        )
+        # Resolved per direction, from the control points as they stand: the degree and
+        # the control-point scale both differ between directions, and `ctrl` is carried
+        # forward from the previous one.
+        if tol is None:
+            tol_deviation = _roundoff_deviation_floor(ctrl, space_1d.degree)
+        elif bspline.is_rational:
+            tol_deviation = _homogeneous_deviation_tolerance(ctrl, tol)
+        else:
+            tol_deviation = tol
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -150,9 +150,30 @@ def _homogeneous_deviation_tolerance(
     Euclidean distance, which loses the direction. Removing it would mean the kernel
     grading the two parts separately.
 
-    That is also why ``1 + |P|_max`` adds a pure number to a length. The
-    inhomogeneity is inherited from ``D``, whose components are not all of one unit,
-    and is not an error in the formula; the bound above holds at every scale.
+    That is also why ``1 + |P|_max`` adds a pure number to a length, and the consequence
+    has to be stated rather than waved past. The inhomogeneity is not an error in the
+    formula: it is inherited from ``D`` itself, whose squared value adds
+    ``(length * weight)^2`` to ``weight^2``, so ``D`` is not a quantity of one unit and no
+    pullback out of it can be. The **bound is sound at every scale** -- the derivation
+    above uses nothing about the size of ``|P|`` -- but its *tightness* is not scale
+    invariant, and where the crossover sits depends on the unit the model is written in:
+
+    * ``|P|_max >> 1``: tight for a weight-carried deviation, loose by ``|P|_max`` for a
+      purely coordinate-carried one.
+    * ``|P|_max << 1``: the reverse. Tight for a coordinate-carried deviation, loose by
+      ``1 / |P|_max`` for a weight-carried one.
+
+    Measured: sweeping a weight perturbation over sixteen decades at a fixed *relative*
+    budget, 20 of the 33 sweep points are accepted at model scale 1 and 1e6 but only 9 at
+    model scale 1e-6, where the ``1`` term dominates. The verdict is therefore covariant
+    in the safe direction only -- a small model refuses removals its budget would allow,
+    and never accepts one it would not.
+
+    Closing that gap is a Layer-3 change, not a better pullback. It needs the kernel to
+    grade ``||dP^w_xyz|| / w`` and ``|P| |dP^w_w| / w`` against ``d`` **separately**, which
+    is dimensionally clean, tight in both regimes and fully covariant. Compressing them
+    into one Euclidean distance is what loses the direction, and once lost it cannot be
+    recovered here.
 
     Args:
         ctrl (npt.NDArray[np.float32 | np.float64]): Homogeneous control points, last

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -2,6 +2,15 @@
 
 This module provides input validation, multiplicity lookup, and
 multi-dimensional orchestration that wrap the Layer 3 knot-removal kernel.
+
+**What the kernel's tolerance grades.** ``_remove_knot_1d_core`` accepts a removal
+when the Euclidean distance between two reconstructions of the same control point
+stays within ``tol``. That distance is taken over *the columns of the array it is
+given*, which for a rational spline are the homogeneous coordinates
+``[w * x, w * y, w * z, w]`` and not the projected point. A caller's budget, on the
+other hand, is a distance in projected space. The two are different quantities, and
+this module is where they are reconciled: see
+:func:`_homogeneous_deviation_tolerance`.
 """
 
 from __future__ import annotations
@@ -17,6 +26,62 @@ from ._bspline_knots import _find_knot_index_and_multiplicity
 
 if TYPE_CHECKING:
     from . import Bspline, BsplineSpace1D
+
+
+def _homogeneous_deviation_tolerance(
+    ctrl: npt.NDArray[np.float32 | np.float64], tol_euclidean: float
+) -> float:
+    """Pull a projected-space deviation budget back to homogeneous control points.
+
+    ``TOL = d * w_min / (1 + |P|_max)``, with ``|P|_max = max_i ||P_i||_2`` in
+    **Euclidean** coordinates and ``w_min = min_i w_i``. This is Eq. (5.30) of Piegl &
+    Tiller, *The NURBS Book*, 2nd ed. (Springer, 1997), p. 185, given there for
+    Algorithm A5.8, which :func:`~pantr.bspline._bspline_knot_removal_core.
+    _remove_knot_1d_core` otherwise implements faithfully.
+
+    Why it is needed: the kernel measures one Euclidean distance ``D`` over every
+    column of the array it is handed, which for a rational spline are the homogeneous
+    coordinates ``[w x, w y, w z, w]``. Moving the homogeneous point by ``dP^w`` moves
+    the projected point by ``(dP^w_xyz - P dP^w_w) / w``, so
+
+        |dP| <= (|dP^w_xyz| + |P| |dP^w_w|) / w <= D (1 + |P|) / w,
+
+    and requiring ``D <= d w_min / (1 + |P|_max)`` gives ``|dP| <= d`` for every point,
+    since ``w >= w_min`` and ``|P| <= |P|_max``. Without it, a deviation carried by the
+    **weight** column is graded as though it were a coordinate: measured with the
+    perturbation in the weight and the coordinates at ``1e6``, the actual projected
+    deviation exceeded the requested tolerance by a factor of ``3.6e5``. A circle cannot
+    show this, because its weights are structurally tied to its coordinates.
+
+    Two honest caveats.
+
+    The bound is **tight for a weight-carried perturbation and conservative for a purely
+    geometric one**, by up to a factor ``1 + |P|_max``. Splitting ``D`` optimally between
+    the two parts gives ``sqrt(1 + |P|_max^2)``, which differs from ``1 + |P|_max`` by at
+    most ``sqrt(2)``, so almost none of that conservatism comes from the triangle
+    inequality: it comes from the kernel compressing a length and a weight into a single
+    Euclidean distance, which loses the direction. Removing it would mean the kernel
+    grading the two parts separately.
+
+    That is also why ``1 + |P|_max`` adds a pure number to a length. The
+    inhomogeneity is inherited from ``D``, whose components are not all of one unit,
+    and is not an error in the formula; the bound above holds at every scale.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Homogeneous control points, last
+            column the weights, of any shape whose last axis is the coordinate axis.
+        tol_euclidean (float): The caller's deviation budget, a distance in projected
+            space.
+
+    Returns:
+        float: The equivalent budget on homogeneous control points.
+    """
+    flat = np.asarray(ctrl, dtype=np.float64).reshape(-1, ctrl.shape[-1])
+    weights = flat[:, -1]
+    w_min = float(np.abs(weights).min())
+    projected = flat[:, :-1] / weights[:, None]
+    p_max = float(np.linalg.norm(projected, axis=1).max())
+    return tol_euclidean * w_min / (1.0 + p_max)
 
 
 def _remove_knot_bspline_1d_impl(  # noqa: PLR0913
@@ -40,7 +105,9 @@ def _remove_knot_bspline_1d_impl(  # noqa: PLR0913
         num (int | None): Maximum number of removals. ``None`` removes as many
             as possible (up to the current multiplicity, capped at ``degree``).
         tol_space (float): Tolerance for knot comparison.
-        tol_deviation (float): Maximum allowed geometric deviation.
+        tol_deviation (float): Maximum allowed control-point deviation, already in the
+            units the kernel measures in (homogeneous for a rational spline); see the
+            module docstring.
 
     Returns:
         tuple[npt.NDArray, npt.NDArray, int]: ``(new_knots, new_ctrl, removals)``
@@ -106,15 +173,14 @@ def _remove_knots_bspline(
             that direction.
         num (int | None): Maximum removals per knot value. ``None`` removes
             as many as possible.
-        tol (float | None): Geometric deviation tolerance. ``None`` uses a
-            default of ``1e-10``.
+        tol (float | None): Deviation tolerance, a distance in **projected** space.
+            ``None`` uses a default of ``1e-10``.
 
     Returns:
         Bspline: New B-spline with reduced knot vectors.
     """
     dim = bspline.dim
     ctrl = bspline.control_points
-    tol_deviation = 1e-10 if tol is None else tol
 
     from ._bspline_space_1d import BsplineSpace1D  # noqa: PLC0415
 
@@ -127,6 +193,13 @@ def _remove_knots_bspline(
         if kv is None or kv.size == 0:
             new_spaces_1d.append(space_1d)
             continue
+
+        # Resolved per direction, from the control points as they stand: `ctrl` is
+        # carried forward from the previous direction.
+        requested = 1e-10 if tol is None else tol
+        tol_deviation = (
+            _homogeneous_deviation_tolerance(ctrl, requested) if bspline.is_rational else requested
+        )
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
 

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -87,6 +87,30 @@ def _control_point_scale(ctrl: npt.NDArray[np.float32 | np.float64]) -> float:
     return max(diagonal, magnitude)
 
 
+def _num_stacked_control_points(ctrl: npt.NDArray[np.float32 | np.float64], axis: int) -> int:
+    """Count the control points the kernel's one distance will span, reducing ``axis``.
+
+    :func:`~pantr._array_utils._flatten_along_axis` moves ``axis`` to the front and
+    flattens everything after it, so the kernel sees ``(ctrl.shape[axis], rest)`` and its
+    Euclidean distance runs over every control point of every *other* direction at once.
+    That count is the product of the basis counts excluding ``axis`` -- one for a curve.
+
+    Kept as its own function because getting it the wrong way round (taking the reduced
+    axis instead of the others) is a mistake no behavioural test can catch: the floor
+    carries a 48x margin, so any positive multiplier still admits the removal. Only a
+    direct assertion on this number can.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points shaped
+            ``(*num_basis, rank)``, coordinate axis last.
+        axis (int): The parametric direction being reduced.
+
+    Returns:
+        int: The number of stacked control points, at least one.
+    """
+    return int(np.prod(ctrl.shape[:-1])) // int(ctrl.shape[axis])
+
+
 def _roundoff_deviation_floor(
     ctrl: npt.NDArray[np.float32 | np.float64], degree: int, num_stacked: int
 ) -> float:
@@ -356,10 +380,9 @@ def _remove_knots_bspline(
         # control-point scale and the number of stacked points all differ between
         # directions, and `ctrl` is carried forward from the previous one.
         if tol is None:
-            # How many control points the kernel's one Euclidean distance will span:
-            # every direction but this one. See `_roundoff_deviation_floor`.
-            num_stacked = int(np.prod(ctrl.shape[:-1])) // ctrl.shape[i]
-            tol_deviation = _roundoff_deviation_floor(ctrl, space_1d.degree, num_stacked)
+            tol_deviation = _roundoff_deviation_floor(
+                ctrl, space_1d.degree, _num_stacked_control_points(ctrl, i)
+            )
         elif bspline.is_rational:
             # Not scaled by `num_stacked`: an explicit budget is a promise about each
             # control point, and widening the aggregate would let one point absorb the

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -204,19 +204,34 @@ def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -
     around ``1e-10`` while ``eps * 1`` would be demanded -- so the scale is the maximum
     of the two.
 
-    The margin that leaves is thin and worth stating rather than assuming.
-    :func:`pantr.tolerance.get_default` is ``64 * eps``, so the threshold is
-    ``64 * eps * scale`` while the floor above is ``C * eps * max|coordinate|`` with
-    ``C`` of the order of ``prod(degree + 1)``. Measured on warped tensor-product maps in
-    1 to 3 directions at degrees 1 to 5, with the geometry translated to ``x = 1e6``: the
-    worst residual over 40 query points reaches ``60 * eps * scale``, against a threshold
-    of ``64``. Every point is still located -- ``C`` is a pessimistic count, since the de
-    Boor sum is a convex combination and its roundings do not all add -- but a caller with
-    a worse-conditioned map should pass ``tol`` explicitly rather than rely on 6 percent.
+    **What the default tier buys, measured.** :func:`pantr.tolerance.get_default` is
+    ``64 * eps``, and an earlier reading of this called that a six percent margin over an
+    arithmetic floor: the worst residual observed came out at ``60 * eps * scale`` against
+    a threshold of 64. That reading is wrong, and the way it is wrong matters, because a
+    thin margin invites loosening the tier and loosening the tier here is the one thing
+    that costs accuracy outright.
 
-    A geometry with no length at all (every control point identical, at the origin)
-    falls back to ``1.0``: there is no scale to read off it, and the tolerance must stay
-    positive.
+    The iteration *stops* at the threshold, so the residuals of the points it returns are
+    censored by it and ``60`` was the ceiling, not a floor. Re-measured at six thresholds
+    from ``2`` to ``4096`` epsilons, on 3960 mildly warped and 5520 strongly warped query
+    points (degrees 1 to 5 in 1 to 3 directions, at scales 1 and ``1e6``, with the targets
+    pushed a few ulp off the machine-exact image so the exact preimage is not a solution):
+    the worst achieved residual tracks whatever threshold is set, to within one part in a
+    hundred, at every one of them. Nothing was lost even at ``4 * eps * scale``.
+
+    Two consequences. The threshold is an **accuracy contract**, not a safety margin, so
+    moving to a looser tier would degrade the returned coordinates one-for-one and buy no
+    robustness. And ``C ~ prod(degree + 1)`` is not the operative floor: the residual shows
+    no dependence on ``prod(degree + 1)`` across 3 to 125. The default tier stays, now for
+    a stated reason rather than by a margin that was an artifact of the measurement.
+
+    A geometry with no length at all -- every control point identical, *at the origin* --
+    falls back to ``1.0``: there is nothing to read a scale off, and the tolerance must
+    stay positive. That fallback is deliberately not a floor of one. A floor would make the
+    tolerance stop shrinking below unit size, so a model in metres and the same model in
+    kilometres would be held to different relative accuracies, which is exactly the
+    non-covariance the rest of this derivation exists to remove. A degenerate geometry
+    sitting *away* from the origin has a magnitude and uses it.
 
     Args:
         lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
@@ -230,7 +245,8 @@ def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -
     box_hi = hi.max(axis=0)
     diagonal = float(np.linalg.norm(box_hi - box_lo))
     magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
-    return max(diagonal, magnitude, 1.0)
+    scale = max(diagonal, magnitude)
+    return scale if scale > 0.0 else 1.0
 
 
 def _build_context(spline: Bspline) -> _LocateContext:

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -27,10 +27,15 @@ because each is what makes one number enough:
 knot vector, then applied to the *refined* one after boundary insertion. Knot
 insertion never changes the first or last knot, so ``_knot_scale`` is identical for
 both and the tolerance means the same thing on either side. The one stage that does
-change the endpoints is the periodic-to-open conversion, which clamps the vector to
-its own domain and can only *shrink* the scale (by the ratio of the padded extent to
-the domain, at most a small factor). The inherited tolerance is then conservative
-rather than tight, which is the safe direction for a merge test.
+change the endpoints is the periodic-to-open conversion, which trims the ghost knots
+and leaves the vector spanning ``[a, b] = [knots[p], knots[-p - 1]]``. That can only
+*shrink* the scale, and the three-line argument is worth writing down rather than
+asserting: ``[a, b]`` is contained in ``[knots[0], knots[-1]]``, so ``b - a`` is at
+most the original span; and the largest absolute value on a real interval is attained
+at an endpoint, so ``|a|`` and ``|b|`` are both at most
+``max(|knots[0]|, |knots[-1]|)``. Each of the three terms of ``_knot_scale`` therefore
+only decreases. The inherited tolerance is then conservative rather than tight, which
+is the safe direction for a merge test.
 
 **The extraction offsets widen, and that direction is deliberate.** The sub-vector
 is cut with ``searchsorted(refined_knots, a_new - tol)`` and

--- a/src/pantr/bspline/_bspline_restrict.py
+++ b/src/pantr/bspline/_bspline_restrict.py
@@ -5,6 +5,52 @@ domain of a B-spline. The core logic inserts knots at the new boundaries until t
 reach multiplicity ``degree + 1``, then extracts the relevant knot sub-vector and
 control points. An optimization skips insertion when a bound coincides with an
 already-open domain endpoint.
+
+Tolerance policy
+----------------
+
+Restriction introduces **no tolerance of its own**, and that is the policy rather
+than an omission. Every comparison it makes is between two parametric coordinates
+of one knot vector -- a requested bound against a domain endpoint, against an
+existing knot, against the refined vector -- so every one of them is the question
+:func:`~pantr.bspline._bspline_knots._knot_tolerance` already answers: *are these
+two values the same knot?* The single ``tol`` threaded through this module is
+:attr:`~pantr.bspline.BsplineSpace1D.tolerance`, the absolute parametric length
+``8 * eps * max(span, |knots[0]|, |knots[-1]|)`` that the space derived once at
+construction. Introducing a second number here would be inventing a second notion
+of knot identity for the same vector.
+
+Three properties of that inheritance are load-bearing and are worth stating,
+because each is what makes one number enough:
+
+**The scale does not move between the stages.** ``tol`` is derived from the input
+knot vector, then applied to the *refined* one after boundary insertion. Knot
+insertion never changes the first or last knot, so ``_knot_scale`` is identical for
+both and the tolerance means the same thing on either side. The one stage that does
+change the endpoints is the periodic-to-open conversion, which clamps the vector to
+its own domain and can only *shrink* the scale (by the ratio of the padded extent to
+the domain, at most a small factor). The inherited tolerance is then conservative
+rather than tight, which is the safe direction for a merge test.
+
+**The extraction offsets widen, and that direction is deliberate.** The sub-vector
+is cut with ``searchsorted(refined_knots, a_new - tol)`` and
+``searchsorted(refined_knots, b_new + tol) - 1``: both move the cut *away* from the
+interval, so a boundary knot can never be dropped by a coordinate landing a rounding
+short of its own value. This is what the previous absolute tolerance got wrong. At a
+domain based at ``1e6`` one ulp of the bound is about ``1.2e-10``, so the old fixed
+``1e-12`` was absorbed entirely by ``b_new + tol == b_new`` and the cut fell before
+the first copy of ``b_new``, silently truncating the last ``degree + 1`` knots. A
+tolerance of ``8 * eps * scale`` is at least four ulp of any coordinate in the
+vector, so the offset always changes the value it is added to and the cut always
+lands past the whole boundary group.
+
+**Widening cannot over-collect.** :class:`~pantr.bspline.BsplineSpace1D` snaps its
+knots by the same rule, so two *distinct* stored knots differ by more than ``tol``
+and a cut widened by ``tol`` cannot reach the next one. The one configuration where
+that is not enough is a bound falling between two distinct knots less than
+``2 * tol`` apart, which requires a mesh already at the format's resolution floor
+for its magnitude -- the regime
+:func:`~pantr.bspline._bspline_knots._check_snapping_kept_an_interval` reports on.
 """
 
 from __future__ import annotations
@@ -33,12 +79,18 @@ def _validate_restrict_bounds(
 ) -> tuple[float, float]:
     """Validate and snap restriction bounds for a 1D B-spline.
 
+    A bound within ``tol`` of a domain endpoint *is* that endpoint: it is accepted
+    rather than rejected as out of range, and then snapped onto the stored value so
+    the rest of the algorithm compares bitwise.
+
     Args:
-        knots: Knot vector.
-        degree: Polynomial degree.
-        tol: Knot comparison tolerance.
-        a_new: Requested left bound.
-        b_new: Requested right bound.
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector.
+        degree (int): Polynomial degree.
+        tol (float): Absolute parametric tolerance, from
+            :attr:`~pantr.bspline.BsplineSpace1D.tolerance`; see the module
+            docstring for why restriction adds nothing to it.
+        a_new (float): Requested left bound.
+        b_new (float): Requested right bound.
 
     Returns:
         tuple[float, float]: Snapped ``(a_new, b_new)`` bounds.
@@ -79,11 +131,15 @@ def _compute_boundary_knots_to_insert(
     Skips insertion when the boundary coincides with an already-open domain endpoint.
 
     Args:
-        knots: Knot vector (must be non-periodic/open-compatible).
-        degree: Polynomial degree.
-        tol: Knot comparison tolerance.
-        a_new: Left bound of the restricted domain.
-        b_new: Right bound of the restricted domain.
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector (must be
+            non-periodic/open-compatible).
+        degree (int): Polynomial degree.
+        tol (float): Absolute parametric tolerance, from
+            :attr:`~pantr.bspline.BsplineSpace1D.tolerance`. It decides which
+            existing knots already *are* the boundary, and so how many copies the
+            boundary is short of multiplicity ``degree + 1``.
+        a_new (float): Left bound of the restricted domain.
+        b_new (float): Right bound of the restricted domain.
 
     Returns:
         npt.NDArray: 1D array of knot values to insert (may be empty).
@@ -140,12 +196,17 @@ def _restrict_bspline_1d_impl(  # noqa: PLR0913
     :func:`_to_open_bspline_1d_impl`.
 
     Args:
-        knots: Knot vector of shape ``(len(knots),)``.
-        degree: Polynomial degree.
-        ctrl_2d: Control point matrix of shape ``(n, rank)``.
-        periodic: Whether the spline is periodic.
-        tol: Knot comparison tolerance.
-        bounds: ``(a_new, b_new)`` — left and right bounds of the restricted domain.
+        knots (npt.NDArray[np.float32 | np.float64]): Knot vector of shape
+            ``(len(knots),)``.
+        degree (int): Polynomial degree.
+        ctrl_2d (npt.NDArray[np.float32 | np.float64]): Control point matrix of
+            shape ``(n, rank)``.
+        periodic (bool): Whether the spline is periodic.
+        tol (float): Absolute parametric tolerance, from
+            :attr:`~pantr.bspline.BsplineSpace1D.tolerance`, serving every
+            comparison here; see the module docstring for the policy.
+        bounds (tuple[float, float]): ``(a_new, b_new)``, the left and right bounds
+            of the restricted domain.
 
     Returns:
         tuple[npt.NDArray, npt.NDArray]: ``(restricted_knots, restricted_ctrl)``
@@ -177,9 +238,12 @@ def _restrict_bspline_1d_impl(  # noqa: PLR0913
     else:
         refined_knots, refined_ctrl = knots, ctrl_2d
 
-    # Extract the sub-region [a_new, b_new].
-    # After insertion, a_new has multiplicity p+1 starting at index i_start,
-    # and b_new has multiplicity p+1 ending at index i_end.
+    # Extract the sub-region [a_new, b_new]. After insertion, a_new has multiplicity
+    # p+1 starting at index i_start, and b_new has multiplicity p+1 ending at i_end.
+    # Both offsets widen the cut away from the interval, so a boundary knot cannot be
+    # dropped by a coordinate landing a rounding short of its own value, and `tol` is
+    # at least four ulp of any coordinate here so the offset is never absorbed; see
+    # the module docstring.
     i_start = int(np.searchsorted(refined_knots, a_new - tol))
     i_end = int(np.searchsorted(refined_knots, b_new + tol)) - 1
 

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -232,7 +232,18 @@ def _slope_bound(
     rejecting a genuine zero. Sharpening it to the knot span holding the zero is a
     tolerance-policy question and is *not* a matter of computing the same quantity on the
     working window: after a hundred insertions the local knot gaps there are degenerate
-    and the same formula returns a bound larger than the spline's own range.
+    and the same formula returns a bound larger than the spline's own range. A correct
+    local version would have to index the *original* knot vector by parametric position,
+    and ``root_tol`` reaches the kernel as one scalar decided before any zero is located,
+    so it would also have to become a per-span quantity the kernel indexes.
+
+    That work is deliberately not done, and the reason is that the looseness has not been
+    shown to cost anything. A search for a live false positive -- a value this threshold
+    accepts that the local bound would reject -- found none across 948 random splines and
+    376 sweep cases. It is therefore a tightening rather than a bug fix, and the direction
+    that would be fatal here is the opposite one: for a root finder, a ``root_tol`` that
+    is too *large* returns values that are not roots, and no local sharpening can make
+    the threshold larger than this bound.
 
     Args:
         coeffs (npt.NDArray[np.float64]): Scalar B-spline coefficients.

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -24,7 +24,7 @@ import numpy as np
 from scipy import sparse
 
 from ..grid import HierarchicalGrid, hierarchical_grid, tensor_product_grid
-from ..tolerance import get_strict
+from ..tolerance import get_conservative, get_strict
 from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core
 from ._bspline_space_nd import BsplineSpace
 from ._thb_eval_core import _combine_tp_values
@@ -145,6 +145,57 @@ def _cell_membership_tolerance(
     """
     scale = np.maximum(np.maximum(np.abs(cell_lo), np.abs(cell_hi)), cell_hi - cell_lo)
     return np.asarray(_CELL_MEMBERSHIP_SAFETY * get_strict(np.float64) * scale, dtype=np.float64)
+
+
+def _prolongation_residual_tolerance(max_coarse_val: float) -> float:
+    """Get the residual above which a coarse column is not reproduced by the fine basis.
+
+    What is graded is ``max_i |A x - b|`` over every column of the prolongation, where
+    ``b`` is a coarse function's coefficient vector in a common tensor-product level and
+    ``A``'s columns are the candidate fine functions' vectors in the same basis. All the
+    entries are refinement (Oslo) coefficients, so the quantity is dimensionless and its
+    natural size is ``max_coarse_val = ||b||_inf`` -- measured to be exactly ``1.0`` for
+    every genuine refinement, the partition-of-unity value. The ``1 +`` is the floor that
+    keeps the threshold positive for a coarse function whose column is empty.
+
+    ``np.linalg.lstsq(rcond=None)`` dispatches to LAPACK's ``gelsd``, which is normwise
+    backward stable: the computed ``x_hat`` solves ``(A + dA) y = b + db`` in the
+    least-squares sense with ``||dA|| <= c eps ||A||`` and ``||db|| <= c eps ||b||``. For
+    a genuine refinement the exact system is consistent, so the exact residual is zero
+    and
+
+        ||A x_hat - b|| <= 2 (||dA|| ||x_hat|| + ||db||) = O(c eps (||A|| ||x|| + ||b||)),
+
+    with every factor on the right of order one here: the entries of ``A``, ``x`` and
+    ``b`` are all refinement coefficients in ``[0, 1]``. The residual is therefore a
+    small multiple of ``eps``, and ``c`` is the part no closed form is available for.
+
+    **Measured**, over 132 configurations (1D, 2D and 3D; degrees 2 to 5; 4 to 16
+    elements per axis; truncated and non-truncated; one and two refinement levels;
+    domains ``[0, 1]``, ``[0, 1e-6]`` and ``[1e6, 1e6 + 1]``): the worst residual is
+    ``18.5 * eps``, and it is bit-identical between ``[0, 1]`` and ``[1e6, 1e6 + 1]``,
+    as a dimensionless quantity must be.
+
+    The tier is :func:`~pantr.tolerance.get_conservative`, ``4096 * eps``, whose stated
+    meaning is a long accumulation -- which an SVD-based least-squares solve is. Against
+    the worst measured that is a safety factor of ``4096 * 2 / 18.5 = 443``, and it is
+    what stands in for the unknown ``c``.
+
+    A ``sqrt(M)`` term with ``M = A.shape[0]`` was considered, since ``||b||_2`` carries
+    one, and **rejected on measurement**: over the same runs ``M`` ranges from 13 to
+    19683 and the residual does not track it (``res / eps`` is 2.0 at ``M = 13`` and 16.5
+    at ``M = 19683``; normalizing by ``sqrt(M)`` makes the spread *worse*, from 3.10 down
+    to 0.10). Carrying it would loosen the gate 140-fold on the largest systems for a
+    growth that is not there. If one ever appears, that term is where it belongs.
+
+    Args:
+        max_coarse_val (float): Largest absolute coefficient over every coarse column,
+            ``||b||_inf``.
+
+    Returns:
+        float: The residual threshold, in the coefficients' own dimensionless units.
+    """
+    return get_conservative(np.float64) * (1.0 + max_coarse_val)
 
 
 def _check_out_array(
@@ -1832,8 +1883,9 @@ class THBSplineSpace:
         Raises:
             TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
             ValueError: If ``fine`` is not a refinement of this space (mismatched
-                root/factor/regularity/truncation, fewer levels, or the prolongation
-                residual is non-negligible).
+                root/factor/regularity/truncation, fewer levels, or a prolongation
+                residual above ``4096 * eps * (1 + max_coarse_value)``; see
+                :func:`_prolongation_residual_tolerance`).
         """
         self._check_is_refinement(fine)
         return self._assemble_prolongation(fine)
@@ -1939,8 +1991,9 @@ class THBSplineSpace:
             index, the fine dof indices its column occupies, and the values there.
 
         Raises:
-            ValueError: If some column cannot reproduce its coarse function (residual
-                above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+            ValueError: If some column cannot reproduce its coarse function -- a
+                residual above :func:`_prolongation_residual_tolerance` -- i.e. ``fine``
+                is not a refinement of ``self``.
 
         Note:
             The residual is only known once every column has been solved, so the check
@@ -1975,10 +2028,11 @@ class THBSplineSpace:
             max_residual = max(max_residual, residual)
             max_coarse_val = max(max_coarse_val, coarse_val)
 
-        if max_residual > 1e-8 * (1.0 + max_coarse_val):
+        residual_tol = _prolongation_residual_tolerance(max_coarse_val)
+        if max_residual > residual_tol:
             raise ValueError(
                 f"fine is not a refinement of this space (prolongation residual "
-                f"{max_residual:.2e})."
+                f"{max_residual:.2e}, above {residual_tol:.2e})."
             )
 
     def _assemble_prolongation(self, fine: THBSplineSpace) -> npt.NDArray[np.float64]:
@@ -1992,8 +2046,9 @@ class THBSplineSpace:
             ``(fine.num_total_basis, self.num_total_basis)``.
 
         Raises:
-            ValueError: If a column cannot reproduce its coarse function (residual
-                above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+            ValueError: If a column cannot reproduce its coarse function -- a residual
+                above :func:`_prolongation_residual_tolerance` -- i.e. ``fine`` is not a
+                refinement of ``self``.
         """
         shape = (fine.num_total_basis, self.num_total_basis)
         prolongation: npt.NDArray[np.float64] = np.zeros(shape, dtype=np.float64)
@@ -2012,8 +2067,9 @@ class THBSplineSpace:
             ``(fine.num_total_basis, self.num_total_basis)``, ``float64``.
 
         Raises:
-            ValueError: If a column cannot reproduce its coarse function (residual
-                above tolerance), i.e. ``fine`` is not a refinement of ``self``.
+            ValueError: If a column cannot reproduce its coarse function -- a residual
+                above :func:`_prolongation_residual_tolerance` -- i.e. ``fine`` is not a
+                refinement of ``self``.
 
         Note:
             Assembled through COO, whose duplicate summation never fires: each column is

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -135,6 +135,15 @@ def _cell_membership_tolerance(
     physical choice this layer is not entitled to make, and it destroys covariance on
     a domain smaller than one unit.
 
+    The dtype is ``float64`` and not the root space's, which is where this departs from
+    :func:`~pantr.bspline._bspline_knots._knot_tolerance`'s ``get_strict(knots.dtype)``.
+    The reason is that it grades different objects: ``cell_bounds`` returns ``float64``
+    whatever the root space is made of, and :meth:`THBSplineSpace._tabulate_orders` casts
+    the query points to ``float64`` before the comparison, so ``float64`` *is* the
+    precision of both sides here. A caller whose points carry only ``float32``
+    information should widen them before asking, rather than have the containment check
+    widened by eight million for everyone.
+
     Args:
         cell_lo (npt.NDArray[np.float64]): Per-axis lower cell bound, shape ``(dim,)``.
         cell_hi (npt.NDArray[np.float64]): Per-axis upper cell bound, same shape.

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy import sparse
 
 from ..grid import HierarchicalGrid, hierarchical_grid, tensor_product_grid
+from ..tolerance import get_strict
 from ._bspline_knot_insertion_core import _compute_oslo_matrix_1d_core
 from ._bspline_space_nd import BsplineSpace
 from ._thb_eval_core import _combine_tp_values
@@ -86,6 +87,64 @@ _EINSUM_MAX_DIM = 24
 ``string.ascii_lowercase`` provides 26 letters; the einsum needs ``dim`` letters for the
 coefficient axes plus one for the point axis, leaving a safe ceiling of 24 dimensions.
 """
+
+_CELL_MEMBERSHIP_SAFETY: float = 2.0
+"""Extra factor on the strict tier for deciding that a point lies in a cell.
+
+Together with :func:`~pantr.tolerance.get_strict` this is ``8 * eps``, the same rule and
+the same number as :func:`~pantr.bspline._bspline_knots._knot_tolerance` -- deliberately,
+because it is the same question. A cell boundary is a parametric coordinate, and asking
+whether a point has fallen off it is asking whether two parametric coordinates are the
+same one.
+
+What has to be covered is the caller's route to the point. A point *in* cell
+``[lo, hi]`` is almost always formed as ``lo + xi * (hi - lo)`` for some ``xi`` in
+``[0, 1]``: a subtraction, a multiplication and an addition, three roundings, each on a
+quantity no larger than ``max(|lo|, |hi|)``, so the computed point sits within
+``3 * eps * max(|lo|, |hi|)`` of the exact one. The bounds themselves arrive from
+:meth:`~pantr.grid.HierarchicalGrid.cell_bounds`, which subdivides the axis by the same
+kind of arithmetic and at the same magnitude. Four epsilons cover either route and eight
+covers both plus an FMA contraction, which is the doubling
+:data:`~pantr.bspline._bspline_knots._KNOT_MERGE_SAFETY` applies for the same reason.
+
+The magnitude it multiplies is the **cell's own**, not the axis's: see
+:func:`_cell_membership_tolerance`.
+"""
+
+
+def _cell_membership_tolerance(
+    cell_lo: npt.NDArray[np.float64], cell_hi: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    """Get the per-axis absolute slack allowed at a cell boundary.
+
+    ``_CELL_MEMBERSHIP_SAFETY * get_strict(float64) * max(|lo|, |hi|, hi - lo)`` per
+    axis, i.e. ``8 * eps`` times the cell's own magnitude. The magnitude is exactly
+    what :func:`~pantr.bspline._bspline_knots._knot_scale` computes, applied to the
+    two-element vector ``[lo, hi]`` rather than to a whole knot vector.
+
+    The scale is the **cell's**, not the axis's, and the difference is not cosmetic.
+    A point in the cell is formed from ``lo`` and ``hi``, so its round-off is relative
+    to those two coordinates; a cell of width ``1e-3`` on a domain reaching ``1e6``
+    would, on the axis scale, accept a point half a billion cell-widths outside. The
+    coordinate terms ``|lo|`` and ``|hi|`` are what carry the case of a *narrow* cell
+    far from the origin, where the width alone would demand agreement the arithmetic
+    that produced the bounds cannot deliver.
+
+    No floor is applied, for the reason
+    :func:`~pantr.bspline._bspline_knots._knot_scale` gives: a floor of one would be a
+    physical choice this layer is not entitled to make, and it destroys covariance on
+    a domain smaller than one unit.
+
+    Args:
+        cell_lo (npt.NDArray[np.float64]): Per-axis lower cell bound, shape ``(dim,)``.
+        cell_hi (npt.NDArray[np.float64]): Per-axis upper cell bound, same shape.
+
+    Returns:
+        npt.NDArray[np.float64]: Per-axis absolute tolerance, shape ``(dim,)``, in the
+        units of the parametric coordinates.
+    """
+    scale = np.maximum(np.maximum(np.abs(cell_lo), np.abs(cell_hi)), cell_hi - cell_lo)
+    return np.asarray(_CELL_MEMBERSHIP_SAFETY * get_strict(np.float64) * scale, dtype=np.float64)
 
 
 def _check_out_array(
@@ -1075,8 +1134,10 @@ class THBSplineSpace:
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
-                cell ``cid``.  A tolerance of ``1e-12`` is applied at the cell
-                boundary; points further outside raise :class:`ValueError`.
+                cell ``cid``.  Per axis, ``8 * eps * max(|lo|, |hi|, hi - lo)`` of slack
+                is allowed at the cell boundary (see
+                :func:`_cell_membership_tolerance`); points further outside raise
+                :class:`ValueError`.
             orders (tuple[int, ...]): Per-direction derivative orders.
             out_basis (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
@@ -1109,10 +1170,11 @@ class THBSplineSpace:
         flat_pts = pts_arr.reshape(num_pts, self.dim)
 
         cell_lo, cell_hi = self._grid.cell_bounds(cid)
-        _tol = 1e-12
-        if not (np.all(flat_pts >= cell_lo - _tol) and np.all(flat_pts <= cell_hi + _tol)):
+        tol = _cell_membership_tolerance(cell_lo, cell_hi)
+        if not (np.all(flat_pts >= cell_lo - tol) and np.all(flat_pts <= cell_hi + tol)):
             raise ValueError(
-                f"pts must lie inside cell {cid!r} with bounds lo={cell_lo}, hi={cell_hi}."
+                f"pts must lie inside cell {cid!r} with bounds lo={cell_lo}, hi={cell_hi} "
+                f"(slack {tol})."
             )
 
         out_shape = (*lead, n_active)
@@ -1184,7 +1246,8 @@ class THBSplineSpace:
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
-                cell ``cid``.  Points outside the cell's bounds raise
+                cell ``cid``.  Per axis, ``8 * eps * max(|lo|, |hi|, hi - lo)`` of
+                slack is allowed at the boundary; points further outside raise
                 :class:`ValueError`.
             out_basis (npt.NDArray[np.float64] | None): Optional output array of shape
                 ``(..., K)`` with ``K = active_basis(cid).size``.  Allocated when
@@ -1226,7 +1289,8 @@ class THBSplineSpace:
         Args:
             cid (int): Active cell flat id in ``[0, grid.num_cells)``.
             pts (npt.ArrayLike): Parametric points of shape ``(..., dim)`` lying in
-                cell ``cid``.  Points outside the cell's bounds raise
+                cell ``cid``.  Per axis, ``8 * eps * max(|lo|, |hi|, hi - lo)`` of
+                slack is allowed at the boundary; points further outside raise
                 :class:`ValueError`.
             orders (int | Sequence[int]): Per-direction derivative orders.  A scalar
                 is broadcast to every direction.  Each entry must be ``>= 0``; orders

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1884,8 +1884,8 @@ class THBSplineSpace:
             TypeError: If ``fine`` is not a :class:`THBSplineSpace`.
             ValueError: If ``fine`` is not a refinement of this space (mismatched
                 root/factor/regularity/truncation, fewer levels, or a prolongation
-                residual above ``4096 * eps * (1 + max_coarse_value)``; see
-                :func:`_prolongation_residual_tolerance`).
+                residual above ``4096 * eps * (1 + max_coarse_value)``, where
+                ``max_coarse_value`` is the largest coefficient of any coarse column).
         """
         self._check_is_refinement(fine)
         return self._assemble_prolongation(fine)

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import copy
 import itertools
 import string
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 import numpy as np
 from scipy import sparse
@@ -88,7 +88,7 @@ _EINSUM_MAX_DIM = 24
 coefficient axes plus one for the point axis, leaving a safe ceiling of 24 dimensions.
 """
 
-_CELL_MEMBERSHIP_SAFETY: float = 2.0
+_CELL_MEMBERSHIP_SAFETY: Final[float] = 2.0
 """Extra factor on the strict tier for deciding that a point lies in a cell.
 
 Together with :func:`~pantr.tolerance.get_strict` this is ``8 * eps``, the same rule and
@@ -158,23 +158,38 @@ def _prolongation_residual_tolerance(max_coarse_val: float) -> float:
     every genuine refinement, the partition-of-unity value. The ``1 +`` is the floor that
     keeps the threshold positive for a coarse function whose column is empty.
 
-    ``np.linalg.lstsq(rcond=None)`` dispatches to LAPACK's ``gelsd``, which is normwise
-    backward stable: the computed ``x_hat`` solves ``(A + dA) y = b + db`` in the
-    least-squares sense with ``||dA|| <= c eps ||A||`` and ``||db|| <= c eps ||b||``. For
-    a genuine refinement the exact system is consistent, so the exact residual is zero
-    and
+    ``np.linalg.lstsq(rcond=None)`` dispatches to LAPACK's ``gelsd``, whose normwise
+    backward stability is the standard result for an SVD-based least-squares solve
+    (Golub & Van Loan, *Matrix Computations*, 4th ed., section 5.5; Higham, *Accuracy and
+    Stability of Numerical Algorithms*, 2nd ed., chapter 20): the computed ``x_hat`` is
+    the exact least-squares solution of ``(A + dA) y ~= b + db`` with
+    ``||dA|| <= c eps ||A||`` and ``||db|| <= c eps ||b||``.
 
-        ||A x_hat - b|| <= 2 (||dA|| ||x_hat|| + ||db||) = O(c eps (||A|| ||x|| + ||b||)),
+    The step from that to a residual bound is worth spelling out, because ``x_hat`` does
+    *not* satisfy the perturbed system exactly -- a least-squares solution leaves its own
+    residual ``r_pert``. Writing ``x`` for the exact solution of the unperturbed system,
+    which for a genuine refinement is consistent (``A x = b``), and using ``x`` as a trial
+    vector for the perturbed minimisation:
 
-    with every factor on the right of order one here: the entries of ``A``, ``x`` and
-    ``b`` are all refinement coefficients in ``[0, 1]``. The residual is therefore a
-    small multiple of ``eps``, and ``c`` is the part no closed form is available for.
+        ||r_pert|| <= ||(A + dA) x - (b + db)|| = ||dA x - db|| <= ||dA|| ||x|| + ||db||,
+        ||A x_hat - b|| <= ||r_pert|| + ||dA|| ||x_hat|| + ||db||
+                        <= 2 (||dA|| max(||x||, ||x_hat||) + ||db||),
+
+    which is ``O(c eps (||A|| ||x|| + ||b||))``. The factor of two is that argument's, not
+    a safety pad. Every factor on the right is of order one here: the entries of ``A``,
+    ``x`` and ``b`` are all refinement coefficients in ``[0, 1]``. The residual is
+    therefore a small multiple of ``eps``, and ``c`` is the part no closed form is
+    available for. The code grades ``max_i |A x - b|``, an infinity norm, which is at most
+    the two-norm the bound is stated in, so the bound covers it.
 
     **Measured**, over 132 configurations (1D, 2D and 3D; degrees 2 to 5; 4 to 16
     elements per axis; truncated and non-truncated; one and two refinement levels;
     domains ``[0, 1]``, ``[0, 1e-6]`` and ``[1e6, 1e6 + 1]``): the worst residual is
-    ``18.5 * eps``, and it is bit-identical between ``[0, 1]`` and ``[1e6, 1e6 + 1]``,
-    as a dimensionless quantity must be.
+    ``18.5 * eps``. It came out bit-identical between ``[0, 1]`` and ``[1e6, 1e6 + 1]``
+    in every one of those configurations, which is a stronger statement than the
+    quantity's dimensionlessness requires -- that only forces the residual to be
+    *comparable* across scales, not bitwise equal -- so it is reported as observed and
+    nothing is built on it.
 
     The tier is :func:`~pantr.tolerance.get_conservative`, ``4096 * eps``, whose stated
     meaning is a long accumulation -- which an SVD-based least-squares solve is. Against

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -94,8 +94,7 @@ def create_coons_surface(
         ValueError: If any curve is not 1D.
         ValueError: If corner points are not geometrically consistent, i.e. two curves
             disagree at a shared corner by more than ``4096 * eps`` times the largest
-            absolute coordinate over all eight corner values (see
-            :func:`_verify_corners_2d`).
+            absolute coordinate over all eight corner values.
     """
     (c_v0, c_v1), (c_u0, c_u1) = curves
 

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -10,10 +10,32 @@ import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ..tolerance import get_conservative
 from ._compat import make_compat
 from ._operations import create_ruled
 from ._primitives import _linear_space_1d, create_bilinear, create_trilinear
 from ._validation import _promote_to_rational
+
+_CORNER_MATCH_TIER = get_conservative
+"""Which :mod:`pantr.tolerance` tier grades a corner mismatch.
+
+The conservative tier, ``4096 * eps``, and the choice is about what this check is
+*for*. Both curves meeting at a corner read it straight off a clamped control point,
+and knot insertion and degree elevation both leave a clamped endpoint untouched, so
+:func:`~pantr.cad.make_compat` does not move it: two curves that genuinely share a
+corner produce **bitwise equal** values, and no tolerance at all is needed for them.
+The slack exists only for a corner the caller *computed* rather than copied, by an
+intersection, a reparametrization or a transform, and the length of that chain is not
+something this function can see.
+
+So the threshold is not sized against a known accumulation; it is sized to catch the
+mistake the check exists for. That mistake is curves given in the wrong order or the
+wrong orientation, which misses by a fraction of the patch, not by epsilons. Failing
+in the other direction is the expensive one: a ``ValueError`` on a geometrically
+perfect patch. The conservative tier is the widest the table sanctions without a
+derivation of its own, and at unit scale it lands on ``9.1e-13``, within a factor of
+1.1 of the ``1e-12`` this check used before it acquired a scale.
+"""
 
 
 def _combine_control_points(
@@ -70,7 +92,10 @@ def create_coons_surface(
 
     Raises:
         ValueError: If any curve is not 1D.
-        ValueError: If corner points are not geometrically consistent.
+        ValueError: If corner points are not geometrically consistent, i.e. two curves
+            disagree at a shared corner by more than ``4096 * eps`` times the largest
+            absolute coordinate over all eight corner values (see
+            :func:`_verify_corners_2d`).
     """
     (c_v0, c_v1), (c_u0, c_u1) = curves
 
@@ -120,10 +145,27 @@ def _verify_corners_2d(
 ) -> None:
     """Verify that corner points from u-curves match v-curves.
 
+    The tolerance is ``_CORNER_MATCH_TIER(float64) * scale`` with ``scale`` the largest
+    absolute coordinate over **all eight** corner values, not just the pair under test.
+    Taking it over all eight is what makes the verdict independent of which corner
+    happens to sit at the origin: a corner at ``(0, 0, 0)`` supplies no scale of its
+    own, and grading it against zero would demand bitwise agreement of a coordinate the
+    caller may well have computed.
+
+    A fixed absolute tolerance cannot do this. Measured across twelve decades of
+    ``1e-12 / L``, a one-ulp corner mismatch was rejected at ``L >= 1e6`` -- a
+    micron-unit model of a metre-scale part failing on a geometrically perfect patch --
+    while a ``1e-9`` *relative* gap was accepted at ``L = 1e-6``.
+
+    ``np.allclose(..., rtol=0)`` is deliberately not used: with ``rtol`` zeroed it is
+    exactly ``max|pu - qv| <= atol``, so it buys nothing over writing that, and it hides
+    which of the two comparisons is doing the work.
+
     Args:
-        u_corners: Corners (p00, p10, p01, p11) extracted from u-curves.
-        c_v0: Left boundary curve (v-direction at u=0).
-        c_v1: Right boundary curve (v-direction at u=1).
+        u_corners (tuple[npt.NDArray[np.float64], ...]): Corners
+            ``(p00, p10, p01, p11)`` extracted from u-curves.
+        c_v0 (Bspline): Left boundary curve (v-direction at u=0).
+        c_v1 (Bspline): Right boundary curve (v-direction at u=1).
 
     Raises:
         ValueError: If any pair of corners does not match.
@@ -134,15 +176,24 @@ def _verify_corners_2d(
     q10 = np.asarray(c_v1.boundary(0, 0), dtype=np.float64)
     q11 = np.asarray(c_v1.boundary(0, 1), dtype=np.float64)
 
-    tol = 1e-12
-    for label, pu, qv in [
+    pairs = [
         ("(0,0)", p00, q00),
         ("(1,0)", p10, q10),
         ("(0,1)", p01, q01),
         ("(1,1)", p11, q11),
-    ]:
-        if not np.allclose(pu, qv, atol=tol, rtol=0):
-            raise ValueError(f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv}.")
+    ]
+    # No floor: eight corners all at the origin have no scale, and are also bitwise
+    # equal, so a zero tolerance is the right answer there rather than a hazard.
+    scale = max(float(np.abs(corner).max()) for _, pu, qv in pairs for corner in (pu, qv))
+    tol = _CORNER_MATCH_TIER(np.float64) * scale
+
+    for label, pu, qv in pairs:
+        gap = float(np.abs(pu - qv).max())
+        if gap > tol:
+            raise ValueError(
+                f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv} "
+                f"(gap {gap:.3e}, above {tol:.3e} at corner scale {scale:.3e})."
+            )
 
 
 def create_coons_volume(

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -16,27 +16,6 @@ from ._operations import create_ruled
 from ._primitives import _linear_space_1d, create_bilinear, create_trilinear
 from ._validation import _promote_to_rational
 
-_CORNER_MATCH_TIER = get_conservative
-"""Which :mod:`pantr.tolerance` tier grades a corner mismatch.
-
-The conservative tier, ``4096 * eps``, and the choice is about what this check is
-*for*. Both curves meeting at a corner read it straight off a clamped control point,
-and knot insertion and degree elevation both leave a clamped endpoint untouched, so
-:func:`~pantr.cad.make_compat` does not move it: two curves that genuinely share a
-corner produce **bitwise equal** values, and no tolerance at all is needed for them.
-The slack exists only for a corner the caller *computed* rather than copied, by an
-intersection, a reparametrization or a transform, and the length of that chain is not
-something this function can see.
-
-So the threshold is not sized against a known accumulation; it is sized to catch the
-mistake the check exists for. That mistake is curves given in the wrong order or the
-wrong orientation, which misses by a fraction of the patch, not by epsilons. Failing
-in the other direction is the expensive one: a ``ValueError`` on a geometrically
-perfect patch. The conservative tier is the widest the table sanctions without a
-derivation of its own, and at unit scale it lands on ``9.1e-13``, within a factor of
-1.1 of the ``1e-12`` this check used before it acquired a scale.
-"""
-
 
 def _combine_control_points(
     bsplines: list[Bspline],
@@ -144,8 +123,22 @@ def _verify_corners_2d(
 ) -> None:
     """Verify that corner points from u-curves match v-curves.
 
-    The tolerance is ``_CORNER_MATCH_TIER(float64) * scale`` with ``scale`` the largest
+    The tolerance is ``get_conservative(float64) * scale`` with ``scale`` the largest
     absolute coordinate over **all eight** corner values, not just the pair under test.
+
+    **Why the conservative tier.** Both curves meeting at a corner read it straight off a
+    clamped control point, and neither knot insertion nor degree elevation moves a clamped
+    endpoint, so :func:`~pantr.cad.make_compat` leaves it alone: two curves that genuinely
+    share a corner produce **bitwise equal** values and need no tolerance at all. The slack
+    exists only for a corner the caller *computed* rather than copied -- an intersection, a
+    reparametrization, a transform -- and the length of that chain is not something this
+    function can see. So the threshold is not sized against a known accumulation; it is
+    sized to catch the mistake the check exists for, which is curves given in the wrong
+    order or the wrong orientation, missing by a fraction of the patch rather than by
+    epsilons. Failing the other way is the expensive one: a ``ValueError`` on a
+    geometrically perfect patch. The conservative tier is the widest the table sanctions
+    without a derivation of its own, and at unit scale it lands on ``9.1e-13``, within a
+    factor of 1.1 of the ``1e-12`` this check used before it acquired a scale.
     Taking it over all eight is what makes the verdict independent of which corner
     happens to sit at the origin: a corner at ``(0, 0, 0)`` supplies no scale of its
     own, and grading it against zero would demand bitwise agreement of a coordinate the
@@ -184,7 +177,7 @@ def _verify_corners_2d(
     # No floor: eight corners all at the origin have no scale, and are also bitwise
     # equal, so a zero tolerance is the right answer there rather than a hazard.
     scale = max(float(np.abs(corner).max()) for _, pu, qv in pairs for corner in (pu, qv))
-    tol = _CORNER_MATCH_TIER(np.float64) * scale
+    tol = get_conservative(np.float64) * scale
 
     for label, pu, qv in pairs:
         gap = float(np.abs(pu - qv).max())

--- a/src/pantr/multipatch/_detect.py
+++ b/src/pantr/multipatch/_detect.py
@@ -62,7 +62,8 @@ class _Tolerances(NamedTuple):
 
     Attributes:
         geometric (float): For control-point coordinates. The relative tolerance
-            scaled by the joint bounding-box diagonal, so it tracks problem size.
+            scaled by ``max(joint bounding-box diagonal, largest |coordinate|)``, so
+            it tracks both the size of the problem and where it sits.
         parametric (float): For knot vectors already normalized to ``[0, 1]``.
             Dimensionless, so it is the bare relative tolerance.
         weight (float): For rational weights. Scaled by the largest weight in play
@@ -107,9 +108,20 @@ def _joint_tolerances(patch_a: Bspline, patch_b: Bspline, tol: float | None) -> 
     )
     extent = np.asarray(coords.max(axis=0) - coords.min(axis=0), dtype=np.float64)
     diagonal = float(np.linalg.norm(extent))
-    # A degenerate joint bounding box (both patches a single point) leaves no scale
-    # to borrow, so fall back to the bare relative tolerance rather than to zero.
-    geometric = relative * diagonal if diagonal > 0.0 else relative
+    # The diagonal alone is not the scale a coordinate comparison is relative to. Two
+    # small patches meeting at x = 1e6 have a diagonal of order one while the difference
+    # of two of their coordinates is formed from numbers of order 1e6, so it carries an
+    # absolute error of eps * 1e6 however short the diagonal is; grading against the
+    # diagonal there asks for agreement eight orders below the noise floor. The largest
+    # coordinate magnitude is therefore taken alongside it and the larger wins -- the
+    # same rule, for the same reason, as `_knot_scale` in the B-spline layer and
+    # `_geometric_scale` in point inversion.
+    magnitude = float(np.abs(coords).max()) if coords.size else 0.0
+    scale = max(diagonal, magnitude)
+    # A degenerate joint bounding box (both patches a single point, at the origin)
+    # leaves no scale to borrow, so fall back to the bare relative tolerance rather
+    # than to zero.
+    geometric = relative * scale if scale > 0.0 else relative
 
     weight_scale = 1.0
     if patch_a.is_rational or patch_b.is_rational:

--- a/src/pantr/tolerance.py
+++ b/src/pantr/tolerance.py
@@ -128,6 +128,20 @@ error is then ``cond * eps`` rather than an operation count times ``eps``, and
 4096 leaves a factor of four over that on top of the same build slack the default
 tier allows. Past this the tolerance stops being a safety factor and starts
 hiding the answer, so a site that needs more needs a derivation of its own.
+
+Both readings are in use. The long-accumulation one grades the prolongation
+residual of a THB refinement, an SVD least-squares solve whose backward-stability
+constant has no closed form
+(``pantr.bspline._thb_spline_space._prolongation_residual_tolerance``); the
+robustness one grades a Coons patch's corner match, where the caller's chain to
+the corner is unbounded and a false rejection costs more than a false accept
+(``pantr.cad._coons``).
+
+The ``1e3`` is this tier's boundary and not a statement about the library. pantr
+does contain a step past it -- ``pantr.change_basis`` documents a cardinal-to-
+Legendre condition number of ``3.0e8`` at degree 8 -- and that step accordingly
+reports the accuracy it actually attains per degree rather than borrowing a
+preset.
 """
 
 

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -599,6 +599,56 @@ class TestToleranceScaling:
         assert annulus.locate(points, max_iter=1)[0].tolist() == [-1, -1]
         assert annulus.locate(points, max_iter=30)[0].tolist() == [0, 0]
 
+    @pytest.mark.parametrize("lam", [1.0e-9, 1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6])
+    def test_the_scale_is_proportional_to_the_geometry_at_every_size(self, lam: float) -> None:
+        """No floor at one: a model in metres and in kilometres get the same relative bar.
+
+        ``max(diagonal, magnitude, 1.0)`` clamped the scale for any geometry smaller than
+        a unit, so a millimetre-scale part was held to a thousand times the relative
+        accuracy of a metre-scale one, and the tolerance stopped being covariant exactly
+        where the rest of this overhaul made it so.
+        """
+        scaled = _quarter_annulus(r_in=lam, r_out=2.0 * lam)
+        assert _scale_of(scaled) == pytest.approx(lam * _scale_of(_quarter_annulus()), rel=1e-12)
+
+    @pytest.mark.parametrize("lam", [1.0e-9, 1.0e-6, 1.0, 1.0e6])
+    def test_a_small_geometry_still_inverts(self, lam: float) -> None:
+        """Removing the floor tightens the bar on a sub-unit model; it must still be met.
+
+        This is the direction worth guarding. The old floor made the threshold *looser*
+        than the geometry warranted below unit size, so nothing down there had ever been
+        required to converge to its own scale.
+        """
+        spline = _quarter_annulus(r_in=lam, r_out=2.0 * lam)
+        xi_true = _sample_parametric(spline, 100, seed=23)
+        points = _evaluate_at(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        assert np.all(cell_ids == 0)
+        np.testing.assert_allclose(ref_coords, xi_true, atol=_XI_REL_ATOL, rtol=0.0)
+
+    def test_a_geometry_with_no_extent_at_the_origin_still_gets_a_positive_scale(self) -> None:
+        """The one case with nothing to read a scale off keeps the fallback of one.
+
+        Every control point identical and at the origin leaves both the diagonal and the
+        coordinate magnitude at zero, and a tolerance of zero would be unusable.
+        """
+        sub = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+        point_map = Bspline(BsplineSpace([sub, sub]), np.zeros((2, 2, 2), dtype=np.float64))
+        assert _scale_of(point_map) == 1.0
+
+    def test_a_geometry_with_no_extent_away_from_the_origin_uses_its_magnitude(self) -> None:
+        """A degenerate geometry that is somewhere still has a somewhere to be graded at.
+
+        The old floor rounded this up to one whenever the magnitude was smaller, which is
+        the same non-covariance in a corner case.
+        """
+        sub = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+        cp = np.full((2, 2, 2), 1.0e-6, dtype=np.float64)
+        point_map = Bspline(BsplineSpace([sub, sub]), cp)
+        assert _scale_of(point_map) == pytest.approx(1.0e-6, rel=1e-12)
+
 
 class TestCellPhysicalBounds:
     """The per-cell physical boxes match an independent brute-force oracle."""

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -89,6 +89,75 @@ class TestCoonsSurface:
             create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
 
 
+class TestCoonsCornerToleranceScaleCovariance:
+    """The corner check must reach the same verdict at every model scale.
+
+    Its tolerance is ``4096 * eps`` times the largest absolute coordinate over all
+    eight corner values.  Before, a fixed ``atol=1e-12`` rejected a one-ulp mismatch
+    on a metre-scale part measured in microns, and accepted a ``1e-9`` relative gap
+    on a micron-scale one.
+    """
+
+    @staticmethod
+    def _square(scale: float, corner_shift: float = 0.0) -> tuple[Bspline, ...]:
+        """Build the four boundary curves of a square of side ``scale``.
+
+        ``corner_shift`` displaces the start of the v1 curve, so it is the single
+        corner inconsistency under test.
+        """
+        s = scale
+        c_u0 = create_line([0, 0, 0], [s, 0, 0])
+        c_u1 = create_line([0, s, 0], [s, s, 0])
+        c_v0 = create_line([0, 0, 0], [0, s, 0])
+        c_v1 = create_line([s + corner_shift, 0, 0], [s, s, 0])
+        return c_v0, c_v1, c_u0, c_u1
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    def test_a_one_ulp_corner_mismatch_is_accepted_at_every_scale(self, scale: float) -> None:
+        """A geometrically perfect patch must never be refused for a last-bit disagreement.
+
+        This is the direction the absolute constant failed in: at ``scale >= 1e6`` one
+        ulp of the coordinate already exceeds ``1e-12``.
+        """
+        shift = float(np.nextafter(scale, np.inf) - scale)
+        c_v0, c_v1, c_u0, c_u1 = self._square(scale, corner_shift=shift)
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        assert srf.dim == 2
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    def test_a_relative_corner_gap_is_rejected_at_every_scale(self, scale: float) -> None:
+        """And this is the direction it failed in on a small model.
+
+        A gap of one part per million of the model size is a real modelling mistake at
+        any scale; the absolute constant accepted it once ``scale`` fell below ``1e-6``.
+        """
+        c_v0, c_v1, c_u0, c_u1 = self._square(scale, corner_shift=1.0e-6 * scale)
+        with pytest.raises(ValueError, match="mismatch"):
+            create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+
+    def test_the_scale_comes_from_all_eight_corners_not_the_pair_under_test(self) -> None:
+        """A patch touching the origin is graded like the rest of the patch.
+
+        The ``(0, 0)`` corner supplies no magnitude of its own.  Reading the scale off
+        only the pair being compared would grade it against zero and demand bitwise
+        agreement there while allowing ``4096 * eps * s`` at the other three.
+        """
+        s = 1.0e6
+        c_u0 = create_line([float(np.nextafter(0.0, 1.0)), 0, 0], [s, 0, 0])
+        c_u1 = create_line([0, s, 0], [s, s, 0])
+        c_v0 = create_line([0, 0, 0], [0, s, 0])
+        c_v1 = create_line([s, 0, 0], [s, s, 0])
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        assert srf.dim == 2
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e9])
+    def test_a_gross_mismatch_is_still_caught_at_every_scale(self, scale: float) -> None:
+        """The mistake the check exists for: a curve given in the wrong place."""
+        c_v0, c_v1, c_u0, c_u1 = self._square(scale, corner_shift=scale)
+        with pytest.raises(ValueError, match="mismatch"):
+            create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+
+
 class TestCoonsVolume:
     """Test the coons_volume function."""
 

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -124,12 +124,18 @@ class TestCoonsCornerToleranceScaleCovariance:
         srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
         assert srf.dim == 2
 
-    @pytest.mark.parametrize("scale", [1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    @pytest.mark.parametrize(
+        "scale", [1.0e-9, 1.0e-8, 1.0e-7, 1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9]
+    )
     def test_a_relative_corner_gap_is_rejected_at_every_scale(self, scale: float) -> None:
         """And this is the direction it failed in on a small model.
 
         A gap of one part per million of the model size is a real modelling mistake at
-        any scale; the absolute constant accepted it once ``scale`` fell below ``1e-6``.
+        any scale; the absolute constant accepted it once the *absolute* gap fell below
+        ``1e-12``, i.e. from ``scale = 1e-6`` down.  The list has to reach ``1e-9`` to
+        pin that: at exactly ``1e-6`` the product ``1e-6 * 1e-6`` rounds a hair above
+        ``1e-12`` and the old code still rejected, so a range stopping there passes on
+        the unfixed code and proves nothing.
         """
         c_v0, c_v1, c_u0, c_u1 = self._square(scale, corner_shift=1.0e-6 * scale)
         with pytest.raises(ValueError, match="mismatch"):

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -381,8 +381,19 @@ class TestRemoveKnotKernelPrecondition:
 
 
 # ===========================================================================
-# Rational deviation
+# The default tolerance
 # ===========================================================================
+
+
+def _random_curve(degree: int, n_el: int, rank: int, scale: float, seed: int) -> Bspline:
+    """Build an open curve of the given degree whose control net has size ``scale``."""
+    knots = np.concatenate(
+        [np.full(degree, 0.0), np.linspace(0.0, 1.0, n_el + 1), np.full(degree, 1.0)]
+    )
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    rng = np.random.default_rng(seed)
+    cp = rng.uniform(-1.0, 1.0, size=(space.num_total_basis, rank)) * scale
+    return Bspline(space, np.ascontiguousarray(cp))
 
 
 def _nurbs_curve(  # noqa: PLR0913
@@ -404,6 +415,92 @@ def _nurbs_curve(  # noqa: PLR0913
     weights = np.exp(rng.uniform(-weight_spread, weight_spread, size=n))
     cp = np.concatenate([pts * weights[:, None], weights[:, None]], axis=1)
     return Bspline(space, np.ascontiguousarray(cp), is_rational=True)
+
+
+class TestDefaultToleranceIsARoundOffFloor:
+    """With no ``tol``, removal is lossless and its verdict is scale covariant.
+
+    The old default was an absolute ``1e-10``, which is a geometric budget wearing no
+    units: the same exactly-removable knot came out at geometry scale 1e-6, 1 and 1e3
+    and was silently refused at 1e6 and 1e9.  The default is now
+    ``8 * (degree + 1) * eps * scale`` with ``scale = max(bbox diagonal, max ||P_i||)``,
+    which admits exactly what the reconstruction arithmetic cannot distinguish from an
+    exact removal.
+    """
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5, 6, 7])
+    def test_an_exactly_removable_knot_comes_out_at_every_geometry_scale(
+        self, degree: int, scale: float
+    ) -> None:
+        """A just-inserted knot is redundant by construction, so it must always go.
+
+        This is the case the absolute default lost above scale 1e6, where one ulp of a
+        coordinate already exceeds ``1e-10``.
+        """
+        from pantr.bspline._bspline_knot_removal import (  # noqa: PLC0415
+            _roundoff_deviation_floor,
+        )
+
+        curve = _random_curve(degree, 5, 3, scale, seed=degree)
+        inserted = curve.insert_knots(np.array([0.37]))
+        before = inserted.space.spaces[0].knots.size
+
+        result = inserted.remove_knots(0.37)
+
+        assert result.space.spaces[0].knots.size == before - 1
+        # And the removal delivered what the budget promised.  The control-point
+        # distance A5.8 measures is an upper bound on the curve deviation, so the two
+        # curves must agree to within the very floor that admitted the removal --
+        # a bound derived from the geometry rather than a round number.
+        floor = _roundoff_deviation_floor(np.asarray(inserted.control_points), degree)
+        t = np.linspace(0.0, 1.0, 401)
+        deviation = float(
+            np.linalg.norm(
+                np.asarray(result.evaluate(t)) - np.asarray(inserted.evaluate(t)), axis=1
+            ).max()
+        )
+        assert deviation <= floor
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    def test_a_knot_the_curve_genuinely_needs_stays_at_every_geometry_scale(
+        self, scale: float
+    ) -> None:
+        """The other half of the verdict: the default must not become a licence.
+
+        Scale covariance is only worth having if both answers travel, so this pins the
+        rejection at the same five scales as the acceptance above.
+        """
+        curve = _random_curve(3, 5, 3, scale, seed=99)
+        before = curve.space.spaces[0].knots.size
+
+        result = curve.remove_knots(0.4)
+
+        assert result.space.spaces[0].knots.size == before
+
+    def test_the_floor_is_proportional_to_the_control_net(self) -> None:
+        """Rescaling the geometry rescales the floor by the same factor."""
+        from pantr.bspline._bspline_knot_removal import (  # noqa: PLC0415
+            _roundoff_deviation_floor,
+        )
+
+        cp = _random_curve(3, 5, 3, 1.0, seed=4).control_points
+        unit = _roundoff_deviation_floor(np.asarray(cp), 3)
+        scaled = _roundoff_deviation_floor(np.asarray(cp) * 1.0e6, 3)
+        assert scaled == pytest.approx(1.0e6 * unit, rel=1.0e-12)
+
+    def test_the_floor_grows_with_degree_and_is_a_multiple_of_eps(self) -> None:
+        """Pin the derivation, not the digits: ``8 * (degree + 1) * eps * scale``."""
+        from pantr.bspline._bspline_knot_removal import (  # noqa: PLC0415
+            _control_point_scale,
+            _roundoff_deviation_floor,
+        )
+
+        cp = np.asarray(_random_curve(3, 5, 3, 1.0, seed=4).control_points)
+        eps = float(np.finfo(np.float64).eps)
+        for degree in (1, 3, 7):
+            expected = 8.0 * (degree + 1) * eps * _control_point_scale(cp)
+            assert _roundoff_deviation_floor(cp, degree) == pytest.approx(expected, rel=1.0e-14)
 
 
 class TestRationalDeviationIsMeasuredInProjectedSpace:
@@ -456,6 +553,23 @@ class TestRationalDeviationIsMeasuredInProjectedSpace:
             )
 
         assert accepted_any, "the sweep never produced an accepted removal, so it proves nothing"
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e6])
+    def test_a_redundant_knot_still_comes_out_of_a_rational_curve(self, scale: float) -> None:
+        """The conversion must not make the default unreachable for a NURBS.
+
+        The round-off floor is deliberately *not* pulled back: it is a statement about
+        the arithmetic, and the arithmetic runs in homogeneous coordinates.  Pulling it
+        back would divide it by ``1 + |P|_max`` and refuse exact removals on any model
+        bigger than a unit.
+        """
+        base = _nurbs_curve(3, 5, 3, scale, 1.5, seed=21)
+        inserted = base.insert_knots(np.array([0.37]))
+        before = inserted.space.spaces[0].knots.size
+
+        result = inserted.remove_knots(0.37)
+
+        assert result.space.spaces[0].knots.size == before - 1
 
     def test_the_conversion_is_the_published_formula(self) -> None:
         """``TOL = d * w_min / (1 + |P|_max)``, checked against a direct computation."""

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -378,3 +378,96 @@ class TestRemoveKnotKernelPrecondition:
 
         knots = np.asarray(result.space.spaces[0].knots)
         assert int(np.sum(np.abs(knots - 3.0) <= 1e-14)) == 0
+
+
+# ===========================================================================
+# Rational deviation
+# ===========================================================================
+
+
+def _nurbs_curve(  # noqa: PLR0913
+    degree: int, n_el: int, rank: int, scale: float, weight_spread: float, seed: int
+) -> Bspline:
+    """Build a rational curve whose weights and coordinates vary **independently**.
+
+    That independence is the point.  A circle cannot expose a mistake in the
+    homogeneous-to-projected conversion, because its weights are structurally tied to
+    its coordinates and a rescaling of one is a rescaling of the other.
+    """
+    knots = np.concatenate(
+        [np.full(degree, 0.0), np.linspace(0.0, 1.0, n_el + 1), np.full(degree, 1.0)]
+    )
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    rng = np.random.default_rng(seed)
+    n = space.num_total_basis
+    pts = rng.uniform(-1.0, 1.0, size=(n, rank)) * scale
+    weights = np.exp(rng.uniform(-weight_spread, weight_spread, size=n))
+    cp = np.concatenate([pts * weights[:, None], weights[:, None]], axis=1)
+    return Bspline(space, np.ascontiguousarray(cp), is_rational=True)
+
+
+class TestRationalDeviationIsMeasuredInProjectedSpace:
+    """A caller's budget is a distance between points, not between homogeneous columns.
+
+    The kernel measures a Euclidean distance over every column of the array it is
+    given, which for a rational spline is ``[w x, w y, w z, w]``.  Eq. (5.30) of Piegl
+    & Tiller (2nd ed., 1997, p. 185) is the conversion, and without it a deviation
+    carried by the weight column is graded as though it were a coordinate.
+    """
+
+    @staticmethod
+    def _max_projected_deviation(a: Bspline, b: Bspline) -> float:
+        """Largest distance between the two curves' projected points over the domain."""
+        t = np.linspace(0.0, 1.0, 601)
+        pa = np.asarray(a.evaluate(t), dtype=np.float64)
+        pb = np.asarray(b.evaluate(t), dtype=np.float64)
+        return float(np.linalg.norm(pa - pb, axis=1).max())
+
+    @pytest.mark.parametrize("degree", [2, 3, 4])
+    @pytest.mark.parametrize("scale", [1.0, 1.0e3, 1.0e6])
+    def test_an_accepted_removal_honours_the_requested_budget(
+        self, degree: int, scale: float
+    ) -> None:
+        """Sweeping the perturbation, every accepted removal must be within budget.
+
+        The perturbation is applied to the **weight** alone, which is the case Eq.
+        (5.30) exists for; the sweep over sixteen decades is what finds the largest one
+        the kernel is willing to accept.  Without the conversion the worst ratio
+        measured over this family is ``7.4e5``; with it, ``0.32``.
+        """
+        base = _nurbs_curve(degree, 6, 3, scale, 1.5, seed=degree * 7)
+        inserted = base.insert_knots(np.array([0.41]))
+        before = inserted.space.spaces[0].knots.size
+        requested = 1.0e-6 * scale
+        accepted_any = False
+
+        for eps_w in np.logspace(-16, 0, 33):
+            cp = np.array(inserted.control_points)
+            cp[cp.shape[0] // 2, -1] *= 1.0 + eps_w
+            perturbed = Bspline(inserted.space, cp, is_rational=True)
+
+            result = perturbed.remove_knots(0.41, tol=requested)
+            if result.space.spaces[0].knots.size == before:
+                continue
+            accepted_any = True
+            deviation = self._max_projected_deviation(result, perturbed)
+            assert deviation <= requested, (
+                f"budget broken by {deviation / requested:.4g}x at eps_w={eps_w:.3g}"
+            )
+
+        assert accepted_any, "the sweep never produced an accepted removal, so it proves nothing"
+
+    def test_the_conversion_is_the_published_formula(self) -> None:
+        """``TOL = d * w_min / (1 + |P|_max)``, checked against a direct computation."""
+        from pantr.bspline._bspline_knot_removal import (  # noqa: PLC0415
+            _homogeneous_deviation_tolerance,
+        )
+
+        curve = _nurbs_curve(3, 5, 3, 100.0, 1.5, seed=13)
+        cp = np.asarray(curve.control_points, dtype=np.float64)
+        w_min = float(cp[:, -1].min())
+        p_max = float(np.linalg.norm(cp[:, :-1] / cp[:, -1:], axis=1).max())
+
+        assert _homogeneous_deviation_tolerance(cp, 1.0e-3) == pytest.approx(
+            1.0e-3 * w_min / (1.0 + p_max), rel=1.0e-14
+        )

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -557,8 +557,11 @@ class TestRationalDeviationIsMeasuredInProjectedSpace:
 
         assert accepted_any, "the sweep never produced an accepted removal, so it proves nothing"
 
-    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e6])
-    def test_a_redundant_knot_still_comes_out_of_a_rational_curve(self, scale: float) -> None:
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    @pytest.mark.parametrize("degree", [3, 4, 6, 7])
+    def test_a_redundant_knot_still_comes_out_of_a_rational_curve(
+        self, degree: int, scale: float
+    ) -> None:
         """The conversion must not make the default unreachable for a NURBS.
 
         The round-off floor is deliberately *not* pulled back: it is a statement about
@@ -566,7 +569,7 @@ class TestRationalDeviationIsMeasuredInProjectedSpace:
         back would divide it by ``1 + |P|_max`` and refuse exact removals on any model
         bigger than a unit.
         """
-        base = _nurbs_curve(3, 5, 3, scale, 1.5, seed=21)
+        base = _nurbs_curve(degree, 5, 3, scale, 1.5, seed=21)
         inserted = base.insert_knots(np.array([0.37]))
         before = inserted.space.spaces[0].knots.size
 
@@ -649,11 +652,33 @@ class TestTheFloorSpansEveryStackedControlPoint:
         assert result.space.spaces[0].knots.size == before
 
     def test_the_stacking_count_is_the_other_directions_and_not_this_one(self) -> None:
-        """A surface removed along its *short* axis stacks the long axis, and vice versa.
+        """Asserted on the count itself, because no behavioural test can catch this.
 
-        Getting the two the wrong way round would pass a square 2D test and fail an
-        oblong one, so the fixture here is deliberately lopsided.
+        Taking the reduced axis instead of the others is the natural way to get this
+        wrong.  It cannot be caught through ``remove_knots``: the floor carries a 48x
+        margin over the measured worst case, so *any* positive multiplier still admits
+        an exactly redundant knot.  Mutating the production line to ``ctrl.shape[axis]``
+        was confirmed to leave a round-trip test passing at 4-vs-4000 and at
+        4-vs-400000.  So the count is asserted directly, on a deliberately lopsided
+        control net where the two candidate answers differ by three orders of magnitude.
         """
+        from pantr.bspline._bspline_knot_removal import (  # noqa: PLC0415
+            _num_stacked_control_points,
+        )
+
+        ctrl = np.zeros((7, 4003, 3))  # 7 basis functions along axis 0, 4003 along axis 1
+        assert _num_stacked_control_points(ctrl, 0) == 4003
+        assert _num_stacked_control_points(ctrl, 1) == 7
+        # A curve stacks nothing, so the floor is exactly the per-point one.
+        assert _num_stacked_control_points(np.zeros((9, 3)), 0) == 1
+        # And a volume stacks the product of the two it is not reducing.
+        vol = np.zeros((5, 6, 7, 3))
+        assert _num_stacked_control_points(vol, 0) == 42
+        assert _num_stacked_control_points(vol, 1) == 35
+        assert _num_stacked_control_points(vol, 2) == 30
+
+    def test_a_lopsided_surface_stays_lossless_along_either_axis(self) -> None:
+        """The behavioural half: whichever axis is reduced, the redundant knot goes."""
 
         def kv(n: int, degree: int = 3) -> npt.NDArray[np.float64]:
             return np.concatenate(

--- a/tests/test_knot_removal.py
+++ b/tests/test_knot_removal.py
@@ -453,7 +453,7 @@ class TestDefaultToleranceIsARoundOffFloor:
         # distance A5.8 measures is an upper bound on the curve deviation, so the two
         # curves must agree to within the very floor that admitted the removal --
         # a bound derived from the geometry rather than a round number.
-        floor = _roundoff_deviation_floor(np.asarray(inserted.control_points), degree)
+        floor = _roundoff_deviation_floor(np.asarray(inserted.control_points), degree, 1)
         t = np.linspace(0.0, 1.0, 401)
         deviation = float(
             np.linalg.norm(
@@ -485,8 +485,8 @@ class TestDefaultToleranceIsARoundOffFloor:
         )
 
         cp = _random_curve(3, 5, 3, 1.0, seed=4).control_points
-        unit = _roundoff_deviation_floor(np.asarray(cp), 3)
-        scaled = _roundoff_deviation_floor(np.asarray(cp) * 1.0e6, 3)
+        unit = _roundoff_deviation_floor(np.asarray(cp), 3, 1)
+        scaled = _roundoff_deviation_floor(np.asarray(cp) * 1.0e6, 3, 1)
         assert scaled == pytest.approx(1.0e6 * unit, rel=1.0e-12)
 
     def test_the_floor_grows_with_degree_and_is_a_multiple_of_eps(self) -> None:
@@ -500,7 +500,10 @@ class TestDefaultToleranceIsARoundOffFloor:
         eps = float(np.finfo(np.float64).eps)
         for degree in (1, 3, 7):
             expected = 8.0 * (degree + 1) * eps * _control_point_scale(cp)
-            assert _roundoff_deviation_floor(cp, degree) == pytest.approx(expected, rel=1.0e-14)
+            assert _roundoff_deviation_floor(cp, degree, 1) == pytest.approx(expected, rel=1e-14)
+        # And the stacking factor is a square root, not a factor of one or of n.
+        base = _roundoff_deviation_floor(cp, 3, 1)
+        assert _roundoff_deviation_floor(cp, 3, 10_000) == pytest.approx(100.0 * base, rel=1e-14)
 
 
 class TestRationalDeviationIsMeasuredInProjectedSpace:
@@ -585,3 +588,104 @@ class TestRationalDeviationIsMeasuredInProjectedSpace:
         assert _homogeneous_deviation_tolerance(cp, 1.0e-3) == pytest.approx(
             1.0e-3 * w_min / (1.0 + p_max), rel=1.0e-14
         )
+
+
+class TestTheFloorSpansEveryStackedControlPoint:
+    """The kernel grades a whole slice at once, so the floor has to as well.
+
+    ``_flatten_along_axis`` collapses every direction but the one being reduced into the
+    trailing axis, so A5.8's single Euclidean distance runs over ``prod(other basis
+    counts)`` control points rather than one.  A per-point floor is then too tight by the
+    ``sqrt`` of that count, and the symptom is silent: an exactly redundant knot is simply
+    not removed, with no error and no warning.
+    """
+
+    @staticmethod
+    def _volume(degree: int, n_removal: int, n_side: int, rank: int, seed: int) -> Bspline:
+        """Build a 3D volume with ``n_side`` elements in each non-removal direction."""
+
+        def kv(n: int) -> npt.NDArray[np.float64]:
+            return np.concatenate(
+                [np.full(degree, 0.0), np.linspace(0.0, 1.0, n + 1), np.full(degree, 1.0)]
+            )
+
+        space = BsplineSpace(
+            [BsplineSpace1D(kv(n_removal), degree)]
+            + [BsplineSpace1D(kv(n_side), degree) for _ in range(2)]
+        )
+        rng = np.random.default_rng(seed)
+        cp = rng.uniform(-1.0, 1.0, size=(*space.num_basis, rank))
+        return Bspline(space, np.ascontiguousarray(cp))
+
+    @pytest.mark.parametrize("n_side", [2, 20, 200, 400])
+    def test_a_redundant_knot_comes_out_of_a_volume_however_wide_the_slice(
+        self, n_side: int
+    ) -> None:
+        """Measured: without the sqrt this refused from ``num_stacked = 124609`` upward.
+
+        ``n_side = 400`` puts ``num_stacked`` at 162409, comfortably past that threshold,
+        while ``n_side = 2`` keeps the curve-like regime the per-point floor was derived
+        and measured in.  Both must remove the knot.
+        """
+        vol = self._volume(3, 5, n_side, 3, seed=n_side)
+        inserted = vol.insert_knots([np.array([0.37]), None, None])
+        before = inserted.space.spaces[0].knots.size
+
+        result = inserted.remove_knots([np.array([0.37]), None, None])
+
+        assert result.space.spaces[0].knots.size == before - 1
+
+    def test_a_knot_a_volume_genuinely_needs_still_stays(self) -> None:
+        """The sqrt must widen the floor, not turn it into a licence.
+
+        Its whole job is to track what the aggregate distance of an *exact* removal
+        reaches; a knot carrying real geometry is orders above that at any slice width.
+        """
+        vol = self._volume(3, 5, 20, 3, seed=5)
+        before = vol.space.spaces[0].knots.size
+
+        result = vol.remove_knots([np.array([0.4]), None, None])
+
+        assert result.space.spaces[0].knots.size == before
+
+    def test_the_stacking_count_is_the_other_directions_and_not_this_one(self) -> None:
+        """A surface removed along its *short* axis stacks the long axis, and vice versa.
+
+        Getting the two the wrong way round would pass a square 2D test and fail an
+        oblong one, so the fixture here is deliberately lopsided.
+        """
+
+        def kv(n: int, degree: int = 3) -> npt.NDArray[np.float64]:
+            return np.concatenate(
+                [np.full(degree, 0.0), np.linspace(0.0, 1.0, n + 1), np.full(degree, 1.0)]
+            )
+
+        space = BsplineSpace([BsplineSpace1D(kv(4), 3), BsplineSpace1D(kv(4000), 3)])
+        rng = np.random.default_rng(31)
+        srf = Bspline(
+            space, np.ascontiguousarray(rng.uniform(-1.0, 1.0, size=(*space.num_basis, 3)))
+        )
+        for axis in (0, 1):
+            values: list[npt.NDArray[np.float64] | None] = [None, None]
+            values[axis] = np.array([0.37])
+            inserted = srf.insert_knots(values)
+            before = inserted.space.spaces[axis].knots.size
+            result = inserted.remove_knots(values)
+            assert result.space.spaces[axis].knots.size == before - 1, f"failed on axis {axis}"
+
+
+class TestRationalRemovalRejectsDegenerateWeights:
+    """A zero weight has no projected point, so the conversion cannot be done at all.
+
+    Left unguarded it divided by zero, raised a `RuntimeWarning` and returned a
+    tolerance of exactly 0.0, which silently blocks every removal in the direction.
+    """
+
+    def test_a_zero_weight_raises_rather_than_silently_blocking(self) -> None:
+        curve = _nurbs_curve(3, 5, 3, 1.0, 1.0, seed=17)
+        cp = np.array(curve.control_points)
+        cp[2, -1] = 0.0
+        degenerate = Bspline(curve.space, cp, is_rational=True)
+
+        with pytest.raises(ValueError, match="strictly positive weights"):
+            degenerate.remove_knots(0.4, tol=1.0e-6)

--- a/tests/test_multipatch.py
+++ b/tests/test_multipatch.py
@@ -404,9 +404,9 @@ def test_detect_l_shape_has_two_interfaces() -> None:
 def test_detect_scale_invariance() -> None:
     """Detection survives a large uniform rescaling of the geometry.
 
-    The geometric tolerance is scaled by the joint bounding-box diagonal, so a
-    problem measured in different units must give the same topology. An absolute
-    epsilon would quietly stop matching here.
+    The geometric tolerance is scaled by the size of the geometry, so a problem
+    measured in different units must give the same topology. An absolute epsilon
+    would quietly stop matching here.
     """
     space = _anisotropic_space_2d()
     for scale in (1e-4, 1.0, 1e5):
@@ -415,6 +415,48 @@ def test_detect_scale_invariance() -> None:
         assert detect_interfaces([first, second]) == (
             Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),
         ), f"failed at scale {scale}"
+
+
+def test_detect_translation_invariance() -> None:
+    """Detection survives moving the geometry far from the origin.
+
+    Rescaling and translating are different tests, and the joint bounding-box diagonal
+    alone tracks only the first. Two unit patches at ``x = 1e6`` keep a diagonal of
+    order one, while every coordinate difference is now formed from numbers of order
+    ``1e6`` and so carries an absolute error of ``eps * 1e6``; a diagonal-only
+    tolerance of ``2.5e-18`` sits eight orders below that noise floor. Taking the
+    largest coordinate magnitude alongside the diagonal is what fixes it.
+
+    The second patch is displaced by **one ulp of the coordinate magnitude**, which is
+    what makes this test discriminating rather than decorative. Two patches built by
+    the same expression have bitwise equal face coordinates and match under any
+    tolerance at all, including a hopeless one; two patches that reached the same face
+    by different arithmetic differ by a rounding at their own magnitude, and that is
+    the gap the diagonal-only rule refuses to forgive.
+    """
+    space = _anisotropic_space_2d()
+    expected = (Interface(patch_a=0, face_a=1, patch_b=1, face_b=0, axis_map=(1,), flips=(False,)),)
+    for shift in (0.0, 1.0e3, 1.0e6, 1.0e9):
+        one_ulp = float(np.spacing(shift)) if shift > 0.0 else 0.0
+        first = Bspline(space, _lattice_patch(space).control_points + shift)
+        second = Bspline(
+            space, _lattice_patch(space, offset=[1.0, 0.0]).control_points + shift + one_ulp
+        )
+        assert detect_interfaces([first, second]) == expected, f"failed at shift {shift}"
+
+
+def test_detect_keeps_separate_patches_separate_far_from_the_origin() -> None:
+    """The looser tolerance far from the origin must not start inventing interfaces.
+
+    The magnitude term multiplies the geometric tolerance by ``1e6`` at this offset,
+    so the guard worth having is that a genuine gap is still a gap: these two patches
+    are a whole patch-width apart and must stay unmatched.
+    """
+    space = _anisotropic_space_2d()
+    shift = 1.0e6
+    first = Bspline(space, _lattice_patch(space).control_points + shift)
+    apart = Bspline(space, _lattice_patch(space, offset=[2.0, 0.0]).control_points + shift)
+    assert detect_interfaces([first, apart]) == ()
 
 
 def test_detect_requires_common_dim() -> None:

--- a/tests/test_restrict.py
+++ b/tests/test_restrict.py
@@ -269,6 +269,98 @@ class TestBsplineRestrictND:
         np.testing.assert_allclose(r.evaluate(lattice), f.evaluate(lattice), atol=1e-13)
 
 
+class TestBsplineRestrictScaleCovariance:
+    """The verdicts restrict reaches must not depend on where the domain sits.
+
+    Restriction adds no tolerance of its own: every comparison it makes is a knot
+    identity question answered by ``BsplineSpace1D.tolerance``, an absolute
+    parametric length derived from the knot vector's own magnitude. These tests pin
+    the property that follows: send ``x -> lambda * x`` and nothing changes but the
+    coordinates.
+    """
+
+    @staticmethod
+    def _shifted(lo: float, span: float, degree: int = 3, n_intervals: int = 5) -> Bspline:
+        """Build an open 1D B-spline on ``[lo, lo + span]`` with a fixed control polygon."""
+        interior = np.linspace(lo, lo + span, n_intervals + 1)[1:-1]
+        knots = np.concatenate([[lo] * (degree + 1), interior, [lo + span] * (degree + 1)])
+        space = BsplineSpace([BsplineSpace1D(knots, degree)])
+        rng = np.random.default_rng(11)
+        return Bspline(space, rng.random((space.num_total_basis, 2)))
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    def test_restriction_keeps_the_whole_boundary_group(self, lam: float) -> None:
+        """The extraction must not truncate the clamped end at any coordinate magnitude.
+
+        ``searchsorted(refined_knots, b_new + tol)`` is what cuts the sub-vector, and
+        with the previous fixed ``1e-12`` the offset was absorbed by ``b_new`` itself
+        once one ulp of the coordinate exceeded it (at ``lam = 1e6`` an ulp is about
+        ``1.2e-10``), so the cut fell before the first copy of ``b_new`` and the last
+        ``degree + 1`` knots were dropped. A tolerance of ``8 * eps * scale`` is at
+        least four ulp of any coordinate present, so the offset always bites.
+        """
+        f = self._shifted(0.0, lam)
+        degree = f.degree[0]
+        r = f.restrict((0.2 * lam, 0.6 * lam))
+
+        lo, hi = r.space.domain[0]
+        assert lo == pytest.approx(0.2 * lam, rel=1.0e-14)
+        assert hi == pytest.approx(0.6 * lam, rel=1.0e-14)
+        # Clamped at both ends: the boundary group survived the cut intact.  Counted
+        # through the space's own notion of knot identity, not bitwise: a boundary that
+        # coincides with an existing knot keeps that knot's stored representative, which
+        # may differ from the requested bound in the last bit.
+        _, mult = r.space.spaces[0].get_unique_knots_and_multiplicity()
+        assert mult[0] == degree + 1
+        assert mult[-1] == degree + 1
+        assert r.space.spaces[0].knots.size == mult.sum()
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    def test_the_restricted_map_still_agrees_with_the_original(self, lam: float) -> None:
+        """Restriction is exact geometry, so the two evaluate alike at every scale."""
+        f = self._shifted(0.0, lam)
+        r = f.restrict((0.2 * lam, 0.6 * lam))
+        pts = np.linspace(0.2 * lam, 0.6 * lam, 50)
+        np.testing.assert_allclose(r.evaluate(pts), f.evaluate(pts), atol=0.0, rtol=1.0e-12)
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    def test_a_bound_one_ulp_outside_the_domain_is_still_the_domain(self, lam: float) -> None:
+        """One ulp of slack is forgiven wherever the domain sits.
+
+        The bound is snapped onto the endpoint rather than rejected, so the right
+        insertion is skipped exactly as it is for the endpoint itself.
+        """
+        f = self._shifted(0.0, lam)
+        just_outside = float(np.nextafter(lam, np.inf))
+        r = f.restrict((0.4 * lam, just_outside))
+        assert r.space.domain[0][1] == pytest.approx(lam, rel=1.0e-15)
+
+    def test_an_offset_domain_reaches_the_same_verdicts_as_a_centered_one(self) -> None:
+        """Translating the knot vector changes the arithmetic, not what restrict decides.
+
+        Only the *verdicts* are covariant.  The control points are not expected to
+        agree bitwise: at an offset of ``1e6`` the insertion weights are formed from
+        coordinates of that magnitude, so they carry a relative error of about
+        ``eps * 1e6 / span = 2.2e-10``, and the control points inherit it.  Measured
+        agreement here is ``2.9e-10`` relative, which is that figure and not a defect;
+        what must be identical is the knot structure the two runs produce.
+        """
+        base = self._shifted(0.0, 1.0)
+        moved = self._shifted(1.0e6, 1.0)
+        r_base = base.restrict((0.2, 0.6))
+        r_moved = moved.restrict((1.0e6 + 0.2, 1.0e6 + 0.6))
+
+        _, mult_base = r_base.space.spaces[0].get_unique_knots_and_multiplicity()
+        _, mult_moved = r_moved.space.spaces[0].get_unique_knots_and_multiplicity()
+        np.testing.assert_array_equal(mult_moved, mult_base)
+        assert r_moved.control_points.shape == r_base.control_points.shape
+        # The insertion-weight error above, with a factor of four for the chain.
+        weight_error = 4.0 * np.finfo(np.float64).eps * 1.0e6
+        np.testing.assert_allclose(
+            r_moved.control_points, r_base.control_points, rtol=weight_error, atol=0.0
+        )
+
+
 # ---------------------------------------------------------------------------
 # Bezier.restrict
 # ---------------------------------------------------------------------------

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1291,6 +1291,88 @@ class TestProlongation:
             coarse.prolongation_to(_grid_1d())  # type: ignore[arg-type]
 
 
+class TestProlongationResidualGate:
+    """The residual gate has to sit between what a refinement leaves and what it does not.
+
+    The threshold is ``get_conservative(float64) * (1 + max_coarse_value)``, roughly
+    ``1.8e-12``.  What matters is that genuine refinements clear it by orders of
+    magnitude while a column that genuinely fails to reproduce does not, so these tests
+    bracket it from both sides rather than pinning the number.
+    """
+
+    @staticmethod
+    def _worst_residual(coarse: THBSplineSpace, fine: THBSplineSpace) -> float:
+        """Return the largest column residual, reading it off the assembled matrix.
+
+        ``P`` reproduces each coarse function exactly when the residual is zero, so
+        evaluating both sides on a common point set recovers the same quantity the gate
+        measures, without reaching into the private column solve.
+        """
+        p = coarse.prolongation_to(fine)
+        mat_c, pts = _collocation(coarse)
+        rows = []
+        for point in pts:
+            cid = fine.grid.locate(point)
+            assert cid is not None
+            values, dofs = fine.tabulate_basis(cid, point)
+            row = np.zeros(fine.num_total_basis)
+            row[dofs] = values
+            rows.append(row)
+        return float(np.abs(np.asarray(rows) @ p - mat_c).max())
+
+    @pytest.mark.parametrize("lo,hi", [(0.0, 1.0), (0.0, 1.0e-6), (1.0e6, 1.0e6 + 1.0)])
+    def test_a_genuine_refinement_clears_the_gate_by_orders_of_magnitude(
+        self, lo: float, hi: float
+    ) -> None:
+        """And by the same margin wherever the parametric domain sits.
+
+        The quantity graded is a set of refinement coefficients, which are dimensionless,
+        so both the residual and the threshold are invariant under ``x -> lambda * x``.
+        Measured worst residual over a 132-configuration sweep is ``18.5 * eps``, against
+        a threshold of ``4096 * eps * 2``.
+        """
+        knots = np.concatenate([[lo] * 3, np.linspace(lo, hi, 5)[1:-1], [hi] * 3])
+        root = BsplineSpace([BsplineSpace1D(knots, 2)])
+        grid = hierarchical_grid(uniform_grid([[lo, hi]], 4), 2)
+        coarse = THBSplineSpace(root, grid)
+        fine = coarse.refine([0, 1])
+        assert self._worst_residual(coarse, fine) < 512.0 * float(np.finfo(np.float64).eps)
+
+    def test_the_gate_rejects_a_space_that_cannot_reproduce_the_coarse_basis(self) -> None:
+        """A structurally compatible pair whose "fine" basis is genuinely too small.
+
+        Both spaces refine one root cell, but different ones, so both have two levels
+        and every check in ``_check_is_refinement`` passes -- same root knots, factor,
+        regularity, truncation and level count.  The level-1 functions the first space
+        carries over cell 0 are simply absent from the second's span, so this exercises
+        the residual gate and nothing else.  A real impostor lands at order one, which
+        is why the previous ``1e-8`` was never the thing catching it; what ``1e-8`` did
+        was leave the whole band ``[1e-14, 1e-8]`` certified as a refinement.
+        """
+        base = THBSplineSpace(_root_1d(), _grid_1d())
+        coarse = base.refine([0], admissible_class=None)
+        impostor = base.refine([3], admissible_class=None)
+        assert impostor.num_levels == coarse.num_levels
+        with pytest.raises(ValueError, match="prolongation residual"):
+            coarse.prolongation_to(impostor)
+
+    def test_the_threshold_is_the_conservative_tier_and_not_a_bare_constant(self) -> None:
+        """Pin the derivation, not the digits: it must be a multiple of an eps tier.
+
+        A regression to a fixed absolute constant would break this even if the digits
+        happened to match at float64.
+        """
+        from pantr.bspline._thb_spline_space import (  # noqa: PLC0415
+            _prolongation_residual_tolerance,
+        )
+        from pantr.tolerance import get_conservative  # noqa: PLC0415
+
+        assert _prolongation_residual_tolerance(1.0) == 2.0 * get_conservative(np.float64)
+        assert _prolongation_residual_tolerance(0.0) == get_conservative(np.float64)
+        # Monotone in the size of the column it grades.
+        assert _prolongation_residual_tolerance(3.0) > _prolongation_residual_tolerance(1.0)
+
+
 class TestCellMembershipTolerance:
     """A point on a cell boundary is inside it, at every coordinate magnitude.
 

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1375,6 +1375,15 @@ class TestProlongationResidualGate:
         # Monotone in the size of the column it grades.
         assert _prolongation_residual_tolerance(3.0) > _prolongation_residual_tolerance(1.0)
 
+        # And the band the old `1e-8` wrongly certified is closed from both ends. Neither
+        # direction test above lands near the threshold -- a genuine refinement sits at
+        # ~18.5 eps and a real impostor at order one -- so this is what pins the
+        # threshold's calibration rather than merely its existence.
+        eps = float(np.finfo(np.float64).eps)
+        gate = _prolongation_residual_tolerance(1.0)
+        assert gate < 1.0e-11, "a residual of 1e-10 must no longer pass as a refinement"
+        assert gate > 100.0 * eps, "the worst measured genuine refinement (18.5 eps) must clear"
+
 
 class TestCellMembershipTolerance:
     """A point on a cell boundary is inside it, at every coordinate magnitude.
@@ -1396,9 +1405,18 @@ class TestCellMembershipTolerance:
         """This is the case the fixed tolerance lost above ``lam = 1e6``."""
         thb = self._space(0.0, lam)
         lo, hi = thb.grid.cell_bounds(1)
-        for outside in (np.nextafter(lo[0], -np.inf), np.nextafter(hi[0], np.inf)):
-            values, _ = thb.tabulate_basis(1, np.array([[outside]]))
-            assert np.all(np.isfinite(values))
+        width = float(hi[0] - lo[0])
+        for edge, outside in (
+            (lo[0], np.nextafter(lo[0], -np.inf)),
+            (hi[0], np.nextafter(hi[0], np.inf)),
+        ):
+            values, dofs = thb.tabulate_basis(1, np.array([[outside]]))
+            # Not merely "no exception": the values must be the ones the boundary itself
+            # gives, to within the slope of a basis function over one ulp of the cell.
+            inside, dofs_in = thb.tabulate_basis(1, np.array([[float(edge)]]))
+            np.testing.assert_array_equal(dofs, dofs_in)
+            np.testing.assert_allclose(values, inside, atol=1.0e-9 / max(width, 1.0e-300))
+            assert values.sum() == pytest.approx(1.0, abs=1.0e-12)
 
     @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
     def test_a_point_a_hundredth_of_a_cell_outside_is_rejected(self, lam: float) -> None:
@@ -1414,6 +1432,63 @@ class TestCellMembershipTolerance:
         for outside in (float(lo[0]) - 0.01 * width, float(hi[0]) + 0.01 * width):
             with pytest.raises(ValueError, match="must lie inside cell"):
                 thb.tabulate_basis(1, np.array([[outside]]))
+
+    def test_the_band_the_old_constant_wrongly_accepted_is_now_closed(self) -> None:
+        """A point 1e-13 outside a unit-domain cell: accepted before, rejected now.
+
+        The direction tests above bracket the verdict widely -- one ulp in, one percent
+        of a cell out -- and both of them pass against the old fixed ``1e-12`` as well.
+        This is the marginal case that does not: on ``[0, 1]`` a cell is 0.25 wide, so
+        the derived slack is ``8 * eps * 0.25 = 4.4e-16`` while the constant allowed
+        ``1e-12``, some 9000 ulp. A point at 1e-13 sits squarely inside that gap.
+        """
+        thb = self._space(0.0, 1.0)
+        lo, _ = thb.grid.cell_bounds(1)
+        with pytest.raises(ValueError, match="must lie inside cell"):
+            thb.tabulate_basis(1, np.array([[float(lo[0]) - 1.0e-13]]))
+
+    def test_the_tolerance_stays_below_the_constant_it_replaced_on_a_unit_domain(
+        self,
+    ) -> None:
+        """And by the margin the class docstring claims: about four orders of magnitude.
+
+        Stated as an inequality against the old constant rather than as digits, so it
+        survives a change of tier but not a reversion to an absolute band.
+        """
+        from pantr.bspline._thb_spline_space import (  # noqa: PLC0415
+            _cell_membership_tolerance,
+        )
+
+        tol = _cell_membership_tolerance(np.array([0.0]), np.array([0.25]))[0]
+        assert tol < 1.0e-12 / 1000.0
+        # But not so tight that a point formed as `lo + xi * (hi - lo)` cannot survive:
+        # three roundings at this magnitude is 3 * eps * 0.25.
+        assert tol > 3.0 * float(np.finfo(np.float64).eps) * 0.25
+
+    def test_a_float32_root_space_is_still_graded_in_float64(self) -> None:
+        """Pins the claim `_cell_membership_tolerance`'s docstring makes to justify its dtype.
+
+        It hardcodes ``get_strict(np.float64)`` rather than reading the root space's
+        dtype, on the grounds that ``cell_bounds`` is float64 whatever the root space is
+        made of and the query points are cast to float64 before the comparison. If
+        either half were false the tolerance would be wrong by eight orders of
+        magnitude, so both are checked here rather than trusted.
+        """
+        knots = np.concatenate([[0.0] * 3, np.linspace(0.0, 1.0, 5)[1:-1], [1.0] * 3]).astype(
+            np.float32
+        )
+        root = BsplineSpace([BsplineSpace1D(knots, 2)])
+        assert root.dtype == np.float32
+        thb = THBSplineSpace(root, hierarchical_grid(uniform_grid([[0.0, 1.0]], 4), 2))
+        lo, hi = thb.grid.cell_bounds(1)
+        assert lo.dtype == np.float64
+        assert hi.dtype == np.float64
+        # And the float64 slack is what is actually applied: one float64 ulp is accepted,
+        # while the float32-sized slop the root dtype would have bought is not.
+        values, _ = thb.tabulate_basis(1, np.array([[float(np.nextafter(lo[0], -np.inf))]]))
+        assert np.all(np.isfinite(values))
+        with pytest.raises(ValueError, match="must lie inside cell"):
+            thb.tabulate_basis(1, np.array([[float(lo[0]) - 1.0e-9]]))
 
     def test_the_slack_tracks_the_cell_and_not_the_axis(self) -> None:
         """A narrow cell far from the origin gets the coordinate's slack, not the width's.

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1336,6 +1336,9 @@ class TestProlongationResidualGate:
         grid = hierarchical_grid(uniform_grid([[lo, hi]], 4), 2)
         coarse = THBSplineSpace(root, grid)
         fine = coarse.refine([0, 1])
+        # 512 eps: about 28x the worst residual the 132-configuration sweep measured
+        # (18.5 eps) and 16x below the gate itself (8192 eps at max_coarse_value = 1), so
+        # it fails on a real loss of accuracy without tracking the gate it is checking.
         assert self._worst_residual(coarse, fine) < 512.0 * float(np.finfo(np.float64).eps)
 
     def test_the_gate_rejects_a_space_that_cannot_reproduce_the_coarse_basis(self) -> None:

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1291,6 +1291,65 @@ class TestProlongation:
             coarse.prolongation_to(_grid_1d())  # type: ignore[arg-type]
 
 
+class TestCellMembershipTolerance:
+    """A point on a cell boundary is inside it, at every coordinate magnitude.
+
+    The old bare ``1e-12`` rejected a point one ulp outside once the parametric domain
+    reached ``1e6``, and accepted some 9000 ulp of slop on ``[0, 1]``.  The replacement
+    is ``8 * eps * max(|lo|, |hi|, hi - lo)`` per axis.
+    """
+
+    @staticmethod
+    def _space(lo: float, hi: float) -> THBSplineSpace:
+        """A degree-2 THB space with four root cells on ``[lo, hi]``."""
+        knots = np.concatenate([[lo] * 3, np.linspace(lo, hi, 5)[1:-1], [hi] * 3])
+        root = BsplineSpace([BsplineSpace1D(knots, 2)])
+        return THBSplineSpace(root, hierarchical_grid(uniform_grid([[lo, hi]], 4), 2))
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    def test_a_point_one_ulp_outside_the_cell_is_accepted(self, lam: float) -> None:
+        """This is the case the fixed tolerance lost above ``lam = 1e6``."""
+        thb = self._space(0.0, lam)
+        lo, hi = thb.grid.cell_bounds(1)
+        for outside in (np.nextafter(lo[0], -np.inf), np.nextafter(hi[0], np.inf)):
+            values, _ = thb.tabulate_basis(1, np.array([[outside]]))
+            assert np.all(np.isfinite(values))
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0, 1.0e6, 1.0e9])
+    def test_a_point_a_hundredth_of_a_cell_outside_is_rejected(self, lam: float) -> None:
+        """And this is the case the fixed tolerance let through on a small domain.
+
+        A hundredth of the cell width is enormous next to ``8 * eps``, so the verdict is
+        the same at every scale -- which the absolute constant could not manage, having
+        accepted about 9000 ulp on ``[0, 1]`` and rejected 1 ulp at ``1e6``.
+        """
+        thb = self._space(0.0, lam)
+        lo, hi = thb.grid.cell_bounds(1)
+        width = float(hi[0] - lo[0])
+        for outside in (float(lo[0]) - 0.01 * width, float(hi[0]) + 0.01 * width):
+            with pytest.raises(ValueError, match="must lie inside cell"):
+                thb.tabulate_basis(1, np.array([[outside]]))
+
+    def test_the_slack_tracks_the_cell_and_not_the_axis(self) -> None:
+        """A narrow cell far from the origin gets the coordinate's slack, not the width's.
+
+        Its width is a millionth of the domain, so a width-only rule would demand
+        agreement a million times finer than the arithmetic that produced the bound can
+        deliver; the ``|lo|``/``|hi|`` terms are what prevent that.
+        """
+        from pantr.bspline._thb_spline_space import (  # noqa: PLC0415
+            _cell_membership_tolerance,
+        )
+
+        eps = float(np.finfo(np.float64).eps)
+        narrow_far = _cell_membership_tolerance(np.array([1.0e6]), np.array([1.0e6 + 1.0e-6]))
+        assert narrow_far[0] == pytest.approx(8.0 * eps * 1.0e6, rel=1.0e-12)
+        # And it stays proportional under a change of scale.
+        unit = _cell_membership_tolerance(np.array([0.0]), np.array([1.0]))
+        scaled = _cell_membership_tolerance(np.array([0.0]), np.array([1.0e6]))
+        assert scaled[0] == pytest.approx(1.0e6 * unit[0], rel=1.0e-12)
+
+
 def _assert_same_field(
     coarse: THBSplineSpace,
     fine: THBSplineSpace,


### PR DESCRIPTION
The semantic half of the tolerance overhaul landed in #295. This finishes it at the individual
sites: every constant below was left alone deliberately, because none of them could be derived
until the preset table meant something. Each now states what quantity it grades, scales by that
quantity's magnitude, names its safety factor, and carries the derivation beneath it.

**The sweep is unchanged at 217 findings — zero new, zero fixed, zero cases changing verdict at
all.** That is the intended outcome: this pass makes existing behaviour derivable and
scale-covariant rather than altering what the library computes, with one deliberate exception
called out below.

## The sites

| site | before | after | grades |
|---|---|---|---|
| THB refinement gate | `1e-8·(1+c)` | `4096·eps·(1+c)` | a dimensionless residual |
| THB cell membership | `1e-12` | `8·eps·max(\|lo\|,\|hi\|,hi−lo)` | a parametric coordinate |
| Coons corner | `1e-12`, `rtol=0` | `4096·eps·max\|coord over all eight corners\|` | a physical coordinate |
| `remove_knots` default | `1e-10` | `8·(degree+1)·eps·scale·sqrt(n)` | a physical deviation |
| rational removal | — | × `w_min/(1+\|P\|_max)` | homogeneous vs projected |
| `restrict` | `1e-12` | the space's own knot tolerance | parametric knot identity |
| `locate` floor | `max(…, 1.0)` | removed | a physical scale |

**The THB gate was 1.1e4× too loose.** Measured over 132 configurations — 1D/2D/3D, degrees 2-5,
4-16 elements per axis, truncated and not, one and two levels, three domain scales — the worst
residual on a genuine refinement is **18.5 eps**, so the old gate certified as a refinement any
impostor landing in `[1e-14, 1e-8]` and returned a prolongation matrix that does not prolong.

**The Coons corner check** rejected a **1-ulp** mismatch at L ≥ 1e6 (a micron-unit model of a
metre-scale part failing on a geometrically perfect patch) while accepting a 1e-9 relative gap at
L = 1e-6. The scale is now taken over all eight corner values, so the verdict does not depend on
which corner sits at the origin.

**The rational knot-removal budget was never pulled back into homogeneous space.** The kernel
measures a distance over all columns of the control-point array — for a NURBS that includes the
weight — while the caller's budget is a Euclidean distance in projected space. Piegl & Tiller
Eq. (5.30) (2nd ed., p. 185, cited there for Algorithm A5.8, which this kernel otherwise implements
faithfully) gives the conversion. Measured, sweeping a weight perturbation over sixteen decades at
coordinates 1e6: without it the worst accepted removal broke the requested budget by **7.4e5×**;
with it, 0.32. A circle cannot exhibit this, because its weights are structurally tied to its
coordinates — the test varies weights and coordinates independently.

## One deliberate behaviour change

`remove_knots(tol=None)` now means **lossless**: remove only what is exact to round-off. It was
`1e-10` absolute, which silently refused an exactly-removable knot at geometry scale 1e6 and above
(verified: removed at 1e-6, 1, 1e3; refused at 1e6, 1e9 — now removed at all five with relative
deviation 2.6e-16). `1e-10` *relative* would not have been defensible either, being ≈450 eps: too
tight for a CAD budget and too loose for a round-off floor. The derived floor is the one default
that needs no arbitrary constant. Callers who want simplification rather than exactness now pass an
explicit budget.

## Two premises in the brief that measurement refuted

**`locate` was not running on 6 % headroom.** The residual is *censored* by the threshold: measured
at six thresholds from 2 to 4096 epsilons over 9480 points (mild and strong warp, degrees 1-5, 1-3
directions, scales 1 and 1e6), the achieved residual tracks whatever threshold is set to within 1 %,
and nothing is lost even at `4·eps·scale`. There is also no dependence on `prod(degree+1)` across
3→125. So the threshold is an accuracy *contract*, not a margin, and loosening the tier would cost
accuracy one-for-one and buy nothing. The tier stays; the derivation is corrected. Its
`max(…, 1.0)` floor is gone — it held a millimetre-scale part to a thousand times the relative
accuracy of a metre-scale one.

**The suggested `sqrt(M)` growth term for the THB gate was rejected on measurement**: M spans 13 to
19683 with no trend (2.0 eps at M = 13, 16.5 eps at M = 19683), so carrying it would loosen the gate
140× on the largest systems for growth that is not there.

## Skipped, with the reason recorded in the source

The root finder's slope bound stays **global**. A correct local version needs the original knot
vector indexed by parametric position *and* `root_tol` to become per-span inside the kernel, where
it is currently one scalar decided before any zero is located. No false positive exists across 948
random splines and 376 sweep cases, and for a root finder the fatal direction is loosening. The
docstring now says this so nobody re-derives it.

Also documented rather than fixed: the rational pullback's *tightness* is not covariant — at
`|P|_max ≪ 1` a weight-carried deviation is graded `1/|P|_max` too tightly. It is **sound at every
scale** and errs conservative. The root cause is the kernel's metric mixing `(length·weight)²` with
`weight²`, so the fix is Layer-3 and not a change to the formula.

## Verification

`ruff`, `ruff format`, `mypy`, `import-lint` and a from-scratch docs build under `-W` all clean.
**5433 passed, 21 skipped, 3 xfailed** against a baseline of 5294 / 21 / 3, so +139 tests. Sweep
217 → 217, diffed by label. Scale covariance measured for every predicate touched: seven of eight
identical at λ = 1e-6, 1, 1e6; the eighth is the documented pullback tightness.

The downstream consumer has zero static exposure to any touched symbol; nine affected test files
were run one per invocation against base and head — 311 tests, identical results.

## Found while working, not fixed

- **`Bezier.minimize_degree` has the same rational defect**, independently reproduced: its
  round-trip L2 error sums over all columns of the homogeneous array, weight included, and is gated
  against a caller-supplied tolerance. A degree-2 rational Bézier at coordinate scale 1e6, elevated
  to 6 with one weight perturbed by 1e-3, collapses back to degree 2 at requested tolerances of
  1e-9, 1e-6 and 1e-3 while the true projected deviation is 70.7 — exceeding the request by up to
  **7.1e10×**. This needs the L2 analogue of Eq. (5.30), a quadratic form rather than a pointwise
  maximum, so it is design work rather than a copy of this fix.
- **A `locate` point is lost independently of the tolerance**: dimension 2, degree 1, six elements,
  mildly warped, unit scale — one of forty points is not found, and is still not found at
  `tol = 1e9·eps·scale` or `max_iter = 200`, with `cond(J) = 3.2`. Not a tolerance failure; likely
  candidate-cell or BVH.
- `create_coons_volume` has no corner or edge consistency check at all, which is now asymmetric with
  the corrected surface path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
