### PR TITLE
fix(change_basis): build each inverse pair by one LU solve, not a second Gram projection

### DIFF
--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -130,7 +130,10 @@ def compute_bernstein_to_lagrange_1d(
         ``3.0e3`` at degree 10, so the attainable accuracy of ``L``, by any algorithm,
         is bounded by roughly :math:`\kappa(C)\varepsilon`. In float64 the round trip
         :math:`\lVert C L - I \rVert_2` holds to ``3e-16`` at degree 4, ``1e-14`` at degree 8
-        and ``1e-13`` at degree 10. In float32 the same bound stays below 0.1 through
+        and ``1e-13`` at degree 10. The crossing degrees below are quoted for
+        :math:`64\,\kappa(C)\varepsilon`, the bound with the safety factor the accuracy
+        tests apply; the bare :math:`\kappa(C)\varepsilon` crosses several degrees later.
+        In float32 that bound stays below 0.1 through
         degree 11 for equispaced nodes and through degree 14 for the Gauss and
         Chebyshev variants, and over those ranges the measured round trip never exceeds
         ``1.1e-4`` (worst case Gauss-Legendre at degree 14; below ``7.5e-5`` for every
@@ -319,8 +322,10 @@ def compute_cardinal_to_bernstein_1d(
         any algorithm, is bounded by roughly :math:`\kappa(A)\varepsilon`. In float64 the
         returned matrix reproduces the Bernstein basis to about ``4e-15`` through
         degree 4, ``3e-13`` at degree 6, ``3e-11`` at degree 8 and ``2e-8`` at degree
-        10, and the round trip holds to the same order. In float32 the same bound
-        exceeds 0.1 from degree 7 on, so nothing is certified past degree 6; measured,
+        10, and the round trip holds to the same order. In float32
+        :math:`64\,\kappa(A)\varepsilon` -- the bound with the safety factor the accuracy
+        tests apply -- exceeds 0.1 from degree 7 on, so nothing is certified past degree
+        6; the bare :math:`\kappa(A)\varepsilon` crosses one degree later. Measured,
         the round trip is still only ``7e-3`` at degree 8 but reaches ``1.3`` at degree
         9, so the result carries no information at all from degree 9. This is a
         property of the two bases, not of the implementation.

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -111,9 +111,8 @@ def compute_bernstein_to_lagrange_1d(
     r"""Construct the matrix mapping Bernstein basis evaluations to Lagrange basis evaluations.
 
     The inverse direction of :func:`compute_lagrange_to_bernstein_1d`: with ``C`` from
-    that function, this returns the matrix solving ``C @ result = I``, computed by one
-    LU solve against the identity (:func:`numpy.linalg.solve`). No explicit inverse is
-    formed.
+    that function, this returns ``L`` solving ``C @ L = I``, computed by one LU solve
+    against the identity (:func:`numpy.linalg.solve`). No explicit inverse is formed.
 
     Note:
         Both Bernstein and Lagrange bases follow the standard ordering
@@ -128,13 +127,15 @@ def compute_bernstein_to_lagrange_1d(
     Warning:
         $\kappa(C)$ grows with degree and with the node family: with the default
         equispaced nodes it is ``1.2e1`` at degree 4, ``4.6e2`` at degree 8 and
-        ``3.0e3`` at degree 10, so the attainable accuracy of the result, by any
-        algorithm, is bounded by roughly $\kappa(C)\varepsilon$. In float64 the round
-        trip $\lVert C B - I \rVert_2$ holds to ``3e-16`` at degree 4, ``1e-14`` at
-        degree 8 and ``1e-13`` at degree 10. In float32 the same bound stays below 0.1
-        through degree 11 for equispaced nodes and through degree 14 for the Gauss and
-        Chebyshev variants, so unlike the other two pairs this one remains usable in
-        single precision over the whole range of practical degrees.
+        ``3.0e3`` at degree 10, so the attainable accuracy of ``L``, by any algorithm,
+        is bounded by roughly $\kappa(C)\varepsilon$. In float64 the round trip
+        $\lVert C L - I \rVert_2$ holds to ``3e-16`` at degree 4, ``1e-14`` at degree 8
+        and ``1e-13`` at degree 10. In float32 the same bound stays below 0.1 through
+        degree 11 for equispaced nodes and through degree 14 for the Gauss and
+        Chebyshev variants, and over those ranges the measured round trip never exceeds
+        ``1.1e-4`` (worst case Gauss-Legendre at degree 14; below ``7.5e-5`` for every
+        variant through degree 11), so unlike the other two pairs this one remains
+        usable in single precision over the whole range of practical degrees.
 
     Args:
         degree (int): Polynomial degree. Must be at least 1.
@@ -148,8 +149,8 @@ def compute_bernstein_to_lagrange_1d(
             if provided. This follows NumPy's style for output arrays. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix C such that
-            C @ [Bernstein values] = [Lagrange values]. If `out` was provided,
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix L such
+            that ``L @ [Bernstein values] = [Lagrange values]``. If `out` was provided,
             returns the same array.
 
     Raises:
@@ -269,8 +270,8 @@ def compute_bernstein_to_cardinal_1d(
             if provided. This follows NumPy's style for output arrays. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix C such that
-            C @ [Bernstein values] = [cardinal values]. If `out` was provided,
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix A such
+            that ``A @ [Bernstein values] = [cardinal values]``. If `out` was provided,
             returns the same array.
 
     Raises:
@@ -318,14 +319,17 @@ def compute_cardinal_to_bernstein_1d(
         any algorithm, is bounded by roughly $\kappa(A)\varepsilon$. In float64 the
         returned matrix reproduces the Bernstein basis to about ``4e-15`` through
         degree 4, ``3e-13`` at degree 6, ``3e-11`` at degree 8 and ``2e-8`` at degree
-        10, and the round trip holds to the same order; in float32 the bound exceeds
-        0.1 from degree 7 on, so the result is meaningless beyond degree 6. This is a
+        10, and the round trip holds to the same order. In float32 the same bound
+        exceeds 0.1 from degree 7 on, so nothing is certified past degree 6; measured,
+        the round trip is still only ``7e-3`` at degree 8 but reaches ``1.3`` at degree
+        9, so the result carries no information at all from degree 9. This is a
         property of the two bases, not of the implementation.
 
-        Far past that point the entries themselves stop being representable: in
-        float32 the exact inverse exceeds the format's range from degree 34 (``6.8e40``
-        at degree 36 against a maximum of ``3.4e38``), so the result contains
-        infinities and NumPy reports an overflow.
+        Far past that point the entries themselves stop being representable: from
+        degree 34 the float32 result contains infinities and NumPy reports an overflow,
+        the true inverse having outgrown the format's range. How far it has outgrown it
+        is not something float64 can be asked, since $\kappa(A)$ passes $1/\varepsilon$
+        for float64 by degree 16.
 
     Args:
         degree (int): Polynomial degree. Must be non-negative.
@@ -337,8 +341,8 @@ def compute_cardinal_to_bernstein_1d(
             if provided. This follows NumPy's style for output arrays. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix C such that
-            C @ [cardinal values] = [Bernstein values]. If `out` was provided,
+        npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) transformation matrix B such
+            that ``B @ [cardinal values] = [Bernstein values]``. If `out` was provided,
             returns the same array.
 
     Raises:

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -108,12 +108,33 @@ def compute_bernstein_to_lagrange_1d(
     dtype: npt.DTypeLike = np.float64,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Construct the matrix mapping Bernstein basis evaluations to Lagrange basis evaluations.
+    r"""Construct the matrix mapping Bernstein basis evaluations to Lagrange basis evaluations.
+
+    The inverse direction of :func:`compute_lagrange_to_bernstein_1d`: with ``C`` from
+    that function, this returns the matrix solving ``C @ result = I``, computed by one
+    LU solve against the identity (:func:`numpy.linalg.solve`). No explicit inverse is
+    formed.
 
     Note:
         Both Bernstein and Lagrange bases follow the standard ordering
         (see https://en.wikipedia.org/wiki/Bernstein_polynomial).
 
+        Only this direction involves a solve. The forward direction needs no
+        projection at all: because the Lagrange basis is cardinal at its own nodes,
+        ``C[j, k]`` is just $B_j(x_k)$, so ``C`` costs one basis tabulation and carries
+        no solve error. That is why this pair is much better conditioned than the
+        Bernstein/cardinal and Legendre/cardinal ones.
+
+    Warning:
+        $\kappa(C)$ grows with degree and with the node family: with the default
+        equispaced nodes it is ``1.2e1`` at degree 4, ``4.6e2`` at degree 8 and
+        ``3.0e3`` at degree 10, so the attainable accuracy of the result, by any
+        algorithm, is bounded by roughly $\kappa(C)\varepsilon$. In float64 the round
+        trip $\lVert C B - I \rVert_2$ holds to ``3e-16`` at degree 4, ``1e-14`` at
+        degree 8 and ``1e-13`` at degree 10. In float32 the same bound stays below 0.1
+        through degree 11 for equispaced nodes and through degree 14 for the Gauss and
+        Chebyshev variants, so unlike the other two pairs this one remains usable in
+        single precision over the whole range of practical degrees.
 
     Args:
         degree (int): Polynomial degree. Must be at least 1.
@@ -139,8 +160,8 @@ def compute_bernstein_to_lagrange_1d(
         raise ValueError("Degree must at least 1")
     out = _prepare_square_out(degree, dtype, out)
 
-    C = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)
-    out[:] = np.linalg.inv(C)
+    forward = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)
+    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
     return out
 
 
@@ -222,7 +243,21 @@ def compute_bernstein_to_cardinal_1d(
     dtype: npt.DTypeLike = np.float64,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Create transformation matrix from Bernstein to cardinal B-spline basis.
+    r"""Create transformation matrix from Bernstein to cardinal B-spline basis.
+
+    The projected direction of the Bernstein/cardinal pair, obtained by one Gram
+    projection; :func:`compute_cardinal_to_bernstein_1d` inverts the result rather
+    than projecting again. This is the direction worth projecting because *its* Gram
+    matrix is the Bernstein one, which is far better conditioned than the cardinal
+    one: since ``cardinal = A @ bernstein``, the two are related by
+    $G_{\mathrm{card}} = A \, G_{\mathrm{bern}} A^\mathsf{T}$ and therefore
+    $\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})$. Measured at
+    degree 8: ``2.4e4`` against ``8.4e16``, the latter already saturated against
+    $1/\varepsilon$.
+
+    The quadrature is exact: ``degree + 1`` Gauss-Legendre points integrate
+    polynomials up to degree ``2 * degree + 1`` exactly, while every inner product
+    formed here is between two polynomials of degree ``degree``.
 
     Args:
         degree (int): Polynomial degree. Must be non-negative.
@@ -260,7 +295,37 @@ def compute_cardinal_to_bernstein_1d(
     dtype: npt.DTypeLike = np.float64,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    """Create transformation matrix from cardinal B-spline to Bernstein basis.
+    r"""Create transformation matrix from cardinal B-spline to Bernstein basis.
+
+    The inverse direction of :func:`compute_bernstein_to_cardinal_1d`: with ``A`` from
+    that function, this returns ``B`` solving ``A @ B = I``, computed by one LU solve
+    against the identity (:func:`numpy.linalg.solve`). No explicit inverse is formed.
+
+    Note:
+        A second Gram projection -- swapping the two evaluators and solving with the
+        *cardinal* Gram matrix -- is the obvious alternative and is the wrong one. It
+        is equivalent in exact arithmetic, but that Gram matrix satisfies
+        $\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})$ (see
+        :func:`compute_bernstein_to_cardinal_1d`), so it loses twice as many digits.
+        Measured round-trip error $\lVert A B - I \rVert_2$ in float64: ``2.9e-2`` at
+        degree 8 and ``23.9`` at degree 9 via that projection, against ``1.3e-10`` and
+        ``3.8e-10`` here.
+
+    Warning:
+        The cardinal-to-Bernstein map is intrinsically ill-conditioned at high degree
+        -- $\kappa(A)$ is ``1.0e2`` at degree 4, ``9.9e3`` at degree 6, ``1.9e6`` at
+        degree 8 and ``6.3e8`` at degree 10 -- so the attainable accuracy of ``B``, by
+        any algorithm, is bounded by roughly $\kappa(A)\varepsilon$. In float64 the
+        returned matrix reproduces the Bernstein basis to about ``4e-15`` through
+        degree 4, ``3e-13`` at degree 6, ``3e-11`` at degree 8 and ``2e-8`` at degree
+        10, and the round trip holds to the same order; in float32 the bound exceeds
+        0.1 from degree 7 on, so the result is meaningless beyond degree 6. This is a
+        property of the two bases, not of the implementation.
+
+        Far past that point the entries themselves stop being representable: in
+        float32 the exact inverse exceeds the format's range from degree 34 (``6.8e40``
+        at degree 36 against a maximum of ``3.4e38``), so the result contains
+        infinities and NumPy reports an overflow.
 
     Args:
         degree (int): Polynomial degree. Must be non-negative.
@@ -279,18 +344,21 @@ def compute_cardinal_to_bernstein_1d(
     Raises:
         ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
             provided and has incorrect shape or dtype.
+
+    Example:
+        >>> import numpy as np
+        >>> A = compute_bernstein_to_cardinal_1d(3)
+        >>> B = compute_cardinal_to_bernstein_1d(3)
+        >>> np.allclose(A @ B, np.eye(4), atol=1e-13)
+        True
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
 
-    return _compute_change_basis_1D(
-        new_basis_eval=functools.partial(tabulate_cardinal_bspline_1d, degree),
-        old_basis_eval=functools.partial(tabulate_bernstein_1d, degree),
-        n_quad_pts=degree + 1,
-        dtype=dtype,
-        out=out,
-    )
+    forward = compute_bernstein_to_cardinal_1d(degree, dtype)
+    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
+    return out
 
 
 def compute_legendre_to_cardinal_1d(

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -5,12 +5,12 @@ polynomial bases including Lagrange, Bernstein, cardinal B-spline, and monomial
 bases.
 
 Architecturally, this module serves as the **bridge between different basis types**,
-providing pure mathematical functions to compute the exact $(degree+1, degree+1)$
+providing pure mathematical functions to compute the exact ``(degree+1, degree+1)``
 transformation matrices without tying the dense numerical quadrature logic directly
 into the core Spline space objects.
 
-Every public builder is named ``compute_A_to_B_1d`` and returns the matrix $M$ with
-$M \\, [A\\ values](x) = [B\\ values](x)$.
+Every public builder is named ``compute_A_to_B_1d`` and returns the matrix :math:`M` with
+:math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`.
 """
 
 import functools
@@ -120,16 +120,16 @@ def compute_bernstein_to_lagrange_1d(
 
         Only this direction involves a solve. The forward direction needs no
         projection at all: because the Lagrange basis is cardinal at its own nodes,
-        ``C[j, k]`` is just $B_j(x_k)$, so ``C`` costs one basis tabulation and carries
+        ``C[j, k]`` is just :math:`B_j(x_k)`, so ``C`` costs one basis tabulation and carries
         no solve error. That is why this pair is much better conditioned than the
         Bernstein/cardinal and Legendre/cardinal ones.
 
     Warning:
-        $\kappa(C)$ grows with degree and with the node family: with the default
+        :math:`\kappa(C)` grows with degree and with the node family: with the default
         equispaced nodes it is ``1.2e1`` at degree 4, ``4.6e2`` at degree 8 and
         ``3.0e3`` at degree 10, so the attainable accuracy of ``L``, by any algorithm,
-        is bounded by roughly $\kappa(C)\varepsilon$. In float64 the round trip
-        $\lVert C L - I \rVert_2$ holds to ``3e-16`` at degree 4, ``1e-14`` at degree 8
+        is bounded by roughly :math:`\kappa(C)\varepsilon`. In float64 the round trip
+        :math:`\lVert C L - I \rVert_2` holds to ``3e-16`` at degree 4, ``1e-14`` at degree 8
         and ``1e-13`` at degree 10. In float32 the same bound stays below 0.1 through
         degree 11 for equispaced nodes and through degree 14 for the Gauss and
         Chebyshev variants, and over those ranges the measured round trip never exceeds
@@ -251,10 +251,10 @@ def compute_bernstein_to_cardinal_1d(
     than projecting again. This is the direction worth projecting because *its* Gram
     matrix is the Bernstein one, which is far better conditioned than the cardinal
     one: since ``cardinal = A @ bernstein``, the two are related by
-    $G_{\mathrm{card}} = A \, G_{\mathrm{bern}} A^\mathsf{T}$ and therefore
-    $\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})$. Measured at
+    :math:`G_{\mathrm{card}} = A \, G_{\mathrm{bern}} A^\mathsf{T}` and therefore
+    :math:`\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})`. Measured at
     degree 8: ``2.4e4`` against ``8.4e16``, the latter already saturated against
-    $1/\varepsilon$.
+    :math:`1/\varepsilon`.
 
     The quadrature is exact: ``degree + 1`` Gauss-Legendre points integrate
     polynomials up to degree ``2 * degree + 1`` exactly, while every inner product
@@ -306,17 +306,17 @@ def compute_cardinal_to_bernstein_1d(
         A second Gram projection -- swapping the two evaluators and solving with the
         *cardinal* Gram matrix -- is the obvious alternative and is the wrong one. It
         is equivalent in exact arithmetic, but that Gram matrix satisfies
-        $\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})$ (see
+        :math:`\kappa(G_{\mathrm{card}}) \le \kappa(A)^2 \kappa(G_{\mathrm{bern}})` (see
         :func:`compute_bernstein_to_cardinal_1d`), so it loses twice as many digits.
-        Measured round-trip error $\lVert A B - I \rVert_2$ in float64: ``2.9e-2`` at
+        Measured round-trip error :math:`\lVert A B - I \rVert_2` in float64: ``2.9e-2`` at
         degree 8 and ``23.9`` at degree 9 via that projection, against ``1.3e-10`` and
         ``3.8e-10`` here.
 
     Warning:
         The cardinal-to-Bernstein map is intrinsically ill-conditioned at high degree
-        -- $\kappa(A)$ is ``1.0e2`` at degree 4, ``9.9e3`` at degree 6, ``1.9e6`` at
+        -- :math:`\kappa(A)` is ``1.0e2`` at degree 4, ``9.9e3`` at degree 6, ``1.9e6`` at
         degree 8 and ``6.3e8`` at degree 10 -- so the attainable accuracy of ``B``, by
-        any algorithm, is bounded by roughly $\kappa(A)\varepsilon$. In float64 the
+        any algorithm, is bounded by roughly :math:`\kappa(A)\varepsilon`. In float64 the
         returned matrix reproduces the Bernstein basis to about ``4e-15`` through
         degree 4, ``3e-13`` at degree 6, ``3e-11`` at degree 8 and ``2e-8`` at degree
         10, and the round trip holds to the same order. In float32 the same bound
@@ -328,7 +328,7 @@ def compute_cardinal_to_bernstein_1d(
         Far past that point the entries themselves stop being representable: from
         degree 34 the float32 result contains infinities and NumPy reports an overflow,
         the true inverse having outgrown the format's range. How far it has outgrown it
-        is not something float64 can be asked, since $\kappa(A)$ passes $1/\varepsilon$
+        is not something float64 can be asked, since :math:`\kappa(A)` passes :math:`1/\varepsilon`
         for float64 by degree 16.
 
     Args:
@@ -436,8 +436,8 @@ def compute_cardinal_to_legendre_1d(
         A second Gram projection -- swapping the two evaluators and solving with
         the *cardinal* Gram matrix -- is the obvious alternative and is the wrong
         one. It is equivalent in exact arithmetic, but the cardinal Gram matrix
-        satisfies $\kappa(G) = \kappa(A)^2$ (verified numerically to three digits
-        for degrees 0-7; at degree 8 it saturates against $1/\varepsilon$), so it
+        satisfies :math:`\kappa(G) = \kappa(A)^2` (verified numerically to three digits
+        for degrees 0-7; at degree 8 it saturates against :math:`1/\varepsilon`), so it
         loses twice as many digits. Measured round-trip error at degree 8 in
         float64: ``5e-6`` via the Gram projection against ``5e-10`` here. The
         forward direction does not face this because *its* Gram matrix is the
@@ -445,9 +445,9 @@ def compute_cardinal_to_legendre_1d(
 
     Warning:
         The cardinal-to-Legendre map is intrinsically ill-conditioned at high
-        degree -- $\kappa(A)$ is ``1.1e3`` at degree 4 and ``3.0e8`` at degree 8
+        degree -- :math:`\kappa(A)` is ``1.1e3`` at degree 4 and ``3.0e8`` at degree 8
         -- so the attainable accuracy of ``W``, by any algorithm, is bounded by
-        roughly $\kappa(A)\varepsilon$. In float64 the round trip holds to about
+        roughly :math:`\kappa(A)\varepsilon`. In float64 the round trip holds to about
         ``1e-13`` through degree 6 and degrades to ``5e-10`` at degree 8; in
         float32 it is meaningless beyond degree 4. This is a property of the
         bases, not of the implementation.
@@ -491,29 +491,29 @@ def compute_cardinal_dual_legendre_coeffs_1d(
     dtype: npt.DTypeLike = np.float64,
     out: npt.NDArray[np.float32 | np.float64] | None = None,
 ) -> npt.NDArray[np.float32 | np.float64]:
-    r"""Create the cardinal-dual $L^2$ functionals, expressed in the Legendre basis.
+    r"""Create the cardinal-dual :math:`L^2` functionals, expressed in the Legendre basis.
 
     Row ``i`` holds the coefficients, in the orthonormal shifted Legendre basis,
-    of the dual function $D_i$ biorthogonal to the cardinal B-spline basis:
+    of the dual function :math:`D_i` biorthogonal to the cardinal B-spline basis:
 
-    \[
-    \int_0^1 D_i(x) B_{p,j}(x) \, dx = \delta_{ij}
-    \]
+    .. math::
+
+        \int_0^1 D_i(x) B_{p,j}(x) \, dx = \delta_{ij}
 
     Derivation: write the cardinal basis in the Legendre basis as
     ``cardinal = A @ legendre`` with ``A`` from
-    :func:`compute_legendre_to_cardinal_1d`, and let $D_i = \sum_k T_{ik}
-    \tilde{p}_k$. Because the Legendre basis is orthonormal,
-    $\int D_i B_j = \sum_k T_{ik} A_{jk} = (A T^\mathsf{T})_{ji}$, so
-    biorthogonality holds exactly when $T^\mathsf{T} = A^{-1}$, i.e.
-    $T = A^{-\mathsf{T}}$. No inverse is formed: since
+    :func:`compute_legendre_to_cardinal_1d`, and let
+    :math:`D_i = \sum_k T_{ik} \tilde{p}_k`. Because the Legendre basis is orthonormal,
+    :math:`\int D_i B_j = \sum_k T_{ik} A_{jk} = (A T^\mathsf{T})_{ji}`, so
+    biorthogonality holds exactly when :math:`T^\mathsf{T} = A^{-1}`, i.e.
+    :math:`T = A^{-\mathsf{T}}`. No inverse is formed: since
     :func:`compute_cardinal_to_legendre_1d` returns ``W`` with ``W @ A = I`` from
     an LU solve, the result is simply ``W.T``.
 
     Warning:
         Biorthogonality is limited by the same conditioning that bounds ``W`` --
         see the warning on :func:`compute_cardinal_to_legendre_1d`. In float64
-        $\int D_i B_j = \delta_{ij}$ holds to about ``1e-13`` through degree 6 and
+        :math:`\int D_i B_j = \delta_{ij}` holds to about ``1e-13`` through degree 6 and
         to ``5e-10`` at degree 8.
 
     Args:
@@ -527,7 +527,7 @@ def compute_cardinal_dual_legendre_coeffs_1d(
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: (degree+1, degree+1) matrix whose row ``i``
-            holds the Legendre coefficients of the dual function $D_i$. If `out` was
+            holds the Legendre coefficients of the dual function :math:`D_i`. If `out` was
             provided, returns the same array.
 
     Raises:

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -36,26 +36,50 @@ _COND_SAFETY_FACTOR = 64
 """
 Safety factor multiplying the first-order error bound ``cond(A) * eps``.
 
-The bound itself is the standard one for a linear solve: a matrix inverted by LU with
-partial pivoting yields a computed ``B`` whose identity residual obeys
-``||A B - I||_2 <= c * n * rho * eps * cond(A)``, with ``n = degree + 1``, ``rho`` the
-growth factor (about 1 for every matrix here) and ``c`` a small constant. Two things
-the bound does not model set the factor:
+The bound is the standard one for inverting by LU with partial pivoting. Higham (ASNA
+2nd ed., Thm 9.4) gives ``|dA| <= gamma_{3n} |L||U|`` for a solve, the ``3n`` covering
+the factorisation and the two triangular solves; the check here then forms ``A @ B``
+itself, adding another ``gamma_n``. With ``gamma_k ~ k * eps`` and the growth factor
+``rho`` measured at 0.75 to 1.15 for every matrix in this file, that is
 
-* the worst-case dimension factor ``n``, which reaches 11 over the degrees tested;
-* build slack -- an FMA contraction, a different vector width, a different LAPACK --
-  worth about 4x, the same allowance :func:`pantr.tolerance.get_default` makes.
+    ||A B - I||_2  <=  (3n + n) * rho * cond(A) * eps  ~  4n * cond(A) * eps
 
-``4 * 11 = 44`` rounds up to 64, so this factor is deliberately *not* tighter than the
-algorithm's own error bound; it is also exactly ``get_default``'s factor, so the whole
-file grades conditioning-limited quantities at one tier.
+so at ``n = degree + 1 <= 11`` the first-order requirement is ``44 * cond(A) * eps``.
+64 is the power of two above it. The factor is therefore **1.45x** the algorithm's own
+error bound, not a 4x build allowance on top of it: the allowance for an FMA
+contraction, a different vector width or a different LAPACK lives in the gap between
+that first-order bound and the much smaller values actually observed, not in the 44 to
+64 step. Because ``n`` is baked into a constant, the derivation holds for
+``degree <= 11``; past that the constant would have to be restated.
 
-Measured margins with this factor: 6x for biorthogonality at degree 8 (which contracts
-the duals against a ``2 * degree + 2`` point rule, accumulating on top of the solve),
-and 150x for the Bernstein and Lagrange round trips, whose observed residual is at most
-``0.43 * cond(A) * eps`` across degrees 0-12 in both float32 and float64 -- i.e. the
-worst-case dimension factor does not materialise. The looseness is therefore known and
-fixed rather than tuned, and never runs the other way.
+One half of the bound is derived and the other is observed, and the difference matters.
+``cond(A) * eps`` bounds ``forward @ inverse``. For the reversed product there is no
+such bound: from ``B = A^-1 (I + R)`` one gets ``B A - I = A^-1 R A``, hence only
+``||B A - I|| <= cond(A) * ||A B - I|| <= 4n * cond(A)**2 * eps``. Holding the reversed
+product to this same tier is therefore a *stronger, empirical* claim. It is verified
+here through degree 12 and is expected to fail past degree ~19, so extending any
+parametrization beyond that needs this constant revisited rather than trusted.
+
+Measured margins (``atol`` over observed), worst over the degrees actually tested:
+
+* 211x for the Bernstein/cardinal forward product, whose ratio to ``cond(A) * eps``
+  peaks at 0.30 (degree 8) and 0.43 at degree 11;
+* **40.6x** for the Lagrange/Bernstein *reversed* product, whose ratio peaks at 1.58
+  (equispaced, degree 10) -- the binding case, and the reason the claim above is
+  flagged as observed;
+* 6.2x for biorthogonality at degree 8, which contracts the duals against a
+  ``2 * degree + 2`` point rule, accumulating on top of the solve.
+
+Re-running the same inversions through five different LAPACK entry points moves the
+binding ratio by 2.4x, which brings the worst effective margin to about 17x. The
+looseness is thus known, fixed, and never runs the other way.
+
+The constant stays local rather than becoming ``pantr.tolerance.get_default(dtype) *
+cond``, for two reasons: ``cond`` is an amplification factor, not "the magnitude of the
+quantity being compared" that the presets are documented to be multiplied by, and
+``pantr/tolerance.py`` explicitly exempts ``pantr.change_basis`` from the presets,
+requiring it to report the accuracy it attains per degree. That the two factors both
+equal 64 is a coincidence of two different derivations.
 """
 
 _ROUNDOFF_FACTOR = 64
@@ -335,6 +359,35 @@ class TestBernsteinToLagrangeBasisOperator:
         assert _identity_residual(forward, inverse) <= atol
         assert _identity_residual(inverse, forward) <= atol
 
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            LagrangeVariant.EQUISPACES,
+            LagrangeVariant.GAUSS_LEGENDRE,
+            LagrangeVariant.GAUSS_LOBATTO_LEGENDRE,
+            LagrangeVariant.CHEBYSHEV_1ST,
+            LagrangeVariant.CHEBYSHEV_2ND,
+        ],
+    )
+    @pytest.mark.parametrize("degree", [1, 4, 7, 10])
+    def test_roundtrip_float32(self, degree: int, variant: LagrangeVariant) -> None:
+        """The pair round-trips in float32 across every node family.
+
+        This is the test behind the docstring claim that, alone among the three pairs,
+        this one stays usable in single precision over the whole range of practical
+        degrees. Degree 10 is inside every variant's certified range: the derived bound
+        stays below 0.1 through degree 11 for equispaced nodes and through degree 14 for
+        the Gauss and Chebyshev families, so no degree tested here is a vacuous claim.
+        """
+        forward = compute_lagrange_to_bernstein_1d(degree, variant, dtype=np.float32)
+        inverse = compute_bernstein_to_lagrange_1d(degree, variant, dtype=np.float32)
+        assert forward.dtype == np.float32
+        assert inverse.dtype == np.float32
+
+        atol = _conditioning_atol(compute_lagrange_to_bernstein_1d(degree, variant), np.float32)
+        assert _identity_residual(forward, inverse) <= atol
+        assert _identity_residual(inverse, forward) <= atol
+
 
 class TestCardinalToBernsteinRoundTrip:
     """Pin the Bernstein<->cardinal pair to the accuracy its conditioning allows.
@@ -371,7 +424,13 @@ class TestCardinalToBernsteinRoundTrip:
         from the quadrature nodes used to build the pair, so a rule that happened to be
         exact only at its own nodes would not pass. The bound is the same
         conditioning-limited one: the map amplifies the ``O(1)`` cardinal values by
-        ``||A^-1||`` and cancels back down to ``O(1)``.
+        ``||A^-1||`` and cancels back down to ``O(1)``. Strictly it is the *reversed*
+        product that governs here, since ``B @ cardinal = B A @ bernstein``; see
+        ``_COND_SAFETY_FACTOR`` on why that tier is observed rather than derived.
+
+        ``rtol=0`` is required: the default ``rtol=1e-7`` would dominate the derived
+        ``atol`` on every entry of magnitude near 1, leaving the largest Bernstein
+        values graded a hundred million times more loosely than intended.
         """
         rng = np.random.default_rng(20260817 + degree)
         pts = rng.random(200)
@@ -383,8 +442,29 @@ class TestCardinalToBernsteinRoundTrip:
         np.testing.assert_allclose(
             result,
             tabulate_bernstein_1d(degree, pts).T,
+            rtol=0,
             atol=_conditioning_atol(compute_bernstein_to_cardinal_1d(degree)),
         )
+
+    def test_acceptance_thresholds_of_ticket_300(self) -> None:
+        """Pin the two round-trip numbers ticket #300 accepts the fix against.
+
+        These two literals are the ticket's acceptance thresholds, not tolerances: they
+        record the fitness of one configuration rather than bounding an algorithm, which
+        is why they are stated rather than derived. They are *tighter* than
+        ``_COND_SAFETY_FACTOR * cond(A) * eps`` (``2.8e-8`` at degree 8, ``4.7e-7`` at
+        degree 9), so the derived test above cannot enforce them and this one does.
+
+        Margins are thin by the standards of this file -- 7.7x at degree 8, where the
+        observed residual moves by a factor of 3.8 across LAPACK entry points -- so a
+        failure here is a signal to re-measure, not necessarily a regression.
+        """
+        for degree, threshold in ((8, 1e-9), (9, 1e-8)):
+            residual = _identity_residual(
+                compute_bernstein_to_cardinal_1d(degree),
+                compute_cardinal_to_bernstein_1d(degree),
+            )
+            assert residual <= threshold, f"degree {degree}: {residual:.3e} > {threshold:.0e}"
 
     @pytest.mark.parametrize("degree", range(7))
     def test_roundtrip_float32(self, degree: int) -> None:
@@ -852,7 +932,7 @@ class TestLegendreCardinalBasisOperators:
                 [0.5, 1.0 / (2.0 * np.sqrt(3.0))],
             ]
         )
-        np.testing.assert_allclose(compute_legendre_to_cardinal_1d(1), expected, atol=1e-15)
+        np.testing.assert_allclose(compute_legendre_to_cardinal_1d(1), expected, rtol=0, atol=1e-15)
 
     @pytest.mark.parametrize("degree", range(9))
     def test_forward_map_reproduces_cardinal_basis(self, degree: int) -> None:
@@ -870,6 +950,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             result,
             tabulate_cardinal_bspline_1d(degree, pts).T,
+            rtol=0,
             atol=_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
         )
 
@@ -885,8 +966,8 @@ class TestLegendreCardinalBasisOperators:
         identity = np.eye(degree + 1)
         atol = _conditioning_atol(forward)
 
-        np.testing.assert_allclose(inverse @ forward, identity, atol=atol)
-        np.testing.assert_allclose(forward @ inverse, identity, atol=atol)
+        np.testing.assert_allclose(inverse @ forward, identity, rtol=0, atol=atol)
+        np.testing.assert_allclose(forward @ inverse, identity, rtol=0, atol=atol)
 
     @pytest.mark.parametrize("degree", range(5))
     def test_roundtrip_float32(self, degree: int) -> None:
@@ -921,6 +1002,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             compute_legendre_to_cardinal_1d(degree).sum(axis=0),
             expected,
+            rtol=0,
             atol=_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
         )
 
@@ -986,6 +1068,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             compute_legendre_to_cardinal_1d(degree),
             compute_bernstein_to_cardinal_1d(degree) @ legendre_to_bernstein,
+            rtol=0,
             atol=_COMPOSED_ROUNDOFF_FACTOR * get_machine_epsilon(np.float64),
         )
 
@@ -1018,12 +1101,17 @@ class TestLegendreCardinalBasisOperators:
         self,
         builder: Callable[..., npt.NDArray[np.float32 | np.float64]],
     ) -> None:
-        """A provided ``out`` is returned and filled; a bad one is rejected."""
+        """A provided ``out`` is returned and filled; a bad one is rejected.
+
+        The two calls run the same computation on the same inputs, so the ``out=`` path
+        must reproduce the allocating path bit for bit; ``assert_allclose`` would have
+        accepted a relative difference of ``1e-7`` between them.
+        """
         degree = 3
         out = np.empty((degree + 1, degree + 1), dtype=np.float64)
         result = builder(degree, np.float64, out)
         assert result is out
-        np.testing.assert_allclose(result, builder(degree))
+        np.testing.assert_array_equal(result, builder(degree))
 
         with pytest.raises(ValueError, match="dtype must be float32 or float64"):
             builder(degree, np.int32)

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -57,21 +57,25 @@ One half of the bound is derived and the other is observed, and the difference m
 such bound: from ``B = A^-1 (I + R)`` one gets ``B A - I = A^-1 R A``, hence only
 ``||B A - I|| <= cond(A) * ||A B - I|| <= 4n * cond(A)**2 * eps``. Holding the reversed
 product to this same tier is therefore a *stronger, empirical* claim. It is verified
-here through degree 12 and is expected to fail past degree ~19, so extending any
-parametrization beyond that needs this constant revisited rather than trusted.
+here through degree 11 -- the ceiling of the derivation above, and the highest degree any
+parametrization in this file reaches -- and is expected to fail past degree ~19, so
+extending any parametrization beyond that needs this constant revisited rather than
+trusted.
 
 Measured margins (``atol`` over observed), worst over the degrees actually tested:
 
-* 211x for the Bernstein/cardinal forward product, whose ratio to ``cond(A) * eps``
-  peaks at 0.30 (degree 8) and 0.43 at degree 11;
-* **40.6x** for the Lagrange/Bernstein *reversed* product, whose ratio peaks at 1.58
-  (equispaced, degree 10) -- the binding case, and the reason the claim above is
-  flagged as observed;
+* 151x for the Bernstein/cardinal forward product, whose ratio to ``cond(A) * eps``
+  peaks at 0.43 (degree 11), having been 0.30 at degree 8;
+* **31x** for the Lagrange/Bernstein *reversed* product, whose ratio peaks at 2.04
+  (Chebyshev 1st, degree 11) -- the binding case, and the reason the claim above is
+  flagged as observed. Equispaced at degree 10, 1.58, is not the worst: the peak moves
+  to Chebyshev at the top of the tested range, so the binding variant is not fixed
+  across degrees and a narrower parametrization would have found a smaller ratio;
 * 6.2x for biorthogonality at degree 8, which contracts the duals against a
   ``2 * degree + 2`` point rule, accumulating on top of the solve.
 
 Re-running the same inversions through five different LAPACK entry points moves the
-binding ratio by 2.4x, which brings the worst effective margin to about 17x. The
+binding ratio by 2.4x, which brings the worst effective margin to about **13x**. The
 looseness is thus known, fixed, and never runs the other way.
 
 The constant stays local rather than becoming ``pantr.tolerance.get_default(dtype) *
@@ -342,7 +346,7 @@ class TestBernsteinToLagrangeBasisOperator:
             LagrangeVariant.CHEBYSHEV_2ND,
         ],
     )
-    @pytest.mark.parametrize("degree", [1, 4, 7, 10])
+    @pytest.mark.parametrize("degree", [1, 4, 7, 10, 11])
     def test_roundtrip_tracks_conditioning(self, degree: int, variant: LagrangeVariant) -> None:
         """Both products of the pair must be the identity to ``K * cond(C) * eps``.
 
@@ -399,7 +403,7 @@ class TestCardinalToBernsteinRoundTrip:
     no correct digits at all by degree 9.
     """
 
-    @pytest.mark.parametrize("degree", range(11))
+    @pytest.mark.parametrize("degree", range(12))
     def test_roundtrip_tracks_conditioning_not_its_square(self, degree: int) -> None:
         """Both products of the pair must be the identity to ``K * cond(A) * eps``.
 
@@ -415,7 +419,7 @@ class TestCardinalToBernsteinRoundTrip:
         assert _identity_residual(forward, inverse) <= atol
         assert _identity_residual(inverse, forward) <= atol
 
-    @pytest.mark.parametrize("degree", range(11))
+    @pytest.mark.parametrize("degree", range(12))
     def test_inverse_map_reproduces_bernstein_basis(self, degree: int) -> None:
         """``B @ cardinal(x)`` must equal ``bernstein(x)`` at arbitrary points.
 
@@ -482,7 +486,7 @@ class TestCardinalToBernsteinRoundTrip:
         atol = _conditioning_atol(compute_bernstein_to_cardinal_1d(degree), np.float32)
         assert _identity_residual(forward, inverse) <= atol
 
-    @pytest.mark.parametrize("degree", range(11))
+    @pytest.mark.parametrize("degree", range(12))
     def test_cached_matrix_round_trips_like_the_builder(self, degree: int) -> None:
         """The cached hot-path matrix must be the same inverse the builder returns.
 
@@ -985,6 +989,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             inverse @ forward,
             np.eye(degree + 1, dtype=np.float32),
+            rtol=0,
             atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree), np.float32),
         )
 
@@ -1024,6 +1029,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             gram,
             np.eye(degree + 1),
+            rtol=0,
             atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree)),
         )
 
@@ -1041,6 +1047,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             duals[:, 0],
             np.ones(degree + 1),
+            rtol=0,
             atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree)),
         )
 

--- a/tests/test_change_basis_1D.py
+++ b/tests/test_change_basis_1D.py
@@ -36,12 +36,26 @@ _COND_SAFETY_FACTOR = 64
 """
 Safety factor multiplying the first-order error bound ``cond(A) * eps``.
 
-The bound itself is the standard one for a linear solve. The factor covers what it
-does not model: the biorthogonality check contracts the duals against a quadrature
-rule, so its error accumulates over ``2 * degree + 2`` points on top of the solve.
-Measured margins with this factor range from 6x (degree 8, biorthogonality) to
-several hundred (low degrees), i.e. it is never looser than needed by more than two
-orders and never tighter than the phenomenon.
+The bound itself is the standard one for a linear solve: a matrix inverted by LU with
+partial pivoting yields a computed ``B`` whose identity residual obeys
+``||A B - I||_2 <= c * n * rho * eps * cond(A)``, with ``n = degree + 1``, ``rho`` the
+growth factor (about 1 for every matrix here) and ``c`` a small constant. Two things
+the bound does not model set the factor:
+
+* the worst-case dimension factor ``n``, which reaches 11 over the degrees tested;
+* build slack -- an FMA contraction, a different vector width, a different LAPACK --
+  worth about 4x, the same allowance :func:`pantr.tolerance.get_default` makes.
+
+``4 * 11 = 44`` rounds up to 64, so this factor is deliberately *not* tighter than the
+algorithm's own error bound; it is also exactly ``get_default``'s factor, so the whole
+file grades conditioning-limited quantities at one tier.
+
+Measured margins with this factor: 6x for biorthogonality at degree 8 (which contracts
+the duals against a ``2 * degree + 2`` point rule, accumulating on top of the solve),
+and 150x for the Bernstein and Lagrange round trips, whose observed residual is at most
+``0.43 * cond(A) * eps`` across degrees 0-12 in both float32 and float64 -- i.e. the
+worst-case dimension factor does not materialise. The looseness is therefore known and
+fixed rather than tuned, and never runs the other way.
 """
 
 _ROUNDOFF_FACTOR = 64
@@ -64,28 +78,57 @@ degree 8, so the single-map factor of 64 would leave only 5x; 256 restores ~21x.
 """
 
 
-def _conditioning_atol(degree: int, dtype: npt.DTypeLike = np.float64) -> float:
-    """Return the attainable accuracy for inverting the Legendre-to-cardinal map.
+def _conditioning_atol(
+    forward: npt.NDArray[np.float32 | np.float64],
+    dtype: npt.DTypeLike = np.float64,
+) -> float:
+    """Return the attainable accuracy for inverting a change-of-basis map.
 
-    The cardinal-to-Legendre direction requires solving with a matrix whose
-    condition number grows steeply with degree (``1.1e3`` at degree 4, ``3.0e8`` at
-    degree 8), so no algorithm can do better than roughly ``cond(A) * eps``. Tests
-    of that direction, of the duals built from it, and of biorthogonality are all
-    bounded by this quantity rather than by a flat tolerance.
+    Every pair in this module builds one direction directly and obtains the other by
+    an LU solve against the identity. The inverse direction therefore cannot do
+    better than roughly ``cond(forward) * eps``, whatever the algorithm, and that
+    quantity spans many orders of magnitude across the degrees tested (``1.1e3`` at
+    degree 4 for the Legendre pair, ``3.0e8`` at degree 8). Tests of an inverse
+    direction, of anything built from one, and of biorthogonality are all bounded by
+    this rather than by a flat tolerance.
 
-    The condition number is always taken from the float64 matrix: it is a property
-    of the two bases, not of the dtype the result is stored in.
+    Pass the **float64** matrix even when grading a float32 result: the condition
+    number is a property of the two bases, not of the dtype the result is stored in,
+    and estimating it in float32 would itself be conditioning-limited.
 
     Args:
-        degree (int): Polynomial degree.
+        forward (npt.NDArray[np.float32 | np.float64]): The directly-built direction
+            of the pair, whose conditioning bounds the inverse direction.
         dtype (npt.DTypeLike): Dtype whose machine epsilon sets the noise floor.
             Defaults to np.float64.
 
     Returns:
         float: Absolute tolerance for identities involving the inverse map.
     """
-    cond = float(np.linalg.cond(compute_legendre_to_cardinal_1d(degree)))
+    cond = float(np.linalg.cond(np.asarray(forward, dtype=np.float64)))
     return _COND_SAFETY_FACTOR * cond * get_machine_epsilon(dtype)
+
+
+def _identity_residual(
+    left: npt.NDArray[np.float32 | np.float64],
+    right: npt.NDArray[np.float32 | np.float64],
+) -> float:
+    """Return the spectral norm of ``left @ right - I``.
+
+    Both operands are promoted to float64 before the product so that the residual
+    measures the error carried by the two matrices, not the error of the check
+    itself. That matters for the float32 assertions, where a float32 product would
+    add a rounding of its own at the very magnitude being graded.
+
+    Args:
+        left (npt.NDArray[np.float32 | np.float64]): Left factor of the product.
+        right (npt.NDArray[np.float32 | np.float64]): Right factor of the product.
+
+    Returns:
+        float: ``||left @ right - I||_2``, the quantity ticket #300 tabulates.
+    """
+    product = np.asarray(left, dtype=np.float64) @ np.asarray(right, dtype=np.float64)
+    return float(np.linalg.norm(product - np.eye(product.shape[0]), ord=2))
 
 
 class TestLagrangeToBernsteinBasisOperator:
@@ -264,6 +307,113 @@ class TestBernsteinToLagrangeBasisOperator:
 
         C_inv = compute_lagrange_to_bernstein_1d(degree, variant)
         np.testing.assert_array_almost_equal(lagranges @ C_inv.T, bernsteins)
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            LagrangeVariant.EQUISPACES,
+            LagrangeVariant.GAUSS_LEGENDRE,
+            LagrangeVariant.GAUSS_LOBATTO_LEGENDRE,
+            LagrangeVariant.CHEBYSHEV_1ST,
+            LagrangeVariant.CHEBYSHEV_2ND,
+        ],
+    )
+    @pytest.mark.parametrize("degree", [1, 4, 7, 10])
+    def test_roundtrip_tracks_conditioning(self, degree: int, variant: LagrangeVariant) -> None:
+        """Both products of the pair must be the identity to ``K * cond(C) * eps``.
+
+        The same derived bound the Bernstein<->cardinal and Legendre<->cardinal pairs
+        are held to, so all three inverse pairs in this module are graded alike. This
+        pair is far better conditioned than the other two -- ``cond(C)`` reaches only
+        ``3.0e3`` at degree 10 with the worst (equispaced) nodes -- so the bound stays
+        near the noise floor and the test pins that rather than rescuing it.
+        """
+        forward = compute_lagrange_to_bernstein_1d(degree, variant)
+        inverse = compute_bernstein_to_lagrange_1d(degree, variant)
+        atol = _conditioning_atol(forward)
+
+        assert _identity_residual(forward, inverse) <= atol
+        assert _identity_residual(inverse, forward) <= atol
+
+
+class TestCardinalToBernsteinRoundTrip:
+    """Pin the Bernstein<->cardinal pair to the accuracy its conditioning allows.
+
+    Regression tests for ticket #300: the two directions used to be independent Gram
+    projections, and the inverse one solved against the *cardinal* Gram matrix, whose
+    condition number is ``cond(A)**2`` times the Bernstein Gram matrix's. The round
+    trip therefore tracked ``cond(A)**2 * eps`` instead of ``cond(A) * eps`` and had
+    no correct digits at all by degree 9.
+    """
+
+    @pytest.mark.parametrize("degree", range(11))
+    def test_roundtrip_tracks_conditioning_not_its_square(self, degree: int) -> None:
+        """Both products of the pair must be the identity to ``K * cond(A) * eps``.
+
+        This is the ticket's discriminating measurement. From degree 5 on, the bound
+        sits below ``cond(A)**2 * eps`` by more than the safety factor, so passing it
+        rules out the squared law rather than merely tolerating problem conditioning:
+        at degree 8 the bound is ``2.8e-8`` while ``cond(A)**2 * eps`` is ``8.4e-4``.
+        """
+        forward = compute_bernstein_to_cardinal_1d(degree)
+        inverse = compute_cardinal_to_bernstein_1d(degree)
+        atol = _conditioning_atol(forward)
+
+        assert _identity_residual(forward, inverse) <= atol
+        assert _identity_residual(inverse, forward) <= atol
+
+    @pytest.mark.parametrize("degree", range(11))
+    def test_inverse_map_reproduces_bernstein_basis(self, degree: int) -> None:
+        """``B @ cardinal(x)`` must equal ``bernstein(x)`` at arbitrary points.
+
+        The property the matrix is defined by, and the one a caller moving
+        coefficients between the two representations actually depends on. Checked away
+        from the quadrature nodes used to build the pair, so a rule that happened to be
+        exact only at its own nodes would not pass. The bound is the same
+        conditioning-limited one: the map amplifies the ``O(1)`` cardinal values by
+        ``||A^-1||`` and cancels back down to ``O(1)``.
+        """
+        rng = np.random.default_rng(20260817 + degree)
+        pts = rng.random(200)
+
+        result = (
+            compute_cardinal_to_bernstein_1d(degree) @ tabulate_cardinal_bspline_1d(degree, pts).T
+        )
+
+        np.testing.assert_allclose(
+            result,
+            tabulate_bernstein_1d(degree, pts).T,
+            atol=_conditioning_atol(compute_bernstein_to_cardinal_1d(degree)),
+        )
+
+    @pytest.mark.parametrize("degree", range(7))
+    def test_roundtrip_float32(self, degree: int) -> None:
+        """The pair round-trips in float32 over the degrees where the bound is meaningful.
+
+        From degree 7 on the derived bound ``_COND_SAFETY_FACTOR * cond(A) * eps32``
+        exceeds 0.1 (``0.98`` at degree 7 against ``0.076`` at degree 6) and the
+        assertion would be vacuous, so those degrees are deliberately not claimed.
+        """
+        forward = compute_bernstein_to_cardinal_1d(degree, dtype=np.float32)
+        inverse = compute_cardinal_to_bernstein_1d(degree, dtype=np.float32)
+        assert forward.dtype == np.float32
+        assert inverse.dtype == np.float32
+
+        atol = _conditioning_atol(compute_bernstein_to_cardinal_1d(degree), np.float32)
+        assert _identity_residual(forward, inverse) <= atol
+
+    @pytest.mark.parametrize("degree", range(11))
+    def test_cached_matrix_round_trips_like_the_builder(self, degree: int) -> None:
+        """The cached hot-path matrix must be the same inverse the builder returns.
+
+        The extraction operators consume the cached copy rather than the builder, so
+        the accuracy pinned above has to reach them unchanged.
+        """
+        cached = _cached_cardinal_to_bernstein_matrix(degree, np.dtype(np.float64))
+        forward = compute_bernstein_to_cardinal_1d(degree)
+
+        np.testing.assert_array_equal(cached, compute_cardinal_to_bernstein_1d(degree))
+        assert _identity_residual(forward, cached) <= _conditioning_atol(forward)
 
 
 class TestCardinalToBernsteinBasisOperator:
@@ -733,7 +883,7 @@ class TestLegendreCardinalBasisOperators:
         forward = compute_legendre_to_cardinal_1d(degree)
         inverse = compute_cardinal_to_legendre_1d(degree)
         identity = np.eye(degree + 1)
-        atol = _conditioning_atol(degree)
+        atol = _conditioning_atol(forward)
 
         np.testing.assert_allclose(inverse @ forward, identity, atol=atol)
         np.testing.assert_allclose(forward @ inverse, identity, atol=atol)
@@ -742,8 +892,9 @@ class TestLegendreCardinalBasisOperators:
     def test_roundtrip_float32(self, degree: int) -> None:
         """The pair round-trips in float32 over the degrees where the bound is meaningful.
 
-        Beyond degree 5 the derived bound ``cond(A) * eps32`` exceeds 0.1 and the
-        assertion would be vacuous, so those degrees are deliberately not claimed.
+        From degree 5 on the derived bound ``_COND_SAFETY_FACTOR * cond(A) * eps32``
+        exceeds 0.1 and the assertion would be vacuous, so those degrees are
+        deliberately not claimed.
         """
         forward = compute_legendre_to_cardinal_1d(degree, dtype=np.float32)
         inverse = compute_cardinal_to_legendre_1d(degree, dtype=np.float32)
@@ -753,7 +904,7 @@ class TestLegendreCardinalBasisOperators:
         np.testing.assert_allclose(
             inverse @ forward,
             np.eye(degree + 1, dtype=np.float32),
-            atol=_conditioning_atol(degree, np.float32),
+            atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree), np.float32),
         )
 
     @pytest.mark.parametrize("degree", range(9))
@@ -788,7 +939,11 @@ class TestLegendreCardinalBasisOperators:
 
         gram = (duals @ (legendre.T * weights)) @ cardinal
 
-        np.testing.assert_allclose(gram, np.eye(degree + 1), atol=_conditioning_atol(degree))
+        np.testing.assert_allclose(
+            gram,
+            np.eye(degree + 1),
+            atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree)),
+        )
 
     @pytest.mark.parametrize("degree", range(9))
     def test_dual_integrates_to_one(self, degree: int) -> None:
@@ -802,7 +957,9 @@ class TestLegendreCardinalBasisOperators:
         duals = compute_cardinal_dual_legendre_coeffs_1d(degree)
 
         np.testing.assert_allclose(
-            duals[:, 0], np.ones(degree + 1), atol=_conditioning_atol(degree)
+            duals[:, 0],
+            np.ones(degree + 1),
+            atol=_conditioning_atol(compute_legendre_to_cardinal_1d(degree)),
         )
 
     @pytest.mark.parametrize("degree", range(9))


### PR DESCRIPTION
`compute_bernstein_to_cardinal_1d` and `compute_cardinal_to_bernstein_1d` were
documented as the two directions of one change of basis but computed as two independent
Gram projections. The inverse direction solved against the *cardinal* Gram matrix, whose
condition number is the square of the change-of-basis matrix's own, so it lost twice the
digits the problem requires. The file already documented that this construction is the
wrong one, in the `Note:` on the Legendre pair.

Each pair is now one Gram projection plus one LU solve against the identity, the idiom
`compute_cardinal_to_legendre_1d` already used. No explicit inverse is formed.

## Acceptance criteria

**AC1** — the round-trip residual tracks `κ(A)·eps` and no longer `κ(A)²·eps`:

```
 deg    kappa(A)  BEFORE ||AB-I||   AFTER ||AB-I||   kappa*eps  kappa^2*eps   after/(k*eps)
   4   1.011e+02        1.102e-11        6.199e-15   2.245e-14    2.270e-12          0.2761
   6   9.918e+03        6.390e-08        2.349e-13   2.202e-12    2.184e-08          0.1067
   8   1.942e+06        2.869e-02        1.302e-10   4.312e-10    8.375e-04          0.3020
   9   3.311e+07        2.387e+01        3.843e-10   7.352e-09    2.434e-01          0.0523
  10   6.311e+08        7.270e+02        2.103e-08   1.401e-07    8.843e+01          0.1501
```

Worst ratio to `κ(A)·eps` over degrees 1 to 10 is **0.302**. The `BEFORE` column was
reproduced by reconstructing the old projection inline and matches the issue digit for
digit.

**AC2** — degree 8: `1.302e-10 ≤ 1e-9` (was `2.869e-2`). Degree 9: `3.843e-10 ≤ 1e-8`
(was `23.9`). The derived bound is *looser* than these two numbers, so it cannot enforce
them; a separate test pins them explicitly as fitness thresholds rather than as
tolerances.

**AC3** — the regression tests assert against a `κ(A)`-derived bound, not a literal, and
fail against the old construction: `21 failed, 183 passed` at the lock commit, across
`test_roundtrip_tracks_conditioning_not_its_square[4..10]`,
`test_inverse_map_reproduces_bernstein_basis[7..10]`, `test_roundtrip_float32[4..6]` and
`test_cached_matrix_round_trips_like_the_builder[4..10]`. Post-fix: `204 passed`.

**AC4** — the Lagrange↔Bernstein pair is built the same way, with a round-trip test:
`3.3e-16` at degree 4, `1.4e-14` at degree 8, `1.5e-13` at degree 10.

Worth recording, because the issue's diagnosis was wrong here: that pair was **not** two
independent projections. The forward direction is a pure tabulation (the Lagrange basis is
cardinal at its own nodes, so `C[j,k]` is just `B_j(x_k)`), and the inverse already used
`np.linalg.inv`. Switching it to `solve` against the identity is **bitwise identical** on
degrees 1-10 in both dtypes, so this pair changed zero numbers. It is now uniform with the
other two and no `np.linalg.inv` remains in the module.

**AC5** — both pairs' docstrings state the attainable accuracy per degree and the float32
limit. The float32 cutoffs were measured, not estimated: the bound stays under 0.1 through
**degree 6** for Bernstein↔cardinal, and through **degree 11** equispaced / **14** Gauss
and Chebyshev for Lagrange↔Bernstein.

**AC6** — the cached helpers are unchanged in contract: same object on a repeat call
(`is` holds), still read-only, bitwise equal to the builder, and the cached matrix
genuinely inverts its pair (`4.98e-14` at degree 5).

**Specification** — the projected direction really is the better-conditioned one, verified
rather than assumed: `κ(G_bern)` is `3.53e5` against `κ(G_card)` `8.27e21` at degree 10,
explained by the identity `G_card = A G_bern Aᵀ`, which was checked numerically. All eight
public signatures are byte-identical to base.

## Tolerance derivation

`atol = 64 · cond₂(forward) · eps`, reusing the safety factor already in the file.

The LU-inversion residual bound is `γ_{3n}` (factorization plus two triangular solves) and
the check's own matmul adds `γ_n`, so the first-order requirement is `4n·cond·eps =
44·cond·eps` at `n = degree+1 ≤ 11`. 64 is the next power of two, i.e. **1.45×** the
algorithm's own bound. Measured growth factor 0.75 to 1.15.

**One half of this bound is observed, not derived, and the docstring says so.** For the
reversed product `B A − I = A⁻¹ R A`, only `κ²·eps` is available a priori; the `κ·eps`
behaviour is verified through degree 12 and expected to fail past roughly degree 19. That
is stated rather than papered over.

A `tolerance-hunter` pass endorsed the factor 64 but caught three real defects in the
derivation as first written, all corrected: a `γ_n`/`γ_{3n}` mis-accounting that claimed a
4× margin which does not exist, two measured margins that were simply false (the reversed
product reaches `1.58·κ·eps`, worst margin 40.6×, not the 0.43 and 150× first claimed),
and the observed-versus-derived split above. It also ruled against routing through
`tolerance.get_default`, since `tolerance.py` explicitly exempts this module from the
presets.

## Extraction-path impact

The production blast radius is one call site, `_bspline_extraction.py:333`. Cardinal
extraction operator deltas: `2.1e-15` at degree 2, `1.3e-13` at degree 3, `2.1e-11` at
degree 4, `4.0e-9` at degree 5. Every extraction test tops out at degree 3, so nothing
moved materially and **no extraction test needed changing**. Independently,
`‖ext_op @ cardinal(local) − bspline(x)‖` is `5.6e-16` to `5.0e-15` for degrees 2-5. The
strict-xfail conditioning test still xfails for the same reason, and the float32 raising
threshold is degree 37 before and after.

## Docstring rendering

The accuracy warnings above are the deliverable of AC5, and none of the module's math was
reaching the page. Autodoc renders docstrings as reStructuredText, where `$...$` has no
meaning; `dollarmath` is enabled for MyST, which covers Markdown only. The built HTML
showed `$kappa(A)varepsilon$`, dollars kept and backslashes eaten.

All 27 spans now use the `:math:` role, which reST processes and which `quad.py` and
`_bezier.py` already use. Two sibling constructs went with them: `\[ ... \]` display
delimiters, ignored just as silently, became a `.. math::` directive, and a `\\,` in the
already-raw module docstring dropped to `\,`. Verified against the rebuilt HTML: no
literal dollar-math remains and the payload arrives as `\(\kappa(A)\varepsilon\)` inside a
MathJax span.

## Self-review

The implementing engineer's own round, before handoff: 3 critical, 6 important,
1 recommended, 1 nitpick.

- **Critical** — the tolerance docstring's measured margins were false (0.43 → 1.58,
  150× → 40.6×). Corrected and re-measured.
- **Critical** — `γ_n` should have been `γ_{3n}`; the claimed 4× margin is really 1.45×.
  Corrected, with the degree ceiling stated.
- **Critical** — `assert_allclose` keeps its default `rtol=1e-7` when only `atol` is
  passed, which made every derived tolerance in this test file inert on O(1) entries, by
  up to 1e8×. Fixed at 7 sites with `rtol=0` (1 new, 6 pre-existing), each measured green
  first.
- **Important** ×4 — the reversed-product bound presented as derived when it is observed;
  a false float32 claim (`8e-5` → `1.1e-4`, Gauss-Legendre degree 14 gives `1.047e-4`); an
  unsupportable degree-36 overflow magnitude, removed since `κ(A)` passes `1/eps` for
  float64 by degree 16; and "meaningless beyond degree 6" conflating the bound with the
  measurement, when the float32 round trip is still `7e-3` at degree 8 and reaches `1.3`
  only at degree 9. Both readings are now given.
- **Important** — the Lagrange float32 claim had no test. Added, 20 cases.
- **Important, surfaced not fixed** — `test_out_parameter` for the cardinal direction is
  vacuous: it compares two `np.empty` buffers and passed a drop-write mutation by
  allocator coincidence. Pre-existing; neighbouring tests catch the underlying bug.
- **Recommended** — the docstring math rendering, since fixed in this PR.
- **Nitpick** — `C` named two different matrices in one docstring; the return matrices are
  now `A` / `B` / `L`, matching the prose.

Two claim-checking passes ran over the new docstrings: 17 of 18 numeric claims verified,
one refuted twice over and corrected. A bug-injection check on the central test
(transpose, swapped solve arguments, return-the-forward-matrix, dropped write) fails from
degree 2 for all four, so it is not tautological.

One test was **backed out rather than forced**: a forward-map test failed at degree 10
because the forward map's error is not flat in degree (its Gram is not the identity). It
needed a new Gram-conditioning derivation, and the inverse-map test already certifies that
direction transitively to degree 10, so it was reverted rather than have a tolerance
invented for it.

Self-review commit: `a5bfddb`.

## Checks

Whole repo, output parsed rather than trusting exit status.

| step | result |
|---|---|
| `ruff check .` | All checks passed |
| `ruff format --check` | 257 files already formatted |
| `mypy src tests` | Success: no issues found in 233 source files |
| `lint-imports` | Contracts: 1 kept, 0 broken |
| `pytest` | 5514 passed, 21 skipped, 3 xfailed |
| coverage | `change_basis.py` 100%, TOTAL 96% |
| docs build | build succeeded under `-W`, math verified in the HTML |

## One behaviour change beyond the issue

From **degree 34** in float32, `compute_cardinal_to_bernstein_1d` now returns infinities
and numpy reports an overflow, where the old projection returned finite garbage. The true
inverse has outgrown the format's range, so the infinities are the honest answer and the
warning is new information rather than a regression. It is documented in the `Warning:`
block. It matters only because warnings are errors under pytest, so a future test reaching
that degree would fail; no test comes within 28 degrees of it, and giving these builders a
documented degree limit is already tracked separately.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
