### PR TITLE
fix(grid): state coarsen's real contract and name the cells that block it

### DIFF
--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1302,9 +1302,10 @@ class HierarchicalGrid(Grid):
         injective** on the grid state and no single :meth:`coarsen` can undo it in
         general: ``coarsen(level, lo, hi)`` reverses this call only when every cell
         of ``[lo, hi)`` was an active leaf at ``level`` beforehand.  When it was
-        not, the paired :meth:`coarsen` demotes the whole box, including the cells
-        this call left alone, and so removes children an earlier :meth:`refine`
-        created.  Where that must not happen, name the cells rather than a box on
+        not, the paired :meth:`coarsen` either refuses the box, if part of it now
+        sits deeper than ``level+1``, or demotes all of it, including the cells this
+        call left alone, and so removes children an earlier :meth:`refine` created.
+        Where that must not happen, name the cells rather than a box on
         the side that destroys them: :meth:`~pantr.bspline.THBSplineSpace.coarsen`
         reactivates a parent only when all of its children are named active
         leaves, so nothing the caller did not name is removed.  (:meth:`refine_cells`
@@ -1419,7 +1420,7 @@ class HierarchicalGrid(Grid):
         lo: Sequence[int],
         hi: Sequence[int],
     ) -> None:
-        """Demote the rectangular region ``[lo, hi)`` at ``level`` back to ``level``.
+        """Demote the rectangular region ``[lo, hi)`` from ``level+1`` back to ``level``.
 
         Reactivates the level-``level`` cells in ``[lo, hi)`` and removes their
         level-``(level+1)`` children.  The region must be **fully refined to exactly
@@ -1432,13 +1433,14 @@ class HierarchicalGrid(Grid):
         currently-active portion.  :meth:`refine` is therefore not injective on the
         grid state, and this call inverts it **only when every cell of ``[lo, hi)``
         was an active leaf at ``level`` before that refine**.  When it was not, this
-        call removes children an earlier :meth:`refine` created: after
-        ``refine(l, A)`` and an overlapping ``refine(l, B)``, ``coarsen(l, B)``
-        demotes all of ``B``, including the part of ``A`` that lies inside it.  It is
-        demoting exactly the box it was given, but it is not undoing the second
-        refine.  To coarsen without risking refinement the caller did not mean to
-        lose, mark cells by id: :meth:`~pantr.bspline.THBSplineSpace.coarsen`
-        reactivates a parent only when all of its children are named active leaves.
+        call either refuses the box, as above, or removes children an earlier
+        :meth:`refine` created: after ``refine(l, A)`` and an overlapping
+        ``refine(l, B)``, ``coarsen(l, B)`` demotes all of ``B``, including the part
+        of ``A`` that lies inside it.  It is demoting exactly the box it was given,
+        but it is not undoing the second refine.  To coarsen without risking
+        refinement the caller did not mean to lose, mark cells by id:
+        :meth:`~pantr.bspline.THBSplineSpace.coarsen` reactivates a parent only when
+        all of its children are named active leaves.
 
         The opposite order carries no hypothesis: coarsening leaves the whole box
         active at ``level``, so ``refine(level, lo, hi)`` always undoes

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -15,7 +15,10 @@ small list of ``(lo, hi)`` index pairs per level.  Memory is therefore
 *Union semantics.*  Calling :meth:`refine` with a region that overlaps an
 already-refined area is silently correct: only the currently-active portion of
 the region is refined.  Since the children of newly-active cells are always
-disjoint from existing level blocks, no deduplication is needed.
+disjoint from existing level blocks, no deduplication is needed.  Refining only
+part of a box is what makes :meth:`refine` non-injective on the grid state, so
+:meth:`coarsen` inverts it conditionally rather than always; both docstrings
+state the hypothesis.
 
 *No balance constraint.*  :meth:`refine` imposes no 2:1 grading: cells of any
 two levels may share a facet.  Facet adjacency (:meth:`neighbor_across_facet`,
@@ -54,6 +57,25 @@ if TYPE_CHECKING:
 # A Block is a pair (lo, hi) of per-direction inclusive-start / exclusive-end
 # integer index tuples, all at the coordinate system of a specific level.
 _Block = tuple[tuple[int, ...], tuple[int, ...]]
+
+_MAX_NAMED_CELLS: int = 6
+"""
+Cells spelled out per reason when :meth:`HierarchicalGrid.coarsen` refuses a region.
+
+Enough to show the pattern of the offending set while keeping the message readable when
+a large region is rejected; the remainder is reported as a count.
+"""
+
+_MAX_DIAGNOSED_CELLS: int = 1 << 20
+"""
+Region size above which :meth:`HierarchicalGrid.coarsen`'s refusal skips naming cells.
+
+The diagnostic materializes three boolean masks shaped like the region, so the cap is a
+memory budget: at this size they cost 3 MiB together.  A region may legitimately be far
+larger than the grid is (level ``l`` has ``factor ** l`` cells per root cell, whether or
+not they exist), and enumerating cells that mostly do not exist would help nobody, so
+past the cap the message reports the region's extent instead.
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +253,54 @@ def _normalize_blocks(blocks: list[_Block]) -> list[_Block]:
             new_blocks.append(merged)
         blocks = new_blocks
     return sorted(blocks)
+
+
+def _mark_region_cells(
+    mask: npt.NDArray[np.bool_],
+    lo: tuple[int, ...],
+    hi: tuple[int, ...],
+    block: _Block,
+) -> None:
+    r"""Set the cells of ``mask`` that ``block`` covers inside the region ``[lo, hi)``.
+
+    ``mask`` is indexed relative to ``lo``, so its shape is ``hi[k] - lo[k]`` per axis
+    ``k``.  A block that misses the region leaves ``mask`` untouched.
+
+    Args:
+        mask (npt.NDArray[np.bool\_]): Region-shaped mask, written in place.
+        lo (tuple[int, ...]): Region lower bound (inclusive).
+        hi (tuple[int, ...]): Region upper bound (exclusive).
+        block (_Block): Rectangle to mark, in the same coordinates as ``lo``/``hi``.
+    """
+    inter = _rect_intersect(block[0], block[1], lo, hi)
+    if inter is None:
+        return
+    i_lo, i_hi = inter
+    mask[tuple(slice(a - o, b - o) for a, b, o in zip(i_lo, i_hi, lo, strict=False))] = True
+
+
+def _name_marked_cells(mask: npt.NDArray[np.bool_], origin: tuple[int, ...]) -> str:
+    r"""Render the marked cells of a region-shaped mask as absolute index tuples.
+
+    At most :data:`_MAX_NAMED_CELLS` cells are spelled out; any remainder is summarized
+    as a count so a large rejected region still yields a readable message.
+
+    Args:
+        mask (npt.NDArray[np.bool\_]): Region-shaped mask of cells to name.
+        origin (tuple[int, ...]): Index of the region's first cell, added to every
+            mask index so the names are in the level's own coordinates.
+
+    Returns:
+        str: Comma-separated index tuples, followed by ``and N more`` when the listing
+        was truncated.
+    """
+    marked = np.argwhere(mask)
+    named = ", ".join(
+        str(tuple(int(i) + int(o) for i, o in zip(row, origin, strict=False)))
+        for row in marked[:_MAX_NAMED_CELLS]
+    )
+    hidden = int(marked.shape[0]) - _MAX_NAMED_CELLS
+    return f"{named} and {hidden} more" if hidden > 0 else named
 
 
 # ---------------------------------------------------------------------------
@@ -1222,9 +1292,25 @@ class HierarchicalGrid(Grid):
         """Refine the rectangular region ``[lo, hi)`` at ``level`` to ``level+1``.
 
         Union semantics: only the currently-active portion of ``[lo, hi)`` is
-        refined.  If the intersection with active blocks at ``level`` is empty,
-        the call is a silent no-op.  Overlapping calls therefore safely extend
-        the refined region.
+        refined, leaving cells that are already deeper untouched.  If the
+        intersection with active blocks at ``level`` is empty, the call is a
+        silent no-op.  Overlapping calls therefore safely extend the refined
+        region.
+
+        That convenience costs invertibility.  Promoting only part of a box sends
+        several distinct grids to the same result, so :meth:`refine` is **not
+        injective** on the grid state and no single :meth:`coarsen` can undo it in
+        general: ``coarsen(level, lo, hi)`` reverses this call only when every cell
+        of ``[lo, hi)`` was an active leaf at ``level`` beforehand.  When it was
+        not, the paired :meth:`coarsen` demotes the whole box, including the cells
+        this call left alone, and so removes children an earlier :meth:`refine`
+        created.  Where that must not happen, name the cells rather than a box on
+        the side that destroys them: :meth:`~pantr.bspline.THBSplineSpace.coarsen`
+        reactivates a parent only when all of its children are named active
+        leaves, so nothing the caller did not name is removed.  (:meth:`refine_cells`
+        also marks by id, but it refines the bounding box of the ids given at each
+        level, so it can promote a cell the caller did not mark; that costs nothing,
+        since refining removes no cell.)
 
         After the call all flat cell ids are **reassigned** (the BVH, cell tags,
         and facet tags are also invalidated).
@@ -1333,14 +1419,30 @@ class HierarchicalGrid(Grid):
         lo: Sequence[int],
         hi: Sequence[int],
     ) -> None:
-        """Coarsen the rectangular region ``[lo, hi)`` at ``level`` (inverse of refine).
+        """Demote the rectangular region ``[lo, hi)`` at ``level`` back to ``level``.
 
         Reactivates the level-``level`` cells in ``[lo, hi)`` and removes their
         level-``(level+1)`` children.  The region must be **fully refined to exactly
         level ``level+1``**: every child cell in ``[lo*factor, hi*factor)`` must be an
         active leaf at ``level+1`` (none further refined, none still a leaf at
-        ``level``).  Calling :meth:`coarsen` with the same arguments as a preceding
-        :meth:`refine` exactly restores the grid.
+        ``level``); otherwise the call raises and the message names the cells that
+        break it.
+
+        The **whole** box is demoted, while :meth:`refine` promotes only the box's
+        currently-active portion.  :meth:`refine` is therefore not injective on the
+        grid state, and this call inverts it **only when every cell of ``[lo, hi)``
+        was an active leaf at ``level`` before that refine**.  When it was not, this
+        call removes children an earlier :meth:`refine` created: after
+        ``refine(l, A)`` and an overlapping ``refine(l, B)``, ``coarsen(l, B)``
+        demotes all of ``B``, including the part of ``A`` that lies inside it.  It is
+        demoting exactly the box it was given, but it is not undoing the second
+        refine.  To coarsen without risking refinement the caller did not mean to
+        lose, mark cells by id: :meth:`~pantr.bspline.THBSplineSpace.coarsen`
+        reactivates a parent only when all of its children are named active leaves.
+
+        The opposite order carries no hypothesis: coarsening leaves the whole box
+        active at ``level``, so ``refine(level, lo, hi)`` always undoes
+        ``coarsen(level, lo, hi)``.
 
         After the call all flat cell ids are **reassigned** (the BVH, cell tags, and
         facet tags are invalidated).
@@ -1397,9 +1499,17 @@ class HierarchicalGrid(Grid):
             covered += _block_size(*inter)
             new_finer.extend(_peel(block_lo, block_hi, *inter))
         if covered != child_size:
+            region_cells = _block_size(lo_t, hi_t)
+            if region_cells > _MAX_DIAGNOSED_CELLS:
+                detail = f" The region spans {region_cells} cells, too many to name."
+            else:
+                obstacles = self._coarsen_obstacles(level, lo_t, hi_t)
+                detail = (
+                    f" Offending cells in level-{level} indices: {obstacles}." if obstacles else ""
+                )
             raise ValueError(
                 f"cannot coarsen [{lo_t}, {hi_t}) at level {level}: the region is not "
-                f"fully refined to exactly level {level + 1}."
+                f"fully refined to exactly level {level + 1}.{detail}"
             )
 
         self._blocks[level + 1] = _normalize_blocks(new_finer)
@@ -1407,6 +1517,83 @@ class HierarchicalGrid(Grid):
         while len(self._blocks) > 1 and not self._blocks[-1]:
             self._blocks.pop()
         self._rebuild()
+
+    def _coarsen_obstacles(
+        self,
+        level: int,
+        lo: tuple[int, ...],
+        hi: tuple[int, ...],
+    ) -> str:
+        """Name the cells of ``[lo, hi)`` that stop it being demoted from ``level+1``.
+
+        A cell of the region blocks :meth:`coarsen` in exactly one of three ways: it is
+        still an active leaf at ``level`` (so it has no children to remove), it is
+        refined past ``level+1`` (so its children are not leaves either), or it is not
+        present at ``level`` at all because a coarser active leaf covers it.  Each class
+        is read off the block lists: active leaves from ``_blocks[level]``, hidden cells
+        from the coarser blocks scaled up to ``level``, and over-refined cells from the
+        deeper blocks scaled down to ``level``.
+
+        Args:
+            level (int): Level whose cells were to be reactivated.
+            lo (tuple[int, ...]): Region lower bound (inclusive), level-``level``
+                coordinates.
+            hi (tuple[int, ...]): Region upper bound (exclusive), level-``level``
+                coordinates.
+
+        Returns:
+            str: Semicolon-separated clauses, each a reason followed by the offending
+            cells; empty when every cell of the region is refined to exactly
+            ``level+1``, which is when :meth:`coarsen` accepts it.
+
+        Note:
+            Reached only from the failing path of :meth:`coarsen`, so it favours a
+            precise message over speed and allocates one region-shaped boolean array
+            per reason.  The caller keeps the region within
+            :data:`_MAX_DIAGNOSED_CELLS` so those arrays stay small.
+        """
+        shape = tuple(h - lo_k for lo_k, h in zip(lo, hi, strict=False))
+        still_leaf = np.zeros(shape, dtype=np.bool_)
+        over_refined = np.zeros(shape, dtype=np.bool_)
+        hidden = np.zeros(shape, dtype=np.bool_)
+
+        for block in self._blocks[level]:
+            _mark_region_cells(still_leaf, lo, hi, block)
+        for coarser in range(level):
+            up = tuple(f ** (level - coarser) for f in self._factor)
+            for b_lo, b_hi in self._blocks[coarser]:
+                _mark_region_cells(
+                    hidden,
+                    lo,
+                    hi,
+                    (
+                        tuple(a * s for a, s in zip(b_lo, up, strict=False)),
+                        tuple(b * s for b, s in zip(b_hi, up, strict=False)),
+                    ),
+                )
+        for deeper in range(level + 2, len(self._blocks)):
+            down = tuple(f ** (deeper - level) for f in self._factor)
+            for b_lo, b_hi in self._blocks[deeper]:
+                # Floor the start and ceil the end: a level-`level` cell holding any
+                # part of a deeper block has a descendant below level+1.
+                _mark_region_cells(
+                    over_refined,
+                    lo,
+                    hi,
+                    (
+                        tuple(a // s for a, s in zip(b_lo, down, strict=False)),
+                        tuple(-(-b // s) for b, s in zip(b_hi, down, strict=False)),
+                    ),
+                )
+
+        reasons = (
+            (still_leaf, f"still active leaves at level {level}, with no children to remove"),
+            (over_refined, f"refined beyond level {level + 1}"),
+            (hidden, f"covered by a coarser active leaf and absent at level {level}"),
+        )
+        return "; ".join(
+            f"{reason}: {_name_marked_cells(mask, lo)}" for mask, reason in reasons if mask.any()
+        )
 
     # ------------------------------------------------------------------
     # Overrides for BVH efficiency

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -693,6 +693,131 @@ class TestHierarchicalGridCoarsen:
             g.coarsen(0, [0, 0], [4, 4])  # 1D grid, 2D lo/hi
 
 
+class TestCoarsenIsNotAnUnconditionalInverse:
+    """`coarsen` demotes its whole box, so it inverts `refine` only conditionally.
+
+    `refine` promotes just the currently-active part of its box (union semantics), so it
+    is not injective on the grid state and no single `coarsen` can invert it.  These
+    tests pin both the conditional inverse and the consequence when the hypothesis
+    fails, with the cell counts of the reproduction hardcoded.
+    """
+
+    def test_coarsen_inverts_refine_of_an_entirely_active_region_1d(self) -> None:
+        """One refine of an all-active box, then coarsen, restores the grid exactly."""
+        g = _grid_1d(6, 2)
+        assert g.num_cells == 6
+        g.refine(0, [0], [2])
+        assert g.num_cells == 8
+        g.coarsen(0, [0], [2])
+        assert g.num_cells == 6
+
+    def test_coarsen_inverts_refine_disjoint_from_an_earlier_one_1d(self) -> None:
+        """Two disjoint refines: coarsening the second is still exact."""
+        g = _grid_1d(6, 2)
+        g.refine(0, [0], [2])
+        g.refine(0, [3], [5])
+        assert g.num_cells == 10
+        g.coarsen(0, [3], [5])
+        assert g.num_cells == 8
+
+    def test_coarsen_after_overlapping_refines_demotes_the_whole_box_1d(self) -> None:
+        """Coarsening a box built by overlapping refines also removes older children.
+
+        The second refine promotes cell 2 alone, because cell 1 was already refined by
+        the first one.  `coarsen` then demotes the *whole* box, so it also removes
+        cell 1's children and the grid ends at 7 cells, not the 8 it had before the
+        second refine.  That is `coarsen`'s documented contract (it demotes the box it
+        is given), **not** a defect to "fix" by changing this number: the route that
+        cannot lose refinement is the cell-id API, where the caller names every cell
+        being destroyed (:meth:`HierarchicalGrid.refine_cells`,
+        :meth:`~pantr.bspline.THBSplineSpace.coarsen`).
+        """
+        g = _grid_1d(6, 2)
+        g.refine(0, [0], [2])
+        assert g.num_cells == 8
+        g.refine(0, [1], [3])
+        assert g.num_cells == 9
+        g.coarsen(0, [1], [3])
+        assert g.num_cells == 7
+        assert g.active_blocks(0) == (((1,), (6,)),)
+        assert g.active_blocks(1) == (((0,), (2,)),)
+
+    def test_coarsen_inverts_refine_of_an_entirely_active_region_2d_non_dyadic(self) -> None:
+        """The 2D control on a non-dyadic factor: single refine, then coarsen, is exact."""
+        g = _grid_2d(3, 3)
+        assert g.num_cells == 9
+        g.refine(0, [1, 1], [3, 3])
+        assert g.num_cells == 41
+        g.coarsen(0, [1, 1], [3, 3])
+        assert g.num_cells == 9
+
+    def test_coarsen_after_overlapping_refines_demotes_the_whole_box_2d_non_dyadic(self) -> None:
+        """The 2D non-dyadic counterpart: cell (1, 1)'s 9 children become 1 cell again.
+
+        Same contract as the 1D case above, on ``factor = 3`` so a factor-dependent
+        regression cannot hide: 41 would mean `coarsen` had inverted the second refine.
+        """
+        g = _grid_2d(3, 3)
+        g.refine(0, [0, 0], [2, 2])
+        assert g.num_cells == 41
+        g.refine(0, [1, 1], [3, 3])
+        assert g.num_cells == 65
+        g.coarsen(0, [1, 1], [3, 3])
+        assert g.num_cells == 33
+
+    def test_refine_undoes_coarsen_unconditionally(self) -> None:
+        """The other direction holds with no hypothesis: refine always undoes coarsen."""
+        g = _grid_1d(6, 2)
+        g.refine(0, [0], [2])
+        g.refine(0, [1], [3])
+        before = _grid_snapshot(g)
+        g.coarsen(0, [1], [3])
+        g.refine(0, [1], [3])
+        assert _grid_snapshot(g) == before
+
+    def test_coarsen_names_cells_that_are_still_leaves(self) -> None:
+        """The refusal names the box cells that have no children to remove."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [1])  # only cell 0 is refined
+        with pytest.raises(ValueError, match="still active leaves at level 0") as excinfo:
+            g.coarsen(0, [0], [2])
+        named = str(excinfo.value).split("still active leaves at level 0")[1]
+        assert "(1,)" in named
+        assert "refined beyond" not in str(excinfo.value)
+        # What the message says is true of the state: cell 1 is a leaf, cell 0 is not.
+        assert g.is_active_leaf(0, (1,))
+        assert not g.is_active_leaf(0, (0,))
+
+    def test_coarsen_names_cells_refined_beyond_the_target_level(self) -> None:
+        """The refusal names the box cells whose children are themselves refined."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        g.refine(1, [0], [2])  # cell 0's children go on to level 2
+        with pytest.raises(ValueError, match="refined beyond level 1") as excinfo:
+            g.coarsen(0, [0], [2])
+        named = str(excinfo.value).split("refined beyond level 1")[1]
+        assert "(0,)" in named
+        assert "still active leaves" not in str(excinfo.value)
+        # True of the state: cell 0's children are not leaves at level 1, but at level 2.
+        assert not g.is_active_leaf(1, (0,))
+        assert g.is_active_leaf(2, (0,))
+
+    def test_coarsen_names_cells_absent_at_the_requested_level(self) -> None:
+        """The refusal names box cells that a coarser active leaf covers."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])
+        g.refine(1, [0], [2])  # max_level 2, so coarsening level 1 is in range
+        with pytest.raises(ValueError, match="covered by a coarser active leaf") as excinfo:
+            g.coarsen(1, [4], [6])  # level-1 cells 4, 5 sit inside level-0 leaf cell 2
+        named = str(excinfo.value).split("covered by a coarser active leaf")[1]
+        assert "(4,)" in named
+        assert "(5,)" in named
+        # True of the state: cell 2 is a level-0 leaf, so level-1 cells 4, 5 do not exist.
+        assert g.is_active_leaf(0, (2,))
+        assert not g.is_active_leaf(1, (4,))
+        assert not g.is_active_leaf(1, (5,))
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # restrict
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import itertools
+import re
+from typing import TYPE_CHECKING
+
 import numpy as np
 import numpy.testing as np_testing
 import pytest
@@ -16,13 +20,20 @@ from pantr.grid import (
     uniform_grid,
 )
 from pantr.grid._hierarchical_grid import (
+    _MAX_DIAGNOSED_CELLS,
+    _MAX_NAMED_CELLS,
     _block_size,
     _in_block,
+    _mark_region_cells,
+    _name_marked_cells,
     _normalize_blocks,
     _peel,
     _rect_intersect,
     _try_merge,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Helper
@@ -93,6 +104,34 @@ class TestBlockHelpers:
     def test_normalize_merges_adjacent(self) -> None:
         blocks: list[tuple[tuple[int, ...], tuple[int, ...]]] = [((0,), (3,)), ((3,), (7,))]
         assert _normalize_blocks(blocks) == [((0,), (7,))]
+
+    def test_mark_region_cells_marks_only_the_overlap(self) -> None:
+        mask = np.zeros((4, 3), dtype=np.bool_)
+        _mark_region_cells(mask, (2, 1), (6, 4), ((4, 0), (9, 3)))  # partly outside
+        expected = np.zeros((4, 3), dtype=np.bool_)
+        expected[2:4, 0:2] = True  # region rows 2-3 (cells 4-5), columns 0-1 (cells 1-2)
+        np_testing.assert_array_equal(mask, expected)
+
+    def test_mark_region_cells_ignores_a_disjoint_block(self) -> None:
+        mask = np.zeros((3,), dtype=np.bool_)
+        _mark_region_cells(mask, (0,), (3,), ((5,), (8,)))
+        assert not mask.any()
+
+    def test_name_marked_cells_offsets_by_the_origin(self) -> None:
+        mask = np.zeros((4,), dtype=np.bool_)
+        mask[[1, 3]] = True
+        assert _name_marked_cells(mask, (10,)) == "(11,), (13,)"
+
+    def test_name_marked_cells_counts_the_remainder(self) -> None:
+        mask = np.ones((_MAX_NAMED_CELLS + 2,), dtype=np.bool_)
+        named = _name_marked_cells(mask, (0,))
+        assert named.count("), (") == _MAX_NAMED_CELLS - 1
+        assert named.endswith("and 2 more")
+
+    def test_name_marked_cells_2d(self) -> None:
+        mask = np.zeros((2, 2), dtype=np.bool_)
+        mask[1, 0] = True
+        assert _name_marked_cells(mask, (3, 7)) == "(4, 7)"
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -630,8 +669,39 @@ def _grid_snapshot(g: HierarchicalGrid) -> tuple[object, ...]:
     return (g.num_cells, g.max_level, tuple(g.active_blocks(lv) for lv in range(g.max_level + 1)))
 
 
+def _obstacles_by_cellwise_walk(
+    g: HierarchicalGrid,
+    level: int,
+    lo: Sequence[int],
+    hi: Sequence[int],
+) -> set[tuple[int, ...]]:
+    """Return the cells of ``[lo, hi)`` that cannot be demoted, found cell by cell.
+
+    An independent oracle for `coarsen`'s refusal: it uses only `is_active_leaf`, so it
+    shares no arithmetic with the block scaling the error message is built from.
+    """
+    blocked: set[tuple[int, ...]] = set()
+    for cell in itertools.product(*[range(a, b) for a, b in zip(lo, hi, strict=True)]):
+        children = [
+            tuple(cell[k] * g.factor[k] + off[k] for k in range(g.ndim))
+            for off in itertools.product(*(range(g.factor[k]) for k in range(g.ndim)))
+        ]
+        if not all(g.is_active_leaf(level + 1, child) for child in children):
+            blocked.add(cell)
+    return blocked
+
+
+def _cells_named_in(message: str) -> set[tuple[int, ...]]:
+    """Return the cell indices a `coarsen` refusal names, excluding its region prefix."""
+    listing = message.split("Offending cells", 1)[1] if "Offending cells" in message else ""
+    return {
+        tuple(int(value) for value in match.group(1).split(","))
+        for match in re.finditer(r"\((\d+(?:,\s*\d+)*),?\)", listing)
+    }
+
+
 class TestHierarchicalGridCoarsen:
-    """Tests for the coarsen method (inverse of refine)."""
+    """Tests for the coarsen method: argument validation and the accepted cases."""
 
     def test_coarsen_inverts_refine_1d(self) -> None:
         g = _grid_1d(4, 2)
@@ -801,6 +871,135 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         # True of the state: cell 0's children are not leaves at level 1, but at level 2.
         assert not g.is_active_leaf(1, (0,))
         assert g.is_active_leaf(2, (0,))
+
+    @pytest.mark.parametrize(
+        ("cells_per_axis", "factor"),
+        [([6], 3), ([4, 3], (2, 3)), ([3, 3], 2), ([2, 3, 2], (2, 1, 3))],
+        ids=["1d-non-dyadic", "2d-anisotropic", "2d-dyadic", "3d-anisotropic"],
+    )
+    def test_named_cells_match_a_cellwise_oracle(
+        self,
+        cells_per_axis: list[int],
+        factor: int | tuple[int, ...],
+    ) -> None:
+        """Every refusal names exactly the cells a cellwise walk finds, and no others.
+
+        The message is built from the block lists with per-axis scaling; the oracle here
+        instead asks :meth:`~pantr.grid.HierarchicalGrid.is_active_leaf` cell by cell, so
+        the two disagree if the scaling is wrong for a non-dyadic or anisotropic factor.
+        """
+        root = uniform_grid([[0.0, 1.0]] * len(cells_per_axis), cells_per_axis)
+        g = hierarchical_grid(root, factor)
+        rng = np.random.default_rng(4)
+        checked = 0
+        for _ in range(24):
+            coarsening = g.max_level > 0 and rng.random() >= 0.6
+            level = int(rng.integers(0, g.max_level if coarsening else g.max_level + 1))
+            extent = g.level_cells_per_axis(level)
+            lo = [int(rng.integers(0, n)) for n in extent]
+            hi = [
+                int(rng.integers(a + 1, min(a + 3, n) + 1)) for a, n in zip(lo, extent, strict=True)
+            ]
+            if not coarsening:
+                g.refine(level, lo, hi)
+                continue
+            expected = _obstacles_by_cellwise_walk(g, level, lo, hi)
+            try:
+                g.coarsen(level, lo, hi)
+            except ValueError as exc:
+                assert expected, f"refused a region the oracle finds coarsenable: {exc}"
+                named = _cells_named_in(str(exc))
+                assert named, f"refused without naming a cell: {exc}"
+                if "more" in str(exc):
+                    assert named <= expected  # truncated: a subset, never an invention
+                else:
+                    assert named == expected, f"named {sorted(named)}, blocked {sorted(expected)}"
+                checked += 1
+            else:
+                assert not expected, "coarsened a region the oracle finds blocked"
+        assert checked, "the sweep never exercised a refusal"
+
+    def test_coarsen_names_exactly_the_cap_without_a_remainder(self) -> None:
+        """A listing landing exactly on the cap must not claim a remainder."""
+        g = _grid_1d(8, 2)
+        g.refine(0, [0], [1])  # cells 1..6 of the box below are leaves: exactly the cap
+        with pytest.raises(ValueError) as excinfo:
+            g.coarsen(0, [0], [1 + _MAX_NAMED_CELLS])
+        message = str(excinfo.value)
+        assert "more" not in message
+        named = message.split("with no children to remove: ")[1]
+        assert named.count("), (") == _MAX_NAMED_CELLS - 1
+        # One cell further, the remainder is reported rather than dropped.
+        with pytest.raises(ValueError, match="and 1 more"):
+            g.coarsen(0, [0], [2 + _MAX_NAMED_CELLS])
+
+    def test_coarsen_truncates_a_long_list_of_offending_cells(self) -> None:
+        """A large rejected region names a few cells and counts the rest."""
+        g = _grid_2d(6, 2)
+        g.refine(0, [0, 0], [1, 1])  # 1 of the 36 level-0 cells is refined
+        with pytest.raises(ValueError) as excinfo:
+            g.coarsen(0, [0, 0], [6, 6])
+        message = str(excinfo.value)
+        named = message.split("with no children to remove: ")[1]
+        assert named.count("), (") == _MAX_NAMED_CELLS - 1  # exactly the cap is spelled out
+        assert f"and {36 - 1 - _MAX_NAMED_CELLS} more" in message
+
+    def test_coarsen_reports_extent_instead_of_cells_for_a_huge_region(self) -> None:
+        """A region far larger than the grid is described, not enumerated.
+
+        Level ``l`` has ``factor ** l`` cells per root cell whether or not they exist, so
+        a deep level admits an in-bounds region with more cells than the grid has.
+        Naming them would need a mask per cell, so past the budget the message reports
+        the extent and the refusal stays a `ValueError` rather than an out-of-memory.
+        """
+        g = _grid_1d(2, 2)
+        for level in range(21):
+            g.refine(level, [0], [1])  # deepen without growing the grid
+        region = g.level_cells_per_axis(20)[0]
+        assert region > _MAX_DIAGNOSED_CELLS
+        with pytest.raises(ValueError, match=f"spans {region} cells, too many to name"):
+            g.coarsen(20, [0], [region])
+
+    def test_coarsen_names_offending_cells_with_an_anisotropic_factor(self) -> None:
+        """The per-axis factor is respected when locating the offending cells."""
+        g = hierarchical_grid(uniform_grid([[0.0, 1.0], [0.0, 1.0]], [2, 2]), (2, 3))
+        assert g.factor == (2, 3)
+        g.refine(0, [0, 0], [2, 2])  # every level-0 cell -> level 1
+        g.refine(1, [0, 0], [1, 1])  # level-1 cell (0, 0) -> level 2
+        with pytest.raises(ValueError, match="refined beyond level 1") as excinfo:
+            g.coarsen(0, [0, 0], [2, 2])
+        named = str(excinfo.value).split("refined beyond level 1")[1]
+        assert "(0, 0)" in named
+        # Only cell (0, 0) owns the level-2 cells, so no other cell may be named.
+        assert named.count("(") == 1
+        assert g.is_active_leaf(2, (0, 0))
+        assert g.is_active_leaf(1, (1, 0))
+
+    def test_coarsen_names_every_reason_and_only_offending_cells(self) -> None:
+        """One box, all three reasons, and a coarsenable cell left unnamed.
+
+        Level-1 cell 0 is refined past level 2, cells 4-7 are still leaves, cells 8-11
+        sit inside level-0 leaves, and cell 1 is refined to exactly level 2, so it must
+        not appear anywhere in the message.
+        """
+        g = _grid_1d(8, 2)
+        g.refine(0, [0], [4])  # level-1 cells 0..7
+        g.refine(1, [0], [4])  # level-1 cells 0..3 -> level-2 cells 0..7
+        g.refine(2, [0], [2])  # level-2 cells 0, 1 -> level 3
+        with pytest.raises(ValueError) as excinfo:
+            g.coarsen(1, [0], [12])
+        message = str(excinfo.value)
+        assert "still active leaves at level 1" in message
+        assert "refined beyond level 2" in message
+        assert "covered by a coarser active leaf" in message
+        assert "(0,)" in message.split("refined beyond level 2")[1]
+        assert "(1,)" not in message.split("Offending cells")[1]
+        # True of the state: cell 0 has a level-3 descendant, cell 1's children are
+        # level-2 leaves, cells 4 and 8 are a level-1 leaf and a hidden cell.
+        assert g.is_active_leaf(3, (0,))
+        assert g.is_active_leaf(2, (2,))
+        assert g.is_active_leaf(1, (4,))
+        assert not g.is_active_leaf(1, (8,))
 
     def test_coarsen_names_cells_absent_at_the_requested_level(self) -> None:
         """The refusal names box cells that a coarser active leaf covers."""

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -691,6 +691,18 @@ def _obstacles_by_cellwise_walk(
     return blocked
 
 
+_REFUSAL_REASONS = (
+    "still active leaves",
+    "refined beyond",
+    "covered by a coarser active leaf",
+)
+"""The three reasons `coarsen`'s refusal can give, as they appear in its message.
+
+Used to assert a randomized sweep actually exercised all three rather than grading
+whichever one its draws happened to reach.
+"""
+
+
 def _cells_named_in(message: str) -> set[tuple[int, ...]]:
     """Return the cell indices a `coarsen` refusal names, excluding its region prefix."""
     listing = message.split("Offending cells", 1)[1] if "Offending cells" in message else ""
@@ -834,6 +846,10 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         assert g.num_cells == 65
         g.coarsen(0, [1, 1], [3, 3])
         assert g.num_cells == 33
+        # The shape, not only the count: dropping the block merge on reactivation leaves
+        # 33 cells in a structurally different partition, which the count alone misses.
+        assert g.active_blocks(0) == (((0, 2), (1, 3)), ((1, 1), (3, 3)), ((2, 0), (3, 1)))
+        assert g.active_blocks(1) == (((0, 0), (3, 6)), ((3, 0), (6, 3)))
 
     def test_refine_undoes_coarsen_unconditionally(self) -> None:
         """The other direction holds with no hypothesis: refine always undoes coarsen."""
@@ -887,12 +903,20 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         The message is built from the block lists with per-axis scaling; the oracle here
         instead asks :meth:`~pantr.grid.HierarchicalGrid.is_active_leaf` cell by cell, so
         the two disagree if the scaling is wrong for a non-dyadic or anisotropic factor.
+
+        The draw count is not arbitrary. At 24 draws this seed leaves three of the four
+        parametrizations never reaching one of the three refusal reasons, so the sweep
+        graded less than it appears to; 96 is the first count at which all four reach all
+        three, which is what the tally at the end asserts. Raising it further only repeats
+        coverage, except that it also exercises the truncated-listing branch more often
+        (never reachable in 1D, where a drawn region spans at most three cells).
         """
         root = uniform_grid([[0.0, 1.0]] * len(cells_per_axis), cells_per_axis)
         g = hierarchical_grid(root, factor)
         rng = np.random.default_rng(4)
         checked = 0
-        for _ in range(24):
+        reasons_seen: set[str] = set()
+        for _ in range(96):
             coarsening = g.max_level > 0 and rng.random() >= 0.6
             level = int(rng.integers(0, g.max_level if coarsening else g.max_level + 1))
             extent = g.level_cells_per_axis(level)
@@ -914,10 +938,17 @@ class TestCoarsenIsNotAnUnconditionalInverse:
                     assert named <= expected  # truncated: a subset, never an invention
                 else:
                     assert named == expected, f"named {sorted(named)}, blocked {sorted(expected)}"
+                reasons_seen |= {phrase for phrase in _REFUSAL_REASONS if phrase in str(exc)}
                 checked += 1
             else:
                 assert not expected, "coarsened a region the oracle finds blocked"
         assert checked, "the sweep never exercised a refusal"
+        # Without this the sweep can grade only one or two of the three reasons and still
+        # report success, which is how a per-axis scaling bug in an unexercised branch
+        # would survive: the message path is the only place that scaling is used.
+        assert reasons_seen == set(_REFUSAL_REASONS), (
+            f"the sweep never exercised {sorted(set(_REFUSAL_REASONS) - reasons_seen)}"
+        )
 
     def test_coarsen_names_exactly_the_cap_without_a_remainder(self) -> None:
         """A listing landing exactly on the cap must not claim a remainder."""

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1737,12 +1737,20 @@ class TestCoarsen:
         fine = coarse.refine([0, 1])
         back = fine.coarsen(_cells_at_level(fine, 1))
         assert _active_indices(back) == _active_indices(coarse)
+        # The cell-id API is injective, so the mesh itself comes back, not just the
+        # function space: unlike the box API, no refinement can be lost on the way.
+        assert (coarse.grid.num_cells, fine.grid.num_cells) == (4, 6)
+        assert back.grid.num_cells == coarse.grid.num_cells
+        assert back.grid.max_level == coarse.grid.max_level == 0
 
     def test_coarsen_inverts_refine_2d(self) -> None:
         coarse = THBSplineSpace(_root_2d(), _grid_2d())
         fine = coarse.refine([0], admissible_class=None)
         back = fine.coarsen(_cells_at_level(fine, 1), admissible_class=None)
         assert _active_indices(back) == _active_indices(coarse)
+        assert (coarse.grid.num_cells, fine.grid.num_cells) == (16, 19)
+        assert back.grid.num_cells == coarse.grid.num_cells
+        assert back.grid.max_level == coarse.grid.max_level == 0
 
     def test_coarsen_partition_of_unity(self) -> None:
         coarse = THBSplineSpace(_root_2d(), _grid_2d())


### PR DESCRIPTION
## The issue's premise was wrong, and the scope was amended before implementing

#299 offered three fixes and recommended making `coarsen` raise when the region is not
uniformly one level deep. **That check already ships.** `_hierarchical_grid.py` has raised
on `covered != child_size` all along, and it fires correctly on both violations:

```
partial region -> cannot coarsen [(0,), (2,)) at level 0: the region is not fully refined to exactly level 1.
deeper region  -> cannot coarsen [(0,), (2,)) at level 0: the region is not fully refined to exactly level 1.
```

It cannot fire on the issue's reproduction, because there the region genuinely *is*
uniformly one level deep:

```
blocks before coarsen: [[((3,), (6,))], [((0,), (6,))]]
level-0 cell 1 active leaf? False      level-0 cell 2 active leaf? False
level-1 children 2..5 active leaves? [True, True, True, True]
```

Both level-0 cells are refined to exactly level 1 with all four children active leaves, so
`coarsen` does precisely what its body documents and returns 7. **The defect is not a
missing guard: it is the false claim in the docstring** that `coarsen` is the "inverse of
refine" and that calling it with a preceding `refine`'s arguments "exactly restores the
grid".

Two options were then closed on evidence:

- **A stricter predicate is not available.** `THBSplineSpace.coarsen` reaches the box
  `coarsen` one parent at a time, and its first call carves `[2,4)` out of a strictly
  larger level-1 block `[0,4)` — structurally identical to the reproduction's
  `coarsen(0,[1],[3])` carving `[2,6)` out of `[0,6)`. Any "must not carve into a larger
  refined region" rule breaks it, which the issue's own non-goals forbid. The destructive
  outcome is also reachable through two single-cell `coarsen` calls, each indistinguishable
  from what THB does, so no state-local predicate separates legitimate from destructive.
  Only refinement provenance does, and that was judged too expensive: it needs state
  surviving `deepcopy`/`restrict`/`_from_blocks`, it stops normalization merging blocks
  across generations (eroding the O(blocks) memory design the module rests on), and it
  makes `coarsen` order-dependent.
- **Making `refine` strict instead is equally blocked.** `refine_cells` relies on union
  semantics: with a cell already refined, its bounding-box aggregation necessarily spans
  that cell and succeeds today.

So this lands the honest contract, keeps behaviour byte-identical, and adds the diagnostic
the refusal was missing. **AC1 was amended accordingly, from "raises or preserves 8 cells"
to "documented and pinned".**

## Acceptance criteria

**AC1 (amended)** — the reproduction, re-run on the branch:

```
control 1, single refine + coarsen:       6 -> 8 -> 6   (expect 6)
control 2, two NON-overlapping + coarsen: 6 -> 10 -> 8  (expect 8)
overlapping refine + coarsen:             6 -> 8 -> 9 -> 7  (documented: demotes the whole box)
```

The 7 is documented in `coarsen`'s docstring and pinned by
`test_coarsen_after_overlapping_refines_demotes_the_whole_box_1d`, whose own docstring says
why it is 7 and not 8 so a future reader does not "fix" the number. It also pins
`active_blocks(0)` and `active_blocks(1)`, so a right-count/wrong-shape bug fails too.

**AC2** — both controls unchanged, verified by direct execution, plus a 2D non-dyadic
control `9 -> 41 -> 9`.

**AC3** — the 1D sequence is hardcoded; the 2D case uses **factor 3**, pinned at
`9 -> 41 -> 65 -> 33`. Since behaviour does not change, the numeric fixtures cannot fail
against the old code — the *message* tests are the ones that do, and they were committed
before the fix and ran red:

```
FAILED ...::test_coarsen_names_cells_that_are_still_leaves
FAILED ...::test_coarsen_names_cells_refined_beyond_the_target_level
FAILED ...::test_coarsen_names_cells_absent_at_the_requested_level
3 failed, 14 passed

E   AssertionError: Regex pattern did not match.
E    Regex: 'covered by a coarser active leaf'
E    Input: 'cannot coarsen [(4,), (6,)) at level 1: the region is not fully refined to exactly level 2.'
```

**AC4** — `coarsen`'s summary no longer says "inverse of refine"; both docstrings state the
injectivity hypothesis, and `refine` no longer advertises overlapping calls as safe without
naming the consequence. `refine`'s text deliberately does **not** repeat the issue's claim
that `refine_cells` is the injective route: it aggregates ids into a bounding box per level
and so can promote an unmarked cell (harmless, since refining destroys nothing), and saying
otherwise would be a new false claim. It points at `THBSplineSpace.coarsen` instead, which
really does reactivate a parent only when all its children are named.

**AC5** — `git diff origin/main -- src/pantr/bspline/_thb_spline_space.py` is **empty**;
`refine_cells` untouched. The THB inverse tests now pin the mesh rather than only the
space: `(4, 6) -> 4` in 1D and `(16, 19) -> 16` in 2D, `max_level` back to 0.

## The new message

```
cannot coarsen [(0,), (2,)) at level 0: ... Offending cells in level-0 indices: still active leaves at level 0, with no children to remove: (1,).
cannot coarsen [(0,), (2,)) at level 0: ... Offending cells in level-0 indices: refined beyond level 1: (0,).
cannot coarsen [(4,), (6,)) at level 1: ... covered by a coarser active leaf and absent at level 1: (4,), (5,).
cannot coarsen [(0,), (12,)) at level 1: ... still active leaves at level 1 ...: (4,), (5,), (6,), (7,); refined beyond level 2: (0,); covered by a coarser active leaf and absent at level 1: (8,), (9,), (10,), (11,).
cannot coarsen [(0, 0), (6, 6)) at level 0: ... (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (1, 0) and 29 more.
cannot coarsen [(0,), (2097152,)) at level 20: ... The region spans 2097152 cells, too many to name.
```

Truthfulness is checked three ways: every named cell satisfies its own reason against
`is_active_leaf`; the fourth message correctly **omits** cell `(1,)`, which is refined to
exactly level 2 and therefore coarsenable; and a cellwise-oracle test re-derives the
blocked set through public queries on non-dyadic and anisotropic factors in 1D/2D/3D. A
further out-of-band sweep over **254 refusals** across dyadic, non-dyadic and anisotropic
per-axis factors matched the oracle every time, with no invented cells and no missed
category.

## Behaviour, blast radius, cost

The accept/reject condition (`covered != child_size`) is byte-identical to base; only the
raise path gained diagnostics, so nothing that succeeded before can now fail or vice versa.

All 20 `.coarsen(` call sites were audited statically and dynamically: instrumenting
`refine`/`coarsen` across the seven grid and THB test files gave **502 passed, 16
`grid.coarsen` calls, 27 grid instances that did have partial refines, and 0 coarsen boxes
overlapping a partial refine**. So no pantr test or internal caller was relying on the
destructive behaviour; the overlapping case was simply never tested, which is how the false
claim survived.

`coarsen`'s success path is unchanged at 162 µs median (40 blocks / 4000 cells, 2D,
dominated by `_rebuild`). The diagnostic runs only when raising: 96 µs for a 1600-cell box,
11.8 µs for a 2-million-cell box via the budget path.

## No hidden corruption

The issue noted that in 2D/3D `_blocks` came back "re-partitioned into a structurally
different shape", which reads like corruption. It is not. A fuzz over 1D/2D/3D, factors 2
and 3, ~600 applied operations, asserting after **every** operation that cell volumes sum
to the domain volume, that 400 random points each land in exactly one active leaf, that
`locate_many` agrees with the bounds, and that per-level blocks are pairwise disjoint: all
clean. The different partition is the legitimate consequence of demoting the whole box.

## Self-review

The implementing engineer's own round: 1 important, 2 recommended, 1 suggested, 4 nitpick,
1 unproven suspicion, plus one defect it found by running its own test.

- **Important, mutation-demonstrated** — the listing-cap boundary was untested: mutating
  `hidden > 0` to `hidden >= 0` produced "and 0 more" with no test failing. Fixed with a
  test covering exactly-at-cap and one-over.
- **Recommended** ×2 — no unit tests for the two new helpers, against this file's
  convention of unit-testing every sibling helper (added, 5 tests); and the mispaired
  `coarsen` sentence gave one outcome as if general when it can also refuse (fixed).
- **Suggested** — `TestHierarchicalGridCoarsen`'s class docstring still said "(inverse of
  refine)", the very claim being removed, sitting next to its own rebuttal. Fixed.
- **Nitpick** — the summary named `level` twice and never `level+1`. Fixed. Three others
  dismissed with reasons.
- **Suggested, declined with reason** — reusing `active_leaf_mask(level)` and
  `~subdomain_mask(level)` sliced to the region would save ~15 lines but allocates a mask
  over the **whole level** rather than the region, reintroducing in a worse form the
  unbounded allocation the memory cap exists to prevent.
- **Unproven suspicion, resolved** — classification on a grid built via `restrict()` was
  unverified. Confirmed benign: the cellwise oracle matches exactly, and an inconsistent
  partition degrades to the base sentence rather than a false statement.
- **Its own defect, found by running** — a cap-boundary assertion counted `"), ("` over the
  whole message, which also matches the region prefix. Fixed by slicing the listing first.

Mutation testing of the diagnostic: dropping the ceil fails 2 tests, a wrong scale exponent
fails 5, and collapsing the per-axis factor to `factor[0]` is caught **only** by the
oracle test's 3D-anisotropic case, which is why that case earns its place.

Self-review commit: `997e3b6`.

## Checks

| step | result |
|---|---|
| `ruff check .` | All checks passed |
| `ruff format --check` | 257 files already formatted |
| `mypy src tests` | Success: no issues found in 233 source files |
| `lint-imports` | Contracts: 1 kept, 0 broken |
| `pytest` | 5456 passed, 21 skipped, 3 xfailed |
| coverage | TOTAL 96% |
| docs build | build succeeded under `-W`, no new warnings |

## Follow-up

The fix that would remove the trap rather than document it is a cell-id coarsening entry
point on the grid — `HierarchicalGrid.coarsen_cells`, promoting the parent-grouping loop
that already exists in `THBSplineSpace.coarsen` into its natural home, so callers get an
injective route that names every cell destroyed. It needs to edit
`_thb_spline_space.py`, which AC5 protects here, so it is being filed separately rather
than folded in.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
