### PR TITLE
fix(bspline): globalize locate's Newton iteration so a lost point cannot cycle

### DIFF
--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -436,12 +436,16 @@ def _nearest_corner_starts(
         targets (npt.NDArray[np.float64]): The query points, shape ``(n, rank)``.
 
     Returns:
-        npt.NDArray[np.float64]: Shape ``(n, dim)`` parametric starting guesses.
+        npt.NDArray[np.float64]: Shape ``(n, dim)`` parametric starting guesses, each a
+        corner of its own cell. That postcondition is why the search starts from a corner
+        rather than from an empty buffer: a mapping whose evaluation is not finite (nothing
+        rejects a non-finite control point at construction) makes every distance ``nan`` and
+        every comparison below False, and an empty buffer would then be returned unwritten.
     """
     lo, hi = _cell_parametric_bounds(spline.space, cell_ids)
     dim = lo.shape[1]
     axes = np.arange(dim)
-    best = np.empty_like(lo)
+    best = lo.copy()
     best_distance = np.full(cell_ids.shape[0], np.inf, dtype=np.float64)
 
     for corner in range(1 << dim):

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -20,15 +20,16 @@ The inversion has two stages:
    box, so an iterate may migrate out of its candidate cell: the candidate box is a
    superset test, never a constraint on the solution.
 
-   The damping is a backtracking line search, and it is what makes the iteration usable
-   away from the basin of attraction: an undamped Newton step is only guaranteed to
-   reduce the residual near a root, and out there it can be arbitrarily longer than the
-   residual it is trying to remove. Accepting such a step and then clamping the result to
-   the domain box does not merely waste an iteration, it can be *periodic* -- the clamp
-   maps two off-basin iterates onto each other -- and then no iteration budget and no
-   tolerance recovers the point. Requiring each accepted step to reduce the residual
-   removes both failure modes at once, and makes the residual of the accepted iterates a
-   monotonically non-increasing sequence.
+   The damping is a backtracking line search over a step first capped to one parametric
+   domain extent, and it is what makes the iteration usable away from the basin of
+   attraction: an undamped Newton step is only guaranteed to reduce the residual near a
+   root, and out there it can be arbitrarily longer than the residual it is trying to
+   remove -- longer, in fact, than the domain the answer has to lie in. Accepting such a
+   step and then clamping the result to the domain box does not merely waste an iteration,
+   it can be *periodic* -- the clamp maps two off-basin iterates onto each other -- and
+   then no iteration budget and no tolerance recovers the point. Requiring each accepted
+   step to reduce the residual removes both failure modes at once, and makes the residual
+   of the accepted iterates a monotonically non-increasing sequence.
 
    What damping cannot do is change which root the iteration finds. A monotone method
    descends into whichever basin it starts in, and on a mapping that folds, the residual
@@ -95,11 +96,20 @@ Relative threshold at which a Newton Jacobian counts as rank-deficient.
 A candidate is abandoned when ``sigma_min <= dim * _JACOBIAN_RANK_REL_TOL * sigma_max``,
 which is the rule and the magnitude :func:`numpy.linalg.matrix_rank` uses by default
 (``max(M, N) * eps * sigma_max``): below it the null direction is indistinguishable from
-rounding noise and the solve returns an arbitrary step. The test is a ratio, so it is
-invariant under scaling the geometry or the parametrization. It is deliberately
-permissive -- it only rejects a Jacobian whose condition number reaches ``1 / (dim *
-eps)`` -- because a merely ill-conditioned Jacobian still gives a usable step, and the
-line search below rejects an overlong one.
+rounding noise and the solve returns an arbitrary step. It is deliberately permissive -- it only
+rejects a Jacobian whose condition number reaches ``1 / (dim * eps)`` -- because a merely
+ill-conditioned Jacobian still gives a usable step, and :data:`_MAX_STEP_EXTENTS` bounds an
+overlong one.
+
+The test is a ratio, so it is invariant under scaling the geometry, and under scaling the
+parametrization **isotropically**. It is *not* invariant under scaling the parametric directions
+independently, which is no more exotic than a different knot-vector span per direction: the
+Jacobian is right-multiplied by a diagonal matrix, and only a scalar multiple of a signed
+permutation leaves singular values alone. Exactly, ``J = diag(1, 100 * eps)`` passes against a
+threshold of ``2 * eps``, while under ``T = diag(1, eps / 100)`` the same map has ratio ``eps**2``
+and is rejected as rank-deficient. This bites only where the Jacobian already sits near the
+guard, so it changes no verdict this library has been observed to reach, but the invariance is
+narrower than it looks.
 """
 
 _ARMIJO_DECREASE: float = 1.0e-4
@@ -113,12 +123,40 @@ the merit function ``||F - x||`` whose descent direction the exact Newton step i
 ``-||r||``, so a decrease of ``lam * ||r||`` is what the linear model promises and this
 constant is the fraction of it that must actually materialize).
 
-**Why any value in ``(0, 1)`` terminates.** Expanding to second order,
-``F(xi - lam * delta) - x = (1 - lam) * r + O(lam^2 * M * ||delta||^2)`` with ``M`` a bound
-on the second derivatives, so the test holds as soon as
-``lam <= 2 * (1 - _ARMIJO_DECREASE) * ||r|| / (M * ||delta||^2)``; the halving loop
-therefore ends after finitely many trials wherever the Jacobian is nonsingular and the
-iterate is interior. See :data:`_MAX_STEP_HALVINGS` for how many that is.
+**When a step is accepted at all.** Let ``dtilde`` be ``delta`` with every coordinate zeroed
+that the clip holds fixed (coordinate ``k`` is held when ``xi[k]`` lies on the domain face
+that ``-delta[k]`` points out of), and let ``Jv`` be the Jacobian of the polynomial piece the
+segment ``xi - t * dtilde`` enters for small ``t > 0``. Some small enough ``lam`` passes if and
+only if
+
+    <r, Jv @ dtilde>  >  _ARMIJO_DECREASE * ||r||^2,
+
+and under the reverse strict inequality every sufficiently small ``lam`` *fails*, so an
+exhausted search is a statement about the point and not about the budget. Only the product
+``Jv @ dtilde`` is well defined, not ``Jv`` itself: a step along a cell face has two pieces to
+choose between and they agree on that product, not on the transverse columns.
+
+**An iterate in the open interior of a knot-span cell, with no coordinate held, always
+passes.** There ``Jv == J``, the left-hand side is ``||r||^2``, and the test holds with
+``_ARMIJO_DECREASE < 1`` to spare. This needs only differentiability of the map at that one
+point together with a nonsingular Jacobian -- no second derivative and no bound on one, which
+is why a degree-1 map having no global bound on its second derivatives is not a threat to
+termination. A second-derivative bound buys a step *length* rather than existence, and only
+for ``lam`` short enough to keep the trial point inside the cell it was derived on; see
+:data:`_MAX_STEP_EXTENTS`, which bounds that length by construction instead.
+
+**An iterate on a knot line where the map is only C0** -- a simple interior knot at degree 1,
+or any knot of multiplicity at least the degree -- can fail at every ``lam``. The span search
+is right-closed, so ``J`` is the right-hand derivative; when the step goes left, ``Jv`` is the
+left-hand one and the criterion becomes ``rho > _ARMIJO_DECREASE`` with ``rho`` the ratio of
+the two directional derivatives along the step. A kink across which that derivative shrinks by
+more than ``1 / _ARMIJO_DECREASE == 1e4`` therefore has every step rejected *while the residual
+is still strictly decreasing along all of them*, and the candidate is abandoned. Measured at
+degree 1 with slopes ``2e-5`` and ``1.99998``, and at degree 3 across a triple interior knot: no
+budget up to 40 converges, and moving the iterate one ulp off the knot converges at 8. The
+configuration is reachable rather than hypothetical, since :func:`_nearest_corner_starts`
+returns cell corners and those are knot values. It is a known limitation of a monotone line
+search on a C0 join, not something a larger budget fixes.
 
 **Why this magnitude.** The constant trades how much of Newton's own step is admitted
 against how much progress an accepted step must show, and both ends are one-sided:
@@ -134,47 +172,93 @@ against how much progress an accepted step must show, and both ends are one-side
   ``1e-4`` sits twelve decades above ``eps`` at ``lam == 1``, and nine decades above it at
   the smallest step length :data:`_MAX_STEP_HALVINGS` admits.
 
-``1e-4`` is also the value the line-search literature settles on for exactly this rule, so
-nothing here is unconventional; what matters for this library is that both bounds above are
-satisfied with decades to spare, which makes the choice insensitive.
+``1e-4`` is also the established value for exactly this rule -- sufficient decrease tested on
+``||F||`` itself, for Newton on ``F(x) = 0`` -- in C. T. Kelley, *Iterative Methods for Linear
+and Nonlinear Equations*, SIAM, 1995, Eq. (8.1) and Algorithm 8.2.1. That attribution is worth
+being precise about, because the far more widely cited ``1e-4`` belongs to a *different* test:
+sufficient decrease on the squared merit function with a gradient inner product (Nocedal and
+Wright, *Numerical Optimization*, 2nd ed., Eq. (3.4)), which is the form PETSc's
+``SNESLINESEARCHBT`` and SciPy's ``scalar_search_armijo`` default to, and the form Kelley says
+he took the number from. So the choice is conventional, but checking it against the Armijo
+literature at large finds the squared form rather than this one.
+
+What matters for this library either way is that both bounds above are satisfied with decades to
+spare, which makes the choice insensitive.
+"""
+
+_MAX_STEP_EXTENTS: float = 1.0
+"""
+Longest first trial step of the line search, in parametric domain extents per direction.
+
+The Newton step is not tried at full length when it is longer than this; the search starts at
+``_MAX_STEP_EXTENTS / max(reach, _MAX_STEP_EXTENTS)`` instead, where ``reach`` is
+``max_k |delta_k| / (hi_k - lo_k)``. It is a trust region, and it is what keeps the halvings
+below :data:`_MAX_STEP_HALVINGS` a bounded requirement rather than a hope.
+
+**Why a cap is needed at all.** The step ``delta = J^-1 r`` grows like ``1 / sigma_min(J)``, so a
+merely ill-conditioned Jacobian -- one nowhere near the rank guard -- produces a step orders of
+magnitude longer than the domain it has to land in. The line search then spends its whole budget
+walking that step back inside, and the halvings needed grow like ``log2(||delta|| / L)`` with
+``L`` the domain extent (measured across ~30 witnesses spanning degrees 1-5, dimensions 1-3 and
+five decades of ``sigma_min``: ``log2(||delta|| / L) + 1.5`` to ``3``). Since ``||delta||`` is
+unbounded over legal inputs, no fixed budget covers that, and exhausting it abandons a candidate
+that was converging. Measured before this cap existed: a strictly monotone degree-5 map whose
+``sigma_min`` is ``1e-4`` -- fifteen orders clear of the rank guard -- was reported *not found*
+with library defaults, needing 11 halvings where the budget allowed 8.
+
+**Why one extent.** A step longer than the domain cannot be a step toward a solution *inside* the
+domain, whatever the linear model says: the clip truncates it anyway, so the only thing its extra
+length changes is how many halvings are needed to discover that. Capping at one extent removes
+exactly the ``log2(||delta|| / L)`` term and leaves the 1.5-to-3 halvings the curvature itself
+demands. On the witness above it cut the requirement from 11 halvings to 2. Nothing is lost near
+the root, where Newton's step is short and the cap is inactive, so the asymptotic rate is
+untouched.
+
+**Why per direction, normalized by each direction's own extent.** ``max_k |delta_k| / (hi_k -
+lo_k)`` is invariant under scaling the parametric directions independently, which is nothing more
+exotic than a different knot-vector span per direction; a cap on ``||delta||_2`` against a single
+length would not be, and would tighten or loosen with the aspect ratio of the domain box.
 """
 
 _MAX_STEP_HALVINGS: int = 8
 """
 Number of times a Newton step may be halved before its candidate cell is abandoned.
 
-The smallest step length tried is ``2 ** -_MAX_STEP_HALVINGS``, about ``3.9e-3``.
+The shortest step length tried is ``2 ** -_MAX_STEP_HALVINGS`` of the first one, and the first
+one is itself bounded by :data:`_MAX_STEP_EXTENTS`. That pairing is the whole point: without the
+cap the halvings needed grow like ``log2(||delta|| / L)`` -- ``||delta|| = ||J^-1 r||`` and ``L``
+the domain extent -- which is unbounded over legal inputs, so **no** fixed budget is correct and
+a converging solve gets abandoned. With the cap that term is gone and what remains is set by the
+map's curvature, which is bounded on any given geometry.
 
-**What a sufficient condition would ask for.** By the expansion in
-:data:`_ARMIJO_DECREASE`, the test accepts once ``lam <= 2 * (1 - _ARMIJO_DECREASE) *
-||r|| / (M * ||delta||^2)``, and with ``||delta|| <= ||J^-1|| * ||r||`` a sufficient
-condition is ``lam <= 2 / (M * ||J^-1||^2 * ||r||)``. Reading the factors off a spline map
-of geometric scale ``S`` over a parametric domain of unit extent -- ``||r|| <= S``,
-``||J^-1|| ~ cond(J) / S``, and ``M ~ C * S`` with ``C`` the map's parametric curvature
-factor -- gives ``lam <= 2 / (C * cond(J)^2)``, in which the scale cancels. That is the
-right shape (the halvings needed are a property of the map, not of its units) but a very
-loose bound, since it takes the worst case of three independent factors at once: it would
-demand 26 halvings for a map with ``C ~ 100`` and ``cond(J) ~ 1e3``, and such a step is
-never what decides whether a query is found.
+**Measured requirement, with the cap in place.** Every query converges at a budget of **2**:
+across the warped-map sweep in ``tests/test_bspline_locate.py`` (2400 queries, 60
+configurations, dimensions 1 to 3, degrees 1 to 5, unit scale and an offset of ``1e6``, on
+mappings that fold), and across 27 near-critical configurations spanning ``sigma_min`` from
+``1e-3`` to ``1e-5`` and raw Newton steps up to ``7e5`` domain extents. At a budget of 1 the
+sweep loses 2 queries and at 0 it loses 6. This budget is four doublings beyond that.
 
-**So the magnitude comes from measurement, with the margin stated.** Over the warped-map
-sweep in ``tests/test_bspline_locate.py`` -- 2400 queries, 60 configurations, dimensions 1
-to 3, degrees 1 to 5, at unit scale and at an offset of ``1e6``, on mappings that fold --
-the smallest budget that loses no point is **2**: at 1 the sweep loses 2 queries and at 0 it
-loses 6. This budget is four doublings of step length beyond that, and covers every point
-where ``C * cond(J)^2 <= 2 ** (_MAX_STEP_HALVINGS + 1)``.
+**What the budget does *not* cover, stated plainly.** A single candidate solve can need more:
+on the folding sweep family, solves converge using up to **15** halvings, and that number is
+real rather than an artifact of the ceiling -- the depth histogram is identical at budgets 16
+and 24, so it has genuinely stopped. Those deep solves are not what decides a query, because
+another candidate cell or the second start reaches the root first, which is why the sweep loses
+nothing from a budget of 2 upward. But that redundancy is a property of the candidate list, not
+headroom in the line search, and it should not be read as margin: **the honest statement is that
+a solve needing more than 8 halvings is abandoned, and a query all of whose candidates and both
+starts need more than 8 would be lost.** Nothing measured exhibits one.
 
-**The cost is why it is not larger.** A candidate that will never converge spends its whole
-budget before being abandoned, so the budget sets the price of a doomed solve, and doomed
-solves are the common case for a query that is off the mapping's image. Against the
-undamped iteration this fix replaces, measured on the sweep above: at this budget, queries
-on the image cost 5 % more and queries off it 31 % *less* (the early abandonment more than
-pays for the line search); at a budget of 30 both cost about three times more.
+**Cost is what stops it being larger.** A candidate that will never converge spends its whole
+budget before being abandoned, and doomed candidates are the common case for a query off the
+mapping's image. Measured against the undamped iteration this replaces: at this budget, queries
+on the image cost 10 % more and queries off it 31 % *less*, the early abandonment more than
+paying for the search. At 12 the on-image case costs about twice the undamped baseline, to cover
+solves whose queries are already found.
 
 Exhausting the budget abandons that candidate cell rather than stepping anyway. It is not a
 verdict on the query: the second start of :func:`_nearest_corner_starts` and the remaining
-candidate cells are tried afterwards, and only a query that fails all of them is reported
-not found.
+candidate cells are tried afterwards, and only a query that fails all of them is reported not
+found.
 """
 
 
@@ -549,15 +633,20 @@ def _accept_damped_step(
     - x|| <= (1 - _ARMIJO_DECREASE * lam) * ||F(xi) - x||``, up to
     :data:`_MAX_STEP_HALVINGS` halvings.
 
-    The trial iterate is clipped to the parametric domain box, so the search runs along the
-    projected path ``lam -> clip(xi - lam * delta)`` rather than along the ray. That path
-    still tends to ``xi`` as ``lam`` does, so shortening the step remains meaningful on the
-    boundary; a direction that leaves the box along the whole path is rejected at every
-    ``lam``, which is the correct answer for a point whose Newton direction only points out
-    of the domain.
+    The first trial is shortened to at most :data:`_MAX_STEP_EXTENTS` domain extents in every
+    parametric direction, so an overlong step from an ill-conditioned Jacobian is capped rather
+    than halved back down one level at a time.
 
-    One map evaluation per halving level serves every point still searching at that level,
-    so a round in which every point accepts its full step costs a single evaluation.
+    The trial iterate is clipped to the parametric domain box, so the search runs along the
+    projected path ``lam -> clip(xi - lam * delta)`` rather than along the ray. That path still
+    tends to ``xi`` as ``lam`` does (``clip`` is 1-Lipschitz and fixes ``xi``, so
+    ``||p(lam) - xi|| <= lam * ||delta||``), which is what keeps shortening the step meaningful
+    on the boundary. What is rejected at *every* ``lam`` is a **constant** projected path -- every
+    coordinate either held by the clip or already zero in ``delta`` -- and not merely a direction
+    that leaves the box, which with only some coordinates held still moves and can be accepted.
+
+    One map evaluation per halving level serves every point still searching at that level, so a
+    round in which every point accepts its first step costs a single evaluation.
 
     Args:
         spline (Bspline): A ``float64`` spline with ``rank == dim``, non-periodic.
@@ -569,17 +658,30 @@ def _accept_damped_step(
             those rows, shape ``(m, dim)``, in the order of ``active``.
 
     Returns:
-        npt.NDArray[np.bool_]: Shape ``(m,)``, True where a step was accepted. A False
-        entry means the line search was exhausted, and its point is at a residual minimum
-        no Newton step from it improves on.
+        npt.NDArray[np.bool_]: Shape ``(m,)``, True where a step was accepted. A False entry
+        means the line search was exhausted: either no step length short enough was reachable
+        within :data:`_MAX_STEP_HALVINGS`, or none exists at all because the criterion in
+        :data:`_ARMIJO_DECREASE` fails. In one dimension an exhausted point on the boundary
+        really is the constrained minimum -- the merit gradient ``J * r == J^2 * delta`` carries
+        ``sign(delta)``, which points out of the box. In two or more it need not be, because
+        ``sign(delta[k])`` need not agree with ``sign((J.T @ J @ delta)[k])``: a bilinear map
+        with ``J.T @ J == [[5, -2], [-2, 1]]`` and ``cond(J) == 5.83`` is abandoned at a corner
+        while its residual still decreases into the box (measured). So a False entry means this
+        candidate made no progress, not that the point is a minimum of the residual.
     """
+    reach = np.max(np.abs(delta) / (state.hi - state.lo), axis=1)
+    first = _MAX_STEP_EXTENTS / np.maximum(reach, _MAX_STEP_EXTENTS)
+
     accepted = np.zeros(active.size, dtype=np.bool_)
     searching = np.arange(active.size, dtype=np.int64)
-    step_length = 1.0
+    shrink = 1.0
 
     for _ in range(_MAX_STEP_HALVINGS + 1):
         rows = active[searching]
-        trial_xi = np.clip(state.xi[rows] - step_length * delta[searching], state.lo, state.hi)
+        step_length = shrink * first[searching]
+        trial_xi = np.clip(
+            state.xi[rows] - step_length[:, np.newaxis] * delta[searching], state.lo, state.hi
+        )
         trial_residual = _eval_map(spline, trial_xi) - targets[rows]
         trial_norm = np.asarray(np.linalg.norm(trial_residual, axis=1), dtype=np.float64)
 
@@ -593,7 +695,7 @@ def _accept_damped_step(
         searching = searching[~passes]
         if searching.size == 0:
             break
-        step_length *= 0.5
+        shrink *= 0.5
 
     return accepted
 

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -12,17 +12,38 @@ The inversion has two stages:
    every weight is positive. Those per-cell boxes are indexed by a
    :class:`pantr.grid.BVH`, so the cells that can contain a query point are found by a
    tree descent instead of by trying Newton on every cell.
-2. **Newton.** Per candidate cell, Newton's method on ``F(xi) - x = 0`` starting from
-   the cell's parametric midpoint, with the Jacobian assembled column by column from
-   :meth:`~pantr.bspline.Bspline.evaluate_derivatives` (already rational-aware through
-   the generalized quotient rule). Iterates are clamped to the parametric domain box,
-   so an iterate may migrate out of its candidate cell: the candidate box is a superset
-   test, never a constraint on the solution.
+2. **Newton.** Per candidate cell, a damped Newton's method on ``F(xi) - x = 0`` starting
+   from the cell's parametric midpoint and, if that does not converge, from the cell
+   corner whose image is nearest the query. The Jacobian is assembled column by column
+   from :meth:`~pantr.bspline.Bspline.evaluate_derivatives` (already rational-aware
+   through the generalized quotient rule). Iterates are clamped to the parametric domain
+   box, so an iterate may migrate out of its candidate cell: the candidate box is a
+   superset test, never a constraint on the solution.
+
+   The damping is a backtracking line search, and it is what makes the iteration usable
+   away from the basin of attraction: an undamped Newton step is only guaranteed to
+   reduce the residual near a root, and out there it can be arbitrarily longer than the
+   residual it is trying to remove. Accepting such a step and then clamping the result to
+   the domain box does not merely waste an iteration, it can be *periodic* -- the clamp
+   maps two off-basin iterates onto each other -- and then no iteration budget and no
+   tolerance recovers the point. Requiring each accepted step to reduce the residual
+   removes both failure modes at once, and makes the residual of the accepted iterates a
+   monotonically non-increasing sequence.
+
+   What damping cannot do is change which root the iteration finds. A monotone method
+   descends into whichever basin it starts in, and on a mapping that folds, the residual
+   has minima on the domain boundary that are not roots; a start that descends into one of
+   those is stuck there legitimately. That is what the second start is for, and why it is a
+   *different point of the same cell* rather than a longer iteration.
 
 Newton runs on the whole batch of points at once: one candidate slot per round, and
 within a round one evaluator call per Jacobian column for all still-active points
-together. The number of Python-level calls into the evaluators is therefore
-``O(rounds * max_iter * dim)``, independent of the number of query points.
+together, plus one per backtracking level for the points still searching at that level.
+The number of Python-level calls into the evaluators is therefore
+``O(rounds * starts * max_iter * (dim + halvings))``, independent of the number of query
+points, with ``starts`` at most two, ``halvings`` at most ``1 + _MAX_STEP_HALVINGS`` and
+equal to one wherever the full Newton step is accepted, and the second start costing a
+further ``2 ** dim`` evaluations for the points that need it.
 
 What is guaranteed is ``F(ref_coords[i]) == points[i]`` within the tolerance, and *not*
 that ``ref_coords[i]`` is any particular preimage. A mapping whose Jacobian determinant
@@ -77,7 +98,82 @@ rounding noise and the solve returns an arbitrary step. The test is a ratio, so 
 invariant under scaling the geometry or the parametrization. It is deliberately
 permissive -- it only rejects a Jacobian whose condition number reaches ``1 / (dim *
 eps)`` -- because a merely ill-conditioned Jacobian still gives a usable step, and the
-clamp to the parametric domain box already bounds an overlong one.
+line search below rejects an overlong one.
+"""
+
+_ARMIJO_DECREASE: float = 1.0e-4
+"""
+Fraction of its own size the residual norm must lose per unit step length, to be accepted.
+
+A damped step ``lam * delta`` passes when ``||F(xi - lam * delta) - x|| <= (1 -
+_ARMIJO_DECREASE * lam) * ||F(xi) - x||``: the Armijo sufficient-decrease rule, applied to
+the merit function ``||F - x||`` whose descent direction the exact Newton step is (with
+``delta = J^-1 r`` one has ``d/dlam ||F(xi - lam * delta) - x||`` at ``lam = 0`` equal to
+``-||r||``, so a decrease of ``lam * ||r||`` is what the linear model promises and this
+constant is the fraction of it that must actually materialize).
+
+**Why any value in ``(0, 1)`` terminates.** Expanding to second order,
+``F(xi - lam * delta) - x = (1 - lam) * r + O(lam^2 * M * ||delta||^2)`` with ``M`` a bound
+on the second derivatives, so the test holds as soon as
+``lam <= 2 * (1 - _ARMIJO_DECREASE) * ||r|| / (M * ||delta||^2)``; the halving loop
+therefore ends after finitely many trials wherever the Jacobian is nonsingular and the
+iterate is interior. See :data:`_MAX_STEP_HALVINGS` for how many that is.
+
+**Why this magnitude.** The constant trades how much of Newton's own step is admitted
+against how much progress an accepted step must show, and both ends are one-sided:
+
+- It must be small enough never to reject the asymptotic step. Newton converges
+  quadratically near a root, ``||r_next|| ~ K * ||r||^2``, which beats
+  ``(1 - _ARMIJO_DECREASE) * ||r||`` by orders of magnitude the moment ``||r||`` is small,
+  so ``lam == 1`` is accepted throughout the endgame and the observed convergence rate is
+  Newton's own. A constant near one would instead veto perfectly good steps.
+- It must stay far above the noise of the comparison. The two norms being compared differ
+  by the relative amount ``_ARMIJO_DECREASE * lam``, and each carries a rounding error of
+  order ``eps``, so a constant approaching ``eps`` would let rounding decide the test.
+  ``1e-4`` sits twelve decades above ``eps`` at ``lam == 1``, and nine decades above it at
+  the smallest step length :data:`_MAX_STEP_HALVINGS` admits.
+
+``1e-4`` is also the value the line-search literature settles on for exactly this rule, so
+nothing here is unconventional; what matters for this library is that both bounds above are
+satisfied with decades to spare, which makes the choice insensitive.
+"""
+
+_MAX_STEP_HALVINGS: int = 8
+"""
+Number of times a Newton step may be halved before its candidate cell is abandoned.
+
+The smallest step length tried is ``2 ** -_MAX_STEP_HALVINGS``, about ``3.9e-3``.
+
+**What a sufficient condition would ask for.** By the expansion in
+:data:`_ARMIJO_DECREASE`, the test accepts once ``lam <= 2 * (1 - _ARMIJO_DECREASE) *
+||r|| / (M * ||delta||^2)``, and with ``||delta|| <= ||J^-1|| * ||r||`` a sufficient
+condition is ``lam <= 2 / (M * ||J^-1||^2 * ||r||)``. Reading the factors off a spline map
+of geometric scale ``S`` over a parametric domain of unit extent -- ``||r|| <= S``,
+``||J^-1|| ~ cond(J) / S``, and ``M ~ C * S`` with ``C`` the map's parametric curvature
+factor -- gives ``lam <= 2 / (C * cond(J)^2)``, in which the scale cancels. That is the
+right shape (the halvings needed are a property of the map, not of its units) but a very
+loose bound, since it takes the worst case of three independent factors at once: it would
+demand 26 halvings for a map with ``C ~ 100`` and ``cond(J) ~ 1e3``, and such a step is
+never what decides whether a query is found.
+
+**So the magnitude comes from measurement, with the margin stated.** Over the warped-map
+sweep in ``tests/test_bspline_locate.py`` -- 2400 queries, 60 configurations, dimensions 1
+to 3, degrees 1 to 5, at unit scale and at an offset of ``1e6``, on mappings that fold --
+the smallest budget that loses no point is **2**: at 1 the sweep loses 2 queries and at 0 it
+loses 6. This budget is four doublings of step length beyond that, and covers every point
+where ``C * cond(J)^2 <= 2 ** (_MAX_STEP_HALVINGS + 1)``.
+
+**The cost is why it is not larger.** A candidate that will never converge spends its whole
+budget before being abandoned, so the budget sets the price of a doomed solve, and doomed
+solves are the common case for a query that is off the mapping's image. Against the
+undamped iteration this fix replaces, measured on the sweep above: at this budget, queries
+on the image cost 5 % more and queries off it 31 % *less* (the early abandonment more than
+pays for the line search); at a budget of 30 both cost about three times more.
+
+Exhausting the budget abandons that candidate cell rather than stepping anyway. It is not a
+verdict on the query: the second start of :func:`_nearest_corner_starts` and the remaining
+candidate cells are tried afterwards, and only a query that fails all of them is reported
+not found.
 """
 
 
@@ -267,6 +363,34 @@ def _build_context(spline: Bspline) -> _LocateContext:
     )
 
 
+def _cell_parametric_bounds(
+    space: BsplineSpace, cell_ids: npt.NDArray[np.int64]
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return the parametric box of each of the given knot-span cells.
+
+    Args:
+        space (BsplineSpace): The space the cells belong to, with no periodic direction.
+        cell_ids (npt.NDArray[np.int64]): Flat cell ids in C-order over
+            ``space.num_intervals``, shape ``(n,)``.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(lo, hi)``, both of
+        shape ``(n, space.dim)``: the consecutive breakpoints bracketing each cell in each
+        parametric direction.
+    """
+    multi = np.unravel_index(cell_ids, space.num_intervals)
+    lo = np.empty((cell_ids.shape[0], space.dim), dtype=np.float64)
+    hi = np.empty_like(lo)
+    for axis, sub in enumerate(space.spaces):
+        breakpoints = np.asarray(
+            sub.get_unique_knots_and_multiplicity(in_domain=True)[0], dtype=np.float64
+        )
+        index = multi[axis]
+        lo[:, axis] = breakpoints[index]
+        hi[:, axis] = breakpoints[index + 1]
+    return lo, hi
+
+
 def _cell_midpoints(
     space: BsplineSpace, cell_ids: npt.NDArray[np.int64]
 ) -> npt.NDArray[np.float64]:
@@ -280,15 +404,56 @@ def _cell_midpoints(
     Returns:
         npt.NDArray[np.float64]: Shape ``(n, space.dim)`` parametric midpoints.
     """
-    multi = np.unravel_index(cell_ids, space.num_intervals)
-    out = np.empty((cell_ids.shape[0], space.dim), dtype=np.float64)
-    for axis, sub in enumerate(space.spaces):
-        breakpoints = np.asarray(
-            sub.get_unique_knots_and_multiplicity(in_domain=True)[0], dtype=np.float64
+    lo, hi = _cell_parametric_bounds(space, cell_ids)
+    return 0.5 * (lo + hi)
+
+
+def _nearest_corner_starts(
+    spline: Bspline,
+    cell_ids: npt.NDArray[np.int64],
+    targets: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Return the corner of each cell whose image is nearest that cell's query point.
+
+    The second starting guess for a candidate cell whose midpoint start did not converge.
+    A monotone iteration can only reach the root whose basin it starts in, and a cell
+    midpoint is one guess out of many: on a mapping that folds, the residual has minima on
+    the domain boundary that a midpoint start can descend into and then never leave, while
+    another point of the *same* cell descends into the root instead (measured). Retrying
+    matters most exactly where the candidate loop cannot help -- a query with a single
+    candidate cell otherwise gets one Newton solve and no fallback at all.
+
+    Among the cell's ``2 ** dim`` corners, the one with the nearest image is the one that
+    starts the iteration at the smallest residual, which is the only ordering the merit
+    function gives. The corners are visited one at a time rather than materialized
+    together, so the cost is ``2 ** dim`` map evaluations and ``O(n * dim)`` memory.
+
+    Args:
+        spline (Bspline): A ``float64`` spline with ``rank == dim``, non-periodic.
+        cell_ids (npt.NDArray[np.int64]): One candidate cell per query point, as flat ids
+            in C-order over ``space.num_intervals``, shape ``(n,)``.
+        targets (npt.NDArray[np.float64]): The query points, shape ``(n, rank)``.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(n, dim)`` parametric starting guesses.
+    """
+    lo, hi = _cell_parametric_bounds(spline.space, cell_ids)
+    dim = lo.shape[1]
+    axes = np.arange(dim)
+    best = np.empty_like(lo)
+    best_distance = np.full(cell_ids.shape[0], np.inf, dtype=np.float64)
+
+    for corner in range(1 << dim):
+        take_hi = ((corner >> axes) & 1).astype(np.bool_)
+        candidate = np.where(take_hi, hi, lo)
+        distance = np.asarray(
+            np.linalg.norm(_eval_map(spline, candidate) - targets, axis=1), dtype=np.float64
         )
-        index = multi[axis]
-        out[:, axis] = 0.5 * (breakpoints[index] + breakpoints[index + 1])
-    return out
+        closer = distance < best_distance
+        best[closer] = candidate[closer]
+        best_distance[closer] = distance[closer]
+
+    return best
 
 
 def _eval_map(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
@@ -335,6 +500,99 @@ def _eval_jacobian(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[
     return out
 
 
+class _NewtonState(NamedTuple):
+    """The state of the batched Newton iteration, one row per query point.
+
+    Three invariants hold on entry to and exit from every step, for every row ``i``:
+    ``lo <= xi[i] <= hi``, ``residual[i] == F(xi[i]) - target[i]``, and ``res_norm[i] ==
+    ||residual[i]||``. Carrying the residual next to the iterate is what lets one map
+    evaluation serve both the line search's acceptance test and the next round's Newton
+    direction, so the damping costs no evaluation at all wherever the full step is
+    accepted; carrying the box is what makes staying inside it the state's own business.
+
+    :func:`_accept_damped_step` writes into the three arrays in place, at the rows it
+    advanced, in the same ``out``-argument style the rest of Layer 2 uses. ``lo`` and ``hi``
+    are fixed for the whole solve.
+
+    Attributes:
+        xi (npt.NDArray[np.float64]): Current parametric iterates, shape ``(n, dim)``.
+        residual (npt.NDArray[np.float64]): ``F(xi) - targets``, shape ``(n, rank)``.
+        res_norm (npt.NDArray[np.float64]): Row 2-norms of ``residual``, shape ``(n,)``.
+        lo (npt.NDArray[np.float64]): Lower corner of the parametric domain box, shape
+            ``(dim,)``.
+        hi (npt.NDArray[np.float64]): Upper corner of the same box, shape ``(dim,)``.
+    """
+
+    xi: npt.NDArray[np.float64]
+    residual: npt.NDArray[np.float64]
+    res_norm: npt.NDArray[np.float64]
+    lo: npt.NDArray[np.float64]
+    hi: npt.NDArray[np.float64]
+
+
+def _accept_damped_step(
+    spline: Bspline,
+    targets: npt.NDArray[np.float64],
+    state: _NewtonState,
+    active: npt.NDArray[np.int64],
+    delta: npt.NDArray[np.float64],
+) -> npt.NDArray[np.bool_]:
+    """Take the longest damped Newton step that reduces the residual, per active point.
+
+    A backtracking line search on the merit function ``||F(xi) - x||``: the full step is
+    tried first and then halved until it satisfies the Armijo test ``||F(xi - lam * delta)
+    - x|| <= (1 - _ARMIJO_DECREASE * lam) * ||F(xi) - x||``, up to
+    :data:`_MAX_STEP_HALVINGS` halvings.
+
+    The trial iterate is clipped to the parametric domain box, so the search runs along the
+    projected path ``lam -> clip(xi - lam * delta)`` rather than along the ray. That path
+    still tends to ``xi`` as ``lam`` does, so shortening the step remains meaningful on the
+    boundary; a direction that leaves the box along the whole path is rejected at every
+    ``lam``, which is the correct answer for a point whose Newton direction only points out
+    of the domain.
+
+    One map evaluation per halving level serves every point still searching at that level,
+    so a round in which every point accepts its full step costs a single evaluation.
+
+    Args:
+        spline (Bspline): A ``float64`` spline with ``rank == dim``, non-periodic.
+        targets (npt.NDArray[np.float64]): Physical query points, shape ``(n, rank)``.
+        state (_NewtonState): The iteration state; its three arrays are updated in place at
+            the rows of ``active`` that accept a step, and left untouched at the others.
+        active (npt.NDArray[np.int64]): Row indices to step, shape ``(m,)``.
+        delta (npt.NDArray[np.float64]): Undamped Newton steps ``J^-1 * residual`` for
+            those rows, shape ``(m, dim)``, in the order of ``active``.
+
+    Returns:
+        npt.NDArray[np.bool_]: Shape ``(m,)``, True where a step was accepted. A False
+        entry means the line search was exhausted, and its point is at a residual minimum
+        no Newton step from it improves on.
+    """
+    accepted = np.zeros(active.size, dtype=np.bool_)
+    searching = np.arange(active.size, dtype=np.int64)
+    step_length = 1.0
+
+    for _ in range(_MAX_STEP_HALVINGS + 1):
+        rows = active[searching]
+        trial_xi = np.clip(state.xi[rows] - step_length * delta[searching], state.lo, state.hi)
+        trial_residual = _eval_map(spline, trial_xi) - targets[rows]
+        trial_norm = np.asarray(np.linalg.norm(trial_residual, axis=1), dtype=np.float64)
+
+        passes = trial_norm <= (1.0 - _ARMIJO_DECREASE * step_length) * state.res_norm[rows]
+        advanced = rows[passes]
+        state.xi[advanced] = trial_xi[passes]
+        state.residual[advanced] = trial_residual[passes]
+        state.res_norm[advanced] = trial_norm[passes]
+        accepted[searching[passes]] = True
+
+        searching = searching[~passes]
+        if searching.size == 0:
+            break
+        step_length *= 0.5
+
+    return accepted
+
+
 def _newton_refine(
     spline: Bspline,
     targets: npt.NDArray[np.float64],
@@ -342,13 +600,25 @@ def _newton_refine(
     tol_phys: float,
     max_iter: int,
 ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
-    """Run a batched Newton inversion, one starting guess per target point.
+    """Run a batched damped Newton inversion, one starting guess per target point.
 
-    Every point is iterated independently but evaluated collectively: each round drops
-    the points that have converged and the points whose Jacobian has become
-    rank-deficient, then takes one Newton step for the rest. Iterates are clamped to the
-    parametric domain box, which both keeps them inside the evaluators' legal input
-    range and bounds an overlong step from an ill-conditioned Jacobian.
+    Every point is iterated independently but evaluated collectively: each round drops the
+    points that have converged, the points whose Jacobian has become rank-deficient, and
+    the points whose line search was exhausted, then takes one damped Newton step for the
+    rest. Iterates are clamped to the parametric domain box, which keeps them inside the
+    evaluators' legal input range; it is :func:`_accept_damped_step`, not the clamp, that
+    bounds an overlong step from an ill-conditioned Jacobian.
+
+    Because every accepted step reduces the residual, the residuals of the iterates form a
+    monotonically non-increasing sequence. It is in fact strictly decreasing, hence free of
+    cycles, for every residual in the normal range: the accepted step satisfies ``||r_next||
+    <= (1 - _ARMIJO_DECREASE * lam) * ||r||`` and that bound is below ``||r||`` whenever
+    ``_ARMIJO_DECREASE * lam`` exceeds the rounding of the product, which it does by nine
+    decades at the smallest step length admitted. The one gap is a *subnormal* residual,
+    where the relative spacing is large enough that the product can round back to ``||r||``;
+    that is 300 decades below any threshold except a subnormal ``tol``. So a point that is
+    not converging exhausts its line search and is abandoned, instead of cycling until the
+    iteration budget runs out.
 
     Args:
         spline (Bspline): A ``float64`` spline with ``rank == dim``, non-periodic.
@@ -357,44 +627,53 @@ def _newton_refine(
             ``(n, dim)``.
         tol_phys (float): Convergence threshold on ``||F(xi) - x||_2``, a distance in
             physical units.
-        max_iter (int): Maximum number of Newton steps. The residual is tested once more
-            after the last step, so a point converging on step ``max_iter`` is reported.
+        max_iter (int): Maximum number of accepted Newton steps. The residual is tested
+            once more after the last step, so a point converging on step ``max_iter`` is
+            reported. The extra map evaluations a line search makes are not steps.
 
     Returns:
         tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]: ``(converged, xi)``.
-        ``converged`` has shape ``(n,)``; ``xi`` has shape ``(n, dim)`` and is only
-        meaningful where ``converged`` is True.
+        ``converged`` has shape ``(n,)``; ``xi`` has shape ``(n, dim)`` and holds each
+        point's last accepted iterate, which is a solution only where ``converged`` is
+        True.
     """
     dim = xi_start.shape[1]
     domain = np.asarray(spline.space.domain, dtype=np.float64)
     lo, hi = domain[:, 0], domain[:, 1]
 
     xi = np.clip(xi_start, lo, hi)
-    converged = np.zeros(xi.shape[0], dtype=np.bool_)
-    active = np.arange(xi.shape[0], dtype=np.int64)
+    residual = _eval_map(spline, xi) - targets
+    state = _NewtonState(
+        xi=xi,
+        residual=residual,
+        res_norm=np.asarray(np.linalg.norm(residual, axis=1), dtype=np.float64),
+        lo=lo,
+        hi=hi,
+    )
+    converged = state.res_norm <= tol_phys
+    active = np.arange(xi.shape[0], dtype=np.int64)[~converged]
 
-    for step in range(max_iter + 1):
-        xi_active = xi[active]
-        residual = _eval_map(spline, xi_active) - targets[active]
-        done = np.linalg.norm(residual, axis=1) <= tol_phys
-        converged[active[done]] = True
-        active, xi_active, residual = active[~done], xi_active[~done], residual[~done]
-        if step == max_iter or active.size == 0:
+    for _ in range(max_iter):
+        if active.size == 0:
             break
 
-        jacobian = _eval_jacobian(spline, xi_active)
+        jacobian = _eval_jacobian(spline, state.xi[active])
         singular_values = np.asarray(np.linalg.svd(jacobian, compute_uv=False), dtype=np.float64)
         healthy = singular_values[:, -1] > (dim * _JACOBIAN_RANK_REL_TOL * singular_values[:, 0])
         active = active[healthy]
         if active.size == 0:
             break
         delta = np.asarray(
-            np.linalg.solve(jacobian[healthy], residual[healthy][..., np.newaxis]),
+            np.linalg.solve(jacobian[healthy], state.residual[active][..., np.newaxis]),
             dtype=np.float64,
         )[..., 0]
-        xi[active] = np.clip(xi_active[healthy] - delta, lo, hi)
 
-    return converged, xi
+        active = active[_accept_damped_step(spline, targets, state, active, delta)]
+        done = state.res_norm[active] <= tol_phys
+        converged[active[done]] = True
+        active = active[~done]
+
+    return converged, state.xi
 
 
 def _validate_points(points: npt.ArrayLike, rank: int) -> npt.NDArray[np.float64]:
@@ -504,13 +783,26 @@ def _locate_impl(
         if not batch:
             break
         index = np.asarray(batch, dtype=np.int64)
-        starts = _cell_midpoints(
-            context.spline.space, np.asarray([candidates[i][slot] for i in batch], dtype=np.int64)
-        )
+        cells = np.asarray([candidates[i][slot] for i in batch], dtype=np.int64)
+
+        starts = _cell_midpoints(context.spline.space, cells)
         converged, xi = _newton_refine(context.spline, pts[index], starts, tol_phys, max_iter)
-        hits = index[converged]
-        ref_coords[hits] = xi[converged]
-        found.extend(int(i) for i in hits)
+        ref_coords[index[converged]] = xi[converged]
+
+        # Second start for the candidates the midpoint could not resolve; see
+        # _nearest_corner_starts. It can only turn a "not found" into a solution that
+        # passes the same residual test, never loosen what "found" means.
+        retry = ~converged
+        if bool(np.any(retry)):
+            retry_index, retry_cells = index[retry], cells[retry]
+            corner_starts = _nearest_corner_starts(context.spline, retry_cells, pts[retry_index])
+            retried, xi = _newton_refine(
+                context.spline, pts[retry_index], corner_starts, tol_phys, max_iter
+            )
+            ref_coords[retry_index[retried]] = xi[retried]
+            converged[retry] = retried
+
+        found.extend(int(i) for i in index[converged])
         resolved = set(found)
         pending = [i for i in pending if i not in resolved]
         slot += 1

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -77,6 +77,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
+from .._numba_compat import wait_for_jit_warmup
 from ..geometry import AABB
 from ..grid import BVH, tensor_product_grid
 from ..tolerance import get_default
@@ -707,6 +708,48 @@ def _validate_points(points: npt.ArrayLike, rank: int) -> npt.NDArray[np.float64
     return np.ascontiguousarray(pts)
 
 
+def _validate_invertible(spline: Bspline, tol: float | None, max_iter: int) -> None:
+    """Check everything about an inversion request that does not depend on the query points.
+
+    Args:
+        spline (Bspline): The spline to invert.
+        tol (float | None): The caller's convergence threshold, or ``None`` for the default.
+        max_iter (int): The caller's iteration budget.
+
+    Raises:
+        NotImplementedError: If ``rank > dim`` (an embedded curve or surface).
+        ValueError: If ``rank < dim``, any direction is periodic, a rational spline has a
+            non-positive weight, ``max_iter < 1``, or ``tol`` is given and is not positive
+            and finite.
+    """
+    dim, rank = spline.dim, spline.rank
+    if rank > dim:
+        raise NotImplementedError(
+            f"locate: embedded geometries (rank {rank} > dim {dim}) need a Gauss-Newton "
+            "closest-point solve, which is not implemented; only square maps "
+            "(rank == dim) can be inverted."
+        )
+    if rank < dim:
+        raise ValueError(
+            f"locate: a B-spline mapping cannot be inverted with fewer physical "
+            f"coordinates than parametric directions; got rank {rank} < dim {dim}."
+        )
+    for axis, sub in enumerate(spline.space.spaces):
+        if sub.periodic:
+            raise ValueError(f"locate: periodic B-spline spaces are not supported (axis {axis}).")
+    if spline.is_rational and not bool(
+        np.all(np.asarray(spline.control_points[..., -1], dtype=np.float64) > 0.0)
+    ):
+        raise ValueError(
+            "locate: every NURBS weight must be strictly positive; the convex-hull "
+            "property the candidate search relies on does not hold otherwise."
+        )
+    if max_iter < 1:
+        raise ValueError(f"locate: max_iter must be >= 1; got {max_iter}.")
+    if tol is not None and not (float(tol) > 0.0 and np.isfinite(tol)):
+        raise ValueError(f"locate: tol must be positive and finite; got {tol}.")
+
+
 def _locate_impl(
     spline: Bspline,
     points: npt.ArrayLike,
@@ -736,34 +779,17 @@ def _locate_impl(
         NotImplementedError: If ``rank > dim`` (an embedded curve or surface).
         ValueError: If ``rank < dim``, any direction is periodic, a rational spline has
             a non-positive weight, ``points`` has a bad shape or a non-finite entry,
-            ``max_iter < 1``, or ``tol`` is given and is not positive and finite.
+            ``max_iter < 1``, or ``tol`` is given and is not positive and finite. See
+            :func:`_validate_invertible` and :func:`_validate_points`.
     """
     dim, rank = spline.dim, spline.rank
-    if rank > dim:
-        raise NotImplementedError(
-            f"locate: embedded geometries (rank {rank} > dim {dim}) need a Gauss-Newton "
-            "closest-point solve, which is not implemented; only square maps "
-            "(rank == dim) can be inverted."
-        )
-    if rank < dim:
-        raise ValueError(
-            f"locate: a B-spline mapping cannot be inverted with fewer physical "
-            f"coordinates than parametric directions; got rank {rank} < dim {dim}."
-        )
-    for axis, sub in enumerate(spline.space.spaces):
-        if sub.periodic:
-            raise ValueError(f"locate: periodic B-spline spaces are not supported (axis {axis}).")
-    if spline.is_rational and not bool(
-        np.all(np.asarray(spline.control_points[..., -1], dtype=np.float64) > 0.0)
-    ):
-        raise ValueError(
-            "locate: every NURBS weight must be strictly positive; the convex-hull "
-            "property the candidate search relies on does not hold otherwise."
-        )
-    if max_iter < 1:
-        raise ValueError(f"locate: max_iter must be >= 1; got {max_iter}.")
-    if tol is not None and not (float(tol) > 0.0 and np.isfinite(tol)):
-        raise ValueError(f"locate: tol must be positive and finite; got {tol}.")
+    _validate_invertible(spline, tol, max_iter)
+
+    # Ensure background JIT compilation is complete before calling Numba kernels that use
+    # parallel=True (avoids concurrent-compilation crash), as the other Layer 2 entry points
+    # over parallel kernels do. The inversion evaluates the mapping many times in quick
+    # succession, so it hits the window the import-time warmup thread leaves open.
+    wait_for_jit_warmup()
 
     pts = _validate_points(points, rank)
     context = _locate_context(spline)

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -12,6 +12,7 @@ import pytest
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_locate import (
     _cell_midpoints,
+    _cell_parametric_bounds,
     _cell_physical_bounds,
     _geometric_scale,
     _locate_context,
@@ -720,6 +721,27 @@ class TestNewtonGlobalization:
             from_corner[1], xi_true, atol=_XI_REL_ATOL * context.scale, rtol=0.0
         )
         assert spline.locate(target)[0].tolist() == [32]
+
+    def test_the_second_start_is_always_a_corner_of_its_own_cell(self) -> None:
+        """The postcondition holds even when no corner can be ranked.
+
+        The nearest-image search keeps the best corner seen so far, and a mapping that
+        evaluates to ``nan`` -- nothing rejects a non-finite control point at construction --
+        makes every distance ``nan`` and every "is this closer" comparison False. Starting
+        the search from a real corner rather than an empty buffer is what keeps the answer a
+        point of the cell instead of whatever the allocator returned.
+        """
+        spline = _warped_patch()
+        cells = np.array([0, 17, 35], dtype=np.int64)
+        lo, hi = _cell_parametric_bounds(spline.space, cells)
+
+        finite = _nearest_corner_starts(spline, cells, _evaluate_at(spline, 0.5 * (lo + hi)))
+        unrankable = _nearest_corner_starts(spline, cells, np.full((3, 2), np.nan))
+
+        for starts in (finite, unrankable):
+            assert np.all(np.isfinite(starts))
+            assert np.all((starts == lo) | (starts == hi)), "a start must be a cell corner"
+            assert np.all(lo <= starts) and np.all(starts <= hi)
 
     def test_a_second_start_cannot_invent_a_solution(self) -> None:
         """Retrying widens what is reached, never what counts as reached.

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -10,10 +10,15 @@ import pytest
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_locate import (
+    _cell_midpoints,
     _cell_physical_bounds,
     _geometric_scale,
+    _locate_context,
     _LocateContext,
+    _newton_refine,
 )
+from pantr.geometry import AABB
+from pantr.tolerance import get_default
 from pantr.transform import AffineTransform
 
 _XI_REL_ATOL: float = 1e-10
@@ -38,6 +43,20 @@ The convergence threshold is :func:`pantr.tolerance.get_default` for ``float32``
 (``1e-6``) times the geometric scale, so the coordinate error is four orders of magnitude
 larger than in the ``float64`` case. Measured worst case over the cases below:
 ``5.2e-6``; the ``1e-4`` leaves a factor of 19.
+"""
+
+_CYCLING_PARAMETER: npt.NDArray[np.float64] = np.array([[0.05411231, 0.64513102]])
+"""
+The parameter whose image an undamped Newton iteration could not recover.
+
+An ordinary interior point of :func:`_warped_patch`'s default geometry, kept as the exact
+triggering datum rather than re-searched for. Its image has one candidate cell, 3, which
+is the cell that contains it, so there is no second start to fall back on. From that
+cell's midpoint the second undamped step is 67 times longer than the residual it removes;
+the iterate leaves the basin and the clamp to the parametric domain then pins it in a
+period-2 cycle between ``(1, 1)`` and ``(0.403985, 0.995004)``, whose residual is
+``0.77``. Being periodic rather than slow is what made the iteration budget useless, and
+a residual seven decades above any plausible threshold is what made the tolerance useless.
 """
 
 
@@ -104,6 +123,33 @@ def _perturbed_patch(
     cp = np.stack(mesh, axis=-1) if dim > 1 else mesh[0][:, np.newaxis]
     cp = cp + 0.12 * rng.uniform(-1.0, 1.0, size=cp.shape)
     return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp.astype(dtype)))
+
+
+def _warped_patch(dim: int = 2, degree: int = 1, n_elem: int = 6, offset: float = 0.0) -> Bspline:
+    """Return the identity map of the unit box plus a smooth 15 % sinusoidal warp.
+
+    Control points sit on a uniform lattice of the unit box and are displaced in every
+    coordinate by ``0.15 * sin(2 * pi * sum(coords))``, then translated by ``offset``.
+
+    The defaults are the exact geometry the undamped Newton iteration diverged on: a
+    degree-1 bivariate map on 6 uniform elements at unit scale.
+
+    The warp is smooth and the Jacobian is well conditioned along it, but the family is
+    **not** injective for ``dim >= 2``, which is worth knowing before reading a result off
+    it. The displacement field ``y + a * sin(2 * pi * sum(y))`` has Jacobian
+    ``I + 2 * pi * a * cos(2 * pi * sum(y)) * ones``, whose eigenvalues are 1 and
+    ``1 + 2 * pi * a * dim * cos(...)``; at ``a == 0.15`` the second turns negative once
+    ``dim >= 2``. Measured over the family: ``det J`` reaches ``-0.56`` at ``dim == 2`` and
+    ``-1.34`` at ``dim == 3``. So a query built from this family has a preimage by
+    construction, but not a unique one, and only ``F(ref_coords) == points`` may be asserted
+    of what comes back.
+    """
+    knots = np.concatenate([np.zeros(degree), np.linspace(0.0, 1.0, n_elem + 1), np.ones(degree)])
+    space = BsplineSpace([BsplineSpace1D(knots, degree) for _ in range(dim)])
+    axes = [np.linspace(0.0, 1.0, n) for n in space.num_basis]
+    cp = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1)
+    cp = cp + 0.15 * np.sin(2.0 * np.pi * cp.sum(axis=-1))[..., None] + offset
+    return Bspline(space, np.ascontiguousarray(cp))
 
 
 def _folded_patch() -> Bspline:
@@ -540,6 +586,101 @@ class TestIdentityMap:
         cell_ids, _ = spline.locate(xi_true, max_iter=1)
 
         assert np.all(cell_ids >= 0)
+
+
+class TestNewtonGlobalization:
+    """A Newton step that does not reduce the residual is rejected, so no iterate cycles."""
+
+    def test_the_cycling_point_is_found_at_every_tolerance_and_budget(self) -> None:
+        """The undamped iteration lost this point at every setting; the damped one must not.
+
+        Neither knob could recover it before: not a tolerance seven decades above the
+        default tier, and not ten times the iteration budget. That is the signature of a
+        cycle rather than of slow convergence, and it is why both axes are swept here.
+        """
+        spline = _warped_patch()
+        target = _evaluate_at(spline, _CYCLING_PARAMETER)
+        scale = _scale_of(spline)
+
+        for factor in (64.0, 4096.0, 1.0e9):
+            for max_iter in (20, 200):
+                tol = factor * float(np.finfo(np.float64).eps) * scale
+                cell_ids, ref_coords = spline.locate(target, tol=tol, max_iter=max_iter)
+                assert cell_ids.tolist() == [3], f"lost at tol={factor}*eps*scale, {max_iter=}"
+                residual = np.linalg.norm(_evaluate_at(spline, ref_coords) - target)
+                assert residual <= tol
+
+    def test_the_recovered_parameter_is_the_preimage(self) -> None:
+        """The answer is the parameter the target was built from, not merely some root."""
+        spline = _warped_patch()
+        target = _evaluate_at(spline, _CYCLING_PARAMETER)
+        assert np.all(_jacobian_determinants(spline, _CYCLING_PARAMETER) > 0.0)
+
+        cell_ids, ref_coords = spline.locate(target)
+
+        np.testing.assert_allclose(
+            ref_coords, _CYCLING_PARAMETER, atol=_XI_REL_ATOL * _scale_of(spline), rtol=0.0
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_the_residual_never_increases_over_the_accepted_iterates(self) -> None:
+        """Monotonicity, read off the iteration itself rather than assumed.
+
+        Budget ``k`` returns the iterate after at most ``k`` accepted steps, so sweeping
+        ``k`` and evaluating the residual at what comes back walks the accepted sequence
+        without needing a hook into the solver. Undamped, the sequence rises from
+        ``1.05e-2`` to ``7.3e-1`` at the third step and then oscillates.
+        """
+        spline = _warped_patch()
+        target = _evaluate_at(spline, _CYCLING_PARAMETER)
+        context = _locate_context(spline)
+        tol = get_default(spline.dtype) * context.scale
+        candidates = np.sort(context.bvh.query_aabb(AABB(target[0], target[0]).pad(tol)))
+        assert candidates.tolist() == [3], "the premise: one candidate, so there is no fallback"
+        start = _cell_midpoints(spline.space, candidates)
+
+        norms = [
+            float(
+                np.linalg.norm(
+                    _evaluate_at(spline, _newton_refine(spline, target, start, tol, k)[1]) - target
+                )
+            )
+            for k in range(1, 13)
+        ]
+
+        assert np.all(np.diff(norms) <= 0.0), f"residual increased over the iterates: {norms}"
+        assert norms[-1] <= tol, f"did not converge within 12 steps: {norms}"
+
+    @pytest.mark.parametrize("offset", [0.0, 1.0e6])
+    @pytest.mark.parametrize("n_elem", [3, 6])
+    @pytest.mark.parametrize("degree", [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize("dim", [1, 2, 3])
+    def test_the_warped_family_loses_no_point_that_has_a_preimage(
+        self, dim: int, degree: int, n_elem: int, offset: float
+    ) -> None:
+        """Every point built by evaluating the map is recovered, across the whole family.
+
+        Sampling the parameter first and mapping it forward is what makes "has a preimage"
+        a fact about each query rather than a hope: the preimage is the parameter the
+        target was made from. It is *a* preimage that is required back, not that one --
+        this family folds for every ``dim >= 2`` member (measured: ``det J`` reaches
+        ``-0.56`` at ``dim == 2``), and a folded mapping sends several parameters to one
+        point. The offset column is there because the residual floor follows the coordinate
+        magnitude, so a family that converges at unit scale can still lose points at
+        ``1e6``.
+        """
+        spline = _warped_patch(dim, degree, n_elem, offset)
+        xi_true = _sample_parametric(spline, 40, seed=1000 * dim + 10 * degree + n_elem)
+        points = _evaluate_at(spline, xi_true)
+        tol = get_default(spline.dtype) * _scale_of(spline)
+
+        cell_ids, ref_coords = spline.locate(points)
+
+        lost = np.flatnonzero(cell_ids < 0)
+        assert lost.size == 0, f"lost {lost.size} of 40 points: {xi_true[lost]}"
+        residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - points, axis=1)
+        assert residuals.max() <= tol, f"worst residual {residuals.max():.3e} over tol {tol:.3e}"
+        _assert_cell_contains(spline, cell_ids, ref_coords)
 
 
 class TestToleranceScaling:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 
 import numpy as np
@@ -842,6 +843,52 @@ class TestToleranceScaling:
         cp = np.full((2, 2, 2), 1.0e-6, dtype=np.float64)
         point_map = Bspline(BsplineSpace([sub, sub]), cp)
         assert _scale_of(point_map) == pytest.approx(1.0e-6, rel=1e-12)
+
+
+class TestNumbaWarmup:
+    """``locate`` waits for the import-time JIT warmup, as its sibling entry points do."""
+
+    def test_the_barrier_runs_before_any_kernel_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``locate`` calls the warmup barrier, and calls it before it evaluates anything.
+
+        ``pantr/__init__.py`` compiles its kernels on a background thread, and Numba's
+        default workqueue threading layer is not safe against a concurrent ``parallel=True``
+        call from another thread: the process *aborts* rather than raising, which takes the
+        whole session with it. Every other Layer 2 entry point over parallel kernels calls
+        :func:`pantr._numba_compat.wait_for_jit_warmup` first; ``locate`` did not, and
+        inverting a batch evaluates often enough to land in the window. Measured before the
+        barrier: 4 of 4 runs of this module's 60-case sweep aborted with ``Fatal Python
+        error: Aborted`` when it was the first thing a process did, both serially and under
+        ``pytest -n 4``; after it, 0 of 4.
+
+        Asserting the *call* rather than the absence of the crash is deliberate. The barrier
+        is a once-per-process event, so by the time any in-process test runs the warmup is
+        long finished and no in-process check can observe the race; and a subprocess that
+        merely inverts a batch does not reproduce it either once the Numba cache is warm
+        (measured: 8 of 8 clean without the barrier). What is worth pinning is therefore the
+        contract, which this does deterministically: delete the call and this test fails.
+        """
+        calls: list[str] = []
+        module = sys.modules["pantr.bspline._bspline_locate"]
+        real_eval_map = module._eval_map
+
+        def _record_barrier() -> None:
+            calls.append("barrier")
+
+        def _record_eval(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            calls.append("evaluate")
+            return np.asarray(real_eval_map(spline, xi), dtype=np.float64)
+
+        monkeypatch.setattr(module, "wait_for_jit_warmup", _record_barrier)
+        monkeypatch.setattr(module, "_eval_map", _record_eval)
+
+        spline = _warped_patch()
+        spline.locate(_evaluate_at(spline, _CYCLING_PARAMETER))
+
+        assert "barrier" in calls, "locate must wait for the JIT warmup"
+        assert calls.index("barrier") < calls.index("evaluate"), (
+            f"the barrier must precede the first kernel call; got {calls[:3]}"
+        )
 
 
 class TestCellPhysicalBounds:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -15,6 +15,7 @@ from pantr.bspline._bspline_locate import (
     _geometric_scale,
     _locate_context,
     _LocateContext,
+    _nearest_corner_starts,
     _newton_refine,
 )
 from pantr.geometry import AABB
@@ -516,12 +517,16 @@ class TestCandidateCells:
         assert cell_ids.tolist() == [-1]
         assert bool(np.all(np.isnan(ref_coords)))
 
-    def test_off_image_query_exhausts_the_iteration_budget(self) -> None:
+    def test_off_image_query_ends_by_stalling_not_by_the_rank_guard(self) -> None:
         """The other way a candidate fails: a healthy Jacobian that never converges.
 
-        ``(0.75, 0.25)`` is also outside the triangle, but the iterate settles at
-        ``(1, 0.25)`` with a well-conditioned Jacobian, so it is the iteration budget that
-        ends the attempt rather than the rank guard.
+        ``(0.75, 0.25)`` is also outside the triangle, but the iterate settles near
+        ``(1, 0.25)`` with a well-conditioned Jacobian, so what ends the attempt is not the
+        rank guard. It used to be the iteration budget, burnt one full step at a time; it is
+        now the line search, which cannot reduce a residual whose minimum over the domain is
+        the distance from the query to the image, and abandons the candidate instead
+        (measured: the midpoint start exits through the line search, the corner start
+        through the rank guard).
         """
         spline = _collapsed_edge_patch()
 
@@ -681,6 +686,54 @@ class TestNewtonGlobalization:
         residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - points, axis=1)
         assert residuals.max() <= tol, f"worst residual {residuals.max():.3e} over tol {tol:.3e}"
         _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_a_second_start_is_what_recovers_a_boundary_minimum(self) -> None:
+        """The one point in the sweep the line search alone cannot reach, and why.
+
+        A monotone iteration from cell 32's midpoint descends to ``(1, 0.4059)``, which is
+        the minimum of the residual along the ``u == 1`` face of the domain: the only
+        descent direction there points out of the box, and moving inward raises the
+        residual, so the root at ``u == 0.9485`` sits behind a ridge in a different basin.
+        Damping cannot cross that ridge -- no monotone method can -- and the corner start
+        does, which is what this pins.
+        """
+        spline = _warped_patch()
+        xi_true = np.array([[0.9485013, 0.34608885]])
+        target = _evaluate_at(spline, xi_true)
+        context = _locate_context(spline)
+        tol = get_default(spline.dtype) * context.scale
+        candidates = np.sort(context.bvh.query_aabb(AABB(target[0], target[0]).pad(tol)))
+        assert candidates.tolist() == [32], "the premise: one candidate, so there is no fallback"
+
+        from_midpoint = _newton_refine(
+            spline, target, _cell_midpoints(spline.space, candidates), tol, 40
+        )
+        from_corner = _newton_refine(
+            spline, target, _nearest_corner_starts(spline, candidates, target), tol, 40
+        )
+
+        assert not bool(from_midpoint[0][0]), "the midpoint start is expected to jam"
+        np.testing.assert_allclose(from_midpoint[1][0], [1.0, 0.405897], atol=1e-6, rtol=0.0)
+        assert bool(from_corner[0][0]), "the corner start must recover the root"
+        np.testing.assert_allclose(
+            from_corner[1], xi_true, atol=_XI_REL_ATOL * context.scale, rtol=0.0
+        )
+        assert spline.locate(target)[0].tolist() == [32]
+
+    def test_a_second_start_cannot_invent_a_solution(self) -> None:
+        """Retrying widens what is reached, never what counts as reached.
+
+        Both queries are off the mapping's image, so no start can drive the residual under
+        the threshold; the extra solve must leave them reported as not found. This is the
+        guard on the one way a second start could do harm.
+        """
+        annulus = _quarter_annulus()
+        holes = np.array([[0.2, 0.2], [0.5, 0.5]])
+
+        cell_ids, ref_coords = annulus.locate(holes)
+
+        assert cell_ids.tolist() == [-1, -1]
+        assert bool(np.all(np.isnan(ref_coords)))
 
 
 class TestToleranceScaling:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -867,6 +867,45 @@ class TestToleranceScaling:
         assert _scale_of(point_map) == pytest.approx(1.0e-6, rel=1e-12)
 
 
+class TestNearCriticalJacobian:
+    """A long Newton step is capped, not walked back one halving at a time."""
+
+    def test_a_monotone_map_with_a_near_critical_jacobian_is_found(self) -> None:
+        """The step-length cap earns its place: without it this query is reported not found.
+
+        A strictly monotone degree-5 map, so the preimage is unique and ``-1`` is unambiguously
+        wrong. Its derivative ``F'(xi) = eta + a * xi**2 * (xi - 1/2)**2`` with ``eta = 1e-4``
+        and ``a = 100`` is near-critical at ``xi == 0`` and ``xi == 1/2``, which are exactly the
+        two points the solver starts from -- the cell corner and the cell midpoint -- so both
+        starts begin where ``||J^-1 r||`` is enormous. ``sigma_min`` is ``1e-4`` there, fifteen
+        orders clear of the rank guard, so nothing about this is degenerate.
+
+        Uncapped, the line search spends its budget shortening a step 300 domain extents long:
+        11 halvings were needed where 8 were allowed, and ``locate`` returned ``-1`` at library
+        defaults. Capping the first trial at one domain extent drops the requirement to 2.
+        """
+        knots = np.array([0.0] * 6 + [1.0] * 6)
+        control_points = np.array(
+            [
+                [0.0],
+                [2.0e-5],
+                [4.0e-5],
+                [0.8333933333333333],
+                [-1.6665866666666664],
+                [3.333433333333334],
+            ]
+        )
+        spline = Bspline(BsplineSpace([BsplineSpace1D(knots, 5)]), control_points)
+        query = np.array([0.03308666666666668])  # F(0.2), to the last bit
+
+        cell_ids, ref_coords = spline.locate(query)
+
+        assert cell_ids.tolist() == [0], "a strictly monotone map must not lose its own image"
+        np.testing.assert_allclose(ref_coords, [[0.2]], atol=1e-12, rtol=0.0)
+        derivative = np.asarray(spline.evaluate_derivatives(np.linspace(0.0, 1.0, 1001), [1]))
+        assert derivative.min() > 0.0, "fixture must be strictly monotone"
+
+
 class TestNumbaWarmup:
     """``locate`` waits for the import-time JIT warmup, as its sibling entry points do."""
 


### PR DESCRIPTION
## What was wrong

`_newton_refine` accepted the full Newton step unconditionally and clamped the result to the
parametric domain box. Away from a root that step is not guaranteed to reduce the residual, and the
clamp turns divergence into a **cycle**: two off-basin iterates map onto each other. The reported
query cycles between `(1, 1)` and `(0.403985, 0.995004)` at a residual of `0.77` — which is why
neither a larger `max_iter` nor a looser `tol` recovered it, with the correct candidate cell and a
well-conditioned Jacobian at the true preimage.

## What changed

**A backtracking line search** (`_accept_damped_step`). A step is accepted only at a length
satisfying the Armijo condition on `‖F(xi) - x‖`, halving from the full step. The residuals of the
accepted iterates are monotonically non-increasing — strictly decreasing, hence cycle-free, for
every residual in the normal range, with the subnormal gap stated in the docstring — and a query
that stops making progress is abandoned rather than iterated. The iteration state now carries the residual
beside the iterate, so the evaluation that tests a step also supplies the next Newton direction:
the damping costs nothing whenever the full step is accepted.

**A second start per candidate cell** (`_nearest_corner_starts`). A monotone method only reaches the
root whose basin it starts in, and damping cannot change that — so this is not redundant with the
line search, it covers what the line search provably cannot. A candidate whose midpoint start fails
is retried from the cell corner whose image is nearest the query. It matters most where the
candidate loop cannot help: a query with one candidate cell otherwise gets one Newton solve and no
fallback. Convergence is still gated on the same residual threshold, so a second start can only
turn a "not found" into a solution meeting the existing accuracy contract.

**A cap on the step length** (`_MAX_STEP_EXTENTS`). The first trial is shortened to at most one
parametric domain extent per direction — a trust region — instead of starting at the full Newton
step. This was added after an adversarial pass showed the halving budget alone was not merely
mis-tuned but the wrong instrument; see below.

The constants are derived in their docstrings, including what they do *not* cover.

The candidate search and the tolerance tier are untouched, as are `locate`'s signature and its
`-1`-means-not-found convention.

## Acceptance criteria

| | verdict | evidence |
|---|---|---|
| AC1 — reproduction reports `found` at every listed `tol` and `max_iter` | ✅ | `found` at all 6 settings, recovering `[0.05411231, 0.64513102]`; all 6 were `LOST` before |
| AC2 — regression test carries the exact spline and parameter, hardcoded, and fails against the old implementation | ✅ | `TestNewtonGlobalization`; at the test-only commit 5 tests fail, 132 pass |
| AC3 — residual monotonically non-increasing over the accepted iterates | ✅ | `test_the_residual_never_increases_over_the_accepted_iterates`, which reproduces the old cycle independently: `1.05e-2`, `7.31e-1`, then `1.16`/`0.77` alternating |
| AC4 — sweep over the warped family (dim 1-3, degrees 1-5, 3 and 6 elements, unit scale and offset `1e6`) loses no point with a preimage | ✅ | 60 parametrizations, 2400 queries, 0 lost |
| AC5 — no regression in the accuracy contract | ✅ | 5499 passed / 21 skipped / 3 xfailed; the sweep also asserts every returned residual is within threshold |

## Two things worth a reviewer's attention

**The ticket's family folds.** Its geometry is described as unremarkable, but the warp
`y + 0.15·sin(2π·Σy)` has Jacobian eigenvalue `1 + 2π·0.15·dim·cos(2π·Σy)`, which turns negative for
`dim >= 2`; measured `det J` reaches `-0.56` at `dim 2` and `-1.34` at `dim 3`. The reported bug is
unaffected (that query has a preimage, and the Jacobian there is fine), but AC4 can only ask for *a*
preimage back, not the generating one, and the test says so.

**The line search alone does not close AC4**, which is why the ticket's optional second start became
part of the fix. The sweep contains a second query, `(0.9485, 0.3461)`, that the damped iteration
also loses: from its cell midpoint it descends to `(1, 0.4059)`, the minimum of the residual along
the `u == 1` face, where the only descent direction points out of the box and moving inward raises
the residual — the root sits behind a ridge in another basin. Damped and undamped lose the same 2 of
2400 without the second start; with it, 0.

## Performance

Measured on the sweep, against the undamped iteration this replaces:

| workload | before | after | |
|---|---|---|---|
| queries on the image | 1.441 s | 1.582 s | +10 % |
| queries off the image | 7.807 s | 5.394 s | −31 % |

Off-image queries get faster because a doomed candidate is now abandoned when its line search
exhausts instead of burning the whole iteration budget. Raising the budget to 12 would cost about
twice the undamped baseline on-image, to cover solves whose queries are already found.

## An unrelated defect fixed in passing (own commit, 2ae476c)

`_locate_impl` did not call `_numba_compat.wait_for_jit_warmup`, which every other Layer 2 entry
point over `parallel=True` kernels does. `pantr/__init__.py` compiles on a background thread and
Numba's workqueue layer aborts the **process** on a concurrent parallel call, so a script that
imports pantr and immediately inverts a batch could die. Measured with the new sweep as the first
thing in a process: 4 of 4 runs aborted, serially and under `pytest -n 4` (what `make test` uses);
0 of 4 with the barrier, at unchanged runtime. Pre-existing and reachable from public API — it
stayed hidden because a test that compiles on its first case gives the warmup time to finish, and
every existing inversion test does. `_locate_impl`'s point-independent validation moved to
`_validate_invertible` to stay inside the statement limit; nothing about what is checked changed.

## The adversarial pass found a false "not found" in this PR (own commit, 11f62f2)

Worth reading before the rest: an attack on the derivations found that **the halving budget as
first written shipped the same failure class this ticket exists to fix.**

A strictly monotone degree-5 map — unique preimage, so `-1` is unambiguously wrong — whose
derivative is near-critical at exactly the two points the solver starts from, `σ_min = 1e-4`,
fifteen orders clear of the rank guard. `locate` returned `-1` at library defaults. It needed 11
halvings where 8 were allowed, and 27 configurations of that family missed, needing 11 to 21.

The cause is that `δ = J⁻¹r` grows like `1/σ_min`, so a healthy but ill-conditioned Jacobian
produces a step orders of magnitude longer than the domain it must land in, and the search spent
its budget walking it back. `‖δ‖` is unbounded over legal inputs, so **no fixed budget is
correct** — which is why the fix is the cap, not a bigger number. With it, the requirement across
all 27 configurations collapses from 11–21 to a flat **2**, independent of `‖δ‖` (up to `7e5`
extents) and of `σ_min` across five decades. The witness is now a regression test.

Two of my own derivations were wrong, and are rewritten:

- the coverage formula assumed `‖J⁻¹‖ ~ cond(J)/S`, but `cond(J) ≡ 1` in one dimension, so it was
  blind to precisely the near-critical Jacobian that breaks it — it claimed the witness *was*
  covered;
- the "four doublings of margin" was read off a sweep that loses nothing at budget 2 only because
  another candidate cell rescues the query. 11.5 % of converging solves need more than 2 halvings
  and single solves reach 15 (the depth histogram is identical at budgets 16 and 24, so it has
  stopped rather than saturated). That is candidate-list redundancy, not headroom.

Three further claims were corrected rather than defended: the termination argument invoked a
second-derivative bound a degree-1 map does not have (existence needs only differentiability at
the iterate — the real obstruction is a C⁰ knot line, where a leftward step is accepted only if
the ratio of one-sided derivatives exceeds `1e-4`, and that is now documented as a limitation);
"its point is at a residual minimum" is true in 1-D and false in 2-D+; and rejection at every
step length requires a *constant* projected path, not merely a direction leaving the box. One
more, predating this branch, is corrected too: `_JACOBIAN_RANK_REL_TOL`'s ratio is not invariant
under anisotropic parametric scaling.

The citation for `1e-4` is also corrected: it is attested for *this* rule (decrease tested on
`‖F‖`) by Kelley specifically, not by the Armijo literature at large, which states it for the
squared merit form.

## A defect in this PR's own new code, caught reviewing it (own commit, ffcdef6)

`_nearest_corner_starts` allocated its result with `np.empty_like` and filled it only through
"is this corner nearer than the best so far". Every comparison against `nan` is False, so a mapping
that evaluates to a non-finite value left the buffer unwritten and the function returned
uninitialized memory as a starting guess (observed: coordinates of `2.5e-323`); nothing rejects a
non-finite control point at construction, so it is reachable. The search now starts from a real
corner, which makes "every returned start is a corner of its own cell" hold unconditionally. The
downstream consequence was mild — the iterate is clipped before evaluation — but nondeterministic,
and it wasted the retry the helper exists to provide.

## Checks

`ruff check` · `ruff format --check` · `mypy` (233 files) · `lint-imports` · `pytest` (5501 passed)
all green repo-wide. The docs build passes with `-W` and zero warnings **with the pyvista gallery
disabled**; the full gallery build segfaults in my sandbox for lack of an OpenGL context, and does so
identically at the base commit, so that part is left to CI.

Closes #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
