### PR TITLE
fix(bezier): grade a rational minimize_degree trial in projected space

### DIFF
--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -442,6 +442,15 @@ class Bezier:
         ``tol``.  For vector-valued Bézier, all rank components are
         checked simultaneously.
 
+        For a **rational** Bézier that error is measured on the projected
+        mapping, not on the homogeneous control coefficients, so ``tol`` is a
+        budget on the geometry the caller sees at any coordinate scale.  Two
+        consequences: it is then a quadrature estimate rather than an exact
+        value, accurate to better than 3% of the true relative deviation over
+        degrees 3 to 20 and weight ratios up to 100; and a reduction is refused
+        outright when a weight is not strictly positive on the domain, since the
+        mapping then has a pole and no projected deviation is defined.
+
         Args:
             tol (float | None): Relative tolerance for accepting a degree
                 reduction.  If *None*, uses a default based on machine

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -12,6 +12,12 @@ Reduction is driven by a *reduction operator* :math:`R`, a dense
 reduced control points are ``R @ ctrl``.  The operator is assembled in exact
 rational arithmetic and rounded to ``float64`` once; see
 :func:`_interpolating_reduction_operator` for why.
+
+Errors are measured in the space the caller budgets in.  For a polynomial Bézier that
+is the exact Bernstein-Gram :math:`L^2` norm of the coefficient difference
+(:func:`_squared_l2_norm`); for a rational one it is the deviation of the *projected*
+mapping, estimated on a Gauss-Legendre grid (:func:`_projected_relative_deviation`),
+because a norm over homogeneous coefficients adds a weight to a weighted coordinate.
 """
 
 from __future__ import annotations
@@ -25,7 +31,9 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
+from ..basis._basis_core import _tabulate_Bernstein_basis_1D_serial_core
 from ..bspline._bspline_degree_core import _apply_reduction_operator, _check_bincoeff_envelope
+from ..quad import get_gauss_legendre_1d
 from ._bezier_core import _degree_elevate_bezier_1d_core
 
 if TYPE_CHECKING:
@@ -51,6 +59,21 @@ zero. A threshold at the bare ``eps`` level would spuriously reject such curves;
 ``1e3 * eps`` (``~2.2e-13`` for ``float64``) comfortably accepts genuine
 reductions while still rejecting curves whose true degree cannot be lowered
 without visible geometric error.
+
+**For a rational Bézier the factor keeps this meaning verbatim**, because the error it
+bounds is now the relative deviation of the *projected* mapping (see
+:func:`_projected_relative_deviation`) rather than of the homogeneous coefficients.
+Both are relative and both sit at the unit-roundoff floor for an exactly reducible
+curve, so nothing about "three digits of headroom above round-off" changes -- only the
+space the round-off is measured in, which is the space the caller cares about.
+
+Measured, to check that the projected floor really is a round-off floor and not
+something larger: over exactly-reducible rational nets (base degrees 1, 2, 5 elevated by
+1, 3 and 8; weight ratios 1, 10 and 100; coordinate scales 1 and ``1e6``; 20 random nets
+each), the projected round-trip relative deviation of the first trial never exceeded
+``1.55 * eps``, and every net recovered its base degree at this default. That leaves
+about ``650x`` of headroom, against the ``1e3`` the factor nominally provides -- the
+difference being that the floor is a small multiple of ``eps`` rather than exactly one.
 """
 
 
@@ -446,6 +469,183 @@ def _squared_l2_norm(
     return abs(float(np.sum(c * g_c)))
 
 
+def _projected_quadrature_size(degree: int) -> int:
+    r"""Get the Gauss-Legendre node count that grades a rational reduction in one direction.
+
+    ``2 * degree + 2``.
+
+    **Derivation.** Writing the current homogeneous curve as :math:`(A, w)` and the
+    round-tripped one as :math:`(\tilde A, \tilde w)`, the projected difference is
+
+    .. math::
+
+        \tilde C - C = \frac{\tilde A}{\tilde w} - \frac{A}{w}
+                     = \frac{w \tilde A - \tilde w A}{w\, \tilde w} ,
+
+    so the integrand of :math:`\lVert \tilde C - C \rVert_{L^2}^2` is a *rational*
+    function whose numerator is a polynomial of degree :math:`4p` per direction and
+    whose denominator :math:`(w \tilde w)^2` is a polynomial of the same degree,
+    strictly positive on the closed domain whenever the control weights are (Bernstein
+    positivity plus partition of unity). No Gauss rule integrates that exactly.
+
+    An ``n``-node Gauss-Legendre rule is exact for polynomials of degree ``2n - 1``, so
+    ``n = 2p + 1`` is the smallest rule that integrates the *numerator* exactly, i.e.
+    the smallest rule that would be exact if the weights were constant -- which is
+    precisely the non-rational case, where the measure reduces to the Bernstein-Gram
+    value :func:`_squared_l2_norm` computes. This function adds one node of margin.
+
+    What remains is the departure of :math:`1/(w \tilde w)^2` from a polynomial, which
+    is *not* bounded here. Measured instead, against a 2e5-point reference over a
+    battery of degrees ``p in {3, 6, 12, 20}``, weight ratios ``w_max / w_min`` up to
+    ``1e2``, and coordinate offsets up to ``1e3``: the estimate agreed to five decimal
+    digits at the median and to within 3% in the worst case (``p = 3``, weight ratio
+    ``1e2``). The relative form helps -- the same denominators appear in the reference
+    norm, so part of the quadrature error cancels.
+
+    Args:
+        degree (int): Polynomial degree ``p`` in the direction (``>= 0``).
+
+    Returns:
+        int: Number of Gauss-Legendre nodes to use in that direction.
+    """
+    return 2 * degree + 2
+
+
+@functools.lru_cache(maxsize=64)
+def _bernstein_collocation_1d(degree: int, num_nodes: int) -> npt.NDArray[np.float64]:
+    r"""Return the cached, read-only Bernstein values at the Gauss-Legendre nodes.
+
+    Entry ``[k, i]`` is :math:`B_{i,\text{degree}}(t_k)` with ``t_k`` the ``num_nodes``
+    Gauss-Legendre nodes on :math:`[0, 1]`. Sampling a control net is then one
+    ``tensordot`` per parametric direction, the same contraction pattern
+    :func:`_squared_l2_norm` uses with the Gram matrices.
+
+    The values come from the serial Bernstein kernel rather than the parallel one: the
+    batches here are a few dozen points, where the fork/join overhead dominates, and
+    keeping :func:`_minimize_degree_bezier` clear of ``parallel=True`` kernels means it
+    needs no JIT-warmup barrier.
+
+    Args:
+        degree (int): Polynomial degree of the basis (``>= 0``).
+        num_nodes (int): Number of Gauss-Legendre nodes (``>= 1``).
+
+    Returns:
+        npt.NDArray[np.float64]: Read-only ``(num_nodes, degree + 1)`` array.
+    """
+    nodes = np.ascontiguousarray(get_gauss_legendre_1d(num_nodes, np.float64)[0], np.float64)
+    basis = np.empty((num_nodes, degree + 1), dtype=np.float64)
+    _tabulate_Bernstein_basis_1D_serial_core(np.int32(degree), nodes, basis)
+    basis.flags.writeable = False
+    return basis
+
+
+@functools.lru_cache(maxsize=64)
+def _tensor_gauss_weights(num_nodes: tuple[int, ...]) -> npt.NDArray[np.float64]:
+    """Return the cached, read-only tensor-product Gauss-Legendre weights on the unit cube.
+
+    Args:
+        num_nodes (tuple[int, ...]): Node count per parametric direction.
+
+    Returns:
+        npt.NDArray[np.float64]: Read-only array of shape ``num_nodes``.
+    """
+    weights = np.ones((), dtype=np.float64)
+    for n in num_nodes:
+        weights = np.multiply.outer(weights, get_gauss_legendre_1d(n, np.float64)[1])
+    result = np.ascontiguousarray(weights, dtype=np.float64)
+    result.flags.writeable = False
+    return result
+
+
+def _sample_projected(
+    ctrl: npt.NDArray[np.floating[Any]], num_nodes: tuple[int, ...]
+) -> npt.NDArray[np.float64] | None:
+    """Evaluate a homogeneous control net on the Gauss grid and divide out the weights.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Homogeneous control points shaped
+            ``(*orders, rank + 1)``, the last column the weights.
+        num_nodes (tuple[int, ...]): Node count per parametric direction.
+
+    Returns:
+        npt.NDArray[np.float64] | None: Projected points of shape
+        ``(*num_nodes, rank)``, or *None* if any sampled weight is not strictly
+        positive.
+
+    Note:
+        A non-positive sample alongside a positive one means ``w`` changes sign, hence
+        vanishes, hence the mapping has a pole on the domain. A uniformly non-positive
+        weight field has no pole but is not a NURBS, and is refused on the strictly
+        positive weight convention the rest of the library already requires (knot
+        removal, ``locate`` and ``find_roots`` all state it). The converse does **not**
+        hold: a sign change confined strictly between two nodes is not detected. Ruling
+        that out would take the Bernstein convex-hull test on the control weights, which
+        is deliberately not done here -- see :func:`_projected_relative_deviation`.
+    """
+    values = np.asarray(ctrl, dtype=np.float64)
+    for axis in range(values.ndim - 1):
+        basis = _bernstein_collocation_1d(ctrl.shape[axis] - 1, num_nodes[axis])
+        values = np.asarray(
+            np.moveaxis(np.tensordot(basis, values, axes=([1], [axis])), 0, axis), np.float64
+        )
+
+    weights = values[..., -1:]
+    if not bool(np.all(weights > 0.0)):
+        return None
+    return np.asarray(values[..., :-1] / weights, dtype=np.float64)
+
+
+def _projected_relative_deviation(
+    values: npt.NDArray[np.float64] | None,
+    trial_values: npt.NDArray[np.float64] | None,
+    quad_weights: npt.NDArray[np.float64],
+) -> float:
+    r"""Grade a rational trial reduction by its deviation in *projected* space.
+
+    Returns the quadrature estimate of :math:`\lVert \tilde C - C \rVert_{L^2} /
+    \lVert C \rVert_{L^2}`, the relative deviation of the round-tripped mapping from
+    the current one, both taken after dividing out the weights. This is the quantity a
+    caller of :meth:`~pantr.bezier.Bezier.minimize_degree` budgets: grading the
+    homogeneous coefficients instead compares a weight against a weighted coordinate,
+    which are not the same quantity and, away from unit coordinate scale, not even the
+    same order of magnitude.
+
+    Hypotheses: the weights of both nets are strictly positive at the quadrature nodes
+    (checked by :func:`_sample_projected`, which returns *None* otherwise), and the
+    quadrature resolves the integrand -- see :func:`_projected_quadrature_size` for the
+    node count and what it does and does not guarantee.
+
+    The residual risk this leaves is a trial whose weight function dips through zero
+    strictly *between* nodes: the deviation is then unbounded near the pole, and a rule
+    that steps over it can under-report. Requiring the trial's *control* weights to be
+    positive would exclude it outright, by Bernstein positivity, at the cost of also
+    refusing trials whose weights are individually negative but whose weight function
+    never vanishes. That guard is deliberately not taken: this measure is chosen for
+    being tight, and the case needs a weight sign pattern that survives every node while
+    failing in between.
+
+    Args:
+        values (npt.NDArray[np.float64] | None): Projected points of the current curve.
+        trial_values (npt.NDArray[np.float64] | None): Projected points of the
+            round-tripped trial curve.
+        quad_weights (npt.NDArray[np.float64]): Tensor-product quadrature weights.
+
+    Returns:
+        float: The relative projected deviation, or :data:`math.inf` when it cannot be
+        graded, so that the caller rejects the reduction.
+    """
+    if values is None or trial_values is None:
+        return math.inf
+
+    deviation2 = float(np.sum(quad_weights * np.sum((trial_values - values) ** 2, axis=-1)))
+    reference2 = float(np.sum(quad_weights * np.sum(values**2, axis=-1)))
+
+    deviation = math.sqrt(deviation2)
+    if reference2 > 0.0:
+        deviation /= math.sqrt(reference2)
+    return deviation if math.isfinite(deviation) else math.inf
+
+
 def _degree_reduction_l2_error(bezier: Bezier, decrements: tuple[int, ...]) -> float:
     r"""Compute the exact :math:`L^2` error of a degree reduction.
 
@@ -490,6 +690,64 @@ def _minimize_degree_bezier(
     into a single error measure, so a reduction is accepted only when every
     component is preserved.
 
+    **Rational input is graded in projected space.**  A rational control net holds
+    homogeneous coordinates ``[w x, w y, ..., w]``, and an :math:`L^2` norm taken over
+    all of its columns adds a weight to a weighted coordinate.  Those are different
+    quantities, and at coordinate scale ``s`` they differ in magnitude by ``s``: a
+    weight-carried round-trip deviation is measured as ``O(dw / s)`` relative while the
+    projected deviation it actually causes is ``O(dw)`` relative, so the homogeneous
+    measure under-reports by a factor of order ``s``.  Measured on the degree-6 rational
+    curve of issue #297, one weight nudged by ``1e-6``, grading its first trial
+    reduction:
+
+    ===========  ====================  ====================  =============
+    scale        homogeneous measure   projected deviation   under-report
+    ===========  ====================  ====================  =============
+    ``1``        ``6.01e-9``           ``7.12e-9``           ``1.2x``
+    ``1e3``      ``1.10e-11``          ``7.12e-9``           ``646x``
+    ``1e6``      ``1.10e-14``          ``7.12e-9``           ``6.5e5x``
+    ===========  ====================  ====================  =============
+
+    The projected column is constant, as it must be: scaling every coordinate is a
+    similarity and cannot change a *relative* deviation.  The under-report grows by the
+    full ``1e3`` per decade only once ``s`` dominates, since at ``s ~ 1`` the coordinate
+    and weight columns are still comparable -- the same crossover
+    :func:`~pantr.bspline._bspline_knot_removal._homogeneous_deviation_tolerance`
+    describes for the max-norm case.
+
+    So for a rational Bézier the trial is graded by
+    :func:`_projected_relative_deviation`: both the current and the round-tripped nets
+    are evaluated on a tensor Gauss-Legendre grid, the weights are divided out, and the
+    relative :math:`L^2` deviation of the *mappings* is compared against ``tol``.  Under
+    a uniform scaling both the deviation and the reference norm scale by the same
+    factor, so the verdict is scale invariant -- which is exactly the property the
+    homogeneous measure lacks.  (It is *not* translation invariant, because the
+    reference norm is taken about the origin; neither is the non-rational branch, and
+    that is what "relative" has always meant here.)  Two consequences to be aware of:
+
+    * unlike the non-rational branch, the measure is a **quadrature estimate** rather
+      than an exact value -- the integrand is rational, so no Gauss rule is exact on it.
+      :func:`_projected_quadrature_size` gives the node count, the argument for it, and
+      the measured agreement with a dense reference;
+    * a reduction is **refused** whenever a weight is not strictly positive at a
+      quadrature node, on either net, since the mapping then has a pole on the domain
+      and no projected deviation is defined.  A net that violates this is returned
+      unreduced rather than raising.
+
+    The non-rational branch is untouched and still uses the exact Bernstein-Gram value.
+
+    The alternative -- an :math:`L^2` analogue of Piegl & Tiller Eq. (5.30), bounding
+    the projected deviation by the homogeneous one -- was prototyped and rejected.  The
+    exact identity is ``dC = (dA - C dw) / (w + dw)``, whose numerator is invariant
+    under translating the model; the triangle inequality ``|dA - C dw| <= |dA| +
+    |C| |dw|`` is not, and it discards precisely the cancellation that keeps the true
+    deviation small.  So on geometry that is not centred on the origin the bound is
+    conservative by three to four orders of magnitude: measured median ``790x`` to
+    ``1235x`` at a weight ratio of only 2 and a coordinate offset of ``1e3``.
+    Recentring the bound at the control-net centroid restores that invariance but still
+    leaves ``12x`` to ``85x`` at a weight ratio of ``1e2``, which would silently make
+    ``minimize_degree`` refuse reductions the caller asked for.
+
     Args:
         bezier (~pantr.bezier.Bezier): The Bézier to simplify.
         tol (float | None): Relative tolerance for accepting a degree
@@ -532,6 +790,14 @@ def _minimize_degree_bezier(
     result = ctrl
     changed = False
 
+    # A rational net is graded in projected space, so the trials are sampled on one
+    # tensor Gauss grid sized from the *input* degrees.  Degrees only ever fall, so a
+    # grid fixed up front is never coarser than `_projected_quadrature_size` asks for at
+    # the current degree, and it keeps the collocation cache warm across every trial.
+    num_nodes = tuple(_projected_quadrature_size(p) for p in bezier.degree)
+    quad_weights = _tensor_gauss_weights(num_nodes) if bezier.is_rational else None
+    projected = _sample_projected(result, num_nodes) if bezier.is_rational else None
+
     for dim in range(bezier.dim):
         # Each direction shrinks until a reduction is rejected.
         while result.shape[dim] >= 2:  # noqa: PLR2004
@@ -548,17 +814,25 @@ def _minimize_degree_bezier(
                 dim,
             )
 
-            # Relative round-trip L2 error across all components.
-            diff_norm2 = total_squared_norm(elevated - result)
-            orig_norm2 = total_squared_norm(result)
-            rel_error = math.sqrt(diff_norm2)
-            if orig_norm2 > 0.0:
-                rel_error /= math.sqrt(orig_norm2)
+            if quad_weights is not None:
+                # Relative round-trip deviation of the projected mapping.
+                rel_error = _projected_relative_deviation(
+                    projected, _sample_projected(elevated, num_nodes), quad_weights
+                )
+            else:
+                # Relative round-trip L2 error across all components.
+                diff_norm2 = total_squared_norm(elevated - result)
+                orig_norm2 = total_squared_norm(result)
+                rel_error = math.sqrt(diff_norm2)
+                if orig_norm2 > 0.0:
+                    rel_error /= math.sqrt(orig_norm2)
 
             if rel_error >= tol:
                 break
             result = reduced
             changed = True
+            if quad_weights is not None:
+                projected = _sample_projected(result, num_nodes)
 
     if not changed:
         return BezierCls(ctrl.copy(), is_rational=bezier.is_rational)

--- a/tests/test_degree_reduction.py
+++ b/tests/test_degree_reduction.py
@@ -9,15 +9,30 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._numba_compat import wait_for_jit_warmup
 from pantr.bezier import Bezier
 from pantr.bezier._bezier_degree import (
+    _degree_elevate_bezier,
+    _degree_reduce_bezier,
     _elevation_matrix_exact,
     _interpolating_reduction_operator,
     _l2_reduction_operator,
+    _projected_quadrature_size,
+    _projected_relative_deviation,
+    _sample_projected,
     _squared_l2_norm,
+    _tensor_gauss_weights,
 )
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D, create_uniform_periodic_knots
 from pantr.bspline._bspline_degree_core import _degree_reduce_1d_core
+
+# Several tests here reach `Bezier.evaluate` within milliseconds of the process
+# starting, and it dispatches to a `parallel=True` kernel. Numba's default workqueue
+# layer is not safe against that racing `pantr/__init__.py`'s background warmup thread:
+# the interpreter *aborts* rather than raising. Measured on this file with a warm Numba
+# cache, before this barrier was added: 3 of 4 runs aborted. Same mitigation, and the
+# same reason, as `tests/test_bernstein_underflow.py`.
+wait_for_jit_warmup()
 
 _EPS = float(np.finfo(np.float64).eps)
 
@@ -41,6 +56,18 @@ already interpolates.  Measured over degrees 1 to 20 and every decrement, the
 ratio stays in ``[1.002, 4.547]``, the worst cases being reductions to a
 straight line.  A regression that dropped the constraints, or one that solved
 the wrong system, would leave this window immediately.
+"""
+
+_QUADRATURE_AGREEMENT = 1.0e-2
+"""Admissible relative gap between the projected measure and a dense reference.
+
+The rational integrand of the projected deviation is not integrated exactly by any
+Gauss rule, so the accept/reject measure is an estimate; ``_projected_quadrature_size``
+records that over degrees 3 to 20, weight ratios to ``1e2`` and coordinate offsets to
+``1e3`` it agreed with a 2e5-point reference to five decimal digits at the median and
+to within 3% at worst.  1% bounds the case pinned here (measured 3.0e-6) with a wide
+margin while still catching a rule that has stopped resolving the integrand: dropping
+the node count from ``2p + 2`` to ``p + 1`` moves this case to 1.6e-2, outside the bound.
 """
 
 
@@ -552,6 +579,267 @@ class TestBezierMinimizeDegree:
         assert b_min.degree[0] < b_elev.degree[0]
         pts = np.linspace(0.0, 1.0, 10, dtype=np.float64)
         np.testing.assert_allclose(b_min.evaluate(pts), b.evaluate(pts), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Minimize degree, rational
+# ---------------------------------------------------------------------------
+
+_NUDGED_WEIGHT_NETS: dict[tuple[float, float], list[list[float]]] = {
+    (1.0, 1.0e-6): [
+        [0.0, 0.0, 1.0],
+        [0.09999999999999999, 0.19999999999999998, 0.8666666666666666],
+        [0.22666666666666668, 0.32, 0.7866666666666666],
+        [0.38, 0.36000000000000004, 0.7600007599999999],
+        [0.56, 0.32, 0.7866666666666666],
+        [0.7666666666666666, 0.19999999999999998, 0.8666666666666666],
+        [1.0, 0.0, 1.0],
+    ],
+    (1.0e3, 1.0e-6): [
+        [0.0, 0.0, 1.0],
+        [100.0, 200.0, 0.8666666666666666],
+        [226.66666666666669, 320.0, 0.7866666666666666],
+        [380.0, 360.00000000000006, 0.7600007599999999],
+        [560.0, 320.0, 0.7866666666666666],
+        [766.6666666666666, 200.0, 0.8666666666666666],
+        [1000.0, 0.0, 1.0],
+    ],
+    (1.0e6, 1.0e-6): [
+        [0.0, 0.0, 1.0],
+        [100000.0, 200000.0, 0.8666666666666666],
+        [226666.6666666667, 320000.0, 0.7866666666666666],
+        [380000.0, 360000.00000000006, 0.7600007599999999],
+        [560000.0, 320000.0, 0.7866666666666666],
+        [766666.6666666666, 200000.0, 0.8666666666666666],
+        [1000000.0, 0.0, 1.0],
+    ],
+    (1.0, 1.0e-3): [
+        [0.0, 0.0, 1.0],
+        [0.09999999999999999, 0.19999999999999998, 0.8666666666666666],
+        [0.22666666666666668, 0.32, 0.7866666666666666],
+        [0.38, 0.36000000000000004, 0.7607599999999999],
+        [0.56, 0.32, 0.7866666666666666],
+        [0.7666666666666666, 0.19999999999999998, 0.8666666666666666],
+        [1.0, 0.0, 1.0],
+    ],
+    (1.0e3, 1.0e-3): [
+        [0.0, 0.0, 1.0],
+        [100.0, 200.0, 0.8666666666666666],
+        [226.66666666666669, 320.0, 0.7866666666666666],
+        [380.0, 360.00000000000006, 0.7607599999999999],
+        [560.0, 320.0, 0.7866666666666666],
+        [766.6666666666666, 200.0, 0.8666666666666666],
+        [1000.0, 0.0, 1.0],
+    ],
+    (1.0e6, 1.0e-3): [
+        [0.0, 0.0, 1.0],
+        [100000.0, 200000.0, 0.8666666666666666],
+        [226666.6666666667, 320000.0, 0.7866666666666666],
+        [380000.0, 360000.00000000006, 0.7607599999999999],
+        [560000.0, 320000.0, 0.7866666666666666],
+        [766666.6666666666, 200000.0, 0.8666666666666666],
+        [1000000.0, 0.0, 1.0],
+    ],
+}
+"""Homogeneous control nets of the case in issue #297, keyed by (scale, weight nudge).
+
+Each is the degree-2 rational Bézier through ``(0, 0)``, ``(0.5, 1)``, ``(1, 0)`` with
+weights ``(1, 0.6, 1)``, scaled by ``scale``, elevated to degree 6, and with the middle
+control weight multiplied by ``1 + nudge``.  Elevation is applied *after* scaling, so the
+three scales are not exact multiples of each other in ``float64``; each is written out
+rather than derived, so the triggering data is exactly the data the issue reports.
+
+The perturbation lives entirely in the weight column, which is what makes the case
+diagnostic: a homogeneous norm reads it as ``O(nudge / scale)`` relative while the
+projected deviation it causes is ``O(nudge)`` relative.
+"""
+
+_ELEVATED_ARC_NETS: dict[float, list[list[float]]] = {
+    1.0: [
+        [1.0, 0.0, 1.0],
+        [0.8828427124746191, 0.282842712474619, 0.8828427124746191],
+        [0.7242640687119286, 0.5242640687119285, 0.8242640687119286],
+        [0.5242640687119285, 0.7242640687119286, 0.8242640687119286],
+        [0.282842712474619, 0.8828427124746191, 0.8828427124746191],
+        [0.0, 1.0, 1.0],
+    ],
+    1.0e6: [
+        [1000000.0, 0.0, 1.0],
+        [882842.712474619, 282842.712474619, 0.8828427124746191],
+        [724264.0687119286, 524264.06871192856, 0.8242640687119286],
+        [524264.06871192856, 724264.0687119286, 0.8242640687119286],
+        [282842.712474619, 882842.712474619, 0.8828427124746191],
+        [0.0, 1000000.0, 1.0],
+    ],
+}
+"""Exact quarter circles of radius ``scale``, degree-elevated from 2 to 5.
+
+Reducing these back to degree 2 is exact up to round-off, so they are the curves the
+default tolerance must keep accepting.
+"""
+
+
+def _projected_deviation(source: Bezier, reduced: Bezier) -> tuple[float, float]:
+    """Measure a reduction's deviation and the curve's extent, both in projected space.
+
+    Args:
+        source (Bezier): The Bézier that was minimized.
+        reduced (Bezier): What ``minimize_degree`` returned.
+
+    Returns:
+        tuple[float, float]: The largest projected deviation over a dense parameter
+        sample, and the largest projected magnitude of ``source`` over the same sample.
+    """
+    pts = np.linspace(0.0, 1.0, 801, dtype=np.float64)
+    values = source.evaluate(pts)
+    return (
+        float(np.linalg.norm(reduced.evaluate(pts) - values, axis=1).max()),
+        float(np.linalg.norm(values, axis=1).max()),
+    )
+
+
+class TestBezierMinimizeDegreeRational:
+    """A rational round-trip is graded in projected space, not in homogeneous one (#297)."""
+
+    @pytest.mark.parametrize(("scale", "tol"), [(1.0, 1.0e-6), (1.0e3, 1.0e-9), (1.0e6, 1.0e-12)])
+    def test_accepted_reduction_stays_within_the_requested_budget(
+        self, scale: float, tol: float
+    ) -> None:
+        """No accepted reduction exceeds ``tol`` times the extent of the geometry.
+
+        This is the case reported in issue #297.  Before the fix the reduction from
+        degree 6 to degree 2 was accepted at all three scales, overshooting the budget
+        by a factor of 61 at ``scale = 1e3`` and 6.1e4 at ``scale = 1e6``.
+        """
+        source = Bezier(np.array(_NUDGED_WEIGHT_NETS[scale, 1.0e-6]), is_rational=True)
+        deviation, span = _projected_deviation(source, source.minimize_degree(tol=tol))
+        assert deviation <= tol * span
+
+    def test_reduction_within_budget_is_still_accepted(self) -> None:
+        """A reduction the caller's budget does allow is not refused by the new measure."""
+        source = Bezier(np.array(_NUDGED_WEIGHT_NETS[1.0, 1.0e-6]), is_rational=True)
+        assert source.minimize_degree(tol=1.0e-6).degree == (2,)
+
+    @pytest.mark.parametrize("tol", [1.0e-6, 1.0e-4])
+    def test_verdict_is_scale_invariant(self, tol: float) -> None:
+        """The same geometry written at three coordinate scales gets the same verdict.
+
+        Scaling every coordinate is a similarity, so the *relative* deviation of a
+        reduction is unchanged by it and the accept/reject verdict must be too.  The
+        homogeneous measure is not scale invariant: at ``tol = 1e-6`` it refused the
+        reduction at scale 1 and accepted it at scale 1e3 and 1e6.
+        """
+        degrees = {
+            Bezier(np.array(_NUDGED_WEIGHT_NETS[scale, 1.0e-3]), is_rational=True)
+            .minimize_degree(tol=tol)
+            .degree
+            for scale in (1.0, 1.0e3, 1.0e6)
+        }
+        assert len(degrees) == 1
+
+    def test_weight_carried_deviation_is_refused_at_large_coordinate_scale(self) -> None:
+        """A weight perturbation invisible to the homogeneous measure is now caught.
+
+        At ``scale = 1e6`` the first trial's homogeneous relative error is 1.1e-11
+        against a true projected 7.1e-6, so every trial cleared a ``1e-6`` budget and
+        the accepted degree 6 to 2 reduction moved the curve by 4.9e-5 relative.
+        """
+        source = Bezier(np.array(_NUDGED_WEIGHT_NETS[1.0e6, 1.0e-3]), is_rational=True)
+        assert source.minimize_degree(tol=1.0e-6).degree == (6,)
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e6])
+    def test_exactly_reducible_curve_still_reduces_at_the_default_tolerance(
+        self, scale: float
+    ) -> None:
+        """An elevated rational curve is recovered by the default tolerance.
+
+        The default is ``1e3 * eps`` on a *relative* error, and the projected round-trip
+        error of an exactly reducible net sits at the round-off floor just as the
+        homogeneous one does, so the default keeps its meaning.
+        """
+        source = Bezier(np.array(_ELEVATED_ARC_NETS[scale]), is_rational=True)
+        assert source.degree == (5,)
+        assert source.minimize_degree().degree == (2,)
+
+    def test_non_rational_measure_is_unchanged(self) -> None:
+        """The same net read as non-rational keeps the exact Bernstein-Gram verdict.
+
+        The weight column is then an ordinary coordinate, so the round-trip error is
+        1.1e-14 relative and a ``1e-12`` budget accepts the reduction.  The fix must not
+        tighten this path.
+        """
+        net = np.array(_NUDGED_WEIGHT_NETS[1.0e6, 1.0e-6])
+        assert Bezier(net, is_rational=False).minimize_degree(tol=1.0e-12).degree == (2,)
+
+    def test_quadrature_measure_agrees_with_a_dense_reference(self) -> None:
+        """The Gauss estimate of the projected deviation matches a dense sample.
+
+        The integrand is rational, so the rule is not exact and the measure is an
+        estimate; this pins how good an estimate.  See
+        :func:`~pantr.bezier._bezier_degree._projected_quadrature_size`.
+        """
+        source = Bezier(np.array(_NUDGED_WEIGHT_NETS[1.0e6, 1.0e-3]), is_rational=True)
+        num_nodes = tuple(_projected_quadrature_size(p) for p in source.degree)
+        trial = _degree_elevate_bezier(_degree_reduce_bezier(source, (1,)), (1,)).control_points
+        estimate = _projected_relative_deviation(
+            _sample_projected(source.control_points, num_nodes),
+            _sample_projected(trial, num_nodes),
+            _tensor_gauss_weights(num_nodes),
+        )
+
+        pts = np.linspace(0.0, 1.0, 200001, dtype=np.float64)
+        values = source.evaluate(pts)
+        difference = Bezier(trial, is_rational=True).evaluate(pts) - values
+        reference = math.sqrt(float(np.sum(difference**2)) / float(np.sum(values**2)))
+
+        assert estimate == pytest.approx(reference, rel=_QUADRATURE_AGREEMENT)
+
+    def test_weight_sign_change_refuses_every_reduction(self) -> None:
+        """A weight function that changes sign has a pole, so nothing reduces.
+
+        Asserting the sampler's verdict as well as the degree is what keeps this from
+        passing for the wrong reason: merely zeroing a control weight leaves ``w(t)``
+        positive everywhere (Bernstein positivity), and the reduction is then refused
+        because the geometry genuinely changed, not because the measure is undefined.
+        A weight of ``-3`` drives ``min w(t)`` to ``-0.46``.
+        """
+        net = np.array(_ELEVATED_ARC_NETS[1.0])
+        net[2, -1] = -3.0
+        num_nodes = tuple(_projected_quadrature_size(p) for p in (5,))
+        assert _sample_projected(net, num_nodes) is None
+        assert Bezier(net, is_rational=True).minimize_degree().degree == (5,)
+
+    def test_two_dimensional_patch_reduces_only_the_redundant_direction(self) -> None:
+        """A rational patch elevated in one direction is reduced in that one alone.
+
+        Sampling a patch contracts the collocation matrix along every parametric axis in
+        turn, which a curve exercises only once; a mistake in that loop would be
+        invisible in the 1D tests.
+        """
+        root_half = 1.0 / math.sqrt(2.0)
+        arc = np.array([[1.0, 0.0, 1.0], [root_half, root_half, root_half], [0.0, 1.0, 1.0]])
+        # Extrude the quarter circle linearly along a third coordinate: the surface is
+        # genuinely quadratic in direction 1 and genuinely linear in direction 0.
+        net = np.stack(
+            [
+                np.column_stack([arc[:, :2], np.zeros(3), arc[:, 2]]),
+                np.column_stack([arc[:, :2], arc[:, 2], arc[:, 2]]),
+            ]
+        )
+        patch = Bezier(net, is_rational=True).elevate_degree((3, 0))
+        assert patch.degree == (4, 2)
+        assert patch.minimize_degree().degree == (1, 2)
+
+    def test_float32_rational_keeps_its_dtype(self) -> None:
+        """A float32 rational Bézier reduces and stays float32.
+
+        The measure is computed in float64 regardless, so what is checked here is that
+        the sampling path accepts a float32 net and does not promote the result.
+        """
+        source = Bezier(np.array(_ELEVATED_ARC_NETS[1.0], dtype=np.float32), is_rational=True)
+        reduced = source.minimize_degree()
+        assert reduced.degree == (2,)
+        assert reduced.control_points.dtype == np.float32
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`Bezier.minimize_degree` documents `tol` as a **relative** budget on the round-trip
degree-reduction error. For a rational Bézier the control net holds homogeneous coordinates
`[w x, w y, …, w]`, and the accept/reject measure took an L2 norm over **every** column, weight
column included. A weight and a weighted coordinate are not the same quantity, so the graded
error was not the error the caller budgets.

The rational branch now grades the deviation of the **projected** mapping. Both the current and
the round-tripped nets are sampled on one tensor Gauss–Legendre grid of `2p + 2` nodes per
direction, through a cached Bernstein collocation matrix, and the relative L2 deviation of the
mappings is compared against `tol`. The non-rational branch is untouched.

## One number in the ticket is wrong

The ticket states the over-budget ratio grows as `scale²`. It does not. The table it prints
varies `scale` ×1e3 **and** `tol` ÷1e3 per row, so the ratio it shows is driven entirely by
`tol` — the projected relative deviation is `6.135e-8` at every scale. Holding `dw` and `tol`
fixed and varying scale alone, on the first trial reduction:

| scale | homogeneous measure | projected deviation | under-report |
|---|---|---|---|
| 1 | 6.01e-9 | 7.12e-9 | 1.2× |
| 1e3 | 1.10e-11 | 7.12e-9 | 646× |
| 1e6 | 1.10e-14 | 7.12e-9 | 6.5e5× |

The under-report is **∝ scale, not scale²**. The ticket's derivation compares an *absolute*
projected deviation `O(dw·s)` against a *relative* measured error `O(dw/s)`; relative-to-relative
(or absolute-to-absolute) both give `s`. The defect, its mechanism and its severity are exactly
as reported — only the exponent is off.

## Why sampling rather than a derived bound

The ticket admits two routes. Route 2, an L2 analogue of Piegl & Tiller Eq. (5.30), was
prototyped and rejected on measurement. The exact identity is `dC = (dA − C dw) / (w + dw)`,
whose numerator is invariant under translating the model; the triangle inequality
`|dA − C dw| ≤ |dA| + |C||dw|` is not, and it discards precisely the cancellation that keeps the
true deviation small. Median conservatism of the bound, over 40 random nets per cell:

| | weight ratio 1 | ratio 2 | ratio 10 | ratio 1e2 |
|---|---|---|---|---|
| centred on the origin | 1.00× | 1.6–2.3× | 5–12× | 13–∞× |
| offset by 1e3 | 1.00× | **684–1235×** | **3.3e3–1.6e4×** | **2e4–∞×** |
| recentred bound, offset 1e3 | 1.00× | 1.8–2.4× | 4–14× | 12–85×, ∞ from p = 12 |

Each cell is the median over 40 random nets, spanning degrees 3, 6, 12 and 20; `∞` is where a
trial's control weights go non-positive and the bound refuses the reduction outright.

Recentring at the control-net centroid restores translation invariance but still leaves 12–85×
once weights spread, which would silently make `minimize_degree` refuse reductions the caller
asked for. The sampled measure is 1.00000× at the median and 1.03× at worst over the same sweep,
and costs ~2–4× on the rational path only (27 µs/trial against a 173 µs whole call for a
degree-12 curve; 234 µs against 1301 µs for a (6,6,6) patch). It uses the **serial** Bernstein
kernel, so `minimize_degree` still reaches no `parallel=True` kernel and needs no JIT-warmup
barrier.

The cost is honesty about exactness: the integrand is rational, so no Gauss rule is exact on it
and the measure is an **estimate**. `_projected_quadrature_size` carries the derivation of the
node count, states what it does *not* bound, and records the measured agreement.

## Acceptance criteria

- **AC1 — no accepted reduction exceeds the requested relative budget, at every listed scale.**
  VERIFIED. The ticket's script now reports `6→2` at scale 1 (deviation 6.13e-8, budget 1.0e-6)
  and refuses the reduction at 1e3 and 1e6. Pinned by
  `TestBezierMinimizeDegreeRational::test_accepted_reduction_stays_within_the_requested_budget`
  (3 parametrizations).
- **AC2 — a regression test carries the exact case, hardcoded, and fails against the current
  implementation.** VERIFIED. `_NUDGED_WEIGHT_NETS` holds the six nets as float literals rather
  than deriving them (elevation is applied after scaling, so the three scales are *not* exact
  multiples in float64). With the fix disabled, 4 of the new tests fail, including 2 of the 3
  AC1 parametrizations.
- **AC3 — non-rational behaviour is bit-unchanged; existing degree tests pass unmodified.**
  VERIFIED bitwise, not by inspection: 767 non-rational cases (float64 and float32, degrees 1–21,
  ranks 1–4, random / degree-elevated / 1e6-scaled, 1D through 3D nets, `tol ∈ {None, 1e-12,
  1e-6, 1e-2, 0, −1}`) produce byte-identical control points before and after. No existing test
  was modified.
- **AC4 — the `tol=None` default is re-derived or documented for a rational curve.** VERIFIED.
  `_AUTO_REDUCTION_TOL_FACTOR`'s docstring now states that the factor keeps its meaning verbatim,
  because the error it bounds is still relative and still sits at the unit-roundoff floor — only
  the space changes. Measured over exactly-reducible rational nets (base degrees 1, 2, 5 elevated
  by 1, 3 and 8; weight ratios 1, 10, 100; scales 1 and 1e6; 20 nets each) the projected
  round-trip floor never exceeded `1.55 · eps`, leaving ~650× of headroom, and every net
  recovered its base degree at the default.
- **AC5 — the chosen bound's derivation is in the docstring, with its hypotheses.** VERIFIED.
  `_projected_quadrature_size` derives the node count from the degree of the rational integrand
  and says plainly what is measured rather than bounded; `_projected_relative_deviation` states
  its hypotheses (strictly positive weights at the nodes, quadrature resolves the integrand) and
  the residual risk it accepts; `_minimize_degree_bezier` records the mechanism, the numbers, and
  why the Eq. (5.30) route was rejected.

## Non-goals respected

The greedy direction-by-direction strategy, the non-rational error measure, and
`_homogeneous_deviation_tolerance` are all untouched.

## A pre-existing crash met on the way

`tests/test_degree_reduction.py` **aborts the interpreter** when run on its own with a warm Numba
cache: `Bezier.evaluate` dispatches to a `parallel=True` kernel milliseconds into the process and
races `pantr/__init__.py`'s background warmup thread. Measured at the parent commit `d68f8b4`,
with no changes applied: 3 of 4 runs aborted. This PR adds the documented mitigation —
`wait_for_jit_warmup()` at the top of that test module, as `tests/test_bernstein_underflow.py`
already does — and 4 of 4 runs then pass.

That is a mitigation, not the fix. The root cause is that `Bezier.evaluate` is an entry point
over `parallel=True` kernels with no warmup barrier, and it is not the only one; the barrier
exists at 4 sites in the library. Deliberately **not** fixed here: it sits outside this ticket's
files, on the library's hottest path, and one site would be a symptom fix. Filed separately on
request.

## Checks

`ruff check` · `ruff format --check` · `mypy` (233 files) · `lint-imports` · `pytest` (5654
passed, 21 skipped, 3 xfailed) · `pytest -n auto` (same) · coverage 96% total, `_bezier_degree.py`
98% with no new uncovered lines · docs build clean.

The docs build passes in full locally, pyvista gallery included, matching the CI job.

Closes #297
