### PR TITLE
fix(cad): refuse two pieces that do not meet where join fuses them

### DIFF
--- a/src/pantr/cad/_join.py
+++ b/src/pantr/cad/_join.py
@@ -5,12 +5,41 @@ Provides :func:`join` for C0-concatenation of B-splines.
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
+from ..tolerance import get_conservative
 from ._compat import _remap_bspline, make_compat
 from ._validation import _promote_to_rational
+
+
+class _ColumnGroup(NamedTuple):
+    """One group of control-point columns that share a physical dimension.
+
+    A rational control point carries homogeneous coordinates, whose units are length times
+    weight, beside a dimensionless weight.  Grading both against one magnitude makes the
+    verdict depend on where the model sits, so each group is graded against its own.
+
+    Attributes:
+        name (str): What the group holds, as the error message names it.
+        columns (slice): The columns of a control-point array the group covers.
+    """
+
+    name: str
+    columns: slice
+
+
+_EUCLIDEAN_COLUMNS = (_ColumnGroup("coordinate", slice(None)),)
+"""tuple[_ColumnGroup, ...]: Column groups of a non-rational row -- all coordinates."""
+
+_HOMOGENEOUS_COLUMNS = (
+    _ColumnGroup("coordinate", slice(0, -1)),
+    _ColumnGroup("weight", slice(-1, None)),
+)
+"""tuple[_ColumnGroup, ...]: Column groups of a rational row -- coordinates, then weight."""
 
 
 def _prepare_for_join(
@@ -76,6 +105,164 @@ def _prepare_for_join(
     return b1, b2, is_rational
 
 
+def _verify_shared_boundary(
+    row1: npt.NDArray[np.float32 | np.float64],
+    row2: npt.NDArray[np.float32 | np.float64],
+    axis: int,
+    is_rational: bool,
+) -> None:
+    """Verify that the two control rows meeting at the junction agree, before averaging them.
+
+    The two rows are not independent data: they are two readings of the same shared face,
+    and ``_concatenate_along_axis`` fuses them by averaging.  When they agree the
+    average is that same row and the join is exact; when they do not, it is a new row
+    belonging to neither input, and the result misses both by *half the gap* -- an error
+    that grows with the mistake rather than staying near roundoff.  Refusing is the same
+    verdict :func:`~pantr.cad.create_coons_surface` and
+    :func:`~pantr.cad.create_coons_volume` reach on the same class of input.
+
+    Both rows are compared in full, not only at the corners of the shared face.  Two
+    patches meeting exactly at both ends of the seam and disagreeing in between produce a
+    result that misses them along the whole interior of it, so the corners are necessary
+    but not sufficient.  By this point ``_prepare_for_join`` has made the non-join axes
+    compatible, so the two rows span the same space, where a spline is determined by its
+    control points; comparing those is therefore an exact comparison of the two boundary
+    patches and needs no sampling.
+
+    The tolerance is ``_verify_corners_2d``'s tier -- its justification lives there and is
+    not restated -- times the largest absolute value over the two rows compared, applied
+    to what is graded here, which is a control-point coefficient rather than a point on a
+    curve.
+
+    **Why that magnitude.**  Not because a genuinely shared seam arrives bitwise equal;
+    that is true only when one side is refined and the other left alone.  When each input
+    carries its own interior knots on a non-join axis -- two surfaces meeting at a seam,
+    each with its own transverse knot vector, which is the ordinary case -- ``make_compat``
+    refines *both*, by different operator sequences, and the readings differ.  Every step
+    between the caller's data and this comparison (rational promotion, join-axis
+    elevation, which leaves the clamped row fixed, and non-join-axis elevation and
+    insertion) is a convex combination, so its absolute rounding error is bounded by
+    ``c * eps * max|coefficient|`` with ``max|coefficient|`` non-increasing under convex
+    combination.  The floor is therefore ``O(eps) * scale``, and measured it is **0.5 to
+    3.3 ulps** of ``scale`` -- flat in the number of insertions, since knot insertion is
+    convex and the two sides' errors are correlated rather than independent -- across
+    degrees 2 to 5 and magnitudes ``1e-9`` to ``1e15``.  Allowing a few ulps of build slack
+    for FMA, vector width and libm, ``16 * eps * scale`` covers it and the conservative
+    tier clears that by a further factor of 250.  That margin is the tier's own robustness
+    reading, not an accident: the slack is for seam data the caller *computed* rather than
+    copied -- a transform, an intersection, a reparametrization -- and is sized to catch
+    pieces given in the wrong place or the wrong orientation, which miss by a fraction of
+    the model rather than by epsilons.
+
+    This is also what justifies the ``* scale`` multiplier twice over: ``max|row|`` is both
+    the magnitude that transports ``eps`` into the compared space (verified proportional
+    over 24 decades) and, by the convex hull below, the geometric magnitude it maps onto.
+
+    **The scale is the seam's, not the model's**, since the two rows are the whole of what
+    is compared.  That is never looser than the Coons rule, whose population spans the
+    whole skeleton, because the seam is part of the model.  It is stricter, and the
+    contract it puts on the caller is worth stating: *the seam must be supplied to within
+    the tier times its own magnitude, not the model's*.  A seam near the origin on a large
+    model, whose coordinates came out of a model-scale chain and so carry model-scale
+    absolute error, is refused.  Erring that way is deliberate; it is the direction that
+    reports rather than the direction that accepts.
+
+    **Each column group is graded against its own magnitude.**  A rational row carries
+    homogeneous coordinates, in units of length times weight, beside a dimensionless
+    weight.  One max over the row would grade the weight against a threshold proportional
+    to the model's *length*, which is dimensionally wrong and breaks scale invariance:
+    sending ``x -> lambda*x`` scales the coordinates and leaves the weights alone.
+    Measured on a seam containing a control point at the origin, the accepted geometric
+    error then grows linearly with coordinate magnitude, from 0.12 times the tier at
+    magnitude 1 to **1.2e7 times the tier at 1e8**, while the non-rational control stays
+    flat at 0.50 at every magnitude.  Grading the coordinate columns against
+    ``max|X|`` and the weight column against ``max|w|`` restores it: under
+    ``x -> lambda*x`` both group scales and both group gaps carry ``lambda``, and under a
+    global weight rescale ``w -> mu*w`` the homogeneous coordinates ``X = w*x`` carry
+    ``mu`` alongside the weights, so both groups carry it too.  It does not disarm the
+    check: a *one-sided* weight rescale still leaves ``gap_w = (mu - 1)*w`` against
+    ``tier * max(w, mu*w)`` and is still refused.  The weight column's own roundoff floor
+    against ``max|w|`` is measured at ``<= 3.2 * eps``, independent of magnitude, degree
+    and refinement, so the tier clears it by about 1290.
+
+    The tier is evaluated at the **coarser of the two inputs' precisions**, not at
+    float64, because pantr's B-spline layer accepts float32 as well.  If the true shared
+    face is ``F``, the two stored readings satisfy ``|row_d - F| <= 0.5 * eps_d * |F|``, so
+    for a genuinely shared face ``|row1 - row2| <= 0.5 * (eps_1 + eps_2) * scale``, which
+    is about ``0.5 * eps_coarse * scale``.  That is a hard floor on any achievable
+    agreement: any tolerance below it refuses a perfect seam.  The tier clears it by 8192.
+    Taking the *promoted* type instead would be exactly backwards, missing the floor by a
+    factor of ``5.4e8`` for a mixed pair.  The consequence is worth stating plainly, since
+    "the same tier as the Coons path" reads as "the same strictness" and it is not: at
+    float32 the tier is ``4.88e-4`` relative, so a float32 join accepts a seam gap of
+    ``1e-5`` of the seam scale and refuses ``1e-3``.  It still catches what the check exists
+    for; it does not catch a small displacement error that float64 would refuse.  The rule
+    also grades by *container* rather than by provenance, so float32-resolution data
+    already copied into a float64 array is graded at float64.
+
+    For non-rational inputs the basis is non-negative and sums to one -- and a tensor
+    product of non-negative partitions of unity is one -- so the largest control-point gap
+    bounds the largest gap between the two boundary patches themselves: the number
+    reported is then a distance in space.  Measured over 400 random pairs the ratio
+    saturates at exactly 1.  For rational inputs it is not: the comparison is of
+    **homogeneous** control points, which is what the average combines, and turning that
+    into a distance would need a lower bound on the weights that this function does not
+    compute; measured, the ratio reaches ``9e4`` at weights of 0.01.  Comparing them
+    homogeneously is still the right test -- two rows that project to the same points
+    under different weights average to a row whose weights are neither input's, so the
+    curve on both sides of the seam is not the curve either input described -- but the
+    reported gap is then a coefficient gap.
+
+    One consequence of comparing coefficients: what is required is that the two boundary
+    patches agree **as parametrized**, which is strictly stronger than agreeing as point
+    sets.  That is the right condition for a join, whose result has to be one spline, but
+    it means two seams tracing the same curve at different speeds are refused.
+
+    Args:
+        row1 (npt.NDArray[np.float32 | np.float64]): The first B-spline's control row at
+            the end of the join axis, of shape ``(*shared_face_shape, rank)``.
+        row2 (npt.NDArray[np.float32 | np.float64]): The second B-spline's control row at
+            the start of the join axis, of the same shape.
+        axis (int): Join axis, named in the message so a caller can tell which seam failed.
+        is_rational (bool): Whether the rows are homogeneous, i.e. whether the trailing
+            column is a weight and has to be graded against its own magnitude.
+
+    Raises:
+        ValueError: If the two rows disagree anywhere on the shared face, in either column
+            group, by more than that group's tolerance.
+    """
+    coarser = max(row1.dtype, row2.dtype, key=lambda d: float(np.finfo(d).eps))
+    tier = get_conservative(coarser)
+    groups = _HOMOGENEOUS_COLUMNS if is_rational else _EUCLIDEAN_COLUMNS
+
+    # Coordinates first: a seam given in the wrong place fails there, and it is the more
+    # informative half to report when both groups are out.
+    for group in groups:
+        left, right = row1[..., group.columns], row2[..., group.columns]
+        # No floor: a group whose two halves are all zero has no scale, and is also
+        # bitwise equal, so a zero tolerance is the right answer there rather than a
+        # hazard.
+        scale = max(float(np.abs(left).max()), float(np.abs(right).max()))
+        tol = tier * scale
+        gaps = np.abs(left - right)
+        gap = float(gaps.max())
+        if gap <= tol:
+            continue
+
+        # Report the control point that disagrees most, so the gap named is the gap
+        # compared.  The whole point is printed even though one group decided the verdict.
+        per_point = gaps.max(axis=-1)
+        index = np.unravel_index(int(np.argmax(per_point)), per_point.shape)
+        # A curve's shared face is a single control point, whose index is the empty tuple:
+        # printing it would read like a defect rather than like a location.
+        where = f" at index {tuple(int(i) for i in index)}" if index else ""
+        raise ValueError(
+            f"Shared boundary mismatch on axis {axis}{where}: "
+            f"the first B-spline gives {row1[index]}, the second gives {row2[index]} "
+            f"(gap {gap:.3e}, above {tol:.3e} at boundary {group.name} scale {scale:.3e})."
+        )
+
+
 def _concatenate_along_axis(
     b1: Bspline,
     b2: Bspline,
@@ -84,8 +271,8 @@ def _concatenate_along_axis(
 ) -> Bspline:
     """Concatenate two prepared B-splines along an axis.
 
-    Averages the shared boundary control points, merges knot vectors,
-    and builds the result.
+    Verifies that the two shared boundary control rows agree, averages them, merges knot
+    vectors, and builds the result.
 
     Args:
         b1: First B-spline (left side).
@@ -95,6 +282,10 @@ def _concatenate_along_axis(
 
     Returns:
         Bspline: The concatenated B-spline.
+
+    Raises:
+        ValueError: If the two shared boundary control rows disagree, as
+            ``_verify_shared_boundary`` grades it.
     """
     dim = b1.dim
     p = b1.degree[axis]
@@ -115,7 +306,14 @@ def _concatenate_along_axis(
 
     cp_left = cp1[tuple(idx_left)]
     cp_right = cp2[tuple(idx_right)]
-    cp_mid = (cp1[tuple(idx_b1_last)] + cp2[tuple(idx_b2_first)]) / 2.0
+
+    row1 = cp1[tuple(idx_b1_last)]
+    row2 = cp2[tuple(idx_b2_first)]
+    _verify_shared_boundary(row1, row2, axis, is_rational)
+    # Exact when the two rows agree, and they are known to by now: (x + x) / 2 returns x
+    # for every finite x whose double does not overflow.  Averaging rather than picking a
+    # side keeps the result symmetric in its two inputs.
+    cp_mid = (row1 + row2) / 2.0
 
     idx_expand: list[int | slice | None] = [slice(None)] * ndim
     idx_expand[axis] = np.newaxis
@@ -155,6 +353,16 @@ def join(bspline1: Bspline, bspline2: Bspline, axis: int) -> Bspline:
     Optionally, knots are removed at the junction to recover higher
     smoothness when the geometry permits it.
 
+    **The two inputs must already meet.**  The face where they join is not independent
+    data: ``bspline1``'s boundary there and ``bspline2``'s are two readings of the same
+    thing, and averaging them is exact only because they agree.  Pieces that do not meet
+    are refused rather than reconciled, since the average of two disagreeing rows lies on
+    neither input and the result would then pass through neither, missing each by half
+    the gap.  For rational inputs -- including a rational joined to a polynomial, which is
+    promoted first -- agreement is required of the **homogeneous** control points, weights
+    included, so two boundaries that describe the same points of space under different
+    weights are refused too.
+
     Args:
         bspline1: First B-spline (left side of the join).
         bspline2: Second B-spline (right side of the join).
@@ -166,6 +374,18 @@ def join(bspline1: Bspline, bspline2: Bspline, axis: int) -> Bspline:
     Raises:
         ValueError: If the inputs have different parametric dimensions.
         ValueError: If *axis* is out of range.
+        ValueError: If the two inputs disagree anywhere on the face they are joined
+            along, by more than ``4096 * eps`` times the largest absolute control-point
+            value over the two boundary rows compared. This is
+            :func:`create_coons_surface`'s tier, justified in ``_verify_corners_2d``, with
+            two differences that follow from what is graded here and are derived in
+            ``_verify_shared_boundary``: ``eps`` is that of the coarser of the two inputs'
+            **own precisions** rather than always float64, so a float32 seam is graded at
+            float32; and the scale is taken over the **seam** rather than over the whole
+            boundary skeleton, so a seam must agree to within the tier times its own
+            magnitude, not the model's. For a rational join the homogeneous coordinates
+            and the weights are graded against their own magnitudes separately, since they
+            do not share a physical dimension.
     """
     dim = bspline1.dim
     if dim != bspline2.dim:

--- a/src/pantr/cad/_join.py
+++ b/src/pantr/cad/_join.py
@@ -123,11 +123,13 @@ def _concatenate_along_axis(
 
     new_cp = np.concatenate([cp_left, cp_mid_expanded, cp_right], axis=axis)
 
-    # Merge knot vectors
+    # Merge knot vectors.  The junction knots take the incoming knots' dtype: built from a
+    # Python float they would be float64, and concatenating would promote a float32 knot
+    # vector while the control points stayed float32, which BsplineSpace1D refuses.
     u_junction = float(b1.space.spaces[axis].domain[1])
     kl = b1.space.spaces[axis].knots[: -p - 1]
     kr = b2.space.spaces[axis].knots[p + 1 :]
-    kc = np.full(p, u_junction)
+    kc = np.full(p, u_junction, dtype=kl.dtype)
     new_knots = np.concatenate([kl, kc, kr])
 
     spaces = list(b1.space.spaces)

--- a/tests/test_cad_join.py
+++ b/tests/test_cad_join.py
@@ -2,11 +2,53 @@
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy import typing as npt
+from numpy.testing import assert_allclose, assert_array_equal
 
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.cad import create_bilinear, create_line, join
+from pantr.tolerance import get_conservative
+
+
+def _bezier_patch(control_points: npt.NDArray[np.float64], degree_u: int, degree_v: int) -> Bspline:
+    """Build a single-Bezier-span B-spline surface of the given bidegree on ``[0, 1]^2``.
+
+    ``create_bilinear`` only reaches bidegree ``(1, 1)``, whose shared boundary row has
+    no interior: every one of its control points is a corner, so it cannot exhibit a
+    disagreement that a corner-only check would miss.
+
+    Args:
+        control_points (npt.NDArray[np.float64]): Shape ``(degree_u + 1, degree_v + 1, 3)``.
+        degree_u (int): Degree in the first parametric direction.
+        degree_v (int): Degree in the second.
+
+    Returns:
+        Bspline: A clamped, non-rational surface on ``[0, 1]^2``.
+    """
+    spaces = [
+        BsplineSpace1D(np.array([0.0] * (d + 1) + [1.0] * (d + 1)), d) for d in (degree_u, degree_v)
+    ]
+    return Bspline(BsplineSpace(spaces), np.asarray(control_points, dtype=np.float64))
+
+
+def _rational_curve(control_points: npt.NDArray[np.float64], degree: int) -> Bspline:
+    """Build a clamped rational B-spline curve from homogeneous control points.
+
+    Args:
+        control_points (npt.NDArray[np.float64]): Shape ``(degree + 1, rank + 1)``, the
+            trailing column being the weight.
+        degree (int): Polynomial degree.
+
+    Returns:
+        Bspline: A clamped rational curve on ``[0, 1]``.
+    """
+    knots = np.array([0.0] * (degree + 1) + [1.0] * (degree + 1))
+    space = BsplineSpace([BsplineSpace1D(knots, degree)])
+    return Bspline(space, np.asarray(control_points, dtype=np.float64), is_rational=True)
 
 
 class TestJoinCurves:
@@ -105,3 +147,311 @@ class TestJoinErrors:
         c2 = create_line([1, 0, 0], [2, 0, 0])
         with pytest.raises(ValueError, match="axis"):
             join(c1, c2, axis=1)
+
+
+class TestJoinSharedBoundaryConsistency:
+    """The two control rows meeting at the junction are not independent data.
+
+    ``join`` fuses two patches by averaging the control row at the end of the first with
+    the one at the start of the second.  When those rows agree the average is that same
+    row and the join is exact; when they do not, the average is a new row belonging to
+    neither input, and the result misses both by half the gap -- silently, and by an
+    amount that grows with the mistake rather than staying near roundoff (pantr issue
+    310).  ``create_coons_surface`` and ``create_coons_volume`` have always refused the
+    same class of input.
+
+    The tolerance is the Coons path's: ``get_conservative(float64)`` times the largest
+    absolute coordinate over the two rows being compared.  Its derivation is in
+    ``pantr.cad._coons._verify_corners_2d``.
+    """
+
+    @staticmethod
+    def _patch_pair(bulge: float) -> tuple[Bspline, Bspline]:
+        """Two bidegree-``(1, 2)`` patches meeting at ``x = 1``, the second's edge bulged.
+
+        The shared boundary row is the three control points at ``u = 1`` of the first and
+        at ``u = 0`` of the second.  ``bulge`` displaces only the *middle* one, so the two
+        rows agree at both of their corners for every value of it.
+
+        Args:
+            bulge (float): Displacement along *z* of the second patch's middle boundary
+                control point.
+
+        Returns:
+            tuple[Bspline, Bspline]: The two patches, in join order.
+        """
+        left = np.array(
+            [
+                [[0, 0, 0], [0, 1, 0], [0, 2, 0]],
+                [[1, 0, 0], [1, 1, 0], [1, 2, 0]],
+            ],
+            dtype=np.float64,
+        )
+        right = np.array(
+            [
+                [[1, 0, 0], [1, 1, bulge], [1, 2, 0]],
+                [[2, 0, 0], [2, 1, 0], [2, 2, 0]],
+            ],
+            dtype=np.float64,
+        )
+        return _bezier_patch(left, 1, 2), _bezier_patch(right, 1, 2)
+
+    def test_two_segments_that_do_not_meet_are_refused(self) -> None:
+        """The reproduction filed with issue 310, hardcoded.
+
+        Two collinear degree-1 segments with a gap of 4 units between them, four times
+        the length of either.  Before the check, ``join`` returned a single spline whose
+        junction sat at ``[3, 0, 0]``, the midpoint of the two disagreeing endpoints,
+        which lies on neither input.
+        """
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([5, 0, 0], [6, 0, 0])
+        with pytest.raises(ValueError, match="mismatch"):
+            join(c1, c2, axis=0)
+
+    def test_the_message_names_the_axis_the_gap_and_the_tolerance(self) -> None:
+        """A refusal has to say what is wrong, not only that something is.
+
+        The tolerance printed must be the one actually compared against, so the message
+        is checked against ``get_conservative(float64)`` times the scale of the two rows
+        -- here 6, the largest coordinate over both -- rather than against itself.
+        """
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([5, 0, 0], [6, 0, 0])
+        with pytest.raises(ValueError) as excinfo:
+            join(c1, c2, axis=0)
+        message = str(excinfo.value)
+        assert "axis 0" in message
+        assert f"{4.0:.3e}" in message
+        assert f"{get_conservative(np.float64) * 6.0:.3e}" in message
+
+    def test_two_segments_that_meet_still_join(self) -> None:
+        """The control of the same reproduction: the check must not cost the good case.
+
+        The junction control point is the average of two bitwise-equal values, which in
+        IEEE arithmetic returns that value exactly, so the result is pinned exactly and
+        not to a tolerance.
+        """
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([1, 0, 0], [2, 0, 0])
+        result = join(c1, c2, axis=0)
+        assert_array_equal(
+            np.asarray(result.control_points),
+            np.array([[0, 0, 0], [1, 0, 0], [2, 0, 0]], dtype=np.float64),
+        )
+        domain = result.space.spaces[0].domain
+        ts = np.linspace(float(domain[0]), float(domain[1]), 5)
+        pts = np.asarray(result.evaluate(ts), dtype=np.float64)
+        for point in ([0, 0, 0], [1, 0, 0], [2, 0, 0]):
+            assert np.isclose(pts, point).all(axis=1).any()
+
+    def test_a_mismatch_in_the_interior_of_a_shared_face_is_refused(self) -> None:
+        """Agreeing at the corners of the shared face is necessary but not sufficient.
+
+        The two patches meet exactly at both ends of the row they share and disagree by
+        half the patch in between, so a check reading only the corners of the junction
+        accepts them.  Before the check, the result missed both patches along the whole
+        interior of the seam.
+        """
+        left, right = self._patch_pair(bulge=0.5)
+        with pytest.raises(ValueError, match="mismatch"):
+            join(left, right, axis=0)
+
+    def test_the_same_patches_join_when_the_shared_face_agrees(self) -> None:
+        """The control for the interior case, and the seam is interpolated.
+
+        With the bulge removed the two rows are bitwise equal, so the averaged row is
+        exactly theirs and the joined surface restricts to the shared boundary curve.
+        """
+        left, right = self._patch_pair(bulge=0.0)
+        result = join(left, right, axis=0)
+        assert result.dim == 2
+        u_junction = float(left.space.spaces[0].domain[1])
+        v = np.linspace(0.0, 1.0, 9)
+        params = np.column_stack([np.full_like(v, u_junction), v])
+        got = np.asarray(result.evaluate(params), dtype=np.float64)
+        want = np.asarray(left.evaluate(params), dtype=np.float64)
+        assert_allclose(got, want, atol=1e-14)
+
+    def test_a_mismatch_in_the_interior_of_a_shared_face_is_refused_on_axis_1(self) -> None:
+        """The check has to reach the seam whichever axis carries it.
+
+        Same construction transposed: two bidegree-``(2, 1)`` patches meeting along
+        ``v``, agreeing at both corners of the shared row and bulging in between.
+        """
+        left, right = (b.permute_directions([1, 0]) for b in self._patch_pair(bulge=0.5))
+        with pytest.raises(ValueError, match="mismatch"):
+            join(left, right, axis=1)
+
+    def test_a_degree_mismatch_on_the_join_axis_is_accepted(self) -> None:
+        """Elevating one side to the common degree must not manufacture a disagreement.
+
+        Degree elevation leaves a clamped endpoint control point where it is, so the two
+        readings of a genuinely shared junction stay equal and no tolerance is spent.
+        Nothing in the suite covered a join across degrees before.
+        """
+        c1 = create_line([0, 0, 0], [1, 0, 0])
+        c2 = create_line([1, 0, 0], [2, 0, 0]).elevate_degree(2)
+        result = join(c1, c2, axis=0)
+        domain = result.space.spaces[0].domain
+        ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
+        assert_allclose(ends, [[0, 0, 0], [2, 0, 0]], atol=1e-14)
+
+    def test_a_knot_mismatch_on_a_non_join_axis_is_accepted(self) -> None:
+        """Making the non-join axes compatible must not manufacture one either.
+
+        The second patch carries an extra knot in ``v``, so ``make_compat`` refines both
+        to a common space before the rows are compared.  That runs the same insertion on
+        coefficients that already agree, so whatever it rounds it rounds identically on
+        both sides.
+        """
+        left, right = self._patch_pair(bulge=0.0)
+        right = right.insert_knots([None, np.array([0.5])])
+        result = join(left, right, axis=0)
+        assert result.dim == 2
+        u_junction = float(left.space.spaces[0].domain[1])
+        v = np.linspace(0.0, 1.0, 9)
+        params = np.column_stack([np.full_like(v, u_junction), v])
+        got = np.asarray(result.evaluate(params), dtype=np.float64)
+        want = np.asarray(left.evaluate(params), dtype=np.float64)
+        assert_allclose(got, want, atol=1e-14)
+
+
+class TestJoinBoundaryToleranceScale:
+    """The junction check must reach the same verdict at every model scale.
+
+    Its tolerance is ``4096 * eps`` times the largest absolute coordinate over the two
+    rows compared, so a last-bit disagreement is accepted on a metre-scale part measured
+    in microns, and a gap of one part per million of the model is refused on a micron-
+    scale one.  A fixed absolute constant can do neither.
+    """
+
+    @staticmethod
+    def _segments(scale: float, shift: float = 0.0) -> tuple[Bspline, Bspline]:
+        """Two collinear segments of length ``scale``, the second's start displaced.
+
+        Args:
+            scale (float): Length of each segment, and so the model size.
+            shift (float): Displacement of the junction as the second segment sees it.
+
+        Returns:
+            tuple[Bspline, Bspline]: The two segments, in join order.
+        """
+        s = scale
+        return (
+            create_line([0, 0, 0], [s, 0, 0]),
+            create_line([s + shift, 0, 0], [2 * s, 0, 0]),
+        )
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9])
+    def test_a_one_ulp_junction_mismatch_is_accepted_at_every_scale(self, scale: float) -> None:
+        """A geometrically perfect join must never be refused for a last-bit disagreement.
+
+        At ``scale >= 1e6`` one ulp of the coordinate already exceeds ``1e-12``, which is
+        the direction an absolute constant fails in.
+        """
+        shift = float(np.nextafter(scale, np.inf) - scale)
+        result = join(*self._segments(scale, shift), axis=0)
+        assert result.dim == 1
+
+    @pytest.mark.parametrize(
+        "scale", [1.0e-9, 1.0e-8, 1.0e-7, 1.0e-6, 1.0e-3, 1.0, 1.0e3, 1.0e6, 1.0e9]
+    )
+    def test_a_relative_junction_gap_is_refused_at_every_scale(self, scale: float) -> None:
+        """And this is the direction an absolute constant fails in on a small model.
+
+        A gap of one part per million of the model is a real modelling mistake at any
+        scale; graded against a fixed ``1e-12`` it would be accepted from ``scale = 1e-6``
+        down.
+        """
+        with pytest.raises(ValueError, match="mismatch"):
+            join(*self._segments(scale, shift=1.0e-6 * scale), axis=0)
+
+    def test_the_scale_comes_from_both_rows_not_from_the_control_point_under_test(self) -> None:
+        """A seam touching the origin is graded like the rest of the seam.
+
+        The control point at the origin supplies no magnitude of its own.  Reading the
+        scale off that point alone would grade it against zero and demand bitwise
+        agreement there, while allowing ``4096 * eps * s`` everywhere else on the same
+        row.  The displacement here is ``1e-9`` on a model spanning ``1e6``, i.e. ``1e-15``
+        relative -- roundoff, not a modelling error.
+        """
+        s = 1.0e6
+        left = np.array(
+            [
+                [[0, 0, 0], [0, s, 0]],
+                [[0, 0, 0], [s, s, 0]],
+            ],
+            dtype=np.float64,
+        )
+        right = np.array(
+            [
+                [[1.0e-9, 0, 0], [s, s, 0]],
+                [[s, 0, 0], [2 * s, s, 0]],
+            ],
+            dtype=np.float64,
+        )
+        result = join(_bezier_patch(left, 1, 1), _bezier_patch(right, 1, 1), axis=0)
+        assert result.dim == 2
+
+
+class TestJoinRationalBoundary:
+    """A rational join compares homogeneous control points, as the Coons edge check does.
+
+    ``join`` averages the homogeneous rows -- weights included -- so those are what has
+    to agree for the average to be the row itself.  Two rows that project to the same
+    points under different weights are therefore refused: the resulting fused row is not
+    either of them, which is exactly the failure the check exists to stop.  The gap it
+    reports is then a coefficient gap and not a distance, since turning one into the
+    other needs a lower bound on the weights that this check does not compute.
+    """
+
+    def test_a_rational_join_with_agreeing_homogeneous_rows_is_accepted(self) -> None:
+        """Non-unit weights are fine as long as both sides carry the same ones."""
+        c1 = _rational_curve(np.array([[0, 0, 0, 1], [2, 0, 0, 2]], dtype=np.float64), 1)
+        c2 = _rational_curve(np.array([[2, 0, 0, 2], [3, 0, 0, 1]], dtype=np.float64), 1)
+        result = join(c1, c2, axis=0)
+        assert result.is_rational
+        domain = result.space.spaces[0].domain
+        ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
+        assert_allclose(ends, [[0, 0, 0], [3, 0, 0]], atol=1e-14)
+
+    def test_a_rational_join_whose_junction_weights_disagree_is_refused(self) -> None:
+        """The two rows project to the same point and are still refused.
+
+        ``[2, 0, 0, 2]`` and ``[1, 0, 0, 1]`` are the same point of space carried at
+        different weights.  Averaging them gives ``[1.5, 0, 0, 1.5]``, which projects
+        back to that same point, but the *weight* at the junction is now neither input's,
+        so the curve on both sides of the seam is not the curve either input described.
+        """
+        c1 = _rational_curve(np.array([[0, 0, 0, 1], [2, 0, 0, 2]], dtype=np.float64), 1)
+        c2 = _rational_curve(np.array([[1, 0, 0, 1], [3, 0, 0, 1]], dtype=np.float64), 1)
+        with pytest.raises(ValueError, match="mismatch"):
+            join(c1, c2, axis=0)
+
+    def test_a_mixed_rational_and_polynomial_join_is_accepted_at_unit_weight(self) -> None:
+        """Promotion gives the polynomial side unit weights, which the rational side has.
+
+        This is the ordinary mixed join, and it must keep working: the check runs after
+        ``_promote_to_rational``, so both rows are homogeneous by the time they meet.
+        """
+        c1 = _rational_curve(np.array([[0, 0, 0, 1], [1, 0, 0, 1]], dtype=np.float64), 1)
+        c2 = create_line([1, 0, 0], [2, 0, 0])
+        result = join(c1, c2, axis=0)
+        assert result.is_rational
+        domain = result.space.spaces[0].domain
+        ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
+        assert_allclose(ends, [[0, 0, 0], [2, 0, 0]], atol=1e-14)
+
+    def test_a_mixed_join_whose_rational_side_carries_a_non_unit_weight_is_refused(self) -> None:
+        """And the documented consequence of comparing homogeneously.
+
+        The rational curve ends at the same point of space the polynomial one starts
+        from, but carries weight 2 there while promotion gives the polynomial side
+        weight 1.  Refusing is the same verdict ``_verify_edges_3d`` reaches on the same
+        input, and the message reports a coefficient gap rather than a distance.
+        """
+        c1 = _rational_curve(np.array([[0, 0, 0, 1], [2, 0, 0, 2]], dtype=np.float64), 1)
+        c2 = create_line([1, 0, 0], [2, 0, 0])
+        with pytest.raises(ValueError, match=re.compile("mismatch")):
+            join(c1, c2, axis=0)

--- a/tests/test_cad_join.py
+++ b/tests/test_cad_join.py
@@ -11,11 +11,17 @@ from numpy import typing as npt
 from numpy.testing import assert_allclose, assert_array_equal
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
-from pantr.cad import create_bilinear, create_line, join
-from pantr.tolerance import get_conservative
+from pantr.cad import create_bilinear, create_line, create_trilinear, join
+from pantr.tolerance import get_conservative, get_default
 
 
-def _bezier_patch(control_points: npt.NDArray[np.float64], degree_u: int, degree_v: int) -> Bspline:
+def _bezier_patch(
+    control_points: npt.NDArray[np.float64],
+    degree_u: int,
+    degree_v: int,
+    *,
+    rational: bool = False,
+) -> Bspline:
     """Build a single-Bezier-span B-spline surface of the given bidegree on ``[0, 1]^2``.
 
     ``create_bilinear`` only reaches bidegree ``(1, 1)``, whose shared boundary row has
@@ -23,17 +29,48 @@ def _bezier_patch(control_points: npt.NDArray[np.float64], degree_u: int, degree
     disagreement that a corner-only check would miss.
 
     Args:
-        control_points (npt.NDArray[np.float64]): Shape ``(degree_u + 1, degree_v + 1, 3)``.
+        control_points (npt.NDArray[np.float64]): Shape
+            ``(degree_u + 1, degree_v + 1, rank)``, the trailing column being a weight if
+            *rational*.
         degree_u (int): Degree in the first parametric direction.
         degree_v (int): Degree in the second.
+        rational (bool): Whether the control points are homogeneous. Defaults to False.
 
     Returns:
-        Bspline: A clamped, non-rational surface on ``[0, 1]^2``.
+        Bspline: A clamped surface on ``[0, 1]^2``.
     """
     spaces = [
         BsplineSpace1D(np.array([0.0] * (d + 1) + [1.0] * (d + 1)), d) for d in (degree_u, degree_v)
     ]
-    return Bspline(BsplineSpace(spaces), np.asarray(control_points, dtype=np.float64))
+    return Bspline(
+        BsplineSpace(spaces), np.asarray(control_points, dtype=np.float64), is_rational=rational
+    )
+
+
+def _assert_on_the_seam(
+    got: npt.NDArray[np.float64],
+    want: npt.NDArray[np.float64],
+    dtype: npt.DTypeLike = np.float64,
+) -> None:
+    """Assert two sampled point sets agree to a tolerance derived from what produced them.
+
+    ``assert_allclose`` keeps ``rtol=1e-7`` unless it is switched off, so passing ``atol``
+    alone grades the nonzero components ten million times more loosely than the number
+    written suggests.  It is zeroed here and the whole bound carried by ``atol``.
+
+    The tier is :func:`~pantr.tolerance.get_default`, ``64 * eps``: what separates *got*
+    from *want* is one de Boor evaluation of each, a short chain, plus build slack across
+    the 3.11/3.13/3.14 matrix.  It is scaled by the magnitude of *want* because the
+    quantity graded is a coordinate, and an absolute bound would break the moment a test
+    datum moved off unit scale.  Attained error in these cases is exactly zero.
+
+    Args:
+        got (npt.NDArray[np.float64]): Points read off the joined B-spline.
+        want (npt.NDArray[np.float64]): Points read off the input it must reproduce.
+        dtype (npt.DTypeLike): Precision the two were computed in. Defaults to float64.
+    """
+    scale = float(np.abs(want).max())
+    assert_allclose(got, want, rtol=0.0, atol=get_default(dtype) * max(scale, 1.0))
 
 
 def _rational_curve(control_points: npt.NDArray[np.float64], degree: int) -> Bspline:
@@ -161,9 +198,11 @@ class TestJoinSharedBoundaryConsistency:
     310).  ``create_coons_surface`` and ``create_coons_volume`` have always refused the
     same class of input.
 
-    The tolerance is the Coons path's: ``get_conservative(float64)`` times the largest
-    absolute coordinate over the two rows being compared.  Its derivation is in
-    ``pantr.cad._coons._verify_corners_2d``.
+    The tolerance is the Coons path's: :func:`~pantr.tolerance.get_conservative` times the
+    largest absolute coordinate over the two rows being compared, read at the coarser of
+    the two inputs' precisions.  Its derivation is in
+    ``pantr.cad._coons._verify_corners_2d``; :class:`TestJoinPrecision` covers the
+    precision half.
     """
 
     @staticmethod
@@ -213,9 +252,10 @@ class TestJoinSharedBoundaryConsistency:
     def test_the_message_names_the_axis_the_gap_and_the_tolerance(self) -> None:
         """A refusal has to say what is wrong, not only that something is.
 
-        The tolerance printed must be the one actually compared against, so the message
-        is checked against ``get_conservative(float64)`` times the scale of the two rows
-        -- here 6, the largest coordinate over both -- rather than against itself.
+        The tolerance printed must be the one actually compared against, so the message is
+        checked against ``get_conservative(float64)`` times the scale of the two rows --
+        here 5, the largest coordinate over the two junction control points ``[1, 0, 0]``
+        and ``[5, 0, 0]``, and not the 6 of the model -- rather than against itself.
         """
         c1 = create_line([0, 0, 0], [1, 0, 0])
         c2 = create_line([5, 0, 0], [6, 0, 0])
@@ -224,14 +264,14 @@ class TestJoinSharedBoundaryConsistency:
         message = str(excinfo.value)
         assert "axis 0" in message
         assert f"{4.0:.3e}" in message
-        assert f"{get_conservative(np.float64) * 6.0:.3e}" in message
+        assert f"{get_conservative(np.float64) * 5.0:.3e}" in message
 
     def test_two_segments_that_meet_still_join(self) -> None:
         """The control of the same reproduction: the check must not cost the good case.
 
-        The junction control point is the average of two bitwise-equal values, which in
-        IEEE arithmetic returns that value exactly, so the result is pinned exactly and
-        not to a tolerance.
+        The junction control point is the average of two bitwise-equal values, and
+        ``(x + x) / 2`` returns ``x`` exactly for every finite ``x`` whose double does not
+        overflow, so the result is pinned exactly and not to a tolerance.
         """
         c1 = create_line([0, 0, 0], [1, 0, 0])
         c2 = create_line([1, 0, 0], [2, 0, 0])
@@ -258,6 +298,50 @@ class TestJoinSharedBoundaryConsistency:
         with pytest.raises(ValueError, match="mismatch"):
             join(left, right, axis=0)
 
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e6])
+    def test_both_sides_refined_differently_still_agree_within_the_tolerance(
+        self, scale: float
+    ) -> None:
+        """The case where a shared seam is *not* bitwise equal, and the tolerance earns its keep.
+
+        Each patch carries its own interior knots on the non-join axis, which is what two
+        surfaces meeting at a seam ordinarily look like.  ``make_compat`` then refines
+        *both*, by different operator sequences, so the two readings of the seam differ --
+        measured at 0.5 to 3.3 ulps of the seam's magnitude, against exactly zero when only
+        one side is refined.  This is the floor the tier has to clear, and it has to clear
+        it at every model size, so the assertion is that the join is accepted rather than
+        that the readings match.
+
+        Args:
+            scale (float): Magnitude of the model.
+        """
+        s = scale
+        seam = np.array([[0, 0, 0], [0.3 * s, 1.1 * s, 0.7 * s], [0, 2 * s, 0]])
+        left = np.stack([np.array([[-s, 0, 0], [-s, 1.1 * s, 0], [-s, 2 * s, 0]]), seam])
+        right = np.stack([seam.copy(), np.array([[s, 0, 0], [s, 1.3 * s, 0], [s, 2 * s, 0]])])
+        s1 = _bezier_patch(left, 1, 2).insert_knots([None, np.array([1.0 / 3.0])])
+        s2 = _bezier_patch(right, 1, 2).insert_knots([None, np.array([0.7123456789])])
+        result = join(s1, s2, axis=0)
+        assert result.dim == 2
+
+    @pytest.mark.parametrize(("position", "expected"), [(1, "(1,)"), (2, "(2,)")])
+    def test_the_message_names_the_control_point_that_disagrees_most(
+        self, position: int, expected: str
+    ) -> None:
+        """The index reported has to be the offending one, not merely the first compared.
+
+        A shared face carries more than one control point as soon as the inputs are
+        surfaces, so a message naming the wrong one sends the reader to a seam that is
+        fine.  Displacing a different control point of the same row must move the index.
+        """
+        left, right = self._patch_pair(bulge=0.0)
+        cps = np.array(right.control_points, dtype=np.float64)
+        cps[0, position, 2] += 0.5
+        right = _bezier_patch(cps, 1, 2)
+        with pytest.raises(ValueError) as excinfo:
+            join(left, right, axis=0)
+        assert f"at index {expected}" in str(excinfo.value)
+
     def test_the_same_patches_join_when_the_shared_face_agrees(self) -> None:
         """The control for the interior case, and the seam is interpolated.
 
@@ -272,7 +356,7 @@ class TestJoinSharedBoundaryConsistency:
         params = np.column_stack([np.full_like(v, u_junction), v])
         got = np.asarray(result.evaluate(params), dtype=np.float64)
         want = np.asarray(left.evaluate(params), dtype=np.float64)
-        assert_allclose(got, want, atol=1e-14)
+        _assert_on_the_seam(got, want)
 
     def test_a_mismatch_in_the_interior_of_a_shared_face_is_refused_on_axis_1(self) -> None:
         """The check has to reach the seam whichever axis carries it.
@@ -283,6 +367,42 @@ class TestJoinSharedBoundaryConsistency:
         left, right = (b.permute_directions([1, 0]) for b in self._patch_pair(bulge=0.5))
         with pytest.raises(ValueError, match="mismatch"):
             join(left, right, axis=1)
+
+    @staticmethod
+    def _unit_cell(offset: float) -> npt.NDArray[np.float64]:
+        """Corner array of the unit cube translated by ``offset`` along *x*.
+
+        Args:
+            offset (float): Translation along *x*.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(2, 2, 2, 3)``, indexed by the side along
+            each of the three directions.
+        """
+        cell = np.zeros((2, 2, 2, 3), dtype=np.float64)
+        for i, j, k in np.ndindex(2, 2, 2):
+            cell[i, j, k] = [offset + i, j, k]
+        return cell
+
+    def test_a_trivariate_join_reports_a_two_index_into_its_shared_face(self) -> None:
+        """A volume's shared face is two-dimensional, and the message has to say where.
+
+        The reported index is a multi-index over the shared face, so it grows with the
+        parametric dimension.  Nothing else in the file joins volumes.
+        """
+        left = create_trilinear(self._unit_cell(0.0))
+        cell = self._unit_cell(1.0)
+        cell[0, 1, 1, 2] += 0.5
+        with pytest.raises(ValueError, match=r"at index \(1, 1\)"):
+            join(left, create_trilinear(cell), axis=0)
+
+    def test_a_trivariate_join_with_an_agreeing_shared_face_is_accepted(self) -> None:
+        """The control for the volume case."""
+        left = create_trilinear(self._unit_cell(0.0))
+        right = create_trilinear(self._unit_cell(1.0))
+        result = join(left, right, axis=0)
+        assert result.dim == 3
+        assert result.control_points.shape == (3, 2, 2, 3)
 
     def test_a_degree_mismatch_on_the_join_axis_is_accepted(self) -> None:
         """Elevating one side to the common degree must not manufacture a disagreement.
@@ -296,18 +416,45 @@ class TestJoinSharedBoundaryConsistency:
         result = join(c1, c2, axis=0)
         domain = result.space.spaces[0].domain
         ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
-        assert_allclose(ends, [[0, 0, 0], [2, 0, 0]], atol=1e-14)
+        _assert_on_the_seam(ends, np.array([[0, 0, 0], [2, 0, 0]], dtype=np.float64))
 
-    def test_a_knot_mismatch_on_a_non_join_axis_is_accepted(self) -> None:
-        """Making the non-join axes compatible must not manufacture one either.
+    @pytest.mark.parametrize(
+        ("elevation", "extra_knots"),
+        [
+            pytest.param(None, np.array([0.5]), id="knots-on-a-non-join-axis"),
+            pytest.param([0, 1], None, id="degree-on-a-non-join-axis"),
+            pytest.param([0, 1], np.array([0.37]), id="degree-and-knots-on-a-non-join-axis"),
+            pytest.param([2, 1], np.array([0.37]), id="degree-on-both-axes-and-knots"),
+        ],
+    )
+    def test_reaching_a_common_space_does_not_manufacture_a_disagreement(
+        self,
+        elevation: list[int] | None,
+        extra_knots: npt.NDArray[np.float64] | None,
+    ) -> None:
+        """Whatever ``_prepare_for_join`` has to do to the inputs, an agreeing seam stays agreeing.
 
-        The second patch carries an extra knot in ``v``, so ``make_compat`` refines both
-        to a common space before the rows are compared.  That runs the same insertion on
-        coefficients that already agree, so whatever it rounds it rounds identically on
-        both sides.
+        The second patch is given a different representation of the same geometry, so
+        ``make_compat`` and the join-axis elevation both have work to do before the rows
+        are compared.  Each runs the same operation on coefficients that already agree, so
+        whatever it rounds it rounds identically on both sides.  This is the evidence for
+        the "bitwise equal" claim in ``_verify_shared_boundary``'s docstring, and it has
+        to cover the combinations, not only one change at a time: the four cases here are
+        the four that claim measures.  The both-sides case, where the readings are *not*
+        bitwise equal, is
+        :meth:`test_both_sides_refined_differently_still_agree_within_the_tolerance`.
+
+        Args:
+            elevation (list[int] | None): Per-axis degree increments applied to the second
+                patch, or ``None`` for no elevation.
+            extra_knots (npt.NDArray[np.float64] | None): Knots inserted into the second
+                patch's non-join axis, or ``None`` for none.
         """
         left, right = self._patch_pair(bulge=0.0)
-        right = right.insert_knots([None, np.array([0.5])])
+        if elevation is not None:
+            right = right.elevate_degree(elevation)
+        if extra_knots is not None:
+            right = right.insert_knots([None, extra_knots])
         result = join(left, right, axis=0)
         assert result.dim == 2
         u_junction = float(left.space.spaces[0].domain[1])
@@ -315,7 +462,7 @@ class TestJoinSharedBoundaryConsistency:
         params = np.column_stack([np.full_like(v, u_junction), v])
         got = np.asarray(result.evaluate(params), dtype=np.float64)
         want = np.asarray(left.evaluate(params), dtype=np.float64)
-        assert_allclose(got, want, atol=1e-14)
+        _assert_on_the_seam(got, want)
 
 
 class TestJoinBoundaryToleranceScale:
@@ -368,6 +515,30 @@ class TestJoinBoundaryToleranceScale:
         with pytest.raises(ValueError, match="mismatch"):
             join(*self._segments(scale, shift=1.0e-6 * scale), axis=0)
 
+    @pytest.mark.parametrize(("factor", "accepted"), [(0.25, True), (4.0, False)])
+    def test_the_tier_itself_is_bracketed_at_a_non_unit_scale(
+        self, factor: float, accepted: bool
+    ) -> None:
+        """Pin the tolerance's magnitude behaviorally, not only through the message text.
+
+        The scale-covariance tests above pin the *rule* -- that the threshold is relative
+        and follows the model -- but a tolerance a thousand times looser obeys that rule
+        too and passes all of them.  Bracketing a quarter of the tier against four times
+        it is what makes the magnitude itself load-bearing.
+
+        Args:
+            factor (float): Junction gap as a multiple of the tolerance.
+            accepted (bool): Whether the join must be accepted at that gap.
+        """
+        s = 3.0
+        gap = factor * get_conservative(np.float64) * s
+        c1, c2 = self._segments(s, shift=gap)
+        if accepted:
+            assert join(c1, c2, axis=0).dim == 1
+        else:
+            with pytest.raises(ValueError, match="mismatch"):
+                join(c1, c2, axis=0)
+
     def test_the_scale_comes_from_both_rows_not_from_the_control_point_under_test(self) -> None:
         """A seam touching the origin is graded like the rest of the seam.
 
@@ -396,6 +567,172 @@ class TestJoinBoundaryToleranceScale:
         assert result.dim == 2
 
 
+class TestJoinPrecision:
+    """A float32 model is graded at float32's precision, and stays float32 through a join.
+
+    ``pantr.tolerance``'s tiers are functions of the dtype because the B-spline layer
+    accepts float32 as well as float64.  Grading a float32 seam at the float64 tier asks
+    for five million times more agreement than the format can express, and refuses joins
+    that are exact as far as either input can say.
+    """
+
+    @staticmethod
+    def _curve(
+        control_points: npt.ArrayLike, dtype: npt.DTypeLike, *, rational: bool = False
+    ) -> Bspline:
+        """Build a clamped degree-1 curve of the given dtype.
+
+        ``create_line`` is float64-only, so a float32 curve has to be built directly.
+
+        Args:
+            control_points (npt.ArrayLike): Two control points, homogeneous if *rational*.
+            dtype (npt.DTypeLike): Floating-point dtype of both the space and the points.
+            rational (bool): Whether the trailing column is a weight. Defaults to False.
+
+        Returns:
+            Bspline: A degree-1 curve on ``[0, 1]``.
+        """
+        knots = np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype)
+        space = BsplineSpace([BsplineSpace1D(knots, 1)])
+        return Bspline(space, np.asarray(control_points, dtype=dtype), is_rational=rational)
+
+    def _line(self, start: Sequence[float], end: Sequence[float], dtype: npt.DTypeLike) -> Bspline:
+        """Build a clamped degree-1 non-rational curve between two points.
+
+        Args:
+            start (Sequence[float]): First control point.
+            end (Sequence[float]): Second control point.
+            dtype (npt.DTypeLike): Floating-point dtype of both the space and the points.
+
+        Returns:
+            Bspline: A degree-1 curve on ``[0, 1]``.
+        """
+        return self._curve([start, end], dtype)
+
+    def test_a_float32_join_keeps_float32(self) -> None:
+        """Joining two float32 curves must produce a float32 result.
+
+        It used to raise instead, and had nothing to do with the seam: the junction knots
+        were built from a Python float, so the merged knot vector promoted to float64
+        while the control points stayed float32, and ``BsplineSpace1D`` refuses that pair.
+        Verified against the parent commit, where the seam here agrees bitwise and the
+        join still fails.
+        """
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32)
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32
+        assert result.space.spaces[0].dtype == np.float32
+
+    def test_a_one_ulp_float32_seam_is_accepted(self) -> None:
+        """One ulp of float32 is roundoff, not a modelling error.
+
+        At the float64 tier the same seam is refused against ``9.09e-13``, five million
+        times tighter than the ``1.19e-07`` the format can resolve at this magnitude.
+        """
+        ulp = float(np.nextafter(np.float32(1.0), np.float32(2.0)) - np.float32(1.0))
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1 + ulp, 0, 0], [2, 0, 0], np.float32)
+        result = join(c1, c2, axis=0)
+        assert result.dim == 1
+
+    def test_a_gross_float32_seam_gap_is_still_refused(self) -> None:
+        """Widening the tier for float32 must not disarm the check on float32 data."""
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([5, 0, 0], [6, 0, 0], np.float32)
+        with pytest.raises(ValueError, match="mismatch"):
+            join(c1, c2, axis=0)
+
+    def test_a_mixed_precision_join_is_graded_at_the_coarser_precision(self) -> None:
+        """The float32 side is what limits the comparison, whichever side it is.
+
+        A mixed join promotes to float64, so reading the tier off the promoted rows would
+        grade data that only ever had float32 resolution at the float64 tier.
+        """
+        ulp = float(np.nextafter(np.float32(1.0), np.float32(2.0)) - np.float32(1.0))
+        for first, second in ((np.float32, np.float64), (np.float64, np.float32)):
+            c1 = self._line([0, 0, 0], [1, 0, 0], first)
+            c2 = self._line([1 + ulp, 0, 0], [2, 0, 0], second)
+            assert join(c1, c2, axis=0).dim == 1
+
+    @pytest.mark.parametrize("increment", [1, 2, 3])
+    def test_a_float32_join_needing_degree_elevation_keeps_float32(self, increment: int) -> None:
+        """The dtype has to survive the operations ``_prepare_for_join`` runs, not only the join.
+
+        The knot-dtype fix reads the incoming knots' dtype, so it is only right if
+        ``elevate_degree`` preserves float32 too.  At ``increment >= 1`` the joined degree
+        exceeds 1, which also puts the result through ``_try_remove_junction_knots``, a
+        third path that had no float32 coverage.
+        """
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).elevate_degree(increment)
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32
+        assert result.space.spaces[0].dtype == np.float32
+
+    def test_a_float32_join_needing_knot_insertion_keeps_float32(self) -> None:
+        """And the same for a knot mismatch on the join axis."""
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).insert_knots(
+            np.array([0.5], dtype=np.float32)
+        )
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32
+
+    @pytest.mark.parametrize(
+        ("dtype1", "rational1", "dtype2", "rational2"),
+        [
+            (np.float32, True, np.float64, False),
+            (np.float64, False, np.float32, True),
+            (np.float32, True, np.float32, False),
+            (np.float32, True, np.float64, True),
+        ],
+    )
+    def test_mixed_precision_and_mixed_rationality_join(
+        self,
+        dtype1: npt.DTypeLike,
+        rational1: bool,
+        dtype2: npt.DTypeLike,
+        rational2: bool,
+    ) -> None:
+        """Promotion to rational and promotion in precision have to compose.
+
+        Each is exercised alone elsewhere; together they were not, and the check sits
+        downstream of both, so it sees whatever combination they produce.
+
+        Args:
+            dtype1 (npt.DTypeLike): Floating-point dtype of the first curve.
+            rational1 (bool): Whether the first curve is rational.
+            dtype2 (npt.DTypeLike): Floating-point dtype of the second curve.
+            rational2 (bool): Whether the second curve is rational.
+        """
+        first = [[0, 0, 0, 1], [1, 0, 0, 1]] if rational1 else [[0, 0, 0], [1, 0, 0]]
+        second = [[1, 0, 0, 1], [2, 0, 0, 1]] if rational2 else [[1, 0, 0], [2, 0, 0]]
+        c1 = self._curve(first, dtype1, rational=rational1)
+        c2 = self._curve(second, dtype2, rational=rational2)
+        result = join(c1, c2, axis=0)
+        assert result.is_rational == (rational1 or rational2)
+        domain = result.space.spaces[0].domain
+        # A float32 result must be evaluated at float32 parameters.
+        params = np.array([float(d) for d in domain], dtype=result.space.spaces[0].dtype)
+        ends = np.asarray(result.evaluate(params), dtype=np.float64)
+        _assert_on_the_seam(
+            ends, np.array([[0, 0, 0], [2, 0, 0]], dtype=np.float64), result.space.spaces[0].dtype
+        )
+
+    def test_a_float64_seam_is_still_graded_at_float64(self) -> None:
+        """And the wider tier must not leak into the float64 path.
+
+        A gap of one float32 ulp on float64 data is a real modelling mistake: it is seven
+        orders above what float64 resolves at this magnitude.
+        """
+        ulp32 = float(np.nextafter(np.float32(1.0), np.float32(2.0)) - np.float32(1.0))
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float64)
+        c2 = self._line([1 + ulp32, 0, 0], [2, 0, 0], np.float64)
+        with pytest.raises(ValueError, match="mismatch"):
+            join(c1, c2, axis=0)
+
+
 class TestJoinRationalBoundary:
     """A rational join compares homogeneous control points, as the Coons edge check does.
 
@@ -415,7 +752,7 @@ class TestJoinRationalBoundary:
         assert result.is_rational
         domain = result.space.spaces[0].domain
         ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
-        assert_allclose(ends, [[0, 0, 0], [3, 0, 0]], atol=1e-14)
+        _assert_on_the_seam(ends, np.array([[0, 0, 0], [3, 0, 0]], dtype=np.float64))
 
     def test_a_rational_join_whose_junction_weights_disagree_is_refused(self) -> None:
         """The two rows project to the same point and are still refused.
@@ -430,6 +767,80 @@ class TestJoinRationalBoundary:
         with pytest.raises(ValueError, match="mismatch"):
             join(c1, c2, axis=0)
 
+    @staticmethod
+    def _weighted_patches(scale: float, weight_gap: float) -> tuple[Bspline, Bspline]:
+        """Two rational patches meeting at a seam that contains a control point at the origin.
+
+        The seam row's homogeneous coordinates run to ``scale`` while every weight is 1, so
+        the two column groups have magnitudes ``scale`` apart.  ``weight_gap`` displaces
+        only the *weight* of the origin control point, which is invisible to the coordinate
+        columns: that point contributes nothing but its weight, so a single max over the
+        whole row grades the weight against ``scale``.
+
+        Args:
+            scale (float): Magnitude of the model's coordinates.
+            weight_gap (float): Displacement of the origin control point's weight.
+
+        Returns:
+            tuple[Bspline, Bspline]: The two patches, in join order.
+        """
+        s = scale
+        seam = np.array([[0, 0, 0, 1], [s, 0, 0, 1], [s, s, 0, 1]], dtype=np.float64)
+        far_left = np.array([[0, -s, 0, 1], [s, -s, 0, 1], [2 * s, -s, 0, 1]], dtype=np.float64)
+        far_right = np.array(
+            [[0, 2 * s, 0, 1], [s, 2 * s, 0, 1], [2 * s, 2 * s, 0, 1]], dtype=np.float64
+        )
+        bumped = seam.copy()
+        bumped[0, 3] += weight_gap
+        return (
+            _bezier_patch(np.stack([far_left, seam]), 1, 2, rational=True),
+            _bezier_patch(np.stack([bumped, far_right]), 1, 2, rational=True),
+        )
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e2, 1.0e4, 1.0e6, 1.0e8])
+    @pytest.mark.parametrize(("factor", "accepted"), [(0.25, True), (4.0, False)])
+    def test_a_weight_is_graded_against_weights_not_against_the_model_size(
+        self, scale: float, factor: float, accepted: bool
+    ) -> None:
+        """A weight has no length, so grading it against a length is not scale invariant.
+
+        A rational control row mixes homogeneous coordinates, whose units are length times
+        weight, with a dimensionless weight.  Taking one maximum over the row grades the
+        weight column against the *coordinates'* magnitude, so the verdict on a weight
+        stops being invariant under ``x -> lambda x``: measured before the split, a weight
+        error accepted at magnitude ``1e8`` let the joined surface miss both inputs by
+        ``1.2e7`` times the tolerance, against ``0.5`` for the same construction without
+        weights.  The verdict must instead be the same at every model size, in both
+        directions.
+
+        Args:
+            scale (float): Magnitude of the model's coordinates.
+            factor (float): Weight gap as a multiple of the tolerance on weights.
+            accepted (bool): Whether the join must be accepted at that gap.
+        """
+        gap = factor * get_conservative(np.float64) * 1.0
+        left, right = self._weighted_patches(scale, gap)
+        if accepted:
+            assert join(left, right, axis=0).is_rational
+        else:
+            with pytest.raises(ValueError, match="mismatch"):
+                join(left, right, axis=0)
+
+    def test_the_message_names_the_column_group_that_decided_the_verdict(self) -> None:
+        """A refusal on a weight must not read as a refusal on a position.
+
+        The two groups carry different magnitudes, so reporting the wrong one sends the
+        reader looking for a displacement that is not there.
+        """
+        left, right = self._weighted_patches(1.0e4, 4.0 * get_conservative(np.float64))
+        with pytest.raises(ValueError, match="boundary weight scale"):
+            join(left, right, axis=0)
+
+        c1 = _rational_curve(np.array([[0, 0, 0, 1], [2, 0, 0, 2]], dtype=np.float64), 1)
+        c2 = _rational_curve(np.array([[1, 0, 0, 1], [3, 0, 0, 1]], dtype=np.float64), 1)
+        with pytest.raises(ValueError, match="boundary coordinate scale"):
+            join(c1, c2, axis=0)
+
     def test_a_mixed_rational_and_polynomial_join_is_accepted_at_unit_weight(self) -> None:
         """Promotion gives the polynomial side unit weights, which the rational side has.
 
@@ -442,7 +853,7 @@ class TestJoinRationalBoundary:
         assert result.is_rational
         domain = result.space.spaces[0].domain
         ends = np.asarray(result.evaluate(np.array([float(d) for d in domain])), dtype=np.float64)
-        assert_allclose(ends, [[0, 0, 0], [2, 0, 0]], atol=1e-14)
+        _assert_on_the_seam(ends, np.array([[0, 0, 0], [2, 0, 0]], dtype=np.float64))
 
     def test_a_mixed_join_whose_rational_side_carries_a_non_unit_weight_is_refused(self) -> None:
         """And the documented consequence of comparing homogeneously.
@@ -456,62 +867,3 @@ class TestJoinRationalBoundary:
         c2 = create_line([1, 0, 0], [2, 0, 0])
         with pytest.raises(ValueError, match=re.compile("mismatch")):
             join(c1, c2, axis=0)
-
-
-class TestJoinPrecision:
-    """A float32 model must survive a join, in both its knots and its control points."""
-
-    @staticmethod
-    def _line(start: Sequence[float], end: Sequence[float], dtype: npt.DTypeLike) -> Bspline:
-        """Build a clamped degree-1 curve of the given dtype.
-
-        ``create_line`` is float64-only, so a float32 curve has to be built directly.
-
-        Args:
-            start (Sequence[float]): First control point.
-            end (Sequence[float]): Second control point.
-            dtype (npt.DTypeLike): Floating-point dtype of both the space and the points.
-
-        Returns:
-            Bspline: A degree-1 curve on ``[0, 1]``.
-        """
-        knots = np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype)
-        space = BsplineSpace([BsplineSpace1D(knots, 1)])
-        return Bspline(space, np.asarray([start, end], dtype=dtype))
-
-    def test_a_float32_join_keeps_float32(self) -> None:
-        """Joining two float32 curves must produce a float32 result.
-
-        It used to raise ``The control points must have the same dtype as the B-spline
-        space``, and had nothing to do with the seam, which here agrees bitwise: the
-        junction knots were built from a Python float, so the merged knot vector promoted
-        to float64 while the control points stayed float32.
-        """
-        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
-        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32)
-        result = join(c1, c2, axis=0)
-        assert result.control_points.dtype == np.float32
-        assert result.space.spaces[0].dtype == np.float32
-
-    @pytest.mark.parametrize("increment", [1, 2, 3])
-    def test_a_float32_join_needing_degree_elevation_keeps_float32(self, increment: int) -> None:
-        """The dtype has to survive what ``_prepare_for_join`` runs, not only the merge.
-
-        The fix reads the incoming knots' dtype, so it is only right if ``elevate_degree``
-        preserves float32 too.  At ``increment >= 1`` the joined degree exceeds 1, which
-        also puts the result through ``_try_remove_junction_knots``.
-        """
-        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
-        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).elevate_degree(increment)
-        result = join(c1, c2, axis=0)
-        assert result.control_points.dtype == np.float32
-        assert result.space.spaces[0].dtype == np.float32
-
-    def test_a_float32_join_needing_knot_insertion_keeps_float32(self) -> None:
-        """And the same for a knot mismatch on the join axis."""
-        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
-        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).insert_knots(
-            np.array([0.5], dtype=np.float32)
-        )
-        result = join(c1, c2, axis=0)
-        assert result.control_points.dtype == np.float32

--- a/tests/test_cad_join.py
+++ b/tests/test_cad_join.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 
 import numpy as np
 import pytest
@@ -455,3 +456,62 @@ class TestJoinRationalBoundary:
         c2 = create_line([1, 0, 0], [2, 0, 0])
         with pytest.raises(ValueError, match=re.compile("mismatch")):
             join(c1, c2, axis=0)
+
+
+class TestJoinPrecision:
+    """A float32 model must survive a join, in both its knots and its control points."""
+
+    @staticmethod
+    def _line(start: Sequence[float], end: Sequence[float], dtype: npt.DTypeLike) -> Bspline:
+        """Build a clamped degree-1 curve of the given dtype.
+
+        ``create_line`` is float64-only, so a float32 curve has to be built directly.
+
+        Args:
+            start (Sequence[float]): First control point.
+            end (Sequence[float]): Second control point.
+            dtype (npt.DTypeLike): Floating-point dtype of both the space and the points.
+
+        Returns:
+            Bspline: A degree-1 curve on ``[0, 1]``.
+        """
+        knots = np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype)
+        space = BsplineSpace([BsplineSpace1D(knots, 1)])
+        return Bspline(space, np.asarray([start, end], dtype=dtype))
+
+    def test_a_float32_join_keeps_float32(self) -> None:
+        """Joining two float32 curves must produce a float32 result.
+
+        It used to raise ``The control points must have the same dtype as the B-spline
+        space``, and had nothing to do with the seam, which here agrees bitwise: the
+        junction knots were built from a Python float, so the merged knot vector promoted
+        to float64 while the control points stayed float32.
+        """
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32)
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32
+        assert result.space.spaces[0].dtype == np.float32
+
+    @pytest.mark.parametrize("increment", [1, 2, 3])
+    def test_a_float32_join_needing_degree_elevation_keeps_float32(self, increment: int) -> None:
+        """The dtype has to survive what ``_prepare_for_join`` runs, not only the merge.
+
+        The fix reads the incoming knots' dtype, so it is only right if ``elevate_degree``
+        preserves float32 too.  At ``increment >= 1`` the joined degree exceeds 1, which
+        also puts the result through ``_try_remove_junction_knots``.
+        """
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).elevate_degree(increment)
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32
+        assert result.space.spaces[0].dtype == np.float32
+
+    def test_a_float32_join_needing_knot_insertion_keeps_float32(self) -> None:
+        """And the same for a knot mismatch on the join axis."""
+        c1 = self._line([0, 0, 0], [1, 0, 0], np.float32)
+        c2 = self._line([1, 0, 0], [2, 0, 0], np.float32).insert_knots(
+            np.array([0.5], dtype=np.float32)
+        )
+        result = join(c1, c2, axis=0)
+        assert result.control_points.dtype == np.float32


### PR DESCRIPTION
## What was wrong

`join` fused two B-splines by averaging the two control rows that meet at the junction, and
never compared them. When they agree the average is that same row and the join is exact, which
is what every test in the file exercised. When they do not, the average is a new row belonging
to neither input: the reported case fused two segments 4 units apart into a curve whose junction
sat at their midpoint, passing through neither, with no exception and no indication of how far
off the inputs were. The error is half the gap, so it grows with the mistake rather than staying
near roundoff. `create_coons_surface`, and after #307 `create_coons_volume`, have always refused
the same class of input.

## What changed

`_verify_shared_boundary` compares the two rows in full before the average, and refuses rather
than repairing. Comparing the whole shared face rather than its corners is the condition the
construction actually needs: two patches meeting exactly at both ends of a seam and disagreeing
in between produce a result that misses them along the whole interior of it. Made compatible,
the two rows span the same space, so comparing control points is an exact comparison of the two
boundary patches and needs no sampling.

The averaging is unchanged and stays: it is exact for the agreeing case, which is now the only
case that reaches it, and it keeps the result symmetric in its two inputs.

### The tolerance

`create_coons_surface`'s tier, times the largest absolute value over the two rows, with two
differences that follow from what is graded here. Both were found by a tolerance audit of the
first draft, and both are pinned by tests.

**The tier is read at the coarser of the two inputs' own precisions**, not always float64.
float32 is a supported precision in the B-spline layer, and at the float64 tier a float32 seam
one ulp out (`1.19e-07`) was refused against `9.09e-13`, five million times tighter than the
format can express. If the true shared face is `F`, the two stored readings satisfy
`|row1 - row2| <= 0.5 (eps1 + eps2) scale`, a hard floor below which any tolerance refuses a
perfect seam; the tier clears it by 8192. Taking the *promoted* type instead is backwards by a
factor of `5.4e8`.

**The coordinate columns and the weight column are graded against their own magnitudes.** A
rational row mixes homogeneous coordinates, in units of length times weight, with a
dimensionless weight, so one maximum over the row grades the weight against a length and the
verdict stops being invariant under `x -> lambda x`. Measured on a seam containing a control
point at the origin, the accepted geometric error grew linearly with coordinate magnitude:

| coordinate magnitude | accepted geometric error, in units of the tolerance |
|---|---|
| 1 | 0.12 |
| 1e2 | 12 |
| 1e4 | 1.2e3 |
| 1e6 | 1.2e5 |
| 1e8 | **1.2e7** |

against a flat 0.50 for the same construction without weights. Splitting the groups flattens it
to 0.12 at every magnitude and still refuses a one-sided weight rescale.

### A claim corrected before it shipped

The first draft justified the magnitude by asserting that a genuinely shared seam always arrives
bitwise equal. That is true only when one side is refined and the other left alone, which is
what the initial measurement happened to cover. When each input carries its own interior knots
on a non-join axis, which is what two surfaces meeting at a seam ordinarily look like,
`make_compat` refines both by different operator sequences and the readings differ by 0.5 to 3.3
ulps of the seam's magnitude, measured across degrees 2 to 5 and magnitudes `1e-9` to `1e15`,
flat in the number of insertions. Every step between the caller's data and the comparison is a
convex combination, so the floor is `O(eps)` times the largest coefficient; `16 eps` covers it
with build slack and the tier clears that by 250. The docstring now carries the measured
derivation, and the both-sides-refined case is a test.

Two further claims are measured rather than asserted: for non-rational inputs the convex-hull
property makes the reported gap a distance in space, with the ratio saturating at exactly 1 over
400 random pairs; for rational inputs it is a coefficient gap, and that ratio reaches `9e4` at
weights of 0.01. The docstring says which is which.

## Acceptance criteria

Verified per ID against the branch, independently of the implementer.

- **AC1** VERIFIED. The mismatched reproduction raises
  `Shared boundary mismatch on axis 0: the first B-spline gives [1. 0. 0.], the second gives [5. 0. 0.] (gap 4.000e+00, above 4.547e-12 at boundary coordinate scale 5.000e+00).`
- **AC2** VERIFIED. The control still joins, control points `[[0,0,0],[1,0,0],[2,0,0]]`, and the
  result passes through all three.
- **AC3** VERIFIED. Both cases are hardcoded tests; at the pin commit the suite is 15 failed /
  20 passed, all failures `DID NOT RAISE`.
- **AC4** VERIFIED. The 7 pre-existing tests are byte-identical and pass.
- **AC5** VERIFIED. The interior case's two rows agree at both corners of the seam and differ by
  0.5 in between; a corner-only check accepts it and `join` refuses it, naming index `(1,)`.
- **AC6** VERIFIED, in the amended form described above: same tier, same scale rule, no new
  numeric constant anywhere in the change, and the docstrings state both deviations.
- **AC7** VERIFIED. `join`'s summary states the requirement and its `Raises:` documents the error
  with its trigger.

## Tests

6 to 71. Ten mutants of the tolerance rule are each killed by at least one test: no check at
all, tier 1000x looser, tier 64x tighter, an absolute constant, unit scale, tier always float64,
tier at the promoted dtype, one scale for the whole rational row, scale from one row only, and
corners of the shared face only. Two of those survived the first draft's suite.

Full suite 5718 passed, 21 skipped, 3 xfailed. ruff, ruff-format, mypy, import-lint and a clean
`-W --keep-going` docs build all pass.

## An unrelated bug fixed alongside, in its own commit

Joining two float32 B-splines raised `The control points must have the same dtype as the
B-spline space` even when the two pieces met bitwise exactly, so the failure had nothing to do
with the geometry. The `p` junction knots were built with `np.full(p, u_junction)` from a Python
float, so that array is float64; concatenating it with two float32 knot vectors promoted the
merged vector while the control points stayed float32. Taking the dtype from the incoming knots
fixes it. Verified failing on this branch's parent; three regression tests cover it, including
the `elevate_degree` and `insert_knots` paths the fix relies on. A mixed float32/float64 join was
and remains unaffected.

## Left for follow-up

`_verify_corners_2d` and `_verify_edges_3d` in `src/pantr/cad/_coons.py` share the two tolerance
defects corrected here, and `create_coons_volume` has a third, unrelated one. All three are
verified on `main` and are outside this change's files; they are being filed separately rather
than widened into this PR.

The scale/tolerance/raise pattern is now written out in three places across `pantr.cad`. That
duplication predates this change and is left alone here.

Closes #310
