### PR TITLE
fix(bspline): give locate's threshold the parametric resolution term it was missing

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -287,8 +287,11 @@ class Bspline:
             tol (float | None): Convergence threshold on ``||F(xi) - x||_2``, as an
                 absolute distance in physical units. ``None`` (default) uses
                 :func:`pantr.tolerance.get_default` for this B-spline's dtype, scaled by
-                the geometry's own size: the larger of its control-point bounding-box
-                diagonal and its largest coordinate magnitude. Defaults to None.
+                the largest of three lengths: the control-point bounding-box diagonal, the
+                largest coordinate magnitude, and the physical length one ulp of a
+                parametric coordinate spans. The last is what keeps the threshold
+                reachable for a knot vector far from the parametric origin, whose
+                coordinates a float64 resolves only to ``eps * |xi|``. Defaults to None.
             max_iter (int): Maximum number of Newton steps per candidate cell.
                 Defaults to 30.
 
@@ -308,7 +311,10 @@ class Bspline:
             ValueError: If ``rank < dim``, any direction is periodic, a rational
                 B-spline has a non-positive weight, ``points`` has the wrong shape or a
                 non-finite entry, ``max_iter < 1``, or ``tol`` is not positive and
-                finite.
+                finite. Also when ``tol`` is ``None`` and the knot vector sits so far
+                from the parametric origin that one ulp of a coordinate moves the image
+                by more than the geometry's own size, since no default threshold can
+                mean anything there; pass an explicit ``tol`` to ask anyway.
 
         Note:
             What is guaranteed is that ``evaluate(ref_coords[i])`` reproduces
@@ -327,6 +333,17 @@ class Bspline:
             below the ``float32`` tolerance preset. Evaluating the returned coordinates
             on the original ``float32`` B-spline therefore reproduces the query point to
             ``float32`` accuracy only.
+
+            The default threshold grows with how far the knot vector sits from the
+            parametric origin, because that is how far one ulp of a coordinate moves the
+            image. A "found" verdict on such a geometry therefore asserts less than the
+            same verdict on one parametrized from the origin. It stays a small fraction of
+            the geometry for any ordinary knot vector; at a reach of ``1e13`` -- a knot
+            span ten trillion times further from the origin than it is wide -- it reaches
+            ``0.14`` of the bounding-box diagonal, and a point ten percent outside the
+            image is reported found. Past ``1 / (64 * eps)`` the default is refused
+            outright rather than served. Pass an explicit ``tol`` wherever the distance
+            matters more than the default's derivation.
 
         Example:
             >>> cell_ids, ref_coords = surface.locate(surface.evaluate(pts))

--- a/src/pantr/bspline/_bspline_knot_removal.py
+++ b/src/pantr/bspline/_bspline_knot_removal.py
@@ -65,11 +65,15 @@ def _control_point_scale(ctrl: npt.NDArray[np.float32 | np.float64]) -> float:
 
     ``max(bounding-box diagonal, largest ||P_i||)`` over the rows of ``ctrl``, the same
     pairing of extent and coordinate magnitude that
-    :func:`~pantr.bspline._bspline_knots._knot_scale` makes in parametric space and
-    :func:`~pantr.bspline._bspline_locate._geometric_scale` in physical space. The
-    extent alone is not enough: a small part sitting at ``x = 1e6`` has control points
-    whose differences carry an absolute error of ``eps * 1e6`` however small the part
-    is.
+    :func:`~pantr.bspline._bspline_knots._knot_scale` makes in parametric space and that
+    :func:`~pantr.bspline._bspline_locate._geometric_scale` makes for the physical half
+    of its own scale. The extent alone is not enough: a small part sitting at ``x = 1e6``
+    has control points whose differences carry an absolute error of ``eps * 1e6`` however
+    small the part is.
+
+    The third length that inversion's scale carries -- what the *parametrization* can
+    resolve -- has no counterpart here. Knot removal grades a distance between control
+    points, which no parametric coordinate enters.
 
     Computed on the array as given, so for a rational spline it is the scale of the
     *homogeneous* control points, which is the space the kernel measures in.

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -274,13 +274,21 @@ class _LocateContext(NamedTuple):
             when it is already ``float64``, otherwise an exact promoted copy.
         bvh (BVH): Hierarchy over the per-cell physical control-point boxes, with cell
             ids flat in C-order over ``space.num_intervals``.
-        scale (float): The geometric scale the default tolerance is expressed in; see
-            :func:`_geometric_scale`.
+        scale (float): The length the default tolerance is expressed in, covering the
+            geometry's size, its distance from the origin, and what its parametrization
+            can resolve; see :func:`_geometric_scale`.
+        diagonal (float): The geometry's own bounding-box diagonal, kept alongside the
+            scale it feeds because :func:`_locate_impl` grades the parametric term against
+            it before accepting a default threshold.
+        parametric (float): The parametric length from :func:`_parametric_scale`, kept for
+            the same comparison.
     """
 
     spline: Bspline
     bvh: BVH
     scale: float
+    diagonal: float
+    parametric: float
 
 
 def _physical_control_points(spline: Bspline) -> npt.NDArray[np.float64]:
@@ -368,22 +376,213 @@ def _cell_physical_bounds(
     return lo.reshape(n_cells, rank), hi.reshape(n_cells, rank)
 
 
-def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -> float:
+def _parametric_reach(domain: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Return, per direction, how far the parametric box sits from the origin in its own widths.
+
+    ``max(|lo_k|, |hi_k|) / (hi_k - lo_k)``: the dimensionless factor by which the
+    representable parameters around the box are coarser, *relative to the extent they have
+    to resolve*, than they would be on a box touching the origin. It is one for a knot
+    vector spanning ``[0, L]``, one half for one spanning ``[-a, a]``, and grows linearly
+    once the box is further from the origin than it is wide. :func:`_geometric_scale` is
+    where it is used and where the argument for it is written down.
+
+    Returned per direction rather than reduced here, because it is only meaningful paired
+    with *that same direction's* physical span: reducing first would pair the worst-offset
+    direction with another direction's stretch, which on an anisotropic domain over-loosens
+    the threshold by exactly the ratio between them -- a factor of ``1e6`` on a map whose
+    second direction has a ``1e-6`` image extent, on geometry the physical-only threshold
+    inverted without losing anything. See :func:`_parametric_scale`.
+
+    A direction with no extent contributes nothing rather than dividing by zero. Such a
+    direction carries no knot span, hence no cell for the inversion to place anything in,
+    and an infinite scale would report every query *found* -- the opposite failure to the
+    one the reach exists to remove, and the worse of the two. The test is for an exact zero,
+    which is narrower than the B-spline layer's own notion of a vanishing extent
+    (``8 * eps * scale``): a positive extent below that is possible only through
+    ``snap_knots=False``, and is a knot vector whose own layer would not vouch for it.
+
+    Args:
+        domain (npt.NDArray[np.float64]): The parametric box, shape ``(dim, 2)``, as
+            :attr:`pantr.bspline.BsplineSpace.domain` returns it.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(dim,)``, non-negative and finite.
+    """
+    lo, hi = domain[:, 0], domain[:, 1]
+    extent = hi - lo
+    magnitude = np.maximum(np.abs(lo), np.abs(hi))
+    return np.divide(magnitude, extent, out=np.zeros_like(extent), where=extent > 0.0)
+
+
+def _net_span_per_direction(spline: Bspline) -> npt.NDArray[np.float64]:
+    """Return the physical length each parametric direction sweeps, one entry per direction.
+
+    For direction ``k``, the diagonal of the bounding box of one line of the control net
+    along ``k``, maximised over the transverse indices. This is the factor that supplies
+    ``sigma_max`` in :func:`_geometric_scale`'s derivation: it stands for ``L_k *
+    ||J e_k||``, the physical length a full traverse of direction ``k`` covers.
+
+    **Exact for an affine map.** The net line is then a straight segment, whose coordinate
+    box has sides ``|B_i - A_i|`` and therefore diagonal exactly ``||B - A||``; and ``B - A``
+    is ``L_k * J e_k``, because an open knot vector's Greville abscissae span the full
+    parametric extent and linear precision reproduces the affine map on them.
+
+    **Why the box of the line and not its chord.** The chord ``||P_last - P_first||`` is also
+    exact for an affine map and cheaper, but it vanishes on a direction that doubles back --
+    a folded map whose net returns to where it started -- and a zero there would delete the
+    parametric term exactly where the map is hardest, reintroducing the defect this exists to
+    remove. The bounding box measures the excursion instead of the displacement, so it is
+    never smaller than the chord and never larger than the geometry's own diagonal (the line
+    lies inside the control-point box).
+
+    Args:
+        spline (Bspline): A ``float64`` spline; rational splines are read through their
+            projected control points, as the rest of this module does.
+
+    Returns:
+        npt.NDArray[np.float64]: Shape ``(dim,)``, non-negative.
+    """
+    cp = _physical_control_points(spline)
+    spans = np.empty(spline.dim, dtype=np.float64)
+    for axis in range(spline.dim):
+        line_extent = cp.max(axis=axis) - cp.min(axis=axis)
+        spans[axis] = float(np.linalg.norm(line_extent, axis=-1).max())
+    return spans
+
+
+def _parametric_scale(spline: Bspline) -> float:
+    """Return the physical length the parametrization's own resolution puts a floor at.
+
+    ``max_k [ reach_k * net_span_k ]``, pulled into the format the *iterate* carries. The
+    pairing is per direction and the maximum is taken over the products, never over the two
+    factors separately; :func:`_parametric_reach` says what goes wrong otherwise.
+
+    **The precision ratio.** The inversion always iterates in ``float64``, whatever the
+    caller's spline carries -- see this module's precision contract. So one ulp of a
+    parametric coordinate is ``eps64 * |xi|`` even for a ``float32`` caller, while
+    :func:`_locate_impl` multiplies this length by ``get_default(spline.dtype)``, which is
+    ``64 * eps32`` there. Handing that tier a ``float64`` quantization would overshoot by
+    ``eps32 / eps64``, a factor of ``5.4e8``, and it shows: an otherwise ordinary
+    ``float32`` patch of unit size at a parametric offset of ``1e5`` would be given a
+    threshold of ``0.76`` of its own diameter, so a query half a diameter outside its image
+    would be reported found. Multiplying by ``eps64 / eps(dtype)`` cancels the caller's
+    format back out, leaving ``64 * eps64 * reach * span`` in every format. The ratio is
+    exactly ``1.0`` for a ``float64`` spline, which is the common path.
+
+    The two physical lengths in :func:`_geometric_scale` are deliberately *not* treated this
+    way. They grade the caller's own data, whose precision really is the caller's format;
+    this one grades the solver's iterate, whose precision is not.
+
+    Args:
+        spline (Bspline): The spline being inverted, before promotion, so that its dtype is
+            the caller's.
+
+    Returns:
+        float: A physical length, non-negative and finite.
+    """
+    domain = np.asarray(spline.space.domain, dtype=np.float64)
+    products = _parametric_reach(domain) * _net_span_per_direction(spline)
+    precision_ratio = float(np.finfo(np.float64).eps) / float(np.finfo(spline.dtype).eps)
+    return precision_ratio * float(products.max())
+
+
+def _geometric_scale(
+    lo: npt.NDArray[np.float64],
+    hi: npt.NDArray[np.float64],
+    parametric: float,
+) -> float:
     """Return the length the default convergence tolerance is a multiple of.
 
-    Two lengths matter and the larger one has to win:
+    Three lengths matter and the largest one has to win:
 
     - the **diagonal** of the geometry's bounding box, which is what makes a residual
-      threshold a *relative* accuracy statement about the mapping; and
+      threshold a *relative* accuracy statement about the mapping;
     - the largest coordinate **magnitude** present, because the computed residual
       ``F(xi) - x`` cannot be resolved below ``~C * eps * max|coordinate|`` (the de Boor
       sum accumulates ``C`` roundings, of the order of ``prod(degree + 1)``), whatever
-      the box's extent is.
+      the box's extent is; and
+    - the **parametric** length of :func:`_parametric_scale`, because a parametric
+      coordinate is a float64 too and the residual cannot be resolved below what one ulp
+      of it produces.
 
     Using the diagonal alone silently makes the tolerance unreachable for a geometry far
     from the origin -- a patch of diameter 1 sitting at ``x = 1e6`` has a residual floor
     around ``1e-10`` while ``eps * 1`` would be demanded -- so the scale is the maximum
-    of the two.
+    of them all.
+
+    **The parametric term.** The first two lengths are properties of the image alone, and
+    a threshold built from them is equally unreachable whenever the *parametrization*
+    cannot resolve the geometry that finely. One ulp of a parametric coordinate is ``eps *
+    |xi_k|``, which the map turns into a physical displacement of ``eps * |xi_k| * ||J
+    e_k||``, so no representable parameter drives the residual below about half the
+    largest such step, however good the solver is. That is a floor of exactly the kind the
+    ``magnitude`` term already covers, and it is invisible to both of the other lengths:
+    translating the knot vector changes it and changes neither of them. Measured on a
+    unit-width span carrying the exactly affine map ``F(xi) = xi - offset``, against the
+    threshold the two physical lengths alone give: the floor is ``0.008`` of it at offset
+    zero, ``0.504`` at ``1e2``, ``4.0`` at ``1e3`` and ``4096`` at ``1e6``, and every
+    query is lost from ``1e3`` upward.
+
+    Splitting that floor at the parametric extent ``L_k = hi_k - lo_k`` separates what can
+    be read off the space from what cannot::
+
+        eps * |xi_k| * ||J e_k||  ==  eps * (|xi_k| / L_k) * (L_k * ||J e_k||)
+
+    The first factor is the reach of :func:`_parametric_reach`. The second is the physical
+    length a full traverse of direction ``k`` sweeps, and **the control net's span along
+    that direction supplies it** -- that is where ``sigma_max`` enters, through
+    :func:`_net_span_per_direction`, exactly for an affine map. The product is formed **per
+    direction and maximised afterwards**. Maximising the two factors separately, as an
+    earlier form of this did, pairs the worst-offset direction with a different direction's
+    stretch: measured on an affine map whose second direction sits at offset ``1e6`` while
+    its image extent shrinks, that inflates the threshold to ``2.4e6`` times the attainable
+    floor once the extent reaches ``1e-4``, on geometry the two physical lengths alone had
+    inverted without losing anything. With the product formed per direction the ratio stays
+    at ``244`` across all four decades of extent. Shrinking the extent further keeps
+    widening the gap, but stops being worth quoting a number for: the floor falls below one
+    ulp of unity, where which representable point is sampled moves it by a factor of a few.
+    The *term's* own inflation there is exact and needs no measurement -- it is
+    ``diagonal / net_span_1``, so ``1e6`` at an extent of ``1e-6``.
+
+    **What the substitution assumes, and what the tier absorbs.** A map whose local stretch
+    exceeds the average over its own direction has a floor above this length, by the
+    amplification ``A = max_k L_k * sup||J e_k|| / net_span_k``. The floor is a half ulp and
+    the tier is ``64 * eps``, so the gap is absorbed to ``A`` of order ``100``: measured on a
+    degree-1 monotone family carrying half its rise in a single span, floor over threshold
+    is ``0.13`` at ``A == 32`` and ``0.53`` at ``A == 128``, passing one between ``A == 128``
+    and ``A == 256``.
+
+    Three things about that limit, so it is not read as more than it is. It is **not new**:
+    the physical ``diagonal`` has always stood in for stretch the same way, and the identical
+    sweep at reach one -- where this term is inactive -- also loses queries once ``A``
+    reaches a few hundred. ``A`` is **unbounded** over legal inputs, rationals included, so
+    this term is a mitigation and not a guarantee. And past the limit the queries are lost
+    against the *physical-only* threshold too, by decades more, so what remains is a residue
+    of the same defect rather than anything the cure introduced.
+
+    **Why the reach and not the parametric magnitude alone.** Dividing by the extent is
+    what keeps the threshold covariant. Under ``xi -> lam * xi`` the coordinate magnitude
+    grows by ``lam`` while the Jacobian shrinks by it, so the physical floor is unchanged
+    and the threshold must be too; a term reading ``max|xi_k|`` without the extent would
+    scale with ``lam``, and a pure reparametrization would change the accuracy demanded of
+    an answer that did not move.
+
+    **Why it multiplies a span and not the magnitude.** The parametric floor is a statement
+    about stretch, and only a span measures stretch: a constant map has ``J == 0`` and no
+    parametric floor at all whatever its coordinates are, and reading the magnitude there
+    would invent one. It is also what holds the term at its floor for ordinary geometry --
+    reach is one for a knot vector spanning ``[0, L]`` and one half for ``[-a, a]``, and no
+    net span exceeds the diagonal, so the term cannot be what decides the maximum.
+    **Bitwise** for the common case, not merely to within a rounding: on a map whose net
+    span along the widest direction *is* the diagonal, ``[0, L]`` gives ``reach == L / L``,
+    exactly ``1.0`` in IEEE arithmetic, and ``1.0 * diagonal`` is exactly ``diagonal``, so
+    the three-way maximum is the two-way one bit for bit. Where the net span is shorter the
+    term is strictly smaller and the maximum returns the physical value unchanged anyway.
+    Nothing parametrized from the origin is held to a different bar than it was.
+
+    An offset that is neither zero nor large does loosen the threshold, and is meant to: a
+    knot vector spanning ``[1, 2]`` has reach two, so its bar doubles, because its floor
+    doubles too.
 
     **What the default tier buys, measured.** :func:`pantr.tolerance.get_default` is
     ``64 * eps``, and an earlier reading of this called that a six percent margin over an
@@ -418,6 +617,7 @@ def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -
         lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
             ``(n_cells, rank)``.
         hi (npt.NDArray[np.float64]): Per-cell box upper corners, same shape.
+        parametric (float): The parametric length from :func:`_parametric_scale`.
 
     Returns:
         float: The geometric scale, strictly positive.
@@ -426,7 +626,7 @@ def _geometric_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -
     box_hi = hi.max(axis=0)
     diagonal = float(np.linalg.norm(box_hi - box_lo))
     magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
-    scale = max(diagonal, magnitude)
+    scale = max(diagonal, magnitude, parametric)
     return scale if scale > 0.0 else 1.0
 
 
@@ -443,8 +643,16 @@ def _build_context(spline: Bspline) -> _LocateContext:
     """
     spline_64 = _promote_to_float64(spline)
     lo, hi = _cell_physical_bounds(spline_64)
+    # Read from the caller's spline, not the promoted one: the precision ratio it applies
+    # has to see the format the caller's tier will be taken from.
+    parametric = _parametric_scale(spline)
+    box_lo, box_hi = lo.min(axis=0), hi.max(axis=0)
     return _LocateContext(
-        spline=spline_64, bvh=BVH.from_cell_bounds(lo, hi), scale=_geometric_scale(lo, hi)
+        spline=spline_64,
+        bvh=BVH.from_cell_bounds(lo, hi),
+        scale=_geometric_scale(lo, hi, parametric),
+        diagonal=float(np.linalg.norm(box_hi - box_lo)),
+        parametric=parametric,
     )
 
 
@@ -757,6 +965,11 @@ def _newton_refine(
         lo=lo,
         hi=hi,
     )
+    # Tested before the first step, so a starting guess already inside the threshold is
+    # returned untouched. That is what makes the threshold a stopping rule and not only an
+    # acceptance rule: under a large one -- a geometry far from either origin -- the cell
+    # midpoint can pass here, and the coordinate that comes back is then accurate to the
+    # threshold rather than to what the map could have delivered.
     converged = state.res_norm <= tol_phys
     active = np.arange(xi.shape[0], dtype=np.int64)[~converged]
 
@@ -856,6 +1069,65 @@ def _validate_invertible(spline: Bspline, tol: float | None, max_iter: int) -> N
         raise ValueError(f"locate: tol must be positive and finite; got {tol}.")
 
 
+def _default_tolerance(spline: Bspline, context: _LocateContext) -> float:
+    """Return the default convergence threshold, or refuse a parametrization that has none.
+
+    ``get_default(dtype) * scale``, with ``scale`` from :func:`_geometric_scale`, except
+    that a parametrization whose own resolution would demand a threshold larger than the
+    geometry it grades is refused instead of served.
+
+    **Why refuse rather than clamp.** Past that point the answer carries no information: a
+    "found" verdict admitting more than a whole diameter of error says only that the query
+    was somewhere near the model. Clamping the scale back would restore an accuracy that
+    *cannot be attained*, which is precisely the defect the parametric term exists to
+    remove -- the same bug, relocated to the far end of the range rather than fixed. So the
+    only honest answers are to serve a meaningless threshold or to say so, and this library
+    already says so elsewhere: :func:`pantr.bspline._bspline_knots._check_snapping_kept_an_interval`
+    refuses a knot vector whose mesh the format cannot resolve, and names the same remedy.
+
+    **Where the line is.** ``get_default(dtype) * parametric > diagonal``: the one place no
+    constant has to be invented, since it compares two lengths the geometry itself supplies
+    and is therefore covariant under scaling the geometry and invariant under scaling the
+    parametrization. It fires only above a reach of ``1 / (64 * eps)``, about ``7e13`` --
+    a knot span sitting seventy trillion times further from the parametric origin than it
+    is wide, and within a factor of eight of what the knot layer refuses outright.
+
+    **What it deliberately does not cover.** Below that line the threshold can still be a
+    sizeable fraction of the geometry: a reach of ``1e13`` buys ``0.14`` of a diameter, at
+    which a query ten percent outside the image is reported found. That is a real loss of
+    meaning and it is stated in :meth:`pantr.bspline.Bspline.locate`'s docstring rather
+    than legislated here, because every candidate line below ``1`` is a number someone
+    picked. The physical half of the scale is left alone entirely: a small geometry far
+    from the origin has always been graded this way, and that behaviour is correct.
+
+    An explicit ``tol`` is never refused. A caller who names a threshold has taken
+    responsibility for what it means, and may well be asking a proximity question rather
+    than an inversion one.
+
+    Args:
+        spline (Bspline): The spline being inverted, whose dtype sets the tolerance tier.
+        context (_LocateContext): Its cached inversion state.
+
+    Returns:
+        float: The default threshold on ``||F(xi) - x||_2``, strictly positive.
+
+    Raises:
+        ValueError: If the parametric term alone would put the threshold above the
+            geometry's own bounding-box diagonal.
+    """
+    tier = get_default(spline.dtype)
+    if tier * context.parametric > context.diagonal:
+        raise ValueError(
+            "locate: this knot vector sits so far from the parametric origin that one ulp "
+            "of a parametric coordinate moves the image by more than the geometry's own "
+            f"size ({tier * context.parametric:.3e} against a bounding-box diagonal of "
+            f"{context.diagonal:.3e}), so no residual threshold can mean anything. Move "
+            "the knot vector nearer the parametric origin, or pass an explicit tol to say "
+            "what distance you want."
+        )
+    return tier * context.scale
+
+
 def _locate_impl(
     spline: Bspline,
     points: npt.ArrayLike,
@@ -886,7 +1158,9 @@ def _locate_impl(
         ValueError: If ``rank < dim``, any direction is periodic, a rational spline has
             a non-positive weight, ``points`` has a bad shape or a non-finite entry,
             ``max_iter < 1``, or ``tol`` is given and is not positive and finite. See
-            :func:`_validate_invertible` and :func:`_validate_points`.
+            :func:`_validate_invertible` and :func:`_validate_points`. Also if ``tol`` is
+            ``None`` and the parametrization cannot support any meaningful threshold; see
+            :func:`_default_tolerance`.
     """
     dim, rank = spline.dim, spline.rank
     _validate_invertible(spline, tol, max_iter)
@@ -899,13 +1173,20 @@ def _locate_impl(
 
     pts = _validate_points(points, rank)
     context = _locate_context(spline)
-    tol_phys = float(tol) if tol is not None else get_default(spline.dtype) * context.scale
+    tol_phys = float(tol) if tol is not None else _default_tolerance(spline, context)
 
     n_pts = pts.shape[0]
     cell_ids = np.full(n_pts, -1, dtype=np.int64)
     ref_coords = np.full((n_pts, dim), np.nan, dtype=np.float64)
 
     # Candidates per point, in ascending cell id: the order the rounds below try them in.
+    # The pad is the threshold itself, so a geometry whose threshold is large -- far from
+    # the physical origin, or far from the parametric one -- returns more candidate cells
+    # per query. That costs solves, never correctness: every extra candidate still has to
+    # pass the same residual test. Measured on a 16x16-cell patch, mean candidates per
+    # query: 4.0 (of 256) at parametric offsets up to 1e9, 7.0 at 1e11, 57.1 at 1e13 --
+    # the blow-up starting only where the verdict is already near-meaningless and
+    # _default_tolerance is about to refuse outright.
     candidates = [np.sort(context.bvh.query_aabb(AABB(x, x).pad(tol_phys))) for x in pts]
     pending = [i for i, cand in enumerate(candidates) if cand.size > 0]
     found: list[int] = []

--- a/src/pantr/multipatch/_detect.py
+++ b/src/pantr/multipatch/_detect.py
@@ -114,8 +114,10 @@ def _joint_tolerances(patch_a: Bspline, patch_b: Bspline, tol: float | None) -> 
     # absolute error of eps * 1e6 however short the diagonal is; grading against the
     # diagonal there asks for agreement eight orders below the noise floor. The largest
     # coordinate magnitude is therefore taken alongside it and the larger wins -- the
-    # same rule, for the same reason, as `_knot_scale` in the B-spline layer and
-    # `_geometric_scale` in point inversion.
+    # same rule, for the same reason, as `_knot_scale` in the B-spline layer and as the
+    # physical half of `_geometric_scale` in point inversion. That one carries a third
+    # length for what its parametrization resolves, which has no counterpart here: this
+    # grades a distance between two physical corner coordinates.
     magnitude = float(np.abs(coords).max()) if coords.size else 0.0
     scale = max(diagonal, magnitude)
     # A degenerate joint bounding box (both patches a single point, at the origin)

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._numba_compat import wait_for_jit_warmup
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.bspline._bspline_locate import (
     _cell_midpoints,
@@ -46,6 +47,15 @@ The convergence threshold is :func:`pantr.tolerance.get_default` for ``float32``
 (``1e-6``) times the geometric scale, so the coordinate error is four orders of magnitude
 larger than in the ``float64`` case. Measured worst case over the cases below:
 ``5.2e-6``; the ``1e-4`` leaves a factor of 19.
+"""
+
+_PARAMETRIC_OFFSETS: list[float] = [0.0, 1.0e2, 1.0e3, 1.0e4, 1.0e6]
+"""
+Parametric offsets of a unit-width knot span, spanning the resolution frontier.
+
+On the fixture below the attainable residual floor is ``0.008`` of the physical-only
+threshold at ``0``, half of it at ``1e2``, and four times it at ``1e3`` -- the first row
+that is impossible to satisfy. At ``1e6`` it is 4096 times the threshold.
 """
 
 _CYCLING_PARAMETER: npt.NDArray[np.float64] = np.array([[0.05411231, 0.64513102]])
@@ -188,6 +198,65 @@ def _collapsed_edge_patch() -> Bspline:
     return Bspline(BsplineSpace([sub, sub]), cp)
 
 
+def _offset_identity_patch(
+    offset: float, degree: int = 2, n_elem: int = 4, dim: int = 1, size: float = 1.0
+) -> Bspline:
+    """Return ``F(xi) = size * (xi - offset)`` on the parametric box ``[offset, offset + 1]``.
+
+    The map is *exactly* affine: the control points are the Greville abscissae less the
+    offset, scaled by ``size``, and linear precision reproduces an affine map exactly. So
+    every singular value of the Jacobian is ``size`` at every point, which is the best
+    conditioned a non-degenerate map can be. Whatever such a patch loses is therefore lost
+    to the parametrization's own resolution and not to conditioning, which is what makes it
+    the fixture for moving the parametric offset while holding the geometry fixed.
+    """
+    knots = np.concatenate(
+        [
+            np.full(degree, offset),
+            np.linspace(offset, offset + 1.0, n_elem + 1),
+            np.full(degree, offset + 1.0),
+        ]
+    )
+    spaces = [BsplineSpace1D(knots, degree) for _ in range(dim)]
+    axes = [size * (_greville_abscissae(sub) - offset) for sub in spaces]
+    mesh = np.meshgrid(*axes, indexing="ij")
+    cp = np.stack(mesh, axis=-1) if dim > 1 else mesh[0][:, np.newaxis]
+    return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp))
+
+
+def _half_ulp_targets(spline: Bspline, xi_true: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Return targets midway between the images of two consecutive representable parameters.
+
+    The hardest request the parametric grid can carry: the target sits halfway between
+    ``F(xi)`` and ``F(nextafter(xi))``, so no representable parameter maps nearer than half
+    the local image spacing, however good the solver is. Asking for the image of ``xi``
+    itself would instead make the exact preimage a solution and hide the resolution limit
+    entirely.
+    """
+    domain = np.asarray(spline.space.domain, dtype=np.float64)
+    upper = np.nextafter(xi_true, domain[:, 1])
+    return 0.5 * (_evaluate_at(spline, xi_true) + _evaluate_at(spline, upper))
+
+
+def _attainable_floor_1d(
+    spline: Bspline, xi_true: npt.NDArray[np.float64], targets: npt.NDArray[np.float64]
+) -> float:
+    """Return the smallest residual any representable parameter can reach, over the queries.
+
+    Scans each parameter and its two neighbours. On a strictly increasing one-dimensional
+    map that is exhaustive rather than a sample: the residual is unimodal in the parameter,
+    so its minimum over *all* representable parameters is attained at one of the two
+    bracketing the target, and widening the scan cannot lower it.
+    """
+    lo, hi = np.asarray(spline.space.domain, dtype=np.float64)[0]
+    worst = 0.0
+    for xi, target in zip(xi_true[:, 0].tolist(), targets[:, 0].tolist(), strict=True):
+        neighbours = np.array([[np.nextafter(xi, lo)], [xi], [np.nextafter(xi, hi)]])
+        residuals = np.abs(_evaluate_at(spline, neighbours)[:, 0] - target)
+        worst = max(worst, float(residuals.min()))
+    return worst
+
+
 def _scale_of(spline: Bspline) -> float:
     """Return the geometric scale the default tolerance is expressed in."""
     return _geometric_scale(*_cell_physical_bounds(spline))
@@ -215,7 +284,17 @@ def _sample_parametric(
 
 
 def _evaluate_at(spline: Bspline, xi: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-    """Evaluate ``spline`` at ``(n, dim)`` parametric points, always returning ``(n, rank)``."""
+    """Evaluate ``spline`` at ``(n, dim)`` parametric points, always returning ``(n, rank)``.
+
+    Waits for the import-time JIT warmup first, for the reason
+    :class:`TestNumbaWarmup` states: :meth:`Bspline.evaluate` is not itself behind that
+    barrier, so a test that evaluates before it locates is a bare ``parallel=True`` call
+    racing the background compilation thread, and the process *aborts* rather than raising.
+    Measured on this file: a selection whose first act is a burst of evaluations aborted 5
+    of 5 runs without this, and 0 of 5 with it. The barrier is once per process, so every
+    call after the first costs nothing.
+    """
+    wait_for_jit_warmup()
     pts = np.ascontiguousarray((xi[:, 0] if spline.dim == 1 else xi).astype(spline.dtype))
     values = spline.evaluate(pts)
     return np.asarray(values, dtype=np.float64).reshape(xi.shape[0], spline.rank)
@@ -865,6 +944,209 @@ class TestToleranceScaling:
         cp = np.full((2, 2, 2), 1.0e-6, dtype=np.float64)
         point_map = Bspline(BsplineSpace([sub, sub]), cp)
         assert _scale_of(point_map) == pytest.approx(1.0e-6, rel=1e-12)
+
+
+class TestParametricResolution:
+    """The default threshold also follows what the *parametrization* can resolve.
+
+    One ulp of a parametric coordinate is ``eps * |xi|``, which a map of stretch ``sigma``
+    turns into a physical residual of ``eps * |xi| * sigma``. A threshold read off the
+    physical side alone is therefore unreachable for a knot span sitting far from the origin
+    relative to its own width, and every query on such a patch is reported not found although
+    it has a preimage.
+    """
+
+    def test_the_frontier_parametric_offset_is_recovered(self) -> None:
+        """The exact case where the attainable floor first passes the old threshold.
+
+        At an offset of ``1e3`` on a unit-width knot span the smallest residual any
+        representable parameter can reach is four times the threshold the old rule demanded,
+        so all 25 queries were reported not found. Kept as its own test, separate from the
+        sweep, because it is the frontier: a threshold that grew with the offset but too
+        slowly would still pass the ``0`` and ``1e2`` rows and fail here.
+        """
+        spline = _offset_identity_patch(1.0e3)
+        xi_true = _sample_parametric(spline, 25, seed=11, margin=0.05)
+        targets = _half_ulp_targets(spline, xi_true)
+        floor = _attainable_floor_1d(spline, xi_true, targets)
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        tol = get_default(spline.dtype) * _scale_of(spline)
+        assert floor <= tol, f"the request is impossible: floor {floor:.3e} over tol {tol:.3e}"
+        assert np.all(cell_ids >= 0), f"lost {int(np.sum(cell_ids < 0))} of 25 queries"
+        residuals = np.abs(_evaluate_at(spline, ref_coords)[:, 0] - targets[:, 0])
+        assert residuals.max() <= tol
+
+    @pytest.mark.parametrize("offset", _PARAMETRIC_OFFSETS)
+    def test_a_shifted_knot_span_loses_no_query_that_has_a_preimage(self, offset: float) -> None:
+        """Every offset of the ticket's table, including the ``1e6`` end.
+
+        The geometry is identical in all five rows -- the same unit segment, the same
+        Jacobian of exactly one -- and only the knot vector moves, so a row that loses points
+        can only have lost them to the parametrization.
+        """
+        spline = _offset_identity_patch(offset)
+        xi_true = _sample_parametric(spline, 25, seed=11, margin=0.05)
+        targets = _half_ulp_targets(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        assert np.all(cell_ids >= 0), f"lost {int(np.sum(cell_ids < 0))} of 25 at offset {offset}"
+        residuals = np.abs(_evaluate_at(spline, ref_coords)[:, 0] - targets[:, 0])
+        assert residuals.max() <= get_default(spline.dtype) * _scale_of(spline)
+
+    @pytest.mark.parametrize("offset", _PARAMETRIC_OFFSETS)
+    def test_the_threshold_stays_above_the_attainable_floor(self, offset: float) -> None:
+        """The derivation, checked directly rather than through the solver.
+
+        What went wrong was not a solver that gave up but a bar set below anything a float64
+        parameter can reach. This measures the bar and the floor separately and asserts the
+        order between them, so it still fails if a future change makes the queries pass for
+        some unrelated reason.
+        """
+        spline = _offset_identity_patch(offset)
+        xi_true = _sample_parametric(spline, 25, seed=11, margin=0.05)
+        targets = _half_ulp_targets(spline, xi_true)
+
+        floor = _attainable_floor_1d(spline, xi_true, targets)
+        tol = get_default(spline.dtype) * _scale_of(spline)
+
+        assert floor <= tol, f"floor {floor:.3e} over tol {tol:.3e} at offset {offset}"
+
+    @pytest.mark.parametrize(
+        ("name", "spline", "expected"),
+        [
+            ("quarter annulus", _quarter_annulus(), 2.8284271247461903),
+            ("warped 2-D degree 1", _warped_patch(), 1.781637023790572),
+            ("warped 3-D degree 3", _warped_patch(dim=3, degree=3, n_elem=3), 2.226234269696677),
+            ("perturbed degree 3 on [0, 4]", _perturbed_patch(3, 4, 2, seed=7), 5.910822971201255),
+            ("folded", _folded_patch(), 2.6704143675085485),
+            ("stretched", _stretched_patch(), 2.27072620893615),
+            (
+                "identity 2-D degree 2",
+                _identity_map([0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0], 2, 2),
+                1.4142135623730951,
+            ),
+        ],
+    )
+    def test_a_knot_vector_starting_at_the_origin_keeps_todays_scale(
+        self, name: str, spline: Bspline, expected: float
+    ) -> None:
+        """Ordinary geometry is held to exactly the bar it was held to before.
+
+        The threshold is an accuracy contract rather than a safety margin, so loosening it
+        degrades every returned coordinate one-for-one. A knot vector spanning ``[0, L]``
+        resolves its own extent to ``eps`` relative -- the parametric term is at its floor
+        there -- and these are the values measured before the term existed.
+        """
+        assert _scale_of(spline) == pytest.approx(expected, rel=1e-15), name
+
+    @pytest.mark.parametrize("half_width", [1.0, 1.0e-3, 1.0e6])
+    def test_a_knot_vector_centred_on_the_origin_keeps_todays_scale(
+        self, half_width: float
+    ) -> None:
+        """A symmetric parametrization resolves its extent better than a one-sided one.
+
+        On ``[-a, a]`` the largest coordinate is half the extent, so the parametric term is
+        half the physical one and can never be what decides the threshold. Pinning this
+        keeps a future form of the term from reading the *extent* where it must read the
+        distance from the origin.
+        """
+        degree, n_elem = 2, 4
+        knots = np.concatenate(
+            [
+                np.full(degree, -half_width),
+                np.linspace(-half_width, half_width, n_elem + 1),
+                np.full(degree, half_width),
+            ]
+        )
+        space = BsplineSpace1D(knots, degree)
+        cp = np.ascontiguousarray(_greville_abscissae(space)[:, np.newaxis])
+        spline = Bspline(BsplineSpace([space]), cp)
+
+        # Diagonal and magnitude of the image ``[-a, a]``: ``2a`` and ``a``.
+        assert _scale_of(spline) == pytest.approx(2.0 * half_width, rel=1e-15)
+
+    @pytest.mark.parametrize("size", [1.0e-3, 1.0, 1.0e3])
+    @pytest.mark.parametrize("offset", [0.0, 1.0e2, 1.0e3, 1.0e6])
+    @pytest.mark.parametrize("dim", [1, 2])
+    def test_the_sweep_over_offsets_and_physical_scales_loses_nothing(
+        self, dim: int, offset: float, size: float
+    ) -> None:
+        """Parametric offset and physical size vary independently; neither may lose a query.
+
+        Two decades of geometry either side of unit size crossed with four parametric
+        offsets. Sampling the parameter first and mapping it forward is what makes "has a
+        preimage" a fact about each query, and the map is injective here, so a ``-1`` would
+        be unambiguously wrong.
+        """
+        spline = _offset_identity_patch(offset, degree=2, n_elem=3, dim=dim, size=size)
+        xi_true = _sample_parametric(spline, 40, seed=int(dim * 977 + np.log10(size + 1.0)))
+        targets = _half_ulp_targets(spline, xi_true)
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        lost = np.flatnonzero(cell_ids < 0)
+        assert lost.size == 0, f"lost {lost.size} of 40 at {dim=}, {offset=}, {size=}"
+        residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - targets, axis=1)
+        tol = get_default(spline.dtype) * _scale_of(spline)
+        assert residuals.max() <= tol, f"worst residual {residuals.max():.3e} over tol {tol:.3e}"
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0e-3, 1.0e3, 1.0e6])
+    def test_the_scale_is_invariant_under_scaling_the_parametrization(self, lam: float) -> None:
+        """Rescaling the knot vector alone changes no physical quantity, so it changes no bar.
+
+        Under ``xi -> lam * xi`` the coordinate magnitude grows by ``lam`` and the Jacobian
+        shrinks by it, so the physical residual a one-ulp parametric step produces is
+        untouched. A term reading the parametric magnitude *without* dividing by the extent
+        would scale the threshold here and break covariance.
+        """
+        base = _offset_identity_patch(1.0e3, degree=2, n_elem=4)
+        knots = lam * np.asarray(base.space.spaces[0].knots, dtype=np.float64)
+        space = BsplineSpace1D(knots, base.space.spaces[0].degree)
+        rescaled = Bspline(BsplineSpace([space]), np.asarray(base.control_points).copy())
+
+        assert _scale_of(rescaled) == pytest.approx(_scale_of(base), rel=1e-12)
+
+    @pytest.mark.parametrize("lam", [1.0e-6, 1.0e-3, 1.0e3, 1.0e6])
+    def test_the_scale_is_proportional_to_the_geometry_at_a_parametric_offset(
+        self, lam: float
+    ) -> None:
+        """Scaling the geometry scales the threshold, offset parametrization included.
+
+        The parametric term is a physical length like the other two, so it must carry the
+        geometry's own factor rather than sit at a fixed size beside it.
+        """
+        unit = _offset_identity_patch(1.0e3, degree=2, n_elem=4, size=1.0)
+        scaled = _offset_identity_patch(1.0e3, degree=2, n_elem=4, size=lam)
+
+        assert _scale_of(scaled) == pytest.approx(lam * _scale_of(unit), rel=1e-12)
+
+    def test_a_parametric_direction_with_no_extent_keeps_the_scale_finite(self) -> None:
+        """A direction with no interval leaves nothing to divide by, and must not divide.
+
+        ``BsplineSpace1D`` accepts ``[a, a, a, a]``: a legal space with zero intervals, whose
+        domain has zero extent. The parametric term reads an extent as a denominator, so this
+        is the one input that could turn the threshold into ``inf`` or ``nan`` -- and an
+        infinite threshold reports every query "found", which is worse than the "not found"
+        this ticket exists to remove.
+
+        Exercised on the scale directly rather than through :meth:`Bspline.locate`, which
+        raises on such a space for an unrelated reason: with no knot-span cell there is no
+        per-cell box to reduce over. Guarding the division here keeps the term total on its
+        own inputs whatever that separate question is settled to.
+        """
+        box_lo = np.array([[0.0, 0.0]])
+        box_hi = np.array([[1.0, 1.0]])
+        domain = np.array([[5.0, 5.0], [0.0, 1.0]])
+
+        scale = _geometric_scale(box_lo, box_hi, domain)
+
+        assert np.isfinite(scale) and scale > 0.0
+        # The zero-extent direction contributes nothing; the ordinary one gives reach 1.
+        assert scale == pytest.approx(_geometric_scale(box_lo, box_hi, domain[1:]), rel=1e-15)
 
 
 class TestNearCriticalJacobian:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -20,6 +20,8 @@ from pantr.bspline._bspline_locate import (
     _LocateContext,
     _nearest_corner_starts,
     _newton_refine,
+    _parametric_reach,
+    _parametric_scale,
 )
 from pantr.geometry import AABB
 from pantr.tolerance import get_default
@@ -257,9 +259,80 @@ def _attainable_floor_1d(
     return worst
 
 
+def _steep_span_patch(offset: float, n_elem: int, flat_fraction: float = 0.5) -> Bspline:
+    """Return a degree-1 monotone map of ``[offset, offset + 1]`` onto ``[0, 1]``, with a kink.
+
+    A fraction ``flat_fraction`` of the rise is spread uniformly over the whole span and the
+    rest is concentrated in one interior span, so ``sup|F'|`` is ``flat_fraction + (1 -
+    flat_fraction) * n_elem`` while the image stays exactly ``[0, 1]``. The amplification the
+    parametric term has to absorb is therefore set by ``n_elem`` alone, and is ``n_elem / 2 +
+    1 / 2`` at the default fraction.
+
+    This is the family the ``sigma_max`` substitution in :func:`_geometric_scale` is argued
+    against: a map whose *local* stretch exceeds the average over its own direction is
+    exactly what a net span underestimates.
+    """
+    knots = np.concatenate(
+        [[offset], np.linspace(offset, offset + 1.0, n_elem + 1), [offset + 1.0]]
+    )
+    space = BsplineSpace1D(knots, 1)
+    uniform = np.linspace(0.0, 1.0, n_elem + 1)
+    step = np.zeros(n_elem + 1)
+    step[n_elem // 2 + 1 :] = 1.0
+    cp = flat_fraction * uniform + (1.0 - flat_fraction) * step
+    return Bspline(BsplineSpace([space]), np.ascontiguousarray(cp[:, np.newaxis]))
+
+
+def _steep_span_queries(
+    spline: Bspline, n_elem: int, seed: int = 3
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return half-ulp queries placed inside the steep span, where the floor is highest."""
+    lo = np.asarray(spline.space.domain, dtype=np.float64)[0, 0]
+    rng = np.random.default_rng(seed)
+    xi_true = (lo + (n_elem // 2 + rng.uniform(0.05, 0.95, size=40)) / n_elem)[:, np.newaxis]
+    return xi_true, _half_ulp_targets(spline, xi_true)
+
+
+def _anisotropic_patch(offset1: float, extent1: float, degree: int = 2, n_elem: int = 4) -> Bspline:
+    """Return an affine 2-D map whose two directions differ in offset and in image size.
+
+    Direction 0 spans ``[0, 1]`` onto a unit image; direction 1 spans ``[offset1, offset1 +
+    1]`` onto an image of length ``extent1``. The two parametric resolutions are therefore
+    unrelated, which is what a term reducing over directions too early gets wrong.
+    """
+    axes, spaces = [], []
+    for offset, extent in ((0.0, 1.0), (offset1, extent1)):
+        knots = np.concatenate(
+            [
+                np.full(degree, offset),
+                np.linspace(offset, offset + 1.0, n_elem + 1),
+                np.full(degree, offset + 1.0),
+            ]
+        )
+        sub = BsplineSpace1D(knots, degree)
+        spaces.append(sub)
+        axes.append((_greville_abscissae(sub) - offset) * extent)
+    cp = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1)
+    return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp))
+
+
+def _physical_only_scale(spline: Bspline) -> float:
+    """Return the scale the rule gave before it had a parametric term.
+
+    Written out here rather than imported, so the "did this loosen anything" comparisons
+    have an oracle that cannot move with the code they grade.
+    """
+    lo, hi = _cell_physical_bounds(spline)
+    box_lo, box_hi = lo.min(axis=0), hi.max(axis=0)
+    diagonal = float(np.linalg.norm(box_hi - box_lo))
+    magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
+    scale = max(diagonal, magnitude)
+    return scale if scale > 0.0 else 1.0
+
+
 def _scale_of(spline: Bspline) -> float:
     """Return the geometric scale the default tolerance is expressed in."""
-    return _geometric_scale(*_cell_physical_bounds(spline))
+    return _geometric_scale(*_cell_physical_bounds(spline), _parametric_scale(spline))
 
 
 def _cache_of(spline: Bspline) -> _LocateContext | None:
@@ -1036,11 +1109,14 @@ class TestParametricResolution:
         """Ordinary geometry is held to exactly the bar it was held to before.
 
         The threshold is an accuracy contract rather than a safety margin, so loosening it
-        degrades every returned coordinate one-for-one. A knot vector spanning ``[0, L]``
-        resolves its own extent to ``eps`` relative -- the parametric term is at its floor
-        there -- and these are the values measured before the term existed.
+        degrades every returned coordinate one-for-one. These are the values measured before
+        the parametric term existed, and equality is asserted *bitwise* rather than to a
+        relative tolerance because it is exact and not merely close: a knot vector spanning
+        ``[0, L]`` gives ``reach == L / L``, which IEEE division makes exactly ``1.0``, and
+        ``1.0 * diagonal`` is exactly ``diagonal``, so the three-way maximum returns the
+        two-way one bit for bit. A term that perturbed it at all would fail here.
         """
-        assert _scale_of(spline) == pytest.approx(expected, rel=1e-15), name
+        assert _scale_of(spline) == expected, name
 
     @pytest.mark.parametrize("half_width", [1.0, 1.0e-3, 1.0e6])
     def test_a_knot_vector_centred_on_the_origin_keeps_todays_scale(
@@ -1065,11 +1141,28 @@ class TestParametricResolution:
         cp = np.ascontiguousarray(_greville_abscissae(space)[:, np.newaxis])
         spline = Bspline(BsplineSpace([space]), cp)
 
+        # ``a / (2a)``, which IEEE makes exactly one half since ``2a`` is exact.
+        reach = _parametric_reach(np.asarray(spline.space.domain, dtype=np.float64))
+        assert reach.tolist() == [0.5]
         # Diagonal and magnitude of the image ``[-a, a]``: ``2a`` and ``a``.
         assert _scale_of(spline) == pytest.approx(2.0 * half_width, rel=1e-15)
 
+    def test_a_moderately_offset_knot_vector_does_loosen_and_is_meant_to(self) -> None:
+        """The unchanged-at-the-origin pins must not be read as unchanged everywhere.
+
+        A knot vector spanning ``[1, 2]`` has reach two, so its threshold is exactly twice
+        the one the same geometry gets on ``[0, 1]`` -- because its resolution floor is twice
+        as high, one ulp of a coordinate near 2 being twice one near 1. This is the ordinary
+        intermediate case, and it is pinned so that "offset zero is unaffected" is not
+        mistaken for "no ordinary domain is affected".
+        """
+        at_origin = _offset_identity_patch(0.0)
+        offset_by_one = _offset_identity_patch(1.0)
+
+        assert _scale_of(offset_by_one) == pytest.approx(2.0 * _scale_of(at_origin), rel=1e-15)
+
     @pytest.mark.parametrize("size", [1.0e-3, 1.0, 1.0e3])
-    @pytest.mark.parametrize("offset", [0.0, 1.0e2, 1.0e3, 1.0e6])
+    @pytest.mark.parametrize("offset", _PARAMETRIC_OFFSETS)
     @pytest.mark.parametrize("dim", [1, 2])
     def test_the_sweep_over_offsets_and_physical_scales_loses_nothing(
         self, dim: int, offset: float, size: float
@@ -1133,20 +1226,171 @@ class TestParametricResolution:
         infinite threshold reports every query "found", which is worse than the "not found"
         this ticket exists to remove.
 
-        Exercised on the scale directly rather than through :meth:`Bspline.locate`, which
-        raises on such a space for an unrelated reason: with no knot-span cell there is no
-        per-cell box to reduce over. Guarding the division here keeps the term total on its
-        own inputs whatever that separate question is settled to.
+        Exercised on :func:`_parametric_reach` directly rather than through
+        :meth:`Bspline.locate`, which raises on such a space for an unrelated reason: with no
+        knot-span cell there is no per-cell box to reduce over. Guarding the division here
+        keeps the term total on its own inputs whatever that separate question is settled to.
         """
-        box_lo = np.array([[0.0, 0.0]])
-        box_hi = np.array([[1.0, 1.0]])
         domain = np.array([[5.0, 5.0], [0.0, 1.0]])
 
-        scale = _geometric_scale(box_lo, box_hi, domain)
+        reach = _parametric_reach(domain)
 
-        assert np.isfinite(scale) and scale > 0.0
+        assert np.all(np.isfinite(reach))
         # The zero-extent direction contributes nothing; the ordinary one gives reach 1.
-        assert scale == pytest.approx(_geometric_scale(box_lo, box_hi, domain[1:]), rel=1e-15)
+        assert reach.tolist() == [0.0, 1.0]
+
+
+class TestParametricStretch:
+    """The one substitution in the derivation, on the family built to break it.
+
+    ``_net_span_per_direction`` stands in for ``sup||J e_k||``. That is exact for an affine
+    map and an underestimate for one whose local stretch exceeds the average over its own
+    direction, by the amplification ``A = L_k * sup||J e_k|| / net_span_k``. The floor is a
+    half ulp against a tier of ``64 * eps``, so the gap is absorbed to ``A`` of order 100.
+    """
+
+    @pytest.mark.parametrize(("n_elem", "amplification"), [(4, 2.5), (64, 32.5), (256, 128.5)])
+    def test_a_locally_steep_map_is_recovered_while_the_tier_absorbs_its_stretch(
+        self, n_elem: int, amplification: float
+    ) -> None:
+        """Below the absorbed limit, a kinked map at a far parametric offset loses nothing.
+
+        Every one of these is lost outright without the parametric term, so the row is a
+        statement about the cure and not only about the substitution inside it.
+        """
+        spline = _steep_span_patch(1.0e6, n_elem)
+        xi_true, targets = _steep_span_queries(spline, n_elem)
+        slope = float(
+            np.abs(
+                np.asarray(
+                    spline.evaluate_derivatives(np.ascontiguousarray(xi_true[:, 0]), [1]),
+                    dtype=np.float64,
+                )
+            ).max()
+        )
+        assert slope == pytest.approx(amplification, rel=1e-9), "fixture must carry the stretch"
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        tol = get_default(spline.dtype) * _scale_of(spline)
+        assert _attainable_floor_1d(spline, xi_true, targets) <= tol
+        assert np.all(cell_ids >= 0), f"lost {int(np.sum(cell_ids < 0))} of 40 at A = {slope}"
+        assert np.abs(_evaluate_at(spline, ref_coords)[:, 0] - targets[:, 0]).max() <= tol
+
+    def test_past_the_absorbed_stretch_the_request_is_impossible_either_way(self) -> None:
+        """Where the substitution stops covering the floor, and why that is not a regression.
+
+        At ``A == 256`` the attainable floor passes the threshold and the queries go back to
+        being unreachable. What makes that a residue rather than a regression is the second
+        assertion: the physical-only threshold cannot reach the floor either, and by decades
+        more, so nothing here was working before and stopped.
+        """
+        spline = _steep_span_patch(1.0e6, 512)
+        xi_true, targets = _steep_span_queries(spline, 512)
+        floor = _attainable_floor_1d(spline, xi_true, targets)
+
+        tol_new = get_default(spline.dtype) * _scale_of(spline)
+        tol_old = get_default(spline.dtype) * _physical_only_scale(spline)
+
+        assert floor > tol_new, "the frontier is meant to sit between A = 128 and A = 256"
+        assert floor > tol_old * 1.0e3, "and the physical-only threshold is nowhere near it"
+        assert tol_new > tol_old, "the term only ever loosened this case"
+
+    @pytest.mark.parametrize("offset", _PARAMETRIC_OFFSETS)
+    @pytest.mark.parametrize("n_elem", [4, 256])
+    def test_the_parametric_term_never_tightens_the_threshold(
+        self, n_elem: int, offset: float
+    ) -> None:
+        """The term may loosen a threshold or leave it alone; it may never raise the bar.
+
+        With the bitwise-unchanged pin for a knot vector spanning ``[0, L]``, this is the
+        whole characterization of what the term is allowed to do, and it is what makes "no
+        geometry is held to a stricter bar than before" checkable rather than argued.
+        """
+        spline = _steep_span_patch(offset, n_elem)
+
+        assert _scale_of(spline) >= _physical_only_scale(spline)
+
+    def test_an_anisotropic_domain_pairs_each_offset_with_its_own_direction(self) -> None:
+        """The reach of one direction may not be multiplied by another direction's stretch.
+
+        Both patches put direction 0 on ``[0, 1]`` onto a unit image and direction 1 at a
+        parametric offset of ``1e6``; they differ only in direction 1's image extent. The
+        parametric length must follow *that* extent, because direction 1's resolution floor
+        is what its own reach and its own stretch produce.
+
+        Reducing the reach over directions before pairing it with a physical length gives
+        both patches ``1e6`` instead, handing direction 1's offset to direction 0's unit
+        stretch: a factor of ``1e6`` too loose on the thin patch, on geometry the
+        physical-only threshold had inverted without losing anything. The assertion is on
+        the two lengths rather than on a ratio to the attainable floor, because at this
+        extent that floor is below one ulp of unity and moves by a factor of a few with
+        which representable point is sampled.
+        """
+        thick = _anisotropic_patch(1.0e6, 1.0)
+        thin = _anisotropic_patch(1.0e6, 1.0e-6)
+
+        assert _parametric_scale(thick) == pytest.approx(1.0e6, rel=1.0e-5)
+        assert _parametric_scale(thin) == pytest.approx(1.0, rel=1.0e-5)
+
+    @pytest.mark.parametrize("window", [(984375.0, 1.0e6), (999984.375, 1.0e6)])
+    def test_restricting_a_patch_leaves_its_absolute_threshold_alone(
+        self, window: tuple[float, float]
+    ) -> None:
+        """A sub-patch is held to the same absolute bar as the parent it was cut from.
+
+        This is the property the reach form has and a diagonal alone cannot. Cutting a
+        window out of an affine map divides the geometry's diagonal by the same factor it
+        multiplies the reach by -- the sub-patch is smaller, but it sits proportionally
+        further from the parametric origin -- so the product, and with it the threshold, is
+        untouched. That is right: the physical resolution attainable at a point of the map
+        does not depend on how much of the map around it was kept.
+
+        Both windows are dyadic, so the restriction lands on exact breakpoints and the only
+        thing under test is the tolerance rule.
+        """
+        degree, n_cells = 2, 64
+        knots = np.concatenate(
+            [
+                np.zeros(degree),
+                np.linspace(0.0, 1.0e6, n_cells + 1),
+                np.full(degree, 1.0e6),
+            ]
+        )
+        space = BsplineSpace1D(knots, degree)
+        cp = np.ascontiguousarray((_greville_abscissae(space) / 1.0e6)[:, np.newaxis])
+        parent = Bspline(BsplineSpace([space]), cp)
+
+        child = parent.restrict(window)
+
+        assert _scale_of(child) == pytest.approx(_scale_of(parent), rel=1e-12)
+
+    def test_a_parametrization_that_cannot_carry_a_threshold_is_refused(self) -> None:
+        """Past a reach of ``1 / (64 * eps)`` the default threshold exceeds the geometry.
+
+        A "found" verdict admitting more than a whole diameter of error says only that the
+        query was somewhere near the model, so it is refused rather than served. Clamping
+        instead would demand an accuracy the parametrization cannot deliver, which is the
+        very defect the term exists to remove, relocated to the far end of the range.
+        """
+        spline = _offset_identity_patch(1.0e14, degree=1, n_elem=1)
+
+        with pytest.raises(ValueError, match="parametric origin"):
+            spline.locate(np.array([0.5]))
+
+        # An explicit tol is never refused: naming a distance is taking responsibility.
+        assert spline.locate(np.array([0.5]), tol=1.0e-3)[0].tolist() == [0]
+
+    def test_an_ordinary_far_offset_is_not_refused(self) -> None:
+        """The refusal must sit far above anything a real model reaches.
+
+        Seven decades of parametric offset below the line, all still served. The boundary is
+        ``1 / (64 * eps)``, about ``7e13``, which is within a factor of eight of what the
+        knot layer refuses outright.
+        """
+        for offset in (1.0e2, 1.0e6, 1.0e10, 1.0e12):
+            spline = _offset_identity_patch(offset, degree=1, n_elem=1)
+            assert spline.locate(np.array([0.5]))[0].tolist() == [0], f"refused at {offset}"
 
 
 class TestNearCriticalJacobian:


### PR DESCRIPTION
`Bspline.locate`'s default convergence threshold was derived from the geometry's **physical**
scale alone: `get_default(dtype) * max(diagonal, magnitude)`, both lengths read off the
control-point box. Nothing in it saw the parametrization.

But a parametric coordinate is a float64 too. One ulp of it is `eps * |xi|`, which the map
turns into a physical residual of about `eps * |xi| * ||J e_k||`, so for a knot span sitting
far from the origin relative to its own width the threshold sat below anything a
representable parameter can reach, and every query on that patch came back `-1` although it
had a preimage. `_geometric_scale` already makes exactly this argument for the physical side,
which is why the `magnitude` term exists; the parametric half of it was missing.

## The change

The scale becomes `max(diagonal, magnitude, parametric)`, with

```
parametric = max_k [ max(|lo_k|, |hi_k|) / L_k ] * net_span_k
```

Splitting the floor at the parametric extent is what makes it computable:

```
eps * |xi_k| * ||J e_k||  ==  eps * (|xi_k| / L_k) * (L_k * ||J e_k||)
```

The first factor is how far the knot span sits from the parametric origin in its own widths.
The second is supplied by **the control net's span along that same direction** — that is where
`sigma_max` enters — and it is *exact* for an affine map: the net line is then a straight
segment, whose coordinate box has diagonal exactly its own length, and that length is
`L_k · J e_k`. The whole derivation is in `_geometric_scale`'s docstring.

## Acceptance criteria

| | Criterion | Evidence |
|---|---|---|
| AC1 | The reproduction finds all 25 queries at every offset, including `1e6` | Ticket script re-run: `lost 0/25` at 0, 1e2, 1e3, 1e4, 1e6. floor/tol falls from `0.008 / 0.504 / 4.0 / 64 / 4096` to a uniform `~0.005` |
| AC2 | A regression test carries the frontier case (`1e3`), failing against the old implementation | `test_the_frontier_parametric_offset_is_recovered`; it was among the 20 failures on the test-only commit |
| AC3 | The threshold is unchanged for a knot vector spanning `[0, 1]` | `test_a_knot_vector_starting_at_the_origin_keeps_todays_scale` over seven fixtures, asserted **bitwise** against values measured before the change |
| AC4 | The derivation is written where the tolerance is derived, naming which factor supplies `sigma_max` | `_geometric_scale`, `_parametric_scale`, `_parametric_reach`, `_net_span_per_direction` |
| AC5 | A sweep over parametric offsets and physical scales loses nothing, and every coordinate meets its threshold | `test_the_sweep_over_offsets_and_physical_scales_loses_nothing`: dims 1–2 × offsets {0, 1e2, 1e3, 1e4, 1e6} × sizes {1e-3, 1, 1e3} |

## Three things the derivation has to get right

- **The product is per direction, reduced afterwards.** Reducing the two factors separately
  pairs the worst-offset direction with a *different* direction's stretch. On an affine map
  whose second direction sits at offset `1e6` while its image extent shrinks, that inflates
  the threshold by exactly the ratio between them — `2.4e6` times the attainable floor at an
  image extent of `1e-4`, on geometry the two physical lengths alone inverted without losing
  anything. Paired per direction the ratio stays at `244` across all four decades.
- **The parametric length carries `eps64`, not the caller's epsilon.** The inversion always
  iterates in float64, so one ulp of a parametric coordinate is `eps64 · |xi|` even for a
  float32 caller, while the tier applied to the scale is `64 · eps32` there. That overshoots
  by `5.4e8`: a float32 patch of unit size at parametric offset `1e5` would be handed a
  threshold of `0.76` of its own diameter. The ratio `eps64 / eps(dtype)` cancels it, and is
  exactly `1.0` on the float64 path.
- **Geometry parametrized from the origin is untouched, bitwise.** `[0, L]` gives a reach of
  `L / L`, exactly `1.0` in IEEE, and no net span exceeds the diagonal, so the three-way
  maximum returns the two-way one bit for bit.

## A parametrization that cannot carry a threshold is now refused

Past a reach of `1 / (64 · eps)` (~`7e13`) the default threshold would exceed the geometry's
own diameter, and a "found" verdict admitting more than a whole diameter of error says only
that the query was somewhere near the model. `locate` raises there instead, following the
precedent of `_check_snapping_kept_an_interval`, which already refuses a knot vector whose
mesh the format cannot resolve and names the same remedy. The line invents no constant — it
compares two lengths the geometry itself supplies — and sits within a factor of eight of what
the knot layer refuses outright. **Clamping was rejected**: above the cut it silently restores
an accuracy that cannot be attained, which is this bug relocated rather than fixed. An
explicit `tol` is never refused.

Below that line the threshold can still be a sizeable fraction of the geometry (`0.14` of a
diameter at a reach of `1e13`, where a point ten percent outside the image is reported found).
That is stated in the public `locate` docstring rather than legislated, because every
candidate line below `1` is a number someone picked.

## The limit that remains

The net span standing in for `sup ||J e_k||` underestimates a map whose local stretch exceeds
the average over its own direction, by an amplification `A`. The floor is a half ulp against a
tier of `64 · eps`, so the gap is absorbed to `A` of order 100 — floor over threshold `0.13` at
`A = 32`, `0.53` at `128`, passing one between `128` and `256`. The limit is **not new** (the
physical diagonal has always stood in for stretch the same way, and the same sweep at reach one
loses queries too), `A` is unbounded over legal inputs, and past the limit the queries are lost
against the physical-only threshold by decades more — so what remains is a residue of the same
defect rather than anything this introduced. `_steep_span_patch` in the test suite is the
fixture every one of those figures comes from.

## Also in this PR

The JIT-warmup barrier now sits behind `tests/test_bspline_locate.py`'s own `_evaluate_at`
helper. `Bspline.evaluate` is not itself behind it, so a selection whose first act is a burst
of evaluations is a bare `parallel=True` call racing the background compilation thread:
measured 5 aborts in 5 runs of the new test class in isolation before, 0 in 5 after.

Two cross-references that described `_geometric_scale` as pairing extent with coordinate
magnitude (`_bspline_knot_removal.py`, `multipatch/_detect.py`) now say that this is its
physical half, and that the third length has no counterpart where they stand.

## Split out rather than folded in

- **#320** — `locate` dies with a numpy reduction error on a knot vector with no interval, which
  `BsplineSpace1D` deliberately accepts. Pre-existing and unchanged by this branch: identical at
  `a9e3679`. Not fixed here because what `locate` *should* do on a space with no cells is a
  decision that reaches past this ticket, and a sibling entry point (`tabulate_basis`) fails on
  the same input.
- **#321** — the threshold is both the stopping rule and the acceptance rule, so the term added
  here also caps the accuracy of coordinates whose exact preimage is representable. Stopping at
  the physical-only threshold and accepting at the full one keeps every query found today and
  improves the worst residual from `1.99e-09` to `2.42e-14` on a warped patch at parametric
  offset `1e6`. Not folded in: it changes `_newton_refine`'s loop and its cost is unmeasured.

Closes #315.
