### PR TITLE
fix(cad): support rational Coons volumes, and grade each boundary check at its own precision and scale

### DIFF
--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -246,7 +246,10 @@ def _verify_corners_2d(
     carries that derivation.  At float64 the tier is ``9.09e-13`` relative while one
     float32 ulp at magnitude 1 is ``1.19e-07``, so a float32 patch whose corner is as
     close as its format allows was refused for a disagreement it cannot even express, by a
-    factor of ``5.4e5``.
+    factor of ``eps32 / (4096 eps64) = 2**17 = 131072``.  (Pantr issue 319 states ``5.4e5``
+    here; that is the ratio of the two *epsilons* divided by 4096 done the wrong way round
+    -- ``eps32 / eps64`` is ``2**29 = 5.4e8`` -- and the figure against the *tier* is
+    ``1.3e5``.  ``test_the_float32_tier_is_the_only_one_a_float32_corner_can_clear`` pins it.)
 
     **One column group, because these are points and not coefficients.**
     :meth:`~pantr.bspline.Bspline.boundary` projects a rational curve down to a point, so
@@ -611,9 +614,9 @@ def _verify_edges_3d(edges: tuple[_EdgeReadings, ...]) -> None:
     **The tier is read at the readings' own precision**, not at float64, for the reason
     :func:`~pantr.cad._validation._coarsest_dtype` gives: at float64 it is ``9.09e-13``
     relative, while one float32 ulp at magnitude 1 is ``1.19e-07``, so a float32 model was
-    graded ``5.4e5`` tighter than anything it can express.  The coarsest of the compared
-    readings decides, matching the scale's population; that is never below the per-edge
-    floor, so no genuinely shared edge is refused by it.
+    graded ``2**17 = 131072`` times tighter than anything it can express.  The coarsest of
+    the compared readings decides, matching the scale's population; that is never below the
+    per-edge floor, so no genuinely shared edge is refused by it.
 
     **Why any slack at all.** Two readings of a genuinely shared edge are usually **bitwise
     equal**, and not only when the two faces store it identically: reaching the common space

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -17,7 +17,12 @@ from ..tolerance import get_conservative
 from ._compat import make_compat
 from ._operations import create_ruled
 from ._primitives import _linear_space_1d, create_bilinear
-from ._validation import _promote_to_rational
+from ._validation import (
+    _coarsest_dtype,
+    _column_groups,
+    _ColumnGroup,
+    _promote_to_rational,
+)
 
 _DIRECTION_NAMES = ("u", "v", "w")
 """tuple[str, str, str]: Names of a Coons volume's parametric directions, in axis order."""
@@ -47,6 +52,28 @@ class _EdgeReadings(NamedTuple):
     corners: tuple[str, str]
 
 
+class _ComparedEdge(NamedTuple):
+    """One edge's two readings, made comparable, with the column groups that grade them.
+
+    Rationality is decided per edge, not per volume: an edge shared by two polynomial
+    faces is compared in three columns of coordinates, while one carried by a rational
+    face is promoted and compared in four, the last of which is a weight.  The groups
+    travel with the arrays because a mixed model has both kinds at once, and a weight
+    column must never be graded against a coordinate magnitude.
+
+    Attributes:
+        edge (_EdgeReadings): The edge, for the labels the mismatch message names.
+        cp_a (npt.NDArray[np.float32 | np.float64]): ``face_a``'s reading, made compatible.
+        cp_b (npt.NDArray[np.float32 | np.float64]): ``face_b``'s reading, same space.
+        groups (tuple[_ColumnGroup, ...]): The column groups of these two arrays.
+    """
+
+    edge: _EdgeReadings
+    cp_a: npt.NDArray[np.float32 | np.float64]
+    cp_b: npt.NDArray[np.float32 | np.float64]
+    groups: tuple[_ColumnGroup, ...]
+
+
 def _corner_label(sides: tuple[int, int, int]) -> str:
     """Name a corner of a Coons volume by the side it occupies in each direction.
 
@@ -62,11 +89,22 @@ def _corner_label(sides: tuple[int, int, int]) -> str:
 def _combine_control_points(
     bsplines: list[Bspline],
     signs: list[int],
-) -> tuple[npt.NDArray[np.float64], bool]:
+) -> tuple[npt.NDArray[np.float32 | np.float64], bool]:
     """Linearly combine control points of compatible B-splines.
 
+    The sum is accumulated in the **first** B-spline's precision, because the caller gives
+    the result that B-spline's space and :class:`~pantr.bspline.Bspline` refuses control
+    points whose dtype does not match their space.  Accumulating in float64 and handing
+    back float64 coefficients for a float32 model would therefore not build at all, and
+    would in any case be a precision escalation no other pantr operation performs -- both
+    :func:`~pantr.cad.create_ruled` and :func:`~pantr.cad.make_compat` stay in the dtype
+    they were given.  A term built here rather than derived from the caller's data may
+    still arrive at float64 (the corner interpolant of a patch does), and is read down
+    into the accumulator; nothing in the sum is promoted.
+
     Args:
-        bsplines: B-splines that share the same space (after compat).
+        bsplines: B-splines that share the same space (after compat).  The first one
+            decides the precision of the result.
         signs: Coefficients (+1 or -1) for each B-spline.
 
     Returns:
@@ -76,9 +114,9 @@ def _combine_control_points(
     if is_rational:
         bsplines = [_promote_to_rational(b) for b in bsplines]
 
-    cp = np.zeros_like(bsplines[0].control_points, dtype=np.float64)
+    cp = np.zeros_like(bsplines[0].control_points)
     for b, s in zip(bsplines, signs, strict=True):
-        cp += s * b.control_points.astype(np.float64)
+        cp += s * b.control_points.astype(cp.dtype, copy=False)
     return cp, is_rational
 
 
@@ -115,7 +153,9 @@ def create_coons_surface(
         ValueError: If any curve is not 1D.
         ValueError: If corner points are not geometrically consistent, i.e. two curves
             disagree at a shared corner by more than ``4096 * eps`` times the largest
-            absolute coordinate over all eight corner values.
+            absolute coordinate over all eight corner values, with ``eps`` read at the
+            **coarsest** of the four curves' precisions rather than at float64, so that a
+            float32 model is graded against something float32 can express.
     """
     (c_v0, c_v1), (c_u0, c_u1) = curves
 
@@ -127,11 +167,12 @@ def create_coons_surface(
     c_u0, c_u1 = make_compat(c_u0, c_u1)
     c_v0, c_v1 = make_compat(c_v0, c_v1)
 
-    # Extract and verify corner points
-    p00 = np.asarray(c_u0.boundary(0, 0), dtype=np.float64)
-    p10 = np.asarray(c_u0.boundary(0, 1), dtype=np.float64)
-    p01 = np.asarray(c_u1.boundary(0, 0), dtype=np.float64)
-    p11 = np.asarray(c_u1.boundary(0, 1), dtype=np.float64)
+    # Extract and verify corner points.  These are read in the curves' own precision,
+    # not float64: it is the precision the disagreement is graded at.
+    p00 = np.asarray(c_u0.boundary(0, 0))
+    p10 = np.asarray(c_u0.boundary(0, 1))
+    p01 = np.asarray(c_u1.boundary(0, 0))
+    p11 = np.asarray(c_u1.boundary(0, 1))
 
     _verify_corners_2d((p00, p10, p01, p11), c_v0, c_v1)
 
@@ -155,18 +196,19 @@ def create_coons_surface(
 
 def _verify_corners_2d(
     u_corners: tuple[
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
+        npt.NDArray[np.float32 | np.float64],
+        npt.NDArray[np.float32 | np.float64],
+        npt.NDArray[np.float32 | np.float64],
+        npt.NDArray[np.float32 | np.float64],
     ],
     c_v0: Bspline,
     c_v1: Bspline,
 ) -> None:
     """Verify that corner points from u-curves match v-curves.
 
-    The tolerance is ``get_conservative(float64) * scale`` with ``scale`` the largest
-    absolute coordinate over **all eight** corner values, not just the pair under test.
+    The tolerance is ``get_conservative(dtype) * scale`` with ``scale`` the largest
+    absolute coordinate over **all eight** corner values, not just the pair under test,
+    and ``dtype`` the coarsest of the eight readings' own precisions.
 
     **Why the conservative tier.** Both curves meeting at a corner read it straight off a
     clamped control point, and neither knot insertion nor degree elevation moves a clamped
@@ -195,9 +237,24 @@ def _verify_corners_2d(
     exactly ``max|pu - qv| <= atol``, so it buys nothing over writing that, and it hides
     which of the two comparisons is doing the work.
 
+    **The tier is read at the readings' own precision**, not at float64, because pantr's
+    B-spline layer accepts float32 as well; :func:`~pantr.cad._validation._coarsest_dtype`
+    carries that derivation.  At float64 the tier is ``9.09e-13`` relative while one
+    float32 ulp at magnitude 1 is ``1.19e-07``, so a float32 patch whose corner is as
+    close as its format allows was refused for a disagreement it cannot even express, by a
+    factor of ``5.4e5``.
+
+    **One column group, because these are points and not coefficients.**
+    :meth:`~pantr.bspline.Bspline.boundary` projects a rational curve down to a point, so
+    all eight readings are physical coordinates in one physical dimension and there is
+    nothing here to separate.  Where a comparison does mix dimensions -- homogeneous
+    coefficients against weights -- it is :func:`_verify_edges_3d`, which splits them.
+    A weight disagreement at a corner of a volume is therefore caught there rather than
+    here, and a rational Coons *patch* has no weight comparison of its own.
+
     Args:
-        u_corners (tuple[npt.NDArray[np.float64], ...]): Corners
-            ``(p00, p10, p01, p11)`` extracted from u-curves.
+        u_corners (tuple[npt.NDArray[np.float32 | np.float64], ...]): Corners
+            ``(p00, p10, p01, p11)`` extracted from u-curves, in the curves' own dtype.
         c_v0 (Bspline): Left boundary curve (v-direction at u=0).
         c_v1 (Bspline): Right boundary curve (v-direction at u=1).
 
@@ -205,10 +262,10 @@ def _verify_corners_2d(
         ValueError: If any pair of corners does not match.
     """
     p00, p10, p01, p11 = u_corners
-    q00 = np.asarray(c_v0.boundary(0, 0), dtype=np.float64)
-    q01 = np.asarray(c_v0.boundary(0, 1), dtype=np.float64)
-    q10 = np.asarray(c_v1.boundary(0, 0), dtype=np.float64)
-    q11 = np.asarray(c_v1.boundary(0, 1), dtype=np.float64)
+    q00 = np.asarray(c_v0.boundary(0, 0))
+    q01 = np.asarray(c_v0.boundary(0, 1))
+    q10 = np.asarray(c_v1.boundary(0, 0))
+    q11 = np.asarray(c_v1.boundary(0, 1))
 
     pairs = [
         ("(0,0)", p00, q00),
@@ -218,8 +275,9 @@ def _verify_corners_2d(
     ]
     # No floor: eight corners all at the origin have no scale, and are also bitwise
     # equal, so a zero tolerance is the right answer there rather than a hazard.
-    scale = max(float(np.abs(corner).max()) for _, pu, qv in pairs for corner in (pu, qv))
-    tol = get_conservative(np.float64) * scale
+    readings = [corner for _, pu, qv in pairs for corner in (pu, qv)]
+    scale = max(float(np.abs(corner).max()) for corner in readings)
+    tol = get_conservative(_coarsest_dtype(*readings)) * scale
 
     for label, pu, qv in pairs:
         gap = float(np.abs(pu - qv).max())
@@ -300,8 +358,12 @@ def create_coons_volume(
             twenty-four corner readings -- the same tier and the same scale rule as
             :func:`create_coons_surface`, derived in ``_verify_corners_3d``.
         ValueError: If two faces sharing an edge disagree along it by more than
-            ``4096 * eps`` times the largest absolute control-point coordinate over the
-            twelve compared edges, derived in ``_verify_edges_3d``.
+            ``4096 * eps`` times that column group's own magnitude over the twelve
+            compared edges: the largest absolute homogeneous coordinate for the
+            coordinate columns, and the largest absolute weight for the weight column of
+            a rational edge, derived in ``_verify_edges_3d``.  Both tolerances read
+            ``eps`` at the coarsest of the compared readings' precisions rather than at
+            float64.
         ValueError: If the blend of rational faces carries a control weight that is not
             above zero, so that the weight field of the result cannot be certified
             positive.  The bound is ``w(u) >= min_i w_i`` and is sufficient rather than
@@ -446,11 +508,13 @@ def _verify_corners_3d(edges: tuple[_EdgeReadings, ...]) -> None:
     """Verify that the three faces meeting at each corner of the volume agree there.
 
     The tolerance is :func:`_verify_corners_2d`'s, which is where its derivation lives:
-    ``get_conservative(float64)`` times the largest absolute coordinate over **all**
-    corner readings, so the verdict does not depend on which corner sits at the origin.
-    Three faces meet at a corner of a volume rather than two curves at a corner of a
-    patch, so the scale is taken over twenty-four readings instead of eight and each
-    corner is graded by three comparisons instead of one; nothing else changes.
+    the conservative tier, read at the coarsest of the readings' own precisions, times the
+    largest absolute coordinate over **all** corner readings, so the verdict does not
+    depend on which corner sits at the origin.  Three faces meet at a corner of a volume
+    rather than two curves at a corner of a patch, so the scale is taken over twenty-four
+    readings instead of eight and each corner is graded by three comparisons instead of
+    one; nothing else changes, including that these are projected points and so carry one
+    physical dimension between them.
 
     The w-faces are the reason this exists.  Every edge, and so every corner, used to be
     read off the u- and v-faces alone, which agree with themselves by construction, so a
@@ -465,17 +529,17 @@ def _verify_corners_3d(edges: tuple[_EdgeReadings, ...]) -> None:
             tolerance.
     """
     # Each (corner, face) pair is an endpoint of two of the twelve edges; read it once.
-    readings: dict[tuple[str, str], npt.NDArray[np.float64]] = {}
+    readings: dict[tuple[str, str], npt.NDArray[np.float32 | np.float64]] = {}
     for edge in edges:
         for end, corner in enumerate(edge.corners):
             for face, curve in ((edge.face_a, edge.curve_a), (edge.face_b, edge.curve_b)):
                 if (corner, face) not in readings:
-                    readings[corner, face] = np.asarray(curve.boundary(0, end), dtype=np.float64)
+                    readings[corner, face] = np.asarray(curve.boundary(0, end))
 
     # No floor: corners all at the origin have no scale, and are also bitwise equal,
     # so a zero tolerance is the right answer there rather than a hazard.
     scale = max(float(np.abs(point).max()) for point in readings.values())
-    tol = get_conservative(np.float64) * scale
+    tol = get_conservative(_coarsest_dtype(*readings.values())) * scale
 
     for sides in np.ndindex(2, 2, 2):
         corner = _corner_label((int(sides[0]), int(sides[1]), int(sides[2])))
@@ -506,8 +570,42 @@ def _verify_edges_3d(edges: tuple[_EdgeReadings, ...]) -> None:
     its control points; comparing those is therefore an exact comparison of the two curves
     and needs no sampling.  The tolerance is :func:`_verify_corners_2d`'s tier and rule
     applied to what is graded here, which is a control-point coefficient rather than a
-    point on the curve: ``get_conservative(float64)`` times the largest absolute
-    control-point coordinate over all twelve compared edges.
+    point on the curve: the conservative tier times the largest absolute coefficient over
+    all twelve compared edges.
+
+    **Each column group is graded against its own magnitude.**  A rational edge is compared
+    as homogeneous control points, whose coordinate columns carry units of length times
+    weight beside a dimensionless weight.  One magnitude over the whole row would grade a
+    weight against a threshold proportional to the model's *length*, which is dimensionally
+    wrong and destroys scale invariance: sending ``x -> lambda x`` scales the coordinates
+    and leaves the weights alone, so the verdict on a weight drifts with the size of the
+    model.  Measured on the cube of side ``s`` with two rational faces, a weight displaced
+    by four times the tier was refused at ``s = 1`` and **accepted at every ``s >= 1e2``**
+    -- the failure this check exists to stop, reappearing on the rational path once the
+    model is large.  Grading the coordinate columns against ``max|X|`` and the weight
+    column against ``max|w|`` restores it: under ``x -> lambda x`` both group scales and
+    both group gaps carry ``lambda``, and under a global weight rescale ``w -> mu w`` the
+    homogeneous coordinates ``X = w x`` carry ``mu`` alongside the weights, so both groups
+    carry it too.  It does not disarm the check a one-sided rescale exists to catch: that
+    still leaves ``gap_w = (mu - 1) w`` against ``tier * max(w, mu w)``, and is refused.
+    The weight column's own roundoff floor against ``max|w|`` is ``<= 3.2 eps``,
+    independent of magnitude, degree and refinement, so the tier clears it by about 1290.
+    :func:`~pantr.cad._join._verify_shared_boundary` carries those measurements; this is
+    the same rule on the same kind of comparison.
+
+    **Each group's scale spans the whole model, and only the edges that carry the group.**
+    The scale population is all twelve edges, as it is for the corners, so the verdict does
+    not depend on which edge happens to sit at the origin.  But an edge shared by two
+    polynomial faces has no weight column, so it contributes to the coordinate scale and
+    says nothing about the weights -- which is what keeps a mixed model's weight tolerance
+    from being set by unit weights the caller never supplied.
+
+    **The tier is read at the readings' own precision**, not at float64, for the reason
+    :func:`~pantr.cad._validation._coarsest_dtype` gives: at float64 it is ``9.09e-13``
+    relative, while one float32 ulp at magnitude 1 is ``1.19e-07``, so a float32 model was
+    graded ``5.4e5`` tighter than anything it can express.  The coarsest of the compared
+    readings decides, matching the scale's population; that is never below the per-edge
+    floor, so no genuinely shared edge is refused by it.
 
     **Why any slack at all.** Two readings of a genuinely shared edge are usually **bitwise
     equal**, and not only when the two faces store it identically: reaching the common space
@@ -525,43 +623,57 @@ def _verify_edges_3d(edges: tuple[_EdgeReadings, ...]) -> None:
     faces it is not: the comparison is of **homogeneous** control points, which is what the
     seven-term formula combines, and turning that into a distance would need a lower bound
     on the weights that this function does not compute.  Comparing them is still the right
-    test -- scaling one face's homogeneous control points by a constant leaves its geometry
-    untouched yet made the volume miss four of the six faces by 17% of the model before this
-    check existed -- but the reported gap is then a coefficient gap, not a distance.
+    test -- scaling one face's homogeneous control points by 2 leaves its geometry bitwise
+    untouched yet, with this check disabled, makes the volume miss each of the four faces
+    adjacent to it by 17% of the model -- but the reported gap is then a coefficient gap,
+    not a distance, and for the weight group it is not even a length.
 
     Args:
         edges (tuple[_EdgeReadings, ...]): The 12 edges of the volume, read from both
             carriers, as :func:`_extract_edge_pairs` returns them.
 
     Raises:
-        ValueError: If two faces sharing an edge disagree along it by more than the
-            tolerance.
+        ValueError: If two faces sharing an edge disagree along it, in either column
+            group, by more than that group's tolerance.
     """
-    compared: list[tuple[_EdgeReadings, npt.NDArray[np.float64], npt.NDArray[np.float64]]] = []
+    compared: list[_ComparedEdge] = []
     for edge in edges:
         curve_a, curve_b = edge.curve_a, edge.curve_b
-        if curve_a.is_rational or curve_b.is_rational:
+        is_rational = curve_a.is_rational or curve_b.is_rational
+        if is_rational:
             curve_a, curve_b = _promote_to_rational(curve_a), _promote_to_rational(curve_b)
         curve_a, curve_b = make_compat(curve_a, curve_b)
         compared.append(
-            (
-                edge,
-                np.asarray(curve_a.control_points, dtype=np.float64),
-                np.asarray(curve_b.control_points, dtype=np.float64),
+            _ComparedEdge(
+                edge=edge,
+                cp_a=np.asarray(curve_a.control_points),
+                cp_b=np.asarray(curve_b.control_points),
+                groups=_column_groups(is_rational=is_rational),
             )
         )
 
-    scale = max(float(np.abs(cp).max()) for _, cp_a, cp_b in compared for cp in (cp_a, cp_b))
-    tol = get_conservative(np.float64) * scale
+    tier = get_conservative(_coarsest_dtype(*(cp for c in compared for cp in (c.cp_a, c.cp_b))))
+    # No floor: a group whose readings are all zero has no scale, and is also bitwise
+    # equal, so a zero tolerance is the right answer there rather than a hazard.  Only
+    # the edges that carry a group contribute to its scale: an edge shared by two
+    # polynomial faces has no weight column and says nothing about the weights.
+    scales: dict[str, float] = {}
+    for c in compared:
+        for group in c.groups:
+            magnitude = max(float(np.abs(cp[..., group.columns]).max()) for cp in (c.cp_a, c.cp_b))
+            scales[group.name] = max(scales.get(group.name, 0.0), magnitude)
 
-    for edge, cp_a, cp_b in compared:
-        gap = float(np.abs(cp_a - cp_b).max())
-        if gap > tol:
-            raise ValueError(
-                f"Edge {edge.label} mismatch: {edge.face_a} and {edge.face_b} disagree "
-                f"along the edge they share "
-                f"(gap {gap:.3e}, above {tol:.3e} at edge scale {scale:.3e})."
-            )
+    for c in compared:
+        for group in c.groups:
+            gap = float(np.abs(c.cp_a[..., group.columns] - c.cp_b[..., group.columns]).max())
+            scale = scales[group.name]
+            tol = tier * scale
+            if gap > tol:
+                raise ValueError(
+                    f"Edge {c.edge.label} mismatch: {c.edge.face_a} and {c.edge.face_b} "
+                    f"disagree along the edge they share "
+                    f"(gap {gap:.3e}, above {tol:.3e} at edge {group.name} scale {scale:.3e})."
+                )
 
 
 def _verify_positive_weights(volume: Bspline) -> None:
@@ -752,14 +864,16 @@ def _build_bilinear_volume(
     n_free = cp.shape[0]
     rank_full = cp.shape[-1]
 
-    # Shape: (2, 2, n_free, rank_full) = (bilinear_0, bilinear_1, free, rank)
-    new_cp = np.empty((2, 2, n_free, rank_full), dtype=np.float64)
+    # Shape: (2, 2, n_free, rank_full) = (bilinear_0, bilinear_1, free, rank).  The dtype
+    # is the edges' own: the free direction reuses their space, and a BsplineSpace whose
+    # directions disagree on precision is refused at construction.
+    new_cp = np.empty((2, 2, n_free, rank_full), dtype=cp.dtype)
     new_cp[0, 0] = e_00.control_points
     new_cp[1, 0] = e_10.control_points
     new_cp[0, 1] = e_01.control_points
     new_cp[1, 1] = e_11.control_points
 
-    lin = _linear_space_1d()
+    lin = _linear_space_1d(dtype=cp.dtype)
     spaces_raw = [
         BsplineSpace1D(lin.knots.copy(), degree=1),
         BsplineSpace1D(lin.knots.copy(), degree=1),

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -16,7 +16,7 @@ from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
 from ..tolerance import get_conservative
 from ._compat import make_compat
 from ._operations import create_ruled
-from ._primitives import _linear_space_1d, create_bilinear, create_trilinear
+from ._primitives import _linear_space_1d, create_bilinear
 from ._validation import _promote_to_rational
 
 _DIRECTION_NAMES = ("u", "v", "w")
@@ -255,6 +255,25 @@ def create_coons_volume(
     inconsistency over the volume and the result then misses faces the caller supplied
     correctly.
 
+    **Rational faces are supported, and the blend is applied in homogeneous space.**  All
+    seven terms are formed from homogeneous coefficients ``(w x, w y, w z, w)`` and the
+    result is projected only when it is evaluated, so the formula stays the linear one
+    above and nothing has to be said about how weights combine under division.  That is
+    what makes the boundary property survive: projection is pointwise, so it commutes with
+    restriction to a face, and a blend whose *homogeneous* restriction to ``u = 0`` is
+    ``face_u0``'s homogeneous data projects to ``face_u0`` itself.  A polynomial face
+    among rational ones is promoted with unit weights, so mixed input takes the same path
+    rather than a third one.
+
+    That argument has a hypothesis, and it is the one the checks below enforce: the faces
+    must agree in **homogeneous** data, weights included, not merely projectively.  A
+    homogeneous representation is unique only up to one constant scaling all of a patch's
+    weights, so two faces can trace the same edge in space while their coefficients differ
+    by a factor, and then the inclusion-exclusion does not cancel.  This is measured rather
+    than feared: scaling one ``w``-face's homogeneous control points by 2 leaves that
+    face's geometry bitwise unchanged yet, with the checks disabled, makes the volume miss
+    each of the four faces adjacent to it by 17% of the model.
+
     Face labelling convention:
 
     - ``faces[0] = (face_u0, face_u1)``: faces at u=0 and u=1,
@@ -283,6 +302,11 @@ def create_coons_volume(
         ValueError: If two faces sharing an edge disagree along it by more than
             ``4096 * eps`` times the largest absolute control-point coordinate over the
             twelve compared edges, derived in ``_verify_edges_3d``.
+        ValueError: If the blend of rational faces carries a control weight that is not
+            above zero, so that the weight field of the result cannot be certified
+            positive.  The bound is ``w(u) >= min_i w_i`` and is sufficient rather than
+            necessary, so this refuses some volumes whose weight field never vanishes;
+            ``_verify_positive_weights`` derives it.
     """
     (face_u0, face_u1), (face_v0, face_v1), (face_w0, face_w1) = faces
 
@@ -304,8 +328,11 @@ def create_coons_volume(
     # reading is only there to be checked against, and by now is known to agree.
     edges = {r.label: r.curve_a for r in edge_readings}
 
-    # Extract corners from edges
-    corners = _extract_corners(edges)
+    # Extract corners from edges, in the space the other six terms are combined in
+    rational_faces = any(
+        f.is_rational for f in (face_u0, face_u1, face_v0, face_v1, face_w0, face_w1)
+    )
+    corners = _extract_corners(edges, is_rational=rational_faces)
 
     # Build 3 ruled volumes
     r_u = create_ruled(face_u0, face_u1).permute_directions([2, 0, 1])
@@ -339,7 +366,7 @@ def create_coons_volume(
     )
 
     # Build trilinear volume
-    t = create_trilinear(corners)
+    t = _build_trilinear_volume(corners, is_rational=rational_faces)
 
     # Make all 7 terms compatible and combine
     r_u, r_v, r_w, b_uv, b_uw, b_vw, t = make_compat(r_u, r_v, r_w, b_uv, b_uw, b_vw, t)
@@ -348,7 +375,10 @@ def create_coons_volume(
         [r_u, r_v, r_w, b_uv, b_uw, b_vw, t],
         [+1, +1, +1, -1, -1, -1, +1],
     )
-    return Bspline(r_u.space, cp, is_rational=is_rational)
+    volume = Bspline(r_u.space, cp, is_rational=is_rational)
+    if is_rational:
+        _verify_positive_weights(volume)
+    return volume
 
 
 def _extract_edge_pairs(
@@ -534,29 +564,154 @@ def _verify_edges_3d(edges: tuple[_EdgeReadings, ...]) -> None:
             )
 
 
-def _extract_corners(edges: dict[str, Bspline]) -> npt.NDArray[np.float64]:
-    """Extract 8 corner points from edges.
+def _verify_positive_weights(volume: Bspline) -> None:
+    """Refuse a rational Coons volume whose weight field is not certified positive.
+
+    A NURBS volume is ``X(u) / w(u)`` and is only defined where its weight field stays
+    away from zero.  Positive weights on the six faces do **not** carry over to the
+    blend: the seven-term formula is an inclusion-exclusion and subtracts three of its
+    terms, so a weight field assembled from strictly positive faces can dip to zero or
+    below inside, and the volume then has a pole the caller never put there.
+
+    **What a control weight settles.**  The result's weight field is
+    ``w(u) = sum_i N_i(u) w_i`` over its own tensor-product B-spline basis, which is
+    non-negative and sums to one on the domain -- a tensor product of non-negative
+    partitions of unity is one -- so
+
+        ``w(u) - min_j w_j = sum_i N_i(u) (w_i - min_j w_j) >= 0``
+
+    for every ``u``.  The weight field therefore never goes below the smallest control
+    weight, and reading the weight column of the **result's** control points bounds it
+    from below without evaluating anything.
+
+    **Sufficient, not necessary, and deliberately so.**  The converse of that inequality
+    is false: ``w(u)`` is a convex combination of the ``w_i`` only at the ends, and in
+    between the basis is strictly positive on more than one coefficient, so a volume
+    whose weight field never comes near zero can still carry a negative control weight
+    and be refused here.  This check is therefore conservative: everything it accepts has
+    a positive weight field, but it does not accept everything that has one.  It reports
+    the bound it can prove rather than pretending to detect the pole itself, which would
+    need a global minimum of ``w`` over the domain.
 
     Args:
-        edges: Dictionary of 12 named edge curves.
+        volume (Bspline): The rational volume just assembled, whose control points carry
+            a trailing weight column.
+
+    Raises:
+        ValueError: If any control weight of *volume* is zero or negative, so that the
+            lower bound no longer keeps the weight field away from zero.
+    """
+    weights = volume.control_points[..., -1]
+    smallest = float(weights.min())
+    if smallest > 0.0:
+        return
+
+    index = tuple(int(i) for i in np.unravel_index(int(np.argmin(weights)), weights.shape))
+    raise ValueError(
+        f"Coons volume weight is not certified positive: control weight {smallest:.3e} "
+        f"at index {index} is not above zero, so the bound w(u) >= min_i w_i no longer "
+        "keeps the blended weight field away from zero and the volume may have a pole. "
+        "The seven-term blend subtracts three of its terms, so positive weights on the "
+        "six faces do not imply positive weights on the volume; supply faces whose "
+        "weights vary less across the model. The test is sufficient, not necessary: a "
+        "volume whose weight field never vanishes can still fail it."
+    )
+
+
+def _homogeneous_endpoint(curve: Bspline, side: int) -> npt.NDArray[np.float32 | np.float64]:
+    """Read one end of a curve as a coefficient, without projecting a rational one.
+
+    :meth:`~pantr.bspline.Bspline.boundary` **projects**: sliced down to a point, a
+    rational curve is divided by its weight and returns ``rank`` components where its
+    coefficients have ``rank + 1``.  Every other term of the Coons blend is combined
+    homogeneously, so a corner read that way is both one component short and in a
+    different space from the terms it is subtracted from.
+
+    Viewing the same coefficients as an ordinary curve of one rank higher is what stops
+    before the division: the de Boor recurrence underneath is linear and does not consult
+    ``is_rational`` (:func:`~pantr.bspline._bspline_slice._slice_bspline` branches on it
+    only for the final ``X / w``), so the arithmetic is identical and the result is the
+    homogeneous corner the blend needs.
+
+    Args:
+        curve (Bspline): A 1-D B-spline, rational or not.
+        side (int): Which end of the domain: ``0`` for the start, ``1`` for the end.
 
     Returns:
-        npt.NDArray[np.float64]: Array of shape ``(2, 2, 2, rank)``.
+        npt.NDArray[np.float32 | np.float64]: The curve's coefficient at that end, of
+        shape ``(rank,)`` when *curve* is non-rational and ``(rank + 1,)`` when it is
+        rational, in *curve*'s own dtype.
     """
-    e = edges["u_v0_w0"]
-    rank = e.control_points.shape[-1]
-    corners = np.zeros((2, 2, 2, rank), dtype=np.float64)
+    homogeneous = Bspline(curve.space, curve.control_points, is_rational=False)
+    return np.asarray(homogeneous.boundary(0, side))
 
-    # Corners from u-edges (boundary of a 1D curve returns ndarray)
-    corners[0, 0, 0] = np.asarray(edges["u_v0_w0"].boundary(0, 0))
-    corners[1, 0, 0] = np.asarray(edges["u_v0_w0"].boundary(0, 1))
-    corners[0, 1, 0] = np.asarray(edges["u_v1_w0"].boundary(0, 0))
-    corners[1, 1, 0] = np.asarray(edges["u_v1_w0"].boundary(0, 1))
-    corners[0, 0, 1] = np.asarray(edges["u_v0_w1"].boundary(0, 0))
-    corners[1, 0, 1] = np.asarray(edges["u_v0_w1"].boundary(0, 1))
-    corners[0, 1, 1] = np.asarray(edges["u_v1_w1"].boundary(0, 0))
-    corners[1, 1, 1] = np.asarray(edges["u_v1_w1"].boundary(0, 1))
+
+def _extract_corners(
+    edges: dict[str, Bspline], *, is_rational: bool
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Extract the volume's 8 corner coefficients from the four edges free in u.
+
+    The array is sized and filled in **one** space, which is what the corner term of the
+    blend needs and what this used to get wrong: it took its width from the edges'
+    coefficients, which are homogeneous for a rational face, and filled it from
+    :meth:`~pantr.bspline.Bspline.boundary`, which projects.  A rational volume then
+    failed with a NumPy broadcast error naming shapes ``(3,)`` and ``(4,)`` rather than
+    anything the caller had supplied (pantr issue 309).  :func:`_homogeneous_endpoint` is
+    the read that stays in the space the width was taken from.
+
+    *is_rational* is the **volume's**, not these four edges': the corner term is one of
+    seven that are added together, so it has to live in the same space as the other six
+    even when the faces that happen to carry the u-edges are polynomial.  Promoting them
+    gives those corners a unit weight, which is the right value exactly when the faces
+    that *are* rational carry a unit weight there too -- and :func:`_verify_edges_3d` has
+    already required that, since it compares each edge's two readings homogeneously and a
+    polynomial reading promotes to weight one.
+
+    Args:
+        edges (dict[str, Bspline]): The 12 named edge curves.
+        is_rational (bool): Whether the volume being built is rational, i.e. whether the
+            corners are wanted as homogeneous coefficients.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Corner coefficients of shape
+        ``(2, 2, 2, rank)``, indexed ``[i, j, k]`` by side along u, v and w, where
+        ``rank`` counts the weight when *is_rational*.
+    """
+    u_edges = {(j, k): edges[f"u_v{j}_w{k}"] for j in (0, 1) for k in (0, 1)}
+    if is_rational:
+        u_edges = {sides: _promote_to_rational(e) for sides, e in u_edges.items()}
+
+    sample = u_edges[0, 0].control_points
+    corners = np.empty((2, 2, 2, sample.shape[-1]), dtype=sample.dtype)
+    for (j, k), edge in u_edges.items():
+        for i in (0, 1):
+            corners[i, j, k] = _homogeneous_endpoint(edge, i)
     return corners
+
+
+def _build_trilinear_volume(
+    corners: npt.NDArray[np.float32 | np.float64], *, is_rational: bool
+) -> Bspline:
+    """Build the trilinear corner term of the Coons blend from the 8 corner coefficients.
+
+    :func:`~pantr.cad.create_trilinear` cannot serve here, for two reasons that both come
+    from its being a public *geometric* primitive: it caps the rank at three, so it
+    rejects the homogeneous ``(w x, w y, w z, w)`` corner of a rational face, and it
+    builds its space at float64 whatever it was handed, which a float32 model cannot then
+    be combined with.  This is the same construction as :func:`_build_bilinear_volume`'s,
+    one direction further.
+
+    Args:
+        corners (npt.NDArray[np.float32 | np.float64]): Corner coefficients of shape
+            ``(2, 2, 2, rank)``, as :func:`_extract_corners` returns them.
+        is_rational (bool): Whether *corners* carries a trailing weight column.
+
+    Returns:
+        Bspline: A 3D, degree-(1, 1, 1) B-spline volume in (u, v, w) order.
+    """
+    knots = _linear_space_1d(dtype=corners.dtype).knots
+    space = BsplineSpace([BsplineSpace1D(knots.copy(), degree=1) for _ in range(3)])
+    return Bspline(space, corners, is_rational=is_rational)
 
 
 def _build_bilinear_volume(

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -147,7 +147,11 @@ def create_coons_surface(
             u-direction (bottom/top).  All must be 1D B-splines.
 
     Returns:
-        Bspline: A 2D B-spline surface.
+        Bspline: A 2D B-spline surface, in the precision the curves were given in: a
+        float32 model is returned at float32 rather than promoted, matching
+        :func:`~pantr.cad.create_ruled` and :func:`~pantr.cad.make_compat`.  Curves of
+        *different* precisions are not a supported input and the result then follows
+        ``curves[0][0]``'s.
 
     Raises:
         ValueError: If any curve is not 1D.
@@ -345,7 +349,11 @@ def create_coons_volume(
         faces: Three pairs of opposite boundary faces.
 
     Returns:
-        Bspline: A 3D (trivariate) B-spline volume.  Because it returns rather than raising,
+        Bspline: A 3D (trivariate) B-spline volume, in the precision the faces were given
+        in: a float32 model is returned at float32 rather than promoted, matching
+        :func:`~pantr.cad.create_ruled` and :func:`~pantr.cad.make_compat`.  Faces of
+        *different* precisions are not a supported input and the result then follows
+        ``faces[0][0]``'s.  Because it returns rather than raising,
         the six faces agree where they meet, and the volume therefore restricts to each of
         them on the corresponding boundary.  That interpolation is exact in exact arithmetic;
         the floating-point residual is **observed** to stay near ``1e-15`` relative, three
@@ -665,15 +673,24 @@ def _verify_edges_3d(edges: tuple[_EdgeReadings, ...]) -> None:
 
     for c in compared:
         for group in c.groups:
-            gap = float(np.abs(c.cp_a[..., group.columns] - c.cp_b[..., group.columns]).max())
+            gaps = np.abs(c.cp_a[..., group.columns] - c.cp_b[..., group.columns])
+            gap = float(gaps.max())
             scale = scales[group.name]
             tol = tier * scale
-            if gap > tol:
-                raise ValueError(
-                    f"Edge {c.edge.label} mismatch: {c.edge.face_a} and {c.edge.face_b} "
-                    f"disagree along the edge they share "
-                    f"(gap {gap:.3e}, above {tol:.3e} at edge {group.name} scale {scale:.3e})."
-                )
+            if gap <= tol:
+                continue
+
+            # Name the control point that disagrees most, so the gap reported is the gap
+            # compared, as :func:`~pantr.cad._join._verify_shared_boundary` does for the
+            # same class of mismatch.  The whole coefficient is printed even though one
+            # column group decided the verdict.
+            index = int(np.argmax(gaps.max(axis=-1)))
+            raise ValueError(
+                f"Edge {c.edge.label} mismatch at control point {index}: {c.edge.face_a} "
+                f"gives {c.cp_a[index]}, {c.edge.face_b} gives {c.cp_b[index]}, and they "
+                f"disagree along the edge they share "
+                f"(gap {gap:.3e}, above {tol:.3e} at edge {group.name} scale {scale:.3e})."
+            )
 
 
 def _verify_positive_weights(volume: Bspline) -> None:

--- a/src/pantr/cad/_join.py
+++ b/src/pantr/cad/_join.py
@@ -5,41 +5,13 @@ Provides :func:`join` for C0-concatenation of B-splines.
 
 from __future__ import annotations
 
-from typing import NamedTuple
-
 import numpy as np
 from numpy import typing as npt
 
 from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
 from ..tolerance import get_conservative
 from ._compat import _remap_bspline, make_compat
-from ._validation import _promote_to_rational
-
-
-class _ColumnGroup(NamedTuple):
-    """One group of control-point columns that share a physical dimension.
-
-    A rational control point carries homogeneous coordinates, whose units are length times
-    weight, beside a dimensionless weight.  Grading both against one magnitude makes the
-    verdict depend on where the model sits, so each group is graded against its own.
-
-    Attributes:
-        name (str): What the group holds, as the error message names it.
-        columns (slice): The columns of a control-point array the group covers.
-    """
-
-    name: str
-    columns: slice
-
-
-_EUCLIDEAN_COLUMNS = (_ColumnGroup("coordinate", slice(None)),)
-"""tuple[_ColumnGroup, ...]: Column groups of a non-rational row -- all coordinates."""
-
-_HOMOGENEOUS_COLUMNS = (
-    _ColumnGroup("coordinate", slice(0, -1)),
-    _ColumnGroup("weight", slice(-1, None)),
-)
-"""tuple[_ColumnGroup, ...]: Column groups of a rational row -- coordinates, then weight."""
+from ._validation import _coarsest_dtype, _column_groups, _promote_to_rational
 
 
 def _prepare_for_join(
@@ -231,9 +203,8 @@ def _verify_shared_boundary(
         ValueError: If the two rows disagree anywhere on the shared face, in either column
             group, by more than that group's tolerance.
     """
-    coarser = max(row1.dtype, row2.dtype, key=lambda d: float(np.finfo(d).eps))
-    tier = get_conservative(coarser)
-    groups = _HOMOGENEOUS_COLUMNS if is_rational else _EUCLIDEAN_COLUMNS
+    tier = get_conservative(_coarsest_dtype(row1, row2))
+    groups = _column_groups(is_rational=is_rational)
 
     # Coordinates first: a seam given in the wrong place fails there, and it is the more
     # informative half to report when both groups are out.

--- a/src/pantr/cad/_validation.py
+++ b/src/pantr/cad/_validation.py
@@ -1,13 +1,14 @@
 """Shared validation and conversion helpers for CAD functions.
 
 Provides utility functions used across the ``cad`` subpackage for
-normalizing point arrays and promoting B-splines between rational and
-non-rational representations.
+normalizing point arrays, promoting B-splines between rational and
+non-rational representations, and grading a comparison of control points
+against a tolerance that matches what it compares.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
@@ -20,6 +21,74 @@ if TYPE_CHECKING:
 
 _PHYSICAL_DIM = 3
 """int: Default physical dimension for all CAD primitives."""
+
+
+class _ColumnGroup(NamedTuple):
+    """One group of control-point columns that share a physical dimension.
+
+    A rational control point carries homogeneous coordinates, whose units are length times
+    weight, beside a dimensionless weight.  Grading both against one magnitude makes the
+    verdict depend on where the model sits, so each group is graded against its own.
+
+    Attributes:
+        name (str): What the group holds, as the error message names it.
+        columns (slice): The columns of a control-point array the group covers.
+    """
+
+    name: str
+    columns: slice
+
+
+_EUCLIDEAN_COLUMNS = (_ColumnGroup("coordinate", slice(None)),)
+"""tuple[_ColumnGroup, ...]: Column groups of non-rational control points -- coordinates only."""
+
+_HOMOGENEOUS_COLUMNS = (
+    _ColumnGroup("coordinate", slice(0, -1)),
+    _ColumnGroup("weight", slice(-1, None)),
+)
+"""tuple[_ColumnGroup, ...]: Column groups of rational control points -- coordinates, weight."""
+
+
+def _column_groups(*, is_rational: bool) -> tuple[_ColumnGroup, ...]:
+    """Split a control-point array's columns into groups that share one physical dimension.
+
+    A relative tolerance's scale has to span exactly one dimension, so the caller grades
+    each group against its own magnitude: sending ``x -> lambda x`` scales the coordinates
+    and leaves the weights alone, and one magnitude over both would make the verdict on a
+    weight drift with the size of the model.
+
+    Args:
+        is_rational (bool): Whether the array's trailing column is a weight.
+
+    Returns:
+        tuple[_ColumnGroup, ...]: The groups, coordinates first -- data given in the wrong
+        place fails there, and it is the more informative half to report when both are out.
+    """
+    return _HOMOGENEOUS_COLUMNS if is_rational else _EUCLIDEAN_COLUMNS
+
+
+def _coarsest_dtype(
+    *arrays: npt.NDArray[np.float32 | np.float64],
+) -> np.dtype[np.floating[Any]]:
+    """Return the coarsest floating precision among the arrays about to be compared.
+
+    A tolerance tier read at float64 while the data is float32 refuses agreement the
+    inputs cannot express: if the true shared value is ``F``, two stored readings satisfy
+    ``|r1 - r2| <= 0.5 (eps1 + eps2) |F|``, a hard floor on any achievable agreement.
+    Reading the tier at the coarsest precision present clears that floor; taking the
+    *promoted* type instead is backwards by ``eps32 / eps64``, about ``5.4e8``.
+
+    The rule grades by **container** rather than by provenance, so float32-resolution data
+    already copied into a float64 array is graded at float64.
+
+    Args:
+        *arrays (npt.NDArray[np.float32 | np.float64]): The arrays being compared.  At
+            least one is required.
+
+    Returns:
+        np.dtype[np.floating[Any]]: The dtype with the largest machine epsilon.
+    """
+    return max((a.dtype for a in arrays), key=lambda d: float(np.finfo(d).eps))
 
 
 def _pad_to_3d(point: npt.ArrayLike) -> npt.NDArray[np.float64]:

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -1348,17 +1348,22 @@ class TestCoonsPrecisionAndColumnScale:
     def _as_rational(face: Bspline) -> Bspline:
         """Rewrite a polynomial face rationally, with every weight 1.
 
+        The precision is the face's own: a ``Bspline`` refuses control points whose dtype
+        differs from its space's, so promoting a float32 face at float64 would not build.
+
         Args:
             face (Bspline): A non-rational face.
 
         Returns:
-            Bspline: The same geometry, carried rationally.
+            Bspline: The same geometry, carried rationally, in *face*'s dtype.
         """
-        cp = np.asarray(face.control_points, dtype=np.float64)
-        weights = np.ones((*cp.shape[:-1], 1))
+        cp = np.asarray(face.control_points)
+        weights = np.ones((*cp.shape[:-1], 1), dtype=cp.dtype)
         return Bspline(face.space, np.concatenate([cp, weights], axis=-1), True)
 
-    def _cube_with_displaced_weight(self, scale: float, gap: float) -> _FacePairs:
+    def _cube_with_displaced_weight(
+        self, scale: float, gap: float, dtype: npt.DTypeLike = np.float64
+    ) -> _FacePairs:
         """Build the ticket's cube with the two w-faces rational and one weight out by *gap*.
 
         Only the w-faces are rational, which is what keeps the reproduction on the
@@ -1370,16 +1375,18 @@ class TestCoonsPrecisionAndColumnScale:
         Args:
             scale (float): Side of the cube.
             gap (float): Amount added to one weight, against weights of 1.
+            dtype (npt.DTypeLike): Precision of the whole model. Defaults to float64.
 
         Returns:
-            _FacePairs: Six faces whose weights disagree at one corner.
+            _FacePairs: Six faces whose weights disagree at one corner, or six consistent
+            ones when ``gap == 0``.
         """
-        pairs = self._cube_faces(np.float64, scale)
+        pairs = self._cube_faces(dtype, scale)
         faces = _flatten_faces(pairs)
         faces[4], faces[5] = self._as_rational(faces[4]), self._as_rational(faces[5])
         cp = np.asarray(faces[4].control_points).copy()
         cp[0, 0, -1] += gap
-        faces[4] = Bspline(faces[4].space, cp, is_rational=True)
+        faces[4] = Bspline(faces[4].space, cp.astype(dtype), is_rational=True)
         u0, u1, v0, v1, w0, w1 = faces
         return ((u0, u1), (v0, v1), (w0, w1))
 
@@ -1496,3 +1503,77 @@ class TestCoonsPrecisionAndColumnScale:
         assert gap == pytest.approx(scale)
         assert reported_scale == pytest.approx(2.0 * scale)
         assert tol == pytest.approx(get_conservative(np.float64) * 2.0 * scale, rel=1e-3)
+
+    @staticmethod
+    def _lifted_corner_faces(dtype: npt.DTypeLike, lift: float) -> _FacePairs:
+        """Build the cube's six faces with ``face_w0``'s ``(u=1, v=1)`` corner lifted.
+
+        The three faces meeting there no longer agree, so the corner check must decide.
+        Only ``face_w0`` carries the displacement, which is the direction pantr issue 301
+        showed was invisible before the w-faces were read at all.
+
+        Args:
+            dtype (npt.DTypeLike): Precision of the knots and control points.
+            lift (float): Displacement along *z* of that corner.
+
+        Returns:
+            _FacePairs: Six faces, consistent iff ``lift == 0``.
+        """
+        pairs = TestCoonsPrecisionAndColumnScale._cube_faces(dtype)
+        faces = _flatten_faces(pairs)
+        cp = np.asarray(faces[4].control_points).copy()
+        cp[1, 1, 2] += lift
+        faces[4] = Bspline(faces[4].space, cp.astype(dtype))
+        u0, u1, v0, v1, w0, w1 = faces
+        return ((u0, u1), (v0, v1), (w0, w1))
+
+    def test_a_float32_volume_grades_its_corners_at_float32(self) -> None:
+        """The tier reaches the volume's corner check too, not only the patch's.
+
+        The pair above pins ``_verify_corners_2d``; this pins ``_verify_corners_3d``, whose
+        population is twenty-four readings rather than eight.  A relative corner gap of
+        ``1e-6`` lies between the two readings of the tier -- above float64's ``9.09e-13``
+        and below float32's ``4.88e-4`` -- so it separates them cleanly: graded at float64
+        this float32 model is refused, graded at its own precision it is accepted.  A gap
+        of ``1e-2`` is above both and must still be refused, and by the float32 tier.
+        """
+        assert get_conservative(np.float64) < 1.0e-6 < get_conservative(np.float32) < 1.0e-2
+
+        volume = create_coons_volume(self._lifted_corner_faces(np.float32, 1.0e-6))
+        assert np.dtype(volume.control_points.dtype) == np.dtype(np.float32)
+
+        with pytest.raises(ValueError, match=r"Corner \(1,1,0\) mismatch") as excinfo:
+            create_coons_volume(self._lifted_corner_faces(np.float32, 1.0e-2))
+        gap, tol, scale = _reported_numbers(str(excinfo.value))
+        assert gap == pytest.approx(1.0e-2, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(np.float32) * scale, rel=1e-3)
+
+    def test_a_float32_rational_volume_is_built_and_graded_at_float32(self) -> None:
+        """Where the two tickets meet: a volume that is rational *and* float32.
+
+        Nothing else covers their intersection.  A rational blend reads its corner term
+        homogeneously (pantr issue 309) and builds it at the corners' own precision
+        (pantr issue 319); a corner term silently promoted to float64 cannot be assembled
+        over a float32 space at all, so this is what would catch it.  The same face set
+        then puts a displaced weight -- which only ``_verify_edges_3d`` can see, the corner
+        check comparing projected points -- on both sides of the float32 tier.
+        """
+        volume = create_coons_volume(self._cube_with_displaced_weight(1.0, 0.0, np.float32))
+        assert volume.is_rational
+        assert np.dtype(volume.control_points.dtype) == np.dtype(np.float32)
+
+        # Between the two tiers: refused if graded at float64, accepted at float32.
+        assert get_conservative(np.float64) < 1.0e-6 < get_conservative(np.float32)
+        create_coons_volume(self._cube_with_displaced_weight(1.0, 1.0e-6, np.float32))
+
+        gap = 4.0 * get_conservative(np.float32)
+        with pytest.raises(ValueError, match=r"Edge \w+ mismatch") as excinfo:
+            create_coons_volume(self._cube_with_displaced_weight(1.0, gap, np.float32))
+        message = str(excinfo.value)
+        assert "weight scale" in message, message
+        reported_gap, tol, scale = _reported_numbers(message)
+        assert reported_gap == pytest.approx(gap, rel=1e-3)
+        # The weight scale is the weight population's own maximum, which the displaced
+        # weight itself raises above 1 -- not the coordinate scale, which is also 1 here.
+        assert scale == pytest.approx(1.0 + gap, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(np.float32) * scale, rel=1e-3)

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -20,7 +20,7 @@ from pantr.cad import (
     create_ruled,
 )
 from pantr.cad._coons import _extract_edge_pairs
-from pantr.tolerance import get_conservative
+from pantr.tolerance import get_conservative, get_machine_epsilon
 
 _RANK_3D = 3
 
@@ -99,6 +99,28 @@ def _face_interpolation_gaps(vol: Bspline, faces: _FacePairs) -> dict[str, float
         want = np.asarray(face.evaluate(face_params), dtype=np.float64)
         gaps[label] = float(np.linalg.norm(got - want, axis=1).max())
     return gaps
+
+
+def _reported_numbers(message: str) -> tuple[float, float, float]:
+    """Parse the gap, tolerance and scale a mismatch message reports.
+
+    Whatever the message says about the tolerance is a claim about the comparison that was
+    actually made, so it is worth checking rather than trusting.  The name between ``at``
+    and ``scale`` is the population the tolerance was taken over -- ``corner``, ``edge
+    coordinate``, ``edge weight`` -- and is checked separately by the tests that care which
+    column group decided the verdict.
+
+    Args:
+        message (str): The ``ValueError`` message.
+
+    Returns:
+        tuple[float, float, float]: ``(gap, tol, scale)`` as printed.
+    """
+    num = r"([-+0-9.eE]+)"
+    found = re.search(rf"gap {num}, above {num} at [a-z -]+ scale {num}", message)
+    assert found is not None, f"unparseable mismatch message: {message!r}"
+    gap, tol, scale = (float(g) for g in found.groups())
+    return gap, tol, scale
 
 
 class TestCoonsSurface:
@@ -539,25 +561,6 @@ class TestCoonsVolumeFaceConsistency:
         faces[4] = self._bezier_patch(w0, 2, 1)
         return self._pairs(faces)
 
-    @staticmethod
-    def _reported_numbers(message: str) -> tuple[float, float, float]:
-        """Parse the gap, tolerance and scale a mismatch message reports.
-
-        Whatever the message says about the tolerance is a claim about the comparison
-        that was actually made, so it is worth checking rather than trusting.
-
-        Args:
-            message (str): The ``ValueError`` message.
-
-        Returns:
-            tuple[float, float, float]: ``(gap, tol, scale)`` as printed.
-        """
-        num = r"([-+0-9.eE]+)"
-        found = re.search(rf"gap {num}, above {num} at [a-z-]+ scale {num}", message)
-        assert found is not None, f"unparseable mismatch message: {message!r}"
-        gap, tol, scale = (float(g) for g in found.groups())
-        return gap, tol, scale
-
     # -- the reproduction -------------------------------------------------------------
 
     def test_the_consistent_cube_is_accepted_and_interpolates_all_six_faces(self) -> None:
@@ -583,7 +586,7 @@ class TestCoonsVolumeFaceConsistency:
             create_coons_volume(faces)
         message = str(excinfo.value)
         assert "face_w0" in message, message
-        gap, tol, scale = self._reported_numbers(message)
+        gap, tol, scale = _reported_numbers(message)
         assert gap == pytest.approx(0.5)
         assert scale == pytest.approx(1.0)
         assert tol == pytest.approx(get_conservative(np.float64), rel=1e-3)
@@ -721,7 +724,7 @@ class TestCoonsVolumeFaceConsistency:
         faces = self._cube_with_lifted_corner(face=4, corner=(1, 1), lift=0.1 * scale, scale=scale)
         with pytest.raises(ValueError, match=r"Corner \(1,1,0\) mismatch") as excinfo:
             create_coons_volume(faces)
-        gap, tol, reported_scale = self._reported_numbers(str(excinfo.value))
+        gap, tol, reported_scale = _reported_numbers(str(excinfo.value))
         assert gap == pytest.approx(0.1 * scale)
         assert reported_scale == pytest.approx(scale)
         assert tol == pytest.approx(get_conservative(np.float64) * scale, rel=1e-3)
@@ -926,7 +929,8 @@ class TestCoonsVolumeRationalFaces:
     commutes with restriction to a face, and a blend whose homogeneous restriction to
     ``u = 0`` is ``face_u0``'s homogeneous data projects to ``face_u0`` itself.  Its
     hypothesis is that the faces agree **homogeneously**, weights included, which
-    ``_verify_edges_3d`` enforces and ``test_a_face_scaled_in_homogeneous_space_is_refused``
+    ``_verify_edges_3d`` enforces and
+    ``TestCoonsVolumeFaceConsistency.test_a_rational_face_whose_weights_disagree_with_its_neighbours_is_refused``
     pins.
     """
 
@@ -1116,30 +1120,6 @@ class TestCoonsVolumeRationalFaces:
             got = np.hypot(xyz[:, 0], xyz[:, 1])
             assert_allclose(got, radius, atol=get_conservative(np.float64) * radius, rtol=0.0)
 
-    # -- the hypothesis the boundary property rests on ---------------------------------
-
-    def test_a_face_scaled_in_homogeneous_space_is_refused(self) -> None:
-        """Faces must agree homogeneously, not merely projectively, and this shows why.
-
-        Scaling one face's homogeneous control points by 2 leaves its geometry **bitwise**
-        unchanged, so no projected comparison can see it -- yet with the edge check
-        disabled the volume misses each of the four faces adjacent to it by 17% of the
-        model (measured on this exact face set).  The check must therefore refuse it, and
-        must say so about the edge rather than about the geometry.
-        """
-        pairs = self._rational_cube_faces()
-        scaled = self._as_rational(self._unit_cube_faces()[2][0], factor=2.0)
-
-        probe = np.asarray([[0.3, 0.7], [0.0, 1.0]])
-        assert_allclose(
-            np.asarray(scaled.evaluate(probe)),
-            np.asarray(pairs[2][0].evaluate(probe)),
-            atol=0.0,
-        )
-
-        with pytest.raises(ValueError, match=r"Edge .* mismatch"):
-            create_coons_volume((pairs[0], pairs[1], (scaled, pairs[2][1])))
-
     # -- the weight field the blend produces -------------------------------------------
 
     @staticmethod
@@ -1209,3 +1189,310 @@ class TestCoonsVolumeRationalFaces:
         assert_allclose(weights.min(), 0.1, atol=get_conservative(np.float64))
         gaps = _face_interpolation_gaps(volume, faces)
         assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+
+class TestCoonsPrecisionAndColumnScale:
+    """A comparison is graded at the precision it is made in, against the scale it grades.
+
+    Two independent defects with opposite failure modes lived in the two boundary checks
+    (pantr issue 319):
+
+    1. the tier was read at float64 whatever the inputs carried, so a **float32 model was
+       refused for a disagreement it cannot express** -- one float32 ulp at magnitude 1 is
+       ``1.19e-07`` against a bar of ``9.09e-13``, tighter by ``5.4e5``;
+    2. the rational edge comparison took one magnitude over a homogeneous control row,
+       mixing coordinates (length times weight) with weights (dimensionless), so a
+       **weight error was graded against the model's length** and was accepted once the
+       model was large.
+
+    The corrected rules are ``pantr.cad._join._verify_shared_boundary``'s, which carries
+    their derivations and measurements.
+    """
+
+    # -- mechanism 1: the tier is read at the inputs' own precision ---------------------
+
+    @staticmethod
+    def _line(a: list[float], b: list[float], dtype: npt.DTypeLike) -> Bspline:
+        """Build the ticket's degree-1 two-point curve in a given precision.
+
+        Args:
+            a (list[float]): Start control point.
+            b (list[float]): End control point.
+            dtype (npt.DTypeLike): Precision of both the knots and the control points.
+
+        Returns:
+            Bspline: A clamped linear curve on ``[0, 1]``.
+        """
+        space = BsplineSpace([BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype), 1)])
+        return Bspline(space, np.asarray([a, b], dtype=dtype))
+
+    def _unit_square_curves(
+        self, dtype: npt.DTypeLike, offset: float
+    ) -> tuple[tuple[Bspline, Bspline], tuple[Bspline, Bspline]]:
+        """Build the ticket's four curves, with the ``(1,0)`` corner displaced by *offset*.
+
+        Args:
+            dtype (npt.DTypeLike): Precision of all four curves.
+            offset (float): Displacement along *x* of ``C_v1``'s start, which ``C_u0``'s
+                end reads as ``1``.
+
+        Returns:
+            tuple: ``((C_v0, C_v1), (C_u0, C_u1))``, as ``create_coons_surface`` takes them.
+        """
+        return (
+            (
+                self._line([0, 0, 0], [0, 1, 0], dtype),
+                self._line([1 + offset, 0, 0], [1, 1, 0], dtype),
+            ),
+            (
+                self._line([0, 0, 0], [1, 0, 0], dtype),
+                self._line([0, 1, 0], [1, 1, 0], dtype),
+            ),
+        )
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_a_corner_one_ulp_out_is_accepted_in_either_precision(
+        self, dtype: npt.DTypeLike
+    ) -> None:
+        """The ticket's reproduction: as close as the format allows must never be refused.
+
+        This is the whole of mechanism 1.  Both precisions must reach the same verdict,
+        because in each the corner is one ulp of *that* format out -- one ulp at magnitude
+        1 being the format's machine epsilon by definition -- while the tier is 4096 of
+        them.  float64 accepted it and float32 did not, reporting a corner mismatch that
+        is not one and was ``5.4e5`` below anything float32 can express.
+        """
+        curves = self._unit_square_curves(dtype, get_machine_epsilon(dtype))
+        surface = create_coons_surface(curves)
+        assert np.dtype(surface.control_points.dtype) == np.dtype(dtype)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_a_corner_a_thousand_ulps_out_is_refused_in_either_precision(
+        self, dtype: npt.DTypeLike
+    ) -> None:
+        """Reading the tier at float32 must not amount to accepting everything.
+
+        The tier is ``4096 * eps`` in every format, so the same *relative* mistake is
+        refused in both -- what changes is only what "relative" resolves to.  Without
+        this, a check that accepted its inputs unconditionally would pass the test above.
+        """
+        offset = 1.0e5 * get_machine_epsilon(dtype)
+        curves = self._unit_square_curves(dtype, offset)
+        with pytest.raises(ValueError, match=r"Corner \(1,0\) mismatch") as excinfo:
+            create_coons_surface(curves)
+        gap, tol, scale = _reported_numbers(str(excinfo.value))
+        assert gap == pytest.approx(offset, rel=1e-3)
+        assert scale == pytest.approx(1.0 + offset, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(dtype) * scale, rel=1e-3)
+
+    @staticmethod
+    def _cube_faces(dtype: npt.DTypeLike, scale: float = 1.0) -> _FacePairs:
+        """Build the six consistent faces of the cube ``[0, scale]^3`` in a given precision.
+
+        ``create_bilinear`` builds at float64 unconditionally, so a float32 model has to
+        be assembled directly.
+
+        Args:
+            dtype (npt.DTypeLike): Precision of the knots and control points.
+            scale (float): Side of the cube. Defaults to 1.0.
+
+        Returns:
+            _FacePairs: Six mutually consistent bilinear faces.
+        """
+        knots = np.array([0.0, 0.0, 1.0, 1.0], dtype=dtype)
+        space = BsplineSpace([BsplineSpace1D(knots.copy(), 1), BsplineSpace1D(knots.copy(), 1)])
+        s = scale
+        arrays = [
+            [[[0, 0, 0], [0, 0, s]], [[0, s, 0], [0, s, s]]],
+            [[[s, 0, 0], [s, 0, s]], [[s, s, 0], [s, s, s]]],
+            [[[0, 0, 0], [0, 0, s]], [[s, 0, 0], [s, 0, s]]],
+            [[[0, s, 0], [0, s, s]], [[s, s, 0], [s, s, s]]],
+            [[[0, 0, 0], [0, s, 0]], [[s, 0, 0], [s, s, 0]]],
+            [[[0, 0, s], [0, s, s]], [[s, 0, s], [s, s, s]]],
+        ]
+        f = [Bspline(space, np.asarray(a, dtype=dtype)) for a in arrays]
+        return ((f[0], f[1]), (f[2], f[3]), (f[4], f[5]))
+
+    def test_a_float32_model_survives_the_blend_in_float32(self) -> None:
+        """Reading the tier at float32 is not enough on its own: the blend must build too.
+
+        Grading a float32 patch correctly only moves the failure downstream if the
+        construction still assembles float64 coefficients over a float32 space, which
+        ``Bspline`` refuses outright, or mixes precisions inside one ``BsplineSpace``,
+        which is refused as well.  Both a patch and a volume are checked, since the two
+        hit different builders.
+        """
+        curves = self._unit_square_curves(np.float32, 0.0)
+        surface = create_coons_surface(curves)
+        assert np.dtype(surface.control_points.dtype) == np.dtype(np.float32)
+
+        faces = self._cube_faces(np.float32)
+        volume = create_coons_volume(faces)
+        assert np.dtype(volume.control_points.dtype) == np.dtype(np.float32)
+
+        # ``evaluate`` requires points in the B-spline's own dtype, which is what
+        # ``_face_interpolation_gaps`` cannot supply; check ``face_u0`` directly instead.
+        s = np.asarray(_FACE_SAMPLES, dtype=np.float32)
+        face_params = np.asarray([[v, w] for v in s for w in s], dtype=np.float32)
+        volume_params = np.asarray([[0.0, v, w] for v in s for w in s], dtype=np.float32)
+        assert_allclose(
+            np.asarray(volume.evaluate(volume_params), dtype=np.float64),
+            np.asarray(faces[0][0].evaluate(face_params), dtype=np.float64),
+            atol=get_conservative(np.float32),
+            rtol=0.0,
+        )
+
+    # -- mechanism 2: a weight is graded against the weights ----------------------------
+
+    @staticmethod
+    def _as_rational(face: Bspline) -> Bspline:
+        """Rewrite a polynomial face rationally, with every weight 1.
+
+        Args:
+            face (Bspline): A non-rational face.
+
+        Returns:
+            Bspline: The same geometry, carried rationally.
+        """
+        cp = np.asarray(face.control_points, dtype=np.float64)
+        weights = np.ones((*cp.shape[:-1], 1))
+        return Bspline(face.space, np.concatenate([cp, weights], axis=-1), True)
+
+    def _cube_with_displaced_weight(self, scale: float, gap: float) -> _FacePairs:
+        """Build the ticket's cube with the two w-faces rational and one weight out by *gap*.
+
+        Only the w-faces are rational, which is what keeps the reproduction on the
+        pre-existing path rather than on the one pantr issue 309 unblocked.  The displaced
+        control point is the corner at the origin, so its homogeneous *coordinates* are
+        zero however the weight moves: the coordinate columns agree exactly and only the
+        weight column can decide the verdict.
+
+        Args:
+            scale (float): Side of the cube.
+            gap (float): Amount added to one weight, against weights of 1.
+
+        Returns:
+            _FacePairs: Six faces whose weights disagree at one corner.
+        """
+        pairs = self._cube_faces(np.float64, scale)
+        faces = _flatten_faces(pairs)
+        faces[4], faces[5] = self._as_rational(faces[4]), self._as_rational(faces[5])
+        cp = np.asarray(faces[4].control_points).copy()
+        cp[0, 0, -1] += gap
+        faces[4] = Bspline(faces[4].space, cp, is_rational=True)
+        u0, u1, v0, v1, w0, w1 = faces
+        return ((u0, u1), (v0, v1), (w0, w1))
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e2, 1.0e4, 1.0e6, 1.0e8])
+    def test_a_weight_error_is_refused_at_every_model_scale(self, scale: float) -> None:
+        """The ticket's reproduction: four times the tier against weights of 1, at five sizes.
+
+        A weight is dimensionless, so this is a gross error at any ``scale``.  Graded
+        against one magnitude over the homogeneous row it was refused at ``scale = 1`` and
+        accepted at every larger size -- the failure the edge check exists to stop,
+        reappearing on the rational path once the model is big.
+        """
+        gap = 4.0 * get_conservative(np.float64)
+        with pytest.raises(ValueError, match=r"Edge \w+ mismatch") as excinfo:
+            create_coons_volume(self._cube_with_displaced_weight(scale, gap))
+
+        message = str(excinfo.value)
+        assert "weight scale" in message, message
+        reported_gap, tol, reported_scale = _reported_numbers(message)
+        assert reported_gap == pytest.approx(gap)
+        assert reported_scale == pytest.approx(1.0)
+        assert tol == pytest.approx(get_conservative(np.float64), rel=1e-3)
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e4, 1.0e8])
+    def test_a_weight_within_the_tier_is_accepted_at_every_model_scale(self, scale: float) -> None:
+        """The other side of the same rule: a quarter of the tier must pass everywhere.
+
+        Splitting the columns tightens the weight comparison by the model's size, so it
+        has to be checked that it did not tighten past what a weight can be stored to.
+        """
+        gap = 0.25 * get_conservative(np.float64)
+        volume = create_coons_volume(self._cube_with_displaced_weight(scale, gap))
+        assert volume.is_rational
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e4, 1.0e8])
+    def test_a_one_sided_weight_rescale_is_still_refused_at_every_scale(self, scale: float) -> None:
+        """Splitting the groups must not disarm the check the volume gained in pantr issue 307.
+
+        Scaling one face's homogeneous control points by ``mu`` leaves its geometry
+        untouched, so only a homogeneous comparison can see it.  Both groups carry ``mu``,
+        which is exactly why the split preserves the verdict: the weight gap
+        ``(mu - 1) w`` is graded against ``tier * max(w, mu w)`` and is refused.
+        """
+        pairs = self._cube_faces(np.float64, scale)
+        faces = _flatten_faces(pairs)
+        rational = self._as_rational(faces[4])
+        cp = np.asarray(rational.control_points) * 2.0
+        faces[4] = Bspline(rational.space, cp, is_rational=True)
+
+        grid = np.array([[a, b] for a in _FACE_SAMPLES for b in _FACE_SAMPLES])
+        assert_allclose(
+            np.asarray(faces[4].evaluate(grid)),
+            np.asarray(pairs[2][0].evaluate(grid)),
+            atol=0.0,
+        )
+
+        u0, u1, v0, v1, w0, w1 = faces
+        with pytest.raises(ValueError, match=r"Edge \w+ mismatch"):
+            create_coons_volume(((u0, u1), (v0, v1), (w0, w1)))
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e8])
+    def test_a_consistent_rational_cube_is_accepted_at_every_scale(self, scale: float) -> None:
+        """Neither rule may refuse correct input, at any model size.
+
+        The control for both mechanisms: all six faces rational, all weights 1, nothing
+        displaced.  It also pins that the coordinate group's scale still spans the model,
+        since a cube of side ``1e8`` is graded against ``1e8`` and not against 1.
+        """
+        pairs = self._cube_faces(np.float64, scale)
+        faces = _flatten_faces(pairs)
+        rational = [self._as_rational(f) for f in faces]
+        volume = create_coons_volume(
+            (
+                (rational[0], rational[1]),
+                (rational[2], rational[3]),
+                (rational[4], rational[5]),
+            )
+        )
+        gaps = _face_interpolation_gaps(
+            volume,
+            (
+                (rational[0], rational[1]),
+                (rational[2], rational[3]),
+                (rational[4], rational[5]),
+            ),
+        )
+        assert max(gaps.values()) <= get_conservative(np.float64) * scale, gaps
+
+    def test_a_coordinate_error_on_a_rational_edge_names_the_coordinate_group(self) -> None:
+        """The split must leave the coordinate half doing its job, and say which half decided.
+
+        One control point of ``face_w0`` has its **whole homogeneous row** doubled, so the
+        point it projects to is unchanged and the corner comparison, which projects, sees
+        nothing.  What is left is an edge disagreement of ``s`` in the coordinate columns
+        beside one of 1 in the weight column, and it must be reported against the model's
+        length rather than against the weights: the two are not comparable, and reporting
+        the wrong one would tell the caller to look at a quantity that is fine.
+        """
+        scale = 100.0
+        pairs = self._cube_faces(np.float64, scale)
+        faces = _flatten_faces(pairs)
+        faces[4], faces[5] = self._as_rational(faces[4]), self._as_rational(faces[5])
+        cp = np.asarray(faces[4].control_points).copy()
+        cp[1, 1] *= 2.0
+        faces[4] = Bspline(faces[4].space, cp, is_rational=True)
+
+        u0, u1, v0, v1, w0, w1 = faces
+        with pytest.raises(ValueError, match=r"Edge \w+ mismatch") as excinfo:
+            create_coons_volume(((u0, u1), (v0, v1), (w0, w1)))
+
+        message = str(excinfo.value)
+        assert "coordinate scale" in message, message
+        gap, tol, reported_scale = _reported_numbers(message)
+        assert gap == pytest.approx(scale)
+        assert reported_scale == pytest.approx(2.0 * scale)
+        assert tol == pytest.approx(get_conservative(np.float64) * 2.0 * scale, rel=1e-3)

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -1199,7 +1199,7 @@ class TestCoonsPrecisionAndColumnScale:
 
     1. the tier was read at float64 whatever the inputs carried, so a **float32 model was
        refused for a disagreement it cannot express** -- one float32 ulp at magnitude 1 is
-       ``1.19e-07`` against a bar of ``9.09e-13``, tighter by ``5.4e5``;
+       ``1.19e-07`` against a bar of ``9.09e-13``, tighter by ``2**17 = 131072``;
     2. the rational edge comparison took one magnitude over a homogeneous control row,
        mixing coordinates (length times weight) with weights (dimensionless), so a
        **weight error was graded against the model's length** and was accepted once the
@@ -1260,11 +1260,25 @@ class TestCoonsPrecisionAndColumnScale:
         because in each the corner is one ulp of *that* format out -- one ulp at magnitude
         1 being the format's machine epsilon by definition -- while the tier is 4096 of
         them.  float64 accepted it and float32 did not, reporting a corner mismatch that
-        is not one and was ``5.4e5`` below anything float32 can express.
+        is not one and was ``2**17 = 131072`` times below anything float32 can express.
         """
         curves = self._unit_square_curves(dtype, get_machine_epsilon(dtype))
         surface = create_coons_surface(curves)
         assert np.dtype(surface.control_points.dtype) == np.dtype(dtype)
+
+    def test_the_float32_tier_is_the_only_one_a_float32_corner_can_clear(self) -> None:
+        """Pin the ratio the docstrings quote, because a number in prose rots silently.
+
+        Pantr issue 319 states the float64 tier is ``5.4e5`` times tighter than one float32
+        ulp at magnitude 1.  It is not: ``5.4e8`` is ``eps32 / eps64``, and dividing that by
+        the tier's own factor of 4096 gives ``2**17 = 131072``, so the figure against the
+        *tier* is ``1.3e5``.  Both docstrings quoted the ticket's number until this test was
+        written.  Nothing else in the suite would notice, since the code never computes the
+        ratio -- which is exactly why it is asserted here rather than left as prose.
+        """
+        one_float32_ulp = get_machine_epsilon(np.float32)
+        assert one_float32_ulp / get_conservative(np.float64) == 2**17
+        assert get_machine_epsilon(np.float32) / get_machine_epsilon(np.float64) == 2**29
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     def test_a_corner_a_thousand_ulps_out_is_refused_in_either_precision(

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -10,7 +10,15 @@ from numpy import typing as npt
 from numpy.testing import assert_allclose
 
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
-from pantr.cad import create_bilinear, create_coons_surface, create_coons_volume, create_line
+from pantr.cad import (
+    create_bilinear,
+    create_circle,
+    create_coons_surface,
+    create_coons_volume,
+    create_extrusion,
+    create_line,
+    create_ruled,
+)
 from pantr.cad._coons import _extract_edge_pairs
 from pantr.tolerance import get_conservative
 
@@ -902,3 +910,302 @@ class TestCoonsVolumeFaceConsistency:
             for k in (0, 1)
             for name, side in (("u", i), ("v", j), ("w", k))
         }
+
+
+class TestCoonsVolumeRationalFaces:
+    """Six rational faces blend like six polynomial ones, because the blend is homogeneous.
+
+    ``create_coons_volume`` used to fail on all-rational faces with a NumPy broadcast
+    error naming shapes ``(3,)`` and ``(4,)`` (pantr issue 309): the corner array was
+    sized from the edges' *homogeneous* coefficients and filled from
+    :meth:`~pantr.bspline.Bspline.boundary`, which **projects**.  Every other term of the
+    seven-term formula was already built homogeneously, so the fix was to read the corner
+    the same way rather than to reopen what the formula means for a NURBS volume.
+
+    What that buys is the boundary property, unchanged: projection is pointwise, so it
+    commutes with restriction to a face, and a blend whose homogeneous restriction to
+    ``u = 0`` is ``face_u0``'s homogeneous data projects to ``face_u0`` itself.  Its
+    hypothesis is that the faces agree **homogeneously**, weights included, which
+    ``_verify_edges_3d`` enforces and ``test_a_face_scaled_in_homogeneous_space_is_refused``
+    pins.
+    """
+
+    @staticmethod
+    def _unit_cube_faces() -> _FacePairs:
+        """Build the six polynomial faces of the unit cube, exactly as pantr issue 309 does.
+
+        Returns:
+            _FacePairs: The reproduction's six bilinear faces.
+        """
+        arrays = [
+            np.array([[[0, 0, 0], [0, 0, 1]], [[0, 1, 0], [0, 1, 1]]], dtype=float),
+            np.array([[[1, 0, 0], [1, 0, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=float),
+            np.array([[[0, 0, 0], [0, 0, 1]], [[1, 0, 0], [1, 0, 1]]], dtype=float),
+            np.array([[[0, 1, 0], [0, 1, 1]], [[1, 1, 0], [1, 1, 1]]], dtype=float),
+            np.array([[[0, 0, 0], [0, 1, 0]], [[1, 0, 0], [1, 1, 0]]], dtype=float),
+            np.array([[[0, 0, 1], [0, 1, 1]], [[1, 0, 1], [1, 1, 1]]], dtype=float),
+        ]
+        u0, u1, v0, v1, w0, w1 = (create_bilinear(a) for a in arrays)
+        return ((u0, u1), (v0, v1), (w0, w1))
+
+    @staticmethod
+    def _as_rational(face: Bspline, factor: float = 1.0) -> Bspline:
+        """Rewrite a polynomial face as a rational one with every weight *factor*.
+
+        Multiplying **all** of a patch's homogeneous coefficients by one constant leaves
+        the projected geometry bitwise unchanged, since ``(k w x) / (k w) = x`` exactly for
+        the powers of two used here.  At ``factor = 1`` this is the reproduction's wrapper.
+
+        Args:
+            face (Bspline): A non-rational face.
+            factor (float): Constant scaling of the homogeneous coefficients.
+                Defaults to 1.0.
+
+        Returns:
+            Bspline: The same geometry, carried rationally.
+        """
+        cp = np.asarray(face.control_points, dtype=np.float64)
+        weights = np.full((*cp.shape[:-1], 1), factor)
+        return Bspline(face.space, np.concatenate([cp * factor, weights], axis=-1), True)
+
+    def _rational_cube_faces(self) -> _FacePairs:
+        """Wrap the reproduction's six faces as rational with all weights 1.
+
+        Returns:
+            _FacePairs: The face set that used to raise a broadcast error.
+        """
+        return tuple(  # type: ignore[return-value]
+            tuple(self._as_rational(f) for f in pair) for pair in self._unit_cube_faces()
+        )
+
+    # -- the reproduction -------------------------------------------------------------
+
+    def test_the_polynomial_control_still_interpolates_all_six_faces(self) -> None:
+        """The reproduction's control must be unaffected: it built before and must still.
+
+        Nothing about the rational path may disturb it, so this checks the property the
+        volume exists for rather than merely that the call returns.
+        """
+        faces = self._unit_cube_faces()
+        gaps = _face_interpolation_gaps(create_coons_volume(faces), faces)
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    def test_all_rational_faces_reproduce_the_polynomial_control(self) -> None:
+        """The reproduction's rational face set builds, and to the same geometry.
+
+        Weights are all 1, so the volume is the polynomial one written rationally and the
+        two must agree to roundoff -- an oracle that does not go through the same code.
+        """
+        polynomial = create_coons_volume(self._unit_cube_faces())
+        rational = create_coons_volume(self._rational_cube_faces())
+
+        assert rational.is_rational
+        assert_allclose(np.asarray(rational.control_points)[..., -1], 1.0, atol=0.0)
+
+        pts = np.asarray(
+            [[u, v, w] for u in (0.0, 0.25, 0.5, 1.0) for v in (0.0, 0.5, 0.9) for w in (0.1, 1.0)]
+        )
+        assert_allclose(
+            np.asarray(rational.evaluate(pts)),
+            np.asarray(polynomial.evaluate(pts)),
+            atol=get_conservative(np.float64),
+            rtol=0.0,
+        )
+
+    def test_all_rational_faces_are_interpolated(self) -> None:
+        """The rational volume restricts to each of the six rational faces it was built from."""
+        faces = self._rational_cube_faces()
+        gaps = _face_interpolation_gaps(create_coons_volume(faces), faces)
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    def test_mixed_faces_take_the_rational_path_rather_than_a_third_one(self) -> None:
+        """Some faces rational and some not must behave like all-rational, not like a third case.
+
+        Which faces are rational also decides *where* the old crash was reachable: the
+        corners were read off the v-faces alone, so a rational u-face never triggered it
+        while a rational v-face did.  Both are checked here, in both directions.
+        """
+        polynomial = self._unit_cube_faces()
+        rational = self._rational_cube_faces()
+        pts = np.asarray([[0.2, 0.4, 0.6], [0.0, 1.0, 0.5], [1.0, 0.0, 0.0]])
+        want = np.asarray(create_coons_volume(polynomial).evaluate(pts))
+
+        for rational_pair in range(3):
+            faces: _FacePairs = tuple(  # type: ignore[assignment]
+                rational[i] if i == rational_pair else polynomial[i] for i in range(3)
+            )
+            volume = create_coons_volume(faces)
+            assert volume.is_rational, rational_pair
+            assert_allclose(
+                np.asarray(volume.evaluate(pts)),
+                want,
+                atol=get_conservative(np.float64),
+                rtol=0.0,
+                err_msg=f"rational pair {rational_pair}",
+            )
+            gaps = _face_interpolation_gaps(volume, faces)
+            assert max(gaps.values()) <= get_conservative(np.float64), (rational_pair, gaps)
+
+    # -- non-unit weights, against an oracle built by a different code path -------------
+
+    @staticmethod
+    def _quarter_annulus_prism() -> Bspline:
+        """Build a quarter-annulus prism as a NURBS volume, without any Coons machinery.
+
+        The body is a ruled surface between two concentric quarter arcs, extruded along
+        *z*: degree ``(2, 1, 1)``, genuinely rational, with the arcs' middle weights at
+        ``1/sqrt(2)``.  Being degree 1 in *v* and *w* is what makes it an oracle for the
+        blend rather than merely an input to it: the Coons operator is
+        ``P = P_u + P_v + P_w - P_u P_v - P_u P_w - P_v P_w + P_u P_v P_w``, and a body
+        with ``P_v V = P_w V = V`` collapses that sum to ``V`` exactly, so the volume
+        rebuilt from its own six faces must be the body itself.
+
+        Returns:
+            Bspline: The exact NURBS quarter-annulus prism of inner radius 1, outer
+            radius 2 and height 3.
+        """
+        arcs = (
+            create_circle(radius=1.0, angle=np.pi / 2),
+            create_circle(radius=2.0, angle=np.pi / 2),
+        )
+        return create_extrusion(create_ruled(*arcs), [0.0, 0.0, 3.0])
+
+    def test_non_unit_weights_rebuild_an_independently_constructed_volume(self) -> None:
+        """A body with real weights, taken apart and blended back, must come back unchanged.
+
+        The oracle is built by ``create_circle``/``create_ruled``/``create_extrusion``,
+        which share no code with the Coons blend, and its weights are ``1/sqrt(2)`` rather
+        than 1, so unit weights cannot hide a mistake in how the corner term is carried.
+        """
+        oracle = self._quarter_annulus_prism()
+        assert oracle.is_rational
+        weights = np.unique(np.asarray(oracle.control_points)[..., -1])
+        assert weights.min() < 1.0, weights
+
+        boundaries = [oracle.boundary(axis, side) for axis in range(3) for side in (0, 1)]
+        faces: _FacePairs = tuple(  # type: ignore[assignment]
+            (boundaries[2 * axis], boundaries[2 * axis + 1]) for axis in range(3)
+        )
+        volume = create_coons_volume(faces)
+
+        pts = np.asarray(
+            [[u, v, w] for u in (0.0, 0.3, 1.0) for v in (0.0, 0.5, 1.0) for w in (0.0, 0.7, 1.0)]
+        )
+        got = np.asarray(volume.evaluate(pts))
+        assert_allclose(got, np.asarray(oracle.evaluate(pts)), atol=1e-14, rtol=0.0)
+
+    def test_non_unit_weights_land_on_the_analytic_cylinder(self) -> None:
+        """The rebuilt prism's curved faces must lie on the circles they represent exactly.
+
+        This is the check that does not consult pantr at all: a NURBS quarter arc of
+        radius *r* is exact, so every point of the rebuilt inner and outer face must
+        satisfy ``x^2 + y^2 = r^2``.  A corner term carried in the wrong space perturbs
+        the weight field and shows up here as a radius that drifts off *r*.
+        """
+        oracle = self._quarter_annulus_prism()
+        boundaries = [oracle.boundary(axis, side) for axis in range(3) for side in (0, 1)]
+        faces: _FacePairs = tuple(  # type: ignore[assignment]
+            (boundaries[2 * axis], boundaries[2 * axis + 1]) for axis in range(3)
+        )
+        volume = create_coons_volume(faces)
+
+        s = _FACE_SAMPLES
+        for radial, radius in ((0.0, 1.0), (1.0, 2.0)):
+            pts = np.asarray([[u, radial, w] for u in s for w in s])
+            xyz = np.asarray(volume.evaluate(pts))
+            got = np.hypot(xyz[:, 0], xyz[:, 1])
+            assert_allclose(got, radius, atol=get_conservative(np.float64) * radius, rtol=0.0)
+
+    # -- the hypothesis the boundary property rests on ---------------------------------
+
+    def test_a_face_scaled_in_homogeneous_space_is_refused(self) -> None:
+        """Faces must agree homogeneously, not merely projectively, and this shows why.
+
+        Scaling one face's homogeneous control points by 2 leaves its geometry **bitwise**
+        unchanged, so no projected comparison can see it -- yet with the edge check
+        disabled the volume misses each of the four faces adjacent to it by 17% of the
+        model (measured on this exact face set).  The check must therefore refuse it, and
+        must say so about the edge rather than about the geometry.
+        """
+        pairs = self._rational_cube_faces()
+        scaled = self._as_rational(self._unit_cube_faces()[2][0], factor=2.0)
+
+        probe = np.asarray([[0.3, 0.7], [0.0, 1.0]])
+        assert_allclose(
+            np.asarray(scaled.evaluate(probe)),
+            np.asarray(pairs[2][0].evaluate(probe)),
+            atol=0.0,
+        )
+
+        with pytest.raises(ValueError, match=r"Edge .* mismatch"):
+            create_coons_volume((pairs[0], pairs[1], (scaled, pairs[2][1])))
+
+    # -- the weight field the blend produces -------------------------------------------
+
+    @staticmethod
+    def _cube_faces_with_interior_weight(interior: float) -> _FacePairs:
+        """Build unit-cube faces carrying one interior control point of weight *interior*.
+
+        Each face is the same square, refined to a 3x3 control net by an interior knot at
+        0.5 in both directions, with every boundary weight left at 1 so all twelve edges
+        still agree.  Only the middle weight is free, which is the point: a face's
+        interior is the part the consistency checks do not constrain.
+
+        With every face's interior weight at *t*, the blend's interior control weight is
+        ``3t - 3 + 1 = 3t - 2`` -- three ruled terms contributing *t*, three bilinear terms
+        and the corner term contributing 1 -- so it crosses zero at ``t = 2/3`` while every
+        input weight stays strictly positive.
+
+        Args:
+            interior (float): Weight of each face's middle control point.
+
+        Returns:
+            _FacePairs: Six mutually consistent faces with strictly positive weights.
+        """
+        knots = np.array([0.0, 0.0, 0.5, 1.0, 1.0])
+        space = BsplineSpace([BsplineSpace1D(knots.copy(), 1), BsplineSpace1D(knots.copy(), 1)])
+        samples = np.array([0.0, 0.5, 1.0])
+        faces = []
+        for pair in TestCoonsVolumeRationalFaces._unit_cube_faces():
+            for face in pair:
+                corners = np.asarray(face.control_points, dtype=np.float64)
+                net = np.empty((3, 3, 3))
+                for a, u in enumerate(samples):
+                    for b, v in enumerate(samples):
+                        net[a, b] = (
+                            (1 - u) * (1 - v) * corners[0, 0]
+                            + u * (1 - v) * corners[1, 0]
+                            + (1 - u) * v * corners[0, 1]
+                            + u * v * corners[1, 1]
+                        )
+                weights = np.ones((3, 3, 1))
+                weights[1, 1, 0] = interior
+                faces.append(Bspline(space, np.concatenate([net * weights, weights], -1), True))
+        return ((faces[0], faces[1]), (faces[2], faces[3]), (faces[4], faces[5]))
+
+    def test_positive_face_weights_do_not_imply_a_positive_blend(self) -> None:
+        """Strictly positive weights on all six faces can still blend to a negative weight.
+
+        The formula is an inclusion-exclusion and subtracts three of its seven terms, so
+        the weight field is not a convex combination of the faces' weights.  At interior
+        weight 0.5 every input weight is in ``[0.5, 1]`` and the blend's middle control
+        weight is ``3 * 0.5 - 2 = -0.5``; at degree 1 with a knot at 0.5 the middle basis
+        function is the only non-zero one at the centre, so the weight field *itself* is
+        ``-0.5`` there and the volume genuinely has a pole.
+        """
+        with pytest.raises(ValueError, match="weight is not certified positive"):
+            create_coons_volume(self._cube_faces_with_interior_weight(0.5))
+
+    def test_a_positive_blend_of_varying_weights_is_accepted(self) -> None:
+        """The guard must not refuse a weight field that stays positive.
+
+        At interior weight 0.7 the same construction lands on ``3 * 0.7 - 2 = 0.1``: still
+        far from the faces' own weights, still accepted, and the volume still interpolates
+        all six faces.  Without this, refusing everything rational would pass the test above.
+        """
+        faces = self._cube_faces_with_interior_weight(0.7)
+        volume = create_coons_volume(faces)
+        weights = np.asarray(volume.control_points)[..., -1]
+        assert_allclose(weights.min(), 0.1, atol=get_conservative(np.float64))
+        gaps = _face_interpolation_gaps(volume, faces)
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps


### PR DESCRIPTION
Closes #309, closes #319.

Two tickets on the same file and the same path, in one branch: #309 makes rational Coons
volumes work, #319 fixes the two boundary checks that are supposed to guard them.

## #309 — rational faces are supported, not refused

The ticket offered "support" or "refuse", and framed support as a design question about how
weights combine under projection. It is not one: the seven-term blend is already formed from
**homogeneous** coefficients everywhere in this file (`_combine_control_points`,
`_build_bilinear_volume`, `_verify_edges_3d`). The single place that left that space was
`_extract_corners`, which sized its array with the homogeneous rank and then filled it with
`boundary()`, which *projects* — hence `could not broadcast (3,) into (4,)`. Corner reads now
stay homogeneous (`_homogeneous_endpoint`), and the formula is untouched.

The boundary property survives projection because projection is pointwise, so it commutes with
restriction to a face: a blend whose homogeneous restriction to `u = 0` is `face_u0`'s data
projects to `face_u0` itself. This holds only if the faces agree in **homogeneous** data,
weights included, rather than merely projectively — which is what `_verify_edges_3d` enforces.

Rational volumes also get a weight guard. The blend is an inclusion-exclusion and subtracts
three of its terms, so strictly positive face weights do not imply a positive weight field
inside, and where it vanishes the volume has a pole. Since the weight field is
`w(u) = Σ_i N_i(u) w_i` over a non-negative partition of unity, `w(u) ≥ min_i w_i`, so the
result's control weights bound it from below with no evaluation. The check is **sufficient,
not necessary** — a volume whose weight field never approaches zero can still carry a negative
control weight and be refused — and both the docstring and the error message say so.

| | |
|---|---|
| AC1 | All-rational unit cube builds; geometry matches the polynomial control to `1.110e-16` over a 4³ interior grid. |
| AC2 | Polynomial control unchanged; all six faces still interpolated. |
| AC3 | Regression test carries the exact rational face set, hardcoded, and fails on the parent commit. |
| AC4 | N/A — rational faces are supported rather than refused. |
| AC5 | Mixed rational/polynomial input behaves as the all-rational case; covered by test. |

## #319 — grade each comparison at its own precision, and against its own dimension

1. **Precision.** The tier was read at float64 whatever the input's precision, so a float32
   model was refused for a disagreement float32 cannot express. It is now read at the coarsest
   of the readings' own dtypes. Corner extraction stops forcing float64, and the blend
   accumulates in the first operand's precision, matching `create_ruled` and `make_compat` —
   a float32 model stays float32 rather than being silently promoted.
2. **Scale.** One max over a homogeneous control row mixes coordinates (length × weight) with
   weights (dimensionless), so a weight error was graded against the model's length. Columns
   are now split into groups that each share a physical dimension and each graded against
   their own magnitude. `_ColumnGroup` moved out of `_join.py` into `_validation.py`, so `join`
   and the Coons checks share one implementation of the rule instead of two.

**A number in the ticket is wrong, and it had been copied into four docstrings.** #319 states
the float64 tier is "5.4e5 times tighter" than one float32 ulp. It is `2^17 = 131072 ≈ 1.3e5`;
`5.4e8` is `eps32/eps64`, and `5.4e5` is that figure mis-scaled by 4096 the wrong way round.
No behaviour depended on it — the code always computed the tier from the dtype — but a
derivation is what licenses a tolerance to exist here, so a wrong constant in one is a wrong
derivation. All four sites are corrected, and a test now **asserts** the two ratios, because
nothing else can reach a number that lives only in prose.

| | |
|---|---|
| AC1 | float32 and float64 both accept a corner one ulp of their own format out. |
| AC2 | The weight error of 4× tolerance is refused at every scale from 1 to 1e8 (previously accepted at four of five). |
| AC3 | Both reproductions carried as hardcoded regression tests, each failing on the parent commit. |
| AC4 | A one-sided weight rescale is still refused; the split does not open that hole. |
| AC5 | Every pre-existing test in `tests/test_cad_coons.py` passes unchanged. |
| AC6 | No new numeric constant; both tolerances still come from `pantr.tolerance`. |
| AC7 | Both rules documented, with the corrected ratio and the guard's sufficiency caveat. |

## Checks

ruff, ruff format, mypy (233 files), `lint-imports` (1 contract kept), pytest **5749 passed,
21 skipped, 3 xfailed**. Acceptance criteria re-verified by direct execution of the tickets'
own reproductions, independently of the test suite.

## Known and deliberately not fixed here

- **`create_coons_surface` has the same rational defect, silently.** Four boundary curves of a
  unit square with one rational (weight 1→2): the surface misses that boundary curve by ~0.095
  in the interior while all four corners match exactly, so the corner check, which compares
  projected points, cannot see it. This is an explicit non-goal of #309 and needs its own
  ticket.
- **The weight guard uses a plain sign test** on a quantity from an alternating seven-term sum,
  where round-off scales with the terms rather than the result. A volume whose true minimum
  weight is slightly negative can compute slightly positive and be accepted. The fix is a
  derived margin, i.e. a new tolerance, which belongs in a tolerance review rather than at the
  end of this one.
- **Mixed float32/float64 input** is documented as unsupported and in practice follows the
  first operand. Making it an explicit `ValueError` would match `BsplineSpace`/`Bspline`, but
  could break a caller relying on today's silent acceptance.
- The full docs build could not be run locally (the gallery segfaults on macOS without a GL
  context, identically on the parent commit); the targeted module build is clean under `-W`.
  CI is the check that matters here.
