### PR TITLE
fix(change_basis): give every solving builder a derived degree/dtype domain

### DIFF
--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -46,27 +46,33 @@ domain replaces. Inside the domain the inverse obeys
 1 / (\varepsilon \lVert M \rVert_\infty)`, and :math:`\lVert M \rVert_\infty \ge 0.036`
 over every supported range here, so no entry of an inverse can exceed
 :math:`2.3 \times 10^{8}` in float32 -- thirty orders of magnitude below that format's
-overflow threshold. And a matrix that is not singular to working precision does not
-produce the exactly zero pivot :class:`numpy.linalg.LinAlgError` reports. Measured, both
-occur only in float32 and only for the two cardinal pairs, and the first of each is at least
-twenty-six degrees past the boundary.
+overflow threshold. The exactly zero pivot :class:`numpy.linalg.LinAlgError` reports is not
+ruled out by that inequality -- the perturbation bound constrains the *exact* matrix, not the
+one pantr forms -- but it is not observed anywhere near the boundary either. Measured, both
+failures occur only in float32 and only in the cardinal-to-Bernstein and cardinal-to-Legendre
+directions: the first infinity is 26 degrees past the boundary in both, and the first
+``LinAlgError`` 29 and 32 degrees past.
 
 The :math:`\kappa_\infty` values behind the tabulated limits come from matrices rebuilt in
 exact rational (or 60-digit decimal) arithmetic from closed forms, rather than from the
 matrices pantr computes. That distinction is load-bearing for the Bernstein/cardinal pair,
 whose forward matrix is itself the output of a Gram solve and so is not exact: near the
-boundary, :func:`numpy.linalg.cond` applied to the matrix pantr forms reports 8.6 times too
-much at degree 13 and 4.9 times too little at degree 15, either of which moves the crossing.
-Applied to the *exact* matrix that same call is accurate to five digits even at
-:math:`4 \times 10^{17}`, so it is the matrix and not the estimator that is at fault.
-Rebuilding from closed forms also keeps the derivation independent of the code it grades. It
-runs as a test, ``tests/test_change_basis_domain.py``, so the tabulated degrees are checked
-rather than asserted.
+boundary, ``numpy.linalg.cond(M, numpy.inf)`` applied to the matrix pantr forms reports 8.6
+times too much at degree 13 and 4.9 times too little at degree 15, either of which moves the
+crossing. (The norm has to be named: :func:`numpy.linalg.cond` defaults to the 2-norm, and
+the criterion here is stated throughout in the infinity norm the perturbation bound uses.)
+Applied to the *exact* matrix the same call tracks :math:`\kappa_\infty` to five digits at
+:math:`1.1 \times 10^{16}` and still to four at :math:`3.7 \times 10^{17}`, so it is the
+matrix and not the estimator that is at fault. Rebuilding from closed forms also keeps the
+derivation independent of the code it grades. It runs as a test,
+``tests/test_change_basis_domain.py``, so the tabulated degrees are checked rather than
+asserted.
 """
 
 import functools
 from collections.abc import Callable, Mapping
 from math import comb
+from types import MappingProxyType
 from typing import Final, NamedTuple
 
 import numpy as np
@@ -142,13 +148,15 @@ conditioning does bound the result and no fidelity cap is needed: the measured e
 the two limits is ``1.7e-4`` (float32, degree 6) and ``1.3e-5`` (float64, degree 12).
 """
 
-_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE: Final[Mapping[LagrangeVariant, _DegreeLimit]] = {
-    LagrangeVariant.EQUISPACES: _DegreeLimit(float32=17, float64=37),
-    LagrangeVariant.GAUSS_LEGENDRE: _DegreeLimit(float32=22, float64=51),
-    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: _DegreeLimit(float32=23, float64=52),
-    LagrangeVariant.CHEBYSHEV_1ST: _DegreeLimit(float32=23, float64=52),
-    LagrangeVariant.CHEBYSHEV_2ND: _DegreeLimit(float32=23, float64=52),
-}
+_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE: Final[Mapping[LagrangeVariant, _DegreeLimit]] = MappingProxyType(
+    {
+        LagrangeVariant.EQUISPACES: _DegreeLimit(float32=17, float64=37),
+        LagrangeVariant.GAUSS_LEGENDRE: _DegreeLimit(float32=22, float64=51),
+        LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: _DegreeLimit(float32=23, float64=52),
+        LagrangeVariant.CHEBYSHEV_1ST: _DegreeLimit(float32=23, float64=52),
+        LagrangeVariant.CHEBYSHEV_2ND: _DegreeLimit(float32=23, float64=52),
+    }
+)
 r"""Supported degrees of :func:`compute_bernstein_to_lagrange_1d`, per node family.
 
 Governing matrix: ``C``, the Lagrange-to-Bernstein matrix this builder inverts, whose
@@ -168,34 +176,41 @@ matrix pantr actually forms rather than an idealized one.
 
 def _validate_degree_in_domain(
     degree: int,
-    dtype: np.dtype[np.float32 | np.float64],
+    dtype: npt.DTypeLike,
     max_degree: _DegreeLimit,
     builder: str,
 ) -> None:
     """Refuse a ``(degree, dtype)`` pair outside a builder's supported domain.
 
     See the module docstring for what sets the boundary. This is a pure precondition:
-    inside the domain it does nothing at all, so it cannot perturb a returned matrix.
+    inside the domain it does nothing at all, so it cannot perturb a returned matrix. It runs
+    *before* the output array is allocated, so a degree far outside the domain is refused with
+    this message rather than by whatever the allocation of a huge array would raise.
 
     Args:
         degree (int): Polynomial degree the caller asked for.
-        dtype (np.dtype[np.float32 | np.float64]): Already-validated output dtype.
+        dtype (npt.DTypeLike): Output dtype; validated here, since this runs before the
+            output array exists.
         max_degree (_DegreeLimit): Largest supported degree per format.
         builder (str): Name of the calling builder, quoted in the message so the caller is
             told which function refused rather than only that some matrix was singular.
 
     Raises:
-        ValueError: If ``degree`` exceeds what ``dtype`` supports.
+        ValueError: If ``dtype`` is not float32/float64, or ``degree`` exceeds what that
+            dtype supports.
     """
-    limit = max_degree.float32 if dtype == np.float32 else max_degree.float64
+    _validate_float_dtype(dtype)
+    resolved = np.dtype(dtype)
+    limit = max_degree.float32 if resolved == np.float32 else max_degree.float64
     if degree <= limit:
         return
     raise ValueError(
-        f"{builder}: degree {degree} is outside the supported domain for {dtype.name} "
+        f"{builder}: degree {degree} is outside the supported domain for {resolved.name} "
         f"(supported: degree <= {max_degree.float32} in float32, "
         f"degree <= {max_degree.float64} in float64). Past that degree the matrix this "
-        f"builder solves with is singular to working precision, so the result would carry "
-        f"no correct digit; see the pantr.change_basis module docstring for the derivation."
+        f"builder solves with is singular to working precision, so the error bound on the "
+        f"result reaches 100% and guarantees no correct digit; see the pantr.change_basis "
+        f"module docstring for the derivation."
     )
 
 
@@ -340,17 +355,17 @@ def compute_bernstein_to_lagrange_1d(
     """
     if degree < 1:
         raise ValueError("Degree must at least 1")
-    out = _prepare_square_out(degree, dtype, out)
     # `LagrangeVariant(...)` rather than a bare lookup: an unrecognized variant would
     # otherwise leave this function through `KeyError`, which is exactly the kind of
     # undocumented exception type the domain exists to stop escaping.
     variant = LagrangeVariant(lagrange_variant)
     _validate_degree_in_domain(
         degree,
-        out.dtype,
+        dtype,
         _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[variant],
         f"compute_bernstein_to_lagrange_1d with {variant.name} nodes",
     )
+    out = _prepare_square_out(degree, dtype, out)
 
     forward = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -451,6 +466,16 @@ def compute_bernstein_to_cardinal_1d(
     polynomials up to degree ``2 * degree + 1`` exactly, while every inner product
     formed here is between two polynomials of degree ``degree``.
 
+    Warning:
+        Accuracy is set by the Bernstein Gram matrix this projection solves with, whose
+        condition number grows like :math:`4^p`: :math:`\kappa_\infty(G_{\mathrm{bern}})` is
+        ``1.7e2`` at degree 4, ``3.4e4`` at degree 8 and ``7.3e6`` at degree 12. Measured
+        against the exact rational answer, the returned matrix is within ``2.4e-6`` relative
+        at degree 4 and ``5.3e-2`` at degree 12 in float32, and within ``1.7e-15`` at degree
+        4 in float64. This direction is much better behaved than its inverse -- see
+        :func:`compute_cardinal_to_bernstein_1d` -- which is why it carries the larger
+        domain of the pair.
+
     Args:
         degree (int): Polynomial degree. Must be non-negative.
         dtype (npt.DTypeLike): Floating point type for the output matrix.
@@ -476,13 +501,13 @@ def compute_bernstein_to_cardinal_1d(
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
-    out = _prepare_square_out(degree, dtype, out)
     _validate_degree_in_domain(
         degree,
-        out.dtype,
+        dtype,
         _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
         "compute_bernstein_to_cardinal_1d",
     )
+    out = _prepare_square_out(degree, dtype, out)
 
     return _compute_change_basis_1D(
         new_basis_eval=functools.partial(tabulate_bernstein_1d, degree),
@@ -567,13 +592,13 @@ def compute_cardinal_to_bernstein_1d(
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
-    out = _prepare_square_out(degree, dtype, out)
     _validate_degree_in_domain(
         degree,
-        out.dtype,
+        dtype,
         _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
         "compute_cardinal_to_bernstein_1d",
     )
+    out = _prepare_square_out(degree, dtype, out)
 
     forward = compute_bernstein_to_cardinal_1d(degree, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -712,13 +737,13 @@ def compute_cardinal_to_legendre_1d(
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
-    out = _prepare_square_out(degree, dtype, out)
     _validate_degree_in_domain(
         degree,
-        out.dtype,
+        dtype,
         _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
         "compute_cardinal_to_legendre_1d",
     )
+    out = _prepare_square_out(degree, dtype, out)
 
     forward = compute_legendre_to_cardinal_1d(degree, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -796,13 +821,13 @@ def compute_cardinal_dual_legendre_coeffs_1d(
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
-    out = _prepare_square_out(degree, dtype, out)
     _validate_degree_in_domain(
         degree,
-        out.dtype,
+        dtype,
         _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
         "compute_cardinal_dual_legendre_coeffs_1d",
     )
+    out = _prepare_square_out(degree, dtype, out)
 
     out[:] = compute_cardinal_to_legendre_1d(degree, dtype).T
     return out
@@ -822,6 +847,11 @@ def compute_monomial_to_bernstein_1d(
 
     The entries are ``M[i, j] = C(i, j) / C(degree, j)`` for ``j <= i``, else
     ``0``, where ``C(n, k)`` is the binomial coefficient.
+
+    Note:
+        This builder carries no degree limit in either dtype, and so appears in no row of
+        the module docstring's domain table: the entries come straight from a closed form
+        and no linear solve is involved at any degree.
 
     Args:
         degree (int): Polynomial degree. Must be non-negative.

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -11,11 +11,58 @@ into the core Spline space objects.
 
 Every public builder is named ``compute_A_to_B_1d`` and returns the matrix :math:`M` with
 :math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`.
+
+Supported ``(degree, dtype)`` domain
+------------------------------------
+
+Five of the builders recover their result from a linear solve, and a solve is only
+defined while the matrix it uses is not singular to working precision. Each of those five
+declares the largest degree it supports per dtype and raises :class:`ValueError` past it,
+naming the degree, the dtype and the supported range, rather than letting
+:class:`numpy.linalg.LinAlgError` or an overflow to infinity escape. The two builders that
+solve nothing carry no degree limit -- :func:`compute_lagrange_to_bernstein_1d`, which is
+a tabulation, and :func:`compute_legendre_to_cardinal_1d`, whose Gram matrix is the
+identity -- and :func:`compute_monomial_to_bernstein_1d` evaluates a closed form.
+
+The boundary is the largest degree :math:`p` at which the matrix :math:`M_p` the builder
+solves with satisfies
+
+.. math::
+
+    \kappa_\infty(M_p) \, \varepsilon < 1 ,
+
+with :math:`\varepsilon` the dtype's machine epsilon. Nothing is tuned here. The standard
+perturbation bound for a linear system puts the relative error of the computed solution at
+order :math:`\kappa_\infty(M) \varepsilon` (Higham, *Accuracy and Stability of Numerical
+Algorithms*, 2nd ed., SIAM 2002), so at :math:`\kappa_\infty \varepsilon = 1` that bound
+reaches 100% and stops asserting anything at all, which is also where :math:`M` becomes
+singular to working precision. It is the only threshold-free choice, and it is a
+*necessary* condition rather than a promise of accuracy: each builder's ``Warning:``
+section states the accuracy actually attained, and that degrades long before the boundary.
+
+Two consequences of the inequality are worth stating, because they are the failures the
+domain replaces. Inside the domain the inverse obeys
+:math:`\lVert M^{-1} \rVert_\infty = \kappa_\infty(M) / \lVert M \rVert_\infty <
+1 / (\varepsilon \lVert M \rVert_\infty)`, and :math:`\lVert M \rVert_\infty \ge 0.036`
+over every supported range here, so no entry of an inverse can exceed
+:math:`2.3 \times 10^{8}` in float32 -- thirty orders of magnitude below that format's
+overflow threshold. And a matrix that is not singular to working precision does not
+produce the exactly zero pivot :class:`numpy.linalg.LinAlgError` reports. Measured, the
+first infinity and the first ``LinAlgError`` appear more than twenty degrees past the
+boundary.
+
+The :math:`\kappa_\infty` values behind the tabulated limits are computed in exact rational
+(or 120-digit decimal) arithmetic from the matrices themselves, not with
+:func:`numpy.linalg.cond`: a float64 SVD cannot resolve a condition number near
+:math:`1/\varepsilon`, which is precisely where the boundary sits. That derivation runs as
+a test, ``tests/test_change_basis_domain.py``, so the tabulated degrees are checked rather
+than asserted.
 """
 
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from math import comb
+from typing import Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -32,6 +79,119 @@ from .basis._basis_utils import (
     _validate_float_dtype,
 )
 from .quad import get_gauss_legendre_1d
+
+
+class _DegreeLimit(NamedTuple):
+    """Largest degree a change-of-basis builder supports, per floating-point format.
+
+    Attributes:
+        float32 (int): Largest degree supported when the output dtype is ``float32``.
+        float64 (int): Largest degree supported when the output dtype is ``float64``.
+    """
+
+    float32: int
+    float64: int
+
+
+_CARDINAL_TO_BERNSTEIN_MAX_DEGREE: Final = _DegreeLimit(float32=8, float64=12)
+r"""Supported degrees of :func:`compute_cardinal_to_bernstein_1d`.
+
+Governing matrix: ``A``, the Bernstein-to-cardinal matrix this builder inverts.
+:math:`\kappa_\infty(A) \varepsilon` is ``0.46`` at degree 8 against ``6.7`` at degree 9 in
+float32, and ``0.091`` at degree 14 against ``2.4`` at degree 15 in float64.
+
+The float64 entry is 12 rather than the 14 that inequality allows, and this is the one
+place in the module where conditioning is not the binding criterion. ``A`` is not exact
+here: it comes out of :func:`compute_bernstein_to_cardinal_1d`'s own Gram solve and so
+carries a relative error of order :math:`\kappa_\infty(G_{\mathrm{bern}}) \varepsilon`,
+which makes :math:`\kappa_\infty(A) \varepsilon` not an error bound for what this builder
+returns. Measured against the exact rational inverse, the returned matrix is still within
+``4.3e-2`` relative at degree 12 and is off by ``9.6`` -- 960% -- at degree 13, so 12 is
+the last degree that carries information. Float32 needs no such cap: its measured error at
+degree 8 is ``0.90``, just inside, and its conditioning limit is 8 as well.
+"""
+
+_BERNSTEIN_TO_CARDINAL_MAX_DEGREE: Final = _DegreeLimit(float32=12, float64=26)
+r"""Supported degrees of :func:`compute_bernstein_to_cardinal_1d`.
+
+Governing matrix: the Bernstein Gram matrix :math:`G_{\mathrm{bern}}` this builder's
+projection solves with, whose condition number grows like :math:`4^p`.
+:math:`\kappa_\infty(G_{\mathrm{bern}}) \varepsilon` is ``0.87`` at degree 12 against
+``3.2`` at degree 13 in float32, and ``0.30`` at degree 26 against ``1.17`` at degree 27 in
+float64. Measured against the exact rational answer, the returned matrix is still within
+``5.3e-2`` relative at degree 12 in float32, so conditioning is not optimistic here and no
+fidelity cap is needed.
+"""
+
+_CARDINAL_TO_LEGENDRE_MAX_DEGREE: Final = _DegreeLimit(float32=6, float64=12)
+r"""Supported degrees of the cardinal-to-Legendre direction.
+
+Shared by :func:`compute_cardinal_to_legendre_1d` and
+:func:`compute_cardinal_dual_legendre_coeffs_1d`, whose result is that matrix transposed.
+
+Governing matrix: ``A``, the Legendre-to-cardinal matrix the first of the two inverts.
+:math:`\kappa_\infty(A) \varepsilon` is ``0.068`` at degree 6 against ``1.6`` at degree 7
+in float32, and ``0.17`` at degree 12 against ``8.2`` at degree 13 in float64. Unlike the
+Bernstein pair, ``A`` here *is* accurate -- its Gram matrix is the identity -- so
+conditioning does bound the result and no fidelity cap is needed: the measured error at
+the two limits is ``1.7e-4`` (float32, degree 6) and ``1.3e-5`` (float64, degree 12).
+"""
+
+_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE: Final[Mapping[LagrangeVariant, _DegreeLimit]] = {
+    LagrangeVariant.EQUISPACES: _DegreeLimit(float32=17, float64=37),
+    LagrangeVariant.GAUSS_LEGENDRE: _DegreeLimit(float32=22, float64=51),
+    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: _DegreeLimit(float32=23, float64=52),
+    LagrangeVariant.CHEBYSHEV_1ST: _DegreeLimit(float32=23, float64=52),
+    LagrangeVariant.CHEBYSHEV_2ND: _DegreeLimit(float32=23, float64=52),
+}
+r"""Supported degrees of :func:`compute_bernstein_to_lagrange_1d`, per node family.
+
+Governing matrix: ``C``, the Lagrange-to-Bernstein matrix this builder inverts, whose
+condition number depends on the nodes -- roughly :math:`2.7^p` for equispaced nodes against
+:math:`2^p` for the other four families, which is why equispaced nodes lose five degrees in
+float32 and fourteen in float64. :math:`\kappa_\infty(C) \varepsilon` at each entry's
+degree and at the one past it: equispaced ``0.63``/``1.7`` (float32) and ``0.43``/``1.2``
+(float64); Gauss-Legendre ``0.63``/``1.3`` and ``0.66``/``1.3``; Gauss-Lobatto-Legendre
+``0.73``/``1.5`` and ``0.73``/``1.5``; Chebyshev 1st ``0.97``/``1.9`` and ``0.99``/``2.0``;
+Chebyshev 2nd ``0.61``/``1.2`` and ``0.57``/``1.1``.
+
+The nodes are the ones :func:`~pantr.basis._basis_lagrange._get_lagrange_points` returns,
+carried into the exact computation as their float64 values, so these limits describe the
+matrix pantr actually forms rather than an idealized one.
+"""
+
+
+def _validate_degree_in_domain(
+    degree: int,
+    dtype: np.dtype[np.float32 | np.float64],
+    max_degree: _DegreeLimit,
+    builder: str,
+) -> None:
+    """Refuse a ``(degree, dtype)`` pair outside a builder's supported domain.
+
+    See the module docstring for what sets the boundary. This is a pure precondition:
+    inside the domain it does nothing at all, so it cannot perturb a returned matrix.
+
+    Args:
+        degree (int): Polynomial degree the caller asked for.
+        dtype (np.dtype[np.float32 | np.float64]): Already-validated output dtype.
+        max_degree (_DegreeLimit): Largest supported degree per format.
+        builder (str): Name of the calling builder, quoted in the message so the caller is
+            told which function refused rather than only that some matrix was singular.
+
+    Raises:
+        ValueError: If ``degree`` exceeds what ``dtype`` supports.
+    """
+    limit = max_degree.float32 if dtype == np.float32 else max_degree.float64
+    if degree <= limit:
+        return
+    raise ValueError(
+        f"{builder}: degree {degree} is outside the supported domain for {dtype.name} "
+        f"(supported: degree <= {max_degree.float32} in float32, "
+        f"degree <= {max_degree.float64} in float64). Past that degree the matrix this "
+        f"builder solves with is singular to working precision, so the result would carry "
+        f"no correct digit; see the pantr.change_basis module docstring for the derivation."
+    )
 
 
 def _prepare_square_out(
@@ -72,6 +232,12 @@ def compute_lagrange_to_bernstein_1d(
 
     Note:
         Both Bernstein and Lagrange bases follow the standard ordering (see https://en.wikipedia.org/wiki/Bernstein_polynomial).
+
+        This builder carries no degree limit in either dtype, and so appears in no row of
+        the module docstring's domain table: it runs no linear solve that could go
+        singular, the Lagrange basis being cardinal at its own nodes, so every entry is a
+        single Bernstein evaluation. The inverse direction,
+        :func:`compute_bernstein_to_lagrange_1d`, is the one that carries a domain.
 
     Args:
         degree (int): Polynomial degree. Must be at least 1.
@@ -157,12 +323,25 @@ def compute_bernstein_to_lagrange_1d(
             returns the same array.
 
     Raises:
-        ValueError: If degree is lower than 1, dtype is not float32 or float64, or if `out` is
-            provided and has incorrect shape or dtype.
+        ValueError: If degree is lower than 1, dtype is not float32 or float64, if `out` is
+            provided and has incorrect shape or dtype, or if the
+            ``(degree, dtype)`` pair is outside the supported domain:
+            in float32, degree at most 17 for equispaced nodes, 22 for
+            Gauss-Legendre and 23 for the Gauss-Lobatto-Legendre and Chebyshev
+            families; in float64, 37, 51 and 52 respectively.
+            The domain is where the solve is still defined, not where the result is
+            still accurate; see the module docstring for the derivation, and the
+            ``Warning:`` above for the accuracy attained inside it.
     """
     if degree < 1:
         raise ValueError("Degree must at least 1")
     out = _prepare_square_out(degree, dtype, out)
+    _validate_degree_in_domain(
+        degree,
+        out.dtype,
+        _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[lagrange_variant],
+        f"compute_bernstein_to_lagrange_1d with {lagrange_variant.name} nodes",
+    )
 
     forward = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -278,12 +457,23 @@ def compute_bernstein_to_cardinal_1d(
             returns the same array.
 
     Raises:
-        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
-            provided and has incorrect shape or dtype.
+        ValueError: If degree is negative, dtype is not float32 or float64, if `out` is
+            provided and has incorrect shape or dtype, or if the
+            ``(degree, dtype)`` pair is outside the supported domain:
+            degree at most 12 in float32 and at most 26 in float64.
+            The domain is where the solve is still defined, not where the result is
+            still accurate; see the module docstring for the derivation, and the
+            ``Warning:`` above for the accuracy attained inside it.
     """
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
+    _validate_degree_in_domain(
+        degree,
+        out.dtype,
+        _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
+        "compute_bernstein_to_cardinal_1d",
+    )
 
     return _compute_change_basis_1D(
         new_basis_eval=functools.partial(tabulate_bernstein_1d, degree),
@@ -351,8 +541,13 @@ def compute_cardinal_to_bernstein_1d(
             returns the same array.
 
     Raises:
-        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
-            provided and has incorrect shape or dtype.
+        ValueError: If degree is negative, dtype is not float32 or float64, if `out` is
+            provided and has incorrect shape or dtype, or if the
+            ``(degree, dtype)`` pair is outside the supported domain:
+            degree at most 8 in float32 and at most 12 in float64.
+            The domain is where the solve is still defined, not where the result is
+            still accurate; see the module docstring for the derivation, and the
+            ``Warning:`` above for the accuracy attained inside it.
 
     Example:
         >>> import numpy as np
@@ -364,6 +559,12 @@ def compute_cardinal_to_bernstein_1d(
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
+    _validate_degree_in_domain(
+        degree,
+        out.dtype,
+        _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
+        "compute_cardinal_to_bernstein_1d",
+    )
 
     forward = compute_bernstein_to_cardinal_1d(degree, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -387,6 +588,14 @@ def compute_legendre_to_cardinal_1d(
     has degree ``2 * degree``. Consequently the Legendre Gram matrix is the
     identity up to round-off, and the returned matrix carries no quadrature
     error beyond floating-point round-off.
+
+    Note:
+        This builder carries no degree limit in either dtype, and so appears in no row of
+        the module docstring's domain table. Its projection does solve, but with the
+        Legendre Gram matrix, which is the identity up to round-off: measured
+        :math:`\kappa_\infty` is ``1.00`` at every degree through 40. The inverse
+        direction, :func:`compute_cardinal_to_legendre_1d`, is the one that carries a
+        domain.
 
     Args:
         degree (int): Polynomial degree. Must be non-negative.
@@ -472,8 +681,13 @@ def compute_cardinal_to_legendre_1d(
             returns the same array.
 
     Raises:
-        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
-            provided and has incorrect shape or dtype.
+        ValueError: If degree is negative, dtype is not float32 or float64, if `out` is
+            provided and has incorrect shape or dtype, or if the
+            ``(degree, dtype)`` pair is outside the supported domain:
+            degree at most 6 in float32 and at most 12 in float64.
+            The domain is where the solve is still defined, not where the result is
+            still accurate; see the module docstring for the derivation, and the
+            ``Warning:`` above for the accuracy attained inside it.
 
     Example:
         Check ``A @ W``, not ``W @ A``. Solving ``A W = I`` bounds the *right*
@@ -490,6 +704,12 @@ def compute_cardinal_to_legendre_1d(
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
+    _validate_degree_in_domain(
+        degree,
+        out.dtype,
+        _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+        "compute_cardinal_to_legendre_1d",
+    )
 
     forward = compute_legendre_to_cardinal_1d(degree, dtype)
     out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
@@ -549,8 +769,14 @@ def compute_cardinal_dual_legendre_coeffs_1d(
             provided, returns the same array.
 
     Raises:
-        ValueError: If degree is negative, dtype is not float32 or float64, or if `out` is
-            provided and has incorrect shape or dtype.
+        ValueError: If degree is negative, dtype is not float32 or float64, if `out` is
+            provided and has incorrect shape or dtype, or if the
+            ``(degree, dtype)`` pair is outside the supported domain:
+            degree at most 6 in float32 and at most 12 in float64, inherited
+            from :func:`compute_cardinal_to_legendre_1d`.
+            The domain is where the solve is still defined, not where the result is
+            still accurate; see the module docstring for the derivation, and the
+            ``Warning:`` above for the accuracy attained inside it.
 
     Example:
         >>> import numpy as np
@@ -562,6 +788,12 @@ def compute_cardinal_dual_legendre_coeffs_1d(
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
+    _validate_degree_in_domain(
+        degree,
+        out.dtype,
+        _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+        "compute_cardinal_dual_legendre_coeffs_1d",
+    )
 
     out[:] = compute_cardinal_to_legendre_1d(degree, dtype).T
     return out

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -104,22 +104,25 @@ class _DegreeLimit(NamedTuple):
     float64: int
 
 
-_CARDINAL_TO_BERNSTEIN_MAX_DEGREE: Final = _DegreeLimit(float32=8, float64=12)
+_CARDINAL_TO_BERNSTEIN_MAX_DEGREE: Final = _DegreeLimit(float32=8, float64=14)
 r"""Supported degrees of :func:`compute_cardinal_to_bernstein_1d`.
 
 Governing matrix: ``A``, the Bernstein-to-cardinal matrix this builder inverts.
 :math:`\kappa_\infty(A) \varepsilon` is ``0.46`` at degree 8 against ``6.7`` at degree 9 in
 float32, and ``0.091`` at degree 14 against ``2.4`` at degree 15 in float64.
 
-The float64 entry is 12 rather than the 14 that inequality allows, and this is the one
-place in the module where conditioning is not the binding criterion. ``A`` is not exact
-here: it comes out of :func:`compute_bernstein_to_cardinal_1d`'s own Gram solve and so
-carries a relative error of order :math:`\kappa_\infty(G_{\mathrm{bern}}) \varepsilon`,
-which makes :math:`\kappa_\infty(A) \varepsilon` not an error bound for what this builder
-returns. Measured against the exact rational inverse, the returned matrix is still within
-``4.3e-2`` relative at degree 12 and is off by ``9.6`` -- 960% -- at degree 13, so 12 is
-the last degree that carries information. Float32 needs no such cap: its measured error at
-degree 8 is ``0.90``, just inside, and its conditioning limit is 8 as well.
+This builder is the one whose *accuracy* the solvability criterion does not bound, and the
+distinction matters enough to state here rather than only in the ``Warning:``. ``A`` is not
+exact: it comes out of :func:`compute_bernstein_to_cardinal_1d`'s own Gram solve, so it
+carries a relative error of order :math:`\kappa_\infty(G_{\mathrm{bern}}) \varepsilon`, and
+inverting a perturbed matrix multiplies that by :math:`\kappa_\infty(A)`. The bound on what
+is returned is therefore the *product*
+:math:`\kappa_\infty(A) \kappa_\infty(G_{\mathrm{bern}}) \varepsilon`, which reaches 100%
+after degree 5 in float32 and after degree 10 in float64 -- well inside the domain. Those
+two degrees are exact and platform-independent, and they are the honest accuracy statement;
+they are deliberately *not* the domain, because the product bound is provably pessimistic
+here (at degree 11 in float64 it stands at ``9.2`` while the returned matrix is accurate to
+``3e-4``), so enforcing it would refuse results with four good digits.
 """
 
 _BERNSTEIN_TO_CARDINAL_MAX_DEGREE: Final = _DegreeLimit(float32=12, float64=26)
@@ -130,8 +133,9 @@ projection solves with, whose condition number grows like :math:`4^p`.
 :math:`\kappa_\infty(G_{\mathrm{bern}}) \varepsilon` is ``0.87`` at degree 12 against
 ``3.2`` at degree 13 in float32, and ``0.30`` at degree 26 against ``1.17`` at degree 27 in
 float64. Measured against the exact rational answer, the returned matrix is still within
-``5.3e-2`` relative at degree 12 in float32, so conditioning is not optimistic here and no
-fidelity cap is needed.
+``5.3e-2`` relative at degree 12 in float32. That measurement only corroborates the
+criterion here; it does not set the limit, and no limit in this module is set by a measured
+quantity.
 """
 
 _CARDINAL_TO_LEGENDRE_MAX_DEGREE: Final = _DegreeLimit(float32=6, float64=12)
@@ -143,9 +147,8 @@ Shared by :func:`compute_cardinal_to_legendre_1d` and
 Governing matrix: ``A``, the Legendre-to-cardinal matrix the first of the two inverts.
 :math:`\kappa_\infty(A) \varepsilon` is ``0.068`` at degree 6 against ``1.6`` at degree 7
 in float32, and ``0.17`` at degree 12 against ``8.2`` at degree 13 in float64. Unlike the
-Bernstein pair, ``A`` here *is* accurate -- its Gram matrix is the identity -- so
-conditioning does bound the result and no fidelity cap is needed: the measured error at
-the two limits is ``1.7e-4`` (float32, degree 6) and ``1.3e-5`` (float64, degree 12).
+Bernstein pair, ``A`` here *is* accurate -- its Gram matrix is the identity -- so the
+solvability criterion bounds the accuracy too, and no separate accuracy statement is needed.
 """
 
 _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE: Final[Mapping[LagrangeVariant, _DegreeLimit]] = MappingProxyType(
@@ -560,6 +563,14 @@ def compute_cardinal_to_bernstein_1d(
         is not something float64 can be asked, since :math:`\kappa(A)` passes :math:`1/\varepsilon`
         for float64 by degree 16.
 
+        The float64 domain runs to degree 14, past both of those: what the domain asserts is
+        that the inversion is still *defined*, never that the result is accurate. The bound
+        on the accuracy is the product
+        :math:`\kappa_\infty(A) \kappa_\infty(G_{\mathrm{bern}}) \varepsilon`, because ``A``
+        itself arrives from a Gram solve rather than exactly; it passes 100% after degree 5
+        in float32 and after degree 10 in float64. Both figures come from exact arithmetic
+        and hold on any platform.
+
     Args:
         degree (int): Polynomial degree. Must be non-negative.
         dtype (npt.DTypeLike): Floating point type for the output matrix.
@@ -578,7 +589,7 @@ def compute_cardinal_to_bernstein_1d(
         ValueError: If degree is negative, dtype is not float32 or float64, if `out` is
             provided and has incorrect shape or dtype, or if the
             ``(degree, dtype)`` pair is outside the supported domain:
-            degree at most 8 in float32 and at most 12 in float64.
+            degree at most 8 in float32 and at most 14 in float64.
             The domain is where the solve is still defined, not where the result is
             still accurate; see the module docstring for the derivation, and the
             ``Warning:`` above for the accuracy attained inside it.

--- a/src/pantr/change_basis.py
+++ b/src/pantr/change_basis.py
@@ -47,16 +47,21 @@ domain replaces. Inside the domain the inverse obeys
 over every supported range here, so no entry of an inverse can exceed
 :math:`2.3 \times 10^{8}` in float32 -- thirty orders of magnitude below that format's
 overflow threshold. And a matrix that is not singular to working precision does not
-produce the exactly zero pivot :class:`numpy.linalg.LinAlgError` reports. Measured, the
-first infinity and the first ``LinAlgError`` appear more than twenty degrees past the
-boundary.
+produce the exactly zero pivot :class:`numpy.linalg.LinAlgError` reports. Measured, both
+occur only in float32 and only for the two cardinal pairs, and the first of each is at least
+twenty-six degrees past the boundary.
 
-The :math:`\kappa_\infty` values behind the tabulated limits are computed in exact rational
-(or 120-digit decimal) arithmetic from the matrices themselves, not with
-:func:`numpy.linalg.cond`: a float64 SVD cannot resolve a condition number near
-:math:`1/\varepsilon`, which is precisely where the boundary sits. That derivation runs as
-a test, ``tests/test_change_basis_domain.py``, so the tabulated degrees are checked rather
-than asserted.
+The :math:`\kappa_\infty` values behind the tabulated limits come from matrices rebuilt in
+exact rational (or 60-digit decimal) arithmetic from closed forms, rather than from the
+matrices pantr computes. That distinction is load-bearing for the Bernstein/cardinal pair,
+whose forward matrix is itself the output of a Gram solve and so is not exact: near the
+boundary, :func:`numpy.linalg.cond` applied to the matrix pantr forms reports 8.6 times too
+much at degree 13 and 4.9 times too little at degree 15, either of which moves the crossing.
+Applied to the *exact* matrix that same call is accurate to five digits even at
+:math:`4 \times 10^{17}`, so it is the matrix and not the estimator that is at fault.
+Rebuilding from closed forms also keeps the derivation independent of the code it grades. It
+runs as a test, ``tests/test_change_basis_domain.py``, so the tabulated degrees are checked
+rather than asserted.
 """
 
 import functools
@@ -336,11 +341,15 @@ def compute_bernstein_to_lagrange_1d(
     if degree < 1:
         raise ValueError("Degree must at least 1")
     out = _prepare_square_out(degree, dtype, out)
+    # `LagrangeVariant(...)` rather than a bare lookup: an unrecognized variant would
+    # otherwise leave this function through `KeyError`, which is exactly the kind of
+    # undocumented exception type the domain exists to stop escaping.
+    variant = LagrangeVariant(lagrange_variant)
     _validate_degree_in_domain(
         degree,
         out.dtype,
-        _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[lagrange_variant],
-        f"compute_bernstein_to_lagrange_1d with {lagrange_variant.name} nodes",
+        _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[variant],
+        f"compute_bernstein_to_lagrange_1d with {variant.name} nodes",
     )
 
     forward = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)

--- a/tests/test_change_basis_domain.py
+++ b/tests/test_change_basis_domain.py
@@ -1,0 +1,561 @@
+r"""Tests for the supported ``(degree, dtype)`` domain of the change-of-basis builders.
+
+This file is where the domain's derivation lives. The limits tabulated in
+``pantr.change_basis`` are not measured with :func:`numpy.linalg.cond` and are not fitted:
+each one is the largest degree at which the matrix its builder solves with satisfies
+:math:`\kappa_\infty(M)\,\varepsilon < 1`, and this module recomputes :math:`\kappa_\infty`
+in exact rational (or high-precision decimal) arithmetic at that degree and at the one past
+it. A float64 SVD cannot settle the question, because the boundary is by construction the
+place where a condition number reaches :math:`1/\varepsilon` and a float64 SVD stops
+resolving it -- measured, :func:`numpy.linalg.cond` puts
+:math:`\kappa(A_{\mathrm{bern}\to\mathrm{card}})` at degree 15 nearly nine times below its
+exact value, which is enough to move the boundary by a degree.
+
+The exact matrices are built from closed forms rather than from pantr's own tabulations, so
+the derivation is independent of the code it grades: the cardinal B-splines from their
+explicit truncated-power expansion, the Bernstein Gram matrix from its binomial closed form,
+and the shifted Legendre polynomials from their integer monomial coefficients. The Lagrange
+node families are the exception and are taken from pantr, since the boundary has to describe
+the matrix pantr actually forms.
+"""
+
+from collections.abc import Callable
+from decimal import Decimal, getcontext
+from fractions import Fraction
+from math import comb, factorial
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr.basis import LagrangeVariant
+from pantr.basis._basis_lagrange import _get_lagrange_points
+from pantr.change_basis import (
+    _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
+    _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE,
+    _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
+    _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+    _DegreeLimit,
+    compute_bernstein_to_cardinal_1d,
+    compute_bernstein_to_lagrange_1d,
+    compute_cardinal_dual_legendre_coeffs_1d,
+    compute_cardinal_to_bernstein_1d,
+    compute_cardinal_to_legendre_1d,
+)
+
+_EXACT_PRECISION = 60
+r"""Significant decimal digits carried by the exact-arithmetic derivation.
+
+Gauss-Jordan elimination on a matrix of condition number :math:`\kappa` loses on the order
+of :math:`\log_{10}\kappa` digits, and no :math:`\kappa` reached here exceeds
+:math:`10^{17}` -- the boundary being where :math:`\kappa\varepsilon \approx 1` and
+:math:`1/\varepsilon_{64} = 4.5 \times 10^{15}`. Sixty digits therefore leaves more than
+forty correct, against the one digit the comparison with 1 actually needs. Checked
+directly: the Chebyshev degree-53 case returns the same :math:`\kappa_\infty` at 40, 60 and
+120 digits.
+"""
+
+_FloatType = type[np.float32] | type[np.float64]
+"""Either of the two floating-point formats every builder accepts."""
+
+_DTYPES: tuple[_FloatType, ...] = (np.float32, np.float64)
+"""The two formats, as a parametrization axis."""
+
+_ExactMatrix = list[list[Decimal]]
+"""Square matrix carried at ``_EXACT_PRECISION`` digits."""
+
+getcontext().prec = _EXACT_PRECISION
+
+
+def _max_degree(limit: _DegreeLimit, dtype: _FloatType) -> int:
+    """Select the entry of a ``_DegreeLimit`` that applies to ``dtype``.
+
+    Args:
+        limit (_DegreeLimit): Tabulated limits for one builder.
+        dtype (_FloatType): Output format.
+
+    Returns:
+        int: The largest degree that format supports.
+    """
+    return limit.float32 if dtype is np.float32 else limit.float64
+
+
+# --------------------------------------------------------------------------------------
+# Exact arithmetic: the matrices the builders solve with
+# --------------------------------------------------------------------------------------
+
+
+def _as_decimal(value: Fraction) -> Decimal:
+    """Convert an exact rational to a ``Decimal`` at the ambient precision.
+
+    Args:
+        value (Fraction): Exact rational number.
+
+    Returns:
+        Decimal: The same number, rounded to ``_EXACT_PRECISION`` digits.
+    """
+    return Decimal(value.numerator) / Decimal(value.denominator)
+
+
+def _norm_inf(matrix: _ExactMatrix) -> Decimal:
+    """Compute the induced infinity norm, the largest absolute row sum.
+
+    Args:
+        matrix (_ExactMatrix): Square matrix.
+
+    Returns:
+        Decimal: ``max_i sum_j |matrix[i][j]|``.
+    """
+    return max(sum((abs(entry) for entry in row), Decimal(0)) for row in matrix)
+
+
+def _invert(matrix: _ExactMatrix) -> _ExactMatrix:
+    """Invert a square matrix by Gauss-Jordan elimination with partial pivoting.
+
+    Args:
+        matrix (_ExactMatrix): Square, non-singular matrix.
+
+    Returns:
+        _ExactMatrix: The inverse, at the ambient precision.
+    """
+    size = len(matrix)
+    tableau = [
+        [*matrix[row], *(Decimal(1) if row == col else Decimal(0) for col in range(size))]
+        for row in range(size)
+    ]
+    for col in range(size):
+        pivot_row = max(range(col, size), key=lambda row: abs(tableau[row][col]))
+        tableau[col], tableau[pivot_row] = tableau[pivot_row], tableau[col]
+        pivot = tableau[col][col]
+        tableau[col] = [entry / pivot for entry in tableau[col]]
+        for row in range(size):
+            if row != col and tableau[row][col] != 0:
+                factor = tableau[row][col]
+                tableau[row] = [
+                    entry - factor * pivot_entry
+                    for entry, pivot_entry in zip(tableau[row], tableau[col], strict=True)
+                ]
+    return [row[size:] for row in tableau]
+
+
+def _kappa_inf(matrix: _ExactMatrix) -> Decimal:
+    """Compute ``||M||_inf * ||M^-1||_inf``.
+
+    The infinity norm is the one the perturbation bound for a linear system is usually
+    stated in, which is why the domain uses it rather than the 2-norm
+    :func:`numpy.linalg.cond` returns by default.
+
+    Args:
+        matrix (_ExactMatrix): Square, non-singular matrix.
+
+    Returns:
+        Decimal: The infinity-norm condition number.
+    """
+    return _norm_inf(matrix) * _norm_inf(_invert(matrix))
+
+
+def _cardinal_monomial(degree: int) -> list[list[Fraction]]:
+    r"""Expand the cardinal B-splines of ``degree`` in the monomial basis on ``[0, 1]``.
+
+    Uses the explicit truncated-power form quoted by
+    :func:`~pantr.basis.tabulate_cardinal_bspline_1d`,
+
+    .. math::
+
+        B_{p,i}(t) = \frac{1}{p!} \sum_{j=0}^{p-i} \binom{p+1}{j} (-1)^j (t + p - i - j)^p ,
+
+    whose coefficients are rational, so the expansion is exact.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        list[list[Fraction]]: Row ``i`` holds the monomial coefficients of the ``i``-th
+        cardinal B-spline, lowest power first.
+    """
+    rows: list[list[Fraction]] = []
+    for index in range(degree + 1):
+        coeffs = [Fraction(0)] * (degree + 1)
+        for term in range(degree - index + 1):
+            shift = degree - index - term
+            sign = Fraction((-1) ** term * comb(degree + 1, term))
+            for power in range(degree + 1):
+                coeffs[power] += sign * comb(degree, power) * Fraction(shift) ** (degree - power)
+        rows.append([coeff / factorial(degree) for coeff in coeffs])
+    return rows
+
+
+def _bernstein_to_cardinal_exact(degree: int) -> _ExactMatrix:
+    """Build ``A`` with ``cardinal = A @ bernstein``, exactly.
+
+    This is what :func:`compute_bernstein_to_cardinal_1d` returns and what
+    :func:`compute_cardinal_to_bernstein_1d` inverts. Obtained by converting each cardinal
+    B-spline's exact monomial expansion into the Bernstein basis with
+    ``t**k = sum_i [C(i,k)/C(p,k)] B_{p,i}(t)``.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        _ExactMatrix: The ``(degree+1, degree+1)`` matrix.
+    """
+    cardinal = _cardinal_monomial(degree)
+    mono_to_bern = [
+        [
+            Fraction(comb(row, col), comb(degree, col)) if col <= row else Fraction(0)
+            for col in range(degree + 1)
+        ]
+        for row in range(degree + 1)
+    ]
+    return [
+        [
+            _as_decimal(
+                sum(
+                    (
+                        mono_to_bern[col][power] * cardinal[row][power]
+                        for power in range(degree + 1)
+                    ),
+                    Fraction(0),
+                )
+            )
+            for col in range(degree + 1)
+        ]
+        for row in range(degree + 1)
+    ]
+
+
+def _legendre_to_cardinal_exact(degree: int) -> _ExactMatrix:
+    """Build ``A`` with ``cardinal = A @ legendre``, exactly.
+
+    This is what :func:`~pantr.change_basis.compute_legendre_to_cardinal_1d` returns and
+    what :func:`compute_cardinal_to_legendre_1d` inverts. Because the shifted Legendre basis
+    is orthonormal, ``A[j, k]`` is the integral of the ``j``-th cardinal B-spline against
+    the ``k``-th basis function; that integral is rational and the ``sqrt(2k+1)``
+    normalization is carried in decimal.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        _ExactMatrix: The ``(degree+1, degree+1)`` matrix.
+    """
+    cardinal = _cardinal_monomial(degree)
+    shifted_legendre = [
+        [
+            Fraction((-1) ** (order + power) * comb(order, power) * comb(order + power, power))
+            if power <= order
+            else Fraction(0)
+            for power in range(degree + 1)
+        ]
+        for order in range(degree + 1)
+    ]
+
+    def integral(left: list[Fraction], right: list[Fraction]) -> Fraction:
+        """Integrate the product of two monomial-coefficient vectors over ``[0, 1]``."""
+        return sum(
+            (
+                lhs * rhs / (i + j + 1)
+                for i, lhs in enumerate(left)
+                if lhs
+                for j, rhs in enumerate(right)
+                if rhs
+            ),
+            Fraction(0),
+        )
+
+    return [
+        [
+            _as_decimal(integral(cardinal[row], shifted_legendre[order]))
+            * Decimal(2 * order + 1).sqrt()
+            for order in range(degree + 1)
+        ]
+        for row in range(degree + 1)
+    ]
+
+
+def _bernstein_gram_exact(degree: int) -> _ExactMatrix:
+    """Build the Bernstein Gram matrix on ``[0, 1]``, exactly.
+
+    ``G[i, j] = C(p,i) C(p,j) / ((2p+1) C(2p, i+j))``. This is the matrix
+    :func:`compute_bernstein_to_cardinal_1d`'s projection solves with.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        _ExactMatrix: The ``(degree+1, degree+1)`` matrix.
+    """
+    return [
+        [
+            _as_decimal(
+                Fraction(
+                    comb(degree, row) * comb(degree, col),
+                    (2 * degree + 1) * comb(2 * degree, row + col),
+                )
+            )
+            for col in range(degree + 1)
+        ]
+        for row in range(degree + 1)
+    ]
+
+
+def _lagrange_to_bernstein_exact(degree: int, variant: LagrangeVariant) -> _ExactMatrix:
+    """Build ``C[i, m] = B_{p,i}(x_m)`` at pantr's own Lagrange nodes, exactly.
+
+    This is what :func:`~pantr.change_basis.compute_lagrange_to_bernstein_1d` returns and
+    what :func:`compute_bernstein_to_lagrange_1d` inverts. The nodes come from pantr, as
+    their exact float64 values, because the domain has to describe the matrix pantr forms.
+
+    Args:
+        degree (int): Polynomial degree.
+        variant (LagrangeVariant): Node family.
+
+    Returns:
+        _ExactMatrix: The ``(degree+1, degree+1)`` matrix.
+    """
+    nodes = [Decimal(float(node)) for node in _get_lagrange_points(variant, degree + 1, np.float64)]
+
+    def power(base: Decimal, exponent: int) -> Decimal:
+        """Raise to a non-negative integer power, with ``base ** 0 == 1`` at ``base == 0``."""
+        return Decimal(1) if exponent == 0 else base**exponent
+
+    return [
+        [
+            Decimal(comb(degree, index)) * power(node, index) * power(1 - node, degree - index)
+            for node in nodes
+        ]
+        for index in range(degree + 1)
+    ]
+
+
+# --------------------------------------------------------------------------------------
+# The derivation: every tabulated limit is the crossing of kappa_inf * eps = 1
+# --------------------------------------------------------------------------------------
+
+_CARDINAL_TO_BERNSTEIN = "cardinal_to_bernstein"
+"""Label of the one entry whose float64 limit is capped below the conditioning crossing."""
+
+_SOLVED_MATRICES: tuple[tuple[str, Callable[[int], _ExactMatrix], _DegreeLimit], ...] = (
+    (_CARDINAL_TO_BERNSTEIN, _bernstein_to_cardinal_exact, _CARDINAL_TO_BERNSTEIN_MAX_DEGREE),
+    ("bernstein_to_cardinal", _bernstein_gram_exact, _BERNSTEIN_TO_CARDINAL_MAX_DEGREE),
+    ("cardinal_to_legendre", _legendre_to_cardinal_exact, _CARDINAL_TO_LEGENDRE_MAX_DEGREE),
+    *(
+        (
+            f"bernstein_to_lagrange[{variant.name}]",
+            (lambda degree, variant=variant: _lagrange_to_bernstein_exact(degree, variant)),
+            _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[variant],
+        )
+        for variant in LagrangeVariant
+    ),
+)
+"""Each solving builder, the matrix it solves with, and the degrees it claims to support."""
+
+
+@pytest.mark.parametrize(
+    ("label", "build", "limit"), _SOLVED_MATRICES, ids=[case[0] for case in _SOLVED_MATRICES]
+)
+@pytest.mark.parametrize("dtype", _DTYPES, ids=("float32", "float64"))
+def test_tabulated_limit_is_the_crossing_of_kappa_eps(
+    label: str,
+    build: Callable[[int], _ExactMatrix],
+    limit: _DegreeLimit,
+    dtype: _FloatType,
+) -> None:
+    """Re-derive each tabulated degree from exact arithmetic.
+
+    The claim under test is that the tabulated degree is the *largest* one satisfying
+    ``kappa_inf(M) * eps(dtype) < 1``: the supported degree has to be inside and the next
+    degree outside. A test asserting only the supported side would pass for any limit small
+    enough, which is why both sides are here.
+    """
+    max_degree = _max_degree(limit, dtype)
+    eps = Decimal(float(np.finfo(dtype).eps))
+    fidelity_capped = label == _CARDINAL_TO_BERNSTEIN and dtype is np.float64
+
+    inside = _kappa_inf(build(max_degree)) * eps
+    assert inside < 1, (
+        f"{label}/{np.dtype(dtype).name}: kappa_inf * eps = {float(inside):.3g} at the "
+        f"supported degree {max_degree}, so the tabulated limit claims a digit the solve "
+        f"does not retain"
+    )
+
+    outside = _kappa_inf(build(max_degree + 1)) * eps
+    if fidelity_capped:
+        assert outside < 1, (
+            "this entry is documented as capped below the conditioning crossing by measured "
+            "fidelity; if conditioning now binds first, that reasoning is stale"
+        )
+    else:
+        assert outside >= 1, (
+            f"{label}/{np.dtype(dtype).name}: kappa_inf * eps = {float(outside):.3g} at "
+            f"degree {max_degree + 1}, still below 1, so the domain is a degree tighter than "
+            f"the criterion requires and refuses a usable result"
+        )
+
+
+def test_cardinal_to_bernstein_float64_limit_is_set_by_fidelity_not_conditioning() -> None:
+    """Pin the one entry whose limit does not come from ``kappa_inf * eps``.
+
+    ``compute_cardinal_to_bernstein_1d`` inverts the output of a Gram solve, so its input
+    carries an error of order ``kappa_inf(G_bern) * eps`` and ``kappa_inf(A) * eps`` is not
+    a bound on what it returns. Measured against the exact inverse, the float64 result is
+    still within a few percent at degree 12 and is off by a factor of ten at degree 13,
+    which is why 12 is tabulated where conditioning alone would have allowed 14.
+
+    Degree 13 is refused now, so the second half cannot go through the builder and repeats
+    its two-line body instead. That is deliberate rather than a mirror of the algorithm: the
+    claim being tested is precisely that *the computation the cap forbids* returns garbage,
+    so the forbidden computation is the thing that has to be run.
+    """
+    eps = Decimal(float(np.finfo(np.float64).eps))
+    conditioning_allows = 14
+    assert _kappa_inf(_bernstein_to_cardinal_exact(conditioning_allows)) * eps < 1
+    assert _kappa_inf(_bernstein_to_cardinal_exact(conditioning_allows + 1)) * eps >= 1
+
+    def relative_error(degree: int, got: npt.NDArray[np.float64]) -> float:
+        """Relative infinity-norm error of a computed matrix against the exact inverse."""
+        exact = _invert(_bernstein_to_cardinal_exact(degree))
+        residual = [
+            [Decimal(float(got[i][j])) - exact[i][j] for j in range(degree + 1)]
+            for i in range(degree + 1)
+        ]
+        return float(_norm_inf(residual) / _norm_inf(exact))
+
+    supported = _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float64
+    assert supported < conditioning_allows, "the cap is what this test is about"
+
+    inside = relative_error(
+        supported,
+        np.asarray(compute_cardinal_to_bernstein_1d(supported, np.float64), dtype=np.float64),
+    )
+    assert inside < 1.0, (
+        f"degree {supported} is inside the domain but its relative error is {inside:.3g}: "
+        f"the returned matrix carries no information"
+    )
+
+    refused = supported + 1
+    forward = np.asarray(compute_bernstein_to_cardinal_1d(refused, np.float64), dtype=np.float64)
+    computed = np.asarray(np.linalg.solve(forward, np.eye(refused + 1)), dtype=np.float64)
+    outside = relative_error(refused, computed)
+    assert outside >= 1.0, (
+        f"degree {refused} is refused, yet the computation it forbids has relative error "
+        f"{outside:.3g}: the cap refuses a usable result"
+    )
+
+
+def test_every_lagrange_variant_declares_a_domain() -> None:
+    """Every node family needs a limit, or it silently receives an unbounded domain."""
+    assert set(_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE) == set(LagrangeVariant)
+
+
+# --------------------------------------------------------------------------------------
+# The contract: what a caller sees at the boundary
+# --------------------------------------------------------------------------------------
+
+_Builder = Callable[[int, _FloatType], npt.NDArray[np.float32 | np.float64]]
+"""A change-of-basis builder reduced to its ``(degree, dtype)`` arguments."""
+
+_BOUNDARY_CASES: tuple[tuple[str, _Builder, _DegreeLimit], ...] = (
+    (
+        "compute_cardinal_to_bernstein_1d",
+        compute_cardinal_to_bernstein_1d,
+        _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
+    ),
+    (
+        "compute_bernstein_to_cardinal_1d",
+        compute_bernstein_to_cardinal_1d,
+        _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
+    ),
+    (
+        "compute_cardinal_to_legendre_1d",
+        compute_cardinal_to_legendre_1d,
+        _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+    ),
+    (
+        "compute_cardinal_dual_legendre_coeffs_1d",
+        compute_cardinal_dual_legendre_coeffs_1d,
+        _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+    ),
+    *(
+        (
+            "compute_bernstein_to_lagrange_1d",
+            (
+                lambda degree, dtype, variant=variant: compute_bernstein_to_lagrange_1d(
+                    degree, variant, dtype
+                )
+            ),
+            _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[variant],
+        )
+        for variant in LagrangeVariant
+    ),
+)
+"""Each builder that refuses, with the limits it enforces."""
+
+_BOUNDARY_IDS = [
+    *(case[0] for case in _BOUNDARY_CASES[:4]),
+    *(f"compute_bernstein_to_lagrange_1d[{variant.name}]" for variant in LagrangeVariant),
+]
+"""Readable ids for ``_BOUNDARY_CASES``, distinguishing the five node families."""
+
+
+@pytest.mark.parametrize(("name", "builder", "limit"), _BOUNDARY_CASES, ids=_BOUNDARY_IDS)
+@pytest.mark.parametrize("dtype", _DTYPES, ids=("float32", "float64"))
+def test_boundary_succeeds_inside_and_refuses_outside(
+    name: str,
+    builder: _Builder,
+    limit: _DegreeLimit,
+    dtype: _FloatType,
+) -> None:
+    """The largest supported degree returns a matrix; the next one raises ``ValueError``.
+
+    Both halves matter. Without the first, a domain that refused everything would pass;
+    without the second, one that refused nothing would.
+    """
+    max_degree = _max_degree(limit, dtype)
+
+    matrix = np.asarray(builder(max_degree, dtype))
+    assert matrix.shape == (max_degree + 1, max_degree + 1)
+    assert matrix.dtype == dtype
+    assert np.all(np.isfinite(matrix))
+
+    with pytest.raises(ValueError) as excinfo:
+        builder(max_degree + 1, dtype)
+    assert not isinstance(excinfo.value, np.linalg.LinAlgError), (
+        "numpy's LinAlgError subclasses ValueError; the point of the domain is that the "
+        "caller gets a message about the argument, not about an internal matrix"
+    )
+    message = str(excinfo.value)
+    assert name in message
+    assert str(max_degree + 1) in message
+    assert np.dtype(dtype).name in message
+    assert f"<= {limit.float32} in float32" in message
+    assert f"<= {limit.float64} in float64" in message
+
+
+def test_ticket_311_overflow_reproduction_now_refuses() -> None:
+    """The issue's own reproduction: degree 36 in float32 returned 74 infinities.
+
+    Measured on the parent commit, ``compute_cardinal_to_bernstein_1d(36, np.float32)``
+    returned an array with 74 non-finite entries out of 1369 and emitted
+    ``RuntimeWarning: overflow encountered in cast``. Under this project's
+    ``filterwarnings = error`` that warning would fail this test on its own, so the check
+    below pins the absence of the warning as well as the refusal.
+    """
+    with pytest.raises(ValueError, match="outside the supported domain"):
+        compute_cardinal_to_bernstein_1d(36, np.float32)
+
+
+def test_extraction_degrees_stay_inside_the_domain() -> None:
+    """The Bezier extraction paths are unaffected by the domain (issue #311).
+
+    ``pantr.bspline._bspline_extraction`` and
+    ``pantr.bspline.spanwise_element_extraction`` reach two of these builders through the
+    cached matrices: the Lagrange-to-Bernstein one, which carries no limit, and the
+    cardinal-to-Bernstein one, which does. Their highest tested spline degree is 4, so this
+    asserts the margin rather than re-running those suites: were a future change to tighten
+    the limit below 4, the extraction tests would start failing for a reason that has
+    nothing to do with extraction.
+    """
+    highest_extraction_degree = 4
+    assert _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float32 >= highest_extraction_degree
+    assert _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float64 >= highest_extraction_degree

--- a/tests/test_change_basis_domain.py
+++ b/tests/test_change_basis_domain.py
@@ -8,12 +8,12 @@ in exact rational (or high-precision decimal) arithmetic at that degree and at t
 it.
 
 Asking :func:`numpy.linalg.cond` for the same number does not settle it, and not because that
-estimator is weak: applied to the *exact* matrix it agrees with the exact
-:math:`\kappa_\infty` to five digits even at :math:`4 \times 10^{17}`. The trouble is the
-matrix. The Bernstein-to-cardinal matrix pantr forms is itself the output of a Gram solve, so
-near the boundary it is no longer the matrix the domain is about, and its computed
-:math:`\kappa_\infty` comes out 8.6 times too large at degree 13 and 4.9 times too small at
-degree 15 -- either of which moves the crossing by a degree.
+estimator is weak: applied to the *exact* matrix it tracks the exact :math:`\kappa_\infty` to
+five digits at :math:`1.1 \times 10^{16}` and still to four at :math:`3.7 \times 10^{17}`.
+The trouble is the matrix. The Bernstein-to-cardinal matrix pantr forms is itself the output
+of a Gram solve, so near the boundary it is no longer the matrix the domain is about, and its
+computed :math:`\kappa_\infty` comes out 8.6 times too large at degree 13 and 4.9 times too
+small at degree 15 -- either of which moves the crossing by a degree.
 
 The exact matrices are built from closed forms rather than from pantr's own tabulations, so
 the derivation is independent of the code it grades: the cardinal B-splines from their
@@ -679,3 +679,23 @@ def test_extraction_degrees_stay_inside_the_domain() -> None:
     highest_extraction_degree = 4
     assert _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float32 >= highest_extraction_degree
     assert _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float64 >= highest_extraction_degree
+
+
+def test_a_pathological_degree_is_refused_before_anything_is_allocated() -> None:
+    """The refusal must not be preceded by an attempt to allocate the matrix.
+
+    ``_validate_degree_in_domain`` runs before ``_prepare_square_out``. Without that
+    ordering a degree of 100000 would ask NumPy for a 10^10-entry array first, and the
+    caller would meet ``MemoryError`` -- an undocumented failure of exactly the kind this
+    domain exists to remove -- instead of the ``ValueError`` that names the argument.
+    """
+    with pytest.raises(ValueError, match="outside the supported domain"):
+        compute_cardinal_to_bernstein_1d(100_000, np.float64)
+
+
+def test_the_per_variant_limit_table_cannot_be_mutated() -> None:
+    """A shared lookup table must not be writable; ``Final`` only stops rebinding."""
+    with pytest.raises(TypeError):
+        _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE[LagrangeVariant.EQUISPACES] = _DegreeLimit(  # type: ignore[index]
+            float32=99, float64=99
+        )

--- a/tests/test_change_basis_domain.py
+++ b/tests/test_change_basis_domain.py
@@ -5,11 +5,15 @@ This file is where the domain's derivation lives. The limits tabulated in
 each one is the largest degree at which the matrix its builder solves with satisfies
 :math:`\kappa_\infty(M)\,\varepsilon < 1`, and this module recomputes :math:`\kappa_\infty`
 in exact rational (or high-precision decimal) arithmetic at that degree and at the one past
-it. A float64 SVD cannot settle the question, because the boundary is by construction the
-place where a condition number reaches :math:`1/\varepsilon` and a float64 SVD stops
-resolving it -- measured, :func:`numpy.linalg.cond` puts
-:math:`\kappa(A_{\mathrm{bern}\to\mathrm{card}})` at degree 15 nearly nine times below its
-exact value, which is enough to move the boundary by a degree.
+it.
+
+Asking :func:`numpy.linalg.cond` for the same number does not settle it, and not because that
+estimator is weak: applied to the *exact* matrix it agrees with the exact
+:math:`\kappa_\infty` to five digits even at :math:`4 \times 10^{17}`. The trouble is the
+matrix. The Bernstein-to-cardinal matrix pantr forms is itself the output of a Gram solve, so
+near the boundary it is no longer the matrix the domain is about, and its computed
+:math:`\kappa_\infty` comes out 8.6 times too large at degree 13 and 4.9 times too small at
+degree 15 -- either of which moves the crossing by a degree.
 
 The exact matrices are built from closed forms rather than from pantr's own tabulations, so
 the derivation is independent of the code it grades: the cardinal B-splines from their
@@ -441,6 +445,25 @@ def test_cardinal_to_bernstein_float64_limit_is_set_by_fidelity_not_conditioning
         f"degree {refused} is refused, yet the computation it forbids has relative error "
         f"{outside:.3g}: the cap refuses a usable result"
     )
+
+
+def test_unknown_lagrange_variant_raises_value_error_not_key_error() -> None:
+    """An unrecognized node family must not leave the builder through ``KeyError``.
+
+    The domain lookup is keyed by ``LagrangeVariant``, so a bare ``dict[...]`` would turn a
+    bad variant into a ``KeyError`` -- an undocumented exception type, which is the very
+    thing this domain exists to stop escaping. It is coerced through ``LagrangeVariant(...)``
+    instead.
+    """
+    with pytest.raises(ValueError, match="not a valid LagrangeVariant"):
+        compute_bernstein_to_lagrange_1d(3, "not_a_node_family", np.float64)  # type: ignore[arg-type]
+
+    # A plain string naming a real family still works: LagrangeVariant is a StrEnum.
+    from_string = np.asarray(compute_bernstein_to_lagrange_1d(3, "equispaces", np.float64))  # type: ignore[arg-type]
+    from_member = np.asarray(
+        compute_bernstein_to_lagrange_1d(3, LagrangeVariant.EQUISPACES, np.float64)
+    )
+    assert np.array_equal(from_string, from_member)
 
 
 def test_every_lagrange_variant_declares_a_domain() -> None:

--- a/tests/test_change_basis_domain.py
+++ b/tests/test_change_basis_domain.py
@@ -340,11 +340,8 @@ def _lagrange_to_bernstein_exact(degree: int, variant: LagrangeVariant) -> _Exac
 # The derivation: every tabulated limit is the crossing of kappa_inf * eps = 1
 # --------------------------------------------------------------------------------------
 
-_CARDINAL_TO_BERNSTEIN = "cardinal_to_bernstein"
-"""Label of the one entry whose float64 limit is capped below the conditioning crossing."""
-
 _SOLVED_MATRICES: tuple[tuple[str, Callable[[int], _ExactMatrix], _DegreeLimit], ...] = (
-    (_CARDINAL_TO_BERNSTEIN, _bernstein_to_cardinal_exact, _CARDINAL_TO_BERNSTEIN_MAX_DEGREE),
+    ("cardinal_to_bernstein", _bernstein_to_cardinal_exact, _CARDINAL_TO_BERNSTEIN_MAX_DEGREE),
     ("bernstein_to_cardinal", _bernstein_gram_exact, _BERNSTEIN_TO_CARDINAL_MAX_DEGREE),
     ("cardinal_to_legendre", _legendre_to_cardinal_exact, _CARDINAL_TO_LEGENDRE_MAX_DEGREE),
     *(
@@ -378,7 +375,6 @@ def test_tabulated_limit_is_the_crossing_of_kappa_eps(
     """
     max_degree = _max_degree(limit, dtype)
     eps = Decimal(float(np.finfo(dtype).eps))
-    fidelity_capped = label == _CARDINAL_TO_BERNSTEIN and dtype is np.float64
 
     inside = _kappa_inf(build(max_degree)) * eps
     assert inside < 1, (
@@ -388,86 +384,65 @@ def test_tabulated_limit_is_the_crossing_of_kappa_eps(
     )
 
     outside = _kappa_inf(build(max_degree + 1)) * eps
-    if fidelity_capped:
-        assert outside < 1, (
-            "this entry is documented as capped below the conditioning crossing by measured "
-            "fidelity; if conditioning now binds first, that reasoning is stale"
-        )
-    else:
-        assert outside >= 1, (
-            f"{label}/{np.dtype(dtype).name}: kappa_inf * eps = {float(outside):.3g} at "
-            f"degree {max_degree + 1}, still below 1, so the domain is a degree tighter than "
-            f"the criterion requires and refuses a usable result"
-        )
+    assert outside >= 1, (
+        f"{label}/{np.dtype(dtype).name}: kappa_inf * eps = {float(outside):.3g} at degree "
+        f"{max_degree + 1}, still below 1, so the domain is a degree tighter than the "
+        f"criterion requires and refuses a usable result"
+    )
 
 
-def test_cardinal_to_bernstein_float64_limit_is_set_by_fidelity_not_conditioning() -> None:
-    """Pin the one entry whose limit does not come from ``kappa_inf * eps``.
+def test_cardinal_to_bernstein_accuracy_bound_is_tighter_than_its_domain() -> None:
+    """The accuracy bound is a product of two exact condition numbers, and is not the domain.
 
-    ``compute_cardinal_to_bernstein_1d`` inverts the output of a Gram solve, so its input
-    carries an error of order ``kappa_inf(G_bern) * eps`` and ``kappa_inf(A) * eps`` is not
-    a bound on what it returns. Measured against the exact inverse, the float64 result is
-    still within a few percent at degree 12 and is off by a factor of ten at degree 13,
-    which is why 12 is tabulated where conditioning alone would have allowed 14.
+    ``compute_cardinal_to_bernstein_1d`` inverts ``A``, which is itself the output of
+    :func:`compute_bernstein_to_cardinal_1d`'s Gram solve and so carries a relative error of
+    order ``kappa_inf(G_bern) * eps``. Inverting a perturbed matrix multiplies that by
+    ``kappa_inf(A)``, so the bound on what this builder returns is the *product*
+    ``kappa_inf(A) * kappa_inf(G_bern) * eps``, not the single factor that sets the domain.
 
-    Degree 13 is refused now, so the second half cannot go through the builder and repeats
-    its two-line body instead. That is deliberate rather than a mirror of the algorithm: the
-    claim being tested is precisely that *the computation the cap forbids* returns garbage,
-    so the forbidden computation is the thing that has to be run.
+    Both quantities are exact rational condition numbers, so this test is the same on every
+    platform. An earlier version of it compared the returned matrix against the exact inverse
+    and asserted where that *measured* error crossed 100%; that number turned out to be
+    round-off noise -- non-monotone in degree locally (9.56 at 13, 3.12 at 14, 1.14 at 15)
+    and different by a factor of 285 on another LAPACK -- so it pinned one machine's
+    realization rather than a property of the problem.
+
+    The product bound is also why it is documented and not enforced: it is pessimistic enough
+    that enforcing it would refuse results with four correct digits, which the last assertion
+    here pins.
     """
-    eps = Decimal(float(np.finfo(np.float64).eps))
-    conditioning_allows = 14
-    assert _kappa_inf(_bernstein_to_cardinal_exact(conditioning_allows)) * eps < 1
-    assert _kappa_inf(_bernstein_to_cardinal_exact(conditioning_allows + 1)) * eps >= 1
+    for dtype, documented_last_accurate_degree in ((np.float32, 5), (np.float64, 10)):
+        eps = Decimal(float(np.finfo(dtype).eps))
 
-    def relative_error(degree: int, got: npt.NDArray[np.float64]) -> float:
-        """Relative infinity-norm error of a computed matrix against the exact inverse."""
-        exact = _invert(_bernstein_to_cardinal_exact(degree))
-        residual = [
-            [Decimal(float(got[i][j])) - exact[i][j] for j in range(degree + 1)]
-            for i in range(degree + 1)
-        ]
-        return float(_norm_inf(residual) / _norm_inf(exact))
+        def product_bound(degree: int, eps: Decimal = eps) -> Decimal:
+            return (
+                _kappa_inf(_bernstein_to_cardinal_exact(degree))
+                * _kappa_inf(_bernstein_gram_exact(degree))
+                * eps
+            )
 
-    supported = _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float64
-    assert supported < conditioning_allows, "the cap is what this test is about"
+        assert product_bound(documented_last_accurate_degree) < 1
+        assert product_bound(documented_last_accurate_degree + 1) >= 1
 
-    inside = relative_error(
-        supported,
-        np.asarray(compute_cardinal_to_bernstein_1d(supported, np.float64), dtype=np.float64),
+        # The domain is strictly larger: it grades solvability, not accuracy.
+        assert _max_degree(_CARDINAL_TO_BERNSTEIN_MAX_DEGREE, dtype) > (
+            documented_last_accurate_degree
+        )
+
+    # Enforcing the product bound would refuse a usable result, which is why it is not the
+    # domain: degree 11 in float64 sits outside it and is still good to four digits.
+    degree = 11
+    exact = _invert(_bernstein_to_cardinal_exact(degree))
+    got = np.asarray(compute_cardinal_to_bernstein_1d(degree, np.float64), dtype=np.float64)
+    residual = [
+        [Decimal(float(got[i][j])) - exact[i][j] for j in range(degree + 1)]
+        for i in range(degree + 1)
+    ]
+    relative_error = float(_norm_inf(residual) / _norm_inf(exact))
+    assert relative_error < 1e-2, (
+        f"degree {degree} in float64 has relative error {relative_error:.3g}; the claim that "
+        f"the product bound is pessimistic rests on this being small"
     )
-    assert inside < 1.0, (
-        f"degree {supported} is inside the domain but its relative error is {inside:.3g}: "
-        f"the returned matrix carries no information"
-    )
-
-    refused = supported + 1
-    forward = np.asarray(compute_bernstein_to_cardinal_1d(refused, np.float64), dtype=np.float64)
-    computed = np.asarray(np.linalg.solve(forward, np.eye(refused + 1)), dtype=np.float64)
-    outside = relative_error(refused, computed)
-    assert outside >= 1.0, (
-        f"degree {refused} is refused, yet the computation it forbids has relative error "
-        f"{outside:.3g}: the cap refuses a usable result"
-    )
-
-
-def test_unknown_lagrange_variant_raises_value_error_not_key_error() -> None:
-    """An unrecognized node family must not leave the builder through ``KeyError``.
-
-    The domain lookup is keyed by ``LagrangeVariant``, so a bare ``dict[...]`` would turn a
-    bad variant into a ``KeyError`` -- an undocumented exception type, which is the very
-    thing this domain exists to stop escaping. It is coerced through ``LagrangeVariant(...)``
-    instead.
-    """
-    with pytest.raises(ValueError, match="not a valid LagrangeVariant"):
-        compute_bernstein_to_lagrange_1d(3, "not_a_node_family", np.float64)  # type: ignore[arg-type]
-
-    # A plain string naming a real family still works: LagrangeVariant is a StrEnum.
-    from_string = np.asarray(compute_bernstein_to_lagrange_1d(3, "equispaces", np.float64))  # type: ignore[arg-type]
-    from_member = np.asarray(
-        compute_bernstein_to_lagrange_1d(3, LagrangeVariant.EQUISPACES, np.float64)
-    )
-    assert np.array_equal(from_string, from_member)
 
 
 def test_every_lagrange_variant_declares_a_domain() -> None:

--- a/tests/test_change_basis_domain.py
+++ b/tests/test_change_basis_domain.py
@@ -39,12 +39,16 @@ from pantr.change_basis import (
     _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE,
     _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
     _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+    _cached_cardinal_to_bernstein_matrix,
     _DegreeLimit,
     compute_bernstein_to_cardinal_1d,
     compute_bernstein_to_lagrange_1d,
     compute_cardinal_dual_legendre_coeffs_1d,
     compute_cardinal_to_bernstein_1d,
     compute_cardinal_to_legendre_1d,
+    compute_lagrange_to_bernstein_1d,
+    compute_legendre_to_cardinal_1d,
+    compute_monomial_to_bernstein_1d,
 )
 
 _EXACT_PRECISION = 60
@@ -566,6 +570,99 @@ def test_ticket_311_overflow_reproduction_now_refuses() -> None:
     """
     with pytest.raises(ValueError, match="outside the supported domain"):
         compute_cardinal_to_bernstein_1d(36, np.float32)
+
+
+_UNLIMITED_BUILDERS: tuple[tuple[str, _Builder], ...] = (
+    ("compute_legendre_to_cardinal_1d", compute_legendre_to_cardinal_1d),
+    ("compute_monomial_to_bernstein_1d", compute_monomial_to_bernstein_1d),
+    *(
+        (
+            f"compute_lagrange_to_bernstein_1d[{variant.name}]",
+            (
+                lambda degree, dtype, variant=variant: compute_lagrange_to_bernstein_1d(
+                    degree, variant, dtype
+                )
+            ),
+        )
+        for variant in LagrangeVariant
+    ),
+)
+"""The builders documented as carrying no degree limit, in either dtype."""
+
+
+@pytest.mark.parametrize(
+    ("name", "builder"), _UNLIMITED_BUILDERS, ids=[case[0] for case in _UNLIMITED_BUILDERS]
+)
+@pytest.mark.parametrize("dtype", _DTYPES, ids=("float32", "float64"))
+def test_builders_without_a_domain_accept_a_high_degree(
+    name: str, builder: _Builder, dtype: _FloatType
+) -> None:
+    """A builder documented as unlimited must stay unlimited.
+
+    The module docstring says these run no solve that could go singular, so they carry no
+    degree limit. Nothing else pins that: extending the domain pattern to one of them by
+    mistake would be an over-restrictive validation on a legitimate call, and every other
+    test here would still pass. Degree 60 is far past every tabulated limit in the module.
+    """
+    degree = 60
+    matrix = np.asarray(builder(degree, dtype))
+    assert matrix.shape == (degree + 1, degree + 1)
+    assert np.all(np.isfinite(matrix)), f"{name} returned non-finite entries at degree {degree}"
+
+
+def test_far_outside_the_domain_still_refuses_cleanly() -> None:
+    """Well past the boundary, not just one degree past, the refusal is still the clean one.
+
+    Degree 40 in float32 is past where the *unguarded* computation starts producing
+    infinities (degree 34 for the Bernstein pair, 32 for the Legendre pair) and, for two of
+    these, past where it starts raising ``LinAlgError`` (37 and 38). The guard has to fire
+    first in every case, or one of those escapes instead.
+    """
+    for builder in (
+        compute_cardinal_to_bernstein_1d,
+        compute_bernstein_to_cardinal_1d,
+        compute_cardinal_to_legendre_1d,
+        compute_cardinal_dual_legendre_coeffs_1d,
+    ):
+        with pytest.raises(ValueError, match="outside the supported domain") as excinfo:
+            builder(40, np.float32)
+        assert not isinstance(excinfo.value, np.linalg.LinAlgError)
+
+
+def test_dtype_is_rejected_before_the_degree_domain() -> None:
+    """An unsupported dtype must still report the dtype, not a domain the dtype has no entry in.
+
+    ``_validate_degree_in_domain`` runs after ``_prepare_square_out``, so the dtype error
+    comes first. That ordering is what lets the domain lookup assume a validated dtype, and
+    nothing else pins it.
+    """
+    with pytest.raises(ValueError, match="dtype must be float32 or float64"):
+        compute_cardinal_to_bernstein_1d(100, np.float16)
+
+
+def test_refusal_leaves_a_caller_supplied_out_untouched() -> None:
+    """Refusing must not scribble in the caller's buffer.
+
+    ``out`` is validated (and so may be a real caller array) before the domain check runs, so
+    the check has to refuse without writing. A sentinel makes that observable.
+    """
+    degree = _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float32 + 1
+    out = np.full((degree + 1, degree + 1), 7.0, dtype=np.float32)
+    with pytest.raises(ValueError, match="outside the supported domain"):
+        compute_cardinal_to_bernstein_1d(degree, np.float32, out=out)
+    assert np.array_equal(out, np.full_like(out, 7.0)), "the refused call wrote into `out`"
+
+
+def test_cached_wrapper_propagates_the_domain_refusal() -> None:
+    """``functools.lru_cache`` must not swallow or reshape the refusal.
+
+    The extraction paths reach these builders through the cached wrappers, so a caller there
+    has to see the same message a direct call gives.
+    """
+    with pytest.raises(ValueError, match="compute_cardinal_to_bernstein_1d"):
+        _cached_cardinal_to_bernstein_matrix(
+            _CARDINAL_TO_BERNSTEIN_MAX_DEGREE.float32 + 1, np.dtype(np.float32)
+        )
 
 
 def test_extraction_degrees_stay_inside_the_domain() -> None:

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -7,7 +7,7 @@ XPASS failure, and the marker comes off, promoting the test to a permanent guard
 same data. That is the convention ``tests/test_review_regressions.py`` follows for the
 June 2026 review, whose markers have all since been removed.
 
-Eleven markers have already come off here: the domain-membership test, closed by the
+Twelve markers have already come off here: the domain-membership test, closed by the
 ``np.isclose`` tolerance-leak fix in #289; the tanh-sinh endpoint test, closed by
 truncating the rule where the endpoint gap stops being resolvable; the Lagrange
 reproducibility test, closed by seeding the barycentric node permutation; the float32
@@ -21,12 +21,13 @@ holding the repeated-iterate stop to Corollary 14's actual hypothesis; and four 
 together by the tolerance-semantics pass -- the two knot-snapping tests and the unique-knot
 accessor directly, and the restriction that returned a shorter domain than asked for as a
 consequence, since its ``b_new + tol`` step ceased to be a no-op once ``tol`` carried the
-knot vector's magnitude.
+knot vector's magnitude; and the change of basis that reported numpy's ``LinAlgError`` for a
+legal degree, closed by giving every builder that solves a declared, documented
+``(degree, dtype)`` domain and a ``ValueError`` that names the argument at fault.
 
-Three remain open, all from the August 2026 triage of the full profile: knot-vector
-factories that disagree with their own documentation at zero intervals, a Lagrange
-extraction that cannot be built on a degree-0 space its two sibling extractions handle, and
-a change of basis that reports numpy's `LinAlgError` for a legal degree.
+Two remain open, both from the August 2026 triage of the full profile: knot-vector
+factories that disagree with their own documentation at zero intervals, and a Lagrange
+extraction that cannot be built on a degree-0 space its two sibling extractions handle.
 
 One test per **root cause**, not per symptom: several of these root causes have many
 triggering combinations, and each test names them in a comment rather than repeating
@@ -947,65 +948,50 @@ def test_lagrange_extraction_handles_a_degree_zero_space() -> None:
 
 
 # ---------------------------------------------------------------------------
-# The cardinal change of basis raises a bare LinAlgError on a legal degree
+# The cardinal change of basis reports its own conditioning limit (fixed)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="the cardinal change-of-basis builders raise numpy's LinAlgError on a legal "
-    "(degree, dtype) pair, an exception type none of them documents and which the caller "
-    "cannot tell apart from an illegal argument",
-)
 def test_cardinal_change_of_basis_reports_its_own_conditioning_limit() -> None:
-    # Found only because the August 2026 triage completed the sweep's verdict flags: with
-    # no `must_succeed`, this read as an UNDOCUMENTED_REJECTION -- a suspicion nobody had
-    # looked at -- because `numpy.linalg.LinAlgError` subclasses `ValueError` and the
-    # runner's `Raises:`-driven rule cannot see that the *reason* is undocumented. Five
-    # `basis` cases and fifteen `bspline` extraction cases are this one cause.
+    # FIXED by giving every change-of-basis builder that solves a declared, documented
+    # (degree, dtype) domain and a `ValueError` that names the degree, the dtype and the
+    # supported range. Kept as a regression guard with its original triggering data, per
+    # this repository's convention that the fix PR un-xfails the tests it closes. The
+    # domain's derivation lives in `tests/test_change_basis_domain.py`.
     #
-    # The numerics are not in dispute. The cardinal-to-Bernstein matrix's condition number
-    # grows like 4 ** degree; measured with `numpy.linalg.cond` on the returned matrix it
-    # is 15 at degree 3, 3.5e10 at degree 10, 1.2e21 at degree 20 and 5.2e32 at degree 30,
-    # while float32 can resolve at most 1 / eps = 8.4e6. So at high degree in float32 the
-    # inverse genuinely cannot be formed, and refusing is right.
+    # What it was: for a degree that is not negative and a dtype that is float32, the
+    # builders raised `LinAlgError: Singular matrix` from three frames down, an exception
+    # type none of their `Raises:` sections mentioned. `numpy.linalg.LinAlgError` subclasses
+    # `ValueError`, so the sweep's `Raises:`-driven rule could not see that the *reason* was
+    # undocumented, and the case read as an UNDOCUMENTED_REJECTION nobody had looked at.
+    # Five `basis` cases and fifteen `bspline` extraction cases were this one cause.
     #
-    # What is wrong is the contract. Every one of these builders documents exactly one
-    # exception -- "ValueError: If degree is negative, dtype is not float32 or float64, or
-    # if `out` is provided and has incorrect shape or dtype" -- and then, for a degree that
-    # is not negative and a dtype that is float32, raises `LinAlgError: Singular matrix`
-    # from three frames down. The caller is told nothing about a degree limit, cannot
-    # discover one from the signature, and gets a message that describes an internal matrix
-    # rather than the argument that caused it. Either the limit belongs in the docstring
-    # with a `ValueError` that names it, or `LinAlgError` belongs in `Raises:`.
+    # The numerics were never in dispute -- refusing at high degree in float32 is right --
+    # only the contract. The caller was told nothing about a degree limit, could not
+    # discover one from the signature, and got a message describing an internal matrix
+    # rather than the argument that caused it.
     #
-    # The threshold measured on this machine, for `compute_cardinal_to_bernstein_1d`:
-    #
-    #   float32   degree 3, 10, 15, 20, 25, 30 -> returns    degree 40, 62 -> LinAlgError
-    #   float64   degree 3 ... 62              -> returns
-    #
-    # so the assertion below uses float32 at degree 62, well past the cliff, and pins
-    # float64 alongside it to keep the failure attributable to precision rather than to
-    # degree alone.
+    # Two corrections to the record this test used to carry, both re-measured on the parent
+    # commit. `kappa(A)` does not grow like `4 ** degree`: the exact infinity-norm condition
+    # number multiplies by about `2 * degree + 1` from one degree to the next, which is
+    # faster. And the float64 column was wrong to read as "no limit": degree 62 in float64
+    # returned an array, but one whose every digit was noise, which is why it is refused
+    # below alongside float32.
     degree = 62
 
-    # float64 handles the same degree, so this is a precision limit and not a degree one.
-    reference = np.asarray(compute_cardinal_to_bernstein_1d(degree, np.float64))
-    assert reference.shape == (degree + 1, degree + 1)
-
-    try:
-        matrix = compute_cardinal_to_bernstein_1d(degree, np.float32)
-    except ValueError as exc:
-        # `LinAlgError` is a `ValueError` subclass, so this catches both. The distinction
-        # the test insists on is the one the caller has to make: a message naming the
-        # argument at fault, not numpy's internal one.
-        assert "Singular matrix" not in str(exc), (
-            f"compute_cardinal_to_bernstein_1d({degree}, float32) raised numpy's "
-            f"{type(exc).__name__}: {exc} -- the documented ValueError should name the "
-            f"degree or the precision, and `Raises:` should list whatever is thrown"
+    for dtype in (np.float32, np.float64):
+        with pytest.raises(ValueError) as excinfo:
+            compute_cardinal_to_bernstein_1d(degree, dtype)
+        message = str(excinfo.value)
+        assert "Singular matrix" not in message, (
+            f"compute_cardinal_to_bernstein_1d({degree}, {np.dtype(dtype).name}) raised "
+            f"numpy's {type(excinfo.value).__name__}: {message} -- the documented "
+            f"ValueError should name the argument at fault, not an internal matrix"
         )
-        raise
-    assert np.asarray(matrix).shape == (degree + 1, degree + 1)
+        assert "compute_cardinal_to_bernstein_1d" in message
+        assert str(degree) in message
+        assert np.dtype(dtype).name in message
+        assert "outside the supported domain" in message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #311.

Five builders that recover their result from a linear solve now declare and enforce a
`(degree, dtype)` domain and raise `ValueError` naming the degree, the dtype and the
supported range. The two that solve nothing carry no limit and document why.

| builder | float32 | float64 |
|---|---|---|
| `compute_cardinal_to_bernstein_1d` | 8 | 14 |
| `compute_bernstein_to_cardinal_1d` | 12 | 26 |
| `compute_cardinal_to_legendre_1d` / `compute_cardinal_dual_legendre_coeffs_1d` | 6 | 12 |
| `compute_bernstein_to_lagrange_1d` | 17–23 by node family | 37–52 by node family |
| `compute_lagrange_to_bernstein_1d`, `compute_legendre_to_cardinal_1d` | none | none |

**Every entry comes from the same exact criterion**: the largest degree with
`κ_∞(M)·ε < 1` on the matrix the builder actually solves with, i.e. the point at which the
perturbation bound reaches 100% of the result. `κ_∞` is computed in exact arithmetic, so the
table is the same on every machine. It subsumes all three reported symptoms at once, since it
bounds `‖M⁻¹‖` far below either format's overflow threshold and rules out a zero pivot across
the supported range. Each constant carries its own `κ_∞·ε` on both sides of its boundary.

**Domain and accuracy are stated separately, and only the domain is enforced.**
`compute_cardinal_to_bernstein_1d` inverts a matrix that is itself the output of a Gram solve,
so its input already carries `κ_∞(G_bern)·ε` and the composed bound on what it returns is
`κ_∞(A)·κ_∞(G_bern)·ε`, which passes 1 after degree 5 in float32 and degree 10 in float64.
That is documented on the constant and in the builder's `Warning:` as the degree past which
nothing is guaranteed — but it is **not** the domain, because it is demonstrably pessimistic:
degree 11 float64 lies outside it and is accurate to `3e-4`, four good digits, and the
existing suite exercises exactly that case. Enforcing it would refuse usable results.

## What CI caught, and what it changed

The first version of this branch capped float64 at 12 on a **measured** fidelity argument,
and CI refuted it. The test asserting that degree 13 is unusable measured a relative error of
`9.56` locally (macOS, Accelerate) and `0.0335` on CI (Linux, OpenBLAS) — a factor of 285 for
the same computation. The local sequence was not even monotone in degree (9.56 at 13, 3.12 at
14, 1.14 at 15), which is the signature of a quantity round-off dominates rather than an error
that grows.

So the cap rested on one platform's realization of round-off, and on CI's platform it refused a
usable result. The fidelity criterion is gone: the domain is the uniform exact criterion above,
which raised float64 from 12 to 14, and the composed bound became the documented accuracy
statement. **No limit in this module now comes from a measured quantity** — that was the only
one, and the two sibling docstrings that mentioned a fidelity check now say the measurement
corroborates the boundary rather than setting it.

## What the ticket got wrong

Its numbers were measured before the inverse construction changed, so several no longer hold:

- **`compute_bernstein_to_lagrange_1d` never raises `LinAlgError`.** The ticket lists it as a
  victim of that symptom. It is clean at every degree 1–90, all five node families, both
  dtypes. Its defect was the undeclared domain, not a leaked exception.
- **`κ` does not grow like `4^degree`** (claimed in the retired xfail). Exact `κ_∞` multiplies
  by about `2p+1` per degree for the Bernstein/cardinal pair and `4p+1` for Legendre/cardinal,
  both faster than `4^p`. Only the Bernstein Gram matrix grows like `4^p`.
- **`LinAlgError` onset is not a conditioning boundary** but an exact-zero-pivot accident (37
  for one pair, 38 for another, never for the rest), so it cannot found a domain.
- **"float64 degree 62 returns"** was recorded as a passing case; it returns pure noise.
- `κ` crosses `1/eps` for float64 at degree 15, not 16.

Reproduced exactly as stated: the first infinity at degree 34 float32, the first `LinAlgError`
at 37, and the reproduction's 74 infinite entries out of 1369.

| | |
|---|---|
| AC1 | Verified over every builder, variant and dtype, 40 degrees past each boundary; the two unbounded builders clean over degrees 1–90. |
| AC2 | The strict xfail is retired; the suite goes from 3 xfails to 2. |
| AC3 | `compute_cardinal_to_bernstein_1d(36, np.float32)` raises `ValueError` naming the domain instead of returning 74 infinities. |
| AC4 | 691 in-domain cases bitwise identical to the parent commit; the two degrees the wider domain newly admits (13 and 14 float64) checked directly against a base-commit worktree, byte-identical by sha256. |
| AC5 | Documented for the five bounded builders; the two unbounded ones state it under `Note:` rather than `Raises:`, since they raise no domain error. |
| AC6 | Boundary covered builder by builder and node family by node family; the generic derivation test now asserts the same statement for all 22 parametrizations with no special case. |
| AC7 | Bézier extraction unaffected: 868 extraction tests pass, and the highest degree those paths exercise is 4 against a float32 limit of 8. |

Also fixed along the way: an undocumented `KeyError` on an unknown `LagrangeVariant` (coerced
through the enum, with a test), a guard that ran after allocation so `degree=100000` hit
`MemoryError` before the clean `ValueError`, a `Final` limit table that was a mutable dict and
is now a `MappingProxyType`, and five docstring claims that overstated what had been measured.

## Checks

ruff, ruff format, mypy (234 files), `lint-imports` (1 contract kept), pytest **5919 passed,
21 skipped, 2 xfailed** on the current base. Acceptance criteria re-verified by running the
ticket's own reproduction, independently of the suite. The module's autodoc build is clean
under `-W` and renders no literal `$…$`.

## Known and deliberately not fixed here

- **The domain is a solvability boundary, not an accuracy one**, and raising float64 to 14
  sharpens that: degrees 11–14 are supported and carry no accuracy guarantee, which is now
  stated exactly and portably but only in prose. Whether a caller should get a machine-readable
  degradation signal — a returned tier, a warning, or a queryable margin against the composed
  bound — is an API decision this PR does not take.
- `BsplineSpace1D.tabulate_{cardinal,Lagrange}_extraction_operators` can now raise this
  `ValueError` and their `Raises:` sections do not mention it. Docstring-only, another file.
- The adversarial sweep's case generators do not know about the domain, so its wider profiles
  will report roughly twenty false `BUG` verdicts until they do. CI is unaffected: the smoke
  profile only reaches degrees 0, 1 and 3 at float64.
