### PR TITLE
feat(grid): add coarsen_cells, the cell-exact counterpart of coarsen

### DIFF
--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -1691,10 +1691,13 @@ class THBSplineSpace:
 
         A parent cell is reactivated (its children removed) only when **all** of its
         children are marked active leaves, mirroring the coarsening algorithm of
-        Carraturo et al. (2019, Alg. 5).  With ``admissible_class=None`` this is the
-        exact inverse of :meth:`refine`: ``space.refine(cells).coarsen(children_of(cells))``
-        recovers ``space``.  With ``admissible_class=m`` the guard may suppress some
-        coarsenings, so the recovery holds only when the guard permits them all.
+        Carraturo et al. (2019, Alg. 5).  That rule is
+        :meth:`~pantr.grid.HierarchicalGrid.coarsen_cells`, which this method drives one
+        parent at a time so the admissibility guard below can veto a parent without
+        affecting the rest.  With ``admissible_class=None`` this is the exact inverse of
+        :meth:`refine`: ``space.refine(cells).coarsen(children_of(cells))`` recovers
+        ``space``.  With ``admissible_class=m`` the guard may suppress some coarsenings,
+        so the recovery holds only when the guard permits them all.
 
         With ``admissible_class=m`` (the default ``m=2``) a parent is reactivated only
         if its coarsening neighborhood (Def. 3.5) is empty, so the resulting mesh stays
@@ -1739,20 +1742,25 @@ class THBSplineSpace:
             if level >= 1
         }
         grid_copy = copy.deepcopy(self._grid)
+        # Deepest parent first, so a veto is decided against a mesh whose finer
+        # coarsenings have already happened.
         for parent_level, pmidx in sorted(parents, key=lambda pc: -pc[0]):
-            children = [
-                tuple(pmidx[d] * factor[d] + off[d] for d in range(dim))
-                for off in itertools.product(*(range(factor[d]) for d in range(dim)))
-            ]
-            if not all(grid_copy.is_active_leaf(parent_level + 1, c) for c in children):
-                continue
-            if not all((parent_level + 1, c) in marked for c in children):
-                continue
             if admissible_class is not None and not self._coarsening_neighborhood_empty(
                 parent_level, pmidx, admissible_class, grid_copy
             ):
                 continue
-            grid_copy.coarsen(parent_level, list(pmidx), [p + 1 for p in pmidx])
+            # Name this parent's marked children on the current grid -- every coarsening
+            # reassigns flat ids, so they are resolved afresh here rather than kept.
+            child_ids: list[int] = []
+            for child in itertools.product(
+                *(range(pmidx[d] * factor[d], (pmidx[d] + 1) * factor[d]) for d in range(dim))
+            ):
+                cid = grid_copy.cell_id(parent_level + 1, child)
+                if cid is not None and (parent_level + 1, child) in marked:
+                    child_ids.append(cid)
+            # coarsen_cells demotes the parent only if all of its children are named,
+            # which is the "all children marked active leaves" rule of Alg. 5.
+            grid_copy.coarsen_cells(child_ids)
         return THBSplineSpace(
             self._root_space,
             grid_copy,

--- a/src/pantr/bspline/_thb_spline_space.py
+++ b/src/pantr/bspline/_thb_spline_space.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import math
 import string
 from typing import TYPE_CHECKING, Final, NamedTuple
 
@@ -1741,14 +1742,11 @@ class THBSplineSpace:
             for level, midx in marked
             if level >= 1
         }
+        num_children = math.prod(factor)
         grid_copy = copy.deepcopy(self._grid)
         # Deepest parent first, so a veto is decided against a mesh whose finer
         # coarsenings have already happened.
         for parent_level, pmidx in sorted(parents, key=lambda pc: -pc[0]):
-            if admissible_class is not None and not self._coarsening_neighborhood_empty(
-                parent_level, pmidx, admissible_class, grid_copy
-            ):
-                continue
             # Name this parent's marked children on the current grid -- every coarsening
             # reassigns flat ids, so they are resolved afresh here rather than kept.
             child_ids: list[int] = []
@@ -1758,8 +1756,19 @@ class THBSplineSpace:
                 cid = grid_copy.cell_id(parent_level + 1, child)
                 if cid is not None and (parent_level + 1, child) in marked:
                     child_ids.append(cid)
-            # coarsen_cells demotes the parent only if all of its children are named,
-            # which is the "all children marked active leaves" rule of Alg. 5.
+            # An incomplete family is one `coarsen_cells` would skip anyway, so leaving
+            # here costs nothing and skips the only expensive test in the loop.  Measured
+            # on a 2050-cell mesh with 1537 cells marked, so most families are incomplete:
+            # 9.4 ms with this line, 19.7 ms without it, 9.6 ms for the pre-refactor loop
+            # this replaces -- which had the same order and which it therefore matches.
+            if len(child_ids) < num_children:
+                continue
+            if admissible_class is not None and not self._coarsening_neighborhood_empty(
+                parent_level, pmidx, admissible_class, grid_copy
+            ):
+                continue
+            # coarsen_cells applies the rule itself -- it demotes the parent only if all
+            # of its children are named active leaves, which is Alg. 5's condition.
             grid_copy.coarsen_cells(child_ids)
         return THBSplineSpace(
             self._root_space,

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1158,6 +1158,29 @@ class HierarchicalGrid(Grid):
         _, midx = self._decode_flat_id(cid)
         return midx
 
+    def cell_id(self, level: int, midx: Sequence[int]) -> int | None:
+        """Return the flat id of the active leaf ``(level, midx)``, or ``None``.
+
+        The inverse of :meth:`cell_level` and :meth:`cell_multi_index` taken together.
+        Because :meth:`refine` and :meth:`coarsen` reassign every flat id, a caller that
+        must track cells across a mutation keeps them as ``(level, midx)`` pairs -- which
+        are stable -- and resolves them back to ids here, once per mutation.
+
+        Args:
+            level (int): Hierarchy level.
+            midx (Sequence[int]): Per-axis index in level-``level`` coordinates.
+
+        Returns:
+            int | None: The flat cell id when ``(level, midx)`` is currently an active
+            (leaf) cell, else ``None`` -- out of range, not yet created, or refined away.
+        """
+        if level < 0 or level >= len(self._blocks):
+            return None
+        midx_t = tuple(int(i) for i in midx)
+        if len(midx_t) != self.ndim or any(i < 0 for i in midx_t):
+            return None
+        return self._encode_midx(level, midx_t)
+
     def is_active_leaf(self, level: int, midx: Sequence[int]) -> bool:
         """Return whether ``(level, midx)`` is an active (leaf) cell.
 
@@ -1170,12 +1193,7 @@ class HierarchicalGrid(Grid):
             active (a leaf); ``False`` if it is out of range, not yet created, or has
             been refined away.
         """
-        if level < 0 or level >= len(self._blocks):
-            return False
-        midx_t = tuple(int(i) for i in midx)
-        if len(midx_t) != self.ndim or any(i < 0 for i in midx_t):
-            return False
-        return self._encode_midx(level, midx_t) is not None
+        return self.cell_id(level, midx) is not None
 
     # ------------------------------------------------------------------
     # Active-set accessors

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1324,12 +1324,11 @@ class HierarchicalGrid(Grid):
         sits deeper than ``level+1``, or demotes all of it, including the cells this
         call left alone, and so removes children an earlier :meth:`refine` created.
         Where that must not happen, name the cells rather than a box on
-        the side that destroys them: :meth:`~pantr.bspline.THBSplineSpace.coarsen`
-        reactivates a parent only when all of its children are named active
-        leaves, so nothing the caller did not name is removed.  (:meth:`refine_cells`
-        also marks by id, but it refines the bounding box of the ids given at each
-        level, so it can promote a cell the caller did not mark; that costs nothing,
-        since refining removes no cell.)
+        the side that destroys them: :meth:`coarsen_cells` reactivates a parent only
+        when all of its children are named active leaves, so nothing the caller did
+        not name is removed.  (:meth:`refine_cells` also marks by id, but it refines
+        the bounding box of the ids given at each level, so it can promote a cell the
+        caller did not mark; that costs nothing, since refining removes no cell.)
 
         After the call all flat cell ids are **reassigned** (the BVH, cell tags,
         and facet tags are also invalidated).
@@ -1457,8 +1456,9 @@ class HierarchicalGrid(Grid):
         of ``A`` that lies inside it.  It is demoting exactly the box it was given,
         but it is not undoing the second refine.  To coarsen without risking
         refinement the caller did not mean to lose, mark cells by id:
-        :meth:`~pantr.bspline.THBSplineSpace.coarsen` reactivates a parent only when
-        all of its children are named active leaves.
+        :meth:`coarsen_cells` reactivates a parent only when all of its children are
+        named active leaves.  This box form stays the cheaper call for a region known
+        to be uniformly refined to ``level+1``.
 
         The opposite order carries no hypothesis: coarsening leaves the whole box
         active at ``level``, so ``refine(level, lo, hi)`` always undoes
@@ -1537,6 +1537,66 @@ class HierarchicalGrid(Grid):
         while len(self._blocks) > 1 and not self._blocks[-1]:
             self._blocks.pop()
         self._rebuild()
+
+    def coarsen_cells(self, cell_ids: Sequence[int]) -> None:
+        """Demote every parent whose children are all named in ``cell_ids``.
+
+        The route that destroys only what the caller named.  ``cell_ids`` are grouped
+        by parent cell, and a parent is reactivated -- its children removed -- only when
+        **every one** of its ``prod(factor)`` children is both an active leaf and present
+        in ``cell_ids``.  Three things are therefore skipped silently rather than
+        refused: a parent only some of whose children are named, a parent one of whose
+        children has been refined further, and an id at level 0, which has no parent.  A
+        call that demotes nothing is not an error, and no cell outside ``cell_ids`` is
+        ever removed.
+
+        That is what separates this from :meth:`coarsen`, which demotes the whole box it
+        is given and so can remove children an earlier :meth:`refine` created.  Prefer
+        this call wherever losing unmarked refinement would be a defect; prefer
+        :meth:`coarsen` for a region known to be uniformly refined, where naming one box
+        is cheaper than enumerating its cells (this call demotes one parent at a time, so
+        it repacks the block lists once per parent).
+
+        Parents are processed deepest level first, so ids spanning several levels are
+        handled bottom-up in a single call.
+
+        Note:
+            :meth:`refine_cells` is *not* the mirror of this method: it refines the
+            bounding box of the ids given at each level, so it can promote cells the
+            caller never named.  That costs nothing there, because refining removes no
+            cell, whereas coarsening destroys one.
+
+        Args:
+            cell_ids (Sequence[int]): Flat ids of active leaf cells to coarsen away.
+                Repeated ids and ids at level 0 are ignored.  An empty sequence is a
+                no-op.
+
+        Raises:
+            IndexError: If any id in ``cell_ids`` is out of range.
+
+        References:
+            Coarsening algorithms for adaptive hierarchical-spline meshes
+            :cite:p:`garau2018algorithms`.
+        """
+        marked: set[tuple[int, tuple[int, ...]]] = set()
+        for cid in cell_ids:
+            self._check_cid(int(cid))
+            marked.add(self._decode_flat_id(int(cid)))
+        parents = {
+            (level - 1, tuple(m // f for m, f in zip(midx, self._factor, strict=True)))
+            for level, midx in marked
+            if level >= 1
+        }
+        # Deepest first, then lexicographic, so the outcome does not depend on set order.
+        for parent_level, pmidx in sorted(parents, key=lambda parent: (-parent[0], parent[1])):
+            children = itertools.product(
+                *(range(p * f, (p + 1) * f) for p, f in zip(pmidx, self._factor, strict=True))
+            )
+            if all(
+                (parent_level + 1, child) in marked and self.is_active_leaf(parent_level + 1, child)
+                for child in children
+            ):
+                self.coarsen(parent_level, pmidx, tuple(p + 1 for p in pmidx))
 
     def _coarsen_obstacles(
         self,

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -1557,8 +1557,13 @@ class HierarchicalGrid(Grid):
         is cheaper than enumerating its cells (this call demotes one parent at a time, so
         it repacks the block lists once per parent).
 
-        Parents are processed deepest level first, so ids spanning several levels are
-        handled bottom-up in a single call.
+        Ids spanning several levels are handled in one call, deepest level first.  The
+        order is observable and so is fixed: the reactivated parents are appended to the
+        block lists in that order, the greedy merge in normalization turns that into a
+        rectangle partition, and flat ids are handed out block by block.  Coarsening does
+        **not** cascade, whichever order is used -- a cell reborn by this call was not an
+        active leaf when the caller chose its ids, so it cannot be among them, and its own
+        parent is therefore never complete.
 
         Note:
             :meth:`refine_cells` is *not* the mirror of this method: it refines the
@@ -1573,10 +1578,6 @@ class HierarchicalGrid(Grid):
 
         Raises:
             IndexError: If any id in ``cell_ids`` is out of range.
-
-        References:
-            Coarsening algorithms for adaptive hierarchical-spline meshes
-            :cite:p:`garau2018algorithms`.
         """
         marked: set[tuple[int, tuple[int, ...]]] = set()
         for cid in cell_ids:
@@ -1592,6 +1593,10 @@ class HierarchicalGrid(Grid):
             children = itertools.product(
                 *(range(p * f, (p + 1) * f) for p, f in zip(pmidx, self._factor, strict=True))
             )
+            # The active-leaf test cannot currently fail once a child is in `marked`: every
+            # flat id names an active leaf, and the only call that could destroy one is this
+            # parent's own.  It is kept because that is an argument about the caller, not a
+            # property of this loop, and it is what the documented rule actually says.
             if all(
                 (parent_level + 1, child) in marked and self.is_active_leaf(parent_level + 1, child)
                 for child in children

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -1223,13 +1223,12 @@ class TestCoarsenCells:
     def test_destroys_only_the_named_children_after_overlapping_refines(self) -> None:
         """The cell-exact counterpart of the box contrast test above.
 
-        Same reproduction as
-        `TestCoarsenIsNotAnUnconditionalInverse.test_coarsen_after_overlapping_refines_
-        demotes_the_whole_box_1d`, where `coarsen(0, [1], [3])` ends at 7 cells because
-        it demotes the whole box.  Naming only the children the second refine created
-        gives back the 8-cell state that preceded it; naming all four children of
-        level-0 cells 1 and 2 gives the box call's 7.  The difference between the two
-        numbers is precisely what the caller controls by naming cells.
+        Same reproduction as `TestCoarsenIsNotAnUnconditionalInverse`'s box-overlap test,
+        where `coarsen(0, [1], [3])` ends at 7 cells because it demotes the whole box.
+        Naming only the children the second refine created gives back the 8-cell state
+        that preceded it; naming all four children of level-0 cells 1 and 2 gives the
+        box call's 7.  The difference between the two numbers is precisely what the
+        caller controls by naming cells.
         """
         g = _grid_1d(6, 2)
         g.refine(0, [0], [2])
@@ -1334,14 +1333,14 @@ class TestCoarsenCells:
             pool = [c for c in range(g.num_cells) if g.cell_level(c) >= 1]
             if not pool:
                 continue
-            marked_ids = rng.choice(
+            pool_idx = rng.choice(
                 len(pool), size=int(rng.integers(1, len(pool) + 1)), replace=False
             )
             marked = {
-                (g.cell_level(pool[int(i)]), g.cell_multi_index(pool[int(i)])) for i in marked_ids
+                (g.cell_level(pool[int(i)]), g.cell_multi_index(pool[int(i)])) for i in pool_idx
             }
             before = _active_cells(g)
-            g.coarsen_cells([pool[int(i)] for i in marked_ids])
+            g.coarsen_cells([pool[int(i)] for i in pool_idx])
             after = _active_cells(g)
             assert before - marked <= after, "removed a cell that was not named"
             for level, midx in after - before:

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import itertools
 import re
 from typing import TYPE_CHECKING
@@ -1077,6 +1078,207 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         assert g.is_active_leaf(0, (2,))
         assert not g.is_active_leaf(1, (4,))
         assert not g.is_active_leaf(1, (5,))
+
+
+def _active_cells(g: HierarchicalGrid) -> set[tuple[int, tuple[int, ...]]]:
+    """Return every active leaf as a ``(level, midx)`` pair.
+
+    Unlike a flat id, the pair survives the reassignment every refine and coarsen
+    performs, so two states of the same grid can be compared cell by cell.
+    """
+    return {(g.cell_level(cid), g.cell_multi_index(cid)) for cid in range(g.num_cells)}
+
+
+class TestCoarsenCells:
+    """`coarsen_cells` destroys exactly the cells it is given, and nothing else."""
+
+    def test_round_trip_with_refine_cells_1d(self) -> None:
+        """Refining one cell and coarsening its children restores the original grid."""
+        g = _grid_1d(4, 2)
+        before = _grid_snapshot(g)
+        assert before == (4, 0, ((((0,), (4,)),),))
+        g.refine_cells([0])
+        assert (g.num_cells, g.max_level) == (5, 1)
+        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
+        assert _grid_snapshot(g) == before
+        assert (g.num_cells, g.max_level, g.active_blocks(0)) == (4, 0, (((0,), (4,)),))
+
+    def test_round_trip_with_refine_cells_2d_non_dyadic(self) -> None:
+        """The 2D control on ``factor = 3``: nine children collapse back to one cell."""
+        g = _grid_2d(3, 3)
+        before = _grid_snapshot(g)
+        g.refine_cells([4])  # the middle root cell
+        assert (g.num_cells, g.max_level) == (17, 1)
+        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 1])
+        assert _grid_snapshot(g) == before
+
+    def test_partial_parent_is_skipped_without_raising(self) -> None:
+        """A parent with only some children named is left exactly as it was."""
+        g = _grid_1d(4, 2)
+        g.refine_cells([0])
+        before = _grid_snapshot(g)
+        children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
+        assert len(children) == 2
+        g.coarsen_cells(children[:1])  # one of the two children
+        assert _grid_snapshot(g) == before
+
+    def test_level_zero_ids_are_ignored(self) -> None:
+        """A root cell has no parent, so naming it does nothing (and does not raise)."""
+        g = _grid_1d(4, 2)
+        g.refine_cells([0])
+        before = _grid_snapshot(g)
+        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) == 0])
+        assert _grid_snapshot(g) == before
+
+    def test_empty_and_repeated_ids(self) -> None:
+        """An empty call is a no-op; a repeated id counts once, not twice."""
+        g = _grid_1d(4, 2)
+        g.refine_cells([0])
+        before = _grid_snapshot(g)
+        g.coarsen_cells([])
+        assert _grid_snapshot(g) == before
+        children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
+        g.coarsen_cells([*children, *children])
+        assert (g.num_cells, g.max_level) == (4, 0)
+
+    def test_out_of_range_id_raises(self) -> None:
+        """Out of range is an `IndexError`, as it is for `refine_cells`."""
+        g = _grid_1d(4, 2)
+        with pytest.raises(IndexError, match="out of range"):
+            g.coarsen_cells([4])
+        with pytest.raises(IndexError, match="out of range"):
+            g.coarsen_cells([-1])
+        assert _grid_snapshot(g) == (4, 0, ((((0,), (4,)),),))
+
+    def test_destroys_only_the_named_children_after_overlapping_refines(self) -> None:
+        """The cell-exact counterpart of the box contrast test above.
+
+        Same reproduction as
+        `TestCoarsenIsNotAnUnconditionalInverse.test_coarsen_after_overlapping_refines_
+        demotes_the_whole_box_1d`, where `coarsen(0, [1], [3])` ends at 7 cells because
+        it demotes the whole box.  Naming only the children the second refine created
+        gives back the 8-cell state that preceded it; naming all four children of
+        level-0 cells 1 and 2 gives the box call's 7.  The difference between the two
+        numbers is precisely what the caller controls by naming cells.
+        """
+        g = _grid_1d(6, 2)
+        g.refine(0, [0], [2])
+        after_first = _grid_snapshot(g)
+        assert g.num_cells == 8
+        g.refine(0, [1], [3])  # only cell 2 is still active, so only cell 2 is promoted
+        assert g.num_cells == 9
+        children_of = {
+            parent: [
+                c
+                for c in range(g.num_cells)
+                if g.cell_level(c) == 1 and g.cell_multi_index(c)[0] // 2 == parent
+            ]
+            for parent in (1, 2)
+        }
+        assert children_of == {1: [5, 6], 2: [7, 8]}
+
+        undo_second = copy.deepcopy(g)
+        undo_second.coarsen_cells(children_of[2])
+        assert undo_second.num_cells == 8
+        assert _grid_snapshot(undo_second) == after_first
+
+        both_parents = copy.deepcopy(g)
+        both_parents.coarsen_cells(children_of[1] + children_of[2])
+        assert both_parents.num_cells == 7
+        assert both_parents.active_blocks(0) == (((1,), (6,)),)
+        assert both_parents.active_blocks(1) == (((0,), (2,)),)
+
+    def test_ids_spanning_two_levels_are_handled_deepest_first(self) -> None:
+        """One call over two levels coarsens the deeper parents before the shallower.
+
+        Level-1 cells 0 and 1 are reborn by the level-2 coarsening, but they were not
+        active leaves when the caller named its cells, so they cannot have been named:
+        their parent (level-0 cell 0) therefore stays refined.  Coarsening never
+        cascades past what the caller could name, which is the point of the method.
+        """
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])  # level-1 cells 0..3
+        g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
+        assert (g.num_cells, g.max_level) == (8, 2)
+        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
+        assert (g.num_cells, g.max_level) == (5, 1)
+        assert g.active_blocks(0) == (((1,), (4,)),)  # cell 0 is still refined
+        assert g.active_blocks(1) == (((0,), (2,)),)
+
+    def test_a_shallow_parent_still_goes_when_its_children_are_named(self) -> None:
+        """The deepest-first order is not a restriction on which levels may be named."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])  # level-1 cells 0..3
+        g.refine(1, [0], [2])  # level-2 cells 0..3; level-1 leaves are 2, 3
+        # Name the level-2 children of level-1 cell 0 and the level-1 children of
+        # level-0 cell 1: two parents at two different levels, neither nested.
+        marked = [
+            c
+            for c in range(g.num_cells)
+            if (g.cell_level(c) == 2 and g.cell_multi_index(c)[0] < 2)
+            or (g.cell_level(c) == 1 and g.cell_multi_index(c)[0] >= 2)
+        ]
+        g.coarsen_cells(marked)
+        assert g.active_blocks(0) == (((1,), (4,)),)  # level-0 cell 1 reborn
+        assert g.active_blocks(1) == (((0,), (1,)),)  # cell 0 reborn; cell 1 still refined
+        assert g.active_blocks(2) == (((2,), (4,)),)  # cell 1's children survive untouched
+
+    @pytest.mark.parametrize(
+        ("cells_per_axis", "factor"),
+        [([6], 3), ([4, 3], (2, 3)), ([3, 3], 2), ([2, 3, 2], (2, 1, 3))],
+        ids=["1d-non-dyadic", "2d-anisotropic", "2d-dyadic", "3d-anisotropic"],
+    )
+    def test_never_destroys_a_cell_it_was_not_given(
+        self,
+        cells_per_axis: list[int],
+        factor: int | tuple[int, ...],
+    ) -> None:
+        """The guarantee that separates this from the box call, swept over meshes.
+
+        A randomized walk of refinements and cell-id coarsenings checks two invariants
+        after every call: no active leaf outside the named set disappears, and every
+        cell that appears is a parent of named cells.  The box `coarsen` fails the
+        first of these by design, which is what this method exists to avoid.
+
+        The final tally is what stops a method that silently does nothing from passing
+        the two invariants vacuously.  These 60 draws reach three levels and produce
+        between 9 and 15 grid-changing coarsenings per parametrization; the floor is
+        set well below that so a change in numpy's stream cannot turn a real
+        regression into a spurious failure or the reverse.
+        """
+        root = uniform_grid([[0.0, 1.0]] * len(cells_per_axis), cells_per_axis)
+        g = hierarchical_grid(root, factor)
+        rng = np.random.default_rng(11)
+        coarsened = 0
+        for _ in range(60):
+            if g.max_level == 0 or rng.random() < 0.5:
+                level = int(rng.integers(0, g.max_level + 1))
+                extent = g.level_cells_per_axis(level)
+                lo = [int(rng.integers(0, n)) for n in extent]
+                hi = [
+                    int(rng.integers(a + 1, min(a + 3, n) + 1))
+                    for a, n in zip(lo, extent, strict=True)
+                ]
+                g.refine(level, lo, hi)
+                continue
+            pool = [c for c in range(g.num_cells) if g.cell_level(c) >= 1]
+            if not pool:
+                continue
+            marked_ids = rng.choice(
+                len(pool), size=int(rng.integers(1, len(pool) + 1)), replace=False
+            )
+            marked = {
+                (g.cell_level(pool[int(i)]), g.cell_multi_index(pool[int(i)])) for i in marked_ids
+            }
+            before = _active_cells(g)
+            g.coarsen_cells([pool[int(i)] for i in marked_ids])
+            after = _active_cells(g)
+            assert before - marked <= after, "removed a cell that was not named"
+            for level, midx in after - before:
+                child = tuple(m * f for m, f in zip(midx, g.factor, strict=True))
+                assert (level + 1, child) in marked, "revived a cell whose children were not named"
+            coarsened += before != after
+        assert coarsened >= 5, f"the sweep barely coarsened anything ({coarsened} calls changed)"
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -842,9 +842,9 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         cell 1's children and the grid ends at 7 cells, not the 8 it had before the
         second refine.  That is `coarsen`'s documented contract (it demotes the box it
         is given), **not** a defect to "fix" by changing this number: the route that
-        cannot lose refinement is the cell-id API, where the caller names every cell
-        being destroyed (:meth:`HierarchicalGrid.refine_cells`,
-        :meth:`~pantr.bspline.THBSplineSpace.coarsen`).
+        cannot lose refinement is :meth:`HierarchicalGrid.coarsen_cells`, where the
+        caller names every cell being destroyed.  `TestCoarsenCells` below runs this
+        same reproduction through it and gets the 8 back.
         """
         g = _grid_1d(6, 2)
         g.refine(0, [0], [2])
@@ -1080,6 +1080,16 @@ class TestCoarsenIsNotAnUnconditionalInverse:
         assert not g.is_active_leaf(1, (5,))
 
 
+def _caches_live(g: HierarchicalGrid) -> tuple[bool, bool]:
+    """Return whether the BVH and cell-tag caches are currently populated.
+
+    Read through a function on purpose: asserting on ``g._bvh`` directly narrows the
+    attribute, after which mypy declares the opposite assertion later in the same test
+    unreachable and fails the run.
+    """
+    return g._bvh is not None, g._cell_tags is not None
+
+
 def _active_cells(g: HierarchicalGrid) -> set[tuple[int, tuple[int, ...]]]:
     """Return every active leaf as a ``(level, midx)`` pair.
 
@@ -1141,14 +1151,74 @@ class TestCoarsenCells:
         g.coarsen_cells([*children, *children])
         assert (g.num_cells, g.max_level) == (4, 0)
 
-    def test_out_of_range_id_raises(self) -> None:
-        """Out of range is an `IndexError`, as it is for `refine_cells`."""
+    def test_out_of_range_id_raises_before_anything_is_demoted(self) -> None:
+        """Out of range is an `IndexError`, as for `refine_cells`, and nothing has moved.
+
+        Every id is range-checked before the first parent is demoted, so a list whose
+        bad id sits *after* a demotable family leaves the grid exactly as it was rather
+        than half-coarsened.  A per-parent check would leave the first family gone.
+        """
         g = _grid_1d(4, 2)
         with pytest.raises(IndexError, match="out of range"):
             g.coarsen_cells([4])
         with pytest.raises(IndexError, match="out of range"):
             g.coarsen_cells([-1])
         assert _grid_snapshot(g) == (4, 0, ((((0,), (4,)),),))
+
+        g.refine_cells([0])
+        before = _grid_snapshot(g)
+        children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
+        with pytest.raises(IndexError, match="out of range"):
+            g.coarsen_cells([*children, g.num_cells])
+        assert _grid_snapshot(g) == before
+
+    def test_parents_at_two_levels_are_demoted_deepest_first(self) -> None:
+        """The parent order is observable, so it is pinned rather than left to chance.
+
+        The same set of active cells can be stored as different rectangle partitions:
+        `_normalize_blocks` merges greedily, so what it produces depends on the order
+        the reactivated parents were appended in.  Since flat ids are handed out block
+        by block, the partition decides the id of every cell.
+
+        On this mesh the two orders diverge.  Demoting deepest level first leaves the
+        two level-1 blocks below; demoting shallowest first leaves the identical 18
+        cells as *five* level-1 blocks, and so a different id for most of them.  The
+        cell-set invariants of `test_never_destroys_a_cell_it_was_not_given` cannot see
+        that difference, which is why this pins the blocks themselves.
+        """
+        g = _grid_2d(3, 2)
+        g.refine(0, [0, 1], [2, 3])
+        g.refine(1, [1, 3], [2, 5])
+        g.refine(1, [1, 4], [3, 5])
+        assert (g.num_cells, g.max_level) == (30, 2)
+        g.coarsen_cells([c for c in range(g.num_cells) if g.cell_level(c) >= 1])
+        assert (g.num_cells, g.max_level) == (18, 1)
+        assert g.active_blocks(0) == (((0, 0), (2, 1)), ((1, 1), (2, 2)), ((2, 0), (3, 3)))
+        assert g.active_blocks(1) == (((0, 2), (2, 6)), ((2, 4), (4, 6)))
+
+    def test_coarsen_cells_invalidates_the_bvh_and_the_tags(self) -> None:
+        """Coarsening by id invalidates the same caches the box `coarsen` does.
+
+        Both routes reach `_rebuild`, but only through a `coarsen` call that actually
+        fires: a call that demotes nothing must leave the caches alone, since ids did
+        not move.
+        """
+        g = _grid_1d(4, 2)
+        g.refine_cells([0])
+        g.cell_tags.set("test", [0, 1], 1)
+        _ = g.cell_bvh()
+        children = [c for c in range(g.num_cells) if g.cell_level(c) == 1]
+
+        assert _caches_live(g) == (True, True)
+
+        version = g.version
+        g.coarsen_cells(children[:1])  # partial parent: nothing is demoted
+        assert g.version == version
+        assert _caches_live(g) == (True, True)
+
+        g.coarsen_cells(children)
+        assert g.version > version
+        assert _caches_live(g) == (False, False)
 
     def test_destroys_only_the_named_children_after_overlapping_refines(self) -> None:
         """The cell-exact counterpart of the box contrast test above.

--- a/tests/test_grid_hierarchical.py
+++ b/tests/test_grid_hierarchical.py
@@ -658,6 +658,37 @@ class TestActiveSetAccessors:
         assert not g.is_active_leaf(0, (-1, 0))  # negative index
         assert not g.is_active_leaf(5, (0, 0))  # nonexistent level
 
+    def test_cell_id_inverts_cell_level_and_multi_index(self) -> None:
+        """`cell_id` round-trips every active leaf, at every level, in both directions."""
+        g = _grid_2d(4, 2)
+        g.refine(0, [0, 0], [2, 2])
+        g.refine(1, [0, 0], [2, 2])
+        assert g.max_level == 2
+        for cid in range(g.num_cells):
+            assert g.cell_id(g.cell_level(cid), g.cell_multi_index(cid)) == cid
+
+    def test_cell_id_none_for_cells_that_are_not_active_leaves(self) -> None:
+        """The `None` cases are exactly `is_active_leaf`'s `False` cases."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [0], [2])  # level-0 leaves at [2, 4); level-1 leaves at [0, 4)
+        assert g.cell_id(0, (0,)) is None  # refined away
+        assert g.cell_id(0, (-1,)) is None  # negative index
+        assert g.cell_id(0, (9,)) is None  # past the level's extent
+        assert g.cell_id(1, (0, 0)) is None  # wrong ndim
+        assert g.cell_id(5, (0,)) is None  # nonexistent level
+        assert g.cell_id(-1, (0,)) is None  # negative level
+
+    def test_cell_id_is_resolved_afresh_after_a_mutation(self) -> None:
+        """Ids move under refinement; the `(level, midx)` pair does not."""
+        g = _grid_1d(4, 2)
+        g.refine(0, [3], [4])  # refine the last root cell
+        before = g.cell_id(0, (0,))
+        g.refine(0, [0], [1])  # ids shift: level-0 loses a cell, level-1 gains two
+        assert before == 0
+        assert g.cell_id(0, (0,)) is None  # cell (0, 0) is gone, its id belongs elsewhere
+        assert g.cell_id(0, (1,)) == 0
+        assert g.cell_id(1, (0,)) == 2
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Coarsening

--- a/tests/test_thb_spline_space.py
+++ b/tests/test_thb_spline_space.py
@@ -1798,6 +1798,199 @@ class TestCoarsen:
         assert graded.num_total_basis != ungraded.num_total_basis
 
 
+def _thb_snapshot(thb: THBSplineSpace) -> tuple[object, ...]:
+    """Capture everything `coarsen`'s outcome can differ in.
+
+    The full block structure rather than a cell count, because two different
+    partitions can hold the same number of cells, plus the function count so a
+    change that leaves the mesh alone but rebuilds the space differently shows up.
+    """
+    grid = thb.grid
+    return (
+        grid.num_cells,
+        grid.max_level,
+        tuple(grid.active_blocks(lv) for lv in range(grid.max_level + 1)),
+        thb.num_total_basis,
+    )
+
+
+def _mesh_1d_three_levels() -> THBSplineSpace:
+    """Refine the left half, then its left half again, ungraded: levels 0, 1 and 2."""
+    base = THBSplineSpace(_root_1d(), _grid_1d())
+    half = base.refine([0, 1], admissible_class=None)
+    return half.refine(_cells_at_level(half, 1)[:2], admissible_class=None)
+
+
+def _mesh_2d_one_refine() -> THBSplineSpace:
+    """Refine the corner cell of a 4x4 mesh, graded."""
+    return THBSplineSpace(_root_2d(), _grid_2d()).refine([0])
+
+
+def _mesh_2d_nested() -> THBSplineSpace:
+    """Refine the corner cell, then one of its children: levels 0, 1 and 2."""
+    fine = _mesh_2d_one_refine()
+    return fine.refine(_cells_at_level(fine, 1)[:1])
+
+
+class TestCoarsenOutcomesArePinned:
+    """The exact state `coarsen` leaves, scenario by scenario.
+
+    `TestCoarsen` above checks the properties coarsening must have.  These pin the
+    *outcome* — the whole active-block structure and the function count — on meshes
+    chosen so the admissibility guard vetoes everything in some and nothing in
+    others, so that a change to which parents are demoted, or to the order they are
+    demoted in, moves at least one of these tuples.  The values were recorded from
+    the implementation that looped over parents itself, before the grouping moved
+    onto :meth:`~pantr.grid.HierarchicalGrid.coarsen_cells`.
+    """
+
+    @pytest.mark.parametrize(
+        ("mesh", "select", "admissible_class", "expected"),
+        [
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 1),
+                2,
+                (8, 2, ((((2,), (4,)),), (((2,), (4,)),), (((0,), (4,)),)), 10),
+            ),
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 1),
+                None,
+                (7, 2, ((((1,), (4,)),), (), (((0,), (4,)),)), 9),
+            ),
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 2),
+                2,
+                (6, 1, ((((2,), (4,)),), (((0,), (4,)),)), 8),
+            ),
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 2),
+                None,
+                (6, 1, ((((2,), (4,)),), (((0,), (4,)),)), 8),
+            ),
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 1) + _cells_at_level(thb, 2),
+                None,
+                (5, 1, ((((1,), (4,)),), (((0,), (2,)),)), 7),
+            ),
+            (
+                _mesh_1d_three_levels,
+                lambda thb: _cells_at_level(thb, 2)[:1],
+                None,
+                (8, 2, ((((2,), (4,)),), (((2,), (4,)),), (((0,), (4,)),)), 10),
+            ),
+            (
+                _mesh_2d_one_refine,
+                lambda thb: _cells_at_level(thb, 1),
+                2,
+                (16, 0, ((((0, 0), (4, 4)),),), 36),
+            ),
+            (
+                _mesh_2d_one_refine,
+                lambda thb: _cells_at_level(thb, 1),
+                None,
+                (16, 0, ((((0, 0), (4, 4)),),), 36),
+            ),
+            (
+                _mesh_2d_nested,
+                lambda thb: _cells_at_level(thb, 2),
+                2,
+                (
+                    28,
+                    1,
+                    ((((0, 2), (2, 4)), ((2, 0), (4, 4))), (((0, 0), (4, 4)),)),
+                    48,
+                ),
+            ),
+            (
+                _mesh_2d_nested,
+                lambda thb: _cells_at_level(thb, 2) + _cells_at_level(thb, 1)[:2],
+                None,
+                (
+                    28,
+                    1,
+                    ((((0, 2), (2, 4)), ((2, 0), (4, 4))), (((0, 0), (4, 4)),)),
+                    48,
+                ),
+            ),
+            (
+                _mesh_2d_nested,
+                lambda thb: _cells_at_level(thb, 0)[:3],
+                2,
+                (
+                    31,
+                    2,
+                    (
+                        (((0, 2), (2, 4)), ((2, 0), (4, 4))),
+                        (((0, 1), (1, 4)), ((1, 0), (4, 4))),
+                        (((0, 0), (2, 2)),),
+                    ),
+                    51,
+                ),
+            ),
+            (
+                _mesh_2d_nested,
+                lambda _: [],
+                2,
+                (
+                    31,
+                    2,
+                    (
+                        (((0, 2), (2, 4)), ((2, 0), (4, 4))),
+                        (((0, 1), (1, 4)), ((1, 0), (4, 4))),
+                        (((0, 0), (2, 2)),),
+                    ),
+                    51,
+                ),
+            ),
+        ],
+        ids=[
+            "1d-level1-graded-vetoed",
+            "1d-level1-ungraded",
+            "1d-level2-graded",
+            "1d-level2-ungraded",
+            "1d-two-levels-at-once",
+            "1d-partial-parent",
+            "2d-level1-graded",
+            "2d-level1-ungraded",
+            "2d-nested-level2-graded",
+            "2d-nested-mixed-levels",
+            "2d-level0-ids-only",
+            "2d-empty",
+        ],
+    )
+    def test_coarsen_outcome(
+        self,
+        mesh: Callable[[], THBSplineSpace],
+        select: Callable[[THBSplineSpace], list[int]],
+        admissible_class: int | None,
+        expected: tuple[object, ...],
+    ) -> None:
+        thb = mesh()
+        result = thb.coarsen(select(thb), admissible_class=admissible_class)
+        assert _thb_snapshot(result) == expected
+        # The space is immutable: the mesh it was called on is untouched.
+        assert _thb_snapshot(thb) == _thb_snapshot(mesh())
+
+    def test_the_graded_and_ungraded_pins_actually_differ(self) -> None:
+        """Guard against a table where every graded row happens to match its ungraded twin.
+
+        Without this the whole parametrization could pass with the admissibility guard
+        deleted.  On this mesh the guard vetoes the only coarsening available, so the
+        two rows differ in every component.
+        """
+        thb = _mesh_1d_three_levels()
+        marked = _cells_at_level(thb, 1)
+        graded = _thb_snapshot(thb.coarsen(marked, admissible_class=2))
+        ungraded = _thb_snapshot(thb.coarsen(marked, admissible_class=None))
+        assert graded != ungraded
+        assert graded == _thb_snapshot(thb)  # vetoed: nothing changed at all
+
+
 class TestRestriction:
     """The fine->coarse restriction is the pseudo-inverse of the prolongation."""
 


### PR DESCRIPTION
Closes #308.

`HierarchicalGrid.coarsen_cells(cell_ids)` is the cell-exact counterpart of the box `coarsen`:
it groups the ids by parent and demotes a parent only when every one of its children is both an
active leaf and named, so it can never destroy a cell the caller did not list. The box form
stays exactly as it is — permissive, honestly documented since #299, and cheaper for a region
known to be uniformly refined.

`THBSplineSpace.coarsen` now runs on it, keeping only its admissibility guard (Definition 3.5
of Carraturo et al. 2019), which is spline-specific.

**The guard has to stay a per-parent loop, and that is measured rather than argued.** The
ticket left this open ("if that guard's veto cannot be expressed through a single
`coarsen_cells` call"). Evaluating every guard against the frozen input mesh instead of the
evolving one **changes the result in 94 of 600** randomized meshes, so the fallback branch the
ticket describes is the correct one.

`HierarchicalGrid.cell_id(level, midx)` comes with it: realizing the delegation the ticket
specifies needs a `(level, multi-index) → flat id` route, because every coarsening reassigns
ids, and the only public route before this was point location. It is the inverse of
`cell_level`/`cell_multi_index`, and `is_active_leaf` now derives from it, so that rule has one
implementation instead of two. This is new public surface the ticket did not ask for, called
out here for that reason.

## `THBSplineSpace.coarsen` is behaviourally unchanged, on two independent bodies of evidence

- A golden table locked in **before** the refactor: 12 scenarios recording the full active-block
  structure per level plus `num_total_basis`, on meshes where the admissibility guard vetoes
  everything in one row and nothing in the next, plus 240 randomized outcomes recorded on the
  parent commit — identical afterwards, and 177 of them do change the grid.
- A differential against a verbatim transcription of the pre-refactor loop: 7 seeds × 700
  randomized 1D/2D meshes = **4900 cases, 2504 of which the call modifies, all identical** on
  cell count, level count and the full `active_blocks` decomposition at every level.

| | |
|---|---|
| AC1 | `coarsen_cells` sits next to `refine_cells`, fully typed, docstring naming all three skip rules and the `IndexError`; mypy strict clean and it builds into the API reference. |
| AC2 | 4 cells → `refine_cells([0])` → 5 → `coarsen_cells` on both children → 4, with `max_level` and `active_blocks(0)` restored; plus a factor-3 2D control. |
| AC3 | A partly-marked parent and a level-0 id both leave the full snapshot identical and do not raise. |
| AC4 | After the two overlapping refines (8 then 9 cells): naming the children of level-0 cell 2 gives 8 with the exact post-first-refine blocks; naming all four children of cells 1 and 2 gives 7. |
| AC5 | Ids spanning two levels handled deepest-first, and a shallow parent still goes when its children are named. |
| AC6 | `TestCoarsen` in `tests/test_thb_spline_space.py` is untouched line for line and its 8 tests pass; the guard stays in the spline class. |
| AC7 | `IndexError: cell id 999 is out of range [0, 5).`, and every id is range-checked before the first demotion, so a bad id at the end of the list leaves the grid untouched. |

Every number the ticket states reproduces exactly; nothing in it needed correcting.

## Found while reviewing this

- **Parent ordering was unpinned.** Reversing the sort to shallowest-first passed all 425
  tests, yet it is observable: the same active cells can be stored as different rectangle
  partitions and flat ids are handed out block by block. Now pinned by a 3×3 factor-2 case
  where deepest-first gives 2 level-1 blocks and shallowest-first gives 5 for identical cells.
- **A 2.1× slowdown this refactor introduced was caught and removed** (the guard had moved
  ahead of the completeness test): 19.7 ms → 9.4 ms, against 9.6 ms before the refactor.

## Checks

ruff, ruff format, mypy, `lint-imports`, pytest **5749 passed, 21 skipped, 3 xfailed**.
Acceptance criteria re-verified by direct execution, independently of the test suite.

## Known and deliberately not fixed here

- **`THBSplineSpace.coarsen` is non-deterministic, and was before this change.** Its
  `sorted(parents, key=-level)` has no tie-break, so within a level the order comes from set
  iteration, and that decides the block partition and therefore the flat id of most cells.
  Adding a lexicographic tie-break changes observable behaviour, which this ticket forbids, so
  it is left alone and needs its own ticket. `coarsen_cells` itself is fully deterministic
  (deepest-first, then lexicographic) and the asymmetry is commented.
- `coarsen_cells` returns `None`, mirroring `refine_cells` as specified, so a caller cannot
  tell "I named four families and one was demoted" from "four were" — while the sibling box
  `coarsen` raises and names the blocking cells. Adding a return later is source-compatible.
- `Sequence[int]` rejects the `np.flatnonzero(mask)` that naturally produces cell ids. Widening
  to `ArrayLike` is right but should be done together with `refine_cells`.
- Per-parent coarsening is slow on a fragmented mesh (1024 parents over 2050 cells takes 5.2 s,
  each demotion repacking the block lists). Measured at 5199 ms before and 5160 ms after, so
  this change does not regress it; it is the pre-existing cost of the per-parent loop, now also
  reachable from the grid.
- `docs/changelog.md` deliberately untouched, since three parallel branches would collide
  there. Entry text is ready and lands with the other two.
