### PR TITLE
docs: record what the wave landed, and the two traps a local green cannot show you

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,20 @@ The local suite passing is necessary but not sufficient. Known traps:
   stale editable install (one pointing at a deleted worktree) makes them fail with
   `ModuleNotFoundError` while the rest of the suite passes. Repair it with
   `pip install -e ".[dev]"` **from the main checkout**, never from a worktree.
+- **The local suite cannot see a result that depends on the BLAS implementation.** macOS
+  links numpy against Accelerate while CI runs OpenBLAS, so any quantity round-off
+  dominates can differ between them by orders of magnitude. Measured here: the relative
+  error of one degree-13 matrix inverse was `9.56` locally and `0.0335` on CI, and the
+  local sequence was not even monotone in degree, which is the giveaway that the number is
+  noise rather than error. A threshold fitted to a measurement taken on one machine is not
+  a threshold. Derive the bound from exact arithmetic (conditioning, epsilon, degree) and
+  it transfers; measure it and CI will disagree with you.
+- **`PYTHONPATH=src` relative is not safe under `conda run`.** It resolves against the
+  working directory `conda run` gives the process, which can be the main checkout rather
+  than your worktree, so the command silently exercises the *installed* package instead of
+  the branch — seen as 21 phantom failures against code that was already fixed. Use
+  `PYTHONPATH="$(pwd)/src"`. Plain `pytest` is unaffected, since `pytest.ini`'s
+  `pythonpath = src` resolves against the rootdir.
 - **CI is the finish line, not the push.** After creating a PR, watch it (`gh pr checks <n> --watch`)
   and do not report the work as done until every required check passes. Avoid pushing twice in quick
   succession: `ci.yaml` sets `cancel-in-progress: true`, so a second push cancels the first run's

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,11 @@
 - `Bspline.locate`: point inversion from physical to parametric coordinates,
   batched over all points, returning the cell and the parameters. The default
   tolerance scales with the coordinate magnitude, not only with the bounding-box
-  diagonal, so a geometry far from the origin does not silently lose points.
+  diagonal, so a geometry far from the origin does not silently lose points, and it
+  carries what the *parametrization* can resolve as well: one ulp of a parametric
+  coordinate becomes a physical residual of about `eps * |xi|`, so a knot span far
+  from the origin relative to its width was being held to a residual no representable
+  parameter could reach, and every query on such a patch came back not found.
 - `BsplineSpace.boundary_dofs`: the control-point indices of a boundary slab of
   chosen thickness, on a chosen face.
 - `BsplineSpace.cell_supports` and `BsplineSpace1D.first_basis_per_interval`:
@@ -48,8 +52,27 @@
 - `Bezier.degree_reduction_error`: the exact $L^2$ norm of the error
   `Bezier.reduce_degree` would introduce, computed through the Bernstein mass
   matrix rather than by sampling.
+- `HierarchicalGrid.coarsen_cells`: the cell-exact counterpart of `coarsen`. It groups the
+  ids by parent and demotes a parent only when every one of its children is both an active
+  leaf and named, so it can never destroy a cell the caller did not list, which the box
+  `coarsen` can after two overlapping refines. The box form stays, and stays cheaper for a
+  region known to be uniformly refined. `THBSplineSpace.coarsen` now runs on it and keeps
+  only its admissibility guard, which has to stay a per-parent loop: evaluating it against
+  the frozen input mesh instead of the evolving one changes the result on 94 of 600
+  randomized meshes.
+- `HierarchicalGrid.cell_id`: the flat id of an active leaf given its level and
+  multi-index, or `None`. The inverse of `cell_level` and `cell_multi_index`, and how a
+  caller re-resolves cells after a refine or a coarsen has reassigned ids.
 
 ### Rejected where it used to be accepted
+- **A weight disagreement between two rational Coons faces is refused at every model
+  size.** The edge check took one magnitude over a homogeneous control row, which mixes
+  coordinates (length times weight) with weights (dimensionless), so a weight error was
+  graded against the model's *length* and passed unnoticed once the model was large: a
+  weight off by four times the tolerance was accepted at every coordinate scale from 1e2
+  up, and the volume then missed faces the caller had supplied correctly. Control-point
+  columns are now split into groups that each share a physical dimension and each graded
+  against their own magnitude. The rule lives in one place, shared with `join`.
 - **A knot vector whose spacing is finer than its dtype resolves at its own coordinate
   magnitude is now refused at construction**, where it used to be accepted and then
   silently behave as if it had no intervals. `BsplineSpace1D` raises a `ValueError`
@@ -207,6 +230,22 @@
   endpoint condition and still returns the mean of the control points.
 
 ### Fixed
+- **`create_coons_volume` builds from rational faces** instead of failing with a NumPy
+  shape error. The seven-term blend was already formed from homogeneous coefficients
+  throughout; only the corner read left that space, through `boundary()`, which projects.
+  Corners are now read homogeneously. The boundary property survives projection because
+  projection is pointwise and therefore commutes with restriction to a face, provided the
+  faces agree in *homogeneous* data, weights included, rather than merely projectively. A
+  rational volume is additionally refused when its weight field is not certified positive:
+  the blend is an inclusion-exclusion and subtracts three of its terms, so positive face
+  weights do not imply a positive weight field inside, while `w(u) >= min_i w_i` over a
+  non-negative partition of unity lets the result's own control weights bound it from
+  below. That test is sufficient and not necessary, and says so where it refuses.
+- **The Coons boundary checks are graded at the input's own precision.** The tier was read
+  at float64 whatever the model's dtype, so a float32 patch whose corner is as close as
+  the format allows was refused for a disagreement float32 cannot express, by a factor of
+  `eps32 / (4096 eps64) = 2**17`. `create_coons_surface` also stops promoting a float32
+  model to float64, matching `create_ruled` and `make_compat`.
 - Knot snapping merged the wrong knots, and from `|knot| ≈ 5` upward merged none
   at all. `BsplineSpace1D._snap_knots` rounded onto a grid of width `tolerance`,
   which was an absolute per-dtype constant: at knot 1.0 the grid was 4.5 ulp wide


### PR DESCRIPTION
The bookkeeping the three parallel branches of this wave deliberately left alone, plus the two
traps that wave taught us.

## Changelog

`docs/changelog.md` was the one file three concurrent worktrees would have collided in, so all
three branches skipped it and three merged changes reached `main` unrecorded. This adds them:

- **`Bspline.locate`'s existing bullet** now states the parametric-resolution term too. locate
  has not shipped, so its `Added` entry is amended rather than a `Fixed` entry appended —
  the changelog should describe what the release will contain, not the path taken to it.
- **`HierarchicalGrid.coarsen_cells` and `cell_id`**, the new public surface.
- **The Coons work**: rational support, the precision fix, and the weight disagreement that is
  now refused at every model size (under *Rejected where it used to be accepted*, which is
  what it is).

## Two traps in `CLAUDE.md`

Both were paid for during this wave, and both share a property that makes them worth writing
down: the local suite passes.

- **A result that depends on the BLAS implementation.** macOS links numpy against Accelerate,
  CI runs OpenBLAS. The same degree-13 matrix inverse measured a relative error of `9.56`
  locally and `0.0335` on CI. The local sequence was not even monotone in degree, which is how
  you tell the number is round-off rather than error. This cost a red check on a branch whose
  full suite was green locally: a domain boundary had been fitted to the local measurement.
  Derive such a bound from exact arithmetic and it transfers.
- **`PYTHONPATH=src` relative under `conda run`** resolves against the working directory
  `conda run` hands the process, which can be the main checkout rather than the worktree, so
  the command exercises the *installed* package instead of the branch. Seen as 21 phantom
  failures against code that was already fixed. `PYTHONPATH="$(pwd)/src"` fixes it; plain
  `pytest` was never affected, since `pytest.ini`'s `pythonpath = src` resolves against the
  rootdir.

## Checks

ruff, ruff format, mypy (233 files), `lint-imports` (1 contract kept), pytest **5860 passed,
21 skipped, 3 xfailed**. Docs build clean under `-W --keep-going` with gallery execution
suppressed, which is the only way it runs on macOS (the gallery segfaults without a GL
context, identically on `main` — three independent confirmations during this wave).

No source change: markdown only.
