### PR TITLE
refactor(bspline): stop locate at the accuracy it owes, accept at what the map can attain

### DIFF
--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -285,13 +285,17 @@ class Bspline:
                 one point of ``rank`` coordinates, except when ``rank == 1``, where it is
                 ``n`` scalar coordinates.
             tol (float | None): Convergence threshold on ``||F(xi) - x||_2``, as an
-                absolute distance in physical units. ``None`` (default) uses
-                :func:`pantr.tolerance.get_default` for this B-spline's dtype, scaled by
-                the largest of three lengths: the control-point bounding-box diagonal, the
-                largest coordinate magnitude, and the physical length one ulp of a
-                parametric coordinate spans. The last is what keeps the threshold
-                reachable for a knot vector far from the parametric origin, whose
-                coordinates a float64 resolves only to ``eps * |xi|``. Defaults to None.
+                absolute distance in physical units, governing where the iteration stops
+                as well as what counts as found. ``None`` (default) separates the two:
+                :func:`pantr.tolerance.get_default` for this B-spline's dtype times the
+                larger of the control-point bounding-box diagonal and the largest
+                coordinate magnitude is where the iteration stops, and the same tier
+                times that length maximised against the physical length one ulp of a
+                parametric coordinate spans is what counts as found. The second is what
+                keeps the verdict reachable for a knot vector far from the parametric
+                origin, whose coordinates a float64 resolves only to ``eps * |xi|``; the
+                first is what keeps the answer as accurate as the geometry allows anyway.
+                They are equal for a knot vector spanning ``[0, L]``. Defaults to None.
             max_iter (int): Maximum number of Newton steps per candidate cell.
                 Defaults to 30.
 
@@ -334,11 +338,12 @@ class Bspline:
             on the original ``float32`` B-spline therefore reproduces the query point to
             ``float32`` accuracy only.
 
-            The default threshold grows with how far the knot vector sits from the
-            parametric origin, because that is how far one ulp of a coordinate moves the
-            image. A "found" verdict on such a geometry therefore asserts less than the
-            same verdict on one parametrized from the origin. It stays a small fraction of
-            the geometry for any ordinary knot vector; at a reach of ``1e13`` -- a knot
+            The default *acceptance* threshold grows with how far the knot vector sits
+            from the parametric origin, because that is how far one ulp of a coordinate
+            moves the image. A "found" verdict on such a geometry therefore asserts less
+            than the same verdict on one parametrized from the origin, though the
+            coordinate itself is still refined as far as the map allows. It stays a small
+            fraction of the geometry for any ordinary knot vector; at a reach of ``1e13`` -- a knot
             span ten trillion times further from the origin than it is wide -- it reaches
             ``0.14`` of the bounding-box diagonal, and a point ten percent outside the
             image is reported found. Past ``1 / (64 * eps)`` the default is refused

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -306,8 +306,12 @@ class Bspline:
             convention of :func:`pantr.grid.tensor_product_grid` and
             :class:`SpanwiseElementExtraction`. ``ref_coords`` has shape ``(n, dim)``
             and holds *parametric* (not cell-local) coordinates satisfying
-            ``evaluate(ref_coords[i]) == points[i]`` within ``tol``. A point not on the
-            mapping's image gets ``cell_ids[i] = -1`` and ``ref_coords[i] = nan``.
+            ``evaluate(ref_coords[i]) == points[i]`` within ``tol``, or -- when ``tol`` is
+            ``None`` -- within the acceptance threshold described under ``tol`` above. That
+            is the bar a coordinate is certified against and not usually the accuracy it
+            carries, which is the tighter of the two thresholds wherever the map can deliver
+            it. A point not on the mapping's image gets ``cell_ids[i] = -1`` and
+            ``ref_coords[i] = nan``.
 
         Raises:
             NotImplementedError: If ``rank > dim`` (an embedded curve or surface, which

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -1039,20 +1039,42 @@ class _LocateThresholds(NamedTuple):
     image, which dominate the cost of a bad batch, are unchanged at ``1.00x``: they never
     reach either threshold, so their trajectories are identical. A worst case of ``1.6x`` on
     the evaluation count, confined to geometry parametrized a million widths from the
-    origin, is what the accuracy above is bought with.
+    origin, is what the accuracy above is bought with. Those are this fixture's ratios, not
+    the range's: over 54 configurations (dimensions 1 to 3, degrees 1/3/5, ``n_elem`` 2/6,
+    reach ``1e4``/``1e6``/``1e8``, both target families) the worst measured is ``1.82x`` map
+    evaluations and ``1.53x`` Jacobians.
+
+    **How a solve now ends, which the split changes.** An on-image query used to terminate
+    by the convergence test; under the split it terminates by the line search stalling at
+    the parametric floor, or by ``max_iter``. So the iteration count is no longer bounded by
+    a threshold the map can meet, and ``max_iter`` is the only bound left. Measured, that
+    bound is not close: the maximum accepted steps per solve is 11 against a default budget
+    of 30, and doubling and quadrupling the budget moves neither the step count nor the
+    worst residual (identical to every digit at 30, 60 and 120), so the iteration is
+    stopping because it has run out of progress and not because it has run out of budget.
+    That is measured on the fixtures here rather than derived, and it is the property to
+    re-check if the tier is ever loosened or :data:`_ARMIJO_DECREASE` tightened.
 
     An explicit ``tol`` sets both. A caller who names a threshold has taken responsibility
     for what it means and may well be asking a proximity question rather than an inversion
     one, and refining past it would charge them for accuracy they did not ask for.
 
-    **The ordering is relied on, not enforced.** It holds by construction --
-    :func:`_geometric_scale` is a maximum over :func:`_physical_scale`, and an explicit
-    ``tol`` sets both members to itself -- and :func:`_newton_refine` uses it: it returns
+    **The ordering is relied on, not enforced.** It is not merely constructed but
+    *unbreakable* by rounding: both members are the same positive ``tier`` times a length,
+    :func:`_geometric_scale` is a maximum over :func:`_physical_scale` so the lengths are
+    ordered, and IEEE round-to-nearest multiplication is monotone, so ``a >= b`` gives
+    ``fl(t * a) >= fl(t * b)``. It cannot round the wrong way, and where ``parametric <=
+    physical`` the two are the same expression and bit-identical. An explicit ``tol`` sets
+    both members to itself. :func:`_newton_refine` uses this: it returns
     ``res_norm <= accept`` alone, with no separate record of which rows stopped, because a
     row that stopped at ``stop`` necessarily passes ``accept``. Were ``accept < stop`` ever
     constructed, the loop would end against the larger number and the verdict be taken
     against the smaller, so nearly every query would be reported not found -- a silent
-    collapse of coverage indistinguishable from genuine non-invertibility. No guard is
+    collapse of coverage indistinguishable from genuine non-invertibility. That failure is
+    one-sided, and that is what makes a guard unnecessary rather than merely inconvenient:
+    it costs coverage, which the caller sees as ``-1`` and ``nan``, and can never return a
+    coordinate above ``accept`` (measured by forcing ``stop = k * accept`` for ``k`` to
+    ``1e6``: found drops steadily, rows accepted above ``accept`` stay at zero). No guard is
     added, for the same reason :class:`_NewtonState`'s three invariants carry none: both
     construction sites are in this module and a few lines from the definition. What stands
     in for one is the suite, which pins the relation in both regimes -- equality for a knot
@@ -1364,6 +1386,10 @@ def _locate_impl(
     # on a 16x16-cell patch, mean candidates per query: 4.0 (of 256) at parametric offsets
     # up to 1e9, 7.0 at 1e11, 57.1 at 1e13 -- the blow-up starting only where the verdict is
     # already near-meaningless and _default_tolerance is about to refuse outright.
+    # AABB.pad rounds to nearest rather than outward, so the realized pad falls short by up
+    # to half an ulp of the coordinate. Since eps * x is at least ulp(x), the pad is at least
+    # 64 ulp and the shortfall at most 0.8 % of it -- absorbed by the tier, but it would stop
+    # being negligible if the threshold were ever built from get_strict instead.
     candidates = [np.sort(context.bvh.query_aabb(AABB(x, x).pad(thresholds.accept))) for x in pts]
     pending = [i for i, cand in enumerate(candidates) if cand.size > 0]
     found: list[int] = []

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -557,11 +557,12 @@ def _geometric_scale(physical: float, parametric: float) -> float:
 
     **The parametric term.** The two lengths behind :func:`_physical_scale` are properties
     of the image alone, and a threshold built from them is equally unreachable whenever the
-    *parametrization* cannot resolve the geometry that finely. One ulp of a parametric coordinate is ``eps *
-    |xi_k|``, which the map turns into a physical displacement of ``eps * |xi_k| * ||J
-    e_k||``, so no representable parameter drives the residual below about half the
-    largest such step, however good the solver is. That is a floor of exactly the kind the
-    ``magnitude`` term already covers, and it is invisible to both of the other lengths:
+    *parametrization* cannot resolve the geometry that finely. One ulp of a parametric
+    coordinate is ``eps * |xi_k|``, which the map turns into a physical displacement of
+    ``eps * |xi_k| * ||J e_k||``, so no representable parameter drives the residual below
+    about half the largest such step, however good the solver is. That is a floor of exactly
+    the kind the ``magnitude`` term already covers, and it is invisible to both of the other
+    lengths:
     translating the knot vector changes it and changes neither of them. Measured on a
     unit-width span carrying the exactly affine map ``F(xi) = xi - offset``, against the
     threshold the two physical lengths alone give: the floor is ``0.008`` of it at offset
@@ -998,16 +999,16 @@ class _LocateThresholds(NamedTuple):
     parametrized on ``[1e6, 1e6 + 1]`` (degree 3, 4 elements per direction, 60 sampled
     parameters), where ``stop`` is ``2.53e-14`` and ``accept`` is ``1.47e-08``:
 
-    ==========================  =====================  ======  ===============
-    targets                     policy                 lost    worst residual
-    ==========================  =====================  ======  ===============
-    exact images                ``accept`` alone       0 / 60  ``1.20e-08``
-                                ``stop`` alone         4 / 60  ``2.46e-14``
-                                split                  0 / 60  ``4.99e-11``
-    a half ulp off the image    ``accept`` alone       0 / 60  ``1.19e-08``
-                                ``stop`` alone        60 / 60  --
-                                split                  0 / 60  ``1.88e-10``
-    ==========================  =====================  ======  ===============
+    ========================  ================  =======  ==============
+    targets                   policy            lost     worst residual
+    ========================  ================  =======  ==============
+    exact images              ``accept`` alone   0 / 60   ``1.20e-08``
+    exact images              ``stop`` alone     4 / 60   ``2.46e-14``
+    exact images              split              0 / 60   ``4.99e-11``
+    a half ulp off the image  ``accept`` alone   0 / 60   ``1.19e-08``
+    a half ulp off the image  ``stop`` alone    60 / 60   --
+    a half ulp off the image  split              0 / 60   ``1.88e-10``
+    ========================  ================  =======  ==============
 
     The split has the coverage of the looser threshold and 240 times the accuracy of it,
     with the median residual on exact images falling from ``3.8e-11`` to ``2.3e-16``. It
@@ -1022,18 +1023,33 @@ class _LocateThresholds(NamedTuple):
     ``1.000x`` map evaluations and ``1.000x`` Jacobians, because a physical offset moves
     both thresholds together. On the fixture above at parametric offset ``1e6``, where the
     split is at its widest: ``1.12x`` map evaluations for targets on the image and
-    ``1.61x`` for half-ulp targets, ``1.15x`` and ``1.25x`` Jacobians, and accepted Newton
-    steps rising from 359 to 430 and to 467 over the 60 solves -- the per-solve mode moving
-    from 5 to 6 and 7 and the maximum from 10 to 12, against a default budget of 30.
-    Queries **off** the mapping's image, which dominate the cost of a bad batch, are
-    unchanged at ``1.00x``: they never reach either threshold, so their trajectories are
-    identical. A worst case of ``1.6x`` on the evaluation count, confined to geometry
-    parametrized a million widths from the origin, is what the accuracy above is bought
-    with.
+    ``1.61x`` for half-ulp targets, and ``1.15x`` and ``1.25x`` Jacobians. Counting instead
+    the *accepted Newton steps* -- one step being one the line search actually took, and one
+    **solve** being one :func:`_newton_refine` row, so one query against one candidate cell
+    from one start, of which those 60 queries make 69 -- the totals go from 350 to 406 and
+    to 398, the median over the solves that step at all from 5 to 6, and the **maximum per
+    solve from 10 to 11**, against a default budget of 30. Queries **off** the mapping's
+    image, which dominate the cost of a bad batch, are unchanged at ``1.00x``: they never
+    reach either threshold, so their trajectories are identical. A worst case of ``1.6x`` on
+    the evaluation count, confined to geometry parametrized a million widths from the
+    origin, is what the accuracy above is bought with.
 
     An explicit ``tol`` sets both. A caller who names a threshold has taken responsibility
     for what it means and may well be asking a proximity question rather than an inversion
     one, and refining past it would charge them for accuracy they did not ask for.
+
+    **The ordering is relied on, not enforced.** It holds by construction --
+    :func:`_geometric_scale` is a maximum over :func:`_physical_scale`, and an explicit
+    ``tol`` sets both members to itself -- and :func:`_newton_refine` uses it: it returns
+    ``res_norm <= accept`` alone, with no separate record of which rows stopped, because a
+    row that stopped at ``stop`` necessarily passes ``accept``. Were ``accept < stop`` ever
+    constructed, the loop would end against the larger number and the verdict be taken
+    against the smaller, so nearly every query would be reported not found -- a silent
+    collapse of coverage indistinguishable from genuine non-invertibility. No guard is
+    added, for the same reason :class:`_NewtonState`'s three invariants carry none: both
+    construction sites are in this module and a few lines from the definition. What stands
+    in for one is the suite, which pins the relation in both regimes -- equality for a knot
+    vector spanning ``[0, L]``, strict inequality at a parametric offset.
 
     Attributes:
         stop (float): The residual at or below which the iteration stops, in physical

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -71,8 +71,15 @@ additionally quantize the parametric iterate at ``eps32``. Promotion removes bot
 the price of one exact cast: the arithmetic floor becomes ``1 - 3 * eps64 * scale``,
 which for a float32 caller is eight orders below the threshold it asks for, so what
 limits the answer is the precision the caller's data carries and not the solver. The
-returned coordinates invert the promoted mapping to float64 accuracy; evaluating them
-on the original ``float32`` spline reproduces the query point to float32 accuracy only.
+returned coordinates invert the promoted mapping to the accuracy the caller's own
+tolerance tier names, ``64 * eps(dtype) * physical`` -- *not* to float64 accuracy, which
+the solver could reach but is never asked for: :func:`_default_tolerance` takes the tier
+from the caller's dtype. Measured on a float32 unit patch at the origin, against targets
+that are exact images of the promoted map: worst residual ``1.07e-05`` against a stopping
+threshold of ``1.08e-05``, where the float64 tier would have demanded ``2.01e-14``. So a
+float32 caller's answer is capped at their declared precision, 5.3e8 above what the
+iteration is capable of, and evaluating it on the original ``float32`` spline reproduces
+the query point to float32 accuracy only.
 
 v1 inverts square maps only (``rank == dim``): planar and volumetric geometry maps. An
 embedded curve or surface (``rank > dim``) needs a Gauss-Newton closest-point solve,

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -546,20 +546,18 @@ def _physical_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) ->
     return scale if scale > 0.0 else 1.0
 
 
-def _geometric_scale(
-    lo: npt.NDArray[np.float64],
-    hi: npt.NDArray[np.float64],
-    parametric: float,
-) -> float:
-    """Return the length the default convergence tolerance is a multiple of.
+def _geometric_scale(physical: float, parametric: float) -> float:
+    """Return the length the default *acceptance* threshold is a multiple of.
 
-    The larger of two lengths: the physical one of :func:`_physical_scale`, and the
+    The larger of two lengths: the image-only one of :func:`_physical_scale`, and the
     **parametric** length of :func:`_parametric_scale`, because a parametric coordinate is
     a float64 too and the residual cannot be resolved below what one ulp of it produces.
+    Which of the two thresholds this length serves, and which one
+    :func:`_physical_scale` serves alone, is settled in :class:`_LocateThresholds`.
 
-    **The parametric term.** The first two lengths are properties of the image alone, and
-    a threshold built from them is equally unreachable whenever the *parametrization*
-    cannot resolve the geometry that finely. One ulp of a parametric coordinate is ``eps *
+    **The parametric term.** The two lengths behind :func:`_physical_scale` are properties
+    of the image alone, and a threshold built from them is equally unreachable whenever the
+    *parametrization* cannot resolve the geometry that finely. One ulp of a parametric coordinate is ``eps *
     |xi_k|``, which the map turns into a physical displacement of ``eps * |xi_k| * ||J
     e_k||``, so no representable parameter drives the residual below about half the
     largest such step, however good the solver is. That is a floor of exactly the kind the
@@ -665,16 +663,14 @@ def _geometric_scale(
     there as well and the maximum is the fallback.
 
     Args:
-        lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
-            ``(n_cells, rank)``.
-        hi (npt.NDArray[np.float64]): Per-cell box upper corners, same shape.
+        physical (float): The image-only length from :func:`_physical_scale`, which already
+            carries the strictly-positive fallback.
         parametric (float): The parametric length from :func:`_parametric_scale`.
 
     Returns:
-        float: The geometric scale, strictly positive and never below
-        :func:`_physical_scale`.
+        float: The geometric scale, strictly positive and never below ``physical``.
     """
-    return max(_physical_scale(lo, hi), parametric)
+    return max(physical, parametric)
 
 
 def _build_context(spline: Bspline) -> _LocateContext:
@@ -693,12 +689,13 @@ def _build_context(spline: Bspline) -> _LocateContext:
     # Read from the caller's spline, not the promoted one: the precision ratio it applies
     # has to see the format the caller's tier will be taken from.
     parametric = _parametric_scale(spline)
+    physical = _physical_scale(lo, hi)
     box_lo, box_hi = lo.min(axis=0), hi.max(axis=0)
     return _LocateContext(
         spline=spline_64,
         bvh=BVH.from_cell_bounds(lo, hi),
-        scale=_geometric_scale(lo, hi, parametric),
-        physical=_physical_scale(lo, hi),
+        scale=_geometric_scale(physical, parametric),
+        physical=physical,
         diagonal=float(np.linalg.norm(box_hi - box_lo)),
         parametric=parametric,
     )

--- a/src/pantr/bspline/_bspline_locate.py
+++ b/src/pantr/bspline/_bspline_locate.py
@@ -31,6 +31,13 @@ The inversion has two stages:
    step to reduce the residual removes both failure modes at once, and makes the residual
    of the accepted iterates a monotonically non-increasing sequence.
 
+   Stopping and acceptance are two different thresholds: the iteration runs until the
+   residual is below what the *image* alone entitles the caller to, and a result counts as
+   found once it is below what the *parametrization* can attain. On a knot vector far from
+   the parametric origin those are decades apart, and serving both from one number would
+   hand back the looser of them. :class:`_LocateThresholds` derives the split, and
+   :func:`_default_tolerance` builds the two numbers.
+
    What damping cannot do is change which root the iteration finds. A monotone method
    descends into whichever basin it starts in, and on a mapping that folds, the residual
    has minima on the domain boundary that are not roots; a start that descends into one of
@@ -274,9 +281,13 @@ class _LocateContext(NamedTuple):
             when it is already ``float64``, otherwise an exact promoted copy.
         bvh (BVH): Hierarchy over the per-cell physical control-point boxes, with cell
             ids flat in C-order over ``space.num_intervals``.
-        scale (float): The length the default tolerance is expressed in, covering the
-            geometry's size, its distance from the origin, and what its parametrization
-            can resolve; see :func:`_geometric_scale`.
+        scale (float): The length the default *acceptance* threshold is expressed in,
+            covering the geometry's size, its distance from the origin, and what its
+            parametrization can resolve; see :func:`_geometric_scale`. It is
+            ``max(physical, parametric)``.
+        physical (float): The image-only half of that scale, which the default *stopping*
+            threshold is expressed in; see :func:`_physical_scale` and
+            :class:`_LocateThresholds`.
         diagonal (float): The geometry's own bounding-box diagonal, kept alongside the
             scale it feeds because :func:`_locate_impl` grades the parametric term against
             it before accepting a default threshold.
@@ -287,6 +298,7 @@ class _LocateContext(NamedTuple):
     spline: Bspline
     bvh: BVH
     scale: float
+    physical: float
     diagonal: float
     parametric: float
 
@@ -486,6 +498,54 @@ def _parametric_scale(spline: Bspline) -> float:
     return precision_ratio * float(products.max())
 
 
+def _physical_scale(lo: npt.NDArray[np.float64], hi: npt.NDArray[np.float64]) -> float:
+    """Return the length the *accuracy* a returned coordinate is entitled to is a multiple of.
+
+    Two lengths matter and the larger one has to win:
+
+    - the **diagonal** of the geometry's bounding box, which is what makes a residual
+      threshold a *relative* accuracy statement about the mapping;
+    - the largest coordinate **magnitude** present, because the computed residual
+      ``F(xi) - x`` cannot be resolved below ``~C * eps * max|coordinate|`` (the de Boor
+      sum accumulates ``C`` roundings, of the order of ``prod(degree + 1)``), whatever
+      the box's extent is.
+
+    Using the diagonal alone silently makes the tolerance unreachable for a geometry far
+    from the origin -- a patch of diameter 1 sitting at ``x = 1e6`` has a residual floor
+    around ``1e-10`` while ``eps * 1`` would be demanded -- so the scale is the maximum
+    of the two.
+
+    Both are properties of the **image** alone. Nothing about the parametrization enters,
+    which is exactly what makes this the length the accuracy contract is read off:
+    reparametrizing a geometry does not change what a caller may expect of a coordinate it
+    gets back. :func:`_geometric_scale` adds the length the parametrization *can resolve*,
+    which is a different question and gets a different threshold; :class:`_LocateThresholds`
+    is where the two are separated.
+
+    A geometry with no length at all -- every control point identical, *at the origin* --
+    falls back to ``1.0``: there is nothing to read a scale off, and the tolerance must
+    stay positive. That fallback is deliberately not a floor of one. A floor would make the
+    tolerance stop shrinking below unit size, so a model in metres and the same model in
+    kilometres would be held to different relative accuracies, which is exactly the
+    non-covariance the rest of this derivation exists to remove. A degenerate geometry
+    sitting *away* from the origin has a magnitude and uses it.
+
+    Args:
+        lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
+            ``(n_cells, rank)``.
+        hi (npt.NDArray[np.float64]): Per-cell box upper corners, same shape.
+
+    Returns:
+        float: The physical scale, strictly positive.
+    """
+    box_lo = lo.min(axis=0)
+    box_hi = hi.max(axis=0)
+    diagonal = float(np.linalg.norm(box_hi - box_lo))
+    magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
+    scale = max(diagonal, magnitude)
+    return scale if scale > 0.0 else 1.0
+
+
 def _geometric_scale(
     lo: npt.NDArray[np.float64],
     hi: npt.NDArray[np.float64],
@@ -493,22 +553,9 @@ def _geometric_scale(
 ) -> float:
     """Return the length the default convergence tolerance is a multiple of.
 
-    Three lengths matter and the largest one has to win:
-
-    - the **diagonal** of the geometry's bounding box, which is what makes a residual
-      threshold a *relative* accuracy statement about the mapping;
-    - the largest coordinate **magnitude** present, because the computed residual
-      ``F(xi) - x`` cannot be resolved below ``~C * eps * max|coordinate|`` (the de Boor
-      sum accumulates ``C`` roundings, of the order of ``prod(degree + 1)``), whatever
-      the box's extent is; and
-    - the **parametric** length of :func:`_parametric_scale`, because a parametric
-      coordinate is a float64 too and the residual cannot be resolved below what one ulp
-      of it produces.
-
-    Using the diagonal alone silently makes the tolerance unreachable for a geometry far
-    from the origin -- a patch of diameter 1 sitting at ``x = 1e6`` has a residual floor
-    around ``1e-10`` while ``eps * 1`` would be demanded -- so the scale is the maximum
-    of them all.
+    The larger of two lengths: the physical one of :func:`_physical_scale`, and the
+    **parametric** length of :func:`_parametric_scale`, because a parametric coordinate is
+    a float64 too and the residual cannot be resolved below what one ulp of it produces.
 
     **The parametric term.** The first two lengths are properties of the image alone, and
     a threshold built from them is equally unreachable whenever the *parametrization*
@@ -605,13 +652,17 @@ def _geometric_scale(
     no dependence on ``prod(degree + 1)`` across 3 to 125. The default tier stays, now for
     a stated reason rather than by a margin that was an artifact of the measurement.
 
-    A geometry with no length at all -- every control point identical, *at the origin* --
-    falls back to ``1.0``: there is nothing to read a scale off, and the tolerance must
-    stay positive. That fallback is deliberately not a floor of one. A floor would make the
-    tolerance stop shrinking below unit size, so a model in metres and the same model in
-    kilometres would be held to different relative accuracies, which is exactly the
-    non-covariance the rest of this derivation exists to remove. A degenerate geometry
-    sitting *away* from the origin has a magnitude and uses it.
+    That the achieved residual *tracks* the threshold is also why this length may not be
+    what the iteration stops at. A threshold this one raises to cover what the
+    parametrization can resolve would, as a stopping rule, hand back exactly that much error
+    on geometry whose answer was far more accurate one iteration on. Which of the two
+    thresholds governs stopping and which governs acceptance is settled in
+    :class:`_LocateThresholds`.
+
+    The degenerate fallback lives in :func:`_physical_scale` and covers this function too:
+    the physical scale vanishes only when every control point is identical and at the
+    origin, and such a geometry has no net span in any direction, so ``parametric`` is zero
+    there as well and the maximum is the fallback.
 
     Args:
         lo (npt.NDArray[np.float64]): Per-cell box lower corners, shape
@@ -620,14 +671,10 @@ def _geometric_scale(
         parametric (float): The parametric length from :func:`_parametric_scale`.
 
     Returns:
-        float: The geometric scale, strictly positive.
+        float: The geometric scale, strictly positive and never below
+        :func:`_physical_scale`.
     """
-    box_lo = lo.min(axis=0)
-    box_hi = hi.max(axis=0)
-    diagonal = float(np.linalg.norm(box_hi - box_lo))
-    magnitude = float(max(np.abs(box_lo).max(), np.abs(box_hi).max()))
-    scale = max(diagonal, magnitude, parametric)
-    return scale if scale > 0.0 else 1.0
+    return max(_physical_scale(lo, hi), parametric)
 
 
 def _build_context(spline: Bspline) -> _LocateContext:
@@ -639,7 +686,7 @@ def _build_context(spline: Bspline) -> _LocateContext:
 
     Returns:
         _LocateContext: The promoted spline, the BVH over its per-cell physical boxes,
-        and the geometric scale.
+        and the lengths the two default thresholds are expressed in.
     """
     spline_64 = _promote_to_float64(spline)
     lo, hi = _cell_physical_bounds(spline_64)
@@ -651,6 +698,7 @@ def _build_context(spline: Bspline) -> _LocateContext:
         spline=spline_64,
         bvh=BVH.from_cell_bounds(lo, hi),
         scale=_geometric_scale(lo, hi, parametric),
+        physical=_physical_scale(lo, hi),
         diagonal=float(np.linalg.norm(box_hi - box_lo)),
         parametric=parametric,
     )
@@ -908,21 +956,120 @@ def _accept_damped_step(
     return accepted
 
 
+class _LocateThresholds(NamedTuple):
+    """The two residual thresholds a solve is governed by, with ``stop <= accept``.
+
+    One number cannot do both jobs. ``stop`` is the **accuracy contract** -- what a caller
+    is entitled to expect of a coordinate that comes back -- and ``accept`` is an
+    **attainability** statement: the residual below which no representable parameter can
+    go, so that a query whose exact preimage is unrepresentable is still reported found.
+    Serving both from one number forces the accuracy contract up to the attainability
+    bound, and it forces it all the way: the re-measurement recorded in
+    :func:`_geometric_scale` found the achieved residual tracking whatever threshold is
+    set, to within one part in a hundred, at every tier from ``2`` to ``4096`` epsilons. So
+    :func:`_newton_refine` keeps iterating while the residual is above ``stop``, and takes
+    the verdict at ``accept``.
+
+    **Why only ``accept`` grows with the parametrization.** ``stop`` is
+    ``get_default(dtype) * physical`` with the length of :func:`_physical_scale`, read off
+    the **image** alone; ``accept`` is the same tier times that length maximised against
+    :func:`_parametric_scale`. How finely a float64 parametric coordinate resolves the
+    geometry decides whether a solution *exists* among representable parameters. It says
+    nothing about the accuracy a caller is owed, which is a property of the image and of
+    nothing else -- reparametrizing a geometry may not change what an answer is worth. For
+    a knot vector spanning ``[0, L]`` the two are equal **bit for bit** (the reach is
+    exactly ``1.0`` and no net span exceeds the diagonal), so nothing parametrized from the
+    origin sees any of this, in accuracy or in cost.
+
+    **Coverage cannot shrink, by construction rather than by measurement.** Every accepted
+    step strictly reduces the residual (:data:`_ARMIJO_DECREASE`), so the residuals of the
+    accepted iterates are monotonically non-increasing. Lowering the *stopping* test from
+    ``accept`` to ``stop`` therefore only extends trajectories the single-threshold
+    iteration would have cut short, and a row whose residual once passed ``accept`` still
+    passes it at exit, however many further steps it takes and whether it ends by
+    converging, by exhausting the line search, by meeting the rank guard or by running out
+    of budget. The queries reported found under the split are a superset of those reported
+    found under ``accept`` alone, on every map. No appeal to the redundancy of candidate
+    cells or of the second start is needed.
+
+    **What each verdict certifies.** ``converged`` is a test on the residual the solve
+    actually achieved, taken once at the end, so no coordinate is returned that fails the
+    threshold it is graded against -- including one whose starting guess was already inside
+    ``accept`` and which the iteration then moved.
+
+    **What it buys.** Measured on a warped unit patch whose second direction is
+    parametrized on ``[1e6, 1e6 + 1]`` (degree 3, 4 elements per direction, 60 sampled
+    parameters), where ``stop`` is ``2.53e-14`` and ``accept`` is ``1.47e-08``:
+
+    ==========================  =====================  ======  ===============
+    targets                     policy                 lost    worst residual
+    ==========================  =====================  ======  ===============
+    exact images                ``accept`` alone       0 / 60  ``1.20e-08``
+                                ``stop`` alone         4 / 60  ``2.46e-14``
+                                split                  0 / 60  ``4.99e-11``
+    a half ulp off the image    ``accept`` alone       0 / 60  ``1.19e-08``
+                                ``stop`` alone        60 / 60  --
+                                split                  0 / 60  ``1.88e-10``
+    ==========================  =====================  ======  ===============
+
+    The split has the coverage of the looser threshold and 240 times the accuracy of it,
+    with the median residual on exact images falling from ``3.8e-11`` to ``2.3e-16``. It
+    does **not** reach ``stop`` on every query, and cannot: at this reach one ulp of the
+    parametric coordinate already moves the image by ``2.3e-10``. What it reaches is the
+    parametric grid's own floor -- the half-ulp worst case of ``1.88e-10`` equals, to five
+    digits, the best residual any parameter within two ulps of the true preimage attains.
+
+    **What it costs.** Where the two coincide the code path is identical, and the
+    ``2400``-query warped-map sweep of ``tests/test_bspline_locate.py`` (60 configurations,
+    dimensions 1 to 3, degrees 1 to 5, physical offsets ``0`` and ``1e6``) measures
+    ``1.000x`` map evaluations and ``1.000x`` Jacobians, because a physical offset moves
+    both thresholds together. On the fixture above at parametric offset ``1e6``, where the
+    split is at its widest: ``1.12x`` map evaluations for targets on the image and
+    ``1.61x`` for half-ulp targets, ``1.15x`` and ``1.25x`` Jacobians, and accepted Newton
+    steps rising from 359 to 430 and to 467 over the 60 solves -- the per-solve mode moving
+    from 5 to 6 and 7 and the maximum from 10 to 12, against a default budget of 30.
+    Queries **off** the mapping's image, which dominate the cost of a bad batch, are
+    unchanged at ``1.00x``: they never reach either threshold, so their trajectories are
+    identical. A worst case of ``1.6x`` on the evaluation count, confined to geometry
+    parametrized a million widths from the origin, is what the accuracy above is bought
+    with.
+
+    An explicit ``tol`` sets both. A caller who names a threshold has taken responsibility
+    for what it means and may well be asking a proximity question rather than an inversion
+    one, and refining past it would charge them for accuracy they did not ask for.
+
+    Attributes:
+        stop (float): The residual at or below which the iteration stops, in physical
+            units. The accuracy contract.
+        accept (float): The residual at or below which the result counts as found, in
+            physical units. Never below ``stop``.
+    """
+
+    stop: float
+    accept: float
+
+
 def _newton_refine(
     spline: Bspline,
     targets: npt.NDArray[np.float64],
     xi_start: npt.NDArray[np.float64],
-    tol_phys: float,
+    thresholds: _LocateThresholds,
     max_iter: int,
 ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
     """Run a batched damped Newton inversion, one starting guess per target point.
 
     Every point is iterated independently but evaluated collectively: each round drops the
-    points that have converged, the points whose Jacobian has become rank-deficient, and
-    the points whose line search was exhausted, then takes one damped Newton step for the
-    rest. Iterates are clamped to the parametric domain box, which keeps them inside the
-    evaluators' legal input range; it is :func:`_accept_damped_step`, not the clamp, that
-    bounds an overlong step from an ill-conditioned Jacobian.
+    points that have reached ``thresholds.stop``, the points whose Jacobian has become
+    rank-deficient, and the points whose line search was exhausted, then takes one damped
+    Newton step for the rest. Iterates are clamped to the parametric domain box, which
+    keeps them inside the evaluators' legal input range; it is :func:`_accept_damped_step`,
+    not the clamp, that bounds an overlong step from an ill-conditioned Jacobian.
+
+    Stopping and acceptance are two different thresholds and the reason is in
+    :class:`_LocateThresholds`. Only ``thresholds.stop`` ends a trajectory; the verdict is
+    a single test of the residual each point actually achieved against
+    ``thresholds.accept``, applied once at the end and therefore covering the points the
+    loop dropped as well as the ones that stopped.
 
     Because every accepted step reduces the residual, the residuals of the iterates form a
     monotonically non-increasing sequence. It is in fact strictly decreasing, hence free of
@@ -940,17 +1087,18 @@ def _newton_refine(
         targets (npt.NDArray[np.float64]): Physical query points, shape ``(n, rank)``.
         xi_start (npt.NDArray[np.float64]): Starting parametric guesses, shape
             ``(n, dim)``.
-        tol_phys (float): Convergence threshold on ``||F(xi) - x||_2``, a distance in
-            physical units.
-        max_iter (int): Maximum number of accepted Newton steps. The residual is tested
-            once more after the last step, so a point converging on step ``max_iter`` is
-            reported. The extra map evaluations a line search makes are not steps.
+        thresholds (_LocateThresholds): The stopping and acceptance thresholds on
+            ``||F(xi) - x||_2``, both distances in physical units.
+        max_iter (int): Maximum number of accepted Newton steps. Exhausting it is not a
+            verdict: the acceptance test is taken afterwards either way, so a point that
+            reached ``thresholds.accept`` on the way is still reported. The extra map
+            evaluations a line search makes are not steps.
 
     Returns:
         tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]: ``(converged, xi)``.
-        ``converged`` has shape ``(n,)``; ``xi`` has shape ``(n, dim)`` and holds each
-        point's last accepted iterate, which is a solution only where ``converged`` is
-        True.
+        ``converged`` has shape ``(n,)`` and is ``||F(xi) - x||_2 <= thresholds.accept``
+        row by row; ``xi`` has shape ``(n, dim)`` and holds each point's last accepted
+        iterate, which is a solution only where ``converged`` is True.
     """
     dim = xi_start.shape[1]
     domain = np.asarray(spline.space.domain, dtype=np.float64)
@@ -965,13 +1113,11 @@ def _newton_refine(
         lo=lo,
         hi=hi,
     )
-    # Tested before the first step, so a starting guess already inside the threshold is
-    # returned untouched. That is what makes the threshold a stopping rule and not only an
-    # acceptance rule: under a large one -- a geometry far from either origin -- the cell
-    # midpoint can pass here, and the coordinate that comes back is then accurate to the
-    # threshold rather than to what the map could have delivered.
-    converged = state.res_norm <= tol_phys
-    active = np.arange(xi.shape[0], dtype=np.int64)[~converged]
+    # Tested before the first step, so a starting guess already inside the stopping
+    # threshold is returned untouched. Under the acceptance one it would not be: on a
+    # geometry far from either origin a cell midpoint can already sit inside that, and
+    # returning it would deliver the bar rather than what the map can resolve.
+    active = np.arange(xi.shape[0], dtype=np.int64)[state.res_norm > thresholds.stop]
 
     for _ in range(max_iter):
         if active.size == 0:
@@ -989,11 +1135,9 @@ def _newton_refine(
         )[..., 0]
 
         active = active[_accept_damped_step(spline, targets, state, active, delta)]
-        done = state.res_norm[active] <= tol_phys
-        converged[active[done]] = True
-        active = active[~done]
+        active = active[state.res_norm[active] > thresholds.stop]
 
-    return converged, state.xi
+    return state.res_norm <= thresholds.accept, state.xi
 
 
 def _validate_points(points: npt.ArrayLike, rank: int) -> npt.NDArray[np.float64]:
@@ -1069,12 +1213,19 @@ def _validate_invertible(spline: Bspline, tol: float | None, max_iter: int) -> N
         raise ValueError(f"locate: tol must be positive and finite; got {tol}.")
 
 
-def _default_tolerance(spline: Bspline, context: _LocateContext) -> float:
-    """Return the default convergence threshold, or refuse a parametrization that has none.
+def _default_tolerance(spline: Bspline, context: _LocateContext) -> _LocateThresholds:
+    """Return the default thresholds, or refuse a parametrization that can carry none.
 
-    ``get_default(dtype) * scale``, with ``scale`` from :func:`_geometric_scale`, except
-    that a parametrization whose own resolution would demand a threshold larger than the
-    geometry it grades is refused instead of served.
+    ``get_default(dtype)`` times each of the two lengths the context carries: the
+    image-only one of :func:`_physical_scale` to stop at, and the one of
+    :func:`_geometric_scale` to accept at. :class:`_LocateThresholds` is where the split
+    itself is derived; this function only assembles the numbers, and refuses a
+    parametrization whose own resolution would demand a threshold larger than the geometry
+    it grades instead of serving it.
+
+    Both are the same tier applied to a length the geometry supplies, so neither introduces
+    a constant, and ``stop <= accept`` holds because :func:`_geometric_scale` is a maximum
+    over :func:`_physical_scale`.
 
     **Why refuse rather than clamp.** Past that point the answer carries no information: a
     "found" verdict admitting more than a whole diameter of error says only that the query
@@ -1109,11 +1260,12 @@ def _default_tolerance(spline: Bspline, context: _LocateContext) -> float:
         context (_LocateContext): Its cached inversion state.
 
     Returns:
-        float: The default threshold on ``||F(xi) - x||_2``, strictly positive.
+        _LocateThresholds: The default thresholds on ``||F(xi) - x||_2``, both strictly
+        positive.
 
     Raises:
-        ValueError: If the parametric term alone would put the threshold above the
-            geometry's own bounding-box diagonal.
+        ValueError: If the parametric term alone would put the acceptance threshold above
+            the geometry's own bounding-box diagonal.
     """
     tier = get_default(spline.dtype)
     if tier * context.parametric > context.diagonal:
@@ -1125,7 +1277,7 @@ def _default_tolerance(spline: Bspline, context: _LocateContext) -> float:
             "the knot vector nearer the parametric origin, or pass an explicit tol to say "
             "what distance you want."
         )
-    return tier * context.scale
+    return _LocateThresholds(stop=tier * context.physical, accept=tier * context.scale)
 
 
 def _locate_impl(
@@ -1141,9 +1293,8 @@ def _locate_impl(
             non-periodic, and, if rational, have strictly positive weights.
         points (npt.ArrayLike): Physical query points; see :func:`_validate_points`.
         tol (float | None): Convergence threshold on ``||F(xi) - x||_2`` as an absolute
-            distance in physical units, or ``None`` for
-            ``pantr.tolerance.get_default(spline.dtype) * scale``, with ``scale`` from
-            :func:`_geometric_scale`.
+            distance in physical units, governing stopping and acceptance alike, or
+            ``None`` for the pair :func:`_default_tolerance` builds.
         max_iter (int): Maximum number of Newton steps per candidate cell.
 
     Returns:
@@ -1173,21 +1324,27 @@ def _locate_impl(
 
     pts = _validate_points(points, rank)
     context = _locate_context(spline)
-    tol_phys = float(tol) if tol is not None else _default_tolerance(spline, context)
+    # An explicit tol governs stopping as well as acceptance; see :class:`_LocateThresholds`.
+    thresholds = (
+        _LocateThresholds(stop=float(tol), accept=float(tol))
+        if tol is not None
+        else _default_tolerance(spline, context)
+    )
 
     n_pts = pts.shape[0]
     cell_ids = np.full(n_pts, -1, dtype=np.int64)
     ref_coords = np.full((n_pts, dim), np.nan, dtype=np.float64)
 
     # Candidates per point, in ascending cell id: the order the rounds below try them in.
-    # The pad is the threshold itself, so a geometry whose threshold is large -- far from
-    # the physical origin, or far from the parametric one -- returns more candidate cells
-    # per query. That costs solves, never correctness: every extra candidate still has to
-    # pass the same residual test. Measured on a 16x16-cell patch, mean candidates per
-    # query: 4.0 (of 256) at parametric offsets up to 1e9, 7.0 at 1e11, 57.1 at 1e13 --
-    # the blow-up starting only where the verdict is already near-meaningless and
-    # _default_tolerance is about to refuse outright.
-    candidates = [np.sort(context.bvh.query_aabb(AABB(x, x).pad(tol_phys))) for x in pts]
+    # The pad is the *acceptance* threshold, which is the one a returned coordinate is
+    # graded against, so no cell that could hold a solution is missed. A geometry whose
+    # threshold is large -- far from the physical origin, or far from the parametric one --
+    # therefore returns more candidate cells per query. That costs solves, never
+    # correctness: every extra candidate still has to pass the same residual test. Measured
+    # on a 16x16-cell patch, mean candidates per query: 4.0 (of 256) at parametric offsets
+    # up to 1e9, 7.0 at 1e11, 57.1 at 1e13 -- the blow-up starting only where the verdict is
+    # already near-meaningless and _default_tolerance is about to refuse outright.
+    candidates = [np.sort(context.bvh.query_aabb(AABB(x, x).pad(thresholds.accept))) for x in pts]
     pending = [i for i, cand in enumerate(candidates) if cand.size > 0]
     found: list[int] = []
     slot = 0
@@ -1199,7 +1356,7 @@ def _locate_impl(
         cells = np.asarray([candidates[i][slot] for i in batch], dtype=np.int64)
 
         starts = _cell_midpoints(context.spline.space, cells)
-        converged, xi = _newton_refine(context.spline, pts[index], starts, tol_phys, max_iter)
+        converged, xi = _newton_refine(context.spline, pts[index], starts, thresholds, max_iter)
         ref_coords[index[converged]] = xi[converged]
 
         # Second start for the candidates the midpoint could not resolve; see
@@ -1210,7 +1367,7 @@ def _locate_impl(
             retry_index, retry_cells = index[retry], cells[retry]
             corner_starts = _nearest_corner_starts(context.spline, retry_cells, pts[retry_index])
             retried, xi = _newton_refine(
-                context.spline, pts[retry_index], corner_starts, tol_phys, max_iter
+                context.spline, pts[retry_index], corner_starts, thresholds, max_iter
             )
             ref_coords[retry_index[retried]] = xi[retried]
             converged[retry] = retried

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -418,8 +418,8 @@ def _physical_only_scale(spline: Bspline) -> float:
 
 
 def _scale_of(spline: Bspline) -> float:
-    """Return the geometric scale the default tolerance is expressed in."""
-    return _geometric_scale(*_cell_physical_bounds(spline), _parametric_scale(spline))
+    """Return the geometric scale the default acceptance threshold is expressed in."""
+    return _geometric_scale(_physical_only_scale(spline), _parametric_scale(spline))
 
 
 def _cache_of(spline: Bspline) -> _LocateContext | None:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -51,6 +51,28 @@ larger than in the ``float64`` case. Measured worst case over the cases below:
 ``5.2e-6``; the ``1e-4`` leaves a factor of 19.
 """
 
+_PARAMETRIC_ULPS_ALLOWED: float = 4.0
+"""
+How many parametric ulps' worth of residual a returned coordinate may carry.
+
+One ulp of a parametric coordinate is ``eps * |xi_k|``, which the map turns into a physical
+displacement of ``eps * |xi_k| * ||J e_k||``; :func:`_parametric_scale` is exactly that
+product with the control net's span standing in for the local stretch, so
+``eps * _parametric_scale(spline)`` is the physical length the parametrization quantizes at
+and no returned coordinate can do better than a fraction of it. The bound is therefore
+``_PARAMETRIC_ULPS_ALLOWED * eps * _parametric_scale(spline)``, which is the acceptance
+threshold divided by ``64 / _PARAMETRIC_ULPS_ALLOWED``.
+
+**Why four.** Two ulps for where the last Newton step lands relative to the true root, and a
+factor of two for the fixture's local stretch against the net-span average the substitution
+uses. Measured on :func:`_parametrically_offset_patch`: the worst residual is ``0.22`` of a
+single ulp's image for targets that are exact images and ``0.82`` for targets a half ulp off
+one, so the bound carries between five and eighteen times its measured requirement. The
+single-threshold policy it replaces violates it on 9 of 60 queries in both families, with a
+worst case of 52 ulps, so nothing about the number is delicate: no factor between 1 and 16
+separates the two policies differently.
+"""
+
 _PARAMETRIC_OFFSETS: list[float] = [0.0, 1.0e2, 1.0e3, 1.0e4, 1.0e6]
 """
 Parametric offsets of a unit-width knot span, spanning the resolution frontier.
@@ -161,10 +183,47 @@ def _warped_patch(dim: int = 2, degree: int = 1, n_elem: int = 6, offset: float 
     """
     knots = np.concatenate([np.zeros(degree), np.linspace(0.0, 1.0, n_elem + 1), np.ones(degree)])
     space = BsplineSpace([BsplineSpace1D(knots, degree) for _ in range(dim)])
+    return Bspline(space, np.ascontiguousarray(_warped_lattice(space) + offset))
+
+
+def _warped_lattice(space: BsplineSpace) -> npt.NDArray[np.float64]:
+    """Return the unit-box control lattice of ``space`` under the 15 % sinusoidal warp.
+
+    Shared by :func:`_warped_patch` and :func:`_parametrically_offset_patch` so that the
+    two differ in their *knot vectors* alone and any difference between them is
+    attributable to the parametrization.
+    """
     axes = [np.linspace(0.0, 1.0, n) for n in space.num_basis]
     cp = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1)
-    cp = cp + 0.15 * np.sin(2.0 * np.pi * cp.sum(axis=-1))[..., None] + offset
-    return Bspline(space, np.ascontiguousarray(cp))
+    return np.asarray(cp + 0.15 * np.sin(2.0 * np.pi * cp.sum(axis=-1))[..., None])
+
+
+def _parametrically_offset_patch(
+    degree: int = 3, n_elem: int = 4, offset: float = 1.0e6
+) -> Bspline:
+    """Return the warped unit patch with direction 1 parametrized on ``[offset, offset + 1]``.
+
+    The geometry is :func:`_warped_patch`'s, so the physical half of the threshold is the
+    one of a unit-sized patch at the origin; only direction 1's knot vector moves. That
+    separates the two halves as far as they go: direction 0 has reach zero and direction 1
+    reach ``offset``, so the acceptance threshold is six decades above the stopping one
+    while the geometry it grades is unchanged.
+
+    A bivariate map rather than a univariate one, and the offset in one direction only,
+    because that is the configuration in which the two thresholds are least alike.
+    """
+    spaces = []
+    for direction_offset in (0.0, offset):
+        knots = np.concatenate(
+            [
+                np.full(degree, direction_offset),
+                np.linspace(direction_offset, direction_offset + 1.0, n_elem + 1),
+                np.full(degree, direction_offset + 1.0),
+            ]
+        )
+        spaces.append(BsplineSpace1D(knots, degree))
+    space = BsplineSpace(spaces)
+    return Bspline(space, np.ascontiguousarray(_warped_lattice(space)))
 
 
 def _folded_patch() -> Bspline:
@@ -314,6 +373,17 @@ def _anisotropic_patch(offset1: float, extent1: float, degree: int = 2, n_elem: 
         axes.append((_greville_abscissae(sub) - offset) * extent)
     cp = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1)
     return Bspline(BsplineSpace(spaces), np.ascontiguousarray(cp))
+
+
+def _parametric_ulp_image(spline: Bspline) -> float:
+    """Return the physical displacement one ulp of a parametric coordinate produces.
+
+    The resolution floor of the parametrization, and the unit
+    :data:`_PARAMETRIC_ULPS_ALLOWED` counts. It is the acceptance threshold divided by the
+    tolerance tier, so it moves with the geometry and with the knot vector exactly as the
+    threshold does and carries no constant of its own.
+    """
+    return float(np.finfo(np.float64).eps) * _parametric_scale(spline)
 
 
 def _physical_only_scale(spline: Bspline) -> float:
@@ -1391,6 +1461,65 @@ class TestParametricStretch:
         for offset in (1.0e2, 1.0e6, 1.0e10, 1.0e12):
             spline = _offset_identity_patch(offset, degree=1, n_elem=1)
             assert spline.locate(np.array([0.5]))[0].tolist() == [0], f"refused at {offset}"
+
+
+class TestStoppingVersusAcceptance:
+    """One threshold cannot be both the accuracy contract and the attainability bound.
+
+    The physical half of the scale says what accuracy a returned coordinate is entitled to;
+    the parametric half says how far below the residual no *representable* parameter can go.
+    Stopping at the second delivers only the second, and on a knot vector far from the
+    parametric origin the two are six decades apart. These pin that the iteration stops at
+    the tighter one while acceptance stays at the looser one, on the geometry where the gap
+    is widest.
+    """
+
+    def test_the_answer_is_as_accurate_as_the_parametrization_allows(self) -> None:
+        """Targets that are exact images are inverted to the parametric grid, not to the bar.
+
+        Sampling the parameter first and mapping it forward makes the preimage a fact about
+        each query, and it is *representable*, so the attainable residual is zero and
+        anything the solver leaves on the table is the stopping rule's doing. The bound is
+        the parametrization's own quantization; see :data:`_PARAMETRIC_ULPS_ALLOWED`.
+        """
+        spline = _parametrically_offset_patch()
+        xi_true = _sample_parametric(spline, 60, seed=321)
+        targets = _evaluate_at(spline, xi_true)
+        bound = _PARAMETRIC_ULPS_ALLOWED * _parametric_ulp_image(spline)
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        assert np.all(cell_ids >= 0), f"lost {int(np.sum(cell_ids < 0))} of 60 queries"
+        residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - targets, axis=1)
+        over = int(np.sum(residuals > bound))
+        assert over == 0, (
+            f"{over} of 60 coordinates stopped short: worst {residuals.max():.3e} over a "
+            f"parametric-resolution bound of {bound:.3e}"
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_a_target_no_representable_parameter_reaches_is_still_found(self) -> None:
+        """The looser bar keeps its coverage while the tighter one sets the accuracy.
+
+        Half-ulp targets have no exact preimage at all, so the tight threshold alone loses
+        every one of them (measured: 60 of 60). They must still come back found, and with
+        the residual the parametric grid allows rather than the one the acceptance bar does.
+        """
+        spline = _parametrically_offset_patch()
+        xi_true = _sample_parametric(spline, 60, seed=321)
+        targets = _half_ulp_targets(spline, xi_true)
+        bound = _PARAMETRIC_ULPS_ALLOWED * _parametric_ulp_image(spline)
+
+        cell_ids, ref_coords = spline.locate(targets)
+
+        assert np.all(cell_ids >= 0), f"lost {int(np.sum(cell_ids < 0))} of 60 queries"
+        residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - targets, axis=1)
+        over = int(np.sum(residuals > bound))
+        assert over == 0, (
+            f"{over} of 60 coordinates stopped short: worst {residuals.max():.3e} over a "
+            f"parametric-resolution bound of {bound:.3e}"
+        )
+        _assert_cell_contains(spline, cell_ids, ref_coords)
 
 
 class TestNearCriticalJacobian:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -73,6 +73,13 @@ one, so the bound carries between five and eighteen times its measured requireme
 single-threshold policy it replaces violates it on 9 of 60 queries in both families, with a
 worst case of 52 ulps, so nothing about the number is delicate: no factor between 1 and 16
 separates the two policies differently.
+
+**What it is not an oracle for.** The bound calls :func:`_parametric_scale`, the same
+function that builds the acceptance threshold, so it cannot detect an error in *that*
+length -- inflating it threefold leaves every test using this bound green. What it detects
+is the stopping rule, because the residual it grades is produced by the Newton iteration's
+own arithmetic and not by any threshold. :func:`_parametric_scale`'s numeric value is
+pinned independently by :class:`TestParametricStretch`, against hand-derived literals.
 """
 
 _PARAMETRIC_OFFSETS: list[float] = [0.0, 1.0e2, 1.0e3, 1.0e4, 1.0e6]
@@ -890,7 +897,9 @@ class TestNewtonGlobalization:
                 np.linalg.norm(
                     _evaluate_at(
                         spline,
-                        _newton_refine(spline, target, start, _LocateThresholds(tol, tol), k)[1],
+                        _newton_refine(
+                            spline, target, start, _LocateThresholds(stop=tol, accept=tol), k
+                        )[1],
                     )
                     - target
                 )
@@ -950,7 +959,7 @@ class TestNewtonGlobalization:
         candidates = np.sort(context.bvh.query_aabb(AABB(target[0], target[0]).pad(tol)))
         assert candidates.tolist() == [32], "the premise: one candidate, so there is no fallback"
 
-        thresholds = _LocateThresholds(tol, tol)
+        thresholds = _LocateThresholds(stop=tol, accept=tol)
         from_midpoint = _newton_refine(
             spline, target, _cell_midpoints(spline.space, candidates), thresholds, 40
         )
@@ -1546,11 +1555,21 @@ class TestStoppingVersusAcceptance:
     def test_a_start_between_the_two_bars_is_refined_instead_of_returned(self) -> None:
         """The stopping rule is the tight one: an iterate inside the loose bar keeps going.
 
-        A starting guess a few ulps off the true preimage already satisfies the acceptance
+        A starting guess one ulp off the true preimage already satisfies the acceptance
         threshold, so under a single threshold it is returned untouched -- that is exactly
         how the accuracy was lost. Under the split it is refined until it meets the stopping
         one, which the same call with both thresholds set to the loose value shows it does
         not do of its own accord.
+
+        **One ulp, not a number picked to work.** The image of one ulp of a parametric
+        coordinate is what :func:`_parametric_scale` measures, and the acceptance threshold
+        is the tolerance tier times that length, so a one-ulp start sits below the loose bar
+        by about the tier itself and far above the tight one. Measured over 20 seeds of 20
+        queries: at worst ``0.025`` of the acceptance threshold (a margin of 40, against the
+        derived 64, the shortfall being this fixture's local stretch over the net-span
+        average) and at least 2178 times the stopping one. Both premises therefore hold by
+        derivation rather than by a constant chosen to make them hold, which is what a
+        premise assertion has to do if its failure is to mean anything.
         """
         spline = _parametrically_offset_patch()
         context = _locate_context(spline)
@@ -1558,8 +1577,7 @@ class TestStoppingVersusAcceptance:
         xi_true = _sample_parametric(spline, 20, seed=17)
         targets = _evaluate_at(spline, xi_true)
         start = xi_true.copy()
-        for _ in range(16):
-            start[:, 1] = np.nextafter(start[:, 1], np.inf)
+        start[:, 1] = np.nextafter(start[:, 1], np.inf)
         start_residual = np.linalg.norm(_evaluate_at(spline, start) - targets, axis=1)
         assert np.all(start_residual > thresholds.stop), "the premise: above the tight bar"
         assert np.all(start_residual <= thresholds.accept), "the premise: inside the loose one"
@@ -1588,7 +1606,7 @@ class TestStoppingVersusAcceptance:
         spline = _parametrically_offset_patch()
         context = _locate_context(spline)
         thresholds = _default_tolerance(spline, context)
-        tight_only = _LocateThresholds(thresholds.stop, thresholds.stop)
+        tight_only = _LocateThresholds(stop=thresholds.stop, accept=thresholds.stop)
         xi_true = _sample_parametric(spline, 20, seed=17)
         targets = _half_ulp_targets(spline, xi_true)
         starts = _cell_midpoints(spline.space, _first_candidates(context, targets, thresholds))
@@ -1615,7 +1633,10 @@ class TestStoppingVersusAcceptance:
         spline = _parametrically_offset_patch()
         context = _locate_context(spline)
         thresholds = _default_tolerance(spline, context)
-        loose = _LocateThresholds(thresholds.accept, thresholds.accept)
+        loose = _LocateThresholds(stop=thresholds.accept, accept=thresholds.accept)
+        # Without this the test goes quiet rather than red: were the two bars ever equal,
+        # `loose` would be `thresholds` and every comparison below a run against itself.
+        assert thresholds.stop < thresholds.accept, "the premise: the two policies differ"
         xi_true = _sample_parametric(spline, 60, seed=321)
         for targets in (_evaluate_at(spline, xi_true), _half_ulp_targets(spline, xi_true)):
             starts = _cell_midpoints(spline.space, _first_candidates(context, targets, thresholds))
@@ -1668,24 +1689,49 @@ class TestStoppingVersusAcceptance:
         assert thresholds.stop == get_default(spline.dtype) * _physical_only_scale(spline)
         assert thresholds.accept / thresholds.stop > 1.0e5, "the fixture's gap is decades wide"
 
-    def test_an_explicit_tolerance_governs_stopping_as_well(self) -> None:
+    def test_an_explicit_tolerance_governs_stopping_as_well(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A named threshold is not silently refined past, so a proximity query stays cheap.
 
         The caller who passes ``tol`` has said what distance they mean; answering to eight
-        decades better than that would charge them for accuracy they did not ask for. Pinned
-        by asking for a deliberately coarse one and checking the answers are coarse.
+        decades better would charge them for accuracy they did not ask for, and the split is
+        exactly what makes that newly possible.
+
+        Read off the thresholds :func:`_locate_impl` hands the solver rather than off the
+        residual it happens to produce. A residual assertion cannot pin this: on this
+        geometry the internal stopping bar is eleven decades below a coarse ``tol``, so a
+        partial leak of it into ``stop`` still leaves every residual far above anything a
+        residual test could distinguish, and passes. The thresholds themselves are exact.
         """
         spline = _warped_patch()
-        xi_true = _sample_parametric(spline, 30, seed=5)
-        targets = _evaluate_at(spline, xi_true)
-        default = _default_tolerance(spline, _locate_context(spline)).accept
+        targets = _evaluate_at(spline, _sample_parametric(spline, 30, seed=5))
+        seen: list[_LocateThresholds] = []
+        module = sys.modules["pantr.bspline._bspline_locate"]
+
+        def _record(
+            sp: Bspline,
+            pts: npt.NDArray[np.float64],
+            start: npt.NDArray[np.float64],
+            thresholds: _LocateThresholds,
+            max_iter: int,
+        ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.float64]]:
+            # The module-level import still names the real function; only the module
+            # attribute the solver looks up is redirected.
+            seen.append(thresholds)
+            return _newton_refine(sp, pts, start, thresholds, max_iter)
+
+        monkeypatch.setattr(module, "_newton_refine", _record)
 
         cell_ids, ref_coords = spline.locate(targets, tol=1.0e-2)
 
+        assert seen, "the premise: the solver was reached at all"
+        assert all(t == _LocateThresholds(stop=1.0e-2, accept=1.0e-2) for t in seen), (
+            f"an explicit tol must govern both thresholds; got {set(seen)}"
+        )
         assert np.all(cell_ids >= 0)
         residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - targets, axis=1)
         assert residuals.max() <= 1.0e-2, "the threshold asked for must still hold"
-        assert residuals.max() > default, "an explicit tol was refined past, at the caller's cost"
 
 
 class TestNearCriticalJacobian:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -67,12 +67,14 @@ threshold divided by ``64 / _PARAMETRIC_ULPS_ALLOWED``.
 
 **Why four.** Two ulps for where the last Newton step lands relative to the true root, and a
 factor of two for the fixture's local stretch against the net-span average the substitution
-uses. Measured on :func:`_parametrically_offset_patch`: the worst residual is ``0.22`` of a
-single ulp's image for targets that are exact images and ``0.82`` for targets a half ulp off
-one, so the bound carries between five and eighteen times its measured requirement. The
-single-threshold policy it replaces violates it on 9 of 60 queries in both families, with a
-worst case of 52 ulps, so nothing about the number is delicate: no factor between 1 and 16
-separates the two policies differently.
+uses. Measured over seven seeds on :func:`_parametrically_offset_patch`, the worst residual
+is ``0.33`` of a single ulp's image for targets that are exact images and ``0.85`` for
+targets a half ulp off one, so the bound carries ``4.7`` times its measured requirement
+here; on sibling fixtures (degree 3 at reach ``1e4``, degree 2 on 8 elements at reach
+``1e10``) the half-ulp worst rises to ``1.33`` and the margin falls to ``3.0``. The
+single-threshold policy it replaces exceeds it on 9 of 60 queries in both families with a
+worst case of 52 ulps, so the two policies are separated by any factor from 3 to 16 -- but
+not by every factor below that, since the good policy itself passes 1.33 on a sibling.
 
 **What it is not an oracle for.** The bound calls :func:`_parametric_scale`, the same
 function that builds the acceptance threshold, so it cannot detect an error in *that*
@@ -385,14 +387,20 @@ def _anisotropic_patch(offset1: float, extent1: float, degree: int = 2, n_elem: 
 
 
 def _parametric_ulp_image(spline: Bspline) -> float:
-    """Return the physical displacement one ulp of a parametric coordinate produces.
+    """Return the resolution floor a returned coordinate is graded against, per ulp.
 
-    The resolution floor of the parametrization, and the unit
-    :data:`_PARAMETRIC_ULPS_ALLOWED` counts. It is the acceptance threshold divided by the
-    tolerance tier, so it moves with the geometry and with the knot vector exactly as the
-    threshold does and carries no constant of its own.
+    The acceptance threshold divided by the tolerance tier, so it moves with the geometry
+    and with the knot vector exactly as the threshold does and carries no constant of its
+    own; :data:`_PARAMETRIC_ULPS_ALLOWED` counts it.
+
+    Taken over *both* lengths and not over the parametric one alone. On a fixture whose
+    parametrization is offset the parametric length wins and the two readings agree, which
+    is every current caller; on one where the physical length wins, the parametric reading
+    would put the bound below the residual floor the coordinates themselves impose and the
+    test would fail for a reason having nothing to do with the parametrization.
     """
-    return float(np.finfo(np.float64).eps) * _parametric_scale(spline)
+    scale = _geometric_scale(_physical_only_scale(spline), _parametric_scale(spline))
+    return float(np.finfo(np.float64).eps) * scale
 
 
 def _first_candidates(
@@ -1700,9 +1708,12 @@ class TestStoppingVersusAcceptance:
         physical``. Opening the split therefore needs ``reach * span > (eps(dtype) / eps64)
         * physical``, and no net span exceeds the bounding-box diagonal, so it needs
         ``reach > eps32 / eps64 == 5.4e8``. A float32 knot vector of width ``L`` at offset
-        ``c`` needs ``c * eps32 < L`` to resolve its own mesh at all, i.e. ``reach < 1 /
-        eps32 == 8.4e6``, two decades short. The next row up confirms the cut-off is the
-        knot layer's and not this module's.
+        ``c`` needs its two endpoints to be distinct float32s at all: for ``c`` in ``[2**e,
+        2**(e+1))`` the smallest representable gap is ``2**(e-24)`` while ``c < 2**(e+1)``,
+        so ``reach < 2**25 == 3.4e7``. The provable margin is therefore exactly ``2**4 ==
+        16``, a format identity rather than a measured quantity. The knot layer is stricter
+        still -- it snaps at ``8 * eps``, which drops the ceiling by another ``8`` -- and the
+        next test confirms the cut-off is its and not this module's.
 
         So the split is a float64 phenomenon, and deliberately: for a float32 caller the
         format the *data* carries is already coarser than anything the parametrization

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -15,9 +15,11 @@ from pantr.bspline._bspline_locate import (
     _cell_midpoints,
     _cell_parametric_bounds,
     _cell_physical_bounds,
+    _default_tolerance,
     _geometric_scale,
     _locate_context,
     _LocateContext,
+    _LocateThresholds,
     _nearest_corner_starts,
     _newton_refine,
     _parametric_reach,
@@ -384,6 +386,21 @@ def _parametric_ulp_image(spline: Bspline) -> float:
     threshold does and carries no constant of its own.
     """
     return float(np.finfo(np.float64).eps) * _parametric_scale(spline)
+
+
+def _first_candidates(
+    context: _LocateContext, targets: npt.NDArray[np.float64], thresholds: _LocateThresholds
+) -> npt.NDArray[np.int64]:
+    """Return the first candidate cell of each target, as ``_locate_impl``'s first round does.
+
+    Lets a test drive :func:`_newton_refine` from the same starting guesses the solver uses
+    without reaching into it, so a comparison between two threshold policies varies the
+    policy alone.
+    """
+    return np.asarray(
+        [np.sort(context.bvh.query_aabb(AABB(x, x).pad(thresholds.accept)))[0] for x in targets],
+        dtype=np.int64,
+    )
 
 
 def _physical_only_scale(spline: Bspline) -> float:
@@ -871,7 +888,11 @@ class TestNewtonGlobalization:
         norms = [
             float(
                 np.linalg.norm(
-                    _evaluate_at(spline, _newton_refine(spline, target, start, tol, k)[1]) - target
+                    _evaluate_at(
+                        spline,
+                        _newton_refine(spline, target, start, _LocateThresholds(tol, tol), k)[1],
+                    )
+                    - target
                 )
             )
             for k in range(1, 13)
@@ -929,11 +950,12 @@ class TestNewtonGlobalization:
         candidates = np.sort(context.bvh.query_aabb(AABB(target[0], target[0]).pad(tol)))
         assert candidates.tolist() == [32], "the premise: one candidate, so there is no fallback"
 
+        thresholds = _LocateThresholds(tol, tol)
         from_midpoint = _newton_refine(
-            spline, target, _cell_midpoints(spline.space, candidates), tol, 40
+            spline, target, _cell_midpoints(spline.space, candidates), thresholds, 40
         )
         from_corner = _newton_refine(
-            spline, target, _nearest_corner_starts(spline, candidates, target), tol, 40
+            spline, target, _nearest_corner_starts(spline, candidates, target), thresholds, 40
         )
 
         assert not bool(from_midpoint[0][0]), "the midpoint start is expected to jam"
@@ -1520,6 +1542,150 @@ class TestStoppingVersusAcceptance:
             f"parametric-resolution bound of {bound:.3e}"
         )
         _assert_cell_contains(spline, cell_ids, ref_coords)
+
+    def test_a_start_between_the_two_bars_is_refined_instead_of_returned(self) -> None:
+        """The stopping rule is the tight one: an iterate inside the loose bar keeps going.
+
+        A starting guess a few ulps off the true preimage already satisfies the acceptance
+        threshold, so under a single threshold it is returned untouched -- that is exactly
+        how the accuracy was lost. Under the split it is refined until it meets the stopping
+        one, which the same call with both thresholds set to the loose value shows it does
+        not do of its own accord.
+        """
+        spline = _parametrically_offset_patch()
+        context = _locate_context(spline)
+        thresholds = _default_tolerance(spline, context)
+        xi_true = _sample_parametric(spline, 20, seed=17)
+        targets = _evaluate_at(spline, xi_true)
+        start = xi_true.copy()
+        for _ in range(16):
+            start[:, 1] = np.nextafter(start[:, 1], np.inf)
+        start_residual = np.linalg.norm(_evaluate_at(spline, start) - targets, axis=1)
+        assert np.all(start_residual > thresholds.stop), "the premise: above the tight bar"
+        assert np.all(start_residual <= thresholds.accept), "the premise: inside the loose one"
+
+        loose_only = _newton_refine(
+            spline, targets, start, _LocateThresholds(thresholds.accept, thresholds.accept), 30
+        )
+        split = _newton_refine(spline, targets, start, thresholds, 30)
+
+        assert np.all(loose_only[0]) and np.all(split[0]), "both policies report found"
+        assert np.array_equal(loose_only[1], start), "one threshold returns the guess as given"
+        refined = np.linalg.norm(_evaluate_at(spline, split[1]) - targets, axis=1)
+        assert np.all(refined < start_residual), f"not refined: {refined} vs {start_residual}"
+        assert np.all(refined <= thresholds.stop), f"did not reach the tight bar: {refined.max()}"
+
+    def test_a_residual_that_cannot_reach_the_tight_bar_is_still_accepted(self) -> None:
+        """The acceptance rule is the loose one, and it is what keeps the coverage.
+
+        Half-ulp targets have no representable preimage, so *no* iterate reaches the
+        stopping threshold; the verdict has to come from the acceptance one, and it does,
+        for a residual the parametric grid genuinely cannot beat. Driven from a single
+        candidate cell and a single start, which is less than the solver gives itself, so
+        the rows this leaves unconverged are the ones a second start recovers rather than a
+        loss.
+        """
+        spline = _parametrically_offset_patch()
+        context = _locate_context(spline)
+        thresholds = _default_tolerance(spline, context)
+        tight_only = _LocateThresholds(thresholds.stop, thresholds.stop)
+        xi_true = _sample_parametric(spline, 20, seed=17)
+        targets = _half_ulp_targets(spline, xi_true)
+        starts = _cell_midpoints(spline.space, _first_candidates(context, targets, thresholds))
+
+        by_the_tight_bar, _ = _newton_refine(spline, targets, starts, tight_only, 30)
+        converged, xi = _newton_refine(spline, targets, starts, thresholds, 30)
+
+        residuals = np.linalg.norm(_evaluate_at(spline, xi) - targets, axis=1)
+        assert not np.any(by_the_tight_bar), "the premise: no iterate reaches the tight bar"
+        assert np.any(converged), "acceptance at the loose bar recovered nothing"
+        assert np.all(residuals[converged] > thresholds.stop)
+        assert np.all(residuals[converged] <= thresholds.accept)
+        # What one candidate cell from one start leaves, locate's own fallbacks recover.
+        assert np.all(spline.locate(targets)[0] >= 0)
+
+    def test_the_split_never_returns_a_worse_coordinate_than_one_threshold_did(self) -> None:
+        """Coverage may not shrink, checked on the geometry with the widest gap.
+
+        The argument is in :class:`_LocateThresholds`: accepted steps never raise the
+        residual, so lowering the *stopping* test only extends trajectories. This runs both
+        policies from the same starts and pins the two consequences -- residuals no larger,
+        and therefore verdicts no fewer -- on queries on and off the mapping's image.
+        """
+        spline = _parametrically_offset_patch()
+        context = _locate_context(spline)
+        thresholds = _default_tolerance(spline, context)
+        loose = _LocateThresholds(thresholds.accept, thresholds.accept)
+        xi_true = _sample_parametric(spline, 60, seed=321)
+        for targets in (_evaluate_at(spline, xi_true), _half_ulp_targets(spline, xi_true)):
+            starts = _cell_midpoints(spline.space, _first_candidates(context, targets, thresholds))
+
+            single, xi_single = _newton_refine(spline, targets, starts, loose, 30)
+            split, xi_split = _newton_refine(spline, targets, starts, thresholds, 30)
+
+            res_single = np.linalg.norm(_evaluate_at(spline, xi_single) - targets, axis=1)
+            res_split = np.linalg.norm(_evaluate_at(spline, xi_split) - targets, axis=1)
+            assert np.any(single), "the premise: the single threshold finds something here"
+            assert np.all(res_split <= res_single), "the split returned a worse coordinate"
+            assert np.all(split | ~single), "the split lost a query the single threshold found"
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            _warped_patch,
+            _quarter_annulus,
+            lambda: _offset_identity_patch(0.0),
+            lambda: _perturbed_patch(2, 3, 2, seed=4),
+        ],
+        ids=["warped", "annulus", "from-origin-affine", "perturbed"],
+    )
+    def test_a_knot_vector_from_the_origin_gets_one_threshold_bit_for_bit(
+        self, factory: Callable[[], Bspline]
+    ) -> None:
+        """The split changes nothing for ordinary geometry, in accuracy or in cost.
+
+        The reach is exactly ``1.0`` for a knot vector spanning ``[0, L]`` and no net span
+        exceeds the diagonal, so the parametric length cannot win the maximum and the two
+        thresholds are the same float. Equal thresholds make the iteration the one that ran
+        before, step for step, which is why no cost measurement is needed here.
+        """
+        spline = factory()
+        thresholds = _default_tolerance(spline, _locate_context(spline))
+
+        assert thresholds.stop == thresholds.accept
+        assert thresholds.stop == get_default(spline.dtype) * _physical_only_scale(spline)
+
+    def test_a_parametric_offset_is_what_separates_them(self) -> None:
+        """The complement of the test above: the gap is real where the reach is.
+
+        Without this the bitwise-equality test could be passing because the split does
+        nothing anywhere.
+        """
+        spline = _parametrically_offset_patch()
+        thresholds = _default_tolerance(spline, _locate_context(spline))
+
+        assert thresholds.stop < thresholds.accept
+        assert thresholds.stop == get_default(spline.dtype) * _physical_only_scale(spline)
+        assert thresholds.accept / thresholds.stop > 1.0e5, "the fixture's gap is decades wide"
+
+    def test_an_explicit_tolerance_governs_stopping_as_well(self) -> None:
+        """A named threshold is not silently refined past, so a proximity query stays cheap.
+
+        The caller who passes ``tol`` has said what distance they mean; answering to eight
+        decades better than that would charge them for accuracy they did not ask for. Pinned
+        by asking for a deliberately coarse one and checking the answers are coarse.
+        """
+        spline = _warped_patch()
+        xi_true = _sample_parametric(spline, 30, seed=5)
+        targets = _evaluate_at(spline, xi_true)
+        default = _default_tolerance(spline, _locate_context(spline)).accept
+
+        cell_ids, ref_coords = spline.locate(targets, tol=1.0e-2)
+
+        assert np.all(cell_ids >= 0)
+        residuals = np.linalg.norm(_evaluate_at(spline, ref_coords) - targets, axis=1)
+        assert residuals.max() <= 1.0e-2, "the threshold asked for must still hold"
+        assert residuals.max() > default, "an explicit tol was refined past, at the caller's cost"
 
 
 class TestNearCriticalJacobian:

--- a/tests/test_bspline_locate.py
+++ b/tests/test_bspline_locate.py
@@ -1689,6 +1689,52 @@ class TestStoppingVersusAcceptance:
         assert thresholds.stop == get_default(spline.dtype) * _physical_only_scale(spline)
         assert thresholds.accept / thresholds.stop > 1.0e5, "the fixture's gap is decades wide"
 
+    @pytest.mark.parametrize("offset", [0.0, 1.0e2, 1.0e4, 1.0e5])
+    def test_a_float32_spline_never_opens_the_split(self, offset: float) -> None:
+        """A float32 caller gets one threshold at every offset its knot vector can carry.
+
+        Not an accident of these four rows. The acceptance threshold's parametric term is
+        format-independent by construction -- :func:`_parametric_scale` multiplies by
+        ``eps64 / eps(dtype)``, so ``get_default(dtype)`` times it is ``64 * eps64 * reach *
+        span`` in every format -- while the stopping threshold is ``64 * eps(dtype) *
+        physical``. Opening the split therefore needs ``reach * span > (eps(dtype) / eps64)
+        * physical``, and no net span exceeds the bounding-box diagonal, so it needs
+        ``reach > eps32 / eps64 == 5.4e8``. A float32 knot vector of width ``L`` at offset
+        ``c`` needs ``c * eps32 < L`` to resolve its own mesh at all, i.e. ``reach < 1 /
+        eps32 == 8.4e6``, two decades short. The next row up confirms the cut-off is the
+        knot layer's and not this module's.
+
+        So the split is a float64 phenomenon, and deliberately: for a float32 caller the
+        format the *data* carries is already coarser than anything the parametrization
+        quantizes at, which is the same reason the inversion promotes to float64 to iterate.
+        """
+        spline = _offset_identity_patch(offset, degree=2, n_elem=4)
+        knots = np.asarray(spline.space.spaces[0].knots, dtype=np.float32)
+        spline32 = Bspline(
+            BsplineSpace([BsplineSpace1D(knots, 2)]),
+            np.ascontiguousarray(np.asarray(spline.control_points, dtype=np.float32)),
+        )
+        thresholds = _default_tolerance(spline32, _locate_context(spline32))
+
+        assert thresholds.stop == thresholds.accept
+        assert thresholds.stop == get_default(np.float32) * _physical_only_scale(spline32)
+
+    def test_the_float32_offset_that_would_open_the_split_is_refused_first(self) -> None:
+        """The knot layer stops a float32 knot vector before this module has to.
+
+        The complement of the test above, and what makes its argument a statement about
+        every float32 spline rather than about the four offsets sampled: one decade further
+        out the knot vector cannot be built at all, because in float32 at ``1e6`` the mesh
+        collapses onto a single knot.
+        """
+        offset = 1.0e6
+        knots = np.concatenate(
+            [np.full(2, offset), np.linspace(offset, offset + 1.0, 5), np.full(2, offset + 1.0)]
+        ).astype(np.float32)
+
+        with pytest.raises(ValueError, match="collapsed every knot"):
+            BsplineSpace1D(knots, 2)
+
     def test_an_explicit_tolerance_governs_stopping_as_well(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Closes #321.

`_newton_refine` stopped and accepted on the same number, so a coordinate was only ever as
accurate as the bar it was measured against. Since #322 gave the default threshold a
parametric-resolution term, geometry parametrized far from the origin got a legitimately
larger bar and stopped early against it, throwing away accuracy that was one iteration away.

The two thresholds now travel together in a `_LocateThresholds(stop, accept)` pair: iterate
while the residual is above `stop`, and accept anything that reached `accept`. The verdict
became a single end-of-loop test, which removed the in-loop `converged` accumulator — the
function is shorter than before.

**`stop` is the accuracy contract**: `get_default(dtype) × max(diagonal, magnitude)`. Both
terms are properties of the *image alone*, because reparametrizing a geometry does not change
what an answer is worth. **`accept` is an attainability statement**:
`get_default(dtype) × max(diagonal, magnitude, parametric)`, where one ulp of a parametric
coordinate is `eps·|xi_k|` and the map turns it into `eps·|xi_k|·‖J e_k‖`, so no representable
parameter can drive the residual lower. Only `accept` grows with the parametrization; on a knot
vector spanning `[0, L]` the two are equal bit for bit. Neither introduces a constant.

## Measured

Independently of the branch's own tests, the same script run against `main` and against this
branch — a warped degree-3 bivariate patch, 4 elements per direction, direction 1 parametrized
on `[1e6, 1e6+1]`, 60 queries at exact images:

| source | lost | worst residual | median |
|---|---|---|---|
| `main` | 0 / 60 | 1.178e-08 | 5.284e-10 |
| this branch | 0 / 60 | **1.496e-14** | **6.206e-17** |

Coverage is identical, which is the invariant that mattered: nothing #322 rescued may be lost
again. The branch's own fixture shows the same shape with different numbers (1.20e-08 →
4.99e-11), as expected from a differently conditioned warp.

Cost: worst case **1.82×** map evaluations, confined to parametrically offset geometry;
**1.000×** on the library's own 2400-query sweep, and 1.00× for off-image queries.

## Three of the ticket's premises are wrong

- **The composite does not reach the physical-only threshold, and cannot.** The ticket predicts
  `2.422e-14`. At reach `1e6` one parametric ulp already moves the image by `2.29e-10`, four
  decades above `stop`. What the split actually delivers is the parametric grid's own floor —
  a half-ulp worst of `1.88e-10` that matches, to five digits, the best residual any parameter
  within two ulps of the true preimage attains. That is a stronger claim than the ticket's, and
  it is what the docstrings now state.
- **The tight policy does lose points**: 4 of 60 on exact-image targets, where the ticket
  records 0 of 60.
- **The cost criterion asks for the wrong sweep.** It requests cost at "parametric offsets 0
  and 1e6" for a fixture whose offset is *physical*, where both thresholds move together and
  the split is inactive. A genuinely parametric-offset fixture was measured instead.

## Known, and deliberately not fixed here

**`stop` is frame-dependent, and #321 as specified is half the fix.** It is built from
`max(diagonal, magnitude)`, but `magnitude` is itself an attainability floor rather than an
accuracy statement, so translating the model relaxes the accuracy contract without bound, and
at a physical offset of `1e6` the split switches off entirely. Measured on the library's own
1200-query sweep: `stop = tier·diagonal` gives a worst relative residual of `3.49e-10` against
`1.00e-08`, at 1.35× cost — or 1.005× with `max(tier·D, get_strict·magnitude)`. Changing it is
this ticket's explicit non-goal ("the derivation of either threshold"), so it is reported rather
than taken, and wants its own ticket.

Two smaller items in the same class: the refusal guard is asymmetric (a query 0.59 diameters
outside the image is reported found when `diagonal/magnitude < 1e-14`), which is one word once
the above is settled; and a caller cannot tell which of the two thresholds their coordinate met
— `find_roots` has the house `RuntimeWarning` convention for exactly this, but `pytest.ini` sets
`filterwarnings = error`, so adding one turns existing tests red.

Fixed along the way, each in its own commit: a float32 precision claim wrong by `5.3e8`; cost
figures that did not reproduce under any convention; a test that could not catch its own bug
(two mutants passed it, now mutation-verified); a magic 16-ulp premise replaced by 1 ulp at
39.8× margin; and an ulp bound graded against the parametric length alone rather than both.

## Checks

ruff, ruff format, mypy (234 files), `lint-imports` (1 contract kept), pytest **5935 passed,
21 skipped, 2 xfailed** on the current base after rebase. Acceptance criteria verified by
direct execution against both sources, independently of the suite.
