### PR TITLE
docs: make every docstring example run, and make CI run them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,6 +177,15 @@ jobs:
           . .venv/bin/activate
           make test
 
+      # On the full matrix rather than once, because an example can drift from the code
+      # on any version and a numpy release that prints a value differently breaks it on
+      # one leg only. A step here rather than a job of its own: it reuses this job's venv
+      # and warm Numba cache, costs a few seconds, and wants no coverage.
+      - name: Run doctests
+        run: |
+          . .venv/bin/activate
+          make doctest
+
       - name: Run pytest with coverage
         run: |
           . .venv/bin/activate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,8 +179,9 @@ jobs:
 
       # On the full matrix rather than once, because an example can drift from the code
       # on any version and a numpy release that prints a value differently breaks it on
-      # one leg only. A step here rather than a job of its own: it reuses this job's venv
-      # and warm Numba cache, costs a few seconds, and wants no coverage.
+      # one leg only. A step here rather than a job of its own: it reuses this job's
+      # venv, runs in under a second, and wants no coverage. The target sets
+      # NUMBA_DISABLE_JIT=1 -- see the Makefile for why.
       - name: Run doctests
         run: |
           . .venv/bin/activate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ All of these assume the `pantr` env, i.e. prefix with `conda run -n pantr`.
 ```bash
 make pre-pull-request                                       # the full check suite CI runs
 pytest                                                      # run tests (JIT enabled, no coverage)
+make doctest                                                # run the docstring examples under src/pantr
 pytest tests/test_basis.py::test_name -v                    # single test
 pytest tests/ -k "keyword" -v                               # filtered tests
 pytest -m "not slow"                                        # skip the slow-marked tests

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,20 @@ test:
 # Run the docstring examples shipped in the package sources. Kept out of `test`
 # because `testpaths = tests` in pytest.ini deliberately excludes src/, and a plain
 # `pytest` run should stay the fast inner loop. No coverage and no xdist: the whole
-# set runs in a few seconds serially, and worker startup would dominate.
+# set runs in under a second, and worker startup would dominate.
+#
+# NUMBA_DISABLE_JIT=1 is deliberate, for two reasons. It removes this run from the
+# concurrent-compilation abort class entirely: with JIT off, `prange` is `range` and
+# no Numba threading layer is ever entered, so nothing here can race the background
+# warmup thread started by pantr/__init__.py. Today the race does not fire (measured:
+# 0 aborts in 44 runs, 24 cold-cache and 20 warm), but only because collection order
+# happens to reach a `wait_for_jit_warmup()` call site first -- reorder the modules or
+# drop those examples and the protection is gone. It also makes the run 28x faster
+# (0.9s against 24s cold). The compiled path is what `test` covers; this target checks
+# that the documentation matches the code, and the values it asserts go through
+# np.allclose or .tolist(), which do not depend on JIT-vs-interpreter rounding.
 doctest:
-	pytest --doctest-modules src/pantr
+	NUMBA_DISABLE_JIT=1 pytest --doctest-modules src/pantr
 
 # Generate an XML coverage report with Numba JIT disabled
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help test coverage clean install ruff-lint ruff-format ruff-format-check type-check import-lint pre-pull-request docs
+.PHONY: help test doctest coverage clean install ruff-lint ruff-format ruff-format-check type-check import-lint pre-pull-request docs
 
 help:
 	@echo "Commands:"
 	@echo "  test      : run the test suite."
+	@echo "  doctest   : run the docstring examples in src/pantr."
 	@echo "  coverage  : generate a coverage report."
 	@echo "  clean     : remove build artifacts."
 	@echo "  install   : install project with dev extras."
@@ -17,6 +18,13 @@ help:
 # Run the test suite with Numba JIT enabled
 test:
 	pytest -n auto
+
+# Run the docstring examples shipped in the package sources. Kept out of `test`
+# because `testpaths = tests` in pytest.ini deliberately excludes src/, and a plain
+# `pytest` run should stay the fast inner loop. No coverage and no xdist: the whole
+# set runs in a few seconds serially, and worker startup would dominate.
+doctest:
+	pytest --doctest-modules src/pantr
 
 # Generate an XML coverage report with Numba JIT disabled
 coverage:
@@ -59,4 +67,4 @@ docs:
 	$(MAKE) -C docs html SPHINXOPTS="$(SPHINXOPTS)"
 
 # Aggregate target to run all checks before creating a pull request
-pre-pull-request: ruff-lint ruff-format ruff-format-check type-check import-lint test coverage docs
+pre-pull-request: ruff-lint ruff-format ruff-format-check type-check import-lint test doctest coverage docs

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,22 @@ test:
 # `pytest` run should stay the fast inner loop. No coverage and no xdist: the whole
 # set runs in under a second, and worker startup would dominate.
 #
-# NUMBA_DISABLE_JIT=1 is deliberate, for two reasons. It removes this run from the
-# concurrent-compilation abort class entirely: with JIT off, `prange` is `range` and
-# no Numba threading layer is ever entered, so nothing here can race the background
-# warmup thread started by pantr/__init__.py. Today the race does not fire (measured:
-# 0 aborts in 44 runs, 24 cold-cache and 20 warm), but only because collection order
-# happens to reach a `wait_for_jit_warmup()` call site first -- reorder the modules or
-# drop those examples and the protection is gone. It also makes the run 28x faster
-# (0.9s against 24s cold). The compiled path is what `test` covers; this target checks
-# that the documentation matches the code, and the values it asserts go through
-# np.allclose or .tolist(), which do not depend on JIT-vs-interpreter rounding.
+# NUMBA_DISABLE_JIT=1 is deliberate. With JIT off, `prange` is `range` and no Numba
+# threading layer is ever entered, so this run cannot race the background warmup thread
+# that pantr/__init__.py starts: the concurrent-compilation abort class is structurally
+# absent here, not merely improbable. It is also 28x faster (0.9s against 24s cold),
+# which matters now that `pre-pull-request` depends on it.
+#
+# Historical note, so nobody "restores" the JIT here: the JIT-enabled run this replaced
+# measured 0 aborts in 44 runs (24 cold-cache, 20 warm), but was safe only because
+# pytest happens to collect basis/_basis_1D.py early and its examples reach a
+# `wait_for_jit_warmup()` call site before any unguarded kernel. Reordering the modules
+# or dropping those examples would have removed that protection silently.
+#
+# What this gives up is the compiled path, which is `test`'s job over the whole suite.
+# This target checks that the documentation matches the code, and the values it asserts
+# go through np.allclose or .tolist(), neither of which depends on JIT-vs-interpreter
+# rounding.
 doctest:
 	NUMBA_DISABLE_JIT=1 pytest --doctest-modules src/pantr
 

--- a/src/pantr/_parallel.py
+++ b/src/pantr/_parallel.py
@@ -128,9 +128,10 @@ def num_threads(n: int, *, limit_blas: bool = False) -> Generator[None, None, No
         the ``with`` block exits.
 
     Example:
+        >>> import pantr
         >>> with pantr.num_threads(1):
-        ...     # all pantr operations run serially here
-        ...     pass
+        ...     pantr.get_num_threads()  # all pantr operations run serially here
+        1
     """
     prev = get_num_threads()
     set_num_threads(n)

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -134,11 +134,12 @@ def _tabulate_Bernstein_basis_1D_impl(
             shape or dtype.
 
     Example:
-        >>> _tabulate_Bernstein_basis_1D_impl(2, [0.0, 0.5, 0.75, 1.0])
-        array([[1.    , 0.    , 0.    ],
-               [0.25  , 0.5   , 0.25  ],
-               [0.0625, 0.375 , 0.5625],
-               [0.    , 0.    , 1.    ]])
+        >>> vals = _tabulate_Bernstein_basis_1D_impl(2, [0.0, 0.5, 0.75, 1.0])
+        >>> np.allclose(
+        ...     vals,
+        ...     [[1.0, 0.0, 0.0], [0.25, 0.5, 0.25], [0.0625, 0.375, 0.5625], [0.0, 0.0, 1.0]],
+        ... )
+        True
     """
     return _tabulate_basis_1D_impl_helper(
         n,
@@ -190,12 +191,9 @@ def _tabulate_cardinal_Bspline_basis_1D_impl(
             shape or dtype.
 
     Example:
-        >>> tabulate_cardinal_bspline_1d(2, [0.0, 0.5, 1.0])
-        array([[0.5    , 0.5    , 0.     ],
-               [0.125  , 0.75   , 0.125  ],
-               [0.03125, 0.6875 , 0.28125],
-               [0.     , 0.5    , 0.5    ]])
-
+        >>> vals = _tabulate_cardinal_Bspline_basis_1D_impl(2, [0.0, 0.5, 1.0])
+        >>> np.allclose(vals, [[0.5, 0.5, 0.0], [0.125, 0.75, 0.125], [0.0, 0.5, 0.5]])
+        True
     """
     return _tabulate_basis_1D_impl_helper(n, t, _tabulate_cardinal_Bspline_basis_1D_core, out)
 

--- a/src/pantr/basis/_basis_tabulate.py
+++ b/src/pantr/basis/_basis_tabulate.py
@@ -69,11 +69,12 @@ def tabulate_bernstein_1d(
             shape or dtype.
 
     Example:
-        >>> tabulate_bernstein_1d(2, [0.0, 0.5, 0.75, 1.0])
-        array([[1.    , 0.    , 0.    ],
-               [0.25  , 0.5   , 0.25  ],
-               [0.0625, 0.375 , 0.5625],
-               [0.    , 0.    , 1.    ]])
+        >>> import numpy as np
+        >>> np.allclose(
+        ...     tabulate_bernstein_1d(2, [0.0, 0.5, 0.75, 1.0]),
+        ...     [[1.0, 0.0, 0.0], [0.25, 0.5, 0.25], [0.0625, 0.375, 0.5625], [0.0, 0.0, 1.0]],
+        ... )
+        True
     """
     return _tabulate_Bernstein_basis_1D_impl(degree, pts, out=out)
 
@@ -120,10 +121,12 @@ def tabulate_cardinal_bspline_1d(
             shape or dtype.
 
     Example:
-        >>> tabulate_cardinal_bspline_1d(2, [0.0, 0.5, 1.0])
-        array([[0.5  , 0.5  , 0.   ],
-               [0.125, 0.75 , 0.125],
-               [0.   , 0.5  , 0.5  ]])
+        >>> import numpy as np
+        >>> np.allclose(
+        ...     tabulate_cardinal_bspline_1d(2, [0.0, 0.5, 1.0]),
+        ...     [[0.5, 0.5, 0.0], [0.125, 0.75, 0.125], [0.0, 0.5, 0.5]],
+        ... )
+        True
 
     """
     return _tabulate_cardinal_Bspline_basis_1D_impl(degree, pts, out=out)

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -514,7 +514,7 @@ class Bezier:
             (2,)
             >>> np.allclose(h.evaluate(np.array([0.5])), [0.25])
             True
-            >>> np.allclose((f * g).control_points, h.control_points)
+            >>> np.allclose((f * g).evaluate(np.array([0.5])), [0.25])  # same via __mul__
             True
         """
         return _multiply_bezier(self, other)

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -212,8 +212,15 @@ class Bezier:
                 negative, or if the points dtype does not match the Bézier dtype.
 
         Example:
-            >>> result = bezier.evaluate_derivatives(pts, 2)
-            >>> result = bezier.evaluate_derivatives(pts, [1, 2])
+            >>> import numpy as np
+            >>> f = Bezier(np.array([[0.0], [2.0]]))  # f(t) = 2t
+            >>> np.allclose(f.evaluate_derivatives(np.array([0.3, 0.7]), 1), [2.0, 2.0])
+            True
+            >>> cp = np.zeros((2, 2, 1))
+            >>> cp[1, 1, 0] = 1.0  # f(u, v) = u * v
+            >>> surf = Bezier(cp)
+            >>> np.allclose(surf.evaluate_derivatives(np.array([[0.3, 0.4]]), [1, 1]), [1.0])
+            True
         """
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_bezier_deriv(self, pts, orders_seq, out)
@@ -253,9 +260,15 @@ class Bezier:
             ValueError: If the degree in the given direction is 0.
 
         Example:
-            >>> f_prime = f.derivative()
-            >>> df_dv = surface.derivative(direction=1)
-            >>> f_prime_same_deg = f.derivative(keep_degree=True)
+            >>> import numpy as np
+            >>> f = Bezier(np.array([[0.0], [0.0], [1.0]]))  # Bernstein form of t**2
+            >>> fp = f.derivative()
+            >>> fp.degree
+            (1,)
+            >>> np.allclose(fp.evaluate(np.array([0.3])), [0.6])
+            True
+            >>> f.derivative(keep_degree=True).degree
+            (2,)
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -493,8 +506,16 @@ class Bezier:
                 or ranks.
 
         Example:
+            >>> import numpy as np
+            >>> f = Bezier(np.array([[0.0], [1.0]]))  # f(t) = t
+            >>> g = Bezier(np.array([[0.0], [1.0]]))  # g(t) = t
             >>> h = f.multiply(g)
-            >>> h2 = f * g
+            >>> h.degree
+            (2,)
+            >>> np.allclose(h.evaluate(np.array([0.5])), [0.25])
+            True
+            >>> np.allclose((f * g).control_points, h.control_points)
+            True
         """
         return _multiply_bezier(self, other)
 
@@ -561,8 +582,14 @@ class Bezier:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
 
         Example:
-            >>> rev = bezier.reverse(direction=0)
-            >>> bezier.reverse(direction=1, in_place=True)
+            >>> import numpy as np
+            >>> f = Bezier(np.array([[0.0], [1.0]]))  # f(t) = t
+            >>> rev = f.reverse()
+            >>> np.allclose(rev.evaluate(np.array([0.3])), [0.7])  # rev(t) = 1 - t
+            True
+            >>> f.reverse(in_place=True)  # mutates in place, returns None
+            >>> np.allclose(f.evaluate(np.array([0.3])), [0.7])
+            True
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -608,7 +635,12 @@ class Bezier:
                 ``range(dim)``.
 
         Example:
-            >>> surface.permute_directions([1, 0])  # swap u ↔ v
+            >>> import numpy as np
+            >>> surf = Bezier(np.zeros((2, 3, 1)))
+            >>> surf.degree
+            (1, 2)
+            >>> surf.permute_directions([1, 0]).degree  # swap u <-> v
+            (2, 1)
         """
         perm = list(permutation)
         if sorted(perm) != list(range(self.dim)):
@@ -662,9 +694,13 @@ class Bezier:
                 geometric rank of the Bézier.
 
         Example:
+            >>> import numpy as np
             >>> from pantr.transform import AffineTransform
+            >>> curve = Bezier(np.array([[0.0, 0.0], [1.0, 1.0]]))  # rank 2
             >>> T = AffineTransform.translation([1.0, 2.0])
-            >>> shifted = bezier.transform(T)
+            >>> shifted = curve.transform(T)
+            >>> np.allclose(shifted.control_points, [[1.0, 2.0], [2.0, 3.0]])
+            True
         """
         new_cp = _apply_affine_to_control_points(
             self._control_points,
@@ -770,8 +806,13 @@ class Bezier:
             ValueError: If ``value`` is not strictly inside ``(0, 1)``.
 
         Example:
+            >>> import numpy as np
+            >>> curve = Bezier(np.array([[0.0], [1.0]]))  # f(t) = t
             >>> left, right = curve.split(0, 0.5)
-            >>> left, right = surface.split(1, 0.3)
+            >>> np.allclose(left.evaluate(np.array([1.0])), [0.5])
+            True
+            >>> np.allclose(right.evaluate(np.array([0.0])), [0.5])
+            True
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -812,10 +853,16 @@ class Bezier:
             ValueError: If ``value`` is outside ``[0, 1]``.
 
         Example:
-            >>> # Slice a surface at v=0.5 to get a curve
-            >>> curve = surface.slice(1, 0.5)
-            >>> # Composable: surface -> curve -> point
-            >>> pt = surface.slice(1, 0.5).slice(0, 0.2)
+            >>> import numpy as np
+            >>> cp = np.zeros((2, 2, 1))
+            >>> cp[1, 1, 0] = 1.0  # f(u, v) = u * v
+            >>> surf = Bezier(cp)
+            >>> curve = surf.slice(1, 0.5)  # fix v=0.5: curve(u) = 0.5u
+            >>> curve.dim
+            1
+            >>> pt = surf.slice(1, 0.5).slice(0, 0.2)  # surface -> curve -> point
+            >>> np.allclose(pt, [0.1])
+            True
         """
         if axis < 0 or axis >= self.dim:
             raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
@@ -846,8 +893,13 @@ class Bezier:
             ValueError: If ``side`` is not 0 or 1.
 
         Example:
-            >>> # Extract left boundary of a surface along direction 0
-            >>> left_curve = surface.boundary(0, 0)
+            >>> import numpy as np
+            >>> cp = np.zeros((2, 2, 1))
+            >>> cp[1, 1, 0] = 1.0  # f(u, v) = u * v
+            >>> surf = Bezier(cp)
+            >>> right_edge = surf.boundary(0, 1)  # u = 1: f(1, v) = v
+            >>> np.allclose(right_edge.evaluate(np.array([0.7])), [0.7])
+            True
         """
         if side not in (0, 1):
             raise ValueError(f"side must be 0 or 1, got {side}.")
@@ -894,8 +946,15 @@ class Bezier:
             ValueError: If any value is outside ``[0, 1]``.
 
         Example:
-            >>> # Collapse a 3D volume along axis 1 at (u=0.3, w=0.7)
-            >>> curve = volume.collapse_along_axis(1, [0.3, 0.7])
+            >>> import numpy as np
+            >>> cp = np.zeros((2, 2, 2, 1))
+            >>> cp[1, 1, 1, 0] = 1.0  # f(u, v, w) = u * v * w
+            >>> vol = Bezier(cp)
+            >>> curve = vol.collapse_along_axis(1, [0.3, 0.7])  # fix u=0.3, w=0.7
+            >>> curve.degree
+            (1,)
+            >>> np.allclose(curve.evaluate(np.array([0.5])), [0.3 * 0.5 * 0.7])
+            True
         """
         if self.dim < 2:  # noqa: PLR2004
             raise ValueError("collapse_along_axis requires dim >= 2.")

--- a/src/pantr/bezier/_root_finding.py
+++ b/src/pantr/bezier/_root_finding.py
@@ -93,8 +93,8 @@ def find_roots(
     Example:
         >>> import numpy as np
         >>> from pantr.bezier import Bezier, find_roots
-        >>> find_roots(Bezier([1.0, -1.0]))
-        array([0.5])
+        >>> np.allclose(find_roots(Bezier([1.0, -1.0])), [0.5])
+        True
 
     References:
         Yuksel's monotone-decomposition root finder :cite:p:`yuksel2022roots`

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -253,16 +253,17 @@ class Bspline:
         Example:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
-            >>> spline = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
+            >>> spline = Bspline(create_uniform_space(2, 1), np.array([[0.0], [0.0], [1.0]]))
             >>> pts = np.array([[0.25], [0.75]])
-            >>> spline.evaluate_derivatives(pts, 2).shape  # 1D: 2nd derivative (int shorthand)
-            (2,)
-            >>> spline.evaluate_derivatives(pts, [2]).shape  # 1D: 2nd derivative (sequence form)
-            (2,)
-            >>> srf = Bspline(create_uniform_space(2, [3, 2]), np.zeros((5, 4, 2)))
-            >>> uv = np.array([[0.25, 0.75]])
-            >>> srf.evaluate_derivatives(uv, [1, 2]).shape  # 2D: partial d3f/du dv2
-            (1, 2)
+            >>> np.allclose(spline.evaluate_derivatives(pts, 2), [2.0, 2.0])  # f(t) = t**2
+            True
+            >>> np.allclose(spline.evaluate_derivatives(pts, [2]), [2.0, 2.0])  # sequence form
+            True
+            >>> u_cp, v_cp = np.array([0.0, 0.5, 1.0]), np.array([0.0, 0.0, 1.0])
+            >>> srf = Bspline(create_uniform_space(2, [1, 1]), np.outer(u_cp, v_cp)[..., None])
+            >>> uv = np.array([[0.3, 0.4]])
+            >>> np.allclose(srf.evaluate_derivatives(uv, [1, 2]), [2.0])  # f = u*v**2, d3f/du dv2
+            True
         """
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_Bspline_deriv(self, pts, orders_seq, out)
@@ -399,14 +400,18 @@ class Bspline:
         Example:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
-            >>> f = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
-            >>> f.derivative().degree  # first derivative of a 1D curve
+            >>> f = Bspline(create_uniform_space(2, 1), np.array([[0.0], [0.0], [1.0]]))
+            >>> fp = f.derivative()  # first derivative of a 1D curve; f(t) = t**2
+            >>> fp.degree
             (1,)
+            >>> np.allclose(fp.evaluate(np.array([[0.3]])), [0.6])  # f'(t) = 2t
+            True
             >>> f.derivative().derivative().degree  # second derivative (composable)
             (0,)
             >>> f.derivative(keep_degree=True).degree  # derivative preserving degree
             (2,)
-            >>> srf = Bspline(create_uniform_space(2, [3, 2]), np.zeros((5, 4, 2)))
+            >>> u_cp, v_cp = np.array([0.0, 0.5, 1.0]), np.array([0.0, 0.0, 1.0])
+            >>> srf = Bspline(create_uniform_space(2, [1, 1]), np.outer(u_cp, v_cp)[..., None])
             >>> srf.derivative(direction=1).degree  # partial derivative along direction 1
             (2, 1)
         """
@@ -925,12 +930,15 @@ class Bspline:
         Example:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
-            >>> f = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
-            >>> g = Bspline(create_uniform_space(1, 3), np.arange(4.0).reshape(4, 1))
-            >>> f.multiply(g).degree
-            (3,)
-            >>> (f * g).degree  # equivalent via __mul__
-            (3,)
+            >>> f = Bspline(create_uniform_space(1, 1), np.array([[0.0], [1.0]]))  # f(t) = t
+            >>> g = Bspline(create_uniform_space(1, 1), np.array([[0.0], [1.0]]))  # g(t) = t
+            >>> h = f.multiply(g)
+            >>> h.degree
+            (2,)
+            >>> np.allclose(h.evaluate(np.array([[0.5]])), [0.25])  # (f g)(t) = t**2
+            True
+            >>> np.allclose((f * g).evaluate(np.array([[0.5]])), [0.25])  # same via __mul__
+            True
         """
         if self.dim == 1:
             from ._bspline_product import _multiply_bspline_1d  # noqa: PLC0415
@@ -1057,11 +1065,15 @@ class Bspline:
         Example:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
-            >>> surface = Bspline(create_uniform_space([2, 1], [3, 2]), np.zeros((5, 3, 2)))
+            >>> space = create_uniform_space([2, 1], [1, 1])
+            >>> surface = Bspline(space, np.arange(6.0).reshape(3, 2, 1))
             >>> surface.degree
             (2, 1)
-            >>> surface.permute_directions([1, 0]).degree  # swap u <-> v
+            >>> swapped = surface.permute_directions([1, 0])  # swap u <-> v
+            >>> swapped.degree
             (1, 2)
+            >>> swapped.control_points[0, 2].tolist()  # was control_points[2, 0]
+            [4.0]
         """
         from .._control_points_utils import _permute_control_points  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
@@ -1127,11 +1139,11 @@ class Bspline:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
             >>> from pantr.transform import AffineTransform
-            >>> spline = Bspline(create_uniform_space(1, 1), np.zeros((2, 2)))
+            >>> spline = Bspline(create_uniform_space(1, 1), np.array([[0.0, 0.0], [1.0, 1.0]]))
             >>> T = AffineTransform.translation([1.0, 2.0])
             >>> shifted = spline.transform(T)
-            >>> shifted.control_points.tolist()
-            [[1.0, 2.0], [1.0, 2.0]]
+            >>> np.allclose(shifted.control_points, [[1.0, 2.0], [2.0, 3.0]])
+            True
         """
         new_cp = _apply_affine_to_control_points(
             self._control_points,
@@ -1259,8 +1271,8 @@ class Bspline:
             >>> volume.slice(2, 0.3).slice(1, 0.5).dim  # and again at v=0.5 to get a curve
             1
             >>> pt = volume.slice(2, 0.3).slice(1, 0.5).slice(0, 0.2)  # composable down to a point
-            >>> np.shape(pt)
-            (3,)
+            >>> np.allclose(pt, volume.evaluate(np.array([[0.2, 0.5, 0.3]])))
+            True
         """
         if axis < 0 or axis >= self.dim:
             raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
@@ -1300,11 +1312,14 @@ class Bspline:
         Example:
             >>> import numpy as np
             >>> from pantr.bspline import create_uniform_space
-            >>> surface = Bspline(create_uniform_space([2, 1], [3, 2]), np.zeros((5, 3, 2)))
-            >>> surface.boundary(0, 0).degree  # left boundary along direction 0
-            (1,)
-            >>> surface.boundary(1, 1).degree  # right boundary along direction 1
-            (2,)
+            >>> space = create_uniform_space([2, 1], [1, 1])
+            >>> surface = Bspline(space, np.arange(6.0).reshape(3, 2, 1))
+            >>> left = surface.boundary(0, 0)  # left boundary along direction 0
+            >>> left.degree, left.control_points.ravel().tolist()
+            ((1,), [0.0, 1.0])
+            >>> right = surface.boundary(1, 1)  # right boundary along direction 1
+            >>> right.degree, right.control_points.ravel().tolist()
+            ((2,), [1.0, 3.0, 5.0])
         """
         if side not in (0, 1):
             raise ValueError(f"side must be 0 or 1, got {side}.")

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -251,12 +251,18 @@ class Bspline:
                 or if ``out`` has incorrect shape or dtype.
 
         Example:
-            >>> # 1D: second derivative (int shorthand)
-            >>> result = spline.evaluate_derivatives(pts, 2)
-            >>> # 1D: second derivative (sequence form)
-            >>> result = spline.evaluate_derivatives(pts, [2])
-            >>> # 2D: partial derivative ∂³f/∂u ∂v²
-            >>> result = spline.evaluate_derivatives(pts, [1, 2])
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> spline = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
+            >>> pts = np.array([[0.25], [0.75]])
+            >>> spline.evaluate_derivatives(pts, 2).shape  # 1D: 2nd derivative (int shorthand)
+            (2,)
+            >>> spline.evaluate_derivatives(pts, [2]).shape  # 1D: 2nd derivative (sequence form)
+            (2,)
+            >>> srf = Bspline(create_uniform_space(2, [3, 2]), np.zeros((5, 4, 2)))
+            >>> uv = np.array([[0.25, 0.75]])
+            >>> srf.evaluate_derivatives(uv, [1, 2]).shape  # 2D: partial d3f/du dv2
+            (1, 2)
         """
         orders_seq: Sequence[int] = [orders] * self.dim if isinstance(orders, int) else orders
         return _evaluate_Bspline_deriv(self, pts, orders_seq, out)
@@ -346,7 +352,16 @@ class Bspline:
             matters more than the default's derivation.
 
         Example:
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> u, v = np.meshgrid([0.0, 0.5, 1.0], [0.0, 0.5, 1.0], indexing="ij")
+            >>> surface = Bspline(create_uniform_space(1, [2, 2]), np.stack([u, v], axis=-1))
+            >>> pts = np.array([[0.25, 0.75], [0.6, 0.3]])
             >>> cell_ids, ref_coords = surface.locate(surface.evaluate(pts))
+            >>> cell_ids.tolist()
+            [1, 2]
+            >>> np.allclose(ref_coords, pts)
+            True
         """
         return _locate_impl(self, points, tol, max_iter)
 
@@ -382,14 +397,18 @@ class Bspline:
             ValueError: If the degree in the given direction is 0.
 
         Example:
-            >>> # First derivative of a 1D curve
-            >>> f_prime = f.derivative()
-            >>> # Partial derivative of a surface with respect to direction 1
-            >>> df_dv = surface.derivative(direction=1)
-            >>> # Second derivative (composable)
-            >>> f_double_prime = f.derivative().derivative()
-            >>> # Derivative preserving degree
-            >>> f_prime_same_deg = f.derivative(keep_degree=True)
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> f = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
+            >>> f.derivative().degree  # first derivative of a 1D curve
+            (1,)
+            >>> f.derivative().derivative().degree  # second derivative (composable)
+            (0,)
+            >>> f.derivative(keep_degree=True).degree  # derivative preserving degree
+            (2,)
+            >>> srf = Bspline(create_uniform_space(2, [3, 2]), np.zeros((5, 4, 2)))
+            >>> srf.derivative(direction=1).degree  # partial derivative along direction 1
+            (2, 1)
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -724,8 +743,14 @@ class Bspline:
             ValueError: If ``value`` is not strictly inside the domain.
 
         Example:
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> spline = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
             >>> left, right = spline.split(0, 0.5)
-            >>> left, right = surface.split(1, 0.3)
+            >>> tuple(float(x) for x in left.space.spaces[0].domain)
+            (0.0, 0.5)
+            >>> tuple(float(x) for x in right.space.spaces[0].domain)
+            (0.5, 1.0)
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -850,6 +875,9 @@ class Bspline:
             ``(3, 2)``.  The Bézier control points are read-only.
 
         Example:
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> spline = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
             >>> beziers = spline.to_beziers()
             >>> beziers.shape
             (3,)
@@ -895,8 +923,14 @@ class Bspline:
             both periodic → periodic, both non-open → non-open, either open → open.
 
         Example:
-            >>> h = f.multiply(g)
-            >>> h2 = f * g  # equivalent via __mul__
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> f = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
+            >>> g = Bspline(create_uniform_space(1, 3), np.arange(4.0).reshape(4, 1))
+            >>> f.multiply(g).degree
+            (3,)
+            >>> (f * g).degree  # equivalent via __mul__
+            (3,)
         """
         if self.dim == 1:
             from ._bspline_product import _multiply_bspline_1d  # noqa: PLC0415
@@ -939,8 +973,15 @@ class Bspline:
             ValueError: If ``direction`` is out of range ``[0, dim)``.
 
         Example:
-            >>> rev = spline.reverse(direction=0)
-            >>> spline.reverse(direction=1, in_place=True)
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> srf = Bspline(create_uniform_space(1, [1, 1]), np.arange(8.0).reshape(2, 2, 2))
+            >>> rev = srf.reverse(direction=0)
+            >>> rev.control_points[:, 0, 0].tolist()
+            [4.0, 0.0]
+            >>> srf.reverse(direction=1, in_place=True)  # mutates in place, returns None
+            >>> srf.control_points[0, :, 0].tolist()
+            [2.0, 0.0]
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")
@@ -1014,7 +1055,13 @@ class Bspline:
                 ``range(dim)``.
 
         Example:
-            >>> surface.permute_directions([1, 0])  # swap u ↔ v
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> surface = Bspline(create_uniform_space([2, 1], [3, 2]), np.zeros((5, 3, 2)))
+            >>> surface.degree
+            (2, 1)
+            >>> surface.permute_directions([1, 0]).degree  # swap u <-> v
+            (1, 2)
         """
         from .._control_points_utils import _permute_control_points  # noqa: PLC0415
         from ._bspline_space_nd import BsplineSpace  # noqa: PLC0415
@@ -1077,9 +1124,14 @@ class Bspline:
                 geometric rank of the B-spline.
 
         Example:
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
             >>> from pantr.transform import AffineTransform
+            >>> spline = Bspline(create_uniform_space(1, 1), np.zeros((2, 2)))
             >>> T = AffineTransform.translation([1.0, 2.0])
             >>> shifted = spline.transform(T)
+            >>> shifted.control_points.tolist()
+            [[1.0, 2.0], [1.0, 2.0]]
         """
         new_cp = _apply_affine_to_control_points(
             self._control_points,
@@ -1198,12 +1250,17 @@ class Bspline:
                 direction.
 
         Example:
-            >>> # Slice a surface at v=0.5 to get a curve
-            >>> curve = surface.slice(1, 0.5)
-            >>> # Slice a volume at w=0.3 to get a surface
-            >>> srf = volume.slice(2, 0.3)
-            >>> # Composable: volume -> surface -> curve -> point
-            >>> pt = volume.slice(2, 0.3).slice(1, 0.5).slice(0, 0.2)
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> space = create_uniform_space(1, [2, 2, 2])
+            >>> volume = Bspline(space, np.arange(81.0).reshape(3, 3, 3, 3))
+            >>> volume.slice(2, 0.3).dim  # slice a volume at w=0.3 to get a surface
+            2
+            >>> volume.slice(2, 0.3).slice(1, 0.5).dim  # and again at v=0.5 to get a curve
+            1
+            >>> pt = volume.slice(2, 0.3).slice(1, 0.5).slice(0, 0.2)  # composable down to a point
+            >>> np.shape(pt)
+            (3,)
         """
         if axis < 0 or axis >= self.dim:
             raise ValueError(f"axis must be in [0, {self.dim}), got {axis}.")
@@ -1241,10 +1298,13 @@ class Bspline:
             ValueError: If ``side`` is not 0 or 1.
 
         Example:
-            >>> # Extract left boundary of a surface along direction 0
-            >>> left_curve = surface.boundary(0, 0)
-            >>> # Extract right boundary along direction 1
-            >>> right_curve = surface.boundary(1, 1)
+            >>> import numpy as np
+            >>> from pantr.bspline import create_uniform_space
+            >>> surface = Bspline(create_uniform_space([2, 1], [3, 2]), np.zeros((5, 3, 2)))
+            >>> surface.boundary(0, 0).degree  # left boundary along direction 0
+            (1,)
+            >>> surface.boundary(1, 1).degree  # right boundary along direction 1
+            (2,)
         """
         if side not in (0, 1):
             raise ValueError(f"side must be 0 or 1, got {side}.")

--- a/src/pantr/bspline/_bspline.py
+++ b/src/pantr/bspline/_bspline.py
@@ -747,10 +747,10 @@ class Bspline:
             >>> from pantr.bspline import create_uniform_space
             >>> spline = Bspline(create_uniform_space(2, 3), np.arange(5.0).reshape(5, 1))
             >>> left, right = spline.split(0, 0.5)
-            >>> tuple(float(x) for x in left.space.spaces[0].domain)
-            (0.0, 0.5)
-            >>> tuple(float(x) for x in right.space.spaces[0].domain)
-            (0.5, 1.0)
+            >>> np.allclose(left.space.spaces[0].domain, [0.0, 0.5])
+            True
+            >>> np.allclose(right.space.spaces[0].domain, [0.5, 1.0])
+            True
         """
         if direction < 0 or direction >= self.dim:
             raise ValueError(f"direction must be in [0, {self.dim}), got {direction}.")

--- a/src/pantr/bspline/_bspline_basis_core.py
+++ b/src/pantr/bspline/_bspline_basis_core.py
@@ -749,13 +749,21 @@ def _tabulate_Bspline_basis_1D_impl(
             has incorrect shape or dtype.
 
     Example:
+        >>> from pantr.bspline import BsplineSpace1D
         >>> bspline = BsplineSpace1D([0, 0, 0, 0.25, 0.7, 0.7, 1, 1, 1], 2)
-        >>> _tabulate_Bspline_basis_1D_impl(bspline, [0.0, 0.5, 0.75, 1.0])
-        (array([[1.        , 0.        , 0.        ],
-                [0.12698413, 0.5643739 , 0.30864198],
-                [0.69444444, 0.27777778, 0.02777778],
-                [0.        , 0.        , 1.        ]]),
-         array([0, 1, 3, 3]))
+        >>> values, first = _tabulate_Bspline_basis_1D_impl(bspline, [0.0, 0.5, 0.75, 1.0])
+        >>> np.allclose(
+        ...     values,
+        ...     [
+        ...         [1.0, 0.0, 0.0],
+        ...         [0.12698413, 0.5643739, 0.30864198],
+        ...         [0.69444444, 0.27777778, 0.02777778],
+        ...         [0.0, 0.0, 1.0],
+        ...     ],
+        ... )
+        True
+        >>> first.tolist()
+        [0, 1, 3, 3]
     """
     input_shape = np.shape(pts)
     pts = _normalize_points_1D(pts)
@@ -854,6 +862,7 @@ def _tabulate_Bspline_basis_deriv_1D_impl(  # noqa: PLR0913
             incorrect shape or dtype.
 
     Example:
+        >>> from pantr.bspline import BsplineSpace1D
         >>> bspline = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
         >>> d, first = _tabulate_Bspline_basis_deriv_1D_impl(bspline, [0.5], n_deriv=1)
         >>> d.shape

--- a/src/pantr/bspline/_bspline_roots.py
+++ b/src/pantr/bspline/_bspline_roots.py
@@ -548,8 +548,8 @@ def find_roots(
         >>> knots = np.array([0.0, 0.0, 1.0, 2.0, 2.0])
         >>> space = BsplineSpace([BsplineSpace1D(knots, 1)])
         >>> spline = Bspline(space, np.array([[-1.0], [1.0], [3.0]]))
-        >>> find_roots(spline)
-        array([0.5])
+        >>> np.allclose(find_roots(spline), [0.5])
+        True
 
     References:
         The unconditionally convergent knot-insertion method of Mørken and

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -369,8 +369,8 @@ class BsplineSpace1D:
 
         Example:
             >>> space = BsplineSpace1D([0, 0, 0, 1, 2, 2, 3, 3, 3], 2)
-            >>> space.first_basis_per_interval()
-            array([0, 1, 3])
+            >>> space.first_basis_per_interval().tolist()
+            [0, 1, 3]
         """
         if self._periodic:
             raise ValueError(
@@ -398,7 +398,8 @@ class BsplineSpace1D:
 
         Example:
             >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 2, 2], 2)
-            >>> bspline.domain
+            >>> start, end = bspline.domain
+            >>> float(start), float(end)
             (0.0, 2.0)
         """
         i0, i1 = self._get_domain_indices()
@@ -506,8 +507,23 @@ class BsplineSpace1D:
         An interval is cardinal if has the same length as the degree-1
         previous and the degree-1 next intervals.
 
+        Concretely, an interval ``[u_k, u_(k+1)]`` is cardinal when both conditions
+        hold: neither bounding knot is repeated, and the ``2 * degree - 1`` knot spans
+        of the window ``u_(k-degree+1), ..., u_(k+degree)`` -- the ``degree - 1`` spans
+        before the interval, the interval itself, and the ``degree - 1`` spans after it
+        -- all have the interval's own length, to within the space tolerance.
+
+        Those ``2 * degree`` knots are exactly the ones the de Boor recursion reads to
+        evaluate on that span: the recursion touches ``u_i`` and ``u_(i+degree+1-r)``
+        for ``i = k-degree+r, ..., k`` at level ``r``, whose indices run from
+        ``k-degree+1`` to ``k+degree`` and no further. So the window carries all the
+        knot information the ``degree + 1`` functions restricted to that interval
+        depend on, and equal spacing across it is what makes the restriction coincide
+        with the cardinal (uniform-knot) one.
+
         In the case of open knot vectors, this definition automatically
-        discards the first degree-1 and the last degree-1 intervals.
+        discards the first degree-1 and the last degree-1 intervals: the repeated
+        end knots put zero-length spans inside their window.
 
         At ``degree == 0`` the equal-length condition ranges over an empty set of
         neighbouring intervals, so it holds vacuously and the knot spacing does not
@@ -532,17 +548,26 @@ class BsplineSpace1D:
             ValueError: If `out` is provided and has incorrect shape or dtype.
 
         Example:
+            Six unit intervals, degree 2: the window is one span either side, so
+            only the two end intervals see a zero-length span from the repeated
+            end knots.
+
             >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 5, 6, 6, 6], 2)
-            >>> bspline.get_cardinal_intervals()
-            array([False, False, True, True, False, False])
+            >>> bspline.get_cardinal_intervals().tolist()
+            [False, True, True, True, True, False]
+
+            Repeating the interior knot 5 disqualifies the two intervals it bounds:
 
             >>> bspline = BsplineSpace1D([0, 0, 0, 1, 2, 3, 4, 5, 5, 6, 6, 6], 2)
-            >>> bspline.get_cardinal_intervals()
-            array([False, False, True, False, False, False])
+            >>> bspline.get_cardinal_intervals().tolist()
+            [False, True, True, True, False, False]
+
+            Degree 3 over the domain ``[3, 5]``: the irregular span ``[7, 10]`` sits
+            outside the two-span window of both intervals, so neither is affected.
 
             >>> bspline = BsplineSpace1D([0, 1, 2, 3, 4, 5, 6, 7, 10], 3)
-            >>> bspline.get_cardinal_intervals()
-            array([True, False])
+            >>> bspline.get_cardinal_intervals().tolist()
+            [True, True]
         """
         return _get_Bspline_cardinal_intervals_1D_impl(
             self._knots, self._degree, self._tol, out=out
@@ -593,13 +618,21 @@ class BsplineSpace1D:
                 has incorrect shape or dtype.
 
         Example:
+            >>> import numpy as np
             >>> bspline = BsplineSpace1D([0, 0, 0, 0.25, 0.7, 0.7, 1, 1, 1], 2)
-            >>> bspline.tabulate_basis([0.0, 0.5, 0.75, 1.0])
-            (array([[1.        , 0.        , 0.        ],
-                    [0.12698413, 0.5643739 , 0.30864198],
-                    [0.69444444, 0.27777778, 0.02777778],
-                    [0.        , 0.        , 1.        ]]),
-             array([0, 1, 3, 3]))
+            >>> values, first = bspline.tabulate_basis([0.0, 0.5, 0.75, 1.0])
+            >>> np.allclose(
+            ...     values,
+            ...     [
+            ...         [1.0, 0.0, 0.0],
+            ...         [0.12698413, 0.5643739, 0.30864198],
+            ...         [0.69444444, 0.27777778, 0.02777778],
+            ...         [0.0, 0.0, 1.0],
+            ...     ],
+            ... )
+            True
+            >>> first.tolist()
+            [0, 1, 3, 3]
 
         References:
             Basis values are computed with the stable Cox-de Boor recurrence
@@ -658,12 +691,14 @@ class BsplineSpace1D:
                 has incorrect shape or dtype.
 
         Example:
+            >>> import numpy as np
             >>> bspline = BsplineSpace1D([0, 0, 0, 1, 1, 1], 2)
             >>> d, first = bspline.tabulate_basis_derivatives([0.5], n_deriv=1)
             >>> d.shape
             (1, 2, 3)
-            >>> d[0, 1, :]   # first derivatives at x=0.5: B0'=-1, B1'=0, B2'=1
-            array([-1.,  0.,  1.])
+            >>> # first derivatives at x=0.5: B0'=-1, B1'=0, B2'=1
+            >>> np.allclose(d[0, 1, :], [-1.0, 0.0, 1.0])
+            True
         """
         return _tabulate_Bspline_basis_deriv_1D_impl(
             self,

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -513,13 +513,13 @@ class BsplineSpace1D:
         before the interval, the interval itself, and the ``degree - 1`` spans after it
         -- all have the interval's own length, to within the space tolerance.
 
-        Those ``2 * degree`` knots are exactly the ones the de Boor recursion reads to
-        evaluate on that span: the recursion touches ``u_i`` and ``u_(i+degree+1-r)``
-        for ``i = k-degree+r, ..., k`` at level ``r``, whose indices run from
-        ``k-degree+1`` to ``k+degree`` and no further. So the window carries all the
-        knot information the ``degree + 1`` functions restricted to that interval
-        depend on, and equal spacing across it is what makes the restriction coincide
-        with the cardinal (uniform-knot) one.
+        Those ``2 * degree`` knots are exactly the ones an evaluation on that span
+        reads. The standard basis-function recurrence works up from level ``1`` to
+        ``degree``, and at level ``j`` it references only ``u_(k+1-j)`` and ``u_(k+j)``;
+        across all levels those indices sweep ``k-degree+1`` through ``k+degree`` and no
+        further. So the window holds every knot the ``degree + 1`` functions restricted
+        to that interval depend on, and equal spacing across it is what makes those
+        restrictions coincide with the cardinal (uniform-knot) ones.
 
         In the case of open knot vectors, this definition automatically
         discards the first degree-1 and the last degree-1 intervals: the repeated
@@ -562,12 +562,17 @@ class BsplineSpace1D:
             >>> bspline.get_cardinal_intervals().tolist()
             [False, True, True, True, False, False]
 
-            Degree 3 over the domain ``[3, 5]``: the irregular span ``[7, 10]`` sits
-            outside the two-span window of both intervals, so neither is affected.
+            Degree 3 over the domain ``[3, 5]``: the window reaches two spans past
+            each interval, so the irregular span ``[7, 10]`` falls outside both and
+            neither interval is affected.
 
             >>> bspline = BsplineSpace1D([0, 1, 2, 3, 4, 5, 6, 7, 10], 3)
             >>> bspline.get_cardinal_intervals().tolist()
             [True, True]
+
+        References:
+            The recurrence whose knot footprint sets this window is Algorithm A2.2
+            of :cite:p:`piegl1997nurbs`.
         """
         return _get_Bspline_cardinal_intervals_1D_impl(
             self._knots, self._degree, self._tol, out=out

--- a/src/pantr/bspline/_bspline_space_factory.py
+++ b/src/pantr/bspline/_bspline_space_factory.py
@@ -52,8 +52,12 @@ def create_uniform_open_knots(
         ValueError: If any parameter is invalid.
 
     Example:
-        >>> create_uniform_open_knots(2, 2, domain=(0.0, 1.0))
-        array([0., 0., 0., 0.5, 1., 1., 1.])
+        >>> import numpy as np
+        >>> np.allclose(
+        ...     create_uniform_open_knots(2, 2, domain=(0.0, 1.0)),
+        ...     [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+        ... )
+        True
     """
     start_value: np.float32 | np.float64 | None
     end_value: np.float32 | np.float64 | None
@@ -118,8 +122,12 @@ def create_uniform_periodic_knots(
         ValueError: If any parameter is invalid.
 
     Example:
-        >>> create_uniform_periodic_knots(2, 2, domain=(0.0, 1.0))
-        array([-1. , -0.5,  0. ,  0.5,  1. ,  1.5,  2. ])
+        >>> import numpy as np
+        >>> np.allclose(
+        ...     create_uniform_periodic_knots(2, 2, domain=(0.0, 1.0)),
+        ...     [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0],
+        ... )
+        True
     """
     start_value: np.float32 | np.float64 | None
     end_value: np.float32 | np.float64 | None
@@ -202,8 +210,9 @@ def create_cardinal_knots(
         ValueError: If num_intervals < 1, degree < 0, or dtype is not float32/float64.
 
     Example:
-        >>> create_cardinal_knots(2, 2)
-        array([-2., -1.,  0.,  1.,  2.,  3., 4.])
+        >>> import numpy as np
+        >>> np.allclose(create_cardinal_knots(2, 2), [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
+        True
     """
     if num_intervals < 1:
         raise ValueError("num_intervals must be at least 1")
@@ -253,11 +262,15 @@ def get_greville_abscissae(
             containing one Greville abscissa per basis function.
 
     Example:
+        >>> import numpy as np
         >>> from pantr.bspline import BsplineSpace1D, create_uniform_open_knots
         >>> knots = create_uniform_open_knots(4, 3)
         >>> space = BsplineSpace1D(knots, 3)
-        >>> get_greville_abscissae(space)
-        array([0.  , 0.08333333, 0.25, 0.5 , 0.75, 0.91666667, 1.  ])
+        >>> np.allclose(
+        ...     get_greville_abscissae(space),
+        ...     [0.0, 1 / 12, 0.25, 0.5, 0.75, 11 / 12, 1.0],
+        ... )
+        True
     """
     if not isinstance(space, BsplineSpace1D):
         raise TypeError(f"Expected BsplineSpace1D, got {type(space).__name__}")
@@ -299,13 +312,14 @@ def create_greville_lattice(
         PointsLattice: Tensor-product grid of Greville abscissae.
 
     Example:
+        >>> import numpy as np
         >>> from pantr.bspline import BsplineSpace1D, BsplineSpace, create_uniform_open_knots
         >>> knots = create_uniform_open_knots(2, 2)
         >>> s1d = BsplineSpace1D(knots, 2)
         >>> space = BsplineSpace([s1d, s1d])
         >>> lattice = create_greville_lattice(space)
-        >>> lattice.pts_per_dir[0]
-        array([0. , 0.25, 0.75, 1.  ])
+        >>> np.allclose(lattice.pts_per_dir[0], [0.0, 0.25, 0.75, 1.0])
+        True
     """
     if not isinstance(space, BsplineSpace):
         raise TypeError(f"Expected BsplineSpace, got {type(space).__name__}")

--- a/src/pantr/bspline/_bspline_space_nd.py
+++ b/src/pantr/bspline/_bspline_space_nd.py
@@ -165,6 +165,7 @@ class BsplineSpace:
             bool: True if knots have open ends and only one span.
 
         Example:
+            >>> from pantr.bspline import BsplineSpace1D
             >>> bspline_1D = BsplineSpace1D([1, 1, 1, 3, 3, 3], 2)
             >>> bspline_2D = BsplineSpace([bspline_1D, bspline_1D])
             >>> bspline_2D.has_Bezier_like_knots()
@@ -253,8 +254,8 @@ class BsplineSpace:
             >>> space = BsplineSpace([first, second])
             >>> space.num_basis
             (5, 3)
-            >>> space.cell_supports([0])
-            array([[0, 1, 2, 3, 4, 5, 6, 7, 8]])
+            >>> space.cell_supports([0]).tolist()
+            [[0, 1, 2, 3, 4, 5, 6, 7, 8]]
         """
         return _cell_supports_impl(self, cell_ids)
 
@@ -301,12 +302,12 @@ class BsplineSpace:
             >>> space = BsplineSpace([first, second])
             >>> space.num_basis
             (5, 4)
-            >>> space.boundary_dofs(0, 0)
-            array([0, 1, 2, 3])
-            >>> space.boundary_dofs(1, 0)
-            array([ 0,  4,  8, 12, 16])
-            >>> space.boundary_dofs(1, 1, layers=2)
-            array([ 2,  3,  6,  7, 10, 11, 14, 15, 18, 19])
+            >>> space.boundary_dofs(0, 0).tolist()
+            [0, 1, 2, 3]
+            >>> space.boundary_dofs(1, 0).tolist()
+            [0, 4, 8, 12, 16]
+            >>> space.boundary_dofs(1, 1, layers=2).tolist()
+            [2, 3, 6, 7, 10, 11, 14, 15, 18, 19]
         """
         if any(space.periodic for space in self._spaces):
             raise ValueError("boundary_dofs: periodic B-spline spaces are not supported.")

--- a/src/pantr/mpi/_collocation.py
+++ b/src/pantr/mpi/_collocation.py
@@ -305,6 +305,8 @@ def interpolate_bspline_distributed(
         :func:`~pantr.bspline.interpolate_bspline`.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> import numpy as np  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
@@ -414,6 +416,8 @@ def fit_bspline_distributed(
         ``global_space.dtype``.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> from pantr.bspline import create_greville_lattice  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP

--- a/src/pantr/mpi/_create.py
+++ b/src/pantr/mpi/_create.py
@@ -73,6 +73,8 @@ def create_distributed_space(  # noqa: PLR0913 -- public factory mirrors the par
             with ``comm`` (e.g. ``comm.size`` mismatch), as raised downstream.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP
         >>> from pantr.mpi import create_distributed_space  # doctest: +SKIP

--- a/src/pantr/mpi/_distributed_function.py
+++ b/src/pantr/mpi/_distributed_function.py
@@ -184,6 +184,8 @@ def create_distributed_function(  # noqa: PLR0913 -- public factory mirrors the 
             incompatible with ``comm`` (as raised downstream).
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> from pantr.bspline import Bspline, create_uniform_space  # doctest: +SKIP
         >>> from pantr.mpi import create_distributed_function  # doctest: +SKIP

--- a/src/pantr/mpi/_l2.py
+++ b/src/pantr/mpi/_l2.py
@@ -202,6 +202,8 @@ def l2_project_bspline_distributed(  # noqa: PLR0913
         points to ``global_space.dtype`` rather than raising.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> import numpy as np  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP

--- a/src/pantr/mpi/_qi.py
+++ b/src/pantr/mpi/_qi.py
@@ -74,6 +74,8 @@ def quasi_interpolate_bspline_distributed(
         :func:`~pantr.bspline.quasi_interpolate_bspline`.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> import numpy as np  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space  # doctest: +SKIP

--- a/src/pantr/mpi/_thb_qi.py
+++ b/src/pantr/mpi/_thb_qi.py
@@ -83,6 +83,8 @@ def quasi_interpolate_thb_spline_distributed(
         ``float64`` on construction, regardless of ``global_space.dtype``.
 
     Example:
+        Needs a live MPI communicator and several ranks, so it is not run as a doctest.
+
         >>> from mpi4py import MPI  # doctest: +SKIP
         >>> import numpy as np  # doctest: +SKIP
         >>> from pantr.bspline import create_uniform_space, create_thb_space  # doctest: +SKIP

--- a/src/pantr/multipatch/_match.py
+++ b/src/pantr/multipatch/_match.py
@@ -114,8 +114,8 @@ def match_face_cps(  # noqa: PLR0913
         >>> from pantr.bspline import BsplineSpace, BsplineSpace1D
         >>> space = BsplineSpace([BsplineSpace1D([0, 0, 1, 1], 1)] * 2)
         >>> a, b = match_face_cps(space, 1, space, 0, (1,), (False,))
-        >>> a, b
-        (array([2, 3]), array([0, 1]))
+        >>> a.tolist(), b.tolist()
+        ([2, 3], [0, 1])
     """
     if space_a.dim != space_b.dim:
         raise ValueError(

--- a/src/pantr/quad.py
+++ b/src/pantr/quad.py
@@ -466,7 +466,7 @@ def get_tanh_sinh_1d(
         True
         >>> bool(((nodes > 0.0) & (nodes < 1.0)).all())
         True
-        >>> abs(weights.sum() - 1.0) < 1e-14
+        >>> bool(abs(weights.sum() - 1.0) < 1e-14)
         True
     """
     _validate_n_pts_and_dtype(n_pts, dtype)

--- a/src/pantr/viz/_scene.py
+++ b/src/pantr/viz/_scene.py
@@ -106,10 +106,12 @@ class Scene:
     create a plotter with :meth:`to_plotter`.
 
     Example:
+        >>> from pantr.cad import create_bilinear, create_line
         >>> scene = Scene()
-        >>> scene.add(surface, color="blue", show_knot_lines=True)
-        >>> scene.add(curve, color="red", show_control_polygon=True)
-        >>> scene.show()
+        >>> scene = scene.add(create_bilinear(), color="blue", show_knot_lines=True)
+        >>> scene = scene.add(create_line([0, 0], [1, 1]), color="red", show_control_polygon=True)
+        >>> # ``show`` opens an interactive render window, so it cannot run headless.
+        >>> scene.show()  # doctest: +SKIP
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
Closes #303.

35 doctests under `src/pantr` failed and nothing ran them, so every docstring example in the
package was unverified. This fixes all of them and adds the run to CI, so a drifted example
becomes a red check instead of rot nobody sees.

**Result: 80 passed, 7 skipped, 0 failed**, identical with and without JIT.

## What the ticket got wrong

Its headline arithmetic holds (27 + 7 + 1 = 35) but the classification does not, in three ways,
and one of them matters:

- **Four genuine value mismatches, not one.** All three `get_cardinal_intervals` examples were
  wrong rather than one, and the second and third were **masked**: doctest reports only the
  first failure per docstring, so fixing the first would have revealed the next. A fourth was
  hiding in the `NameError` bucket —
  `_tabulate_cardinal_Bspline_basis_1D_impl` showed four rows of output for three evaluation
  points, and was misfiled only because it happened to fail on an undefined name first.
- **Of the 27 `NameError`s, only 22 are illustrative pseudo-examples.** Four are real examples
  missing an import, and one calls a function name that does not exist in its module.
- **The version-fragility scope was too narrow.** Eleven further docstrings were *passing*
  while matching printed numpy array formatting. Converting only the seven failing ones would
  have left identical rot primed to recur on the next numpy release. All are converted; zero
  examples in the package now match an array `repr`.

The code was not changed to satisfy any example. `get_cardinal_intervals`'s examples are
corrected to what the code returns, and the docstring now states the `degree-1` window rule
that makes those values right, cited to Piegl & Tiller A2.2 rather than re-derived inline.

## Where the CI run went, and the abort class it avoids

A step in the existing `tests` job (`make doctest`, also wired into `pre-pull-request`), on the
full three-version matrix: an example can drift on any version, and a numpy release that prints
a value differently breaks one leg only. A step rather than a job because it reuses that job's
venv, needs no coverage, and runs in under a second.

The target sets `NUMBA_DISABLE_JIT=1`, and that is not a shortcut. With JIT off, `prange` is
`range` and no Numba threading layer is entered, so the run cannot race the background warmup
thread that `pantr/__init__.py` starts — the concurrent-compilation abort class is
**structurally absent** rather than improbable. The JIT-enabled configuration measured 0 aborts
in 44 runs (24 cold-cache, 20 warm), but was safe only because pytest happens to collect
`basis/_basis_1D.py` early and its examples reach a `wait_for_jit_warmup()` call before any
unguarded kernel; `Bspline.evaluate` and `Bezier.evaluate` have no barrier. Reordering modules
or dropping those examples would have removed that protection silently, and the symptom would
have been an aborted CI job rather than a red test. The Makefile records this so nobody
"restores" the JIT there. It is also 28× faster (0.9 s against 24 s cold).

## Skipped, with reasons

Eight sites: the seven MPI blocks ("needs a live MPI communicator and several ranks") and
`Scene.show()` ("opens an interactive render window, so it cannot run headless"). `Scene.add`
itself now runs on real `pantr.cad` primitives and renders nothing, which keeps it inside the
headless constraint the CI test job imposes.

## Verified at the gate

Independently of the branch's own reporting: `make doctest` exits **2** on a deliberately
drifted expectation and **0** clean, so the check genuinely goes red; **0** examples matching
array `repr` remain package-wide; and the full suite passes (**5919 passed, 21 skipped,
2 xfailed**) with ruff, ruff format, mypy (234 files) and `lint-imports` clean.

## Reported, not changed

- **`Bspline.__init__` reshapes control points blind.** It validates only that
  `control_points.size % num_total_basis == 0` and then reshapes, with no per-axis shape check,
  so a scrambled control array is silently reinterpreted rather than rejected. Surfaced when a
  no-op permutation produced wrong control points with no error. Library behaviour, so
  untouched here; it wants its own ticket.
- `tests/test_viz_scene.py` asserts `plotter is not None` throughout, so nothing checks that a
  scene draws the right thing.
- `quad.py` carries a bare `1e-14` absolute tolerance (pre-existing).
- `_bspline_knots.py` states the cardinal-interval rule in a vaguer form than its public
  counterpart now uses; worth syncing.

## Scope note

This branch's own self-review caught nine issues in the examples it had just written, each
proved by a mutation that slipped past the first version: a `Bezier.multiply` assertion that
compared a bare alias with itself, and several examples built on `np.zeros` geometry where
scaling an affine map or making a permutation a no-op left them green. An example that cannot
fail documents nothing. Two review angles were **not** sampled on this branch — API consistency
and clarity — because those agents were lost to a session limit and not re-run.
