### PR TITLE
fix(bspline): refuse a space with no interval where a space is built

### DIFF
--- a/docs/guide/spaces-knots.md
+++ b/docs/guide/spaces-knots.md
@@ -14,6 +14,12 @@ basis is a degree-``p`` polynomial, and the knot multiplicities control how the 
 join (see [Continuity](#continuity) below). A {class}`~pantr.bspline.BsplineSpace` is a
 tensor product of these 1-D spaces.
 
+Every space has **at least one span**. The domain runs from ``knots[p]`` to
+``knots[-p-1]``, and a vector whose in-domain knots all collapse to a single knot is
+refused at construction with a message saying so. Nothing can be evaluated, tabulated or
+located on a space with no span, so this is checked once where the space is built rather
+than by each operation in its own way.
+
 You rarely type knot vectors by hand. The factories in {mod}`pantr.bspline` build the
 standard families:
 

--- a/src/pantr/bspline/_bspline_knots.py
+++ b/src/pantr/bspline/_bspline_knots.py
@@ -104,12 +104,14 @@ def _check_snapping_kept_an_interval(
 ) -> None:
     """Reject a knot vector that snapping collapsed onto a single point.
 
-    A caller who passes a genuinely degenerate vector -- every knot already the same
-    value -- gets it back untouched and no error, because that is what was asked for.
-    What is refused is the case the caller cannot see coming: the knots *were*
-    distinct, and the merge rule found none of them distinguishable at their own
-    magnitude, so the space would carry no interval and every operation on it would
-    fail on an empty domain with a message about something else.
+    This function refuses one specific cause -- the knots *were* distinct, and the
+    merge rule found none of them distinguishable at their own magnitude -- so that
+    the caller is told the thing they could not see coming. A vector that arrived
+    already flat is not this function's case and passes through it untouched; it is
+    refused a step later by :func:`_check_space_has_an_interval`, which owns the
+    *consequence* both causes share. Keeping the two apart is what lets each message
+    be true: "this mesh is finer than float32 resolves here" is actionable, and false
+    of a vector the caller supplied flat.
 
     This is reachable, and the arithmetic that makes it so is not a defect. Two knots
     obtained by different routes differ by up to ``4 * eps * scale``, so telling them
@@ -152,6 +154,68 @@ def _check_snapping_kept_an_interval(
         f"more than {tol:.3g} ({tol / ulp:.0f} ulp there), and the closest pair in "
         f"[{float(raw[0])!r}, {float(raw[-1])!r}] is {closest:.3g} apart. This mesh is "
         f"finer than {name} resolves at that magnitude. {remedy}"
+    )
+
+
+def _check_space_has_an_interval(
+    knots: npt.NDArray[np.float32 | np.float64],
+    degree: int,
+    num_intervals: int,
+    tol: float,
+) -> None:
+    """Reject a knot vector whose domain is a single point.
+
+    A space with no interval has no cell, and every operation defined over its cells
+    is therefore undefined on it. It was accepted until issue #320, and each consumer
+    then met the degeneracy on its own terms: ``tensor_product_grid`` named the
+    breakpoints, ``Bspline.locate`` surfaced ``numpy``'s zero-size ``min``,
+    ``tabulate_basis_derivatives`` divided by zero, and -- worse than any error --
+    ``Bspline.evaluate`` returned ``0.0`` while ``tabulate_basis`` and
+    ``evaluate_derivatives`` returned ``NaN``. Those three returned a value, so a
+    survey of what *raised* would not have found them, which is why the rule lives
+    here at the one place a space comes into being rather than at each consumer. It
+    is also the rule ``create_cardinal_knots`` has always applied, as
+    ``num_intervals must be at least 1``.
+
+    The predicate is the interval count, not "every knot is the same value". The
+    family is wider than it looks: ``[0, 1, 1, 1, 2]`` at degree 1 holds three
+    distinct values and still has a domain of ``(1.0, 1.0)``, because the domain runs
+    from ``knots[degree]`` to ``knots[-degree-1]`` and an interior knot of high enough
+    multiplicity swallows it whole. Counting intervals catches that case and the flat
+    one together, and it introduces no threshold of its own -- the count is decided by
+    the same knot grouping the space uses everywhere else.
+
+    That grouping splits on ``knots[i] - knots[i-1] > tol``, so it chains: the two
+    domain ends can be further apart than ``tol`` and still fall in one class, through
+    knots between them. The message therefore reports what is actually true of every
+    case it fires on -- each consecutive step across the domain is at most ``tol`` --
+    rather than claiming the two ends are within ``tol`` of each other, which they need
+    not be.
+
+    Args:
+        knots (npt.NDArray[np.float32 | np.float64]): The knot vector, non-decreasing
+            and already snapped if snapping was requested.
+        degree (int): Polynomial degree, which fixes where the domain starts and ends.
+        num_intervals (int): The space's interval count, one less than the number of
+            distinct in-domain knots.
+        tol (float): The absolute tolerance the count was taken at, from
+            :func:`_knot_tolerance`.
+
+    Raises:
+        ValueError: If ``num_intervals`` is zero.
+    """
+    if num_intervals > 0:
+        return
+
+    last = knots.size - degree - 1
+    lo, hi = float(knots[degree]), float(knots[last])
+    raise ValueError(
+        f"knot vector spans no interval: at degree {degree} the domain runs from "
+        f"knots[{degree}] = {lo!r} to knots[{last}] = {hi!r}, and every step between "
+        f"them is at most this vector's tolerance of {tol:.3g}, so its in-domain knots "
+        f"are all one knot, the space has no cell, and nothing can be evaluated, "
+        f"tabulated or located on it. The domain needs two consecutive knots more than "
+        f"{tol:.3g} apart."
     )
 
 
@@ -841,6 +905,7 @@ def _warmup_numba_functions() -> None:
 
 __all__ = [
     "_check_snapping_kept_an_interval",
+    "_check_space_has_an_interval",
     "_check_spline_info",
     "_count_multiplicity",
     "_find_knot_index_and_multiplicity",

--- a/src/pantr/bspline/_bspline_space_1d.py
+++ b/src/pantr/bspline/_bspline_space_1d.py
@@ -29,6 +29,7 @@ from ._bspline_knot_insertion import (
 )
 from ._bspline_knots import (
     _check_snapping_kept_an_interval,
+    _check_space_has_an_interval,
     _get_Bspline_cardinal_intervals_1D_impl,
     _get_Bspline_num_basis_1D_impl,
     _get_unique_knots_and_multiplicity_impl,
@@ -82,6 +83,10 @@ class BsplineSpace1D:
     parameters, compute various geometric characteristics of the spline,
     and access various properties of the B-spline.
 
+    An instance always has :attr:`num_intervals` at least 1: a knot vector whose
+    in-domain knots all fall in one class is refused at construction, since such a
+    space has no cell and nothing can be evaluated, tabulated or located on it.
+
     Attributes:
         _tol (float): Absolute tolerance for parametric comparisons on this space,
             in the units of its knots. Derived once at construction by
@@ -117,12 +122,15 @@ class BsplineSpace1D:
 
         Raises:
             ValueError: If degree is negative, knots are insufficient, or knots are
-                not non-decreasing; or if ``snap_knots`` is set and snapping
-                collapses a knot vector that had more than one distinct knot onto a
-                single point, which means the requested spacing is finer than the
-                dtype resolves at that coordinate magnitude. A vector that was
-                already degenerate is accepted unchanged, and ``snap_knots=False``
-                bypasses both the merging and this check.
+                not non-decreasing; if the resulting space would span no interval,
+                i.e. every step between ``knots[degree]`` and ``knots[-degree-1]`` is
+                within :attr:`tolerance`, so the domain is one knot and the space has
+                no cell; or if
+                ``snap_knots`` is set and snapping is what collapsed a knot vector
+                that had more than one distinct knot onto that single point, which
+                means the requested spacing is finer than the dtype resolves at that
+                coordinate magnitude. ``snap_knots=False`` bypasses the merging and
+                the snapping diagnosis, but not the interval requirement.
             TypeError: If knots cannot be converted to a numpy array.
         """
         BsplineSpace1D._validate_input(knots, degree, periodic)
@@ -146,7 +154,12 @@ class BsplineSpace1D:
 
         if snap_knots:
             self._snap_knots()
+            # Runs first: when snapping is what destroyed the mesh, its diagnosis is
+            # the specific one and names the remedy. The check below owns the same
+            # symptom from any other cause, including ``snap_knots=False``.
             _check_snapping_kept_an_interval(knots_arr, self._knots, self._tol)
+
+        _check_space_has_an_interval(self._knots, self._degree, self.num_intervals, self._tol)
 
         self._knots.flags.writeable = False
 

--- a/tests/test_knot_tolerance_absolute.py
+++ b/tests/test_knot_tolerance_absolute.py
@@ -49,6 +49,7 @@ from pantr.bspline._bspline_knots import (
     _find_knot_index_and_multiplicity,
     _get_unique_knots_and_multiplicity_impl,
     _is_in_domain_impl,
+    _knot_tolerance,
 )
 from pantr.bspline._bspline_product import _get_boundary_mults
 from pantr.bspline._bspline_restrict import (
@@ -591,9 +592,20 @@ class TestDerivedKnotTolerance:
         read off the input -- and the vector is all one knot either way. Pinned
         because a zero tolerance is the kind of degenerate value that invites a
         well-meaning floor.
+
+        Exercised through the knot layer rather than through a space, because
+        ``_knot_scale`` is ``max(span, |knots[0]|, |knots[-1]|)`` and so vanishes only
+        when the whole vector is zero -- which is exactly the zero-interval case
+        ``BsplineSpace1D`` refuses since issue #320. The scale-free regime is
+        therefore reachable in the knot layer and nowhere above it, and that is a
+        property of the derivation worth stating rather than a gap in the test.
         """
-        space = BsplineSpace1D(np.zeros(8, dtype=np.float64), 3)
-        assert space.tolerance == 0.0
-        unique, mults = space.get_unique_knots_and_multiplicity()
+        knots = np.zeros(8, dtype=np.float64)
+        assert _knot_tolerance(knots) == 0.0
+
+        unique, mults = _get_unique_knots_and_multiplicity_impl(knots, 3, 0.0, False)
         assert unique.tolist() == [0.0]
         assert mults.tolist() == [8]
+
+        with pytest.raises(ValueError, match="spans no interval"):
+            BsplineSpace1D(knots, 3)

--- a/tests/test_sweep_regressions.py
+++ b/tests/test_sweep_regressions.py
@@ -429,25 +429,38 @@ def test_a_domain_below_its_own_resolution_is_refused() -> None:
     assert resolved.num_intervals == 2
 
 
-def test_an_already_degenerate_knot_vector_is_still_accepted() -> None:
-    """The refusal fires only when *snapping* destroyed the mesh, not when it arrived flat.
+def test_the_snapping_refusal_does_not_claim_a_vector_that_arrived_flat() -> None:
+    """The *snapping* diagnosis fires only when snapping destroyed the mesh.
 
-    A caller who passes a knot vector that is already a single repeated value asked for
-    exactly that and gets it, at any magnitude and in either dtype. Distinguishing the
-    two is what keeps the new rejection from being a general ban on degenerate spaces:
-    the case worth refusing is the one the caller could not see coming.
+    A vector that arrived flat is refused too -- issue #320 moved that to
+    ``_check_space_has_an_interval``, because a space with no interval has no cell and
+    three of its consumers answered ``0.0`` or ``NaN`` rather than raising. What this
+    test guards is that the two keep their own messages: "this mesh is finer than
+    float32 resolves here" tells a caller who supplied a flat vector something false,
+    and points at a remedy that would not help. ``tests/test_zero_interval_space.py``
+    owns the refusal itself.
     """
     for dtype in (np.float32, np.float64):
         for value in (0.0, 1.0, 1e6, -3.5):
-            space = BsplineSpace1D(np.full(8, value, dtype=dtype), 3)
-            assert space.num_intervals == 0
-            assert np.all(np.asarray(space.knots) == dtype(value))
+            with pytest.raises(ValueError, match="spans no interval"):
+                BsplineSpace1D(np.full(8, value, dtype=dtype), 3)
 
-    # And `snap_knots=False` bypasses merging and the check together, as documented.
+    # `snap_knots=False` still bypasses the merging and the snapping diagnosis: the
+    # stored vector comes back exactly as supplied, unmerged.
     lo, hi = 1e6, 1e6 + 1.0
-    raw = np.asarray([lo, lo, lo, lo + 0.5, hi, hi, hi], dtype=np.float32)
+    raw = np.asarray([lo, lo, lo, lo + 0.5, hi, hi, hi], dtype=np.float64)
     kept = BsplineSpace1D(raw, 2, snap_knots=False)
     assert np.array_equal(np.asarray(kept.knots), raw)
+    assert kept.num_intervals == 2
+
+    # What it does *not* bypass, since #320, is the interval requirement. The same
+    # vector in float32 has a tolerance of 0.954 there, so the three domain knots
+    # chain-merge into one group and the space has no cell -- whether or not the
+    # stored vector was snapped, because the interval count is taken with the same
+    # tolerance either way. Before #320 this constructed, and `snap_knots=False` was
+    # a way to obtain the very space the snapping check exists to refuse.
+    with pytest.raises(ValueError, match="spans no interval"):
+        BsplineSpace1D(raw.astype(np.float32), 2, snap_knots=False)
 
 
 def test_snapping_keeps_knots_the_format_can_resolve() -> None:

--- a/tests/test_zero_interval_space.py
+++ b/tests/test_zero_interval_space.py
@@ -1,0 +1,220 @@
+"""A B-spline space with no interval is refused at construction (issue #320).
+
+``BsplineSpace1D`` used to accept a knot vector whose domain is a single point --
+``BsplineSpace1D(np.full(4, 5.0), 1)`` constructed, reported ``num_intervals == 0``
+and a domain of zero extent -- and every consumer then met the degeneracy on its
+own terms. Measured at ``4d1c28a``:
+
+===============================================  ==================================
+entry point                                      behaviour before the fix
+===============================================  ==================================
+``pantr.grid.tensor_product_grid``               ``ValueError`` naming the
+                                                 breakpoints
+``Bspline.evaluate`` away from the point         ``ValueError`` naming the domain
+``Bspline.locate``                               ``ValueError`` from ``numpy``'s
+                                                 zero-size ``min``
+``BsplineSpace1D.tabulate_basis_derivatives``    ``ZeroDivisionError``
+``BsplineSpace1D.tabulate_basis``                returned ``[[nan, nan]]``
+``Bspline.evaluate`` *at* the point              returned ``0.0``
+``Bspline.evaluate_derivatives`` at it           returned ``nan``
+===============================================  ==================================
+
+The last three are why the decision went to the constructor rather than to each
+consumer: a guard added per entry point has to be added to every one of them, and
+the three that returned a value would not have been found by surveying what
+raises. One rule at the one place a space comes into being covers all of them, and
+it matches ``create_cardinal_knots``, which has always refused
+``num_intervals < 1``.
+
+The ticket reported ``tabulate_basis`` raising ``AttributeError: 'int' object has
+no attribute 'shape'``. That is unrelated to the degeneracy: its reproduction
+called ``space.tabulate_basis(pts, 0)``, and the second positional parameter is
+``out_basis``, so the ``0`` was validated as an output array. The same call raises
+identically on a healthy space. What ``tabulate_basis`` actually did on a
+zero-interval space is the ``NaN`` in the table above, and ``validate=True`` did
+not catch it, because the query point does lie in the zero-extent domain.
+
+The predicate is ``num_intervals == 0``, not "every knot is the same value": the
+family is wider than the ticket's example. ``BsplineSpace1D([0, 1, 1, 1, 2], 1)``
+has a knot vector with three distinct values and a domain of ``(1.0, 1.0)``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._numba_compat import wait_for_jit_warmup
+from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
+from pantr.bspline._bspline_knots import _knot_tolerance
+
+wait_for_jit_warmup()
+
+
+TICKET_KNOTS = np.full(4, 5.0)
+"""The exact knot vector from the ticket's reproduction."""
+
+TICKET_DEGREE = 1
+"""The degree the ticket's reproduction pairs with :data:`TICKET_KNOTS`."""
+
+_NO_INTERVAL = re.compile("spans no interval")
+"""Match the new refusal without pinning the whole message."""
+
+
+def test_the_ticket_reproduction_is_refused_at_construction() -> None:
+    """AC1/AC3: the ticket's own space, and the message it must now produce.
+
+    Before the fix this constructed silently and the reproduction went on to fail
+    two calls later inside ``numpy``, with ``ValueError: zero-size array to
+    reduction operation minimum which has no identity`` -- a message naming
+    neither the spline nor the degeneracy.
+    """
+    with pytest.raises(ValueError, match=_NO_INTERVAL) as excinfo:
+        BsplineSpace1D(TICKET_KNOTS, TICKET_DEGREE)
+
+    message = str(excinfo.value)
+    # The reader has to be able to act without opening our source: what is wrong,
+    # which coordinate the domain collapsed onto, and what to supply instead.
+    assert "5.0" in message, message
+    assert "degree 1" in message, message
+    assert "two consecutive knots" in message, message
+
+
+def test_the_consumers_the_ticket_named_are_no_longer_reachable() -> None:
+    """AC2: every entry point agrees, because none of them can be handed such a space.
+
+    That is the whole content of the decision. ``tabulate_basis`` grows no guard
+    of its own and needs none: there is no space to call it on.
+    """
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        space = BsplineSpace1D(TICKET_KNOTS, TICKET_DEGREE)
+        # Unreachable. Kept so the test states which calls the refusal now stands
+        # in front of, rather than only that construction failed.
+        spline = Bspline(BsplineSpace([space]), np.array([[0.0], [1.0]]))
+        spline.locate(np.array([0.5]))
+        space.tabulate_basis(np.array([5.0]))
+        space.tabulate_basis_derivatives(np.array([5.0]), 1)
+        spline.evaluate(np.array([[5.0]]))
+        spline.evaluate_derivatives(np.array([[5.0]]), 1)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("value", [0.0, 1.0, -3.5, 1e6])
+@pytest.mark.parametrize("degree", [0, 1, 2, 3])
+def test_a_flat_knot_vector_is_refused_at_every_degree_dtype_and_magnitude(
+    degree: int, value: float, dtype: type[Any]
+) -> None:
+    """The whole of the previously-accepted family, at the shortest length allowed.
+
+    ``2 * degree + 2`` is the minimum ``_validate_input`` requires, so this is the
+    smallest flat vector that reaches the new check at each degree. The magnitudes
+    span the range over which the snapping tolerance itself varies, and ``0.0`` is
+    the one value for which that tolerance is exactly zero.
+    """
+    knots = np.full(2 * degree + 2, value, dtype=dtype)
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        BsplineSpace1D(knots, degree)
+
+
+@pytest.mark.parametrize(
+    ("knots", "degree"),
+    [
+        # Distinct knot values, and still no interval: the domain runs from
+        # ``knots[degree]`` to ``knots[-degree-1]``, and an interior knot of high
+        # enough multiplicity swallows it whole. ``raw[0] == raw[-1]``, the
+        # predicate the snapping check uses, is blind to every one of these.
+        ([0.0, 1.0, 1.0, 2.0], 1),
+        ([0.0, 1.0, 1.0, 1.0, 2.0], 1),
+        ([0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0], 2),
+    ],
+)
+def test_an_interior_knot_that_swallows_the_domain_is_refused_too(
+    knots: list[float], degree: int
+) -> None:
+    """The predicate is ``num_intervals == 0``, not "every knot is the same value"."""
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        BsplineSpace1D(np.asarray(knots), degree)
+
+
+def test_periodic_and_unsnapped_construction_are_covered_as_well() -> None:
+    """Neither ``periodic=True`` nor ``snap_knots=False`` is a way back in.
+
+    ``snap_knots=False`` matters because the library uses it internally
+    (``_bspline_split``, ``_bspline_restrict``, ``_bspline_roots``); had the check
+    ridden on snapping, those paths would have kept the hole open.
+    """
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        BsplineSpace1D(np.full(4, 5.0), 1, periodic=True)
+
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        BsplineSpace1D(np.full(4, 5.0), 1, snap_knots=False)
+
+
+def test_the_snapping_refusal_still_owns_its_own_case() -> None:
+    """The snapping message must not be borrowed for a vector that arrived flat.
+
+    The ticket's Non-goals put the snapping rule out of scope, and the two
+    diagnoses are genuinely different: "this mesh is finer than float32 resolves
+    here" is actionable, and false of a vector the caller supplied flat. Both
+    refuse; each says its own thing.
+    """
+    degree = 2
+    lo, hi = 1e6, 1e6 + 1.0
+    collapsing = np.asarray(
+        [lo] * (degree + 1) + [lo + 0.5] + [hi] * (degree + 1), dtype=np.float32
+    )
+    with pytest.raises(ValueError, match="collapsed every knot"):
+        BsplineSpace1D(collapsing, degree)
+
+    with pytest.raises(ValueError, match=_NO_INTERVAL):
+        BsplineSpace1D(np.full(8, 1e6, dtype=np.float32), degree)
+
+
+def test_the_message_stays_true_when_the_domain_ends_are_not_close() -> None:
+    """A chain of near knots merges two ends that are not near each other.
+
+    The grouping splits on ``knots[i] - knots[i-1] > tol``, so it joins by steps. In
+    float32 at ``1e6`` the tolerance is 0.954, the three domain knots here are 0.5
+    apart in turn, and all three land in one class although the ends are 1.0 apart --
+    more than the tolerance. So a message reading "these two are the same knot at a
+    tolerance of 0.954" would be false, and the remedy it implies ("make them differ
+    by more than 0.954") already holds. What the message reports is the step.
+    """
+    lo, hi = 1e6, 1e6 + 1.0
+    raw = np.asarray([lo, lo, lo, lo + 0.5, hi, hi, hi], dtype=np.float32)
+
+    with pytest.raises(ValueError, match=_NO_INTERVAL) as excinfo:
+        BsplineSpace1D(raw, 2, snap_knots=False)
+
+    message = str(excinfo.value)
+    assert "every step between them is at most" in message, message
+    # The premise of the test: the ends are genuinely further apart than the
+    # tolerance the message quotes, so a span-based claim would have been wrong.
+    assert hi - lo > _knot_tolerance(raw)
+
+
+def test_a_space_with_a_single_interval_is_untouched() -> None:
+    """The ticket's invariant: nothing changes for a space that has an interval.
+
+    One interval is the boundary of the new rule, so it is what would break first
+    if the predicate were off by one. Every entry point the ticket listed is
+    exercised on it.
+    """
+    space = BsplineSpace1D(np.array([0.0, 0.0, 1.0, 1.0]), 1)
+    assert space.num_intervals == 1
+    assert space.domain == (0.0, 1.0)
+
+    values, _ = space.tabulate_basis(np.array([0.0, 0.5, 1.0]))
+    basis: npt.NDArray[np.float64] = np.asarray(values, dtype=np.float64)
+    assert np.allclose(basis.sum(axis=-1), 1.0)
+    space.tabulate_basis_derivatives(np.array([0.5]), 1)
+
+    spline = Bspline(BsplineSpace([space]), np.array([[0.0], [1.0]]))
+    assert np.allclose(np.asarray(spline.evaluate(np.array([[0.25]]))), 0.25)
+    cell_ids, ref_coords = spline.locate(np.array([[0.25]]))
+    assert np.array_equal(np.asarray(cell_ids), np.array([0]))
+    assert np.allclose(np.asarray(ref_coords).ravel(), 0.25)


### PR DESCRIPTION
## What

`BsplineSpace1D` accepted a knot vector whose domain is a single point. Every consumer then met the degeneracy on its own terms. This adds one rule at the one place a space comes into being: a space with no interval is refused at construction.

Measured at `4d1c28a` on the ticket's own space, `BsplineSpace1D(np.full(4, 5.0), 1)`:

| entry point | before |
|---|---|
| `pantr.grid.tensor_product_grid` | `ValueError` naming the breakpoints |
| `Bspline.evaluate` away from the point | `ValueError` naming the domain |
| `Bspline.locate` | `ValueError` from numpy's zero-size `min` |
| `BsplineSpace1D.tabulate_basis_derivatives` | `ZeroDivisionError: division by zero` |
| `BsplineSpace1D.tabulate_basis` | **returned `[[nan, nan]]`** |
| `Bspline.evaluate` *at* the point | **returned `0.0`** |
| `Bspline.evaluate_derivatives` at it | **returned `nan`** |

The last three are why the rule went to the constructor rather than to each consumer: a per-entry-point guard has to be written for every one of them, and the three that returned a value would not have been found by surveying what raises. `create_cardinal_knots` has always applied this rule as `num_intervals must be at least 1`; the direct constructor was the hole.

## Two corrections to the ticket

**The severity argument is wrong.** The ticket says "no wrong value is ever produced". Three entry points return one, as measured above. The two `NaN` cases carry only a `RuntimeWarning: invalid value encountered in divide`, which nothing raises on.

**The `tabulate_basis` symptom is not a symptom.** The ticket reports `AttributeError: 'int' object has no attribute 'shape'`. Its reproduction calls `space.tabulate_basis(pts, 0)`, and the second positional parameter is `out_basis`, so the `0` was validated as an output array. The same call raises identically on a healthy space:

```
healthy space, ticket's literal call -> AttributeError : 'int' object has no attribute 'shape'
```

What `tabulate_basis` actually did on a zero-interval space is the `NaN` above, and `validate=True` did not catch it because the query point does lie in the zero-extent domain.

## The predicate

`num_intervals == 0`, not "every knot is the same value". The family is wider than the ticket's example: `BsplineSpace1D([0, 1, 1, 1, 2], 1)` holds three distinct knot values and still has a domain of `(1.0, 1.0)`, because the domain runs from `knots[degree]` to `knots[-degree-1]` and an interior knot of high enough multiplicity swallows it whole. `raw[0] == raw[-1]`, the predicate the snapping check uses, is blind to it.

No new threshold is introduced: the count is taken with the tolerance the space already uses everywhere else.

## What the message says, and why

Knot grouping splits on `knots[i] - knots[i-1] > tol`, so it chains. At float32 around `1e6` the tolerance is 0.954 and three knots 0.5 apart in turn merge into one class although the domain ends are 1.0 apart. A message claiming the two ends are "the same knot at tolerance 0.954" would be false there, and its implied remedy would already hold. The message therefore reports the consecutive step, which is true of every case it fires on. `test_the_message_stays_true_when_the_domain_ends_are_not_close` pins exactly that case.

## Deliberate behavior changes

- **A public constructor now rejects input it used to accept.** This is the reversal the ticket names as one of its two options.
- **`snap_knots=False` no longer evades the check.** It still bypasses the merging and the snapping diagnosis, but not the interval requirement, which it could previously be used to evade: `BsplineSpace1D(raw.astype(np.float32), 2, snap_knots=False)` on a 1e6-based vector built a zero-interval space before this change.
- The snapping refusal keeps its own case and its own message and now runs first. Its docstring no longer documents the acceptance; it points at the new rule instead. The ticket's Non-goal on snapping logic is respected: nothing in the merge rule changed.

## Acceptance criteria

- **AC1 — VERIFIED.** The ticket's literal reproduction now fails at the constructor: `ValueError: knot vector spans no interval: at degree 1 the domain runs from knots[1] = 5.0 to knots[2] = 5.0, and every step between them is at most this vector's tolerance of 8.88e-15, so its in-domain knots are all one knot, the space has no cell, and nothing can be evaluated, tabulated or located on it. The domain needs two consecutive knots more than 8.88e-15 apart.`
- **AC2 — VERIFIED.** `tabulate_basis` agrees, because there is no space to call it on: the same `ValueError` arrives at construction. It grows no guard of its own. The `AttributeError` the criterion names was a caller error, per the correction above.
- **AC3 — VERIFIED.** `tests/test_zero_interval_space.py` carries the exact space. Against `4d1c28a` source with the tests in place, 40 of its 41 tests fail; the one that passes is `test_a_space_with_a_single_interval_is_untouched`, which must pass on both sides. All 41 pass on this branch.
- **AC4 — VERIFIED.** Written down in three places: `_check_space_has_an_interval`'s docstring in `_bspline_knots.py`, which is where the acceptance used to be documented and is now cross-referenced from `_check_snapping_kept_an_interval`; the `BsplineSpace1D` class docstring and its `__init__` `Raises:`; and `docs/guide/spaces-knots.md` for the user-facing side.

## Interaction with an open xfail

`tests/test_sweep_regressions.py::test_knot_factories_agree_on_zero_intervals` is still `xfail(strict=True)` and says "either answer would be defensible: reject zero as the cardinal factory does, or return an empty-domain vector". This PR settles that question for the library: reject. Whoever closes that finding should make the two accepting factories reject rather than return an empty-domain vector. Left untouched here, since factory behavior is outside this ticket.

## Checks

Full suite on the whole repo, in the `pantr` env: `ruff check` 0, `ruff format --check` 0, `mypy` 0 (234 files), `lint-imports` 0, `pytest` **5474 passed, 21 skipped, 3 xfailed**, docs build with `-W --keep-going` 0. `tests/test_zero_interval_space.py` also run alone 4/4 clean, against the warmup-barrier abort trap.

## Gates

- **Tolerance gate — not fired.** No tolerance, threshold, epsilon or clamp is introduced. The predicate is an integer count, and the `tol` the message quotes is the space's existing `_knot_tolerance`.
- **Numerical-stress gate — not fired.** No algorithm, kernel or certificate is added; the change removes a class of input.
- **Claims gate — fired, and it caught something.** The first draft of the message asserted the two domain ends were within tolerance of each other. Grouping is chain-based, so that is false whenever intermediate knots bridge a wider gap; the message and its docstring were corrected and the case pinned by a test.

Closes #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
