### PR TITLE
fix(cad): compare and blend a rational Coons patch's corners in homogeneous data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -81,7 +81,7 @@
   comparison — and a disagreement raises a `ValueError` naming the corner and the column
   group that decided. Rescaling *every* curve's homogeneous coefficients by one constant
   is not a disagreement and is still accepted; it describes the same patch. Polynomial
-  input is unaffected, byte for byte.
+  input is unaffected.
 - **A weight disagreement between two rational Coons faces is refused at every model
   size.** The edge check took one magnitude over a homogeneous control row, which mixes
   coordinates (length times weight) with weights (dimensionless), so a weight error was
@@ -255,7 +255,14 @@
   corner weight came out as `2w - 1` instead of `w`. It is now read homogeneously and built
   by the same helper the volume's corner term uses (`_build_trilinear_volume` became
   `_build_multilinear_corner_term`, taking its dimension from the corners), so the two
-  paths cannot drift apart again. Polynomial patches are byte-identical to before.
+  paths cannot drift apart again. Polynomial patches at float64 are byte-identical to
+  before. At float32 they are byte-identical too *unless* the corner term needs degree
+  elevation or knot insertion to meet the two ruled terms, in which case they differ by a
+  couple of float32 ulps (measured: 2 ulps, `2.384e-07` at unit scale): the corner term
+  used to be built at float64 whatever the model's dtype and rounded down once at the end,
+  and it is now built in the curves' own precision like every other term. That is the
+  no-promotion rule the previous release adopted for this function, applied to the one term
+  that still escaped it.
 - **A Coons patch from curves carrying two coordinates builds** instead of dying in NumPy
   with `operands could not be broadcast together with shapes (2,2,2) (2,2,3) (2,2,2)`,
   which named nothing the caller had supplied. The corner term no longer goes through

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,23 @@
   caller re-resolves cells after a refine or a coarsen has reassigned ids.
 
 ### Rejected where it used to be accepted
+- **Four Coons boundary curves that disagree in homogeneous data at a shared corner are
+  refused.** The patch's corner check read its corners through `boundary()`, which
+  *projects*, so both readings were physical points and agreed exactly whenever the
+  geometry did; the weight never entered the comparison. But a homogeneous representation
+  is unique only up to one constant scaling all of a patch's weights, so two curves can
+  name the same point of space at a corner while supplying different `(w x, w y, w z, w)`
+  there, and the three-term blend — formed homogeneously and projected only on evaluation
+  — then fails to cancel. Measured on a unit square with a single rational boundary whose
+  weights run 1 to 2: every corner matched to `1.1e-16` and the patch missed one of the
+  four curves it had been handed by `1.7e-01`, 17% of the model. Corners are now compared
+  as homogeneous coefficients, with the coordinate and weight columns in separate scale
+  groups so a dimensionless weight is never graded against the model's length — the rule
+  `_verify_shared_boundary` and the volume's edge check already apply to the same kind of
+  comparison — and a disagreement raises a `ValueError` naming the corner and the column
+  group that decided. Rescaling *every* curve's homogeneous coefficients by one constant
+  is not a disagreement and is still accepted; it describes the same patch. Polynomial
+  input is unaffected, byte for byte.
 - **A weight disagreement between two rational Coons faces is refused at every model
   size.** The edge check took one magnitude over a homogeneous control row, which mixes
   coordinates (length times weight) with weights (dimensionless), so a weight error was
@@ -230,6 +247,20 @@
   endpoint condition and still returns the mean of the control points.
 
 ### Fixed
+- **A rational Coons patch carries the corner weight its curves agreed on.** The corner
+  term of `create_coons_surface` was read through `boundary()` and then promoted with unit
+  weights, so four curves agreeing homogeneously at every corner still produced a patch
+  that missed them whenever the weight they agreed on was not 1: measured `2.2e-02` on a
+  degree-2 model whose corner weights were all 2, with nothing refused, and the blend's
+  corner weight came out as `2w - 1` instead of `w`. It is now read homogeneously and built
+  by the same helper the volume's corner term uses (`_build_trilinear_volume` became
+  `_build_multilinear_corner_term`, taking its dimension from the corners), so the two
+  paths cannot drift apart again. Polynomial patches are byte-identical to before.
+- **A Coons patch from curves carrying two coordinates builds** instead of dying in NumPy
+  with `operands could not be broadcast together with shapes (2,2,2) (2,2,3) (2,2,2)`,
+  which named nothing the caller had supplied. The corner term no longer goes through
+  `create_bilinear`, a public *geometric* primitive that zero-pads its corners to rank 3 —
+  the same reason the volume never used `create_trilinear` for its own corner term.
 - **`create_coons_volume` builds from rational faces** instead of failing with a NumPy
   shape error. The seven-term blend was already formed from homogeneous coefficients
   throughout; only the corner read left that space, through `boundary()`, which projects.

--- a/docs/guide/cad.md
+++ b/docs/guide/cad.md
@@ -161,6 +161,33 @@ blend volumes from edge quadruples, and $T$ is the trilinear corner
 interpolant.  Edges and corners are extracted automatically from face
 boundaries.
 
+### Rational boundaries, and what the blend requires of them
+
+Both Coons constructors accept rational (NURBS) input, and both apply the blend to
+homogeneous coefficients $(w\,x, w\,y, w\,z, w)$, projecting only at evaluation. That
+is what makes the result pass through the boundaries it was built from: projection is
+pointwise, so it commutes with restriction to a boundary.
+
+The catch is that the argument needs the pieces to agree in *homogeneous* data where they
+meet, weights included, and not merely to trace the same points of space. A homogeneous
+representation is unique only up to one constant scaling **all** of a patch's weights, so
+two curves can name the same corner while carrying different weights there, and the
+inclusion-exclusion then fails to cancel. Input like that is refused, with a `ValueError`
+naming the corner (or, for a volume, the edge) and whether the coordinates or the weights
+disagreed:
+
+```python
+c_v0 = ...  # ends at (0, 1, 0) carrying weight 2
+c_u1 = ...  # starts at (0, 1, 0) carrying weight 1
+create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+# ValueError: Corner (0,1) mismatch: C_u1 gives [0. 1. 0. 1.], C_v0 gives [0. 2. 0. 2.] ...
+```
+
+Rescaling every curve's homogeneous coefficients by the same constant is not a
+disagreement and is accepted; it describes the same patch. A polynomial curve among
+rational ones is promoted with unit weights, so mixed input needs the rational curves to
+carry weight 1 where they meet a polynomial one.
+
 ## Compatibility and assembly
 
 ### make_compat

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -52,6 +52,30 @@ class _EdgeReadings(NamedTuple):
     corners: tuple[str, str]
 
 
+class _CornerReadings(NamedTuple):
+    """One corner of a Coons patch, as read off each of the two curves that carry it.
+
+    Two curves meet at each corner of a patch, so each of the four corners can be read
+    twice, and the two readings must agree -- in homogeneous data, weights included -- for
+    the patch to interpolate both curves.
+
+    Attributes:
+        label (str): Corner name ``"(i,j)"``, by side along u and v.
+        u_curve (str): Name of the u-curve carrying it, as the mismatch message prints it.
+        from_u (npt.NDArray[np.float32 | np.float64]): The corner as ``u_curve`` sees it,
+            in that curve's own precision.
+        v_curve (str): Name of the v-curve carrying it.
+        from_v (npt.NDArray[np.float32 | np.float64]): The corner as ``v_curve`` sees it,
+            in that curve's own precision.
+    """
+
+    label: str
+    u_curve: str
+    from_u: npt.NDArray[np.float32 | np.float64]
+    v_curve: str
+    from_v: npt.NDArray[np.float32 | np.float64]
+
+
 class _ComparedEdge(NamedTuple):
     """One edge's two readings, made comparable, with the column groups that grade them.
 
@@ -209,7 +233,7 @@ def create_coons_surface(
     # refuse v-curves that contradict them there.  These are read in the curves' own
     # precision, not float64: it is the precision the disagreement is graded at.
     corners = _extract_corners_2d((c_u0, c_u1), is_rational=rational_curves)
-    _verify_corners_2d(corners, (c_v0, c_v1), is_rational=rational_curves)
+    _verify_corners_2d((c_u0, c_u1), (c_v0, c_v1), is_rational=rational_curves)
 
     # R0: ruled in v from C_v0 to C_v1, then transpose to (u, v)
     r0 = create_ruled(c_v0, c_v1).permute_directions([1, 0])
@@ -270,7 +294,7 @@ def _extract_corners_2d(
 
 
 def _verify_corners_2d(
-    u_corners: npt.NDArray[np.float32 | np.float64],
+    u_curves: tuple[Bspline, Bspline],
     v_curves: tuple[Bspline, Bspline],
     *,
     is_rational: bool,
@@ -347,12 +371,20 @@ def _verify_corners_2d(
     whole set.  That is what :func:`_extract_corners_2d` needs anyway: the corner term is one
     of three summed in a single space.
 
+    **Each of the eight readings is taken from its own curve**, rather than four of them
+    from :func:`_extract_corners_2d`'s output.  That array is sized from ``C_u0`` alone, so
+    routing ``C_u1``'s corners through it would widen them to ``C_u0``'s dtype and
+    :func:`~pantr.cad._validation._coarsest_dtype` would no longer see the precision they
+    were actually supplied in -- reading the tier at float64 for a float32 curve, and
+    refusing a corner by a factor of ``2**17`` more than that curve can express.  Curves of
+    different precisions are not a supported input, but they are a reachable one, and this
+    is the direction that errs towards accepting them.
+
     Args:
-        u_corners (npt.NDArray[np.float32 | np.float64]): Corner coefficients of shape
-            ``(2, 2, rank)`` read off the u-curves, as :func:`_extract_corners_2d` returns
-            them, in those curves' own dtype.
-        v_curves (tuple[Bspline, Bspline]): ``(C_v0, C_v1)``, the boundaries at ``u = 0`` and
-            ``u = 1``, each free in v, whose own endpoints are compared against *u_corners*.
+        u_curves (tuple[Bspline, Bspline]): ``(C_u0, C_u1)``, the boundaries at ``v = 0``
+            and ``v = 1``, each free in u and already made compatible with each other.
+        v_curves (tuple[Bspline, Bspline]): ``(C_v0, C_v1)``, the boundaries at ``u = 0``
+            and ``u = 1``, each free in v.
         is_rational (bool): Whether the patch being built is rational, i.e. whether the
             readings carry a trailing weight column that has to be graded against the weights.
 
@@ -360,17 +392,20 @@ def _verify_corners_2d(
         ValueError: If any pair of corners does not match, in either column group.
     """
     if is_rational:
+        u_curves = (_promote_to_rational(u_curves[0]), _promote_to_rational(u_curves[1]))
         v_curves = (_promote_to_rational(v_curves[0]), _promote_to_rational(v_curves[1]))
+    c_u0, c_u1 = u_curves
     c_v0, c_v1 = v_curves
 
-    pairs = [
-        ("(0,0)", u_corners[0, 0], _homogeneous_endpoint(c_v0, 0)),
-        ("(1,0)", u_corners[1, 0], _homogeneous_endpoint(c_v1, 0)),
-        ("(0,1)", u_corners[0, 1], _homogeneous_endpoint(c_v0, 1)),
-        ("(1,1)", u_corners[1, 1], _homogeneous_endpoint(c_v1, 1)),
+    read = _homogeneous_endpoint
+    corners = [
+        _CornerReadings("(0,0)", "C_u0", read(c_u0, 0), "C_v0", read(c_v0, 0)),
+        _CornerReadings("(1,0)", "C_u0", read(c_u0, 1), "C_v1", read(c_v1, 0)),
+        _CornerReadings("(0,1)", "C_u1", read(c_u1, 0), "C_v0", read(c_v0, 1)),
+        _CornerReadings("(1,1)", "C_u1", read(c_u1, 1), "C_v1", read(c_v1, 1)),
     ]
     groups = _column_groups(is_rational=is_rational)
-    readings = [corner for _, pu, qv in pairs for corner in (pu, qv)]
+    readings = [r for c in corners for r in (c.from_u, c.from_v)]
     tier = get_conservative(_coarsest_dtype(*readings))
     # No floor: a group whose eight readings are all zero has no scale, and is also bitwise
     # equal, so a zero tolerance is the right answer there rather than a hazard.
@@ -378,16 +413,17 @@ def _verify_corners_2d(
         group.name: max(float(np.abs(r[group.columns]).max()) for r in readings) for group in groups
     }
 
-    for label, pu, qv in pairs:
+    for c in corners:
         # Coordinates first: a curve given in the wrong place fails there, and it is the
         # more informative half to report when both groups are out.
         for group in groups:
-            gap = float(np.abs(pu[group.columns] - qv[group.columns]).max())
+            gap = float(np.abs(c.from_u[group.columns] - c.from_v[group.columns]).max())
             scale = scales[group.name]
             tol = tier * scale
             if gap > tol:
                 raise ValueError(
-                    f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv} "
+                    f"Corner {c.label} mismatch: {c.u_curve} gives {c.from_u}, "
+                    f"{c.v_curve} gives {c.from_v} "
                     f"(gap {gap:.3e}, above {tol:.3e} at corner {group.name} "
                     f"scale {scale:.3e})."
                 )
@@ -464,8 +500,12 @@ def create_coons_volume(
         ValueError: If any face is not a 2D B-spline.
         ValueError: If two faces meeting at a corner of the volume disagree there by more
             than ``4096 * eps`` times the largest absolute coordinate over all
-            twenty-four corner readings -- the same tier and the same scale rule as
-            :func:`create_coons_surface`, derived in ``_verify_corners_3d``.
+            twenty-four corner readings, derived in ``_verify_corners_3d``.  Same tier as
+            :func:`create_coons_surface`, but one undivided scale rather than that
+            function's two column groups: these are **projected** points and so carry one
+            physical dimension between them, while a patch compares homogeneous
+            coefficients.  A weight disagreement on the volume path is caught by
+            ``_verify_edges_3d`` instead, which does split the columns.
         ValueError: If two faces sharing an edge disagree along it by more than
             ``4096 * eps`` times that column group's own magnitude over the twelve
             compared edges: the largest absolute homogeneous coordinate for the

--- a/src/pantr/cad/_coons.py
+++ b/src/pantr/cad/_coons.py
@@ -16,7 +16,7 @@ from ..bspline import Bspline, BsplineSpace, BsplineSpace1D
 from ..tolerance import get_conservative
 from ._compat import make_compat
 from ._operations import create_ruled
-from ._primitives import _linear_space_1d, create_bilinear
+from ._primitives import _linear_space_1d
 from ._validation import (
     _coarsest_dtype,
     _column_groups,
@@ -98,9 +98,10 @@ def _combine_control_points(
     back float64 coefficients for a float32 model would therefore not build at all, and
     would in any case be a precision escalation no other pantr operation performs -- both
     :func:`~pantr.cad.create_ruled` and :func:`~pantr.cad.make_compat` stay in the dtype
-    they were given.  A term built here rather than derived from the caller's data may
-    still arrive at float64 (the corner interpolant of a patch does), and is read down
-    into the accumulator; nothing in the sum is promoted.
+    they were given.  Every term is built in the precision of the data it was read from,
+    including the corner interpolant, so on supported input the accumulator narrows nothing;
+    the read-down covers curves or faces supplied at *different* precisions, which is not a
+    supported combination and follows the first one's.  Nothing in the sum is promoted.
 
     Args:
         bsplines: B-splines that share the same space (after compat).  The first one
@@ -140,6 +141,29 @@ def create_coons_surface(
         o--------------o
         C_v0   C_u0
 
+    **Rational curves are supported, and the blend is applied in homogeneous space.**  All
+    three terms are formed from homogeneous coefficients ``(w x, w y, w z, w)`` and the
+    result is projected only when it is evaluated, so the formula stays the linear one above
+    and nothing has to be said about how weights combine under division.  That is what makes
+    the boundary property survive: projection is pointwise, so it commutes with restriction
+    to a boundary, and a blend whose *homogeneous* restriction to ``u = 0`` is ``C_v0``'s
+    homogeneous data projects to ``C_v0`` itself.  A polynomial curve among rational ones is
+    promoted with unit weights, so mixed input takes the same path rather than a third one.
+
+    That argument has a hypothesis, and it is the one the corner check enforces: **the four
+    curves must agree in homogeneous data where they meet, weights included, not merely
+    projectively.**  A homogeneous representation is unique only up to one constant scaling
+    all of a patch's weights, so two curves can name the same point of space at a shared
+    corner while their coefficients differ by a factor, and the three-term inclusion-exclusion
+    then does not cancel.  Curves that disagree are **refused** rather than blended, which is
+    the verdict :func:`create_coons_volume` reaches on faces that disagree along a shared
+    edge.  Rescaling *every* curve's homogeneous coefficients by one constant is not a
+    disagreement and is accepted, since it describes the same patch.
+
+    This is measured rather than feared: with a single rational boundary whose weights run 1
+    to 2, every corner matched to ``1.1e-16`` and the patch missed one of the four curves it
+    was handed by 17% of the model (pantr issue 327).
+
     Args:
         curves: ``((C_v0, C_v1), (C_u0, C_u1))`` -- two pairs of
             opposite boundary curves.  ``C_v0`` and ``C_v1`` run in the
@@ -151,15 +175,21 @@ def create_coons_surface(
         float32 model is returned at float32 rather than promoted, matching
         :func:`~pantr.cad.create_ruled` and :func:`~pantr.cad.make_compat`.  Curves of
         *different* precisions are not a supported input and the result then follows
-        ``curves[0][0]``'s.
+        ``curves[0][0]``'s.  Because it returns rather than raising, the four curves agree
+        at every shared corner, and the patch therefore restricts to each of them on the
+        corresponding boundary.  That interpolation is exact in exact arithmetic; the
+        floating-point residual is **observed** to stay near ``1e-16`` relative, three
+        orders below the tolerance the check below uses, and is not a proved bound.
 
     Raises:
         ValueError: If any curve is not 1D.
-        ValueError: If corner points are not geometrically consistent, i.e. two curves
-            disagree at a shared corner by more than ``4096 * eps`` times the largest
-            absolute coordinate over all eight corner values, with ``eps`` read at the
-            **coarsest** of the four curves' precisions rather than at float64, so that a
-            float32 model is graded against something float32 can express.
+        ValueError: If two curves disagree at a shared corner by more than ``4096 * eps``
+            times that column group's own magnitude over all eight corner readings: the
+            largest absolute homogeneous coordinate for the coordinate columns, and the
+            largest absolute weight for the weight column of a rational patch.  ``eps`` is
+            read at the **coarsest** of the eight readings' precisions rather than at
+            float64, so that a float32 model is graded against something float32 can
+            express.  ``_verify_corners_2d`` derives all of it.
     """
     (c_v0, c_v1), (c_u0, c_u1) = curves
 
@@ -171,26 +201,22 @@ def create_coons_surface(
     c_u0, c_u1 = make_compat(c_u0, c_u1)
     c_v0, c_v1 = make_compat(c_v0, c_v1)
 
-    # Extract and verify corner points.  These are read in the curves' own precision,
-    # not float64: it is the precision the disagreement is graded at.
-    p00 = np.asarray(c_u0.boundary(0, 0))
-    p10 = np.asarray(c_u0.boundary(0, 1))
-    p01 = np.asarray(c_u1.boundary(0, 0))
-    p11 = np.asarray(c_u1.boundary(0, 1))
+    # Rationality is the patch's, not each curve's: the three terms are added together and
+    # so have to share one space, in which a polynomial curve carries unit weights.
+    rational_curves = any(c.is_rational for c in (c_u0, c_u1, c_v0, c_v1))
 
-    _verify_corners_2d((p00, p10, p01, p11), c_v0, c_v1)
+    # Read the corners off the u-curves in the space the three terms are combined in, and
+    # refuse v-curves that contradict them there.  These are read in the curves' own
+    # precision, not float64: it is the precision the disagreement is graded at.
+    corners = _extract_corners_2d((c_u0, c_u1), is_rational=rational_curves)
+    _verify_corners_2d(corners, (c_v0, c_v1), is_rational=rational_curves)
 
     # R0: ruled in v from C_v0 to C_v1, then transpose to (u, v)
     r0 = create_ruled(c_v0, c_v1).permute_directions([1, 0])
     # R1: ruled in u from C_u0 to C_u1 (already in (u, v) order)
     r1 = create_ruled(c_u0, c_u1)
     # B: bilinear from corners
-    corners = np.zeros((2, 2, p00.size), dtype=np.float64)
-    corners[0, 0] = p00
-    corners[1, 0] = p10
-    corners[0, 1] = p01
-    corners[1, 1] = p11
-    b = create_bilinear(corners)
+    b = _build_multilinear_corner_term(corners, is_rational=rational_curves)
 
     r0, r1, b = make_compat(r0, r1, b)
 
@@ -198,21 +224,62 @@ def create_coons_surface(
     return Bspline(r0.space, cp, is_rational=is_rational)
 
 
-def _verify_corners_2d(
-    u_corners: tuple[
-        npt.NDArray[np.float32 | np.float64],
-        npt.NDArray[np.float32 | np.float64],
-        npt.NDArray[np.float32 | np.float64],
-        npt.NDArray[np.float32 | np.float64],
-    ],
-    c_v0: Bspline,
-    c_v1: Bspline,
-) -> None:
-    """Verify that corner points from u-curves match v-curves.
+def _extract_corners_2d(
+    u_curves: tuple[Bspline, Bspline], *, is_rational: bool
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Extract a Coons patch's 4 corner coefficients from the two curves free in u.
 
-    The tolerance is ``get_conservative(dtype) * scale`` with ``scale`` the largest
-    absolute coordinate over **all eight** corner values, not just the pair under test,
-    and ``dtype`` the coarsest of the eight readings' own precisions.
+    The array is read and sized in **one** space, which is what the corner term of the blend
+    needs.  :meth:`~pantr.bspline.Bspline.boundary` **projects**, so reading a rational corner
+    through it and promoting the result afterwards gives ``(x, y, z, 1)`` where the other two
+    terms carry ``(w x, w y, w z, w)``; the three-term inclusion-exclusion then fails to
+    cancel and the patch misses the curves it was built from by a fraction of the model.
+    Measured with four curves agreeing homogeneously at every corner and all four corner
+    weights 2, that was 2.2% of the model, with nothing refused (pantr issue 327).
+    :func:`_homogeneous_endpoint` is the read that stays in the space the width was taken
+    from, as it is for the volume's :func:`_extract_corners`.
+
+    *is_rational* is the **patch's**, not these two curves': the corner term is one of three
+    that are added together, so it has to live in the same space as the other two even when
+    the u-curves are polynomial and only a v-curve is rational.  Promoting them gives those
+    corners a unit weight, which is the right value exactly when the rational curves carry a
+    unit weight there too -- and :func:`_verify_corners_2d` requires precisely that, since it
+    compares each corner's two readings homogeneously and a polynomial reading promotes to
+    weight one.
+
+    Args:
+        u_curves (tuple[Bspline, Bspline]): ``(C_u0, C_u1)``, the boundaries at ``v = 0`` and
+            ``v = 1``, each free in u and already made compatible with each other.
+        is_rational (bool): Whether the patch being built is rational, i.e. whether the
+            corners are wanted as homogeneous coefficients.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: Corner coefficients of shape ``(2, 2, rank)``,
+        indexed ``[i, j]`` by side along u and v, where ``rank`` counts the weight when
+        *is_rational*, in ``C_u0``'s own dtype.
+    """
+    if is_rational:
+        u_curves = (_promote_to_rational(u_curves[0]), _promote_to_rational(u_curves[1]))
+
+    sample = u_curves[0].control_points
+    corners = np.empty((2, 2, sample.shape[-1]), dtype=sample.dtype)
+    for j, curve in enumerate(u_curves):
+        for i in (0, 1):
+            corners[i, j] = _homogeneous_endpoint(curve, i)
+    return corners
+
+
+def _verify_corners_2d(
+    u_corners: npt.NDArray[np.float32 | np.float64],
+    v_curves: tuple[Bspline, Bspline],
+    *,
+    is_rational: bool,
+) -> None:
+    """Verify that the corners read off the u-curves match what the v-curves say there.
+
+    The tolerance is ``get_conservative(dtype) * scale`` with ``scale`` that column group's
+    own largest absolute value over **all eight** corner readings, not just the pair under
+    test, and ``dtype`` the coarsest of the eight readings' own precisions.
 
     **Why the conservative tier.** Both curves meeting at a corner read it straight off a
     clamped control point, and neither knot insertion nor degree elevation moves a clamped
@@ -251,48 +318,79 @@ def _verify_corners_2d(
     -- ``eps32 / eps64`` is ``2**29 = 5.4e8`` -- and the figure against the *tier* is
     ``1.3e5``.  ``test_the_float32_tier_is_the_only_one_a_float32_corner_can_clear`` pins it.)
 
-    **One column group, because these are points and not coefficients.**
-    :meth:`~pantr.bspline.Bspline.boundary` projects a rational curve down to a point, so
-    all eight readings are physical coordinates in one physical dimension and there is
-    nothing here to separate.  Where a comparison does mix dimensions -- homogeneous
-    coefficients against weights -- it is :func:`_verify_edges_3d`, which splits them.
-    A weight disagreement at a corner of a volume is therefore caught there rather than
-    here, and a rational Coons *patch* has no weight comparison of its own.
+    **A rational patch is compared homogeneously, in two column groups.**  The three terms
+    of the blend are formed from homogeneous coefficients and projected only on evaluation,
+    which is what makes the boundary property survive projection -- but only if the four
+    curves agree in homogeneous data.  A homogeneous representation is unique just up to one
+    constant scaling all of a patch's weights, so two curves can name the same point of space
+    at a shared corner while supplying different ``(w x, w y, w z, w)`` there, and the
+    three-term inclusion-exclusion then fails to cancel.  Reading the corners through
+    :meth:`~pantr.bspline.Bspline.boundary`, which **projects**, hid exactly that: both
+    readings were physical points and agreed whenever the geometry did, so the weight never
+    entered the comparison.  Measured with a single rational boundary whose weights run 1 to
+    2, every corner matched to ``1.1e-16`` and the patch missed one of the four curves it was
+    handed by 17% of the model (pantr issue 327).  :func:`_homogeneous_endpoint` is the read
+    that stops before the division, and :func:`_extract_corners_2d` is where it happens.
+
+    So a rational reading carries a dimensionless weight beside coordinates in units of
+    length times weight, and **each column group is graded against its own magnitude**.  One
+    magnitude over the whole row would grade a weight against a threshold proportional to the
+    model's *length*, which is dimensionally wrong and destroys scale invariance: sending
+    ``x -> lambda x`` scales the homogeneous coordinates and leaves the weights alone.  That
+    rule, its scale-invariance argument and its measured roundoff floor are
+    :func:`~pantr.cad._join._verify_shared_boundary`'s, and :func:`_verify_edges_3d` applies
+    them to the same kind of comparison; this is the third site and does not restate them.
+    A polynomial patch has one group covering every column and is graded exactly as before.
+
+    Unlike :func:`_verify_edges_3d`, rationality here is the **patch's** and not the corner's,
+    so every one of the eight readings carries both groups and both scale populations are the
+    whole set.  That is what :func:`_extract_corners_2d` needs anyway: the corner term is one
+    of three summed in a single space.
 
     Args:
-        u_corners (tuple[npt.NDArray[np.float32 | np.float64], ...]): Corners
-            ``(p00, p10, p01, p11)`` extracted from u-curves, in the curves' own dtype.
-        c_v0 (Bspline): Left boundary curve (v-direction at u=0).
-        c_v1 (Bspline): Right boundary curve (v-direction at u=1).
+        u_corners (npt.NDArray[np.float32 | np.float64]): Corner coefficients of shape
+            ``(2, 2, rank)`` read off the u-curves, as :func:`_extract_corners_2d` returns
+            them, in those curves' own dtype.
+        v_curves (tuple[Bspline, Bspline]): ``(C_v0, C_v1)``, the boundaries at ``u = 0`` and
+            ``u = 1``, each free in v, whose own endpoints are compared against *u_corners*.
+        is_rational (bool): Whether the patch being built is rational, i.e. whether the
+            readings carry a trailing weight column that has to be graded against the weights.
 
     Raises:
-        ValueError: If any pair of corners does not match.
+        ValueError: If any pair of corners does not match, in either column group.
     """
-    p00, p10, p01, p11 = u_corners
-    q00 = np.asarray(c_v0.boundary(0, 0))
-    q01 = np.asarray(c_v0.boundary(0, 1))
-    q10 = np.asarray(c_v1.boundary(0, 0))
-    q11 = np.asarray(c_v1.boundary(0, 1))
+    if is_rational:
+        v_curves = (_promote_to_rational(v_curves[0]), _promote_to_rational(v_curves[1]))
+    c_v0, c_v1 = v_curves
 
     pairs = [
-        ("(0,0)", p00, q00),
-        ("(1,0)", p10, q10),
-        ("(0,1)", p01, q01),
-        ("(1,1)", p11, q11),
+        ("(0,0)", u_corners[0, 0], _homogeneous_endpoint(c_v0, 0)),
+        ("(1,0)", u_corners[1, 0], _homogeneous_endpoint(c_v1, 0)),
+        ("(0,1)", u_corners[0, 1], _homogeneous_endpoint(c_v0, 1)),
+        ("(1,1)", u_corners[1, 1], _homogeneous_endpoint(c_v1, 1)),
     ]
-    # No floor: eight corners all at the origin have no scale, and are also bitwise
-    # equal, so a zero tolerance is the right answer there rather than a hazard.
+    groups = _column_groups(is_rational=is_rational)
     readings = [corner for _, pu, qv in pairs for corner in (pu, qv)]
-    scale = max(float(np.abs(corner).max()) for corner in readings)
-    tol = get_conservative(_coarsest_dtype(*readings)) * scale
+    tier = get_conservative(_coarsest_dtype(*readings))
+    # No floor: a group whose eight readings are all zero has no scale, and is also bitwise
+    # equal, so a zero tolerance is the right answer there rather than a hazard.
+    scales = {
+        group.name: max(float(np.abs(r[group.columns]).max()) for r in readings) for group in groups
+    }
 
     for label, pu, qv in pairs:
-        gap = float(np.abs(pu - qv).max())
-        if gap > tol:
-            raise ValueError(
-                f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv} "
-                f"(gap {gap:.3e}, above {tol:.3e} at corner scale {scale:.3e})."
-            )
+        # Coordinates first: a curve given in the wrong place fails there, and it is the
+        # more informative half to report when both groups are out.
+        for group in groups:
+            gap = float(np.abs(pu[group.columns] - qv[group.columns]).max())
+            scale = scales[group.name]
+            tol = tier * scale
+            if gap > tol:
+                raise ValueError(
+                    f"Corner {label} mismatch: u-curve gives {pu}, v-curve gives {qv} "
+                    f"(gap {gap:.3e}, above {tol:.3e} at corner {group.name} "
+                    f"scale {scale:.3e})."
+                )
 
 
 def create_coons_volume(
@@ -439,7 +537,7 @@ def create_coons_volume(
     )
 
     # Build trilinear volume
-    t = _build_trilinear_volume(corners, is_rational=rational_faces)
+    t = _build_multilinear_corner_term(corners, is_rational=rational_faces)
 
     # Make all 7 terms compatible and combine
     r_u, r_v, r_w, b_uv, b_uw, b_vw, t = make_compat(r_u, r_v, r_w, b_uv, b_uw, b_vw, t)
@@ -821,28 +919,37 @@ def _extract_corners(
     return corners
 
 
-def _build_trilinear_volume(
+def _build_multilinear_corner_term(
     corners: npt.NDArray[np.float32 | np.float64], *, is_rational: bool
 ) -> Bspline:
-    """Build the trilinear corner term of the Coons blend from the 8 corner coefficients.
+    """Build the corner term of a Coons blend from its ``2**dim`` corner coefficients.
 
-    :func:`~pantr.cad.create_trilinear` cannot serve here, for two reasons that both come
-    from its being a public *geometric* primitive: it caps the rank at three, so it
-    rejects the homogeneous ``(w x, w y, w z, w)`` corner of a rational face, and it
-    builds its space at float64 whatever it was handed, which a float32 model cannot then
-    be combined with.  This is the same construction as :func:`_build_bilinear_volume`'s,
-    one direction further.
+    :func:`~pantr.cad.create_bilinear` and :func:`~pantr.cad.create_trilinear` cannot serve
+    here, for two reasons that both come from their being public *geometric* primitives: they
+    cap the rank at three, so they reject the homogeneous ``(w x, w y, w z, w)`` corner of a
+    rational boundary, and they build their space at float64 whatever they were handed, which
+    a float32 model cannot then be combined with.
+
+    The parametric dimension is read from *corners*, so one construction serves the patch's
+    bilinear term and the volume's trilinear one; both are the construction
+    :func:`_build_bilinear_volume` uses for its two blended directions.  Keeping them one
+    function is what stops the two paths drifting apart, which is how the patch came to
+    build its corner term from projected points while the volume built its from homogeneous
+    ones (pantr issue 327).
 
     Args:
         corners (npt.NDArray[np.float32 | np.float64]): Corner coefficients of shape
-            ``(2, 2, 2, rank)``, as :func:`_extract_corners` returns them.
+            ``(2,) * dim + (rank,)``, as :func:`_extract_corners_2d` and
+            :func:`_extract_corners` return them.
         is_rational (bool): Whether *corners* carries a trailing weight column.
 
     Returns:
-        Bspline: A 3D, degree-(1, 1, 1) B-spline volume in (u, v, w) order.
+        Bspline: A *dim*-dimensional B-spline of degree 1 in every direction, in the axis
+        order *corners* is indexed by and in its precision.
     """
+    dim = corners.ndim - 1
     knots = _linear_space_1d(dtype=corners.dtype).knots
-    space = BsplineSpace([BsplineSpace1D(knots.copy(), degree=1) for _ in range(3)])
+    space = BsplineSpace([BsplineSpace1D(knots.copy(), degree=1) for _ in range(dim)])
     return Bspline(space, corners, is_rational=is_rational)
 
 

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -531,7 +531,7 @@ class TestCoonsSurfaceHomogeneousCorners:
         # 2 is the largest homogeneous coordinate over all eight readings.
         assert gap == pytest.approx(1.0)
         assert scale == pytest.approx(2.0)
-        assert tol == pytest.approx(get_conservative(np.float64) * 2.0, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(np.float64) * 2.0, rel=1e-3, abs=0.0)
 
     def test_four_curves_rational_the_same_way_are_refused_too(self) -> None:
         """The ticket's variant: all four curves rational with weights running 1 to 2.
@@ -598,10 +598,14 @@ class TestCoonsSurfaceHomogeneousCorners:
         message = str(excinfo.value)
         assert "weight scale" in message, message
         gap, tol, reported_scale = _reported_numbers(message)
-        assert gap == pytest.approx(weight_gap)
+        # `abs=0.0` because these are sub-picoscale quantities and `pytest.approx`'s
+        # default absolute tolerance is 1e-12, which alone exceeds the tier being asserted.
+        assert gap == pytest.approx(weight_gap, rel=1e-3, abs=0.0)
         # The weight population's own maximum, which the displaced weight itself sets.
         assert reported_scale == pytest.approx(1.0 + weight_gap)
-        assert tol == pytest.approx(get_conservative(np.float64) * reported_scale, rel=1e-3)
+        assert tol == pytest.approx(
+            get_conservative(np.float64) * reported_scale, rel=1e-3, abs=0.0
+        )
 
     @pytest.mark.parametrize("scale", [1.0, 1.0e4, 1.0e8])
     def test_a_weight_within_the_tier_is_accepted_at_every_model_scale(self, scale: float) -> None:
@@ -685,6 +689,44 @@ class TestCoonsSurfaceHomogeneousCorners:
         surface = create_coons_surface(((scaled(c_v0), scaled(c_v1)), (scaled(c_u0), scaled(c_u1))))
         gaps = _boundary_interpolation_gaps(surface, ((c_v0, c_v1), (c_u0, c_u1)))
         assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    def test_the_tier_follows_the_curve_a_corner_was_actually_read_from(self) -> None:
+        """Each of the eight readings must keep the precision it was supplied in.
+
+        The corner term is sized from ``C_u0`` alone, so routing ``C_u1``'s corners through
+        that array widens them to ``C_u0``'s dtype and the tier is then read at float64 for a
+        corner that came off a float32 curve -- refusing it by ``2**17`` more than that curve
+        can express, on input the previous release accepted.  Here the ``(0,1)`` corner is
+        read by ``C_u1``, which is float32, and is out by ``1e-5``: between the two tiers, so
+        it separates them cleanly.  Curves of different precisions are not a supported input,
+        but they are a reachable one, and this is the direction that errs towards accepting.
+        """
+        assert get_conservative(np.float64) < 1.0e-5 < get_conservative(np.float32)
+
+        curves = (
+            (self._line([0, 0, 0], [0, 1, 0]), self._line([1, 0, 0], [1, 1, 0])),
+            (
+                self._line([0, 0, 0], [1, 0, 0]),
+                self._line([1.0e-5, 1, 0], [1, 1, 0], np.float32),
+            ),
+        )
+        surface = create_coons_surface(curves)
+        assert surface.rank == _RANK_3D
+
+        # And reading it at the coarser precision must not amount to accepting anything: a
+        # gap above the float32 tier is still refused, and refused against that tier.
+        gross = (
+            (self._line([0, 0, 0], [0, 1, 0]), self._line([1, 0, 0], [1, 1, 0])),
+            (
+                self._line([0, 0, 0], [1, 0, 0]),
+                self._line([1.0e-2, 1, 0], [1, 1, 0], np.float32),
+            ),
+        )
+        with pytest.raises(ValueError, match=r"Corner \(0,1\) mismatch") as excinfo:
+            create_coons_surface(gross)
+        gap, tol, scale = _reported_numbers(str(excinfo.value))
+        assert gap == pytest.approx(1.0e-2, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(np.float32) * scale, rel=1e-3)
 
     def test_a_float32_rational_patch_is_built_and_graded_at_float32(self) -> None:
         """The tier must reach the weight group at the readings' own precision too.

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -24,6 +24,9 @@ from pantr.tolerance import get_conservative, get_machine_epsilon
 
 _RANK_3D = 3
 
+_RANK_PLANAR = 2
+"""Rank of a B-spline whose control points carry two coordinates rather than three."""
+
 _FacePairs = tuple[
     tuple[Bspline, Bspline],
     tuple[Bspline, Bspline],
@@ -108,6 +111,24 @@ def _face_interpolation_gaps(vol: Bspline, faces: _FacePairs) -> dict[str, float
         want = np.asarray(face.evaluate(face_params), dtype=np.float64)
         gaps[label] = float(np.linalg.norm(got - want, axis=1).max())
     return gaps
+
+
+def _bezier_space_1d(degree: int, dtype: npt.DTypeLike = np.float64) -> BsplineSpace:
+    """Build a clamped single-span 1D space of the given degree on ``[0, 1]``.
+
+    ``create_line`` and ``create_circle`` cover the shapes the geometric tests need; this is
+    for the ones that set control points and weights directly, including at float32, which
+    the public primitives build at float64 unconditionally.
+
+    Args:
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): Precision of the knot vector. Defaults to float64.
+
+    Returns:
+        BsplineSpace: A 1D space with ``degree + 1`` basis functions.
+    """
+    knots = np.array([0.0] * (degree + 1) + [1.0] * (degree + 1), dtype=dtype)
+    return BsplineSpace([BsplineSpace1D(knots, degree)])
 
 
 def _boundary_interpolation_gaps(srf: Bspline, curves: _CurvePairs) -> dict[str, float]:
@@ -228,6 +249,25 @@ class TestCoonsSurface:
         pt = srf.evaluate(np.array([[0.5, 0.5]]))
         assert_allclose(pt, [0.5, 0, 0.5], atol=1e-13)
 
+    def test_planar_rank_2_curves_build_a_rank_2_patch(self) -> None:
+        """Curves that carry two coordinates must blend into a patch that carries two.
+
+        The corner term used to be built by ``create_bilinear``, a public *geometric*
+        primitive that zero-pads its corners to rank 3, so a rank-2 model produced a rank-3
+        term beside two rank-2 ruled surfaces and the sum died in NumPy with
+        ``operands could not be broadcast together with shapes (2,2,2) (2,2,3) (2,2,2)``,
+        naming nothing the caller had supplied.  ``_build_multilinear_corner_term`` takes the
+        rank from the corners, which is the same reason it exists for the volume.
+        """
+        c_v0 = Bspline(_bezier_space_1d(1), np.array([[0.0, 0.0], [0.0, 1.0]]))
+        c_v1 = Bspline(_bezier_space_1d(1), np.array([[1.0, 0.0], [1.0, 1.0]]))
+        c_u0 = Bspline(_bezier_space_1d(1), np.array([[0.0, 0.0], [1.0, 0.0]]))
+        c_u1 = Bspline(_bezier_space_1d(1), np.array([[0.0, 1.0], [1.0, 1.0]]))
+
+        srf = create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+        assert srf.rank == _RANK_PLANAR
+        assert_allclose(srf.evaluate(np.array([[0.25, 0.75]])), [0.25, 0.75], atol=1e-15)
+
     def test_non_1d_curve_raises(self) -> None:
         """Test that a surface as input raises ValueError."""
         srf = create_bilinear()
@@ -346,20 +386,6 @@ class TestCoonsSurfaceHomogeneousCorners:
     ``pantr.cad._join._verify_shared_boundary``.
     """
 
-    @staticmethod
-    def _bezier_space(degree: int, dtype: npt.DTypeLike = np.float64) -> BsplineSpace:
-        """Build a clamped single-span space of the given degree on ``[0, 1]``.
-
-        Args:
-            degree (int): Polynomial degree.
-            dtype (npt.DTypeLike): Precision of the knot vector. Defaults to float64.
-
-        Returns:
-            BsplineSpace: A 1D space with ``degree + 1`` basis functions.
-        """
-        knots = np.array([0.0] * (degree + 1) + [1.0] * (degree + 1), dtype=dtype)
-        return BsplineSpace([BsplineSpace1D(knots, degree)])
-
     @classmethod
     def _line(cls, a: list[float], b: list[float], dtype: npt.DTypeLike = np.float64) -> Bspline:
         """Build a polynomial straight-line curve between two points.
@@ -372,7 +398,7 @@ class TestCoonsSurfaceHomogeneousCorners:
         Returns:
             Bspline: A clamped degree-1 non-rational curve on ``[0, 1]``.
         """
-        return Bspline(cls._bezier_space(1, dtype), np.asarray([a, b], dtype=dtype))
+        return Bspline(_bezier_space_1d(1, dtype), np.asarray([a, b], dtype=dtype))
 
     @classmethod
     def _rational_line(
@@ -402,7 +428,7 @@ class TestCoonsSurfaceHomogeneousCorners:
         cp = np.array(
             [[*(np.asarray(a, float) * wa), wa], [*(np.asarray(b, float) * wb), wb]], dtype=dtype
         )
-        return Bspline(cls._bezier_space(1, dtype), cp, is_rational=True)
+        return Bspline(_bezier_space_1d(1, dtype), cp, is_rational=True)
 
     @classmethod
     def _rational_arc(
@@ -423,7 +449,7 @@ class TestCoonsSurfaceHomogeneousCorners:
         cp = np.array(
             [[*(np.asarray(p, float) * w), w] for p, w in zip(points, weights, strict=True)]
         )
-        return Bspline(cls._bezier_space(2), cp, is_rational=True)
+        return Bspline(_bezier_space_1d(2), cp, is_rational=True)
 
     @classmethod
     def _unit_square_arcs(cls, corner_weight: float, interior_weight: float) -> _CurvePairs:

--- a/tests/test_cad_coons.py
+++ b/tests/test_cad_coons.py
@@ -37,6 +37,15 @@ _VOLUME_FACE_LABELS = ("u0", "u1", "v0", "v1", "w0", "w1")
 _FACE_SAMPLES = np.linspace(0.0, 1.0, 11)
 """Normalized per-direction samples used to compare a volume's boundary against a face."""
 
+_CurvePairs = tuple[tuple[Bspline, Bspline], tuple[Bspline, Bspline]]
+"""The argument of :func:`~pantr.cad.create_coons_surface`: two pairs of opposite curves."""
+
+_SURFACE_BOUNDARY_LABELS = ("v0", "v1", "u0", "u1")
+"""Flat order of a patch's four boundary curves, matching the pairs of :data:`_CurvePairs`."""
+
+_CURVE_SAMPLES = np.linspace(0.0, 1.0, 21)
+"""Normalized samples used to compare a patch's boundary against the curve supplied."""
+
 
 def _flatten_faces(faces: _FacePairs) -> list[Bspline]:
     """Flatten three pairs of opposite faces into ``(u0, u1, v0, v1, w0, w1)`` order.
@@ -101,14 +110,51 @@ def _face_interpolation_gaps(vol: Bspline, faces: _FacePairs) -> dict[str, float
     return gaps
 
 
+def _boundary_interpolation_gaps(srf: Bspline, curves: _CurvePairs) -> dict[str, float]:
+    """Measure how far a Coons patch's boundary is from each curve it was built from.
+
+    A Coons patch's defining property is that it interpolates all four boundary curves, so
+    every entry must vanish to roundoff.  Flattened, the constructor's pairs are already in
+    ``(axis, side)`` order: entry ``k`` is the boundary at side ``k % 2`` of axis ``k // 2``.
+
+    Args:
+        srf (Bspline): The patch under test.
+        curves (_CurvePairs): The four curves it was built from.
+
+    Returns:
+        dict[str, float]: Boundary label from :data:`_SURFACE_BOUNDARY_LABELS` mapped to
+        ``max |S restricted to that boundary - the curve|`` over :data:`_CURVE_SAMPLES`.
+    """
+    flat = [curve for pair in curves for curve in pair]
+    gaps: dict[str, float] = {}
+    for k, (label, curve) in enumerate(zip(_SURFACE_BOUNDARY_LABELS, flat, strict=True)):
+        axis, free = k // 2, 1 - k // 2
+        srf_params = np.empty((_CURVE_SAMPLES.size, 2))
+        srf_params[:, axis] = _to_domain(srf, axis, np.array([float(k % 2)]))[0]
+        srf_params[:, free] = _to_domain(srf, free, _CURVE_SAMPLES)
+        curve_params = _to_domain(curve, 0, _CURVE_SAMPLES)
+        got = np.asarray(
+            srf.evaluate(np.ascontiguousarray(srf_params, dtype=srf.control_points.dtype)),
+            dtype=np.float64,
+        )
+        want = np.asarray(
+            curve.evaluate(np.ascontiguousarray(curve_params, dtype=curve.control_points.dtype)),
+            dtype=np.float64,
+        )
+        gaps[label] = float(np.linalg.norm(got - want, axis=1).max())
+    return gaps
+
+
 def _reported_numbers(message: str) -> tuple[float, float, float]:
     """Parse the gap, tolerance and scale a mismatch message reports.
 
     Whatever the message says about the tolerance is a claim about the comparison that was
     actually made, so it is worth checking rather than trusting.  The name between ``at``
-    and ``scale`` is the population the tolerance was taken over -- ``corner``, ``edge
-    coordinate``, ``edge weight`` -- and is checked separately by the tests that care which
-    column group decided the verdict.
+    and ``scale`` is the population the tolerance was taken over -- ``corner``, ``corner
+    coordinate``, ``corner weight``, ``edge coordinate``, ``edge weight`` -- and is checked
+    separately by the tests that care which column group decided the verdict.  The bare
+    ``corner`` is the volume's corner check, which compares projected points and so has one
+    physical dimension to name; every homogeneous comparison names its column group.
 
     Args:
         message (str): The ``ValueError`` message.
@@ -273,6 +319,373 @@ class TestCoonsCornerToleranceScaleCovariance:
         c_v0, c_v1, c_u0, c_u1 = self._square(scale, corner_shift=scale)
         with pytest.raises(ValueError, match="mismatch"):
             create_coons_surface(((c_v0, c_v1), (c_u0, c_u1)))
+
+
+class TestCoonsSurfaceHomogeneousCorners:
+    """Curves meeting at a corner of a patch must agree there in **homogeneous** data.
+
+    :meth:`~pantr.bspline.Bspline.boundary` projects, so the corner check compared physical
+    points and a weight never entered it.  Two curves can name the same point of space at a
+    shared corner while supplying different ``(w x, w y, w z, w)`` there -- a homogeneous
+    representation is unique only up to one constant scaling all of a patch's weights -- and
+    the three-term blend, which is formed and subtracted homogeneously, then fails to cancel.
+    Measured on the unit square with a single rational boundary whose weights run 1 to 2, the
+    patch missed one of the four curves it was handed by ``1.714e-01``, 17% of the model,
+    while every corner matched to ``1.110e-16`` (pantr issue 327).
+
+    The corner term is the other half of the same requirement, and the half the ticket did
+    not name.  It used to be read through :meth:`~pantr.bspline.Bspline.boundary` as well and
+    promoted with unit weights, so four curves agreeing homogeneously at every corner still
+    produced a patch that missed them whenever the weight they agreed on was not 1: measured
+    ``2.198e-02`` on a degree-2 model whose corner weights were all 2, with nothing refused.
+    ``create_coons_volume`` never had that defect -- ``_extract_corners`` reads homogeneously
+    and the corner term carries the weight column -- and the patch now takes the same path.
+
+    Where a refusal grades homogeneous data it uses ``_verify_edges_3d``'s rule, coordinate
+    and weight columns in separate scale groups, whose derivation and measurements live in
+    ``pantr.cad._join._verify_shared_boundary``.
+    """
+
+    @staticmethod
+    def _bezier_space(degree: int, dtype: npt.DTypeLike = np.float64) -> BsplineSpace:
+        """Build a clamped single-span space of the given degree on ``[0, 1]``.
+
+        Args:
+            degree (int): Polynomial degree.
+            dtype (npt.DTypeLike): Precision of the knot vector. Defaults to float64.
+
+        Returns:
+            BsplineSpace: A 1D space with ``degree + 1`` basis functions.
+        """
+        knots = np.array([0.0] * (degree + 1) + [1.0] * (degree + 1), dtype=dtype)
+        return BsplineSpace([BsplineSpace1D(knots, degree)])
+
+    @classmethod
+    def _line(cls, a: list[float], b: list[float], dtype: npt.DTypeLike = np.float64) -> Bspline:
+        """Build a polynomial straight-line curve between two points.
+
+        Args:
+            a (list[float]): Start point.
+            b (list[float]): End point.
+            dtype (npt.DTypeLike): Precision of the curve. Defaults to float64.
+
+        Returns:
+            Bspline: A clamped degree-1 non-rational curve on ``[0, 1]``.
+        """
+        return Bspline(cls._bezier_space(1, dtype), np.asarray([a, b], dtype=dtype))
+
+    @classmethod
+    def _rational_line(
+        cls,
+        a: list[float],
+        b: list[float],
+        wa: float,
+        wb: float,
+        dtype: npt.DTypeLike = np.float64,
+    ) -> Bspline:
+        """Build straight-line geometry carrying non-unit weights, as pantr issue 327 does.
+
+        The geometry is the segment from *a* to *b* whatever the weights, since a degree-1
+        rational curve traces the straight line between its projected control points; only
+        the parametrization and the homogeneous coefficients change.
+
+        Args:
+            a (list[float]): Start point.
+            b (list[float]): End point.
+            wa (float): Weight at the start.
+            wb (float): Weight at the end.
+            dtype (npt.DTypeLike): Precision of the curve. Defaults to float64.
+
+        Returns:
+            Bspline: A clamped degree-1 rational curve on ``[0, 1]``.
+        """
+        cp = np.array(
+            [[*(np.asarray(a, float) * wa), wa], [*(np.asarray(b, float) * wb), wb]], dtype=dtype
+        )
+        return Bspline(cls._bezier_space(1, dtype), cp, is_rational=True)
+
+    @classmethod
+    def _rational_arc(
+        cls, points: list[list[float]], weights: tuple[float, float, float]
+    ) -> Bspline:
+        """Build the degree-2 rational curve of the control case of pantr issue 327.
+
+        The first and last weights are the patch corner weights the curve carries; the
+        middle one touches no corner and is unconstrained.
+
+        Args:
+            points (list[list[float]]): The three projected control points.
+            weights (tuple[float, float, float]): Their weights, in the same order.
+
+        Returns:
+            Bspline: A clamped degree-2 rational curve on ``[0, 1]``.
+        """
+        cp = np.array(
+            [[*(np.asarray(p, float) * w), w] for p, w in zip(points, weights, strict=True)]
+        )
+        return Bspline(cls._bezier_space(2), cp, is_rational=True)
+
+    @classmethod
+    def _unit_square_arcs(cls, corner_weight: float, interior_weight: float) -> _CurvePairs:
+        """Build four degree-2 rational curves agreeing homogeneously at every corner.
+
+        Every corner is read by two curves and both give it *corner_weight*, so nothing is
+        inconsistent however far *interior_weight* is from 1.
+
+        Args:
+            corner_weight (float): Weight both curves carry at each of the four corners.
+            interior_weight (float): Weight of every middle control point.
+
+        Returns:
+            _CurvePairs: ``((C_v0, C_v1), (C_u0, C_u1))`` over the unit square.
+        """
+        w = (corner_weight, interior_weight, corner_weight)
+        return (
+            (
+                cls._rational_arc([[0, 0, 0], [0, 0.5, 0], [0, 1, 0]], w),
+                cls._rational_arc([[1, 0, 0], [1, 0.5, 0], [1, 1, 0]], w),
+            ),
+            (
+                cls._rational_arc([[0, 0, 0], [0.5, 0, 0], [1, 0, 0]], w),
+                cls._rational_arc([[0, 1, 0], [0.5, 1, 0], [1, 1, 0]], w),
+            ),
+        )
+
+    @classmethod
+    def _square_with_corner_weight(
+        cls, scale: float, weight_gap: float, dtype: npt.DTypeLike = np.float64
+    ) -> _CurvePairs:
+        """Build a rational square of side *scale* with ``C_u0``'s start weight out by a gap.
+
+        The displaced corner is the one at the origin, so its homogeneous *coordinates* are
+        zero however the weight moves: the coordinate columns agree exactly and only the
+        weight column can decide the verdict.
+
+        Args:
+            scale (float): Side of the square.
+            weight_gap (float): Amount added to that one weight, against weights of 1.
+            dtype (npt.DTypeLike): Precision of all four curves. Defaults to float64.
+
+        Returns:
+            _CurvePairs: Four rational curves, consistent iff ``weight_gap == 0``.
+        """
+        s = scale
+        return (
+            (
+                cls._rational_line([0, 0, 0], [0, s, 0], 1.0, 1.0, dtype),
+                cls._rational_line([s, 0, 0], [s, s, 0], 1.0, 1.0, dtype),
+            ),
+            (
+                cls._rational_line([0, 0, 0], [s, 0, 0], 1.0 + weight_gap, 1.0, dtype),
+                cls._rational_line([0, s, 0], [s, s, 0], 1.0, 1.0, dtype),
+            ),
+        )
+
+    # -- refusing curves that disagree homogeneously -------------------------------------
+
+    def test_the_reproduction_is_refused_at_the_corner_that_disagrees(self) -> None:
+        """Reproduce pantr issue 327: one rational edge whose weights run 1 to 2.
+
+        ``C_v0`` ends at ``(0, 1, 0)`` with weight 2 while ``C_u1`` starts at the same point
+        with weight 1, so the two agree projectively and disagree homogeneously by the whole
+        of the second coordinate.  The patch used to be returned and to miss ``C_u1`` by
+        ``1.714e-01`` while every corner matched to ``1.110e-16``.
+        """
+        curves = (
+            (self._rational_line([0, 0, 0], [0, 1, 0], 1.0, 2.0), self._line([1, 0, 0], [1, 1, 0])),
+            (self._line([0, 0, 0], [1, 0, 0]), self._line([0, 1, 0], [1, 1, 0])),
+        )
+        with pytest.raises(ValueError, match=r"Corner \(0,1\) mismatch") as excinfo:
+            create_coons_surface(curves)
+
+        message = str(excinfo.value)
+        assert "coordinate scale" in message, message
+        gap, tol, scale = _reported_numbers(message)
+        # The homogeneous coordinates of that corner are (0, 2, 0) against (0, 1, 0), and
+        # 2 is the largest homogeneous coordinate over all eight readings.
+        assert gap == pytest.approx(1.0)
+        assert scale == pytest.approx(2.0)
+        assert tol == pytest.approx(get_conservative(np.float64) * 2.0, rel=1e-3)
+
+    def test_four_curves_rational_the_same_way_are_refused_too(self) -> None:
+        """The ticket's variant: all four curves rational with weights running 1 to 2.
+
+        Every corner is then read at weight 1 by one curve and at weight 2 by the other, and
+        two of the four boundaries were missed, by ``7.171e-02`` each.  ``(0,0)`` is the one
+        corner both readings agree on, since a zero coordinate is zero at either weight and
+        both weights there are 1, so ``(1,0)`` is the first refused.
+        """
+        curves = (
+            (
+                self._rational_line([0, 0, 0], [0, 1, 0], 1.0, 2.0),
+                self._rational_line([1, 0, 0], [1, 1, 0], 1.0, 2.0),
+            ),
+            (
+                self._rational_line([0, 0, 0], [1, 0, 0], 1.0, 2.0),
+                self._rational_line([0, 1, 0], [1, 1, 0], 1.0, 2.0),
+            ),
+        )
+        with pytest.raises(ValueError, match=r"Corner \(1,0\) mismatch"):
+            create_coons_surface(curves)
+
+    def test_a_polynomial_curve_meeting_a_rational_one_needs_unit_weight_there(self) -> None:
+        """A polynomial curve promotes with unit weights, so that is the weight it demands.
+
+        The three blend terms are added together and so share one space, and a polynomial
+        curve among rational ones is promoted with weight 1 -- the argument ``_extract_corners``
+        makes for the volume.  The mismatch is put at the origin, where the homogeneous
+        coordinates are zero at any weight, so only the weight column can see it: projecting,
+        as the old check did, gives ``(0, 0, 0)`` on both sides.
+        """
+        curves = (
+            (
+                self._line([0, 0, 0], [0, 1, 0]),
+                self._rational_line([1, 0, 0], [1, 1, 0], 1.0, 1.0),
+            ),
+            (
+                self._rational_line([0, 0, 0], [1, 0, 0], 2.0, 1.0),
+                self._rational_line([0, 1, 0], [1, 1, 0], 1.0, 1.0),
+            ),
+        )
+        with pytest.raises(ValueError, match=r"Corner \(0,0\) mismatch") as excinfo:
+            create_coons_surface(curves)
+        assert "weight scale" in str(excinfo.value), str(excinfo.value)
+
+    # -- a weight is graded against the weights, at every model scale ---------------------
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e2, 1.0e4, 1.0e6, 1.0e8])
+    def test_a_weight_only_corner_mismatch_is_refused_at_every_model_scale(
+        self, scale: float
+    ) -> None:
+        """A weight is dimensionless and must never be graded against the model's length.
+
+        Four times the tier against weights of 1 is a gross error at any ``scale``.  One
+        magnitude over the homogeneous row would grade it against ``max|w x|``, accepting it
+        from ``scale = 1e2`` up -- the failure ``_verify_shared_boundary`` and
+        ``_verify_edges_3d`` were split into column groups to stop, on the path this ticket
+        brought onto the same rule.
+        """
+        weight_gap = 4.0 * get_conservative(np.float64)
+        with pytest.raises(ValueError, match=r"Corner \(0,0\) mismatch") as excinfo:
+            create_coons_surface(self._square_with_corner_weight(scale, weight_gap))
+
+        message = str(excinfo.value)
+        assert "weight scale" in message, message
+        gap, tol, reported_scale = _reported_numbers(message)
+        assert gap == pytest.approx(weight_gap)
+        # The weight population's own maximum, which the displaced weight itself sets.
+        assert reported_scale == pytest.approx(1.0 + weight_gap)
+        assert tol == pytest.approx(get_conservative(np.float64) * reported_scale, rel=1e-3)
+
+    @pytest.mark.parametrize("scale", [1.0, 1.0e4, 1.0e8])
+    def test_a_weight_within_the_tier_is_accepted_at_every_model_scale(self, scale: float) -> None:
+        """The other side of the same rule: a quarter of the tier must pass everywhere.
+
+        Splitting the columns tightens the weight comparison by the model's size, so it has
+        to be checked that it did not tighten past what a weight can be stored to.
+        """
+        weight_gap = 0.25 * get_conservative(np.float64)
+        surface = create_coons_surface(self._square_with_corner_weight(scale, weight_gap))
+        assert surface.is_rational
+
+    @pytest.mark.parametrize("scale", [1.0e-6, 1.0, 1.0e8])
+    def test_a_consistent_rational_square_is_accepted_at_every_scale(self, scale: float) -> None:
+        """Neither rule may refuse correct input, at any model size.
+
+        The control for both column groups: four rational curves, all weights 1, nothing
+        displaced.  It also pins that the coordinate group's scale still spans the model,
+        since a square of side ``1e8`` is graded against ``1e8`` and not against 1.
+        """
+        curves = self._square_with_corner_weight(scale, 0.0)
+        surface = create_coons_surface(curves)
+        gaps = _boundary_interpolation_gaps(surface, curves)
+        assert max(gaps.values()) <= get_conservative(np.float64) * scale, gaps
+
+    # -- the blend carries the corner weight the curves agreed on ------------------------
+
+    @pytest.mark.parametrize("interior_weight", [1.0, 1.5, 3.0])
+    def test_consistent_corner_weights_reproduce_all_four_boundaries(
+        self, interior_weight: float
+    ) -> None:
+        """Reproduce the control of pantr issue 327: degree-2 curves with weights ``(1, w, 1)``.
+
+        The defect is the inconsistency, not rationality.  Every corner weight is 1 here, so
+        all four curves agree homogeneously and the patch must interpolate all four to
+        roundoff however strongly the interior weight varies.  Measured before this fix and
+        unchanged by it: ``1.11e-16`` at ``w = 1.0`` and ``1.5``, ``2.22e-16`` at ``3.0``.
+        """
+        curves = self._unit_square_arcs(1.0, interior_weight)
+        surface = create_coons_surface(curves)
+        assert surface.is_rational
+        gaps = _boundary_interpolation_gaps(surface, curves)
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    @pytest.mark.parametrize("interior_weight", [0.5, 1.0, 3.0])
+    @pytest.mark.parametrize("corner_weight", [0.5, 2.0])
+    def test_a_shared_corner_weight_other_than_one_is_carried_into_the_blend(
+        self, corner_weight: float, interior_weight: float
+    ) -> None:
+        """Agreement between the curves is only half the requirement; the corner term is the other.
+
+        All four curves agree homogeneously at every corner, so nothing is refused -- and the
+        patch still missed them, because the corner term was read projected and promoted with
+        unit weights.  Measured before the fix at ``corner_weight = 2``: ``2.198e-02`` at
+        ``interior_weight = 1``, ``4.013e-02`` at ``0.5`` and ``1.246e-02`` at ``3``.  It
+        reduces to the control above exactly when the shared corner weight is 1, which is why
+        the control could not catch it.
+        """
+        curves = self._unit_square_arcs(corner_weight, interior_weight)
+        surface = create_coons_surface(curves)
+        gaps = _boundary_interpolation_gaps(surface, curves)
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    @pytest.mark.parametrize("mu", [0.25, 7.0])
+    def test_rescaling_every_weight_by_one_constant_changes_nothing(self, mu: float) -> None:
+        """A homogeneous representation is unique up to one constant scaling all the weights.
+
+        Multiplying all four curves' homogeneous control points by ``mu`` leaves every curve's
+        geometry bitwise unchanged and leaves the four consistent with each other, so it must
+        be accepted and must still interpolate.  This is the input the check must *not* refuse,
+        and the reason the rule is agreement in homogeneous data rather than equality of
+        weights -- and it is what makes a one-sided rescale, which the tests above refuse, a
+        genuine inconsistency rather than a different spelling of the same patch.  The patch
+        is compared against the curves *before* the rescale, which is the same geometry.
+        """
+
+        def scaled(curve: Bspline) -> Bspline:
+            return Bspline(curve.space, np.asarray(curve.control_points) * mu, is_rational=True)
+
+        (c_v0, c_v1), (c_u0, c_u1) = self._unit_square_arcs(1.0, 1.5)
+        surface = create_coons_surface(((scaled(c_v0), scaled(c_v1)), (scaled(c_u0), scaled(c_u1))))
+        gaps = _boundary_interpolation_gaps(surface, ((c_v0, c_v1), (c_u0, c_u1)))
+        assert max(gaps.values()) <= get_conservative(np.float64), gaps
+
+    def test_a_float32_rational_patch_is_built_and_graded_at_float32(self) -> None:
+        """The tier must reach the weight group at the readings' own precision too.
+
+        A float32 rational patch has to build at float32 -- ``Bspline`` refuses control points
+        whose dtype differs from their space's, so a corner term silently assembled at float64
+        would not build at all -- and its weights have to be graded against something float32
+        can express.  A weight gap of ``1e-6`` lies between the two tiers, so it separates
+        them cleanly: graded at float64 this float32 patch is refused, graded at its own
+        precision it is accepted.  Four float32 tiers is above both and must still be refused.
+        """
+        assert get_conservative(np.float64) < 1.0e-6 < get_conservative(np.float32)
+
+        surface = create_coons_surface(self._square_with_corner_weight(1.0, 0.0, np.float32))
+        assert surface.is_rational
+        assert np.dtype(surface.control_points.dtype) == np.dtype(np.float32)
+        create_coons_surface(self._square_with_corner_weight(1.0, 1.0e-6, np.float32))
+
+        weight_gap = 4.0 * get_conservative(np.float32)
+        with pytest.raises(ValueError, match=r"Corner \(0,0\) mismatch") as excinfo:
+            create_coons_surface(self._square_with_corner_weight(1.0, weight_gap, np.float32))
+        message = str(excinfo.value)
+        assert "weight scale" in message, message
+        gap, tol, scale = _reported_numbers(message)
+        assert gap == pytest.approx(weight_gap, rel=1e-3)
+        assert scale == pytest.approx(1.0 + weight_gap, rel=1e-3)
+        assert tol == pytest.approx(get_conservative(np.float32) * scale, rel=1e-3)
 
 
 class TestCoonsVolume:


### PR DESCRIPTION
Closes #327.

`create_coons_surface` returned a surface that did not interpolate the curves it was given. The
ticket blamed one mechanism; there were two, and the second is the one that mattered more.

## Two defects, not one

**1. A corner disagreement was invisible.** `_verify_corners_2d` read its corners through
`Bspline.boundary`, which *projects*, so two curves meeting at a corner could name the same
point in space while carrying different weights and be accepted. The blend's inclusion-exclusion
then failed to cancel and the surface missed a boundary by 17 % of a unit square. Corners are
now compared as homogeneous coefficients, reusing the column-group rule already shared by
`_verify_edges_3d` and `join` rather than restating it: coordinates and weights are graded
against their own magnitudes, and the tier is read at the coarsest of the readings' own
precisions.

**2. Refusing bad input was not sufficient, and the ticket did not say so.** The corner term was
itself read through `boundary()` and promoted with unit weight, so four curves agreeing
homogeneously at *every* corner still produced a wrong patch whenever the shared corner weight
was not 1: the blend's corner weight came out as `2w − 1` instead of `w`. Nothing was refused,
because nothing was inconsistent. Corners are now read homogeneously for the blend as well, via
the `_homogeneous_endpoint` helper the volume path already used.

Measured on `main` against this branch, four degree-2 curves whose corner weights agree and
whose interior weight differs:

| corner w, interior w | `main` | this branch |
|---|---|---|
| 1.0, 1.5 | 1.110e-16 | 1.110e-16 |
| 2.0, 1.0 | **2.198e-02** | 2.220e-16 |
| 2.0, 3.0 | **1.246e-02** | 1.110e-16 |
| 0.5, 2.0 | **nan**, `invalid value encountered in divide` | 1.110e-16 |

The last row is the sharp one: at corner weight 0.5 the wrong corner term drives the blended
weight field through zero, so `main` returns NaN geometry rather than merely inaccurate
geometry.

The first row is the ticket's own control experiment, and it is blind to defect 2 by
construction — its weights are `(1, w, 1)`, and corner weight 1 is exactly the value at which
`2w − 1 = w`. A control chosen to isolate one mechanism cannot refute the hypothesis it was
built for.

## Acceptance criteria

| | |
|---|---|
| AC1 | The reproduction now raises `ValueError: Corner (0,1) mismatch: C_u1 gives [0. 1. 0. 1.], C_v0 gives [0. 2. 0. 2.] (gap 1.000e+00, above 1.819e-12 at corner coordinate scale 2.000e+00)`. |
| AC2 | Regression test carries the reproduction verbatim; confirmed `DID NOT RAISE` when run against the parent commit in a detached worktree. |
| AC3 | Control case is a test at `w = 1.0, 1.5, 3.0`, measured twice independently: `1.11e-16`, `1.11e-16`, `2.22e-16`. |
| AC4 | **Partly refuted — see below.** float64 polynomial patches are byte-identical (55 arrays over 11 patches, plus an independent 14/14 check). |
| AC5 | `create_coons_surface`'s docstring states the route and defines "consistent" as agreement in homogeneous data, weights included. |

**AC4 as worded is false at float32**, and the change that breaks it is correct. Polynomial
patches differ by 2 float32 ulps (`2.384e-07`) when the corner term needs degree elevation or
knot insertion, because the base built that term at float64 unconditionally and rounded once at
the end, while it is now built in the curves' own precision. That is exactly the no-promotion
rule #319 landed for this function and that `_combine_control_points` documents. The claim is
corrected rather than the behaviour reverted.

## Route

Route 1 of the ticket (refuse), matching the volume path and `join`. Route 2 (normalize to a
common homogeneous scaling) was never viable: a *global* rescale is already accepted, tested at
μ = 0.25 and 7, so route 2 would only act on a genuine per-curve disagreement — which is a
modelling error rather than a representation difference, and normalizing it would silently pick
one curve's weights over another's.

`_build_trilinear_volume` was generalized to `_build_multilinear_corner_term` rather than
duplicated, so the patch and the volume now share one corner-term builder.

## Caught in this branch's own review

A precision regression it had just introduced: `_extract_corners_2d` sized its array from one
curve alone, so with `C_u0` at float64 and `C_u1` at float32 a corner off by `1e-5` was refused
against the float64 tier — `2**17` tighter than float32 can express — **on input the parent
commit accepted**. `_verify_corners_2d` now reads all eight corners itself. Pinned by a test
confirmed failing without the fix. Also fixed: three `pytest.approx` assertions whose default
`abs=1e-12` exceeded the very tier they were asserting, so they could not fail.

7 of 8 targeted mutations were killed, including reverting to the projected read (16 failures)
and collapsing the column groups (fails from coordinate scale 1e2 up).

## Checks

ruff, ruff format, mypy (234 files), `lint-imports` (1 contract kept), pytest **5963 passed,
21 skipped, 2 xfailed**, `make doctest` **80 passed, 7 skipped**, docs build clean under `-W`.
The table above was measured at the gate against both sources, independently of the suite.

## Reported, not fixed

- **`create_coons_surface` has no positive-weight guard**, while `create_coons_volume` refuses a
  blend whose weight field is not certified positive. A patch built from perfectly consistent
  curves can still carry a negative control weight — corner weight 1 with interior weight 0.1
  gives a minimum of `-0.8`, measured identically on the parent commit, so it is pre-existing
  and needs degree ≥ 2. Adding the guard would refuse currently-accepted input, which is a
  design change this ticket's non-goals do not sanction.
- `_verify_corners_3d` still prints a bare "at corner scale" where every other check names its
  column group.
- The same vacuous-`pytest.approx` pattern remains in two older volume-path tests.
- `_validation.py`'s shared helpers have no direct unit tests; they are exercised only
  transitively.
