### PR TITLE
ci: stop apt from depending on the mirror that keeps stalling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint (Ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.11", "3.13", "3.14"]
@@ -73,6 +74,7 @@ jobs:
   type-check:
     name: Type check (mypy)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.11", "3.13", "3.14"]
@@ -123,6 +125,7 @@ jobs:
     name: Tests with coverage
     needs: [lint, type-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ["3.11", "3.13", "3.14"]
@@ -161,17 +164,15 @@ jobs:
 
       - name: Install OpenMPI
         run: |
-          # The runner images point apt at azure.archive.ubuntu.com, which
-          # intermittently stops answering: this step has taken 16 s and 240 s on
-          # identical input, and once ran past 38 minutes without finishing while the
-          # log filled with `Ign` lines for that host. The canonical mirror is a little
-          # slower on a good day and does not do that. Noble keeps its sources in
-          # deb822 format under sources.list.d; older images use sources.list, so both
-          # are rewritten and neither is required to exist.
-          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
-            /etc/apt/sources.list.d/ubuntu.sources || true
-          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
-            /etc/apt/sources.list || true
+          # The runner images do not name a mirror in sources.list: they point apt at
+          # a mirror *list*, `mirror+file:/etc/apt/apt-mirrors.txt`, whose first entry
+          # is azure.archive.ubuntu.com. That host intermittently stops answering, and
+          # apt then spends a full timeout per index file before falling back to the
+          # canonical mirror -- which is why this step has taken 16 s and 240 s on
+          # identical input, and once sat past 38 minutes with a log full of `Ign`
+          # lines. Replacing the list with a single entry removes the retry round: apt
+          # either reaches the mirror or fails, and does not spend minutes finding out.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
           sudo apt-get update -q
           sudo apt-get install -y libopenmpi-dev openmpi-bin
 
@@ -214,6 +215,7 @@ jobs:
     name: Build documentation
     needs: [lint, type-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -281,6 +283,7 @@ jobs:
     name: MPI tests (mpiexec)
     needs: [lint, type-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # The only job that exercises the real distributed stack under multiple ranks. It
     # builds mpi4py from source against the system OpenMPI -- the prebuilt wheels are not
     # guaranteed to match the system launcher's wire protocol. PANTR_RUN_MPI enables the
@@ -303,17 +306,15 @@ jobs:
 
       - name: Install OpenMPI
         run: |
-          # The runner images point apt at azure.archive.ubuntu.com, which
-          # intermittently stops answering: this step has taken 16 s and 240 s on
-          # identical input, and once ran past 38 minutes without finishing while the
-          # log filled with `Ign` lines for that host. The canonical mirror is a little
-          # slower on a good day and does not do that. Noble keeps its sources in
-          # deb822 format under sources.list.d; older images use sources.list, so both
-          # are rewritten and neither is required to exist.
-          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
-            /etc/apt/sources.list.d/ubuntu.sources || true
-          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
-            /etc/apt/sources.list || true
+          # The runner images do not name a mirror in sources.list: they point apt at
+          # a mirror *list*, `mirror+file:/etc/apt/apt-mirrors.txt`, whose first entry
+          # is azure.archive.ubuntu.com. That host intermittently stops answering, and
+          # apt then spends a full timeout per index file before falling back to the
+          # canonical mirror -- which is why this step has taken 16 s and 240 s on
+          # identical input, and once sat past 38 minutes with a log full of `Ign`
+          # lines. Replacing the list with a single entry removes the retry round: apt
+          # either reaches the mirror or fails, and does not spend minutes finding out.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
           sudo apt-get update -q
           sudo apt-get install -y libopenmpi-dev openmpi-bin
 
@@ -353,6 +354,7 @@ jobs:
     name: Adversarial sweep (Numba bounds check)
     needs: [lint, type-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # The only job that compiles the Layer-3 kernels with bounds checking on. It needs a
     # job of its own because NUMBA_BOUNDSCHECK is not part of the Numba cache key, so it is
     # silently ignored for a cache=True kernel that was already compiled without it -- and

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,17 @@ jobs:
 
       - name: Install OpenMPI
         run: |
+          # The runner images point apt at azure.archive.ubuntu.com, which
+          # intermittently stops answering: this step has taken 16 s and 240 s on
+          # identical input, and once ran past 38 minutes without finishing while the
+          # log filled with `Ign` lines for that host. The canonical mirror is a little
+          # slower on a good day and does not do that. Noble keeps its sources in
+          # deb822 format under sources.list.d; older images use sources.list, so both
+          # are rewritten and neither is required to exist.
+          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources || true
+          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list || true
           sudo apt-get update -q
           sudo apt-get install -y libopenmpi-dev openmpi-bin
 
@@ -292,6 +303,17 @@ jobs:
 
       - name: Install OpenMPI
         run: |
+          # The runner images point apt at azure.archive.ubuntu.com, which
+          # intermittently stops answering: this step has taken 16 s and 240 s on
+          # identical input, and once ran past 38 minutes without finishing while the
+          # log filled with `Ign` lines for that host. The canonical mirror is a little
+          # slower on a good day and does not do that. Noble keeps its sources in
+          # deb822 format under sources.list.d; older images use sources.list, so both
+          # are rewritten and neither is required to exist.
+          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list.d/ubuntu.sources || true
+          sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' \
+            /etc/apt/sources.list || true
           sudo apt-get update -q
           sudo apt-get install -y libopenmpi-dev openmpi-bin
 


### PR DESCRIPTION
Two jobs install OpenMPI — `mpi-tests` and, less obviously, `tests` — and both have been
stalling in that step. It is not the install:

| run | `Install OpenMPI` | the MPI tests themselves |
|---|---|---|
| 2026-08-18 19:39 | 16 s | 51 s |
| 2026-08-18 19:33 | 186 s | 59 s |
| 2026-08-19 06:57 | 240 s | 36 s |
| 2026-08-19 07:11 | ran past 53 min, cancelled | never reached |

Same step, same input, a 15× spread, while the work it exists to enable finishes in under a
minute throughout.

## What is actually wrong

The runner images do not name a mirror in `sources.list`. They point apt at a mirror **list**,
`mirror+file:/etc/apt/apt-mirrors.txt`, whose first entry is `azure.archive.ubuntu.com`. When
that host stops answering — which it does intermittently — apt spends a full timeout per index
file before falling back to the canonical mirror. The stalled logs show exactly that: a wall of
`Ign` lines for the Azure host, then `Hit` lines for `archive.ubuntu.com`. The fallback works;
it is the waiting that costs the run.

Replacing the list with a single canonical entry removes the retry round. apt either reaches
the mirror or fails, and does not spend minutes finding out.

**The first commit on this branch got this wrong** and is kept in the history rather than
squashed away, because the correction is the useful part. It rewrote the Azure host in
`sources.list` and `sources.list.d`, where the runners do not keep it, so it changed nothing. A
`tests` job then stalled 17 minutes in that same step *with the fix applied*, which is what
refuted it. The evidence had been visible from the start, in a log line nobody read closely:
`Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]`.

## Every job is now bounded

No job in this workflow declared `timeout-minutes`, so a stall ran to GitHub's 360-minute
default. Two runs today sat for 53 and 66 minutes and would have kept going; both had to be
cancelled by hand.

| job | budget | slowest healthy run observed |
|---|---|---|
| lint | 10 min | 25 s |
| type-check | 15 min | 1 min |
| tests | 30 min | 8 min 23 s |
| docs | 20 min | 1 min 7 s |
| mpi-tests | 20 min | 4 min 56 s |
| adversarial-sweep | 20 min | 2 min 16 s |

About three times the slowest healthy run of each, so ordinary variation cannot trip them while
a stall fails in minutes instead of hours.

## What this does not claim

That the stall is gone. A single green run cannot show that: the step's healthy range already
spans 16 s to 240 s, so one fast run is equally consistent with a healthy runner. What the
timeouts *do* guarantee is that the next occurrence costs 30 minutes rather than 6 hours, and
that it shows up as a red check rather than as a PR that never finishes.

Caching the `.deb` closure was considered and left out: it skips the network on a cache hit but
falls back to apt on a miss, needs the runner image version in its key to avoid restoring
packages built for a different Ubuntu, and is a lot of machinery for a job whose real work takes
50 seconds. Worth revisiting only if this does not hold.
