### PR TITLE
ci(release): bump the publish action to one that knows metadata 2.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,15 @@ jobs:
       - name: Publish to TestPyPI
         # Pinned to the release/v1 commit SHA (third-party action handling an OIDC
         # token that can publish to PyPI). Bump deliberately; @release/v1 is mutable.
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 @ 2026-02-18
+        #
+        # This pin has to keep up with the core metadata version the build emits. The
+        # action verifies the distributions with the twine it ships, and twine rejects a
+        # metadata version its `packaging` does not know: the 2026-02-18 pin carried
+        # twine 6.1.0 / packaging 25.0, which know up to 2.4, so it refused the 0.7.0
+        # wheel with `InvalidDistribution: '2.5' is not a valid metadata version` once
+        # hatchling 1.32.0 made 2.5 its default. v1.14.2 ships twine 7.0.0 /
+        # packaging 26.2, and PyPI itself pins packaging 26.2, so the index accepts 2.5.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 @ 2026-07-29
         with:
           repository-url: https://test.pypi.org/legacy/
           # Re-running a tag (or a dispatch on the same version) must not fail
@@ -111,7 +119,7 @@ jobs:
 
       - name: Publish to PyPI
         # Pinned to the release/v1 commit SHA; see the TestPyPI step above.
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 @ 2026-02-18
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2 @ 2026-07-29
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
The 0.7.0 tag build was refused by the TestPyPI job with

    InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid
    metadata version

before anything was uploaded. hatchling 1.32.0 (2026-08-11) made core metadata
2.5 its default, and `[build-system] requires = ["hatchling>=1.27"]` has no
ceiling, so the wheel now carries 2.5 where 0.6.0 carried 2.4. The action
verifies distributions with the twine it ships, and the 2026-02-18 pin shipped
twine 6.1.0 / packaging 25.0, which know metadata versions only up to 2.4. The
build job's own `twine check` passed because it installs twine fresh.

v1.14.2 ships twine 7.0.0 / packaging 26.2. The index is not the constraint:
Warehouse pins packaging 26.2 too, so PyPI accepts a 2.5 wheel.

Bumped in both publish steps, with the reason recorded at the pin: this one has
to keep up with the metadata version the build emits, which is not something the
SHA itself says.

## Checks

Full suite green: ruff, `ruff format --check` (259 files), mypy (235 files), `lint-imports`, pytest (6004 passed), `make doctest` (80 passed), coverage (5949 passed), docs with `-W` (0 warnings).

## After merge

Rehearse with a `workflow_dispatch` run of Release (TestPyPI only), then move the `v0.7.0` tag onto the merge commit to re-trigger the real path. Nothing was published: the job failed at verification, and TestPyPI still holds only 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)