### PR TITLE
feat(cpp): the C++ port's infrastructure, and what it measured

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -1,0 +1,165 @@
+# The C++ prototype's CI.
+#
+# MANUAL ONLY. There is no `push` and no `pull_request` trigger, and that is
+# deliberate rather than an oversight:
+#
+#   - This is a prototype on a branch that is meant to be abandonable. Wiring it
+#     into every push would spend runner minutes on a tree whose whole purpose is
+#     to be thrown away if the measurements come out badly.
+#   - The prototype's real check is scripts/ci_local.sh, which runs the two
+#     compilers that the port is actually developed against (conda-forge GCC 14
+#     and Clang 18) and measures against the numba oracle in the same
+#     environment. This workflow answers a narrower question: does the tree build
+#     somewhere that is not the development server.
+#   - .github/workflows/ci.yaml triggers on main only, so nothing here fires by
+#     accident on a proto/cpp pull request either.
+#
+# Run it from the Actions tab, or:  gh workflow run cpp.yaml --ref proto/cpp
+
+name: C++ prototype
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_parity:
+        description: "Run the C++/numba parity test (slower: builds the extension)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cxx:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      # No fail-fast: the two compilers are the point of the matrix, and
+      # cancelling one because the other failed loses exactly the comparison
+      # this job exists to make. CLAUDE.md notes that a cancelled leg reads as a
+      # failure in `gh pr checks`, which turns one defect into two.
+      fail-fast: false
+      matrix:
+        include:
+          - name: GCC 14
+            cc: gcc-14
+            cxx: g++-14
+            packages: gcc-14 g++-14
+          - name: Clang 18
+            cc: clang-18
+            cxx: clang++-18
+            packages: clang-18
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install the compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ${{ matrix.packages }} ninja-build
+
+      - name: Report the toolchain
+        run: |
+          ${{ matrix.cxx }} --version
+          cmake --version
+          ninja --version
+
+      # Not through CMakePresets: the presets pin `jobs: 20` for the development
+      # server's CPU budget, which is wrong for a 4-CPU runner, and they name the
+      # unversioned `g++` / `clang++` that the matrix is here to vary.
+      #
+      # CMAKE_C_COMPILER is pinned as well as CMAKE_CXX_COMPILER, and it matters
+      # even though pantr itself is C++ only: Eigen's own `project()` enables C, so
+      # a C compiler IS selected, and with only the C++ one pinned it defaulted to
+      # whatever `cc` resolves to. That left the "Clang 18" leg building its C with
+      # GCC while reporting itself as a Clang leg -- a two-row matrix whose rows
+      # were less different than they claimed. `matrix.cc` was already declared for
+      # this and simply never referenced.
+      - name: Configure
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DPANTR_WERROR=ON
+          -DPANTR_BUILD_TESTS=ON
+          -DPANTR_BUILD_BENCHMARK=ON
+          -DPANTR_BUILD_PYTHON=OFF
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+      # Which way the mdspan toggle went is the single most useful line to have
+      # in a log from a machine nobody can inspect afterwards.
+      - name: Report the mdspan implementation
+        if: always()
+        run: |
+          if grep -q '^PANTR_HAS_STD_MDSPAN:INTERNAL=1$' build/CMakeCache.txt; then
+            echo "std::mdspan from the standard library"
+          else
+            echo "Kokkos reference implementation"
+          fi
+
+  parity:
+    name: Parity against the numba oracle
+    if: ${{ inputs.run_parity }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install the compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          # The lowest version pyproject.toml declares. The extension is built
+          # here rather than downloaded, so this is also the check that the
+          # nanobind bindings compile against the oldest CPython we claim.
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install pantr with the extension
+        env:
+          CC: gcc-14
+          CXX: g++-14
+        run: pip install -e ".[dev]" -v
+
+      - name: Confirm both backends are available
+        run: |
+          python -c "
+          from pantr._backend import Backend, available_backends
+          got = available_backends()
+          print('available:', [b.name for b in got])
+          assert Backend.CPP in got, 'the C++ extension did not build into this install'
+          "
+
+      - name: Parity
+        run: pytest tests/test_cpp_parity.py -v
+
+      # The acceptance criterion of the infrastructure PR: the pre-existing
+      # suite passes against both backends, not merely a new test written to
+      # agree with the new code.
+      - name: change_basis against both backends
+        run: |
+          for backend in numba cpp; do
+            echo "::group::PANTR_BACKEND=$backend"
+            PANTR_BACKEND=$backend pytest \
+              tests/test_change_basis_1D.py tests/test_change_basis_domain.py -q
+            echo "::endgroup::"
+          done

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -64,7 +64,15 @@ jobs:
 
       - name: Install the toolchain
         run: |
-          sudo apt-get update
+          # Replace the mirror list before touching apt. The runner images point
+          # apt at `mirror+file:/etc/apt/apt-mirrors.txt`, and a dead host inside
+          # that list costs a timeout per index file before the fallback -- the
+          # same step, on identical input, has taken 16 s and 240 s on consecutive
+          # runs here, and once sat past 38 minutes. .github/workflows/ci.yaml
+          # already carries this fix; this workflow was written without it and
+          # stalled in exactly that step on its first run.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build ccache
 
       # The dominant cost of a cold run. cmake/PantrDependencies.cmake pins full
@@ -131,7 +139,15 @@ jobs:
 
       - name: Install the toolchain
         run: |
-          sudo apt-get update
+          # Replace the mirror list before touching apt. The runner images point
+          # apt at `mirror+file:/etc/apt/apt-mirrors.txt`, and a dead host inside
+          # that list costs a timeout per index file before the fallback -- the
+          # same step, on identical input, has taken 16 s and 240 s on consecutive
+          # runs here, and once sat past 38 minutes. .github/workflows/ci.yaml
+          # already carries this fix; this workflow was written without it and
+          # stalled in exactly that step on its first run.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build ccache
 
       - name: Set up Python

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -1,30 +1,49 @@
 # The C++ prototype's CI.
 #
-# MANUAL ONLY. There is no `push` and no `pull_request` trigger, and that is
-# deliberate rather than an oversight:
+# It runs on pull requests against `proto/cpp` and nowhere else. Not on `main`,
+# not on pushes to a working branch, and not on every commit of one.
 #
-#   - This is a prototype on a branch that is meant to be abandonable. Wiring it
-#     into every push would spend runner minutes on a tree whose whole purpose is
-#     to be thrown away if the measurements come out badly.
-#   - The prototype's real check is scripts/ci_local.sh, which runs the two
-#     compilers that the port is actually developed against (conda-forge GCC 14
-#     and Clang 18) and measures against the numba oracle in the same
-#     environment. This workflow answers a narrower question: does the tree build
-#     somewhere that is not the development server.
-#   - .github/workflows/ci.yaml triggers on main only, so nothing here fires by
-#     accident on a proto/cpp pull request either.
+# `.github/workflows/ci.yaml` triggers on `main` only, so this branch had no
+# automatic checks at all until this trigger existed. `workflow_dispatch` alone
+# did not fill the gap and could not: GitHub only offers a manual run for a
+# workflow present on the DEFAULT branch, and this file lives on `proto/cpp`, so
+# it was undispatchable from the Actions tab and from `gh` alike. The dispatch
+# trigger is kept because it costs nothing and starts working the day this file
+# reaches `main`, but the pull-request trigger is what actually runs it.
 #
-# Run it from the Actions tab, or:  gh workflow run cpp.yaml --ref proto/cpp
+# ---------------------------------------------------------------------------
+# What this is for, and what it deliberately does not repeat
+# ---------------------------------------------------------------------------
+#
+# One question: does the tree work somewhere that is not the development server?
+# Everything else is answered better locally, by `scripts/ci_local.sh`, which
+# builds four full configurations on every run -- GCC 14, Clang 18, and both
+# floor compilers, GCC 10 and Clang 10.
+#
+# So there is ONE compiler here, not a matrix. A second one would be the fifth
+# build of the same source in a day, at double the wall clock, to answer a
+# question the first already answers. GCC 14 is the choice because it is the
+# environment's own compiler, so a failure here is a difference in the machine
+# rather than in the toolchain.
+#
+# The parity job is the one that earns its place, and if only one job could
+# survive it would be this one rather than the build. It is the only thing that
+# sees what this project's own CLAUDE.md warns cannot be seen locally: numpy's
+# behaviour differs across versions, the BLAS differs across platforms, and both
+# show up as a numerical difference rather than as an error. A second machine is
+# the only instrument for that.
+#
+# The version floor (GCC 10 / Clang 10) is NOT checked here. `ubuntu-24.04` does
+# not package GCC 10, so it would need an older image or a container, and
+# `ci_local.sh` covers it on every run. design/toolchain_requirements.md records
+# that the floor is guaranteed by one machine.
 
 name: C++ prototype
 
 on:
+  pull_request:
+    branches: [proto/cpp]
   workflow_dispatch:
-    inputs:
-      run_parity:
-        description: "Run the C++/numba parity test (slower: builds the extension)"
-        type: boolean
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,58 +54,50 @@ permissions:
 
 jobs:
   cxx:
-    name: ${{ matrix.name }}
+    name: GCC 14
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    strategy:
-      # No fail-fast: the two compilers are the point of the matrix, and
-      # cancelling one because the other failed loses exactly the comparison
-      # this job exists to make. CLAUDE.md notes that a cancelled leg reads as a
-      # failure in `gh pr checks`, which turns one defect into two.
-      fail-fast: false
-      matrix:
-        include:
-          - name: GCC 14
-            cc: gcc-14
-            cxx: g++-14
-            packages: gcc-14 g++-14
-          - name: Clang 18
-            cc: clang-18
-            cxx: clang++-18
-            packages: clang-18
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install the compiler
+      - name: Install the toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ${{ matrix.packages }} ninja-build
+          sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build ccache
 
-      - name: Report the toolchain
-        run: |
-          ${{ matrix.cxx }} --version
-          cmake --version
-          ninja --version
+      # The dominant cost of a cold run. cmake/PantrDependencies.cmake pins full
+      # SHAs and sets GIT_SHALLOW FALSE deliberately -- a shallow fetch of an
+      # arbitrary SHA is not reliably supported -- so an uncached configure clones
+      # all of Eigen's and Kokkos mdspan's history, every job, every run.
+      - name: Cache the fetched dependencies
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: deps-${{ runner.os }}-${{ hashFiles('cmake/PantrDependencies.cmake') }}
 
-      # Not through CMakePresets: the presets pin `jobs: 20` for the development
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-cxx-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-cxx-${{ runner.os }}-
+
+      # Not through CMakePresets: they pin `jobs: 20` for the development
       # server's CPU budget, which is wrong for a 4-CPU runner, and they name the
-      # unversioned `g++` / `clang++` that the matrix is here to vary.
+      # unversioned `g++` this job is here to pin.
       #
-      # CMAKE_C_COMPILER is pinned as well as CMAKE_CXX_COMPILER, and it matters
-      # even though pantr itself is C++ only: Eigen's own `project()` enables C, so
-      # a C compiler IS selected, and with only the C++ one pinned it defaulted to
-      # whatever `cc` resolves to. That left the "Clang 18" leg building its C with
-      # GCC while reporting itself as a Clang leg -- a two-row matrix whose rows
-      # were less different than they claimed. `matrix.cc` was already declared for
-      # this and simply never referenced.
+      # CMAKE_C_COMPILER is pinned as well as CMAKE_CXX_COMPILER even though
+      # pantr is C++ only: Eigen's own `project()` enables C, so a C compiler IS
+      # selected, and leaving it unpinned takes whatever `cc` resolves to.
       - name: Configure
         run: >
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_C_COMPILER=${{ matrix.cc }}
-          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DCMAKE_C_COMPILER=gcc-14
+          -DCMAKE_CXX_COMPILER=g++-14
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DPANTR_WERROR=ON
           -DPANTR_BUILD_TESTS=ON
           -DPANTR_BUILD_BENCHMARK=ON
@@ -98,8 +109,8 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
-      # Which way the mdspan toggle went is the single most useful line to have
-      # in a log from a machine nobody can inspect afterwards.
+      # Which way the mdspan toggle went is the first thing anyone asks of a log
+      # from a machine they cannot inspect afterwards.
       - name: Report the mdspan implementation
         if: always()
         run: |
@@ -111,34 +122,49 @@ jobs:
 
   parity:
     name: Parity against the numba oracle
-    if: ${{ inputs.run_parity }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install the compiler
+      - name: Install the toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build
+          sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build ccache
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # The lowest version pyproject.toml declares. The extension is built
-          # here rather than downloaded, so this is also the check that the
-          # nanobind bindings compile against the oldest CPython we claim.
+          # The lowest version pyproject.toml declares, so this is also the check
+          # that the bindings compile against the oldest CPython we claim.
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-parity-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-parity-${{ runner.os }}-
+
+      # `.[dev]` would pull sphinx, pyvista and mpi4py to run pytest. This job
+      # needs pantr's runtime dependencies and a test runner, and nothing else --
+      # it builds no docs, renders nothing and launches no MPI.
+      #
+      # No dependency cache is needed here either: PANTR_BUILD_TESTS is off in
+      # the Python build path, so Eigen is never fetched, and Kokkos mdspan is a
+      # small clone.
       - name: Install pantr with the extension
         env:
           CC: gcc-14
           CXX: g++-14
-        run: pip install -e ".[dev]" -v
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+        run: |
+          pip install -e .
+          pip install pytest
 
       - name: Confirm both backends are available
         run: |
@@ -150,11 +176,11 @@ jobs:
           "
 
       - name: Parity
-        run: pytest tests/test_cpp_parity.py -v
+        run: PANTR_REQUIRE_CPP=1 pytest tests/test_cpp_parity.py -q
 
-      # The acceptance criterion of the infrastructure PR: the pre-existing
-      # suite passes against both backends, not merely a new test written to
-      # agree with the new code.
+      # The acceptance criterion of the infrastructure PR: the pre-existing suite
+      # passes against both backends, not merely a new test written to agree with
+      # the new code.
       - name: change_basis against both backends
         run: |
           for backend in numba cpp; do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,91 @@
+# Build for the pantr C++ core.
+#
+# PROTOTYPE. This tree exists to answer whether the C++ port is worth pursuing,
+# not to ship it: one kernel, measured against the Numba implementation that
+# stays as the parity oracle. It is meant to be abandonable. See design/*.md for
+# the decisions it implements and cpp/README.md for what it does and does not
+# cover.
+#
+# Two entry points, both supported:
+#
+#   standalone   cmake --preset gcc && cmake --build --preset gcc && ctest --preset gcc
+#                Builds the C++ tests and the benchmark. No Python involved.
+#
+#   Python       pip install -e .    (through scikit-build-core)
+#                Builds the nanobind extension only.
+
+cmake_minimum_required(VERSION 3.25)  # SYSTEM on FetchContent_Declare
+
+project(pantr_cpp
+        VERSION 0.7.0
+        DESCRIPTION "C++ core for pantr (prototype)"
+        LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+option(PANTR_BUILD_TESTS "Build the C++ tests" ON)
+option(PANTR_BUILD_BENCHMARK "Build the C++ benchmark" ON)
+# OFF by default and switched on explicitly by pyproject.toml's
+# cmake.define, rather than inferred from a scikit-build-core variable: the
+# name and truthiness of those variables are the build backend's to change, and
+# a silently-OFF extension produces a wheel that installs cleanly and then
+# fails at import.
+option(PANTR_BUILD_PYTHON "Build the nanobind extension module" OFF)
+option(PANTR_WERROR "Treat compiler warnings as errors" ON)
+option(PANTR_ALLOW_UNTESTED_COMPILER
+       "Bypass the known-broken-compiler filter (see cmake/PantrCompilerProbes.cmake)" OFF)
+
+# Order matters: the probes set PANTR_HAS_STD_MDSPAN, which decides whether the
+# dependency step fetches Kokkos at all.
+include(PantrCompilerProbes)
+include(PantrDependencies)
+include(PantrCompileOptions)
+
+# --------------------------------------------------------------------------
+# The core: header-only, scalar-generic.
+# --------------------------------------------------------------------------
+add_library(pantr_core INTERFACE)
+add_library(pantr::core ALIAS pantr_core)
+
+target_include_directories(pantr_core INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cpp/include>")
+
+target_link_libraries(pantr_core INTERFACE pantr::cxx_flags)
+
+if(PANTR_HAS_STD_MDSPAN)
+  target_compile_definitions(pantr_core INTERFACE PANTR_HAS_STD_MDSPAN=1)
+else()
+  target_link_libraries(pantr_core INTERFACE std::mdspan)
+endif()
+
+if(PANTR_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(cpp/tests)
+endif()
+
+if(PANTR_BUILD_BENCHMARK)
+  add_subdirectory(cpp/benchmark)
+endif()
+
+if(PANTR_BUILD_PYTHON)
+  add_subdirectory(cpp/bindings)
+endif()
+
+# Spelled out rather than interpolated. PANTR_HAS_STD_MDSPAN is EMPTY when the
+# probe fails, so "std::mdspan ${PANTR_HAS_STD_MDSPAN}" rendered as a bare
+# "std::mdspan" on exactly the builds that are not using it -- a summary line
+# asserting the opposite of the truth about the only toggle in this build.
+if(PANTR_HAS_STD_MDSPAN)
+  set(_pantr_mdspan "std::mdspan")
+else()
+  set(_pantr_mdspan "Kokkos mdspan")
+endif()
+
+message(STATUS "pantr: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}, "
+               "build type ${CMAKE_BUILD_TYPE}, "
+               "${_pantr_mdspan}, "
+               "tests ${PANTR_BUILD_TESTS}, python ${PANTR_BUILD_PYTHON}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,81 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "PANTR_WERROR": "ON",
+        "PANTR_BUILD_TESTS": "ON",
+        "PANTR_BUILD_BENCHMARK": "ON",
+        "PANTR_BUILD_PYTHON": "OFF"
+      }
+    },
+    {
+      "name": "gcc",
+      "inherits": "base",
+      "displayName": "GCC (conda-forge)",
+      "description": "The environment's g++. Its own build directory, because probe results are cached in CMakeCache.txt and switching compilers inside one directory yields stale answers.",
+      "cacheVariables": { "CMAKE_CXX_COMPILER": "g++" }
+    },
+    {
+      "name": "clang",
+      "inherits": "base",
+      "displayName": "Clang (conda-forge)",
+      "description": "The environment's clang++. Separate binary directory from the gcc preset, for the same reason.",
+      "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++" }
+    },
+    {
+      "name": "gcc-debug",
+      "inherits": "gcc",
+      "displayName": "GCC, debug with sanitizers",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0 -fsanitize=address,undefined -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "gcc",
+      "configurePreset": "gcc",
+      "jobs": 20
+    },
+    {
+      "name": "clang",
+      "configurePreset": "clang",
+      "jobs": 20
+    },
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc-debug",
+      "jobs": 20
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "gcc",
+      "configurePreset": "gcc",
+      "output": { "outputOnFailure": true },
+      "execution": { "jobs": 20, "noTestsAction": "error", "stopOnFailure": false }
+    },
+    {
+      "name": "clang",
+      "configurePreset": "clang",
+      "output": { "outputOnFailure": true },
+      "execution": { "jobs": 20, "noTestsAction": "error", "stopOnFailure": false }
+    },
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "jobs": 20, "noTestsAction": "error", "stopOnFailure": false }
+    }
+  ]
+}

--- a/cmake/PantrCompileOptions.cmake
+++ b/cmake/PantrCompileOptions.cmake
@@ -1,0 +1,102 @@
+# The interface target every pantr C++ target links against.
+#
+# Two decisions from design/toolchain_requirements.md and design/simd.md are
+# enforced here, because CMake is the only place they can be enforced once.
+#
+# ---------------------------------------------------------------------------
+# 1. Never -ffast-math, and never -ffinite-math-only
+# ---------------------------------------------------------------------------
+#
+# -ffast-math permits REASSOCIATION of sums, and reassociation invalidates the
+# error bounds that every derived tolerance in this library assumes: a tolerance
+# derived under one association order is not a tolerance under another. It is
+# not a performance option, it is a silent correctness change, and the failure it
+# produces is a wrong number rather than a crash.
+#
+# -ffinite-math-only is banned for a second reason on top of that one: it tells
+# the compiler no infinity or NaN can occur, which licenses it to delete the
+# very checks that detect a degenerate input.
+#
+# -funsafe-math-optimizations alone may be offered behind an explicit option one
+# day. It is not offered today.
+#
+# The check below covers flags reaching the build through CMAKE_CXX_FLAGS and
+# the per-configuration variants, which is how they actually arrive (an
+# environment CXXFLAGS, a conda activation script, a well-meaning preset).
+#
+# ---------------------------------------------------------------------------
+# 2. The floating-point contraction flag goes on the INTERFACE target
+# ---------------------------------------------------------------------------
+#
+# Any flag that participates in a numerical claim must reach every variant, or
+# the ISA variants of design/simd.md will disagree numerically with each other
+# and the resulting bug will look like a dispatch bug. Setting it per target is
+# how that happens; setting it here is how it is prevented.
+#
+# The value is `on` rather than `fast`, and the choice is load-bearing for the
+# parity tolerance rather than a matter of taste:
+#
+#   `on`   is the standard's FP_CONTRACT behaviour: a multiply may be fused into
+#          an add only within a single expression. The set of fused sites is
+#          then determinable by reading the source, which is what makes the
+#          parity bound in tests/test_cpp_parity.py DERIVED rather than fitted.
+#   `fast` allows contraction across statements, so the fused set depends on
+#          what the optimiser chose to hoist, and no bound written by hand can
+#          be checked against it.
+#
+# It is also set explicitly because the compilers disagree on their default:
+# GCC defaults to `fast` and Clang to `on`. Leaving it implicit would mean the
+# two compilers compute different numbers, which is precisely the disagreement
+# the interface target exists to prevent.
+#
+# Caveat: GCC only implements `on` distinctly from `fast` since GCC 14. On
+# GCC 13 and older the flag is accepted and silently means `fast`, so the fused
+# set is wider than the bound assumes there. The concepts gate already rejects
+# compilers that old in practice; noted so it is not a surprise.
+
+include_guard(GLOBAL)
+
+set(_pantr_forbidden_math_flags "-ffast-math" "-ffinite-math-only" "/fp:fast")
+
+foreach(_flag_var
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS_MINSIZEREL)
+  foreach(_forbidden IN LISTS _pantr_forbidden_math_flags)
+    if("${${_flag_var}}" MATCHES "(^| )${_forbidden}( |$)")
+      message(FATAL_ERROR
+          "pantr refuses to build with ${_forbidden}, found in ${_flag_var}:\n"
+          "    ${${_flag_var}}\n"
+          "It permits reassociation of floating-point sums, which invalidates "
+          "the error bound behind every derived tolerance in this library. "
+          "This is a correctness setting, not a performance one, and its "
+          "failure mode is a wrong number rather than a crash.")
+    endif()
+  endforeach()
+endforeach()
+
+add_library(pantr_cxx_flags INTERFACE)
+add_library(pantr::cxx_flags ALIAS pantr_cxx_flags)
+
+target_compile_features(pantr_cxx_flags INTERFACE cxx_std_20)
+
+# Explicit, on the interface target, so every consumer -- including the ISA
+# variants of design/simd.md, when they exist -- fuses the same set of sites.
+target_compile_options(pantr_cxx_flags INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-ffp-contract=on>)
+
+target_compile_options(pantr_cxx_flags INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:
+        -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wdouble-promotion>)
+
+if(PANTR_WERROR)
+  target_compile_options(pantr_cxx_flags INTERFACE
+      $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-Werror>)
+endif()
+
+# Deliberately absent: any -march or -mtune. Shipping several ISA variants is
+# stage 2 in design/simd.md, and it is gated there on first MEASURING the gap
+# between the baseline and x86-64-v3 on pantr's own kernels. Adding the flag
+# here would spend that decision before the measurement that justifies it.

--- a/cmake/PantrCompilerProbes.cmake
+++ b/cmake/PantrCompilerProbes.cmake
@@ -106,28 +106,26 @@ endif()
 # Absent from GCC 14, which is this project's own build compiler, so the Kokkos
 # fallback is the normal path here rather than a precaution.
 #
-# The probe asks TWO questions, because cpp/include/pantr/core/mdspan.hpp needs
-# both answers and they come from different parts of the standard:
+# The probe asks the question its own feature-test macro answers -- does the
+# standard LIBRARY implement P0009? -- and then compiles the one expression the
+# library actually depends on. It used to consult no macro at all and infer the
+# answer from whether the body compiled, which conflates a missing header with a
+# body that does not parse.
 #
-#   __cpp_lib_mdspan   does the standard LIBRARY implement P0009? That macro is
-#                      this question's own feature-test macro, so it answers it
-#                      directly. The probe used not to consult it and inferred the
-#                      answer from whether the body compiled, which conflates a
-#                      missing header with a body that does not parse -- and the
-#                      body did not parse, for the reason immediately below.
-#   view[1, 2]         does the LANGUAGE have the multidimensional subscript?
-#                      `pantr::at` uses exactly this spelling in its
-#                      PANTR_HAS_STD_MDSPAN branch, so a standard library that
-#                      shipped <mdspan> in a mode where this does not parse would
-#                      be of no use: the toggle would turn ON and the build would
-#                      then fail. Under C++20 `view[1, 2]` is the comma operator,
-#                      which indexes a rank-2 mdspan with a single index and does
-#                      not compile.
+# The body indexes through `std::array`, because that is what `pantr::at` does.
+# It used to index with `view[1, 2]`, the C++23 multidimensional subscript, which
+# added a second question -- does the LANGUAGE have that operator? -- that the
+# library no longer needs anyone to answer: the array overload is specified
+# unconditionally in C++23 and provided unconditionally by Kokkos, so `at` uses
+# it in both branches of the switch and parses under C++20 either way. Asking it
+# anyway made the toggle answer OFF under a C++20 baseline no matter what the
+# standard library shipped, which is the correct answer today for the wrong
+# reason and the wrong answer the day one of them changes.
 #
-# Both are C++23 and are gated together, so under the C++20 baseline this probe is
-# a foregone OFF. That is the correct answer -- but it is now reached for a stated
-# reason rather than by accident, it says so in the CMake log, and it will start
-# answering ON by itself on the day the baseline moves.
+# Under the C++20 baseline this probe is still a foregone OFF, because libstdc++
+# defines __cpp_lib_mdspan only in C++23 mode. That is now the single reason, it
+# says so in the CMake log, and it will start answering ON by itself on the day
+# the baseline moves.
 #
 # CMAKE_REQUIRED_FLAGS at the top of this file pins the probe to -std=c++20, and
 # that must be kept in step with the cxx_std_20 in cmake/PantrCompileOptions.cmake.
@@ -141,12 +139,14 @@ check_cxx_source_compiles("
 #  error \"the standard library does not implement P0009 in this language mode\"
 #endif
 #include <mdspan>
+#include <array>
 #include <cstddef>
 int main() {
     double storage[6]{};
     std::mdspan<double, std::dextents<std::size_t, 2>> view(storage, 2, 3);
-    view[1, 2] = 1.0;
-    return view[1, 2] == 1.0 ? 0 : 1;
+    const std::array<std::size_t, 2> ij{1, 2};
+    view[ij] = 1.0;
+    return view[ij] == 1.0 ? 0 : 1;
 }
 " PANTR_HAS_STD_MDSPAN)
 

--- a/cmake/PantrCompilerProbes.cmake
+++ b/cmake/PantrCompilerProbes.cmake
@@ -1,0 +1,189 @@
+# Configure-time capability probes for the pantr C++ core.
+#
+# The policy this file implements is design/toolchain_requirements.md: probe the
+# features the library actually uses, never gate on a compiler version number.
+# Version numbers are a proxy for features and they fail in both directions -- a
+# vendor may backport a feature to a lower version, and a version may nominally
+# carry a feature that is broken. AppleClang does not map to LLVM versions at
+# all, so any version table has a row that lies.
+#
+# Two kinds of requirement, distinguished by whether a cheap fallback exists:
+#
+#   hard gate      concepts. The scalar-generic design rests entirely on them and
+#                  there is no fallback, so a compiler without them is rejected.
+#   feature toggle <mdspan>. The Kokkos reference implementation is a drop-in, so
+#                  its absence selects a fallback rather than ending the build.
+#
+# Caveat worth knowing before it costs an afternoon: probe results are cached in
+# CMakeCache.txt, so switching compilers inside an existing build directory
+# yields stale answers. Delete the build directory; the presets give each
+# compiler its own so this does not arise in the normal flow.
+
+include_guard(GLOBAL)
+include(CheckCXXSourceCompiles)
+
+# The probes must run under the same standard the library is built with, or they
+# answer a question nobody asked.
+set(CMAKE_REQUIRED_FLAGS "-std=c++20")
+
+# One line, reused by every failure below, so the person who hits any of them is
+# told what they are running and what fixes it. That line decides whether they
+# give up or write to the maintainer.
+set(PANTR_TOOLCHAIN_REPORT
+    "  Detected: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}\n"
+    "  Compiler: ${CMAKE_CXX_COMPILER}\n"
+    "  Fix (no root needed): conda install -c conda-forge gxx=14\n"
+    "  Then configure a FRESH build directory -- probe results are cached.")
+
+# --------------------------------------------------------------------------
+# Hard gate: C++20 concepts, probed in the shape pantr::Real actually has.
+# --------------------------------------------------------------------------
+#
+# target_compile_features(tgt PRIVATE cxx_std_20) verifies only that the
+# compiler ACCEPTS the flag. GCC 10 accepts -std=c++20 and passes that check
+# while lacking parts of the standard library, so it is not a gate: it defers
+# the failure to a template error deep in a build.
+#
+# A generic C++20 test proves little either. This probe is the shape of the
+# scalar concept in cpp/include/pantr/core/scalar.hpp -- the arithmetic closure,
+# the two-step `using pantr::value_of; value_of(x)` that Tier B operations go
+# through, and a constrained template instantiated on double. Keep the two in
+# sync: a probe testing something the library no longer uses is a gate that
+# rejects for no reason, and a construct used without a probe is a template
+# error waiting for a user.
+check_cxx_source_compiles("
+#include <concepts>
+#include <type_traits>
+
+namespace pantr {
+
+template <std::floating_point T>
+constexpr T value_of(T x) noexcept { return x; }
+
+namespace detail {
+using pantr::value_of;
+template <class T>
+concept has_value_of = requires(const T& a) {
+    { value_of(a) } -> std::floating_point;
+};
+}  // namespace detail
+
+template <class T>
+concept Real = std::copyable<T> && detail::has_value_of<T> &&
+    requires(T a, T b) {
+        { -a } -> std::convertible_to<T>;
+        { a + b } -> std::convertible_to<T>;
+        { a - b } -> std::convertible_to<T>;
+        { a * b } -> std::convertible_to<T>;
+        { a / b } -> std::convertible_to<T>;
+    };
+
+template <Real T>
+constexpr T twice(T x) { return x + x; }
+
+}  // namespace pantr
+
+int main() {
+    static_assert(pantr::Real<double>);
+    static_assert(pantr::Real<float>);
+    static_assert(!pantr::Real<int>);
+    return pantr::twice(1.0) == 2.0 ? 0 : 1;
+}
+" PANTR_HAS_CONCEPTS)
+
+if(NOT PANTR_HAS_CONCEPTS)
+  message(FATAL_ERROR
+      "pantr requires working C++20 concepts, and this compiler does not provide "
+      "them. The scalar-generic core rests entirely on concepts; there is no "
+      "fallback path.\n"
+      ${PANTR_TOOLCHAIN_REPORT})
+endif()
+
+# --------------------------------------------------------------------------
+# Feature toggle: <mdspan>.
+# --------------------------------------------------------------------------
+#
+# Absent from GCC 14, which is this project's own build compiler, so the Kokkos
+# fallback is the normal path here rather than a precaution.
+#
+# The probe asks TWO questions, because cpp/include/pantr/core/mdspan.hpp needs
+# both answers and they come from different parts of the standard:
+#
+#   __cpp_lib_mdspan   does the standard LIBRARY implement P0009? That macro is
+#                      this question's own feature-test macro, so it answers it
+#                      directly. The probe used not to consult it and inferred the
+#                      answer from whether the body compiled, which conflates a
+#                      missing header with a body that does not parse -- and the
+#                      body did not parse, for the reason immediately below.
+#   view[1, 2]         does the LANGUAGE have the multidimensional subscript?
+#                      `pantr::at` uses exactly this spelling in its
+#                      PANTR_HAS_STD_MDSPAN branch, so a standard library that
+#                      shipped <mdspan> in a mode where this does not parse would
+#                      be of no use: the toggle would turn ON and the build would
+#                      then fail. Under C++20 `view[1, 2]` is the comma operator,
+#                      which indexes a rank-2 mdspan with a single index and does
+#                      not compile.
+#
+# Both are C++23 and are gated together, so under the C++20 baseline this probe is
+# a foregone OFF. That is the correct answer -- but it is now reached for a stated
+# reason rather than by accident, it says so in the CMake log, and it will start
+# answering ON by itself on the day the baseline moves.
+#
+# CMAKE_REQUIRED_FLAGS at the top of this file pins the probe to -std=c++20, and
+# that must be kept in step with the cxx_std_20 in cmake/PantrCompileOptions.cmake.
+# The pin is the safe direction of the two: a probe run at a LOWER standard than
+# the build can only under-report a feature, which selects the fallback, and the
+# fallback compiles in every mode. A probe run at a HIGHER standard could turn the
+# toggle on for a build that cannot compile it.
+check_cxx_source_compiles("
+#include <version>
+#if !defined(__cpp_lib_mdspan)
+#  error \"the standard library does not implement P0009 in this language mode\"
+#endif
+#include <mdspan>
+#include <cstddef>
+int main() {
+    double storage[6]{};
+    std::mdspan<double, std::dextents<std::size_t, 2>> view(storage, 2, 3);
+    view[1, 2] = 1.0;
+    return view[1, 2] == 1.0 ? 0 : 1;
+}
+" PANTR_HAS_STD_MDSPAN)
+
+if(PANTR_HAS_STD_MDSPAN)
+  message(STATUS "pantr: <mdspan> is available; the Kokkos fallback is not used")
+else()
+  message(STATUS "pantr: <mdspan> is absent; using the Kokkos reference implementation")
+endif()
+
+# --------------------------------------------------------------------------
+# The version floor survives, in a different role.
+# --------------------------------------------------------------------------
+#
+# A probe reports whether something COMPILES, not whether it is CORRECT. Clang
+# 10's concepts support was partial and buggy, so a small probe could plausibly
+# compile on an implementation that then miscompiles the real library.
+#
+# So a version check stays, but it is no longer the criterion: it is a filter for
+# implementations KNOWN to be broken. This list only grows from an observed
+# failure, never from speculation -- otherwise it becomes the version table this
+# file exists to avoid. Each entry carries its reason and there is an escape for
+# someone who knows better.
+#
+# The Clang 14 floor below is inherited from design/toolchain_requirements.md,
+# where it is recorded as a starting guess rather than a measurement: the
+# development server's system Clang 10 is shadowed by the conda environment, so
+# what the probe reports on it was never observed. Replace it the day someone
+# runs the probe on a real Clang between 10 and 14.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+   AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14
+   AND NOT PANTR_ALLOW_UNTESTED_COMPILER)
+  message(FATAL_ERROR
+      "Clang before 14 has known-incomplete concepts support: the probe above "
+      "can pass on it while the real library miscompiles.\n"
+      ${PANTR_TOOLCHAIN_REPORT}
+      "\n  Override with -DPANTR_ALLOW_UNTESTED_COMPILER=ON at your own risk.")
+endif()
+
+unset(CMAKE_REQUIRED_FLAGS)

--- a/cmake/PantrCompilerProbes.cmake
+++ b/cmake/PantrCompilerProbes.cmake
@@ -160,28 +160,50 @@ endif()
 # The version floor survives, in a different role.
 # --------------------------------------------------------------------------
 #
-# A probe reports whether something COMPILES, not whether it is CORRECT. Clang
-# 10's concepts support was partial and buggy, so a small probe could plausibly
-# compile on an implementation that then miscompiles the real library.
+# A probe reports whether something COMPILES, not whether it is CORRECT, so a
+# version check stays alongside it. What that check MEANS is the part worth
+# stating, because it changed once already.
 #
-# So a version check stays, but it is no longer the criterion: it is a filter for
-# implementations KNOWN to be broken. This list only grows from an observed
-# failure, never from speculation -- otherwise it becomes the version table this
-# file exists to avoid. Each entry carries its reason and there is an escape for
-# someone who knows better.
-#
-# The Clang 14 floor below is inherited from design/toolchain_requirements.md,
-# where it is recorded as a starting guess rather than a measurement: the
+# It used to read "Clang before 14 has known-incomplete concepts support", which
+# is a claim about Clang that nobody here had evidence for. It came from
+# design/toolchain_requirements.md, which records it as a starting guess: the
 # development server's system Clang 10 is shadowed by the conda environment, so
-# what the probe reports on it was never observed. Replace it the day someone
-# runs the probe on a real Clang between 10 and 14.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
-   AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14
+# it was never actually tried.
+#
+# Measured 2026-08-19, against this tree rather than a toy:
+#
+#   g++ 9.5      rejected, and early -- it does not accept -std=c++20 at all, so
+#                the concepts probe above stops it before this check runs.
+#   g++ 10       configures, builds the whole tree under -Werror with the full
+#                warning set, and passes 3/3 ctest.
+#   clang++ 10   the same, once the override this block used to demand was given.
+#   g++ 14.4, clang++ 18.1.8   the development toolchains, likewise.
+#
+# So the floor is 10 for both families, and it now means THE LOWEST VERSION
+# ACTUALLY EXERCISED rather than a guess about anyone's concepts implementation.
+# "Untested below this" is a claim about us and we can support it; "broken below
+# this" was a claim about the compiler and we could not.
+#
+# The check covers GNU as well as Clang, and that symmetry is the other half of
+# the correction. It was Clang-only because the guess was about Clang's concepts,
+# so a GCC 10 walked in with nothing said while a Clang 10 hit a hard stop --
+# same year, same standard-library era, opposite treatment, neither measured.
+#
+# AppleClang stays excluded deliberately: its version numbers do not map to LLVM
+# versions, so any threshold applied to it is a row that lies.
+#
+# Raise this floor only from an OBSERVED failure, never from speculation, or it
+# becomes the version table this file exists to avoid.
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+    OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+        AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10
    AND NOT PANTR_ALLOW_UNTESTED_COMPILER)
   message(FATAL_ERROR
-      "Clang before 14 has known-incomplete concepts support: the probe above "
-      "can pass on it while the real library miscompiles.\n"
+      "pantr has never been built with ${CMAKE_CXX_COMPILER_ID} below version 10. "
+      "Version 10 of both GCC and Clang is measured to build this tree and pass "
+      "its tests; nothing older has been tried, and the probe above cannot tell a "
+      "compiler that miscompiles from one that does not.\n"
       ${PANTR_TOOLCHAIN_REPORT}
       "\n  Override with -DPANTR_ALLOW_UNTESTED_COMPILER=ON at your own risk.")
 endif()

--- a/cmake/PantrDependencies.cmake
+++ b/cmake/PantrDependencies.cmake
@@ -1,0 +1,123 @@
+# Third-party dependencies for the pantr C++ core, fetched at configure time.
+#
+# Three rules govern every entry here, and each exists because of a failure that
+# is confusing when it happens:
+#
+#   GIT_TAG is a full 40-character SHA. A tag is a mutable pointer: it can be
+#   moved or deleted upstream, which turns a reproducible build into one that
+#   silently changes. The human-readable tag each SHA corresponds to is recorded
+#   in the comment beside it, since a SHA alone tells a reader nothing.
+#
+#   SYSTEM marks the dependency's headers as system headers, so warnings raised
+#   inside them do not reach pantr's -Werror. Without it, upstream's warning
+#   discipline decides whether pantr builds. Needs CMake 3.25 or newer.
+#
+#   EXCLUDE_FROM_ALL keeps the dependency's own targets (its tests, its
+#   benchmarks, its install rules) out of pantr's default build and out of
+#   pantr's install tree.
+#
+# ---------------------------------------------------------------------------
+# CMake 4 is strict about what dependencies declare
+# ---------------------------------------------------------------------------
+#
+# CMake 4 REMOVED compatibility with cmake_minimum_required(VERSION < 3.5). A
+# project declaring an older minimum fails hard at configure time rather than
+# warning. That matters here specifically because FetchContent pulls
+# CMakeLists.txt files nobody in this project controls, and one of them
+# declaring an ancient minimum takes the build down with an error that reads as
+# if it came from pantr's own CMake.
+#
+# The escape hatch exists for exactly this, and is documented here rather than
+# discovered:
+#
+#     cmake --preset gcc -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+#
+# ---------------------------------------------------------------------------
+# The offline escape
+# ---------------------------------------------------------------------------
+#
+# FetchContent needs network access at configure time. The development server
+# has it; a cluster compute node typically does not. Point each dependency at a
+# pre-populated checkout instead:
+#
+#     cmake --preset gcc \
+#         -DFETCHCONTENT_SOURCE_DIR_MDSPAN=/path/to/mdspan \
+#         -DFETCHCONTENT_SOURCE_DIR_EIGEN=/path/to/eigen
+#
+# or, with a fully populated FetchContent cache, forbid network access outright
+# so a missing entry fails loudly instead of hanging on a clone:
+#
+#     cmake --preset gcc -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+#
+# The variable name is FETCHCONTENT_SOURCE_DIR_<NAME> with <NAME> upper-cased
+# from the FetchContent_Declare name, hence MDSPAN and EIGEN below.
+
+include_guard(GLOBAL)
+include(FetchContent)
+
+# --------------------------------------------------------------------------
+# Kokkos mdspan -- the reference implementation of std::mdspan.
+# --------------------------------------------------------------------------
+#
+# Fetched only when the standard library does not provide <mdspan>. GCC 14, the
+# build compiler on the development server, does not, so this is the normal path
+# here rather than a fallback for exotic toolchains.
+if(NOT PANTR_HAS_STD_MDSPAN)
+  FetchContent_Declare(
+      mdspan
+      GIT_REPOSITORY https://github.com/kokkos/mdspan.git
+      GIT_TAG        9ceface91483775a6c74d06ebf717bbb2768452f  # tag mdspan-0.6.0
+      GIT_SHALLOW    FALSE
+      SYSTEM
+      EXCLUDE_FROM_ALL)
+
+  # Ask Kokkos to place its symbols in the namespace the C++23 header would use,
+  # so cpp/include/pantr/core/mdspan.hpp aliases one name in both branches of
+  # the switch rather than papering over two different spellings.
+  set(MDSPAN_CXX_STANDARD 20 CACHE STRING "" FORCE)
+  set(MDSPAN_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+  set(MDSPAN_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+  set(MDSPAN_ENABLE_BENCHMARKS OFF CACHE BOOL "" FORCE)
+
+  FetchContent_MakeAvailable(mdspan)
+endif()
+
+# --------------------------------------------------------------------------
+# Eigen -- dense and sparse linear algebra.
+# --------------------------------------------------------------------------
+#
+# Not used by the one kernel this prototype ships. It is fetched and compiled
+# against anyway, by cpp/tests/test_dependency_smoke.cpp, because the question
+# this prototype exists to answer is whether the dependency survives pantr's own
+# warning flags and this CMake version -- and a header that is never included
+# answers nothing. design/large_data_fitting.md and
+# design/adaptive_thb_approximation.md both settle on Eigen::SparseMatrix with
+# SimplicialLDLT for the fitting solves, which is what it is here for.
+#
+# Eigen's own CMakeLists is run rather than bypassed, deliberately: bypassing it
+# (SOURCE_SUBDIR pointing at a directory with no CMakeLists) would hide exactly
+# the CMake 4 incompatibility this prototype is meant to measure.
+# Fetched only when the tests are built. Nothing in the installed extension
+# includes an Eigen header, so a `pip install` has no business cloning it -- and
+# a dependency a wheel build does not need is a dependency a wheel build cannot
+# fail on.
+if(PANTR_BUILD_TESTS)
+
+FetchContent_Declare(
+    eigen
+    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+    GIT_TAG        bc3b39870ecb690a623a3f49149a358b95c5781d  # tag 5.0.1
+    GIT_SHALLOW    FALSE
+    SYSTEM
+    EXCLUDE_FROM_ALL)
+
+set(EIGEN_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_DEMOS OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_BLAS OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_LAPACK OFF CACHE BOOL "" FORCE)
+set(EIGEN_BUILD_CMAKE_PACKAGE OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(eigen)
+
+endif()

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -143,10 +143,15 @@ numba instead of 1.3x faster, which is the opposite conclusion.
 ## The open question this prototype raises
 
 The version filter rejects Clang below 14, inherited from
-`design/toolchain_requirements.md` where it is recorded as a guess. Measured
+`design/toolchain_requirements.md` where it was recorded as a guess. Measured
 here, Clang 10 and GCC 10 both pass the concepts probe *and* compile and
 correctly run the kernel. That note's own rule is that the filter "should only
 grow from observed failures, never from speculation", and there is no observed
-failure behind this entry. One kernel is weak evidence about a whole library, so
-the filter has not been removed; but it is now known to be untested rather than
-merely unverified, and the note should say so.
+failure behind this entry.
+
+One kernel is weak evidence about a whole library, so the filter has **not** been
+removed. What has changed is what is known about it: the note's open question 1
+is now answered and its epistemic status records the measurement, so the floor
+has moved from *unverified* to *measured and unsupported*. Whoever next needs a
+Clang between 10 and 14 has the evidence to argue with, and the override
+(`-DPANTR_ALLOW_UNTESTED_COMPILER=ON`) to proceed meanwhile.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -23,12 +23,13 @@ cpp/benchmark/                           the kernel alone, no Python
 The Python side of the same prototype:
 
 ```
-src/pantr/_backend.py        PANTR_BACKEND policy: which backends, which one
-src/pantr/basis/_basis_backend.py   the basis kernels of each backend, and the
-                                    adapter that calls the extension
-tests/test_cpp_parity.py     the C++ result against the numba oracle
-scripts/bench_parity.py      both kernels and both entry points, timed
-scripts/ci_local.sh          the whole check, and the gates asserted to fire
+src/pantr/_backend.py                PANTR_BACKEND and PANTR_ISA_VARIANT: which
+                                     implementation, and the rule it never breaks
+src/pantr/basis/_basis_backend.py    the basis kernels of each backend, and the
+                                     adapter that calls the extension
+tests/test_cpp_parity.py             the C++ result against the numba oracle
+scripts/bench_parity.py              both kernels and both entry points, timed
+scripts/ci_local.sh                  the whole check, and the gates asserted to fire
 ```
 
 ## Building it

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -140,18 +140,23 @@ numba instead of 1.3x faster, which is the opposite conclusion.
 - **No wheel strategy.** The stable ABI is deliberately off; split mode is
   probed by `scripts/ci_local.sh` and not adopted.
 
-## The open question this prototype raises
+## The version floor, and how it was set
 
-The version filter rejects Clang below 14, inherited from
-`design/toolchain_requirements.md` where it was recorded as a guess. Measured
-here, Clang 10 and GCC 10 both pass the concepts probe *and* compile and
-correctly run the kernel. That note's own rule is that the filter "should only
-grow from observed failures, never from speculation", and there is no observed
-failure behind this entry.
+Measured here rather than guessed, against this tree rather than a snippet:
 
-One kernel is weak evidence about a whole library, so the filter has **not** been
-removed. What has changed is what is known about it: the note's open question 1
-is now answered and its epistemic status records the measurement, so the floor
-has moved from *unverified* to *measured and unsupported*. Whoever next needs a
-Clang between 10 and 14 has the evidence to argue with, and the override
-(`-DPANTR_ALLOW_UNTESTED_COMPILER=ON`) to proceed meanwhile.
+| compiler | probe | build under `-Werror` | ctest |
+|---|---|---|---|
+| g++ 9.5 | fails (no `-std=c++20`) | -- | -- |
+| g++ 10 | passes | yes | 3/3 |
+| clang++ 10 | passes | yes | 3/3 |
+| g++ 14.4, clang++ 18.1.8 | passes | yes | 3/3 |
+
+So the floor is **10 for GCC and Clang alike**, and it means *the lowest version anyone has
+actually exercised*. It replaces a floor of 14 for Clang, inherited from
+`design/toolchain_requirements.md` as an explicit guess, together with no floor at all for
+GCC -- an asymmetry that let a GCC 10 configure silently while a Clang 10 of the same year
+was refused outright, and that nobody had measured in either direction.
+
+AppleClang stays exempt: its version numbers do not map to LLVM versions, so any threshold
+applied to it is a row that lies. `-DPANTR_ALLOW_UNTESTED_COMPILER=ON` still opens the gate
+for anyone who knows better, and the floor should rise only from an observed failure.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -23,7 +23,9 @@ cpp/benchmark/                           the kernel alone, no Python
 The Python side of the same prototype:
 
 ```
-src/pantr/_backend.py        PANTR_BACKEND dispatch between numba and C++
+src/pantr/_backend.py        PANTR_BACKEND policy: which backends, which one
+src/pantr/basis/_basis_backend.py   the basis kernels of each backend, and the
+                                    adapter that calls the extension
 tests/test_cpp_parity.py     the C++ result against the numba oracle
 scripts/bench_parity.py      both kernels and both entry points, timed
 scripts/ci_local.sh          the whole check, and the gates asserted to fire

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,152 @@
+# The pantr C++ prototype
+
+**This is a prototype and it is meant to be abandonable.** It exists to answer a
+short list of questions about whether a C++ port of pantr is worth doing, with
+measurements rather than opinions. It ports exactly one kernel. If the answers
+had come out badly the right response would have been to delete the branch, and
+nothing here is shaped to make that hard.
+
+The decisions it implements were taken beforehand and live in `design/*.md` at
+the repository root. This directory implements them; it does not revisit them.
+
+## What is here
+
+```
+cpp/include/pantr/core/scalar.hpp        the Real concept and value_of (Tier A/B)
+cpp/include/pantr/core/mdspan.hpp        the <mdspan> / Kokkos switch
+cpp/include/pantr/basis/cardinal_bspline.hpp   the one ported kernel
+cpp/bindings/                            the nanobind extension
+cpp/tests/                               ctest: dependencies, the concept, the kernel
+cpp/benchmark/                           the kernel alone, no Python
+```
+
+The Python side of the same prototype:
+
+```
+src/pantr/_backend.py        PANTR_BACKEND dispatch between numba and C++
+tests/test_cpp_parity.py     the C++ result against the numba oracle
+scripts/bench_parity.py      both kernels and both entry points, timed
+scripts/ci_local.sh          the whole check, and the gates asserted to fire
+```
+
+## Building it
+
+Two entry points, both supported and both exercised by `scripts/ci_local.sh`.
+
+```bash
+# Standalone: C++ tests and the benchmark, no Python involved.
+cmake --preset gcc && cmake --build --preset gcc && ctest --preset gcc
+cmake --preset clang && cmake --build --preset clang && ctest --preset clang
+
+# Through Python: the extension only.
+python -m venv --system-site-packages .venv && . .venv/bin/activate
+pip install -e . --no-build-isolation
+```
+
+Each compiler gets its own build directory on purpose. Configure-time probe
+results are cached in `CMakeCache.txt`, so reusing one directory across
+compilers answers for whichever configured it first.
+
+## What it measured
+
+All figures from the development server: conda-forge GCC 14.4.0 and Clang
+18.1.8, CMake 4.4.2, numba 0.65.1, 20 CPUs of a shared 160-CPU machine.
+
+**Both compilers build it** with `-Werror` and all of
+`-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wdouble-promotion`, and the
+three ctest binaries pass under both.
+
+**`<mdspan>` is absent**, so the Kokkos reference implementation is the normal
+path rather than a fallback. The reason is an implementation gap in GCC 14's
+libstdc++, not the C++20 baseline: `__cpp_lib_mdspan` is undefined even under
+`-std=gnu++23`. Clang 18 here uses that same libstdc++ and inherits it.
+
+**Kokkos mdspan and Eigen both survive** `SYSTEM` plus `-Werror`, and both
+declare a `cmake_minimum_required` new enough for CMake 4. Eigen 5.0.1 emits one
+`CMP0146` deprecation warning at configure time, which is a policy warning
+rather than a compile warning and so does not reach `-Werror`.
+
+**GCC 10 and Clang 10 pass the concepts probe** and compile and correctly run
+the ported kernel. This matters because it means the probe alone does not keep
+them out; the version filter in `cmake/PantrCompilerProbes.cmake` does. See the
+open question at the end.
+
+**No FMA is emitted.** The build sets `-ffp-contract=on` but no `-march`, so the
+target is baseline x86-64, which has no FMA instruction to fuse into. Verified
+by disassembly: no `vfmadd` in any object either preset produces, and the one
+`a*b+c` site compiles to `mulsd` + `addsd` on both compilers. Adding `-mfma`
+fuses that site and only that site. numba emits it unfused in both cases. So the
+two backends currently execute an identical sequence of IEEE-754 operations, and
+`tests/test_cpp_parity.py` asserts exactness rather than a tolerance, switching
+to the derived FMA bound when the extension reports `__fp_contract__ ==
+"available"`.
+
+**Speed, kernel against kernel, single-threaded** (minimum of 5 runs, ms):
+
+| degree | points | numba, 1 thread | C++ | ratio |
+|---:|---:|---:|---:|---:|
+| 1 | 10^6 | 4.04 | 2.78 | 1.45x |
+| 2 | 10^6 | 7.94 | 5.93 | 1.34x |
+| 3 | 10^6 | 13.29 | 10.22 | 1.30x |
+| 5 | 10^6 | 23.22 | 23.62 | 0.98x |
+| 8 | 10^6 | 49.62 | 52.49 | 0.95x |
+
+So the port is somewhat faster at low degree and level at high degree. That is
+the honest headline, and it is a modest one: both compilers are generating
+reasonable code for the same recurrence, and there is no free factor of ten
+waiting in a straight transliteration.
+
+At the *entry point* the picture differs at small sizes, and not because of the
+kernel: the numba cardinal B-spline kernel is `parallel=True` unconditionally
+and has no serial twin, so it pays a fork/join even for 100 points. The C++
+backend is 4x to 7x faster there and 0.2x as fast at 10^6 points, where numba's
+20 threads do what 20 threads do.
+
+**One defect this measurement found.** `nanobind_add_module()` appends `-Os`
+after the build type's `-O3`, and the last optimisation flag wins, so the kernel
+was being compiled for size inside the extension while the standalone benchmark
+compiled it for speed. Same source, 31.4 ms against 10.3 ms at degree 3. Fixed
+with `NOMINSIZE` in `cpp/bindings/CMakeLists.txt`, where the numbers are
+recorded. Without the fix the prototype reported the port as 3x slower than
+numba instead of 1.3x faster, which is the opposite conclusion.
+
+## What it deliberately does not do
+
+- **No second module.** One kernel per PR.
+- **No `-march`, no SIMD, no ISA variants.** `design/simd.md` makes that stage 2
+  and gates it on first measuring the baseline gap against `-march=x86-64-v3`.
+  **That measurement is now taken**, at `-O3` on the standalone kernel, 10^6
+  points, minimum of repeats:
+
+  | target | degree 3 | degree 8 | `vfmadd` sites |
+  |---|---:|---:|---:|
+  | baseline x86-64 | 10.47 ms | 50.73 ms | 0 |
+  | `-march=x86-64-v3` | 8.69 ms | 40.04 ms | 1 |
+  | `-march=native` (AVX-512) | 9.20 ms | 43.69 ms | 1 |
+
+  So the gap is real but modest, 1.20x to 1.27x, and it is a decision for
+  whoever opens stage 2 rather than a free win. Two things in that table are
+  worth more than the ratios. The ISA introduces **exactly one** fused site,
+  which is the one the parity bound is derived around. And **`-march=native` is
+  slower than `-march=x86-64-v3`** on this machine, whose AVX-512 the wider
+  target enables: `design/simd.md` lists "AVX-512 can be slower" as a hazard
+  stated from knowledge and not measured, and this measures it on one of pantr's
+  own kernels.
+- **No threading on the C++ side.** A single-threaded kernel is what makes the
+  comparison above readable, and the threading model is constrained by decisions
+  in `design/user_functions_across_the_boundary.md` that this PR does not spend.
+- **No MPI, no CUDA, no AD type.** `scalar.hpp` keeps the door open for a
+  forward-mode `Dual`; nothing instantiates one except `cpp/tests/test_scalar_generic.cpp`.
+- **No wheel strategy.** The stable ABI is deliberately off; split mode is
+  probed by `scripts/ci_local.sh` and not adopted.
+
+## The open question this prototype raises
+
+The version filter rejects Clang below 14, inherited from
+`design/toolchain_requirements.md` where it is recorded as a guess. Measured
+here, Clang 10 and GCC 10 both pass the concepts probe *and* compile and
+correctly run the kernel. That note's own rule is that the filter "should only
+grow from observed failures, never from speculation", and there is no observed
+failure behind this entry. One kernel is weak evidence about a whole library, so
+the filter has not been removed; but it is now known to be untested rather than
+merely unverified, and the note should say so.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -160,3 +160,9 @@ was refused outright, and that nobody had measured in either direction.
 AppleClang stays exempt: its version numbers do not map to LLVM versions, so any threshold
 applied to it is a row that lies. `-DPANTR_ALLOW_UNTESTED_COMPILER=ON` still opens the gate
 for anyone who knows better, and the floor should rise only from an observed failure.
+
+`scripts/ci_local.sh` builds and tests with both floor compilers on every run, so the table
+above is re-established rather than remembered. **The GitHub workflow does not**: it runs
+GCC 14 and Clang 18, and `ubuntu-24.04` does not package GCC 10. So the floor is guaranteed
+by one machine, and that is a deliberate trade rather than an oversight -- covering it in CI
+needs an older runner image or a container, which is more than this prototype should carry.

--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(bench_cardinal_bspline bench_cardinal_bspline.cpp)
+target_link_libraries(bench_cardinal_bspline PRIVATE pantr::core)

--- a/cpp/benchmark/bench_cardinal_bspline.cpp
+++ b/cpp/benchmark/bench_cardinal_bspline.cpp
@@ -1,0 +1,90 @@
+/// \file
+/// Single-threaded throughput of the Cox-de Boor tabulation.
+///
+/// The number this produces is the kernel alone: no binding, no numpy, no
+/// allocation inside the timed region. The user-facing comparison against the
+/// numba backend lives in scripts/bench_parity.py, which times both through the
+/// same Python entry point and so includes the overhead a caller actually pays.
+/// Both are reported, because either alone is misleading -- the C++ kernel looks
+/// better than it is without the binding, and worse than it is with it.
+///
+/// **This kernel is single-threaded and the numba one is not.** The numba
+/// tabulation runs a `prange` over points above `_PARALLEL_MIN_NUM_PTS` and a
+/// serial twin below it. Comparing a serial C++ kernel against a 20-thread numba
+/// kernel would measure the thread pool, not the port. scripts/bench_parity.py
+/// therefore reports against both numba variants, and the serial one is the
+/// like-for-like figure.
+///
+/// Threading the C++ side is deliberately not in this prototype: it is a design
+/// decision (design/user_functions_across_the_boundary.md fixes the rule that a
+/// callback is invoked from one thread only, which constrains the pool) and
+/// spending it here would buy a nicer number in exchange for a commitment
+/// nothing yet requires.
+
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <span>
+#include <vector>
+
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+/// A deterministic, reproducible spread of points over [0, 1]. Not random: a
+/// benchmark whose input changes between runs cannot be compared with an earlier
+/// run, and the kernel is branch-free in the point value anyway, so nothing is
+/// gained by randomising it.
+std::vector<double> make_points(std::size_t n) {
+    std::vector<double> pts(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        pts[i] = static_cast<double>(i) / static_cast<double>(n - 1);
+    }
+    return pts;
+}
+
+double run(int degree, std::size_t num_pts, int repeats) {
+    const auto pts = make_points(num_pts);
+    const auto stride = static_cast<std::size_t>(degree + 1);
+    std::vector<double> out(num_pts * stride, 0.0);
+    const pantr::span2d<double> view(out.data(), num_pts, stride);
+
+    // Warm the caches and the branch predictor, so the first timed repeat is not
+    // measuring a cold page fault on `out`.
+    pantr::tabulate_cardinal_bspline_1d<double>(degree, std::span<const double>(pts), view);
+
+    const auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < repeats; ++i) {
+        pantr::tabulate_cardinal_bspline_1d<double>(degree, std::span<const double>(pts), view);
+    }
+    const auto stop = std::chrono::steady_clock::now();
+
+    // Consume the result so the optimiser cannot delete the loop.
+    double checksum = 0.0;
+    for (const double v : out) {
+        checksum += v;
+    }
+    if (checksum < 0.0) {
+        std::fprintf(stderr, "impossible checksum %g\n", checksum);
+    }
+
+    const auto elapsed = std::chrono::duration<double>(stop - start).count();
+    return elapsed / repeats;
+}
+
+}  // namespace
+
+int main() {
+    std::printf("%8s %12s %14s %14s\n", "degree", "points", "seconds", "Mpoint/s");
+    for (const int degree : {1, 2, 3, 5, 8}) {
+        for (const std::size_t num_pts : {std::size_t{1024}, std::size_t{65536},
+                                          std::size_t{1048576}}) {
+            const int repeats = num_pts >= 1048576 ? 20 : 200;
+            const double seconds = run(degree, num_pts, repeats);
+            std::printf("%8d %12zu %14.6e %14.2f\n", degree, num_pts, seconds,
+                        static_cast<double>(num_pts) / seconds / 1e6);
+        }
+    }
+    return 0;
+}

--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -1,0 +1,151 @@
+# The nanobind extension module.
+#
+# nanobind is located through the interpreter rather than through a system
+# package, because the version that matters is the one in the environment doing
+# the build -- which under scikit-build-core is the isolated build environment,
+# not the developer's shell.
+
+find_package(Python 3.11 REQUIRED COMPONENTS Interpreter Development.Module)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE nanobind_ROOT
+    RESULT_VARIABLE _nanobind_probe)
+
+if(NOT _nanobind_probe EQUAL 0)
+  message(FATAL_ERROR
+      "nanobind was not importable by ${Python_EXECUTABLE}.\n"
+      "  Fix: pip install nanobind")
+endif()
+
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import nanobind; print(nanobind.__version__)"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE PANTR_NANOBIND_VERSION)
+message(STATUS "pantr: nanobind ${PANTR_NANOBIND_VERSION}")
+
+# Deliberately NOT built with STABLE_ABI.
+#
+# The stable ABI buys one wheel per platform instead of one per Python version,
+# at the cost of routing every call through the limited API's slower dispatch.
+# This prototype's whole purpose includes measuring how fast the C++ kernel is
+# against numba, and a measurement taken through the stable-ABI dispatcher would
+# understate it while telling nobody which part of the gap was the port and which
+# was the packaging.
+#
+# The wheel strategy is a separate decision and is not this PR's to make.
+# design/_memory/nanobind-status.md records that nanobind's split mode supersedes
+# the stable-ABI approach on both axes that mattered, and that it was still
+# unreleased (3.0.0.dev2, nanobind-backend 1.0.0.dev2) when this was written.
+# scripts/ci_local.sh exercises split mode against the dev release so the answer
+# is measured rather than assumed.
+# NOMINSIZE is load-bearing, and its absence cost this prototype its headline
+# measurement once already.
+#
+# nanobind_add_module() optimises for SIZE by default: it appends `-Os
+# -ffunction-sections -fdata-sections` AFTER the build type's `-O3`, and the
+# last optimisation flag on the command line is the one that takes effect. That
+# is the right default for nanobind -- a binding module is mostly dispatch glue,
+# where size is what costs -- and the wrong one here, because the numerical
+# kernel is compiled into this same translation unit and silently inherits it.
+#
+# Measured on this machine, cardinal B-spline tabulation, degree 3, 10^6 points,
+# GCC 14.4.0, against the numba kernel on one thread:
+#
+#     -Os (nanobind's default)   31.4 ms   0.44x
+#     -O3 (NOMINSIZE)            10.3 ms   1.33x
+#
+# So this one word decides whether the prototype reports the port as three times
+# slower than numba or a third faster, on identical source. The standalone
+# benchmark in cpp/benchmark/ never saw it, because it is a plain executable and
+# nanobind's CMake never touches it -- which is exactly how the discrepancy was
+# noticed, and an argument for keeping both benchmarks rather than one.
+#
+# The cost is a larger extension. That is the trade nanobind's default declines
+# to make on your behalf, and it is obviously the right way round once a kernel
+# lives in the module.
+#
+# NOSTRIP is the same argument applied to the symbol table.
+#
+# nanobind_add_module() strips the module by default, which is right for a binding
+# that is only ever imported and wrong for one whose stated purpose is to be
+# MEASURED. Verified on the shipped build before this was added: `nm` on the
+# installed .so reported "no symbols", so `perf` could attribute time to the module
+# but not to any function inside it, and a segfault produced a backtrace with
+# nothing in it but an address. Both are exactly what this prototype exists to
+# look at, and the second one was needed while these bindings were being fixed.
+#
+# The cost is disk and nothing else: a symbol table does not change the code that
+# is generated, so no measurement is affected by its presence.
+#
+# ---------------------------------------------------------------------------
+# PANTR_NANOBIND_SPLIT: the wheel-strategy probe, off by default
+# ---------------------------------------------------------------------------
+#
+# Split mode (nanobind 3) replaces the stable-ABI approach: the extension splits
+# into a frontend targeting the Python 3.10 stable ABI, one wheel per platform
+# covering every version, plus a small version-specific backend installed from
+# PyPI. design/_memory/nanobind-status.md records why that is better on both
+# axes that mattered, and that its composition with a multi-ISA build is
+# UNVERIFIED and must be tested by this skeleton.
+#
+# It is an option rather than the default because nanobind 3 is a pre-release
+# and because it makes `nanobind-backend` a RUNTIME dependency of the wheel,
+# which is a packaging decision this PR does not get to make. scripts/ci_local.sh
+# turns it on against the dev release so the answer is measured.
+#
+# NB_STATIC and split mode are mutually exclusive: NB_STATIC links libnanobind
+# into the extension, which is precisely what split mode moves out of it.
+option(PANTR_NANOBIND_SPLIT "Build the extension in nanobind split mode (needs nanobind 3)" OFF)
+
+if(PANTR_NANOBIND_SPLIT)
+  if(PANTR_NANOBIND_VERSION VERSION_LESS 3)
+    message(FATAL_ERROR
+        "PANTR_NANOBIND_SPLIT needs nanobind 3 or newer; found ${PANTR_NANOBIND_VERSION}.\n"
+        "  Fix: pip install --pre 'nanobind>=3.0.0.dev0'")
+  endif()
+  # NB_SUPPRESS_WARNINGS is required here and has no equivalent below.
+  #
+  # In split mode nanobind adds its own include directory straight onto the
+  # extension target, and marks it SYSTEM only when this option is passed. The
+  # foreach further down cannot help: it retags the include directories of
+  # `nanobind-static`, and split mode creates no such target -- the whole point
+  # is that libnanobind is not linked in. Measured with nanobind 3.0.0.dev2 and
+  # GCC 14: without this, `nb_attr.h:78: using arg = arg_t<>` trips -Wshadow and
+  # -Werror ends the build.
+  nanobind_add_module(_pantr_cpp NOMINSIZE NOSTRIP NB_SUPPRESS_WARNINGS
+                      BACKEND_MODULE nanobind_backend pantr_cpp.cpp)
+else()
+  nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP pantr_cpp.cpp)
+endif()
+
+# nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14
+# raises `declaration of 'value' shadows a member` in nb_types.h, nb_attr.h and
+# several others), and pantr builds with -Werror. Marking them SYSTEM is the same
+# decision cmake/PantrDependencies.cmake takes for the fetched dependencies: a
+# third party's warning discipline must not decide whether pantr builds.
+#
+# It has to be done by hand here, and the reason is worth recording because the
+# asymmetry is not obvious. CMake treats an IMPORTED target's interface includes
+# as system by default, but `nanobind-static` is BUILT by nanobind_add_module
+# rather than imported, so its includes arrive as -I. Re-adding them as -isystem
+# on the consuming target does not work either: GCC drops an -isystem path that
+# already appeared as -I. The property has to move on the producing target.
+foreach(_nb_target IN ITEMS nanobind-static nanobind-static-abi3 nanobind)
+  if(TARGET ${_nb_target})
+    get_target_property(_nb_includes ${_nb_target} INTERFACE_INCLUDE_DIRECTORIES)
+    if(_nb_includes)
+      set_target_properties(${_nb_target} PROPERTIES
+          INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_nb_includes}")
+    endif()
+  endif()
+endforeach()
+
+target_link_libraries(_pantr_cpp PRIVATE pantr::core)
+
+# scikit-build-core installs whatever lands in the install tree. The extension
+# belongs next to the pure-Python package so `pantr._pantr_cpp` resolves.
+install(TARGETS _pantr_cpp LIBRARY DESTINATION pantr)

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -1,0 +1,187 @@
+/// \file
+/// nanobind bindings for the pantr C++ prototype.
+///
+/// ## No docstrings here
+///
+/// Every user-visible docstring lives in `src/pantr/_backend.py`, not in a
+/// string literal in this file, and that is deliberate. A docstring written in
+/// C++ is invisible to ruff's pydocstyle rules, to the doctest runner, and to the
+/// docs build, so the project's documentation conventions -- which CLAUDE.md
+/// states in full and enforces in CI -- would silently stop applying to exactly
+/// the functions a user calls. The thin Python layer owns the contract; this file
+/// owns the call.
+///
+/// ## What the nanobind version question looks like from here
+///
+/// design/_memory/nanobind-status.md lists the API changes in nanobind 3 that
+/// touch decisions already taken: `NB_TRAMPOLINE` losing its `Size` argument,
+/// return-value policies and argument annotations becoming compile-time tags,
+/// and `nb::gil_scoped_acquire` gaining an `is_valid()` that the callback and
+/// plugin seams must consult.
+///
+/// **None of the three has a site in this file**, and saying so is more useful
+/// than pretending otherwise: there is no trampoline because nothing here is a
+/// virtual class, no return-value policy because both functions return `void`,
+/// and no `gil_scoped_acquire` because nothing calls back into Python.
+///
+/// The annotations are the one that needs care, because the conclusion is right
+/// and the obvious reason for it is wrong. `nb::arg` is *not* a compile-time tag
+/// under both: it becomes one in 3.x. Read from the two headers --
+///
+///   2.14.0  `struct arg` is a plain runtime struct. `noconvert()` clears a
+///           `uint8_t convert_` member ON the object and returns `arg&`.
+///   3.0.0   `using arg = arg_t<Flags, Locked>`, and `noconvert()` is
+///           `constexpr` and returns a DIFFERENT TYPE,
+///           `arg_t<Flags & ~convert, Locked>`. The flag moved out of the value
+///           and into the type.
+///
+/// What makes this file portable is therefore not that the two are the same kind
+/// of object, but that the SPELLING `nb::arg("out").noconvert()` is valid in
+/// both and yields something `m.def` accepts in both.
+///
+/// So this file compiles unchanged against 2.15.0 and 3.0.0.dev2, and the
+/// version choice is decided by what is stable rather than by what the source
+/// needs. scripts/ci_local.sh builds it against both.
+///
+/// The GIL *is* released around the kernel, which is the one threading-adjacent
+/// decision this file does make: the kernel touches no Python object, so holding
+/// the GIL through it would serialise any caller that threads at the Python
+/// level for no reason.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// The array shapes the kernel accepts, expressed in the type system.
+///
+/// nanobind checks dtype, rank, C-contiguity and device before the function body
+/// runs and raises a `TypeError` otherwise, so these aliases *are* the input
+/// validation for everything they can express. What they cannot express is a
+/// relation BETWEEN two arguments -- `out.shape(0) == points.size()` and
+/// `out.shape(1) == degree + 1` -- and that is checked in the function body
+/// below.
+template <class T>
+using const_points = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// Tabulate into `out`, after checking what the kernel assumes and never checks.
+///
+/// **This function is Layer 2's C++ half**, and the checks below belong here for
+/// the reason CLAUDE.md gives: a Layer 3 kernel validates nothing, so every
+/// guarantee it relies on is established by its caller. `pantr._backend` is the
+/// Python half of the same layer, but it is not the only caller -- the extension
+/// is importable, and `pantr._pantr_cpp.tabulate_cardinal_bspline_1d` is a public
+/// attribute of a public module. Measured before these checks existed, one line
+/// of Python reached undefined behaviour twice over: a negative `degree` became
+/// `SIZE_MAX` at `static_cast<std::size_t>(degree)` and exited with SIGSEGV, and
+/// an `out` too small for the degree overran the allocation and corrupted the
+/// heap. Neither raised anything a caller could catch.
+///
+/// `degree` is `unsigned` rather than `int` so that the negative case never
+/// reaches this body at all: nanobind's own caster rejects it, raising a
+/// `TypeError` before any of pantr's code runs. The kernel's parameter stays
+/// `int` -- it is a discrete-structure parameter, and design/automatic
+/// _differentiation.md's fourth discipline keeps those as plain integers -- so
+/// the one range that `unsigned` admits and `int` does not is refused explicitly
+/// rather than wrapped around by the cast.
+///
+/// The cost is three integer comparisons in front of an
+/// `O(points.size() * degree^2)` kernel.
+template <class T>
+void tabulate(unsigned degree, const_points<T> points, out_matrix<T> out) {
+    constexpr unsigned max_degree = static_cast<unsigned>(std::numeric_limits<int>::max());
+    if (degree > max_degree) {
+        throw nb::value_error(("degree " + std::to_string(degree) +
+                               " exceeds the largest degree the kernel can express (" +
+                               std::to_string(max_degree) + ")")
+                                  .c_str());
+    }
+
+    const std::size_t num_pts = points.size();
+    const std::size_t num_basis = static_cast<std::size_t>(degree) + 1;
+    if (out.shape(0) != num_pts || out.shape(1) != num_basis) {
+        throw nb::value_error(("out has shape (" + std::to_string(out.shape(0)) + ", " +
+                               std::to_string(out.shape(1)) + "), but degree " +
+                               std::to_string(degree) + " at " + std::to_string(num_pts) +
+                               " points needs (" + std::to_string(num_pts) + ", " +
+                               std::to_string(num_basis) + ")")
+                                  .c_str());
+    }
+
+    const std::span<const T> pts(points.data(), num_pts);
+    const pantr::span2d<T> view(out.data(), num_pts, num_basis);
+
+    // The kernel touches no Python object, so the GIL buys nothing while it
+    // runs. Releasing it is what lets a caller thread at the Python level.
+    const nb::gil_scoped_release release;
+    pantr::tabulate_cardinal_bspline_1d<T>(static_cast<int>(degree), pts, view);
+}
+
+}  // namespace
+
+NB_MODULE(_pantr_cpp, m) {
+    m.attr("__doc__") = nb::none();  // the docstring lives in pantr._backend
+
+    // `.noconvert()` on `out` is a correctness requirement, not a tuning knob.
+    //
+    // An `nb::ndarray<T, c_contig>` parameter does NOT reject an argument that
+    // fails the constraint: nanobind satisfies the constraint by CONVERTING it
+    // into a contiguous temporary. For an input that is merely wasteful. For an
+    // output it is silently wrong -- the kernel fills the temporary, the
+    // temporary is discarded, and the caller's array comes back untouched.
+    //
+    // Measured before the fix: with PANTR_BACKEND=cpp,
+    // `tabulate_cardinal_bspline_1d(2, pts, out=non_contiguous)` returned all
+    // zeros while the numba backend returned the right answer, with no error
+    // anywhere. An out-parameter that quietly does nothing is the worst failure
+    // shape available: no exception, no warning, a plausible-looking array of
+    // the right shape and dtype.
+    //
+    // `points` gets it too. There a conversion is correct, so the argument is
+    // weaker -- but this prototype exists to measure, and a silent copy of a
+    // 10^6-element array inside the timed region would be attributed to the
+    // kernel. Better to refuse and make the caller fix the layout.
+    m.def("tabulate_cardinal_bspline_1d", &tabulate<double>, nb::arg("degree"),
+          nb::arg("points").noconvert(), nb::arg("out").noconvert());
+    m.def("tabulate_cardinal_bspline_1d", &tabulate<float>, nb::arg("degree"),
+          nb::arg("points").noconvert(), nb::arg("out").noconvert());
+
+    // Build provenance, so a measurement can name the binary that produced it
+    // rather than the source tree it was built from. `fp_contract` is the one
+    // that matters for the parity bound: see tests/test_cpp_parity.py.
+    m.attr("__compiler__") =
+#if defined(__clang__)
+        "clang " __clang_version__;
+#elif defined(__GNUC__)
+        "gcc " __VERSION__;
+#else
+        "unknown";
+#endif
+
+    m.attr("__has_std_mdspan__") =
+#if defined(PANTR_HAS_STD_MDSPAN)
+        true;
+#else
+        false;
+#endif
+
+    m.attr("__fp_contract__") =
+#if defined(__FP_FAST_FMA)
+        "available";
+#else
+        "unavailable-on-target-isa";
+#endif
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -3,8 +3,9 @@
 ///
 /// ## No docstrings here
 ///
-/// Every user-visible docstring lives in `src/pantr/_backend.py`, not in a
-/// string literal in this file, and that is deliberate. A docstring written in
+/// Every user-visible docstring lives in the Python layer -- for this kernel,
+/// `src/pantr/basis/` -- and not in a string literal in this file, and that is
+/// deliberate. A docstring written in
 /// C++ is invisible to ruff's pydocstyle rules, to the doctest runner, and to the
 /// docs build, so the project's documentation conventions -- which CLAUDE.md
 /// states in full and enforces in CI -- would silently stop applying to exactly
@@ -81,8 +82,9 @@ using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
 ///
 /// **This function is Layer 2's C++ half**, and the checks below belong here for
 /// the reason CLAUDE.md gives: a Layer 3 kernel validates nothing, so every
-/// guarantee it relies on is established by its caller. `pantr._backend` is the
-/// Python half of the same layer, but it is not the only caller -- the extension
+/// guarantee it relies on is established by its caller. The adapter in
+/// `pantr.basis._basis_backend` is the Python half of the same layer, but it is
+/// not the only caller -- the extension
 /// is importable, and `pantr._pantr_cpp.tabulate_cardinal_bspline_1d` is a public
 /// attribute of a public module. Measured before these checks existed, one line
 /// of Python reached undefined behaviour twice over: a negative `degree` became
@@ -133,7 +135,7 @@ void tabulate(unsigned degree, const_points<T> points, out_matrix<T> out) {
 }  // namespace
 
 NB_MODULE(_pantr_cpp, m) {
-    m.attr("__doc__") = nb::none();  // the docstring lives in pantr._backend
+    m.attr("__doc__") = nb::none();  // the docstrings live in the Python layer
 
     // `.noconvert()` on `out` is a correctness requirement, not a tuning knob.
     //

--- a/cpp/include/pantr/basis/cardinal_bspline.hpp
+++ b/cpp/include/pantr/basis/cardinal_bspline.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+/// \file
+/// Cox-de Boor tabulation of the cardinal B-spline basis on the central span.
+///
+/// Port of `_tabulate_cardinal_Bspline_basis_1D_core` in
+/// `src/pantr/basis/_basis_core.py`, which stays as the parity oracle. The
+/// recurrence is unchanged; what is new is that the accumulation type is stated
+/// rather than inherited from a promotion rule (see below).
+///
+/// ## Why this kernel and not another
+///
+/// It is the whole of the C++ in this prototype, chosen so the infrastructure is
+/// exercised without numerical risk riding along:
+///
+///   - no linear solve and no BLAS, so nothing here depends on which LAPACK the
+///     machine links against;
+///   - no transcendental, so no libm difference between platforms;
+///   - no domain limit on the kernel -- the degree ceilings in
+///     `pantr.change_basis` belong to the builders that solve a Gram system, not
+///     to this tabulation;
+///   - exactly one site of the form `a * b + c`, so the set of places the two
+///     backends could ever disagree is one, and it can be read off the source.
+///     Whether that site actually fuses is a property of the BUILD, not of the
+///     kernel: see below.
+///
+/// ## The recurrence, and why its error analysis is easy
+///
+/// For `u` in `[0, 1]` and the central span of a uniform knot vector with unit
+/// spacing, `term = (r + 1 - u) / k` lies in `[0, 1]`, so `term` and `1 - term`
+/// are both non-negative and each stage forms a *convex combination* of the
+/// previous stage's values. Nothing here can cancel.
+///
+/// That is what makes the parity bound derivable rather than fitted: a relative
+/// error bound on two non-negative summands is inherited by their sum, so
+/// relative errors propagate additively through the stages instead of being
+/// amplified. The bound itself is derived in tests/test_cpp_parity.py, next to
+/// the assertion that uses it.
+///
+/// ## Accumulation type: stated, not inherited
+///
+/// **Verified against numba 0.65.1**: the Python kernel's intermediates are
+/// float64 even when the arrays are float32. `1.0 - u` puts a Python float
+/// literal next to a `float32`, and numba's type unification promotes the
+/// result to `float64` -- `probe.nopython_signatures` reports
+/// `(float32,) -> UniTuple(float64 x 3)` for the expression in isolation. So
+/// `one_minus_u`, `inv_k`, `term` and the running `saved` are all float64 there,
+/// and only the stores into `out` round to float32.
+///
+/// That is the right arithmetic and the wrong reason: it is a consequence of
+/// literal typing, not a decision. design/large_data_fitting.md states the
+/// decision independently -- accumulate in float64 even when the data is
+/// float32, because the cost is a scalar accumulator and the alternative loses
+/// relative accuracy of order `sqrt(m) * eps32` on a length-`m` accumulation.
+///
+/// `pantr::accumulator_t` writes it down. A C++ kernel that computed a `float`
+/// instantiation entirely in `float` would be a faithful-looking port that
+/// silently disagrees with the oracle by far more than the FMA bound allows,
+/// and the disagreement would be read as a bug in the port.
+
+#include <cstddef>
+#include <span>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+/// The type intermediate quantities are accumulated in.
+///
+/// `double` for `float` storage, for the reason above; the scalar itself
+/// otherwise, so a differentiable type is not silently narrowed or widened.
+template <Real T>
+struct accumulator {
+    using type = T;
+};
+
+template <>
+struct accumulator<float> {
+    using type = double;
+};
+
+template <Real T>
+using accumulator_t = typename accumulator<T>::type;
+
+/// Tabulate the cardinal B-spline basis of `degree` at every point of `points`.
+///
+/// Evaluates the `degree + 1` basis functions active over the central unit span
+/// `[0, 1]` of a uniform knot vector with unit spacing, using the Cox-de Boor
+/// recurrence specialised to span index 0.
+///
+/// \param degree Degree of the basis. Must be non-negative.
+/// \param points Evaluation points. Values outside `[0, 1]` are evaluated by the
+///        same recurrence rather than clamped, matching the Python kernel.
+/// \param out Output view of shape `(points.size(), degree + 1)`, written in
+///        full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel in the
+///       layering of CLAUDE.md, and every guarantee it relies on is established
+///       by its Layer 2 caller. Two of them are load-bearing for memory safety
+///       rather than merely for the answer: `degree >= 0`, because it is widened
+///       to `std::size_t` below and a negative value becomes a loop bound of
+///       `SIZE_MAX`; and `out` having exactly `points.size()` rows and
+///       `degree + 1` columns, because nothing here bounds-checks a write. Both
+///       are checked by `tabulate` in cpp/bindings/pantr_cpp.cpp, which is the
+///       Layer 2 caller on the Python side; a C++ caller establishes them
+///       itself. Non-finite points are NOT a precondition -- they propagate into
+///       non-finite outputs, which is an answer rather than undefined behaviour.
+///       For general use call `pantr.basis.tabulate_cardinal_bspline_1d`.
+template <Real T>
+void tabulate_cardinal_bspline_1d(int degree, std::span<const T> points, span2d<T> out) {
+    using Acc = accumulator_t<T>;
+
+    const std::size_t num_pts = points.size();
+
+    if (degree == 0) {
+        // The basis is the single constant function.
+        for (std::size_t j = 0; j < num_pts; ++j) {
+            at(out, j, 0) = T(1);
+        }
+        return;
+    }
+
+    const auto n = static_cast<std::size_t>(degree);
+
+    for (std::size_t j = 0; j < num_pts; ++j) {
+        at(out, j, 0) = T(1);
+
+        const Acc u = static_cast<Acc>(points[j]);
+        const Acc one_minus_u = Acc(1) - u;
+
+        for (std::size_t k = 1; k <= n; ++k) {
+            const Acc inv_k = Acc(1) / Acc(static_cast<double>(k));
+            Acc saved = Acc(0);
+
+            for (std::size_t r = 0; r < k; ++r) {
+                const Acc nr_old = static_cast<Acc>(at(out, j, r));
+                const Acc term = (Acc(static_cast<double>(r)) + one_minus_u) * inv_k;
+
+                // The only `a * b + c` in the kernel, and so the only site where
+                // the two backends can disagree at all.
+                //
+                // Whether it FUSES is decided by the build, not by this line, and
+                // both answers are measured rather than assumed:
+                //
+                //   as shipped   no -march is set (see cmake/PantrCompileOptions
+                //                .cmake for why that is deliberate), so the target
+                //                is baseline x86-64, which has no FMA instruction.
+                //                -ffp-contract=on cannot fuse what the ISA cannot
+                //                execute. Verified: `objdump -d` over every object
+                //                either preset produces contains no vfmadd, and
+                //                this line compiles to mulsd + addsd on GCC 14 and
+                //                on Clang 18 alike.
+                //   with -mfma   it fuses, and ONLY here -- neither
+                //                `nr_old * (1 - term)` below nor `term` above is
+                //                in a*b+c form, so neither can.
+                //
+                // numba emits it unfused in both cases (verified in its LLVM IR:
+                // fmul then fadd, never fmuladd). So parity is bit-exact on the
+                // shipped build and becomes a one-rounding-per-stage question the
+                // day design/simd.md's stage 2 turns the ISA ladder on.
+                // tests/test_cpp_parity.py selects between the two by reading
+                // `pantr._pantr_cpp.__fp_contract__`, and derives the bound for
+                // the second.
+                at(out, j, r) = static_cast<T>(saved + nr_old * term);
+
+                saved = nr_old * (Acc(1) - term);
+            }
+
+            at(out, j, k) = static_cast<T>(saved);
+        }
+    }
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/basis/cardinal_bspline.hpp
+++ b/cpp/include/pantr/basis/cardinal_bspline.hpp
@@ -48,15 +48,16 @@
 /// and only the stores into `out` round to float32.
 ///
 /// That is the right arithmetic and the wrong reason: it is a consequence of
-/// literal typing, not a decision. design/large_data_fitting.md states the
-/// decision independently -- accumulate in float64 even when the data is
-/// float32, because the cost is a scalar accumulator and the alternative loses
-/// relative accuracy of order `sqrt(m) * eps32` on a length-`m` accumulation.
+/// literal typing, not a decision. `pantr::accumulator_t`
+/// (cpp/include/pantr/core/scalar.hpp) writes the decision down, as a
+/// project-wide policy rather than as a property of this kernel.
 ///
-/// `pantr::accumulator_t` writes it down. A C++ kernel that computed a `float`
-/// instantiation entirely in `float` would be a faithful-looking port that
-/// silently disagrees with the oracle by far more than the FMA bound allows,
-/// and the disagreement would be read as a bug in the port.
+/// What justifies it HERE is parity, not accuracy. A `float` instantiation
+/// computed entirely in `float` would be a faithful-looking port that disagrees
+/// with the oracle by about one float32 ulp, and the disagreement would be read
+/// as a bug in the port. The accuracy argument of design/large_data_fitting.md
+/// is a different one and does not reach this kernel -- the trait's own
+/// documentation says why, and that note was amended in this branch to agree.
 
 #include <cstddef>
 #include <span>
@@ -65,23 +66,6 @@
 #include "pantr/core/scalar.hpp"
 
 namespace pantr {
-
-/// The type intermediate quantities are accumulated in.
-///
-/// `double` for `float` storage, for the reason above; the scalar itself
-/// otherwise, so a differentiable type is not silently narrowed or widened.
-template <Real T>
-struct accumulator {
-    using type = T;
-};
-
-template <>
-struct accumulator<float> {
-    using type = double;
-};
-
-template <Real T>
-using accumulator_t = typename accumulator<T>::type;
 
 /// Tabulate the cardinal B-spline basis of `degree` at every point of `points`.
 ///

--- a/cpp/include/pantr/core/mdspan.hpp
+++ b/cpp/include/pantr/core/mdspan.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/// \file
+/// The `<mdspan>` switch: the standard header where it exists, the Kokkos
+/// reference implementation where it does not.
+///
+/// design/toolchain_requirements.md classifies `<mdspan>` as a feature toggle
+/// rather than a hard gate, because a drop-in fallback exists and is
+/// maintained by the same people who wrote the proposal. `PANTR_HAS_STD_MDSPAN`
+/// is set by the configure-time probe in cmake/PantrCompilerProbes.cmake.
+///
+/// **On this project's toolchain the toggle resolves to Kokkos**, and the
+/// reason is an implementation gap rather than a language-mode restriction.
+/// Measured here: GCC 14.4.0's libstdc++ ships no `mdspan` header at all, and
+/// `__cpp_lib_mdspan` is undefined even under `-std=gnu++23` -- which is that
+/// macro's whole job, so its absence in C++23 mode settles that the library has
+/// not implemented P0009, rather than that a standard-version gate is hiding a
+/// header it does ship. Clang 18 here resolves to that same libstdc++ and not
+/// to libc++, so it inherits the absence for the same reason.
+///
+/// Worth stating precisely, because the plausible explanation is the wrong one:
+/// "it is a C++23 header and we build with -std=c++20" predicts that
+/// `-std=c++23` makes it appear, and measurably it does not. The standard
+/// branch below is kept because it is what the toggle is for once libstdc++
+/// implements it, and because it costs three lines.
+///
+/// ## The one API difference the switch has to absorb
+///
+/// C++23 `std::mdspan` indexes with the multidimensional subscript operator,
+/// `view[i, j]`, which is a C++23 *language* feature and so is not available
+/// under the C++20 baseline at all. Kokkos indexes with `view(i, j)` in C++20
+/// mode. Neither spelling works in both branches, so element access goes
+/// through `pantr::at` rather than through either operator directly.
+
+#include <cstddef>
+
+#if defined(PANTR_HAS_STD_MDSPAN)
+#  include <mdspan>
+#else
+#  include <experimental/mdspan>
+#endif
+
+namespace pantr {
+
+#if defined(PANTR_HAS_STD_MDSPAN)
+namespace md = std;
+#else
+namespace md = std::experimental;
+#endif
+
+/// A 2D view over contiguous, row-major storage: the shape every tabulation
+/// kernel writes into.
+template <class T>
+using span2d = md::mdspan<T, md::dextents<std::size_t, 2>, md::layout_right>;
+
+/// Element access, spelled once so the two branches of the switch stay source
+/// compatible. See the note above on why neither operator can be used directly.
+template <class View>
+[[nodiscard]] constexpr decltype(auto) at(const View& view, std::size_t i, std::size_t j) noexcept {
+#if defined(PANTR_HAS_STD_MDSPAN)
+    return view[i, j];
+#else
+    return view(i, j);
+#endif
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/core/mdspan.hpp
+++ b/cpp/include/pantr/core/mdspan.hpp
@@ -43,7 +43,10 @@
 /// fixed at rank 2 while `span_nd` had already been generalised.
 ///
 /// The Kokkos half of that claim is compiled and run at ranks 1, 2 and 3 by
-/// cpp/tests/test_dependency_smoke.cpp. The standard half is not, and cannot be
+/// cpp/tests/test_dependency_smoke.cpp, and separately with
+/// `MDSPAN_USE_BRACKET_OPERATOR` forced on and `MDSPAN_USE_PAREN_OPERATOR` forced
+/// off, which is the configuration the deleted `#if` existed for. The standard
+/// half is not, and cannot be
 /// on this toolchain -- no standard library here ships the header, which is why
 /// the toggle is OFF -- so it rests on the wording of C++23 [mdspan.mdspan]
 /// rather than on a build.
@@ -98,8 +101,9 @@ using span2d = span_nd<T, 2>;
 ///
 /// \param view The view to index.
 /// \param idx One index per dimension of `view`, outermost first. Supplying the
-///        wrong number of them is a compile error rather than an out-of-bounds
-///        access.
+///        wrong number was already a compile error before the `static_assert`,
+///        since every mdspan subscript overload is constrained on the rank; the
+///        assertion only replaces a page of template diagnostics with a sentence.
 /// \return The element, with the reference type the view's accessor yields.
 ///
 /// \note No bounds checking is performed, in either branch of the switch.

--- a/cpp/include/pantr/core/mdspan.hpp
+++ b/cpp/include/pantr/core/mdspan.hpp
@@ -26,12 +26,29 @@
 ///
 /// ## The one API difference the switch has to absorb
 ///
-/// C++23 `std::mdspan` indexes with the multidimensional subscript operator,
-/// `view[i, j]`, which is a C++23 *language* feature and so is not available
-/// under the C++20 baseline at all. Kokkos indexes with `view(i, j)` in C++20
-/// mode. Neither spelling works in both branches, so element access goes
-/// through `pantr::at` rather than through either operator directly.
+/// The two branches disagree on how a pack of indices is spelled. C++23
+/// `std::mdspan` uses the multidimensional subscript operator, `view[i, j]`,
+/// which is a C++23 *language* feature and does not parse under the C++20
+/// baseline at all; Kokkos falls back to `view(i, j)` there. So element access
+/// goes through `pantr::at` rather than through either operator directly.
+///
+/// What `at` uses is a third spelling that both branches accept: a single
+/// `std::array` of indices. C++23 specifies that overload, and Kokkos provides
+/// it UNCONDITIONALLY -- in `__p0009_bits/mdspan.hpp`, outside the
+/// `MDSPAN_USE_BRACKET_OPERATOR` guard that picks between the two spellings
+/// above. So one spelling serves both branches and `at` needs no preprocessor
+/// branch of its own. It carried one until this was checked against the Kokkos
+/// source, on the stated premise that no single spelling could work in both;
+/// that premise was false, and the branch it justified was also what kept `at`
+/// fixed at rank 2 while `span_nd` had already been generalised.
+///
+/// The Kokkos half of that claim is compiled and run at ranks 1, 2 and 3 by
+/// cpp/tests/test_dependency_smoke.cpp. The standard half is not, and cannot be
+/// on this toolchain -- no standard library here ships the header, which is why
+/// the toggle is OFF -- so it rests on the wording of C++23 [mdspan.mdspan]
+/// rather than on a build.
 
+#include <array>
 #include <cstddef>
 
 #if defined(PANTR_HAS_STD_MDSPAN)
@@ -77,14 +94,20 @@ template <class T>
 using span2d = span_nd<T, 2>;
 
 /// Element access, spelled once so the two branches of the switch stay source
-/// compatible. See the note above on why neither operator can be used directly.
-template <class View>
-[[nodiscard]] constexpr decltype(auto) at(const View& view, std::size_t i, std::size_t j) noexcept {
-#if defined(PANTR_HAS_STD_MDSPAN)
-    return view[i, j];
-#else
-    return view(i, j);
-#endif
+/// compatible, at whatever rank the view has.
+///
+/// \param view The view to index.
+/// \param idx One index per dimension of `view`, outermost first. Supplying the
+///        wrong number of them is a compile error rather than an out-of-bounds
+///        access.
+/// \return The element, with the reference type the view's accessor yields.
+///
+/// \note No bounds checking is performed, in either branch of the switch.
+template <class View, class... Idx>
+[[nodiscard]] constexpr decltype(auto) at(const View& view, Idx... idx) noexcept {
+    static_assert(sizeof...(Idx) == View::rank(), "index count must match the view's rank");
+    using I = typename View::index_type;
+    return view[std::array<I, sizeof...(Idx)>{static_cast<I>(idx)...}];
 }
 
 }  // namespace pantr

--- a/cpp/include/pantr/core/mdspan.hpp
+++ b/cpp/include/pantr/core/mdspan.hpp
@@ -48,10 +48,33 @@ namespace md = std;
 namespace md = std::experimental;
 #endif
 
+/// A view of `Rank` dimensions over contiguous, row-major storage.
+///
+/// Generic in the rank and fixed in the layout, and the asymmetry is deliberate.
+/// The rank is already known to vary: design/bezier_extraction_api.md specifies
+/// an mdspan of shape `(n_el, (p+1)^d, rank)` for the extraction sweep, which is
+/// rank 3. Naming the rank now costs one line and changes no call site; naming it
+/// after five kernels have copied a rank-2 signature costs five signatures.
+///
+/// The layout stays `layout_right` because the decision that would generalise it
+/// has not been taken. design/large_data_fitting.md wants the per-direction
+/// kernel to read strided input directly rather than materialise a contiguous
+/// transpose, but it offers ping-pong buffers as the alternative and does not
+/// settle between them. Templating the kernel on the layout costs readability
+/// today and would spend that decision early, so it waits for the kernel that
+/// actually needs a stride.
+///
+/// One consequence is visible now and is the price of waiting: a non-contiguous
+/// `out` cannot be described by this alias, so `pantr._backend` computes into a
+/// contiguous buffer and copies back, where the numba kernel fills the caller's
+/// array in place.
+template <class T, std::size_t Rank>
+using span_nd = md::mdspan<T, md::dextents<std::size_t, Rank>, md::layout_right>;
+
 /// A 2D view over contiguous, row-major storage: the shape every tabulation
 /// kernel writes into.
 template <class T>
-using span2d = md::mdspan<T, md::dextents<std::size_t, 2>, md::layout_right>;
+using span2d = span_nd<T, 2>;
 
 /// Element access, spelled once so the two branches of the switch stay source
 /// compatible. See the note above on why neither operator can be used directly.

--- a/cpp/include/pantr/core/mdspan.hpp
+++ b/cpp/include/pantr/core/mdspan.hpp
@@ -82,9 +82,9 @@ namespace md = std::experimental;
 /// actually needs a stride.
 ///
 /// One consequence is visible now and is the price of waiting: a non-contiguous
-/// `out` cannot be described by this alias, so `pantr._backend` computes into a
-/// contiguous buffer and copies back, where the numba kernel fills the caller's
-/// array in place.
+/// `out` cannot be described by this alias, so the Python adapter in
+/// `pantr.basis._basis_backend` computes into a contiguous buffer and copies
+/// back, where the numba kernel fills the caller's array in place.
 template <class T, std::size_t Rank>
 using span_nd = md::mdspan<T, md::dextents<std::size_t, Rank>, md::layout_right>;
 

--- a/cpp/include/pantr/core/scalar.hpp
+++ b/cpp/include/pantr/core/scalar.hpp
@@ -114,13 +114,29 @@ using value_of_result_t = decltype(value_of(std::declval<const T&>()));
 /// and ordering are reached through `value_of` instead, and a scalar type is
 /// free not to provide them at all.
 ///
+/// `std::constructible_from<T, double>` is required because the kernels build
+/// constants: `T(1)` seeds the recurrence, and `Acc(0)`, `Acc(1)` and
+/// `Acc(static_cast<double>(k))` appear inside it. Without it the concept was a
+/// strict subset of what a kernel actually needs, so it certified types the
+/// kernel then rejected -- measured with a forward-mode `Dual` built by factory
+/// functions rather than by a numeric constructor, a common AD shape: it
+/// satisfied `Real` and then produced thirty lines of template error from inside
+/// a header its author did not write, which is precisely the failure concepts
+/// exist to prevent.
+///
+/// It does not weaken the Tier B discipline. An *explicit* constructor satisfies
+/// `constructible_from` without opening an implicit conversion, so
+/// `!std::convertible_to<Dual1, double>` and `!std::convertible_to<double,
+/// Dual1>` both still hold; cpp/tests/test_scalar_generic.cpp asserts all three.
+///
 /// Satisfied by `float` and `double`. A forward-mode `Dual<T, N>` satisfies it
-/// by supplying the five arithmetic operators and a `value_of` overload;
-/// cpp/tests/test_scalar_generic.cpp defines one and instantiates the kernel on
-/// it, which is what keeps the claim honest rather than aspirational.
+/// by supplying the five arithmetic operators, a `value_of` overload and a
+/// constructor from `double`; cpp/tests/test_scalar_generic.cpp defines one and
+/// instantiates the kernel on it, which is what keeps the claim honest rather
+/// than aspirational.
 template <class T>
 concept Real =
-    std::copyable<T> && detail::has_value_of<T> &&
+    std::copyable<T> && detail::has_value_of<T> && std::constructible_from<T, double> &&
     requires(T a, T b) {
         { -a } -> std::convertible_to<T>;
         { a + b } -> std::convertible_to<T>;

--- a/cpp/include/pantr/core/scalar.hpp
+++ b/cpp/include/pantr/core/scalar.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+/// \file
+/// The scalar concept the pantr core is generic over, and the Tier B access
+/// point every non-differentiable operation goes through.
+///
+/// ## Why the core is templated at all
+///
+/// Not for automatic differentiation. design/automatic_differentiation.md
+/// concludes that no flavour of the intended work requires AD inside the
+/// library: three of the four optimisation flavours are served by linearity plus
+/// an analytic rule, and the fourth has few enough parameters for hand-derived
+/// formulas. The justification is `float32`, which halves memory and doubles the
+/// SIMD lane count, and which the large-image fitting case needs on its own
+/// terms. AD compatibility rides along for free, because the discipline that
+/// admits a `Dual` type is the same discipline that admits `float`.
+///
+/// That ordering matters under pressure. If compile times become painful,
+/// `float32` support is kept and the AD discipline is what gets relaxed. The
+/// reverse would be the wrong trade.
+///
+/// ## The tiers
+///
+/// **Tier A** is generic in the scalar: arithmetic only, and every operation is
+/// meaningful for a differentiable type. Kernels live here.
+///
+/// **Tier B** is value-only: comparisons and branches, `floor`, casts to an
+/// integer index. These are not differentiable operations and they are not
+/// errors -- a knot-span search is genuinely a function of the *value* -- but
+/// they must be written so, by passing through `value_of`. A comparison applied
+/// to the scalar directly compiles for `double` and then either fails to compile
+/// or, worse, compares the wrong component for a `Dual`.
+///
+/// **Tier C** replaces differentiating an iteration with an analytic derivative
+/// rule. No Tier C code exists in this prototype; it is named here so the three
+/// are not confused.
+///
+/// ## The four disciplines
+///
+/// From design/automatic_differentiation.md, all four cheap up front and
+/// expensive to retrofit:
+///
+///  1. Comparisons and branches on the scalar go through `value_of`.
+///  2. No `std::floor` and no integer casts on the scalar.
+///  3. Unqualified calls with a using-declaration (`using std::sqrt; sqrt(x);`),
+///     never `std::sqrt(x)`, which hard-blocks any AD type by preventing ADL
+///     from finding the type's own overload. This prototype's one kernel is
+///     arithmetic-only and so has no site that exercises the rule; the guard in
+///     scripts/ci_local.sh enforces it for the day one appears.
+///  4. Parameters that change discrete structure are value-only. The degree is
+///     the example here: it decides how many basis functions exist, so it is an
+///     `int` and never a scalar.
+
+#include <concepts>
+#include <type_traits>
+
+namespace pantr {
+
+/// Tier B access: the floating-point value underlying a scalar.
+///
+/// This overload covers the built-in floating-point types, for which the value
+/// is the number itself. A differentiable type supplies its own overload in its
+/// own namespace, found by argument-dependent lookup through the two-step
+/// pattern below.
+///
+/// Every Tier B operation in the library is written as
+///
+/// ```cpp
+/// using pantr::value_of;          // makes this overload visible for double
+/// if (value_of(u) > value_of(u_max)) { ... }   // ADL finds a Dual's overload
+/// ```
+///
+/// rather than as `pantr::value_of(u)`, for the same reason `std::swap` is used
+/// that way: qualifying the call suppresses ADL and so silently excludes every
+/// user-supplied type.
+template <std::floating_point T>
+[[nodiscard]] constexpr T value_of(T x) noexcept {
+    return x;
+}
+
+namespace detail {
+
+using pantr::value_of;
+
+/// Satisfied when `value_of` is reachable for `T` and yields a floating-point
+/// value. Kept in a namespace that has the using-declaration in scope so the
+/// concept itself is checked through the same two-step lookup the library uses.
+template <class T>
+concept has_value_of = requires(const T& a) {
+    { value_of(a) } -> std::floating_point;
+};
+
+/// What the two-step lookup yields for `T`, as a type.
+///
+/// It exists so that `value_type_t` below can be written without naming
+/// `value_of` at its own point of use. Spelling it there as
+/// `detail::value_of(x)` is a QUALIFIED call, which suppresses ADL and so never
+/// finds a scalar's hidden-friend overload -- the exact mistake this file's
+/// header spends ten lines warning about, made in the one place the warning
+/// could not be read. The unqualified call has to happen *here*, inside the
+/// namespace that has the using-declaration in scope, exactly as
+/// `has_value_of` above does it.
+template <class T>
+using value_of_result_t = decltype(value_of(std::declval<const T&>()));
+
+}  // namespace detail
+
+/// The scalar type the Tier A core is generic over.
+///
+/// Deliberately *not* requiring `std::regular`, and the omission is the point:
+/// `std::regular` demands `operator==`, which would make
+/// `if (a == b)` compile on every conforming scalar and so make the Tier B
+/// discipline unenforceable at exactly the site it exists to protect. Equality
+/// and ordering are reached through `value_of` instead, and a scalar type is
+/// free not to provide them at all.
+///
+/// Satisfied by `float` and `double`. A forward-mode `Dual<T, N>` satisfies it
+/// by supplying the five arithmetic operators and a `value_of` overload;
+/// cpp/tests/test_scalar_generic.cpp defines one and instantiates the kernel on
+/// it, which is what keeps the claim honest rather than aspirational.
+template <class T>
+concept Real =
+    std::copyable<T> && detail::has_value_of<T> &&
+    requires(T a, T b) {
+        { -a } -> std::convertible_to<T>;
+        { a + b } -> std::convertible_to<T>;
+        { a - b } -> std::convertible_to<T>;
+        { a * b } -> std::convertible_to<T>;
+        { a / b } -> std::convertible_to<T>;
+    };
+
+/// The floating-point type underlying a `Real`: `double` for `double`, and the
+/// value component for a differentiable type.
+///
+/// `cpp/tests/test_scalar_generic.cpp` pins all three answers as static
+/// assertions, and it has to. An alias template is only checked where something
+/// instantiates it, and the case this one exists for -- a scalar reached only by
+/// ADL -- is exactly the case a `double`-only build never instantiates.
+template <Real T>
+using value_type_t = std::remove_cvref_t<detail::value_of_result_t<T>>;
+
+}  // namespace pantr

--- a/cpp/include/pantr/core/scalar.hpp
+++ b/cpp/include/pantr/core/scalar.hpp
@@ -177,8 +177,10 @@ using value_type_t = std::remove_cvref_t<detail::value_of_result_t<T>>;
 /// **For the tabulation kernels the reason is PARITY, not accuracy.** numba
 /// promotes float32 intermediates to float64 as a side effect of literal
 /// typing, so a port that computed in `float` throughout disagrees with the
-/// oracle by about one float32 ulp; cpp/include/pantr/basis/cardinal_bspline.hpp
-/// measures that. It is *not* the `sqrt(m) * eps32` argument of
+/// oracle by about one float32 ulp. cpp/include/pantr/basis/cardinal_bspline.hpp
+/// records the numba measurement that establishes the promotion, and
+/// `test_float32_intermediates_are_float64` in tests/test_cpp_parity.py is what
+/// checks the C++ side against it. It is *not* the `sqrt(m) * eps32` argument of
 /// design/large_data_fitting.md: that argument is about a length-`m`
 /// scalar accumulation, and a Cox-de Boor tabulation stores its state back into
 /// the output array at every stage, where the measured float32 error is flat in
@@ -190,9 +192,9 @@ using value_type_t = std::remove_cvref_t<detail::value_of_result_t<T>>;
 template <Real T>
 struct accumulator {
     static_assert(std::same_as<T, value_type_t<T>> || std::same_as<value_type_t<T>, double>,
-                  "a scalar carrying a value component narrower than double has to be "
-                  "widened by rebinding that component, which no scalar here supplies a "
-                  "hook for; specialise pantr::accumulator for it before using it");
+                  "a scalar whose value component is not itself double has to be widened "
+                  "by rebinding that component, which no scalar here supplies a hook for; "
+                  "specialise pantr::accumulator for it before using it");
 
     /// The accumulation type for `T`.
     using type = std::conditional_t<std::same_as<value_type_t<T>, float>, double, T>;

--- a/cpp/include/pantr/core/scalar.hpp
+++ b/cpp/include/pantr/core/scalar.hpp
@@ -155,4 +155,56 @@ concept Real =
 template <Real T>
 using value_type_t = std::remove_cvref_t<detail::value_of_result_t<T>>;
 
+/// The type intermediate quantities are accumulated in: `double` for `float`
+/// storage, and the scalar itself otherwise.
+///
+/// ## Why the decision is keyed on the VALUE type
+///
+/// The rule is about the format the arithmetic runs in, and that is a property
+/// of the scalar's value component rather than of the wrapper carrying it.
+/// Keyed on the storage type instead -- as a `template <> struct
+/// accumulator<float>` specialisation -- the same question gets two answers by
+/// accident: it fires for `float` and silently misses every scalar whose value
+/// component is a `float` without being one.
+///
+/// A scalar of that second shape is rejected here rather than answered wrongly.
+/// Widening it means rebinding its value component to `double`, which needs a
+/// hook no scalar in this library supplies; the static assertion says so at the
+/// trait, instead of letting the kernel fail thirty lines into a template.
+///
+/// ## What justifies widening at all
+///
+/// **For the tabulation kernels the reason is PARITY, not accuracy.** numba
+/// promotes float32 intermediates to float64 as a side effect of literal
+/// typing, so a port that computed in `float` throughout disagrees with the
+/// oracle by about one float32 ulp; cpp/include/pantr/basis/cardinal_bspline.hpp
+/// measures that. It is *not* the `sqrt(m) * eps32` argument of
+/// design/large_data_fitting.md: that argument is about a length-`m`
+/// scalar accumulation, and a Cox-de Boor tabulation stores its state back into
+/// the output array at every stage, where the measured float32 error is flat in
+/// the degree. That note was amended in this branch to bound its own rule
+/// accordingly.
+///
+/// Both reasons reach the same policy, which is why the policy lives here in the
+/// core and not in the header of whichever kernel needed it first.
+template <Real T>
+struct accumulator {
+    static_assert(std::same_as<T, value_type_t<T>> || std::same_as<value_type_t<T>, double>,
+                  "a scalar carrying a value component narrower than double has to be "
+                  "widened by rebinding that component, which no scalar here supplies a "
+                  "hook for; specialise pantr::accumulator for it before using it");
+
+    /// The accumulation type for `T`.
+    using type = std::conditional_t<std::same_as<value_type_t<T>, float>, double, T>;
+};
+
+/// The accumulation type of `T`, as an alias.
+///
+/// `cpp/tests/test_scalar_generic.cpp` pins all three answers -- `double` for
+/// `double`, `double` for `float`, and a differentiable scalar for itself -- for
+/// the same reason it pins `value_type_t`: nothing checks an alias template
+/// until something instantiates it.
+template <Real T>
+using accumulator_t = typename accumulator<T>::type;
+
 }  // namespace pantr

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+# C++ tests. Plain executables registered with ctest -- see cpp/tests/check.hpp
+# for why there is no test framework here.
+
+set(PANTR_TEST_SOURCES
+    test_dependency_smoke.cpp
+    test_cardinal_bspline.cpp
+    test_scalar_generic.cpp)
+
+foreach(_src IN LISTS PANTR_TEST_SOURCES)
+  cmake_path(GET _src STEM _name)
+  add_executable(${_name} ${_src})
+  target_link_libraries(${_name} PRIVATE pantr::core)
+  target_include_directories(${_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  add_test(NAME ${_name} COMMAND ${_name})
+endforeach()
+
+# Eigen is only reached by the dependency smoke test. Linking it to pantr::core
+# would put it on the include path of the kernel and the bindings too, which
+# would let a stray #include compile without anyone deciding to take the
+# dependency on.
+target_link_libraries(test_dependency_smoke PRIVATE Eigen3::Eigen)

--- a/cpp/tests/check.hpp
+++ b/cpp/tests/check.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+/// \file
+/// A three-macro test harness.
+///
+/// Deliberately not GoogleTest or Catch2. This tree is a prototype whose first
+/// requirement is that it be cheap to abandon, and a test framework is a
+/// FetchContent entry, a configure-time cost and a compile-time cost bought for
+/// assertions that fit in twenty lines. If the port outlives the prototype, this
+/// is the first thing to replace.
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace pantr::test {
+
+inline int failures = 0;
+
+inline void report(bool ok, const char* expr, const char* file, int line, const std::string& note) {
+    if (ok) {
+        return;
+    }
+    ++failures;
+    std::fprintf(stderr, "FAIL %s:%d\n  %s\n", file, line, expr);
+    if (!note.empty()) {
+        std::fprintf(stderr, "  %s\n", note.c_str());
+    }
+}
+
+inline int summary(const char* name) {
+    if (failures == 0) {
+        std::printf("PASS %s\n", name);
+        return EXIT_SUCCESS;
+    }
+    std::fprintf(stderr, "%d failure(s) in %s\n", failures, name);
+    return EXIT_FAILURE;
+}
+
+}  // namespace pantr::test
+
+#define PANTR_CHECK(expr) ::pantr::test::report((expr), #expr, __FILE__, __LINE__, {})
+
+#define PANTR_CHECK_MSG(expr, note) ::pantr::test::report((expr), #expr, __FILE__, __LINE__, (note))

--- a/cpp/tests/test_cardinal_bspline.cpp
+++ b/cpp/tests/test_cardinal_bspline.cpp
@@ -1,0 +1,270 @@
+/// \file
+/// Properties of the Cox-de Boor cardinal B-spline tabulation.
+///
+/// Every tolerance below is derived from the same forward-error argument, stated
+/// once here and referred to by name afterwards.
+///
+/// ## The forward-error bound
+///
+/// Write `u` for the unit roundoff (`eps / 2`, but `eps` is used throughout
+/// below, which only makes the bounds looser). For evaluation points in
+/// `[0, 1]`, `term = (r + 1 - u) / k` lies in `[0, 1]`, so every stage of the
+/// recurrence forms a convex combination: the stage map has non-negative
+/// coefficients that sum to one, i.e. it is a stochastic matrix, and a
+/// stochastic matrix does not amplify an absolute error vector in the 1-norm.
+///
+/// So the error accumulated over the stages is the *sum* of what each stage
+/// introduces, with no growth factor. Per stage, and per index `r`, the
+/// roundings are: two forming `term` (one add, one multiply), at most two
+/// forming `saved + nr_old * term` (one multiply, one add -- one if the compiler
+/// fuses them), and two forming `nr_old * (1 - term)` (one subtract, one
+/// multiply). Six roundings, each contributing at most `eps` times the magnitude
+/// of the quantity it perturbs. Because the values at any stage are
+/// non-negative and sum to one, those magnitudes sum to one across `r`, so a
+/// whole stage introduces at most `6 * eps` of absolute error in the 1-norm.
+///
+/// Over `n` stages:
+///
+///     sum_r |N_computed[r] - N_exact[r]|  <=  6 * n * eps                  (1)
+///
+/// and in particular each component obeys the same bound. Second-order terms are
+/// `O(n^2 eps^2)`, which at `n = 20` in float64 is about `5e-30`, so they are
+/// dropped rather than carried.
+///
+/// Partition of unity additionally sums `n + 1` computed values, costing at most
+/// `n * eps` more, hence `7 * n * eps`. The constant used below is `8`, which is
+/// (1) rounded up to the next power of two -- an acknowledged safety factor of
+/// `8 / 7`, and the only fudge in this file.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+/// The bound of equation (1) in this file's header, plus the summation term.
+constexpr double partition_bound(int degree) {
+    return 8.0 * static_cast<double>(degree) * kEps;
+}
+
+/// Evaluation points, chosen to include both endpoints and to avoid landing only
+/// on values whose binary representation is exact.
+std::vector<double> sample_points() {
+    std::vector<double> pts;
+    constexpr int n_pts = 65;
+    pts.reserve(n_pts);
+    for (int i = 0; i < n_pts; ++i) {
+        pts.push_back(static_cast<double>(i) / static_cast<double>(n_pts - 1));
+    }
+    return pts;
+}
+
+std::vector<double> tabulate(int degree, const std::vector<double>& pts) {
+    std::vector<double> out(pts.size() * static_cast<std::size_t>(degree + 1), 0.0);
+    const pantr::span2d<double> view(out.data(), pts.size(),
+                                     static_cast<std::size_t>(degree + 1));
+    pantr::tabulate_cardinal_bspline_1d<double>(degree, std::span<const double>(pts), view);
+    return out;
+}
+
+/// Partition of unity. The defining property of a B-spline basis, and the one
+/// that fails loudly if the recurrence is wrong anywhere.
+void partition_of_unity() {
+    const auto pts = sample_points();
+    for (int degree = 0; degree <= 20; ++degree) {
+        const auto values = tabulate(degree, pts);
+        const auto stride = static_cast<std::size_t>(degree + 1);
+        const double bound = partition_bound(degree) + kEps;  // the +eps covers degree 0
+
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            double sum = 0.0;
+            for (std::size_t r = 0; r < stride; ++r) {
+                sum += values[j * stride + r];
+            }
+            PANTR_CHECK_MSG(std::abs(sum - 1.0) <= bound,
+                            "degree " + std::to_string(degree) + " at u=" +
+                                std::to_string(pts[j]) + ": |sum-1| = " +
+                                std::to_string(std::abs(sum - 1.0)) + " > " +
+                                std::to_string(bound));
+        }
+    }
+}
+
+/// Non-negativity. Not a rounding statement: every value is a product or a sum of
+/// non-negative quantities, so a negative entry means the recurrence took a
+/// branch it should not have, not that it lost precision.
+void values_are_non_negative() {
+    const auto pts = sample_points();
+    for (int degree = 0; degree <= 20; ++degree) {
+        const auto values = tabulate(degree, pts);
+        for (const double v : values) {
+            PANTR_CHECK_MSG(v >= 0.0, "degree " + std::to_string(degree) +
+                                          ": negative value " + std::to_string(v));
+        }
+    }
+}
+
+/// Symmetry: the cardinal basis on the central span satisfies
+/// `N_r(u) = N_{n-r}(1-u)`, because the knot vector is uniform and the span is
+/// central. An independent structural property -- it constrains the answer
+/// without recomputing it.
+void basis_is_symmetric() {
+    const auto pts = sample_points();
+    std::vector<double> mirrored(pts.size());
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        mirrored[j] = 1.0 - pts[pts.size() - 1 - j];
+    }
+
+    for (int degree = 0; degree <= 12; ++degree) {
+        const auto direct = tabulate(degree, pts);
+        const auto reflected = tabulate(degree, mirrored);
+        const auto stride = static_cast<std::size_t>(degree + 1);
+        // Two independent evaluations, so twice the bound of equation (1).
+        const double bound = 2.0 * partition_bound(degree) + kEps;
+
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            for (std::size_t r = 0; r < stride; ++r) {
+                const double a = direct[j * stride + r];
+                const double b = reflected[(pts.size() - 1 - j) * stride + (stride - 1 - r)];
+                PANTR_CHECK_MSG(std::abs(a - b) <= bound,
+                                "degree " + std::to_string(degree) + " r=" +
+                                    std::to_string(r) + ": " + std::to_string(a) + " vs " +
+                                    std::to_string(b));
+            }
+        }
+    }
+}
+
+/// Closed forms for the low degrees, written out independently of the
+/// recurrence. This is the only check here that is a genuine oracle rather than
+/// a property: it compares against an expression derived on paper, so it would
+/// catch a recurrence that is self-consistent and wrong.
+///
+/// Bound: equation (1) for the kernel, plus a handful of roundings for the
+/// closed form itself. At these degrees that is well under `16 * eps`, which is
+/// what is used.
+void low_degrees_match_closed_forms() {
+    const auto pts = sample_points();
+    const double bound = 16.0 * kEps;
+
+    {  // degree 1: N_0 = 1 - u, N_1 = u
+        const auto v = tabulate(1, pts);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            const double t = pts[j];
+            PANTR_CHECK(std::abs(v[2 * j + 0] - (1.0 - t)) <= bound);
+            PANTR_CHECK(std::abs(v[2 * j + 1] - t) <= bound);
+        }
+    }
+
+    {  // degree 2: (1-u)^2/2, (1 + 2u - 2u^2)/2, u^2/2
+        const auto v = tabulate(2, pts);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            const double t = pts[j];
+            PANTR_CHECK(std::abs(v[3 * j + 0] - (1.0 - t) * (1.0 - t) / 2.0) <= bound);
+            PANTR_CHECK(std::abs(v[3 * j + 1] - (1.0 + 2.0 * t - 2.0 * t * t) / 2.0) <= bound);
+            PANTR_CHECK(std::abs(v[3 * j + 2] - t * t / 2.0) <= bound);
+        }
+    }
+
+    {  // degree 3: (1-u)^3/6, (3u^3 - 6u^2 + 4)/6, (-3u^3 + 3u^2 + 3u + 1)/6, u^3/6
+        const auto v = tabulate(3, pts);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            const double t = pts[j];
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            PANTR_CHECK(std::abs(v[4 * j + 0] - (1.0 - t) * (1.0 - t) * (1.0 - t) / 6.0) <= bound);
+            PANTR_CHECK(std::abs(v[4 * j + 1] - (3.0 * t3 - 6.0 * t2 + 4.0) / 6.0) <= bound);
+            PANTR_CHECK(std::abs(v[4 * j + 2] -
+                                 (-3.0 * t3 + 3.0 * t2 + 3.0 * t + 1.0) / 6.0) <= bound);
+            PANTR_CHECK(std::abs(v[4 * j + 3] - t3 / 6.0) <= bound);
+        }
+    }
+}
+
+/// The float32 instantiation: it compiles, it runs, and it satisfies partition of
+/// unity to the float32 STORAGE bound rather than to a float32 forward bound.
+///
+/// **This test is not the check that `accumulator_t` is wired up**, though an
+/// earlier comment here said it was. It cannot be: partition of unity is
+/// dominated by the float32 stores, and the accumulator's precision barely shows
+/// through them. Measured, by building this same function against a mutant header
+/// with `accumulator<float>::type = float` -- the change that removes the entire
+/// point of `accumulator_t` -- it **passes at every degree from 0 to 20**, with an
+/// observed error between 4.8% and 10% of the bound. It never comes close to
+/// failing, so no re-derivation of the constant would rescue the claim; the
+/// invariant simply does not see the accumulator.
+///
+/// The checks that do are exact and live elsewhere:
+/// `static_assert(std::same_as<pantr::accumulator_t<float>, double>)` in
+/// cpp/tests/test_scalar_generic.cpp, which is a build failure rather than a
+/// tolerance, and `test_float32_intermediates_are_float64` in
+/// tests/test_cpp_parity.py, which compares against an explicit model of the
+/// arithmetic contract in both directions. This one keeps its own smaller job:
+/// the `float` instantiation exists, runs, and is not grossly wrong.
+void float32_instantiation_holds_partition_of_unity() {
+    constexpr float kEps32 = std::numeric_limits<float>::epsilon();
+    std::vector<float> pts;
+    for (int i = 0; i <= 32; ++i) {
+        pts.push_back(static_cast<float>(i) / 32.0F);
+    }
+
+    for (int degree = 0; degree <= 10; ++degree) {
+        const auto stride = static_cast<std::size_t>(degree + 1);
+        std::vector<float> out(pts.size() * stride, 0.0F);
+        const pantr::span2d<float> view(out.data(), pts.size(), stride);
+        pantr::tabulate_cardinal_bspline_1d<float>(degree, std::span<const float>(pts), view);
+
+        // The bound, derived the way equation (1) above is, and NOT by counting
+        // stores. Stage `k` stores `k + 1` values, so the kernel commits
+        // `n * (n + 3) / 2` storage roundings -- 65 at degree 10, not 11, which is
+        // what an earlier comment here claimed.
+        //
+        // The count is not what the bound rests on. At every stage the stored
+        // values are non-negative and sum to one, so however many of them there
+        // are their roundings add at most `eps32 / 2` in the 1-norm; and the next
+        // stage's map is stochastic, so it does not amplify what came before.
+        // That gives `n * eps32 / 2` over the stages. The summation below adds
+        // `n` float32 additions on partial sums bounded by one, for `n * eps32 / 2`
+        // more. Total `n * eps32`. The recurrence itself runs in float64 and
+        // contributes `6 * n * eps64 ~ 1e-15`, negligible against `eps32 ~ 1e-7`.
+        //
+        // `2 * (degree + 1)` rather than `degree` is about a factor of two of
+        // acknowledged margin, and covers degree 0, where the derived bound is 0
+        // and the answer is exact anyway.
+        //
+        // Correct, and loose in a way worth recording: measured, the error is FLAT
+        // in degree (1 eps32 from degree 4 through 20, 1.5 at degree 16) because
+        // the per-stage roundings have mixed signs and cancel, while this bound
+        // grows linearly. It is not a tight statement about this kernel.
+        const float bound = 2.0F * static_cast<float>(degree + 1) * kEps32;
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            float sum = 0.0F;
+            for (std::size_t r = 0; r < stride; ++r) {
+                sum += out[j * stride + r];
+            }
+            PANTR_CHECK_MSG(std::abs(sum - 1.0F) <= bound,
+                            "float32 degree " + std::to_string(degree) + ": |sum-1| = " +
+                                std::to_string(std::abs(sum - 1.0F)));
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    partition_of_unity();
+    values_are_non_negative();
+    basis_is_symmetric();
+    low_degrees_match_closed_forms();
+    float32_instantiation_holds_partition_of_unity();
+    return pantr::test::summary("test_cardinal_bspline");
+}

--- a/cpp/tests/test_cardinal_bspline.cpp
+++ b/cpp/tests/test_cardinal_bspline.cpp
@@ -196,9 +196,9 @@ void low_degrees_match_closed_forms() {
 /// **This test is not the check that `accumulator_t` is wired up**, though an
 /// earlier comment here said it was. It cannot be: partition of unity is
 /// dominated by the float32 stores, and the accumulator's precision barely shows
-/// through them. Measured, by building this same function against a mutant header
-/// with `accumulator<float>::type = float` -- the change that removes the entire
-/// point of `accumulator_t` -- it **passes at every degree from 0 to 20**, with an
+/// through them. Measured, by building this same function against a mutant trait
+/// answering `float` for `float` -- the change that removes the entire point of
+/// `accumulator_t` -- it **passes at every degree from 0 to 20**, with an
 /// observed error between 4.8% and 10% of the bound. It never comes close to
 /// failing, so no re-derivation of the constant would rescue the claim; the
 /// invariant simply does not see the accumulator.

--- a/cpp/tests/test_dependency_smoke.cpp
+++ b/cpp/tests/test_dependency_smoke.cpp
@@ -1,0 +1,94 @@
+/// \file
+/// Compiles and runs against every fetched dependency, under pantr's own
+/// warning flags.
+///
+/// This is the test that answers "do Kokkos mdspan and Eigen survive -Werror
+/// with SYSTEM, and CMake 4?". A dependency that is declared in CMake but never
+/// `#include`d answers none of that: the include path is never exercised, no
+/// header is ever parsed, and the warning flags never meet upstream's code. So
+/// this file includes both and uses both.
+///
+/// Eigen is otherwise unused by this prototype. design/large_data_fitting.md and
+/// design/adaptive_thb_approximation.md both settle on Eigen::SparseMatrix with
+/// SimplicialLDLT for the fitting solves, so it is fetched now to find out
+/// whether it builds clean here rather than on the day it is needed.
+
+#include <Eigen/Dense>
+#include <Eigen/SparseCholesky>
+#include <Eigen/SparseCore>
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+void mdspan_view_is_row_major() {
+    std::vector<double> storage(6);
+    const pantr::span2d<double> view(storage.data(), 2, 3);
+
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            pantr::at(view, i, j) = static_cast<double>(3 * i + j);
+        }
+    }
+
+    // layout_right means element (i, j) sits at flat offset 3*i + j. Checking it
+    // through the raw storage rather than through the view is the point: the
+    // kernels hand this buffer to numpy, which assumes exactly this layout.
+    for (std::size_t k = 0; k < storage.size(); ++k) {
+        PANTR_CHECK(storage[k] == static_cast<double>(k));
+    }
+
+    PANTR_CHECK(view.extent(0) == 2);
+    PANTR_CHECK(view.extent(1) == 3);
+}
+
+void eigen_solves_a_banded_spd_system() {
+    // A 1D second-difference operator: symmetric positive definite, half
+    // bandwidth 1. The same shape of system design/large_data_fitting.md routes
+    // through SimplicialLDLT, at a size small enough to check by hand.
+    constexpr int n = 5;
+    Eigen::SparseMatrix<double> a(n, n);
+    std::vector<Eigen::Triplet<double>> entries;
+    for (int i = 0; i < n; ++i) {
+        entries.emplace_back(i, i, 2.0);
+        if (i + 1 < n) {
+            entries.emplace_back(i, i + 1, -1.0);
+            entries.emplace_back(i + 1, i, -1.0);
+        }
+    }
+    a.setFromTriplets(entries.begin(), entries.end());
+
+    Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+    solver.compute(a);
+    PANTR_CHECK(solver.info() == Eigen::Success);
+
+    const Eigen::VectorXd rhs = Eigen::VectorXd::Ones(n);
+    const Eigen::VectorXd x = solver.solve(rhs);
+    PANTR_CHECK(solver.info() == Eigen::Success);
+
+    // Residual rather than a hard-coded solution: the bound is the standard
+    // backward-stability statement for a direct solve, ||A x - b|| <= c(n)
+    // kappa(A) eps ||b||, with c(n) a low-degree polynomial in n. At n = 5 the
+    // second-difference matrix has kappa_2 ~ 13, so 64 * eps * ||b|| clears it
+    // by a wide and deliberate margin -- this test exists to prove Eigen links
+    // and runs, not to measure its accuracy.
+    const double residual = (a * x - rhs).norm();
+    const double bound = 64.0 * std::numeric_limits<double>::epsilon() * rhs.norm();
+    PANTR_CHECK_MSG(residual <= bound,
+                    "residual " + std::to_string(residual) + " > bound " + std::to_string(bound));
+}
+
+}  // namespace
+
+int main() {
+    mdspan_view_is_row_major();
+    eigen_solves_a_banded_spd_system();
+    return pantr::test::summary("test_dependency_smoke");
+}

--- a/cpp/tests/test_dependency_smoke.cpp
+++ b/cpp/tests/test_dependency_smoke.cpp
@@ -49,6 +49,49 @@ void mdspan_view_is_row_major() {
     PANTR_CHECK(view.extent(1) == 3);
 }
 
+/// `pantr::at` indexes a view of any rank, through the one overload both
+/// branches of the mdspan switch provide.
+///
+/// This is a dependency assumption and so belongs in this file: `at` reaches the
+/// element through `operator[](const std::array<index_type, rank()>&)`, which
+/// Kokkos declares outside its `MDSPAN_USE_BRACKET_OPERATOR` guard and C++23
+/// specifies unconditionally. If a future mdspan release moved that overload
+/// behind a guard, `at` would stop compiling and this is where it would show,
+/// with the reason attached.
+///
+/// Ranks 1, 2 and 3 are all exercised because rank is where the assumption is
+/// least uniform: at rank 1 the array overload competes with a single-index one,
+/// and rank 3 is what design/bezier_extraction_api.md needs next. Each rank is
+/// checked through the raw storage, so a transposed index would show up as a
+/// wrong flat offset rather than being hidden by a symmetric read-back.
+void at_indexes_a_view_of_every_rank() {
+    std::vector<double> storage(24);
+
+    const pantr::span_nd<double, 1> vec(storage.data(), 4);
+    for (std::size_t i = 0; i < 4; ++i) {
+        pantr::at(vec, i) = static_cast<double>(i);
+    }
+    for (std::size_t k = 0; k < 4; ++k) {
+        PANTR_CHECK(storage[k] == static_cast<double>(k));
+    }
+
+    const pantr::span_nd<double, 3> cube(storage.data(), 2, 3, 4);
+    for (std::size_t i = 0; i < 2; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            for (std::size_t k = 0; k < 4; ++k) {
+                pantr::at(cube, i, j, k) = static_cast<double>(12 * i + 4 * j + k);
+            }
+        }
+    }
+    for (std::size_t k = 0; k < storage.size(); ++k) {
+        PANTR_CHECK(storage[k] == static_cast<double>(k));
+    }
+
+    PANTR_CHECK(cube.extent(0) == 2);
+    PANTR_CHECK(cube.extent(1) == 3);
+    PANTR_CHECK(cube.extent(2) == 4);
+}
+
 void eigen_solves_a_banded_spd_system() {
     // A 1D second-difference operator: symmetric positive definite, half
     // bandwidth 1. The same shape of system design/large_data_fitting.md routes
@@ -89,6 +132,7 @@ void eigen_solves_a_banded_spd_system() {
 
 int main() {
     mdspan_view_is_row_major();
+    at_indexes_a_view_of_every_rank();
     eigen_solves_a_banded_spd_system();
     return pantr::test::summary("test_dependency_smoke");
 }

--- a/cpp/tests/test_dependency_smoke.cpp
+++ b/cpp/tests/test_dependency_smoke.cpp
@@ -65,16 +65,18 @@ void mdspan_view_is_row_major() {
 /// checked through the raw storage, so a transposed index would show up as a
 /// wrong flat offset rather than being hidden by a symmetric read-back.
 void at_indexes_a_view_of_every_rank() {
-    std::vector<double> storage(24);
-
-    const pantr::span_nd<double, 1> vec(storage.data(), 4);
+    std::vector<double> line(4);
+    const pantr::span_nd<double, 1> vec(line.data(), 4);
     for (std::size_t i = 0; i < 4; ++i) {
         pantr::at(vec, i) = static_cast<double>(i);
     }
-    for (std::size_t k = 0; k < 4; ++k) {
-        PANTR_CHECK(storage[k] == static_cast<double>(k));
+    for (std::size_t k = 0; k < line.size(); ++k) {
+        PANTR_CHECK(line[k] == static_cast<double>(k));
     }
 
+    // Its own buffer, so that neither rank's check can be satisfied by what the
+    // other wrote.
+    std::vector<double> storage(24);
     const pantr::span_nd<double, 3> cube(storage.data(), 2, 3, 4);
     for (std::size_t i = 0; i < 2; ++i) {
         for (std::size_t j = 0; j < 3; ++j) {

--- a/cpp/tests/test_scalar_generic.cpp
+++ b/cpp/tests/test_scalar_generic.cpp
@@ -1,0 +1,245 @@
+/// \file
+/// The Tier A discipline, checked by compiling the kernel on a type that breaks
+/// if the discipline is broken.
+///
+/// design/automatic_differentiation.md concludes that pantr does not need
+/// automatic differentiation, and that templating the scalar is enough to keep
+/// the option open at four disciplines' cost. The risk with a conclusion of that
+/// shape is that the four disciplines quietly rot: nothing in a `double`-only
+/// build notices when a comparison starts bypassing `value_of`, when a `floor`
+/// or an `int` cast lands on the scalar, or when a math call is written
+/// `std::sqrt(x)` and so blocks argument-dependent lookup.
+///
+/// So this file defines a minimal forward-mode dual number and instantiates the
+/// kernel on it. Every one of those four violations is a compile error against
+/// this type, which turns the disciplines from a convention into a build
+/// failure. The type is a test fixture and nothing more -- design/automatic
+/// _differentiation.md's `Dual<T, N>` is a later decision, not this.
+///
+/// It also checks the derivative it produces, because a dual number that
+/// compiles but propagates the wrong derivative would pass a compile-only test
+/// while proving nothing.
+
+#include <algorithm>
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace {
+
+/// Forward-mode dual number carrying one derivative component.
+///
+/// Deliberately minimal, and deliberately missing things:
+///
+///   - **no `operator==` and no ordering.** This is the point of the fixture.
+///     `pantr::Real` does not require `std::regular` precisely so that a scalar
+///     may omit them, which makes `if (a < b)` on the scalar a compile error and
+///     forces the Tier B spelling `value_of(a) < value_of(b)`.
+///   - **no conversion to `double`.** So an integer cast or a `std::floor` on
+///     the scalar cannot compile either.
+///
+/// `value_of` is a hidden friend, so it is found by argument-dependent lookup
+/// through the two-step pattern the library uses and *only* through it.
+class Dual1 {
+  public:
+    constexpr Dual1() noexcept = default;
+    constexpr explicit Dual1(double value) noexcept : value_(value) {}
+    constexpr Dual1(double value, double derivative) noexcept
+        : value_(value), derivative_(derivative) {}
+
+    [[nodiscard]] constexpr double derivative() const noexcept { return derivative_; }
+
+    constexpr Dual1 operator-() const noexcept { return {-value_, -derivative_}; }
+
+    friend constexpr Dual1 operator+(Dual1 a, Dual1 b) noexcept {
+        return {a.value_ + b.value_, a.derivative_ + b.derivative_};
+    }
+    friend constexpr Dual1 operator-(Dual1 a, Dual1 b) noexcept {
+        return {a.value_ - b.value_, a.derivative_ - b.derivative_};
+    }
+    friend constexpr Dual1 operator*(Dual1 a, Dual1 b) noexcept {
+        return {a.value_ * b.value_, a.derivative_ * b.value_ + a.value_ * b.derivative_};
+    }
+    friend constexpr Dual1 operator/(Dual1 a, Dual1 b) noexcept {
+        const double q = a.value_ / b.value_;
+        return {q, (a.derivative_ - q * b.derivative_) / b.value_};
+    }
+
+    /// The Tier B access point. A hidden friend, so `pantr::value_of(x)` does
+    /// *not* find it and only the `using pantr::value_of; value_of(x)` spelling
+    /// works -- which is the behaviour the library's convention relies on.
+    friend constexpr double value_of(Dual1 x) noexcept { return x.value_; }
+
+  private:
+    double value_ = 0.0;
+    double derivative_ = 0.0;
+};
+
+// The design claims, as static assertions rather than as prose.
+static_assert(pantr::Real<Dual1>, "the fixture must satisfy the scalar concept");
+static_assert(!std::equality_comparable<Dual1>,
+              "Real must not require operator==; requiring it would make the Tier B "
+              "discipline unenforceable at the comparison sites it exists to protect");
+static_assert(!std::convertible_to<Dual1, double>,
+              "a scalar convertible to double would let an integer cast or a floor "
+              "compile silently");
+static_assert(std::same_as<pantr::accumulator_t<Dual1>, Dual1>,
+              "a differentiable scalar must not be narrowed to double for accumulation");
+static_assert(std::same_as<pantr::accumulator_t<float>, double>);
+static_assert(std::same_as<pantr::accumulator_t<double>, double>);
+
+// `value_type_t` is an alias template, so nothing checks it until something
+// instantiates it, and it shipped with no instantiation anywhere in the tree.
+//
+// It named `value_of` through a QUALIFIED call. That is the failure the header's
+// own comment spends ten lines warning about, and it failed in the way that
+// warning describes rather than uniformly: measured with this project's GCC
+// 14.4.0, the qualified spelling still compiled for `double` and for `float` --
+// the `using pantr::value_of;` in `detail` makes the built-in overload visible to
+// qualified lookup too -- and failed only for `Dual1`, whose `value_of` is a
+// hidden friend that only ADL can reach.
+//
+// So a `double`-only build could never have noticed, which is precisely why all
+// three are pinned here and not just the interesting one.
+static_assert(std::same_as<pantr::value_type_t<double>, double>);
+static_assert(std::same_as<pantr::value_type_t<float>, float>);
+static_assert(std::same_as<pantr::value_type_t<Dual1>, double>,
+              "a differentiable scalar's underlying value type must be reachable through "
+              "the two-step lookup, which is the only way a hidden-friend value_of is found");
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+std::vector<Dual1> seeded_points(const std::vector<double>& pts) {
+    std::vector<Dual1> seeded;
+    seeded.reserve(pts.size());
+    for (const double t : pts) {
+        seeded.emplace_back(t, 1.0);  // d/du seeded to 1
+    }
+    return seeded;
+}
+
+std::vector<double> sample_points() {
+    std::vector<double> pts;
+    for (int i = 0; i <= 32; ++i) {
+        pts.push_back(static_cast<double>(i) / 32.0);
+    }
+    return pts;
+}
+
+std::vector<Dual1> tabulate_dual(int degree, const std::vector<Dual1>& pts) {
+    const auto stride = static_cast<std::size_t>(degree + 1);
+    std::vector<Dual1> out(pts.size() * stride);
+    const pantr::span2d<Dual1> view(out.data(), pts.size(), stride);
+    pantr::tabulate_cardinal_bspline_1d<Dual1>(degree, std::span<const Dual1>(pts), view);
+    return out;
+}
+
+/// The kernel's values must not depend on the scalar type carrying a derivative:
+/// a dual number's value component obeys exactly the `double` recurrence, so the
+/// two agree to the last bit. This is a stronger statement than a tolerance and
+/// it is the correct one -- the arithmetic performed on the value component is
+/// operation for operation the same.
+void dual_value_component_matches_double_exactly() {
+    using pantr::value_of;
+    const auto pts = sample_points();
+    const auto seeded = seeded_points(pts);
+
+    for (int degree = 0; degree <= 8; ++degree) {
+        const auto stride = static_cast<std::size_t>(degree + 1);
+        const auto dual = tabulate_dual(degree, seeded);
+
+        std::vector<double> plain(pts.size() * stride, 0.0);
+        const pantr::span2d<double> view(plain.data(), pts.size(), stride);
+        pantr::tabulate_cardinal_bspline_1d<double>(degree, std::span<const double>(pts), view);
+
+        for (std::size_t i = 0; i < plain.size(); ++i) {
+            PANTR_CHECK_MSG(value_of(dual[i]) == plain[i],
+                            "degree " + std::to_string(degree) + " index " +
+                                std::to_string(i) + ": dual " +
+                                std::to_string(value_of(dual[i])) + " vs double " +
+                                std::to_string(plain[i]));
+        }
+    }
+}
+
+/// Differentiating partition of unity: `sum_r N_r(u) = 1` for all `u`, so the
+/// derivatives must sum to zero. An independent constraint on the propagated
+/// derivative -- it does not recompute it.
+void derivatives_sum_to_zero() {
+    const auto pts = sample_points();
+    const auto seeded = seeded_points(pts);
+
+    for (int degree = 0; degree <= 12; ++degree) {
+        const auto stride = static_cast<std::size_t>(degree + 1);
+        const auto dual = tabulate_dual(degree, seeded);
+
+        // The derivative components are NOT sign-definite, unlike the values, so
+        // the convex-combination argument of test_cardinal_bspline.cpp does not
+        // apply and cancellation is possible. The scale is set by the largest
+        // derivative in the row, which for the cardinal basis is O(degree), so
+        // the bound is the summation bound `stride * eps` times that scale.
+        double scale = 0.0;
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            for (std::size_t r = 0; r < stride; ++r) {
+                scale = std::max(scale, std::abs(dual[j * stride + r].derivative()));
+            }
+        }
+        const double bound = 8.0 * static_cast<double>(stride) * kEps * std::max(scale, 1.0);
+
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            double sum = 0.0;
+            for (std::size_t r = 0; r < stride; ++r) {
+                sum += dual[j * stride + r].derivative();
+            }
+            PANTR_CHECK_MSG(std::abs(sum) <= bound,
+                            "degree " + std::to_string(degree) + " at u=" +
+                                std::to_string(pts[j]) + ": sum of derivatives " +
+                                std::to_string(sum) + " > " + std::to_string(bound));
+        }
+    }
+}
+
+/// Closed-form derivatives at low degree, derived on paper from the closed forms
+/// in test_cardinal_bspline.cpp. The oracle for the derivative, as opposed to the
+/// constraint above.
+void low_degree_derivatives_match_closed_forms() {
+    const auto pts = sample_points();
+    const auto seeded = seeded_points(pts);
+    const double bound = 16.0 * kEps;
+
+    {  // degree 1: d/du (1 - u, u) = (-1, 1)
+        const auto v = tabulate_dual(1, seeded);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            PANTR_CHECK(std::abs(v[2 * j + 0].derivative() + 1.0) <= bound);
+            PANTR_CHECK(std::abs(v[2 * j + 1].derivative() - 1.0) <= bound);
+        }
+    }
+
+    {  // degree 2: d/du ((1-u)^2/2, (1 + 2u - 2u^2)/2, u^2/2) = (u - 1, 1 - 2u, u)
+        const auto v = tabulate_dual(2, seeded);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            const double t = pts[j];
+            PANTR_CHECK(std::abs(v[3 * j + 0].derivative() - (t - 1.0)) <= bound);
+            PANTR_CHECK(std::abs(v[3 * j + 1].derivative() - (1.0 - 2.0 * t)) <= bound);
+            PANTR_CHECK(std::abs(v[3 * j + 2].derivative() - t) <= bound);
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    dual_value_component_matches_double_exactly();
+    derivatives_sum_to_zero();
+    low_degree_derivatives_match_closed_forms();
+    return pantr::test::summary("test_scalar_generic");
+}

--- a/cpp/tests/test_scalar_generic.cpp
+++ b/cpp/tests/test_scalar_generic.cpp
@@ -97,6 +97,85 @@ static_assert(std::same_as<pantr::accumulator_t<Dual1>, Dual1>,
 static_assert(std::same_as<pantr::accumulator_t<float>, double>);
 static_assert(std::same_as<pantr::accumulator_t<double>, double>);
 
+static_assert(std::constructible_from<Dual1, double>,
+              "the kernels build constants -- T(1) seeds the recurrence -- so a scalar "
+              "that cannot be constructed from a double is not usable by them");
+static_assert(!std::convertible_to<double, Dual1>,
+              "constructible_from must be satisfied by an EXPLICIT constructor: an "
+              "implicit conversion the other way would let a stray double enter the "
+              "computation silently");
+
+/// A scalar the concept must REJECT, and the reason it exists.
+///
+/// A forward-mode dual built by named factories rather than by a numeric
+/// constructor is a common AD shape: it keeps `Dual d = 3;` from compiling, which
+/// is usually what its author wants. It has the five operators and a `value_of`,
+/// so before `std::constructible_from<T, double>` joined `Real` it satisfied the
+/// concept -- and then failed to compile inside the kernel at `T(1)`, producing a
+/// template error from a header its author did not write.
+///
+/// Pinned here so `Real` is checked to be the kernel's actual contract rather
+/// than a subset of it: it must reject this type *at the constraint*.
+class DualByFactory {
+  public:
+    static constexpr DualByFactory constant(double v) noexcept { return {v, 0.0}; }
+    static constexpr DualByFactory seed(double v) noexcept { return {v, 1.0}; }
+
+    constexpr DualByFactory() noexcept = default;
+
+    constexpr DualByFactory operator-() const noexcept { return {-value_, -derivative_}; }
+    friend constexpr DualByFactory operator+(DualByFactory a, DualByFactory b) noexcept {
+        return {a.value_ + b.value_, a.derivative_ + b.derivative_};
+    }
+    friend constexpr DualByFactory operator-(DualByFactory a, DualByFactory b) noexcept {
+        return {a.value_ - b.value_, a.derivative_ - b.derivative_};
+    }
+    friend constexpr DualByFactory operator*(DualByFactory a, DualByFactory b) noexcept {
+        return {a.value_ * b.value_, a.derivative_ * b.value_ + a.value_ * b.derivative_};
+    }
+    friend constexpr DualByFactory operator/(DualByFactory a, DualByFactory b) noexcept {
+        const double q = a.value_ / b.value_;
+        return {q, (a.derivative_ - q * b.derivative_) / b.value_};
+    }
+    friend constexpr double value_of(DualByFactory x) noexcept { return x.value_; }
+
+  private:
+    constexpr DualByFactory(double value, double derivative) noexcept
+        : value_(value), derivative_(derivative) {}
+
+    double value_ = 0.0;
+    double derivative_ = 0.0;
+};
+
+/// Exercise every operator of the fixture, so that its rejection is known to be
+/// about the missing constructor and nothing else.
+///
+/// This is not decoration. The `static_assert`s below short-circuit on
+/// `constructible_from`, so without a real use the operators are never
+/// instantiated -- Clang says so and refuses the build under `-Werror`
+/// (`-Wunused-function`), which is the correct complaint: a fixture whose
+/// arithmetic is never compiled cannot be claimed to differ from `Real` by one
+/// requirement. Evaluating it here compiles all five, and the expected value is
+/// worked out by hand rather than read off a run.
+///
+/// With `a = (2, 1)` and `b = (3, 0)`: `a + b = (5, 1)`, `a * b = (6, 3)`,
+/// `(a * b) / b = (2, 1)`, so `a + b - (a * b) / b = (3, 0)` and negating gives
+/// `(-3, 0)`.
+constexpr DualByFactory fixture_arithmetic() noexcept {
+    const DualByFactory a = DualByFactory::seed(2.0);
+    const DualByFactory b = DualByFactory::constant(3.0);
+    return -(a + b - a * b / b);
+}
+
+static_assert(value_of(fixture_arithmetic()) == -3.0,
+              "the fixture's operators must be real arithmetic, not placeholders");
+
+static_assert(!pantr::Real<DualByFactory>,
+              "Real must reject a scalar the kernel cannot build a constant of, at the "
+              "constraint rather than thirty lines into a template instantiation");
+static_assert(!std::constructible_from<DualByFactory, double>,
+              "the fixture is only meaningful while this is the reason it is rejected");
+
 // `value_type_t` is an alias template, so nothing checks it until something
 // instantiates it, and it shipped with no instantiation anywhere in the tree.
 //

--- a/design/_memory/MEMORY.md
+++ b/design/_memory/MEMORY.md
@@ -1,4 +1,4 @@
 - [Where the decisions live](decisions-pointer.md) — the C++ port's design decisions are in `design/*.md` in this repository; read them before proposing anything about the port.
 - [Naming constraint and licensing](naming-and-licensing.md) — two sibling libraries are private and unpublished; never name them in anything that leaves the machine. Plus the dependency direction the licence plan forbids.
 - [Build machine](build-machine.md) — the shared Linux server, its 20-CPU cap, and the calibration trap that comes with many cores.
-- [nanobind status](nanobind-status.md) — dated: split mode changes the wheel strategy but was unreleased as of 2026-08-19. Re-check before committing to it.
+- [nanobind status](nanobind-status.md) — split mode verified working and composing with a second compiled variant; the expensive traps are nanobind's build defaults (`-Os`, strip) and what `nb::ndarray` silently converts.

--- a/design/_memory/MEMORY.md
+++ b/design/_memory/MEMORY.md
@@ -2,3 +2,4 @@
 - [Naming constraint and licensing](naming-and-licensing.md) — two sibling libraries are private and unpublished; never name them in anything that leaves the machine. Plus the dependency direction the licence plan forbids.
 - [Build machine](build-machine.md) — the shared Linux server, its 20-CPU cap, and the calibration trap that comes with many cores.
 - [nanobind status](nanobind-status.md) — split mode verified working and composing with a second compiled variant; the expensive traps are nanobind's build defaults (`-Os`, strip) and what `nb::ndarray` silently converts.
+- [Performance follow-up](performance-followup.md) — wanted later, deliberately deferred in the infrastructure PR; carries what is already measured so it is not re-measured, and what to attack first.

--- a/design/_memory/nanobind-status.md
+++ b/design/_memory/nanobind-status.md
@@ -1,30 +1,81 @@
 ---
 name: nanobind-status
-description: nanobind split mode replaces the abi3 wheel strategy, but was unreleased as of 2026-08-19; re-check before committing
+description: Split mode is verified to work and to compose with a second compiled variant; the traps are nanobind's build defaults, not its API
 metadata:
   type: reference
 ---
 
-**Dated 2026-08-19 and time-sensitive. Re-check the release state before choosing the wheel
-strategy.** At that date: nanobind stable was **2.15.0**; **3.0.0.dev1** and
-**nanobind-backend 1.0.0.dev1** were on PyPI, and the changelog said stabilising split mode
-would still take time.
+**Measured on the build server, 2026-08-19**, by building and running rather than reading.
+Supersedes the earlier version of this note, which recorded split mode as unreleased and its
+composition with a multi-ISA build as unverified.
 
-**Split mode** replaces the stable-ABI (abi3) approach and is better on both axes that
-mattered. The extension splits into a frontend targeting the **Python 3.10 stable ABI** (one
-wheel per platform covering every version) and a tiny version-specific backend shipped from
-PyPI. So the Python floor is no longer forced up to 3.12 to get one wheel, and the function
-dispatcher stops paying the stable-ABI penalty. Enabled with one CMake argument
-(`BACKEND_MODULE`), so it is opt-in and the decision can wait.
+**Versions at that date:** stable **2.15.0**; **3.0.0.dev2** and **nanobind-backend
+1.0.0.dev2** on PyPI. The conda env carries **2.14.0**.
 
-Costs: `nanobind-backend` becomes a **runtime** dependency of the wheel, and its composition
-with a multi-ISA build (several frontends, one backend) is **unverified** and must be tested
-by the skeleton.
+## Split mode works, and it composes
 
-**API changes that touch decisions already taken:** `nb::gil_scoped_acquire` can now fail and
-grows `is_valid()`, which the callback and plugin seams must consult; `NB_TRAMPOLINE` no
-longer takes a `Size`, and instance-level monkey-patching is ignored; return-value policies
-and argument annotations became compile-time tags, so "computed" ones are illegal.
+`nanobind_add_module(... BACKEND_MODULE nanobind_backend)` builds, imports and runs. The
+frontend links as `.abi3.so`, confirming it targets the stable ABI as advertised. **Two
+frontends built from one source at different `-march`, sharing a single backend, both import
+in the same process and both run** -- which is the multi-ISA composition the earlier note
+recorded as unverified and load-bearing.
+
+Two conditions, both found by hitting them:
+
+- **`NB_SUPPRESS_WARNINGS` is required.** In split mode nanobind adds its own include
+  directory straight onto the extension target and marks it SYSTEM *only* with that option.
+  Without it, `nb_attr.h`'s `using arg = arg_t<>` trips `-Wshadow` and `-Werror` ends the
+  build. The `NB_STATIC` path needs a different workaround entirely: retag
+  `nanobind-static`'s includes on the *producing* target, because it is built rather than
+  imported, so its includes arrive as `-I` and GCC drops a later `-isystem` for the same path.
+- **`nanobind-backend` becomes a hard runtime dependency** of the wheel. It fails with a
+  clear, actionable message, which is the right failure, but it is a packaging commitment.
+
+**No behavioural difference between split mode and `NB_STATIC`** was found: identical
+acceptance across a 17-case matrix, and throughput within run-to-run spread. The differences
+are packaging only.
+
+## The real traps are the build defaults, not the API
+
+`nanobind_add_module()` silently applies five things. The first cost this project its
+headline measurement:
+
+- **`-Os` appended after the build type's `-O3`**, and the last optimisation flag wins. A
+  numerical kernel compiled into the module inherits it: measured **31.4 ms against 10.3 ms**
+  on identical source. `NOMINSIZE` turns it off. The single most expensive default.
+- **`-Wl,-s`**, so the module is stripped: `nm` reports "no symbols", `perf` cannot name the
+  kernel and a segfault gives no backtrace. `NOSTRIP` turns it off.
+- `-fno-strict-aliasing` unconditionally, with no option to disable it. Measured as free for
+  a simple recurrence kernel; worth watching for a pointer-heavy one, since it means the
+  module and a plain executable compile the same header under different alias analysis.
+- `-fno-stack-protector` unless `PROTECT_STACK`, and `-ffunction-sections -fdata-sections`
+  guarded by a *different* variable than `NOMINSIZE`.
+
+## `nb::ndarray` constrains less than it appears to
+
+Its constraints are not all guarantees. **nanobind satisfies `c_contig` and a dtype mismatch
+by CONVERTING to a temporary rather than rejecting.** For an input that is merely wasteful;
+for an `out` parameter it is silently wrong -- the kernel fills the temporary and the
+caller's array comes back untouched, with no exception. `.noconvert()` closes exactly those
+two axes. Rank, writability and device were never convertible and always hard-reject.
+
+`nb::ndarray<const T, ...>` behaves differently from the mutable form, and correctly: a
+non-writable array is accepted as an input and refused as an output.
+
+**A masked array is accepted through the buffer protocol with the mask silently ignored**,
+which is how a C++ backend can return numbers where the numba oracle raises.
+
+**An unvalidated integer parameter is a segfault, not an error.** `int degree` reaching a
+`static_cast<std::size_t>` turns `-1` into `SIZE_MAX`; declaring the binding parameter
+`unsigned` makes it a clean `TypeError` and leaves the `.pyi` rendering `degree: int`.
+
+## API changes across 2.x and 3.x
+
+For a module with no bound types, no trampoline and no `gil_scoped_acquire`, **there is no
+behavioural difference**: `ndarray_import` is byte-identical 2.14 to 2.15 and equivalent in
+3.x. One correction to what was recorded before: `nb::arg` is a **runtime struct in 2.x**
+whose `noconvert()` mutates a bool, and only a compile-time tag in 3.x. Source written
+against the 3.x spelling still compiles on 2.x, but not for the reason previously given.
 
 Python floor for pantr is **3.12**, decided separately: numpy 2.5 and scipy 1.18 already
-require it, so supporting 3.11 would mean supporting frozen-old dependencies.
+require it.

--- a/design/_memory/performance-followup.md
+++ b/design/_memory/performance-followup.md
@@ -1,0 +1,51 @@
+---
+name: performance-followup
+description: Performance is a wanted follow-up on the C++ port, deliberately deferred; here is what is already measured so it is not re-measured
+metadata:
+  type: project
+---
+
+**Pablo wants to go deeper on performance later.** Recorded 2026-08-19, when the C++
+infrastructure prototype (PR #335 against `proto/cpp`) deliberately stopped short of it.
+
+## Already measured, do not redo
+
+All on the shared build server, GCC 14.4.0, the cardinal B-spline Cox-de Boor tabulation,
+minimum over repeats. Reproduce with `scripts/bench_parity.py` and
+`cpp/benchmark/bench_cardinal_bspline.cpp`.
+
+- **Kernel against kernel, single-threaded, 10^6 points:** 1.42x at degree 1, 1.30x at
+  degree 3, 0.98x at degree 8. Modest. Both compilers generate reasonable code for the same
+  recurrence and there is no free factor waiting in a straight transliteration.
+- **At the public entry point** the C++ backend is 2.4x to 4x faster at 100 points and 0.17x
+  to 0.29x at 10^6 against numba's 20 threads. The small-input win is not the port: the numba
+  cardinal B-spline kernel is `parallel=True` **unconditionally** and, unlike the Bernstein
+  kernels, has **no serial twin**, so it pays a fork/join for three points.
+- **The ISA ladder gap**, which `design/simd.md` gates stage 2 on: baseline to
+  `-march=x86-64-v3` is 1.20x to 1.27x. **`-march=native` (AVX-512 here) is slower than
+  `x86-64-v3`**, measuring that note's stated hazard on a real pantr kernel.
+- **The trap that dominated everything else:** `nanobind_add_module()` appends `-Os` after
+  the build type's `-O3` and the last flag wins, so the kernel was compiled for size inside
+  the extension: 31.4 ms against 10.3 ms on identical source. `NOMINSIZE`, plus `NOSTRIP` and
+  `install.strip = false` for symbols. Any future measurement must check the effective flags
+  first.
+
+## Not done, and what to attack
+
+- **Profiling.** Now possible: the module keeps its symbols, so `perf` names
+  `tabulate<double>`. Nobody has profiled anything yet; every number above is wall clock.
+- **Threading on the C++ side.** Absent on purpose. It is constrained by
+  `design/user_functions_across_the_boundary.md`'s rule that a callback is invoked from one
+  thread only, so it is a design decision rather than a tuning knob.
+- **Blocking, then SIMD, in that order.** `design/simd.md` is emphatic: the banded
+  contraction is bandwidth-bound at ~0.2 flops/byte unblocked, so vectorising it first would
+  measure as a disappointment and be mistaken for evidence that SIMD does not help.
+- **`simd.md` open question 1 is still open:** does the blocked contraction auto-vectorise?
+  If yes, no batch abstraction is needed and xsimd never enters the dependency list. That is
+  the first measurement to take, via `-fopt-info-vec-missed` / `-Rpass-missed=loop-vectorize`.
+- **The threshold trap.** `_PARALLEL_MIN_NUM_PTS = 4096` and anything like it must be
+  **derived**, never measured on this machine: see [[build-machine]].
+
+The tool for this is the `optimizer` agent or the `perf-tune` skill, which is
+measurement-first and parity-preserving. Parity here means the harness in
+`tests/_parity_harness.py`, which already exists and already knows how to state a bound.

--- a/design/automatic_differentiation.md
+++ b/design/automatic_differentiation.md
@@ -197,6 +197,27 @@ sacrificing the wrong one.
 - **Not investigated:** how often optimization iterates actually land near a classification
   transition in practice, which is what decides whether the kink is a nuisance or a real
   obstacle for the line search.
+- **Tested 2026-08-19, and the "templates are enough" conclusion needed two repairs before
+  it was true.** The C++ prototype implements the four disciplines and instantiates its
+  kernel on a `Dual` fixture with no equality, no ordering and no conversion to `double`, so
+  the compiler enforces three of them rather than a convention. Two gaps showed up the moment
+  that was compiled rather than argued:
+
+  `value_type_t`, the trait the tiering rests on, **did not compile for any differentiable
+  type**. It spelled its lookup as a qualified call, which suppresses ADL -- the exact
+  mistake discipline 3 exists to prevent, committed inside the header that states it. It had
+  no uses in the tree, so nothing caught it.
+
+  And the scalar concept was a **strict subset of what the kernels require**: they build
+  constants (`T(1)` seeds the recurrence), which the concept did not ask for, so a
+  forward-mode `Dual` built by named factories rather than a numeric constructor -- a common
+  AD shape -- satisfied the concept and then failed inside the kernel with a template error.
+  Fixed by requiring `std::constructible_from<T, double>`, which an *explicit* constructor
+  satisfies without opening an implicit conversion, so the Tier B discipline is unweakened.
+
+  Both are repaired and pinned by static assertions, including one on a fixture the concept
+  must *reject*. The conclusion stands; what this records is that it was not free, and that
+  the parts of it nothing instantiates are the parts that were wrong.
 
 ## Open questions
 

--- a/design/large_data_fitting.md
+++ b/design/large_data_fitting.md
@@ -307,6 +307,18 @@ blocking discussed in `design/bezier_extraction_api.md`, and the natural unit fo
   across right-hand-side columns, and that is the first thing a profile should confirm or
   refute.
 
+- **Measured 2026-08-19, and it bounds where this note's accumulation rule applies.** The
+  C++ prototype adopted "accumulate in float64 even when the data is float32" for its first
+  ported kernel, a Cox-de Boor tabulation, citing this note. The rule turned out to be right
+  there for a *different* reason than the one given here: that kernel's state vector
+  round-trips through the float32 output array at every stage rather than living in a scalar
+  accumulator, and its measured float32 error is **flat in the degree**, not the
+  `sqrt(m) * eps32` growth of a length-`m` accumulation. What made the widening necessary was
+  parity, not accuracy -- numba's kernel promotes float32 intermediates to float64 as a side
+  effect of literal typing, and a port that computed in `float` throughout disagrees with it
+  by about one float32 ulp. The rule as stated here is for the fitting solves it was written
+  for; a kernel that stores its state in the output array is outside its argument.
+
 ## Open questions
 
 1. Which regimes must be supported: interpolation at full resolution, coarse

--- a/design/simd.md
+++ b/design/simd.md
@@ -243,7 +243,28 @@ another. It is not a performance option, it is a silent correctness change.
 - **Standard platform facts, stated from knowledge and worth a check:** the lane widths
   table; that AVX2 gather costs roughly 5 to 12 cycles and NEON has none; that sustained
   AVX-512 use downclocks on many Intel parts; that Apple Silicon has several NEON pipelines
-  and no SVE. None of these were measured here.
+  and no SVE. None of these were measured *here*, but see the next item for the third.
+- **Measured 2026-08-19 on the C++ prototype's cardinal B-spline kernel** (GCC 14.4.0,
+  `-O3`, 10^6 points, minimum over repeats), which is the measurement the ISA-variant
+  section gates itself on:
+
+  | target | degree 3 | degree 8 | fused sites |
+  |---|---:|---:|---:|
+  | baseline x86-64 | 10.47 ms | 50.73 ms | 0 |
+  | `-march=x86-64-v3` | 8.69 ms | 40.04 ms | 1 |
+  | `-march=native` (AVX-512 here) | 9.20 ms | 43.69 ms | 1 |
+
+  Three things follow. The gap is **real but modest**, 1.20x to 1.27x, so the ladder is a
+  decision rather than a free win. **`-march=native` is slower than `-march=x86-64-v3`** on
+  this machine, which measures the "AVX-512 can be slower" hazard above on one of pantr's own
+  kernels rather than asserting it. And the ISA introduces **exactly one** fused site, the
+  one the parity bound is derived around, confirming by disassembly that the fused set is
+  determinable from the source -- which is what the `-ffp-contract=on` choice rests on.
+- **Measured, and it corrects nothing here but is worth recording next to the flag
+  discussion:** with no `-march` the target has no FMA instruction at all, so
+  `-ffp-contract=on` fuses nothing and the C++ and numba backends agree **bit for bit**. The
+  parity tolerance this note calls for is therefore dormant on the shipped build and becomes
+  live exactly when the ladder is turned on.
 - **Asserted, not measured:** every expected-gain figure in the candidates table. They are
   upper bounds from lane width discounted for loop overhead and dependencies, not
   benchmarks. The purpose of the table is to rank candidates, not to predict outcomes.
@@ -257,7 +278,7 @@ another. It is not a performance option, it is a silent correctness change.
 1. Does the blocked contraction auto-vectorize? If yes, no batch abstraction is needed at
    all for the main kernel and xsimd never enters the dependency list.
 2. Is the block width `W` a compile-time constant per ISA variant, or a runtime parameter?
-   Compile-time composes with the `D13` multi-ISA build, which already compiles the module
+   Compile-time composes with the multi-ISA build below, which already compiles the module
    once per ISA, and lets the remainder handling be resolved at compile time.
 3. Should scattered-point evaluation be a documented slow path, given that it is the only
    case needing a gather and NEON cannot do one? This is the same

--- a/design/toolchain_requirements.md
+++ b/design/toolchain_requirements.md
@@ -4,8 +4,10 @@
 **Date:** 2026-08-19.
 **Scope:** what a compiler must provide to build pantr, how that is checked, and the flag
 decisions that live in the same CMake file.
-**Companions:** `design/simd.md` (which flags earn their place) and `design/isa_dispatch.md`
-(how variants are shipped). This note is about whether the build may proceed at all.
+**Companions:** `design/simd.md`, both for which flags earn their place and, in its
+"Shipping several ISA variants" section, for how variants are shipped. (Earlier drafts cited
+a `design/isa_dispatch.md`; that note was folded into `simd.md` and never existed as a file.)
+This note is about whether the build may proceed at all.
 
 **Validated against:** pantr **0.7.0** (`main`, tag `v0.7.0`), 2026-08-19. Line numbers
 below refer to that tree.
@@ -116,7 +118,7 @@ enforced once:
   offered behind an explicit option.
 - **The floating-point contraction flag goes on the interface target**, not on individual
   targets. Any flag that participates in a numerical claim must reach every variant, or the
-  ISA variants of `design/isa_dispatch.md` will disagree numerically with each other.
+  ISA variants of `design/simd.md` will disagree numerically with each other.
 
 ## CMake 4 is strict about what dependencies declare
 
@@ -159,14 +161,27 @@ lines of CMake, and the day it is needed is the day nobody wants to be writing t
 - **Verified:** that GCC 15.2 lacks `<mdspan>` while the laptop's Clang has it, which is what
   makes mdspan a toggle rather than a gate; that the sibling project gates only on
   `cxx_std_20`, so copying its CMake would not have caught GCC 10.
+- **Corrected 2026-08-19, on the reason rather than the fact:** the absence of `<mdspan>`
+  here is an *implementation gap*, not a consequence of the C++20 baseline.
+  `__cpp_lib_mdspan` is undefined under `-std=gnu++23` as well, so GCC 14's libstdc++ has
+  simply not implemented P0009, and the environment's Clang 18 inherits the absence because
+  it resolves to that same libstdc++ rather than to libc++. The plausible explanation --
+  "a C++23 header hidden by `-std=c++20`" -- predicts that C++23 makes it appear, and
+  measurably it does not.
 - **Measured on the build server (2026-08-19):** the conda environment shadows the system
   GCC 10 and Clang 10 with conda-forge GCC 14 and Clang 18.1.8, and **all three of `g++`,
   `clang++` and `x86_64-conda-linux-gnu-g++` pass a C++20 concepts probe**. `<mdspan>` is
   **absent** there, confirming on the actual build machine that the Kokkos fallback is
   required and not merely a precaution. CMake 4.4.2, Ninja 1.13.2, ccache 4.13.6.
-- **Consequently unanswered and now mostly moot:** what the probe reports on the *system*
-  GCC 10 and Clang 10, since the environment shadows them and the build will not use them.
-  What that would have told us is where the real floor sits.
+- **Measured 2026-08-19, and it answers open question 1 uncomfortably:** the system
+  GCC 10 and Clang 10 **both pass the concepts probe**, in the probe's real shape rather
+  than a toy one, and Clang 10 also **compiles and correctly runs** the prototype's kernel
+  (`(1-u)^3/6` at `u = 0.25`, to the last bit). GCC 9 fails, and fails early: it does not
+  accept `-std=c++20` at all. So the probe alone does not keep either 2020 compiler out.
+  The Clang 14 filter does, and it now rests on no observed failure -- which this note's own
+  rule forbids. One kernel is weak evidence about a whole library, so nothing was changed;
+  but the floor has moved from *unverified* to *measured and unsupported*, and that is a
+  different thing to leave in place.
 - **Stated from knowledge and explicitly uncertain:** the exact C++20 feature matrix of GCC 10
   and Clang 10, and the version at which Clang's concepts support became reliable. The
   Clang 14 floor above is a starting guess and should be replaced by whatever the probe run on
@@ -176,8 +191,11 @@ lines of CMake, and the day it is needed is the day nobody wants to be writing t
 
 ## Open questions
 
-1. What does the probe report on the development server's GCC 10 and Clang 10? That result
-   replaces the guessed Clang 14 floor with a measured one.
+1. ~~What does the probe report on the development server's GCC 10 and Clang 10?~~
+   **Answered 2026-08-19: both pass**, and Clang 10 additionally compiles and correctly runs
+   the ported kernel. See the epistemic status above. What remains open is the decision this
+   turns into: the filter is now known to reject a compiler that works on the evidence
+   available, and this note's own rule says the list may only grow from observed failures.
 2. Which compiler does `manylinux_2_28` provide? If it is older than the gate, the wheel build
    fails and either the image or the gate has to move.
 3. Should the gate run in the Python build path too, or only for a direct CMake configure?

--- a/design/toolchain_requirements.md
+++ b/design/toolchain_requirements.md
@@ -183,6 +183,14 @@ lines of CMake, and the day it is needed is the day nobody wants to be writing t
   configured with nothing said while a Clang 10 hit a hard stop, same year and same
   standard-library era, neither measured. The floor now means the lowest version actually
   exercised, which is a claim about us rather than about anyone's concepts implementation.
+- **The floor is verified locally and not by CI, deliberately.** `scripts/ci_local.sh`'s
+  `cxx` section builds and runs the tests with `g++-10` and `clang++-10` on every run, so the
+  claim is maintained rather than dated. The GitHub workflow does not: it runs GCC 14 and
+  Clang 18, and `ubuntu-24.04` does not package GCC 10, so covering the floor there would
+  need an older image or a container -- more weight than a prototype should carry. The
+  consequence is worth stating rather than discovering: **the floor is guaranteed by one
+  machine.** Anyone who cannot run `ci_local.sh` is trusting a measurement they cannot
+  reproduce.
 - **Stated from knowledge and explicitly uncertain:** the exact C++20 feature matrix of GCC 10
   and Clang 10, and the version at which Clang's concepts support became reliable. The
   Clang 14 floor above is a starting guess and should be replaced by whatever the probe run on

--- a/design/toolchain_requirements.md
+++ b/design/toolchain_requirements.md
@@ -175,13 +175,14 @@ lines of CMake, and the day it is needed is the day nobody wants to be writing t
   required and not merely a precaution. CMake 4.4.2, Ninja 1.13.2, ccache 4.13.6.
 - **Measured 2026-08-19, and it answers open question 1 uncomfortably:** the system
   GCC 10 and Clang 10 **both pass the concepts probe**, in the probe's real shape rather
-  than a toy one, and Clang 10 also **compiles and correctly runs** the prototype's kernel
-  (`(1-u)^3/6` at `u = 0.25`, to the last bit). GCC 9 fails, and fails early: it does not
-  accept `-std=c++20` at all. So the probe alone does not keep either 2020 compiler out.
-  The Clang 14 filter does, and it now rests on no observed failure -- which this note's own
-  rule forbids. One kernel is weak evidence about a whole library, so nothing was changed;
-  but the floor has moved from *unverified* to *measured and unsupported*, and that is a
-  different thing to leave in place.
+  than a toy one, and **both build the whole C++ tree under `-Werror` with the full warning
+  set and pass 3/3 ctest** -- not merely the one kernel. GCC 9 fails, and fails early: it
+  does not accept `-std=c++20` at all, so the concepts probe stops it before any version
+  check runs. **Acted on**: the floor is now 10, and it applies to GCC and Clang alike.
+  It had been 14 for Clang, on a guess, and *nothing at all for GCC* -- so a GCC 10
+  configured with nothing said while a Clang 10 hit a hard stop, same year and same
+  standard-library era, neither measured. The floor now means the lowest version actually
+  exercised, which is a claim about us rather than about anyone's concepts implementation.
 - **Stated from knowledge and explicitly uncertain:** the exact C++20 feature matrix of GCC 10
   and Clang 10, and the version at which Clang's concepts support became reliable. The
   Clang 14 floor above is a starting guess and should be replaced by whatever the probe run on

--- a/design/toolchain_requirements.md
+++ b/design/toolchain_requirements.md
@@ -205,8 +205,18 @@ lines of CMake, and the day it is needed is the day nobody wants to be writing t
    the ported kernel. See the epistemic status above. What remains open is the decision this
    turns into: the filter is now known to reject a compiler that works on the evidence
    available, and this note's own rule says the list may only grow from observed failures.
-2. Which compiler does `manylinux_2_28` provide? If it is older than the gate, the wheel build
-   fails and either the image or the gate has to move.
+2. ~~Which compiler does `manylinux_2_28` provide?~~ **Answered 2026-08-19: GCC 14**, on an
+   AlmaLinux 8 base, and `manylinux_2_34` (AlmaLinux 9) likewise. Both are far above the
+   floor of 10, so neither the image nor the gate has to move and this question closes
+   without consequences. (From the `pypa/manylinux` README rather than from running the
+   image; the margin is wide enough that the distinction does not change the conclusion.)
+
+   The answer does carry one thing nobody was looking for. **`manylinux_2_31`, the armv7l
+   image, ships GCC 9** -- which does not accept `-std=c++20` at all, measured on this
+   machine. So armv7l is not a case of the floor being in the way: it is **out of reach for
+   the C++ backend entirely**, at any floor compatible with the C++20 baseline this note
+   fixes. If pantr ever ships armv7l wheels they are Numba-only, and that is a packaging
+   consequence of `D4` rather than of anything decided here.
 3. Should the gate run in the Python build path too, or only for a direct CMake configure?
    scikit-build-core invokes CMake, so it inherits the gate, but the error surfaces inside a
    `pip install` log where it is much easier to miss.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["hatchling>=1.27"]
-build-backend = "hatchling.build"
+# scikit-build-core replaces hatchling because the wheel now contains a compiled
+# extension. nanobind is a BUILD requirement, not a runtime one: the extension
+# links it statically (NB_STATIC), so nothing imports nanobind at run time.
+requires = ["scikit-build-core>=0.10", "nanobind>=2.14"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "pantr"
@@ -101,16 +104,47 @@ Documentation = "https://pantr.readthedocs.io"
 Source = "https://github.com/FELIGN/pantr"
 Issues = "https://github.com/FELIGN/pantr/issues"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/pantr"]
+[tool.scikit-build]
+# The pure-Python package ships as it always did; CMake adds the extension
+# alongside it (see cpp/bindings/CMakeLists.txt for the install destination).
+wheel.packages = ["src/pantr"]
+cmake.version = ">=3.25"
+cmake.build-type = "Release"
+# Out of the Python build: the C++ tests and the benchmark are built by
+# CMakePresets, not by pip. Nothing that a `pip install` produces should depend
+# on Eigen having been fetched.
+cmake.define.PANTR_BUILD_PYTHON = "ON"
+cmake.define.PANTR_BUILD_TESTS = "OFF"
+cmake.define.PANTR_BUILD_BENCHMARK = "OFF"
+cmake.define.PANTR_WERROR = "ON"
+# Keep the symbol table in the INSTALLED extension. This prototype exists to be
+# measured, and a stripped module gives `perf` nothing to attribute time to and a
+# segfault nothing to build a backtrace from.
+#
+# It takes both this and NOSTRIP in cpp/bindings/CMakeLists.txt, because there are
+# two strippers and either one is enough on its own. nanobind's
+# `nanobind_add_module` strips at LINK time unless told not to; scikit-build-core
+# strips again at INSTALL time, and its default for that is derived from
+# `cmake.build-type` -- true for Release and MinSizeRel, which is exactly the
+# build being measured. Verified: with NOSTRIP alone the build tree's .so carried
+# 364 symbols while the installed one still reported "no symbols" to `nm`.
+#
+# The cost is disk. It does not change a single generated instruction, so no
+# measurement is affected by its presence.
+install.strip = false
+# A persistent build directory, so an editable rebuild is incremental. Without
+# it every `pip install -e .` reconfigures from scratch and re-clones Eigen,
+# which is the single most painful part of the worktree workflow.
+build-dir = "build/skbuild/{wheel_tag}"
+sdist.exclude = ["build", "design/_memory", ".github"]
 
 # Single source of truth for the version: `__version__` in the package __init__.
 # The explicit pattern is required because the assignment carries a type
-# annotation (`__version__: Final[str] = "..."`), which hatchling's default
-# regex does not match.
-[tool.hatch.version]
-path = "src/pantr/__init__.py"
-pattern = '^__version__[^=]*=\s*"(?P<version>[^"]+)"'
+# annotation (`__version__: Final[str] = "..."`), which no default regex matches.
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "src/pantr/__init__.py"
+regex = '^__version__[^=]*=\s*"(?P<value>[^"]+)"'
 
 [tool.importlinter]
 root_package = "pantr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,20 @@ source_modules = [
   "pantr.viz",
 ]
 forbidden_modules = ["pantr.mpi"]
+
+# pantr._backend answers "which backend is selected". The map from that answer to
+# the kernels themselves lives beside the kernels (pantr.basis._basis_backend and
+# one such module per ported package), because a catalogue has to import what it
+# hands out and its consumers import the policy -- so a catalogue here would close
+# a cycle that only lazy imports could hold open, one more per kernel ported.
+#
+# Indirect imports are allowed because every module reaches every other through
+# pantr/__init__.py: the probe `import pantr._pantr_cpp` pulls in the root package,
+# whose __init__ imports the library. The rule this contract exists for is about
+# the DIRECT dependency, which is the one a future edit would add.
+[[tool.importlinter.contracts]]
+name = "Backend policy must not import the library it selects for"
+type = "forbidden"
+source_modules = ["pantr._backend"]
+forbidden_modules = ["pantr.*"]
+allow_indirect_imports = true

--- a/reviews/cpp-infrastructure-2026-08-19.md
+++ b/reviews/cpp-infrastructure-2026-08-19.md
@@ -168,10 +168,17 @@ requirement, so a future release could silently break version single-sourcing.
 **R1-7 · Three spellings of "evaluation points"** across one vertical slice (`pts`, `t`,
 `points`); the adapter uses two of them in eight lines.
 
-**R1-8 · The seam's type was cut to fit the one kernel with no serial twin.**
+**R1-8 · The seam's type was cut to fit a kernel with no serial twin.**
 `_tabulate_basis_1D_impl_helper` takes a *pair* (parallel plus serial) and dispatches on
-`_PARALLEL_MIN_NUM_PTS`. Cardinal B-spline is the only basis kernel with no twin. Porting
-Bernstein next forces a second return shape for the same concept.
+`_PARALLEL_MIN_NUM_PTS`. Porting Bernstein next forces a second return shape for the same
+concept.
+
+*Corrected 2026-08-20.* This finding originally read "cardinal B-spline is the only basis
+kernel with no twin", and that is backwards: **Bernstein is the only 1D basis tabulation
+that has one.** Cardinal B-spline, Lagrange and Legendre all lack a twin, and
+`_basis_1D.py` passes `core_func_serial=` at exactly one of its four call sites. The
+conclusion is unaffected and better supported -- the bare callable fits three of the four
+kernels by coincidence, not one.
 
 ### Suggested and nitpick
 
@@ -247,9 +254,10 @@ here with their ruling.
   on the storage type. It encodes a project-wide policy from a basis-specific header, and
   the same rule currently answers differently depending on whether the scalar is a built-in.
 - **B · A `CoreKernels(parallel, serial)` record** for the seam, `serial=None` allowed. The
-  consumer already takes a pair and dispatches on `_PARALLEL_MIN_NUM_PTS`; cardinal B-spline
-  is the only basis kernel with no serial twin, which is the only reason a bare callable
-  fits. Porting Bernstein forces a second return shape for one concept.
+  consumer already takes a pair and dispatches on `_PARALLEL_MIN_NUM_PTS`, and Bernstein is
+  the only 1D basis tabulation that has a serial twin -- so the bare callable fits the
+  kernel ported so far by coincidence. Porting Bernstein forces a second return shape for
+  one concept. (See the correction under R1-8: this was first written the other way round.)
 - **C · Invert the `_backend` import cycle**: policy in `_backend`, catalogue beside each
   kernel. Removes two `noqa: PLC0415`, the `TYPE_CHECKING` import and the cycle itself, and
   lets `lint-imports` hold it with a one-line contract.

--- a/reviews/cpp-infrastructure-2026-08-19.md
+++ b/reviews/cpp-infrastructure-2026-08-19.md
@@ -1,0 +1,258 @@
+# Deep review: the C++ infrastructure prototype
+
+**Target:** branch `feat/cpp-infrastructure`, to be merged into `proto/cpp`. The C++ port's
+skeleton: CMake with configure-time gates, FetchContent for Kokkos mdspan and Eigen, a
+nanobind extension, one ported kernel, a dual-backend Python seam, and a parity harness.
+
+**Date:** 2026-08-19.
+**Machine:** shared Linux server, 20-CPU cap. conda-forge GCC 14.4.0 and Clang 18.1.8,
+CMake 4.4.2, Ninja 1.13.2, CPython 3.14.6, numba 0.65.1, numpy 2.4.6, nanobind 2.14.0.
+
+## Lenses
+
+**Run:** API and contracts (`api-auditor`) · architecture, adversarial (`architect`) ·
+mathematical claims, attack (`mathematician`) · tolerance policy (`tolerance-hunter`) ·
+dependency assumptions (`surveyor`, on nanobind) · test coverage (`test-writer`) · style
+conformance (`stylist`) · three regional `reviewer`s over the build files, the C++ tree, and
+the parity harness.
+
+**Skipped, with reasons:** `numerics-shakedown`, because parity against the oracle is
+bit-exact across degrees 0-16 in both dtypes and in and out of domain, the kernel is a
+verbatim port introducing no new algorithm, and the protocol writes to the repo.
+`optimizer`, because the performance question was measured directly during the work and its
+one finding (`-Os`) was fixed; the suite runs in 1.5 s. `doc-writer`, because the prototype
+has no docs-tree entry and `cpp/README.md` is its documentation, covered by the regional
+reviewers.
+
+## Findings
+
+Ranked. `C` critical, `I` important, `R` recommended, `S` suggested, `N` nitpick,
+`U` unconfirmed. Round 1.
+
+### Critical
+
+**C1-1 · `pantr::value_type_t` does not compile for any type it exists for.**
+`cpp/include/pantr/core/scalar.hpp`. The alias spells its lookup `detail::value_of(...)`, a
+*qualified* call, which suppresses ADL and so never finds a scalar type's hidden-friend
+`value_of` — the exact mistake the file spends ten lines warning about immediately above.
+Confirmed independently by three lenses, each compiling it: `value_type_t<Dual1>`, against
+the project's own test fixture, fails to compile. It survived because the alias has zero
+uses in the tree. **Failure scenario:** the first person to write the `Dual<T,N>` of
+`design/automatic_differentiation.md` reaches for the trait the design rests on and gets a
+template error from a header they did not write. **Direction:** the two-step ADL pattern the
+neighbouring `has_value_of` concept already gets right; four lines, and a `static_assert` so
+it cannot regress unused.
+
+**C1-2 · The binding turns a bad argument into memory corruption, reachable from one line
+of Python.** `cpp/bindings/pantr_cpp.cpp`. Reproduced here and by three lenses:
+`_pantr_cpp.tabulate_cardinal_bspline_1d(-1, pts, out)` exits with SIGSEGV, as does a call
+whose `out` is smaller than `(points.size, degree+1)`. `static_cast<std::size_t>(degree)` in
+the kernel turns `-1` into `SIZE_MAX`. The numba oracle returns normally on the same input.
+**Failure scenario:** CLAUDE.md records that a downstream consumer imports pantr's private
+symbols; the extension is importable and its `.pyi` invites a positional call with an
+unconstrained `degree: int`. **Direction:** validate at the binding, which is Layer 2's C++
+half — not in the kernel, which stays Layer 3. Three comparisons against an O(n·p²) kernel.
+
+**C1-3 · The B1 regression test does not test the fix it claims to pin.**
+`tests/test_cpp_parity.py`. Its docstring claims to pin both halves of the non-contiguous-`out`
+fix. A lens stripped `nb::arg("out").noconvert()` from the binding and the suite still passed
+119/119: the test goes through the public API, and the adapter in `pantr._backend` buffers a
+strided `out` before nanobind ever sees one. **Failure scenario:** the `.noconvert()` is
+removed in a later refactor and nothing notices, restoring a silent wrong-answer bug.
+**Direction:** call the raw binding directly and assert `TypeError`; correct the docstring to
+claim only what it tests.
+
+**C1-4 · The accuracy bound is violated by six orders of magnitude, one degree-list entry
+away from turning the suite red against correct code.** `tests/test_cpp_parity.py`,
+`_companion_bounds`. Every rounding is modelled as purely relative (`u·|x|`); in the gradual
+underflow range a rounding commits an *absolute* error floored at the smallest subnormal.
+Measured on the module's own oracle points, float32, error over bound: 0.353 at degree 8,
+**459 645 at degree 12**, **1 048 576 at degree 16**. `test_matches_the_exact_rational_oracle`
+escapes only because its degree list stops at 8 while `DEGREES` runs to 16. **Failure
+scenario:** the next contributor adds degree 12 — the natural thing to do — and the suite
+fails against a correct kernel, which is the most expensive kind of red. **Direction:**
+Higham's model with the `η` term, `η_fmt = smallest_subnormal`, added per accumulator
+rounding and per store.
+
+**C1-5 · `absolute_tolerance` has the same missing floor, at harness level.**
+`tests/_parity_harness.py`. Returns `2·γ·amplification`, purely relative. At float32,
+degree 11, `u = 1e-3`, the tolerance is 42.7× smaller than one subnormal ulp there, so a
+one-ulp disagreement would be rejected as a bound violation. Dormant only because parity is
+currently bitwise. **Failure scenario:** it becomes live the day `-march=x86-64-v3` lands,
+and **all five following PRs inherit it** regardless of what their kernels do.
+**Direction:** the same floor, expressed with the counts `Roundings` already carries — no new
+API surface. Reported inflation on every previously valid case is exactly 1.000000×.
+
+### Important
+
+**I1-1 · `use_backend` is not thread-safe, in a design that invites threading.**
+`src/pantr/_backend.py` mutates a module global under a context manager. Demonstrated
+deterministically: two overlapping blocks in two threads leave the process permanently on
+`CPP`; a thread reads `NUMBA` while the main thread is inside a `CPP` block. The binding
+releases the GIL specifically so callers can thread at the Python level, and `pytest -n` uses
+processes so the suite cannot see it. **Direction:** `contextvars.ContextVar`, six lines,
+same shape; state the semantic change (a spawned thread inherits the process default).
+
+**I1-2 · A masked array makes the two backends disagree at the public API.** Measured:
+numba raises `NumbaTypeError`, the C++ path accepts it through the buffer protocol, silently
+ignores the mask, and returns numbers. That is exactly what `_backend.py`'s docstring
+promises cannot happen. **Direction:** reject it in Layer 2; the numba behaviour is correct.
+
+**I1-3 · A wrong derivation in a C++ test, and the test does not discriminate what it
+claims.** `cpp/tests/test_cardinal_bspline.cpp`. The stated store count is `degree + 1`; the
+kernel performs `n(n+3)/2` — 65 at degree 10, not 11. The bound holds by a different argument
+(each stage is a stochastic map over non-negative values, so it adds at most `eps32` in the
+1-norm) and the measured error is *flat* in degree while the stated bound grows linearly.
+Separately, a mutant with `accumulator<float>::type = float` — disabling the whole point of
+the trait — still passes this test at every degree 0-20; the real protection is a
+`static_assert` in a different file.
+
+**I1-4 · nanobind strips the module, so nothing can be profiled or backtraced.**
+`nm` on the shipped `.so` reports "no symbols". In a prototype whose stated job is
+measurement and provenance, `perf` cannot name the kernel and C1-2's segfault gives no
+backtrace. **Direction:** `NOSTRIP` beside `NOMINSIZE`.
+
+**I1-5 · The `<mdspan>` toggle is structurally unreachable.** The probe body uses
+`view[1, 2]`, a C++23 *language* feature, while the probe is pinned to `-std=c++20` where
+that is the comma operator. `PANTR_HAS_STD_MDSPAN` can therefore only ever be OFF, even on a
+libstdc++ that does ship the header. **Direction:** probe `__cpp_lib_mdspan`, or use the
+`std::array` subscript form.
+
+**I1-6 · The offline-escape gate is vacuous on every from-scratch run.**
+`scripts/ci_local.sh` runs `gates` before `cxx`, and the offline check needs
+`build/gcc/_deps` populated, which only `cxx` does. So the one workflow meant to prove the
+escape works always SKIPs it. Honest, not a lying pass, but it proves nothing.
+
+**I1-7 · Four files misattribute the validation site.** `cpp/bindings/pantr_cpp.cpp` says the
+extent check "is checked in `src/pantr/_backend.py`". It is in
+`src/pantr/basis/_basis_1D.py`; `_backend.py`'s adapter explicitly disclaims validation.
+C1-2 makes this material — a reader chasing the guarantee looks in the wrong file.
+
+**I1-8 · `cardinal_bspline.hpp` calls the nanobind wrapper "the validating wrapper".**
+False, and it points a reader at the path that segfaults.
+
+**I1-9 · `requires_cpp_backend` is dead code that reintroduces the named silent-skip trap.**
+`tests/_parity_harness.py` exports it, nothing uses it, and it implements a plain skip with
+no `PANTR_REQUIRE_CPP` escalation. It is the obvious symbol for the author of PR 2 to reach
+for, and CLAUDE.md names that failure mode explicitly.
+
+**I1-10 · Two "measured" docstring claims do not hold.** The "96 unit roundoffs" figure is
+off by 2× in the file's own `u = eps/2` units (~192), and `OUTSIDE_DEGREES`'s stated overflow
+rationale is falsified by direct computation — the amplification *decreases* with degree at
+fixed `|u|`.
+
+### Recommended
+
+**R1-1 · `matrix.cc` is dead in the workflow**, so `CMAKE_C_COMPILER` is never pinned while
+Eigen's `project()` enables C implicitly. The Clang leg does not build entirely under Clang.
+
+**R1-2 · The `-ffinite-math-only` gate is weaker than its `-ffast-math` sibling** — it
+asserts only that configure failed, so an unrelated failure reads as the gate firing.
+
+**R1-3 · `ci_local.sh` writes to fixed `/tmp` paths** that collide between concurrent runs on
+this explicitly shared machine.
+
+**R1-4 · Build policy leaks into the library's usage requirements.** `pantr_core` links an
+interface target carrying `-Werror` and the whole warning set, so anything linking
+`pantr::core` inherits pantr's warning discipline. Latent today; a support burden the day the
+core is installable.
+
+**R1-5 · `CMakePresets.json` pins `jobs: 20`**, a machine-specific constant in a committed
+file, which already forced the workflow to bypass the presets — the exact drift presets exist
+to prevent.
+
+**R1-6 · `pyproject.toml` uses an already-deprecated scikit-build-core metadata API**
+(`tool.scikit-build.metadata`, which warns at build time) with no upper bound on the
+requirement, so a future release could silently break version single-sourcing.
+
+**R1-7 · Three spellings of "evaluation points"** across one vertical slice (`pts`, `t`,
+`points`); the adapter uses two of them in eight lines.
+
+**R1-8 · The seam's type was cut to fit the one kernel with no serial twin.**
+`_tabulate_basis_1D_impl_helper` takes a *pair* (parallel plus serial) and dispatches on
+`_PARALLEL_MIN_NUM_PTS`. Cardinal B-spline is the only basis kernel with no twin. Porting
+Bernstein next forces a second return shape for the same concept.
+
+### Suggested and nitpick
+
+**S1-1** No `.clang-format`/`.clang-tidy` in the tree, and no C++ format check anywhere; the
+four new headers are hand-formatted and consistent, which is luck rather than mechanism.
+**S1-2** `pantr::at` takes two adjacent `std::size_t` — Core Guidelines I.24, and a swap here
+silently transposes output. **S1-3** The Layer 3 kernel is not `noexcept`. **S1-4** The
+binding's header comment claims `nb::arg` is a compile-time tag in 2.x; it is a runtime
+struct there, and only a tag in 3.x. The conclusion holds, the reason does not.
+**N1-1** `accumulator_t` has no standalone docstring. **N1-2** `_ACTIVE` and `_CPP_AVAILABLE`
+document the identical "resolved once at import" behaviour asymmetrically.
+
+### Unconfirmed — worth a look
+
+**U1-1** The claim that GCC implements `-ffp-contract=on` distinctly from `fast` only since
+GCC 14 could not be settled here (no GCC 12/13 toolchain). It is load-bearing: the parity
+bound's derivation rests on the fused set being readable from the source. Cheapest check: a
+two-statement fusion probe on GCC 13 versus 14, diff the assembly.
+**U1-2** Compile time for one TU carrying every binding, times N ISA variants, times two
+scalar types. Not measurable at one kernel; the escape (explicit instantiation in a `.cpp`)
+stays available.
+**U1-3** Intermittent parity failures observed by one lens (`sums=0`, then `109 skipped`) that
+vanished on rerun, attributed to a concurrent editable rebuild racing the test process — the
+extension is a symlink into `build/skbuild`. Almost certainly environmental, and I caused at
+least one instance of it myself, but worth confirming no real reentrancy defect hides behind
+it before dismissing.
+
+## Where the code refuted a design note
+
+Recorded separately because the notes are sealed and the user rules on them.
+
+1. **`toolchain_requirements.md` open question 1 is answered, uncomfortably.** GCC 10 and
+   Clang 10 both pass the concepts probe *and* compile and correctly run the kernel. The
+   note's own rule is that the known-broken list "should only grow from observed failures,
+   never from speculation", and there is no observed failure behind the Clang < 14 entry.
+2. **The `<mdspan>` toggle, as implemented, is a permanent OFF** (I1-5). The note's
+   classification is right; the probe cannot express it. Separately, `mdspan.hpp`'s stated
+   reason for the absence was wrong (it is a libstdc++ implementation gap, not a
+   standard-version gate) and has been corrected in this branch.
+3. **`automatic_differentiation.md`'s "templates are enough" is not yet earned by the code.**
+   `Real` certifies a legitimate forward-mode `Dual` that the kernel then rejects with a
+   template dump — the concept is a strict subset of the kernel's actual requirements — and
+   `value_type_t` does not compile for it at all (C1-1).
+4. **`large_data_fitting.md`'s float64-accumulation rationale does not apply to this
+   kernel.** The state vector round-trips through float32 storage every stage, and the
+   measured float32 error is flat in degree, not `sqrt(m)·eps32`. The rule is right for the
+   fitting kernels it was written for; `accumulator_t` imports its justification into a
+   kernel where it does not hold.
+5. **`simd.md`'s AVX-512 hazard is now measured** on a pantr kernel rather than asserted:
+   `-march=native` (AVX-512 here) is slower than `-march=x86-64-v3`.
+6. **`design/isa_dispatch.md` is cited by two notes and does not exist.** Its content appears
+   to have been folded into `simd.md`.
+
+## Design questions left open for the user
+
+Not findings. Each is cheap now and expensive per kernel added.
+
+- Rank-generic `span_nd<T, Rank>` now, or the current rank-2 `span2d`? The notes already
+  specify rank 3 for extraction and strided reads for fitting. Three lines, zero call-site
+  churn, and it decides the signature every later kernel copies.
+- `std::constructible_from<T, double>` on `Real`, so the concept is the kernel's actual
+  contract.
+- Move `accumulator_t` to `core/` and key it on the value type rather than the storage type.
+- A `CoreKernels(parallel, serial)` record for the seam (R1-8).
+- Invert the `_backend` import cycle: policy in `_backend`, catalogue next to each kernel.
+  Two `noqa: PLC0415` comments currently document the cycle and no contract prevents its
+  growth.
+- Separate `Backend` (which family) from an `IsaVariant` axis (which build), before
+  `PANTR_BACKEND`'s accepted values are user-facing.
+- Make `_backend`'s surface public like `_parallel`'s, or mark it explicitly unstable.
+
+## What holds up
+
+The kernel is a faithful port: read line by line against the oracle by two lenses, and
+bit-exact against it across degrees 0-16 in both dtypes, inside and outside the domain. Every
+configure-time gate genuinely fires — the concepts hard gate, the version filter and its
+override, both math-flag refusals were each triggered by hand. The FetchContent SHAs match
+their claimed tags. A real wheel and a real sdist were built and inspected: `py.typed`, the
+stub and the extension present, version single-sourcing working, no nanobind runtime
+dependency. The `ParityClaim`/`Roundings` type design — a rounding *count* rather than a
+magnitude, with an underived tolerance made inexpressible — is the best-designed thing in the
+PR and should be the model for the rest. Six mutants of the kernel were each caught by 11 to
+89 of the 119 tests, and a bug injected into *both* backends simultaneously — the one case
+parity cannot see — was caught by the exact rational oracle at a ratio of 5×10¹⁴.

--- a/reviews/cpp-infrastructure-2026-08-19.md
+++ b/reviews/cpp-infrastructure-2026-08-19.md
@@ -281,6 +281,25 @@ here with their ruling.
 **Nothing from this review is left undecided.** Every finding was applied, and every design
 question was ruled on.
 
+**One follow-up needs a fact nobody here can see.** `CoreKernels(parallel, serial)` is
+unpacked where it reaches `_tabulate_basis_1D_impl_helper`, which still takes
+`core_func` and `core_func_serial` as separate parameters -- so the concept has a record on
+one side of the seam and two parameters on the other. Passing the record straight in is the
+clean end state and touches four call sites, all inside `src/pantr/basis/_basis_1D.py`.
+
+It was not done because that helper is long-standing private surface and CLAUDE.md records
+that a not-yet-public downstream consumer imports pantr private symbols, where pantr's CI
+cannot see the breakage. Two things make this safe to defer rather than urgent: the change
+would break **loudly** (a `TypeError` at the call), and unlike the six decisions above it
+does **not** get more expensive with a second kernel -- four call sites now, four later.
+
+What settles it is one grep in that consumer's repository for
+`_tabulate_basis_1D_impl_helper` (and, while there, `cardinal_bspline_core` and
+`_BasisCoreFunc`, which also moved in this branch). If it does not appear, make the change.
+If it does, the unpacking stays and the reason is recorded rather than rediscovered. The
+natural moment either way is the PR that ports Bernstein, which is the only 1D basis
+tabulation with a serial twin and so the first one to exercise the shape.
+
 ## Design questions left open for the user
 
 Not findings. Each is cheap now and expensive per kernel added.

--- a/reviews/cpp-infrastructure-2026-08-19.md
+++ b/reviews/cpp-infrastructure-2026-08-19.md
@@ -258,14 +258,20 @@ here with their ruling.
   so one spelling serves both branches. Removing the branch also makes `at` rank-generic,
   which is what `span_nd` now needs.
 
-**Still open, and deliberately.**
+- **E · Split `Backend` from an `IsaVariant` axis.** Two orthogonal questions -- which family
+  and which build of that family -- and folding the second into the first would multiply
+  `available_backends()`, the parse and every `if chosen is Backend.NUMBA` by their product.
+  Deciding it now is free; deciding it later changes the accepted values of an environment
+  variable, which is user-facing surface the moment anyone puts it in a script. The
+  measurement that gated stage 2 has now been taken, so that day is nearer than it was.
+- **F · Mark `pantr._backend` explicitly unstable** in its module docstring: scaffolding for
+  the duration of the port, removable when the port ends. Not made public like
+  `pantr._parallel`, despite being maintained to the same standard -- going public commits
+  to maintaining it past the point where its reason to exist has gone, and CLAUDE.md warns
+  that a downstream consumer already imports pantr private symbols where CI cannot see it.
 
-- Whether `Backend` should be split from an `IsaVariant` axis before `PANTR_BACKEND`'s
-  accepted values become user-facing surface.
-- Whether `pantr._backend` is made public like `pantr._parallel`, or marked explicitly
-  unstable in its own docstring. The recommendation on record is the latter: it is
-  scaffolding for the duration of the port, and CLAUDE.md warns that a downstream consumer
-  already imports pantr private symbols.
+**Nothing from this review is left undecided.** Every finding was applied, and every design
+question was ruled on.
 
 ## Design questions left open for the user
 

--- a/reviews/cpp-infrastructure-2026-08-19.md
+++ b/reviews/cpp-infrastructure-2026-08-19.md
@@ -225,6 +225,48 @@ Recorded separately because the notes are sealed and the user rules on them.
 6. **`design/isa_dispatch.md` is cited by two notes and does not exist.** Its content appears
    to have been folded into `simd.md`.
 
+## Design questions: ruled on
+
+Decided 2026-08-19, after the review. Four were applied in this PR and four are recorded
+here with their ruling.
+
+**Applied.**
+
+- **Rank-generic `span_nd<T, Rank>`**, with `span2d = span_nd<T, 2>` so no call site moved.
+  The layout stays `layout_right` until a kernel needs a stride.
+- **`std::constructible_from<T, double>` on `Real`**, so the concept is the kernel's contract
+  rather than a subset of it, pinned by a fixture the concept must reject.
+- **The version floor**, set to 10 for GCC and Clang alike from a measurement, and covered by
+  `scripts/ci_local.sh` on every run rather than by a one-off.
+- **A `pull_request` trigger scoped to `proto/cpp`**, after the workflow turned out to be
+  undispatchable, with the run cut to one compiler and cached.
+
+**Approved, not yet applied.** Each is cheaper now, with one kernel, than after the second:
+
+- **A · Move `accumulator_t` to `core/scalar.hpp`** and key it on `value_type_t` rather than
+  on the storage type. It encodes a project-wide policy from a basis-specific header, and
+  the same rule currently answers differently depending on whether the scalar is a built-in.
+- **B · A `CoreKernels(parallel, serial)` record** for the seam, `serial=None` allowed. The
+  consumer already takes a pair and dispatches on `_PARALLEL_MIN_NUM_PTS`; cardinal B-spline
+  is the only basis kernel with no serial twin, which is the only reason a bare callable
+  fits. Porting Bernstein forces a second return shape for one concept.
+- **C · Invert the `_backend` import cycle**: policy in `_backend`, catalogue beside each
+  kernel. Removes two `noqa: PLC0415`, the `TYPE_CHECKING` import and the cycle itself, and
+  lets `lint-imports` hold it with a one-line contract.
+- **D · Make `pantr::at` variadic and drop its `#if`.** Its stated premise is false: Kokkos
+  0.6.0 provides `operator[](const std::array<I, rank()>&)` unconditionally, as C++23 does,
+  so one spelling serves both branches. Removing the branch also makes `at` rank-generic,
+  which is what `span_nd` now needs.
+
+**Still open, and deliberately.**
+
+- Whether `Backend` should be split from an `IsaVariant` axis before `PANTR_BACKEND`'s
+  accepted values become user-facing surface.
+- Whether `pantr._backend` is made public like `pantr._parallel`, or marked explicitly
+  unstable in its own docstring. The recommendation on record is the latter: it is
+  scaffolding for the duration of the port, and CLAUDE.md warns that a downstream consumer
+  already imports pantr private symbols.
+
 ## Design questions left open for the user
 
 Not findings. Each is cheap now and expensive per kernel added.

--- a/scripts/bench_parity.py
+++ b/scripts/bench_parity.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+"""Time the C++ cardinal B-spline kernel against the numba one it is ported from.
+
+The number this prototype exists to produce. Run it as::
+
+    python scripts/bench_parity.py
+    python scripts/bench_parity.py --degrees 3 --points 1000 1000000
+
+Two levels, because one level cannot answer the question
+---------------------------------------------------------
+
+The first version of this script compared the numba kernel called *directly*
+against the C++ kernel called *through the public Python entry point*, and
+concluded the port was three times slower. That comparison was wrong, and wrong
+in the direction that would have killed the prototype: it charged the C++ side
+for the binding, the Layer 2 validation and the numpy round trip while charging
+the numba side for none of them.
+
+So both levels are measured, each with both backends on the same footing:
+
+``kernel``
+    The compiled kernel alone. numba's ``_tabulate_cardinal_Bspline_basis_1D_core``
+    against the raw nanobind function ``pantr._pantr_cpp.tabulate_cardinal_bspline_1d``.
+    Both take ``(degree, points, out)`` with ``out`` preallocated, so neither
+    allocates and neither validates. **This is the port's own figure.**
+
+``entry``
+    :func:`pantr.basis.tabulate_cardinal_bspline_1d`, once per backend. Identical
+    Layer 2 validation, identical allocation, identical dispatch on both sides;
+    the only difference is which kernel runs underneath. **This is what a caller
+    experiences.**
+
+The gap between the two columns is the fixed cost of the Python entry point, and
+it is paid by both backends. Reporting only ``entry`` hides how good the kernel
+is; reporting only ``kernel`` hides that most callers will never see it.
+
+Threads
+-------
+
+The C++ kernel is single-threaded. The numba kernel is ``parallel=True``
+*unconditionally* -- unlike the Bernstein kernels it has no serial twin and so
+never dispatches to one, paying a fork/join even for three points. It is
+therefore timed twice: on every thread, and on one thread via
+``numba.set_num_threads(1)``, which lowers the count around a single compiled
+kernel. **The one-thread column is the like-for-like comparison.**
+
+Two things that would make the numbers lie, and how they are avoided
+--------------------------------------------------------------------
+
+**JIT compilation.** A numba kernel's first call includes compiling it, of the
+order of a second, which would swamp everything. Every timed callable is run
+once untimed first, and ``wait_for_jit_warmup`` is awaited before anything --
+the background warmup thread ``pantr/__init__.py`` starts is not safe against a
+concurrent ``parallel=True`` call from another thread, and the failure mode is
+an abort rather than an exception.
+
+**The clock.** The reported figure is the *minimum* over repeats, not the mean.
+Timing noise on a shared machine is one-sided: interference can only make a run
+slower. The minimum is the best estimate of the true cost; the mean measures how
+busy the server was.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from collections.abc import Callable
+from typing import Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._backend import Backend, available_backends, use_backend
+from pantr._numba_compat import wait_for_jit_warmup
+from pantr.basis import tabulate_cardinal_bspline_1d
+from pantr.basis._basis_core import _tabulate_cardinal_Bspline_basis_1D_core
+
+DEFAULT_DEGREES: Final[tuple[int, ...]] = (1, 2, 3, 5, 8)
+"""Degrees timed by default: the range isogeometric analysis actually uses."""
+
+DEFAULT_POINT_COUNTS: Final[tuple[int, ...]] = (100, 4_096, 100_000, 1_000_000)
+"""Point counts timed by default.
+
+Spanning four orders of magnitude, because the answer changes across them: at
+100 points a numba launch costs more than the arithmetic it distributes, and at
+10^6 both kernels are streaming memory and the gap should close. A measurement
+taken at one size reports whichever of those regimes it landed in.
+
+4096 is ``_PARALLEL_MIN_NUM_PTS``, the count at which the *Bernstein* kernels
+switch to their serial twin. This kernel has no twin and does not switch, but
+the threshold is the library's own estimate of where a parallel launch starts
+paying for itself, which makes it a meaningful place to look.
+"""
+
+DEFAULT_REPEATS: Final[int] = 7
+"""Repeats per case. The reported figure is the minimum over these."""
+
+
+class Timing(NamedTuple):
+    """One case's measurements, in seconds.
+
+    A named record rather than a dict, per the project's convention that a fixed
+    set of named values is never carried in a mapping.
+
+    Attributes:
+        degree (int): Degree of the basis.
+        num_pts (int): Number of evaluation points.
+        numba_kernel_par (float): numba kernel alone, every thread.
+        numba_kernel_1thr (float): numba kernel alone, one thread.
+        cpp_kernel (float): C++ kernel alone, through the raw binding.
+        numba_entry (float): Public entry point on the numba backend.
+        cpp_entry (float): Public entry point on the C++ backend.
+    """
+
+    degree: int
+    num_pts: int
+    numba_kernel_par: float
+    numba_kernel_1thr: float
+    cpp_kernel: float
+    numba_entry: float
+    cpp_entry: float
+
+    @property
+    def kernel_speedup(self) -> float:
+        """Speedup of the C++ kernel over the one-thread numba kernel.
+
+        The like-for-like figure, and the port's own: both single-threaded, both
+        called directly, neither allocating or validating.
+
+        Returns:
+            float: Ratio of one-thread numba kernel time to C++ kernel time.
+        """
+        return self.numba_kernel_1thr / self.cpp_kernel
+
+    @property
+    def entry_speedup(self) -> float:
+        """Speedup at the public entry point, backend against backend.
+
+        Returns:
+            float: Ratio of numba entry-point time to C++ entry-point time.
+        """
+        return self.numba_entry / self.cpp_entry
+
+    @property
+    def entry_overhead(self) -> float:
+        """Seconds the Python entry point adds on top of the C++ kernel.
+
+        Paid by both backends, so it is neither backend's fault; reported so the
+        two columns can be read against each other.
+
+        Returns:
+            float: Difference between the C++ entry-point and kernel times.
+        """
+        return self.cpp_entry - self.cpp_kernel
+
+
+def _best_of(call: Callable[[], object], repeats: int) -> float:
+    """Time a zero-argument callable, returning the minimum elapsed time.
+
+    Args:
+        call (Callable[[], object]): The callable to time.
+        repeats (int): Number of timed repetitions.
+
+    Returns:
+        float: The smallest elapsed time, in seconds.
+    """
+    call()  # Warm: JIT compilation, first-touch page faults, cache.
+    best = float("inf")
+    for _ in range(repeats):
+        start = time.perf_counter()
+        call()
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+def _time_case(degree: int, num_pts: int, repeats: int) -> Timing:
+    """Time both kernels and both entry points for one case.
+
+    Args:
+        degree (int): Degree of the basis.
+        num_pts (int): Number of evaluation points.
+        repeats (int): Repetitions per measurement.
+
+    Returns:
+        Timing: The five measurements.
+    """
+    import numba  # noqa: PLC0415  (imported here so --help works without it)
+
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent unless the port is built)
+
+    pts: npt.NDArray[np.float64] = np.linspace(0.0, 1.0, num_pts, dtype=np.float64)
+    out: npt.NDArray[np.float64] = np.empty((num_pts, degree + 1), dtype=np.float64)
+    n = np.int32(degree)
+
+    max_threads = numba.get_num_threads()
+
+    numba.set_num_threads(max_threads)
+    numba_kernel_par = _best_of(
+        lambda: _tabulate_cardinal_Bspline_basis_1D_core(n, pts, out), repeats
+    )
+
+    # set_num_threads can only LOWER the count -- NUMBA_NUM_THREADS is read once
+    # at import and cannot be raised afterwards -- which is the direction needed.
+    numba.set_num_threads(1)
+    try:
+        numba_kernel_1thr = _best_of(
+            lambda: _tabulate_cardinal_Bspline_basis_1D_core(n, pts, out), repeats
+        )
+    finally:
+        numba.set_num_threads(max_threads)
+
+    # The raw binding, not the entry point: same contract as the numba kernel
+    # above, so the two are comparable.
+    cpp_kernel = _best_of(
+        lambda: _pantr_cpp.tabulate_cardinal_bspline_1d(degree, pts, out), repeats
+    )
+
+    with use_backend(Backend.NUMBA):
+        numba_entry = _best_of(lambda: tabulate_cardinal_bspline_1d(degree, pts, out=out), repeats)
+    with use_backend(Backend.CPP):
+        cpp_entry = _best_of(lambda: tabulate_cardinal_bspline_1d(degree, pts, out=out), repeats)
+
+    return Timing(
+        degree=degree,
+        num_pts=num_pts,
+        numba_kernel_par=numba_kernel_par,
+        numba_kernel_1thr=numba_kernel_1thr,
+        cpp_kernel=cpp_kernel,
+        numba_entry=numba_entry,
+        cpp_entry=cpp_entry,
+    )
+
+
+def _format_table(timings: list[Timing]) -> str:
+    """Render the measurements as a fixed-width table, times in milliseconds.
+
+    Args:
+        timings (list[Timing]): The measurements to render.
+
+    Returns:
+        str: The rendered table.
+    """
+    header = (
+        f"{'deg':>4} {'points':>9} | {'nb par':>9} {'nb 1thr':>9} {'cpp':>9} {'kernel':>8}"
+        f" | {'nb entry':>9} {'cpp entry':>9} {'entry':>8}"
+    )
+    lines = [header, "-" * len(header)]
+    for t in timings:
+        lines.append(
+            f"{t.degree:>4} {t.num_pts:>9} | "
+            f"{t.numba_kernel_par * 1e3:>9.3f} {t.numba_kernel_1thr * 1e3:>9.3f} "
+            f"{t.cpp_kernel * 1e3:>9.3f} {t.kernel_speedup:>7.2f}x | "
+            f"{t.numba_entry * 1e3:>9.3f} {t.cpp_entry * 1e3:>9.3f} {t.entry_speedup:>7.2f}x"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Run the benchmark and print the table.
+
+    Returns:
+        int: Process exit status; 1 if the C++ backend is not available.
+    """
+    parser = argparse.ArgumentParser(description="C++ against numba, kernel and entry point")
+    parser.add_argument("--degrees", type=int, nargs="+", default=list(DEFAULT_DEGREES))
+    parser.add_argument("--points", type=int, nargs="+", default=list(DEFAULT_POINT_COUNTS))
+    parser.add_argument("--repeats", type=int, default=DEFAULT_REPEATS)
+    args = parser.parse_args()
+
+    if Backend.CPP not in available_backends():
+        print(
+            "The C++ backend is not available in this installation, so there is\n"
+            "nothing to compare against.\n"
+            "  Fix: pip install -e . --no-build-isolation"
+        )
+        return 1
+
+    # numba's background warmup thread is not safe against a concurrent
+    # parallel=True call: the process aborts rather than raising. See CLAUDE.md.
+    wait_for_jit_warmup()
+
+    import numba  # noqa: PLC0415
+
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    print(f"numba threads:  {numba.get_num_threads()}")
+    print(f"C++ built by:   {_pantr_cpp.__compiler__}")
+    print(f"FMA on target:  {_pantr_cpp.__fp_contract__}")
+    print("this kernel is parallel=True unconditionally; it has no serial twin")
+    print()
+
+    timings = [
+        _time_case(degree, num_pts, args.repeats)
+        for degree in args.degrees
+        for num_pts in args.points
+    ]
+    print(_format_table(timings))
+    print(
+        "\nTimes in ms, minimum over repeats.\n"
+        "  'kernel' -- C++ against ONE numba thread, both called directly. The port's figure.\n"
+        "  'entry'  -- both through the public entry point. What a caller sees.\n"
+        "The gap between the two is the Python entry point's fixed cost, paid by both."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -444,14 +444,19 @@ python_checks() {
         return 0
     fi
 
-    # An explicit backend request that cannot be served must FAIL rather than
-    # fall back. This is the rule that makes every A/B measurement in this
-    # prototype trustworthy, so it is asserted rather than assumed.
-    if PANTR_BACKEND=nonesuch python -c "import pantr" 2>/dev/null; then
-        record FAIL "unknown PANTR_BACKEND fails loudly" "import SUCCEEDED"
-    else
-        record PASS "unknown PANTR_BACKEND fails loudly"
-    fi
+    # An explicit request that cannot be served must FAIL rather than fall back.
+    # This is the rule that makes every A/B measurement in this prototype
+    # trustworthy, so it is asserted rather than assumed -- on both selection
+    # axes, because they are two variables answering two questions and a rule
+    # asserted on one of them says nothing about the other.
+    local var
+    for var in PANTR_BACKEND PANTR_ISA_VARIANT; do
+        if env "$var=nonesuch" python -c "import pantr" 2>/dev/null; then
+            record FAIL "unknown $var fails loudly" "import SUCCEEDED"
+        else
+            record PASS "unknown $var fails loudly"
+        fi
+    done
 
     check "parity: C++ vs numba" python -m pytest tests/test_cpp_parity.py -q
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,491 @@
+#!/usr/bin/env bash
+#
+# The full local check for the C++ prototype, run before pushing.
+#
+# CI for this branch is workflow_dispatch-only (.github/workflows/cpp.yaml), so
+# this script -- not GitHub -- is where the prototype is actually checked. It is
+# written to be the thing whose output answers the questions the prototype
+# exists to ask, rather than a wrapper that prints "ok".
+#
+# Usage:
+#     scripts/ci_local.sh              # everything
+#     scripts/ci_local.sh gates        # only the configure-time gate checks
+#     scripts/ci_local.sh cxx          # only the two C++ toolchains
+#     scripts/ci_local.sh python       # only the extension, parity and backends
+#     scripts/ci_local.sh discipline   # only the source-level rule guards
+#     scripts/ci_local.sh splitmode    # only the nanobind split-mode probe
+#
+# Run it inside the pantr conda environment (`conda activate pantr`), which is
+# where the two compilers and the pinned CMake live.
+#
+# ---------------------------------------------------------------------------
+# The CPU budget
+# ---------------------------------------------------------------------------
+#
+# This is a shared 160-CPU server and the work is capped at 20 CPUs. The cap is
+# already enforced twice -- `taskset -cp 0-19 $$` in ~/.bashrc, inherited by
+# every child, and CMAKE_BUILD_PARALLEL_LEVEL / CTEST_PARALLEL_LEVEL in the
+# environment's activate.d. This script therefore does NOT set -j itself, with
+# one exception: the CMakePresets carry an explicit `jobs: 20`, because a preset
+# is also read by editors and CI images that never sourced the activate.d.
+#
+# Never add `-j$(nproc)` or `pytest -n auto` here: both size themselves from
+# os.cpu_count(), which reports 160 and steps straight over the affinity mask.
+
+set -euo pipefail
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+readonly VENV="$ROOT/.venv"
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+#
+# Every check appends one line to a summary printed at the end. A run that
+# scrolls a thousand lines of compiler output and finishes with a bare exit code
+# tells the reader nothing about which of the prototype's questions is still
+# open, which is the whole point of running it.
+
+declare -a RESULTS=()
+FAILED=0
+
+# Per-run log directory.
+#
+# These used to be fixed paths under /tmp (`pantr_ci_step.log` and friends). This
+# is a SHARED machine and several agents run this script at once, so two runs
+# overwrote each other's logs and the tail printed after a failure could belong to
+# the other run. A run-scoped directory removes the question.
+LOGDIR="$(mktemp -d -t pantr_ci_XXXXXXXX)"
+readonly LOGDIR
+
+# Scratch directory for the throwaway configure trees the gate checks build.
+# Empty until `gates` runs; the trap tolerates that.
+tmp=""
+
+# The logs are kept on failure and removed on success: they are worth reading
+# exactly when something went wrong, and a path printed after the directory has
+# been deleted is worse than no path at all.
+cleanup() {
+    [[ -n "$tmp" ]] && rm -rf "$tmp"
+    if [[ "$FAILED" -eq 0 ]]; then
+        rm -rf "$LOGDIR"
+    else
+        printf '\nFull logs for this run: %s\n' "$LOGDIR"
+    fi
+    return 0
+}
+trap cleanup EXIT
+
+step() { printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
+
+record() {
+    local status="$1" name="$2" detail="${3:-}"
+    RESULTS+=("$(printf '%-7s %-38s %s' "$status" "$name" "$detail")")
+    [[ "$status" == "FAIL" ]] && FAILED=1
+    return 0
+}
+
+# Run a command, record PASS/FAIL, never abort the whole script on failure:
+# a run that stops at the first problem hides the other five.
+check() {
+    local name="$1"; shift
+    if "$@" >"$LOGDIR/step.log" 2>&1; then
+        record PASS "$name"
+    else
+        record FAIL "$name" "(see output above)"
+        tail -40 "$LOGDIR/step.log"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# gates -- the configure-time behaviour of design/toolchain_requirements.md
+# --------------------------------------------------------------------------
+#
+# Each of these asserts that a gate FIRES, not merely that a good toolchain
+# builds. A gate nobody has ever seen reject anything is not known to be a gate.
+
+gates() {
+    step "Configure-time gates"
+
+    # Script-scoped and cleaned by the EXIT trap, NOT function-local with a
+    # RETURN trap: a RETURN trap fires again as the script itself unwinds, by
+    # which point a `local` is out of scope, and `set -u` then kills the run
+    # with "tmp: unbound variable" AFTER the summary has printed "All checks
+    # passed". The exit status said 1 while the output said 0.
+    tmp="$(mktemp -d)"
+
+    # The -ffast-math refusal must actually refuse. This is the check most
+    # likely to rot: the guard lives in cmake/PantrCompileOptions.cmake and
+    # matches flag strings, so a reformat of that loop can silently stop
+    # matching while the build still succeeds.
+    if cmake -S . -B "$tmp/fastmath" -G Ninja \
+             -DCMAKE_CXX_FLAGS="-ffast-math" \
+             -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+             >"$tmp/fastmath.log" 2>&1; then
+        record FAIL "-ffast-math is refused" "configure SUCCEEDED; the guard did not fire"
+    elif grep -q "pantr refuses to build with -ffast-math" "$tmp/fastmath.log"; then
+        record PASS "-ffast-math is refused"
+    else
+        record FAIL "-ffast-math is refused" "configure failed for some other reason"
+        tail -20 "$tmp/fastmath.log"
+    fi
+
+    # Same for -ffinite-math-only, which is banned for an additional reason:
+    # it licenses the compiler to delete the checks that detect a degenerate
+    # input.
+    #
+    # The message is grepped for, exactly as above. Asserting only that configure
+    # FAILED is not the same assertion: a typo in the flag name, an unrelated
+    # CMake error, or a missing compiler all make configure fail too, and this
+    # check would have gone on reporting PASS for a guard that had stopped firing.
+    if cmake -S . -B "$tmp/finite" -G Ninja \
+             -DCMAKE_CXX_FLAGS="-ffinite-math-only" \
+             -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+             >"$tmp/finite.log" 2>&1; then
+        record FAIL "-ffinite-math-only is refused" "configure SUCCEEDED; the guard did not fire"
+    elif grep -q "pantr refuses to build with -ffinite-math-only" "$tmp/finite.log"; then
+        record PASS "-ffinite-math-only is refused"
+    else
+        record FAIL "-ffinite-math-only is refused" "configure failed for some other reason"
+        tail -20 "$tmp/finite.log"
+    fi
+
+    # The concepts probe must reject a compiler that lacks concepts. GCC 9 is
+    # the one to hand on this machine: it does not even accept -std=c++20, so
+    # it exercises the gate rather than the version filter below it.
+    if [[ -x /usr/bin/g++-9 ]]; then
+        if cmake -S . -B "$tmp/gcc9" -G Ninja \
+                 -DCMAKE_CXX_COMPILER=/usr/bin/g++-9 \
+                 -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+                 >"$tmp/gcc9.log" 2>&1; then
+            record FAIL "concepts gate rejects GCC 9" "configure SUCCEEDED"
+        elif grep -qE "requires working C\+\+20 concepts|C\+\+20|std=c\+\+20" "$tmp/gcc9.log"; then
+            record PASS "concepts gate rejects GCC 9"
+        else
+            record FAIL "concepts gate rejects GCC 9" "rejected, but not by the gate"
+        fi
+    else
+        record SKIP "concepts gate rejects GCC 9" "/usr/bin/g++-9 absent"
+    fi
+
+    # The known-broken-compiler filter, and its documented override. Clang 10
+    # PASSES the concepts probe and compiles this prototype's kernel correctly
+    # (measured), so the filter -- not the probe -- is what keeps it out. Both
+    # halves are asserted: that it rejects, and that the escape hatch works.
+    if [[ -x /usr/bin/clang++-10 ]]; then
+        if cmake -S . -B "$tmp/clang10" -G Ninja \
+                 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 \
+                 -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+                 >"$tmp/clang10.log" 2>&1; then
+            record FAIL "version filter rejects Clang 10" "configure SUCCEEDED"
+        elif grep -q "known-incomplete concepts support" "$tmp/clang10.log"; then
+            record PASS "version filter rejects Clang 10"
+        else
+            record FAIL "version filter rejects Clang 10" "rejected, but not by the filter"
+        fi
+
+        if cmake -S . -B "$tmp/clang10ovr" -G Ninja \
+                 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 \
+                 -DPANTR_ALLOW_UNTESTED_COMPILER=ON \
+                 -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+                 >"$tmp/clang10ovr.log" 2>&1; then
+            record PASS "PANTR_ALLOW_UNTESTED_COMPILER overrides it"
+        else
+            record FAIL "PANTR_ALLOW_UNTESTED_COMPILER overrides it" "still rejected"
+        fi
+    else
+        record SKIP "version filter rejects Clang 10" "/usr/bin/clang++-10 absent"
+    fi
+
+    # The offline escape. FETCHCONTENT_FULLY_DISCONNECTED with a populated
+    # source dir must configure without touching the network; this is the path
+    # a cluster compute node needs and the day it is needed is the day nobody
+    # wants to be discovering it.
+    #
+    # The sources have to come from somewhere, and where they used to come from
+    # was build/gcc/_deps -- which `cxx` creates and `main` runs AFTER this
+    # function. So on any from-scratch run this check SKIPped, every time, and the
+    # escape it exists to exercise was never once exercised. It now populates its
+    # own copy when that directory is absent, which fixes the ordering and makes
+    # `ci_local.sh gates` self-contained as a bonus.
+    #
+    # PANTR_BUILD_TESTS is left ON in both configures below, and has to be: Eigen
+    # is only declared when the tests are built (cmake/PantrDependencies.cmake),
+    # so with tests OFF there would be no eigen-src to point at and the check
+    # would pass while testing half of what it claims.
+    local deps_root="$ROOT/build/gcc/_deps"
+    local have_deps=1
+    if [[ ! -d "$deps_root/mdspan-src" || ! -d "$deps_root/eigen-src" ]]; then
+        if cmake -S . -B "$tmp/fetch" -G Ninja -DPANTR_BUILD_PYTHON=OFF \
+                 >"$LOGDIR/fetch.log" 2>&1; then
+            deps_root="$tmp/fetch/_deps"
+        else
+            have_deps=0
+        fi
+    fi
+
+    if [[ "$have_deps" -eq 0 ]]; then
+        # A genuine SKIP rather than a FAIL: with no network and no prior build
+        # there is nothing to point the disconnected configure at, and that is a
+        # property of the machine rather than of the tree.
+        record SKIP "offline escape configures" "could not populate _deps to point at"
+        tail -20 "$LOGDIR/fetch.log"
+    elif cmake -S . -B "$tmp/offline" -G Ninja \
+               -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+               -DFETCHCONTENT_SOURCE_DIR_MDSPAN="$deps_root/mdspan-src" \
+               -DFETCHCONTENT_SOURCE_DIR_EIGEN="$deps_root/eigen-src" \
+               -DPANTR_BUILD_PYTHON=OFF \
+               >"$tmp/offline.log" 2>&1; then
+        record PASS "offline escape configures"
+    else
+        record FAIL "offline escape configures"
+        tail -20 "$tmp/offline.log"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# cxx -- both toolchains, from scratch
+# --------------------------------------------------------------------------
+#
+# Each compiler gets its own build directory, and each is DELETED first. Probe
+# results are cached in CMakeCache.txt, so a reused directory can answer for the
+# compiler that configured it rather than the one being tested -- the failure
+# mode design/toolchain_requirements.md flags as worth an afternoon.
+
+cxx() {
+    step "C++ toolchains"
+
+    local preset
+    for preset in gcc clang; do
+        rm -rf "$ROOT/build/$preset"
+        check "$preset: configure" cmake --preset "$preset"
+        check "$preset: build (-Werror)" cmake --build --preset "$preset"
+        check "$preset: ctest" ctest --preset "$preset"
+    done
+
+    # The mdspan toggle is a decision the build makes silently; print which way
+    # it went, because "which mdspan am I actually using" is the first question
+    # asked when a build behaves oddly.
+    local which_mdspan="Kokkos reference implementation"
+    if grep -q "^PANTR_HAS_STD_MDSPAN:INTERNAL=1$" "$ROOT/build/gcc/CMakeCache.txt" 2>/dev/null; then
+        which_mdspan="<mdspan> from the standard library"
+    fi
+    record INFO "mdspan implementation" "$which_mdspan"
+}
+
+# --------------------------------------------------------------------------
+# discipline -- the source-level rules no compiler enforces
+# --------------------------------------------------------------------------
+#
+# The four disciplines of design/automatic_differentiation.md, which a
+# scalar-generic core has to keep if a forward-mode `Dual` is ever to be dropped
+# in.
+#
+# Most of them are NOT checked here, and that is the right answer rather than a
+# gap: cpp/tests/test_scalar_generic.cpp defines a `Dual1` with the five
+# arithmetic operators and deliberately WITHOUT `operator==`, without ordering
+# and without a conversion to `double`, then instantiates the kernel on it. So a
+# comparison that bypasses `value_of`, a `floor` on the scalar, or an integer
+# cast of it all fail to COMPILE. A type system that rejects the violation beats
+# a regular expression that reports it, and the check that matters is therefore
+# that the fixture still exists and is still instantiated.
+#
+# What is left for grep is the one discipline the compiler cannot see: a
+# qualified call. `std::sqrt(x)` compiles perfectly for `double` AND for a
+# `Dual` that happens to be convertible to one, while silently computing the
+# wrong thing.
+
+discipline() {
+    step "Scalar-generic disciplines"
+
+    local hits
+
+    # The compile-time enforcement itself. If this fixture stops instantiating
+    # the kernel, three of the four disciplines quietly stop being checked at
+    # all and nothing else in this script would notice.
+    if grep -q 'static_assert(pantr::Real<Dual1>' "$ROOT/cpp/tests/test_scalar_generic.cpp" \
+       && grep -q '!std::equality_comparable<Dual1>' "$ROOT/cpp/tests/test_scalar_generic.cpp" \
+       && grep -q 'tabulate_cardinal_bspline_1d<Dual1>' "$ROOT/cpp/tests/test_scalar_generic.cpp"; then
+        record PASS "Dual fixture still enforces Tier B"
+    else
+        record FAIL "Dual fixture still enforces Tier B" \
+               "test_scalar_generic.cpp no longer pins the concept or the instantiation"
+    fi
+
+    # Discipline 3: unqualified math calls with a using-declaration.
+    # `std::sqrt(x)` names the overload directly, suppressing ADL, which is
+    # exactly how a user-defined scalar's own overload gets excluded. The
+    # comment in cpp/include/pantr/core/scalar.hpp promises this guard exists.
+    #
+    # Two exclusions, both deliberate. Comment lines are stripped, because the
+    # rule is stated in prose in several headers and a guard that fires on its
+    # own documentation gets switched off within a week. And cpp/tests and
+    # cpp/benchmark are out of scope: they are instantiated on concrete `double`
+    # and `float`, so `std::abs` there is a call on a known type rather than on
+    # a scalar, and banning it would be enforcing a rule that does not apply.
+    # The scope is the library -- the headers, and the bindings that call them.
+    hits="$(grep -rnE 'std::(sqrt|cbrt|abs|fabs|pow|exp|log|log2|log10|sin|cos|tan|asin|acos|atan|atan2|sinh|cosh|tanh|hypot|fma|fmin|fmax|copysign|floor|ceil|round|trunc)\(' \
+            --include='*.hpp' --include='*.cpp' "$ROOT/cpp/include" "$ROOT/cpp/bindings" 2>/dev/null \
+            | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(///|//|\*)' || true)"
+    if [[ -n "$hits" ]]; then
+        record FAIL "no qualified std:: math calls" "$(wc -l <<<"$hits") site(s)"
+        printf '%s\n' "$hits"
+    else
+        record PASS "no qualified std:: math calls"
+    fi
+
+    # No kernel takes an IndexMap. The MPI distribution type belongs to the
+    # parallel layer; a kernel that accepts one has had the layering leak into
+    # it. Vacuous today -- pantr has no such type in any language -- and
+    # asserted so it stays that way, since this is cheap now and archaeology
+    # later.
+    hits="$(grep -rn 'IndexMap' --include='*.hpp' --include='*.cpp' "$ROOT/cpp" 2>/dev/null || true)"
+    if [[ -n "$hits" ]]; then
+        record FAIL "no kernel takes an IndexMap" "$(wc -l <<<"$hits") site(s)"
+        printf '%s\n' "$hits"
+    else
+        record PASS "no kernel takes an IndexMap"
+    fi
+
+    # -march must not reach the BUILD. design/simd.md makes ISA variants stage 2
+    # and gates them on a measurement; cpp/README.md now reports that
+    # measurement, so documentation naturally mentions the flag and must not be
+    # scanned. Only files that can actually set a compile option are.
+    hits="$(grep -rn -- '-march=' "$ROOT/cmake" "$ROOT/CMakeLists.txt" \
+            "$ROOT/CMakePresets.json" "$ROOT/pyproject.toml" \
+            --include='*.cmake' --include='CMakeLists.txt' --include='*.json' \
+            --include='*.toml' 2>/dev/null || true)"
+    if [[ -n "$hits" ]]; then
+        record FAIL "no -march in the build files" "$(wc -l <<<"$hits") site(s)"
+        printf '%s\n' "$hits"
+    else
+        record PASS "no -march in the build files"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# python -- the extension, the parity harness, both backends
+# --------------------------------------------------------------------------
+
+python_checks() {
+    step "Python: extension, parity, backends"
+
+    if [[ ! -d "$VENV" ]]; then
+        record SKIP "python checks" "no .venv; run: python -m venv --system-site-packages .venv"
+        return 0
+    fi
+
+    # shellcheck disable=SC1091
+    source "$VENV/bin/activate"
+
+    check "editable install" pip install -e . --no-build-isolation -q
+
+    # The extension must be present. Every check below it would otherwise SKIP,
+    # and a suite that skips its way to green is the trap CLAUDE.md names: a
+    # missing optional dependency skips without complaint.
+    if python -c "import pantr._pantr_cpp" 2>/dev/null; then
+        record PASS "pantr._pantr_cpp imports"
+    else
+        record FAIL "pantr._pantr_cpp imports" "everything below is meaningless"
+        return 0
+    fi
+
+    # An explicit backend request that cannot be served must FAIL rather than
+    # fall back. This is the rule that makes every A/B measurement in this
+    # prototype trustworthy, so it is asserted rather than assumed.
+    if PANTR_BACKEND=nonesuch python -c "import pantr" 2>/dev/null; then
+        record FAIL "unknown PANTR_BACKEND fails loudly" "import SUCCEEDED"
+    else
+        record PASS "unknown PANTR_BACKEND fails loudly"
+    fi
+
+    check "parity: C++ vs numba" python -m pytest tests/test_cpp_parity.py -q
+
+    # The acceptance criterion: the EXISTING suite passes against both backends.
+    # change_basis is the module that reaches the ported kernel, so it is named
+    # explicitly; the full suite follows because a kernel swap that breaks
+    # something else is exactly what a narrow run would miss.
+    local be
+    for be in numba cpp; do
+        PANTR_BACKEND=$be check "change_basis on $be" python -m pytest \
+            tests/test_change_basis_1D.py tests/test_change_basis_domain.py -q
+    done
+    for be in numba cpp; do
+        PANTR_BACKEND=$be check "full suite on $be" python -m pytest tests -q -x -m "not slow"
+    done
+}
+
+# --------------------------------------------------------------------------
+# splitmode -- the nanobind wheel-strategy probe
+# --------------------------------------------------------------------------
+#
+# design/_memory/nanobind-status.md records that split mode supersedes the
+# stable-ABI approach on both axes that mattered, and that it was unreleased.
+# The bindings are written against the nanobind 3 API (NB_TRAMPOLINE without a
+# Size, return-value policies and argument annotations as compile-time tags,
+# gil_scoped_acquire consulting is_valid()), which also compiles under 2.x -- so
+# this probe answers whether it BUILDS and IMPORTS under the dev release,
+# without the shipped build depending on the answer.
+#
+# It is expected to be the flakiest check here, because it installs a
+# pre-release into a throwaway environment. A failure is information, not a
+# blocker: it is reported and does not fail the run.
+
+splitmode() {
+    step "nanobind split mode (pre-release probe)"
+
+    local tmpvenv
+    tmpvenv="$(mktemp -d)/venv"
+    if ! python -m venv --system-site-packages "$tmpvenv" >/dev/null 2>&1; then
+        record SKIP "nanobind split mode" "could not create a probe venv"
+        return 0
+    fi
+    # shellcheck disable=SC1091
+    source "$tmpvenv/bin/activate"
+
+    if ! pip install -q --pre "nanobind>=3.0.0.dev0" >"$LOGDIR/nb3.log" 2>&1; then
+        record SKIP "nanobind split mode" "pre-release not installable"
+        deactivate || true
+        return 0
+    fi
+
+    local nbver
+    nbver="$(python -c 'import nanobind; print(nanobind.__version__)' 2>/dev/null || echo unknown)"
+
+    if pip install -e . --no-build-isolation -q \
+         --config-settings=cmake.define.PANTR_NANOBIND_SPLIT=ON >"$LOGDIR/split.log" 2>&1 \
+       && python -c "import pantr._pantr_cpp" >>"$LOGDIR/split.log" 2>&1; then
+        record PASS "nanobind split mode" "nanobind $nbver"
+    else
+        record WARN "nanobind split mode" "nanobind $nbver: see the log tail below"
+        tail -25 "$LOGDIR/split.log"
+    fi
+    deactivate || true
+}
+
+# --------------------------------------------------------------------------
+
+main() {
+    local what="${1:-all}"
+    case "$what" in
+        gates)      gates ;;
+        cxx)        cxx ;;
+        discipline) discipline ;;
+        python)     python_checks ;;
+        splitmode)  splitmode ;;
+        all)        gates; cxx; discipline; python_checks; splitmode ;;
+        *)          echo "unknown section: $what" >&2; exit 2 ;;
+    esac
+
+    step "Summary"
+    printf '%s\n' "${RESULTS[@]}"
+    if [[ "$FAILED" -eq 1 ]]; then
+        printf '\n\033[31mFAILED\033[0m\n'
+        exit 1
+    fi
+    printf '\n\033[32mAll checks passed\033[0m\n'
+}
+
+main "$@"

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -434,6 +434,25 @@ python_checks() {
 
     check "editable install" pip install -e . --no-build-isolation -q
 
+    # An explicit request that cannot be served must FAIL rather than fall back.
+    # This is the rule that makes every A/B measurement in this prototype
+    # trustworthy, so it is asserted rather than assumed -- on both selection
+    # axes, because they are two variables answering two questions and a rule
+    # asserted on one of them says nothing about the other.
+    #
+    # Above the extension check below, and deliberately: neither variable needs
+    # the extension to be built for an unknown value to fail, and the ISA axis is
+    # documented as independent of whether the C++ backend is installed, so
+    # checking it only where the extension exists would not check that.
+    local var
+    for var in PANTR_BACKEND PANTR_ISA_VARIANT; do
+        if env "$var=nonesuch" python -c "import pantr" 2>/dev/null; then
+            record FAIL "unknown $var fails loudly" "import SUCCEEDED"
+        else
+            record PASS "unknown $var fails loudly"
+        fi
+    done
+
     # The extension must be present. Every check below it would otherwise SKIP,
     # and a suite that skips its way to green is the trap CLAUDE.md names: a
     # missing optional dependency skips without complaint.
@@ -443,20 +462,6 @@ python_checks() {
         record FAIL "pantr._pantr_cpp imports" "everything below is meaningless"
         return 0
     fi
-
-    # An explicit request that cannot be served must FAIL rather than fall back.
-    # This is the rule that makes every A/B measurement in this prototype
-    # trustworthy, so it is asserted rather than assumed -- on both selection
-    # axes, because they are two variables answering two questions and a rule
-    # asserted on one of them says nothing about the other.
-    local var
-    for var in PANTR_BACKEND PANTR_ISA_VARIANT; do
-        if env "$var=nonesuch" python -c "import pantr" 2>/dev/null; then
-            record FAIL "unknown $var fails loudly" "import SUCCEEDED"
-        else
-            record PASS "unknown $var fails loudly"
-        fi
-    done
 
     check "parity: C++ vs numba" python -m pytest tests/test_cpp_parity.py -q
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -282,6 +282,41 @@ cxx() {
         check "$preset: ctest" ctest --preset "$preset"
     done
 
+    # The version floor, built rather than merely accepted.
+    #
+    # `gates` above asserts that the floor compilers CONFIGURE. That is the gate's
+    # behaviour, and it is not the claim the floor makes. The floor says version 10
+    # of both families builds this tree and passes its tests, and until that is
+    # re-checked it rests on one manual measurement taken the day the floor was
+    # set: the first commit using something GCC 10 lacks would break the claim with
+    # nothing to notice.
+    #
+    # This is the ONLY place that check exists. .github/workflows/cpp.yaml runs
+    # GCC 14 and Clang 18, and ubuntu-24.04 does not package GCC 10, so covering
+    # the floor there needs an older image or a container -- more weight than a
+    # prototype should carry. design/toolchain_requirements.md records that the
+    # floor is verified locally and not by CI.
+    local floor_cxx floor_name floor_dir
+    for floor_cxx in /usr/bin/g++-10 /usr/bin/clang++-10; do
+        floor_name="$(basename "$floor_cxx")"
+        if [[ ! -x "$floor_cxx" ]]; then
+            record SKIP "floor: $floor_name" "$floor_cxx absent"
+            continue
+        fi
+        floor_dir="$ROOT/build/floor-$floor_name"
+        rm -rf "$floor_dir"
+        # PANTR_ALLOW_UNTESTED_COMPILER is deliberately NOT passed: the floor is
+        # 10, so 10 must configure on its own. If it ever needs the override, the
+        # floor moved and this check is what says so.
+        check "floor: $floor_name configure" \
+            cmake -S "$ROOT" -B "$floor_dir" -G Ninja \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_CXX_COMPILER="$floor_cxx" \
+                  -DPANTR_WERROR=ON -DPANTR_BUILD_PYTHON=OFF
+        check "floor: $floor_name build (-Werror)" cmake --build "$floor_dir"
+        check "floor: $floor_name ctest" ctest --test-dir "$floor_dir" --output-on-failure
+    done
+
     # The mdspan toggle is a decision the build makes silently; print which way
     # it went, because "which mdspan am I actually using" is the first question
     # asked when a build behaves oddly.

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -170,33 +170,50 @@ gates() {
         record SKIP "concepts gate rejects GCC 9" "/usr/bin/g++-9 absent"
     fi
 
-    # The known-broken-compiler filter, and its documented override. Clang 10
-    # PASSES the concepts probe and compiles this prototype's kernel correctly
-    # (measured), so the filter -- not the probe -- is what keeps it out. Both
-    # halves are asserted: that it rejects, and that the escape hatch works.
-    if [[ -x /usr/bin/clang++-10 ]]; then
-        if cmake -S . -B "$tmp/clang10" -G Ninja \
-                 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 \
-                 -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
-                 >"$tmp/clang10.log" 2>&1; then
-            record FAIL "version filter rejects Clang 10" "configure SUCCEEDED"
-        elif grep -q "known-incomplete concepts support" "$tmp/clang10.log"; then
-            record PASS "version filter rejects Clang 10"
-        else
-            record FAIL "version filter rejects Clang 10" "rejected, but not by the filter"
+    # The version floor is 10 for GCC and Clang alike, and 10 is the lowest
+    # version this tree has actually been built and tested with. So the assertion
+    # here is that both of the machine's 2020 compilers are ACCEPTED -- the
+    # opposite of what this check asserted until the floor was measured, when it
+    # sat at 14 for Clang on a guess and at nothing at all for GCC.
+    #
+    # Configuring is not the interesting half. `cxx` below builds the whole tree
+    # with the development toolchains; what these two prove is that the gate does
+    # not stand in the way of a compiler that works, which is the failure mode a
+    # version table produces and the reason this file distrusts them.
+    for _old_cxx in /usr/bin/clang++-10 /usr/bin/g++-10; do
+        _name="$(basename "$_old_cxx")"
+        if [[ ! -x "$_old_cxx" ]]; then
+            record SKIP "$_name is accepted" "$_old_cxx absent"
+            continue
         fi
+        if cmake -S . -B "$tmp/$_name" -G Ninja \
+                 -DCMAKE_CXX_COMPILER="$_old_cxx" \
+                 -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
+                 >"$tmp/$_name.log" 2>&1; then
+            record PASS "$_name is accepted"
+        else
+            record FAIL "$_name is accepted" "the floor rejects a version measured to work"
+            tail -20 "$tmp/$_name.log"
+        fi
+    done
 
-        if cmake -S . -B "$tmp/clang10ovr" -G Ninja \
-                 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-10 \
+    # The override still has to work, because the floor still rejects something
+    # below it and someone will need past it one day. There is no compiler below
+    # 10 on this machine to try it against -- g++ 9.5 is stopped earlier, by the
+    # concepts probe -- so this asserts the flag is at least accepted and does not
+    # itself break a configure.
+    if [[ -x /usr/bin/g++-10 ]]; then
+        if cmake -S . -B "$tmp/override" -G Ninja \
+                 -DCMAKE_CXX_COMPILER=/usr/bin/g++-10 \
                  -DPANTR_ALLOW_UNTESTED_COMPILER=ON \
                  -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF \
-                 >"$tmp/clang10ovr.log" 2>&1; then
-            record PASS "PANTR_ALLOW_UNTESTED_COMPILER overrides it"
+                 >"$tmp/override.log" 2>&1; then
+            record PASS "PANTR_ALLOW_UNTESTED_COMPILER is honoured"
         else
-            record FAIL "PANTR_ALLOW_UNTESTED_COMPILER overrides it" "still rejected"
+            record FAIL "PANTR_ALLOW_UNTESTED_COMPILER is honoured"
         fi
     else
-        record SKIP "version filter rejects Clang 10" "/usr/bin/clang++-10 absent"
+        record SKIP "PANTR_ALLOW_UNTESTED_COMPILER is honoured" "no old compiler to try"
     fi
 
     # The offline escape. FETCHCONTENT_FULLY_DISCONNECTED with a populated

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -1,0 +1,332 @@
+"""Backend selection between the Numba kernels and the C++ prototype.
+
+PaNTr is being ported from Python-with-Numba to a C++ core (see ``design/*.md``).
+During the port the **Numba implementation stays as the parity oracle**: the C++
+backend is validated against it module by module, with the choice made here, at
+the Python level, rather than at build time.
+
+Selection
+---------
+
+The environment variable ``PANTR_BACKEND`` chooses the backend for the process:
+
+.. code-block:: console
+
+    PANTR_BACKEND=numba pytest tests/     # the oracle, and the default
+    PANTR_BACKEND=cpp   pytest tests/     # the port
+
+Unset, the backend is :attr:`Backend.NUMBA`, which is always available.
+
+**An explicit request never falls back.** If ``PANTR_BACKEND`` names a backend
+that is not available, importing :mod:`pantr` fails, loudly, naming what is
+missing and how to build it. That is deliberate and it is the whole point of the
+rule: a silent downgrade to the other backend would make every A/B measurement
+untrustworthy, and the measurement is what the override exists to enable. The
+same reasoning appears in ``design/simd.md`` for the ISA-variant override, where
+a variant that is requested and missing must fail rather than quietly load
+another.
+
+Scope
+-----
+
+One kernel is ported so far, the cardinal B-spline tabulation of
+:func:`pantr.basis.tabulate_cardinal_bspline_1d`. Selecting the C++ backend
+changes that kernel and nothing else; every other function keeps running its
+Numba implementation regardless. So a suite run under ``PANTR_BACKEND=cpp`` is
+not a C++ run, it is a run in which one kernel is C++.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from enum import IntEnum
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    # Imported for typing only: at run time this would be an import cycle, since
+    # pantr.basis._basis_1D is what asks this module which kernel to call.
+    from pantr.basis._basis_1D import _BasisCoreFunc
+
+__all__ = [
+    "Backend",
+    "active_backend",
+    "available_backends",
+    "cardinal_bspline_core",
+    "use_backend",
+]
+
+_ENV_VAR: Final[str] = "PANTR_BACKEND"
+"""Name of the environment variable that selects the backend."""
+
+
+class Backend(IntEnum):
+    """The available implementations of a ported kernel.
+
+    An :class:`~enum.IntEnum` rather than a string, per the project's convention
+    that a closed set of choices is never stringly typed. The environment
+    variable is a string because the operating system offers nothing else; it is
+    a boundary and is converted on the way in by :func:`_parse_backend_name`.
+
+    Attributes:
+        NUMBA: The Numba kernels. Always available, and the parity oracle every
+            C++ result is checked against.
+        CPP: The C++ prototype, available only when the ``pantr._pantr_cpp``
+            extension was built.
+    """
+
+    NUMBA = 0
+    CPP = 1
+
+
+def _cpp_extension_is_present() -> bool:
+    """Report whether the compiled extension was built into this installation.
+
+    Only presence is recorded, not the module object. The kernel adapter imports
+    ``pantr._pantr_cpp`` by name where it calls it, so mypy resolves the call
+    against ``src/pantr/_pantr_cpp.pyi`` and would reject a call that no longer
+    matches the binding. A stored module object would be typed
+    :class:`~types.ModuleType`, which accepts any attribute and would keep
+    typechecking after the signature changed underneath it.
+
+    Returns:
+        bool: True when ``pantr._pantr_cpp`` imports.
+    """
+    try:
+        import pantr._pantr_cpp  # noqa: F401, PLC0415  (probe only, deliberately lazy)
+    except ImportError:
+        return False
+    return True
+
+
+_CPP_AVAILABLE: Final = _cpp_extension_is_present()
+"""Whether the C++ backend can be selected in this process.
+
+Resolved once at import: whether the extension exists cannot change during a
+run, and re-probing per call would put a `try/except ImportError` on a hot path.
+"""
+
+
+def available_backends() -> tuple[Backend, ...]:
+    """List the backends this installation can actually run.
+
+    Returns:
+        tuple[Backend, ...]: The available backends, in ascending enum order.
+            :attr:`Backend.NUMBA` is always present.
+    """
+    if not _CPP_AVAILABLE:
+        return (Backend.NUMBA,)
+    return (Backend.NUMBA, Backend.CPP)
+
+
+def _parse_backend_name(name: str) -> Backend:
+    """Convert the environment variable's string to a :class:`Backend`.
+
+    The single place a backend name crosses from text into the type system.
+
+    Args:
+        name (str): Value of ``PANTR_BACKEND``, matched case-insensitively and
+            with surrounding whitespace ignored.
+
+    Returns:
+        Backend: The named backend.
+
+    Raises:
+        ValueError: If ``name`` does not name a backend.
+    """
+    normalized = name.strip().lower()
+    for backend in Backend:
+        if backend.name.lower() == normalized:
+            return backend
+    known = ", ".join(sorted(b.name.lower() for b in Backend))
+    raise ValueError(f"{_ENV_VAR}={name!r} does not name a backend. Known backends: {known}.")
+
+
+def _resolve_backend_from_environment() -> Backend:
+    """Read and validate the backend requested by the environment.
+
+    Returns:
+        Backend: The requested backend, or :attr:`Backend.NUMBA` when
+            ``PANTR_BACKEND`` is unset.
+
+    Raises:
+        ValueError: If ``PANTR_BACKEND`` does not name a backend.
+        RuntimeError: If it names a backend this installation cannot run. This is
+            raised rather than silently falling back, so that a measurement taken
+            under an explicit request cannot be a measurement of the other
+            backend.
+    """
+    requested = os.environ.get(_ENV_VAR)
+    if requested is None:
+        return Backend.NUMBA
+
+    backend = _parse_backend_name(requested)
+    if backend in available_backends():
+        return backend
+
+    raise RuntimeError(
+        f"{_ENV_VAR}={requested!r} was requested but the {backend.name} backend is "
+        f"not available in this installation.\n"
+        f"  The C++ extension pantr._pantr_cpp was not built.\n"
+        f"  Fix: pip install -e . (which builds it through scikit-build-core)\n"
+        f"pantr does not fall back to another backend here: an explicit request "
+        f"that silently ran something else would make any A/B measurement taken "
+        f"under it meaningless."
+    )
+
+
+_PROCESS_DEFAULT: Final[Backend] = _resolve_backend_from_environment()
+"""The backend every thread and task starts from, resolved once from the environment."""
+
+_ACTIVE: Final[ContextVar[Backend]] = ContextVar("pantr_active_backend", default=_PROCESS_DEFAULT)
+"""The backend in effect, per thread and per task.
+
+A :class:`~contextvars.ContextVar` rather than a module global, with the
+environment-resolved value as its default so that a thread or task which entered
+no :func:`use_backend` block reads exactly what ``PANTR_BACKEND`` selected.
+
+A global is wrong here for two measured reasons, neither of them exotic. Two
+overlapping :func:`use_backend` blocks in different threads lose an update: the
+second saves the first's override as its "previous" and restores the process to
+*that* on the way out, so the selection stays changed after every block has
+exited. And an override in one thread reaches into every other one, so a worker
+that never asked for a backend changes kernel mid-flight. Both are the *only*
+outcome of their interleaving rather than a rare race, and the binding releases
+the GIL specifically so that callers may thread at the Python level, which makes
+this the shape the module invites rather than a pathological one.
+``tests/test_cpp_parity.py`` pins both.
+"""
+
+
+def active_backend() -> Backend:
+    """Report the backend currently in effect.
+
+    Returns:
+        Backend: The backend selected by ``PANTR_BACKEND``, or by a
+            :func:`use_backend` block enclosing this call **in this thread or
+            task**. A thread that entered no such block reads the environment's
+            selection, whatever another thread is doing.
+    """
+    return _ACTIVE.get()
+
+
+@contextmanager
+def use_backend(backend: Backend) -> Iterator[None]:
+    """Run a block with a different backend in effect.
+
+    A scoped context manager rather than a setter, so the selection cannot be
+    left changed by a function that returns early or raises. Existing tests use
+    it to run the same assertions against both backends within one process.
+
+    **The scope is the calling thread or task, not the process.** A thread
+    started inside the block runs on the process default (what ``PANTR_BACKEND``
+    selected), not on ``backend``; to give it the override, pass the backend into
+    the worker and let it open its own block. That is the deliberate direction:
+    the alternative reaches into threads that never asked, which is the same
+    silent substitution this module refuses to do for a missing backend -- and
+    the one place a wrong answer would look like a measurement.
+
+    Args:
+        backend (Backend): The backend to select for the duration of the block.
+
+    Yields:
+        None: The block runs with ``backend`` active in this thread or task.
+
+    Raises:
+        RuntimeError: If ``backend`` is not available. As with the environment
+            variable, an explicit request never falls back.
+
+    Example:
+        >>> from pantr._backend import Backend, active_backend, use_backend
+        >>> with use_backend(Backend.NUMBA):
+        ...     active_backend()
+        <Backend.NUMBA: 0>
+    """
+    if backend not in available_backends():
+        raise RuntimeError(
+            f"the {backend.name} backend is not available in this installation; "
+            f"available: {', '.join(b.name for b in available_backends())}"
+        )
+    token = _ACTIVE.set(backend)
+    try:
+        yield
+    finally:
+        _ACTIVE.reset(token)
+
+
+def _cpp_cardinal_bspline_core(
+    n: np.int32,
+    t: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Adapt the C++ kernel to the :class:`_BasisCoreFunc` signature.
+
+    The adapter's whole job is that **the public API must behave identically on
+    both backends**, because otherwise an A/B measurement is comparing two
+    contracts rather than two kernels. One difference has to be absorbed here:
+    the numba kernel accepts a non-contiguous ``out`` and fills it, while the
+    C++ binding requires C-contiguous memory and refuses anything else. So a
+    non-contiguous ``out`` is computed into a contiguous buffer and copied back,
+    and the caller sees the numba behaviour either way.
+
+    Refusing instead would be the wrong fix: it would make ``PANTR_BACKEND``
+    change what the library accepts, not just how fast it is.
+
+    Args:
+        n (np.int32): Degree of the basis. Assumed non-negative.
+        t (npt.NDArray[np.float32 | np.float64]): 1D evaluation points.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(t.size, n + 1)`` and matching dtype. Need not be contiguous.
+
+    Note:
+        No input validation is performed. Shape and dtype are established by the
+        Layer 2 caller; dtype, rank and contiguity are re-checked by nanobind's
+        typed signature, which raises :class:`TypeError` before the kernel runs
+        rather than silently converting -- see the ``.noconvert()`` in
+        ``cpp/bindings/pantr_cpp.cpp`` and why it is a correctness requirement.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    points = np.ascontiguousarray(t)
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, out)
+        return
+
+    # The uncommon path. The check above is a flag read, so the common case pays
+    # essentially nothing for it; only a caller that actually passes a strided
+    # view pays for the buffer and the copy back.
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, buffer)
+    out[...] = buffer
+
+
+def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
+    """Return the cardinal B-spline tabulation kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`active_backend`. Defaults to None.
+
+    Returns:
+        _BasisCoreFunc: The kernel, callable as ``(n, t, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.NUMBA:
+        from pantr.basis._basis_core import (  # noqa: PLC0415  (avoids an import cycle)
+            _tabulate_cardinal_Bspline_basis_1D_core,
+        )
+
+        return _tabulate_cardinal_Bspline_basis_1D_core
+
+    if not _CPP_AVAILABLE:
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return _cpp_cardinal_bspline_core

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -34,6 +34,22 @@ One kernel is ported so far, the cardinal B-spline tabulation of
 changes that kernel and nothing else; every other function keeps running its
 Numba implementation regardless. So a suite run under ``PANTR_BACKEND=cpp`` is
 not a C++ run, it is a run in which one kernel is C++.
+
+What is here, and what is not
+-----------------------------
+
+**This module is policy only.** It names the backends, resolves the selection
+and enforces the never-fall-back rule; it holds no kernel and knows of none.
+The map from a selection to the callables lives beside the kernels themselves --
+:mod:`pantr.basis._basis_backend` for the basis kernels, one such module per
+ported package.
+
+That is what keeps the dependency one-directional: a catalogue imports its
+kernels, and its consumers import the policy, so a catalogue placed here would
+close a cycle that only lazy imports could hold open -- one more per kernel
+ported. An import-linter contract in ``pyproject.toml`` forbids this module from
+importing any subpackage of :mod:`pantr`, so the arrangement cannot quietly
+revert.
 """
 
 from __future__ import annotations
@@ -43,21 +59,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import IntEnum
-from typing import TYPE_CHECKING, Final
-
-import numpy as np
-import numpy.typing as npt
-
-if TYPE_CHECKING:
-    # Imported for typing only: at run time this would be an import cycle, since
-    # pantr.basis._basis_1D is what asks this module which kernel to call.
-    from pantr.basis._basis_1D import _BasisCoreFunc
+from typing import Final
 
 __all__ = [
     "Backend",
     "active_backend",
     "available_backends",
-    "cardinal_bspline_core",
     "use_backend",
 ]
 
@@ -87,10 +94,11 @@ class Backend(IntEnum):
 def _cpp_extension_is_present() -> bool:
     """Report whether the compiled extension was built into this installation.
 
-    Only presence is recorded, not the module object. The kernel adapter imports
-    ``pantr._pantr_cpp`` by name where it calls it, so mypy resolves the call
-    against ``src/pantr/_pantr_cpp.pyi`` and would reject a call that no longer
-    matches the binding. A stored module object would be typed
+    Only presence is recorded, not the module object. Each kernel adapter --
+    :func:`pantr.basis._basis_backend._cpp_cardinal_bspline_core` is the one that
+    exists so far -- imports ``pantr._pantr_cpp`` by name where it calls it, so
+    mypy resolves the call against ``src/pantr/_pantr_cpp.pyi`` and would reject a
+    call that no longer matches the binding. A stored module object would be typed
     :class:`~types.ModuleType`, which accepts any attribute and would keep
     typechecking after the signature changed underneath it.
 
@@ -257,76 +265,3 @@ def use_backend(backend: Backend) -> Iterator[None]:
         yield
     finally:
         _ACTIVE.reset(token)
-
-
-def _cpp_cardinal_bspline_core(
-    n: np.int32,
-    t: npt.NDArray[np.float32 | np.float64],
-    out: npt.NDArray[np.float32 | np.float64],
-) -> None:
-    """Adapt the C++ kernel to the :class:`_BasisCoreFunc` signature.
-
-    The adapter's whole job is that **the public API must behave identically on
-    both backends**, because otherwise an A/B measurement is comparing two
-    contracts rather than two kernels. One difference has to be absorbed here:
-    the numba kernel accepts a non-contiguous ``out`` and fills it, while the
-    C++ binding requires C-contiguous memory and refuses anything else. So a
-    non-contiguous ``out`` is computed into a contiguous buffer and copied back,
-    and the caller sees the numba behaviour either way.
-
-    Refusing instead would be the wrong fix: it would make ``PANTR_BACKEND``
-    change what the library accepts, not just how fast it is.
-
-    Args:
-        n (np.int32): Degree of the basis. Assumed non-negative.
-        t (npt.NDArray[np.float32 | np.float64]): 1D evaluation points.
-        out (npt.NDArray[np.float32 | np.float64]): Output of shape
-            ``(t.size, n + 1)`` and matching dtype. Need not be contiguous.
-
-    Note:
-        No input validation is performed. Shape and dtype are established by the
-        Layer 2 caller; dtype, rank and contiguity are re-checked by nanobind's
-        typed signature, which raises :class:`TypeError` before the kernel runs
-        rather than silently converting -- see the ``.noconvert()`` in
-        ``cpp/bindings/pantr_cpp.cpp`` and why it is a correctness requirement.
-    """
-    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
-
-    points = np.ascontiguousarray(t)
-    if out.flags["C_CONTIGUOUS"]:
-        _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, out)
-        return
-
-    # The uncommon path. The check above is a flag read, so the common case pays
-    # essentially nothing for it; only a caller that actually passes a strided
-    # view pays for the buffer and the copy back.
-    buffer = np.empty_like(out, order="C")
-    _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, buffer)
-    out[...] = buffer
-
-
-def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
-    """Return the cardinal B-spline tabulation kernel of the requested backend.
-
-    Args:
-        backend (Backend | None): The backend to use. ``None`` means the backend
-            currently in effect, per :func:`active_backend`. Defaults to None.
-
-    Returns:
-        _BasisCoreFunc: The kernel, callable as ``(n, t, out) -> None``.
-
-    Raises:
-        RuntimeError: If ``backend`` is given and is not available.
-    """
-    chosen = active_backend() if backend is None else backend
-
-    if chosen is Backend.NUMBA:
-        from pantr.basis._basis_core import (  # noqa: PLC0415  (avoids an import cycle)
-            _tabulate_cardinal_Bspline_basis_1D_core,
-        )
-
-        return _tabulate_cardinal_Bspline_basis_1D_core
-
-    if not _CPP_AVAILABLE:
-        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
-    return _cpp_cardinal_bspline_core

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -5,6 +5,23 @@ During the port the **Numba implementation stays as the parity oracle**: the C++
 backend is validated against it module by module, with the choice made here, at
 the Python level, rather than at build time.
 
+Unstable
+--------
+
+**This module is scaffolding and carries no compatibility promise.** It exists to
+run two implementations side by side while the port proceeds, and when the port
+ends the reason for it ends too -- so it may be renamed, reshaped or deleted
+without a deprecation cycle, and nothing outside :mod:`pantr` should import it.
+It is deliberately not re-exported from :mod:`pantr` and not listed in the docs
+reference, unlike :mod:`pantr._parallel`, which is maintained to the same
+standard but is meant to outlive the port. Making this one public would commit
+the project to maintaining it past the point where it has a job.
+
+Said plainly because it is known not to be enough: ``CLAUDE.md`` records that a
+downstream consumer already imports pantr's private symbols, where pantr's own CI
+cannot see the breakage. This paragraph is the notice; it is not a promise, and a
+consumer that pins to this module is choosing to track it.
+
 Selection
 ---------
 

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -21,10 +21,31 @@ Unset, the backend is :attr:`Backend.NUMBA`, which is always available.
 that is not available, importing :mod:`pantr` fails, loudly, naming what is
 missing and how to build it. That is deliberate and it is the whole point of the
 rule: a silent downgrade to the other backend would make every A/B measurement
-untrustworthy, and the measurement is what the override exists to enable. The
-same reasoning appears in ``design/simd.md`` for the ISA-variant override, where
-a variant that is requested and missing must fail rather than quietly load
-another.
+untrustworthy, and the measurement is what the override exists to enable.
+
+Two axes, not one
+-----------------
+
+``design/simd.md`` schedules a second choice: ship the extension compiled
+several times (baseline, ``x86-64-v3``, ``x86-64-v4``) and pick one at import.
+That is a **different question** from :class:`Backend`. Which family runs the
+kernel, and which build of that family, are independent -- so they are two enums
+and two variables, :class:`IsaVariant` and ``PANTR_ISA_VARIANT``, under the same
+never-fall-back rule.
+
+Folding the second into the first, as ``CPP_V3`` and ``CPP_V4`` members of
+:class:`Backend`, would multiply :func:`available_backends`, the parse, and
+every ``is Backend.NUMBA`` branch by the product of the two. It is written down
+now rather than when the ladder is built, because the accepted values of an
+environment variable are user-facing the moment anyone puts one in a script:
+adding an axis later is additive, but re-spelling ``PANTR_BACKEND=cpp`` as
+``PANTR_BACKEND=cpp_v3`` is a break. **Today's accepted values are unchanged.**
+
+**No ISA variant is built.** ``design/simd.md`` gates the ladder on a
+measurement, ``cmake/PantrCompileOptions.cmake`` sets no ``-march``, and
+``scripts/ci_local.sh discipline`` asserts that none appears in the build files.
+So :func:`available_isa_variants` reports the baseline alone, and this axis is a
+shape rather than a capability.
 
 Scope
 -----
@@ -59,17 +80,26 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import IntEnum
-from typing import Final
+from typing import Final, TypeVar
 
 __all__ = [
     "Backend",
+    "IsaVariant",
     "active_backend",
+    "active_isa_variant",
     "available_backends",
+    "available_isa_variants",
     "use_backend",
 ]
 
 _ENV_VAR: Final[str] = "PANTR_BACKEND"
 """Name of the environment variable that selects the backend."""
+
+_ISA_ENV_VAR: Final[str] = "PANTR_ISA_VARIANT"
+"""Name of the environment variable that selects the ISA variant."""
+
+_Choice = TypeVar("_Choice", bound=IntEnum)
+"""One of the closed sets of choices this module resolves from the environment."""
 
 
 class Backend(IntEnum):
@@ -78,7 +108,7 @@ class Backend(IntEnum):
     An :class:`~enum.IntEnum` rather than a string, per the project's convention
     that a closed set of choices is never stringly typed. The environment
     variable is a string because the operating system offers nothing else; it is
-    a boundary and is converted on the way in by :func:`_parse_backend_name`.
+    a boundary and is converted on the way in by :func:`_parse_choice`.
 
     Attributes:
         NUMBA: The Numba kernels. Always available, and the parity oracle every
@@ -132,64 +162,153 @@ def available_backends() -> tuple[Backend, ...]:
     return (Backend.NUMBA, Backend.CPP)
 
 
-def _parse_backend_name(name: str) -> Backend:
-    """Convert the environment variable's string to a :class:`Backend`.
+class IsaVariant(IntEnum):
+    """Which build of the C++ extension runs: the instruction-set ladder.
 
-    The single place a backend name crosses from text into the type system.
+    A second axis, orthogonal to :class:`Backend`. ``design/simd.md`` settles the
+    shape of the ladder -- compile the extension once per instruction-set level,
+    pick one at import through a probe module compiled at the toolchain baseline
+    -- and gates **building** any of it on a measurement that has been taken but
+    not acted on. So this enum has one member today.
+
+    The two questions are kept apart because they compose rather than combine:
+    folding the ladder into :class:`Backend` as ``CPP_V3`` and ``CPP_V4`` would
+    multiply the parse, the availability list and every branch by the product of
+    the two axes, and it would make ``PANTR_BACKEND``'s accepted values change
+    when the ladder lands. Adding a member here is additive instead.
+
+    Attributes:
+        BASELINE: The extension as it is built today -- no ``-march``, so
+            whatever the compiler's default target is. Always the answer until
+            the ladder is built.
+    """
+
+    BASELINE = 0
+
+
+def available_isa_variants() -> tuple[IsaVariant, ...]:
+    """List the ISA variants this installation can actually load.
+
+    The ladder is not built: ``cmake/PantrCompileOptions.cmake`` sets no
+    ``-march`` and ``scripts/ci_local.sh discipline`` asserts that none appears
+    in the build files, so the one extension that exists is the baseline. When
+    the ladder lands this becomes a probe -- which variant modules were shipped,
+    intersected with what the CPU and the operating system actually support, per
+    ``design/simd.md``.
+
+    Deliberately independent of :func:`available_backends`. A variant describes
+    which build of the C++ family would be used, which is a well-formed answer
+    even where the C++ backend is not installed; coupling them would make
+    ``PANTR_ISA_VARIANT=baseline`` an error on a Numba-only installation, where
+    it is merely inert.
+
+    Returns:
+        tuple[IsaVariant, ...]: The available variants, in ascending enum order.
+            :attr:`IsaVariant.BASELINE` is always present.
+    """
+    return (IsaVariant.BASELINE,)
+
+
+def _parse_choice(value: str, choices: type[_Choice], env_var: str) -> _Choice:
+    """Convert an environment variable's string to one of a closed set of choices.
+
+    The single place a name crosses from text into the type system, for both
+    axes. The variables are strings because the operating system offers nothing
+    else; they are a boundary and are converted here on the way in.
 
     Args:
-        name (str): Value of ``PANTR_BACKEND``, matched case-insensitively and
-            with surrounding whitespace ignored.
+        value (str): Value of the variable, matched case-insensitively and with
+            surrounding whitespace ignored.
+        choices (type[_Choice]): The enum to match against.
+        env_var (str): Name of the variable, for the error message.
 
     Returns:
-        Backend: The named backend.
+        _Choice: The named member.
 
     Raises:
-        ValueError: If ``name`` does not name a backend.
+        ValueError: If ``value`` names no member of ``choices``.
     """
-    normalized = name.strip().lower()
-    for backend in Backend:
-        if backend.name.lower() == normalized:
-            return backend
-    known = ", ".join(sorted(b.name.lower() for b in Backend))
-    raise ValueError(f"{_ENV_VAR}={name!r} does not name a backend. Known backends: {known}.")
+    normalized = value.strip().lower()
+    for choice in choices:
+        if choice.name.lower() == normalized:
+            return choice
+    known = ", ".join(sorted(c.name.lower() for c in choices))
+    raise ValueError(f"{env_var}={value!r} is not one of: {known}.")
 
 
-def _resolve_backend_from_environment() -> Backend:
-    """Read and validate the backend requested by the environment.
+def _resolve_from_environment(
+    env_var: str,
+    choices: type[_Choice],
+    available: tuple[_Choice, ...],
+    default: _Choice,
+    fix_hint: str,
+) -> _Choice:
+    """Read and validate one axis of the selection, refusing to fall back.
+
+    Shared by both axes, because the rule is one rule: an explicit request that
+    cannot be honoured raises rather than quietly running something else. Written
+    once so the two cannot drift apart -- the failure that drift would produce is
+    an A/B measurement of the wrong thing, which looks like a result.
+
+    Args:
+        env_var (str): Name of the environment variable to read.
+        choices (type[_Choice]): The enum it selects from.
+        available (tuple[_Choice, ...]): The members this installation can run.
+        default (_Choice): What an unset variable means.
+        fix_hint (str): Indented lines telling the user what is missing and how
+            to get it, quoted in the failure.
 
     Returns:
-        Backend: The requested backend, or :attr:`Backend.NUMBA` when
-            ``PANTR_BACKEND`` is unset.
+        _Choice: The requested member, or ``default`` when the variable is unset.
 
     Raises:
-        ValueError: If ``PANTR_BACKEND`` does not name a backend.
-        RuntimeError: If it names a backend this installation cannot run. This is
-            raised rather than silently falling back, so that a measurement taken
-            under an explicit request cannot be a measurement of the other
-            backend.
+        ValueError: If the variable names no member of ``choices``.
+        RuntimeError: If it names one this installation cannot run.
     """
-    requested = os.environ.get(_ENV_VAR)
+    requested = os.environ.get(env_var)
     if requested is None:
-        return Backend.NUMBA
+        return default
 
-    backend = _parse_backend_name(requested)
-    if backend in available_backends():
-        return backend
+    chosen = _parse_choice(requested, choices, env_var)
+    if chosen in available:
+        return chosen
 
     raise RuntimeError(
-        f"{_ENV_VAR}={requested!r} was requested but the {backend.name} backend is "
-        f"not available in this installation.\n"
-        f"  The C++ extension pantr._pantr_cpp was not built.\n"
-        f"  Fix: pip install -e . (which builds it through scikit-build-core)\n"
-        f"pantr does not fall back to another backend here: an explicit request "
+        f"{env_var}={requested!r} was requested but {chosen.name} is not available "
+        f"in this installation.\n"
+        f"{fix_hint}\n"
+        f"pantr does not fall back to another choice here: an explicit request "
         f"that silently ran something else would make any A/B measurement taken "
         f"under it meaningless."
     )
 
 
-_PROCESS_DEFAULT: Final[Backend] = _resolve_backend_from_environment()
+_PROCESS_DEFAULT: Final[Backend] = _resolve_from_environment(
+    _ENV_VAR,
+    Backend,
+    available_backends(),
+    Backend.NUMBA,
+    "  The C++ extension pantr._pantr_cpp was not built.\n"
+    "  Fix: pip install -e . (which builds it through scikit-build-core)",
+)
 """The backend every thread and task starts from, resolved once from the environment."""
+
+_ACTIVE_ISA_VARIANT: Final[IsaVariant] = _resolve_from_environment(
+    _ISA_ENV_VAR,
+    IsaVariant,
+    available_isa_variants(),
+    IsaVariant.BASELINE,
+    "  Only the baseline is built: design/simd.md gates the ISA ladder on a\n"
+    "  measurement, and no -march reaches the build.",
+)
+"""The ISA variant in effect, resolved once at import.
+
+A plain constant rather than a :class:`~contextvars.ContextVar`, because there is
+nothing to scope: the variant decides which extension module is *loaded*, so
+changing it inside a running process would mean unloading one binary and
+importing another. :func:`use_backend` has a scoped form because both backends
+are loaded at once and choosing between them is a per-call decision; this is not.
+"""
 
 _ACTIVE: Final[ContextVar[Backend]] = ContextVar("pantr_active_backend", default=_PROCESS_DEFAULT)
 """The backend in effect, per thread and per task.
@@ -221,6 +340,21 @@ def active_backend() -> Backend:
             selection, whatever another thread is doing.
     """
     return _ACTIVE.get()
+
+
+def active_isa_variant() -> IsaVariant:
+    """Report the ISA variant in effect.
+
+    Resolved once at import from ``PANTR_ISA_VARIANT``, and process-wide: unlike
+    the backend, the variant selects which binary is loaded, so it has no scoped
+    override.
+
+    Returns:
+        IsaVariant: The variant selected by ``PANTR_ISA_VARIANT``, or
+            :attr:`IsaVariant.BASELINE` when it is unset. The baseline is the
+            only variant built today.
+    """
+    return _ACTIVE_ISA_VARIANT
 
 
 @contextmanager

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -2,8 +2,8 @@
 
 The extension is a nanobind module, so mypy cannot see into it: without this
 file every use of :mod:`pantr._pantr_cpp` is an ``attr-defined`` error under the
-project's strict configuration, and ``pantr._backend`` is the module that uses
-it. The stub is written by hand rather than generated, because it is fifteen
+project's strict configuration, and the kernel adapters under ``pantr.basis``
+are what use it. The stub is written by hand rather than generated, because it is fifteen
 lines and a generated one would need regenerating on every signature change
 anyway.
 

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -1,0 +1,78 @@
+"""Type stub for the compiled C++ extension.
+
+The extension is a nanobind module, so mypy cannot see into it: without this
+file every use of :mod:`pantr._pantr_cpp` is an ``attr-defined`` error under the
+project's strict configuration, and ``pantr._backend`` is the module that uses
+it. The stub is written by hand rather than generated, because it is fifteen
+lines and a generated one would need regenerating on every signature change
+anyway.
+
+**It is a promise that has to be kept by hand.** Nothing checks this file
+against ``cpp/bindings/pantr_cpp.cpp``; if the binding's signature changes and
+this does not, mypy will happily typecheck a call that fails at run time. The
+parity test exercises the real call, which is what actually catches it.
+"""
+
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+
+__compiler__: Final[str]
+"""Compiler and version that built the extension, e.g. ``"gcc 14.4.0"``."""
+
+__has_std_mdspan__: Final[bool]
+"""Whether the build used ``std::mdspan`` rather than the Kokkos fallback."""
+
+__fp_contract__: Final[str]
+"""Whether the target ISA can fuse a multiply-add.
+
+``"available"`` or ``"unavailable-on-target-isa"``. Read by
+``tests/test_cpp_parity.py`` to choose between asserting bit-exact parity with
+the numba oracle and asserting the derived FMA bound: with no fused instruction
+on the target there is no rounding difference for a tolerance to absorb.
+"""
+
+def tabulate_cardinal_bspline_1d(
+    degree: int,
+    points: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Tabulate the cardinal B-spline basis of ``degree`` at ``points``.
+
+    The **C++ half of Layer 2** in the layering of CLAUDE.md, not Layer 3: it
+    validates every precondition the kernel behind it assumes and never checks.
+    That is not optional here -- the kernel indexes ``out`` using ``degree`` and
+    ``points.size`` with no bounds check of its own, so an unvalidated call
+    reaches undefined behaviour rather than an exception.
+
+    What is checked, and where:
+
+    * dtype, rank, C-contiguity, device and writability, by nanobind's typed
+      signature, before the body runs;
+    * that ``degree`` is a non-negative integer, by that same signature -- the
+      C++ parameter is ``unsigned``, so a negative value is rejected by the
+      caster and never reaches pantr's code;
+    * that ``out.shape == (points.size, degree + 1)``, in the function body.
+
+    Call :func:`pantr.basis.tabulate_cardinal_bspline_1d` for the ordinary path,
+    which additionally takes points of any shape and allocates ``out`` for you.
+
+    Args:
+        degree (int): Degree of the basis. Must be non-negative and must fit a
+            C ``int``.
+        points (npt.NDArray[np.float32 | np.float64]): Evaluation points, 1D and
+            C-contiguous.
+        out (npt.NDArray[np.float32 | np.float64]): Output array of shape
+            ``(points.size, degree + 1)``, matching ``points`` in dtype,
+            C-contiguous and writable. Written in full.
+
+    Raises:
+        TypeError: If ``degree`` is negative or is not an integer, if either
+            array has the wrong dtype or rank, or if either is not C-contiguous.
+            A non-contiguous array is **refused rather than converted**:
+            converting an ``out`` would fill a temporary and leave the caller's
+            array untouched, which is why ``.noconvert()`` is on it.
+        ValueError: If ``out.shape`` is not ``(points.size, degree + 1)``, or if
+            ``degree`` is too large to express as a C ``int``.
+    """

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -193,7 +193,10 @@ def _tabulate_cardinal_Bspline_basis_1D_impl(
     # tests -- without any of them knowing. Everything below this line, and all
     # of the Layer 2 validation above it, is shared by both backends, which is
     # what makes the comparison a comparison of kernels.
-    return _tabulate_basis_1D_impl_helper(n, t, cardinal_bspline_core(), out)
+    kernels = cardinal_bspline_core()
+    return _tabulate_basis_1D_impl_helper(
+        n, t, kernels.parallel, out, core_func_serial=kernels.serial
+    )
 
 
 def _tabulate_Lagrange_basis_1D_impl(

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -7,14 +7,13 @@ output array management.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from .._backend import cardinal_bspline_core
 from .._numba_compat import wait_for_jit_warmup
+from ._basis_backend import _BasisCoreFunc, cardinal_bspline_core
 from ._basis_core import (
     _PARALLEL_MIN_NUM_PTS,
     _tabulate_Bernstein_basis_1D_core,
@@ -30,13 +29,6 @@ from ._basis_utils import (
 
 if TYPE_CHECKING:
     from . import LagrangeVariant
-
-
-_BasisCoreFunc = Callable[
-    [np.int32, npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
-    None,
-]
-"""Signature of a 1D basis tabulation core kernel: ``(degree, pts, out) -> None``."""
 
 
 def _tabulate_basis_1D_impl_helper(
@@ -196,7 +188,7 @@ def _tabulate_cardinal_Bspline_basis_1D_impl(
         True
     """
     # The one seam of the C++ port: which implementation of this kernel runs is
-    # chosen per call by pantr._backend, so PANTR_BACKEND=cpp reaches every
+    # chosen per call by _basis_backend, so PANTR_BACKEND=cpp reaches every
     # caller of this function -- including pantr.change_basis and its existing
     # tests -- without any of them knowing. Everything below this line, and all
     # of the Layer 2 validation above it, is shared by both backends, which is

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 
+from .._backend import cardinal_bspline_core
 from .._numba_compat import wait_for_jit_warmup
 from ._basis_core import (
     _PARALLEL_MIN_NUM_PTS,
     _tabulate_Bernstein_basis_1D_core,
     _tabulate_Bernstein_basis_1D_serial_core,
-    _tabulate_cardinal_Bspline_basis_1D_core,
     _tabulate_Legendre_basis_1D_core,
 )
 from ._basis_lagrange import _tabulate_lagrange_basis_1D_core
@@ -195,7 +195,13 @@ def _tabulate_cardinal_Bspline_basis_1D_impl(
         >>> np.allclose(vals, [[0.5, 0.5, 0.0], [0.125, 0.75, 0.125], [0.0, 0.5, 0.5]])
         True
     """
-    return _tabulate_basis_1D_impl_helper(n, t, _tabulate_cardinal_Bspline_basis_1D_core, out)
+    # The one seam of the C++ port: which implementation of this kernel runs is
+    # chosen per call by pantr._backend, so PANTR_BACKEND=cpp reaches every
+    # caller of this function -- including pantr.change_basis and its existing
+    # tests -- without any of them knowing. Everything below this line, and all
+    # of the Layer 2 validation above it, is shared by both backends, which is
+    # what makes the comparison a comparison of kernels.
+    return _tabulate_basis_1D_impl_helper(n, t, cardinal_bspline_core(), out)
 
 
 def _tabulate_Lagrange_basis_1D_impl(

--- a/src/pantr/basis/_basis_backend.py
+++ b/src/pantr/basis/_basis_backend.py
@@ -46,11 +46,12 @@ class CoreKernels(NamedTuple):
     callable because the consumer already needs two of them:
     :func:`pantr.basis._basis_1D._tabulate_basis_1D_impl_helper` dispatches on
     ``_PARALLEL_MIN_NUM_PTS``, calling the serial twin below that many points to
-    avoid a parallel launch that costs more than the work. Cardinal B-spline is
-    the only 1D basis kernel with no twin, so a bare callable happens to fit the
-    one kernel ported so far and would stop fitting at the next one -- the same
-    concept would then have two return shapes, and every consumer would have to
-    know which.
+    avoid a parallel launch that costs more than the work. Bernstein is the only
+    1D basis tabulation that has such a twin today -- cardinal B-spline, Lagrange
+    and Legendre have none -- so a bare callable happens to fit the one kernel
+    ported so far and would stop fitting at Bernstein, which is the obvious next
+    one. The same concept would then have two return shapes, and every consumer
+    would have to know which it got.
 
     Attributes:
         parallel (_BasisCoreFunc): The kernel used for batches of

--- a/src/pantr/basis/_basis_backend.py
+++ b/src/pantr/basis/_basis_backend.py
@@ -16,12 +16,15 @@ nothing from the library, and an import-linter contract in ``pyproject.toml``
 keeps it that way.
 
 - :data:`_BasisCoreFunc`: the signature every 1D tabulation kernel has.
-- :func:`cardinal_bspline_core`: the cardinal B-spline kernel of a backend.
+- :class:`CoreKernels`: a tabulation's kernels in one backend, parallel and
+  serial.
+- :func:`cardinal_bspline_core`: the cardinal B-spline kernels of a backend.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -34,6 +37,31 @@ _BasisCoreFunc = Callable[
     None,
 ]
 """Signature of a 1D basis tabulation core kernel: ``(degree, pts, out) -> None``."""
+
+
+class CoreKernels(NamedTuple):
+    """The kernels implementing one tabulation, in one backend.
+
+    What a catalogue function returns, and it is a record rather than a bare
+    callable because the consumer already needs two of them:
+    :func:`pantr.basis._basis_1D._tabulate_basis_1D_impl_helper` dispatches on
+    ``_PARALLEL_MIN_NUM_PTS``, calling the serial twin below that many points to
+    avoid a parallel launch that costs more than the work. Cardinal B-spline is
+    the only 1D basis kernel with no twin, so a bare callable happens to fit the
+    one kernel ported so far and would stop fitting at the next one -- the same
+    concept would then have two return shapes, and every consumer would have to
+    know which.
+
+    Attributes:
+        parallel (_BasisCoreFunc): The kernel used for batches of
+            ``_PARALLEL_MIN_NUM_PTS`` points or more.
+        serial (_BasisCoreFunc | None): The serial twin, used below that
+            threshold. ``None`` when this tabulation has none, in which case
+            ``parallel`` runs at every batch size. Defaults to None.
+    """
+
+    parallel: _BasisCoreFunc
+    serial: _BasisCoreFunc | None = None
 
 
 def _cpp_cardinal_bspline_core(
@@ -82,8 +110,15 @@ def _cpp_cardinal_bspline_core(
     out[...] = buffer
 
 
-def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
-    """Return the cardinal B-spline tabulation kernel of the requested backend.
+def cardinal_bspline_core(backend: Backend | None = None) -> CoreKernels:
+    """Return the cardinal B-spline tabulation kernels of the requested backend.
+
+    Neither backend has a serial twin for this tabulation, so ``serial`` is
+    ``None`` in both. The Numba kernel is ``parallel=True`` and pays the launch
+    overhead at every batch size; the C++ one runs on the calling thread.
+    Whether a twin is worth adding is a performance question, and
+    ``design/simd.md`` open question 4 already asks whether the threshold that
+    would select it is derived or measured.
 
     Args:
         backend (Backend | None): The backend to use. ``None`` means the backend
@@ -91,7 +126,7 @@ def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
             Defaults to None.
 
     Returns:
-        _BasisCoreFunc: The kernel, callable as ``(n, t, out) -> None``.
+        CoreKernels: The kernels, each callable as ``(n, t, out) -> None``.
 
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
@@ -99,8 +134,8 @@ def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
     chosen = active_backend() if backend is None else backend
 
     if chosen is Backend.NUMBA:
-        return _tabulate_cardinal_Bspline_basis_1D_core
+        return CoreKernels(parallel=_tabulate_cardinal_Bspline_basis_1D_core)
 
     if chosen not in available_backends():
         raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
-    return _cpp_cardinal_bspline_core
+    return CoreKernels(parallel=_cpp_cardinal_bspline_core)

--- a/src/pantr/basis/_basis_backend.py
+++ b/src/pantr/basis/_basis_backend.py
@@ -1,0 +1,106 @@
+"""Which implementation of a basis kernel runs: the Numba one or the C++ port.
+
+:mod:`pantr._backend` owns the **policy** -- which backends exist, which one is
+selected, and the rule that an explicit request never falls back. This module
+owns the **catalogue** for the basis package: it maps that selection onto the
+callables themselves, and it is where the C++ adapter lives.
+
+The split is what keeps the dependency one-directional. A catalogue has to
+import the kernels it hands out, so a catalogue living inside the policy module
+makes :mod:`pantr._backend` import a subpackage of :mod:`pantr` -- while
+:mod:`pantr.basis._basis_1D` imports the policy to ask which kernel to call.
+That cycle used to be held open by a lazy import and a ``TYPE_CHECKING`` one,
+and it would have grown by one lazy import per kernel ported. Keeping each
+catalogue next to its own kernels removes it instead: the policy module imports
+nothing from the library, and an import-linter contract in ``pyproject.toml``
+keeps it that way.
+
+- :data:`_BasisCoreFunc`: the signature every 1D tabulation kernel has.
+- :func:`cardinal_bspline_core`: the cardinal B-spline kernel of a backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+from ._basis_core import _tabulate_cardinal_Bspline_basis_1D_core
+
+_BasisCoreFunc = Callable[
+    [np.int32, npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
+    None,
+]
+"""Signature of a 1D basis tabulation core kernel: ``(degree, pts, out) -> None``."""
+
+
+def _cpp_cardinal_bspline_core(
+    n: np.int32,
+    t: npt.NDArray[np.float32 | np.float64],
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Adapt the C++ kernel to the :data:`_BasisCoreFunc` signature.
+
+    The adapter's whole job is that **the public API must behave identically on
+    both backends**, because otherwise an A/B measurement is comparing two
+    contracts rather than two kernels. One difference has to be absorbed here:
+    the numba kernel accepts a non-contiguous ``out`` and fills it, while the
+    C++ binding requires C-contiguous memory and refuses anything else. So a
+    non-contiguous ``out`` is computed into a contiguous buffer and copied back,
+    and the caller sees the numba behaviour either way.
+
+    Refusing instead would be the wrong fix: it would make ``PANTR_BACKEND``
+    change what the library accepts, not just how fast it is.
+
+    Args:
+        n (np.int32): Degree of the basis. Assumed non-negative.
+        t (npt.NDArray[np.float32 | np.float64]): 1D evaluation points.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(t.size, n + 1)`` and matching dtype. Need not be contiguous.
+
+    Note:
+        No input validation is performed. Shape and dtype are established by the
+        Layer 2 caller; dtype, rank and contiguity are re-checked by nanobind's
+        typed signature, which raises :class:`TypeError` before the kernel runs
+        rather than silently converting -- see the ``.noconvert()`` in
+        ``cpp/bindings/pantr_cpp.cpp`` and why it is a correctness requirement.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    points = np.ascontiguousarray(t)
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, out)
+        return
+
+    # The uncommon path. The check above is a flag read, so the common case pays
+    # essentially nothing for it; only a caller that actually passes a strided
+    # view pays for the buffer and the copy back.
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.tabulate_cardinal_bspline_1d(int(n), points, buffer)
+    out[...] = buffer
+
+
+def cardinal_bspline_core(backend: Backend | None = None) -> _BasisCoreFunc:
+    """Return the cardinal B-spline tabulation kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        _BasisCoreFunc: The kernel, callable as ``(n, t, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.NUMBA:
+        return _tabulate_cardinal_Bspline_basis_1D_core
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return _cpp_cardinal_bspline_core

--- a/src/pantr/basis/_basis_tabulate.py
+++ b/src/pantr/basis/_basis_tabulate.py
@@ -65,6 +65,9 @@ def tabulate_bernstein_1d(
         If `out` was provided, returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
 
@@ -117,6 +120,9 @@ def tabulate_cardinal_bspline_1d(
         If `out` was provided, returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If provided degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
 
@@ -164,6 +170,9 @@ def tabulate_lagrange_1d(
         If `out` was provided, returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If provided degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
@@ -197,6 +206,9 @@ def tabulate_legendre_1d(
         If `out` was provided, returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If provided degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
@@ -258,6 +270,9 @@ def tabulate_bernstein(
         returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If any degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
@@ -301,6 +316,9 @@ def tabulate_cardinal_bspline(
         returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If any degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
@@ -346,6 +364,9 @@ def tabulate_lagrange(
         returns the same array.
 
     Raises:
+        TypeError: If `pts` or `out` is a `numpy.ma.MaskedArray`. No kernel can honour
+            a mask, and dropping it silently would make the result depend on which
+            backend is selected.
         ValueError: If any degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """

--- a/src/pantr/basis/_basis_utils.py
+++ b/src/pantr/basis/_basis_utils.py
@@ -20,6 +20,40 @@ from .._array_utils import _validate_float_dtype
 __all__ = ["_validate_float_dtype"]
 
 
+def _reject_masked_array(array: npt.ArrayLike, role: str) -> None:
+    """Refuse a masked array, which no kernel below this layer can honour.
+
+    A :class:`numpy.ma.MaskedArray` carries per-element validity that every
+    kernel would silently drop -- and the two backends do not even drop it the
+    same way. Measured on ``tabulate_cardinal_bspline_1d``: Numba refuses the
+    type outright, while the C++ binding accepts it through the buffer protocol,
+    computes on the underlying data and returns plausible numbers for the entries
+    the caller marked invalid. That is precisely the divergence
+    ``pantr._backend`` promises cannot happen: selecting a backend must change
+    how fast the library is, never what it accepts.
+
+    So the mask is refused here, in the layer that owns validation, and the
+    refusal follows Numba, which is the correct behaviour of the two. Other
+    ``ndarray`` subclasses are deliberately not checked: this is the one whose
+    *semantics* are lost, rather than merely its subclass identity.
+
+    Args:
+        array (npt.ArrayLike): The argument to inspect. Anything that is not a
+            masked array passes.
+        role (str): What the argument is, named in the message (e.g. ``points``).
+
+    Raises:
+        TypeError: If ``array`` is a :class:`numpy.ma.MaskedArray`.
+    """
+    if isinstance(array, np.ma.MaskedArray):
+        raise TypeError(
+            f"{role} is a numpy.ma.MaskedArray, which pantr does not accept: the mask "
+            f"would be discarded and the masked entries computed on anyway. Pass "
+            f"`{role}.filled(fill_value)` to choose what those entries hold, or "
+            f"`np.asarray({role})` to drop the mask deliberately."
+        )
+
+
 def _normalize_points_1D(pts: npt.ArrayLike) -> npt.NDArray[np.float32 | np.float64]:
     """Normalize points to a 1D float array for basis function evaluation.
 
@@ -38,7 +72,12 @@ def _normalize_points_1D(pts: npt.ArrayLike) -> npt.NDArray[np.float32 | np.floa
         point dtype. The dtype is preserved from the input if it's already a
         floating point type (float32/float64), otherwise converted to np.float64.
         The array is guaranteed to have exactly one dimension (ndim == 1).
+
+    Raises:
+        TypeError: If ``pts`` is a masked array; see :func:`_reject_masked_array`.
     """
+    _reject_masked_array(pts, "points")
+
     if not isinstance(pts, np.ndarray):
         pts = np.array(pts)
 
@@ -108,8 +147,13 @@ def _validate_out_array(
             ``np.float64``, ``np.bool_``, ``np.int_``).
 
     Raises:
+        TypeError: If ``out`` is a masked array; see :func:`_reject_masked_array`.
+            An ``out`` is the worse half of that divergence -- the C++ backend
+            writes through the mask into the caller's own array.
         ValueError: If the array shape, dtype, or writability does not match.
     """
+    _reject_masked_array(out, "out")
+
     if out.shape != expected_shape:
         raise ValueError(f"Output array has shape {out.shape}, but expected shape {expected_shape}")
     if out.dtype != np.dtype(expected_dtype):

--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -1,0 +1,862 @@
+"""Kernel-agnostic harness for checking a C++ port against its Numba oracle.
+
+This module is **infrastructure, not tests**. It is deliberately not named
+``test_*.py`` so pytest does not collect it, and it is imported by the per-kernel
+parity modules (``tests/test_cpp_parity.py`` today, one more per ported module as
+the port proceeds).
+
+Why it exists
+-------------
+
+The port keeps the Numba implementation as the parity oracle, so every ported
+kernel needs the same question answered: *how far apart may the two backends be,
+and why exactly that far?* Answered once per kernel by hand, that question
+produces a bare ``1e-12`` in five different files. The purpose of this module is
+to make a bare number **impossible to express**.
+
+There is no ``atol``, no ``rtol`` and no scalar tolerance parameter anywhere in
+this API. A parity assertion takes a :class:`ParityClaim`, and a claim can only
+be built by one of two factories:
+
+``bitwise_parity(why=...)``
+    The two backends perform the identical sequence of IEEE-754 operations in the
+    identical order, so the results agree bit for bit. Nothing but a reason is
+    required, because nothing but a reason is available.
+
+``bounded_parity(roundings=..., accumulator=..., storage=..., amplification=..., why=...)``
+    The two backends differ somewhere, and the difference is bounded by a
+    *derivation*: how many sequential stages the recurrence has, how many
+    roundings each stage commits in the accumulator and in the storage format,
+    which formats those are, and how much the recurrence amplifies a perturbation
+    at each output element. The tolerance is computed from those; it cannot be
+    typed in.
+
+The keyword arguments are all required and all keyword-only. Supplying them is
+the derivation.
+
+The amplification array
+-----------------------
+
+``amplification`` is the piece that carries the mathematics of the particular
+kernel, and it is an **array**, one entry per output element, not a scalar. It is
+the elementwise factor by which the recurrence magnifies a relative perturbation
+of its intermediates: for a recurrence that forms convex combinations of
+non-negative values it equals the value itself (a relative bound), and for one
+that cancels it is strictly larger (the running sum of the magnitudes of the
+contributions). Making it an array rather than a number is what lets one bound
+cover both the well-conditioned interior of a domain and its badly conditioned
+outside, without a second tolerance and without excluding the hard cases.
+
+The usual way to produce it is a *companion recurrence*: run the kernel's own
+recurrence with every coefficient replaced by its absolute value. See
+``tests/test_cpp_parity.py`` for a worked one.
+
+The underflow floor
+-------------------
+
+A bound built only from ``amplification`` is proportional to the magnitude of the
+result, and so goes to zero with it. Floating-point error does not: below the
+smallest normal the spacing stops shrinking, and a rounding costs an absolute
+amount no relative bound can express. A purely relative bound therefore asserts
+*bit-for-bit agreement* on every result small enough, which it has no grounds
+for and which correct code violates. It did: on the cardinal B-spline's own
+oracle point set, float32 at degree 16, the shipped bound was exceeded by a
+factor of 1.0e6 by two backends that agree perfectly.
+
+So every tolerance here carries both halves of Higham's model -- a relative term
+and an absolute floor. :func:`underflow_floor` supplies the magnitude, and the
+counts already in :class:`Roundings` supply how many of them there are. No new
+keyword argument was needed for it, which is the point: the budget was always
+stated as a count, and only its conversion to a magnitude was incomplete.
+
+What the harness deliberately does not do
+-----------------------------------------
+
+It does not know whether the two backends are **right**, only whether they
+**agree**. Parity is a consistency check, and a consistency check whose reference
+is the code itself certifies nothing. Every per-kernel module using this harness
+owes an independent oracle as well: closed-form values, exact rational
+arithmetic, an analytic invariant. :func:`assert_accuracy` is the slot for that,
+and it takes an elementwise derived bound for the same reason.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import IntEnum
+from typing import Any, Final, NamedTuple, cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+__all__ = [
+    "AccuracyClaim",
+    "BuildProvenance",
+    "Deviation",
+    "ParityClaim",
+    "ParityKind",
+    "Roundings",
+    "absolute_tolerance",
+    "assert_accuracy",
+    "assert_parity",
+    "bitwise_parity",
+    "bounded_parity",
+    "build_provenance",
+    "contraction_may_fuse",
+    "cpp_backend_available",
+    "demand_cpp_backend",
+    "derived_accuracy",
+    "underflow_floor",
+    "unit_roundoff",
+]
+
+FloatArray = npt.NDArray[np.floating[Any]]
+"""Any real-valued NumPy array the backends can produce or consume."""
+
+_REQUIRE_ENV_VAR: Final[str] = "PANTR_REQUIRE_CPP"
+"""Environment variable that turns "the extension is absent" from a skip into a failure."""
+
+_BUILD_HINT: Final[str] = (
+    "build it with `pip install -e .` (scikit-build-core drives CMake), and set "
+    f"{_REQUIRE_ENV_VAR}=1 to make its absence a failure rather than a skip"
+)
+"""What to do about a missing extension, quoted in every skip reason."""
+
+
+# ---------------------------------------------------------------------------
+# Availability, and making its absence audible
+# ---------------------------------------------------------------------------
+
+
+def cpp_backend_available() -> bool:
+    """Report whether the compiled extension is importable in this installation.
+
+    Returns:
+        bool: True when ``pantr._pantr_cpp`` was built into this installation.
+    """
+    from pantr._backend import Backend, available_backends  # noqa: PLC0415
+
+    return Backend.CPP in available_backends()
+
+
+def require_cpp_backend_is_set() -> bool:
+    """Report whether the environment demands the extension be present.
+
+    CLAUDE.md records that a missing optional dependency skips silently here, and
+    that a local green built on such a skip has let real failures through. CI sets
+    this variable in the job that builds the extension, so that job cannot pass by
+    skipping the very tests it exists to run.
+
+    Returns:
+        bool: True when ``PANTR_REQUIRE_CPP`` is set to a non-empty value.
+    """
+    return bool(os.environ.get(_REQUIRE_ENV_VAR, ""))
+
+
+SKIP_REASON: Final[str] = (
+    f"the pantr._pantr_cpp extension is not built in this installation; {_BUILD_HINT}"
+)
+"""Reason attached to every skipped parity test, printed by ``pytest -rs``."""
+
+_MISSING_BUT_REQUIRED: Final[str] = (
+    f"{_REQUIRE_ENV_VAR} is set but pantr._pantr_cpp is not importable, so every C++ "
+    f"parity test that asked for it would have been skipped. Build the extension with "
+    f"`pip install -e .`, or unset {_REQUIRE_ENV_VAR} if this run is meant to be "
+    f"Numba-only."
+)
+"""Message for the one configuration in which a missing extension must fail."""
+
+
+def demand_cpp_backend() -> None:
+    """Skip, or fail, when the compiled extension is absent.
+
+    **The only supported way for a parity test to require the extension**, and the
+    reason a plain ``pytest.mark.skipif`` is not offered here. A bare skip is the
+    trap CLAUDE.md names by name: a missing optional dependency skips without
+    complaint, and a local green built on such a skip has let real failures through
+    in this repository before. Under ``PANTR_REQUIRE_CPP`` the absence is a failure
+    instead, which is what stops the CI job that builds the extension from passing
+    by skipping the very tests it exists to run.
+
+    Call it from a fixture rather than applying it module-wide: a module-level mark
+    silences the test that reports the extension's *presence* along with everything
+    else, and that report is the whole point.
+
+    Raises:
+        Failed: Via :func:`pytest.fail`, when ``PANTR_REQUIRE_CPP`` is set and the
+            extension is missing.
+        Skipped: Via :func:`pytest.skip`, when it is missing and not required.
+    """
+    if cpp_backend_available():
+        return
+    if require_cpp_backend_is_set():
+        pytest.fail(_MISSING_BUT_REQUIRED)
+    pytest.skip(SKIP_REASON)
+
+
+class BuildProvenance(NamedTuple):
+    """Which binary produced a measurement, and how it treats contraction.
+
+    The extension reports these itself (``cpp/bindings/pantr_cpp.cpp``), so a
+    parity claim can be conditioned on the build rather than on an assumption
+    about the build.
+
+    Attributes:
+        compiler (str): Compiler name and version, e.g. ``"gcc 14.4.0"``.
+        fp_contract (str): ``"available"`` when the target ISA has an FMA the
+            compiler may contract into, ``"unavailable-on-target-isa"`` otherwise.
+        has_std_mdspan (bool): Whether the standard library supplied
+            ``std::mdspan`` rather than the fetched reference implementation.
+    """
+
+    compiler: str
+    fp_contract: str
+    has_std_mdspan: bool
+
+
+FP_CONTRACT_AVAILABLE: Final[str] = "available"
+"""Value of ``__fp_contract__`` meaning the target ISA has an FMA to contract into."""
+
+FP_CONTRACT_UNAVAILABLE: Final[str] = "unavailable-on-target-isa"
+"""Value of ``__fp_contract__`` meaning no FMA instruction exists on the target."""
+
+
+def build_provenance() -> BuildProvenance:
+    """Read the compiled extension's self-reported build provenance.
+
+    Returns:
+        BuildProvenance: The compiler, the contraction availability and whether
+            ``std::mdspan`` came from the standard library.
+
+    Raises:
+        RuntimeError: If the extension is not available.
+    """
+    if not cpp_backend_available():
+        raise RuntimeError(SKIP_REASON)
+
+    # Imported here rather than read off a module handle held in pantr._backend:
+    # the provenance attributes are declared in src/pantr/_pantr_cpp.pyi, so this
+    # spelling is the one mypy can actually check.
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return BuildProvenance(
+        compiler=str(_pantr_cpp.__compiler__),
+        fp_contract=str(_pantr_cpp.__fp_contract__),
+        has_std_mdspan=bool(_pantr_cpp.__has_std_mdspan__),
+    )
+
+
+def contraction_may_fuse() -> bool:
+    """Report whether this build can fuse a multiply-add at all.
+
+    ``cmake/PantrCompileOptions.cmake`` sets ``-ffp-contract=on`` but no
+    ``-march``, so the target is baseline x86-64, which has no FMA instruction and
+    therefore nothing to contract into. ``design/simd.md`` schedules
+    ``-march=x86-64-v3`` as a later stage, at which point this flips and the
+    bounded branch of a parity claim becomes the live one.
+
+    Returns:
+        bool: True when the target ISA offers a fused multiply-add.
+    """
+    return build_provenance().fp_contract == FP_CONTRACT_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# The claim types
+# ---------------------------------------------------------------------------
+
+
+class ParityKind(IntEnum):
+    """How far apart two backends are allowed to be.
+
+    An :class:`~enum.IntEnum` rather than a string, per the project's rule that a
+    closed set of choices is never stringly typed.
+
+    Attributes:
+        BITWISE: Identical operation sequence in identical order, so identical
+            bits. The strongest claim available, and the one to make whenever it
+            holds: a tolerance that is never approached asserts nothing.
+        BOUNDED: The backends differ, within a bound derived from a rounding
+            budget and an elementwise amplification.
+    """
+
+    BITWISE = 0
+    BOUNDED = 1
+
+
+class Roundings(NamedTuple):
+    """The rounding budget of one kernel, as a count rather than a magnitude.
+
+    Counting roundings is the part a reader can check against the source; turning
+    a count into a magnitude is arithmetic the harness does. Splitting the count
+    by format is what makes one budget serve float32 and float64 storage over a
+    float64 accumulator, which is the shape every pantr kernel has.
+
+    Attributes:
+        stages (int): Sequential stages in the recurrence, i.e. the length of the
+            dependency chain from an input to an output element. Not the total
+            operation count: independent operations do not compound.
+        accumulator_per_stage (int): Roundings each stage commits in the
+            accumulator format, counted along the dominant path. Independent
+            summands of a non-cancelling sum count once between them, not once
+            each.
+        storage_per_stage (int): Roundings each stage commits when narrowing to
+            the storage format, i.e. stores back into the output array.
+    """
+
+    stages: int
+    accumulator_per_stage: int
+    storage_per_stage: int
+
+
+class ParityClaim(NamedTuple):
+    """A statement about how far two backends may differ, with its derivation.
+
+    Built by :func:`bitwise_parity` or :func:`bounded_parity`; do not construct it
+    positionally.
+
+    Attributes:
+        kind (ParityKind): Which of the two statements is being made.
+        roundings (Roundings | None): The rounding budget. None for BITWISE.
+        accumulator (np.dtype[np.floating[Any]] | None): Format intermediates are
+            accumulated in. None for BITWISE.
+        storage (np.dtype[np.floating[Any]] | None): Format the output array
+            holds. None for BITWISE.
+        amplification (FloatArray | None): Elementwise factor by which the
+            recurrence magnifies a relative perturbation. None for BITWISE.
+        why (str): The derivation, or the reason exactness holds. Quoted verbatim
+            in any failure message.
+    """
+
+    kind: ParityKind
+    roundings: Roundings | None
+    accumulator: np.dtype[np.floating[Any]] | None
+    storage: np.dtype[np.floating[Any]] | None
+    amplification: FloatArray | None
+    why: str
+
+
+class AccuracyClaim(NamedTuple):
+    """An elementwise absolute error bound against an independent oracle.
+
+    Built by :func:`derived_accuracy`.
+
+    Attributes:
+        bound (FloatArray): Elementwise absolute bound, same shape as the result.
+        why (str): The derivation. Quoted verbatim in any failure message.
+    """
+
+    bound: FloatArray
+    why: str
+
+
+class Deviation(NamedTuple):
+    """What a comparison actually observed, for a caller that wants to assert on it.
+
+    Attributes:
+        max_absolute (float): Largest absolute difference over all elements.
+        max_ratio_to_bound (float): Largest ratio of difference to its own
+            elementwise bound. At most 1 for a comparison that passed; 0 when the
+            arrays are identical.
+        num_differing (int): How many elements differed at all.
+    """
+
+    max_absolute: float
+    max_ratio_to_bound: float
+    num_differing: int
+
+
+def _float_dtype(dtype: npt.DTypeLike) -> np.dtype[np.floating[Any]]:
+    """Normalise a dtype-like value to a floating dtype.
+
+    Args:
+        dtype (npt.DTypeLike): A floating-point dtype.
+
+    Returns:
+        np.dtype[np.floating[Any]]: The normalised dtype.
+
+    Raises:
+        TypeError: If it is not a floating-point dtype.
+    """
+    resolved = np.dtype(dtype)
+    if not np.issubdtype(resolved, np.floating):
+        raise TypeError(f"{resolved} is not a floating-point dtype")
+    return cast("np.dtype[np.floating[Any]]", resolved)
+
+
+def unit_roundoff(dtype: npt.DTypeLike) -> float:
+    """Return the unit roundoff of a floating format.
+
+    Half an epsilon, not an epsilon: ``eps`` is the gap between 1 and its
+    successor, and round-to-nearest commits at most half a gap.
+
+    Args:
+        dtype (npt.DTypeLike): A floating-point dtype.
+
+    Returns:
+        float: The unit roundoff ``u`` of that format.
+    """
+    return float(np.finfo(np.dtype(dtype)).eps) / 2.0
+
+
+def underflow_floor(dtype: npt.DTypeLike) -> float:
+    r"""Return the absolute error floor of one rounding in a floating format.
+
+    The other half of the rounding model, and the half a purely relative bound
+    silently omits. Higham's model of a floating-point operation is
+
+    .. math::
+
+        \mathrm{fl}(x \mathbin{\mathrm{op}} y)
+            = (x \mathbin{\mathrm{op}} y)(1 + \delta) + \eta,
+        \qquad |\delta| \le u, \quad |\eta| \le \eta_{\text{fmt}},
+        \quad \delta\eta = 0,
+
+    with :math:`\eta` non-zero only when the exact result falls in the gradual-
+    underflow range. There the spacing is no longer proportional to the value: it
+    is the constant :math:`\lambda`, the smallest positive subnormal, and a
+    rounding commits at most :math:`\lambda / 2`. A bound written as
+    :math:`u |x|` alone therefore goes to zero with :math:`x` while the true
+    error does not, and asserts something false about every result small enough.
+
+    :math:`\lambda` is returned rather than the sharp :math:`\lambda / 2`, and the
+    reason is representability rather than a safety margin. Halving the smallest
+    subnormal always ties to even and gives zero *in that format* -- true of every
+    binary format, not a float64 peculiarity. What differs is the format the
+    bounds here are accumulated in, which is float64: so :math:`\lambda / 2`
+    survives for float32 (``7.0e-46``) and collapses for float64, where it is
+    exactly ``0.0``. Returning the sharp constant would therefore leave float64
+    with no floor at all, which is the bug this function exists to fix. The
+    resulting factor-of-two over-estimate costs nothing, because the floor only
+    ever binds where the relative term has already collapsed.
+
+    Args:
+        dtype (npt.DTypeLike): A floating-point dtype.
+
+    Returns:
+        float: The absolute floor of one rounding in that format.
+    """
+    return float(np.finfo(np.dtype(dtype)).smallest_subnormal)
+
+
+def bitwise_parity(*, why: str) -> ParityClaim:
+    """Claim that the two backends produce identical bits.
+
+    Args:
+        why (str): Why the two operation sequences are identical. A build-specific
+            reason (no FMA on the target ISA, say) must name what would change it.
+
+    Returns:
+        ParityClaim: A claim asserting bit-for-bit agreement.
+
+    Raises:
+        ValueError: If ``why`` is empty.
+    """
+    if not why.strip():
+        raise ValueError("a bitwise parity claim must say why the operation sequences agree")
+    return ParityClaim(
+        kind=ParityKind.BITWISE,
+        roundings=None,
+        accumulator=None,
+        storage=None,
+        amplification=None,
+        why=why,
+    )
+
+
+def bounded_parity(
+    *,
+    roundings: Roundings,
+    accumulator: npt.DTypeLike,
+    storage: npt.DTypeLike,
+    amplification: FloatArray,
+    why: str,
+) -> ParityClaim:
+    """Claim that the two backends differ within a derived elementwise bound.
+
+    Every argument is required and keyword-only. Together they *are* the
+    derivation: there is no parameter into which a fitted number could be typed.
+
+    Args:
+        roundings (Roundings): The kernel's rounding budget.
+        accumulator (npt.DTypeLike): Format intermediates are accumulated in.
+        storage (npt.DTypeLike): Format the output array holds.
+        amplification (FloatArray): Elementwise amplification factor, same shape
+            as the result. Must be finite and non-negative.
+        why (str): The derivation, in prose, including what makes the
+            amplification array correct.
+
+    Returns:
+        ParityClaim: A claim asserting agreement within the derived bound.
+
+    Raises:
+        ValueError: If ``why`` is empty, if the budget is not a positive number of
+            stages, or if the amplification array is not finite and non-negative.
+    """
+    if not why.strip():
+        raise ValueError("a bounded parity claim must carry its derivation")
+    if roundings.stages < 1:
+        raise ValueError("a bounded claim over zero stages is a bitwise claim; use bitwise_parity")
+    if roundings.accumulator_per_stage < 0 or roundings.storage_per_stage < 0:
+        raise ValueError("rounding counts are counts, so they cannot be negative")
+    amp = np.asarray(amplification, dtype=np.float64)
+    if not np.all(np.isfinite(amp)) or np.any(amp < 0.0):
+        raise ValueError(
+            "the amplification array must be finite and non-negative; an infinite "
+            "entry means the kernel overflowed and the comparison is vacuous there"
+        )
+    return ParityClaim(
+        kind=ParityKind.BOUNDED,
+        roundings=roundings,
+        accumulator=_float_dtype(accumulator),
+        storage=_float_dtype(storage),
+        amplification=amp,
+        why=why,
+    )
+
+
+def derived_accuracy(*, bound: FloatArray, why: str) -> AccuracyClaim:
+    """Claim an elementwise absolute error bound against an independent oracle.
+
+    Args:
+        bound (FloatArray): Elementwise absolute bound, same shape as the result.
+        why (str): How the bound was derived.
+
+    Returns:
+        AccuracyClaim: The claim.
+
+    Raises:
+        ValueError: If ``why`` is empty or the bound is not finite and positive.
+    """
+    if not why.strip():
+        raise ValueError("an accuracy claim must carry its derivation")
+    arr = np.asarray(bound, dtype=np.float64)
+    if not np.all(np.isfinite(arr)) or np.any(arr < 0.0):
+        raise ValueError("the accuracy bound must be finite and non-negative")
+    return AccuracyClaim(bound=arr, why=why)
+
+
+ONE_SIDED_TO_TWO_SIDED: Final[int] = 2
+"""Factor turning a one-sided forward-error bound into a two-sided parity bound.
+
+Neither backend is the exact answer. Each sits within its own forward-error bound
+of the exact recurrence, so their difference is bounded by the sum of the two.
+The factor is 2 because the two bounds are equal, and it is a derivation rather
+than a safety margin: dropping it would be claiming one backend rounds perfectly.
+"""
+
+
+def _relative_growth(claim: ParityClaim) -> float:
+    """Accumulate a claim's per-stage rounding budget over its stages.
+
+    Args:
+        claim (ParityClaim): A BOUNDED claim.
+
+    Returns:
+        float: The relative factor ``(1 + delta)**stages - 1``, the standard
+            ``gamma`` of a forward-error analysis.
+
+    Raises:
+        ValueError: If the budget is so large that the bound carries no
+            information (a relative bound at or above 1 accepts everything).
+    """
+    assert claim.roundings is not None  # BOUNDED by construction
+    assert claim.accumulator is not None
+    assert claim.storage is not None
+
+    u_acc = unit_roundoff(claim.accumulator)
+    # A store into the accumulator's own format rounds nothing, so it costs
+    # nothing. Only a narrowing store does.
+    u_store = 0.0 if claim.storage == claim.accumulator else unit_roundoff(claim.storage)
+
+    per_stage = (
+        claim.roundings.accumulator_per_stage * u_acc + claim.roundings.storage_per_stage * u_store
+    )
+    if per_stage == 0.0:
+        raise ValueError(
+            f"the rounding budget {claim.roundings} commits no rounding at all in "
+            f"accumulator {claim.accumulator} with storage {claim.storage}, so the "
+            f"relative bound is exactly zero and this BOUNDED claim asserts bit-for-bit "
+            f"agreement while saying it does not. Use bitwise_parity, which says so and "
+            f"reports a violation as one."
+        )
+    growth = float((1.0 + per_stage) ** claim.roundings.stages - 1.0)
+    if growth >= 1.0:
+        raise ValueError(
+            f"the rounding budget accumulates to a relative bound of {growth:.3g}, "
+            f"which accepts every finite result. {claim.roundings.stages} stages of "
+            f"{per_stage:.3g} exhaust the format; the comparison would be vacuous."
+        )
+    return growth
+
+
+def _underflow_budget(claim: ParityClaim) -> float:
+    """Accumulate a claim's per-stage rounding budget as an ABSOLUTE floor.
+
+    The magnitude half of a budget :class:`Roundings` already carries as a count.
+    Each rounding contributes at most :func:`underflow_floor` of its own format
+    absolutely, on top of its relative contribution, and the floors add over the
+    stages:
+
+    * where the amplification is at most 1 -- inside the span, where every stage
+      map is a convex combination of non-negative values -- an absolute
+      perturbation is passed on unamplified, so the total is exactly the sum;
+    * where the amplification exceeds 1, a floor introduced at one stage can be
+      magnified by the later ones, by at most that same amplification. That case
+      needs no separate term, because it is already inside the relative one: the
+      magnified floor is at most ``amplification * stages * floor``, which is
+      below ``gamma * amplification`` whenever ``stages * floor <= gamma``. Both
+      sides are linear in the stage count, so that comparison does not depend on
+      the degree at all -- it is a fact about the formats. Measured, for the two
+      this harness is used with: float64 storage leaves ``gamma`` larger by 307
+      orders of magnitude, float32 storage by 38.
+
+    Neither margin is close, so the relative term absorbs the amplified floor
+    whole and the simple sum is a bound in both regimes.
+
+    So the floor binds only where the relative term has collapsed -- which is
+    exactly where it must, since that is where a purely relative bound asserts
+    that two backends may not differ at all.
+
+    Args:
+        claim (ParityClaim): A BOUNDED claim.
+
+    Returns:
+        float: The absolute floor accumulated over the claim's stages.
+    """
+    assert claim.roundings is not None  # BOUNDED by construction
+    assert claim.accumulator is not None
+    assert claim.storage is not None
+
+    eta_acc = underflow_floor(claim.accumulator)
+    # A store into the accumulator's own format rounds nothing, so it has no
+    # floor either -- the same reasoning as for its relative cost.
+    eta_store = 0.0 if claim.storage == claim.accumulator else underflow_floor(claim.storage)
+
+    per_stage = (
+        claim.roundings.accumulator_per_stage * eta_acc
+        + claim.roundings.storage_per_stage * eta_store
+    )
+    return claim.roundings.stages * per_stage
+
+
+def absolute_tolerance(claim: ParityClaim) -> FloatArray:
+    """Compute the elementwise absolute tolerance a claim permits.
+
+    Args:
+        claim (ParityClaim): The claim.
+
+    Returns:
+        FloatArray: Zero everywhere for BITWISE; otherwise
+            ``2 * (gamma * amplification + underflow floor)``, the two halves of
+            the rounding model that :func:`underflow_floor` describes. Both are
+            doubled for the same reason: neither backend is the exact answer, so
+            the parity bound is twice a one-sided forward-error bound.
+    """
+    if claim.kind is ParityKind.BITWISE:
+        shape = () if claim.amplification is None else claim.amplification.shape
+        return np.zeros(shape, dtype=np.float64)
+    assert claim.amplification is not None  # BOUNDED by construction
+    relative = _relative_growth(claim) * claim.amplification
+    return ONE_SIDED_TO_TWO_SIDED * (relative + _underflow_budget(claim))
+
+
+def _bit_pattern(array: FloatArray) -> npt.NDArray[np.unsignedinteger[Any]]:
+    """View a float array as the unsigned integer of the same width.
+
+    Args:
+        array (FloatArray): A contiguous float32 or float64 array.
+
+    Returns:
+        npt.NDArray[np.unsignedinteger[Any]]: The raw bit patterns.
+
+    Raises:
+        TypeError: If the dtype is neither float32 nor float64.
+    """
+    contiguous = np.ascontiguousarray(array)
+    if contiguous.dtype == np.float64:
+        return contiguous.view(np.uint64)
+    if contiguous.dtype == np.float32:
+        return contiguous.view(np.uint32)
+    raise TypeError(f"no bit view defined for dtype {contiguous.dtype}")
+
+
+def _bits_differ(actual: FloatArray, reference: FloatArray) -> npt.NDArray[np.bool_]:
+    """Locate elements whose bit patterns differ, treating the two zeros as equal.
+
+    ``-0.0`` and ``+0.0`` have different bit patterns and the same value. CLAUDE.md
+    records that the sign of a min/max tie already differs across the NumPy
+    versions in the CI matrix, so a suite that pins the sign of a zero pins
+    something the platform does not promise. A signed-zero disagreement is
+    therefore not counted here; a disagreement in any other bit is.
+
+    Args:
+        actual (FloatArray): One result.
+        reference (FloatArray): The other.
+
+    Returns:
+        npt.NDArray[np.bool_]: True where the two differ in value.
+    """
+    differ = _bit_pattern(actual) != _bit_pattern(reference)
+    both_zero = (actual == 0.0) & (reference == 0.0)
+    return np.asarray(differ & ~both_zero)
+
+
+def _worst_element_report(
+    actual: FloatArray,
+    reference: FloatArray,
+    tolerance: FloatArray,
+    offenders: npt.NDArray[np.bool_],
+) -> str:
+    """Describe the single worst offending element in a failed comparison.
+
+    Args:
+        actual (FloatArray): One result.
+        reference (FloatArray): The other.
+        tolerance (FloatArray): Elementwise tolerance, broadcast to the results.
+        offenders (npt.NDArray[np.bool_]): Mask of elements that failed.
+
+    Returns:
+        str: A multi-line description naming the index, both values and the ratio.
+    """
+    difference = np.abs(actual.astype(np.float64) - reference.astype(np.float64))
+    penalized = np.where(offenders, difference, -np.inf)
+    flat = int(np.argmax(penalized))
+    index = np.unravel_index(flat, difference.shape)
+    allowed = float(np.broadcast_to(tolerance, difference.shape)[index])
+    observed = float(difference[index])
+    ratio = observed / allowed if allowed > 0.0 else np.inf
+    return (
+        f"  worst element {index}:\n"
+        f"    actual    = {float(actual[index])!r}\n"
+        f"    reference = {float(reference[index])!r}\n"
+        f"    |diff|    = {observed:.6e}\n"
+        f"    allowed   = {allowed:.6e}\n"
+        f"    ratio     = {ratio:.4g}\n"
+        f"  {int(np.count_nonzero(offenders))} of {difference.size} elements out of bound"
+    )
+
+
+def assert_parity(
+    actual: FloatArray,
+    reference: FloatArray,
+    claim: ParityClaim,
+    *,
+    context: str,
+) -> Deviation:
+    """Assert that two backends agree as far as a claim says they must.
+
+    Args:
+        actual (FloatArray): The backend under test, conventionally the C++ one.
+        reference (FloatArray): The oracle, conventionally the Numba one.
+        claim (ParityClaim): What agreement is being claimed, and why.
+        context (str): What was being computed, quoted in a failure message.
+
+    Returns:
+        Deviation: What was observed, so a caller can assert on the margin as well
+            as on the pass.
+
+    Raises:
+        AssertionError: If shapes or dtypes disagree, if any element is not finite
+            in one result and finite in the other, or if the claim is violated.
+    """
+    assert actual.shape == reference.shape, (
+        f"{context}: shape {actual.shape} against {reference.shape}"
+    )
+    assert actual.dtype == reference.dtype, (
+        f"{context}: dtype {actual.dtype} against {reference.dtype}"
+    )
+
+    finite_actual = np.isfinite(actual)
+    assert np.array_equal(finite_actual, np.isfinite(reference)), (
+        f"{context}: the two backends disagree about which entries are finite, "
+        f"which no tolerance can absorb"
+    )
+
+    if claim.kind is ParityKind.BITWISE:
+        offenders = _bits_differ(actual, reference)
+        difference = np.abs(actual.astype(np.float64) - reference.astype(np.float64))
+        deviation = Deviation(
+            max_absolute=float(difference.max(initial=0.0)),
+            max_ratio_to_bound=0.0 if not offenders.any() else float(np.inf),
+            num_differing=int(np.count_nonzero(offenders)),
+        )
+        if offenders.any():
+            zeros = np.zeros_like(difference)
+            raise AssertionError(
+                f"{context}: bitwise parity claimed and violated.\n"
+                f"  claim: {claim.why}\n"
+                f"{_worst_element_report(actual, reference, zeros, offenders)}\n"
+                f"  A bitwise claim failing means the two backends no longer perform "
+                f"the same operations in the same order. Either the port changed, or "
+                f"the build did (check pantr._pantr_cpp.__fp_contract__ and "
+                f"__compiler__); do not relax this to a tolerance without deriving one."
+            )
+        return deviation
+
+    tolerance = np.broadcast_to(absolute_tolerance(claim), actual.shape)
+    difference = np.abs(actual.astype(np.float64) - reference.astype(np.float64))
+    offenders = np.asarray(difference > tolerance)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratios = np.where(
+            tolerance > 0.0, difference / tolerance, np.where(difference > 0.0, np.inf, 0.0)
+        )
+    deviation = Deviation(
+        max_absolute=float(difference.max(initial=0.0)),
+        max_ratio_to_bound=float(np.max(ratios, initial=0.0)),
+        num_differing=int(np.count_nonzero(difference > 0.0)),
+    )
+    if offenders.any():
+        raise AssertionError(
+            f"{context}: the backends differ by more than the derived bound.\n"
+            f"  derivation: {claim.why}\n"
+            f"  budget: {claim.roundings}, accumulator {claim.accumulator}, "
+            f"storage {claim.storage}\n"
+            f"{_worst_element_report(actual, reference, tolerance, offenders)}"
+        )
+    return deviation
+
+
+def assert_accuracy(
+    computed: FloatArray,
+    exact: FloatArray,
+    claim: AccuracyClaim,
+    *,
+    context: str,
+) -> Deviation:
+    """Assert that a result matches an independent oracle within a derived bound.
+
+    Args:
+        computed (FloatArray): What a backend produced.
+        exact (FloatArray): The oracle's values.
+        claim (AccuracyClaim): The elementwise bound and its derivation.
+        context (str): What was being computed, quoted in a failure message.
+
+    Returns:
+        Deviation: What was observed.
+
+    Raises:
+        AssertionError: If the bound is violated.
+    """
+    assert computed.shape == exact.shape, (
+        f"{context}: shape {computed.shape} against oracle shape {exact.shape}"
+    )
+    difference = np.abs(computed.astype(np.float64) - exact.astype(np.float64))
+    bound = np.broadcast_to(claim.bound, difference.shape)
+    offenders = np.asarray(difference > bound)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratios = np.where(bound > 0.0, difference / bound, np.where(difference > 0.0, np.inf, 0.0))
+    deviation = Deviation(
+        max_absolute=float(difference.max(initial=0.0)),
+        max_ratio_to_bound=float(np.max(ratios, initial=0.0)),
+        num_differing=int(np.count_nonzero(difference > 0.0)),
+    )
+    if offenders.any():
+        raise AssertionError(
+            f"{context}: the result is further from the independent oracle than the "
+            f"derived bound allows.\n"
+            f"  derivation: {claim.why}\n"
+            f"{_worst_element_report(computed, exact, bound, offenders)}"
+        )
+    return deviation

--- a/tests/test_cpp_parity.py
+++ b/tests/test_cpp_parity.py
@@ -942,8 +942,14 @@ def test_degree_one_is_bitwise_exact_in_every_build(cpp_backend: None) -> None:
 def test_float32_intermediates_are_float64(cpp_backend: None) -> None:
     """The float32 path accumulates in float64, and the check can tell the difference.
 
-    ``accumulator_t`` in the C++ header states this decision, and
-    ``design/large_data_fitting.md`` gives its reason. It cannot be checked by the
+    ``pantr::accumulator_t`` in ``cpp/include/pantr/core/scalar.hpp`` states this
+    decision, and the reason it gives is **parity**: numba promotes float32
+    intermediates to float64 as a side effect of literal typing, so a port that
+    computed in ``float`` throughout would disagree with the oracle. It is not the
+    accuracy argument of ``design/large_data_fitting.md``, which is about a
+    length-``m`` scalar accumulation and does not reach a kernel that stores its
+    state back into the output array every stage; that note was amended in this
+    branch to say so. It cannot be checked by the
     float32 parity tolerance: a port accumulating in ``float`` throughout differs by
     about one ulp of float32, and the derived float32 parity bound is
     ``degree`` ulps, so it would wave the bug through for any degree above 2.
@@ -1442,8 +1448,16 @@ def test_an_unavailable_backend_request_never_falls_back(
         pytest.fail("use_backend must refuse an unavailable backend before yielding")
 
     # And the Numba backend is still reachable, i.e. the guard rejects rather than
-    # disabling the selector.
-    assert cardinal_bspline_core(Backend.NUMBA).parallel is not None
+    # disabling the selector. Compared by identity against the kernel itself: that
+    # the returned object is not None says nothing, since a function reference
+    # never is.
+    from pantr.basis._basis_core import (  # noqa: PLC0415
+        _tabulate_cardinal_Bspline_basis_1D_core,
+    )
+
+    assert cardinal_bspline_core(Backend.NUMBA).parallel is (
+        _tabulate_cardinal_Bspline_basis_1D_core
+    )
 
 
 def test_overlapping_use_backend_blocks_in_two_threads_do_not_leak(cpp_backend: None) -> None:

--- a/tests/test_cpp_parity.py
+++ b/tests/test_cpp_parity.py
@@ -178,9 +178,9 @@ import numpy.typing as npt
 import pytest
 
 from pantr import _numba_compat
-from pantr._backend import Backend, active_backend, use_backend
+from pantr._backend import Backend, active_backend, available_backends, use_backend
 from pantr.basis import tabulate_cardinal_bspline_1d
-from pantr.basis._basis_backend import cardinal_bspline_core
+from pantr.basis._basis_backend import CoreKernels, cardinal_bspline_core
 from tests._parity_harness import (
     AccuracyClaim,
     FloatArray,
@@ -641,7 +641,7 @@ def _tabulate(backend: Backend, degree: int, points: FloatArray) -> FloatArray:
         FloatArray: Shape ``(points.size, degree + 1)`` in ``points.dtype``.
     """
     out = np.full((points.size, degree + 1), np.nan, dtype=points.dtype)
-    cardinal_bspline_core(backend)(np.int32(degree), points, out)
+    cardinal_bspline_core(backend).parallel(np.int32(degree), points, out)
     return out
 
 
@@ -1326,6 +1326,33 @@ def test_a_masked_array_is_refused_identically_by_both_backends(
     np.testing.assert_array_equal(results[0], results[1])
 
 
+def test_the_seam_returns_a_kernel_record_for_every_available_backend() -> None:
+    """Every backend answers with the same shape, whether or not it has a serial twin.
+
+    The catalogue's return type is what a consumer dispatches on, so it has to be
+    the same for every kernel and every backend. Cardinal B-spline has no serial
+    twin in either backend, which a bare callable would have fitted -- and would
+    have stopped fitting at the first kernel that has one, giving one concept two
+    return shapes. This pins the record instead, so adding a twin later changes a
+    field rather than a type.
+
+    Runs on whatever backends this installation has, so it is not a C++ test: the
+    invariant is about the seam, and the Numba half of it holds in a Numba-only
+    install too.
+    """
+    for backend in available_backends():
+        kernels = cardinal_bspline_core(backend)
+        assert isinstance(kernels, CoreKernels), (
+            f"{backend.name} did not return a CoreKernels record"
+        )
+        assert callable(kernels.parallel), f"{backend.name} has no parallel kernel"
+        assert kernels.serial is None, (
+            f"{backend.name} reports a serial twin for the cardinal B-spline kernel; "
+            f"if one was added, tests/test_cpp_parity.py must exercise it and "
+            f"pantr.basis._basis_backend.cardinal_bspline_core must say so"
+        )
+
+
 def test_an_unavailable_backend_request_never_falls_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1349,7 +1376,7 @@ def test_an_unavailable_backend_request_never_falls_back(
 
     # And the Numba backend is still reachable, i.e. the guard rejects rather than
     # disabling the selector.
-    assert cardinal_bspline_core(Backend.NUMBA) is not None
+    assert cardinal_bspline_core(Backend.NUMBA).parallel is not None
 
 
 def test_overlapping_use_backend_blocks_in_two_threads_do_not_leak(cpp_backend: None) -> None:

--- a/tests/test_cpp_parity.py
+++ b/tests/test_cpp_parity.py
@@ -1,0 +1,1754 @@
+r"""Parity and correctness of the C++ cardinal B-spline kernel against its Numba oracle.
+
+`cpp/include/pantr/basis/cardinal_bspline.hpp` names this file as the place its
+parity tolerance is derived. This is that derivation, and the tests that would
+notice if it stopped holding. The shared, kernel-agnostic machinery lives in
+``tests/_parity_harness.py``; only what is specific to this kernel is here.
+
+The kernel
+----------
+
+Both backends run the same specialisation of Cox-de Boor to span index 0. Writing
+:math:`N^{(k)}_r` for the value of output column ``r`` after stage ``k``, and with
+:math:`u` the evaluation point:
+
+.. math::
+
+    t^{(k)}_r = \frac{r + (1 - u)}{k}, \qquad s^{(k)}_r = 1 - t^{(k)}_r,
+
+    N^{(k)}_r = N^{(k-1)}_{r-1}\, s^{(k)}_{r-1} + N^{(k-1)}_r\, t^{(k)}_r,
+    \qquad N^{(0)}_0 = 1 .
+
+There are ``degree`` stages, and the dependency chain from an input to an output
+element has length ``degree`` -- not ``degree * (degree + 1) / 2``, which is the
+operation count. Errors compound along the chain, not along the operation count.
+
+What the two backends share, bit for bit
+----------------------------------------
+
+This is the observation the whole parity analysis rests on, and it is what makes a
+parity bound a different object from an accuracy bound.
+
+``one_minus_u``, ``inv_k``, ``term`` and ``1 - term`` are computed by the identical
+expressions in both backends, from identical inputs, and neither expression admits
+contraction (``(r + one_minus_u) * inv_k`` is an add feeding a multiply, which is
+the wrong way round to fuse). So the *coefficients* :math:`\hat t` and
+:math:`\hat s` are bit-identical in the two backends, rounding errors included.
+
+Every error they carry is therefore **common mode**: it cancels exactly in the
+difference between the backends, and it does not cancel at all in the difference
+between either backend and the mathematics. Hence:
+
+* the **parity** bound is derived against a reference recurrence that uses the
+  *computed* coefficients, where the convexity argument below applies;
+* the **accuracy** bound is derived against the exact spline, where it does not.
+
+Where the convexity argument holds, and where it does not
+---------------------------------------------------------
+
+For :math:`u \in [0, 1]` and :math:`0 \le r \le k-1`, :math:`t^{(k)}_r \in [0,1]`,
+so :math:`s` and :math:`t` are both non-negative and each stage is a convex
+combination of non-negative values. The lemma that matters is elementary and is
+the reason the bound is linear rather than exponential in the degree: if
+:math:`x, y \ge 0` and each is known to within a relative :math:`\varepsilon`,
+then :math:`x + y` is known to within the same relative :math:`\varepsilon`. A
+non-cancelling sum **inherits** its summands' relative error instead of
+amplifying it, so per-stage errors add across stages.
+
+Three corrections to the argument as originally stated:
+
+1. **It is not "one rounding per stage".** Once the two backends' values differ at
+   all, every later rounding differs too -- ``fl(a*s)`` and ``fl(b*s)`` for
+   :math:`a \ne b` commit unrelated errors of size up to :math:`u` each, which is
+   a first-order effect, not a second-order one. There is no cancellation to
+   exploit, so the honest route is
+   :math:`|A - B| \le |A - \text{exact}| + |\text{exact} - B|`: **twice** a
+   one-sided forward-error bound. Per stage each backend commits one multiply
+   rounding on the dominant summand (the two summands' multiplies count once
+   between them, by the lemma) plus one add rounding, so the one-sided growth is
+   :math:`2u` per stage and the parity bound is :math:`4\,n\,u` relative, not
+   :math:`n\,u/2`. Measured against a deliberately FMA-enabled build (see below),
+   the observed worst case reaches 0.29 of that bound, so it is neither wrong nor
+   idle.
+
+2. **The recurrence does cancel, just not where the argument looked.** ``1 - term``
+   is a subtraction of two nearby quantities whenever ``term`` is near 1, which
+   happens at :math:`r = k-1` for small :math:`u`, where
+   :math:`1 - t = u/k`. Its *relative* error is
+   :math:`\sim u_{\text{roundoff}} \cdot k / u`, unbounded as :math:`u \to 0`.
+   Measured: at degree 1 and :math:`u = 1/400`, ``1 - fl(1 - u)`` is
+   ``0.0024999999999999467`` against an exact ``0.0025``, wrong by **192 unit
+   roundoffs** relative, against a claimed 2. (That is 96 *epsilons*; this file
+   counts in :math:`u = \varepsilon/2` throughout, and the two were once
+   conflated here.) The claim "nothing here can cancel" in the header's comment is
+   false as an accuracy claim. It survives as a *parity* claim only because those
+   coefficients are common mode.
+
+   Pushed far enough the cancellation is total: once :math:`u \le \varepsilon/4`,
+   ``1 - u`` rounds to exactly 1 and ``1 - term`` is exactly 0, so the last column
+   comes back as 0 while the true value is :math:`u^n/n! > 0`. That is a complete
+   loss of *relative* accuracy at an entry whose absolute size is negligible, and
+   :func:`_companion_bounds` has to bound it rather than deny it -- see the hull
+   there, and the two regression points at the end of :func:`_oracle_points`.
+
+3. **Outside :math:`[0,1]` the convexity argument dies**, as expected: ``term``
+   leaves :math:`[0,1]`, the stage weights take opposite signs, and contributions
+   cancel. The domain is **not excluded** here, because it does not have to be.
+   Replacing the recurrence's coefficients by their absolute values gives a
+   companion recurrence :math:`X` (:func:`_companion_bounds`) that bounds the sum
+   of the magnitudes of all contributions to each output element, and the error
+   bound is relative to :math:`X` rather than to the value. Inside
+   :math:`[0,1]` every coefficient is already non-negative, so :math:`X` equals
+   the value and the bound degenerates exactly to the relative one. One bound,
+   one implementation, valid on both sides of the span ends. What *is* excluded is
+   :math:`|u|` large enough for the recurrence to overflow, where :math:`X` is
+   infinite and no comparison means anything; the harness rejects an infinite
+   amplification rather than silently passing.
+
+Which claim holds in this build
+-------------------------------
+
+The two backends differ at exactly one site: ``saved + nr_old * term``, which the
+C++ may fuse under ``-ffp-contract=on`` and Numba emits unfused. Whether it
+*does* fuse is a property of the build, and the extension reports it
+(``pantr._pantr_cpp.__fp_contract__``):
+
+* ``cmake/PantrCompileOptions.cmake`` sets ``-ffp-contract=on`` but no ``-march``,
+  so the target is baseline x86-64, which has **no FMA instruction**. Nothing can
+  fuse, the two backends execute the identical sequence of IEEE-754 operations in
+  the identical order, and parity is **bit-exact**. Asserting a
+  ``degree * eps`` tolerance here would pass while asserting nothing.
+* ``design/simd.md`` schedules ``-march=x86-64-v3`` as a later stage. Then the
+  site fuses, and the bounded claim above becomes the live one.
+
+So the claim is selected from the build's own provenance, and both branches are
+written and both are exercised -- the bounded branch by
+:func:`test_bounded_branch_admits_a_perturbation_at_the_bound` and its sibling,
+which drive the harness directly rather than waiting for the rebuild.
+
+float32
+-------
+
+Both backends accumulate in float64 and round only on the store into ``out``
+(``accumulator_t`` in the header; verified for Numba in the header's own note, and
+re-verified here by :func:`test_float32_intermediates_are_float64`). The parity
+bound then carries one float32 store rounding per stage, giving
+:math:`2\,n\,u_{32}` relative -- that is :math:`n` ulps of float32, not one.
+"One ulp" is the per-site statement, and it is not the per-result statement:
+measured on an FMA-enabled build at degree 11, two entries of one row differ by
+**2 ulps** of float32, so the tighter claim is already refuted at degrees the
+library uses.
+
+That bound is also **too loose to catch the mistake it looks like it guards**: a
+port that accumulated in ``float`` throughout differs from this one by about
+1 ulp of float32, which :math:`n\,u_{32}` waves through for any :math:`n > 2`.
+That bug gets its own test against an explicit model of the arithmetic contract,
+not a tolerance.
+
+And it is **too tight below the smallest normal**, which is the direction that
+actually broke. Every bound above is proportional to a magnitude, so it goes to
+zero with the value while the true error does not: a float32 store commits an
+absolute error of up to one subnormal however small the result is. On this file's
+own :func:`_oracle_points`, float32 at degree 16, that made the accuracy bound
+too small by a factor of :math:`10^6` -- for two backends that agree perfectly and
+a kernel that is right. Every bound here therefore carries an absolute floor as
+well as a relative term; see :func:`~tests._parity_harness.underflow_floor`.
+
+Ground truth
+------------
+
+Parity is a consistency check. Both backends running the same wrong recurrence
+agree perfectly, so this file also carries an oracle that is not the code: the
+truncated-power form of the cardinal B-spline evaluated in exact rational
+arithmetic (:func:`_exact_rows`), plus two analytic invariants (partition of
+unity, and the reflection :math:`N_r(u) = N_{n-r}(1-u)`). Those are what would
+catch a recurrence that is wrong in both backends at once.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from fractions import Fraction
+from typing import Any, Final
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr import _numba_compat
+from pantr._backend import Backend, active_backend, cardinal_bspline_core, use_backend
+from pantr.basis import tabulate_cardinal_bspline_1d
+from tests._parity_harness import (
+    AccuracyClaim,
+    FloatArray,
+    ParityClaim,
+    ParityKind,
+    Roundings,
+    absolute_tolerance,
+    assert_accuracy,
+    assert_parity,
+    bitwise_parity,
+    bounded_parity,
+    build_provenance,
+    contraction_may_fuse,
+    cpp_backend_available,
+    demand_cpp_backend,
+    derived_accuracy,
+    underflow_floor,
+    unit_roundoff,
+)
+
+
+@pytest.fixture(scope="session")
+def cpp_backend() -> None:
+    """Require the compiled extension for the test that asks for it.
+
+    Requested explicitly rather than applied module-wide, so the harness self-tests
+    and the Numba-side invariants below still run in an installation without the
+    extension -- which is the common local configuration. The skip-or-fail decision
+    itself lives in the harness, so the next ported kernel inherits it instead of
+    reaching for a plain ``skipif`` that would skip silently.
+    """
+    demand_cpp_backend()
+
+
+DTYPES: Final = (np.float64, np.float32)
+"""The two storage formats the B-spline layer accepts."""
+
+DEGREES: Final = (0, 1, 2, 3, 4, 5, 7, 11, 16)
+"""Degrees swept by the main parity tests.
+
+0 and 1 are the two branches that are provably exact; 2 is the smallest degree at
+which the backends can diverge at all; 16 is past any degree pantr's own builders
+reach, so the linear-in-degree bound is exercised where it is loosest.
+"""
+
+OUTSIDE_DEGREES: Final = (1, 2, 3, 5, 8, 12, 16)
+"""Degrees swept off the central span, reaching the same top degree as :data:`DEGREES`.
+
+This list used to stop at 12, on the stated grounds that the extrapolated
+polynomial grows like ``|u|**degree`` until the companion recurrence overflows.
+**That reason is false**, and in the harmless direction: the recurrence divides by
+``k`` at every stage, so the amplification behaves like ``|u|**n / n!`` and turns
+over once ``n`` passes ``|u|``. Measured on :func:`_outside_points`, whose largest
+magnitude is 4, the maximum amplification rises to 49.9 at degree 12 and then
+*falls* -- 47.1 at degree 16, 27.4 at degree 60 -- and is finite at every degree
+tried. Nothing here approaches overflow, so nothing had to be capped.
+
+There would still be a real ceiling for a point set reaching much further out,
+where ``|u|**n`` outruns ``n!`` for the degrees of interest. The harness refuses
+an infinite amplification rather than passing vacuously, so that case reports
+itself.
+"""
+
+
+def _span_points(dtype: npt.DTypeLike) -> FloatArray:
+    """Build the in-span evaluation set on a dyadic grid.
+
+    A grid of 1/64 rather than an arbitrary linspace so that ``1 - u`` is exact in
+    both formats, which the reflection test needs: an inexact mirror point would
+    put a rounding of the *argument* inside a comparison of *values*.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        FloatArray: Points covering [0, 1] inclusive.
+    """
+    return np.linspace(0.0, 1.0, 65, dtype=dtype)
+
+
+def _boundary_points(dtype: npt.DTypeLike) -> FloatArray:
+    """Build the set of points at and immediately around the span ends.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        FloatArray: The two span ends, their nearest neighbours on both sides, and
+            both signed zeros.
+    """
+    one = np.array(1.0, dtype=dtype)
+    zero = np.array(0.0, dtype=dtype)
+    return np.array(
+        [
+            0.0,
+            -0.0,
+            float(np.nextafter(zero, np.array(-1.0, dtype=dtype))),
+            float(np.nextafter(zero, one)),
+            float(np.nextafter(one, zero)),
+            1.0,
+            float(np.nextafter(one, np.array(2.0, dtype=dtype))),
+        ],
+        dtype=dtype,
+    )
+
+
+def _outside_points(dtype: npt.DTypeLike) -> FloatArray:
+    """Build the off-span evaluation set.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        FloatArray: Points strictly outside [0, 1] on both sides.
+    """
+    return np.array([-3.0, -2.0, -1.0, -0.5, -0.25, 1.25, 1.5, 2.0, 3.0, 4.0], dtype=dtype)
+
+
+def _oracle_points(dtype: npt.DTypeLike) -> FloatArray:
+    """Build the small mixed set the exact rational oracle is evaluated on.
+
+    Kept short because the oracle costs one exact rational power per term, and
+    deliberately **not** dyadic throughout: on a grid of 1/64 the whole recurrence
+    is exact at low degree, the observed error is identically zero, and a test that
+    the bound is not idle would have nothing to measure. Thirds, sevenths and 0.1
+    are what make the roundings happen; 0.001 and 0.999 are what make the
+    cancellation in ``1 - term`` bite.
+
+    The last two are the regression points for the two ways a bound built only
+    from relative terms fails, and both are the *smallest* points that reach
+    their case rather than arbitrary small ones:
+
+    * ``nextafter(0, 1)`` is the smallest positive float64, where every product
+      of it underflows and the error stops being proportional to anything;
+    * ``5e-17`` is below ``eps/4``, which is the largest point at which
+      ``1 - u`` still returns exactly 1. That is what makes the computed
+      ``1 - term`` exactly zero at ``r = k-1`` and collapses a companion built on
+      the computed coefficients.
+
+    In float32 both narrow to values already covered (0 and a normal), which is
+    fine: the float32 case of the same family is already reached by ``0.999``,
+    whose leading entry shrinks past what float32 can hold as the degree rises.
+    Measured there: at degree 11 it is ``2.5e-41`` and still stored as a normal;
+    at degree 12, ``2.1e-45``, stored as the smallest subnormal; from degree 13
+    the store flushes it to exactly zero, and by degree 16 the true value is
+    ``4.8e-62`` against a stored 0. The relative-only bound is first violated at
+    degree 11 -- before any flush to zero, because a subnormal store already
+    commits an absolute error no relative term can express.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        FloatArray: Points inside, at, and outside the span.
+    """
+    return np.array(
+        [
+            -1.5,
+            -1.0 / 3.0,
+            -0.25,
+            0.0,
+            1.0 / 1024.0,
+            0.001,
+            0.1,
+            0.125,
+            1.0 / 3.0,
+            0.375,
+            0.5,
+            0.625,
+            1.0 / 7.0,
+            0.9375,
+            0.999,
+            1.0,
+            1.25,
+            1.7,
+            2.5,
+            float(np.nextafter(0.0, 1.0)),
+            5e-17,
+        ],
+        dtype=dtype,
+    )
+
+
+def _rounding_points(dtype: npt.DTypeLike) -> FloatArray:
+    """Build a dense set of points on which the recurrence actually rounds.
+
+    A grid of 1/200 rather than 1/64: dyadic points make the low-degree recurrence
+    exact in *any* accumulator format, which would leave the accumulator check
+    comparing two models that happen to agree.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        FloatArray: Points on [0, 1] plus a few adversarial ones.
+    """
+    return np.concatenate(
+        [
+            np.linspace(0.0, 1.0, 201),
+            np.array([1.0 / 3.0, 1.0 / 7.0, 0.1, 1.0e-4, 1.0 - 1.0e-4]),
+        ]
+    ).astype(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Oracles
+# ---------------------------------------------------------------------------
+
+
+def _exact_rows(degree: int, points: FloatArray) -> npt.NDArray[np.float64]:
+    r"""Evaluate the tabulation exactly, in rational arithmetic, without a recurrence.
+
+    Independent of the code under test: it uses the truncated-power form of the
+    cardinal B-spline rather than Cox-de Boor, so a wrong recurrence in *both*
+    backends does not hide behind it.
+
+    With :math:`M_n` the cardinal B-spline supported on :math:`[0, n+1]`,
+
+    .. math::
+
+        M_n(x) = \frac{1}{n!} \sum_{i=0}^{n+1} (-1)^i \binom{n+1}{i} (x - i)_+^n ,
+
+    the ``degree + 1`` functions the kernel returns are
+    :math:`\text{out}[j, r] = M_n(u_j + n - r)`, whose leading term is the one with
+    :math:`i \le n - r`. Dropping the truncation and keeping exactly those terms
+    gives the **polynomial piece** on the central span, analytically continued --
+    which is what the kernel computes off the span too, since its arithmetic is
+    polynomial in ``u`` and branches on nothing.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): Evaluation points; each is converted to the rational
+            it exactly is.
+
+    Returns:
+        npt.NDArray[np.float64]: Exact values, rounded once to float64 on return.
+    """
+    factorial = math.factorial(degree)
+    out = np.zeros((points.size, degree + 1), dtype=np.float64)
+    for j, point in enumerate(points):
+        base = Fraction(float(point))
+        for r in range(degree + 1):
+            x = base + (degree - r)
+            total = Fraction(0)
+            for i in range(degree - r + 1):
+                total += (-1) ** i * math.comb(degree + 1, i) * (x - i) ** degree
+            out[j, r] = float(total / factorial)
+    return out
+
+
+def _companion_bounds(
+    degree: int, points: FloatArray, storage: npt.DTypeLike
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    r"""Run the amplification and forward-error companions of the kernel's recurrence.
+
+    Two arrays, both elementwise, both produced by walking the kernel's own
+    recurrence with the kernel's own computed coefficients:
+
+    ``X`` -- the same recurrence with every coefficient replaced by an upper bound
+    on its magnitude and started at 1. It bounds the sum of the magnitudes of all
+    contributions to each output element, so it is the factor by which a relative
+    perturbation of the intermediates can appear in the result. Inside
+    :math:`[0,1]` all coefficients are already non-negative and ``X`` coincides
+    with the value itself to within a rounding.
+
+    The bound used is the **hull** :math:`|\hat c| + \delta_c` -- the computed
+    coefficient widened by its own error -- and not :math:`|\hat c|` alone. The
+    difference is invisible almost everywhere, inflating ``X`` by about
+    :math:`3nu`, which is :math:`5 \times 10^{-15}` at degree 16. In one place it
+    is the entire bound. A computed coefficient can be **exactly zero** while the
+    true one is not: for :math:`u \lesssim \varepsilon/4` the subtraction
+    ``1 - u`` returns exactly 1, so ``1 - term`` at :math:`r = k-1` is exactly 0,
+    and a companion built on :math:`|\hat c|` has its last column collapse to 0
+    at that stage and every later one, after which it bounds nothing. The true
+    value there is not zero -- at :math:`u = 5\times 10^{-17}`, degree 3, it is
+    :math:`2.1\times 10^{-50}` where the kernel returns exactly 0 -- so the
+    bound was exceeded by a factor of :math:`1/u = 2^{53}`. That is a *correct*
+    kernel losing all relative accuracy on an entry of negligible absolute size,
+    which is the case a companion has to survive rather than deny.
+
+    ``E`` -- an absolute forward-error bound, propagated by the same recurrence and
+    fed at each step by the roundings that step commits:
+
+    * the coefficient ``term`` carries three accumulator roundings (``1/k``, the
+      add, the multiply) plus the propagated error of ``1 - u``;
+    * ``1 - term`` carries one more, **plus the absolute error of** ``term``, which
+      is where the cancellation enters: near ``term = 1`` that absolute error is
+      large compared with ``1 - term`` itself;
+    * each stage commits one multiply and one add in the accumulator, and one
+      store into the storage format.
+
+    Every one of those roundings is charged **twice over**, once relatively and
+    once absolutely, per Higham's model ``fl(x op y) = (x op y)(1 + d) + eta``.
+    The absolute part is :func:`~tests._parity_harness.underflow_floor` of the
+    format the rounding happens in, and omitting it is not a small error: a
+    relative-only bound shrinks with the value while the true error does not, so
+    it goes to zero exactly where the recurrence underflows. Measured on
+    :func:`_oracle_points` with the relative-only version, float32 at degree 16
+    exceeded its own bound by a factor of ``1.0e6`` -- at ``u = 0.999``, where
+    the leading basis function is ``4.8e-62`` and the float32 store flushes it to
+    zero. That store commits an absolute error of ``4.8e-62``, which no multiple
+    of ``u * 4.8e-62`` can cover, and which one float32 subnormal
+    (``1.4e-45``) covers with room to spare.
+
+    ``E`` is the accuracy bound (against the exact spline). The parity bound uses
+    only ``X`` and the harness's own floor, because the coefficient errors are
+    common to the two backends.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): Evaluation points.
+        storage (npt.DTypeLike): Format the output array holds.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: ``(X, E)``, both
+            of shape ``(points.size, degree + 1)``.
+    """
+    narrow_store = np.dtype(storage) != np.float64
+    u_acc = unit_roundoff(np.float64)
+    u_store = unit_roundoff(storage) if narrow_store else 0.0
+    # A store into the accumulator's own format rounds nothing, so it carries
+    # neither a relative cost nor a floor.
+    eta_acc = underflow_floor(np.float64)
+    eta_store = underflow_floor(storage) if narrow_store else 0.0
+
+    amplification = np.zeros((points.size, degree + 1), dtype=np.float64)
+    error = np.zeros_like(amplification)
+    amplification[:, 0] = 1.0
+    if degree == 0:
+        return amplification, error
+
+    one_minus_u = 1.0 - points.astype(np.float64)
+    d_one_minus_u = u_acc * np.abs(one_minus_u) + eta_acc
+
+    for k in range(1, degree + 1):
+        inv_k = 1.0 / k
+        saved_x = np.zeros(points.size, dtype=np.float64)
+        saved_e = np.zeros(points.size, dtype=np.float64)
+        for r in range(k):
+            x_old = amplification[:, r].copy()
+            e_old = error[:, r].copy()
+
+            term = (r + one_minus_u) * inv_k
+            complement = 1.0 - term
+            d_term = 3.0 * u_acc * np.abs(term) + 3.0 * eta_acc + inv_k * d_one_minus_u
+            d_complement = u_acc * np.abs(complement) + eta_acc + d_term
+
+            # The hulls: each bounds BOTH the computed coefficient and the exact
+            # one, which is what lets X bound the exact value as well as the
+            # computed one. See the note above on the column that collapses.
+            term_hull = np.abs(term) + d_term
+            complement_hull = np.abs(complement) + d_complement
+
+            new_x = saved_x + x_old * term_hull
+            amplification[:, r] = new_x
+            error[:, r] = (
+                saved_e
+                + term_hull * e_old
+                + x_old * d_term
+                + u_acc * x_old * np.abs(term)
+                + eta_acc
+                + u_acc * new_x
+                + eta_acc
+                + u_store * new_x
+                + eta_store
+            )
+            saved_e = (
+                complement_hull * e_old
+                + x_old * d_complement
+                + u_acc * x_old * np.abs(complement)
+                + eta_acc
+            )
+            saved_x = x_old * complement_hull
+        amplification[:, k] = saved_x
+        error[:, k] = saved_e + u_store * saved_x + eta_store
+
+    return amplification, error
+
+
+def _arithmetic_contract_model(
+    degree: int, points: FloatArray, accumulator: npt.DTypeLike
+) -> FloatArray:
+    """Recompute the kernel in NumPy with a *chosen* accumulator format.
+
+    This is deliberately a mirror of the kernel's arithmetic and is worth nothing
+    as a correctness oracle -- it recomputes the same algorithm. Its one job is to
+    pin the *arithmetic contract*: which format the intermediates live in. Run with
+    ``accumulator=np.float64`` it must reproduce both backends bit for bit; run
+    with ``accumulator=np.float32`` it must not. The pair is what makes the check
+    discriminating, and neither half means anything alone.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): Evaluation points, in the storage format.
+        accumulator (npt.DTypeLike): Format the intermediates are held in.
+
+    Returns:
+        FloatArray: Values in ``points.dtype``, stored exactly as the kernel does.
+    """
+    # Untyped on purpose: these are scalar constructors chosen at run time, which
+    # is the whole point of the model.
+    acc: Any = np.dtype(accumulator).type
+    store: Any = points.dtype.type
+    out = np.zeros((points.size, degree + 1), dtype=points.dtype)
+    if degree == 0:
+        out[:, 0] = store(1.0)
+        return out
+    for j in range(points.size):
+        out[j, 0] = store(1.0)
+        u = acc(points[j])
+        one_minus_u = acc(1.0) - u
+        for k in range(1, degree + 1):
+            inv_k = acc(1.0) / acc(k)
+            saved = acc(0.0)
+            for r in range(k):
+                nr_old = acc(out[j, r])
+                term = (acc(r) + one_minus_u) * inv_k
+                out[j, r] = store(saved + nr_old * term)
+                saved = nr_old * (acc(1.0) - term)
+            out[j, k] = store(saved)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Running the kernels, and stating the claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _jit_warmup_barrier() -> None:
+    """Block until the background Numba warmup finished, before any kernel call.
+
+    Session-scoped because the barrier is a once-per-process event. CLAUDE.md
+    records the failure it prevents: a Layer 3 ``parallel=True`` kernel called from
+    the main thread while ``pantr.__init__`` is still compiling on a background
+    thread **aborts** the interpreter rather than raising, and a kernel-heavy file
+    reaching kernels early is exactly the pattern that triggers it. This file calls
+    the Layer 3 kernel directly, bypassing the Layer 2 entry points that carry the
+    barrier themselves, so it must take the barrier itself.
+    """
+    _numba_compat.wait_for_jit_warmup()
+
+
+def _tabulate(backend: Backend, degree: int, points: FloatArray) -> FloatArray:
+    """Run one backend's Layer 3 kernel into a freshly poisoned output array.
+
+    The output is filled with NaN rather than zeros, so an element the kernel
+    fails to write is a NaN in the result rather than a plausible zero. Every
+    comparison in this file therefore also checks that the kernel wrote everything
+    it promised to write.
+
+    Args:
+        backend (Backend): Which implementation to call.
+        degree (int): Degree of the basis.
+        points (FloatArray): Contiguous 1D evaluation points.
+
+    Returns:
+        FloatArray: Shape ``(points.size, degree + 1)`` in ``points.dtype``.
+    """
+    out = np.full((points.size, degree + 1), np.nan, dtype=points.dtype)
+    cardinal_bspline_core(backend)(np.int32(degree), points, out)
+    return out
+
+
+def _both_backends(degree: int, points: FloatArray) -> tuple[FloatArray, FloatArray]:
+    """Run both backends on the same input.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): Contiguous 1D evaluation points.
+
+    Returns:
+        tuple[FloatArray, FloatArray]: ``(cpp, numba)``.
+    """
+    return (
+        _tabulate(Backend.CPP, degree, points),
+        _tabulate(Backend.NUMBA, degree, points),
+    )
+
+
+_EXACT_BY_STRUCTURE: Final[str] = (
+    "degree {degree} has no site at which the backends can diverge. Degree 0 writes "
+    "the literal 1 and returns. Degree 1 runs the recurrence once, at k=1, r=0, where "
+    "`saved` is exactly 0 and `nr_old` is exactly 1: the site `saved + nr_old * term` "
+    "is `0 + 1 * term`, whose product is exact, so fusing and not fusing round the same "
+    "real number the same once. This holds in every build, FMA or not."
+)
+
+_EXACT_BY_BUILD: Final[str] = (
+    "this build cannot fuse: pantr._pantr_cpp.__fp_contract__ is "
+    "'unavailable-on-target-isa', because cmake/PantrCompileOptions.cmake sets "
+    "-ffp-contract=on but no -march, leaving the target at baseline x86-64 which has "
+    "no FMA instruction. Numba emits the same site unfused. The two backends therefore "
+    "execute the identical sequence of IEEE-754 operations in the identical order. "
+    "Adding -march=x86-64-v3 (design/simd.md, stage 2) flips this to the bounded claim; "
+    "a tolerance asserted here instead would be satisfied by construction."
+)
+
+_BOUNDED_BY_FMA: Final[str] = (
+    "the backends differ at one site, `saved + nr_old * term`, which this build may "
+    "fuse and Numba does not. Neither is the exact answer, so the parity bound is twice "
+    "a one-sided forward-error bound. Per stage each backend commits one multiply "
+    "rounding on the dominant summand -- the two summands are non-negative inside the "
+    "span, so a non-cancelling sum inherits the larger of their relative errors rather "
+    "than the sum, and the two multiplies count once between them -- plus one add, plus "
+    "one store when the storage format is narrower than the float64 accumulator. Over "
+    "`degree` stages that gives 2*gamma, and the elementwise amplification is the "
+    "companion recurrence run on |coefficients|, which equals the value itself inside "
+    "[0, 1] and is strictly larger outside, where the stage weights change sign and the "
+    "convexity argument no longer applies. The coefficients themselves are bit-identical "
+    "in the two backends and their (large, cancelling) errors are common mode."
+)
+
+
+def _parity_claim(degree: int, points: FloatArray) -> ParityClaim:
+    """Select the parity claim this build supports for a given case.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): The evaluation points, which fix the amplification.
+
+    Returns:
+        ParityClaim: The strongest claim this build supports for this case.
+    """
+    if degree <= 1:
+        return bitwise_parity(why=_EXACT_BY_STRUCTURE.format(degree=degree))
+    if not contraction_may_fuse():
+        return bitwise_parity(why=_EXACT_BY_BUILD)
+    amplification, _ = _companion_bounds(degree, points, points.dtype)
+    return bounded_parity(
+        roundings=Roundings(stages=degree, accumulator_per_stage=2, storage_per_stage=1),
+        accumulator=np.float64,
+        storage=points.dtype,
+        amplification=amplification,
+        why=_BOUNDED_BY_FMA,
+    )
+
+
+def _accuracy_claim(
+    degree: int, points: FloatArray, exact: npt.NDArray[np.float64]
+) -> AccuracyClaim:
+    """Build the accuracy claim against the exact rational oracle.
+
+    Args:
+        degree (int): Degree of the basis.
+        points (FloatArray): Evaluation points.
+        exact (npt.NDArray[np.float64]): The oracle's values.
+
+    Returns:
+        AccuracyClaim: The elementwise bound and its derivation.
+    """
+    _, error = _companion_bounds(degree, points, points.dtype)
+    bound = error + unit_roundoff(np.float64) * np.abs(exact)
+    return derived_accuracy(
+        bound=bound,
+        why=(
+            "the forward-error companion of the recurrence (see _companion_bounds), "
+            "fed per stage by three accumulator roundings on `term`, one more on "
+            "`1 - term` carrying `term`'s absolute error -- which is the cancellation "
+            "the convexity argument misses -- one multiply and one add on the values, "
+            "and one store when the storage format is narrower than the accumulator. "
+            "Plus one float64 rounding for converting the exact rational oracle to a "
+            "float. This bound is NOT the parity bound: the coefficient errors it is "
+            "dominated by are common to both backends and cancel in parity."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Availability, and making a skip audible
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_extension_presence_is_declared() -> None:
+    """Report the extension's presence as a test outcome rather than as silence.
+
+    CLAUDE.md: "A missing optional dependency skips tests silently", and a local
+    green built on such a skip has let real failures through here before. This test
+    exists so that state is always in the report -- a pass when the extension is
+    there, one visible skip with a build hint when it is not, and a failure when
+    ``PANTR_REQUIRE_CPP`` says it had to be.
+    """
+    demand_cpp_backend()
+    assert cpp_backend_available()
+
+
+def test_build_provenance_is_reported(cpp_backend: None) -> None:
+    """Pin the three attributes the parity claim is selected from.
+
+    The claim in :func:`_parity_claim` is conditional on ``__fp_contract__``. A
+    binding that stopped reporting it, or reported an unrecognised value, would send
+    every parity test down whichever branch a default happened to pick, silently.
+    """
+    provenance = build_provenance()
+    assert provenance.compiler, "the extension must name the compiler that built it"
+    assert provenance.fp_contract in {"available", "unavailable-on-target-isa"}, (
+        f"unrecognised __fp_contract__ {provenance.fp_contract!r}: the parity claim is "
+        f"selected from this value and cannot be selected from a value it does not know"
+    )
+    assert isinstance(provenance.has_std_mdspan, bool)
+
+
+def test_jit_warmup_barrier_was_taken() -> None:
+    """Assert the session barrier ran before any kernel call.
+
+    No in-process test can observe the race it prevents (the barrier is a
+    once-per-process event and the failure is an abort, not an exception), so what
+    is testable is that the barrier was taken. CLAUDE.md says exactly this.
+    """
+    assert _numba_compat._warmup_done, (
+        "the session-scoped warmup barrier did not run before the kernel tests; a "
+        "parallel=True kernel called during background compilation aborts the process"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+def test_parity_on_the_span(degree: int, dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """The two backends agree on [0, 1], as far as this build's claim allows.
+
+    The broad sweep. It catches anything that changes what the port computes: a
+    shifted index, a swapped ``term`` and ``1 - term``, a wrong loop bound, a
+    ``float`` accumulator, a row written in reverse. The output array is
+    NaN-poisoned before the call, so an element neither backend writes fails here
+    too rather than comparing equal at zero.
+    """
+    points = _span_points(dtype)
+    cpp, numba = _both_backends(degree, points)
+    assert np.all(np.isfinite(cpp)), "the C++ kernel left an element unwritten"
+    assert_parity(
+        cpp,
+        numba,
+        _parity_claim(degree, points),
+        context=f"cardinal B-spline, degree {degree}, {np.dtype(dtype).name}, on [0, 1]",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+def test_parity_at_the_span_ends(degree: int, dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """The two backends agree at 0, at 1, and one ulp either side of each.
+
+    The span ends are where a well-meaning guard gets added: an ``if (u < 0)``, a
+    ``std::clamp``, a ``std::max(T(0), ...)``. Any of them changes the value at
+    ``nextafter(0, -1)`` and at ``nextafter(1, 2)`` while leaving the interior
+    untouched, so the sweep above would not see it. Both signed zeros are included
+    because the kernel's first stage subtracts the point from 1.
+    """
+    points = _boundary_points(dtype)
+    cpp, numba = _both_backends(degree, points)
+    assert_parity(
+        cpp,
+        numba,
+        _parity_claim(degree, points),
+        context=f"cardinal B-spline, degree {degree}, {np.dtype(dtype).name}, at the span ends",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", OUTSIDE_DEGREES)
+def test_parity_outside_the_span(degree: int, dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """The two backends agree off the span, where the convexity argument does not hold.
+
+    Both the docstring of the C++ kernel and the Python one promise that points
+    outside [0, 1] are *evaluated*, not clamped: the recurrence is polynomial in
+    ``u`` and branches on nothing, so it returns the analytic continuation of the
+    central polynomial piece. This is the case a clamp would break, and it is also
+    the case that exercises the amplification array -- inside the span the
+    amplification equals the value and the bound is a plain relative one, outside it
+    is strictly larger.
+    """
+    points = _outside_points(dtype)
+    cpp, numba = _both_backends(degree, points)
+    assert np.all(np.isfinite(cpp)), "the C++ kernel produced a non-finite value off the span"
+    assert_parity(
+        cpp,
+        numba,
+        _parity_claim(degree, points),
+        context=f"cardinal B-spline, degree {degree}, {np.dtype(dtype).name}, outside [0, 1]",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_empty_input_writes_nothing_and_returns(dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """Zero evaluation points is a no-op, in both backends.
+
+    ``num_pts`` is a ``std::size_t`` in the C++ kernel, so a loop written
+    ``j <= num_pts - 1`` would wrap to 2**64 iterations and walk off the array
+    instead of doing nothing. That class of bug is invisible at every other size.
+    """
+    points = np.zeros(0, dtype=dtype)
+    for degree in (0, 1, 3):
+        cpp, numba = _both_backends(degree, points)
+        assert cpp.shape == (0, degree + 1)
+        assert_parity(
+            cpp,
+            numba,
+            bitwise_parity(why="no element is computed, so there is nothing to round"),
+            context=f"cardinal B-spline, degree {degree}, empty input",
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_degree_zero_writes_exactly_one(dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """Degree 0 is the constant 1, written into every element.
+
+    Its own branch in both kernels, reached by no other test's arithmetic. The
+    NaN poisoning is what makes this catch the real failure -- a branch that returns
+    without writing leaves the caller's array untouched, which a zero-filled output
+    would hide.
+    """
+    points = np.concatenate([_span_points(dtype), _outside_points(dtype)])
+    cpp = _tabulate(Backend.CPP, 0, points)
+    assert cpp.shape == (points.size, 1)
+    assert np.array_equal(cpp, np.ones_like(cpp)), (
+        "degree 0 must be exactly 1 everywhere, including off the span: the constant "
+        "basis function is not truncated by this kernel any more than the others are"
+    )
+
+
+def test_degree_one_is_bitwise_exact_in_every_build(cpp_backend: None) -> None:
+    """Degree 1 agrees bit for bit whatever the build does about contraction.
+
+    Proved rather than measured: at degree 1 the only site is ``k=1, r=0``, where
+    ``saved`` is exactly 0 and ``nr_old`` is exactly 1, so ``saved + nr_old * term``
+    is ``0 + 1 * term`` and the product is exact -- fused and unfused round the same
+    real number once.
+
+    This is the sharpest bit-level assertion in the file, and it catches something
+    no tolerance can: a port that rearranged the *expression*, computing
+    ``(r + 1 - u) / k`` instead of ``(r + one_minus_u) * inv_k``. That rearrangement
+    is algebraically identical, numerically different in the last bits, and would be
+    absorbed silently by any bounded claim.
+    """
+    for dtype in DTYPES:
+        for points in (_span_points(dtype), _boundary_points(dtype), _outside_points(dtype)):
+            cpp, numba = _both_backends(1, points)
+            assert_parity(
+                cpp,
+                numba,
+                bitwise_parity(why=_EXACT_BY_STRUCTURE.format(degree=1)),
+                context=f"cardinal B-spline, degree 1, {np.dtype(dtype).name}",
+            )
+
+
+def test_float32_intermediates_are_float64(cpp_backend: None) -> None:
+    """The float32 path accumulates in float64, and the check can tell the difference.
+
+    ``accumulator_t`` in the C++ header states this decision, and
+    ``design/large_data_fitting.md`` gives its reason. It cannot be checked by the
+    float32 parity tolerance: a port accumulating in ``float`` throughout differs by
+    about one ulp of float32, and the derived float32 parity bound is
+    ``degree`` ulps, so it would wave the bug through for any degree above 2.
+
+    So it is checked against an explicit model of the arithmetic contract, in both
+    directions. The second assertion is the one that gives the first its meaning: if
+    the two models did not differ, agreeing with one of them would say nothing.
+    """
+    points = _rounding_points(np.float32)
+    for degree in (1, 2, 3, 6, 11):
+        cpp = _tabulate(Backend.CPP, degree, points)
+        wide = _arithmetic_contract_model(degree, points, np.float64)
+        narrow = _arithmetic_contract_model(degree, points, np.float32)
+        assert np.array_equal(cpp, wide), (
+            f"degree {degree}: the float32 kernel does not match a float64-accumulator "
+            f"model bit for bit, so its intermediates are not float64"
+        )
+        assert not np.array_equal(wide, narrow), (
+            f"degree {degree}: the float64- and float32-accumulator models agree here, "
+            f"so the assertion above is vacuous and this case proves nothing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Correctness against an oracle that is not the code
+# ---------------------------------------------------------------------------
+
+
+def test_exact_oracle_reproduces_the_published_degree_two_values() -> None:
+    """Check the oracle itself against values published in the library's own docs.
+
+    The rational oracle is the only ground truth in this file that is not the code,
+    so nothing else would catch it being wrong. These four rows are the worked
+    example in :func:`pantr.basis.tabulate_cardinal_bspline_1d`'s docstring, and
+    every entry is a dyadic rational, so the comparison is exact.
+    """
+    points = np.array([0.0, 0.5, 0.75, 1.0])
+    expected = np.array(
+        [
+            [0.5, 0.5, 0.0],
+            [0.125, 0.75, 0.125],
+            [0.03125, 0.6875, 0.28125],
+            [0.0, 0.5, 0.5],
+        ]
+    )
+    assert np.array_equal(_exact_rows(2, points), expected)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", (0, 1, 2, 3, 5, 8, 12))
+def test_matches_the_exact_rational_oracle(
+    degree: int, dtype: npt.DTypeLike, cpp_backend: None
+) -> None:
+    """Both backends compute the right function, not merely the same function.
+
+    Parity is a consistency check: two backends running the same wrong recurrence
+    agree perfectly. This is the test that would notice, and it is the reason the
+    suite's ground truth is not the code under test. The bound is the forward-error
+    companion of the recurrence, which is far larger than the parity bound because
+    the cancellation in ``1 - term`` is real -- it just happens to be common mode
+    between the backends.
+
+    Degree 12 is here because the degree list used to stop at 8 while
+    :data:`DEGREES` ran to 16, and the gap was load-bearing: on float32 this test
+    is violated from degree 11 upwards by an error model with no underflow floor,
+    and its own sweep never reached one. A degree list shorter than the one the
+    parity tests use is a place for exactly that to hide.
+    """
+    points = _oracle_points(dtype)
+    exact = _exact_rows(degree, points)
+    claim = _accuracy_claim(degree, points, exact)
+    for backend in (Backend.CPP, Backend.NUMBA):
+        assert_accuracy(
+            _tabulate(backend, degree, points),
+            exact,
+            claim,
+            context=f"{backend.name} cardinal B-spline, degree {degree}, {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("degree", (0, 1, 2, 3, 5, 8))
+def test_forward_error_bound_is_neither_violated_nor_idle(degree: int, cpp_backend: None) -> None:
+    """The derived accuracy bound is both correct and tight enough to bite.
+
+    A bound nothing approaches is a bound that would not notice the kernel getting
+    worse. This asserts the observed error reaches at least 1% of it somewhere,
+    which is the check that would have caught the original derivation: that one
+    claimed ``2 * degree`` unit roundoffs relative and the true error reaches
+    several hundred, so it is violated rather than idle.
+
+    **Where the 1% comes from.** The bound sums roughly ``6 * degree`` worst cases,
+    each of which assumes its rounding took the largest value of the right sign.
+    Real roundings have mixed signs, so a realization behaves like a random walk
+    and reaches about ``1 / sqrt(N)`` of a sum of ``N`` worst cases -- between
+    0.41 and 0.12 over the degrees swept here. That is a heuristic and not a
+    bound, so the threshold is set an order of magnitude below it. What the test
+    then detects is a bound more than ten times looser than any realization could
+    plausibly approach, which is the shape of the defect that actually occurred.
+    Measured, for calibration rather than as the criterion: the observed ratio
+    runs from 0.136 at degree 1 to 0.213 at degree 12, so the assertion holds with
+    more than a factor of ten to spare and is nowhere near being a fitted number.
+    """
+    points = _oracle_points(np.float64)
+    exact = _exact_rows(degree, points)
+    claim = _accuracy_claim(degree, points, exact)
+    deviation = assert_accuracy(
+        _tabulate(Backend.CPP, degree, points),
+        exact,
+        claim,
+        context=f"cardinal B-spline, degree {degree}, tightness probe",
+    )
+    if degree == 0:
+        assert deviation.max_absolute == 0.0, "degree 0 is exact"
+        return
+    assert deviation.max_ratio_to_bound > 0.01, (
+        f"degree {degree}: the observed error reaches only "
+        f"{deviation.max_ratio_to_bound:.3g} of the derived bound, which is loose "
+        f"enough that it would accept a substantially worse kernel without complaint"
+    )
+
+
+def test_the_bounds_slack_does_not_shrink_as_the_degree_grows(cpp_backend: None) -> None:
+    """Falsify the bound's degree dependence rather than assume it.
+
+    The bound grows linearly in ``degree``. If the true error grew faster, the
+    ratio of the two would climb with degree, and a bound that is correct at
+    degree 2 and wrong in its degree dependence would still pass an "is it under
+    the bound" test at small degrees while failing this one.
+
+    **What this cannot see, despite an earlier claim that it could.** It cannot
+    distinguish errors that *add* across stages from errors that *compound*. Those
+    differ by ``(1 + 2u)^n - 1`` against ``2nu``, whose ratio is ``1 + (n-1)u`` --
+    at degree 12 in float64 that is ``1 + 1.2e-15``, some fourteen orders of
+    magnitude below the ratio's own scatter. No measurement in this format can
+    resolve it, so no test can, and one claiming to would be asserting a check
+    nobody performs.
+
+    **What it can see, and where the threshold comes from.** A bound short by a
+    factor growing like the degree -- the realistic way to get the shape wrong,
+    and what a missing stage or a mis-stated stage count produces. Such a bound
+    would make the ratio grow by ``12 / 3 = 4`` between the two ends of the sweep,
+    while a correct one keeps it flat, i.e. a growth of 1. The threshold is the
+    geometric mean of the two hypotheses, ``sqrt(1 * 4) = 2``, which is the choice
+    that does not favour either. Measured, as corroboration rather than as the
+    derivation: the correct bound gives a growth of 0.82 (it drifts slightly
+    *down*), and simulating the linear shortfall on top of that gives about 3.2 --
+    3.26 if the ratio profile is taken as unchanged and simply scaled by 4, 3.24 if
+    each degree's ratio is scaled by its own degree. So the threshold rejects the
+    alternative by a factor of about 1.6 and accepts the truth by about 2.4, and
+    the gap does not depend on which of the two readings is used.
+
+    The shipped threshold was 4, which accepts 3.2 and so admitted precisely the
+    alternative the docstring named.
+    """
+    low_degrees = (1, 2, 3)
+    high_degrees = (10, 11, 12)
+    # A bound short by one power of the degree would inflate the ratio by this
+    # much across the sweep; a correct one leaves it flat. Split the difference.
+    growth_if_short_by_one_power = max(high_degrees) / max(low_degrees)
+    max_growth = math.sqrt(growth_if_short_by_one_power)
+
+    points = _oracle_points(np.float64)
+    ratios: dict[int, float] = {}
+    for degree in range(1, max(high_degrees) + 1):
+        exact = _exact_rows(degree, points)
+        deviation = assert_accuracy(
+            _tabulate(Backend.CPP, degree, points),
+            exact,
+            _accuracy_claim(degree, points, exact),
+            context=f"cardinal B-spline, degree {degree}, scaling probe",
+        )
+        ratios[degree] = deviation.max_ratio_to_bound
+
+    low = max(ratios[degree] for degree in low_degrees)
+    high = max(ratios[degree] for degree in high_degrees)
+    assert high <= max_growth * low, (
+        f"the observed error is outgrowing the bound's degree dependence: the "
+        f"error-to-bound ratio rises from {low:.4g} at low degree to {high:.4g} at "
+        f"high degree, a growth of {high / low:.4g} against the {max_growth:.4g} "
+        f"that separates a correct linear bound from one short by a power of the "
+        f"degree. A linear-in-degree bound is then the wrong shape, and it will "
+        f"fail on correct code at some degree beyond this sweep. Ratios: {ratios}"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+def test_partition_of_unity(degree: int, dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """The basis sums to 1 at every point of the span, in both backends.
+
+    An analytic invariant, so it does not care which backend is running or whether
+    they agree. It catches a recurrence that lost or duplicated a term while keeping
+    every value plausible. The tolerance is the sum of the elementwise forward-error
+    bounds plus the roundings of the summation itself, both derived.
+    """
+    points = _span_points(dtype)
+    amplification, error = _companion_bounds(degree, points, dtype)
+    # The summation's own roundings, bounded by the magnitudes being summed, which
+    # is what the amplification array already is.
+    tolerance = error.sum(axis=1) + degree * unit_roundoff(np.float64) * amplification.sum(axis=1)
+    for backend in (Backend.CPP, Backend.NUMBA):
+        sums = _tabulate(backend, degree, points).astype(np.float64).sum(axis=1)
+        assert np.all(np.abs(sums - 1.0) <= tolerance), (
+            f"{backend.name}, degree {degree}, {np.dtype(dtype).name}: partition of "
+            f"unity is violated by up to {np.max(np.abs(sums - 1.0)):.3e} against a "
+            f"derived bound of {np.max(tolerance):.3e}"
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", (1, 2, 3, 5, 8))
+def test_reflection_symmetry(degree: int, dtype: npt.DTypeLike, cpp_backend: None) -> None:
+    """``N_r(u)`` equals ``N_{degree-r}(1-u)``, in both backends.
+
+    A second analytic invariant, and one that partition of unity cannot see: a
+    kernel that wrote its output row reversed still sums to 1. The mirror points are
+    exact because the grid is dyadic, so this compares values and not a rounding of
+    the argument.
+    """
+    points = _span_points(dtype)
+    mirrored = (1.0 - points.astype(np.float64)).astype(dtype)
+    _, error = _companion_bounds(degree, points, dtype)
+    _, error_mirrored = _companion_bounds(degree, mirrored, dtype)
+    tolerance = error + error_mirrored[:, ::-1]
+    for backend in (Backend.CPP, Backend.NUMBA):
+        direct = _tabulate(backend, degree, points).astype(np.float64)
+        reflected = _tabulate(backend, degree, mirrored).astype(np.float64)[:, ::-1]
+        assert np.all(np.abs(direct - reflected) <= tolerance), (
+            f"{backend.name}, degree {degree}, {np.dtype(dtype).name}: the basis is not "
+            f"symmetric under u -> 1-u, by up to "
+            f"{np.max(np.abs(direct - reflected)):.3e} against {np.max(tolerance):.3e}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The seam: Layer 1/2 over the backend selector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_public_api_agrees_across_backends_for_every_input_shape(
+    dtype: npt.DTypeLike, cpp_backend: None
+) -> None:
+    """The seam passes the same data to both backends, whatever shape the caller used.
+
+    The kernels agreeing says nothing about the adapter between them: shape
+    flattening and restoration, the dtype dispatch that picks one of the two
+    nanobind overloads, and the ``out`` convention all live in
+    ``pantr.basis._basis_1D`` and ``pantr._backend``, and none of them is exercised
+    by calling the Layer 3 kernel directly. This is the only test here that runs the
+    path a user runs.
+    """
+    degree = 3
+    inputs: tuple[Any, ...] = (
+        np.asarray(0.375, dtype=dtype),
+        [0.0, 0.25, 0.5, 1.0],
+        np.linspace(0.0, 1.0, 9, dtype=dtype),
+        np.linspace(-0.5, 1.5, 12, dtype=dtype).reshape(3, 4),
+        np.array([0, 1], dtype=np.int64),
+    )
+    for points in inputs:
+        with use_backend(Backend.CPP):
+            from_cpp = tabulate_cardinal_bspline_1d(degree, points)
+        with use_backend(Backend.NUMBA):
+            from_numba = tabulate_cardinal_bspline_1d(degree, points)
+        assert from_cpp.shape == from_numba.shape
+        assert from_cpp.dtype == from_numba.dtype
+
+        # The claim needs the points as the kernel saw them: flattened, and in the
+        # dtype Layer 2 normalised them to (integers become float64).
+        flat = np.ascontiguousarray(np.asarray(points).reshape(-1), dtype=from_cpp.dtype)
+        assert flat.size * (degree + 1) == from_cpp.size
+        assert_parity(
+            from_cpp.reshape(-1, degree + 1),
+            from_numba.reshape(-1, degree + 1),
+            _parity_claim(degree, flat),
+            context=f"public API, degree {degree}, input {np.shape(points)}",
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_out_argument_is_filled_in_place_by_both_backends(
+    dtype: npt.DTypeLike, cpp_backend: None
+) -> None:
+    """A caller-supplied contiguous ``out`` is written, not replaced.
+
+    The ``out`` convention is the project's, not NumPy's doing: Layer 2 validates
+    the array and the kernel writes into it. A binding that converted its argument
+    would write into a temporary, return normally, and leave the caller's array
+    exactly as it was -- a silent wrong answer with no exception anywhere.
+    """
+    points = np.linspace(0.0, 1.0, 7, dtype=dtype)
+    degree = 4
+    results = []
+    for backend in (Backend.CPP, Backend.NUMBA):
+        out = np.full((points.size, degree + 1), np.nan, dtype=dtype)
+        with use_backend(backend):
+            returned = tabulate_cardinal_bspline_1d(degree, points, out=out)
+        assert returned is out, "the out convention returns the caller's own array"
+        assert np.all(np.isfinite(out)), f"{backend.name} did not write into the caller's array"
+        results.append(out)
+    assert_parity(
+        results[0],
+        results[1],
+        _parity_claim(degree, points),
+        context=f"public API with out=, degree {degree}, {np.dtype(dtype).name}",
+    )
+
+
+def test_a_non_contiguous_out_is_filled_identically_by_both_backends(
+    cpp_backend: None,
+) -> None:
+    """A strided ``out`` is written, with the same values, whichever backend runs.
+
+    This is the regression test for B1, and it pins **one** of the two halves of
+    that fix: the buffering in ``pantr._backend._cpp_cardinal_bspline_core``,
+    which computes into a contiguous temporary and copies back so that the public
+    API accepts the same inputs under either ``PANTR_BACKEND``.
+
+    It does **not** pin the other half. Measured: stripping
+    ``nb::arg("out").noconvert()`` from the binding leaves this test passing,
+    because the buffering above intercepts every non-contiguous ``out`` before
+    nanobind ever sees one. That half is pinned by
+    :func:`test_the_binding_refuses_a_non_contiguous_out`, which calls the
+    binding directly.
+
+    Layer 2 validates shape, dtype and writability but not contiguity, so a
+    strided ``out`` does reach ``_cpp_cardinal_bspline_core`` and this path is
+    live.
+    """
+    points = np.linspace(0.0, 1.0, 5)
+    results = []
+    for backend in (Backend.NUMBA, Backend.CPP):
+        out = np.zeros((5, 6))[:, ::2]
+        assert not out.flags["C_CONTIGUOUS"]
+        with use_backend(backend):
+            returned = tabulate_cardinal_bspline_1d(2, points, out=out)
+        assert returned is out, f"{backend.name} did not return the caller's out array"
+        assert np.any(out != 0.0), (
+            f"the {backend.name} backend returned normally and wrote nothing into "
+            f"the caller's non-contiguous out array"
+        )
+        results.append(out.copy())
+    np.testing.assert_array_equal(
+        results[0], results[1], err_msg="the two backends disagree on a strided out"
+    )
+
+
+@pytest.mark.parametrize("argument", ("points", "out"))
+def test_a_masked_array_is_refused_identically_by_both_backends(
+    argument: str, cpp_backend: None
+) -> None:
+    """A masked array raises on both backends rather than being honoured by neither.
+
+    ``pantr._backend`` promises that selecting a backend changes how fast the
+    library is and never what it accepts. Measured before the fix, a masked array
+    broke that promise in the worst available direction: Numba raised
+    ``NumbaTypeError``, while the C++ backend accepted the array through the
+    buffer protocol, ignored the mask and returned ordinary-looking numbers for
+    entries the caller had marked invalid. With ``out`` masked it went further
+    and wrote through the mask into the caller's own array.
+
+    The fix refuses the type in Layer 2, so neither kernel is reached. Numba's
+    behaviour is the correct one of the two, so following it costs nothing.
+    """
+    masked_points = np.ma.MaskedArray([0.0, 0.25, 0.5, 1.0], mask=[False, True, False, False])
+    degree = 2
+
+    for backend in (Backend.CPP, Backend.NUMBA):
+        with pytest.raises(TypeError, match="MaskedArray"), use_backend(backend):
+            if argument == "points":
+                tabulate_cardinal_bspline_1d(degree, masked_points)
+            else:
+                tabulate_cardinal_bspline_1d(
+                    degree,
+                    np.asarray(masked_points),
+                    out=np.ma.MaskedArray(np.zeros((masked_points.size, degree + 1))),
+                )
+
+    # What is refused is the mask, not the data: the escape the message names
+    # works, and the two backends still agree on it.
+    results = []
+    for backend in (Backend.CPP, Backend.NUMBA):
+        with use_backend(backend):
+            results.append(tabulate_cardinal_bspline_1d(degree, masked_points.filled(0.0)))
+    np.testing.assert_array_equal(results[0], results[1])
+
+
+def test_an_unavailable_backend_request_never_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit request for a missing backend raises rather than running the other.
+
+    ``pantr._backend`` states this as the reason the selector exists: a silent
+    downgrade makes every A/B measurement a measurement of the wrong thing, and the
+    measurement is what the override is for. It is untestable as written on a
+    machine where both backends exist, so the absence is simulated: the extension
+    handle is removed and the two entry points are asked for it anyway.
+    """
+    from pantr import _backend  # noqa: PLC0415
+
+    monkeypatch.setattr(_backend, "_CPP_AVAILABLE", False)
+
+    assert _backend.available_backends() == (Backend.NUMBA,)
+    with pytest.raises(RuntimeError, match="not available"):
+        _backend.cardinal_bspline_core(Backend.CPP)
+    with pytest.raises(RuntimeError, match="not available"), use_backend(Backend.CPP):
+        pytest.fail("use_backend must refuse an unavailable backend before yielding")
+
+    # And the Numba backend is still reachable, i.e. the guard rejects rather than
+    # disabling the selector.
+    assert _backend.cardinal_bspline_core(Backend.NUMBA) is not None
+
+
+def test_overlapping_use_backend_blocks_in_two_threads_do_not_leak(cpp_backend: None) -> None:
+    """Two threads whose ``use_backend`` blocks overlap both restore what they found.
+
+    The lost update, forced deterministically with events rather than sleeps: A
+    enters, B enters while A is inside, A exits, B exits. Against a plain module
+    global, B's saved "previous" is A's override rather than the process default,
+    so B restores the process to A's value on the way out and it stays there --
+    for the rest of the process, with nothing left in scope to put it back.
+
+    That is not a race in the sense of a rare interleaving. It is the *only*
+    outcome of this ordering, which is why the test is deterministic.
+
+    The backend the two threads select is whichever one the process is *not*
+    already on, and the assertion is against the ambient value rather than a named
+    one. Both matter: this file is run under ``PANTR_BACKEND=numba`` and under
+    ``PANTR_BACKEND=cpp``, and a fixed backend makes the test assert nothing under
+    one of the two.
+    """
+    ambient = active_backend()
+    other = Backend.NUMBA if ambient is Backend.CPP else Backend.CPP
+    entered_a = threading.Event()
+    entered_b = threading.Event()
+    exited_a = threading.Event()
+    timeout = 10.0
+
+    def first() -> None:
+        with use_backend(other):
+            entered_a.set()
+            assert entered_b.wait(timeout), "the second thread never entered its block"
+        exited_a.set()
+
+    def second() -> None:
+        assert entered_a.wait(timeout), "the first thread never entered its block"
+        with use_backend(other):
+            entered_b.set()
+            assert exited_a.wait(timeout), "the first thread never left its block"
+
+    threads = [threading.Thread(target=first), threading.Thread(target=second)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=timeout)
+        assert not thread.is_alive(), "a thread did not finish; the events deadlocked"
+
+    assert active_backend() is ambient, (
+        f"two use_backend blocks that overlapped have left the process on "
+        f"{active_backend().name} rather than the {ambient.name} it started on, so "
+        f"every later call in this process runs a kernel nobody asked for"
+    )
+
+
+def test_use_backend_does_not_reach_into_another_thread(cpp_backend: None) -> None:
+    """A thread started inside a ``use_backend`` block runs on the process default.
+
+    The other half, and the one that decides an A/B measurement. The binding
+    releases the GIL precisely so a caller can thread at the Python level, so
+    "one thread is inside an override while another is working" is the shape this
+    module invites rather than a pathological one. Against a module global the
+    worker silently switches backend mid-flight, which is exactly the silent
+    downgrade ``pantr._backend`` exists to prevent -- only in the other
+    direction, and without an exception to notice it by.
+
+    The direction asserted here is the deliberate one: an override is scoped to
+    the thread (and the task) that took it, so a thread inherits the process
+    default rather than its spawner's override. :func:`use_backend` says so.
+
+    The override is whichever backend the process is *not* already on, so that
+    the two values being compared always differ. Naming a fixed backend would
+    make this assert nothing whenever ``PANTR_BACKEND`` happened to select it.
+    """
+    ambient = active_backend()
+    other = Backend.NUMBA if ambient is Backend.CPP else Backend.CPP
+    observed: list[Backend] = []
+
+    with use_backend(other):
+        assert active_backend() is other, "the override did not take in its own thread"
+        worker = threading.Thread(target=lambda: observed.append(active_backend()))
+        worker.start()
+        worker.join(timeout=10.0)
+        assert not worker.is_alive(), "the observing thread did not finish"
+
+    assert observed == [ambient], (
+        f"a thread started inside a use_backend({other.name}) block observed "
+        f"{[b.name for b in observed]} rather than the process default "
+        f"{ambient.name}, so the selection is process-wide rather than scoped to "
+        f"the block that took it"
+    )
+
+
+def test_kernel_is_reentrant_across_threads(cpp_backend: None) -> None:
+    """Concurrent calls on disjoint outputs match the serial results.
+
+    The binding releases the GIL around the kernel, which is what makes this
+    reachable at all. It catches shared mutable state in the C++ -- a static
+    scratch buffer, a cached span index -- which is invisible to every single-
+    threaded test and produces a wrong answer only under load.
+    """
+    degree = 6
+    batches = [np.linspace(start, start + 1.0, 97) for start in (0.0, 0.25, 0.5, 0.75)]
+    serial = [_tabulate(Backend.CPP, degree, points) for points in batches]
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        concurrent = list(pool.map(lambda p: _tabulate(Backend.CPP, degree, p), batches))
+    for index, (one, many) in enumerate(zip(serial, concurrent, strict=True)):
+        assert np.array_equal(one, many), (
+            f"batch {index}: the C++ kernel gave a different answer when four threads "
+            f"ran it at once, so it holds state across calls"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The binding's own contract, exercised where the public API cannot reach it
+# ---------------------------------------------------------------------------
+#
+# Every test above goes through `pantr.basis` or through `cardinal_bspline_core`,
+# so all of them are separated from the binding by Layer 2 -- which normalises
+# the degree, allocates `out`, and buffers a strided one. That is the right thing
+# for a user and the wrong thing for a test of the binding: it means none of the
+# tests above can observe what the binding does with an argument Layer 2 would
+# never pass it. `pantr._pantr_cpp` is an importable module with a public
+# attribute, so those arguments are one line of Python away, and two of them
+# reached undefined behaviour before these tests existed.
+
+
+def test_the_binding_refuses_a_negative_degree(cpp_backend: None) -> None:
+    """A negative degree is refused before the kernel runs.
+
+    The regression test for a crash rather than for a wrong answer, so its
+    failure mode before the fix was not an assertion but the death of the
+    process: the kernel does ``static_cast<std::size_t>(degree)``, which turns
+    ``-1`` into ``SIZE_MAX``, and then indexes ``out`` that many times. Measured
+    before the fix: ``SIGSEGV``, from exactly the call below.
+
+    The exception is a ``TypeError`` rather than a ``ValueError`` because the C++
+    parameter is ``unsigned``: nanobind's own caster rejects the value, so no
+    pantr code runs at all. That is the reason to spell it that way -- a check
+    inside the body can be forgotten, a type cannot.
+
+    The Numba kernel is *not* the model to copy here. Called at Layer 3 with the
+    same degree it returns normally, having written nothing, which is only safe
+    because NumPy bounds-checks. Both backends agree at the public API, where
+    Layer 2 refuses a negative degree before either is reached.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent in a Numba-only install)
+
+    points = np.linspace(0.0, 1.0, 4)
+
+    # Python ints and NumPy integer scalars of every width, because the Layer 2
+    # caller passes `int(n)` but a direct caller need not: `np.int32(-1)` is the
+    # shape a kernel-level caller would actually reach for, and it goes through a
+    # different path in nanobind's caster than a Python int does.
+    negatives: tuple[Any, ...] = (
+        -1,
+        -2,
+        -(2**31),
+        np.int8(-1),
+        np.int32(-1),
+        np.int64(-1),
+    )
+    for degree in negatives:
+        with pytest.raises(TypeError):
+            _pantr_cpp.tabulate_cardinal_bspline_1d(degree, points, np.zeros((4, 1)))
+
+    # A non-integer degree is refused by the same mechanism rather than truncated.
+    # The type: ignore is the point of the assertion rather than a workaround:
+    # `src/pantr/_pantr_cpp.pyi` declares `degree: int`, and this checks that the
+    # binding enforces at run time what the stub only promises statically.
+    with pytest.raises(TypeError):
+        _pantr_cpp.tabulate_cardinal_bspline_1d(3.0, points, np.zeros((4, 4)))  # type: ignore[arg-type]
+
+    # The public API is where a user meets this, and there it is a ValueError
+    # from Layer 2, identically on both backends.
+    for backend in (Backend.CPP, Backend.NUMBA):
+        with pytest.raises(ValueError, match="degree must be non-negative"), use_backend(backend):
+            tabulate_cardinal_bspline_1d(-1, points)
+
+
+def test_the_binding_refuses_an_out_of_the_wrong_extent(cpp_backend: None) -> None:
+    """An ``out`` that does not match ``(points.size, degree + 1)`` is refused.
+
+    The other half of the same crash. nanobind's typed signature pins the dtype,
+    the rank and the contiguity of ``out``, but a relation *between* two
+    arguments is not something a type can state, so an ``out`` of the right rank
+    and the wrong extent passed every check and the kernel wrote past the end of
+    it. Measured before the fix: heap corruption, reported by glibc as
+    ``corrupted size vs. prev_size`` and an abort.
+
+    The last case is the one a plausible caller hits: ``out`` correct in every
+    respect but one column short.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent in a Numba-only install)
+
+    degree = 3
+    points = np.linspace(0.0, 1.0, 4)
+    wrong = (
+        np.zeros((2, 2)),  # smaller in both extents
+        np.zeros((5, 4)),  # too many rows
+        np.zeros((4, 5)),  # too many columns
+        np.zeros((4, 3)),  # one column short
+    )
+    for out in wrong:
+        with pytest.raises(ValueError, match="out has shape"):
+            _pantr_cpp.tabulate_cardinal_bspline_1d(degree, points, out)
+        assert not out.any(), "the binding wrote into an array it went on to reject"
+
+    # The positive control. Without it the four assertions above are consistent
+    # with a binding that refuses everything.
+    accepted = np.zeros((points.size, degree + 1))
+    _pantr_cpp.tabulate_cardinal_bspline_1d(degree, points, accepted)
+    assert accepted.any(), "the correctly shaped call was refused too"
+
+
+def test_the_binding_refuses_a_non_contiguous_out(cpp_backend: None) -> None:
+    """A strided ``out`` reaches a ``TypeError``, not a discarded temporary.
+
+    This is the half of B1 that lives in the binding, and it needs a direct call
+    to be tested at all: ``pantr._backend._cpp_cardinal_bspline_core`` buffers a
+    non-contiguous ``out`` before nanobind sees it, so the public-API test cannot
+    tell whether ``nb::arg("out").noconvert()`` is present. Verified by removing
+    it from a copy of the tree: the rest of the file still passed, and this test
+    failed.
+
+    Without ``.noconvert()`` nanobind satisfies the ``c_contig`` constraint by
+    CONVERTING rather than by rejecting: the kernel fills a contiguous temporary,
+    the temporary is discarded, and the caller's array comes back untouched --
+    with no exception anywhere. The second assertion is what distinguishes the
+    two: a refusal leaves ``out`` as it was, and so does the silent conversion,
+    but only the refusal raises.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (absent in a Numba-only install)
+
+    points = np.linspace(0.0, 1.0, 5)
+    out = np.zeros((5, 6))[:, ::2]
+    assert not out.flags["C_CONTIGUOUS"], "the case this test exists for is not being built"
+
+    with pytest.raises(TypeError):
+        _pantr_cpp.tabulate_cardinal_bspline_1d(2, points, out)
+    assert not out.any(), "the binding wrote into a strided out it should have refused"
+
+
+# ---------------------------------------------------------------------------
+# The harness itself: can these assertions fail?
+# ---------------------------------------------------------------------------
+
+
+def test_point_sets_reach_the_cases_they_are_named_for() -> None:
+    """The constructed point sets really contain the boundary and outside cases.
+
+    A generator is only worth what it actually produces, and these are edited by
+    hand. Without this, a later edit that dropped the span ends would leave every
+    boundary test passing on interior points.
+    """
+    for dtype in DTYPES:
+        boundary = _boundary_points(dtype)
+        assert np.any(boundary == 0.0) and np.any(boundary == 1.0)
+        assert np.any(boundary < 0.0), "no point below the span"
+        assert np.any(boundary > 1.0), "no point above the span"
+        outside = _outside_points(dtype)
+        assert np.all((outside < 0.0) | (outside > 1.0))
+        span = _span_points(dtype)
+        assert span[0] == 0.0 and span[-1] == 1.0
+        oracle = _oracle_points(dtype)
+        assert np.any(oracle < 0.0) and np.any(oracle > 1.0), "oracle set stays on the span"
+        mirrored = 1.0 - span.astype(np.float64)
+        assert np.array_equal(np.sort(mirrored), np.sort(span.astype(np.float64))), (
+            "the span grid is not closed under u -> 1-u, so the reflection test would "
+            "be comparing values at points that are not exact mirrors"
+        )
+
+
+def test_the_rounding_grid_actually_rounds() -> None:
+    """The dense grid really distinguishes a float64 accumulator from a float32 one.
+
+    :func:`test_float32_intermediates_are_float64` is only as good as its point
+    set: on a dyadic grid the two accumulator models agree at low degree and the
+    check silently proves nothing. This pins the property the grid was chosen for,
+    separately from the test that relies on it, so a later edit to the grid fails
+    here rather than quietly hollowing out that test.
+    """
+    points = _rounding_points(np.float32)
+    for degree in (1, 2, 3):
+        wide = _arithmetic_contract_model(degree, points, np.float64)
+        narrow = _arithmetic_contract_model(degree, points, np.float32)
+        differing = int(np.count_nonzero(wide != narrow))
+        assert differing > 10, (
+            f"degree {degree}: only {differing} of {wide.size} entries distinguish a "
+            f"float64 accumulator from a float32 one on this grid"
+        )
+
+
+def test_bitwise_claim_detects_a_one_ulp_difference() -> None:
+    """A bitwise claim fails on the smallest possible disagreement.
+
+    The sensitivity probe for the strongest assertion in the file: if this passed,
+    every bitwise test above would be certifying nothing.
+    """
+    points = _span_points(np.float64)
+    reference = _tabulate(Backend.NUMBA, 3, points)
+    perturbed = reference.copy()
+    perturbed[2, 1] = np.nextafter(perturbed[2, 1], np.float64(np.inf))
+    with pytest.raises(AssertionError, match="bitwise parity claimed and violated"):
+        assert_parity(
+            perturbed,
+            reference,
+            bitwise_parity(why="probe"),
+            context="sensitivity probe",
+        )
+
+
+def test_bounded_branch_admits_a_perturbation_at_the_bound() -> None:
+    """The bounded branch accepts a difference just inside the bound it derives.
+
+    The FMA branch of :func:`_parity_claim` is not taken on a baseline build, so
+    without this it would ship unexecuted and its first run would be the day
+    ``-march=x86-64-v3`` lands. Driving the harness directly exercises it now.
+    """
+    points = _span_points(np.float64)
+    reference = _tabulate(Backend.NUMBA, 5, points)
+    amplification, _ = _companion_bounds(5, points, np.float64)
+    claim = bounded_parity(
+        roundings=Roundings(stages=5, accumulator_per_stage=2, storage_per_stage=1),
+        accumulator=np.float64,
+        storage=np.float64,
+        amplification=amplification,
+        why="probe: the same budget the FMA branch of _parity_claim builds",
+    )
+    tolerance = absolute_tolerance(claim)
+    assert claim.kind is ParityKind.BOUNDED
+    assert np.max(tolerance) > 0.0, "the bounded branch derived a zero tolerance"
+    perturbed = reference + 0.75 * tolerance
+    assert_parity(perturbed, reference, claim, context="sensitivity probe, inside the bound")
+
+
+def test_bounded_branch_rejects_a_perturbation_past_the_bound() -> None:
+    """The bounded branch fails on a difference just outside the bound it derives.
+
+    The other half of the probe. A tolerance nothing can exceed is not a tolerance.
+    """
+    points = _span_points(np.float64)
+    reference = _tabulate(Backend.NUMBA, 5, points)
+    amplification, _ = _companion_bounds(5, points, np.float64)
+    claim = bounded_parity(
+        roundings=Roundings(stages=5, accumulator_per_stage=2, storage_per_stage=1),
+        accumulator=np.float64,
+        storage=np.float64,
+        amplification=amplification,
+        why="probe: the same budget the FMA branch of _parity_claim builds",
+    )
+    perturbed = reference + 1.5 * absolute_tolerance(claim)
+    with pytest.raises(AssertionError, match="more than the derived bound"):
+        assert_parity(perturbed, reference, claim, context="sensitivity probe, past the bound")
+
+
+def test_a_tolerance_cannot_be_stated_without_a_derivation() -> None:
+    """Every way of building a claim without a derivation is refused.
+
+    The harness's whole purpose is that the next five ported modules cannot express
+    an underived tolerance. That property is a property of the API, so it is tested
+    like any other.
+    """
+    with pytest.raises(ValueError, match="why"):
+        bitwise_parity(why="   ")
+    with pytest.raises(ValueError, match="derivation"):
+        bounded_parity(
+            roundings=Roundings(stages=3, accumulator_per_stage=2, storage_per_stage=0),
+            accumulator=np.float64,
+            storage=np.float64,
+            amplification=np.ones((2, 2)),
+            why="",
+        )
+    with pytest.raises(ValueError, match="bitwise_parity"):
+        bounded_parity(
+            roundings=Roundings(stages=0, accumulator_per_stage=2, storage_per_stage=0),
+            accumulator=np.float64,
+            storage=np.float64,
+            amplification=np.ones((2, 2)),
+            why="zero stages is not a bound",
+        )
+    with pytest.raises(ValueError, match="finite"):
+        bounded_parity(
+            roundings=Roundings(stages=3, accumulator_per_stage=2, storage_per_stage=0),
+            accumulator=np.float64,
+            storage=np.float64,
+            amplification=np.array([[np.inf]]),
+            why="an overflowed amplification makes the comparison vacuous",
+        )
+
+
+def test_a_budget_that_exhausts_the_format_is_refused() -> None:
+    """A bound that accepts every finite result is reported, not returned.
+
+    The failure mode a "derived" tolerance still permits: derive it for a degree so
+    large, or a format so narrow, that the bound exceeds 1 in relative terms and the
+    comparison stops meaning anything. That is worth an error rather than a pass.
+    """
+    claim = bounded_parity(
+        roundings=Roundings(stages=10**8, accumulator_per_stage=2, storage_per_stage=1),
+        accumulator=np.float64,
+        storage=np.float32,
+        amplification=np.ones((2, 2)),
+        why="probe: a budget large enough to exhaust float32",
+    )
+    with pytest.raises(ValueError, match="vacuous"):
+        absolute_tolerance(claim)

--- a/tests/test_cpp_parity.py
+++ b/tests/test_cpp_parity.py
@@ -178,8 +178,9 @@ import numpy.typing as npt
 import pytest
 
 from pantr import _numba_compat
-from pantr._backend import Backend, active_backend, cardinal_bspline_core, use_backend
+from pantr._backend import Backend, active_backend, use_backend
 from pantr.basis import tabulate_cardinal_bspline_1d
+from pantr.basis._basis_backend import cardinal_bspline_core
 from tests._parity_harness import (
     AccuracyClaim,
     FloatArray,
@@ -1183,7 +1184,8 @@ def test_public_api_agrees_across_backends_for_every_input_shape(
     The kernels agreeing says nothing about the adapter between them: shape
     flattening and restoration, the dtype dispatch that picks one of the two
     nanobind overloads, and the ``out`` convention all live in
-    ``pantr.basis._basis_1D`` and ``pantr._backend``, and none of them is exercised
+    ``pantr.basis._basis_1D`` and ``pantr.basis._basis_backend``, and none of them is
+    exercised
     by calling the Layer 3 kernel directly. This is the only test here that runs the
     path a user runs.
     """
@@ -1250,7 +1252,8 @@ def test_a_non_contiguous_out_is_filled_identically_by_both_backends(
     """A strided ``out`` is written, with the same values, whichever backend runs.
 
     This is the regression test for B1, and it pins **one** of the two halves of
-    that fix: the buffering in ``pantr._backend._cpp_cardinal_bspline_core``,
+    that fix: the buffering in
+    ``pantr.basis._basis_backend._cpp_cardinal_bspline_core``,
     which computes into a contiguous temporary and copies back so that the public
     API accepts the same inputs under either ``PANTR_BACKEND``.
 
@@ -1340,13 +1343,13 @@ def test_an_unavailable_backend_request_never_falls_back(
 
     assert _backend.available_backends() == (Backend.NUMBA,)
     with pytest.raises(RuntimeError, match="not available"):
-        _backend.cardinal_bspline_core(Backend.CPP)
+        cardinal_bspline_core(Backend.CPP)
     with pytest.raises(RuntimeError, match="not available"), use_backend(Backend.CPP):
         pytest.fail("use_backend must refuse an unavailable backend before yielding")
 
     # And the Numba backend is still reachable, i.e. the guard rejects rather than
     # disabling the selector.
-    assert _backend.cardinal_bspline_core(Backend.NUMBA) is not None
+    assert cardinal_bspline_core(Backend.NUMBA) is not None
 
 
 def test_overlapping_use_backend_blocks_in_two_threads_do_not_leak(cpp_backend: None) -> None:
@@ -1564,7 +1567,7 @@ def test_the_binding_refuses_a_non_contiguous_out(cpp_backend: None) -> None:
     """A strided ``out`` reaches a ``TypeError``, not a discarded temporary.
 
     This is the half of B1 that lives in the binding, and it needs a direct call
-    to be tested at all: ``pantr._backend._cpp_cardinal_bspline_core`` buffers a
+    to be tested at all: the adapter in ``pantr.basis._basis_backend`` buffers a
     non-contiguous ``out`` before nanobind sees it, so the public-API test cannot
     tell whether ``nb::arg("out").noconvert()`` is present. Verified by removing
     it from a copy of the tree: the rest of the file still passed, and this test

--- a/tests/test_cpp_parity.py
+++ b/tests/test_cpp_parity.py
@@ -178,7 +178,15 @@ import numpy.typing as npt
 import pytest
 
 from pantr import _numba_compat
-from pantr._backend import Backend, active_backend, available_backends, use_backend
+from pantr._backend import (
+    Backend,
+    IsaVariant,
+    active_backend,
+    active_isa_variant,
+    available_backends,
+    available_isa_variants,
+    use_backend,
+)
 from pantr.basis import tabulate_cardinal_bspline_1d
 from pantr.basis._basis_backend import CoreKernels, cardinal_bspline_core
 from tests._parity_harness import (
@@ -1351,6 +1359,65 @@ def test_the_seam_returns_a_kernel_record_for_every_available_backend() -> None:
             f"if one was added, tests/test_cpp_parity.py must exercise it and "
             f"pantr.basis._basis_backend.cardinal_bspline_core must say so"
         )
+
+
+def test_the_isa_variant_is_a_separate_axis_from_the_backend() -> None:
+    """Which family runs, and which build of it, are two questions with two enums.
+
+    The assertion on :class:`Backend`'s members is the load-bearing one. The
+    accepted values of ``PANTR_BACKEND`` are exactly those names, lowercased, and
+    they are user-facing the moment anyone writes one into a script -- so folding
+    the ISA ladder in later as ``cpp_v3`` would break every such script. Splitting
+    the axes now costs nothing and makes that impossible; this pins it.
+    """
+    assert [b.name for b in Backend] == ["NUMBA", "CPP"], (
+        "PANTR_BACKEND's accepted values are the lowercased member names, and "
+        "changing them breaks any script that sets the variable"
+    )
+    assert [v.name for v in IsaVariant] == ["BASELINE"], (
+        "design/simd.md gates building an ISA variant on a measurement; a member "
+        "here without a module to load would make available_isa_variants() lie"
+    )
+    assert available_isa_variants() == (IsaVariant.BASELINE,)
+    assert active_isa_variant() is IsaVariant.BASELINE
+
+
+def test_a_requested_choice_that_is_missing_raises_on_either_axis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The never-fall-back rule is one rule, and it already holds on the ISA axis.
+
+    The backend half is covered below, through the entry points a caller reaches.
+    The ISA half has no such entry point yet -- one variant exists and it is
+    always available -- so the shared resolver is called directly with the empty
+    availability list that an unbuilt variant will produce. That is the case
+    ``design/simd.md`` says must fail rather than quietly load another module,
+    and testing it now is what keeps the rule from being written twice and
+    drifting when the ladder lands.
+    """
+    from pantr import _backend  # noqa: PLC0415
+
+    monkeypatch.setenv("PANTR_ISA_VARIANT", "baseline")
+    with pytest.raises(RuntimeError, match="does not fall back"):
+        _backend._resolve_from_environment(
+            "PANTR_ISA_VARIANT", IsaVariant, (), IsaVariant.BASELINE, "  nothing is built"
+        )
+
+    monkeypatch.setenv("PANTR_ISA_VARIANT", "x86_64_v3")
+    with pytest.raises(ValueError, match="PANTR_ISA_VARIANT='x86_64_v3' is not one of"):
+        _backend._resolve_from_environment(
+            "PANTR_ISA_VARIANT",
+            IsaVariant,
+            available_isa_variants(),
+            IsaVariant.BASELINE,
+            "",
+        )
+
+    monkeypatch.delenv("PANTR_ISA_VARIANT")
+    unset = _backend._resolve_from_environment(
+        "PANTR_ISA_VARIANT", IsaVariant, available_isa_variants(), IsaVariant.BASELINE, ""
+    )
+    assert unset is IsaVariant.BASELINE, "an unset variable must mean the default"
 
 
 def test_an_unavailable_backend_request_never_falls_back(


### PR DESCRIPTION
The skeleton of the C++ port, and the measurements it exists to produce.

**This is a prototype.** It ports one kernel, keeps the Numba implementation as the parity
oracle, and is meant to be abandonable. It is not a step toward `main`.

## What it answers

**Both compilers build it.** GCC 14.4.0 and Clang 18.1.8 from the environment, from-scratch
configure, `-Werror` with `-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wdouble-promotion`,
3/3 ctest binaries each.

**Kokkos mdspan and Eigen survive `SYSTEM` plus `-Werror`, and CMake 4.4.2.** Both declare a
`cmake_minimum_required` new enough. Eigen 5.0.1 emits one `CMP0146` deprecation, which is a
configure-time policy warning and does not reach `-Werror`.

**`<mdspan>` is absent, so Kokkos is the normal path.** The reason is an implementation gap,
not the C++20 baseline: `__cpp_lib_mdspan` is undefined even under `-std=gnu++23`, so GCC
14's libstdc++ has not implemented P0009, and Clang 18 here resolves to that same libstdc++.

**nanobind split mode works and composes.** 3.0.0.dev2 plus `nanobind-backend` builds,
imports, runs, and links as `.abi3.so`. Two frontends built from one source at different
`-march`, sharing one backend, both import in the same process. It needs
`NB_SUPPRESS_WARNINGS`, and it makes `nanobind-backend` a runtime dependency of the wheel.
Split mode is behind `PANTR_NANOBIND_SPLIT`, off by default: the wheel strategy is not this
PR's decision to make.

**Parity is bit-exact, and that is a derived result rather than a lucky one.** No `-march` is
set, so the target is baseline x86-64, which has no FMA instruction, and `-ffp-contract=on`
cannot fuse what the ISA cannot execute — verified by disassembly on both compilers, and
Numba emits the same site unfused. The two backends therefore perform an identical sequence
of IEEE-754 operations in an identical order. Measured: degrees 0 through 16, `float32` and
`float64`, points spanning `[-0.25, 1.25]`, worst relative difference exactly `0.0`.

The tolerance branch is not vestigial. With `-march=x86-64-v3` exactly one site fuses, two
such variants disagree, and the harness switches to a derived bound by reading the
extension's own `__fp_contract__`. A naive `degree · eps/2` is refuted by measurement at
degrees 3 to 5, so the harness uses a per-stage rounding budget with an underflow floor
instead.

**Speed, kernel against kernel on one thread, 10^6 points:** 1.45× at degree 1, 1.30× at
degree 3, 0.95× at degree 8. Modest, and honest. At the public entry point the C++ backend
is 4-7× faster at 100 points, because the Numba cardinal B-spline kernel is `parallel=True`
unconditionally and has no serial twin, and 0.2× at 10^6 points against 20 threads.

**The worktree flow is cheap:** 7.5 s for a cold editable install, 9.3 s with build
isolation, 2.5 s incremental, thanks to a persistent build directory and to Eigen being
fetched only when the C++ tests are built.

## What it deliberately does not do

One kernel. No `-march`, no SIMD, no ISA variants — `design/simd.md` gates those on
measuring the baseline gap first, and that measurement is now taken and recorded in
`cpp/README.md` (1.20-1.27×, and `-march=native` is *slower* than `x86-64-v3` here, which
measures a hazard that note only asserted). No threading on the C++ side. No MPI, no CUDA, no
AD type. No wheel strategy.

## Two defects this work found in itself

**`nanobind_add_module()` appends `-Os` after the build type's `-O3`**, and the last
optimisation flag wins, so the numerical kernel was compiled for size inside the extension
while the standalone benchmark compiled it for speed: 31.4 ms against 10.3 ms on identical
source. Without `NOMINSIZE` this PR would have reported the port as three times slower than
Numba instead of a third faster.

**An `nb::ndarray<T, c_contig>` out-parameter does not reject a non-contiguous argument** —
nanobind converts it to a temporary, the kernel fills the temporary, and the caller's array
comes back untouched with no error. Fixed with `.noconvert()`, with the adapter absorbing the
difference so the public API accepts the same inputs on both backends.

## Review

`reviews/cpp-infrastructure-2026-08-19.md` records a nine-lens review and what it found,
including the design questions left open and the places where the compiler contradicted a
`design/*.md` note.

## Checks

Run in the development environment, not by CI (this branch's workflow is manual):
`ctest` 3/3 under GCC 14.4.0 and under Clang 18.1.8 · the full Python suite **6080 passed**
under `PANTR_BACKEND=numba` and **6080 passed** under `PANTR_BACKEND=cpp`, identical counts ·
130 parity tests · 81 doctests · import contracts kept · `mypy` clean over 239 files · `ruff`
and `ruff format` clean on every file this branch touches · docs build clean under `-W`.

Parity re-verified independently of the harness: 306 612 elements over degrees 0-16, both
dtypes, points spanning `[-0.25, 1.25]` plus both signed zeros, **zero bit mismatches**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
