### PR TITLE
fix(ci): give the split-mode probe a build directory of its own

### DIFF
--- a/design/_memory/MEMORY.md
+++ b/design/_memory/MEMORY.md
@@ -1,4 +1,8 @@
-- [Where the decisions live](decisions-pointer.md) — the C++ port's design decisions are in `design/*.md` in this repository; read them before proposing anything about the port.
+- [Active task](active-task.md) — PR 2 of the C++ port (quad) is MERGED as #337; the four measured parity results, the four follow-ups now filed as #338 to #341, and the one piece of work still waiting.
+- [Where the decisions live](decisions-pointer.md) — the C++ port's design decisions are in `design/*.md` in this repository; both PRs merged, nothing in flight. Read backend_parity.md first before proposing anything about a bound.
 - [Naming constraint and licensing](naming-and-licensing.md) — two sibling libraries are private and unpublished; never name them in anything that leaves the machine. Plus the dependency direction the licence plan forbids.
 - [Build machine](build-machine.md) — the shared Linux server, its 20-CPU cap, and the calibration trap that comes with many cores.
 - [nanobind status](nanobind-status.md) — split mode verified working and composing with multi-ISA; the three mandatory build flags, including the -Os trap that costs a silent 3x.
+- [Performance follow-up](performance-followup.md) — wanted later, deliberately deferred in the infrastructure PR; carries what is already measured so it is not re-measured, and what to attack first.
+- [How to ask me things](asking-style.md) — one question at a time, with concrete options AND an explicit recommendation, and the counter-argument written into the other options.
+- [Reviewing my own measurements](reviewing-my-own-measurements.md) — in numerical work my prose fails far more often than my code, and why; the six checks that would have caught it.

--- a/design/_memory/active-task.md
+++ b/design/_memory/active-task.md
@@ -1,0 +1,52 @@
+---
+name: active-task
+description: The pantr C++ port after both PRs merged, the four follow-ups now filed, and the one piece of work still waiting
+metadata:
+  node_type: memory
+  type: project
+  modified: 2026-08-20T23:55:00.000Z
+---
+
+**PR 2 of the C++ port is MERGED**: `pantr.quad`'s rule generation, PR #337 into `proto/cpp`,
+36 commits, CI green. PR 1 was #335. **No work is in flight.** `proto/cpp` is at `8e8f37c`,
+the merge commit; a local checkout can sit well behind it, so fetch before reading its tip.
+
+Four measured parity results, since they set expectations for the ports that follow:
+Gauss-Legendre and trapezoidal are **bit-identical** in both storage formats, Lambert W is
+within one ulp, modified Chebyshev is exact in float64 and one unit of roundoff in float32,
+and tanh-sinh is bounded with its node **count** identical. Exactness is a property of the
+BUILD, not of the kernels: `-march=native` moves 1994 of 2143 values and `-ffp-contract=off`
+restores them.
+
+**The four follow-ups are FILED**, each root-caused with a verified reproduction, none a
+regression from #337: **#338** `PointsLattice` neither copies nor freezes its arrays while
+`QuadratureRule` in the same package does both; **#339** the basis parity tests assume a
+compiled kernel and fail under `NUMBA_DISABLE_JIT=1`, which is what breaks `make coverage`
+with the extension present; **#340** `ci_local.sh`'s split-mode probe shares the persistent
+build dir, one cause behind both the wrong-nanobind resolution and the non-idempotency;
+**#341** an enhancement, not a bug, to keep tanh-sinh's endpoint distance.
+
+Two corrections to what was believed before they were filed, both found by re-checking rather
+than by trusting the note. The tanh-sinh plateau is **not a defect**: the docstring has
+documented and quantified it since #291, and its model predicts the measured error to three
+digits, so it was filed as an enhancement. And the proof that #339 predates the port does
+**not** work by running the old test file unchanged, which fails on API drift instead; it
+needs the mechanical `Backend.NUMBA` to `Backend.PYTHON` rename applied first.
+
+**One piece of work waiting**: the `QuadKernels` redesign, where the record's stated
+justification is exercised by no call site and the catalogue's signature convention is
+unwritten and inconsistent between the two ports that exist.
+
+**The backend cache-keying fix is NOT waiting, contrary to what was planned.** It was to be
+its own PR and it shipped inside #337 instead, as commit `b5c562b`. The merged version is
+better than the standalone branch was: the standalone one named the two backends absolutely
+in its threading test, which fails once the suite runs under `PANTR_BACKEND=cpp`, and the
+merged one names them relative to the ambient backend and skips when only one exists. Do not
+go looking for that PR. Verified `14 passed` under each backend.
+
+A session-scoped handoff brief carried every directive verbatim, the twenty-nine decisions in
+force, and what the cycle taught. That path does not outlive its session. **The durable
+equivalents are in the repository**: `design/backend_parity.md`, `design/build_findings.md`
+and `design/quadrature_algorithms.md`.
+
+See [[decisions-pointer]], [[performance-followup]] and [[reviewing-my-own-measurements]].

--- a/design/_memory/asking-style.md
+++ b/design/_memory/asking-style.md
@@ -1,0 +1,32 @@
+---
+name: asking-style
+description: Pablo wants questions asked one at a time through the question tool, each with concrete options AND an explicit recommendation
+metadata:
+  type: feedback
+---
+
+When a decision is genuinely his, **ask through the question tool with concrete options and
+say which one you recommend and why.** He asked for this twice, in those words: *"preguntame
+dinamicamente ofreciendo opciones y recomendaciones para cada pregunta"*.
+
+**Why:** his global instructions already say to ask dynamically rather than dumping a wall of
+questions. The refinement is the recommendation. A list of options with no recommendation
+pushes the analysis back onto him, which is the work he delegated; a recommendation with no
+options hides what was traded away. He wants both, and he overrode the recommendation at
+least once (the Clang version floor) after reading the counter-argument in the option text —
+which only worked because the counter-argument was written down.
+
+**How to apply:**
+
+- Put the recommended option first and mark it "(Recomendada)".
+- Write the argument **against** the recommendation into the other options' descriptions, not
+  only the argument for it. That is what makes overriding possible.
+- Before asking, write down what you already found: the file, the measurement, the numbers.
+  An underdone question is one whose answer was sitting in the codebase unchecked.
+- Use `preview` for shape-of-code decisions, where seeing the two forms side by side decides
+  it faster than prose.
+- Batch into one call only when the budget is tight, and say that is why.
+
+If he pushes back and you still think he is wrong, hold the position and explain; if the
+evidence then goes his way, say so plainly and move on. See [[decisions-pointer]] for the
+standing rule that the design notes are his to overrule, not yours.

--- a/design/_memory/decisions-pointer.md
+++ b/design/_memory/decisions-pointer.md
@@ -1,6 +1,6 @@
 ---
 name: decisions-pointer
-description: The C++ port's design decisions live in design/*.md in the repository, not in memory
+description: The C++ port's design decisions live in design/*.md in the repository, not in memory; two modules are ported and nothing is in flight
 metadata:
   type: project
 ---
@@ -10,22 +10,51 @@ bindings. **The design decisions live in `design/*.md` in this repository.** Rea
 before proposing anything about the port; they are long, cross-referenced, and each one
 carries an epistemic-status section separating what was verified from what was derived.
 
-Two that govern everything else:
+**They are sealed against 0.7.0 but were written without compiling a line.** Four were
+amended on 2026-08-19 when the compiler contradicted them — epistemic status and open
+questions only, never a decision. If the code refutes a note again, say so and let Pablo
+rule; do not silently work around it and do not silently obey it.
+
+Two decisions that govern everything else:
 
 - **Dual backend.** The existing Python implementation stays as the **parity oracle**. The
-  C++ backend is validated against it, module by module, with dispatch at the Python level.
-  Note that the oracle is **not always Numba**: `geometry`, `transform`, `quad`,
-  `change_basis` and `tolerance` are pure NumPy, while `basis` (18 kernels), `grid` (15) and
-  `bezier` (41) are Numba. That distinction changes both the parity evidence required and
-  what a speed figure means — see `design/build_findings.md`, which is the note to read after
-  this one.
+  C++ backend is validated against it, module by module, with dispatch at the Python level
+  via `PANTR_BACKEND`, and an explicit request never falls back. Note that the oracle is
+  **not always Numba**: `geometry`, `transform`, `quad`, `change_basis` and `tolerance` are
+  pure NumPy, while `basis` (18 kernels), `grid` (15) and `bezier` (41) are Numba. That
+  distinction changes both the parity evidence required and what a speed figure means; see
+  `design/build_findings.md`, the note to read after this one.
 - **Stage 1 scope** is what a downstream consumer actually imports: `geometry`, `grid`,
   `quad`, `transform`, `change_basis`, `bezier`. Roughly 8-10k lines, not 47k. `bspline`,
   THB, extraction, `cad`, `multipatch` and `mpi` stay in Python for now.
 
-The port is a **prototype** on a branch, not a landing on `main`. It is gated on an
-in-progress bug study of the Python library: that study blocks porting modules, not the
-architecture record or the build skeleton.
+**Status, 2026-08-20.** Both PRs are **merged** into `proto/cpp`: the build skeleton (#335)
+and the `quad` module (#337). Nothing is in flight. See [[active-task]].
+
+**Three notes were added by PR 2 and they govern everything ported after it.**
+`design/backend_parity.md` is the one to read first: it states what a bound may claim and in
+which frame, and each of its **six** rules carries the failure that produced it rather than
+the principle it illustrates. Rule 6 is the newest and the least obvious: a sensitivity
+derived at a distinguished point set is **not** that sensitivity at the image of that set
+under a coordinate map, and comparing the two arrays by their maxima cannot see the
+difference. Its last section now answers whether the harness generalized (yes in vocabulary,
+no in meaning) instead of deferring it. `design/build_findings.md`, written by Pablo, is
+where both PRs' build findings live consolidated. `design/cross_backend_types.md` settles that **no type crosses the
+boundary** (types are Python-owned, only arrays and scalars cross) and that `dtype` is an
+output format rather than a computation precision. `design/quadrature_algorithms.md` records
+why Gauss-Legendre is Newton rather than Golub-Welsch, and why Eigen was declined there.
+
+**PR 2 refuted its own brief's premise, and that is the pattern to expect.** The brief assumed
+numpy computes Gauss nodes by a nonsymmetric companion matrix; reading the source showed it is
+already symmetric Golub-Welsch plus a Newton polish. Measurement then chose a different
+algorithm than the one specified. The rule above held: the note was not silently worked
+around, Pablo ruled, and the decision is recorded.
+
+The port is still a **prototype** on a branch, not a landing on `main`. Two modules are
+ported: `pantr.basis`'s cardinal B-spline (#335) and `pantr.quad`'s rule generation (#337).
+Within `quad` only four of the seven public rules dispatch, and `pantr._backend`'s Scope
+section names the three that never do, because identical output from one of those is the
+switch being a no-op rather than a parity success.
 
 One working note is deliberately **not** in this repository (it documents a sibling
 project's mechanism in detail and quotes its code); it stays on the laptop. See

--- a/design/_memory/reviewing-my-own-measurements.md
+++ b/design/_memory/reviewing-my-own-measurements.md
@@ -1,0 +1,34 @@
+---
+name: reviewing-my-own-measurements
+description: In numerical work my prose fails far more often than my code, because nothing checks prose
+metadata:
+  node_type: memory
+  type: feedback
+  modified: 2026-08-20T23:30:00.000Z
+---
+
+A six-lens deep review of the quad port found six critical defects. **Not one was a wrong
+number in the shipped code.** Every one was a claim *about* a measurement: units swapped
+(`eps` quoted as `u`, halving every stated margin), a test range fitted to one machine's
+libm, a figure correct for one sweep cited in a file whose constants describe another, a
+sensitivity formula evaluated in a coordinate its derivation does not cover.
+
+**Why:** the suite checks code on every commit and checks prose never. In a numerics PR the
+prose *is* the deliverable, because the bounds, their derivations and the contract other
+work inherits live in docstrings and design notes.
+
+**How to apply:**
+- **Re-measure a number before writing it into a permanent artifact**, and say which sweep
+  produced it. "Measured over a twelve-size probe, not this file's own constants" is the
+  sentence that would have prevented four of the six.
+- **A sampled sweep can miss every failing case.** Sweep exhaustively when the cost allows;
+  a recorded slack of 0.43 turned out to be 0.947 exhaustively.
+- **Never compare two arrays by their maxima.** A max ratio of 0.9999991 hid an elementwise
+  factor of 1.9e12.
+- **A transliteration contract is a claim about the binary.** `nm -D` and `objdump`, not the
+  source.
+- **State absolute vs relative explicitly.** I conflated them five times in one cycle.
+- Prefer a guard that makes the mistake unrepresentable over a comment warning against it:
+  refusing an array with no negative entry beats a docstring saying "pass the unmapped nodes".
+
+See [[active-task]].

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -553,18 +553,43 @@ python_checks() {
 splitmode() {
     step "nanobind split mode (pre-release probe)"
 
-    local tmpvenv
-    tmpvenv="$(mktemp -d)/venv"
+    # The probe gets a build directory of its own, and that is load-bearing
+    # rather than tidiness. pyproject sets a PERSISTENT build-dir so an editable
+    # rebuild stays incremental, and a CMake cache is sticky in both directions:
+    #
+    #   * cpp/bindings/CMakeLists.txt finds nanobind through the interpreter and
+    #     writes `nanobind_ROOT` as a normal variable, but find_package records
+    #     the result in the CACHE variable `nanobind_DIR`. On any later
+    #     configure a valid cached <pkg>_DIR wins over <pkg>_ROOT, so the probe
+    #     would silently configure against whichever nanobind the ordinary build
+    #     resolved first -- reporting on 2.x while claiming to test 3.x.
+    #   * PANTR_NANOBIND_SPLIT=ON would likewise stay in that cache and be
+    #     inherited by the NEXT ordinary editable install, which then fails.
+    #     That made `ci_local.sh all` pass once and fail the second time.
+    #
+    # Sharing nothing is the whole fix. See the issue this closes.
+    local probedir tmpvenv probebuild
+    probedir="$(mktemp -d)"
+    tmpvenv="$probedir/venv"
+    probebuild="$probedir/skbuild"
     if ! python -m venv --system-site-packages "$tmpvenv" >/dev/null 2>&1; then
         record SKIP "nanobind split mode" "could not create a probe venv"
+        rm -rf "$probedir"
         return 0
     fi
     # shellcheck disable=SC1091
     source "$tmpvenv/bin/activate"
 
-    if ! pip install -q --pre "nanobind>=3.0.0.dev0" >"$LOGDIR/nb3.log" 2>&1; then
+    # BOTH halves, because that is what split mode is. The frontend links
+    # against the stable ABI and the backend module carries the runtime; with
+    # only the frontend installed the extension builds and then refuses to
+    # import, naming the missing backend. design/_memory/nanobind-status.md
+    # records the pairing that was measured to work.
+    if ! pip install -q --pre "nanobind>=3.0.0.dev0" "nanobind-backend" \
+            >"$LOGDIR/nb3.log" 2>&1; then
         record SKIP "nanobind split mode" "pre-release not installable"
         deactivate || true
+        rm -rf "$probedir"
         return 0
     fi
 
@@ -572,6 +597,7 @@ splitmode() {
     nbver="$(python -c 'import nanobind; print(nanobind.__version__)' 2>/dev/null || echo unknown)"
 
     if pip install -e . --no-build-isolation -q \
+         --config-settings=build-dir="$probebuild" \
          --config-settings=cmake.define.PANTR_NANOBIND_SPLIT=ON >"$LOGDIR/split.log" 2>&1 \
        && python -c "import pantr._pantr_cpp" >>"$LOGDIR/split.log" 2>&1; then
         record PASS "nanobind split mode" "nanobind $nbver"
@@ -579,7 +605,37 @@ splitmode() {
         record WARN "nanobind split mode" "nanobind $nbver: see the log tail below"
         tail -25 "$LOGDIR/split.log"
     fi
+
+    # Which nanobind CMake actually loaded, rather than which one Python could
+    # import. The two disagreeing is precisely the failure above, and the
+    # version line the build prints comes from the interpreter, so it cannot
+    # tell them apart on its own.
+    #
+    # This one is a FAIL rather than a WARN, and the distinction is deliberate:
+    # the step is non-blocking about whether the PRE-RELEASE works, not about
+    # whether the probe measured what it claims. A probe that quietly configured
+    # against a different nanobind reports a verdict on the wrong subject, which
+    # is worse than reporting nothing.
+    #
+    # `|| true` is required, not defensive: `set -euo pipefail` is in force, so
+    # an unmatched grep inside a command substitution would abort the function
+    # before it records anything.
+    local nbcmake
+    # Both levels: pyproject's build-dir carries a `{wheel_tag}` component, but
+    # the override above is a literal path, so the cache lands directly in it.
+    nbcmake="$(grep -hm1 '^nanobind_DIR:' \
+        "$probebuild"/CMakeCache.txt "$probebuild"/*/CMakeCache.txt 2>/dev/null \
+        | cut -d= -f2- || true)"
+    if [ -z "$nbcmake" ]; then
+        record WARN "split probe used the probe's nanobind" "no CMake cache to read"
+    elif [[ "$nbcmake" == "$tmpvenv"/* ]]; then
+        record PASS "split probe used the probe's nanobind"
+    else
+        record FAIL "split probe used the probe's nanobind" "configured against $nbcmake"
+    fi
+
     deactivate || true
+    rm -rf "$probedir"
 }
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Closes #340. `scripts/ci_local.sh`'s split-mode probe was reusing the repository's
persistent build directory, which pyproject sets so that an editable rebuild stays
incremental. A CMake cache is sticky in both directions, so that one fact produced both
symptoms the issue reports.

## Specification

Give the probe a build directory of its own, so it shares no CMake state with the ordinary
build in either direction.

## What changed

`scripts/ci_local.sh`, `splitmode()` only.

- The probe's venv and build directory now live under one `mktemp -d`, removed on every exit
  path. The editable install passes `--config-settings=build-dir=` pointing at it.
- The probe installs `nanobind-backend` as well as `nanobind`. Split mode is two pieces: the
  frontend links against the stable ABI and the backend module carries the runtime. With only
  the frontend the extension builds and then refuses to import, naming what is missing. This
  was invisible before, because configuration failed first.
- A new check reads `nanobind_DIR` back out of the probe's cache and verifies it points inside
  the probe's own venv.

## Why the guard is a FAIL and not a WARN

The step is deliberately non-blocking, and stays so: whether the pre-release builds is
reported, never blocking. The new check asks a different question, which is whether the probe
measured the subject it claims. A probe that silently configures against a different nanobind
returns a verdict about the wrong thing, and that is worse than returning nothing.

## The mechanism, for the record

`cpp/bindings/CMakeLists.txt` finds nanobind through the interpreter and writes
`nanobind_ROOT` as a normal variable, but `find_package` records its result in the **cache**
variable `nanobind_DIR`, and a valid cached `<pkg>_DIR` takes precedence over `<pkg>_ROOT`.
The probe therefore configured against whichever nanobind the ordinary build had resolved
first, while printing the version it had *imported*: the recorded log reads
`-- pantr: nanobind 3.0.0-dev4` directly above an error raised by a 2.x config that does not
know `BACKEND_MODULE`.

In the other direction the same cache carried `PANTR_NANOBIND_SPLIT=ON` into the next ordinary
editable install, which then failed. That is why the suite passed once and failed the second
time.

## Acceptance criteria

- [x] **`scripts/ci_local.sh all` run twice in a row, no cleanup in between, gives the same
      result.** 38 checks, **zero SKIP**, the two summaries identical line by line, both
      `exit=0`. The second run reports `PASS editable install`, which is the step that used
      to fail.
- [x] **The probe's configure names a nanobind cmake directory inside the probe venv.** The
      new check reports `PASS split probe used the probe's nanobind`. It is not vacuous: fed
      the path from the recorded failure it returns `FAIL`, and fed the probe venv's path it
      returns `PASS`.
- [x] **No `PANTR_NANOBIND_SPLIT:BOOL=ON` in the ordinary cache after a probe run.** After two
      full runs, each including a probe, the ordinary cache reads
      `PANTR_NANOBIND_SPLIT:BOOL=OFF` with its own nanobind untouched.
- [ ] **The probe still reports `WARN` rather than failing when the pre-release genuinely does
      not build.** Not re-exercised, and said plainly rather than ticked: that `else` branch is
      unchanged, but the probe now passes, so the branch cannot be reached without breaking
      something on purpose.

## A side effect worth naming

With both halves installed and configuration reaching the compiler, **the probe passes for the
first time**: `PASS nanobind split mode — nanobind 3.0.0-dev4`. Split mode builds, imports and
runs. That is a new measurement rather than part of the fix, and it does not change what the
shipped build does, since the probe remains non-blocking and nothing selects split mode.

## Non-goals

- Making the probe a blocking check.
- Changing how the shipped build locates nanobind.
- Adopting split mode.

## Checks

`scripts/ci_local.sh all` twice: 38 PASS, 0 FAIL, 0 SKIP, both times. The suite covers the
configure-time gates, both toolchains plus the compiler floor with ctest, the source-level
discipline guards, the editable install, parity against the Python oracle, and the whole test
suite under each backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
