### PR TITLE
refactor(quad): one catalogue accessor per kernel, and write the rule down

### DIFF
--- a/design/cross_backend_types.md
+++ b/design/cross_backend_types.md
@@ -68,6 +68,36 @@ A kernel entry point takes and returns only these:
 Validation, allocation, dtype normalization and the construction of any object stay in
 Python, above the seam, exactly where `CLAUDE.md` already puts Layer 2.
 
+### What the catalogue hands out, and in what shape
+
+Two rules, both settled on 2026-08-21 while reworking `pantr.quad`'s catalogue, and both
+binding on every module ported after it. They exist because the first two ports produced two
+different shapes without either being wrong, and a third port would have had to guess.
+
+**A catalogue returns a record when the consumer needs more than one kernel at once, and a
+bare callable when it does not.** `pantr.basis` needs the record: `CoreKernels` carries a
+parallel kernel and its serial twin, and the consumer picks between them per call on a point
+count. `pantr.quad` does not: a rule is built once and cached, so there is no threshold and
+no twin, and every consumer takes exactly one kernel. Five accessors say that; a five-field
+record says the opposite, and if both shapes are used regardless of need then neither shape
+carries information.
+
+An argument that did not survive, recorded so it is not made again: that bundling the five
+prevented a rule whose nodes came from one backend and whose weights from another. Every rule
+kernel returns the pair from one call, so the signature already forbids that. And a catalogue
+reads the active backend when it is called, so five calls behave exactly as five accessors do.
+
+**A catalogue entry mirrors its module's public surface**, and the criterion is that neither
+shape introduces a copy between Layer 2 and Layer 3. `pantr.basis` takes `out` on its public
+functions, so its kernels take the caller's buffer and fill it. No public function in
+`pantr.quad` takes `out`: every rule getter constructs and returns, because there is no
+caller-owned buffer to fill. So a quad kernel allocates and returns. The two conventions
+differ because the two public surfaces differ, and a module whose public API grows an `out`
+should move its kernels with it.
+
+Note this is a rule about the **catalogue entry**, not about the binding. Both C++ bindings
+below these entries take output buffers, which is the flat-ABI constraint and is unaffected.
+
 ### `dtype` is an output format, not a computation precision
 
 Measured across all seven of `quad`'s rules: for six of them the `dtype` argument selects

--- a/src/pantr/quad/_quad_backend.py
+++ b/src/pantr/quad/_quad_backend.py
@@ -18,30 +18,59 @@ is defined for functions, and two backends cannot own two different classes that
 are then passed between them. Every record in this module -- :class:`QuadKernels`
 and the arrays it hands back -- is Python-owned and stays on this side.
 
-Why one record rather than five catalogue functions
----------------------------------------------------
+One accessor per kernel, and when a record is right instead
+-----------------------------------------------------------
 
-:mod:`pantr.basis._basis_backend` publishes one catalogue function per
-tabulation, because each returns a :class:`~pantr.basis._basis_backend.CoreKernels`
-carrying a parallel kernel and an optional serial twin, and which of the two runs
-is a per-call decision. Quadrature has no such split: a rule generator builds an
-``n``-point rule once and is then cached, so there is nothing to dispatch on
-below a threshold and no twin to carry.
+**The rule, which every module ported after this one inherits: a catalogue
+returns a record when the consumer needs more than one kernel at once, and a
+bare callable when it does not.**
 
-What the five *do* share is that they are ported and shipped as a unit and are
-always taken from the same backend -- a rule whose nodes came from one
-implementation and whose weights came from another would be a bug no test looks
-for. One record makes that impossible to express, and makes "which backend built
-this rule" a single question rather than five.
+:mod:`pantr.basis._basis_backend` needs the record. Its
+:class:`~pantr.basis._basis_backend.CoreKernels` carries a parallel kernel and
+its optional serial twin, and
+:func:`pantr.basis._basis_1D._tabulate_basis_1D_impl_helper` chooses between
+them per call on ``_PARALLEL_MIN_NUM_PTS``. Two kernels reach one consumer, so
+one object carries both.
 
-- :class:`QuadKernels`: the five rule kernels of one backend.
-- :func:`quad_kernels`: the kernels of the requested backend.
+Quadrature has no such split. A rule generator builds an ``n``-point rule once
+and the result is cached, so there is no threshold to dispatch on and no twin to
+carry, and every consumer in :mod:`pantr.quad._rules` takes exactly one kernel.
+Five accessors say that; a five-field record says the opposite, and the two
+shapes then mean nothing, because the same structure would stand for "these
+belong together" in one package and "these happen to live nearby" in the other.
+
+An earlier version of this module argued the record made it impossible to
+express a rule whose nodes came from one backend and whose weights from another.
+That argument does not hold, and it is recorded here so it is not reinvented:
+every rule kernel returns the pair from a single call, so its **signature**
+already forbids the mix. Nor did the record buy atomicity across kernels. The
+catalogue reads :func:`pantr._backend.active_backend` when it is called, so five
+calls behave exactly as five accessors do, and no consumer ever held two fields
+at once for a backend switch to land between.
+
+What a catalogue entry looks like
+---------------------------------
+
+**The entry mirrors its module's public surface**, and the criterion is that
+neither shape introduces a copy between Layer 2 and Layer 3.
+
+:mod:`pantr.basis` takes ``out`` on its public functions, so its kernels take
+the caller's buffer and fill it. No public function in :mod:`pantr.quad` takes
+``out``: every rule getter constructs its arrays and returns them, because a
+rule is built once and cached and there is no caller-owned buffer to fill. So a
+quad kernel allocates and returns. The two conventions differ because the two
+public surfaces differ, not because either drifted.
+
+- :func:`gauss_legendre_kernel`, :func:`lambert_w_kernel`,
+  :func:`tanh_sinh_kernel`, :func:`trapezoidal_kernel`,
+  :func:`chebyshev_nodes_kernel`: one rule kernel each, from the requested
+  backend.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -54,6 +83,9 @@ from ._rules_core import (
     _modified_chebyshev_nodes_core,
     _trapezoidal_core,
 )
+
+_K = TypeVar("_K")
+"""One kernel's signature, so :func:`_select` returns the type it was given."""
 
 _GaussLegendreFunc = Callable[[int], tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]
 """Signature of the Gauss-Legendre kernel: ``(n) -> (nodes, weights)`` on ``[-1, 1]``."""
@@ -82,29 +114,6 @@ rather than a formatting one: the Python computes in the storage format, so a
 float32 request is float32 *arithmetic* and not a narrowed float64 result. The
 two were measured to differ on 62% of arguments.
 """
-
-
-class QuadKernels(NamedTuple):
-    """The five quadrature rule kernels, in one backend.
-
-    Attributes:
-        gauss_legendre (_GaussLegendreFunc): Gauss-Legendre nodes and weights on
-            ``[-1, 1]``, in float64 whatever the caller will narrow to.
-        lambert_w (_LambertWFunc): The principal branch of Lambert W, which the
-            tanh-sinh step size is solved from.
-        tanh_sinh (_TanhSinhFunc): The tanh-sinh rule on ``[-1, 1]``, returning
-            its own effective node count.
-        trapezoidal (_TrapezoidalFunc): The trapezoidal rule, already on
-            ``[0, 1]`` and so needing no mapping.
-        chebyshev_nodes (_ChebyshevNodesFunc): The modified Chebyshev
-            interpolation nodes on ``[0, 1]``, computed in the storage format.
-    """
-
-    gauss_legendre: _GaussLegendreFunc
-    lambert_w: _LambertWFunc
-    tanh_sinh: _TanhSinhFunc
-    trapezoidal: _TrapezoidalFunc
-    chebyshev_nodes: _ChebyshevNodesFunc
 
 
 def _cpp_gauss_legendre(n: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
@@ -210,16 +219,21 @@ def _cpp_chebyshev_nodes(n: int, dtype: npt.DTypeLike) -> npt.NDArray[np.float32
     return nodes
 
 
-def quad_kernels(backend: Backend | None = None) -> QuadKernels:
-    """Return the quadrature rule kernels of the requested backend.
+def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
+    """Pick one kernel's implementation for the requested backend.
+
+    The one place the never-fall-back rule is applied for this package, so the
+    five accessors below cannot drift from each other on it.
 
     Args:
         backend (Backend | None): The backend to use. ``None`` means the backend
             currently in effect, per :func:`pantr._backend.active_backend`.
-            Defaults to None.
+        python_kernel (_K): The Python implementation, always available.
+        cpp_kernel (_K): The C++ implementation, available only when the
+            extension was built.
 
     Returns:
-        QuadKernels: The five kernels of that backend.
+        _K: The kernel of the chosen backend.
 
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
@@ -227,20 +241,94 @@ def quad_kernels(backend: Backend | None = None) -> QuadKernels:
     chosen = active_backend() if backend is None else backend
 
     if chosen is Backend.PYTHON:
-        return QuadKernels(
-            gauss_legendre=_gauss_legendre_symmetric_core,
-            lambert_w=_lambert_w_principal_core,
-            tanh_sinh=_generate_tanh_sinh_core,
-            trapezoidal=_trapezoidal_core,
-            chebyshev_nodes=_modified_chebyshev_nodes_core,
-        )
+        return python_kernel
 
     if chosen not in available_backends():
         raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
-    return QuadKernels(
-        gauss_legendre=_cpp_gauss_legendre,
-        lambert_w=_cpp_lambert_w,
-        tanh_sinh=_cpp_tanh_sinh,
-        trapezoidal=_cpp_trapezoidal,
-        chebyshev_nodes=_cpp_chebyshev_nodes,
-    )
+    return cpp_kernel
+
+
+def gauss_legendre_kernel(backend: Backend | None = None) -> _GaussLegendreFunc:
+    """Get the Gauss-Legendre kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _GaussLegendreFunc: The kernel, ``(n) -> (nodes, weights)`` on ``[-1, 1]``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _gauss_legendre_symmetric_core, _cpp_gauss_legendre)
+
+
+def lambert_w_kernel(backend: Backend | None = None) -> _LambertWFunc:
+    """Get the Lambert W kernel of the requested backend.
+
+    Exposed for its own sake rather than for a consumer: the tanh-sinh kernels
+    each solve their step size internally, so nothing in the library calls this
+    one. It is dispatched so that the two implementations of a function the
+    rules depend on can be compared directly, instead of only through the rule
+    that hides it.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _LambertWFunc: The kernel, ``(x) -> W(x)`` on the principal branch.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _lambert_w_principal_core, _cpp_lambert_w)
+
+
+def tanh_sinh_kernel(backend: Backend | None = None) -> _TanhSinhFunc:
+    """Get the tanh-sinh kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _TanhSinhFunc: The kernel, ``(n, min_gap) -> (data, count)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _generate_tanh_sinh_core, _cpp_tanh_sinh)
+
+
+def trapezoidal_kernel(backend: Backend | None = None) -> _TrapezoidalFunc:
+    """Get the trapezoidal kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _TrapezoidalFunc: The kernel, ``(n) -> (nodes, weights)`` on ``[0, 1]``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _trapezoidal_core, _cpp_trapezoidal)
+
+
+def chebyshev_nodes_kernel(backend: Backend | None = None) -> _ChebyshevNodesFunc:
+    """Get the modified Chebyshev nodes kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _ChebyshevNodesFunc: The kernel, ``(n, dtype) -> nodes`` on ``[0, 1]``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _modified_chebyshev_nodes_core, _cpp_chebyshev_nodes)

--- a/src/pantr/quad/_rules.py
+++ b/src/pantr/quad/_rules.py
@@ -16,7 +16,13 @@ from numpy.polynomial import chebyshev, legendre
 
 from .._array_utils import _validate_float_dtype
 from ..tolerance import get_machine_epsilon
-from ._quad_backend import quad_kernels
+from ._quad_backend import (
+    chebyshev_nodes_kernel,
+    gauss_legendre_kernel,
+    lambert_w_kernel,
+    tanh_sinh_kernel,
+    trapezoidal_kernel,
+)
 
 # Re-exported so the name keeps resolving where it always did. It predates the
 # split of the kernels into ``_rules_core`` for the C++ port, and CLAUDE.md
@@ -91,7 +97,7 @@ def get_trapezoidal_1d(
     """
     _validate_n_pts_and_dtype(n_pts, dtype)
 
-    nodes, weights = quad_kernels().trapezoidal(n_pts)
+    nodes, weights = trapezoidal_kernel()(n_pts)
     return nodes.astype(dtype), weights.astype(dtype)
 
 
@@ -119,7 +125,7 @@ def _gauss_legendre_symmetric(n: int) -> tuple[npt.NDArray[np.float64], npt.NDAr
             in ``(-1, 1)`` and their weights, summing to 2 up to the rounding of
             that sum.
     """
-    return quad_kernels().gauss_legendre(n)
+    return gauss_legendre_kernel()(n)
 
 
 def get_gauss_legendre_1d(
@@ -235,7 +241,7 @@ def get_modified_chebyshev_nodes_1d(
     """
     _validate_n_pts_and_dtype(n_pts, dtype, min_pts=2)
 
-    return quad_kernels().chebyshev_nodes(n_pts, dtype)
+    return chebyshev_nodes_kernel()(n_pts, dtype)
 
 
 def get_chebyshev_gauss_2nd_kind_1d(
@@ -353,7 +359,7 @@ def _lambert_w_principal(x: float) -> float:
     Returns:
         float: ``W(x)``, within about one unit of roundoff of ``W``.
     """
-    return quad_kernels().lambert_w(x)
+    return lambert_w_kernel()(x)
 
 
 def _generate_tanh_sinh(
@@ -391,7 +397,7 @@ def _generate_tanh_sinh(
         Nodes and weights follow the double-exponential formulas of Takahasi &
         Mori (1974), *Publ. RIMS, Kyoto Univ.* 9(3), 721-741.
     """
-    return quad_kernels().tanh_sinh(n, _tanh_sinh_min_gap(dtype))
+    return tanh_sinh_kernel()(n, _tanh_sinh_min_gap(dtype))
 
 
 def get_tanh_sinh_1d(

--- a/tests/parity/test_dispatch.py
+++ b/tests/parity/test_dispatch.py
@@ -11,6 +11,7 @@ sibling module under `tests/parity`.
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 
 import pytest
 
@@ -24,6 +25,13 @@ from pantr._backend import (
     use_backend,
 )
 from pantr.basis._basis_backend import cardinal_bspline_core
+from pantr.quad._quad_backend import (
+    chebyshev_nodes_kernel,
+    gauss_legendre_kernel,
+    lambert_w_kernel,
+    tanh_sinh_kernel,
+    trapezoidal_kernel,
+)
 from tests._parity_harness import build_provenance, cpp_backend_available, demand_cpp_backend
 
 
@@ -249,3 +257,90 @@ def test_use_backend_does_not_reach_into_another_thread(cpp_backend: None) -> No
         f"{ambient.name}, so the selection is process-wide rather than scoped to "
         f"the block that took it"
     )
+
+
+# The quad catalogue is five accessors rather than one record, and the tests below
+# are what keeps it that way. Identity is the assertion throughout, for the reason
+# the test above gives: that a returned object is not None says nothing about a
+# function reference, and identity also fails if the five are ever re-bundled into
+# a record, since a record is not the function it carries.
+_QUAD_ACCESSORS = (
+    ("gauss_legendre", gauss_legendre_kernel),
+    ("lambert_w", lambert_w_kernel),
+    ("tanh_sinh", tanh_sinh_kernel),
+    ("trapezoidal", trapezoidal_kernel),
+    ("chebyshev_nodes", chebyshev_nodes_kernel),
+)
+"""The quad catalogue's five entry points, named for the failure message."""
+
+
+@pytest.mark.parametrize(("name", "accessor"), _QUAD_ACCESSORS, ids=[n for n, _ in _QUAD_ACCESSORS])
+def test_a_quad_accessor_hands_back_the_python_kernel_itself(
+    name: str, accessor: Callable[[Backend | None], object]
+) -> None:
+    """Each quad accessor returns the Python kernel, by identity, not a wrapper.
+
+    Args:
+        name (str): The kernel's name, for the failure message.
+        accessor (Callable[[Backend | None], object]): The catalogue entry point.
+    """
+    from pantr.quad import _rules_core  # noqa: PLC0415
+
+    expected = {
+        "gauss_legendre": _rules_core._gauss_legendre_symmetric_core,
+        "lambert_w": _rules_core._lambert_w_principal_core,
+        "tanh_sinh": _rules_core._generate_tanh_sinh_core,
+        "trapezoidal": _rules_core._trapezoidal_core,
+        "chebyshev_nodes": _rules_core._modified_chebyshev_nodes_core,
+    }[name]
+    assert accessor(Backend.PYTHON) is expected, (
+        f"{name}: the catalogue returned something other than the kernel itself"
+    )
+
+
+@pytest.mark.parametrize(("name", "accessor"), _QUAD_ACCESSORS, ids=[n for n, _ in _QUAD_ACCESSORS])
+def test_a_quad_accessor_hands_back_the_cpp_adapter_itself(
+    name: str, accessor: Callable[[Backend | None], object], cpp_backend: None
+) -> None:
+    """Each quad accessor returns the C++ adapter, by identity, not a wrapper.
+
+    Args:
+        name (str): The kernel's name, for the failure message.
+        accessor (Callable[[Backend | None], object]): The catalogue entry point.
+        cpp_backend (None): Requires the compiled extension.
+    """
+    from pantr.quad import _quad_backend  # noqa: PLC0415
+
+    expected = {
+        "gauss_legendre": _quad_backend._cpp_gauss_legendre,
+        "lambert_w": _quad_backend._cpp_lambert_w,
+        "tanh_sinh": _quad_backend._cpp_tanh_sinh,
+        "trapezoidal": _quad_backend._cpp_trapezoidal,
+        "chebyshev_nodes": _quad_backend._cpp_chebyshev_nodes,
+    }[name]
+    assert accessor(Backend.CPP) is expected, (
+        f"{name}: the catalogue returned something other than the adapter itself"
+    )
+
+
+def test_no_quad_accessor_falls_back_when_the_extension_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All five quad accessors refuse an explicit C++ request, not just the first.
+
+    The never-fall-back rule is applied once, in the catalogue's ``_select``, so
+    the five cannot drift apart on it. This asserts the property they are meant to
+    share rather than the helper's existence, which would pass just as happily if
+    someone reinstated five separate copies of the check.
+    """
+    from pantr import _backend  # noqa: PLC0415
+
+    monkeypatch.setattr(_backend, "_CPP_AVAILABLE", False)
+
+    for name, accessor in _QUAD_ACCESSORS:
+        try:
+            accessor(Backend.CPP)
+        except RuntimeError as exc:
+            assert "not available" in str(exc), f"{name}: raised, but not for that reason: {exc}"
+        else:
+            pytest.fail(f"{name}: an explicit CPP request was served without the extension")


### PR DESCRIPTION
## Context

The quad catalogue returned a five-field record, `QuadKernels`, and every one of its five
consumers took a single field and discarded the other four:

```
_rules.py:94   quad_kernels().trapezoidal(n_pts)
_rules.py:122  quad_kernels().gauss_legendre(n)
_rules.py:238  quad_kernels().chebyshev_nodes(n_pts, dtype)
_rules.py:356  quad_kernels().lambert_w(x)
_rules.py:394  quad_kernels().tanh_sinh(n, _tanh_sinh_min_gap(dtype))
```

The basis catalogue returns a record too, but for a reason: `CoreKernels` carries a parallel
kernel and its serial twin, and `_tabulate_basis_1D_impl_helper` picks between them per call
on `_PARALLEL_MIN_NUM_PTS`. So one shape stood for two different things, "these belong
together" in one package and "these happen to live nearby" in the other, and neither shape
carried information. Three more modules are due to be ported and each would have had to guess
which catalogue to copy.

`pantr.quad._quad_backend` and `pantr.basis._basis_backend` do not exist on `main`. The whole
dual-backend layer is prototype-only, so nothing outside this branch can be importing the
names this changes.

## Specification

Settle the catalogue's shape and its signature convention, apply them, and write both down
where the next porter reads.

## What changed

**`src/pantr/quad/_quad_backend.py`** publishes `gauss_legendre_kernel`, `lambert_w_kernel`,
`tanh_sinh_kernel`, `trapezoidal_kernel` and `chebyshev_nodes_kernel`, each returning one
callable, over a private `_select` that applies the never-fall-back rule in one place so the
five cannot drift apart on it. `QuadKernels` and `quad_kernels` are gone. `pantr.basis` keeps
its record, unchanged.

**`src/pantr/quad/_rules.py`**: the five call sites.

**`design/cross_backend_types.md`** gains both rules, in the section a kernel author reads.

**`tests/parity/test_dispatch.py`** gains three tests. The catalogue had no direct test at
all; it was exercised only through the public API.

## The record's justification does not survive being checked

The module argued that bundling the five made it impossible to express a rule whose nodes came
from one backend and whose weights from another. That is not what the record was doing:

- every rule kernel returns the **pair** from a single call, so its signature already forbids
  the mix;
- the catalogue reads `active_backend()` when it is called, so five calls behave exactly as
  five accessors do, and no consumer ever held two fields across a possible switch.

The refutation is written into the module rather than dropped, so it is not made again.

## The two rules, now recorded

**A catalogue returns a record when the consumer needs more than one kernel at once, and a
bare callable when it does not.**

**A catalogue entry mirrors its module's public surface**, the criterion being that neither
shape introduces a copy between Layer 2 and Layer 3. `basis` takes `out=` on its public
functions, so its kernels fill the caller's buffer. No public function in `quad` takes `out=`,
because a rule is built once and cached and there is no caller-owned buffer to fill, so a quad
kernel allocates and returns. The two conventions differ because the two public surfaces do,
not because either drifted. This is a rule about the catalogue entry and not about the
binding: both C++ bindings underneath take output buffers, which is the flat-ABI constraint
and is untouched.

## Acceptance criteria

- [x] No consumer takes more than one kernel; the five call sites read as single accessors.
- [x] The never-fall-back rule is applied in exactly one place and holds for all five, tested.
- [x] The catalogue has direct tests, and they discriminate: wrapping one accessor so it
      returns a closure instead of the kernel makes all three fail, the never-fall-back one
      included, since deferring the `_select` call moves the exception out of the accessor.
- [x] Both rules are written where a porter reads them, with the refuted argument recorded.
- [x] `pantr.basis` is untouched.

## Non-goals

- Changing which kernels the catalogue contains. `lambert_w_kernel` has no consumer outside
  the tests, because the tanh-sinh kernels each solve their step size internally; it stays
  dispatched so the two implementations can be compared directly rather than only through the
  rule that hides one. Whether it belongs in the catalogue at all is a separate question from
  the catalogue's shape.
- Any change to the C++ side, the bindings, or numerical behaviour.

## Checks

`scripts/ci_local.sh all`: **38 PASS, 0 FAIL, 0 SKIP**, including the whole test suite under
each backend. `mypy src tests scripts` clean over 257 files. `lint-imports` both contracts
kept. `ruff check .` and `ruff format --check .` clean over 281 files.

One note on that last line, since it cost a diagnosis: the conda environment carries ruff
0.16.3 while `pyproject.toml` pins `ruff>=0.12.0,<0.13`. The newer one reports 12 findings in
three files this branch does not touch, under rules that did not exist in the pinned range.
The figures above are from 0.12.12, which is what CI resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
