### PR TITLE
fix(quad): make PointsLattice immutable, as its sibling already is

### DIFF
--- a/src/pantr/quad/_lattice.py
+++ b/src/pantr/quad/_lattice.py
@@ -12,12 +12,35 @@ if TYPE_CHECKING:
     from ..basis import LagrangeVariant
 
 
+def _frozen_copy(
+    pts: npt.NDArray[np.float32 | np.float64],
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Take a read-only, contiguous copy of one direction's coordinates.
+
+    Args:
+        pts (npt.NDArray[np.float32 | np.float64]): The caller's coordinate array.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: A copy the caller cannot reach and
+            nobody can write to.
+    """
+    frozen = np.ascontiguousarray(pts).copy()
+    frozen.flags.writeable = False
+    return frozen
+
+
 class PointsLattice:
     """A tensor-product grid of evaluation points in multiple dimensions.
 
     Stores one 1D array of coordinates per spatial direction and provides
     helpers for constructing the full set of grid points or querying grid
     metadata.
+
+    Immutable once constructed: each coordinate array is copied on the way in
+    and the stored copies are read-only, so what
+    :meth:`_validate_pts_per_dir` checked at construction stays true for the
+    object's whole life. :class:`pantr.quad.QuadratureRule` does the same, and
+    for the same reason.
 
     Attributes:
         _pts_per_dir (tuple[npt.NDArray[np.float32 | np.float64], ...]): One
@@ -35,7 +58,15 @@ class PointsLattice:
         Raises:
             ValueError: If the dimension is less than 1 or the points have different dtypes.
         """
-        self._pts_per_dir: tuple[npt.NDArray[np.float32 | np.float64], ...] = tuple(pts_per_dir)
+        # Snapshot, then freeze, in that order. ``tuple()`` copies the container
+        # and not the arrays, so without the copy the caller keeps a live handle
+        # on the lattice's coordinates, and without the freeze so does anyone
+        # who reads :attr:`pts_per_dir`. Validation below would then describe a
+        # state the object need not still be in: ``arr.shape = (n, 1)`` reshapes
+        # in place and breaks the 1-D invariant with no error raised.
+        self._pts_per_dir: tuple[npt.NDArray[np.float32 | np.float64], ...] = tuple(
+            _frozen_copy(pts) for pts in pts_per_dir
+        )
         self._validate_pts_per_dir()
 
     def _validate_pts_per_dir(self) -> None:
@@ -81,9 +112,17 @@ class PointsLattice:
 
         Returns:
             tuple[npt.NDArray[np.float32 | np.float64], ...]: One 1D coordinate
-            array for each spatial dimension.
+            array for each spatial dimension, read-only.
         """
-        return self._pts_per_dir
+        # Fresh read-only views rather than the stored arrays themselves, because
+        # ``writeable = False`` stops writes to the data and not changes to the
+        # metadata: ``arr.shape = (n, 1)`` reshapes a read-only array in place and
+        # would leave the lattice holding a 2-D array while :attr:`dim` still
+        # reported 1. A view carries its own shape, so that lands on the caller's
+        # copy and not on ours. Measured at about 640 ns for three directions,
+        # against evaluations that read this once per direction per call and cost
+        # milliseconds.
+        return tuple(pts.view() for pts in self._pts_per_dir)
 
     def get_all_points(
         self, order: Literal["C", "F"] = "C"

--- a/tests/test_quad.py
+++ b/tests/test_quad.py
@@ -404,6 +404,33 @@ class TestPointsLattice:
         assert np.allclose(all_pts[6], [1.0, 1.0, 0.0])
         assert np.allclose(all_pts[7], [1.0, 1.0, 1.0])
 
+    # Immutability. Three separate holes, and freezing alone closes only two of
+    # them: numpy's writeable flag governs the data and not the metadata, so the
+    # in-place reshape below needs the property to hand out views instead.
+    # QuadratureRule in the same package has made all three promises since it was
+    # written, which is why these read as catching up rather than as new policy.
+
+    def test_the_caller_s_array_is_not_aliased(self) -> None:
+        source = np.array([0.0, 0.5, 1.0])
+        lattice = PointsLattice([source])
+        source[1] = 999.0
+        nptest.assert_array_equal(lattice.pts_per_dir[0], [0.0, 0.5, 1.0])
+        nptest.assert_array_equal(lattice.get_all_points().ravel(), [0.0, 0.5, 1.0])
+
+    def test_the_exposed_arrays_are_read_only(self) -> None:
+        lattice = PointsLattice([np.array([0.0, 0.5, 1.0])])
+        assert not lattice.pts_per_dir[0].flags.writeable
+        with pytest.raises(ValueError, match="read-only"):
+            lattice.pts_per_dir[0][0] = -7.0
+
+    def test_reshaping_what_the_property_returned_does_not_reach_the_lattice(self) -> None:
+        lattice = PointsLattice([np.array([0.0, 0.5, 1.0])])
+        borrowed = lattice.pts_per_dir[0]
+        borrowed.shape = (3, 1)
+        assert lattice.pts_per_dir[0].ndim == 1
+        assert lattice.dim == 1
+        nptest.assert_array_equal(lattice.get_all_points().ravel(), [0.0, 0.5, 1.0])
+
 
 class TestCreateLagrangePointsLattice:
     """Tests for create_lagrange_points_lattice function."""


### PR DESCRIPTION
Fixes #338, which is not closed automatically: GitHub resolves closing keywords only for
pull requests merged into the default branch, and this targets `proto/cpp`.

## Context

`PointsLattice` kept the caller's coordinate arrays by reference and handed them back
writeable. `QuadratureRule`, in the same package, copies and freezes and says so in its
docstring. The class validates an invariant at construction, that every array is 1-D,
non-empty and of one shared dtype, and none of that survived a later mutation.

## Read this before merging

**This one can break a caller outside the repository, and the check is outstanding.**

`PointsLattice` ships from `main` and `pts_per_dir` is public, so anything doing

```python
lattice.pts_per_dir[0][:] = new_values
```

now raises `ValueError: assignment destination is read-only`. Inside the tree nothing does:
6367 tests pass, and the whole suite passes under each backend. That says nothing about the
downstream consumer this project's CI cannot see. A search for `pts_per_dir` and
`PointsLattice` over that repository is what settles it, and it has not been done.

## Freezing alone closes two of the three holes, not three

The issue lists three, and the obvious fix handles only the first two, because **numpy's
writeable flag governs the data and not the metadata**:

| hole | before | copy + freeze | this PR |
|---|---|---|---|
| the caller's array is aliased | leaks in | fixed | fixed |
| the exposed array is writeable | `[0] = -7.0` lands | fixed | fixed |
| `arr.shape = (n, 1)` reshapes in place | `ndim` becomes 2 while `dim` says 1 | **still broken** | fixed |

So `pts_per_dir` hands out **fresh read-only views**. A view carries its own shape, so a
reshape lands on the caller's copy rather than on the stored array.

Measured: about 640 ns to build the views for three directions, against 31 ns to return the
stored tuple. Every read in the tree is once per direction per call, in functions whose own
work is milliseconds, so this is roughly 2 microseconds per evaluation.

## Acceptance criteria

- [x] All three mutations in the issue's reproduction fail or have no effect on the lattice.
- [x] A regression test pins each of the three, and each fails against the previous code, for
      its own reason: `AssertionError` on the values, `assert not True` on the writeable flag,
      `assert 2 == 1` on `ndim`.
- [x] The class docstring states the immutability, as `QuadratureRule`'s does.
- [x] `dtype`, `dim`, `pts_per_dir` and `get_all_points` behave as before for read-only use:
      6367 passed, 6 skipped, 7 xfailed.
- [ ] **No caller relies on the old behaviour.** Verified inside this repository only. See
      above.

## Non-goals

- `QuadratureRule`, which already does this.
- Anything on the C++ side or at the backend boundary; this is a Python object contract.

## Checks

`scripts/ci_local.sh all`: 37 PASS, 0 FAIL, 0 SKIP, including the whole suite under each
backend. `mypy src tests scripts` clean over 257 files. `ruff check .` and
`ruff format --check .` clean, run with 0.12.12, which is what `pyproject.toml` pins and what
CI resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
