### PR TITLE
fix(tests): enforce a liveness guard only where its numbers were measured

### DIFF
--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -211,6 +211,43 @@ any rule of two points or more has a node below `-1/2`. An amplification array b
 with no negative entry at all is the mapped one, handed over by mistake, and refusing it is one
 line. **Where a bound depends on a frame, make the frame a precondition rather than a convention.**
 
+## Rule 7: a bound is a property of the code; whether it is approached is a property of the host
+
+A bound that nothing exercises can rot without any test noticing, so the parity suite grew
+guards that assert the opposite of a bound: that the two backends still **disagree** somewhere,
+that the worst observed ratio is still close to the bound, that the Halley iterate still reaches
+a two-value limit cycle. Each of those was a good instinct and each was written as a hard
+assertion.
+
+**They are not assertions about this library.** `glibc` selects its `exp` through IFUNC on the
+processor's features, and numpy dispatches its own loops the same way, so which arguments the
+two round differently is a fact about the machine. Change the host and two implementations that
+differed by one ulp can agree exactly. Nothing about the port has changed; the port has got a
+better result on that host, and the suite calls it a failure.
+
+**Measured, and this is what settles it against argument.** Commit `767f502` was run twice on
+this project's CI with nothing changed between the runs. The first gave `6 failed, 309 passed,
+3 xfailed`; the second `313 passed, 5 xfailed`. Two strict `xfail`s XPASSed in the first and not
+the second. Same runner image, same numpy, same numba, same compiler. One of the six failures
+compares numpy against itself with no C++ involved at all, which is what rules out the change
+under review as the cause.
+
+So: **the bound stays a hard assertion everywhere. The liveness guard is enforced only where its
+numbers were measured**, which `scripts/ci_local.sh` marks with `PANTR_REFERENCE_HOST`, and
+reports with a written reason anywhere else. `tests/_parity_harness.py`'s
+`demand_the_reference_host` is the only supported way to write one, for the same reason
+`demand_cpp_backend` is the only supported way to require the extension.
+
+The same applies to an `xfail(strict=True)` whose expected failure is a disagreement between two
+libraries: `strict` becomes `on_the_reference_host()`. An `xfail` whose expected failure is
+structural stays strict, and the two kinds are easy to tell apart because the reason text says
+which it is. Of the five strict `xfail`s in `test_quad_shakedown.py`, two say an XPASS would mean
+the platform's libraries stopped straddling a threshold, and those two are gated; the other
+three are about what a binding accepts and what an emptied rule returns, and stay strict.
+
+**The cost of getting this wrong is not the red.** It is that an intermittent red teaches
+everyone to discount reds, which is worth less than no guard at all.
+
 ## The two corrections the infrastructure PR made, kept here because they generalize
 
 **The underflow floor.** `eta` per rounding, the unhalved smallest subnormal. Without it the

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -487,6 +487,25 @@ python_checks() {
     # shellcheck disable=SC1091
     source "$VENV/bin/activate"
 
+    # This script is the calibrated-host runner, so the parity suite's liveness
+    # guards are enforced here and only here.
+    #
+    # Those guards check that a bound is still doing work: that the two backends
+    # still disagree somewhere, that the worst observed ratio is still close to the
+    # bound. Worth having, because a bound nothing exercises can rot unnoticed. But
+    # the quantities behind them are chosen at run time by the CPU, since glibc
+    # dispatches `exp` through IFUNC on the processor's features and numpy
+    # dispatches its own loops the same way, so a different host can make two
+    # implementations agree that used to differ. On GitHub that produced a red from
+    # an unchanged tree: the same commit gave 6 failures on one run and none on a
+    # re-run. Off this variable the guards report instead of failing, and
+    # tests/_parity_harness.py's demand_the_reference_host carries the argument.
+    #
+    # Running this on a machine that is NOT the one those numbers were measured on
+    # will therefore fail them. That is the calibration not transferring, not the
+    # code being wrong; re-measure before changing a number.
+    export PANTR_REFERENCE_HOST=1
+
     check "editable install" pip install -e . --no-build-isolation -q
 
     # An explicit request that cannot be served must FAIL rather than fall back.

--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -135,6 +135,9 @@ FloatArray = npt.NDArray[np.floating[Any]]
 """Any real-valued NumPy array the backends can produce or consume."""
 
 _REQUIRE_ENV_VAR: Final[str] = "PANTR_REQUIRE_CPP"
+
+_REFERENCE_HOST_ENV_VAR: Final[str] = "PANTR_REFERENCE_HOST"
+"""Marks the machine a liveness guard's numbers were measured on."""
 """Environment variable that turns "the extension is absent" from a skip into a failure."""
 
 _BUILD_HINT: Final[str] = (
@@ -186,6 +189,60 @@ _MISSING_BUT_REQUIRED: Final[str] = (
     f"Numba-only."
 )
 """Message for the one configuration in which a missing extension must fail."""
+
+
+def on_the_reference_host() -> bool:
+    """Report whether this run is on the machine a liveness guard was calibrated on.
+
+    Returns:
+        bool: True when ``PANTR_REFERENCE_HOST`` is set to a non-empty value.
+    """
+    return bool(os.environ.get(_REFERENCE_HOST_ENV_VAR, ""))
+
+
+def demand_the_reference_host(guard: str, measured: str) -> None:
+    """Skip a liveness guard on a machine that cannot enforce its numbers.
+
+    **A bound is a property of the code; whether that bound is still approached is
+    a property of the host.** The two are different claims and only the first
+    transfers. This is what separates them.
+
+    The guards in question assert that a bound is still doing work: that the two
+    backends still disagree somewhere, that the worst observed ratio is still close
+    to the bound, that the Halley iterate still reaches a two-value limit cycle.
+    Each is worth having, because a bound nothing exercises can rot without any
+    test noticing. But each was measured on one machine, and the quantities behind
+    them are chosen at run time by the CPU: glibc dispatches ``exp`` through IFUNC
+    on the processor's features, and numpy dispatches its own loops the same way.
+    A different host gives a different ``exp``, and then two implementations that
+    disagreed by one ulp may agree exactly.
+
+    That is not a regression. It is a better outcome on that host, and failing the
+    build for it teaches everyone to discount a red, which costs more than the
+    guard ever earned. Measured: commit 767f502 was run twice on this project's CI
+    with no change between the runs, and gave ``6 failed, 309 passed, 3 xfailed``
+    and then ``313 passed, 5 xfailed``. Two strict xfails XPASSed in the first and
+    not the second.
+
+    So the guard keeps its teeth where its numbers came from, which
+    ``scripts/ci_local.sh`` marks, and reports rather than fails anywhere else. The
+    correctness assertions in the same tests are **not** gated and run everywhere.
+
+    Args:
+        guard (str): What the guard checks, for the skip reason.
+        measured (str): Where and to what value it was measured, so a reader can
+            re-establish it on a new reference host.
+
+    Raises:
+        Skipped: Via :func:`pytest.skip`, when not on the reference host.
+    """
+    if on_the_reference_host():
+        return
+    pytest.skip(
+        f"{guard} is a property of this host rather than of the code, so it is "
+        f"enforced only where it was calibrated ({measured}). Set "
+        f"{_REFERENCE_HOST_ENV_VAR} to enforce it here; scripts/ci_local.sh does."
+    )
 
 
 def demand_cpp_backend() -> None:

--- a/tests/parity/test_quad_shakedown.py
+++ b/tests/parity/test_quad_shakedown.py
@@ -118,7 +118,11 @@ from pantr.quad._rules_core import (
     _TANH_SINH_DECAY_FACTOR,
     _generate_tanh_sinh_core,
 )
-from tests._parity_harness import absolute_tolerance
+from tests._parity_harness import (
+    absolute_tolerance,
+    demand_the_reference_host,
+    on_the_reference_host,
+)
 from tests.parity.test_quad_tanh_sinh import N_PTS as SHIPPED_N_PTS
 from tests.parity.test_quad_tanh_sinh import _node_claim, _weight_claim
 
@@ -330,7 +334,7 @@ def _discriminating_degree(min_gap: float, limit: int = 200) -> int | None:
 
 
 @pytest.mark.xfail(
-    strict=True,
+    strict=on_the_reference_host(),
     reason=(
         "REFUTED. tanh_sinh.hpp and test_quad_tanh_sinh.py both claim the Lambert W "
         "step size is bit-identical across backends; over n from 2 to 1000 it is not, "
@@ -387,6 +391,10 @@ def test_the_halley_iteration_reaches_a_last_bit_limit_cycle(cpp_backend: None) 
     through_numpy = sorted(set(_halley_iterates_numpy(argument, 12)[4:]))
     through_libm = sorted(set(_halley_iterates(argument, 12)[4:]))
 
+    demand_the_reference_host(
+        "whether the numpy Halley iteration reaches a two-value limit cycle",
+        "a cycle of exactly two doubles from step 5 on, on this project's build server",
+    )
     assert len(through_numpy) == 2, (
         f"the numpy iteration was expected to alternate between two doubles at n="
         f"{WORST_WEIGHT_RATIO_DEGREE}; steps 5 to 12 took {len(through_numpy)} distinct "
@@ -474,6 +482,10 @@ def test_the_tanh_sinh_bounds_are_closer_to_failing_than_the_shipped_sweep_recor
         usable = np.asarray(tolerance) > 0.0
         observed[name] = float(np.max(deviation[usable] / np.asarray(tolerance)[usable]))
 
+    demand_the_reference_host(
+        "how closely the recorded weight bound is approached",
+        "0.90 of the bound, on this project's build server",
+    )
     assert observed["weights"] > 0.85, (
         f"the weight bound was approached to {observed['weights']:.3f} of itself at "
         f"n={WORST_WEIGHT_RATIO_DEGREE}, where 0.90 was measured. Below 0.85 either the "
@@ -507,7 +519,7 @@ def test_the_tanh_sinh_bounds_are_closer_to_failing_than_the_shipped_sweep_recor
 
 
 @pytest.mark.xfail(
-    strict=True,
+    strict=on_the_reference_host(),
     reason=(
         "REFUTED, by construction. tanh_sinh.hpp says a count that moved between "
         "backends would be a genuine parity failure rather than a rounding "

--- a/tests/parity/test_quad_tanh_sinh.py
+++ b/tests/parity/test_quad_tanh_sinh.py
@@ -137,6 +137,7 @@ from tests._parity_harness import (
     Roundings,
     assert_parity,
     bounded_parity,
+    demand_the_reference_host,
 )
 
 DTYPES: Final = (np.float64, np.float32)
@@ -411,6 +412,10 @@ def test_the_lambert_w_step_size_agrees_to_one_ulp(cpp_backend: None) -> None:
         f"counts. That is a diverged iteration rather than a library rounding "
         f"difference, and h = 2 W / n multiplies every transform coordinate"
     )
+    demand_the_reference_host(
+        "whether the two backends' Lambert W step sizes still differ anywhere",
+        "nine disagreements over n from 2 to 1000, on this project's build server",
+    )
     assert differing, (
         "the two backends now agree at every count from 2 to 1000, where nine "
         "disagreements were measured. If the platform's libm changed, the node "
@@ -497,6 +502,10 @@ def test_the_bounds_are_reached_rather_than_idle(cpp_backend: None) -> None:
         worst_node = max(worst_node, node_deviation.max_ratio_to_bound)
         worst_weight = max(worst_weight, weight_deviation.max_ratio_to_bound)
 
+    demand_the_reference_host(
+        "how closely the tanh-sinh node and weight bounds are approached",
+        "worst ratios above 0.1 and 0.05 respectively, on this project's build server",
+    )
     assert worst_node > 0.1, (
         f"the node bound is never approached more closely than {worst_node:.3g} of "
         f"itself, so it is no longer distinguishing a correct port from a wrong one"


### PR DESCRIPTION
## Context

Six tests in `tests/parity` fail intermittently on CI, on an unchanged tree. They are not
flaky in the usual sense of a race: each asserts the **opposite** of a bound, that the bound is
still doing work, and that is a fact about the host rather than about this library.

**Proven by run, not by argument.** Commit `767f502` was run twice on this project's CI with
nothing changed between the runs:

```
first run   6 failed, 309 passed, 3 xfailed
re-run      313 passed, 5 xfailed
```

Same runner image (`20260816.277.1`), same numpy (2.4.6), same numba, same compiler. Two strict
`xfail`s XPASSed in the first and not the second.

The mechanism, stated as the hypothesis it is: `glibc` selects its `exp` through IFUNC on the
processor's features, and numpy dispatches its own loops the same way, so a host of a different
generation gives a different `exp` and two implementations that differed by one ulp can agree
exactly. What is **proven** is the non-determinism; the CPU is the remaining variable after the
image, the libraries and the compiler are all held equal, but the runner logs do not report it.

What rules out the change that happened to be under review: one of the six failures compares
numpy against itself, with no C++ in it at all.

## The rule

**A bound is a property of the code; whether it is approached is a property of the host.**

- Bound assertions stay hard, everywhere, unchanged.
- Liveness guards are enforced only on the host their numbers were measured on, which
  `scripts/ci_local.sh` marks with `PANTR_REFERENCE_HOST`, and skip elsewhere with a written
  reason naming what was measured and where, so it can be re-established rather than guessed.

`demand_the_reference_host` in `tests/_parity_harness.py` is the only supported way to write
one, for the same reason `demand_cpp_backend` is the only supported way to require the
extension: a bare `skipif` here is how a suite skips its way to green.

## What changed

Four liveness assertions gated, in `test_quad_shakedown.py` and `test_quad_tanh_sinh.py`. Each
gate sits **after** the correctness assertions in its test, so those still run everywhere.

Two of the five strict `xfail`s become `strict=on_the_reference_host()`. They were chosen by
their own reason text, both of which already said an XPASS would mean this platform's libraries
had stopped straddling a threshold. The other three stay strict: one turns on the compiler
folding `pow(x, 2.0)`, which is pinned per job, and two are about what a binding accepts and
what an emptied rule returns.

`design/backend_parity.md` gains this as **Rule 7**.

## This revisits a decision, deliberately

The five `xfail`s were made strict on purpose, so that a claim silently becoming true would be
noticed. That reasoning still holds for three of them. It does not hold for the two whose
expected failure is a disagreement between two libraries, because there "the claim became true"
and "the job landed on a different CPU" are indistinguishable, and only one of them is worth a
red.

The file already knew this, which is the strongest argument that the guards were the anomaly
rather than the rule. `LAMBERT_W_OFFENDERS` is documented as "not asserted as a
platform-independent fact: which arguments numpy's `exp` and libm's `exp` disagree on is a
property of two libraries on one machine."

## Acceptance criteria

- [x] Off the reference host: `51 passed, 4 skipped, 5 xfailed`, each skip printing what was
      measured, where, and the variable that enforces it.
- [x] On the reference host: `55 passed, 5 xfailed`, identical to the behaviour before this
      change. No guard was weakened where it was calibrated.
- [x] No correctness assertion is gated. The gates sit after them.
- [x] `design/backend_parity.md` carries the rule, with the two runs as its evidence.
- [x] This PR's own CI run exercises the fix, since the guards must skip rather than fail there.

## Non-goals

- Re-deriving any bound. Every bound is unchanged.
- The three `xfail`s whose expected failure is structural.
- Making CI pin a CPU, which is not on offer.

## Checks

`scripts/ci_local.sh all`: 37 PASS, 0 FAIL, 0 SKIP, including the whole suite under each
backend, with the guards enforced. `mypy src tests scripts` clean over 257 files.
`ruff check .` and `ruff format --check .` clean, run with the pinned 0.12.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
