### PR TITLE
fix(tests): skip a float32 claim about a kernel that is not compiled

### DIFF
--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -191,6 +191,16 @@ _MISSING_BUT_REQUIRED: Final[str] = (
 """Message for the one configuration in which a missing extension must fail."""
 
 
+def the_jit_is_disabled() -> bool:
+    """Report whether Numba compilation is switched off for this process.
+
+    Returns:
+        bool: True when ``NUMBA_DISABLE_JIT`` is set to ``"1"``, which is the form
+            Numba itself reads and the form ``make coverage`` passes.
+    """
+    return os.environ.get("NUMBA_DISABLE_JIT", "0") == "1"
+
+
 def on_the_reference_host() -> bool:
     """Report whether this run is on the machine a liveness guard was calibrated on.
 
@@ -198,6 +208,45 @@ def on_the_reference_host() -> bool:
         bool: True when ``PANTR_REFERENCE_HOST`` is set to a non-empty value.
     """
     return bool(os.environ.get(_REFERENCE_HOST_ENV_VAR, ""))
+
+
+def demand_the_compiled_kernel(dtype: npt.DTypeLike) -> None:
+    """Skip a ``float32`` claim about the Python backend when its kernel is not compiled.
+
+    Under ``NUMBA_DISABLE_JIT=1`` the Numba kernels run as interpreted Python over
+    numpy, and **that is a different object from the one every bound here
+    describes**. The bounds and the bitwise-parity claims were derived for the
+    compiled kernel's arithmetic, so asserting them against the interpreted path
+    measures something this project does not ship.
+
+    The switch is deterministic, which is what separates this from
+    :func:`demand_the_reference_host`: 29 failures, three runs, identical. It is a
+    configuration difference, not a host one.
+
+    Gated on ``float32`` alone, and that is measured rather than assumed. For a
+    degree-5 tabulation at 11 points, the ``float64`` output is **bitwise identical**
+    with the JIT on and off, while the ``float32`` output differs. The interpreted
+    path is not simply computing in ``float64`` and rounding, either: its ``float32``
+    result matches neither the compiled ``float32`` one nor the ``float64`` one cast
+    down. Which intermediates promote has not been pinned, and no claim is made about
+    it here; what is established is that ``float64`` is unaffected and ``float32`` is
+    not, which is exactly what this gate needs.
+
+    Only ``make coverage`` sets the variable, so a plain ``pytest`` run is untouched.
+
+    Args:
+        dtype (npt.DTypeLike): The storage format the calling test is parametrized on.
+
+    Raises:
+        Skipped: Via :func:`pytest.skip`, for ``float32`` with the JIT disabled.
+    """
+    if not the_jit_is_disabled() or np.dtype(dtype) != np.float32:
+        return
+    pytest.skip(
+        "with NUMBA_DISABLE_JIT the Python backend is interpreted, and its float32 "
+        "arithmetic is not the compiled kernel's, which is what this claim's bound "
+        "was derived for. float64 is bitwise unaffected and still runs."
+    )
 
 
 def demand_the_reference_host(guard: str, measured: str) -> None:

--- a/tests/parity/test_basis_cardinal_bspline.py
+++ b/tests/parity/test_basis_cardinal_bspline.py
@@ -198,6 +198,7 @@ from tests._parity_harness import (
     bitwise_parity,
     bounded_parity,
     contraction_may_fuse,
+    demand_the_compiled_kernel,
     derived_accuracy,
     underflow_floor,
     unit_roundoff,
@@ -738,6 +739,7 @@ def test_parity_on_the_span(degree: int, dtype: npt.DTypeLike, cpp_backend: None
     NaN-poisoned before the call, so an element neither backend writes fails here
     too rather than comparing equal at zero.
     """
+    demand_the_compiled_kernel(dtype)
     points = _span_points(dtype)
     cpp, numba = _both_backends(degree, points)
     assert np.all(np.isfinite(cpp)), "the C++ kernel left an element unwritten"
@@ -760,6 +762,7 @@ def test_parity_at_the_span_ends(degree: int, dtype: npt.DTypeLike, cpp_backend:
     untouched, so the sweep above would not see it. Both signed zeros are included
     because the kernel's first stage subtracts the point from 1.
     """
+    demand_the_compiled_kernel(dtype)
     points = _boundary_points(dtype)
     cpp, numba = _both_backends(degree, points)
     assert_parity(
@@ -783,6 +786,7 @@ def test_parity_outside_the_span(degree: int, dtype: npt.DTypeLike, cpp_backend:
     amplification equals the value and the bound is a plain relative one, outside it
     is strictly larger.
     """
+    demand_the_compiled_kernel(dtype)
     points = _outside_points(dtype)
     cpp, numba = _both_backends(degree, points)
     assert np.all(np.isfinite(cpp)), "the C++ kernel produced a non-finite value off the span"
@@ -936,6 +940,7 @@ def test_matches_the_exact_rational_oracle(
     and its own sweep never reached one. A degree list shorter than the one the
     parity tests use is a place for exactly that to hide.
     """
+    demand_the_compiled_kernel(dtype)
     points = _oracle_points(dtype)
     exact = _exact_rows(degree, points)
     claim = _accuracy_claim(degree, points, exact)
@@ -1087,6 +1092,7 @@ def test_reflection_symmetry(degree: int, dtype: npt.DTypeLike, cpp_backend: Non
     exact because the grid is dyadic, so this compares values and not a rounding of
     the argument.
     """
+    demand_the_compiled_kernel(dtype)
     points = _span_points(dtype)
     mirrored = (1.0 - points.astype(np.float64)).astype(dtype)
     _, error = _companion_bounds(degree, points, dtype)
@@ -1121,6 +1127,7 @@ def test_public_api_agrees_across_backends_for_every_input_shape(
     by calling the Layer 3 kernel directly. This is the only test here that runs the
     path a user runs.
     """
+    demand_the_compiled_kernel(dtype)
     degree = 3
     inputs: tuple[Any, ...] = (
         np.asarray(0.375, dtype=dtype),
@@ -1160,6 +1167,7 @@ def test_out_argument_is_filled_in_place_by_both_backends(
     would write into a temporary, return normally, and leave the caller's array
     exactly as it was -- a silent wrong answer with no exception anywhere.
     """
+    demand_the_compiled_kernel(dtype)
     points = np.linspace(0.0, 1.0, 7, dtype=dtype)
     degree = 4
     results = []


### PR DESCRIPTION
Fixes #339, which is not closed automatically: GitHub resolves closing keywords only for pull
requests merged into the default branch, and this targets `proto/cpp`.

## Context

`make coverage` runs the suite with `NUMBA_DISABLE_JIT=1`. With the extension present, 29 tests
in `tests/parity/test_basis_cardinal_bspline.py` failed, every one of them a `float32` case. The
target has been unusable with a built extension for as long as both have existed, and a plain
`pytest` run stays green, so only whoever runs coverage locally meets it.

## Diagnosis

With the JIT off, the Numba kernels run as interpreted Python over numpy, and **that is a
different object from the one every bound in the file describes**. The bounds and the
bitwise-parity claims were derived for the compiled kernel's arithmetic. Asserting them against
the interpreted path measures something this project does not ship, so there is nothing to
compare and skipping is the honest reading rather than the cheap one.

## This is deliberately not Rule 7

`design/backend_parity.md`'s Rule 7, added in #345, says a bound is a property of the code while
whether it is approached is a property of the host. The two look alike, since both say the
result depends on how the code is run rather than on what it computes. One cheap test separates
them: **repeat it.**

| | Rule 7, the liveness guards | this |
|---|---|---|
| repeated | 6 failures, then 0 on an unchanged tree | 29, 29, 29 |
| varies with | the CI host, outside anyone's control | a variable set on purpose |
| remedy | enforce only where it was calibrated | the object under test is not the one the bound describes |

Reusing the reference-host gate here would have introduced a host concept where no host is
involved: `make coverage` disables the JIT on every machine, always.

## The gate is float32 only, and that is measured

For a degree-5 tabulation at 11 points, the `float64` output is **bitwise identical** with the
JIT on and off, while the `float32` output differs. So `float64` keeps running everywhere and
only the `float32` claims are gated.

**No claim is made about why `float32` differs.** It is not simply "compute in `float64`, round
at the end": the interpreted `float32` result matches neither the compiled `float32` one nor the
`float64` one cast down. Which intermediates promote was not pinned down, and the helper's
docstring says so rather than guessing.

## On skipping 39 where 29 failed

The other 10 assert the same inapplicable claim and passed only because their degree did not
expose the difference. So this is the claim not applying to them, not coverage being dropped,
and the distinction is measurable rather than rhetorical:

```
src/pantr/basis, tests/parity, JIT off
  with the gate     476 statements, 225 missed, 53%
  without the gate  476 statements, 225 missed, 53%
```

Identical. Their `float64` twins reach the same lines.

## Acceptance criteria

- [x] `NUMBA_DISABLE_JIT=1 pytest tests/parity/` reports no failures with the extension present:
      270 passed, 43 skipped, 5 xfailed.
- [x] `make coverage` completes with the extension present: **6256 passed, 48 skipped, 0
      failed**, 97% total against a threshold of 85.
- [x] Every skip states why, naming the compiled kernel and that `float64` still runs.
- [x] The tests still catch a real break: with the JIT enabled nothing is gated, and the file
      behaves exactly as before at 309 passed, 4 skipped, 5 xfailed.
- [x] Coverage does not fall silently. It does not fall at all; the figures are above.

## Non-goals

- Any kernel, C++ or Numba.
- Loosening a bound that is correct for the compiled path. None is touched.
- Pinning why interpreted `float32` rounds differently. Worth knowing, not needed here.

## Checks

`scripts/ci_local.sh all`: all checks passed, including the whole suite under each backend.
`mypy src tests scripts` clean over 257 files. `ruff check .` and `ruff format --check .` clean
with the pinned 0.12.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
