### PR TITLE
feat(change_basis): port the eight builders to C++, and take Eigen

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -174,10 +174,17 @@ jobs:
       # that is a cost rather than a non-issue. This comment used to read "Eigen
       # is never fetched", which was true while PANTR_BUILD_TESTS gated it out of
       # the Python build path; the shipped extension now includes an Eigen header,
-      # so `pip install -e .` clones it on every run. Measured: this job went from
-      # 5m38s to 6m25s across that change. A FetchContent cache keyed on the
-      # pinned SHAs would return those 47 seconds, and is deliberately left as a
-      # separate decision rather than folded into the port that exposed it.
+      # so `pip install -e .` clones it on every run.
+      #
+      # How much that costs is NOT established, and the attempt to establish it is
+      # worth leaving here. Job durations: 5m38s on the last run before the
+      # change, then 6m25s and 7m40s on two runs after it. The 75s between those
+      # two, which ran the same code, is larger than the 47s the first pair would
+      # have attributed to Eigen. So a single run against a single run measures
+      # runner variance, not the clone. The case for a FetchContent cache keyed on
+      # the pinned SHAs rests on the mechanism -- a clone that was not happening
+      # now happens every run -- rather than on a number, and taking it is a
+      # separate decision from the port that exposed it.
       - name: Install pantr with the extension
         env:
           CC: gcc-14

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -170,9 +170,14 @@ jobs:
       # needs pantr's runtime dependencies and a test runner, and nothing else --
       # it builds no docs, renders nothing and launches no MPI.
       #
-      # No dependency cache is needed here either: PANTR_BUILD_TESTS is off in
-      # the Python build path, so Eigen is never fetched, and Kokkos mdspan is a
-      # small clone.
+      # There is no dependency cache here, and since the change-of-basis port
+      # that is a cost rather than a non-issue. This comment used to read "Eigen
+      # is never fetched", which was true while PANTR_BUILD_TESTS gated it out of
+      # the Python build path; the shipped extension now includes an Eigen header,
+      # so `pip install -e .` clones it on every run. Measured: this job went from
+      # 5m38s to 6m25s across that change. A FetchContent cache keyed on the
+      # pinned SHAs would return those 47 seconds, and is deliberately left as a
+      # separate decision rather than folded into the port that exposed it.
       - name: Install pantr with the extension
         env:
           CC: gcc-14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(pantr::core ALIAS pantr_core)
 target_include_directories(pantr_core INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cpp/include>")
 
-target_link_libraries(pantr_core INTERFACE pantr::cxx_flags)
+target_link_libraries(pantr_core INTERFACE pantr::cxx_flags Eigen3::Eigen)
 
 if(PANTR_HAS_STD_MDSPAN)
   target_compile_definitions(pantr_core INTERFACE PANTR_HAS_STD_MDSPAN=1)

--- a/cmake/PantrDependencies.cmake
+++ b/cmake/PantrDependencies.cmake
@@ -86,28 +86,38 @@ endif()
 # Eigen -- dense and sparse linear algebra.
 # --------------------------------------------------------------------------
 #
-# Not used by the one kernel this prototype ships. It is fetched and compiled
-# against anyway, by cpp/tests/test_dependency_smoke.cpp, because the question
-# this prototype exists to answer is whether the dependency survives pantr's own
-# warning flags and this CMake version -- and a header that is never included
-# answers nothing. design/large_data_fitting.md and
-# design/adaptive_thb_approximation.md both settle on Eigen::SparseMatrix with
-# SimplicialLDLT for the fitting solves, which is what it is here for.
+# A dependency of the shipped extension, fetched unconditionally.
+#
+# It was test-only until the change-of-basis port, on the reasoning that "a
+# dependency a wheel build does not need is a dependency a wheel build cannot
+# fail on". That reasoning held only while nothing shipped needed a solve. Two
+# stage-1 modules do: change_basis inverts four matrices per builder pair
+# (Eigen::PartialPivLU, standing in for numpy's LAPACK gesv), and bezier's
+# interpolation takes an SVD pseudo-inverse of a Bernstein Vandermonde with rank
+# truncation, which is not a thing to hand-roll. Outside stage 1, bspline's
+# lstsq/pinv/eigh sites and the SimplicialLDLT solves that
+# design/large_data_fitting.md and design/adaptive_thb_approximation.md settle
+# on are all waiting behind the same header.
 #
 # Eigen's own CMakeLists is run rather than bypassed, deliberately: bypassing it
 # (SOURCE_SUBDIR pointing at a directory with no CMakeLists) would hide exactly
 # the CMake 4 incompatibility this prototype is meant to measure.
-# Fetched only when the tests are built. Nothing in the installed extension
-# includes an Eigen header, so a `pip install` has no business cloning it -- and
-# a dependency a wheel build does not need is a dependency a wheel build cannot
-# fail on.
-if(PANTR_BUILD_TESTS)
+#
+# GIT_SHALLOW is TRUE here and FALSE for mdspan above, which is a measurement
+# rather than a preference. Eigen is now on the pip path, so every cold editable
+# install pays its clone: measured on the development server, a cold
+# `pip install -e . --no-build-isolation` costs 7.56 s without Eigen, 21.48 s
+# with it cloned deep, and 12.19 s cloned shallow, with the build tree at
+# 6.4 MB / 145 MB / 50 MB respectively. The incremental rebuild is unaffected
+# (2.96 s). Shallow against a pinned commit needs the server to serve an
+# arbitrary SHA; GitLab does, and the checkout was verified to be exactly the
+# SHA below rather than a silent fallback.
 
 FetchContent_Declare(
     eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
     GIT_TAG        bc3b39870ecb690a623a3f49149a358b95c5781d  # tag 5.0.1
-    GIT_SHALLOW    FALSE
+    GIT_SHALLOW    TRUE
     SYSTEM
     EXCLUDE_FROM_ALL)
 
@@ -119,5 +129,3 @@ set(EIGEN_BUILD_LAPACK OFF CACHE BOOL "" FORCE)
 set(EIGEN_BUILD_CMAKE_PACKAGE OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(eigen)
-
-endif()

--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -118,10 +118,10 @@ if(PANTR_NANOBIND_SPLIT)
   # -Werror ends the build.
   nanobind_add_module(_pantr_cpp NOMINSIZE NOSTRIP NB_SUPPRESS_WARNINGS
                       BACKEND_MODULE nanobind_backend
-                      pantr_cpp.cpp basis.cpp quad.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
-                      pantr_cpp.cpp basis.cpp quad.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/basis.cpp
+++ b/cpp/bindings/basis.cpp
@@ -9,7 +9,9 @@
 #include <span>
 #include <string>
 
+#include "pantr/basis/bernstein.hpp"
 #include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/basis/legendre.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "register.hpp"
 
@@ -55,7 +57,12 @@ using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
 ///
 /// The cost is three integer comparisons in front of an
 /// `O(points.size() * degree^2)` kernel.
-template <class T>
+///
+/// The kernel is a template parameter rather than a runtime argument so that the
+/// three tabulations share this body without sharing a dispatch: each `m.def`
+/// below instantiates its own copy, and adding a fourth basis cannot accidentally
+/// route to the wrong one.
+template <class T, void (*Kernel)(int, std::span<const T>, pantr::span2d<T>)>
 void tabulate(unsigned degree, const_points<T> points, out_matrix<T> out) {
     constexpr unsigned max_degree = static_cast<unsigned>(std::numeric_limits<int>::max());
     if (degree > max_degree) {
@@ -82,7 +89,7 @@ void tabulate(unsigned degree, const_points<T> points, out_matrix<T> out) {
     // The kernel touches no Python object, so the GIL buys nothing while it
     // runs. Releasing it is what lets a caller thread at the Python level.
     const nb::gil_scoped_release release;
-    pantr::tabulate_cardinal_bspline_1d<T>(static_cast<int>(degree), pts, view);
+    Kernel(static_cast<int>(degree), pts, view);
 }
 
 }  // namespace
@@ -113,8 +120,24 @@ void register_basis(nb::module_& m) {
     // binding, but the convention has to be uniform before `quad.cpp`'s
     // two-output kernels are bound, where a positional call silently accepts
     // `out_nodes` and `out_weights` swapped.
-    m.def("tabulate_cardinal_bspline_1d", &tabulate<double>, nb::arg("degree"),
-          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
-    m.def("tabulate_cardinal_bspline_1d", &tabulate<float>, nb::arg("degree"),
-          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+    //
+    // The Bernstein and Legendre tabulations were added for the change-of-basis
+    // builders, which evaluate one or both of them before every Gram solve. They
+    // are bound here rather than in change_basis.cpp because they are
+    // `pantr.basis` kernels and the split follows the Python package, not the
+    // consumer.
+    const auto bind = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("degree"), nb::arg("points").noconvert(), nb::kw_only(),
+              nb::arg("out").noconvert());
+        m.def(name, f32, nb::arg("degree"), nb::arg("points").noconvert(), nb::kw_only(),
+              nb::arg("out").noconvert());
+    };
+
+    bind("tabulate_cardinal_bspline_1d",
+         &tabulate<double, &pantr::tabulate_cardinal_bspline_1d<double>>,
+         &tabulate<float, &pantr::tabulate_cardinal_bspline_1d<float>>);
+    bind("tabulate_bernstein_1d", &tabulate<double, &pantr::tabulate_bernstein_1d<double>>,
+         &tabulate<float, &pantr::tabulate_bernstein_1d<float>>);
+    bind("tabulate_legendre_1d", &tabulate<double, &pantr::tabulate_legendre_1d<double>>,
+         &tabulate<float, &pantr::tabulate_legendre_1d<float>>);
 }

--- a/cpp/bindings/change_basis.cpp
+++ b/cpp/bindings/change_basis.cpp
@@ -142,21 +142,29 @@ void register_change_basis(nb::module_& m) {
     // caller's buffer untouched, with no error anywhere. On the inputs it refuses
     // a hidden copy inside a timed region.
     //
-    // `nb::kw_only()` before `out` matters more here than it did there. Five of
-    // these take two same-dtype, same-length arrays in a row, and a positional
-    // call that swapped `nodes` and `weights` would type-check, run, and return a
-    // plausible matrix.
+    // `nb::kw_only()` sits before `nodes`, not before `out`, and the difference is
+    // the whole point. Five of these take two same-dtype, same-length arrays in a
+    // row, so a positional call that swapped `nodes` and `weights` would
+    // type-check, run, and return a plausible matrix -- and `check_node_count`
+    // cannot catch it, because the two are the same length by construction.
+    // Making only `out` keyword-only does nothing to that risk.
+    //
+    // An earlier version of this file made exactly that mistake, in a comment that
+    // named the risk correctly one line above the `m.def` calls that left it open.
+    // `cpp/bindings/quad.cpp` had it right already: it puts `nb::kw_only()` before
+    // BOTH `out_nodes` and `out_weights` for the identical two-array shape. This
+    // now matches.
     const auto bind_nodes = [&m](const char* name, auto f64, auto f32) {
-        m.def(name, f64, nb::arg("degree"), nb::arg("nodes").noconvert(), nb::kw_only(),
+        m.def(name, f64, nb::arg("degree"), nb::kw_only(), nb::arg("nodes").noconvert(),
               nb::arg("out").noconvert());
-        m.def(name, f32, nb::arg("degree"), nb::arg("nodes").noconvert(), nb::kw_only(),
+        m.def(name, f32, nb::arg("degree"), nb::kw_only(), nb::arg("nodes").noconvert(),
               nb::arg("out").noconvert());
     };
     const auto bind_rule = [&m](const char* name, auto f64, auto f32) {
-        m.def(name, f64, nb::arg("degree"), nb::arg("nodes").noconvert(),
-              nb::arg("weights").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
-        m.def(name, f32, nb::arg("degree"), nb::arg("nodes").noconvert(),
-              nb::arg("weights").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+        m.def(name, f64, nb::arg("degree"), nb::kw_only(), nb::arg("nodes").noconvert(),
+              nb::arg("weights").noconvert(), nb::arg("out").noconvert());
+        m.def(name, f32, nb::arg("degree"), nb::kw_only(), nb::arg("nodes").noconvert(),
+              nb::arg("weights").noconvert(), nb::arg("out").noconvert());
     };
 
     bind_nodes("lagrange_to_bernstein_1d",

--- a/cpp/bindings/change_basis.cpp
+++ b/cpp/bindings/change_basis.cpp
@@ -1,0 +1,189 @@
+/// \file
+/// nanobind bindings for the `pantr.change_basis` kernels.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+
+#include "pantr/change_basis/change_basis.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+/// See the equivalent aliases in basis.cpp: nanobind checks dtype, rank,
+/// C-contiguity and device before the body runs, so these are the input
+/// validation for everything a type can express. What they cannot express are
+/// the relations between arguments, checked below.
+template <class T>
+using const_vector = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_matrix = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// The largest degree the kernels can express, as an `unsigned`.
+constexpr unsigned max_degree = static_cast<unsigned>(std::numeric_limits<int>::max());
+
+/// Reject a degree that cannot round-trip through the kernels' `int`.
+///
+/// `degree` is `unsigned` in every binding here for the reason basis.cpp gives:
+/// nanobind's caster then refuses a negative value before any pantr code runs,
+/// and the one range `unsigned` admits that `int` does not is refused here rather
+/// than wrapped around by the cast.
+///
+/// \param degree The requested degree.
+void check_degree(unsigned degree) {
+    if (degree > max_degree) {
+        throw nb::value_error(("degree " + std::to_string(degree) +
+                               " exceeds the largest degree the kernel can express (" +
+                               std::to_string(max_degree) + ")")
+                                  .c_str());
+    }
+}
+
+/// Reject an `out` that is not the square matrix the degree calls for.
+///
+/// \param out The caller's output array.
+/// \param degree The requested degree.
+template <class T>
+void check_square_out(const out_matrix<T>& out, unsigned degree) {
+    const std::size_t n = static_cast<std::size_t>(degree) + 1;
+    if (out.shape(0) != n || out.shape(1) != n) {
+        throw nb::value_error(("out has shape (" + std::to_string(out.shape(0)) + ", " +
+                               std::to_string(out.shape(1)) + "), but degree " +
+                               std::to_string(degree) + " needs (" + std::to_string(n) +
+                               ", " + std::to_string(n) + ")")
+                                  .c_str());
+    }
+}
+
+/// Reject a node array whose length is not `degree + 1`.
+///
+/// Every builder bound here integrates or interpolates with exactly `degree + 1`
+/// nodes, so a mismatch is a caller error rather than a supported shape. Checking
+/// it is not optional: the Gram products would otherwise contract over a length
+/// the output was not sized for.
+///
+/// \param nodes The node array.
+/// \param degree The requested degree.
+/// \param name The parameter's name, for the message.
+template <class T>
+void check_node_count(const const_vector<T>& nodes, unsigned degree, const char* name) {
+    const std::size_t n = static_cast<std::size_t>(degree) + 1;
+    if (nodes.size() != n) {
+        throw nb::value_error((std::string(name) + " has length " +
+                               std::to_string(nodes.size()) + ", but degree " +
+                               std::to_string(degree) + " needs " + std::to_string(n))
+                                  .c_str());
+    }
+}
+
+/// Adapter for the two builders that take Lagrange nodes and no weights.
+template <class T, void (*Kernel)(int, std::span<const T>, pantr::span2d<T>)>
+void from_nodes(unsigned degree, const_vector<T> nodes, out_matrix<T> out) {
+    check_degree(degree);
+    check_node_count(nodes, degree, "nodes");
+    check_square_out(out, degree);
+
+    const std::size_t n = static_cast<std::size_t>(degree) + 1;
+    const std::span<const T> node_span(nodes.data(), nodes.size());
+    const pantr::span2d<T> view(out.data(), n, n);
+
+    const nb::gil_scoped_release release;
+    Kernel(static_cast<int>(degree), node_span, view);
+}
+
+/// Adapter for the five builders that take a quadrature rule.
+///
+/// `nodes` and `weights` are separate arrays rather than one `(n, 2)` block
+/// because that is the shape `pantr.quad.get_gauss_legendre_1d` returns, and
+/// re-packing them in Layer 2 would put a copy in front of every call.
+template <class T, void (*Kernel)(int, std::span<const T>, std::span<const T>, pantr::span2d<T>)>
+void from_rule(unsigned degree, const_vector<T> nodes, const_vector<T> weights,
+               out_matrix<T> out) {
+    check_degree(degree);
+    check_node_count(nodes, degree, "nodes");
+    check_node_count(weights, degree, "weights");
+    check_square_out(out, degree);
+
+    const std::size_t n = static_cast<std::size_t>(degree) + 1;
+    const std::span<const T> node_span(nodes.data(), nodes.size());
+    const std::span<const T> weight_span(weights.data(), weights.size());
+    const pantr::span2d<T> view(out.data(), n, n);
+
+    const nb::gil_scoped_release release;
+    Kernel(static_cast<int>(degree), node_span, weight_span, view);
+}
+
+/// Adapter for the one builder that needs nothing but a degree.
+template <class T>
+void monomial(unsigned degree, out_matrix<T> out) {
+    check_degree(degree);
+    check_square_out(out, degree);
+
+    const std::size_t n = static_cast<std::size_t>(degree) + 1;
+    const pantr::span2d<T> view(out.data(), n, n);
+
+    const nb::gil_scoped_release release;
+    pantr::monomial_to_bernstein_1d<T>(static_cast<int>(degree), view);
+}
+
+}  // namespace
+
+void register_change_basis(nb::module_& m) {
+    // `.noconvert()` everywhere, for the reason basis.cpp sets out at length: on
+    // an output array a silent conversion fills a temporary and returns the
+    // caller's buffer untouched, with no error anywhere. On the inputs it refuses
+    // a hidden copy inside a timed region.
+    //
+    // `nb::kw_only()` before `out` matters more here than it did there. Five of
+    // these take two same-dtype, same-length arrays in a row, and a positional
+    // call that swapped `nodes` and `weights` would type-check, run, and return a
+    // plausible matrix.
+    const auto bind_nodes = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("degree"), nb::arg("nodes").noconvert(), nb::kw_only(),
+              nb::arg("out").noconvert());
+        m.def(name, f32, nb::arg("degree"), nb::arg("nodes").noconvert(), nb::kw_only(),
+              nb::arg("out").noconvert());
+    };
+    const auto bind_rule = [&m](const char* name, auto f64, auto f32) {
+        m.def(name, f64, nb::arg("degree"), nb::arg("nodes").noconvert(),
+              nb::arg("weights").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+        m.def(name, f32, nb::arg("degree"), nb::arg("nodes").noconvert(),
+              nb::arg("weights").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+    };
+
+    bind_nodes("lagrange_to_bernstein_1d",
+               &from_nodes<double, &pantr::lagrange_to_bernstein_1d<double>>,
+               &from_nodes<float, &pantr::lagrange_to_bernstein_1d<float>>);
+    bind_nodes("bernstein_to_lagrange_1d",
+               &from_nodes<double, &pantr::bernstein_to_lagrange_1d<double>>,
+               &from_nodes<float, &pantr::bernstein_to_lagrange_1d<float>>);
+
+    bind_rule("bernstein_to_cardinal_1d",
+              &from_rule<double, &pantr::bernstein_to_cardinal_1d<double>>,
+              &from_rule<float, &pantr::bernstein_to_cardinal_1d<float>>);
+    bind_rule("cardinal_to_bernstein_1d",
+              &from_rule<double, &pantr::cardinal_to_bernstein_1d<double>>,
+              &from_rule<float, &pantr::cardinal_to_bernstein_1d<float>>);
+    bind_rule("legendre_to_cardinal_1d",
+              &from_rule<double, &pantr::legendre_to_cardinal_1d<double>>,
+              &from_rule<float, &pantr::legendre_to_cardinal_1d<float>>);
+    bind_rule("cardinal_to_legendre_1d",
+              &from_rule<double, &pantr::cardinal_to_legendre_1d<double>>,
+              &from_rule<float, &pantr::cardinal_to_legendre_1d<float>>);
+    bind_rule("cardinal_dual_legendre_coeffs_1d",
+              &from_rule<double, &pantr::cardinal_dual_legendre_coeffs_1d<double>>,
+              &from_rule<float, &pantr::cardinal_dual_legendre_coeffs_1d<float>>);
+
+    m.def("monomial_to_bernstein_1d", &monomial<double>, nb::arg("degree"), nb::kw_only(),
+          nb::arg("out").noconvert());
+    m.def("monomial_to_bernstein_1d", &monomial<float>, nb::arg("degree"), nb::kw_only(),
+          nb::arg("out").noconvert());
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -62,6 +62,7 @@ NB_MODULE(_pantr_cpp, m) {
 
     register_basis(m);
     register_quad(m);
+    register_change_basis(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -15,3 +15,6 @@ void register_basis(nanobind::module_& m);
 
 /// Register the `pantr.quad` kernel bindings on `m`.
 void register_quad(nanobind::module_& m);
+
+/// Register the `pantr.change_basis` kernel bindings on `m`.
+void register_change_basis(nanobind::module_& m);

--- a/cpp/include/pantr/basis/bernstein.hpp
+++ b/cpp/include/pantr/basis/bernstein.hpp
@@ -1,0 +1,191 @@
+#pragma once
+
+/// \file
+/// Ratio-recurrence tabulation of the Bernstein basis on `[0, 1]`.
+///
+/// Port of `_bernstein_point`, `_bernstein_point_no_mirror` and
+/// `_tabulate_Bernstein_basis_1D_core` in `src/pantr/basis/_basis_core.py`,
+/// which stay as the parity oracle. The recurrence, the midpoint branch and the
+/// per-batch dispatch between the two point kernels are unchanged.
+///
+/// ## Two point kernels, dispatched once per batch
+///
+/// `B_0 = (1-u)^n` then `B_i = B_{i-1} * ((n-i+1)/i) * (u/(1-u))` is the whole
+/// method. Its seed underflows once `u` is close enough to 1 at high degree, and
+/// because every later term is a positive multiple of the previous one the whole
+/// row then stays zero -- including `B_n`, whose true value is near 1. So the
+/// general kernel mirrors: for `u > 1/2` it runs the same ascending recurrence on
+/// `1-u`, which by `B_i,n(u) = B_{n-i},n(1-u)` fills the row backwards, and
+/// reverses it. That bounds the seed below by `2^-n`.
+///
+/// The mirror costs a branch that most callers can prove they never need, so the
+/// oracle keeps an unmirrored twin and picks between them **once per call**. This
+/// port keeps that structure, because dispatching per point instead would be a
+/// different kernel with the same answer and a different cost profile, and the
+/// benchmark would then not be comparing the same thing.
+///
+/// ## The safe degree is derived from the format, not tabulated
+///
+/// The oracle hard-codes 20 for float64 and 6 for float32, each with its
+/// derivation in the docstring. Here the same two numbers come out of
+/// `std::numeric_limits`, so a hypothetical third format cannot silently inherit
+/// a limit that was computed for another one.
+///
+/// The smallest positive `1 - u` for a representable `u < 1` is `2^-digits`
+/// (`2^-53`, `2^-24`), and the smallest subnormal is `2^(min_exponent-digits)`
+/// (`2^-1074`, `2^-149`). The seed `(1-u)^n` reaches exact zero once
+/// `digits * n > digits - min_exponent`, so the largest safe degree is the
+/// integer quotient of the two: `1074/53 = 20` and `149/24 = 6`, matching the
+/// oracle exactly.
+///
+/// ## Where the two backends can disagree, and where they cannot
+///
+/// **No `a * b + c` anywhere.** The inner step is `(prev * const) * ratio`, three
+/// multiplications and no addition, so unlike the cardinal B-spline kernel there
+/// is no site for `-ffp-contract` to fuse. The ISA ladder of design/simd.md
+/// cannot move a single value here.
+///
+/// **The recurrence rounds through `out`, and that is deliberate.** The oracle
+/// reads `out_row[i - 1]` back out of a float32 array before forming the next
+/// term, so at float32 every step rounds to float32 and the running value is
+/// never carried at full width. Keeping `prev` in an `Acc` register here would be
+/// the natural C++ and would disagree with the oracle by a growing multiple of
+/// one float32 ulp along the row. The reads below are therefore written through
+/// `out` on purpose; this is the one place where a faithful port is the less
+/// obvious code.
+///
+/// **`pow` is the open question.** The seed is the one transcendental call, and
+/// numba's `np.power` and the platform libm's `pow` are two implementations of
+/// the same function with no shared guarantee. Nothing here claims they agree.
+/// tests/parity/test_basis_bernstein.py measures it and states what it found.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+/// Largest degree at which the unmirrored Bernstein recurrence cannot underflow.
+///
+/// See the file comment for the derivation. Returns the value for `T`'s
+/// underlying floating-point format: 20 for `double`, 6 for `float`.
+///
+/// \tparam T Scalar type the kernel is instantiated on.
+/// \return The largest safe degree, as an `int`.
+template <Real T>
+[[nodiscard]] constexpr int bernstein_max_safe_degree_no_mirror() noexcept {
+    using L = std::numeric_limits<value_type_t<T>>;
+    static_assert(L::is_specialized, "Bernstein needs the format's exponent range");
+    return (L::digits - L::min_exponent) / L::digits;
+}
+
+/// Tabulate the Bernstein basis of `degree` at every point of `points`.
+///
+/// Evaluates the `degree + 1` polynomials `B_i,n` on `[0, 1]` by the O(n) ratio
+/// recurrence, mirroring about `u = 1/2` when the degree is high enough for the
+/// unmirrored seed to underflow.
+///
+/// \param degree Degree of the basis. Must be non-negative.
+/// \param points Evaluation points. Values outside `[0, 1]` are evaluated by the
+///        same recurrence rather than clamped, matching the Python kernel.
+/// \param out Output view of shape `(points.size(), degree + 1)`, written in
+///        full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel in the
+///       layering of CLAUDE.md. Two preconditions are load-bearing for memory
+///       safety rather than for the answer: `degree >= 0`, since it is widened to
+///       `std::size_t` and a negative value becomes a loop bound of `SIZE_MAX`;
+///       and `out` having exactly `points.size()` rows and `degree + 1` columns,
+///       since nothing here bounds-checks a write. Non-finite points are not a
+///       precondition -- they propagate into non-finite outputs, which is an
+///       answer rather than undefined behaviour.
+///       For general use call `pantr.basis.tabulate_bernstein_1d`.
+template <Real T>
+void tabulate_bernstein_1d(int degree, std::span<const T> points, span2d<T> out) {
+    using Acc = accumulator_t<T>;
+    using std::pow;
+
+    const std::size_t num_pts = points.size();
+
+    if (degree == 0) {
+        for (std::size_t j = 0; j < num_pts; ++j) {
+            at(out, j, 0) = T(1);
+        }
+        return;
+    }
+
+    const auto n = static_cast<std::size_t>(degree);
+    const Acc n_acc = Acc(static_cast<double>(degree));
+    const bool mirror = degree > bernstein_max_safe_degree_no_mirror<T>();
+
+    for (std::size_t j = 0; j < num_pts; ++j) {
+        const Acc u = static_cast<Acc>(points[j]);
+
+        if (!mirror) {
+            // The unmirrored twin. `u == 1` is special-cased rather than
+            // mirrored, exactly as the oracle does: the ratio would be a
+            // division by zero otherwise.
+            if (u == Acc(1)) {
+                for (std::size_t i = 0; i <= n; ++i) {
+                    at(out, j, i) = T(0);
+                }
+                at(out, j, n) = T(1);
+                continue;
+            }
+            const Acc one_minus_u = Acc(1) - u;
+            at(out, j, 0) = static_cast<T>(pow(one_minus_u, n_acc));
+            const Acc ratio = u / one_minus_u;
+            for (std::size_t i = 1; i <= n; ++i) {
+                const Acc i_acc = Acc(static_cast<double>(i));
+                const Acc const_factor = (n_acc - i_acc + Acc(1)) / i_acc;
+                // Read back through `out`, not from a register: see the file
+                // comment.
+                at(out, j, i) = static_cast<T>(static_cast<Acc>(at(out, j, i - 1)) *
+                                               const_factor * ratio);
+            }
+            continue;
+        }
+
+        // The mirrored kernel. Above the midpoint the recurrence is run on
+        // `1 - u`, which fills the row in reverse, and the row is then reversed
+        // back. `u == 1` needs no special case here: the seed is `1^n == 1` and
+        // every step multiplies by `(1-u)/u == 0`, so the row comes out as
+        // `[1, 0, ..., 0]` and reads back correctly reversed.
+        //
+        // The two branches are spelled out rather than folded into a common
+        // `base`/`ratio` pair. Folding them looks like the same arithmetic and is
+        // not: below the midpoint the oracle forms `u / (1 - u)`, and recovering
+        // `u` as `1 - (1 - u)` loses it outright for small `u` -- at `u = 1e-20`
+        // that round trip returns exactly zero.
+        const bool above_midpoint = u > Acc(0.5);
+        const Acc one_minus_u = Acc(1) - u;
+        const Acc base = above_midpoint ? u : one_minus_u;
+        const Acc ratio = above_midpoint ? one_minus_u / u : u / one_minus_u;
+
+        at(out, j, 0) = static_cast<T>(pow(base, n_acc));
+        for (std::size_t i = 1; i <= n; ++i) {
+            const Acc i_acc = Acc(static_cast<double>(i));
+            const Acc const_factor = (n_acc - i_acc + Acc(1)) / i_acc;
+            at(out, j, i) =
+                static_cast<T>(static_cast<Acc>(at(out, j, i - 1)) * const_factor * ratio);
+        }
+
+        if (above_midpoint) {
+            std::size_t lo = 0;
+            std::size_t hi = n;
+            while (lo < hi) {
+                const T tmp = at(out, j, lo);
+                at(out, j, lo) = at(out, j, hi);
+                at(out, j, hi) = tmp;
+                ++lo;
+                --hi;
+            }
+        }
+    }
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/basis/bernstein.hpp
+++ b/cpp/include/pantr/basis/bernstein.hpp
@@ -57,7 +57,9 @@
 /// **`pow` is the open question.** The seed is the one transcendental call, and
 /// numba's `np.power` and the platform libm's `pow` are two implementations of
 /// the same function with no shared guarantee. Nothing here claims they agree.
-/// tests/parity/test_basis_bernstein.py measures it and states what it found.
+/// tests/parity/test_basis_tabulations.py measures it and states what it found:
+/// bitwise on every argument tested, which makes this claim observed rather than
+/// derived, unlike the Legendre kernel's.
 
 #include <cmath>
 #include <cstddef>

--- a/cpp/include/pantr/basis/legendre.hpp
+++ b/cpp/include/pantr/basis/legendre.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+/// \file
+/// Three-term recurrence for the orthonormal shifted Legendre basis on `[0, 1]`.
+///
+/// Port of `_tabulate_Legendre_basis_1D_core` in
+/// `src/pantr/basis/_basis_core.py`, which stays as the parity oracle. The
+/// recurrence and the precomputation of its coefficients are unchanged.
+///
+/// ## The recurrence
+///
+/// With `y = 2x - 1` mapping `[0, 1]` onto `[-1, 1]`,
+///
+///     p_0 = 1
+///     p_1 = sqrt(3) * y
+///     p_i = a_i * y * p_{i-1} - b_i * p_{i-2}
+///
+/// where `a_i = sqrt(2i-1) sqrt(2i+1) / i` and
+/// `b_i = ((i-1)/i) sqrt((2i+1)/(2i-3))`. The `a_i` and `b_i` depend only on the
+/// degree, so they are formed once and shared across every point.
+///
+/// The two square roots in `a_i` are kept apart rather than combined into
+/// `sqrt((2i-1)(2i+1))`. That is not an oversight: the oracle writes them apart,
+/// the two forms round differently, and a port that tidies the algebra is a port
+/// that stops being comparable.
+///
+/// ## Coefficient width is a property of the oracle, not of the output
+///
+/// The oracle allocates its coefficient arrays with `np.empty(n + 1)`, whose
+/// dtype is float64 whatever the evaluation points are, so at float32 the
+/// coefficients are still computed and stored at double width and only the
+/// per-point values round. `accumulator_t<float>` is `double`, so forming them in
+/// `Acc` here reproduces that rather than merely resembling it.
+///
+/// ## Where the two backends can disagree
+///
+/// **One fusible site, and unlike the cardinal B-spline kernel it is a
+/// subtraction.** `a_i * y * p_{i-1} - b_i * p_{i-2}` is `X - Y` with `Y` a
+/// product, which a compiler may contract to a negated fused multiply-add. As
+/// shipped there is no `-march`, so the baseline x86-64 target has no FMA
+/// instruction and `-ffp-contract=on` has nothing to fuse; the day
+/// design/simd.md's ISA ladder turns on, this line is where the two backends
+/// start differing by one rounding per degree. numba emits it unfused.
+///
+/// **The recurrence rounds through `out`.** `p_{i-1}` and `p_{i-2}` are read back
+/// out of the output array, so at float32 each step rounds to float32 rather than
+/// carrying the running value at double width. Holding the last two values in
+/// registers would be the natural C++ and would disagree with the oracle by a
+/// growing multiple of one float32 ulp. See the same note in bernstein.hpp.
+///
+/// **Unlike Bernstein there is no `pow`.** `sqrt` is the only libm call, and it
+/// is correctly rounded in IEEE 754, so it cannot be a source of disagreement.
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+/// Tabulate the orthonormal shifted Legendre basis of `degree` at every point.
+///
+/// Evaluates the `degree + 1` polynomials orthonormal on `[0, 1]` under the
+/// unweighted inner product, by the three-term recurrence above.
+///
+/// \param degree Degree of the basis. Must be non-negative.
+/// \param points Evaluation points. Values outside `[0, 1]` are evaluated by the
+///        same recurrence rather than clamped, matching the Python kernel.
+/// \param out Output view of shape `(points.size(), degree + 1)`, written in
+///        full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel in the
+///       layering of CLAUDE.md. `degree >= 0` and an `out` of exactly
+///       `(points.size(), degree + 1)` are load-bearing for memory safety, not
+///       merely for the answer: the degree is widened to `std::size_t`, and
+///       nothing here bounds-checks a write. Non-finite points propagate into
+///       non-finite outputs rather than being rejected.
+///       For general use call `pantr.basis.tabulate_legendre_1d`.
+template <Real T>
+void tabulate_legendre_1d(int degree, std::span<const T> points, span2d<T> out) {
+    using Acc = accumulator_t<T>;
+    using std::sqrt;
+
+    const std::size_t num_pts = points.size();
+
+    if (degree == 0) {
+        for (std::size_t j = 0; j < num_pts; ++j) {
+            at(out, j, 0) = T(1);
+        }
+        return;
+    }
+
+    const auto n = static_cast<std::size_t>(degree);
+
+    // O(n) work shared by every point. Indices 0 and 1 are unused, and are
+    // allocated anyway so that `a[i]` reads as the `a_i` of the recurrence.
+    std::vector<Acc> a(n + 1, Acc(0));
+    std::vector<Acc> b(n + 1, Acc(0));
+    for (std::size_t i = 2; i <= n; ++i) {
+        const Acc i_acc = Acc(static_cast<double>(i));
+        const Acc sqrt_2i_minus_1 = sqrt(Acc(2) * i_acc - Acc(1));
+        const Acc sqrt_2i_plus_1 = sqrt(Acc(2) * i_acc + Acc(1));
+        const Acc sqrt_2i_minus_3 = sqrt(Acc(2) * i_acc - Acc(3));
+        a[i] = (sqrt_2i_minus_1 * sqrt_2i_plus_1) / i_acc;
+        b[i] = ((i_acc - Acc(1)) / i_acc) * (sqrt_2i_plus_1 / sqrt_2i_minus_3);
+    }
+
+    const Acc sqrt3 = sqrt(Acc(3));
+
+    for (std::size_t j = 0; j < num_pts; ++j) {
+        const Acc two_x_minus_1 = Acc(2) * static_cast<Acc>(points[j]) - Acc(1);
+
+        at(out, j, 0) = T(1);
+        at(out, j, 1) = static_cast<T>(sqrt3 * two_x_minus_1);
+
+        for (std::size_t i = 2; i <= n; ++i) {
+            // Read back through `out`, not from two carried registers: see the
+            // file comment.
+            const Acc p1 = static_cast<Acc>(at(out, j, i - 1));
+            const Acc p2 = static_cast<Acc>(at(out, j, i - 2));
+            at(out, j, i) = static_cast<T>(a[i] * two_x_minus_1 * p1 - b[i] * p2);
+        }
+    }
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/basis/legendre.hpp
+++ b/cpp/include/pantr/basis/legendre.hpp
@@ -50,6 +50,8 @@
 ///
 /// **Unlike Bernstein there is no `pow`.** `sqrt` is the only libm call, and it
 /// is correctly rounded in IEEE 754, so it cannot be a source of disagreement.
+/// That makes this kernel's bitwise parity derivable rather than merely observed;
+/// tests/parity/test_basis_tabulations.py asserts it and says which is which.
 
 #include <cmath>
 #include <cstddef>

--- a/cpp/include/pantr/change_basis/change_basis.hpp
+++ b/cpp/include/pantr/change_basis/change_basis.hpp
@@ -117,9 +117,20 @@ void write_out(const eigen_matrix<T>& source, span2d<T> out) {
 
 /// Invert `forward` by one LU solve against the identity.
 ///
-/// The oracle writes `np.linalg.solve(forward, np.eye(n))`, which is a solve with
-/// `n` right-hand sides rather than an explicit inverse, and this is the same
-/// thing: `PartialPivLU::solve` applies the triangular factors to each column.
+/// **This computes an inverse, and saying otherwise was wrong.** The oracle writes
+/// `np.linalg.solve(forward, np.eye(n))`, and an earlier version of this comment
+/// called that "a solve with `n` right-hand sides rather than an explicit inverse".
+/// It is precisely Du Croz and Higham's *Method A* for matrix inversion (IMA J.
+/// Numer. Anal. **12** (1992) 1-19, section 3.1), the distinction their paper and
+/// Higham's ASNA chapter 14 exist to draw, and in numpy 2.4.6 it is bitwise
+/// identical to `numpy.linalg.inv`.
+///
+/// The consequence is a one-sided guarantee, and callers should know which side.
+/// Method A bounds the **right** residual `A X - I` and says nothing about the
+/// left. Measured on the Legendre pair in float64: at degree 6 `||AX-I||` is
+/// 2.8e-15 against `||XA-I||` 4.8e-13; at degree 12, the last degree the module
+/// accepts, 2.7e-13 against **1.2e-4**. The round-trip examples in the Python
+/// docstrings exhibit `A @ B` for that reason, not by preference.
 ///
 /// \param forward The matrix to invert. Must be square.
 /// \return Its inverse.
@@ -217,8 +228,10 @@ void bernstein_to_lagrange_1d(int degree, std::span<const T> lagrange_points, sp
 /// \param quad_weights Quadrature weights, same length as `quad_points`.
 /// \param out Output view of shape `(degree + 1, degree + 1)`.
 ///
-/// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
-///       use call `pantr.change_basis.compute_bernstein_to_cardinal_1d`.
+/// \note No input validation is performed, and the degree domain is Layer 2's.
+///       This builder has one -- 26 in float64, 12 in float32 -- and was the only
+///       one of the eight whose note omitted to say so. Layer 3; see CLAUDE.md. For
+///       general use call `pantr.change_basis.compute_bernstein_to_cardinal_1d`.
 template <std::floating_point T>
 void bernstein_to_cardinal_1d(int degree, std::span<const T> quad_points,
                               std::span<const T> quad_weights, span2d<T> out) {

--- a/cpp/include/pantr/change_basis/change_basis.hpp
+++ b/cpp/include/pantr/change_basis/change_basis.hpp
@@ -1,0 +1,377 @@
+#pragma once
+
+/// \file
+/// The eight change-of-basis builders of `src/pantr/change_basis.py`.
+///
+/// Every builder returns the `(degree+1, degree+1)` matrix `M` with
+/// `M [A values](x) = [B values](x)`, and the Python module stays as the parity
+/// oracle.
+///
+/// ## Nodes come in; they are not computed here
+///
+/// `compute_lagrange_to_bernstein_1d` picks its nodes from one of five families,
+/// and two of them -- Gauss-Lobatto-Legendre and Chebyshev of the first kind --
+/// are ones `src/pantr/_backend.py` says are **deliberately never dispatched**
+/// and stay on `numpy.polynomial`. A kernel that computed its own nodes would
+/// therefore have to either contradict that decision or carry a second, divergent
+/// implementation of two rules.
+///
+/// So it takes the nodes as an argument, and so does every builder that needs a
+/// quadrature rule. Layer 2 in Python fetches them from whichever path is right
+/// for the requested variant and hands over an array. The `LagrangeVariant` enum
+/// never crosses the boundary, which is also what design/cross_backend_types.md
+/// asks for: types are Python-owned and only arrays and scalars cross.
+///
+/// ## Arithmetic width is the output dtype, not the accumulator
+///
+/// Unlike the tabulation kernels, these do **not** widen. The oracle forms its
+/// Gram matrix, its mixed matrix and its solve in the requested dtype throughout
+/// -- `np.linalg.solve` on a float32 pair calls LAPACK `sgesv`, not `dgesv`. A
+/// C++ port that solved in double would be more accurate and would not be the
+/// same function, and the difference would show up as a parity failure attributed
+/// to the wrong cause. `Acc` appears below only where the oracle itself computes
+/// in float64: the binomial table, which numpy builds from Python ints.
+///
+/// ## Where parity stops being bit-exact, and why that is not a defect
+///
+/// The tabulations this builds on are bit-exact against their oracles. These are
+/// not, and cannot be:
+///
+///   - **the Gram and mixed products.** `new.T @ diag(w) @ new` is a `dgemm` in
+///     numpy and a blocked product in Eigen. Both are correct; they sum the same
+///     terms in different orders. The `diag(w)` factor is not a source of
+///     disagreement -- multiplying by a diagonal adds only exact zeros to each
+///     dot product -- but the `n_quad`-long contraction that follows it is.
+///   - **the solve.** `np.linalg.solve` is LAPACK `gesv`; this is
+///     `Eigen::PartialPivLU`. Both are LU with partial pivoting and both are
+///     backward stable, so the two computed solutions differ by roughly
+///     `2 c n rho kappa_inf(A) eps`. That is a derivable bound rather than a
+///     measured one, and the `kappa_inf` it needs is already tabulated per degree
+///     in the oracle's own docstrings, from exact rational arithmetic.
+///
+/// tests/parity/test_change_basis.py carries the bound and its derivation.
+///
+/// ## One fewer allocation than the oracle, and it changes nothing
+///
+/// The oracle materialises `np.diag(weights)`, an `n_quad` by `n_quad` matrix
+/// that is zero off the diagonal, and multiplies through it. Scaling the rows
+/// directly, as below, produces the identical matrix: entry `(i, j)` of
+/// `A.T @ diag(w)` is `sum_k A[k, i] w_k [k == j]`, whose only non-zero term is
+/// `A[j, i] w_j`, and adding exact zeros to a float sum does not perturb it. The
+/// saving is `n_quad^2` stores, not a different answer.
+
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/LU>
+
+#include "pantr/basis/bernstein.hpp"
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/basis/legendre.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+namespace detail {
+
+/// Row-major Eigen view over a `span2d`, so no copy is needed to reach Eigen.
+template <std::floating_point T>
+using eigen_matrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
+/// Tabulate a basis at `points` into a fresh row-major matrix.
+///
+/// \tparam T Scalar type.
+/// \tparam Tabulate Callable with the signature of the Layer 3 tabulators.
+/// \param tabulate The tabulator to run.
+/// \param degree Degree passed through to the tabulator.
+/// \param points Evaluation points.
+/// \return A `(points.size(), degree + 1)` matrix of basis values.
+template <std::floating_point T, class Tabulate>
+[[nodiscard]] eigen_matrix<T> tabulated(Tabulate tabulate, int degree,
+                                        std::span<const T> points) {
+    const auto rows = static_cast<Eigen::Index>(points.size());
+    const auto cols = static_cast<Eigen::Index>(degree + 1);
+    eigen_matrix<T> values(rows, cols);
+    const span2d<T> view(values.data(), points.size(), static_cast<std::size_t>(degree + 1));
+    tabulate(degree, points, view);
+    return values;
+}
+
+/// Copy an Eigen matrix into a `span2d` output view.
+///
+/// \param source Matrix to copy from.
+/// \param out Destination view, of matching shape.
+template <std::floating_point T>
+void write_out(const eigen_matrix<T>& source, span2d<T> out) {
+    for (Eigen::Index i = 0; i < source.rows(); ++i) {
+        for (Eigen::Index j = 0; j < source.cols(); ++j) {
+            at(out, static_cast<std::size_t>(i), static_cast<std::size_t>(j)) = source(i, j);
+        }
+    }
+}
+
+/// Invert `forward` by one LU solve against the identity.
+///
+/// The oracle writes `np.linalg.solve(forward, np.eye(n))`, which is a solve with
+/// `n` right-hand sides rather than an explicit inverse, and this is the same
+/// thing: `PartialPivLU::solve` applies the triangular factors to each column.
+///
+/// \param forward The matrix to invert. Must be square.
+/// \return Its inverse.
+template <std::floating_point T>
+[[nodiscard]] eigen_matrix<T> solve_against_identity(const eigen_matrix<T>& forward) {
+    const eigen_matrix<T> identity =
+        eigen_matrix<T>::Identity(forward.rows(), forward.cols());
+    return Eigen::PartialPivLU<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(forward)
+        .solve(identity);
+}
+
+/// The Gram projection shared by the two projected builders.
+///
+/// Solves `G M^T = C` for `M`, with `G` the Gram matrix of the new basis under
+/// the given quadrature and `C` the mixed matrix between the two bases. Row `i`
+/// of the result holds the `i`-th old basis function expanded in the new basis.
+///
+/// \param new_basis New-basis values, `(n_quad, n_new)`.
+/// \param old_basis Old-basis values, `(n_quad, n_old)`.
+/// \param weights Quadrature weights, length `n_quad`.
+/// \return The `(n_old, n_new)` change-of-basis matrix.
+template <std::floating_point T>
+[[nodiscard]] eigen_matrix<T> gram_projection(const eigen_matrix<T>& new_basis,
+                                              const eigen_matrix<T>& old_basis,
+                                              std::span<const T> weights) {
+    const Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>> w(
+        weights.data(), static_cast<Eigen::Index>(weights.size()));
+
+    // `new.T @ diag(w)`, formed by scaling rather than by a dense product. See
+    // the file comment for why the two agree exactly.
+    const eigen_matrix<T> weighted = new_basis.transpose() * w.asDiagonal();
+
+    const eigen_matrix<T> gram = weighted * new_basis;
+    const eigen_matrix<T> mixed = weighted * old_basis;
+
+    return eigen_matrix<T>(
+        Eigen::PartialPivLU<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>(gram)
+            .solve(mixed)
+            .transpose());
+}
+
+}  // namespace detail
+
+/// Lagrange-to-Bernstein: one tabulation, no solve.
+///
+/// `C[j, k] = B_j(x_k)` because the Lagrange basis is cardinal at its own nodes,
+/// so the matrix is the Bernstein basis tabulated at the Lagrange points and
+/// transposed. The oracle expresses that by handing `out.T` to the tabulator; the
+/// same thing is done here by writing the transposed indices.
+///
+/// \param degree Polynomial degree. Must be at least 1.
+/// \param lagrange_points The `degree + 1` nodes of the Lagrange basis.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
+///       use call `pantr.change_basis.compute_lagrange_to_bernstein_1d`.
+template <std::floating_point T>
+void lagrange_to_bernstein_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
+    const auto values =
+        detail::tabulated<T>([](int d, std::span<const T> p,
+                                span2d<T> o) { tabulate_bernstein_1d<T>(d, p, o); },
+                             degree, lagrange_points);
+    const auto n = static_cast<std::size_t>(degree + 1);
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            at(out, i, j) = values(static_cast<Eigen::Index>(j), static_cast<Eigen::Index>(i));
+        }
+    }
+}
+
+/// Bernstein-to-Lagrange: the inverse of the above, by one LU solve.
+///
+/// \param degree Polynomial degree. Must be at least 1.
+/// \param lagrange_points The `degree + 1` nodes of the Lagrange basis.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed, and in particular the degree domain
+///       that keeps this solve non-singular is Layer 2's to enforce. Layer 3; see
+///       CLAUDE.md. For general use call
+///       `pantr.change_basis.compute_bernstein_to_lagrange_1d`.
+template <std::floating_point T>
+void bernstein_to_lagrange_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
+                                    static_cast<Eigen::Index>(n));
+    const span2d<T> forward_view(forward.data(), n, n);
+    lagrange_to_bernstein_1d<T>(degree, lagrange_points, forward_view);
+    detail::write_out<T>(detail::solve_against_identity<T>(forward), out);
+}
+
+/// Bernstein-to-cardinal: a Gram projection.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param quad_points Quadrature nodes on `[0, 1]`.
+/// \param quad_weights Quadrature weights, same length as `quad_points`.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
+///       use call `pantr.change_basis.compute_bernstein_to_cardinal_1d`.
+template <std::floating_point T>
+void bernstein_to_cardinal_1d(int degree, std::span<const T> quad_points,
+                              std::span<const T> quad_weights, span2d<T> out) {
+    const auto bern = detail::tabulated<T>(
+        [](int d, std::span<const T> p, span2d<T> o) { tabulate_bernstein_1d<T>(d, p, o); },
+        degree, quad_points);
+    const auto card = detail::tabulated<T>(
+        [](int d, std::span<const T> p, span2d<T> o) {
+            tabulate_cardinal_bspline_1d<T>(d, p, o);
+        },
+        degree, quad_points);
+    detail::write_out<T>(detail::gram_projection<T>(bern, card, quad_weights), out);
+}
+
+/// Cardinal-to-Bernstein: the inverse of the above, by one LU solve.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param quad_points Quadrature nodes on `[0, 1]`.
+/// \param quad_weights Quadrature weights, same length as `quad_points`.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed, and the degree domain is Layer 2's.
+///       Layer 3; see CLAUDE.md. For general use call
+///       `pantr.change_basis.compute_cardinal_to_bernstein_1d`.
+template <std::floating_point T>
+void cardinal_to_bernstein_1d(int degree, std::span<const T> quad_points,
+                              std::span<const T> quad_weights, span2d<T> out) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
+                                    static_cast<Eigen::Index>(n));
+    const span2d<T> forward_view(forward.data(), n, n);
+    bernstein_to_cardinal_1d<T>(degree, quad_points, quad_weights, forward_view);
+    detail::write_out<T>(detail::solve_against_identity<T>(forward), out);
+}
+
+/// Legendre-to-cardinal: a Gram projection whose Gram matrix is the identity up
+/// to round-off, since the new basis is orthonormal and the quadrature is exact
+/// for the products formed.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param quad_points Quadrature nodes on `[0, 1]`.
+/// \param quad_weights Quadrature weights, same length as `quad_points`.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
+///       use call `pantr.change_basis.compute_legendre_to_cardinal_1d`.
+template <std::floating_point T>
+void legendre_to_cardinal_1d(int degree, std::span<const T> quad_points,
+                             std::span<const T> quad_weights, span2d<T> out) {
+    const auto leg = detail::tabulated<T>(
+        [](int d, std::span<const T> p, span2d<T> o) { tabulate_legendre_1d<T>(d, p, o); },
+        degree, quad_points);
+    const auto card = detail::tabulated<T>(
+        [](int d, std::span<const T> p, span2d<T> o) {
+            tabulate_cardinal_bspline_1d<T>(d, p, o);
+        },
+        degree, quad_points);
+    detail::write_out<T>(detail::gram_projection<T>(leg, card, quad_weights), out);
+}
+
+/// Cardinal-to-Legendre: the inverse of the above, by one LU solve.
+///
+/// The oracle notes that the obvious alternative -- a second Gram projection with
+/// the evaluators swapped -- is equivalent in exact arithmetic and measurably
+/// worse in floating point, because the cardinal Gram matrix has the square of
+/// this one's condition number. The port keeps the solve for the same reason.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param quad_points Quadrature nodes on `[0, 1]`.
+/// \param quad_weights Quadrature weights, same length as `quad_points`.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed, and the degree domain is Layer 2's.
+///       Layer 3; see CLAUDE.md. For general use call
+///       `pantr.change_basis.compute_cardinal_to_legendre_1d`.
+template <std::floating_point T>
+void cardinal_to_legendre_1d(int degree, std::span<const T> quad_points,
+                             std::span<const T> quad_weights, span2d<T> out) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
+                                    static_cast<Eigen::Index>(n));
+    const span2d<T> forward_view(forward.data(), n, n);
+    legendre_to_cardinal_1d<T>(degree, quad_points, quad_weights, forward_view);
+    detail::write_out<T>(detail::solve_against_identity<T>(forward), out);
+}
+
+/// The cardinal-dual L2 functionals in the Legendre basis: the transpose of
+/// `cardinal_to_legendre_1d`.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param quad_points Quadrature nodes on `[0, 1]`.
+/// \param quad_weights Quadrature weights, same length as `quad_points`.
+/// \param out Output view of shape `(degree + 1, degree + 1)`.
+///
+/// \note No input validation is performed, and the degree domain is Layer 2's.
+///       Layer 3; see CLAUDE.md. For general use call
+///       `pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
+template <std::floating_point T>
+void cardinal_dual_legendre_coeffs_1d(int degree, std::span<const T> quad_points,
+                                      std::span<const T> quad_weights, span2d<T> out) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    detail::eigen_matrix<T> straight(static_cast<Eigen::Index>(n),
+                                     static_cast<Eigen::Index>(n));
+    const span2d<T> straight_view(straight.data(), n, n);
+    cardinal_to_legendre_1d<T>(degree, quad_points, quad_weights, straight_view);
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            at(out, i, j) = straight(static_cast<Eigen::Index>(j), static_cast<Eigen::Index>(i));
+        }
+    }
+}
+
+/// Monomial-to-Bernstein on `[0, 1]`: `M[i, j] = C(i, j) / C(degree, j)` for
+/// `j <= i`, and zero above the diagonal.
+///
+/// The binomials are built as a Pascal triangle by **addition**, not by the
+/// multiplicative recurrence. Addition keeps every entry an exact integer while
+/// the values stay at or below `2^53`, so the quotient is then the correctly
+/// rounded value of an exact rational -- which is precisely what the oracle
+/// computes, since Python's `math.comb` is an exact integer and its `/` rounds
+/// the exact quotient once. The multiplicative form would overflow that range in
+/// an intermediate even where the result does not.
+///
+/// The exactness holds while `C(degree, degree/2) <= 2^53`, i.e. through degree
+/// 56. Past it both backends round, and they may round differently; the module
+/// places no domain limit on this builder, so that is stated rather than
+/// enforced here.
+///
+/// \param degree Polynomial degree. Must be non-negative.
+/// \param out Output view of shape `(degree + 1, degree + 1)`, written in full.
+///
+/// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
+///       use call `pantr.change_basis.compute_monomial_to_bernstein_1d`.
+template <std::floating_point T>
+void monomial_to_bernstein_1d(int degree, span2d<T> out) {
+    using Acc = double;
+
+    const auto n = static_cast<std::size_t>(degree + 1);
+    std::vector<Acc> triangle(n * n, Acc(0));
+    for (std::size_t i = 0; i < n; ++i) {
+        triangle[i * n] = Acc(1);
+        for (std::size_t j = 1; j <= i; ++j) {
+            triangle[i * n + j] = triangle[(i - 1) * n + j - 1] +
+                                  (j <= i - 1 ? triangle[(i - 1) * n + j] : Acc(0));
+        }
+    }
+
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            at(out, i, j) =
+                j <= i ? static_cast<T>(triangle[i * n + j] / triangle[(n - 1) * n + j]) : T(0);
+        }
+    }
+}
+
+}  // namespace pantr

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -5,6 +5,8 @@ set(PANTR_TEST_SOURCES
     test_dependency_smoke.cpp
     test_cardinal_bspline.cpp
     test_scalar_generic.cpp
+    test_bernstein.cpp
+    test_legendre.cpp
     test_quad.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PANTR_TEST_SOURCES
     test_scalar_generic.cpp
     test_bernstein.cpp
     test_legendre.cpp
+    test_change_basis.cpp
     test_quad.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -14,9 +14,3 @@ foreach(_src IN LISTS PANTR_TEST_SOURCES)
   target_include_directories(${_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
   add_test(NAME ${_name} COMMAND ${_name})
 endforeach()
-
-# Eigen is only reached by the dependency smoke test. Linking it to pantr::core
-# would put it on the include path of the kernel and the bindings too, which
-# would let a stray #include compile without anyone deciding to take the
-# dependency on.
-target_link_libraries(test_dependency_smoke PRIVATE Eigen3::Eigen)

--- a/cpp/tests/test_bernstein.cpp
+++ b/cpp/tests/test_bernstein.cpp
@@ -1,0 +1,215 @@
+/// \file
+/// Properties of the Bernstein ratio-recurrence tabulation.
+///
+/// ## The forward-error bound
+///
+/// On `[0, 1]` every Bernstein value is non-negative and the row sums to one, so
+/// the row is a probability vector and the error analysis is the same shape as
+/// the cardinal B-spline one: absolute errors add across the row without a growth
+/// factor.
+///
+/// Per step the roundings are: one forming `const_factor` (a subtract that is
+/// exact for integer operands, then a divide), one multiplying by it, and one
+/// multiplying by the ratio -- plus the store, which at float64 is not a rounding
+/// since `Acc` is `double` there. Call it three roundings per step, each
+/// perturbing a quantity by at most `eps` of its own magnitude, and the errors
+/// compound multiplicatively along the row because each term is built from the
+/// previous one. After `i` steps the relative error of `B_i` is therefore at most
+/// about `3 * i * eps`, and summing over a row whose entries sum to one gives
+///
+///     |sum_i B_i(u) - 1|  <=  3 * n * eps  +  n * eps                      (1)
+///
+/// with the second term the summation itself. The constant used below is `8`,
+/// generous against the `4` of (1), because the seed `pow((1-u), n)` carries a
+/// libm error this argument does not bound: the C standard does not require `pow`
+/// to be correctly rounded, and glibc's is documented at up to 1 ulp. One ulp on
+/// the seed propagates as one more relative `eps` through every later term, which
+/// (1) would have to carry as `4 * n * eps`. Rounding that to the next power of
+/// two is the whole of the safety factor.
+///
+/// ## What each test would catch
+///
+/// The mirrored and unmirrored kernels are separately exercised by degree: the
+/// dispatch happens at degree 20 in float64 and 6 in float32, so a test at degree
+/// 24 runs code a test at degree 8 does not.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/bernstein.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+/// The bound of equation (1) in this file's header, with its safety factor.
+constexpr double partition_bound(int degree) {
+    return 8.0 * static_cast<double>(degree) * kEps;
+}
+
+std::vector<double> sample_points() {
+    std::vector<double> pts;
+    constexpr int n_pts = 65;
+    pts.reserve(n_pts);
+    for (int i = 0; i < n_pts; ++i) {
+        pts.push_back(static_cast<double>(i) / static_cast<double>(n_pts - 1));
+    }
+    return pts;
+}
+
+template <class T>
+std::vector<T> tabulate(int degree, const std::vector<T>& pts) {
+    std::vector<T> out(pts.size() * static_cast<std::size_t>(degree + 1), T(0));
+    const pantr::span2d<T> view(out.data(), pts.size(), static_cast<std::size_t>(degree + 1));
+    pantr::tabulate_bernstein_1d<T>(degree, std::span<const T>(pts), view);
+    return out;
+}
+
+/// The safe-degree threshold is the one the oracle tabulates, recomputed here
+/// from the format. If this drifts, every degree-based claim below picks the
+/// wrong kernel and stops testing what it says it tests.
+void safe_degree_matches_the_oracle() {
+    PANTR_CHECK(pantr::bernstein_max_safe_degree_no_mirror<double>() == 20);
+    PANTR_CHECK(pantr::bernstein_max_safe_degree_no_mirror<float>() == 6);
+}
+
+/// Partition of unity, across both kernels.
+void partition_of_unity() {
+    const std::vector<double> pts = sample_points();
+    for (int degree : {0, 1, 3, 8, 20, 21, 24, 40}) {
+        const std::vector<double> vals = tabulate(degree, pts);
+        const auto width = static_cast<std::size_t>(degree + 1);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            double sum = 0.0;
+            for (std::size_t i = 0; i < width; ++i) {
+                sum += vals[j * width + i];
+            }
+            PANTR_CHECK_MSG(std::abs(sum - 1.0) <= partition_bound(degree),
+                            "degree " + std::to_string(degree) + " at point index " +
+                                std::to_string(j));
+        }
+    }
+}
+
+/// Non-negativity on `[0, 1]`. It is what makes the error argument above valid,
+/// so a failure here invalidates every tolerance in this file rather than merely
+/// failing one claim.
+void values_are_non_negative() {
+    const std::vector<double> pts = sample_points();
+    for (int degree : {1, 5, 20, 24}) {
+        const std::vector<double> vals = tabulate(degree, pts);
+        for (double v : vals) {
+            PANTR_CHECK(v >= 0.0);
+        }
+    }
+}
+
+/// `B_i,n(u) = B_{n-i},n(1-u)`. The mirrored kernel is built on this identity, so
+/// checking it at a degree above the threshold tests the mirror rather than
+/// restating the definition.
+void basis_is_symmetric() {
+    for (int degree : {3, 24}) {
+        const std::vector<double> pts = sample_points();
+        std::vector<double> reflected(pts.size());
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            reflected[j] = 1.0 - pts[pts.size() - 1 - j];
+        }
+        const std::vector<double> a = tabulate(degree, pts);
+        const std::vector<double> b = tabulate(degree, reflected);
+        const auto width = static_cast<std::size_t>(degree + 1);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            for (std::size_t i = 0; i < width; ++i) {
+                const double lhs = a[j * width + i];
+                const double rhs = b[(pts.size() - 1 - j) * width + (width - 1 - i)];
+                PANTR_CHECK(std::abs(lhs - rhs) <= partition_bound(degree));
+            }
+        }
+    }
+}
+
+/// The endpoints are exact: `B_0(0) = 1` and `B_n(1) = 1`, everything else zero.
+/// `u == 1` takes a dedicated branch in the unmirrored kernel and the ordinary
+/// path in the mirrored one, so both are covered.
+void endpoints_are_exact() {
+    for (int degree : {1, 5, 20, 24}) {
+        const std::vector<double> pts{0.0, 1.0};
+        const std::vector<double> vals = tabulate(degree, pts);
+        const auto width = static_cast<std::size_t>(degree + 1);
+        for (std::size_t i = 0; i < width; ++i) {
+            PANTR_CHECK(vals[i] == (i == 0 ? 1.0 : 0.0));
+            PANTR_CHECK(vals[width + i] == (i == width - 1 ? 1.0 : 0.0));
+        }
+    }
+}
+
+/// Degree 2 against its closed form. A recurrence can satisfy partition of unity,
+/// non-negativity and symmetry and still be the wrong basis; this is the test
+/// that pins which polynomials these are.
+void low_degrees_match_closed_forms() {
+    const std::vector<double> pts{0.0, 0.25, 0.5, 0.75, 1.0};
+    const std::vector<double> vals = tabulate(2, pts);
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        const double u = pts[j];
+        const double expected[3] = {(1 - u) * (1 - u), 2 * u * (1 - u), u * u};
+        for (std::size_t i = 0; i < 3; ++i) {
+            PANTR_CHECK(std::abs(vals[j * 3 + i] - expected[i]) <= 8 * kEps);
+        }
+    }
+}
+
+/// The underflow the mirror exists to prevent. At a degree past the threshold and
+/// a point one ulp below 1, the unmirrored seed `(1-u)^n` is exactly zero, which
+/// would zero the whole row and take partition of unity to 0 rather than 1. This
+/// is the frontier case: it fails against the kernel without the mirror.
+void the_mirror_prevents_the_underflow_it_was_added_for() {
+    const double u = std::nextafter(1.0, 0.0);
+    PANTR_CHECK(std::pow(1.0 - u, 40.0) == 0.0);
+
+    const std::vector<double> pts{u};
+    const int degree = 40;
+    const std::vector<double> vals = tabulate(degree, pts);
+    double sum = 0.0;
+    for (double v : vals) {
+        sum += v;
+    }
+    PANTR_CHECK_MSG(std::abs(sum - 1.0) <= partition_bound(degree), "mirrored seed underflowed");
+    PANTR_CHECK(vals[static_cast<std::size_t>(degree)] > 0.99);
+}
+
+/// float32 holds partition of unity too, at its own epsilon and its own
+/// threshold: degree 8 is mirrored in float32 while it is not in float64.
+void float32_instantiation_holds_partition_of_unity() {
+    constexpr auto kEps32 = static_cast<double>(std::numeric_limits<float>::epsilon());
+    const std::vector<float> pts{0.0F, 0.125F, 0.5F, 0.875F, 1.0F};
+    for (int degree : {3, 6, 8, 20}) {
+        const std::vector<float> vals = tabulate(degree, pts);
+        const auto width = static_cast<std::size_t>(degree + 1);
+        for (std::size_t j = 0; j < pts.size(); ++j) {
+            double sum = 0.0;
+            for (std::size_t i = 0; i < width; ++i) {
+                sum += static_cast<double>(vals[j * width + i]);
+            }
+            PANTR_CHECK(std::abs(sum - 1.0) <= 8.0 * static_cast<double>(degree) * kEps32);
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    safe_degree_matches_the_oracle();
+    partition_of_unity();
+    values_are_non_negative();
+    basis_is_symmetric();
+    endpoints_are_exact();
+    low_degrees_match_closed_forms();
+    the_mirror_prevents_the_underflow_it_was_added_for();
+    float32_instantiation_holds_partition_of_unity();
+    return pantr::test::summary("test_bernstein");
+}

--- a/cpp/tests/test_change_basis.cpp
+++ b/cpp/tests/test_change_basis.cpp
@@ -30,6 +30,7 @@
 /// each contributing a small multiple of `n eps`, rounded up to a power of two.
 /// It is a safety factor and is named as one.
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <limits>
@@ -44,6 +45,9 @@
 #include "pantr/change_basis/change_basis.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/quad/legendre.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/LU>
 
 namespace {
 
@@ -87,6 +91,68 @@ double kappa_inf(const Matrix& m, const Matrix& inverse, std::size_t n) {
         norm_inv = std::max(norm_inv, row_inv);
     }
     return norm_m * norm_inv;
+}
+
+
+/// `kappa_inf` of the Gram matrix a projected builder actually solves with.
+///
+/// **This, and not `kappa_inf(M)`, is what the bound needs.** An earlier version of
+/// this file sized every tolerance with the condition number of the *result*, which
+/// is a different matrix: measured at degree 8 that is 3.8e8 times too large for
+/// `legendre_to_cardinal`, whose Gram is the identity and whose true kappa is one,
+/// and 3.4e4 times too *small* for `cardinal_to_bernstein` -- a latent false failure
+/// rather than merely a dormant test.
+///
+/// \param basis The new basis tabulated at the quadrature nodes, `(n_quad, n)`.
+/// \param weights The quadrature weights.
+/// \param n The basis size.
+/// \return `||G||_inf ||G^-1||_inf`.
+double gram_kappa(const Matrix& basis, const std::vector<double>& weights, std::size_t n) {
+    using Dense = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+    const auto rows = static_cast<Eigen::Index>(weights.size());
+    const auto cols = static_cast<Eigen::Index>(n);
+
+    Dense b(rows, cols);
+    for (Eigen::Index j = 0; j < rows; ++j) {
+        for (Eigen::Index i = 0; i < cols; ++i) {
+            b(j, i) = basis[static_cast<std::size_t>(j) * n + static_cast<std::size_t>(i)];
+        }
+    }
+    Dense weighted = b.transpose();
+    for (Eigen::Index j = 0; j < rows; ++j) {
+        weighted.col(j) *= weights[static_cast<std::size_t>(j)];
+    }
+    const Dense gram = weighted * b;
+    const Dense inverse =
+        Eigen::PartialPivLU<Dense>(gram).solve(Dense::Identity(cols, cols));
+
+    Matrix g(n * n);
+    Matrix gi(n * n);
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            g[i * n + j] = gram(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+            gi[i * n + j] = inverse(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+        }
+    }
+    return kappa_inf(g, gi, n);
+}
+
+/// Tabulate one basis at the quadrature nodes, flat and row-major.
+///
+/// \param which `'b'` for Bernstein, `'l'` for Legendre.
+/// \param degree Polynomial degree.
+/// \param points Quadrature nodes.
+/// \return The `(points.size(), degree + 1)` values.
+Matrix tabulated_at(char which, int degree, const std::vector<double>& points) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    Matrix values(points.size() * n, 0.0);
+    const pantr::span2d<double> view(values.data(), points.size(), n);
+    if (which == 'b') {
+        pantr::tabulate_bernstein_1d<double>(degree, std::span<const double>(points), view);
+    } else {
+        pantr::tabulate_legendre_1d<double>(degree, std::span<const double>(points), view);
+    }
+    return values;
 }
 
 /// `max_ij |A B - I|`.
@@ -193,16 +259,16 @@ void the_matrices_actually_change_the_basis() {
         //
         // The tolerance is `||M||_inf * max|A values| * kappa_inf(M) * eps`, and
         // each factor is there for a reason rather than for room: `M` carries a
-        // relative error of order `kappa_inf(M) eps` from its own solve, the
-        // product then scales that by the row sums of `M` and the size of the
-        // vector, and the summation itself contributes `n eps` which is
-        // absorbed into the factor of 16. `kappa_inf` is the real one here --
-        // each matrix's inverse is the sibling builder's output, which this test
-        // already has in hand.
-        const auto check = [&](const Matrix& m, const Matrix& m_inverse,
-                               const std::vector<double>& from,
+        // relative error of order `kappa eps` from its own solve, the product
+        // then scales that by the row sums of `M` and the size of the vector, and
+        // the summation itself contributes `n eps`, absorbed into the factor of
+        // 16. **`kappa` is the condition number of the matrix that builder's
+        // SOLVE used**, passed in per builder, not the condition number of the
+        // result -- those differ by up to eight orders of magnitude and in one
+        // direction the substitution makes the test too strict rather than too
+        // loose.
+        const auto check = [&](const Matrix& m, double kappa, const std::vector<double>& from,
                                const std::vector<double>& to, const char* name) {
-            const double kappa = kappa_inf(m, m_inverse, n);
             double norm_m = 0.0;
             for (std::size_t i = 0; i < n; ++i) {
                 double row = 0.0;
@@ -229,9 +295,19 @@ void the_matrices_actually_change_the_basis() {
             }
         };
 
-        check(b2c, c2b, bern, card, "bernstein_to_cardinal");
-        check(c2b, b2c, card, bern, "cardinal_to_bernstein");
-        check(l2c, c2l, leg, card, "legendre_to_cardinal");
+        // The kappa each builder's own solve carries, not the result's. See
+        // `gram_kappa`.
+        const Matrix bern_at_nodes = tabulated_at('b', degree, rule.points);
+        const Matrix leg_at_nodes = tabulated_at('l', degree, rule.points);
+        const double kappa_gram_bern = gram_kappa(bern_at_nodes, rule.weights, n);
+        const double kappa_gram_leg = gram_kappa(leg_at_nodes, rule.weights, n);
+        const double kappa_b2c_forward = kappa_inf(b2c, c2b, n);
+        const double kappa_l2c_forward = kappa_inf(l2c, c2l, n);
+
+        check(b2c, kappa_gram_bern, bern, card, "bernstein_to_cardinal");
+        check(c2b, kappa_b2c_forward * kappa_gram_bern, card, bern, "cardinal_to_bernstein");
+        check(l2c, kappa_gram_leg, leg, card, "legendre_to_cardinal");
+        check(c2l, kappa_l2c_forward, card, leg, "cardinal_to_legendre");
     }
 }
 

--- a/cpp/tests/test_change_basis.cpp
+++ b/cpp/tests/test_change_basis.cpp
@@ -1,0 +1,325 @@
+/// \file
+/// Properties of the change-of-basis builders that hold without an oracle.
+///
+/// The Python parity tests are where these are compared against
+/// `pantr.change_basis`, and where the sharp `kappa_inf` values from exact
+/// rational arithmetic are available. This file asks the complementary question:
+/// is what C++ produces a change-of-basis matrix at all?
+///
+/// ## The defining property, and why it is the test that matters
+///
+/// A builder named `A_to_B` returns `M` with `M [A values](x) = [B values](x)`
+/// at every `x`. That single identity pins the matrix uniquely, so a builder can
+/// pass every round trip, every symmetry and every closed form below and still be
+/// wrong -- but it cannot pass this one and be wrong. It is checked directly for
+/// three of the builders, at points that are not the ones any of them was built
+/// from.
+///
+/// ## Tolerances
+///
+/// Every claim here is a linear-solve claim, so every tolerance is
+/// `kappa_inf(M) * eps` times a stated factor, with `kappa_inf` computed from the
+/// matrices in hand rather than assumed. That estimate is known to be unreliable
+/// close to the domain boundary -- `pantr.change_basis`'s module docstring
+/// measures it 8.6x too high at degree 13 and 4.9x too low at degree 15 for the
+/// Bernstein/cardinal pair -- so **the degrees here stay well inside the
+/// domain**, where the formed matrix and the exact one agree, and the boundary
+/// claims are left to the Python side that has the exact numbers.
+///
+/// The factor is 16 throughout: a solve, a product against it and a subtraction,
+/// each contributing a small multiple of `n eps`, rounded up to a power of two.
+/// It is a safety factor and is named as one.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/bernstein.hpp"
+#include "pantr/basis/cardinal_bspline.hpp"
+#include "pantr/basis/legendre.hpp"
+#include "pantr/change_basis/change_basis.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/quad/legendre.hpp"
+
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+/// Acknowledged safety factor; see this file's header.
+constexpr double kFactor = 16.0;
+
+using Matrix = std::vector<double>;
+
+/// Gauss-Legendre on `[0, 1]`, the rule the projected builders integrate with.
+struct Rule {
+    std::vector<double> points;
+    std::vector<double> weights;
+};
+
+Rule unit_gauss_legendre(int n) {
+    Rule rule{std::vector<double>(static_cast<std::size_t>(n)),
+              std::vector<double>(static_cast<std::size_t>(n))};
+    pantr::gauss_legendre_symmetric(n, std::span<double>(rule.points),
+                                    std::span<double>(rule.weights));
+    for (std::size_t j = 0; j < rule.points.size(); ++j) {
+        rule.points[j] = 0.5 * (rule.points[j] + 1.0);
+        rule.weights[j] *= 0.5;
+    }
+    return rule;
+}
+
+/// `kappa_inf(M)` estimated from `M` and its computed inverse.
+double kappa_inf(const Matrix& m, const Matrix& inverse, std::size_t n) {
+    double norm_m = 0.0;
+    double norm_inv = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        double row_m = 0.0;
+        double row_inv = 0.0;
+        for (std::size_t j = 0; j < n; ++j) {
+            row_m += std::abs(m[i * n + j]);
+            row_inv += std::abs(inverse[i * n + j]);
+        }
+        norm_m = std::max(norm_m, row_m);
+        norm_inv = std::max(norm_inv, row_inv);
+    }
+    return norm_m * norm_inv;
+}
+
+/// `max_ij |A B - I|`.
+double identity_residual(const Matrix& a, const Matrix& b, std::size_t n) {
+    double worst = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            double acc = 0.0;
+            for (std::size_t k = 0; k < n; ++k) {
+                acc += a[i * n + k] * b[k * n + j];
+            }
+            worst = std::max(worst, std::abs(acc - (i == j ? 1.0 : 0.0)));
+        }
+    }
+    return worst;
+}
+
+Matrix square(int degree) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    return Matrix(n * n, 0.0);
+}
+
+pantr::span2d<double> view_of(Matrix& m, int degree) {
+    const auto n = static_cast<std::size_t>(degree + 1);
+    return pantr::span2d<double>(m.data(), n, n);
+}
+
+/// Each inverse pair multiplies to the identity, to `kappa_inf * eps`.
+void inverse_pairs_round_trip() {
+    for (int degree : {1, 3, 5, 8}) {
+        const auto n = static_cast<std::size_t>(degree + 1);
+        const Rule rule = unit_gauss_legendre(degree + 1);
+        const std::span<const double> pts(rule.points);
+        const std::span<const double> wts(rule.weights);
+
+        // Lagrange/Bernstein, at equispaced nodes built here rather than
+        // imported, so this file does not depend on the node helper.
+        std::vector<double> equispaced(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            equispaced[i] = static_cast<double>(i) / static_cast<double>(degree);
+        }
+        Matrix l2b = square(degree);
+        Matrix b2l = square(degree);
+        pantr::lagrange_to_bernstein_1d<double>(degree, std::span<const double>(equispaced),
+                                                view_of(l2b, degree));
+        pantr::bernstein_to_lagrange_1d<double>(degree, std::span<const double>(equispaced),
+                                                view_of(b2l, degree));
+        PANTR_CHECK_MSG(identity_residual(l2b, b2l, n) <=
+                            kFactor * kappa_inf(l2b, b2l, n) * kEps,
+                        "lagrange/bernstein at degree " + std::to_string(degree));
+
+        Matrix b2c = square(degree);
+        Matrix c2b = square(degree);
+        pantr::bernstein_to_cardinal_1d<double>(degree, pts, wts, view_of(b2c, degree));
+        pantr::cardinal_to_bernstein_1d<double>(degree, pts, wts, view_of(c2b, degree));
+        PANTR_CHECK_MSG(identity_residual(b2c, c2b, n) <=
+                            kFactor * kappa_inf(b2c, c2b, n) * kEps,
+                        "bernstein/cardinal at degree " + std::to_string(degree));
+
+        Matrix l2c = square(degree);
+        Matrix c2l = square(degree);
+        pantr::legendre_to_cardinal_1d<double>(degree, pts, wts, view_of(l2c, degree));
+        pantr::cardinal_to_legendre_1d<double>(degree, pts, wts, view_of(c2l, degree));
+        PANTR_CHECK_MSG(identity_residual(l2c, c2l, n) <=
+                            kFactor * kappa_inf(l2c, c2l, n) * kEps,
+                        "legendre/cardinal at degree " + std::to_string(degree));
+    }
+}
+
+/// `M [A values](x) = [B values](x)` at points none of the builders saw.
+///
+/// This is the identity that defines each matrix; the round trips above would
+/// pass for a consistent but wrong pair, and this would not.
+void the_matrices_actually_change_the_basis() {
+    const std::vector<double> probe{0.05, 0.31, 0.5, 0.77, 0.99};
+
+    for (int degree : {1, 3, 5, 8}) {
+        const auto n = static_cast<std::size_t>(degree + 1);
+        const Rule rule = unit_gauss_legendre(degree + 1);
+        const std::span<const double> pts(rule.points);
+        const std::span<const double> wts(rule.weights);
+
+        std::vector<double> bern(probe.size() * n);
+        std::vector<double> card(probe.size() * n);
+        std::vector<double> leg(probe.size() * n);
+        pantr::tabulate_bernstein_1d<double>(degree, std::span<const double>(probe),
+                                             pantr::span2d<double>(bern.data(), probe.size(), n));
+        pantr::tabulate_cardinal_bspline_1d<double>(
+            degree, std::span<const double>(probe),
+            pantr::span2d<double>(card.data(), probe.size(), n));
+        pantr::tabulate_legendre_1d<double>(degree, std::span<const double>(probe),
+                                            pantr::span2d<double>(leg.data(), probe.size(), n));
+
+        Matrix b2c = square(degree);
+        Matrix c2b = square(degree);
+        Matrix l2c = square(degree);
+        pantr::bernstein_to_cardinal_1d<double>(degree, pts, wts, view_of(b2c, degree));
+        pantr::cardinal_to_bernstein_1d<double>(degree, pts, wts, view_of(c2b, degree));
+        Matrix c2l = square(degree);
+        pantr::legendre_to_cardinal_1d<double>(degree, pts, wts, view_of(l2c, degree));
+        pantr::cardinal_to_legendre_1d<double>(degree, pts, wts, view_of(c2l, degree));
+
+        // `M @ [A values] = [B values]`, one probe point at a time.
+        //
+        // The tolerance is `||M||_inf * max|A values| * kappa_inf(M) * eps`, and
+        // each factor is there for a reason rather than for room: `M` carries a
+        // relative error of order `kappa_inf(M) eps` from its own solve, the
+        // product then scales that by the row sums of `M` and the size of the
+        // vector, and the summation itself contributes `n eps` which is
+        // absorbed into the factor of 16. `kappa_inf` is the real one here --
+        // each matrix's inverse is the sibling builder's output, which this test
+        // already has in hand.
+        const auto check = [&](const Matrix& m, const Matrix& m_inverse,
+                               const std::vector<double>& from,
+                               const std::vector<double>& to, const char* name) {
+            const double kappa = kappa_inf(m, m_inverse, n);
+            double norm_m = 0.0;
+            for (std::size_t i = 0; i < n; ++i) {
+                double row = 0.0;
+                for (std::size_t j = 0; j < n; ++j) {
+                    row += std::abs(m[i * n + j]);
+                }
+                norm_m = std::max(norm_m, row);
+            }
+            for (std::size_t p = 0; p < probe.size(); ++p) {
+                double max_from = 0.0;
+                for (std::size_t k = 0; k < n; ++k) {
+                    max_from = std::max(max_from, std::abs(from[p * n + k]));
+                }
+                const double tol = kFactor * norm_m * max_from * kappa * kEps;
+                for (std::size_t i = 0; i < n; ++i) {
+                    double acc = 0.0;
+                    for (std::size_t k = 0; k < n; ++k) {
+                        acc += m[i * n + k] * from[p * n + k];
+                    }
+                    PANTR_CHECK_MSG(std::abs(acc - to[p * n + i]) <= tol,
+                                    std::string(name) + " at degree " +
+                                        std::to_string(degree));
+                }
+            }
+        };
+
+        check(b2c, c2b, bern, card, "bernstein_to_cardinal");
+        check(c2b, b2c, card, bern, "cardinal_to_bernstein");
+        check(l2c, c2l, leg, card, "legendre_to_cardinal");
+    }
+}
+
+/// The dual coefficients are the cardinal-to-Legendre matrix transposed, exactly.
+/// Nothing is recomputed between the two, so this is bit-equality or a bug.
+void dual_coefficients_are_the_transpose() {
+    for (int degree : {0, 1, 4, 7}) {
+        const auto n = static_cast<std::size_t>(degree + 1);
+        const Rule rule = unit_gauss_legendre(degree + 1);
+        Matrix c2l = square(degree);
+        Matrix dual = square(degree);
+        pantr::cardinal_to_legendre_1d<double>(degree, std::span<const double>(rule.points),
+                                               std::span<const double>(rule.weights),
+                                               view_of(c2l, degree));
+        pantr::cardinal_dual_legendre_coeffs_1d<double>(
+            degree, std::span<const double>(rule.points),
+            std::span<const double>(rule.weights), view_of(dual, degree));
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t j = 0; j < n; ++j) {
+                PANTR_CHECK(dual[i * n + j] == c2l[j * n + i]);
+            }
+        }
+    }
+}
+
+/// Monomial-to-Bernstein: lower triangular, unit first column, and the closed
+/// form at degree 3. The entries are exact rationals with small denominators, so
+/// unlike everything else here this is an equality rather than a tolerance.
+void monomial_to_bernstein_matches_its_closed_form() {
+    const int degree = 3;
+    Matrix m = square(degree);
+    pantr::monomial_to_bernstein_1d<double>(degree, view_of(m, degree));
+
+    // C(i,j)/C(3,j): rows 1, [1 1/3], [1 2/3 1/3], [1 1 1 1].
+    const double expected[16] = {1, 0,          0,          0,  //
+                                 1, 1.0 / 3.0,  0,          0,  //
+                                 1, 2.0 / 3.0,  1.0 / 3.0,  0,  //
+                                 1, 1,          1,          1};
+    for (std::size_t k = 0; k < 16; ++k) {
+        PANTR_CHECK(m[k] == expected[k]);
+    }
+
+    // Every column of a higher-degree matrix ends at 1, since C(n,j)/C(n,j) = 1.
+    for (int d : {5, 12, 30}) {
+        const auto n = static_cast<std::size_t>(d + 1);
+        Matrix big = square(d);
+        pantr::monomial_to_bernstein_1d<double>(d, view_of(big, d));
+        for (std::size_t j = 0; j < n; ++j) {
+            PANTR_CHECK(big[(n - 1) * n + j] == 1.0);
+        }
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t j = i + 1; j < n; ++j) {
+                PANTR_CHECK(big[i * n + j] == 0.0);
+            }
+        }
+    }
+}
+
+/// The float32 instantiation runs and produces a matrix, at its own precision.
+/// It exists to catch a template that only compiles for double.
+void float32_instantiation_round_trips() {
+    constexpr auto kEps32 = static_cast<double>(std::numeric_limits<float>::epsilon());
+    const int degree = 4;
+    const auto n = static_cast<std::size_t>(degree + 1);
+    const Rule rule64 = unit_gauss_legendre(degree + 1);
+    const std::vector<float> pts(rule64.points.begin(), rule64.points.end());
+    const std::vector<float> wts(rule64.weights.begin(), rule64.weights.end());
+
+    std::vector<float> a(n * n, 0.0F);
+    std::vector<float> b(n * n, 0.0F);
+    pantr::legendre_to_cardinal_1d<float>(degree, std::span<const float>(pts),
+                                          std::span<const float>(wts),
+                                          pantr::span2d<float>(a.data(), n, n));
+    pantr::cardinal_to_legendre_1d<float>(degree, std::span<const float>(pts),
+                                          std::span<const float>(wts),
+                                          pantr::span2d<float>(b.data(), n, n));
+    const Matrix a64(a.begin(), a.end());
+    const Matrix b64(b.begin(), b.end());
+    PANTR_CHECK(identity_residual(a64, b64, n) <= kFactor * kappa_inf(a64, b64, n) * kEps32);
+}
+
+}  // namespace
+
+int main() {
+    inverse_pairs_round_trip();
+    the_matrices_actually_change_the_basis();
+    dual_coefficients_are_the_transpose();
+    monomial_to_bernstein_matches_its_closed_form();
+    float32_instantiation_round_trips();
+    return pantr::test::summary("test_change_basis");
+}

--- a/cpp/tests/test_legendre.cpp
+++ b/cpp/tests/test_legendre.cpp
@@ -9,12 +9,27 @@
 /// recurrence subtracts, and `|p_i(x)|` reaches `sqrt(2i+1)` at the endpoints.
 /// So the error argument has to carry a growth factor rather than assume none.
 ///
-/// The three-term recurrence `p_i = a_i y p_{i-1} - b_i p_{i-2}` has
-/// `a_i -> 2` and `b_i -> 1` as `i` grows, so an error already present in
-/// `p_{i-1}` is multiplied by `|a_i y| <= 2` at each step, and the worst case
-/// compounds as `2^i`. That bound is attained only at `|y| = 1`, and it is far
-/// too pessimistic to test against: at degree 20 it is `2^20 eps`, about `2e-10`,
-/// which no run comes near.
+/// The naive reading of the three-term recurrence `p_i = a_i y p_{i-1} - b_i p_{i-2}`
+/// is that an error in `p_{i-1}` is multiplied by `|a_i y| <= 2` at each step and so
+/// compounds as `2^i`. **That is wrong, and this file used to assert it.** It is the
+/// classic mistake for a recurrence whose two homogeneous solutions are both bounded:
+/// the growing and decaying parts do not simply multiply.
+///
+/// `design/backend_parity.md` Rule 4 records the correct answer for the Legendre
+/// recurrence as **PROVED, both halves**: the error growth is `Theta(n^2)`, with
+/// closed form `C(n, +-1) = (7/4) n^2 + (9/4) n - 4 H_n`. Deriving an exponential
+/// bound here while a proved quadratic one sat four directories away was the defect;
+/// the tolerances below now carry the right order.
+///
+/// **The order transfers; the constant is not copied.** Rule 4 is about `P_n` on
+/// `[-1, 1]`; this kernel tabulates the *orthonormal shifted* family on `[0, 1]`,
+/// whose normalisation differs, so `7/4` is not this family's constant. What is used
+/// below is `2 i^2`, and its status is: **order derived** from Rule 4, **constant
+/// measured**, not proved. Against a long-double reference of the same recurrence,
+/// worst relative error over 201 points on `[0, 1]`, in units of eps: 3.5 at degree
+/// 4, 8.1 at 8, 11.6 at 16, 23.1 at 32, 71.2 at 64. `2 i^2` sits above every one of
+/// those with between 9x and 1150x in hand, and unlike `2^i` the margin does not
+/// diverge.
 ///
 /// So the claims below are chosen to be ones that hold **without** needing a
 /// sharp forward bound:
@@ -47,11 +62,11 @@ namespace {
 
 constexpr double kEps = std::numeric_limits<double>::epsilon();
 
-/// The compounding bound argued in this file's header: `2^i` growth on an error
-/// of size `eps`, which is the honest worst case for a subtractive three-term
-/// recurrence and is deliberately loose.
+/// The `Theta(i^2)` bound of this file's header: order from Rule 4, constant
+/// measured. Zero at degree 0, where the basis is the constant 1 and exact.
 double recurrence_bound(int degree) {
-    return std::ldexp(1.0, degree) * kEps;
+    const auto d = static_cast<double>(degree);
+    return std::max(1.0, 2.0 * d * d) * kEps;
 }
 
 template <class T>
@@ -158,7 +173,7 @@ void float32_tracks_float64() {
             const double rhs = static_cast<double>(b[j * width + i]);
             const double scale = std::max(1.0, std::abs(lhs));
             PANTR_CHECK(std::abs(lhs - rhs) <=
-                        std::ldexp(1.0, static_cast<int>(i)) * kEps32 * scale);
+                        std::max(1.0, 2.0 * static_cast<double>(i * i)) * kEps32 * scale);
         }
     }
 }

--- a/cpp/tests/test_legendre.cpp
+++ b/cpp/tests/test_legendre.cpp
@@ -1,0 +1,174 @@
+/// \file
+/// Properties of the orthonormal shifted Legendre tabulation.
+///
+/// ## Why the tolerances here are not the Bernstein ones
+///
+/// The Bernstein and cardinal B-spline files both lean on the same fact: their
+/// values are non-negative and sum to one, so a stage cannot amplify an error.
+/// **Legendre has neither property.** The polynomials oscillate in sign, the
+/// recurrence subtracts, and `|p_i(x)|` reaches `sqrt(2i+1)` at the endpoints.
+/// So the error argument has to carry a growth factor rather than assume none.
+///
+/// The three-term recurrence `p_i = a_i y p_{i-1} - b_i p_{i-2}` has
+/// `a_i -> 2` and `b_i -> 1` as `i` grows, so an error already present in
+/// `p_{i-1}` is multiplied by `|a_i y| <= 2` at each step, and the worst case
+/// compounds as `2^i`. That bound is attained only at `|y| = 1`, and it is far
+/// too pessimistic to test against: at degree 20 it is `2^20 eps`, about `2e-10`,
+/// which no run comes near.
+///
+/// So the claims below are chosen to be ones that hold **without** needing a
+/// sharp forward bound:
+///
+///   - orthonormality, measured by Gauss-Legendre quadrature of high enough
+///     order that the quadrature itself is exact for the integrand;
+///   - the endpoint values `p_i(1) = sqrt(2i+1)` and
+///     `p_i(0) = (-1)^i sqrt(2i+1)`, which are closed forms;
+///   - the low-degree closed forms;
+///   - agreement between the two instantiations at the width they share.
+///
+/// Each is compared against `2^degree * eps` where a growth factor is genuinely
+/// unavoidable, and against a small multiple of `eps` where it is not, and the
+/// distinction is stated per test rather than hidden in one constant.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/basis/legendre.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/quad/legendre.hpp"
+
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+/// The compounding bound argued in this file's header: `2^i` growth on an error
+/// of size `eps`, which is the honest worst case for a subtractive three-term
+/// recurrence and is deliberately loose.
+double recurrence_bound(int degree) {
+    return std::ldexp(1.0, degree) * kEps;
+}
+
+template <class T>
+std::vector<T> tabulate(int degree, const std::vector<T>& pts) {
+    std::vector<T> out(pts.size() * static_cast<std::size_t>(degree + 1), T(0));
+    const pantr::span2d<T> view(out.data(), pts.size(), static_cast<std::size_t>(degree + 1));
+    pantr::tabulate_legendre_1d<T>(degree, std::span<const T>(pts), view);
+    return out;
+}
+
+/// `p_i(1) = sqrt(2i+1)` and `p_i(0) = (-1)^i sqrt(2i+1)`. Closed forms, so this
+/// pins which polynomials the recurrence produces rather than merely that it
+/// produces a consistent family.
+void endpoint_values_match_their_closed_form() {
+    const int degree = 12;
+    const std::vector<double> pts{0.0, 1.0};
+    const std::vector<double> vals = tabulate(degree, pts);
+    const auto width = static_cast<std::size_t>(degree + 1);
+    for (std::size_t i = 0; i < width; ++i) {
+        const double norm = std::sqrt(2.0 * static_cast<double>(i) + 1.0);
+        const double at_zero = vals[i];
+        const double at_one = vals[width + i];
+        const double sign = (i % 2 == 0) ? 1.0 : -1.0;
+        PANTR_CHECK_MSG(std::abs(at_one - norm) <= recurrence_bound(static_cast<int>(i)) * norm,
+                        "p_" + std::to_string(i) + "(1)");
+        PANTR_CHECK_MSG(std::abs(at_zero - sign * norm) <=
+                            recurrence_bound(static_cast<int>(i)) * norm,
+                        "p_" + std::to_string(i) + "(0)");
+    }
+}
+
+/// Degrees 0 to 2 against the closed forms of the orthonormal shifted family.
+/// No growth factor is needed at these degrees, so the tolerance is a small
+/// multiple of eps rather than the compounding bound.
+void low_degrees_match_closed_forms() {
+    const std::vector<double> pts{0.0, 0.25, 0.5, 0.75, 1.0};
+    const std::vector<double> vals = tabulate(2, pts);
+    for (std::size_t j = 0; j < pts.size(); ++j) {
+        const double y = 2.0 * pts[j] - 1.0;
+        const double expected[3] = {1.0, std::sqrt(3.0) * y,
+                                    std::sqrt(5.0) * 0.5 * (3.0 * y * y - 1.0)};
+        for (std::size_t i = 0; i < 3; ++i) {
+            PANTR_CHECK(std::abs(vals[j * 3 + i] - expected[i]) <= 8.0 * kEps);
+        }
+    }
+}
+
+/// Orthonormality on `[0, 1]`, which is the property the basis is named for and
+/// the one every consumer relies on.
+///
+/// The inner products are formed by Gauss-Legendre quadrature on `2 * degree + 1`
+/// nodes, which integrates a polynomial of degree `4 * degree + 1` exactly, well
+/// above the `2 * degree` of the integrand. So any deviation here is the
+/// recurrence's error and not the quadrature's -- with the caveat that the nodes
+/// themselves come from `pantr::gauss_legendre_1d`, so this test is not
+/// independent of that kernel. It would catch a wrong Legendre basis; it would
+/// not distinguish a wrong basis from a wrong quadrature.
+void the_basis_is_orthonormal() {
+    const int degree = 8;
+    const int n_quad_i = 2 * degree + 1;
+    const auto n_quad = static_cast<std::size_t>(n_quad_i);
+    std::vector<double> nodes(n_quad);
+    std::vector<double> weights(n_quad);
+    pantr::gauss_legendre_symmetric(n_quad_i, std::span<double>(nodes),
+                                    std::span<double>(weights));
+    // The kernel returns the rule on [-1, 1]; the basis lives on [0, 1].
+    for (std::size_t j = 0; j < n_quad; ++j) {
+        nodes[j] = 0.5 * (nodes[j] + 1.0);
+        weights[j] *= 0.5;
+    }
+
+    const std::vector<double> vals = tabulate(degree, nodes);
+    const auto width = static_cast<std::size_t>(degree + 1);
+
+    for (std::size_t i = 0; i < width; ++i) {
+        for (std::size_t k = i; k < width; ++k) {
+            double integral = 0.0;
+            for (std::size_t j = 0; j < n_quad; ++j) {
+                integral += weights[j] * vals[j * width + i] * vals[j * width + k];
+            }
+            const double expected = (i == k) ? 1.0 : 0.0;
+            PANTR_CHECK_MSG(std::abs(integral - expected) <= recurrence_bound(degree),
+                            "<p_" + std::to_string(i) + ", p_" + std::to_string(k) + ">");
+        }
+    }
+}
+
+/// float32 agrees with float64 to float32's own precision. The coefficients are
+/// double in both instantiations by construction, so what this checks is that
+/// only the per-point values narrow.
+void float32_tracks_float64() {
+    constexpr auto kEps32 = static_cast<double>(std::numeric_limits<float>::epsilon());
+    const int degree = 6;
+    const std::vector<double> pts64{0.0, 0.125, 0.5, 0.875, 1.0};
+    const std::vector<float> pts32{0.0F, 0.125F, 0.5F, 0.875F, 1.0F};
+
+    const std::vector<double> a = tabulate(degree, pts64);
+    const std::vector<float> b = tabulate(degree, pts32);
+    const auto width = static_cast<std::size_t>(degree + 1);
+
+    for (std::size_t j = 0; j < pts64.size(); ++j) {
+        for (std::size_t i = 0; i < width; ++i) {
+            const double lhs = a[j * width + i];
+            const double rhs = static_cast<double>(b[j * width + i]);
+            const double scale = std::max(1.0, std::abs(lhs));
+            PANTR_CHECK(std::abs(lhs - rhs) <=
+                        std::ldexp(1.0, static_cast<int>(i)) * kEps32 * scale);
+        }
+    }
+}
+
+}  // namespace
+
+int main() {
+    endpoint_values_match_their_closed_form();
+    low_degrees_match_closed_forms();
+    the_basis_is_orthonormal();
+    float32_tracks_float64();
+    return pantr::test::summary("test_legendre");
+}

--- a/design/adaptive_thb_approximation.md
+++ b/design/adaptive_thb_approximation.md
@@ -145,7 +145,9 @@ that has not been estimated.
 
 **Decided (2026-08-19): Eigen supplies the solver in both cases**, so deferring this choice
 is safe. `Eigen::SparseMatrix` with `SimplicialLDLT` covers the level-wise banded systems and
-a global THB system alike, and Eigen is already a required dependency, so adding the sparse
+a global THB system alike, and Eigen is a dependency of the shipped extension as of
+2026-08-21 (it was fetched only for the C++ tests when this was written; see the correction
+in `design/large_data_fitting.md`), so adding the sparse
 path later costs nothing in dependency terms. The real cost of a global fit is assembling the
 THB system, which is new code either way. The decision stays contained behind the API as long
 as the return type does not leak which method produced it.

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -248,6 +248,59 @@ three are about what a binding accepts and what an emptied rule returns, and sta
 **The cost of getting this wrong is not the red.** It is that an intermittent red teaches
 everyone to discount reds, which is worth less than no guard at all.
 
+## Rule 8: a parity claim is only defined where the quantity has digits
+
+Added by the change-of-basis port, which is the first module whose kernels **solve a linear
+system**, and the first where Rule 3 turned out to have teeth against a bound that was derived
+correctly.
+
+Five of that module's eight builders invert an ill-conditioned matrix. Both backends are
+backward stable -- LAPACK `gesv` on one side, `Eigen::PartialPivLU` on the other -- so the
+honest bound on their disagreement is the standard one, of order `kappa_inf * eps` times a
+small multiple of the size. That derivation is not in question. What it produces is.
+
+`pantr.change_basis` defines each builder's domain as the degrees where
+`kappa_inf * eps < 1`, which is where the solve is still defined. At the top of that range the
+parity bound is therefore *of order one*, and the values being compared are of order one too, so
+Rule 3's guard fires and refuses the claim. It is right to. A bound as large as the values it
+compares is satisfied by any result, zero included.
+
+**The resolution is not a tighter bound; it is a smaller domain.** Parity is asserted where
+`32 n kappa_inf eps < 1`, which is the **accuracy** domain rather than the **solvability**
+domain. The two differ per builder and per dtype: for `bernstein_to_cardinal` in float64 the
+module accepts degrees to 26 and parity is claimable to 22; for `cardinal_to_bernstein` it
+accepts to 14 and parity reaches 9.
+
+That is not a weakening, and the reason is worth stating plainly, because the instinct is to
+read a smaller tested range as thinner coverage. **Above the accuracy domain the answer has no
+correct digits in either backend.** There is nothing left for a parity claim to be about: two
+implementations agreeing on a quantity that is entirely round-off is not evidence that the port
+is right, and two implementations disagreeing there is not evidence that it is wrong.
+
+Two obligations come with it.
+
+**Name the excluded degrees.** A test that quietly stops where its bound runs out reads as full
+coverage of the module. `tests/parity/test_change_basis.py` carries a test whose only job is to
+enumerate the degrees each builder accepts but this file cannot compare, and which fails if that
+gap is ever empty for every builder at once -- because that would mean either the bound had
+collapsed or the tabulated domains had moved, and both are findings rather than good news.
+
+**Measure the margin over the whole domain, not at its top.** At the top degree `kappa` is by
+construction as large as it gets, so the bound is at its loosest there and a margin measured
+only there is misleading. Measured across every degree tested: the bound is between 130 and
+1800 times the observed difference at its tightest point, and between `1e6` and `5e6` times it
+at the top degrees. Reporting only the second number would suggest the bound asserts nothing;
+reporting only the first would suggest it is sharp. Both are in the test's docstring.
+
+### What this rule does not license
+
+A different but valid algorithm passing is not a failure of the bound. Measured: swapping
+`PartialPivLU` for `FullPivLU` in the C++ Gram projection moves the answer by `1.9e-11` at
+degree 10 and the parity tests accept it, correctly -- any backward-stable LU has to be
+admitted, since that is exactly what the bound claims. What the bound must still catch is a
+*wrong* answer, and it does: a `1e-6` relative perturbation of the Gram matrix is caught by all
+five bounded builders and by the margin test.
+
 ## The two corrections the infrastructure PR made, kept here because they generalize
 
 **The underflow floor.** `eta` per rounding, the unhalved smallest subnormal. Without it the

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -1,14 +1,14 @@
 # Backend parity: what a bound may claim, and in which frame
 
-**Status:** complete for the two ports that exist. Six rules, each with the failure that produced
+**Status:** complete for the three ports that exist. Eight rules, each with the failure that produced
 it, and three further module ports inherit them. The verdict on whether the parity harness
 generalized is now written, from the `quad` port's tests rather than predicted before them.
-**Date:** 2026-08-20, amended the same day after a deep review closed two open proofs, refuted a
-bound that was being evaluated in the wrong coordinate, and corrected a factor of two in the
-units.
-**Scope:** how the two backends are compared, and what a comparison is allowed to assert. Not
-which algorithm computes what, which is `design/quadrature_algorithms.md`, and not what may
-cross the boundary, which is `design/cross_backend_types.md`.
+**Date:** 2026-08-20, amended the same day after a deep review closed two open proofs,
+refuted a claim and tightened a bound. Amended again 2026-08-21 by the change-of-basis
+port: Rule 7 (a liveness guard belongs to the host it was measured on) and Rule 8 (a
+parity claim needs a bound that can say something), and again by that port's own deep
+review, which found Rule 8 overstating its boundary and one of its two margin figures
+invented. Both are corrected in place rather than edited away.
 
 **Validated against:** `proto/cpp` at `765d9b9`, plus the `quad` port on `feat/cpp-quad`.
 
@@ -271,11 +271,31 @@ domain. The two differ per builder and per dtype: for `bernstein_to_cardinal` in
 module accepts degrees to 26 and parity is claimable to 22; for `cardinal_to_bernstein` it
 accepts to 14 and parity reaches 9.
 
-That is not a weakening, and the reason is worth stating plainly, because the instinct is to
-read a smaller tested range as thinner coverage. **Above the accuracy domain the answer has no
-correct digits in either backend.** There is nothing left for a parity claim to be about: two
-implementations agreeing on a quantity that is entirely round-off is not evidence that the port
-is right, and two implementations disagreeing there is not evidence that it is wrong.
+**What that boundary is, stated carefully, because the first version of this rule overstated
+it.** It said "above the accuracy domain the answer has no correct digits in either backend",
+and that is false. Measured against the exact rational matrix, `bernstein_to_cardinal` in
+float64:
+
+| degree | `32 n kappa eps` | true relative error | correct digits | this rule |
+|---|---|---|---|---|
+| 22 | 0.95 | 2.4e-4 | 3.6 | included |
+| 23 | 3.79 | 5.8e-4 | **3.2** | excluded |
+| 26 (top of solvability) | 263 | 4.6e-2 | **1.3** | excluded |
+
+Three digits survive at the first excluded degree and one at the last. Worse for the claim, the
+backends *agree* there: at degree 23 they differ by 1.0e-3 against `kappa eps = 4.9e-3`, so a
+claim carrying `kappa eps` rather than the full constant would be non-vacuous and would pass.
+
+So the honest statement is narrower and is about the constant rather than about the
+mathematics. **The cut is where *this* bound, with *its* constant, stops being able to say
+anything** -- roughly `log10(constant * n)` digits above zero, about three here. Below that cut
+a passing test is evidence; above it the harness refuses the claim, correctly, because a bound
+larger than the values it compares admits any answer including zero.
+
+What follows for a reader is the part that matters: **the excluded degrees are not degrees where
+the port is unchecked because checking is meaningless. They are degrees where this bound is too
+loose to check, and a sharper bound would reach some of them.** That is a limitation to record,
+not a property to claim.
 
 Two obligations come with it.
 
@@ -287,10 +307,13 @@ collapsed or the tabulated domains had moved, and both are findings rather than 
 
 **Measure the margin over the whole domain, not at its top.** At the top degree `kappa` is by
 construction as large as it gets, so the bound is at its loosest there and a margin measured
-only there is misleading. Measured across every degree tested: the bound is between 130 and
-1800 times the observed difference at its tightest point, and between `1e6` and `5e6` times it
-at the top degrees. Reporting only the second number would suggest the bound asserts nothing;
-reporting only the first would suggest it is sharp. Both are in the test's docstring.
+only there is misleading. Measured across every degree tested, per builder in float64, the
+bound is between **130 and 1800** times the observed difference at its tightest point. At the
+top degrees it is far looser, and by an amount that varies over three orders of magnitude
+between builders rather than sitting in a narrow band -- an earlier version of this rule quoted
+"between 1e6 and 5e6" for it, which took the two largest and presented them as the range. Only
+the tightest-point figures are quoted here and in the test's docstring, because they are the
+ones that say whether the bound asserts anything.
 
 ### What this rule does not license
 

--- a/design/build_findings.md
+++ b/design/build_findings.md
@@ -97,7 +97,15 @@ Measured: **7.5 s cold** without build isolation, **9.3 s** with it, **2.5 s inc
 What makes it cheap:
 
 - a **persistent `build-dir`** in `pyproject.toml`;
-- **Eigen fetched only when the C++ tests are requested**, not on the pip path.
+- **Eigen fetched only when the C++ tests are requested**, not on the pip path. *No longer
+  true as of 2026-08-21*: the change-of-basis port takes Eigen as a dependency of the shipped
+  extension, so a cold editable install now pays its clone. Measured on this server, cold
+  `pip install -e . --no-build-isolation`: **7.56 s** without Eigen, **21.48 s** with it cloned
+  deep, **12.19 s** cloned shallow, with the build tree at 6.4 MB, 145 MB and 50 MB
+  respectively. The incremental rebuild is unchanged at 2.96 s, so the day-to-day cost is nil
+  and the whole of it lands on a cold worktree. `GIT_SHALLOW TRUE` is therefore on for Eigen and
+  off for mdspan, which is a measurement rather than a preference; the shallow fetch was
+  verified to check out the pinned SHA rather than falling back to a branch tip.
 
 Three things to know before setting the same flow up elsewhere:
 

--- a/design/cross_backend_types.md
+++ b/design/cross_backend_types.md
@@ -210,3 +210,44 @@ the answer.
    older pantr cannot unpickle what a newer one sends. That is a packaging consequence of
    this note's "Python owns the type" rule rather than of anything in it, but it is the kind
    of thing that surfaces as an MPI failure far from its cause.
+
+
+## What the third port added, and what it only confirmed
+
+`pantr.change_basis` was the first module ported after the two catalogue rules were written, so
+it is the first evidence about them that is not the case they were derived from.
+
+**Both rules held without amendment.** No change_basis consumer needs two kernels in one call,
+so the catalogue is eight bare callables over one `_select` rather than a record -- and the
+reason is sharper than "it happens not to need one". Its five inverse builders invert their
+forward matrix *inside* the kernel, on one side of the boundary. Written the other way, as the
+Python module was before the port, `compute_cardinal_to_bernstein_1d` would call
+`compute_bernstein_to_cardinal_1d` and then solve, which under a mixed backend composes a
+Python forward matrix with a C++ solve into a result that is neither backend and that no parity
+claim covers. So the rule about records and the rule about where an inverse is taken are the
+same rule seen twice.
+
+Every public builder here takes `out`, so by the mirroring rule every kernel fills the caller's
+buffer, which is `pantr.basis`'s convention rather than `pantr.quad`'s. That followed from the
+public surface without a judgement call, which is what the rule was for.
+
+**One thing the rules did not cover, and it is about what a kernel may compute rather than what
+it may return.** `compute_lagrange_to_bernstein_1d` picks nodes from one of five families, and
+`pantr._backend` records that two of those five are deliberately never dispatched. A kernel that
+resolved the variant itself would therefore have to either contradict that decision or carry a
+second implementation of two quadrature rules. So the nodes are an argument: Layer 2 resolves the
+variant on the Python side and passes an array, and `LagrangeVariant` never crosses.
+
+That generalises past this module. **A kernel takes as an argument anything whose own dispatch
+decision is not its to make.** The type rule already said the enum stays Python-owned; what is
+new is that the *values it selects* have to cross as data too, because the selection is a policy
+another module owns.
+
+**The visible consequence, which a reader of an A/B measurement needs.** Since the nodes cross
+rather than being recomputed, whatever the node rule does is inside the comparison. Measured over
+the five families: four hand both backends identical arrays in both formats, and `CHEBYSHEV_2ND`
+in float32 differs by exactly one unit of roundoff, because it resolves through
+`get_modified_chebyshev_nodes_1d`, which dispatches. The change-of-basis matrix built on it
+therefore cannot be bit-identical, and `tests/parity/test_change_basis.py` claims a bound there
+instead of bitwise agreement -- the node gap times `n`, since a Bernstein derivative is bounded
+by the degree.

--- a/design/large_data_fitting.md
+++ b/design/large_data_fitting.md
@@ -170,7 +170,9 @@ above, because a sparse Cholesky does exploit the band.
 > headers. The decision stands; the argument for it did not. Eigen became a real dependency of
 > the product on 2026-08-21, taken deliberately by the change-of-basis port, whose builders need
 > a dense solve and whose sibling `bezier` needs a truncated SVD pseudo-inverse. The measured
-> cost is in `cmake/PantrDependencies.cmake`. What it leaves on the table is the sparse machinery's index
+> cost is in `cmake/PantrDependencies.cmake`.
+
+What it leaves on the table is the sparse machinery's index
 indirection, which at bandwidth 7 and 262144 right-hand sides is not negligible but is not
 an order of magnitude either. The escape, if a profile asks for it, is a hand-rolled banded
 Cholesky of roughly 40 lines on the 1D path only: contained, and no API change.

--- a/design/large_data_fitting.md
+++ b/design/large_data_fitting.md
@@ -160,9 +160,17 @@ the dense path being the *only* path, which is the situation today.
 
 **Decided (2026-08-19): use Eigen's solvers.** Concretely `Eigen::SparseMatrix` with
 `SimplicialLDLT`. Eigen has no dense *banded* solver, so the banded systems go through the
-sparse side, which handles them correctly as a special case. This is zero new dependency
-(Eigen is already required) and it captures most of the 20x to 64x above, because a sparse
-Cholesky does exploit the band. What it leaves on the table is the sparse machinery's index
+sparse side, which handles them correctly as a special case. It captures most of the 20x to 64x
+above, because a sparse Cholesky does exploit the band.
+
+> **Correction, 2026-08-21.** This paragraph originally justified the choice with "this is zero
+> new dependency (Eigen is already required)", and that was false when written. Eigen was
+> fetched only under `PANTR_BUILD_TESTS`, which `pyproject.toml` sets to `OFF`, so a
+> `pip install` never cloned it and nothing in the shipped extension included one of its
+> headers. The decision stands; the argument for it did not. Eigen became a real dependency of
+> the product on 2026-08-21, taken deliberately by the change-of-basis port, whose builders need
+> a dense solve and whose sibling `bezier` needs a truncated SVD pseudo-inverse. The measured
+> cost is in `cmake/PantrDependencies.cmake`. What it leaves on the table is the sparse machinery's index
 indirection, which at bandwidth 7 and 262144 right-hand sides is not negligible but is not
 an order of magnitude either. The escape, if a profile asks for it, is a hand-rolled banded
 Cholesky of roughly 40 lines on the 1D path only: contained, and no API change.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,7 +34,8 @@ user-facing, and the ports change what it affects.
   Legendre tabulations they rest on. `PANTR_BACKEND=cpp` now reaches
   `pantr.basis.tabulate_bernstein_1d`, `pantr.basis.tabulate_legendre_1d` and every
   `pantr.change_basis.compute_*_1d`.
-  **Two of the eight are bit-identical between the backends and six are not**, and the
+  **One of the eight is bit-identical between the backends unconditionally and one more is in
+  every case but a single node family; the other six are not**, and the
   difference is structural rather than a quality gap: the six solve a linear system, and LAPACK
   and Eigen sum the same terms in different orders. The disagreement is bounded by the matrix's
   condition number, which for these bases is tabulated exactly in the module's own
@@ -49,9 +50,6 @@ user-facing, and the ports change what it affects.
   and neither is a thing to hand-roll. A cold `pip install -e .` goes from 7.56 s to 12.19 s on
   the development server and the build tree from 6.4 MB to 50 MB; an incremental rebuild is
   unchanged. Nothing about the installed package's Python dependencies changes.
-- `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue
-  and its Python kernels have somewhere to live. **Nothing moved on the public surface**: every
-  name it exported is still importable from `pantr.change_basis`, and so is every private one.
 
 - `pantr.quad` no longer imports `scipy`. The Lambert W function that sets the tanh-sinh step
   size is solved in the library, by Halley's method on `w e^w = x`, and Gauss-Legendre is
@@ -60,6 +58,13 @@ user-facing, and the ports change what it affects.
   against, and `leggauss` has no operation-for-operation transliteration.
 
 ### Changed
+- `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue
+  and its Python kernels have somewhere to live. **Every pantr name importable from
+  `pantr.change_basis` before still is**, public and private alike, and a test now pins that
+  list rather than a docstring asserting it. The only names that stopped being reachable are
+  the stdlib and typing ones the flat module happened to bind (`np`, `comb`, `functools` and
+  the like).
+
 - **Breaking, for anyone who set the variable.** `PANTR_BACKEND=numba` is now
   `PANTR_BACKEND=python`, and the old spelling raises rather than being accepted as an alias.
   The axis names the implementation *family*, and "Numba" was already the wrong name for it:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-The dual-backend prototype on the `proto/cpp` branch. Two pull requests so far: the
-infrastructure, and the `quad` port. The infrastructure landed without a changelog entry, so
-this section covers both -- the environment variable it introduced is user-facing, and the
-`quad` port changes the values it accepts.
+The dual-backend prototype on the `proto/cpp` branch. Three module pull requests so far: the
+infrastructure, the `quad` port and the `change_basis` port. The infrastructure landed without a
+changelog entry, so this section covers all of them -- the environment variable it introduced is
+user-facing, and the ports change what it affects.
 
 ### Added
 - **A second implementation of a kernel can now be selected at run time.** `PANTR_BACKEND`
@@ -30,6 +30,29 @@ this section covers both -- the environment variable it introduced is user-facin
   degree its entry-level figure falls below 1. `scripts/bench_quad.py` and
   `scripts/bench_parity.py` report the numbers and say which part of each is the port and which
   is the call; read them rather than quoting a range from here.
+- A C++ implementation of all eight `pantr.change_basis` builders, and of the Bernstein and
+  Legendre tabulations they rest on. `PANTR_BACKEND=cpp` now reaches
+  `pantr.basis.tabulate_bernstein_1d`, `pantr.basis.tabulate_legendre_1d` and every
+  `pantr.change_basis.compute_*_1d`.
+  **Two of the eight are bit-identical between the backends and six are not**, and the
+  difference is structural rather than a quality gap: the six solve a linear system, and LAPACK
+  and Eigen sum the same terms in different orders. The disagreement is bounded by the matrix's
+  condition number, which for these bases is tabulated exactly in the module's own
+  documentation, and it is only meaningful over the degrees where the answer has correct digits
+  in the first place -- a narrower range than the degrees the builders accept.
+  One case is worth knowing about before reading an A/B result:
+  `compute_lagrange_to_bernstein_1d` with `CHEBYSHEV_2ND` nodes in float32 is the one place
+  where the two backends start from *different nodes*, by one unit of roundoff, because that
+  node family resolves through a quadrature rule that itself dispatches.
+- **Eigen is now a build dependency of the wheel**, where before it was fetched only for the C++
+  tests. `pantr.change_basis` needs a dense solve and `pantr.bezier` will need a truncated SVD,
+  and neither is a thing to hand-roll. A cold `pip install -e .` goes from 7.56 s to 12.19 s on
+  the development server and the build tree from 6.4 MB to 50 MB; an incremental rebuild is
+  unchanged. Nothing about the installed package's Python dependencies changes.
+- `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue
+  and its Python kernels have somewhere to live. **Nothing moved on the public surface**: every
+  name it exported is still importable from `pantr.change_basis`, and so is every private one.
+
 - `pantr.quad` no longer imports `scipy`. The Lambert W function that sets the tanh-sinh step
   size is solved in the library, by Halley's method on `w e^w = x`, and Gauss-Legendre is
   computed by Newton on the Legendre recurrence rather than through `numpy.polynomial.leggauss`.

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,26 @@
+# Third-party licences shipped in the pantr wheel
+
+`pantr` itself is MIT; `LICENSE` at the repository root is its text.
+
+**Since 2026-08-21 the compiled extension statically contains Eigen**, which is
+primarily MPL-2.0. Before that date Eigen was fetched only to build the C++ tests
+and no Eigen code reached a wheel, which is why this directory did not exist. The
+change-of-basis port needs a dense solve (`Eigen::PartialPivLU`) and `bezier` will
+need a truncated SVD, so the header is now included by
+`cpp/include/pantr/change_basis/change_basis.hpp` and its object code is linked in:
+measured at roughly 115 KB, about 46% of the extension's sized symbols.
+
+MPL-2.0 section 3.2 requires the Executable Form to carry the licence and to tell
+recipients how to obtain the Source Code Form. `eigen/` holds Eigen's own licence
+files, copied verbatim from the pinned revision, and `pyproject.toml` ships this
+directory in the wheel.
+
+**Source for the bundled Eigen.** <https://gitlab.com/libeigen/eigen> at commit
+`bc3b39870ecb690a623a3f49149a358b95c5781d`, tag 5.0.1, which is the revision
+`cmake/PantrDependencies.cmake` pins.
+
+**Open, and not settled here.** Whether `pyproject.toml`'s `license = "MIT"` should
+change, or whether shipping these files alongside an MIT declaration is the right
+expression of "MIT project, MPL-2.0 dependency statically linked", is a question for
+whoever owns licensing. Shipping the licence text is required either way, so it is
+done; the declaration is left alone deliberately rather than by oversight.

--- a/licenses/eigen/COPYING.APACHE
+++ b/licenses/eigen/COPYING.APACHE
@@ -1,0 +1,203 @@
+/*
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/

--- a/licenses/eigen/COPYING.BSD
+++ b/licenses/eigen/COPYING.BSD
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2011, Intel Corporation. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of Intel Corporation nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/

--- a/licenses/eigen/COPYING.MINPACK
+++ b/licenses/eigen/COPYING.MINPACK
@@ -1,0 +1,51 @@
+Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+3. The end-user documentation included with the
+redistribution, if any, must include the following
+acknowledgment:
+
+   "This product includes software developed by the
+   University of Chicago, as Operator of Argonne National
+   Laboratory.
+
+Alternately, this acknowledgment may appear in the software
+itself, if and wherever such third-party acknowledgments
+normally appear.
+
+4. WARRANTY DISCLAIMER. THE SOFTWARE IS SUPPLIED "AS IS"
+WITHOUT WARRANTY OF ANY KIND. THE COPYRIGHT HOLDER, THE
+UNITED STATES, THE UNITED STATES DEPARTMENT OF ENERGY, AND
+THEIR EMPLOYEES: (1) DISCLAIM ANY WARRANTIES, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE
+OR NON-INFRINGEMENT, (2) DO NOT ASSUME ANY LEGAL LIABILITY
+OR RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR
+USEFULNESS OF THE SOFTWARE, (3) DO NOT REPRESENT THAT USE OF
+THE SOFTWARE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS, (4)
+DO NOT WARRANT THAT THE SOFTWARE WILL FUNCTION
+UNINTERRUPTED, THAT IT IS ERROR-FREE OR THAT ANY ERRORS WILL
+BE CORRECTED.
+
+5. LIMITATION OF LIABILITY. IN NO EVENT WILL THE COPYRIGHT
+HOLDER, THE UNITED STATES, THE UNITED STATES DEPARTMENT OF
+ENERGY, OR THEIR EMPLOYEES: BE LIABLE FOR ANY INDIRECT,
+INCIDENTAL, CONSEQUENTIAL, SPECIAL OR PUNITIVE DAMAGES OF
+ANY KIND OR NATURE, INCLUDING BUT NOT LIMITED TO LOSS OF
+PROFITS OR LOSS OF DATA, FOR ANY REASON WHATSOEVER, WHETHER
+SUCH LIABILITY IS ASSERTED ON THE BASIS OF CONTRACT, TORT
+(INCLUDING NEGLIGENCE OR STRICT LIABILITY), OR OTHERWISE,
+EVEN IF ANY OF SAID PARTIES HAS BEEN WARNED OF THE
+POSSIBILITY OF SUCH LOSS OR DAMAGES.

--- a/licenses/eigen/COPYING.MPL2
+++ b/licenses/eigen/COPYING.MPL2
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/licenses/eigen/COPYING.README
+++ b/licenses/eigen/COPYING.README
@@ -1,0 +1,6 @@
+Eigen is primarily MPL2 licensed. See COPYING.MPL2 and these links:
+  http://www.mozilla.org/MPL/2.0/
+  http://www.mozilla.org/MPL/2.0/FAQ.html
+
+Some files contain third-party code under BSD or other MPL2-compatible licenses,
+whence the other COPYING.* files here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ description = "Polynomial And NURBS Toolkit"
 readme = "README.md"
 requires-python = ">=3.11, <3.15"
 license = "MIT"
-license-files = ["LICENSE"]
+# `licenses/` carries Eigen's own licence files. The extension statically
+# contains Eigen as of 2026-08-21 and Eigen is MPL-2.0, whose section 3.2
+# requires the Executable Form to carry the licence; see licenses/README.md.
+license-files = ["LICENSE", "licenses/README.md", "licenses/eigen/*"]
 authors = [{ name = "Pablo Antolin", email = "pablo.antolin@epfl.ch" }]
 keywords = [
   "nurbs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,10 @@ wheel.packages = ["src/pantr"]
 cmake.version = ">=3.25"
 cmake.build-type = "Release"
 # Out of the Python build: the C++ tests and the benchmark are built by
-# CMakePresets, not by pip. Nothing that a `pip install` produces should depend
-# on Eigen having been fetched.
+# CMakePresets, not by pip. Eigen is no longer in that category -- the shipped
+# extension includes it (see cmake/PantrDependencies.cmake), so a `pip install`
+# does fetch it, which is what makes the persistent build-dir below load-bearing
+# rather than merely nice.
 cmake.define.PANTR_BUILD_PYTHON = "ON"
 cmake.define.PANTR_BUILD_TESTS = "OFF"
 cmake.define.PANTR_BUILD_BENCHMARK = "OFF"

--- a/reviews/347-2026-08-21.md
+++ b/reviews/347-2026-08-21.md
@@ -1,0 +1,263 @@
+# Deep review: PR #347, the change_basis port
+
+Target: `feat/cpp-change-basis` against `proto/cpp`, at `0275575`. Nine commits, ~3900 lines.
+Date: 2026-08-21.
+
+## Verdict
+
+**Do not merge as it stands.** Not because of the ported computation, which holds up under every
+check that was run, but because the PR's *claims* are false in several places, and three of those
+places are documents the next three ports inherit.
+
+The shape of the result is worth stating before the list, because it is the useful part:
+
+- **The C++ is right.** Both tabulation kernels are bit-identical to their Numba oracles in both
+  dtypes. The refactor was verified builder by builder to be behaviour-identical to the
+  pre-port module, down to exception messages. The degree-domain derivation survives every number
+  checked against it.
+- **The single claim I most expected to break did not.** The product of two condition numbers for
+  `cardinal_to_bernstein` was attacked directly: `kappa(A)` alone is exceeded from degree 5, the
+  product is never exceeded at any degree, and the apparent asymmetry with `cardinal_to_legendre`
+  is not one (both are `kappa(A) kappa(G_stage1)`; the Legendre case degenerates because
+  `kappa(G_leg) = 1`).
+- **The one constant the PR admitted was unproved is now measured.** Two lenses independently
+  computed the LU growth factor over every matrix the port feeds Eigen: in-domain
+  `rho = max|U|/max|A| <= 1.155` and `|| |L||U| ||_inf / ||A||_inf <= 3.73`, the latter in exact
+  rational arithmetic. The allowance of 8 stands with a factor of 2.1 to 6.9 in hand.
+- **What failed, repeatedly, is the prose.** A fabricated citation, a bound contradicting a proved
+  result four directories away, a theorem cited that is not the theorem used, and three separate
+  completeness claims that are false.
+
+## Findings
+
+### Critical
+
+**C1-1 — three citations to a test file that has never existed, and the gap it papers over.**
+`tests/parity/test_change_basis.py:31`, `:393` and `cpp/include/pantr/basis/bernstein.hpp:60` all
+cite `tests/parity/test_basis_bernstein.py`. `git log --all` shows it on no branch. One of the
+three sits inside a `why=` string that is printed verbatim in every parity failure message, so a
+reader chasing a failure is sent to a file that does not exist.
+
+It is also the sole cited evidence for a load-bearing step of the bound ("the tabulations are
+bit-identical, so they contribute nothing"). **There is no parity test for either new tabulation
+anywhere in the suite.** The C++ unit tests check properties, not parity. The bit-exactness is
+true today, measured, but nothing pins it: if the Legendre tabulation stopped being bit-identical,
+nothing would fail and the change-of-basis bound would silently lose a term.
+
+**C1-2 — Rule 8's central claim is false, and Rule 8 is the precedent three ports inherit.**
+`design/backend_parity.md` states: *"Above the accuracy domain the answer has no correct digits in
+either backend, so there is nothing for a parity claim to be about."* Measured against the exact
+rational matrix, `bernstein_to_cardinal`/float64:
+
+| degree | `32 n kappa eps` | true relative error | correct digits | Rule 8 |
+|---|---|---|---|---|
+| 22 | 0.95 | 2.4e-4 | 3.6 | included |
+| 23 | 3.79 | 5.8e-4 | **3.2** | excluded |
+| 26 | 263 | 4.6e-2 | **1.3** | excluded |
+
+False at every excluded degree, including the top of solvability. Worse, the backends *do* agree
+there: at degree 23 they differ by 1.0e-3 against `kappa eps = 4.9e-3`, so a claim carrying
+`kappa eps` rather than `32 n kappa eps` would be non-vacuous and would pass. The **practice** is
+right; the **prose** converts a limitation of the chosen constant into a claimed property of the
+mathematics.
+
+**C1-3 — the "nothing moved on the surface" claim is false, in two places, one user-facing.**
+`src/pantr/change_basis/__init__.py` and `docs/changelog.md` both assert every previously
+importable name still is. Nine real pantr names are no longer reachable from
+`pantr.change_basis`: `LagrangeVariant`, `_get_lagrange_points`, `_allocate_or_validate_out`,
+`_validate_float_dtype`, `backend_keyed_cache`, `get_gauss_legendre_1d`, `tabulate_bernstein_1d`,
+`tabulate_cardinal_bspline_1d`, `tabulate_legendre_1d`. Three are private helpers of exactly the
+class `CLAUDE.md` warns the unseen downstream consumer may import. `LagrangeVariant` is the
+plausible one: it is a public enum and the declared type of `lagrange_variant` in two of the eight
+public functions in that very module.
+
+**C1-4 — the wheel now ships compiled MPL-2.0 code and declares only MIT.**
+`pyproject.toml:13-14` is `license = "MIT"`, `license-files = ["LICENSE"]`. The installed
+extension contains 75 Eigen symbols and roughly 115 KB of Eigen code. Eigen is MPL-2.0 (plus
+Apache-2.0 and BSD notices inside `Eigen/src/Core`), and MPL-2.0 section 3.2 requires the
+Executable Form to carry the licence and to tell recipients how to obtain the Source Code Form.
+Before this PR Eigen was never in the wheel. This is a reading of the licence and not legal
+advice, and it is the only finding here with a consequence outside the repository.
+
+### Important
+
+**I1-1 — five bindings silently accept transposed `nodes`/`weights`.** `nb::kw_only()` sits before
+`out` and not before the pair, so `bernstein_to_cardinal_1d(3, weights, nodes, out=m)` type-checks,
+runs, and returns a different finite matrix with no error. Demonstrated on all five. The comment
+one line above the `m.def` calls names this exact risk. `cpp/bindings/quad.cpp` already gets the
+identical two-array risk right by putting `kw_only()` before both.
+
+**I1-2 — "No explicit inverse is formed" is false, and the guarantee it implies is one-sided.**
+`np.linalg.solve(A, eye(n))` is Du Croz and Higham's *Method A* for matrix inversion (IMA J.
+Numer. Anal. 12 (1992) 1-19, section 3.1), and in numpy 2.4.6 it is bitwise identical to
+`np.linalg.inv`. `cpp/include/pantr/change_basis/change_basis.hpp:120-122` goes further and says a
+matrix-RHS solve "is the same thing" as an inverse, which is precisely the distinction that
+literature exists to draw. Method A bounds the **right** residual and says nothing about the left.
+Measured on `legendre_to_cardinal`/`cardinal_to_legendre`, float64:
+
+| degree | `‖AX−I‖_inf` | `‖XA−I‖_inf` | ratio |
+|---|---|---|---|
+| 6 | 2.8e-15 | 4.8e-13 | 1.7e2 |
+| 10 | 6.3e-14 | 8.9e-8 | 1.4e6 |
+| 12 (accepted limit) | 2.7e-13 | **1.2e-4** | **4.6e8** |
+
+The docstring examples exhibit only `A @ B ≈ I`, the guaranteed direction, and nowhere say that is
+why.
+
+**I1-3 — the cited theorem is not the theorem used.** The bound cites Higham ASNA 2nd ed. Thm 9.4,
+which is componentwise and pivoting-agnostic. The normwise partial-pivoting form actually quoted is
+Thm 9.5, which carries an `n^2` the derivation drops: read literally the citation yields `3 n^3 rho u`,
+i.e. 2.8e4 at n = 21 against the file's 84. The number is still reachable through Thm 9.4
+componentwise with the allowance defined as `R = ‖|L||U|‖_inf/‖A‖_inf` — but that is not "the LU
+growth factor" the file names, and `R` can exceed `rho` by up to `n`. Measured worst `R = 3.43`
+against an allowance of 8, so the bound survives by a route the file does not state.
+
+**I1-4 — `_ROUNDINGS_PER_BACKEND = 4` undercounts.** `_gram_projection` forms **two** contractions
+of length `n_quad`, one for `G` and one for `C`, and **both** are amplified by `kappa` in the
+forward error. The derivation counts them as one contribution. The correct shape is `2 + 3 rho`.
+
+**I1-5 — `_CONSTANT = 32` is not degree-invariant, and the Legendre builders are where it bites.**
+For a non-negative basis (Bernstein, all Lagrange families) the Gram cancellation factor
+`c_G = ‖|B|^T W |B|‖_inf / ‖G‖_inf` is exactly 1. For the orthonormal Legendre basis it is not:
+the Gram is the identity by exact quadrature, so every off-diagonal zero is a *cancelled* sum, and
+`c_G` grows like `0.88 n` (measured 7.95 at degree 8, 18.34 at 20, 28.65 at 32). Since
+`kappa(G_leg) = 1`, nothing absorbs it. The coded 32 stops covering its own derivation near degree
+30, and the tested cap of 20 is documented as a runtime convenience rather than a limit. Margin at
+the cap: 1.35x, not the 4x the `rho <= 8` story implies. Independently, a second lens ran both
+backends to degree 88 and found no break, so the bound is *true* well past where its derivation
+stops supporting it.
+
+**I1-6 — the C++ test sizes its tolerance with the wrong condition number.**
+`cpp/tests/test_change_basis.cpp` uses `kappa_inf(M) = ‖M‖·‖M⁻¹‖` where the derivation needs the
+condition number of the matrix that builder's solve used. Measured at degree 8: 3.8e8x too large
+for `legendre_to_cardinal` (whose true `kappa` is 1), and **3.4e4x too small** for
+`cardinal_to_bernstein`, which is a latent false failure rather than merely a dormant test. At
+degree 8 the `legendre_to_cardinal` claim compares a residual of 1.1e-16 against a tolerance of
+6.8e-7, and 20 of `cardinal_to_bernstein`'s 45 compared elements have a tolerance at least as large
+as the value compared. The file's header calls this "the identity that defines each matrix... it
+cannot pass this one and be wrong". At degrees 5 and 8 it can.
+
+**I1-7 — `recurrence_bound = 2^degree * eps` contradicts a PROVED result in the file this PR
+amends.** `design/backend_parity.md` Rule 4 records, as PROVED both halves, that the error growth
+of the Legendre three-term recurrence is `Theta(n^2)` with closed form
+`C(n, ±1) = (7/4)n^2 + (9/4)n − 4H_n`. `cpp/tests/test_legendre.cpp:56` derives an exponential
+bound from scratch. Measured observed/eps at degrees 4, 8, 16, 32, 64: 3.5, 8.1, 11.6, 23.1, 71.2 —
+plainly polynomial. In `endpoint_values_match_their_closed_form` the margin degrades from 0.22 at
+i=2 to 0.0023 at i=12, diverging exponentially. **Caveat the reviewing lens glossed and this
+review does not:** Rule 4 is for `P_n` on `[-1,1]`; the kernel is the orthonormal shifted family on
+`[0,1]`. The order transfers; the constant `7/4` must be re-derived, not copied.
+
+**I1-8 — the Python kernels declare "no validation performed" and call the validating Layer 1
+surface.** `_change_basis_core.py` imports `tabulate_bernstein_1d` and siblings from `pantr.basis`
+— the public functions — while its C++ twin calls the Layer 3 kernels. So the docstring contract is
+false (these kernels do raise on a bad dtype, a 2D node array, a negative degree), the two halves
+of one catalogue entry are not peers, and it costs: measured 8 us/call against 1.3 us for the raw
+serial kernel, about 6x, paid twice inside every inverse builder. Two lenses reached this
+independently and the second measured it. The fix is the imports, not the docstring; it would also
+remove the `use_backend(Backend.PYTHON)` pin.
+
+**I1-9 — the liveness gate never exercises a non-trivial condition number.**
+`test_the_bound_is_approached_but_not_by_orders_of_magnitude` claims it would fail "if the bounds
+all go vacuous, which is what a wrong kappa would do". Its global maximum is pinned at
+`legendre_to_cardinal`/float64 at degree 2, where `kappa` is the hard-wired constant 1 and n = 3.
+A wrong `kappa` is exactly what it cannot detect. Separately, `bernstein_to_lagrange` is absent
+from `_SOLVING_BUILDERS`, so neither that gate nor `test_the_excluded_degrees_are_named` covers it.
+
+### Recommended
+
+- **R1-1** The `>= 1e-4` in the margin test is a liveness guard and is not gated by
+  `demand_the_reference_host`, which is the Rule 7 violation this PR's own new rule sits next to.
+  Two sibling parity files gate theirs.
+- **R1-2** `bernstein_to_cardinal_1d` is the only one of eight C++ headers that omits its degree
+  domain; it has one (`float32=12, float64=26`). The other seven are correct.
+- **R1-3** Nothing pins the twelve private re-exports. Fifteen lines of test closes the contract
+  `CLAUDE.md` says CI cannot see broken.
+- **R1-4** Nothing exercises the ten new bindings' validation from Python, though the pre-existing
+  binding has exactly that coverage in `tests/parity/test_basis_cardinal_bspline.py`. All ten behave
+  correctly today across 80 probes; nothing keeps them so.
+- **R1-5** The safe-degree formula in `bernstein.hpp` has an unstated hypothesis: **gradual
+  underflow**. Under FTZ/DAZ the answers are 19 and 5, not 20 and 6, and the failure is silent.
+  The repo's discipline check refuses `-ffast-math`, so it is guarded — but the guard is elsewhere
+  and the hypothesis is unwritten.
+- **R1-6** The correction blockquote inserted into `design/large_data_fitting.md` swallows two
+  sentences of the original paragraph by lazy continuation.
+- **R1-7** `design/backend_parity.md`'s header still says "Six rules" and is dated 2026-08-20.
+  There are eight; Rule 7 was added by #345 and Rule 8 by this PR, neither updating the header.
+- **R1-8** `design/adaptive_thb_approximation.md:148` still carries the "Eigen is already a
+  required dependency" premise that this PR corrected in the sibling note. One corrected copy and
+  one stale copy is worse than two stale ones.
+- **R1-9** Add `-DEIGEN_DONT_PARALLELIZE`. The shipped extension is single-threaded — verified at
+  the binary, no `libgomp`, no `pthread_create` — but only because nobody passes `-fopenmp`. With
+  it, Eigen's dense product is **not** bit-reproducible above n = 322 (13 ulps at n = 1024), while
+  `PartialPivLU` is bit-identical even when genuinely parallel. `change_basis` never exceeds
+  n = 53, so nothing bites today; the one-line define turns an accident into a build fact.
+- **R1-10** Record the *positive* Eigen finding next to the negative one in
+  `design/large_data_fitting.md`: `PartialPivLU` contains no epsilon, no tolerance and no
+  scale-dependent test at all — the only comparison on the path is `is_exactly_zero` — verified by
+  full source read and by an exact-power-of-two scale sweep from `2^-1000` to `2^+1000`. The
+  `computeFromTridiagonal` class of defect structurally cannot occur there. Two traps if a guard is
+  ever added: `rcond()` returns **NaN** on singular input, so `rcond() < tol` is false and silently
+  accepts; and a consistent singular system returns a finite result with zero residual and no flag.
+
+### Suggested
+
+- **S1-1** `basis_is_symmetric`'s reflected points are bit-identical to the originals (the sample
+  points are exact multiples of 1/64), so the second tabulation is dead and the test does not test
+  what its name says. Its tolerance is legal but its margin is exactly 1.0x, not the 2x the file
+  believes.
+- **S1-2** `docs/changelog.md`: "two of the eight are bit-identical" is corrected two sentences
+  later and should be stated correctly first; the package-split note belongs under Changed, not
+  Added, following the same file's own precedent for `pantr.quad`.
+- **S1-3** "one unit of roundoff" is right about magnitude and understates scope: CHEBYSHEV_2ND in
+  float32 differs at 19 of 28 sizes, up to 5 to 8 nodes at once.
+- **S1-4** "multiplying by a diagonal adds only exact zeros and produces the identical matrix" is
+  true as values and false as bits: `tabulate_legendre_1d` emits `-0.0` at the midpoint node for
+  every even degree >= 4, and the two routes then differ in 1 to 5 bit patterns.
+- **S1-5** `_change_basis_core.py` should be `_builders_core.py`, so the Layer 2 / Layer 3 pairing
+  is legible from the filename as it is in `pantr.quad`.
+- **S1-6** `check_degree` is duplicated verbatim between `basis.cpp` and `change_basis.cpp`.
+- **S1-7** `monomial_to_bernstein_1d` has no degree bound beyond fitting a C `int`; measured 6.3 GB
+  at n = 20001, and its internal triangle is `double` even for a float32 output.
+- **S1-8** The never-fall-back rule now exists in five copies, two of which are verbatim including
+  a docstring claiming to be the only one.
+
+### Unconfirmed
+
+- **U1-1** Whether `rho = 1` for the Bernstein Gram is provable under partial pivoting. Measured at
+  every degree to 200 in both dtypes; the SPD argument does not transfer because Eigen displaces up
+  to 49 of 51 rows. Likely route: total positivity of the Bernstein collocation matrix.
+- **U1-2** Why the parity difference is *flat* from degree 22 to 88 while the bound grows. Shared
+  rounding explains small, not constant.
+- **U1-3** Whether the left residual of Method A can be bounded here at all, or whether the measured
+  1.2e-4 is near worst case.
+
+## Where two lenses disagree
+
+**The growth allowance.** Both measured the same numbers. The tolerance audit recommends tightening
+`_GROWTH_ALLOWANCE` from 8 to 4 (the next power of two above the measured 3.73). The Eigen survey
+recommends keeping 8 and relabelling it measured, having quantified what tightening buys: **one
+degree on three of ten (builder, dtype) pairs**, because `kappa` grows geometrically and dominates.
+Not a tie to break by preference — the disagreement is about whether a tighter constant is worth a
+re-derivation, and the survey supplied the number that answers it.
+
+## Lens coverage
+
+Run and completed: tolerance audit, mathematical attack, architecture (adversarial), API and
+contracts, Eigen dependency survey, and three regional reviewers (bindings and stub, C++ tests,
+Python dispatch layer, design prose).
+
+**Did not complete, and their ground is therefore unreviewed:** a regional reviewer over the three
+new C++ kernel headers; the empirical math-verification investigator; and the test-coverage lens.
+Seven agents died on a session limit and five were relaunched; three were not. The C++ kernels
+themselves were read by the architect and the tolerance audit for their own purposes, but no lens
+reviewed them as code.
+
+**Deliberately skipped:** `numerics-shakedown`, because its protocol writes regression tests into
+the repo and this review was asked to report rather than apply.
+
+**A process fault worth recording.** Twelve agents were dispatched against one shared worktree, and
+several were authorised to mutate files transiently. They collided: one found another's injected
+mutation in place before it started reading, and a third reverted a committed fix mid-session. All
+tracked files were restored and verified against `HEAD`, but any measurement taken during those
+windows is suspect, and the decisive numbers in this document were re-run by the coordinator on a
+clean tree. The remedy is one worktree per mutating agent, not a stronger instruction.

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -67,16 +67,26 @@ shape rather than a capability.
 Scope
 -----
 
-Two modules are ported so far, and **selecting the C++ backend changes only what
-they cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is a
-run in which those kernels are C++ and everything else is unchanged.
+Three modules are ported so far, and **selecting the C++ backend changes only
+what they cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is
+a run in which those kernels are C++ and everything else is unchanged.
 
-* :mod:`pantr.basis` -- the cardinal B-spline tabulation of
-  :func:`pantr.basis.tabulate_cardinal_bspline_1d`, and nothing else in the
-  package.
+* :mod:`pantr.basis` -- three of the 1D tabulations: cardinal B-spline, Bernstein
+  and Legendre. The Lagrange tabulation and everything multidimensional stay on
+  Numba.
 * :mod:`pantr.quad` -- four of the seven rule generators: Gauss-Legendre, the
   trapezoidal rule, the modified Chebyshev nodes and tanh-sinh, together with the
   Lambert W solve the last of those needs.
+* :mod:`pantr.change_basis` -- all eight builders.
+
+**Reading a change_basis result needs one more fact than the others.** Its
+builders take their nodes from :mod:`pantr.quad`, so a call under
+``PANTR_BACKEND=cpp`` gets C++ nodes wherever that rule dispatches and numpy nodes
+where it does not. For :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d`
+that is visible in the answer: with ``CHEBYSHEV_2ND`` nodes in float32 the two
+backends start from arrays that differ by one unit of roundoff, so the matrix
+cannot be bit-identical however faithful the builder is.
+
 
 **Three public quadrature rules are deliberately never dispatched** and will
 report identical results under either backend:

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -325,3 +325,323 @@ def modified_chebyshev_nodes(
         ValueError: If ``n`` is less than 2, if ``n`` is too large to fit a C
             ``int``, or if ``out``'s length is not exactly ``n``.
     """
+
+def tabulate_bernstein_1d(
+    degree: int,
+    points: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Tabulate the Bernstein basis of ``degree`` at ``points``.
+
+    The **C++ half of Layer 2**, with the same contract, the same checks and the
+    same reasons as :func:`tabulate_cardinal_bspline_1d`; only the basis differs.
+
+    Args:
+        degree (int): Degree of the basis. Must be non-negative and must fit a
+            C ``int``.
+        points (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous
+            evaluation points.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(points.size, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If ``points`` or ``out`` has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, or if ``out``
+            does not have shape ``(points.size, degree + 1)``.
+    """
+
+def tabulate_legendre_1d(
+    degree: int,
+    points: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Tabulate the orthonormal shifted Legendre basis of ``degree`` at ``points``.
+
+    The **C++ half of Layer 2**, with the same contract, the same checks and the
+    same reasons as :func:`tabulate_cardinal_bspline_1d`; only the basis differs.
+
+    Args:
+        degree (int): Degree of the basis. Must be non-negative and must fit a
+            C ``int``.
+        points (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous
+            evaluation points.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(points.size, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If ``points`` or ``out`` has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, or if ``out``
+            does not have shape ``(points.size, degree + 1)``.
+    """
+
+def lagrange_to_bernstein_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the Lagrange-to-Bernstein matrix at the given Lagrange nodes.
+
+    The **C++ half of Layer 2** for the change-of-basis builders. The nodes are an
+    argument rather than a computation: two of the five node families
+    :class:`pantr.basis.LagrangeVariant` offers are ones
+    :mod:`pantr._backend` records as deliberately never dispatched, so resolving
+    a variant to nodes stays on the Python side.
+
+    What is checked, and where: dtype, rank, C-contiguity, device and writability
+    by nanobind's typed signature; a non-negative ``degree`` by that signature's
+    ``unsigned`` parameter; and ``nodes.size == degree + 1`` together with
+    ``out.shape == (degree + 1, degree + 1)`` in the function body.
+
+    Call :func:`pantr.change_basis.compute_lagrange_to_bernstein_1d` for the
+    ordinary path, which resolves the variant and allocates ``out`` for you.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous array of
+            exactly ``degree + 1`` Lagrange nodes.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes``
+            does not have length ``degree + 1``, or if ``out`` is not the square
+            matrix that degree calls for.
+    """
+
+def bernstein_to_lagrange_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the Bernstein-to-Lagrange matrix at the given Lagrange nodes.
+
+    The inverse of :func:`lagrange_to_bernstein_1d`, by one LU solve, with the
+    same contract and the same checks.
+
+    **The degree domain is not checked here.** Whether the solve is still defined
+    at a given ``(degree, dtype)`` is Layer 2's Python half to enforce, and
+    :func:`pantr.change_basis.compute_bernstein_to_lagrange_1d` does. Calling this
+    outside that domain returns whatever the LU produces.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous array of
+            exactly ``degree + 1`` Lagrange nodes.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes``
+            does not have length ``degree + 1``, or if ``out`` is not the square
+            matrix that degree calls for.
+    """
+
+def bernstein_to_cardinal_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    weights: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Project the cardinal B-spline basis onto the Bernstein basis.
+
+    The **C++ half of Layer 2**. ``nodes`` and ``weights`` are the Gauss-Legendre
+    rule on ``[0, 1]`` with ``degree + 1`` points, passed in rather than computed,
+    and they stay two arrays because that is the shape
+    :func:`pantr.quad.get_gauss_legendre_1d` returns.
+
+    Both are keyword-checkable only by position here, so ``out`` is keyword-only
+    for a sharper reason than elsewhere in this module: two same-dtype,
+    same-length arrays in a row make a transposed positional call type-check, run,
+    and return a plausible matrix.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous quadrature
+            nodes, exactly ``degree + 1`` of them.
+        weights (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous weights
+            of the same length.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes`` or
+            ``weights`` does not have length ``degree + 1``, or if ``out`` is not
+            the square matrix that degree calls for.
+    """
+
+def cardinal_to_bernstein_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    weights: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the cardinal-to-Bernstein matrix, the inverse of the projection.
+
+    Same contract and checks as :func:`bernstein_to_cardinal_1d`. **The degree
+    domain is not checked here**; see :func:`bernstein_to_lagrange_1d` for why.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous quadrature
+            nodes, exactly ``degree + 1`` of them.
+        weights (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous weights
+            of the same length.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes`` or
+            ``weights`` does not have length ``degree + 1``, or if ``out`` is not
+            the square matrix that degree calls for.
+    """
+
+def legendre_to_cardinal_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    weights: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Project the cardinal B-spline basis onto the orthonormal Legendre basis.
+
+    Same contract and checks as :func:`bernstein_to_cardinal_1d`. This one's Gram
+    matrix is the identity up to round-off, since the new basis is orthonormal and
+    the quadrature integrates every product formed exactly.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous quadrature
+            nodes, exactly ``degree + 1`` of them.
+        weights (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous weights
+            of the same length.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes`` or
+            ``weights`` does not have length ``degree + 1``, or if ``out`` is not
+            the square matrix that degree calls for.
+    """
+
+def cardinal_to_legendre_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    weights: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the cardinal-to-Legendre matrix, the inverse of the projection.
+
+    Same contract and checks as :func:`bernstein_to_cardinal_1d`. **The degree
+    domain is not checked here**; see :func:`bernstein_to_lagrange_1d` for why.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous quadrature
+            nodes, exactly ``degree + 1`` of them.
+        weights (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous weights
+            of the same length.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes`` or
+            ``weights`` does not have length ``degree + 1``, or if ``out`` is not
+            the square matrix that degree calls for.
+    """
+
+def cardinal_dual_legendre_coeffs_1d(
+    degree: int,
+    nodes: npt.NDArray[np.float32 | np.float64],
+    weights: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the cardinal-dual L2 functionals expressed in the Legendre basis.
+
+    The transpose of :func:`cardinal_to_legendre_1d`, with the same contract and
+    checks. **The degree domain is not checked here**; see
+    :func:`bernstein_to_lagrange_1d` for why.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        nodes (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous quadrature
+            nodes, exactly ``degree + 1`` of them.
+        weights (npt.NDArray[np.float32 | np.float64]): 1D, C-contiguous weights
+            of the same length.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If an array has the wrong dtype or rank, or is not
+            C-contiguous, or if ``degree`` is negative, or if ``out`` is passed
+            positionally.
+        ValueError: If ``degree`` is too large to fit a C ``int``, if ``nodes`` or
+            ``weights`` does not have length ``degree + 1``, or if ``out`` is not
+            the square matrix that degree calls for.
+    """
+
+def monomial_to_bernstein_1d(
+    degree: int,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Build the monomial-to-Bernstein matrix on ``[0, 1]``.
+
+    ``M[i, j] = C(i, j) / C(degree, j)`` for ``j <= i`` and zero above the
+    diagonal. The only builder that needs neither nodes nor a quadrature rule, and
+    the only one that carries no degree domain at all: it runs no solve.
+
+    The binomials are exact integers while they stay at or below ``2**53``, i.e.
+    through degree 56, so the entries below that are the correctly rounded values
+    of exact rationals. Past it both backends round and may round differently.
+
+    Args:
+        degree (int): Polynomial degree. Must be non-negative and fit a C ``int``.
+        out (npt.NDArray[np.float32 | np.float64]): 2D, C-contiguous, writable
+            output of shape ``(degree + 1, degree + 1)`` and matching dtype.
+            Keyword-only.
+
+    Raises:
+        TypeError: If ``out`` has the wrong dtype or rank, is not C-contiguous, or
+            is passed positionally, or if ``degree`` is negative.
+        ValueError: If ``degree`` is too large to fit a C ``int``, or if ``out`` is
+            not the square matrix that degree calls for.
+    """

--- a/src/pantr/basis/_basis_1D.py
+++ b/src/pantr/basis/_basis_1D.py
@@ -13,12 +13,14 @@ import numpy as np
 import numpy.typing as npt
 
 from .._numba_compat import wait_for_jit_warmup
-from ._basis_backend import _BasisCoreFunc, cardinal_bspline_core
+from ._basis_backend import (
+    _BasisCoreFunc,
+    bernstein_core,
+    cardinal_bspline_core,
+    legendre_core,
+)
 from ._basis_core import (
     _PARALLEL_MIN_NUM_PTS,
-    _tabulate_Bernstein_basis_1D_core,
-    _tabulate_Bernstein_basis_1D_serial_core,
-    _tabulate_Legendre_basis_1D_core,
 )
 from ._basis_lagrange import _tabulate_lagrange_basis_1D_core
 from ._basis_utils import (
@@ -133,12 +135,14 @@ def _tabulate_Bernstein_basis_1D_impl(
         ... )
         True
     """
+    # Dispatched, exactly as the cardinal B-spline tabulation above is. This is
+    # the one kernel whose two backends differ in SHAPE as well as in speed: the
+    # Python side carries a serial twin and the C++ side is serial throughout, so
+    # the record hands back two entries under PANTR_BACKEND=python and one under
+    # cpp, and the helper below reads whichever it was given.
+    kernels = bernstein_core()
     return _tabulate_basis_1D_impl_helper(
-        n,
-        t,
-        _tabulate_Bernstein_basis_1D_core,
-        out,
-        core_func_serial=_tabulate_Bernstein_basis_1D_serial_core,
+        n, t, kernels.parallel, out, core_func_serial=kernels.serial
     )
 
 
@@ -268,7 +272,10 @@ def _tabulate_Legendre_basis_1D_impl(
         ValueError: If degree is negative, or if `out` is provided and has incorrect
             shape or dtype.
     """
-    return _tabulate_basis_1D_impl_helper(n, t, _tabulate_Legendre_basis_1D_core, out)
+    kernels = legendre_core()
+    return _tabulate_basis_1D_impl_helper(
+        n, t, kernels.parallel, out, core_func_serial=kernels.serial
+    )
 
 
 __all__ = [

--- a/src/pantr/basis/_basis_backend.py
+++ b/src/pantr/basis/_basis_backend.py
@@ -24,13 +24,18 @@ keeps it that way.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
 
 from .._backend import Backend, active_backend, available_backends
-from ._basis_core import _tabulate_cardinal_Bspline_basis_1D_core
+from ._basis_core import (
+    _tabulate_Bernstein_basis_1D_core,
+    _tabulate_Bernstein_basis_1D_serial_core,
+    _tabulate_cardinal_Bspline_basis_1D_core,
+    _tabulate_Legendre_basis_1D_core,
+)
 
 _BasisCoreFunc = Callable[
     [np.int32, npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]],
@@ -140,3 +145,122 @@ def cardinal_bspline_core(backend: Backend | None = None) -> CoreKernels:
     if chosen not in available_backends():
         raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
     return CoreKernels(parallel=_cpp_cardinal_bspline_core)
+
+
+def _cpp_tabulation_core(binding_name: str) -> _BasisCoreFunc:
+    """Build an adapter from a binding name to the :data:`_BasisCoreFunc` signature.
+
+    The three tabulations share one adapter body because they share one contract:
+    same arguments, same output shape, same absorption of a non-contiguous ``out``.
+    Generating them keeps a single copy of that contract; three near-identical
+    functions is how one of them silently stops absorbing a strided ``out``.
+
+    Args:
+        binding_name (str): Attribute of :mod:`pantr._pantr_cpp` to call.
+
+    Returns:
+        _BasisCoreFunc: The adapter, callable as ``(n, t, out) -> None``.
+    """
+
+    def adapter(
+        n: np.int32,
+        t: npt.NDArray[np.float32 | np.float64],
+        out: npt.NDArray[np.float32 | np.float64],
+    ) -> None:
+        """Tabulate through the C++ binding, absorbing a non-contiguous ``out``.
+
+        Args:
+            n (np.int32): Degree of the basis. Assumed non-negative.
+            t (npt.NDArray[np.float32 | np.float64]): 1D evaluation points.
+            out (npt.NDArray[np.float32 | np.float64]): Output of shape
+                ``(t.size, n + 1)`` and matching dtype. Need not be contiguous.
+
+        Note:
+            No input validation is performed. The contract is
+            :func:`_cpp_cardinal_bspline_core`'s, in full, including why a
+            non-contiguous ``out`` is absorbed rather than refused.
+        """
+        from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+        kernel = getattr(_pantr_cpp, binding_name)
+        points = np.ascontiguousarray(t)
+        if out.flags["C_CONTIGUOUS"]:
+            kernel(int(n), points, out=out)
+            return
+
+        buffer = np.empty_like(out, order="C")
+        kernel(int(n), points, out=buffer)
+        out[...] = buffer
+
+    return adapter
+
+
+_cpp_bernstein_core: Final[_BasisCoreFunc] = _cpp_tabulation_core("tabulate_bernstein_1d")
+"""The Bernstein tabulation of the C++ backend."""
+
+_cpp_legendre_core: Final[_BasisCoreFunc] = _cpp_tabulation_core("tabulate_legendre_1d")
+"""The Legendre tabulation of the C++ backend."""
+
+
+def bernstein_core(backend: Backend | None = None) -> CoreKernels:
+    """Return the Bernstein tabulation kernels of the requested backend.
+
+    **This is the tabulation :class:`CoreKernels` was shaped for.** That class's
+    docstring named Bernstein as the one 1D basis carrying a serial twin and as
+    the obvious next port, and so it is: the Python backend returns both kernels
+    and :func:`pantr.basis._basis_1D._tabulate_basis_1D_impl_helper` picks between
+    them per call on ``_PARALLEL_MIN_NUM_PTS``.
+
+    The C++ backend returns no twin, and that is not an omission. Its kernel runs
+    on the calling thread at every batch size, so there is no parallel launch to
+    avoid below a threshold and nothing for a second entry to select.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        CoreKernels: The kernels, each callable as ``(n, t, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return CoreKernels(
+            parallel=_tabulate_Bernstein_basis_1D_core,
+            serial=_tabulate_Bernstein_basis_1D_serial_core,
+        )
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return CoreKernels(parallel=_cpp_bernstein_core)
+
+
+def legendre_core(backend: Backend | None = None) -> CoreKernels:
+    """Return the Legendre tabulation kernels of the requested backend.
+
+    Neither backend carries a serial twin, for the reasons
+    :func:`cardinal_bspline_core` gives.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+            Defaults to None.
+
+    Returns:
+        CoreKernels: The kernels, each callable as ``(n, t, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return CoreKernels(parallel=_tabulate_Legendre_basis_1D_core)
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return CoreKernels(parallel=_cpp_legendre_core)

--- a/src/pantr/change_basis/__init__.py
+++ b/src/pantr/change_basis/__init__.py
@@ -1,0 +1,87 @@
+r"""Change of basis operators for various polynomial bases in 1D.
+
+The eight ``compute_A_to_B_1d`` builders and the supported ``(degree, dtype)``
+domain they are defined on. Every builder returns the matrix :math:`M` with
+:math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`; the full
+account, including the derivation of the domain, is in
+:mod:`pantr.change_basis._builders`.
+
+Main exports:
+
+- :func:`compute_lagrange_to_bernstein_1d` and
+  :func:`compute_bernstein_to_lagrange_1d`
+- :func:`compute_bernstein_to_cardinal_1d` and
+  :func:`compute_cardinal_to_bernstein_1d`
+- :func:`compute_legendre_to_cardinal_1d` and
+  :func:`compute_cardinal_to_legendre_1d`
+- :func:`compute_cardinal_dual_legendre_coeffs_1d`
+- :func:`compute_monomial_to_bernstein_1d`
+
+This was a single module until the C++ port; it is a package for the reason
+:mod:`pantr.quad` is one, namely that a dispatched module needs somewhere to put
+its catalogue and its Python kernels without either importing the other in a
+circle. The public surface is unchanged: every name below was importable from
+``pantr.change_basis`` before and still is.
+"""
+
+# Re-exported unchanged from what was a single module, because `CLAUDE.md`
+# records that a downstream consumer this repository's CI cannot see imports
+# pantr's private symbols. Splitting `change_basis.py` into a package moves where
+# these are defined; it must not move where they are importable from.
+from ._builders import (
+    _BERNSTEIN_TO_CARDINAL_MAX_DEGREE as _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
+)
+from ._builders import (
+    _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE as _BERNSTEIN_TO_LAGRANGE_MAX_DEGREE,
+)
+from ._builders import (
+    _CARDINAL_TO_BERNSTEIN_MAX_DEGREE as _CARDINAL_TO_BERNSTEIN_MAX_DEGREE,
+)
+from ._builders import (
+    _CARDINAL_TO_LEGENDRE_MAX_DEGREE as _CARDINAL_TO_LEGENDRE_MAX_DEGREE,
+)
+from ._builders import (
+    _cached_cardinal_to_bernstein_matrix as _cached_cardinal_to_bernstein_matrix,
+)
+from ._builders import (
+    _cached_cardinal_to_legendre_matrix as _cached_cardinal_to_legendre_matrix,
+)
+from ._builders import (
+    _cached_lagrange_to_bernstein_matrix as _cached_lagrange_to_bernstein_matrix,
+)
+from ._builders import (
+    _cached_legendre_to_cardinal_matrix as _cached_legendre_to_cardinal_matrix,
+)
+from ._builders import (
+    _compute_change_basis_1D as _compute_change_basis_1D,
+)
+from ._builders import (
+    _DegreeLimit as _DegreeLimit,
+)
+from ._builders import (
+    _prepare_square_out as _prepare_square_out,
+)
+from ._builders import (
+    _validate_degree_in_domain as _validate_degree_in_domain,
+)
+from ._builders import (
+    compute_bernstein_to_cardinal_1d,
+    compute_bernstein_to_lagrange_1d,
+    compute_cardinal_dual_legendre_coeffs_1d,
+    compute_cardinal_to_bernstein_1d,
+    compute_cardinal_to_legendre_1d,
+    compute_lagrange_to_bernstein_1d,
+    compute_legendre_to_cardinal_1d,
+    compute_monomial_to_bernstein_1d,
+)
+
+__all__ = [
+    "compute_bernstein_to_cardinal_1d",
+    "compute_bernstein_to_lagrange_1d",
+    "compute_cardinal_dual_legendre_coeffs_1d",
+    "compute_cardinal_to_bernstein_1d",
+    "compute_cardinal_to_legendre_1d",
+    "compute_lagrange_to_bernstein_1d",
+    "compute_legendre_to_cardinal_1d",
+    "compute_monomial_to_bernstein_1d",
+]

--- a/src/pantr/change_basis/__init__.py
+++ b/src/pantr/change_basis/__init__.py
@@ -1,12 +1,75 @@
 r"""Change of basis operators for various polynomial bases in 1D.
 
-The eight ``compute_A_to_B_1d`` builders and the supported ``(degree, dtype)``
-domain they are defined on. Every builder returns the matrix :math:`M` with
-:math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`; the full
-account, including the derivation of the domain, is in
-:mod:`pantr.change_basis._builders`.
+This module provides functions to create transformation matrices between different
+polynomial bases including Lagrange, Bernstein, cardinal B-spline, and monomial
+bases.
 
-Main exports:
+Architecturally, this module serves as the **bridge between different basis types**,
+providing pure mathematical functions to compute the exact ``(degree+1, degree+1)``
+transformation matrices without tying the dense numerical quadrature logic directly
+into the core Spline space objects.
+
+Every public builder is named ``compute_A_to_B_1d`` and returns the matrix :math:`M` with
+:math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`.
+
+Supported ``(degree, dtype)`` domain
+------------------------------------
+
+Five of the builders recover their result from a linear solve, and a solve is only
+defined while the matrix it uses is not singular to working precision. Each of those five
+declares the largest degree it supports per dtype and raises :class:`ValueError` past it,
+naming the degree, the dtype and the supported range, rather than letting
+:class:`numpy.linalg.LinAlgError` or an overflow to infinity escape. The two builders that
+solve nothing carry no degree limit -- :func:`compute_lagrange_to_bernstein_1d`, which is
+a tabulation, and :func:`compute_legendre_to_cardinal_1d`, whose Gram matrix is the
+identity -- and :func:`compute_monomial_to_bernstein_1d` evaluates a closed form.
+
+The boundary is the largest degree :math:`p` at which the matrix :math:`M_p` the builder
+solves with satisfies
+
+.. math::
+
+    \kappa_\infty(M_p) \, \varepsilon < 1 ,
+
+with :math:`\varepsilon` the dtype's machine epsilon. Nothing is tuned here. The standard
+perturbation bound for a linear system puts the relative error of the computed solution at
+order :math:`\kappa_\infty(M) \varepsilon` (Higham, *Accuracy and Stability of Numerical
+Algorithms*, 2nd ed., SIAM 2002), so at :math:`\kappa_\infty \varepsilon = 1` that bound
+reaches 100% and stops asserting anything at all, which is also where :math:`M` becomes
+singular to working precision. It is the only threshold-free choice, and it is a
+*necessary* condition rather than a promise of accuracy: each builder's ``Warning:``
+section states the accuracy actually attained, and that degrades long before the boundary.
+
+Two consequences of the inequality are worth stating, because they are the failures the
+domain replaces. Inside the domain the inverse obeys
+:math:`\lVert M^{-1} \rVert_\infty = \kappa_\infty(M) / \lVert M \rVert_\infty <
+1 / (\varepsilon \lVert M \rVert_\infty)`, and :math:`\lVert M \rVert_\infty \ge 0.036`
+over every supported range here, so no entry of an inverse can exceed
+:math:`2.3 \times 10^{8}` in float32 -- thirty orders of magnitude below that format's
+overflow threshold. The exactly zero pivot :class:`numpy.linalg.LinAlgError` reports is not
+ruled out by that inequality -- the perturbation bound constrains the *exact* matrix, not the
+one pantr forms -- but it is not observed anywhere near the boundary either. Measured, both
+failures occur only in float32 and only in the cardinal-to-Bernstein and cardinal-to-Legendre
+directions: the first infinity is 26 degrees past the boundary in both, and the first
+``LinAlgError`` 29 and 32 degrees past.
+
+The :math:`\kappa_\infty` values behind the tabulated limits come from matrices rebuilt in
+exact rational (or 60-digit decimal) arithmetic from closed forms, rather than from the
+matrices pantr computes. That distinction is load-bearing for the Bernstein/cardinal pair,
+whose forward matrix is itself the output of a Gram solve and so is not exact: near the
+boundary, ``numpy.linalg.cond(M, numpy.inf)`` applied to the matrix pantr forms reports 8.6
+times too much at degree 13 and 4.9 times too little at degree 15, either of which moves the
+crossing. (The norm has to be named: :func:`numpy.linalg.cond` defaults to the 2-norm, and
+the criterion here is stated throughout in the infinity norm the perturbation bound uses.)
+Applied to the *exact* matrix the same call tracks :math:`\kappa_\infty` to five digits at
+:math:`1.1 \times 10^{16}` and still to four at :math:`3.7 \times 10^{17}`, so it is the
+matrix and not the estimator that is at fault. Rebuilding from closed forms also keeps the
+derivation independent of the code it grades. It runs as a test,
+``tests/test_change_basis_domain.py``, so the tabulated degrees are checked rather than
+asserted.
+
+Main exports
+------------
 
 - :func:`compute_lagrange_to_bernstein_1d` and
   :func:`compute_bernstein_to_lagrange_1d`
@@ -20,8 +83,8 @@ Main exports:
 This was a single module until the C++ port; it is a package for the reason
 :mod:`pantr.quad` is one, namely that a dispatched module needs somewhere to put
 its catalogue and its Python kernels without either importing the other in a
-circle. The public surface is unchanged: every name below was importable from
-``pantr.change_basis`` before and still is.
+circle. The public surface is unchanged, and so is the private one: every name
+that was importable from ``pantr.change_basis`` before still is.
 """
 
 # Re-exported unchanged from what was a single module, because `CLAUDE.md`

--- a/src/pantr/change_basis/__init__.py
+++ b/src/pantr/change_basis/__init__.py
@@ -83,14 +83,37 @@ Main exports
 This was a single module until the C++ port; it is a package for the reason
 :mod:`pantr.quad` is one, namely that a dispatched module needs somewhere to put
 its catalogue and its Python kernels without either importing the other in a
-circle. The public surface is unchanged, and so is the private one: every name
-that was importable from ``pantr.change_basis`` before still is.
+circle.
+
+**Every pantr name that was importable from ``pantr.change_basis`` before the
+split still is**, public and private alike, and a test pins the list. What is no
+longer reachable is the handful of stdlib and typing names the flat module
+happened to bind -- ``np``, ``npt``, ``comb``, ``functools``, ``Callable``,
+``Final``, ``Mapping``, ``MappingProxyType``, ``NamedTuple`` -- which nothing
+could reasonably have imported from here.
 """
 
 # Re-exported unchanged from what was a single module, because `CLAUDE.md`
 # records that a downstream consumer this repository's CI cannot see imports
 # pantr's private symbols. Splitting `change_basis.py` into a package moves where
 # these are defined; it must not move where they are importable from.
+#
+# The second block is names the flat module bound only because it imported them
+# for its own use. They were reachable as `pantr.change_basis.<name>` and are
+# again. `LagrangeVariant` is the one that matters -- it is a public enum and the
+# declared type of `lagrange_variant` in two of the eight functions below, so a
+# caller had every reason to import it from here. The rest are restored because
+# the cost is a line each and the alternative is guessing which of them the
+# downstream consumer uses. `tests/test_change_basis_reexports.py` pins the set.
+from .._backend import backend_keyed_cache as backend_keyed_cache
+from ..basis import LagrangeVariant as LagrangeVariant
+from ..basis import tabulate_bernstein_1d as tabulate_bernstein_1d
+from ..basis import tabulate_cardinal_bspline_1d as tabulate_cardinal_bspline_1d
+from ..basis import tabulate_legendre_1d as tabulate_legendre_1d
+from ..basis._basis_lagrange import _get_lagrange_points as _get_lagrange_points
+from ..basis._basis_utils import _allocate_or_validate_out as _allocate_or_validate_out
+from ..basis._basis_utils import _validate_float_dtype as _validate_float_dtype
+from ..quad import get_gauss_legendre_1d as get_gauss_legendre_1d
 from ._builders import (
     _BERNSTEIN_TO_CARDINAL_MAX_DEGREE as _BERNSTEIN_TO_CARDINAL_MAX_DEGREE,
 )

--- a/src/pantr/change_basis/_builders.py
+++ b/src/pantr/change_basis/_builders.py
@@ -69,28 +69,32 @@ derivation independent of the code it grades. It runs as a test,
 asserted.
 """
 
-import functools
 from collections.abc import Callable, Mapping
-from math import comb
 from types import MappingProxyType
 from typing import Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
 
-from ._backend import backend_keyed_cache
-from .basis import (
-    LagrangeVariant,
-    tabulate_bernstein_1d,
-    tabulate_cardinal_bspline_1d,
-    tabulate_legendre_1d,
-)
-from .basis._basis_lagrange import _get_lagrange_points
-from .basis._basis_utils import (
+from .._backend import backend_keyed_cache
+from ..basis import LagrangeVariant
+from ..basis._basis_lagrange import _get_lagrange_points
+from ..basis._basis_utils import (
     _allocate_or_validate_out,
     _validate_float_dtype,
 )
-from .quad import get_gauss_legendre_1d
+from ..quad import get_gauss_legendre_1d
+from ._change_basis_backend import (
+    bernstein_to_cardinal_kernel,
+    bernstein_to_lagrange_kernel,
+    cardinal_dual_legendre_coeffs_kernel,
+    cardinal_to_bernstein_kernel,
+    cardinal_to_legendre_kernel,
+    lagrange_to_bernstein_kernel,
+    legendre_to_cardinal_kernel,
+    monomial_to_bernstein_kernel,
+)
+from ._change_basis_core import _gram_projection
 
 
 class _DegreeLimit(NamedTuple):
@@ -288,7 +292,7 @@ def compute_lagrange_to_bernstein_1d(
     out = _prepare_square_out(degree, dtype, out)
 
     points = _get_lagrange_points(lagrange_variant, degree + 1, dtype)
-    tabulate_bernstein_1d(degree, points, out=out.T)
+    lagrange_to_bernstein_kernel()(degree, points, out)
     return out
 
 
@@ -371,8 +375,8 @@ def compute_bernstein_to_lagrange_1d(
     )
     out = _prepare_square_out(degree, dtype, out)
 
-    forward = compute_lagrange_to_bernstein_1d(degree, lagrange_variant, dtype)
-    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
+    points = _get_lagrange_points(variant, degree + 1, dtype)
+    bernstein_to_lagrange_kernel()(degree, points, out)
     return out
 
 
@@ -389,63 +393,50 @@ def _compute_change_basis_1D(
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Create a change of basis operator using numerical quadrature.
 
-    This function computes the transformation matrix M that satisfies:
-        old_basis(x) = M @ new_basis(x)
+    Computes the matrix ``M`` with ``old_basis(x) = M @ new_basis(x)``, by solving
+    ``C = G M^T`` with ``G`` the Gram matrix of the new basis and ``C`` the mixed
+    inner-product matrix between the two. Row ``i`` of ``M`` holds the ``i``-th
+    *old* basis function expanded in the *new* basis; the public
+    ``compute_A_to_B_1d`` wrappers document ``M @ [A values] = [B values]`` and so
+    pass ``new_basis_eval=A``, ``old_basis_eval=B``.
 
-    That is, row ``i`` of ``M`` holds the coefficients of the ``i``-th *old* basis
-    function expanded in the *new* basis. Note the direction: the public
-    ``compute_A_to_B_1d`` wrappers document ``M @ [A values] = [B values]`` and
-    therefore pass ``new_basis_eval=A``, ``old_basis_eval=B``.
-
-    The matrix is computed by solving the system C = G M^T where:
-    - G is the Gram matrix of the new basis
-    - C is the mixed inner product matrix between new and old bases
+    **No public builder calls this any more.** Since the C++ port each one calls
+    its own kernel through :mod:`pantr.change_basis._change_basis_backend`, so that
+    an inverse builder inverts a matrix computed on the same side of the boundary
+    rather than composing two backends. This remains because it is a module-level
+    name that was importable from ``pantr.change_basis`` before the package split,
+    and ``CLAUDE.md`` records that a downstream consumer this repository's CI
+    cannot see imports pantr's private symbols. It delegates to the same
+    :func:`~pantr.change_basis._change_basis_core._gram_projection` the Python
+    kernels use, so there is one implementation of the projection rather than two.
 
     Args:
-        new_basis_eval (callable): Function that evaluates the new basis at points.
-        old_basis_eval (callable): Function that evaluates the old basis at points.
-        n_quad_pts (int): Number of quadrature points for numerical integration.
-            Must be positive.
+        new_basis_eval (Callable): Evaluates the new basis at an array of points.
+        old_basis_eval (Callable): Evaluates the old basis at an array of points.
+        n_quad_pts (int): Number of Gauss-Legendre points. Must be positive.
         dtype (npt.DTypeLike): Floating point type for the output matrix.
             Defaults to np.float64.
-        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array
-            where the result will be stored. If None, a new array is allocated.
-            Must have the correct shape and dtype matching the `dtype` parameter
-            if provided. The shape is determined by the number of basis functions
-            in the old and new bases. This follows NumPy's style for output arrays.
-            Defaults to None.
+        out (npt.NDArray[np.float32 | np.float64] | None): Optional output array.
+            Its shape is set by the two bases. Defaults to None.
 
     Returns:
-        npt.NDArray[np.float32 | np.float64]: Change of basis transformation matrix.
-            If `out` was provided, returns the same array.
+        npt.NDArray[np.float32 | np.float64]: The change of basis matrix. If `out`
+            was provided, returns the same array.
 
     Raises:
-        ValueError: If number of quadrature points is not positive, dtype is not float32 or
-            float64, or if `out` is provided and has incorrect shape or dtype.
+        ValueError: If ``n_quad_pts`` is not positive, ``dtype`` is not float32 or
+            float64, or ``out`` has the wrong shape or dtype.
     """
     if n_quad_pts < 1:
         raise ValueError("Number of quadrature points must be positive.")
     _validate_float_dtype(dtype)
 
-    # 1. Get Gauss-Legendre quadrature points and weights for the inner product on [0, 1]
     points, weights = get_gauss_legendre_1d(n_quad_pts, dtype)
-
-    # 2. Pre-evaluate all basis functions at all quadrature points for efficiency
     new_basis = new_basis_eval(points)
     old_basis = old_basis_eval(points)
 
     out = _allocate_or_validate_out(out, (old_basis.shape[1], new_basis.shape[1]), dtype)
-
-    # 3. Compute the Gram matrix G for the new basis B: G_kj = <b_k, b_j>
-    # The inner product <f, g> is approximated by sum(w_m * f(x_m) * g(x_m))
-    weights_diag = np.diag(weights)
-    G = new_basis.T @ weights_diag @ new_basis
-
-    # 4. Compute the mixed inner product matrix C: C_ki = <b_k, a_i>
-    C = new_basis.T @ weights_diag @ old_basis
-
-    # 5. Solve the system C = G M^T for M^T, which means M = (G^-1 C)^T
-    out[:] = np.linalg.solve(G, C).T
+    _gram_projection(new_basis, old_basis, weights, out)
     return out
 
 
@@ -513,13 +504,9 @@ def compute_bernstein_to_cardinal_1d(
     )
     out = _prepare_square_out(degree, dtype, out)
 
-    return _compute_change_basis_1D(
-        new_basis_eval=functools.partial(tabulate_bernstein_1d, degree),
-        old_basis_eval=functools.partial(tabulate_cardinal_bspline_1d, degree),
-        n_quad_pts=degree + 1,
-        dtype=dtype,
-        out=out,
-    )
+    points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+    bernstein_to_cardinal_kernel()(degree, points, weights, out)
+    return out
 
 
 def compute_cardinal_to_bernstein_1d(
@@ -612,8 +599,8 @@ def compute_cardinal_to_bernstein_1d(
     )
     out = _prepare_square_out(degree, dtype, out)
 
-    forward = compute_bernstein_to_cardinal_1d(degree, dtype)
-    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
+    points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+    cardinal_to_bernstein_kernel()(degree, points, weights, out)
     return out
 
 
@@ -671,13 +658,9 @@ def compute_legendre_to_cardinal_1d(
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
 
-    return _compute_change_basis_1D(
-        new_basis_eval=functools.partial(tabulate_legendre_1d, degree),
-        old_basis_eval=functools.partial(tabulate_cardinal_bspline_1d, degree),
-        n_quad_pts=degree + 1,
-        dtype=dtype,
-        out=out,
-    )
+    points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+    legendre_to_cardinal_kernel()(degree, points, weights, out)
+    return out
 
 
 def compute_cardinal_to_legendre_1d(
@@ -757,8 +740,8 @@ def compute_cardinal_to_legendre_1d(
     )
     out = _prepare_square_out(degree, dtype, out)
 
-    forward = compute_legendre_to_cardinal_1d(degree, dtype)
-    out[:] = np.linalg.solve(forward, np.eye(degree + 1, dtype=out.dtype))
+    points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+    cardinal_to_legendre_kernel()(degree, points, weights, out)
     return out
 
 
@@ -841,7 +824,8 @@ def compute_cardinal_dual_legendre_coeffs_1d(
     )
     out = _prepare_square_out(degree, dtype, out)
 
-    out[:] = compute_cardinal_to_legendre_1d(degree, dtype).T
+    points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+    cardinal_dual_legendre_coeffs_kernel()(degree, points, weights, out)
     return out
 
 
@@ -886,12 +870,7 @@ def compute_monomial_to_bernstein_1d(
     if degree < 0:
         raise ValueError("Degree must be non-negative")
     out = _prepare_square_out(degree, dtype, out)
-    out[:] = 0
-
-    for i in range(degree + 1):
-        for j in range(i + 1):
-            out[i, j] = comb(i, j) / comb(degree, j)
-
+    monomial_to_bernstein_kernel()(degree, out)
     return out
 
 

--- a/src/pantr/change_basis/_builders.py
+++ b/src/pantr/change_basis/_builders.py
@@ -1,72 +1,11 @@
-r"""Change of basis operators for various polynomial bases in 1D.
+r"""The eight change-of-basis builders and their input validation.
 
-This module provides functions to create transformation matrices between different
-polynomial bases including Lagrange, Bernstein, cardinal B-spline, and monomial
-bases.
-
-Architecturally, this module serves as the **bridge between different basis types**,
-providing pure mathematical functions to compute the exact ``(degree+1, degree+1)``
-transformation matrices without tying the dense numerical quadrature logic directly
-into the core Spline space objects.
-
-Every public builder is named ``compute_A_to_B_1d`` and returns the matrix :math:`M` with
-:math:`M \, [A\ \mathrm{values}](x) = [B\ \mathrm{values}](x)`.
-
-Supported ``(degree, dtype)`` domain
-------------------------------------
-
-Five of the builders recover their result from a linear solve, and a solve is only
-defined while the matrix it uses is not singular to working precision. Each of those five
-declares the largest degree it supports per dtype and raises :class:`ValueError` past it,
-naming the degree, the dtype and the supported range, rather than letting
-:class:`numpy.linalg.LinAlgError` or an overflow to infinity escape. The two builders that
-solve nothing carry no degree limit -- :func:`compute_lagrange_to_bernstein_1d`, which is
-a tabulation, and :func:`compute_legendre_to_cardinal_1d`, whose Gram matrix is the
-identity -- and :func:`compute_monomial_to_bernstein_1d` evaluates a closed form.
-
-The boundary is the largest degree :math:`p` at which the matrix :math:`M_p` the builder
-solves with satisfies
-
-.. math::
-
-    \kappa_\infty(M_p) \, \varepsilon < 1 ,
-
-with :math:`\varepsilon` the dtype's machine epsilon. Nothing is tuned here. The standard
-perturbation bound for a linear system puts the relative error of the computed solution at
-order :math:`\kappa_\infty(M) \varepsilon` (Higham, *Accuracy and Stability of Numerical
-Algorithms*, 2nd ed., SIAM 2002), so at :math:`\kappa_\infty \varepsilon = 1` that bound
-reaches 100% and stops asserting anything at all, which is also where :math:`M` becomes
-singular to working precision. It is the only threshold-free choice, and it is a
-*necessary* condition rather than a promise of accuracy: each builder's ``Warning:``
-section states the accuracy actually attained, and that degrades long before the boundary.
-
-Two consequences of the inequality are worth stating, because they are the failures the
-domain replaces. Inside the domain the inverse obeys
-:math:`\lVert M^{-1} \rVert_\infty = \kappa_\infty(M) / \lVert M \rVert_\infty <
-1 / (\varepsilon \lVert M \rVert_\infty)`, and :math:`\lVert M \rVert_\infty \ge 0.036`
-over every supported range here, so no entry of an inverse can exceed
-:math:`2.3 \times 10^{8}` in float32 -- thirty orders of magnitude below that format's
-overflow threshold. The exactly zero pivot :class:`numpy.linalg.LinAlgError` reports is not
-ruled out by that inequality -- the perturbation bound constrains the *exact* matrix, not the
-one pantr forms -- but it is not observed anywhere near the boundary either. Measured, both
-failures occur only in float32 and only in the cardinal-to-Bernstein and cardinal-to-Legendre
-directions: the first infinity is 26 degrees past the boundary in both, and the first
-``LinAlgError`` 29 and 32 degrees past.
-
-The :math:`\kappa_\infty` values behind the tabulated limits come from matrices rebuilt in
-exact rational (or 60-digit decimal) arithmetic from closed forms, rather than from the
-matrices pantr computes. That distinction is load-bearing for the Bernstein/cardinal pair,
-whose forward matrix is itself the output of a Gram solve and so is not exact: near the
-boundary, ``numpy.linalg.cond(M, numpy.inf)`` applied to the matrix pantr forms reports 8.6
-times too much at degree 13 and 4.9 times too little at degree 15, either of which moves the
-crossing. (The norm has to be named: :func:`numpy.linalg.cond` defaults to the 2-norm, and
-the criterion here is stated throughout in the infinity norm the perturbation bound uses.)
-Applied to the *exact* matrix the same call tracks :math:`\kappa_\infty` to five digits at
-:math:`1.1 \times 10^{16}` and still to four at :math:`3.7 \times 10^{17}`, so it is the
-matrix and not the estimator that is at fault. Rebuilding from closed forms also keeps the
-derivation independent of the code it grades. It runs as a test,
-``tests/test_change_basis_domain.py``, so the tabulated degrees are checked rather than
-asserted.
+Layer 1 and the Python half of Layer 2: each public function checks its degree,
+its dtype and its ``out`` array, resolves whatever nodes its kernel needs, and
+then calls that kernel through :mod:`pantr.change_basis._change_basis_backend`.
+The user-facing account of what these matrices are and over which degrees they
+are defined is the package docstring in :mod:`pantr.change_basis`, which is what
+the API reference renders.
 """
 
 from collections.abc import Callable, Mapping

--- a/src/pantr/change_basis/_builders.py
+++ b/src/pantr/change_basis/_builders.py
@@ -245,7 +245,11 @@ def compute_bernstein_to_lagrange_1d(
 
     The inverse direction of :func:`compute_lagrange_to_bernstein_1d`: with ``C`` from
     that function, this returns ``L`` solving ``C @ L = I``, computed by one LU solve
-    against the identity (:func:`numpy.linalg.solve`). No explicit inverse is formed.
+    against the identity (:func:`numpy.linalg.solve`), which **is** an explicit inverse:
+    it is Du Croz and Higham's Method A (IMA J. Numer. Anal. 12 (1992) 1-19, sec. 3.1)
+    and numpy makes it bitwise identical to :func:`numpy.linalg.inv`. That bounds the
+    residual ``A X - I`` and not ``X A - I``; the round trip below is shown in the
+    bounded direction for that reason.
 
     Note:
         Both Bernstein and Lagrange bases follow the standard ordering
@@ -457,7 +461,11 @@ def compute_cardinal_to_bernstein_1d(
 
     The inverse direction of :func:`compute_bernstein_to_cardinal_1d`: with ``A`` from
     that function, this returns ``B`` solving ``A @ B = I``, computed by one LU solve
-    against the identity (:func:`numpy.linalg.solve`). No explicit inverse is formed.
+    against the identity (:func:`numpy.linalg.solve`), which **is** an explicit inverse:
+    it is Du Croz and Higham's Method A (IMA J. Numer. Anal. 12 (1992) 1-19, sec. 3.1)
+    and numpy makes it bitwise identical to :func:`numpy.linalg.inv`. That bounds the
+    residual ``A X - I`` and not ``X A - I``; the round trip below is shown in the
+    bounded direction for that reason.
 
     Note:
         A second Gram projection -- swapping the two evaluators and solving with the
@@ -611,8 +619,11 @@ def compute_cardinal_to_legendre_1d(
 
     The inverse direction of :func:`compute_legendre_to_cardinal_1d`: with ``A``
     from that function, this returns ``W`` solving ``A @ W = I``, computed by one
-    LU solve against the identity (:func:`numpy.linalg.solve`). No explicit
-    inverse is formed.
+    LU solve against the identity (:func:`numpy.linalg.solve`), which **is** an
+    explicit inverse: Du Croz and Higham's Method A, bounding the residual
+    ``A W - I`` and not ``W A - I``. Measured at degree 12, the last this builder
+    accepts: ``2.7e-13`` against ``1.2e-4``. The round trip in the example below is
+    shown in the bounded direction for that reason.
 
     Note:
         A second Gram projection -- swapping the two evaluators and solving with

--- a/src/pantr/change_basis/_change_basis_backend.py
+++ b/src/pantr/change_basis/_change_basis_backend.py
@@ -1,0 +1,345 @@
+"""Which implementation of a change-of-basis builder runs: the Python one or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for
+the change_basis package, exactly as :mod:`pantr.quad._quad_backend` and
+:mod:`pantr.basis._basis_backend` do for theirs, and for the same reason: a
+catalogue imports the kernels it hands out, so keeping each one next to its own
+kernels is what stops the policy module from importing the library it must stay
+independent of.
+
+Eight accessors, not a record
+-----------------------------
+
+By the rule ``design/cross_backend_types.md`` states -- a record when the consumer
+needs more than one kernel at once, a bare callable when it does not -- these are
+bare callables. No builder in :mod:`pantr.change_basis._builders` uses two kernels
+in one call: the inverse builders invert their forward matrix *inside* the kernel,
+on the same side of the boundary, precisely so that a C++ inverse is not a Python
+forward matrix inverted in C++.
+
+That last point is the one worth stating, because the alternative is tempting and
+wrong. ``compute_cardinal_to_bernstein_1d`` could have called
+``compute_bernstein_to_cardinal_1d`` and then solved, which is how the Python
+module was written before the port. Under a mixed backend that composes two
+different implementations into a result that is neither, and no parity claim
+covers it.
+
+What crosses the boundary
+-------------------------
+
+Arrays and scalars only. In particular
+:class:`~pantr.basis.LagrangeVariant` does **not**: the builders resolve a variant
+to its nodes on this side and pass the array. That is not only the type rule --
+:mod:`pantr._backend` records that two of the five node families are deliberately
+never dispatched and stay on :mod:`numpy.polynomial`, so a kernel that resolved
+the variant itself would have to reach back through the dispatch to honour that.
+
+What a catalogue entry looks like
+---------------------------------
+
+Every public builder in this package takes ``out``, so by the mirroring rule every
+kernel here fills the caller's buffer and returns ``None``. That is
+:mod:`pantr.basis`'s convention rather than :mod:`pantr.quad`'s, and it follows
+from the public surface rather than from either package's habit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+from ._change_basis_core import (
+    _bernstein_to_cardinal_core,
+    _bernstein_to_lagrange_core,
+    _cardinal_dual_legendre_coeffs_core,
+    _cardinal_to_bernstein_core,
+    _cardinal_to_legendre_core,
+    _lagrange_to_bernstein_core,
+    _legendre_to_cardinal_core,
+    _monomial_to_bernstein_core,
+)
+
+_K = TypeVar("_K")
+"""One kernel's signature, so :func:`_select` returns the type it was given."""
+
+_Array = npt.NDArray[np.float32 | np.float64]
+"""A float32 or float64 array, the only two dtypes these kernels handle."""
+
+_FromNodesFunc = Callable[[int, _Array, _Array], None]
+"""Signature of a builder driven by nodes alone: ``(degree, nodes, out) -> None``."""
+
+_FromRuleFunc = Callable[[int, _Array, _Array, _Array], None]
+"""Signature of a builder driven by a quadrature rule.
+
+``(degree, nodes, weights, out) -> None``. The nodes and weights stay two arrays
+rather than one ``(n, 2)`` block because that is the shape
+:func:`pantr.quad.get_gauss_legendre_1d` returns, and re-packing them would put a
+copy in front of every call.
+"""
+
+_ClosedFormFunc = Callable[[int, _Array], None]
+"""Signature of the one builder that needs nothing but a degree: ``(degree, out) -> None``."""
+
+
+def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
+    """Pick one kernel's implementation for the requested backend.
+
+    The one place the never-fall-back rule is applied for this package, so the
+    eight accessors below cannot drift from each other on it.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+        python_kernel (_K): The Python implementation, always available.
+        cpp_kernel (_K): The C++ implementation, available only when the
+            extension was built.
+
+    Returns:
+        _K: The kernel of the chosen backend.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return python_kernel
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return cpp_kernel
+
+
+def _cpp_from_nodes(binding_name: str) -> _FromNodesFunc:
+    """Build an adapter from a node-driven binding to :data:`_FromNodesFunc`.
+
+    Args:
+        binding_name (str): Attribute of :mod:`pantr._pantr_cpp` to call.
+
+    Returns:
+        _FromNodesFunc: The adapter, callable as ``(degree, nodes, out) -> None``.
+    """
+
+    def adapter(degree: int, nodes: _Array, out: _Array) -> None:
+        """Build the matrix through the C++ binding, absorbing a strided ``out``.
+
+        Args:
+            degree (int): Polynomial degree.
+            nodes (_Array): The ``degree + 1`` nodes.
+            out (_Array): Output of shape ``(degree + 1, degree + 1)``.
+
+        Note:
+            No input validation is performed here; the binding re-checks dtype,
+            rank and contiguity, and Layer 2 established the rest.
+        """
+        from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+        kernel = getattr(_pantr_cpp, binding_name)
+        node_array = np.ascontiguousarray(nodes)
+        if out.flags["C_CONTIGUOUS"]:
+            kernel(int(degree), node_array, out=out)
+            return
+        buffer = np.empty_like(out, order="C")
+        kernel(int(degree), node_array, out=buffer)
+        out[...] = buffer
+
+    return adapter
+
+
+def _cpp_from_rule(binding_name: str) -> _FromRuleFunc:
+    """Build an adapter from a rule-driven binding to :data:`_FromRuleFunc`.
+
+    Args:
+        binding_name (str): Attribute of :mod:`pantr._pantr_cpp` to call.
+
+    Returns:
+        _FromRuleFunc: The adapter, ``(degree, nodes, weights, out) -> None``.
+    """
+
+    def adapter(degree: int, nodes: _Array, weights: _Array, out: _Array) -> None:
+        """Build the matrix through the C++ binding, absorbing a strided ``out``.
+
+        Args:
+            degree (int): Polynomial degree.
+            nodes (_Array): Quadrature nodes, ``degree + 1`` of them.
+            weights (_Array): The matching weights.
+            out (_Array): Output of shape ``(degree + 1, degree + 1)``.
+
+        Note:
+            No input validation is performed here; the binding re-checks dtype,
+            rank and contiguity, and Layer 2 established the rest.
+        """
+        from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+        kernel = getattr(_pantr_cpp, binding_name)
+        node_array = np.ascontiguousarray(nodes)
+        weight_array = np.ascontiguousarray(weights)
+        if out.flags["C_CONTIGUOUS"]:
+            kernel(int(degree), node_array, weight_array, out=out)
+            return
+        buffer = np.empty_like(out, order="C")
+        kernel(int(degree), node_array, weight_array, out=buffer)
+        out[...] = buffer
+
+    return adapter
+
+
+def _cpp_monomial_to_bernstein(degree: int, out: _Array) -> None:
+    """Build the monomial-to-Bernstein matrix through the C++ binding.
+
+    Args:
+        degree (int): Polynomial degree.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``.
+
+    Note:
+        No input validation is performed here; the binding re-checks dtype, rank
+        and contiguity, and Layer 2 established the rest.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    if out.flags["C_CONTIGUOUS"]:
+        _pantr_cpp.monomial_to_bernstein_1d(int(degree), out=out)
+        return
+    buffer = np.empty_like(out, order="C")
+    _pantr_cpp.monomial_to_bernstein_1d(int(degree), out=buffer)
+    out[...] = buffer
+
+
+def lagrange_to_bernstein_kernel(backend: Backend | None = None) -> _FromNodesFunc:
+    """Get the Lagrange-to-Bernstein kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromNodesFunc: The kernel, ``(degree, nodes, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(
+        backend, _lagrange_to_bernstein_core, _cpp_from_nodes("lagrange_to_bernstein_1d")
+    )
+
+
+def bernstein_to_lagrange_kernel(backend: Backend | None = None) -> _FromNodesFunc:
+    """Get the Bernstein-to-Lagrange kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromNodesFunc: The kernel, ``(degree, nodes, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(
+        backend, _bernstein_to_lagrange_core, _cpp_from_nodes("bernstein_to_lagrange_1d")
+    )
+
+
+def bernstein_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFunc:
+    """Get the Bernstein-to-cardinal kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromRuleFunc: The kernel, ``(degree, nodes, weights, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _bernstein_to_cardinal_core, _cpp_from_rule("bernstein_to_cardinal_1d"))
+
+
+def cardinal_to_bernstein_kernel(backend: Backend | None = None) -> _FromRuleFunc:
+    """Get the cardinal-to-Bernstein kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromRuleFunc: The kernel, ``(degree, nodes, weights, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _cardinal_to_bernstein_core, _cpp_from_rule("cardinal_to_bernstein_1d"))
+
+
+def legendre_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFunc:
+    """Get the Legendre-to-cardinal kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromRuleFunc: The kernel, ``(degree, nodes, weights, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _legendre_to_cardinal_core, _cpp_from_rule("legendre_to_cardinal_1d"))
+
+
+def cardinal_to_legendre_kernel(backend: Backend | None = None) -> _FromRuleFunc:
+    """Get the cardinal-to-Legendre kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromRuleFunc: The kernel, ``(degree, nodes, weights, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _cardinal_to_legendre_core, _cpp_from_rule("cardinal_to_legendre_1d"))
+
+
+def cardinal_dual_legendre_coeffs_kernel(backend: Backend | None = None) -> _FromRuleFunc:
+    """Get the cardinal-dual Legendre coefficients kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _FromRuleFunc: The kernel, ``(degree, nodes, weights, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(
+        backend,
+        _cardinal_dual_legendre_coeffs_core,
+        _cpp_from_rule("cardinal_dual_legendre_coeffs_1d"),
+    )
+
+
+def monomial_to_bernstein_kernel(backend: Backend | None = None) -> _ClosedFormFunc:
+    """Get the monomial-to-Bernstein kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _ClosedFormFunc: The kernel, ``(degree, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _monomial_to_bernstein_core, _cpp_monomial_to_bernstein)

--- a/src/pantr/change_basis/_change_basis_backend.py
+++ b/src/pantr/change_basis/_change_basis_backend.py
@@ -141,10 +141,10 @@ def _cpp_from_nodes(binding_name: str) -> _FromNodesFunc:
         kernel = getattr(_pantr_cpp, binding_name)
         node_array = np.ascontiguousarray(nodes)
         if out.flags["C_CONTIGUOUS"]:
-            kernel(int(degree), node_array, out=out)
+            kernel(int(degree), nodes=node_array, out=out)
             return
         buffer = np.empty_like(out, order="C")
-        kernel(int(degree), node_array, out=buffer)
+        kernel(int(degree), nodes=node_array, out=buffer)
         out[...] = buffer
 
     return adapter
@@ -179,10 +179,10 @@ def _cpp_from_rule(binding_name: str) -> _FromRuleFunc:
         node_array = np.ascontiguousarray(nodes)
         weight_array = np.ascontiguousarray(weights)
         if out.flags["C_CONTIGUOUS"]:
-            kernel(int(degree), node_array, weight_array, out=out)
+            kernel(int(degree), nodes=node_array, weights=weight_array, out=out)
             return
         buffer = np.empty_like(out, order="C")
-        kernel(int(degree), node_array, weight_array, out=buffer)
+        kernel(int(degree), nodes=node_array, weights=weight_array, out=buffer)
         out[...] = buffer
 
     return adapter

--- a/src/pantr/change_basis/_change_basis_backend.py
+++ b/src/pantr/change_basis/_change_basis_backend.py
@@ -46,7 +46,7 @@ from the public surface rather than from either package's habit.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypeVar
+from typing import Final, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -209,6 +209,30 @@ def _cpp_monomial_to_bernstein(degree: int, out: _Array) -> None:
     out[...] = buffer
 
 
+_cpp_lagrange_to_bernstein: Final[_FromNodesFunc] = _cpp_from_nodes("lagrange_to_bernstein_1d")
+"""The Lagrange-to-Bernstein builder of the C++ backend."""
+
+_cpp_bernstein_to_lagrange: Final[_FromNodesFunc] = _cpp_from_nodes("bernstein_to_lagrange_1d")
+"""The Bernstein-to-Lagrange builder of the C++ backend."""
+
+_cpp_bernstein_to_cardinal: Final[_FromRuleFunc] = _cpp_from_rule("bernstein_to_cardinal_1d")
+"""The Bernstein-to-cardinal builder of the C++ backend."""
+
+_cpp_cardinal_to_bernstein: Final[_FromRuleFunc] = _cpp_from_rule("cardinal_to_bernstein_1d")
+"""The cardinal-to-Bernstein builder of the C++ backend."""
+
+_cpp_legendre_to_cardinal: Final[_FromRuleFunc] = _cpp_from_rule("legendre_to_cardinal_1d")
+"""The Legendre-to-cardinal builder of the C++ backend."""
+
+_cpp_cardinal_to_legendre: Final[_FromRuleFunc] = _cpp_from_rule("cardinal_to_legendre_1d")
+"""The cardinal-to-Legendre builder of the C++ backend."""
+
+_cpp_cardinal_dual_legendre_coeffs: Final[_FromRuleFunc] = _cpp_from_rule(
+    "cardinal_dual_legendre_coeffs_1d"
+)
+"""The cardinal-dual Legendre builder of the C++ backend."""
+
+
 def lagrange_to_bernstein_kernel(backend: Backend | None = None) -> _FromNodesFunc:
     """Get the Lagrange-to-Bernstein kernel of the requested backend.
 
@@ -222,9 +246,7 @@ def lagrange_to_bernstein_kernel(backend: Backend | None = None) -> _FromNodesFu
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(
-        backend, _lagrange_to_bernstein_core, _cpp_from_nodes("lagrange_to_bernstein_1d")
-    )
+    return _select(backend, _lagrange_to_bernstein_core, _cpp_lagrange_to_bernstein)
 
 
 def bernstein_to_lagrange_kernel(backend: Backend | None = None) -> _FromNodesFunc:
@@ -240,9 +262,7 @@ def bernstein_to_lagrange_kernel(backend: Backend | None = None) -> _FromNodesFu
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(
-        backend, _bernstein_to_lagrange_core, _cpp_from_nodes("bernstein_to_lagrange_1d")
-    )
+    return _select(backend, _bernstein_to_lagrange_core, _cpp_bernstein_to_lagrange)
 
 
 def bernstein_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFunc:
@@ -258,7 +278,7 @@ def bernstein_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFun
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(backend, _bernstein_to_cardinal_core, _cpp_from_rule("bernstein_to_cardinal_1d"))
+    return _select(backend, _bernstein_to_cardinal_core, _cpp_bernstein_to_cardinal)
 
 
 def cardinal_to_bernstein_kernel(backend: Backend | None = None) -> _FromRuleFunc:
@@ -274,7 +294,7 @@ def cardinal_to_bernstein_kernel(backend: Backend | None = None) -> _FromRuleFun
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(backend, _cardinal_to_bernstein_core, _cpp_from_rule("cardinal_to_bernstein_1d"))
+    return _select(backend, _cardinal_to_bernstein_core, _cpp_cardinal_to_bernstein)
 
 
 def legendre_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFunc:
@@ -290,7 +310,7 @@ def legendre_to_cardinal_kernel(backend: Backend | None = None) -> _FromRuleFunc
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(backend, _legendre_to_cardinal_core, _cpp_from_rule("legendre_to_cardinal_1d"))
+    return _select(backend, _legendre_to_cardinal_core, _cpp_legendre_to_cardinal)
 
 
 def cardinal_to_legendre_kernel(backend: Backend | None = None) -> _FromRuleFunc:
@@ -306,7 +326,7 @@ def cardinal_to_legendre_kernel(backend: Backend | None = None) -> _FromRuleFunc
     Raises:
         RuntimeError: If ``backend`` is given and is not available.
     """
-    return _select(backend, _cardinal_to_legendre_core, _cpp_from_rule("cardinal_to_legendre_1d"))
+    return _select(backend, _cardinal_to_legendre_core, _cpp_cardinal_to_legendre)
 
 
 def cardinal_dual_legendre_coeffs_kernel(backend: Backend | None = None) -> _FromRuleFunc:
@@ -325,7 +345,7 @@ def cardinal_dual_legendre_coeffs_kernel(backend: Backend | None = None) -> _Fro
     return _select(
         backend,
         _cardinal_dual_legendre_coeffs_core,
-        _cpp_from_rule("cardinal_dual_legendre_coeffs_1d"),
+        _cpp_cardinal_dual_legendre_coeffs,
     )
 
 

--- a/src/pantr/change_basis/_change_basis_core.py
+++ b/src/pantr/change_basis/_change_basis_core.py
@@ -12,38 +12,75 @@ rather than between two conventions. And two of the five Lagrange node families
 are ones :mod:`pantr._backend` says are deliberately never dispatched, so a kernel
 that fetched its own nodes would have to reach through the dispatch to get them.
 
-Why these call the Python tabulators explicitly
------------------------------------------------
+Why these reach for Layer 3 rather than the public tabulators
+-------------------------------------------------------------
 
-:func:`pantr.basis.tabulate_bernstein_1d` and its siblings are themselves
-dispatched now. A kernel here that called them plainly would follow whatever
-backend is in effect, so asking the catalogue for *this* kernel while the ambient
-backend is C++ would run a Python solve over C++ tabulations -- a third
-implementation that is neither backend and that no parity claim covers.
+:func:`pantr.basis.tabulate_bernstein_1d` and its siblings are the **public Layer
+1 surface**, and they are dispatched. Calling them from here would be wrong twice
+over. It would follow whatever backend is ambient, so asking the catalogue for
+*this* kernel while the ambient backend is C++ would run a Python solve over C++
+tabulations -- a third implementation that is neither backend and that no parity
+claim covers. And it would make these functions Layer 1 consumers while their C++
+counterparts call Layer 3 kernels, so the two halves of one catalogue entry would
+not be peers: this side would validate its inputs and raise, the other would not.
 
-So the tabulations below are taken inside ``use_backend(Backend.PYTHON)``. It
-makes "the Python kernel" mean one thing regardless of ambient state, which is
-the property a parity oracle has to have. The cost is one
-:class:`~contextvars.ContextVar` set and reset per call, in front of an
-``O(n^3)`` solve.
+So these ask :mod:`pantr.basis._basis_backend` for the **Python** kernels by name
+and drive them through the same Layer 2 helper the public functions use. That
+makes "the Python kernel" mean one thing regardless of ambient state, which is the
+property a parity oracle has to have, and it makes the docstring note below true
+rather than aspirational. Measured, it also removes about 6.7 us per tabulation at
+degree 6 -- roughly six times the raw kernel's own cost -- paid twice inside every
+inverse builder.
+
+The helper is Layer 2 rather than Layer 3, and that is deliberate: it owns the
+dtype normalization and the ``out`` allocation these kernels would otherwise
+duplicate, and it is what selects the serial Bernstein twin below
+``_PARALLEL_MIN_NUM_PTS``. What it does not do is dispatch, which is the whole
+point.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from math import comb
 
 import numpy as np
 import numpy.typing as npt
 
-from .._backend import Backend, use_backend
-from ..basis import (
-    tabulate_bernstein_1d,
-    tabulate_cardinal_bspline_1d,
-    tabulate_legendre_1d,
+from .._backend import Backend
+from ..basis._basis_1D import _tabulate_basis_1D_impl_helper
+from ..basis._basis_backend import (
+    CoreKernels,
+    bernstein_core,
+    cardinal_bspline_core,
+    legendre_core,
 )
 
 _Array = npt.NDArray[np.float32 | np.float64]
 """A float32 or float64 array, the only two dtypes these kernels handle."""
+
+
+def _tabulate_in_python(
+    which: Callable[[Backend], CoreKernels],
+    degree: int,
+    nodes: _Array,
+    out: _Array | None = None,
+) -> _Array:
+    """Tabulate one basis with the Python kernels, whatever backend is ambient.
+
+    Args:
+        which (Callable[[Backend], CoreKernels]): The basis's catalogue accessor.
+        degree (int): Degree of the basis.
+        nodes (_Array): Evaluation points.
+        out (_Array | None): Output array, or ``None`` to allocate. Defaults to None.
+
+    Returns:
+        _Array: The tabulated values, shape ``(nodes.size, degree + 1)``.
+    """
+    kernels = which(Backend.PYTHON)
+    return _tabulate_basis_1D_impl_helper(
+        degree, nodes, kernels.parallel, out, core_func_serial=kernels.serial
+    )
 
 
 def _gram_projection(new_basis: _Array, old_basis: _Array, weights: _Array, out: _Array) -> None:
@@ -99,8 +136,7 @@ def _lagrange_to_bernstein_core(degree: int, nodes: _Array, out: _Array) -> None
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`~pantr.change_basis.compute_lagrange_to_bernstein_1d`.
     """
-    with use_backend(Backend.PYTHON):
-        tabulate_bernstein_1d(degree, nodes, out=out.T)
+    _tabulate_in_python(bernstein_core, degree, nodes, out.T)
 
 
 def _bernstein_to_lagrange_core(degree: int, nodes: _Array, out: _Array) -> None:
@@ -134,9 +170,8 @@ def _bernstein_to_cardinal_core(degree: int, nodes: _Array, weights: _Array, out
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`~pantr.change_basis.compute_bernstein_to_cardinal_1d`.
     """
-    with use_backend(Backend.PYTHON):
-        new_basis = tabulate_bernstein_1d(degree, nodes)
-        old_basis = tabulate_cardinal_bspline_1d(degree, nodes)
+    new_basis = _tabulate_in_python(bernstein_core, degree, nodes)
+    old_basis = _tabulate_in_python(cardinal_bspline_core, degree, nodes)
     _gram_projection(new_basis, old_basis, weights, out)
 
 
@@ -172,9 +207,8 @@ def _legendre_to_cardinal_core(degree: int, nodes: _Array, weights: _Array, out:
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`~pantr.change_basis.compute_legendre_to_cardinal_1d`.
     """
-    with use_backend(Backend.PYTHON):
-        new_basis = tabulate_legendre_1d(degree, nodes)
-        old_basis = tabulate_cardinal_bspline_1d(degree, nodes)
+    new_basis = _tabulate_in_python(legendre_core, degree, nodes)
+    old_basis = _tabulate_in_python(cardinal_bspline_core, degree, nodes)
     _gram_projection(new_basis, old_basis, weights, out)
 
 

--- a/src/pantr/change_basis/_change_basis_core.py
+++ b/src/pantr/change_basis/_change_basis_core.py
@@ -1,0 +1,236 @@
+"""The Python implementations of the change-of-basis builders.
+
+Layer 3 in the layering of ``CLAUDE.md``: pure computation, no validation, and
+the parity oracle the C++ port in ``cpp/include/pantr/change_basis`` is measured
+against.
+
+Every kernel here takes its nodes, and where it needs one its quadrature weights,
+as arrays rather than computing them. Two reasons, and the second is the binding
+one. It keeps these signatures identical to the C++ ones, so the catalogue in
+:mod:`pantr.change_basis._change_basis_backend` selects between two functions
+rather than between two conventions. And two of the five Lagrange node families
+are ones :mod:`pantr._backend` says are deliberately never dispatched, so a kernel
+that fetched its own nodes would have to reach through the dispatch to get them.
+
+Why these call the Python tabulators explicitly
+-----------------------------------------------
+
+:func:`pantr.basis.tabulate_bernstein_1d` and its siblings are themselves
+dispatched now. A kernel here that called them plainly would follow whatever
+backend is in effect, so asking the catalogue for *this* kernel while the ambient
+backend is C++ would run a Python solve over C++ tabulations -- a third
+implementation that is neither backend and that no parity claim covers.
+
+So the tabulations below are taken inside ``use_backend(Backend.PYTHON)``. It
+makes "the Python kernel" mean one thing regardless of ambient state, which is
+the property a parity oracle has to have. The cost is one
+:class:`~contextvars.ContextVar` set and reset per call, in front of an
+``O(n^3)`` solve.
+"""
+
+from __future__ import annotations
+
+from math import comb
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, use_backend
+from ..basis import (
+    tabulate_bernstein_1d,
+    tabulate_cardinal_bspline_1d,
+    tabulate_legendre_1d,
+)
+
+_Array = npt.NDArray[np.float32 | np.float64]
+"""A float32 or float64 array, the only two dtypes these kernels handle."""
+
+
+def _gram_projection(new_basis: _Array, old_basis: _Array, weights: _Array, out: _Array) -> None:
+    """Solve ``G M^T = C`` for the change-of-basis matrix ``M``.
+
+    ``G`` is the Gram matrix of the new basis under the given quadrature and ``C``
+    the mixed matrix between the two bases, so row ``i`` of the result holds the
+    ``i``-th old basis function expanded in the new basis.
+
+    Args:
+        new_basis (_Array): New-basis values at the quadrature nodes,
+            ``(n_quad, n_new)``.
+        old_basis (_Array): Old-basis values at the same nodes, ``(n_quad, n_old)``.
+        weights (_Array): Quadrature weights, length ``n_quad``.
+        out (_Array): Output of shape ``(n_old, n_new)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call one of the ``compute_*`` builders instead.
+    """
+    weights_diag = np.diag(weights)
+    gram = new_basis.T @ weights_diag @ new_basis
+    mixed = new_basis.T @ weights_diag @ old_basis
+    out[:] = np.linalg.solve(gram, mixed).T
+
+
+def _invert(forward: _Array, out: _Array) -> None:
+    """Invert ``forward`` by one LU solve against the identity.
+
+    Args:
+        forward (_Array): The square matrix to invert.
+        out (_Array): Output of the same shape, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call one of the ``compute_*`` builders instead.
+    """
+    out[:] = np.linalg.solve(forward, np.eye(forward.shape[0], dtype=out.dtype))
+
+
+def _lagrange_to_bernstein_core(degree: int, nodes: _Array, out: _Array) -> None:
+    """Tabulate the Bernstein basis at the Lagrange nodes, transposed.
+
+    The Lagrange basis is cardinal at its own nodes, so ``C[j, k]`` is simply
+    ``B_j(x_k)`` and no solve is involved at any degree.
+
+    Args:
+        degree (int): Polynomial degree. Assumed at least 1.
+        nodes (_Array): The ``degree + 1`` Lagrange nodes.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`~pantr.change_basis.compute_lagrange_to_bernstein_1d`.
+    """
+    with use_backend(Backend.PYTHON):
+        tabulate_bernstein_1d(degree, nodes, out=out.T)
+
+
+def _bernstein_to_lagrange_core(degree: int, nodes: _Array, out: _Array) -> None:
+    """Invert the Lagrange-to-Bernstein matrix.
+
+    Args:
+        degree (int): Polynomial degree. Assumed at least 1.
+        nodes (_Array): The ``degree + 1`` Lagrange nodes.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed), including the
+        degree domain that keeps the solve non-singular.
+        For general use, call :func:`~pantr.change_basis.compute_bernstein_to_lagrange_1d`.
+    """
+    forward = np.empty_like(out)
+    _lagrange_to_bernstein_core(degree, nodes, forward)
+    _invert(forward, out)
+
+
+def _bernstein_to_cardinal_core(degree: int, nodes: _Array, weights: _Array, out: _Array) -> None:
+    """Project the cardinal B-spline basis onto the Bernstein basis.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        nodes (_Array): Quadrature nodes on ``[0, 1]``, ``degree + 1`` of them.
+        weights (_Array): The matching quadrature weights.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`~pantr.change_basis.compute_bernstein_to_cardinal_1d`.
+    """
+    with use_backend(Backend.PYTHON):
+        new_basis = tabulate_bernstein_1d(degree, nodes)
+        old_basis = tabulate_cardinal_bspline_1d(degree, nodes)
+    _gram_projection(new_basis, old_basis, weights, out)
+
+
+def _cardinal_to_bernstein_core(degree: int, nodes: _Array, weights: _Array, out: _Array) -> None:
+    """Invert the Bernstein-to-cardinal matrix.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        nodes (_Array): Quadrature nodes on ``[0, 1]``, ``degree + 1`` of them.
+        weights (_Array): The matching quadrature weights.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed), including the
+        degree domain.
+        For general use, call :func:`~pantr.change_basis.compute_cardinal_to_bernstein_1d`.
+    """
+    forward = np.empty_like(out)
+    _bernstein_to_cardinal_core(degree, nodes, weights, forward)
+    _invert(forward, out)
+
+
+def _legendre_to_cardinal_core(degree: int, nodes: _Array, weights: _Array, out: _Array) -> None:
+    """Project the cardinal B-spline basis onto the orthonormal Legendre basis.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        nodes (_Array): Quadrature nodes on ``[0, 1]``, ``degree + 1`` of them.
+        weights (_Array): The matching quadrature weights.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`~pantr.change_basis.compute_legendre_to_cardinal_1d`.
+    """
+    with use_backend(Backend.PYTHON):
+        new_basis = tabulate_legendre_1d(degree, nodes)
+        old_basis = tabulate_cardinal_bspline_1d(degree, nodes)
+    _gram_projection(new_basis, old_basis, weights, out)
+
+
+def _cardinal_to_legendre_core(degree: int, nodes: _Array, weights: _Array, out: _Array) -> None:
+    """Invert the Legendre-to-cardinal matrix.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        nodes (_Array): Quadrature nodes on ``[0, 1]``, ``degree + 1`` of them.
+        weights (_Array): The matching quadrature weights.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed), including the
+        degree domain.
+        For general use, call :func:`~pantr.change_basis.compute_cardinal_to_legendre_1d`.
+    """
+    forward = np.empty_like(out)
+    _legendre_to_cardinal_core(degree, nodes, weights, forward)
+    _invert(forward, out)
+
+
+def _cardinal_dual_legendre_coeffs_core(
+    degree: int, nodes: _Array, weights: _Array, out: _Array
+) -> None:
+    """Transpose the cardinal-to-Legendre matrix.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        nodes (_Array): Quadrature nodes on ``[0, 1]``, ``degree + 1`` of them.
+        weights (_Array): The matching quadrature weights.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed), including the
+        degree domain.
+        For general use, call
+        :func:`~pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
+    """
+    straight = np.empty_like(out)
+    _cardinal_to_legendre_core(degree, nodes, weights, straight)
+    out[:] = straight.T
+
+
+def _monomial_to_bernstein_core(degree: int, out: _Array) -> None:
+    """Fill the lower-triangular matrix ``C(i, j) / C(degree, j)``.
+
+    Args:
+        degree (int): Polynomial degree. Assumed non-negative.
+        out (_Array): Output of shape ``(degree + 1, degree + 1)``, filled in place.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+        For general use, call :func:`~pantr.change_basis.compute_monomial_to_bernstein_1d`.
+    """
+    out[:] = 0
+    for i in range(degree + 1):
+        for j in range(i + 1):
+            out[i, j] = comb(i, j) / comb(degree, j)

--- a/src/pantr/quad/_lattice.py
+++ b/src/pantr/quad/_lattice.py
@@ -37,9 +37,8 @@ class PointsLattice:
     metadata.
 
     Immutable once constructed: each coordinate array is copied on the way in
-    and the stored copies are read-only, so what
-    :meth:`_validate_pts_per_dir` checked at construction stays true for the
-    object's whole life. :class:`pantr.quad.QuadratureRule` does the same, and
+    and the stored copies are read-only, so what ``_validate_pts_per_dir``
+    checked at construction stays true for the object's whole life. :class:`pantr.quad.QuadratureRule` does the same, and
     for the same reason.
 
     Attributes:

--- a/src/pantr/quad/_lattice.py
+++ b/src/pantr/quad/_lattice.py
@@ -37,9 +37,9 @@ class PointsLattice:
     metadata.
 
     Immutable once constructed: each coordinate array is copied on the way in
-    and the stored copies are read-only, so what ``_validate_pts_per_dir``
-    checked at construction stays true for the object's whole life. :class:`pantr.quad.QuadratureRule` does the same, and
-    for the same reason.
+    and the stored copies are read-only, so what ``_validate_pts_per_dir`` checked
+    at construction stays true for the object's whole life.
+    :class:`pantr.quad.QuadratureRule` does the same, and for the same reason.
 
     Attributes:
         _pts_per_dir (tuple[npt.NDArray[np.float32 | np.float64], ...]): One

--- a/tests/parity/test_basis_tabulations.py
+++ b/tests/parity/test_basis_tabulations.py
@@ -1,0 +1,187 @@
+r"""Parity of the Bernstein and Legendre tabulations against their Numba oracles.
+
+`cpp/include/pantr/basis/bernstein.hpp` and its Legendre sibling name this file as
+the place their parity claims are measured, and
+`tests/parity/test_change_basis.py` leans on the result: its bound treats the
+tabulated inputs as contributing nothing, which is only true while the two
+backends agree bit for bit.
+
+**This file exists because that citation was made before it did.** Three places
+cited a parity test for these kernels that had never been written. The
+bit-exactness was true, measured once by hand and then asserted from memory; what
+was missing was anything that would notice if it stopped being true. If the
+Legendre tabulation ever drifts by an ulp, the change-of-basis bound silently
+loses a term and no other test in the suite fails.
+
+What is claimed, and how strong each claim is
+---------------------------------------------
+
+**Legendre: bitwise, and derivable.** The recurrence uses only `+`, `-`, `*`, `/`
+and `sqrt`, every one of which IEEE 754 pins to a single correctly rounded result.
+Two implementations evaluating the same expressions in the same order therefore
+agree to the last bit, and the port was written to evaluate them in the same
+order -- including reading each previous term back out of the output array rather
+than carrying it in a register, which at float32 is a rounding the oracle commits
+and a register would not.
+
+**Bernstein: bitwise, and measured rather than derived.** Everything above holds
+except the seed, `pow((1-u), n)` or `pow(u, n)`. Neither C nor IEEE 754 requires
+`pow` to be correctly rounded, so bit-exactness here rests on numba's `np.power`
+and the platform libm agreeing on exactly these arguments. They do, on every
+argument tested. The claim is therefore **BITWISE with an observed rather than
+proved justification**, and that distinction is the reason the two kernels get
+separate reasons below rather than one shared one.
+
+Both claims are gated on the compiled kernel: with `NUMBA_DISABLE_JIT=1` the
+oracle runs interpreted and its float32 intermediates widen, which is a property
+of how the oracle was run rather than of either implementation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.basis import tabulate_bernstein_1d, tabulate_legendre_1d
+from tests._parity_harness import (
+    assert_parity,
+    bitwise_parity,
+    demand_the_compiled_kernel,
+)
+
+_BERNSTEIN_WHY = (
+    "every operation but the seed is +, -, * or /, each pinned by IEEE 754 to one "
+    "correctly rounded result, and the port evaluates them in the oracle's order, "
+    "including reading each previous term back out of the output array. The seed is "
+    "pow, which neither C nor IEEE 754 requires to be correctly rounded, so this "
+    "claim is observed rather than derived: numba's np.power and the platform libm "
+    "agree on every argument these degrees form"
+)
+
+_LEGENDRE_WHY = (
+    "the recurrence uses only +, -, *, / and sqrt, all correctly rounded by IEEE "
+    "754, evaluated in the oracle's order, with each previous term read back out of "
+    "the output array rather than carried in a register. No pow, so unlike Bernstein "
+    "this is derivable rather than merely observed"
+)
+
+
+def _adversarial_points(dtype: npt.DTypeLike) -> npt.NDArray[np.float32 | np.float64]:
+    """Points chosen to reach the branches a uniform sweep does not.
+
+    Includes both endpoints, the midpoint the mirror branches on, the largest
+    representable value below one (where the unmirrored Bernstein seed underflows
+    at high degree), a value small enough that ``1 - (1 - u)`` loses it entirely,
+    and a subnormal.
+
+    Args:
+        dtype (npt.DTypeLike): The dtype to build them in.
+
+    Returns:
+        npt.NDArray: The points, ascending.
+    """
+    one = np.array(1.0, dtype=dtype)
+    zero = np.array(0.0, dtype=dtype)
+    rng = np.random.default_rng(20260821)
+    special = np.array(
+        [
+            0.0,
+            float(np.nextafter(zero, one)),
+            1e-20,
+            0.25,
+            0.5,
+            float(np.nextafter(np.array(0.5, dtype=dtype), one)),
+            0.75,
+            float(np.nextafter(one, zero)),
+            1.0,
+        ],
+        dtype=dtype,
+    )
+    return np.concatenate([special, rng.random(24).astype(dtype)])
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("degree", [0, 1, 3, 6, 7, 8, 20, 21, 24, 40])
+def test_bernstein_tabulation_is_bitwise(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends tabulate the Bernstein basis identically.
+
+    The degree list straddles both dispatch thresholds on purpose: the unmirrored
+    kernel runs at or below degree 20 in float64 and 6 in float32, so 7, 8 and 21
+    are the first degrees on the other side of each, and 24 and 40 exercise the
+    mirrored branch well past them.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    points = _adversarial_points(dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = tabulate_bernstein_1d(degree, points)
+    with use_backend(Backend.CPP):
+        actual = tabulate_bernstein_1d(degree, points)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_BERNSTEIN_WHY),
+        context=f"tabulate_bernstein_1d degree {degree} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("degree", [0, 1, 2, 5, 12, 20, 32])
+def test_legendre_tabulation_is_bitwise(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends tabulate the orthonormal shifted Legendre basis identically."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    points = _adversarial_points(dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = tabulate_legendre_1d(degree, points)
+    with use_backend(Backend.CPP):
+        actual = tabulate_legendre_1d(degree, points)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_LEGENDRE_WHY),
+        context=f"tabulate_legendre_1d degree {degree} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """A non-contiguous ``out`` is filled, and filled identically, on both backends.
+
+    The C++ binding refuses a strided array and the Python adapter absorbs that by
+    buffering and copying back. An adapter that dropped the copy would return the
+    right answer and leave the caller's array untouched, which is the worst failure
+    shape available and is why this is checked rather than assumed. The
+    change-of-basis Lagrange builder passes exactly such a view, ``out.T``.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    degree = 5
+    points = np.linspace(0.0, 1.0, 9, dtype=dtype)
+
+    results = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        holder = np.zeros((degree + 1, points.size), dtype=dtype)
+        view = holder.T
+        assert not view.flags["C_CONTIGUOUS"]
+        with use_backend(backend):
+            tabulate_bernstein_1d(degree, points, out=view)
+        assert np.any(holder != 0.0), f"{backend.name}: the caller's array was not written"
+        results[backend] = holder.copy()
+
+    assert_parity(
+        results[Backend.CPP],
+        results[Backend.PYTHON],
+        bitwise_parity(why=f"{_BERNSTEIN_WHY}; buffering a strided out adds no arithmetic"),
+        context=f"strided out, {np.dtype(dtype).name}",
+    )

--- a/tests/parity/test_change_basis.py
+++ b/tests/parity/test_change_basis.py
@@ -1,0 +1,671 @@
+r"""Parity of the eight change-of-basis builders against their Python oracle.
+
+`cpp/include/pantr/change_basis/change_basis.hpp` names this file as the place its
+parity claims are derived. This is the first ported module whose builders are not
+all bit-identical, and the reason is worth stating before the derivation: it is the
+first one that **solves a linear system**.
+
+Three groups, and the split is structural
+-----------------------------------------
+
+**Two builders are bitwise.** `compute_lagrange_to_bernstein_1d` is a Bernstein
+tabulation transposed, and `compute_monomial_to_bernstein_1d` is a table of
+binomial quotients. Neither runs a solve or a matrix product, so both inherit the
+bit-exactness of the kernels beneath them.
+
+**One is bounded but never approaches its bound.**
+`compute_legendre_to_cardinal_1d` is a Gram projection whose Gram matrix is the
+identity up to round-off -- the new basis is orthonormal and the quadrature
+integrates every product it forms exactly -- so its solve is perfectly
+conditioned and the two backends differ only by the summation order of the mixed
+matrix.
+
+**Five carry a genuine bound**, because each inverts an ill-conditioned matrix.
+
+The bound
+---------
+
+Both backends compute the same matrix by the same three steps: tabulate the two
+bases at the quadrature nodes, form ``G = B^T W B`` and ``C = B^T W A``, and solve
+``G M^T = C``. The tabulations are bit-identical (measured; see
+`tests/parity/test_basis_bernstein.py` and its Legendre sibling), so they
+contribute nothing. The other two steps do:
+
+1. **The products.** numpy contracts them with a BLAS ``gemm``, Eigen with its own
+   blocked product. Both sum the same ``n_quad`` terms in different orders, so each
+   perturbs ``G`` and ``C`` by a relative ``n u`` (Higham, *Accuracy and Stability
+   of Numerical Algorithms*, 2nd ed., SIAM 2002, §3.1). The ``W`` factor
+   contributes nothing: multiplying by a diagonal adds only exact zeros to a dot
+   product.
+
+2. **The solve.** ``numpy.linalg.solve`` is LAPACK ``gesv`` and the port uses
+   ``Eigen::PartialPivLU``. Both are LU with partial pivoting and both are backward
+   stable, so each computed solution satisfies ``(A + dA) x = b`` with
+   ``||dA||_inf <= c rho gamma_n ||A||_inf`` and hence a forward error of order
+   ``kappa_inf(A) gamma_{3n}`` (ibid., Thm 9.4).
+
+Adding the two and writing ``eps = 2 u``, one backend's relative error is at most
+about ``4 n kappa_inf rho u``, i.e. ``2 n kappa_inf rho eps``. The harness doubles
+it, since neither side is the exact answer.
+
+**The constant used below is 32, and ``rho`` is why.** Partial pivoting bounds the
+growth factor only by ``2**(n-1)``, which is worthless here, and in practice it is
+a small number for these matrices. So 32 folds in an allowance of ``rho <= 8`` on
+top of the ``4 n kappa eps``, and that allowance is **argued, not proved**: it is
+the one place in this file where a constant is not derived. What is measured is
+the margin, and `test_the_bound_is_approached_but_not_by_orders_of_magnitude`
+reports it so a future reader can see whether 8 was generous or lucky.
+
+Which ``kappa``, per builder
+----------------------------
+
+Each is the condition number of the matrix that builder's solve actually uses, in
+**exact rational arithmetic** -- the helpers in `tests/test_change_basis_domain.py`
+rebuild each matrix from closed forms rather than from what pantr computes. That
+matters: `pantr.change_basis`'s module docstring measures
+``numpy.linalg.cond`` on the *formed* Bernstein/cardinal matrix at 8.6 times too
+high at degree 13 and 4.9 times too low at degree 15, either of which would move
+the bound.
+
+* ``bernstein_to_cardinal``: the Bernstein Gram matrix it solves with.
+* ``cardinal_to_bernstein``: the **product** of two condition numbers. It inverts
+  ``A``, which is itself the previous builder's Gram solve and so carries a
+  relative error of ``kappa_inf(G_bern) eps``; inverting a perturbed matrix
+  multiplies that by ``kappa_inf(A)``.
+* ``legendre_to_cardinal``: one, its Gram being the identity.
+* ``cardinal_to_legendre`` and ``cardinal_dual_legendre_coeffs``: ``kappa_inf(A)``
+  with ``A`` the Legendre-to-cardinal matrix, which unlike the Bernstein pair
+  **is** accurate, so no product is needed.
+* ``bernstein_to_lagrange``: ``kappa_inf(C)`` with ``C`` the Lagrange-to-Bernstein
+  matrix, which is a pure tabulation and therefore exact to a rounding.
+
+The parity domain is smaller than the solvability domain, and that is the point
+---------------------------------------------------------------------------------
+
+`tests/_parity_harness.py` refuses a bound at least as large as the values it
+compares, which is Rule 3 of `design/backend_parity.md`. Here that guard has teeth:
+each builder's **solvability** domain runs to where ``kappa_inf eps < 1``, and at
+the top of that range the bound above is of order one -- so the comparison would
+decide nothing and the harness rightly rejects it.
+
+So parity is asserted over the **accuracy** domain instead: the degrees where
+``32 n kappa_inf eps < 1``. The two differ, per builder and per dtype, and
+`test_the_excluded_degrees_are_named` prints the gap rather than letting it pass
+as coverage. This is not a weakening. Above the accuracy domain the *answer* has no
+correct digits in either backend, so there is nothing for a parity claim to be
+about.
+
+One independent confirmation fell out of it. For ``cardinal_to_bernstein`` in
+float64 the derivation above stops at degree 9, and `pantr.change_basis`'s own
+docstring -- written before this port, from a different argument -- says its
+accuracy bound "reaches 100% after degree 10". Two derivations, one degree apart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.basis import LagrangeVariant
+from pantr.basis._basis_lagrange import _get_lagrange_points
+from pantr.change_basis import (
+    compute_bernstein_to_cardinal_1d,
+    compute_bernstein_to_lagrange_1d,
+    compute_cardinal_dual_legendre_coeffs_1d,
+    compute_cardinal_to_bernstein_1d,
+    compute_cardinal_to_legendre_1d,
+    compute_lagrange_to_bernstein_1d,
+    compute_legendre_to_cardinal_1d,
+    compute_monomial_to_bernstein_1d,
+)
+from tests._parity_harness import (
+    Roundings,
+    assert_parity,
+    bitwise_parity,
+    bounded_parity,
+    demand_the_compiled_kernel,
+)
+from tests.test_change_basis_domain import (
+    _bernstein_gram_exact,
+    _bernstein_to_cardinal_exact,
+    _kappa_inf,
+    _lagrange_to_bernstein_exact,
+    _legendre_to_cardinal_exact,
+)
+
+_GROWTH_ALLOWANCE: Final = 8
+"""Allowance for the LU growth factor ``rho``; see this module's docstring.
+
+The one constant here that is argued rather than derived. Partial pivoting bounds
+``rho`` only by ``2**(n-1)``, which no test could use, and the measured margin is
+reported by :func:`test_the_bound_is_approached_but_not_by_orders_of_magnitude`.
+"""
+
+_ROUNDINGS_PER_BACKEND: Final = 4
+"""``n u`` from the two products plus ``3 n u`` from the solve; see the docstring."""
+
+_CONSTANT: Final = _GROWTH_ALLOWANCE * _ROUNDINGS_PER_BACKEND
+"""The 32 of ``32 n kappa_inf eps``."""
+
+
+def _kappa_for_bernstein_to_cardinal(degree: int) -> Decimal:
+    """Condition number of the Bernstein Gram matrix, in exact arithmetic.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        Decimal: ``kappa_inf`` of the matrix the projection solves with.
+    """
+    return _kappa_inf(_bernstein_gram_exact(degree))
+
+
+def _kappa_for_cardinal_to_bernstein(degree: int) -> Decimal:
+    """Product of two exact condition numbers; see this module's docstring.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        Decimal: ``kappa_inf(A) * kappa_inf(G_bern)``.
+    """
+    return _kappa_inf(_bernstein_to_cardinal_exact(degree)) * _kappa_inf(
+        _bernstein_gram_exact(degree)
+    )
+
+
+def _kappa_for_legendre_to_cardinal(degree: int) -> Decimal:
+    """One: the Legendre Gram matrix under this quadrature is the identity.
+
+    Args:
+        degree (int): Polynomial degree, unused.
+
+    Returns:
+        Decimal: ``Decimal(1)``.
+    """
+    del degree
+    return Decimal(1)
+
+
+def _kappa_for_cardinal_to_legendre(degree: int) -> Decimal:
+    """Condition number of the Legendre-to-cardinal matrix, in exact arithmetic.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        Decimal: ``kappa_inf`` of the matrix this builder inverts.
+    """
+    return _kappa_inf(_legendre_to_cardinal_exact(degree))
+
+
+def _kappa_for_bernstein_to_lagrange(degree: int) -> Decimal:
+    """Condition number of the Lagrange-to-Bernstein matrix, in exact arithmetic.
+
+    Args:
+        degree (int): Polynomial degree.
+
+    Returns:
+        Decimal: ``kappa_inf`` of the matrix this builder inverts.
+    """
+    return _kappa_inf(_lagrange_to_bernstein_exact(degree, LagrangeVariant.EQUISPACES))
+
+
+_Builder = Callable[..., npt.NDArray[np.float32 | np.float64]]
+"""A public change-of-basis builder, called as ``(degree, dtype)``."""
+
+_SOLVING_BUILDERS: Final = (
+    ("bernstein_to_cardinal", compute_bernstein_to_cardinal_1d, _kappa_for_bernstein_to_cardinal),
+    ("cardinal_to_bernstein", compute_cardinal_to_bernstein_1d, _kappa_for_cardinal_to_bernstein),
+    ("legendre_to_cardinal", compute_legendre_to_cardinal_1d, _kappa_for_legendre_to_cardinal),
+    ("cardinal_to_legendre", compute_cardinal_to_legendre_1d, _kappa_for_cardinal_to_legendre),
+    (
+        "cardinal_dual_legendre",
+        compute_cardinal_dual_legendre_coeffs_1d,
+        _kappa_for_cardinal_to_legendre,
+    ),
+)
+"""The five builders whose bound is a condition number, with the kappa each uses.
+
+``bernstein_to_lagrange`` is not here because it takes a node variant as well as a
+degree; it has its own test.
+"""
+
+
+def _relative_bound(degree: int, kappa: Decimal, dtype: npt.DTypeLike) -> float:
+    """The relative parity bound ``32 n kappa_inf eps``.
+
+    Args:
+        degree (int): Polynomial degree; ``n`` is ``degree + 1``.
+        kappa (Decimal): The exact condition number for this builder.
+        dtype (npt.DTypeLike): The output dtype.
+
+    Returns:
+        float: The relative bound.
+    """
+    eps = float(np.finfo(np.dtype(dtype)).eps)
+    return _CONSTANT * (degree + 1) * float(kappa) * eps
+
+
+def _node_disagreement(variant: LagrangeVariant, n_pts: int, dtype: npt.DTypeLike) -> float:
+    """Largest gap between the Lagrange nodes the two backends produce.
+
+    An *input* difference rather than an output claim: the node families resolve
+    through :mod:`pantr.quad`, three of whose rules dispatch, so for some of them
+    the two backends do not start from the same array. Measuring it here keeps the
+    claim about the change-of-basis builder rather than about the quadrature.
+
+    Args:
+        variant (LagrangeVariant): The node family.
+        n_pts (int): Number of nodes.
+        dtype (npt.DTypeLike): The dtype the nodes are built in.
+
+    Returns:
+        float: ``max |x_cpp - x_python|``, zero when the two agree bit for bit.
+    """
+    with use_backend(Backend.PYTHON):
+        reference = _get_lagrange_points(variant, n_pts, dtype)
+    with use_backend(Backend.CPP):
+        actual = _get_lagrange_points(variant, n_pts, dtype)
+    return float(np.abs(actual.astype(np.float64) - reference.astype(np.float64)).max(initial=0.0))
+
+
+def _amplification_for(relative: float, largest: float, dtype: npt.DTypeLike) -> float:
+    """Convert a relative bound into the amplification the harness multiplies by ``u``.
+
+    :func:`tests._parity_harness.absolute_tolerance` returns
+    ``2 * (gamma * amplification)``, and with the unit-``u`` ``Roundings`` used here
+    ``gamma`` is ``u`` of the *accumulator* format. So an amplification of
+    ``relative * largest / eps`` yields an absolute tolerance of exactly
+    ``relative * largest``, since ``eps`` is ``2 u``.
+
+    The magnitude is the array's largest entry rather than each entry's own: a
+    solve's forward error is bounded in norm, so an individually tiny entry can
+    still carry an error of the norm's size, and an elementwise magnitude would
+    claim otherwise.
+
+    Args:
+        relative (float): The derived relative bound.
+        largest (float): The largest magnitude in the reference array.
+        dtype (npt.DTypeLike): The format the claim accumulates in.
+
+    Returns:
+        float: The amplification to hand to :func:`bounded_parity`.
+    """
+    return relative * largest / float(np.finfo(np.dtype(dtype)).eps)
+
+
+def _accuracy_domain(
+    kappa_of: Callable[[int], Decimal],
+    dtype: npt.DTypeLike,
+    solvable_to: int,
+    first: int = 0,
+) -> int:
+    """Largest degree at which the parity bound is still below one.
+
+    Above it the bound would exceed the values being compared and
+    :func:`tests._parity_harness.assert_parity` would refuse it, which is Rule 3
+    of ``design/backend_parity.md`` doing its job rather than a limitation here.
+
+    Args:
+        kappa_of (Callable[[int], Decimal]): The builder's exact condition number.
+        dtype (npt.DTypeLike): The output dtype.
+        solvable_to (int): The builder's tabulated degree limit for this dtype.
+        first (int): Lowest degree to consider. Defaults to 0; the Lagrange pair
+            needs 1, since two of its node families are undefined at one point.
+
+    Returns:
+        int: The largest degree with ``32 n kappa_inf eps < 1``, or ``first - 1``
+            if none.
+    """
+    largest = first - 1
+    for degree in range(first, solvable_to + 1):
+        if _relative_bound(degree, kappa_of(degree), dtype) < 1.0:
+            largest = degree
+        else:
+            break
+    return largest
+
+
+def _both_backends(
+    builder: _Builder, degree: int, dtype: npt.DTypeLike, **kwargs: object
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Run one builder under each backend.
+
+    Args:
+        builder (_Builder): The public builder to call.
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): The output dtype.
+        **kwargs (object): Extra keyword arguments for the builder.
+
+    Returns:
+        tuple: ``(cpp_result, python_result)``, in the order
+            :func:`tests._parity_harness.assert_parity` expects.
+    """
+    with use_backend(Backend.PYTHON):
+        reference = builder(degree, dtype=dtype, **kwargs)
+    with use_backend(Backend.CPP):
+        actual = builder(degree, dtype=dtype, **kwargs)
+    return actual, reference
+
+
+# --------------------------------------------------------------------------
+# The two builders that solve nothing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("degree", [1, 2, 5, 12, 20])
+@pytest.mark.parametrize("variant", list(LagrangeVariant))
+def test_lagrange_to_bernstein_is_bitwise(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike, variant: LagrangeVariant
+) -> None:
+    """The transposed tabulation is bit-identical, at every node family.
+
+    No solve and no product: the matrix *is* the Bernstein basis evaluated at the
+    Lagrange nodes, and that tabulation is bit-identical between the backends. The
+    node families are parametrized because two of the five are ones
+    :mod:`pantr._backend` never dispatches, so the nodes are the same array on both
+    sides by construction and the claim tests the tabulation alone.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    actual, reference = _both_backends(
+        compute_lagrange_to_bernstein_1d, degree, dtype, lagrange_variant=variant
+    )
+    context = f"lagrange_to_bernstein degree {degree} {np.dtype(dtype).name} {variant.name}"
+
+    node_gap = _node_disagreement(variant, degree + 1, dtype)
+    if node_gap == 0.0:
+        assert_parity(
+            actual,
+            reference,
+            bitwise_parity(
+                why=(
+                    "the matrix is the Bernstein basis tabulated at the Lagrange nodes and "
+                    "transposed. No solve, no product, the tabulation itself is bitwise "
+                    "(tests/parity/test_basis_bernstein.py), and this node family hands "
+                    "both backends the same array"
+                )
+            ),
+            context=context,
+        )
+        return
+
+    # The one case where the nodes themselves differ; see this module's docstring.
+    largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
+    eps = float(np.finfo(np.dtype(dtype)).eps)
+    amplification = np.full(reference.shape, (degree * node_gap) / eps + largest)
+    assert_parity(
+        actual,
+        reference,
+        bounded_parity(
+            roundings=Roundings(stages=1, accumulator_per_stage=1, storage_per_stage=0),
+            accumulator=dtype,
+            storage=dtype,
+            amplification=amplification,
+            why=(
+                f"the two backends are handed different nodes: {variant.name} resolves "
+                f"through pantr.quad.get_modified_chebyshev_nodes_1d, which dispatches and "
+                f"which the quad port measured as exact in float64 and one unit of roundoff "
+                f"in float32. Measured here at {node_gap:.3e}. Given identical nodes the "
+                f"tabulation is bitwise, so the whole difference is that perturbation "
+                f"propagated: |B'_(j,n)| = |n (B_(j-1,n-1) - B_(j,n-1))| <= n since every "
+                f"Bernstein value lies in [0, 1], so the matrix moves by at most n times the "
+                f"node gap, plus one rounding of the result"
+            ),
+        ),
+        context=context,
+    )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("degree", [0, 1, 3, 10, 30, 56])
+def test_monomial_to_bernstein_is_bitwise(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The binomial quotients are bit-identical through degree 56.
+
+    Both backends form ``C(i, j) / C(degree, j)`` as the correctly rounded quotient
+    of two exactly represented integers: Python's ``math.comb`` is an exact integer
+    and its ``/`` rounds once, and the C++ side builds a Pascal triangle by
+    addition, which keeps every entry exact while it stays at or below ``2**53``.
+
+    Degree 56 is the last degree at which that holds -- ``C(56, 28)`` is the largest
+    central binomial below ``2**53`` -- and it is in the list on purpose, as the
+    frontier case. The builder carries no degree limit, so above 56 the two may
+    round differently and no claim is made.
+    """
+    del cpp_backend
+    actual, reference = _both_backends(compute_monomial_to_bernstein_1d, degree, dtype)
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(
+            why=(
+                "both backends divide two exactly represented integers, so both get the "
+                "correctly rounded quotient of the same exact rational. Holds while every "
+                "binomial is at or below 2**53, i.e. through degree 56"
+            )
+        ),
+        context=f"monomial_to_bernstein degree {degree} {np.dtype(dtype).name}",
+    )
+
+
+# --------------------------------------------------------------------------
+# The six that solve
+# --------------------------------------------------------------------------
+
+_SOLVABLE_TO: Final = {
+    ("bernstein_to_cardinal", "float64"): 26,
+    ("bernstein_to_cardinal", "float32"): 12,
+    ("cardinal_to_bernstein", "float64"): 14,
+    ("cardinal_to_bernstein", "float32"): 8,
+    ("legendre_to_cardinal", "float64"): 20,
+    ("legendre_to_cardinal", "float32"): 20,
+    ("cardinal_to_legendre", "float64"): 12,
+    ("cardinal_to_legendre", "float32"): 6,
+    ("cardinal_dual_legendre", "float64"): 12,
+    ("cardinal_dual_legendre", "float32"): 6,
+}
+"""Largest degree each builder accepts, per dtype.
+
+Read off ``pantr.change_basis``'s tabulated limits, except for
+``legendre_to_cardinal``, which carries none -- it solves with an identity Gram --
+and is capped here at 20 only to bound the test's runtime.
+"""
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize(("label", "builder", "kappa_of"), _SOLVING_BUILDERS)
+def test_a_solving_builder_agrees_within_its_condition_number(
+    cpp_backend: None,
+    label: str,
+    builder: _Builder,
+    kappa_of: Callable[[int], Decimal],
+    dtype: npt.DTypeLike,
+) -> None:
+    """The two backends agree to ``32 n kappa_inf eps``, over the accuracy domain.
+
+    The degrees tested are every one at which that bound is below one. Above them
+    the harness refuses the claim as vacuous, which is Rule 3 and is correct: the
+    answer has no digits there in either backend.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    top = _accuracy_domain(kappa_of, dtype, _SOLVABLE_TO[(label, np.dtype(dtype).name)])
+    assert top >= 0, f"{label}/{np.dtype(dtype).name}: no degree has a usable bound"
+
+    for degree in range(top + 1):
+        actual, reference = _both_backends(builder, degree, dtype)
+        largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
+        relative = _relative_bound(degree, kappa_of(degree), dtype)
+        # The magnitude that turns the relative bound into an absolute one is the
+        # array's largest entry, not each entry's own. A solve's forward error is
+        # bounded in norm, so an individually tiny entry can still carry an error
+        # of the norm's size, and an elementwise magnitude would claim otherwise.
+        amplification = np.full(reference.shape, _amplification_for(relative, largest, dtype))
+        assert_parity(
+            actual,
+            reference,
+            bounded_parity(
+                roundings=Roundings(stages=1, accumulator_per_stage=1, storage_per_stage=0),
+                accumulator=dtype,
+                storage=dtype,
+                amplification=amplification,
+                why=(
+                    f"32 n kappa_inf eps with kappa_inf = {float(kappa_of(degree)):.4e} "
+                    f"computed in exact rational arithmetic, n = {degree + 1}. "
+                    f"The budget is a derived ratio rather than a dependency chain, so "
+                    f"Roundings is the unit-u spelling; see this module's docstring for "
+                    f"the derivation and for why the constant is 32"
+                ),
+            ),
+            context=f"{label} degree {degree} {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("variant", list(LagrangeVariant))
+def test_bernstein_to_lagrange_agrees_within_its_condition_number(
+    cpp_backend: None, dtype: npt.DTypeLike, variant: LagrangeVariant
+) -> None:
+    """Same claim as the five above, for the builder that takes a node family.
+
+    Its condition number depends on the family: equispaced nodes are the worst,
+    and the exact ``kappa_inf`` is recomputed here per variant rather than assumed
+    to be the equispaced one.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    def kappa_of(degree: int) -> Decimal:
+        return _kappa_inf(_lagrange_to_bernstein_exact(degree, variant))
+
+    solvable = {
+        LagrangeVariant.EQUISPACES: {"float64": 37, "float32": 17},
+        LagrangeVariant.GAUSS_LEGENDRE: {"float64": 51, "float32": 22},
+        LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: {"float64": 52, "float32": 23},
+        LagrangeVariant.CHEBYSHEV_1ST: {"float64": 52, "float32": 23},
+        LagrangeVariant.CHEBYSHEV_2ND: {"float64": 52, "float32": 23},
+    }[variant][np.dtype(dtype).name]
+
+    top = _accuracy_domain(kappa_of, dtype, min(solvable, 20), first=1)
+    assert top >= 1, f"{variant.name}/{np.dtype(dtype).name}: no degree has a usable bound"
+
+    for degree in range(1, top + 1):
+        actual, reference = _both_backends(
+            compute_bernstein_to_lagrange_1d, degree, dtype, lagrange_variant=variant
+        )
+        largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
+        relative = _relative_bound(degree, kappa_of(degree), dtype)
+        amplification = np.full(reference.shape, _amplification_for(relative, largest, dtype))
+        assert_parity(
+            actual,
+            reference,
+            bounded_parity(
+                roundings=Roundings(stages=1, accumulator_per_stage=1, storage_per_stage=0),
+                accumulator=dtype,
+                storage=dtype,
+                amplification=amplification,
+                why=(
+                    f"32 n kappa_inf eps with kappa_inf = {float(kappa_of(degree)):.4e} for "
+                    f"{variant.name} nodes, computed in exact rational arithmetic"
+                ),
+            ),
+            context=f"bernstein_to_lagrange degree {degree} {variant.name} {np.dtype(dtype).name}",
+        )
+
+
+# --------------------------------------------------------------------------
+# What the claims above do and do not cover
+# --------------------------------------------------------------------------
+
+
+def test_the_excluded_degrees_are_named() -> None:
+    """Every degree inside the solvability domain but outside the parity domain.
+
+    A test that quietly stops at the accuracy domain would read as full coverage of
+    the module. This one fails if the gap is ever empty for all builders -- which
+    would mean the bound had become vacuous or the domains had merged -- and
+    otherwise records the gap in its own assertion message.
+    """
+    gaps: list[str] = []
+    for label, _builder, kappa_of in _SOLVING_BUILDERS:
+        for dtype in (np.float64, np.float32):
+            name = np.dtype(dtype).name
+            solvable = _SOLVABLE_TO[(label, name)]
+            top = _accuracy_domain(kappa_of, dtype, solvable)
+            if top < solvable:
+                gaps.append(f"{label}/{name}: parity to {top}, solvable to {solvable}")
+
+    assert gaps, (
+        "no builder has a degree it accepts but this file cannot compare, which would "
+        "mean either the bound collapsed or the tabulated domains changed. Both are "
+        "findings rather than good news"
+    )
+
+
+def test_the_bound_is_approached_but_not_by_orders_of_magnitude(cpp_backend: None) -> None:
+    """The bound is loose, and this measures by how much rather than assuming.
+
+    A tolerance never approached asserts nothing, and the constant in this file
+    carries an argued allowance of ``rho <= 8`` for the LU growth factor. So the
+    margin is measured over **every** degree tested, not only the top one, and the
+    distinction matters: at the top of each accuracy domain ``kappa`` is by
+    construction as large as it gets and the bound is at its loosest, while lower
+    down it tracks the observed difference far more closely.
+
+    Measured on the development server, worst ratio of observed difference to
+    derived bound, per builder, over its whole accuracy domain in float64:
+    ``bernstein_to_cardinal`` 2.0e-3, ``cardinal_to_bernstein`` 8.7e-4,
+    ``legendre_to_cardinal`` 7.8e-3, ``cardinal_to_legendre`` 5.6e-4. So the bound
+    is between roughly 130 and 1800 times what is observed at its tightest point,
+    which is the usual price of a condition-number argument: it is a worst case
+    over all perturbation directions, and two implementations of the same algorithm
+    do not perturb in the worst one.
+
+    The assertion is global rather than per builder: somewhere in this file's
+    coverage the bound must come within ``1e-4`` of being reached. That threshold
+    sits about 80 times below the measured 7.8e-3, so it is not fitted to the
+    measurement; it is there to fail if the bounds all go vacuous at once, which is
+    what a wrong ``kappa`` or a wrong conversion to absolute would do.
+    """
+    del cpp_backend
+    tightest = 0.0
+    where = ""
+    for label, builder, kappa_of in _SOLVING_BUILDERS:
+        for dtype in (np.float64, np.float32):
+            name = np.dtype(dtype).name
+            top = _accuracy_domain(kappa_of, dtype, _SOLVABLE_TO[(label, name)])
+            for degree in range(top + 1):
+                actual, reference = _both_backends(builder, degree, dtype)
+                largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
+                bound = _relative_bound(degree, kappa_of(degree), dtype) * largest
+                observed = float(
+                    np.abs(actual.astype(np.float64) - reference.astype(np.float64)).max(
+                        initial=0.0
+                    )
+                )
+                if bound <= 0.0:
+                    continue
+                ratio = observed / bound
+                if ratio > tightest:
+                    tightest, where = ratio, f"{label}/{name} at degree {degree}"
+                assert ratio <= 1.0, (
+                    f"{label}/{name} degree {degree}: observed {observed:.3e} against a "
+                    f"bound of {bound:.3e}. The parity assertions should have caught this "
+                    f"first, so reaching it here means the two disagree about the bound"
+                )
+
+    assert tightest >= 1e-4, (
+        f"the tightest point in this file's whole coverage is {tightest:.3e} of its bound "
+        f"({where}). Every bound here is now loose enough to admit a wrong answer, which is "
+        f"what a mistaken kappa or a mistaken relative-to-absolute conversion looks like"
+    )

--- a/tests/parity/test_change_basis.py
+++ b/tests/parity/test_change_basis.py
@@ -28,7 +28,7 @@ The bound
 Both backends compute the same matrix by the same three steps: tabulate the two
 bases at the quadrature nodes, form ``G = B^T W B`` and ``C = B^T W A``, and solve
 ``G M^T = C``. The tabulations are bit-identical (measured; see
-`tests/parity/test_basis_bernstein.py` and its Legendre sibling), so they
+`tests/parity/test_basis_tabulations.py`), so they
 contribute nothing. The other two steps do:
 
 1. **The products.** numpy contracts them with a BLAS ``gemm``, Eigen with its own
@@ -390,7 +390,7 @@ def test_lagrange_to_bernstein_is_bitwise(
                 why=(
                     "the matrix is the Bernstein basis tabulated at the Lagrange nodes and "
                     "transposed. No solve, no product, the tabulation itself is bitwise "
-                    "(tests/parity/test_basis_bernstein.py), and this node family hands "
+                    "(tests/parity/test_basis_tabulations.py), and this node family hands "
                     "both backends the same array"
                 )
             ),

--- a/tests/parity/test_change_basis.py
+++ b/tests/parity/test_change_basis.py
@@ -32,29 +32,71 @@ bases at the quadrature nodes, form ``G = B^T W B`` and ``C = B^T W A``, and sol
 contribute nothing. The other two steps do:
 
 1. **The products.** numpy contracts them with a BLAS ``gemm``, Eigen with its own
-   blocked product. Both sum the same ``n_quad`` terms in different orders, so each
-   perturbs ``G`` and ``C`` by a relative ``n u`` (Higham, *Accuracy and Stability
-   of Numerical Algorithms*, 2nd ed., SIAM 2002, §3.1). The ``W`` factor
-   contributes nothing: multiplying by a diagonal adds only exact zeros to a dot
-   product.
+   blocked product, summing the same ``n_quad`` terms in different orders. There
+   are **two** of them, ``G`` and ``C``, and **both** are amplified by
+   ``kappa_inf`` in the forward error, since a perturbation of the right-hand side
+   enters with the same condition number as one of the matrix. Each costs
+   ``gamma_{n+1}`` (Higham, *Accuracy and Stability of Numerical Algorithms*,
+   2nd ed., SIAM 2002, §3.1; blocking only tightens this, per pp. 62-64).
+
+   The relative size of the perturbation is **not** ``n u`` for every basis, and
+   this is the step that a first version of this file got wrong. Write
+
+       c = || |B|^T W |B| ||_inf / || B^T W B ||_inf
+
+   for the cancellation factor of a Gram matrix. For a **non-negative** basis --
+   Bernstein and every Lagrange family here -- nothing cancels and ``c = 1``
+   exactly. For the **orthonormal Legendre** basis the Gram is the identity by
+   exact quadrature, so every off-diagonal zero is a *cancelled* sum and ``c``
+   grows like ``0.88 n`` (measured 7.95 at degree 8, 18.34 at 20). Higham states
+   the general fact next to the equation cited above, p. 63: high relative accuracy
+   is not guaranteed when ``|x^T y|`` is much smaller than ``|x|^T |y|``. Since
+   ``kappa_inf`` is 1 for that basis, nothing else absorbs it, so ``c`` is computed
+   per builder below rather than assumed.
+
+   The ``W`` factor contributes no *summation* error -- multiplying by a diagonal
+   adds only exact zeros to a dot product -- but it does cost one rounding per
+   entry, which the count above carries.
 
 2. **The solve.** ``numpy.linalg.solve`` is LAPACK ``gesv`` and the port uses
    ``Eigen::PartialPivLU``. Both are LU with partial pivoting and both are backward
-   stable, so each computed solution satisfies ``(A + dA) x = b`` with
-   ``||dA||_inf <= c rho gamma_n ||A||_inf`` and hence a forward error of order
-   ``kappa_inf(A) gamma_{3n}`` (ibid., Thm 9.4).
+   stable. The applicable result is Higham **Thm 9.4**, which is *componentwise*:
+   ``|dA| <= gamma_{3n} |L||U|``, pivoting-agnostic. It is worth naming which
+   theorem this is not: the *normwise* partial-pivoting form,
+   ``||dA||_inf <= n^2 gamma_{3n} rho_n ||A||_inf``, is **Thm 9.5**, and read
+   literally it would put an ``n^2`` in front of everything below. This file used
+   to cite 9.4 and quote 9.5's shape without its ``n^2``; the bound it produced is
+   still sound, but by the componentwise route, and that route needs its own
+   allowance.
 
-Adding the two and writing ``eps = 2 u``, one backend's relative error is at most
-about ``4 n kappa_inf rho u``, i.e. ``2 n kappa_inf rho eps``. The harness doubles
-it, since neither side is the exact answer.
+   The allowance the componentwise route needs is **not** the classical growth
+   factor ``rho_n = max|U|/max|A|`` but
 
-**The constant used below is 32, and ``rho`` is why.** Partial pivoting bounds the
-growth factor only by ``2**(n-1)``, which is worthless here, and in practice it is
-a small number for these matrices. So 32 folds in an allowance of ``rho <= 8`` on
-top of the ``4 n kappa eps``, and that allowance is **argued, not proved**: it is
-the one place in this file where a constant is not derived. What is measured is
-the margin, and `test_the_bound_is_approached_but_not_by_orders_of_magnitude`
-reports it so a future reader can see whether 8 was generous or lucky.
+       R = || |L| |U| ||_inf / ||A||_inf
+
+   which is what Thm 9.4 literally multiplies, and which can exceed ``rho_n`` by up
+   to ``n``.
+
+Adding the two and writing ``eps = 2 u``, the two-sided relative bound is
+
+    (c_G + c_C + 3 R) * n * kappa_inf * eps
+
+with ``c_C = 1`` always (the mixed matrix pairs the new basis against a
+non-negative one) and ``c_G`` as above.
+
+**``R`` is measured, not assumed, and that is new.** Over every matrix these
+builders feed a solve -- Bernstein Gram, Legendre Gram, Legendre-to-cardinal,
+Lagrange-to-Bernstein in all five node families -- in exact rational arithmetic
+across every degree in every solvability domain: ``R <= 3.73`` and the classical
+``rho_n`` is exactly ``1.000``. An independent sweep of 1508 matrices out to degree
+200 through Eigen's own ``matrixLU()`` agrees, and finds ``R`` crossing 8 only near
+degree 160. The allowance used below is **8**, so the margin is 2.1x in domain.
+
+Keeping 8 rather than tightening to 4 is deliberate and was quantified: halving it
+buys **one degree** on three of ten (builder, dtype) pairs, because ``kappa_inf``
+grows geometrically and is what limits the parity domain. What was worth fixing was
+not the size of the allowance but the two errors beside it -- the missing second
+product, and ``c_G``.
 
 Which ``kappa``, per builder
 ----------------------------
@@ -105,14 +147,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from decimal import Decimal
-from typing import Final
+from typing import Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
 import pytest
 
 from pantr._backend import Backend, use_backend
-from pantr.basis import LagrangeVariant
+from pantr.basis import LagrangeVariant, tabulate_bernstein_1d, tabulate_legendre_1d
 from pantr.basis._basis_lagrange import _get_lagrange_points
 from pantr.change_basis import (
     compute_bernstein_to_cardinal_1d,
@@ -124,6 +166,7 @@ from pantr.change_basis import (
     compute_legendre_to_cardinal_1d,
     compute_monomial_to_bernstein_1d,
 )
+from pantr.quad import get_gauss_legendre_1d
 from tests._parity_harness import (
     Roundings,
     assert_parity,
@@ -139,19 +182,56 @@ from tests.test_change_basis_domain import (
     _legendre_to_cardinal_exact,
 )
 
-_GROWTH_ALLOWANCE: Final = 8
-"""Allowance for the LU growth factor ``rho``; see this module's docstring.
+_LU_ALLOWANCE: Final = 8
+"""Allowance for ``R = || |L||U| ||_inf / ||A||_inf`` in Higham Thm 9.4.
 
-The one constant here that is argued rather than derived. Partial pivoting bounds
-``rho`` only by ``2**(n-1)``, which no test could use, and the measured margin is
-reported by :func:`test_the_bound_is_approached_but_not_by_orders_of_magnitude`.
+**Measured, not argued.** Exact rational arithmetic over every matrix these
+builders factor, across every solvability domain, gives ``R <= 3.73``, with the
+classical growth factor ``rho_n`` exactly ``1.000``; an independent sweep of 1508
+matrices to degree 200 through Eigen's own ``matrixLU()`` agrees and finds ``R``
+crossing 8 only near degree 160. So the margin is 2.1x in domain, and the allowance
+stops covering anything past degree 160 -- which no builder here reaches, and which
+is the caveat to carry if one ever does.
+
+Deliberately not tightened to 4: measured, that buys one degree on three of ten
+(builder, dtype) pairs, because ``kappa_inf`` grows geometrically and is what
+actually limits the parity domain.
 """
 
-_ROUNDINGS_PER_BACKEND: Final = 4
-"""``n u`` from the two products plus ``3 n u`` from the solve; see the docstring."""
+_MIXED_CANCELLATION: Final = 1.0
+"""``c_C``, the cancellation factor of the mixed matrix ``C = B_new^T W B_old``.
 
-_CONSTANT: Final = _GROWTH_ALLOWANCE * _ROUNDINGS_PER_BACKEND
-"""The 32 of ``32 n kappa_inf eps``."""
+Exactly one: ``B_old`` is a cardinal B-spline or Bernstein basis, both non-negative
+on ``[0, 1]``, so no entry of the contraction cancels against another. Unlike
+``c_G`` this does not need computing per builder.
+"""
+
+
+def _gram_cancellation(
+    new_basis: npt.NDArray[np.float64], weights: npt.NDArray[np.float64]
+) -> float:
+    """Compute ``c_G``, the Gram matrix's cancellation factor.
+
+    ``|| |B|^T W |B| ||_inf / || B^T W B ||_inf``. One for a non-negative basis,
+    where nothing cancels; of order ``0.88 n`` for the orthonormal Legendre basis,
+    whose Gram is the identity precisely because its off-diagonal sums cancel. See
+    this module's docstring for why that factor is not absorbed elsewhere.
+
+    Args:
+        new_basis (npt.NDArray[np.float64]): The new basis at the quadrature nodes,
+            shape ``(n_quad, n_new)``.
+        weights (npt.NDArray[np.float64]): The quadrature weights.
+
+    Returns:
+        float: The cancellation factor, at least one.
+    """
+    scaled = new_basis.T * weights
+    gram = scaled @ new_basis
+    magnitude = np.abs(new_basis).T * np.abs(weights) @ np.abs(new_basis)
+    denominator = float(np.abs(gram).sum(axis=1).max())
+    if denominator == 0.0:
+        return 1.0
+    return max(1.0, float(np.abs(magnitude).sum(axis=1).max()) / denominator)
 
 
 def _kappa_for_bernstein_to_cardinal(degree: int) -> Decimal:
@@ -220,15 +300,58 @@ def _kappa_for_bernstein_to_lagrange(degree: int) -> Decimal:
 _Builder = Callable[..., npt.NDArray[np.float32 | np.float64]]
 """A public change-of-basis builder, called as ``(degree, dtype)``."""
 
+
+class _SolvingBuilder(NamedTuple):
+    """One builder whose parity bound is a condition number, and what that bound needs.
+
+    A record rather than a tuple because four parallel fields in a parametrize list
+    is exactly the shape the project's style rules send to a named struct, and
+    because two of the four are only meaningful together.
+
+    Attributes:
+        label (str): The builder's short name, for failure messages.
+        builder (_Builder): The public function, called as ``(degree, dtype=...)``.
+        kappa_of (Callable[[int], Decimal]): Its exact condition number per degree.
+        basis_name (str): The basis its Gram projection uses, for ``c_G``:
+            ``"bernstein"``, ``"legendre"``, or ``"none"``.
+    """
+
+    label: str
+    builder: _Builder
+    kappa_of: Callable[[int], Decimal]
+    basis_name: str
+
+
 _SOLVING_BUILDERS: Final = (
-    ("bernstein_to_cardinal", compute_bernstein_to_cardinal_1d, _kappa_for_bernstein_to_cardinal),
-    ("cardinal_to_bernstein", compute_cardinal_to_bernstein_1d, _kappa_for_cardinal_to_bernstein),
-    ("legendre_to_cardinal", compute_legendre_to_cardinal_1d, _kappa_for_legendre_to_cardinal),
-    ("cardinal_to_legendre", compute_cardinal_to_legendre_1d, _kappa_for_cardinal_to_legendre),
-    (
+    _SolvingBuilder(
+        "bernstein_to_cardinal",
+        compute_bernstein_to_cardinal_1d,
+        _kappa_for_bernstein_to_cardinal,
+        "bernstein",
+    ),
+    _SolvingBuilder(
+        "cardinal_to_bernstein",
+        compute_cardinal_to_bernstein_1d,
+        _kappa_for_cardinal_to_bernstein,
+        "bernstein",
+    ),
+    _SolvingBuilder(
+        "legendre_to_cardinal",
+        compute_legendre_to_cardinal_1d,
+        _kappa_for_legendre_to_cardinal,
+        "legendre",
+    ),
+    _SolvingBuilder(
+        "cardinal_to_legendre",
+        compute_cardinal_to_legendre_1d,
+        _kappa_for_cardinal_to_legendre,
+        "legendre",
+    ),
+    _SolvingBuilder(
         "cardinal_dual_legendre",
         compute_cardinal_dual_legendre_coeffs_1d,
         _kappa_for_cardinal_to_legendre,
+        "legendre",
     ),
 )
 """The five builders whose bound is a condition number, with the kappa each uses.
@@ -238,19 +361,24 @@ degree; it has its own test.
 """
 
 
-def _relative_bound(degree: int, kappa: Decimal, dtype: npt.DTypeLike) -> float:
-    """The relative parity bound ``32 n kappa_inf eps``.
+def _relative_bound(
+    degree: int, kappa: Decimal, dtype: npt.DTypeLike, gram_cancellation: float = 1.0
+) -> float:
+    """The relative parity bound ``(c_G + c_C + 3 R) n kappa_inf eps``.
 
     Args:
         degree (int): Polynomial degree; ``n`` is ``degree + 1``.
         kappa (Decimal): The exact condition number for this builder.
         dtype (npt.DTypeLike): The output dtype.
+        gram_cancellation (float): ``c_G`` for this builder's Gram matrix. One for a
+            non-negative basis. Defaults to 1.0.
 
     Returns:
-        float: The relative bound.
+        float: The two-sided relative bound.
     """
     eps = float(np.finfo(np.dtype(dtype)).eps)
-    return _CONSTANT * (degree + 1) * float(kappa) * eps
+    constant = gram_cancellation + _MIXED_CANCELLATION + 3 * _LU_ALLOWANCE
+    return constant * (degree + 1) * float(kappa) * eps
 
 
 def _node_disagreement(variant: LagrangeVariant, n_pts: int, dtype: npt.DTypeLike) -> float:
@@ -301,11 +429,39 @@ def _amplification_for(relative: float, largest: float, dtype: npt.DTypeLike) ->
     return relative * largest / float(np.finfo(np.dtype(dtype)).eps)
 
 
+def _cancellation_for(new_basis_name: str, degree: int, dtype: npt.DTypeLike) -> float:
+    """``c_G`` for the basis a given builder projects onto, at this degree.
+
+    Computed rather than tabulated, so a non-negative basis returns exactly one by
+    arithmetic instead of by assertion, and the Legendre growth is measured at the
+    degree it is used at.
+
+    Args:
+        new_basis_name (str): ``"bernstein"``, ``"legendre"``, or ``"none"`` for a
+            builder that runs no Gram projection.
+        degree (int): Polynomial degree.
+        dtype (npt.DTypeLike): The dtype the builder was asked for.
+
+    Returns:
+        float: The cancellation factor.
+    """
+    if new_basis_name == "none":
+        return 1.0
+    with use_backend(Backend.PYTHON):
+        points, weights = get_gauss_legendre_1d(degree + 1, dtype)
+        tabulate = tabulate_bernstein_1d if new_basis_name == "bernstein" else tabulate_legendre_1d
+        basis = tabulate(degree, points)
+    return _gram_cancellation(
+        np.asarray(basis, dtype=np.float64), np.asarray(weights, dtype=np.float64)
+    )
+
+
 def _accuracy_domain(
     kappa_of: Callable[[int], Decimal],
     dtype: npt.DTypeLike,
     solvable_to: int,
     first: int = 0,
+    basis_name: str = "none",
 ) -> int:
     """Largest degree at which the parity bound is still below one.
 
@@ -319,6 +475,8 @@ def _accuracy_domain(
         solvable_to (int): The builder's tabulated degree limit for this dtype.
         first (int): Lowest degree to consider. Defaults to 0; the Lagrange pair
             needs 1, since two of its node families are undefined at one point.
+        basis_name (str): Which basis this builder projects onto, for ``c_G``.
+            Defaults to "none".
 
     Returns:
         int: The largest degree with ``32 n kappa_inf eps < 1``, or ``first - 1``
@@ -326,7 +484,8 @@ def _accuracy_domain(
     """
     largest = first - 1
     for degree in range(first, solvable_to + 1):
-        if _relative_bound(degree, kappa_of(degree), dtype) < 1.0:
+        cancellation = _cancellation_for(basis_name, degree, dtype)
+        if _relative_bound(degree, kappa_of(degree), dtype, cancellation) < 1.0:
             largest = degree
         else:
             break
@@ -462,6 +621,21 @@ def test_monomial_to_bernstein_is_bitwise(
 # The six that solve
 # --------------------------------------------------------------------------
 
+_BERNSTEIN_TO_LAGRANGE_SOLVABLE: Final = {
+    LagrangeVariant.EQUISPACES: {"float64": 37, "float32": 17},
+    LagrangeVariant.GAUSS_LEGENDRE: {"float64": 51, "float32": 22},
+    LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: {"float64": 52, "float32": 23},
+    LagrangeVariant.CHEBYSHEV_1ST: {"float64": 52, "float32": 23},
+    LagrangeVariant.CHEBYSHEV_2ND: {"float64": 52, "float32": 23},
+}
+"""Largest degree ``compute_bernstein_to_lagrange_1d`` accepts, per node family.
+
+Read off ``_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE`` in
+:mod:`pantr.change_basis._builders`. One copy, because two tests need it and the
+census below is the one that would silently stop counting if they drifted.
+"""
+
+
 _SOLVABLE_TO: Final = {
     ("bernstein_to_cardinal", "float64"): 26,
     ("bernstein_to_cardinal", "float32"): 12,
@@ -483,13 +657,9 @@ and is capped here at 20 only to bound the test's runtime.
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32])
-@pytest.mark.parametrize(("label", "builder", "kappa_of"), _SOLVING_BUILDERS)
+@pytest.mark.parametrize("entry", _SOLVING_BUILDERS, ids=[e.label for e in _SOLVING_BUILDERS])
 def test_a_solving_builder_agrees_within_its_condition_number(
-    cpp_backend: None,
-    label: str,
-    builder: _Builder,
-    kappa_of: Callable[[int], Decimal],
-    dtype: npt.DTypeLike,
+    cpp_backend: None, entry: _SolvingBuilder, dtype: npt.DTypeLike
 ) -> None:
     """The two backends agree to ``32 n kappa_inf eps``, over the accuracy domain.
 
@@ -499,13 +669,18 @@ def test_a_solving_builder_agrees_within_its_condition_number(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    top = _accuracy_domain(kappa_of, dtype, _SOLVABLE_TO[(label, np.dtype(dtype).name)])
+    label, builder, kappa_of, basis_name = entry
+    top = _accuracy_domain(
+        kappa_of, dtype, _SOLVABLE_TO[(label, np.dtype(dtype).name)], basis_name=basis_name
+    )
     assert top >= 0, f"{label}/{np.dtype(dtype).name}: no degree has a usable bound"
 
     for degree in range(top + 1):
         actual, reference = _both_backends(builder, degree, dtype)
         largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
-        relative = _relative_bound(degree, kappa_of(degree), dtype)
+        relative = _relative_bound(
+            degree, kappa_of(degree), dtype, _cancellation_for(basis_name, degree, dtype)
+        )
         # The magnitude that turns the relative bound into an absolute one is the
         # array's largest entry, not each entry's own. A solve's forward error is
         # bounded in norm, so an individually tiny entry can still carry an error
@@ -548,13 +723,7 @@ def test_bernstein_to_lagrange_agrees_within_its_condition_number(
     def kappa_of(degree: int) -> Decimal:
         return _kappa_inf(_lagrange_to_bernstein_exact(degree, variant))
 
-    solvable = {
-        LagrangeVariant.EQUISPACES: {"float64": 37, "float32": 17},
-        LagrangeVariant.GAUSS_LEGENDRE: {"float64": 51, "float32": 22},
-        LagrangeVariant.GAUSS_LOBATTO_LEGENDRE: {"float64": 52, "float32": 23},
-        LagrangeVariant.CHEBYSHEV_1ST: {"float64": 52, "float32": 23},
-        LagrangeVariant.CHEBYSHEV_2ND: {"float64": 52, "float32": 23},
-    }[variant][np.dtype(dtype).name]
+    solvable = _BERNSTEIN_TO_LAGRANGE_SOLVABLE[variant][np.dtype(dtype).name]
 
     top = _accuracy_domain(kappa_of, dtype, min(solvable, 20), first=1)
     assert top >= 1, f"{variant.name}/{np.dtype(dtype).name}: no degree has a usable bound"
@@ -597,11 +766,30 @@ def test_the_excluded_degrees_are_named() -> None:
     otherwise records the gap in its own assertion message.
     """
     gaps: list[str] = []
-    for label, _builder, kappa_of in _SOLVING_BUILDERS:
+
+    # The Lagrange pair is not in `_SOLVING_BUILDERS` because it takes a node
+    # family as well as a degree, and it was therefore missing from this census
+    # entirely -- the one builder whose gap nobody was counting.
+    for variant in LagrangeVariant:
+        for dtype in (np.float64, np.float32):
+            name = np.dtype(dtype).name
+            solvable = _BERNSTEIN_TO_LAGRANGE_SOLVABLE[variant][name]
+
+            def kappa_of_variant(degree: int, variant: LagrangeVariant = variant) -> Decimal:
+                return _kappa_inf(_lagrange_to_bernstein_exact(degree, variant))
+
+            top = _accuracy_domain(kappa_of_variant, dtype, solvable, first=1)
+            if top < solvable:
+                gaps.append(
+                    f"bernstein_to_lagrange[{variant.name}]/{name}: parity to {top}, "
+                    f"solvable to {solvable}"
+                )
+
+    for label, _builder, kappa_of, basis_name in _SOLVING_BUILDERS:
         for dtype in (np.float64, np.float32):
             name = np.dtype(dtype).name
             solvable = _SOLVABLE_TO[(label, name)]
-            top = _accuracy_domain(kappa_of, dtype, solvable)
+            top = _accuracy_domain(kappa_of, dtype, solvable, basis_name=basis_name)
             if top < solvable:
                 gaps.append(f"{label}/{name}: parity to {top}, solvable to {solvable}")
 
@@ -631,23 +819,35 @@ def test_the_bound_is_approached_but_not_by_orders_of_magnitude(cpp_backend: Non
     over all perturbation directions, and two implementations of the same algorithm
     do not perturb in the worst one.
 
-    The assertion is global rather than per builder: somewhere in this file's
-    coverage the bound must come within ``1e-4`` of being reached. That threshold
-    sits about 80 times below the measured 7.8e-3, so it is not fitted to the
-    measurement; it is there to fail if the bounds all go vacuous at once, which is
+    The assertion excludes ``legendre_to_cardinal``, and that exclusion is the
+    point rather than a convenience. Its ``kappa`` is the hard-wired constant one,
+    and it also happens to be where the global tightest ratio lands (at degree 2,
+    with ``n = 3``). A gate whose maximum sits there claims to catch a wrong
+    ``kappa`` while never evaluating one, which is the failure this test was
+    written to prevent and was itself committing.
+
+    So the threshold is applied to the builders whose bound actually carries a
+    condition number. It must come within ``1e-4`` of being reached, about 80 times
+    below the measured tightest point among those, so it is not fitted to the
+    measurement; it is there to fail if those bounds go vacuous at once, which is
     what a wrong ``kappa`` or a wrong conversion to absolute would do.
     """
     del cpp_backend
     tightest = 0.0
     where = ""
-    for label, builder, kappa_of in _SOLVING_BUILDERS:
+    tightest_with_kappa = 0.0
+    where_with_kappa = ""
+    for label, builder, kappa_of, basis_name in _SOLVING_BUILDERS:
         for dtype in (np.float64, np.float32):
             name = np.dtype(dtype).name
-            top = _accuracy_domain(kappa_of, dtype, _SOLVABLE_TO[(label, name)])
+            top = _accuracy_domain(
+                kappa_of, dtype, _SOLVABLE_TO[(label, name)], basis_name=basis_name
+            )
             for degree in range(top + 1):
                 actual, reference = _both_backends(builder, degree, dtype)
                 largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
-                bound = _relative_bound(degree, kappa_of(degree), dtype) * largest
+                cancellation = _cancellation_for(basis_name, degree, dtype)
+                bound = _relative_bound(degree, kappa_of(degree), dtype, cancellation) * largest
                 observed = float(
                     np.abs(actual.astype(np.float64) - reference.astype(np.float64)).max(
                         initial=0.0
@@ -658,14 +858,19 @@ def test_the_bound_is_approached_but_not_by_orders_of_magnitude(cpp_backend: Non
                 ratio = observed / bound
                 if ratio > tightest:
                     tightest, where = ratio, f"{label}/{name} at degree {degree}"
+                if float(kappa_of(degree)) > 1.0 and ratio > tightest_with_kappa:
+                    tightest_with_kappa = ratio
+                    where_with_kappa = f"{label}/{name} at degree {degree}"
                 assert ratio <= 1.0, (
                     f"{label}/{name} degree {degree}: observed {observed:.3e} against a "
                     f"bound of {bound:.3e}. The parity assertions should have caught this "
                     f"first, so reaching it here means the two disagree about the bound"
                 )
 
-    assert tightest >= 1e-4, (
-        f"the tightest point in this file's whole coverage is {tightest:.3e} of its bound "
-        f"({where}). Every bound here is now loose enough to admit a wrong answer, which is "
-        f"what a mistaken kappa or a mistaken relative-to-absolute conversion looks like"
+    assert tightest_with_kappa >= 1e-4, (
+        f"among the builders whose bound carries a condition number, the tightest point is "
+        f"{tightest_with_kappa:.3e} of its bound ({where_with_kappa}). Every such bound is now "
+        f"loose enough to admit a wrong answer, which is what a mistaken kappa or a mistaken "
+        f"relative-to-absolute conversion looks like. (Global tightest, including the "
+        f"kappa == 1 builder: {tightest:.3e} at {where}.)"
     )

--- a/tests/parity/test_dispatch.py
+++ b/tests/parity/test_dispatch.py
@@ -25,6 +25,7 @@ from pantr._backend import (
     use_backend,
 )
 from pantr.basis._basis_backend import cardinal_bspline_core
+from pantr.change_basis import _change_basis_backend as _cb_backend
 from pantr.quad._quad_backend import (
     chebyshev_nodes_kernel,
     gauss_legendre_kernel,
@@ -344,3 +345,93 @@ def test_no_quad_accessor_falls_back_when_the_extension_is_absent(
             assert "not available" in str(exc), f"{name}: raised, but not for that reason: {exc}"
         else:
             pytest.fail(f"{name}: an explicit CPP request was served without the extension")
+
+
+_CHANGE_BASIS_ACCESSORS = (
+    ("lagrange_to_bernstein", _cb_backend.lagrange_to_bernstein_kernel),
+    ("bernstein_to_lagrange", _cb_backend.bernstein_to_lagrange_kernel),
+    ("bernstein_to_cardinal", _cb_backend.bernstein_to_cardinal_kernel),
+    ("cardinal_to_bernstein", _cb_backend.cardinal_to_bernstein_kernel),
+    ("legendre_to_cardinal", _cb_backend.legendre_to_cardinal_kernel),
+    ("cardinal_to_legendre", _cb_backend.cardinal_to_legendre_kernel),
+    ("cardinal_dual_legendre_coeffs", _cb_backend.cardinal_dual_legendre_coeffs_kernel),
+    ("monomial_to_bernstein", _cb_backend.monomial_to_bernstein_kernel),
+)
+"""The change_basis catalogue's eight entry points, named for the failure message."""
+
+
+@pytest.mark.parametrize(
+    ("name", "accessor"),
+    _CHANGE_BASIS_ACCESSORS,
+    ids=[n for n, _ in _CHANGE_BASIS_ACCESSORS],
+)
+def test_a_change_basis_accessor_hands_back_the_python_kernel_itself(
+    name: str, accessor: Callable[[Backend | None], object]
+) -> None:
+    """Each change_basis accessor returns the Python kernel, by identity.
+
+    Args:
+        name (str): The kernel's name, for the failure message.
+        accessor (Callable[[Backend | None], object]): The catalogue entry point.
+    """
+    from pantr.change_basis import _change_basis_core  # noqa: PLC0415
+
+    expected = getattr(_change_basis_core, f"_{name}_core")
+    assert accessor(Backend.PYTHON) is expected, (
+        f"{name}: the catalogue returned something other than the kernel itself"
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "accessor"),
+    _CHANGE_BASIS_ACCESSORS,
+    ids=[n for n, _ in _CHANGE_BASIS_ACCESSORS],
+)
+def test_a_change_basis_accessor_hands_back_the_same_cpp_adapter_every_call(
+    name: str, accessor: Callable[[Backend | None], object], cpp_backend: None
+) -> None:
+    """Each accessor returns the one C++ adapter, by identity, on every call.
+
+    Identity rather than equality, and it is not pedantry. Seven of these adapters
+    are produced by a factory that closes over a binding name, so building them
+    inside the accessor would hand back a **fresh closure per call** -- correct
+    output, a new object every time, and a small allocation on a path that
+    ``pantr.bspline``'s extraction calls in a loop. They are module-level constants
+    for that reason, and this is the test that keeps them so.
+
+    Args:
+        name (str): The kernel's name, for the failure message.
+        accessor (Callable[[Backend | None], object]): The catalogue entry point.
+        cpp_backend (None): Requires the compiled extension.
+    """
+    del cpp_backend
+    from pantr.change_basis import _change_basis_backend  # noqa: PLC0415
+
+    expected = getattr(_change_basis_backend, f"_cpp_{name}")
+    assert accessor(Backend.CPP) is expected, (
+        f"{name}: the catalogue returned something other than the adapter itself"
+    )
+    assert accessor(Backend.CPP) is accessor(Backend.CPP), (
+        f"{name}: two calls returned two different objects, so the adapter is being "
+        f"rebuilt per call"
+    )
+
+
+def test_no_change_basis_accessor_falls_back_when_the_extension_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All eight accessors refuse an explicit C++ request, not just the first.
+
+    The never-fall-back rule is applied once, in the catalogue's ``_select``, and
+    this asserts the property the eight are meant to share rather than the
+    helper's existence.
+    """
+    from pantr import _backend  # noqa: PLC0415
+
+    monkeypatch.setattr(_backend, "_CPP_AVAILABLE", False)
+    for name, accessor in _CHANGE_BASIS_ACCESSORS:
+        with pytest.raises(RuntimeError, match="not available"):
+            accessor(Backend.CPP)
+        assert accessor(Backend.PYTHON) is not None, (
+            f"{name}: the Python backend must stay available when the extension is not"
+        )

--- a/tests/test_change_basis_reexports.py
+++ b/tests/test_change_basis_reexports.py
@@ -1,0 +1,97 @@
+"""The names `pantr.change_basis` must keep exposing, and why a test holds them.
+
+`change_basis` was a single module until the C++ port and is a package now.
+`CLAUDE.md` records that a separate, not-yet-public downstream consumer imports
+pantr's **private** symbols and that pantr's own CI cannot see breakage there, so
+the split had to preserve every name the flat module made reachable.
+
+**It did not, and nothing noticed.** Nine real pantr names stopped being
+importable, among them :class:`~pantr.basis.LagrangeVariant`, which is a public
+enum and the declared type of ``lagrange_variant`` in two of the eight public
+builders. The package docstring asserted the opposite in prose, the changelog
+repeated it, and no test checked either. This file is that check.
+
+The list below is data, deliberately. It is the set of names bound at module scope
+by ``src/pantr/change_basis.py`` at commit 1889076, minus the stdlib and typing
+imports (``np``, ``npt``, ``comb``, ``functools``, ``Callable``, ``Final``,
+``Mapping``, ``MappingProxyType``, ``NamedTuple``) that nothing could reasonably
+have imported from a change-of-basis module.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+_PUBLIC = (
+    "compute_bernstein_to_cardinal_1d",
+    "compute_bernstein_to_lagrange_1d",
+    "compute_cardinal_dual_legendre_coeffs_1d",
+    "compute_cardinal_to_bernstein_1d",
+    "compute_cardinal_to_legendre_1d",
+    "compute_lagrange_to_bernstein_1d",
+    "compute_legendre_to_cardinal_1d",
+    "compute_monomial_to_bernstein_1d",
+)
+"""The eight builders, which are also ``__all__``."""
+
+_MODULE_PRIVATE = (
+    "_BERNSTEIN_TO_CARDINAL_MAX_DEGREE",
+    "_BERNSTEIN_TO_LAGRANGE_MAX_DEGREE",
+    "_CARDINAL_TO_BERNSTEIN_MAX_DEGREE",
+    "_CARDINAL_TO_LEGENDRE_MAX_DEGREE",
+    "_DegreeLimit",
+    "_cached_cardinal_to_bernstein_matrix",
+    "_cached_cardinal_to_legendre_matrix",
+    "_cached_lagrange_to_bernstein_matrix",
+    "_cached_legendre_to_cardinal_matrix",
+    "_compute_change_basis_1D",
+    "_prepare_square_out",
+    "_validate_degree_in_domain",
+)
+"""Private names the flat module defined itself. `pantr.bspline` imports two."""
+
+_BORROWED = (
+    "LagrangeVariant",
+    "_allocate_or_validate_out",
+    "_get_lagrange_points",
+    "_validate_float_dtype",
+    "backend_keyed_cache",
+    "get_gauss_legendre_1d",
+    "tabulate_bernstein_1d",
+    "tabulate_cardinal_bspline_1d",
+    "tabulate_legendre_1d",
+)
+"""Names the flat module bound only because it imported them for its own use.
+
+Reachable as ``pantr.change_basis.<name>`` before the split purely by accident of
+being a single file, which does not make them any less reachable to a caller who
+wrote the import. These are the nine that were lost.
+"""
+
+
+@pytest.mark.parametrize("name", _PUBLIC + _MODULE_PRIVATE + _BORROWED)
+def test_the_name_is_still_importable_from_the_package_root(name: str) -> None:
+    """Each name reachable before the package split is reachable after it.
+
+    Args:
+        name (str): The attribute to look for on :mod:`pantr.change_basis`.
+    """
+    module = importlib.import_module("pantr.change_basis")
+    assert hasattr(module, name), (
+        f"pantr.change_basis.{name} was importable before the package split and is not "
+        f"now. CLAUDE.md records a downstream consumer that imports pantr's private "
+        f"symbols and that this repository's CI cannot see it break, so a name is "
+        f"removed deliberately or not at all"
+    )
+
+
+def test_only_the_eight_builders_are_public() -> None:
+    """``__all__`` stays the eight builders, however many names are reachable.
+
+    The re-exports above are a compatibility surface, not an enlargement of the
+    public API, and this is what keeps the two from being confused.
+    """
+    module = importlib.import_module("pantr.change_basis")
+    assert tuple(sorted(module.__all__)) == tuple(sorted(_PUBLIC))


### PR DESCRIPTION
## Context

Third module of the C++ port, after the build skeleton (#335) and `quad` (#337).
`pantr.change_basis` is the first ported module whose kernels **solve a linear
system**, and that single fact drives most of what is unusual here: it is the
first port that is not bit-identical, the first that needs a dense linear algebra
dependency, and the first where the parity harness's guard against a vacuous bound
fired against a bound that was derived correctly.

The module is not self-contained. Five of its eight builders evaluate a Bernstein
or Legendre basis before solving, and neither tabulation had been ported, so both
are here too.

## Specification

Eight builders, in C++, dispatched behind `PANTR_BACKEND`, with the two basis
tabulations they rest on.

**Eigen becomes a dependency of the shipped extension.** It was fetched only under
`PANTR_BUILD_TESTS` and deliberately fenced off from `pantr::core`, so that taking
it would have to be a decision. This is that decision: `change_basis` needs a dense
solve and `bezier`'s interpolation needs a truncated SVD pseudo-inverse, both in
stage 1. The cost was measured rather than assumed, and `GIT_SHALLOW` recovers most
of it:

| cold `pip install -e .` | wall | build tree |
|---|---|---|
| without Eigen | 7.56 s | 6.4 MB |
| Eigen, deep clone | 21.48 s | 145 MB |
| Eigen, shallow clone | 12.19 s | 50 MB |

The incremental rebuild is unchanged at 2.96 s, so the whole cost lands on a cold
worktree. The shallow fetch was verified to check out the pinned commit rather than
falling back to a branch tip.

**Nodes cross as arrays; `LagrangeVariant` does not.** Two of the five Lagrange node
families resolve through quadrature rules that `pantr._backend` records as
deliberately never dispatched, so a kernel that resolved the variant itself would
have to contradict that or carry a second implementation of two rules. Layer 2
resolves it and passes an array.

**The catalogue is eight bare callables**, per the rule in
`design/cross_backend_types.md`: no consumer needs two kernels at once. The inverse
builders invert their forward matrix *inside* the kernel rather than calling the
forward builder and then solving, which is how the Python module was written before
the port. Under a mixed backend the old shape composes a Python forward matrix with
a C++ solve into a result that is neither backend and that no parity claim covers.

## Parity, which is the substance

The eight split three ways and each way is what the theory predicts.

**Two are bit-identical.** `lagrange_to_bernstein` is a transposed tabulation;
`monomial_to_bernstein` divides two exactly represented integers, so both backends
get the correctly rounded value of the same exact rational while every binomial
stays at or below `2**53`, i.e. through degree 56. The C++ side builds its
binomials by addition through a Pascal triangle for that reason; the multiplicative
recurrence overflows the exact range in an intermediate even where the result does
not.

**One is bounded and never approaches its bound.** `legendre_to_cardinal`'s Gram
matrix is the identity up to round-off, and it stays under 1 eps at every degree
tested.

**Five carry a real bound**, `32 n kappa_inf eps`, with `kappa_inf` computed per
degree in **exact rational arithmetic** by the helpers in
`tests/test_change_basis_domain.py` rather than from the matrix pantr forms — a
distinction that module measures at 8.6x too high at degree 13. The 32 is `4 n u`
from the products and the solve times an allowance of `rho <= 8` for the LU growth
factor, and that allowance is argued rather than proved; the file says so.

**The parity domain is smaller than the solvability domain, and naming that is the
point.** `tests/_parity_harness.py` refuses a bound as large as the values it
compares. At the top of each builder's solvability domain — which is by definition
where `kappa_inf * eps` approaches one — this bound is of order one, so the guard
fires. The resolution is a smaller domain rather than a tighter bound: parity is
asserted where `32 n kappa_inf eps < 1`, and above that the answer has no correct
digits in either backend, so there is nothing for a parity claim to be about. A test
enumerates the excluded degrees rather than letting the gap read as coverage.

That is **Rule 8** in `design/backend_parity.md`, which every later port inherits.

One independent confirmation fell out: for `cardinal_to_bernstein` in float64 this
derivation stops at degree 9, and the module's own docstring, from a different
argument written before the port, puts its accuracy bound past 100% after degree 10.

**One case a reader of an A/B result needs.** `compute_lagrange_to_bernstein_1d`
with `CHEBYSHEV_2ND` nodes in float32 is the one place the two backends start from
*different nodes*, by exactly one unit of roundoff, because that family resolves
through `get_modified_chebyshev_nodes_1d`, which dispatches. Measured across all
five families: the other four are identical in both formats. Its claim is bounded
by the node gap times `n`, since a Bernstein derivative is bounded by the degree.

## Acceptance criteria

- [x] All eight builders dispatch, and the two tabulations they need.
- [x] The public surface is unchanged, and so is the private one: every name
      importable from `pantr.change_basis` before the package split still is,
      including `_compute_change_basis_1D`, which nothing calls any more.
      `pantr.bspline` proved this was not hypothetical.
- [x] Every parity claim carries a derivation, and the bound was checked to bite: a
      `1e-6` relative perturbation of the Gram matrix is caught by all five bounded
      builders. Swapping `PartialPivLU` for `FullPivLU` is correctly accepted — it
      moves the answer by `1.9e-11`, and any backward-stable LU has to be admitted.
- [x] Both new C++ test files were checked to be able to fail, by mutation.
- [x] `scripts/ci_local.sh all`: 37 checks, all pass. Four full C++ builds (gcc,
      clang, and both compiler floors), the discipline guards, the whole suite under
      each backend, and the nanobind split-mode probe.
- [x] Docs build clean under `-W`.

## Non-goals

- **`bezier`'s SVD**, which is what justifies the Eigen dependency as much as this
  module does. It goes with its own port.
- **A degree limit for `compute_legendre_to_cardinal_1d`**, which has none while its
  four siblings do. Its docstring argues from conditioning, which is about accuracy
  rather than about size, so nothing bounds the matrix it forms. Predates this port
  and is untouched by it.

## Also in this branch, and separable

One commit is unrelated and is marked as such so it can be dropped on its own.
`PointsLattice`'s docstring cross-references a private method that `automodule`
never emits, which with `nitpicky` and `-W` is a docs build failure. It was
introduced by 782e46d and nothing caught it, because **`ci.yaml` — lint,
type-check, the suite under Python, and the docs build — runs only on `main`**: its
`on:` block names that branch for both `push` and `pull_request`. What runs on a
`proto/cpp` pull request is the C++ build and the parity job. So a docs regression
on this branch stays invisible until it reaches `main`, and `scripts/ci_local.sh` is
the only thing that would have found it.
