### PR TITLE
feat(bezier): port the arithmetic kernels to C++, bit-exact against the oracle

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -118,10 +118,10 @@ if(PANTR_NANOBIND_SPLIT)
   # -Werror ends the build.
   nanobind_add_module(_pantr_cpp NOMINSIZE NOSTRIP NB_SUPPRESS_WARNINGS
                       BACKEND_MODULE nanobind_backend
-                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
-                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bezier.cpp
+++ b/cpp/bindings/bezier.cpp
@@ -16,7 +16,26 @@
 /// checks below, and each one is in front of a kernel that would otherwise write
 /// past the allocation.
 ///
-/// One is not a shape at all. `degree_elevate` and `scalar_bernstein_product`
+/// Two are not shapes at all.
+///
+/// **A degree inferred from a shape has a floor that nothing else states.** Five
+/// of these kernels take no `degree` argument and compute `ctrl.extent(0) - 1` in
+/// `std::size_t`, so a zero-row `ctrl` underflows to `SIZE_MAX` and the kernel
+/// walks off the allocation. Measured before `require_control_points` existed:
+/// `slice_bezier_1d(np.empty((0, 2)), 0.5, out=...)` exited with SIGSEGV, no
+/// exception. `basis.cpp` avoids this class by taking `degree` as an `unsigned`
+/// the caster refuses to make negative; there is no such argument here, so the
+/// floor has to be checked explicitly.
+///
+/// **A parameter domain the docstring states is a promise.** `value`, `lower` and
+/// `upper` are documented as living in the unit interval, and outside it the
+/// two-pass restriction stops being a sequence of convex combinations. Unchecked,
+/// `slice_bezier_1d(ctrl, 2.5, ...)` extrapolated silently and
+/// `restrict_bezier_1d(ctrl, 0.8, 0.2, ...)` -- the bounds transposed -- returned a
+/// different, plausible Bézier. `lower` and `upper` are adjacent same-typed
+/// positional parameters, so ordering them is what closes that transposition trap.
+///
+/// And `degree_elevate` and `scalar_bernstein_product`
 /// form binomial coefficients, and past `core::kBincoeffMaxN` the exact-integer
 /// recurrence overflows -- undefined behaviour in C++, where the numba original
 /// merely wraps. Python's Layer 2 checks it too, through
@@ -79,6 +98,79 @@ void require_length(const Arr& out, std::size_t n, const char* what) {
     }
 }
 
+/// Raise unless `ctrl` holds at least one control point.
+///
+/// The floor for every kernel that infers its degree from a shape. See the file
+/// comment: below it the subtraction underflows and the kernel is not merely
+/// wrong but undefined.
+template <class Arr>
+void require_control_points(const Arr& ctrl, const char* what) {
+    if (ctrl.shape(0) == 0) {
+        throw nb::value_error(
+            (std::string(what) + " has no rows, but its degree is inferred as "
+             "rows - 1, which needs at least one")
+                .c_str());
+    }
+}
+
+/// Raise unless `value` lies in the closed unit interval.
+///
+/// Written as a conjunction of two comparisons rather than a negated range so a
+/// NaN, which compares false against everything, is refused rather than admitted.
+void require_unit_interval(double value, const char* what) {
+    if (!(value >= 0.0 && value <= 1.0)) {
+        throw nb::value_error((std::string(what) + " must lie in [0, 1], got " +
+                               std::to_string(value))
+                                  .c_str());
+    }
+}
+
+/// Raise unless `0 <= lower <= upper <= 1`.
+///
+/// The ordering is the half that matters: the two bounds are adjacent same-typed
+/// positional parameters, so nothing in the type system stops a transposed call,
+/// and a transposed call returns a different restriction rather than an error.
+void require_ordered_bounds(double lower, double upper) {
+    require_unit_interval(lower, "lower");
+    require_unit_interval(upper, "upper");
+    if (lower > upper) {
+        throw nb::value_error(("lower (" + std::to_string(lower) + ") must not exceed upper (" +
+                               std::to_string(upper) +
+                               "); transposing them returns a different restriction rather "
+                               "than an error")
+                                  .c_str());
+    }
+}
+
+/// Refuse two output buffers that overlap in memory.
+///
+/// The same guard `cpp/bindings/quad.cpp` applies to its two-output rules, and for
+/// the same reason: the two buffers have the same dtype, rank, shape and
+/// contiguity, so nanobind accepts one array passed twice and the second write
+/// overwrites the first. Measured before this existed:
+/// `split_bezier_1d(ctrl, 0.5, out_left=same, out_right=same)` returned the RIGHT
+/// half under both names, with no exception. `nb::kw_only()` closes transposition;
+/// only this closes aliasing.
+///
+/// Overlap rather than equality: two views onto one buffer alias just as
+/// destructively as the same object twice.
+template <class Arr>
+void refuse_overlapping_outputs(const Arr& first, const char* first_name, const Arr& second,
+                                const char* second_name) {
+    const auto* first_begin = first.data();
+    const auto* first_end = first_begin + first.size();
+    const auto* second_begin = second.data();
+    const auto* second_end = second_begin + second.size();
+    if (first_begin < second_end && second_begin < first_end) {
+        throw nb::value_error(
+            (std::string(first_name) + " and " + second_name +
+             " overlap in memory. Each half is written independently, so one would "
+             "silently overwrite the other and the result would be neither. Pass "
+             "two separate arrays.")
+                .c_str());
+    }
+}
+
 /// Raise unless the exact-integer binomial recurrence stays inside its envelope.
 void require_bincoeff_envelope(std::size_t n, const char* what) {
     if (n > static_cast<std::size_t>(pantr::core::kBincoeffMaxN)) {
@@ -93,6 +185,7 @@ void require_bincoeff_envelope(std::size_t n, const char* what) {
 
 template <class T>
 void bind_evaluate(const_mat<T> ctrl, const_vec<T> points, out_mat<T> out) {
+    require_control_points(ctrl, "ctrl");
     const std::size_t num_pts = points.size();
     const std::size_t rank = ctrl.shape(1);
     require_shape(out, num_pts, rank, "out");
@@ -112,6 +205,7 @@ void bind_evaluate_deriv(const_mat<T> ctrl, const_vec<T> points, unsigned n_deri
     if (n_deriv > max_deriv) {
         throw nb::value_error("n_deriv exceeds the largest order the kernel can express");
     }
+    require_control_points(ctrl, "ctrl");
     const std::size_t num_pts = points.size();
     const std::size_t rank = ctrl.shape(1);
     const std::size_t orders = static_cast<std::size_t>(n_deriv) + 1;
@@ -161,6 +255,8 @@ void bind_degree_elevate(unsigned degree, const_mat<T> ctrl, unsigned degree_inc
 
 template <class T>
 void bind_slice(const_mat<T> ctrl, double value, out_vec<T> out) {
+    require_control_points(ctrl, "ctrl");
+    require_unit_interval(value, "value");
     const std::size_t n_cols = ctrl.shape(1);
     require_length(out, n_cols, "out");
 
@@ -173,10 +269,13 @@ void bind_slice(const_mat<T> ctrl, double value, out_vec<T> out) {
 
 template <class T>
 void bind_split(const_mat<T> ctrl, double value, out_mat<T> out_left, out_mat<T> out_right) {
+    require_control_points(ctrl, "ctrl");
+    require_unit_interval(value, "value");
     const std::size_t rows = ctrl.shape(0);
     const std::size_t n_cols = ctrl.shape(1);
     require_shape(out_left, rows, n_cols, "out_left");
     require_shape(out_right, rows, n_cols, "out_right");
+    refuse_overlapping_outputs(out_left, "out_left", out_right, "out_right");
 
     const pantr::span2d<const T> ctrl_view(ctrl.data(), rows, n_cols);
     const pantr::span2d<T> left_view(out_left.data(), rows, n_cols);
@@ -188,6 +287,8 @@ void bind_split(const_mat<T> ctrl, double value, out_mat<T> out_left, out_mat<T>
 
 template <class T>
 void bind_restrict(const_mat<T> ctrl, double lower, double upper, out_mat<T> out) {
+    require_control_points(ctrl, "ctrl");
+    require_ordered_bounds(lower, upper);
     const std::size_t rows = ctrl.shape(0);
     const std::size_t n_cols = ctrl.shape(1);
     require_shape(out, rows, n_cols, "out");

--- a/cpp/bindings/bezier.cpp
+++ b/cpp/bindings/bezier.cpp
@@ -1,0 +1,299 @@
+/// \file
+/// nanobind bindings for the `pantr.bezier` arithmetic kernels.
+///
+/// Eight entry points: the seven of `_bezier_core.py` and the reduction-operator
+/// apply that `pantr.bezier` reaches for through `pantr.bspline`. The checks in
+/// this file are Layer 2's C++ half, for the reason `basis.cpp` states at length:
+/// a Layer 3 kernel validates nothing, the extension is importable, and every
+/// bound name here is a public attribute of a public module.
+///
+/// ## What the shape checks are for
+///
+/// nanobind's typed parameters settle dtype, rank, C-contiguity and device before
+/// any body runs. What they cannot express is a relation between arguments, and
+/// every kernel here has one: `out` must have `degree + 1` rows, or
+/// `points.size()` of them, or `a.size() + b.size() - 1` entries. Those are the
+/// checks below, and each one is in front of a kernel that would otherwise write
+/// past the allocation.
+///
+/// One is not a shape at all. `degree_elevate` and `scalar_bernstein_product`
+/// form binomial coefficients, and past `core::kBincoeffMaxN` the exact-integer
+/// recurrence overflows -- undefined behaviour in C++, where the numba original
+/// merely wraps. Python's Layer 2 checks it too, through
+/// `_check_bincoeff_envelope`, but a direct call on the extension does not go
+/// through Python's Layer 2.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <string>
+
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/reduction_operator.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+template <class T>
+using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using const_mat = nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_vec = nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_mat = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_cube = nb::ndarray<T, nb::ndim<3>, nb::c_contig, nb::device::cpu>;
+
+/// Raise unless `out` has exactly `rows` by `cols`.
+template <class Arr>
+void require_shape(const Arr& out, std::size_t rows, std::size_t cols, const char* what) {
+    if (out.shape(0) != rows || out.shape(1) != cols) {
+        throw nb::value_error((std::string(what) + " has shape (" +
+                               std::to_string(out.shape(0)) + ", " +
+                               std::to_string(out.shape(1)) + "), but this call needs (" +
+                               std::to_string(rows) + ", " + std::to_string(cols) + ")")
+                                  .c_str());
+    }
+}
+
+/// Raise unless `out` has exactly `n` entries.
+template <class Arr>
+void require_length(const Arr& out, std::size_t n, const char* what) {
+    if (out.shape(0) != n) {
+        throw nb::value_error((std::string(what) + " has length " +
+                               std::to_string(out.shape(0)) + ", but this call needs " +
+                               std::to_string(n))
+                                  .c_str());
+    }
+}
+
+/// Raise unless the exact-integer binomial recurrence stays inside its envelope.
+void require_bincoeff_envelope(std::size_t n, const char* what) {
+    if (n > static_cast<std::size_t>(pantr::core::kBincoeffMaxN)) {
+        throw nb::value_error(
+            (std::string(what) + " needs binomial coefficients up to C(" + std::to_string(n) +
+             ", k), beyond the largest upper index " +
+             std::to_string(pantr::core::kBincoeffMaxN) +
+             " the exact-integer recurrence can compute without an int64 overflow")
+                .c_str());
+    }
+}
+
+template <class T>
+void bind_evaluate(const_mat<T> ctrl, const_vec<T> points, out_mat<T> out) {
+    const std::size_t num_pts = points.size();
+    const std::size_t rank = ctrl.shape(1);
+    require_shape(out, num_pts, rank, "out");
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), ctrl.shape(0), rank);
+    const std::span<const T> pts(points.data(), num_pts);
+    const pantr::span2d<T> out_view(out.data(), num_pts, rank);
+
+    const nb::gil_scoped_release release;
+    pantr::evaluate_bezier_1d<T>(ctrl_view, pts, out_view);
+}
+
+template <class T>
+void bind_evaluate_deriv(const_mat<T> ctrl, const_vec<T> points, unsigned n_deriv,
+                         out_cube<T> out) {
+    constexpr unsigned max_deriv = static_cast<unsigned>(std::numeric_limits<int>::max());
+    if (n_deriv > max_deriv) {
+        throw nb::value_error("n_deriv exceeds the largest order the kernel can express");
+    }
+    const std::size_t num_pts = points.size();
+    const std::size_t rank = ctrl.shape(1);
+    const std::size_t orders = static_cast<std::size_t>(n_deriv) + 1;
+    if (out.shape(0) != num_pts || out.shape(1) != orders || out.shape(2) != rank) {
+        throw nb::value_error(("out has shape (" + std::to_string(out.shape(0)) + ", " +
+                               std::to_string(out.shape(1)) + ", " +
+                               std::to_string(out.shape(2)) + "), but this call needs (" +
+                               std::to_string(num_pts) + ", " + std::to_string(orders) + ", " +
+                               std::to_string(rank) + ")")
+                                  .c_str());
+    }
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), ctrl.shape(0), rank);
+    const std::span<const T> pts(points.data(), num_pts);
+    const pantr::span_nd<T, 3> out_view(out.data(), num_pts, orders, rank);
+
+    const nb::gil_scoped_release release;
+    pantr::evaluate_bezier_deriv_1d<T>(ctrl_view, pts, static_cast<int>(n_deriv), out_view);
+}
+
+template <class T>
+void bind_degree_elevate(unsigned degree, const_mat<T> ctrl, unsigned degree_increment,
+                         out_mat<T> out) {
+    constexpr unsigned max_degree = static_cast<unsigned>(std::numeric_limits<int>::max()) / 2;
+    if (degree > max_degree || degree_increment > max_degree) {
+        throw nb::value_error("degree or degree_increment exceeds what the kernel can express");
+    }
+    const std::size_t rank = ctrl.shape(1);
+    const std::size_t elevated = static_cast<std::size_t>(degree) +
+                                 static_cast<std::size_t>(degree_increment) + 1;
+    require_bincoeff_envelope(elevated - 1, "degree elevation");
+    if (ctrl.shape(0) != static_cast<std::size_t>(degree) + 1) {
+        throw nb::value_error(("ctrl has " + std::to_string(ctrl.shape(0)) +
+                               " rows, but degree " + std::to_string(degree) + " needs " +
+                               std::to_string(degree + 1))
+                                  .c_str());
+    }
+    require_shape(out, elevated, rank, "out");
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), ctrl.shape(0), rank);
+    const pantr::span2d<T> out_view(out.data(), elevated, rank);
+
+    const nb::gil_scoped_release release;
+    pantr::degree_elevate_bezier_1d<T>(static_cast<int>(degree), ctrl_view,
+                                       static_cast<int>(degree_increment), out_view);
+}
+
+template <class T>
+void bind_slice(const_mat<T> ctrl, double value, out_vec<T> out) {
+    const std::size_t n_cols = ctrl.shape(1);
+    require_length(out, n_cols, "out");
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), ctrl.shape(0), n_cols);
+    const std::span<T> out_view(out.data(), n_cols);
+
+    const nb::gil_scoped_release release;
+    pantr::slice_bezier_1d<T>(ctrl_view, value, out_view);
+}
+
+template <class T>
+void bind_split(const_mat<T> ctrl, double value, out_mat<T> out_left, out_mat<T> out_right) {
+    const std::size_t rows = ctrl.shape(0);
+    const std::size_t n_cols = ctrl.shape(1);
+    require_shape(out_left, rows, n_cols, "out_left");
+    require_shape(out_right, rows, n_cols, "out_right");
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), rows, n_cols);
+    const pantr::span2d<T> left_view(out_left.data(), rows, n_cols);
+    const pantr::span2d<T> right_view(out_right.data(), rows, n_cols);
+
+    const nb::gil_scoped_release release;
+    pantr::split_bezier_1d<T>(ctrl_view, value, left_view, right_view);
+}
+
+template <class T>
+void bind_restrict(const_mat<T> ctrl, double lower, double upper, out_mat<T> out) {
+    const std::size_t rows = ctrl.shape(0);
+    const std::size_t n_cols = ctrl.shape(1);
+    require_shape(out, rows, n_cols, "out");
+
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), rows, n_cols);
+    const pantr::span2d<T> out_view(out.data(), rows, n_cols);
+
+    const nb::gil_scoped_release release;
+    pantr::restrict_bezier_1d<T>(ctrl_view, lower, upper, out_view);
+}
+
+template <class T>
+void bind_product(const_vec<T> a, const_vec<T> b, out_vec<T> out) {
+    if (a.size() == 0 || b.size() == 0) {
+        throw nb::value_error("a and b must each hold at least one control point");
+    }
+    const std::size_t degree_sum = a.size() + b.size() - 2;
+    require_bincoeff_envelope(degree_sum, "the Bernstein product");
+    require_length(out, degree_sum + 1, "out");
+
+    const std::span<const T> a_view(a.data(), a.size());
+    const std::span<const T> b_view(b.data(), b.size());
+    const std::span<T> out_view(out.data(), degree_sum + 1);
+
+    const nb::gil_scoped_release release;
+    pantr::scalar_bernstein_product_1d<T>(a_view, b_view, out_view);
+}
+
+template <class T>
+void bind_apply_reduction_operator(const_mat<double> op, const_mat<T> ctrl, out_mat<T> out) {
+    const std::size_t n_out = op.shape(0);
+    const std::size_t n_in = op.shape(1);
+    const std::size_t rank = ctrl.shape(1);
+    if (ctrl.shape(0) != n_in) {
+        throw nb::value_error(("ctrl has " + std::to_string(ctrl.shape(0)) +
+                               " rows, but the operator's " + std::to_string(n_in) +
+                               " columns need that many")
+                                  .c_str());
+    }
+    require_shape(out, n_out, rank, "out");
+
+    const pantr::span2d<const double> op_view(op.data(), n_out, n_in);
+    const pantr::span2d<const T> ctrl_view(ctrl.data(), n_in, rank);
+    const pantr::span2d<T> out_view(out.data(), n_out, rank);
+
+    const nb::gil_scoped_release release;
+    pantr::core::apply_reduction_operator<T>(op_view, ctrl_view, out_view);
+}
+
+}  // namespace
+
+void register_bezier(nb::module_& m) {
+    // `.noconvert()` everywhere and `nb::kw_only()` before the outputs, for the
+    // two reasons `basis.cpp` sets out in full: without `.noconvert()` nanobind
+    // satisfies a contiguity constraint by filling a temporary and discarding it,
+    // so an out-parameter silently does nothing; and a positional call is how
+    // two same-dtype same-shape output buffers get swapped.
+    //
+    // `split_bezier_1d` is the first kernel in the tree where that second risk is
+    // real rather than anticipatory. Its `out_left` and `out_right` have the same
+    // dtype and the same shape, so nothing in the type system separates them, and
+    // a caller that passed them the wrong way round would get a plausible answer
+    // with the two halves exchanged. Keyword-only is what makes that unsayable.
+    m.def("evaluate_bezier_1d", &bind_evaluate<double>, nb::arg("ctrl").noconvert(),
+          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("evaluate_bezier_1d", &bind_evaluate<float>, nb::arg("ctrl").noconvert(),
+          nb::arg("points").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("evaluate_bezier_deriv_1d", &bind_evaluate_deriv<double>, nb::arg("ctrl").noconvert(),
+          nb::arg("points").noconvert(), nb::arg("n_deriv"), nb::kw_only(),
+          nb::arg("out").noconvert());
+    m.def("evaluate_bezier_deriv_1d", &bind_evaluate_deriv<float>, nb::arg("ctrl").noconvert(),
+          nb::arg("points").noconvert(), nb::arg("n_deriv"), nb::kw_only(),
+          nb::arg("out").noconvert());
+
+    m.def("degree_elevate_bezier_1d", &bind_degree_elevate<double>, nb::arg("degree"),
+          nb::arg("ctrl").noconvert(), nb::arg("degree_increment"), nb::kw_only(),
+          nb::arg("out").noconvert());
+    m.def("degree_elevate_bezier_1d", &bind_degree_elevate<float>, nb::arg("degree"),
+          nb::arg("ctrl").noconvert(), nb::arg("degree_increment"), nb::kw_only(),
+          nb::arg("out").noconvert());
+
+    m.def("slice_bezier_1d", &bind_slice<double>, nb::arg("ctrl").noconvert(), nb::arg("value"),
+          nb::kw_only(), nb::arg("out").noconvert());
+    m.def("slice_bezier_1d", &bind_slice<float>, nb::arg("ctrl").noconvert(), nb::arg("value"),
+          nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("split_bezier_1d", &bind_split<double>, nb::arg("ctrl").noconvert(), nb::arg("value"),
+          nb::kw_only(), nb::arg("out_left").noconvert(), nb::arg("out_right").noconvert());
+    m.def("split_bezier_1d", &bind_split<float>, nb::arg("ctrl").noconvert(), nb::arg("value"),
+          nb::kw_only(), nb::arg("out_left").noconvert(), nb::arg("out_right").noconvert());
+
+    m.def("restrict_bezier_1d", &bind_restrict<double>, nb::arg("ctrl").noconvert(),
+          nb::arg("lower"), nb::arg("upper"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("restrict_bezier_1d", &bind_restrict<float>, nb::arg("ctrl").noconvert(),
+          nb::arg("lower"), nb::arg("upper"), nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("scalar_bernstein_product_1d", &bind_product<double>, nb::arg("a").noconvert(),
+          nb::arg("b").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("scalar_bernstein_product_1d", &bind_product<float>, nb::arg("a").noconvert(),
+          nb::arg("b").noconvert(), nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("apply_reduction_operator", &bind_apply_reduction_operator<double>,
+          nb::arg("operator").noconvert(), nb::arg("ctrl").noconvert(), nb::kw_only(),
+          nb::arg("out").noconvert());
+    m.def("apply_reduction_operator", &bind_apply_reduction_operator<float>,
+          nb::arg("operator").noconvert(), nb::arg("ctrl").noconvert(), nb::kw_only(),
+          nb::arg("out").noconvert());
+}

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -63,6 +63,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_basis(m);
     register_quad(m);
     register_change_basis(m);
+    register_bezier(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -18,3 +18,6 @@ void register_quad(nanobind::module_& m);
 
 /// Register the `pantr.change_basis` kernel bindings on `m`.
 void register_change_basis(nanobind::module_& m);
+
+/// Register the `pantr.bezier` kernel bindings on `m`.
+void register_bezier(nanobind::module_& m);

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -51,6 +51,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <vector>
 
@@ -292,12 +293,25 @@ void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, i
             }
         }
 
-        // The falling factorial is exact integer arithmetic in the oracle, and the
-        // promotion it forces against a float32 table is the one place this kernel
-        // leaves T's width.
-        std::int64_t fac = static_cast<std::int64_t>(degree);
+        // The falling factorial, and it is accumulated UNSIGNED on purpose.
+        //
+        // The oracle holds it in a numba `int64`, which wraps on overflow, and it
+        // does overflow: at degree 30 from `n_deriv = 14`, at degree 61 from 11,
+        // both reachable through `Bezier.evaluate_derivatives`. Signed overflow is
+        // undefined in C++ where numba's is merely wrong, so the natural
+        // translation is worse than its original -- confirmed under
+        // `-fsanitize=undefined`, which the repository's own `gcc-debug` preset
+        // enables.
+        //
+        // Unsigned arithmetic is modular by definition and the C++20 conversion
+        // back to `std::int64_t` is the two's-complement reinterpretation, so this
+        // reproduces the oracle's wrapped value bit for bit while being defined.
+        // Widening to `double` would have removed the undefined behaviour and
+        // broken parity instead, since past 2^53 a double rounds where an int64
+        // wraps.
+        std::uint64_t fac = static_cast<std::uint64_t>(degree);
         for (std::size_t k = 1; k <= num_derivs; ++k) {
-            const Acc fac_acc = Acc(static_cast<double>(fac));
+            const Acc fac_acc = Acc(static_cast<double>(static_cast<std::int64_t>(fac)));
             for (std::size_t j = 0; j < order; ++j) {
                 const Acc scaled = static_cast<Acc>(bd_at(k, j)) * fac_acc;
                 for (std::size_t r = 0; r < rank; ++r) {
@@ -306,7 +320,8 @@ void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, i
                                        scaled * static_cast<Acc>(at(ctrl, j, r)));
                 }
             }
-            fac *= static_cast<std::int64_t>(degree) - static_cast<std::int64_t>(k);
+            fac *= static_cast<std::uint64_t>(static_cast<std::int64_t>(degree) -
+                                              static_cast<std::int64_t>(k));
         }
     }
 }

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -1,0 +1,583 @@
+#pragma once
+
+/// \file
+/// The seven Bézier arithmetic kernels of `src/pantr/bezier/_bezier_core.py`,
+/// which stays as the parity oracle.
+///
+/// ## Three accumulation widths, and none of them is a choice made here
+///
+/// The oracle does not use one width. Reproducing which is which is most of the
+/// work in this file, and getting one wrong is invisible at `float64` and moves
+/// values at `float32`. Measured on the de Casteljau kernel: accumulating in
+/// `float` where the oracle accumulates in `double` moves 125 of 630 values.
+///
+///  1. **`evaluate`, `slice`, `split`, `restrict` accumulate in `double`.** The
+///     oracle's scalars are Python floats, and numba promotes a `float64` scalar
+///     against a `float32` array, so each step is computed at full width and
+///     rounded once on the store into the `float32` workspace. `Acc` is that
+///     width.
+///  2. **`evaluate_deriv` runs at the point dtype throughout.** Alone among the
+///     seven, that kernel opens with `dtype = pts.dtype` and allocates every
+///     workspace in it, so at `float32` the `ndu` table, the `a_arr` ping-pong
+///     and the derivative table are all `float32`. The one exception is the
+///     factorial scaling, where a `float32` against a Python `int` promotes.
+///  3. **`degree_elevate` and `scalar_bernstein_product` mix.** Their coefficient
+///     tables are `float64` unconditionally -- `bezalfs` is declared so, and
+///     `bincoeff` returns a `double` -- while the destination is the control
+///     points' dtype, so each `+=` computes wide and rounds narrow.
+///
+/// ## Where the two backends can disagree, and where they cannot
+///
+/// Every inner step here is `a * b + c * d` or `a * b`, so unlike the Bernstein
+/// tabulation there **are** sites for `-ffp-contract` to fuse. At the baseline
+/// target that is inert, since base `x86-64` has no FMA instruction; with
+/// `-march=native` it is not, and 125 of 630 `float64` de Casteljau values move.
+/// This is the `__fp_contract__` runtime gate of design/build_findings.md, not a
+/// property of the code, and the parity tests read it rather than assuming it.
+///
+/// The one transcendental is `pow`, seeding the evaluation recurrence.
+/// `cpp/include/pantr/basis/bernstein.hpp` records the same open question and the
+/// same answer: numba's `np.power` and the platform `pow` agree bitwise on every
+/// argument tested, which makes it observed rather than derived.
+///
+/// ## The de Casteljau workspace is read back, not carried in a register
+///
+/// `d[i] = one_minus_u * d[i] + u * d[i + 1]` reads two `float32` entries and
+/// writes one, so the running value never carries at full width across steps.
+/// Hoisting `d[i]` into an `Acc` register would be the natural C++ and would
+/// drift from the oracle by a growing multiple of one `float32` ulp. The
+/// evaluation kernel is the opposite case: there the oracle's `b_curr` *is* a
+/// register, so it stays one here.
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+/// Midpoint at which the evaluation recurrence switches to its mirrored branch.
+///
+/// Bounds the seed below by `0.5^p`, so it never underflows regardless of degree.
+/// Mirrors `_bezier_core._MIRROR_THRESHOLD`.
+inline constexpr double kBezierMirrorThreshold = 0.5;
+
+/// Evaluate a 1D Bézier at every point of `points`, fusing basis and contraction.
+///
+/// Runs the Bernstein ratio recurrence and contracts each term with the control
+/// points in one pass, so no basis row is ever materialised. Above the midpoint
+/// the recurrence runs on `1 - u` and walks the control points backwards, which
+/// is what keeps the seed from underflowing at high degree.
+///
+/// \param ctrl Control points, shape `(degree + 1, rank)`.
+/// \param points Evaluation points.
+/// \param out Output of shape `(points.size(), rank)`, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel.
+///       For general use call `pantr.bezier.Bezier.evaluate`.
+template <Real T>
+void evaluate_bezier_1d(span2d<const T> ctrl, std::span<const T> points, span2d<T> out) {
+    using Acc = accumulator_t<T>;
+    using std::pow;
+
+    const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
+    const std::size_t rank = ctrl.extent(1);
+    const std::size_t num_pts = points.size();
+    const Acc degree_acc = Acc(static_cast<double>(degree));
+
+    for (std::size_t pt = 0; pt < num_pts; ++pt) {
+        const Acc u = static_cast<Acc>(points[pt]);
+
+        if (degree == 0) {
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, r) = at(ctrl, std::size_t{0}, r);
+            }
+            continue;
+        }
+        if (u == Acc(1)) {
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, r) = at(ctrl, degree, r);
+            }
+            continue;
+        }
+
+        const Acc one_minus_u = Acc(1) - u;
+
+        if (u > Acc(kBezierMirrorThreshold)) {
+            // `b_curr = B_{i,p}(1-u) = B_{p-i,p}(u)`, pairing with `ctrl[p - i]`.
+            //
+            // The seed is formed at `T`'s width, not `Acc`'s, and that asymmetry
+            // is the oracle's rather than a choice here. This branch raises `u`,
+            // which is the point array's own dtype; the branch below raises
+            // `1 - u`, which numba has already promoted to `float64` by the
+            // literal `1.0`. Computing both in `Acc` is the natural port and is
+            // wrong at `float32`: measured at degree 17 and `u = 0.75`, where
+            // `0.75^17 = 3^17 / 2^34` needs 27 significand bits, the wide seed
+            // survives and the narrow one rounds, and the difference reaches the
+            // output as one ulp.
+            Acc b_curr = static_cast<Acc>(pow(static_cast<T>(u), static_cast<T>(degree_acc)));
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, r) = static_cast<T>(b_curr * static_cast<Acc>(at(ctrl, degree, r)));
+            }
+            const Acc ratio = one_minus_u / u;
+            for (std::size_t i = 1; i <= degree; ++i) {
+                const Acc i_acc = Acc(static_cast<double>(i));
+                const Acc const_factor = (degree_acc - i_acc + Acc(1)) / i_acc;
+                b_curr = b_curr * const_factor * ratio;
+                for (std::size_t r = 0; r < rank; ++r) {
+                    at(out, pt, r) = static_cast<T>(
+                        static_cast<Acc>(at(out, pt, r)) +
+                        b_curr * static_cast<Acc>(at(ctrl, degree - i, r)));
+                }
+            }
+            continue;
+        }
+
+        Acc b_prev = pow(one_minus_u, degree_acc);
+        for (std::size_t r = 0; r < rank; ++r) {
+            at(out, pt, r) = static_cast<T>(b_prev * static_cast<Acc>(at(ctrl, std::size_t{0}, r)));
+        }
+        const Acc ratio = u / one_minus_u;
+        for (std::size_t i = 1; i <= degree; ++i) {
+            const Acc i_acc = Acc(static_cast<double>(i));
+            const Acc b_curr = b_prev * ((degree_acc - i_acc + Acc(1)) / i_acc) * ratio;
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, r) =
+                    static_cast<T>(static_cast<Acc>(at(out, pt, r)) +
+                                   b_curr * static_cast<Acc>(at(ctrl, i, r)));
+            }
+            b_prev = b_curr;
+        }
+    }
+}
+
+/// Evaluate a 1D Bézier and its derivatives up to order `n_deriv`.
+///
+/// Algorithm A2.3 of Piegl & Tiller specialised to Bernstein polynomials: build
+/// the `ndu` table, run the triangular derivative recursion, then scale by the
+/// falling factorial and contract with the control points.
+///
+/// \param ctrl Control points, shape `(degree + 1, rank)`.
+/// \param points Evaluation points.
+/// \param n_deriv Highest derivative order, `>= 0`.
+/// \param out Output of shape `(points.size(), n_deriv + 1, rank)`, written in
+///        full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel.
+///       Unlike its six siblings this kernel computes at `T`'s own width, since
+///       the oracle allocates every workspace at the point dtype. See the file
+///       comment.
+///       For general use call `pantr.bezier.Bezier.evaluate_derivatives`.
+template <Real T>
+void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, int n_deriv,
+                              span_nd<T, 3> out) {
+    using Acc = accumulator_t<T>;
+
+    const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
+    const std::size_t rank = ctrl.extent(1);
+    const std::size_t num_pts = points.size();
+    const std::size_t order = degree + 1;
+    const auto num_derivs = static_cast<std::size_t>(n_deriv);
+
+    // Hoisted out of the point loop and re-zeroed inside it. The oracle
+    // reallocates all three per point, which zeroes them; `a_arr` genuinely
+    // depends on that, since the `rr` loop below reuses it without re-zeroing
+    // and reads entries a later `rr` never wrote.
+    std::vector<T> ndu(order * order);
+    std::vector<T> a_arr(2 * (num_derivs + 1));
+    std::vector<T> basis_derivs((num_derivs + 1) * order);
+
+    for (std::size_t pt = 0; pt < num_pts; ++pt) {
+        const T s = points[pt];
+
+        for (std::size_t k = 0; k <= num_derivs; ++k) {
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, k, r) = T(0);
+            }
+        }
+        for (T& v : ndu) {
+            v = T(0);
+        }
+        for (T& v : a_arr) {
+            v = T(0);
+        }
+        for (T& v : basis_derivs) {
+            v = T(0);
+        }
+
+        const auto ndu_at = [&ndu, order](std::size_t i, std::size_t j) -> T& {
+            return ndu[i * order + j];
+        };
+        const auto a_at = [&a_arr, num_derivs](std::size_t i, std::size_t j) -> T& {
+            return a_arr[i * (num_derivs + 1) + j];
+        };
+        const auto bd_at = [&basis_derivs, order](std::size_t i, std::size_t j) -> T& {
+            return basis_derivs[i * order + j];
+        };
+
+        // The ndu table for uniform Bernstein knots: every knot difference is 1.
+        ndu_at(0, 0) = T(1);
+        for (std::size_t j = 1; j < order; ++j) {
+            T saved = T(0);
+            for (std::size_t rr = 0; rr < j; ++rr) {
+                ndu_at(j, rr) = T(1);
+                const T temp = ndu_at(rr, j - 1);
+                ndu_at(rr, j) = static_cast<T>(saved + (T(1) - s) * temp);
+                saved = static_cast<T>(s * temp);
+            }
+            ndu_at(j, j) = saved;
+        }
+
+        for (std::size_t j = 0; j < order; ++j) {
+            const T basis_val = ndu_at(j, degree);
+            for (std::size_t r = 0; r < rank; ++r) {
+                at(out, pt, 0, r) =
+                    static_cast<T>(at(out, pt, 0, r) + basis_val * at(ctrl, j, r));
+            }
+            bd_at(0, j) = basis_val;
+        }
+
+        // A2.3's triangular recursion, on signed indices: `rk` and `pk` go
+        // negative and the loop bounds are derived from them.
+        const auto p_signed = static_cast<int>(degree);
+        for (int rr = 0; rr < static_cast<int>(order); ++rr) {
+            int s1 = 0;
+            int s2 = 1;
+            a_at(0, 0) = T(1);
+
+            for (int k = 1; k <= n_deriv; ++k) {
+                T d = T(0);
+                const int rk = rr - k;
+                const int pk = p_signed - k;
+
+                if (rr >= k) {
+                    a_at(static_cast<std::size_t>(s2), 0) = a_at(static_cast<std::size_t>(s1), 0);
+                    d = static_cast<T>(a_at(static_cast<std::size_t>(s2), 0) *
+                                       ndu_at(static_cast<std::size_t>(rk),
+                                              static_cast<std::size_t>(pk)));
+                }
+
+                const int j1 = (rk >= -1) ? 1 : -rk;
+                const int j2 = ((rr - 1) <= pk) ? (k - 1) : (p_signed - rr);
+
+                for (int jj = j1; jj <= j2; ++jj) {
+                    const auto jz = static_cast<std::size_t>(jj);
+                    a_at(static_cast<std::size_t>(s2), jz) =
+                        static_cast<T>(a_at(static_cast<std::size_t>(s1), jz) -
+                                       a_at(static_cast<std::size_t>(s1), jz - 1));
+                    d = static_cast<T>(d + a_at(static_cast<std::size_t>(s2), jz) *
+                                               ndu_at(static_cast<std::size_t>(rk + jj),
+                                                      static_cast<std::size_t>(pk)));
+                }
+
+                if (rr <= pk) {
+                    a_at(static_cast<std::size_t>(s2), static_cast<std::size_t>(k)) =
+                        static_cast<T>(-a_at(static_cast<std::size_t>(s1),
+                                             static_cast<std::size_t>(k - 1)));
+                    d = static_cast<T>(d + a_at(static_cast<std::size_t>(s2),
+                                                static_cast<std::size_t>(k)) *
+                                               ndu_at(static_cast<std::size_t>(rr),
+                                                      static_cast<std::size_t>(pk)));
+                }
+
+                bd_at(static_cast<std::size_t>(k), static_cast<std::size_t>(rr)) = d;
+
+                const int tmp_s = s1;
+                s1 = s2;
+                s2 = tmp_s;
+            }
+        }
+
+        // The falling factorial is exact integer arithmetic in the oracle, and the
+        // promotion it forces against a float32 table is the one place this kernel
+        // leaves T's width.
+        std::int64_t fac = static_cast<std::int64_t>(degree);
+        for (std::size_t k = 1; k <= num_derivs; ++k) {
+            const Acc fac_acc = Acc(static_cast<double>(fac));
+            for (std::size_t j = 0; j < order; ++j) {
+                const Acc scaled = static_cast<Acc>(bd_at(k, j)) * fac_acc;
+                for (std::size_t r = 0; r < rank; ++r) {
+                    at(out, pt, k, r) =
+                        static_cast<T>(static_cast<Acc>(at(out, pt, k, r)) +
+                                       scaled * static_cast<Acc>(at(ctrl, j, r)));
+                }
+            }
+            fac *= static_cast<std::int64_t>(degree) - static_cast<std::int64_t>(k);
+        }
+    }
+}
+
+/// Degree-elevate a single Bézier segment by `degree_increment`.
+///
+/// Builds the `bezalfs` table of elevation coefficients and applies it. The
+/// table is `double` regardless of `T`, matching the oracle, and its upper half
+/// is filled by the symmetry `bezalfs[j, i] = bezalfs[p - j, ph - i]` rather than
+/// recomputed.
+///
+/// \param degree Original degree `p >= 0`.
+/// \param ctrl Control points, shape `(p + 1, rank)`.
+/// \param degree_increment Degrees to add, `t >= 1`.
+/// \param out Output of shape `(p + t + 1, rank)`. Zeroed, then written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. In
+///       particular `p + t` must not exceed `core::kBincoeffMaxN`; the Python
+///       Layer 2 checks that before the call.
+///       For general use call `pantr.bezier.Bezier.elevate_degree`.
+template <Real T>
+void degree_elevate_bezier_1d(int degree, span2d<const T> ctrl, int degree_increment,
+                              span2d<T> out) {
+    using Acc = accumulator_t<T>;
+
+    const int p = degree;
+    const int t = degree_increment;
+    const int ph = p + t;
+    const std::size_t rank = ctrl.extent(1);
+    const int ph2 = ph / 2;
+
+    std::vector<double> bezalfs(static_cast<std::size_t>(p + 1) *
+                                static_cast<std::size_t>(ph + 1));
+    const auto bez = [&bezalfs, ph](int j, int i) -> double& {
+        return bezalfs[static_cast<std::size_t>(j) * static_cast<std::size_t>(ph + 1) +
+                       static_cast<std::size_t>(i)];
+    };
+
+    bez(0, 0) = 1.0;
+    bez(p, ph) = 1.0;
+
+    for (int i = 1; i <= ph2; ++i) {
+        const double inv = 1.0 / core::bincoeff(ph, i);
+        const int mpi = (p < i) ? p : i;
+        for (int j = (i - t > 0 ? i - t : 0); j <= mpi; ++j) {
+            bez(j, i) = inv * core::bincoeff(p, j) * core::bincoeff(t, i - j);
+        }
+    }
+    for (int i = ph2 + 1; i < ph; ++i) {
+        const int mpi = (p < i) ? p : i;
+        for (int j = (i - t > 0 ? i - t : 0); j <= mpi; ++j) {
+            bez(j, i) = bez(p - j, ph - i);
+        }
+    }
+
+    for (int i = 0; i <= ph; ++i) {
+        for (std::size_t r = 0; r < rank; ++r) {
+            at(out, static_cast<std::size_t>(i), r) = T(0);
+        }
+    }
+    for (int i = 0; i <= ph; ++i) {
+        const int mpi = (p < i) ? p : i;
+        for (int j = (i - t > 0 ? i - t : 0); j <= mpi; ++j) {
+            const Acc coeff = Acc(bez(j, i));
+            for (std::size_t r = 0; r < rank; ++r) {
+                const auto iz = static_cast<std::size_t>(i);
+                at(out, iz, r) = static_cast<T>(
+                    static_cast<Acc>(at(out, iz, r)) +
+                    coeff * static_cast<Acc>(at(ctrl, static_cast<std::size_t>(j), r)));
+            }
+        }
+    }
+}
+
+/// Evaluate a 1D Bézier at a single parameter by de Casteljau, per column.
+///
+/// \param ctrl Control points, shape `(degree + 1, n_cols)`.
+/// \param value Parameter in `[0, 1]`.
+/// \param out Output of shape `(n_cols,)`.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel.
+///       For general use call `pantr.bezier.Bezier.slice`.
+template <Real T>
+void slice_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, std::span<T> out) {
+    using Acc = accumulator_t<T>;
+
+    const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
+    const std::size_t n_cols = ctrl.extent(1);
+    const Acc u = value;
+    const Acc one_minus_u = Acc(1) - u;
+
+    if (u == Acc(0)) {
+        for (std::size_t col = 0; col < n_cols; ++col) {
+            out[col] = at(ctrl, std::size_t{0}, col);
+        }
+        return;
+    }
+    if (u == Acc(1)) {
+        for (std::size_t col = 0; col < n_cols; ++col) {
+            out[col] = at(ctrl, degree, col);
+        }
+        return;
+    }
+
+    std::vector<T> d(degree + 1);
+    for (std::size_t col = 0; col < n_cols; ++col) {
+        for (std::size_t i = 0; i <= degree; ++i) {
+            d[i] = at(ctrl, i, col);
+        }
+        for (std::size_t r = 1; r <= degree; ++r) {
+            for (std::size_t i = 0; i + r <= degree; ++i) {
+                d[i] = static_cast<T>(one_minus_u * static_cast<Acc>(d[i]) +
+                                      u * static_cast<Acc>(d[i + 1]));
+            }
+        }
+        out[col] = d[0];
+    }
+}
+
+/// Split a 1D Bézier at `value` into its two halves, by de Casteljau.
+///
+/// \param ctrl Control points, shape `(degree + 1, n_cols)`.
+/// \param value Parameter in `[0, 1]`.
+/// \param out_left Left half, shape `(degree + 1, n_cols)`.
+/// \param out_right Right half, shape `(degree + 1, n_cols)`.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. Unlike
+///       `slice_bezier_1d` there are no endpoint shortcuts, matching the oracle:
+///       a split at 0 or 1 still runs the triangle.
+///       For general use call `pantr.bezier.Bezier.split`.
+template <Real T>
+void split_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, span2d<T> out_left,
+                     span2d<T> out_right) {
+    using Acc = accumulator_t<T>;
+
+    const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
+    const std::size_t n_cols = ctrl.extent(1);
+    const Acc u = value;
+    const Acc one_minus_u = Acc(1) - u;
+
+    std::vector<T> d(degree + 1);
+    for (std::size_t col = 0; col < n_cols; ++col) {
+        for (std::size_t i = 0; i <= degree; ++i) {
+            d[i] = at(ctrl, i, col);
+        }
+        at(out_left, std::size_t{0}, col) = d[0];
+
+        for (std::size_t r = 1; r <= degree; ++r) {
+            for (std::size_t i = 0; i + r <= degree; ++i) {
+                d[i] = static_cast<T>(one_minus_u * static_cast<Acc>(d[i]) +
+                                      u * static_cast<Acc>(d[i + 1]));
+            }
+            at(out_left, r, col) = d[0];
+        }
+        for (std::size_t i = 0; i <= degree; ++i) {
+            at(out_right, i, col) = d[i];
+        }
+    }
+}
+
+/// Restrict a 1D Bézier to `[lower, upper]`, reparametrized to `[0, 1]`.
+///
+/// Two de Casteljau passes, ordered so that neither divides by a small number:
+/// if `|upper| >= |lower - 1|` the left pass runs at `upper` and the right at
+/// `lower / upper`, otherwise the right pass runs at `lower` and the left at
+/// `(upper - lower) / (1 - lower)`.
+///
+/// \param ctrl Control points, shape `(degree + 1, n_cols)`.
+/// \param lower Left bound in `[0, 1)`.
+/// \param upper Right bound in `(0, 1]`.
+/// \param out Restricted coefficients, shape `(degree + 1, n_cols)`.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel.
+///       For general use call `pantr.bezier.Bezier.restrict`.
+template <Real T>
+void restrict_bezier_1d(span2d<const T> ctrl, accumulator_t<T> lower, accumulator_t<T> upper,
+                        span2d<T> out) {
+    using Acc = accumulator_t<T>;
+    using std::abs;
+
+    const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
+    const std::size_t n_cols = ctrl.extent(1);
+    const auto p = static_cast<std::ptrdiff_t>(degree);
+
+    const bool left_first = abs(upper) >= abs(lower - Acc(1));
+    const Acc tau = left_first ? upper : lower;
+    const Acc tau2 = left_first ? (lower / upper) : ((upper - lower) / (Acc(1) - lower));
+
+    std::vector<T> d(degree + 1);
+    for (std::size_t col = 0; col < n_cols; ++col) {
+        for (std::size_t i = 0; i <= degree; ++i) {
+            d[i] = at(ctrl, i, col);
+        }
+
+        // `left(a)` then `right(b)`, or `right(a)` then `left(b)`; the two passes
+        // are the same two loops in the opposite order, with the opposite tau.
+        const auto pass_left = [&d, p](Acc t_val) {
+            for (std::ptrdiff_t step = 1; step <= p; ++step) {
+                for (std::ptrdiff_t j = p; j >= step; --j) {
+                    const auto jz = static_cast<std::size_t>(j);
+                    d[jz] = static_cast<T>(static_cast<Acc>(d[jz]) * t_val +
+                                           static_cast<Acc>(d[jz - 1]) * (Acc(1) - t_val));
+                }
+            }
+        };
+        const auto pass_right = [&d, p](Acc t_val) {
+            for (std::ptrdiff_t step = 1; step <= p; ++step) {
+                for (std::ptrdiff_t j = 0; j <= p - step; ++j) {
+                    const auto jz = static_cast<std::size_t>(j);
+                    d[jz] = static_cast<T>(static_cast<Acc>(d[jz]) * (Acc(1) - t_val) +
+                                           static_cast<Acc>(d[jz + 1]) * t_val);
+                }
+            }
+        };
+
+        if (left_first) {
+            pass_left(tau);
+            pass_right(tau2);
+        } else {
+            pass_right(tau);
+            pass_left(tau2);
+        }
+
+        for (std::size_t i = 0; i <= degree; ++i) {
+            at(out, i, col) = d[i];
+        }
+    }
+}
+
+/// Multiply two scalar 1D Béziers in the Bernstein basis.
+///
+/// `c_k = (1 / C(p+q, k)) * sum_i C(p, i) C(q, k-i) a_i b_{k-i}`, formed as the
+/// oracle forms it: scale `a_i` by `C(p, i)` once, accumulate `a_i_scaled * b_j *
+/// C(q, j)` left to right, then divide the whole row by `C(p+q, k)`.
+///
+/// \param a Control points of the first curve, shape `(p + 1,)`.
+/// \param b Control points of the second curve, shape `(q + 1,)`.
+/// \param out Product control points, shape `(p + q + 1,)`. Zeroed, then written
+///        in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel. `p + q`
+///       must not exceed `core::kBincoeffMaxN`; the Python Layer 2 checks it.
+///       For general use call `pantr.bezier.Bezier.multiply`.
+template <Real T>
+void scalar_bernstein_product_1d(std::span<const T> a, std::span<const T> b, std::span<T> out) {
+    using Acc = accumulator_t<T>;
+
+    const auto p = static_cast<int>(a.size()) - 1;
+    const auto q = static_cast<int>(b.size()) - 1;
+    const int r = p + q;
+
+    for (std::size_t k = 0; k < out.size(); ++k) {
+        out[k] = T(0);
+    }
+
+    for (int i = 0; i <= p; ++i) {
+        const Acc a_scaled = static_cast<Acc>(a[static_cast<std::size_t>(i)]) *
+                             Acc(core::bincoeff(p, i));
+        for (int j = 0; j <= q; ++j) {
+            const auto kz = static_cast<std::size_t>(i + j);
+            out[kz] = static_cast<T>(
+                static_cast<Acc>(out[kz]) +
+                a_scaled * static_cast<Acc>(b[static_cast<std::size_t>(j)]) *
+                    Acc(core::bincoeff(q, j)));
+        }
+    }
+
+    for (int k = 0; k <= r; ++k) {
+        const auto kz = static_cast<std::size_t>(k);
+        out[kz] = static_cast<T>(static_cast<Acc>(out[kz]) / Acc(core::bincoeff(r, k)));
+    }
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -8,8 +8,11 @@
 ///
 /// The oracle does not use one width. Reproducing which is which is most of the
 /// work in this file, and getting one wrong is invisible at `float64` and moves
-/// values at `float32`. Measured on the de Casteljau kernel: accumulating in
-/// `float` where the oracle accumulates in `double` moves 125 of 630 values.
+/// values at `float32`. Measured on the de Casteljau kernel at **float32**:
+/// accumulating in `float` where the oracle accumulates in `double` moves 125 of
+/// 630 values. The same count appears further down for a different perturbation at
+/// **float64**; the two are a coincidence of one 630-value grid, not one
+/// measurement quoted twice.
 ///
 ///  1. **`evaluate`, `slice`, `split`, `restrict` accumulate in `double`.** The
 ///     oracle's scalars are Python floats, and numba promotes a `float64` scalar
@@ -63,7 +66,21 @@ namespace pantr {
 
 /// Midpoint at which the evaluation recurrence switches to its mirrored branch.
 ///
-/// Bounds the seed below by `0.5^p`, so it never underflows regardless of degree.
+/// Bounds the seed below by `0.5^p`, which is the largest floor available: the seed
+/// is `min(u, 1-u)^p`, maximised uniquely at one half. Verified by the
+/// underflow-free degree it buys, 1074 against 812 at a threshold of 0.4.
+///
+/// **It does not make the seed underflow-proof, and the oracle's docstring says it
+/// does.** `0.5^p` reaches zero at `p >= 1075` in `float64` and `p >= 150` in
+/// `float32`, with gradual-underflow loss well before either. At `float32` the limit
+/// belongs to the *mirrored* branch specifically, a consequence of the width
+/// asymmetry documented above: this branch forms its seed from `u` at storage width
+/// while the unmirrored one forms it from `1 - u`, which the oracle's literal `1.0`
+/// has already promoted. So the branch that exists to prevent underflow is the one
+/// that underflows first at `float32`, near `p = 127` against `p = 1075`. Faithful
+/// to the oracle and outside any degree pantr reaches; recorded because the sentence
+/// it replaces was wrong.
+///
 /// Mirrors `_bezier_core._MIRROR_THRESHOLD`.
 inline constexpr double kBezierMirrorThreshold = 0.5;
 
@@ -79,6 +96,11 @@ inline constexpr double kBezierMirrorThreshold = 0.5;
 /// \param out Output of shape `(points.size(), rank)`, written in full.
 ///
 /// \note No input validation is performed. This is a Layer 3 kernel.
+///       Two preconditions are load-bearing for memory safety rather than for the
+///       answer: `ctrl` must have at least one row, since the degree is `rows - 1`
+///       widened to `std::size_t` and zero rows become a loop bound of `SIZE_MAX`;
+///       and `out` must have exactly `points.size()` rows and `ctrl.extent(1)`
+///       columns, since nothing here bounds-checks a write.
 ///       For general use call `pantr.bezier.Bezier.evaluate`.
 template <Real T>
 void evaluate_bezier_1d(span2d<const T> ctrl, std::span<const T> points, span2d<T> out) {
@@ -172,6 +194,9 @@ void evaluate_bezier_1d(span2d<const T> ctrl, std::span<const T> points, span2d<
 ///       Unlike its six siblings this kernel computes at `T`'s own width, since
 ///       the oracle allocates every workspace at the point dtype. See the file
 ///       comment.
+///       `ctrl` must have at least one row and `n_deriv` must be non-negative,
+///       both for memory safety: each is widened to `std::size_t` and sizes a
+///       workspace.
 ///       For general use call `pantr.bezier.Bezier.evaluate_derivatives`.
 template <Real T>
 void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, int n_deriv,
@@ -403,6 +428,8 @@ void degree_elevate_bezier_1d(int degree, span2d<const T> ctrl, int degree_incre
 /// \param out Output of shape `(n_cols,)`.
 ///
 /// \note No input validation is performed. This is a Layer 3 kernel.
+///       `ctrl` must have at least one row; see `evaluate_bezier_1d`'s note for why
+///       that is a memory-safety precondition rather than a shape convention.
 ///       For general use call `pantr.bezier.Bezier.slice`.
 template <Real T>
 void slice_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, std::span<T> out) {
@@ -451,6 +478,9 @@ void slice_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, std::span<T> 
 /// \note No input validation is performed. This is a Layer 3 kernel. Unlike
 ///       `slice_bezier_1d` there are no endpoint shortcuts, matching the oracle:
 ///       a split at 0 or 1 still runs the triangle.
+///       `ctrl` must have at least one row, and `out_left` and `out_right` must not
+///       overlap: each half is written independently, so one buffer passed twice
+///       returns the right half under both names.
 ///       For general use call `pantr.bezier.Bezier.split`.
 template <Real T>
 void split_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, span2d<T> out_left,
@@ -484,10 +514,23 @@ void split_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, span2d<T> out
 
 /// Restrict a 1D Bézier to `[lower, upper]`, reparametrized to `[0, 1]`.
 ///
-/// Two de Casteljau passes, ordered so that neither divides by a small number:
-/// if `|upper| >= |lower - 1|` the left pass runs at `upper` and the right at
-/// `lower / upper`, otherwise the right pass runs at `lower` and the left at
-/// `(upper - lower) / (1 - lower)`.
+/// Two de Casteljau passes. If `|upper| >= |lower - 1|` the left pass runs at
+/// `upper` and the right at `lower / upper`, otherwise the right pass runs at
+/// `lower` and the left at `(upper - lower) / (1 - lower)`.
+///
+/// **What the ordering buys is not what the oracle's docstring says.** It reads
+/// "ordered to avoid dividing by a small number", and a small divisor is not itself
+/// a problem, since the division is correctly rounded either way. Measured against
+/// an exact rational reference over fourteen interval shapes including very thin
+/// ones, the chosen ordering ranges from 0.14x to 7x the other's error, in both
+/// directions, all at 0.03 to 1.9 `eps * max|c|`. There is no accuracy story.
+///
+/// What it does buy: for `0 <= lower <= upper <= 1` the divisor is
+/// `max(upper, 1 - lower) >= 1/2`, since `upper < 1/2` forces `1 - lower > 1/2`, so
+/// `tau2` lands in `[0, 1]` with one rounding and the second pass stays a convex
+/// combination. And it keeps the degenerate corners from forming `0/0`:
+/// `lower = upper = 0` and `lower = upper = 1` both return finite values through
+/// this ordering and divide by zero through the other.
 ///
 /// \param ctrl Control points, shape `(degree + 1, n_cols)`.
 /// \param lower Left bound in `[0, 1)`.
@@ -495,6 +538,8 @@ void split_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, span2d<T> out
 /// \param out Restricted coefficients, shape `(degree + 1, n_cols)`.
 ///
 /// \note No input validation is performed. This is a Layer 3 kernel.
+///       `ctrl` must have at least one row, and `0 <= lower <= upper <= 1`: outside
+///       that the second pass stops being a convex combination.
 ///       For general use call `pantr.bezier.Bezier.restrict`.
 template <Real T>
 void restrict_bezier_1d(span2d<const T> ctrl, accumulator_t<T> lower, accumulator_t<T> upper,

--- a/cpp/include/pantr/core/binomial.hpp
+++ b/cpp/include/pantr/core/binomial.hpp
@@ -32,9 +32,14 @@
 /// overflow and returns a corrupted value; in C++ signed overflow is undefined
 /// behaviour, so the same input is worse here than there. The two callers in
 /// `bezier` are guarded on the Python side by `_check_bincoeff_envelope`, which
-/// runs in Layer 2 before any kernel is entered. `checked_bincoeff` below is for
-/// a C++ caller that has no such guard above it; `bincoeff` is the Layer 3 form
-/// and validates nothing, as Layer 3 does not.
+/// runs in Layer 2 before any kernel is entered, and `cpp/bindings/bezier.cpp`
+/// re-checks it for a caller that reaches the extension directly. `bincoeff` is the
+/// Layer 3 form and validates nothing, as Layer 3 does not.
+///
+/// A `checked_bincoeff` wrapper lived here briefly and was deleted as dead code. It
+/// had no caller, and the binding had independently written the same check with a
+/// different message -- which is the divergence this file's first paragraph warns
+/// about, one layer up. The check now exists once.
 ///
 /// Independently of the integer limit, the `double` return is lossless only
 /// while `C(n, k) <= 2^53`, i.e. up to `n = 56`; `C(57, 28)` is the first past
@@ -44,8 +49,6 @@
 /// rounded operand is all a ratio can use.
 
 #include <cstdint>
-#include <stdexcept>
-#include <string>
 
 namespace pantr::core {
 
@@ -69,8 +72,9 @@ inline constexpr int kBincoeffExactDoubleMaxN = 56;
 ///         correctly rounded above it.
 ///
 /// \note No input validation is performed. Passing `n > kBincoeffMaxN` is
-///       undefined behaviour, not a wrong answer. For general use call
-///       `checked_bincoeff` instead.
+///       undefined behaviour, not a wrong answer. The caller establishes the
+///       envelope; `cpp/bindings/bezier.cpp`'s `require_bincoeff_envelope` is where
+///       the library does so.
 [[nodiscard]] constexpr double bincoeff(int n, int k) noexcept {
     if (k < 0 || k > n) {
         return 0.0;
@@ -81,24 +85,6 @@ inline constexpr int kBincoeffExactDoubleMaxN = 56;
         result = result * static_cast<std::int64_t>(n - kk + i) / static_cast<std::int64_t>(i);
     }
     return static_cast<double>(result);
-}
-
-/// `bincoeff` with the envelope enforced, for a caller with no Layer 2 above it.
-///
-/// \param n Upper index.
-/// \param k Lower index.
-/// \param what Description of the requested operation, used in the message.
-/// \return `C(n, k)`, as `bincoeff`.
-/// \throws std::invalid_argument If `n` exceeds `kBincoeffMaxN`.
-[[nodiscard]] inline double checked_bincoeff(int n, int k, const char* what) {
-    if (n > kBincoeffMaxN) {
-        throw std::invalid_argument(
-            std::string(what) + " needs binomial coefficients up to C(" + std::to_string(n) +
-            ", k), beyond the largest upper index " + std::to_string(kBincoeffMaxN) +
-            " that pantr's exact-integer binomial kernel can compute without an int64 "
-            "overflow.");
-    }
-    return bincoeff(n, k);
 }
 
 }  // namespace pantr::core

--- a/cpp/include/pantr/core/binomial.hpp
+++ b/cpp/include/pantr/core/binomial.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+/// \file
+/// Exact-integer binomial coefficients, the C++ twin of
+/// `pantr.bspline._bspline_degree_core._bincoeff`.
+///
+/// ## Why this lives in `core/` and not in `bezier/`
+///
+/// It is `bezier`'s degree elevation and Bernstein product that need it first,
+/// but the Python original sits in `bspline` and `bspline`'s own port will want
+/// the same function. Two implementations of one recurrence is how the two
+/// diverge, and the divergence would be silent: both would agree on every small
+/// argument and part company only near the envelope, where nobody looks.
+///
+/// ## The recurrence, and why it is exact
+///
+/// `C(m, i) = C(m - 1, i - 1) * m / i` run over the smaller of `k` and `n - k`.
+/// The running product after step `i` is exactly `C(n - kk + i, i)`, an integer,
+/// so every division is exact and the result carries no rounding at all. The
+/// route through `lgamma` that this replaces is off by 380 at `(57, 28)`, since
+/// a value above `2^53` cannot be recovered from logarithms, and where it starts
+/// failing depends on the `libm` in use. Integer arithmetic makes the envelope a
+/// property of the algorithm rather than of the platform.
+///
+/// ## The envelope, and how it differs from Python's
+///
+/// The largest intermediate is `C(n, k) * min(k, n - k)`, which fits in `int64`
+/// for every `k` up to `n = 61`. That bound is shared with the Python kernel and
+/// `kBincoeffMaxN` states it.
+///
+/// **The consequence of exceeding it is not shared.** Numba wraps on int64
+/// overflow and returns a corrupted value; in C++ signed overflow is undefined
+/// behaviour, so the same input is worse here than there. The two callers in
+/// `bezier` are guarded on the Python side by `_check_bincoeff_envelope`, which
+/// runs in Layer 2 before any kernel is entered. `checked_bincoeff` below is for
+/// a C++ caller that has no such guard above it; `bincoeff` is the Layer 3 form
+/// and validates nothing, as Layer 3 does not.
+///
+/// Independently of the integer limit, the `double` return is lossless only
+/// while `C(n, k) <= 2^53`, i.e. up to `n = 56`; `C(57, 28)` is the first past
+/// it. Between 57 and 61 the exact integer is computed and then correctly
+/// rounded, which is the most a `double` return can carry. Every caller consumes
+/// these only inside a floating-point *ratio* of binomials, so a correctly
+/// rounded operand is all a ratio can use.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace pantr::core {
+
+/// Largest upper index for which the exact-integer recurrence cannot overflow.
+///
+/// Mirrors `pantr.bspline._bspline_degree_core._BINCOEFF_MAX_N`. Above this the
+/// Python kernel wraps silently and this one is undefined; neither is usable.
+inline constexpr int kBincoeffMaxN = 61;
+
+/// Largest upper index for which every `C(n, k)` is representable in a `double`.
+///
+/// Between this and `kBincoeffMaxN` the integer is still exact and the cast
+/// rounds once.
+inline constexpr int kBincoeffExactDoubleMaxN = 56;
+
+/// Compute `C(n, k)` in exact integer arithmetic, returning `0.0` outside `[0, n]`.
+///
+/// \param n Upper index. Must satisfy `n <= kBincoeffMaxN`.
+/// \param k Lower index.
+/// \return `C(n, k)` as a `double`, exact for `n <= kBincoeffExactDoubleMaxN` and
+///         correctly rounded above it.
+///
+/// \note No input validation is performed. Passing `n > kBincoeffMaxN` is
+///       undefined behaviour, not a wrong answer. For general use call
+///       `checked_bincoeff` instead.
+[[nodiscard]] constexpr double bincoeff(int n, int k) noexcept {
+    if (k < 0 || k > n) {
+        return 0.0;
+    }
+    const int kk = (k < n - k) ? k : n - k;
+    std::int64_t result = 1;
+    for (int i = 1; i <= kk; ++i) {
+        result = result * static_cast<std::int64_t>(n - kk + i) / static_cast<std::int64_t>(i);
+    }
+    return static_cast<double>(result);
+}
+
+/// `bincoeff` with the envelope enforced, for a caller with no Layer 2 above it.
+///
+/// \param n Upper index.
+/// \param k Lower index.
+/// \param what Description of the requested operation, used in the message.
+/// \return `C(n, k)`, as `bincoeff`.
+/// \throws std::invalid_argument If `n` exceeds `kBincoeffMaxN`.
+[[nodiscard]] inline double checked_bincoeff(int n, int k, const char* what) {
+    if (n > kBincoeffMaxN) {
+        throw std::invalid_argument(
+            std::string(what) + " needs binomial coefficients up to C(" + std::to_string(n) +
+            ", k), beyond the largest upper index " + std::to_string(kBincoeffMaxN) +
+            " that pantr's exact-integer binomial kernel can compute without an int64 "
+            "overflow.");
+    }
+    return bincoeff(n, k);
+}
+
+}  // namespace pantr::core

--- a/cpp/include/pantr/core/reduction_operator.hpp
+++ b/cpp/include/pantr/core/reduction_operator.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+/// \file
+/// Application of a dense degree-reduction operator, the C++ twin of
+/// `pantr.bspline._bspline_degree_core._apply_reduction_operator`.
+///
+/// ## Why this is in `core/` when the Python is in `bspline`
+///
+/// The Python docstring says why it lives where it does: `_bezier_core` already
+/// imports `_bincoeff` from `_bspline_degree_core`, so putting this kernel in
+/// `pantr.bezier` would close an import cycle. That is a packaging constraint of
+/// the Python side, not a statement about where the code belongs, and C++ headers
+/// have no cycle to avoid. Mirroring the Python location would be importing an
+/// accident, so this sits beside `binomial.hpp` for the same reason that one
+/// does: two modules need it, and neither should have to depend on the other.
+///
+/// ## What the operator is, and what is not here
+///
+/// `R` is assembled in **exact rational arithmetic** by
+/// `_bezier_degree._l2_reduction_operator` and its interpolating sibling, cached
+/// per `(p, q)`, and only then converted to `float64`. None of that is ported:
+/// it runs once per degree pair, it is not a kernel, and the Python comment
+/// records the reason it is exact at all -- a `float64` normal-equation solve for
+/// the same operator loses eleven digits. What crosses the boundary is the
+/// finished `float64` matrix, which is an array, so the type rule of
+/// design/cross_backend_types.md is satisfied without argument.
+///
+/// ## The accumulation width is a promise, not a detail
+///
+/// The oracle accumulates in `float64` regardless of the control points' dtype
+/// and rounds once on the write. At `float32` that is the difference between one
+/// rounding per row and `p + 1` of them, and the docstring states it, so it is a
+/// contract this port has to keep exactly rather than approximately.
+///
+/// Rows of `R` that pin an endpoint are unit vectors. Their outputs therefore
+/// reproduce their inputs bit for bit, in either backend and at either dtype,
+/// which is what makes the reduced segments of a spline stitch exactly C0.
+
+#include <cstddef>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::core {
+
+/// Apply a dense reduction operator to one set of control points: `out = R * ctrl`.
+///
+/// \param op Reduction operator `R`, shape `(q + 1, p + 1)`, always `double`.
+/// \param ctrl Control points, shape `(p + 1, rank)`.
+/// \param out Output, shape `(q + 1, rank)`, written in full.
+///
+/// \note No input validation is performed. This is a Layer 3 kernel in the
+///       layering of CLAUDE.md.
+///       For general use call `pantr.bezier.Bezier.reduce_degree`.
+template <Real T>
+void apply_reduction_operator(span2d<const double> op, span2d<const T> ctrl, span2d<T> out) {
+    using Acc = accumulator_t<T>;
+
+    const std::size_t n_out = op.extent(0);
+    const std::size_t n_in = op.extent(1);
+    const std::size_t rank = ctrl.extent(1);
+
+    for (std::size_t i = 0; i < n_out; ++i) {
+        for (std::size_t r = 0; r < rank; ++r) {
+            Acc acc = Acc(0);
+            for (std::size_t j = 0; j < n_in; ++j) {
+                acc = acc + Acc(at(op, i, j)) * static_cast<Acc>(at(ctrl, j, r));
+            }
+            at(out, i, r) = static_cast<T>(acc);
+        }
+    }
+}
+
+}  // namespace pantr::core

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -9,7 +9,8 @@ set(PANTR_TEST_SOURCES
     test_legendre.cpp
     test_change_basis.cpp
     test_quad.cpp
-    test_binomial.cpp)
+    test_binomial.cpp
+    test_bezier.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)
   cmake_path(GET _src STEM _name)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ set(PANTR_TEST_SOURCES
     test_bernstein.cpp
     test_legendre.cpp
     test_change_basis.cpp
-    test_quad.cpp)
+    test_quad.cpp
+    test_binomial.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)
   cmake_path(GET _src STEM _name)

--- a/cpp/tests/test_bezier.cpp
+++ b/cpp/tests/test_bezier.cpp
@@ -1,0 +1,428 @@
+/// \file
+/// Mathematical properties of the Bézier arithmetic kernels.
+///
+/// ## What this file is for, given that parity is already exhaustive
+///
+/// `tests/parity/test_bezier_arithmetic.py` compares every kernel here against
+/// its Numba oracle bit for bit, over 519 cases. What it cannot catch is a bug
+/// the **oracle shares**: a port faithful to a wrong formula passes parity
+/// perfectly. So nothing here compares the two backends. Every check below is
+/// against a property the mathematics fixes, or against an oracle computed a
+/// different way.
+///
+/// ## The exact cases, and why they are exact
+///
+/// Most of these assert bit equality rather than a tolerance, and each has a
+/// reason it can:
+///
+///  - **The endpoints.** `B(0) = c_0` and `B(1) = c_p` are structural, not
+///    approximate. At `u = 0` the seed `(1-u)^p` is exactly 1 and the ratio
+///    `u/(1-u)` is exactly 0, so every later term vanishes; `u = 1` is
+///    short-circuited. Elevation carries `bezalfs[0][0] = bezalfs[p][ph] = 1`
+///    exactly, and a split's first left point and last right point are copies.
+///  - **`restrict` over the full domain, on finite input.** With `lower = 0` and
+///    `upper = 1` the branch picks the left pass at `tau = 1`, whose step is
+///    `d[j]*1 + d[j-1]*0`, then the right pass at `tau2 = 0/1 = 0`, whose step is
+///    `d[j]*1 + d[j+1]*0`. Both return their input exactly for every finite value,
+///    subnormals included. **They do not for a signed zero or an infinity**, since
+///    `-0.0 + 0.0` is `+0.0` and `inf * 0` is a NaN that then poisons the column.
+///    An earlier draft of this file claimed the identity held for those too; the
+///    test refuted it, the oracle was measured to behave identically, and both
+///    exceptions are now pinned rather than excluded.
+///  - **de Casteljau at one half, on integers.** Each step is
+///    `0.5*d[i] + 0.5*d[i+1]`, which for integer operands is `(d[i]+d[i+1])/2`, a
+///    dyadic rational held exactly while the numerator stays under `2^53`. The
+///    independent oracle is `sum_i C(p,i) c_i / 2^p`, assembled in exact `int64`
+///    and divided by a power of two, which is also exact. Two different
+///    algorithms, both exact, so the comparison is an equality with no tolerance
+///    to argue about. This is the one check here that would catch a wrong
+///    *formula* rather than a wrong endpoint.
+///
+/// ## The two bounded cases
+///
+/// `product_with_unit` forms `(a_k * C(p,k)) / C(p,k)`, two roundings, so the
+/// result is within `2u` relative of `a_k` and is exact only when the binomial is
+/// a power of two. `derivative_at_the_endpoints` compares against
+/// `p * (c_1 - c_0)`, where the subtraction of two neighbouring control points is
+/// exact by Sterbenz only when they are within a factor of two of each other, so
+/// the control points there are chosen to make it so and the remaining slack is
+/// the A2.3 recursion's own.
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+constexpr double kEps = std::numeric_limits<double>::epsilon();
+
+/// A control net laid out row-major as `(degree + 1, rank)`.
+struct Net {
+    std::vector<double> data;
+    std::size_t rows = 0;
+    std::size_t cols = 0;
+
+    [[nodiscard]] pantr::span2d<const double> view() const {
+        return pantr::span2d<const double>(data.data(), rows, cols);
+    }
+};
+
+/// Build a net from a flat row-major list.
+Net net(std::vector<double> values, std::size_t rows, std::size_t cols) {
+    return Net{std::move(values), rows, cols};
+}
+
+/// A deterministic net of small integers, so exact arithmetic stays available.
+Net integer_net(std::size_t rows, std::size_t cols) {
+    std::vector<double> values(rows * cols);
+    // A fixed, non-monotone pattern in [-9, 9]: monotone data hides an index slip
+    // in a de Casteljau triangle, because neighbouring values are then close.
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        const auto k = static_cast<std::int64_t>(i);
+        values[i] = static_cast<double>(((k * 7 + 3) % 19) - 9);
+    }
+    return net(std::move(values), rows, cols);
+}
+
+/// `sum_i C(p, i) c_i / 2^p`, the value of a Bézier at one half, exactly.
+///
+/// Assembled in `int64` from integer control points, so it is an independent
+/// oracle rather than the same recurrence run twice.
+double value_at_half_exact(const Net& n, std::size_t col) {
+    const auto p = static_cast<int>(n.rows) - 1;
+    std::int64_t total = 0;
+    for (int i = 0; i <= p; ++i) {
+        const auto c = static_cast<std::int64_t>(
+            n.data[static_cast<std::size_t>(i) * n.cols + col]);
+        total += static_cast<std::int64_t>(pantr::core::bincoeff(p, i)) * c;
+    }
+    return std::ldexp(static_cast<double>(total), -p);
+}
+
+void test_slice_at_one_half_matches_an_exact_binomial_sum() {
+    // Degree 40 keeps `sum |C(40, i) * 9|` near 9 * 2^40, far under 2^53, so both
+    // sides stay in exact integer arithmetic.
+    for (std::size_t degree : {std::size_t{0}, std::size_t{1}, std::size_t{2},
+                               std::size_t{5}, std::size_t{13}, std::size_t{40}}) {
+        const Net n = integer_net(degree + 1, 3);
+        std::vector<double> got(3);
+        pantr::slice_bezier_1d<double>(n.view(), 0.5, std::span<double>(got));
+        for (std::size_t col = 0; col < 3; ++col) {
+            const double want = value_at_half_exact(n, col);
+            PANTR_CHECK_MSG(got[col] == want,
+                            "degree " + std::to_string(degree) + " column " +
+                                std::to_string(col) + ": " + std::to_string(got[col]) +
+                                " against the exact " + std::to_string(want));
+        }
+    }
+}
+
+void test_evaluate_reproduces_the_end_control_points() {
+    for (std::size_t degree : {std::size_t{0}, std::size_t{1}, std::size_t{4},
+                               std::size_t{17}, std::size_t{30}}) {
+        const Net n = integer_net(degree + 1, 2);
+        const std::vector<double> pts{0.0, 1.0};
+        std::vector<double> got(4);
+        pantr::evaluate_bezier_1d<double>(n.view(), std::span<const double>(pts),
+                                          pantr::span2d<double>(got.data(), 2, 2));
+        for (std::size_t col = 0; col < 2; ++col) {
+            PANTR_CHECK_MSG(got[col] == n.data[col],
+                            "degree " + std::to_string(degree) + ": B(0) is not c_0");
+            PANTR_CHECK_MSG(got[2 + col] == n.data[degree * 2 + col],
+                            "degree " + std::to_string(degree) + ": B(1) is not c_p");
+        }
+    }
+}
+
+void test_slice_reproduces_the_end_control_points() {
+    for (std::size_t degree : {std::size_t{0}, std::size_t{1}, std::size_t{9}}) {
+        const Net n = integer_net(degree + 1, 2);
+        std::vector<double> at_zero(2);
+        std::vector<double> at_one(2);
+        pantr::slice_bezier_1d<double>(n.view(), 0.0, std::span<double>(at_zero));
+        pantr::slice_bezier_1d<double>(n.view(), 1.0, std::span<double>(at_one));
+        for (std::size_t col = 0; col < 2; ++col) {
+            PANTR_CHECK(at_zero[col] == n.data[col]);
+            PANTR_CHECK(at_one[col] == n.data[degree * 2 + col]);
+        }
+    }
+}
+
+void test_split_preserves_the_endpoints_and_shares_a_point() {
+    // The shared point is what makes a split a partition rather than two
+    // approximations: the last left control point and the first right one are the
+    // same de Casteljau vertex, so they must be identical bit for bit.
+    for (std::size_t degree : {std::size_t{1}, std::size_t{3}, std::size_t{11}}) {
+        for (double u : {0.125, 0.5, 0.9}) {
+            const Net n = integer_net(degree + 1, 2);
+            std::vector<double> left((degree + 1) * 2);
+            std::vector<double> right((degree + 1) * 2);
+            pantr::split_bezier_1d<double>(n.view(), u,
+                                           pantr::span2d<double>(left.data(), degree + 1, 2),
+                                           pantr::span2d<double>(right.data(), degree + 1, 2));
+            for (std::size_t col = 0; col < 2; ++col) {
+                PANTR_CHECK_MSG(left[col] == n.data[col], "left half moved the start point");
+                PANTR_CHECK_MSG(right[degree * 2 + col] == n.data[degree * 2 + col],
+                                "right half moved the end point");
+                PANTR_CHECK_MSG(left[degree * 2 + col] == right[col],
+                                "the two halves do not share the split point at degree " +
+                                    std::to_string(degree));
+            }
+        }
+    }
+}
+
+void test_elevate_preserves_the_endpoints() {
+    for (int degree : {0, 1, 4, 12}) {
+        for (int inc : {1, 2, 7}) {
+            const Net n = integer_net(static_cast<std::size_t>(degree) + 1, 2);
+            const auto rows = static_cast<std::size_t>(degree + inc + 1);
+            std::vector<double> out(rows * 2);
+            pantr::degree_elevate_bezier_1d<double>(
+                degree, n.view(), inc, pantr::span2d<double>(out.data(), rows, 2));
+            for (std::size_t col = 0; col < 2; ++col) {
+                PANTR_CHECK_MSG(out[col] == n.data[col], "elevation moved the start point");
+                PANTR_CHECK_MSG(out[(rows - 1) * 2 + col] ==
+                                    n.data[static_cast<std::size_t>(degree) * 2 + col],
+                                "elevation moved the end point");
+            }
+        }
+    }
+}
+
+void test_elevating_a_linear_gives_the_midpoint() {
+    // Degree 1 to 2 has one interior coefficient, `(a + b) / 2`, and for integer
+    // endpoints that is exact. A wrong `bezalfs` entry shows up here as a value
+    // that is not the midpoint at all, rather than as a last-bit difference.
+    const Net n = net({4.0, -2.0, 10.0, 6.0}, 2, 2);
+    std::vector<double> out(6);
+    pantr::degree_elevate_bezier_1d<double>(1, n.view(), 1,
+                                            pantr::span2d<double>(out.data(), 3, 2));
+    PANTR_CHECK(out[2] == 7.0);
+    PANTR_CHECK(out[3] == 2.0);
+}
+
+void test_restrict_to_the_full_domain_is_the_identity_on_finite_input() {
+    // Exact on finite input, and the qualifier is load-bearing. Both passes reduce
+    // to `d[j] * 1 + d[neighbour] * 0`, which returns `d[j]` unchanged for every
+    // finite value including subnormals -- but `inf * 0` is a NaN, so one infinity
+    // anywhere in a column poisons the whole column, and `-0.0 + 0.0` is `+0.0`, so
+    // a signed zero does not survive either.
+    //
+    // Neither of those is a defect of the port: measured, the numba oracle does
+    // exactly the same, and the parity suite covers the agreement. They are
+    // recorded below rather than excluded, because "restrict over the full domain
+    // returns its input" is the kind of sentence that ends up in a docstring, and
+    // it is false as stated.
+    Net n = integer_net(8, 3);
+    n.data[2] = std::numeric_limits<double>::denorm_min();
+    n.data[5] = std::numeric_limits<double>::max();
+    std::vector<double> out(8 * 3);
+    pantr::restrict_bezier_1d<double>(n.view(), 0.0, 1.0,
+                                      pantr::span2d<double>(out.data(), 8, 3));
+    for (std::size_t i = 0; i < out.size(); ++i) {
+        PANTR_CHECK_MSG(out[i] == n.data[i],
+                        "restrict to [0, 1] changed entry " + std::to_string(i));
+    }
+}
+
+void test_restrict_over_the_full_domain_loses_a_signed_zero_and_an_infinity() {
+    // The two documented exceptions to the identity above, pinned so that a later
+    // rewrite of the pass cannot change them silently in one backend only.
+    Net signed_zero = integer_net(4, 1);
+    signed_zero.data[1] = -0.0;
+    std::vector<double> out(4);
+    pantr::restrict_bezier_1d<double>(signed_zero.view(), 0.0, 1.0,
+                                      pantr::span2d<double>(out.data(), 4, 1));
+    PANTR_CHECK_MSG(out[1] == 0.0 && !std::signbit(out[1]),
+                    "a signed zero is expected to come back positive, since the pass "
+                    "forms -0.0 + 0.0");
+
+    Net infinite = integer_net(4, 1);
+    infinite.data[0] = std::numeric_limits<double>::infinity();
+    pantr::restrict_bezier_1d<double>(infinite.view(), 0.0, 1.0,
+                                      pantr::span2d<double>(out.data(), 4, 1));
+    bool any_nan = false;
+    for (double v : out) {
+        any_nan = any_nan || std::isnan(v);
+    }
+    PANTR_CHECK_MSG(any_nan, "an infinity is expected to reach the output as a NaN, "
+                             "since the pass forms inf * 0");
+}
+
+void test_product_with_the_unit_polynomial_reproduces_its_input() {
+    // `c_k = (a_k * C(p,k)) / C(p,k)`: two roundings, so within 2u relative, and
+    // exact whenever the binomial is a power of two. Anything larger than that is
+    // a wrong scaling rather than rounding.
+    for (int p : {0, 1, 3, 10, 20}) {
+        const Net a = integer_net(static_cast<std::size_t>(p) + 1, 1);
+        const std::vector<double> unit{1.0};
+        std::vector<double> out(static_cast<std::size_t>(p) + 1);
+        pantr::scalar_bernstein_product_1d<double>(
+            std::span<const double>(a.data), std::span<const double>(unit),
+            std::span<double>(out));
+        for (std::size_t k = 0; k < out.size(); ++k) {
+            const double want = a.data[k];
+            const double slack = 2.0 * kEps * std::abs(want);
+            PANTR_CHECK_MSG(std::abs(out[k] - want) <= slack,
+                            "degree " + std::to_string(p) + " coefficient " +
+                                std::to_string(k) + ": " + std::to_string(out[k]) +
+                                " against " + std::to_string(want));
+        }
+    }
+}
+
+void test_the_first_derivative_at_the_endpoints() {
+    // `B'(0) = p (c_1 - c_0)` and `B'(1) = p (c_p - c_{p-1})`, exactly in exact
+    // arithmetic. The control points below are consecutive small integers, so
+    // every difference is exact by Sterbenz and all the slack left is the A2.3
+    // recursion's own: at most `p` roundings of a quantity of size `p * |dc|`,
+    // hence the `p` in the tolerance.
+    for (int p : {1, 2, 5, 9}) {
+        const auto rows = static_cast<std::size_t>(p) + 1;
+        std::vector<double> values(rows);
+        for (std::size_t i = 0; i < rows; ++i) {
+            values[i] = 3.0 + static_cast<double>(i);
+        }
+        const Net n = net(values, rows, 1);
+        const std::vector<double> pts{0.0, 1.0};
+        std::vector<double> out(2 * 2 * 1);
+        pantr::evaluate_bezier_deriv_1d<double>(n.view(), std::span<const double>(pts), 1,
+                                                pantr::span_nd<double, 3>(out.data(), 2, 2, 1));
+        const double want = static_cast<double>(p) * 1.0;  // every difference is 1
+        const double slack = static_cast<double>(p) * kEps * std::abs(want);
+        PANTR_CHECK_MSG(std::abs(out[1] - want) <= slack,
+                        "degree " + std::to_string(p) + ": B'(0) is " +
+                            std::to_string(out[1]) + ", expected " + std::to_string(want));
+        PANTR_CHECK_MSG(std::abs(out[3] - want) <= slack,
+                        "degree " + std::to_string(p) + ": B'(1) is " +
+                            std::to_string(out[3]) + ", expected " + std::to_string(want));
+    }
+}
+
+void test_a_split_reconstructs_the_original_curve() {
+    // The left half at parameter `s` is the whole curve at `u * s`. This is the one
+    // check that ties the split to the evaluation, so a triangle that is internally
+    // consistent but wrong fails here rather than nowhere.
+    //
+    // The bound: de Casteljau on `[0, 1]` is a sequence of convex combinations, so
+    // after `p` stages the accumulated error is at most `p` roundings of a quantity
+    // bounded by `max |c_i|`. Evaluation adds its own `3p` roundings of the same
+    // scale, per the Bernstein recurrence's three multiplications per step, and the
+    // constant below rounds `4p` up to `8p` to cover the `pow` seed's libm error.
+    const std::size_t degree = 9;
+    const Net n = integer_net(degree + 1, 1);
+    double worst_c = 0.0;
+    for (double v : n.data) {
+        worst_c = std::max(worst_c, std::abs(v));
+    }
+
+    for (double u : {0.25, 0.5, 0.75}) {
+        std::vector<double> left(degree + 1);
+        std::vector<double> right(degree + 1);
+        pantr::split_bezier_1d<double>(n.view(), u,
+                                       pantr::span2d<double>(left.data(), degree + 1, 1),
+                                       pantr::span2d<double>(right.data(), degree + 1, 1));
+        const pantr::span2d<const double> left_view(left.data(), degree + 1, 1);
+
+        for (double s : {0.0, 0.3, 0.6, 1.0}) {
+            const std::vector<double> half_pt{s};
+            const std::vector<double> whole_pt{u * s};
+            double from_half = 0.0;
+            double from_whole = 0.0;
+            pantr::evaluate_bezier_1d<double>(left_view, std::span<const double>(half_pt),
+                                              pantr::span2d<double>(&from_half, 1, 1));
+            pantr::evaluate_bezier_1d<double>(n.view(), std::span<const double>(whole_pt),
+                                              pantr::span2d<double>(&from_whole, 1, 1));
+            const double slack = 8.0 * static_cast<double>(degree) * kEps * worst_c;
+            PANTR_CHECK_MSG(std::abs(from_half - from_whole) <= slack,
+                            "split at " + std::to_string(u) + ", left half at " +
+                                std::to_string(s) + ": " + std::to_string(from_half) +
+                                " against " + std::to_string(from_whole));
+        }
+    }
+}
+
+void test_restrict_agrees_with_evaluation_on_the_subinterval() {
+    // The restricted curve at `s` is the original at `lower + s * (upper - lower)`.
+    // Both branches of the pass-ordering test are exercised, which is what makes
+    // this more than a repeat of the split check above.
+    const std::size_t degree = 7;
+    const Net n = integer_net(degree + 1, 1);
+    double worst_c = 0.0;
+    for (double v : n.data) {
+        worst_c = std::max(worst_c, std::abs(v));
+    }
+
+    const double bounds[][2] = {{0.1, 0.9}, {0.0, 0.4}, {0.6, 1.0}, {0.25, 0.75}};
+    for (const auto& b : bounds) {
+        std::vector<double> sub(degree + 1);
+        pantr::restrict_bezier_1d<double>(n.view(), b[0], b[1],
+                                          pantr::span2d<double>(sub.data(), degree + 1, 1));
+        const pantr::span2d<const double> sub_view(sub.data(), degree + 1, 1);
+
+        for (double s : {0.0, 0.5, 1.0}) {
+            const std::vector<double> sub_pt{s};
+            const std::vector<double> whole_pt{b[0] + s * (b[1] - b[0])};
+            double from_sub = 0.0;
+            double from_whole = 0.0;
+            pantr::evaluate_bezier_1d<double>(sub_view, std::span<const double>(sub_pt),
+                                              pantr::span2d<double>(&from_sub, 1, 1));
+            pantr::evaluate_bezier_1d<double>(n.view(), std::span<const double>(whole_pt),
+                                              pantr::span2d<double>(&from_whole, 1, 1));
+            // Two de Casteljau passes rather than one, so twice the split's budget.
+            const double slack = 16.0 * static_cast<double>(degree) * kEps * worst_c;
+            PANTR_CHECK_MSG(std::abs(from_sub - from_whole) <= slack,
+                            "restrict to [" + std::to_string(b[0]) + ", " +
+                                std::to_string(b[1]) + "] at " + std::to_string(s) + ": " +
+                                std::to_string(from_sub) + " against " +
+                                std::to_string(from_whole));
+        }
+    }
+}
+
+void test_float32_runs_the_same_structural_identities() {
+    // The exact endpoint identities hold at every width, so they are the cheapest
+    // way to instantiate the kernels on `float` and find out that they do.
+    const std::vector<float> values{4.0F, -2.0F, 10.0F, 6.0F, 1.0F, 0.0F};
+    const pantr::span2d<const float> view(values.data(), 3, 2);
+    std::vector<float> got(2);
+    pantr::slice_bezier_1d<float>(view, 0.0, std::span<float>(got));
+    PANTR_CHECK(got[0] == 4.0F && got[1] == -2.0F);
+    pantr::slice_bezier_1d<float>(view, 1.0, std::span<float>(got));
+    PANTR_CHECK(got[0] == 1.0F && got[1] == 0.0F);
+
+    std::vector<float> elevated(4 * 2);
+    pantr::degree_elevate_bezier_1d<float>(2, view, 1,
+                                           pantr::span2d<float>(elevated.data(), 4, 2));
+    PANTR_CHECK(elevated[0] == 4.0F && elevated[1] == -2.0F);
+    PANTR_CHECK(elevated[6] == 1.0F && elevated[7] == 0.0F);
+}
+
+}  // namespace
+
+int main() {
+    test_slice_at_one_half_matches_an_exact_binomial_sum();
+    test_evaluate_reproduces_the_end_control_points();
+    test_slice_reproduces_the_end_control_points();
+    test_split_preserves_the_endpoints_and_shares_a_point();
+    test_elevate_preserves_the_endpoints();
+    test_elevating_a_linear_gives_the_midpoint();
+    test_restrict_to_the_full_domain_is_the_identity_on_finite_input();
+    test_restrict_over_the_full_domain_loses_a_signed_zero_and_an_infinity();
+    test_product_with_the_unit_polynomial_reproduces_its_input();
+    test_the_first_derivative_at_the_endpoints();
+    test_a_split_reconstructs_the_original_curve();
+    test_restrict_agrees_with_evaluation_on_the_subinterval();
+    test_float32_runs_the_same_structural_identities();
+    return pantr::test::summary("test_bezier");
+}

--- a/cpp/tests/test_bezier.cpp
+++ b/cpp/tests/test_bezier.cpp
@@ -38,15 +38,33 @@
 ///    to argue about. This is the one check here that would catch a wrong
 ///    *formula* rather than a wrong endpoint.
 ///
-/// ## The two bounded cases
+/// ## The bounded cases, and two claims a review refuted
 ///
-/// `product_with_unit` forms `(a_k * C(p,k)) / C(p,k)`, two roundings, so the
-/// result is within `2u` relative of `a_k` and is exact only when the binomial is
-/// a power of two. `derivative_at_the_endpoints` compares against
-/// `p * (c_1 - c_0)`, where the subtraction of two neighbouring control points is
-/// exact by Sterbenz only when they are within a factor of two of each other, so
-/// the control points there are chosen to make it so and the remaining slack is
-/// the A2.3 recursion's own.
+/// `split_reconstructs` and `restrict_agrees` carry real bounds, `8p` and `16p`
+/// times `eps * max|c|`, measured at 31-45x margin to degree 55 across 600
+/// decades. One caveat their derivation omitted: they are computed in `eps` where
+/// the argument is written in `u = eps/2`, an unacknowledged further factor of two.
+/// `cpp/tests/test_cardinal_bspline.cpp` states that substitution explicitly and
+/// this file now does too.
+///
+/// **Two other tolerances here were not bounds at all, and both are gone.**
+///
+/// `product_with_unit` claimed to be "exact only when the binomial is a power of
+/// two". False: exactness holds whenever `a_k * C(p,k)` is representable, which for
+/// integers in `[-9, 9]` is every `p <= 53`. All five swept degrees gave error
+/// exactly zero at binomials 3, 45, 252 and 184756, none a power of two, so the
+/// tolerance had never been consumed. It is an equality now, with its envelope
+/// stated.
+///
+/// `derivative_at_the_endpoints` justified `p * eps * |want|` by Sterbenz exactness
+/// of `c_1 - c_0`. **The kernel never subtracts two control points** -- `ctrl`
+/// enters only as `+= weight * ctrl` -- so the mechanism does not exist. The bound
+/// was also vacuous on its own data (error exactly zero at every swept degree) and
+/// false off it: with `c = 1e6 + i/3` at unit scale it is exceeded 1.7e5 times at
+/// `p = 5`. The scaling was the wrong quantity, because A2.3's roundings act on
+/// contraction terms of size `sum_j |B'_{j,p}| * max|c| <= 2p * max|c|`, not on
+/// `|want| = p * |dc|`. It is now an equality on the exact case and a derived
+/// `2 p^2 eps max|c|` on a case that actually rounds.
 
 #include <cmath>
 #include <cstddef>
@@ -260,9 +278,15 @@ void test_restrict_over_the_full_domain_loses_a_signed_zero_and_an_infinity() {
 }
 
 void test_product_with_the_unit_polynomial_reproduces_its_input() {
-    // `c_k = (a_k * C(p,k)) / C(p,k)`: two roundings, so within 2u relative, and
-    // exact whenever the binomial is a power of two. Anything larger than that is
-    // a wrong scaling rather than rounding.
+    // `c_k = (a_k * C(p,k)) / C(p,k)`, and this is an EQUALITY, not a tolerance.
+    // Both operations are exact whenever `a_k * C(p,k)` is representable: the
+    // multiply lands on an integer below 2^53 and the divide undoes it exactly. For
+    // `|a| <= 9` that holds through `p = 53`, five orders past the largest swept
+    // degree (1.3e6 against 9.0e15). An earlier version asserted `2 * eps * |want|`
+    // and justified it by the binomial being a power of two, which is false and
+    // which made the assertion vacuous: the error is zero at binomials 3, 45, 252
+    // and 184756. A wrong scaling now fails outright rather than inside a tolerance
+    // nothing consumed.
     for (int p : {0, 1, 3, 10, 20}) {
         const Net a = integer_net(static_cast<std::size_t>(p) + 1, 1);
         const std::vector<double> unit{1.0};
@@ -271,22 +295,31 @@ void test_product_with_the_unit_polynomial_reproduces_its_input() {
             std::span<const double>(a.data), std::span<const double>(unit),
             std::span<double>(out));
         for (std::size_t k = 0; k < out.size(); ++k) {
-            const double want = a.data[k];
-            const double slack = 2.0 * kEps * std::abs(want);
-            PANTR_CHECK_MSG(std::abs(out[k] - want) <= slack,
+            PANTR_CHECK_MSG(out[k] == a.data[k],
                             "degree " + std::to_string(p) + " coefficient " +
                                 std::to_string(k) + ": " + std::to_string(out[k]) +
-                                " against " + std::to_string(want));
+                                " against the exact " + std::to_string(a.data[k]));
         }
     }
 }
 
-void test_the_first_derivative_at_the_endpoints() {
-    // `B'(0) = p (c_1 - c_0)` and `B'(1) = p (c_p - c_{p-1})`, exactly in exact
-    // arithmetic. The control points below are consecutive small integers, so
-    // every difference is exact by Sterbenz and all the slack left is the A2.3
-    // recursion's own: at most `p` roundings of a quantity of size `p * |dc|`,
-    // hence the `p` in the tolerance.
+void test_the_first_derivative_at_the_endpoints_is_exact_on_integers() {
+    // `B'(0) = p (c_1 - c_0)` and `B'(1) = p (c_p - c_{p-1})`, and on this data it
+    // is an EQUALITY.
+    //
+    // At `s = 0` and `s = 1` every `ndu` entry collapses to exactly 0 or 1, A2.3's
+    // `a`-recursion forms differences of exact integers, and the falling factorial
+    // is exact integer arithmetic, so the contraction is a sum of exactly
+    // representable integers while `2^{n_deriv} p (p+1) max|c| < 2^53` -- at most
+    // 1080 for the degrees below.
+    //
+    // The version this replaces asserted `p * eps * |want|` and justified it by
+    // Sterbenz exactness of `c_1 - c_0`. That mechanism does not exist: the kernel
+    // never subtracts two control points, only accumulates `weight * ctrl`. The
+    // assertion was also never exercised, since the error was exactly zero at every
+    // swept degree, so the wrong bound sat behind a passing test. See
+    // `test_the_first_derivative_under_cancellation` below for the case that does
+    // round, and the bound that actually holds there.
     for (int p : {1, 2, 5, 9}) {
         const auto rows = static_cast<std::size_t>(p) + 1;
         std::vector<double> values(rows);
@@ -299,13 +332,53 @@ void test_the_first_derivative_at_the_endpoints() {
         pantr::evaluate_bezier_deriv_1d<double>(n.view(), std::span<const double>(pts), 1,
                                                 pantr::span_nd<double, 3>(out.data(), 2, 2, 1));
         const double want = static_cast<double>(p) * 1.0;  // every difference is 1
-        const double slack = static_cast<double>(p) * kEps * std::abs(want);
+        PANTR_CHECK_MSG(out[1] == want, "degree " + std::to_string(p) + ": B'(0) is " +
+                                            std::to_string(out[1]) + ", expected exactly " +
+                                            std::to_string(want));
+        PANTR_CHECK_MSG(out[3] == want, "degree " + std::to_string(p) + ": B'(1) is " +
+                                            std::to_string(out[3]) + ", expected exactly " +
+                                            std::to_string(want));
+    }
+}
+
+void test_the_first_derivative_under_cancellation() {
+    // The case the exact test above cannot reach, and the bound that holds there.
+    //
+    // `c_i = 1e6 + i/3` makes the answer `p/3` while every control point is 1e6, so
+    // the derivative is a difference of large numbers and the roundings act on the
+    // contraction terms rather than on the result. A2.3's derivative basis satisfies
+    // `sum_j |B'_{j,p}(s)| <= 2p`, and the contraction commits at most one rounding
+    // per stage of the recursion, so the absolute error is bounded by
+    //
+    //     |err|  <=  2 * p^2 * eps * max|c|                                    (1)
+    //
+    // which is what the tolerance below is. The bound it replaces, `p * eps *
+    // |want|`, is scaled by the RESULT rather than by the data, and this data is
+    // exactly where those differ: it is exceeded 1.7e5 times at `p = 5`.
+    for (int p : {2, 5, 9, 25}) {
+        const auto rows = static_cast<std::size_t>(p) + 1;
+        std::vector<double> values(rows);
+        double worst_c = 0.0;
+        for (std::size_t i = 0; i < rows; ++i) {
+            values[i] = 1.0e6 + static_cast<double>(i) / 3.0;
+            worst_c = std::max(worst_c, std::abs(values[i]));
+        }
+        const Net n = net(values, rows, 1);
+        const std::vector<double> pts{0.0, 1.0};
+        std::vector<double> out(2 * 2 * 1);
+        pantr::evaluate_bezier_deriv_1d<double>(n.view(), std::span<const double>(pts), 1,
+                                                pantr::span_nd<double, 3>(out.data(), 2, 2, 1));
+        const double want = static_cast<double>(p) / 3.0;
+        const double pd = static_cast<double>(p);
+        const double slack = 2.0 * pd * pd * kEps * worst_c;
         PANTR_CHECK_MSG(std::abs(out[1] - want) <= slack,
-                        "degree " + std::to_string(p) + ": B'(0) is " +
-                            std::to_string(out[1]) + ", expected " + std::to_string(want));
+                        "degree " + std::to_string(p) + ": B'(0) error " +
+                            std::to_string(std::abs(out[1] - want)) + " exceeds " +
+                            std::to_string(slack));
         PANTR_CHECK_MSG(std::abs(out[3] - want) <= slack,
-                        "degree " + std::to_string(p) + ": B'(1) is " +
-                            std::to_string(out[3]) + ", expected " + std::to_string(want));
+                        "degree " + std::to_string(p) + ": B'(1) error " +
+                            std::to_string(std::abs(out[3] - want)) + " exceeds " +
+                            std::to_string(slack));
     }
 }
 
@@ -319,6 +392,12 @@ void test_a_split_reconstructs_the_original_curve() {
     // bounded by `max |c_i|`. Evaluation adds its own `3p` roundings of the same
     // scale, per the Bernstein recurrence's three multiplications per step, and the
     // constant below rounds `4p` up to `8p` to cover the `pow` seed's libm error.
+    //
+    // Written in `eps` while the argument is in `u = eps/2`, so the coded constant
+    // is a further factor of two loose. Stated rather than removed, as
+    // `cpp/tests/test_cardinal_bspline.cpp` states it: measured margin over the
+    // observed worst is 31-45x to degree 55 across 600 decades, so the slack is not
+    // what makes the test pass.
     const std::size_t degree = 9;
     const Net n = integer_net(degree + 1, 1);
     double worst_c = 0.0;
@@ -420,7 +499,8 @@ int main() {
     test_restrict_to_the_full_domain_is_the_identity_on_finite_input();
     test_restrict_over_the_full_domain_loses_a_signed_zero_and_an_infinity();
     test_product_with_the_unit_polynomial_reproduces_its_input();
-    test_the_first_derivative_at_the_endpoints();
+    test_the_first_derivative_at_the_endpoints_is_exact_on_integers();
+    test_the_first_derivative_under_cancellation();
     test_a_split_reconstructs_the_original_curve();
     test_restrict_agrees_with_evaluation_on_the_subinterval();
     test_float32_runs_the_same_structural_identities();

--- a/cpp/tests/test_binomial.cpp
+++ b/cpp/tests/test_binomial.cpp
@@ -1,0 +1,130 @@
+/// \file
+/// The exact-integer binomial recurrence, against an independently-computed oracle.
+///
+/// ## Why Pascal's triangle is the oracle
+///
+/// `bincoeff` runs a multiplicative recurrence, `C(m, i) = C(m - 1, i - 1) * m / i`,
+/// and its whole claim is that every one of those divisions is exact. A test that
+/// recomputed the same recurrence would agree with a wrong one, so the oracle here
+/// builds the triangle by **addition** instead: `C(n, k) = C(n-1, k-1) + C(n-1, k)`.
+/// Two different algorithms, and addition needs no exactness argument at all.
+///
+/// The oracle is itself exact over the whole envelope: the largest coefficient in
+/// range is `C(61, 30) = 232714176627630544`, well inside `int64`. So this test
+/// covers *every* `(n, k)` with `n <= 61` rather than sampling.
+///
+/// ## What the other checks would catch
+///
+/// Symmetry and the row sum are cheap and independent of the oracle: `C(n, k)` must
+/// equal `C(n, n - k)`, and a row must sum to `2^n`. The `double` return is exact up
+/// to `n = 56` and correctly rounded above it, so the row-sum identity is asserted
+/// in integers and the `double` comparison stops where representability does.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/binomial.hpp"
+
+namespace {
+
+using pantr::core::bincoeff;
+using pantr::core::kBincoeffExactDoubleMaxN;
+using pantr::core::kBincoeffMaxN;
+
+/// Pascal's triangle in exact `int64`, rows 0 through `kBincoeffMaxN`.
+std::vector<std::vector<std::int64_t>> pascal() {
+    std::vector<std::vector<std::int64_t>> rows;
+    rows.reserve(static_cast<std::size_t>(kBincoeffMaxN) + 1);
+    rows.push_back({1});
+    for (int n = 1; n <= kBincoeffMaxN; ++n) {
+        const std::vector<std::int64_t>& prev = rows.back();
+        std::vector<std::int64_t> row(static_cast<std::size_t>(n) + 1, 1);
+        for (int k = 1; k < n; ++k) {
+            const auto kk = static_cast<std::size_t>(k);
+            row[kk] = prev[kk - 1] + prev[kk];
+        }
+        rows.push_back(std::move(row));
+    }
+    return rows;
+}
+
+void test_against_pascal() {
+    const std::vector<std::vector<std::int64_t>> oracle = pascal();
+    for (int n = 0; n <= kBincoeffMaxN; ++n) {
+        for (int k = 0; k <= n; ++k) {
+            const std::int64_t want = oracle[static_cast<std::size_t>(n)][static_cast<std::size_t>(k)];
+            const double got = bincoeff(n, k);
+            // Above the double envelope the return is correctly rounded, not exact,
+            // so compare against the rounded oracle rather than the integer.
+            const double want_as_double = static_cast<double>(want);
+            PANTR_CHECK_MSG(got == want_as_double,
+                            "C(" + std::to_string(n) + ", " + std::to_string(k) + ") = " +
+                                std::to_string(got) + ", oracle " + std::to_string(want));
+        }
+    }
+}
+
+void test_exact_below_the_double_envelope() {
+    const std::vector<std::vector<std::int64_t>> oracle = pascal();
+    for (int n = 0; n <= kBincoeffExactDoubleMaxN; ++n) {
+        for (int k = 0; k <= n; ++k) {
+            const std::int64_t want = oracle[static_cast<std::size_t>(n)][static_cast<std::size_t>(k)];
+            // Exact means the round trip through double loses nothing.
+            PANTR_CHECK_MSG(static_cast<std::int64_t>(bincoeff(n, k)) == want,
+                            "C(" + std::to_string(n) + ", " + std::to_string(k) + ") not exact");
+        }
+    }
+}
+
+void test_out_of_range_is_zero() {
+    PANTR_CHECK(bincoeff(5, -1) == 0.0);
+    PANTR_CHECK(bincoeff(5, 6) == 0.0);
+    PANTR_CHECK(bincoeff(0, 1) == 0.0);
+    PANTR_CHECK(bincoeff(0, 0) == 1.0);
+    // A negative upper index has no coefficients at all: every k is out of [0, n].
+    PANTR_CHECK(bincoeff(-1, 0) == 0.0);
+}
+
+void test_symmetry() {
+    for (int n = 0; n <= kBincoeffMaxN; ++n) {
+        for (int k = 0; k <= n; ++k) {
+            PANTR_CHECK_MSG(bincoeff(n, k) == bincoeff(n, n - k),
+                            "asymmetric at n = " + std::to_string(n) + ", k = " + std::to_string(k));
+        }
+    }
+}
+
+void test_row_sums_are_powers_of_two() {
+    // Exact in int64 while 2^n fits, which covers the whole envelope; and exact in
+    // double only while every summand is, so the check stops at 56 in that frame.
+    for (int n = 0; n <= kBincoeffExactDoubleMaxN; ++n) {
+        double total = 0.0;
+        for (int k = 0; k <= n; ++k) {
+            total += bincoeff(n, k);
+        }
+        PANTR_CHECK_MSG(total == static_cast<double>(std::int64_t{1} << n),
+                        "row " + std::to_string(n) + " sums to " + std::to_string(total));
+    }
+}
+
+void test_constexpr_usable() {
+    // The elevation kernel builds its coefficient table at run time, but a
+    // compile-time constant is the cheapest proof that nothing in the body escapes
+    // constant evaluation -- no allocation, no libm, no undefined shift.
+    static_assert(bincoeff(10, 5) == 252.0);
+    static_assert(bincoeff(61, 30) == 232714176627630544.0);
+}
+
+}  // namespace
+
+int main() {
+    test_against_pascal();
+    test_exact_below_the_double_envelope();
+    test_out_of_range_is_zero();
+    test_symmetry();
+    test_row_sums_are_powers_of_two();
+    test_constexpr_usable();
+    return pantr::test::summary("test_binomial");
+}

--- a/cpp/tests/test_binomial.cpp
+++ b/cpp/tests/test_binomial.cpp
@@ -11,7 +11,12 @@
 ///
 /// The oracle is itself exact over the whole envelope: the largest coefficient in
 /// range is `C(61, 30) = 232714176627630544`, well inside `int64`. So this test
-/// covers *every* `(n, k)` with `n <= 61` rather than sampling.
+/// covers *every* `(n, k)` with `n <= 61` rather than sampling, which is **1953**
+/// pairs.
+///
+/// That number is recorded here because commit `fcf2d7c`'s message says 2016, which
+/// is the sum to `n = 62` rather than to 61. A commit message is history and cannot
+/// be corrected in place, so the right figure lives where a reader will look.
 ///
 /// ## What the other checks would catch
 ///

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -1,14 +1,17 @@
 # Backend parity: what a bound may claim, and in which frame
 
-**Status:** complete for the three ports that exist. Eight rules, each with the failure that produced
-it, and three further module ports inherit them. The verdict on whether the parity harness
+**Status:** complete for the four ports that exist. Nine rules, each with the failure that produced
+it, and the remaining module ports inherit them. The verdict on whether the parity harness
 generalized is now written, from the `quad` port's tests rather than predicted before them.
 **Date:** 2026-08-20, amended the same day after a deep review closed two open proofs,
-refuted a claim and tightened a bound. Amended again 2026-08-21 by the change-of-basis
+refuted a claim and tightened a bound. Amended 2026-08-21 by the change-of-basis
 port: Rule 7 (a liveness guard belongs to the host it was measured on) and Rule 8 (a
 parity claim needs a bound that can say something), and again by that port's own deep
 review, which found Rule 8 overstating its boundary and one of its two margin figures
-invented. Both are corrected in place rather than edited away.
+invented. Both are corrected in place rather than edited away. Amended again the same day by
+the Bézier arithmetic port with Rule 9 (an oracle's accumulation width is a per-kernel fact),
+which is the first rule here that is about reproducing an oracle exactly rather than about
+bounding a difference, because that port is the first whose every kernel can be bit-exact.
 
 **Validated against:** `proto/cpp` at `765d9b9`, plus the `quad` port on `feat/cpp-quad`.
 
@@ -323,6 +326,73 @@ degree 10 and the parity tests accept it, correctly -- any backward-stable LU ha
 admitted, since that is exactly what the bound claims. What the bound must still catch is a
 *wrong* answer, and it does: a `1e-6` relative perturbation of the Gram matrix is caught by all
 five bounded builders and by the margin test.
+
+## Rule 9: an oracle's accumulation width is a per-kernel fact, not a module convention
+
+Added by the Bézier arithmetic port, which is the first module where **every** kernel can be
+bit-exact against its oracle, and therefore the first where reproducing the oracle exactly was
+the whole of the work rather than a bonus on top of a bound.
+
+`_bezier_core.py` holds seven kernels and uses **three different accumulation widths** among
+them, none of them announced:
+
+- the four de Casteljau kernels compute each step in `float64` and round once on the store,
+  because their scalars are Python floats and numba promotes a `float64` scalar against a
+  `float32` array;
+- `_evaluate_bezier_deriv_1d_core` does the opposite. It opens with `dtype = pts.dtype` and
+  allocates the `ndu` table, the `a` ping-pong and the derivative table in it, so at `float32`
+  the entire A2.3 recursion is `float32`;
+- degree elevation and the Bernstein product mix, their coefficient tables being `float64`
+  unconditionally against a destination in the control points' dtype, so each `+=` computes wide
+  and rounds narrow.
+
+**None of this is visible at `float64`, where all three coincide.** Measured on one kernel:
+accumulating narrow where the oracle accumulates wide moves 125 of 630 `float32` values.
+Widening where the oracle narrows is the same error the other way and was caught the same way,
+in `_evaluate_bezier_deriv_1d_core`, by a mutation that failed nine parity cases.
+
+So the rule is procedural rather than mathematical: **read the width off each kernel, one at a
+time, and mutation-test that the parity suite would notice if you got it wrong.** Inferring it
+from the module, or from the kernel next door, is what produces a port that is exact at
+`float64` and quietly wrong at `float32` -- which is the half of the matrix nobody reads first.
+
+### The sharper case, and why measurement rather than reading found it
+
+Within a single kernel, `_evaluate_bezier_1d_core` seeds its two branches from bases of
+different width. Above the mirror threshold it raises `u`, which is the point array's own dtype;
+below it it raises `1 - u`, which the literal `1.0` has already promoted to `float64`. Reading
+the source does not make that leap out, and the consequence is one value in 16224: at degree 17
+and `u = 0.75`, where `0.75^17 = 3^17 / 2^34` needs 27 significand bits, the wide seed survives
+and the narrow one rounds.
+
+A sweep that had used round parameters and a modest degree would have missed it entirely. What
+found it was a case list built to be adversarial about *representability* rather than about
+magnitude.
+
+### The `float32` half is far less contraction-sensitive, and that is a consequence
+
+Three kernels now measured, with `-march=native` against the same build without it:
+
+| kernel | `float64` values moved | `float32` values moved |
+|---|---|---|
+| de Casteljau (slice) | 125 / 630 | 2 / 630 |
+| reduction-operator apply | 237 / 970 | 0 / 970 |
+
+The asymmetry is the wide accumulator doing its job: a fused multiply-add changes the `double`
+intermediate, and the narrowing store to `float32` then discards most of the difference. Worth
+knowing before the ISA ladder of `design/simd.md` lands, because it says the `float64` path is
+where a contraction bound will actually be needed.
+
+### What is NOT here, and it is a real gap
+
+**No parity bound is derived for a fusing build.** Unlike the Bernstein tabulation, every kernel
+in this module contains an `a * b + c * d` site. `tests/parity/test_bezier_arithmetic.py` skips
+rather than weakens when `__fp_contract__` reports a fused multiply-add is available, and says
+so in the skip reason. That is deliberate: a bound written for a branch no host in this project
+can execute would ship untested, and Rule 7 is what licenses deferring it. **It is a
+prerequisite for the ISA ladder, not for the port**, and it should be derived at the same time
+as the ladder rather than in advance of it.
+
 
 ## The two corrections the infrastructure PR made, kept here because they generalize
 

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -361,13 +361,23 @@ from the module, or from the kernel next door, is what produces a port that is e
 Within a single kernel, `_evaluate_bezier_1d_core` seeds its two branches from bases of
 different width. Above the mirror threshold it raises `u`, which is the point array's own dtype;
 below it it raises `1 - u`, which the literal `1.0` has already promoted to `float64`. Reading
-the source does not make that leap out, and the consequence is one value in 16224: at degree 17
-and `u = 0.75`, where `0.75^17 = 3^17 / 2^34` needs 27 significand bits, the wide seed survives
-and the narrow one rounds.
+the source does not make that leap out, and the consequence is a single value in a whole-kernel
+sweep: at degree 17 and `u = 0.75`, where `0.75^17 = 3^17 / 2^34` needs 27 significand bits, the
+wide seed survives and the narrow one rounds.
 
 A sweep that had used round parameters and a modest degree would have missed it entirely. What
 found it was a case list built to be adversarial about *representability* rather than about
 magnitude.
+
+### Every figure above is reproducible, and that had to be fixed
+
+An earlier version of this rule quoted counts whose only artifact was a scratch directory. They
+were real, and three were later reproduced exactly by an independent reviewer, but a number
+nobody else can re-derive is a number nobody else can refute, which is the wrong shape for a
+design note. `scripts/measure_bezier_parity.py` now reproduces the sweep counts and the `pow`
+agreement, and prints the rebuild command for the two figures that need `-march=native`.
+`cpp/include/pantr/basis/bernstein.hpp` had been doing this correctly for its own claim all
+along, by pointing at a committed test.
 
 ### The `float32` half is far less contraction-sensitive, and that is a consequence
 

--- a/design/cross_backend_types.md
+++ b/design/cross_backend_types.md
@@ -265,13 +265,28 @@ re-elevates the result, inside a single call, so that the round-trip error can b
 against a tolerance. Two kernels, one call, so `degree_kernels()` returns a
 `DegreeKernels(elevate, reduce_apply)` and the other six accessors stay bare callables.
 
-The reason is not tidiness. `active_backend()` reads a `ContextVar`, and `use_backend` scopes a
-switch to a thread or a task, so two separate resolutions inside one call can genuinely see
-different answers. A round trip whose reduction was computed by one implementation and whose
-re-elevation by the other is not a round trip, and the error it reports is not the error of
-anything. `_reduce_along_axis` therefore **takes its kernel as an argument** rather than
-resolving one, which is what lets its two callers differ: `_degree_reduce_bezier` needs only the
-reduction and resolves once, while `_minimize_degree_bezier` resolves the pair.
+**The reason first given for this was wrong, and the correction changes the rule.** The note
+said that `active_backend()` reads a `ContextVar` scoped by `use_backend` to a thread or a task,
+so two resolutions inside one call could see different answers. That inverts the mechanism. A
+`ContextVar` gives each thread its own context and an `asyncio.Task` runs in a **copy** taken at
+creation, so a sibling's `set` can never be observed by another's reads: the property cited as
+the danger is exactly what makes the failure impossible. Measured, 2026-08-21: a sibling thread
+inside `use_backend(CPP)` was observed 0 times in 2000 reads, a sibling task 0 in 2000, and there
+is no `await` or `yield` between the two resolutions to open a same-context path.
+
+So **the rule is not about preventing a divergence.** What resolving once at a Layer 2 entry
+point actually buys is that the backend becomes a property of the call rather than of each
+lookup, that the dependency is stated in a signature instead of read from ambient state, and
+that a kernel invoked in a loop is not re-resolved per iteration -- `Bezier.compose` performs 277
+resolutions in a single call on a 3D map, each a `ContextVar.get()` in front of a kernel measured
+in microseconds.
+
+Stated that way the mechanism generalises and the record does not: `_reduce_along_axis`
+**takes its kernel as an argument** rather than resolving one, which works at any call depth and
+would reach `compose` too, while a record only groups two lookups that happen to be adjacent. So
+read `DegreeKernels` as the convenient shape for two kernels always fetched together, not as the
+thing that enforces anything. Whether the catalogue rule should be restated around entry-point
+resolution rather than around records is an open question this note does not settle.
 
 **The mirroring rule needed a judgement this time, and it went the same way.** Bézier's public
 surface is mixed: `evaluate` and `evaluate_derivatives` take `out`, while `split`, `restrict`,
@@ -290,10 +305,21 @@ fix the oracle's shape before it can mirror it.**
 
 ### A third thing the rules still do not cover
 
-`Bezier.multiply` reaches `_bernstein_product_coefficients_nd`, a pure-numpy helper with no
-kernel and no catalogue entry, while the scalar 1D product kernel it resembles is reached only
-from `compose`. Nothing in the catalogue rules says whether a numpy helper that duplicates a
+`Bezier.multiply` reaches `_bernstein_product_coefficients` for a 1D Bézier and
+`_bernstein_product_coefficients_nd` above that -- both pure-numpy helpers with no kernel and no
+catalogue entry -- while the scalar 1D product kernel they resemble is reached only from
+`compose`. Nothing in the catalogue rules says whether a numpy helper that duplicates a
 dispatched kernel's mathematics should itself be dispatched, be routed through the kernel, or be
-left alone. It is left alone here, deliberately and without an argument that it is right. The
-concrete cost is already visible: a parity test aimed at `multiply` exercises none of the ported
-code, which is how it was noticed.
+left alone.
+
+It is left alone, and unlike an earlier draft of this section that is now an argued position
+rather than an admission of arbitrariness. Routing `multiply` through the kernel would be a
+numerics change, not a refactor: the two 1D implementations differ by about 2 eps because the
+numpy one builds its binomials in the control-point dtype and multiplies by a precomputed
+reciprocal where the kernel builds them in float64 and divides; their domains differ, the numpy
+path staying exact at `p + q = 80` where the kernel is outside its int64 binomial envelope; and
+the helper has a cross-package consumer in `pantr.bspline`. The genuinely open question is the
+other one: of the two 1D products, the dispatched kernel is the less general.
+
+The concrete cost of leaving the rule unstated is already visible: a parity test aimed at
+`multiply` exercised none of the ported code, and only a mutation showed it.

--- a/design/cross_backend_types.md
+++ b/design/cross_backend_types.md
@@ -251,3 +251,49 @@ in float32 differs by exactly one unit of roundoff, because it resolves through
 therefore cannot be bit-identical, and `tests/parity/test_change_basis.py` claims a bound there
 instead of bitwise agreement -- the node gap times `n`, since a Bernstein derivative is bounded
 by the degree.
+
+## What the fourth port added: the record rule finally fired
+
+`pantr.bezier`'s arithmetic is the first module in the tree where the record half of the
+catalogue rule is **used** rather than merely satisfied. Until now every consumer needed exactly
+one kernel per call, so the rule's two branches had one example each and one of them
+(`pantr.basis`) predates the rule. This is the first case decided by the rule rather than
+described by it.
+
+**The consumer is `_minimize_degree_bezier`.** Its greedy search reduces a degree by one and then
+re-elevates the result, inside a single call, so that the round-trip error can be compared
+against a tolerance. Two kernels, one call, so `degree_kernels()` returns a
+`DegreeKernels(elevate, reduce_apply)` and the other six accessors stay bare callables.
+
+The reason is not tidiness. `active_backend()` reads a `ContextVar`, and `use_backend` scopes a
+switch to a thread or a task, so two separate resolutions inside one call can genuinely see
+different answers. A round trip whose reduction was computed by one implementation and whose
+re-elevation by the other is not a round trip, and the error it reports is not the error of
+anything. `_reduce_along_axis` therefore **takes its kernel as an argument** rather than
+resolving one, which is what lets its two callers differ: `_degree_reduce_bezier` needs only the
+reduction and resolves once, while `_minimize_degree_bezier` resolves the pair.
+
+**The mirroring rule needed a judgement this time, and it went the same way.** Bézier's public
+surface is mixed: `evaluate` and `evaluate_derivatives` take `out`, while `split`, `restrict`,
+`elevate_degree` and the rest return new `Bezier` objects. That is not `pantr.quad`'s case, where
+no public function takes a buffer, and the mixture could have been read either way. It goes to
+`pantr.basis`'s convention -- every kernel fills a caller-supplied buffer -- because the methods
+that return an object still hand Layer 2 an array to fill before wrapping it, so a returning
+kernel would introduce exactly the copy the rule exists to prevent.
+
+Two of the seven kernels had to be **changed** to satisfy that: `_degree_elevate_bezier_1d_core`
+and `_scalar_bernstein_product_1d_core` allocated their result with `np.zeros` and returned it.
+Both output shapes are computable by the caller without running the kernel, so the shape
+computation moved to Layer 2 in its own commit, ahead of any C++. Worth stating as a general
+expectation: **the mirroring rule is a constraint on the Python side too, and a port may have to
+fix the oracle's shape before it can mirror it.**
+
+### A third thing the rules still do not cover
+
+`Bezier.multiply` reaches `_bernstein_product_coefficients_nd`, a pure-numpy helper with no
+kernel and no catalogue entry, while the scalar 1D product kernel it resembles is reached only
+from `compose`. Nothing in the catalogue rules says whether a numpy helper that duplicates a
+dispatched kernel's mathematics should itself be dispatched, be routed through the kernel, or be
+left alone. It is left alone here, deliberately and without an argument that it is right. The
+concrete cost is already visible: a parity test aimed at `multiply` exercises none of the ported
+code, which is how it was noticed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,6 +45,19 @@ user-facing, and the ports change what it affects.
   `compute_lagrange_to_bernstein_1d` with `CHEBYSHEV_2ND` nodes in float32 is the one place
   where the two backends start from *different nodes*, by one unit of roundoff, because that
   node family resolves through a quadrature rule that itself dispatches.
+- A C++ implementation of `pantr.bezier`'s arithmetic: evaluation and its derivatives, degree
+  elevation and reduction, slice, split, restrict, and the Bernstein product. `PANTR_BACKEND=cpp`
+  now reaches `Bezier.evaluate`, `evaluate_derivatives`, `elevate_degree`, `reduce_degree`,
+  `minimize_degree`, `slice`, `split`, `restrict` and `compose`.
+  **Every one of these is bit-for-bit identical between the two backends**, which none of the
+  earlier ports could claim: `quad` runs a different algorithm on each side and `change_basis`
+  puts a dense solve in the middle, while here both sides evaluate the same expressions in the
+  same order. Two things qualify that. It is a property of the **build** rather than of the code,
+  because these kernels contain fused-multiply-add sites and the shipped build targets a baseline
+  ISA that has no such instruction; and the evaluation kernel's seed is a `pow`, which no standard
+  requires to be correctly rounded, so its exactness is measured rather than derived.
+  `Bezier.multiply` is deliberately **not** part of this: it goes through a numpy helper that no
+  kernel backs, and is unaffected by `PANTR_BACKEND`.
 - **Eigen is now a build dependency of the wheel**, where before it was fetched only for the C++
   tests. `pantr.change_basis` needs a dense solve and `pantr.bezier` will need a truncated SVD,
   and neither is a thing to hand-roll. A cold `pip install -e .` goes from 7.56 s to 12.19 s on

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-The dual-backend prototype on the `proto/cpp` branch. Three module pull requests so far: the
-infrastructure, the `quad` port and the `change_basis` port. The infrastructure landed without a
-changelog entry, so this section covers all of them -- the environment variable it introduced is
+The dual-backend prototype on the `proto/cpp` branch. Four module pull requests so far: the
+infrastructure, the `quad` port, the `change_basis` port and the `bezier` arithmetic port. The
+infrastructure landed without a changelog entry, so this section covers all of them -- the environment variable it introduced is
 user-facing, and the ports change what it affects.
 
 ### Added

--- a/reviews/348-2026-08-21.md
+++ b/reviews/348-2026-08-21.md
@@ -1,0 +1,313 @@
+# Deep review: PR #348, the Bézier arithmetic port
+
+**Target:** `feat/cpp-bezier-arithmetic` at `602dd5f` against `proto/cpp`, repository FELIGN/pantr.
+**Date:** 2026-08-21. **CI:** green (GCC 14, parity). **Local:** `scripts/ci_local.sh` 37/37, 7087
+tests under each backend, docs with `-W`.
+
+## The shape of the result
+
+Nineteen confirmed findings. **The kernels are right**: every one of the eight is bit-for-bit
+identical to its oracle, the accumulation widths were reproduced correctly, and the mutation
+testing discriminates. Three lenses spot-checked the arithmetic independently and none refuted
+it.
+
+What failed is the same thing that failed in the three previous cycles: **the prose about the
+kernels, and the boundary around them.** Three of the four numbered justifications this port
+wrote for its own decisions are refuted. Two of them are refuted by evidence already in this
+repository.
+
+Every finding below was reproduced by the coordinator before being recorded. Figures quoted
+from an agent without independent reproduction are marked so.
+
+---
+
+## Critical
+
+### C1-1 · Five bindings segfault the interpreter on a zero-row `ctrl`
+
+`cpp/bindings/bezier.cpp` — `bind_evaluate`, `bind_evaluate_deriv`, `bind_slice`, `bind_split`,
+`bind_restrict`.
+
+They derive the degree as `ctrl.extent(0) - 1` in `std::size_t`, so zero rows underflow to
+`SIZE_MAX` and the kernel walks off the allocation. Reproduced: `rc = -11` on all five.
+
+**Not pre-existing.** The merged bindings take `degree` as an explicit `unsigned` and return
+normally on an empty input; this PR introduced the hole by binding kernels that infer the degree
+from a shape. `scalar_bernstein_product_1d` in the same file guards the identical hazard class
+(`a.size() == 0 || b.size() == 0`), so the discipline was applied inconsistently within one file
+rather than missed.
+
+Not reachable through `Bezier`, which refuses a zero-length axis at Layer 1. Reachable by
+importing `pantr._pantr_cpp`, which this file's own header comment names as the reason its checks
+exist.
+
+**Failure scenario:** `_pantr_cpp.slice_bezier_1d(np.empty((0, 2)), 0.5, out=np.empty(2))` kills
+the process with no exception.
+
+### C1-2 · `split_bezier_1d` accepts aliased outputs and silently returns one half twice
+
+Passing the same array as `out_left` and `out_right` returns the **right** half under both names,
+no exception. Reproduced.
+
+`cpp/bindings/quad.cpp:58` already has `refuse_overlapping_outputs`, applied at three sites, written
+for exactly this shape — two same-dtype, same-shape output buffers. It was not carried over.
+`test_the_split_binding_refuses_its_outputs_positionally` covers only transposition.
+
+### C1-3 · Documented parameter domains are never enforced
+
+`slice_bezier_1d(ctrl, 2.5, …)` extrapolates silently; `restrict_bezier_1d(ctrl, 0.8, 0.2, …)`
+with the bounds transposed returns a different, plausible restriction; `split_bezier_1d(ctrl, 5.0,
+…)` succeeds. All reproduced. The `.pyi` states each domain and lists no `ValueError`, so a reader
+cannot tell the domains are decorative. `lambert_w_principal` in the same stub does enforce and
+document its domain, and `bernstein_to_lagrange_1d` explicitly discloses that it does not — this
+surface does neither.
+
+`lower`/`upper` are adjacent same-typed positional parameters, so a `lower < upper` check would
+also close a transposition trap.
+
+---
+
+## Important
+
+### I1-1 · The derivative test's tolerance is vacuous on its data and false off it
+
+`cpp/tests/test_bezier.cpp:302`, `p * eps * |want|`.
+
+Three separate defects, all reproduced:
+
+- **The stated mechanism does not exist.** The comment justifies the bound by Sterbenz exactness
+  of `c_1 - c_0`. `evaluate_bezier_deriv_1d` never subtracts two control points; `ctrl` appears
+  only at `bezier.hpp:239` and `:306`, both as `+= weight * ctrl`.
+- **On its own data the assertion is an equality.** Error is exactly `0.0` for every swept degree,
+  so no slack has ever been consumed.
+- **Off its data the bound is false by five orders of magnitude.** With `c = 1e6 + i/3` at unit
+  scale: `p = 5` gives `err/slack = 1.7e5`, `p = 25` gives `5.4e4`.
+
+The scaling is the wrong quantity: A2.3's roundings act on contraction terms of size
+`Σ_j |B'_{j,p}| · max|c| ≤ 2p · max|c|`, not on `|want| = p · |Δc|`.
+
+**Direction.** At `s ∈ {0, 1}` every `ndu` entry is exactly 0 or 1 and the falling factorial is
+exact integer arithmetic, so the result is a sum of exactly representable integers while
+`2^{n_deriv} · p · (p+1) · max|c| < 2^53`. Assert an **equality**, which is what the rest of the
+file does and says it prefers. If a tolerance is wanted for wider data, the derived one is
+`2 · p² · eps · max|c|`.
+
+### I1-2 · `PANTR_BACKEND` changes what the library *accepts*
+
+`_scalar_bernstein_product_1d_core(a_f32, b_f32, out_f64)`: Numba accepts it and accumulates
+wide (1 of 5 coefficients moves with the data tried); the C++ binding refuses with `TypeError`.
+Reproduced.
+
+That is precisely what `_fill`'s own docstring says must not happen, in the other direction.
+**Introduced by this PR's first commit**: before it, the kernels allocated with `dtype=a.dtype`,
+so the mismatch was unrepresentable. The refactor traded a structurally enforced accumulation
+width for an unenforced one — in the same PR that added Rule 9 saying the accumulation width is a
+contract.
+
+**Direction.** Assert `out.dtype == ctrl.dtype` at the three Layer 2 allocation sites and state
+it in the kernel contract.
+
+### I1-3 · The justification for the record-shaped catalogue entry is refuted
+
+`design/cross_backend_types.md` and `_bezier_backend.py`'s module docstring both say two
+resolutions inside one call can see different backends because `active_backend()` reads a
+`ContextVar` that `use_backend` scopes to a thread or task.
+
+That inverts the mechanism. A `ContextVar` gives each thread its own context and an
+`asyncio.Task` runs in a **copy**, so a sibling's `set` can never be observed. Reproduced: a
+sibling thread inside `use_backend(CPP)` was seen 0 times in 2000 reads; a sibling task, 0 in
+2000. There is no `await` or `yield` between the two resolutions.
+
+**This matters more than the code does.** The code is harmless. The sentence is in the design note
+that governs the next ports, and it will be copied.
+
+### I1-4 · The reason given for having no bound on a fusing build is refuted by this directory
+
+`tests/parity/test_bezier_arithmetic.py` skips all 519 assertions when `contraction_may_fuse()`,
+on the stated grounds that "a bound written for a branch no host in this project can execute would
+ship untested".
+
+`tests/parity/test_quad_gauss_legendre.py` solves exactly that, on this same non-fusing host: it
+builds the fused claim unconditionally, asserts the derived tolerance is positive and exceeds one
+ulp of the data, and uses `pytest.raises` to confirm a 1.5× perturbation is caught. Verified at
+lines 475, 509 and 574.
+
+The cost is asymmetric with the siblings': on the first `-march=x86-64-v3` build this module loses
+519 of 519 assertions and the suite stays green, while the siblings degrade to a weaker live claim.
+
+**Direction.** Derive the bound. Every fusable site is `acc += w * x`, which removes exactly one
+rounding of a quantity bounded by the term's magnitude, and maps onto the existing `Roundings`
+record with no new machinery. Then probe it as `test_quad_gauss_legendre.py` does.
+
+### I1-5 · Signed-integer overflow (undefined behaviour) in the falling factorial
+
+`cpp/include/pantr/bezier/bezier.hpp`, `evaluate_bezier_deriv_1d`'s `std::int64_t fac`.
+
+The falling factorial overflows `int64` at `n_deriv = 14` for degree 30, `11` for degree 61.
+Numba wraps; C++ signed overflow is **undefined**. Confirmed under `-fsanitize=undefined`:
+`runtime error: signed integer overflow: 17 * 745747076954880000`.
+
+Reachable from the public API: `Bezier(degree 30).evaluate_derivatives(pts, orders=25)` is
+accepted. The two backends **agree today** — GCC happens to wrap as numba does — so this is not a
+parity failure, but the agreement is not guaranteed, and the repository ships a `gcc-debug` preset
+with `-fsanitize=undefined,address` under which it aborts.
+
+No test reaches it: the parity suite caps `n_deriv` at 4 and degree at 17.
+
+### I1-6 · "Exact only when the binomial is a power of two" is false
+
+`cpp/tests/test_bezier.cpp:275`. Exactness holds whenever `a_k · C(p,k)` is representable, which
+for the test's integers in `[-9, 9]` is every `p ≤ 53`. All five swept degrees give error exactly
+zero at binomials 3, 45, 252 and 184756, none a power of two. The assertion is vacuous.
+
+### I1-7 · The mirror threshold's stated guarantee is false at both widths
+
+`bezier.hpp:67` and `_bezier_core.py:21`: "bounds the recurrence seed below by `0.5^p`, so it
+never underflows regardless of degree." `0.5^p` itself underflows at `p ≥ 1075` (float64) and
+`p ≥ 150` (float32).
+
+The interesting half is specific to this kernel: the mirrored branch raises `u` at storage width
+(the asymmetry this port discovered and reproduced deliberately), so **the branch that exists to
+prevent underflow is the one that underflows first** at float32, near `p ≈ 127` against `p ≈ 1075`.
+The port is faithful and parity holds; the sentence is wrong. `_basis_core.py` derives exactly this
+kind of bound crisply for its own constant and is the model.
+
+### I1-8 · Wrong function named for `Bezier.multiply`, in two places
+
+`design/cross_backend_types.md` and `tests/parity/test_bezier_arithmetic.py` both say `multiply`
+reaches `_bernstein_product_coefficients_nd`. For a 1D Bézier it reaches
+`_bernstein_product_coefficients`, the 1D helper (`_bezier_product.py:204`).
+
+The conclusion survives — undispatched either way — but the error hides that the exclusion is
+better justified than the note admits. Per the architect, unverified by the coordinator: the two
+1D implementations differ by ~2 eps, the numpy path is exact at `p+q = 80` where the kernel is
+off by 1e7 relative (the binomial envelope), and the helper has a cross-package consumer at
+`bspline/_bspline_product.py:661`. So routing `multiply` through the kernel is a numerics change,
+not a refactor, and the note should carry that argument instead of calling the exclusion
+arbitrary.
+
+### I1-9 · `test_minimize_degree_is_bitwise` claims to prove path equality and tests one branch
+
+Its docstring says bit-exact control points "prove the two backends took the same path". The file
+contains zero rational cases, and the rational branch is where two further backend-dependent
+decisions live — `_tensor_gauss_weights` and `_bernstein_collocation_1d`, the latter combining
+dispatched Gauss-Legendre nodes with a Bernstein tabulation imported directly from
+`basis._basis_core`, bypassing that package's catalogue.
+
+**The bypass is pre-existing** (present on `proto/cpp`, commit `b5c562b`) and is not charged to
+this PR. The overstated claim is.
+
+### I1-10 · The headline measurements have no reproducible artifact in the repository
+
+"1280384 pairs", "16224 values", "125 of 630", "237 of 970" and the seven mutation counts appear
+in the design note, the C++ header and the test module docstring. None is reproducible from the
+tree: the probe scripts live in a session-scoped temporary directory. `bernstein.hpp`'s analogous
+`pow` claim points at a committed test, which is the convention.
+
+A reviewer independently reproduced three mutation counts exactly (15, 24, 31) and got 11-12
+where the commit says 9 — the difference being the mutation's scope, which is also unrecorded.
+
+### I1-11 · Catalogue accessors use the superseded naming convention
+
+`evaluate_core`, `slice_core`, … follow `basis/_basis_backend.py`, the oldest of the four
+catalogues. `quad/_quad_backend.py` and `change_basis/_change_basis_backend.py` both use
+`_kernel`, and the latter landed the same day. Verified by reading all four.
+
+---
+
+## Recommended
+
+- **R1-1** `checked_bincoeff` (`core/binomial.hpp:93`) is dead: unused anywhere, and
+  `cpp/bindings/bezier.cpp:82` reimplements the same envelope check with a different message.
+  Verified. That is the drift `binomial.hpp`'s own file comment warns about, one layer up.
+- **R1-2** Every `\note` in `bezier.hpp` and `reduction_operator.hpp` says only "no input
+  validation is performed", where `bernstein.hpp` names which preconditions are load-bearing for
+  *memory safety*. `ctrl.extent(0) >= 1` and `n_deriv >= 0` are exactly such preconditions, and
+  their absence from the notes is why C1-1 was invisible.
+- **R1-3** Five comparisons bypass `value_of`, against discipline 1 of `core/scalar.hpp`:
+  `bezier.hpp:101`, `:110`, `:401`, `:407`, `:494`. Latent — no `Dual` instantiation exists — and
+  `bernstein.hpp:134` already does it, so this is not invented here.
+- **R1-4** `bezier.hpp` holds three distinct mathematical stories (the de Casteljau family, A2.3,
+  the binomial-scaled pair) where `quad/` and `basis/` keep one per header. The argument is
+  invariant locality: a header whose comment must say "six do X and the seventh does Y" is one
+  careless edit from normalising the exception away.
+- **R1-5** "125 of 630" appears for two different perturbations. Both are true — narrow
+  accumulation at **float32**, `-march=native` at **float64** — but `bezier.hpp:12` omits the
+  dtype, so they read as one measurement.
+- **R1-6** Commit `fcf2d7c` says `test_against_pascal` covers "all 2016 pairs". The loop covers
+  **1953** (`Σ(n+1)`, `n = 0..61`); 2016 is the sum to `n = 62`. Verified by arithmetic.
+- **R1-7** `docs/changelog.md:5` still says "Three module pull requests so far" with this PR's
+  fourth bullet directly below it.
+- **R1-8** `8p` / `16p` in `test_bezier.cpp` are computed in `eps` while the derivation is written
+  in `u`, an unacknowledged factor of 2. `test_cardinal_bspline.cpp:9` states the substitution
+  explicitly; this file does not, and `tests/_parity_harness.py` defines `unit_roundoff()` as
+  `eps/2`. The bounds themselves are sound: measured margin 31-45× to degree 55 across 600 decades.
+- **R1-9** `restrict`'s branch comment says the ordering avoids dividing by a small number.
+  Measured, the chosen ordering is between 0.14× and 7× the other's error, so there is no stability
+  story. What the branch actually buys is `max(upper, 1-lower) >= 1/2`, keeping `tau2` in `[0,1]`,
+  and avoiding `0/0` at the degenerate corners.
+- **R1-10** No parity test exercises a non-contiguous **input**, though every adapter absorbs one
+  through `np.ascontiguousarray`.
+
+## Nitpick
+
+- **N1-1** `_bezier_backend.py:25` says "The other five call sites"; there are six. Verified.
+- **N1-2** `test_evaluate_derivatives_is_bitwise` fixes `rank = 2` where its sibling parametrizes it.
+
+## Unconfirmed — worth a look
+
+- **U1-1** The "1253 tests pass under each" figure in `fe2949c` could not be reproduced by the
+  reviewer under any filter it tried. (It came from `pytest -k "bezier or root_finding or compose
+  or degree"`, which the message does not state — so the figure is right and unreproducible from
+  the artifact, which is the same defect as I1-10.)
+- **U1-2** The `ndu`-widening mutation count: 9 (recorded) against 11-12 (reproduced), with the
+  mutation's scope unrecorded either way.
+- **U1-3** The mirror branch makes `evaluate` discontinuous at `u = 0.5`, measured up to 13 ulps at
+  degree 25 against an exact rational reference. Inert today — root finding uses de Casteljau, not
+  `evaluate` — and becomes live the moment a consumer brackets a sign change with it.
+- **U1-4** Whether an SVML substitution for `llvm.pow` would break the `pow` agreement.
+  `USING_SVML` is False here and the seed's loop should not vectorize.
+
+## Recorded, not charged to this PR
+
+Found during the review, pre-existing on `proto/cpp`:
+
+- `_bezier_degree.py:35` imports `_tabulate_Bernstein_basis_1D_serial_core` directly from
+  `basis._basis_core`, bypassing that catalogue, so under `PANTR_BACKEND=cpp` the collocation
+  matrix mixes C++ nodes with a Numba tabulation.
+- `_AUTO_REDUCTION_TOL_FACTOR` is dilation-invariant but not translation-invariant: measured, the
+  same curve reduces to degree 3 at the origin and degree 2 at offset 1e2.
+- `_bezier_degree.py:478` uses `abs(cᵀGc)` where `max(0.0, ·)` is meant; `abs` turns a large
+  negative into a large positive.
+- `scalar_bernstein_product_1d` overflows to `inf` for `|a| · C(p,k) > 1.8e308`.
+
+## One claim was strengthened rather than refuted
+
+The `pow` agreement is recorded as "observed rather than derived" over 1280384 pairs. It is
+better: numba lowers `np.power` to `llvm.pow.f64`/`llvm.pow.f32`, and the extension imports
+`pow@GLIBC_2.29` and `powf@GLIBC_2.27`, so both sides enter the same symbol in the same process.
+Structural, with a narrow residual (a vectorised libm substitution).
+
+## Lenses run, and the ground left unreviewed
+
+**Ran and reported:** `api-auditor`; `architect` (adversarial); `tolerance-hunter`; three
+`reviewer`s over the C++ headers, the binding layer, and the tests and prose.
+
+**Died on a session limit, and their ground is NOT covered:**
+
+- **`mathematician` (attack on the four bitwise-claim strings).** Its last message says a verifier
+  had confirmed a refutation and corrected its proposed replacement, but no report survives. **The
+  four `_WHY` strings in `tests/parity/test_bezier_arithmetic.py` have not been adversarially
+  audited.** That is the argument the entire PR rests on.
+- **`investigator` (accumulation widths against numba's typed IR).** Partially covered by accident:
+  the C++ header reviewer spot-verified the `b_curr` seed's width via an SSA dump and the float32
+  promotion rules, and found them accurate. Not covered: a systematic per-kernel IR verification,
+  and an adversarial hunt for an input where a width difference would show that the current 519
+  cases do not reach. The `fac` overflow question this lens was asked was answered by the
+  coordinator instead, and became I1-5.
+- A `verifier` dispatched by the mathematician.
+
+**Not run, deliberately:** `optimizer` (performance is deferred by an explicit prior decision),
+`surveyor` (no new dependency), `razor` and `stylist` (linters clean; the architect covered
+over-complexity), `doc-writer` (docs build green), `numerics-shakedown` (held back for
+concurrency, then blocked by the session limit) and `test-writer` (same).

--- a/scripts/measure_bezier_parity.py
+++ b/scripts/measure_bezier_parity.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+"""Reproduce the parity figures the Bézier port's prose quotes.
+
+A deep review found that the headline measurements in
+``design/backend_parity.md`` Rule 9, ``cpp/include/pantr/bezier/bezier.hpp`` and
+``tests/parity/test_bezier_arithmetic.py`` had no reproducible artifact anywhere in
+the tree: the scripts that produced them lived in a scratch directory and are gone.
+``cpp/include/pantr/basis/bernstein.hpp`` does the opposite for its own ``pow``
+claim, pointing at a committed test, and that is the convention. This script is the
+missing half.
+
+It is **not** a test. The parity suite asserts; this reports, because the numbers in
+the prose are counts over specific grids and a reader deciding whether to believe
+them wants the grid, not a green tick.
+
+Run it as::
+
+    PYTHONPATH="$(pwd)/src" .venv/bin/python scripts/measure_bezier_parity.py
+
+Two figures it cannot reproduce, and says so rather than omitting them: the
+``-march=native`` movement counts need a second build of the extension with that
+flag, which is a rebuild rather than a run. The command is printed at the end.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from functools import partial
+from typing import Any, Final
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._backend import Backend, available_backends, use_backend
+from pantr.bezier import Bezier
+
+DEGREES: Final = (0, 1, 2, 3, 4, 7, 11, 17, 25)
+"""The degree sweep the whole-kernel figure is taken over."""
+
+SLICE_DEGREES: Final = (0, 1, 2, 3, 5, 8, 13, 21, 34)
+"""The degree sweep the de Casteljau figure is taken over."""
+
+PARAMS: Final = (
+    0.0,
+    1e-300,
+    1e-20,
+    1e-8,
+    0.25,
+    0.5,
+    0.5 + 2**-52,
+    0.75,
+    1.0 - 1e-8,
+    float(np.nextafter(1.0, 0.0)),
+    1.0,
+)
+"""Adversarial parameters: both endpoints, either side of the mirror threshold, and
+values chosen so that ``1 - (1 - u)`` loses them."""
+
+
+def _mixed(
+    rng: np.random.Generator, shape: tuple[int, ...], dtype: npt.DTypeLike
+) -> npt.NDArray[np.floating[Any]]:
+    """Random control points spanning twelve decades, so cancellation has work to do.
+
+    Args:
+        rng (np.random.Generator): Source of randomness.
+        shape (tuple[int, ...]): Shape of the net.
+        dtype (npt.DTypeLike): Storage format.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The control points, C-contiguous.
+    """
+    values = rng.standard_normal(shape) * 10.0 ** rng.integers(-6, 7, shape)
+    return np.ascontiguousarray(values, dtype=dtype)
+
+
+def _bit_differences(
+    actual: npt.NDArray[np.floating[Any]], reference: npt.NDArray[np.floating[Any]]
+) -> int:
+    """Count elements whose bit patterns differ, NaN pairs excluded.
+
+    Args:
+        actual (npt.NDArray[np.floating[Any]]): The C++ backend's result.
+        reference (npt.NDArray[np.floating[Any]]): The Numba oracle's result.
+
+    Returns:
+        int: How many elements differ.
+    """
+    unsigned = np.uint64 if actual.dtype == np.float64 else np.uint32
+    differ = actual.view(unsigned) != reference.view(unsigned)
+    both_nan = np.isnan(actual) & np.isnan(reference)
+    return int((differ & ~both_nan).sum())
+
+
+def _as_array(result: object) -> npt.NDArray[np.floating[Any]]:
+    """Coerce a public-API return to the array to compare.
+
+    :meth:`~pantr.bezier.Bezier.slice` returns a bare array when the Bézier is
+    univariate and a :class:`~pantr.bezier.Bezier` otherwise, so the caller cannot
+    know which without branching.
+
+    Args:
+        result (object): Whatever the method returned.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The values, as an array.
+    """
+    control_points = getattr(result, "control_points", result)
+    return np.asarray(control_points)
+
+
+def _sliced(ctrl: npt.NDArray[np.floating[Any]], value: float) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate a univariate Bézier at one parameter.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+        value (float): Parameter in ``[0, 1]``.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The point, one entry per column.
+    """
+    return _as_array(Bezier(ctrl).slice(0, value))
+
+
+def _evaluated(
+    ctrl: npt.NDArray[np.floating[Any]], points: npt.NDArray[np.floating[Any]]
+) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate a Bézier at every point.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+        points (npt.NDArray[np.floating[Any]]): Evaluation points.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The values.
+    """
+    return _as_array(Bezier(ctrl).evaluate(points))
+
+
+def _differentiated(
+    ctrl: npt.NDArray[np.floating[Any]], points: npt.NDArray[np.floating[Any]]
+) -> npt.NDArray[np.floating[Any]]:
+    """Evaluate a Bézier's derivatives up to order two.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+        points (npt.NDArray[np.floating[Any]]): Evaluation points.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The derivative values.
+    """
+    return _as_array(Bezier(ctrl).evaluate_derivatives(points, 2))
+
+
+def _elevated(ctrl: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+    """Raise a Bézier's degree by two.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The elevated control points.
+    """
+    return _as_array(Bezier(ctrl).elevate_degree(2))
+
+
+def _restricted(ctrl: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+    """Restrict a Bézier to a sub-interval.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The restricted control points.
+    """
+    return _as_array(Bezier(ctrl).restrict((0.1, 0.9)))
+
+
+def _left_half(ctrl: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+    """Split a Bézier and return the left half's control points.
+
+    Args:
+        ctrl (npt.NDArray[np.floating[Any]]): Control points.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The left half.
+    """
+    return _as_array(Bezier(ctrl).split(0, 0.25)[0])
+
+
+def _both(
+    build: Callable[[], npt.NDArray[np.floating[Any]]],
+) -> tuple[npt.NDArray[np.floating[Any]], npt.NDArray[np.floating[Any]]]:
+    """Run ``build`` under each backend and return the two results.
+
+    Args:
+        build (Callable[[], npt.NDArray[np.floating[Any]]]): Produces the array to
+            compare, using whichever backend is in effect.
+
+    Returns:
+        tuple: The Numba result and the C++ result, in that order.
+    """
+    with use_backend(Backend.PYTHON):
+        reference = build()
+    with use_backend(Backend.CPP):
+        actual = build()
+    return reference, actual
+
+
+def measure_de_casteljau() -> tuple[int, int]:
+    """Count values and bit differences on the de Casteljau grid.
+
+    The grid that produces the "630 values" figure: nine degrees, ten parameters,
+    seven columns. The endpoints are excluded because ``slice`` short-circuits them,
+    which is what makes the count 630 rather than 693.
+
+    Returns:
+        tuple[int, int]: Values compared, and bit differences, summed over dtypes.
+    """
+    total = 0
+    bad = 0
+    for dtype in (np.float64, np.float32):
+        rng = np.random.default_rng(20260821)
+        for degree in SLICE_DEGREES:
+            ctrl = _mixed(rng, (degree + 1, 7), dtype)
+            for value in PARAMS[:-1]:
+                reference, actual = _both(partial(_sliced, ctrl, value))
+                total += reference.size
+                bad += _bit_differences(actual, reference)
+    return total, bad
+
+
+def measure_every_kernel() -> tuple[int, int]:
+    """Count values and bit differences across all seven arithmetic kernels.
+
+    The sweep behind the "16224 values" figure. Each kernel is driven through the
+    public :class:`~pantr.bezier.Bezier` surface, so what is compared is what a
+    caller gets rather than what a binding returns.
+
+    Returns:
+        tuple[int, int]: Values compared, and bit differences, summed over dtypes.
+    """
+    total = 0
+    bad = 0
+    for dtype in (np.float64, np.float32):
+        rng = np.random.default_rng(20260821)
+        for degree in DEGREES:
+            for rank in (1, 3):
+                ctrl = _mixed(rng, (degree + 1, rank), dtype)
+                points: npt.NDArray[np.floating[Any]] = np.ascontiguousarray(PARAMS, dtype=dtype)
+                cases: list[Callable[[], npt.NDArray[np.floating[Any]]]] = [
+                    partial(_evaluated, ctrl, points),
+                    partial(_differentiated, ctrl, points),
+                    partial(_elevated, ctrl),
+                    partial(_restricted, ctrl),
+                ]
+                if degree >= 1:
+                    cases.append(partial(_left_half, ctrl))
+                for build in cases:
+                    reference, actual = _both(build)
+                    total += reference.size
+                    bad += _bit_differences(actual, reference)
+    return total, bad
+
+
+def measure_pow_agreement() -> tuple[int, int]:
+    """Count agreements between numba's ``np.power`` and the platform ``powf``.
+
+    The evaluation kernel's mirrored branch seeds its recurrence with ``u`` raised
+    at **storage width**, so at ``float32`` the C++ calls ``powf``. The comparison
+    has to call the same symbol, which is what the ``ctypes`` handle below does; an
+    earlier draft of this script computed in ``double`` and narrowed instead, and
+    reported 1305 differences out of 1280256. That number is not a refutation of the
+    parity claim, it is a measurement of the mistake this port made once and fixed:
+    computing the mirrored seed at the wrong width.
+
+    Returns:
+        tuple[int, int]: Pairs compared, and pairs differing.
+    """
+    import ctypes  # noqa: PLC0415
+
+    from numba import njit  # noqa: PLC0415
+
+    libm = ctypes.CDLL("libm.so.6")
+    libm.powf.argtypes = [ctypes.c_float, ctypes.c_float]
+    libm.powf.restype = ctypes.c_float
+
+    @njit(cache=False)  # type: ignore[untyped-decorator]  # numba's is untyped
+    def seeds(bases: npt.NDArray[np.float32], power: int, out: npt.NDArray[np.float32]) -> None:
+        for i in range(bases.size):
+            out[i] = np.power(bases[i], power)
+
+    rng = np.random.default_rng(7)
+    # The mirrored branch only ever raises a base in (0.5, 1], plus the exact
+    # endpoints, so that is the whole domain this claim has to cover.
+    bases: npt.NDArray[np.float32] = np.concatenate(
+        [rng.uniform(0.5, 1.0, 20000), np.array([0.5, 0.75, 1.0, 0.9999999])]
+    ).astype(np.float32)
+    total = 0
+    bad = 0
+    reference = np.empty(bases.size, dtype=np.float32)
+    for power in range(1, 65):
+        seeds(bases, power, reference)
+        got = np.array([libm.powf(float(b), float(power)) for b in bases], dtype=np.float32)
+        total += bases.size
+        bad += int((reference.view(np.uint32) != got.view(np.uint32)).sum())
+    return total, bad
+
+
+def main() -> int:
+    """Report every figure this script can reproduce without a rebuild.
+
+    Returns:
+        int: 0 if every count agrees bit for bit, 1 otherwise.
+    """
+    if Backend.CPP not in available_backends():
+        print("the C++ backend is not built; nothing to compare")
+        return 1
+
+    rows = [
+        ("de Casteljau grid (slice)", *measure_de_casteljau()),
+        ("all seven kernels", *measure_every_kernel()),
+        ("pow, numba against libm", *measure_pow_agreement()),
+    ]
+    print(f"{'measurement':<28} {'values':>10} {'differing':>10}")
+    for label, total, bad in rows:
+        print(f"{label:<28} {total:>10} {bad:>10}")
+
+    print(
+        "\nNot reproducible from a run: the -march=native movement counts, which need a\n"
+        "second build. To take them:\n"
+        "  cmake --preset gcc -B build/native -DCMAKE_CXX_FLAGS=-march=native\n"
+        "  cmake --build build/native && ctest --test-dir build/native\n"
+        "then re-run this script against an extension built the same way."
+    )
+    return 0 if all(bad == 0 for _, _, bad in rows) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -645,3 +645,233 @@ def monomial_to_bernstein_1d(
         ValueError: If ``degree`` is too large to fit a C ``int``, or if ``out`` is
             not the square matrix that degree calls for.
     """
+
+def evaluate_bezier_1d(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    points: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate a 1D Bézier at ``points``, fusing basis and contraction.
+
+    Runs the Bernstein ratio recurrence and contracts each term with the control
+    points in one pass, mirroring about ``u = 1/2`` so the seed cannot underflow
+    at high degree.
+
+    Call :meth:`pantr.bezier.Bezier.evaluate` for the ordinary path, which takes
+    points of any shape and allocates ``out``.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, rank)``, 2D and C-contiguous.
+        points (npt.NDArray[np.float32 | np.float64]): Evaluation points, 1D and
+            C-contiguous.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(points.size, rank)``, matching dtype, C-contiguous and writable.
+            Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``out`` is not the shape the other two arguments call for.
+    """
+
+def evaluate_bezier_deriv_1d(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    points: npt.NDArray[np.float32 | np.float64],
+    n_deriv: int,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate a 1D Bézier and its derivatives up to order ``n_deriv``.
+
+    Algorithm A2.3 of Piegl & Tiller specialised to Bernstein polynomials.
+
+    Call :meth:`pantr.bezier.Bezier.evaluate_derivatives` for the ordinary path.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, rank)``, 2D and C-contiguous.
+        points (npt.NDArray[np.float32 | np.float64]): Evaluation points, 1D and
+            C-contiguous.
+        n_deriv (int): Highest derivative order. Must be non-negative and fit a C
+            ``int``.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(points.size, n_deriv + 1, rank)``, matching dtype, 3D,
+            C-contiguous and writable. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            if ``out`` is passed positionally, or if ``n_deriv`` is negative.
+        ValueError: If ``out`` is not the shape the other arguments call for.
+    """
+
+def degree_elevate_bezier_1d(
+    degree: int,
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    degree_increment: int,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Degree-elevate a single Bézier segment by ``degree_increment``.
+
+    Call :meth:`pantr.bezier.Bezier.elevate_degree` for the ordinary path.
+
+    Args:
+        degree (int): Original degree. Non-negative.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, rank)``, 2D and C-contiguous.
+        degree_increment (int): Degrees to add. Non-negative.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(degree + degree_increment + 1, rank)``, matching dtype,
+            C-contiguous and writable. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            if ``out`` is passed positionally, or if either degree is negative.
+        ValueError: If ``ctrl`` does not have ``degree + 1`` rows, if ``out`` is
+            the wrong shape, or if ``degree + degree_increment`` exceeds the
+            exact-integer binomial envelope of 61.
+    """
+
+def slice_bezier_1d(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    value: float,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Evaluate a 1D Bézier at a single parameter, per column, by de Casteljau.
+
+    Call :meth:`pantr.bezier.Bezier.slice` for the ordinary path.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, n_cols)``, 2D and C-contiguous.
+        value (float): Parameter in ``[0, 1]``.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(n_cols,)``, matching dtype, 1D, C-contiguous and writable.
+            Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``out`` does not have ``ctrl.shape[1]`` entries.
+    """
+
+def split_bezier_1d(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    value: float,
+    *,
+    out_left: npt.NDArray[np.float32 | np.float64],
+    out_right: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Split a 1D Bézier at ``value`` into its two halves.
+
+    The two outputs share a dtype and a shape, so nothing in the type system
+    separates them and a positional call could exchange the halves silently.
+    Both are keyword-only for that reason.
+
+    Call :meth:`pantr.bezier.Bezier.split` for the ordinary path.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, n_cols)``, 2D and C-contiguous.
+        value (float): Parameter in ``[0, 1]``.
+        out_left (npt.NDArray[np.float32 | np.float64]): Left half, shape
+            ``(degree + 1, n_cols)``, matching dtype, C-contiguous and writable.
+            Written in full. Keyword-only.
+        out_right (npt.NDArray[np.float32 | np.float64]): Right half, same
+            requirements. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if either output is passed positionally.
+        ValueError: If either output is not the shape ``ctrl`` calls for.
+    """
+
+def restrict_bezier_1d(
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    lower: float,
+    upper: float,
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Restrict a 1D Bézier to ``[lower, upper]``, reparametrized to ``[0, 1]``.
+
+    Two de Casteljau passes, ordered so that neither divides by a small number.
+
+    Call :meth:`pantr.bezier.Bezier.restrict` for the ordinary path.
+
+    Args:
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(degree + 1, n_cols)``, 2D and C-contiguous.
+        lower (float): Left bound in ``[0, 1)``.
+        upper (float): Right bound in ``(0, 1]``.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(degree + 1, n_cols)``, matching dtype, C-contiguous and writable.
+            Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``out`` is not the shape ``ctrl`` calls for.
+    """
+
+def scalar_bernstein_product_1d(
+    a: npt.NDArray[np.float32 | np.float64],
+    b: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Multiply two scalar 1D Béziers in the Bernstein basis.
+
+    ``c_k = (1 / C(p+q, k)) * sum_i C(p, i) C(q, k-i) a_i b_{k-i}``.
+
+    Args:
+        a (npt.NDArray[np.float32 | np.float64]): Control points of the first
+            curve, 1D and C-contiguous, at least one entry.
+        b (npt.NDArray[np.float32 | np.float64]): Control points of the second
+            curve, same requirements and dtype.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(a.size + b.size - 1,)``, matching dtype, C-contiguous and
+            writable. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If either input is empty, if ``out`` is the wrong length, or
+            if the summed degree exceeds the exact-integer binomial envelope
+            of 61.
+    """
+
+def apply_reduction_operator(
+    operator: npt.NDArray[np.float64],
+    ctrl: npt.NDArray[np.float32 | np.float64],
+    *,
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
+    """Apply a dense degree-reduction operator: ``out = operator @ ctrl``.
+
+    Accumulates in ``float64`` regardless of the control points' dtype and rounds
+    once on the write, which is the contract the numba original states and this
+    one keeps. Rows of the operator that pin an endpoint are unit vectors, so
+    those outputs reproduce their inputs bit for bit.
+
+    The operator itself is assembled in exact rational arithmetic on the Python
+    side and converted to ``float64`` before it reaches here.
+
+    Args:
+        operator (npt.NDArray[np.float64]): Reduction operator of shape
+            ``(q + 1, p + 1)``. Always ``float64``, 2D and C-contiguous.
+        ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
+            ``(p + 1, rank)``, 2D and C-contiguous.
+        out (npt.NDArray[np.float32 | np.float64]): Output of shape
+            ``(q + 1, rank)``, matching ``ctrl``'s dtype, C-contiguous and
+            writable. Written in full. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``ctrl`` does not have as many rows as the operator has
+            columns, or if ``out`` is the wrong shape.
+    """

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -1,0 +1,485 @@
+"""Which implementation of a Bézier arithmetic kernel runs: the Numba one or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for
+the bezier package, exactly as :mod:`pantr.basis._basis_backend`,
+:mod:`pantr.quad._quad_backend` and
+:mod:`pantr.change_basis._change_basis_backend` do for theirs, and for the same
+reason: a catalogue imports the kernels it hands out, so keeping each one beside
+its own kernels is what stops the policy module from importing the library it has
+to stay independent of.
+
+Seven accessors over eight kernels
+----------------------------------
+
+Six are bare callables and one is a record, which is the rule
+``design/cross_backend_types.md`` states: a record when a consumer needs more
+than one kernel at once, a bare callable when it does not.
+:func:`~pantr.bezier._bezier_degree._minimize_degree_bezier` is the consumer that
+needs two. Inside one call it reduces a degree and then re-elevates the result so
+the trial can be compared against the original, so it reaches for the reduction
+apply and the elevation in the same breath. Resolving the backend twice there
+would let a scoped switch on another thread land between the two halves of a
+round trip, and the two halves would then be computed by different
+implementations. :class:`DegreeKernels` makes that unsayable.
+
+The other five call sites use exactly one kernel each, so they get one callable.
+
+What crosses the boundary
+-------------------------
+
+Arrays and scalars only. The reduction operator is the case worth naming, because
+it looks like a type and is not: it is assembled in exact rational arithmetic by
+:func:`~pantr.bezier._bezier_degree._l2_reduction_operator` and its interpolating
+sibling, cached per degree pair, and converted to ``float64`` before it ever
+reaches a kernel. What crosses is that finished matrix.
+
+Every kernel here fills the caller's buffer and returns ``None``, which is
+:mod:`pantr.basis`'s convention rather than :mod:`pantr.quad`'s. It follows from
+the public surface: :meth:`pantr.bezier.Bezier.evaluate` and
+:meth:`~pantr.bezier.Bezier.evaluate_derivatives` take ``out``, and the methods
+that do not still hand Layer 2 an array to fill before wrapping it in a
+:class:`~pantr.bezier.Bezier`.
+
+- :class:`DegreeKernels`: the elevation and reduction-apply kernels of one backend.
+- :func:`evaluate_core`, :func:`evaluate_deriv_core`, :func:`slice_core`,
+  :func:`split_core`, :func:`restrict_core`, :func:`product_core`,
+  :func:`degree_kernels`: the accessors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Final, NamedTuple, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+from ..bspline._bspline_degree_core import _apply_reduction_operator
+from ._bezier_core import (
+    _degree_elevate_bezier_1d_core,
+    _evaluate_bezier_1d_core,
+    _evaluate_bezier_deriv_1d_core,
+    _restrict_bezier_1d_core,
+    _scalar_bernstein_product_1d_core,
+    _slice_bezier_1d_core,
+    _split_bezier_1d_core,
+)
+
+_K = TypeVar("_K")
+"""One kernel's signature, so :func:`_select` returns the type it was given."""
+
+_Array = npt.NDArray[np.float32 | np.float64]
+"""A float32 or float64 array, the only two dtypes these kernels handle."""
+
+_EvaluateFunc = Callable[[_Array, _Array, _Array], None]
+"""Signature of the fused evaluation kernel: ``(ctrl, points, out) -> None``."""
+
+_EvaluateDerivFunc = Callable[[_Array, _Array, int, _Array], None]
+"""Signature of the derivative kernel: ``(ctrl, points, n_deriv, out) -> None``."""
+
+_ElevateFunc = Callable[[int, _Array, int, _Array], None]
+"""Signature of degree elevation: ``(degree, ctrl, degree_increment, out) -> None``."""
+
+_SliceFunc = Callable[[_Array, float, _Array], None]
+"""Signature of the single-parameter de Casteljau: ``(ctrl, value, out) -> None``."""
+
+_SplitFunc = Callable[[_Array, float, _Array, _Array], None]
+"""Signature of the split: ``(ctrl, value, out_left, out_right) -> None``."""
+
+_RestrictFunc = Callable[[_Array, float, float, _Array], None]
+"""Signature of the restriction: ``(ctrl, lower, upper, out) -> None``."""
+
+_ProductFunc = Callable[[_Array, _Array, _Array], None]
+"""Signature of the Bernstein product: ``(a, b, out) -> None``."""
+
+_ReduceApplyFunc = Callable[[npt.NDArray[np.float64], _Array, _Array], None]
+"""Signature of the reduction-operator apply: ``(operator, ctrl, out) -> None``.
+
+The operator is ``float64`` whatever the control points are, in both backends.
+"""
+
+
+class DegreeKernels(NamedTuple):
+    """The two kernels a degree round trip needs, from one backend.
+
+    Attributes:
+        elevate (_ElevateFunc): Degree elevation.
+        reduce_apply (_ReduceApplyFunc): Application of a reduction operator.
+    """
+
+    elevate: _ElevateFunc
+    reduce_apply: _ReduceApplyFunc
+
+
+def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
+    """Pick one kernel's implementation for the requested backend.
+
+    The one place the never-fall-back rule is applied for this package, so the
+    accessors below cannot drift from each other on it.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+        python_kernel (_K): The Python implementation, always available.
+        cpp_kernel (_K): The C++ implementation, available only when the
+            extension was built.
+
+    Returns:
+        _K: The kernel of the chosen backend.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return python_kernel
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return cpp_kernel
+
+
+def _fill(out: _Array, run: Callable[[_Array], None]) -> None:
+    """Run ``run`` against ``out``, absorbing a non-contiguous destination.
+
+    The numba kernels fill a strided ``out`` in place; the C++ bindings require
+    C-contiguous memory and refuse anything else, because ``.noconvert()`` is what
+    stops nanobind from filling a temporary and discarding it. So a strided ``out``
+    is computed into a contiguous buffer and copied back, and the caller sees the
+    numba behaviour on either backend.
+
+    Refusing instead would make ``PANTR_BACKEND`` change what the library accepts
+    rather than only how fast it is.
+
+    Args:
+        out (_Array): The caller's destination. Need not be contiguous.
+        run (Callable[[_Array], None]): Calls the binding with the array it is
+            given as the destination.
+    """
+    if out.flags["C_CONTIGUOUS"]:
+        run(out)
+        return
+
+    # The uncommon path. The test above is a flag read, so a contiguous caller
+    # pays essentially nothing; only one that passes a strided view pays the copy.
+    buffer = np.empty_like(out, order="C")
+    run(buffer)
+    out[...] = buffer
+
+
+def _cpp_evaluate(ctrl: _Array, points: _Array, out: _Array) -> None:
+    """Evaluate through the C++ binding, absorbing non-contiguous arrays.
+
+    Args:
+        ctrl (_Array): Control points of shape ``(degree + 1, rank)``.
+        points (_Array): 1D evaluation points.
+        out (_Array): Output of shape ``(points.size, rank)``.
+
+    Note:
+        No input validation is performed here. Shape and dtype were established
+        by Layer 2; the binding re-checks dtype, rank and contiguity.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    pts_c = np.ascontiguousarray(points)
+    _fill(out, lambda dest: _pantr_cpp.evaluate_bezier_1d(ctrl_c, pts_c, out=dest))
+
+
+def _cpp_evaluate_deriv(ctrl: _Array, points: _Array, n_deriv: int, out: _Array) -> None:
+    """Evaluate derivatives through the C++ binding, absorbing non-contiguous arrays.
+
+    Args:
+        ctrl (_Array): Control points of shape ``(degree + 1, rank)``.
+        points (_Array): 1D evaluation points.
+        n_deriv (int): Highest derivative order.
+        out (_Array): Output of shape ``(points.size, n_deriv + 1, rank)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    pts_c = np.ascontiguousarray(points)
+    _fill(
+        out,
+        lambda dest: _pantr_cpp.evaluate_bezier_deriv_1d(ctrl_c, pts_c, int(n_deriv), out=dest),
+    )
+
+
+def _cpp_degree_elevate(degree: int, ctrl: _Array, degree_increment: int, out: _Array) -> None:
+    """Degree-elevate through the C++ binding, absorbing non-contiguous arrays.
+
+    Args:
+        degree (int): Original degree.
+        ctrl (_Array): Control points of shape ``(degree + 1, rank)``.
+        degree_increment (int): Degrees to add.
+        out (_Array): Output of shape ``(degree + degree_increment + 1, rank)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    _fill(
+        out,
+        lambda dest: _pantr_cpp.degree_elevate_bezier_1d(
+            int(degree), ctrl_c, int(degree_increment), out=dest
+        ),
+    )
+
+
+def _cpp_slice(ctrl: _Array, value: float, out: _Array) -> None:
+    """Evaluate at one parameter through the C++ binding.
+
+    Args:
+        ctrl (_Array): Control points of shape ``(degree + 1, n_cols)``.
+        value (float): Parameter in ``[0, 1]``.
+        out (_Array): Output of shape ``(n_cols,)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    _fill(out, lambda dest: _pantr_cpp.slice_bezier_1d(ctrl_c, float(value), out=dest))
+
+
+def _cpp_split(ctrl: _Array, value: float, out_left: _Array, out_right: _Array) -> None:
+    """Split through the C++ binding, absorbing non-contiguous destinations.
+
+    Both halves are absorbed independently, so a caller may pass one contiguous
+    and one strided.
+
+    Args:
+        ctrl (_Array): Control points of shape ``(degree + 1, n_cols)``.
+        value (float): Parameter in ``[0, 1]``.
+        out_left (_Array): Left half, shape ``(degree + 1, n_cols)``.
+        out_right (_Array): Right half, same shape.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    left_c = out_left if out_left.flags["C_CONTIGUOUS"] else np.empty_like(out_left, order="C")
+    right_c = out_right if out_right.flags["C_CONTIGUOUS"] else np.empty_like(out_right, order="C")
+    _pantr_cpp.split_bezier_1d(ctrl_c, float(value), out_left=left_c, out_right=right_c)
+    if left_c is not out_left:
+        out_left[...] = left_c
+    if right_c is not out_right:
+        out_right[...] = right_c
+
+
+def _cpp_restrict(ctrl: _Array, lower: float, upper: float, out: _Array) -> None:
+    """Restrict through the C++ binding, absorbing non-contiguous arrays.
+
+    Args:
+        ctrl (_Array): Control points of shape ``(degree + 1, n_cols)``.
+        lower (float): Left bound.
+        upper (float): Right bound.
+        out (_Array): Output of shape ``(degree + 1, n_cols)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    ctrl_c = np.ascontiguousarray(ctrl)
+    _fill(
+        out,
+        lambda dest: _pantr_cpp.restrict_bezier_1d(ctrl_c, float(lower), float(upper), out=dest),
+    )
+
+
+def _cpp_product(a: _Array, b: _Array, out: _Array) -> None:
+    """Multiply two scalar Béziers through the C++ binding.
+
+    Args:
+        a (_Array): Control points of the first curve.
+        b (_Array): Control points of the second curve.
+        out (_Array): Product control points, shape ``(a.size + b.size - 1,)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    a_c = np.ascontiguousarray(a)
+    b_c = np.ascontiguousarray(b)
+    _fill(out, lambda dest: _pantr_cpp.scalar_bernstein_product_1d(a_c, b_c, out=dest))
+
+
+def _cpp_reduce_apply(operator: npt.NDArray[np.float64], ctrl: _Array, out: _Array) -> None:
+    """Apply a reduction operator through the C++ binding.
+
+    Args:
+        operator (npt.NDArray[np.float64]): Reduction operator, shape
+            ``(q + 1, p + 1)``.
+        ctrl (_Array): Control points of shape ``(p + 1, rank)``.
+        out (_Array): Output of shape ``(q + 1, rank)``.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_evaluate`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    op_c = np.ascontiguousarray(operator, dtype=np.float64)
+    ctrl_c = np.ascontiguousarray(ctrl)
+    _fill(out, lambda dest: _pantr_cpp.apply_reduction_operator(op_c, ctrl_c, out=dest))
+
+
+# Hoisted to module level rather than rebuilt inside each accessor. An accessor
+# that closed over a fresh function object would return a different callable on
+# every call, which defeats identity comparison in the tests and re-creates a
+# closure in front of a kernel measured in microseconds. The change_basis port
+# shipped that bug once.
+_CPP_EVALUATE: Final[_EvaluateFunc] = _cpp_evaluate
+"""The fused evaluation kernel of the C++ backend."""
+
+_CPP_EVALUATE_DERIV: Final[_EvaluateDerivFunc] = _cpp_evaluate_deriv
+"""The derivative-evaluation kernel of the C++ backend."""
+
+_CPP_DEGREE_KERNELS: Final[DegreeKernels] = DegreeKernels(
+    elevate=_cpp_degree_elevate, reduce_apply=_cpp_reduce_apply
+)
+"""The degree round-trip kernels of the C++ backend."""
+
+_PYTHON_DEGREE_KERNELS: Final[DegreeKernels] = DegreeKernels(
+    elevate=_degree_elevate_bezier_1d_core, reduce_apply=_apply_reduction_operator
+)
+"""The degree round-trip kernels of the Numba backend."""
+
+_CPP_SLICE: Final[_SliceFunc] = _cpp_slice
+"""The single-parameter de Casteljau of the C++ backend."""
+
+_CPP_SPLIT: Final[_SplitFunc] = _cpp_split
+"""The split kernel of the C++ backend."""
+
+_CPP_RESTRICT: Final[_RestrictFunc] = _cpp_restrict
+"""The restriction kernel of the C++ backend."""
+
+_CPP_PRODUCT: Final[_ProductFunc] = _cpp_product
+"""The Bernstein product of the C++ backend."""
+
+
+def evaluate_core(backend: Backend | None = None) -> _EvaluateFunc:
+    """Return the fused evaluation kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _EvaluateFunc: Callable as ``(ctrl, points, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _evaluate_bezier_1d_core, _CPP_EVALUATE)
+
+
+def evaluate_deriv_core(backend: Backend | None = None) -> _EvaluateDerivFunc:
+    """Return the derivative-evaluation kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _EvaluateDerivFunc: Callable as ``(ctrl, points, n_deriv, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _evaluate_bezier_deriv_1d_core, _CPP_EVALUATE_DERIV)
+
+
+def degree_kernels(backend: Backend | None = None) -> DegreeKernels:
+    """Return the elevation and reduction-apply kernels of the requested backend.
+
+    The two travel together because
+    :func:`~pantr.bezier._bezier_degree._minimize_degree_bezier` reduces and
+    re-elevates within a single call; see the module docstring.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        DegreeKernels: Both kernels, from the same backend.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _PYTHON_DEGREE_KERNELS, _CPP_DEGREE_KERNELS)
+
+
+def slice_core(backend: Backend | None = None) -> _SliceFunc:
+    """Return the single-parameter de Casteljau kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _SliceFunc: Callable as ``(ctrl, value, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _slice_bezier_1d_core, _CPP_SLICE)
+
+
+def split_core(backend: Backend | None = None) -> _SplitFunc:
+    """Return the split kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _SplitFunc: Callable as ``(ctrl, value, out_left, out_right) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _split_bezier_1d_core, _CPP_SPLIT)
+
+
+def restrict_core(backend: Backend | None = None) -> _RestrictFunc:
+    """Return the restriction kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _RestrictFunc: Callable as ``(ctrl, lower, upper, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _restrict_bezier_1d_core, _CPP_RESTRICT)
+
+
+def product_core(backend: Backend | None = None) -> _ProductFunc:
+    """Return the Bernstein product kernel of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _ProductFunc: Callable as ``(a, b, out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _scalar_bernstein_product_1d_core, _CPP_PRODUCT)

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -17,10 +17,16 @@ than one kernel at once, a bare callable when it does not.
 :func:`~pantr.bezier._bezier_degree._minimize_degree_bezier` is the consumer that
 needs two. Inside one call it reduces a degree and then re-elevates the result so
 the trial can be compared against the original, so it reaches for the reduction
-apply and the elevation in the same breath. Resolving the backend twice there
-would let a scoped switch on another thread land between the two halves of a
-round trip, and the two halves would then be computed by different
-implementations. :class:`DegreeKernels` makes that unsayable.
+apply and the elevation in the same breath. It therefore resolves once and takes both.
+
+**Not because two resolutions could disagree.** An earlier version of this docstring
+said a scoped switch on another thread could land between them; that is measurably
+false, because a :class:`~contextvars.ContextVar` gives each thread its own context
+and a task runs in a copy, so no sibling's ``set`` is ever observable here. What
+resolving once buys is that the backend is a property of the call rather than of
+each lookup, and that the dependency is stated in a signature rather than read from
+ambient state. :class:`DegreeKernels` is the convenient shape for two kernels always
+fetched together, not a safety mechanism.
 
 The other six call sites use exactly one kernel each, so they get one callable.
 

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -22,7 +22,12 @@ would let a scoped switch on another thread land between the two halves of a
 round trip, and the two halves would then be computed by different
 implementations. :class:`DegreeKernels` makes that unsayable.
 
-The other five call sites use exactly one kernel each, so they get one callable.
+The other six call sites use exactly one kernel each, so they get one callable.
+
+The accessors are named ``*_kernel`` rather than ``*_core``, following
+:mod:`pantr.quad._quad_backend` and :mod:`pantr.change_basis._change_basis_backend`.
+:mod:`pantr.basis._basis_backend` uses ``*_core``, and it is the oldest of the four;
+the two written since converged on ``_kernel`` and this is the third to do so.
 
 What crosses the boundary
 -------------------------
@@ -41,8 +46,8 @@ that do not still hand Layer 2 an array to fill before wrapping it in a
 :class:`~pantr.bezier.Bezier`.
 
 - :class:`DegreeKernels`: the elevation and reduction-apply kernels of one backend.
-- :func:`evaluate_core`, :func:`evaluate_deriv_core`, :func:`slice_core`,
-  :func:`split_core`, :func:`restrict_core`, :func:`product_core`,
+- :func:`evaluate_kernel`, :func:`evaluate_deriv_kernel`, :func:`slice_kernel`,
+  :func:`split_kernel`, :func:`restrict_kernel`, :func:`product_kernel`,
   :func:`degree_kernels`: the accessors.
 """
 
@@ -369,7 +374,7 @@ _CPP_PRODUCT: Final[_ProductFunc] = _cpp_product
 """The Bernstein product of the C++ backend."""
 
 
-def evaluate_core(backend: Backend | None = None) -> _EvaluateFunc:
+def evaluate_kernel(backend: Backend | None = None) -> _EvaluateFunc:
     """Return the fused evaluation kernel of the requested backend.
 
     Args:
@@ -385,7 +390,7 @@ def evaluate_core(backend: Backend | None = None) -> _EvaluateFunc:
     return _select(backend, _evaluate_bezier_1d_core, _CPP_EVALUATE)
 
 
-def evaluate_deriv_core(backend: Backend | None = None) -> _EvaluateDerivFunc:
+def evaluate_deriv_kernel(backend: Backend | None = None) -> _EvaluateDerivFunc:
     """Return the derivative-evaluation kernel of the requested backend.
 
     Args:
@@ -421,7 +426,7 @@ def degree_kernels(backend: Backend | None = None) -> DegreeKernels:
     return _select(backend, _PYTHON_DEGREE_KERNELS, _CPP_DEGREE_KERNELS)
 
 
-def slice_core(backend: Backend | None = None) -> _SliceFunc:
+def slice_kernel(backend: Backend | None = None) -> _SliceFunc:
     """Return the single-parameter de Casteljau kernel of the requested backend.
 
     Args:
@@ -437,7 +442,7 @@ def slice_core(backend: Backend | None = None) -> _SliceFunc:
     return _select(backend, _slice_bezier_1d_core, _CPP_SLICE)
 
 
-def split_core(backend: Backend | None = None) -> _SplitFunc:
+def split_kernel(backend: Backend | None = None) -> _SplitFunc:
     """Return the split kernel of the requested backend.
 
     Args:
@@ -453,7 +458,7 @@ def split_core(backend: Backend | None = None) -> _SplitFunc:
     return _select(backend, _split_bezier_1d_core, _CPP_SPLIT)
 
 
-def restrict_core(backend: Backend | None = None) -> _RestrictFunc:
+def restrict_kernel(backend: Backend | None = None) -> _RestrictFunc:
     """Return the restriction kernel of the requested backend.
 
     Args:
@@ -469,7 +474,7 @@ def restrict_core(backend: Backend | None = None) -> _RestrictFunc:
     return _select(backend, _restrict_bezier_1d_core, _CPP_RESTRICT)
 
 
-def product_core(backend: Backend | None = None) -> _ProductFunc:
+def product_kernel(backend: Backend | None = None) -> _ProductFunc:
     """Return the Bernstein product kernel of the requested backend.
 
     Args:

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -281,6 +281,7 @@ def _product_fn(
         Inputs are assumed to be correct (no validation performed).
     """
     if use_1d_kernel:
-        result_1d = _scalar_bernstein_product_1d_core(a[:, 0], b[:, 0])
+        result_1d = np.empty(a.shape[0] + b.shape[0] - 1, dtype=a.dtype)
+        _scalar_bernstein_product_1d_core(a[:, 0], b[:, 0], result_1d)
         return result_1d[:, np.newaxis]
     return _bernstein_product_coefficients_nd(a, b)

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -18,7 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..bspline._bspline_degree_core import _check_bincoeff_envelope
-from ._bezier_core import _scalar_bernstein_product_1d_core
+from ._bezier_backend import product_core
 from ._bezier_product import _bernstein_product_coefficients_nd
 
 if TYPE_CHECKING:
@@ -282,6 +282,6 @@ def _product_fn(
     """
     if use_1d_kernel:
         result_1d = np.empty(a.shape[0] + b.shape[0] - 1, dtype=a.dtype)
-        _scalar_bernstein_product_1d_core(a[:, 0], b[:, 0], result_1d)
+        product_core()(a[:, 0], b[:, 0], result_1d)
         return result_1d[:, np.newaxis]
     return _bernstein_product_coefficients_nd(a, b)

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -18,7 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..bspline._bspline_degree_core import _check_bincoeff_envelope
-from ._bezier_backend import product_core
+from ._bezier_backend import product_kernel
 from ._bezier_product import _bernstein_product_coefficients_nd
 
 if TYPE_CHECKING:
@@ -282,6 +282,6 @@ def _product_fn(
     """
     if use_1d_kernel:
         result_1d = np.empty(a.shape[0] + b.shape[0] - 1, dtype=a.dtype)
-        product_core()(a[:, 0], b[:, 0], result_1d)
+        product_kernel()(a[:, 0], b[:, 0], result_1d)
         return result_1d[:, np.newaxis]
     return _bernstein_product_coefficients_nd(a, b)

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -266,6 +266,16 @@ def _degree_elevate_bezier_1d_core(
             and then fully written; its previous contents are discarded.
 
     Note:
+        **Matching dtypes is a precondition, and violating it is silent here.**
+        Until this kernel filled a caller's buffer it allocated one with
+        ``dtype=ctrl.dtype``, so a mismatch was unrepresentable. It is now the
+        caller's to get right, and Numba will accept a wider ``out`` and quietly
+        accumulate at that width instead, where the C++ twin raises
+        :class:`TypeError`. Layer 2 establishes the match at every call site the
+        library makes, and :meth:`pantr.bezier.Bezier.evaluate` refuses a
+        mismatched ``out`` identically on both backends; this note is for a caller
+        that reaches the kernel directly.
+
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_bezier_degree._degree_elevate_bezier` instead.
     """
@@ -521,6 +531,12 @@ def _scalar_bernstein_product_1d_core(
             then fully written; its previous contents are discarded.
 
     Note:
+        **Matching dtypes is a precondition, and violating it is silent here.**
+        See :func:`_degree_elevate_bezier_1d_core`'s note: the two kernels lost the
+        same structural guarantee when they stopped allocating their own result,
+        and Numba accepts a wider ``out`` where the C++ twin raises
+        :class:`TypeError`.
+
         Inputs are assumed to be correct (no validation performed).
         For general use, call :func:`_bezier_compose._compose_bezier` instead.
     """

--- a/src/pantr/bezier/_bezier_core.py
+++ b/src/pantr/bezier/_bezier_core.py
@@ -242,7 +242,8 @@ def _degree_elevate_bezier_1d_core(
     degree: int,
     ctrl: npt.NDArray[np.float32 | np.float64],
     degree_increment: int,
-) -> npt.NDArray[np.float32 | np.float64]:
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
     r"""Degree-elevate a single Bézier segment.
 
     Computes the ``bezalfs`` matrix of Bézier degree elevation coefficients
@@ -260,10 +261,9 @@ def _degree_elevate_bezier_1d_core(
         ctrl (npt.NDArray[np.float32 | np.float64]): Control points of shape
             ``(p+1, rank)``.
         degree_increment (int): Number of degrees to add (``t >= 1``).
-
-    Returns:
-        npt.NDArray[np.float32 | np.float64]: Elevated control points of shape
-        ``(p+t+1, rank)``.
+        out (npt.NDArray[np.float32 | np.float64]): Destination for the elevated
+            control points, shape ``(p+t+1, rank)`` and ``ctrl``'s dtype. Zeroed
+            and then fully written; its previous contents are discarded.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -292,16 +292,14 @@ def _degree_elevate_bezier_1d_core(
         for j in range(max(0, i - t), mpi + 1):
             bezalfs[j, i] = bezalfs[p - j, ph - i]
 
-    # Apply elevation: new_ctrl[i] = sum_j bezalfs[j, i] * ctrl[j]
-    new_ctrl = np.zeros((ph + 1, rank), dtype=ctrl.dtype)
+    # Apply elevation: out[i] = sum_j bezalfs[j, i] * ctrl[j]
+    out[:, :] = 0.0
     for i in range(ph + 1):
         mpi = min(p, i)
         for j in range(max(0, i - t), mpi + 1):
             coeff = bezalfs[j, i]
             for r in range(rank):
-                new_ctrl[i, r] += coeff * ctrl[j, r]
-
-    return new_ctrl
+                out[i, r] += coeff * ctrl[j, r]
 
 
 @nb_jit(
@@ -500,7 +498,8 @@ def _restrict_bezier_1d_core(  # noqa: PLR0912
 def _scalar_bernstein_product_1d_core(
     a: npt.NDArray[np.float32 | np.float64],
     b: npt.NDArray[np.float32 | np.float64],
-) -> npt.NDArray[np.float32 | np.float64]:
+    out: npt.NDArray[np.float32 | np.float64],
+) -> None:
     r"""Compute the Bernstein product of two scalar 1D Bézier curves.
 
     Given two scalar Bézier curves with control points ``a`` (degree ``p``)
@@ -517,10 +516,9 @@ def _scalar_bernstein_product_1d_core(
             scalar Bézier, shape ``(p + 1,)``.
         b (npt.NDArray[np.float32 | np.float64]): Control points of the second
             scalar Bézier, shape ``(q + 1,)``.
-
-    Returns:
-        npt.NDArray[np.float32 | np.float64]: Product control points of shape
-        ``(p + q + 1,)``.
+        out (npt.NDArray[np.float32 | np.float64]): Destination for the product
+            control points, shape ``(p + q + 1,)`` and ``a``'s dtype. Zeroed and
+            then fully written; its previous contents are discarded.
 
     Note:
         Inputs are assumed to be correct (no validation performed).
@@ -530,7 +528,7 @@ def _scalar_bernstein_product_1d_core(
     q = b.shape[0] - 1
     r = p + q
 
-    out = np.zeros(r + 1, dtype=a.dtype)
+    out[:] = 0.0
 
     for i in range(p + 1):
         ai_scaled = a[i] * _bincoeff(p, i)
@@ -539,8 +537,6 @@ def _scalar_bernstein_product_1d_core(
 
     for k in nb_prange(r + 1):
         out[k] /= _bincoeff(r, k)
-
-    return out
 
 
 def _warmup_numba_functions() -> None:
@@ -559,11 +555,13 @@ def _warmup_numba_functions() -> None:
 
     _evaluate_bezier_1d_core(ctrl_dummy, pts_dummy, out_eval_dummy)
     _evaluate_bezier_deriv_1d_core(ctrl_dummy, pts_dummy, 0, out_deriv_dummy)
-    _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1)
+    out_elevate_dummy = np.empty((4, 2), dtype=np.float64)
+    _degree_elevate_bezier_1d_core(2, ctrl_dummy, 1, out_elevate_dummy)
     _slice_bezier_1d_core(ctrl_dummy, 0.5, out_slice_dummy)
     _split_bezier_1d_core(ctrl_dummy, 0.5, out_split_dummy, out_split_dummy.copy())
     _restrict_bezier_1d_core(ctrl_dummy, 0.2, 0.8, out_split_dummy)
 
     a_dummy = np.array([0.0, 1.0], dtype=np.float64)
     b_dummy = np.array([1.0, 0.0], dtype=np.float64)
-    _scalar_bernstein_product_1d_core(a_dummy, b_dummy)
+    out_product_dummy = np.empty(3, dtype=np.float64)
+    _scalar_bernstein_product_1d_core(a_dummy, b_dummy, out_product_dummy)

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -33,9 +33,9 @@ import numpy.typing as npt
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
 from .._backend import backend_keyed_cache
 from ..basis._basis_core import _tabulate_Bernstein_basis_1D_serial_core
-from ..bspline._bspline_degree_core import _apply_reduction_operator, _check_bincoeff_envelope
+from ..bspline._bspline_degree_core import _check_bincoeff_envelope
 from ..quad import get_gauss_legendre_1d
-from ._bezier_core import _degree_elevate_bezier_1d_core
+from ._bezier_backend import _ReduceApplyFunc, degree_kernels
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -108,9 +108,10 @@ def _degree_elevate_bezier(
 
     ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
     degrees = bezier.degree
+    elevate = degree_kernels().elevate
 
-    # ``_degree_elevate_bezier_1d_core`` builds its coefficient table from
-    # ``C(p + inc, i)``, so the elevated degree is what has to stay in range.
+    # The elevation kernel builds its coefficient table from ``C(p + inc, i)``,
+    # so the elevated degree is what has to stay in range.
     for d in range(bezier.dim):
         if increments[d] > 0:
             elevated = degrees[d] + increments[d]
@@ -127,7 +128,7 @@ def _degree_elevate_bezier(
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
         new_pts_2d = np.empty((p + inc + 1, pts_2d.shape[1]), dtype=pts_2d.dtype)
-        _degree_elevate_bezier_1d_core(p, pts_2d, inc, new_pts_2d)
+        elevate(p, pts_2d, inc, new_pts_2d)
         ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, d)
 
         # Update degrees for subsequent iterations.
@@ -344,6 +345,7 @@ def _reduce_along_axis(
     ctrl: npt.NDArray[np.float32 | np.float64],
     axis: int,
     operator: npt.NDArray[np.float64],
+    apply_kernel: _ReduceApplyFunc,
 ) -> npt.NDArray[np.float32 | np.float64]:
     """Apply a reduction operator along one axis of a control-point array.
 
@@ -353,6 +355,9 @@ def _reduce_along_axis(
         axis (int): Parametric direction to reduce.
         operator (npt.NDArray[np.float64]): Reduction operator of shape
             ``(new_order, ctrl.shape[axis])``.
+        apply_kernel (_ReduceApplyFunc): The backend's reduction-operator apply.
+            Passed in rather than resolved here so that a caller which also
+            elevates gets both kernels from one backend selection.
 
     Returns:
         npt.NDArray[np.float32 | np.float64]: Control points with ``axis``
@@ -360,7 +365,7 @@ def _reduce_along_axis(
     """
     pts_2d, trailing_shape = _flatten_along_axis(ctrl, axis)
     reduced = np.empty((operator.shape[0], pts_2d.shape[1]), dtype=pts_2d.dtype)
-    _apply_reduction_operator(operator, np.ascontiguousarray(pts_2d), reduced)
+    apply_kernel(operator, np.ascontiguousarray(pts_2d), reduced)
     return _unflatten_along_axis(reduced, trailing_shape, axis)
 
 
@@ -391,6 +396,7 @@ def _degree_reduce_bezier(
     from . import Bezier as BezierCls  # noqa: PLC0415
 
     ctrl: npt.NDArray[np.float32 | np.float64] = bezier.control_points
+    reduce_apply = degree_kernels().reduce_apply
 
     for d in range(bezier.dim):
         dec = decrements[d]
@@ -398,7 +404,7 @@ def _degree_reduce_bezier(
             continue
 
         operator = _interpolating_reduction_operator(bezier.degree[d], dec)
-        ctrl = _reduce_along_axis(ctrl, d, operator)
+        ctrl = _reduce_along_axis(ctrl, d, operator, reduce_apply)
 
     return BezierCls(ctrl, is_rational=bezier.is_rational)
 
@@ -800,20 +806,28 @@ def _minimize_degree_bezier(
     quad_weights = _tensor_gauss_weights(num_nodes) if bezier.is_rational else None
     projected = _sample_projected(result, num_nodes) if bezier.is_rational else None
 
+    # One backend selection for the whole search, and this is the call site that
+    # makes the catalogue hand out a record rather than two callables: each trial
+    # reduces and then re-elevates, and a round trip whose two halves came from
+    # different implementations would not be a round trip.
+    elevate, reduce_apply = degree_kernels()
+
     for dim in range(bezier.dim):
         # Each direction shrinks until a reduction is rejected.
         while result.shape[dim] >= 2:  # noqa: PLR2004
             degree = result.shape[dim] - 1
 
             # Reduce by one along `dim` (all rank components together) ...
-            reduced = _reduce_along_axis(result, dim, _interpolating_reduction_operator(degree, 1))
+            reduced = _reduce_along_axis(
+                result, dim, _interpolating_reduction_operator(degree, 1), reduce_apply
+            )
 
             # ... then re-elevate so the trial can be compared to `result`.
             flat_reduced, trailing_reduced = _flatten_along_axis(reduced, dim)
             flat_elevated = np.empty(
                 (flat_reduced.shape[0] + 1, flat_reduced.shape[1]), dtype=flat_reduced.dtype
             )
-            _degree_elevate_bezier_1d_core(degree - 1, flat_reduced, 1, flat_elevated)
+            elevate(degree - 1, flat_reduced, 1, flat_elevated)
             elevated = _unflatten_along_axis(flat_elevated, trailing_reduced, dim)
 
             if quad_weights is not None:

--- a/src/pantr/bezier/_bezier_degree.py
+++ b/src/pantr/bezier/_bezier_degree.py
@@ -126,7 +126,8 @@ def _degree_elevate_bezier(
         p = degrees[d]
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, d)
-        new_pts_2d = _degree_elevate_bezier_1d_core(p, pts_2d, inc)
+        new_pts_2d = np.empty((p + inc + 1, pts_2d.shape[1]), dtype=pts_2d.dtype)
+        _degree_elevate_bezier_1d_core(p, pts_2d, inc, new_pts_2d)
         ctrl = _unflatten_along_axis(new_pts_2d, trailing_shape, d)
 
         # Update degrees for subsequent iterations.
@@ -809,11 +810,11 @@ def _minimize_degree_bezier(
 
             # ... then re-elevate so the trial can be compared to `result`.
             flat_reduced, trailing_reduced = _flatten_along_axis(reduced, dim)
-            elevated = _unflatten_along_axis(
-                _degree_elevate_bezier_1d_core(degree - 1, flat_reduced, 1),
-                trailing_reduced,
-                dim,
+            flat_elevated = np.empty(
+                (flat_reduced.shape[0] + 1, flat_reduced.shape[1]), dtype=flat_reduced.dtype
             )
+            _degree_elevate_bezier_1d_core(degree - 1, flat_reduced, 1, flat_elevated)
+            elevated = _unflatten_along_axis(flat_elevated, trailing_reduced, dim)
 
             if quad_weights is not None:
                 # Relative round-trip deviation of the projected mapping.

--- a/src/pantr/bezier/_bezier_eval.py
+++ b/src/pantr/bezier/_bezier_eval.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..basis._basis_utils import _validate_out_array
-from ._bezier_core import _evaluate_bezier_1d_core, _evaluate_bezier_deriv_1d_core
+from ._bezier_backend import evaluate_core, evaluate_deriv_core
 from ._bezier_utils import _tabulate_bernstein_1d_fast
 
 if TYPE_CHECKING:
@@ -98,7 +98,7 @@ def _evaluate_bezier_1d(
 
     # Allocate raw output (includes weight column for rational)
     out_raw = np.empty((n_pts, cp_size), dtype=dtype)
-    _evaluate_bezier_1d_core(ctrl, pts_array, out_raw)
+    evaluate_core()(ctrl, pts_array, out_raw)
 
     result = _project_rational(bezier, out_raw)
 
@@ -403,7 +403,7 @@ def _evaluate_bezier_deriv_1d_non_rational(  # noqa: PLR0913
         npt.NDArray[np.float32 | np.float64]: Derivative values.
     """
     deriv_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
-    _evaluate_bezier_deriv_1d_core(ctrl, pts_array, n_deriv, deriv_all)
+    evaluate_deriv_core()(ctrl, pts_array, n_deriv, deriv_all)
     result = deriv_all[:, n_deriv, :]
 
     if cp_size == 1:
@@ -446,7 +446,7 @@ def _evaluate_bezier_deriv_1d_rational(  # noqa: PLR0913
 
     # Compute all homogeneous derivatives 0..n_deriv
     hom_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
-    _evaluate_bezier_deriv_1d_core(ctrl, pts_array, n_deriv, hom_all)
+    evaluate_deriv_core()(ctrl, pts_array, n_deriv, hom_all)
 
     # Algorithm A4.2 quotient rule
     W = hom_all[:, 0, -1:]  # (n_pts, 1)

--- a/src/pantr/bezier/_bezier_eval.py
+++ b/src/pantr/bezier/_bezier_eval.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..basis._basis_utils import _validate_out_array
-from ._bezier_backend import evaluate_core, evaluate_deriv_core
+from ._bezier_backend import evaluate_deriv_kernel, evaluate_kernel
 from ._bezier_utils import _tabulate_bernstein_1d_fast
 
 if TYPE_CHECKING:
@@ -98,7 +98,7 @@ def _evaluate_bezier_1d(
 
     # Allocate raw output (includes weight column for rational)
     out_raw = np.empty((n_pts, cp_size), dtype=dtype)
-    evaluate_core()(ctrl, pts_array, out_raw)
+    evaluate_kernel()(ctrl, pts_array, out_raw)
 
     result = _project_rational(bezier, out_raw)
 
@@ -403,7 +403,7 @@ def _evaluate_bezier_deriv_1d_non_rational(  # noqa: PLR0913
         npt.NDArray[np.float32 | np.float64]: Derivative values.
     """
     deriv_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
-    evaluate_deriv_core()(ctrl, pts_array, n_deriv, deriv_all)
+    evaluate_deriv_kernel()(ctrl, pts_array, n_deriv, deriv_all)
     result = deriv_all[:, n_deriv, :]
 
     if cp_size == 1:
@@ -446,7 +446,7 @@ def _evaluate_bezier_deriv_1d_rational(  # noqa: PLR0913
 
     # Compute all homogeneous derivatives 0..n_deriv
     hom_all = np.empty((n_pts, n_deriv + 1, cp_size), dtype=dtype)
-    evaluate_deriv_core()(ctrl, pts_array, n_deriv, hom_all)
+    evaluate_deriv_kernel()(ctrl, pts_array, n_deriv, hom_all)
 
     # Algorithm A4.2 quotient rule
     W = hom_all[:, 0, -1:]  # (n_pts, 1)

--- a/src/pantr/bezier/_bezier_restrict.py
+++ b/src/pantr/bezier/_bezier_restrict.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bezier_backend import restrict_core
+from ._bezier_backend import restrict_kernel
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -49,7 +49,7 @@ def _restrict_bezier(
 
     ctrl = bezier.control_points
     any_restricted = False
-    restrict = restrict_core()
+    restrict = restrict_kernel()
 
     for i, bounds in enumerate(bounds_per_dim):
         if bounds is None:

--- a/src/pantr/bezier/_bezier_restrict.py
+++ b/src/pantr/bezier/_bezier_restrict.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bezier_core import _restrict_bezier_1d_core
+from ._bezier_backend import restrict_core
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -28,7 +28,7 @@ def _restrict_bezier(
 ) -> Bezier:
     """Restrict a Bézier to a sub-region of ``[0, 1]^dim``.
 
-    Applies :func:`_restrict_bezier_1d_core` per parametric direction via the
+    Applies the backend's restriction kernel per parametric direction via the
     shared :func:`_flatten_along_axis` / :func:`_unflatten_along_axis` helpers.
     Directions with ``None`` bounds are left unchanged.
 
@@ -49,6 +49,7 @@ def _restrict_bezier(
 
     ctrl = bezier.control_points
     any_restricted = False
+    restrict = restrict_core()
 
     for i, bounds in enumerate(bounds_per_dim):
         if bounds is None:
@@ -64,7 +65,7 @@ def _restrict_bezier(
 
         pts_2d, trailing_shape = _flatten_along_axis(ctrl, i)
         out = np.empty_like(pts_2d)
-        _restrict_bezier_1d_core(pts_2d, lower, upper, out)
+        restrict(pts_2d, lower, upper, out)
         ctrl = _unflatten_along_axis(out, trailing_shape, i)
 
     if not any_restricted:

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -18,7 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis
-from ._bezier_backend import slice_core
+from ._bezier_backend import slice_kernel
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -61,7 +61,7 @@ def _slice_bezier(
 
     # Apply 1D de Casteljau via Numba kernel.
     result_1d = np.empty(pts_2d.shape[1], dtype=pts_2d.dtype)
-    slice_core()(pts_2d, value, result_1d)
+    slice_kernel()(pts_2d, value, result_1d)
 
     if bezier.dim == 1:
         # Result is a point.  For rational Béziers, project to physical coords.

--- a/src/pantr/bezier/_bezier_slice.py
+++ b/src/pantr/bezier/_bezier_slice.py
@@ -18,7 +18,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._array_utils import _flatten_along_axis
-from ._bezier_core import _slice_bezier_1d_core
+from ._bezier_backend import slice_core
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -61,7 +61,7 @@ def _slice_bezier(
 
     # Apply 1D de Casteljau via Numba kernel.
     result_1d = np.empty(pts_2d.shape[1], dtype=pts_2d.dtype)
-    _slice_bezier_1d_core(pts_2d, value, result_1d)
+    slice_core()(pts_2d, value, result_1d)
 
     if bezier.dim == 1:
         # Result is a point.  For rational Béziers, project to physical coords.

--- a/src/pantr/bezier/_bezier_split.py
+++ b/src/pantr/bezier/_bezier_split.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bezier_core import _split_bezier_1d_core
+from ._bezier_backend import split_core
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -56,7 +56,7 @@ def _split_bezier(
     pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
     out_left = np.empty_like(pts_2d)
     out_right = np.empty_like(pts_2d)
-    _split_bezier_1d_core(pts_2d, value, out_left, out_right)
+    split_core()(pts_2d, value, out_left, out_right)
     left_ctrl = _unflatten_along_axis(out_left, trailing_shape, direction)
     right_ctrl = _unflatten_along_axis(out_right, trailing_shape, direction)
 

--- a/src/pantr/bezier/_bezier_split.py
+++ b/src/pantr/bezier/_bezier_split.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array_utils import _flatten_along_axis, _unflatten_along_axis
-from ._bezier_backend import split_core
+from ._bezier_backend import split_kernel
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -56,7 +56,7 @@ def _split_bezier(
     pts_2d, trailing_shape = _flatten_along_axis(ctrl, direction)
     out_left = np.empty_like(pts_2d)
     out_right = np.empty_like(pts_2d)
-    split_core()(pts_2d, value, out_left, out_right)
+    split_kernel()(pts_2d, value, out_left, out_right)
     left_ctrl = _unflatten_along_axis(out_left, trailing_shape, direction)
     right_ctrl = _unflatten_along_axis(out_right, trailing_shape, direction)
 

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -28,14 +28,25 @@ unconditionally. Accumulating narrow where the oracle accumulates wide moved 125
 **The evaluation kernel's two branches seed from bases of different width.** Above
 the mirror threshold the oracle raises ``u``, which is the point array's own dtype;
 below it it raises ``1 - u``, which the literal ``1.0`` has already promoted to
-float64. One value in 16224 caught that, at degree 17 and ``u = 0.75``, where
-``0.75^17 = 3^17 / 2^34`` needs 27 significand bits.
+float64. A single value in a whole-kernel sweep caught that, at degree 17 and
+``u = 0.75``, where ``0.75^17 = 3^17 / 2^34`` needs 27 significand bits and the wide
+seed survives where the narrow one rounds. Computing the mirrored seed in double is
+still the natural port, and ``scripts/measure_bezier_parity.py`` reports 1305
+differences out of 1280256 if you do it.
 
 **The seed is a ``pow``, so its claim is observed rather than derived.** Neither C
-nor IEEE 754 requires ``pow`` to be correctly rounded. Measured separately over
-1280384 pairs, degrees 1 to 64 across the whole mirrored range: the platform
-``powf`` and numba's ``np.power`` agree on every one. `bernstein.hpp` records the
-same open question with the same answer.
+nor IEEE 754 requires ``pow`` to be correctly rounded, and the mirrored branch raises
+``u`` at storage width, so at float32 the C++ calls ``powf``. Measured over 1280256
+pairs, degrees 1 to 64 across the whole mirrored range: it and numba's ``np.power``
+agree on every one. `bernstein.hpp` records the same open question with the same
+answer.
+
+**Every figure in this docstring is reproducible**, by
+``scripts/measure_bezier_parity.py``. That is a script rather than a test because
+these are counts over particular grids, and a reader deciding whether to believe one
+wants the grid rather than a green tick. It exists because an earlier version of this
+file quoted numbers whose only artifact was a scratch directory that no longer
+exists.
 
 What this file does NOT cover, and it is a real gap
 ---------------------------------------------------
@@ -347,17 +358,34 @@ def test_reduce_degree_is_bitwise(
 
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", [3, 4, 7, 12])
-def test_minimize_degree_is_bitwise(cpp_backend: None, degree: int, dtype: npt.DTypeLike) -> None:
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_minimize_degree_is_bitwise(
+    cpp_backend: None, degree: int, is_rational: bool, dtype: npt.DTypeLike
+) -> None:
     """The greedy degree search takes the same decisions on both backends.
 
-    This is the one consumer that needs two kernels within a single call, and so
-    the reason `pantr.bezier._bezier_backend` hands out a record for them rather
-    than two callables. It is also the only test here whose output is *discrete*:
-    the search accepts or rejects each trial by comparing a round-trip error
-    against a tolerance, so a one-ulp disagreement in either kernel can change the
-    resulting degree rather than the last bit of a coefficient. Bit-exact control
-    points therefore prove more here than elsewhere -- they prove the two backends
-    took the same path, not only that they landed nearby.
+    This is the one consumer that reaches two dispatched kernels within a single
+    call, which is why `pantr.bezier._bezier_backend` hands out a record for them.
+    It is also the only test here whose output is *discrete*: the search accepts or
+    rejects each trial by comparing a round-trip error against a tolerance, so a
+    disagreement in either kernel can change the resulting degree rather than the
+    last bit of a coefficient. The degree is asserted before the coefficients for
+    that reason.
+
+    **The rational parametrization is not decoration, and its absence was a real
+    gap.** An earlier version swept only the non-rational branch while claiming the
+    test proved the two backends "took the same path". They do not take the same
+    path on a rational net: that branch grades in projected space, so it samples on
+    a tensor Gauss grid and builds a Bernstein collocation matrix, and
+    ``_bernstein_collocation_1d`` takes its nodes from the dispatched
+    :func:`~pantr.quad.get_gauss_legendre_1d` while tabulating them with a kernel
+    imported directly from ``pantr.basis._basis_core``, bypassing that package's
+    catalogue. So under ``PANTR_BACKEND=cpp`` the accept/reject verdict rests on a
+    matrix that is half one backend and half the other.
+
+    That bypass predates this port and is not fixed here. What this parametrization
+    does is make it visible: if the mixed matrix ever moves a verdict, this is the
+    test that says so.
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
@@ -366,13 +394,19 @@ def test_minimize_degree_is_bitwise(cpp_backend: None, degree: int, dtype: npt.D
     # A net that is genuinely reducible, so the search has something to find: a
     # quadratic elevated to `degree`, which is exactly recoverable. The lowest
     # degree swept is 3 because elevating by zero is refused.
-    base = _mixed_control_points((3, 2), dtype)
-    ctrl = Bezier(base).elevate_degree(degree - 2).control_points
+    # A rational net needs a weight column, and the weights are kept near one so the
+    # projected geometry stays well conditioned and the search decides on the curve
+    # rather than on a near-singular divide.
+    rank = 3 if is_rational else 2
+    base = _mixed_control_points((3, rank), dtype, exponents=(-1, 2))
+    if is_rational:
+        base[:, -1] = np.array([1.0, 0.8, 1.2], dtype=dtype)
+    ctrl = Bezier(base, is_rational=is_rational).elevate_degree(degree - 2).control_points
 
     with use_backend(Backend.PYTHON):
-        reference = Bezier(ctrl).minimize_degree()
+        reference = Bezier(ctrl, is_rational=is_rational).minimize_degree()
     with use_backend(Backend.CPP):
-        actual = Bezier(ctrl).minimize_degree()
+        actual = Bezier(ctrl, is_rational=is_rational).minimize_degree()
 
     assert actual.degree == reference.degree, (
         f"minimize_degree from {degree} in {np.dtype(dtype).name}: the backends "

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -494,12 +494,12 @@ def test_compose_is_bitwise(
 
     Driven through :meth:`Bezier.compose` and **not** through
     :meth:`Bezier.multiply`, which is the route a first draft of this test took and
-    which exercises none of the ported code. ``multiply`` goes to
-    ``_bernstein_product_coefficients_nd``, a pure-numpy helper that is not
-    dispatched at all; the scalar 1D product kernel is reached only from
-    ``compose``, and only when the inner map is univariate. The mistake was caught
-    by mutation: reassociating the kernel's accumulation left the ``multiply``
-    version passing.
+    which exercises none of the ported code. For a 1D Bézier ``multiply`` goes to
+    ``_bernstein_product_coefficients`` (and to its ``_nd`` sibling above 1D), both
+    pure-numpy helpers that are not dispatched at all; the scalar 1D product kernel
+    is reached only from ``compose``, and only when the inner map is univariate. The
+    mistake was caught by mutation: reassociating the kernel's accumulation left the
+    ``multiply`` version passing.
 
     A composition runs the kernel many times over -- once per Bernstein basis power
     of the inner map, then again for each tensor term -- so a single case here

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -1,0 +1,548 @@
+r"""Parity of the eight Bézier arithmetic kernels against their Numba oracles.
+
+`cpp/include/pantr/bezier/bezier.hpp` and
+`cpp/include/pantr/core/reduction_operator.hpp` name this file as the place their
+parity claims are measured.
+
+Every claim here is **bitwise**, and that is a first for this port. `quad` could
+not claim it because Golub-Welsch and a companion-matrix eigensolver are different
+algorithms; `change_basis` could not because a dense solve sits in the middle. Here
+both backends run the same expressions in the same order over `+`, `-`, `*` and
+`/`, each of which IEEE 754 pins to one correctly rounded result, so the two agree
+to the last bit.
+
+Where exactness was not free
+----------------------------
+
+Three things had to be got right, and each one is invisible at float64.
+
+**The accumulation widths are not uniform, and are not this port's to choose.** The
+four de Casteljau kernels compute each step in double and round once on the store,
+because numba promotes their float64 scalars against a float32 workspace. The
+derivative kernel is the exception: it opens with ``dtype = pts.dtype`` and
+allocates every workspace in it, so at float32 the whole recursion is float32.
+Elevation and the product mix, their coefficient tables being float64
+unconditionally. Accumulating narrow where the oracle accumulates wide moved 125 of
+630 values in the measurement that found it.
+
+**The evaluation kernel's two branches seed from bases of different width.** Above
+the mirror threshold the oracle raises ``u``, which is the point array's own dtype;
+below it it raises ``1 - u``, which the literal ``1.0`` has already promoted to
+float64. One value in 16224 caught that, at degree 17 and ``u = 0.75``, where
+``0.75^17 = 3^17 / 2^34`` needs 27 significand bits.
+
+**The seed is a ``pow``, so its claim is observed rather than derived.** Neither C
+nor IEEE 754 requires ``pow`` to be correctly rounded. Measured separately over
+1280384 pairs, degrees 1 to 64 across the whole mirrored range: the platform
+``powf`` and numba's ``np.power`` agree on every one. `bernstein.hpp` records the
+same open question with the same answer.
+
+What this file does NOT cover, and it is a real gap
+---------------------------------------------------
+
+Unlike the Bernstein tabulation, these kernels contain ``a * b + c * d`` sites, so
+``-ffp-contract`` has something to fuse and the exactness above is a property of
+the **build**, not of the code. Measured with ``-march=native``: 125 of 630 float64
+de Casteljau values move, and 237 of 970 for the reduction-operator apply. None of
+the float32 ones do, in either kernel, because the wide accumulator absorbs the
+difference before the narrowing store.
+
+**No bound is derived here for a fusing build.** The tests skip rather than weaken,
+and the skip is the honest report: a bound written for a branch no host in this
+project can execute would ship untested, which is how a wrong bound gets believed.
+Deriving it is a prerequisite for the ISA ladder of design/simd.md, not for this
+port, and Rule 7 of design/backend_parity.md is the reason it can be deferred at
+all: a bound is a property of the code and whether it is approached is a property
+of the host.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bezier import Bezier
+from tests._parity_harness import (
+    assert_parity,
+    bitwise_parity,
+    contraction_may_fuse,
+    demand_the_compiled_kernel,
+)
+
+DTYPES: Final = (np.float64, np.float32)
+"""The two storage formats the Bézier layer accepts."""
+
+DEGREES: Final = (0, 1, 2, 3, 5, 8, 13, 17, 25)
+"""Degrees swept by the univariate tests.
+
+0 and 1 are the two branches the evaluation kernel short-circuits; 17 is the degree
+at which the mirrored seed's width was caught, and is kept for that reason; 25 is
+past anything pantr's own builders reach.
+"""
+
+_DE_CASTELJAU_WHY = (
+    "the triangle is +, -, * and / only, each pinned by IEEE 754 to one correctly "
+    "rounded result, evaluated in the oracle's order and rounded through the "
+    "workspace at the oracle's width rather than carried in a register. No fused "
+    "multiply-add is available on this build, so the one operation that could "
+    "differ cannot occur"
+)
+
+_EVALUATE_WHY = (
+    "every operation but the seed is +, -, * or /, evaluated in the oracle's order, "
+    "with the running term carried in a register exactly as the oracle carries it. "
+    "The seed is pow, which neither C nor IEEE 754 requires to be correctly rounded, "
+    "so this claim is observed rather than derived: measured over 1280384 pairs, the "
+    "platform pow and numba's np.power agree on every argument these degrees form, "
+    "at both widths the two branches seed at. No fused multiply-add on this build"
+)
+
+_BINOMIAL_WHY = (
+    "the coefficient tables are built from an exact-integer binomial recurrence that "
+    "is the same recurrence on both sides, and every later operation is +, -, * or / "
+    "in the oracle's order. No fused multiply-add on this build"
+)
+
+_REDUCTION_WHY = (
+    "the operator is assembled once in exact rational arithmetic on the Python side "
+    "and crosses as float64, so both backends multiply the same matrix; the apply "
+    "accumulates in float64 in the same order on both sides and rounds once on the "
+    "write. No fused multiply-add on this build"
+)
+
+_NO_BOUND_FOR_A_FUSING_BUILD = (
+    "this build can fuse a multiply-add, and no parity bound has been derived for "
+    "the Bezier kernels in that regime. Measured with -march=native: 125 of 630 "
+    "float64 de Casteljau values move and 237 of 970 for the reduction apply. "
+    "Deriving the bound is a prerequisite for the ISA ladder of design/simd.md; see "
+    "this file's docstring."
+)
+
+
+def demand_a_non_fusing_build() -> None:
+    """Skip when the build can fuse, since no bound covers that case yet.
+
+    Raises:
+        Skipped: Always, on a build whose target ISA offers a fused multiply-add.
+    """
+    if contraction_may_fuse():
+        pytest.skip(_NO_BOUND_FOR_A_FUSING_BUILD)
+
+
+def _mixed_control_points(
+    shape: tuple[int, ...],
+    dtype: npt.DTypeLike,
+    seed: int = 20260821,
+    exponents: tuple[int, int] = (-6, 7),
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Control points spanning many magnitudes, so the triangle has cancellation to do.
+
+    A net of uniform magnitude is the easy case: every partial sum is the size of
+    the answer and nothing cancels. Scaling each entry by a random power of ten
+    between 1e-6 and 1e6 is what makes a difference in accumulation width or in
+    operation order actually reach the output.
+
+    Args:
+        shape (tuple[int, ...]): Shape of the control net, rank last.
+        dtype (npt.DTypeLike): Storage format.
+        seed (int): Generator seed. Defaults to 20260821.
+        exponents (tuple[int, int]): Half-open range of decimal exponents to draw
+            from. The default spans twelve orders of magnitude, which is right for
+            an operation whose output is the size of its input. An operation that
+            raises its input to a power needs a narrower range or it overflows
+            float32 before any kernel is at fault. Defaults to (-6, 7).
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The control points.
+    """
+    rng = np.random.default_rng(seed)
+    values = rng.standard_normal(shape) * 10.0 ** rng.integers(*exponents, shape)
+    return np.ascontiguousarray(values, dtype=dtype)
+
+
+def _adversarial_parameters(dtype: npt.DTypeLike) -> list[float]:
+    """Parameters reaching the branches a uniform sweep does not.
+
+    Both endpoints, either side of the mirror threshold, a value small enough that
+    ``1 - (1 - u)`` loses it outright, and both neighbours of one, where the
+    unmirrored seed underflows at high degree.
+
+    Args:
+        dtype (npt.DTypeLike): Storage format, which sets what "next to one" means.
+
+    Returns:
+        list[float]: The parameters, ascending.
+    """
+    one = np.array(1.0, dtype=dtype)
+    half = np.array(0.5, dtype=dtype)
+    return [
+        0.0,
+        1e-20,
+        1e-8,
+        0.25,
+        0.5,
+        float(np.nextafter(half, one)),
+        0.75,
+        1.0 - 1e-8,
+        float(np.nextafter(one, np.array(0.0, dtype=dtype))),
+        1.0,
+    ]
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize("rank", [1, 3])
+def test_evaluate_is_bitwise(
+    cpp_backend: None, degree: int, rank: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends evaluate a curve identically at every adversarial parameter."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, rank), dtype)
+    points = np.array(_adversarial_parameters(dtype), dtype=dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).evaluate(points)
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).evaluate(points)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_EVALUATE_WHY),
+        context=f"evaluate degree {degree} rank {rank} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", [0, 1, 3, 8, 17])
+@pytest.mark.parametrize("order", [0, 1, 2, 4])
+def test_evaluate_derivatives_is_bitwise(
+    cpp_backend: None, degree: int, order: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends agree on every derivative order, including past the degree.
+
+    ``order`` runs above ``degree`` on purpose: A2.3's index bounds go negative
+    there and the recursion takes branches a well-matched order never reaches.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 2), dtype)
+    points = np.array(_adversarial_parameters(dtype), dtype=dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).evaluate_derivatives(points, order)
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).evaluate_derivatives(points, order)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        context=f"evaluate_derivatives degree {degree} order {order} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize("increment", [1, 2, 5])
+def test_elevate_degree_is_bitwise(
+    cpp_backend: None, degree: int, increment: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends elevate identically, coefficient table included."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 3), dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).elevate_degree(increment).control_points
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).elevate_degree(increment).control_points
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_BINOMIAL_WHY),
+        context=f"elevate_degree {degree} by {increment} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", [2, 3, 5, 8, 13, 20])
+@pytest.mark.parametrize("decrement", [1, 2])
+def test_reduce_degree_is_bitwise(
+    cpp_backend: None, degree: int, decrement: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends apply the same reduction operator to the same result."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 3), dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).reduce_degree(decrement).control_points
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).reduce_degree(decrement).control_points
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_REDUCTION_WHY),
+        context=f"reduce_degree {degree} by {decrement} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", [3, 4, 7, 12])
+def test_minimize_degree_is_bitwise(cpp_backend: None, degree: int, dtype: npt.DTypeLike) -> None:
+    """The greedy degree search takes the same decisions on both backends.
+
+    This is the one consumer that needs two kernels within a single call, and so
+    the reason `pantr.bezier._bezier_backend` hands out a record for them rather
+    than two callables. It is also the only test here whose output is *discrete*:
+    the search accepts or rejects each trial by comparing a round-trip error
+    against a tolerance, so a one-ulp disagreement in either kernel can change the
+    resulting degree rather than the last bit of a coefficient. Bit-exact control
+    points therefore prove more here than elsewhere -- they prove the two backends
+    took the same path, not only that they landed nearby.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    # A net that is genuinely reducible, so the search has something to find: a
+    # quadratic elevated to `degree`, which is exactly recoverable. The lowest
+    # degree swept is 3 because elevating by zero is refused.
+    base = _mixed_control_points((3, 2), dtype)
+    ctrl = Bezier(base).elevate_degree(degree - 2).control_points
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).minimize_degree()
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).minimize_degree()
+
+    assert actual.degree == reference.degree, (
+        f"minimize_degree from {degree} in {np.dtype(dtype).name}: the backends "
+        f"stopped at different degrees, {actual.degree} against {reference.degree}"
+    )
+    assert_parity(
+        actual.control_points,
+        reference.control_points,
+        bitwise_parity(why=_REDUCTION_WHY),
+        context=f"minimize_degree from {degree} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize("value", [0.0, 1e-20, 0.25, 0.5, 0.75, 1.0])
+def test_slice_is_bitwise(
+    cpp_backend: None, degree: int, value: float, dtype: npt.DTypeLike
+) -> None:
+    """The two backends run the same de Casteljau triangle to the same last bit."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, degree + 1, 2), dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).slice(0, value)
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).slice(0, value)
+
+    assert isinstance(actual, Bezier) and isinstance(reference, Bezier)
+    assert_parity(
+        actual.control_points,
+        reference.control_points,
+        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        context=f"slice degree {degree} at {value!r} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize("value", [1e-20, 1e-8, 0.25, 0.5, 0.75, 1.0 - 1e-8])
+def test_split_is_bitwise(
+    cpp_backend: None, degree: int, value: float, dtype: npt.DTypeLike
+) -> None:
+    """Both halves of a split agree bit for bit.
+
+    The endpoints are absent because Layer 1 refuses them: :meth:`Bezier.split`
+    requires a value strictly inside ``(0, 1)``. The kernel itself has no such
+    shortcut and would run the full triangle at either end, unlike
+    :meth:`~pantr.bezier.Bezier.slice`, so 1e-20 and ``1 - 1e-8`` are as close to
+    the ends as this test can legitimately get.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 3), dtype)
+
+    with use_backend(Backend.PYTHON):
+        ref_left, ref_right = Bezier(ctrl).split(0, value)
+    with use_backend(Backend.CPP):
+        got_left, got_right = Bezier(ctrl).split(0, value)
+
+    for name, actual, reference in (
+        ("left", got_left, ref_left),
+        ("right", got_right, ref_right),
+    ):
+        assert_parity(
+            actual.control_points,
+            reference.control_points,
+            bitwise_parity(why=_DE_CASTELJAU_WHY),
+            context=f"split {name} degree {degree} at {value!r} {np.dtype(dtype).name}",
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize(
+    "bounds",
+    [(0.1, 0.9), (0.0, 1e-8), (1.0 - 1e-8, 1.0), (0.25, 0.75), (0.9, 1.0), (0.0, 0.1)],
+)
+def test_restrict_is_bitwise(
+    cpp_backend: None, degree: int, bounds: tuple[float, float], dtype: npt.DTypeLike
+) -> None:
+    """Both orderings of the two-pass restriction agree bit for bit.
+
+    The bounds list straddles the ``|upper| >= |lower - 1|`` test that chooses
+    which pass runs first, so both branches are exercised rather than whichever
+    one a symmetric interval happens to pick.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 3), dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).restrict(bounds).control_points
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).restrict(bounds).control_points
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        context=f"restrict degree {degree} to {bounds} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("outer_degree", [1, 2, 3, 5, 8])
+@pytest.mark.parametrize("inner_degree", [1, 2, 4])
+def test_compose_is_bitwise(
+    cpp_backend: None, outer_degree: int, inner_degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The Bernstein product agrees bit for bit, binomial scaling included.
+
+    Driven through :meth:`Bezier.compose` and **not** through
+    :meth:`Bezier.multiply`, which is the route a first draft of this test took and
+    which exercises none of the ported code. ``multiply`` goes to
+    ``_bernstein_product_coefficients_nd``, a pure-numpy helper that is not
+    dispatched at all; the scalar 1D product kernel is reached only from
+    ``compose``, and only when the inner map is univariate. The mistake was caught
+    by mutation: reassociating the kernel's accumulation left the ``multiply``
+    version passing.
+
+    A composition runs the kernel many times over -- once per Bernstein basis power
+    of the inner map, then again for each tensor term -- so a single case here
+    carries far more products than a single multiply would have.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    # `inner.rank` must equal `outer.dim`, so a univariate outer map takes a
+    # rank-1 inner one. That is exactly the case `use_1d_kernel` selects.
+    # A composition of degree `outer_degree` raises the inner map to that power, so
+    # the twelve-decade default range overflows float32 well before any kernel is
+    # at fault: measured, 1e6 to the eighth is 1e48 against a float32 ceiling near
+    # 3.4e38. Three decades still spans enough scale for cancellation to bite.
+    spread = (-1, 2)
+    outer = Bezier(_mixed_control_points((outer_degree + 1, 2), dtype, 11, spread))
+    inner = Bezier(_mixed_control_points((inner_degree + 1, 1), dtype, 22, spread))
+
+    with use_backend(Backend.PYTHON):
+        reference = outer.compose(inner).control_points
+    with use_backend(Backend.CPP):
+        actual = outer.compose(inner).control_points
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_BINOMIAL_WHY),
+        context=(f"compose degree {outer_degree} with {inner_degree} {np.dtype(dtype).name}"),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """A non-contiguous ``out`` is filled, and filled identically, on both backends.
+
+    The C++ binding refuses a strided array, because ``.noconvert()`` is what stops
+    nanobind from filling a temporary and discarding it, and the Python adapter
+    absorbs that by buffering and copying back. An adapter that dropped the copy
+    would return the right answer and leave the caller's array untouched, with no
+    exception anywhere, which is the worst failure shape available.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((6, 3), dtype)
+    points = np.linspace(0.0, 1.0, 9, dtype=dtype)
+
+    results = {}
+    for backend in (Backend.PYTHON, Backend.CPP):
+        holder = np.zeros((3, points.size), dtype=dtype)
+        view = holder.T
+        assert not view.flags["C_CONTIGUOUS"]
+        with use_backend(backend):
+            Bezier(ctrl).evaluate(points, out=view)
+        assert np.any(holder != 0.0), f"{backend.name}: the caller's array was not written"
+        results[backend] = holder.copy()
+
+    assert_parity(
+        results[Backend.CPP],
+        results[Backend.PYTHON],
+        bitwise_parity(why=f"{_EVALUATE_WHY}; buffering a strided out adds no arithmetic"),
+        context=f"strided out, {np.dtype(dtype).name}",
+    )
+
+
+def test_the_split_binding_refuses_its_outputs_positionally(cpp_backend: None) -> None:
+    """``out_left`` and ``out_right`` are keyword-only, so they cannot be exchanged.
+
+    They share a dtype and a shape, so nothing in the type system separates them
+    and a positional call would silently return the two halves the wrong way round.
+    This asserts the guard exists rather than trusting that it was written.
+    """
+    del cpp_backend
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    ctrl = np.ascontiguousarray(np.linspace(0.0, 1.0, 8).reshape(4, 2))
+    left = np.empty((4, 2))
+    right = np.empty((4, 2))
+
+    with pytest.raises(TypeError):
+        _pantr_cpp.split_bezier_1d(ctrl, 0.5, left, right)  # type: ignore[misc]
+
+    _pantr_cpp.split_bezier_1d(ctrl, 0.5, out_left=left, out_right=right)
+    assert not np.array_equal(left, right), (
+        "a split at the midpoint of a non-symmetric net must give two different halves"
+    )

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -252,6 +252,48 @@ def test_evaluate_derivatives_is_bitwise(
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(("degree", "order"), [(25, 16), (30, 14), (30, 25), (40, 13)])
+def test_derivatives_agree_past_the_factorial_overflow(
+    cpp_backend: None, degree: int, order: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends agree where A2.3's falling factorial overflows its integer.
+
+    ``fac`` accumulates ``p (p-1) ... (p-k+1)`` in an ``int64`` in both backends, and
+    it overflows: at degree 30 from order 14, at degree 61 from order 11. Every case
+    below is past that point, and every one is reachable through
+    :meth:`Bezier.evaluate_derivatives`, which imposes no ceiling on ``orders``.
+
+    The oracle wraps, because numba does not trap integer overflow. The port must
+    wrap identically, which is why its accumulator is **unsigned**: signed overflow is
+    undefined in C++, and the natural translation was undefined behaviour rather than
+    a merely wrong answer. Confirmed under ``-fsanitize=undefined``, which this
+    repository's ``gcc-debug`` preset enables, so the sanitizer build was aborting on
+    a case the parity suite did not reach.
+
+    Neither backend's answer is *correct* here in any useful sense. What is under test
+    is that they are the same, and that the C++ reaches it by a defined route.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+    demand_a_non_fusing_build()
+
+    ctrl = _mixed_control_points((degree + 1, 2), dtype, exponents=(-1, 2))
+    points = np.array([0.0, 0.25, 0.5, 1.0], dtype=dtype)
+
+    with use_backend(Backend.PYTHON):
+        reference = Bezier(ctrl).evaluate_derivatives(points, order)
+    with use_backend(Backend.CPP):
+        actual = Bezier(ctrl).evaluate_derivatives(points, order)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        context=f"derivatives degree {degree} order {order} {np.dtype(dtype).name}",
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", DEGREES)
 @pytest.mark.parametrize("increment", [1, 2, 5])
 def test_elevate_degree_is_bitwise(

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -107,9 +107,10 @@ _EVALUATE_WHY = (
     "every operation but the seed is +, -, * or /, evaluated in the oracle's order, "
     "with the running term carried in a register exactly as the oracle carries it. "
     "The seed is pow, which neither C nor IEEE 754 requires to be correctly rounded, "
-    "so this claim is observed rather than derived: measured over 1280384 pairs, the "
-    "platform pow and numba's np.power agree on every argument these degrees form, "
-    "at both widths the two branches seed at. No fused multiply-add on this build"
+    "so this claim is observed rather than derived: over 1280256 pairs, reproducible "
+    "by scripts/measure_bezier_parity.py, the platform powf and numba's np.power "
+    "agree on every argument these degrees form, at both widths the two branches "
+    "seed at. No fused multiply-add on this build"
 )
 
 _BINOMIAL_WHY = (

--- a/tests/parity/test_bezier_binding_contract.py
+++ b/tests/parity/test_bezier_binding_contract.py
@@ -1,0 +1,161 @@
+"""What the eight Bézier bindings refuse, and why each refusal has to be a test.
+
+`cpp/bindings/bezier.cpp` is the C++ half of Layer 2: the kernels behind it validate
+nothing, so every precondition they rely on is established here. That is only true if
+the checks exist, and three classes of them did not until a deep review found them.
+Each is pinned below with the failure it prevents, because each failure is silent or
+worse.
+
+**A degree inferred from a shape has a floor.** Five kernels take no ``degree``
+argument and compute ``ctrl.extent(0) - 1`` in ``std::size_t``. A zero-row ``ctrl``
+underflowed to ``SIZE_MAX`` and the kernel walked off the allocation: measured,
+SIGSEGV with no exception, on all five. `basis.cpp` avoids the class by taking
+``degree`` as an ``unsigned`` the caster refuses to make negative; there is no such
+argument here.
+
+**Two same-shaped output buffers can be the same buffer.** ``split_bezier_1d``
+returned the right half under both names when handed one array twice.
+``nb::kw_only()`` closes transposition and nothing closed aliasing.
+`cpp/bindings/quad.cpp` had carried the guard for its own two-output rules since the
+quad port; it simply was not brought across.
+
+**A documented domain is a promise.** ``value``, ``lower`` and ``upper`` were
+documented as living in the unit interval and never checked, so ``slice`` at 2.5
+extrapolated silently and ``restrict`` with its bounds transposed returned a
+different, plausible Bézier.
+
+These are reachable by importing :mod:`pantr._pantr_cpp`, not through
+:class:`~pantr.bezier.Bezier`, whose Layer 1 refuses all of them first. That is
+exactly the surface `basis.cpp` documents as real: the extension is importable and
+every name here is a public attribute of a public module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+_CTRL = np.ascontiguousarray(np.arange(8.0).reshape(4, 2))
+"""A well-formed degree-3, rank-2 control net, so only the argument under test is bad."""
+
+
+def _bindings() -> Any:
+    """Import the extension.
+
+    Returns:
+        Any: The :mod:`pantr._pantr_cpp` module.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        "evaluate_bezier_1d",
+        "evaluate_bezier_deriv_1d",
+        "slice_bezier_1d",
+        "split_bezier_1d",
+        "restrict_bezier_1d",
+    ],
+)
+def test_an_empty_control_net_raises_rather_than_crashing(cpp_backend: None, call: str) -> None:
+    """The five kernels that infer a degree from a shape refuse a zero-row ``ctrl``.
+
+    Before the check, every one of these exited with SIGSEGV. A test cannot observe a
+    segfault in its own process, so what it observes instead is the exception that now
+    stands in its place: if the check is removed, this test does not fail, it takes the
+    whole run down, which is a louder signal than a red.
+    """
+    del cpp_backend
+    empty = np.empty((0, 2))
+    bindings = _bindings()
+    invocations = {
+        "evaluate_bezier_1d": lambda: bindings.evaluate_bezier_1d(
+            empty, np.array([0.5]), out=np.empty((1, 2))
+        ),
+        "evaluate_bezier_deriv_1d": lambda: bindings.evaluate_bezier_deriv_1d(
+            empty, np.array([0.5]), 1, out=np.empty((1, 2, 2))
+        ),
+        "slice_bezier_1d": lambda: bindings.slice_bezier_1d(empty, 0.5, out=np.empty(2)),
+        "split_bezier_1d": lambda: bindings.split_bezier_1d(
+            empty, 0.5, out_left=np.empty((0, 2)), out_right=np.empty((0, 2))
+        ),
+        "restrict_bezier_1d": lambda: bindings.restrict_bezier_1d(
+            empty, 0.2, 0.8, out=np.empty((0, 2))
+        ),
+    }
+    with pytest.raises(ValueError, match="no rows"):
+        invocations[call]()
+
+
+def test_split_refuses_two_outputs_that_are_the_same_array(cpp_backend: None) -> None:
+    """Aliased halves are refused rather than silently collapsed into one.
+
+    Measured before the guard: the call returned the right half under both names, with
+    no exception. Two views onto one buffer alias just as destructively, so the guard
+    tests for overlap rather than identity, and this checks both.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    same = np.zeros((4, 2))
+    with pytest.raises(ValueError, match="overlap in memory"):
+        bindings.split_bezier_1d(_CTRL, 0.5, out_left=same, out_right=same)
+
+    # Two halves of one allocation: different objects, overlapping storage.
+    holder = np.zeros((8, 2))
+    with pytest.raises(ValueError, match="overlap in memory"):
+        bindings.split_bezier_1d(_CTRL, 0.5, out_left=holder[:4], out_right=holder[3:7])
+
+    # Adjacent but disjoint is legal, which is what makes the guard about overlap and
+    # not about sharing a base array.
+    bindings.split_bezier_1d(_CTRL, 0.5, out_left=holder[:4], out_right=holder[4:])
+    assert np.any(holder != 0.0)
+
+
+@pytest.mark.parametrize("value", [-0.5, 1.5, 2.5, 5.0, float("nan"), float("inf")])
+def test_a_parameter_outside_the_unit_interval_is_refused(cpp_backend: None, value: float) -> None:
+    """``slice`` and ``split`` refuse a parameter their docstring says is in ``[0, 1]``.
+
+    NaN is in the list deliberately: the check is written as a conjunction of two
+    comparisons rather than a negated range, because a NaN compares false against
+    everything and a negated range would have admitted it.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+        bindings.slice_bezier_1d(_CTRL, value, out=np.empty(2))
+
+    with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+        bindings.split_bezier_1d(
+            _CTRL, value, out_left=np.empty((4, 2)), out_right=np.empty((4, 2))
+        )
+
+
+def test_restrict_refuses_transposed_bounds(cpp_backend: None) -> None:
+    """``lower`` and ``upper`` are ordered, which is what closes the transposition trap.
+
+    They are adjacent same-typed positional parameters, so nothing in the type system
+    separates them, and a transposed call used to return a different and entirely
+    plausible restriction. Ordering them makes that call an error instead.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    with pytest.raises(ValueError, match="must not exceed upper"):
+        bindings.restrict_bezier_1d(_CTRL, 0.8, 0.2, out=np.empty((4, 2)))
+
+    for bad in (-0.1, 1.5, float("nan")):
+        with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+            bindings.restrict_bezier_1d(_CTRL, bad, 1.0, out=np.empty((4, 2)))
+        with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+            bindings.restrict_bezier_1d(_CTRL, 0.0, bad, out=np.empty((4, 2)))
+
+    # A zero-width interval is admitted: the kernel is well defined there, and Layer 1
+    # is the layer that decides whether it is a useful thing to ask for.
+    bindings.restrict_bezier_1d(_CTRL, 0.5, 0.5, out=np.empty((4, 2)))

--- a/tests/test_bezier_core_out_contract.py
+++ b/tests/test_bezier_core_out_contract.py
@@ -73,3 +73,45 @@ def test_bernstein_product_of_two_linears_is_exact() -> None:
     out = np.empty(3)
     _scalar_bernstein_product_1d_core(linear, linear, out)
     assert_array_equal(out, np.array([1.0, 0.0, 0.0]))
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["evaluate", "evaluate_derivatives"],
+)
+def test_the_public_surface_refuses_a_mismatched_out_dtype_on_both_backends(
+    method: str,
+) -> None:
+    """``PANTR_BACKEND`` must not change which ``out`` the library accepts.
+
+    The two kernels above lost a structural guarantee when they stopped allocating
+    their own result: while they called ``np.zeros(..., dtype=a.dtype)`` a
+    mismatched accumulation width was unrepresentable, and now it is the caller's
+    to get right. Numba accepts a wider ``out`` and accumulates at that width; the
+    C++ binding refuses it with :class:`TypeError`. That asymmetry is confined to a
+    direct Layer 3 call, where nothing validates anything by design.
+
+    What must not differ is the **library's** surface, and this pins it: Layer 2
+    refuses the mismatch with the same exception under either backend. If a future
+    refactor lets one backend through, this fails rather than the difference being
+    discovered as a wrong number at float32.
+    """
+    from pantr._backend import Backend, available_backends, use_backend  # noqa: PLC0415
+    from pantr.bezier import Bezier  # noqa: PLC0415
+
+    ctrl = np.ascontiguousarray(np.linspace(0.0, 1.0, 8).reshape(4, 2), dtype=np.float32)
+    points = np.array([0.25, 0.5], dtype=np.float32)
+
+    messages = {}
+    for backend in available_backends():
+        wide = np.empty((2, 2) if method == "evaluate" else (2, 2, 2), dtype=np.float64)
+        args = (points,) if method == "evaluate" else (points, 1)
+        with use_backend(backend), pytest.raises(ValueError) as caught:
+            getattr(Bezier(ctrl), method)(*args, out=wide)
+        messages[backend] = str(caught.value)
+
+    if Backend.CPP in messages:
+        assert messages[Backend.PYTHON] == messages[Backend.CPP], (
+            "the two backends refuse a mismatched out with different messages, so the "
+            "library's surface depends on PANTR_BACKEND"
+        )

--- a/tests/test_bezier_core_out_contract.py
+++ b/tests/test_bezier_core_out_contract.py
@@ -1,0 +1,75 @@
+"""The ``out`` contract of the two Bézier kernels that used to allocate their result.
+
+:func:`~pantr.bezier._bezier_core._degree_elevate_bezier_1d_core` and
+:func:`~pantr.bezier._bezier_core._scalar_bernstein_product_1d_core` both accumulate
+into their destination, so they must zero it first. While they allocated with
+:func:`numpy.zeros` that was free; now that the caller owns the buffer it is a promise,
+and a kernel that forgets it reads as correct against a freshly allocated array and
+wrong against a reused one.
+
+That is the failure these tests exist to catch, and it is the one a C++ port is most
+likely to reintroduce, since the natural translation of ``np.zeros`` is a destination
+the caller already zeroed.
+"""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from numpy.testing import assert_array_equal
+
+from pantr.bezier._bezier_core import (
+    _degree_elevate_bezier_1d_core,
+    _scalar_bernstein_product_1d_core,
+)
+
+# A value no correct result can contain, so a surviving one is unmistakable.
+_POISON = -12345.0
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize(("degree", "increment", "rank"), [(0, 1, 1), (2, 1, 3), (5, 4, 2)])
+def test_degree_elevate_zeros_its_destination(
+    degree: int, increment: int, rank: int, dtype: type[np.floating]
+) -> None:
+    """Elevation into a poisoned buffer matches elevation into a zeroed one."""
+    rng = np.random.default_rng(20260821)
+    ctrl: npt.NDArray[np.floating] = rng.random((degree + 1, rank)).astype(dtype)
+    shape = (degree + increment + 1, rank)
+
+    clean = np.zeros(shape, dtype=dtype)
+    _degree_elevate_bezier_1d_core(degree, ctrl, increment, clean)
+
+    poisoned = np.full(shape, _POISON, dtype=dtype)
+    _degree_elevate_bezier_1d_core(degree, ctrl, increment, poisoned)
+
+    assert_array_equal(poisoned, clean)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize(("p", "q"), [(0, 0), (1, 1), (3, 5)])
+def test_bernstein_product_zeros_its_destination(p: int, q: int, dtype: type[np.floating]) -> None:
+    """The Bernstein product into a poisoned buffer matches the product into a zeroed one."""
+    rng = np.random.default_rng(20260821)
+    a: npt.NDArray[np.floating] = rng.random(p + 1).astype(dtype)
+    b: npt.NDArray[np.floating] = rng.random(q + 1).astype(dtype)
+
+    clean = np.zeros(p + q + 1, dtype=dtype)
+    _scalar_bernstein_product_1d_core(a, b, clean)
+
+    poisoned = np.full(p + q + 1, _POISON, dtype=dtype)
+    _scalar_bernstein_product_1d_core(a, b, poisoned)
+
+    assert_array_equal(poisoned, clean)
+
+
+def test_bernstein_product_of_two_linears_is_exact() -> None:
+    """``(1-t)*(1-t)`` in Bernstein form has control points ``(1, 0, 0)`` exactly.
+
+    A known-answer case, so it fails on a wrong binomial scaling rather than only on a
+    forgotten zeroing. In Bernstein form ``1 - t`` is ``(1, 0)``, and the square of a
+    polynomial whose only nonzero coefficient sits at index 0 keeps that shape.
+    """
+    linear = np.array([1.0, 0.0])
+    out = np.empty(3)
+    _scalar_bernstein_product_1d_core(linear, linear, out)
+    assert_array_equal(out, np.array([1.0, 0.0, 0.0]))

--- a/tests/test_bezier_reexports.py
+++ b/tests/test_bezier_reexports.py
@@ -69,12 +69,12 @@ defines them is still where they live, and a test that imports one directly, as
 _CATALOGUE = (
     "DegreeKernels",
     "degree_kernels",
-    "evaluate_core",
-    "evaluate_deriv_core",
-    "product_core",
-    "restrict_core",
-    "slice_core",
-    "split_core",
+    "evaluate_kernel",
+    "evaluate_deriv_kernel",
+    "product_kernel",
+    "restrict_kernel",
+    "slice_kernel",
+    "split_kernel",
 )
 """The catalogue's accessors, added by this port."""
 

--- a/tests/test_bezier_reexports.py
+++ b/tests/test_bezier_reexports.py
@@ -1,0 +1,118 @@
+"""The names `pantr.bezier` must keep importable, and why a test holds them.
+
+`CLAUDE.md` records that a separate, not-yet-public downstream consumer imports
+pantr's **private** symbols, and that pantr's own CI cannot see breakage there. The
+`change_basis` port learned that the hard way: nine names stopped being importable
+when a flat module became a package, the docstring claimed otherwise, and no test
+checked. `tests/test_change_basis_reexports.py` is that check for its module and
+this is the one for this module.
+
+**`bezier` is the first port that touches symbols the consumer actually uses.** A
+grep over its checkout on 2026-08-21 found two:
+``pantr.bezier._root_finding_core._de_casteljau_eval_scalar``, a `@nb_jit` kernel,
+and ``pantr.bezier._bezier.Bezier``, which is public as ``pantr.bezier.Bezier``
+with only the path private. Neither is in this port's scope, which is exactly why
+they are pinned here: a later stage will reorganise `_root_finding_core`, and this
+is the test that will notice.
+
+The rest of the list is the surface this port did move. Routing Layer 2 through
+`pantr.bezier._bezier_backend` removed the kernels from the namespaces of the six
+modules that used to import them directly, so anything reachable through one of
+those paths before is not reachable now. That is a deliberate change and the names
+below are the ones that must survive it.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+_PUBLIC = (
+    "Bezier",
+    "create_from_bspline",
+    "find_monotone_root",
+    "find_roots",
+    "fit_bezier",
+    "interpolate_bezier",
+)
+"""The package's ``__all__``, unchanged by the port."""
+
+_CONSUMER_PRIVATE = (
+    ("pantr.bezier._root_finding_core", "_de_casteljau_eval_scalar"),
+    ("pantr.bezier._bezier", "Bezier"),
+)
+"""Private paths the downstream consumer imports, measured 2026-08-21.
+
+Pinned by full path rather than by name, because the path is the part that is
+fragile: ``Bezier`` is public under another name and would survive a move of
+``_bezier.py``, while the consumer's import would not.
+"""
+
+_KERNELS = (
+    "_degree_elevate_bezier_1d_core",
+    "_evaluate_bezier_1d_core",
+    "_evaluate_bezier_deriv_1d_core",
+    "_restrict_bezier_1d_core",
+    "_scalar_bernstein_product_1d_core",
+    "_slice_bezier_1d_core",
+    "_split_bezier_1d_core",
+)
+"""The seven Layer 3 kernels, which stay importable from ``_bezier_core``.
+
+They are the Numba half of the dual backend now rather than the only
+implementation, so Layer 2 reaches them through the catalogue. The module that
+defines them is still where they live, and a test that imports one directly, as
+``tests/test_root_finding_stress.py`` does, must keep working.
+"""
+
+_CATALOGUE = (
+    "DegreeKernels",
+    "degree_kernels",
+    "evaluate_core",
+    "evaluate_deriv_core",
+    "product_core",
+    "restrict_core",
+    "slice_core",
+    "split_core",
+)
+"""The catalogue's accessors, added by this port."""
+
+
+@pytest.mark.parametrize("name", _PUBLIC)
+def test_the_public_surface_is_importable(name: str) -> None:
+    """Every name in ``__all__`` resolves on the package."""
+    module = importlib.import_module("pantr.bezier")
+    assert hasattr(module, name), f"pantr.bezier lost {name}"
+
+
+def test_all_matches_the_public_list() -> None:
+    """``__all__`` is exactly the list above, so an addition has to be recorded here."""
+    module = importlib.import_module("pantr.bezier")
+    assert tuple(sorted(module.__all__)) == tuple(sorted(_PUBLIC))
+
+
+@pytest.mark.parametrize(("path", "name"), _CONSUMER_PRIVATE)
+def test_the_consumer_visible_private_paths_still_resolve(path: str, name: str) -> None:
+    """The private paths a downstream consumer imports are still importable.
+
+    Failing this does not mean the change is wrong. It means the consumer's
+    checkout has to be updated in the same breath, which is the whole point of
+    finding out here rather than there.
+    """
+    module = importlib.import_module(path)
+    assert hasattr(module, name), f"{path} lost {name}, which a downstream consumer imports"
+
+
+@pytest.mark.parametrize("name", _KERNELS)
+def test_the_kernels_stay_where_they_were(name: str) -> None:
+    """Every Layer 3 kernel is still reachable from ``pantr.bezier._bezier_core``."""
+    module = importlib.import_module("pantr.bezier._bezier_core")
+    assert hasattr(module, name), f"_bezier_core lost {name}"
+
+
+@pytest.mark.parametrize("name", _CATALOGUE)
+def test_the_catalogue_exposes_its_accessors(name: str) -> None:
+    """Every accessor the port added is reachable on the catalogue module."""
+    module = importlib.import_module("pantr.bezier._bezier_backend")
+    assert hasattr(module, name), f"_bezier_backend lost {name}"

--- a/tests/test_root_finding_stress.py
+++ b/tests/test_root_finding_stress.py
@@ -95,13 +95,15 @@ def _make_double_root_coeff(
     r = rng.uniform(0.2, 0.8)
     linear = np.array([-r, 1.0 - r], dtype=np.float64)
     # Square it via Bernstein product
-    squared = _scalar_bernstein_product_1d_core(linear, linear)
+    squared = np.empty(2 * linear.shape[0] - 1, dtype=np.float64)
+    _scalar_bernstein_product_1d_core(linear, linear, squared)
 
     # Multiply by a random cofactor to reach target degree
     remaining = degree - 2
     if remaining > 0:
         cofactor = rng.uniform(0.5, 2.0, remaining + 1).astype(np.float64)
-        result = _scalar_bernstein_product_1d_core(squared, cofactor)
+        result = np.empty(squared.shape[0] + cofactor.shape[0] - 1, dtype=np.float64)
+        _scalar_bernstein_product_1d_core(squared, cofactor, result)
     else:
         result = squared
 


### PR DESCRIPTION
## Context

The fourth module port of the dual-backend prototype, and the first slice of `pantr.bezier`.
`bezier` is roughly 7000 lines across three blocks with very different risk profiles, so it is
being ported in three PRs. This is block A, the arithmetic: everything that manipulates control
points without iterating and without solving. Root finding and interpolation follow separately.

It is also the first port whose whole surface can be **bit-for-bit identical** between the two
backends. `quad` could not claim that because Golub-Welsch and a companion-matrix eigensolver
are different algorithms; `change_basis` could not because a dense solve sits in the middle.
Here both sides evaluate the same expressions in the same order.

## Specification

Eight kernels ported, bound, and dispatched:

| kernel | reached from |
|---|---|
| `evaluate_bezier_1d` | `Bezier.evaluate` |
| `evaluate_bezier_deriv_1d` | `Bezier.evaluate_derivatives` |
| `degree_elevate_bezier_1d` | `Bezier.elevate_degree`, `minimize_degree` |
| `slice_bezier_1d` | `Bezier.slice` |
| `split_bezier_1d` | `Bezier.split` |
| `restrict_bezier_1d` | `Bezier.restrict` |
| `scalar_bernstein_product_1d` | `Bezier.compose` |
| `apply_reduction_operator` | `Bezier.reduce_degree`, `minimize_degree` |

Plus `core/binomial.hpp`, the exact-integer binomial recurrence both elevation and the product
need, which lives in `core/` so a later `bspline` port reuses one implementation rather than
growing a second.

Eight commits, one logical change each. The first is Python-only and lands before any C++.

## What was hard, and none of it is visible at float64

**The oracle does not use one accumulation width.** `_bezier_core.py` uses three across seven
kernels, none announced: the four de Casteljau kernels compute in `double` and round on the
store, the derivative kernel runs the entire A2.3 recursion at the point dtype, and elevation
and the product mix a `float64` coefficient table against a narrower destination. Accumulating
narrow where the oracle accumulates wide moves 125 of 630 `float32` values; widening where it
narrows is the same error the other way. This is now Rule 9 in `design/backend_parity.md`.

**One kernel seeds its two branches at different widths.** Above the mirror threshold the
evaluation recurrence raises `u`, the point array's own dtype; below it it raises `1 - u`, which
the literal `1.0` has already promoted to `float64`. Computing both in `double` is the natural
port and disagrees at degree 17 and `u = 0.75`, where `0.75^17 = 3^17 / 2^34` needs 27
significand bits. One value in 16224, found by a case list built to be adversarial about
representability rather than about magnitude.

**The `pow` seed is now load-bearing**, so it was stressed separately: 1 280 384 pairs over
degrees 1 to 64 across the whole mirrored range, zero differences between the platform `powf`
and numba's `np.power`. Observed rather than derived, as `bernstein.hpp` records for its own
seed.

## Acceptance

- [x] All eight kernels bit-for-bit identical to their Numba oracle, both dtypes, 519 parity
      cases through the public API.
- [x] Every kernel **mutation-verified**, one realistic mutation each: narrow accumulation (39
      failures), widened `ndu` recursion (9), narrow reduction accumulator (12), reassociated
      evaluation (12), `bezalfs` at the wrong width (22), flipped `restrict` branch (31),
      reassociated product (8).
- [x] C++ property tests that do not compare backends, so a bug the oracle shares is still
      catchable. The strongest evaluates at one half on integer control points against an exact
      `int64` binomial sum, two exact algorithms, up to degree 40.
- [x] Re-export guard pinning the public surface, the seven kernels, and by full path the two
      private symbols a downstream consumer was measured importing.
- [x] `scripts/ci_local.sh` 37/37, including both toolchains, both floor compilers and split mode.
- [x] Full suite 7087 passed under each backend, 82 doctests, docs built with `-W`.
- [x] ruff, ruff format, mypy (267 files), import-linter (2 contracts).

## Non-goals, and one real gap

**No parity bound is derived for a build that can fuse a multiply-add.** Unlike the Bernstein
tabulation these kernels contain `a * b + c * d` sites, so the exactness above is a property of
the build. Measured with `-march=native`: 125 of 630 `float64` de Casteljau values move and 237
of 970 for the reduction apply. `float32` barely moves in either, because the wide accumulator
absorbs the difference before the narrowing store. The parity tests **skip rather than weaken**
on such a build, and say so in the skip reason. Deriving the bound is a prerequisite for the ISA
ladder of `design/simd.md`, not for this port; Rule 7 is what licenses deferring it.

Also deliberately out of scope: the exact-rational assembly of the reduction operator, which
runs once per degree pair on the Python side and is exact because a `float64` normal-equation
solve for it loses eleven digits; `Bezier.multiply`, which goes through a numpy helper that no
kernel backs; and `bezier`'s root finding and interpolation blocks.

One thing the catalogue rules still do not settle, recorded rather than resolved: whether a
numpy helper that duplicates a dispatched kernel's mathematics should be dispatched, routed
through the kernel, or left alone. `Bezier.multiply` is that case, and the cost of leaving it
open is already visible: a parity test aimed at it exercised none of the ported code, which is
how it was noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
