### PR TITLE
Bound the Bézier parity claims on a build that can fuse a multiply-add

### DIFF
--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -34,7 +34,10 @@
 /// Every inner step here is `a * b + c * d` or `a * b`, so unlike the Bernstein
 /// tabulation there **are** sites for `-ffp-contract` to fuse. At the baseline
 /// target that is inert, since base `x86-64` has no FMA instruction; with
-/// `-march=native` it is not, and 125 of 630 `float64` de Casteljau values move.
+/// `-march=native` it is not, and 91 of 1260 de Casteljau values move. (An earlier
+/// version of this sentence said 125 of 630 `float64` values, which is the
+/// accumulation-width measurement from further up this file, at `float32`. Wrong
+/// number, wrong dtype and wrong cause.)
 /// This is the `__fp_contract__` runtime gate of design/build_findings.md, not a
 /// property of the code, and the parity tests read it rather than assuming it: they
 /// claim bitwise where the target ISA has no fused multiply-add and bounded where it

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -36,7 +36,10 @@
 /// target that is inert, since base `x86-64` has no FMA instruction; with
 /// `-march=native` it is not, and 125 of 630 `float64` de Casteljau values move.
 /// This is the `__fp_contract__` runtime gate of design/build_findings.md, not a
-/// property of the code, and the parity tests read it rather than assuming it.
+/// property of the code, and the parity tests read it rather than assuming it: they
+/// claim bitwise where the target ISA has no fused multiply-add and bounded where it
+/// has one. Rule 10 of design/backend_parity.md states the bound, and
+/// scripts/measure_bezier_fma_bound.py reproduces its slack.
 ///
 /// The one transcendental is `pow`, seeding the evaluation recurrence.
 /// `cpp/include/pantr/basis/bernstein.hpp` records the same open question and the

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -1,6 +1,6 @@
 # Backend parity: what a bound may claim, and in which frame
 
-**Status:** complete for the four ports that exist. Nine rules, each with the failure that produced
+**Status:** complete for the four ports that exist. Ten rules, each with the failure that produced
 it, and the remaining module ports inherit them. The verdict on whether the parity harness
 generalized is now written, from the `quad` port's tests rather than predicted before them.
 **Date:** 2026-08-20, amended the same day after a deep review closed two open proofs,
@@ -12,6 +12,9 @@ invented. Both are corrected in place rather than edited away. Amended again the
 the Bézier arithmetic port with Rule 9 (an oracle's accumulation width is a per-kernel fact),
 which is the first rule here that is about reproducing an oracle exactly rather than about
 bounding a difference, because that port is the first whose every kernel can be bit-exact.
+Amended 2026-08-22 with Rule 10 (contraction removes one rounding per fused site), which closes
+the gap Rule 9's section declared: the Bézier claims are now conditional on what the build can
+do rather than skipped where it can fuse.
 
 **Validated against:** `proto/cpp` at `765d9b9`, plus the `quad` port on `feat/cpp-quad`.
 
@@ -393,16 +396,106 @@ intermediate, and the narrowing store to `float32` then discards most of the dif
 knowing before the ISA ladder of `design/simd.md` lands, because it says the `float64` path is
 where a contraction bound will actually be needed.
 
-### What is NOT here, and it is a real gap
+### What was NOT here, and was a real gap -- closed 2026-08-22 by Rule 10
 
-**No parity bound is derived for a fusing build.** Unlike the Bernstein tabulation, every kernel
-in this module contains an `a * b + c * d` site. `tests/parity/test_bezier_arithmetic.py` skips
-rather than weakens when `__fp_contract__` reports a fused multiply-add is available, and says
-so in the skip reason. That is deliberate: a bound written for a branch no host in this project
-can execute would ship untested, and Rule 7 is what licenses deferring it. **It is a
-prerequisite for the ISA ladder, not for the port**, and it should be derived at the same time
-as the ladder rather than in advance of it.
+**No parity bound was derived for a fusing build.** Unlike the Bernstein tabulation, every
+kernel in this module contains an `a * b + c * d` site, and
+`tests/parity/test_bezier_arithmetic.py` skipped rather than weakened when `__fp_contract__`
+reported a fused multiply-add. **The reason given for deferring it was refuted**: it read "a
+bound written for a branch no host in this project can execute would ship untested", and
+`tests/parity/test_quad_gauss_legendre.py` had been deriving such a bound and probing it on this
+same non-fusing host since the `quad` port. Three lines of it. Rule 7 licenses conditioning a
+claim on the host; it does not license leaving the other branch unwritten.
 
+Rule 10 is that bound. The three tests that still skip do so for reasons the bound genuinely
+cannot cover -- a discrete verdict, a wrapped factorial, operands not observable from the public
+surface -- and each names its own.
+
+The `float32` asymmetry above survived the derivation and is now explained rather than observed:
+seven of the eight kernels contract in a `float64` accumulator, so only a straddled narrowing
+store carries a difference to a `float32` output.
+
+
+## Rule 10: contraction removes one rounding per fused site, and only the amplification differs
+
+Added by the Bézier arithmetic port's follow-up, which derived the bound Rule 9's section
+deferred. It is the answer to a question the four earlier ports could postpone: what does a
+parity claim say on a build whose target ISA has a fused multiply-add?
+
+**The budget is one line and it is the same for every kernel.** At a fused site the oracle
+computes `fl(a + fl(b*c))` and the C++ backend `fl(a + b*c)`. Writing the first as
+`(a + b*c(1 + d1))(1 + d2)` and the second as `(a + b*c)(1 + d3)` with every `|d| <= u`, the two
+differ by at most
+
+    |b*c| * u * (1 + u)  +  |a + b*c| * 2u,
+
+so **three accumulator roundings per stage**. Where the storage format is narrower than the
+accumulator, the two pre-store values can fall either side of a rounding boundary, and a straddle
+costs one ulp, so **two storage roundings per stage**. In the harness that is
+`Roundings(stages, 3, 2)`, which serves all eight kernels unchanged.
+
+**What differs per kernel is the amplification, and getting it from `max|c|` to something usable
+was the whole of the work.** `max|c|` is a correct magnitude for every convex kernel here and it
+is useless: on a net spanning twelve decades whose output cancels to order one, it bounds a
+`float32` de Casteljau by 25 against values of 0.75, and Rule 3 refuses that. Seven parity cases
+failed exactly that way, all `float32`, all at degree 25 or within 1e-8 of an endpoint.
+
+The fix is the one Rule 3's own failure message prescribes, and it is licensed here because these
+recurrences are convex: **run the same operation on `|c|` and use the result, elementwise.** Every
+weight is non-negative and they sum to one, so the absolute-value companion is exactly the
+magnitude reachable at each output element, and it is tight rather than merely valid. Two kernels
+are not convex and must not use it:
+
+| kernel | stages | amplification |
+|---|---|---|
+| `evaluate`, `slice`, `split` | `p` | the absolute-value companion |
+| `restrict` | `2p`, two passes | the absolute-value companion |
+| `degree_elevate` | `p + 1` | the absolute-value companion |
+| `scalar_bernstein_product` | `min(p,q) + 1` | `sum_i C(p,i)C(q,k-i)|a_i||b_{k-i}| / C(p+q,k)` |
+| reduction apply | `p + 1` | `|R| @ |c|`, since `R` has negative entries |
+| `evaluate_deriv` | `p + 1` | `p!/(p-k)! * 2^k * max|c|`, and the accumulator is the storage |
+
+The derivative amplification follows from `B^(k) = p!/(p-k)! sum_j (Delta^k c)_j B_{j,p-k}` with
+`||Delta^k||_inf <= 2^k`, and it is **attained**: driving the kernel with the identity net gives
+`max_s sum_j |B^(k)_{j,p}(s)| / (p!/(p-k)! 2^k) = 1.0000` for `k` up to 4 over nine degrees.
+
+### The premise the bound rests on, and it is not ours
+
+**The oracle never fuses.** That is not obvious: numba compiles for the host CPU, so on any
+machine with an FMA it could. It does not, because LLVM does not contract without `fastmath`, and
+no pantr kernel sets it. Verified discriminatingly rather than by observing a zero: on this host
+`a * b + c` compiles to no FMA under `fastmath=False` and to one under `fastmath=True`.
+
+That is a property of numba's defaults and could change under us, which would make the bound
+describe the wrong difference -- it assumes the extra rounding is always on the oracle's side.
+`test_the_oracle_does_not_contract_a_multiply_add` pins it.
+
+### What the enumeration cost, and why reading the source was not enough on its own
+
+Fourteen sites fuse. Reading the source predicted fourteen and the disassembly of a
+`-march=native` build found the same fourteen, which is the check being reported rather than a
+coincidence worth relying on next time. What reading alone would **not** have given is the
+*width* of each: seven of the eight kernels contract in a `float64` accumulator whatever the
+storage, so at `float32` only a straddled narrowing store carries the difference out, and they
+barely move. `evaluate_deriv` emits four storage-width FMAs and is the exception -- Rule 9
+reappearing, now on the bounded side.
+
+**Contraction is the only mechanism.** `-march=native` with `-ffp-contract=off` on top restores
+bit-identity exactly while the vectorisation stays, which separates the two the same way the
+`quad` port separated them.
+
+### Two build facts that will outlive this rule
+
+`-DCMAKE_CXX_FLAGS=-ffp-contract=off` **does nothing**: `PantrCompileOptions.cmake` adds
+`-ffp-contract=on` as a target option, which lands after `CMAKE_CXX_FLAGS` and wins. The first
+build made to isolate contraction was byte-identical to the fusing one and only
+`compile_commands.json` showed it.
+
+And **Eigen does not compile under `-march=native` with `PANTR_WERROR=ON`**: its AVX512
+`TrsmKernel.h` trips `-Wmaybe-uninitialized` in its own code. That is a decision waiting for the
+ISA ladder of `design/simd.md`, not for this rule.
+
+`scripts/measure_bezier_fma_bound.py` reproduces every figure above.
 
 ## The two corrections the infrastructure PR made, kept here because they generalize
 

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -446,18 +446,66 @@ weight is non-negative and they sum to one, so the absolute-value companion is e
 magnitude reachable at each output element, and it is tight rather than merely valid. Two kernels
 are not convex and must not use it:
 
-| kernel | stages | amplification |
-|---|---|---|
-| `evaluate`, `slice`, `split` | `p` | the absolute-value companion |
-| `restrict` | `2p`, two passes | the absolute-value companion |
-| `degree_elevate` | `p + 1` | the absolute-value companion |
-| `scalar_bernstein_product` | `min(p,q) + 1` | `sum_i C(p,i)C(q,k-i)|a_i||b_{k-i}| / C(p+q,k)` |
-| reduction apply | `p + 1` | `|R| @ |c|`, since `R` has negative entries |
-| `evaluate_deriv` | `p + 1` | `p!/(p-k)! * 2^k * max|c|`, and the accumulator is the storage |
+| kernel | stages | narrowing stores | amplification |
+|---|---|---|---|
+| `evaluate`, `slice`, `split` | `p` | one per stage | the absolute-value companion |
+| `restrict` | `2p`, two passes | one per stage | the absolute-value companion |
+| `degree_elevate` | `min(p, t) + 1` | one per stage | the absolute-value companion |
+| `scalar_bernstein_product` | `min(p,q) + 1` | one per stage | `sum_i C(p,i)C(q,k-i)|a_i||b_{k-i}| / C(p+q,k)` |
+| reduction apply | `p + 1` | **one in total** | `|R| @ |c|`, since `R` has negative entries |
+| `evaluate_deriv` | `2p + k + 2` | one per stage | the A2.3 majorant's row action, accumulator = storage |
 
-The derivative amplification follows from `B^(k) = p!/(p-k)! sum_j (Delta^k c)_j B_{j,p-k}` with
-`||Delta^k||_inf <= 2^k`, and it is **attained**: driving the kernel with the identity net gives
-`max_s sum_j |B^(k)_{j,p}(s)| / (p!/(p-k)! 2^k) = 1.0000` for `k` up to 4 over nine degrees.
+**Three of those six entries were wrong in the first version and a tolerance audit found them.**
+`degree_elevate`'s chain is `min(p, t) + 1` and not `p + 1`, because the accumulation into `out[i]`
+runs `j` from `max(0, i - t)` to `min(p, i)`; charging `p + 1` was 13x too loose at `p = 25`. The
+reduction apply accumulates into a `float64` local and narrows **once per output element**, outside
+the loop over the operator row, so charging a store per stage over-counted it by `p + 1`, measured
+up to 52x at `float32`. And a zero-stage claim -- degree 0, where every one of these kernels
+short-circuits -- was being clamped to one stage instead of being what it is, which is bitwise;
+`bounded_parity`'s own guard says so and the clamp was suppressing it.
+
+### Why the derivative kernel cannot use a companion, and what it uses instead
+
+The convex kernels get the absolute-value companion because their weights are non-negative and sum
+to one. **A2.3 differences, so it has no such companion**, and the first attempt at its
+amplification failed twice in instructive ways.
+
+`p!/(p-k)! * 2^k * max|c|` is correct, follows from
+`B^(k) = p!/(p-k)! sum_j (Delta^k c)_j B_{j,p-k}` with `||Delta^k||_inf <= 2^k`, and is **unusable**:
+it bounds the operator norm rather than the row, and applies the *input* maximum where the
+comparison happens per output element. On the parity suite's own parametrization that made 45 of
+280 non-zero `float32` values carry a tolerance at least as large as their own magnitude, worst
+case 1.6e5 times. Rule 3's guard did not fire, because it compares the largest tolerance against
+the largest magnitude and a flat amplification is sized for exactly that element. **That is Rule 6's
+failure committed inside Rule 10**: a scalar summary hiding an elementwise disagreement.
+
+Replacing it with the row action of the finished operator -- `sum_j |B^(k)_{j,p}(s_i)| |c_{j,r}|`,
+obtained by driving the kernel with the identity net -- fixed the vacuity and was then **exceeded by
+4.32x** at degree 17, orders 4 and 6, identically at both dtypes. The identical figure is the
+signature: a structural shortfall, not rounding. The finished row is not enough precisely because
+the recursion is not convex, so its partial sums can exceed what survives to the output, and no
+telescoping argument recovers them.
+
+What works is the **majorant of the recursion itself**: run A2.3 with every coefficient replaced by
+its modulus. For a linear recursion with signed coefficients that bounds every intermediate, by
+induction, and with the signs gone the partial sums are monotone so the final value majorises all of
+them. Two lines change from the oracle, both in the `a` table. Checked over 75563 (point, basis)
+entries: **0 violations, and a largest ratio of exactly 1.000000**, so it is attained rather than
+conservative.
+
+### The harness's factor of two is a margin here, not a derivation
+
+`absolute_tolerance` multiplies by `ONE_SIDED_TO_TWO_SIDED = 2`, whose docstring justifies it by
+"each backend sits within its own forward-error bound of the exact recurrence, so their difference
+is bounded by the sum of the two". **That justification does not apply to these claims.** The budget
+above is already a backend-to-backend *difference*, derived as one, not a one-sided forward error.
+The other parity files pass one-sided counts and say so.
+
+The factor stays, and its provenance for Rule 10 is restated rather than inherited: it is an
+acknowledged safety factor of two, covering the compiler's freedom in choosing which of two products
+to fuse at a site with both, and the re-rounding of operands that have already diverged. That second
+one is first order rather than second, because correctly rounded arithmetic on inputs one ulp apart
+does not track the gap.
 
 ### The premise the bound rests on, and it is not ours
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,8 +72,11 @@ user-facing, and the ports change what it affects.
 - **The Bézier parity claims now hold on a build that can fuse a multiply-add**, instead of
   being skipped there. Each claim is selected at run time: exact where the target ISA has no
   fused multiply-add, which is the shipped configuration, and bounded where it has one. The
-  bound charges three accumulator roundings and two storage roundings per stage of the
-  dependency chain, and differs between kernels only in the magnitude it multiplies. This
+  bound charges three accumulator roundings per stage of the dependency chain and two
+  more at each narrowing store, and differs between kernels only in the magnitude it
+  multiplies: the same operation run on the absolute values of the control net where
+  that operation is a convex combination, and the absolute row action of the operator
+  where it is not. This
   matters ahead of any build that raises the instruction-set baseline: before it, such a build
   would have turned every one of those assertions into a skip and left the suite green.
 - `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,15 @@ user-facing, and the ports change what it affects.
   computed by Newton on the Legendre recurrence rather than through `numpy.polynomial.leggauss`.
   Neither is a reimplementation for its own sake: both are the reference the C++ is checked
   against, and `leggauss` has no operation-for-operation transliteration.
+- **The Bézier parity claims now hold on a build that can fuse a multiply-add**, instead of
+  being skipped there. Each claim is selected at run time: exact where the target ISA has no
+  fused multiply-add, which is the shipped configuration, and bounded where it has one. The
+  bound charges three accumulator roundings and two storage roundings per stage of the
+  dependency chain, and differs between kernels only in the magnitude it multiplies. This
+  matters ahead of any build that raises the instruction-set baseline: before it, such a build
+  would have turned every one of those assertions into a skip and left the suite green.
+- `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever
+  extension is installed, and prints how to build one that fuses.
 
 ### Changed
 - `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue

--- a/scripts/measure_bezier_fma_bound.py
+++ b/scripts/measure_bezier_fma_bound.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+"""Reproduce the contraction bound of the Bézier kernels, and the slack it carries.
+
+The shipped build sets ``-ffp-contract=on`` and no ``-march``, so the target is
+baseline x86-64, which has no fused multiply-add and nothing to contract into. Every
+parity claim in ``tests/parity/test_bezier_arithmetic.py`` therefore takes its
+**bitwise** branch, and the **bounded** branch, which is the one this script is
+about, ships unevaluated.
+
+Run it against the shipped build and it reports zeros and says so. Run it against a
+build that fuses and it reports, per kernel and per dtype, how many values move and
+how much of the derived bound the worst one uses.
+
+    PYTHONPATH="$(pwd)/src:$(pwd)" .venv/bin/python scripts/measure_bezier_fma_bound.py
+
+Building one that fuses, and the two traps in doing so
+------------------------------------------------------
+
+**``-DCMAKE_CXX_FLAGS=-ffp-contract=off`` does nothing.** ``PantrCompileOptions.cmake``
+adds ``-ffp-contract=on`` as a target option, which lands *after* ``CMAKE_CXX_FLAGS``
+on the command line, and the last one wins. A build meant to isolate contraction from
+vectorisation has to append the flag some other way -- a compiler wrapper script is
+the shortest. Check ``compile_commands.json`` rather than trusting the cache.
+
+**Eigen does not compile under ``-march=native`` with ``PANTR_WERROR=ON``.** Its
+AVX512 ``TrsmKernel.h`` trips ``-Wmaybe-uninitialized`` in its own code. Measurement
+builds pass ``-DPANTR_WERROR=OFF``; the ISA ladder of ``design/simd.md`` will have to
+decide what the shipped build does about it.
+
+    cmake --preset gcc -B build/fma-native -DPANTR_BUILD_PYTHON=ON \
+        -DPANTR_BUILD_TESTS=OFF -DPANTR_BUILD_BENCHMARK=OFF -DPANTR_WERROR=OFF \
+        -DPython_EXECUTABLE="$(pwd)/.venv/bin/python" -DCMAKE_CXX_FLAGS=-march=native
+    cmake --build build/fma-native
+    cp build/fma-native/cpp/bindings/_pantr_cpp*.so \
+       .venv/lib/python3*/site-packages/pantr/
+
+Restore the shipped extension afterwards with ``pip install -e ".[dev]"``.
+
+What was measured when this was written
+---------------------------------------
+
+With ``-march=native`` on gcc 14.4, fourteen sites fuse and every one was predicted by
+reading the source first: two in ``evaluate`` (the two accumulation branches), five in
+``evaluate_deriv``, two in ``restrict`` (one per pass) and one each in
+``degree_elevate``, ``slice``, ``split``, ``scalar_bernstein_product`` and the
+reduction apply. The baseline build contains none, in the whole shared object.
+
+Contraction is the only mechanism: ``-march=native`` with contraction genuinely off
+restores bit-identity exactly, 0 of 1260 and 0 of 3616, while the vectorisation stays
+(191 packed instructions against 34). And the oracle never fuses -- numba targets this
+host's ISA and still emits no FMA without ``fastmath``, which
+``test_the_oracle_does_not_contract_a_multiply_add`` pins.
+
+Slack of the derived bounds, worst case over this sweep, on that build: 6.8x for the
+two de Casteljau kernels, 70x for ``evaluate``, and between those for the rest. At
+float32 only ``evaluate_deriv`` and ``restrict`` move at all -- the other six contract
+in a float64 accumulator and the narrowing store absorbs it -- so ``restrict``'s
+float32 slack reads 883x, which is the bound being honest about a straddle that almost
+never happens rather than the bound being wrong.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from math import comb, prod
+from typing import Any, Final
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._backend import Backend, available_backends, use_backend
+from pantr.bezier import _bezier_backend as backend
+from pantr.bezier._bezier_degree import _interpolating_reduction_operator
+from tests._parity_harness import (
+    absolute_tolerance,
+    build_provenance,
+    contraction_may_fuse,
+    unit_roundoff,
+)
+from tests.parity.test_bezier_arithmetic import (
+    _Budget,
+    _derivative_scale,
+    _fused_claim,
+    _mixed_control_points,
+    _net_magnitude,
+    _reduction_amplification,
+)
+
+DEGREES: Final = (1, 2, 3, 5, 8, 13, 17, 25, 34)
+"""Degrees swept. 34 is past anything pantr builds and is where the reduction operator
+grows enough for its amplification to matter."""
+
+PARAMS: Final = (0.0, 1e-8, 0.25, 0.5, 0.75, 1.0 - 1e-8, 1.0)
+"""Parameters swept, straddling the mirror threshold and both endpoints."""
+
+MAX_PRODUCT_DEGREE: Final = 56
+"""Largest sum of degrees the binomial table stays exact for.
+
+``core::kBincoeffExactDoubleMaxN``: past it ``C(n, k)`` no longer fits a double
+exactly, and the kernel's Layer 2 refuses the call rather than rounding it."""
+
+
+def _run_both(
+    fill: Callable[[Backend, npt.NDArray[Any]], None],
+    shape: tuple[int, ...],
+    dtype: npt.DTypeLike,
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any]]:
+    """Drive one kernel under each backend at its own entry point.
+
+    Args:
+        fill (Callable): Takes a backend and an output array, and fills it.
+        shape (tuple[int, ...]): Output shape.
+        dtype (npt.DTypeLike): Output dtype.
+
+    Returns:
+        tuple: The Numba result and the C++ result, in that order.
+    """
+    reference = np.zeros(shape, dtype=dtype)
+    actual = np.zeros(shape, dtype=dtype)
+    with use_backend(Backend.PYTHON):
+        fill(Backend.PYTHON, reference)
+    with use_backend(Backend.CPP):
+        fill(Backend.CPP, actual)
+    return reference, actual
+
+
+def _product_amplification(
+    left: npt.NDArray[Any], right: npt.NDArray[Any]
+) -> npt.NDArray[np.float64]:
+    """Convex amplification of the Bernstein product, per output coefficient.
+
+    Args:
+        left (npt.NDArray[Any]): First operand.
+        right (npt.NDArray[Any]): Second operand.
+
+    Returns:
+        npt.NDArray[np.float64]: The weighted sum of ``|a_i b_j|``.
+    """
+    p = left.size - 1
+    q = right.size - 1
+    total = p + q
+    return np.array(
+        [
+            sum(
+                comb(p, i) * comb(q, k - i) * abs(float(left[i])) * abs(float(right[k - i]))
+                for i in range(max(0, k - q), min(p, k) + 1)
+            )
+            / comb(total, k)
+            for k in range(total + 1)
+        ],
+        dtype=np.float64,
+    )
+
+
+def _cases(degree: int, dtype: npt.DTypeLike, rng: np.random.Generator) -> list[Any]:
+    """Build one case per kernel at one degree.
+
+    Args:
+        degree (int): The degree.
+        dtype (npt.DTypeLike): Storage format.
+        rng (np.random.Generator): Unused; the nets come from the test module's
+            deterministic generator so the figures match the suite's.
+
+    Returns:
+        list: Name, driver, shape, budget and accumulator, one entry per kernel.
+    """
+    del rng
+    ctrl = _mixed_control_points((degree + 1, 3), dtype)
+    points = np.ascontiguousarray(PARAMS, dtype=dtype)
+    magnitude = _net_magnitude(ctrl)
+    rank = 3
+
+    left = _mixed_control_points((degree + 1,), dtype, seed=20260822)
+    right = _mixed_control_points((min(degree, 8) + 1,), dtype, seed=20260823)
+    operator = _interpolating_reduction_operator(degree, 1)
+
+    cases = [
+        (
+            "evaluate",
+            lambda b, o: backend.evaluate_kernel(b)(ctrl, points, o),
+            (len(PARAMS), rank),
+            _Budget(degree, np.full((len(PARAMS), rank), magnitude, dtype=np.float64)),
+            np.float64,
+        ),
+        (
+            "evaluate_deriv",
+            lambda b, o: backend.evaluate_deriv_kernel(b)(ctrl, points, 2, o),
+            (len(PARAMS), 3, rank),
+            _Budget(
+                degree + 1,
+                np.stack(
+                    [
+                        np.full((len(PARAMS), rank), _derivative_scale(degree, k, magnitude))
+                        for k in range(3)
+                    ],
+                    axis=1,
+                ),
+            ),
+            dtype,
+        ),
+        (
+            "degree_elevate",
+            lambda b, o: backend.degree_kernels(b).elevate(degree, ctrl, 2, o),
+            (degree + 3, rank),
+            _Budget(degree + 1, np.full((degree + 3, rank), magnitude, dtype=np.float64)),
+            np.float64,
+        ),
+        (
+            "slice",
+            lambda b, o: backend.slice_kernel(b)(ctrl, 0.25, o),
+            (rank,),
+            _Budget(degree, np.full((rank,), magnitude, dtype=np.float64)),
+            np.float64,
+        ),
+        (
+            "split",
+            lambda b, o: backend.split_kernel(b)(ctrl, 0.25, o, np.zeros_like(o)),
+            (degree + 1, rank),
+            _Budget(degree, np.full((degree + 1, rank), magnitude, dtype=np.float64)),
+            np.float64,
+        ),
+        (
+            "restrict",
+            lambda b, o: backend.restrict_kernel(b)(ctrl, 0.1, 0.9, o),
+            (degree + 1, rank),
+            _Budget(2 * degree, np.full((degree + 1, rank), magnitude, dtype=np.float64)),
+            np.float64,
+        ),
+        (
+            "reduce_apply",
+            lambda b, o: backend.degree_kernels(b).reduce_apply(operator, ctrl, o),
+            (degree, rank),
+            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1)),
+            np.float64,
+        ),
+    ]
+    if left.size - 1 + right.size - 1 <= MAX_PRODUCT_DEGREE:
+        cases.append(
+            (
+                "scalar_product",
+                lambda b, o: backend.product_kernel(b)(left, right, o),
+                (left.size + right.size - 1,),
+                _Budget(min(left.size, right.size), _product_amplification(left, right)),
+                np.float64,
+            )
+        )
+    return cases
+
+
+def measure() -> dict[tuple[str, str], tuple[int, int, float]]:
+    """Measure movement and slack for every kernel at both dtypes.
+
+    Returns:
+        dict: Keyed by kernel and dtype name; values are elements moved, elements
+            compared, and the worst ratio of the observed difference to the bound.
+    """
+    results: dict[tuple[str, str], tuple[int, int, float]] = {}
+    for dtype in (np.float64, np.float32):
+        name = str(np.dtype(dtype).name)
+        rng = np.random.default_rng(20260822)
+        for degree in DEGREES:
+            for kernel, fill, shape, budget, accumulator in _cases(degree, dtype, rng):
+                reference, actual = _run_both(fill, shape, dtype)
+                claim = _fused_claim(
+                    fused_why=f"{kernel} at degree {degree}",
+                    budget=budget,
+                    storage=dtype,
+                    accumulator=accumulator,
+                )
+                tolerance = np.broadcast_to(absolute_tolerance(claim), np.shape(reference))
+                difference = np.abs(np.float64(actual) - np.float64(reference))
+                usable = np.isfinite(difference) & (tolerance > 0.0)
+                moved, seen, worst = results.get((kernel, name), (0, 0, 0.0))
+                moved += int((difference[usable] > 0.0).sum())
+                seen += int(usable.sum())
+                if usable.any():
+                    worst = max(worst, float((difference[usable] / tolerance[usable]).max()))
+                results[(kernel, name)] = (moved, seen, worst)
+    return results
+
+
+def derivative_amplification_is_sharp() -> float:
+    """Measure how much of the derivative amplification the basis actually reaches.
+
+    The order-``k`` block of the bound is ``p!/(p-k)! * 2^k * max|c|``, from
+    ``B^(k) = p!/(p-k)! sum_j (Delta^k c)_j B_{j,p-k}`` and ``||Delta^k||_inf <= 2``.
+    Driving the kernel with the identity net returns the basis derivatives themselves,
+    so ``max_s sum_j |B^(k)_{j,p}(s)|`` divided by that factor says how tight it is. A
+    value below 1 would mean the amplification is loose; above 1 would refute it.
+
+    Returns:
+        float: The largest ratio over the sweep. Measured 1.0000 when written.
+    """
+    sampled = np.linspace(0.0, 1.0, 401)
+    worst = 0.0
+    for degree in DEGREES:
+        orders = min(4, degree)
+        identity = np.ascontiguousarray(np.eye(degree + 1))
+        out = np.zeros((sampled.size, orders + 1, degree + 1))
+        with use_backend(Backend.PYTHON):
+            backend.evaluate_deriv_kernel(Backend.PYTHON)(
+                identity, np.ascontiguousarray(sampled), orders, out
+            )
+        for order in range(orders + 1):
+            falling = prod(range(degree - order + 1, degree + 1)) if order else 1
+            reached = float(np.abs(out[:, order, :]).sum(axis=1).max())
+            worst = max(worst, reached / (falling * 2.0**order))
+    return worst
+
+
+def main() -> int:
+    """Report the bound's slack against whatever extension is installed.
+
+    Returns:
+        int: 0 if every bound held, 1 if the C++ backend is missing or one was
+            exceeded.
+    """
+    if Backend.CPP not in available_backends():
+        print("the C++ backend is not built; nothing to compare")
+        return 1
+
+    provenance = build_provenance()
+    fusing = contraction_may_fuse()
+    print(f"compiler            {provenance.compiler}")
+    print(f"__fp_contract__     {provenance.fp_contract}")
+    print(f"unit roundoff       float64 {unit_roundoff(np.float64):.3e}")
+    print(f"                    float32 {unit_roundoff(np.float32):.3e}")
+    if not fusing:
+        print(
+            "\nThis build's target ISA has no fused multiply-add, so the suite takes its\n"
+            "bitwise branch and every count below will be zero. That is the expected\n"
+            "result here and not a measurement of the bound. Build with -march=native to\n"
+            "exercise it; the header of this file says how, and names the two traps."
+        )
+
+    print(f"\n{'kernel':<18}{'dtype':<10}{'moved':>8}{'seen':>8}{'worst/bound':>14}{'slack':>10}")
+    exceeded = False
+    for (kernel, dtype), (moved, seen, worst) in sorted(measure().items()):
+        slack = f"{1 / worst:8.1f}x" if worst > 0.0 else "     n/a"
+        print(f"{kernel:<18}{dtype:<10}{moved:>8}{seen:>8}{worst:>14.5f}{slack:>10}")
+        exceeded = exceeded or worst > 1.0
+
+    sharpness = derivative_amplification_is_sharp()
+    print(
+        f"\nderivative amplification, reached / derived: {sharpness:.4f}\n"
+        f"  1.0000 means the bound p!/(p-k)! * 2^k is attained rather than conservative."
+    )
+
+    if exceeded:
+        print("\nAt least one bound was EXCEEDED. The derivation is wrong, not the build.")
+    return 1 if exceeded else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_bezier_fma_bound.py
+++ b/scripts/measure_bezier_fma_bound.py
@@ -44,6 +44,9 @@ reading the source first: two in ``evaluate`` (the two accumulation branches), f
 ``evaluate_deriv``, two in ``restrict`` (one per pass) and one each in
 ``degree_elevate``, ``slice``, ``split``, ``scalar_bernstein_product`` and the
 reduction apply. The baseline build contains none, in the whole shared object.
+:func:`report_the_disassembly` re-derives all of that, and the packed-instruction
+counts beside it, rather than quoting them: a review found both had been written into
+permanent artifacts with nothing in the tree able to reproduce either.
 
 Contraction is the only mechanism: ``-march=native`` with contraction genuinely off
 restores bit-identity exactly, 0 of 1260 and 0 of 3616, while the vectorisation stays
@@ -52,24 +55,39 @@ host's ISA and still emits no FMA without ``fastmath``, which
 ``test_the_oracle_does_not_contract_a_multiply_add`` pins.
 
 Slack of the derived bounds, worst case over this sweep, on that build: 6.8x for the
-two de Casteljau kernels, 70x for ``evaluate``, and between those for the rest. At
-float32 only ``evaluate_deriv`` and ``restrict`` move at all -- the other six contract
-in a float64 accumulator and the narrowing store absorbs it -- so ``restrict``'s
-float32 slack reads 883x, which is the bound being honest about a straddle that almost
-never happens rather than the bound being wrong.
+two de Casteljau kernels, 14.5x for the product, 17.9x for elevation, 18.3x and 43.2x
+for the derivative, 26.2x for the reduction apply, 35.8x for ``restrict`` at float64
+and 70x for ``evaluate``. At float32 only ``evaluate_deriv`` and ``restrict`` move at
+all, because the other six contract in a float64 accumulator and the narrowing store
+absorbs it.
+
+**Two things the slack column does not tell you, and both were review findings.** It
+is ``1 / max(diff/tolerance)``, the *tightest* point in the array, so a block whose
+bound is orders of magnitude too loose can only lower that maximum and is structurally
+invisible here. And it is not a fixed safety factor: at float32 it is roughly
+``2 * stages * (amplification / |value|)``, so it grows with the degree by
+construction. ``restrict`` at float32 reads 883x for exactly that reason, one whole
+storage ulp charged at each of ``2p`` stages while a real run straddles a rounding
+boundary once or twice, and not because a straddle is rare in some fixed proportion.
 """
 
 from __future__ import annotations
 
+import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
-from math import comb, prod
+from math import comb
+from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
 import numpy.typing as npt
 
 from pantr._backend import Backend, available_backends, use_backend
+from pantr.bezier import Bezier
 from pantr.bezier import _bezier_backend as backend
 from pantr.bezier._bezier_degree import _interpolating_reduction_operator
 from tests._parity_harness import (
@@ -79,8 +97,9 @@ from tests._parity_harness import (
     unit_roundoff,
 )
 from tests.parity.test_bezier_arithmetic import (
+    _a23_absolute_rows,
     _Budget,
-    _derivative_scale,
+    _derivative_amplification,
     _fused_claim,
     _mixed_control_points,
     _net_magnitude,
@@ -188,14 +207,8 @@ def _cases(degree: int, dtype: npt.DTypeLike, rng: np.random.Generator) -> list[
             lambda b, o: backend.evaluate_deriv_kernel(b)(ctrl, points, 2, o),
             (len(PARAMS), 3, rank),
             _Budget(
-                degree + 1,
-                np.stack(
-                    [
-                        np.full((len(PARAMS), rank), _derivative_scale(degree, k, magnitude))
-                        for k in range(3)
-                    ],
-                    axis=1,
-                ),
+                2 * degree + 4,
+                np.stack([_derivative_amplification(ctrl, points, k) for k in range(3)], axis=1),
             ),
             dtype,
         ),
@@ -203,7 +216,7 @@ def _cases(degree: int, dtype: npt.DTypeLike, rng: np.random.Generator) -> list[
             "degree_elevate",
             lambda b, o: backend.degree_kernels(b).elevate(degree, ctrl, 2, o),
             (degree + 3, rank),
-            _Budget(degree + 1, np.full((degree + 3, rank), magnitude, dtype=np.float64)),
+            _Budget(min(degree, 2) + 1, np.full((degree + 3, rank), magnitude, dtype=np.float64)),
             np.float64,
         ),
         (
@@ -231,7 +244,7 @@ def _cases(degree: int, dtype: npt.DTypeLike, rng: np.random.Generator) -> list[
             "reduce_apply",
             lambda b, o: backend.degree_kernels(b).reduce_apply(operator, ctrl, o),
             (degree, rank),
-            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1)),
+            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1), narrowing_stores=1),
             np.float64,
         ),
     ]
@@ -280,33 +293,197 @@ def measure() -> dict[tuple[str, str], tuple[int, int, float]]:
     return results
 
 
-def derivative_amplification_is_sharp() -> float:
-    """Measure how much of the derivative amplification the basis actually reaches.
+_PROBE_SOURCE: Final = """
+// Instantiate every Bezier kernel at both widths behind a noinline wrapper, so a
+// disassembler can attribute each fused multiply-add to one kernel and one line.
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/core/reduction_operator.hpp"
+using pantr::span2d;
+using pantr::span_nd;
+#define K __attribute__((noinline))
+template <class T> K void k1(span2d<const T> c, std::span<const T> p, span2d<T> o) {
+    pantr::evaluate_bezier_1d<T>(c, p, o); }
+template <class T> K void k2(span2d<const T> c, std::span<const T> p, int n, span_nd<T,3> o) {
+    pantr::evaluate_bezier_deriv_1d<T>(c, p, n, o); }
+template <class T> K void k3(int d, span2d<const T> c, int t, span2d<T> o) {
+    pantr::degree_elevate_bezier_1d<T>(d, c, t, o); }
+template <class T> K void k4(span2d<const T> c, pantr::accumulator_t<T> v, std::span<T> o) {
+    pantr::slice_bezier_1d<T>(c, v, o); }
+template <class T> K void k5(span2d<const T> c, pantr::accumulator_t<T> v, span2d<T> l,
+                             span2d<T> r) { pantr::split_bezier_1d<T>(c, v, l, r); }
+template <class T> K void k6(span2d<const T> c, pantr::accumulator_t<T> a,
+                             pantr::accumulator_t<T> b, span2d<T> o) {
+    pantr::restrict_bezier_1d<T>(c, a, b, o); }
+template <class T> K void k7(std::span<const T> a, std::span<const T> b, std::span<T> o) {
+    pantr::scalar_bernstein_product_1d<T>(a, b, o); }
+template <class T> K void k8(span2d<const double> op, span2d<const T> c, span2d<T> o) {
+    pantr::core::apply_reduction_operator<T>(op, c, o); }
+#define INST(T) \\
+  template void k1<T>(span2d<const T>, std::span<const T>, span2d<T>); \\
+  template void k2<T>(span2d<const T>, std::span<const T>, int, span_nd<T,3>); \\
+  template void k3<T>(int, span2d<const T>, int, span2d<T>); \\
+  template void k4<T>(span2d<const T>, double, std::span<T>); \\
+  template void k5<T>(span2d<const T>, double, span2d<T>, span2d<T>); \\
+  template void k6<T>(span2d<const T>, double, double, span2d<T>); \\
+  template void k7<T>(std::span<const T>, std::span<const T>, std::span<T>); \\
+  template void k8<T>(span2d<const double>, span2d<const T>, span2d<T>);
+INST(float)
+INST(double)
+"""
+"""A translation unit that instantiates all eight kernels, for the disassembly."""
 
-    The order-``k`` block of the bound is ``p!/(p-k)! * 2^k * max|c|``, from
-    ``B^(k) = p!/(p-k)! sum_j (Delta^k c)_j B_{j,p-k}`` and ``||Delta^k||_inf <= 2``.
-    Driving the kernel with the identity net returns the basis derivatives themselves,
-    so ``max_s sum_j |B^(k)_{j,p}(s)|`` divided by that factor says how tight it is. A
-    value below 1 would mean the amplification is loose; above 1 would refute it.
+_FUSED_MNEMONIC: Final = re.compile(r"\bvf(n?)m(add|sub)[a-z0-9]*\b")
+"""x86 fused multiply-add mnemonics, in all their add/subtract/negate spellings."""
+
+_PACKED_ARITHMETIC: Final = re.compile(r"\bv(add|sub|mul|fmadd|fnmadd)[a-z]*p[sd]\b")
+"""Packed floating-point arithmetic, which is how vectorisation shows up.
+
+Named explicitly because a count of "SIMD instructions" is meaningless without it:
+a broader pattern that also caught moves and shuffles gives a number twice as large
+and says nothing about whether the arithmetic was vectorised.
+"""
+
+
+def enumerate_fused_sites(extra_flags: list[str]) -> dict[tuple[str, int], int] | None:
+    """Compile the probe and count fused multiply-adds per source line.
+
+    This is the artifact behind "fourteen sites fuse". A review found that claim, and
+    the packed-instruction counts beside it, quoted from a scratch directory with
+    nothing in the tree to re-derive them -- the same failure Rule 9 of
+    design/backend_parity.md records against itself.
+
+    Args:
+        extra_flags (list[str]): Compiler flags to add, e.g. ``["-march=native"]``.
 
     Returns:
-        float: The largest ratio over the sweep. Measured 1.0000 when written.
+        dict[tuple[str, int], int] | None: Fused instruction count per (file, line),
+            or None if the toolchain is not available.
     """
-    sampled = np.linspace(0.0, 1.0, 401)
+    root = Path(__file__).resolve().parent.parent
+    mdspan = root / "build" / "gcc" / "_deps" / "mdspan-src" / "include"
+    if not shutil.which("g++") or not shutil.which("objdump") or not mdspan.is_dir():
+        return None
+
+    with tempfile.TemporaryDirectory() as scratch:
+        source = Path(scratch) / "probe.cpp"
+        obj = Path(scratch) / "probe.o"
+        source.write_text(_PROBE_SOURCE)
+        compile_command = [
+            "g++", "-std=c++20", "-O3", "-g", "-ffp-contract=on",
+            f"-I{root / 'cpp' / 'include'}", f"-I{mdspan}",
+            *extra_flags, "-c", str(source), "-o", str(obj),
+        ]  # fmt: skip
+        if subprocess.run(compile_command, capture_output=True, check=False).returncode:
+            return None
+        listing = subprocess.run(
+            ["objdump", "-dl", "-C", "--no-show-raw-insn", str(obj)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+    sites: dict[tuple[str, int], int] = {}
+    location: tuple[str, int] | None = None
+    for line in listing.splitlines():
+        source_line = re.match(r"^(/\S+):(\d+)", line)
+        if source_line:
+            location = (Path(source_line.group(1)).name, int(source_line.group(2)))
+            continue
+        mnemonic = re.match(r"^\s+[0-9a-f]+:\s+(\S+)", line)
+        if mnemonic and _FUSED_MNEMONIC.match(mnemonic.group(1)) and location is not None:
+            sites[location] = sites.get(location, 0) + 1
+    return sites
+
+
+def count_packed_arithmetic(extra_flags: list[str]) -> int | None:
+    """Count packed floating-point arithmetic instructions in the probe.
+
+    Used to separate vectorisation from contraction: turning contraction off must not
+    turn vectorisation off, or the isolation argument compares two different things.
+
+    Args:
+        extra_flags (list[str]): Compiler flags to add.
+
+    Returns:
+        int | None: The count, or None if the toolchain is not available.
+    """
+    root = Path(__file__).resolve().parent.parent
+    mdspan = root / "build" / "gcc" / "_deps" / "mdspan-src" / "include"
+    if not shutil.which("g++") or not shutil.which("objdump") or not mdspan.is_dir():
+        return None
+    with tempfile.TemporaryDirectory() as scratch:
+        source = Path(scratch) / "probe.cpp"
+        obj = Path(scratch) / "probe.o"
+        source.write_text(_PROBE_SOURCE)
+        command = [
+            "g++", "-std=c++20", "-O3", "-ffp-contract=on",
+            f"-I{root / 'cpp' / 'include'}", f"-I{mdspan}",
+            *extra_flags, "-c", str(source), "-o", str(obj),
+        ]  # fmt: skip
+        if subprocess.run(command, capture_output=True, check=False).returncode:
+            return None
+        listing = subprocess.run(
+            ["objdump", "-d", str(obj)], capture_output=True, text=True, check=True
+        ).stdout
+    return len(_PACKED_ARITHMETIC.findall(listing))
+
+
+def report_the_disassembly() -> None:
+    """Print the fused-site enumeration and the vectorisation counts."""
+    baseline = enumerate_fused_sites([])
+    fusing = enumerate_fused_sites(["-march=native"])
+    unfused = enumerate_fused_sites(["-march=native", "-ffp-contract=off"])
+    if baseline is None or fusing is None or unfused is None:
+        print("\nno g++/objdump or no fetched mdspan, so the disassembly is not reported")
+        return
+
+    print(f"\nfused sites, baseline target       {sum(baseline.values()):>6}")
+    print(f"fused sites, -march=native         {len(fusing):>6} distinct source lines")
+    print(f"fused sites, and contraction off   {sum(unfused.values()):>6}")
+    for (name, line), count in sorted(fusing.items()):
+        print(f"    {name}:{line:<5} x{count}")
+
+    packed_on = count_packed_arithmetic(["-march=native"])
+    packed_off = count_packed_arithmetic(["-march=native", "-ffp-contract=off"])
+    print(
+        f"\npacked FP arithmetic, -march=native: {packed_on} with contraction, "
+        f"{packed_off} without.\n"
+        f"  Both non-zero, which is the point: turning contraction off leaves the "
+        f"vectorisation\n  in place, so the bit-identity it restores isolates "
+        f"contraction and nothing else.\n"
+        f"  The second number is the larger because each fused instruction becomes two."
+    )
+
+
+def the_a23_majorant_holds() -> tuple[int, int, float]:
+    """Check that the A2.3 majorant bounds the signed basis derivatives it replaces.
+
+    ``tests.parity.test_bezier_arithmetic._a23_absolute_rows`` runs A2.3 with every
+    coefficient replaced by its modulus, which is the standard majorant for a linear
+    recursion with signed coefficients. This is the check that it is one: a violation
+    would mean the derivative kernel's amplification is unsound, and a maximum ratio
+    far below 1 would mean it is loose.
+
+    Returns:
+        tuple[int, int, float]: Entries checked, violations, and the largest ratio of
+            the signed value to its majorant. Measured 0 violations and 1.000000 when
+            written, so the majorant is attained rather than conservative.
+    """
+    sampled = np.linspace(0.0, 1.0, 97)
+    checked = violations = 0
     worst = 0.0
     for degree in DEGREES:
-        orders = min(4, degree)
         identity = np.ascontiguousarray(np.eye(degree + 1))
-        out = np.zeros((sampled.size, orders + 1, degree + 1))
-        with use_backend(Backend.PYTHON):
-            backend.evaluate_deriv_kernel(Backend.PYTHON)(
-                identity, np.ascontiguousarray(sampled), orders, out
-            )
-        for order in range(orders + 1):
-            falling = prod(range(degree - order + 1, degree + 1)) if order else 1
-            reached = float(np.abs(out[:, order, :]).sum(axis=1).max())
-            worst = max(worst, reached / (falling * 2.0**order))
-    return worst
+        for order in range(min(degree, 6) + 1):
+            majorant = _a23_absolute_rows(degree, sampled, order)
+            with use_backend(Backend.PYTHON):
+                driven = Bezier(identity).evaluate_derivatives(sampled, order)
+            signed = np.abs(np.asarray(driven).reshape(sampled.size, degree + 1))
+            checked += signed.size
+            violations += int((signed > majorant * (1.0 + 1e-12)).sum())
+            live = majorant > 0.0
+            worst = max(worst, float(np.max(signed[live] / majorant[live])))
+    return checked, violations, worst
 
 
 def main() -> int:
@@ -341,11 +518,18 @@ def main() -> int:
         print(f"{kernel:<18}{dtype:<10}{moved:>8}{seen:>8}{worst:>14.5f}{slack:>10}")
         exceeded = exceeded or worst > 1.0
 
-    sharpness = derivative_amplification_is_sharp()
+    checked, violations, worst_ratio = the_a23_majorant_holds()
     print(
-        f"\nderivative amplification, reached / derived: {sharpness:.4f}\n"
-        f"  1.0000 means the bound p!/(p-k)! * 2^k is attained rather than conservative."
+        f"\nA2.3 majorant: {violations} violations over {checked} (point, basis) entries, "
+        f"largest |signed| / majorant {worst_ratio:.6f}\n"
+        f"  Must be at most 1. Exactly 1 means the majorant is attained rather than "
+        f"conservative;\n  a violation would mean the derivative kernel's amplification "
+        f"is unsound."
     )
+    if violations:
+        exceeded = True
+
+    report_the_disassembly()
 
     if exceeded:
         print("\nAt least one bound was EXCEEDED. The derivation is wrong, not the build.")

--- a/scripts/measure_bezier_parity.py
+++ b/scripts/measure_bezier_parity.py
@@ -234,7 +234,7 @@ def measure_de_casteljau() -> tuple[int, int]:
 def measure_every_kernel() -> tuple[int, int]:
     """Count values and bit differences across all seven arithmetic kernels.
 
-    The sweep behind the "16224 values" figure. Each kernel is driven through the
+    The sweep behind the "3616 values" figure. Each kernel is driven through the
     public :class:`~pantr.bezier.Bezier` surface, so what is compared is what a
     caller gets rather than what a binding returns.
 

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -48,28 +48,46 @@ wants the grid rather than a green tick. It exists because an earlier version of
 file quoted numbers whose only artifact was a scratch directory that no longer
 exists.
 
-What this file does NOT cover, and it is a real gap
----------------------------------------------------
+A build that can fuse, and why the claims are conditional
+---------------------------------------------------------
 
 Unlike the Bernstein tabulation, these kernels contain ``a * b + c * d`` sites, so
-``-ffp-contract`` has something to fuse and the exactness above is a property of
-the **build**, not of the code. Measured with ``-march=native``: 125 of 630 float64
-de Casteljau values move, and 237 of 970 for the reduction-operator apply. None of
-the float32 ones do, in either kernel, because the wide accumulator absorbs the
-difference before the narrowing store.
+``-ffp-contract`` has something to fuse and the exactness above is a property of the
+**build**, not of the code. Each claim below is therefore selected at run time:
+bitwise where the target ISA has no fused multiply-add, bounded where it has one.
+Rule 7 of design/backend_parity.md is what licenses that shape, and Rule 10 states
+the bound.
 
-**No bound is derived here for a fusing build.** The tests skip rather than weaken,
-and the skip is the honest report: a bound written for a branch no host in this
-project can execute would ship untested, which is how a wrong bound gets believed.
-Deriving it is a prerequisite for the ISA ladder of design/simd.md, not for this
-port, and Rule 7 of design/backend_parity.md is the reason it can be deferred at
-all: a bound is a property of the code and whether it is approached is a property
-of the host.
+The bound is one budget for all eight kernels and eight different amplifications.
+At a fused site the oracle computes ``fl(a + fl(b*c))`` and this backend
+``fl(a + b*c)``, so the two differ by at most ``u|b*c| + 2u|a + b*c|``: three
+accumulator roundings per stage. Where the storage is narrower the two pre-store
+values can fall either side of a rounding boundary, which costs one further ulp, so
+two storage roundings per stage. What differs per kernel is the stage count and the
+magnitude the relative budget multiplies, and those are what the ``_amplification``
+helpers below carry.
+
+Fourteen sites fuse, and they were enumerated by disassembling a ``-march=native``
+build rather than by reading the source: two in ``evaluate``, five in
+``evaluate_deriv``, two in ``restrict`` and one each in the other five kernels.
+``scripts/measure_bezier_fma_bound.py`` reproduces that enumeration, the movement
+counts, and the slack each bound carries.
+
+Three tests still skip on a fusing build, each for a reason the bound cannot cover:
+``minimize_degree`` because its verdict is a **discrete** degree rather than a
+coefficient, so no tolerance saves a flipped decision; the factorial-overflow test
+because a wrapped falling factorial no longer describes the quantity the
+amplification is derived from; and ``compose`` because the product kernel's operands
+are formed inside the composition and are not observable from the public surface, so
+no tight amplification can be built for them. The last is covered instead by a test
+that drives the product kernel at its own entry point, where the operands are known.
 """
 
 from __future__ import annotations
 
-from typing import Final
+from collections.abc import Callable
+from math import comb, prod
+from typing import Any, Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
@@ -77,12 +95,20 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.bezier import Bezier
+from pantr.bezier._bezier_degree import _interpolating_reduction_operator
 from tests._parity_harness import (
+    ParityClaim,
+    Roundings,
+    absolute_tolerance,
     assert_parity,
     bitwise_parity,
+    bounded_parity,
     contraction_may_fuse,
     demand_the_compiled_kernel,
 )
+
+_TINY: Final = float(np.finfo(np.float64).tiny)
+"""Smallest positive double, used so an amplification is never exactly zero."""
 
 DTYPES: Final = (np.float64, np.float32)
 """The two storage formats the Bézier layer accepts."""
@@ -126,23 +152,361 @@ _REDUCTION_WHY = (
     "write. No fused multiply-add on this build"
 )
 
-_NO_BOUND_FOR_A_FUSING_BUILD = (
-    "this build can fuse a multiply-add, and no parity bound has been derived for "
-    "the Bezier kernels in that regime. Measured with -march=native: 125 of 630 "
-    "float64 de Casteljau values move and 237 of 970 for the reduction apply. "
-    "Deriving the bound is a prerequisite for the ISA ladder of design/simd.md; see "
-    "this file's docstring."
+_ACCUMULATOR_ROUNDINGS_PER_STAGE: Final = 3
+"""Accumulator roundings by which the two backends may differ, per stage.
+
+At a fused site the oracle evaluates ``fl(a + fl(b*c))`` and this backend
+``fl(a + b*c)``. Writing the first as ``(a + b*c(1 + d1))(1 + d2)`` and the second as
+``(a + b*c)(1 + d3)`` with every ``|d| <= u``, their difference is
+
+    ``|b*c| * u * (1 + u)  +  |a + b*c| * 2u``,
+
+so three roundings' worth, of which the first is charged against the **product** and
+the last two against the stage's own value. Both are folded into one count because
+``amplification`` carries a magnitude that dominates each: for every kernel here the
+amplification bounds the partial sums, hence the products, as well as the result.
+"""
+
+_STORAGE_ROUNDINGS_PER_STAGE: Final = 2
+"""Storage roundings by which the two backends may differ, per stage.
+
+Two values differing by less than one ulp of the storage format usually round to the
+same stored value and occasionally straddle a boundary and do not. A straddle costs
+one ulp, which is ``2u`` in the harness's unit-roundoff convention. The harness
+charges this at zero when the storage format is the accumulator's own, which is why
+one budget serves both dtypes.
+
+This term is what the float32 measurements are about: for seven of the eight kernels
+the fusion happens in a float64 accumulator and only a straddle can carry it to the
+output, so float32 barely moves. ``evaluate_deriv`` is the exception and contracts at
+storage width, which is Rule 9 of design/backend_parity.md reappearing.
+"""
+
+_FUSED_PREFIX: Final = (
+    "this build can fuse a multiply-add, so the two backends commit different numbers "
+    "of roundings at the fused sites. Isolated to contraction and nothing else: "
+    "rebuilt with -march=native, 91 of 1260 de Casteljau values and 472 of 3616 "
+    "whole-kernel values move, and -ffp-contract=off on top of the same -march "
+    "restores bit-identity exactly. The oracle never fuses: numba targets this host's "
+    "ISA and emits no FMA without fastmath, which no pantr kernel sets. "
+)
+
+_DISCRETE_VERDICT: Final = (
+    "this build can fuse, and the quantity under test is a discrete degree rather "
+    "than a coefficient, so no tolerance covers a flipped decision. The greedy search "
+    "accepts or rejects each trial by comparing a round-trip error against a "
+    "tolerance; a contraction difference can move that comparison and change the "
+    "resulting degree by one, which is not a bounded disagreement."
+)
+
+_WRAPPED_FACTORIAL: Final = (
+    "this build can fuse, and the falling factorial has wrapped, so the amplification "
+    "the bound is derived from -- p!/(p-k)! -- no longer describes the quantity the "
+    "kernel computes. Both backends wrap identically on a non-fusing build, which is "
+    "what this test exists to pin; bounding the fused case would need an "
+    "amplification derived from the wrapped value, which is not a magnitude of "
+    "anything."
+)
+
+_OPERANDS_NOT_OBSERVABLE: Final = (
+    "this build can fuse, and the product kernel's operands are formed inside "
+    "compose, so no tight amplification can be built from the public surface: the "
+    "only bound available from outside is max|outer| * (1 + 2 max|inner|)^p, which is "
+    "1e18 at the degrees swept here and would accept anything. "
+    "test_the_product_kernel_is_bounded_under_contraction covers the same kernel at "
+    "its own entry point, where the operands are known and the amplification is the "
+    "exact convex sum."
 )
 
 
-def demand_a_non_fusing_build() -> None:
-    """Skip when the build can fuse, since no bound covers that case yet.
+_DE_CASTELJAU_FUSED_WHY: Final = (
+    "every stage is a convex combination (1-t)a + tb with t in [0, 1], so a "
+    "divergence introduced at one stage passes through the remaining ones without "
+    "growing in the max norm and the per-stage injections merely add. max|c| bounds "
+    "the whole triangle, and it is the right magnitude rather than |result|: the "
+    "triangle can cancel to near zero while the error that reached it does not"
+)
+
+
+def demand_a_bound_the_claim_can_carry(reason: str) -> None:
+    """Skip on a fusing build where the derived bound does not describe the quantity.
+
+    Three tests reach this and each names its own reason. Everything else states a
+    bounded claim instead of skipping.
+
+    Args:
+        reason (str): Why a bound cannot be formed for this quantity.
 
     Raises:
-        Skipped: Always, on a build whose target ISA offers a fused multiply-add.
+        Skipped: On a build whose target ISA offers a fused multiply-add.
     """
     if contraction_may_fuse():
-        pytest.skip(_NO_BOUND_FOR_A_FUSING_BUILD)
+        pytest.skip(reason)
+
+
+def _net_magnitude(*arrays: npt.NDArray[Any]) -> float:
+    """Return the largest absolute entry across some control nets.
+
+    Every kernel whose stages are convex combinations amplifies a perturbation by at
+    most this, because a convex combination of entries is bounded by the largest of
+    them and so is every partial sum along the way.
+
+    Args:
+        *arrays (npt.NDArray[Any]): The nets.
+
+    Returns:
+        float: The largest absolute entry, or the smallest positive double if every
+            entry is zero, so that a tolerance is never identically zero.
+    """
+    largest = max((float(np.max(np.abs(np.float64(a)))) for a in arrays if a.size), default=0.0)
+    return largest if largest > 0.0 else float(np.finfo(np.float64).tiny)
+
+
+class _Budget(NamedTuple):
+    """The two things that differ from kernel to kernel in the fused claim.
+
+    Attributes:
+        stages (int): Length of the dependency chain the fused sites sit on.
+        amplification (npt.NDArray[np.float64]): Elementwise magnitude the relative
+            budget multiplies, matching the compared arrays' shape.
+    """
+
+    stages: int
+    amplification: npt.NDArray[np.float64]
+
+
+def _sliced_control_points(
+    ctrl: npt.NDArray[Any], value: float
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Slice a net and return the coefficients, whatever ``slice`` chose to return.
+
+    :meth:`Bezier.slice` returns a bare array for a univariate Bézier and a
+    :class:`Bezier` otherwise, so a caller that only wants the numbers has to branch.
+
+    Args:
+        ctrl (npt.NDArray[Any]): The control net.
+        value (float): Parameter to slice at.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The sliced coefficients.
+    """
+    sliced = Bezier(ctrl).slice(0, value)
+    return np.asarray(getattr(sliced, "control_points", sliced))
+
+
+def _split_half(value: float, half: int) -> Callable[[npt.NDArray[np.float64]], npt.NDArray[Any]]:
+    """Return a driver that splits a net and hands back one of the two halves.
+
+    A named factory rather than a lambda with a default argument, because the latter
+    is what the loop over the two halves would otherwise need and mypy cannot infer
+    its type.
+
+    Args:
+        value (float): Parameter to split at.
+        half (int): 0 for the left half, 1 for the right.
+
+    Returns:
+        Callable: Takes a float64 net and returns that half's coefficients.
+    """
+
+    def build(net: npt.NDArray[np.float64]) -> npt.NDArray[Any]:
+        return np.asarray(Bezier(net).split(0, value)[half].control_points)
+
+    return build
+
+
+def _absolute_companion(
+    build: Callable[[npt.NDArray[np.float64]], npt.NDArray[Any]], ctrl: npt.NDArray[Any]
+) -> npt.NDArray[np.float64]:
+    """Bound each output element by running the same operation on ``|c|``.
+
+    The tight amplification for a recurrence whose weights are non-negative and sum
+    to one: the magnitude reachable at output element ``i`` is exactly what the
+    operation produces from the absolute values of the net, because every weight
+    passes through the absolute value unchanged. It is what the harness's own
+    vacuity message prescribes, and it is licensed here and **only** here -- the same
+    trick applied to an oscillatory recurrence diverges, which is why
+    ``evaluate_deriv`` and ``reduce_degree`` derive their amplification instead.
+
+    ``max|c|`` was the first thing tried and it is correct but useless: on a net
+    spanning twelve decades whose output cancels to order one, it bounds a float32
+    de Casteljau by 25 against values of 0.75, and the harness refuses that as a
+    bound satisfied by any result. Seven cases failed that way, all float32, all at
+    degree 25 or at a parameter within 1e-8 of an endpoint.
+
+    Args:
+        build (Callable): Runs the operation on a float64 net and returns the result.
+        ctrl (npt.NDArray[Any]): The control net.
+
+    Returns:
+        npt.NDArray[np.float64]: Elementwise magnitude bound, never exactly zero.
+    """
+    with use_backend(Backend.PYTHON):
+        companion = np.abs(np.asarray(build(np.abs(np.asarray(ctrl, dtype=np.float64)))))
+    return np.asarray(np.maximum(companion, _TINY), dtype=np.float64)
+
+
+def _parity_claim(
+    *,
+    bitwise_why: str,
+    fused_why: str,
+    budget: _Budget,
+    storage: npt.DTypeLike,
+    accumulator: npt.DTypeLike = np.float64,
+) -> ParityClaim:
+    """State the parity claim for one kernel, conditioned on what the build can do.
+
+    Bitwise where the target ISA has no fused multiply-add, which is the shipped
+    configuration; bounded where it has one. Copied in shape from
+    ``tests/parity/test_basis_cardinal_bspline.py``, which is the precedent for a
+    selector, and from ``tests/parity/test_quad_gauss_legendre.py``, which is the
+    precedent for the bounded half being probed on a host that cannot reach it.
+
+    Args:
+        bitwise_why (str): Justification for the exact claim.
+        fused_why (str): What the stage count and amplification are, for the bounded
+            claim. Prefixed with the shared contraction argument.
+        budget (_Budget): This kernel's stage count and amplification.
+        storage (npt.DTypeLike): Format the output array holds.
+        accumulator (npt.DTypeLike): Format intermediates accumulate in. float64 for
+            every kernel but ``evaluate_deriv``, which accumulates at storage width.
+
+    Returns:
+        ParityClaim: BITWISE or BOUNDED, whichever this build supports.
+    """
+    if not contraction_may_fuse():
+        return bitwise_parity(why=bitwise_why)
+    return _fused_claim(
+        fused_why=fused_why, budget=budget, storage=storage, accumulator=accumulator
+    )
+
+
+def _fused_claim(
+    *,
+    fused_why: str,
+    budget: _Budget,
+    storage: npt.DTypeLike,
+    accumulator: npt.DTypeLike = np.float64,
+) -> ParityClaim:
+    """Build the bounded claim unconditionally, whatever this build can do.
+
+    Split out from :func:`_parity_claim` so the probes below can exercise the branch
+    no host in this project reaches. That is the whole reason the quad port's fused
+    claims survived review: a bound only this file's author has ever evaluated is a
+    bound nobody has checked.
+
+    Args:
+        fused_why (str): What the stage count and amplification are.
+        budget (_Budget): This kernel's stage count and amplification.
+        storage (npt.DTypeLike): Format the output array holds.
+        accumulator (npt.DTypeLike): Format intermediates accumulate in.
+
+    Returns:
+        ParityClaim: The BOUNDED claim.
+    """
+    return bounded_parity(
+        roundings=Roundings(
+            stages=max(budget.stages, 1),
+            accumulator_per_stage=_ACCUMULATOR_ROUNDINGS_PER_STAGE,
+            storage_per_stage=_STORAGE_ROUNDINGS_PER_STAGE,
+        ),
+        accumulator=accumulator,
+        storage=storage,
+        amplification=budget.amplification,
+        why=f"{_FUSED_PREFIX}{fused_why}",
+    )
+
+
+def _flat_amplification(shape: tuple[int, ...], magnitude: float) -> npt.NDArray[np.float64]:
+    """Spread one magnitude over an output's shape.
+
+    Args:
+        shape (tuple[int, ...]): Shape of the compared arrays.
+        magnitude (float): The magnitude.
+
+    Returns:
+        npt.NDArray[np.float64]: A full array, since the harness reports the worst
+            element and wants an amplification it can index alongside the values.
+    """
+    return np.full(shape, magnitude, dtype=np.float64)
+
+
+def _derivative_scale(degree: int, order: int, magnitude: float) -> float:
+    """Amplification of the derivative kernel at one derivative order.
+
+    See :func:`_derivative_amplification` for the derivation; this is the scalar it
+    is built from, and the public API returns one order at a time rather than the
+    kernel's stack.
+
+    Args:
+        degree (int): Degree of the curve.
+        order (int): Derivative order.
+        magnitude (float): ``max|c|``.
+
+    Returns:
+        float: The amplification, never zero so that a tolerance never vanishes.
+    """
+    if degree < order:
+        return float(np.finfo(np.float64).tiny)
+    falling = prod(range(degree - order + 1, degree + 1)) if order else 1
+    scale = falling * (2.0**order) * magnitude
+    return scale if scale > 0.0 else float(np.finfo(np.float64).tiny)
+
+
+def _derivative_amplification(
+    shape: tuple[int, ...], degree: int, magnitude: float
+) -> npt.NDArray[np.float64]:
+    """Amplification of the derivative kernel, per derivative order.
+
+    The ``k``-th derivative of a Bernstein form is
+    ``p!/(p-k)! * sum_j (Delta^k c)_j B_{j,p-k}``, and ``Delta = shift - identity``
+    has infinity norm 2, so ``|Delta^k c| <= 2^k max|c|`` and the order-``k`` block is
+    bounded by ``p!/(p-k)! * 2^k * max|c|``.
+
+    **The bound is attained, not merely valid.** Driving the kernel with the identity
+    net gives the basis derivatives themselves, and
+    ``max_s sum_j |B^(k)_{j,p}(s)| / (p!/(p-k)! * 2^k)`` measures exactly 1.0000 for
+    ``k`` up to 4 over nine degrees. ``scripts/measure_bezier_fma_bound.py`` reports
+    that ratio; a value below 1 would mean this amplification is loose and a value
+    above 1 would refute it.
+
+    Args:
+        shape (tuple[int, ...]): Shape of the compared arrays, ``(pts, order + 1,
+            rank)``.
+        degree (int): Degree of the curve.
+        magnitude (float): ``max|c|``.
+
+    Returns:
+        npt.NDArray[np.float64]: The amplification, one value per derivative order.
+    """
+    amplification = np.empty(shape, dtype=np.float64)
+    for order in range(shape[1]):
+        amplification[:, order, :] = _derivative_scale(degree, order, magnitude)
+    return amplification
+
+
+def _reduction_amplification(
+    ctrl: npt.NDArray[Any], degree: int, decrement: int
+) -> npt.NDArray[np.float64]:
+    """Amplification of the reduction-operator apply, per output element.
+
+    The reduction operator is **not** a convex combination -- it has negative entries
+    and reproduces the endpoints exactly while approximating the interior -- so
+    ``max|c|`` is not a magnitude for its output. The absolute row action
+    ``|R| @ |c|`` is, and it is what a dot product's forward-error bound carries
+    anyway.
+
+    Args:
+        ctrl (npt.NDArray[Any]): The control net being reduced.
+        degree (int): Its degree.
+        decrement (int): Degrees removed.
+
+    Returns:
+        npt.NDArray[np.float64]: The row action, shaped like the reduced net.
+    """
+    operator = _interpolating_reduction_operator(degree, decrement)
+    action = np.abs(operator) @ np.abs(np.float64(ctrl))
+    return np.asarray(np.maximum(action, np.finfo(np.float64).tiny), dtype=np.float64)
 
 
 def _mixed_control_points(
@@ -208,13 +572,12 @@ def _adversarial_parameters(dtype: npt.DTypeLike) -> list[float]:
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", DEGREES)
 @pytest.mark.parametrize("rank", [1, 3])
-def test_evaluate_is_bitwise(
+def test_evaluate_matches_the_oracle(
     cpp_backend: None, degree: int, rank: int, dtype: npt.DTypeLike
 ) -> None:
     """The two backends evaluate a curve identically at every adversarial parameter."""
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, rank), dtype)
     points = np.array(_adversarial_parameters(dtype), dtype=dtype)
@@ -227,7 +590,27 @@ def test_evaluate_is_bitwise(
     assert_parity(
         actual,
         reference,
-        bitwise_parity(why=_EVALUATE_WHY),
+        _parity_claim(
+            bitwise_why=_EVALUATE_WHY,
+            fused_why=(
+                "the ratio recurrence that builds the basis contains no addition, so "
+                "it cannot fuse and both backends form bit-identical basis values; "
+                "the disassembly confirms it, with an FMA on the two accumulation "
+                "lines and nowhere else. The single chain is therefore the "
+                "contraction, degree stages of a convex sum, and max|c| bounds every "
+                "partial sum along it as well as the result"
+            ),
+            budget=_Budget(
+                degree,
+                _absolute_companion(
+                    lambda net: np.asarray(
+                        Bezier(net).evaluate(np.asarray(points, dtype=np.float64))
+                    ),
+                    ctrl,
+                ),
+            ),
+            storage=dtype,
+        ),
         context=f"evaluate degree {degree} rank {rank} {np.dtype(dtype).name}",
     )
 
@@ -235,7 +618,7 @@ def test_evaluate_is_bitwise(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", [0, 1, 3, 8, 17])
 @pytest.mark.parametrize("order", [0, 1, 2, 4])
-def test_evaluate_derivatives_is_bitwise(
+def test_evaluate_derivatives_matches_the_oracle(
     cpp_backend: None, degree: int, order: int, dtype: npt.DTypeLike
 ) -> None:
     """The two backends agree on every derivative order, including past the degree.
@@ -245,7 +628,6 @@ def test_evaluate_derivatives_is_bitwise(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, 2), dtype)
     points = np.array(_adversarial_parameters(dtype), dtype=dtype)
@@ -258,7 +640,26 @@ def test_evaluate_derivatives_is_bitwise(
     assert_parity(
         actual,
         reference,
-        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        _parity_claim(
+            bitwise_why=_DE_CASTELJAU_WHY,
+            fused_why=(
+                "four of this kernel's five fused sites emit a storage-width FMA, "
+                "because the oracle allocates every workspace at the point dtype and "
+                "this port follows it. So the accumulator IS the storage here, and it "
+                "is the one kernel whose float32 path a wide accumulator does not "
+                "protect. The ndu table is a de Casteljau triangle and is "
+                "non-expansive; the A2.3 recursion differences it, which is where the "
+                "2^k in the amplification comes from"
+            ),
+            budget=_Budget(
+                degree + 1,
+                _flat_amplification(
+                    np.shape(reference), _derivative_scale(degree, order, _net_magnitude(ctrl))
+                ),
+            ),
+            storage=dtype,
+            accumulator=dtype,
+        ),
         context=f"evaluate_derivatives degree {degree} order {order} {np.dtype(dtype).name}",
     )
 
@@ -287,7 +688,7 @@ def test_derivatives_agree_past_the_factorial_overflow(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
+    demand_a_bound_the_claim_can_carry(_WRAPPED_FACTORIAL)
 
     ctrl = _mixed_control_points((degree + 1, 2), dtype, exponents=(-1, 2))
     points = np.array([0.0, 0.25, 0.5, 1.0], dtype=dtype)
@@ -308,13 +709,12 @@ def test_derivatives_agree_past_the_factorial_overflow(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", DEGREES)
 @pytest.mark.parametrize("increment", [1, 2, 5])
-def test_elevate_degree_is_bitwise(
+def test_elevate_degree_matches_the_oracle(
     cpp_backend: None, degree: int, increment: int, dtype: npt.DTypeLike
 ) -> None:
     """The two backends elevate identically, coefficient table included."""
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, 3), dtype)
 
@@ -326,7 +726,23 @@ def test_elevate_degree_is_bitwise(
     assert_parity(
         actual,
         reference,
-        bitwise_parity(why=_BINOMIAL_WHY),
+        _parity_claim(
+            bitwise_why=_BINOMIAL_WHY,
+            fused_why=(
+                "the coefficient table is built from an exact-integer recurrence and "
+                "no addition of it fuses, so the one fused site is the accumulation. "
+                "Its weights are C(p,j)C(t,i-j)/C(p+t,i), non-negative and summing to "
+                "one by Vandermonde's identity, so the output is a convex combination "
+                "of the input net and max|c| bounds the partial sums with it"
+            ),
+            budget=_Budget(
+                degree + 1,
+                _absolute_companion(
+                    lambda net: Bezier(net).elevate_degree(increment).control_points, ctrl
+                ),
+            ),
+            storage=dtype,
+        ),
         context=f"elevate_degree {degree} by {increment} {np.dtype(dtype).name}",
     )
 
@@ -334,13 +750,12 @@ def test_elevate_degree_is_bitwise(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", [2, 3, 5, 8, 13, 20])
 @pytest.mark.parametrize("decrement", [1, 2])
-def test_reduce_degree_is_bitwise(
+def test_reduce_degree_matches_the_oracle(
     cpp_backend: None, degree: int, decrement: int, dtype: npt.DTypeLike
 ) -> None:
     """The two backends apply the same reduction operator to the same result."""
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, 3), dtype)
 
@@ -352,7 +767,18 @@ def test_reduce_degree_is_bitwise(
     assert_parity(
         actual,
         reference,
-        bitwise_parity(why=_REDUCTION_WHY),
+        _parity_claim(
+            bitwise_why=_REDUCTION_WHY,
+            fused_why=(
+                "one fused site, the dot product of an operator row with the net, so "
+                "the chain is one stage per input coefficient. The operator is the "
+                "only one of the eight that is not a convex combination, which is why "
+                "the amplification is the absolute row action |R| @ |c| rather than "
+                "max|c|"
+            ),
+            budget=_Budget(degree + 1, _reduction_amplification(ctrl, degree, decrement)),
+            storage=dtype,
+        ),
         context=f"reduce_degree {degree} by {decrement} {np.dtype(dtype).name}",
     )
 
@@ -390,7 +816,7 @@ def test_minimize_degree_is_bitwise(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
+    demand_a_bound_the_claim_can_carry(_DISCRETE_VERDICT)
 
     # A net that is genuinely reducible, so the search has something to find: a
     # quadratic elevated to `degree`, which is exactly recoverable. The lowest
@@ -424,13 +850,12 @@ def test_minimize_degree_is_bitwise(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", DEGREES)
 @pytest.mark.parametrize("value", [0.0, 1e-20, 0.25, 0.5, 0.75, 1.0])
-def test_slice_is_bitwise(
+def test_slice_matches_the_oracle(
     cpp_backend: None, degree: int, value: float, dtype: npt.DTypeLike
 ) -> None:
     """The two backends run the same de Casteljau triangle to the same last bit."""
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, degree + 1, 2), dtype)
 
@@ -443,7 +868,17 @@ def test_slice_is_bitwise(
     assert_parity(
         actual.control_points,
         reference.control_points,
-        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        _parity_claim(
+            bitwise_why=_DE_CASTELJAU_WHY,
+            fused_why=_DE_CASTELJAU_FUSED_WHY,
+            budget=_Budget(
+                degree,
+                _absolute_companion(
+                    lambda net: np.asarray(_sliced_control_points(net, value)), ctrl
+                ),
+            ),
+            storage=dtype,
+        ),
         context=f"slice degree {degree} at {value!r} {np.dtype(dtype).name}",
     )
 
@@ -451,7 +886,7 @@ def test_slice_is_bitwise(
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("degree", DEGREES)
 @pytest.mark.parametrize("value", [1e-20, 1e-8, 0.25, 0.5, 0.75, 1.0 - 1e-8])
-def test_split_is_bitwise(
+def test_split_matches_the_oracle(
     cpp_backend: None, degree: int, value: float, dtype: npt.DTypeLike
 ) -> None:
     """Both halves of a split agree bit for bit.
@@ -464,7 +899,6 @@ def test_split_is_bitwise(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, 3), dtype)
 
@@ -473,14 +907,25 @@ def test_split_is_bitwise(
     with use_backend(Backend.CPP):
         got_left, got_right = Bezier(ctrl).split(0, value)
 
-    for name, actual, reference in (
-        ("left", got_left, ref_left),
-        ("right", got_right, ref_right),
+    for half, name, actual, reference in (
+        (0, "left", got_left, ref_left),
+        (1, "right", got_right, ref_right),
     ):
         assert_parity(
             actual.control_points,
             reference.control_points,
-            bitwise_parity(why=_DE_CASTELJAU_WHY),
+            _parity_claim(
+                bitwise_why=_DE_CASTELJAU_WHY,
+                fused_why=_DE_CASTELJAU_FUSED_WHY,
+                budget=_Budget(
+                    degree,
+                    _absolute_companion(
+                        _split_half(value, half),
+                        ctrl,
+                    ),
+                ),
+                storage=dtype,
+            ),
             context=f"split {name} degree {degree} at {value!r} {np.dtype(dtype).name}",
         )
 
@@ -491,7 +936,7 @@ def test_split_is_bitwise(
     "bounds",
     [(0.1, 0.9), (0.0, 1e-8), (1.0 - 1e-8, 1.0), (0.25, 0.75), (0.9, 1.0), (0.0, 0.1)],
 )
-def test_restrict_is_bitwise(
+def test_restrict_matches_the_oracle(
     cpp_backend: None, degree: int, bounds: tuple[float, float], dtype: npt.DTypeLike
 ) -> None:
     """Both orderings of the two-pass restriction agree bit for bit.
@@ -502,7 +947,6 @@ def test_restrict_is_bitwise(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((degree + 1, 3), dtype)
 
@@ -514,7 +958,20 @@ def test_restrict_is_bitwise(
     assert_parity(
         actual,
         reference,
-        bitwise_parity(why=_DE_CASTELJAU_WHY),
+        _parity_claim(
+            bitwise_why=_DE_CASTELJAU_WHY,
+            fused_why=(
+                f"{_DE_CASTELJAU_FUSED_WHY}. Twice the stages, because this is two "
+                f"passes; the second is convex as well, since the ordering forces the "
+                f"divisor to be at least one half and tau2 therefore lands in [0, 1], "
+                f"which the kernel header derives"
+            ),
+            budget=_Budget(
+                2 * degree,
+                _absolute_companion(lambda net: Bezier(net).restrict(bounds).control_points, ctrl),
+            ),
+            storage=dtype,
+        ),
         context=f"restrict degree {degree} to {bounds} {np.dtype(dtype).name}",
     )
 
@@ -542,7 +999,7 @@ def test_compose_is_bitwise(
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
+    demand_a_bound_the_claim_can_carry(_OPERANDS_NOT_OBSERVABLE)
 
     # `inner.rank` must equal `outer.dim`, so a univariate outer map takes a
     # rank-1 inner one. That is exactly the case `use_1d_kernel` selects.
@@ -579,7 +1036,6 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: npt.D
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
-    demand_a_non_fusing_build()
 
     ctrl = _mixed_control_points((6, 3), dtype)
     points = np.linspace(0.0, 1.0, 9, dtype=dtype)
@@ -597,7 +1053,24 @@ def test_a_strided_out_reaches_the_callers_array(cpp_backend: None, dtype: npt.D
     assert_parity(
         results[Backend.CPP],
         results[Backend.PYTHON],
-        bitwise_parity(why=f"{_EVALUATE_WHY}; buffering a strided out adds no arithmetic"),
+        _parity_claim(
+            bitwise_why=f"{_EVALUATE_WHY}; buffering a strided out adds no arithmetic",
+            fused_why=(
+                "the same claim as evaluate at degree 5; buffering a strided out adds "
+                "a copy and no arithmetic, so it changes neither the stage count nor "
+                "the amplification"
+            ),
+            budget=_Budget(
+                5,
+                _absolute_companion(
+                    lambda net: np.asarray(
+                        Bezier(net).evaluate(np.asarray(points, dtype=np.float64))
+                    ).T,
+                    ctrl,
+                ),
+            ),
+            storage=dtype,
+        ),
         context=f"strided out, {np.dtype(dtype).name}",
     )
 
@@ -622,4 +1095,221 @@ def test_the_split_binding_refuses_its_outputs_positionally(cpp_backend: None) -
     _pantr_cpp.split_bezier_1d(ctrl, 0.5, out_left=left, out_right=right)
     assert not np.array_equal(left, right), (
         "a split at the midpoint of a non-symmetric net must give two different halves"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The bounded branch, exercised on a host that cannot reach it
+# ---------------------------------------------------------------------------
+#
+# `contraction_may_fuse()` is false on the shipped build, so every claim above takes
+# its bitwise branch and the bounded one ships unevaluated. These three tests build
+# it anyway and check the two things that make a bound a bound: that it permits a
+# displacement inside itself, and that it refuses one outside. Copied from
+# `tests/parity/test_quad_gauss_legendre.py`, which does the same for its FMA claims.
+
+
+def _probe_budgets() -> list[tuple[str, _Budget, npt.DTypeLike, npt.DTypeLike]]:
+    """Return one representative budget per kernel, for the probes.
+
+    The magnitudes are the ones a real net produces, so a tolerance that came out
+    absurdly small or large here would show up as a failing probe rather than as a
+    number nobody looked at.
+
+    Returns:
+        list: Name, budget, storage and accumulator, one entry per kernel.
+    """
+    degree = 8
+    ctrl = _mixed_control_points((degree + 1, 3), np.float64)
+    magnitude = _net_magnitude(ctrl)
+    flat = _flat_amplification((degree + 1, 3), magnitude)
+    return [
+        ("evaluate", _Budget(degree, flat), np.float64, np.float64),
+        ("slice", _Budget(degree, flat), np.float64, np.float64),
+        ("split", _Budget(degree, flat), np.float64, np.float64),
+        ("restrict", _Budget(2 * degree, flat), np.float64, np.float64),
+        ("degree_elevate", _Budget(degree + 1, flat), np.float64, np.float64),
+        (
+            "reduce_degree",
+            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1)),
+            np.float64,
+            np.float64,
+        ),
+        (
+            "evaluate_deriv float32",
+            _Budget(
+                degree + 1,
+                _flat_amplification((degree + 1, 3), _derivative_scale(degree, 2, magnitude)),
+            ),
+            np.float32,
+            np.float32,
+        ),
+        ("evaluate float32", _Budget(degree, flat), np.float32, np.float64),
+    ]
+
+
+def test_the_fused_bound_admits_a_displacement_inside_itself() -> None:
+    """Each kernel's bounded claim accepts three quarters of its own tolerance.
+
+    Needs no C++ backend: what is under test is the claim's own arithmetic.
+    """
+    for name, budget, storage, accumulator in _probe_budgets():
+        claim = _fused_claim(
+            fused_why=f"probe for {name}",
+            budget=budget,
+            storage=storage,
+            accumulator=accumulator,
+        )
+        tolerance = absolute_tolerance(claim)
+        assert float(np.max(tolerance)) > 0.0, (
+            f"{name}: the bounded branch derived a zero tolerance"
+        )
+        reference = np.asarray(budget.amplification, dtype=storage)
+        deviation = assert_parity(
+            np.asarray(reference + 0.75 * tolerance, dtype=storage),
+            reference,
+            claim,
+            context=f"{name} fused probe, inside the bound",
+        )
+        assert deviation.max_ratio_to_bound > 0.5, (
+            f"{name}: a displacement of three quarters of the bound registered as "
+            f"{deviation.max_ratio_to_bound:.3g} of it, so the perturbation did not "
+            f"survive its own rounding and this probe tested nothing"
+        )
+
+
+def test_the_fused_bound_refuses_a_displacement_past_itself() -> None:
+    """Each kernel's bounded claim rejects one and a half times its own tolerance.
+
+    The half that decides whether the bound is a bound at all: a tolerance nothing
+    can exceed would pass the probe above unchanged.
+    """
+    for name, budget, storage, accumulator in _probe_budgets():
+        claim = _fused_claim(
+            fused_why=f"probe for {name}",
+            budget=budget,
+            storage=storage,
+            accumulator=accumulator,
+        )
+        reference = np.asarray(budget.amplification, dtype=storage)
+        perturbed = np.asarray(reference + 1.5 * absolute_tolerance(claim), dtype=storage)
+        with pytest.raises(AssertionError, match="more than the derived bound"):
+            assert_parity(
+                perturbed, reference, claim, context=f"{name} fused probe, past the bound"
+            )
+
+
+def test_the_oracle_does_not_contract_a_multiply_add() -> None:
+    """Numba emits no FMA without fastmath, which is what makes the bound one-sided.
+
+    **This is the premise the whole fused bound rests on**, and it is a property of
+    numba's code generation rather than of pantr. Numba compiles for the host CPU, so
+    on any machine with an FMA the oracle *could* fuse; it does not, because LLVM does
+    not contract unless fastmath is on, and no pantr kernel sets it. If that default
+    ever changes the bound stops being one-sided in the direction it assumes, and this
+    test is what says so.
+
+    Deliberately probed on a throwaway function rather than on the Bezier kernels:
+    ``inspect_asm`` returns a warning and invalid output for code loaded from numba's
+    on-disk cache, which every pantr kernel is. A ``cache=False`` function is the only
+    spelling that reports the compiler's real output.
+    """
+    import re  # noqa: PLC0415
+
+    from numba import njit  # noqa: PLC0415
+
+    fused = re.compile(r"\bvf(n?)m(add|sub)[a-z0-9]*\b")
+
+    @njit(cache=False, fastmath=False)
+    def without_fastmath(a: float, b: float, c: float) -> float:
+        return a * b + c
+
+    @njit(cache=False, fastmath=True)
+    def with_fastmath(a: float, b: float, c: float) -> float:
+        return a * b + c
+
+    without_fastmath(1.0, 2.0, 3.0)
+    with_fastmath(1.0, 2.0, 3.0)
+
+    plain = sum(len(fused.findall(asm)) for asm in without_fastmath.inspect_asm().values())
+    fast = sum(len(fused.findall(asm)) for asm in with_fastmath.inspect_asm().values())
+
+    if fast == 0:
+        pytest.skip(
+            "this host's numba target has no fused multiply-add, so the check cannot "
+            "discriminate: a zero from the fastmath=False build would mean nothing"
+        )
+    assert plain == 0, (
+        f"numba emitted {plain} fused multiply-adds for a * b + c without fastmath, on "
+        f"a target where fastmath produces {fast}. The Bezier parity bound assumes the "
+        f"oracle never fuses and this backend may, so a fusing oracle makes the bound "
+        f"describe the wrong difference"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(("p_degree", "q_degree"), [(1, 1), (3, 2), (8, 5), (17, 8), (25, 13)])
+def test_the_product_kernel_matches_the_oracle_at_its_own_entry(
+    cpp_backend: None, p_degree: int, q_degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The Bernstein product agrees, driven where its operands are visible.
+
+    ``test_compose_is_bitwise`` reaches this kernel through the public surface, which
+    is the right level for an exactness claim and the wrong one for a bounded claim:
+    the operands are formed inside the composition, so the only amplification
+    available from outside is ``max|outer| * (1 + 2 max|inner|)^p``, which is around
+    1e18 at those degrees and would accept anything.
+
+    Driven at the Layer 3 entry the operands are known and the amplification is the
+    exact convex sum ``sum_i C(p,i) C(q,k-i) |a_i| |b_{k-i}| / C(p+q,k)``, whose
+    weights are non-negative and sum to one by Vandermonde's identity. That is what
+    lets this kernel keep a real bound on a fusing build while ``compose`` skips.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    from pantr.bezier import _bezier_backend as backend  # noqa: PLC0415
+
+    total = p_degree + q_degree
+    left = _mixed_control_points((p_degree + 1,), dtype, seed=20260822)
+    right = _mixed_control_points((q_degree + 1,), dtype, seed=20260823)
+
+    results = {}
+    for which in (Backend.PYTHON, Backend.CPP):
+        out = np.zeros(total + 1, dtype=dtype)
+        backend.product_kernel(which)(left, right, out)
+        results[which] = out
+
+    weights = np.array(
+        [
+            sum(
+                comb(p_degree, i)
+                * comb(q_degree, k - i)
+                * abs(float(left[i]))
+                * abs(float(right[k - i]))
+                for i in range(max(0, k - q_degree), min(p_degree, k) + 1)
+            )
+            / comb(total, k)
+            for k in range(total + 1)
+        ],
+        dtype=np.float64,
+    )
+
+    assert_parity(
+        results[Backend.CPP],
+        results[Backend.PYTHON],
+        _parity_claim(
+            bitwise_why=_BINOMIAL_WHY,
+            fused_why=(
+                "one fused site, the accumulation of a_i * b_j scaled by the two "
+                "binomials, so the chain is min(p, q) + 1 stages long. Dividing the "
+                "finished row by C(p+q,k) makes the weights a partition of unity, by "
+                "Vandermonde, so the amplification is the convex sum of |a_i b_j| and "
+                "the accumulator is float64 at both storage widths because the "
+                "binomial table is float64 unconditionally"
+            ),
+            budget=_Budget(min(p_degree, q_degree) + 1, np.maximum(weights, _TINY)),
+            storage=dtype,
+        ),
+        context=f"scalar product {p_degree} x {q_degree} {np.dtype(dtype).name}",
     )

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -63,9 +63,18 @@ At a fused site the oracle computes ``fl(a + fl(b*c))`` and this backend
 ``fl(a + b*c)``, so the two differ by at most ``u|b*c| + 2u|a + b*c|``: three
 accumulator roundings per stage. Where the storage is narrower the two pre-store
 values can fall either side of a rounding boundary, which costs one further ulp, so
-two storage roundings per stage. What differs per kernel is the stage count and the
-magnitude the relative budget multiplies, and those are what the ``_amplification``
-helpers below carry.
+two storage roundings per stage -- once per **narrowing store**, which is once per
+stage for every kernel but the reduction apply, and that one accumulates into a local
+and narrows once per output element.
+
+What differs per kernel is the stage count and the magnitude the relative budget
+multiplies. Five kernels are convex combinations and take the absolute-value
+companion: the same operation run on ``|c|``, elementwise. Three cannot. The product
+carries an explicit convex sum of ``|a_i b_j|``, the reduction apply the absolute row
+action ``|R| @ |c|``, and the derivative kernel the row action of the **majorant of
+A2.3** -- the recursion with every coefficient replaced by its modulus, because it
+differences and so has no companion of its own. Rule 10 of design/backend_parity.md
+records what each of those cost to get wrong.
 
 Fourteen sites fuse, and they were enumerated by disassembling a ``-march=native``
 build rather than by reading the source: two in ``evaluate``, five in
@@ -86,7 +95,7 @@ that drives the product kernel at its own entry point, where the operands are kn
 from __future__ import annotations
 
 from collections.abc import Callable
-from math import comb, prod
+from math import comb
 from typing import Any, Final, NamedTuple
 
 import numpy as np
@@ -108,7 +117,18 @@ from tests._parity_harness import (
 )
 
 _TINY: Final = float(np.finfo(np.float64).tiny)
-"""Smallest positive double, used so an amplification is never exactly zero."""
+"""Floor under an amplification, where a zero would mean something other than zero.
+
+**Not** "so a tolerance is never zero", which was the first reason given and is false:
+the harness's own underflow budget already makes every bounded tolerance strictly
+positive, because it charges `underflow_floor` per accumulator rounding. Measured, the
+floor changes a float32 tolerance not at all and a float64 one by 1e-322.
+
+What it is for is the one place a zero would be a claim rather than a magnitude: an
+output element whose amplification really is zero is one where the derivative is
+identically zero, both backends produce exact zeros by construction, and the honest
+statement is that they agree rather than that they agree to within nothing.
+"""
 
 DTYPES: Final = (np.float64, np.float32)
 """The two storage formats the Bézier layer accepts."""
@@ -219,12 +239,23 @@ _OPERANDS_NOT_OBSERVABLE: Final = (
 )
 
 
+_NO_CHAIN_TO_FUSE: Final = (
+    "the dependency chain has no stages at this degree, so there is no fused site and "
+    "the two backends run the same short-circuit. `bounded_parity` refuses a zero-stage "
+    "budget for exactly this reason, and clamping the count to one instead would permit "
+    "a difference of 2.4e-7 relative where the true difference is zero"
+)
+
 _DE_CASTELJAU_FUSED_WHY: Final = (
-    "every stage is a convex combination (1-t)a + tb with t in [0, 1], so a "
-    "divergence introduced at one stage passes through the remaining ones without "
-    "growing in the max norm and the per-stage injections merely add. max|c| bounds "
-    "the whole triangle, and it is the right magnitude rather than |result|: the "
-    "triangle can cancel to near zero while the error that reached it does not"
+    "every stage is a convex combination (1-t)a + tb with t in [0, 1]. Write D for the "
+    "same triangle run on |c|, which is what the amplification is. The injection at "
+    "stage r is bounded by 3u times the INTERMEDIATE magnitude D_i^r rather than the "
+    "output's, and it reaches the output weighted by B_i^{p-r}(t); the weighted sum "
+    "telescopes, because sum_i B_i^{p-r}(t) D_i^r = D_0^p for every r, so each stage "
+    "contributes 3u times the OUTPUT companion and the stages add. The three roundings "
+    "cover both the fusion difference and the re-rounding of two operands that have "
+    "already diverged, which is first order and not second: correctly rounded "
+    "arithmetic on inputs one ulp apart does not track the gap"
 )
 
 
@@ -263,16 +294,23 @@ def _net_magnitude(*arrays: npt.NDArray[Any]) -> float:
 
 
 class _Budget(NamedTuple):
-    """The two things that differ from kernel to kernel in the fused claim.
+    """What differs from kernel to kernel in the fused claim.
 
     Attributes:
         stages (int): Length of the dependency chain the fused sites sit on.
         amplification (npt.NDArray[np.float64]): Elementwise magnitude the relative
             budget multiplies, matching the compared arrays' shape.
+        narrowing_stores (int | None): How many times the chain rounds down into the
+            storage format. ``None`` means once per stage, which is what a kernel
+            whose workspace is the output array does. The reduction apply is the
+            exception: it accumulates into a local and narrows **once per output
+            element**, outside the loop over the operator row, so charging a store per
+            stage over-counts it by ``p + 1`` and cost up to 52x at float32.
     """
 
     stages: int
     amplification: npt.NDArray[np.float64]
+    narrowing_stores: int | None = None
 
 
 def _sliced_control_points(
@@ -376,6 +414,8 @@ def _parity_claim(
     """
     if not contraction_may_fuse():
         return bitwise_parity(why=bitwise_why)
+    if budget.stages == 0:
+        return bitwise_parity(why=_NO_CHAIN_TO_FUSE)
     return _fused_claim(
         fused_why=fused_why, budget=budget, storage=storage, accumulator=accumulator
     )
@@ -404,12 +444,25 @@ def _fused_claim(
     Returns:
         ParityClaim: The BOUNDED claim.
     """
-    return bounded_parity(
-        roundings=Roundings(
-            stages=max(budget.stages, 1),
+    stores = budget.stages if budget.narrowing_stores is None else budget.narrowing_stores
+    roundings = (
+        Roundings(
+            stages=budget.stages,
             accumulator_per_stage=_ACCUMULATOR_ROUNDINGS_PER_STAGE,
             storage_per_stage=_STORAGE_ROUNDINGS_PER_STAGE,
-        ),
+        )
+        if stores == budget.stages
+        # Collapsed to one stage because the two counts no longer share a
+        # denominator, which `Roundings` documents as the way to spell exactly that.
+        # The chain is still `budget.stages` long and `why` says so.
+        else Roundings(
+            stages=1,
+            accumulator_per_stage=_ACCUMULATOR_ROUNDINGS_PER_STAGE * budget.stages,
+            storage_per_stage=_STORAGE_ROUNDINGS_PER_STAGE * stores,
+        )
+    )
+    return bounded_parity(
+        roundings=roundings,
         accumulator=accumulator,
         storage=storage,
         amplification=budget.amplification,
@@ -431,58 +484,119 @@ def _flat_amplification(shape: tuple[int, ...], magnitude: float) -> npt.NDArray
     return np.full(shape, magnitude, dtype=np.float64)
 
 
-def _derivative_scale(degree: int, order: int, magnitude: float) -> float:
-    """Amplification of the derivative kernel at one derivative order.
+def _a23_absolute_rows(
+    degree: int, points: npt.NDArray[np.float64], order: int
+) -> npt.NDArray[np.float64]:
+    """Majorise every quantity A2.3 forms, by running it with its signs removed.
 
-    See :func:`_derivative_amplification` for the derivation; this is the scalar it
-    is built from, and the public API returns one order at a time rather than the
-    kernel's stack.
+    A2.3 is a **linear** recursion with signed coefficients, and for those the standard
+    majorant is the same recursion with every coefficient replaced by its modulus: each
+    intermediate is then non-negative and bounds the modulus of its signed counterpart,
+    by induction on the recursion. Two lines change from the oracle, both in the ``a``
+    table -- ``a[s2, jj] = a[s1, jj] - a[s1, jj-1]`` becomes a sum, and
+    ``a[s2, k] = -a[s1, k-1]`` drops its negation. The ``ndu`` table is already
+    non-negative for ``s`` in ``[0, 1]``, which is the kernel's domain.
+
+    **This is why the finished row is not enough**, and it is the difference between
+    this kernel and the five convex ones. There the absolute-value companion of the
+    *output* suffices, because each stage's injection reaches the output weighted by a
+    partition of unity and the weighted sum telescopes back to the output companion.
+    A2.3 differences, so its partial sums can exceed what survives to the output, and
+    an amplification built from the finished basis derivatives alone under-states them.
+    Measured: it was exceeded by 4.32x at degree 17, orders 4 and 6, identically at
+    both dtypes, which is the signature of a structural shortfall rather than of
+    rounding. With the signs removed the partial sums are monotone, so the final value
+    majorises every one of them.
 
     Args:
         degree (int): Degree of the curve.
+        points (npt.NDArray[np.float64]): Evaluation points, in ``[0, 1]``.
         order (int): Derivative order.
-        magnitude (float): ``max|c|``.
 
     Returns:
-        float: The amplification, never zero so that a tolerance never vanishes.
+        npt.NDArray[np.float64]: Shape ``(len(points), degree + 1)``; entry ``(i, j)`` majorises
+            ``|B^(order)_{j,degree}(s_i)|`` and every partial sum forming it.
     """
-    if degree < order:
-        return float(np.finfo(np.float64).tiny)
-    falling = prod(range(degree - order + 1, degree + 1)) if order else 1
-    scale = falling * (2.0**order) * magnitude
-    return scale if scale > 0.0 else float(np.finfo(np.float64).tiny)
+    span = degree + 1
+    rows = np.zeros((points.size, span), dtype=np.float64)
+    for pt_id, s in enumerate(np.asarray(points, dtype=np.float64)):
+        ndu = np.zeros((span, span))
+        ndu[0, 0] = 1.0
+        for j in range(1, span):
+            saved = 0.0
+            for rr in range(j):
+                ndu[j, rr] = 1.0
+                temp = ndu[rr, j - 1]
+                ndu[rr, j] = saved + (1.0 - s) * temp
+                saved = s * temp
+            ndu[j, j] = saved
+        if order == 0:
+            rows[pt_id, :] = np.abs(ndu[:, degree])
+            continue
+        basis = np.zeros((order + 1, span))
+        basis[0, :] = ndu[:, degree]
+        a_arr = np.zeros((2, order + 1))
+        for rr in range(span):
+            s1, s2 = 0, 1
+            a_arr[0, 0] = 1.0
+            for k in range(1, order + 1):
+                d = 0.0
+                rk, pk = rr - k, degree - k
+                if rr >= k:
+                    a_arr[s2, 0] = a_arr[s1, 0]
+                    d = a_arr[s2, 0] * ndu[rk, pk]
+                j1 = 1 if rk >= -1 else -rk
+                j2 = k - 1 if (rr - 1) <= pk else degree - rr
+                for jj in range(j1, j2 + 1):
+                    # The oracle subtracts here; the majorant adds.
+                    a_arr[s2, jj] = a_arr[s1, jj] + a_arr[s1, jj - 1]
+                    d += a_arr[s2, jj] * ndu[rk + jj, pk]
+                if rr <= pk:
+                    # The oracle negates here; the majorant does not.
+                    a_arr[s2, k] = a_arr[s1, k - 1]
+                    d += a_arr[s2, k] * ndu[rr, pk]
+                basis[k, rr] = d
+                s1, s2 = s2, s1
+        falling = 1.0
+        for k in range(1, order + 1):
+            falling *= degree - k + 1
+        rows[pt_id, :] = basis[order, :] * falling
+    return rows
 
 
 def _derivative_amplification(
-    shape: tuple[int, ...], degree: int, magnitude: float
+    ctrl: npt.NDArray[Any], points: npt.NDArray[Any], order: int
 ) -> npt.NDArray[np.float64]:
-    """Amplification of the derivative kernel, per derivative order.
+    """Bound each derivative output element by the absolute row action of A2.3.
 
-    The ``k``-th derivative of a Bernstein form is
-    ``p!/(p-k)! * sum_j (Delta^k c)_j B_{j,p-k}``, and ``Delta = shift - identity``
-    has infinity norm 2, so ``|Delta^k c| <= 2^k max|c|`` and the order-``k`` block is
-    bounded by ``p!/(p-k)! * 2^k * max|c|``.
+    The kernel applies a linear operator to the control net, so the magnitude
+    reachable at output element ``(i, r)`` is ``sum_j M_{i,j} |c_{j,r}|`` with ``M``
+    the majorant of :func:`_a23_absolute_rows`. Same ``|R| @ |c|`` shape
+    :func:`_reduction_amplification` uses, and for the same reason: the operator is
+    not a convex combination, so no companion of the output exists.
 
-    **The bound is attained, not merely valid.** Driving the kernel with the identity
-    net gives the basis derivatives themselves, and
-    ``max_s sum_j |B^(k)_{j,p}(s)| / (p!/(p-k)! * 2^k)`` measures exactly 1.0000 for
-    ``k`` up to 4 over nine degrees. ``scripts/measure_bezier_fma_bound.py`` reports
-    that ratio; a value below 1 would mean this amplification is loose and a value
-    above 1 would refute it.
+    **The flat ``p!/(p-k)! * 2^k * max|c|`` this replaces was correct and unusable.**
+    It bounds the operator norm rather than the row and applies the *input* maximum
+    where the comparison happens per output element, so on the parametrization this
+    file already sweeps it made 45 of 280 non-zero float32 values carry a tolerance at
+    least as large as their own magnitude, worst case 1.6e5 times. Rule 3's guard did
+    not fire because it compares the largest tolerance against the largest magnitude,
+    and a flat amplification is sized for exactly that element. That is Rule 6's
+    failure, a scalar summary hiding an elementwise disagreement, committed inside
+    Rule 10.
 
     Args:
-        shape (tuple[int, ...]): Shape of the compared arrays, ``(pts, order + 1,
-            rank)``.
-        degree (int): Degree of the curve.
-        magnitude (float): ``max|c|``.
+        ctrl (npt.NDArray[Any]): The control net, shape ``(p + 1, rank)``.
+        points (npt.NDArray[Any]): The evaluation points.
+        order (int): Derivative order.
 
     Returns:
-        npt.NDArray[np.float64]: The amplification, one value per derivative order.
+        npt.NDArray[np.float64]: The row action, shaped like the compared output.
     """
-    amplification = np.empty(shape, dtype=np.float64)
-    for order in range(shape[1]):
-        amplification[:, order, :] = _derivative_scale(degree, order, magnitude)
-    return amplification
+    degree = np.shape(ctrl)[0] - 1
+    rows = _a23_absolute_rows(degree, np.asarray(points, dtype=np.float64).ravel(), order)
+    action = rows @ np.abs(np.asarray(ctrl, dtype=np.float64))
+    return np.asarray(np.maximum(action, _TINY), dtype=np.float64)
 
 
 def _reduction_amplification(
@@ -597,8 +711,9 @@ def test_evaluate_matches_the_oracle(
                 "it cannot fuse and both backends form bit-identical basis values; "
                 "the disassembly confirms it, with an FMA on the two accumulation "
                 "lines and nowhere else. The single chain is therefore the "
-                "contraction, degree stages of a convex sum, and max|c| bounds every "
-                "partial sum along it as well as the result"
+                "contraction, degree stages of a convex sum, and the absolute-value "
+                "companion is its elementwise magnitude, by the telescoping argument in "
+                "_DE_CASTELJAU_FUSED_WHY"
             ),
             budget=_Budget(
                 degree,
@@ -647,15 +762,15 @@ def test_evaluate_derivatives_matches_the_oracle(
                 "because the oracle allocates every workspace at the point dtype and "
                 "this port follows it. So the accumulator IS the storage here, and it "
                 "is the one kernel whose float32 path a wide accumulator does not "
-                "protect. The ndu table is a de Casteljau triangle and is "
-                "non-expansive; the A2.3 recursion differences it, which is where the "
-                "2^k in the amplification comes from"
+                "protect. The chain is p levels of the ndu triangle, order + 1 in the "
+                "A2.3 accumulation, and p + 1 in the contraction with the net. The "
+                "amplification is the absolute row action of the operator the kernel "
+                "computes, obtained by driving the kernel itself with the identity "
+                "net, which is the same shape reduce_degree uses"
             ),
             budget=_Budget(
-                degree + 1,
-                _flat_amplification(
-                    np.shape(reference), _derivative_scale(degree, order, _net_magnitude(ctrl))
-                ),
+                2 * degree + order + 2,
+                _derivative_amplification(ctrl, points, order),
             ),
             storage=dtype,
             accumulator=dtype,
@@ -733,10 +848,13 @@ def test_elevate_degree_matches_the_oracle(
                 "no addition of it fuses, so the one fused site is the accumulation. "
                 "Its weights are C(p,j)C(t,i-j)/C(p+t,i), non-negative and summing to "
                 "one by Vandermonde's identity, so the output is a convex combination "
-                "of the input net and max|c| bounds the partial sums with it"
+                "of the input net and the absolute-value companion is its elementwise "
+                "magnitude. The chain is min(p, t) + 1 and not p + 1: the accumulation "
+                "into out[i] runs j from max(0, i - t) to min(p, i), which is at most "
+                "min(p, t) + 1 terms however large p is"
             ),
             budget=_Budget(
-                degree + 1,
+                min(degree, increment) + 1,
                 _absolute_companion(
                     lambda net: Bezier(net).elevate_degree(increment).control_points, ctrl
                 ),
@@ -773,10 +891,17 @@ def test_reduce_degree_matches_the_oracle(
                 "one fused site, the dot product of an operator row with the net, so "
                 "the chain is one stage per input coefficient. The operator is the "
                 "only one of the eight that is not a convex combination, which is why "
-                "the amplification is the absolute row action |R| @ |c| rather than "
-                "max|c|"
+                "the amplification is the absolute row action |R| @ |c| rather than a "
+                "companion. And the kernel accumulates into a float64 local and narrows "
+                "ONCE per output element, outside the loop over the row, so the storage "
+                "rounding is charged once rather than once per stage; charging it per "
+                "stage over-counted by p + 1, measured up to 52x at float32"
             ),
-            budget=_Budget(degree + 1, _reduction_amplification(ctrl, degree, decrement)),
+            budget=_Budget(
+                degree + 1,
+                _reduction_amplification(ctrl, degree, decrement),
+                narrowing_stores=1,
+            ),
             storage=dtype,
         ),
         context=f"reduce_degree {degree} by {decrement} {np.dtype(dtype).name}",
@@ -962,9 +1087,11 @@ def test_restrict_matches_the_oracle(
             bitwise_why=_DE_CASTELJAU_WHY,
             fused_why=(
                 f"{_DE_CASTELJAU_FUSED_WHY}. Twice the stages, because this is two "
-                f"passes; the second is convex as well, since the ordering forces the "
-                f"divisor to be at least one half and tau2 therefore lands in [0, 1], "
-                f"which the kernel header derives"
+                f"passes. The second is convex too, and that does not depend on the "
+                f"ordering: lower/upper lies in [0, 1) because lower < upper, and "
+                f"(upper - lower)/(1 - lower) lies in [0, 1] because upper <= 1, in "
+                f"either branch. What the ordering buys is conditioning, which the "
+                f"kernel header derives, not convexity"
             ),
             budget=_Budget(
                 2 * degree,
@@ -1112,39 +1239,40 @@ def test_the_split_binding_refuses_its_outputs_positionally(cpp_backend: None) -
 def _probe_budgets() -> list[tuple[str, _Budget, npt.DTypeLike, npt.DTypeLike]]:
     """Return one representative budget per kernel, for the probes.
 
-    The magnitudes are the ones a real net produces, so a tolerance that came out
-    absurdly small or large here would show up as a failing probe rather than as a
-    number nobody looked at.
+    **Built from the same amplification helpers the claims use**, not from a flat
+    magnitude. An earlier version passed a flat ``max|c|`` to every entry, which meant
+    the probes validated ``absolute_tolerance``'s arithmetic and never touched the
+    amplifications the suite actually relies on -- so the derivative kernel's, which
+    was wrong by up to 1.6e5, went through them untouched.
 
     Returns:
         list: Name, budget, storage and accumulator, one entry per kernel.
     """
     degree = 8
     ctrl = _mixed_control_points((degree + 1, 3), np.float64)
-    magnitude = _net_magnitude(ctrl)
-    flat = _flat_amplification((degree + 1, 3), magnitude)
+    points = np.array(_adversarial_parameters(np.float64), dtype=np.float64)
+    companion = _absolute_companion(lambda net: Bezier(net).elevate_degree(2).control_points, ctrl)
+    triangle = _absolute_companion(
+        lambda net: Bezier(net).restrict((0.1, 0.9)).control_points, ctrl
+    )
+    evaluated = _absolute_companion(lambda net: np.asarray(Bezier(net).evaluate(points)), ctrl)
     return [
-        ("evaluate", _Budget(degree, flat), np.float64, np.float64),
-        ("slice", _Budget(degree, flat), np.float64, np.float64),
-        ("split", _Budget(degree, flat), np.float64, np.float64),
-        ("restrict", _Budget(2 * degree, flat), np.float64, np.float64),
-        ("degree_elevate", _Budget(degree + 1, flat), np.float64, np.float64),
+        ("evaluate", _Budget(degree, evaluated), np.float64, np.float64),
+        ("evaluate float32", _Budget(degree, evaluated), np.float32, np.float64),
+        ("restrict", _Budget(2 * degree, triangle), np.float64, np.float64),
+        ("degree_elevate", _Budget(min(degree, 2) + 1, companion), np.float64, np.float64),
         (
             "reduce_degree",
-            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1)),
-            np.float64,
+            _Budget(degree + 1, _reduction_amplification(ctrl, degree, 1), narrowing_stores=1),
+            np.float32,
             np.float64,
         ),
         (
             "evaluate_deriv float32",
-            _Budget(
-                degree + 1,
-                _flat_amplification((degree + 1, 3), _derivative_scale(degree, 2, magnitude)),
-            ),
+            _Budget(2 * degree + 4, _derivative_amplification(ctrl, points, 2)),
             np.float32,
             np.float32,
         ),
-        ("evaluate float32", _Budget(degree, flat), np.float32, np.float64),
     ]
 
 


### PR DESCRIPTION
## Context

Every parity assertion in the Bézier arithmetic tests was skipped when
`__fp_contract__` reported a fused multiply-add available. The shipped build sets
`-ffp-contract=on` and no `-march`, so the target is baseline x86-64 and nothing fuses;
the first build raising the instruction-set baseline would have turned 519 assertions
into skips and left the suite green.

The reason originally given for deferring the bound was that writing one for a branch
no host in this project can execute would ship it untested. That was refuted:
`tests/parity/test_quad_gauss_legendre.py` has been deriving exactly such a bound and
probing it on this same non-fusing host since the `quad` port.

## Specification

**One budget for all eight kernels.** At a fused site the oracle computes
`fl(a + fl(b*c))` and this backend `fl(a + b*c)`, differing by at most
`|b*c| u + 2u |a + b*c|`: three accumulator roundings per stage, plus two more at each
narrowing store.

**What differs per kernel is the amplification.** Five kernels are convex combinations
and take the absolute-value companion, the same operation run on `|c|` elementwise. The
product carries an explicit convex sum of `|a_i b_j|`; the reduction apply the absolute
row action `|R| @ |c|`; and the derivative kernel the row action of the **majorant of
A2.3**, that recursion with every coefficient replaced by its modulus, because it
differences and so has no companion of its own.

**The fourteen fusing sites were enumerated by reading the source and confirmed by
disassembling a `-march=native` build.** Both give the same fourteen.
`scripts/measure_bezier_fma_bound.py` re-derives that enumeration rather than quoting
it, along with the movement counts, the slack per kernel, and the majorant check.

## Acceptance criteria

- [x] Every claim selected at run time: exact where the ISA has no FMA, bounded where
      it has one.
- [x] The bound holds against a real `-march=native` build: 494 passed, 54 skipped,
      none exceeded. Against the shipped build, 548 passed.
- [x] Contraction isolated as the only mechanism: `-march=native` with
      `-ffp-contract=off` restores bit-identity exactly (0 of 1260 and 0 of 3616) while
      the vectorisation stays (191 packed arithmetic instructions against 34).
- [x] The bounded branch is exercised on this non-fusing host, by a probe inside the
      tolerance and one past it, both built from the real amplifications.
- [x] The premise that the oracle never fuses is pinned by a discriminating test:
      `a*b+c` gives no FMA under `fastmath=False` and one under `fastmath=True`.
- [x] The A2.3 majorant validated over 75563 (point, basis) entries: no violations,
      largest ratio exactly 1.000000, so it is attained rather than conservative.
- [x] No amplification is vacuous per element: 0 of 280 non-zero float32 derivative
      values carry a tolerance as large as their own magnitude, against 45 before.
- [x] Full local check suite green: 37/37 discipline and build checks, ruff, ruff
      format, mypy, import-lint, 82 doctests, docs with `-W`.

## What review changed, and it was not cosmetic

A scoped review ran three lenses. The claim verifier confirmed 11 of 13 quoted figures
exactly and found two with no committed artifact; the tolerance audit found two
criticals and five importants; the mathematician died on a session limit without
returning, and what it was to cover is named under Non-goals.

- **The derivative amplification was vacuous per element.** `p!/(p-k)! * 2^k * max|c|`
  bounds the operator norm rather than the row, and applies the input maximum where the
  comparison happens per output element: 45 of 280 non-zero float32 values carried a
  tolerance at least as large as their own magnitude, worst case 1.6e5 times. The
  vacuity guard could not see it, because it compares the largest tolerance against the
  largest magnitude and a flat amplification is sized for that element.
- Replacing it with the finished operator's row action removed the vacuity and was then
  **exceeded by 4.32x**, identically at both dtypes. A2.3 differences, so its partial
  sums can exceed what survives to the output. The majorant of the recursion is what
  holds.
- The elevation chain is `min(p, t) + 1`, 13x tighter at degree 25. The reduction apply
  narrows once per output element rather than once per stage, 52x tighter at float32. A
  zero-stage claim is bitwise rather than a clamped single stage.
- **Five justifications quoted `max|c|` while the code passed the companion.** The
  amplification changed during the work and the prose did not follow it, and that prose
  is printed verbatim in every failure message.
- The harness's factor of two justifies itself by a convention this budget does not use.
  It stays, restated as an acknowledged safety margin.

## Non-goals

- **No CI job building with `-march=native`.** Eigen does not compile that way with
  warnings as errors, its AVX512 triangular-solve kernel tripping
  `-Wmaybe-uninitialized` in its own code.
- **No change to what the shipped build does.** The baseline still cannot fuse and every
  claim still takes its exact branch there.
- **Two questions the lens that died was to settle**, neither load-bearing for the bound
  as it now stands: whether using a multiplicative growth model for an additive
  accumulation is conservative or a category error that happens to be safe, and whether
  `sum_j |B^(k)_j(s)|` attains `p!/(p-k)! 2^k` pointwise in `s` or only at the
  endpoints. The second no longer feeds any amplification here.

## Three tests still skip on a fusing build

Each names its own reason: `minimize_degree` returns a **discrete** degree, so no
tolerance covers a decision that flips; the factorial-overflow case has **wrapped**, so
the falling factorial describes no magnitude; and `compose` forms the product kernel's
operands internally, where the only externally available amplification is around 1e18. A
separate test drives that kernel at its own entry point, where the operands are known.

## Two build traps recorded in the design note

`-DCMAKE_CXX_FLAGS=-ffp-contract=off` **does nothing**: the target option added by
`cmake/PantrCompileOptions.cmake` lands after it and wins. The first build made to
isolate contraction was byte-identical to the fusing one, and only
`compile_commands.json` showed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
