### PR TITLE
feat(bezier): port the root-finding block to C++ behind the dual-backend dispatch

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -118,10 +118,12 @@ if(PANTR_NANOBIND_SPLIT)
   # -Werror ends the build.
   nanobind_add_module(_pantr_cpp NOMINSIZE NOSTRIP NB_SUPPRESS_WARNINGS
                       BACKEND_MODULE nanobind_backend
-                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
+                      bezier_root_finding.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
-                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp)
+                      pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
+                      bezier_root_finding.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/bezier_root_finding.cpp
+++ b/cpp/bindings/bezier_root_finding.cpp
@@ -1,0 +1,259 @@
+/// \file
+/// nanobind bindings for the `pantr.bezier` root-finding kernels.
+///
+/// Six entry points, which are exactly the seam `src/pantr/bezier/_find_roots.py`
+/// reaches for. The sixteen kernels behind them are not bound and cannot be: they
+/// call each other from inside `nopython` code on the Numba side, and no dispatch
+/// can be inserted between two Numba kernels, so the boundary is forced up to here.
+/// That is also why `_root_finding_core.py` keeps its kernels and its module path
+/// untouched by this port, including the one a downstream consumer imports.
+///
+/// ## These kernels return a count, and that is deliberate
+///
+/// `bezier.cpp`'s eight fill the caller's buffer and return `None`. These fill a
+/// buffer and return **how much of it is valid**, because the answer's size is not
+/// a function of the input: a degree-`n` polynomial has anywhere from zero to `n`
+/// roots and the caller cannot size the result in advance. Returning the count is
+/// the alternative to returning a fresh array, and it keeps the allocation with the
+/// caller where the rest of the tree keeps it.
+///
+/// The Numba side returns `(array, count)` instead. `_root_finding_backend.py`
+/// adapts, in three lines per kernel, rather than the oracle being reshaped to
+/// match: the oracle is what parity is measured against and it was cross-checked
+/// bit for bit before any of this existed, so changing it to suit the binding would
+/// move the thing being measured.
+///
+/// ## What the checks are for
+///
+/// nanobind settles dtype, rank and contiguity. What it cannot express is that
+/// `out` must be long enough for the *worst case* of a search whose result size is
+/// unknown, and each bound below is the kernel's own worst case rather than a
+/// guess: `degree` roots from Yuksel, `3 * degree + 4` from clipping before the
+/// duplicates are merged, `n_roots` from the merge itself.
+///
+/// **An empty coefficient array is undefined, not merely wrong.** Every kernel here
+/// takes `degree` as `coeff.size() - 1`, and the clipping driver indexes
+/// `root_coeff[0]` before any loop bound could stop it. Same class as the floor
+/// `bezier.cpp` documents, reached by a different route.
+///
+/// **A non-positive or non-finite tolerance is refused**, matching
+/// `_find_roots._resolve_tol`, which a direct call on the extension bypasses. The
+/// iteration terminates on its depth cap regardless, so this is a contract check
+/// rather than a safety one, and it is here so the two backends refuse the same
+/// inputs rather than one of them returning an answer to a question that was not
+/// asked.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+
+#include "pantr/bezier/root_finding.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+template <class T>
+using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using const_mat = nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_vec = nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_mat = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// Raise unless `coeff` holds at least one coefficient.
+///
+/// The degree is inferred as `size - 1`, and the clipping driver dereferences
+/// `coeff[0]` before any loop bound could stop it.
+template <class Arr>
+void require_coefficients(const Arr& coeff, const char* what) {
+    if (coeff.shape(0) == 0) {
+        throw nb::value_error(
+            (std::string(what) + " is empty, but its degree is inferred as its length minus one, "
+                                 "which needs at least one coefficient")
+                .c_str());
+    }
+}
+
+/// Raise unless `out` can hold `needed` entries.
+///
+/// A lower bound rather than an equality: the caller sizes the row by the degree
+/// while a kernel's worst case can be larger, and refusing a buffer that is merely
+/// generous would be wrong.
+template <class Arr>
+void require_capacity(const Arr& out, std::size_t needed, const char* what) {
+    if (out.shape(0) < needed) {
+        throw nb::value_error((std::string(what) + " holds " + std::to_string(out.shape(0)) +
+                               " entries, but this call can produce " + std::to_string(needed))
+                                  .c_str());
+    }
+}
+
+/// Raise unless `tol` is finite and strictly positive.
+///
+/// Mirrors `_find_roots._resolve_tol`, which a direct call on the extension skips.
+/// Written as a conjunction so a NaN is refused rather than admitted.
+void require_tolerance(double tol, const char* what) {
+    if (!(tol > 0.0 && std::isfinite(tol))) {
+        throw nb::value_error(
+            (std::string(what) + " must be finite and positive, got " + std::to_string(tol))
+                .c_str());
+    }
+}
+
+/// The largest number of roots Yuksel's decomposition can report.
+std::size_t yuksel_capacity(std::size_t coeff_count) {
+    return coeff_count > 1 ? coeff_count - 1 : 1;
+}
+
+/// The largest number of candidates Bézier clipping can report before the merge.
+std::size_t clip_capacity(std::size_t coeff_count) {
+    return 3 * (coeff_count - 1) + 4;
+}
+
+template <class T>
+int bind_yuksel_roots(const_vec<T> coeff, double tol, out_vec<double> out) {
+    require_coefficients(coeff, "coeff");
+    require_tolerance(tol, "tol");
+    require_capacity(out, yuksel_capacity(coeff.shape(0)), "out");
+    return pantr::yuksel_roots<T>(std::span<const T>(coeff.data(), coeff.shape(0)), tol,
+                                  std::span<double>(out.data(), out.shape(0)));
+}
+
+template <class T>
+int bind_clip_roots(const_vec<T> coeff, double param_tol, double geom_tol, out_vec<double> out) {
+    require_coefficients(coeff, "coeff");
+    require_tolerance(param_tol, "param_tol");
+    require_tolerance(geom_tol, "geom_tol");
+    require_capacity(out, clip_capacity(coeff.shape(0)), "out");
+    return pantr::clip_roots<T>(std::span<const T>(coeff.data(), coeff.shape(0)), param_tol,
+                                geom_tol, std::span<double>(out.data(), out.shape(0)));
+}
+
+template <class T>
+int bind_dedup_roots(const_vec<double> raw_roots, int n_roots, const_vec<T> coeff,
+                     double param_tol, double geom_tol, out_vec<double> out) {
+    require_coefficients(coeff, "coeff");
+    require_tolerance(param_tol, "param_tol");
+    require_tolerance(geom_tol, "geom_tol");
+    if (n_roots < 0 || static_cast<std::size_t>(n_roots) > raw_roots.shape(0)) {
+        throw nb::value_error(("n_roots is " + std::to_string(n_roots) +
+                               ", which is not a valid count for a raw_roots of length " +
+                               std::to_string(raw_roots.shape(0)))
+                                  .c_str());
+    }
+    require_capacity(out, static_cast<std::size_t>(n_roots), "out");
+    return pantr::dedup_roots<T>(
+        std::span<const double>(raw_roots.data(), raw_roots.shape(0)), n_roots,
+        std::span<const T>(coeff.data(), coeff.shape(0)), param_tol, geom_tol,
+        std::span<double>(out.data(), out.shape(0)));
+}
+
+template <class T>
+double bind_solve_monotone_root(const_vec<T> coeff, double tol) {
+    require_coefficients(coeff, "coeff");
+    require_tolerance(tol, "tol");
+    return pantr::solve_monotone_root<T>(std::span<const T>(coeff.data(), coeff.shape(0)), tol);
+}
+
+template <class T>
+void bind_find_roots_batch(const_mat<T> coeffs, double param_tol, double geom_tol,
+                           out_mat<double> out_roots, out_vec<std::int64_t> out_counts) {
+    require_tolerance(param_tol, "param_tol");
+    require_tolerance(geom_tol, "geom_tol");
+    if (coeffs.shape(1) == 0) {
+        throw nb::value_error("coeffs has no columns, but each row's degree is inferred as its "
+                              "length minus one, which needs at least one coefficient");
+    }
+    if (out_roots.shape(0) != coeffs.shape(0) || out_counts.shape(0) != coeffs.shape(0)) {
+        throw nb::value_error(("out_roots and out_counts must have " +
+                               std::to_string(coeffs.shape(0)) + " rows, got " +
+                               std::to_string(out_roots.shape(0)) + " and " +
+                               std::to_string(out_counts.shape(0)))
+                                  .c_str());
+    }
+    require_capacity(out_roots, 1, "out_roots");
+    pantr::find_roots_batch<T>(
+        pantr::span2d<const T>(coeffs.data(), coeffs.shape(0), coeffs.shape(1)), param_tol,
+        geom_tol, pantr::span2d<double>(out_roots.data(), out_roots.shape(0), out_roots.shape(1)),
+        std::span<std::int64_t>(out_counts.data(), out_counts.shape(0)));
+}
+
+template <class T>
+void bind_solve_monotone_root_batch(const_mat<T> coeffs, double tol, out_vec<double> out_roots) {
+    require_tolerance(tol, "tol");
+    if (coeffs.shape(1) == 0) {
+        throw nb::value_error("coeffs has no columns, but each row's degree is inferred as its "
+                              "length minus one, which needs at least one coefficient");
+    }
+    if (out_roots.shape(0) != coeffs.shape(0)) {
+        throw nb::value_error(("out_roots must have " + std::to_string(coeffs.shape(0)) +
+                               " entries, got " + std::to_string(out_roots.shape(0)))
+                                  .c_str());
+    }
+    pantr::solve_monotone_root_batch<T>(
+        pantr::span2d<const T>(coeffs.data(), coeffs.shape(0), coeffs.shape(1)), tol,
+        std::span<double>(out_roots.data(), out_roots.shape(0)));
+}
+
+}  // namespace
+
+void register_bezier_root_finding(nb::module_& m) {
+    // `.noconvert()` and keyword-only outputs, for the reasons `basis.cpp` sets out
+    // and `bezier.cpp` repeats: without `.noconvert()` nanobind can satisfy a
+    // contiguity constraint by filling a temporary and discarding it, so an
+    // out-parameter silently does nothing.
+    //
+    // `param_tol` and `geom_tol` are adjacent same-typed positional parameters and
+    // transposing them returns a different, plausible root set rather than an
+    // error. They are not made keyword-only because the Numba kernels they stand in
+    // for take them positionally and the catalogue hands out both; the ordering trap
+    // is instead closed one layer up, where `_find_roots.py` passes the same
+    // resolved tolerance to each.
+    m.def("yuksel_roots", &bind_yuksel_roots<double>, nb::arg("coeff").noconvert(),
+          nb::arg("tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("yuksel_roots", &bind_yuksel_roots<float>, nb::arg("coeff").noconvert(), nb::arg("tol"),
+          nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("clip_roots", &bind_clip_roots<double>, nb::arg("coeff").noconvert(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("clip_roots", &bind_clip_roots<float>, nb::arg("coeff").noconvert(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("dedup_roots", &bind_dedup_roots<double>, nb::arg("raw_roots").noconvert(),
+          nb::arg("n_roots"), nb::arg("coeff").noconvert(), nb::arg("param_tol"),
+          nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("dedup_roots", &bind_dedup_roots<float>, nb::arg("raw_roots").noconvert(),
+          nb::arg("n_roots"), nb::arg("coeff").noconvert(), nb::arg("param_tol"),
+          nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+
+    m.def("solve_monotone_root", &bind_solve_monotone_root<double>, nb::arg("coeff").noconvert(),
+          nb::arg("tol"));
+    m.def("solve_monotone_root", &bind_solve_monotone_root<float>, nb::arg("coeff").noconvert(),
+          nb::arg("tol"));
+
+    m.def("find_roots_batch", &bind_find_roots_batch<double>, nb::arg("coeffs").noconvert(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(),
+          nb::arg("out_roots").noconvert(), nb::arg("out_counts").noconvert());
+    m.def("find_roots_batch", &bind_find_roots_batch<float>, nb::arg("coeffs").noconvert(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(),
+          nb::arg("out_roots").noconvert(), nb::arg("out_counts").noconvert());
+
+    m.def("solve_monotone_root_batch", &bind_solve_monotone_root_batch<double>,
+          nb::arg("coeffs").noconvert(), nb::arg("tol"), nb::kw_only(),
+          nb::arg("out_roots").noconvert());
+    m.def("solve_monotone_root_batch", &bind_solve_monotone_root_batch<float>,
+          nb::arg("coeffs").noconvert(), nb::arg("tol"), nb::kw_only(),
+          nb::arg("out_roots").noconvert());
+}

--- a/cpp/bindings/bezier_root_finding.cpp
+++ b/cpp/bindings/bezier_root_finding.cpp
@@ -86,16 +86,27 @@ void require_coefficients(const Arr& coeff, const char* what) {
     }
 }
 
-/// Raise unless `out` can hold `needed` entries.
+/// Raise unless `out` can hold `needed` entries along `axis`.
 ///
 /// A lower bound rather than an equality: the caller sizes the row by the degree
 /// while a kernel's worst case can be larger, and refusing a buffer that is merely
 /// generous would be wrong.
+///
+/// The axis is explicit because getting it wrong is silent. An earlier version took
+/// `shape(0)` implicitly, which is the right axis for the 1-D outputs and the wrong
+/// one for `find_roots_batch`'s 2-D `out_roots`, whose first axis is the polynomial
+/// count and whose **second** is the row the kernel writes into. The check then
+/// duplicated a constraint already enforced two lines above, the row width went
+/// unchecked, and an undersized buffer was accepted with the per-row count silently
+/// clamped to whatever fitted: a batch with two roots reported one, and with a
+/// zero-width row reported none, both without an error.
 template <class Arr>
-void require_capacity(const Arr& out, std::size_t needed, const char* what) {
-    if (out.shape(0) < needed) {
-        throw nb::value_error((std::string(what) + " holds " + std::to_string(out.shape(0)) +
-                               " entries, but this call can produce " + std::to_string(needed))
+void require_capacity(const Arr& out, std::size_t axis, std::size_t needed, const char* what) {
+    if (out.shape(axis) < needed) {
+        throw nb::value_error((std::string(what) + " holds " +
+                               std::to_string(out.shape(axis)) + " entries along axis " +
+                               std::to_string(axis) + ", but this call can produce " +
+                               std::to_string(needed))
                                   .c_str());
     }
 }
@@ -123,11 +134,11 @@ std::size_t clip_capacity(std::size_t coeff_count) {
 }
 
 template <class T>
-int bind_yuksel_roots(const_vec<T> coeff, double tol, out_vec<double> out) {
+int bind_yuksel_roots(const_vec<T> coeff, double param_tol, out_vec<double> out) {
     require_coefficients(coeff, "coeff");
-    require_tolerance(tol, "tol");
-    require_capacity(out, yuksel_capacity(coeff.shape(0)), "out");
-    return pantr::yuksel_roots<T>(std::span<const T>(coeff.data(), coeff.shape(0)), tol,
+    require_tolerance(param_tol, "param_tol");
+    require_capacity(out, 0, yuksel_capacity(coeff.shape(0)), "out");
+    return pantr::yuksel_roots<T>(std::span<const T>(coeff.data(), coeff.shape(0)), param_tol,
                                   std::span<double>(out.data(), out.shape(0)));
 }
 
@@ -136,13 +147,13 @@ int bind_clip_roots(const_vec<T> coeff, double param_tol, double geom_tol, out_v
     require_coefficients(coeff, "coeff");
     require_tolerance(param_tol, "param_tol");
     require_tolerance(geom_tol, "geom_tol");
-    require_capacity(out, clip_capacity(coeff.shape(0)), "out");
+    require_capacity(out, 0, clip_capacity(coeff.shape(0)), "out");
     return pantr::clip_roots<T>(std::span<const T>(coeff.data(), coeff.shape(0)), param_tol,
                                 geom_tol, std::span<double>(out.data(), out.shape(0)));
 }
 
 template <class T>
-int bind_dedup_roots(const_vec<double> raw_roots, int n_roots, const_vec<T> coeff,
+int bind_dedup_roots(const_vec<T> coeff, const_vec<double> raw_roots, int n_roots,
                      double param_tol, double geom_tol, out_vec<double> out) {
     require_coefficients(coeff, "coeff");
     require_tolerance(param_tol, "param_tol");
@@ -153,7 +164,7 @@ int bind_dedup_roots(const_vec<double> raw_roots, int n_roots, const_vec<T> coef
                                std::to_string(raw_roots.shape(0)))
                                   .c_str());
     }
-    require_capacity(out, static_cast<std::size_t>(n_roots), "out");
+    require_capacity(out, 0, static_cast<std::size_t>(n_roots), "out");
     return pantr::dedup_roots<T>(
         std::span<const double>(raw_roots.data(), raw_roots.shape(0)), n_roots,
         std::span<const T>(coeff.data(), coeff.shape(0)), param_tol, geom_tol,
@@ -161,10 +172,11 @@ int bind_dedup_roots(const_vec<double> raw_roots, int n_roots, const_vec<T> coef
 }
 
 template <class T>
-double bind_solve_monotone_root(const_vec<T> coeff, double tol) {
+double bind_solve_monotone_root(const_vec<T> coeff, double param_tol) {
     require_coefficients(coeff, "coeff");
-    require_tolerance(tol, "tol");
-    return pantr::solve_monotone_root<T>(std::span<const T>(coeff.data(), coeff.shape(0)), tol);
+    require_tolerance(param_tol, "param_tol");
+    return pantr::solve_monotone_root<T>(std::span<const T>(coeff.data(), coeff.shape(0)),
+                                         param_tol);
 }
 
 template <class T>
@@ -183,7 +195,10 @@ void bind_find_roots_batch(const_mat<T> coeffs, double param_tol, double geom_to
                                std::to_string(out_counts.shape(0)))
                                   .c_str());
     }
-    require_capacity(out_roots, 1, "out_roots");
+    // The row the kernel writes into. A degree-n polynomial has at most n roots,
+    // and Layer 2 allocates max(n, 1) so a degree-0 batch still has somewhere to
+    // write nothing.
+    require_capacity(out_roots, 1, yuksel_capacity(coeffs.shape(1)), "out_roots");
     pantr::find_roots_batch<T>(
         pantr::span2d<const T>(coeffs.data(), coeffs.shape(0), coeffs.shape(1)), param_tol,
         geom_tol, pantr::span2d<double>(out_roots.data(), out_roots.shape(0), out_roots.shape(1)),
@@ -191,8 +206,9 @@ void bind_find_roots_batch(const_mat<T> coeffs, double param_tol, double geom_to
 }
 
 template <class T>
-void bind_solve_monotone_root_batch(const_mat<T> coeffs, double tol, out_vec<double> out_roots) {
-    require_tolerance(tol, "tol");
+void bind_solve_monotone_root_batch(const_mat<T> coeffs, double param_tol,
+                                    out_vec<double> out_roots) {
+    require_tolerance(param_tol, "param_tol");
     if (coeffs.shape(1) == 0) {
         throw nb::value_error("coeffs has no columns, but each row's degree is inferred as its "
                               "length minus one, which needs at least one coefficient");
@@ -203,7 +219,7 @@ void bind_solve_monotone_root_batch(const_mat<T> coeffs, double tol, out_vec<dou
                                   .c_str());
     }
     pantr::solve_monotone_root_batch<T>(
-        pantr::span2d<const T>(coeffs.data(), coeffs.shape(0), coeffs.shape(1)), tol,
+        pantr::span2d<const T>(coeffs.data(), coeffs.shape(0), coeffs.shape(1)), param_tol,
         std::span<double>(out_roots.data(), out_roots.shape(0)));
 }
 
@@ -215,45 +231,53 @@ void register_bezier_root_finding(nb::module_& m) {
     // contiguity constraint by filling a temporary and discarding it, so an
     // out-parameter silently does nothing.
     //
-    // `param_tol` and `geom_tol` are adjacent same-typed positional parameters and
-    // transposing them returns a different, plausible root set rather than an
-    // error. They are not made keyword-only because the Numba kernels they stand in
-    // for take them positionally and the catalogue hands out both; the ordering trap
-    // is instead closed one layer up, where `_find_roots.py` passes the same
-    // resolved tolerance to each.
+    // Two traps closed by the signature rather than by a comment, both found by an
+    // audit of this surface against its three siblings.
+    //
+    // `param_tol` and `geom_tol` are adjacent, same-typed, and nothing orders them,
+    // so `require_ordered_bounds` -- the guard `bezier.cpp` uses for `lower`/`upper`
+    // -- has no analogue here. Transposed, they return a different and plausible
+    // root set. An earlier version left them positional on the grounds that the
+    // Numba kernels take them so; that does not bind this signature, since the
+    // catalogue already adapts the return shape and can adapt the call too.
+    //
+    // `dedup_roots` takes the coefficients **first**, as every sibling in this file
+    // and every accessor in the four catalogues does. Its `raw_roots` is always
+    // `float64` and `coeff` frequently is, so a transposed call type-checks, runs,
+    // and merges against the wrong data.
     m.def("yuksel_roots", &bind_yuksel_roots<double>, nb::arg("coeff").noconvert(),
-          nb::arg("tol"), nb::kw_only(), nb::arg("out").noconvert());
-    m.def("yuksel_roots", &bind_yuksel_roots<float>, nb::arg("coeff").noconvert(), nb::arg("tol"),
-          nb::kw_only(), nb::arg("out").noconvert());
+          nb::arg("param_tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("yuksel_roots", &bind_yuksel_roots<float>, nb::arg("coeff").noconvert(),
+          nb::arg("param_tol"), nb::kw_only(), nb::arg("out").noconvert());
 
-    m.def("clip_roots", &bind_clip_roots<double>, nb::arg("coeff").noconvert(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
-    m.def("clip_roots", &bind_clip_roots<float>, nb::arg("coeff").noconvert(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("clip_roots", &bind_clip_roots<double>, nb::arg("coeff").noconvert(), nb::kw_only(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
+    m.def("clip_roots", &bind_clip_roots<float>, nb::arg("coeff").noconvert(), nb::kw_only(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
 
-    m.def("dedup_roots", &bind_dedup_roots<double>, nb::arg("raw_roots").noconvert(),
-          nb::arg("n_roots"), nb::arg("coeff").noconvert(), nb::arg("param_tol"),
-          nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
-    m.def("dedup_roots", &bind_dedup_roots<float>, nb::arg("raw_roots").noconvert(),
-          nb::arg("n_roots"), nb::arg("coeff").noconvert(), nb::arg("param_tol"),
-          nb::arg("geom_tol"), nb::kw_only(), nb::arg("out").noconvert());
+    m.def("dedup_roots", &bind_dedup_roots<double>, nb::arg("coeff").noconvert(),
+          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::kw_only(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
+    m.def("dedup_roots", &bind_dedup_roots<float>, nb::arg("coeff").noconvert(),
+          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::kw_only(),
+          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
 
     m.def("solve_monotone_root", &bind_solve_monotone_root<double>, nb::arg("coeff").noconvert(),
-          nb::arg("tol"));
+          nb::arg("param_tol"));
     m.def("solve_monotone_root", &bind_solve_monotone_root<float>, nb::arg("coeff").noconvert(),
-          nb::arg("tol"));
+          nb::arg("param_tol"));
 
     m.def("find_roots_batch", &bind_find_roots_batch<double>, nb::arg("coeffs").noconvert(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(),
+          nb::kw_only(), nb::arg("param_tol"), nb::arg("geom_tol"),
           nb::arg("out_roots").noconvert(), nb::arg("out_counts").noconvert());
     m.def("find_roots_batch", &bind_find_roots_batch<float>, nb::arg("coeffs").noconvert(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::kw_only(),
+          nb::kw_only(), nb::arg("param_tol"), nb::arg("geom_tol"),
           nb::arg("out_roots").noconvert(), nb::arg("out_counts").noconvert());
 
     m.def("solve_monotone_root_batch", &bind_solve_monotone_root_batch<double>,
-          nb::arg("coeffs").noconvert(), nb::arg("tol"), nb::kw_only(),
+          nb::arg("coeffs").noconvert(), nb::arg("param_tol"), nb::kw_only(),
           nb::arg("out_roots").noconvert());
     m.def("solve_monotone_root_batch", &bind_solve_monotone_root_batch<float>,
-          nb::arg("coeffs").noconvert(), nb::arg("tol"), nb::kw_only(),
+          nb::arg("coeffs").noconvert(), nb::arg("param_tol"), nb::kw_only(),
           nb::arg("out_roots").noconvert());
 }

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -64,6 +64,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_quad(m);
     register_change_basis(m);
     register_bezier(m);
+    register_bezier_root_finding(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -19,5 +19,12 @@ void register_quad(nanobind::module_& m);
 /// Register the `pantr.change_basis` kernel bindings on `m`.
 void register_change_basis(nanobind::module_& m);
 
-/// Register the `pantr.bezier` kernel bindings on `m`.
+/// Register the `pantr.bezier` arithmetic kernel bindings on `m`.
 void register_bezier(nanobind::module_& m);
+
+/// Register the `pantr.bezier` root-finding kernel bindings on `m`.
+///
+/// Separate from `register_bezier` because the two halves of the package are
+/// separate ports with separate parity claims, and the file comments that justify
+/// each one's checks do not belong in the same file.
+void register_bezier_root_finding(nanobind::module_& m);

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -1,0 +1,1343 @@
+#pragma once
+
+/// \file
+/// The sixteen root-finding kernels of `src/pantr/bezier/_root_finding_core.py`,
+/// `_clipping_core.py`, `_yuksel_core.py` and `_batch_core.py`, which stay as the
+/// parity oracle.
+///
+/// This is a **transliteration**, branch for branch and expression for expression,
+/// and that is a decision rather than laziness. The block is iterative and every
+/// verdict it reaches is discrete: how many roots, which intervals survive, which
+/// hull vertices are kept. A cleaner reimplementation would have to be graded by a
+/// set distance over a discrete verdict, with the Numba side as the only available
+/// reference, which is the weakest parity claim in the tree. Reproducing the
+/// arithmetic instead buys an equality, and an equality is checked rather than
+/// argued.
+///
+/// ## Numba's `float()` does not widen, and three of five widths follow from that
+///
+/// `float(coeff[0])` in a `nopython` kernel reads as a promotion and is a no-op: a
+/// `float32` stays a `float32` and so does every operation built on it. What widens
+/// in Numba is type unification across assignments, so a variable seeded with `0.0`
+/// or `float("inf")` and later given a `float32` is `float64` throughout. Six sites
+/// in the oracle carry a `float()` a reader would take for a cast; none promotes.
+///
+/// `scripts/measure_root_finding_widths.py` measures all of this behaviourally, two
+/// rival models per site against the kernel, and reports how often the two models
+/// disagree so a match cannot come from a check that could not fail. It is the
+/// specification this file is written against, and it is the thing to re-run rather
+/// than the table below to trust.
+///
+/// | site | width | what a C++ author writes by default |
+/// |---|---|---|
+/// | de Casteljau triangle | accumulate `Acc`, **store `T`** | keeps the running value in a register |
+/// | `d1 - d0` in the derivative | **`T`** | subtracts two `Acc` locals |
+/// | hull orientation predicate | differences in **`T`**, product in `double` | templates the whole expression on `T` |
+/// | Yuksel forward difference | subtract in **`T`**, widen on store | subtracts into the `double` destination |
+/// | degree-1 base case `c0/(c0-c1)` | **`T`** | divides in `double` |
+///
+/// The last is the one that matters most. Writing `double root = c0 / (c0 - c1);`
+/// breaks parity on **every** `float32` input (the `double` model matched none of
+/// 20000 pairs) and the difference reads as round-off rather than as a defect. Every
+/// Yuksel recursion bottoms out there.
+///
+/// And two sites look exactly like those and behave the opposite way, so none of
+/// this is a per-kernel or per-module rule: `_batch_core.py:87` divides in `double`
+/// and `_yuksel_core.py:309` divides the same shape of expression in `T`. What
+/// separates them is whether some other assignment forced the variable wider.
+///
+/// ## Two library spellings, both measured rather than assumed
+///
+/// The one call in the whole block that leaves the four arithmetic operations is
+/// `zero_tol ** (1/3)`, and it must be `std::pow(x, 1.0 / 3.0)`. `std::cbrt` differs
+/// from Numba's `**` on 49659 of 50000 tolerances spanning `1e-300` to `1e3`, while
+/// `std::pow` differs on none.
+///
+/// Minima and maxima must be `std::min` and `std::max`, whose ternary expansion
+/// matches Numba's builtins on NaN, on signed zero and on infinities. `std::fmin`
+/// and `std::fmax` return the non-NaN operand and would not.
+///
+/// ## Contraction can change a verdict here, not just a last bit
+///
+/// The hull orientation predicate is `a * b - c * d`. On an **exactly collinear**
+/// control polygon it evaluates to exactly zero, so `cross >= 0` holds and Andrew's
+/// monotone chain pops the vertex. With `-ffp-contract=on` and an FMA-capable target
+/// the compiler may fuse it, that exact tie becomes a signed residue, and the
+/// tie-break turns into a coin toss: which vertices survive changes, and so does the
+/// clipped interval. Measured against the kernel, an unfused transliteration agrees
+/// on all 4800 collinear cases and a fused one on 3789.
+///
+/// A collinear control polygon is not exotic. A degree-elevated linear polynomial,
+/// an affine segment and a constant all produce one.
+///
+/// The shipped build carries no `-march`, so the baseline target has no fused
+/// multiply-add and nothing to contract into, which is why the parity claim is an
+/// equality there and bounded above it. That gate is `__fp_contract__`, read at run
+/// time by the parity tests, not assumed here.
+///
+/// ## Two defects are reproduced on purpose
+///
+/// The oracle has two pre-existing wrong answers in this block, filed as
+/// FELIGN/pantr#351 and #352, and this file reproduces both **deliberately**,
+/// because the port's contract is parity and not correction. They are marked at
+/// their sites. Fixing either means fixing both backends and the parity tests in one
+/// change; fixing one backend alone breaks the equality this whole file exists to
+/// support.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr {
+
+/// Machine epsilon for IEEE 754 double precision.
+///
+/// Spelled as a literal rather than taken from `std::numeric_limits`, and `double`
+/// whatever the coefficients are, mirroring `_root_finding_core._DBL_EPSILON`. Both
+/// choices are the oracle's: the constant is `float64` there even on the `float32`
+/// path, so deriving it from `T` here would change every tolerance in the block.
+inline constexpr double kDblEpsilon = 2.2204460492503131e-16;
+
+/// Iteration cap for the Newton/bisection hybrid. Mirrors `_yuksel_core._MAX_NEWTON_ITER`.
+inline constexpr int kMaxNewtonIter = 64;
+
+/// Relative interval reduction below which clipping subdivides instead of recursing.
+///
+/// Mirrors `_clipping_core._CLIP_REDUCTION_THRESHOLD`.
+inline constexpr double kClipReductionThreshold = 0.2;
+
+/// Recursion-depth cap for Bézier clipping. Mirrors `_clipping_core._CLIP_MAX_DEPTH`.
+inline constexpr int kClipMaxDepth = 64;
+
+/// Interval-stack capacity for Bézier clipping. Mirrors `_clipping_core._MAX_STACK_SIZE`.
+inline constexpr int kMaxStackSize = 256;
+
+/// Lowest degree at which Bézier clipping is considered. Mirrors `_batch_core._CLIP_MIN_DEGREE`.
+inline constexpr int kClipMinDegree = 6;
+
+/// Coefficient dynamic range above which clipping is declined. Mirrors
+/// `_batch_core._CLIP_COEFF_RANGE_LIMIT`.
+inline constexpr double kClipCoeffRangeLimit = 1e8;
+
+namespace detail {
+
+/// Evaluate a scalar Bernstein polynomial at one parameter, by de Casteljau.
+///
+/// The workspace carries the **coefficient** type while the parameter is `double`,
+/// so each step computes at accumulator width and rounds once on the store. Hoisting
+/// `work[i]` into an accumulator register would be the natural C++ and would drift
+/// from the oracle by a growing multiple of one `T` ulp.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `n + 1`.
+/// \param t Parameter in [0, 1].
+/// \param work Scratch of at least `coeff.size()` entries; contents are not read.
+/// \return The polynomial value, at coefficient width, as the oracle returns it.
+///
+/// Mirrors `_root_finding_core._de_casteljau_eval_scalar`. No validation is
+/// performed; the Python layer guarantees the shapes.
+template <Real T>
+T de_casteljau_eval_scalar(std::span<const T> coeff, accumulator_t<T> t, std::span<T> work) {
+    const auto n = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
+    std::copy(coeff.begin(), coeff.end(), work.begin());
+    for (std::ptrdiff_t k = 1; k <= n; ++k) {
+        for (std::ptrdiff_t i = 0; i <= n - k; ++i) {
+            work[static_cast<std::size_t>(i)] = static_cast<T>(
+                (accumulator_t<T>{1} - t) * static_cast<accumulator_t<T>>(work[static_cast<std::size_t>(i)])
+                + t * static_cast<accumulator_t<T>>(work[static_cast<std::size_t>(i) + 1]));
+        }
+    }
+    return work[0];
+}
+
+/// Evaluate a scalar Bernstein polynomial and its derivative at one parameter.
+///
+/// Runs the triangle to the penultimate row, whose two entries give the derivative.
+/// **`d1 - d0` is a `T` subtraction**, not a `double` one: the two entries are read
+/// out of the narrow workspace and subtracted before the degree factor promotes the
+/// product. Subtracting them as accumulators instead matched only 1543 of 2400
+/// float32 cases.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `n + 1`.
+/// \param t Parameter in [0, 1].
+/// \param work Scratch of at least `coeff.size()` entries; contents are not read.
+/// \param out_deriv Receives the derivative.
+/// \return The polynomial value.
+///
+/// Mirrors `_root_finding_core._de_casteljau_eval_and_deriv_scalar`. No validation is
+/// performed.
+template <Real T>
+accumulator_t<T> de_casteljau_eval_and_deriv_scalar(std::span<const T> coeff, accumulator_t<T> t,
+                                                    std::span<T> work,
+                                                    accumulator_t<T>& out_deriv) {
+    using Acc = accumulator_t<T>;
+    const auto n = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
+    if (n == 0) {
+        out_deriv = Acc{0};
+        return static_cast<Acc>(coeff[0]);
+    }
+
+    const Acc s = Acc{1} - t;
+    std::copy(coeff.begin(), coeff.end(), work.begin());
+    for (std::ptrdiff_t k = 1; k < n; ++k) {
+        for (std::ptrdiff_t i = 0; i <= n - k; ++i) {
+            work[static_cast<std::size_t>(i)] =
+                static_cast<T>(s * static_cast<Acc>(work[static_cast<std::size_t>(i)])
+                               + t * static_cast<Acc>(work[static_cast<std::size_t>(i) + 1]));
+        }
+    }
+
+    const T d0 = work[0];
+    const T d1 = work[1];
+    // Narrow on purpose: the oracle subtracts two workspace entries, not two doubles.
+    const T narrow_difference = static_cast<T>(d1 - d0);
+    out_deriv = static_cast<Acc>(n) * static_cast<Acc>(narrow_difference);
+    return s * static_cast<Acc>(d0) + t * static_cast<Acc>(d1);
+}
+
+/// Restrict a scalar Bernstein polynomial to `[lower, upper]`, reparametrised to [0, 1].
+///
+/// Two-pass de Casteljau, the pass order chosen to avoid dividing by a small number.
+/// The workspace is `double` whatever the coefficients are, so the widening happens
+/// once on the way in and every step after it is a `double` step.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `p + 1`.
+/// \param lower Left bound in [0, 1).
+/// \param upper Right bound in (0, 1].
+/// \param out Receives `p + 1` restricted coefficients.
+///
+/// Mirrors `_root_finding_core._restrict_scalar`. No validation is performed.
+template <Real T>
+void restrict_scalar(std::span<const T> coeff, double lower, double upper, std::span<double> out) {
+    const auto p = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
+    for (std::ptrdiff_t i = 0; i <= p; ++i) {
+        out[static_cast<std::size_t>(i)] = static_cast<double>(coeff[static_cast<std::size_t>(i)]);
+    }
+
+    if (std::abs(upper) >= std::abs(lower - 1.0)) {
+        const double tau = upper;
+        for (std::ptrdiff_t step = 1; step <= p; ++step) {
+            for (std::ptrdiff_t j = p; j >= step; --j) {
+                const auto u = static_cast<std::size_t>(j);
+                out[u] = out[u] * tau + out[u - 1] * (1.0 - tau);
+            }
+        }
+        const double tau2 = upper != 0.0 ? lower / upper : 0.0;
+        for (std::ptrdiff_t step = 1; step <= p; ++step) {
+            for (std::ptrdiff_t j = 0; j <= p - step; ++j) {
+                const auto u = static_cast<std::size_t>(j);
+                out[u] = out[u] * (1.0 - tau2) + out[u + 1] * tau2;
+            }
+        }
+    } else {
+        const double tau = lower;
+        for (std::ptrdiff_t step = 1; step <= p; ++step) {
+            for (std::ptrdiff_t j = 0; j <= p - step; ++j) {
+                const auto u = static_cast<std::size_t>(j);
+                out[u] = out[u] * (1.0 - tau) + out[u + 1] * tau;
+            }
+        }
+        const double tau2 = lower != 1.0 ? (upper - lower) / (1.0 - lower) : 0.0;
+        for (std::ptrdiff_t step = 1; step <= p; ++step) {
+            for (std::ptrdiff_t j = p; j >= step; --j) {
+                const auto u = static_cast<std::size_t>(j);
+                out[u] = out[u] * tau2 + out[u - 1] * (1.0 - tau2);
+            }
+        }
+    }
+}
+
+/// Extract Bernstein coefficients for the sub-interval `[t_min, t_max]`.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients on [0, 1].
+/// \param t_min Sub-interval start, clamped into [0, 1].
+/// \param t_max Sub-interval end, clamped into [0, 1].
+/// \param out Receives `coeff.size()` reparametrised coefficients.
+///
+/// Mirrors `_root_finding_core._subdivide_scalar`. No validation is performed.
+template <Real T>
+void subdivide_scalar(std::span<const T> coeff, double t_min, double t_max,
+                      std::span<double> out) {
+    if (t_min <= 0.0 && t_max >= 1.0) {
+        for (std::size_t i = 0; i < coeff.size(); ++i) {
+            out[i] = static_cast<double>(coeff[i]);
+        }
+        return;
+    }
+    // std::min/std::max, never fmin/fmax: the ternary expansion is what Numba's
+    // builtins do on NaN and on signed zero.
+    t_min = std::min(std::max(t_min, 0.0), 1.0);
+    t_max = std::min(std::max(t_max, 0.0), 1.0);
+    restrict_scalar<T>(coeff, t_min, t_max, out);
+}
+
+/// Count sign changes in a Bernstein coefficient sequence, ignoring exact zeros.
+///
+/// Comparisons only, so this kernel has no width at all and needs none of the care
+/// the rest of the file does.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients.
+/// \return The number of sign changes, which bounds the root count above by the
+///     variation-diminishing property.
+///
+/// Mirrors `_root_finding_core._count_sign_changes`. No validation is performed.
+template <Real T>
+int count_sign_changes(std::span<const T> coeff) {
+    int changes = 0;
+    int previous = 0;
+    for (std::size_t i = 0; i < coeff.size(); ++i) {
+        const T v = coeff[i];
+        int sign = 0;
+        if (v > T{0}) {
+            sign = 1;
+        } else if (v < T{0}) {
+            sign = -1;
+        } else {
+            continue;
+        }
+        if (previous != 0 && previous != sign) {
+            ++changes;
+        }
+        previous = sign;
+    }
+    return changes;
+}
+
+/// Clip the parameter range using the convex hull of the control polygon.
+///
+/// Andrew's monotone chain over vertices `(i/n, c_i)`, whose x-coordinates are
+/// already ordered so no sort is needed, then every hull edge is tested against
+/// `y = 0`.
+///
+/// Two things about the orientation predicate. Its coefficient **differences run at
+/// `T`** and only the integer factor promotes the product, which is numpy's
+/// promotion of `int64` against `float32` and the opposite of what a C++ template
+/// over `T` gives by default; widening the differences first matched only 3541 of
+/// 10000 float32 triples. And on an exactly collinear polygon the predicate is
+/// exactly zero, so `cross >= 0` holds and the vertex is popped: that exact tie is
+/// what contraction destroys. See this file's opening note.
+///
+/// \tparam T Coefficient type. Reached with `double` from every call site in the
+///     library, since the caller passes the widened sub-interval coefficients; the
+///     `float` instantiation exists because the oracle accepts one.
+/// \param coeff Bernstein coefficients, length `n + 1`.
+/// \param chain Scratch of at least `n + 1` entries for the hull vertex indices.
+/// \param t_lo Receives the lowest crossing parameter found, untouched if none is.
+/// \param t_hi Receives the highest.
+/// \return Whether any zero crossing was detected.
+///
+/// Mirrors `_root_finding_core._clip_hull_to_zero`. No validation is performed.
+template <Real T>
+bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, double& t_lo,
+                       double& t_hi) {
+    const auto n = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
+    t_lo = 0.0;
+    t_hi = 0.0;
+    if (n < 1) {
+        return false;
+    }
+
+    const double inv_n = 1.0 / static_cast<double>(n);
+    t_lo = 1.0;
+    t_hi = 0.0;
+    bool found = false;
+
+    // The oracle builds the upper hull and consumes it, then does the same for the
+    // lower one, so a single scratch array serves both passes.
+    for (const bool upper : {true, false}) {
+        std::ptrdiff_t size = 0;
+        for (std::ptrdiff_t i = 0; i <= n; ++i) {
+            while (size >= 2) {
+                const auto j0 = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(size) - 2]);
+                const auto j1 = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(size) - 1]);
+                // Differences at T, products at double: numpy promotes int64 against
+                // float32 to float64, so only the index factors widen the product.
+                const T rise = static_cast<T>(coeff[static_cast<std::size_t>(i)]
+                                              - coeff[static_cast<std::size_t>(j0)]);
+                const T edge = static_cast<T>(coeff[static_cast<std::size_t>(j1)]
+                                              - coeff[static_cast<std::size_t>(j0)]);
+                const double cross = static_cast<double>(j1 - j0) * static_cast<double>(rise)
+                                     - static_cast<double>(edge) * static_cast<double>(i - j0);
+                if (upper ? (cross >= 0.0) : (cross <= 0.0)) {
+                    --size;
+                } else {
+                    break;
+                }
+            }
+            chain[static_cast<std::size_t>(size)] = static_cast<std::int64_t>(i);
+            ++size;
+        }
+
+        for (std::ptrdiff_t k = 0; k < size - 1; ++k) {
+            const auto ia = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(k)]);
+            const auto ib = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(k) + 1]);
+            const auto da = static_cast<double>(coeff[static_cast<std::size_t>(ia)]);
+            const auto db = static_cast<double>(coeff[static_cast<std::size_t>(ib)]);
+            if (da * db < 0.0) {
+                const double ta = static_cast<double>(ia) * inv_n;
+                const double tb = static_cast<double>(ib) * inv_n;
+                const double crossing = ta + (-da) / (db - da) * (tb - ta);
+                t_lo = std::min(t_lo, crossing);
+                t_hi = std::max(t_hi, crossing);
+                found = true;
+            }
+            if (da == 0.0) {
+                const double ta = static_cast<double>(ia) * inv_n;
+                t_lo = std::min(t_lo, ta);
+                t_hi = std::max(t_hi, ta);
+                found = true;
+            }
+        }
+
+        const auto last = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(size) - 1]);
+        if (coeff[static_cast<std::size_t>(last)] == T{0}) {
+            const double ta = static_cast<double>(last) * inv_n;
+            t_lo = std::min(t_lo, ta);
+            t_hi = std::max(t_hi, ta);
+            found = true;
+        }
+    }
+    return found;
+}
+
+/// Polish a root candidate with a single Newton step, accepted only if it improves.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Original Bernstein coefficients on [0, 1].
+/// \param mid Initial estimate.
+/// \param lo Left bound of the current interval.
+/// \param hi Right bound.
+/// \param param_tol Width of the acceptance neighbourhood around `[lo, hi]`.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \param out_f Receives the residual at the returned parameter.
+/// \param out_df Receives the derivative at `mid`, whatever is returned.
+/// \return The polished parameter, or `mid` unchanged.
+///
+/// Mirrors `_root_finding_core._newton_polish_scalar`. No validation is performed.
+template <Real T>
+accumulator_t<T> newton_polish_scalar(std::span<const T> coeff, accumulator_t<T> mid,
+                                      accumulator_t<T> lo, accumulator_t<T> hi,
+                                      accumulator_t<T> param_tol, std::span<T> work,
+                                      accumulator_t<T>& out_f, accumulator_t<T>& out_df) {
+    using Acc = accumulator_t<T>;
+    Acc df_mid{};
+    const Acc f_mid = de_casteljau_eval_and_deriv_scalar<T>(coeff, mid, work, df_mid);
+    out_df = df_mid;
+    if (std::abs(df_mid) > static_cast<Acc>(kDblEpsilon)) {
+        Acc newton = mid - f_mid / df_mid;
+        if (lo - param_tol <= newton && newton <= hi + param_tol) {
+            newton = std::max(Acc{0}, std::min(Acc{1}, newton));
+            const Acc f_newton = static_cast<Acc>(de_casteljau_eval_scalar<T>(coeff, newton, work));
+            if (std::abs(f_newton) <= std::abs(f_mid)) {
+                out_f = f_newton;
+                return newton;
+            }
+        }
+    }
+    out_f = f_mid;
+    return mid;
+}
+
+/// Find the unique root of a monotone Bernstein polynomial on [0, 1].
+///
+/// Yuksel's clamped Newton/bisection hybrid, seeded by false position clamped away
+/// from the boundaries where the derivative may vanish.
+///
+/// **`f_lo` and `f_hi` are at `T`, not at accumulator width.** The oracle writes
+/// `float(coeff[0])`, which does not widen in Numba, so the guard below, the
+/// false-position denominator and the initial quotient are all `T` operations.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients of a monotone scalar polynomial.
+/// \param param_tol Bracket-width termination tolerance.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \return The root parameter, or NaN when no sign change is detected.
+///
+/// Mirrors `_yuksel_core._solve_monotone_root_kernel`. No validation is performed.
+template <Real T>
+accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulator_t<T> param_tol,
+                                            std::span<T> work) {
+    using Acc = accumulator_t<T>;
+    Acc lo{0};
+    Acc hi{1};
+
+    const T f_lo = coeff[0];
+    const T f_hi = coeff[coeff.size() - 1];
+
+    // FELIGN/pantr#351, reproduced deliberately. This product is at T, so at float32
+    // two same-sign coefficients below about 1e-23 multiply to zero, the guard does
+    // not fire, and a root is returned for a polynomial that has none. Computing it
+    // at Acc would be correct and would break parity with the oracle.
+    if (f_lo * f_hi > T{0}) {
+        return std::numeric_limits<Acc>::quiet_NaN();
+    }
+
+    Acc x{};
+    if (std::abs(static_cast<Acc>(static_cast<T>(f_hi - f_lo))) > Acc{0}) {
+        // Divide at T, then promote: `(-f_lo) / (f_hi - f_lo)` binds before the
+        // multiplication by the double-valued span.
+        const T quotient = static_cast<T>(static_cast<T>(-f_lo) / static_cast<T>(f_hi - f_lo));
+        x = lo + static_cast<Acc>(quotient) * (hi - lo);
+        const Acc margin = Acc{0.1} * (hi - lo);
+        x = std::max(lo + margin, std::min(x, hi - margin));
+    } else {
+        x = Acc{0.5} * (lo + hi);
+    }
+
+    for (int iteration = 0; iteration < kMaxNewtonIter; ++iteration) {
+        Acc dfx{};
+        const Acc fx = de_casteljau_eval_and_deriv_scalar<T>(coeff, x, work, dfx);
+
+        if (static_cast<Acc>(f_lo) * fx <= Acc{0}) {
+            hi = x;
+        } else {
+            lo = x;
+        }
+
+        if ((hi - lo) <= param_tol) {
+            break;
+        }
+
+        const Acc x_new = std::abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
+        x = (lo < x_new && x_new < hi) ? x_new : Acc{0.5} * (lo + hi);
+    }
+
+    return Acc{0.5} * (lo + hi);
+}
+
+/// Find one root of a Bernstein polynomial on `[lo, hi]` without reparametrising.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients on [0, 1].
+/// \param lo Left boundary of the search interval.
+/// \param hi Right boundary.
+/// \param f_lo Pre-evaluated value at `lo`.
+/// \param tol Bracket-width termination tolerance.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \return The root parameter in `[lo, hi]`.
+///
+/// Mirrors `_yuksel_core._solve_on_interval`. No validation is performed.
+template <Real T>
+accumulator_t<T> solve_on_interval(std::span<const T> coeff, accumulator_t<T> lo,
+                                   accumulator_t<T> hi, accumulator_t<T> f_lo,
+                                   accumulator_t<T> tol, std::span<T> work) {
+    using Acc = accumulator_t<T>;
+    Acc x = Acc{0.5} * (lo + hi);
+
+    for (int iteration = 0; iteration < kMaxNewtonIter; ++iteration) {
+        Acc dfx{};
+        const Acc fx = de_casteljau_eval_and_deriv_scalar<T>(coeff, x, work, dfx);
+
+        if (f_lo * fx <= Acc{0}) {
+            hi = x;
+        } else {
+            lo = x;
+        }
+
+        if ((hi - lo) <= tol) {
+            return Acc{0.5} * (lo + hi);
+        }
+
+        const Acc x_new = std::abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
+        x = (lo < x_new && x_new < hi) ? x_new : Acc{0.5} * (lo + hi);
+    }
+
+    return Acc{0.5} * (lo + hi);
+}
+
+/// Find every root by walking the monotone intervals the critical parameters define.
+///
+/// **`f_prev` and `f_curr` are at `T`.** They come from `float(coeff[i])`, which does
+/// not widen, and from the evaluation kernel, which returns at coefficient width. So
+/// the sign-change test below is a `T` product, and so is the scale that sizes
+/// `boundary_eps`.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `n + 1`.
+/// \param crit Sorted critical parameters, of which the first `n_crit` are valid.
+/// \param n_crit Number of valid critical parameters.
+/// \param tol Bracket-width tolerance.
+/// \param roots Receives at most `n` roots.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \return How many entries of `roots` are valid.
+///
+/// Mirrors `_yuksel_core._find_roots_at_level`. No validation is performed.
+template <Real T>
+int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, int n_crit,
+                        accumulator_t<T> tol, std::span<double> roots, std::span<T> work) {
+    using Acc = accumulator_t<T>;
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    int count = 0;
+
+    const T d_min = *std::min_element(coeff.begin(), coeff.end());
+    const T d_max = *std::max_element(coeff.begin(), coeff.end());
+    // The subtraction is at T: `float()` does not widen, so widening here would size
+    // every boundary test differently. Measured, 6000 of 6000.
+    const T scale = static_cast<T>(d_max - d_min);
+    // FELIGN/pantr#352, reproduced deliberately. The 1e-30 floor is absolute inside
+    // an otherwise scale-relative tolerance, so below it every coefficient of the
+    // problem reads as zero and the endpoints are returned as roots. Rescaling the
+    // same polynomial moves the answer, which is the defect.
+    const Acc boundary_eps =
+        std::max(static_cast<Acc>(std::abs(scale)) * static_cast<Acc>(kDblEpsilon) * Acc{8},
+                 Acc{1e-30});
+
+    Acc prev_t{0};
+    T f_prev = coeff[0];
+
+    for (int k = 0; k <= n_crit; ++k) {
+        const Acc curr_t =
+            k < n_crit ? static_cast<Acc>(crit[static_cast<std::size_t>(k)]) : Acc{1};
+
+        const T f_at_curr =
+            curr_t < Acc{1} ? de_casteljau_eval_scalar<T>(coeff, curr_t, work)
+                            : coeff[static_cast<std::size_t>(n)];
+
+        if (curr_t - prev_t < tol) {
+            f_prev = f_at_curr;
+            prev_t = curr_t;
+            continue;
+        }
+
+        const T f_curr = f_at_curr;
+
+        if (std::abs(static_cast<Acc>(f_prev)) <= boundary_eps
+            && (count == 0
+                || std::abs(roots[static_cast<std::size_t>(count) - 1] - prev_t) > tol)) {
+            if (count < n) {
+                roots[static_cast<std::size_t>(count)] = prev_t;
+                ++count;
+            }
+            f_prev = f_curr;
+            prev_t = curr_t;
+            continue;
+        }
+
+        // FELIGN/pantr#351, reproduced deliberately: a T product, so at float32 two
+        // opposite-sign values below about 1e-23 multiply to zero, no sign change is
+        // seen, and a root that exists is lost.
+        if (f_prev * f_curr < T{0}) {
+            const Acc root = solve_on_interval<T>(coeff, prev_t, curr_t,
+                                                  static_cast<Acc>(f_prev), tol, work);
+            if (count < n) {
+                roots[static_cast<std::size_t>(count)] = root;
+                ++count;
+            }
+        }
+
+        f_prev = f_curr;
+        prev_t = curr_t;
+    }
+
+    if (std::abs(static_cast<Acc>(f_prev)) <= boundary_eps
+        && (count == 0 || std::abs(roots[static_cast<std::size_t>(count) - 1] - Acc{1}) > tol)
+        && count < n) {
+        roots[static_cast<std::size_t>(count)] = 1.0;
+        ++count;
+    }
+
+    return count;
+}
+
+/// Find every root on [0, 1] by Yuksel's monotone decomposition.
+///
+/// Differentiates down to degree one, solves there, and walks back up using each
+/// level's roots as the next level's monotone-interval boundaries.
+///
+/// The degree-1 base case is the sharpest width in the block: `c0 / (c0 - c1)` is a
+/// **`T` division**, and dividing at accumulator width instead reproduced *none* of
+/// 20000 float32 pairs. Every recursion reaches it.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `n + 1`.
+/// \param tol Bracket-width tolerance.
+/// \param roots Receives at most `max(n, 1)` roots, unsorted.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \return How many entries of `roots` are valid.
+///
+/// Mirrors `_yuksel_core._yuksel_roots`. No validation is performed.
+template <Real T>
+int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<double> roots,
+                 std::span<T> work) {
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    if (n <= 0) {
+        return 0;
+    }
+
+    T d_min = coeff[0];
+    T d_max = coeff[0];
+    for (int i = 1; i <= n; ++i) {
+        d_min = std::min(d_min, coeff[static_cast<std::size_t>(i)]);
+        d_max = std::max(d_max, coeff[static_cast<std::size_t>(i)]);
+    }
+    if (d_min > T{0} || d_max < T{0}) {
+        return 0;
+    }
+
+    if (n == 1) {
+        const T c0 = coeff[0];
+        const T c1 = coeff[1];
+        if (c0 == c1) {
+            return 0;
+        }
+        // Divide at T. This is the width the whole file is most exposed to.
+        const T root = static_cast<T>(c0 / static_cast<T>(c0 - c1));
+        if (T{0} <= root && root <= T{1}) {
+            roots[0] = static_cast<double>(root);
+            return 1;
+        }
+        return 0;
+    }
+
+    // derivs[lev] holds the level-`lev` derivative, of degree `n - 1 - lev`.
+    std::vector<double> derivs(static_cast<std::size_t>(n - 1) * static_cast<std::size_t>(n), 0.0);
+    const auto row = [&derivs, n](int lev) {
+        return std::span<double>(derivs.data() + static_cast<std::size_t>(lev)
+                                                     * static_cast<std::size_t>(n),
+                                 static_cast<std::size_t>(n));
+    };
+    for (int i = 0; i < n; ++i) {
+        // Subtract at T, widen on the store. The destination array being float64
+        // says nothing about the width the subtraction ran at: widening first
+        // reproduced only 88 of 4000 float32 vectors.
+        row(0)[static_cast<std::size_t>(i)] = static_cast<double>(
+            static_cast<T>(coeff[static_cast<std::size_t>(i) + 1] - coeff[static_cast<std::size_t>(i)]));
+    }
+    for (int lev = 1; lev < n - 1; ++lev) {
+        const int size_prev = n - lev;
+        for (int i = 0; i < size_prev; ++i) {
+            row(lev)[static_cast<std::size_t>(i)] =
+                row(lev - 1)[static_cast<std::size_t>(i) + 1] - row(lev - 1)[static_cast<std::size_t>(i)];
+        }
+    }
+
+    const int deepest = n - 2;
+    std::vector<double> crit(static_cast<std::size_t>(n), 0.0);
+    std::vector<double> crit_next(static_cast<std::size_t>(n), 0.0);
+    std::vector<double> level_work(static_cast<std::size_t>(n), 0.0);
+    int n_crit = 0;
+    {
+        const double c0 = row(deepest)[0];
+        const double c1 = row(deepest)[1];
+        if (c0 != c1) {
+            const double r = c0 / (c0 - c1);
+            if (0.0 <= r && r <= 1.0) {
+                crit[0] = r;
+                n_crit = 1;
+            }
+        }
+    }
+
+    for (int lev = deepest - 1; lev >= 0; --lev) {
+        const int deg_lev = n - 1 - lev;
+        const std::span<const double> coeff_lev(row(lev).data(),
+                                                static_cast<std::size_t>(deg_lev) + 1);
+
+        double lo_val = coeff_lev[0];
+        double hi_val = coeff_lev[0];
+        for (int i = 1; i <= deg_lev; ++i) {
+            lo_val = std::min(lo_val, coeff_lev[static_cast<std::size_t>(i)]);
+            hi_val = std::max(hi_val, coeff_lev[static_cast<std::size_t>(i)]);
+        }
+        if (lo_val > 0.0 || hi_val < 0.0) {
+            n_crit = 0;
+            continue;
+        }
+
+        if (n_crit == 0) {
+            const double f_lo = coeff_lev[0];
+            const double f_hi = coeff_lev[static_cast<std::size_t>(deg_lev)];
+            const double scale = std::abs(hi_val - lo_val);
+            const double boundary_eps = std::max(scale * kDblEpsilon * 8.0, 1e-30);
+
+            if (std::abs(f_lo) <= boundary_eps) {
+                crit[0] = 0.0;
+                n_crit = 1;
+            } else if (f_lo * f_hi < 0.0) {
+                crit[0] = solve_on_interval<double>(coeff_lev, 0.0, 1.0, f_lo, tol, level_work);
+                n_crit = 1;
+            } else if (std::abs(f_hi) <= boundary_eps) {
+                crit[0] = 1.0;
+                n_crit = 1;
+            } else {
+                n_crit = 0;
+            }
+            continue;
+        }
+
+        n_crit = find_roots_at_level<double>(coeff_lev, std::span<const double>(crit.data(),
+                                                                               static_cast<std::size_t>(n_crit)),
+                                             n_crit, tol, crit_next, level_work);
+        std::swap(crit, crit_next);
+    }
+
+    return find_roots_at_level<T>(coeff,
+                                  std::span<const double>(crit.data(),
+                                                          static_cast<std::size_t>(n_crit)),
+                                  n_crit, tol, roots, work);
+}
+
+/// Stack-based Bézier clipping root finder.
+///
+/// Always subdivides from the original coefficients rather than from the previous
+/// sub-interval's, so repeated de Casteljau splits cannot accumulate error.
+///
+/// Note the contrast with `yuksel_roots`: its degree-1 base case divides at `T`,
+/// this one divides at `double`, because here the operands come from the widened
+/// sub-interval coefficients. The same expression, two widths, and nothing about the
+/// kernel says which.
+///
+/// \tparam T Coefficient type.
+/// \param root_coeff Original Bernstein coefficients on [0, 1].
+/// \param param_tol Bracket-width termination tolerance.
+/// \param geom_tol Geometric tolerance for near-zero detection.
+/// \param roots Receives at most `3 * n + 4` unsorted, possibly duplicated roots.
+/// \param work Scratch of at least `root_coeff.size()` entries.
+/// \return How many entries of `roots` are valid.
+///
+/// Mirrors `_clipping_core._clip_roots_core`. No validation is performed.
+template <Real T>
+int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
+                    accumulator_t<T> geom_tol, std::span<double> roots, std::span<T> work) {
+    using Acc = accumulator_t<T>;
+    const auto n = static_cast<int>(root_coeff.size()) - 1;
+    const int max_roots = 3 * n + 4;
+    int n_roots = 0;
+
+    // Seeded with a double, so unification makes the running maximum double even
+    // where the coefficients are float32.
+    double coeff_scale = 0.0;
+    for (int i = 0; i <= n; ++i) {
+        coeff_scale =
+            std::max(coeff_scale, static_cast<double>(std::abs(root_coeff[static_cast<std::size_t>(i)])));
+    }
+    const double zero_tol =
+        std::max(coeff_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
+
+    if (std::abs(static_cast<double>(root_coeff[0])) <= zero_tol) {
+        roots[static_cast<std::size_t>(n_roots)] = 0.0;
+        ++n_roots;
+    }
+    if (std::abs(static_cast<double>(root_coeff[static_cast<std::size_t>(n)])) <= zero_tol) {
+        roots[static_cast<std::size_t>(n_roots)] = 1.0;
+        ++n_roots;
+    }
+
+    std::vector<double> stack_lo(static_cast<std::size_t>(kMaxStackSize));
+    std::vector<double> stack_hi(static_cast<std::size_t>(kMaxStackSize));
+    std::vector<std::int64_t> stack_depth(static_cast<std::size_t>(kMaxStackSize));
+    std::vector<double> local(static_cast<std::size_t>(n) + 1);
+    std::vector<std::int64_t> chain(static_cast<std::size_t>(n) + 1);
+    stack_lo[0] = 0.0;
+    stack_hi[0] = 1.0;
+    stack_depth[0] = 0;
+    int stack_size = 1;
+
+    const auto push = [&](double lo_value, double hi_value, std::int64_t depth_value) {
+        stack_lo[static_cast<std::size_t>(stack_size)] = lo_value;
+        stack_hi[static_cast<std::size_t>(stack_size)] = hi_value;
+        stack_depth[static_cast<std::size_t>(stack_size)] = depth_value;
+        ++stack_size;
+    };
+
+    while (stack_size > 0) {
+        --stack_size;
+        const double lo = stack_lo[static_cast<std::size_t>(stack_size)];
+        const double hi = stack_hi[static_cast<std::size_t>(stack_size)];
+        const std::int64_t depth = stack_depth[static_cast<std::size_t>(stack_size)];
+        const double span = hi - lo;
+
+        // Step 1: convergence.
+        if (span <= param_tol || depth > kClipMaxDepth) {
+            double mid = 0.5 * (lo + hi);
+            if (lo <= 0.0 && hi <= param_tol) {
+                mid = 0.0;
+            } else if (lo >= 1.0 - param_tol && hi >= 1.0) {
+                mid = 1.0;
+            }
+
+            Acc f_mid{};
+            Acc df_mid{};
+            mid = newton_polish_scalar<T>(root_coeff, mid, lo, hi, param_tol, work, f_mid, df_mid);
+
+            if (std::abs(f_mid) <= zero_tol) {
+                if (std::abs(df_mid) <= static_cast<Acc>(kDblEpsilon)) {
+                    // Double root: the derivative is useless, so bisect.
+                    double a = lo;
+                    double b = hi;
+                    T fa = de_casteljau_eval_scalar<T>(root_coeff, a, work);
+                    for (int bisect = 0; bisect < 10; ++bisect) {
+                        const double m = 0.5 * (a + b);
+                        const T fm = de_casteljau_eval_scalar<T>(root_coeff, m, work);
+                        // FELIGN/pantr#351, third site: a T product, so it can
+                        // underflow at float32. Reproduced deliberately; unlike the
+                        // other two this one has no verified reproduction, only the
+                        // same mechanism.
+                        if (std::abs(fm) < std::abs(fa)) {
+                            if (fa * fm <= T{0}) {
+                                b = m;
+                            } else {
+                                a = m;
+                                fa = fm;
+                            }
+                        } else if (fa * fm <= T{0}) {
+                            b = m;
+                        } else {
+                            a = m;
+                            fa = fm;
+                        }
+                        if (b - a <= kDblEpsilon) {
+                            break;
+                        }
+                    }
+                    mid = 0.5 * (a + b);
+                }
+
+                const T f_final = de_casteljau_eval_scalar<T>(root_coeff, mid, work);
+                if (std::abs(static_cast<Acc>(f_final)) <= zero_tol && n_roots < max_roots) {
+                    roots[static_cast<std::size_t>(n_roots)] = mid;
+                    ++n_roots;
+                }
+            }
+            continue;
+        }
+
+        // Step 2: local coefficients, widened once and double from here on.
+        subdivide_scalar<T>(root_coeff, lo, hi, local);
+        double local_scale = 0.0;
+        for (int i = 0; i <= n; ++i) {
+            local_scale = std::max(local_scale, std::abs(local[static_cast<std::size_t>(i)]));
+        }
+        const double local_zero_tol =
+            std::max(local_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
+
+        // Step 3: coefficient range.
+        double c_min = local[0];
+        double c_max = local[0];
+        for (int i = 1; i <= n; ++i) {
+            c_min = std::min(c_min, local[static_cast<std::size_t>(i)]);
+            c_max = std::max(c_max, local[static_cast<std::size_t>(i)]);
+        }
+
+        // Step 4: quick rejection when every coefficient shares a sign.
+        if (c_min > local_zero_tol || c_max < -local_zero_tol) {
+            const double rejection_margin = c_min > local_zero_tol ? c_min : -c_max;
+            if (rejection_margin <= zero_tol) {
+                Acc f_mid{};
+                Acc df_mid{};
+                const double mid = newton_polish_scalar<T>(root_coeff, 0.5 * (lo + hi), lo, hi,
+                                                           Acc{0}, work, f_mid, df_mid);
+                if (std::abs(f_mid) <= zero_tol && n_roots < max_roots) {
+                    roots[static_cast<std::size_t>(n_roots)] = mid;
+                    ++n_roots;
+                }
+            }
+            continue;
+        }
+
+        // Step 5: flat within noise.
+        if (c_max - c_min <= geom_tol) {
+            if (std::abs(c_min) <= local_zero_tol || std::abs(c_max) <= local_zero_tol
+                || c_min * c_max < 0.0) {
+                const double mid = 0.5 * (lo + hi);
+                const T f_mid = de_casteljau_eval_scalar<T>(root_coeff, mid, work);
+                if (std::abs(static_cast<Acc>(f_mid)) <= zero_tol && n_roots < max_roots) {
+                    roots[static_cast<std::size_t>(n_roots)] = mid;
+                    ++n_roots;
+                }
+            }
+            continue;
+        }
+
+        // Step 6: endpoint roots.
+        if (std::abs(local[0]) <= local_zero_tol && n_roots < max_roots) {
+            roots[static_cast<std::size_t>(n_roots)] = lo;
+            ++n_roots;
+        }
+        if (std::abs(local[static_cast<std::size_t>(n)]) <= local_zero_tol && n_roots < max_roots) {
+            roots[static_cast<std::size_t>(n_roots)] = hi;
+            ++n_roots;
+        }
+
+        // Step 7: variation-diminishing bound.
+        const int n_sc = count_sign_changes<double>(local);
+        if (n_sc == 0) {
+            continue;
+        }
+
+        // Step 8: linear base case, at double here.
+        if (n == 1) {
+            const double c0 = local[0];
+            const double c1 = local[1];
+            if (c0 != c1) {
+                const double r = c0 / (c0 - c1);
+                if (0.0 <= r && r <= 1.0 && n_roots < max_roots) {
+                    roots[static_cast<std::size_t>(n_roots)] = lo + r * span;
+                    ++n_roots;
+                }
+            }
+            continue;
+        }
+
+        // Step 9: convex-hull clipping.
+        double t_lo_clip = 0.0;
+        double t_hi_clip = 0.0;
+        const bool clip_found =
+            clip_hull_to_zero<double>(local, chain, t_lo_clip, t_hi_clip);
+        if (!clip_found) {
+            if (n_sc > 0 && stack_size + 1 < kMaxStackSize) {
+                const double mid_param = 0.5 * (lo + hi);
+                push(lo, mid_param, depth + 1);
+                push(mid_param, hi, depth + 1);
+            }
+            continue;
+        }
+
+        const double margin = static_cast<double>(n + 1) * 4.0 * kDblEpsilon;
+        const double t_lo_safe = std::max(t_lo_clip - margin, 0.0);
+        const double t_hi_safe = std::min(t_hi_clip + margin, 1.0);
+
+        const double new_lo = lo + t_lo_safe * span;
+        const double new_hi = lo + t_hi_safe * span;
+        const double new_span = new_hi - new_lo;
+
+        if (new_span <= param_tol) {
+            Acc f_mid{};
+            Acc df_mid{};
+            const double mid = newton_polish_scalar<T>(root_coeff, 0.5 * (new_lo + new_hi), new_lo,
+                                                       new_hi, param_tol, work, f_mid, df_mid);
+            if (std::abs(f_mid) <= zero_tol && n_roots < max_roots) {
+                roots[static_cast<std::size_t>(n_roots)] = mid;
+                ++n_roots;
+            }
+            continue;
+        }
+
+        // Step 10: recurse, split, or give up on the clip and split the original.
+        const double reduction = span > 0.0 ? 1.0 - (new_span / span) : 0.0;
+
+        if (n_sc == 1) {
+            if (reduction >= kClipReductionThreshold) {
+                if (stack_size < kMaxStackSize) {
+                    push(new_lo, new_hi, depth + 1);
+                }
+            } else if (stack_size + 1 < kMaxStackSize) {
+                const double mid = 0.5 * (new_lo + new_hi);
+                push(new_lo, mid, depth + 1);
+                push(mid, new_hi, depth + 1);
+            }
+        } else if (reduction >= kClipReductionThreshold) {
+            if (stack_size + 1 < kMaxStackSize) {
+                const double mid = 0.5 * (new_lo + new_hi);
+                push(new_lo, mid, depth + 1);
+                push(mid, new_hi, depth + 1);
+            }
+        } else if (stack_size + 1 < kMaxStackSize) {
+            const double mid = 0.5 * (lo + hi);
+            push(lo, mid, depth + 1);
+            push(mid, hi, depth + 1);
+        }
+    }
+
+    return n_roots;
+}
+
+/// Sort root candidates and merge the duplicates, with a derivative-aware radius.
+///
+/// The same root reaches this from several converging intervals. The gap between
+/// duplicates is `O(zero_tol / |f'|)`, so the merge radius is computed per candidate
+/// and capped at `zero_tol^(1/3)`, an upper bound on the cluster width around a root
+/// of multiplicity up to three. Without the cap an exact multiple root, where the
+/// derivative vanishes, would swallow every later candidate.
+///
+/// The cap **must** be `std::pow(x, 1.0 / 3.0)`. `std::cbrt` is the natural spelling
+/// and differs from Numba's `**` on 49659 of 50000 tolerances.
+///
+/// The insertion sort is transliterated rather than replaced by `std::sort`, which
+/// is not stable and would need an argument about ties this way avoids needing.
+///
+/// \tparam T Coefficient type.
+/// \param raw_roots Candidates, of which the first `n_roots` are valid.
+/// \param n_roots Number of valid candidates.
+/// \param coeff Original Bernstein coefficients, for the derivative.
+/// \param param_tol Parametric tolerance.
+/// \param geom_tol Geometric tolerance.
+/// \param out Receives at most `n_roots` roots, sorted ascending.
+/// \param work Scratch of at least `coeff.size()` entries.
+/// \return How many entries of `out` are valid.
+///
+/// Mirrors `_clipping_core._dedup_roots_core`. No validation is performed.
+template <Real T>
+int dedup_roots_core(std::span<const double> raw_roots, int n_roots, std::span<const T> coeff,
+                     accumulator_t<T> param_tol, accumulator_t<T> geom_tol,
+                     std::span<double> out, std::span<T> work) {
+    using Acc = accumulator_t<T>;
+    if (n_roots == 0) {
+        return 0;
+    }
+
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    double coeff_scale = 0.0;
+    for (int i = 0; i <= n; ++i) {
+        coeff_scale =
+            std::max(coeff_scale, std::abs(static_cast<double>(coeff[static_cast<std::size_t>(i)])));
+    }
+    const double zero_tol =
+        std::max(coeff_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
+    const double base_dedup = std::max(param_tol * 2.0, zero_tol * 4.0);
+    const double radius_cap = std::pow(zero_tol, 1.0 / 3.0);
+
+    for (int i = 0; i < n_roots; ++i) {
+        out[static_cast<std::size_t>(i)] = raw_roots[static_cast<std::size_t>(i)];
+    }
+    for (int i = 1; i < n_roots; ++i) {
+        const double key = out[static_cast<std::size_t>(i)];
+        int j = i - 1;
+        while (j >= 0 && out[static_cast<std::size_t>(j)] > key) {
+            out[static_cast<std::size_t>(j) + 1] = out[static_cast<std::size_t>(j)];
+            --j;
+        }
+        out[static_cast<std::size_t>(j) + 1] = key;
+    }
+
+    int count = 1;
+    for (int i = 1; i < n_roots; ++i) {
+        const double gap =
+            out[static_cast<std::size_t>(i)] - out[static_cast<std::size_t>(count) - 1];
+        if (gap <= base_dedup) {
+            continue;
+        }
+        Acc df{};
+        de_casteljau_eval_and_deriv_scalar<T>(
+            coeff, out[static_cast<std::size_t>(count) - 1], work, df);
+        const double local_tol = zero_tol / std::max(std::abs(df), static_cast<Acc>(kDblEpsilon));
+        if (gap <= std::max(base_dedup, std::min(local_tol * 4.0, radius_cap))) {
+            continue;
+        }
+        out[static_cast<std::size_t>(count)] = out[static_cast<std::size_t>(i)];
+        ++count;
+    }
+
+    return count;
+}
+
+/// Choose between Yuksel and clipping for one polynomial, then deduplicate.
+///
+/// `c_max` and `c_min_nonzero` are seeded with a `double` and with infinity, so
+/// unification makes the dynamic-range ratio a `double` division even at float32.
+/// This is the sibling of `yuksel_roots`'s base case, which divides at `T`, and the
+/// pair is why the widths in this file cannot be applied by rule.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients.
+/// \param param_tol Parametric tolerance.
+/// \param geom_tol Geometric tolerance.
+/// \param out Receives the sorted, deduplicated roots.
+/// \return How many entries of `out` are valid.
+///
+/// Mirrors `_batch_core._dispatch_and_find`. No validation is performed.
+template <Real T>
+int dispatch_and_find(std::span<const T> coeff, accumulator_t<T> param_tol,
+                      accumulator_t<T> geom_tol, std::span<double> out) {
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    if (n < 1) {
+        return 0;
+    }
+
+    bool all_zero = true;
+    for (int i = 0; i <= n; ++i) {
+        if (std::abs(static_cast<accumulator_t<T>>(coeff[static_cast<std::size_t>(i)]))
+            > geom_tol) {
+            all_zero = false;
+            break;
+        }
+    }
+    if (all_zero) {
+        return 0;
+    }
+
+    bool use_clipping = false;
+    if (n >= kClipMinDegree) {
+        double c_max = 0.0;
+        double c_min_nonzero = std::numeric_limits<double>::infinity();
+        for (int i = 0; i <= n; ++i) {
+            const auto av =
+                static_cast<double>(std::abs(coeff[static_cast<std::size_t>(i)]));
+            c_max = std::max(c_max, av);
+            if (av > 0.0 && av < c_min_nonzero) {
+                c_min_nonzero = av;
+            }
+        }
+        const double coeff_range = c_min_nonzero < std::numeric_limits<double>::infinity()
+                                       ? c_max / c_min_nonzero
+                                       : std::numeric_limits<double>::infinity();
+        if (coeff_range <= kClipCoeffRangeLimit) {
+            use_clipping = true;
+        }
+    }
+
+    std::vector<T> work(coeff.size());
+    std::vector<double> raw(static_cast<std::size_t>(3 * n + 4));
+    const int n_raw = use_clipping
+                          ? clip_roots_core<T>(coeff, param_tol, geom_tol, raw, work)
+                          : yuksel_roots<T>(coeff, param_tol, raw, work);
+    if (n_raw == 0) {
+        return 0;
+    }
+
+    return dedup_roots_core<T>(std::span<const double>(raw.data(), static_cast<std::size_t>(n_raw)),
+                               n_raw, coeff, param_tol, geom_tol, out, work);
+}
+
+}  // namespace detail
+
+/// Find every root on [0, 1] by Yuksel's monotone decomposition.
+///
+/// The scratch the algorithm needs is allocated here, as the oracle allocates it per
+/// call, rather than being threaded through the binding layer.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `degree + 1`.
+/// \param tol Bracket-width tolerance.
+/// \param out Receives at most `degree` roots, unsorted and possibly duplicated.
+/// \return How many entries of `out` are valid.
+///
+/// Mirrors `_yuksel_core._yuksel_roots`. No validation is performed.
+template <Real T>
+int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<double> out) {
+    std::vector<T> work(coeff.size());
+    return detail::yuksel_roots<T>(coeff, tol, out, work);
+}
+
+/// Find every root on [0, 1] by Bézier clipping.
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients, length `degree + 1`.
+/// \param param_tol Bracket-width termination tolerance.
+/// \param geom_tol Geometric tolerance for near-zero detection.
+/// \param out Receives at most `3 * degree + 4` roots, unsorted and possibly
+///     duplicated.
+/// \return How many entries of `out` are valid.
+///
+/// Mirrors `_clipping_core._clip_roots_core`. No validation is performed.
+template <Real T>
+int clip_roots(std::span<const T> coeff, accumulator_t<T> param_tol, accumulator_t<T> geom_tol,
+               std::span<double> out) {
+    std::vector<T> work(coeff.size());
+    return detail::clip_roots_core<T>(coeff, param_tol, geom_tol, out, work);
+}
+
+/// Sort root candidates and merge the duplicates.
+///
+/// \tparam T Coefficient type.
+/// \param raw_roots Candidates, of which the first `n_roots` are valid.
+/// \param n_roots Number of valid candidates.
+/// \param coeff Original Bernstein coefficients, for the derivative.
+/// \param param_tol Parametric tolerance.
+/// \param geom_tol Geometric tolerance.
+/// \param out Receives at most `n_roots` roots, sorted ascending.
+/// \return How many entries of `out` are valid.
+///
+/// Mirrors `_clipping_core._dedup_roots_core`. No validation is performed.
+template <Real T>
+int dedup_roots(std::span<const double> raw_roots, int n_roots, std::span<const T> coeff,
+                accumulator_t<T> param_tol, accumulator_t<T> geom_tol, std::span<double> out) {
+    std::vector<T> work(coeff.size());
+    return detail::dedup_roots_core<T>(raw_roots, n_roots, coeff, param_tol, geom_tol, out, work);
+}
+
+/// Find the unique root of a monotone scalar Bernstein polynomial on [0, 1].
+///
+/// \tparam T Coefficient type.
+/// \param coeff Bernstein coefficients of a monotone polynomial.
+/// \param tol Bracket-width termination tolerance.
+/// \return The root parameter, or NaN when no sign change is detected.
+///
+/// Mirrors `_yuksel_core._solve_monotone_root_kernel`. No validation is performed.
+template <Real T>
+accumulator_t<T> solve_monotone_root(std::span<const T> coeff, accumulator_t<T> tol) {
+    std::vector<T> work(coeff.size());
+    return detail::solve_monotone_root_kernel<T>(coeff, tol, work);
+}
+
+/// Find the roots of many same-degree scalar Bernstein polynomials.
+///
+/// Each polynomial is independent and writes only its own row, so unlike a reduction
+/// this kernel's result cannot move with the thread count.
+///
+/// \tparam T Coefficient type.
+/// \param coeffs Batch of coefficients, shape `(n_polys, degree + 1)`.
+/// \param param_tol Parametric tolerance.
+/// \param geom_tol Geometric tolerance.
+/// \param out_roots Shape `(n_polys, degree)`. Entries past each row's count keep
+///     whatever the caller left there, which is NaN.
+/// \param out_counts Shape `(n_polys,)`, receiving the per-row root count.
+///
+/// Mirrors `_batch_core._find_roots_batch_core`. No validation is performed.
+template <Real T>
+void find_roots_batch(span2d<const T> coeffs, accumulator_t<T> param_tol,
+                      accumulator_t<T> geom_tol, span2d<double> out_roots,
+                      std::span<std::int64_t> out_counts) {
+    const auto n_polys = static_cast<std::ptrdiff_t>(coeffs.extent(0));
+    const auto width = static_cast<std::ptrdiff_t>(coeffs.extent(1));
+    const auto row_capacity = static_cast<int>(out_roots.extent(1));
+
+    std::vector<T> coeff_row(static_cast<std::size_t>(width));
+    std::vector<double> found(static_cast<std::size_t>(3 * width + 4));
+
+    for (std::ptrdiff_t i = 0; i < n_polys; ++i) {
+        for (std::ptrdiff_t j = 0; j < width; ++j) {
+            coeff_row[static_cast<std::size_t>(j)] = at(coeffs, i, j);
+        }
+        int count = detail::dispatch_and_find<T>(coeff_row, param_tol, geom_tol, found);
+        // A degree-n polynomial has at most n roots; clamp as a memory-safety
+        // backstop so a dedup artifact can never overflow the row.
+        count = std::min(count, row_capacity);
+        out_counts[static_cast<std::size_t>(i)] = count;
+        for (int j = 0; j < count; ++j) {
+            at(out_roots, i, j) = found[static_cast<std::size_t>(j)];
+        }
+    }
+}
+
+/// Solve for the monotone root of many same-degree scalar Bernstein polynomials.
+///
+/// \tparam T Coefficient type.
+/// \param coeffs Batch of coefficients, shape `(n_polys, degree + 1)`.
+/// \param param_tol Parameter-space termination tolerance.
+/// \param out_roots Shape `(n_polys,)`, pre-filled with NaN by the caller. A row
+///     whose polynomial has no root is left untouched.
+///
+/// Mirrors `_batch_core._solve_monotone_root_batch_core`. No validation is performed.
+template <Real T>
+void solve_monotone_root_batch(span2d<const T> coeffs, accumulator_t<T> param_tol,
+                               std::span<double> out_roots) {
+    const auto n_polys = static_cast<std::ptrdiff_t>(coeffs.extent(0));
+    const auto width = static_cast<std::ptrdiff_t>(coeffs.extent(1));
+
+    std::vector<T> coeff_row(static_cast<std::size_t>(width));
+    std::vector<T> work(static_cast<std::size_t>(width));
+
+    for (std::ptrdiff_t i = 0; i < n_polys; ++i) {
+        for (std::ptrdiff_t j = 0; j < width; ++j) {
+            coeff_row[static_cast<std::size_t>(j)] = at(coeffs, i, j);
+        }
+        const auto root = detail::solve_monotone_root_kernel<T>(coeff_row, param_tol, work);
+        if (!std::isnan(root)) {
+            out_roots[static_cast<std::size_t>(i)] = root;
+        }
+    }
+}
+
+}  // namespace pantr

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -75,6 +75,11 @@
 /// equality there and bounded above it. That gate is `__fp_contract__`, read at run
 /// time by the parity tests, not assumed here.
 ///
+/// Rule 11 of design/backend_parity.md states all of this, including the bound that
+/// applies where contraction is live: it is the algorithm's, not the arithmetic's,
+/// and it is the larger of the bracketing tolerance and the interval where the
+/// computed residual is indistinguishable from zero.
+///
 /// ## Two defects are reproduced on purpose
 ///
 /// The oracle has two pre-existing wrong answers in this block, filed as

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -326,13 +326,19 @@ int count_sign_changes(std::span<const T> coeff) {
 /// already ordered so no sort is needed, then every hull edge is tested against
 /// `y = 0`.
 ///
-/// Two things about the orientation predicate. Its coefficient **differences run at
-/// `T`** and only the integer factor promotes the product, which is numpy's
-/// promotion of `int64` against `float32` and the opposite of what a C++ template
-/// over `T` gives by default; widening the differences first matched only 3541 of
-/// 10000 float32 triples. And on an exactly collinear polygon the predicate is
-/// exactly zero, so `cross >= 0` holds and the vertex is popped: that exact tie is
-/// what contraction destroys. See this file's opening note.
+/// Two widths here, and the second was missed on the first pass. The orientation
+/// predicate's coefficient **differences run at `T`** and only the integer factor
+/// promotes the product, which is numpy's promotion of `int64` against `float32` and
+/// the opposite of what a C++ template over `T` gives by default; widening the
+/// differences first matched only 3541 of 10000 float32 triples. The **edge-crossing
+/// quotient** is at `T` too, for a plainer reason: the oracle reads both endpoints
+/// out of the coefficient array and divides them, and only the multiplication by the
+/// float64 span promotes. That one was written widened and diverged on all 10143
+/// sign-changing float32 edges measured.
+///
+/// And on an exactly collinear polygon the predicate is exactly zero, so `cross >= 0`
+/// holds and the vertex is popped: that exact tie is what contraction destroys. See
+/// this file's opening note.
 ///
 /// \tparam T Coefficient type. Reached with `double` from every call site in the
 ///     library, since the caller passes the widened sub-interval coefficients; the
@@ -388,17 +394,24 @@ bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, 
         for (std::ptrdiff_t k = 0; k < size - 1; ++k) {
             const auto ia = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(k)]);
             const auto ib = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(k) + 1]);
-            const auto da = static_cast<double>(coeff[static_cast<std::size_t>(ia)]);
-            const auto db = static_cast<double>(coeff[static_cast<std::size_t>(ib)]);
-            if (da * db < 0.0) {
+            const T da = coeff[static_cast<std::size_t>(ia)];
+            const T db = coeff[static_cast<std::size_t>(ib)];
+            // At T, not at double. The oracle reads both endpoints straight out of
+            // the coefficient array, so the sign test and the quotient are T
+            // operations and only the multiplication by the float64 span promotes.
+            // Widening them first diverges on every one of 10143 sign-changing
+            // float32 edges measured, and the T-width product can underflow to zero
+            // and miss a crossing, which is the same mechanism as FELIGN/pantr#351.
+            if (da * db < T{0}) {
                 const double ta = static_cast<double>(ia) * inv_n;
                 const double tb = static_cast<double>(ib) * inv_n;
-                const double crossing = ta + (-da) / (db - da) * (tb - ta);
+                const T quotient = static_cast<T>(static_cast<T>(-da) / static_cast<T>(db - da));
+                const double crossing = ta + static_cast<double>(quotient) * (tb - ta);
                 t_lo = std::min(t_lo, crossing);
                 t_hi = std::max(t_hi, crossing);
                 found = true;
             }
-            if (da == 0.0) {
+            if (da == T{0}) {
                 const double ta = static_cast<double>(ia) * inv_n;
                 t_lo = std::min(t_lo, ta);
                 t_hi = std::max(t_hi, ta);

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -223,12 +223,13 @@ accumulator_t<T> de_casteljau_eval_and_deriv_scalar(std::span<const T> coeff, ac
 /// Mirrors `_root_finding_core._restrict_scalar`. No validation is performed.
 template <Real T>
 void restrict_scalar(std::span<const T> coeff, double lower, double upper, std::span<double> out) {
+    using std::abs;
     const auto p = static_cast<std::ptrdiff_t>(coeff.size()) - 1;
     for (std::ptrdiff_t i = 0; i <= p; ++i) {
         out[static_cast<std::size_t>(i)] = static_cast<double>(coeff[static_cast<std::size_t>(i)]);
     }
 
-    if (std::abs(upper) >= std::abs(lower - 1.0)) {
+    if (abs(upper) >= abs(lower - 1.0)) {
         const double tau = upper;
         for (std::ptrdiff_t step = 1; step <= p; ++step) {
             for (std::ptrdiff_t j = p; j >= step; --j) {
@@ -435,16 +436,17 @@ accumulator_t<T> newton_polish_scalar(std::span<const T> coeff, accumulator_t<T>
                                       accumulator_t<T> lo, accumulator_t<T> hi,
                                       accumulator_t<T> param_tol, std::span<T> work,
                                       accumulator_t<T>& out_f, accumulator_t<T>& out_df) {
+    using std::abs;
     using Acc = accumulator_t<T>;
     Acc df_mid{};
     const Acc f_mid = de_casteljau_eval_and_deriv_scalar<T>(coeff, mid, work, df_mid);
     out_df = df_mid;
-    if (std::abs(df_mid) > static_cast<Acc>(kDblEpsilon)) {
+    if (abs(df_mid) > static_cast<Acc>(kDblEpsilon)) {
         Acc newton = mid - f_mid / df_mid;
         if (lo - param_tol <= newton && newton <= hi + param_tol) {
             newton = std::max(Acc{0}, std::min(Acc{1}, newton));
             const Acc f_newton = static_cast<Acc>(de_casteljau_eval_scalar<T>(coeff, newton, work));
-            if (std::abs(f_newton) <= std::abs(f_mid)) {
+            if (abs(f_newton) <= abs(f_mid)) {
                 out_f = f_newton;
                 return newton;
             }
@@ -473,6 +475,7 @@ accumulator_t<T> newton_polish_scalar(std::span<const T> coeff, accumulator_t<T>
 template <Real T>
 accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulator_t<T> param_tol,
                                             std::span<T> work) {
+    using std::abs;
     using Acc = accumulator_t<T>;
     Acc lo{0};
     Acc hi{1};
@@ -489,7 +492,7 @@ accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulato
     }
 
     Acc x{};
-    if (std::abs(static_cast<Acc>(static_cast<T>(f_hi - f_lo))) > Acc{0}) {
+    if (abs(static_cast<Acc>(static_cast<T>(f_hi - f_lo))) > Acc{0}) {
         // Divide at T, then promote: `(-f_lo) / (f_hi - f_lo)` binds before the
         // multiplication by the double-valued span.
         const T quotient = static_cast<T>(static_cast<T>(-f_lo) / static_cast<T>(f_hi - f_lo));
@@ -514,7 +517,7 @@ accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulato
             break;
         }
 
-        const Acc x_new = std::abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
+        const Acc x_new = abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
         x = (lo < x_new && x_new < hi) ? x_new : Acc{0.5} * (lo + hi);
     }
 
@@ -537,6 +540,7 @@ template <Real T>
 accumulator_t<T> solve_on_interval(std::span<const T> coeff, accumulator_t<T> lo,
                                    accumulator_t<T> hi, accumulator_t<T> f_lo,
                                    accumulator_t<T> tol, std::span<T> work) {
+    using std::abs;
     using Acc = accumulator_t<T>;
     Acc x = Acc{0.5} * (lo + hi);
 
@@ -554,7 +558,7 @@ accumulator_t<T> solve_on_interval(std::span<const T> coeff, accumulator_t<T> lo
             return Acc{0.5} * (lo + hi);
         }
 
-        const Acc x_new = std::abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
+        const Acc x_new = abs(dfx) > Acc{0} ? x - fx / dfx : Acc{0.5} * (lo + hi);
         x = (lo < x_new && x_new < hi) ? x_new : Acc{0.5} * (lo + hi);
     }
 
@@ -581,6 +585,7 @@ accumulator_t<T> solve_on_interval(std::span<const T> coeff, accumulator_t<T> lo
 template <Real T>
 int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, int n_crit,
                         accumulator_t<T> tol, std::span<double> roots, std::span<T> work) {
+    using std::abs;
     using Acc = accumulator_t<T>;
     const auto n = static_cast<int>(coeff.size()) - 1;
     int count = 0;
@@ -595,7 +600,7 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
     // problem reads as zero and the endpoints are returned as roots. Rescaling the
     // same polynomial moves the answer, which is the defect.
     const Acc boundary_eps =
-        std::max(static_cast<Acc>(std::abs(scale)) * static_cast<Acc>(kDblEpsilon) * Acc{8},
+        std::max(static_cast<Acc>(abs(scale)) * static_cast<Acc>(kDblEpsilon) * Acc{8},
                  Acc{1e-30});
 
     Acc prev_t{0};
@@ -617,9 +622,9 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
 
         const T f_curr = f_at_curr;
 
-        if (std::abs(static_cast<Acc>(f_prev)) <= boundary_eps
+        if (abs(static_cast<Acc>(f_prev)) <= boundary_eps
             && (count == 0
-                || std::abs(roots[static_cast<std::size_t>(count) - 1] - prev_t) > tol)) {
+                || abs(roots[static_cast<std::size_t>(count) - 1] - prev_t) > tol)) {
             if (count < n) {
                 roots[static_cast<std::size_t>(count)] = prev_t;
                 ++count;
@@ -645,8 +650,8 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
         prev_t = curr_t;
     }
 
-    if (std::abs(static_cast<Acc>(f_prev)) <= boundary_eps
-        && (count == 0 || std::abs(roots[static_cast<std::size_t>(count) - 1] - Acc{1}) > tol)
+    if (abs(static_cast<Acc>(f_prev)) <= boundary_eps
+        && (count == 0 || abs(roots[static_cast<std::size_t>(count) - 1] - Acc{1}) > tol)
         && count < n) {
         roots[static_cast<std::size_t>(count)] = 1.0;
         ++count;
@@ -675,6 +680,7 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
 template <Real T>
 int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<double> roots,
                  std::span<T> work) {
+    using std::abs;
     const auto n = static_cast<int>(coeff.size()) - 1;
     if (n <= 0) {
         return 0;
@@ -763,16 +769,16 @@ int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<doubl
         if (n_crit == 0) {
             const double f_lo = coeff_lev[0];
             const double f_hi = coeff_lev[static_cast<std::size_t>(deg_lev)];
-            const double scale = std::abs(hi_val - lo_val);
+            const double scale = abs(hi_val - lo_val);
             const double boundary_eps = std::max(scale * kDblEpsilon * 8.0, 1e-30);
 
-            if (std::abs(f_lo) <= boundary_eps) {
+            if (abs(f_lo) <= boundary_eps) {
                 crit[0] = 0.0;
                 n_crit = 1;
             } else if (f_lo * f_hi < 0.0) {
                 crit[0] = solve_on_interval<double>(coeff_lev, 0.0, 1.0, f_lo, tol, level_work);
                 n_crit = 1;
-            } else if (std::abs(f_hi) <= boundary_eps) {
+            } else if (abs(f_hi) <= boundary_eps) {
                 crit[0] = 1.0;
                 n_crit = 1;
             } else {
@@ -815,6 +821,7 @@ int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<doubl
 template <Real T>
 int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
                     accumulator_t<T> geom_tol, std::span<double> roots, std::span<T> work) {
+    using std::abs;
     using Acc = accumulator_t<T>;
     const auto n = static_cast<int>(root_coeff.size()) - 1;
     const int max_roots = 3 * n + 4;
@@ -825,16 +832,16 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
     double coeff_scale = 0.0;
     for (int i = 0; i <= n; ++i) {
         coeff_scale =
-            std::max(coeff_scale, static_cast<double>(std::abs(root_coeff[static_cast<std::size_t>(i)])));
+            std::max(coeff_scale, static_cast<double>(abs(root_coeff[static_cast<std::size_t>(i)])));
     }
     const double zero_tol =
         std::max(coeff_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
 
-    if (std::abs(static_cast<double>(root_coeff[0])) <= zero_tol) {
+    if (abs(static_cast<double>(root_coeff[0])) <= zero_tol) {
         roots[static_cast<std::size_t>(n_roots)] = 0.0;
         ++n_roots;
     }
-    if (std::abs(static_cast<double>(root_coeff[static_cast<std::size_t>(n)])) <= zero_tol) {
+    if (abs(static_cast<double>(root_coeff[static_cast<std::size_t>(n)])) <= zero_tol) {
         roots[static_cast<std::size_t>(n_roots)] = 1.0;
         ++n_roots;
     }
@@ -876,8 +883,8 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
             Acc df_mid{};
             mid = newton_polish_scalar<T>(root_coeff, mid, lo, hi, param_tol, work, f_mid, df_mid);
 
-            if (std::abs(f_mid) <= zero_tol) {
-                if (std::abs(df_mid) <= static_cast<Acc>(kDblEpsilon)) {
+            if (abs(f_mid) <= zero_tol) {
+                if (abs(df_mid) <= static_cast<Acc>(kDblEpsilon)) {
                     // Double root: the derivative is useless, so bisect.
                     double a = lo;
                     double b = hi;
@@ -889,7 +896,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
                         // underflow at float32. Reproduced deliberately; unlike the
                         // other two this one has no verified reproduction, only the
                         // same mechanism.
-                        if (std::abs(fm) < std::abs(fa)) {
+                        if (abs(fm) < abs(fa)) {
                             if (fa * fm <= T{0}) {
                                 b = m;
                             } else {
@@ -910,7 +917,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
                 }
 
                 const T f_final = de_casteljau_eval_scalar<T>(root_coeff, mid, work);
-                if (std::abs(static_cast<Acc>(f_final)) <= zero_tol && n_roots < max_roots) {
+                if (abs(static_cast<Acc>(f_final)) <= zero_tol && n_roots < max_roots) {
                     roots[static_cast<std::size_t>(n_roots)] = mid;
                     ++n_roots;
                 }
@@ -922,7 +929,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
         subdivide_scalar<T>(root_coeff, lo, hi, local);
         double local_scale = 0.0;
         for (int i = 0; i <= n; ++i) {
-            local_scale = std::max(local_scale, std::abs(local[static_cast<std::size_t>(i)]));
+            local_scale = std::max(local_scale, abs(local[static_cast<std::size_t>(i)]));
         }
         const double local_zero_tol =
             std::max(local_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
@@ -943,7 +950,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
                 Acc df_mid{};
                 const double mid = newton_polish_scalar<T>(root_coeff, 0.5 * (lo + hi), lo, hi,
                                                            Acc{0}, work, f_mid, df_mid);
-                if (std::abs(f_mid) <= zero_tol && n_roots < max_roots) {
+                if (abs(f_mid) <= zero_tol && n_roots < max_roots) {
                     roots[static_cast<std::size_t>(n_roots)] = mid;
                     ++n_roots;
                 }
@@ -953,11 +960,11 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
 
         // Step 5: flat within noise.
         if (c_max - c_min <= geom_tol) {
-            if (std::abs(c_min) <= local_zero_tol || std::abs(c_max) <= local_zero_tol
+            if (abs(c_min) <= local_zero_tol || abs(c_max) <= local_zero_tol
                 || c_min * c_max < 0.0) {
                 const double mid = 0.5 * (lo + hi);
                 const T f_mid = de_casteljau_eval_scalar<T>(root_coeff, mid, work);
-                if (std::abs(static_cast<Acc>(f_mid)) <= zero_tol && n_roots < max_roots) {
+                if (abs(static_cast<Acc>(f_mid)) <= zero_tol && n_roots < max_roots) {
                     roots[static_cast<std::size_t>(n_roots)] = mid;
                     ++n_roots;
                 }
@@ -966,11 +973,11 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
         }
 
         // Step 6: endpoint roots.
-        if (std::abs(local[0]) <= local_zero_tol && n_roots < max_roots) {
+        if (abs(local[0]) <= local_zero_tol && n_roots < max_roots) {
             roots[static_cast<std::size_t>(n_roots)] = lo;
             ++n_roots;
         }
-        if (std::abs(local[static_cast<std::size_t>(n)]) <= local_zero_tol && n_roots < max_roots) {
+        if (abs(local[static_cast<std::size_t>(n)]) <= local_zero_tol && n_roots < max_roots) {
             roots[static_cast<std::size_t>(n_roots)] = hi;
             ++n_roots;
         }
@@ -1022,7 +1029,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
             Acc df_mid{};
             const double mid = newton_polish_scalar<T>(root_coeff, 0.5 * (new_lo + new_hi), new_lo,
                                                        new_hi, param_tol, work, f_mid, df_mid);
-            if (std::abs(f_mid) <= zero_tol && n_roots < max_roots) {
+            if (abs(f_mid) <= zero_tol && n_roots < max_roots) {
                 roots[static_cast<std::size_t>(n_roots)] = mid;
                 ++n_roots;
             }
@@ -1087,6 +1094,8 @@ template <Real T>
 int dedup_roots_core(std::span<const double> raw_roots, int n_roots, std::span<const T> coeff,
                      accumulator_t<T> param_tol, accumulator_t<T> geom_tol,
                      std::span<double> out, std::span<T> work) {
+    using std::abs;
+    using std::pow;
     using Acc = accumulator_t<T>;
     if (n_roots == 0) {
         return 0;
@@ -1096,12 +1105,12 @@ int dedup_roots_core(std::span<const double> raw_roots, int n_roots, std::span<c
     double coeff_scale = 0.0;
     for (int i = 0; i <= n; ++i) {
         coeff_scale =
-            std::max(coeff_scale, std::abs(static_cast<double>(coeff[static_cast<std::size_t>(i)])));
+            std::max(coeff_scale, abs(static_cast<double>(coeff[static_cast<std::size_t>(i)])));
     }
     const double zero_tol =
         std::max(coeff_scale * static_cast<double>(n + 1) * 4.0 * kDblEpsilon, geom_tol);
     const double base_dedup = std::max(param_tol * 2.0, zero_tol * 4.0);
-    const double radius_cap = std::pow(zero_tol, 1.0 / 3.0);
+    const double radius_cap = pow(zero_tol, 1.0 / 3.0);
 
     for (int i = 0; i < n_roots; ++i) {
         out[static_cast<std::size_t>(i)] = raw_roots[static_cast<std::size_t>(i)];
@@ -1126,7 +1135,7 @@ int dedup_roots_core(std::span<const double> raw_roots, int n_roots, std::span<c
         Acc df{};
         de_casteljau_eval_and_deriv_scalar<T>(
             coeff, out[static_cast<std::size_t>(count) - 1], work, df);
-        const double local_tol = zero_tol / std::max(std::abs(df), static_cast<Acc>(kDblEpsilon));
+        const double local_tol = zero_tol / std::max(abs(df), static_cast<Acc>(kDblEpsilon));
         if (gap <= std::max(base_dedup, std::min(local_tol * 4.0, radius_cap))) {
             continue;
         }
@@ -1155,6 +1164,7 @@ int dedup_roots_core(std::span<const double> raw_roots, int n_roots, std::span<c
 template <Real T>
 int dispatch_and_find(std::span<const T> coeff, accumulator_t<T> param_tol,
                       accumulator_t<T> geom_tol, std::span<double> out) {
+    using std::abs;
     const auto n = static_cast<int>(coeff.size()) - 1;
     if (n < 1) {
         return 0;
@@ -1162,7 +1172,7 @@ int dispatch_and_find(std::span<const T> coeff, accumulator_t<T> param_tol,
 
     bool all_zero = true;
     for (int i = 0; i <= n; ++i) {
-        if (std::abs(static_cast<accumulator_t<T>>(coeff[static_cast<std::size_t>(i)]))
+        if (abs(static_cast<accumulator_t<T>>(coeff[static_cast<std::size_t>(i)]))
             > geom_tol) {
             all_zero = false;
             break;
@@ -1178,7 +1188,7 @@ int dispatch_and_find(std::span<const T> coeff, accumulator_t<T> param_tol,
         double c_min_nonzero = std::numeric_limits<double>::infinity();
         for (int i = 0; i <= n; ++i) {
             const auto av =
-                static_cast<double>(std::abs(coeff[static_cast<std::size_t>(i)]));
+                static_cast<double>(abs(coeff[static_cast<std::size_t>(i)]));
             c_max = std::max(c_max, av);
             if (av > 0.0 && av < c_min_nonzero) {
                 c_min_nonzero = av;

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ set(PANTR_TEST_SOURCES
     test_change_basis.cpp
     test_quad.cpp
     test_binomial.cpp
-    test_bezier.cpp)
+    test_bezier.cpp
+    test_bezier_root_finding.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)
   cmake_path(GET _src STEM _name)

--- a/cpp/tests/test_bezier_root_finding.cpp
+++ b/cpp/tests/test_bezier_root_finding.cpp
@@ -1,0 +1,388 @@
+/// \file
+/// Mathematical properties of the Bézier root-finding kernels.
+///
+/// ## What this file is for, given that parity is exhaustive
+///
+/// `tests/parity/test_bezier_root_finding.py` compares every entry point against
+/// its Numba oracle bit for bit. What it cannot catch is a bug the **oracle
+/// shares**: a transliteration faithful to a wrong algorithm passes parity
+/// perfectly, and this block was transliterated deliberately. So nothing here
+/// compares the two backends. Every check is against a property the mathematics
+/// fixes, or against a second algorithm.
+///
+/// That distinction is not hypothetical here. The oracle carries two known wrong
+/// answers, FELIGN/pantr#351 and #352, which the C++ reproduces on purpose. Both
+/// live at coefficient magnitudes below `1e-23` and `1e-30`; every polynomial in
+/// this file is of order one, so nothing below is testing in their shadow.
+///
+/// ## The exact checks, and why they can be exact
+///
+///  - **All-positive coefficients admit no root.** A Bernstein polynomial is a
+///    convex combination of its coefficients, and a convex combination of
+///    positive numbers is positive. Nothing rounds this: the claim is about the
+///    sign of a sum of positive terms, and every partial sum in de Casteljau is
+///    itself a convex combination of positives. An integer count, so no tolerance.
+///  - **Every root lies in [0, 1].** Structural: the search never leaves the
+///    interval and the endpoints are clamped.
+///  - **The count never exceeds the number of sign changes.** The
+///    variation-diminishing property, and an integer comparison.
+///  - **The merged roots come back ascending.** The merge sorts before it merges.
+///  - **A degree-1 root is `c0 / (c0 - c1)`.** One division, correctly rounded,
+///    against the same expression written out here.
+///
+/// ## The bounded checks
+///
+/// **The residual at a returned root.** A bracketing method stops on a bracket of
+/// width `param_tol` containing a sign change, so the returned midpoint is within
+/// `param_tol / 2` of a root and `|B(r)| <= |B'| * param_tol / 2` plus whatever
+/// error the evaluation itself carries. The evaluation here is an independent one:
+/// the explicit sum `sum_i c_i C(n,i) t^i (1-t)^(n-i)`, not de Casteljau, so a
+/// wrong triangle cannot hide behind itself. Its own error is bounded by
+/// `2 (n + 1) eps max|c|`, being `n + 1` terms each formed in a few roundings, and
+/// the factor two is an acknowledged margin rather than a derivation.
+///
+/// This check does **not** apply at a double root, where `B'` vanishes and the
+/// bound says nothing; those polynomials are excluded by name below rather than by
+/// a tolerance that would quietly absorb them.
+///
+/// **The two algorithms agree.** Yuksel's monotone decomposition and Bézier
+/// clipping share only the evaluation kernel; the searches are unrelated. Where
+/// both report a root they must report the same one, to within the sum of their
+/// bracketing tolerances. This is the check that would catch a wrong *algorithm*
+/// rather than a wrong endpoint, and it is the reason this file exists.
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/bezier/root_finding.hpp"
+#include "pantr/core/binomial.hpp"
+
+namespace {
+
+constexpr double kTol = 1e-12;
+constexpr double kEps = 2.2204460492503131e-16;
+
+/// Evaluate a Bernstein polynomial by its explicit sum, independently of de Casteljau.
+///
+/// \param coeff Bernstein coefficients.
+/// \param t Parameter in [0, 1].
+/// \return The polynomial value.
+double explicit_bernstein(std::span<const double> coeff, double t) {
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    double total = 0.0;
+    for (int i = 0; i <= n; ++i) {
+        const double basis = static_cast<double>(pantr::core::bincoeff(n, i))
+                             * std::pow(t, static_cast<double>(i))
+                             * std::pow(1.0 - t, static_cast<double>(n - i));
+        total += coeff[static_cast<std::size_t>(i)] * basis;
+    }
+    return total;
+}
+
+/// The derivative of a Bernstein polynomial, by the same explicit sum one degree down.
+///
+/// \param coeff Bernstein coefficients.
+/// \param t Parameter in [0, 1].
+/// \return The derivative value.
+double explicit_derivative(std::span<const double> coeff, double t) {
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    if (n < 1) {
+        return 0.0;
+    }
+    std::vector<double> difference(static_cast<std::size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        difference[static_cast<std::size_t>(i)] =
+            static_cast<double>(n)
+            * (coeff[static_cast<std::size_t>(i) + 1] - coeff[static_cast<std::size_t>(i)]);
+    }
+    return explicit_bernstein(difference, t);
+}
+
+/// The largest magnitude among a polynomial's coefficients.
+///
+/// \param coeff Bernstein coefficients.
+/// \return `max |c_i|`.
+double coefficient_scale(std::span<const double> coeff) {
+    double largest = 0.0;
+    for (const double c : coeff) {
+        largest = std::max(largest, std::abs(c));
+    }
+    return largest;
+}
+
+/// Run Yuksel's decomposition and return the roots it found.
+///
+/// \param coeff Bernstein coefficients.
+/// \return The roots, unsorted.
+std::vector<double> yuksel(std::span<const double> coeff) {
+    std::vector<double> found(std::max(coeff.size(), std::size_t{2}));
+    const int count = pantr::yuksel_roots<double>(coeff, kTol, found);
+    found.resize(static_cast<std::size_t>(count));
+    return found;
+}
+
+/// Run Bézier clipping, merge the duplicates, and return the roots.
+///
+/// \param coeff Bernstein coefficients.
+/// \return The roots, ascending.
+std::vector<double> clipped(std::span<const double> coeff) {
+    const auto n = static_cast<int>(coeff.size()) - 1;
+    std::vector<double> raw(static_cast<std::size_t>(3 * n + 4));
+    const int count = pantr::clip_roots<double>(coeff, kTol, kTol, raw);
+    if (count == 0) {
+        return {};
+    }
+    std::vector<double> merged(static_cast<std::size_t>(count));
+    const int unique = pantr::dedup_roots<double>(
+        std::span<const double>(raw.data(), static_cast<std::size_t>(count)), count, coeff, kTol,
+        kTol, merged);
+    merged.resize(static_cast<std::size_t>(unique));
+    return merged;
+}
+
+/// A family of polynomials of order one, with a stated number of real roots each.
+struct Sample {
+    std::vector<double> coeff;
+    const char* name;
+};
+
+/// The polynomials every property below is checked against.
+///
+/// \return The samples.
+std::vector<Sample> samples() {
+    std::vector<Sample> out;
+    out.push_back({{-1.0, 1.0}, "linear"});
+    out.push_back({{1.0, -1.0, 1.0}, "quadratic, two roots"});
+    out.push_back({{-1.0, 0.0, 1.0}, "quadratic, one root"});
+    out.push_back({{1.0, -0.5, 0.25, -1.0}, "cubic, oscillating"});
+    out.push_back({{-1.0, 2.0, -3.0, 4.0, -5.0, 6.0}, "quintic, alternating"});
+    out.push_back({{1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0}, "degree six, alternating"});
+    out.push_back({{0.3, -0.7, 0.2, 0.9, -0.4, 0.6, -0.8, 0.1, 0.5}, "degree eight, mixed"});
+
+    // A straight control polygon: every hull orientation test is an exact tie.
+    std::vector<double> straight(12);
+    for (std::size_t i = 0; i < straight.size(); ++i) {
+        straight[i] = 1.0 - 2.0 * static_cast<double>(i) / 11.0;
+    }
+    out.push_back({straight, "degree eleven, collinear"});
+    return out;
+}
+
+void test_the_samples_actually_have_roots() {
+    // Every property below is of the form "each root satisfies X". A sample set
+    // that found no roots would satisfy all of them vacuously and pass in silence,
+    // so the count is pinned here rather than assumed. The figure is what the two
+    // algorithms agree on today; if a change moves it, that is the thing to look at
+    // rather than the number to update.
+    int total = 0;
+    int with_roots = 0;
+    for (const Sample& sample : samples()) {
+        const int count = static_cast<int>(yuksel(sample.coeff).size());
+        total += count;
+        with_roots += count > 0 ? 1 : 0;
+    }
+    PANTR_CHECK_MSG(with_roots == static_cast<int>(samples().size()),
+                    "some sample has no roots, so it exercises nothing below");
+    PANTR_CHECK_MSG(total >= 12, "the sample set collectively yields too few roots to test on");
+}
+
+void test_a_positive_control_polygon_admits_no_root() {
+    for (int degree = 1; degree <= 12; ++degree) {
+        std::vector<double> coeff(static_cast<std::size_t>(degree) + 1);
+        for (std::size_t i = 0; i < coeff.size(); ++i) {
+            // Positive and varying, so the answer is not trivially constant.
+            coeff[i] = 0.25 + static_cast<double>(i);
+        }
+        PANTR_CHECK_MSG(yuksel(coeff).empty(),
+                        "a convex combination of positive coefficients cannot vanish");
+        PANTR_CHECK_MSG(clipped(coeff).empty(),
+                        "clipping reported a root of a strictly positive polynomial");
+    }
+}
+
+void test_every_root_lies_in_the_unit_interval() {
+    for (const Sample& sample : samples()) {
+        for (const auto& roots : {yuksel(sample.coeff), clipped(sample.coeff)}) {
+            for (const double r : roots) {
+                PANTR_CHECK_MSG(r >= 0.0 && r <= 1.0,
+                                std::string("a root left the unit interval: ") + sample.name);
+            }
+        }
+    }
+}
+
+void test_the_count_never_exceeds_the_sign_changes() {
+    for (const Sample& sample : samples()) {
+        const int changes = pantr::detail::count_sign_changes<double>(sample.coeff);
+        // The variation-diminishing property. Clipping is compared after the merge,
+        // since before it the same root arrives from several intervals.
+        PANTR_CHECK_MSG(static_cast<int>(clipped(sample.coeff).size()) <= changes,
+                        std::string("more roots than sign changes: ") + sample.name);
+        PANTR_CHECK_MSG(static_cast<int>(yuksel(sample.coeff).size()) <= changes,
+                        std::string("more roots than sign changes: ") + sample.name);
+    }
+}
+
+void test_the_merged_roots_come_back_ascending() {
+    for (const Sample& sample : samples()) {
+        const std::vector<double> roots = clipped(sample.coeff);
+        PANTR_CHECK_MSG(std::is_sorted(roots.begin(), roots.end()),
+                        std::string("the merge returned an unsorted set: ") + sample.name);
+    }
+}
+
+void test_a_linear_root_is_the_one_division_it_should_be() {
+    for (const double c0 : {-1.0, -0.25, 0.5, 3.0}) {
+        for (const double c1 : {-2.0, 0.75, 1.0, 4.0}) {
+            if (c0 == c1 || (c0 > 0.0) == (c1 > 0.0)) {
+                continue;
+            }
+            const std::vector<double> coeff{c0, c1};
+            const std::vector<double> roots = yuksel(coeff);
+            PANTR_CHECK_MSG(roots.size() == 1, "a linear with a sign change has one root");
+            if (roots.size() == 1) {
+                // One correctly rounded division against the same expression, so
+                // the comparison is an equality rather than a tolerance.
+                PANTR_CHECK_MSG(roots[0] == c0 / (c0 - c1),
+                                "the degree-1 base case is not its own formula");
+            }
+        }
+    }
+}
+
+void test_a_returned_root_has_a_small_residual() {
+    for (const Sample& sample : samples()) {
+        const std::span<const double> coeff(sample.coeff);
+        const double scale = coefficient_scale(coeff);
+        const auto n = static_cast<double>(coeff.size() - 1);
+        // See the file comment: the bracket contributes |B'| * param_tol / 2 and the
+        // independent evaluation contributes 2 (n + 1) eps max|c|, the two being
+        // added rather than maximised because both are present at once.
+        const double evaluation_error = 2.0 * (n + 1.0) * kEps * scale;
+
+        for (const auto& roots : {yuksel(sample.coeff), clipped(sample.coeff)}) {
+            for (const double r : roots) {
+                const double slope = std::abs(explicit_derivative(coeff, r));
+                const double allowed = slope * kTol / 2.0 + evaluation_error;
+                if (slope <= evaluation_error) {
+                    // A vanishing derivative is a multiple root, where this bound
+                    // says nothing. Excluded by name rather than absorbed.
+                    continue;
+                }
+                PANTR_CHECK_MSG(std::abs(explicit_bernstein(coeff, r)) <= allowed,
+                                std::string("a returned root does not satisfy the polynomial: ")
+                                    + sample.name);
+            }
+        }
+    }
+}
+
+void test_the_two_algorithms_find_the_same_roots() {
+    for (const Sample& sample : samples()) {
+        std::vector<double> from_yuksel = yuksel(sample.coeff);
+        const std::vector<double> from_clipping = clipped(sample.coeff);
+        std::sort(from_yuksel.begin(), from_yuksel.end());
+
+        PANTR_CHECK_MSG(from_yuksel.size() == from_clipping.size(),
+                        std::string("the two algorithms disagree on how many roots exist: ")
+                            + sample.name);
+        if (from_yuksel.size() != from_clipping.size()) {
+            continue;
+        }
+        for (std::size_t i = 0; i < from_yuksel.size(); ++i) {
+            // Each brackets to within kTol, so their answers sit within the sum.
+            PANTR_CHECK_MSG(std::abs(from_yuksel[i] - from_clipping[i]) <= 2.0 * kTol,
+                            std::string("the two algorithms found different roots: ")
+                                + sample.name);
+        }
+    }
+}
+
+void test_the_hull_clip_contains_every_root() {
+    for (const Sample& sample : samples()) {
+        const std::vector<double> roots = yuksel(sample.coeff);
+        if (roots.empty()) {
+            continue;
+        }
+        std::vector<std::int64_t> chain(sample.coeff.size());
+        double lo = 0.0;
+        double hi = 0.0;
+        const bool found = pantr::detail::clip_hull_to_zero<double>(sample.coeff, chain, lo, hi);
+        PANTR_CHECK_MSG(found, std::string("the hull found no crossing though roots exist: ")
+                                   + sample.name);
+        if (!found) {
+            continue;
+        }
+        // The convex hull of the control polygon contains the graph, so every root
+        // lies between the outermost crossings of the hull with y = 0. Two terms in
+        // the margin, and the first is the larger by three orders: the root being
+        // compared is a bracket midpoint, so it sits within `kTol / 2` of the true
+        // root the hull actually contains, and the crossing itself carries the
+        // rounding margin `_clip_roots_core` applies. An earlier version of this
+        // test carried only the second and failed by 5e-13 against a margin of
+        // 2.7e-15, which is the bracketing term it had left out.
+        const auto n = static_cast<double>(sample.coeff.size() - 1);
+        const double margin = kTol / 2.0 + (n + 1.0) * 4.0 * kEps;
+        for (const double r : roots) {
+            PANTR_CHECK_MSG(r >= lo - margin && r <= hi + margin,
+                            std::string("a root fell outside the hull's clip: ") + sample.name);
+        }
+    }
+}
+
+void test_the_monotone_solver_reports_no_root_without_a_sign_change() {
+    // Strictly increasing and strictly positive: no sign change, so no root.
+    const std::vector<double> rising{0.5, 1.0, 2.0, 4.0};
+    PANTR_CHECK_MSG(std::isnan(pantr::solve_monotone_root<double>(rising, kTol)),
+                    "the monotone solver invented a root of a positive polynomial");
+
+    // A genuine sign change: the answer must satisfy the polynomial.
+    const std::vector<double> crossing{-1.0, -0.25, 0.5, 2.0};
+    const double root = pantr::solve_monotone_root<double>(crossing, kTol);
+    PANTR_CHECK_MSG(!std::isnan(root), "the monotone solver missed a sign change");
+    if (!std::isnan(root)) {
+        const double slope = std::abs(explicit_derivative(crossing, root));
+        const double allowed = slope * kTol / 2.0 + 2.0 * 4.0 * kEps * 2.0;
+        PANTR_CHECK_MSG(std::abs(explicit_bernstein(crossing, root)) <= allowed,
+                        "the monotone solver's root does not satisfy the polynomial");
+    }
+}
+
+void test_float32_runs_the_same_structural_identities() {
+    // Not a precision check: the widths are parity's business. This is here so a
+    // template that only ever instantiated at double cannot pass unnoticed.
+    const std::vector<float> coeff{-1.0F, 0.0F, 1.0F};
+    std::vector<double> found(2);
+    const int count = pantr::yuksel_roots<float>(coeff, kTol, found);
+    PANTR_CHECK_MSG(count == 1, "the float32 instantiation lost a root");
+    if (count == 1) {
+        PANTR_CHECK_MSG(found[0] >= 0.0 && found[0] <= 1.0,
+                        "the float32 instantiation left the unit interval");
+    }
+
+    const std::vector<float> positive{0.5F, 1.0F, 2.0F};
+    PANTR_CHECK_MSG(std::isnan(pantr::solve_monotone_root<float>(positive, kTol)),
+                    "the float32 monotone solver invented a root");
+}
+
+}  // namespace
+
+int main() {
+    test_the_samples_actually_have_roots();
+    test_a_positive_control_polygon_admits_no_root();
+    test_every_root_lies_in_the_unit_interval();
+    test_the_count_never_exceeds_the_sign_changes();
+    test_the_merged_roots_come_back_ascending();
+    test_a_linear_root_is_the_one_division_it_should_be();
+    test_a_returned_root_has_a_small_residual();
+    test_the_two_algorithms_find_the_same_roots();
+    test_the_hull_clip_contains_every_root();
+    test_the_monotone_solver_reports_no_root_without_a_sign_change();
+    test_float32_runs_the_same_structural_identities();
+    return pantr::test::summary("test_bezier_root_finding");
+}

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -696,10 +696,28 @@ transliteration agrees on all 4800 collinear cases and a fused one on 3833.
 A collinear control polygon is not exotic. A degree-elevated linear polynomial, an affine segment
 and a constant all produce one.
 
-**Why this is a different kind of hazard.** Rule 10's contraction bound absorbs a displacement
-because the two backends compute the same quantity to different last bits. Here contraction
-changes which branch is taken, and downstream of a branch the two backends are computing
-different things. No tolerance covers that, and no amplification makes it smaller.
+**Why this is a different kind of hazard, and one sentence here was wrong.** Rule 10's
+contraction bound absorbs a displacement because the two backends compute the same quantity to
+different last bits. Here contraction changes which branch is taken, and a branch is not a
+quantity a tolerance can bound.
+
+The first version of this section then said that downstream of a flipped tie-break the two
+backends compute different things. **Measured, that is false for the mechanism it names.**
+Andrew's monotone chain with `cross >= 0` pops a collinear vertex and with a tiny negative
+residue keeps it, but either way the hull is the same **polyline**: keeping a collinear vertex
+splits one edge into two collinear pieces and the crossing lies on exactly one of them, at the
+same point. Over the collinear family at every degree and both contraction orders, vertex-set
+flips do occur, the returned interval changes in fewer cases than the vertex set does, and when
+it changes it changes by **one to two ulp**. That is a displacement, which is exactly what a
+tolerance covers.
+
+**The conclusion stands, for a mechanism this rule did not name.** A count can change, but
+through threshold comparisons on displaced values rather than through exact ties: fusion moves
+the subdivided net by ulps, and `_count_sign_changes`, `abs(local[0]) <= local_zero_tol` and
+`c_min > local_zero_tol` all read it. That mechanism is generic and has nothing to do with
+collinearity, which means a collinear adversary is aimed at the wrong target. How close that
+cliff sits: perturbing one coefficient by one ulp across the parity matrix changes the root
+count in **199 of 1464 perturbations**.
 
 **What follows for a parity claim.** Assert the count on its own, before and separately from any
 numeric comparison. `tests/parity/test_bezier_root_finding.py` does, and its failure message says
@@ -712,38 +730,60 @@ were identical, 113 moved in value and **zero changed the root set**. That is ev
 proof: the tie-break demonstrably can flip, so a set change is possible and simply did not occur.
 The count agreement is asserted per case rather than derived.
 
-### The bound where contraction is live, and the two corrections it needed
+### The bound where contraction is live: certify it, do not predict it
 
-The displacement is **not** a rounding bound and cannot be spelled as one. A root is located only
-to within the interval where the computed residual is indistinguishable from zero, of half-width
-`eps_f / |f'(r)|`, and below that scale the bracketing tolerance also applies; the bound is the
-larger of the two. `eps_f` is the evaluation's own forward error, at the **coefficient** width,
-and the half-width is capped at `eps_f^(1/3)`, the cluster width around a root of multiplicity up
-to three, which is the same cap and the same reasoning `_dedup_roots_core` already uses for its
-merge radius.
+Two predicted bounds were tried here and both were refuted. They are recorded because the way
+each failed is more useful than the formula that replaced them.
 
-Two corrections got it there, and both are the kind that pass every test until something forces
-the branch to run.
+**The first was fitted where one term happened to dominate.** Over 732 float64-heavy results the
+worst displacement was `4.951e-13` against a `param_tol` of `1e-12`, so the bracketing tolerance
+looked like the whole bound and looked *tight*, which is normally the sign a derivation is right.
+At `float32` a degree-5 case moved by `2e-8`. The term it omitted is around `1e-15` at float64
+and cannot be seen there. **A measurement cannot refute a bound in a regime where the missing
+term is invisible.**
 
-**The first bound was fitted where one term happened to dominate.** Measured over 732
-float64-heavy results, the worst displacement was `4.951e-13` against a `param_tol` of `1e-12`,
-which looked like the bracketing tolerance was the whole bound and looked *tight*, which is
-normally the sign a derivation is right. At `float32` a degree-5 case moved by `2e-8`, four
-orders past it: the residual term is around `1e-15` at `float64` and never shows. A measurement
-cannot refute a bound in a regime where the missing term is invisible.
+**The second predicted the acceptance component's half-width as `eps_f / |f'(r)|`, capped at
+`eps_f^(1/3)`, and an adversarial review took it apart on four counts:**
 
-**The vacuity guard's premise fails for a quantity on a bounded domain.** Rule 3 refuses a bound
-that reaches the values it compares, which is right for a coefficient and wrong for a curve
-parameter: a root at `3.6e-13` is not a quantity with no digits, it is a parameter next to an
-endpoint, and a bound of `1e-12` on it still says something a wrong answer would violate. With
-the root's own magnitude as the scale, two cases were refused as vacuous **while the two backends
-agreed bit for bit**. The harness now lets a claim name the scale its quantity lives on, and the
-guard takes the larger of that and the values.
+- `eps_f = (degree + 1) u max|c|` is **false at float64**, by an exact-rational counterexample at
+  degree 1 exceeding it by 1.126x. The literature constant is Mainar and Peña's `gamma_2n`
+  (1999), corrected by Hermes (2019) to `gamma_3n` because the original did not charge the
+  rounding of `1 - t`, which this kernel commits.
+- **It used the wrong epsilon.** The kernel accepts a candidate on `abs(f_final) <= zero_tol`,
+  and computes `zero_tol` itself. For `f(t) = t - 1/2`, the simplest polynomial in the parity
+  matrix, the acceptance band is **exactly twice** what the bound claimed.
+- The linearisation needs a curvature hypothesis nobody stated, and there is a measured window
+  at `|f'| ~ 2 sqrt(eps)` where it fails by 2.75x **and the cap has not yet engaged**. The two
+  thresholds are unrelated quantities; the cap only fires three decades further down.
+- **The cap is not scale-invariant and is dimensionally wrong.** `eps_f^(1/3)` has units of
+  `[f]^(1/3)` and is compared against `[t]`; the correct cluster half-width is
+  `(eps / |a_m|)^(1/m)`. Measured, a triple root came back **bit-identical over 2^60 of
+  coefficient scaling** while the cap moved by a factor of a million. A bound that moves when
+  the bounded quantity does not is not a bound. This one is inherited: `_dedup_roots_core`'s own
+  `radius_cap` has the same two defects, and predates the port.
 
-Where the bound genuinely does reach the whole domain, Rule 8 applies unchanged and the case is
-named: eight decades of coefficient range at `float32` reach a tenth of the interval at degree 8,
-which is weak but still refutable and so is asserted, and `9.5` at degree 17, which covers the
-interval and is skipped with its number in the message.
+**Certifying answers all four at once, and it is the cheaper thing to write.** Rather than
+predicting the component's width from derivatives at the root, prove it: restrict the Bernstein
+net to each flanking interval and use the convex-hull property, which says the graph over an
+interval lies within the range of that interval's own coefficients. If they are all above `eps`
+or all below `-eps`, no point of that flank can be accepted, so the component cannot reach past
+the half-width being tested. Binary search the half-width; certification is monotone in it.
+
+The certificate is scale-invariant because scaling the coefficients scales the band with them;
+dimensionally correct because a half-width is the thing it searches for; and multiplicity-
+agnostic because no derivative appears. The restriction is done in **exact rational arithmetic**,
+which makes the hull bound a proof rather than an estimate needing its own error term, and it is
+written out rather than borrowed from `_subdivide_scalar`, so a bug in the kernels cannot
+certify itself.
+
+Verified on the case the old cap existed for: a triple root certifies at `1.221e-04` for a
+coefficient scale of 1, 1e6 and 1e-6 alike. Over the parity matrix it bounds **83 of 86** cases
+below the parameter interval; the three it does not are `float32` polynomials whose roots have
+no digits left, which Rule 8 excludes by name.
+
+The band it certifies against is the algorithm's own `zero_tol` plus the evaluation's forward
+error at the corrected `gamma_3n`, written first-order as `n u_T + 3n u_64`. Note which epsilon
+that is: the one the code uses, not one derived for it.
 
 ### A claim kind the harness did not have
 

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -1,6 +1,6 @@
 # Backend parity: what a bound may claim, and in which frame
 
-**Status:** complete for the four ports that exist. Ten rules, each with the failure that produced
+**Status:** complete for the five ports that exist. Eleven rules, each with the failure that produced
 it, and the remaining module ports inherit them. The verdict on whether the parity harness
 generalized is now written, from the `quad` port's tests rather than predicted before them.
 **Date:** 2026-08-20, amended the same day after a deep review closed two open proofs,
@@ -14,9 +14,14 @@ which is the first rule here that is about reproducing an oracle exactly rather 
 bounding a difference, because that port is the first whose every kernel can be bit-exact.
 Amended 2026-08-22 with Rule 10 (contraction removes one rounding per fused site), which closes
 the gap Rule 9's section declared: the Bézier claims are now conditional on what the build can
-do rather than skipped where it can fuse.
+do rather than skipped where it can fuse. Amended 2026-08-24 by the root-finding port with
+Rule 11 (an exact tie does not survive contraction, and a tie-break is a verdict rather than
+a displacement), and with a section added to Rule 9 recording that numba's `float()` does not
+widen a `float32`, which is the mechanism the three earlier width surprises rest on.
 
-**Validated against:** `proto/cpp` at `765d9b9`, plus the `quad` port on `feat/cpp-quad`.
+**Validated against:** `proto/cpp` at `765d9b9`, the `quad` port on `feat/cpp-quad`, and the
+root-finding port on `feat/cpp-bezier-roots`, whose fused branch was exercised against an
+extension built at `-march=native` rather than reasoned about.
 
 ## The one fact everything else follows from
 
@@ -349,6 +354,34 @@ them, none of them announced:
   unconditionally against a destination in the control points' dtype, so each `+=` computes wide
   and rounds narrow.
 
+**The root-finding port found the mechanism underneath this, and it is worse than a convention
+nobody wrote down.** `float()` does not widen a `float32` in numba's `nopython` mode.
+`float(coeff[0])` reads as a promotion and is a no-op; so does `float(np.min(coeff))`. What
+widens is **type unification across assignments**, so a variable seeded with `0.0` or
+`float("inf")` and later given a `float32` is `float64` throughout, while one that only ever
+holds an array element stays narrow however many `float()` calls surround it.
+
+Six sites in the root-finding block carry a `float()` a reader would take for a cast. None
+promotes, and three of the five widths there follow from that alone. Two consequences worth
+carrying forward:
+
+- **A width cannot be read off the source, and cannot be inferred per kernel or per module.**
+  `_batch_core.py:87` divides in `float64` and `_yuksel_core.py:309` divides the same shape of
+  expression in `float32`; what separates them is whether some *other* assignment forced the
+  variable wider. The transliteration has to go expression by expression.
+- **The destination's dtype says nothing about the width the operation ran at.**
+  `derivs[0, i] = coeff[i + 1] - coeff[i]` writes into a `float64` array and subtracts in
+  `float32`, widening only on the store. The model that widened first reproduced 88 of 4000
+  float32 vectors.
+
+`scripts/measure_root_finding_widths.py` measures every one of these behaviourally, two rival
+models per site against the kernel, and reports how often the two disagree so a match cannot come
+from a check that could not fail. **That script, not a reading of the source, is what a
+transliteration should be written against.** The sharpest case is the degree-1 base case
+`c0 / (c0 - c1)`, where the `float64` model reproduced *none* of 20000 pairs: a C++
+`double root = c0 / (c0 - c1);` breaks parity on every `float32` input, and the difference reads
+as round-off rather than as a defect.
+
 **None of this is visible at `float64`, where all three coincide.** Measured on one kernel:
 accumulating narrow where the oracle accumulates wide moves 125 of 630 `float32` values.
 Widening where the oracle narrows is the same error the other way and was caught the same way,
@@ -641,6 +674,97 @@ Nothing structural, on this evidence. But **`Roundings` and `amplification` both
 docstrings corrected** to say what they actually carry, and a fourth consumer whose bound is again
 neither a chain nor a magnitude would be the point at which the field's meaning, rather than its
 documentation, has to change.
+
+## Rule 11: an exact tie does not survive contraction, and a tie-break is a verdict
+
+Added by the Bézier root-finding port, the first whose kernels are **iterative** and whose
+results carry a discrete verdict as well as a value: how many roots there are, which intervals
+survive, which hull vertices are kept. Rules 1 to 10 all bound a displacement. None of them says
+anything about a count, and a count is what this block can get wrong.
+
+**The mechanism.** The convex-hull clipper's orientation predicate is `a*b - c*d`. On an exactly
+collinear control polygon the two products are equal reals and the expression evaluates to
+**exactly zero**, so `cross >= 0` holds and Andrew's monotone chain pops the vertex. Under
+`-ffp-contract=on` on a target with a fused multiply-add, the compiler may compute
+`fma(a, b, -(c*d))`, which returns the exact residual of the rounding in `c*d`: a tiny nonzero
+value of arbitrary sign. The tie-break becomes a coin toss.
+
+Measured on 200000 constructed collinear triples: 184224 evaluate to exactly zero unfused, and
+fusing flips the branch on **130538**. Measured against the kernel itself, an unfused
+transliteration agrees on all 4800 collinear cases and a fused one on 3833.
+
+A collinear control polygon is not exotic. A degree-elevated linear polynomial, an affine segment
+and a constant all produce one.
+
+**Why this is a different kind of hazard.** Rule 10's contraction bound absorbs a displacement
+because the two backends compute the same quantity to different last bits. Here contraction
+changes which branch is taken, and downstream of a branch the two backends are computing
+different things. No tolerance covers that, and no amplification makes it smaller.
+
+**What follows for a parity claim.** Assert the count on its own, before and separately from any
+numeric comparison. `tests/parity/test_bezier_root_finding.py` does, and its failure message says
+that a changed count is a changed verdict rather than a displaced value. Folding the two together
+is the error to avoid: a bounded claim compares elementwise and cannot see two results of
+different length at all.
+
+**What is measured and what is not.** Over 732 public results on a `-march=native` build, 619
+were identical, 113 moved in value and **zero changed the root set**. That is evidence and not a
+proof: the tie-break demonstrably can flip, so a set change is possible and simply did not occur.
+The count agreement is asserted per case rather than derived.
+
+### The bound where contraction is live, and the two corrections it needed
+
+The displacement is **not** a rounding bound and cannot be spelled as one. A root is located only
+to within the interval where the computed residual is indistinguishable from zero, of half-width
+`eps_f / |f'(r)|`, and below that scale the bracketing tolerance also applies; the bound is the
+larger of the two. `eps_f` is the evaluation's own forward error, at the **coefficient** width,
+and the half-width is capped at `eps_f^(1/3)`, the cluster width around a root of multiplicity up
+to three, which is the same cap and the same reasoning `_dedup_roots_core` already uses for its
+merge radius.
+
+Two corrections got it there, and both are the kind that pass every test until something forces
+the branch to run.
+
+**The first bound was fitted where one term happened to dominate.** Measured over 732
+float64-heavy results, the worst displacement was `4.951e-13` against a `param_tol` of `1e-12`,
+which looked like the bracketing tolerance was the whole bound and looked *tight*, which is
+normally the sign a derivation is right. At `float32` a degree-5 case moved by `2e-8`, four
+orders past it: the residual term is around `1e-15` at `float64` and never shows. A measurement
+cannot refute a bound in a regime where the missing term is invisible.
+
+**The vacuity guard's premise fails for a quantity on a bounded domain.** Rule 3 refuses a bound
+that reaches the values it compares, which is right for a coefficient and wrong for a curve
+parameter: a root at `3.6e-13` is not a quantity with no digits, it is a parameter next to an
+endpoint, and a bound of `1e-12` on it still says something a wrong answer would violate. With
+the root's own magnitude as the scale, two cases were refused as vacuous **while the two backends
+agreed bit for bit**. The harness now lets a claim name the scale its quantity lives on, and the
+guard takes the larger of that and the values.
+
+Where the bound genuinely does reach the whole domain, Rule 8 applies unchanged and the case is
+named: eight decades of coefficient range at `float32` reach a tenth of the interval at degree 8,
+which is weak but still refutable and so is asserted, and `9.5` at degree 17, which covers the
+interval and is skipped with its number in the message.
+
+### A claim kind the harness did not have
+
+None of this can be written with `bounded_parity`, which builds its bound from a rounding budget
+times an amplification. Reaching a given number that way would mean choosing an amplification to
+produce it, which is the fitted constant the harness exists to make unsayable. `ParityKind`
+gained a third member, `CONVERGED`, carrying an absolute bound and the scale its quantity lives
+on.
+
+### The branch that ships unevaluated is the one that is broken
+
+Rule 9's section deferred the fused claim entirely and Rule 10 derived it, but on the shipped
+build neither branch runs: the target carries no `-march`, so nothing fuses and every claim takes
+its bitwise arm. **This port's fused branch shipped broken during development** -- it called
+`bounded_parity` with an argument that function does not take -- and 133 tests passed over it,
+because none of them reached it. It was found by building the extension at `-march=native` and
+running the suite there.
+
+An unexercised claim is not a weak claim, it is an unevaluated one. Building the fusing variant
+and running against it is cheap, the recipe is in `scripts/measure_bezier_fma_bound.py`, and it
+should be part of finishing any port that carries a conditional claim.
 
 ## Epistemic status
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -93,12 +93,15 @@ user-facing, and the ports change what it affects.
   test evaluates to exactly zero, and fusing turns that tie into a signed residue. Measured over
   732 results on such a build, 113 roots moved in value and none changed the set, but that is
   evidence rather than a proof.
-  **Where the values do move, the bound is the algorithm's, not the arithmetic's.** A root is
-  located only to within the interval where the computed residual is indistinguishable from zero.
-  At `float64` that is invisible under the bracketing tolerance; at `float32` it dominates by four
-  orders. For coefficients spanning eight decades at `float32` it reaches a tenth of the parameter
-  interval at degree 8 and the whole of it by degree 17, which is the accuracy limit of the
-  problem at that width rather than a difference between the backends.
+  **Where the values do move, the bound is certified rather than predicted.** A root is located
+  only to within the connected set where the computed residual is inside the band the algorithm
+  itself accepts, and that set's width is *proved* by restricting the Bernstein net to each
+  flanking interval in exact rational arithmetic and applying the convex-hull property. Two
+  predicted formulas were tried first and both were refuted; the certificate needs no derivative,
+  no curvature hypothesis and no bound on any multiplicity, and unlike them it does not move when
+  the coefficients are rescaled. It bounds 83 of 86 cases in the parity matrix; the three it does
+  not are `float32` polynomials spanning eight decades, whose roots have no digits left at that
+  width, and those are named rather than skipped quietly.
 - `scripts/measure_root_finding_widths.py`, which measures the arithmetic width of every
   expression in the root-finding kernels, two rival models per site against the kernel plus a
   count of how often the two disagree. It exists because numba's `float()` does **not** widen a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 The dual-backend prototype on the `proto/cpp` branch. Four module pull requests so far: the
-infrastructure, the `quad` port, the `change_basis` port and the `bezier` arithmetic port. The
+infrastructure, the `quad` port, the `change_basis` port, the `bezier` arithmetic port and the
+`bezier` root-finding port. The
 infrastructure landed without a changelog entry, so this section covers all of them -- the environment variable it introduced is
 user-facing, and the ports change what it affects.
 
@@ -79,6 +80,30 @@ user-facing, and the ports change what it affects.
   where it is not. This
   matters ahead of any build that raises the instruction-set baseline: before it, such a build
   would have turned every one of those assertions into a skip and left the suite green.
+- A C++ implementation of `pantr.bezier`'s **root finding**: Yuksel's monotone decomposition,
+  Bezier clipping, the duplicate merge and both batch entry points. `PANTR_BACKEND=cpp` now
+  reaches `find_roots` and `find_monotone_root`, single and batched.
+  **Bit-for-bit identical between the two backends on the shipped build**, as the arithmetic port
+  is and for the same reason: the target carries no `-march`, so baseline x86-64 has no fused
+  multiply-add and both sides evaluate the same expressions in the same order.
+  Two things are new here and worth knowing.
+  **A root set carries a discrete verdict, not just a value.** How many roots there are is not
+  something a tolerance bounds, so the count is asserted on its own. On a build that *does* fuse,
+  the convex-hull tie-break can flip: on an exactly collinear control polygon the orientation
+  test evaluates to exactly zero, and fusing turns that tie into a signed residue. Measured over
+  732 results on such a build, 113 roots moved in value and none changed the set, but that is
+  evidence rather than a proof.
+  **Where the values do move, the bound is the algorithm's, not the arithmetic's.** A root is
+  located only to within the interval where the computed residual is indistinguishable from zero.
+  At `float64` that is invisible under the bracketing tolerance; at `float32` it dominates by four
+  orders. For coefficients spanning eight decades at `float32` it reaches a tenth of the parameter
+  interval at degree 8 and the whole of it by degree 17, which is the accuracy limit of the
+  problem at that width rather than a difference between the backends.
+- `scripts/measure_root_finding_widths.py`, which measures the arithmetic width of every
+  expression in the root-finding kernels, two rival models per site against the kernel plus a
+  count of how often the two disagree. It exists because numba's `float()` does **not** widen a
+  `float32`, so three of the five widths are narrower than the source reads, and a C++ author
+  writing the obvious thing would break parity on every `float32` input at the degree-1 base case.
 - `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever
   extension is installed, and prints how to build one that fuses.
 

--- a/scripts/measure_root_finding_widths.py
+++ b/scripts/measure_root_finding_widths.py
@@ -1,0 +1,865 @@
+#!/usr/bin/env python
+"""Measure the arithmetic width of every operation in the root-finding kernels.
+
+``design/backend_parity.md`` Rule 9 says an oracle's accumulation width is a
+**per-kernel fact, not a module convention**, and that getting it wrong is invisible
+at float64. This script is the measurement for ``pantr.bezier``'s root-finding block,
+and it is what the C++ transliteration in ``cpp/include/pantr/bezier/root_finding.hpp``
+is written against.
+
+The method is behavioural rather than a reading of Numba's type inference: for each
+site, two rival models are run against the kernel and compared **bit for bit**. A
+model that matches proves nothing on its own, so every site also reports how often
+the two models *disagree*. A hypothesis confirmed by a check that cannot fail is not
+confirmed.
+
+    PYTHONPATH="$(pwd)/src:$(pwd)" .venv/bin/python scripts/measure_root_finding_widths.py
+
+What it found when it was written
+---------------------------------
+
+**Numba's ``float()`` does not widen a float32.** That is the finding the rest rests
+on, and it is the opposite of what the source reads like: ``float(coeff[0])`` is a
+no-op, and so is ``float(np.min(coeff))``. What widens is type unification across
+assignments, so a variable seeded with ``0.0`` or ``float("inf")`` and later given a
+float32 is float64 throughout. Six sites in the block carry a ``float()`` a reader
+would take for a promotion; none of them promotes.
+
+Five widths follow, three of them not what a C++ author would write by default:
+
+* the de Casteljau triangle accumulates in ``float64``, because the parameter is a
+  float64 argument, and **narrows on every store** into the ``coeff.copy()`` buffer;
+* the derivative kernel does the same and then takes ``d1 - d0`` **in float32**;
+* the hull predicate subtracts ``coeff[i] - coeff[j0]`` **in float32** before the
+  integer factor promotes the product;
+* the Yuksel forward difference subtracts **in float32** and widens on the store into
+  a ``float64`` array;
+* the degree-1 base case divides ``c0 / (c0 - c1)`` **entirely in float32**. This is
+  the worst of the five: the float64 model matched *none* of 20000 pairs, so a C++
+  ``double root = c0 / (c0 - c1);`` breaks parity on every float32 input, and it reads
+  as round-off rather than as a defect.
+
+And two sites that look exactly like those and are not, which is why the table cannot
+be read as a per-kernel or per-module rule. ``_batch_core.py:87`` divides in float64
+and ``_yuksel_core.py:309`` divides the same shape of expression in float32; what
+separates them is whether some other assignment forced the variable wider. The C++ has
+to be transliterated expression by expression.
+
+Two of the widths are measured but unreachable through the public entry points:
+``_clip_hull_to_zero`` and ``_count_sign_changes`` are only ever called on the float64
+array that ``_subdivide_scalar`` returns. They are here because the kernels accept
+float32 and a direct caller can reach them.
+
+Plus two library facts and one hazard that is not about width at all. See
+:func:`measure_the_cube_root`, :func:`report_minimum_and_maximum` and
+:func:`measure_the_hull_under_contraction`.
+
+"""
+
+from __future__ import annotations
+
+import sys
+from fractions import Fraction
+from typing import Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._numba_compat import nb_jit
+from pantr.bezier._root_finding_core import (
+    _clip_hull_to_zero,
+    _de_casteljau_eval_and_deriv_scalar,
+    _de_casteljau_eval_scalar,
+)
+
+_SEED: Final = 20260824
+"""Fixed so a rerun reproduces the table rather than a similar one.
+
+Every measurement gets its **own** generator derived from this, rather than all of
+them drawing from one. Sharing a generator makes each number depend on how many
+samples the measurements above it happened to take, so adding a site silently
+moves every figure below it, and a number quoted from this script goes stale
+without anything changing about what it measures."""
+
+_F32: Final = np.float32
+"""The narrow dtype, spelled once."""
+
+_DEGREES: Final = (1, 2, 3, 5, 8, 13, 21, 34)
+"""A spread rather than a sweep: the widths do not depend on degree, but the number
+of roundings that can accumulate before the two models separate does."""
+
+_FloatArray = npt.NDArray[np.float32 | np.float64]
+"""A coefficient array at either width."""
+
+_COLLINEAR_SHARE: Final = 0.5
+"""Fraction of hull samples drawn as a near-straight control polygon."""
+
+_HULL_MIN_STACK: Final = 2
+"""Andrew's monotone chain needs two vertices on the stack before it can turn."""
+
+
+class Verdict(NamedTuple):
+    """One width hypothesis, measured against the kernel.
+
+    Attributes:
+        site (str): Where the operation lives, as ``file:line`` or a kernel name.
+        hypothesis (str): The width this model assumes.
+        matched (int): Cases in which the model reproduced the oracle bit for bit.
+        total (int): Cases run.
+        rivals_differ (int): Cases in which this model and its rival disagree. A
+            hypothesis whose rival never disagrees has not been discriminated, and
+            the match count means nothing.
+    """
+
+    site: str
+    hypothesis: str
+    matched: int
+    total: int
+    rivals_differ: int
+
+
+def bits(value: float) -> int:
+    """Reinterpret a float64 as its integer bit pattern, so equality is bitwise.
+
+    Args:
+        value (float): The value to reinterpret. ``nan`` compares equal to itself
+            here, which ``==`` does not.
+
+    Returns:
+        int: The IEEE 754 binary64 bit pattern as a signed integer.
+    """
+    return int(np.float64(value).view(np.int64))
+
+
+def _round_to_double(exact: Fraction) -> float:
+    """Round an exact rational to the nearest float64.
+
+    Used to build a fused reference without ``math.fma``, which arrived in Python
+    3.13 while this project supports 3.11. ``float(Fraction)`` divides two integers,
+    and CPython's integer true division is correctly rounded, so this is exact.
+
+    Args:
+        exact (Fraction): The exact value.
+
+    Returns:
+        float: The nearest float64, ties to even.
+    """
+    return float(exact)
+
+
+def fused_product_difference(a: float, b: float, c: float, d: float) -> float:
+    """Compute ``a*b - c*d`` the way a contracting compiler may emit it.
+
+    With ``-ffp-contract=on`` a compiler is free to turn ``a*b - c*d`` into
+    ``fma(a, b, -(c*d))``: the first product stays exact and only the subtraction
+    rounds, where the unfused form rounds both products and then the subtraction.
+
+    Args:
+        a (float): First factor of the first product.
+        b (float): Second factor of the first product.
+        c (float): First factor of the second product.
+        d (float): Second factor of the second product.
+
+    Returns:
+        float: One correctly rounded result of ``a*b - fl(c*d)``.
+    """
+    return _round_to_double(Fraction(a) * Fraction(b) - Fraction(c * d))
+
+
+@nb_jit(nopython=True, cache=False)
+def _forward_difference(coeff: _FloatArray, n: int) -> npt.NDArray[np.float64]:
+    """Reproduce the Yuksel derivative-chain seed, ``_yuksel_core.py:318-319``.
+
+    Args:
+        coeff (_FloatArray): Bernstein coefficients of length ``n + 1``.
+        n (int): The degree.
+
+    Returns:
+        npt.NDArray[np.float64]: The first forward difference, in a float64 array.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed). This is a probe,
+        not a library function.
+    """
+    out = np.zeros(n, dtype=np.float64)
+    for i in range(n):
+        out[i] = coeff[i + 1] - coeff[i]
+    return out
+
+
+@nb_jit(nopython=True, cache=False)
+def _linear_root(coeff: _FloatArray) -> float:
+    """Reproduce the degree-1 base case, ``_yuksel_core.py:309``.
+
+    Args:
+        coeff (_FloatArray): Two Bernstein coefficients.
+
+    Returns:
+        float: ``c0 / (c0 - c1)``, at whatever width Numba chooses.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed). The caller
+        guarantees ``coeff[0] != coeff[1]``.
+    """
+    c0 = coeff[0]
+    c1 = coeff[1]
+    return float(c0 / (c0 - c1))
+
+
+@nb_jit(nopython=True, cache=False)
+def _hull_cross(coeff: _FloatArray, i: int, j0: int, j1: int) -> float:
+    """Reproduce the orientation predicate, ``_root_finding_core.py:274``.
+
+    Args:
+        coeff (_FloatArray): Bernstein coefficients.
+        i (int): Index of the candidate vertex.
+        j0 (int): Index of the earlier stack vertex.
+        j1 (int): Index of the later stack vertex.
+
+    Returns:
+        float: The signed area of the triple, at whatever width Numba chooses.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    return float((j1 - j0) * (coeff[i] - coeff[j0]) - (coeff[j1] - coeff[j0]) * (i - j0))
+
+
+def measure_de_casteljau(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of the scalar de Casteljau triangle.
+
+    The working buffer is ``coeff.copy()`` (``_root_finding_core.py:51``), so it
+    carries the input dtype while the parameter is a Python float. Every store
+    therefore narrows.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The wide model and the narrow model, in that order.
+    """
+
+    def wide(coeff: _FloatArray, t: float) -> float:
+        work = coeff.copy()
+        n = len(work) - 1
+        for k in range(1, n + 1):
+            for i in range(n - k + 1):
+                work[i] = (1.0 - t) * float(work[i]) + t * float(work[i + 1])
+        return float(work[0])
+
+    def narrow(coeff: _FloatArray, t: float) -> float:
+        work = coeff.copy()
+        n = len(work) - 1
+        s, tt = _F32(1.0) - _F32(t), _F32(t)
+        for k in range(1, n + 1):
+            for i in range(n - k + 1):
+                work[i] = _F32(_F32(s * work[i]) + _F32(tt * work[i + 1]))
+        return float(work[0])
+
+    hits = [0, 0]
+    differ = total = 0
+    for degree in _DEGREES:
+        for _trial in range(400):
+            coeff = rng.standard_normal(degree + 1).astype(_F32)
+            t = float(rng.uniform(0.0, 1.0))
+            oracle = bits(_de_casteljau_eval_scalar(coeff, t))
+            models = (bits(wide(coeff, t)), bits(narrow(coeff, t)))
+            total += 1
+            hits = [h + (m == oracle) for h, m in zip(hits, models, strict=True)]
+            differ += models[0] != models[1]
+
+    site = "_root_finding_core.py:51"
+    return [
+        Verdict(site, "accumulate float64, narrow on store", hits[0], total, differ),
+        Verdict(site, "every operation in float32", hits[1], total, differ),
+    ]
+
+
+def measure_de_casteljau_derivative(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of ``d1 - d0`` in the value-and-derivative kernel.
+
+    The triangle itself behaves as :func:`measure_de_casteljau` found, so this
+    isolates the one operation that differs: the penultimate row is read out of the
+    narrow buffer and subtracted **before** the degree factor promotes the product.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The float32 subtraction and the widened subtraction.
+    """
+
+    def model(coeff: _FloatArray, t: float, *, narrow_diff: bool) -> float:
+        n = len(coeff) - 1
+        if n == 0:
+            return 0.0
+        s = 1.0 - t
+        row = coeff.copy()
+        for k in range(1, n):
+            for i in range(n - k + 1):
+                row[i] = s * float(row[i]) + t * float(row[i + 1])
+        d0, d1 = row[0], row[1]
+        diff = float(_F32(d1 - d0)) if narrow_diff else float(d1) - float(d0)
+        return float(n) * diff
+
+    hits = [0, 0]
+    differ = total = 0
+    for degree in _DEGREES:
+        for _trial in range(300):
+            coeff = rng.standard_normal(degree + 1).astype(_F32)
+            t = float(rng.uniform(0.0, 1.0))
+            oracle = bits(_de_casteljau_eval_and_deriv_scalar(coeff, t)[1])
+            models = (
+                bits(model(coeff, t, narrow_diff=True)),
+                bits(model(coeff, t, narrow_diff=False)),
+            )
+            total += 1
+            hits = [h + (m == oracle) for h, m in zip(hits, models, strict=True)]
+            differ += models[0] != models[1]
+
+    site = "_root_finding_core.py:157"
+    return [
+        Verdict(site, "d1 - d0 in float32", hits[0], total, differ),
+        Verdict(site, "d1 - d0 widened to float64", hits[1], total, differ),
+    ]
+
+
+def measure_hull_predicate(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of the convex-hull orientation predicate.
+
+    The index factors are ``int64``, and numpy promotes ``int64`` with ``float32`` to
+    ``float64``, so the *products* are float64 at both dtypes. The question is the
+    coefficient differences, which happen first.
+
+    A C++ template over the scalar type gets this wrong in the opposite direction:
+    ``int64 * float`` is ``float`` in C++ but ``float64`` in numpy, so the integer
+    factor needs an explicit cast to ``double``.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The in-dtype model and the widen-first model.
+    """
+
+    def in_dtype(coeff: _FloatArray, i: int, j0: int, j1: int) -> float:
+        d1, d2 = coeff[i] - coeff[j0], coeff[j1] - coeff[j0]
+        return float(j1 - j0) * float(d1) - float(d2) * float(i - j0)
+
+    def widen_first(coeff: _FloatArray, i: int, j0: int, j1: int) -> float:
+        return float(j1 - j0) * (float(coeff[i]) - float(coeff[j0])) - (
+            float(coeff[j1]) - float(coeff[j0])
+        ) * float(i - j0)
+
+    hits = [0, 0]
+    differ = total = 0
+    for degree in (3, 6, 10, 17, 25):
+        for _trial in range(2000):
+            coeff = _sample_coefficients(rng, degree, _F32)
+            j0, j1, i = (int(v) for v in sorted(rng.choice(degree + 1, 3, replace=False)))
+            oracle = bits(_hull_cross(coeff, i, j0, j1))
+            models = (bits(in_dtype(coeff, i, j0, j1)), bits(widen_first(coeff, i, j0, j1)))
+            total += 1
+            hits = [h + (m == oracle) for h, m in zip(hits, models, strict=True)]
+            differ += models[0] != models[1]
+
+    site = "_root_finding_core.py:274"
+    return [
+        Verdict(site, "coefficient differences in float32", hits[0], total, differ),
+        Verdict(site, "coefficient differences widened first", hits[1], total, differ),
+    ]
+
+
+def measure_forward_difference(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of the Yuksel derivative-chain seed.
+
+    The destination array is ``float64``, which is what makes this one easy to get
+    wrong: the array's dtype says nothing about the width the subtraction ran at.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The float32 subtraction and the widened subtraction.
+    """
+    hits = [0, 0]
+    differ = total = 0
+    for _trial in range(4000):
+        n = int(rng.integers(2, 30))
+        coeff = rng.standard_normal(n + 1).astype(_F32)
+        oracle = [bits(v) for v in _forward_difference(coeff, n)]
+        narrow = [bits(float(_F32(coeff[i + 1] - coeff[i]))) for i in range(n)]
+        wide = [bits(float(coeff[i + 1]) - float(coeff[i])) for i in range(n)]
+        total += 1
+        hits = [h + (m == oracle) for h, m in zip(hits, (narrow, wide), strict=True)]
+        differ += narrow != wide
+
+    site = "_yuksel_core.py:319"
+    return [
+        Verdict(site, "subtract in float32, widen on store", hits[0], total, differ),
+        Verdict(site, "widen, then subtract in float64", hits[1], total, differ),
+    ]
+
+
+def measure_linear_base_case(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of the degree-1 base case ``c0 / (c0 - c1)``.
+
+    Every Yuksel recursion bottoms out here, and the result is stored into a
+    ``float64`` array, so the narrow division is invisible downstream.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The float32 division and the float64 division.
+    """
+    hits = [0, 0]
+    differ = total = 0
+    for _trial in range(20000):
+        coeff = rng.standard_normal(2).astype(_F32)
+        if coeff[0] == coeff[1]:
+            continue
+        oracle = bits(_linear_root(coeff))
+        models = (
+            bits(float(_F32(coeff[0] / _F32(coeff[0] - coeff[1])))),
+            bits(float(coeff[0]) / (float(coeff[0]) - float(coeff[1]))),
+        )
+        total += 1
+        hits = [h + (m == oracle) for h, m in zip(hits, models, strict=True)]
+        differ += models[0] != models[1]
+
+    site = "_yuksel_core.py:309"
+    return [
+        Verdict(site, "divide in float32", hits[0], total, differ),
+        Verdict(site, "divide in float64", hits[1], total, differ),
+    ]
+
+
+def measure_the_near_misses(rng: np.random.Generator) -> list[Verdict]:
+    """Measure two sites that look like the traps above and are not.
+
+    Both read out of a float32 array and both look like they then work in float64,
+    one because an explicit ``float()`` stands in the way and the other because the
+    variable is seeded with ``float("inf")``. Only the second actually widens, and
+    that is the whole point of measuring rather than reading: see
+    :func:`report_the_float_cast`.
+
+    They are here so the table cannot be read as a per-kernel or per-module rule.
+    ``_batch_core.py:87`` divides in float64 and ``_yuksel_core.py:309`` divides the
+    same shape of expression in float32, and what separates them is whether some
+    other assignment to the same variable forced a wider type.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: Each site's correct model first, its plausible rival second.
+    """
+
+    @nb_jit(nopython=True, cache=False)
+    def level_scale(coeff: _FloatArray) -> float:
+        """Reproduce ``_yuksel_core.py:206-207``.
+
+        Args:
+            coeff (_FloatArray): Bernstein coefficients.
+
+        Returns:
+            float: ``abs(d_max - d_min)`` with both ends widened before subtracting.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        d_min = float(np.min(coeff))
+        d_max = float(np.max(coeff))
+        return float(abs(d_max - d_min))
+
+    @nb_jit(nopython=True, cache=False)
+    def coefficient_range(coeff: _FloatArray) -> float:
+        """Reproduce ``_batch_core.py:79-87``.
+
+        Args:
+            coeff (_FloatArray): Bernstein coefficients, none of them zero.
+
+        Returns:
+            float: The ratio of the largest magnitude to the smallest non-zero one.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        c_max = 0.0
+        c_min_nonzero = float("inf")
+        for i in range(len(coeff)):
+            av = abs(coeff[i])
+            c_max = max(c_max, av)
+            if av > 0.0 and av < c_min_nonzero:
+                c_min_nonzero = av
+        return float(c_max / c_min_nonzero)
+
+    scale_hits = [0, 0]
+    range_hits = [0, 0]
+    scale_differ = range_differ = total = 0
+    for _trial in range(6000):
+        degree = int(rng.integers(2, 30))
+        coeff = rng.standard_normal(degree + 1).astype(_F32)
+        low, high = _F32(np.min(coeff)), _F32(np.max(coeff))
+        wide_scale = bits(abs(float(high) - float(low)))
+        narrow_scale = bits(float(abs(_F32(high - low))))
+        oracle_scale = bits(level_scale(coeff))
+
+        magnitudes = np.abs(coeff)
+        biggest, smallest = _F32(magnitudes.max()), _F32(magnitudes.min())
+        if smallest == 0.0:
+            continue
+        wide_range = bits(float(biggest) / float(smallest))
+        narrow_range = bits(float(_F32(biggest / smallest)))
+        oracle_range = bits(coefficient_range(coeff))
+
+        total += 1
+        scale_hits = [
+            h + (m == oracle_scale)
+            for h, m in zip(scale_hits, (wide_scale, narrow_scale), strict=True)
+        ]
+        range_hits = [
+            h + (m == oracle_range)
+            for h, m in zip(range_hits, (wide_range, narrow_range), strict=True)
+        ]
+        scale_differ += wide_scale != narrow_scale
+        range_differ += wide_range != narrow_range
+
+    return [
+        Verdict(
+            "_yuksel_core.py:207",
+            "subtract in float32; float() is a no-op",
+            scale_hits[1],
+            total,
+            scale_differ,
+        ),
+        Verdict("_yuksel_core.py:207", "subtract in float64", scale_hits[0], total, scale_differ),
+        Verdict("_batch_core.py:87", "divide in float64", range_hits[0], total, range_differ),
+        Verdict("_batch_core.py:87", "divide in float32", range_hits[1], total, range_differ),
+    ]
+
+
+def _sample_coefficients(
+    rng: np.random.Generator, degree: int, dtype: type[np.floating]
+) -> _FloatArray:
+    """Draw coefficients, half of them a near-collinear control polygon.
+
+    The hull predicate is fragile exactly where the control polygon is close to
+    straight, and independent normal samples almost never land there.
+
+    Args:
+        rng (np.random.Generator): Source of randomness.
+        degree (int): Polynomial degree; the array has ``degree + 1`` entries.
+        dtype (type[np.floating]): The width to return.
+
+    Returns:
+        _FloatArray: The coefficients.
+    """
+    if rng.random() < _COLLINEAR_SHARE:
+        index = np.arange(degree + 1, dtype=np.float64)
+        line = rng.standard_normal() + rng.standard_normal() * index
+        return np.asarray(line + rng.standard_normal(degree + 1) * 1e-7, dtype=dtype)
+    return np.asarray(rng.standard_normal(degree + 1), dtype=dtype)
+
+
+def measure_the_cube_root(rng: np.random.Generator) -> None:
+    """Report which C++ spelling reproduces ``zero_tol ** (1/3)``.
+
+    ``_clipping_core.py:349`` is the only call in the whole block that leaves the
+    four arithmetic operations, so it is the only place a library can disagree.
+
+    Args:
+        rng (np.random.Generator): Source of the sample exponents.
+    """
+
+    @nb_jit(nopython=True, cache=False)
+    def kernel(x: float) -> float:
+        """Reproduce the one non-arithmetic call in the block.
+
+        Args:
+            x (float): The tolerance to take the cube root of.
+
+        Returns:
+            float: ``x ** (1/3)``.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        return float(x ** (1.0 / 3.0))
+
+    import math  # noqa: PLC0415 -- only this function needs it
+
+    mismatch_pow = mismatch_cbrt = total = 0
+    for _trial in range(50000):
+        x = float(10.0 ** rng.uniform(-300.0, 3.0)) * float(rng.uniform(0.5, 2.0))
+        reference = bits(kernel(x))
+        total += 1
+        mismatch_pow += reference != bits(math.pow(x, 1.0 / 3.0))
+        mismatch_cbrt += reference != bits(math.cbrt(x))
+
+    print(f"\nThe one library call, {total} tolerances spanning 1e-300 to 1e3")
+    print(f"  std::pow(x, 1.0/3.0)   differs on {mismatch_pow:>6} -- this is the spelling to use")
+    print(f"  std::cbrt(x)           differs on {mismatch_cbrt:>6} -- do not transliterate to this")
+
+
+def report_minimum_and_maximum() -> None:
+    """Report whether the C++ ``std::min``/``std::max`` ternary matches Numba.
+
+    ``std::fmin`` and ``std::fmax`` do not: they return the non-NaN operand, where
+    the ternary and Numba's builtins propagate whichever the comparison selects.
+    The block compares tolerances against values that can be NaN, so this decides a
+    branch rather than a last bit.
+    """
+
+    @nb_jit(nopython=True, cache=False)
+    def kernel(a: float, b: float) -> tuple[float, float]:
+        """Return Numba's ``min`` and ``max`` of two floats.
+
+        Args:
+            a (float): First operand.
+            b (float): Second operand.
+
+        Returns:
+            tuple[float, float]: ``(min(a, b), max(a, b))``.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        return min(a, b), max(a, b)
+
+    nan, inf = float("nan"), float("inf")
+    print("\nmin/max, against the C++ ternary that std::min and std::max expand to")
+    for a, b in ((nan, 1.0), (1.0, nan), (-0.0, 0.0), (0.0, -0.0), (-inf, inf)):
+        low, high = kernel(a, b)
+        agrees = bits(low) == bits(b if b < a else a) and bits(high) == bits(b if a < b else a)
+        print(
+            f"  min({a!r:>6}, {b!r:>6}) = {low!r:>6}   max = {high!r:>6}   ternary agrees: {agrees}"
+        )
+
+
+def report_the_float_cast(rng: np.random.Generator) -> bool:
+    """Show that Numba's ``float()`` does not widen a float32, and what does.
+
+    This is the finding the rest of the table rests on, and it is the opposite of
+    what the source reads like. ``float(coeff[0])`` looks like a widening cast and
+    is a no-op: the value stays float32 and so does every operation built on it.
+    What *does* widen is type unification across assignments, so a variable seeded
+    with ``0.0`` or ``float("inf")`` and later given a float32 is float64 throughout.
+
+    Six sites in this block carry an explicit ``float()`` that a reader would take
+    for a promotion. None of them promotes, and that is why three of the five widths
+    above are narrower than the source suggests.
+
+    Measured behaviourally rather than read off a compiled signature, so it stands on
+    the same evidence as everything else here.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        bool: True when ``float()`` was observed to widen, which would invalidate the
+            widths above and is therefore a failure.
+    """
+
+    @nb_jit(nopython=True, cache=False)
+    def through_a_cast(coeff: _FloatArray) -> float:
+        """Subtract two array elements that were passed through ``float()``.
+
+        Args:
+            coeff (_FloatArray): Two Bernstein coefficients.
+
+        Returns:
+            float: Their difference, at whatever width Numba chooses.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        low = float(coeff[0])
+        high = float(coeff[1])
+        return float(high - low)
+
+    @nb_jit(nopython=True, cache=False)
+    def through_a_seed(coeff: _FloatArray) -> float:
+        """Subtract two array elements held in variables seeded with a float64.
+
+        Args:
+            coeff (_FloatArray): Two Bernstein coefficients.
+
+        Returns:
+            float: Their difference, at whatever width Numba chooses.
+
+        Note:
+            Inputs are assumed to be correct (no validation performed).
+        """
+        low = 0.0
+        high = 0.0
+        for i in range(len(coeff)):
+            if i == 0:
+                low = coeff[i]
+            else:
+                high = coeff[i]
+        return float(high - low)
+
+    cast_narrow = seed_wide = total = 0
+    for _trial in range(6000):
+        pair = rng.standard_normal(2).astype(_F32)
+        narrow = bits(float(_F32(pair[1] - pair[0])))
+        wide = bits(float(pair[1]) - float(pair[0]))
+        if narrow == wide:
+            continue
+        total += 1
+        cast_narrow += bits(through_a_cast(pair)) == narrow
+        seed_wide += bits(through_a_seed(pair)) == wide
+
+    print(f"\nWhat float() does to a float32, {total} discriminating pairs")
+    print(f"  float(c[1]) - float(c[0])          stayed narrow in {cast_narrow}/{total}")
+    print(f"  the same, via variables seeded 0.0  widened     in {seed_wide}/{total}")
+    widens = cast_narrow != total
+    print(f"  float() is a no-op on a float32: {not widens}; unification is what widens")
+    return widens
+
+
+def transliterate_hull(coeff: npt.NDArray[np.float64], *, fuse: bool) -> tuple[float, float, bool]:
+    """Reimplement ``_clip_hull_to_zero`` with the orientation predicate switchable.
+
+    Args:
+        coeff (npt.NDArray[np.float64]): Bernstein coefficients.
+        fuse (bool): Evaluate the predicate as a contracting compiler would.
+
+    Returns:
+        tuple[float, float, bool]: ``(t_lo, t_hi, found)``, as the kernel returns.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    n = len(coeff) - 1
+    if n < 1:
+        return 0.0, 0.0, False
+    inv_n = 1.0 / n
+    t_lo, t_hi, found = 1.0, 0.0, False
+
+    for upper in (True, False):
+        chain = np.empty(n + 1, dtype=np.int64)
+        size = 0
+        for i in range(n + 1):
+            while size >= _HULL_MIN_STACK:
+                j0, j1 = int(chain[size - 2]), int(chain[size - 1])
+                a, b = float(j1 - j0), float(coeff[i]) - float(coeff[j0])
+                c, d = float(coeff[j1]) - float(coeff[j0]), float(i - j0)
+                cross = fused_product_difference(a, b, c, d) if fuse else a * b - c * d
+                if (cross >= 0.0) if upper else (cross <= 0.0):
+                    size -= 1
+                else:
+                    break
+            chain[size] = i
+            size += 1
+        for k in range(size - 1):
+            ia, ib = int(chain[k]), int(chain[k + 1])
+            da, db = float(coeff[ia]), float(coeff[ib])
+            if da * db < 0.0:
+                ta, tb = ia * inv_n, ib * inv_n
+                crossing = ta + (-da) / (db - da) * (tb - ta)
+                t_lo, t_hi, found = min(t_lo, crossing), max(t_hi, crossing), True
+            if da == 0.0:
+                ta = ia * inv_n
+                t_lo, t_hi, found = min(t_lo, ta), max(t_hi, ta), True
+        last = int(chain[size - 1])
+        if coeff[last] == 0.0:
+            ta = last * inv_n
+            t_lo, t_hi, found = min(t_lo, ta), max(t_hi, ta), True
+    return t_lo, t_hi, found
+
+
+def measure_the_hull_under_contraction(rng: np.random.Generator) -> None:
+    """Report whether contraction can change the hull, and on what input.
+
+    This is not a width question and it is the one hazard in the block that a
+    tolerance cannot absorb. The predicate is ``a*b - c*d``, and on an exactly
+    collinear control polygon it evaluates to **exactly zero**, so ``cross >= 0``
+    holds and the vertex is popped. Fusing turns that exact tie into a signed
+    residue, and the tie-break becomes a coin toss.
+
+    A collinear control polygon is not an exotic input: a degree-elevated linear
+    polynomial, an affine segment and a constant all produce one.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+    """
+    random = [rng.standard_normal(d + 1) for d in (3, 6, 10, 17, 25) for _ in range(600)]
+    collinear = [
+        rng.standard_normal() + rng.standard_normal() * np.arange(d + 1, dtype=np.float64)
+        for d in range(2, 26)
+        for _ in range(200)
+    ]
+
+    print("\nThe hull predicate under contraction, against the kernel")
+    for name, cases in (("random", random), ("collinear", collinear)):
+        for fuse in (False, True):
+            same = sum(transliterate_hull(c, fuse=fuse) == _clip_hull_to_zero(c) for c in cases)
+            label = "fused  " if fuse else "unfused"
+            print(f"  {label} on {name:>9}: {same:>4}/{len(cases)} identical")
+
+
+def report(verdicts: list[Verdict]) -> bool:
+    """Print the width table and say whether every site was discriminated.
+
+    Args:
+        verdicts (list[Verdict]): The measurements, rivals adjacent and the expected
+            winner first.
+
+    Returns:
+        bool: True when every site has exactly one model matching every case and a
+            rival that disagrees somewhere, which is what makes the match meaningful.
+    """
+    print(f"{'site':<32} {'hypothesis':<40} {'matched':>12} {'discriminated':>14}")
+    sound = True
+    for index, verdict in enumerate(verdicts):
+        share = f"{verdict.matched}/{verdict.total}"
+        print(
+            f"{verdict.site:<32} {verdict.hypothesis:<40} {share:>12} {verdict.rivals_differ:>14}"
+        )
+        expected_winner = index % 2 == 0
+        won = verdict.matched == verdict.total
+        if won != expected_winner or verdict.rivals_differ == 0:
+            sound = False
+    return sound
+
+
+def main() -> int:
+    """Run every measurement and report.
+
+    Returns:
+        int: 0 when every width was confirmed and discriminated, 1 otherwise.
+    """
+    seeds = np.random.SeedSequence(_SEED).spawn(9)
+    verdicts: list[Verdict] = []
+    measurements = (
+        measure_de_casteljau,
+        measure_de_casteljau_derivative,
+        measure_hull_predicate,
+        measure_forward_difference,
+        measure_linear_base_case,
+        measure_the_near_misses,
+    )
+    for seed, measure in zip(seeds, measurements, strict=False):
+        verdicts.extend(measure(np.random.default_rng(seed)))
+    sound = report(verdicts)
+
+    widened = report_the_float_cast(np.random.default_rng(seeds[6]))
+    measure_the_cube_root(np.random.default_rng(seeds[7]))
+    report_minimum_and_maximum()
+    measure_the_hull_under_contraction(np.random.default_rng(seeds[8]))
+
+    if widened:
+        print("\nfloat() widened after all, so every width above needs re-deriving.")
+        return 1
+    if not sound:
+        print("\nA width was not confirmed, or its check could not have failed.")
+        return 1
+    print("\nEvery width confirmed, and every check discriminates.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_root_finding_widths.py
+++ b/scripts/measure_root_finding_widths.py
@@ -31,7 +31,10 @@ Five widths follow, three of them not what a C++ author would write by default:
   float64 argument, and **narrows on every store** into the ``coeff.copy()`` buffer;
 * the derivative kernel does the same and then takes ``d1 - d0`` **in float32**;
 * the hull predicate subtracts ``coeff[i] - coeff[j0]`` **in float32** before the
-  integer factor promotes the product;
+  integer factor promotes the product, and the hull's **edge-crossing quotient** is
+  at float32 too, for a different reason: no integer enters it until the span. That
+  second one was missed on the first pass and the C++ was written widened as a
+  result, inert only because the kernel is reached with a float64 buffer;
 * the Yuksel forward difference subtracts **in float32** and widens on the store into
   a ``float64`` array;
 * the degree-1 base case divides ``c0 / (c0 - c1)`` **entirely in float32**. This is
@@ -207,6 +210,30 @@ def _linear_root(coeff: _FloatArray) -> float:
 
 
 @nb_jit(nopython=True, cache=False)
+def _hull_crossing(coeff: _FloatArray, ia: int, ib: int, inv_n: float) -> float:
+    """Reproduce the edge-crossing quotient, ``_root_finding_core.py:290``.
+
+    Args:
+        coeff (_FloatArray): Bernstein coefficients.
+        ia (int): Index of the edge's left vertex.
+        ib (int): Index of its right vertex.
+        inv_n (float): One over the degree.
+
+    Returns:
+        float: The parameter at which the hull edge crosses zero.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed). The caller
+        guarantees the two coefficients have opposite signs.
+    """
+    da = coeff[ia]
+    db = coeff[ib]
+    ta = ia * inv_n
+    tb = ib * inv_n
+    return float(ta + (-da) / (db - da) * (tb - ta))
+
+
+@nb_jit(nopython=True, cache=False)
 def _hull_cross(coeff: _FloatArray, i: int, j0: int, j1: int) -> float:
     """Reproduce the orientation predicate, ``_root_finding_core.py:274``.
 
@@ -367,6 +394,53 @@ def measure_hull_predicate(rng: np.random.Generator) -> list[Verdict]:
     return [
         Verdict(site, "coefficient differences in float32", hits[0], total, differ),
         Verdict(site, "coefficient differences widened first", hits[1], total, differ),
+    ]
+
+
+def measure_hull_crossing(rng: np.random.Generator) -> list[Verdict]:
+    """Measure the width of the hull's edge-crossing quotient.
+
+    A second width in the same kernel as :func:`measure_hull_predicate` and a
+    different one, which is why it is measured separately rather than assumed to
+    follow. The predicate promotes because an integer factor enters; this has no
+    integer factor until the span, so the division stays at the coefficient width and
+    only the multiplication by the float64 span promotes.
+
+    This site was **missed** by the first version of this script, and the C++ was
+    written widened as a result. The error was inert, because the kernel is only ever
+    reached with the float64 subdivision buffer, but the header claims a float
+    instantiation and would have been wrong the day one existed.
+
+    Args:
+        rng (np.random.Generator): Source of the coefficient samples.
+
+    Returns:
+        list[Verdict]: The in-dtype model and the widen-first model.
+    """
+    hits = [0, 0]
+    differ = total = 0
+    for _trial in range(20000):
+        degree = int(rng.integers(2, 20))
+        coeff = rng.standard_normal(degree + 1).astype(_F32)
+        ia, ib = 0, degree
+        if (coeff[ia] > 0) == (coeff[ib] > 0):
+            continue
+        inv_n = 1.0 / degree
+        oracle = bits(_hull_crossing(coeff, ia, ib, inv_n))
+
+        da, db = coeff[ia], coeff[ib]
+        span = ib * inv_n - ia * inv_n
+        in_dtype = bits(ia * inv_n + float(_F32(_F32(-da) / _F32(db - da))) * span)
+        widened = bits(ia * inv_n + (-float(da)) / (float(db) - float(da)) * span)
+
+        total += 1
+        hits = [h + (m == oracle) for h, m in zip(hits, (in_dtype, widened), strict=True)]
+        differ += in_dtype != widened
+
+    site = "_root_finding_core.py:290"
+    return [
+        Verdict(site, "divide in float32, promote at the span", hits[0], total, differ),
+        Verdict(site, "widen both endpoints first", hits[1], total, differ),
     ]
 
 
@@ -832,12 +906,13 @@ def main() -> int:
     Returns:
         int: 0 when every width was confirmed and discriminated, 1 otherwise.
     """
-    seeds = np.random.SeedSequence(_SEED).spawn(9)
+    seeds = np.random.SeedSequence(_SEED).spawn(10)
     verdicts: list[Verdict] = []
     measurements = (
         measure_de_casteljau,
         measure_de_casteljau_derivative,
         measure_hull_predicate,
+        measure_hull_crossing,
         measure_forward_difference,
         measure_linear_base_case,
         measure_the_near_misses,
@@ -846,10 +921,10 @@ def main() -> int:
         verdicts.extend(measure(np.random.default_rng(seed)))
     sound = report(verdicts)
 
-    widened = report_the_float_cast(np.random.default_rng(seeds[6]))
-    measure_the_cube_root(np.random.default_rng(seeds[7]))
+    widened = report_the_float_cast(np.random.default_rng(seeds[7]))
+    measure_the_cube_root(np.random.default_rng(seeds[8]))
     report_minimum_and_maximum()
-    measure_the_hull_under_contraction(np.random.default_rng(seeds[8]))
+    measure_the_hull_under_contraction(np.random.default_rng(seeds[9]))
 
     if widened:
         print("\nfloat() widened after all, so every width above needs re-deriving.")

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -878,7 +878,7 @@ def apply_reduction_operator(
 
 def yuksel_roots(
     coeff: npt.NDArray[np.float32 | np.float64],
-    tol: float,
+    param_tol: float,
     *,
     out: npt.NDArray[np.float64],
 ) -> int:
@@ -887,7 +887,7 @@ def yuksel_roots(
     Args:
         coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients,
             C-contiguous and non-empty.
-        tol (float): Bracket-width tolerance. Finite and strictly positive.
+        param_tol (float): Bracket-width tolerance. Finite and strictly positive.
         out (npt.NDArray[np.float64]): Receives the roots, unsorted. Always
             ``float64`` whatever ``coeff`` is, C-contiguous, writable, and at least
             ``max(degree, 1)`` long. Only the returned count of entries is written.
@@ -899,15 +899,15 @@ def yuksel_roots(
     Raises:
         TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
             or if ``out`` is passed positionally.
-        ValueError: If ``coeff`` is empty, if ``tol`` is not finite and positive,
-            or if ``out`` is too short.
+        ValueError: If ``coeff`` is empty, if ``param_tol`` is not finite and
+            positive, or if ``out`` is too short.
     """
 
 def clip_roots(
     coeff: npt.NDArray[np.float32 | np.float64],
+    *,
     param_tol: float,
     geom_tol: float,
-    *,
     out: npt.NDArray[np.float64],
 ) -> int:
     """Find every root on [0, 1] by Bézier clipping.
@@ -919,8 +919,10 @@ def clip_roots(
         coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients,
             C-contiguous and non-empty.
         param_tol (float): Bracket-width termination tolerance. Finite, positive.
+            Keyword-only, with ``geom_tol``: nothing orders the two, so transposing
+            them returns a different and plausible root set rather than an error.
         geom_tol (float): Geometric tolerance for near-zero detection. Finite,
-            positive.
+            positive. Keyword-only.
         out (npt.NDArray[np.float64]): Receives the candidates. Always ``float64``,
             C-contiguous, writable, and at least ``3 * degree + 4`` long, which is
             the kernel's own worst case before the merge. Keyword-only.
@@ -936,24 +938,28 @@ def clip_roots(
     """
 
 def dedup_roots(
+    coeff: npt.NDArray[np.float32 | np.float64],
     raw_roots: npt.NDArray[np.float64],
     n_roots: int,
-    coeff: npt.NDArray[np.float32 | np.float64],
+    *,
     param_tol: float,
     geom_tol: float,
-    *,
     out: npt.NDArray[np.float64],
 ) -> int:
     """Sort root candidates and merge the duplicates, with a derivative-aware radius.
 
     Args:
+        coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein
+            coefficients, used for the derivative. C-contiguous and non-empty.
+            First, as in every sibling: it and ``raw_roots`` are both ``float64``
+            when the coefficients are, so a transposed call would type-check and
+            merge against the wrong data.
         raw_roots (npt.NDArray[np.float64]): Candidates, of which the first
             ``n_roots`` are valid. C-contiguous.
         n_roots (int): Number of valid candidates, in ``[0, len(raw_roots)]``.
-        coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein
-            coefficients, used for the derivative. C-contiguous and non-empty.
-        param_tol (float): Parametric tolerance. Finite and positive.
-        geom_tol (float): Geometric tolerance. Finite and positive.
+        param_tol (float): Parametric tolerance. Finite and positive. Keyword-only,
+            with ``geom_tol``.
+        geom_tol (float): Geometric tolerance. Finite and positive. Keyword-only.
         out (npt.NDArray[np.float64]): Receives the merged roots, sorted ascending.
             C-contiguous, writable, at least ``n_roots`` long. Keyword-only.
 
@@ -970,29 +976,39 @@ def dedup_roots(
 
 def solve_monotone_root(
     coeff: npt.NDArray[np.float32 | np.float64],
-    tol: float,
+    param_tol: float,
 ) -> float:
     """Find the unique root of a monotone scalar Bernstein polynomial on [0, 1].
 
     Args:
         coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients of
             a monotone polynomial. C-contiguous and non-empty.
-        tol (float): Bracket-width termination tolerance. Finite and positive.
+        param_tol (float): Bracket-width termination tolerance. Finite and positive.
 
     Returns:
         float: The root parameter, or NaN when no sign change is detected across
             [0, 1].
 
+    Note:
+        There is a third outcome the return value does not distinguish. The
+        Newton/bisection hybrid runs at most 64 iterations and returns its bracket's
+        midpoint whether or not ``param_tol`` was met, so an exhausted budget is
+        indistinguishable from a converged root. Reaching it needs a ``param_tol``
+        below about ``5e-20``, since 64 halvings of the unit interval get there even
+        with no Newton step ever accepted, so it is unreachable for any tolerance a
+        caller can usefully pass. Stated because the two documented outcomes above
+        would otherwise read as exhaustive.
+
     Raises:
         TypeError: If ``coeff`` has the wrong dtype or rank, or is not C-contiguous.
-        ValueError: If ``coeff`` is empty or ``tol`` is not finite and positive.
+        ValueError: If ``coeff`` is empty or ``param_tol`` is not finite and positive.
     """
 
 def find_roots_batch(
     coeffs: npt.NDArray[np.float32 | np.float64],
+    *,
     param_tol: float,
     geom_tol: float,
-    *,
     out_roots: npt.NDArray[np.float64],
     out_counts: npt.NDArray[np.int64],
 ) -> None:
@@ -1005,11 +1021,16 @@ def find_roots_batch(
     Args:
         coeffs (npt.NDArray[np.float32 | np.float64]): Batch of shape
             ``(n_polys, degree + 1)``, C-contiguous with at least one column.
-        param_tol (float): Parametric tolerance. Finite and positive.
-        geom_tol (float): Geometric tolerance. Finite and positive.
+        param_tol (float): Parametric tolerance. Finite and positive. Keyword-only,
+            with ``geom_tol``.
+        geom_tol (float): Geometric tolerance. Finite and positive. Keyword-only.
         out_roots (npt.NDArray[np.float64]): Shape ``(n_polys, max(degree, 1))``,
-            C-contiguous and writable. Entries past each row's count are left as the
-            caller set them, which is NaN. Keyword-only.
+            C-contiguous and writable. **Both axes are checked**: a row narrower than
+            ``max(degree, 1)`` is refused rather than filled to capacity, because the
+            kernel clamps its per-row count to whatever fits and an undersized buffer
+            would otherwise report fewer roots than exist, silently. Entries past each
+            row's count are left untouched, so the caller's pre-fill is what they
+            hold. Keyword-only.
         out_counts (npt.NDArray[np.int64]): Shape ``(n_polys,)``, C-contiguous and
             writable, receiving the per-row root count. Keyword-only.
 
@@ -1017,12 +1038,13 @@ def find_roots_batch(
         TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
             or if an output is passed positionally.
         ValueError: If ``coeffs`` has no columns, if either tolerance is not finite
-            and positive, or if the outputs do not have ``n_polys`` rows.
+            and positive, if the outputs do not have ``n_polys`` rows, or if
+            ``out_roots``'s rows are narrower than ``max(degree, 1)``.
     """
 
 def solve_monotone_root_batch(
     coeffs: npt.NDArray[np.float32 | np.float64],
-    tol: float,
+    param_tol: float,
     *,
     out_roots: npt.NDArray[np.float64],
 ) -> None:
@@ -1031,7 +1053,7 @@ def solve_monotone_root_batch(
     Args:
         coeffs (npt.NDArray[np.float32 | np.float64]): Batch of shape
             ``(n_polys, degree + 1)``, C-contiguous with at least one column.
-        tol (float): Bracket-width termination tolerance. Finite and positive.
+        param_tol (float): Bracket-width termination tolerance. Finite and positive.
         out_roots (npt.NDArray[np.float64]): Shape ``(n_polys,)``, C-contiguous and
             writable, **pre-filled with NaN by the caller**: a row whose polynomial
             has no root is left untouched rather than written. Keyword-only.
@@ -1039,6 +1061,6 @@ def solve_monotone_root_batch(
     Raises:
         TypeError: If ``coeffs`` or ``out_roots`` has the wrong dtype or rank, is
             not C-contiguous, or if ``out_roots`` is passed positionally.
-        ValueError: If ``coeffs`` has no columns, if ``tol`` is not finite and
+        ValueError: If ``coeffs`` has no columns, if ``param_tol`` is not finite and
             positive, or if ``out_roots`` does not have ``n_polys`` entries.
     """

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -875,3 +875,170 @@ def apply_reduction_operator(
         ValueError: If ``ctrl`` does not have as many rows as the operator has
             columns, or if ``out`` is the wrong shape.
     """
+
+def yuksel_roots(
+    coeff: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+    *,
+    out: npt.NDArray[np.float64],
+) -> int:
+    """Find every root on [0, 1] by Yuksel's monotone decomposition.
+
+    Args:
+        coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients,
+            C-contiguous and non-empty.
+        tol (float): Bracket-width tolerance. Finite and strictly positive.
+        out (npt.NDArray[np.float64]): Receives the roots, unsorted. Always
+            ``float64`` whatever ``coeff`` is, C-contiguous, writable, and at least
+            ``max(degree, 1)`` long. Only the returned count of entries is written.
+            Keyword-only.
+
+    Returns:
+        int: How many entries of ``out`` are valid.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``coeff`` is empty, if ``tol`` is not finite and positive,
+            or if ``out`` is too short.
+    """
+
+def clip_roots(
+    coeff: npt.NDArray[np.float32 | np.float64],
+    param_tol: float,
+    geom_tol: float,
+    *,
+    out: npt.NDArray[np.float64],
+) -> int:
+    """Find every root on [0, 1] by Bézier clipping.
+
+    The candidates are unsorted and may repeat: the same root reaches the output
+    from several converging intervals, and merging them is :func:`dedup_roots`.
+
+    Args:
+        coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients,
+            C-contiguous and non-empty.
+        param_tol (float): Bracket-width termination tolerance. Finite, positive.
+        geom_tol (float): Geometric tolerance for near-zero detection. Finite,
+            positive.
+        out (npt.NDArray[np.float64]): Receives the candidates. Always ``float64``,
+            C-contiguous, writable, and at least ``3 * degree + 4`` long, which is
+            the kernel's own worst case before the merge. Keyword-only.
+
+    Returns:
+        int: How many entries of ``out`` are valid.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``coeff`` is empty, if either tolerance is not finite and
+            positive, or if ``out`` is too short.
+    """
+
+def dedup_roots(
+    raw_roots: npt.NDArray[np.float64],
+    n_roots: int,
+    coeff: npt.NDArray[np.float32 | np.float64],
+    param_tol: float,
+    geom_tol: float,
+    *,
+    out: npt.NDArray[np.float64],
+) -> int:
+    """Sort root candidates and merge the duplicates, with a derivative-aware radius.
+
+    Args:
+        raw_roots (npt.NDArray[np.float64]): Candidates, of which the first
+            ``n_roots`` are valid. C-contiguous.
+        n_roots (int): Number of valid candidates, in ``[0, len(raw_roots)]``.
+        coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein
+            coefficients, used for the derivative. C-contiguous and non-empty.
+        param_tol (float): Parametric tolerance. Finite and positive.
+        geom_tol (float): Geometric tolerance. Finite and positive.
+        out (npt.NDArray[np.float64]): Receives the merged roots, sorted ascending.
+            C-contiguous, writable, at least ``n_roots`` long. Keyword-only.
+
+    Returns:
+        int: How many entries of ``out`` are valid.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if ``out`` is passed positionally.
+        ValueError: If ``coeff`` is empty, if either tolerance is not finite and
+            positive, if ``n_roots`` is not a valid count, or if ``out`` is too
+            short.
+    """
+
+def solve_monotone_root(
+    coeff: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+) -> float:
+    """Find the unique root of a monotone scalar Bernstein polynomial on [0, 1].
+
+    Args:
+        coeff (npt.NDArray[np.float32 | np.float64]): 1-D Bernstein coefficients of
+            a monotone polynomial. C-contiguous and non-empty.
+        tol (float): Bracket-width termination tolerance. Finite and positive.
+
+    Returns:
+        float: The root parameter, or NaN when no sign change is detected across
+            [0, 1].
+
+    Raises:
+        TypeError: If ``coeff`` has the wrong dtype or rank, or is not C-contiguous.
+        ValueError: If ``coeff`` is empty or ``tol`` is not finite and positive.
+    """
+
+def find_roots_batch(
+    coeffs: npt.NDArray[np.float32 | np.float64],
+    param_tol: float,
+    geom_tol: float,
+    *,
+    out_roots: npt.NDArray[np.float64],
+    out_counts: npt.NDArray[np.int64],
+) -> None:
+    """Find the roots of many same-degree scalar Bernstein polynomials.
+
+    Each polynomial is dispatched between Yuksel and clipping on its own degree and
+    dynamic range, then deduplicated. Rows are independent and each writes only its
+    own, so no reduction crosses them.
+
+    Args:
+        coeffs (npt.NDArray[np.float32 | np.float64]): Batch of shape
+            ``(n_polys, degree + 1)``, C-contiguous with at least one column.
+        param_tol (float): Parametric tolerance. Finite and positive.
+        geom_tol (float): Geometric tolerance. Finite and positive.
+        out_roots (npt.NDArray[np.float64]): Shape ``(n_polys, max(degree, 1))``,
+            C-contiguous and writable. Entries past each row's count are left as the
+            caller set them, which is NaN. Keyword-only.
+        out_counts (npt.NDArray[np.int64]): Shape ``(n_polys,)``, C-contiguous and
+            writable, receiving the per-row root count. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if an output is passed positionally.
+        ValueError: If ``coeffs`` has no columns, if either tolerance is not finite
+            and positive, or if the outputs do not have ``n_polys`` rows.
+    """
+
+def solve_monotone_root_batch(
+    coeffs: npt.NDArray[np.float32 | np.float64],
+    tol: float,
+    *,
+    out_roots: npt.NDArray[np.float64],
+) -> None:
+    """Solve for the monotone root of many same-degree Bernstein polynomials.
+
+    Args:
+        coeffs (npt.NDArray[np.float32 | np.float64]): Batch of shape
+            ``(n_polys, degree + 1)``, C-contiguous with at least one column.
+        tol (float): Bracket-width termination tolerance. Finite and positive.
+        out_roots (npt.NDArray[np.float64]): Shape ``(n_polys,)``, C-contiguous and
+            writable, **pre-filled with NaN by the caller**: a row whose polynomial
+            has no root is left untouched rather than written. Keyword-only.
+
+    Raises:
+        TypeError: If ``coeffs`` or ``out_roots`` has the wrong dtype or rank, is
+            not C-contiguous, or if ``out_roots`` is passed positionally.
+        ValueError: If ``coeffs`` has no columns, if ``tol`` is not finite and
+            positive, or if ``out_roots`` does not have ``n_polys`` entries.
+    """

--- a/src/pantr/bezier/_clipping_core.py
+++ b/src/pantr/bezier/_clipping_core.py
@@ -9,8 +9,8 @@ projection polynomials arising from rational curves with d=9).
 Main exports:
 
 - :func:`_clip_roots_core` -- stack-based iterative clipping loop (Numba-compiled).
-- :func:`_dedup_roots` -- sort and deduplicate raw root candidates with
-  derivative-aware merge radius (plain Python).
+- :func:`_dedup_roots_core` -- sort and deduplicate raw root candidates with
+  derivative-aware merge radius (Numba-compiled).
 
 References:
     T. Nishita, T. W. Sederberg, M. Kakimoto (1990), *Ray Tracing Trimmed
@@ -373,37 +373,6 @@ def _dedup_roots_core(
         count += 1
 
     return out, count
-
-
-def _dedup_roots(
-    raw_roots: npt.NDArray[np.float32 | np.float64],
-    n_roots: int,
-    coeff: npt.NDArray[np.float32 | np.float64],
-    param_tol: float,
-    geom_tol: float,
-) -> npt.NDArray[np.float64]:
-    """Sort and deduplicate raw root candidates (plain-Python wrapper).
-
-    Thin wrapper around :func:`_dedup_roots_core` returning only the valid
-    prefix; see that kernel for the merge-radius logic.
-
-    Args:
-        raw_roots (npt.NDArray[np.float32 | np.float64]): Unsorted array of root
-            candidates. Only the first ``n_roots`` entries are valid.
-        n_roots (int): Number of valid entries in ``raw_roots``.
-        coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein coefficients
-            (used for derivative evaluation during dedup).
-        param_tol (float): Parametric tolerance.
-        geom_tol (float): Geometric tolerance.
-
-    Returns:
-        npt.NDArray[np.float64]: Sorted, deduplicated array of unique roots.
-    """
-    if n_roots == 0:
-        return np.empty(0, dtype=np.float64)
-    out, count = _dedup_roots_core(raw_roots, n_roots, coeff, param_tol, geom_tol)
-    result: npt.NDArray[np.float64] = out[:count].copy()
-    return result
 
 
 def _warmup_numba_functions() -> None:

--- a/src/pantr/bezier/_find_roots.py
+++ b/src/pantr/bezier/_find_roots.py
@@ -17,10 +17,11 @@ from numpy import typing as npt
 
 from pantr._numba_compat import wait_for_jit_warmup
 from pantr.bezier._bezier import Bezier
-from pantr.bezier._clipping_core import _clip_roots_core, _dedup_roots
-from pantr.bezier._yuksel_core import (
-    _solve_monotone_root_kernel,
-    _yuksel_roots,
+from pantr.bezier._root_finding_backend import (
+    clip_roots_kernel,
+    dedup_roots_kernel,
+    solve_monotone_root_kernel,
+    yuksel_roots_kernel,
 )
 from pantr.tolerance import get_strict
 
@@ -230,7 +231,7 @@ def _dispatch_single(  # noqa: PLR0911
 
     # Low degree: Yuksel is cheaper and equally robust.
     if n < _CLIP_MIN_DEGREE:
-        roots_arr, n_roots = _yuksel_roots(coeff, param_tol)
+        roots_arr, n_roots = yuksel_roots_kernel()(coeff, param_tol)
         if n_roots == 0:
             return np.empty(0, dtype=np.float64)
         result = np.sort(roots_arr[:n_roots])
@@ -245,11 +246,17 @@ def _dispatch_single(  # noqa: PLR0911
 
     if coeff_range <= _CLIP_COEFF_RANGE_LIMIT:
         # Well-conditioned: use Bezier clipping.
-        raw_roots, n_roots = _clip_roots_core(coeff, param_tol, geom_tol)
-        return _dedup_roots(raw_roots, n_roots, coeff, param_tol, geom_tol)
+        raw_roots, n_roots = clip_roots_kernel()(coeff, param_tol, geom_tol)
+        if n_roots == 0:
+            return np.empty(0, dtype=np.float64)
+        # The merge returns its buffer plus a count; only the prefix is a root,
+        # and it is copied so the caller cannot see the scratch behind it.
+        merged, count = dedup_roots_kernel()(raw_roots, n_roots, coeff, param_tol, geom_tol)
+        unique: npt.NDArray[np.float64] = merged[:count].copy()
+        return unique
 
     # Extreme range: fall back to Yuksel.
-    roots_arr, n_roots = _yuksel_roots(coeff, param_tol)
+    roots_arr, n_roots = yuksel_roots_kernel()(coeff, param_tol)
     if n_roots == 0:
         return np.empty(0, dtype=np.float64)
     return np.sort(roots_arr[:n_roots])
@@ -275,8 +282,8 @@ def _find_roots_batch_impl(
     tol: float | None = None,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.intp]]:
     """L2 implementation for :func:`pantr.bezier.find_roots`."""
-    from pantr.bezier._batch_core import (  # noqa: PLC0415
-        _find_roots_batch_core,
+    from pantr.bezier._root_finding_backend import (  # noqa: PLC0415
+        find_roots_batch_kernel,
     )
 
     coeffs = _extract_batch_coeffs(beziers)
@@ -295,7 +302,7 @@ def _find_roots_batch_impl(
     out_counts = np.zeros(n_polys, dtype=np.intp)
 
     if degree >= 1:
-        _find_roots_batch_core(arr, resolved_tol, resolved_tol, out_roots, out_counts)
+        find_roots_batch_kernel()(arr, resolved_tol, resolved_tol, out_roots, out_counts)
 
     return out_roots, out_counts
 
@@ -311,7 +318,7 @@ def _solve_monotone_root_impl(
     wait_for_jit_warmup()
     arr = _validate_coeff_array(coeff, ndim=1, name="coeff")
     resolved_tol = _resolve_tol(arr, tol)
-    return float(_solve_monotone_root_kernel(arr, resolved_tol))
+    return float(solve_monotone_root_kernel()(arr, resolved_tol))
 
 
 def _solve_monotone_root_batch_impl(
@@ -320,8 +327,8 @@ def _solve_monotone_root_batch_impl(
     tol: float | None = None,
 ) -> npt.NDArray[np.float64]:
     """L2 implementation for :func:`pantr.bezier.find_monotone_root`."""
-    from pantr.bezier._batch_core import (  # noqa: PLC0415
-        _solve_monotone_root_batch_core,
+    from pantr.bezier._root_finding_backend import (  # noqa: PLC0415
+        solve_monotone_root_batch_kernel,
     )
 
     coeffs = _extract_batch_coeffs(beziers)
@@ -336,6 +343,6 @@ def _solve_monotone_root_batch_impl(
     resolved_tol = _resolve_tol(arr[0], tol)
     out_roots = np.full(n_polys, np.nan, dtype=np.float64)
 
-    _solve_monotone_root_batch_core(arr, resolved_tol, out_roots)
+    solve_monotone_root_batch_kernel()(arr, resolved_tol, out_roots)
 
     return out_roots

--- a/src/pantr/bezier/_root_finding_backend.py
+++ b/src/pantr/bezier/_root_finding_backend.py
@@ -39,11 +39,22 @@ and the allocation belongs with the caller. Those two shapes are reconciled here
 three lines per kernel, rather than by giving the Numba kernels an ``out`` parameter
 as the arithmetic port did to two of its own.
 
+The precedent for returning a count rather than filling and returning ``None`` is
+:func:`pantr._pantr_cpp.generate_tanh_sinh`, which established it for the same reason:
+an effective count below a worst case the caller had to allocate for.
+
 The reason is specific to this block: the oracle is what parity is measured against,
 and the transliteration was checked against it bit for bit over 198 cases before any
 of this existed. Reshaping the oracle to suit the binding would move the thing being
 measured, and it would also change kernels that ``tests/test_root_finding.py`` calls
 directly.
+
+The six C++ adapters are plain module-level functions rather than the ``Final``
+constants :mod:`pantr.bezier._bezier_backend` hoists. That module hoists because
+:mod:`pantr.change_basis` once shipped a bug from rebuilding a closure per call; none
+of these six is a factory-produced closure, so there is nothing to rebuild and
+hoisting would buy an attribute lookup. Stated because the two catalogues sit in the
+same package and now read differently.
 
 What crosses the boundary
 -------------------------
@@ -90,8 +101,15 @@ _Array = npt.NDArray[np.float32 | np.float64]
 _Roots = npt.NDArray[np.float64]
 """A root array. Always float64, whatever the coefficients are."""
 
-_Counts = npt.NDArray[np.intp]
-"""Per-polynomial root counts, for the batch kernels."""
+_Counts = npt.NDArray[np.int64]
+"""Per-polynomial root counts, for the batch kernels.
+
+``np.int64`` rather than ``np.intp``, which is what Layer 2 allocates and what the
+Numba kernel annotates. The two are the same type on every 64-bit platform and numpy
+2's stubs unify them, so mypy accepts either locally; ``CLAUDE.md`` records that
+stub behaviour is CI-matrix-dependent, and the binding's own signature says
+``int64``, so the alias says what the binding says.
+"""
 
 _YukselFunc = Callable[[_Array, float], tuple[_Roots, int]]
 """Signature of Yuksel's decomposition: ``(coeff, param_tol) -> (roots, count)``."""
@@ -184,7 +202,7 @@ def _cpp_clip_roots(coeff: _Array, param_tol: float, geom_tol: float) -> tuple[_
 
     coeff_c = np.ascontiguousarray(coeff)
     out = np.empty(3 * (coeff_c.size - 1) + 4, dtype=np.float64)
-    count = _pantr_cpp.clip_roots(coeff_c, param_tol, geom_tol, out=out)
+    count = _pantr_cpp.clip_roots(coeff_c, param_tol=param_tol, geom_tol=geom_tol, out=out)
     return out, count
 
 
@@ -215,7 +233,9 @@ def _cpp_dedup_roots(
     raw_c = np.ascontiguousarray(raw_roots, dtype=np.float64)
     coeff_c = np.ascontiguousarray(coeff)
     out = np.empty(max(n_roots, 1), dtype=np.float64)
-    count = _pantr_cpp.dedup_roots(raw_c, n_roots, coeff_c, param_tol, geom_tol, out=out)
+    count = _pantr_cpp.dedup_roots(
+        coeff_c, raw_c, n_roots, param_tol=param_tol, geom_tol=geom_tol, out=out
+    )
     return out, count
 
 
@@ -272,7 +292,11 @@ def _cpp_find_roots_batch(
         out_counts if out_counts.flags["C_CONTIGUOUS"] else np.empty_like(out_counts, order="C")
     )
     _pantr_cpp.find_roots_batch(
-        coeffs_c, param_tol, geom_tol, out_roots=roots_buffer, out_counts=counts_buffer
+        coeffs_c,
+        param_tol=param_tol,
+        geom_tol=geom_tol,
+        out_roots=roots_buffer,
+        out_counts=counts_buffer,
     )
     if roots_buffer is not out_roots:
         out_roots[...] = roots_buffer

--- a/src/pantr/bezier/_root_finding_backend.py
+++ b/src/pantr/bezier/_root_finding_backend.py
@@ -1,0 +1,406 @@
+"""Which implementation of a Bézier root-finding kernel runs: the Numba one or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for
+the root-finding half of the bezier package, beside :mod:`pantr.bezier._bezier_backend`
+which owns the arithmetic half, for the reason that module states: a catalogue
+imports the kernels it hands out, so keeping each one beside its own kernels is what
+stops the policy module from importing the library it has to stay independent of.
+
+Six accessors over sixteen kernels
+----------------------------------
+
+The other ten are unreachable from here and that is structural rather than an
+oversight. Inside the Numba backend they call each other from within ``nopython``
+code, and no dispatch can be inserted between two Numba kernels, so the boundary is
+forced up to the five places :mod:`pantr.bezier._find_roots` reaches for a kernel,
+plus the deduplication it reaches for straight after clipping.
+
+One consequence is worth stating because a later reader will look for it:
+:mod:`pantr.bezier._root_finding_core` is **not touched** by this port. Its seven
+kernels stay where they are, still imported by :mod:`pantr.bezier._clipping_core`
+and :mod:`pantr.bezier._yuksel_core` at ``nopython`` call sites that cannot route
+through here, and still importable at their own module path, which is what a
+downstream consumer of ``_de_casteljau_eval_scalar`` relies on.
+
+Six bare callables and no record, which is the rule
+``design/cross_backend_types.md`` states: a record when a consumer needs more than
+one kernel at once, a bare callable when it does not. No call site here needs two.
+:func:`~pantr.bezier._find_roots._dispatch_single` uses clipping and then
+deduplication in one call, which looks like the exception and is not: it chooses
+between clipping and Yuksel first, so which second kernel it needs is not known
+until the first has been picked.
+
+Why the C++ side is adapted rather than the oracle reshaped
+-----------------------------------------------------------
+
+The Numba kernels return ``(array, count)``. The C++ bindings fill a caller buffer
+and return the count, because the size of a root set is not a function of the input
+and the allocation belongs with the caller. Those two shapes are reconciled here, in
+three lines per kernel, rather than by giving the Numba kernels an ``out`` parameter
+as the arithmetic port did to two of its own.
+
+The reason is specific to this block: the oracle is what parity is measured against,
+and the transliteration was checked against it bit for bit over 198 cases before any
+of this existed. Reshaping the oracle to suit the binding would move the thing being
+measured, and it would also change kernels that ``tests/test_root_finding.py`` calls
+directly.
+
+What crosses the boundary
+-------------------------
+
+Arrays and scalars only. Root arrays are ``float64`` in both backends whatever the
+coefficients are, matching the oracle, so a ``float32`` curve still gets ``float64``
+roots.
+
+The two batch kernels are imported inside their accessors rather than at module
+scope. :mod:`pantr.bezier._find_roots` deferred that import before this catalogue
+existed, and routing it through here would have made it eager without anyone
+deciding to; :mod:`pantr.bezier._batch_core` is the only module in the block whose
+kernels carry ``parallel=True``, so it is the one worth not pulling in until asked.
+
+One difference that is **not** parity: the two Numba batch kernels carry
+``parallel=True`` and run one polynomial per thread, while the C++ ones are serial.
+Each polynomial writes only its own row and there is no reduction, so the answer
+cannot move with the thread count either way; only the speed differs, and nothing
+here has been profiled yet.
+
+- :func:`yuksel_roots_kernel`, :func:`clip_roots_kernel`, :func:`dedup_roots_kernel`,
+  :func:`solve_monotone_root_kernel`, :func:`find_roots_batch_kernel`,
+  :func:`solve_monotone_root_batch_kernel`: the accessors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+from ._clipping_core import _clip_roots_core, _dedup_roots_core
+from ._yuksel_core import _solve_monotone_root_kernel, _yuksel_roots
+
+_K = TypeVar("_K")
+"""One kernel's signature, so :func:`_select` returns the type it was given."""
+
+_Array = npt.NDArray[np.float32 | np.float64]
+"""A float32 or float64 array, the only two dtypes these kernels handle."""
+
+_Roots = npt.NDArray[np.float64]
+"""A root array. Always float64, whatever the coefficients are."""
+
+_Counts = npt.NDArray[np.intp]
+"""Per-polynomial root counts, for the batch kernels."""
+
+_YukselFunc = Callable[[_Array, float], tuple[_Roots, int]]
+"""Signature of Yuksel's decomposition: ``(coeff, param_tol) -> (roots, count)``."""
+
+_ClipFunc = Callable[[_Array, float, float], tuple[_Roots, int]]
+"""Signature of Bézier clipping: ``(coeff, param_tol, geom_tol) -> (roots, count)``."""
+
+_DedupFunc = Callable[[_Roots, int, _Array, float, float], tuple[_Roots, int]]
+"""Signature of the merge: ``(raw, n_raw, coeff, param_tol, geom_tol) -> (roots, count)``."""
+
+_MonotoneFunc = Callable[[_Array, float], float]
+"""Signature of the monotone solver: ``(coeff, param_tol) -> root or NaN``."""
+
+_BatchRootsFunc = Callable[[_Array, float, float, _Roots, _Counts], None]
+"""Signature of the batch search: ``(coeffs, param_tol, geom_tol, out_roots, out_counts)``."""
+
+_BatchMonotoneFunc = Callable[[_Array, float, _Roots], None]
+"""Signature of the batch monotone solver: ``(coeffs, param_tol, out_roots)``."""
+
+
+def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
+    """Pick one kernel's implementation for the requested backend.
+
+    The one place the never-fall-back rule is applied for this half of the package,
+    so the accessors below cannot drift from each other on it.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+        python_kernel (_K): The Numba implementation, always available.
+        cpp_kernel (_K): The C++ implementation, available only when the extension
+            was built.
+
+    Returns:
+        _K: The kernel of the chosen backend.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return python_kernel
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return cpp_kernel
+
+
+def _cpp_yuksel_roots(coeff: _Array, param_tol: float) -> tuple[_Roots, int]:
+    """Run Yuksel's decomposition through the C++ binding.
+
+    Args:
+        coeff (_Array): 1-D Bernstein coefficients.
+        param_tol (float): Bracket-width tolerance.
+
+    Returns:
+        tuple[_Roots, int]: ``(roots, count)``, of which the first ``count`` entries
+            are valid. Unsorted, as the Numba kernel leaves them.
+
+    Note:
+        No input validation is performed here. Shape and dtype were established by
+        Layer 2; the binding re-checks dtype, rank, contiguity and the tolerance.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    coeff_c = np.ascontiguousarray(coeff)
+    out = np.empty(max(coeff_c.size - 1, 1), dtype=np.float64)
+    count = _pantr_cpp.yuksel_roots(coeff_c, param_tol, out=out)
+    return out, count
+
+
+def _cpp_clip_roots(coeff: _Array, param_tol: float, geom_tol: float) -> tuple[_Roots, int]:
+    """Run Bézier clipping through the C++ binding.
+
+    Args:
+        coeff (_Array): 1-D Bernstein coefficients.
+        param_tol (float): Bracket-width termination tolerance.
+        geom_tol (float): Geometric tolerance for near-zero detection.
+
+    Returns:
+        tuple[_Roots, int]: ``(roots, count)``. Unsorted and possibly duplicated,
+            as the Numba kernel leaves them; the merge is a separate kernel.
+
+    Note:
+        No input validation is performed here. The buffer is sized to the kernel's
+        own worst case of ``3 * degree + 4``, which the binding re-checks.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    coeff_c = np.ascontiguousarray(coeff)
+    out = np.empty(3 * (coeff_c.size - 1) + 4, dtype=np.float64)
+    count = _pantr_cpp.clip_roots(coeff_c, param_tol, geom_tol, out=out)
+    return out, count
+
+
+def _cpp_dedup_roots(
+    raw_roots: _Roots,
+    n_roots: int,
+    coeff: _Array,
+    param_tol: float,
+    geom_tol: float,
+) -> tuple[_Roots, int]:
+    """Sort and merge duplicate candidates through the C++ binding.
+
+    Args:
+        raw_roots (_Roots): Candidates, of which the first ``n_roots`` are valid.
+        n_roots (int): Number of valid candidates.
+        coeff (_Array): Original Bernstein coefficients, for the derivative.
+        param_tol (float): Parametric tolerance.
+        geom_tol (float): Geometric tolerance.
+
+    Returns:
+        tuple[_Roots, int]: ``(roots, count)``, sorted ascending.
+
+    Note:
+        No input validation is performed here.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    raw_c = np.ascontiguousarray(raw_roots, dtype=np.float64)
+    coeff_c = np.ascontiguousarray(coeff)
+    out = np.empty(max(n_roots, 1), dtype=np.float64)
+    count = _pantr_cpp.dedup_roots(raw_c, n_roots, coeff_c, param_tol, geom_tol, out=out)
+    return out, count
+
+
+def _cpp_solve_monotone_root(coeff: _Array, param_tol: float) -> float:
+    """Solve for a monotone root through the C++ binding.
+
+    Args:
+        coeff (_Array): 1-D Bernstein coefficients of a monotone polynomial.
+        param_tol (float): Bracket-width termination tolerance.
+
+    Returns:
+        float: The root parameter, or NaN when no sign change is detected.
+
+    Note:
+        No input validation is performed here.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return float(_pantr_cpp.solve_monotone_root(np.ascontiguousarray(coeff), param_tol))
+
+
+def _cpp_find_roots_batch(
+    coeffs: _Array,
+    param_tol: float,
+    geom_tol: float,
+    out_roots: _Roots,
+    out_counts: _Counts,
+) -> None:
+    """Run the batch search through the C++ binding, absorbing strided outputs.
+
+    Args:
+        coeffs (_Array): Batch of coefficients, shape ``(n_polys, degree + 1)``.
+        param_tol (float): Parametric tolerance.
+        geom_tol (float): Geometric tolerance.
+        out_roots (_Roots): Shape ``(n_polys, max(degree, 1))``, pre-filled with NaN.
+        out_counts (_Counts): Shape ``(n_polys,)``, receiving the per-row counts.
+
+    Note:
+        No input validation is performed here. The Numba kernel fills a strided
+        destination in place while the binding refuses one, so a strided caller is
+        computed into a contiguous buffer and copied back; refusing instead would
+        make ``PANTR_BACKEND`` change what the library accepts rather than only how
+        fast it is.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    coeffs_c = np.ascontiguousarray(coeffs)
+    roots_buffer = (
+        out_roots
+        if out_roots.flags["C_CONTIGUOUS"]
+        else np.ascontiguousarray(out_roots, dtype=np.float64)
+    )
+    counts_buffer = (
+        out_counts if out_counts.flags["C_CONTIGUOUS"] else np.empty_like(out_counts, order="C")
+    )
+    _pantr_cpp.find_roots_batch(
+        coeffs_c, param_tol, geom_tol, out_roots=roots_buffer, out_counts=counts_buffer
+    )
+    if roots_buffer is not out_roots:
+        out_roots[...] = roots_buffer
+    if counts_buffer is not out_counts:
+        out_counts[...] = counts_buffer
+
+
+def _cpp_solve_monotone_root_batch(coeffs: _Array, param_tol: float, out_roots: _Roots) -> None:
+    """Run the batch monotone solver through the C++ binding.
+
+    Args:
+        coeffs (_Array): Batch of coefficients, shape ``(n_polys, degree + 1)``.
+        param_tol (float): Bracket-width termination tolerance.
+        out_roots (_Roots): Shape ``(n_polys,)``, pre-filled with NaN by the caller.
+            A row whose polynomial has no root is left untouched, which is why the
+            pre-fill is the caller's job in both backends.
+
+    Note:
+        No input validation is performed here.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    coeffs_c = np.ascontiguousarray(coeffs)
+    buffer = (
+        out_roots
+        if out_roots.flags["C_CONTIGUOUS"]
+        else np.ascontiguousarray(out_roots, dtype=np.float64)
+    )
+    _pantr_cpp.solve_monotone_root_batch(coeffs_c, param_tol, out_roots=buffer)
+    if buffer is not out_roots:
+        out_roots[...] = buffer
+
+
+def yuksel_roots_kernel(backend: Backend | None = None) -> _YukselFunc:
+    """Get the Yuksel monotone-decomposition kernel of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _YukselFunc: ``(coeff, param_tol) -> (roots, count)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _yuksel_roots, _cpp_yuksel_roots)
+
+
+def clip_roots_kernel(backend: Backend | None = None) -> _ClipFunc:
+    """Get the Bézier clipping kernel of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _ClipFunc: ``(coeff, param_tol, geom_tol) -> (roots, count)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _clip_roots_core, _cpp_clip_roots)
+
+
+def dedup_roots_kernel(backend: Backend | None = None) -> _DedupFunc:
+    """Get the duplicate-merging kernel of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _DedupFunc: ``(raw, n_raw, coeff, param_tol, geom_tol) -> (roots, count)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _dedup_roots_core, _cpp_dedup_roots)
+
+
+def solve_monotone_root_kernel(backend: Backend | None = None) -> _MonotoneFunc:
+    """Get the monotone-root solver of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _MonotoneFunc: ``(coeff, param_tol) -> root or NaN``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _solve_monotone_root_kernel, _cpp_solve_monotone_root)
+
+
+def find_roots_batch_kernel(backend: Backend | None = None) -> _BatchRootsFunc:
+    """Get the batch root-finding kernel of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _BatchRootsFunc: ``(coeffs, param_tol, geom_tol, out_roots, out_counts)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    from ._batch_core import _find_roots_batch_core  # noqa: PLC0415
+
+    return _select(backend, _find_roots_batch_core, _cpp_find_roots_batch)
+
+
+def solve_monotone_root_batch_kernel(backend: Backend | None = None) -> _BatchMonotoneFunc:
+    """Get the batch monotone-root solver of the chosen backend.
+
+    Args:
+        backend (Backend | None): The backend to use, or ``None`` for the one in
+            effect. Defaults to ``None``.
+
+    Returns:
+        _BatchMonotoneFunc: ``(coeffs, param_tol, out_roots)``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    from ._batch_core import _solve_monotone_root_batch_core  # noqa: PLC0415
+
+    return _select(backend, _solve_monotone_root_batch_core, _cpp_solve_monotone_root_batch)

--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -124,6 +124,7 @@ __all__ = [
     "bounded_parity",
     "build_provenance",
     "contraction_may_fuse",
+    "converged_parity",
     "cpp_backend_available",
     "demand_cpp_backend",
     "derived_accuracy",
@@ -405,10 +406,20 @@ class ParityKind(IntEnum):
             holds: a tolerance that is never approached asserts nothing.
         BOUNDED: The backends differ, within a bound derived from a rounding
             budget and an elementwise amplification.
+        CONVERGED: The backends differ, within a bound that comes from the
+            **algorithm** rather than from arithmetic: both ran the same
+            convergent iteration to the same termination criterion, so each
+            answer lies within that criterion of the quantity it converged to.
+            Such a bound does not scale with epsilon, does not grow with degree,
+            and would hold between two runs of the *same* backend that happened
+            to take different iteration paths. Added by the root-finding port,
+            which is the first kernel family whose difference is not a rounding
+            difference. See ``design/backend_parity.md`` Rule 11.
     """
 
     BITWISE = 0
     BOUNDED = 1
+    CONVERGED = 2
 
 
 class Roundings(NamedTuple):
@@ -450,11 +461,11 @@ class Roundings(NamedTuple):
 class ParityClaim(NamedTuple):
     """A statement about how far two backends may differ, with its derivation.
 
-    Built by :func:`bitwise_parity` or :func:`bounded_parity`; do not construct it
-    positionally.
+    Built by :func:`bitwise_parity`, :func:`bounded_parity` or
+    :func:`converged_parity`; do not construct it positionally.
 
     Attributes:
-        kind (ParityKind): Which of the two statements is being made.
+        kind (ParityKind): Which of the three statements is being made.
         roundings (Roundings | None): The rounding budget. None for BITWISE.
         accumulator (np.dtype[np.floating[Any]] | None): Format intermediates are
             accumulated in. None for BITWISE.
@@ -469,6 +480,20 @@ class ParityClaim(NamedTuple):
             both; where the result spans decades, or vanishes while its error
             does not, the magnitude has to be multiplied in deliberately. See
             ``design/backend_parity.md`` Rules 2 and 4. None for BITWISE.
+        scale (float | None): The magnitude the quantity is meaningful against,
+            used **only** by CONVERGED. For most kernels a bound is vacuous when it
+            reaches the values it compares, which is what the vacuity guard checks.
+            A quantity confined to a **bounded domain** breaks that premise: a curve
+            parameter near zero is not an ill-determined quantity, it is a parameter
+            near an endpoint, and its natural scale is the domain rather than its own
+            magnitude. Where a claim carries a scale, the guard takes the larger of
+            the two. None otherwise.
+        absolute (FloatArray | None): Elementwise absolute bound, used **only**
+            by CONVERGED, where the bound is the algorithm's own termination
+            criterion and no rounding model produces it. None otherwise. Kept
+            separate from ``amplification`` rather than overloading it, because
+            the two are different quantities: one is dimensionless and gets
+            multiplied by a rounding budget, the other is already a tolerance.
         why (str): The derivation, or the reason exactness holds. Quoted verbatim
             in any failure message.
     """
@@ -479,6 +504,8 @@ class ParityClaim(NamedTuple):
     storage: np.dtype[np.floating[Any]] | None
     amplification: FloatArray | None
     why: str
+    absolute: FloatArray | None = None
+    scale: float | None = None
 
 
 class AccuracyClaim(NamedTuple):
@@ -663,6 +690,60 @@ def bounded_parity(
     )
 
 
+def converged_parity(*, bound: FloatArray, scale: float, why: str) -> ParityClaim:
+    """Claim that two backends agree within their shared termination criterion.
+
+    For an iterative kernel whose difference is **not** a rounding difference. Both
+    backends run the same convergent iteration and stop on the same criterion, so
+    each answer lies within that criterion of the quantity it converged to and the
+    two lie within it of each other. Nothing about floating point enters, which is
+    why this cannot be spelled with :func:`bounded_parity`: that builds its bound
+    from a rounding budget times an amplification, and reaching a given number that
+    way would mean choosing an amplification to produce it, which is the fitted
+    constant the harness exists to make unsayable.
+
+    **What this claim does not cover.** It assumes the two backends converged to the
+    *same* quantity. Where an iteration's control flow can branch differently, that
+    assumption is separate and has to be asserted separately, because no tolerance
+    bounds a changed verdict.
+
+    Args:
+        bound (FloatArray): Elementwise absolute bound, same shape as the result.
+            Normally the iteration's termination tolerance.
+        scale (float): The magnitude the quantity is meaningful against, which for
+            an iterate on a bounded domain is the domain's width rather than the
+            iterate's own value. Required rather than defaulted: getting it wrong is
+            how a vacuous bound passes, and there is no scale that is right for every
+            iteration.
+        why (str): The derivation: which criterion, and why each answer lies within
+            it of what it converged to.
+
+    Returns:
+        ParityClaim: A claim asserting agreement within the algorithmic bound.
+
+    Raises:
+        ValueError: If ``why`` is empty, if the bound is not finite and non-negative,
+            or if the scale is not finite and positive.
+    """
+    if not why.strip():
+        raise ValueError("a converged parity claim must carry its derivation")
+    arr = np.asarray(bound, dtype=np.float64)
+    if not np.all(np.isfinite(arr)) or np.any(arr < 0.0):
+        raise ValueError("the convergence bound must be finite and non-negative")
+    if not (np.isfinite(scale) and scale > 0.0):
+        raise ValueError("the scale must be finite and positive")
+    return ParityClaim(
+        kind=ParityKind.CONVERGED,
+        roundings=None,
+        accumulator=None,
+        storage=None,
+        amplification=None,
+        why=why,
+        absolute=arr,
+        scale=float(scale),
+    )
+
+
 def derived_accuracy(*, bound: FloatArray, why: str) -> AccuracyClaim:
     """Claim an elementwise absolute error bound against an independent oracle.
 
@@ -832,7 +913,8 @@ def absolute_tolerance(claim: ParityClaim) -> FloatArray:
         claim (ParityClaim): The claim.
 
     Returns:
-        FloatArray: Zero everywhere for BITWISE; otherwise
+        FloatArray: Zero everywhere for BITWISE; the stated bound for CONVERGED;
+            otherwise
             ``2 * (gamma * amplification + underflow floor)``, the two halves of
             the rounding model that :func:`underflow_floor` describes. Both are
             doubled for the same reason: neither backend is the exact answer, so
@@ -841,6 +923,14 @@ def absolute_tolerance(claim: ParityClaim) -> FloatArray:
     if claim.kind is ParityKind.BITWISE:
         shape = () if claim.amplification is None else claim.amplification.shape
         return np.zeros(shape, dtype=np.float64)
+    if claim.kind is ParityKind.CONVERGED:
+        assert claim.absolute is not None  # CONVERGED by construction
+        # Already a tolerance rather than an amplification, and **not** doubled:
+        # the factor of two turns a one-sided forward-error bound into a two-sided
+        # one, and this bound is two-sided to begin with. Each backend's answer is
+        # within the criterion of the quantity it converged to, and the criterion
+        # is the same one, so the difference is bounded by it directly.
+        return claim.absolute
     assert claim.amplification is not None  # BOUNDED by construction
     relative = _relative_growth(claim) * claim.amplification
     return ONE_SIDED_TO_TWO_SIDED * (relative + _underflow_budget(claim))
@@ -957,9 +1047,15 @@ def _refuse_a_vacuous_bound(
         context (str): What was being computed.
 
     Raises:
-        AssertionError: If the bound exceeds the largest reference magnitude.
+        AssertionError: If the bound reaches the scale the quantity lives on.
     """
+    # A claim that names its own scale is compared against the larger of the two.
+    # The default premise, that a bound is vacuous once it reaches the values it
+    # compares, fails for a quantity confined to a bounded domain: a curve parameter
+    # near zero is not ill-determined, it is near an endpoint. See ParityClaim.scale.
     largest = float(np.abs(reference.astype(np.float64)).max(initial=0.0))
+    if claim.scale is not None:
+        largest = max(largest, claim.scale)
     worst = float(np.asarray(tolerance).max(initial=0.0))
     if largest > 0.0 and worst >= largest:
         raise AssertionError(
@@ -1049,9 +1145,13 @@ def assert_parity(
         raise AssertionError(
             f"{context}: the backends differ by more than the derived bound.\n"
             f"  derivation: {claim.why}\n"
-            f"  budget: {claim.roundings}, accumulator {claim.accumulator}, "
-            f"storage {claim.storage}\n"
-            f"{_worst_element_report(actual, reference, tolerance, offenders)}"
+            + (
+                ""
+                if claim.roundings is None
+                else f"  budget: {claim.roundings}, accumulator {claim.accumulator}, "
+                f"storage {claim.storage}\n"
+            )
+            + f"{_worst_element_report(actual, reference, tolerance, offenders)}"
         )
     return deviation
 

--- a/tests/_parity_harness.py
+++ b/tests/_parity_harness.py
@@ -488,7 +488,7 @@ class ParityClaim(NamedTuple):
             near an endpoint, and its natural scale is the domain rather than its own
             magnitude. Where a claim carries a scale, the guard takes the larger of
             the two. None otherwise.
-        absolute (FloatArray | None): Elementwise absolute bound, used **only**
+        bound (FloatArray | None): Elementwise absolute bound, used **only**
             by CONVERGED, where the bound is the algorithm's own termination
             criterion and no rounding model produces it. None otherwise. Kept
             separate from ``amplification`` rather than overloading it, because
@@ -504,7 +504,7 @@ class ParityClaim(NamedTuple):
     storage: np.dtype[np.floating[Any]] | None
     amplification: FloatArray | None
     why: str
-    absolute: FloatArray | None = None
+    bound: FloatArray | None = None
     scale: float | None = None
 
 
@@ -739,7 +739,7 @@ def converged_parity(*, bound: FloatArray, scale: float, why: str) -> ParityClai
         storage=None,
         amplification=None,
         why=why,
-        absolute=arr,
+        bound=arr,
         scale=float(scale),
     )
 
@@ -924,13 +924,13 @@ def absolute_tolerance(claim: ParityClaim) -> FloatArray:
         shape = () if claim.amplification is None else claim.amplification.shape
         return np.zeros(shape, dtype=np.float64)
     if claim.kind is ParityKind.CONVERGED:
-        assert claim.absolute is not None  # CONVERGED by construction
+        assert claim.bound is not None  # CONVERGED by construction
         # Already a tolerance rather than an amplification, and **not** doubled:
         # the factor of two turns a one-sided forward-error bound into a two-sided
         # one, and this bound is two-sided to begin with. Each backend's answer is
         # within the criterion of the quantity it converged to, and the criterion
         # is the same one, so the difference is bounded by it directly.
-        return claim.absolute
+        return claim.bound
     assert claim.amplification is not None  # BOUNDED by construction
     relative = _relative_growth(claim) * claim.amplification
     return ONE_SIDED_TO_TWO_SIDED * (relative + _underflow_budget(claim))

--- a/tests/parity/conftest.py
+++ b/tests/parity/conftest.py
@@ -43,3 +43,27 @@ def _jit_warmup_barrier() -> None:
     than one kernel's file alone.
     """
     _numba_compat.wait_for_jit_warmup()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def the_oracle_is_self_consistent() -> None:
+    """Refuse to run if Numba would use SVML, which makes the oracle disagree with itself.
+
+    `_dedup_roots_core` calls `pow`, and it is reached both serially and from
+    `_find_roots_batch_core`, which carries ``parallel=True``. SVML's `pow` is not
+    bit-identical to glibc's, so with SVML present the batch path and the serial path
+    could return different roots **within the Numba backend**, and every parity figure
+    measured against it would be measuring two different oracles.
+
+    Not a hypothetical guarded on principle: it is one `pip install icc_rt` away, and
+    nothing else in the suite would notice. Numba enables SVML automatically when the
+    runtime is importable.
+    """
+    from numba import config  # noqa: PLC0415
+
+    assert not config.USING_SVML, (
+        "numba is using SVML, so its `pow` is not the platform one and the serial and "
+        "parallel root-finding paths may disagree inside the oracle itself. Remove "
+        "icc_rt / intel-cmplr-lib-rt, or set NUMBA_DISABLE_INTEL_SVML=1, before "
+        "trusting any parity figure from this suite."
+    )

--- a/tests/parity/test_bezier_binding_contract.py
+++ b/tests/parity/test_bezier_binding_contract.py
@@ -159,3 +159,113 @@ def test_restrict_refuses_transposed_bounds(cpp_backend: None) -> None:
     # A zero-width interval is admitted: the kernel is well defined there, and Layer 1
     # is the layer that decides whether it is a useful thing to ask for.
     bindings.restrict_bezier_1d(_CTRL, 0.5, 0.5, out=np.empty((4, 2)))
+
+
+_ROOT_COEFF = np.array([1.0, -1.0, -1.0, 1.0])
+"""A degree-3 polynomial with two real roots, so a truncated output is observable."""
+
+
+def test_the_batch_binding_refuses_a_row_too_narrow_for_its_roots(cpp_backend: None) -> None:
+    """`find_roots_batch` checks the axis it writes into, not the one already checked.
+
+    This is the regression test for a defect an API audit found and this file's
+    absence allowed: the capacity check tested ``out_roots.shape(0)``, which the two
+    lines above it had already forced equal to the polynomial count, while the row
+    width the kernel actually indexes went unchecked. The kernel clamps its per-row
+    count to whatever fits, so an undersized buffer reported **fewer roots than
+    exist, with no error**: a two-root polynomial came back with one, and a
+    zero-width row came back claiming none.
+
+    The sibling single-call bindings all refused the equivalent case, which is what
+    makes this a slip rather than a policy. Nothing reached it because the only
+    in-tree caller is `pantr.bezier.find_roots`, which always allocates correctly.
+    """
+    del cpp_backend
+    bindings = _bindings()
+    coeffs = _ROOT_COEFF.reshape(1, -1)
+    counts = np.zeros(1, dtype=np.int64)
+
+    for narrow in (0, 1, 2):
+        with pytest.raises(ValueError, match="along axis 1"):
+            bindings.find_roots_batch(
+                coeffs,
+                param_tol=1e-12,
+                geom_tol=1e-12,
+                out_roots=np.full((1, narrow), np.nan),
+                out_counts=counts,
+            )
+
+    # The worst case is `degree` roots, and a row that wide is accepted and used.
+    roots = np.full((1, 3), np.nan)
+    bindings.find_roots_batch(
+        coeffs, param_tol=1e-12, geom_tol=1e-12, out_roots=roots, out_counts=counts
+    )
+    assert counts[0] == 2, "the two roots of this polynomial were not both reported"
+
+
+def test_the_root_finding_bindings_refuse_a_short_output(cpp_backend: None) -> None:
+    """Each single-call binding names the worst case it can produce, not the typical one.
+
+    A root set's size is not a function of the input, so the caller sizes for the
+    worst case and the binding says what that is. Clipping's is `3 * degree + 4`,
+    before the merge removes the duplicates the same root arrives as.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    with pytest.raises(ValueError, match="can produce 3"):
+        bindings.yuksel_roots(_ROOT_COEFF, 1e-12, out=np.empty(2))
+    with pytest.raises(ValueError, match="can produce 13"):
+        bindings.clip_roots(_ROOT_COEFF, param_tol=1e-12, geom_tol=1e-12, out=np.empty(12))
+    with pytest.raises(ValueError, match="can produce 2"):
+        bindings.dedup_roots(
+            _ROOT_COEFF,
+            np.array([0.25, 0.75]),
+            2,
+            param_tol=1e-12,
+            geom_tol=1e-12,
+            out=np.empty(1),
+        )
+
+
+def test_the_root_finding_bindings_refuse_an_unusable_tolerance(cpp_backend: None) -> None:
+    """Zero, negative and NaN are all refused, matching `_find_roots._resolve_tol`.
+
+    A direct call on the extension skips Layer 2, so the two backends would otherwise
+    accept different inputs rather than merely running at different speeds. NaN is
+    the one worth a test of its own: it compares false against everything, so a check
+    written as a negated range would admit it.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    for bad in (0.0, -1e-12, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="finite and positive"):
+            bindings.yuksel_roots(_ROOT_COEFF, bad, out=np.empty(3))
+        with pytest.raises(ValueError, match="finite and positive"):
+            bindings.solve_monotone_root(_ROOT_COEFF, bad)
+
+
+def test_the_root_finding_bindings_refuse_the_tolerances_positionally(
+    cpp_backend: None,
+) -> None:
+    """Nothing orders `param_tol` against `geom_tol`, so keyword-only is the only guard.
+
+    `restrict_bezier_1d`'s `lower`/`upper` can be ordered and are checked that way.
+    These two cannot: neither bounds the other, and transposed they return a
+    different and plausible root set. Making them unsayable positionally is what
+    closes it.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    with pytest.raises(TypeError):
+        bindings.clip_roots(_ROOT_COEFF, 1e-12, 1e-12, out=np.empty(13))
+    with pytest.raises(TypeError):
+        bindings.find_roots_batch(
+            _ROOT_COEFF.reshape(1, -1),
+            1e-12,
+            1e-12,
+            out_roots=np.full((1, 3), np.nan),
+            out_counts=np.zeros(1, dtype=np.int64),
+        )

--- a/tests/parity/test_bezier_root_finding.py
+++ b/tests/parity/test_bezier_root_finding.py
@@ -484,6 +484,32 @@ def _assert_the_same_roots(
         assert_parity(actual, reference, bitwise_parity(why=_BITWISE_WHY), context=context)
         return
 
+    # Equal counts do not mean the same roots. Measured: one ulp on a coefficient
+    # turned [0.5, 0.828] into [0.1715, 0.5] at the same count, and the elementwise
+    # comparison then pairs 0.5 against 0.1715 and fails on the value bound, blaming
+    # a displacement for what is a changed set. Checking the pairing first is what
+    # makes the diagnosis right; the test failed either way.
+    # Only where the two arrays are sorted root sets of one polynomial. The batch
+    # results correspond by row, not by proximity, and applying a nearest-neighbour
+    # test to them compares a polynomial's root against another polynomial's.
+    sorted_roots = (
+        reference.size > 1
+        and bool(np.all(np.diff(reference) > 0.0))
+        and bool(np.all(np.isfinite(reference)))
+    )
+    if sorted_roots:
+        for position, value in enumerate(actual):
+            if not np.isfinite(value):
+                continue
+            distances = np.abs(reference - value)
+            assert int(np.argmin(distances)) == position, (
+                f"{context}: the backends returned root sets that do not correspond. "
+                f"Entry {position} of the C++ result, {value!r}, is nearer to the "
+                f"oracle's entry {int(np.argmin(distances))} than to its own. The "
+                f"counts match, so this is a changed set rather than a displaced "
+                f"value, and no tolerance covers it."
+            )
+
     bound = (
         np.full(actual.shape, case.tol, dtype=np.float64)
         if case.coeff is None

--- a/tests/parity/test_bezier_root_finding.py
+++ b/tests/parity/test_bezier_root_finding.py
@@ -54,6 +54,7 @@ correct on its own is what breaks the equality this file exists to hold.
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Final, NamedTuple
 
 import numpy as np
@@ -101,6 +102,14 @@ return an empty array, they agree, and the test passes **without reaching the de
 at all**. A tolerance below the coefficients is what makes these tests able to fail.
 """
 
+_DBL_EPSILON: Final = 2.2204460492503131e-16
+"""What the kernels use to size their own tolerances, float64 even on the float32 path.
+
+Mirrors ``_root_finding_core._DBL_EPSILON``. Reproducing it rather than deriving one
+from the dtype is the point: :func:`_acceptance_band` has to compute the band the
+algorithm actually uses, not the one it arguably should.
+"""
+
 _BITWISE_WHY: Final = (
     "every operation in the block is a correctly rounded add, subtract, multiply, "
     "divide or compare, and the C++ reproduces the oracle's per-expression widths, "
@@ -112,28 +121,48 @@ _BITWISE_WHY: Final = (
 """Why the two backends are bit-identical where nothing can fuse."""
 
 _FUSED_WHY: Final = (
-    "a root is located only to within the interval where the COMPUTED residual is "
-    "indistinguishable from zero, which has half-width eps_f / |f'(r)| for an "
-    "evaluation whose forward error is eps_f. Two backends whose residuals differ "
-    "within eps_f may return any point of that interval, so their roots differ by at "
-    "most twice it. Below that scale the bracketing tolerance also applies, so the "
-    "bound is the larger of the two. De Casteljau is a convex combination at every "
-    "stage, so it neither amplifies nor cancels and eps_f is (degree + 1) roundings "
-    "at the COEFFICIENT width times the coefficient magnitude -- the coefficient "
-    "width, not float64, because the triangle stores back into a buffer of the input "
-    "dtype at every step. The half-width is capped at eps_f^(1/3), the cluster width "
-    "around a root of multiplicity up to three, which is the same cap and the same "
-    "reasoning _dedup_roots_core uses for its merge radius; without it a double root, "
-    "where f' vanishes, would carry an unbounded tolerance"
+    "the two backends may return any point of the acceptance component around a "
+    "root, that being the connected set where the computed residual is inside the "
+    "band the algorithm itself accepts, so their answers differ by at most that "
+    "component's width. The width is CERTIFIED rather than predicted: the Bernstein "
+    "net is restricted to each flanking interval in exact rational arithmetic and "
+    "the convex-hull property proves the residual stays outside the band there, so "
+    "the component cannot reach past the certified half-width. Nothing local is "
+    "assumed, so there is no curvature hypothesis to fail, no derivative to vanish "
+    "and no multiplicity to bound. The band itself is the algorithm's own zero_tol "
+    "plus the evaluation's forward error at Hermes' corrected gamma_3n. Below that "
+    "scale the bracketing tolerance also applies, so the bound is the larger"
 )
 """Why a fusing build still agrees, and to what.
 
-**An earlier version of this claimed the bound was `param_tol` alone**, derived from
-both backends returning a bracket midpoint. That was fitted to float64 data, where
-``eps_f / |f'|`` is around 1e-15 and ``param_tol`` of 1e-12 hides it. At float32 the
-residual term is four orders larger and dominates: a degree-5 case moved by 2e-8. The
-measurement that produced the wrong bound, 732 float64-heavy results with a worst
-displacement of 4.951e-13, was consistent with it and could not have refuted it.
+**Two earlier versions of this were refuted, and the second failed in a way worth
+keeping.** The first claimed ``param_tol`` alone, fitted to float64 data where the
+other term is around 1e-15 and hidden; at float32 a degree-5 case moved by 2e-8. The
+second predicted the component's half-width as ``eps_f / |f'|`` capped at
+``eps_f^(1/3)``, and an adversarial review took it apart on four counts:
+
+* ``eps_f = (degree + 1) * u * max|c|`` is **false at float64**, by an exact-rational
+  counterexample at degree 1 exceeding it by 1.126x. The literature constant is
+  Mainar and Peña's ``gamma_2n``, corrected by Hermes to ``gamma_3n`` because the
+  original did not charge the rounding of ``1 - t``, which this kernel commits;
+* it used the wrong epsilon entirely. The kernel accepts on ``abs(f) <= zero_tol``,
+  which it computes itself, and for ``f(t) = t - 1/2``, the simplest polynomial in
+  this suite, the acceptance band is **exactly twice** what was claimed;
+* the linearisation needs a curvature hypothesis nobody stated, and there is a
+  measured window at ``|f'| ~ 2*sqrt(eps)`` where it fails by 2.75x and the cap has
+  not yet engaged, the two thresholds being unrelated quantities;
+* the cap is not scale-invariant and is dimensionally wrong. ``eps_f^(1/3)`` has
+  units of ``[f]^(1/3)`` and is compared against ``[t]``; the correct cluster width
+  is ``(eps/|a_m|)^(1/m)``. Measured, a triple root came back **bit-identical over
+  2^60 of coefficient scaling** while the cap moved by a factor of a million. A bound
+  that moves when the bounded quantity does not is not a bound.
+
+Certifying instead of predicting answers all four at once, and it is the review's own
+recommendation. The certificate is scale-invariant because scaling the coefficients
+scales the band with them; dimensionally correct because a half-width is what it
+searches for; and multiplicity-agnostic because no derivative appears. Verified on
+the case the old cap existed for: a triple root certifies at 1.221e-04 for lambda of
+1, 1e6 and 1e-6 alike.
 """
 
 
@@ -156,8 +185,14 @@ def _polynomial(degree: int, dtype: npt.DTypeLike, kind: str) -> npt.NDArray[np.
     elif kind == "sign_changes":
         coeff = np.cos(np.pi * index / max(degree, 1) * 3.0)
     elif kind == "double_root":
-        centre = index / max(degree, 1) - 0.5
-        coeff = centre * centre
+        # The Bernstein coefficients of (t - 1/2)^2, which has a genuine double root
+        # at t = 1/2. NOT `(i/n - 1/2)^2`, which is what this said first and which is
+        # the polynomial (1 - 1/n)(t - 1/2)^2 + 1/(4n): strictly positive, minimum
+        # 1/(4n), and it found zero roots at every degree while its docstring claimed
+        # it reached the bisection branch.
+        n = max(degree, 1)
+        squared = index * (index - 1.0) / (n * (n - 1.0)) if n > 1 else index * 0.0
+        coeff = squared - index / n + 0.25
     elif kind == "wide_range":
         coeff = np.cos(index) * 10.0 ** (index - degree / 2.0)
     elif kind == "endpoint_zeros":
@@ -224,19 +259,145 @@ shipped build.
 """
 
 
+def _restrict_exactly(coeff: npt.NDArray[np.floating], a: Fraction, b: Fraction) -> list[Fraction]:
+    """Bernstein coefficients of the same polynomial on ``[a, b]``, in exact arithmetic.
+
+    Written out here rather than taken from :func:`~pantr.bezier._root_finding_core.
+    _subdivide_scalar`, on purpose: this is the machinery that certifies the kernels,
+    so borrowing one of them would let a bug in it certify itself. Exact rationals
+    rather than float64 for the same reason, and a stronger one: the convex-hull
+    bound below is then a proof rather than an estimate needing its own error term.
+
+    Args:
+        coeff (npt.NDArray[np.floating]): Bernstein coefficients on [0, 1].
+        a (Fraction): Left bound of the sub-interval.
+        b (Fraction): Right bound, strictly greater than ``a``.
+
+    Returns:
+        list[Fraction]: The restricted coefficients, reparametrised to [0, 1].
+    """
+    d = [Fraction(float(c)) for c in coeff]
+    p = len(d) - 1
+    for step in range(1, p + 1):
+        for j in range(p, step - 1, -1):
+            d[j] = d[j] * b + d[j - 1] * (Fraction(1) - b)
+    tau = a / b if b != 0 else Fraction(0)
+    for step in range(1, p + 1):
+        for j in range(p - step + 1):
+            d[j] = d[j] * (Fraction(1) - tau) + d[j + 1] * tau
+    return d
+
+
+def _flank_is_clear(coeff: npt.NDArray[np.floating], a: float, b: float, eps: float) -> bool:
+    """Prove that ``|f| > eps`` everywhere on ``[a, b]``.
+
+    A Bernstein polynomial is a convex combination of its coefficients, so its graph
+    over an interval lies within the range of that interval's own coefficients. If
+    they are all above ``eps`` or all below ``-eps``, no point of the interval can be
+    accepted as a root. Exact, and it needs no derivative, no curvature hypothesis
+    and no knowledge of any multiplicity.
+
+    Args:
+        coeff (npt.NDArray[np.floating]): Bernstein coefficients on [0, 1].
+        a (float): Left bound.
+        b (float): Right bound. An empty or inverted interval is clear vacuously.
+        eps (float): The acceptance band's half-height.
+
+    Returns:
+        bool: True when the interval provably contains no acceptable point.
+    """
+    if a >= b:
+        return True
+    net = _restrict_exactly(coeff, Fraction(a), Fraction(b))
+    return min(net) > Fraction(eps) or max(net) < -Fraction(eps)
+
+
+def _acceptance_band(coeff: npt.NDArray[np.floating], geom_tol: float) -> float:
+    """The half-height of the set of values either backend may accept as zero.
+
+    Two terms, and the first is the algorithm's rather than the arithmetic's.
+    :func:`~pantr.bezier._clipping_core._clip_roots_core` accepts a candidate when
+    ``abs(f_final) <= zero_tol``, and computes ``zero_tol`` itself; that is the
+    quantity, not a forward error invented here. An earlier version of this file used
+    only a forward error and was out by a factor of exactly two on the simplest
+    polynomial in the suite.
+
+    The second is the evaluation's own error, so that a value the kernel computed as
+    inside the band might really be outside it. De Casteljau at storage width commits
+    three roundings per stage at accumulator width and one on the narrowing store,
+    which is Mainar and Peña's ``gamma_2n`` corrected by Hermes to account for the
+    rounding of ``1 - t`` that this kernel commits. Written as the first-order
+    ``n * u_T + 3n * u_64``, which is above the sharp ``2.5n * u`` at float64 and is
+    the storage term alone at float32, where the accumulator part is a relative
+    ``5.6e-9`` correction.
+
+    Args:
+        coeff (npt.NDArray[np.floating]): Bernstein coefficients.
+        geom_tol (float): The geometric tolerance the call ran at.
+
+    Returns:
+        float: The band's half-height, in the units of the coefficients.
+    """
+    degree = coeff.size - 1
+    scale = float(np.max(np.abs(coeff), initial=0.0))
+    zero_tol = max(scale * (degree + 1) * 4.0 * _DBL_EPSILON, geom_tol)
+    evaluation = degree * (unit_roundoff(coeff.dtype) + 3.0 * unit_roundoff(np.float64)) * scale
+    return zero_tol + evaluation
+
+
+def _certified_half_width(
+    coeff: npt.NDArray[np.floating], root: float, left: float, right: float, eps: float
+) -> float | None:
+    """The smallest certifiable half-width of the acceptance component around a root.
+
+    Binary search over the exponent. Certification is monotone in ``h``: a larger
+    half-width leaves smaller flanks to prove clear, so if ``h`` certifies then so
+    does anything larger, and the search is well posed.
+
+    Args:
+        coeff (npt.NDArray[np.floating]): Bernstein coefficients.
+        root (float): The oracle's root, at the centre of the neighbourhood.
+        left (float): Left edge of the neighbourhood, normally the midpoint to the
+            previous root.
+        right (float): Right edge.
+        eps (float): The acceptance band, from :func:`_acceptance_band`.
+
+    Returns:
+        float | None: The half-width, or None when no rung of the ladder certified,
+            which the caller must report rather than absorb.
+    """
+    low, high = 0, 52
+    best: float | None = None
+    while low <= high:
+        middle = (low + high) // 2
+        h = 2.0**-middle
+        if _flank_is_clear(coeff, left, root - h, eps) and _flank_is_clear(
+            coeff, root + h, right, eps
+        ):
+            best, low = h, middle + 1
+        else:
+            high = middle - 1
+    return best
+
+
 def _root_uncertainty(
     coeff: npt.NDArray[np.floating], roots: npt.NDArray[np.float64], param_tol: float
 ) -> npt.NDArray[np.float64]:
     """Elementwise bound on how far two backends' versions of one root may sit apart.
 
-    See :data:`_FUSED_WHY` for the derivation. The derivative is taken from the
-    oracle at the oracle's own roots, which is the only derivative available: an
-    exact one would need the root, which is what is being bounded.
+    Certified rather than predicted. See :data:`_FUSED_WHY` for why the predicted
+    form was withdrawn.
+
+    Each root gets the neighbourhood bounded by the midpoints to its neighbours, so a
+    near-double pair is not asked to separate further than it can. A root whose
+    neighbourhood cannot be certified at any rung gets ``inf``, which the harness's
+    own guard will then refuse as vacuous: that is the intended outcome, since a
+    component nobody could bound is a case with no claim rather than a case that
+    passes.
 
     Args:
-        coeff (npt.NDArray[np.floating]): The polynomial's Bernstein coefficients,
-            whose dtype sets the evaluation's rounding unit.
-        roots (npt.NDArray[np.float64]): The oracle's roots.
+        coeff (npt.NDArray[np.floating]): The polynomial.
+        roots (npt.NDArray[np.float64]): The oracle's roots, ascending.
         param_tol (float): The bracketing tolerance the call ran at.
 
     Returns:
@@ -245,22 +406,21 @@ def _root_uncertainty(
     if roots.size == 0:
         return np.zeros(0, dtype=np.float64)
 
-    degree = coeff.size - 1
-    scale = float(np.max(np.abs(coeff), initial=0.0))
-    residual_error = float(degree + 1) * unit_roundoff(coeff.dtype) * scale
+    eps = _acceptance_band(coeff, param_tol)
+    finite = np.clip(np.nan_to_num(roots, nan=0.5), 0.0, 1.0)
+    order = np.argsort(finite)
+    bound = np.empty(roots.shape, dtype=np.float64)
 
-    inside = np.clip(np.nan_to_num(roots, nan=0.5), 0.0, 1.0).astype(coeff.dtype)
-    with use_backend(Backend.PYTHON):
-        derivative = np.asarray(
-            Bezier(coeff.reshape(-1, 1)).evaluate_derivatives(inside, 1), dtype=np.float64
-        ).reshape(inside.size, -1)[:, 0]
+    for rank, index in enumerate(order):
+        root = float(finite[index])
+        left = 0.0 if rank == 0 else 0.5 * (root + float(finite[order[rank - 1]]))
+        right = 1.0 if rank + 1 == order.size else 0.5 * (root + float(finite[order[rank + 1]]))
+        half = _certified_half_width(coeff, root, left, right, eps)
+        bound[index] = param_tol if half is None else max(param_tol, 2.0 * half)
+        if half is None:
+            bound[index] = np.inf
 
-    slope = np.maximum(np.abs(derivative), np.finfo(np.float64).tiny)
-    # Capped at the multiplicity-three cluster width, exactly as the oracle's own
-    # merge radius is: at a double root the slope vanishes and the ratio diverges.
-    half_width = np.minimum(residual_error / slope, residual_error ** (1.0 / 3.0))
-    bound = np.maximum(np.full(roots.shape, param_tol, dtype=np.float64), 2.0 * half_width)
-    return np.asarray(bound, dtype=np.float64)
+    return bound
 
 
 def _both_backends(
@@ -333,22 +493,28 @@ def _assert_the_same_roots(
     worst = float(bound.max(initial=0.0))
     if worst >= PARAMETER_DOMAIN:
         # Rule 8: a parity claim is only defined where the quantity still has digits.
-        # Here the derived uncertainty covers the whole parameter interval, so there
-        # is nothing left to compare. Named and reported rather than skipped
-        # silently, and asserted to be a float32 phenomenon: the same bound reaching
-        # the domain at float64 would mean the derivation, not the arithmetic, is at
-        # fault.
-        assert case.coeff is not None and case.coeff.dtype == np.float32, (
-            f"{context}: the derived uncertainty {worst:.3e} covers the whole "
-            f"parameter domain at {None if case.coeff is None else case.coeff.dtype}. "
-            f"Outside float32 that is a defect in the derivation rather than a limit "
-            f"of the format."
+        # Two ways to get here and both are honest outcomes rather than escapes. The
+        # certificate may bound the component only by the whole interval, which is
+        # what happens when every coefficient is inside the acceptance band; or it
+        # may fail at every rung, which the caller marks as `inf`. Named and reported
+        # with its number, never absorbed.
+        #
+        # An earlier version asserted the dtype was float32 before allowing the skip,
+        # on the reasoning that a float64 case reaching here would mean the
+        # derivation was wrong. That was a proxy and it was false: the #352 regime
+        # reaches it at float64 for a reason that has nothing to do with the
+        # derivation, since below 1e-30 the oracle reads every coefficient as zero.
+        # `test_the_certificate_bounds_most_of_the_matrix` is the guard that a
+        # newly-slack bound cannot hide behind this branch.
+        reason = (
+            "no rung of the ladder certified it"
+            if not np.isfinite(worst)
+            else f"the certified width {worst:.3e} covers it"
         )
         pytest.skip(
-            f"{context}: outside the parity domain. The derived uncertainty "
-            f"{worst:.3e} covers the whole parameter interval, so the roots carry no "
-            f"digits to compare at this width. Bit-identical on the shipped build, "
-            f"where nothing fuses."
+            f"{context}: outside the parity domain. The acceptance component spans "
+            f"the parameter interval, {reason}, so the roots carry no digits to "
+            f"compare at this width. Bit-identical on the shipped build."
         )
 
     assert_parity(
@@ -643,3 +809,35 @@ def test_a_bound_reaching_the_whole_domain_is_refused() -> None:
     )
     with pytest.raises(AssertionError, match="vacuous"):
         assert_parity(tiny_root, tiny_root, vacuous, context="a bound covering the domain")
+
+
+def test_the_certificate_bounds_most_of_the_matrix(cpp_backend: None) -> None:
+    """The fused branch asserts something, rather than skipping its way to green.
+
+    Every case whose acceptance component cannot be bounded below the parameter
+    interval is skipped, with its reason. That is the right outcome per Rule 8 and it
+    is also a way for a slack bound to disappear quietly, so the rate is pinned here.
+
+    The figure is what the certificate achieves today over the hand-built matrix. A
+    change that moves it is the thing to look at; it is not a number to update.
+    """
+    del cpp_backend
+    certified = total = 0
+    for dtype in DTYPES:
+        for degree in DEGREES:
+            for kind in KINDS:
+                coeff = _polynomial(degree, dtype, kind)
+                with use_backend(Backend.PYTHON):
+                    roots = np.asarray(find_roots(Bezier(coeff.reshape(-1, 1)), tol=TOL))
+                if roots.size == 0:
+                    continue
+                total += 1
+                bound = _root_uncertainty(coeff, roots, TOL)
+                certified += float(bound.max(initial=0.0)) < PARAMETER_DOMAIN
+
+    assert total >= 40, f"only {total} cases have any root, so the rate means little"
+    assert certified >= 0.75 * total, (
+        f"the certificate bounded only {certified} of {total} cases below the "
+        f"parameter interval. Every one that fails is skipped on a fusing build, so "
+        f"a rate this low means the fused claim covers little of the matrix."
+    )

--- a/tests/parity/test_bezier_root_finding.py
+++ b/tests/parity/test_bezier_root_finding.py
@@ -1,0 +1,645 @@
+"""Parity of the root-finding block: what the two backends must agree on, and why.
+
+Sixteen kernels, all iterative, reached through six dispatch points. Unlike the
+arithmetic block next door, every result here carries a **discrete verdict** as well
+as a value: how many roots there are. A tolerance bounds a value and says nothing
+about a count, so the two are asserted separately throughout, and the count is never
+folded into a numeric claim.
+
+The claim, and the one place it is not an equality
+--------------------------------------------------
+
+**On the shipped build the claim is bitwise**, and that is not a hope. The target
+carries no ``-march``, so baseline ``x86-64`` has no fused multiply-add and nothing to
+contract into; every operation on both sides is a correctly rounded add, subtract,
+multiply, divide or compare, and the C++ reproduces the oracle's per-expression widths
+(``scripts/measure_root_finding_widths.py`` measures those and is the specification the
+transliteration was written against).
+
+**On a fusing build the values move and the sets do not.** Measured rather than
+assumed, by building the extension at ``-march=native`` and comparing 732 public
+results against the Numba oracle: 619 identical, 113 displaced, and **zero changed the
+root set**. The worst displacement was ``4.951e-13`` against a ``param_tol`` of
+``1e-12``.
+
+That ratio is the derivation rather than a coincidence. Both backends run the same
+bracketing iteration and stop when ``hi - lo <= param_tol``, returning ``0.5 * (lo +
+hi)``. A midpoint of a bracket of width at most ``param_tol`` that contains a root is
+within ``param_tol / 2`` of that root, so two such answers for the same root differ by
+at most ``param_tol``. The observed worst is ``0.495`` of that, which is the bound
+being approached rather than merely respected.
+
+So the fused claim is the **algorithm's own termination tolerance**, not a
+floating-point bound: it does not grow with degree, it does not depend on the
+coefficient magnitudes, and it would hold between two runs of the same backend that
+happened to take different bracket paths.
+
+What the fused claim does **not** cover, and this is stated rather than hidden: it
+assumes both backends found the same roots. Contraction can flip the convex-hull
+tie-break, which changes which vertices survive and so which interval is clipped, and
+that is demonstrable at the predicate level. It did not change a single count in 732
+results, but 732 results are evidence and not a proof, so the count agreement is
+asserted as its own check and Rule 11 of ``design/backend_parity.md`` records that it
+is measured rather than derived.
+
+Two defects are asserted, not worked around
+-------------------------------------------
+
+The oracle returns a wrong answer in two regimes, filed as FELIGN/pantr#351 and #352,
+and the C++ reproduces both deliberately because the port's contract is parity and not
+correction. The tests below name them. **If you are here because one of them started
+failing, the fix is in both backends and in these tests together**; making one side
+correct on its own is what breaks the equality this file exists to hold.
+"""
+
+from __future__ import annotations
+
+from typing import Final, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bezier import Bezier, find_monotone_root, find_roots
+from tests._parity_harness import (
+    assert_parity,
+    bitwise_parity,
+    contraction_may_fuse,
+    converged_parity,
+    demand_the_compiled_kernel,
+    unit_roundoff,
+)
+
+DTYPES: Final = (np.float64, np.float32)
+"""The two storage formats the root finder accepts."""
+
+DEGREES: Final = (1, 2, 3, 5, 6, 8, 11, 17)
+"""Degrees swept by the single-polynomial tests.
+
+1 is the base case every Yuksel recursion bottoms out in, and the sharpest width in
+the block. 5 and 6 straddle ``_CLIP_MIN_DEGREE``, so the pair exercises both arms of
+the dispatch on otherwise identical data. 17 is deep enough that the derivative chain
+has fifteen levels.
+"""
+
+TOL: Final = 1e-12
+"""The tolerance every test passes explicitly.
+
+Explicit rather than defaulted because it is the bound in the fused claim: the
+displacement between backends is at most one ``param_tol``, so a test that let the
+default vary by dtype would be asserting two different bounds under one name.
+"""
+
+DEFECT_TOL: Final = 1e-40
+"""The tolerance the two defect tests pass, and why it is not :data:`TOL`.
+
+Both defects live at coefficient magnitudes around ``1e-25`` and ``1e-31``, and
+:func:`pantr.bezier._find_roots._dispatch_single` rejects a polynomial outright when
+``all(abs(coeff) <= geom_tol)``. At ``TOL`` that guard fires first, both backends
+return an empty array, they agree, and the test passes **without reaching the defect
+at all**. A tolerance below the coefficients is what makes these tests able to fail.
+"""
+
+_BITWISE_WHY: Final = (
+    "every operation in the block is a correctly rounded add, subtract, multiply, "
+    "divide or compare, and the C++ reproduces the oracle's per-expression widths, "
+    "which scripts/measure_root_finding_widths.py measures. The one library call is "
+    "the dedup radius cap, where std::pow reproduces numba's ** on every tolerance "
+    "tested. Nothing rounds twice and nothing is reassociated, so the two backends "
+    "compute the same sequence of correctly rounded results"
+)
+"""Why the two backends are bit-identical where nothing can fuse."""
+
+_FUSED_WHY: Final = (
+    "a root is located only to within the interval where the COMPUTED residual is "
+    "indistinguishable from zero, which has half-width eps_f / |f'(r)| for an "
+    "evaluation whose forward error is eps_f. Two backends whose residuals differ "
+    "within eps_f may return any point of that interval, so their roots differ by at "
+    "most twice it. Below that scale the bracketing tolerance also applies, so the "
+    "bound is the larger of the two. De Casteljau is a convex combination at every "
+    "stage, so it neither amplifies nor cancels and eps_f is (degree + 1) roundings "
+    "at the COEFFICIENT width times the coefficient magnitude -- the coefficient "
+    "width, not float64, because the triangle stores back into a buffer of the input "
+    "dtype at every step. The half-width is capped at eps_f^(1/3), the cluster width "
+    "around a root of multiplicity up to three, which is the same cap and the same "
+    "reasoning _dedup_roots_core uses for its merge radius; without it a double root, "
+    "where f' vanishes, would carry an unbounded tolerance"
+)
+"""Why a fusing build still agrees, and to what.
+
+**An earlier version of this claimed the bound was `param_tol` alone**, derived from
+both backends returning a bracket midpoint. That was fitted to float64 data, where
+``eps_f / |f'|`` is around 1e-15 and ``param_tol`` of 1e-12 hides it. At float32 the
+residual term is four orders larger and dominates: a degree-5 case moved by 2e-8. The
+measurement that produced the wrong bound, 732 float64-heavy results with a worst
+displacement of 4.951e-13, was consistent with it and could not have refuted it.
+"""
+
+
+def _polynomial(degree: int, dtype: npt.DTypeLike, kind: str) -> npt.NDArray[np.floating]:
+    """Build one adversarial coefficient vector.
+
+    Args:
+        degree (int): Polynomial degree; the vector has ``degree + 1`` entries.
+        dtype (npt.DTypeLike): Storage format.
+        kind (str): Which adversary. See :data:`KINDS` for what each one attacks.
+
+    Returns:
+        npt.NDArray[np.floating]: Bernstein coefficients on [0, 1].
+    """
+    index = np.arange(degree + 1, dtype=np.float64)
+    if kind == "collinear":
+        # Every orientation test in the hull's monotone chain is an exact tie here,
+        # which is the configuration contraction destroys.
+        coeff = 1.0 - 2.0 * index / max(degree, 1)
+    elif kind == "sign_changes":
+        coeff = np.cos(np.pi * index / max(degree, 1) * 3.0)
+    elif kind == "double_root":
+        centre = index / max(degree, 1) - 0.5
+        coeff = centre * centre
+    elif kind == "wide_range":
+        coeff = np.cos(index) * 10.0 ** (index - degree / 2.0)
+    elif kind == "endpoint_zeros":
+        coeff = np.sin(np.pi * index / max(degree, 1))
+    else:  # "monotone"
+        coeff = index / max(degree, 1) - 0.5
+    return np.asarray(coeff, dtype=dtype)
+
+
+KINDS: Final = (
+    "collinear",
+    "sign_changes",
+    "double_root",
+    "wide_range",
+    "endpoint_zeros",
+    "monotone",
+)
+"""What each adversary attacks.
+
+``collinear`` is the one this block was written for: a straight control polygon makes
+every hull orientation test an exact tie, and an exact tie is what contraction turns
+into a signed residue. ``double_root`` reaches the bisection refinement, which is the
+only branch that uses the third of the three sign-test-by-product sites.
+``wide_range`` crosses ``_CLIP_COEFF_RANGE_LIMIT`` so the dispatch declines clipping.
+"""
+
+
+class Case(NamedTuple):
+    """What is being compared, so the assertion helper takes one argument for it.
+
+    Attributes:
+        coeff (npt.NDArray[np.floating] | None): The polynomial, which sizes the
+            residual term of the fused bound. None where the caller has no single
+            polynomial to name, in which case the bound falls back to the bracketing
+            term alone and the claim is weaker than it could be.
+        tol (float): The bracketing tolerance the call ran at.
+    """
+
+    coeff: npt.NDArray[np.floating] | None
+    tol: float
+
+
+PARAMETER_DOMAIN: Final = 1.0
+"""The scale a root is meaningful against, and it is not the root's own magnitude.
+
+Every root here is a curve parameter confined to [0, 1]. The harness's vacuity guard
+otherwise compares a bound against the values it is applied to, which is right for a
+coefficient and wrong for a parameter: a root at ``3.6e-13`` is not a quantity with no
+digits, it is a parameter sitting next to an endpoint, and a bound of ``1e-12`` on it
+still says something a wrong answer would violate.
+
+Measured while getting this wrong: with the root's own magnitude as the scale, two
+cases of the seeded sweep were refused as vacuous **while the two backends agreed
+bit for bit**.
+
+How loose the fused bound gets, honestly. For coefficients spanning eight decades at
+``float32`` it reaches ``1.067e-01`` at degree 8, a tenth of the domain: weak, but a
+wrong answer would still violate it, so it is asserted rather than excluded. By degree
+17 the same family reaches ``9.5``, which covers the whole interval and asserts
+nothing; that case is skipped, named, with its number in the message, which is what
+Rule 8 of ``design/backend_parity.md`` asks for. Both are the accuracy limit of the
+problem at that width rather than a parity failure, and both are bit-identical on the
+shipped build.
+"""
+
+
+def _root_uncertainty(
+    coeff: npt.NDArray[np.floating], roots: npt.NDArray[np.float64], param_tol: float
+) -> npt.NDArray[np.float64]:
+    """Elementwise bound on how far two backends' versions of one root may sit apart.
+
+    See :data:`_FUSED_WHY` for the derivation. The derivative is taken from the
+    oracle at the oracle's own roots, which is the only derivative available: an
+    exact one would need the root, which is what is being bounded.
+
+    Args:
+        coeff (npt.NDArray[np.floating]): The polynomial's Bernstein coefficients,
+            whose dtype sets the evaluation's rounding unit.
+        roots (npt.NDArray[np.float64]): The oracle's roots.
+        param_tol (float): The bracketing tolerance the call ran at.
+
+    Returns:
+        npt.NDArray[np.float64]: One bound per root.
+    """
+    if roots.size == 0:
+        return np.zeros(0, dtype=np.float64)
+
+    degree = coeff.size - 1
+    scale = float(np.max(np.abs(coeff), initial=0.0))
+    residual_error = float(degree + 1) * unit_roundoff(coeff.dtype) * scale
+
+    inside = np.clip(np.nan_to_num(roots, nan=0.5), 0.0, 1.0).astype(coeff.dtype)
+    with use_backend(Backend.PYTHON):
+        derivative = np.asarray(
+            Bezier(coeff.reshape(-1, 1)).evaluate_derivatives(inside, 1), dtype=np.float64
+        ).reshape(inside.size, -1)[:, 0]
+
+    slope = np.maximum(np.abs(derivative), np.finfo(np.float64).tiny)
+    # Capped at the multiplicity-three cluster width, exactly as the oracle's own
+    # merge radius is: at a double root the slope vanishes and the ratio diverges.
+    half_width = np.minimum(residual_error / slope, residual_error ** (1.0 / 3.0))
+    bound = np.maximum(np.full(roots.shape, param_tol, dtype=np.float64), 2.0 * half_width)
+    return np.asarray(bound, dtype=np.float64)
+
+
+def _both_backends(
+    call: str, coeff: npt.NDArray[np.floating], tol: float = TOL
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Run one public entry point under each backend.
+
+    Args:
+        call (str): ``"roots"`` or ``"monotone"``.
+        coeff (npt.NDArray[np.floating]): 1-D Bernstein coefficients.
+        tol (float): Root-finding tolerance. Defaults to :data:`TOL`.
+
+    Returns:
+        tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]: The oracle's result
+            and the C++ one, in that order.
+    """
+    curve = Bezier(coeff.reshape(-1, 1))
+    with use_backend(Backend.PYTHON):
+        reference = (
+            find_roots(curve, tol=tol)
+            if call == "roots"
+            else np.array([find_monotone_root(curve, tol=tol)], dtype=np.float64)
+        )
+    with use_backend(Backend.CPP):
+        actual = (
+            find_roots(curve, tol=tol)
+            if call == "roots"
+            else np.array([find_monotone_root(curve, tol=tol)], dtype=np.float64)
+        )
+    return np.asarray(reference, dtype=np.float64), np.asarray(actual, dtype=np.float64)
+
+
+def _assert_the_same_roots(
+    actual: npt.NDArray[np.float64],
+    reference: npt.NDArray[np.float64],
+    context: str,
+    case: Case,
+) -> None:
+    """Assert the two backends agree, on the count first and then on the values.
+
+    The count is checked on its own rather than folded into the numeric claim,
+    because no tolerance bounds a verdict: two backends that find a different number
+    of roots have not disagreed by a small amount, they have disagreed about what is
+    true. On a fusing build that is the one outcome this file's claim does not cover.
+
+    Args:
+        actual (npt.NDArray[np.float64]): The C++ backend's roots.
+        reference (npt.NDArray[np.float64]): The oracle's roots.
+        context (str): What was being computed, quoted in a failure message.
+        case (Case): The polynomial and the tolerance the call ran at.
+    """
+    assert actual.shape == reference.shape, (
+        f"{context}: the backends found different numbers of roots, "
+        f"{actual.size} against {reference.size}. That is a changed verdict rather "
+        f"than a displaced value, and no tolerance covers it. Rule 11 of "
+        f"design/backend_parity.md records that contraction can flip the convex-hull "
+        f"tie-break; if this build fuses, that is the first thing to check."
+    )
+
+    if not contraction_may_fuse():
+        assert_parity(actual, reference, bitwise_parity(why=_BITWISE_WHY), context=context)
+        return
+
+    bound = (
+        np.full(actual.shape, case.tol, dtype=np.float64)
+        if case.coeff is None
+        else _root_uncertainty(case.coeff, reference, case.tol)
+    )
+
+    worst = float(bound.max(initial=0.0))
+    if worst >= PARAMETER_DOMAIN:
+        # Rule 8: a parity claim is only defined where the quantity still has digits.
+        # Here the derived uncertainty covers the whole parameter interval, so there
+        # is nothing left to compare. Named and reported rather than skipped
+        # silently, and asserted to be a float32 phenomenon: the same bound reaching
+        # the domain at float64 would mean the derivation, not the arithmetic, is at
+        # fault.
+        assert case.coeff is not None and case.coeff.dtype == np.float32, (
+            f"{context}: the derived uncertainty {worst:.3e} covers the whole "
+            f"parameter domain at {None if case.coeff is None else case.coeff.dtype}. "
+            f"Outside float32 that is a defect in the derivation rather than a limit "
+            f"of the format."
+        )
+        pytest.skip(
+            f"{context}: outside the parity domain. The derived uncertainty "
+            f"{worst:.3e} covers the whole parameter interval, so the roots carry no "
+            f"digits to compare at this width. Bit-identical on the shipped build, "
+            f"where nothing fuses."
+        )
+
+    assert_parity(
+        actual,
+        reference,
+        converged_parity(bound=bound, scale=PARAMETER_DOMAIN, why=_FUSED_WHY),
+        context=context,
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+@pytest.mark.parametrize("kind", KINDS)
+def test_find_roots_matches_the_oracle(
+    cpp_backend: None, degree: int, kind: str, dtype: npt.DTypeLike
+) -> None:
+    """The two backends find the same roots of the same polynomial."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    coeff = _polynomial(degree, dtype, kind)
+    reference, actual = _both_backends("roots", coeff)
+    _assert_the_same_roots(
+        actual,
+        reference,
+        f"find_roots, {kind}, degree {degree}, {dtype}",
+        Case(coeff, TOL),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+def test_find_monotone_root_matches_the_oracle(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The two backends solve the same monotone polynomial identically."""
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    coeff = _polynomial(degree, dtype, "monotone")
+    reference, actual = _both_backends("monotone", coeff)
+    _assert_the_same_roots(
+        actual,
+        reference,
+        f"find_monotone_root, degree {degree}, {dtype}",
+        Case(coeff, TOL),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("degree", DEGREES)
+def test_the_batch_path_matches_the_oracle(
+    cpp_backend: None, degree: int, dtype: npt.DTypeLike
+) -> None:
+    """The batch entry points agree row by row, counts included.
+
+    The batch kernels are the only ones in the block where the Numba side is
+    ``parallel=True`` and the C++ side is serial. Each polynomial writes only its own
+    row and no reduction crosses them, so the thread count cannot move a result and
+    this is a parity test rather than a reproducibility one; it is here to hold that
+    property rather than to discover it.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    curves = [Bezier(_polynomial(degree, dtype, kind).reshape(-1, 1)) for kind in KINDS]
+
+    with use_backend(Backend.PYTHON):
+        reference_roots, reference_counts = find_roots(curves, tol=TOL)
+        reference_mono = find_monotone_root(curves, tol=TOL)
+    with use_backend(Backend.CPP):
+        actual_roots, actual_counts = find_roots(curves, tol=TOL)
+        actual_mono = find_monotone_root(curves, tol=TOL)
+
+    np.testing.assert_array_equal(
+        actual_counts,
+        reference_counts,
+        err_msg=f"batch root counts, degree {degree}, {dtype}: a changed verdict, "
+        "which no tolerance covers",
+    )
+
+    # Only the prefix of each row is contractual; the rest is the NaN the caller
+    # pre-filled, and comparing it would be comparing untouched memory.
+    for row, count in enumerate(reference_counts):
+        _assert_the_same_roots(
+            np.asarray(actual_roots[row, :count], dtype=np.float64),
+            np.asarray(reference_roots[row, :count], dtype=np.float64),
+            f"batch find_roots row {row}, degree {degree}, {dtype}",
+            Case(_polynomial(degree, dtype, KINDS[row]), TOL),
+        )
+
+    _assert_the_same_roots(
+        np.asarray(actual_mono, dtype=np.float64),
+        np.asarray(reference_mono, dtype=np.float64),
+        f"batch find_monotone_root, degree {degree}, {dtype}",
+        Case(None, TOL),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_backends_agree_on_the_root_that_is_not_there(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """Both backends reproduce FELIGN/pantr#351, and that is the assertion.
+
+    `find_monotone_root` reports a root of a strictly positive polynomial when the
+    coefficients are small enough at ``float32``: the no-sign-change guard is written
+    as ``f_lo * f_hi > 0.0`` on two ``float32`` values, their product falls under that
+    format's minimum subnormal and rounds to zero, and the guard does not fire.
+
+    **This test asserts a wrong answer on purpose.** The C++ reproduces the defect
+    because the port's contract is parity, not correction. When #351 is fixed, it is
+    fixed in both backends and here in one change; correcting one side alone breaks
+    the equality rather than improving anything.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    coeff = np.array([1e-25, 0.5e-25, 2e-25], dtype=dtype)
+    reference, actual = _both_backends("monotone", coeff, DEFECT_TOL)
+
+    if dtype is np.float32:
+        assert np.isfinite(reference[0]), (
+            "the defect is gone from the oracle. If #351 was fixed, fix the C++ and "
+            "this test in the same change rather than relaxing either."
+        )
+    else:
+        assert np.isnan(reference[0]), "float64 is wide enough that the guard fires"
+
+    _assert_the_same_roots(actual, reference, f"the #351 regime, {dtype}", Case(coeff, DEFECT_TOL))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_backends_agree_on_the_root_that_is_lost(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """Both backends reproduce the second face of FELIGN/pantr#351.
+
+    ``B(t) = a(1 - 2t)`` has its only root at ``t = 0.5``. At ``float32`` with
+    ``a = 1e-25`` the sign-change test ``f_prev * f_curr < 0.0`` underflows, no sign
+    change is seen, and the root is lost. See the note on the sibling test: the
+    assertion is deliberate.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    coeff = np.array([1e-25, 0.0, -1e-25], dtype=dtype)
+    reference, actual = _both_backends("roots", coeff, DEFECT_TOL)
+
+    if dtype is np.float32:
+        assert reference.size == 0, (
+            "the defect is gone from the oracle. If #351 was fixed, fix the C++ and "
+            "this test in the same change rather than relaxing either."
+        )
+    else:
+        np.testing.assert_allclose(reference, [0.5], atol=TOL)
+
+    _assert_the_same_roots(
+        actual,
+        reference,
+        f"the lost-root face of #351, {dtype}",
+        Case(coeff, DEFECT_TOL),
+    )
+
+
+def test_the_backends_agree_where_the_tolerance_stops_scaling(cpp_backend: None) -> None:
+    """Both backends reproduce FELIGN/pantr#352, at ``float64``.
+
+    ``boundary_eps`` carries an absolute ``1e-30`` floor inside an otherwise
+    scale-relative tolerance, so below it every coefficient reads as zero, the
+    endpoints are reported as roots and the real one is lost. Rescaling the same
+    polynomial moves the answer, which is what makes it a defect rather than a limit.
+
+    Asserted here for the same reason as #351: the C++ reproduces it, and both sides
+    change together or not at all.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(np.float64)
+
+    for scale, expected in ((1e-29, [0.5]), (1e-31, [0.0, 1.0])):
+        coeff = np.array([scale, 0.0, -scale], dtype=np.float64)
+        reference, actual = _both_backends("roots", coeff, DEFECT_TOL)
+        np.testing.assert_allclose(
+            reference,
+            expected,
+            atol=TOL,
+            err_msg=f"the oracle changed at scale {scale:.0e}; if #352 was fixed, fix "
+            "the C++ and this test in the same change",
+        )
+        _assert_the_same_roots(
+            actual,
+            reference,
+            f"the #352 regime at scale {scale:.0e}",
+            Case(coeff, DEFECT_TOL),
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_seeded_sweep_matches_the_oracle(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """The two backends agree over a seeded sweep of random polynomials.
+
+    The families above are hand-built to attack one mechanism each, which means they
+    can only find what someone thought of. This is the breadth complement: 240
+    polynomials over eight degrees, four generators each, drawn from a fixed seed so
+    a failure is reproducible.
+
+    It is the cross-check that validated the transliteration before any binding
+    existed, moved into the suite so it runs on every commit rather than once on one
+    machine.
+    """
+    del cpp_backend
+    demand_the_compiled_kernel(dtype)
+
+    rng = np.random.default_rng(20260824)
+    for degree in DEGREES:
+        for trial in range(30):
+            base: npt.NDArray[np.floating] = rng.standard_normal(degree + 1)
+            if trial % 4 == 1:
+                # A straight control polygon: every hull orientation test is a tie.
+                base = rng.standard_normal() + rng.standard_normal() * np.arange(degree + 1)
+            elif trial % 4 == 2:
+                # Sorted, so a sign change is guaranteed and the solver runs.
+                base = np.sort(base)
+            elif trial % 4 == 3:
+                base = base * 10.0 ** rng.integers(-6, 7, size=degree + 1)
+            coeff = np.asarray(base, dtype=dtype)
+
+            reference, actual = _both_backends("roots", coeff)
+            _assert_the_same_roots(
+                actual,
+                reference,
+                f"seeded sweep, degree {degree}, trial {trial}, {dtype}",
+                Case(coeff, TOL),
+            )
+
+
+def test_a_changed_root_count_is_refused() -> None:
+    """The count check fires, and says why no tolerance would have caught it.
+
+    The helper's first assertion is the one nothing else in the harness covers, so
+    it needs its own probe: a bounded claim compares elementwise and cannot see two
+    results of different length at all.
+    """
+    with pytest.raises(AssertionError, match="different numbers of roots"):
+        _assert_the_same_roots(
+            np.array([0.25, 0.75]),
+            np.array([0.25]),
+            "a fabricated count mismatch",
+            Case(None, TOL),
+        )
+
+
+def test_the_converged_bound_refuses_a_displacement_past_itself() -> None:
+    """The fused branch's bound is not vacuous, and rejects what it should.
+
+    Built unconditionally rather than behind ``contraction_may_fuse()``, because on
+    the shipped build that branch is never taken and an unexercised branch is how a
+    claim ships broken. This file's fused branch **did** ship broken during
+    development: it called ``bounded_parity`` with an argument that function does not
+    take, and 133 tests passed over it because none of them reached the branch.
+    """
+    reference = np.array([0.5])
+    inside = np.array([0.5 + 4e-13])
+    outside = np.array([0.5 + 4e-12])
+
+    claim = converged_parity(
+        bound=np.full(1, TOL), scale=PARAMETER_DOMAIN, why="a probe of the bound itself"
+    )
+
+    assert_parity(inside, reference, claim, context="a displacement inside the bound")
+    with pytest.raises(AssertionError, match="more than the derived bound"):
+        assert_parity(outside, reference, claim, context="a displacement past the bound")
+
+
+def test_a_bound_reaching_the_whole_domain_is_refused() -> None:
+    """The vacuity guard still fires, now against the domain rather than the value.
+
+    Two probes, because the change that made the near-endpoint roots pass could also
+    have disabled the guard entirely: a bound of one covers every parameter in [0, 1]
+    and must be refused, while a bound far under the domain must be accepted even
+    when it exceeds the root's own magnitude.
+    """
+    tiny_root = np.array([3.6e-13])
+
+    accepted = converged_parity(
+        bound=np.full(1, TOL), scale=PARAMETER_DOMAIN, why="a probe of the domain premise"
+    )
+    assert_parity(tiny_root, tiny_root, accepted, context="a root next to an endpoint")
+
+    vacuous = converged_parity(
+        bound=np.full(1, PARAMETER_DOMAIN), scale=PARAMETER_DOMAIN, why="a probe of the guard"
+    )
+    with pytest.raises(AssertionError, match="vacuous"):
+        assert_parity(tiny_root, tiny_root, vacuous, context="a bound covering the domain")

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -22,7 +22,7 @@ from pantr.bezier import (
 )
 from pantr.bezier._clipping_core import (
     _clip_roots_core,
-    _dedup_roots,
+    _dedup_roots_core,
 )
 from pantr.bezier._find_roots import _validate_coeff_array
 from pantr.bezier._root_finding_core import (
@@ -243,7 +243,7 @@ class TestYukselRoots(unittest.TestCase):
 
 
 class TestClipRootsCore(unittest.TestCase):
-    """Tests for :func:`_clip_roots_core` and :func:`_dedup_roots`."""
+    """Tests for :func:`_clip_roots_core` and :func:`_dedup_roots_core`."""
 
     def _find_roots_clip(
         self,
@@ -257,7 +257,11 @@ class TestClipRootsCore(unittest.TestCase):
         if np.all(np.abs(c) <= geom_tol):
             return np.empty(0, dtype=np.float64)
         raw, n = _clip_roots_core(c, param_tol, geom_tol)
-        return _dedup_roots(raw, n, c, param_tol, geom_tol)
+        if n == 0:
+            return np.empty(0, dtype=np.float64)
+        merged, count = _dedup_roots_core(raw, n, c, param_tol, geom_tol)
+        unique: npt.NDArray[np.float64] = merged[:count].copy()
+        return unique
 
     def test_linear_single_root(self) -> None:
         """Degree-1: root at t = 0.2."""

--- a/tests/test_root_finding_stress.py
+++ b/tests/test_root_finding_stress.py
@@ -20,7 +20,7 @@ import pytest
 from numpy import typing as npt
 
 from pantr.bezier import Bezier, find_roots
-from pantr.bezier._clipping_core import _clip_roots_core, _dedup_roots
+from pantr.bezier._clipping_core import _clip_roots_core, _dedup_roots_core
 from pantr.bezier._root_finding_core import _de_casteljau_eval_scalar
 from pantr.bezier._yuksel_core import _yuksel_roots
 
@@ -151,7 +151,11 @@ def _find_roots_clipping(
     if len(coeff) < 2 or np.all(np.abs(coeff) <= tol):
         return np.empty(0, dtype=np.float64)
     raw, count = _clip_roots_core(coeff, tol, tol)
-    return _dedup_roots(raw, count, coeff, tol, tol)
+    if count == 0:
+        return np.empty(0, dtype=np.float64)
+    merged, n_unique = _dedup_roots_core(raw, count, coeff, tol, tol)
+    unique: npt.NDArray[np.float64] = merged[:n_unique].copy()
+    return unique
 
 
 def _assert_roots_valid(


### PR DESCRIPTION
## Context

The second of `pantr.bezier`'s three ports: root finding. Sixteen Numba kernels across
`_root_finding_core.py`, `_clipping_core.py`, `_yuksel_core.py` and `_batch_core.py`, about
1900 lines, reached through six dispatch points.

Two things make this block different from the four ports before it. Every kernel is
**iterative**, so a result carries a discrete verdict as well as a value: how many roots there
are. And the block was the one carrying an open question from the arithmetic port, namely what
to do about `_de_casteljau_eval_scalar`, which a downstream consumer imports by its private
path in the module this port reorganises.

That question dissolved on inspection. All kernel-to-kernel calls here happen inside
`nopython`, so no catalogue can be inserted between two of them and the dispatch boundary is
forced up to `_find_roots.py`. `_root_finding_core.py` is not touched by this PR: its seven
kernels stay at their own module path, still imported by the two kernel modules above them, and
the consumer's import survives without anything being decided about it.

## Specification

Transliterate rather than reimplement, branch for branch and expression for expression. A
cleaner C++ would have to be graded by a set distance over a discrete verdict with the Numba
side as the only available reference, which is the weakest parity claim in the tree.
Reproducing the arithmetic buys an equality instead, and an equality is checked rather than
argued.

## Acceptance criteria

- [x] AC1: `PANTR_BACKEND=cpp` reaches `find_roots` and `find_monotone_root`, single and
      batched, at both dtypes.
- [x] AC2: The two backends are **bit-identical** on the shipped build. Verified end to end
      through the public API, each backend in its own process: 732 of 732 results identical
      over 244 polynomials.
- [x] AC3: The parity claim on a build that fuses is derived and **exercised**, not merely
      stated. The extension was built at `-march=native` and the suite run against it.
- [x] AC4: Root counts are asserted separately from values, since no tolerance bounds a verdict.
- [x] AC5: The arithmetic widths are measured rather than read, with a committed script and a
      discrimination count per site.
- [x] AC6: C++ property tests check the algorithm against mathematics and against a second
      algorithm, not against the other backend.
- [x] AC7: Full local suite green: 37/37 in `scripts/ci_local.sh`, plus ruff, ruff format, mypy,
      import-linter, 82 doctests and the docs build under `-W`.

## What is worth a reviewer's attention

**The widths, and why a script rather than a reading.** Numba's `float()` does not widen a
`float32`: `float(coeff[0])` reads as a promotion and is a no-op, and what widens is type
unification across assignments. Three of the five widths in this block are therefore narrower
than the source looks. The sharpest is the degree-1 base case `c0 / (c0 - c1)`, where the
`float64` model reproduced **none** of 20000 pairs, so the obvious C++ breaks parity on every
`float32` input and the difference reads as round-off. Two further sites look identical to those
and behave the opposite way. `scripts/measure_root_finding_widths.py` is the specification.

**The fused branch shipped broken, and that is the finding.** It called `bounded_parity` with an
argument that function does not take, and 133 tests passed over it because the shipped build
never reaches that branch. Building the fusing variant is cheap and found it in one run. The
same run refuted the first bound: 732 float64-heavy results gave a worst displacement of
`4.951e-13` against a `param_tol` of `1e-12`, tight enough to look like a correct derivation,
while at `float32` a degree-5 case moved by `2e-8`. The residual term the bound omitted is
invisible at `float64`.

**Two pre-existing defects are reproduced on purpose**, filed as #351 and #352 and asserted by
name in the parity suite. Neither is introduced here and the three files are byte-identical to
`main`. Fixing either means fixing both backends and those tests in one change; correcting one
side alone breaks the equality.

**A third parity kind in the harness.** A bound that comes from an algorithm's termination
criterion cannot be spelled with `bounded_parity`, which builds its bound from a rounding budget
times an amplification; reaching a given number that way would mean choosing an amplification to
produce it. `ParityKind.CONVERGED` carries an absolute bound and the scale its quantity lives on
— the second being needed because the vacuity guard's premise fails for a parameter confined to
[0, 1]: a root at `3.6e-13` is next to an endpoint, not a quantity without digits.

## Non-goals

- Performance. Nothing here has been profiled, and the C++ batch kernels are serial where the
  Numba ones carry `parallel=True`. Each polynomial writes only its own row and no reduction
  crosses them, so the answer cannot move with the thread count either way.
- Fixing #351 or #352.
- `_bezier_interpolate`, which is the third and last bezier port.

## Related

- Follows the arithmetic port and its FMA bound.
- Adds Rule 11 to `design/backend_parity.md` and a section to Rule 9.
- Surfaced #351 and #352, which this PR deliberately does not fix.
