### PR TITLE
perf(bezier): build the interpolation pseudo-inverse once per node set, and rule that the block stays in Python

### DIFF
--- a/design/_memory/MEMORY.md
+++ b/design/_memory/MEMORY.md
@@ -1,14 +1,14 @@
-- [Active task](active-task.md) — bezier's arithmetic and its FMA parity bound merged; two bezier blocks left, and how to pick an amplification.
-- [Where the decisions live](decisions-pointer.md) — the C++ port's design decisions are in `design/*.md`; five PRs merged, nothing in flight. Read backend_parity.md's ten rules before proposing anything about a bound.
+- [Active task](active-task.md) — bezier is closed: its last block was ruled NOT ported, PR #355 open and unmerged, grid is next.
+- [Where the decisions live](decisions-pointer.md) — the C++ port's design decisions are in `design/*.md`; six merged, #355 open. Read backend_parity.md's eleven rules before proposing anything about a bound, and bezier_interpolation_port.md before proposing a port.
 - [Working on proto/cpp](proto-cpp-pr-mechanics.md) — Closes #N never fires, a branch cut from it carries unpushed commits, and its CI is two jobs rather than eight.
 - [What the downstream consumer imports](downstream-consumer-surface.md) — measured at last: the PointsLattice debt is discharged, and bezier is the first port that touches symbols it uses.
 - [Naming constraint and licensing](naming-and-licensing.md) — two sibling libraries are private and unpublished; never name them in anything that leaves the machine. Plus the dependency direction the licence plan forbids.
 - [Unpushed corpus](unpushed-corpus.md) — claude-config is six commits ahead; do not push it, and why that costs something.
-- [Build machine](build-machine.md) — the shared Linux server, its 20-CPU cap, and the calibration trap that comes with many cores.
+- [Build machine](build-machine.md) — the shared Linux server, its 20-CPU cap, the calibration trap, and why every BLAS timing here must pin the threads first.
 - [nanobind status](nanobind-status.md) — split mode verified working and composing with multi-ISA; the three mandatory build flags, including the -Os trap that costs a silent 3x.
 - [Performance follow-up](performance-followup.md) — wanted later, deliberately deferred in the infrastructure PR; carries what is already measured so it is not re-measured, and what to attack first.
-- [Merge authority](merge-authority.md) — I may merge a port PR unasked when three conditions hold; the horizon ends with bezier, and agents are for review only.
+- [Merge authority](merge-authority.md) — the three conditions still stand, but the horizon dissolved when block C was ruled not-ported. Re-ask before merging.
 - [How to ask me things](asking-style.md) — one question at a time, with concrete options AND an explicit recommendation, and the counter-argument written into the other options.
-- [Reviewing my own measurements](reviewing-my-own-measurements.md) — my prose fails far more often than my code, five cycles running; the newest is a justification that went stale inside one session because the code moved under it.
+- [Reviewing my own measurements](reviewing-my-own-measurements.md) — six cycles; the newest inverts the pattern, a speedup that was thread noise on a cache that was not even on the call path. Give a cache a hit counter before a benchmark.
 - [Expired guard rationales](expired-guard-rationales.md) — a fence whose stated reason no longer holds is not a constraint; check the reason, not just the guard.
 - [Dispatching agents](dispatching-agents.md) — a brief is not an isolation mechanism; anything that mutates or measures needs its own worktree.

--- a/design/_memory/active-task.md
+++ b/design/_memory/active-task.md
@@ -1,20 +1,35 @@
 ---
 name: active-task
-description: bezier's root-finding block merged; block C (interpolation) is next, and what the review of block B established
+description: bezier is closed; block C was ruled NOT ported and the reason is measured, PR #355 open. The merge authority's stated terminus no longer exists.
 metadata:
   type: project
 ---
 
-**Updated 2026-08-24.** `bezier`'s root-finding block is **merged** (#353, six PRs now on
-`proto/cpp`). Remaining in `bezier`: **block C, `_bezier_interpolate`**, 756 lines, no kernels,
-an SVD pseudo-inverse of a Bernstein Vandermonde with **rank truncation** whose threshold is
-discontinuous. Checkable, because the matrices are deterministic per degree: verify no singular
-value sits within a few eps of the threshold. First use of Eigen outside `change_basis`.
+**Updated 2026-08-24.** `bezier` is **closed**, but not the way it was planned. Blocks A (#348),
+the FMA bound (#349) and B (#353) are merged ports. **Block C, interpolation, was ruled NOT
+ported**, and PR **#355** carries that ruling plus the thing that turned out to be worth doing.
 
-The question block B opened is **closed and it dissolved**: `_de_casteljau_eval_scalar` never had
-to move. All kernel-to-kernel calls in that block are inside `nopython`, so no catalogue can be
-inserted between two of them and the dispatch boundary is forced up to `_find_roots.py`. See
-[[downstream-consumer-surface]].
+**The reasoning is in `design/bezier_interpolation_port.md`** and reproducible from
+`scripts/measure_bezier_interpolation_port.py`. Short form: the blocker everyone expected
+(Eigen and LAPACK disagreeing about the truncation rank, a discrete verdict no tolerance bounds)
+**does not fire** on the real matrices, twelve cases including the two tightest. But nothing
+positive replaced it. Eigen's SVD is not faster; the downstream consumer imports neither entry
+point and never passes float32, which is the only regime the truncation fires in; the scattered
+site is shared with out-of-scope `bspline`; and once the factorization is memoized the numerical
+work C++ would replace is **about 7% of a warm call**, the rest being Python including a callable
+the API is handed.
+
+**What shipped instead:** `_build_bernstein_pinv`, the one site both public entry points reach,
+is memoized on the nodes' bytes. Bitwise identical, three to eight times faster with threads
+pinned.
+
+**A ruling is owed.** The merge authority granted 2026-08-24 says it "expires when block C
+lands". Block C is not landing as a port, so its terminus no longer exists. #355 is also not a
+port PR and carries no parity claim, so its conditions do not really apply either. It was left
+unmerged deliberately. See [[merge-authority]].
+
+**Next after this is `grid`**, which needs a fresh ruling anyway: the BVH's inclusive-face tie
+contract produces a discrete verdict no tolerance bounds, the same family as Rule 11.
 
 **What block B's review established, and it is the reusable part:**
 
@@ -33,23 +48,20 @@ inserted between two of them and the dispatch boundary is forced up to `_find_ro
 - **Numba's `float()` does not widen a `float32`.** Type unification across assignments does.
   Three of six measured widths follow from that alone.
 
-**Two facts to carry into block C and into grid.** `scripts/measure_root_finding_widths.py` is
-the shape a port's specification should take: rival models per site, measured against the kernel,
-with a discrimination count so a match cannot come from a check that could not fail. And
-`design/backend_parity.md` now has **eleven** rules; Rule 11 is the first about a discrete verdict
+**Two facts to carry into grid.** `scripts/measure_root_finding_widths.py` is the shape a port's
+specification should take: rival models per site, measured against the kernel, with a
+discrimination count so a match cannot come from a check that could not fail. And
+`design/backend_parity.md` has **eleven** rules; Rule 11 is the first about a discrete verdict
 rather than a displacement.
-
-**Block C reconnaissance, already measured, do not repeat it.** `_bezier_interpolate.py` truncates
-at `sigma_i < 100 * eps * sigma_0`. At **float64 that branch is dead** up to n=39, closest approach
-350x. At **float32 it fires from n=19**, and at n=36 a singular value sits **0.22% above the
-threshold**, which two SVD implementations will not agree on. When the rank differs the
-pseudo-inverse moves by a rank-1 term of order `1/(tol*sigma_0)`: a verdict, not a displacement.
-The open question that may change everything is whether the pseudo-inverse is **cached**; if the
-SVD runs once per degree per process, not porting this block is a serious option.
 
 **Three tickets filed 2026-08-24**, all pre-existing and none fixed: #351, #352, #354. All three
 are tolerance-derivation defects in the same kernels and one coherent rework may close all three.
 The C++ reproduces #351 and #352 deliberately, asserted by name.
 
 **One review finding downgraded rather than fixed:** `ParityClaim` carries optional fields
-meaningful for one variant. Pre-existing for four; this port added two more.
+meaningful for one variant. Pre-existing for four; block B added two more.
+
+**One piece of doc rot left alone deliberately:** `_bezier_interpolate.py`'s module docstring
+says its helpers serve "the resultant pipeline". No such pipeline exists in the repo, and
+`_bernstein_interpolate` has no caller there outside tests. Either stale or naming an out-of-tree
+consumer; not establishable from this machine.

--- a/design/_memory/build-machine.md
+++ b/design/_memory/build-machine.md
@@ -39,3 +39,26 @@ rules make it report findings that do not exist for CI, which resolves the pin: 
 ruff` is not the lint CI runs.** The checkout's own `.venv/bin/ruff` has 0.12.12 installed
 for exactly this.
 
+
+
+## Threaded OpenBLAS destroys small-matrix timings here, 2026-08-24
+
+With the env's `OPENBLAS_NUM_THREADS=20`, a **36-by-36 LAPACK SVD** cost between one and two
+orders of magnitude more than the same call pinned to one thread, and its timing varied by
+nearly an order of magnitude between batches. Twenty threads synchronizing over a matrix that
+fits in L1 is pure overhead, and the box is shared, so the contention is real rather than
+theoretical.
+
+This is not the "OpenBLAS spawns 128 threads" trap: the variables are set correctly to 20. It
+is that 20 threads on a tiny dense factorization is simply the wrong configuration, and the cap
+does not save you from it.
+
+**How to apply: pin the threads before timing anything that calls into BLAS or LAPACK on a small
+matrix** (`OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1`). Unpinned numbers here
+are noise, and noise that happens to look like a speedup: an unpinned measurement of a cache was
+quoted as a 2.9x win in this repo before a pinned re-run showed the cache was not even on the
+call path. `scripts/measure_bezier_interpolation_port.py` refuses to run unpinned for this
+reason, which is the shape any future timing script should copy.
+
+A separate consequence for the port: a **single-threaded C++ implementation compared against
+threaded LAPACK on this box would look far better than it is**. Never take that comparison.

--- a/design/_memory/decisions-pointer.md
+++ b/design/_memory/decisions-pointer.md
@@ -1,6 +1,6 @@
 ---
 name: decisions-pointer
-description: The C++ port's design decisions live in design/*.md; six PRs merged, nothing in flight, and backend_parity.md now has eleven rules
+description: The C++ port's design decisions live in design/*.md; six PRs merged and one open, bezier closed with its last block deliberately not ported
 metadata:
   type: project
 ---
@@ -30,8 +30,16 @@ Two decisions that govern everything else:
 
 **Status, 2026-08-24.** Six PRs are **merged** into `proto/cpp`: the build skeleton (#335),
 `quad` (#337), `change_basis` (#347), `bezier`'s arithmetic block (#348), its FMA parity bound
-(#349) and its root-finding block (#353). Nothing is in flight. One `bezier` PR remains,
-interpolation. See [[active-task]].
+(#349) and its root-finding block (#353). **PR #355 is open and unmerged**, and it is the first
+that decides *not* to port something: `design/bezier_interpolation_port.md` rules that
+`_bezier_interpolate.py` stays in Python, with the measurements behind it and what would reopen
+the question. `bezier` therefore closes as *ported except interpolation*. Next is `grid`. See
+[[active-task]] and [[merge-authority]].
+
+**That note is worth reading before proposing any further port**, because it is the template for
+declining one: it does not argue from taste, it measures the blocker (which did not fire), the
+speed (a wash), the reachable fraction (about 7% of a warm call) and the consumer's actual
+surface, and it records what would make the answer flip.
 
 **Eigen is a dependency of the shipped extension** as of #347, and that is the architectural
 decision this cycle added. It was test-only before, fenced off from `pantr::core` so that taking

--- a/design/_memory/merge-authority.md
+++ b/design/_memory/merge-authority.md
@@ -1,6 +1,6 @@
 ---
 name: merge-authority
-description: Standing authority to merge a port PR without asking, with three conditions and a horizon that ends when bezier is done
+description: Standing authority to merge a port PR without asking, with three conditions; its stated terminus dissolved when block C was ruled not-ported and it needs re-granting
 metadata:
   type: feedback
 ---
@@ -19,10 +19,18 @@ explain.
 hard stop that adds nothing when the three conditions already encode what he would check.
 Revert is cheap on a prototype branch, which is what makes the trade sane.
 
-**How to apply:** the horizon is **bezier only**, blocks B and C. It does **not** extend to
-`grid`, deliberately: the BVH's inclusive-face tie contract produces a discrete verdict that
+**How to apply:** the horizon was **bezier only**, blocks B and C, and it does **not** extend
+to `grid`, deliberately: the BVH's inclusive-face tie contract produces a discrete verdict that
 no tolerance bounds, and that decision goes to Pablo before it is frozen into a second
-implementation. Re-ask when bezier is done. See [[active-task]] and [[decisions-pointer]].
+implementation.
+
+**The horizon dissolved rather than expired, 2026-08-24.** Block C was ruled **not ported**
+(PR #355, `design/bezier_interpolation_port.md`), so the event the grant named as its terminus
+never happens. #355 itself was left **unmerged** and put to Pablo, on two grounds: it is not a
+port PR and carries no parity claim, so condition 3 has nothing to bite on; and this session's
+own rules forbid dispatching agents unless asked, so condition 1's review could not be run the
+way the grant assumes. **Re-ask before merging anything on `proto/cpp`.** See [[active-task]]
+and [[decisions-pointer]].
 
 Two related standing permissions granted at the same time:
 
@@ -30,7 +38,9 @@ Two related standing permissions granted at the same time:
   light for a bounded change with no new numerical content, deep for new public surface or
   new mathematics. Never for implementing. This resolves a real contradiction, since the
   standing rule since #347 is to review before merging a port while the session rule
-  forbade dispatching agents at all.
+  forbade dispatching agents at all. **Note it does not always survive:** a later session
+  carried an explicit "do not call the Agent tool unless the user requested it", which wins,
+  and then condition 1 above cannot be satisfied. Say so rather than merging unreviewed.
 - **Tickets are still approved before creation**, but **batched at each PR boundary**
   rather than interrupting. Something that *blocks* the port goes up immediately.
 

--- a/design/_memory/reviewing-my-own-measurements.md
+++ b/design/_memory/reviewing-my-own-measurements.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-my-own-measurements
-description: In numerical work my prose fails far more often than my code, because nothing checks prose
+description: In numerical work my prose fails far more often than my code, because nothing checks prose; six cycles, and the newest failure was a measurement rather than a claim
 metadata:
   node_type: memory
   type: feedback
@@ -160,3 +160,40 @@ And one about my own measurement, caught before it reached Pablo: my first vacui
 165 of 400, inflated by rows where the reference is exactly zero and both backends agree
 trivially. The honest count is 45 of 280. **Excluding the degenerate rows is part of the
 measurement, not a refinement of it.**
+
+
+## The interpolation cycle, 2026-08-24: the measurement itself was wrong, not the claim about it
+
+Sixth cycle, and it inverts the pattern. The previous five were prose failing while the numbers
+held. This time **the number was wrong at the source**, and the prose faithfully reported it.
+
+I measured a memoization at **1.09x to 2.88x** and reported it to Pablo as an input to a
+decision. Both halves of that were wrong:
+
+- It was taken **unpinned** on a 20-thread box, where a small LAPACK SVD's timing varies by
+  nearly an order of magnitude between batches. The 2.88x was thread noise. Pinned, the same
+  comparison gives 0.99x to 1.10x. See [[build-machine]].
+- **The cache was not on the call path at all.** I had memoized `_bernstein_vandermonde_svd`
+  believing the public entry points reached it. They reach `_build_bernstein_pinv`. Neither
+  `grep` nor the passing tests nor the plausible-looking speedup revealed it.
+
+**What caught it: `cache_info()`.** Zero hits, zero misses, after thousands of calls. One line.
+
+**How to apply, and these are cheap:**
+
+- **Before timing anything that calls BLAS or LAPACK, pin the threads.** A speedup that does not
+  survive a thread pin is not a speedup. Bake the refusal into the script rather than remembering.
+- **A cache gets a hit counter before it gets a benchmark.** `cache_info()`, or an equivalent
+  assertion in a test, proves the thing you are measuring is the thing that runs. The benchmark
+  cannot: an improvement and a coincidence look identical.
+- **Follow the call graph before optimising, do not infer it from names.** `_bernstein_interpolate`
+  and `_bernstein_vandermonde_svd` read like the main path and are reached by nothing.
+- **When the fix lands somewhere else, delete the first attempt rather than keeping it "since it
+  is free".** I nearly shipped a second cache on an uncalled function out of sunk cost. It would
+  have needed its own size policy beside the real one, which is how a module accumulates.
+
+**And one that went right, worth recording for the tally.** I predicted Eigen's `BDCSVD` would
+be slower than LAPACK's `gesdd` and was ready to build an argument on it. I benchmarked instead
+and it is competitive, sometimes faster. The prediction would have been a confident, plausible,
+entirely wrong premise under a design decision. **Benchmark the premise you are about to lean
+on, especially when it feels obvious.**

--- a/design/bezier_interpolation_port.md
+++ b/design/bezier_interpolation_port.md
@@ -1,0 +1,194 @@
+# Bézier interpolation: why the block stays in Python
+
+**Status:** decided 2026-08-24. The memoization described in "What ships instead" is
+implemented; nothing else here is.
+**Scope:** `src/pantr/bezier/_bezier_interpolate.py` (756 lines) and the part of
+`src/pantr/_interpolation_utils.py` it uses. This is the third and last block of the
+`bezier` port, after the arithmetic (#348, #349) and the root finding (#353).
+**Decision:** the block is **not ported**. `bezier` closes as *ported except interpolation*.
+
+The other two blocks were ported because measurement said they would pay. This one was
+measured the same way and said the opposite, so the note records the numbers rather than the
+intention, and states what would have to change for the answer to change.
+
+## What the block does
+
+Both public entry points, `interpolate_bezier` (samples a callable) and `fit_bezier`
+(pre-evaluated values), recover Bernstein coefficients from a Bernstein Vandermonde system.
+The matrix is severely ill-conditioned at high degree, so every path inverts it through a
+**truncated SVD pseudo-inverse**: singular values below `tol * sigma[0]` are zeroed, with
+`tol = SVD_TOL_FACTOR * eps` and `SVD_TOL_FACTOR = 100.0`
+(`_interpolation_utils.resolve_svd_tolerance`).
+
+Three call sites take their own `np.linalg.svd`, and which of them a call reaches is not
+obvious from the module's shape:
+
+| site | matrix | determined by | on a public path? |
+|---|---|---|---|
+| `_build_bernstein_pinv` | 1D nodes, square or tall | the nodes, `tol`, `degree` | **yes**, every tensor-product call, once per direction |
+| `_fit_from_scattered` | tensor-product basis at scattered points | the caller's points | **yes**, the scattered branch of `fit_bezier` |
+| `_bernstein_vandermonde_svd` | square, at modified Chebyshev nodes | `(n, dtype)` alone | **no** |
+
+The last row is worth pausing on, because the module docstring presents it as a supporting
+utility and it reads like the main one. Nothing in this repository calls it outside the tests:
+its only caller is `_bernstein_interpolate`, which nothing here calls either.
+
+## The five measurements that decided it
+
+`scripts/measure_bezier_interpolation_port.py` reproduces all of them, and writes out the
+matrices and the Eigen comparison program that measurement 2 needs a compiler for. Run it as its
+docstring says: it refuses to time anything unless the thread counts are pinned.
+
+**1. The SVD dominates, and it was not memoized.** It accounted for between a seventh and a
+half of a tensor-product call, and about three fifths of a scattered one, and every call
+recomputed it, once per parametric direction.
+
+**2. Eigen's `BDCSVD` and LAPACK's `gesdd` agree on the rank.** This was the expected blocker.
+The truncation is a *discrete verdict*, so two SVD implementations disagreeing about whether a
+singular value clears the threshold would move the pseudo-inverse by a rank-one term of order
+`1 / (tol * sigma[0])` rather than by a few ulps. That is `backend_parity.md`'s Rule 11 family,
+and no tolerance bounds it.
+
+It does not happen. Over the real Bernstein Vandermonde matrices at orders 10, 20, 25, 30, 36
+and 39, in both dtypes, the two implementations chose the **same rank in every case**. The
+regime where it could bite at all is float32 from order 20 up, where truncation actually
+fires; float64 does not truncate at any order measured, up to 39, and its closest approach
+to the threshold is more than two decades away. The tightest float32 case, order 36, sits about
+two parts in a
+thousand above the cut, and the two implementations placed it within about one part in ten
+thousand of each other: roughly a factor of twenty of headroom.
+
+That is **measured on the matrices this code builds, not proved**. Six orders is thin evidence
+for a discrete verdict, which is precisely why it is not by itself a reason to port.
+
+**3. Eigen's SVD is not the faster one.** `BDCSVD` came in between about four tenths and about
+one and a half times LAPACK's time on the same matrices, faster at float32 and slower at
+float64. There is no speed argument for moving the dominant term.
+
+**4. The portable numerical work is about a fifteenth of a call.** This is the sharpest of the
+four. Once the factorization is memoized, a warm one-dimensional call is dominated by
+Python-level work, and the part a C++ kernel would actually replace, one `tensordot` per
+direction, is around seven percent of it. Twice that again goes to the caller's own Python
+function, which `interpolate_bezier` is *handed* and no port can remove. The rest is
+validation, lattice construction and component splitting: portable in principle, but only by
+moving the entry point itself into C++, which a Python callable in the signature forbids.
+
+So the ceiling is not a small constant factor. It is a few percent.
+
+## The scope facts that settle it
+
+- **The downstream consumer imports neither entry point.** It takes `Bezier`,
+  `_de_casteljau_eval_scalar` and one BVH constant. Interpolation is not on its surface.
+- **It never uses float32 near pantr.** The one regime carrying the rank-discontinuity risk is
+  a regime nothing in Stage 1 scope enters.
+- **`_fit_from_scattered` is shared with `bspline`** (`_bspline_interpolate.py`), which is
+  explicitly out of Stage 1 scope. Porting it would drag a boundary this stage drew.
+
+So the risk lives where nobody goes, and the gain lands on functions nobody in scope calls.
+
+## What ships instead
+
+One memoization, of a pure function of hashable inputs, bitwise identical to what it replaces.
+
+**`_build_bernstein_pinv`.** It is the single site both `interpolate_bezier` and `fit_bezier`
+reach for a tensor-product fit, once per parametric direction, and its truncated SVD is the
+largest cost in the call. It is memoized on
+`(nodes, tol, degree)`, keyed on the nodes' **bytes and dtype** rather than the array object,
+so a regenerated node set hits the same entry. That is what makes it work at all: the default
+path builds its Chebyshev nodes fresh on every call, so a key based on identity would never
+hit. The dtype belongs in the key because two arrays of different dtype and length can share a
+buffer length, and the tolerance and degree belong in it because the truncation depends on
+both.
+
+Measured with threads pinned, a tensor-product call runs roughly three to eight times faster,
+the gain growing with the order. A square two-dimensional grid gains twice over, since both
+directions share one node set and therefore one entry. The scattered path does not move: it
+goes through `_fit_from_scattered`, whose Vandermonde is built from the caller's own points, and
+that site is
+left alone.
+
+**`_bernstein_vandermonde_svd` was memoized too, and then it was not.** Its matrix is
+determined outright by `(n, dtype)`, since it generates its own nodes, so memoizing it is just
+as sound and just as free. It was dropped anyway, because it has **no production caller in this
+repository**: only tests reach it, and its own caller `_bernstein_interpolate` has none either.
+A cache on a function nothing calls is speculative, and it would have needed its own size
+policy to sit beside the one below. The function now carries a note saying so, and this section
+is the record of the option, in case the "resultant pipeline" its module docstring names turns
+out to be real. It did gain a first direct test on the way past.
+
+The entry point hands out a **copy**, so callers keep the independent, writable array they have
+always had. Copying is quadratic in the order where the factorization it avoids is cubic, and
+building the byte key is cheaper still, so neither erodes the saving.
+
+Building the pseudo-inverse from the factors, and applying it, together cost a few percent of
+the factorization, so there was nothing to gain by memoizing at a finer grain.
+
+**A size guard keeps the cache from becoming a leak.** Entry count alone does not bound memory:
+an entry is a whole `(degree + 1)`-by-`n_pts` matrix, and `n_pts` is the caller's to choose. The
+shape that pays worst is a wide, low-degree fit against very many nodes, where the saving scales
+with the degree while the retained memory scales with the node count, and which is usually
+performed once anyway. Above `_PINV_CACHE_MAX_ELEMENTS` the factorization is computed and
+discarded. That cap is a **policy choice and says so in its docstring**, not a derivation; it is
+set so a full cache stays under twenty megabytes while still admitting every square case this
+module is accurate at.
+
+## A machine artifact worth recording
+
+On the development machine, with the thread-count variables set to 20, a 36-by-36 LAPACK SVD
+cost between one and two orders of magnitude more than the same call pinned to one thread, and
+its timing varied by nearly an order of magnitude between batches. Twenty threads synchronizing
+over a matrix that fits in L1 is pure overhead, and the box is shared.
+
+The consequence is procedural: **any timing of this block on a many-core machine is worthless
+unless threads are pinned**, and a comparison against a single-threaded C++ implementation on
+those numbers would flatter the port by a factor that has nothing to do with the code. The
+figures above were taken with threads pinned for this reason.
+
+## What would reopen this
+
+- The downstream consumer starts importing `interpolate_bezier` or `fit_bezier`, or starts
+  passing float32 into them. Both are checkable by grep over its tree.
+- `bspline` enters the port's scope, which brings `_fit_from_scattered` with it and changes the
+  shared-site argument.
+- A profile of real downstream work shows interpolation on a hot path. Nothing measured so far
+  suggests it.
+- `_bernstein_interpolate` acquires a caller, in which case memoizing its factorization is the
+  cheap thing to do before anything else is considered.
+
+If it does reopen, the parity claim cannot be an equality. It would need a derived bound plus a
+**named exclusion** under Rule 8 for float32 at order 20 and above, and the rank agreement would
+need far more than six orders behind it.
+
+## Epistemic status
+
+- **Verified by running it:** all five measurements above, and the machine artifact. The rank
+  agreement was checked by feeding the same matrices to both implementations and comparing
+  singular values and the resulting ranks.
+- **Verified by reading the code:** the three SVD sites and what determines each matrix; that
+  `_build_bernstein_pinv` is the only one on the tensor-product path, that
+  `_fit_from_scattered` is the only one on the scattered path, and that
+  `_bernstein_vandermonde_svd` is on neither; that the former is a pure function of its three
+  arguments and the latter of `(n, dtype)`; that `_fit_from_scattered` is imported by `bspline`;
+  that no in-tree caller mutates what either returns.
+- **Taken from an earlier measurement, not re-checked here:** what the downstream consumer
+  imports and that it never passes float32 (recorded 2026-08-21 against that repository, which
+  moves).
+- **Asserted, not proved:** that Eigen and LAPACK agree on the rank in general. Six orders in
+  two dtypes is evidence, not a theorem, and the note leans on the scope facts rather than on
+  this.
+- **Not investigated:** why LAPACK's threaded path is so much worse here than its serial one.
+  It is recorded as an artifact affecting measurement, not diagnosed.
+- **Got wrong once, recorded so it is not repeated.** The first version of this work quoted a
+  speedup measured *unpinned*, and it was thread noise rather than a saving; and it memoized
+  `_bernstein_vandermonde_svd` believing it was the site on the public path, which it is not.
+  Both were caught the same way, by instrumenting the cache and finding it took no hits at all.
+  A speedup that survives neither a thread pin nor a hit counter is not a speedup.
+
+## Open questions
+
+- The module docstring of `_bezier_interpolate.py` says its supporting utilities are "used
+  internally and by the resultant pipeline". No resultant pipeline exists in this repository,
+  and `_bernstein_interpolate` has no caller here outside its tests. Either the phrase is stale
+  or it names an out-of-tree consumer; it was left untouched because neither could be
+  established from here, and it is the reason the second memoization was kept rather than
+  dropped as dead.

--- a/design/bezier_interpolation_port.md
+++ b/design/bezier_interpolation_port.md
@@ -30,8 +30,9 @@ obvious from the module's shape:
 | `_bernstein_vandermonde_svd` | square, at modified Chebyshev nodes | `(n, dtype)` alone | **no** |
 
 The last row is worth pausing on, because the module docstring presents it as a supporting
-utility and it reads like the main one. Nothing in this repository calls it outside the tests:
-its only caller is `_bernstein_interpolate`, which nothing here calls either.
+utility and it reads like the main one. **No production code calls it.** Its only caller is
+`_bernstein_interpolate`, which is reached only from the tests and from
+`tools/adversarial_sweep/_probes_bezier.py`, itself gated behind `PANTR_RUN_SWEEP`.
 
 ## The five measurements that decided it
 
@@ -110,7 +111,7 @@ left alone.
 **`_bernstein_vandermonde_svd` was memoized too, and then it was not.** Its matrix is
 determined outright by `(n, dtype)`, since it generates its own nodes, so memoizing it is just
 as sound and just as free. It was dropped anyway, because it has **no production caller in this
-repository**: only tests reach it, and its own caller `_bernstein_interpolate` has none either.
+repository**: it is reached only from the tests and from the adversarial sweep under `tools/`.
 A cache on a function nothing calls is speculative, and it would have needed its own size
 policy to sit beside the one below. The function now carries a note saying so, and this section
 is the record of the option, in case the "resultant pipeline" its module docstring names turns
@@ -128,9 +129,19 @@ an entry is a whole `(degree + 1)`-by-`n_pts` matrix, and `n_pts` is the caller'
 shape that pays worst is a wide, low-degree fit against very many nodes, where the saving scales
 with the degree while the retained memory scales with the node count, and which is usually
 performed once anyway. Above `_PINV_CACHE_MAX_ELEMENTS` the factorization is computed and
-discarded. That cap is a **policy choice and says so in its docstring**, not a derivation; it is
-set so a full cache stays under twenty megabytes while still admitting every square case this
-module is accurate at.
+discarded. That cap is a **policy choice and says so in its docstring**, not a derivation.
+
+Sizing it took two corrections worth recording. `functools.lru_cache` retains the **key** as
+well as the value, and the key here holds the nodes' bytes, so an entry costs about twice the
+matrix rather than the matrix; the first cap was set against the matrix alone and its stated
+bound was wrong by a factor of two. Measured directly, thirty-two entries with eight-byte values
+and one-megabyte keys grew the process by 33 MiB.
+
+Then the corrected bound *looked* refuted too, at 61 MiB peak against 8 declared, and it was
+not: peak resident memory includes a factorization's own transient workspace, which is larger
+than the entry it produces and which no cache policy touches. Summed exactly over what the
+cache holds, the retained figure is 8.00 MiB, matching. **A cap on retention is not a cap on
+peak, and measuring the wrong one refutes nothing.**
 
 ## A machine artifact worth recording
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-The dual-backend prototype on the `proto/cpp` branch. Four module pull requests so far: the
+The dual-backend prototype on the `proto/cpp` branch. Five module pull requests so far: the
 infrastructure, the `quad` port, the `change_basis` port, the `bezier` arithmetic port and the
 `bezier` root-finding port. The
 infrastructure landed without a changelog entry, so this section covers all of them -- the environment variable it introduced is
@@ -109,6 +109,19 @@ user-facing, and the ports change what it affects.
   writing the obvious thing would break parity on every `float32` input at the degree-1 base case.
 - `scripts/measure_bezier_fma_bound.py`, which reproduces the bound's slack against whatever
   extension is installed, and prints how to build one that fuses.
+
+### Performance
+- **`interpolate_bezier` and `fit_bezier` are several times faster on a tensor-product grid.**
+  Both recovered the Bernstein coefficients through a truncated-SVD pseudo-inverse that they
+  rebuilt from scratch on every call, once per parametric direction, and that factorization was
+  the largest single cost in the call. It is now computed once per distinct set of nodes,
+  tolerance and target degree. Measured with threads pinned, roughly three to eight times
+  faster, the gain growing with the order; a square two-dimensional grid gains twice
+  over, since both directions share one node set. Results are **bitwise identical**, and the
+  matrix is handed out as a fresh copy, so a caller that mutates it still can.
+
+  Fitting to **scattered** points is unchanged: its matrix is built from the caller's own
+  points, so there is nothing to reuse between calls.
 
 ### Changed
 - `pantr.change_basis` is a package rather than a single module, so that its dispatch catalogue

--- a/scripts/measure_bezier_interpolation_port.py
+++ b/scripts/measure_bezier_interpolation_port.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
-"""Reproduce the four measurements behind the decision not to port Bézier interpolation.
+"""Reproduce the five measurements behind the decision not to port Bézier interpolation.
 
 ``design/bezier_interpolation_port.md`` rules that ``_bezier_interpolate.py`` stays in
 Python, and rests that ruling on numbers. This is where they come from.
 
-    OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
         PYTHONPATH="$(pwd)/src" .venv/bin/python \
         scripts/measure_bezier_interpolation_port.py
 
 **Pin the threads.** On a many-core box a threaded LAPACK SVD of a matrix that fits in
 L1 costs orders of magnitude more than the same call on one thread, and varies wildly
-between batches. Section 5 measures that directly; every other section is meaningless
+between batches. Section 6 measures that directly; every other section is meaningless
 without the pin, which is why the script refuses to run unpinned unless told to.
 
-The four measurements
+The five measurements
 ---------------------
 
 1. **What the SVD costs**, as a share of a call, and how many times a call takes one.
@@ -505,7 +505,7 @@ def main() -> int:
     pinned = all(os.environ.get(name) == "1" for name in _THREAD_VARS)
     if not pinned and not args.allow_unpinned:
         print(f"Threads are not pinned ({_thread_setting()}).", file=sys.stderr)
-        print("Timings taken this way are noise; see section 5. Re-run with", file=sys.stderr)
+        print("Timings taken this way are noise; see section 6. Re-run with", file=sys.stderr)
         print(f"  {' '.join(f'{name}=1' for name in _THREAD_VARS)} ...", file=sys.stderr)
         print("or pass --allow-unpinned to measure the artifact deliberately.", file=sys.stderr)
         return 1

--- a/scripts/measure_bezier_interpolation_port.py
+++ b/scripts/measure_bezier_interpolation_port.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python
+"""Reproduce the four measurements behind the decision not to port Bézier interpolation.
+
+``design/bezier_interpolation_port.md`` rules that ``_bezier_interpolate.py`` stays in
+Python, and rests that ruling on numbers. This is where they come from.
+
+    OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+        PYTHONPATH="$(pwd)/src" .venv/bin/python \
+        scripts/measure_bezier_interpolation_port.py
+
+**Pin the threads.** On a many-core box a threaded LAPACK SVD of a matrix that fits in
+L1 costs orders of magnitude more than the same call on one thread, and varies wildly
+between batches. Section 5 measures that directly; every other section is meaningless
+without the pin, which is why the script refuses to run unpinned unless told to.
+
+The four measurements
+---------------------
+
+1. **What the SVD costs**, as a share of a call, and how many times a call takes one.
+2. **What memoizing it buys**, and that the results are unchanged bit for bit.
+3. **How much of a warm call a port could reach at all**, once the factorization is no
+   longer being rebuilt.
+4. **Where the truncation threshold actually bites**: per order and dtype, the rank
+   LAPACK chooses and how close the nearest singular value comes to the cut.
+5. **Whether Eigen would choose the same rank.** This half needs a C++ compiler, so the
+   script writes the matrices and a self-contained comparison program, then prints the
+   two commands that build and run it. Pass ``--emit-cpp DIR`` to produce them.
+
+6 is the threading artifact, reported for the record rather than as an input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import pathlib
+import sys
+import time
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from pantr._interpolation_utils import resolve_svd_tolerance
+from pantr.bezier import fit_bezier, interpolate_bezier
+from pantr.bezier._bezier_interpolate import (
+    _build_bernstein_pinv,
+    _compute_bernstein_pinv,
+)
+from pantr.bezier._bezier_utils import _tabulate_bernstein_1d_fast
+from pantr.quad import PointsLattice, get_modified_chebyshev_nodes_1d
+
+ORDERS: tuple[int, ...] = (10, 20, 25, 30, 36, 39)
+"""Orders sampled throughout. Spans below, across and above where float32 starts truncating."""
+
+_MEMO_ATTR = "_bernstein_pinv_cached"
+"""Name of the cache that :func:`_memoization_bypassed` swaps out, as an attribute."""
+
+_THREAD_VARS: tuple[str, ...] = ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS")
+"""Variables that must read ``1`` for a timing on this script to mean anything."""
+
+
+def _best_of(fn: Callable[[], Any], reps: int, batches: int = 5) -> float:
+    """Time a callable, returning the fastest batch mean in milliseconds.
+
+    The minimum over batches is used rather than the mean because the contaminant on a
+    shared machine is always additive.
+
+    Args:
+        fn (Callable[[], Any]): The callable to time. Called for effect.
+        reps (int): Repetitions per batch.
+        batches (int): Number of batches. Defaults to 5.
+
+    Returns:
+        float: Milliseconds per call, fastest batch.
+    """
+    for _ in range(min(reps, 20)):
+        fn()
+    best = float("inf")
+    for _ in range(batches):
+        start = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        best = min(best, (time.perf_counter() - start) / reps * 1e3)
+    return best
+
+
+def _count_svd_calls(fn: Callable[[], Any]) -> tuple[int, float, float]:
+    """Run a callable with ``np.linalg.svd`` instrumented.
+
+    Args:
+        fn (Callable[[], Any]): The callable to run once.
+
+    Returns:
+        tuple[int, float, float]: Number of SVD calls, milliseconds spent inside them,
+        and total milliseconds for the callable.
+    """
+    calls = 0
+    inside = 0.0
+    real = np.linalg.svd
+
+    def counting(
+        matrix: npt.NDArray[np.floating[Any]], *, full_matrices: bool = True
+    ) -> tuple[
+        npt.NDArray[np.floating[Any]],
+        npt.NDArray[np.floating[Any]],
+        npt.NDArray[np.floating[Any]],
+    ]:
+        nonlocal calls, inside
+        start = time.perf_counter()
+        result = real(matrix, full_matrices=full_matrices)
+        inside += time.perf_counter() - start
+        calls += 1
+        return result
+
+    np.linalg.svd = counting  # type: ignore[assignment]
+    try:
+        start = time.perf_counter()
+        fn()
+        total = time.perf_counter() - start
+    finally:
+        np.linalg.svd = real
+    return calls, inside * 1e3, total * 1e3
+
+
+def _cubic(lattice: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+    """Sample a univariate cubic on a lattice.
+
+    Args:
+        lattice (PointsLattice): The sampling lattice passed by ``interpolate_bezier``.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Values at the lattice points.
+    """
+    return np.asarray(lattice.get_all_points()[:, 0] ** 3)
+
+
+def _biquadratic(lattice: PointsLattice) -> npt.NDArray[np.floating[Any]]:
+    """Sample a bivariate product on a lattice.
+
+    Args:
+        lattice (PointsLattice): The sampling lattice passed by ``interpolate_bezier``.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Values at the lattice points.
+    """
+    points = lattice.get_all_points()
+    return np.asarray((points[:, 0] * points[:, 1]) ** 2)
+
+
+def _cases() -> list[tuple[str, Callable[[], Any]]]:
+    """Build the call shapes both measurements use.
+
+    Returns:
+        list[tuple[str, Callable[[], Any]]]: Labelled zero-argument calls.
+    """
+    rng = np.random.default_rng(0)
+    scattered_pts = rng.random((200, 2))
+    scattered_vals = scattered_pts[:, 0] ** 2 + scattered_pts[:, 1]
+    return [
+        ("1D order 10", lambda: interpolate_bezier(_cubic, 10)),
+        ("1D order 30", lambda: interpolate_bezier(_cubic, 30)),
+        ("1D order 39", lambda: interpolate_bezier(_cubic, 39)),
+        ("2D 30x30", lambda: interpolate_bezier(_biquadratic, [30, 30])),
+        ("1D lsq 40/11", lambda: interpolate_bezier(_cubic, 40, degree=10)),
+        ("scattered 200", lambda: fit_bezier(scattered_vals, nodes=scattered_pts, degree=[5, 5])),
+    ]
+
+
+def measure_svd_share() -> None:
+    """Report how much of a call the SVD is, and how many the call takes."""
+    print("\n1. What the SVD costs, per call, with the memoization bypassed")
+    print("   " + "-" * 68)
+    print(f"   {'case':14s} {'svd calls':>9s} {'svd ms':>8s} {'total ms':>9s} {'share':>7s}")
+    for label, fn in _cases():
+        fn()  # let Numba compile before anything is timed
+        with _memoization_bypassed():
+            shares = [_count_svd_calls(fn) for _ in range(9)]
+        shares.sort(key=lambda row: row[2])
+        calls, inside, total = shares[len(shares) // 2]
+        print(f"   {label:14s} {calls:9d} {inside:8.3f} {total:9.3f} {100 * inside / total:6.1f}%")
+    print("   Every tensor-product call reaches _build_bernstein_pinv, one factorization per")
+    print("   direction, and this is what it costs when it rebuilds them every time.")
+
+
+def measure_memoization() -> None:
+    """Report the speedup from memoizing, and that it changes no result."""
+    print("\n2. What memoizing the pseudo-inverse buys")
+    print("   " + "-" * 68)
+    print(f"   {'case':14s} {'no memo ms':>11s} {'memoized ms':>12s} {'speedup':>8s}")
+
+    for label, fn in _cases():
+        fn()
+        memoized = _best_of(fn, 200)
+        with _memoization_bypassed():
+            plain = _best_of(fn, 200)
+        print(f"   {label:14s} {plain:11.3f} {memoized:12.3f} {plain / memoized:7.2f}x")
+    print("   The scattered case does not move: its Vandermonde is built from the caller's")
+    print("   own points by _fit_from_scattered, which is a different site and not memoized.")
+
+    with _memoization_bypassed():
+        plain_result = interpolate_bezier(_cubic, 30).control_points.copy()
+    memo_result = interpolate_bezier(_cubic, 30).control_points
+    print(
+        f"   Memoized and unmemoized results identical bit for bit: "
+        f"{np.array_equal(plain_result, memo_result)}"
+    )
+
+    nodes = get_modified_chebyshev_nodes_1d(39, np.float64)
+    matrix = _build_bernstein_pinv(nodes)
+    copy_cost = _best_of(matrix.copy, 2000)
+    key_cost = _best_of(nodes.tobytes, 2000)
+    factorize = _best_of(lambda: _compute_bernstein_pinv(nodes, None, None), 200)
+    print(
+        f"   Order 39: the copy and the key cost {copy_cost * 1e3:.2f} us and "
+        f"{key_cost * 1e3:.2f} us against {factorize * 1e3:.2f} us to rebuild"
+    )
+
+
+@contextlib.contextmanager
+def _memoization_bypassed() -> Iterator[None]:
+    """Route the pseudo-inverse around its cache for the duration of the block.
+
+    Yields:
+        None: The block runs with every call recomputing the factorization.
+    """
+    module = sys.modules[_build_bernstein_pinv.__module__]
+    original = getattr(module, _MEMO_ATTR)
+    setattr(module, _MEMO_ATTR, _keyless_passthrough)
+    try:
+        yield
+    finally:
+        setattr(module, _MEMO_ATTR, original)
+
+
+def _keyless_passthrough(
+    node_bytes: bytes,
+    dtype: np.dtype[np.floating[Any]],
+    tol: float | None,
+    degree: int | None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Stand in for the cache, recomputing on every call.
+
+    Args:
+        node_bytes (bytes): The node array's buffer, as the cache receives it.
+        dtype (np.dtype[np.floating[Any]]): The node array's dtype.
+        tol (float | None): SVD truncation tolerance.
+        degree (int | None): Target Bernstein degree.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The freshly computed pseudo-inverse.
+    """
+    return _compute_bernstein_pinv(np.frombuffer(node_bytes, dtype=dtype).copy(), tol, degree)
+
+
+def measure_portable_fraction() -> None:
+    """Report how much of a warm call a C++ port could even reach."""
+    print("\n3. How much of a warm call is portable at all")
+    print("   " + "-" * 68)
+    print(
+        f"   {'case':14s} {'warm ms':>8s} {'apply ms':>9s} "
+        f"{'callable ms':>12s} {'apply share':>12s}"
+    )
+    for order in (10, 30, 39):
+        nodes = get_modified_chebyshev_nodes_1d(order, np.float64)
+        lattice = PointsLattice([nodes])
+        values = np.asarray(_cubic(lattice))
+        pinv = _build_bernstein_pinv(nodes)
+
+        def whole_call(count: int = order) -> object:
+            return interpolate_bezier(_cubic, count)
+
+        def apply_once(
+            matrix: npt.NDArray[np.floating[Any]] = pinv,
+            data: npt.NDArray[np.floating[Any]] = values,
+        ) -> object:
+            return np.tensordot(matrix, data, axes=([1], [0]))
+
+        def sample_once(grid: PointsLattice = lattice) -> object:
+            return _cubic(grid)
+
+        warm = _best_of(whole_call, 300)
+        apply_cost = _best_of(apply_once, 2000)
+        callable_cost = _best_of(sample_once, 2000)
+        print(
+            f"   1D order {order:<5d} {warm:8.3f} {apply_cost:9.4f} {callable_cost:12.4f} "
+            f"{100 * apply_cost / warm:11.1f}%"
+        )
+    print("   Everything but the apply is Python-level: validation, lattice construction,")
+    print("   component splitting, and the caller's own function. interpolate_bezier is")
+    print("   handed a Python callable, so no port removes that column.")
+
+
+def vandermonde(n: int, dtype: npt.DTypeLike) -> npt.NDArray[np.floating[Any]]:
+    """Build the Bernstein Vandermonde this module factorizes.
+
+    Args:
+        n (int): Number of nodes and coefficients.
+        dtype (npt.DTypeLike): Floating dtype.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: The ``n``-by-``n`` matrix.
+    """
+    nodes = get_modified_chebyshev_nodes_1d(max(n, 2), dtype)[:n]
+    return _tabulate_bernstein_1d_fast(n - 1, nodes, dtype)
+
+
+def measure_truncation() -> dict[str, dict[str, Any]]:
+    """Report where the rank truncation actually fires, and by how little.
+
+    Returns:
+        dict[str, dict[str, Any]]: Per case, the LAPACK singular values, the resolved
+        tolerance and the timing, keyed ``"<n>_<dtype>"``.
+    """
+    print("\n4. Where the truncation threshold bites, per order and dtype")
+    print("   " + "-" * 68)
+    print(f"   {'case':16s} {'kept':>7s} {'nearest ratio to the cut':>26s} {'ms':>7s}")
+    out: dict[str, dict[str, Any]] = {}
+    for dtype in (np.float64, np.float32):
+        for n in ORDERS:
+            matrix = vandermonde(n, dtype)
+            sigma = np.linalg.svd(matrix, full_matrices=False)[1]
+            tol = resolve_svd_tolerance(np.dtype(dtype), None)
+            ratios = sigma / sigma[0] / tol
+            kept = int((ratios >= 1.0).sum())
+            nearest = float(ratios[int(np.argmin(np.abs(np.log10(ratios))))])
+
+            def factorize(target: npt.NDArray[np.floating[Any]] = matrix) -> object:
+                return np.linalg.svd(target, full_matrices=False)
+
+            ms = _best_of(factorize, 200)
+            key = f"{n}_{np.dtype(dtype).name}"
+            out[key] = {"sigma": [float(x) for x in sigma], "tol": tol, "ms": ms}
+            print(f"   {key:16s} {kept:3d}/{n:<3d} {nearest:26.6f} {ms:7.4f}")
+    print("   A ratio near 1 is a singular value sitting on the cut: that is where two")
+    print("   implementations could disagree about the rank, and the verdict would jump.")
+    return out
+
+
+def emit_cpp(target: pathlib.Path, reference: dict[str, dict[str, Any]]) -> None:
+    """Write the matrices and an Eigen comparison program, and print how to run it.
+
+    Args:
+        target (pathlib.Path): Directory to write into. Created if absent.
+        reference (dict[str, dict[str, Any]]): The LAPACK result from
+            :func:`measure_truncation`, written alongside for comparison.
+    """
+    target.mkdir(parents=True, exist_ok=True)
+    for key in reference:
+        n_text, dtype_name = key.split("_")
+        matrix = vandermonde(int(n_text), np.dtype(dtype_name))
+        np.savetxt(target / f"V_{key}.txt", np.asarray(matrix, dtype=np.float64), fmt="%.17g")
+    with (target / "lapack_sigma.txt").open("w") as handle:
+        for key, record in reference.items():
+            handle.write(f"{key} {record['tol']:.17g} ")
+            handle.write(" ".join(f"{x:.17g}" for x in record["sigma"]) + "\n")
+    (target / "compare_eigen.cpp").write_text(_CPP_SOURCE)
+    print(f"\n   Wrote the matrices and comparison program to {target}")
+    print("   Build and run it with:")
+    print(
+        f"       g++ -O3 -DNDEBUG -ffp-contract=on -w "
+        f"-I build/gcc/_deps/eigen-src -o {target}/compare_eigen {target}/compare_eigen.cpp"
+    )
+    print(f"       {target}/compare_eigen {target}")
+    print("   It prints one line per case and flags any where the two ranks differ.")
+
+
+_CPP_SOURCE = r"""// Compare Eigen's BDCSVD against the LAPACK singular values dumped beside it.
+// Written by scripts/measure_bezier_interpolation_port.py; see
+// design/bezier_interpolation_port.md for what the comparison is for.
+#include <Eigen/Dense>
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::vector<double>> load_matrix(const std::string& path) {
+    std::ifstream file(path);
+    std::string line;
+    std::vector<std::vector<double>> rows;
+    while (std::getline(file, line)) {
+        std::istringstream stream(line);
+        std::vector<double> row;
+        double value = 0.0;
+        while (stream >> value) row.push_back(value);
+        if (!row.empty()) rows.push_back(row);
+    }
+    return rows;
+}
+
+template <class Scalar>
+std::vector<double> eigen_singular_values(const std::vector<std::vector<double>>& rows) {
+    using Mat = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+    Mat matrix(rows.size(), rows[0].size());
+    for (std::size_t i = 0; i < rows.size(); ++i)
+        for (std::size_t j = 0; j < rows[0].size(); ++j)
+            matrix(i, j) = static_cast<Scalar>(rows[i][j]);
+    Eigen::BDCSVD<Mat> svd(matrix, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    std::vector<double> out;
+    for (int i = 0; i < svd.singularValues().size(); ++i)
+        out.push_back(static_cast<double>(svd.singularValues()(i)));
+    return out;
+}
+
+int rank_above(const std::vector<double>& sigma, double tol) {
+    int kept = 0;
+    for (double value : sigma)
+        if (value >= tol * sigma[0]) ++kept;
+    return kept;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::string dir = argc > 1 ? argv[1] : ".";
+    std::ifstream reference(dir + "/lapack_sigma.txt");
+    std::string line;
+    int disagreements = 0;
+    while (std::getline(reference, line)) {
+        std::istringstream stream(line);
+        std::string key;
+        double tol = 0.0;
+        stream >> key >> tol;
+        std::vector<double> lapack;
+        double value = 0.0;
+        while (stream >> value) lapack.push_back(value);
+
+        const auto rows = load_matrix(dir + "/V_" + key + ".txt");
+        const bool single = key.find("float32") != std::string::npos;
+        const auto eigen = single ? eigen_singular_values<float>(rows)
+                                  : eigen_singular_values<double>(rows);
+
+        const int rank_lapack = rank_above(lapack, tol);
+        const int rank_eigen = rank_above(eigen, tol);
+        double worst = 0.0;
+        for (std::size_t i = 0; i < lapack.size(); ++i)
+            worst = std::max(worst, std::abs(eigen[i] - lapack[i]) / lapack[0]);
+        const bool differs = rank_lapack != rank_eigen;
+        disagreements += differs;
+        std::printf("%-16s rank lapack=%3d eigen=%3d  max |dsigma|/sigma0=%.3e%s\n",
+                    key.c_str(), rank_lapack, rank_eigen, worst,
+                    differs ? "   <== RANKS DIFFER" : "");
+    }
+    std::printf("\n%d case(s) where the two implementations chose a different rank.\n",
+                disagreements);
+    return 0;
+}
+"""
+
+
+def measure_threading_artifact() -> None:
+    """Report how much a threaded LAPACK SVD of a tiny matrix costs, versus one thread."""
+    print("\n6. The threading artifact, for the record")
+    print("   " + "-" * 68)
+    pinned = all(os.environ.get(name) == "1" for name in _THREAD_VARS)
+    matrix = vandermonde(36, np.float64)
+    spread = [
+        _best_of(lambda: np.linalg.svd(matrix, full_matrices=False), 100, batches=1)
+        for _ in range(5)
+    ]
+    state = "pinned to one thread" if pinned else f"unpinned ({_thread_setting()})"
+    print(f"   Order 36, float64, {state}: {min(spread):.4f} to {max(spread):.4f} ms")
+    if pinned:
+        print("   Re-run without the pin to see the same call cost orders of magnitude more,")
+        print("   and vary between batches. Twenty threads over a matrix that fits in L1 is")
+        print("   pure synchronization, and no timing taken that way means anything.")
+
+
+def _thread_setting() -> str:
+    """Describe the thread-count environment in one line.
+
+    Returns:
+        str: The relevant variables and their values, or a note that none are set.
+    """
+    parts = [f"{name}={os.environ[name]}" for name in _THREAD_VARS if name in os.environ]
+    return ", ".join(parts) if parts else "no thread variables set"
+
+
+def main() -> int:
+    """Run the measurements.
+
+    Returns:
+        int: Process exit status.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--emit-cpp",
+        type=pathlib.Path,
+        metavar="DIR",
+        help="write the matrices and the Eigen comparison program into DIR",
+    )
+    parser.add_argument(
+        "--allow-unpinned",
+        action="store_true",
+        help="run the timings even though the thread counts are not pinned to 1",
+    )
+    args = parser.parse_args()
+
+    pinned = all(os.environ.get(name) == "1" for name in _THREAD_VARS)
+    if not pinned and not args.allow_unpinned:
+        print(f"Threads are not pinned ({_thread_setting()}).", file=sys.stderr)
+        print("Timings taken this way are noise; see section 5. Re-run with", file=sys.stderr)
+        print(f"  {' '.join(f'{name}=1' for name in _THREAD_VARS)} ...", file=sys.stderr)
+        print("or pass --allow-unpinned to measure the artifact deliberately.", file=sys.stderr)
+        return 1
+
+    print("Bézier interpolation port: the measurements behind design/bezier_interpolation_port.md")
+    print(f"numpy {np.__version__}, {_thread_setting()}")
+    measure_svd_share()
+    measure_memoization()
+    measure_portable_fraction()
+    reference = measure_truncation()
+    print("\n5. Whether Eigen would choose the same rank")
+    print("   " + "-" * 68)
+    if args.emit_cpp is None:
+        print("   Needs a compiler. Re-run with --emit-cpp DIR to write the matrices and the")
+        print("   comparison program, along with the two commands that build and run it.")
+    else:
+        emit_cpp(args.emit_cpp, reference)
+    measure_threading_artifact()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -51,7 +51,7 @@ so this is generous for the case the cache exists to serve and small enough to
 bound the pathological one.
 """
 
-_PINV_CACHE_MAX_ELEMENTS: Final[int] = 1 << 16
+_PINV_CACHE_MAX_ELEMENTS: Final[int] = 1 << 14
 """Largest pseudo-inverse that is worth holding on to, in matrix entries.
 
 Entry count alone does not bound memory, because an entry is a whole
@@ -61,10 +61,19 @@ worst: the saving scales with the degree while the memory scales with the node
 count, and such a fit is usually performed once rather than repeatedly.  Above
 this size the factorization is computed and discarded.
 
-The cap itself is a **policy choice, not a derivation**.  It is set so that a
-full cache of ``_PINV_CACHE_SIZE`` float64 entries stays under twenty megabytes,
-and so that every square case this module is accurate at, and any rectangular fit
-of plausible width, still lands inside it.
+**An entry costs about twice the matrix**, because :func:`functools.lru_cache`
+retains the key as well as the value and the key holds the nodes' bytes.  At
+``degree = 0`` the two are the same size, which is the worst case and also the
+shape above.  So the cache *retains* at most about
+``2 * _PINV_CACHE_SIZE * _PINV_CACHE_MAX_ELEMENTS`` float64 values, eight
+megabytes.  That bounds what is held, not the peak: one factorization's own
+workspace is transiently larger than the entry it produces, and no cache policy
+changes that.
+
+The cap itself is a **policy choice, not a derivation**.  It admits every square
+case this module is accurate at with room to spare (the Bernstein Vandermonde is
+outside its accuracy domain well below 128 nodes), and a rectangular fit of any
+plausible width: a degree-5 fit against 2730 nodes still lands inside it.
 """
 
 
@@ -87,9 +96,10 @@ def _bernstein_vandermonde_svd(
 
     Note:
         Unlike :func:`_build_bernstein_pinv`, this factorization is **not**
-        memoized, because nothing in this package calls it: neither public entry
+        memoized, because no production code calls it: neither public entry
         point reaches it, and its only caller, :func:`_bernstein_interpolate`,
-        has no caller here either.  See
+        is itself reached only from the tests and from
+        ``tools/adversarial_sweep``.  See
         ``design/bezier_interpolation_port.md`` for the measurement and for what
         would make memoizing it worthwhile.
 
@@ -238,6 +248,36 @@ def _resolve_nodes(
     return node_list_seq
 
 
+def _resolve_degree(n_pts: int, degree: int | None) -> int:
+    """Resolve the target Bernstein degree, defaulting to exact interpolation.
+
+    Single source of the default so that :func:`_build_bernstein_pinv`'s size
+    guard and :func:`_compute_bernstein_pinv` cannot drift apart: the guard must
+    bound the matrix the computation actually builds.
+
+    Args:
+        n_pts (int): Number of interpolation nodes.
+        degree (int | None): Requested degree, or *None* for ``n_pts - 1``.
+
+    Returns:
+        int: The degree the pseudo-inverse will be built for.
+    """
+    return n_pts - 1 if degree is None else degree
+
+
+def _pinv_size(n_pts: int, degree: int | None) -> int:
+    """Count the entries of the pseudo-inverse for a node count and degree.
+
+    Args:
+        n_pts (int): Number of interpolation nodes.
+        degree (int | None): Requested degree, or *None* for ``n_pts - 1``.
+
+    Returns:
+        int: ``(degree + 1) * n_pts``, the size the cache is bounded on.
+    """
+    return (_resolve_degree(n_pts, degree) + 1) * n_pts
+
+
 def _build_bernstein_pinv(
     nodes: npt.NDArray[np.floating[Any]],
     tol: float | None = None,
@@ -280,8 +320,7 @@ def _build_bernstein_pinv(
         ``(degree + 1, n_pts)``.  Freshly copied and safe to mutate.
     """
     n_pts = nodes.shape[0]
-    deg = n_pts - 1 if degree is None else degree
-    if (deg + 1) * n_pts > _PINV_CACHE_MAX_ELEMENTS:
+    if _pinv_size(n_pts, degree) > _PINV_CACHE_MAX_ELEMENTS:
         return _compute_bernstein_pinv(nodes, tol, degree)
     return _bernstein_pinv_cached(nodes.tobytes(), nodes.dtype, tol, degree).copy()
 
@@ -344,7 +383,7 @@ def _compute_bernstein_pinv(
     """
     n_pts = nodes.shape[0]
     dtype = nodes.dtype
-    deg = n_pts - 1 if degree is None else degree
+    deg = _resolve_degree(n_pts, degree)
 
     if n_pts == 1 and deg == 0:
         return np.ones((1, 1), dtype=dtype)

--- a/src/pantr/bezier/_bezier_interpolate.py
+++ b/src/pantr/bezier/_bezier_interpolate.py
@@ -25,8 +25,9 @@ Supporting utilities (used internally and by the resultant pipeline):
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -37,6 +38,34 @@ from ._bezier_utils import _tabulate_bernstein_1d_fast
 
 if TYPE_CHECKING:
     from . import Bezier
+
+
+_PINV_CACHE_SIZE: Final[int] = 32
+"""Entries kept in the Bernstein pseudo-inverse cache.
+
+Keyed by the nodes, the tolerance and the target degree, so this counts *node
+sets*: a caller fitting against many different user-supplied node arrays fills
+it, where one repeatedly using the generated Chebyshev nodes occupies a single
+entry per order.  A handful of distinct node sets is the realistic working set,
+so this is generous for the case the cache exists to serve and small enough to
+bound the pathological one.
+"""
+
+_PINV_CACHE_MAX_ELEMENTS: Final[int] = 1 << 16
+"""Largest pseudo-inverse that is worth holding on to, in matrix entries.
+
+Entry count alone does not bound memory, because an entry is a whole
+``(degree + 1)``-by-``n_pts`` matrix and ``n_pts`` is the caller's to choose.
+A wide, low-degree fit against very many nodes is exactly the shape that pays
+worst: the saving scales with the degree while the memory scales with the node
+count, and such a fit is usually performed once rather than repeatedly.  Above
+this size the factorization is computed and discarded.
+
+The cap itself is a **policy choice, not a derivation**.  It is set so that a
+full cache of ``_PINV_CACHE_SIZE`` float64 entries stays under twenty megabytes,
+and so that every square case this module is accurate at, and any rectangular fit
+of plausible width, still lands inside it.
+"""
 
 
 def _bernstein_vandermonde_svd(
@@ -55,6 +84,14 @@ def _bernstein_vandermonde_svd(
     ``n - 1``.  ``V`` is square (``n`` nodes, ``n`` coefficients), so its SVD
     underlies the truncated pseudo-inverse used to invert the (ill-conditioned
     at high degree) interpolation system.
+
+    Note:
+        Unlike :func:`_build_bernstein_pinv`, this factorization is **not**
+        memoized, because nothing in this package calls it: neither public entry
+        point reaches it, and its only caller, :func:`_bernstein_interpolate`,
+        has no caller here either.  See
+        ``design/bezier_interpolation_port.md`` for the measurement and for what
+        would make memoizing it worthwhile.
 
     Args:
         n (int): Number of nodes/coefficients (degree + 1). Must be >= 1.
@@ -216,6 +253,19 @@ def _build_bernstein_pinv(
     ``degree < len(nodes) - 1``, the Vandermonde is rectangular and the
     pseudo-inverse yields a least-squares fit.
 
+    This is the pseudo-inverse both :func:`interpolate_bezier` and
+    :func:`fit_bezier` reach on every tensor-product call, once per parametric
+    direction, and its truncated SVD is the largest single cost in one.  It is
+    therefore memoized per ``(nodes, tol, degree)`` by
+    :func:`_bernstein_pinv_cached`, keyed on the nodes' bytes rather than the
+    array object so that a regenerated node set hits the same entry, which the
+    default Chebyshev path relies on.  A fresh copy is returned, so the caller
+    keeps the independent, writable array it has always had.
+
+    A matrix larger than ``_PINV_CACHE_MAX_ELEMENTS`` is computed and discarded
+    rather than retained, since holding it would cost more than rebuilding it is
+    likely to save.
+
     Args:
         nodes (npt.NDArray[np.floating[Any]]): 1D interpolation nodes on
             [0, 1], shape ``(n_pts,)``.
@@ -224,6 +274,69 @@ def _build_bernstein_pinv(
         degree (int | None): Polynomial degree of the output Bernstein
             representation.  If *None*, defaults to ``n_pts - 1`` (exact
             interpolation).
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix, shape
+        ``(degree + 1, n_pts)``.  Freshly copied and safe to mutate.
+    """
+    n_pts = nodes.shape[0]
+    deg = n_pts - 1 if degree is None else degree
+    if (deg + 1) * n_pts > _PINV_CACHE_MAX_ELEMENTS:
+        return _compute_bernstein_pinv(nodes, tol, degree)
+    return _bernstein_pinv_cached(nodes.tobytes(), nodes.dtype, tol, degree).copy()
+
+
+@functools.lru_cache(maxsize=_PINV_CACHE_SIZE)
+def _bernstein_pinv_cached(
+    node_bytes: bytes,
+    dtype: np.dtype[np.floating[Any]],
+    tol: float | None,
+    degree: int | None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Memoize :func:`_compute_bernstein_pinv` under a hashable key.
+
+    The matrix is a pure function of the nodes, the truncation tolerance and
+    the target degree, so memoizing it is sound.  The nodes arrive as their
+    bytes because an ndarray is not hashable; together with ``dtype`` they
+    determine the node array, including its length.
+
+    Callers must not mutate the returned matrix, which is the cache's own.
+    :func:`_build_bernstein_pinv` is the entry point that enforces this by
+    handing out copies.
+
+    Args:
+        node_bytes (bytes): The 1D node array's buffer, in C order.
+        dtype (np.dtype[np.floating[Any]]): The node array's floating dtype.
+        tol (float | None): SVD truncation tolerance, or *None* for the
+            dtype-based default.
+        degree (int | None): Target Bernstein degree, or *None* for exact
+            interpolation.
+
+    Returns:
+        npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix, shape
+        ``(degree + 1, n_pts)``.  Owned by the cache; do not mutate.
+    """
+    return _compute_bernstein_pinv(np.frombuffer(node_bytes, dtype=dtype).copy(), tol, degree)
+
+
+def _compute_bernstein_pinv(
+    nodes: npt.NDArray[np.floating[Any]],
+    tol: float | None,
+    degree: int | None,
+) -> npt.NDArray[np.floating[Any]]:
+    """Build the Bernstein pseudo-inverse, without consulting any cache.
+
+    This is the computation :func:`_build_bernstein_pinv` documents; that
+    function is the entry point, and decides whether the result is worth
+    keeping.
+
+    Args:
+        nodes (npt.NDArray[np.floating[Any]]): 1D interpolation nodes on
+            [0, 1], shape ``(n_pts,)``.
+        tol (float | None): SVD truncation tolerance, or *None* for the
+            dtype-based default.
+        degree (int | None): Target Bernstein degree, or *None* for exact
+            interpolation.
 
     Returns:
         npt.NDArray[np.floating[Any]]: Pseudo-inverse matrix, shape

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Iterator
+from typing import Any, Final
 
 import numpy as np
 import numpy.testing as nptest
@@ -10,7 +11,14 @@ import numpy.typing as npt
 import pytest
 
 from pantr.bezier import fit_bezier, interpolate_bezier
-from pantr.bezier._bezier_interpolate import _bernstein_interpolate
+from pantr.bezier._bezier_interpolate import (
+    _PINV_CACHE_MAX_ELEMENTS,
+    _bernstein_interpolate,
+    _bernstein_pinv_cached,
+    _bernstein_vandermonde_svd,
+    _build_bernstein_pinv,
+    _compute_bernstein_pinv,
+)
 from pantr.bezier._bezier_utils import _tabulate_bernstein_1d_fast
 from pantr.quad import PointsLattice, get_modified_chebyshev_nodes_1d
 
@@ -697,3 +705,144 @@ class TestFitValidation:
         """Values with wrong number of dims raises ValueError."""
         with pytest.raises(ValueError, match="dimensions"):
             fit_bezier(np.ones((2, 3, 4)), np.array([0.0, 1.0]))
+
+
+# ---------------------------------------------------------------------------
+# _bernstein_vandermonde_svd
+# ---------------------------------------------------------------------------
+
+_SVD_RECONSTRUCTION_FACTOR: Final[float] = 16.0
+"""Safety factor in the SVD reconstruction bound below.
+
+The backward stability of a QR- or divide-and-conquer-based SVD gives
+``||V - U diag(sigma) Vt||_F <= p(n) * eps * ||V||_2`` with ``p`` a low-degree
+polynomial in the dimensions (Demmel, *Applied Numerical Linear Algebra*,
+Thm. 5.5).  The theorem does not pin ``p``, so this factor is an acknowledged
+safety margin over ``p(n) = n`` and **not** a derivation.  ``pantr.tolerance``'s
+relative tolerances are deliberately not reused here: they are dimensionless
+comparison tolerances with no dependence on ``n``, which is the wrong shape for
+the Frobenius norm of an ``n``-by-``n`` residual.
+"""
+
+
+class TestBernsteinVandermondeSvd:
+    """The Bernstein Vandermonde factorization, which had no direct test before."""
+
+    @pytest.mark.parametrize("n", [1, 2, 5, 17, 30])
+    @pytest.mark.parametrize("dtype", [np.float64, np.float32])
+    def test_the_factors_reconstruct_the_vandermonde(
+        self, n: int, dtype: type[np.floating[Any]]
+    ) -> None:
+        """U diag(sigma) Vt returns the matrix that was factorized."""
+        U, sigma, Vt = _bernstein_vandermonde_svd(n, dtype)
+        nodes = get_modified_chebyshev_nodes_1d(max(n, 2), dtype)[:n]
+        expected = _tabulate_bernstein_1d_fast(n - 1, nodes, dtype)
+
+        residual = float(np.linalg.norm(np.asarray(U * sigma) @ Vt - expected))
+        eps = float(np.finfo(dtype).eps)
+        assert residual <= _SVD_RECONSTRUCTION_FACTOR * n * eps * float(sigma[0])
+
+
+# ---------------------------------------------------------------------------
+# _build_bernstein_pinv — memoization
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clean_pinv_cache() -> Iterator[None]:
+    """Empty the pseudo-inverse cache around a test that counts its misses.
+
+    Yields:
+        None: The test runs with an empty cache and leaves one behind.
+    """
+    _bernstein_pinv_cached.cache_clear()
+    yield
+    _bernstein_pinv_cached.cache_clear()
+
+
+class TestBernsteinPinvCache:
+    """The memoized Bernstein pseudo-inverse, which both entry points reach."""
+
+    def test_mutating_a_result_does_not_corrupt_the_cache(self) -> None:
+        """The caller owns what it gets, so a later call is unaffected by its edits."""
+        nodes = get_modified_chebyshev_nodes_1d(7, np.float64)
+        pristine = _build_bernstein_pinv(nodes).copy()
+
+        _build_bernstein_pinv(nodes)[...] += 1.0
+
+        nptest.assert_array_equal(_build_bernstein_pinv(nodes), pristine)
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_a_repeated_node_set_factorizes_only_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Equal nodes hit the same entry even when they are distinct array objects."""
+        calls = 0
+        real_svd = np.linalg.svd
+
+        def counting_svd(*args: Any, **kwargs: Any) -> Any:
+            nonlocal calls
+            calls += 1
+            return real_svd(*args, **kwargs)
+
+        monkeypatch.setattr(np.linalg, "svd", counting_svd)
+        for _ in range(4):
+            _build_bernstein_pinv(get_modified_chebyshev_nodes_1d(12, np.float64))
+
+        assert calls == 1
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_the_same_bytes_in_a_different_dtype_do_not_collide(self) -> None:
+        """Two node arrays sharing a buffer length are still distinct cache keys.
+
+        Four ``float32`` nodes and two ``float64`` nodes occupy the same sixteen
+        bytes, so a key made of the buffer alone would confuse them.  The dtype is
+        part of the key for exactly this reason.
+        """
+        wide = np.array([0.0, 1.0], dtype=np.float64)
+        narrow = np.frombuffer(wide.tobytes(), dtype=np.float32).copy()
+        assert wide.tobytes() == narrow.tobytes()
+
+        assert _build_bernstein_pinv(wide).shape == (2, 2)
+        assert _build_bernstein_pinv(narrow).shape == (4, 4)
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_a_different_tolerance_is_a_different_entry(self) -> None:
+        """Truncating at a tolerance that discards singular values changes the result."""
+        nodes = get_modified_chebyshev_nodes_1d(12, np.float64)
+
+        default = _build_bernstein_pinv(nodes)
+        blunt = _build_bernstein_pinv(nodes, 0.5)
+
+        assert not np.array_equal(default, blunt)
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_a_strided_node_array_agrees_with_its_contiguous_copy(self) -> None:
+        """Keying on the buffer must read the logical values, not the memory layout."""
+        dense = get_modified_chebyshev_nodes_1d(16, np.float64)
+        strided = np.repeat(dense, 2)[::2]
+        assert not strided.flags.c_contiguous
+
+        nptest.assert_array_equal(_build_bernstein_pinv(strided), _build_bernstein_pinv(dense))
+
+    def test_the_degenerate_single_node_case_still_short_circuits(self) -> None:
+        """One node at degree zero returns the one-by-one identity without a solve."""
+        nptest.assert_array_equal(
+            _build_bernstein_pinv(np.array([0.5])), np.ones((1, 1), dtype=np.float64)
+        )
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_a_matrix_too_large_to_hold_is_not_cached(self) -> None:
+        """A wide fit against very many nodes computes and discards, rather than retaining.
+
+        The shape that pays worst is the one the guard is for: the saving scales with
+        the degree while the retained memory scales with the node count.
+        """
+        degree = 5
+        n_pts = 2 * _PINV_CACHE_MAX_ELEMENTS // (degree + 1)
+        nodes = np.linspace(0.0, 1.0, n_pts)
+
+        pinv = _build_bernstein_pinv(nodes, None, degree)
+
+        assert _bernstein_pinv_cached.cache_info().currsize == 0
+        nptest.assert_array_equal(pinv, _compute_bernstein_pinv(nodes, None, degree))

--- a/tests/test_bezier_interpolate.py
+++ b/tests/test_bezier_interpolate.py
@@ -818,12 +818,17 @@ class TestBernsteinPinvCache:
 
     @pytest.mark.usefixtures("_clean_pinv_cache")
     def test_a_strided_node_array_agrees_with_its_contiguous_copy(self) -> None:
-        """Keying on the buffer must read the logical values, not the memory layout."""
+        """Keying on the buffer must read the logical values, not the memory layout.
+
+        Equal output is not enough to show that: it would hold even if the strided
+        call missed and recomputed. The cache size pins that the two share one entry.
+        """
         dense = get_modified_chebyshev_nodes_1d(16, np.float64)
         strided = np.repeat(dense, 2)[::2]
         assert not strided.flags.c_contiguous
 
         nptest.assert_array_equal(_build_bernstein_pinv(strided), _build_bernstein_pinv(dense))
+        assert _bernstein_pinv_cached.cache_info().currsize == 1
 
     def test_the_degenerate_single_node_case_still_short_circuits(self) -> None:
         """One node at degree zero returns the one-by-one identity without a solve."""
@@ -832,17 +837,49 @@ class TestBernsteinPinvCache:
         )
 
     @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_a_different_degree_is_a_different_entry(self) -> None:
+        """The same nodes at two degrees give two matrices, not one reused twice.
+
+        Unlike a wrong dtype or tolerance, a dropped ``degree`` key would usually
+        surface as a shape mismatch somewhere downstream rather than here, which is
+        why it gets its own assertion.
+        """
+        nodes = get_modified_chebyshev_nodes_1d(10, np.float64)
+
+        exact = _build_bernstein_pinv(nodes, None, None)
+        reduced = _build_bernstein_pinv(nodes, None, 4)
+
+        assert exact.shape == (10, 10)
+        assert reduced.shape == (5, 10)
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
+    def test_the_cached_matrix_is_the_one_the_computation_produces(self) -> None:
+        """A cache hit returns what an uncached build would have, bit for bit.
+
+        The size-guard test below cannot check this: its branch *is* a call to
+        :func:`_compute_bernstein_pinv`, so the two sides agree by construction. This
+        one goes through the cache, where the nodes are rebuilt from their bytes.
+        """
+        nodes = get_modified_chebyshev_nodes_1d(13, np.float64)
+        expected = _compute_bernstein_pinv(nodes, None, None)
+
+        _build_bernstein_pinv(nodes)  # populate
+        nptest.assert_array_equal(_build_bernstein_pinv(nodes), expected)
+
+    @pytest.mark.usefixtures("_clean_pinv_cache")
     def test_a_matrix_too_large_to_hold_is_not_cached(self) -> None:
         """A wide fit against very many nodes computes and discards, rather than retaining.
 
         The shape that pays worst is the one the guard is for: the saving scales with
-        the degree while the retained memory scales with the node count.
+        the degree while the retained memory scales with the node count. The pair
+        straddles the cap so the test pins the boundary rather than one side of it.
         """
         degree = 5
-        n_pts = 2 * _PINV_CACHE_MAX_ELEMENTS // (degree + 1)
-        nodes = np.linspace(0.0, 1.0, n_pts)
+        under = _PINV_CACHE_MAX_ELEMENTS // (degree + 1)
+        over = 2 * under
 
-        pinv = _build_bernstein_pinv(nodes, None, degree)
+        _build_bernstein_pinv(np.linspace(0.0, 1.0, under), None, degree)
+        assert _bernstein_pinv_cached.cache_info().currsize == 1
 
-        assert _bernstein_pinv_cached.cache_info().currsize == 0
-        nptest.assert_array_equal(pinv, _compute_bernstein_pinv(nodes, None, degree))
+        _build_bernstein_pinv(np.linspace(0.0, 1.0, over), None, degree)
+        assert _bernstein_pinv_cached.cache_info().currsize == 1


### PR DESCRIPTION
## Context

The third and last `bezier` block for the C++ port is `_bezier_interpolate.py`. It was
measured the way the arithmetic and root-finding blocks were, and the measurement went the
other way: **the block is not ported**. What ships instead is the memoization the profiling
turned up, which needs no C++ at all.

`design/bezier_interpolation_port.md` is the ruling and its evidence.
`scripts/measure_bezier_interpolation_port.py` reproduces all five measurements.

## What the measurements said

**The blocker anticipated for this block does not fire.** Truncating the pseudo-inverse at
`tol * sigma[0]` is a discrete verdict, not a displacement, so two SVD implementations
disagreeing about whether a singular value clears the cut would move the result by a rank-one
term of order `1 / (tol * sigma[0])`. Over the real Bernstein Vandermonde matrices at orders
10, 20, 25, 30, 36 and 39 in both dtypes, Eigen's `BDCSVD` and LAPACK's `gesdd` chose the
**same rank in every case**, including the tightest, where a singular value sits about two
parts in a thousand above the cut and the two place it within about one part in ten thousand
of each other.

**But nothing positive replaces it.**

- Eigen's SVD is not the faster one, so there is no speed argument for moving the dominant term.
- Once the factorization is memoized, the numerical work a C++ kernel would actually replace,
  one `tensordot` per direction, is about **a fifteenth of a warm call**. Twice that again goes
  to the caller's own Python function, which `interpolate_bezier` is *handed* and no port
  removes.
- The downstream consumer imports neither entry point, and never passes float32 anywhere near
  this code. Float32 from order 20 up is the only regime where the truncation fires at all.
- `_fit_from_scattered` is shared with `bspline`, which is out of Stage 1 scope.

## What ships

`_build_bernstein_pinv` is the single site both `interpolate_bezier` and `fit_bezier` reach for
a tensor-product fit, once per parametric direction, and its truncated SVD was the largest
single cost in the call. It rebuilt it every time. It is now memoized on
`(nodes, tol, degree)`, **keyed on the nodes' bytes and dtype** rather than on the array
object, because the default path generates its Chebyshev nodes fresh on each call and a key
based on identity would never hit.

Results are **bitwise identical**. Measured with threads pinned, a tensor-product call runs
roughly three to eight times faster; a square two-dimensional grid gains twice over, since both
directions share one node set. The scattered path does not move, and says so in the changelog.

Two details worth review:

- The entry point returns a **copy**, so callers keep the independent, writable array they have
  always had. The copy is quadratic in the order where the factorization it avoids is cubic.
- A matrix above `_PINV_CACHE_MAX_ELEMENTS` is computed and discarded rather than retained.
  Entry count alone does not bound memory, and a wide, low-degree fit against very many nodes
  both retains the most and is least likely to be repeated. **That cap is a policy choice and
  its docstring says so**; it is not derived.

`_bernstein_vandermonde_svd` was memoized too, then dropped: nothing in the package calls it,
and its own caller `_bernstein_interpolate` has no caller here either. It gains a first direct
test but no cache, and a `Note:` saying why.

## A machine artifact this turned up

With the thread-count variables at 20, a 36-by-36 LAPACK SVD cost between one and two orders of
magnitude more than the same call pinned to one thread, and varied by nearly an order of
magnitude between batches. Twenty threads synchronizing over a matrix that fits in L1 is pure
overhead.

The consequence is procedural: **any timing of this block on a many-core machine is worthless
unless threads are pinned**. The measurement script refuses to time anything otherwise. This is
recorded because the first version of this work quoted an unpinned figure as a speedup when it
was thread noise, and the design note keeps that on the record.

## Acceptance criteria

- [x] `interpolate_bezier` and `fit_bezier` return bitwise-identical results, on every existing
      test and on a direct comparison against the unmemoized path.
- [x] A returned matrix can be mutated without corrupting the cache.
- [x] Equal nodes in distinct array objects share one entry; the same buffer under a different
      dtype does not collide; the tolerance is part of the key; a strided node array agrees with
      its contiguous copy.
- [x] A matrix above the size cap is not retained.
- [x] Each of those guards was checked by breaking the code and watching the matching test fail.
- [x] `scripts/ci_local.sh` 37/37; full suite green under both backends; ruff, ruff format,
      mypy, import-lint, doctests and the docs build all clean.

## Non-goals

- Porting any part of `_bezier_interpolate.py` to C++.
- Touching `_fit_from_scattered`, which `bspline` also imports.
- The three open tolerance-derivation tickets in the root-finding kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
