### PR TITLE
fix(bezier): test a sign by comparing signs, and drop an absolute tolerance floor

### DIFF
--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -608,13 +608,16 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
     // The subtraction is at T: `float()` does not widen, so widening here would size
     // every boundary test differently. Measured, 6000 of 6000.
     const T scale = static_cast<T>(d_max - d_min);
-    // FELIGN/pantr#352, reproduced deliberately. The 1e-30 floor is absolute inside
-    // an otherwise scale-relative tolerance, so below it every coefficient of the
-    // problem reads as zero and the endpoints are returned as roots. Rescaling the
-    // same polynomial moves the answer, which is the defect.
+    // No absolute floor, matching the oracle. FELIGN/pantr#352 was a `1e-30` floor
+    // here, absolute inside an otherwise scale-relative tolerance: below a
+    // coefficient range of about 5.6e-16 it won the maximum, every coefficient of
+    // the problem read as zero, and the endpoints came back as roots. Rescaling the
+    // same polynomial moved the answer, which is what made it a defect rather than a
+    // limit. Reproduced here deliberately while the oracle carried it; both sides
+    // dropped it in one change. The factor of 8 is inherited from the oracle, not
+    // derived.
     const Acc boundary_eps =
-        std::max(static_cast<Acc>(abs(scale)) * static_cast<Acc>(kDblEpsilon) * Acc{8},
-                 Acc{1e-30});
+        static_cast<Acc>(abs(scale)) * static_cast<Acc>(kDblEpsilon) * Acc{8};
 
     Acc prev_t{0};
     T f_prev = coeff[0];
@@ -784,7 +787,9 @@ int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<doubl
             const double f_lo = coeff_lev[0];
             const double f_hi = coeff_lev[static_cast<std::size_t>(deg_lev)];
             const double scale = abs(hi_val - lo_val);
-            const double boundary_eps = std::max(scale * kDblEpsilon * 8.0, 1e-30);
+            // Same bound over this level's own span, floorless for the reason
+            // given in find_roots_at_level. FELIGN/pantr#352.
+            const double boundary_eps = scale * kDblEpsilon * 8.0;
 
             if (abs(f_lo) <= boundary_eps) {
                 crit[0] = 0.0;

--- a/cpp/include/pantr/bezier/root_finding.hpp
+++ b/cpp/include/pantr/bezier/root_finding.hpp
@@ -396,13 +396,12 @@ bool clip_hull_to_zero(std::span<const T> coeff, std::span<std::int64_t> chain, 
             const auto ib = static_cast<std::ptrdiff_t>(chain[static_cast<std::size_t>(k) + 1]);
             const T da = coeff[static_cast<std::size_t>(ia)];
             const T db = coeff[static_cast<std::size_t>(ib)];
-            // At T, not at double. The oracle reads both endpoints straight out of
-            // the coefficient array, so the sign test and the quotient are T
-            // operations and only the multiplication by the float64 span promotes.
-            // Widening them first diverges on every one of 10143 sign-changing
-            // float32 edges measured, and the T-width product can underflow to zero
-            // and miss a crossing, which is the same mechanism as FELIGN/pantr#351.
-            if (da * db < T{0}) {
+            // The quotient stays at T: the oracle reads both endpoints straight out
+            // of the coefficient array, so it is a T operation and only the
+            // multiplication by the float64 span promotes. Widening it first diverges
+            // on every one of 10143 sign-changing float32 edges measured. The sign
+            // test no longer has a width, because it no longer forms a product.
+            if (have_opposite_signs(da, db)) {
                 const double ta = static_cast<double>(ia) * inv_n;
                 const double tb = static_cast<double>(ib) * inv_n;
                 const T quotient = static_cast<T>(static_cast<T>(-da) / static_cast<T>(db - da));
@@ -496,11 +495,12 @@ accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulato
     const T f_lo = coeff[0];
     const T f_hi = coeff[coeff.size() - 1];
 
-    // FELIGN/pantr#351, reproduced deliberately. This product is at T, so at float32
-    // two same-sign coefficients below about 1e-23 multiply to zero, the guard does
-    // not fire, and a root is returned for a polynomial that has none. Computing it
-    // at Acc would be correct and would break parity with the oracle.
-    if (f_lo * f_hi > T{0}) {
+    // FELIGN/pantr#351 was reproduced here deliberately while the oracle carried it:
+    // the guard was a T product, so at float32 two same-sign coefficients below about
+    // 1e-23 multiplied to zero, it did not fire, and a root was returned for a
+    // polynomial that has none. The oracle now compares the signs, so this does too,
+    // and the question of which width to form the product at does not arise.
+    if (have_same_sign(f_lo, f_hi)) {
         return std::numeric_limits<Acc>::quiet_NaN();
     }
 
@@ -520,7 +520,7 @@ accumulator_t<T> solve_monotone_root_kernel(std::span<const T> coeff, accumulato
         Acc dfx{};
         const Acc fx = de_casteljau_eval_and_deriv_scalar<T>(coeff, x, work, dfx);
 
-        if (static_cast<Acc>(f_lo) * fx <= Acc{0}) {
+        if (spans_zero(static_cast<Acc>(f_lo), fx)) {
             hi = x;
         } else {
             lo = x;
@@ -561,7 +561,7 @@ accumulator_t<T> solve_on_interval(std::span<const T> coeff, accumulator_t<T> lo
         Acc dfx{};
         const Acc fx = de_casteljau_eval_and_deriv_scalar<T>(coeff, x, work, dfx);
 
-        if (f_lo * fx <= Acc{0}) {
+        if (spans_zero(f_lo, fx)) {
             hi = x;
         } else {
             lo = x;
@@ -647,10 +647,11 @@ int find_roots_at_level(std::span<const T> coeff, std::span<const double> crit, 
             continue;
         }
 
-        // FELIGN/pantr#351, reproduced deliberately: a T product, so at float32 two
-        // opposite-sign values below about 1e-23 multiply to zero, no sign change is
-        // seen, and a root that exists is lost.
-        if (f_prev * f_curr < T{0}) {
+        // The lost-root face of FELIGN/pantr#351, reproduced here deliberately while
+        // the oracle carried it: a T product, so at float32 two opposite-sign values
+        // below about 1e-23 multiplied to zero, no sign change was seen, and a root
+        // that exists was lost. Both sides compare the signs now.
+        if (have_opposite_signs(f_prev, f_curr)) {
             const Acc root = solve_on_interval<T>(coeff, prev_t, curr_t,
                                                   static_cast<Acc>(f_prev), tol, work);
             if (count < n) {
@@ -788,7 +789,7 @@ int yuksel_roots(std::span<const T> coeff, accumulator_t<T> tol, std::span<doubl
             if (abs(f_lo) <= boundary_eps) {
                 crit[0] = 0.0;
                 n_crit = 1;
-            } else if (f_lo * f_hi < 0.0) {
+            } else if (have_opposite_signs(f_lo, f_hi)) {
                 crit[0] = solve_on_interval<double>(coeff_lev, 0.0, 1.0, f_lo, tol, level_work);
                 n_crit = 1;
             } else if (abs(f_hi) <= boundary_eps) {
@@ -905,18 +906,18 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
                     for (int bisect = 0; bisect < 10; ++bisect) {
                         const double m = 0.5 * (a + b);
                         const T fm = de_casteljau_eval_scalar<T>(root_coeff, m, work);
-                        // FELIGN/pantr#351, third site: a T product, so it can
-                        // underflow at float32. Reproduced deliberately; unlike the
-                        // other two this one has no verified reproduction, only the
-                        // same mechanism.
+                        // The third site of FELIGN/pantr#351: a T product, so it
+                        // could underflow at float32. Unlike the other two this one
+                        // never had a verified reproduction, only the same mechanism,
+                        // and it is fixed on that ground.
                         if (abs(fm) < abs(fa)) {
-                            if (fa * fm <= T{0}) {
+                            if (spans_zero(fa, fm)) {
                                 b = m;
                             } else {
                                 a = m;
                                 fa = fm;
                             }
-                        } else if (fa * fm <= T{0}) {
+                        } else if (spans_zero(fa, fm)) {
                             b = m;
                         } else {
                             a = m;
@@ -974,7 +975,7 @@ int clip_roots_core(std::span<const T> root_coeff, accumulator_t<T> param_tol,
         // Step 5: flat within noise.
         if (c_max - c_min <= geom_tol) {
             if (abs(c_min) <= local_zero_tol || abs(c_max) <= local_zero_tol
-                || c_min * c_max < 0.0) {
+                || have_opposite_signs(c_min, c_max)) {
                 const double mid = 0.5 * (lo + hi);
                 const T f_mid = de_casteljau_eval_scalar<T>(root_coeff, mid, work);
                 if (abs(static_cast<Acc>(f_mid)) <= zero_tol && n_roots < max_roots) {

--- a/cpp/include/pantr/core/scalar.hpp
+++ b/cpp/include/pantr/core/scalar.hpp
@@ -51,6 +51,7 @@
 ///     the example here: it decides how many basis functions exist, so it is an
 ///     `int` and never a scalar.
 
+#include <cmath>
 #include <concepts>
 #include <type_traits>
 
@@ -144,6 +145,72 @@ concept Real =
         { a * b } -> std::convertible_to<T>;
         { a / b } -> std::convertible_to<T>;
     };
+
+/// Test whether two scalars are both strictly positive or both strictly negative.
+///
+/// Tier B: a sign test is a function of the value, so both operands pass through
+/// `value_of`.
+///
+/// ## Why this exists rather than `a * b > 0`
+///
+/// The product is the defect. Two operands of magnitude `1e-23` are perfectly
+/// representable at `float32` while their product falls under that format's
+/// minimum subnormal and flushes to zero, so the test answers as though one
+/// operand had vanished -- inventing a root for a polynomial that has none, or
+/// losing one that exists. FELIGN/pantr#351 records both faces with verified
+/// reproductions. Comparing the signs forms no product and so cannot underflow
+/// or overflow at any width, which also retires the question of which width the
+/// product should be computed at.
+///
+/// Exactly equivalent to `a * b > 0` on every IEEE input. A zero or a NaN
+/// operand makes both forms false, and `inf * 0` is NaN, which is not greater
+/// than zero either.
+template <Real T>
+[[nodiscard]] constexpr bool have_same_sign(const T& a, const T& b) noexcept {
+    using pantr::value_of;
+    const auto va = value_of(a);
+    const auto vb = value_of(b);
+    using V = decltype(va);
+    return (va > V{0} && vb > V{0}) || (va < V{0} && vb < V{0});
+}
+
+/// Test whether two scalars have strictly opposite signs.
+///
+/// Tier B, and exactly equivalent to `a * b < 0` on every IEEE input; see
+/// `have_same_sign` for why the product form is the defect. A zero or a NaN
+/// operand makes both forms false.
+template <Real T>
+[[nodiscard]] constexpr bool have_opposite_signs(const T& a, const T& b) noexcept {
+    using pantr::value_of;
+    const auto va = value_of(a);
+    const auto vb = value_of(b);
+    using V = decltype(va);
+    return (va > V{0} && vb < V{0}) || (va < V{0} && vb > V{0});
+}
+
+/// Test whether two bracket values span zero, counting an exact zero as spanned.
+///
+/// Tier B, and exactly equivalent to `a * b <= 0` on every IEEE input; see
+/// `have_same_sign` for why the product form is the defect.
+///
+/// The finiteness guards are what make that equivalence exact rather than
+/// approximate, and they are the reason this is not simply the negation of
+/// `have_same_sign`. `a * b` is a signed zero when one operand is zero and the
+/// other is finite, but it is NaN when the other is an infinity, and NaN is not
+/// less than or equal to zero. Dropping the guards would report a spanned
+/// bracket for `(0, inf)`, where the product form reports none; negating
+/// `have_same_sign` instead would report one for `(NaN, NaN)`.
+template <Real T>
+[[nodiscard]] constexpr bool spans_zero(const T& a, const T& b) noexcept {
+    using pantr::value_of;
+    const auto va = value_of(a);
+    const auto vb = value_of(b);
+    using V = decltype(va);
+    if ((va > V{0} && vb < V{0}) || (va < V{0} && vb > V{0})) {
+        return true;
+    }
+    return (va == V{0} && std::isfinite(vb)) || (vb == V{0} && std::isfinite(va));
+}
 
 /// The floating-point type underlying a `Real`: `double` for `double`, and the
 /// value component for a differentiable type.

--- a/cpp/tests/test_bezier_root_finding.cpp
+++ b/cpp/tests/test_bezier_root_finding.cpp
@@ -10,10 +10,13 @@
 /// compares the two backends. Every check is against a property the mathematics
 /// fixes, or against a second algorithm.
 ///
-/// That distinction is not hypothetical here. The oracle carries two known wrong
-/// answers, FELIGN/pantr#351 and #352, which the C++ reproduces on purpose. Both
-/// live at coefficient magnitudes below `1e-23` and `1e-30`; every polynomial in
-/// this file is of order one, so nothing below is testing in their shadow.
+/// That distinction is not hypothetical here. The oracle used to carry two known
+/// wrong answers, FELIGN/pantr#351 and #352, which the C++ reproduced on purpose;
+/// both are now fixed on both sides. They lived at coefficient magnitudes below
+/// `1e-23` and `1e-30`, and every polynomial in this file is of order one, so
+/// nothing below ever tested in their shadow -- which is also why nothing below
+/// changed when they were fixed. The sign-predicate substitution that closed
+/// #351 is checked in test_scalar_generic.cpp, at the magnitudes that reach it.
 ///
 /// ## The exact checks, and why they can be exact
 ///

--- a/cpp/tests/test_scalar_generic.cpp
+++ b/cpp/tests/test_scalar_generic.cpp
@@ -316,9 +316,107 @@ void low_degree_derivatives_match_closed_forms() {
 
 }  // namespace
 
+/// The three sign predicates are exactly the product forms they replace.
+///
+/// They exist to remove a product from a sign test, because the product is the
+/// defect: two operands of magnitude `1e-23` are perfectly representable at
+/// `float32` while their product falls under that format's minimum subnormal and
+/// flushes to zero, so the test answers as though one operand had vanished
+/// (FELIGN/pantr#351). Substituting them is only sound if they agree with the
+/// product everywhere the product is right.
+///
+/// Every pair drawn from the value list has an exact product -- `inf * 0 = NaN`
+/// included -- so agreement here must be total. Both floating-point widths are
+/// checked, since the substituted sites span `T` and `accumulator_t<T>`.
+template <std::floating_point V>
+void sign_predicates_match_the_product_forms() {
+    const V values[] = {-std::numeric_limits<V>::infinity(),
+                        V{-3},
+                        V{-1},
+                        V{-0.0},
+                        V{0},
+                        V{1},
+                        V{3},
+                        std::numeric_limits<V>::infinity(),
+                        std::numeric_limits<V>::quiet_NaN()};
+
+    for (const V a : values) {
+        for (const V b : values) {
+            const V product = a * b;
+            PANTR_CHECK(pantr::have_same_sign(a, b) == (product > V{0}));
+            PANTR_CHECK(pantr::have_opposite_signs(a, b) == (product < V{0}));
+            PANTR_CHECK(pantr::spans_zero(a, b) == (product <= V{0}));
+        }
+    }
+}
+
+/// The predicates are right in the regime where the product flushes to zero.
+///
+/// This is the defect itself, reached at `float` where it bites the shipped code
+/// and again at `double` so that no dtype conversion is involved. Both operands
+/// stay perfectly representable; only their product cannot be formed.
+template <std::floating_point V>
+void sign_predicates_survive_underflow(V tiny) {
+    PANTR_CHECK(tiny > V{0});
+    PANTR_CHECK(tiny * tiny == V{0});
+
+    PANTR_CHECK(pantr::have_same_sign(tiny, tiny));
+    PANTR_CHECK(!(tiny * tiny > V{0}));
+
+    PANTR_CHECK(pantr::have_opposite_signs(tiny, -tiny));
+    PANTR_CHECK(!(tiny * -tiny < V{0}));
+
+    PANTR_CHECK(!pantr::spans_zero(tiny, tiny));
+    PANTR_CHECK(tiny * tiny <= V{0});
+}
+
+/// A zero paired with an infinity is not a spanned bracket.
+///
+/// The single pair that separates the exact predicate from the naive one: `0 *
+/// inf` is NaN, which is not less than or equal to zero, so the product form
+/// reports no span and `spans_zero` must agree. A regression here is invisible
+/// in the matrix above, which is why it is called out.
+void zero_with_infinity_is_not_spanned() {
+    for (const double zero : {0.0, -0.0}) {
+        for (const double infinity : {HUGE_VAL, -HUGE_VAL}) {
+            PANTR_CHECK(!pantr::spans_zero(zero, infinity));
+            PANTR_CHECK(!pantr::spans_zero(infinity, zero));
+        }
+    }
+}
+
+/// The predicates are reachable from a scalar that has no ordering of its own.
+///
+/// This is the Tier B claim, and `Dual1` is what makes it a build failure rather
+/// than a convention: the fixture deliberately supplies no `operator==` and no
+/// ordering, so `a * b < T{0}` -- the form these predicates replaced -- cannot
+/// compile for it at all. Going through `value_of` is what makes them work here,
+/// and this function failing to compile is the regression signal.
+void sign_predicates_reach_a_scalar_without_ordering() {
+    static_assert(pantr::Real<Dual1>, "the fixture must still satisfy Real");
+
+    const Dual1 positive{2.0, 1.0};
+    const Dual1 negative{-2.0, 1.0};
+    const Dual1 zero{0.0, 1.0};
+
+    PANTR_CHECK(pantr::have_same_sign(positive, positive));
+    PANTR_CHECK(!pantr::have_same_sign(positive, negative));
+    PANTR_CHECK(pantr::have_opposite_signs(positive, negative));
+    PANTR_CHECK(!pantr::have_opposite_signs(positive, positive));
+    PANTR_CHECK(pantr::spans_zero(positive, negative));
+    PANTR_CHECK(pantr::spans_zero(positive, zero));
+    PANTR_CHECK(!pantr::spans_zero(positive, positive));
+}
+
 int main() {
     dual_value_component_matches_double_exactly();
     derivatives_sum_to_zero();
     low_degree_derivatives_match_closed_forms();
+    sign_predicates_match_the_product_forms<float>();
+    sign_predicates_match_the_product_forms<double>();
+    sign_predicates_survive_underflow(1e-25F);
+    sign_predicates_survive_underflow(1e-200);
+    zero_with_infinity_is_not_spanned();
+    sign_predicates_reach_a_scalar_without_ordering();
     return pantr::test::summary("test_scalar_generic");
 }

--- a/src/pantr/bezier/_clipping_core.py
+++ b/src/pantr/bezier/_clipping_core.py
@@ -29,7 +29,9 @@ from pantr.bezier._root_finding_core import (
     _count_sign_changes,
     _de_casteljau_eval_and_deriv_scalar,
     _de_casteljau_eval_scalar,
+    _have_opposite_signs,
     _newton_polish_scalar,
+    _spans_zero,
     _subdivide_scalar,
 )
 
@@ -131,12 +133,12 @@ def _clip_roots_core(  # noqa: PLR0912, PLR0915
                         m = 0.5 * (a + b)
                         fm = _de_casteljau_eval_scalar(root_coeff, m)
                         if abs(fm) < abs(fa):
-                            if fa * fm <= 0.0:
+                            if _spans_zero(fa, fm):
                                 b = m
                             else:
                                 a = m
                                 fa = fm
-                        elif fa * fm <= 0.0:
+                        elif _spans_zero(fa, fm):
                             b = m
                         else:
                             a = m
@@ -182,7 +184,11 @@ def _clip_roots_core(  # noqa: PLR0912, PLR0915
 
         # ---- Step 5: near-zero polynomial (flat within noise) -----------
         if c_max - c_min <= geom_tol:
-            if abs(c_min) <= local_zero_tol or abs(c_max) <= local_zero_tol or c_min * c_max < 0.0:
+            if (
+                abs(c_min) <= local_zero_tol
+                or abs(c_max) <= local_zero_tol
+                or _have_opposite_signs(c_min, c_max)
+            ):
                 mid = 0.5 * (lo + hi)
                 f_mid = _de_casteljau_eval_scalar(root_coeff, mid)
                 if abs(f_mid) <= zero_tol and n_roots < max_roots:

--- a/src/pantr/bezier/_root_finding_core.py
+++ b/src/pantr/bezier/_root_finding_core.py
@@ -26,6 +26,87 @@ _DBL_EPSILON: float = 2.2204460492503131e-16
 """Machine epsilon for IEEE 754 double precision."""
 
 
+# The three predicates below replace sign tests written as ``a * b`` compared
+# against zero. The product is the defect: at ``float32`` two operands of
+# magnitude 1e-23 are perfectly representable while their product falls under
+# that format's minimum subnormal and flushes to zero, so the test answers as
+# though one operand vanished. Comparing the signs needs no product and cannot
+# underflow or overflow.
+#
+# Each is exactly equivalent to the product form it replaces on every IEEE
+# input, infinities and NaN included, which is what lets them be substituted
+# without a parity claim. That equivalence is asserted exhaustively over a
+# special-value matrix in tests/test_root_finding.py rather than argued here.
+
+
+@nb_jit(nopython=True, cache=True)
+def _have_same_sign(a: float, b: float) -> bool:
+    """Test whether two values are both strictly positive or both strictly negative.
+
+    Exactly equivalent to ``a * b > 0.0``, without forming the product. A zero
+    or a NaN operand makes both forms false, and ``inf * 0.0`` is NaN, which is
+    not greater than zero either.
+
+    Args:
+        a (float): First value.
+        b (float): Second value.
+
+    Returns:
+        bool: True if both are strictly positive or both strictly negative.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    return (a > 0.0 and b > 0.0) or (a < 0.0 and b < 0.0)
+
+
+@nb_jit(nopython=True, cache=True)
+def _have_opposite_signs(a: float, b: float) -> bool:
+    """Test whether two values have strictly opposite signs.
+
+    Exactly equivalent to ``a * b < 0.0``, without forming the product. A zero
+    or a NaN operand makes both forms false.
+
+    Args:
+        a (float): First value.
+        b (float): Second value.
+
+    Returns:
+        bool: True if one value is strictly positive and the other strictly negative.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    return (a > 0.0 and b < 0.0) or (a < 0.0 and b > 0.0)
+
+
+@nb_jit(nopython=True, cache=True)
+def _spans_zero(a: float, b: float) -> bool:
+    """Test whether two bracket values span zero, counting an exact zero as spanned.
+
+    Exactly equivalent to ``a * b <= 0.0``, without forming the product. The
+    finiteness guards are what make the equivalence exact rather than
+    approximate: ``a * b`` is a signed zero when one operand is zero and the
+    other is finite, but it is NaN when the other is an infinity, and NaN is
+    not less than or equal to zero. Dropping the guards would report a spanned
+    bracket for ``(0.0, inf)``, where the product form reports none.
+
+    Args:
+        a (float): Value at one end of the bracket.
+        b (float): Value at the other end.
+
+    Returns:
+        bool: True if the two values have opposite signs or either is an exact
+            zero paired with a finite partner.
+
+    Note:
+        Inputs are assumed to be correct (no validation performed).
+    """
+    if (a > 0.0 and b < 0.0) or (a < 0.0 and b > 0.0):
+        return True
+    return (a == 0.0 and np.isfinite(b)) or (b == 0.0 and np.isfinite(a))
+
+
 @nb_jit(nopython=True, cache=True)
 def _de_casteljau_eval_scalar(
     coeff: npt.NDArray[np.float32 | np.float64],
@@ -285,7 +366,7 @@ def _clip_hull_to_zero(  # noqa: PLR0912, PLR0915
         ib = upper[k + 1]
         da = coeff[ia]
         db = coeff[ib]
-        if da * db < 0.0:
+        if _have_opposite_signs(da, db):
             ta = ia * inv_n
             tb = ib * inv_n
             t_cross = ta + (-da) / (db - da) * (tb - ta)
@@ -326,7 +407,7 @@ def _clip_hull_to_zero(  # noqa: PLR0912, PLR0915
         ib = lower[k + 1]
         da = coeff[ia]
         db = coeff[ib]
-        if da * db < 0.0:
+        if _have_opposite_signs(da, db):
             ta = ia * inv_n
             tb = ib * inv_n
             t_cross = ta + (-da) / (db - da) * (tb - ta)

--- a/src/pantr/bezier/_yuksel_core.py
+++ b/src/pantr/bezier/_yuksel_core.py
@@ -36,6 +36,9 @@ from pantr.bezier._root_finding_core import (
     _DBL_EPSILON,
     _de_casteljau_eval_and_deriv_scalar,
     _de_casteljau_eval_scalar,
+    _have_opposite_signs,
+    _have_same_sign,
+    _spans_zero,
 )
 
 _MAX_NEWTON_ITER: int = 64
@@ -90,7 +93,7 @@ def _solve_monotone_root_kernel(
     f_hi = float(coeff[-1])
 
     # No sign change: no root.
-    if f_lo * f_hi > 0.0:
+    if _have_same_sign(f_lo, f_hi):
         return np.nan
 
     # False-position initial guess.
@@ -106,7 +109,7 @@ def _solve_monotone_root_kernel(
         fx, dfx = _de_casteljau_eval_and_deriv_scalar(coeff, x)
 
         # Shrink bracket.
-        if f_lo * fx <= 0.0:
+        if _spans_zero(f_lo, fx):
             hi = x
         else:
             lo = x
@@ -157,7 +160,7 @@ def _solve_on_interval(
     for _ in range(_MAX_NEWTON_ITER):
         fx, dfx = _de_casteljau_eval_and_deriv_scalar(coeff, x)
 
-        if f_lo * fx <= 0.0:
+        if _spans_zero(f_lo, fx):
             hi = x
         else:
             lo = x
@@ -236,7 +239,7 @@ def _find_roots_at_level(
                 continue
 
         # Check for sign change -> guaranteed interior root.
-        if f_prev * f_curr < 0.0:
+        if _have_opposite_signs(f_prev, f_curr):
             root = _solve_on_interval(coeff, prev_t, curr_t, f_prev, tol)
             if count < n:
                 roots[count] = root
@@ -362,7 +365,7 @@ def _yuksel_roots(  # noqa: PLR0912, PLR0915
                 crit = np.empty(1, dtype=np.float64)
                 crit[0] = 0.0
                 n_crit = 1
-            elif f_lo * f_hi < 0.0:
+            elif _have_opposite_signs(f_lo, f_hi):
                 root = _solve_on_interval(coeff_lev, 0.0, 1.0, f_lo, tol)
                 crit = np.empty(1, dtype=np.float64)
                 crit[0] = root

--- a/src/pantr/bezier/_yuksel_core.py
+++ b/src/pantr/bezier/_yuksel_core.py
@@ -208,10 +208,28 @@ def _find_roots_at_level(
     count = 0
 
     # Scale-relative boundary tolerance for detecting near-zero values.
+    #
+    # No absolute floor. One used to sit here as `max(..., 1e-30)` and it broke
+    # scale invariance: below a coefficient range of about 5.6e-16 the floor won
+    # the maximum, every coefficient of the problem read as zero however well
+    # separated they were, and the same polynomial rescaled got a different
+    # answer (FELIGN/pantr#352). Scaling a root-finding problem by a positive
+    # constant moves none of its roots, so that was an invariance broken rather
+    # than a precision limit reached.
+    #
+    # The `scale == 0` limit needs no floor either. It means every coefficient is
+    # equal, so the polynomial is constant, and the test then accepts only an
+    # exact zero -- the right reading of "this endpoint vanishes" for a function
+    # with no variation. A constant that is actually zero never arrives here:
+    # `_find_roots._find_roots_scalar` returns empty for an all-zero polynomial
+    # before any kernel is called.
+    #
+    # The factor of 8 is inherited, not derived, and it is the remaining soft
+    # spot in this bound. FELIGN/pantr#354 is where these tolerances are reworked.
     d_min = float(np.min(coeff))
     d_max = float(np.max(coeff))
     scale = abs(d_max - d_min)
-    boundary_eps = max(scale * _DBL_EPSILON * 8.0, 1e-30)
+    boundary_eps = scale * _DBL_EPSILON * 8.0
 
     prev_t = 0.0
     f_prev = float(coeff[0])
@@ -358,8 +376,10 @@ def _yuksel_roots(  # noqa: PLR0912, PLR0915
             f_lo = coeff_lev[0]
             f_hi = coeff_lev[deg_lev]
 
+            # Same bound as in `_find_roots_at_level`, over this level's own
+            # span, and with no absolute floor for the same reason. See there.
             scale = abs(hi_val - lo_val)
-            boundary_eps = max(scale * _DBL_EPSILON * 8.0, 1e-30)
+            boundary_eps = scale * _DBL_EPSILON * 8.0
 
             if abs(f_lo) <= boundary_eps:
                 crit = np.empty(1, dtype=np.float64)

--- a/tests/parity/test_bezier_root_finding.py
+++ b/tests/parity/test_bezier_root_finding.py
@@ -42,19 +42,19 @@ results, but 732 results are evidence and not a proof, so the count agreement is
 asserted as its own check and Rule 11 of ``design/backend_parity.md`` records that it
 is measured rather than derived.
 
-One defect is asserted, not worked around
-----------------------------------------
+Two defects were asserted here, and both are now fixed
+-----------------------------------------------------
 
-The oracle still returns a wrong answer in one regime, FELIGN/pantr#352, and the C++
-reproduces it deliberately because the port's contract is parity and not correction.
-The test below names it. **If you are here because it started failing, the fix is in
-both backends and in that test together**; making one side correct on its own is what
-breaks the equality this file exists to hold.
+FELIGN/pantr#351 and #352 were both pinned in this file as wrong answers that the C++
+reproduced deliberately, because the port's contract is parity and not correction.
+Both are now fixed on both sides, and the three tests that pinned the wrong answers
+pin the mathematics instead: no root for a strictly positive polynomial, the one root
+of ``a(1 - 2t)`` at ``t = 1/2``, and that same root at every scale.
 
-FELIGN/pantr#351 was asserted here the same way and is now fixed on both sides, which
-is what that procedure looks like when it is carried out: the oracle stopped forming a
-product to test a sign, the C++ stopped with it, and the two tests that had pinned the
-wrong answer now pin the mathematics instead.
+The procedure those tests were written to force is worth keeping in view, because the
+next such defect will land the same way. **The fix goes into both backends and into
+the test in one change**; making one side correct on its own is what breaks the
+equality this file exists to hold, and relaxing the test instead loses the defect.
 """
 
 from __future__ import annotations
@@ -718,33 +718,38 @@ def test_the_backends_agree_on_the_root_that_is_lost(
 
 
 def test_the_backends_agree_where_the_tolerance_stops_scaling(cpp_backend: None) -> None:
-    """Both backends reproduce FELIGN/pantr#352, at ``float64``.
+    """Both backends put the root of ``a(1 - 2t)`` at ``t = 0.5`` at every scale.
 
-    ``boundary_eps`` carries an absolute ``1e-30`` floor inside an otherwise
-    scale-relative tolerance, so below it every coefficient reads as zero, the
-    endpoints are reported as roots and the real one is lost. Rescaling the same
-    polynomial moves the answer, which is what makes it a defect rather than a limit.
+    This test used to assert the opposite, at ``1e-31``. ``boundary_eps`` carried an
+    absolute ``1e-30`` floor inside an otherwise scale-relative tolerance, so below
+    it every coefficient read as zero, the endpoints came back as roots and the real
+    one was lost. Rescaling the same polynomial moved the answer, which is what made
+    it FELIGN/pantr#352 rather than a precision limit.
 
-    Asserted here for the same reason as #351: the C++ reproduces it, and both sides
-    change together or not at all.
+    Both backends dropped the floor in one change, so the assertion is now the
+    invariance itself: scaling a root-finding problem by a positive constant moves
+    none of its roots. The sweep straddles where the floor used to fire and runs
+    several decades past it, since a fix that merely lowered the floor would pass at
+    ``1e-31`` and fail further down.
     """
     del cpp_backend
     demand_the_compiled_kernel(np.float64)
 
-    for scale, expected in ((1e-29, [0.5]), (1e-31, [0.0, 1.0])):
+    for exponent in (-29, -30, -31, -33, -35):
+        scale = 10.0**exponent
         coeff = np.array([scale, 0.0, -scale], dtype=np.float64)
         reference, actual = _both_backends("roots", coeff, DEFECT_TOL)
         np.testing.assert_allclose(
             reference,
-            expected,
+            [0.5],
             atol=TOL,
-            err_msg=f"the oracle changed at scale {scale:.0e}; if #352 was fixed, fix "
-            "the C++ and this test in the same change",
+            err_msg=f"the oracle lost scale invariance at 1e{exponent}, which is "
+            "FELIGN/pantr#352 back. Fix the oracle rather than this test.",
         )
         _assert_the_same_roots(
             actual,
             reference,
-            f"the #352 regime at scale {scale:.0e}",
+            f"the #352 regime at scale 1e{exponent}",
             Case(coeff, DEFECT_TOL),
         )
 

--- a/tests/parity/test_bezier_root_finding.py
+++ b/tests/parity/test_bezier_root_finding.py
@@ -42,14 +42,19 @@ results, but 732 results are evidence and not a proof, so the count agreement is
 asserted as its own check and Rule 11 of ``design/backend_parity.md`` records that it
 is measured rather than derived.
 
-Two defects are asserted, not worked around
--------------------------------------------
+One defect is asserted, not worked around
+----------------------------------------
 
-The oracle returns a wrong answer in two regimes, filed as FELIGN/pantr#351 and #352,
-and the C++ reproduces both deliberately because the port's contract is parity and not
-correction. The tests below name them. **If you are here because one of them started
-failing, the fix is in both backends and in these tests together**; making one side
-correct on its own is what breaks the equality this file exists to hold.
+The oracle still returns a wrong answer in one regime, FELIGN/pantr#352, and the C++
+reproduces it deliberately because the port's contract is parity and not correction.
+The test below names it. **If you are here because it started failing, the fix is in
+both backends and in that test together**; making one side correct on its own is what
+breaks the equality this file exists to hold.
+
+FELIGN/pantr#351 was asserted here the same way and is now fixed on both sides, which
+is what that procedure looks like when it is carried out: the oracle stopped forming a
+product to test a sign, the C++ stopped with it, and the two tests that had pinned the
+wrong answer now pin the mathematics instead.
 """
 
 from __future__ import annotations
@@ -644,31 +649,35 @@ def test_the_batch_path_matches_the_oracle(
 def test_the_backends_agree_on_the_root_that_is_not_there(
     cpp_backend: None, dtype: npt.DTypeLike
 ) -> None:
-    """Both backends reproduce FELIGN/pantr#351, and that is the assertion.
+    """Both backends report no root for a strictly positive polynomial.
 
-    `find_monotone_root` reports a root of a strictly positive polynomial when the
-    coefficients are small enough at ``float32``: the no-sign-change guard is written
-    as ``f_lo * f_hi > 0.0`` on two ``float32`` values, their product falls under that
-    format's minimum subnormal and rounds to zero, and the guard does not fire.
+    This test used to assert the opposite. FELIGN/pantr#351 made
+    `find_monotone_root` report a root of a strictly positive polynomial once the
+    coefficients were small enough at ``float32``: the no-sign-change guard was
+    written as ``f_lo * f_hi > 0.0``, the product of two ``float32`` values that
+    small falls under that format's minimum subnormal and rounds to zero, and the
+    guard did not fire. Both backends carried it deliberately, because the port's
+    contract is parity and not correction.
 
-    **This test asserts a wrong answer on purpose.** The C++ reproduces the defect
-    because the port's contract is parity, not correction. When #351 is fixed, it is
-    fixed in both backends and here in one change; correcting one side alone breaks
-    the equality rather than improving anything.
+    Both now compare the signs instead, so there is no product to underflow and no
+    wrong answer to keep in step. What the two backends agree on here is the
+    mathematics: a Bernstein polynomial is a convex combination of its
+    coefficients, and a convex combination of positive numbers is positive.
+
+    The magnitude is the frontier rather than a comfortable one. ``1e-23`` squares
+    to ``1e-46`` and underflows; ``1e-22`` squares to ``1e-44`` and does not. A fix
+    that merely moved the threshold would still fail here.
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
 
-    coeff = np.array([1e-25, 0.5e-25, 2e-25], dtype=dtype)
+    coeff = np.array([1e-23, 0.5e-23, 2e-23], dtype=dtype)
     reference, actual = _both_backends("monotone", coeff, DEFECT_TOL)
 
-    if dtype is np.float32:
-        assert np.isfinite(reference[0]), (
-            "the defect is gone from the oracle. If #351 was fixed, fix the C++ and "
-            "this test in the same change rather than relaxing either."
-        )
-    else:
-        assert np.isnan(reference[0]), "float64 is wide enough that the guard fires"
+    assert np.isnan(reference[0]), (
+        "the oracle reports a root for a strictly positive polynomial, which is "
+        "FELIGN/pantr#351 back. Fix the oracle rather than this test."
+    )
 
     _assert_the_same_roots(actual, reference, f"the #351 regime, {dtype}", Case(coeff, DEFECT_TOL))
 
@@ -677,26 +686,28 @@ def test_the_backends_agree_on_the_root_that_is_not_there(
 def test_the_backends_agree_on_the_root_that_is_lost(
     cpp_backend: None, dtype: npt.DTypeLike
 ) -> None:
-    """Both backends reproduce the second face of FELIGN/pantr#351.
+    """Both backends find the one root of ``a(1 - 2t)``, at every scale tried.
 
-    ``B(t) = a(1 - 2t)`` has its only root at ``t = 0.5``. At ``float32`` with
-    ``a = 1e-25`` the sign-change test ``f_prev * f_curr < 0.0`` underflows, no sign
-    change is seen, and the root is lost. See the note on the sibling test: the
-    assertion is deliberate.
+    The second face of FELIGN/pantr#351, and this test also used to assert the
+    wrong answer. ``B(t) = a(1 - 2t)`` has its only root at ``t = 0.5`` for every
+    nonzero ``a``; at ``float32`` the sign-change test ``f_prev * f_curr < 0.0``
+    underflowed and the root was lost. Both backends compare the signs now.
+
+    At the frontier magnitude, for the reason given in the sibling test.
     """
     del cpp_backend
     demand_the_compiled_kernel(dtype)
 
-    coeff = np.array([1e-25, 0.0, -1e-25], dtype=dtype)
+    coeff = np.array([1e-23, 0.0, -1e-23], dtype=dtype)
     reference, actual = _both_backends("roots", coeff, DEFECT_TOL)
 
-    if dtype is np.float32:
-        assert reference.size == 0, (
-            "the defect is gone from the oracle. If #351 was fixed, fix the C++ and "
-            "this test in the same change rather than relaxing either."
-        )
-    else:
-        np.testing.assert_allclose(reference, [0.5], atol=TOL)
+    np.testing.assert_allclose(
+        reference,
+        [0.5],
+        atol=TOL,
+        err_msg="the oracle lost the only root of a(1 - 2t), which is "
+        "FELIGN/pantr#351 back. Fix the oracle rather than this test.",
+    )
 
     _assert_the_same_roots(
         actual,

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -30,7 +30,10 @@ from pantr.bezier._root_finding_core import (
     _count_sign_changes,
     _de_casteljau_eval_and_deriv_scalar,
     _de_casteljau_eval_scalar,
+    _have_opposite_signs,
+    _have_same_sign,
     _newton_polish_scalar,
+    _spans_zero,
     _subdivide_scalar,
 )
 from pantr.bezier._yuksel_core import (
@@ -735,6 +738,86 @@ class TestBoundaryEpsScaleInvariance(unittest.TestCase):
             with self.subTest(a=f"1e{exponent}"):
                 bez = Bezier(np.array([[a], [0.5 * a], [2.0 * a]], dtype=np.float64))
                 self.assertEqual(len(find_roots(bez, tol=1e-40)), 0)
+
+
+class TestSignPredicateEquivalence(unittest.TestCase):
+    """The sign predicates are exactly the product forms they replace.
+
+    The three predicates in :mod:`pantr.bezier._root_finding_core` exist to
+    remove a product from a sign test, and substituting them is only sound if
+    they agree with the product everywhere the product is right. That is a claim
+    about IEEE 754 semantics, so it is checked exhaustively over a matrix of
+    special values rather than argued in a comment.
+
+    Every pair drawn from ``VALUES`` has a well-defined product that neither
+    underflows nor overflows, ``inf * 0.0 = nan`` included, so agreement here
+    must be total. Where the product *is* wrong -- the underflow regime -- the
+    predicates are supposed to differ from it, and that is asserted separately.
+    """
+
+    #: Signs, both zeros, both infinities and a NaN. All 81 pairs have an exact product.
+    VALUES = (-np.inf, -3.0, -1.0, -0.0, 0.0, 1.0, 3.0, np.inf, np.nan)
+
+    def test_same_sign_matches_product_gt_zero(self) -> None:
+        """``_have_same_sign`` equals ``a * b > 0.0`` on every special-value pair."""
+        for a in self.VALUES:
+            for b in self.VALUES:
+                with self.subTest(a=a, b=b):
+                    self.assertEqual(_have_same_sign(a, b), a * b > 0.0)
+
+    def test_opposite_signs_matches_product_lt_zero(self) -> None:
+        """``_have_opposite_signs`` equals ``a * b < 0.0`` on every special-value pair."""
+        for a in self.VALUES:
+            for b in self.VALUES:
+                with self.subTest(a=a, b=b):
+                    self.assertEqual(_have_opposite_signs(a, b), a * b < 0.0)
+
+    def test_spans_zero_matches_product_le_zero(self) -> None:
+        """``_spans_zero`` equals ``a * b <= 0.0`` on every special-value pair.
+
+        This is the predicate whose naive form is *not* equivalent: without its
+        finiteness guards it would report a spanned bracket for ``(0.0, inf)``,
+        where the product is NaN and the product form reports none.
+        """
+        for a in self.VALUES:
+            for b in self.VALUES:
+                with self.subTest(a=a, b=b):
+                    self.assertEqual(_spans_zero(a, b), a * b <= 0.0)
+
+    def test_zero_paired_with_infinity_is_not_spanned(self) -> None:
+        """``(0, inf)`` is not a spanned bracket, because ``0 * inf`` is NaN.
+
+        Called out on its own because it is the single pair that separates the
+        exact predicate from the naive one, and a regression here would be
+        invisible in the matrix above.
+        """
+        for zero in (0.0, -0.0):
+            for infinity in (np.inf, -np.inf):
+                with self.subTest(zero=zero, infinity=infinity):
+                    self.assertFalse(_spans_zero(zero, infinity))
+                    self.assertFalse(_spans_zero(infinity, zero))
+
+    def test_predicates_survive_the_underflow_the_product_does_not(self) -> None:
+        """The predicates are right in the regime where the product flushes to zero.
+
+        Two operands of magnitude ``1e-200`` are ordinary ``float64`` values,
+        but their product is ``1e-400`` and underflows to zero. The product form
+        then answers as though an operand vanished; the predicates do not. This
+        is the same mechanism as the ``float32`` defect, reached at ``float64``
+        so that no dtype conversion is involved.
+        """
+        tiny = 1e-200
+        # Same sign, and the product cannot see it.
+        self.assertEqual(tiny * tiny, 0.0)
+        self.assertTrue(_have_same_sign(tiny, tiny))
+        self.assertFalse(tiny * tiny > 0.0)
+        # Opposite signs, likewise.
+        self.assertEqual(tiny * -tiny, 0.0)
+        self.assertTrue(_have_opposite_signs(tiny, -tiny))
+        self.assertFalse(tiny * -tiny < 0.0)
+        # And the bracket test reports a span that is not there.
+        self.assertFalse(_spans_zero(tiny, tiny))
+        self.assertTrue(tiny * tiny <= 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_root_finding.py
+++ b/tests/test_root_finding.py
@@ -643,5 +643,99 @@ class TestValidateCoeffArray(unittest.TestCase):
         self.assertEqual(result.dtype, np.float32)
 
 
+class TestSignTestUnderflow(unittest.TestCase):
+    """A sign test written as a product must not underflow (FELIGN/pantr#351).
+
+    Six sites in the root-finding kernels ask "do these two values share a sign?"
+    by multiplying and comparing the product against zero. At ``float32`` the
+    product of two operands of magnitude ``a`` is ``a**2``, which falls under
+    that format's minimum subnormal (about ``1e-45``) once ``a`` drops below
+    roughly ``1e-23`` -- while both operands remain perfectly representable.
+    The test then answers as though one operand were zero.
+
+    The cases below sit at that frontier rather than comfortably past it:
+    ``1e-22`` squares to ``1e-44`` and survives, ``1e-23`` squares to ``1e-46``
+    and does not. Each has a ``float64`` control, where the same product is
+    nowhere near underflow.
+    """
+
+    #: Largest coefficient magnitude whose float32 square still underflows.
+    FRONTIER = 1e-23
+
+    def test_monotone_root_not_invented_at_frontier(self) -> None:
+        """No root is reported for a strictly positive Bezier at the frontier."""
+        for dtype in (np.float32, np.float64):
+            with self.subTest(dtype=np.dtype(dtype).name):
+                a = self.FRONTIER
+                # B(t) > 0 on [0, 1]: every control value is positive, so the
+                # convex-hull property forbids a root.
+                bez = Bezier(np.array([[a], [0.5 * a], [2.0 * a]], dtype=dtype))
+                self.assertTrue(math.isnan(find_monotone_root(bez)))
+
+    def test_root_not_lost_at_frontier(self) -> None:
+        """The single root of ``a(1 - 2t)`` survives at the frontier."""
+        for dtype in (np.float32, np.float64):
+            with self.subTest(dtype=np.dtype(dtype).name):
+                a = self.FRONTIER
+                bez = Bezier(np.array([[a], [0.0], [-a]], dtype=dtype))
+                roots = find_roots(bez, tol=1e-40)
+                self.assertEqual(len(roots), 1)
+                self.assertAlmostEqual(roots[0], 0.5, places=10)
+
+    def test_sign_tests_are_scale_invariant_over_decades(self) -> None:
+        """Both faces stay correct across the decades spanning the frontier.
+
+        Scaling a root-finding problem by a positive constant moves no root, so
+        every decade here must give the same answer. The sweep runs from two
+        decades above the frontier to six below, at ``float32``, which is the
+        width that distinguishes a fix of the *test* from one that merely moves
+        the underflow threshold.
+        """
+        for exponent in range(-21, -30, -1):
+            a = 10.0**exponent
+            with self.subTest(a=f"1e{exponent}"):
+                positive = Bezier(np.array([[a], [0.5 * a], [2.0 * a]], dtype=np.float32))
+                self.assertTrue(math.isnan(find_monotone_root(positive)))
+
+                crossing = Bezier(np.array([[a], [0.0], [-a]], dtype=np.float32))
+                roots = find_roots(crossing, tol=1e-40)
+                self.assertEqual(len(roots), 1)
+                self.assertAlmostEqual(roots[0], 0.5, places=10)
+
+
+class TestBoundaryEpsScaleInvariance(unittest.TestCase):
+    """An absolute floor inside a scale-relative tolerance (FELIGN/pantr#352).
+
+    ``_find_roots_at_level`` and ``_yuksel_roots`` grade "is this coefficient
+    zero?" against ``max(scale * eps * 8, 1e-30)``. The first term is relative
+    to the problem's own coefficient range and correct; the second is an
+    absolute floor, and below it every coefficient reads as zero however well
+    separated the coefficients are from each other.
+
+    Scaling a root-finding problem by a positive constant does not move its
+    roots, so this is an invariance being broken rather than a precision limit
+    being reached. The sweep straddles the literal: ``1e-29`` is correct today
+    and ``1e-30`` is not.
+    """
+
+    def test_single_root_is_scale_invariant(self) -> None:
+        """``a(1 - 2t)`` has its only root at ``t = 0.5`` for every ``a != 0``."""
+        for exponent in range(-25, -36, -1):
+            a = 10.0**exponent
+            with self.subTest(a=f"1e{exponent}"):
+                bez = Bezier(np.array([[a], [0.0], [-a]], dtype=np.float64))
+                roots = find_roots(bez, tol=1e-40)
+                self.assertEqual(len(roots), 1)
+                self.assertAlmostEqual(roots[0], 0.5, places=12)
+
+    def test_no_root_is_scale_invariant(self) -> None:
+        """A strictly positive Bezier reports no root at every scale."""
+        for exponent in range(-25, -36, -1):
+            a = 10.0**exponent
+            with self.subTest(a=f"1e{exponent}"):
+                bez = Bezier(np.array([[a], [0.5 * a], [2.0 * a]], dtype=np.float64))
+                self.assertEqual(len(find_roots(bez, tol=1e-40)), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Context

Two of the three tolerance defects filed against `pantr.bezier`'s root-finding kernels
during the port of that block: FELIGN/pantr#351 and #352. Both are pre-existing on `main`
and neither was introduced by the port. The third, #354, is deliberately **not** fixed
here; see Non-goals.

These are the first fixes on this branch that change the **oracle**, so each one changes
the Python and the C++ together. The parity suite asserted both defects on purpose,
because the port's contract is parity rather than correction, and the tests carried
instructions saying to fix both backends and the test in one change rather than relaxing
any of them. That is what this does, and it is why the parity diff looks larger than the
kernel diff.

`main` is zero commits behind `proto/cpp`, so the affected kernel files are identical on
both branches and each fix was authored once.

## Specification

**#351 — a sign test must not be able to underflow.** Six places asked "do these two
values share a sign?" by multiplying and comparing the product against zero. At `float32`
two operands of magnitude `1e-23` are perfectly representable while their product is
`1e-46`, under that format's minimum subnormal, so it flushes to zero and the test answers
as though one operand had vanished. Ten sites in the oracle and nine in the C++ now compare
the signs directly; the counts differ by one only because the C++ hull clip runs both
chains through a single loop body where the oracle duplicates it.

Three predicates replace three product forms, and each is **exactly** equivalent to the
form it replaces on every IEEE input rather than approximately so:

| predicate | replaces |
|---|---|
| `have_same_sign` | `a * b > 0` |
| `have_opposite_signs` | `a * b < 0` |
| `spans_zero` | `a * b <= 0` |

The third needs finiteness guards, and they are why it is not simply the negation of the
first. `a * b` is a signed zero when one operand is zero and the other finite, but NaN when
the other is an infinity, and NaN is not `<= 0`. Without the guards the predicate would
report a spanned bracket for `(0, inf)` where the product reports none; negating
`have_same_sign` instead would report one for `(NaN, NaN)`. Non-finite coefficients do reach
these kernels, since nothing validates against them, so this is reachable rather than
hypothetical.

**#352 — an absolute floor inside a scale-relative tolerance.** `boundary_eps` graded "is
this coefficient zero?" against `max(scale * eps * 8, 1e-30)`. The floor won the maximum
below a coefficient range of about `5.6e-16`, which is exactly `1e-30 / (8 * DBL_EPSILON)`,
and below it every coefficient of the problem read as zero however well separated they
were. Scaling a root-finding problem by a positive constant moves none of its roots, so
this was a broken invariance and not a precision limit. Four sites, two per backend.

Removing the floor rather than adjusting it is what makes the blast radius **provable**
instead of measured: `max(x, 1e-30)` is `x` whenever `x >= 1e-30`, so no result outside the
defect region moves by one bit. The `scale == 0` limit needs no floor either -- it means
the polynomial is constant, and an all-zero polynomial never reaches these kernels because
`_find_roots_scalar` returns empty first.

## Acceptance criteria

- [x] AC1: `find_monotone_root` on a strictly positive Bezier returns `nan` at `float32`,
      at the frontier magnitude `1e-23`.
- [x] AC2: `find_roots` on `a(1 - 2t)` returns `[0.5]` at `float32`, same magnitude.
- [x] AC3: regression tests pin the frontier rather than a comfortable magnitude, and
      failed against the parent commit. `1e-22` squares to `1e-44` and survives, `1e-23`
      squares to `1e-46` and does not; the flip is measured at exactly that decade.
- [x] AC4: every site uses a test that cannot underflow, including the ones whose operands
      are `float64` today and so are only one refactor from the same failure.
- [x] AC5: `find_roots` is scale-invariant on `a(1 - 2t)` across five decades spanning
      where the floor used to fire, on both backends.
- [x] AC6: the three predicates are checked against the product form over the full matrix
      of signs, both zeros, both infinities and NaN -- 81 pairs, at both floating widths on
      the C++ side. "Exactly equivalent" is a claim, so it is tested rather than asserted.
- [x] AC7: both backends agree everywhere. 1150 parity tests against a locally built
      extension, 7302 of the full suite, 10 `ctest` targets, compiled with
      `PANTR_WERROR=ON`.

## A Tier B violation fixed along the way

On the C++ side the substitution also fixes something that only compiled by accident.
`cpp/include/pantr/core/scalar.hpp`'s `Real` concept deliberately omits `operator==` and
ordering, so that comparisons must route through `value_of` -- the header says as much, and
the point is to make a Tier B violation a build failure. But `da * db < T{0}` compared `T`
directly and worked only because `T` is `float` or `double`.

The predicates go through `value_of`, so `test_scalar_generic.cpp` now calls them on the
`Dual1` fixture, which supplies no ordering at all. That call failing to compile is the
regression signal.

Retiring the product also retires a question. Four C++ sites carried comments weighing
which width to form the product at, one measured over 10143 `float32` edges. A sign
comparison has no width, so those comments now say only what still bears on the quotient
beside them.

## Non-goals

- **FELIGN/pantr#354 is not fixed.** Its mechanism is now pinned, where the ticket had said
  it was not, and the issue carries a comment with the full degree-by-tolerance grid. The
  fix is unbounded on three independent counts: it changes a Layer 3 kernel signature
  (`np.finfo` is unavailable under `nopython`, so the working precision has to come from
  Layer 2), it changes `float32` root **counts** in the ordinary regime and not only in the
  defect regime, which is `design/backend_parity.md` Rule 11 territory, and `_DBL_EPSILON`
  has three further roles in the same kernel needing a derivation each.
- **The factor of 8 in `boundary_eps` is not derived.** It is inherited, it is now the
  remaining soft spot in that bound, and a comment where the bound is computed says so and
  points at #354.
- **No change to any kernel's arithmetic width.** The widths are a deliberate per-kernel
  fact the C++ reproduces; this is about the sign test and the floor, not the precision.

## What could not be verified here

Stated rather than glossed. The `pantr` environment on the build machine runs tools the
project does not admit -- `ruff` 0.16.3 against a declared `<0.13`, `mypy` 2.3.1 against
`<2` -- and has no `sphinx` at all, so `scripts/ci_local.sh` cannot pass and its output is
not signal. Since `proto/cpp` CI is the build plus parity, **nothing has checked lint,
types or the docs build for this change.**

What was done instead: `ruff` and `mypy` were run on the changed files only, and both are
clean, with every reported failure confirmed to sit in files this branch does not touch and
to be present on the parent commit. For the docs build, the failure class that has actually
shipped on this branch before is a Sphinx role pointing at a private symbol; the added
`src/` docstrings contain no Sphinx roles at all, which excludes it.

Closing keywords do not fire for a PR merged outside the default branch, so #351 and #352
have to be closed by hand after this lands.
