### PR TITLE
feat(grid): port the nine grid kernels to C++, with an equality parity claim

### DIFF
--- a/cpp/bindings/CMakeLists.txt
+++ b/cpp/bindings/CMakeLists.txt
@@ -119,11 +119,11 @@ if(PANTR_NANOBIND_SPLIT)
   nanobind_add_module(_pantr_cpp NOMINSIZE NOSTRIP NB_SUPPRESS_WARNINGS
                       BACKEND_MODULE nanobind_backend
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
-                      bezier_root_finding.cpp)
+                      bezier_root_finding.cpp grid.cpp)
 else()
   nanobind_add_module(_pantr_cpp NB_STATIC NOMINSIZE NOSTRIP
                       pantr_cpp.cpp basis.cpp quad.cpp change_basis.cpp bezier.cpp
-                      bezier_root_finding.cpp)
+                      bezier_root_finding.cpp grid.cpp)
 endif()
 
 # nanobind's own headers are not -Wshadow clean (measured: 2.14.0 on GCC 14

--- a/cpp/bindings/grid.cpp
+++ b/cpp/bindings/grid.cpp
@@ -1,0 +1,518 @@
+/// \file
+/// nanobind bindings for the `pantr.grid` kernels.
+///
+/// Eight entry points over nine oracle kernels. The missing one is
+/// `_hier_core._block_of_midx`, and it is missing structurally rather than by
+/// oversight: on the Numba side it is called from inside `_hier_locate_points_core`
+/// at a `nopython` call site, and no dispatch can be inserted between two Numba
+/// kernels, so the boundary is forced up to the eight places Layer 2 reaches for a
+/// kernel. Its C++ counterpart is bound anyway, under the name of the oracle's
+/// one-line wrapper `_encode_midx_core`, because that wrapper *is* a Layer 2 seam
+/// and the two functions are one here.
+///
+/// ## `double` only, and that is not laziness
+///
+/// Every sibling binding registers `double` and `float` overloads. These register
+/// `double` alone, because the oracle is `float64`-only -- `_locate_core.py`,
+/// `_bvh_core.py` and `_hier_core.py` mention `float32` nowhere. Registering
+/// `float` would create a surface with no oracle behind it, and
+/// `design/backend_parity.md` Rule 8 is explicit that a parity claim is only
+/// defined where the comparison can say something. The headers are templated on
+/// `Real` regardless, which is the core's convention and what keeps the Tier B
+/// discipline live; only the instantiation is narrow.
+///
+/// ## What the checks are for, and the one the oracle does not make
+///
+/// nanobind settles dtype, rank and contiguity. What it cannot express is that a
+/// pile of flat descriptor arrays agree with each other, and these kernels take
+/// several: an inconsistent `ndim` between `points` and `knot_starts`, or a
+/// `knot_starts[d] + cells_per_axis[d]` past the end of `knots_flat`, is an
+/// out-of-bounds read rather than a wrong answer. Those are checked.
+///
+/// **The stack-depth contract is checked where the oracle checks it and nowhere
+/// else.** `bvh_build` validates it in closed form, because median-of-longest-axis
+/// splits are balanced by construction and the height follows from the cell count
+/// alone. The two query bindings do **not** validate it: `_bvh.py` establishes it
+/// once, at construction, with an O(n) walk it then does not repeat per query, and
+/// a binding that walked the tree on every query would make a box query linear in
+/// the tree it exists to avoid traversing. So a caller assembling node arrays by
+/// hand owns that contract, exactly as it does on the Numba side.
+///
+/// **Nearly every argument is keyword-only, which is deliberate and is the one
+/// place this file is stricter than the oracle.** These signatures are full of
+/// adjacent, same-typed, mutually unordered `int64` descriptor arrays --
+/// `block_lo`/`block_hi`, `node_left`/`node_right`,
+/// `knot_starts`/`cells_per_axis`/`strides`. Transposed, every one of them
+/// type-checks, runs, and returns a plausible wrong answer; `bezier_root_finding.cpp`
+/// records two such traps found by an audit rather than by a test, which is the
+/// evidence that a comment would not have been enough. Where an ordering constraint
+/// exists it is checked instead of merely named: `cell_hi >= cell_lo` and
+/// `block_hi > block_lo` are real invariants and are enforced.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/bvh.hpp"
+#include "pantr/grid/hierarchical.hpp"
+#include "pantr/grid/locate.hpp"
+#include "register.hpp"
+
+namespace nb = nanobind;
+
+namespace {
+
+template <class T>
+using const_vec = nb::ndarray<const T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using const_mat = nb::ndarray<const T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_vec = nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+template <class T>
+using out_mat = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+using i64_vec = const_vec<std::int64_t>;
+using i64_mat = const_mat<std::int64_t>;
+
+/// Raise unless two extents agree.
+void require_same(std::size_t got, std::size_t want, const char* what, const char* against) {
+    if (got != want) {
+        throw nb::value_error((std::string(what) + " has " + std::to_string(got) +
+                               " entries but " + against + " implies " + std::to_string(want))
+                                  .c_str());
+    }
+}
+
+/// Raise unless `out` can hold `needed` entries along `axis`.
+///
+/// A lower bound, not an equality: refusing a buffer that is merely generous would
+/// be wrong. The axis is explicit because getting it wrong is silent -- the trap
+/// `bezier_root_finding.cpp` records, where a 2-D output's row width went unchecked
+/// because the first axis was checked twice.
+template <class Arr>
+void require_capacity(const Arr& out, std::size_t axis, std::size_t needed, const char* what) {
+    if (out.shape(axis) < needed) {
+        throw nb::value_error((std::string(what) + " holds " +
+                               std::to_string(out.shape(axis)) + " entries along axis " +
+                               std::to_string(axis) + ", but this call needs " +
+                               std::to_string(needed))
+                                  .c_str());
+    }
+}
+
+/// Raise unless every axis declares at least one cell and stays inside `knots_flat`.
+///
+/// Both failures are out-of-bounds reads rather than wrong answers: the kernel
+/// indexes `knots_flat[knot_starts[d] + cells_per_axis[d]]` before any loop bound
+/// could stop it.
+void require_knot_ranges(std::size_t n_knots, i64_vec knot_starts, i64_vec cells_per_axis) {
+    for (std::size_t d = 0; d < knot_starts.shape(0); ++d) {
+        const std::int64_t start = knot_starts(d);
+        const std::int64_t ncells = cells_per_axis(d);
+        if (ncells < 1) {
+            throw nb::value_error((std::string("axis ") + std::to_string(d) + " declares " +
+                                   std::to_string(ncells) + " cells; at least one is needed")
+                                      .c_str());
+        }
+        if (start < 0 || static_cast<std::size_t>(start + ncells) >= n_knots) {
+            throw nb::value_error(
+                (std::string("axis ") + std::to_string(d) + " spans knots [" +
+                 std::to_string(start) + ", " + std::to_string(start + ncells) +
+                 "] but knots_flat holds " + std::to_string(n_knots))
+                    .c_str());
+        }
+    }
+}
+
+/// Raise unless the packed block descriptor is self-consistent.
+///
+/// `level_block_start` must be non-decreasing and end at the block count, since the
+/// kernels use consecutive entries as a half-open range, and every block must have
+/// a positive extent, since the collect kernel divides by it.
+void require_block_descriptor(i64_mat block_lo, i64_mat block_hi, i64_vec block_base,
+                             i64_vec level_block_start) {
+    const std::size_t n_blocks = block_base.shape(0);
+    require_same(block_lo.shape(0), n_blocks, "block_lo rows", "block_base");
+    require_same(block_hi.shape(0), n_blocks, "block_hi rows", "block_base");
+    require_same(block_hi.shape(1), block_lo.shape(1), "block_hi columns", "block_lo");
+
+    if (level_block_start.shape(0) < 2) {
+        throw nb::value_error("level_block_start needs at least two entries, for one level");
+    }
+    if (level_block_start(0) != 0) {
+        throw nb::value_error("level_block_start must begin at 0");
+    }
+    for (std::size_t i = 1; i < level_block_start.shape(0); ++i) {
+        if (level_block_start(i) < level_block_start(i - 1)) {
+            throw nb::value_error("level_block_start must be non-decreasing");
+        }
+    }
+    if (static_cast<std::size_t>(level_block_start(level_block_start.shape(0) - 1)) != n_blocks) {
+        throw nb::value_error("level_block_start must end at the block count");
+    }
+    for (std::size_t b = 0; b < n_blocks; ++b) {
+        for (std::size_t k = 0; k < block_lo.shape(1); ++k) {
+            if (block_hi(b, k) <= block_lo(b, k)) {
+                throw nb::value_error(
+                    (std::string("block ") + std::to_string(b) + " axis " + std::to_string(k) +
+                     " has extent " + std::to_string(block_hi(b, k) - block_lo(b, k)) +
+                     "; every block extent must be positive")
+                        .c_str());
+            }
+        }
+    }
+}
+
+void bind_locate_points(const_mat<double> points, const_vec<double> knots_flat,
+                        i64_vec knot_starts, i64_vec cells_per_axis, i64_vec strides,
+                        out_vec<std::int64_t> out) {
+    const std::size_t ndim = points.shape(1);
+    require_same(knot_starts.shape(0), ndim, "knot_starts", "the point array's second axis");
+    require_same(cells_per_axis.shape(0), ndim, "cells_per_axis", "the point array's second axis");
+    require_same(strides.shape(0), ndim, "strides", "the point array's second axis");
+    require_knot_ranges(knots_flat.shape(0), knot_starts, cells_per_axis);
+    require_capacity(out, 0, points.shape(0), "out");
+
+    pantr::grid::locate_points<double>(
+        pantr::span2d<const double>(points.data(), points.shape(0), ndim),
+        std::span<const double>(knots_flat.data(), knots_flat.shape(0)),
+        std::span<const std::int64_t>(knot_starts.data(), ndim),
+        std::span<const std::int64_t>(cells_per_axis.data(), ndim),
+        std::span<const std::int64_t>(strides.data(), ndim),
+        std::span<std::int64_t>(out.data(), out.shape(0)));
+}
+
+void bind_bvh_build(const_mat<double> cell_lo, const_mat<double> cell_hi,
+                    out_mat<double> node_lo, out_mat<double> node_hi,
+                    out_vec<std::int64_t> node_left, out_vec<std::int64_t> node_right,
+                    out_vec<std::int64_t> node_cell) {
+    const std::size_t n_cells = cell_lo.shape(0);
+    const std::size_t ndim = cell_lo.shape(1);
+    if (n_cells == 0) {
+        throw nb::value_error("cell_lo is empty; the build needs at least one cell");
+    }
+    require_same(cell_hi.shape(0), n_cells, "cell_hi rows", "cell_lo");
+    require_same(cell_hi.shape(1), ndim, "cell_hi columns", "cell_lo");
+
+    // hi >= lo is an ordering constraint, so it is checked rather than left to the
+    // caller getting the two keywords the right way round.
+    for (std::size_t i = 0; i < n_cells; ++i) {
+        for (std::size_t k = 0; k < ndim; ++k) {
+            if (!(cell_hi(i, k) >= cell_lo(i, k))) {
+                throw nb::value_error((std::string("cell ") + std::to_string(i) + " axis " +
+                                       std::to_string(k) + " has hi < lo, or a NaN corner")
+                                          .c_str());
+            }
+        }
+    }
+
+    // The build's own splits are balanced, so the height follows from the cell count
+    // and needs no tree walk. Mirrors BVH.from_cell_bounds, including the `+ 1` for
+    // the root push.
+    const auto n = static_cast<double>(n_cells);
+    const std::int64_t max_depth =
+        n_cells > 1 ? static_cast<std::int64_t>(std::ceil(std::log2(n))) + 1 : 1;
+    if (max_depth > pantr::grid::kBvhStackDepth) {
+        throw nb::value_error((std::to_string(n_cells) + " cells would produce a tree of depth >= " +
+                               std::to_string(max_depth) + ", exceeding the traversal stack depth " +
+                               std::to_string(pantr::grid::kBvhStackDepth))
+                                  .c_str());
+    }
+
+    const std::size_t n_nodes = 2 * n_cells - 1;
+    require_capacity(node_lo, 0, n_nodes, "node_lo");
+    require_capacity(node_hi, 0, n_nodes, "node_hi");
+    require_same(node_lo.shape(1), ndim, "node_lo columns", "cell_lo");
+    require_same(node_hi.shape(1), ndim, "node_hi columns", "cell_lo");
+    require_capacity(node_left, 0, n_nodes, "node_left");
+    require_capacity(node_right, 0, n_nodes, "node_right");
+    require_capacity(node_cell, 0, n_nodes, "node_cell");
+
+    pantr::grid::bvh_build<double>(
+        pantr::span2d<const double>(cell_lo.data(), n_cells, ndim),
+        pantr::span2d<const double>(cell_hi.data(), n_cells, ndim),
+        pantr::span2d<double>(node_lo.data(), node_lo.shape(0), ndim),
+        pantr::span2d<double>(node_hi.data(), node_hi.shape(0), ndim),
+        std::span<std::int64_t>(node_left.data(), node_left.shape(0)),
+        std::span<std::int64_t>(node_right.data(), node_right.shape(0)),
+        std::span<std::int64_t>(node_cell.data(), node_cell.shape(0)));
+}
+
+/// Shared shape checks for the two query kernels, so they cannot drift apart.
+std::size_t check_query(const_vec<double> qlo, const_vec<double> qhi, const_mat<double> node_lo,
+                        const_mat<double> node_hi, i64_vec node_left, i64_vec node_right,
+                        i64_vec node_cell) {
+    const std::size_t ndim = qlo.shape(0);
+    const std::size_t n_nodes = node_cell.shape(0);
+    require_same(qhi.shape(0), ndim, "qhi", "qlo");
+    require_same(node_lo.shape(1), ndim, "node_lo columns", "qlo");
+    require_same(node_hi.shape(1), ndim, "node_hi columns", "qlo");
+    require_same(node_lo.shape(0), n_nodes, "node_lo rows", "node_cell");
+    require_same(node_hi.shape(0), n_nodes, "node_hi rows", "node_cell");
+    require_same(node_left.shape(0), n_nodes, "node_left", "node_cell");
+    require_same(node_right.shape(0), n_nodes, "node_right", "node_cell");
+    if (n_nodes == 0) {
+        throw nb::value_error("the node arrays are empty; a query needs at least a root");
+    }
+    return n_nodes;
+}
+
+std::int64_t bind_bvh_query_count(const_vec<double> qlo, const_vec<double> qhi,
+                                  const_mat<double> node_lo, const_mat<double> node_hi,
+                                  i64_vec node_left, i64_vec node_right, i64_vec node_cell) {
+    const std::size_t n_nodes =
+        check_query(qlo, qhi, node_lo, node_hi, node_left, node_right, node_cell);
+    const std::size_t ndim = qlo.shape(0);
+    return pantr::grid::bvh_query_count<double>(
+        std::span<const double>(qlo.data(), ndim), std::span<const double>(qhi.data(), ndim),
+        pantr::span2d<const double>(node_lo.data(), n_nodes, ndim),
+        pantr::span2d<const double>(node_hi.data(), n_nodes, ndim),
+        std::span<const std::int64_t>(node_left.data(), n_nodes),
+        std::span<const std::int64_t>(node_right.data(), n_nodes),
+        std::span<const std::int64_t>(node_cell.data(), n_nodes));
+}
+
+std::int64_t bind_bvh_query_emit(const_vec<double> qlo, const_vec<double> qhi,
+                                 const_mat<double> node_lo, const_mat<double> node_hi,
+                                 i64_vec node_left, i64_vec node_right, i64_vec node_cell,
+                                 out_vec<std::int64_t> out) {
+    const std::size_t n_nodes =
+        check_query(qlo, qhi, node_lo, node_hi, node_left, node_right, node_cell);
+    const std::size_t ndim = qlo.shape(0);
+    const std::int64_t count = pantr::grid::bvh_query_emit<double>(
+        std::span<const double>(qlo.data(), ndim), std::span<const double>(qhi.data(), ndim),
+        pantr::span2d<const double>(node_lo.data(), n_nodes, ndim),
+        pantr::span2d<const double>(node_hi.data(), n_nodes, ndim),
+        std::span<const std::int64_t>(node_left.data(), n_nodes),
+        std::span<const std::int64_t>(node_right.data(), n_nodes),
+        std::span<const std::int64_t>(node_cell.data(), n_nodes),
+        std::span<std::int64_t>(out.data(), out.shape(0)));
+
+    // The kernel counts unconditionally and writes only within capacity, so this
+    // catches an undersized `out` after the fact instead of corrupting it. It is
+    // also the count/emit agreement the oracle's module docstring names as the one
+    // invariant the two opposite traversal orders must preserve.
+    if (static_cast<std::size_t>(count) > out.shape(0)) {
+        throw nb::value_error((std::string("out holds ") + std::to_string(out.shape(0)) +
+                               " entries but the query matched " + std::to_string(count) +
+                               " cells; size it from bvh_query_count")
+                                  .c_str());
+    }
+    return count;
+}
+
+std::int64_t bind_encode_midx(std::int64_t level, i64_vec midx, i64_mat block_lo,
+                              i64_mat block_hi, i64_vec block_base, i64_vec level_block_start) {
+    require_block_descriptor(block_lo, block_hi, block_base, level_block_start);
+    require_same(midx.shape(0), block_lo.shape(1), "midx", "block_lo columns");
+    const std::int64_t n_levels = static_cast<std::int64_t>(level_block_start.shape(0)) - 1;
+    if (level < 0 || level >= n_levels) {
+        throw nb::value_error((std::string("level ") + std::to_string(level) +
+                               " is outside [0, " + std::to_string(n_levels) + ")")
+                                  .c_str());
+    }
+    return pantr::grid::block_of_midx(
+        level, std::span<const std::int64_t>(midx.data(), midx.shape(0)),
+        pantr::span2d<const std::int64_t>(block_lo.data(), block_lo.shape(0), block_lo.shape(1)),
+        pantr::span2d<const std::int64_t>(block_hi.data(), block_hi.shape(0), block_hi.shape(1)),
+        std::span<const std::int64_t>(block_base.data(), block_base.shape(0)),
+        std::span<const std::int64_t>(level_block_start.data(), level_block_start.shape(0)));
+}
+
+std::int64_t bind_decode_flat_id(std::int64_t cid, i64_mat block_lo, i64_mat block_hi,
+                                 i64_vec block_base, i64_vec level_block_start,
+                                 out_vec<std::int64_t> out_midx) {
+    require_block_descriptor(block_lo, block_hi, block_base, level_block_start);
+    require_capacity(out_midx, 0, block_lo.shape(1), "out_midx");
+
+    // The upper-bound search takes `lo_b - 1`, so a cid below the first block's base
+    // would index -1. Layer 2 never produces one; a direct call could.
+    if (cid < 0 || cid < block_base(0)) {
+        throw nb::value_error((std::string("cid ") + std::to_string(cid) +
+                               " is below the first block's base " +
+                               std::to_string(block_base(0)))
+                                  .c_str());
+    }
+    return pantr::grid::decode_flat_id(
+        cid,
+        pantr::span2d<const std::int64_t>(block_lo.data(), block_lo.shape(0), block_lo.shape(1)),
+        pantr::span2d<const std::int64_t>(block_hi.data(), block_hi.shape(0), block_hi.shape(1)),
+        std::span<const std::int64_t>(block_base.data(), block_base.shape(0)),
+        std::span<const std::int64_t>(level_block_start.data(), level_block_start.shape(0)),
+        std::span<std::int64_t>(out_midx.data(), out_midx.shape(0)));
+}
+
+void bind_hier_locate_points(const_mat<double> points, const_vec<double> knots_flat,
+                             i64_vec knot_starts, i64_vec root_cells_per_axis, i64_vec factor,
+                             i64_mat block_lo, i64_mat block_hi, i64_vec block_base,
+                             i64_vec level_block_start, out_vec<std::int64_t> out) {
+    const std::size_t ndim = points.shape(1);
+    require_block_descriptor(block_lo, block_hi, block_base, level_block_start);
+    require_same(block_lo.shape(1), ndim, "block_lo columns", "the point array's second axis");
+    require_same(knot_starts.shape(0), ndim, "knot_starts", "the point array's second axis");
+    require_same(root_cells_per_axis.shape(0), ndim, "root_cells_per_axis",
+                 "the point array's second axis");
+    require_same(factor.shape(0), ndim, "factor", "the point array's second axis");
+    require_knot_ranges(knots_flat.shape(0), knot_starts, root_cells_per_axis);
+    require_capacity(out, 0, points.shape(0), "out");
+    for (std::size_t k = 0; k < ndim; ++k) {
+        if (factor(k) < 2) {
+            throw nb::value_error((std::string("factor[") + std::to_string(k) + "] is " +
+                                   std::to_string(factor(k)) +
+                                   "; a subdivision factor below two never refines")
+                                      .c_str());
+        }
+    }
+
+    pantr::grid::hier_locate_points<double>(
+        pantr::span2d<const double>(points.data(), points.shape(0), ndim),
+        std::span<const double>(knots_flat.data(), knots_flat.shape(0)),
+        std::span<const std::int64_t>(knot_starts.data(), ndim),
+        std::span<const std::int64_t>(root_cells_per_axis.data(), ndim),
+        std::span<const std::int64_t>(factor.data(), ndim),
+        pantr::span2d<const std::int64_t>(block_lo.data(), block_lo.shape(0), ndim),
+        pantr::span2d<const std::int64_t>(block_hi.data(), block_hi.shape(0), ndim),
+        std::span<const std::int64_t>(block_base.data(), block_base.shape(0)),
+        std::span<const std::int64_t>(level_block_start.data(), level_block_start.shape(0)),
+        std::span<std::int64_t>(out.data(), out.shape(0)));
+}
+
+void bind_hier_collect_cell_bounds(const_vec<double> knots_flat, i64_vec knot_starts,
+                                   i64_vec factor, i64_mat block_lo, i64_mat block_hi,
+                                   i64_vec block_base, i64_vec level_block_start,
+                                   out_mat<double> out_lo, out_mat<double> out_hi) {
+    require_block_descriptor(block_lo, block_hi, block_base, level_block_start);
+    const std::size_t ndim = block_lo.shape(1);
+    require_same(knot_starts.shape(0), ndim, "knot_starts", "block_lo columns");
+    require_same(factor.shape(0), ndim, "factor", "block_lo columns");
+    require_same(out_hi.shape(0), out_lo.shape(0), "out_hi rows", "out_lo");
+    require_same(out_lo.shape(1), ndim, "out_lo columns", "block_lo");
+    require_same(out_hi.shape(1), ndim, "out_hi columns", "block_lo");
+
+    for (std::size_t k = 0; k < ndim; ++k) {
+        if (factor(k) < 2) {
+            throw nb::value_error((std::string("factor[") + std::to_string(k) + "] is " +
+                                   std::to_string(factor(k)) +
+                                   "; a subdivision factor below two never refines")
+                                      .c_str());
+        }
+    }
+
+    // Two bounds, both computed per block rather than taken on trust, because both
+    // failures are out-of-bounds accesses rather than wrong answers.
+    //
+    // The rows: the odometer writes `block_base[b] + n_block` of them for each
+    // block, so the output must cover the largest flat id any block reaches.
+    //
+    // The knots: the kernel reads `knots_flat[knot_starts[k] + root_ik + 1]` where
+    // `root_ik = ik / factor[k]**level` over `ik < block_hi(b, k)`. So the bound is
+    // the largest root index any block reaches at its own level, which is NOT
+    // `factor[k]` and is not `block_hi` either -- an earlier version of this check
+    // passed `factor` where the helper wanted a root cell count, which both
+    // rejected valid grids and admitted out-of-range ones.
+    std::size_t needed = 0;
+    const auto n_levels = static_cast<std::int64_t>(level_block_start.shape(0)) - 1;
+    for (std::size_t b = 0; b < block_base.shape(0); ++b) {
+        std::int64_t level = 0;
+        for (std::int64_t lev = 0; lev < n_levels; ++lev) {
+            const auto l = static_cast<std::size_t>(lev);
+            if (level_block_start(l) <= static_cast<std::int64_t>(b)
+                && static_cast<std::int64_t>(b) < level_block_start(l + 1)) {
+                level = lev;
+                break;
+            }
+        }
+        std::int64_t n_block = 1;
+        for (std::size_t k = 0; k < ndim; ++k) {
+            n_block *= block_hi(b, k) - block_lo(b, k);
+
+            std::int64_t m_pow = 1;
+            for (std::int64_t i = 0; i < level; ++i) {
+                m_pow *= factor(k);
+            }
+            const std::int64_t max_root = (block_hi(b, k) - 1) / m_pow;
+            const std::int64_t start = knot_starts(k);
+            if (start < 0 || static_cast<std::size_t>(start + max_root + 1) >= knots_flat.shape(0)) {
+                throw nb::value_error(
+                    (std::string("block ") + std::to_string(b) + " axis " + std::to_string(k) +
+                     " reaches root cell " + std::to_string(max_root) + " at knot index " +
+                     std::to_string(start + max_root + 1) + ", but knots_flat holds " +
+                     std::to_string(knots_flat.shape(0)))
+                        .c_str());
+            }
+        }
+        needed = std::max(needed, static_cast<std::size_t>(block_base(b) + n_block));
+    }
+    require_capacity(out_lo, 0, needed, "out_lo");
+    require_capacity(out_hi, 0, needed, "out_hi");
+
+    pantr::grid::hier_collect_cell_bounds<double>(
+        std::span<const double>(knots_flat.data(), knots_flat.shape(0)),
+        std::span<const std::int64_t>(knot_starts.data(), ndim),
+        std::span<const std::int64_t>(factor.data(), ndim),
+        pantr::span2d<const std::int64_t>(block_lo.data(), block_lo.shape(0), ndim),
+        pantr::span2d<const std::int64_t>(block_hi.data(), block_hi.shape(0), ndim),
+        std::span<const std::int64_t>(block_base.data(), block_base.shape(0)),
+        std::span<const std::int64_t>(level_block_start.data(), level_block_start.shape(0)),
+        pantr::span2d<double>(out_lo.data(), out_lo.shape(0), ndim),
+        pantr::span2d<double>(out_hi.data(), out_hi.shape(0), ndim));
+}
+
+}  // namespace
+
+void register_grid(nb::module_& m) {
+    m.def("locate_points", &bind_locate_points, nb::arg("points").noconvert(), nb::kw_only(),
+          nb::arg("knots_flat").noconvert(), nb::arg("knot_starts").noconvert(),
+          nb::arg("cells_per_axis").noconvert(), nb::arg("strides").noconvert(),
+          nb::arg("out").noconvert());
+
+    m.def("bvh_build", &bind_bvh_build, nb::kw_only(), nb::arg("cell_lo").noconvert(),
+          nb::arg("cell_hi").noconvert(), nb::arg("node_lo").noconvert(),
+          nb::arg("node_hi").noconvert(), nb::arg("node_left").noconvert(),
+          nb::arg("node_right").noconvert(), nb::arg("node_cell").noconvert());
+
+    m.def("bvh_query_count", &bind_bvh_query_count, nb::kw_only(), nb::arg("qlo").noconvert(),
+          nb::arg("qhi").noconvert(), nb::arg("node_lo").noconvert(),
+          nb::arg("node_hi").noconvert(), nb::arg("node_left").noconvert(),
+          nb::arg("node_right").noconvert(), nb::arg("node_cell").noconvert());
+
+    m.def("bvh_query_emit", &bind_bvh_query_emit, nb::kw_only(), nb::arg("qlo").noconvert(),
+          nb::arg("qhi").noconvert(), nb::arg("node_lo").noconvert(),
+          nb::arg("node_hi").noconvert(), nb::arg("node_left").noconvert(),
+          nb::arg("node_right").noconvert(), nb::arg("node_cell").noconvert(),
+          nb::arg("out").noconvert());
+
+    m.def("encode_midx", &bind_encode_midx, nb::arg("level"), nb::kw_only(),
+          nb::arg("midx").noconvert(), nb::arg("block_lo").noconvert(),
+          nb::arg("block_hi").noconvert(), nb::arg("block_base").noconvert(),
+          nb::arg("level_block_start").noconvert());
+
+    m.def("decode_flat_id", &bind_decode_flat_id, nb::arg("cid"), nb::kw_only(),
+          nb::arg("block_lo").noconvert(), nb::arg("block_hi").noconvert(),
+          nb::arg("block_base").noconvert(), nb::arg("level_block_start").noconvert(),
+          nb::arg("out_midx").noconvert());
+
+    m.def("hier_locate_points", &bind_hier_locate_points, nb::arg("points").noconvert(),
+          nb::kw_only(), nb::arg("knots_flat").noconvert(), nb::arg("knot_starts").noconvert(),
+          nb::arg("root_cells_per_axis").noconvert(), nb::arg("factor").noconvert(),
+          nb::arg("block_lo").noconvert(), nb::arg("block_hi").noconvert(),
+          nb::arg("block_base").noconvert(), nb::arg("level_block_start").noconvert(),
+          nb::arg("out").noconvert());
+
+    m.def("hier_collect_cell_bounds", &bind_hier_collect_cell_bounds, nb::kw_only(),
+          nb::arg("knots_flat").noconvert(), nb::arg("knot_starts").noconvert(),
+          nb::arg("factor").noconvert(), nb::arg("block_lo").noconvert(),
+          nb::arg("block_hi").noconvert(), nb::arg("block_base").noconvert(),
+          nb::arg("level_block_start").noconvert(), nb::arg("out_lo").noconvert(),
+          nb::arg("out_hi").noconvert());
+}

--- a/cpp/bindings/grid.cpp
+++ b/cpp/bindings/grid.cpp
@@ -206,11 +206,28 @@ void bind_bvh_build(const_mat<double> cell_lo, const_mat<double> cell_hi,
 
     // hi >= lo is an ordering constraint, so it is checked rather than left to the
     // caller getting the two keywords the right way round.
+    // Finiteness first, and `hi >= lo` is NOT enough to give it. That test rejects
+    // a NaN corner, since every NaN comparison is false, but it ADMITS infinities:
+    // `+inf >= -inf` holds. The build then computes the centroid as
+    // `0.5 * (lo + hi)`, so a cell spanning `[-inf, +inf]` yields NaN from two
+    // corners that passed -- and a NaN key makes the stable sort's comparator an
+    // invalid strict weak ordering, which is undefined behaviour under
+    // [alg.sorting]/4 rather than merely a divergence from the oracle. The guard
+    // the sort needs is on the centroid, and no `hi >= lo` check can supply it.
+    // `pantr.grid.BVH.from_cell_bounds` rejects non-finite corners for the same
+    // reason; this is the same contract on the path that bypasses it.
     for (std::size_t i = 0; i < n_cells; ++i) {
         for (std::size_t k = 0; k < ndim; ++k) {
+            if (!std::isfinite(cell_lo(i, k)) || !std::isfinite(cell_hi(i, k))) {
+                throw nb::value_error((std::string("cell ") + std::to_string(i) + " axis " +
+                                       std::to_string(k) +
+                                       " has a non-finite corner; the centroid a "
+                                       "non-finite corner produces is not orderable")
+                                          .c_str());
+            }
             if (!(cell_hi(i, k) >= cell_lo(i, k))) {
                 throw nb::value_error((std::string("cell ") + std::to_string(i) + " axis " +
-                                       std::to_string(k) + " has hi < lo, or a NaN corner")
+                                       std::to_string(k) + " has hi < lo")
                                           .c_str());
             }
         }
@@ -366,10 +383,17 @@ void bind_hier_locate_points(const_mat<double> points, const_vec<double> knots_f
     require_knot_ranges(knots_flat.shape(0), knot_starts, root_cells_per_axis);
     require_capacity(out, 0, points.shape(0), "out");
     for (std::size_t k = 0; k < ndim; ++k) {
-        if (factor(k) < 2) {
+        // `< 1`, not `< 2`. The oracle documents a factor of 1 as legal -- it
+        // "prevents subdivision in that direction", which is what an anisotropic
+        // grid needs -- validates `f < 1`, and has a committed test asserting it.
+        // Rejecting 1 here made the two backends disagree on the DOMAIN rather
+        // than on a value, and it rejected the one factor at which the descent's
+        // contraction site provably cannot diverge: the clamp forces `j = 0`, so
+        // the product is exactly zero.
+        if (factor(k) < 1) {
             throw nb::value_error((std::string("factor[") + std::to_string(k) + "] is " +
                                    std::to_string(factor(k)) +
-                                   "; a subdivision factor below two never refines")
+                                   "; a subdivision factor must be at least one")
                                       .c_str());
         }
     }
@@ -400,10 +424,17 @@ void bind_hier_collect_cell_bounds(const_vec<double> knots_flat, i64_vec knot_st
     require_same(out_hi.shape(1), ndim, "out_hi columns", "block_lo");
 
     for (std::size_t k = 0; k < ndim; ++k) {
-        if (factor(k) < 2) {
+        // `< 1`, not `< 2`. The oracle documents a factor of 1 as legal -- it
+        // "prevents subdivision in that direction", which is what an anisotropic
+        // grid needs -- validates `f < 1`, and has a committed test asserting it.
+        // Rejecting 1 here made the two backends disagree on the DOMAIN rather
+        // than on a value, and it rejected the one factor at which the descent's
+        // contraction site provably cannot diverge: the clamp forces `j = 0`, so
+        // the product is exactly zero.
+        if (factor(k) < 1) {
             throw nb::value_error((std::string("factor[") + std::to_string(k) + "] is " +
                                    std::to_string(factor(k)) +
-                                   "; a subdivision factor below two never refines")
+                                   "; a subdivision factor must be at least one")
                                       .c_str());
         }
     }

--- a/cpp/bindings/pantr_cpp.cpp
+++ b/cpp/bindings/pantr_cpp.cpp
@@ -65,6 +65,7 @@ NB_MODULE(_pantr_cpp, m) {
     register_change_basis(m);
     register_bezier(m);
     register_bezier_root_finding(m);
+    register_grid(m);
 
     // Build provenance, so a measurement can name the binary that produced it
     // rather than the source tree it was built from. `fp_contract` is the one

--- a/cpp/bindings/register.hpp
+++ b/cpp/bindings/register.hpp
@@ -22,6 +22,13 @@ void register_change_basis(nanobind::module_& m);
 /// Register the `pantr.bezier` arithmetic kernel bindings on `m`.
 void register_bezier(nanobind::module_& m);
 
+/// Register the `pantr.grid` kernel bindings on `m`.
+///
+/// One entry point rather than three, unlike the two `pantr.bezier` halves below:
+/// the three grid headers are one port with one parity claim, and the comments
+/// that justify their checks argue from the same place.
+void register_grid(nanobind::module_& m);
+
 /// Register the `pantr.bezier` root-finding kernel bindings on `m`.
 ///
 /// Separate from `register_bezier` because the two halves of the package are

--- a/cpp/include/pantr/grid/bvh.hpp
+++ b/cpp/include/pantr/grid/bvh.hpp
@@ -308,7 +308,18 @@ template <Real T>
 /// \param node_right Right-child indices.
 /// \param node_cell Per-leaf cell ids; -1 marks an internal node.
 /// \param out Output cell ids, sized by a prior `bvh_query_count`.
-/// \return The number of cell ids written.
+/// \return The number of overlapping leaves, which is what `bvh_query_count`
+///         returns for the same arguments -- **not** the number written, when
+///         `out` is too small to hold them all.
+///
+/// The oracle writes unconditionally and would corrupt memory on an undersized
+/// `out`. This one counts unconditionally and writes only within capacity, so an
+/// undersized buffer is detectable rather than fatal: the caller compares the
+/// returned count against the capacity it allocated. That comparison is exactly
+/// the count/emit agreement the oracle's own module docstring says is the only
+/// thing the two traversal orders have to preserve, and the binding raises on it.
+/// A deliberate deviation, and the only one in this file that changes behaviour on
+/// any input -- undersized buffers being the input, which Layer 2 never produces.
 template <Real T>
 std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
                             span2d<const T> node_lo, span2d<const T> node_hi,
@@ -329,7 +340,9 @@ std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
         }
         const std::int64_t cell = node_cell[node];
         if (cell >= 0) {
-            out[static_cast<std::size_t>(count)] = cell;
+            if (static_cast<std::size_t>(count) < out.size()) {
+                out[static_cast<std::size_t>(count)] = cell;
+            }
             ++count;
         } else {
             stack[top] = node_left[node];

--- a/cpp/include/pantr/grid/bvh.hpp
+++ b/cpp/include/pantr/grid/bvh.hpp
@@ -1,0 +1,344 @@
+#pragma once
+
+/// \file
+/// A bounding-volume hierarchy over grid-cell AABBs: build, and box-overlap query.
+///
+/// Ports `src/pantr/grid/_bvh_core.py`, which stays as the parity oracle.
+///
+/// ## Why this port keeps pantr's own BVH rather than adopting a library
+///
+/// `design/bvh.md` decides that, and the reason is not the obvious one: the five
+/// node arrays are **public API**, not an implementation detail. A downstream
+/// consumer does not call the query at all -- it walks the tree itself, probing at
+/// each internal node with its own predicate. So the layout is a contract, and
+/// swapping implementations would rewrite that consumer. The note also records
+/// that the only query is box overlap, while every candidate library is tuned for
+/// *ray* queries, so their advantages buy nothing here.
+///
+/// That makes the layout the thing this port must not disturb, which is why the
+/// header reproduces it exactly rather than choosing a better one.
+///
+/// ## Why the parity claim is an equality, and the argument for each verdict
+///
+/// The build takes three **discrete** decisions, and `design/backend_parity.md`
+/// Rule 11 warns that no tolerance bounds a discrete verdict. None is needed,
+/// because each rests on a quantity that is bit-identical between the backends:
+///
+///  1. **The node AABB** is a running min/max over the cells' own stored corners.
+///     No arithmetic at all -- the values are copied, not computed -- so the only
+///     question is tie behaviour, and Python's two-argument `min` keeps its first
+///     argument on a tie. The form below keeps the incumbent for the same reason,
+///     which also settles the signed-zero trap `CLAUDE.md` records for
+///     `np.minimum(-0.0, 0.0)`: that trap is about numpy's ufunc, the oracle uses
+///     the builtin, and "keep the incumbent" is identical on either sign of zero.
+///  2. **The longest axis** compares `hi - lo` per axis with a strict `>`, so a tie
+///     keeps the lower axis, matching `np.argmax`. One subtraction of two
+///     bit-identical values; there is no fused-multiply-add site in it.
+///  3. **The median split** is a *stable* sort of the node's cells by centroid.
+///     Stability is what makes this exactly reproducible rather than merely
+///     similar: a stable sort's output permutation is **uniquely determined** --
+///     indices ordered by value, ties in increasing index order -- so any two
+///     correct stable sorts agree, and `std::stable_sort` therefore reproduces
+///     `np.argsort(kind="mergesort")` by argument and not by coincidence.
+///
+/// The centroid itself is `0.5 * (lo + hi)`: the addition rounds once and the
+/// multiplication by `0.5` is exact, and because the multiply follows the add
+/// there is no product for a compiler to fuse into it. So `-ffp-contract=on`
+/// cannot move it, which is what separates this kernel from
+/// `pantr/bezier/root_finding.hpp`, where contraction is live and Rule 10 has to
+/// budget for it.
+///
+/// The stable sort's comparator is a valid strict weak ordering only on finite
+/// values, and a NaN would make it undefined behaviour rather than merely
+/// divergent. It cannot arrive: `_bvh.py:322` rejects any non-finite corner before
+/// the kernel is reached. Checked rather than assumed, because the consequence of
+/// being wrong here is UB and not a wrong answer.
+///
+/// ## The query is exact for a duller reason
+///
+/// Both query kernels are comparisons on stored node bounds plus an integer
+/// stack. The overlap test is inclusive on every face, so a query box sharing a
+/// face with a cell is reported -- matching `pantr.geometry.AABB.overlaps` -- and
+/// that too is a discrete verdict decided without arithmetic.
+///
+/// Count and emit must agree on the output size, so they share one traversal
+/// order: the left child is pushed first and the right last, so the stack pops
+/// right first. That is the opposite direction from the build's left-to-right
+/// preorder, and the oracle's own docstring records that only count/emit
+/// consistency matters. Reproduced as it stands rather than tidied, because
+/// tidying it would change which cells land at which output index.
+///
+/// ## Allocation
+///
+/// The build allocates its scratch; the queries do not. The split is deliberate
+/// and follows `pantr/change_basis/change_basis.hpp`, which allocates a triangle
+/// for the same reason: a one-off construction is not an inner loop, and the
+/// alternative is a work-span argument per scratch array that Layer 2 would have
+/// to size. The queries keep the fixed stack and no allocation, which is where the
+/// kernel discipline earns its keep.
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::grid {
+
+/// Maximum depth of the iterative-descent stack.
+///
+/// Mirrors `_bvh_core._BVH_STACK_DEPTH`. The oracle's copy is the source of truth
+/// and stays where it is: a downstream consumer imports it from that path, and
+/// Layer 2 validates a tree against it before either query kernel runs, so this
+/// constant is never the one a caller is checked against.
+inline constexpr std::int64_t kBvhStackDepth = 128;
+
+/// Build the BVH arrays from per-cell AABBs, by median-of-longest-axis splits.
+///
+/// Mirrors `_bvh_core._bvh_build_core`. No validation is performed.
+///
+/// \tparam T Coordinate type.
+/// \param cell_lo Per-cell lo corners, shape `(n_cells, ndim)`, `n_cells >= 1`.
+/// \param cell_hi Per-cell hi corners, same shape; `hi >= lo` is assumed.
+/// \param node_lo Output per-node lo corners, shape `(2 * n_cells - 1, ndim)`.
+/// \param node_hi Output per-node hi corners, same shape.
+/// \param node_left Output left-child indices, shape `(2 * n_cells - 1,)`;
+///        must be pre-filled with -1.
+/// \param node_right Output right-child indices, same shape and pre-fill.
+/// \param node_cell Output per-leaf cell ids, same shape and pre-fill.
+template <Real T>
+void bvh_build(span2d<const T> cell_lo, span2d<const T> cell_hi, span2d<T> node_lo,
+               span2d<T> node_hi, std::span<std::int64_t> node_left,
+               std::span<std::int64_t> node_right, std::span<std::int64_t> node_cell) {
+    using pantr::value_of;
+
+    const auto n_cells = static_cast<std::int64_t>(cell_lo.extent(0));
+    const std::size_t ndim = cell_lo.extent(1);
+
+    std::vector<T> centroid(static_cast<std::size_t>(n_cells) * ndim);
+    for (std::int64_t c = 0; c < n_cells; ++c) {
+        for (std::size_t k = 0; k < ndim; ++k) {
+            const auto i = static_cast<std::size_t>(c);
+            centroid[i * ndim + k] = T(0.5) * (cell_lo(i, k) + cell_hi(i, k));
+        }
+    }
+
+    std::vector<std::int64_t> perm(static_cast<std::size_t>(n_cells));
+    std::iota(perm.begin(), perm.end(), std::int64_t{0});
+
+    // Work stack of (node_idx, cell_start, cell_end) triples. Its peak size is
+    // bounded by the tree height, which Layer 2 has validated against the depth.
+    std::vector<std::int64_t> stack_idx(static_cast<std::size_t>(kBvhStackDepth));
+    std::vector<std::int64_t> stack_start(static_cast<std::size_t>(kBvhStackDepth));
+    std::vector<std::int64_t> stack_end(static_cast<std::size_t>(kBvhStackDepth));
+    stack_idx[0] = 0;
+    stack_start[0] = 0;
+    stack_end[0] = n_cells;
+    std::int64_t sp = 1;
+    std::int64_t next_idx = 1;
+
+    std::vector<T> vals;
+    std::vector<std::int64_t> order;
+    std::vector<std::int64_t> sub;
+
+    while (sp > 0) {
+        --sp;
+        const std::int64_t idx = stack_idx[static_cast<std::size_t>(sp)];
+        const std::int64_t start = stack_start[static_cast<std::size_t>(sp)];
+        const std::int64_t end = stack_end[static_cast<std::size_t>(sp)];
+        const auto node = static_cast<std::size_t>(idx);
+
+        // Tight AABB of the node: a running min/max over its cells, keeping the
+        // incumbent on a tie exactly as the oracle's builtin min/max do.
+        for (std::size_t k = 0; k < ndim; ++k) {
+            const auto first = static_cast<std::size_t>(perm[static_cast<std::size_t>(start)]);
+            T lo_k = cell_lo(first, k);
+            T hi_k = cell_hi(first, k);
+            for (std::int64_t c = start + 1; c < end; ++c) {
+                const auto i = static_cast<std::size_t>(perm[static_cast<std::size_t>(c)]);
+                const T v_lo = cell_lo(i, k);
+                const T v_hi = cell_hi(i, k);
+                if (value_of(v_lo) < value_of(lo_k)) {
+                    lo_k = v_lo;
+                }
+                if (value_of(v_hi) > value_of(hi_k)) {
+                    hi_k = v_hi;
+                }
+            }
+            node_lo(node, k) = lo_k;
+            node_hi(node, k) = hi_k;
+        }
+
+        const std::int64_t count = end - start;
+        if (count == 1) {
+            node_cell[node] = perm[static_cast<std::size_t>(start)];
+            continue;
+        }
+
+        // Longest axis of the node AABB, first maximum, matching np.argmax.
+        std::size_t axis = 0;
+        auto best = value_of(static_cast<T>(node_hi(node, 0) - node_lo(node, 0)));
+        for (std::size_t k = 1; k < ndim; ++k) {
+            const auto extent_k = value_of(static_cast<T>(node_hi(node, k) - node_lo(node, k)));
+            if (extent_k > best) {
+                best = extent_k;
+                axis = k;
+            }
+        }
+
+        // Stable sort of the node's cells by centroid along the split axis.
+        const auto n = static_cast<std::size_t>(count);
+        vals.resize(n);
+        order.resize(n);
+        sub.resize(n);
+        for (std::size_t c = 0; c < n; ++c) {
+            const auto i = static_cast<std::size_t>(perm[static_cast<std::size_t>(start) + c]);
+            vals[c] = centroid[i * ndim + axis];
+        }
+        std::iota(order.begin(), order.end(), std::int64_t{0});
+        std::stable_sort(order.begin(), order.end(),
+                         [&vals](std::int64_t a, std::int64_t b) {
+                             return value_of(vals[static_cast<std::size_t>(a)])
+                                    < value_of(vals[static_cast<std::size_t>(b)]);
+                         });
+        for (std::size_t c = 0; c < n; ++c) {
+            sub[c] = perm[static_cast<std::size_t>(start) + c];
+        }
+        for (std::size_t c = 0; c < n; ++c) {
+            perm[static_cast<std::size_t>(start) + c] =
+                sub[static_cast<std::size_t>(order[c])];
+        }
+
+        const std::int64_t mid = start + count / 2;
+        const std::int64_t left_idx = next_idx;
+        const std::int64_t right_idx = next_idx + 1;
+        next_idx += 2;
+        node_left[node] = left_idx;
+        node_right[node] = right_idx;
+
+        // Push right first so left pops first: preorder, left to right, matching
+        // the construction order the oracle's module docstring declares.
+        stack_idx[static_cast<std::size_t>(sp)] = right_idx;
+        stack_start[static_cast<std::size_t>(sp)] = mid;
+        stack_end[static_cast<std::size_t>(sp)] = end;
+        stack_idx[static_cast<std::size_t>(sp + 1)] = left_idx;
+        stack_start[static_cast<std::size_t>(sp + 1)] = start;
+        stack_end[static_cast<std::size_t>(sp + 1)] = mid;
+        sp += 2;
+    }
+}
+
+/// Whether a node's AABB overlaps the query box, inclusive on every face.
+///
+/// Factored out so that count and emit cannot drift from each other on the tie
+/// contract, which is the one thing about them that is not obviously the same.
+template <Real T>
+[[nodiscard]] bool node_overlaps(std::span<const T> qlo, std::span<const T> qhi,
+                                 span2d<const T> node_lo, span2d<const T> node_hi,
+                                 std::size_t node) {
+    using pantr::value_of;
+    for (std::size_t d = 0; d < qlo.size(); ++d) {
+        if (value_of(qhi[d]) < value_of(node_lo(node, d))
+            || value_of(qlo[d]) > value_of(node_hi(node, d))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// Count the leaves whose AABB overlaps the query box.
+///
+/// Mirrors `_bvh_core._bvh_query_count_core`. No validation is performed. Called
+/// before the emit pass so Layer 2 can allocate an exact-size output array.
+///
+/// \tparam T Coordinate type.
+/// \param qlo Query box lo corner, shape `(ndim,)`.
+/// \param qhi Query box hi corner, same shape.
+/// \param node_lo Per-node AABB lower corners, shape `(n_nodes, ndim)`.
+/// \param node_hi Per-node AABB upper corners, same shape.
+/// \param node_left Left-child indices; -1 marks a leaf.
+/// \param node_right Right-child indices.
+/// \param node_cell Per-leaf cell ids; -1 marks an internal node.
+/// \return The number of overlapping leaves.
+template <Real T>
+[[nodiscard]] std::int64_t bvh_query_count(std::span<const T> qlo, std::span<const T> qhi,
+                                           span2d<const T> node_lo, span2d<const T> node_hi,
+                                           std::span<const std::int64_t> node_left,
+                                           std::span<const std::int64_t> node_right,
+                                           std::span<const std::int64_t> node_cell) {
+    std::array<std::int64_t, static_cast<std::size_t>(kBvhStackDepth)> stack{};
+    stack[0] = 0;
+    std::int64_t top = 1;
+    std::int64_t count = 0;
+
+    while (top > 0) {
+        --top;
+        const auto node = static_cast<std::size_t>(stack[top]);
+        if (!node_overlaps<T>(qlo, qhi, node_lo, node_hi, node)) {
+            continue;
+        }
+        if (node_cell[node] >= 0) {
+            ++count;
+        } else {
+            stack[top] = node_left[node];
+            ++top;
+            stack[top] = node_right[node];
+            ++top;
+        }
+    }
+    return count;
+}
+
+/// Fill `out` with the cell ids of the leaves whose AABB overlaps the query box.
+///
+/// Mirrors `_bvh_core._bvh_query_emit_core`. No validation is performed. Visits
+/// nodes in the same order as `bvh_query_count`, so the two agree on the size.
+///
+/// \tparam T Coordinate type.
+/// \param qlo Query box lo corner, shape `(ndim,)`.
+/// \param qhi Query box hi corner, same shape.
+/// \param node_lo Per-node AABB lower corners, shape `(n_nodes, ndim)`.
+/// \param node_hi Per-node AABB upper corners, same shape.
+/// \param node_left Left-child indices; -1 marks a leaf.
+/// \param node_right Right-child indices.
+/// \param node_cell Per-leaf cell ids; -1 marks an internal node.
+/// \param out Output cell ids, sized by a prior `bvh_query_count`.
+/// \return The number of cell ids written.
+template <Real T>
+std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
+                            span2d<const T> node_lo, span2d<const T> node_hi,
+                            std::span<const std::int64_t> node_left,
+                            std::span<const std::int64_t> node_right,
+                            std::span<const std::int64_t> node_cell,
+                            std::span<std::int64_t> out) {
+    std::array<std::int64_t, static_cast<std::size_t>(kBvhStackDepth)> stack{};
+    stack[0] = 0;
+    std::int64_t top = 1;
+    std::int64_t count = 0;
+
+    while (top > 0) {
+        --top;
+        const auto node = static_cast<std::size_t>(stack[top]);
+        if (!node_overlaps<T>(qlo, qhi, node_lo, node_hi, node)) {
+            continue;
+        }
+        const std::int64_t cell = node_cell[node];
+        if (cell >= 0) {
+            out[static_cast<std::size_t>(count)] = cell;
+            ++count;
+        } else {
+            stack[top] = node_left[node];
+            ++top;
+            stack[top] = node_right[node];
+            ++top;
+        }
+    }
+    return count;
+}
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -66,8 +66,12 @@
 /// nothing fuses either way, so no test on such a build can catch a re-inlining --
 /// `design/build_findings.md` is what says two-sided evidence is needed here, and
 /// the disassembly is the other side. `tests/parity/test_grid.py` carries the
-/// counterexample above as a named case, which will fail the moment the ISA ladder
-/// of `design/simd.md` lands and the product is inlined again.
+/// counterexample above as a named case that runs the real kernel at that input
+/// under both backends, so it fails if the product is inlined again on a target
+/// that fuses. That test also asserts, independently of any backend, that the input
+/// is still a *discriminator* -- that a fused evaluation diverges from an unfused
+/// one there -- which is the half that says something on a build where nothing
+/// fuses at all.
 ///
 /// Rule 11's operational consequence still stands and is independent of all this: a
 /// caller comparing the two backends must assert the returned **ids** on their own,

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -23,29 +23,56 @@
 /// hi[k]  = lo[k] + size_k
 /// ```
 ///
-/// `lo[k]` is rewritten each level from an expression a compiler may contract into
-/// a fused multiply-add, and the rewritten value feeds the next level's `size_k`,
-/// its truncation and its own update. So the two backends can in principle take
+/// `lo[k]` is rewritten each level, and the rewritten value feeds the next level's
+/// `size_k`, its truncation and its own update. Written as one expression that
+/// update is contractible, and `-ffp-contract=on` permits exactly that; the oracle
+/// never fuses, since numba defaults to `fastmath=False`. The two would then take
 /// different branches, and `design/backend_parity.md` Rule 11 is explicit that no
 /// tolerance bounds a branch.
 ///
-/// **Measured, they do not.** 300000 descents of twelve levels, spans and
-/// subdivision factors varied, 23.8% of the 3.6 million child decisions taken at a
-/// `j` that is not a power of two so the product is genuinely inexact, and half the
-/// query points placed one ulp off an exact child boundary: zero child-index
-/// sequences differ. The mechanism is that the perturbation is never introduced
-/// rather than that it fails to grow -- fusing changes the sum only when `|lo|` and
-/// `|j * size|` are comparable, and in a descent the second shrinks geometrically
-/// while the first does not, so within two or three levels the ratio is past the
-/// point where any difference survives.
+/// **So the product is named rather than inlined, at both sites, and that is what
+/// makes the equality hold.** It is a property of how the statement is written, not
+/// of the target: `-ffp-contract=on` was chosen over `fast` precisely because it
+/// confines fusion to within a single expression, so splitting the statement puts
+/// the multiplication's rounding back where the oracle has it. Verified by
+/// disassembly at `-march=x86-64-v3` and at `-march=native`.
 ///
-/// **That is evidence and not proof**, and it is deliberately held to the same
-/// standard as Rule 11's own note about the Bézier root set: the primitive
-/// demonstrably *can* differ, so a divergence is possible and simply did not occur.
-/// The operational consequence is the one Rule 11 states: a caller comparing the
-/// two backends must assert the returned **ids** on their own, before and
-/// separately from any numeric comparison, because a changed id is a changed
-/// verdict and not a displaced value.
+/// **Two things are worth knowing about how this paragraph used to read**, because
+/// both are traps a later reader could fall into again.
+///
+/// It claimed the descent could not diverge, and justified that with a sweep of
+/// 300000 descents and a mechanism: that fusing moves a sum only when its two terms
+/// are comparable in magnitude, which in a descent stops holding after a level or
+/// two. Both parts were wrong. The sweep ran on a build with **no** `-march`, where
+/// baseline x86-64 is SSE2 and has no fused multiply-add at all, so it compared two
+/// unfused implementations and carried no information about contraction. And the
+/// mechanism is false in the direction that matters: comparable magnitude is
+/// neither necessary nor sufficient, and the ratio that actually decides the
+/// verdict, `|dlo| / size_k`, is *invariant* rather than decaying, because the
+/// truncation divides by a `size_k` that shrinks at the same geometric rate. Once
+/// two backends disagree on `j` their indices never coincide again and the
+/// difference grows.
+///
+/// The counterexample, for anyone tempted to inline the product again: root cell
+/// `[1.0, 2.0]`, factor 10, `x = 1.71`. At level 0 the unfused sum is
+/// `1.7000000000000002` and the fused one `1.7`, one ulp apart; at level 1 the
+/// quotients are `0.9999999999999778` and exactly `1.0`, so the truncation gives
+/// child 0 against child 1. Note which side is right: the exact value of
+/// `1.0 + 7*fl(0.1)` is `1.7`, so the fused result is the correctly rounded one and
+/// the oracle is one ulp high. Splitting the statement deliberately forbids the
+/// more accurate answer, because this port's contract is parity and not correction.
+///
+/// **What protects the split, and what does not.** On a build with no `-march`
+/// nothing fuses either way, so no test on such a build can catch a re-inlining --
+/// `design/build_findings.md` is what says two-sided evidence is needed here, and
+/// the disassembly is the other side. `tests/parity/test_grid.py` carries the
+/// counterexample above as a named case, which will fail the moment the ISA ladder
+/// of `design/simd.md` lands and the product is inlined again.
+///
+/// Rule 11's operational consequence still stands and is independent of all this: a
+/// caller comparing the two backends must assert the returned **ids** on their own,
+/// before and separately from any numeric comparison, because a changed id is a
+/// changed verdict and not a displaced value.
 ///
 /// ## Two deviations from the oracle's shape, both deliberate
 ///

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -1,0 +1,387 @@
+#pragma once
+
+/// \file
+/// Cell addressing and point location on a hierarchical grid.
+///
+/// Ports `src/pantr/grid/_hier_core.py`, which stays as the parity oracle.
+///
+/// ## Where this file's parity claim differs from its siblings'
+///
+/// `pantr/grid/locate.hpp` and `pantr/grid/bvh.hpp` claim an equality and can
+/// argue it structurally: one performs no floating-point arithmetic at all, and
+/// the other's every discrete verdict rests on a quantity with a single rounding
+/// and no site a compiler could fuse. **This file cannot make that argument**, and
+/// saying so is the point of this section.
+///
+/// Three of its five kernels are pure integer arithmetic and are exact for the
+/// same dull reason as the others. The other two run a descent:
+///
+/// ```
+/// size_k = (hi[k] - lo[k]) / factor[k]
+/// j      = int((x[k] - lo[k]) / size_k)     // truncation: a discrete verdict
+/// lo[k]  = lo[k] + j * size_k               // a multiply feeding an add: fusable
+/// hi[k]  = lo[k] + size_k
+/// ```
+///
+/// `lo[k]` is rewritten each level from an expression a compiler may contract into
+/// a fused multiply-add, and the rewritten value feeds the next level's `size_k`,
+/// its truncation and its own update. So the two backends can in principle take
+/// different branches, and `design/backend_parity.md` Rule 11 is explicit that no
+/// tolerance bounds a branch.
+///
+/// **Measured, they do not.** 300000 descents of twelve levels, spans and
+/// subdivision factors varied, 23.8% of the 3.6 million child decisions taken at a
+/// `j` that is not a power of two so the product is genuinely inexact, and half the
+/// query points placed one ulp off an exact child boundary: zero child-index
+/// sequences differ. The mechanism is that the perturbation is never introduced
+/// rather than that it fails to grow -- fusing changes the sum only when `|lo|` and
+/// `|j * size|` are comparable, and in a descent the second shrinks geometrically
+/// while the first does not, so within two or three levels the ratio is past the
+/// point where any difference survives.
+///
+/// **That is evidence and not proof**, and it is deliberately held to the same
+/// standard as Rule 11's own note about the Bézier root set: the primitive
+/// demonstrably *can* differ, so a divergence is possible and simply did not occur.
+/// The operational consequence is the one Rule 11 states: a caller comparing the
+/// two backends must assert the returned **ids** on their own, before and
+/// separately from any numeric comparison, because a changed id is a changed
+/// verdict and not a displaced value.
+///
+/// ## Two deviations from the oracle's shape, both deliberate
+///
+/// **The oracle's `_encode_midx_core` is merged into `block_of_midx` here.** In the
+/// oracle they are two functions and the second is a one-line call to the first:
+/// one is a `nopython` helper reached from inside the descent, the other a serial
+/// entry point for a scalar Python caller. That split serves a Numba constraint --
+/// no dispatch can be inserted between two Numba kernels -- and has no analogue in
+/// C++, where one function serves both callers. Nothing computed changes.
+///
+/// **Both parallel kernels are serial here.** The oracle's outer loops are
+/// `prange`. Each iteration writes only its own output entry and there is no
+/// reduction, so the answer cannot move with the thread count either way; the same
+/// argument and the same precedent as the bezier batch kernels. Only the speed
+/// differs, and nothing here has been profiled.
+///
+/// ## Integer division, which is where a transliteration would quietly go wrong
+///
+/// The oracle uses Python's `//` and `%`, which floor; C++ truncates toward zero.
+/// They agree only for non-negative operands, so each site needs its own reason
+/// and gets one:
+///
+///  - `(lo_i + hi_i) / 2` in the binary search: both bounds start non-negative and
+///    only move inward.
+///  - `offset % extent` and `offset /= extent` in the decode: `offset` starts as
+///    `cid - block_base[b]`, which the upper-bound search leaves non-negative, and
+///    `extent` is a block width, so positive.
+///  - `ik / m_pow[k]` and `ik % m_pow[k]` in the collect: `ik` is a cell index and
+///    `m_pow` a positive power of the subdivision factor.
+///
+/// `m_pow` is built by repeated multiplication rather than by `pow`, matching the
+/// oracle, so that the two cannot disagree through a floating-point exponentiation
+/// neither of them should be doing.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::grid {
+
+/// Flat cell id of `(level, midx)`, or -1 when that position is not active.
+///
+/// Mirrors `_hier_core._block_of_midx`, and also `_hier_core._encode_midx_core`,
+/// which is a one-line call to it; see the file comment for why the two are one
+/// here. No validation is performed.
+///
+/// \param level Hierarchy level of the queried position.
+/// \param midx Per-axis index, shape `(ndim,)`, in level-`level` coordinates.
+/// \param block_lo Packed block lower bounds, shape `(n_blocks, ndim)`.
+/// \param block_hi Packed block upper bounds, same shape.
+/// \param block_base Flat-id base per block, shape `(n_blocks,)`.
+/// \param level_block_start Block index range per level, shape `(n_levels + 1,)`.
+/// \return The flat cell id, or -1 when `(level, midx)` is not an active leaf.
+[[nodiscard]] inline std::int64_t block_of_midx(std::int64_t level,
+                                                std::span<const std::int64_t> midx,
+                                                span2d<const std::int64_t> block_lo,
+                                                span2d<const std::int64_t> block_hi,
+                                                std::span<const std::int64_t> block_base,
+                                                std::span<const std::int64_t> level_block_start) {
+    const std::size_t ndim = midx.size();
+    const std::int64_t first = level_block_start[static_cast<std::size_t>(level)];
+    const std::int64_t last = level_block_start[static_cast<std::size_t>(level) + 1];
+
+    for (std::int64_t bi = first; bi < last; ++bi) {
+        const auto b = static_cast<std::size_t>(bi);
+        bool inside = true;
+        for (std::size_t k = 0; k < ndim; ++k) {
+            if (midx[k] < block_lo(b, k) || midx[k] >= block_hi(b, k)) {
+                inside = false;
+                break;
+            }
+        }
+        if (!inside) {
+            continue;
+        }
+        std::int64_t offset = 0;
+        for (std::size_t k = 0; k < ndim; ++k) {
+            offset = offset * (block_hi(b, k) - block_lo(b, k)) + (midx[k] - block_lo(b, k));
+        }
+        return block_base[b] + offset;
+    }
+    return -1;
+}
+
+/// Recover a cell's level and level-coordinate index from its flat id.
+///
+/// Mirrors `_hier_core._decode_flat_id_core`. No validation is performed.
+///
+/// \param cid Flat cell id in `[0, num_cells)`.
+/// \param block_lo Packed block lower bounds, shape `(n_blocks, ndim)`.
+/// \param block_hi Packed block upper bounds, same shape.
+/// \param block_base Flat-id base per block, globally ascending in flat-id order.
+/// \param level_block_start Block index range per level, shape `(n_levels + 1,)`.
+/// \param out_midx Output per-axis index, shape `(ndim,)`, in level coordinates.
+/// \return The cell's level.
+[[nodiscard]] inline std::int64_t decode_flat_id(std::int64_t cid,
+                                                 span2d<const std::int64_t> block_lo,
+                                                 span2d<const std::int64_t> block_hi,
+                                                 std::span<const std::int64_t> block_base,
+                                                 std::span<const std::int64_t> level_block_start,
+                                                 std::span<std::int64_t> out_midx) {
+    const auto ndim = static_cast<std::int64_t>(out_midx.size());
+    const auto n_blocks = static_cast<std::int64_t>(block_base.size());
+    const std::int64_t n_levels = static_cast<std::int64_t>(level_block_start.size()) - 1;
+
+    // upper_bound: the first block whose base exceeds cid, minus one.
+    std::int64_t lo_b = 0;
+    std::int64_t hi_b = n_blocks;
+    while (lo_b < hi_b) {
+        const std::int64_t mid = (lo_b + hi_b) / 2;
+        if (block_base[static_cast<std::size_t>(mid)] <= cid) {
+            lo_b = mid + 1;
+        } else {
+            hi_b = mid;
+        }
+    }
+    const auto b = static_cast<std::size_t>(lo_b - 1);
+
+    std::int64_t level = 0;
+    for (std::int64_t lev = 0; lev < n_levels; ++lev) {
+        const auto l = static_cast<std::size_t>(lev);
+        if (level_block_start[l] <= static_cast<std::int64_t>(b)
+            && static_cast<std::int64_t>(b) < level_block_start[l + 1]) {
+            level = lev;
+            break;
+        }
+    }
+
+    // Expand the C-order offset inside the block, last axis fastest.
+    std::int64_t offset = cid - block_base[b];
+    for (std::int64_t k = ndim - 1; k >= 0; --k) {
+        const auto kk = static_cast<std::size_t>(k);
+        const std::int64_t extent = block_hi(b, kk) - block_lo(b, kk);
+        out_midx[kk] = block_lo(b, kk) + offset % extent;
+        offset /= extent;
+    }
+    return level;
+}
+
+/// Locate a batch of points on a hierarchical grid.
+///
+/// Mirrors `_hier_core._hier_locate_points_core`. No validation is performed.
+/// This is one of the two kernels whose equality claim rests on measurement
+/// rather than on structure; see the file comment.
+///
+/// \tparam T Coordinate type.
+/// \param points Query points, shape `(npts, ndim)`.
+/// \param knots_flat Root per-axis breakpoints concatenated end to end.
+/// \param knot_starts Per-axis start offset into `knots_flat`.
+/// \param root_cells_per_axis Per-axis root cell counts.
+/// \param factor Per-axis subdivision factor.
+/// \param block_lo Packed block lower bounds, shape `(n_blocks, ndim)`.
+/// \param block_hi Packed block upper bounds, same shape.
+/// \param block_base Flat-id base per block.
+/// \param level_block_start Block index range per level.
+/// \param out Output flat cell ids, shape `(npts,)`; -1 outside the root domain.
+template <Real T>
+void hier_locate_points(span2d<const T> points, std::span<const T> knots_flat,
+                        std::span<const std::int64_t> knot_starts,
+                        std::span<const std::int64_t> root_cells_per_axis,
+                        std::span<const std::int64_t> factor,
+                        span2d<const std::int64_t> block_lo, span2d<const std::int64_t> block_hi,
+                        std::span<const std::int64_t> block_base,
+                        std::span<const std::int64_t> level_block_start,
+                        std::span<std::int64_t> out) {
+    using pantr::value_of;
+
+    const std::size_t npts = points.extent(0);
+    const std::size_t ndim = points.extent(1);
+    const std::int64_t n_levels = static_cast<std::int64_t>(level_block_start.size()) - 1;
+
+    std::vector<std::int64_t> midx(ndim);
+    std::vector<T> lo(ndim);
+    std::vector<T> hi(ndim);
+
+    for (std::size_t p = 0; p < npts; ++p) {
+        // Root-level location: one independent lower_bound per axis.
+        bool inside = true;
+        for (std::size_t d = 0; d < ndim; ++d) {
+            const std::int64_t start = knot_starts[d];
+            const std::int64_t ncells = root_cells_per_axis[d];
+            const auto x = value_of(points(p, d));
+
+            if (x < value_of(knots_flat[static_cast<std::size_t>(start)])
+                || x > value_of(knots_flat[static_cast<std::size_t>(start + ncells)])) {
+                inside = false;
+                break;
+            }
+            std::int64_t lo_i = 0;
+            std::int64_t hi_i = ncells + 1;
+            while (lo_i < hi_i) {
+                const std::int64_t mid = (lo_i + hi_i) / 2;
+                if (value_of(knots_flat[static_cast<std::size_t>(start + mid)]) < x) {
+                    lo_i = mid + 1;
+                } else {
+                    hi_i = mid;
+                }
+            }
+            std::int64_t cell_i = lo_i - 1;
+            if (cell_i < 0) {
+                cell_i = 0;
+            } else if (cell_i > ncells - 1) {
+                cell_i = ncells - 1;
+            }
+            midx[d] = cell_i;
+            lo[d] = knots_flat[static_cast<std::size_t>(start + cell_i)];
+            hi[d] = knots_flat[static_cast<std::size_t>(start + cell_i + 1)];
+        }
+        if (!inside) {
+            out[p] = -1;
+            continue;
+        }
+
+        // Top-down descent through the levels.
+        std::int64_t result = -1;
+        for (std::int64_t level = 0; level < n_levels; ++level) {
+            const std::int64_t cid =
+                block_of_midx(level, std::span<const std::int64_t>(midx), block_lo, block_hi,
+                              block_base, level_block_start);
+            if (cid >= 0) {
+                result = cid;
+                break;
+            }
+            if (level >= n_levels - 1) {
+                break;  // unreachable in a consistent grid
+            }
+            for (std::size_t k = 0; k < ndim; ++k) {
+                const std::int64_t fk = factor[k];
+                const T size_k = static_cast<T>((hi[k] - lo[k]) / T(static_cast<double>(fk)));
+                auto j = static_cast<std::int64_t>(
+                    value_of(static_cast<T>((points(p, k) - lo[k]) / size_k)));
+                if (j < 0) {
+                    j = 0;
+                } else if (j > fk - 1) {
+                    j = fk - 1;
+                }
+                lo[k] = lo[k] + T(static_cast<double>(j)) * size_k;
+                hi[k] = lo[k] + size_k;
+                midx[k] = midx[k] * fk + j;
+            }
+        }
+        out[p] = result;
+    }
+}
+
+/// Materialize per-cell `(lo, hi)` bounds in flat-id order.
+///
+/// Mirrors `_hier_core._hier_collect_cell_bounds_core`. No validation is
+/// performed. The second of the two kernels whose equality rests on measurement.
+///
+/// \tparam T Coordinate type.
+/// \param knots_flat Root per-axis breakpoints concatenated end to end.
+/// \param knot_starts Per-axis start offset into `knots_flat`.
+/// \param factor Per-axis subdivision factor.
+/// \param block_lo Packed block lower bounds, shape `(n_blocks, ndim)`.
+/// \param block_hi Packed block upper bounds, same shape.
+/// \param block_base Flat-id base per block.
+/// \param level_block_start Block index range per level.
+/// \param out_lo Output lower corners, shape `(num_cells, ndim)`.
+/// \param out_hi Output upper corners, same shape.
+template <Real T>
+void hier_collect_cell_bounds(std::span<const T> knots_flat,
+                              std::span<const std::int64_t> knot_starts,
+                              std::span<const std::int64_t> factor,
+                              span2d<const std::int64_t> block_lo,
+                              span2d<const std::int64_t> block_hi,
+                              std::span<const std::int64_t> block_base,
+                              std::span<const std::int64_t> level_block_start, span2d<T> out_lo,
+                              span2d<T> out_hi) {
+    const std::size_t ndim = block_lo.extent(1);
+    const std::int64_t n_levels = static_cast<std::int64_t>(level_block_start.size()) - 1;
+    const auto n_blocks = static_cast<std::int64_t>(block_base.size());
+
+    std::vector<std::int64_t> m_pow(ndim);
+    std::vector<std::int64_t> midx(ndim);
+
+    for (std::int64_t bi = 0; bi < n_blocks; ++bi) {
+        const auto b = static_cast<std::size_t>(bi);
+
+        // Recover the block's level; blocks are packed level by level.
+        std::int64_t level = 0;
+        for (std::int64_t lev = 0; lev < n_levels; ++lev) {
+            const auto l = static_cast<std::size_t>(lev);
+            if (level_block_start[l] <= bi && bi < level_block_start[l + 1]) {
+                level = lev;
+                break;
+            }
+        }
+
+        // Per-axis subdivision, by repeated multiplication as the oracle does.
+        for (std::size_t k = 0; k < ndim; ++k) {
+            std::int64_t mp = 1;
+            for (std::int64_t i = 0; i < level; ++i) {
+                mp *= factor[k];
+            }
+            m_pow[k] = mp;
+        }
+
+        // Odometer over the block's cells in C-order.
+        std::int64_t n_block = 1;
+        for (std::size_t k = 0; k < ndim; ++k) {
+            midx[k] = block_lo(b, k);
+            n_block *= block_hi(b, k) - block_lo(b, k);
+        }
+
+        std::int64_t flat_id = block_base[b];
+        for (std::int64_t c = 0; c < n_block; ++c) {
+            const auto row = static_cast<std::size_t>(flat_id);
+            for (std::size_t k = 0; k < ndim; ++k) {
+                const std::int64_t ik = midx[k];
+                const std::int64_t root_ik = ik / m_pow[k];
+                const std::int64_t sub_ik = ik % m_pow[k];
+                const T root_lo_k = knots_flat[static_cast<std::size_t>(knot_starts[k] + root_ik)];
+                const T root_hi_k =
+                    knots_flat[static_cast<std::size_t>(knot_starts[k] + root_ik + 1)];
+                const T size_k = static_cast<T>((root_hi_k - root_lo_k)
+                                                / T(static_cast<double>(m_pow[k])));
+                out_lo(row, k) = root_lo_k + T(static_cast<double>(sub_ik)) * size_k;
+                out_hi(row, k) = out_lo(row, k) + size_k;
+            }
+            ++flat_id;
+            // Increment the odometer, last axis fastest.
+            for (std::int64_t k = static_cast<std::int64_t>(ndim) - 1; k >= 0; --k) {
+                const auto kk = static_cast<std::size_t>(k);
+                midx[kk] += 1;
+                if (midx[kk] < block_hi(b, kk)) {
+                    break;
+                }
+                midx[kk] = block_lo(b, kk);
+            }
+        }
+    }
+}
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -286,7 +286,20 @@ void hier_locate_points(span2d<const T> points, std::span<const T> knots_flat,
                 } else if (j > fk - 1) {
                     j = fk - 1;
                 }
-                lo[k] = lo[k] + T(static_cast<double>(j)) * size_k;
+                // The product is named rather than inlined, and that is the whole of
+                // this port's exactness guarantee rather than a style choice.
+                // `lo + j * size` is one expression, so a target with a fused
+                // multiply-add may contract it, and `-ffp-contract=on` permits
+                // exactly that within an expression. The oracle never fuses
+                // (numba defaults to `fastmath=False`), so the two would then
+                // disagree -- and because the next line truncates a quotient, they
+                // would disagree on a CELL ID, which Rule 11 says no tolerance
+                // bounds. Splitting the statement puts the multiplication's
+                // rounding back where the oracle has it. Measured: `vmulsd` plus
+                // `vaddsd` at `-march=x86-64-v3` and at `-march=native`, against
+                // `vfmadd132sd` for the single-expression form.
+                const T step = T(static_cast<double>(j)) * size_k;
+                lo[k] = lo[k] + step;
                 hi[k] = lo[k] + size_k;
                 midx[k] = midx[k] * fk + j;
             }
@@ -367,7 +380,13 @@ void hier_collect_cell_bounds(std::span<const T> knots_flat,
                     knots_flat[static_cast<std::size_t>(knot_starts[k] + root_ik + 1)];
                 const T size_k = static_cast<T>((root_hi_k - root_lo_k)
                                                 / T(static_cast<double>(m_pow[k])));
-                out_lo(row, k) = root_lo_k + T(static_cast<double>(sub_ik)) * size_k;
+                // Split for the reason given at the descent site. This one is
+                // NOT protected by a small subdivision factor: `sub_ik` runs over
+                // `[0, factor**level)`, so it reaches 3 at level 2 even at factor
+                // 2, and a divergence was measured at factor 2 on the root cell
+                // [1.0, 1.1] from level 6.
+                const T offset = T(static_cast<double>(sub_ik)) * size_k;
+                out_lo(row, k) = root_lo_k + offset;
                 out_hi(row, k) = out_lo(row, k) + size_k;
             }
             ++flat_id;

--- a/cpp/include/pantr/grid/locate.hpp
+++ b/cpp/include/pantr/grid/locate.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+/// \file
+/// Batch point location on an axis-aligned tensor-product grid.
+///
+/// Ports `src/pantr/grid/_locate_core.py`, which stays as the parity oracle.
+///
+/// ## Why this one's parity claim is an equality, structurally
+///
+/// This kernel performs **no floating-point arithmetic at all**. Enumerated by
+/// walking the oracle's syntax tree rather than by reading it: every binary
+/// operation in `_locate_core.py` is on an integer index, and every use of a
+/// coordinate is a *comparison*. So there is no rounding to bound, no
+/// accumulation order to preserve and no fused-multiply-add site, and the two
+/// backends agree bit for bit for reasons that do not depend on the compiler,
+/// the vectorization width or the libm. That is a stronger claim than the
+/// contraction bounds `design/backend_parity.md` Rules 9 and 10 state for the
+/// bezier kernels, and it is stronger for a simpler reason: there is nothing
+/// there to differ.
+///
+/// The oracle is `float64`-only -- `_locate_core.py` mentions `float32` nowhere --
+/// so `T` is instantiated at `double` and nothing else. It is templated anyway,
+/// which is the core's convention (`pantr/core/scalar.hpp`) and costs nothing:
+/// the discipline that admits a `Dual` is the discipline that admits `float`, and
+/// a kernel whose only use of the scalar is a comparison is the easiest place to
+/// keep it.
+///
+/// ## The tie contract, and why it survives the port for free
+///
+/// A point exactly on an interior breakpoint belongs to the **lower**-indexed
+/// cell sharing that face; a point on the outer boundary belongs to the adjacent
+/// boundary cell; a point outside the domain maps to `-1`. That is a discrete
+/// verdict, which `design/backend_parity.md` Rule 11 warns no tolerance can
+/// bound. Here it needs none: the verdict is decided by `<` and `>` on
+/// coordinates that were never arithmetic operands, so both backends read the
+/// same bits and take the same branch.
+///
+/// ## One difference that is not parity
+///
+/// The oracle's outer loop is `prange`, so it runs one point per thread; this is
+/// serial. Each point writes only its own entry of `out` and there is no
+/// reduction, so the answer cannot move with the thread count either way. The
+/// same argument and the same precedent as the bezier batch kernels
+/// (`pantr/bezier/root_finding.hpp`); only the speed differs, and nothing here
+/// has been profiled.
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::grid {
+
+/// Locate a batch of points on an axis-aligned tensor-product grid.
+///
+/// Mirrors `_locate_core._locate_points_core`. No validation is performed.
+///
+/// \tparam T Coordinate type.
+/// \param points Query points, shape `(npts, ndim)`.
+/// \param knots_flat All per-axis knot vectors concatenated end to end; axis `d`
+///        occupies `[knot_starts[d], knot_starts[d] + cells_per_axis[d] + 1)` and
+///        must be strictly increasing.
+/// \param knot_starts Per-axis start offset into `knots_flat`, shape `(ndim,)`.
+/// \param cells_per_axis Per-axis cell counts, shape `(ndim,)`.
+/// \param strides Per-axis C-order flat strides, shape `(ndim,)`.
+/// \param out Output flat cell ids, shape `(npts,)`; `-1` for a point outside the
+///        grid domain.
+template <Real T>
+void locate_points(span2d<const T> points, std::span<const T> knots_flat,
+                   std::span<const std::int64_t> knot_starts,
+                   std::span<const std::int64_t> cells_per_axis,
+                   std::span<const std::int64_t> strides, std::span<std::int64_t> out) {
+    using pantr::value_of;
+
+    const std::size_t npts = points.extent(0);
+    const std::size_t ndim = points.extent(1);
+
+    for (std::size_t p = 0; p < npts; ++p) {
+        std::int64_t cid = 0;
+        bool inside = true;
+
+        for (std::size_t d = 0; d < ndim; ++d) {
+            const std::int64_t start = knot_starts[d];
+            const std::int64_t ncells = cells_per_axis[d];
+            const auto x = value_of(points(p, d));
+
+            const auto first = value_of(knots_flat[static_cast<std::size_t>(start)]);
+            const auto last = value_of(knots_flat[static_cast<std::size_t>(start + ncells)]);
+            if (x < first || x > last) {
+                inside = false;
+                break;
+            }
+
+            // lower_bound: the first index idx with knots[idx] >= x. Written out
+            // rather than delegated to std::lower_bound so that the comparison is
+            // the oracle's own and passes through value_of, which the standard
+            // algorithm's default comparator would not.
+            std::int64_t lo_i = 0;
+            std::int64_t hi_i = ncells + 1;
+            while (lo_i < hi_i) {
+                const std::int64_t mid = (lo_i + hi_i) / 2;
+                if (value_of(knots_flat[static_cast<std::size_t>(start + mid)]) < x) {
+                    lo_i = mid + 1;
+                } else {
+                    hi_i = mid;
+                }
+            }
+
+            std::int64_t cell_i = lo_i - 1;
+            if (cell_i < 0) {
+                cell_i = 0;
+            } else if (cell_i > ncells - 1) {
+                cell_i = ncells - 1;
+            }
+            cid += cell_i * strides[d];
+        }
+
+        out[p] = inside ? cid : -1;
+    }
+}
+
+}  // namespace pantr::grid

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -11,7 +11,10 @@ set(PANTR_TEST_SOURCES
     test_quad.cpp
     test_binomial.cpp
     test_bezier.cpp
-    test_bezier_root_finding.cpp)
+    test_bezier_root_finding.cpp
+    test_grid_locate.cpp
+    test_grid_bvh.cpp
+    test_grid_hierarchical.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES)
   cmake_path(GET _src STEM _name)

--- a/cpp/tests/test_grid_bvh.cpp
+++ b/cpp/tests/test_grid_bvh.cpp
@@ -1,0 +1,211 @@
+/// \file
+/// The BVH build and its box-overlap query, checked against structural
+/// properties rather than against the oracle.
+///
+/// Nothing here compares the two backends. What it checks is that the tree is a
+/// tree, that every node's box actually bounds its subtree's cells, and that a
+/// query returns exactly the cells whose boxes meet the query box -- the last one
+/// against a brute-force scan, which is an independent algorithm rather than a
+/// second copy of this one.
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/bvh.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::grid::bvh_build;
+using pantr::grid::bvh_query_count;
+using pantr::grid::bvh_query_emit;
+
+/// A built tree plus the cells it was built from.
+struct Tree {
+    std::int64_t n_cells;
+    std::size_t ndim;
+    std::vector<double> lo, hi;              // cells, row-major (n_cells, ndim)
+    std::vector<double> nlo, nhi;            // nodes, row-major (2n-1, ndim)
+    std::vector<std::int64_t> left, right, cell;
+};
+
+Tree build(std::int64_t n_cells, std::size_t ndim, const std::vector<double>& lo,
+           const std::vector<double>& hi) {
+    Tree t{n_cells, ndim, lo, hi, {}, {}, {}, {}, {}};
+    const auto n_nodes = static_cast<std::size_t>(2 * n_cells - 1);
+    t.nlo.assign(n_nodes * ndim, 0.0);
+    t.nhi.assign(n_nodes * ndim, 0.0);
+    t.left.assign(n_nodes, -1);
+    t.right.assign(n_nodes, -1);
+    t.cell.assign(n_nodes, -1);
+    bvh_build<double>(span2d<const double>(t.lo.data(), static_cast<std::size_t>(n_cells), ndim),
+                      span2d<const double>(t.hi.data(), static_cast<std::size_t>(n_cells), ndim),
+                      span2d<double>(t.nlo.data(), n_nodes, ndim),
+                      span2d<double>(t.nhi.data(), n_nodes, ndim), std::span<std::int64_t>(t.left),
+                      std::span<std::int64_t>(t.right), std::span<std::int64_t>(t.cell));
+    return t;
+}
+
+/// A deterministic spread of boxes; no Math.random-style nondeterminism.
+Tree make_boxes(std::int64_t n, std::size_t ndim) {
+    std::vector<double> lo(static_cast<std::size_t>(n) * ndim);
+    std::vector<double> hi(lo.size());
+    std::uint64_t s = 0x2545F4914F6CDD1DULL;
+    auto next = [&s]() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        return static_cast<double>(s & 0xFFFFFFULL) / 16777216.0;
+    };
+    for (std::size_t i = 0; i < lo.size(); ++i) {
+        const double a = -3.0 + 6.0 * next();
+        lo[i] = a;
+        hi[i] = a + 0.01 + 0.5 * next();
+    }
+    return build(n, ndim, lo, hi);
+}
+
+/// Collect the leaf cell ids under a node, and check the node bounds them.
+void check_subtree(const Tree& t, std::size_t node, std::vector<std::int64_t>& leaves) {
+    if (t.cell[node] >= 0) {
+        PANTR_CHECK_MSG(t.left[node] == -1 && t.right[node] == -1,
+                        "a leaf must have no children");
+        leaves.push_back(t.cell[node]);
+        return;
+    }
+    PANTR_CHECK_MSG(t.left[node] >= 0 && t.right[node] >= 0,
+                    "an internal node must have both children");
+    std::vector<std::int64_t> l, r;
+    check_subtree(t, static_cast<std::size_t>(t.left[node]), l);
+    check_subtree(t, static_cast<std::size_t>(t.right[node]), r);
+    PANTR_CHECK_MSG(!l.empty() && !r.empty(), "neither side of a split may be empty");
+    leaves.insert(leaves.end(), l.begin(), l.end());
+    leaves.insert(leaves.end(), r.begin(), r.end());
+
+    // The node's box must contain every cell below it, exactly -- it is a running
+    // min/max of stored corners, so equality is the right assertion, not closeness.
+    for (std::size_t k = 0; k < t.ndim; ++k) {
+        double lo_k = t.hi[static_cast<std::size_t>(leaves[0]) * t.ndim + k];
+        double hi_k = t.lo[static_cast<std::size_t>(leaves[0]) * t.ndim + k];
+        for (const std::int64_t c : leaves) {
+            lo_k = std::min(lo_k, t.lo[static_cast<std::size_t>(c) * t.ndim + k]);
+            hi_k = std::max(hi_k, t.hi[static_cast<std::size_t>(c) * t.ndim + k]);
+        }
+        PANTR_CHECK_MSG(t.nlo[node * t.ndim + k] == lo_k, "node lo must be the exact min");
+        PANTR_CHECK_MSG(t.nhi[node * t.ndim + k] == hi_k, "node hi must be the exact max");
+    }
+}
+
+/// Every cell appears exactly once as a leaf, and every node bounds its subtree.
+void the_tree_is_a_partition_and_its_boxes_bound() {
+    for (const std::int64_t n : {1, 2, 3, 5, 8, 17, 64}) {
+        for (const std::size_t ndim : {1u, 2u, 3u}) {
+            const Tree t = make_boxes(n, ndim);
+            std::vector<std::int64_t> leaves;
+            check_subtree(t, 0, leaves);
+            std::sort(leaves.begin(), leaves.end());
+            PANTR_CHECK_MSG(static_cast<std::int64_t>(leaves.size()) == n,
+                            "every cell must appear exactly once as a leaf");
+            for (std::int64_t i = 0; i < n; ++i) {
+                PANTR_CHECK(leaves[static_cast<std::size_t>(i)] == i);
+            }
+        }
+    }
+}
+
+/// The query returns exactly the overlapping cells, against a brute-force scan.
+void the_query_agrees_with_a_brute_force_scan() {
+    for (const std::int64_t n : {1, 2, 7, 33}) {
+        const std::size_t ndim = 2;
+        const Tree t = make_boxes(n, ndim);
+        const auto n_nodes = static_cast<std::size_t>(2 * n - 1);
+
+        for (int q = 0; q < 40; ++q) {
+            const double c = -3.5 + 0.2 * static_cast<double>(q);
+            const std::vector<double> qlo{c, c - 0.3};
+            const std::vector<double> qhi{c + 0.4, c + 0.6};
+
+            std::vector<std::int64_t> expected;
+            for (std::int64_t i = 0; i < n; ++i) {
+                bool ov = true;
+                for (std::size_t k = 0; k < ndim; ++k) {
+                    const auto j = static_cast<std::size_t>(i) * ndim + k;
+                    if (qhi[k] < t.lo[j] || qlo[k] > t.hi[j]) {
+                        ov = false;
+                        break;
+                    }
+                }
+                if (ov) {
+                    expected.push_back(i);
+                }
+            }
+
+            const auto count = bvh_query_count<double>(
+                std::span<const double>(qlo), std::span<const double>(qhi),
+                span2d<const double>(t.nlo.data(), n_nodes, ndim),
+                span2d<const double>(t.nhi.data(), n_nodes, ndim),
+                std::span<const std::int64_t>(t.left), std::span<const std::int64_t>(t.right),
+                std::span<const std::int64_t>(t.cell));
+            PANTR_CHECK_MSG(count == static_cast<std::int64_t>(expected.size()),
+                            "count must equal the brute-force overlap count");
+
+            std::vector<std::int64_t> got(static_cast<std::size_t>(count), -1);
+            const auto emitted = bvh_query_emit<double>(
+                std::span<const double>(qlo), std::span<const double>(qhi),
+                span2d<const double>(t.nlo.data(), n_nodes, ndim),
+                span2d<const double>(t.nhi.data(), n_nodes, ndim),
+                std::span<const std::int64_t>(t.left), std::span<const std::int64_t>(t.right),
+                std::span<const std::int64_t>(t.cell), std::span<std::int64_t>(got));
+            PANTR_CHECK_MSG(emitted == count, "emit must write exactly what count promised");
+            std::sort(got.begin(), got.end());
+            PANTR_CHECK(got == expected);
+        }
+    }
+}
+
+/// A query box sharing only a face with a cell is reported as overlapping.
+///
+/// The tie contract, and the one discrete verdict in this file worth its own case.
+void a_shared_face_counts_as_overlap() {
+    const Tree t = build(2, 1, {0.0, 1.0}, {1.0, 2.0});
+    const std::size_t n_nodes = 3;
+    // A degenerate query box exactly at the shared breakpoint x = 1.
+    const std::vector<double> qlo{1.0};
+    const std::vector<double> qhi{1.0};
+    const auto count = bvh_query_count<double>(
+        std::span<const double>(qlo), std::span<const double>(qhi),
+        span2d<const double>(t.nlo.data(), n_nodes, 1),
+        span2d<const double>(t.nhi.data(), n_nodes, 1), std::span<const std::int64_t>(t.left),
+        std::span<const std::int64_t>(t.right), std::span<const std::int64_t>(t.cell));
+    PANTR_CHECK_MSG(count == 2, "a box on the shared face must meet BOTH cells");
+}
+
+/// Cells with identical centroids still split, which is what stability buys.
+///
+/// With every centroid equal the sort has nothing to order, so the split rests
+/// entirely on the stable sort keeping the input order. A non-stable sort would
+/// still produce a valid tree here, so this case does not prove stability -- it
+/// pins that the degenerate input does not hang or produce an empty side.
+void identical_centroids_still_split() {
+    const std::int64_t n = 8;
+    std::vector<double> lo(static_cast<std::size_t>(n), -1.0);
+    std::vector<double> hi(static_cast<std::size_t>(n), 1.0);
+    const Tree t = build(n, 1, lo, hi);
+    std::vector<std::int64_t> leaves;
+    check_subtree(t, 0, leaves);
+    PANTR_CHECK(static_cast<std::int64_t>(leaves.size()) == n);
+}
+
+}  // namespace
+
+int main() {
+    the_tree_is_a_partition_and_its_boxes_bound();
+    the_query_agrees_with_a_brute_force_scan();
+    a_shared_face_counts_as_overlap();
+    identical_centroids_still_split();
+    return pantr::test::summary("test_grid_bvh");
+}

--- a/cpp/tests/test_grid_hierarchical.cpp
+++ b/cpp/tests/test_grid_hierarchical.cpp
@@ -1,0 +1,201 @@
+/// \file
+/// Hierarchical cell addressing and point location.
+///
+/// Nothing here compares the two backends. The checks are properties that tie the
+/// kernels to each other and to the geometry, which is what makes them an oracle
+/// rather than a second copy of the code:
+///
+///  - **collect and locate agree.** Locating the midpoint of every cell that
+///    `hier_collect_cell_bounds` produces must return that cell's own flat id.
+///    Neither kernel can satisfy this by mirroring the other -- one walks blocks
+///    and expands an odometer, the other descends levels and truncates a quotient.
+///  - **the cells tile the domain.** Sorted by lower corner they must abut
+///    exactly, with no gap and no overlap. An exact assertion, not a close one:
+///    the shared corner is produced by the same expression on both sides.
+///  - **decode inverts encode.** Round-tripping every flat id through
+///    `decode_flat_id` and back through `block_of_midx` must return it unchanged.
+///
+/// The two grids below are worked out by hand in the comments so that a reader can
+/// check the fixture itself rather than trusting it.
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/hierarchical.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::grid::block_of_midx;
+using pantr::grid::decode_flat_id;
+using pantr::grid::hier_collect_cell_bounds;
+using pantr::grid::hier_locate_points;
+
+/// A hand-built hierarchical grid, 1-D.
+struct Grid1D {
+    std::vector<double> knots;          // root breakpoints
+    std::vector<std::int64_t> starts;   // per-axis offset into knots
+    std::vector<std::int64_t> root_cells;
+    std::vector<std::int64_t> factor;
+    std::vector<std::int64_t> blo, bhi;  // (n_blocks, 1)
+    std::vector<std::int64_t> base;
+    std::vector<std::int64_t> lbs;  // level_block_start
+    std::int64_t num_cells;
+
+    [[nodiscard]] std::size_t n_blocks() const { return base.size(); }
+};
+
+/// One level, two root cells, both active. Cells: [0,1] and [1,2].
+Grid1D flat_grid() {
+    return Grid1D{{0.0, 1.0, 2.0}, {0}, {2}, {2}, {0}, {2}, {0}, {0, 1}, 2};
+}
+
+/// Two levels. Root cell 1 stays coarse; root cell 0 splits in two.
+///
+/// level 0: one block over level-0 indices [1,2)  -> flat id 0, the cell [1,2]
+/// level 1: one block over level-1 indices [0,2)  -> flat ids 1,2, cells
+///          [0,0.5] and [0.5,1]
+Grid1D refined_grid() {
+    return Grid1D{{0.0, 1.0, 2.0}, {0}, {2}, {2}, {1, 0}, {2, 2}, {0, 1}, {0, 1, 2}, 3};
+}
+
+std::vector<std::int64_t> locate(const Grid1D& g, const std::vector<double>& xs) {
+    std::vector<std::int64_t> out(xs.size(), -99);
+    hier_locate_points<double>(
+        span2d<const double>(xs.data(), xs.size(), 1), std::span<const double>(g.knots),
+        std::span<const std::int64_t>(g.starts), std::span<const std::int64_t>(g.root_cells),
+        std::span<const std::int64_t>(g.factor),
+        span2d<const std::int64_t>(g.blo.data(), g.n_blocks(), 1),
+        span2d<const std::int64_t>(g.bhi.data(), g.n_blocks(), 1),
+        std::span<const std::int64_t>(g.base), std::span<const std::int64_t>(g.lbs),
+        std::span<std::int64_t>(out));
+    return out;
+}
+
+std::pair<std::vector<double>, std::vector<double>> collect(const Grid1D& g) {
+    std::vector<double> lo(static_cast<std::size_t>(g.num_cells), -99.0);
+    std::vector<double> hi(lo.size(), -99.0);
+    hier_collect_cell_bounds<double>(
+        std::span<const double>(g.knots), std::span<const std::int64_t>(g.starts),
+        std::span<const std::int64_t>(g.factor),
+        span2d<const std::int64_t>(g.blo.data(), g.n_blocks(), 1),
+        span2d<const std::int64_t>(g.bhi.data(), g.n_blocks(), 1),
+        std::span<const std::int64_t>(g.base), std::span<const std::int64_t>(g.lbs),
+        span2d<double>(lo.data(), lo.size(), 1), span2d<double>(hi.data(), hi.size(), 1));
+    return {lo, hi};
+}
+
+/// The fixture itself, checked against the hand computation in its comment.
+void the_fixtures_are_what_they_claim() {
+    const auto [lo, hi] = collect(refined_grid());
+    PANTR_CHECK_MSG(lo[0] == 1.0 && hi[0] == 2.0, "flat id 0 is the coarse cell [1,2]");
+    PANTR_CHECK_MSG(lo[1] == 0.0 && hi[1] == 0.5, "flat id 1 is [0,0.5]");
+    PANTR_CHECK_MSG(lo[2] == 0.5 && hi[2] == 1.0, "flat id 2 is [0.5,1]");
+}
+
+/// Locating the midpoint of every collected cell returns that cell's own id.
+void collect_and_locate_agree(const Grid1D& g, const char* what) {
+    const auto [lo, hi] = collect(g);
+    std::vector<double> mids(lo.size());
+    for (std::size_t i = 0; i < lo.size(); ++i) {
+        mids[i] = 0.5 * (lo[i] + hi[i]);
+    }
+    const auto got = locate(g, mids);
+    for (std::size_t i = 0; i < mids.size(); ++i) {
+        PANTR_CHECK_MSG(got[i] == static_cast<std::int64_t>(i),
+                        std::string("the midpoint of cell ") + std::to_string(i) + " of " + what
+                            + " located to " + std::to_string(got[i]));
+    }
+}
+
+/// The collected cells tile the root domain exactly: no gap, no overlap.
+void the_cells_tile_the_domain(const Grid1D& g, const char* what) {
+    auto [lo, hi] = collect(g);
+    std::vector<std::size_t> order(lo.size());
+    for (std::size_t i = 0; i < order.size(); ++i) {
+        order[i] = i;
+    }
+    std::sort(order.begin(), order.end(), [&lo](std::size_t a, std::size_t b) {
+        return lo[a] < lo[b];
+    });
+    PANTR_CHECK_MSG(lo[order.front()] == g.knots.front(),
+                    std::string("the first cell of ") + what + " must start at the domain");
+    PANTR_CHECK_MSG(hi[order.back()] == g.knots.back(),
+                    std::string("the last cell of ") + what + " must end at the domain");
+    for (std::size_t i = 1; i < order.size(); ++i) {
+        PANTR_CHECK_MSG(hi[order[i - 1]] == lo[order[i]],
+                        std::string("cells of ") + what + " must abut exactly");
+    }
+}
+
+/// decode_flat_id inverts block_of_midx for every id in the grid.
+void decode_inverts_encode(const Grid1D& g, const char* what) {
+    for (std::int64_t cid = 0; cid < g.num_cells; ++cid) {
+        std::vector<std::int64_t> midx(1, -99);
+        const std::int64_t level =
+            decode_flat_id(cid, span2d<const std::int64_t>(g.blo.data(), g.n_blocks(), 1),
+                           span2d<const std::int64_t>(g.bhi.data(), g.n_blocks(), 1),
+                           std::span<const std::int64_t>(g.base),
+                           std::span<const std::int64_t>(g.lbs), std::span<std::int64_t>(midx));
+        const std::int64_t back =
+            block_of_midx(level, std::span<const std::int64_t>(midx),
+                          span2d<const std::int64_t>(g.blo.data(), g.n_blocks(), 1),
+                          span2d<const std::int64_t>(g.bhi.data(), g.n_blocks(), 1),
+                          std::span<const std::int64_t>(g.base),
+                          std::span<const std::int64_t>(g.lbs));
+        PANTR_CHECK_MSG(back == cid, std::string("round trip of id ") + std::to_string(cid)
+                                         + " in " + what + " gave " + std::to_string(back));
+    }
+}
+
+/// A position that is not an active leaf is -1, not a neighbouring cell's id.
+void an_inactive_position_is_minus_one() {
+    const Grid1D g = refined_grid();
+    // level 0, index 0: that root cell was refined away, so it is not active.
+    const std::vector<std::int64_t> midx{0};
+    const std::int64_t got =
+        block_of_midx(0, std::span<const std::int64_t>(midx),
+                      span2d<const std::int64_t>(g.blo.data(), g.n_blocks(), 1),
+                      span2d<const std::int64_t>(g.bhi.data(), g.n_blocks(), 1),
+                      std::span<const std::int64_t>(g.base), std::span<const std::int64_t>(g.lbs));
+    PANTR_CHECK_MSG(got == -1, "a refined-away position must not resolve to a cell");
+}
+
+/// Outside the root domain is -1 on either side, and the corners are inside.
+void outside_the_root_domain_is_minus_one() {
+    const Grid1D g = refined_grid();
+    const auto got = locate(g, {-1e-12, 2.0 + 1e-12, 0.0, 2.0});
+    PANTR_CHECK(got[0] == -1);
+    PANTR_CHECK(got[1] == -1);
+    PANTR_CHECK_MSG(got[2] == 1, "the lower corner is in the first refined cell");
+    PANTR_CHECK_MSG(got[3] == 0, "the upper corner is in the coarse cell");
+}
+
+/// An interior breakpoint of the refined level takes the lower child.
+///
+/// The descent's truncation is a discrete verdict, so the tie gets its own case.
+void a_child_boundary_takes_the_lower_child() {
+    const Grid1D g = refined_grid();
+    const auto got = locate(g, {0.5});
+    PANTR_CHECK_MSG(got[0] == 2, "x = 0.5 is the lower corner of cell 2, so it takes cell 2");
+}
+
+}  // namespace
+
+int main() {
+    the_fixtures_are_what_they_claim();
+    collect_and_locate_agree(flat_grid(), "the flat grid");
+    collect_and_locate_agree(refined_grid(), "the refined grid");
+    the_cells_tile_the_domain(flat_grid(), "the flat grid");
+    the_cells_tile_the_domain(refined_grid(), "the refined grid");
+    decode_inverts_encode(flat_grid(), "the flat grid");
+    decode_inverts_encode(refined_grid(), "the refined grid");
+    an_inactive_position_is_minus_one();
+    outside_the_root_domain_is_minus_one();
+    a_child_boundary_takes_the_lower_child();
+    return pantr::test::summary("test_grid_hierarchical");
+}

--- a/cpp/tests/test_grid_locate.cpp
+++ b/cpp/tests/test_grid_locate.cpp
@@ -1,0 +1,171 @@
+/// \file
+/// Point location on a tensor-product grid, checked against properties the
+/// mathematics fixes rather than against the oracle.
+///
+/// Nothing here compares the two backends: that is what `tests/parity/` is for,
+/// and a transliteration faithful to a wrong algorithm passes a parity test
+/// perfectly. What this file checks is that the kernel says what the grid means.
+///
+/// The tie contract is the interesting part and it gets most of the cases. A point
+/// exactly on an interior breakpoint belongs to the LOWER cell sharing that face;
+/// a point on either outer boundary belongs to the adjacent boundary cell; a point
+/// outside maps to -1. Those are exact claims about integers, so they carry no
+/// tolerance -- and they are decided by comparisons on coordinates that were never
+/// arithmetic operands, which is why the port can claim them at all.
+
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/locate.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::grid::locate_points;
+
+/// Locate points on a 1-D grid with the given breakpoints.
+std::vector<std::int64_t> locate_1d(const std::vector<double>& knots,
+                                    const std::vector<double>& xs) {
+    const auto ncells = static_cast<std::int64_t>(knots.size()) - 1;
+    std::vector<std::int64_t> starts{0};
+    std::vector<std::int64_t> cells{ncells};
+    std::vector<std::int64_t> strides{1};
+    std::vector<std::int64_t> out(xs.size(), -99);
+
+    locate_points<double>(span2d<const double>(xs.data(), xs.size(), 1),
+                          std::span<const double>(knots), std::span<const std::int64_t>(starts),
+                          std::span<const std::int64_t>(cells),
+                          std::span<const std::int64_t>(strides), std::span<std::int64_t>(out));
+    return out;
+}
+
+/// A point strictly inside cell k lands in cell k.
+void interior_points_land_in_their_own_cell() {
+    const std::vector<double> knots{0.0, 1.0, 2.0, 3.0};
+    const auto got = locate_1d(knots, {0.5, 1.5, 2.5});
+    PANTR_CHECK(got[0] == 0);
+    PANTR_CHECK(got[1] == 1);
+    PANTR_CHECK(got[2] == 2);
+}
+
+/// An interior breakpoint belongs to the lower of the two cells sharing it.
+void interior_breakpoints_go_to_the_lower_cell() {
+    const std::vector<double> knots{0.0, 1.0, 2.0, 3.0};
+    const auto got = locate_1d(knots, {1.0, 2.0});
+    PANTR_CHECK_MSG(got[0] == 0, "x = 1.0 must take cell 0, not cell 1");
+    PANTR_CHECK_MSG(got[1] == 1, "x = 2.0 must take cell 1, not cell 2");
+}
+
+/// Either outer boundary belongs to the adjacent boundary cell, not to -1.
+void outer_boundaries_are_inside() {
+    const std::vector<double> knots{0.0, 1.0, 2.0, 3.0};
+    const auto got = locate_1d(knots, {0.0, 3.0});
+    PANTR_CHECK_MSG(got[0] == 0, "the lower boundary belongs to the first cell");
+    PANTR_CHECK_MSG(got[1] == 2, "the upper boundary belongs to the last cell");
+}
+
+/// Anything outside the closed domain is -1.
+void outside_maps_to_minus_one() {
+    const std::vector<double> knots{0.0, 1.0, 2.0, 3.0};
+    const auto got = locate_1d(knots, {-1e-300, 3.0 + 1e-15, -5.0, 100.0});
+    for (std::size_t i = 0; i < 4; ++i) {
+        PANTR_CHECK(got[i] == -1);
+    }
+}
+
+/// One ulp inside the boundary is inside; one ulp outside is not.
+///
+/// The frontier of the domain test, which is where an off-by-one in the
+/// comparison would hide. Uses nextafter rather than a comfortable epsilon so the
+/// case cannot pass by being far from the edge.
+void the_domain_frontier_is_exact() {
+    const std::vector<double> knots{0.0, 1.0};
+    const double below = std::nextafter(0.0, -1.0);
+    const double above = std::nextafter(1.0, 2.0);
+    const auto got = locate_1d(knots, {below, 0.0, 1.0, above});
+    PANTR_CHECK_MSG(got[0] == -1, "one ulp below the domain is outside");
+    PANTR_CHECK_MSG(got[1] == 0, "the lower corner is inside");
+    PANTR_CHECK_MSG(got[2] == 0, "the upper corner is inside, in the last cell");
+    PANTR_CHECK_MSG(got[3] == -1, "one ulp above the domain is outside");
+}
+
+/// A degenerate one-cell grid still resolves both corners and the interior.
+void a_single_cell_grid_works() {
+    const auto got = locate_1d({-1.3, 2.7}, {-1.3, 0.0, 2.7});
+    PANTR_CHECK(got[0] == 0);
+    PANTR_CHECK(got[1] == 0);
+    PANTR_CHECK(got[2] == 0);
+}
+
+/// Non-uniform breakpoints: the search must not assume a uniform spacing.
+void non_uniform_breakpoints_resolve() {
+    const std::vector<double> knots{0.0, 0.001, 0.002, 100.0};
+    const auto got = locate_1d(knots, {0.0005, 0.0015, 50.0, 0.001, 0.002});
+    PANTR_CHECK(got[0] == 0);
+    PANTR_CHECK(got[1] == 1);
+    PANTR_CHECK(got[2] == 2);
+    PANTR_CHECK_MSG(got[3] == 0, "a breakpoint of a tiny cell still takes the lower one");
+    PANTR_CHECK_MSG(got[4] == 1, "and so does the next");
+}
+
+/// The 2-D flat id is the row-major combination of the per-axis indices.
+///
+/// Checked against the definition rather than against a table, so the test says
+/// what C-order means instead of restating the kernel's own multiply.
+void two_dimensional_ids_are_row_major() {
+    // axis 0: [0,1,2,3] -> 3 cells;  axis 1: [0,1,2] -> 2 cells.  strides (2, 1).
+    const std::vector<double> knots{0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0};
+    const std::vector<std::int64_t> starts{0, 4};
+    const std::vector<std::int64_t> cells{3, 2};
+    const std::vector<std::int64_t> strides{2, 1};
+    const std::vector<double> pts{0.5, 0.5, 2.5, 1.5, 1.0, 1.0, 3.0, 2.0};
+    std::vector<std::int64_t> out(4, -99);
+
+    locate_points<double>(span2d<const double>(pts.data(), 4, 2), std::span<const double>(knots),
+                          std::span<const std::int64_t>(starts),
+                          std::span<const std::int64_t>(cells),
+                          std::span<const std::int64_t>(strides), std::span<std::int64_t>(out));
+
+    PANTR_CHECK(out[0] == 0 * 2 + 0);
+    PANTR_CHECK(out[1] == 2 * 2 + 1);
+    PANTR_CHECK_MSG(out[2] == 0 * 2 + 0, "a breakpoint on both axes takes the lower cell on both");
+    PANTR_CHECK_MSG(out[3] == 2 * 2 + 1, "the far corner is the last cell, not -1");
+}
+
+/// A point outside on ONE axis is outside, whatever the other axes say.
+void outside_on_any_axis_is_outside() {
+    const std::vector<double> knots{0.0, 1.0, 0.0, 1.0};
+    const std::vector<std::int64_t> starts{0, 2};
+    const std::vector<std::int64_t> cells{1, 1};
+    const std::vector<std::int64_t> strides{1, 1};
+    const std::vector<double> pts{0.5, 2.0, 2.0, 0.5, 0.5, 0.5};
+    std::vector<std::int64_t> out(3, -99);
+
+    locate_points<double>(span2d<const double>(pts.data(), 3, 2), std::span<const double>(knots),
+                          std::span<const std::int64_t>(starts),
+                          std::span<const std::int64_t>(cells),
+                          std::span<const std::int64_t>(strides), std::span<std::int64_t>(out));
+
+    PANTR_CHECK_MSG(out[0] == -1, "outside on axis 1 only");
+    PANTR_CHECK_MSG(out[1] == -1, "outside on axis 0 only");
+    PANTR_CHECK(out[2] == 0);
+}
+
+}  // namespace
+
+int main() {
+    interior_points_land_in_their_own_cell();
+    interior_breakpoints_go_to_the_lower_cell();
+    outer_boundaries_are_inside();
+    outside_maps_to_minus_one();
+    the_domain_frontier_is_exact();
+    a_single_cell_grid_works();
+    non_uniform_breakpoints_resolve();
+    two_dimensional_ids_are_row_major();
+    outside_on_any_axis_is_outside();
+    return pantr::test::summary("test_grid_locate");
+}

--- a/reviews/357-2026-08-25.md
+++ b/reviews/357-2026-08-25.md
@@ -1,0 +1,352 @@
+# Deep review — PR #357, the `pantr.grid` C++ port
+
+**Date:** 2026-08-25 · **Target:** `feat/grid-cpp-port`, commits `1b98a6d`, `1a3309a`, `110d6d1`
+**CI at review time:** green on both `proto/cpp` jobs. Local gate green: 7368 tests under each
+backend, ruff, ruff format, mypy over 276 files, `lint-imports`, docs under `-W`.
+
+## Verdict: DO NOT MERGE. The headline claim is refuted.
+
+The PR claims *"an EQUALITY for all nine kernels… the strongest one in the tree so far."*
+**Seven kernels hold. Two do not**, each for two independent reasons. Neither failure is a
+transliteration error — the port reproduces its oracle faithfully. Both are failures of the
+*claim*: it asserts a property of the algorithm that is in fact a property of the build, and it
+asserts a domain the two backends do not share.
+
+| kernel | verdict |
+|---|---|
+| `locate_points` | equality **proved**, one hypothesis unstated |
+| `bvh_build`, `bvh_query_count`, `bvh_query_emit` | **proved** on finite input, **refuted** on infinite corners |
+| `encode_midx`, `block_of_midx`, `decode_flat_id` | equality **proved** (integer only) |
+| `hier_locate_points` | **refuted** twice |
+| `hier_collect_cell_bounds` | **refuted** twice |
+
+## Lenses
+
+**Run (6):** claim verification (`verifier`), API and contracts (`api-auditor`), test coverage
+(`test-writer`), mathematical claims (`mathematician`, attack), numerical stress
+(`numerics-shakedown`), and two regional breadth reviewers (the three C++ headers; the catalogue
+and Layer 2 wiring).
+
+**Skipped, with reasons:** `tolerance-hunter` — the port introduces no tolerance, threshold or
+epsilon comparison, so there is nothing to attack. `optimizer` — nothing in this port or the four
+before it has been profiled, and the `prange`-to-serial change is declared rather than hidden;
+the suite's own runtime is ~2 min, unchanged. `architect` — the structure copies four merged
+precedents exactly; the `api-auditor` covers the surface and the `razor`'s territory is folded
+into the regional reviewers.
+
+**Two lenses converged independently on the central finding** (the `mathematician` by derivation
+and counterexample, the `numerics-shakedown` by 180 000 adversarial emulations). That agreement is
+why it is stated as refuted rather than suspected.
+
+---
+
+## Critical
+
+### C1-1 — `dedup_roots` returns a plausible wrong answer on a transposed call. In MERGED code.
+
+`cpp/bindings/bezier_root_finding.cpp:156-172`, `:258-263`. `coeff` and `raw_roots` are adjacent,
+identically typed and **positional**. Transposed, the call type-checks, runs, and returns a
+different, plausible answer.
+
+```python
+coeff, raw = np.array([-1.0, 1.0]), np.array([0.5])   # linear Bézier, only root t = 0.5
+dedup_roots(coeff, raw, 1, param_tol=1e-9, geom_tol=1e-9, out=out)  # -> [0.5]   correct
+dedup_roots(raw, coeff, 1, param_tol=1e-9, geom_tol=1e-9, out=out)  # -> [-1.0]  wrong, silent
+```
+
+Reproduced twice independently. **That file's own comment names this exact risk and leaves it
+open** — and this PR cited that comment as the justification for its keyword-only policy. The
+lesson was written in the file that did not apply it. Pre-existing (PR #353); outside this diff.
+**Direction:** `file-bug`, then promote the two arguments to keyword-only. No correctly ordered
+caller breaks.
+
+### C1-2 — The BVH parity test cannot catch any of the three tie-breaks it claims to check.
+
+`tests/parity/test_grid.py:172-203` calls itself "the strongest check in this file" and claims
+bit-identical tie behaviour for the min/max incumbent, the first-maximum axis choice, and the
+stable-sort permutation. Its fixture `_random_boxes` (`:162-167`) draws continuous
+`rng.uniform` floats, so **no two cells ever share an extent, a corner or a centroid** and none
+of the three ties can occur. Across all 15 parametrizations: 0 centroid ties, 0 extent ties, 0
+exact zeros.
+
+Proved by fault injection, extension rebuilt each time, **all 25 parity tests green every time**:
+
+| mutation in `bvh.hpp` | result |
+|---|---|
+| `extent_k > best` → `>=` | 25/25 pass |
+| min/max incumbent `<`/`>` → `<=`/`>=` | 25/25 pass |
+| `std::stable_sort` → `std::sort` | 25/25 pass |
+
+The last is the sharpest: **the port's headline argument is that a stable sort's permutation is
+uniquely determined and therefore reproduces `np.argsort(kind="mergesort")` by proof.** The
+argument is sound — separately verified — and no test would catch its violation.
+
+Not inherent: four unit cells at a square's corners give an exact `3.0 == 3.0` extent tie whose
+two axes order the centroids differently, and there the mutation *does* change `node_cell`.
+**Direction:** add that case to the parity file, comparing all five node arrays.
+
+### C1-3 — The hierarchical fixture steps the descent exactly once.
+
+`_two_level_grid` (`tests/parity/test_grid.py:238-250`) tops out at two levels, and
+`hierarchical.hpp:211-238` only runs the `lo[k]`/`hi[k]` update when `level < n_levels - 1`. So it
+fires **once per query** and the loop exits before a second application. The guard
+`_assert_more_than_one_level` (`:253-259`) checks that two levels *exist*, not that the descent
+chains twice — this was added in response to an earlier vacuity finding and is insufficient in
+the same way.
+
+Proved with a realistic bug class (failing to refresh `hi[k]` before the next `size_k`, which
+only shows on the second chained step): 0 mismatches over 5507 points on the shipped fixture;
+**7% at depth 2 and 11% at depth 4** on a three-to-four level fixture with factor 3.
+
+So the header cites 300 000 descents of twelve levels while the suite that runs on every push
+re-verifies **one**. **Direction:** one more `refine_cells` call on a child cell, and a
+non-power-of-two factor.
+
+### C1-4 — `factor = 1`: the two backends disagree on the DOMAIN. No FMA involved, shipped build, public API.
+
+`src/pantr/grid/_hierarchical_grid.py:373-376` documents factor 1 as legal ("a factor of 1 on an
+axis prevents subdivision in that direction"), validates `f < 1` at `:395-398`, and
+`tests/test_grid_hierarchical.py:176` asserts it. The bindings reject `< 2` at
+`cpp/bindings/grid.cpp:369-374` and `:403-408`, with no comment justifying it.
+
+```
+python  locate_many -> [3 2 4]    collect_cell_bounds -> (5, 2)
+cpp     ValueError: factor[0] is 1; a subdivision factor below two never refines
+```
+
+The Numba answer is a correct grid that tiles the domain exactly, so **the C++ refusal is the
+defect.** It breaks every anisotropic grid under `PANTR_BACKEND=cpp`, with no recovery path — the
+never-fall-back rule is deliberate. And `fk = 1` is the **one factor value at which the descent's
+contraction site provably cannot diverge**, since the clamp forces `j = 0`: the safest
+configuration in the space is the only one rejected.
+
+Why 7368 dual-backend tests missed it: the only two tests touching factor 1 stop short of a
+kernel. **Direction:** widen the binding to `factor < 1`, and give the existing test a
+`locate_many` and a `collect_cell_bounds` call.
+
+### C1-5 — The descent diverges under FMA, and the measurement offered as evidence had no discriminating power.
+
+Verified counterexample, root cell `[1.0, 2.0]`, factor 10, `x = 1.71`, a decimal literal:
+
+```
+level 0: j = 7,  size = 0.1
+         unfused  1.0 + fl(7*0.1) = 1.7000000000000002   (3ffb333333333334)
+         fused    fma(7, 0.1, 1.0) = 1.7                 (3ffb333333333333)   one ulp
+level 1: unfused (1.71-1.7000000000000002)/size2 = 0.9999999999999778 -> j = 0
+         fused   (1.71-1.7)              /size2 = 1.0    exactly    -> j = 1
+         midx 70 vs 71. Different cell.
+```
+
+Against the real kernels: baseline **70**, `-march=x86-64-v3` **71**, `-march=native` **71**,
+Numba **70**. The second kernel fails the same way straight into a `float64` output — `out_lo[7]`
+differs by one ulp — **at factor 2**, the common AMR case, on a non-dyadic root cell.
+
+Note which side is right: the exact value of `1.0 + 7·fl(0.1)` is `1.7`, so the **fused** result
+is correctly rounded and the oracle is one ulp high. Demanding bit-equality forbids the more
+accurate answer. Defensible — the contract is parity, not correction — but it must be stated.
+
+**And the measurement behind the claim tested nothing.** `__fp_contract__` reports
+`unavailable-on-target-isa`; there are **zero** `vfmadd*` instructions in the shipped `.so`;
+`cmake/PantrCompileOptions.cmake:89` sets `-ffp-contract=on` and the same file ends "Deliberately
+absent: any -march or -mtune", and baseline x86-64 is SSE2 with no fused opcode. Numba does not
+contract either (`fastmath=False`). So the 300 000-descent sweep **compared two unfused
+implementations**: good evidence that the transliteration is faithful, no information about
+contraction. The conclusions drawn from it are **unsupported**, not merely unproven.
+
+The stated mechanism is refuted in all three parts. Comparable magnitude is neither necessary
+(witness at ratio 2⁻⁵⁴) nor sufficient (witness at ratio 0.674), and the decay claim is
+**inverted**: over 16 divergent traces at 6 levels, `|Δlo| / size_k` is exactly **1.0000 at every
+level**, because the truncation divides by `size_k`, which shrinks at the same geometric rate.
+The header measured `|Δlo| / |lo|` and drew a conclusion about the other ratio. Proved
+separately: once `j` differs, `midx` can never coincide again and the index difference **grows**
+geometrically (`|d'| ≥ fk·|d| - (fk-1)`).
+
+The `numerics-shakedown` reached the same conclusion independently and added where it bites
+hardest: **domains straddling zero**, where `lo + j*size` becomes a cancellation that drives
+`|lo|` toward zero — exactly the regime the argument says cannot arise. 19 724 of 180 000
+adversarial cases would change the descent under live fusion; 10.4% versus 4.6% at levels ≤ 5.
+
+**The project had already written the rule this violates.** `design/build_findings.md`, under
+*"Exactness is a property of the build, not of the kernel"*: "a claim of bit-exact parity is never
+a property of the algorithm… A claim hard-coded at design time would be false on the first
+machine that enables the ISA ladder." It names `grid` among the modules needing two-sided
+evidence. `design/simd.md:210-215` states the same hazard and its trigger.
+
+**Direction, and it is one line per site.** Split the expression:
+`const T prod = T(static_cast<double>(j)) * size_k; lo[k] = lo[k] + prod;` at
+`hierarchical.hpp:289` and `:370`. Verified to emit `vmulsd` + `vaddsd` at both
+`-march=x86-64-v3` and `native`, versus `vfmadd132sd` for the single-expression form. Zero cost,
+and `-ffp-contract=on` was chosen over `fast` precisely because it confines fusion to one
+expression. That converts the claim from exact-by-build to **exact-by-structure**, which is the
+only option that keeps an unconditional equality.
+
+### C1-6 — Infinite corners produce a NaN centroid, an invalid ordering, and undefined behaviour.
+
+`cpp/bindings/grid.cpp:209-217` guards `cell_hi >= cell_lo`, which rejects NaN (all NaN
+comparisons are false) but **admits infinities**, since `+inf >= -inf`. The centroid
+`0.5 * (lo + hi)` then yields `0.5 * (-inf + inf)` = **NaN** from two corners that passed.
+
+```
+BVH.from_cell_bounds   ValueError: must contain only finite values
+_pantr_cpp.bvh_build   accepted.   node_cell = [-1 -1 -1 0 1 2 3]
+_bvh_build_core        completed.  node_cell = [-1 -1 -1 0 2 3 1]
+```
+
+**Different trees**, and `design/bvh.md:18-24` establishes the five node arrays as public API a
+downstream consumer traverses itself. On the C++ side this is not merely divergence: with
+`vals = [0.5, NaN, 2.5, 3.5]`, `equiv(0,1) ∧ equiv(1,2)` but `¬equiv(0,2)`, violating
+`[alg.sorting]/4`. It did not crash; that is luck. numpy is well defined on the same input.
+
+The header claims "it cannot arrive: `_bvh.py:322` rejects any non-finite corner" — but that guard
+is not the one on the reachable binding path, and **no `hi >= lo` check can supply what the sort
+needs, which is a guard on the centroid.** Reachable only through private modules, which
+moderates severity; `CLAUDE.md` records that a downstream consumer imports private symbols.
+**Direction:** a finiteness check on both corners in `bind_bvh_build`, and correct
+`bvh.hpp:51-55`.
+
+---
+
+## Important
+
+**I1-1 — Heap-buffer-overflow in `hierarchical.hpp` where the oracle degrades safely.**
+`decode_flat_id` (`:169`) and `block_of_midx` (`:106`) cast to `std::size_t` values that began as
+possibly-negative `std::int64_t` and index without a clamp. Confirmed under AddressSanitizer:
+`heap-buffer-overflow … READ of size 8 … 8 bytes before 8-byte region` at `:182`. The asymmetry is
+the finding: **Numba arrays support negative indexing**, so the oracle degrades to a
+wrong-but-memory-safe answer. The bindings guard the shipped Python surface; the headers are
+public symbols and a downstream consumer imports private ones.
+
+**I1-2 — The one line where the port deliberately differs from the oracle has no test.**
+`bvh_query_emit` counts unconditionally and writes only within capacity. `test_grid_bvh.cpp:156`
+always sizes `got` to exactly `count`; the parity suite never passes an undersized buffer; there
+is no `test_grid_binding_contract.py` analogous to `test_bezier_binding_contract.py`.
+
+**I1-3 — A measured number in a comment with no reproducible script.** The 300 000-descent
+figures appear at `hierarchical.hpp:32`, `tests/parity/test_grid.py:25` and `:79`, and nowhere in
+`design/` or `scripts/`. Three independent confirmations. Every sibling measured claim ships a
+script (`measure_bezier_fma_bound.py`, …). Per `CLAUDE.md` a measured number with no reproducible
+command is **deleted, not corrected**.
+
+**I1-4 — A test claims to catch a drift it cannot see.**
+`test_grid_reexports.py::test_the_stack_depth_constant_still_has_its_value` says it pins
+`_BVH_STACK_DEPTH` "by path and by value" so two spellings cannot drift. It only reads the Python
+side; `kBvhStackDepth` is never exposed to Python. The docstring's claim is false as written.
+`pantr_cpp.cpp` already has precedent for exposing provenance as a module attribute.
+
+**I1-5 — Composition never runs under the C++ backend.** `cell_quadrature`, `partition_grid` and
+`overlay` are exercised by no committed test under `Backend.CPP`. Verified working by hand; a
+regression reachable only through those call shapes would ship silently.
+
+**I1-6 — The docstring's stated reason for the wrapping asymmetry is false.**
+`_grid_backend.py:45-50` says inputs are wrapped "where a copy is harmless" and outputs are left
+for the binding to reject. Measured: a non-contiguous **input** raises the identical `TypeError`.
+`.noconvert()` is on all 57 array arguments (the two without it are integers), so the binding
+draws no such distinction. The real invariant is that Layer 2 always constructs these fresh and
+contiguous. Conclusion right, reasoning wrong.
+
+**I1-7 — And that decision, presented as the module's central design point, has no test** — unlike
+all four sibling ports, e.g. `test_basis_cardinal_bspline.py::test_the_binding_refuses_a_non_contiguous_out`.
+
+**I1-8 — `test_grid.py` does not gate on the build.** Four sibling parity modules call
+`contraction_may_fuse()` and use the `_EXACT_BY_STRUCTURE` / `_EXACT_BY_BUILD` / `_BOUNDED_BY_FMA`
+vocabulary. The module covering the port's **only two contraction sites** does not. The grid claim
+is an `_EXACT_BY_BUILD` filed as `_EXACT_BY_STRUCTURE`.
+
+**I1-9 — A second int64 overflow site, previously unflagged.** `block_of_midx`'s offset
+accumulation, shared by `hier_locate_points` and `encode_midx` — the same class as the `m_pow`
+overflow the header already names. Both backends produce identical wrapped garbage, which is
+*guaranteed* for Numba and merely *this compiler's behaviour* for C++.
+
+**I1-10 — The private query-kernel boundary.** A deep-chain tree segfaults the C++ at depth 140+,
+heap-corrupts the oracle at 150+, and **corrupts silently at 128-132**. `BVH.__init__` guards
+both correctly and the binding's decision not to re-walk per query is documented and reasoned —
+but the private symbols are what a downstream consumer imports, and `design/bvh.md` says it walks
+the tree itself.
+
+---
+
+## Recommended / Suggested
+
+- **R1-1** — `_backend.py:90` says the Scope list "was wrong for two releases". Nothing shipped in
+  a tagged release; it was two **PRs**. This project uses "release" precisely elsewhere.
+- **R1-2** — The `cell_i > ncells - 1` upper clamp in both locate kernels is **provably dead** for
+  any input, NaN included. The `cell_i < 0` clamp is load-bearing and additionally absorbs NaN.
+  The `j < 0` clamp never fired in 800 real and 200 000 theoretical trials, refuting the
+  hypothesis that it masks overshoot: both languages truncate toward zero. `razor` territory.
+- **S1-1** — The `design/backend_parity.md` Rule 8 citation in `grid.cpp` and `_grid_backend.py`
+  borrows the rule's title for a different situation (Rule 8 is about a bound going vacuous under
+  ill-conditioning, not about there being no comparandum). **Two lenses converged on this
+  independently.** The conclusion stands on its own; the citation does not say what it is cited
+  as saying.
+- **S1-2** — `_EncodeFunc` and `_DecodeFunc` are structurally identical `Callable` aliases with
+  different meanings; mypy cannot catch a swap.
+- **S1-3** — `.gitignore` covers `build/` but not `build-ext/`, which the documented build command
+  uses. This is why `ruff check .` scans vendored dependencies.
+- **S1-4** — `NUMBA_NUM_THREADS=N conda run …` is **clobbered** by the env's `activate.d`; the
+  process sees 20. Any thread-count measurement taken that way measures nothing.
+- **N1-1** — The warmup barrier sits after validation here and before it in
+  `basis/_basis_1D.py` and `bezier/_find_roots.py`. Arguably better; undocumented divergence.
+- **N1-2** — "Ties in increasing index order" in `bvh.hpp` means position in the current `perm`
+  sub-range, not cell id. 5 of 11 node sorts run on a slice not in ascending id order. Both
+  backends agree today; a cleanup that broke ties by cell id would satisfy the wording and change
+  the tree.
+
+## Unconfirmed — worth a look
+
+- **U1-1** — Whether the four adjacent-cell pairs whose reported bounds overlap by one ulp (a
+  consequence of independently rounded corners, present in **both** backends, not a parity defect)
+  matter to any consumer. Settles with a decision, not a measurement.
+- **U1-2** — Whether `hier_locate_points`'s `j == fk` case is reachable in the wild with a
+  non-power-of-two factor. Not fuzzed; the reproducer script below would settle it.
+
+## The safe set, and why every test is inside it
+
+The two contraction sites are exact — hence fused and unfused agree on any ISA — only for:
+
+- **the descent site**, bounded by the factor because the clamp confines `j` to `[0, fk-1]`:
+  `fk = 1` vacuously (`j = 0`), `fk ∈ {2,3}` at every level on every ISA (multiplying by 0, 1 or
+  2 is exact), and **exposed from `fk ≥ 4`** where `j = 3` needs two extra significand bits;
+- **the collect site**, *not* bounded by the factor, since `sub_ik` reaches 3 at level 2 even at
+  factor 2. Safe for dyadic root geometry with small bit counts, or unconditionally when
+  `root_lo == 0.0`. Divergence verified at **factor 2** on `[1.0, 1.1]` from level 6.
+
+An AST census of every `HierarchicalGrid` construction in `tests/` yields factors `{0,1,2,3}`
+only. **Factor ≤ 3 is exactly the verified safe set.** The parity fixture evaluates 522 products
+at the descent site with **0 inexact**. So everything the tests exercise is inside the safe set,
+and everything a user is likely to build — a decimal domain, factor 4 or 10, more than one level —
+is outside it.
+
+## Regression tests already written
+
+The shakedown committed three, `b497723`, +146 lines, in its own worktree at
+`.claude/worktrees/agent-abe2e7de2ec817aba`, each fault-injection verified to be the only failure
+of 28 with its fault planted: the BVH longest-axis tie, a non-dyadic straddling-zero descent, and
+its coordinate companion. Non-vacuity checked: 5370 points, all 137 cells hit, both levels
+reached, 734 coordinates exactly on a cell corner. **They are not on this branch.**
+
+## What holds up, stated so it is not re-checked
+
+The transliteration itself is faithful branch-for-branch: tie direction in min/max, the strict `>`
+in axis selection, the opposite build/query push order, the odometer direction, and the per-site
+floor-versus-truncate arguments all reproduce the oracle exactly, each independently verified.
+Tier B discipline is respected without exception — no raw comparison on `T` anywhere. The eight
+Layer 2 call sites pass arguments in the right order and count against both the Numba signatures
+and the compiled stub, with no transposition. The three `wait_for_jit_warmup()` insertions are
+exactly the three call sites that reach a `parallel=True` kernel. `_select()` is a verbatim copy
+of its four predecessors with the never-fall-back rule verified live. The `.pyi` stub matches all
+eight compiled signatures exactly. `locate_points` is proved equal over 2440 constructed boundary
+cases. The BVH's stable-sort uniqueness argument is **valid**, and covers a branch that would
+otherwise hide — libstdc++ compiles both `__merge_sort_with_buffer` and `__inplace_stable_sort`
+into the shipped `.so`, and arguing from stability rather than from "both are mergesort" is what
+makes the timsort question moot. numpy 2.4.6's `mergesort` is empirically stable for float64 over
+97 640 exhaustive cases.
+
+## One hypothesis the port does not state
+
+`locate.hpp`'s "no floating-point arithmetic" is **not sufficient** for the equality. It also
+needs both backends to receive bit-identical inputs. That holds — `_tensor_product_grid.py:299-311`
+builds the descriptor arrays once, above the dispatch — but not for the reason given. There *is*
+real floating-point arithmetic in Layer 2: `uniform_grid` builds breakpoints with `np.linspace`
+(`:467`), and that file's own comment at `:53` refers to "round-off from the linspace that
+generated it". An AST walk of the kernel is structurally incapable of seeing it. The hypothesis
+to state is **"the coordinate arrays are computed once and shared"**.

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -67,9 +67,9 @@ shape rather than a capability.
 Scope
 -----
 
-Three modules are ported so far, and **selecting the C++ backend changes only
-what they cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is
-a run in which those kernels are C++ and everything else is unchanged.
+Five modules are ported so far, and **selecting the C++ backend changes only what
+they cover**. A suite run under ``PANTR_BACKEND=cpp`` is not a C++ run; it is a run
+in which those kernels are C++ and everything else is unchanged.
 
 * :mod:`pantr.basis` -- three of the 1D tabulations: cardinal B-spline, Bernstein
   and Legendre. The Lagrange tabulation and everything multidimensional stay on
@@ -78,6 +78,19 @@ a run in which those kernels are C++ and everything else is unchanged.
   trapezoidal rule, the modified Chebyshev nodes and tanh-sinh, together with the
   Lambert W solve the last of those needs.
 * :mod:`pantr.change_basis` -- all eight builders.
+* :mod:`pantr.bezier` -- the arithmetic and the root finding, through two
+  catalogues rather than one because they are two ports with two parity claims.
+  **Interpolation is deliberately not ported**, and
+  ``design/bezier_interpolation_port.md`` is where that ruling and its measurements
+  live; it is worth reading before proposing any further port, because it is the
+  template for declining one.
+* :mod:`pantr.grid` -- all nine kernels: tensor-product point location, the BVH's
+  build and its two query passes, and the five hierarchical addressing kernels.
+
+**This list was wrong for two releases and that is worth a sentence.** It said three
+modules and named neither half of ``bezier`` while both were merged and dispatching.
+Nothing checks a prose list, so it drifts silently; if you port a module, the change
+is not finished until this paragraph names it.
 
 **Reading a change_basis result needs one more fact than the others.** Its
 builders take their nodes from :mod:`pantr.quad`, so a call under

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -1316,7 +1316,9 @@ def hier_locate_points(
             Keyword-only.
         root_cells_per_axis (npt.NDArray[np.int64]): Per-axis root cell counts.
             Keyword-only.
-        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least two.
+        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least one.
+            A factor of one prevents subdivision on that axis, which is what an
+            anisotropic grid needs; the oracle documents and tests it.
             Keyword-only.
         block_lo (npt.NDArray[np.int64]): Packed block lower bounds. Keyword-only.
         block_hi (npt.NDArray[np.int64]): Packed block upper bounds. Keyword-only.
@@ -1331,7 +1333,7 @@ def hier_locate_points(
         TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
         ValueError: If the descriptor arrays disagree on ``ndim``, if the block
             descriptor is inconsistent, if an axis spans past the end of
-            ``knots_flat``, if a subdivision factor is below two, or if ``out`` is
+            ``knots_flat``, if a subdivision factor is below one, or if ``out`` is
             shorter than ``npts``.
     """
 
@@ -1354,7 +1356,9 @@ def hier_collect_cell_bounds(
             end to end. Keyword-only.
         knot_starts (npt.NDArray[np.int64]): Per-axis offset into ``knots_flat``.
             Keyword-only.
-        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least two.
+        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least one.
+            A factor of one prevents subdivision on that axis, which is what an
+            anisotropic grid needs; the oracle documents and tests it.
             Keyword-only.
         block_lo (npt.NDArray[np.int64]): Packed block lower bounds. Keyword-only.
         block_hi (npt.NDArray[np.int64]): Packed block upper bounds. Keyword-only.
@@ -1369,7 +1373,7 @@ def hier_collect_cell_bounds(
     Raises:
         TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
         ValueError: If the block descriptor is inconsistent, if the descriptor
-            arrays disagree on ``ndim``, if a subdivision factor is below two, if a
+            arrays disagree on ``ndim``, if a subdivision factor is below one, if a
             block reaches a root cell past the end of ``knots_flat``, or if the
             outputs cannot hold every block's flat-id range.
     """

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -1064,3 +1064,312 @@ def solve_monotone_root_batch(
         ValueError: If ``coeffs`` has no columns, if ``param_tol`` is not finite and
             positive, or if ``out_roots`` does not have ``n_polys`` entries.
     """
+
+def locate_points(
+    points: npt.NDArray[np.float64],
+    *,
+    knots_flat: npt.NDArray[np.float64],
+    knot_starts: npt.NDArray[np.int64],
+    cells_per_axis: npt.NDArray[np.int64],
+    strides: npt.NDArray[np.int64],
+    out: npt.NDArray[np.int64],
+) -> None:
+    """Locate a batch of points on an axis-aligned tensor-product grid.
+
+    Args:
+        points (npt.NDArray[np.float64]): Query points of shape ``(npts, ndim)``,
+            C-contiguous.
+        knots_flat (npt.NDArray[np.float64]): All per-axis knot vectors concatenated
+            end to end, strictly increasing within each axis. Keyword-only.
+        knot_starts (npt.NDArray[np.int64]): Per-axis offset into ``knots_flat``,
+            shape ``(ndim,)``. Keyword-only.
+        cells_per_axis (npt.NDArray[np.int64]): Per-axis cell counts, shape
+            ``(ndim,)``, each at least one. Keyword-only.
+        strides (npt.NDArray[np.int64]): Per-axis C-order flat strides, shape
+            ``(ndim,)``. Keyword-only.
+        out (npt.NDArray[np.int64]): Shape ``(npts,)``, C-contiguous and writable.
+            Receives the flat cell id, or ``-1`` outside the domain. Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
+            or if a keyword-only argument is passed positionally.
+        ValueError: If the descriptor arrays disagree on ``ndim``, if an axis
+            declares fewer than one cell or spans past the end of ``knots_flat``,
+            or if ``out`` is shorter than ``npts``.
+    """
+
+def bvh_build(
+    *,
+    cell_lo: npt.NDArray[np.float64],
+    cell_hi: npt.NDArray[np.float64],
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+) -> None:
+    """Build a BVH over per-cell AABBs by median-of-longest-axis splits.
+
+    Every argument is keyword-only: ``cell_lo``/``cell_hi`` and
+    ``node_left``/``node_right`` are same-typed neighbours that would type-check
+    and run if transposed.
+
+    Args:
+        cell_lo (npt.NDArray[np.float64]): Per-cell lo corners, shape
+            ``(n_cells, ndim)`` with ``n_cells >= 1``. Keyword-only.
+        cell_hi (npt.NDArray[np.float64]): Per-cell hi corners, same shape, with
+            ``hi >= lo`` everywhere. Keyword-only.
+        node_lo (npt.NDArray[np.float64]): Output per-node lo corners, at least
+            ``2 * n_cells - 1`` rows of ``ndim`` columns. Keyword-only.
+        node_hi (npt.NDArray[np.float64]): Output per-node hi corners, same shape.
+            Keyword-only.
+        node_left (npt.NDArray[np.int64]): Output left-child indices, at least
+            ``2 * n_cells - 1`` entries, pre-filled with ``-1``. Keyword-only.
+        node_right (npt.NDArray[np.int64]): Output right-child indices, likewise.
+            Keyword-only.
+        node_cell (npt.NDArray[np.int64]): Output per-leaf cell ids, likewise.
+            Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If ``cell_lo`` is empty, if the shapes disagree, if any cell has
+            ``hi < lo`` or a non-finite corner, if an output cannot hold
+            ``2 * n_cells - 1`` entries, or if the cell count would produce a tree
+            deeper than the traversal stack allows.
+    """
+
+def bvh_query_count(
+    *,
+    qlo: npt.NDArray[np.float64],
+    qhi: npt.NDArray[np.float64],
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+) -> int:
+    """Count the leaves whose AABB overlaps the query box, inclusive on every face.
+
+    Called before :func:`bvh_query_emit` so the caller can size its output exactly.
+
+    Args:
+        qlo (npt.NDArray[np.float64]): Query box lo corner, shape ``(ndim,)``.
+            Keyword-only.
+        qhi (npt.NDArray[np.float64]): Query box hi corner, same shape. Keyword-only.
+        node_lo (npt.NDArray[np.float64]): Per-node lo corners, shape
+            ``(n_nodes, ndim)``. Keyword-only.
+        node_hi (npt.NDArray[np.float64]): Per-node hi corners, same shape.
+            Keyword-only.
+        node_left (npt.NDArray[np.int64]): Left-child indices, ``-1`` at a leaf.
+            Keyword-only.
+        node_right (npt.NDArray[np.int64]): Right-child indices. Keyword-only.
+        node_cell (npt.NDArray[np.int64]): Per-leaf cell ids, ``-1`` at an internal
+            node. Keyword-only.
+
+    Returns:
+        int: The number of overlapping leaves.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the arrays disagree on ``ndim`` or on the node count, or if
+            the node arrays are empty.
+
+    Note:
+        The tree's depth is **not** validated here, matching
+        :class:`pantr.grid.BVH`, which establishes it once at construction rather
+        than on every query. A caller assembling node arrays by hand owns that
+        contract; an unbalanced tree overflows a fixed-size traversal stack.
+    """
+
+def bvh_query_emit(
+    *,
+    qlo: npt.NDArray[np.float64],
+    qhi: npt.NDArray[np.float64],
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+    out: npt.NDArray[np.int64],
+) -> int:
+    """Write the cell ids of the leaves whose AABB overlaps the query box.
+
+    Visits nodes in the same order as :func:`bvh_query_count`, so the two agree on
+    the size.
+
+    Args:
+        qlo (npt.NDArray[np.float64]): Query box lo corner, shape ``(ndim,)``.
+            Keyword-only.
+        qhi (npt.NDArray[np.float64]): Query box hi corner, same shape. Keyword-only.
+        node_lo (npt.NDArray[np.float64]): Per-node lo corners. Keyword-only.
+        node_hi (npt.NDArray[np.float64]): Per-node hi corners. Keyword-only.
+        node_left (npt.NDArray[np.int64]): Left-child indices. Keyword-only.
+        node_right (npt.NDArray[np.int64]): Right-child indices. Keyword-only.
+        node_cell (npt.NDArray[np.int64]): Per-leaf cell ids. Keyword-only.
+        out (npt.NDArray[np.int64]): C-contiguous and writable, sized from a prior
+            :func:`bvh_query_count`. Keyword-only.
+
+    Returns:
+        int: The number of overlapping leaves, which equals what
+            :func:`bvh_query_count` returns for the same arguments.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the arrays disagree on ``ndim`` or on the node count, or if
+            ``out`` is too small to hold the matches.
+
+    Note:
+        The kernel counts unconditionally and writes only within ``out``'s capacity,
+        so an undersized buffer raises rather than corrupting memory. The oracle
+        writes unconditionally; this is a deliberate difference, and the only input
+        on which the two disagree is one Layer 2 never produces.
+    """
+
+def encode_midx(
+    level: int,
+    *,
+    midx: npt.NDArray[np.int64],
+    block_lo: npt.NDArray[np.int64],
+    block_hi: npt.NDArray[np.int64],
+    block_base: npt.NDArray[np.int64],
+    level_block_start: npt.NDArray[np.int64],
+) -> int:
+    """Return the flat cell id of ``(level, midx)``, or ``-1`` when not active.
+
+    Args:
+        level (int): Hierarchy level of the queried position, in
+            ``[0, n_levels)``.
+        midx (npt.NDArray[np.int64]): Per-axis index in level coordinates, shape
+            ``(ndim,)``. Keyword-only.
+        block_lo (npt.NDArray[np.int64]): Packed block lower bounds, shape
+            ``(n_blocks, ndim)``. Keyword-only.
+        block_hi (npt.NDArray[np.int64]): Packed block upper bounds, same shape,
+            strictly greater than ``block_lo`` on every axis. Keyword-only.
+        block_base (npt.NDArray[np.int64]): Flat-id base per block, shape
+            ``(n_blocks,)``. Keyword-only.
+        level_block_start (npt.NDArray[np.int64]): Block index range per level,
+            shape ``(n_levels + 1,)``, non-decreasing, starting at 0 and ending at
+            ``n_blocks``. Keyword-only.
+
+    Returns:
+        int: The flat cell id, or ``-1`` when the position is not an active leaf.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the block descriptor is inconsistent, if ``midx`` disagrees
+            with ``block_lo`` on ``ndim``, or if ``level`` is out of range.
+    """
+
+def decode_flat_id(
+    cid: int,
+    *,
+    block_lo: npt.NDArray[np.int64],
+    block_hi: npt.NDArray[np.int64],
+    block_base: npt.NDArray[np.int64],
+    level_block_start: npt.NDArray[np.int64],
+    out_midx: npt.NDArray[np.int64],
+) -> int:
+    """Recover a cell's level and level-coordinate index from its flat id.
+
+    Args:
+        cid (int): Flat cell id, at least the first block's base.
+        block_lo (npt.NDArray[np.int64]): Packed block lower bounds, shape
+            ``(n_blocks, ndim)``. Keyword-only.
+        block_hi (npt.NDArray[np.int64]): Packed block upper bounds, same shape.
+            Keyword-only.
+        block_base (npt.NDArray[np.int64]): Flat-id base per block, ascending in
+            flat-id order. Keyword-only.
+        level_block_start (npt.NDArray[np.int64]): Block index range per level.
+            Keyword-only.
+        out_midx (npt.NDArray[np.int64]): Shape ``(ndim,)``, C-contiguous and
+            writable. Receives the per-axis index. Keyword-only.
+
+    Returns:
+        int: The cell's level.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the block descriptor is inconsistent, if ``out_midx`` is
+            shorter than ``ndim``, or if ``cid`` is below the first block's base.
+    """
+
+def hier_locate_points(
+    points: npt.NDArray[np.float64],
+    *,
+    knots_flat: npt.NDArray[np.float64],
+    knot_starts: npt.NDArray[np.int64],
+    root_cells_per_axis: npt.NDArray[np.int64],
+    factor: npt.NDArray[np.int64],
+    block_lo: npt.NDArray[np.int64],
+    block_hi: npt.NDArray[np.int64],
+    block_base: npt.NDArray[np.int64],
+    level_block_start: npt.NDArray[np.int64],
+    out: npt.NDArray[np.int64],
+) -> None:
+    """Locate a batch of points on a hierarchical grid.
+
+    Args:
+        points (npt.NDArray[np.float64]): Query points, shape ``(npts, ndim)``.
+        knots_flat (npt.NDArray[np.float64]): Root per-axis breakpoints concatenated
+            end to end. Keyword-only.
+        knot_starts (npt.NDArray[np.int64]): Per-axis offset into ``knots_flat``.
+            Keyword-only.
+        root_cells_per_axis (npt.NDArray[np.int64]): Per-axis root cell counts.
+            Keyword-only.
+        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least two.
+            Keyword-only.
+        block_lo (npt.NDArray[np.int64]): Packed block lower bounds. Keyword-only.
+        block_hi (npt.NDArray[np.int64]): Packed block upper bounds. Keyword-only.
+        block_base (npt.NDArray[np.int64]): Flat-id base per block. Keyword-only.
+        level_block_start (npt.NDArray[np.int64]): Block index range per level.
+            Keyword-only.
+        out (npt.NDArray[np.int64]): Shape ``(npts,)``, C-contiguous and writable.
+            Receives the flat cell id, or ``-1`` outside the root domain.
+            Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the descriptor arrays disagree on ``ndim``, if the block
+            descriptor is inconsistent, if an axis spans past the end of
+            ``knots_flat``, if a subdivision factor is below two, or if ``out`` is
+            shorter than ``npts``.
+    """
+
+def hier_collect_cell_bounds(
+    *,
+    knots_flat: npt.NDArray[np.float64],
+    knot_starts: npt.NDArray[np.int64],
+    factor: npt.NDArray[np.int64],
+    block_lo: npt.NDArray[np.int64],
+    block_hi: npt.NDArray[np.int64],
+    block_base: npt.NDArray[np.int64],
+    level_block_start: npt.NDArray[np.int64],
+    out_lo: npt.NDArray[np.float64],
+    out_hi: npt.NDArray[np.float64],
+) -> None:
+    """Materialize per-cell ``(lo, hi)`` bounds in flat-id order.
+
+    Args:
+        knots_flat (npt.NDArray[np.float64]): Root per-axis breakpoints concatenated
+            end to end. Keyword-only.
+        knot_starts (npt.NDArray[np.int64]): Per-axis offset into ``knots_flat``.
+            Keyword-only.
+        factor (npt.NDArray[np.int64]): Per-axis subdivision factor, at least two.
+            Keyword-only.
+        block_lo (npt.NDArray[np.int64]): Packed block lower bounds. Keyword-only.
+        block_hi (npt.NDArray[np.int64]): Packed block upper bounds. Keyword-only.
+        block_base (npt.NDArray[np.int64]): Flat-id base per block. Keyword-only.
+        level_block_start (npt.NDArray[np.int64]): Block index range per level.
+            Keyword-only.
+        out_lo (npt.NDArray[np.float64]): Output lower corners, shape
+            ``(num_cells, ndim)``, C-contiguous and writable. Keyword-only.
+        out_hi (npt.NDArray[np.float64]): Output upper corners, same shape.
+            Keyword-only.
+
+    Raises:
+        TypeError: If any array has the wrong dtype or rank or is not C-contiguous.
+        ValueError: If the block descriptor is inconsistent, if the descriptor
+            arrays disagree on ``ndim``, if a subdivision factor is below two, if a
+            block reaches a root cell past the end of ``knots_flat``, or if the
+            outputs cannot hold every block's flat-id range.
+    """

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -39,11 +39,11 @@ from typing import TYPE_CHECKING, Self
 
 import numpy as np
 
-from ._bvh_core import (
-    _BVH_STACK_DEPTH,
-    _bvh_build_core,
-    _bvh_query_count_core,
-    _bvh_query_emit_core,
+from ._bvh_core import _BVH_STACK_DEPTH
+from ._grid_backend import (
+    bvh_build_kernel,
+    bvh_query_count_kernel,
+    bvh_query_emit_kernel,
 )
 from ._grid_utils import _as_float64
 
@@ -350,7 +350,7 @@ class BVH:
         node_left = np.full(max_nodes, -1, dtype=np.int64)
         node_right = np.full(max_nodes, -1, dtype=np.int64)
         node_cell = np.full(max_nodes, -1, dtype=np.int64)
-        _bvh_build_core(lo, hi, node_lo, node_hi, node_left, node_right, node_cell)
+        bvh_build_kernel()(lo, hi, node_lo, node_hi, node_left, node_right, node_cell)
         return cls(node_lo, node_hi, node_left, node_right, node_cell, n_cells=n_cells)
 
     def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
@@ -374,7 +374,7 @@ class BVH:
         if self.n_cells == 0:
             return np.zeros(0, dtype=np.int64)
         count = int(
-            _bvh_query_count_core(
+            bvh_query_count_kernel()(
                 aabb.lo,
                 aabb.hi,
                 self._node_lo,
@@ -388,7 +388,7 @@ class BVH:
         if count == 0:
             return out
         written = int(
-            _bvh_query_emit_core(
+            bvh_query_emit_kernel()(
                 aabb.lo,
                 aabb.hi,
                 self._node_lo,

--- a/src/pantr/grid/_grid_backend.py
+++ b/src/pantr/grid/_grid_backend.py
@@ -1,0 +1,612 @@
+"""Which implementation of a grid kernel runs: the Numba one or C++.
+
+:mod:`pantr._backend` owns the **policy**. This module owns the **catalogue** for
+:mod:`pantr.grid`, and it lives here rather than beside the policy for the reason
+that module's own docstring gives: a catalogue imports the kernels it hands out, so
+keeping each one beside its own kernels is what stops the policy module from
+importing the library it has to stay independent of.
+
+Eight accessors over nine kernels
+---------------------------------
+
+The ninth is :func:`~pantr.grid._hier_core._block_of_midx`, and it is absent
+structurally rather than by oversight. On the Numba side it is called from inside
+:func:`~pantr.grid._hier_core._hier_locate_points_core` at a ``nopython`` call
+site, and no dispatch can be inserted between two Numba kernels, so the boundary is
+forced up to the eight places Layer 2 reaches for a kernel. Its C++ counterpart is
+reachable under another name: the oracle's :func:`_encode_midx_core` is a one-line
+call to it and *is* a Layer 2 seam, so the two are one function in C++ and the
+accessor carries the wrapper's name.
+
+Eight bare callables and no record, which is the rule
+``design/cross_backend_types.md`` states: a record when a consumer needs more than
+one kernel at once, a bare callable when it does not. The BVH looks like the
+exception and is not. :meth:`pantr.grid.BVH.query_aabb` uses count and then emit in
+one call, but it needs the count's *answer* to size the emit's output, so the two
+are sequential rather than simultaneous and nothing is served by handing them over
+together.
+
+Every accessor adapts, and that is the price of the keyword-only bindings
+-------------------------------------------------------------------------
+
+The C++ signatures are almost entirely keyword-only, deliberately: they are full of
+adjacent, same-typed, mutually unordered ``int64`` descriptor arrays --
+``block_lo``/``block_hi``, ``node_left``/``node_right``,
+``knot_starts``/``cells_per_axis``/``strides`` -- and every one of them type-checks,
+runs and returns a plausible wrong answer if transposed. ``cpp/bindings/grid.cpp``
+says why at length, and ``bezier_root_finding.cpp`` records two such traps found by
+an audit rather than by a test.
+
+The Numba kernels take those arrays positionally. So each accessor below wraps a
+thin positional-to-keyword adapter, which is what lets the Layer 2 call sites keep
+one call shape for both backends. Eight three-line adapters is the cost; a
+transposition that runs is what it buys.
+
+The adapters do **not** wrap output arrays in :func:`numpy.ascontiguousarray`, and
+that omission is the point. A non-contiguous ``out`` would be silently copied,
+written and discarded, which is exactly the failure ``.noconvert()`` exists to
+prevent on the C++ side. Leaving it unwrapped means the binding rejects it loudly
+instead. Input arrays are wrapped, where a copy is harmless and Layer 2 has usually
+made one unnecessary anyway.
+
+What crosses the boundary
+-------------------------
+
+Arrays and scalars only. Every coordinate array is ``float64`` and every descriptor
+and output array is ``int64``, in both backends: the oracle is ``float64``-only --
+none of the three kernel modules mentions ``float32`` -- so unlike
+:mod:`pantr.bezier` there is no dtype axis here and the C++ registers no ``float``
+overload. ``design/backend_parity.md`` Rule 8 is the reason it should not: a parity
+claim is only defined where the comparison can say something, and a ``float32``
+surface would have no oracle behind it.
+
+- :func:`locate_points_kernel`, :func:`bvh_build_kernel`,
+  :func:`bvh_query_count_kernel`, :func:`bvh_query_emit_kernel`,
+  :func:`encode_midx_kernel`, :func:`decode_flat_id_kernel`,
+  :func:`hier_locate_points_kernel`, :func:`hier_collect_cell_bounds_kernel`:
+  the accessors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+
+from .._backend import Backend, active_backend, available_backends
+from ._bvh_core import _bvh_build_core, _bvh_query_count_core, _bvh_query_emit_core
+from ._hier_core import (
+    _decode_flat_id_core,
+    _encode_midx_core,
+    _hier_collect_cell_bounds_core,
+    _hier_locate_points_core,
+)
+from ._locate_core import _locate_points_core
+
+_K = TypeVar("_K")
+"""One kernel's signature, so :func:`_select` returns the type it was given."""
+
+_Coords = npt.NDArray[np.float64]
+"""A coordinate array. Always float64: the grid kernels have no dtype axis."""
+
+_Index = npt.NDArray[np.int64]
+"""A descriptor or output array of cell indices."""
+
+_LocateFunc = Callable[[_Coords, _Coords, _Index, _Index, _Index, _Index], None]
+"""``(points, knots_flat, knot_starts, cells_per_axis, strides, out) -> None``."""
+
+_BvhBuildFunc = Callable[[_Coords, _Coords, _Coords, _Coords, _Index, _Index, _Index], None]
+"""``(cell_lo, cell_hi, node_lo, node_hi, node_left, node_right, node_cell) -> None``."""
+
+_BvhCountFunc = Callable[[_Coords, _Coords, _Coords, _Coords, _Index, _Index, _Index], int]
+"""``(qlo, qhi, node_lo, node_hi, node_left, node_right, node_cell) -> count``."""
+
+_BvhEmitFunc = Callable[[_Coords, _Coords, _Coords, _Coords, _Index, _Index, _Index, _Index], int]
+"""As :data:`_BvhCountFunc`, plus a trailing ``out`` array; returns the count."""
+
+_EncodeFunc = Callable[[int, _Index, _Index, _Index, _Index, _Index], int]
+"""``(level, midx, block_lo, block_hi, block_base, level_block_start) -> cid``."""
+
+_DecodeFunc = Callable[[int, _Index, _Index, _Index, _Index, _Index], int]
+"""``(cid, block_lo, block_hi, block_base, level_block_start, out_midx) -> level``."""
+
+_HierLocateFunc = Callable[
+    [_Coords, _Coords, _Index, _Index, _Index, _Index, _Index, _Index, _Index, _Index], None
+]
+"""The hierarchical locate: points, the root descriptor, the block descriptor, ``out``."""
+
+_HierBoundsFunc = Callable[
+    [_Coords, _Index, _Index, _Index, _Index, _Index, _Index, _Coords, _Coords], None
+]
+"""The bounds collector: the root and block descriptors, then ``out_lo`` and ``out_hi``."""
+
+
+def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
+    """Pick one kernel's implementation for the requested backend.
+
+    The one place the never-fall-back rule is applied for this package, so the
+    accessors below cannot drift from each other on it.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect, per :func:`pantr._backend.active_backend`.
+        python_kernel (_K): The Numba implementation, always available.
+        cpp_kernel (_K): The C++ implementation, available only when the extension
+            was built.
+
+    Returns:
+        _K: The kernel of the chosen backend.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    chosen = active_backend() if backend is None else backend
+
+    if chosen is Backend.PYTHON:
+        return python_kernel
+
+    if chosen not in available_backends():
+        raise RuntimeError(f"the {chosen.name} backend is not available in this installation")
+    return cpp_kernel
+
+
+def _cpp_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    points: _Coords,
+    knots_flat: _Coords,
+    knot_starts: _Index,
+    cells_per_axis: _Index,
+    strides: _Index,
+    out: _Index,
+) -> None:
+    """Locate a batch of points through the C++ binding.
+
+    Args:
+        points (_Coords): Query points, shape ``(npts, ndim)``.
+        knots_flat (_Coords): Concatenated per-axis knot vectors.
+        knot_starts (_Index): Per-axis offset into ``knots_flat``.
+        cells_per_axis (_Index): Per-axis cell counts.
+        strides (_Index): Per-axis C-order flat strides.
+        out (_Index): Output flat cell ids, shape ``(npts,)``.
+
+    Note:
+        No input validation is performed here. Shape and dtype were established by
+        Layer 2; the binding re-checks dtype, rank, contiguity and the descriptors'
+        mutual consistency.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    _pantr_cpp.locate_points(
+        np.ascontiguousarray(points),
+        knots_flat=np.ascontiguousarray(knots_flat),
+        knot_starts=knot_starts,
+        cells_per_axis=cells_per_axis,
+        strides=strides,
+        out=out,
+    )
+
+
+def _cpp_bvh_build(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    cell_lo: _Coords,
+    cell_hi: _Coords,
+    node_lo: _Coords,
+    node_hi: _Coords,
+    node_left: _Index,
+    node_right: _Index,
+    node_cell: _Index,
+) -> None:
+    """Build the BVH node arrays through the C++ binding.
+
+    Args:
+        cell_lo (_Coords): Per-cell lo corners, shape ``(n_cells, ndim)``.
+        cell_hi (_Coords): Per-cell hi corners, same shape.
+        node_lo (_Coords): Output per-node lo corners.
+        node_hi (_Coords): Output per-node hi corners.
+        node_left (_Index): Output left-child indices.
+        node_right (_Index): Output right-child indices.
+        node_cell (_Index): Output per-leaf cell ids.
+
+    Note:
+        No input validation is performed here. The binding checks the shapes, that
+        every cell has ``hi >= lo`` and finite corners, and that the cell count
+        cannot produce a tree deeper than the traversal stack allows.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    _pantr_cpp.bvh_build(
+        cell_lo=np.ascontiguousarray(cell_lo),
+        cell_hi=np.ascontiguousarray(cell_hi),
+        node_lo=node_lo,
+        node_hi=node_hi,
+        node_left=node_left,
+        node_right=node_right,
+        node_cell=node_cell,
+    )
+
+
+def _cpp_bvh_query_count(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    qlo: _Coords,
+    qhi: _Coords,
+    node_lo: _Coords,
+    node_hi: _Coords,
+    node_left: _Index,
+    node_right: _Index,
+    node_cell: _Index,
+) -> int:
+    """Count the overlapping leaves through the C++ binding.
+
+    Args:
+        qlo (_Coords): Query box lo corner, shape ``(ndim,)``.
+        qhi (_Coords): Query box hi corner, same shape.
+        node_lo (_Coords): Per-node lo corners.
+        node_hi (_Coords): Per-node hi corners.
+        node_left (_Index): Left-child indices.
+        node_right (_Index): Right-child indices.
+        node_cell (_Index): Per-leaf cell ids.
+
+    Returns:
+        int: The number of overlapping leaves.
+
+    Note:
+        No input validation is performed here, and in particular the tree's depth is
+        not revalidated: :class:`pantr.grid.BVH` establishes it once at
+        construction, which is also where the oracle establishes it.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.bvh_query_count(
+        qlo=np.ascontiguousarray(qlo),
+        qhi=np.ascontiguousarray(qhi),
+        node_lo=node_lo,
+        node_hi=node_hi,
+        node_left=node_left,
+        node_right=node_right,
+        node_cell=node_cell,
+    )
+
+
+def _cpp_bvh_query_emit(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    qlo: _Coords,
+    qhi: _Coords,
+    node_lo: _Coords,
+    node_hi: _Coords,
+    node_left: _Index,
+    node_right: _Index,
+    node_cell: _Index,
+    out: _Index,
+) -> int:
+    """Write the overlapping cell ids through the C++ binding.
+
+    Args:
+        qlo (_Coords): Query box lo corner, shape ``(ndim,)``.
+        qhi (_Coords): Query box hi corner, same shape.
+        node_lo (_Coords): Per-node lo corners.
+        node_hi (_Coords): Per-node hi corners.
+        node_left (_Index): Left-child indices.
+        node_right (_Index): Right-child indices.
+        node_cell (_Index): Per-leaf cell ids.
+        out (_Index): Output cell ids, sized from a prior count.
+
+    Returns:
+        int: The number of overlapping leaves.
+
+    Note:
+        No input validation is performed here. Unlike the oracle, the binding raises
+        rather than corrupting memory when ``out`` cannot hold the matches.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.bvh_query_emit(
+        qlo=np.ascontiguousarray(qlo),
+        qhi=np.ascontiguousarray(qhi),
+        node_lo=node_lo,
+        node_hi=node_hi,
+        node_left=node_left,
+        node_right=node_right,
+        node_cell=node_cell,
+        out=out,
+    )
+
+
+def _cpp_encode_midx(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    level: int,
+    midx: _Index,
+    block_lo: _Index,
+    block_hi: _Index,
+    block_base: _Index,
+    level_block_start: _Index,
+) -> int:
+    """Encode a ``(level, midx)`` position through the C++ binding.
+
+    Args:
+        level (int): Hierarchy level of the queried position.
+        midx (_Index): Per-axis index in level coordinates.
+        block_lo (_Index): Packed block lower bounds.
+        block_hi (_Index): Packed block upper bounds.
+        block_base (_Index): Flat-id base per block.
+        level_block_start (_Index): Block index range per level.
+
+    Returns:
+        int: The flat cell id, or ``-1`` when the position is not an active leaf.
+
+    Note:
+        No input validation is performed here. The binding checks the block
+        descriptor's self-consistency and that ``level`` is in range.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.encode_midx(
+        level,
+        midx=np.ascontiguousarray(midx),
+        block_lo=block_lo,
+        block_hi=block_hi,
+        block_base=block_base,
+        level_block_start=level_block_start,
+    )
+
+
+def _cpp_decode_flat_id(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    cid: int,
+    block_lo: _Index,
+    block_hi: _Index,
+    block_base: _Index,
+    level_block_start: _Index,
+    out_midx: _Index,
+) -> int:
+    """Decode a flat cell id through the C++ binding.
+
+    Args:
+        cid (int): Flat cell id.
+        block_lo (_Index): Packed block lower bounds.
+        block_hi (_Index): Packed block upper bounds.
+        block_base (_Index): Flat-id base per block.
+        level_block_start (_Index): Block index range per level.
+        out_midx (_Index): Output per-axis index, shape ``(ndim,)``.
+
+    Returns:
+        int: The cell's level.
+
+    Note:
+        No input validation is performed here. The binding checks the block
+        descriptor and refuses a ``cid`` below the first block's base, which the
+        oracle's upper-bound search would index as ``-1``.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.decode_flat_id(
+        cid,
+        block_lo=block_lo,
+        block_hi=block_hi,
+        block_base=block_base,
+        level_block_start=level_block_start,
+        out_midx=out_midx,
+    )
+
+
+def _cpp_hier_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    points: _Coords,
+    knots_flat: _Coords,
+    knot_starts: _Index,
+    root_cells_per_axis: _Index,
+    factor: _Index,
+    block_lo: _Index,
+    block_hi: _Index,
+    block_base: _Index,
+    level_block_start: _Index,
+    out: _Index,
+) -> None:
+    """Locate a batch of points on a hierarchical grid through the C++ binding.
+
+    Args:
+        points (_Coords): Query points, shape ``(npts, ndim)``.
+        knots_flat (_Coords): Root per-axis breakpoints, concatenated.
+        knot_starts (_Index): Per-axis offset into ``knots_flat``.
+        root_cells_per_axis (_Index): Per-axis root cell counts.
+        factor (_Index): Per-axis subdivision factor.
+        block_lo (_Index): Packed block lower bounds.
+        block_hi (_Index): Packed block upper bounds.
+        block_base (_Index): Flat-id base per block.
+        level_block_start (_Index): Block index range per level.
+        out (_Index): Output flat cell ids, shape ``(npts,)``.
+
+    Note:
+        No input validation is performed here. The binding checks the descriptors'
+        mutual consistency, the knot ranges and that every subdivision factor is at
+        least two.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    _pantr_cpp.hier_locate_points(
+        np.ascontiguousarray(points),
+        knots_flat=np.ascontiguousarray(knots_flat),
+        knot_starts=knot_starts,
+        root_cells_per_axis=root_cells_per_axis,
+        factor=factor,
+        block_lo=block_lo,
+        block_hi=block_hi,
+        block_base=block_base,
+        level_block_start=level_block_start,
+        out=out,
+    )
+
+
+def _cpp_hier_collect_cell_bounds(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+    knots_flat: _Coords,
+    knot_starts: _Index,
+    factor: _Index,
+    block_lo: _Index,
+    block_hi: _Index,
+    block_base: _Index,
+    level_block_start: _Index,
+    out_lo: _Coords,
+    out_hi: _Coords,
+) -> None:
+    """Materialize per-cell bounds through the C++ binding.
+
+    Args:
+        knots_flat (_Coords): Root per-axis breakpoints, concatenated.
+        knot_starts (_Index): Per-axis offset into ``knots_flat``.
+        factor (_Index): Per-axis subdivision factor.
+        block_lo (_Index): Packed block lower bounds.
+        block_hi (_Index): Packed block upper bounds.
+        block_base (_Index): Flat-id base per block.
+        level_block_start (_Index): Block index range per level.
+        out_lo (_Coords): Output lower corners, shape ``(num_cells, ndim)``.
+        out_hi (_Coords): Output upper corners, same shape.
+
+    Note:
+        No input validation is performed here. The binding computes, per block, both
+        the output rows and the largest root cell the block reaches, since either
+        one being short is an out-of-bounds access rather than a wrong answer.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    _pantr_cpp.hier_collect_cell_bounds(
+        knots_flat=np.ascontiguousarray(knots_flat),
+        knot_starts=knot_starts,
+        factor=factor,
+        block_lo=block_lo,
+        block_hi=block_hi,
+        block_base=block_base,
+        level_block_start=level_block_start,
+        out_lo=out_lo,
+        out_hi=out_hi,
+    )
+
+
+def locate_points_kernel(backend: Backend | None = None) -> _LocateFunc:
+    """Get the batch point-location kernel for a tensor-product grid.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _LocateFunc: ``(points, knots_flat, knot_starts, cells_per_axis, strides,
+            out) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _locate_points_core, _cpp_locate_points)
+
+
+def bvh_build_kernel(backend: Backend | None = None) -> _BvhBuildFunc:
+    """Get the BVH construction kernel.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _BvhBuildFunc: ``(cell_lo, cell_hi, node_lo, node_hi, node_left,
+            node_right, node_cell) -> None``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _bvh_build_core, _cpp_bvh_build)
+
+
+def bvh_query_count_kernel(backend: Backend | None = None) -> _BvhCountFunc:
+    """Get the BVH overlap-counting kernel.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _BvhCountFunc: ``(qlo, qhi, node_lo, node_hi, node_left, node_right,
+            node_cell) -> count``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _bvh_query_count_core, _cpp_bvh_query_count)
+
+
+def bvh_query_emit_kernel(backend: Backend | None = None) -> _BvhEmitFunc:
+    """Get the BVH overlap-emitting kernel.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _BvhEmitFunc: as :func:`bvh_query_count_kernel`'s, plus a trailing ``out``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _bvh_query_emit_core, _cpp_bvh_query_emit)
+
+
+def encode_midx_kernel(backend: Backend | None = None) -> _EncodeFunc:
+    """Get the hierarchical position-to-flat-id kernel.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _EncodeFunc: ``(level, midx, block_lo, block_hi, block_base,
+            level_block_start) -> cid``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _encode_midx_core, _cpp_encode_midx)
+
+
+def decode_flat_id_kernel(backend: Backend | None = None) -> _DecodeFunc:
+    """Get the hierarchical flat-id-to-position kernel.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _DecodeFunc: ``(cid, block_lo, block_hi, block_base, level_block_start,
+            out_midx) -> level``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _decode_flat_id_core, _cpp_decode_flat_id)
+
+
+def hier_locate_points_kernel(backend: Backend | None = None) -> _HierLocateFunc:
+    """Get the batch point-location kernel for a hierarchical grid.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _HierLocateFunc: the hierarchical locate kernel.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _hier_locate_points_core, _cpp_hier_locate_points)
+
+
+def hier_collect_cell_bounds_kernel(backend: Backend | None = None) -> _HierBoundsFunc:
+    """Get the hierarchical per-cell bounds collector.
+
+    Args:
+        backend (Backend | None): Backend to use, or ``None`` for the active one.
+
+    Returns:
+        _HierBoundsFunc: the bounds-collecting kernel.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    return _select(backend, _hier_collect_cell_bounds_core, _cpp_hier_collect_cell_bounds)
+
+
+__all__ = [
+    "bvh_build_kernel",
+    "bvh_query_count_kernel",
+    "bvh_query_emit_kernel",
+    "decode_flat_id_kernel",
+    "encode_midx_kernel",
+    "hier_collect_cell_bounds_kernel",
+    "hier_locate_points_kernel",
+    "locate_points_kernel",
+]

--- a/src/pantr/grid/_grid_backend.py
+++ b/src/pantr/grid/_grid_backend.py
@@ -152,7 +152,7 @@ def _select(backend: Backend | None, python_kernel: _K, cpp_kernel: _K) -> _K:
     return cpp_kernel
 
 
-def _cpp_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_locate_points(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     points: _Coords,
     knots_flat: _Coords,
     knot_starts: _Index,
@@ -187,7 +187,7 @@ def _cpp_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat a
     )
 
 
-def _cpp_bvh_build(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_bvh_build(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     cell_lo: _Coords,
     cell_hi: _Coords,
     node_lo: _Coords,
@@ -225,7 +225,7 @@ def _cpp_bvh_build(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argum
     )
 
 
-def _cpp_bvh_query_count(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_bvh_query_count(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     qlo: _Coords,
     qhi: _Coords,
     node_lo: _Coords,
@@ -266,7 +266,7 @@ def _cpp_bvh_query_count(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat
     )
 
 
-def _cpp_bvh_query_emit(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_bvh_query_emit(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     qlo: _Coords,
     qhi: _Coords,
     node_lo: _Coords,
@@ -309,7 +309,7 @@ def _cpp_bvh_query_emit(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat 
     )
 
 
-def _cpp_encode_midx(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_encode_midx(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     level: int,
     midx: _Index,
     block_lo: _Index,
@@ -346,7 +346,7 @@ def _cpp_encode_midx(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat arg
     )
 
 
-def _cpp_decode_flat_id(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_decode_flat_id(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     cid: int,
     block_lo: _Index,
     block_hi: _Index,
@@ -384,7 +384,7 @@ def _cpp_decode_flat_id(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat 
     )
 
 
-def _cpp_hier_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_hier_locate_points(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     points: _Coords,
     knots_flat: _Coords,
     knot_starts: _Index,
@@ -431,7 +431,7 @@ def _cpp_hier_locate_points(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's f
     )
 
 
-def _cpp_hier_collect_cell_bounds(  # noqa: PLR0913, PLR0917 -- mirrors the kernel's flat argument list
+def _cpp_hier_collect_cell_bounds(  # noqa: PLR0913 -- mirrors the kernel's flat argument list
     knots_flat: _Coords,
     knot_starts: _Index,
     factor: _Index,

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -39,14 +39,15 @@ from typing import TYPE_CHECKING, Self
 
 import numpy as np
 
+from .._numba_compat import wait_for_jit_warmup
 from ._grid import Grid, GridRestriction
-from ._grid_utils import _as_float64, _mask_nonfinite_locate
-from ._hier_core import (
-    _decode_flat_id_core,
-    _encode_midx_core,
-    _hier_collect_cell_bounds_core,
-    _hier_locate_points_core,
+from ._grid_backend import (
+    decode_flat_id_kernel,
+    encode_midx_kernel,
+    hier_collect_cell_bounds_kernel,
+    hier_locate_points_kernel,
 )
+from ._grid_utils import _as_float64, _mask_nonfinite_locate
 from ._tensor_product_grid import TensorProductGrid
 
 if TYPE_CHECKING:
@@ -595,7 +596,7 @@ class HierarchicalGrid(Grid):
         if not 0 <= cid < self._num_cells:
             raise IndexError(f"cell id {cid!r} is out of range [0, {self._num_cells}).")
         midx = np.empty(self._root.ndim, dtype=np.int64)
-        level = _decode_flat_id_core(
+        level = decode_flat_id_kernel()(
             int(cid),
             self._packed_block_lo,
             self._packed_block_hi,
@@ -627,7 +628,7 @@ class HierarchicalGrid(Grid):
         """
         if level >= len(self._blocks):
             return None
-        cid = _encode_midx_core(
+        cid = encode_midx_kernel()(
             int(level),
             np.asarray(midx, dtype=np.int64),
             self._packed_block_lo,
@@ -787,7 +788,9 @@ class HierarchicalGrid(Grid):
         """
         pts = self._normalize_points(points)
         out = np.empty(pts.shape[0], dtype=np.int64)
-        _hier_locate_points_core(
+        # ``parallel=True``; see the note in TensorProductGrid.locate_many.
+        wait_for_jit_warmup()
+        hier_locate_points_kernel()(
             pts,
             self._root_knots_flat,
             self._root_knot_starts,
@@ -1700,7 +1703,9 @@ class HierarchicalGrid(Grid):
         nd = self.ndim
         cell_lo = np.empty((n, nd), dtype=np.float64)
         cell_hi = np.empty((n, nd), dtype=np.float64)
-        _hier_collect_cell_bounds_core(
+        # ``parallel=True``; see the note in TensorProductGrid.locate_many.
+        wait_for_jit_warmup()
+        hier_collect_cell_bounds_kernel()(
             self._root_knots_flat,
             self._root_knot_starts,
             np.asarray(self._factor, dtype=np.int64),

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -35,10 +35,11 @@ from typing import TYPE_CHECKING, Final
 
 import numpy as np
 
+from .._numba_compat import wait_for_jit_warmup
 from ._cell_index import c_order_strides, flat_to_multi, multi_to_flat
 from ._grid import Grid, GridRestriction
+from ._grid_backend import locate_points_kernel
 from ._grid_utils import _as_float64, _mask_nonfinite_locate
-from ._locate_core import _locate_points_core
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -302,7 +303,11 @@ class TensorProductGrid(Grid):
         knots_flat = np.concatenate(self._breakpoints).astype(np.float64, copy=False)
         cells_per_axis = np.array(self._cells_per_axis, dtype=np.int64)
         out = np.empty(pts.shape[0], dtype=np.int64)
-        _locate_points_core(pts, knots_flat, knot_starts, cells_per_axis, self._strides, out)
+        # The Numba kernel behind this is ``parallel=True`` and the import-time
+        # warmup compiles on a background thread; Numba's workqueue layer aborts
+        # the process rather than raising if a parallel call races it.
+        wait_for_jit_warmup()
+        locate_points_kernel()(pts, knots_flat, knot_starts, cells_per_axis, self._strides, out)
         _mask_nonfinite_locate(pts, out)
         return out
 

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -61,7 +61,13 @@ import pytest
 
 from pantr._backend import Backend, use_backend
 from pantr.geometry import AABB
-from pantr.grid import BVH, HierarchicalGrid, hierarchical_grid, uniform_grid
+from pantr.grid import (
+    BVH,
+    HierarchicalGrid,
+    TensorProductGrid,
+    hierarchical_grid,
+    uniform_grid,
+)
 from tests._parity_harness import assert_parity, bitwise_parity
 
 _LOCATE_WHY = (
@@ -500,6 +506,49 @@ def test_hierarchical_cell_bounds_are_bitwise_on_a_non_dyadic_grid(cpp_backend: 
     )
 
 
+def test_the_descent_counterexample_runs_through_the_real_kernels(cpp_backend: None) -> None:
+    """Both backends agree on the input that separates a fused descent from an unfused one.
+
+    The companion to :func:`test_the_descent_counterexample_is_a_genuine_discriminator`,
+    and the half that exercises the compiled code. That one asserts the input is still
+    a discriminator in exact arithmetic; this one asserts the two shipped kernels
+    resolve it the same way.
+
+    On a build with no ``-march`` this passes whether or not the port keeps its two
+    statements separate, because the baseline ISA has no fused multiply-add to
+    contract into -- so on its own it proves nothing here. Its value is that it
+    **fails** the moment ``design/simd.md``'s ISA ladder lands and the product is
+    inlined again: measured, an inlined build at ``-march=native`` returns cell 71
+    where the oracle returns 70.
+
+    The grid is the counterexample's own geometry: root cell ``[1.0, 2.0]``,
+    subdivision factor 10, refined twice so the descent chains, and the query point
+    ``x = 1.71``.
+    """
+    del cpp_backend
+    root = TensorProductGrid([np.array([1.0, 2.0])])
+    grid = hierarchical_grid(root, 10)
+    grid.refine_cells([0])
+    point = np.array([[1.71]])
+    first = grid.locate_many(point)
+    grid.refine_cells([int(first[0])])
+
+    reference, actual = _both(lambda: grid.locate_many(point))
+
+    np.testing.assert_array_equal(
+        actual,
+        reference,
+        err_msg="the two backends resolved the descent counterexample to different "
+        "cells. If this build has a fused multiply-add, the product at "
+        "hierarchical.hpp's descent site has been inlined again; see that file.",
+    )
+    level, _ = grid._decode_flat_id(int(reference[0]))
+    assert level == 2, (
+        f"the point landed at level {level}, so the descent did not chain twice and "
+        "this case no longer reaches the contraction site it exists to guard"
+    )
+
+
 def test_the_descent_counterexample_is_a_genuine_discriminator() -> None:
     """The input that separates a fused descent from an unfused one still separates them.
 
@@ -564,4 +613,88 @@ def test_the_descent_counterexample_is_a_genuine_discriminator() -> None:
     assert child_unfused != child_fused, (
         f"level 1 now agrees ({child_unfused}), so the one-ulp difference no longer "
         "reaches the truncation and this case pins nothing about the descent"
+    )
+
+
+def test_bvh_node_boxes_agree_bit_for_bit_on_a_signed_zero_tie(cpp_backend: None) -> None:
+    """Both backends keep the same zero when a node box's min or max ties.
+
+    The node box is a running min/max over corners, and on a tie both sides keep the
+    **incumbent** -- Python's two-argument ``min`` returns its first argument, and
+    the C++ only assigns on a strict ``<``. That agreement is one of the three
+    tie-breaks ``bvh.hpp`` argues its equality from, and until this test nothing
+    exercised it: mutating those comparisons to ``<=``/``>=`` left the whole parity
+    suite green, because a fixture of continuous random floats never produces a tie
+    at all, and a tie between two *identical* values is unobservable.
+
+    ``-0.0`` and ``+0.0`` are what make it observable: equal in value, different in
+    bits, so which one survives is visible.
+
+    **This test asserts that the two backends agree, and deliberately not which zero
+    they keep.** ``CLAUDE.md`` records that ``np.minimum(-0.0, 0.0)`` returns
+    different signs on different NumPy versions in the CI matrix, so pinning the sign
+    would pin something no platform promises. The oracle does not use that ufunc --
+    it uses the builtin ``min`` inside a kernel -- but the agreement is the property
+    the port needs either way, and it is the one that survives a NumPy upgrade.
+
+    It compares bit patterns directly rather than through
+    :func:`~tests._parity_harness.assert_parity`, and that is required rather than a
+    preference: the harness's comparison exempts signed-zero disagreements on
+    purpose, so the one hazard this test exists for is the one it cannot see.
+    """
+    del cpp_backend
+    # Two cells sharing a corner at zero, written with opposite signs. Whichever the
+    # min keeps, both backends must keep the same one.
+    lo = np.array([[-0.0, 1.0], [0.0, -1.0]])
+    hi = np.array([[2.0, 3.0], [1.0, -0.0]])
+
+    reference, actual = _both(lambda: BVH.from_cell_bounds(lo, hi))
+
+    for name in ("node_lo", "node_hi"):
+        ref_bits = np.asarray(getattr(reference, name), dtype=np.float64).view(np.uint64)
+        act_bits = np.asarray(getattr(actual, name), dtype=np.float64).view(np.uint64)
+        np.testing.assert_array_equal(
+            act_bits,
+            ref_bits,
+            err_msg=f"the two backends kept different zeros in {name}. One of them "
+            "stopped keeping the incumbent on a min/max tie, which is one of the "
+            "three tie-breaks bvh.hpp's equality argument rests on.",
+        )
+
+
+def test_bvh_split_permutation_agrees_on_a_large_tied_set(cpp_backend: None) -> None:
+    """Both backends split an all-tied centroid set the same way.
+
+    The median split sorts by centroid, and ``bvh.hpp`` argues the two backends agree
+    because a **stable** sort's output permutation is uniquely determined. That
+    argument is sound and, until this test, nothing checked it: replacing
+    ``std::stable_sort`` with ``std::sort`` left the whole parity suite green.
+
+    Two things have to be true for the substitution to be visible, and the existing
+    fixtures satisfy neither. The centroids must actually tie, which continuous
+    random floats never do. And there must be **enough** of them: libstdc++'s
+    introsort falls back to insertion sort below roughly sixteen elements, and
+    insertion sort happens to be stable, so a small tied set cannot tell the two
+    apart. Measured, ten tied pairs separate them and four cells do not.
+
+    Every cell here is centred on the origin, so every centroid is exactly ``0.0``
+    and the sort has nothing to order -- the resulting tree is decided entirely by
+    which permutation the sort leaves behind, and that shows up in ``node_cell``.
+    """
+    del cpp_backend
+    n_cells = 24
+    half = np.arange(1, n_cells + 1, dtype=np.float64).reshape(-1, 1)
+    lo, hi = -half, half
+
+    reference, actual = _both(lambda: BVH.from_cell_bounds(lo, hi))
+
+    np.testing.assert_array_equal(
+        actual.node_cell,
+        reference.node_cell,
+        err_msg="the two backends split an all-tied centroid set differently, so one "
+        "of them is not using a stable sort. bvh.hpp's equality argument is that a "
+        "stable sort's permutation is uniquely determined; this is what checks it.",
+    )
+    assert len(set(reference.node_cell.tolist())) > n_cells // 2, (
+        "the fixture stopped producing distinct leaves, so it no longer observes a permutation"
     )

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -22,9 +22,12 @@ The third path cannot, and the tests below say so where it applies. The
 hierarchical descent rewrites ``lo[k]`` each level from ``lo[k] + j * size_k``, a
 multiply feeding an add, and that value decides the next level's truncation -- a
 **discrete verdict**, which ``design/backend_parity.md`` Rule 11 is explicit that no
-tolerance bounds. Measured over 300000 descents it never diverges, and the reason is
-that the perturbation is never introduced rather than that it fails to grow, but
-that is evidence and not proof.
+tolerance bounds. So the port keeps the multiply and the add as separate statements,
+which is what makes the equality hold: `-ffp-contract=on` confines fusion to within
+a single expression, so a named product cannot be contracted on any target. An
+earlier version of this file argued instead from a sweep of 300000 descents, which
+was worthless -- it ran on a build with no `-march`, where the baseline ISA has no
+fused multiply-add at all, so it compared two unfused implementations.
 
 So the operational lesson of Rule 11 applies here in full: **every cell id is
 asserted on its own, before and separately from any comparison of coordinates.** A
@@ -47,6 +50,7 @@ something.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from functools import partial
 from typing import TypeVar
@@ -75,12 +79,14 @@ _BVH_WHY = (
 )
 
 _HIER_WHY = (
-    "the descent's `lo + j * size` is a contraction site and this equality is "
-    "MEASURED rather than derived: 300000 descents of twelve levels, 23.8% of the "
-    "child decisions at a non-power-of-two j, half the points one ulp off a child "
-    "boundary, and no divergence. Fusing moves a sum only when its two terms are "
-    "comparable in magnitude, and in a descent the second shrinks geometrically. "
-    "A build on a target that contracts differently would be the thing to re-measure"
+    "the descent multiplies then adds, and the two statements are kept SEPARATE so "
+    "that no target can contract them into a fused multiply-add: -ffp-contract=on "
+    "confines fusion to within one expression, and the oracle never fuses at all "
+    "(numba defaults to fastmath=False). That makes the equality a property of how "
+    "the statement is written rather than of the build. Inline the product again and "
+    "this fails at root cell [1.0, 2.0], factor 10, x = 1.71 -- but only on a build "
+    "that has a fused multiply-add, so the disassembly is the other half of the "
+    "evidence. See cpp/include/pantr/grid/hierarchical.hpp"
 )
 
 
@@ -491,4 +497,71 @@ def test_hierarchical_cell_bounds_are_bitwise_on_a_non_dyadic_grid(cpp_backend: 
         ref_hi,
         bitwise_parity(why=_HIER_WHY),
         context="collect_cell_bounds upper corners on a non-dyadic grid",
+    )
+
+
+def test_the_descent_counterexample_is_a_genuine_discriminator() -> None:
+    """The input that separates a fused descent from an unfused one still separates them.
+
+    This is the case that refuted an earlier version of this file's equality claim:
+    root cell ``[1.0, 2.0]``, factor 10, ``x = 1.71``, a decimal literal rather than
+    a bit-twiddled value. At level 0 the unfused sum is ``1.7000000000000002`` and
+    the fused one is ``1.7``, one ulp apart; at level 1 the quotients are
+    ``0.9999999999999778`` and exactly ``1.0``, so the truncation gives child 0
+    against child 1 and the two arithmetics land in different cells.
+
+    **This test does not need the extension and does not compare backends**, and that
+    is deliberate. On a build with no ``-march`` there is no fused multiply-add
+    instruction at all, so a backend comparison here would pass whether or not the
+    port keeps its two statements separate -- it would be exactly the kind of
+    comfortable case that let the original claim stand. What this asserts instead is
+    that the input remains a **discriminator**: that a fused evaluation really does
+    diverge from an unfused one on it. If a future numpy, libm or Python changed
+    something that made this input benign, the guard in
+    ``cpp/include/pantr/grid/hierarchical.hpp`` would be resting on nothing and this
+    test says so before the parity suite silently stops testing anything.
+
+    The paired assertion -- that the *shipped* kernels agree -- is what
+    :func:`test_hierarchical_locate_ids_are_identical` and the non-dyadic descent
+    test do. Their value rises the moment ``design/simd.md``'s ISA ladder lands.
+    """
+    lo0, hi0, x, factor = 1.0, 2.0, 1.71, 10
+
+    size = (hi0 - lo0) / factor
+    j = int((x - lo0) / size)
+    assert j == 7, f"the fixture drifted: expected child 7, got {j}"
+
+    # The unfused half needs no `math.fma`, so it is pinned on every supported
+    # Python. These are the exact bits the shipped kernels and the oracle produce.
+    unfused = lo0 + j * size
+    assert unfused.hex() == "0x1.b333333333334p+0", (
+        f"the unfused level-0 sum drifted to {unfused.hex()}; this case is built on its exact value"
+    )
+    child_unfused = int((x - unfused) / ((unfused + size - unfused) / factor))
+    assert child_unfused == 0, f"the unfused descent no longer takes child 0, got {child_unfused}"
+
+    # The fused half needs a correctly rounded fused multiply-add. `math.fma` is
+    # Python 3.13+, and this project supports 3.11, so it is gated rather than
+    # assumed -- the alternative would be an AttributeError on two of the four
+    # supported versions.
+    if not hasattr(math, "fma"):  # pragma: no cover - version-dependent
+        pytest.skip("math.fma is Python 3.13+; the unfused half above still ran")
+
+    fused = math.fma(float(j), size, lo0)
+    assert fused.hex() == "0x1.b333333333333p+0", f"the fused level-0 sum drifted to {fused.hex()}"
+    assert unfused != fused, (
+        "level 0 no longer distinguishes a fused sum from an unfused one, so this "
+        "input has stopped being a counterexample and the guard in the header rests "
+        "on nothing"
+    )
+    assert abs(unfused - fused) == abs(np.nextafter(fused, math.inf) - fused), (
+        "the two sums are no longer exactly one ulp apart"
+    )
+
+    # The divergence has to survive into the next level's truncation to change a
+    # cell id; one ulp in a coordinate is not by itself a changed verdict.
+    child_fused = int((x - fused) / ((fused + size - fused) / factor))
+    assert child_unfused != child_fused, (
+        f"level 1 now agrees ({child_unfused}), so the one-ulp difference no longer "
+        "reaches the truncation and this case pins nothing about the descent"
     )

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -235,6 +235,55 @@ def test_bvh_query_returns_the_same_cells(cpp_backend: None, n_cells: int) -> No
     assert matched > 0, "no box matched anything, so this test asserted nothing"
 
 
+def test_bvh_longest_axis_tie_keeps_the_lower_axis(cpp_backend: None) -> None:
+    """Pin the split-axis tie-break, which no other test in the repo can see.
+
+    ``_random_boxes`` draws continuous random floats, so two axis extents are never
+    exactly equal and the tie-break is never reached. Confirmed by fault injection:
+    replacing the longest-axis comparison in ``bvh.hpp`` with ``>=`` -- which flips the
+    tie from the lower axis to the higher -- leaves every other test in this file and
+    all three C++ suites passing, so the direction is otherwise unpinned in both
+    backends at once.
+
+    Four unit cells at the corners of a square give the root an exact ``3.0 == 3.0``
+    extent tie, and the two candidate axes order the centroids differently, so the
+    choice is observable in ``node_cell``: axis 0 yields the leaf order ``[0, 2, 1,
+    3]`` and axis 1 would yield ``[0, 1, 2, 3]``. Asserted as a direction and not only
+    as agreement, because two backends that both flipped would still agree.
+    """
+    del cpp_backend
+    cell_lo = np.array([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0], [2.0, 2.0]])
+    cell_hi = cell_lo + 1.0
+
+    reference, actual = _both(lambda: BVH.from_cell_bounds(cell_lo, cell_hi))
+
+    extent = reference.node_hi[0] - reference.node_lo[0]
+    assert extent[0] == extent[1], (
+        f"the fixture stopped being a tie: root extents are {extent.tolist()}, so this "
+        "test no longer reaches the tie-break it exists to pin"
+    )
+    assert [int(c) for c in reference.node_cell if c >= 0] == [0, 2, 1, 3], (
+        "the longest-axis tie no longer keeps the LOWER axis; splitting on axis 1 "
+        "instead of axis 0 gives the leaf order [0, 1, 2, 3]"
+    )
+    np.testing.assert_array_equal(
+        actual.node_cell,
+        reference.node_cell,
+        err_msg=f"the backends split the tied axis differently. {_BVH_WHY}",
+    )
+    for name in ("node_left", "node_right"):
+        np.testing.assert_array_equal(
+            getattr(actual, name), getattr(reference, name), err_msg=f"{name} on a tied axis"
+        )
+    for name in ("node_lo", "node_hi"):
+        assert_parity(
+            getattr(actual, name),
+            getattr(reference, name),
+            bitwise_parity(why=_BVH_WHY),
+            context=f"BVH.{name} on a tied split axis",
+        )
+
+
 def _two_level_grid() -> HierarchicalGrid:
     """A hierarchical grid with a genuinely refined region.
 
@@ -346,3 +395,100 @@ def test_hierarchical_encode_and_decode_agree(cpp_backend: None) -> None:
     assert actual == reference, "a decode/encode round trip differed between backends"
     for cid, (_, _, back) in enumerate(reference):
         assert back == cid, f"the round trip of id {cid} returned {back}"
+
+
+def _non_dyadic_grid() -> HierarchicalGrid:
+    """A hierarchy whose descent arithmetic is inexact, unlike ``_two_level_grid``.
+
+    ``_two_level_grid`` subdivides by 2 over ``[0, 4]``, so the per-axis child index
+    ``j`` is 0 or 1 and ``j * size_k`` is *exact* -- there is no rounding in that
+    product for a fused multiply-add to remove. That fixture therefore cannot
+    exercise the one contraction site ``hierarchical.hpp`` names as this kernel's
+    parity risk, which is the site both hierarchical parity claims rest on.
+
+    This one subdivides by 3 over non-dyadic spans that straddle zero, so ``size_k``
+    is inexact, ``j`` reaches 2, and ``lo[k] + j * size_k`` is a **cancellation** --
+    the regime where a fused and an unfused sum differ by the most. The straddle is
+    deliberate: ``hierarchical.hpp`` argues that fusing cannot bite because ``|lo|``
+    does not shrink while ``|j * size|`` shrinks geometrically, and that argument does
+    not hold once the two terms have opposite signs.
+    """
+    root = uniform_grid(np.array([[-1.0, 2.0 / 3.0], [-0.1, 0.3]]), 3)
+    grid = hierarchical_grid(root, 3)
+    grid.refine_cells([0, 4, 8])
+    grid.refine_cells([9, 15])
+    return grid
+
+
+def _non_dyadic_points(grid: HierarchicalGrid) -> npt.NDArray[np.float64]:
+    """Interior points plus the cell corners and their ulp neighbours.
+
+    The frontier half is the point of it. A truncation `int((x - lo) / size_k)` only
+    changes when a one-ulp move in `lo` carries `(x - lo) / size_k` across an integer,
+    so a sweep of random interior points is the one thing that cannot detect the
+    contraction hazard this fixture exists for -- the same reason
+    `_adversarial_points_1d` exists for the tensor-product tie contract.
+    """
+    lo, hi = grid.collect_cell_bounds()
+    corners = np.vstack([lo, hi])
+    nudged = [corners]
+    for direction in (-np.inf, np.inf):
+        nudged.append(np.nextafter(corners, direction))
+        nudged.append(np.nextafter(np.nextafter(corners, direction), direction))
+    rng = np.random.default_rng(20260825)
+    interior = np.column_stack(
+        [rng.uniform(-1.0, 2.0 / 3.0, size=4000), rng.uniform(-0.1, 0.3, size=4000)]
+    )
+    return np.vstack([*nudged, interior])
+
+
+def test_hierarchical_locate_ids_survive_a_non_dyadic_descent(cpp_backend: None) -> None:
+    """Both backends return the same ids where the descent's product is inexact.
+
+    The same verdict assertion as the two-level test, in the regime that test cannot
+    reach. A changed id here is a changed verdict, not a displaced value.
+    """
+    del cpp_backend
+    grid = _non_dyadic_grid()
+    _assert_more_than_one_level(grid)
+    points = _non_dyadic_points(grid)
+
+    reference, actual = _both(lambda: grid.locate_many(points))
+
+    located = int((reference >= 0).sum())
+    assert located > len(points) // 2, (
+        f"only {located} of {len(points)} points landed in a cell; the fixture has "
+        "drifted off its own domain and is no longer exercising the descent"
+    )
+    np.testing.assert_array_equal(
+        actual, reference, err_msg=f"a hierarchical cell id changed. {_HIER_WHY}"
+    )
+
+
+def test_hierarchical_cell_bounds_are_bitwise_on_a_non_dyadic_grid(cpp_backend: None) -> None:
+    """Both backends materialize identical bounds where ``sub_ik * size_k`` is inexact.
+
+    The companion to the ids above, on the coordinates rather than the verdict. With
+    subdivision factor 3 the offset ``sub_ik`` reaches 2 and the product genuinely
+    rounds, which is what the shipped factor-2 fixture cannot produce.
+    """
+    del cpp_backend
+    grid = _non_dyadic_grid()
+    _assert_more_than_one_level(grid)
+
+    reference, actual = _both(lambda: grid.collect_cell_bounds())
+
+    ref_lo, ref_hi = reference
+    act_lo, act_hi = actual
+    assert_parity(
+        act_lo,
+        ref_lo,
+        bitwise_parity(why=_HIER_WHY),
+        context="collect_cell_bounds lower corners on a non-dyadic grid",
+    )
+    assert_parity(
+        act_hi,
+        ref_hi,
+        bitwise_parity(why=_HIER_WHY),
+        context="collect_cell_bounds upper corners on a non-dyadic grid",
+    )

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -1,0 +1,348 @@
+"""Parity between the Numba and C++ implementations of the `pantr.grid` kernels.
+
+The claim is an **equality**, for all nine kernels, and it is the strongest one in
+the tree so far. Two of the three paths can argue it structurally rather than
+measure it:
+
+- **Tensor-product point location performs no floating-point arithmetic at all.**
+  Every binary operation in `_locate_core.py` is on an integer index and every use
+  of a coordinate is a comparison, established by walking the oracle's syntax tree
+  rather than by reading it. There is no rounding to bound, no accumulation order
+  to preserve and no site a compiler could contract.
+- **The BVH's every discrete verdict rests on a bit-identical quantity.** The node
+  AABB is a running min/max over corners that are copied rather than computed; the
+  longest-axis tie compares one subtraction with a strict ``>``; and the centroid is
+  ``0.5 * (lo + hi)``, where the addition rounds once and the multiplication by
+  ``0.5`` is exact *and follows the addition*, so there is no product for a compiler
+  to fuse into it. The median split is a stable sort, and stability determines the
+  output permutation uniquely, so `std::stable_sort` reproduces
+  ``np.argsort(kind="mergesort")`` by argument rather than by coincidence.
+
+The third path cannot, and the tests below say so where it applies. The
+hierarchical descent rewrites ``lo[k]`` each level from ``lo[k] + j * size_k``, a
+multiply feeding an add, and that value decides the next level's truncation -- a
+**discrete verdict**, which ``design/backend_parity.md`` Rule 11 is explicit that no
+tolerance bounds. Measured over 300000 descents it never diverges, and the reason is
+that the perturbation is never introduced rather than that it fails to grow, but
+that is evidence and not proof.
+
+So the operational lesson of Rule 11 applies here in full: **every cell id is
+asserted on its own, before and separately from any comparison of coordinates.** A
+changed id is a changed verdict, not a displaced value, and a bounded comparison
+cannot see two answers of different length at all.
+
+The parity harness is used for the coordinate arrays and **not** for the cell ids,
+and the split is not arbitrary. ``tests/_parity_harness`` compares floats bit for bit
+through a bit view and has no integer path -- ``FloatArray`` is its whole domain --
+because until now no ported kernel returned a *verdict* as its primary output.
+:mod:`pantr.grid` is the first that does, so the ids are asserted with a plain array
+equality carrying the same reasoning in its message. For an integer, "bitwise" and
+"equal" are the same assertion and the machinery buys nothing.
+
+There is no dtype axis. The oracle is ``float64``-only -- none of the three kernel
+modules mentions ``float32`` -- so the C++ registers no ``float`` overload, which
+Rule 8 requires: a parity claim is only defined where the comparison can say
+something.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import partial
+from typing import TypeVar
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.geometry import AABB
+from pantr.grid import BVH, HierarchicalGrid, hierarchical_grid, uniform_grid
+from tests._parity_harness import assert_parity, bitwise_parity
+
+_LOCATE_WHY = (
+    "the kernel performs no floating-point arithmetic: every binary operation is on "
+    "an integer index and every use of a coordinate is a comparison, so there is "
+    "nothing for either backend to round differently"
+)
+
+_BVH_WHY = (
+    "every discrete verdict rests on a bit-identical quantity -- the node box is a "
+    "running min/max over copied corners, the longest-axis tie is one subtraction "
+    "compared with a strict >, and the centroid's multiply by 0.5 follows its add so "
+    "no contraction site exists -- and the median split's stable sort has a uniquely "
+    "determined output permutation"
+)
+
+_HIER_WHY = (
+    "the descent's `lo + j * size` is a contraction site and this equality is "
+    "MEASURED rather than derived: 300000 descents of twelve levels, 23.8% of the "
+    "child decisions at a non-power-of-two j, half the points one ulp off a child "
+    "boundary, and no divergence. Fusing moves a sum only when its two terms are "
+    "comparable in magnitude, and in a descent the second shrinks geometrically. "
+    "A build on a target that contracts differently would be the thing to re-measure"
+)
+
+
+_T = TypeVar("_T")
+
+
+def _both(call: Callable[[], _T]) -> tuple[_T, _T]:
+    """Run one callable under each backend and return ``(reference, actual)``."""
+    with use_backend(Backend.PYTHON):
+        reference = call()
+    with use_backend(Backend.CPP):
+        actual = call()
+    return reference, actual
+
+
+def _adversarial_points_1d() -> npt.NDArray[np.float64]:
+    """Points that attack the tie contract and the domain frontier, not the interior.
+
+    Every interior breakpoint, both outer corners, one ulp inside and outside each
+    corner, and a handful of ordinary interior points so the sweep is not all
+    frontier.
+    """
+    breaks = [0.0, 1.0, 2.0, 3.0]
+    pts = list(breaks)
+    pts += [np.nextafter(0.0, -1.0), np.nextafter(3.0, 4.0)]
+    pts += [np.nextafter(0.0, 1.0), np.nextafter(3.0, 2.0)]
+    pts += [np.nextafter(1.0, 0.0), np.nextafter(1.0, 2.0)]
+    pts += [0.5, 1.5, 2.5, -10.0, 10.0]
+    return np.asarray(pts, dtype=np.float64).reshape(-1, 1)
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_tensor_product_locate_is_bitwise(cpp_backend: None, ndim: int) -> None:
+    """Both backends assign every point to the same cell of a tensor-product grid.
+
+    The ids are integers, so "bitwise" and "equal" coincide and the assertion is
+    exact by nature rather than by tolerance.
+    """
+    del cpp_backend
+    grid = uniform_grid(np.tile([0.0, 3.0], (ndim, 1)), 3)
+    rng = np.random.default_rng(20260825)
+    interior = rng.uniform(-0.5, 3.5, size=(200, ndim))
+    corners = np.array(np.meshgrid(*([[0.0, 1.0, 2.0, 3.0]] * ndim))).reshape(ndim, -1).T
+    points = np.vstack([interior, corners])
+
+    reference, actual = _both(lambda: grid.locate_many(points))
+
+    np.testing.assert_array_equal(
+        actual,
+        reference,
+        err_msg=f"TensorProductGrid.locate_many disagreed at ndim {ndim}. {_LOCATE_WHY}",
+    )
+
+
+def test_tensor_product_locate_holds_at_the_tie_contract(cpp_backend: None) -> None:
+    """The tie contract survives the port, on the frontier rather than the interior.
+
+    Called out separately from the sweep above because the tie -- an interior
+    breakpoint belongs to the LOWER cell -- is a discrete verdict, and a sweep of
+    random interior points would never reach one.
+    """
+    del cpp_backend
+    grid = uniform_grid(np.tile([0.0, 3.0], (1, 1)), 3)
+    points = _adversarial_points_1d()
+
+    reference, actual = _both(lambda: grid.locate_many(points))
+
+    np.testing.assert_array_equal(
+        actual,
+        reference,
+        err_msg="a cell id changed on the tie contract, which is a changed verdict "
+        "and not a displaced value",
+    )
+    assert reference[0] == 0, "the lower corner belongs to the first cell"
+    assert reference[3] == 2, "the upper corner belongs to the last cell"
+    assert reference[1] == 0, "an interior breakpoint belongs to the lower cell"
+
+
+def _random_boxes(n: int, ndim: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """A deterministic spread of overlapping axis-aligned boxes."""
+    rng = np.random.default_rng(4242 + n + ndim)
+    lo = rng.uniform(-2.0, 2.0, size=(n, ndim))
+    hi = lo + rng.uniform(0.05, 0.9, size=(n, ndim))
+    return lo, hi
+
+
+@pytest.mark.parametrize("n_cells", [1, 2, 3, 9, 64])
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_bvh_node_arrays_are_bitwise(cpp_backend: None, n_cells: int, ndim: int) -> None:
+    """Both backends build the identical tree, node array by node array.
+
+    The strongest check in this file, and deliberately not a query comparison: it
+    compares the whole structure, so the stable sort's permutation and every
+    tie-break agree rather than merely producing the same answer to one question.
+
+    That matters beyond parity. ``design/bvh.md`` records that the five node arrays
+    are **public API** -- a downstream consumer walks the tree itself with its own
+    predicate -- so a port that got the layout subtly right for queries and wrong for
+    traversal would break that consumer without failing a query test.
+    """
+    del cpp_backend
+    lo, hi = _random_boxes(n_cells, ndim)
+
+    reference, actual = _both(lambda: BVH.from_cell_bounds(lo, hi))
+
+    for name in ("node_lo", "node_hi"):
+        assert_parity(
+            getattr(actual, name),
+            getattr(reference, name),
+            bitwise_parity(why=_BVH_WHY),
+            context=f"BVH.from_cell_bounds {name}, {n_cells} cells in {ndim}-D",
+        )
+    for name in ("node_left", "node_right", "node_cell"):
+        np.testing.assert_array_equal(
+            getattr(actual, name),
+            getattr(reference, name),
+            err_msg=f"BVH.from_cell_bounds {name} differs at {n_cells} cells in {ndim}-D. "
+            "The two backends built trees of different SHAPE, which no tolerance could "
+            f"bound. {_BVH_WHY}",
+        )
+
+
+@pytest.mark.parametrize("n_cells", [1, 5, 40])
+def test_bvh_query_returns_the_same_cells(cpp_backend: None, n_cells: int) -> None:
+    """Both backends return the same overlapping cells, count asserted first.
+
+    The count is asserted on its own before the ids, per Rule 11: two results of
+    different length are a changed verdict, and comparing them elementwise cannot
+    see the difference at all.
+    """
+    del cpp_backend
+    lo, hi = _random_boxes(n_cells, 2)
+    boxes = [
+        AABB(lo.min(axis=0) - 0.1, lo.min(axis=0) + 0.5 * (hi.max(axis=0) - lo.min(axis=0))),
+        AABB(lo.min(axis=0) - 5.0, hi.max(axis=0) + 5.0),  # everything
+        AABB(hi.max(axis=0) + 1.0, hi.max(axis=0) + 2.0),  # nothing
+        AABB(lo[0], lo[0]),  # a degenerate box on a corner
+    ]
+
+    def query(b: AABB) -> npt.NDArray[np.int64]:
+        return BVH.from_cell_bounds(lo, hi).query_aabb(b)
+
+    matched = 0
+    for i, box in enumerate(boxes):
+        reference, actual = _both(partial(query, box))
+        assert len(actual) == len(reference), (
+            f"box {i} matched {len(actual)} cells against the oracle's {len(reference)}; "
+            "a changed count is a changed verdict, not a displaced value"
+        )
+        np.testing.assert_array_equal(actual, reference, err_msg=f"box {i} cell ids")
+        matched += len(reference)
+    assert matched > 0, "no box matched anything, so this test asserted nothing"
+
+
+def _two_level_grid() -> HierarchicalGrid:
+    """A hierarchical grid with a genuinely refined region.
+
+    ``hierarchical_grid`` alone returns a **single-level** grid, and on one of those
+    the descent below never runs: the root lookup finds an active cell at level 0 and
+    returns, so the contraction site these tests exist to exercise is never reached.
+    So this refines a corner, and the callers assert that it worked rather than
+    trusting that it did.
+    """
+    root = uniform_grid(np.tile([0.0, 4.0], (2, 1)), 4)
+    grid = hierarchical_grid(root, 2)
+    grid.refine_cells([0, 1, 4])
+    return grid
+
+
+def _assert_more_than_one_level(grid: HierarchicalGrid) -> None:
+    """Fail if the fixture degenerated to a single level, which would test nothing."""
+    levels = {grid._decode_flat_id(cid)[0] for cid in range(grid.num_cells)}
+    assert len(levels) > 1, (
+        f"the fixture has only level(s) {sorted(levels)}; on a single-level grid the "
+        "descent never runs and these tests assert nothing about it"
+    )
+
+
+def test_hierarchical_locate_ids_are_identical(cpp_backend: None) -> None:
+    """Both backends assign every point to the same hierarchical cell.
+
+    This is the path whose equality is measured rather than derived, so the ids are
+    asserted as a verdict on their own -- there is no numeric comparison here at all
+    to fold them into.
+    """
+    del cpp_backend
+    grid = _two_level_grid()
+    _assert_more_than_one_level(grid)
+    rng = np.random.default_rng(99)
+    pts = np.vstack(
+        [
+            rng.uniform(-0.5, 4.5, size=(400, 2)),
+            np.array([[0.0, 0.0], [4.0, 4.0], [2.0, 2.0], [1.0, 3.0]]),  # corners and breakpoints
+        ]
+    )
+
+    reference, actual = _both(lambda: grid.locate_many(pts))
+
+    np.testing.assert_array_equal(
+        actual,
+        reference,
+        err_msg="a hierarchical cell id changed between backends. That is a changed "
+        "verdict, not a displaced value, and it is the outcome the descent's "
+        "contraction site was measured NOT to produce -- so re-measure rather "
+        "than loosen anything.",
+    )
+    assert (np.asarray(reference) >= 0).any(), "every point landed outside; nothing was asserted"
+
+
+def test_hierarchical_cell_bounds_are_bitwise(cpp_backend: None) -> None:
+    """Both backends materialize identical per-cell bounds.
+
+    Unlike the ids above these are coordinates, so this is where the descent's
+    ``root_lo + sub * size`` contraction site would show as a displacement if it
+    showed at all.
+    """
+    del cpp_backend
+    grid = _two_level_grid()
+    _assert_more_than_one_level(grid)
+
+    reference, actual = _both(lambda: grid.collect_cell_bounds())
+
+    ref_lo, ref_hi = reference
+    act_lo, act_hi = actual
+    assert_parity(
+        act_lo,
+        ref_lo,
+        bitwise_parity(why=_HIER_WHY),
+        context="HierarchicalGrid.collect_cell_bounds lower corners",
+    )
+    assert_parity(
+        act_hi,
+        ref_hi,
+        bitwise_parity(why=_HIER_WHY),
+        context="HierarchicalGrid.collect_cell_bounds upper corners",
+    )
+
+
+def test_hierarchical_encode_and_decode_agree(cpp_backend: None) -> None:
+    """Both backends round-trip every flat id through decode and back through encode.
+
+    Two of the eight dispatched kernels are reached only here, and both are pure
+    integer arithmetic, so the equality is structural and the round trip is the
+    property that makes the test non-vacuous: it checks the two kernels against each
+    other rather than each against a table.
+    """
+    del cpp_backend
+    grid = _two_level_grid()
+    _assert_more_than_one_level(grid)
+    n = grid.num_cells
+    assert n > 0
+
+    def round_trip() -> list[tuple[int, tuple[int, ...], int | None]]:
+        out: list[tuple[int, tuple[int, ...], int | None]] = []
+        for cid in range(n):
+            level, midx = grid._decode_flat_id(cid)
+            back = grid._encode_midx(level, midx)
+            out.append((level, tuple(midx), back))
+        return out
+
+    reference, actual = _both(round_trip)
+
+    assert actual == reference, "a decode/encode round trip differed between backends"
+    for cid, (_, _, back) in enumerate(reference):
+        assert back == cid, f"the round trip of id {cid} returned {back}"

--- a/tests/test_grid_reexports.py
+++ b/tests/test_grid_reexports.py
@@ -1,0 +1,155 @@
+"""The names `pantr.grid` must keep importable, and why a test holds them.
+
+``CLAUDE.md`` records that a separate, not-yet-public downstream consumer imports
+pantr's **private** symbols, and that pantr's own CI cannot see breakage there.
+``tests/test_bezier_reexports.py`` is that check for its module and this is the one
+for this one.
+
+**One name here is imported by that consumer**, measured over its checkout on
+2026-08-21: ``pantr.grid._bvh_core._BVH_STACK_DEPTH``. It is pinned by full path
+rather than by value, because the path is the fragile part: this port added a C++
+mirror of the constant in ``cpp/include/pantr/grid/bvh.hpp``, and the oracle's copy
+stays the source of truth precisely so that the consumer's import keeps resolving.
+
+**The BVH's five node arrays are the other consumer-visible surface, and they are
+public API rather than an implementation detail.** ``design/bvh.md`` records why: the
+consumer does not call :meth:`~pantr.grid.BVH.query_aabb` at all, it walks the tree
+itself, probing at each internal node with its own predicate. So the properties are
+pinned here too. A port that got the layout right for queries and wrong for
+traversal would break that consumer without failing a query test.
+
+The rest of the list is the surface this port moved. Routing Layer 2 through
+``pantr.grid._grid_backend`` removed the kernels from the namespaces of the three
+modules that used to import them directly, so anything reachable through one of
+those paths before is not reachable now. That is deliberate, and the names below are
+the ones that must survive it.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pantr.grid import BVH
+
+_PUBLIC = (
+    "BVH",
+    "CellTags",
+    "FacetTags",
+    "Grid",
+    "GridRestriction",
+    "HierarchicalGrid",
+    "Partition",
+    "TensorProductGrid",
+    "cell_quadrature",
+    "hierarchical_grid",
+    "overlay",
+    "partition_grid",
+    "tensor_product_grid",
+    "uniform_grid",
+)
+"""The package's ``__all__``, unchanged by the port."""
+
+_CONSUMER_PRIVATE = (("pantr.grid._bvh_core", "_BVH_STACK_DEPTH"),)
+"""Private paths the downstream consumer imports, measured 2026-08-21."""
+
+_NODE_ARRAYS = ("node_lo", "node_hi", "node_left", "node_right", "node_cell")
+"""The five node arrays a downstream consumer traverses itself. See `design/bvh.md`."""
+
+_KERNELS = (
+    ("pantr.grid._locate_core", "_locate_points_core"),
+    ("pantr.grid._bvh_core", "_bvh_build_core"),
+    ("pantr.grid._bvh_core", "_bvh_query_count_core"),
+    ("pantr.grid._bvh_core", "_bvh_query_emit_core"),
+    ("pantr.grid._hier_core", "_block_of_midx"),
+    ("pantr.grid._hier_core", "_decode_flat_id_core"),
+    ("pantr.grid._hier_core", "_encode_midx_core"),
+    ("pantr.grid._hier_core", "_hier_collect_cell_bounds_core"),
+    ("pantr.grid._hier_core", "_hier_locate_points_core"),
+)
+"""The nine Layer 3 kernels, which stay importable from the modules that define them.
+
+They are the Numba half of the dual backend now rather than the only implementation,
+so Layer 2 reaches them through the catalogue. The modules that define them are still
+where they live, and a test that imports one directly must keep working.
+"""
+
+_CATALOGUE = (
+    "bvh_build_kernel",
+    "bvh_query_count_kernel",
+    "bvh_query_emit_kernel",
+    "decode_flat_id_kernel",
+    "encode_midx_kernel",
+    "hier_collect_cell_bounds_kernel",
+    "hier_locate_points_kernel",
+    "locate_points_kernel",
+)
+"""The catalogue's eight accessors, added by this port."""
+
+
+@pytest.mark.parametrize("name", _PUBLIC)
+def test_the_public_surface_is_importable(name: str) -> None:
+    """Every name in ``__all__`` resolves on the package."""
+    module = importlib.import_module("pantr.grid")
+    assert hasattr(module, name), f"pantr.grid lost {name}"
+
+
+def test_all_matches_the_public_list() -> None:
+    """``__all__`` is exactly the list above, so an addition has to be recorded here."""
+    module = importlib.import_module("pantr.grid")
+    assert tuple(sorted(module.__all__)) == tuple(sorted(_PUBLIC))
+
+
+@pytest.mark.parametrize(("path", "name"), _CONSUMER_PRIVATE)
+def test_the_consumer_visible_private_paths_still_resolve(path: str, name: str) -> None:
+    """The private paths a downstream consumer imports are still importable.
+
+    Failing this does not mean the change is wrong. It means the consumer's checkout
+    has to be updated in the same breath, which is the whole point of finding out
+    here rather than there.
+    """
+    module = importlib.import_module(path)
+    assert hasattr(module, name), f"{path} lost {name}, which a downstream consumer imports"
+
+
+def test_the_stack_depth_constant_still_has_its_value() -> None:
+    """``_BVH_STACK_DEPTH`` is 128 on both sides, and the oracle's copy is the source.
+
+    Pinned as a value as well as a path because the port added a second copy in C++.
+    Two spellings of one constant that can drift is exactly the failure this catches,
+    and the consumer reads the Python one.
+    """
+    module = importlib.import_module("pantr.grid._bvh_core")
+    assert module._BVH_STACK_DEPTH == 128
+
+
+@pytest.mark.parametrize("name", _NODE_ARRAYS)
+def test_the_bvh_node_arrays_are_still_properties(name: str) -> None:
+    """Each of the five node arrays is still readable off a built BVH.
+
+    The consumer traverses these directly, so they are contract rather than detail.
+    """
+    tree = BVH.from_cell_bounds(np.zeros((2, 1)), np.ones((2, 1)))
+    assert hasattr(tree, name), f"BVH lost the {name} property a consumer traverses"
+
+
+@pytest.mark.parametrize(("path", "name"), _KERNELS)
+def test_the_kernels_stay_where_they_were(path: str, name: str) -> None:
+    """Every Layer 3 kernel is still reachable from the module that defines it."""
+    module = importlib.import_module(path)
+    assert hasattr(module, name), f"{path} lost {name}"
+
+
+@pytest.mark.parametrize("name", _CATALOGUE)
+def test_the_catalogue_accessors_resolve(name: str) -> None:
+    """Every accessor this port added is importable from the catalogue."""
+    module = importlib.import_module("pantr.grid._grid_backend")
+    assert hasattr(module, name), f"pantr.grid._grid_backend lost {name}"
+
+
+def test_the_catalogue_covers_every_dispatched_kernel() -> None:
+    """``__all__`` is exactly the eight accessors, so a ninth has to be recorded here."""
+    module = importlib.import_module("pantr.grid._grid_backend")
+    assert tuple(sorted(module.__all__)) == tuple(sorted(_CATALOGUE))


### PR DESCRIPTION
## Context

`pantr.grid`, the fourth Stage 1 module and the largest so far by kernel count: nine
Numba kernels across `_locate_core.py`, `_bvh_core.py` and `_hier_core.py`, about 800
lines, reached through eight Layer 2 call sites.

**This PR was reviewed after it was opened, the review refuted its original claim, and
the three commits that follow the port are the correction.** The description below is
the corrected one. The original — which claimed a bit-exact equality for all nine
kernels as a property of the algorithm — was wrong in a way no passing test could
surface, and the full account is committed at `reviews/357-2026-08-25.md`.

## Specification

**The claim is an equality for all nine kernels, and it holds because of how two
statements are written.**

Two of the three paths argue it structurally, and those two were never in doubt:

- **Tensor-product point location performs no floating-point arithmetic whatsoever.**
  Every binary operation is on an integer index and every use of a coordinate is a
  comparison, established by an AST walk of the oracle rather than by reading it.
- **Every discrete verdict in the BVH rests on a bit-identical quantity.** The node box
  is a running min/max over copied corners; the longest-axis tie compares one
  subtraction with a strict `>`; the centroid's multiply by `0.5` follows its add, so
  there is no product to fuse into. The median split is a *stable* sort, and stability
  determines the output permutation uniquely, so `std::stable_sort` reproduces
  `np.argsort(kind="mergesort")` by argument rather than by coincidence.

**The hierarchical descent is the one that needed fixing.** It computes
`lo[k] = lo[k] + j * size_k` and then truncates a quotient of the result. Written as
one expression that update is contractible into a fused multiply-add, and
`-ffp-contract=on` permits exactly that; the oracle never fuses, since numba defaults
to `fastmath=False`. So on a target with an FMA the two backends take different
branches — and a branch here is a **cell id**, which Rule 11 says no tolerance bounds.

The fix is to name the product instead of inlining it, at both sites. Verified by
disassembly: `vmulsd` + `vaddsd` for the split form at `-march=x86-64-v3` and at
`-march=native`, against `vfmadd132sd` for the single expression. `-ffp-contract=on`
was chosen over `fast` precisely because it confines fusion to within one expression,
so the split is a guarantee rather than a hope. That makes the equality
**exact-by-structure** instead of conditional on shipping without `-march`.

## What the review found, and what the last three commits do

The full artifact is `reviews/357-2026-08-25.md`: six lenses, 6 critical, 10 important,
2 recommended, 4 suggested. **Two lenses converged independently on the central
finding**, one by derivation and one by 180000 adversarial emulations. The five
critical findings that belong to this PR are closed here; the sixth is in already-merged
code and is being filed separately.

**`13170e4` — three code fixes.**

- *The contraction sites*, as above. The counterexample it closes: root cell
  `[1.0, 2.0]`, factor 10, `x = 1.71`, a decimal literal. At level 0 the unfused sum is
  `1.7000000000000002` and the fused one `1.7`, one ulp apart; at level 1 the quotients
  are `0.9999999999999778` and exactly `1.0`, so the truncation gives child 0 against
  child 1. Against the real kernels before the fix: baseline **70**, `x86-64-v3` **71**,
  `native` **71**, oracle **70**. Note which side was right — the exact value of
  `1.0 + 7·fl(0.1)` is `1.7`, so the *fused* result was correctly rounded and the oracle
  is one ulp high. This deliberately forbids the more accurate answer, because the
  contract is parity and not correction.
- *The factor guard was wrong, and needed no ISA to fire.* The oracle documents a factor
  of 1 as legal, validates `f < 1`, and has a committed test asserting it; the bindings
  rejected anything below 2. So the two backends disagreed on the **domain** rather than
  on a value, and every anisotropic grid was unusable under `PANTR_BACKEND=cpp` with no
  recovery path. The rejected value was also the one factor at which the descent
  provably cannot diverge, since the clamp forces `j = 0`.
- *The BVH build guarded `hi >= lo`, which is not finiteness.* That rejects a NaN corner
  but admits infinities, and the centroid `0.5 * (lo + hi)` then yields NaN from two
  corners that passed — making the sort's comparator an invalid strict weak ordering,
  which is undefined behaviour rather than merely a divergence. Measured, the two
  backends built different trees, and `design/bvh.md` establishes the five node arrays
  as public API a consumer traverses itself.

**`8b57733` — two coverage gaps the fixtures could not reach**, each fault-injection
verified to be the only failure of 28 with its fault planted: the BVH longest-axis tie,
and a non-dyadic descent over domains straddling zero.

**`fb698b8` — the claim's own wording.** The header justified the old claim with a sweep
of 300000 descents that ran on a build with **no** `-march`, where baseline x86-64 is
SSE2 and has no fused multiply-add at all: it compared two unfused implementations and
carried no information about contraction. The mechanism it offered is false in the
direction that matters — comparable magnitude is neither necessary nor sufficient, and
`|Δlo| / size_k` is *invariant* rather than decaying, because the truncation divides by
a `size_k` shrinking at the same rate. Per `CLAUDE.md` a measured number with no
reproducible command is deleted rather than corrected.

The counterexample is now a test rather than a sentence. Its design is the part worth
reading: comparing backends on that input proves nothing on a build with no FMA, so the
test asserts instead that the input remains a **discriminator** — that a fused
evaluation really does diverge from an unfused one — which says something on this
machine and fails if a future toolchain makes the input benign while the header still
cites it as a guard.

## Acceptance criteria

- [x] AC1: `PANTR_BACKEND=cpp` reaches all eight Layer 2 seams.
- [x] AC2: the equality is asserted per case, ids separately from coordinates.
- [x] AC3: the BVH's parity covers **all five node arrays**, not a query result.
- [x] AC4: the frontier is covered — every interior breakpoint, both domain corners, one
      ulp either side, a degenerate query box on a cell corner, a box sharing only a face.
- [x] AC5: 7372 tests under **each** backend; 29 parity; 40 re-export pins; 13 `ctest`
      targets under `PANTR_WERROR=ON`.
- [x] AC6: ruff, ruff format, mypy over 277 files, `lint-imports`, docs under `-W`.
- [x] AC7 (new): the equality is exact-by-structure, verified by disassembly at two ISA
      levels, and the counterexample that would break a re-inlining is a committed test.

## Judgment calls

1. **Nearly every binding argument is keyword-only**, stricter than the oracle. These
   signatures are full of adjacent, same-typed, mutually unordered `int64` descriptor
   arrays that would type-check and run if transposed. The review found this policy
   applied consistently in seven of eight functions; `hier_collect_cell_bounds` puts
   `knots_flat` behind `kw_only()` although it has no transposable sibling, which is
   either a documented extension of the rule or an inconsistency — **flagged, not fixed**.
2. **`double` only, no `float` overload.** The oracle is float64-only, verified across
   Layer 1, 2 and 3, so a float32 surface would have no oracle behind it. **Correcting
   the original description of this PR:** it is not true that every sibling registers
   both — `quad.cpp` already has 4 of 5 functions `double`-only for an analogous reason.
   This extends an existing pattern rather than inventing one.
3. **`_encode_midx_core` is merged into `block_of_midx`**, a split that serves Numba's
   inability to dispatch between two kernels and has no analogue in C++.
4. **Both `prange` kernels are serial in C++**: each iteration writes only its own output
   and there is no reduction. A shakedown probed nine thread counts and found no movement.
5. **`bvh_query_emit` counts unconditionally but writes only within capacity**, where the
   oracle would corrupt memory on an undersized `out`. **The review notes this is the one
   line where the port deliberately differs from the oracle and it has no test** — carried
   as an open finding rather than closed here.

## Open findings, not closed in this PR

Nine `I`-level findings are recorded in the artifact and deliberately left open, the two
worth naming being a heap-buffer-overflow on out-of-contract input where the oracle
degrades safely (both reachable only through private symbols — which is what the
downstream consumer imports), and the private BVH query boundary, which corrupts
**silently** at tree depth 128-132. Also open: a second int64 overflow site, the untested
`bvh_query_emit` deviation, and a docstring claiming to catch a constant drift it cannot
see. These are being triaged as a batch through `file-bug` rather than filed as symptoms.

**One correction the review made to this PR's own citations:** two lenses independently
read `design/backend_parity.md` Rule 8 and found this PR's citation of it a stretch — the
rule is about a bound going vacuous under ill-conditioning, not about there being no
comparandum at all. The conclusion stands on its own; the citation does not say what it
was cited as saying.

## Non-goals

- **No BVH improvement.** `design/bvh.md` lists four, and item 4 — clustering 4-8 cells
  per leaf — is flagged there as "now or never" because it breaks the node layout. This
  port freezes that layout in a second implementation without settling it, which is worth
  a decision rather than a default.
- **No profiling**, consistent with every port before it.
- **`_hierarchical_grid.py`'s 1874 lines of Layer 1/2 Python are untouched**, as are
  `_tags`, `_partition`, `_overlay` and `_cell_quadrature`. Only the kernels ported.
