### PR TITLE
fix(bezier): make dedup_roots' two arrays unsayable by position

### DIFF
--- a/cpp/bindings/bezier_root_finding.cpp
+++ b/cpp/bindings/bezier_root_finding.cpp
@@ -243,8 +243,12 @@ void register_bezier_root_finding(nb::module_& m) {
     //
     // `dedup_roots` takes the coefficients **first**, as every sibling in this file
     // and every accessor in the four catalogues does. Its `raw_roots` is always
-    // `float64` and `coeff` frequently is, so a transposed call type-checks, runs,
-    // and merges against the wrong data.
+    // `float64` and `coeff` frequently is, so for the `double` overload the two are
+    // indistinguishable to the caster: a transposed call type-checked, ran, and
+    // merged against the wrong data, returning a coefficient rather than a root. A
+    // comment saying so was the whole guard and did not hold. `nb::kw_only()` now
+    // sits directly after `coeff`, giving this binding the same shape as
+    // `clip_roots` -- one positional argument and nothing else sayable by position.
     m.def("yuksel_roots", &bind_yuksel_roots<double>, nb::arg("coeff").noconvert(),
           nb::arg("param_tol"), nb::kw_only(), nb::arg("out").noconvert());
     m.def("yuksel_roots", &bind_yuksel_roots<float>, nb::arg("coeff").noconvert(),
@@ -255,12 +259,12 @@ void register_bezier_root_finding(nb::module_& m) {
     m.def("clip_roots", &bind_clip_roots<float>, nb::arg("coeff").noconvert(), nb::kw_only(),
           nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
 
-    m.def("dedup_roots", &bind_dedup_roots<double>, nb::arg("coeff").noconvert(),
-          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::kw_only(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
-    m.def("dedup_roots", &bind_dedup_roots<float>, nb::arg("coeff").noconvert(),
-          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::kw_only(),
-          nb::arg("param_tol"), nb::arg("geom_tol"), nb::arg("out").noconvert());
+    m.def("dedup_roots", &bind_dedup_roots<double>, nb::arg("coeff").noconvert(), nb::kw_only(),
+          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::arg("param_tol"),
+          nb::arg("geom_tol"), nb::arg("out").noconvert());
+    m.def("dedup_roots", &bind_dedup_roots<float>, nb::arg("coeff").noconvert(), nb::kw_only(),
+          nb::arg("raw_roots").noconvert(), nb::arg("n_roots"), nb::arg("param_tol"),
+          nb::arg("geom_tol"), nb::arg("out").noconvert());
 
     m.def("solve_monotone_root", &bind_solve_monotone_root<double>, nb::arg("coeff").noconvert(),
           nb::arg("param_tol"));

--- a/src/pantr/_pantr_cpp.pyi
+++ b/src/pantr/_pantr_cpp.pyi
@@ -939,9 +939,9 @@ def clip_roots(
 
 def dedup_roots(
     coeff: npt.NDArray[np.float32 | np.float64],
+    *,
     raw_roots: npt.NDArray[np.float64],
     n_roots: int,
-    *,
     param_tol: float,
     geom_tol: float,
     out: npt.NDArray[np.float64],
@@ -951,12 +951,14 @@ def dedup_roots(
     Args:
         coeff (npt.NDArray[np.float32 | np.float64]): Original Bernstein
             coefficients, used for the derivative. C-contiguous and non-empty.
-            First, as in every sibling: it and ``raw_roots`` are both ``float64``
-            when the coefficients are, so a transposed call would type-check and
-            merge against the wrong data.
+            The only positional argument, as in :func:`clip_roots`: it and
+            ``raw_roots`` are both ``float64`` when the coefficients are, so a
+            transposed call type-checked and merged against the wrong data until
+            everything after it was made keyword-only.
         raw_roots (npt.NDArray[np.float64]): Candidates, of which the first
-            ``n_roots`` are valid. C-contiguous.
+            ``n_roots`` are valid. C-contiguous. Keyword-only.
         n_roots (int): Number of valid candidates, in ``[0, len(raw_roots)]``.
+            Keyword-only.
         param_tol (float): Parametric tolerance. Finite and positive. Keyword-only,
             with ``geom_tol``.
         geom_tol (float): Geometric tolerance. Finite and positive. Keyword-only.
@@ -968,7 +970,7 @@ def dedup_roots(
 
     Raises:
         TypeError: If any array has the wrong dtype or rank, is not C-contiguous,
-            or if ``out`` is passed positionally.
+            or if anything but ``coeff`` is passed positionally.
         ValueError: If ``coeff`` is empty, if either tolerance is not finite and
             positive, if ``n_roots`` is not a valid count, or if ``out`` is too
             short.

--- a/src/pantr/bezier/_root_finding_backend.py
+++ b/src/pantr/bezier/_root_finding_backend.py
@@ -234,7 +234,12 @@ def _cpp_dedup_roots(
     coeff_c = np.ascontiguousarray(coeff)
     out = np.empty(max(n_roots, 1), dtype=np.float64)
     count = _pantr_cpp.dedup_roots(
-        coeff_c, raw_c, n_roots, param_tol=param_tol, geom_tol=geom_tol, out=out
+        coeff_c,
+        raw_roots=raw_c,
+        n_roots=n_roots,
+        param_tol=param_tol,
+        geom_tol=geom_tol,
+        out=out,
     )
     return out, count
 

--- a/tests/parity/test_bezier_binding_contract.py
+++ b/tests/parity/test_bezier_binding_contract.py
@@ -220,8 +220,8 @@ def test_the_root_finding_bindings_refuse_a_short_output(cpp_backend: None) -> N
     with pytest.raises(ValueError, match="can produce 2"):
         bindings.dedup_roots(
             _ROOT_COEFF,
-            np.array([0.25, 0.75]),
-            2,
+            raw_roots=np.array([0.25, 0.75]),
+            n_roots=2,
             param_tol=1e-12,
             geom_tol=1e-12,
             out=np.empty(1),

--- a/tests/parity/test_bezier_binding_contract.py
+++ b/tests/parity/test_bezier_binding_contract.py
@@ -269,3 +269,42 @@ def test_the_root_finding_bindings_refuse_the_tolerances_positionally(
             out_roots=np.full((1, 3), np.nan),
             out_counts=np.zeros(1, dtype=np.int64),
         )
+
+
+def test_dedup_roots_refuses_its_two_arrays_positionally(cpp_backend: None) -> None:
+    """``coeff`` and ``raw_roots`` are the same bound type, so only keyword-only closes it.
+
+    ``raw_roots`` is always ``float64`` and ``coeff`` frequently is, so for the
+    ``double`` overload the two are indistinguishable to the caster. Transposed, the
+    call type-checked, ran, and returned ``-1.0``: a coefficient rather than a root,
+    and outside ``[0, 1]``, the interval every root finder in this module is defined
+    on. Nothing raised and nothing warned.
+
+    The ``float32`` overload was never exposed to it, and the difference is the point:
+    there the two arrays have different dtypes, so ``.noconvert()`` already separates
+    them by type and neither overload accepts the transposition. It is asserted here
+    because the guard must hold on both, not because both were broken.
+
+    The correctly ordered call is kept alongside as the control: it isolates the
+    defect as the transposability rather than anything in the kernel.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    # B(t) = -1 + 2t in Bernstein form. Its only root is t = 0.5.
+    coeff = np.array([-1.0, 1.0])
+    raw = np.array([0.5])
+
+    out = np.empty(8)
+    count = bindings.dedup_roots(
+        coeff, raw_roots=raw, n_roots=1, param_tol=1e-9, geom_tol=1e-9, out=out
+    )
+    assert count == 1
+    assert out[0] == 0.5
+
+    with pytest.raises(TypeError):
+        bindings.dedup_roots(raw, coeff, 1, param_tol=1e-9, geom_tol=1e-9, out=np.empty(8))
+    with pytest.raises(TypeError):
+        bindings.dedup_roots(
+            raw, coeff.astype(np.float32), 1, param_tol=1e-9, geom_tol=1e-9, out=np.empty(8)
+        )


### PR DESCRIPTION
## Context

Closes #358. `dedup_roots` bound `coeff` and `raw_roots` as adjacent positional
parameters. For the `double` overload both are `ndarray<const double, ndim<1>, c_contig>`,
so nanobind, which resolves by type, could not tell the two orders apart. A transposed
call type-checked, ran, and returned a merged root set computed against the wrong array,
with no exception and no warning.

The file's own comment named the risk and did not close it. That is the point worth
keeping: the guard was prose.

## Specification

`nb::kw_only()` moves from after `n_roots` to directly after `coeff`. The binding then
has the same shape as `clip_roots` beside it: one positional argument, and nothing else
sayable by position.

## Acceptance

- **AC1** — a transposed call raises `TypeError` on both overloads. The `float32` half
  was never exposed to the defect, since there the two arrays differ in dtype and
  `.noconvert()` already separated them; it is asserted so the guard is pinned on both.
- **AC2** — the regression test carries the reproduction from the issue verbatim and was
  confirmed to fail against the previous binding (`DID NOT RAISE`), before the fix
  landed. It is the first of the two commits, deliberately.
- **AC3** — full suite, 7376 passed / 23 skipped / 7 xfailed, under both
  `PANTR_BACKEND=cpp` and the Python backend. No value moves: the change touches no
  arithmetic.
- **AC4** — `src/pantr/_pantr_cpp.pyi` is updated in the same commit as the binding. It
  is hand-maintained and nothing checks it.

## One correction to the issue

The issue calls the change source-compatible with every correctly ordered caller. It is
not, and cannot be: making `raw_roots` keyword-only refuses correctly ordered positional
calls too, which is the entire mechanism. Three call sites move to the keyword form and
all three are in this diff: the Layer 2 accessor `_cpp_dedup_roots`, and two cases in
`tests/parity/test_bezier_binding_contract.py`. A grep over `src`, `tests`, `scripts`,
`tools`, `docs` and `tutorials` finds no others.

## Non-goals

The kernel's arithmetic, which carries a bit-exactness parity claim, and the other
bindings in the file, which an audit found already consistent.

## Checks

ruff, ruff format, mypy (277 files), import-lint (2 contracts kept), the full suite under
both backends, doctest (82 passed), and the docs build under `-W`.

The `coverage` target fails, and fails **identically on the base commit** 1e7ccc8: 17
bitwise-parity tests, none of which reach `dedup_roots`. They run with
`NUMBA_DISABLE_JIT=1`, so the parity oracle is not the compiled kernel and bit-exactness
is not expected of it; they are skipped rather than run wherever the extension is absent,
which is why the target passes elsewhere. Pre-existing and out of scope here.
