### PR TITLE
test(parity): pin the JIT-disabled configuration in the fast suite

### DIFF
--- a/tests/test_jit_disabled_configuration.py
+++ b/tests/test_jit_disabled_configuration.py
@@ -1,0 +1,95 @@
+"""Pin the three ways the suite broke under ``NUMBA_DISABLE_JIT=1``.
+
+``make coverage`` runs the whole suite with the JIT off, because coverage.py cannot
+trace machine code numba compiled. That configuration is not a second opinion about
+the same code: it swaps the Numba oracle for interpreted python, and three separate
+things then break. All three were live at once, none was caught by a plain ``pytest``
+run, and each shipped for as long as it did because nothing outside ``make coverage``
+exercises the configuration at all.
+
+The three, in the order they were diagnosed:
+
+- **A bitwise parity claim compared against an oracle that is not the compiled
+  kernel.** ``np.power`` is not pinned by IEEE 754 and numba's disagrees with numpy's
+  by an ulp; a falling-factorial accumulator wraps at int64 compiled and grows without
+  bound interpreted, which past the overflow is a factor of about seven rather than a
+  rounding. `demand_a_compiled_seed` is what skips those claims.
+- **A test that reads generated assembly where none is generated.** With the JIT off
+  ``njit`` returns the plain python function, which has no ``inspect_asm``, so the
+  check that numba emits no fused multiply-add raised ``AttributeError``.
+- **An assertion tighter than the precision of its own data.** A ``float32`` root
+  asserted to ten decimal places held only because the compiled path happened to land
+  on the exact value.
+
+This test spawns one child ``pytest`` over the parity suite and the root finder with
+the variable set. It
+is the whole point that it runs in the **plain** suite: ``make coverage`` already
+catches all of this, and catching it there means catching it in CI, minutes later,
+after a full instrumented run, rather than here in seconds.
+
+It is meaningful without the compiled extension. Only the first of the three needs it;
+the other two are pinned either way, and the assertion below refuses a child run that
+skipped its way to green.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+"""The repository root, which is also pytest's rootdir and so its `pythonpath` anchor."""
+
+_TARGETS: Final[tuple[str, ...]] = (
+    "tests/parity",
+    "tests/test_root_finding.py",
+)
+"""What the child runs.
+
+The whole parity directory rather than the six tests that carry a gate today, which
+costs about three seconds more and buys the case every reviewer of this machinery
+asked about: a kernel added later that seeds with ``pow`` or accumulates an integer,
+in a module that currently has nothing to gate. Named as directories, the list needs
+no maintenance when that happens; named as tests, it would silently stop covering the
+thing it exists for.
+"""
+
+
+def test_the_jit_disabled_configuration_still_passes() -> None:
+    """Run the affected suites in a child process with the JIT switched off.
+
+    A child process is not a stylistic choice. ``NUMBA_DISABLE_JIT`` is read once,
+    when ``numba.core.config`` is imported, so by the time any test function runs the
+    kernels are already compiled or already not. Monkeypatching the variable moves
+    what `the_jit_is_disabled` reports and nothing else, which is enough to test a
+    guard in isolation and cannot reproduce the configuration itself.
+
+    Raises:
+        AssertionError: If the child fails, or reports no passing test.
+    """
+    if os.environ.get("NUMBA_DISABLE_JIT", "0") == "1":
+        pytest.skip("already inside a JIT-disabled run, so the child would be a copy of it")
+
+    child = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--no-header", "-p", "no:cacheprovider", *_TARGETS],
+        cwd=_ROOT,
+        env={**os.environ, "NUMBA_DISABLE_JIT": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    report = f"\n--- child stdout ---\n{child.stdout}\n--- child stderr ---\n{child.stderr}"
+
+    assert child.returncode == 0, (
+        f"the suite does not pass with NUMBA_DISABLE_JIT=1, which is the configuration "
+        f"`make coverage` runs in.{report}"
+    )
+    assert " passed" in child.stdout, (
+        f"the child reported nothing passing, so this test asserted nothing. A run that "
+        f"skips its way to green is the trap CLAUDE.md names by name.{report}"
+    )


### PR DESCRIPTION
## Context

`make coverage` runs the whole suite with `NUMBA_DISABLE_JIT=1`, because coverage.py
cannot trace machine code numba compiled. That configuration swaps the Numba oracle for
interpreted python, and three separate defects lived in it at once, fixed in #361. None
was visible to a plain `pytest` run. Each survived as long as it did because **nothing
outside `make coverage` exercises the configuration at all**, and `make coverage` is the
part of the check suite people skip.

This adds one test that spawns a child `pytest` with the variable set.

Severity: **minor**. Nothing is wrong today; this stops the three from coming back
unnoticed, and moves the detection from a full instrumented CI run to thirteen seconds in
the local suite.

## Why a subprocess

`NUMBA_DISABLE_JIT` is read once, when `numba.core.config` is imported. By the time any
test function runs, the kernels are already compiled or already not. Monkeypatching the
variable moves what `the_jit_is_disabled` reports and nothing else, which is enough to
test a guard in isolation and cannot reproduce the configuration itself. Two separate
reviewers checked this independently before it was written.

## Verified by mutation

Each mutation reverts the fix that closed one cause. The pin must fail for each.

| mutation | result |
|---|---|
| drop `demand_a_compiled_seed()` from the Bernstein tabulation | caught |
| drop the `inspect_asm` skip from the contraction probe | caught |
| restore `places=10` on the `float32` root assertion | caught |

**The first one is why this runs the whole `tests/parity` directory** rather than the six
tests that carry a gate today. The narrow list of test ids that was proposed first
**passed that mutation while failing the other two**: it looked like a pin and covered two
thirds of what it claimed. Naming directories instead also covers the case every review of
this machinery raised, a kernel added later that seeds with `pow` in a module that has
nothing to gate today.

## The cost, stated because it is the thing to argue with

Thirteen seconds, against about nine for a list naming the three modules with gates today,
and two for the list that did not work. The suite runs in about two minutes, so this is
roughly a tenth of it. If the target list ever needs to grow further, that ratio is the
reason to look again rather than widen it reflexively.

It skips inside a JIT-disabled run, so `make coverage` neither pays for it nor recurses
into it. It is meaningful without the compiled extension, since only the first cause needs
one, and it refuses a child run that reported nothing passing, which is the
skips-its-way-to-green trap `CLAUDE.md` names.

## Non-goals

The three defects themselves, fixed in #361. The `_basis_derivs_point` accumulator that
carries the same construct with no C++ counterpart and no parity test yet: this pin covers
it automatically on the day it gets one, which is the point of naming directories.

## Checks

ruff, ruff format, mypy (278 files), import-lint (2 contracts kept), doctest (82 passed),
the docs build under `-W`, `make coverage` (6798 passed, 534 skipped, 0 failed, 97%,
14726 of 15243 statements, unchanged from the base commit), and the full suite at
7378 passed / 23 skipped / 7 xfailed under both `PANTR_BACKEND=cpp` and the Python backend.
