### PR TITLE
docs(parity): record what an interpreted oracle is, as Rule 12

### DIFF
--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -1,6 +1,6 @@
 # Backend parity: what a bound may claim, and in which frame
 
-**Status:** complete for the five ports that exist. Eleven rules, each with the failure that produced
+**Status:** complete for the five ports that exist. Twelve rules, each with the failure that produced
 it, and the remaining module ports inherit them. The verdict on whether the parity harness
 generalized is now written, from the `quad` port's tests rather than predicted before them.
 **Date:** 2026-08-20, amended the same day after a deep review closed two open proofs,
@@ -17,7 +17,10 @@ the gap Rule 9's section declared: the Bézier claims are now conditional on wha
 do rather than skipped where it can fuse. Amended 2026-08-24 by the root-finding port with
 Rule 11 (an exact tie does not survive contraction, and a tie-break is a verdict rather than
 a displacement), and with a section added to Rule 9 recording that numba's `float()` does not
-widen a `float32`, which is the mechanism the three earlier width surprises rest on.
+widen a `float32`, which is the mechanism the three earlier width surprises rest on. Amended
+2026-08-26 with Rule 12 (the interpreted oracle is a different object), which enumerates the
+three ways `NUMBA_DISABLE_JIT=1` changes what the oracle computes, and records that a
+width-dependent regression test can be inert in that configuration without saying so.
 
 **Validated against:** `proto/cpp` at `765d9b9`, the `quad` port on `feat/cpp-quad`, and the
 root-finding port on `feat/cpp-bezier-roots`, whose fused branch was exercised against an
@@ -806,6 +809,70 @@ An unexercised claim is not a weak claim, it is an unevaluated one. Building the
 and running against it is cheap, the recipe is in `scripts/measure_bezier_fma_bound.py`, and it
 should be part of finishing any port that carries a conditional claim.
 
+## Rule 12: the interpreted oracle is a different object, and which claims survive it is knowable
+
+`make coverage` runs the whole suite with `NUMBA_DISABLE_JIT=1`, because coverage.py cannot
+trace machine code numba compiled. That is not a second opinion about the same kernels. It
+replaces the oracle with interpreted python over numpy, and **three things then differ, no
+more and no fewer**. Naming them is what lets a claim be gated precisely instead of a whole
+suite being skipped.
+
+Every figure below is printed by `scripts/measure_interpreted_divergences.py`, so it can be
+re-measured rather than re-read. Expect the `pow` count to move with a numpy or numba upgrade;
+what must not move is that it is non-zero.
+
+**One: storage width, which is Rule 9 read in the other direction.** Rule 9 records that
+`float()` does not widen a `float32` in `nopython` mode. Interpreted, `float()` is CPython's
+and *does* widen, so every one of the six sites Rule 9 enumerates promotes where the compiled
+kernel does not. `demand_the_compiled_kernel(dtype)` owns this, and only at `float32`.
+
+**Two: `pow`, which IEEE 754 does not pin.** `_bernstein_point`, `_bernstein_point_no_mirror`
+and `_evaluate_bezier_1d_core` seed a ratio recurrence with `np.power`, and what their bitwise
+claims rest on -- stated in their own `why` text -- is that *numba's* `np.power` agrees with the
+platform libm. Interpreted, numpy's is called instead. Measured: they differ by exactly one ulp
+in 2887 of 60000 arguments swept over degrees 0 to 29.
+
+**Three: integer width, which is not a rounding question at all.** `_bernstein_derivs_point` and
+`_evaluate_bezier_deriv_1d_core` accumulate a falling factorial in an integer that wraps at
+int64 when compiled and grows without bound when interpreted. At degree 25 order 16 the true
+value is `42744736671436800000` and its two's-complement wrap is `5851248524017696768`, a ratio
+of 7.305, which is what the parity failure reports. No tolerance answers this: the claim has to
+be skipped, not loosened. `_bincoeff` is the deliberate counter-example, casting each step to
+`np.int64` explicitly and so wrapping identically either way.
+
+**And the complementary half, which is what stops the gate being written too wide.** For a
+kernel built from `+`, `-`, `*`, `/` and `sqrt`, IEEE 754 pins every result, so the interpreted
+path reproduces the compiled path's bits **by guarantee rather than by luck**, and a bitwise
+claim over it is as true there as anywhere. This was not obvious and cost two wrong attempts.
+Keying the gate on "the JIT is off" skipped 433 test cases to fix 15; keying it on "the claim is
+bitwise" skipped 442 of 495 `float64` cases, no better. Keying it on the two constructs above
+skips 79 and costs no statements of coverage at all.
+
+So: a **bitwise** claim over a kernel carrying `pow` or an integer accumulator must be gated. A
+**bounded** or **converged** claim need not be, because a bound derived from a rounding budget
+absorbs a seed that moved by an ulp. The three gates live in `tests/_parity_harness.py` and
+`tests/test_jit_disabled_configuration.py` runs the configuration in the fast suite, since
+nothing else outside `make coverage` exercises it.
+
+### The consequence nobody had drawn: a regression test can be inert in this configuration
+
+`TestSignTestUnderflow` pins the fix for FELIGN/pantr#351, an underflow in a product-form sign
+test. **It cannot exercise that defect under `NUMBA_DISABLE_JIT=1` at all**, and this follows
+from the first divergence above rather than from anything about the test. The defect needs a
+`float32` product to underflow; interpreted, `float()` widens the operands to `float64` and the
+product is about `-1e-46`, nowhere near it. At the frontier coefficient the narrow product is
+exactly zero and the widened one is not, which is the whole difference.
+
+So `make coverage` would never have caught a regression of #351, before or after the gates were
+written. Nothing said so, and nothing in the output distinguishes a test that ran and passed
+from one that ran a different computation and passed.
+
+**The general form, and it is the part worth carrying:** the interpreted path is a different
+object, so a test that pins a *width-dependent* defect is inert there, silently. Rule 9 already
+says a width cannot be read off the source. This adds that a width-dependent **test** cannot be
+assumed to run in every configuration the suite is executed in, and that the suite reports
+nothing when it does not.
+
 ## Epistemic status
 
 - **PROVED, with the argument recorded outside this repository:** the closed form
@@ -847,3 +914,7 @@ should be part of finishing any port that carries a conditional claim.
    nobody here has read it, and until someone does that category is a placeholder.
 3. Rule 2 says use two comparisons. Is there a rule for **how many**, or does each kernel argue
    it? Four comparisons per rule was proposed for `quad` and never justified as the right number.
+4. Rule 12 enumerates three divergences and claims they are all of them. Two were found by a
+   parity failure and one by reading; none was found by looking for the *fourth*. A
+   transcendental other than `pow` in a future kernel would be one, and nothing would report it
+   until a bitwise claim over that kernel failed under `make coverage`.

--- a/scripts/measure_interpreted_divergences.py
+++ b/scripts/measure_interpreted_divergences.py
@@ -1,0 +1,126 @@
+"""Measure the three ways an interpreted numba oracle differs from a compiled one.
+
+``make coverage`` runs the suite with ``NUMBA_DISABLE_JIT=1``, because coverage.py
+cannot trace machine code numba compiled. ``design/backend_parity.md`` Rule 12 states
+that exactly three things then differ, and quotes a figure for each. This script is
+where those figures come from, so they can be re-measured rather than re-read.
+
+Run it from the repository root, inside the project environment::
+
+    PYTHONPATH="$(pwd)/src" python scripts/measure_interpreted_divergences.py
+
+Every number it prints is a property of numba, numpy and the platform libm on the
+machine it runs on, not of pantr. Expect the ``pow`` disagreement count in particular
+to move with a numpy or numba upgrade; what must not move is that it is non-zero,
+because a bitwise parity claim seeded with ``pow`` rests on it being zero for the
+compiled kernel alone.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numba import njit
+
+_INT64_MODULUS = 2**64
+"""Where a numba integer accumulator wraps, and a Python one does not."""
+
+_INT64_CEILING = 2**63
+"""Above this a wrapped value reads as negative in two's complement."""
+
+
+@njit(cache=False)  # type: ignore[untyped-decorator]
+def _compiled_pow(u: float, p: int) -> float:
+    """Seed a Bernstein ratio recurrence the way three kernels in `pantr` do.
+
+    Compiled with ``cache=False`` deliberately: a cached kernel is loaded from disk
+    rather than compiled here, and the point is to exercise numba's own code
+    generation.
+
+    Args:
+        u (float): The base, in ``[0, 1]``.
+        p (int): The exponent.
+
+    Returns:
+        float: ``u ** p`` as the compiled kernel computes it.
+    """
+    return float(np.power(u, p))
+
+
+def measure_pow_disagreement(degrees: int = 30, per_degree: int = 2000) -> tuple[int, int]:
+    """Count how often numba's ``np.power`` differs from numpy's own.
+
+    Args:
+        degrees (int): Exponents swept, from 0 upward. Defaults to 30.
+        per_degree (int): Random bases per exponent. Defaults to 2000.
+
+    Returns:
+        tuple[int, int]: ``(disagreements, comparisons)``.
+    """
+    _compiled_pow(0.5, 2)
+    rng = np.random.default_rng(0)
+    disagreements = 0
+    comparisons = 0
+    for exponent in range(degrees):
+        for base in rng.random(per_degree):
+            comparisons += 1
+            if _compiled_pow(float(base), exponent) != np.power(base, exponent):
+                disagreements += 1
+    return disagreements, comparisons
+
+
+def measure_factorial_wrap(degree: int = 25, order: int = 16) -> tuple[int, int, float]:
+    """Compute a falling factorial exactly and as int64 would hold it.
+
+    ``_evaluate_bezier_deriv_1d_core`` and ``_bernstein_derivs_point`` accumulate this
+    product. Compiled, the accumulator is an int64 and wraps; interpreted, it is a
+    Python integer and grows, so past the overflow the two paths differ by a factor
+    rather than by a rounding.
+
+    Args:
+        degree (int): The polynomial degree. Defaults to 25.
+        order (int): The derivative order. Defaults to 16.
+
+    Returns:
+        tuple[int, int, float]: ``(exact, wrapped, ratio)``.
+    """
+    exact = degree
+    for k in range(1, order):
+        exact *= degree - k
+    residue = exact % _INT64_MODULUS
+    wrapped = residue - _INT64_MODULUS if residue >= _INT64_CEILING else residue
+    return exact, wrapped, exact / wrapped
+
+
+def measure_float32_underflow(scale: float = 1e-23) -> tuple[float, float]:
+    """Show a product that underflows at ``float32`` and does not once widened.
+
+    This is the mechanism behind FELIGN/pantr#351, and the reason its regression test
+    cannot exercise the defect under ``NUMBA_DISABLE_JIT=1``: numba's ``float()`` does
+    not widen a ``float32`` while CPython's does, so interpreted, the product never
+    reaches the subnormal range where the defect lives.
+
+    Args:
+        scale (float): Coefficient magnitude. Defaults to 1e-23, the frontier.
+
+    Returns:
+        tuple[float, float]: ``(narrow_product, widened_product)``.
+    """
+    lo = np.float32(scale)
+    hi = np.float32(-scale)
+    return float(lo * hi), float(lo) * float(hi)
+
+
+def main() -> None:
+    """Print all three measurements with the labels Rule 12 quotes them under."""
+    disagreements, comparisons = measure_pow_disagreement()
+    print(f"pow disagreement:  {disagreements} of {comparisons}")
+
+    exact, wrapped, ratio = measure_factorial_wrap()
+    print(f"factorial wrap:    exact {exact}, wrapped {wrapped}, ratio {ratio:.4f}")
+
+    narrow, widened = measure_float32_underflow()
+    print(f"float32 underflow: narrow {narrow}, widened {widened:.3e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

Three defects lived in the `NUMBA_DISABLE_JIT=1` configuration at once, were diagnosed
over #361, and were fixed without the reason landing anywhere permanent. It survived in
docstrings and commit messages. `design/backend_parity.md` is where this project keeps
exactly this kind of rule, and it had eleven; this makes twelve.

Severity: **minor**, and it changes no code. What it protects against is the next port
rediscovering all of it.

## What Rule 12 says

`make coverage` does not re-run the same kernels with instrumentation. It **replaces the
oracle**: the Numba side becomes interpreted python over numpy. Three things then differ,
and naming them is what let the gate be scoped to 79 skips instead of 433.

- **Storage width**, which is Rule 9 read in the other direction. Rule 9 already records
  that `float()` does not widen a `float32` in `nopython` mode. Interpreted, `float()` is
  CPython's and does widen, so every site Rule 9 enumerates promotes where the compiled
  kernel does not.
- **`pow`, which IEEE 754 does not pin.** Three kernels seed a ratio recurrence with
  `np.power`, and what their bitwise claims rest on is that *numba's* agrees with the
  platform libm. Interpreted, numpy's is called. Measured: one ulp apart in 2887 of 60000
  arguments.
- **Integer width**, which is not a rounding question. Two kernels accumulate a falling
  factorial in an integer that wraps at int64 compiled and grows interpreted. At degree 25
  order 16 the ratio is 7.305, so no tolerance answers it and the claim must be skipped
  rather than loosened.

**And the half that bounds them.** For a kernel built from `+`, `-`, `*`, `/` and `sqrt`,
IEEE 754 pins every result, so interpretation reproduces the compiled bits **by guarantee
rather than by luck**. That is what stops the gate being written too wide, and it cost two
wrong attempts to learn: keying on "the JIT is off" skipped 433 cases to fix 15, and
keying on "the claim is bitwise" skipped 442 of 495, no better.

## The consequence nobody had drawn

A regression test can be **inert** in this configuration without saying so. `TestSignTestUnderflow`
pins the fix for #351, an underflow in a product-form sign test. The defect needs a `float32`
product to reach the subnormal range; interpreted, the operands widen and the product is about
`-1e-46`. So `make coverage` has never been able to exercise that defect, before or after the
gates were written, and nothing in the output distinguishes a test that ran from one that ran a
different computation.

Rule 9 says a width cannot be read off the source. This adds that a width-dependent **test**
cannot be assumed to run in every configuration the suite is executed in.

## The figures are reproducible, not recited

`scripts/measure_interpreted_divergences.py` prints all three, following the pattern Rule 9
already uses with `measure_root_finding_widths.py`. The script says plainly that the `pow` count
will move with a numpy or numba upgrade and that what must not move is its being non-zero.

Three numbers quoted from review reports were re-measured before being written down, and **one
was wrong**: the widened product is about `-1e-46`, not `2e-46`.

## What it admits it does not know

Open question 4, added: two of the three divergences were found by a parity failure and one by
reading, and nobody went looking for a fourth. A transcendental other than `pow` in a future
kernel would be one, and nothing would report it until a bitwise claim over that kernel failed
under `make coverage`.

## Checks

ruff, ruff format, mypy (279 files), import-lint (2 contracts kept), doctest (82 passed), the
docs build under `-W`, `make coverage` (6798 passed, 534 skipped, 0 failed, 97%, 517 statements
uncovered of 15243) and the full suite at 7378 passed / 23 skipped / 7 xfailed under both
backends. All unchanged from the base commit, as a documentation change should be.

One note on how that was measured, since it is the trap this branch is about: the first coverage
run in this worktree reported 96% and 1175 skips, because the worktree had no compiled extension
and the whole parity suite skipped. The numbers above are from a run with it built.
