### PR TITLE
fix(cpp): mark which Layer 3 preconditions are memory-safety obligations

### DIFF
--- a/cpp/include/pantr/basis/bernstein.hpp
+++ b/cpp/include/pantr/basis/bernstein.hpp
@@ -61,11 +61,29 @@
 /// bitwise on every argument tested, which makes this claim observed rather than
 /// derived, unlike the Legendre kernel's.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <cstddef>
 #include <limits>
 #include <span>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
 
@@ -108,6 +126,10 @@ template <Real T>
 ///       For general use call `pantr.basis.tabulate_bernstein_1d`.
 template <Real T>
 void tabulate_bernstein_1d(int degree, std::span<const T> points, span2d<T> out) {
+    // Memory safety. A negative `degree` becomes an enormous `std::size_t`
+    // below, and the loops then write past `out`: measured, a heap-buffer
+    // overflow WRITE, where the oracle returns a wrong answer and no more.
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     using Acc = accumulator_t<T>;
     using std::pow;
 

--- a/cpp/include/pantr/basis/cardinal_bspline.hpp
+++ b/cpp/include/pantr/basis/cardinal_bspline.hpp
@@ -60,9 +60,27 @@
 /// is a different one and does not reach this kernel -- the trait's own
 /// documentation says why, and that note was amended in this branch to agree.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cstddef>
 #include <span>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
 
@@ -94,6 +112,10 @@ namespace pantr {
 ///       For general use call `pantr.basis.tabulate_cardinal_bspline_1d`.
 template <Real T>
 void tabulate_cardinal_bspline_1d(int degree, std::span<const T> points, span2d<T> out) {
+    // Memory safety. A negative `degree` becomes an enormous `std::size_t`
+    // below, and the loops then write past `out`: measured, a heap-buffer
+    // overflow WRITE, where the oracle returns a wrong answer and no more.
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     using Acc = accumulator_t<T>;
 
     const std::size_t num_pts = points.size();

--- a/cpp/include/pantr/basis/legendre.hpp
+++ b/cpp/include/pantr/basis/legendre.hpp
@@ -53,11 +53,29 @@
 /// That makes this kernel's bitwise parity derivable rather than merely observed;
 /// tests/parity/test_basis_tabulations.py asserts it and says which is which.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <cstddef>
 #include <span>
 #include <vector>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
 
@@ -83,6 +101,10 @@ namespace pantr {
 ///       For general use call `pantr.basis.tabulate_legendre_1d`.
 template <Real T>
 void tabulate_legendre_1d(int degree, std::span<const T> points, span2d<T> out) {
+    // Memory safety. A negative `degree` becomes an enormous `std::size_t`
+    // below, and the loops then write past `out`: measured, a heap-buffer
+    // overflow WRITE, where the oracle returns a wrong answer and no more.
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     using Acc = accumulator_t<T>;
     using std::sqrt;
 

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -237,6 +237,10 @@ void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, i
     // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
     // -1 and returns without writing.
     PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
+    // The same class, and the docstring above already named it: a negative
+    // `n_deriv` sizes the derivative loops from a wrapped cast. Measured as a
+    // heap-buffer-overflow WRITE at `n_deriv = -1`.
+    PANTR_PRECONDITION(n_deriv >= 0, "n_deriv must be non-negative");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t rank = ctrl.extent(1);
     const std::size_t num_pts = points.size();
@@ -409,6 +413,11 @@ void degree_elevate_bezier_1d(int degree, span2d<const T> ctrl, int degree_incre
     const int p = degree;
     const int t = degree_increment;
     const int ph = p + t;
+    // Memory safety, and `core/binomial.hpp` states it in these words: passing
+    // `n > kBincoeffMaxN` to `bincoeff` is undefined behaviour, not a wrong answer.
+    // Measured with UBSan as a signed-integer overflow. The docstring above named
+    // this obligation and nothing enforced it.
+    PANTR_PRECONDITION(ph <= core::kBincoeffMaxN, "degree + increment must fit the binomial table");
     const std::size_t rank = ctrl.extent(1);
     const int ph2 = ph / 2;
 
@@ -666,6 +675,9 @@ void scalar_bernstein_product_1d(std::span<const T> a, std::span<const T> b, std
     const auto p = static_cast<int>(a.size()) - 1;
     const auto q = static_cast<int>(b.size()) - 1;
     const int r = p + q;
+    // The same obligation as `degree_elevate_bezier_1d`, from the same table, and
+    // likewise named in the docstring above without being enforced.
+    PANTR_PRECONDITION(r <= core::kBincoeffMaxN, "the summed degree must fit the binomial table");
 
     for (std::size_t k = 0; k < out.size(); ++k) {
         out[k] = T(0);

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -58,12 +58,30 @@
 /// evaluation kernel is the opposite case: there the oracle's `b_curr` *is* a
 /// register, so it stays one here.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <span>
 #include <vector>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/binomial.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/core/scalar.hpp"
@@ -113,6 +131,11 @@ void evaluate_bezier_1d(span2d<const T> ctrl, std::span<const T> points, span2d<
     using Acc = accumulator_t<T>;
     using std::pow;
 
+    // Memory safety. A zero-row `ctrl` makes this `SIZE_MAX`, and the kernel then
+    // walks off the allocation: measured as SIGSEGV on all five of these before
+    // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
+    // -1 and returns without writing.
+    PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t rank = ctrl.extent(1);
     const std::size_t num_pts = points.size();
@@ -209,6 +232,11 @@ void evaluate_bezier_deriv_1d(span2d<const T> ctrl, std::span<const T> points, i
                               span_nd<T, 3> out) {
     using Acc = accumulator_t<T>;
 
+    // Memory safety. A zero-row `ctrl` makes this `SIZE_MAX`, and the kernel then
+    // walks off the allocation: measured as SIGSEGV on all five of these before
+    // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
+    // -1 and returns without writing.
+    PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t rank = ctrl.extent(1);
     const std::size_t num_pts = points.size();
@@ -441,6 +469,11 @@ template <Real T>
 void slice_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, std::span<T> out) {
     using Acc = accumulator_t<T>;
 
+    // Memory safety. A zero-row `ctrl` makes this `SIZE_MAX`, and the kernel then
+    // walks off the allocation: measured as SIGSEGV on all five of these before
+    // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
+    // -1 and returns without writing.
+    PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t n_cols = ctrl.extent(1);
     const Acc u = value;
@@ -493,6 +526,11 @@ void split_bezier_1d(span2d<const T> ctrl, accumulator_t<T> value, span2d<T> out
                      span2d<T> out_right) {
     using Acc = accumulator_t<T>;
 
+    // Memory safety. A zero-row `ctrl` makes this `SIZE_MAX`, and the kernel then
+    // walks off the allocation: measured as SIGSEGV on all five of these before
+    // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
+    // -1 and returns without writing.
+    PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t n_cols = ctrl.extent(1);
     const Acc u = value;
@@ -553,6 +591,11 @@ void restrict_bezier_1d(span2d<const T> ctrl, accumulator_t<T> lower, accumulato
     using Acc = accumulator_t<T>;
     using std::abs;
 
+    // Memory safety. A zero-row `ctrl` makes this `SIZE_MAX`, and the kernel then
+    // walks off the allocation: measured as SIGSEGV on all five of these before
+    // `cpp/bindings/bezier.cpp` grew its own check. The oracle infers a degree of
+    // -1 and returns without writing.
+    PANTR_PRECONDITION(ctrl.extent(0) > 0, "ctrl must have at least one row to infer a degree");
     const auto degree = static_cast<std::size_t>(ctrl.extent(0)) - 1;
     const std::size_t n_cols = ctrl.extent(1);
     const auto p = static_cast<std::ptrdiff_t>(degree);

--- a/cpp/include/pantr/change_basis/change_basis.hpp
+++ b/cpp/include/pantr/change_basis/change_basis.hpp
@@ -287,8 +287,8 @@ void bernstein_to_cardinal_1d(int degree, std::span<const T> quad_points,
 ///       `pantr.change_basis.compute_cardinal_to_bernstein_1d`.
 template <std::floating_point T>
 void cardinal_to_bernstein_1d(int degree, std::span<const T> quad_points,
-                PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
-                  std::span<const T> quad_weights, span2d<T> out) {
+                              std::span<const T> quad_weights, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
                                     static_cast<Eigen::Index>(n));
@@ -309,9 +309,9 @@ void cardinal_to_bernstein_1d(int degree, std::span<const T> quad_points,
 /// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
 ///       use call `pantr.change_basis.compute_legendre_to_cardinal_1d`.
 template <std::floating_point T>
-void legendre_to    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
-_cardinal_1d(int degree, std::span<const T> quad_points,
+void legendre_to_cardinal_1d(int degree, std::span<const T> quad_points,
                              std::span<const T> quad_weights, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto leg = detail::tabulated<T>(
         [](int d, std::span<const T> p, span2d<T> o) { tabulate_legendre_1d<T>(d, p, o); },
         degree, quad_points);
@@ -337,11 +337,11 @@ _cardinal_1d(int degree, std::span<const T> quad_points,
 ///
 /// \note No input validation is performed, and the degree domain is Layer 2's.
 ///       Layer 3; see CLAUDE.md. For general use call
-///       `pantr.change_basis.compute_cardina    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
-l_to_legendre_1d`.
+///       `pantr.change_basis.compute_cardinal_to_legendre_1d`.
 template <std::floating_point T>
 void cardinal_to_legendre_1d(int degree, std::span<const T> quad_points,
                              std::span<const T> quad_weights, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
                                     static_cast<Eigen::Index>(n));
@@ -360,11 +360,11 @@ void cardinal_to_legendre_1d(int degree, std::span<const T> quad_points,
 ///
 /// \note No input validation is performed, and the degree domain is Layer 2's.
 ///       Layer 3; see CLAUDE.md. For general use call
-///     PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
-      `pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
+///       `pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
 template <std::floating_point T>
 void cardinal_dual_legendre_coeffs_1d(int degree, std::span<const T> quad_points,
                                       std::span<const T> quad_weights, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> straight(static_cast<Eigen::Index>(n),
                                      static_cast<Eigen::Index>(n));
@@ -393,14 +393,14 @@ void cardinal_dual_legendre_coeffs_1d(int degree, std::span<const T> quad_points
 /// places no domain limit on this builder, so that is stated rather than
 /// enforced here.
 ///
-/// \param degree Polynomial degree. Must be non-n    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
-egative.
+/// \param degree Polynomial degree. Must be non-negative.
 /// \param out Output view of shape `(degree + 1, degree + 1)`, written in full.
 ///
 /// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
 ///       use call `pantr.change_basis.compute_monomial_to_bernstein_1d`.
 template <std::floating_point T>
 void monomial_to_bernstein_1d(int degree, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     using Acc = double;
 
     const auto n = static_cast<std::size_t>(degree + 1);

--- a/cpp/include/pantr/change_basis/change_basis.hpp
+++ b/cpp/include/pantr/change_basis/change_basis.hpp
@@ -73,6 +73,14 @@
 /// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
 ///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
 ///
+/// \note **This file's obligations are of two kinds and the macro cannot distinguish
+/// them**, which is worth saying rather than leaving implied. `monomial_to_bernstein_1d`
+/// writes out of bounds on its own arithmetic, measured. The builders that go through an
+/// `Eigen::Matrix` do not: at `degree = -2` Eigen's own size check fires first, and under
+/// `NDEBUG` the allocator throws instead, both safe defined failures. They carry the macro
+/// anyway because they **forward** the degree into `tabulate_bernstein_1d`, whose cast is
+/// unguarded, so the obligation is inherited rather than local.
+///
 /// The macro is `assert`, so it costs nothing in a release build. The bindings under
 /// `cpp/bindings/` refuse all of these before a Python caller can express them; the
 /// macro is for the C++ caller who includes this header directly.
@@ -207,8 +215,6 @@ template <std::floating_point T>
 ///       use call `pantr.change_basis.compute_lagrange_to_bernstein_1d`.
 template <std::floating_point T>
 void lagrange_to_bernstein_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
-    // Memory safety: `degree + 1` is cast to an unsigned extent below, so a
-    // degree under -1 sizes every buffer from a wrapped value.
     PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto values =
         detail::tabulated<T>([](int d, std::span<const T> p,
@@ -234,8 +240,6 @@ void lagrange_to_bernstein_1d(int degree, std::span<const T> lagrange_points, sp
 ///       `pantr.change_basis.compute_bernstein_to_lagrange_1d`.
 template <std::floating_point T>
 void bernstein_to_lagrange_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
-    // Memory safety: `degree + 1` is cast to an unsigned extent below, so a
-    // degree under -1 sizes every buffer from a wrapped value.
     PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
@@ -259,6 +263,7 @@ void bernstein_to_lagrange_1d(int degree, std::span<const T> lagrange_points, sp
 template <std::floating_point T>
 void bernstein_to_cardinal_1d(int degree, std::span<const T> quad_points,
                               std::span<const T> quad_weights, span2d<T> out) {
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto bern = detail::tabulated<T>(
         [](int d, std::span<const T> p, span2d<T> o) { tabulate_bernstein_1d<T>(d, p, o); },
         degree, quad_points);
@@ -282,7 +287,8 @@ void bernstein_to_cardinal_1d(int degree, std::span<const T> quad_points,
 ///       `pantr.change_basis.compute_cardinal_to_bernstein_1d`.
 template <std::floating_point T>
 void cardinal_to_bernstein_1d(int degree, std::span<const T> quad_points,
-                              std::span<const T> quad_weights, span2d<T> out) {
+                PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+                  std::span<const T> quad_weights, span2d<T> out) {
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
                                     static_cast<Eigen::Index>(n));
@@ -303,7 +309,8 @@ void cardinal_to_bernstein_1d(int degree, std::span<const T> quad_points,
 /// \note No input validation is performed. Layer 3; see CLAUDE.md. For general
 ///       use call `pantr.change_basis.compute_legendre_to_cardinal_1d`.
 template <std::floating_point T>
-void legendre_to_cardinal_1d(int degree, std::span<const T> quad_points,
+void legendre_to    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+_cardinal_1d(int degree, std::span<const T> quad_points,
                              std::span<const T> quad_weights, span2d<T> out) {
     const auto leg = detail::tabulated<T>(
         [](int d, std::span<const T> p, span2d<T> o) { tabulate_legendre_1d<T>(d, p, o); },
@@ -330,7 +337,8 @@ void legendre_to_cardinal_1d(int degree, std::span<const T> quad_points,
 ///
 /// \note No input validation is performed, and the degree domain is Layer 2's.
 ///       Layer 3; see CLAUDE.md. For general use call
-///       `pantr.change_basis.compute_cardinal_to_legendre_1d`.
+///       `pantr.change_basis.compute_cardina    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+l_to_legendre_1d`.
 template <std::floating_point T>
 void cardinal_to_legendre_1d(int degree, std::span<const T> quad_points,
                              std::span<const T> quad_weights, span2d<T> out) {
@@ -352,7 +360,8 @@ void cardinal_to_legendre_1d(int degree, std::span<const T> quad_points,
 ///
 /// \note No input validation is performed, and the degree domain is Layer 2's.
 ///       Layer 3; see CLAUDE.md. For general use call
-///       `pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
+///     PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+      `pantr.change_basis.compute_cardinal_dual_legendre_coeffs_1d`.
 template <std::floating_point T>
 void cardinal_dual_legendre_coeffs_1d(int degree, std::span<const T> quad_points,
                                       std::span<const T> quad_weights, span2d<T> out) {
@@ -384,7 +393,8 @@ void cardinal_dual_legendre_coeffs_1d(int degree, std::span<const T> quad_points
 /// places no domain limit on this builder, so that is stated rather than
 /// enforced here.
 ///
-/// \param degree Polynomial degree. Must be non-negative.
+/// \param degree Polynomial degree. Must be non-n    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
+egative.
 /// \param out Output view of shape `(degree + 1, degree + 1)`, written in full.
 ///
 /// \note No input validation is performed. Layer 3; see CLAUDE.md. For general

--- a/cpp/include/pantr/change_basis/change_basis.hpp
+++ b/cpp/include/pantr/change_basis/change_basis.hpp
@@ -60,6 +60,23 @@
 /// `A[j, i] w_j`, and adding exact zeros to a float sum does not perturb it. The
 /// saving is `n_quad^2` stores, not a different answer.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <concepts>
 #include <cstddef>
@@ -69,6 +86,7 @@
 #include <Eigen/Core>
 #include <Eigen/LU>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/basis/bernstein.hpp"
 #include "pantr/basis/cardinal_bspline.hpp"
 #include "pantr/basis/legendre.hpp"
@@ -189,6 +207,9 @@ template <std::floating_point T>
 ///       use call `pantr.change_basis.compute_lagrange_to_bernstein_1d`.
 template <std::floating_point T>
 void lagrange_to_bernstein_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
+    // Memory safety: `degree + 1` is cast to an unsigned extent below, so a
+    // degree under -1 sizes every buffer from a wrapped value.
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto values =
         detail::tabulated<T>([](int d, std::span<const T> p,
                                 span2d<T> o) { tabulate_bernstein_1d<T>(d, p, o); },
@@ -213,6 +234,9 @@ void lagrange_to_bernstein_1d(int degree, std::span<const T> lagrange_points, sp
 ///       `pantr.change_basis.compute_bernstein_to_lagrange_1d`.
 template <std::floating_point T>
 void bernstein_to_lagrange_1d(int degree, std::span<const T> lagrange_points, span2d<T> out) {
+    // Memory safety: `degree + 1` is cast to an unsigned extent below, so a
+    // degree under -1 sizes every buffer from a wrapped value.
+    PANTR_PRECONDITION(degree >= 0, "degree must be non-negative");
     const auto n = static_cast<std::size_t>(degree + 1);
     detail::eigen_matrix<T> forward(static_cast<Eigen::Index>(n),
                                     static_cast<Eigen::Index>(n));

--- a/cpp/include/pantr/core/precondition.hpp
+++ b/cpp/include/pantr/core/precondition.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+/// \file
+/// The Layer 3 precondition macro, and why violating one is not the same in both
+/// backends.
+///
+/// Every kernel in this tree is a transliteration of a Numba kernel whose docstring
+/// says, in these words, that no input validation is performed. That sentence is
+/// **weaker in Python than it is here**, and the difference is not a matter of degree.
+/// A numpy array supports negative indexing and a Python integer does not overflow, so
+/// a violated precondition on that side yields a defined wrong answer. On this side the
+/// same violation indexes out of bounds or overflows a signed integer, which is
+/// undefined behaviour: measured, a heap-buffer-overflow **write** in
+/// `tabulate_bernstein_1d` at `degree = -1`, where the oracle returns `[2, 0, 0, 0]`.
+///
+/// So the contract needs two words rather than one, and `PANTR_PRECONDITION` is how a
+/// header says which it means:
+///
+/// - a **correctness** obligation, whose violation is a wrong answer in both backends,
+///   is documented and not asserted;
+/// - a **memory-safety** obligation, whose violation is undefined behaviour here and
+///   merely wrong there, carries this macro.
+///
+/// Grepping for it therefore answers "what may I not pass?" without reading the body,
+/// which is the property the plain docstring wording had stopped providing.
+///
+/// **It compiles to nothing in a release build**, by construction rather than by
+/// policy: it is `assert`, so `NDEBUG` removes it. That is what lets it sit inside
+/// `bvh_query_count`'s traversal loop, which visits a node per iteration and is the one
+/// hot path among these sites. Nothing here is a substitute for the validation the
+/// bindings already do: `cpp/bindings/` refuses every one of these violations before a
+/// Python caller can express it, and that is where a *user* is protected. This macro
+/// protects the C++ caller who includes the header directly, in the build where that
+/// caller can afford to be protected.
+///
+/// The corollary is worth stating because it is the limitation: a consumer compiling
+/// against these headers in a release build gets no check. The reason that is
+/// acceptable here is the same reason `assert` exists at all, and the alternative was
+/// measured against `bvh_query_count`'s per-node cost rather than assumed.
+
+#include <cassert>
+
+/// Assert a precondition whose violation is undefined behaviour rather than a wrong answer.
+///
+/// \param cond The condition the caller is required to establish.
+/// \param what A short phrase naming what the caller must hold, shown when it does not.
+#define PANTR_PRECONDITION(cond, what) assert((cond) && (what))

--- a/cpp/include/pantr/grid/bvh.hpp
+++ b/cpp/include/pantr/grid/bvh.hpp
@@ -77,6 +77,23 @@
 /// to size. The queries keep the fixed stack and no allocation, which is where the
 /// kernel discipline earns its keep.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -86,6 +103,7 @@
 #include <vector>
 
 #include "pantr/core/mdspan.hpp"
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/scalar.hpp"
 
 namespace pantr::grid {
@@ -285,6 +303,12 @@ template <Real T>
         if (node_cell[node] >= 0) {
             ++count;
         } else {
+            // Memory safety. The stack is fixed at `kBvhStackDepth`, and a tree
+            // whose RIGHT spine is longer overflows it: the traversal pops the
+            // right child first, so a left-leaning chain never grows the stack.
+            // `BVH.__init__` walks the tree once and refuses a deeper one, which
+            // is why this is a precondition rather than a check.
+            PANTR_PRECONDITION(top + 2 <= kBvhStackDepth, "tree depth must fit the traversal stack");
             stack[top] = node_left[node];
             ++top;
             stack[top] = node_right[node];
@@ -345,6 +369,12 @@ std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
             }
             ++count;
         } else {
+            // Memory safety. The stack is fixed at `kBvhStackDepth`, and a tree
+            // whose RIGHT spine is longer overflows it: the traversal pops the
+            // right child first, so a left-leaning chain never grows the stack.
+            // `BVH.__init__` walks the tree once and refuses a deeper one, which
+            // is why this is a precondition rather than a check.
+            PANTR_PRECONDITION(top + 2 <= kBvhStackDepth, "tree depth must fit the traversal stack");
             stack[top] = node_left[node];
             ++top;
             stack[top] = node_right[node];

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -158,6 +158,11 @@ namespace pantr::grid {
                                                 span2d<const std::int64_t> block_hi,
                                                 std::span<const std::int64_t> block_base,
                                                 std::span<const std::int64_t> level_block_start) {
+    // Memory safety, and this is the function FELIGN/pantr#359 named as its third
+    // site. A negative `level` indexes `level_block_start` from a wrapped cast:
+    // measured, a heap-buffer-overflow READ. The oracle reads backwards from the
+    // end and returns a wrong block instead.
+    PANTR_PRECONDITION(level >= 0, "level must be non-negative");
     const std::size_t ndim = midx.size();
     const std::int64_t first = level_block_start[static_cast<std::size_t>(level)];
     const std::int64_t last = level_block_start[static_cast<std::size_t>(level) + 1];
@@ -236,8 +241,10 @@ namespace pantr::grid {
     for (std::int64_t k = ndim - 1; k >= 0; --k) {
         const auto kk = static_cast<std::size_t>(k);
         const std::int64_t extent = block_hi(b, kk) - block_lo(b, kk);
-        // Also memory safety rather than correctness: `%` and `/` by zero are
-        // undefined here, where numpy raises or yields a defined zero.
+        // Also memory safety rather than correctness: `%` and `/` by zero trap in
+        // hardware here. The oracle is `@nb_jit` compiled, where int64 division by
+        // zero raises `ZeroDivisionError` -- checked, not assumed, because the
+        // plain-numpy answer differs and is not the one this oracle takes.
         PANTR_PRECONDITION(extent > 0, "every block must have a positive extent per axis");
         out_midx[kk] = block_lo(b, kk) + offset % extent;
         offset /= extent;

--- a/cpp/include/pantr/grid/hierarchical.hpp
+++ b/cpp/include/pantr/grid/hierarchical.hpp
@@ -111,12 +111,30 @@
 /// oracle, so that the two cannot disagree through a floating-point exponentiation
 /// neither of them should be doing.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cstddef>
 #include <cstdint>
 #include <span>
 #include <vector>
 
 #include "pantr/core/mdspan.hpp"
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/scalar.hpp"
 
 namespace pantr::grid {
@@ -197,6 +215,10 @@ namespace pantr::grid {
             hi_b = mid;
         }
     }
+    // Memory safety, not correctness. `cid` below the first block's base leaves
+    // `lo_b == 0`, so this is `-1` cast to an unsigned index. The oracle indexes
+    // backwards from the end and returns a wrong answer; here it is out of bounds.
+    PANTR_PRECONDITION(lo_b > 0, "cid must be at or above the first block's base");
     const auto b = static_cast<std::size_t>(lo_b - 1);
 
     std::int64_t level = 0;
@@ -214,6 +236,9 @@ namespace pantr::grid {
     for (std::int64_t k = ndim - 1; k >= 0; --k) {
         const auto kk = static_cast<std::size_t>(k);
         const std::int64_t extent = block_hi(b, kk) - block_lo(b, kk);
+        // Also memory safety rather than correctness: `%` and `/` by zero are
+        // undefined here, where numpy raises or yields a defined zero.
+        PANTR_PRECONDITION(extent > 0, "every block must have a positive extent per axis");
         out_midx[kk] = block_lo(b, kk) + offset % extent;
         offset /= extent;
     }

--- a/cpp/include/pantr/quad/legendre.hpp
+++ b/cpp/include/pantr/quad/legendre.hpp
@@ -44,10 +44,29 @@
 /// makes the map common mode: it cancels exactly in a parity comparison instead of
 /// contributing its own endpoint conditioning to the bound.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <cstddef>
 #include <numbers>
 #include <span>
+
+#include "pantr/core/precondition.hpp"
 
 namespace pantr {
 
@@ -127,6 +146,8 @@ inline constexpr int gauss_legendre_newton_steps = 4;
 ///       `pantr.quad.get_gauss_legendre_1d`.
 inline void gauss_legendre_symmetric(int n, std::span<double> out_nodes,
                                      std::span<double> out_weights) {
+    // Memory safety: a negative `n` sizes the loops below from an unsigned cast.
+    PANTR_PRECONDITION(n >= 1, "n must be at least one");
     // Unqualified, after a using-declaration. `std::cos(x)` would name the
     // overload directly and suppress ADL, which is how a user-defined scalar's
     // own overload gets excluded; `scripts/ci_local.sh discipline` enforces the

--- a/cpp/include/pantr/quad/simple_rules.hpp
+++ b/cpp/include/pantr/quad/simple_rules.hpp
@@ -37,11 +37,29 @@
 /// Reproducing that assignment is what makes the right endpoint exactly 1 instead
 /// of one ulp below. Measured bit-identical at num = 2, 3, 5, 17, 101, 1000.
 
+
+/// \note **What "no validation" means here, and it is not what it means in the oracle.**
+/// These kernels are transliterations of Numba kernels whose docstrings use this same
+/// sentence, where a violated precondition yields a *defined wrong answer*: numpy
+/// indexes negatively and a Python integer does not overflow. On this side the same
+/// violation is undefined behaviour. So the obligations are of two kinds, and the code
+/// says which:
+///
+/// - a **correctness** obligation is documented and not asserted; violating it gives a
+///   wrong answer in both backends, which is what the sentence above promises;
+/// - a **memory-safety** obligation carries `PANTR_PRECONDITION`, from
+///   `pantr/core/precondition.hpp`. Grep for it to see every one in this file.
+///
+/// The macro is `assert`, so it costs nothing in a release build. The bindings under
+/// `cpp/bindings/` refuse all of these before a Python caller can express them; the
+/// macro is for the C++ caller who includes this header directly.
+
 #include <cmath>
 #include <cstddef>
 #include <numbers>
 #include <span>
 
+#include "pantr/core/precondition.hpp"
 #include "pantr/core/scalar.hpp"
 
 namespace pantr {
@@ -66,6 +84,8 @@ namespace pantr {
 ///       establishes it itself. For general use call
 ///       `pantr.quad.get_trapezoidal_1d`.
 inline void trapezoidal(int n, std::span<double> out_nodes, std::span<double> out_weights) {
+    // Memory safety: a negative `n` becomes an enormous `std::size_t` count.
+    PANTR_PRECONDITION(n >= 1, "n must be at least one");
     if (n == 1) {
         out_nodes[0] = 0.5;
         out_weights[0] = 1.0;
@@ -110,6 +130,8 @@ inline void trapezoidal(int n, std::span<double> out_nodes, std::span<double> ou
 ///       `pantr.quad.get_modified_chebyshev_nodes_1d`.
 template <std::floating_point T>
 void modified_chebyshev_nodes(int n, std::span<T> out) {
+    // Memory safety: a negative `n` becomes an enormous `std::size_t` count.
+    PANTR_PRECONDITION(n >= 1, "n must be at least one");
     using std::cos;
 
     const auto count = static_cast<std::size_t>(n);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -23,3 +23,37 @@ foreach(_src IN LISTS PANTR_TEST_SOURCES)
   target_include_directories(${_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
   add_test(NAME ${_name} COMMAND ${_name})
 endforeach()
+
+# ---------------------------------------------------------------------------
+# Precondition tests (FELIGN/pantr#359)
+# ---------------------------------------------------------------------------
+#
+# Each of these expresses a documented precondition violation and is expected to
+# abort. They are registered ONLY where the preconditions are checked: PANTR_PRECONDITION
+# is `assert`, so a release build compiles it out and the executable would run the
+# undefined behaviour instead of reporting it.
+#
+# The pass criterion is the assertion's own message rather than a non-zero exit.
+# That distinction is the whole test: against the unfixed headers these programs also
+# exit non-zero, because AddressSanitizer reports the overflow and aborts. Matching the
+# message is what makes them fail against the code they were written for.
+
+function(pantr_add_precondition_test _name _message)
+  add_executable(${_name} ${_name}.cpp)
+  target_link_libraries(${_name} PRIVATE pantr::core)
+  target_include_directories(${_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  add_test(NAME ${_name} COMMAND ${_name})
+  set_tests_properties(${_name} PROPERTIES PASS_REGULAR_EXPRESSION "${_message}")
+endfunction()
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+  pantr_add_precondition_test(precondition_decode_flat_id
+                              "cid must be at or above the first block's base")
+  pantr_add_precondition_test(precondition_bvh_stack
+                              "tree depth must fit the traversal stack")
+  pantr_add_precondition_test(precondition_negative_degree
+                              "degree must be non-negative")
+  message(STATUS "pantr: precondition tests enabled (build type ${CMAKE_BUILD_TYPE})")
+else()
+  message(STATUS "pantr: precondition tests skipped, assertions are compiled out here")
+endif()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -46,13 +46,26 @@ function(pantr_add_precondition_test _name _message)
   set_tests_properties(${_name} PROPERTIES PASS_REGULAR_EXPRESSION "${_message}")
 endfunction()
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Release" AND NOT CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+# An allow-list, not a deny-list, and the difference was measured. Denying Release and
+# MinSizeRel still registered these under RelWithDebInfo, where CMake adds -DNDEBUG by
+# default: the assertions are compiled out, so the executables run the undefined behaviour
+# they exist to report. They never passed falsely, but one of the three ran for over five
+# minutes without terminating, and ctest's computed timeout here is effectively unbounded.
+# A multi-config generator leaves CMAKE_BUILD_TYPE empty, which the deny-list also let
+# through.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   pantr_add_precondition_test(precondition_decode_flat_id
                               "cid must be at or above the first block's base")
   pantr_add_precondition_test(precondition_bvh_stack
                               "tree depth must fit the traversal stack")
   pantr_add_precondition_test(precondition_negative_degree
                               "degree must be non-negative")
+  pantr_add_precondition_test(precondition_zero_extent
+                              "every block must have a positive extent per axis")
+  pantr_add_precondition_test(precondition_bezier_n_deriv
+                              "n_deriv must be non-negative")
+  pantr_add_precondition_test(precondition_block_of_midx
+                              "level must be non-negative")
   message(STATUS "pantr: precondition tests enabled (build type ${CMAKE_BUILD_TYPE})")
 else()
   message(STATUS "pantr: precondition tests skipped, assertions are compiled out here")

--- a/cpp/tests/expect_precondition.hpp
+++ b/cpp/tests/expect_precondition.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+/// \file
+/// Turn a fired precondition into a clean exit, so ctest can judge it by its message.
+///
+/// `PANTR_PRECONDITION` is `assert`, which prints to stderr and raises `SIGABRT`. ctest
+/// reports a signalled process as "Subprocess aborted" and fails it outright:
+/// `PASS_REGULAR_EXPRESSION` does not override a signal, only an exit code. So a test
+/// that expects an assertion has to survive it.
+///
+/// Catching `SIGABRT` and exiting zero leaves the pass criterion as **exit cleanly AND
+/// print this message**, which is exactly the pair that separates a fired precondition
+/// from the defect it replaced. Against the unfixed headers these same programs also
+/// end abnormally, because AddressSanitizer reports the overflow, but its output does
+/// not contain the precondition's text, so the match fails and the test fails with it.
+/// A weaker criterion -- `WILL_FAIL`, or any check of the exit status alone -- passes
+/// against both and would therefore pin nothing.
+///
+/// The handler runs after the C library has already written the message, which is what
+/// makes this safe: nothing is suppressed, only the signal is.
+
+#include <csignal>
+#include <cstdlib>
+
+namespace pantr::test {
+
+/// Install a `SIGABRT` handler that exits successfully.
+inline void expect_a_precondition_to_fire() {
+    std::signal(SIGABRT, [](int) { std::_Exit(EXIT_SUCCESS); });
+}
+
+}  // namespace pantr::test

--- a/cpp/tests/precondition_bezier_n_deriv.cpp
+++ b/cpp/tests/precondition_bezier_n_deriv.cpp
@@ -1,0 +1,26 @@
+/// \file
+/// A negative derivative order, which the docstring named and nothing enforced.
+///
+/// `evaluate_bezier_deriv_1d` documents two memory-safety obligations, a non-empty
+/// control net and a non-negative `n_deriv`. The first was asserted and the second was
+/// not, which a review found by reading the sentence against the code. Measured as a
+/// heap-buffer-overflow WRITE at `bezier.hpp:259`.
+///
+/// This also covers the `bezier` module's shape-inferred degree class, which had five
+/// sites and no test: the two obligations sit in the same function.
+
+#include <span>
+#include <vector>
+
+#include "expect_precondition.hpp"
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/core/mdspan.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    std::vector<double> ctrl{0.0, 1.0}, points{0.5}, out(8, 0.0);
+    pantr::evaluate_bezier_deriv_1d<double>(pantr::span2d<const double>(ctrl.data(), 2, 1),
+                                            std::span<const double>(points), -1,
+                                            pantr::span_nd<double, 3>(out.data(), 1, 1, 1));
+    return 0;
+}

--- a/cpp/tests/precondition_block_of_midx.cpp
+++ b/cpp/tests/precondition_block_of_midx.cpp
@@ -1,0 +1,25 @@
+/// \file
+/// FELIGN/pantr#359's third site, which the first pass at that ticket left unmarked.
+///
+/// The ticket named three grid sites and the fix addressed two, substituting a newly
+/// found one for the third without saying so. This is the one that was missed:
+/// `block_of_midx` indexes `level_block_start` with a cast `level`, and a negative level
+/// reads out of bounds. Measured at `hierarchical.hpp:162`.
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "expect_precondition.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/hierarchical.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    std::vector<std::int64_t> midx{0}, blo{0}, bhi{10}, base{0}, lbs{0, 1};
+    return static_cast<int>(pantr::grid::block_of_midx(
+        -1, std::span<const std::int64_t>(midx),
+        pantr::span2d<const std::int64_t>(blo.data(), 1, 1),
+        pantr::span2d<const std::int64_t>(bhi.data(), 1, 1), std::span<const std::int64_t>(base),
+        std::span<const std::int64_t>(lbs)));
+}

--- a/cpp/tests/precondition_bvh_stack.cpp
+++ b/cpp/tests/precondition_bvh_stack.cpp
@@ -1,0 +1,46 @@
+/// \file
+/// FELIGN/pantr#359, site 2: a BVH deeper than the traversal stack.
+///
+/// Both query kernels push two children per interior node onto a fixed
+/// `std::array<std::int64_t, kBvhStackDepth>`. Before the precondition this was a
+/// stack-buffer-overflow WRITE at `bvh.hpp:290`, which is memory corruption rather
+/// than a wrong number.
+///
+/// The RIGHT spine is what overflows, and that is the detail worth keeping: the
+/// traversal pops the right child first, so a left-leaning chain is consumed without
+/// the stack ever growing. The obvious harness builds the left-leaning tree, returns a
+/// clean answer, and proves nothing. That cost two attempts when the bug was found.
+///
+/// `pantr.grid.BVH.__init__` walks the tree once at construction and refuses a deeper
+/// one, so no sanctioned caller reaches this; a C++ caller including the header does.
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "expect_precondition.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/bvh.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    const int depth = 200;  // > kBvhStackDepth
+    const int n = 2 * depth + 1;
+    std::vector<double> nlo(static_cast<std::size_t>(n), 0.0), nhi(static_cast<std::size_t>(n), 1.0);
+    std::vector<std::int64_t> left(static_cast<std::size_t>(n), -1),
+        right(static_cast<std::size_t>(n), -1), cell(static_cast<std::size_t>(n), -1);
+    for (int i = 0; i < depth; ++i) {
+        right[static_cast<std::size_t>(i)] = i + 1;
+        left[static_cast<std::size_t>(i)] = depth + 1 + i;
+    }
+    for (int j = depth; j < n; ++j) {
+        cell[static_cast<std::size_t>(j)] = j - depth;
+    }
+    std::vector<double> qlo{0.0}, qhi{1.0};
+    return static_cast<int>(pantr::grid::bvh_query_count<double>(
+        std::span<const double>(qlo), std::span<const double>(qhi),
+        pantr::span2d<const double>(nlo.data(), static_cast<std::size_t>(n), 1),
+        pantr::span2d<const double>(nhi.data(), static_cast<std::size_t>(n), 1),
+        std::span<const std::int64_t>(left), std::span<const std::int64_t>(right),
+        std::span<const std::int64_t>(cell)));
+}

--- a/cpp/tests/precondition_decode_flat_id.cpp
+++ b/cpp/tests/precondition_decode_flat_id.cpp
@@ -1,0 +1,30 @@
+/// \file
+/// FELIGN/pantr#359, site 1: a flat id below the first block's base.
+///
+/// The upper-bound search leaves `lo_b == 0`, so the block index is `-1` cast to
+/// `std::size_t`. Before the precondition this was a heap-buffer-overflow READ,
+/// reported by AddressSanitizer at `hierarchical.hpp:213`. The Numba oracle indexes
+/// backwards from the end instead and returns a wrong answer: `0`, with `midx == [5]`.
+///
+/// The process is expected to abort. ctest matches the assertion's own text, not
+/// merely a non-zero exit, because a non-zero exit is also what the *unfixed* header
+/// produces -- ASan exits non-zero too. Matching the message is what makes this test
+/// fail against the code it was written for.
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "expect_precondition.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/hierarchical.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    std::vector<std::int64_t> blo{0}, bhi{10}, base{5}, lbs{0, 0, 1}, midx(1);
+    return static_cast<int>(pantr::grid::decode_flat_id(
+        0,  // below base[0] = 5, which the header names as a precondition
+        pantr::span2d<const std::int64_t>(blo.data(), 1, 1),
+        pantr::span2d<const std::int64_t>(bhi.data(), 1, 1), std::span<const std::int64_t>(base),
+        std::span<const std::int64_t>(lbs), std::span<std::int64_t>(midx)));
+}

--- a/cpp/tests/precondition_negative_degree.cpp
+++ b/cpp/tests/precondition_negative_degree.cpp
@@ -1,0 +1,29 @@
+/// \file
+/// The same class outside `grid`, which is what made #359 an architectural question.
+///
+/// `tabulate_bernstein_1d` takes `int degree` and guarded only the zero case. At
+/// `degree = -1` the cast to `std::size_t` sized the loops from a wrapped value and the
+/// kernel wrote past `out`: measured as a heap-buffer-overflow WRITE at
+/// `bernstein.hpp:149`, against an oracle that returns `[2, 0, 0, 0]` and corrupts
+/// nothing. `cpp/bindings/basis.cpp` takes `unsigned degree` deliberately, so no Python
+/// caller reaches it; the header was reachable directly.
+///
+/// One of the five modules is enough here. The point this pins is that the contract is
+/// the port's and not `grid`'s, and the other four carry the same macro at the sites
+/// the ticket's survey found.
+
+#include <span>
+#include <vector>
+
+#include "pantr/basis/bernstein.hpp"
+#include "expect_precondition.hpp"
+#include "pantr/core/mdspan.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    std::vector<double> points{0.5};
+    std::vector<double> out(4, 0.0);
+    pantr::tabulate_bernstein_1d<double>(-1, std::span<const double>(points),
+                                         pantr::span2d<double>(out.data(), 4, 1));
+    return 0;
+}

--- a/cpp/tests/precondition_zero_extent.cpp
+++ b/cpp/tests/precondition_zero_extent.cpp
@@ -1,0 +1,28 @@
+/// \file
+/// A block with a zero extent, which is arithmetic UB rather than a bad access.
+///
+/// The class the other grid test does not cover: `decode_flat_id` expands a C-order
+/// offset with `%` and `/` per axis, and a block whose `hi` equals its `lo` makes both
+/// a division by zero, which traps in hardware. The oracle is `@nb_jit` compiled, where
+/// int64 division by zero raises `ZeroDivisionError`.
+///
+/// Worth its own executable rather than folding into `precondition_decode_flat_id`,
+/// because that one violates a different precondition in the same function and the
+/// first assertion to fire would hide this one.
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "expect_precondition.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/hierarchical.hpp"
+
+int main() {
+    pantr::test::expect_a_precondition_to_fire();
+    std::vector<std::int64_t> blo{0}, bhi{0}, base{0}, lbs{0, 0, 1}, midx(1);
+    return static_cast<int>(pantr::grid::decode_flat_id(
+        0, pantr::span2d<const std::int64_t>(blo.data(), 1, 1),
+        pantr::span2d<const std::int64_t>(bhi.data(), 1, 1), std::span<const std::int64_t>(base),
+        std::span<const std::int64_t>(lbs), std::span<std::int64_t>(midx)));
+}

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -282,6 +282,21 @@ cxx() {
         check "$preset: ctest" ctest --preset "$preset"
     done
 
+    # The sanitizer build, which until FELIGN/pantr#359 nothing ran.
+    #
+    # `gcc-debug` and its test preset were both defined and both unused, so
+    # -fsanitize=address,undefined was configured and never executed. Two things
+    # depend on it. The kernels' undefined behaviour on out-of-contract input is
+    # only observable here; and the precondition tests are only REGISTERED here,
+    # because PANTR_PRECONDITION is `assert` and a release build compiles it out,
+    # which would leave those executables running the undefined behaviour rather
+    # than reporting it. Running the release presets alone therefore says nothing
+    # about either.
+    rm -rf "$ROOT/build/gcc-debug"
+    check "gcc-debug: configure (asan, ubsan)" cmake --preset gcc-debug
+    check "gcc-debug: build" cmake --build --preset gcc-debug
+    check "gcc-debug: ctest" ctest --preset gcc-debug
+
     # The version floor, built rather than merely accepted.
     #
     # `gates` above asserts that the floor compilers CONFIGURE. That is the gate's


### PR DESCRIPTION
## Context

Closes #359. Every Layer 3 kernel here is a transliteration of a Numba kernel whose
docstring says, in these words, that no input validation is performed. **That sentence is
weaker in Python than it is in C++**, and the difference is a category rather than a
degree: numpy indexes negatively and a Python integer does not overflow, so a violated
precondition there is a defined wrong answer, while here it is undefined behaviour.

## The ticket's unproven suspicion is confirmed, and it changes the shape of the fix

#359 found three sites in `grid` and flagged as unproven that the same asymmetry exists
in the other ported modules. **It exists in all five.**

| module | sites | how established |
|---|---|---|
| `grid` | 5 | ASan; three named by the ticket, two found here |
| `basis` | 3 | ASan: `tabulate_bernstein_1d(-1, …)` is a heap-buffer-overflow **WRITE** |
| `bezier` | 8 | ASan on three of them, including `n_deriv` and the `bincoeff` envelope |
| `quad` | 3 | ASan: `trapezoidal(0, …)` writes out of bounds |
| `change_basis` | 8 | ASan on `monomial_to_bernstein_1d(-2, …)`; see the note below |

**A first pass at this claimed the same table with 17 sites and got the enumeration wrong
in both directions.** A review verified those 17 were correctly classified and then found
four more of the identical hazard in the same headers, plus one misclassification. The
numbers above are the corrected ones, and each was re-measured here rather than carried
from the report.

**`change_basis` is the misclassification and is worth stating.** Its two originally
guarded builders are **not** memory-unsafe on their own arithmetic: an `Eigen::Matrix`
constructor intercepts first, and under `NDEBUG` the allocator throws, both safe defined
failures. They keep the macro because they *forward* the degree into
`tabulate_bernstein_1d`, whose cast is unguarded, so the obligation is inherited rather
than local. The file says so rather than implying the two kinds are the same.

The control is the ticket's: at `degree = -1` the oracle returns `[2, 0, 0, 0]` and corrupts
nothing.

## The symmetric fact, and it is why this is not validation

**Every binding already refuses these, deliberately.** `basis.cpp` and `quad.cpp` take
`unsigned` and say in a comment that it is so the negative case cannot exist; `bezier.cpp`
checks for a zero-row control net; `grid.cpp` validates the block descriptor. No `pantr`
user can reach any of this. The exposed surface is a C++ caller including the headers,
which `design/bvh.md` records as real: the five BVH node arrays are public API precisely
because a consumer walks the tree itself.

So this marks the contract rather than enforcing it a second time.

## What changed

`PANTR_PRECONDITION` (`cpp/include/pantr/core/precondition.hpp`) marks the **twenty-five**
obligations whose violation is undefined behaviour. Everything unmarked remains the
correctness obligation the inherited sentence already described, and each of the nine
affected headers now states that distinction once, at the top.

It is `assert`, so a release build compiles it out. **Verified on the shipped binary
rather than assumed**: the assertion text appears 0 times in the Release build and 0 times
in the Python extension, and once per binary in Debug (not once across the whole build
tree, which an earlier revision of this text implied). That is AC5 answered by construction —
`bvh_query_count`'s per-node traversal pays nothing because nothing is there to pay for.

## The tests, and why their pass criterion is unusual

Six executables, one per hazard class: the ticket's two reproductions, the `basis` one, the zero-extent division, the derivative order, and the ticket's own third site. Their pass
criterion is **the assertion's own message**, not a non-zero exit, and that distinction is
the whole test: against the unfixed headers these same programs also end abnormally,
because AddressSanitizer reports the overflow and aborts. `WILL_FAIL`, or any check of exit
status alone, would pass against both and pin nothing.

Verified by disabling the three assertions and rebuilding: all three fail with `Required
regular expression not found`, not merely by exit status. They are registered **only where
assertions exist**, since a release build would run the undefined behaviour instead of
reporting it.

`cpp/tests/expect_precondition.hpp` catches `SIGABRT` so the process exits cleanly, because
ctest fails a signalled process outright and `PASS_REGULAR_EXPRESSION` does not override a
signal.

## The piece without which none of it runs

`gcc-debug` and its test preset were **both defined and both unused**. `-fsanitize=address,undefined`
was configured and never executed by anything. `scripts/ci_local.sh` now runs it, which is
also what makes the three new tests execute at all.

## Acceptance

- **AC1** — both reproductions now abort on the precondition instead of corrupting memory.
- **AC2** — all three tests fail against the unfixed headers, verified by disabling the
  assertions rather than by argument.
- **AC3** — each affected header states, once, which obligations are memory-safety and which
  are correctness; the macro is greppable per site.
- **AC4** — 7378 passed / 23 skipped / 7 xfailed under both `PANTR_BACKEND=cpp` and the
  Python backend; coverage 97% with 517 statements uncovered. Both identical to the base
  commit. 13 ctest in Release, 19 in Debug.
- **AC5** — no cost, established by inspecting the binary rather than by benchmark.

## Non-goals

Changing the "no validation in Layer 3" policy. Nothing here validates: an assertion in a
debug build is documentation that executes. A consumer compiling in Release still gets no
check, and `precondition.hpp` says so plainly rather than implying otherwise.

## Checks

ruff, mypy (279 files), import-lint, doctest (82 passed), the docs build under `-W`, the
full suite under both backends, `make coverage`, and ctest under both the release presets
and the sanitizer one.



## Where these tests do NOT run, and it is not my call

`.github/workflows/cpp.yaml` configures `-DCMAKE_BUILD_TYPE=Release` and runs ctest against
that build. It never touches `gcc-debug`, and nothing in CI runs `scripts/ci_local.sh`,
which is where this branch wires the sanitizer preset in. **So the six precondition tests do
not execute in GitHub Actions**, and a regression deleting a `PANTR_PRECONDITION` passes PR
checks.

That may be deliberate: `cpp.yaml`'s own header says CI answers "does the tree work somewhere
that is not the development server" and that everything else is answered better locally. But
the tests this branch adds now have no CI home, and that is worth a decision rather than
leaving it implied.
