### PR TITLE
ci(cpp): run the sanitizer build, and make UBSan able to fail

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -33,6 +33,21 @@
 # show up as a numerical difference rather than as an error. A second machine is
 # the only instrument for that.
 #
+# A third job builds with AddressSanitizer and UndefinedBehaviorSanitizer, and
+# it is not a duplicate of the first. The two jobs above configure Release, and
+# cpp/tests/CMakeLists.txt registers the precondition tests only under Debug --
+# PANTR_PRECONDITION is `assert`, so any other build type compiles it out and the
+# executables would run the undefined behaviour instead of reporting it. The
+# consequence, until this job existed, is that no precondition test had ever run
+# in CI: they ran on the development server through scripts/ci_local.sh and
+# nowhere else, which is the single-machine dependency the rest of this file is
+# written to avoid.
+#
+# It is also the only job that can see undefined behaviour at all. The contract
+# in cpp/include/pantr/core/precondition.hpp rests on measured UB -- a
+# heap-buffer-overflow write in tabulate_bernstein_1d -- and nothing in a Release
+# build observes that.
+#
 # The version floor (GCC 10 / Clang 10) is NOT checked here. `ubuntu-24.04` does
 # not package GCC 10, so it would need an older image or a container, and
 # `ci_local.sh` covers it on every run. design/toolchain_requirements.md records
@@ -224,3 +239,84 @@ jobs:
       # the same answer for the same minutes.
       - name: The whole suite against the C++ backend
         run: PANTR_BACKEND=cpp pytest -q
+
+  sanitizers:
+    name: GCC 14, ASan + UBSan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install the toolchain
+        run: |
+          # The same apt mirror replacement as the sibling jobs; the `cxx` job
+          # carries the reason.
+          echo 'https://archive.ubuntu.com/ubuntu/' | sudo tee /etc/apt/apt-mirrors.txt
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends gcc-14 g++-14 ninja-build ccache
+
+      - name: Cache the fetched dependencies
+        uses: actions/cache@v4
+        with:
+          # Its own path and key rather than the `cxx` job's. The preset's
+          # binaryDir is build/gcc-debug, so _deps lands inside it.
+          path: build/gcc-debug/_deps
+          key: deps-debug-${{ runner.os }}-${{ hashFiles('cmake/PantrDependencies.cmake') }}
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          # Debug -O0 with instrumentation shares no object with the Release job,
+          # so a shared key would be a cache of misses.
+          path: ~/.cache/ccache
+          key: ccache-asan-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-asan-${{ runner.os }}-
+
+      # Through the preset, unlike the `cxx` job above, and the difference is
+      # deliberate. What must not drift here is the sanitizer flag list: it is one
+      # string, scripts/ci_local.sh builds the same preset from it, and a second
+      # copy in this file would let the local script and this job sanitize
+      # different things with nothing to say so.
+      #
+      # Both reasons `cxx` gives for avoiding presets are answerable on the
+      # command line. A `-D` overrides a preset's cacheVariables, measured rather
+      # than assumed, so the unversioned `g++` the preset names is replaced here;
+      # and `cmake --build <dir>` instead of `--build --preset` leaves the build
+      # presets' `jobs: 20` -- the development server's CPU budget, wrong on a
+      # 4-CPU runner -- out of it entirely.
+      - name: Configure
+        run: >
+          cmake --preset gcc-debug
+          -DCMAKE_C_COMPILER=gcc-14
+          -DCMAKE_CXX_COMPILER=g++-14
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: cmake --build build/gcc-debug
+
+      # The check that this job is doing what it was added for, rather than
+      # passing while running nothing. If the Debug condition in
+      # cpp/tests/CMakeLists.txt ever stops matching, ctest still runs every other
+      # test and still reports success -- the failure mode is a green job, not a
+      # red one, so it needs asserting.
+      #
+      # Counted against the declarations rather than a literal, so a seventh
+      # precondition test does not need this file edited.
+      - name: Confirm the precondition tests are registered
+        run: |
+          declared=$(grep -cE '^ *pantr_add_precondition_test\(' cpp/tests/CMakeLists.txt || true)
+          registered=$(ctest --test-dir build/gcc-debug -N | grep -cE 'Test +#[0-9]+: precondition_' || true)
+          echo "declared=$declared registered=$registered"
+          test "$declared" -gt 0
+          test "$declared" -eq "$registered"
+
+      - name: Test
+        env:
+          # UBSan halts on its own: -fno-sanitize-recover=undefined is in the
+          # preset's flags. This asks only for the trace, which is the difference
+          # between a log that names a line and a log that names a file, on a
+          # machine nobody can inspect afterwards.
+          UBSAN_OPTIONS: print_stacktrace=1
+        run: ctest --test-dir build/gcc-debug --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,9 +34,10 @@
       "name": "gcc-debug",
       "inherits": "gcc",
       "displayName": "GCC, debug with sanitizers",
+      "description": "ASan and UBSan, and the build type that registers the precondition tests -- PANTR_PRECONDITION is `assert`, so only Debug keeps them. -fno-sanitize-recover=undefined is load-bearing rather than decorative: UBSan's default is to print a diagnostic and carry on, so without it a signed overflow is reported and the process still exits 0, which makes every consumer of this preset green on a finding it did report.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0 -fsanitize=address,undefined -fno-omit-frame-pointer",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0 -fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer",
         "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
       }
     }

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -292,6 +292,13 @@ cxx() {
     # which would leave those executables running the undefined behaviour rather
     # than reporting it. Running the release presets alone therefore says nothing
     # about either.
+    #
+    # It also ran in UBSan's recover mode until the preset gained
+    # -fno-sanitize-recover=undefined, which means a UBSan finding was printed
+    # here and the step still recorded PASS. Measured on a signed overflow: exit
+    # 0 without the flag, exit 1 with it. The flag lives in the preset rather
+    # than in this script so that .github/workflows/cpp.yaml, which builds the
+    # same preset, cannot end up sanitizing something different.
     rm -rf "$ROOT/build/gcc-debug"
     check "gcc-debug: configure (asan, ubsan)" cmake --preset gcc-debug
     check "gcc-debug: build" cmake --build --preset gcc-debug

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -307,10 +307,11 @@ cxx() {
     # nothing to notice.
     #
     # This is the ONLY place that check exists. .github/workflows/cpp.yaml runs
-    # GCC 14 and Clang 18, and ubuntu-24.04 does not package GCC 10, so covering
-    # the floor there needs an older image or a container -- more weight than a
-    # prototype should carry. design/toolchain_requirements.md records that the
-    # floor is verified locally and not by CI.
+    # GCC 14 only -- deliberately, as its own header says -- and ubuntu-24.04 does
+    # not package GCC 10, so covering the floor there needs an older image or a
+    # container -- more weight than a prototype should carry.
+    # design/toolchain_requirements.md records that the floor is verified locally
+    # and not by CI.
     local floor_cxx floor_name floor_dir
     for floor_cxx in /usr/bin/g++-10 /usr/bin/clang++-10; do
         floor_name="$(basename "$floor_cxx")"


### PR DESCRIPTION
## Context

The Layer 3 precondition contract landed in #364. This makes CI able to check it, and
fixes the reason the local sanitizer build could not fail on half of what it detects.

## Two gaps, and the second hid the first

**No precondition test had ever run in CI.** `cpp/tests/CMakeLists.txt` registers them
only when `CMAKE_BUILD_TYPE` is exactly `Debug`, because `PANTR_PRECONDITION` is `assert`
and any other build type compiles it out. Both existing jobs configure `Release`. They ran
through `scripts/ci_local.sh` on one machine and nowhere else, which is the single-machine
dependency the rest of `cpp.yaml` is written to avoid. The same job is also the only one
that can observe undefined behaviour at all, and the contract in
`cpp/include/pantr/core/precondition.hpp` rests on measured UB.

**The sanitizer build could not fail on a UBSan finding.** UBSan's default is to print a
diagnostic and continue, so the process exits 0. The `gcc-debug` preset has existed since
#359 and has been green in a way that would not have caught one.

| configuration | UBSan detects | exit code |
|---|---|---|
| as configured before this PR | yes, prints it | **0** |
| `UBSAN_OPTIONS=halt_on_error=1` | yes | 1 |
| `-fno-sanitize-recover=undefined` | yes | 1 |

The flag goes in the preset rather than in the workflow, so `ci_local.sh` and CI cannot end
up sanitizing different things. The compile-time form is preferred over the environment
variable because it cannot be forgotten by a new caller.

## Why this job uses the preset when its sibling does not

`cpp.yaml` argues against presets on two grounds: they pin a job count sized for a
20-CPU machine, and they name an unversioned `g++`. Both are answerable on the command
line, and this was checked rather than assumed: a `-D` overrides a preset's
`cacheVariables`, and `cmake --build <dir>` instead of `--build --preset` leaves the build
presets' job count out of it. What must not drift here is the sanitizer flag list, and a
second copy of it in the workflow would let the local script and CI diverge silently.

## The job asserts it is doing something

If the `Debug` condition stops matching, `ctest` runs every other test and reports success
— the failure mode is a green job, not a red one. So a step counts the registered
precondition tests against their declarations in `cpp/tests/CMakeLists.txt`, rather than
against a literal that a seventh test would invalidate.

## Verification

Run locally in a worktree, counted rather than read off a last line:

- `gcc-debug` configure / build / `ctest`: 0 errors, 0 warnings, 19/19, 6 precondition
  tests registered and passing.
- The flag reaches all 20 entries in `compile_commands.json`, not just `CMakeCache.txt`.
- The guard step executed exactly as it appears in the YAML, under `bash -e`.
- **Negative control**: a test with a signed overflow passes without the flag and fails
  with it, so the flag is what does the work.
- **Guard control**: under the `Release` preset the guard reports `6 != 0` and fails, which
  is the silent-green case it exists to catch.
- Full `pre-pull-request` equivalents: ruff clean, mypy clean over 279 files, import-lint
  2 kept 0 broken, 6231 passed, 82 doctests, coverage 96%, docs build succeeded.

## Out of scope, and reported rather than folded in

`proto/cpp` is currently **red under clang `-Werror`**, 12 errors at six sites in
`cpp/include/pantr/grid/bvh.hpp`, all of the form `stack[top]` where `top` is
`std::int64_t`. Measured provenance: clang is green at `daf7cdf` and red at `56192e1`, so
`873e3b48` (the grid port) introduced it. Not touched here, because the review of that port
answered the same hazard in `hierarchical.hpp` with `PANTR_PRECONDITION` rather than a
cast, and choosing between the two forms in memory-safety code is a decision this PR should
not make quietly.

The mechanism is worth recording: `cmake/PantrCompileOptions.cmake:93` passes `-Wconversion`
to both compilers, but the flag does not mean the same thing. Measured — `g++ -Wconversion`:
0 warnings; `g++ -Wconversion -Wsign-conversion`: 1; `clang++ -Wconversion`: 1. GCC does not
imply `-Wsign-conversion` and clang does, so a GCC-only CI is structurally blind to this
class, and clang runs on one machine only.

The second commit is separate and unrelated: `ci_local.sh` claimed `cpp.yaml` runs
"GCC 14 and Clang 18". It never has.
