### PR TITLE
fix(grid): restore the Clang build, and make -Wconversion mean the same in both compilers

### DIFF
--- a/cmake/PantrCompileOptions.cmake
+++ b/cmake/PantrCompileOptions.cmake
@@ -88,9 +88,16 @@ target_compile_features(pantr_cxx_flags INTERFACE cxx_std_20)
 target_compile_options(pantr_cxx_flags INTERFACE
     $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-ffp-contract=on>)
 
+# -Wsign-conversion is named explicitly because -Wconversion does NOT mean the
+# same thing in the two compilers: Clang implies it, GCC does not. Measured on an
+# `std::int64_t` indexing an `std::array` -- `g++ -Wconversion` warns 0 times,
+# `g++ -Wconversion -Wsign-conversion` and `clang++ -Wconversion` warn once each.
+# The asymmetry let six sites in grid/bvh.hpp break the Clang build for two days
+# while the GCC-only CI stayed green, and only scripts/ci_local.sh runs Clang.
 target_compile_options(pantr_cxx_flags INTERFACE
     $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:
-        -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wdouble-promotion>)
+        -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion
+        -Wdouble-promotion>)
 
 if(PANTR_WERROR)
   target_compile_options(pantr_cxx_flags INTERFACE

--- a/cpp/include/pantr/grid/bvh.hpp
+++ b/cpp/include/pantr/grid/bvh.hpp
@@ -296,7 +296,8 @@ template <Real T>
 
     while (top > 0) {
         --top;
-        const auto node = static_cast<std::size_t>(stack[top]);
+        const auto slot = static_cast<std::size_t>(top);
+        const auto node = static_cast<std::size_t>(stack[slot]);
         if (!node_overlaps<T>(qlo, qhi, node_lo, node_hi, node)) {
             continue;
         }
@@ -309,10 +310,9 @@ template <Real T>
             // `BVH.__init__` walks the tree once and refuses a deeper one, which
             // is why this is a precondition rather than a check.
             PANTR_PRECONDITION(top + 2 <= kBvhStackDepth, "tree depth must fit the traversal stack");
-            stack[top] = node_left[node];
-            ++top;
-            stack[top] = node_right[node];
-            ++top;
+            stack[slot] = node_left[node];
+            stack[slot + 1] = node_right[node];
+            top += 2;
         }
     }
     return count;
@@ -358,7 +358,8 @@ std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
 
     while (top > 0) {
         --top;
-        const auto node = static_cast<std::size_t>(stack[top]);
+        const auto slot = static_cast<std::size_t>(top);
+        const auto node = static_cast<std::size_t>(stack[slot]);
         if (!node_overlaps<T>(qlo, qhi, node_lo, node_hi, node)) {
             continue;
         }
@@ -375,10 +376,9 @@ std::int64_t bvh_query_emit(std::span<const T> qlo, std::span<const T> qhi,
             // `BVH.__init__` walks the tree once and refuses a deeper one, which
             // is why this is a precondition rather than a check.
             PANTR_PRECONDITION(top + 2 <= kBvhStackDepth, "tree depth must fit the traversal stack");
-            stack[top] = node_left[node];
-            ++top;
-            stack[top] = node_right[node];
-            ++top;
+            stack[slot] = node_left[node];
+            stack[slot + 1] = node_right[node];
+            top += 2;
         }
     }
     return count;

--- a/cpp/tests/test_grid_hierarchical.cpp
+++ b/cpp/tests/test_grid_hierarchical.cpp
@@ -114,7 +114,13 @@ void collect_and_locate_agree(const Grid1D& g, const char* what) {
 
 /// The collected cells tile the root domain exactly: no gap, no overlap.
 void the_cells_tile_the_domain(const Grid1D& g, const char* what) {
-    auto [lo, hi] = collect(g);
+    // Deliberately not a structured binding. The comparator below has to capture
+    // `lo`, and capturing a structured binding is C++20 (P1091), which the Clang 10
+    // version floor does not implement. The two bindings above are fine: declaring
+    // one is C++17, only capturing one is not.
+    const auto bounds = collect(g);
+    const std::vector<double>& lo = bounds.first;
+    const std::vector<double>& hi = bounds.second;
     std::vector<std::size_t> order(lo.size());
     for (std::size_t i = 0; i < order.size(); ++i) {
         order[i] = i;


### PR DESCRIPTION
## Context

`proto/cpp` has not built with Clang since the grid port landed on 25 August. Nothing
reported it: `.github/workflows/cpp.yaml` runs GCC only, and Clang runs in
`scripts/ci_local.sh` on one machine. Two defects, both from that port, plus the flag that
would have caught the first.

## The Clang build, and why GCC could not see it

`bvh_query_count` and `bvh_query_emit` index a `std::array` with an `std::int64_t`, at six
sites. Provenance measured rather than attributed:

| commit | Clang `-Werror` |
|---|---|
| `daf7cdf`, the grid port's parent | green, 0 errors |
| `56192e1`, before this PR | red, 12 errors |

**`-Wconversion` does not mean the same thing in the two compilers.** Measured on an
`std::int64_t` indexing a `std::array`:

| | warnings |
|---|---|
| `g++ -Wconversion` | 0 |
| `g++ -Wconversion -Wsign-conversion` | 1 |
| `clang++ -Wconversion` | 1 |

`cmake/PantrCompileOptions.cmake` passed one flag to both compilers and got two different
warning sets, so a GCC-only CI is structurally blind to this class. This PR names
`-Wsign-conversion` explicitly, which is the regression guard: with it, GCC surfaces exactly
these six sites and no others, in the tests, the benchmark and the bindings alike.

## Why a cast and not a precondition

The neighbouring hazard in `hierarchical.hpp` was answered with `PANTR_PRECONDITION`, so the
choice is worth stating. `top` is provably non-negative from the loop's own structure: the
body is entered only when `top > 0`, and its first statement decrements. The upper bound is
what the existing `PANTR_PRECONDITION(top + 2 <= kBvhStackDepth, ...)` already covers.
`PANTR_PRECONDITION` documents what a **caller** must establish; non-negativity here is a
local invariant no caller can violate, so the macro is the wrong tool and a cast is the right
one.

A named `slot` rather than six inline casts, because the minimal fix at the pop site would
have nested one cast inside another. Hoisting it also lets the two pushes name consecutive
slots instead of interleaving `++top`. Stored values and the final `top` are unchanged, and
the parity suite against the C++ backend confirms it rather than the argument alone.

## The second defect, which the first was hiding

`test_grid_hierarchical.cpp` captures a structured binding in a lambda. That is C++20
(P1091) and Clang 10, the declared version floor, does not implement it. So the floor claim
has been false since the same commit.

It went unseen because **one build failure masked another**: Ninja stopped at the `bvh.hpp`
errors and never compiled this file. Confirmed independent of them with `-fsyntax-only`, no
`-Werror` and no `-Wsign-conversion`, where Clang 10 still rejects it with the same three
errors.

## Verification

`scripts/ci_local.sh`, on the rebased tree, all fifteen checks of the `cxx` section:

| leg | before | after |
|---|---|---|
| GCC 14 `-Werror` | pass | pass |
| Clang 18 `-Werror` | **fail** | pass |
| `gcc-debug`, ASan + UBSan | pass | pass |
| floor `g++-10` | pass | pass |
| floor `clang++-10` | **fail** | pass |

Also: bindings built with `PANTR_BUILD_PYTHON=ON -DPANTR_WERROR=ON`, 0 errors 0 warnings;
`ci_local.sh python` 9/9 including `parity: C++ vs numba`, `full suite on python` and `full
suite on cpp`; and ruff, mypy over 279 files, import-lint, 82 doctests, coverage, docs build.

## One pre-existing failure this PR does not touch

`ci_local.sh`'s `no qualified std:: math calls` check fails at `cpp/bindings/grid.cpp:241`,
and it fails on unmodified `proto/cpp` too. The call is `std::log2(n)` where `n` is an
explicit `static_cast<double>`, which is a call on a concrete type rather than on a generic
scalar. That is the same reasoning the check uses to exempt `cpp/benchmark`, and it does not
extend that exemption to the bindings. So the defect may well be in the check rather than in
the code, which is a judgement call this PR should not make on its own.
