### PR TITLE
docs: record the four port decisions taken on 2026-08-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,9 @@ pip install -e ".[dev]"   # includes all optional feature extras
 ## License
 
 PaNTr is licensed under the MIT License. See `LICENSE` for details.
+
+A **built wheel also contains compiled [Eigen](https://gitlab.com/libeigen/eigen)
+code**, which is MPL-2.0. The MPL is copyleft per file and no pantr file falls under
+it, so the package stays MIT; `licenses/README.md` gives the clause-by-clause reading,
+what is required of us, and where to obtain Eigen's source. A source distribution
+contains no Eigen at all -- it is fetched at build time.

--- a/design/backend_parity.md
+++ b/design/backend_parity.md
@@ -38,6 +38,36 @@ The infrastructure PR measured what this is worth: an independent exact-rational
 a bug injected into **both** backends at once, by a factor of 5e14 over its bound. Nothing else
 in the suite could have.
 
+### What the oracle becomes when Numba is retired, decided 2026-08-27
+
+Every rule below compares C++ against the Python implementation with its Numba kernels
+compiled. The end state chosen on 2026-08-27 is a C++ core usable with no interpreter, which
+retires Numba, and on that day the twelve rules would have nothing left to measure against.
+The successor was decided before more porting rather than after:
+
+**Numba goes; the pure Python/NumPy implementation stays, and it is the oracle.** It remains
+*re-derivable* -- a kernel ported next year still gets an oracle, which a set of frozen
+recorded outputs could not give it -- and Rule 12 has already enumerated how that interpreted
+path differs from the compiled one, so the characterisation work is done rather than owed.
+
+Two consequences, and both are obligations rather than remarks:
+
+- **Rule 12 stops being a note about a test configuration and becomes the definition of the
+  oracle.** Its three divergences are no longer things that happen under
+  `NUMBA_DISABLE_JIT=1`; they are properties of the reference. Any bound stated against the
+  compiled oracle has to be re-read against the interpreted one before Numba is removed, and
+  Rule 12's own claim that the three are *all* of them becomes load-bearing at that moment.
+- **An oracle with no users rots silently.** Once nothing but the tests calls the Python
+  path, a defect in it is invisible until a parity test blames C++ for it. The independent
+  check in the paragraph above is what covers this, and it stops being "not optional" as a
+  matter of rigour and starts being the only thing standing between a rotted oracle and a
+  false parity failure.
+
+**Epistemic status.** The choice is ruled, not derived. That Rule 12's three divergences are
+exhaustive is *claimed* in Rule 12 and was not re-checked here; two of the three were found by
+a review rather than by the rule's author, which is the reason to re-check it rather than
+inherit it.
+
 ## Rule 1: state a bound in the frame the comparison happens in
 
 **This is the rule that was violated first and would have been violated silently.**

--- a/design/cross_backend_types.md
+++ b/design/cross_backend_types.md
@@ -1,7 +1,11 @@
 # What crosses the backend boundary, and what does not
 
-**Status:** decided. Governs every module ported after the infrastructure PR.
-**Date:** 2026-08-20.
+**Status:** the central rule is **superseded, 2026-08-27** -- see the next section. What
+survives it: the kernel-seam table, the `dtype` rule, the two catalogue rules, and the
+argument about `PointsLattice` specifically. The superseded text is kept in full below
+rather than rewritten, because the hazard it names is still real and the amendment has to
+answer it.
+**Date:** 2026-08-20, amended 2026-08-27.
 **Scope:** the contract between the Python and C++ backends: which values may cross, what
 shape a kernel entry point takes, and who owns a type. Not how the two are compared, which
 is `design/backend_parity.md`.
@@ -10,11 +14,107 @@ this note's rule generalizes; `design/automatic_differentiation.md`, for the sca
 a kernel signature has to respect.
 
 **Validated against:** pantr **0.7.0**, and the C++ prototype as merged into `proto/cpp`
-at `765d9b9`. Line numbers below refer to that tree.
+at `765d9b9`. Line numbers below refer to that tree, **except in the 2026-08-27 supersession
+section**, whose own counts and locators were taken at `proto/cpp` `83f03aa` and say so where
+they appear. The two trees are not reconciled here on purpose: a locator is only worth
+anything with the tree it was read in attached to it.
 
-## The decision
+## Superseded, 2026-08-27: the boundary moved, so the ownership moved with it
+
+**The new rule: pantr's domain types are owned by C++, and Python wraps them.**
+
+Two things this rule is *not*. It is not "some types are also implemented in C++": ownership
+moves, it is not duplicated. And it is not "the types that carry an invariant": that criterion
+would sort the domain into owned-here and owned-there and put the boundary back one class at a
+time, and the boundary is what was removed.
+
+**Where the line does fall, and it is a different axis: what the library models, against what
+makes it run.** A domain type -- `AABB`, `Grid`, `Bezier`, `QuadratureRule`, anything a user of
+either language would name when describing what pantr is for -- moves to C++, with no exception
+to argue about. A type that exists only to implement the Python binding or its dispatch stays in
+Python, because it could not move even in principle. The example to hold in mind is
+`DegreeKernels` (`src/pantr/bezier/_bezier_backend.py:114`): a `NamedTuple` whose two fields are
+references to Python kernel *functions*, selected by `_select` from the requested backend. There
+is no C++ object it could be a wrapper for; it exists so that the never-fall-back rule is applied
+in one place. Stating the line is what keeps it from becoming an unwritten exception list, which
+is the failure mode of writing the rule as unconditional.
+
+`pantr._backend`'s `Backend` and `IsaVariant` are **not** examples of this, and it is worth
+saying why, since they look like they should be: they are `IntEnum`s, and the kernel-seam table
+below already settles enums -- they cross as integers. ISA selection in particular is a question
+C++ very much has.
+
+The rule says nothing about *when* each domain type moves. That is the staging in "What the
+reversal does not license" below.
+
+### What changed
+
+This note assumed, without writing it down, that the C++ side exists in order to be called
+from Python. On 2026-08-27 that assumption was overruled: **a C++ program links pantr with
+no interpreter present.** Under the 2026-08-20 rule such a program receives kernels over raw
+arrays and nothing else, so it must reimplement validation, error reporting and every
+invariant this package already knows how to maintain -- once per consumer, in the consumer.
+That consequence was never chosen; it fell out of an assumption that has now been denied.
+
+### Why this does not reintroduce the failure the note was written to prevent
+
+The failure named in "Why the question had to be settled" is **two implementations of one
+type**, and a value produced by one being handed to the other. Reversing ownership does not
+create that, because it does not create a second implementation: it moves the single
+implementation to the far side of the seam. Python keeps exactly one class per concept, as
+it does today; that class holds a handle to the C++ object instead of holding the arrays
+itself. The `isinstance` dispatch sites keep working for the same reason -- there is still
+one Python class to dispatch on. There are **16** of them, not the "about twenty" the
+superseded text below estimates, over five files in `basis`, `bezier` and `bspline`;
+counted at `83f03aa` with `grep -rn "isinstance(.*PointsLattice" src/pantr --include=*.py`.
+
+The shape that *would* reintroduce the failure is a C++ type and a Python type maintained
+in parallel with a conversion between them. **That is forbidden**, and it is the specific
+thing to look for when reviewing any port done under this amendment.
+
+### What the reversal does not license
+
+- **It is not a licence to port a type early.** The four properties that made
+  `PointsLattice` a poor candidate -- transient, its only real method the one the design
+  already rejects, no identity, dispatched on at sixteen sites -- are properties of
+  that class, and they are unchanged. What is refuted is the *general* rule the note drew
+  from it, not the reading of the class.
+- **The kernel seam is unchanged.** A kernel entry point still takes and returns arrays,
+  sizes and status codes. The table in "The rule in the form a kernel author needs" is still
+  the contract for that seam. What the amendment adds is a layer *above* the kernels on the
+  C++ side, which did not exist when the table was written.
+- **It does not settle the staging order.** Ownership moves module by module as each module
+  is ported, and a module not yet ported keeps its Python-owned type until it is.
+
+### What it costs
+
+Measured on `proto/cpp` at `83f03aa`, by `grep -rn "^class [A-Z]" src/pantr --include=*.py`:
+**36 classes in the package, 33 outside `mpi` and `viz`**, of which **14 fall inside the
+Stage 1 scope** (`geometry` 1, `grid` 8, `quad` 2, `transform` 1, `bezier` 2; `change_basis`
+has none). `bspline`, at 12, is the largest single block and is untouched.
+
+None of Layer 1 or Layer 2 is ported today: what exists in C++ is kernels. So the amendment
+converts an unstarted layer into the main body of remaining work, and it should be read as
+enlarging the port rather than redirecting it.
+
+### Epistemic status of this amendment
+
+- **Ruled**, 2026-08-27: that a C++ consumer must work with no interpreter. That is the
+  input, not a finding.
+- **Derived**: that ownership therefore moves to C++ rather than being duplicated. The
+  derivation is the paragraph above -- the original note's own hazard admits only one
+  implementation, and the ruling requires that one to be reachable without Python.
+- **Not yet demonstrated**: that a Python class wrapping a C++ handle preserves the sixteen
+  `isinstance` sites and the pickling behaviour they sit next to. Nothing has been built.
+  The first ported type is where this gets tested, and if it fails, this amendment is what
+  should be revisited rather than worked around.
+
+## The decision (superseded 2026-08-27; see the section above)
 
 **Types are owned by Python. Only arrays and scalars cross the boundary.**
+
+> This rule no longer holds. It is kept verbatim because the amendment above answers it
+> point by point, and because the reasoning under it about `PointsLattice` still stands.
 
 There is no `pantr::PointsLattice`, no `pantr::QuadratureRule`, and no C++ counterpart of
 any other pantr class. A binding takes the arrays a Python object already holds and hands

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -51,13 +51,21 @@ rather than a certainty.
 **If Eigen is ever patched in place** rather than consumed as an upstream pin, the
 patched files stay MPL-2.0 and must ship as source. Nothing does that today.
 
-## Left alone deliberately
+## The metadata question, settled 2026-08-27
 
 `pyproject.toml` declares `license = "MIT"`, which is accurate for pantr's own code
-and is what the MPL requires nothing of. An argument exists for `MIT AND MPL-2.0` on
+and is what the MPL requires nothing of. An argument existed for `MIT AND MPL-2.0` on
 a wheel that carries both compiled in, and an argument against, since it would
 suggest to downstream tooling that pantr propagates copyleft when its file-level
-scope means it does not. That is a metadata-precision question rather than a
-compliance one, and it is not a port's to settle.
+scope means it does not. It is a metadata-precision question rather than a compliance
+one, and it was left open because it is not a port's to settle.
+
+**Decided: the declaration stays `MIT`, and what the wheel contains is documented
+instead.** Two places carry it, so that neither a reader of the repository nor a
+reader of the installed package has to find this file by accident: the README's
+License section links here, and `license-files` ships this directory inside the
+wheel. The known cost of the choice is stated rather than assumed away -- an
+automated licence auditor reading only the `license` field sees MIT and does not see
+that MPL-2.0 object code is linked in. That is the reason the two pointers exist.
 
 None of this is legal advice.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,14 @@ cmake.define.PANTR_WERROR = "ON"
 # lands under site-packages/lib/cmake where CMake does not look. Whether a pip
 # install should also ship the C++ package is a separate decision from having
 # install rules at all.
+#
+# Decided 2026-08-27: it stays OFF, and the two audiences are served by two routes.
+# pip serves the Python consumer; a C++ consumer takes pantr through a CMake install
+# (later, a conda package). The deciding fact is that the exported target carries a
+# hard `find_dependency(Eigen3)` and the wheel does not carry Eigen, so a
+# wheel-shipped `find_package(pantr)` would fail on any machine that has not
+# installed Eigen separately -- which is the default for someone installing by pip.
+# Shipping headers that cannot be configured against is worse than not shipping them.
 cmake.define.PANTR_INSTALL = "OFF"
 # Keep the symbol table in the INSTALLED extension. This prototype exists to be
 # measured, and a stripped module gives `perf` nothing to attribute time to and a


### PR DESCRIPTION
## Context

Four strategic questions had been sitting open on this branch, none of them
technical enough for a port PR to settle in passing. They are now decided and this
PR is only the record: no code changes, no test changes.

## What is decided

**1. Type ownership reverses (`design/cross_backend_types.md`).** The note was marked
*decided, 2026-08-20* and said types are owned by Python, with no C++ counterpart of
any pantr class. The ruling that a C++ program must link pantr with no interpreter
present contradicts it — under the old rule such a program gets kernels over raw
arrays and must reimplement validation, error reporting and every invariant, once per
consumer.

The new rule: **pantr's domain types are owned by C++, and Python wraps them.**
Ownership *moves*; it is not duplicated, because the note's own hazard — two
implementations of one type — admits only one. The line falls on what the library
models against what makes it run, not on which types carry an invariant; the latter
criterion would put the boundary back one class at a time. `DegreeKernels` is the
worked example of the far side.

The superseded text is kept verbatim with its heading marked. Its reading of
`PointsLattice` specifically is unaffected and still argues against porting that
class early.

**2. The oracle survives Numba (`design/backend_parity.md`).** All twelve rules
compare C++ against the Python implementation with Numba compiled; retiring Numba
would leave them nothing to measure against. Decided: **Numba goes, the pure
Python/NumPy implementation stays and is the oracle** — it remains re-derivable,
which frozen recorded outputs would not be. Two obligations are written down: Rule 12
becomes the *definition* of the oracle rather than a note about a test configuration,
so its exhaustiveness claim becomes load-bearing and must be re-checked; and an oracle
with no users rots silently, which promotes the independent accuracy check from rigour
to necessity.

**3. Licence metadata (`licenses/README.md`, `README.md`).** The clause-by-clause
MPL-2.0 reading was already there; only the metadata question was open. The
declaration **stays `MIT`**, and what a built wheel contains is documented instead.
The known cost is stated rather than assumed away: an auditor reading only the
`license` field sees MIT and not the linked MPL-2.0 object code. Hence two pointers —
the README's License section, and `license-files`, which already ships that directory
inside the wheel.

**4. The wheel does not ship the C++ package (`pyproject.toml`).** `PANTR_INSTALL`
stays OFF. The deciding fact: `cmake/pantrConfig.cmake.in` carries a hard
`find_dependency(Eigen3)` and the wheel carries no Eigen, so a wheel-shipped
`find_package(pantr)` would fail on any machine without a separately installed Eigen —
the default for someone installing by pip. Shipping headers that cannot be configured
against is worse than not shipping them.

## Numbers, remeasured rather than inherited

Taken at `83f03aa`, with the commands in the note:

- 36 classes in the package, 33 outside `mpi` and `viz`, **14 inside the Stage 1
  scope** (`grid` 8, `quad` 2, `bezier` 2, `geometry` 1, `transform` 1,
  `change_basis` 0). `bspline`'s 12 is the largest untouched block.
- The `isinstance(PointsLattice)` sites are **16**, not the "about twenty" the
  superseded text estimates. The discrepancy is stated in the amendment rather than
  quietly corrected.

Three errors of my own were caught while drafting and are worth naming, since none
would have been caught by a suite: the headline rule first read *"a type that carries
an invariant"*, which is the criterion that had been rejected; "unconditional" was
then demonstrably false against `DegreeKernels`; and `Backend`/`IsaVariant` were cited
as dispatch plumbing when they are `IntEnum`s already settled by the kernel-seam
table, ISA selection being very much a question C++ has.

## Non-goals

Nothing is implemented. The amendment records as **not yet demonstrated** that a
Python class wrapping a C++ handle preserves the 16 `isinstance` sites and the
pickling behaviour they sit next to. The first ported type is where that gets tested.

## Verification

`make pre-pull-request` in full: ruff check and format over 304 files, mypy,
import-lint, **6231 tests passed** (1174 skipped, 3 xfailed), doctests, and the docs
build. `pyproject.toml` re-parsed with its values unchanged (`license = "MIT"`,
`PANTR_INSTALL = "OFF"`).
