### PR TITLE
fix(transform): pickle the affine map by its arrays, not its handle

### DIFF
--- a/src/pantr/transform.py
+++ b/src/pantr/transform.py
@@ -792,6 +792,23 @@ class AffineTransform:
         impl.apply(flat, out)
         return out.reshape(pts.shape)
 
+    def __reduce__(self) -> tuple[type[AffineTransform], tuple[npt.NDArray[np.float64], ...]]:
+        """Pickle by matrix and offset rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire
+        format: a pickle written with the C++ backend has to load under the
+        Python one and the other way round, or the backend switch would silently
+        become a data-format switch. This is also the route ``copy.deepcopy``
+        takes, which is how a grid holding a reference map gets copied.
+
+        The cached ``inverse`` is deliberately not carried: it is a memo over
+        the two arrays below, so the reconstructed map recomputes it on demand.
+
+        Returns:
+            tuple: The class and the ``(matrix, offset)`` pair to rebuild it from.
+        """
+        return (type(self), (self.matrix, self.offset))
+
     def __repr__(self) -> str:
         """Return a developer-friendly string representation.
 

--- a/tests/parity/test_transform_affine.py
+++ b/tests/parity/test_transform_affine.py
@@ -53,6 +53,8 @@ trigonometry**, and each test says which it is.
 
 from __future__ import annotations
 
+import copy
+import pickle
 from typing import Any
 
 import numpy as np
@@ -601,3 +603,27 @@ def test_the_wrapper_is_backend_invariant() -> None:
     assert repr(py_map) == repr(cpp_map)
     assert not hasattr(AffineTransform, "__eq__") or AffineTransform.__eq__ is object.__eq__
     assert py_map != cpp_map, "identity comparison must survive the port"
+
+
+def test_a_transform_survives_pickling_under_either_backend() -> None:
+    """A pickle written under one backend loads under the other.
+
+    The C++ handle is not picklable and must not reach the wire format, or the
+    backend switch would silently become a data-format switch. ``AABB`` states
+    that contract at :meth:`pantr.geometry.AABB.__reduce__` and this map owes
+    the same one: ``Grid.reference_map`` returns an ``AffineTransform``, and
+    ``copy.deepcopy`` reaches ``__reduce_ex__`` by the same route pickling does.
+    """
+    matrix = [[2.0, 0.0], [0.0, 0.5]]
+    translation = [1.0, 2.0]
+    for writer in (Backend.PYTHON, Backend.CPP):
+        with use_backend(writer):
+            payload = pickle.dumps(AffineTransform(matrix, translation))
+            round_tripped = copy.deepcopy(AffineTransform(matrix, translation))
+        assert np.array_equal(round_tripped.matrix, matrix)
+        assert np.array_equal(round_tripped.offset, translation)
+        for reader in (Backend.PYTHON, Backend.CPP):
+            with use_backend(reader):
+                loaded = pickle.loads(payload)
+            assert np.array_equal(loaded.matrix, matrix), f"{writer.name} -> {reader.name}"
+            assert np.array_equal(loaded.offset, translation), f"{writer.name} -> {reader.name}"


### PR DESCRIPTION
## Context

Under the C++ backend, pickling or deep-copying an `AffineTransform` raised

```
TypeError: cannot pickle 'pantr._pantr_cpp.AffineTransform' object
    when serializing dict item '_impl'
```

Under the Python backend the same call succeeded. So the backend switch was silently a
data-format switch, which is the thing `AABB.__reduce__` exists to prevent and says so in
its own docstring.

No binding registers pickle support — there is no `nb::pickle`, `__getstate__` or
`__setstate__` anywhere in `cpp/bindings/` — so the default path reached the nanobind handle
held in `_impl`. `AABB` works around that by serializing through its corner arrays;
`AffineTransform` had no `__reduce__` at all, and nothing tested for one.

It is not a hypothetical gap. `Grid.reference_map()` returns an `AffineTransform`, and
`copy.deepcopy` reaches `__reduce_ex__` by the same route pickling does — `pantr.bspline`
deep-copies a grid in two places today. Once grids are C++-owned, that copy walks into this.

## Specification

`AffineTransform.__reduce__` returns `(type(self), (self.matrix, self.offset))`, mirroring
`AABB.__reduce__`: the constructor's own arguments, never the implementation handle. The
cached `inverse` is deliberately not carried — it is a memo over those two arrays, so a
reconstructed map recomputes it on demand.

## Acceptance

- `test_a_transform_survives_pickling_under_either_backend` round-trips **every**
  writer/reader backend pair, not just the crashing one: the property that was broken is
  cross-backend interchange, and the `TypeError` was only how it surfaced. It also covers
  `copy.deepcopy`, which is the path a grid copy takes.
- Verified failing before the fix, for the stated reason (`when serializing dict item
  '_impl'`), and passing after.
- Full suite green locally with the extension built: ruff, ruff format, mypy (284 files),
  import-lint (2 contracts kept), 7471 passed / 39 skipped / 7 xfailed, docs build under
  `-W`.

## Non-goals

- No pickle support is added to the bindings. The wrapper is the right layer: a pickle must
  load under either backend, so the wire format cannot be a C++ handle in the first place.
- `AffineTransform` still has no `__eq__` and no `__hash__`. The oracle has neither, and
  `cpp/bindings/transform.cpp` argues that a port reproduces its oracle including the
  operations it does not offer. Unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
