### PR TITLE
feat(bezier): own the Bezier value type in C++ and wrap it from Python

### DIFF
--- a/cpp/bindings/bezier_type.cpp
+++ b/cpp/bindings/bezier_type.cpp
@@ -1,15 +1,126 @@
 /// \file
-/// nanobind bindings for the `pantr::bezier::Bezier` type -- reserved, empty.
+/// nanobind bindings for `pantr::bezier::Bezier`.
 ///
-/// The module's three assembly points (`pantr_cpp.cpp`, `register.hpp` and
-/// `CMakeLists.txt`) are edited once, here, so the ticket that ports the type
-/// edits this file and nothing else. Thirteen tickets in this milestone would
-/// otherwise collide on those three.
+/// ## Two registrations, not one
+///
+/// `AABB` and `AffineTransform` are bound at `double` only, because their Python
+/// oracles coerce everything to `float64` and a `float` registration would be a
+/// surface with no oracle behind it. `pantr.bezier.Bezier` is different in exactly
+/// that respect: it stores whatever float dtype it is handed, its `dtype` property
+/// is public, `tests/test_bezier.py::TestBezierInit::test_float32` pins the
+/// behaviour, and `tools/adversarial_sweep/_probes_bezier.py` sweeps both formats.
+/// So both are registered, as `Bezier32` and `Bezier64`, and
+/// `pantr.bezier._impl_class` picks between them by dtype.
+///
+/// The two names carry the storage format because there is nothing else to carry
+/// it: the class of the handle *is* the dtype, and a single `Bezier` name would
+/// have to smuggle the format through a constructor argument that could then
+/// disagree with the array it was given.
+///
+/// ## What this file validates, and what it does not
+///
+/// Nothing, beyond what nanobind's typed parameters settle for it -- dtype,
+/// C-contiguity and device. `Bezier` and `ControlNet` validate their own arguments
+/// and throw `std::invalid_argument`, which nanobind surfaces as `ValueError`, the
+/// exception the oracle raises for the same inputs. Duplicating the checks here
+/// would put a second copy of the contract in a second language, which is the
+/// shape this port exists to avoid.
+///
+/// The rank of the array is deliberately unconstrained. A Bézier is a curve, a
+/// surface or a volume, so its control points have any rank from 1 upward, and a
+/// rank-0 array is rejected by `ControlNet` with the oracle's own message rather
+/// than by a caster with a message about C++ types.
+///
+/// The dtype is not converted, and that *is* a check. Without `.noconvert()`
+/// nanobind silently casts, so `Bezier32(a_float64_array)` would narrow the
+/// caller's geometry and `Bezier64(a_float32_array)` would widen it, both without
+/// a word -- and the class name is the only thing carrying the storage format, so
+/// there would be nothing left to notice with. Refusing the cast makes
+/// `pantr.bezier._impl_class` picking the wrong class a loud failure instead of a
+/// quiet change of precision. The cost is that the caller owes a C-contiguous
+/// array of the right dtype, which the wrapper already produces.
+///
+/// ## `control_points` is a view, and read-only
+///
+/// The two merged ports copy their corner arrays out, because a corner is a
+/// handful of doubles. A control net is not: it is the whole geometry, read on
+/// every evaluation, and copying it per property access would make the natural
+/// spelling of every operation quadratic in nothing.
+///
+/// So the array returned here views the Bézier's own storage, with the Bézier as
+/// its owner, and is read-only because the scalar type is `const T` -- nanobind
+/// passes `std::is_const_v<Scalar>` straight into the array's writeable flag. Both
+/// halves are load-bearing. The owner is what keeps the storage alive when the
+/// array outlives the handle it came from; the read-only flag is what stops a
+/// caller mutating a validated geometry from the outside, which is the half of
+/// FELIGN/pantr#338's defect that lives on the way *out*.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "pantr/bezier/bezier.hpp"
 #include "register.hpp"
 
-void register_bezier_type(nanobind::module_&) {
-    // Nothing yet: the port adds the `nanobind::class_` for the type here.
+namespace nb = nanobind;
+
+namespace {
+
+/// A read-only, contiguous array of any rank as nanobind sees it.
+template <class T>
+using const_nd = nb::ndarray<const T, nb::c_contig, nb::device::cpu>;
+
+/// Register one scalar type's `Bezier`.
+///
+/// \param m The extension module.
+/// \param name The Python-visible class name, `Bezier32` or `Bezier64`.
+template <class T>
+void bind_bezier(nb::module_& m, const char* name) {
+    using Bez = pantr::bezier::Bezier<T>;
+    using Net = pantr::bezier::ControlNet<T>;
+
+    nb::class_<Bez>(m, name)
+        .def(
+            "__init__",
+            [](Bez* self, const_nd<T> control_points, bool is_rational) {
+                std::vector<std::size_t> shape(control_points.ndim());
+                for (std::size_t d = 0; d < shape.size(); ++d) {
+                    shape[d] = control_points.shape(d);
+                }
+                new (self) Bez(Net(std::span<const T>(control_points.data(),
+                                                      control_points.size()),
+                                   std::span<const std::size_t>(shape)),
+                               is_rational);
+            },
+            nb::arg("control_points").noconvert(), nb::arg("is_rational") = false)
+        .def_prop_ro("control_points",
+                     [](nb::handle self) {
+                         const Bez& b = nb::cast<const Bez&>(self);
+                         const std::span<const std::size_t> shape = b.net().shape();
+                         return nb::ndarray<nb::numpy, const T>(b.net().values().data(),
+                                                                shape.size(), shape.data(), self);
+                     })
+        .def_prop_ro("is_rational", &Bez::is_rational)
+        .def_prop_ro("dim", &Bez::dim)
+        .def_prop_ro("rank", &Bez::rank)
+        // A tuple rather than a list, because the oracle's `degree` is a tuple and
+        // a caller comparing `b.degree == (2, 3)` must not start failing under the
+        // C++ backend.
+        .def_prop_ro("degree", [](const Bez& b) {
+            nb::list degrees;
+            for (const std::size_t p : b.degree()) {
+                degrees.append(p);
+            }
+            return nb::tuple(degrees);
+        });
+}
+
+}  // namespace
+
+void register_bezier_type(nb::module_& m) {
+    bind_bezier<float>(m, "Bezier32");
+    bind_bezier<double>(m, "Bezier64");
 }

--- a/cpp/include/pantr/bezier/bezier.hpp
+++ b/cpp/include/pantr/bezier/bezier.hpp
@@ -1,25 +1,168 @@
 #pragma once
 
 /// \file
-/// Compatibility forwarder for the old name of `pantr/bezier/kernels_1d.hpp`.
+/// The Bézier value type, and the compatibility forwarder for the old name of
+/// `pantr/bezier/kernels_1d.hpp`.
 ///
-/// The kernels moved because this directory is about to gain a `Bezier` *type*,
-/// and two headers called `bezier` in one directory is a trap: a reader cannot
-/// tell from an include line which of the two a translation unit meant.
+/// ## Two things in one file, on purpose
 ///
-/// This file stays because the header set is a promise. The top-level
-/// `CMakeLists.txt` installs `cpp/include/pantr` wholesale and exports a findable
-/// package with `COMPATIBILITY SameMinorVersion`, so an already-installed
-/// consumer including this path must keep compiling until someone decides
-/// otherwise. `cpp/consumer/main.cpp` includes it for exactly that reason, which
-/// is what stops this file from being deleted by accident.
+/// The kernels that used to live here moved to `kernels_1d.hpp` so that this name
+/// could hold the *type*. The include below stays because the header set is a
+/// promise: the top-level `CMakeLists.txt` installs `cpp/include/pantr` wholesale
+/// and exports a findable package with `COMPATIBILITY SameMinorVersion`, so an
+/// already-installed consumer including this path must keep getting the kernels
+/// until someone decides otherwise. `cpp/consumer/main.cpp` includes it for
+/// exactly that reason, which is what stops the forwarding include from being
+/// deleted by accident.
 ///
-/// **It is scaffolding.** What removes it is a deliberate decision to break the
-/// installed header set -- a major version, or a note in the release that the old
-/// path is gone. Nothing in the tree should include it: in-tree code includes
-/// `pantr/bezier/kernels_1d.hpp` directly.
+/// **The forwarding include is scaffolding.** What removes it is a deliberate
+/// decision to break the installed header set -- a major version, or a note in the
+/// release that the old path no longer carries the kernels. In-tree code that
+/// wants a kernel includes `pantr/bezier/kernels_1d.hpp` directly; in-tree code
+/// that wants the type includes this file and gets the kernels it did not ask for
+/// as a side effect until that day.
 ///
 /// Note that the namespace moved with the file, from `pantr` to `pantr::bezier`.
 /// This header forwards the *path*, not the old spelling of the names.
+///
+/// ## What this type owns, and what it does not
+///
+/// It owns the *value*: the control net and the rationality flag, plus the
+/// quantities they determine -- `dim`, `degree` and `rank`. It owns no operations.
+/// Evaluation, degree elevation and reduction, the shape operations and the
+/// product are four separate ports over free functions taking a `const Bezier&`,
+/// which is what lets them proceed independently of one another once this type
+/// exists.
+///
+/// ## Validating rather than asserting
+///
+/// `pantr/core/precondition.hpp` says a Layer 3 kernel asserts, and that the
+/// bindings are where a *user* is protected. Both stay true: this is not a kernel
+/// but the C++ counterpart of Layer 2, so it validates and throws
+/// `std::invalid_argument` in a release build as much as a debug one. A caller
+/// with no Python cannot be protected by `cpp/bindings/`.
+///
+/// ## Parity notes for the Python oracle
+///
+/// `pantr.bezier.Bezier` is the oracle. Three things it does that this type
+/// reproduces, and one it does that this type deliberately does not:
+///
+///  - **The rank check counts the weight column out, and can report a negative
+///    number.** The oracle computes `rank = shape[-1] - 1` for a rational
+///    geometry and rejects `rank <= 0`, so a rational net with no components at
+///    all is reported as `rank -1`. The arithmetic here is signed for that reason
+///    alone.
+///  - **The order of the checks is the oracle's:** shape first, in `ControlNet`,
+///    rank second. Two simultaneously bad arguments must produce the same message
+///    on both sides, and only the order decides which one they get.
+///  - **The messages are the oracle's, character for character.**
+///    `tests/parity/test_bezier_type.py` asserts it.
+///  - **It copies the control points; the oracle does not.** The oracle stores the
+///    caller's array and hands the same object back from `control_points`, so a
+///    caller can mutate a constructed Bézier through either end. That is a defect
+///    of the oracle -- the same shape as FELIGN/pantr#338 -- and this type does not
+///    reproduce it. Fixing it on the Python side is FELIGN/pantr#375; until then
+///    the two backends differ there, deliberately and in the safe direction.
 
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bezier/control_net.hpp"
 #include "pantr/bezier/kernels_1d.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bezier {
+
+/// A Bézier curve, surface or volume over `[0, 1]^dim`.
+///
+/// Holds a control net and nothing else but a flag. The polynomial degree in each
+/// parametric direction is *inferred*: `degree(d) == net().extent(d) - 1`. For a
+/// rational Bézier the last component of every coefficient is a homogeneous
+/// weight and the coordinates are stored weighted, so `rank()` is one less than
+/// the net's component count.
+///
+/// Instances are immutable: no operation changes an existing Bézier, and every
+/// derived one is returned by value.
+template <Real T>
+class Bezier {
+  public:
+    /// Build a Bézier from a control net, validating its rank.
+    ///
+    /// \param net The control points; moved in.
+    /// \param is_rational Whether the last component of each coefficient is a
+    ///        homogeneous weight.
+    /// \throws std::invalid_argument If the resulting rank is not at least 1.
+    Bezier(ControlNet<T> net, bool is_rational)
+        : net_(std::move(net)), is_rational_(is_rational) {
+        const std::ptrdiff_t rank = signed_rank();
+        if (rank <= 0) {
+            throw std::invalid_argument("The Bézier must have at least rank one. Got rank "
+                                        + std::to_string(rank) + ".");
+        }
+    }
+
+    /// The control points.
+    ///
+    /// \return The stored net, valid while the Bézier lives.
+    [[nodiscard]] const ControlNet<T>& net() const noexcept { return net_; }
+
+    /// Whether the last component of each coefficient is a homogeneous weight.
+    ///
+    /// \return `true` for a rational Bézier.
+    [[nodiscard]] bool is_rational() const noexcept { return is_rational_; }
+
+    /// The number of parametric directions.
+    ///
+    /// \return `net().dim()`, at least 1.
+    [[nodiscard]] std::size_t dim() const noexcept { return net_.dim(); }
+
+    /// The polynomial degree in every parametric direction.
+    ///
+    /// \return One degree per direction, `net().extent(d) - 1`. Never empty, and
+    ///         no entry underflows, because `ControlNet` rejects a zero extent.
+    [[nodiscard]] std::vector<std::size_t> degree() const {
+        std::vector<std::size_t> degrees(dim());
+        for (std::size_t d = 0; d < dim(); ++d) {
+            degrees[d] = net_.shape()[d] - 1;
+        }
+        return degrees;
+    }
+
+    /// The polynomial degree in one parametric direction.
+    ///
+    /// \param d The direction, in `[0, dim())`.
+    /// \return `net().extent(d) - 1`.
+    /// \throws std::out_of_range If `d >= dim()`.
+    [[nodiscard]] std::size_t degree(std::size_t d) const { return net_.extent(d) - 1; }
+
+    /// The number of value components a caller sees.
+    ///
+    /// The weight column of a rational Bézier is not one of them: a rational curve
+    /// in the plane stores three components and has rank 2.
+    ///
+    /// \return `net().num_components()`, less one when rational. At least 1.
+    [[nodiscard]] std::size_t rank() const noexcept {
+        return static_cast<std::size_t>(signed_rank());
+    }
+
+  private:
+    /// The rank, before it is known to be positive.
+    ///
+    /// Split out so that the constructor's check and the public accessor cannot
+    /// drift apart: the accessor's cast to `std::size_t` is sound only because the
+    /// constructor rejected everything this can return that is not positive.
+    ///
+    /// \return The component count less the weight column, possibly negative.
+    [[nodiscard]] std::ptrdiff_t signed_rank() const noexcept {
+        return static_cast<std::ptrdiff_t>(net_.num_components())
+               - (is_rational_ ? std::ptrdiff_t{1} : std::ptrdiff_t{0});
+    }
+
+    ControlNet<T> net_;  ///< The control points, owned.
+    bool is_rational_;   ///< Whether the last component is a homogeneous weight.
+};
+
+}  // namespace pantr::bezier

--- a/cpp/include/pantr/bezier/control_net.hpp
+++ b/cpp/include/pantr/bezier/control_net.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+/// \file
+/// The control-point array of a tensor-product geometry, and the shape questions
+/// it answers.
+///
+/// ## Why this is a type and not just a vector plus a shape
+///
+/// A control net is `(*num_basis, num_components)`: one coefficient per
+/// tensor-product index, each of `num_components` scalars, laid out row-major so
+/// that the last axis is contiguous. Every consumer needs the same four answers
+/// from it -- how many parametric directions, how long each one is, how many
+/// components, and how many coefficients in total -- and every one of them is a
+/// subtraction or a product away from being wrong in a way that walks off the
+/// allocation. Answering them once, beside the storage, is the whole of this
+/// type's job.
+///
+/// It is deliberately *not* a Bézier. Nothing here knows what the extents mean:
+/// for `pantr::bezier::Bezier` an extent is `degree + 1`, for a B-spline it is a
+/// basis count, and neither reading belongs to the array. `degree()` therefore
+/// lives on `Bezier` and `extent()` lives here.
+///
+/// ## Parity notes for the Python oracle
+///
+/// Two conveniences of `pantr.bezier.Bezier.__init__` are reproduced here rather
+/// than in the Python wrapper, so that both languages meet one definition of what
+/// a well-formed control net is:
+///
+///  - **A rank-1 shape `(n,)` is read as `(n, 1)`.** The oracle spells this
+///    `cp[:, np.newaxis]` and documents it as "a 1D input of shape `(n,)` is
+///    reshaped to `(n, 1)` (scalar field)". A C++ caller building a scalar curve
+///    from a flat vector of coefficients wants exactly the same reading.
+///  - **The two rejections carry the oracle's messages verbatim.** A rank-0 shape
+///    and a zero-length parametric direction are the two the oracle raises, and
+///    `tests/parity/test_bezier_type.py` asserts the text of both matches
+///    character for character. Rewording one of them is a parity failure, not a
+///    style change.
+///
+/// The oracle has no counterpart for the values-against-shape consistency check
+/// below, and cannot: a numpy array's data and shape agree by construction. It is
+/// here for the caller that has no numpy.
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bezier {
+
+/// The control points of a tensor-product geometry, owned by value.
+///
+/// Stores `size()` scalars in row-major order under the shape
+/// `(extent(0), ..., extent(dim() - 1), num_components())`. Instances are
+/// immutable: nothing here changes a net once it is built, and every derived net
+/// is a new object.
+///
+/// The stored copy is the point. A net built from a caller's buffer does not
+/// alias it, so no later write through that buffer can change a geometry that has
+/// already been validated.
+template <Real T>
+class ControlNet {
+  public:
+    /// Build a net from a flat coefficient buffer and its shape, validating both.
+    ///
+    /// \param values The coefficients, row-major, `prod(shape)` of them.
+    /// \param shape The extents; the last is the component count. A rank-1 shape
+    ///        `(n,)` is read as `(n, 1)`.
+    /// \throws std::invalid_argument If `shape` is empty, if any parametric
+    ///         extent is zero, or if `values` does not have `prod(shape)` entries.
+    ControlNet(std::span<const T> values, std::span<const std::size_t> shape)
+        : values_(values.begin(), values.end()), shape_(shape.begin(), shape.end()) {
+        if (shape_.empty()) {
+            throw std::invalid_argument("Control points must be at least 1D.");
+        }
+        if (shape_.size() == 1) {
+            shape_.push_back(1);
+        }
+        for (std::size_t d = 0; d + 1 < shape_.size(); ++d) {
+            if (shape_[d] < 1) {
+                throw std::invalid_argument(
+                    "Control points must have at least 1 entry in parametric direction "
+                    + std::to_string(d) + ", got " + std::to_string(shape_[d]) + ".");
+            }
+        }
+        std::size_t expected = 1;
+        for (const std::size_t extent : shape_) {
+            expected *= extent;
+        }
+        if (values_.size() != expected) {
+            throw std::invalid_argument("Control points hold " + std::to_string(values_.size())
+                                        + " values, but the shape asks for "
+                                        + std::to_string(expected) + ".");
+        }
+    }
+
+    /// The coefficients, row-major.
+    ///
+    /// \return A view of the stored values, valid while the net lives.
+    [[nodiscard]] std::span<const T> values() const noexcept { return values_; }
+
+    /// The shape, `(extent(0), ..., extent(dim() - 1), num_components())`.
+    ///
+    /// \return A view of the stored shape, valid while the net lives. Always at
+    ///         least two entries long.
+    [[nodiscard]] std::span<const std::size_t> shape() const noexcept { return shape_; }
+
+    /// The number of parametric directions.
+    ///
+    /// \return `shape().size() - 1`, at least 1.
+    [[nodiscard]] std::size_t dim() const noexcept { return shape_.size() - 1; }
+
+    /// The extent along one parametric direction.
+    ///
+    /// \param d The direction, in `[0, dim())`.
+    /// \return The number of coefficients along `d`.
+    /// \throws std::out_of_range If `d >= dim()`.
+    [[nodiscard]] std::size_t extent(std::size_t d) const {
+        if (d >= dim()) {
+            throw std::out_of_range("ControlNet.extent: direction " + std::to_string(d)
+                                    + " is out of range for dim " + std::to_string(dim()) + ".");
+        }
+        return shape_[d];
+    }
+
+    /// The length of the component axis, weights included.
+    ///
+    /// This is the *stored* width. `pantr::bezier::Bezier::rank` is the width a
+    /// caller sees, which is one less for a rational geometry.
+    ///
+    /// \return `shape().back()`.
+    [[nodiscard]] std::size_t num_components() const noexcept { return shape_.back(); }
+
+    /// The total number of stored scalars.
+    ///
+    /// \return `values().size()`, which equals the product of the shape.
+    [[nodiscard]] std::size_t size() const noexcept { return values_.size(); }
+
+  private:
+    std::vector<T> values_;             ///< Coefficients, row-major.
+    std::vector<std::size_t> shape_;    ///< Extents, at least two of them.
+};
+
+}  // namespace pantr::bezier

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ set(PANTR_TEST_SOURCES
     test_grid_bvh.cpp
     test_grid_hierarchical.cpp
     test_aabb.cpp
-    test_affine.cpp)
+    test_affine.cpp
+    test_bezier_type.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -41,7 +42,6 @@ set(PANTR_PLACEHOLDER_TEST_SOURCES
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp
     test_quad_rule.cpp
-    test_bezier_type.cpp
     test_bezier_evaluate.cpp
     test_bezier_degree.cpp
     test_bezier_shape.cpp

--- a/cpp/tests/test_bezier_type.cpp
+++ b/cpp/tests/test_bezier_type.cpp
@@ -1,17 +1,193 @@
 /// \file
-/// Reserved slot for the pantr::bezier::Bezier type tests -- no assertions yet.
+/// Properties of the Bézier value type and its control net.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// ## Why these cases and not others
+///
+/// Nothing here computes: the type stores coefficients and answers a handful of
+/// questions about their shape. So there is no forward-error budget and no
+/// tolerance -- every assertion below is exact, and a tolerance would be hiding
+/// something rather than allowing for it. The cases are chosen for what they would
+/// catch:
+///
+///  - **Validation, with its message.** The type is the C++ counterpart of Layer
+///    2, so a caller with no Python is protected by these throws and nothing else.
+///    The messages are asserted verbatim rather than merely "it threw", because
+///    they are also the Python oracle's messages and
+///    `tests/parity/test_bezier_type.py` compares the two character for character.
+///    A reworded message here is a parity failure that a test asserting only the
+///    exception *type* would not notice.
+///  - **The rank arithmetic around the weight column.** Three shapes give a rank
+///    of zero or less, each reaching it differently: no components at all, one
+///    component consumed by the weight, and a rational net with no components,
+///    which the oracle reports as `rank -1`. That last one is the whole reason the
+///    subtraction is signed; an unsigned one would still reject the input while
+///    reporting a number near 2^64, and only an assertion on the text catches a
+///    wrong message on a correct verdict.
+///  - **The rank-1 shape promotion.** `(n,)` means the scalar field `(n, 1)`, and
+///    getting it wrong turns a degree-`n-1` curve into a degree-0 one in silence.
+///  - **The copy at construction.** This is the defect of the oracle that the port
+///    does not reproduce, so it is asserted rather than assumed: writing through
+///    the caller's buffer after construction must not move the stored net.
+///  - **Both scalar types.** `float32` is a supported storage format for a pantr
+///    Bézier, unlike for `AABB`, so the type is exercised at `float` too.
 
-#include <cstdio>
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/bezier/bezier.hpp"
+
+namespace {
+
+using pantr::bezier::Bezier;
+using pantr::bezier::ControlNet;
+
+/// Build a control net from a coefficient list and a shape, for brevity below.
+///
+/// \param values The coefficients, row-major.
+/// \param shape The extents.
+/// \return The net.
+template <class T>
+ControlNet<T> net(std::vector<T> values, std::vector<std::size_t> shape) {
+    return ControlNet<T>(std::span<const T>(values), std::span<const std::size_t>(shape));
+}
+
+/// The message of the `std::invalid_argument` that `fn` throws.
+///
+/// Returns a marker rather than asserting, so that the caller's own check is the
+/// one that reports and a failure names the case it came from.
+///
+/// \param fn The call to attempt.
+/// \return The exception's `what()`, or a marker saying what happened instead.
+template <class F>
+std::string message_of(F&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& e) {
+        return e.what();
+    } catch (...) {
+        return "<threw something other than std::invalid_argument>";
+    }
+    return "<did not throw>";
+}
+
+/// Whether calling `fn` throws `std::out_of_range`.
+///
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class F>
+bool throws_out_of_range(F&& fn) {
+    try {
+        fn();
+    } catch (const std::out_of_range&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+void check_shape_validation() {
+    PANTR_CHECK(message_of([] { (void)net<double>({}, {}); })
+                == "Control points must be at least 1D.");
+
+    // The parametric directions are checked; the component axis is not, and must
+    // not be -- a zero component count is the rank check's to report, with a
+    // message of its own.
+    PANTR_CHECK(message_of([] { (void)net<double>({}, {0, 2}); })
+                == "Control points must have at least 1 entry in parametric direction 0, got 0.");
+    PANTR_CHECK(message_of([] { (void)net<double>({}, {2, 0, 3}); })
+                == "Control points must have at least 1 entry in parametric direction 1, got 0.");
+
+    // No oracle counterpart: a numpy array's data and shape agree by
+    // construction, so only a caller without numpy can reach this one.
+    PANTR_CHECK(message_of([] { (void)net<double>({1.0, 2.0}, {3, 1}); })
+                == "Control points hold 2 values, but the shape asks for 3.");
+}
+
+void check_rank_validation() {
+    PANTR_CHECK(message_of([] { (void)Bezier<double>(net<double>({}, {3, 0}), false); })
+                == "The Bézier must have at least rank one. Got rank 0.");
+    PANTR_CHECK(message_of(
+                    [] { (void)Bezier<double>(net<double>({1.0, 2.0, 3.0}, {3, 1}), true); })
+                == "The Bézier must have at least rank one. Got rank 0.");
+    PANTR_CHECK(message_of([] { (void)Bezier<double>(net<double>({}, {3, 0}), true); })
+                == "The Bézier must have at least rank one. Got rank -1.");
+
+    // The shape check runs first, so a net that is bad in both ways reports the
+    // shape. Reordering the two would silently change what a caller reads and
+    // would diverge from the oracle.
+    PANTR_CHECK(message_of([] { (void)Bezier<double>(net<double>({}, {0, 0}), true); })
+                == "Control points must have at least 1 entry in parametric direction 0, got 0.");
+}
+
+void check_derived_quantities() {
+    const std::vector<double> cube{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
+    const Bezier<double> surface(net<double>(cube, {2, 2, 2}), false);
+    PANTR_CHECK(surface.dim() == 2);
+    PANTR_CHECK(surface.rank() == 2);
+    PANTR_CHECK(surface.degree() == std::vector<std::size_t>({1, 1}));
+    PANTR_CHECK(surface.degree(0) == 1);
+    PANTR_CHECK(!surface.is_rational());
+    PANTR_CHECK(surface.net().num_components() == 2);
+    PANTR_CHECK(surface.net().size() == 8);
+    PANTR_CHECK(surface.net().extent(1) == 2);
+    PANTR_CHECK(throws_out_of_range([&surface] { (void)surface.net().extent(2); }));
+    PANTR_CHECK(throws_out_of_range([&surface] { (void)surface.degree(2); }));
+
+    // A rational planar curve: three stored components, rank 2.
+    const Bezier<double> curve(net<double>({0.0, 0.0, 1.0, 1.0, 1.0, 2.0}, {2, 3}), true);
+    PANTR_CHECK(curve.dim() == 1);
+    PANTR_CHECK(curve.rank() == 2);
+    PANTR_CHECK(curve.degree() == std::vector<std::size_t>({1}));
+    PANTR_CHECK(curve.is_rational());
+
+    // Degree 0 in one direction is legal: one coefficient is a constant, not an
+    // empty direction.
+    const Bezier<double> ribbon(net<double>({1.0, 2.0, 3.0}, {1, 3, 1}), false);
+    PANTR_CHECK(ribbon.degree() == std::vector<std::size_t>({0, 2}));
+}
+
+void check_rank_one_shape_is_promoted() {
+    const Bezier<double> scalar_curve(net<double>({0.0, 1.0, 4.0}, {3}), false);
+    PANTR_CHECK(scalar_curve.dim() == 1);
+    PANTR_CHECK(scalar_curve.rank() == 1);
+    PANTR_CHECK(scalar_curve.degree() == std::vector<std::size_t>({2}));
+    PANTR_CHECK(scalar_curve.net().shape().size() == 2);
+    PANTR_CHECK(scalar_curve.net().shape()[1] == 1);
+}
+
+void check_the_net_copies_its_input() {
+    std::vector<double> values{0.0, 1.0, 2.0, 3.0};
+    const std::vector<std::size_t> shape{4, 1};
+    const Bezier<double> curve(
+        ControlNet<double>(std::span<const double>(values), std::span<const std::size_t>(shape)),
+        false);
+
+    values[0] = 99.0;
+    PANTR_CHECK_MSG(curve.net().values()[0] == 0.0,
+                    "the net aliased the caller's buffer instead of copying it");
+}
+
+void check_float_storage() {
+    const Bezier<float> curve(net<float>({0.0F, 1.0F, 2.0F, 3.0F}, {2, 2}), true);
+    PANTR_CHECK(curve.dim() == 1);
+    PANTR_CHECK(curve.rank() == 1);
+    PANTR_CHECK(curve.degree() == std::vector<std::size_t>({1}));
+    PANTR_CHECK(curve.net().values()[3] == 3.0F);
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_bezier_type asserts nothing yet");
+    check_shape_validation();
+    check_rank_validation();
+    check_derived_quantities();
+    check_rank_one_shape_is_promoted();
+    check_the_net_copies_its_input();
+    check_float_storage();
     return pantr::test::summary("test_bezier_type");
 }

--- a/src/pantr/_backend.py
+++ b/src/pantr/_backend.py
@@ -79,7 +79,15 @@ in which those kernels are C++ and everything else is unchanged.
   Lambert W solve the last of those needs.
 * :mod:`pantr.change_basis` -- all eight builders.
 * :mod:`pantr.bezier` -- the arithmetic and the root finding, through two
-  catalogues rather than one because they are two ports with two parity claims.
+  catalogues rather than one because they are two ports with two parity claims;
+  and, since FELIGN/pantr#385, the :class:`~pantr.bezier.Bezier` **value type**.
+  That last one is a different kind of entry from every other line here. A
+  catalogue decides which code computes; a ported type decides which object holds
+  the state, so under ``PANTR_BACKEND=cpp`` a Bézier's control points live in C++
+  and the Python class is a wrapper around them. Two types moved that way before
+  it -- :class:`pantr.geometry.AABB` and :class:`pantr.transform.AffineTransform`
+  -- and this list still does not name them, which is the drift the paragraph
+  below is about, caught again.
   **Interpolation is deliberately not ported**, and
   ``design/bezier_interpolation_port.md`` is where that ruling and its measurements
   live; it is worth reading before proposing any further port, because it is the

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -50,6 +50,8 @@ from ._basis import monomial_to_bernstein_1d as monomial_to_bernstein_1d
 from ._basis import tabulate_bernstein_1d as tabulate_bernstein_1d
 from ._basis import tabulate_cardinal_bspline_1d as tabulate_cardinal_bspline_1d
 from ._basis import tabulate_legendre_1d as tabulate_legendre_1d
+from ._bezier import Bezier32 as Bezier32
+from ._bezier import Bezier64 as Bezier64
 from ._bezier import apply_reduction_operator as apply_reduction_operator
 from ._bezier import clip_roots as clip_roots
 from ._bezier import dedup_roots as dedup_roots

--- a/src/pantr/_pantr_cpp/_bezier.pyi
+++ b/src/pantr/_pantr_cpp/_bezier.pyi
@@ -1,11 +1,75 @@
-"""Bezier arithmetic and root-finding kernels of the compiled extension.
+"""Bezier value type, arithmetic kernels and root-finding kernels of the extension.
 
-Bound by ``cpp/bindings/bezier.cpp`` and ``cpp/bindings/bezier_root_finding.cpp``.
-See ``__init__.pyi`` for what this package promises and who has to keep it.
+Bound by ``cpp/bindings/bezier_type.cpp``, ``cpp/bindings/bezier.cpp`` and
+``cpp/bindings/bezier_root_finding.cpp``. See ``__init__.pyi`` for what this
+package promises and who has to keep it.
 """
 
 import numpy as np
 import numpy.typing as npt
+
+class Bezier32:
+    """A ``float32`` Bézier owned by the C++ core.
+
+    Wrapped by :class:`pantr.bezier.Bezier`, which is the class a caller holds;
+    this one is reached only through it. The storage format is in the class name
+    because the class of the handle is the only thing left to carry it: there is
+    no dtype argument, and the constructor refuses an array of any other dtype
+    rather than casting it.
+
+    The control points are **copied** at construction and handed back as a
+    **read-only view** of the copy, so neither end aliases the caller's array.
+
+    Attributes:
+        control_points (npt.NDArray[np.float32]): Control points, shape
+            ``(*degrees_plus_1, rank_with_weight)``, read-only.
+        is_rational (bool): Whether the last coordinate is a homogeneous weight.
+        dim (int): Number of parametric directions, ``>= 1``.
+        degree (tuple[int, ...]): Polynomial degree per parametric direction.
+        rank (int): Number of value components, weight excluded, ``>= 1``.
+    """
+
+    def __init__(
+        self, control_points: npt.NDArray[np.float32], is_rational: bool = False
+    ) -> None: ...
+    @property
+    def control_points(self) -> npt.NDArray[np.float32]: ...
+    @property
+    def is_rational(self) -> bool: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def degree(self) -> tuple[int, ...]: ...
+    @property
+    def rank(self) -> int: ...
+
+class Bezier64:
+    """A ``float64`` Bézier owned by the C++ core.
+
+    The ``float64`` twin of :class:`Bezier32`; see it for what the two share.
+
+    Attributes:
+        control_points (npt.NDArray[np.float64]): Control points, shape
+            ``(*degrees_plus_1, rank_with_weight)``, read-only.
+        is_rational (bool): Whether the last coordinate is a homogeneous weight.
+        dim (int): Number of parametric directions, ``>= 1``.
+        degree (tuple[int, ...]): Polynomial degree per parametric direction.
+        rank (int): Number of value components, weight excluded, ``>= 1``.
+    """
+
+    def __init__(
+        self, control_points: npt.NDArray[np.float64], is_rational: bool = False
+    ) -> None: ...
+    @property
+    def control_points(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def is_rational(self) -> bool: ...
+    @property
+    def dim(self) -> int: ...
+    @property
+    def degree(self) -> tuple[int, ...]: ...
+    @property
+    def rank(self) -> int: ...
 
 def evaluate_bezier_1d(
     ctrl: npt.NDArray[np.float32 | np.float64],

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -393,12 +393,36 @@ class Bezier:
         replaced. Both leave this wrapper carrying the new value; only the array's
         identity differs, and only where the oracle's aliasing is what defined it.
 
+        Rebuilding the implementation reads the *active* backend, so mutating a
+        Bézier inside a :func:`~pantr._backend.use_backend` block that selects a
+        different one would silently hand the caller back an object of the other
+        implementation -- and, going from C++ to Python, silently drop the
+        read-only guarantee on an array they still hold. Reconciling two
+        implementations of one type by converting between them is the shape
+        ``design/cross_backend_types.md`` forbids, so this refuses rather than
+        converts, exactly as :meth:`pantr.geometry.AABB._peer` does for a binary
+        operation. Immutable ported types cannot reach this; ``Bezier`` is the
+        first with observable mutation.
+
         Args:
             rebuild (Callable[[NDArray], NDArray]): Given a writable control-point
                 array, returns the new one. It may write into the array it is
                 given and return it.
+
+        Raises:
+            TypeError: If the active backend no longer selects this Bézier's own
+                implementation.
         """
         impl = self._impl
+        mine = type(impl)
+        theirs = _impl_class(impl.control_points.dtype)
+        if mine is not theirs:
+            raise TypeError(
+                f"Bezier: cannot mutate a Bezier built under a different backend "
+                f"({mine.__name__} against the active {theirs.__name__}); the "
+                f"backend is chosen per process, so this means the active one "
+                f"changed after this Bezier was built."
+            )
         if isinstance(impl, _BezierPython):
             impl._replace_control_points(rebuild(impl.control_points))
         else:

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -1,13 +1,26 @@
-"""Bezier geometric object: the Bezier class."""
+"""Bezier geometric object: the Bezier class.
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the value
+itself is owned by C++ (``cpp/include/pantr/bezier/bezier.hpp``) and
+:class:`Bezier` is a wrapper holding one implementation of it. Ownership moves;
+it is never duplicated. There are two implementations and they are not two
+Béziers: :class:`_BezierPython` is the oracle the port is checked against, and
+the C++ handle is the thing being checked. :func:`_impl_class` picks between
+them, per process and per dtype.
+
+The operations are unchanged and still live in the sibling ``_bezier_*`` modules
+as free functions over a :class:`Bezier`. Only the *state* moved.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, overload
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, cast, overload
 
 import numpy as np
 from numpy import typing as npt
 
+from .._backend import Backend, active_backend, available_backends
 from .._transform_control_points import _apply_affine_to_control_points
 from ._bezier_collapse import _collapse_along_axis
 from ._bezier_compose import _compose_bezier
@@ -25,17 +38,52 @@ from ._bezier_slice import _slice_bezier
 from ._bezier_split import _split_bezier
 
 if TYPE_CHECKING:
+    from .._pantr_cpp import Bezier32 as _CppBezier32
+    from .._pantr_cpp import Bezier64 as _CppBezier64
     from ..bspline import Bspline
     from ..quad import PointsLattice
     from ..transform import AffineTransform
 
+    _Impl: TypeAlias = "_BezierPython | _CppBezier32 | _CppBezier64"
+    """The implementation a :class:`Bezier` holds: the oracle, or a C++ handle.
 
-class Bezier:
-    """A parametric Bézier curve, surface, or volume defined by control points.
+    Type-checking only. The three are unrelated nominal types that happen to
+    offer the same surface, which is the port's whole claim; naming the union
+    here is what lets the checker verify it instead of taking it on trust.
+    """
 
-    Stores only control points and an ``is_rational`` flag. The polynomial
-    degree in each parametric direction is inferred from the control point
-    array shape: ``degree[d] = control_points.shape[d] - 1``.
+_ControlPoints: TypeAlias = "npt.NDArray[np.float32 | np.float64]"
+"""A control-point array in one of the two storage formats a Bézier may use."""
+
+_SUPPORTED_DTYPES: Final = (np.dtype(np.float32), np.dtype(np.float64))
+"""The two storage formats a Bézier may hold, after integer input has been cast.
+
+Narrower than what the oracle's constructor used to accept, which was anything
+:func:`numpy.asarray` produced -- ``float16`` and ``bool`` included, both of which
+build a Bézier no kernel below it can evaluate. The type annotations, the kernel
+catalogue in :mod:`pantr.bezier._bezier_backend` and now the C++ registration all
+say two formats, so the constructor says two as well. Rejecting is the wrapper's
+job rather than the C++ type's: a dtype is a type-kind check, and nanobind has no
+path that produces a :class:`TypeError`.
+"""
+
+
+class _BezierPython:
+    """The Bézier value as the Python backend stores it: the port's oracle.
+
+    Holds the control points and the rationality flag, and answers the four
+    questions they determine. Everything the class used to do beyond that is on
+    :class:`Bezier`, which is the only class a caller ever holds; this one is
+    reachable only through it. When the C++ core stops being optional this class
+    goes and :class:`Bezier` collapses onto the handle.
+
+    **It aliases the caller's array, and that is a defect it keeps on purpose.**
+    ``__init__`` stores what :func:`numpy.asarray` returns and
+    :attr:`control_points` hands the same object back, so a caller can mutate a
+    constructed Bézier through either end. That is the shape of FELIGN/pantr#338,
+    the C++ implementation copies instead, and a port never edits its own oracle
+    -- so the two backends differ here, deliberately, until the ticket that fixes
+    this side lands.
 
     Attributes:
         _control_points (npt.NDArray[np.float32 | np.float64]): Control point
@@ -44,6 +92,8 @@ class Bezier:
         _is_rational (bool): Whether the Bézier is rational (last control
             point coordinate is a homogeneous weight).
     """
+
+    __slots__ = ("_control_points", "_is_rational")
 
     def __init__(
         self,
@@ -83,11 +133,26 @@ class Bezier:
                     f"direction {d}, got {cp.shape[d]}."
                 )
 
-        self._control_points: npt.NDArray[np.float32 | np.float64] = cp
+        self._control_points: _ControlPoints = cp
         self._is_rational = is_rational
 
         if self.rank <= 0:
             raise ValueError(f"The Bézier must have at least rank one. Got rank {self.rank}.")
+
+    def _replace_control_points(self, control_points: _ControlPoints) -> None:
+        """Adopt an already-validated control-point array, in place.
+
+        The one mutating operation on this class, and it exists only because
+        ``reverse``, ``permute_directions`` and ``transform`` take an
+        ``in_place`` flag that :class:`Bezier` ports faithfully. It re-validates
+        nothing: every caller derives the array from this Bézier's own, so the
+        shape either did not change or changed by a permutation.
+
+        Args:
+            control_points (npt.NDArray[np.float32 | np.float64]): The array to
+                store.
+        """
+        self._control_points = control_points
 
     @property
     def dim(self) -> int:
@@ -109,12 +174,13 @@ class Bezier:
         return tuple(s - 1 for s in self._control_points.shape[:-1])
 
     @property
-    def control_points(self) -> npt.NDArray[np.float32 | np.float64]:
+    def control_points(self) -> _ControlPoints:
         """Get the control points of the Bézier.
 
         Returns:
             npt.NDArray[np.float32 | np.float64]: Control point array with
-            shape ``(*degrees_plus_1, rank)``.
+            shape ``(*degrees_plus_1, rank)``. The stored array itself, not a
+            copy; see the class docstring.
         """
         return self._control_points
 
@@ -142,15 +208,293 @@ class Bezier:
         rk = int(self._control_points.shape[-1])
         return rk - 1 if self.is_rational else rk
 
+
+def _stored_dtype(control_points: npt.ArrayLike) -> tuple[_ControlPoints, np.dtype[Any]]:
+    """Normalize an array-like to the array a Bézier would store, and its dtype.
+
+    The two steps are the oracle's own first two lines, lifted out because the
+    wrapper has to know the dtype *before* it can choose an implementation: the
+    C++ side registers one class per storage format, so the format is what picks
+    the class.
+
+    Integer input is cast to ``float64``, which the constructor documents.
+    Everything else keeps its dtype, which is how ``float32`` survives.
+
+    Args:
+        control_points (npt.ArrayLike): The caller's argument.
+
+    Returns:
+        tuple[npt.NDArray[np.float32 | np.float64], np.dtype[Any]]: The array
+        and its dtype. The dtype is not yet known to be one a Bézier supports;
+        :func:`_new_impl` is what rejects the rest.
+
+    Raises:
+        TypeError: If the argument cannot be read as an array at all.
+    """
+    cp = np.asarray(control_points)
+    if np.issubdtype(cp.dtype, np.integer):
+        cp = cp.astype(np.float64)
+    return cp, cp.dtype
+
+
+def _impl_class(dtype: np.dtype[Any]) -> type[_BezierPython] | type[_CppBezier32 | _CppBezier64]:
+    """The implementation class the active backend and the dtype select.
+
+    The backend is per process rather than per instance, deliberately, and for
+    the reason ``pantr.geometry`` states: two Béziers built under different
+    backends could otherwise meet in a binary operation, and reconciling them
+    would mean converting one implementation into the other, which is the shape
+    ``design/cross_backend_types.md`` forbids.
+
+    The dtype, by contrast, *is* per instance. It has to be: ``float32`` is a
+    supported storage format for a Bézier, unlike for :class:`pantr.geometry.AABB`,
+    and the C++ side carries the format in the class name because the class of
+    the handle is the only thing left to carry it.
+
+    Args:
+        dtype (np.dtype[Any]): The dtype the control points will be stored in.
+
+    Returns:
+        type[_BezierPython] | type[_CppBezier32 | _CppBezier64]: The oracle under
+        the Python backend, and the C++ class for that storage format otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if active_backend() is Backend.PYTHON:
+        return _BezierPython
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.Bezier32 if dtype == np.float32 else _pantr_cpp.Bezier64
+
+
+def _new_impl(control_points: npt.ArrayLike, is_rational: bool) -> _Impl:
+    """Build a Bézier value in whichever implementation the active backend selects.
+
+    Args:
+        control_points (npt.ArrayLike): Control points, in any of the forms
+            :meth:`Bezier.__init__` accepts.
+        is_rational (bool): Whether the last coordinate is a homogeneous weight.
+
+    Returns:
+        _Impl: The implementation object; a :class:`_BezierPython` or a C++ handle.
+
+    Raises:
+        TypeError: If the control points have a dtype no Bézier can store.
+        ValueError: If the shape does not describe a Bézier.
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    cp, dtype = _stored_dtype(control_points)
+    if dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(
+            f"Bezier control points must be float32, float64 or an integer type; got dtype {dtype}."
+        )
+
+    cls = _impl_class(dtype)
+    if cls is _BezierPython:
+        return _BezierPython(cp, is_rational)
+
+    # `np.ascontiguousarray` promotes a 0-d array to shape `(1,)`, which would turn
+    # the "must be at least 1D" rejection into a silently accepted degree-0 curve.
+    # The same trap is recorded at `pantr.transform.AffineTransform.apply`. A 0-d
+    # array is contiguous anyway, so skipping it costs nothing.
+    contiguous = cp if cp.ndim == 0 else np.ascontiguousarray(cp)
+    # Each C++ class accepts only its own storage format and refuses rather than
+    # casts, so the array's dtype and the class have to agree. They do: the class
+    # was chosen from that dtype one line above. That is a correlation between a
+    # value and a type, which the checker cannot state, and the cast is what
+    # stands in for it.
+    return cls(cast("Any", contiguous), bool(is_rational))
+
+
+class Bezier:
+    """A parametric Bézier curve, surface, or volume defined by control points.
+
+    Stores only control points and an ``is_rational`` flag. The polynomial
+    degree in each parametric direction is inferred from the control point
+    array shape: ``degree[d] = control_points.shape[d] - 1``.
+
+    **This class is a wrapper.** Since the 2026-08-27 amendment to
+    ``design/cross_backend_types.md`` the value is owned by C++
+    (``cpp/include/pantr/bezier/bezier.hpp``) and this class holds one
+    implementation of it, chosen by :func:`_impl_class`. The operations are still
+    Python and still live in the sibling ``_bezier_*`` modules; only the state
+    moved.
+
+    One behaviour depends on which implementation is in hand, and it is the point
+    of the port rather than an oversight: the C++ value **copies** the control
+    points at construction and hands out a read-only view, so neither end aliases
+    the caller's array. The Python oracle aliases at both ends, which is the
+    defect FELIGN/pantr#338 names, and it is not fixed here because a port does
+    not edit its own oracle.
+
+    Attributes:
+        _impl (_Impl): The implementation this wrapper holds; see
+            :func:`_impl_class`.
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_impl_class`."""
+
+    def __init__(
+        self,
+        control_points: npt.ArrayLike,
+        is_rational: bool = False,
+    ) -> None:
+        """Initialize a Bézier from control points.
+
+        Args:
+            control_points (npt.ArrayLike): Control points. Shape must be at
+                least 2D: ``(*degrees_plus_1, rank)``. A 1D input of shape
+                ``(n,)`` is reshaped to ``(n, 1)`` (scalar field). Integer
+                arrays are cast to ``float64``; ``float32`` and ``float64``
+                are stored as they are.
+            is_rational (bool): Whether the Bézier is rational. Defaults to
+                False.
+
+        Raises:
+            TypeError: If the control points have a dtype no Bézier can store.
+            ValueError: If the control points have fewer than 1 entry in any
+                parametric direction.
+            ValueError: If the Bézier has rank smaller than 1.
+        """
+        self._impl = _new_impl(control_points, is_rational)
+
+    @classmethod
+    def _wrap(cls, impl: _Impl) -> Bezier:
+        """Wrap an implementation object that is already valid.
+
+        Args:
+            impl (_Impl): The implementation object to adopt.
+
+        Returns:
+            Bezier: A wrapper around ``impl``, with no re-validation.
+        """
+        self = object.__new__(cls)
+        self._impl = impl
+        return self
+
+    def _mutate_control_points(self, rebuild: Callable[[_ControlPoints], _ControlPoints]) -> None:
+        """Replace this Bézier's control points with ``rebuild``'s result, in place.
+
+        The single place the two implementations differ in *kind* rather than in
+        provenance, so the branch lives here once instead of in each of the three
+        ``in_place=True`` methods.
+
+        Under the Python backend ``rebuild`` is handed the stored array itself, so
+        a helper writing into it mutates the Bézier exactly as it always has --
+        ``id(bezier.control_points)`` included, which ``tests/test_transform.py``
+        pins. Under the C++ backend the storage belongs to the C++ object and is
+        read-only, so ``rebuild`` gets a writable copy and the *implementation* is
+        replaced. Both leave this wrapper carrying the new value; only the array's
+        identity differs, and only where the oracle's aliasing is what defined it.
+
+        Args:
+            rebuild (Callable[[NDArray], NDArray]): Given a writable control-point
+                array, returns the new one. It may write into the array it is
+                given and return it.
+        """
+        impl = self._impl
+        if isinstance(impl, _BezierPython):
+            impl._replace_control_points(rebuild(impl.control_points))
+        else:
+            self._impl = _new_impl(rebuild(np.array(impl.control_points)), impl.is_rational)
+
+    def __reduce__(self) -> tuple[type[Bezier], tuple[_ControlPoints, bool]]:
+        """Pickle by the constructor's arguments rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire
+        format: a pickle written under the C++ backend has to load under the
+        Python one and the other way round, or the backend switch would silently
+        become a data-format switch.
+
+        Returns:
+            tuple: The class, and the control points and rationality flag to
+            rebuild it from.
+        """
+        control_points = self.control_points
+        if not control_points.flags.writeable:
+            # The C++ backend hands out a read-only view and pickle preserves that
+            # flag (measured). Reconstructing under the Python backend would then
+            # store a read-only array, where `reverse(in_place=True)` raises. The
+            # copy is what keeps one backend's storage decision out of the wire
+            # format.
+            control_points = np.array(control_points)
+        return (type(self), (control_points, self.is_rational))
+
+    @property
+    def dim(self) -> int:
+        """Get the parametric dimension of the Bézier.
+
+        Returns:
+            int: Number of parametric dimensions.
+        """
+        return int(self._impl.dim)
+
+    @property
+    def degree(self) -> tuple[int, ...]:
+        """Get the polynomial degrees per parametric direction.
+
+        Returns:
+            tuple[int, ...]: Polynomial degree for each parametric dimension,
+            computed as ``shape[d] - 1``.
+        """
+        return self._impl.degree
+
+    @property
+    def control_points(self) -> _ControlPoints:
+        """Get the control points of the Bézier.
+
+        Returns:
+            npt.NDArray[np.float32 | np.float64]: Control point array with
+            shape ``(*degrees_plus_1, rank)``. Under the C++ backend this is a
+            **read-only view** of the Bézier's own storage: writing through it
+            raises, and it stays valid after the Bézier is dropped. Under the
+            Python backend it is the stored array itself, writable, which is the
+            aliasing defect the class docstring names.
+        """
+        return self._impl.control_points
+
+    @property
+    def is_rational(self) -> bool:
+        """Check whether the Bézier is rational.
+
+        Returns:
+            bool: True if the Bézier is rational (i.e., the last control point
+            coordinate is a homogeneous weight), False otherwise.
+        """
+        return bool(self._impl.is_rational)
+
+    @property
+    def rank(self) -> int:
+        """Get the output rank of the Bézier.
+
+        The rank is the number of value dimensions produced by the mapping.
+        For a scalar field it is 1; for a 3D curve it is 3. For rational
+        Béziers the weight coordinate is excluded.
+
+        Returns:
+            int: Output rank of the Bézier.
+        """
+        return int(self._impl.rank)
+
     @property
     def dtype(self) -> npt.DTypeLike:
         """Get the floating-point dtype of the Bézier.
+
+        Read off the control points rather than delegated: the C++ handle carries
+        its storage format in its class name, not as a numpy dtype it could hand
+        back.
 
         Returns:
             npt.DTypeLike: The numpy dtype (float32 or float64) of the control
             point array.
         """
-        return self._control_points.dtype
+        return self.control_points.dtype
 
     # ------------------------------------------------------------------
     # Evaluation
@@ -596,11 +940,13 @@ class Bezier:
 
         from .._control_points_utils import _reverse_control_points  # noqa: PLC0415
 
-        new_cp = _reverse_control_points(self._control_points, direction, in_place=in_place)
-
         if in_place:
+            self._mutate_control_points(
+                lambda cp: _reverse_control_points(cp, direction, in_place=True)
+            )
             return None
-        return Bezier(new_cp, is_rational=self._is_rational)
+        new_cp = _reverse_control_points(self.control_points, direction, in_place=False)
+        return Bezier(new_cp, is_rational=self.is_rational)
 
     @overload
     def permute_directions(
@@ -648,12 +994,11 @@ class Bezier:
 
         from .._control_points_utils import _permute_control_points  # noqa: PLC0415
 
-        new_cp = _permute_control_points(self._control_points, perm, self.dim)
-
         if in_place:
-            self._control_points = new_cp
+            self._mutate_control_points(lambda cp: _permute_control_points(cp, perm, self.dim))
             return None
-        return Bezier(new_cp, is_rational=self._is_rational)
+        new_cp = _permute_control_points(self.control_points, perm, self.dim)
+        return Bezier(new_cp, is_rational=self.is_rational)
 
     # ------------------------------------------------------------------
     # Affine transformation
@@ -702,16 +1047,21 @@ class Bezier:
             >>> np.allclose(shifted.control_points, [[1.0, 2.0], [2.0, 3.0]])
             True
         """
+        if in_place:
+            self._mutate_control_points(
+                lambda cp: _apply_affine_to_control_points(
+                    cp, self.is_rational, affine.matrix, affine.offset, in_place=True
+                )
+            )
+            return None
         new_cp = _apply_affine_to_control_points(
-            self._control_points,
-            self._is_rational,
+            self.control_points,
+            self.is_rational,
             affine.matrix,
             affine.offset,
-            in_place=in_place,
+            in_place=False,
         )
-        if in_place:
-            return None
-        return Bezier(new_cp, is_rational=self._is_rational)
+        return Bezier(new_cp, is_rational=self.is_rational)
 
     # ------------------------------------------------------------------
     # Restrict
@@ -976,7 +1326,9 @@ class Bezier:
         Args:
             copy (bool): If ``True`` (default), the control points are
                 deep-copied into the new B-spline. If ``False``, the
-                B-spline shares the same underlying control point array.
+                B-spline shares the same underlying control point array --
+                which, under the C++ backend, is the Bézier's own storage and
+                is read-only, so the B-spline is then read-only too.
 
         Returns:
             ~pantr.bspline.Bspline: Equivalent B-spline representation.
@@ -991,8 +1343,8 @@ class Bezier:
             knots[p + 1 :] = 1.0
             spaces.append(BsplineSpace1D(knots, p))
 
-        cp = self._control_points.copy() if copy else self._control_points
-        return BsplineCls(BsplineSpace(spaces), cp, self._is_rational)
+        cp = self.control_points.copy() if copy else self.control_points
+        return BsplineCls(BsplineSpace(spaces), cp, self.is_rational)
 
     # ------------------------------------------------------------------
     # Visualization
@@ -1042,7 +1394,10 @@ def create_from_bspline(bspline: Bspline, *, copy: bool = True) -> Bezier:
             knot structure.
         copy (bool): If ``True`` (default), the control points are
             deep-copied into the new Bézier. If ``False``, the Bézier
-            shares the same underlying control point array.
+            shares the same underlying control point array -- **under the
+            Python backend only**. The C++ value owns its storage and copies
+            at construction, so there ``copy=False`` saves nothing and shares
+            nothing.
 
     Returns:
         Bezier: The equivalent Bézier.

--- a/tests/parity/test_bezier_binding_contract.py
+++ b/tests/parity/test_bezier_binding_contract.py
@@ -24,6 +24,15 @@ documented as living in the unit interval and never checked, so ``slice`` at 2.5
 extrapolated silently and ``restrict`` with its bounds transposed returned a
 different, plausible Bézier.
 
+**A dtype conversion the caller did not ask for is a lost format.** The two
+``Bezier`` classes `cpp/bindings/bezier_type.cpp` registers carry their storage
+format in their names, and nothing else carries it. Without ``.noconvert()``
+nanobind casts silently, so ``Bezier32`` handed a ``float64`` net would narrow the
+caller's geometry and ``Bezier64`` handed a ``float32`` one would widen it, with
+nothing left to notice by. The refusal is what makes
+:func:`pantr.bezier._bezier._impl_class` picking the wrong class a loud failure
+instead of a quiet change of precision.
+
 These are reachable by importing :mod:`pantr._pantr_cpp`, not through
 :class:`~pantr.bezier.Bezier`, whose Layer 1 refuses all of them first. That is
 exactly the surface `basis.cpp` documents as real: the extension is importable and
@@ -308,3 +317,49 @@ def test_dedup_roots_refuses_its_two_arrays_positionally(cpp_backend: None) -> N
         bindings.dedup_roots(
             raw, coeff.astype(np.float32), 1, param_tol=1e-9, geom_tol=1e-9, out=np.empty(8)
         )
+
+
+def test_the_bezier_type_refuses_a_dtype_it_would_have_to_cast(cpp_backend: None) -> None:
+    """Each `Bezier` class takes its own storage format and no other.
+
+    The class name is the only place the format lives, so a silent cast would move
+    the geometry between formats with nothing left to report it -- a narrowing for
+    ``Bezier32`` and a widening for ``Bezier64``, both of which type-check, run, and
+    return a well-formed Bézier of the wrong precision.
+
+    An integer net is refused here too, and that is not an oversight: the cast to
+    ``float64`` is the wrapper's, documented on
+    :meth:`pantr.bezier.Bezier.__init__`, and this class sits below it.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    net64 = np.ascontiguousarray(np.arange(6.0).reshape(3, 2))
+    assert bindings.Bezier64(net64).control_points.dtype == np.float64
+    assert bindings.Bezier32(net64.astype(np.float32)).control_points.dtype == np.float32
+
+    with pytest.raises(TypeError):
+        bindings.Bezier32(net64)
+    with pytest.raises(TypeError):
+        bindings.Bezier64(net64.astype(np.float32))
+    with pytest.raises(TypeError):
+        bindings.Bezier64(np.arange(6).reshape(3, 2))
+
+
+def test_the_bezier_type_refuses_a_control_net_it_would_have_to_reorder(
+    cpp_backend: None,
+) -> None:
+    """A Fortran-ordered net is refused rather than silently copied.
+
+    The same ``.noconvert()`` that closes the dtype cast also closes this one, and
+    it is asserted separately because the two failures are different: a reordering
+    copy is correct but unbudgeted work on every construction, where the dtype cast
+    is a wrong answer. The wrapper makes the array contiguous before it gets here,
+    so the refusal costs a caller going through :class:`~pantr.bezier.Bezier`
+    nothing.
+    """
+    del cpp_backend
+    bindings = _bindings()
+
+    with pytest.raises(TypeError):
+        bindings.Bezier64(np.asfortranarray(np.arange(6.0).reshape(3, 2)))

--- a/tests/parity/test_bezier_type.py
+++ b/tests/parity/test_bezier_type.py
@@ -1,0 +1,444 @@
+"""Parity of the `Bezier` value type: the state, the rejections, and the wire format.
+
+What this file compares is a *value*, not a computation. `pantr.bezier.Bezier`
+stores control points and a flag and answers four questions about them; between
+the Python oracle and the C++ port there is no arithmetic at all, only a copy. So
+every claim here is bitwise or exact, and a tolerance anywhere in this file would
+be hiding a transcription error rather than allowing for rounding. The kernels
+that *do* arithmetic are the subject of `test_bezier_arithmetic.py`, which builds
+its Béziers through this same type.
+
+Three things are checked that a field-by-field state comparison does not reach:
+
+- **The rejections, verbatim.** Both implementations refuse the same malformed
+  control nets, and a caller writing ``pytest.raises(ValueError, match=...)``
+  must not have to know which backend built the object. The messages are
+  therefore compared character for character rather than by exception type.
+- **The copy at construction, and the read-only view on the way out.** The C++
+  value does not alias the caller's array at either end, which the oracle does.
+  This is the one place the two backends differ on purpose: it is
+  FELIGN/pantr#338's defect, fixed on the side the port owns, and
+  FELIGN/pantr#375 is the ticket that fixes the other. Both halves are asserted
+  here, because a criterion covering only construction leaves the other half of a
+  bidirectional defect unpinned.
+- **The wire format.** ``__reduce__`` pickles by the constructor's arguments, so a
+  pickle written under one backend loads under the other. Without that the backend
+  switch would silently become a data-format switch, and a C++ handle is not
+  picklable in any case.
+
+The dtype is part of the state and is compared as such. It is the axis on which
+this type differs from the two already-ported ones: `AABB` and `AffineTransform`
+coerce everything to ``float64`` and are bound at ``double`` only, while a Bézier
+stores ``float32`` too and the C++ side therefore registers two classes.
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+from typing import Any, Final
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bezier import Bezier
+from pantr.bezier._bezier import _BezierPython
+from tests._parity_harness import (
+    Field,
+    assert_object_parity,
+    bitwise_parity,
+    exact_parity,
+)
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+DTYPES: Final = (np.float64, np.float32)
+"""Both storage formats. Unlike `AABB`, a Bézier has a genuine `float32` oracle."""
+
+_STORED_WHY: Final = (
+    "the value type stores the coefficients it is handed and performs no arithmetic on "
+    "them, so the two backends can only differ by a transcription error -- a wrong stride, "
+    "a narrowing cast, a byte lost to the shape. Every one of those is visible bitwise and "
+    "invisible under any tolerance wide enough to be called a rounding budget."
+)
+
+_DERIVED_WHY: Final = (
+    "dim, degree and rank are subtractions on the shape, computed in exact integer "
+    "arithmetic on both sides. A difference is an off-by-one in the shape handling, which "
+    "is exact or wrong."
+)
+
+_FLAG_WHY: Final = "the rationality flag is stored and returned; nothing transforms it."
+
+_DTYPE_WHY: Final = (
+    "the storage format is the state a caller reads through `Bezier.dtype`, and on the C++ "
+    "side it is carried by the class of the handle. A disagreement means `_impl_class` "
+    "picked the wrong class, which would silently narrow or widen the geometry."
+)
+
+FIELDS: Final = (
+    Field("control_points", bitwise_parity(why=_STORED_WHY)),
+    Field("is_rational", exact_parity(why=_FLAG_WHY)),
+    Field("dim", exact_parity(why=_DERIVED_WHY)),
+    Field("degree", exact_parity(why=_DERIVED_WHY)),
+    Field("rank", exact_parity(why=_DERIVED_WHY)),
+    Field("dtype", exact_parity(why=_DTYPE_WHY)),
+)
+"""Every piece of a Bézier's state, one field each.
+
+`degree` is a homogeneous tuple of ints, which is one quantity and stays one
+field; the harness refuses a value mixing element kinds, and this is not one.
+There is deliberately no derived-convenience field beyond these: `dtype` is a
+function of `control_points` and is named anyway, because it is the axis the two
+C++ classes differ on and a wrong one is otherwise only visible as a rounding.
+"""
+
+
+def _control_points(
+    shape: tuple[int, ...], dtype: npt.DTypeLike, *, seed: int
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a control net whose values span many decades.
+
+    Magnitudes spread over the format's exponent range, so a narrowing cast in the
+    port shows up as a changed bit pattern rather than as a value that happens to
+    survive both formats.
+
+    Args:
+        shape (tuple[int, ...]): The control-net shape, `(*degrees_plus_1, rank)`.
+        dtype (npt.DTypeLike): Storage format.
+        seed (int): Seed for the draw.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The control points, C-contiguous.
+    """
+    rng = np.random.default_rng(seed)
+    size = int(np.prod(shape))
+    mantissa = rng.uniform(-1.0, 1.0, size=size)
+    exponent = rng.integers(-20, 20, size=size)
+    return np.ascontiguousarray((mantissa * np.float64(2.0) ** exponent).reshape(shape), dtype)
+
+
+def _both(
+    control_points: npt.NDArray[np.float32 | np.float64], *, is_rational: bool
+) -> tuple[Bezier, Bezier]:
+    """Build the same Bézier under each backend.
+
+    Args:
+        control_points (npt.NDArray[np.float32 | np.float64]): The control net.
+        is_rational (bool): Whether the last coordinate is a weight.
+
+    Returns:
+        tuple[Bezier, Bezier]: `(py, cpp)`, in the order `assert_object_parity`
+        names its arguments.
+    """
+    with use_backend(Backend.PYTHON):
+        py = Bezier(control_points, is_rational)
+    with use_backend(Backend.CPP):
+        cpp = Bezier(control_points, is_rational)
+    return py, cpp
+
+
+def _cpp_class(dtype: npt.DTypeLike) -> Any:
+    """The bound C++ class for one storage format.
+
+    Args:
+        dtype (npt.DTypeLike): `float32` or `float64`.
+
+    Returns:
+        Any: `pantr._pantr_cpp.Bezier32` or `Bezier64`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    return _pantr_cpp.Bezier32 if np.dtype(dtype) == np.float32 else _pantr_cpp.Bezier64
+
+
+# The shapes are `(*degrees_plus_1, num_components)`. Between them they cover
+# every axis the type's arithmetic touches: one to three parametric directions,
+# degree 0 (one coefficient, a constant, which is legal and is the case a
+# `shape - 1` underflow would break), an asymmetric degree so a transposed shape
+# cannot pass, and a component count of 1 so the rational rank check sits one
+# step from its rejection.
+SHAPES: Final = (
+    (4, 1),
+    (4, 3),
+    (1, 2),
+    (3, 5, 2),
+    (2, 3, 4, 3),
+)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_two_backends_hold_the_same_value(
+    shape: tuple[int, ...], dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """Every piece of state agrees, at both storage formats.
+
+    What this catches: a stride or shape mistake in the flat-buffer round trip, a
+    narrowing cast in the wrong-dtype class, an off-by-one in `degree` or `rank`,
+    and the weight column being counted into the rank or out of the storage.
+    """
+    if is_rational and shape[-1] < 2:
+        pytest.skip("a rational Bezier needs a weight and at least one coordinate")
+    control_points = _control_points(shape, dtype, seed=hash(shape) % 2**32)
+    py, cpp = _both(control_points, is_rational=is_rational)
+    assert_object_parity(
+        py=py, cpp=cpp, fields=FIELDS, context=f"Bezier({shape}, {dtype}, rational={is_rational})"
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_one_dimensional_control_net_is_reshaped_the_same_way(dtype: npt.DTypeLike) -> None:
+    """`(n,)` becomes the scalar field `(n, 1)` on both sides.
+
+    What this catches: the convenience living on only one side, which would make a
+    flat coefficient vector a degree-0 Bézier of rank `n` under one backend and a
+    degree-`n-1` Bézier of rank 1 under the other -- both well formed, so nothing
+    downstream would raise.
+    """
+    control_points = np.asarray([0.0, 1.0, 4.0, 9.0], dtype=dtype)
+    py, cpp = _both(control_points, is_rational=False)
+    assert_object_parity(py=py, cpp=cpp, fields=FIELDS, context="Bezier from a 1-D array")
+    assert cpp.control_points.shape == (4, 1)
+
+
+def _message_of(build: Any) -> str:
+    """The text of the `ValueError` that `build` raises.
+
+    Args:
+        build (Any): A no-argument call expected to raise.
+
+    Returns:
+        str: The message, or a marker saying what happened instead, so that the
+        caller's assertion is the one that reports.
+    """
+    try:
+        build()
+    except ValueError as error:
+        return str(error)
+    return "<did not raise ValueError>"
+
+
+MALFORMED: Final = (
+    (lambda cls, dtype: cls(np.asarray(1.0, dtype=dtype)), "a 0-d array"),
+    (lambda cls, dtype: cls(np.zeros((0, 2), dtype=dtype)), "an empty parametric direction"),
+    (lambda cls, dtype: cls(np.zeros((2, 0, 3), dtype=dtype)), "an empty second direction"),
+    (lambda cls, dtype: cls(np.zeros((3, 0), dtype=dtype)), "no components at all"),
+    (lambda cls, dtype: cls(np.zeros((3, 1), dtype=dtype), True), "a weight and nothing else"),
+    (lambda cls, dtype: cls(np.zeros((3, 0), dtype=dtype), True), "a rational net of rank -1"),
+)
+"""Every construction both implementations must refuse, and what makes it bad.
+
+The last two are the rank check's two sides of zero: `rank -1` is the one that
+made the C++ subtraction signed, and an unsigned one would reject the input while
+reporting a number near 2^64.
+"""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(("build", "what"), MALFORMED)
+def test_error_messages_agree_verbatim(build: Any, what: str, dtype: npt.DTypeLike) -> None:
+    """Both implementations raise `ValueError` and say exactly the same thing.
+
+    What this catches: a reworded message. A caller catching
+    `pytest.raises(ValueError, match=...)` must not have to know which backend
+    built the object, and the type of the exception alone does not carry that --
+    both sides raise `ValueError` for every case here, so only the text can tell
+    a reordered check from a faithful one.
+    """
+    oracle = _message_of(lambda: build(_BezierPython, dtype))
+    ported = _message_of(lambda: build(_cpp_class(dtype), dtype))
+    assert oracle == ported, f"{what}: oracle said {oracle!r}, C++ said {ported!r}"
+    assert not oracle.startswith("<"), f"{what}: neither implementation refused it"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_cpp_value_does_not_alias_the_array_it_was_built_from(dtype: npt.DTypeLike) -> None:
+    """Mutating the constructor's argument afterwards does not move the Bézier.
+
+    What this catches: the C++ constructor taking a view of the caller's buffer
+    instead of copying, which would let a validated geometry change under its
+    owner's feet -- the way in of FELIGN/pantr#338's defect.
+    """
+    control_points = np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype)
+    with use_backend(Backend.CPP):
+        bezier = Bezier(control_points)
+
+    before = bezier.control_points.copy()
+    control_points[0, 0] = 99.0
+    assert np.array_equal(bezier.control_points, before)
+    assert not np.shares_memory(bezier.control_points, control_points)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_writing_through_control_points_is_refused(dtype: npt.DTypeLike) -> None:
+    """The array handed out is read-only, and the Bézier is unchanged either way.
+
+    What this catches: the way *out* of the same defect. A writable view would let
+    a caller edit a constructed geometry through the property, which is the half a
+    criterion about construction alone leaves unpinned.
+    """
+    with use_backend(Backend.CPP):
+        bezier = Bezier(np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype))
+
+    handed_out = bezier.control_points
+    assert not handed_out.flags.writeable
+    with pytest.raises(ValueError, match="read-only"):
+        handed_out[0, 0] = 99.0
+    assert bezier.control_points[0, 0] == 0.0
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_view_outlives_the_bezier_it_came_from(dtype: npt.DTypeLike) -> None:
+    """The array keeps the C++ storage alive after the handle is dropped.
+
+    What this catches: a view returned without an owner. The values would be read
+    from freed memory, which is a use-after-free that usually reads back correct
+    and occasionally does not -- so this asserts the values rather than merely that
+    nothing crashed.
+    """
+    import gc  # noqa: PLC0415 -- only this test needs a deterministic collection
+
+    with use_backend(Backend.CPP):
+        handed_out = Bezier(np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype)).control_points
+    gc.collect()
+    assert np.array_equal(handed_out, np.asarray([[0.0, 1.0], [2.0, 3.0]], dtype=dtype))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_a_bezier_survives_pickling_across_every_backend_pair(
+    dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """A pickle written under one backend loads under the other, at both dtypes.
+
+    What this catches: a `__reduce__` that reaches the implementation rather than
+    the constructor's arguments. The C++ handle is not picklable at all, and a
+    payload that carried one would make `PANTR_BACKEND` a data-format switch --
+    a pickle written on one machine unreadable on another. `copy.deepcopy` goes
+    through `__reduce_ex__` by the same route, so it is swept over the same pairs.
+    """
+    control_points = _control_points((4, 3), dtype, seed=20260829)
+    for writer in (Backend.PYTHON, Backend.CPP):
+        with use_backend(writer):
+            original = Bezier(control_points, is_rational)
+            payload = pickle.dumps(original)
+        for reader in (Backend.PYTHON, Backend.CPP):
+            where = f"{writer.name} -> {reader.name}"
+            with use_backend(reader):
+                loaded = pickle.loads(payload)
+                cloned = copy.deepcopy(original)
+            for rebuilt, how in ((loaded, "pickle"), (cloned, "deepcopy")):
+                assert rebuilt.control_points.tobytes() == control_points.tobytes(), (
+                    f"{where} {how}"
+                )
+                assert rebuilt.dtype == np.dtype(dtype), f"{where} {how}"
+                assert rebuilt.is_rational is is_rational, f"{where} {how}"
+                assert rebuilt.degree == original.degree, f"{where} {how}"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_an_unpickled_bezier_can_still_be_mutated_in_place(dtype: npt.DTypeLike) -> None:
+    """The wire format does not carry one backend's read-only flag to the other.
+
+    What this catches: `__reduce__` handing out the C++ backend's read-only view.
+    numpy preserves that flag through a pickle, so a payload written under the C++
+    backend would rebuild, under the Python backend, a Bézier whose stored array
+    cannot be written -- and `reverse(in_place=True)` would raise on an object the
+    caller built by ordinary means.
+    """
+    with use_backend(Backend.CPP):
+        payload = pickle.dumps(Bezier(np.asarray([[0.0], [1.0], [2.0]], dtype=dtype)))
+    with use_backend(Backend.PYTHON):
+        rebuilt = pickle.loads(payload)
+        rebuilt.reverse(in_place=True)
+    assert np.array_equal(rebuilt.control_points, np.asarray([[2.0], [1.0], [0.0]], dtype=dtype))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_in_place_mutators_agree_on_the_value_they_leave_behind(
+    dtype: npt.DTypeLike, is_rational: bool
+) -> None:
+    """`reverse`, `permute_directions` and `transform` agree under both backends.
+
+    What this catches: the C++ path's rebuild-the-implementation strategy losing
+    the rationality flag, the dtype or a permuted stride. Only the array's
+    *identity* is allowed to differ -- the C++ value owns its storage, so an
+    in-place mutation replaces it -- and `tests/test_transform.py` pins that
+    identity for the Python backend alone.
+    """
+    from pantr.transform import AffineTransform  # noqa: PLC0415
+
+    control_points = _control_points((3, 4, 3), dtype, seed=20260830)
+    shift = AffineTransform.translation([1.0, 2.0] if is_rational else [1.0, 2.0, 3.0])
+
+    def mutated(backend: Backend) -> Bezier:
+        # A fresh copy per backend, and not a convenience: the Python
+        # implementation aliases what it is given, so an in-place mutation under
+        # that backend edits `control_points` itself and the C++ run would then
+        # start from an already-reversed net. Sharing one array here made this
+        # test fail on every element while both backends were in fact correct.
+        with use_backend(backend):
+            bezier = Bezier(control_points.copy(), is_rational)
+            bezier.reverse(1, in_place=True)
+            bezier.permute_directions([1, 0], in_place=True)
+            bezier.transform(shift, in_place=True)
+            return bezier
+
+    assert_object_parity(
+        py=mutated(Backend.PYTHON),
+        cpp=mutated(Backend.CPP),
+        fields=FIELDS,
+        context=f"in-place reverse, permute and transform ({dtype}, rational={is_rational})",
+    )
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+def test_an_unsupported_dtype_is_refused_the_same_way_under_both_backends(
+    backend: Backend,
+) -> None:
+    """A dtype no kernel can evaluate is a `TypeError`, from the wrapper.
+
+    What this catches: the restriction living on the C++ side only, which would
+    make `PANTR_BACKEND` decide whether a `float16` control net is accepted. The
+    check is a type-kind check, so it belongs in the wrapper: nanobind's default
+    translator has no path that produces a `TypeError`.
+    """
+    with use_backend(backend), pytest.raises(TypeError, match="float32, float64"):
+        Bezier(np.zeros((3, 2), dtype=np.float16))
+
+
+@pytest.mark.parametrize("backend", [Backend.PYTHON, Backend.CPP])
+def test_integer_control_points_are_cast_to_float64_under_both_backends(
+    backend: Backend,
+) -> None:
+    """The one documented dtype conversion happens on both sides.
+
+    What this catches: the cast being skipped under the C++ backend, where the
+    `.noconvert()` on the binding would then refuse an integer array outright and
+    turn a documented convenience into a `TypeError`.
+    """
+    with use_backend(backend):
+        bezier = Bezier(np.asarray([[0, 0], [1, 1], [2, 0]], dtype=np.int64))
+    assert bezier.dtype == np.float64
+    assert bezier.degree == (2,)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_wrapper_holds_the_implementation_its_backend_selects(dtype: npt.DTypeLike) -> None:
+    """The dtype picks the class, and the backend picks the family.
+
+    What this catches: `_impl_class` ignoring its dtype argument. Every other
+    assertion in this file would still pass if it always returned `Bezier64`,
+    because nothing else here can see which class was chosen -- the `.noconvert()`
+    on the binding turns the mistake into a refusal for one direction only.
+    """
+    control_points = np.zeros((3, 2), dtype=dtype)
+    with use_backend(Backend.PYTHON):
+        assert isinstance(Bezier(control_points)._impl, _BezierPython)
+    with use_backend(Backend.CPP):
+        assert isinstance(Bezier(control_points)._impl, _cpp_class(dtype))

--- a/tests/parity/test_bezier_type.py
+++ b/tests/parity/test_bezier_type.py
@@ -205,6 +205,77 @@ def test_a_one_dimensional_control_net_is_reshaped_the_same_way(dtype: npt.DType
     assert cpp.control_points.shape == (4, 1)
 
 
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_rational", [False, True])
+def test_the_ieee_menagerie_transits_unchanged(dtype: npt.DTypeLike, is_rational: bool) -> None:
+    """NaN, both zeros, a subnormal and both infinities survive the copy.
+
+    What this catches: the whole premise of this file is that the two backends
+    only copy, and a copy is exactly where these values are cheap to test and
+    expensive to lose. A caster round-tripping through a wider intermediate, a
+    narrowing cast, or a memcpy replaced by element-wise assignment through a
+    different type all show first on a NaN payload, on a ``-0.0`` whose sign an
+    addition drops, or on a ``float32`` subnormal flushed to zero -- and every one
+    of those is invisible to a value comparison and visible bitwise, which is why
+    the claim on ``control_points`` is ``bitwise_parity`` and not a tolerance.
+
+    The finite specials and the NaN go through the same ``FIELDS``, so ``dtype``,
+    ``degree`` and ``rank`` are checked over them too: a Bézier of NaNs is not a
+    special case in the type's eyes and must not become one.
+
+    **The two infinities are asserted separately, and not by choice.**
+    ``assert_parity`` computes a diagnostic ``|actual - reference|`` before it
+    reports a bitwise result (``tests/_parity_harness.py``), and ``inf - inf``
+    raises the IEEE invalid flag, which numpy reports as ``RuntimeWarning:
+    invalid value encountered in subtract`` and this suite turns into an error.
+    So a bitwise claim cannot presently be made about an array holding an
+    infinity, and the harness is where that has to be fixed rather than here.
+    NaN is unaffected: quiet-NaN propagation raises no flag, so the harness's
+    claim to compare NaN by bit pattern holds as written.
+    """
+    finfo = np.finfo(np.dtype(dtype))
+    finite_specials = np.asarray(
+        [
+            [0.0, np.nan],
+            [-0.0, float(finfo.smallest_subnormal)],
+            [float(finfo.max), float(finfo.tiny)],
+        ],
+        dtype=dtype,
+    )
+    py, cpp = _both(finite_specials, is_rational=is_rational)
+    assert_object_parity(
+        py=py, cpp=cpp, fields=FIELDS, context=f"IEEE menagerie ({dtype}, {is_rational})"
+    )
+    # Asserted on the bytes rather than through the harness, because that is the
+    # specific loss this case exists for: `assert_object_parity` would pass if
+    # BOTH backends had flushed the subnormal or normalized the signed zero the
+    # same way, and it is the transit that is under test, not the agreement.
+    assert cpp.control_points.tobytes() == finite_specials.tobytes()
+
+    with_infinities = np.asarray([[np.inf, -np.inf], [1.0, -0.0]], dtype=dtype)
+    _, cpp_inf = _both(with_infinities, is_rational=is_rational)
+    assert cpp_inf.control_points.tobytes() == with_infinities.tobytes()
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_a_non_contiguous_control_net_reaches_both_backends_alike(dtype: npt.DTypeLike) -> None:
+    """A Fortran-ordered or strided array builds the same Bézier under either backend.
+
+    What this catches: the ``np.ascontiguousarray`` step in ``_new_impl``. The C++
+    binding refuses a non-contiguous array outright rather than copying it, so
+    without that step the public constructor would raise a ``TypeError`` about C++
+    argument types under one backend and succeed under the other. Nothing else
+    exercises the branch: ``test_bezier_binding_contract.py`` tests the raw
+    binding's refusal, which is the opposite path.
+    """
+    fortran = np.asfortranarray(np.arange(24.0, dtype=dtype).reshape(4, 3, 2))
+    strided = np.arange(48.0, dtype=dtype).reshape(8, 3, 2)[::2]
+    for control_points, how in ((fortran, "Fortran-ordered"), (strided, "strided")):
+        assert not control_points.flags.c_contiguous, how
+        py, cpp = _both(control_points, is_rational=False)
+        assert_object_parity(py=py, cpp=cpp, fields=FIELDS, context=f"{how} control net ({dtype})")
+
+
 def _message_of(build: Any) -> str:
     """The text of the `ValueError` that `build` raises.
 
@@ -229,12 +300,23 @@ MALFORMED: Final = (
     (lambda cls, dtype: cls(np.zeros((3, 0), dtype=dtype)), "no components at all"),
     (lambda cls, dtype: cls(np.zeros((3, 1), dtype=dtype), True), "a weight and nothing else"),
     (lambda cls, dtype: cls(np.zeros((3, 0), dtype=dtype), True), "a rational net of rank -1"),
+    (lambda cls, dtype: cls(np.zeros((0, 0), dtype=dtype), True), "bad in both ways at once"),
 )
 """Every construction both implementations must refuse, and what makes it bad.
 
-The last two are the rank check's two sides of zero: `rank -1` is the one that
-made the C++ subtraction signed, and an unsigned one would reject the input while
+Three of these are the rank check's sides of zero: `rank -1` is the one that made
+the C++ subtraction signed, and an unsigned one would reject the input while
 reporting a number near 2^64.
+
+**The last case is the only one bad in more than one way, and it is the one that
+pins the ORDER of the checks.** Every other entry violates exactly one rule, so
+each has one possible message and a reordering is invisible: measured, moving the
+oracle's rank check in front of its shape loop left this file entirely green.
+`(0, 0)` rational has an empty parametric direction *and* rank -1, so which
+message a caller reads is decided by the order alone, and
+`cpp/include/pantr/bezier/bezier.hpp` states that order as a cross-language
+contract. `cpp/tests/test_bezier_type.cpp` asserts the C++ half against a
+hardcoded literal; this is the half that compares it against the live oracle.
 """
 
 
@@ -338,6 +420,11 @@ def test_a_bezier_survives_pickling_across_every_backend_pair(
                 assert rebuilt.dtype == np.dtype(dtype), f"{where} {how}"
                 assert rebuilt.is_rational is is_rational, f"{where} {how}"
                 assert rebuilt.degree == original.degree, f"{where} {how}"
+                # `rank` folds the flag against the component axis, so it is the
+                # one field that would catch a round trip which kept the byte
+                # count and the per-direction degrees while moving which axis
+                # carries the components.
+                assert rebuilt.rank == original.rank, f"{where} {how}"
 
 
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/parity/test_bezier_type.py
+++ b/tests/parity/test_bezier_type.py
@@ -529,3 +529,41 @@ def test_the_wrapper_holds_the_implementation_its_backend_selects(dtype: npt.DTy
         assert isinstance(Bezier(control_points)._impl, _BezierPython)
     with use_backend(Backend.CPP):
         assert isinstance(Bezier(control_points)._impl, _cpp_class(dtype))
+
+
+def test_mutating_under_a_switched_backend_is_refused_rather_than_converted() -> None:
+    """An in-place mutator refuses a backend that is not the one this Bézier was built under.
+
+    Rebuilding the implementation reads the *active* backend, so without this
+    check a Bézier built under C++ and reversed inside a
+    ``use_backend(Backend.PYTHON)`` block came back as ``_BezierPython`` -- and
+    the caller's ``control_points`` went from read-only to writeable underneath
+    them, on an array they still held. Converting between two implementations of
+    one type is the shape ``design/cross_backend_types.md`` forbids;
+    :meth:`pantr.geometry.AABB._peer` already refuses it for a binary operation,
+    and this is the same rule for mutation.
+
+    ``Bezier`` is the first ported type with observable mutation, so it is the
+    first that could reach this at all: an immutable type only ever produces a
+    *derived* object under the other backend, never reconciles a live one.
+
+    Pins that the refusal leaves the object untouched, and that a mutation under
+    the matching backend still works -- a check that merely raises everywhere
+    would pass the first half.
+    """
+    control_points = np.array([[0.0], [1.0], [2.0]], dtype=np.float64)
+
+    with use_backend(Backend.CPP):
+        bezier = Bezier(control_points, is_rational=False)
+    assert not bezier.control_points.flags.writeable
+
+    with use_backend(Backend.PYTHON), pytest.raises(TypeError, match="different backend"):
+        bezier.reverse(in_place=True)
+
+    assert isinstance(bezier._impl, _cpp_class(np.dtype(np.float64)))
+    assert not bezier.control_points.flags.writeable
+    assert bezier.control_points.ravel().tolist() == [0.0, 1.0, 2.0]
+
+    with use_backend(Backend.CPP):
+        bezier.reverse(in_place=True)
+    assert bezier.control_points.ravel().tolist() == [2.0, 1.0, 0.0]

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -4,9 +4,20 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._backend import Backend, active_backend
 from pantr.bezier import Bezier, create_from_bspline
 from pantr.bspline import Bspline, BsplineSpace, BsplineSpace1D
 from pantr.quad import PointsLattice
+
+_SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
+    active_backend() is not Backend.PYTHON,
+    reason=(
+        "This records the Python Bezier's known aliasing defect rather than a contract: the "
+        "C++ value copies its control points at construction, so `copy=False` shares nothing "
+        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side."
+    ),
+)
+"""Marks an assertion that pins sharing only the Python implementation offers."""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -170,6 +181,7 @@ class TestBezierConversion:
         b_back = create_from_bspline(bs, copy=True)
         assert not np.shares_memory(bs.control_points, b_back.control_points)
 
+    @_SHARING_IS_PYTHON_ONLY
     def test_from_bspline_copy_false(self) -> None:
         """Test that from_bspline with copy=False shares the control point array."""
         b_orig = _make_bezier_1d([1.0, 2.0, 3.0])

--- a/tests/test_bezier.py
+++ b/tests/test_bezier.py
@@ -14,7 +14,9 @@ _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     reason=(
         "This records the Python Bezier's known aliasing defect rather than a contract: the "
         "C++ value copies its control points at construction, so `copy=False` shares nothing "
-        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side."
+        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side. The "
+        "C++ path is not left untested by the skip -- what it does instead is asserted in "
+        "tests/parity/test_bezier_type.py, which pins the copy at both ends."
     ),
 )
 """Marks an assertion that pins sharing only the Python implementation offers."""

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -24,7 +24,9 @@ _SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
     reason=(
         "This records the Python Bezier's known aliasing defect rather than a contract: the "
         "C++ value copies its control points at construction, so `copy=False` shares nothing "
-        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side."
+        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side. The "
+        "C++ path is not left untested by the skip -- what it does instead is asserted in "
+        "tests/parity/test_bezier_type.py, which pins the copy at both ends."
     ),
 )
 """Marks an assertion that pins sharing only the Python implementation offers."""

--- a/tests/test_bspline_conversion.py
+++ b/tests/test_bspline_conversion.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._backend import Backend, active_backend
 from pantr.bezier import Bezier
 from pantr.bspline import (
     Bspline,
@@ -17,6 +18,16 @@ from pantr.bspline import (
 from pantr.bspline._bspline_basis_core import _compute_basis_nurbs_book_impl
 from pantr.bspline._bspline_to_beziers import _first_basis_per_element
 from pantr.bspline.spanwise_element_extraction import SpanwiseElementExtraction
+
+_SHARING_IS_PYTHON_ONLY = pytest.mark.skipif(
+    active_backend() is not Backend.PYTHON,
+    reason=(
+        "This records the Python Bezier's known aliasing defect rather than a contract: the "
+        "C++ value copies its control points at construction, so `copy=False` shares nothing "
+        "under that backend; FELIGN/pantr#375 is the ticket that fixes the Python side."
+    ),
+)
+"""Marks an assertion that pins sharing only the Python implementation offers."""
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -563,6 +574,7 @@ class TestToBezier:
         bez = bs.to_bezier(copy=True)
         assert not np.shares_memory(bs.control_points, bez.control_points)
 
+    @_SHARING_IS_PYTHON_ONLY
     def test_copy_false(self) -> None:
         """Test that to_bezier with copy=False shares the control point array."""
         knots = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -21,7 +21,9 @@ _PYTHON_BACKEND_ONLY = pytest.mark.skipif(
         "This records the Python Bezier's known aliasing defect rather than a contract: the "
         "C++ value copies its control points and hands back a read-only view, so an in-place "
         "mutation replaces the array instead of writing into it; FELIGN/pantr#375 is the "
-        "ticket that fixes the Python side."
+        "ticket that fixes the Python side. The skip loses no coverage of the C++ path: the "
+        "value an in-place mutation leaves behind is compared across both backends in "
+        "tests/parity/test_bezier_type.py, and only the array's identity is unpinned here."
     ),
 )
 """Marks an assertion that pins aliasing only the Python implementation has."""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -8,11 +8,23 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+from pantr._backend import Backend, active_backend
 from pantr.transform import AffineTransform
 
 if TYPE_CHECKING:
     from pantr.bezier import Bezier
     from pantr.bspline import Bspline
+
+_PYTHON_BACKEND_ONLY = pytest.mark.skipif(
+    active_backend() is not Backend.PYTHON,
+    reason=(
+        "This records the Python Bezier's known aliasing defect rather than a contract: the "
+        "C++ value copies its control points and hands back a read-only view, so an in-place "
+        "mutation replaces the array instead of writing into it; FELIGN/pantr#375 is the "
+        "ticket that fixes the Python side."
+    ),
+)
+"""Marks an assertion that pins aliasing only the Python implementation has."""
 
 # ======================================================================
 # Helpers
@@ -513,6 +525,7 @@ class TestBezierTransform:
         assert result is None
         npt.assert_allclose(b.control_points[0], [5.0, 5.0])
 
+    @_PYTHON_BACKEND_ONLY
     def test_inplace_no_extra_alloc(self) -> None:
         """in_place=True writes directly into the existing array."""
         b = _make_bezier_1d([[0.0, 0.0], [1.0, 1.0]])

--- a/tools/adversarial_sweep/_probes_bezier.py
+++ b/tools/adversarial_sweep/_probes_bezier.py
@@ -435,7 +435,10 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
     )
     # The remaining three are conveniences the `control_points` docstring promises
     # outright: "A 1D input of shape (n,) is reshaped to (n, 1) (scalar field). Integer
-    # arrays are cast to float64" -- and, by omission, float32 is left alone.
+    # arrays are cast to float64; float32 and float64 are stored as they are." The last
+    # clause used to hold only by omission; since the type moved to C++ there are exactly
+    # two registered storage formats and the constructor states them, which is what the
+    # float16 case below pins.
     yield Case(
         GROUP,
         "construct_1d_list_reshape",
@@ -475,6 +478,18 @@ def _construct_cases(profile: Profile) -> Iterator[Case]:
         ),
         arrays={"control_points": float32_cp},
         must_succeed=True,
+    )
+    # The complement of the two cases above, and the one this group did not have: a
+    # float dtype that is neither of the two a Bezier can store. It used to build a
+    # Bezier no kernel below it could evaluate, which is a rejection deferred to
+    # whichever call site reached numba first.
+    yield Case(
+        GROUP,
+        "construct_float16_refused",
+        Bezier,
+        lambda: Bezier(np.zeros((3, 2), dtype=np.float16)),
+        {"kind": "unsupported-dtype"},
+        must_reject=True,
     )
 
 


### PR DESCRIPTION
Moves the `Bezier` **value type** to C++ ownership, with Python wrapping it. Ports no algebra:
evaluation, degree, shape and product operations are #389–#392, which are blocked on this and
inherit the shape it sets.

`Closes #385` — closing keywords do not fire on a non-default base, so close by hand after merge.

**Base is `build/380-shared-files-for-type-port` (PR #406), not `proto/cpp`.** Merge that first.

## Acceptance criteria

| AC | Evidence |
|---|---|
| `AC1` | `pytest -q` → `7562 passed, 41 skipped, 7 xfailed`; `PANTR_BACKEND=cpp pytest -q` → `7559 passed, 44 skipped, 7 xfailed` |
| `AC2` | `make doctest` → `82 passed, 7 skipped`; `reverse(in_place=True)` still prints nothing under both backends |
| `AC3` | the C++ value does not alias the array it was built from, at both dtypes; writing through `control_points` raises `ValueError: assignment destination is read-only` |
| `AC4` | the three narrowed skips fire with reasons naming #375 and where the C++ side is covered instead |
| `AC5` | pickle round-trips over 4 writer/reader pairs × 2 dtypes × 2 rationalities × {pickle, deepcopy}, asserting bytes, dtype, flag, degree and `rank` |
| `AC6` | whole suite green under `PANTR_BACKEND=cpp`, so every `match=` regex still matches; reinforced by a verbatim character-for-character message comparison |
| `AC7` | five mutations, each caught — see below |

Machinery: ruff clean · `mypy Success: no issues found in 291 source files` · `lint-imports` 2 kept ·
`ctest --preset gcc` 26/26 · `ctest --preset gcc-debug` (ASan+UBSan) clean.

**Extension-skip check:** `64 skipped` with the `.so` moved aside, `62 passed, 2 skipped` restored.
Zero pass without the extension, so the parity suite cannot be comparing the oracle with itself.

## The type, and what #389–#392 inherit

```cpp
namespace pantr::bezier {
  template <Real T> class ControlNet {          // control_net.hpp, new
      std::span<const T> values() const;        // row-major, owned copy
      std::span<const std::size_t> shape() const;   // always >= 2 entries
  };
  template <Real T> class Bezier {
      Bezier(ControlNet<T> net, bool is_rational);
      bool is_rational();  std::size_t dim(), rank(), degree(d);
  };
}
```

Settled here so four tickets do not each re-decide it:

- **Storage is flat + shape, row-major, owned by value.** No mdspan of variable rank is needed.
- **`ControlNet` is deliberately not a Bézier.** `extent()` is the net's, `degree()` the Bézier's,
  because an extent means `degree+1` here and a basis count in a B-spline. Milestone 2's `Bspline`
  can reuse it unchanged.
- **Rational convention:** coordinates stored weighted, weight last,
  `rank() == num_components() - is_rational()`, the subtraction deliberately signed because the
  oracle reports `rank -1`.
- **Validation order is a cross-language contract:** shape first, rank second, now pinned against
  the live oracle rather than a hardcoded literal.
- **`(n,)` reads as `(n, 1)`**, so a C++ caller and a Python caller meet one definition.
- **`control_points` is a read-only view**, not a copy, with the Python object as owner.

## Two classes, `Bezier32` and `Bezier64`

Unlike `AABB` and `AffineTransform`, a Bézier has a genuine float32 oracle, so a double-only
binding would have been a surface with no oracle behind it in the *opposite* direction. The class
name is the only carrier of the storage format, enforced by `.noconvert()` on every ndarray
argument whose dtype selects the class — without it nanobind casts silently and `Bezier32(float64)`
narrows the caller's geometry with nothing left to notice.

**This narrows the public constructor.** Previously any dtype numpy could produce built a `Bezier`
(`float16`, `bool`, `longdouble`), none of which any kernel below it can evaluate; those now raise
`TypeError` from the wrapper under both backends. Checked against the downstream consumer, which
has zero `pantr.bezier` exposure and already carries a test asserting that neither of its two
exotic dtypes is built by pantr — so this makes explicit what that consumer already relies on.

## A design ruling this PR carries out

A `Bezier` built under the C++ backend and mutated in place inside `use_backend(Backend.PYTHON)`
silently became a `_BezierPython`, and the caller's `control_points` went from read-only to
writeable on an array they still held. The value stayed correct, so nothing failed. Converting
between two implementations of one type is the shape `design/cross_backend_types.md` forbids, and
`AABB._peer` already refuses a mismatched pair for a binary operation rather than converting.

**Ruled: refuse, do not convert.** `Bezier` is the first ported type able to reach this at all —
an immutable type only ever produces a *derived* object under the other backend, never reconciles
a live one. The test pins both halves, since a check that raised unconditionally would pass the
first: the refusal leaves implementation, read-only flag and values untouched, and a mutation
under the matching backend still works.

## Mutation checks

| Mutation | C++ `test_bezier_type` | pytest |
|---|---|---|
| rational branch inverted | aborted | **66 failed** |
| degree loses its `- 1` | failed | **67 failed** |
| `control_points` handed out writable | **passed** — correctly, out of its scope | **2 failed**, exactly the intended pair |
| rank-1 shape promotion removed | failed | failed |
| oracle reordered: rank before shape | n/a | **2 failed**, exactly the new both-ways-bad case |

The third is the instructive one: the C++ test cannot see it, because the read-only flag lives in
the binding. Only the Python-side criterion catches it. The fifth was `0 failures` before this PR
added the one case that is bad in two ways at once.

The bitwise claim was verified over **10 000 random Béziers** (dim 1–4, extents 1–7, 1–5
components, both dtypes, values across each format's whole exponent range with NaN, ±inf, ±0 and
subnormals mixed in; 9 175 carried a NaN): **0 failures**, against 20 parametrizations that ship.

## Tolerances

**None written, none moved, none reused.** The type stores coefficients and answers shape
questions; there is no arithmetic between the two backends, so every claim is `bitwise_parity` or
`exact_parity`. Stated explicitly because the standing rule fires on any new tolerance.

## Review

An independent `reviewer` (this branch's own two were lost to a session limit and re-run
afterwards) plus a `test-writer` audit. **No critical and no important finding.** It verified by
running rather than reading: a 2000-object view-lifetime stress test after `del`/`gc.collect()`
with 200 k intervening allocations found 0/2000 corrupted views, and every numpy route to a
writable alias (`.base`, `np.asarray`, `.view()`, `np.frombuffer`, setting the flag) is refused.
Findings closed or carried: 2 `R`, 1 `S`, 1 `N`.

## Scaffolding

One, inherited rather than new: `cpp/include/pantr/bezier/bezier.hpp` is now the type header and
still includes `kernels_1d.hpp`, because `cpp/consumer/main.cpp` uses the old path and the
installed header set is a compatibility promise. Removed by a deliberate decision to break that
set. `ci_local.sh`'s `consumer: build` and `consumer: run` both pass, which is what proves the
forwarder still works against the *installed* package.

## Known, carried forward

- `scripts/ci_local.sh` fails at the g++-10 floor build on `geometry/aabb.hpp` — floating-point
  `std::to_chars` needs libstdc++ 11. Pre-existing, independently reproduced against a pristine
  base, ticket pending.
- A `Rule 8` citation in three sibling binding files is a misattribution. The decisions those
  comments justify are sound; only the citation is wrong. Reported, not fixed — those files belong
  to other tickets.
- `make docs` has not been run on this branch, and `nitpicky = True`.
