### PR TITLE
feat(quad): own QuadratureRule in C++ and wrap it from Python

### DIFF
--- a/cpp/bindings/quad_types.cpp
+++ b/cpp/bindings/quad_types.cpp
@@ -1,15 +1,147 @@
 /// \file
-/// nanobind bindings for `pantr::quad::QuadratureRule` -- reserved, empty.
+/// nanobind bindings for `pantr::quad::QuadratureRule`.
 ///
-/// The module's three assembly points (`pantr_cpp.cpp`, `register.hpp` and
-/// `CMakeLists.txt`) are edited once, here, so the ticket that ports the type
-/// edits this file and nothing else. Thirteen tickets in this milestone would
-/// otherwise collide on those three.
+/// The third binding that exposes a type rather than kernels, after
+/// `geometry.cpp` and `transform.cpp`. Under the 2026-08-27 amendment to
+/// `design/cross_backend_types.md` the rule is owned by C++ and
+/// `src/pantr/quad/_rule_nd.py` holds one.
+///
+/// ## `double` only, and here it is not a choice
+///
+/// `pantr.quad.QuadratureRule` casts points and weights to `float64`
+/// unconditionally, so there is no `float32` oracle a second overload could be
+/// parity against -- `design/backend_parity.md` Rule 8. The header is
+/// `double`-only for that reason and for the measured one `scripts/ci_local.sh`
+/// enforces, so unlike `AABB` there is no generic version to narrow *from*.
+///
+/// ## What this file validates, and what it does not
+///
+/// Almost nothing, and the exceptions are the point. The type validates its own
+/// arguments and throws `std::invalid_argument`, which nanobind surfaces as
+/// `ValueError` -- the exception the oracle raises for the same inputs. What
+/// stays on this side is only what the C++ signature cannot express:
+///
+///  - **Rank and dtype**, refused by nanobind's typed signature before the body
+///    runs. A rank error therefore reaches Python as `TypeError`, where the
+///    oracle raises `ValueError`, so `_rule_nd.py` checks rank *before* calling
+///    and this layer never sees a wrong-rank array from the ordinary path.
+///  - **The `(ndim, npts)` calling convention** of `gauss_legendre_quadrature`,
+///    which exists only in Python: the C++ factory takes one span and reads the
+///    dimension off it, so there is no second argument for the two to disagree
+///    about. `_rule_nd.py` owns those two checks for the same reason.
+///
+/// ## The pair, and why it is not a `Rule1D` here
+///
+/// The header takes `std::span<const Rule1D>` so that a C++ caller cannot pair
+/// one axis's nodes with another's weights (FELIGN/pantr#358). That guarantee
+/// stops at this boundary on purpose: `tensor_product_quadrature`'s **public
+/// Python signature** already takes `Sequence[tuple[nodes, weights]]`, it is not
+/// this ticket's to change, and binding `Rule1D` as a Python class would expose a
+/// non-owning view of two numpy buffers whose lifetime nothing here controls. So
+/// the pairs are unpacked into named locals immediately below and turned into
+/// `Rule1D`s before anything else happens, which is the narrowest place the
+/// transposition can still be made and the one line that has to be read.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
+#include <cstddef>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/quad/rule.hpp"
 #include "register.hpp"
 
-void register_quad_types(nanobind::module_&) {
-    // Nothing yet: the port adds the `nanobind::class_` for the type here.
+namespace nb = nanobind;
+
+namespace {
+
+using Rule = pantr::quad::QuadratureRule;
+
+/// A read-only, contiguous 1D `float64` array as nanobind sees it.
+using const_vec = nb::ndarray<const double, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A read-only, contiguous 2D `float64` array as nanobind sees it.
+using const_mat = nb::ndarray<const double, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// One axis's `(nodes, weights)` pair as it crosses the boundary.
+using Pair1D = std::pair<const_vec, const_vec>;
+
+/// View a 1D nanobind array as a span.
+///
+/// \param a The array.
+/// \return A span over its storage, valid while the array is alive.
+std::span<const double> as_span(const const_vec& a) {
+    return {a.data(), a.shape(0)};
+}
+
+/// Copy a contiguous block into a freshly allocated, read-only numpy array.
+///
+/// Copied rather than viewed, for the same reason as `AABB`'s corners and the
+/// affine map's matrix: a view could outlive the rule, and the rule is immutable
+/// precisely so that nobody has to reason about when its storage changes. The
+/// Python wrapper caches the result, so a rule is copied out once rather than
+/// once per attribute read.
+///
+/// \param data The block to copy.
+/// \param rows Row count; zero means a 1D result.
+/// \param cols Column count, or the length when `rows` is zero.
+/// \return An owning `float64` array, flagged read-only.
+nb::object to_numpy(const double* data, std::size_t rows, std::size_t cols) {
+    const std::size_t total = (rows == 0 ? cols : rows * cols);
+    auto* owned = new std::vector<double>(data, data + total);
+    nb::capsule owner(owned,
+                      [](void* p) noexcept { delete static_cast<std::vector<double>*>(p); });
+    if (rows == 0) {
+        return nb::cast(
+            nb::ndarray<nb::numpy, const double, nb::ndim<1>>(owned->data(), {cols}, owner));
+    }
+    return nb::cast(
+        nb::ndarray<nb::numpy, const double, nb::ndim<2>>(owned->data(), {rows, cols}, owner));
+}
+
+/// Build the tensor product from per-axis `(nodes, weights)` pairs.
+///
+/// \param axes One pair per axis.
+/// \return The rule.
+Rule tensor_product(const std::vector<Pair1D>& axes) {
+    std::vector<pantr::quad::Rule1D> rules;
+    rules.reserve(axes.size());
+    for (const auto& [nodes, weights] : axes) {
+        rules.push_back(pantr::quad::Rule1D{as_span(nodes), as_span(weights)});
+    }
+    return Rule::tensor_product(rules);
+}
+
+}  // namespace
+
+void register_quad_types(nb::module_& m) {
+    nb::class_<Rule>(m, "QuadratureRule")
+        .def(
+            "__init__",
+            [](Rule* self, const_mat points, const_vec weights) {
+                new (self) Rule(
+                    pantr::span2d<const double>(points.data(), points.shape(0), points.shape(1)),
+                    as_span(weights));
+            },
+            nb::arg("points"), nb::arg("weights"))
+        .def_static("tensor_product", &tensor_product, nb::arg("rules"))
+        .def_static(
+            "gauss_legendre",
+            [](const std::vector<int>& npts) { return Rule::gauss_legendre(npts); },
+            nb::arg("npts"))
+        .def_prop_ro("ndim", &Rule::ndim)
+        .def_prop_ro("num_points", &Rule::num_points)
+        .def_prop_ro("points",
+                     [](const Rule& r) {
+                         return to_numpy(r.points().data_handle(), r.num_points(), r.ndim());
+                     })
+        .def_prop_ro("weights",
+                     [](const Rule& r) { return to_numpy(r.weights().data(), 0, r.num_points()); })
+        .def("__repr__", &Rule::to_string);
 }

--- a/cpp/include/pantr/quad/rule.hpp
+++ b/cpp/include/pantr/quad/rule.hpp
@@ -1,0 +1,355 @@
+#pragma once
+
+/// \file
+/// The reference quadrature rule on the unit cube, and the two factories that
+/// build one.
+///
+/// ## Why this header contains a class
+///
+/// `design/cross_backend_types.md`'s 2026-08-27 supersession names
+/// `QuadratureRule` among the domain types a C++ program has to be able to build
+/// with no interpreter present. `AABB` and `AffineTransform` moved first and are
+/// the working precedent; this is the same move, applied to `pantr.quad`.
+///
+/// Like those two, and unlike every kernel header in this directory, the type
+/// **validates and throws** rather than asserting. It is the C++ counterpart of
+/// Layer 2, not a Layer 3 kernel, so its checks stand in a release build; a
+/// caller with no Python cannot be protected by `cpp/bindings/`.
+///
+/// ## `double` only, and not templated on the scalar
+///
+/// Two independent reasons, and the second is enforced.
+///
+///  1. **It is faithful.** `src/pantr/quad/_rule_nd.py` casts points and weights
+///     to `float64` unconditionally, so there is no `float32` oracle a templated
+///     instantiation could be parity against, and `design/backend_parity.md`
+///     Rule 8 forbids a surface with no oracle behind it.
+///  2. **`scripts/ci_local.sh` asserts it.** Exactly one `template <` may appear
+///     under `cpp/include/pantr/quad`, and it must be the one in
+///     `simple_rules.hpp`. The guard's recorded reason is measured: instantiating
+///     Newton at `float` gave a 1.46e-3 relative weight error at n = 200, while a
+///     double-then-narrow port of the Chebyshev nodes differed on 17% of
+///     `float32` arguments. So this file declares no template of its own -- it
+///     *uses* `span2d`, which is declared in `pantr/core/mdspan.hpp` and is not
+///     under this directory.
+///
+/// ## `Rule1D`, and the defect class it closes
+///
+/// The tensor-product factory needs one 1-D rule per axis. Written as two
+/// parallel sequences of spans it would admit a transposed call that pairs every
+/// axis's nodes with the wrong axis's weights -- silently, with no type error and
+/// no shape mismatch whenever the counts happen to agree. That is the defect
+/// recorded by FELIGN/pantr#358 for `dedup_roots`, met a second time here, so the
+/// pair is a named struct instead. It does not exist in the Python either; it is
+/// new, and it exists to make the transposition unspellable rather than to tidy.
+///
+/// ## Parity notes for the Python oracle
+///
+/// Three places where reproducing `src/pantr/quad/_rule_nd.py` exactly takes care.
+///
+///  - **The weight of a tensor-product point is accumulated left to right.** The
+///    oracle forms it as `np.prod(..., axis=0)` over an `(ndim, num_points)`
+///    block, which reduces axis 0 in order, so `((w0 * w1) * w2)`. Any other
+///    association differs in the last bits from three axes up.
+///  - **Points are enumerated in C order, last axis fastest**, matching
+///    `np.meshgrid(..., indexing="ij")` followed by `ravel()`, and matching
+///    `pantr.grid.TensorProductGrid` cell ids. Each coordinate is a copy of a
+///    node, so that half of the rule is exact by construction.
+///  - **The map from `[-1, 1]` onto `[0, 1]` is `(x + 1) * 0.5` and `w * 0.5`**,
+///    the same two operations in the same order as
+///    `pantr.quad._rules._scale_and_cast_nodes_and_weights`. Both are elementwise
+///    and both are pinned by IEEE 754, so the map is common mode and cancels
+///    exactly; `design/backend_parity.md` Rule 1 is why that matters and why the
+///    bound would otherwise have to be transported.
+///
+/// ## The messages are the oracle's, verbatim
+///
+/// A caller that catches on a message must not see `PANTR_BACKEND` change what
+/// the library says. So the text below names the *Python* entry points
+/// (`tensor_product_quadrature`, `gauss_legendre_quadrature`) even where the C++
+/// spelling differs, which is the same decision `AABB` took for `union` /`merge`.
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "pantr/core/error.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/quad/legendre.hpp"
+
+namespace pantr::quad {
+
+namespace detail {
+
+/// Render a length the way Python renders a 1-D shape tuple.
+///
+/// \param n The length.
+/// \return `"(n,)"`.
+[[nodiscard]] inline std::string format_shape(std::size_t n) {
+    return "(" + std::to_string(n) + ",)";
+}
+
+/// Render two extents the way Python renders a 2-D shape tuple.
+///
+/// \param rows The first extent.
+/// \param cols The second extent.
+/// \return `"(rows, cols)"`.
+[[nodiscard]] inline std::string format_shape(std::size_t rows, std::size_t cols) {
+    return "(" + std::to_string(rows) + ", " + std::to_string(cols) + ")";
+}
+
+/// Render point counts the way Python's `repr` renders a tuple of ints.
+///
+/// The trailing comma of a one-element tuple is part of that spelling, and the
+/// oracle interpolates the tuple with `!r`, so it has to be reproduced.
+///
+/// \param counts The per-axis counts.
+/// \return `"(2, 3)"`, or `"(2,)"` for a single axis.
+[[nodiscard]] inline std::string format_counts(std::span<const int> counts) {
+    std::string text = "(";
+    for (std::size_t d = 0; d < counts.size(); ++d) {
+        if (d > 0) {
+            text += ", ";
+        }
+        text += std::to_string(counts[d]);
+    }
+    if (counts.size() == 1) {
+        text += ",";
+    }
+    return text + ")";
+}
+
+}  // namespace detail
+
+/// One axis's 1-D rule: nodes and weights that must not be transposed.
+///
+/// A non-owning view of two arrays the caller keeps alive for the duration of
+/// the call. See this file's comment for why the pair is named rather than
+/// passed as two adjacent same-typed spans.
+struct Rule1D {
+    std::span<const double> nodes;    ///< The axis's nodes, on `[0, 1]`.
+    std::span<const double> weights;  ///< The matching weights, of equal length.
+};
+
+/// An immutable quadrature rule on the unit cube `[0, 1]^ndim`.
+///
+/// Bundles quadrature points and weights as the *reference* rule that
+/// `pantr.grid.cell_quadrature` affinely maps onto each cell of a grid. Points
+/// lie in the closed unit cube; the rules the two factories build have weights
+/// summing to `1`, the measure of the unit cube, so the rule integrates the
+/// constant `1` to within the rounding of that sum and not exactly.
+///
+/// Instances are immutable: there is no operation that changes an existing rule,
+/// and both factories return by value.
+class QuadratureRule {
+  public:
+    /// Build a rule from its points and weights, validating them.
+    ///
+    /// \param points `(num_points, ndim)` table of points, each coordinate in
+    ///        `[0, 1]`.
+    /// \param weights `(num_points,)` weights. Any finite value is legal,
+    ///        negative ones included: several legitimate rules (Newton-Cotes past
+    ///        degree 8, moment-fitted rules) carry them, and the oracle checks
+    ///        neither sign nor sum.
+    /// \throws std::invalid_argument If either extent of `points` is zero, the
+    ///         two lengths disagree, any value is not finite, or any coordinate
+    ///         lies outside `[0, 1]`.
+    QuadratureRule(span2d<const double> points, std::span<const double> weights)
+        : points_(), weights_(weights.begin(), weights.end()), num_points_(points.extent(0)),
+          ndim_(points.extent(1)) {
+        if (num_points_ == 0 || ndim_ == 0) {
+            throw std::invalid_argument("points must be non-empty; got shape "
+                                        + detail::format_shape(num_points_, ndim_) + ".");
+        }
+        if (weights_.size() != num_points_) {
+            throw std::invalid_argument("weights length " + std::to_string(weights_.size())
+                                        + " must match the number of points "
+                                        + std::to_string(num_points_) + ".");
+        }
+        points_.resize(num_points_ * ndim_);
+        for (std::size_t i = 0; i < num_points_; ++i) {
+            for (std::size_t d = 0; d < ndim_; ++d) {
+                points_[i * ndim_ + d] = at(points, i, d);
+            }
+        }
+        // The three loops are separate and in this order because the oracle
+        // reports the first failure of each kind in exactly this order, and the
+        // message a caller sees is part of the contract.
+        for (const double value : points_) {
+            if (!std::isfinite(value)) {
+                throw std::invalid_argument("points must contain only finite values.");
+            }
+        }
+        for (const double value : weights_) {
+            if (!std::isfinite(value)) {
+                throw std::invalid_argument("weights must contain only finite values.");
+            }
+        }
+        for (const double value : points_) {
+            if (value < 0.0 || value > 1.0) {
+                throw std::invalid_argument("points must lie in the unit cube [0, 1]^ndim.");
+            }
+        }
+    }
+
+    /// Build the tensor product of one 1-D rule per axis.
+    ///
+    /// Points are enumerated in row-major order -- the last axis varies fastest,
+    /// matching `pantr.grid.TensorProductGrid` cell ids -- and each weight is the
+    /// product of the corresponding per-axis weights, accumulated from axis 0
+    /// upwards.
+    ///
+    /// \param rules One 1-D rule per axis, at least one.
+    /// \return The `rules.size()`-dimensional rule on `[0, 1]^ndim`.
+    /// \throws std::invalid_argument If `rules` is empty, if any axis carries an
+    ///         empty or mismatched `(nodes, weights)` pair, or -- through the
+    ///         constructor -- if any node lies outside `[0, 1]` or is not finite.
+    /// \throws CapacityError If the point count, or the point table it implies,
+    ///         does not fit `std::size_t`. The oracle instead dies inside numpy's
+    ///         allocator, so the two backends diverge in a regime neither can
+    ///         serve; this is the limit of *this* build rather than a defect in
+    ///         the argument, which is why it is not `std::invalid_argument`.
+    [[nodiscard]] static QuadratureRule tensor_product(std::span<const Rule1D> rules) {
+        if (rules.empty()) {
+            throw std::invalid_argument(
+                "tensor_product_quadrature: rules must have at least one axis.");
+        }
+        const std::size_t ndim = rules.size();
+        std::size_t num_points = 1;
+        for (std::size_t d = 0; d < ndim; ++d) {
+            const std::size_t count = rules[d].nodes.size();
+            if (count == 0 || count != rules[d].weights.size()) {
+                throw std::invalid_argument(
+                    "tensor_product_quadrature: axis " + std::to_string(d)
+                    + " needs matching non-empty (nodes, weights); got shapes "
+                    + detail::format_shape(count) + " and "
+                    + detail::format_shape(rules[d].weights.size()) + ".");
+            }
+            require_product_fits(num_points, count);
+            num_points *= count;
+        }
+        require_product_fits(num_points, ndim);
+
+        std::vector<double> points(num_points * ndim);
+        std::vector<double> weights(num_points);
+        std::vector<std::size_t> index(ndim, 0);
+        for (std::size_t i = 0; i < num_points; ++i) {
+            // Left to right, matching `np.prod(..., axis=0)` over the oracle's
+            // (ndim, num_points) block. See this file's comment.
+            double weight = rules[0].weights[index[0]];
+            points[i * ndim] = rules[0].nodes[index[0]];
+            for (std::size_t d = 1; d < ndim; ++d) {
+                points[i * ndim + d] = rules[d].nodes[index[d]];
+                weight *= rules[d].weights[index[d]];
+            }
+            weights[i] = weight;
+            // Odometer over the axes, last one fastest.
+            for (std::size_t d = ndim; d-- > 0;) {
+                if (++index[d] < rules[d].nodes.size()) {
+                    break;
+                }
+                index[d] = 0;
+            }
+        }
+        return QuadratureRule(span2d<const double>(points.data(), num_points, ndim), weights);
+    }
+
+    /// Build the tensor product of per-axis Gauss-Legendre rules.
+    ///
+    /// Exact for tensor-product polynomials of per-axis degree `2 * npts[d] - 1`;
+    /// the weights sum to `1` up to the rounding of that sum.
+    ///
+    /// \param npts Points per axis; `npts.size()` is the spatial dimension.
+    /// \return The tensor-product Gauss-Legendre rule on `[0, 1]^ndim`.
+    /// \throws std::invalid_argument If `npts` is empty or any entry is below 1.
+    /// \throws CapacityError As for `tensor_product`.
+    [[nodiscard]] static QuadratureRule gauss_legendre(std::span<const int> npts) {
+        if (npts.empty()) {
+            throw std::invalid_argument("gauss_legendre_quadrature: ndim must be >= 1; got 0.");
+        }
+        for (const int count : npts) {
+            if (count < 1) {
+                throw std::invalid_argument(
+                    "gauss_legendre_quadrature: every npts entry must be >= 1; got "
+                    + detail::format_counts(npts) + ".");
+            }
+        }
+        const std::size_t ndim = npts.size();
+        std::vector<std::vector<double>> nodes(ndim);
+        std::vector<std::vector<double>> weights(ndim);
+        std::vector<Rule1D> rules(ndim);
+        for (std::size_t d = 0; d < ndim; ++d) {
+            const auto count = static_cast<std::size_t>(npts[d]);
+            nodes[d].resize(count);
+            weights[d].resize(count);
+            gauss_legendre_symmetric(npts[d], nodes[d], weights[d]);
+            // The oracle's map onto [0, 1], operation for operation. Elementwise
+            // and pinned by IEEE 754, so it is common mode across the backends.
+            for (std::size_t i = 0; i < count; ++i) {
+                nodes[d][i] = (nodes[d][i] + 1.0) * 0.5;
+                weights[d][i] = weights[d][i] * 0.5;
+            }
+            rules[d] = Rule1D{nodes[d], weights[d]};
+        }
+        return tensor_product(rules);
+    }
+
+    /// The spatial dimension.
+    ///
+    /// \return The number of axes, `>= 1`.
+    [[nodiscard]] std::size_t ndim() const noexcept { return ndim_; }
+
+    /// The number of quadrature points.
+    ///
+    /// \return The point count, `>= 1`.
+    [[nodiscard]] std::size_t num_points() const noexcept { return num_points_; }
+
+    /// The quadrature points.
+    ///
+    /// \return A `(num_points, ndim)` view of the stored points, valid while the
+    ///         rule lives.
+    [[nodiscard]] span2d<const double> points() const noexcept {
+        return span2d<const double>(points_.data(), num_points_, ndim_);
+    }
+
+    /// The quadrature weights.
+    ///
+    /// \return A view of the stored weights, valid while the rule lives.
+    [[nodiscard]] std::span<const double> weights() const noexcept { return weights_; }
+
+    /// A compact representation, matching the oracle's `__repr__`.
+    ///
+    /// Only two integers, so there is none of the float-formatting difficulty
+    /// `AABB` had to solve. The Python wrapper formats its own `__repr__`
+    /// regardless, so this is what a C++ caller sees.
+    ///
+    /// \return `"QuadratureRule(ndim=..., num_points=...)"`.
+    [[nodiscard]] std::string to_string() const {
+        return "QuadratureRule(ndim=" + std::to_string(ndim_)
+               + ", num_points=" + std::to_string(num_points_) + ")";
+    }
+
+  private:
+    /// Reject a product of sizes that would wrap around.
+    ///
+    /// \param value The running product.
+    /// \param factor What it is about to be multiplied by; must be non-zero.
+    /// \throws CapacityError If the product would exceed `SIZE_MAX`.
+    static void require_product_fits(std::size_t value, std::size_t factor) {
+        if (value > std::numeric_limits<std::size_t>::max() / factor) {
+            throw CapacityError("tensor_product_quadrature: the point count does not fit "
+                                "this platform's size type.");
+        }
+    }
+
+    std::vector<double> points_;   ///< Points, row-major, `num_points * ndim` long.
+    std::vector<double> weights_;  ///< Weights, `num_points` long.
+    std::size_t num_points_;       ///< Number of points, `>= 1`.
+    std::size_t ndim_;             ///< Number of axes, `>= 1`.
+};
+
+}  // namespace pantr::quad

--- a/cpp/include/pantr/quad/rule.hpp
+++ b/cpp/include/pantr/quad/rule.hpp
@@ -24,8 +24,8 @@
 ///     to `float64` unconditionally, so there is no `float32` oracle a templated
 ///     instantiation could be parity against, and `design/backend_parity.md`
 ///     Rule 8 forbids a surface with no oracle behind it.
-///  2. **`scripts/ci_local.sh` asserts it.** Exactly one `template <` may appear
-///     under `cpp/include/pantr/quad`, and it must be the one in
+///  2. **`scripts/ci_local.sh` asserts it.** Exactly one template declaration may
+///     appear under `cpp/include/pantr/quad`, and it must be the one in
 ///     `simple_rules.hpp`. The guard's recorded reason is measured: instantiating
 ///     Newton at `float` gave a 1.46e-3 relative weight error at n = 200, while a
 ///     double-then-narrow port of the Chebyshev nodes differed on 17% of

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -17,7 +17,8 @@ set(PANTR_TEST_SOURCES
     test_grid_hierarchical.cpp
     test_aabb.cpp
     test_affine.cpp
-    test_bezier_type.cpp)
+    test_bezier_type.cpp
+    test_quad_rule.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -41,7 +42,6 @@ set(PANTR_PLACEHOLDER_TEST_SOURCES
     test_grid_bvh_type.cpp
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp
-    test_quad_rule.cpp
     test_bezier_evaluate.cpp
     test_bezier_degree.cpp
     test_bezier_shape.cpp

--- a/cpp/tests/test_quad_rule.cpp
+++ b/cpp/tests/test_quad_rule.cpp
@@ -66,6 +66,7 @@
 #include <vector>
 
 #include "check.hpp"
+#include "pantr/core/error.hpp"
 #include "pantr/core/mdspan.hpp"
 #include "pantr/quad/rule.hpp"
 
@@ -252,6 +253,48 @@ void test_tensor_product_validates() {
     }) == "points must lie in the unit cube [0, 1]^ndim.");
 }
 
+void test_tensor_product_refuses_a_point_count_that_cannot_be_indexed() {
+    // 64 axes of two nodes is 2**64 points, one past what `std::size_t` can
+    // index. The guard fires inside the validation loop, so it costs 64 span
+    // reads and allocates nothing -- which is what makes this testable at all.
+    //
+    // `CapacityError` rather than `std::invalid_argument`, because the argument is
+    // well formed and it is this platform's index type that runs out;
+    // `pantr/core/error.hpp` draws that line. It reaches Python as a subclass of
+    // RuntimeError, which is also what the oracle raises here (numpy's own
+    // 32-dimension ceiling), so the two backends agree on the class if not on the
+    // ceiling -- see tests/parity/test_quad_rule.py.
+    const std::vector<double> nodes{0.25, 0.75};
+    const std::vector<double> weights{0.5, 0.5};
+    const std::vector<Rule1D> too_many(64, Rule1D{nodes, weights});
+    bool threw = false;
+    try {
+        (void)QuadratureRule::tensor_product(too_many);
+    } catch (const pantr::CapacityError&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a point count past SIZE_MAX must be refused, not wrapped");
+
+    // 63 axes is refused too, and by the SECOND guard rather than the first:
+    // 2**63 points fit `std::size_t`, but the (num_points, ndim) table they imply
+    // does not. Written down because the two guards are easy to mistake for one,
+    // and because this is the only case that reaches the second.
+    const std::vector<Rule1D> table_too_wide(63, Rule1D{nodes, weights});
+    threw = false;
+    try {
+        (void)QuadratureRule::tensor_product(table_too_wide);
+    } catch (const pantr::CapacityError&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "a point TABLE past SIZE_MAX must be refused as well");
+
+    // And the guard is not simply refusing anything large: 16 axes is 65536
+    // points, which builds. Without this the two checks above would also pass
+    // against a factory that refused every tensor product outright.
+    const std::vector<Rule1D> merely_large(16, Rule1D{nodes, weights});
+    PANTR_CHECK(QuadratureRule::tensor_product(merely_large).num_points() == 65536);
+}
+
 void test_tensor_product_orders_last_axis_fastest() {
     // The two axes carry disjoint node sets, so a transposed or reversed
     // enumeration cannot reproduce this table by accident.
@@ -380,6 +423,7 @@ int main() {
     test_the_boundary_and_a_negative_weight_are_legal();
     test_the_rule_copies_its_arguments();
     test_tensor_product_validates();
+    test_tensor_product_refuses_a_point_count_that_cannot_be_indexed();
     test_tensor_product_orders_last_axis_fastest();
     test_gauss_legendre_validates();
     test_gauss_legendre_one_point_is_the_midpoint_rule();

--- a/cpp/tests/test_quad_rule.cpp
+++ b/cpp/tests/test_quad_rule.cpp
@@ -1,17 +1,391 @@
 /// \file
-/// Reserved slot for the pantr::quad::QuadratureRule tests -- no assertions yet.
+/// Properties of the reference quadrature rule on the unit cube.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// ## Why these cases and not others
+///
+/// The type does three things, and each fails in its own way:
+///
+///  - **Validation.** It is the C++ counterpart of Layer 2, so a caller with no
+///    Python is protected by these throws and nothing else. The messages are
+///    checked verbatim rather than by exception type, because
+///    `design/backend_parity.md` treats what the library *says* as part of the
+///    contract, and a message that drifts here makes `PANTR_BACKEND` change it.
+///  - **Ordering.** The tensor product's whole observable content is which node
+///    lands at which row. A transposed or reversed enumeration produces an array
+///    of the right shape holding the right multiset of numbers, which no shape
+///    check and no sum can see. `test_tensor_product_orders_last_axis_fastest`
+///    pins it against two axes whose node sets are disjoint.
+///  - **Arithmetic.** Only two places compute anything: the weight product, and
+///    the Gauss-Legendre generation behind the second factory. Both are checked
+///    against an oracle independent of this file -- the exact rational moment of
+///    a monomial, and the exact product of two binary-exact weights.
+///
+/// ## The tolerance, and where every term comes from
+///
+/// Two assertions below compare a floating-point sum against an exact rational
+/// value, so both need a bound. It is the same bound, built once in
+/// `moment_bound` and derived rather than fitted.
+///
+/// Write `u = eps/2` for the unit roundoff, `N` for the point count, `ndim` for
+/// the number of axes, `n_d` for the count on axis `d`, and `M` for the total
+/// monomial degree `sum_d m_d`. Every term of `sum_i w_i prod_d x_id^{m_d}` is
+/// **non-negative** -- Gauss-Legendre weights are positive and the cube lies in
+/// the first orthant -- so the sum is perfectly conditioned, and every relative
+/// bound below becomes an absolute one on multiplying by the exact value, which
+/// is at most 1.
+///
+///  1. **Summation**: `N - 1` additions of a positive sum, `(N - 1) u`.
+///  2. **Evaluating the monomial**: `M` multiplications to form the powers and
+///     `ndim` to multiply them into the weight, `(M + ndim) u`.
+///  3. **Displaced nodes**: `design/backend_parity.md` Rule 4 bounds the
+///     Gauss-Legendre node displacement at `4.5 u` absolute on `[-1, 1]`, flat in
+///     `n`. The map onto `[0, 1]` halves it and adds two roundings of its own, so
+///     `4.5 u` covers it in that frame too. `|d/dx_d prod_d x^{m_d}| <= m_d` on
+///     the cube, so the monomial moves by at most `M * 4.5 u`.
+///  4. **Perturbed weights**: Rule 4 again, `|dw_i| <= u (4.5 A_i |w_i| + 5 |w_i|)`
+///     with `A_i = 2|x_i| / (1 - x_i^2)`, and `max_i A_i |w_i| <= 2.6` uniformly
+///     in `n` -- SUPPORTED there by a sweep to n = 2000, not proved. Summing over
+///     one axis gives `u (11.7 n_d + 5)`. A tensor weight is a product of `ndim`
+///     of them, whose relative errors add, and the remaining axes' weights sum to
+///     1, so the axes' contributions add: `u sum_d (11.7 n_d + 5)`. Plus `ndim - 1`
+///     roundings for forming the product itself.
+///
+/// The sum of the four is what `moment_bound` returns. It is conservative -- the
+/// Python class's docstring records a *measured* worst case of 4 ulp for the
+/// weight sum in 3-D -- and it is still twelve orders below the values compared,
+/// so it asserts something rather than admitting anything. Rule 3's vacuity trap
+/// is guarded from the other side too: `test_gauss_legendre_integrates_monomials`
+/// checks that one degree above the rule's claim the same bound is *exceeded*.
 
-#include <cstdio>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/quad/rule.hpp"
+
+namespace {
+
+using pantr::at;
+using pantr::quad::QuadratureRule;
+using pantr::quad::Rule1D;
+
+constexpr double kUnitRoundoff = std::numeric_limits<double>::epsilon() / 2.0;
+constexpr double kNodeDisplacementUnits = 4.5;  ///< Rule 4, absolute, flat in n.
+constexpr double kWeightAmplification = 11.7;   ///< 4.5 * 2.6, from Rule 4's sup.
+constexpr double kWeightFormulaRoundings = 5.0;
+
+/// Build a rule from a flat row-major point table, for brevity below.
+///
+/// \param points Row-major `(num_points, ndim)` values.
+/// \param ndim Number of axes.
+/// \param weights One weight per point.
+/// \return The rule.
+QuadratureRule rule_of(const std::vector<double>& points, std::size_t ndim,
+                       const std::vector<double>& weights) {
+    return QuadratureRule(pantr::span2d<const double>(points.data(), weights.size(), ndim),
+                          std::span<const double>(weights));
+}
+
+/// The message of the `std::invalid_argument` a call raises, or a marker.
+///
+/// \param fn The call to attempt.
+/// \return The exception's `what()`, or a string naming what happened instead.
+template <class F>
+std::string message_of(F&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& exc) {
+        return exc.what();
+    } catch (...) {
+        return "<a different exception>";
+    }
+    return "<no exception>";
+}
+
+/// The derived absolute bound on a weighted monomial moment; see the file comment.
+///
+/// \param counts Points per axis.
+/// \param degrees Monomial degree per axis, same length as `counts`.
+/// \return The bound, absolute.
+double moment_bound(std::span<const int> counts, std::span<const int> degrees) {
+    const auto ndim = static_cast<double>(counts.size());
+    double num_points = 1.0;
+    double total_degree = 0.0;
+    double weight_terms = 0.0;
+    for (std::size_t d = 0; d < counts.size(); ++d) {
+        num_points *= static_cast<double>(counts[d]);
+        total_degree += static_cast<double>(degrees[d]);
+        weight_terms +=
+            kWeightAmplification * static_cast<double>(counts[d]) + kWeightFormulaRoundings;
+    }
+    const double summation = num_points - 1.0;
+    const double evaluation = total_degree + ndim;
+    const double displaced_nodes = total_degree * kNodeDisplacementUnits;
+    const double product = ndim - 1.0;
+    return kUnitRoundoff * (summation + evaluation + displaced_nodes + weight_terms + product);
+}
+
+/// Evaluate `sum_i w_i prod_d x_id^{m_d}` over a rule.
+///
+/// \param rule The rule.
+/// \param degrees One exponent per axis.
+/// \return The quadrature approximation of the monomial's integral.
+double moment(const QuadratureRule& rule, std::span<const int> degrees) {
+    const auto points = rule.points();
+    double total = 0.0;
+    for (std::size_t i = 0; i < rule.num_points(); ++i) {
+        double term = rule.weights()[i];
+        for (std::size_t d = 0; d < rule.ndim(); ++d) {
+            for (int k = 0; k < degrees[d]; ++k) {
+                term *= at(points, i, d);
+            }
+        }
+        total += term;
+    }
+    return total;
+}
+
+void test_construction_validates() {
+    const std::vector<double> one_point{0.5};
+    const std::vector<double> one_weight{1.0};
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<double> empty{};
+        (void)QuadratureRule(pantr::span2d<const double>(empty.data(), 0, 1),
+                             std::span<const double>(empty));
+    }) == "points must be non-empty; got shape (0, 1).");
+
+    PANTR_CHECK(message_of([&one_point] {
+        (void)QuadratureRule(pantr::span2d<const double>(one_point.data(), 1, 0),
+                             std::span<const double>(one_point));
+    }) == "points must be non-empty; got shape (1, 0).");
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<double> points{0.25, 0.75};
+        const std::vector<double> weights{1.0};
+        (void)QuadratureRule(pantr::span2d<const double>(points.data(), 2, 1),
+                             std::span<const double>(weights));
+    }) == "weights length 1 must match the number of points 2.");
+
+    PANTR_CHECK(message_of([&one_weight] {
+        const std::vector<double> points{std::numeric_limits<double>::infinity()};
+        (void)rule_of(points, 1, one_weight);
+    }) == "points must contain only finite values.");
+
+    PANTR_CHECK(message_of([&one_point] {
+        const std::vector<double> weights{std::numeric_limits<double>::quiet_NaN()};
+        (void)rule_of(one_point, 1, weights);
+    }) == "weights must contain only finite values.");
+
+    PANTR_CHECK(message_of([&one_weight] {
+        const std::vector<double> points{-0.25};
+        (void)rule_of(points, 1, one_weight);
+    }) == "points must lie in the unit cube [0, 1]^ndim.");
+
+    PANTR_CHECK(message_of([&one_weight] {
+        const std::vector<double> points{1.5};
+        (void)rule_of(points, 1, one_weight);
+    }) == "points must lie in the unit cube [0, 1]^ndim.");
+
+    // A NaN coordinate is reported as non-finite rather than as out of range:
+    // `NaN < 0.0` and `NaN > 1.0` are both false, so the ORDER of the two checks
+    // decides the message, and the oracle checks finiteness first.
+    PANTR_CHECK(message_of([&one_weight] {
+        const std::vector<double> points{std::numeric_limits<double>::quiet_NaN()};
+        (void)rule_of(points, 1, one_weight);
+    }) == "points must contain only finite values.");
+}
+
+void test_the_boundary_and_a_negative_weight_are_legal() {
+    // Lobatto-style endpoints, and a negative weight: neither is an error. The
+    // class documents no constraint on weight sign or sum, and Newton-Cotes past
+    // degree 8 and moment-fitted rules both carry negative weights.
+    const std::vector<double> points{0.0, 1.0};
+    const std::vector<double> weights{-1.0, 2.0};
+    const QuadratureRule rule = rule_of(points, 1, weights);
+    PANTR_CHECK(rule.ndim() == 1);
+    PANTR_CHECK(rule.num_points() == 2);
+    PANTR_CHECK(rule.weights()[0] == -1.0);
+}
+
+void test_the_rule_copies_its_arguments() {
+    std::vector<double> points{0.5};
+    const std::vector<double> weights{1.0};
+    const QuadratureRule rule = rule_of(points, 1, weights);
+    points[0] = 0.25;
+    PANTR_CHECK_MSG(at(rule.points(), 0, 0) == 0.5, "the rule aliased its caller's array");
+}
+
+void test_tensor_product_validates() {
+    PANTR_CHECK(message_of([] { (void)QuadratureRule::tensor_product({}); })
+                == "tensor_product_quadrature: rules must have at least one axis.");
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<double> nodes{0.25, 0.75};
+        const std::vector<double> weights{1.0};
+        const std::vector<Rule1D> rules{Rule1D{nodes, weights}};
+        (void)QuadratureRule::tensor_product(rules);
+    }) == "tensor_product_quadrature: axis 0 needs matching non-empty (nodes, weights); "
+          "got shapes (2,) and (1,).");
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<double> good{0.5};
+        const std::vector<double> none{};
+        const std::vector<Rule1D> rules{Rule1D{good, good}, Rule1D{none, none}};
+        (void)QuadratureRule::tensor_product(rules);
+    }) == "tensor_product_quadrature: axis 1 needs matching non-empty (nodes, weights); "
+          "got shapes (0,) and (0,).");
+
+    // A node outside the cube is the constructor's to reject, and this message
+    // proves the factory delegates rather than re-checking.
+    PANTR_CHECK(message_of([] {
+        const std::vector<double> nodes{2.0};
+        const std::vector<double> weights{1.0};
+        const std::vector<Rule1D> rules{Rule1D{nodes, weights}};
+        (void)QuadratureRule::tensor_product(rules);
+    }) == "points must lie in the unit cube [0, 1]^ndim.");
+}
+
+void test_tensor_product_orders_last_axis_fastest() {
+    // The two axes carry disjoint node sets, so a transposed or reversed
+    // enumeration cannot reproduce this table by accident.
+    const std::vector<double> nodes_0{0.1, 0.2};
+    const std::vector<double> weights_0{0.25, 0.75};
+    const std::vector<double> nodes_1{0.7, 0.8, 0.9};
+    const std::vector<double> weights_1{0.5, 0.25, 0.25};
+    const std::vector<Rule1D> rules{Rule1D{nodes_0, weights_0}, Rule1D{nodes_1, weights_1}};
+
+    const QuadratureRule rule = QuadratureRule::tensor_product(rules);
+    PANTR_CHECK(rule.ndim() == 2);
+    PANTR_CHECK(rule.num_points() == 6);
+
+    const auto points = rule.points();
+    for (std::size_t i = 0; i < 6; ++i) {
+        const std::size_t i0 = i / 3;
+        const std::size_t i1 = i % 3;
+        PANTR_CHECK_MSG(at(points, i, 0) == nodes_0[i0], "axis 0 node at row " + std::to_string(i));
+        PANTR_CHECK_MSG(at(points, i, 1) == nodes_1[i1], "axis 1 node at row " + std::to_string(i));
+        // Both factors are exact in binary, so their product is exact and this is
+        // an equality rather than a bound.
+        PANTR_CHECK_MSG(rule.weights()[i] == weights_0[i0] * weights_1[i1],
+                        "weight at row " + std::to_string(i));
+    }
+}
+
+void test_gauss_legendre_validates() {
+    PANTR_CHECK(message_of([] { (void)QuadratureRule::gauss_legendre({}); })
+                == "gauss_legendre_quadrature: ndim must be >= 1; got 0.");
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<int> npts{0};
+        (void)QuadratureRule::gauss_legendre(npts);
+    }) == "gauss_legendre_quadrature: every npts entry must be >= 1; got (0,).");
+
+    PANTR_CHECK(message_of([] {
+        const std::vector<int> npts{2, -1};
+        (void)QuadratureRule::gauss_legendre(npts);
+    }) == "gauss_legendre_quadrature: every npts entry must be >= 1; got (2, -1).");
+}
+
+void test_gauss_legendre_one_point_is_the_midpoint_rule() {
+    // The one rule whose values are exactly writable down: the single node is the
+    // exact centre and the weight is the exact measure of the cube, so this is an
+    // equality rather than a bound.
+    const std::vector<int> npts{1, 1};
+    const QuadratureRule rule = QuadratureRule::gauss_legendre(npts);
+    PANTR_CHECK(rule.num_points() == 1);
+    PANTR_CHECK(at(rule.points(), 0, 0) == 0.5);
+    PANTR_CHECK(at(rule.points(), 0, 1) == 0.5);
+    PANTR_CHECK(rule.weights()[0] == 1.0);
+}
+
+void test_gauss_legendre_integrates_monomials() {
+    // n-point Gauss-Legendre is exact to degree 2n - 1 per axis. The oracle is
+    // the exact rational moment of x^m on [0, 1], namely 1/(m + 1), which owes
+    // nothing to this file.
+    const std::vector<int> npts{4, 3};
+    const QuadratureRule rule = QuadratureRule::gauss_legendre(npts);
+    PANTR_CHECK(rule.num_points() == 12);
+
+    for (int m0 = 0; m0 <= 7; ++m0) {
+        for (int m1 = 0; m1 <= 5; ++m1) {
+            const std::vector<int> degrees{m0, m1};
+            const double exact =
+                1.0 / static_cast<double>(m0 + 1) / static_cast<double>(m1 + 1);
+            const double got = moment(rule, degrees);
+            const double bound = moment_bound(npts, degrees);
+            PANTR_CHECK_MSG(std::abs(got - exact) <= bound,
+                            "degree (" + std::to_string(m0) + ", " + std::to_string(m1)
+                                + "): " + std::to_string(got) + " against "
+                                + std::to_string(exact) + ", bound " + std::to_string(bound));
+        }
+    }
+
+    // One degree above what the rule claims, the quadrature must NOT reproduce
+    // the moment. Without this the loop above would also pass for a bound so
+    // loose that it admits a genuinely different answer.
+    const std::vector<int> too_high{8, 0};
+    PANTR_CHECK_MSG(std::abs(moment(rule, too_high) - 1.0 / 9.0) > moment_bound(npts, too_high),
+                    "degree 8 is beyond a 4-point rule and must not be reproduced");
+}
+
+void test_gauss_legendre_weights_sum_to_the_measure_of_the_cube() {
+    // Degree zero on every axis, so the monomial is the constant 1 and its exact
+    // integral is the measure of the unit cube.
+    const std::vector<int> degrees{0, 0, 0};
+    for (const int n : {1, 2, 5, 17}) {
+        const std::vector<int> npts{n, n, n};
+        const QuadratureRule rule = QuadratureRule::gauss_legendre(npts);
+        double total = 0.0;
+        for (const double w : rule.weights()) {
+            total += w;
+        }
+        PANTR_CHECK_MSG(std::abs(total - 1.0) <= moment_bound(npts, degrees),
+                        "weight sum at n = " + std::to_string(n) + ": " + std::to_string(total));
+    }
+}
+
+void test_gauss_legendre_maps_a_large_rule_into_the_open_cube() {
+    // The constructor would have thrown had a node left the cube, so this says
+    // the factory reaches it, and it is the one place a 200-point rule is built.
+    const std::vector<int> npts{200};
+    const QuadratureRule rule = QuadratureRule::gauss_legendre(npts);
+    PANTR_CHECK(rule.num_points() == 200);
+    const auto points = rule.points();
+    bool ascending = true;
+    for (std::size_t i = 1; i < rule.num_points(); ++i) {
+        ascending = ascending && at(points, i - 1, 0) < at(points, i, 0);
+    }
+    PANTR_CHECK_MSG(ascending, "the mapped nodes must stay strictly ascending");
+    PANTR_CHECK(at(points, 0, 0) > 0.0);
+    PANTR_CHECK(at(points, rule.num_points() - 1, 0) < 1.0);
+}
+
+void test_to_string_names_both_counts() {
+    const std::vector<int> npts{2, 3};
+    PANTR_CHECK(QuadratureRule::gauss_legendre(npts).to_string()
+                == "QuadratureRule(ndim=2, num_points=6)");
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_quad_rule asserts nothing yet");
+    test_construction_validates();
+    test_the_boundary_and_a_negative_weight_are_legal();
+    test_the_rule_copies_its_arguments();
+    test_tensor_product_validates();
+    test_tensor_product_orders_last_axis_fastest();
+    test_gauss_legendre_validates();
+    test_gauss_legendre_one_point_is_the_midpoint_rule();
+    test_gauss_legendre_integrates_monomials();
+    test_gauss_legendre_weights_sum_to_the_measure_of_the_cube();
+    test_gauss_legendre_maps_a_large_rule_into_the_open_cube();
+    test_to_string_names_both_counts();
     return pantr::test::summary("test_quad_rule");
 }

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -75,6 +75,7 @@ from ._grid import encode_midx as encode_midx
 from ._grid import hier_collect_cell_bounds as hier_collect_cell_bounds
 from ._grid import hier_locate_points as hier_locate_points
 from ._grid import locate_points as locate_points
+from ._quad import QuadratureRule as QuadratureRule
 from ._quad import gauss_legendre_symmetric as gauss_legendre_symmetric
 from ._quad import generate_tanh_sinh as generate_tanh_sinh
 from ._quad import lambert_w_principal as lambert_w_principal

--- a/src/pantr/_pantr_cpp/_quad.pyi
+++ b/src/pantr/_pantr_cpp/_quad.pyi
@@ -1,8 +1,12 @@
-"""Quadrature-rule kernels of the compiled extension.
+"""Quadrature kernels and the quadrature rule type of the compiled extension.
 
-Bound by ``cpp/bindings/quad.cpp``. See ``__init__.pyi`` for what this package
-promises and who has to keep it.
+The kernels are bound by ``cpp/bindings/quad.cpp`` and :class:`QuadratureRule`
+by ``cpp/bindings/quad_types.cpp``; both land in the one extension module, so
+one stub module covers them. See ``__init__.pyi`` for what this package promises
+and who has to keep it.
 """
+
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -247,3 +251,63 @@ def modified_chebyshev_nodes(
         ValueError: If ``n`` is less than 2, if ``n`` is too large to fit a C
             ``int``, or if ``out``'s length is not exactly ``n``.
     """
+
+class QuadratureRule:
+    """Reference quadrature rule on the unit cube, owned by the C++ core.
+
+    The third type this extension exposes rather than a free function, under the
+    2026-08-27 amendment to ``design/cross_backend_types.md``. Wrapped by
+    :class:`pantr.quad.QuadratureRule`, which is the class a caller holds; this
+    one is reached only through it.
+
+    Every method here is ``double``-only and there is no second overload, unlike
+    :func:`modified_chebyshev_nodes` above. The reason is not symmetry: the
+    oracle casts points and weights to ``float64`` unconditionally, so a
+    ``float32`` surface would have no oracle behind it
+    (``design/backend_parity.md`` Rule 8), and ``scripts/ci_local.sh`` asserts
+    that no template appears in ``cpp/include/pantr/quad/rule.hpp`` for the
+    measured reason recorded there.
+
+    What is checked, and where:
+
+    * dtype (float64 only), rank, C-contiguity and device of ``points`` and
+      ``weights``, by nanobind's typed signature, before the body runs -- so a
+      wrong-rank array reaches Python as ``TypeError`` where the oracle raises
+      ``ValueError``, and :mod:`pantr.quad._rule_nd` checks rank before calling;
+    * emptiness, the length agreement between points and weights, finiteness,
+      and membership of the closed unit cube, in the C++ constructor;
+    * for :meth:`tensor_product`, that there is at least one axis and that each
+      axis carries a matching non-empty ``(nodes, weights)`` pair, in C++;
+    * for :meth:`gauss_legendre`, that ``npts`` is non-empty and every entry is
+      at least 1, in C++. The Python-only ``(ndim, npts)`` convention -- a
+      negative ``ndim``, or a sequence of the wrong length -- has no counterpart
+      here and is checked by :mod:`pantr.quad._rule_nd`.
+
+    Call :class:`pantr.quad.QuadratureRule` and its two factories for the
+    ordinary path.
+
+    Attributes:
+        ndim (int): Spatial dimension, ``>= 1``.
+        num_points (int): Number of quadrature points, ``>= 1``.
+        points (npt.NDArray[np.float64]): ``(num_points, ndim)`` array in
+            ``[0, 1]^ndim``, freshly allocated and read-only on every access.
+        weights (npt.NDArray[np.float64]): ``(num_points,)`` array, likewise.
+    """
+
+    def __init__(
+        self, points: npt.NDArray[np.float64], weights: npt.NDArray[np.float64]
+    ) -> None: ...
+    @property
+    def ndim(self) -> int: ...
+    @property
+    def num_points(self) -> int: ...
+    @property
+    def points(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def weights(self) -> npt.NDArray[np.float64]: ...
+    @staticmethod
+    def tensor_product(
+        rules: Sequence[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+    ) -> QuadratureRule: ...
+    @staticmethod
+    def gauss_legendre(npts: Sequence[int]) -> QuadratureRule: ...

--- a/src/pantr/quad/__init__.py
+++ b/src/pantr/quad/__init__.py
@@ -9,6 +9,7 @@ This module provides:
 - :class:`QuadratureRule`: a d-dimensional quadrature rule on the unit cube,
   with :func:`tensor_product_quadrature` and :func:`gauss_legendre_quadrature`
   factories; the reference rule consumed by :func:`pantr.grid.cell_quadrature`.
+  Owned by the C++ core and wrapped here; see :mod:`pantr.quad._rule_nd`.
 """
 
 from ._lattice import PointsLattice, create_lagrange_points_lattice
@@ -41,6 +42,10 @@ from ._rules import (
 # Rebind __module__ so pickles and repr() report the public path, not the
 # private submodule they are actually defined in.  Both classes are pickled
 # by mpi4py for collective calls (see pantr.mpi._l2, pantr.mpi._collocation).
+# QuadratureRule is a wrapper over the C++ type since the 2026-08-27 amendment
+# to design/cross_backend_types.md, which makes this load-bearing rather than
+# cosmetic: `__reduce__` names `type(self)`, so a pickle written by one backend
+# has to resolve to the same public class under the other.
 PointsLattice.__module__ = __name__
 QuadratureRule.__module__ = __name__
 

--- a/src/pantr/quad/_rule_nd.py
+++ b/src/pantr/quad/_rule_nd.py
@@ -34,6 +34,25 @@ if TYPE_CHECKING:
 _POINTS_NDIM = 2
 """Rank of the ``points`` argument: ``(num_points, ndim)``."""
 
+_MAX_NPTS = 2**31 - 1
+"""Largest point count per axis a Gauss-Legendre rule can be asked for.
+
+Not a policy: it is the range of the C ``int`` that carries the count.
+``pantr::quad::QuadratureRule::gauss_legendre`` takes ``std::span<const int>``
+and ``pantr::gauss_legendre_symmetric`` takes ``int n``, so a larger value cannot
+cross without wrapping -- the same quantity ``cpp/bindings/quad.cpp`` caps as
+``max_count`` for the 1-D kernel, and capped here for the same reason.
+
+It is checked on this side rather than in C++ because **no C integer type can
+carry an arbitrary-precision Python int**: whatever width the binding declares, a
+large enough argument fails in nanobind's caster as a ``TypeError``, which is the
+one exception class ``cpp/include/pantr/core/error.hpp`` records the C++ side
+cannot produce deliberately. Measured before this guard existed,
+``gauss_legendre_quadrature(1, 10**20)`` raised ``TypeError`` under the C++
+backend and ``ValueError`` under the Python one, so ``PANTR_BACKEND`` decided
+which exception a caller had to catch.
+"""
+
 
 def _validate_ranks(pts: npt.NDArray[np.float64], wts: npt.NDArray[np.float64]) -> None:
     """Reject a points or weights array of the wrong rank.
@@ -495,14 +514,22 @@ def tensor_product_quadrature(
 
 
 def _normalize_npts(ndim: int, npts: int | Sequence[int]) -> tuple[int, ...]:
-    """Broadcast the point count over the axes and check the Python-only contract.
+    """Broadcast the point count over the axes and check the whole ``npts`` contract.
 
-    Both checks here belong to the ``(ndim, npts)`` calling convention, which
-    exists in Python and not in C++: ``QuadratureRule::gauss_legendre`` takes one
-    span and reads the dimension off it, so there is no second argument for the
-    two to disagree about, and a negative ``ndim`` cannot be recovered from the
-    broadcast tuple in order to be reported. ``cpp/include/pantr/core/error.hpp``'s
-    rule still holds for everything else: the per-entry range check lives in C++.
+    Every check here is one the C++ signature cannot express, which is what puts
+    them on this side of ``cpp/include/pantr/core/error.hpp``'s rule rather than in
+    the type. The ``(ndim, npts)`` convention exists only in Python --
+    ``QuadratureRule::gauss_legendre`` takes one span and reads the dimension off
+    it, so there is no second argument for the two to disagree about, and a
+    negative ``ndim`` cannot be recovered from the broadcast tuple in order to be
+    reported. The two per-entry bounds are here for a related reason: an
+    arbitrary-precision Python int has no C type to arrive in, so a value outside
+    :data:`_MAX_NPTS` fails in nanobind's caster as a ``TypeError`` before any C++
+    check could run. See :data:`_MAX_NPTS`.
+
+    The C++ factory keeps its own copies of the lower bound and the emptiness
+    check. That is not a duplicated contract but a type defending itself for a
+    caller that has no Python at all.
 
     Args:
         ndim (int): Number of axes (``>= 1``).
@@ -512,7 +539,8 @@ def _normalize_npts(ndim: int, npts: int | Sequence[int]) -> tuple[int, ...]:
         tuple[int, ...]: The per-axis counts, of length ``ndim``.
 
     Raises:
-        ValueError: If ``ndim < 1`` or ``npts`` is a sequence of the wrong length.
+        ValueError: If ``ndim < 1``, ``npts`` is a sequence of the wrong length, or
+            any count is below 1 or above :data:`_MAX_NPTS`.
     """
     if ndim < 1:
         raise ValueError(f"gauss_legendre_quadrature: ndim must be >= 1; got {ndim}.")
@@ -521,6 +549,15 @@ def _normalize_npts(ndim: int, npts: int | Sequence[int]) -> tuple[int, ...]:
         raise ValueError(
             f"gauss_legendre_quadrature: npts must be a scalar or a length-{ndim} sequence; "
             f"got length {len(npts_tuple)}."
+        )
+    if any(n < 1 for n in npts_tuple):
+        raise ValueError(
+            f"gauss_legendre_quadrature: every npts entry must be >= 1; got {npts_tuple!r}."
+        )
+    if any(n > _MAX_NPTS for n in npts_tuple):
+        raise ValueError(
+            f"gauss_legendre_quadrature: every npts entry must be at most {_MAX_NPTS}, "
+            f"the largest count a C int can carry; got {npts_tuple!r}."
         )
     return npts_tuple
 
@@ -533,16 +570,13 @@ def _gauss_legendre_quadrature_python(npts: tuple[int, ...]) -> _QuadratureRuleP
     on this side; ``design/backend_parity.md`` Rule 1 is why that map matters.
 
     Args:
-        npts (tuple[int, ...]): Points per axis, already broadcast to ``ndim``.
+        npts (tuple[int, ...]): Points per axis, already broadcast to ``ndim`` and
+            already range-checked by :func:`_normalize_npts`, which is this
+            function's only caller.
 
     Returns:
         _QuadratureRulePython: The tensor-product Gauss-Legendre rule.
-
-    Raises:
-        ValueError: If any count is ``< 1``.
     """
-    if any(n < 1 for n in npts):
-        raise ValueError(f"gauss_legendre_quadrature: every npts entry must be >= 1; got {npts!r}.")
     rules = [get_gauss_legendre_1d(n, dtype=np.float64) for n in npts]
     return _tensor_product_quadrature_python(_coerce_axis_rules(rules))
 

--- a/src/pantr/quad/_rule_nd.py
+++ b/src/pantr/quad/_rule_nd.py
@@ -1,17 +1,78 @@
-"""Multi-dimensional quadrature rules on the unit cube (:class:`QuadratureRule`)."""
+"""Multi-dimensional quadrature rules on the unit cube (:class:`QuadratureRule`).
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the rule
+itself is owned by the C++ core (``cpp/include/pantr/quad/rule.hpp``) and
+:class:`QuadratureRule` here is a wrapper holding one. Ownership moved rather
+than being duplicated: there is one implementation of a rule and one Python class
+in front of it. Under ``PANTR_BACKEND=python`` the thing held is
+:class:`_QuadratureRulePython`, the port's oracle, which is temporary.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
 import numpy.typing as npt
 
+from pantr._backend import Backend, active_backend, available_backends
+
 from ._rules import get_gauss_legendre_1d
 
+if TYPE_CHECKING:
+    from pantr._pantr_cpp import QuadratureRule as _CppQuadratureRule
 
-class QuadratureRule:
-    """Immutable quadrature rule on the unit cube ``[0, 1]^ndim``.
+    _Impl: TypeAlias = "_QuadratureRulePython | _CppQuadratureRule"
+    """The implementation a :class:`QuadratureRule` holds; see :func:`_use_python`.
+
+    Type-checking only. The two are unrelated nominal types that happen to offer
+    the same surface, which is the port's whole claim; naming the union here is
+    what lets the checker verify it instead of taking it on trust.
+    """
+
+_POINTS_NDIM = 2
+"""Rank of the ``points`` argument: ``(num_points, ndim)``."""
+
+
+def _validate_ranks(pts: npt.NDArray[np.float64], wts: npt.NDArray[np.float64]) -> None:
+    """Reject a points or weights array of the wrong rank.
+
+    Shared by the oracle and the wrapper's C++ branch rather than left to the C++
+    type, and that is forced rather than chosen: nanobind's typed signature
+    refuses a wrong-rank array with a ``TypeError``, and
+    ``cpp/include/pantr/core/error.hpp`` records that no C++ exception reaches
+    Python as one. The oracle raises ``ValueError`` here, so the check has to
+    happen before the call.
+
+    Args:
+        pts (npt.NDArray[np.float64]): The points array.
+        wts (npt.NDArray[np.float64]): The weights array.
+
+    Raises:
+        ValueError: If ``pts`` is not 2D or ``wts`` is not 1D.
+    """
+    if pts.ndim != _POINTS_NDIM:
+        raise ValueError(f"points must be 2D (num_points, ndim); got shape {pts.shape}.")
+    if wts.ndim != 1:
+        raise ValueError(f"weights must be 1D (num_points,); got shape {wts.shape}.")
+
+
+class _QuadratureRulePython:
+    """The pure-Python quadrature rule, kept as the port's oracle.
+
+    This was the public :class:`QuadratureRule` until the amendment named in the
+    module docstring. It survives for two reasons and both are temporary: it is
+    what the parity suite compares the C++ rule against, and it is what runs
+    under ``PANTR_BACKEND=python``, which is how the package still imports in a
+    tree with no compiled extension.
+
+    **It is not a second implementation of the public type.**
+    :class:`QuadratureRule` is the only class a caller ever holds; this one is
+    reachable only through it. When the C++ core stops being optional, this class
+    goes and :class:`QuadratureRule` collapses into a plain wrapper.
+
+    Immutable quadrature rule on the unit cube ``[0, 1]^ndim``.
 
     Bundles quadrature points and weights as the *reference* rule that
     :func:`pantr.grid.cell_quadrature` affinely maps onto each cell of a grid.
@@ -42,10 +103,7 @@ class QuadratureRule:
         """
         pts = np.array(points, dtype=np.float64)
         wts = np.array(weights, dtype=np.float64)
-        if pts.ndim != 2:  # noqa: PLR2004
-            raise ValueError(f"points must be 2D (num_points, ndim); got shape {pts.shape}.")
-        if wts.ndim != 1:
-            raise ValueError(f"weights must be 1D (num_points,); got shape {wts.shape}.")
+        _validate_ranks(pts, wts)
         if pts.shape[0] == 0 or pts.shape[1] == 0:
             raise ValueError(f"points must be non-empty; got shape {pts.shape}.")
         if wts.shape[0] != pts.shape[0]:
@@ -113,6 +171,290 @@ class QuadratureRule:
         return f"QuadratureRule(ndim={self._ndim}, num_points={self._num_points})"
 
 
+def _use_python() -> bool:
+    """Report whether the active backend selects the pure-Python oracle.
+
+    The choice is per process rather than per instance, deliberately: two rules
+    built under different backends could otherwise meet, and reconciling them
+    would mean converting one implementation into the other -- the shape
+    ``design/cross_backend_types.md`` forbids.
+
+    Returns:
+        bool: ``True`` under the Python backend.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if active_backend() is Backend.PYTHON:
+        return True
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    return False
+
+
+def _cpp_class() -> type[_CppQuadratureRule]:
+    """The bound C++ rule class.
+
+    Split from :func:`_use_python` so that a caller past the branch has a single
+    concrete type rather than a union, which is what lets the checker verify the
+    factories instead of taking them on trust.
+
+    Returns:
+        type[_CppQuadratureRule]: The class exposed by the extension.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.QuadratureRule
+
+
+def _f64(value: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """Normalize an argument to the contiguous float64 array the binding needs.
+
+    The oracle accepts anything array-like; the binding refuses a non-contiguous
+    or wrongly-typed array outright. Normalizing here keeps ``PANTR_BACKEND`` from
+    changing what the library accepts.
+
+    Args:
+        value (npt.ArrayLike): The caller's argument.
+
+    Returns:
+        npt.NDArray[np.float64]: A contiguous ``float64`` array.
+    """
+    return np.ascontiguousarray(np.asarray(value, dtype=np.float64))
+
+
+class QuadratureRule:
+    """Immutable quadrature rule on the unit cube ``[0, 1]^ndim``.
+
+    Bundles quadrature points and weights as the *reference* rule that
+    :func:`pantr.grid.cell_quadrature` affinely maps onto each cell of a grid.
+    Points lie in the closed unit cube; the factory-built rules
+    (:func:`tensor_product_quadrature`, :func:`gauss_legendre_quadrature`) have
+    weights summing to ``1``, the measure of the unit cube, so the rule
+    integrates the constant ``1`` to within the rounding of that sum and not
+    exactly: a ``ndim``-fold product of rounded 1D weights, summed over
+    ``num_points`` terms, cannot land on ``1.0`` bitwise. Measured over Gauss-
+    Legendre rules of 1 to 40 points per direction, the largest ``|sum - 1|`` is
+    2 ulp in 1D, 3 ulp in 2D and 4 ulp in 3D. The stored arrays are read-only.
+
+    **This class is a wrapper.** The rule itself is owned by the C++ core
+    (``cpp/include/pantr/quad/rule.hpp``) and this class holds one; see the module
+    docstring. Under ``PANTR_BACKEND=python`` it holds
+    :class:`_QuadratureRulePython` instead.
+
+    Attributes:
+        ndim (int): Number of axes (``>= 1``).
+        num_points (int): Number of quadrature points (``>= 1``).
+        points (npt.NDArray[np.float64]): Read-only ``(num_points, ndim)`` array.
+        weights (npt.NDArray[np.float64]): Read-only ``(num_points,)`` array.
+    """
+
+    __slots__ = ("_impl", "_points", "_weights")
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_use_python`."""
+
+    _points: npt.NDArray[np.float64] | None
+    """The points array once read, or ``None``; see :attr:`points`."""
+
+    _weights: npt.NDArray[np.float64] | None
+    """The weights array once read, or ``None``; see :attr:`points`."""
+
+    def __init__(self, points: npt.ArrayLike, weights: npt.ArrayLike) -> None:
+        """Build and validate a quadrature rule on the unit cube.
+
+        Args:
+            points (npt.ArrayLike): ``(num_points, ndim)`` array-like; every
+                coordinate must lie in ``[0, 1]``.
+            weights (npt.ArrayLike): ``(num_points,)`` array-like of weights.
+
+        Raises:
+            ValueError: If ``points`` is not 2D, ``weights`` is not 1D, their
+                lengths disagree, either is empty, any value is non-finite, or any
+                point lies outside ``[0, 1]``.
+        """
+        if _use_python():
+            self._adopt(_QuadratureRulePython(points, weights))
+            return
+        pts = _f64(points)
+        wts = _f64(weights)
+        _validate_ranks(pts, wts)
+        self._adopt(_cpp_class()(pts, wts))
+
+    def _adopt(self, impl: _Impl) -> None:
+        """Hold an implementation object, with an empty array cache.
+
+        Args:
+            impl (_Impl): The implementation to hold.
+        """
+        self._impl = impl
+        self._points = None
+        self._weights = None
+
+    @classmethod
+    def _wrap(cls, impl: _Impl) -> QuadratureRule:
+        """Wrap an implementation object that is already valid.
+
+        Args:
+            impl (_Impl): The implementation object to adopt.
+
+        Returns:
+            QuadratureRule: A wrapper around ``impl``, with no re-validation.
+        """
+        self = object.__new__(cls)
+        self._adopt(impl)
+        return self
+
+    def __reduce__(self) -> tuple[type[QuadratureRule], tuple[npt.NDArray[np.float64], ...]]:
+        """Pickle by points and weights rather than by implementation.
+
+        The C++ handle is not picklable and must not become part of the wire
+        format: a pickle written with the C++ backend has to load under the Python
+        one and the other way round, or the backend switch would silently become a
+        data-format switch. ``pantr.quad.__init__`` rebinds ``__module__`` so the
+        pickle names the public path, and ``pantr.mpi`` sends these across
+        collective calls, so this is load-bearing rather than a convenience.
+
+        Returns:
+            tuple: The class and the ``(points, weights)`` pair to rebuild it from.
+        """
+        return (type(self), (self.points, self.weights))
+
+    @property
+    def ndim(self) -> int:
+        """Get the spatial dimension of the rule.
+
+        Returns:
+            int: Number of axes (``>= 1``).
+        """
+        return int(self._impl.ndim)
+
+    @property
+    def num_points(self) -> int:
+        """Get the number of quadrature points.
+
+        Returns:
+            int: Point count (``>= 1``).
+        """
+        return int(self._impl.num_points)
+
+    @property
+    def points(self) -> npt.NDArray[np.float64]:
+        """Get the quadrature points on the unit cube.
+
+        Cached on first read. The C++ binding hands out a fresh copy on every
+        access -- a view could outlive the rule, which is immutable precisely so
+        that nobody has to reason about when its storage changes -- and a rule can
+        carry tens of thousands of points, so an uncached property would copy the
+        whole table on every ``rule.points[i]``. Caching also restores the
+        oracle's own semantics, where the array is the same object every time.
+
+        Returns:
+            npt.NDArray[np.float64]: Read-only ``(num_points, ndim)`` array in
+            ``[0, 1]^ndim``.
+        """
+        if self._points is None:
+            self._points = self._impl.points
+        return self._points
+
+    @property
+    def weights(self) -> npt.NDArray[np.float64]:
+        """Get the quadrature weights.
+
+        Cached on first read; see :attr:`points`.
+
+        Returns:
+            npt.NDArray[np.float64]: Read-only ``(num_points,)`` array.
+        """
+        if self._weights is None:
+            self._weights = self._impl.weights
+        return self._weights
+
+    def __repr__(self) -> str:
+        """Return a compact representation useful for debugging.
+
+        Formatted here rather than by the implementation, so that the two backends
+        print identically.
+
+        Returns:
+            str: ``"QuadratureRule(ndim=..., num_points=...)"``.
+        """
+        return f"QuadratureRule(ndim={self.ndim}, num_points={self.num_points})"
+
+
+def _coerce_axis_rules(
+    rules: Sequence[tuple[npt.ArrayLike, npt.ArrayLike]],
+) -> list[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+    """Coerce the per-axis rules and reject the ranks C++ cannot reject.
+
+    Unpacking the pair is a Python-shaped operation and the rank check cannot
+    produce a ``ValueError`` from C++, so both stay here; see
+    :func:`_validate_ranks` and ``cpp/bindings/quad_types.cpp``.
+
+    Args:
+        rules (Sequence[tuple[npt.ArrayLike, npt.ArrayLike]]): One
+            ``(nodes, weights)`` pair per axis.
+
+    Returns:
+        list[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]: The same
+        pairs as contiguous ``float64`` arrays.
+
+    Raises:
+        ValueError: If any axis's nodes or weights are not 1D.
+    """
+    coerced: list[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = []
+    for d, pair in enumerate(rules):
+        nodes_d = _f64(pair[0])
+        weights_d = _f64(pair[1])
+        if nodes_d.ndim != 1 or weights_d.ndim != 1:
+            raise ValueError(
+                f"tensor_product_quadrature: axis {d} nodes and weights must be 1D; "
+                f"got shapes {nodes_d.shape} and {weights_d.shape}."
+            )
+        coerced.append((nodes_d, weights_d))
+    return coerced
+
+
+def _tensor_product_quadrature_python(
+    rules: Sequence[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+) -> _QuadratureRulePython:
+    """Build the tensor product of per-axis 1D rules, in pure Python.
+
+    The port's oracle for :func:`tensor_product_quadrature`; see
+    :class:`_QuadratureRulePython`. Ranks are already checked by
+    :func:`_coerce_axis_rules`.
+
+    Args:
+        rules (Sequence[tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]):
+            One ``(nodes, weights)`` pair per axis, each 1D and ``float64``.
+
+    Returns:
+        _QuadratureRulePython: The tensor-product rule on ``[0, 1]^ndim``.
+
+    Raises:
+        ValueError: If ``rules`` is empty, any axis pair is empty or of mismatched
+            length, or (via :class:`_QuadratureRulePython`) any node lies outside
+            ``[0, 1]``.
+    """
+    if len(rules) == 0:
+        raise ValueError("tensor_product_quadrature: rules must have at least one axis.")
+    nodes_per_axis: list[npt.NDArray[np.float64]] = []
+    weights_per_axis: list[npt.NDArray[np.float64]] = []
+    for d, (nodes_d, weights_d) in enumerate(rules):
+        if nodes_d.shape[0] == 0 or nodes_d.shape != weights_d.shape:
+            raise ValueError(
+                f"tensor_product_quadrature: axis {d} needs matching non-empty "
+                f"(nodes, weights); got shapes {nodes_d.shape} and {weights_d.shape}."
+            )
+        nodes_per_axis.append(nodes_d)
+        weights_per_axis.append(weights_d)
+    node_mesh = np.meshgrid(*nodes_per_axis, indexing="ij")
+    weight_mesh = np.meshgrid(*weights_per_axis, indexing="ij")
+    points = np.stack([m.ravel() for m in node_mesh], axis=1)
+    weights = np.prod(np.stack([w.ravel() for w in weight_mesh], axis=0), axis=0)
+    return _QuadratureRulePython(points, weights)
+
+
 def tensor_product_quadrature(
     rules: Sequence[tuple[npt.ArrayLike, npt.ArrayLike]],
 ) -> QuadratureRule:
@@ -140,30 +482,69 @@ def tensor_product_quadrature(
             pair of non-empty 1D arrays, or (via :class:`QuadratureRule`) any
             node lies outside ``[0, 1]``.
     """
-    if len(rules) == 0:
+    coerced = _coerce_axis_rules(rules)
+    if _use_python():
+        return QuadratureRule._wrap(_tensor_product_quadrature_python(coerced))
+    if len(coerced) == 0:
+        # Refused here as well as in C++, because nanobind's `std::vector` caster
+        # accepts an empty list happily and would call the factory with a span
+        # this side had already decided was illegal. The C++ factory rejects it
+        # too, with the same message, for a caller that has no Python.
         raise ValueError("tensor_product_quadrature: rules must have at least one axis.")
-    nodes_per_axis: list[npt.NDArray[np.float64]] = []
-    weights_per_axis: list[npt.NDArray[np.float64]] = []
-    for d, pair in enumerate(rules):
-        nodes_d = np.asarray(pair[0], dtype=np.float64)
-        weights_d = np.asarray(pair[1], dtype=np.float64)
-        if nodes_d.ndim != 1 or weights_d.ndim != 1:
-            raise ValueError(
-                f"tensor_product_quadrature: axis {d} nodes and weights must be 1D; "
-                f"got shapes {nodes_d.shape} and {weights_d.shape}."
-            )
-        if nodes_d.shape[0] == 0 or nodes_d.shape != weights_d.shape:
-            raise ValueError(
-                f"tensor_product_quadrature: axis {d} needs matching non-empty "
-                f"(nodes, weights); got shapes {nodes_d.shape} and {weights_d.shape}."
-            )
-        nodes_per_axis.append(nodes_d)
-        weights_per_axis.append(weights_d)
-    node_mesh = np.meshgrid(*nodes_per_axis, indexing="ij")
-    weight_mesh = np.meshgrid(*weights_per_axis, indexing="ij")
-    points = np.stack([m.ravel() for m in node_mesh], axis=1)
-    weights = np.prod(np.stack([w.ravel() for w in weight_mesh], axis=0), axis=0)
-    return QuadratureRule(points, weights)
+    return QuadratureRule._wrap(_cpp_class().tensor_product(coerced))
+
+
+def _normalize_npts(ndim: int, npts: int | Sequence[int]) -> tuple[int, ...]:
+    """Broadcast the point count over the axes and check the Python-only contract.
+
+    Both checks here belong to the ``(ndim, npts)`` calling convention, which
+    exists in Python and not in C++: ``QuadratureRule::gauss_legendre`` takes one
+    span and reads the dimension off it, so there is no second argument for the
+    two to disagree about, and a negative ``ndim`` cannot be recovered from the
+    broadcast tuple in order to be reported. ``cpp/include/pantr/core/error.hpp``'s
+    rule still holds for everything else: the per-entry range check lives in C++.
+
+    Args:
+        ndim (int): Number of axes (``>= 1``).
+        npts (int | Sequence[int]): Points per axis, scalar or per-axis.
+
+    Returns:
+        tuple[int, ...]: The per-axis counts, of length ``ndim``.
+
+    Raises:
+        ValueError: If ``ndim < 1`` or ``npts`` is a sequence of the wrong length.
+    """
+    if ndim < 1:
+        raise ValueError(f"gauss_legendre_quadrature: ndim must be >= 1; got {ndim}.")
+    npts_tuple = (int(npts),) * ndim if isinstance(npts, int) else tuple(int(n) for n in npts)
+    if len(npts_tuple) != ndim:
+        raise ValueError(
+            f"gauss_legendre_quadrature: npts must be a scalar or a length-{ndim} sequence; "
+            f"got length {len(npts_tuple)}."
+        )
+    return npts_tuple
+
+
+def _gauss_legendre_quadrature_python(npts: tuple[int, ...]) -> _QuadratureRulePython:
+    """Build the tensor-product Gauss-Legendre rule, in pure Python.
+
+    The port's oracle for :func:`gauss_legendre_quadrature`. The 1D rules come
+    from :func:`pantr.quad.get_gauss_legendre_1d`, which maps them onto ``[0, 1]``
+    on this side; ``design/backend_parity.md`` Rule 1 is why that map matters.
+
+    Args:
+        npts (tuple[int, ...]): Points per axis, already broadcast to ``ndim``.
+
+    Returns:
+        _QuadratureRulePython: The tensor-product Gauss-Legendre rule.
+
+    Raises:
+        ValueError: If any count is ``< 1``.
+    """
+    if any(n < 1 for n in npts):
+        raise ValueError(f"gauss_legendre_quadrature: every npts entry must be >= 1; got {npts!r}.")
+    rules = [get_gauss_legendre_1d(n, dtype=np.float64) for n in npts]
+    return _tensor_product_quadrature_python(_coerce_axis_rules(rules))
 
 
 def gauss_legendre_quadrature(ndim: int, npts: int | Sequence[int]) -> QuadratureRule:
@@ -188,17 +569,7 @@ def gauss_legendre_quadrature(ndim: int, npts: int | Sequence[int]) -> Quadratur
         Nodes and weights follow the classical Gauss-Legendre construction
         :cite:p:`golub1969gauss`.
     """
-    if ndim < 1:
-        raise ValueError(f"gauss_legendre_quadrature: ndim must be >= 1; got {ndim}.")
-    npts_tuple = (int(npts),) * ndim if isinstance(npts, int) else tuple(int(n) for n in npts)
-    if len(npts_tuple) != ndim:
-        raise ValueError(
-            f"gauss_legendre_quadrature: npts must be a scalar or a length-{ndim} sequence; "
-            f"got length {len(npts_tuple)}."
-        )
-    if any(n < 1 for n in npts_tuple):
-        raise ValueError(
-            f"gauss_legendre_quadrature: every npts entry must be >= 1; got {npts_tuple!r}."
-        )
-    rules = [get_gauss_legendre_1d(n, dtype=np.float64) for n in npts_tuple]
-    return tensor_product_quadrature(rules)
+    npts_tuple = _normalize_npts(ndim, npts)
+    if _use_python():
+        return QuadratureRule._wrap(_gauss_legendre_quadrature_python(npts_tuple))
+    return QuadratureRule._wrap(_cpp_class().gauss_legendre(list(npts_tuple)))

--- a/tests/parity/test_quad_rule.py
+++ b/tests/parity/test_quad_rule.py
@@ -699,6 +699,25 @@ def test_pickle_round_trips_across_every_backend_pair(writer: Backend, reader: B
     assert restored.num_points == original.num_points
 
 
+def test_both_backends_refuse_more_axes_than_either_can_serve() -> None:
+    """Past 32 axes both backends refuse, and the two ceilings are different objects.
+
+    This pins the behaviour rather than reconciling it, which is deliberate. The
+    oracle stops at `numpy.meshgrid`'s 32-dimension limit; the C++ side stops when
+    the point count would leave ``std::size_t``, at 64 axes of two nodes. Both are
+    limits of an implementation rather than defects in the argument, both surface
+    as a ``RuntimeError`` -- ``CapacityError`` is one -- and neither backend could
+    serve the request anyway, since 2**64 points do not fit in any machine.
+
+    Making the C++ side refuse at 32 to match would write numpy's limitation into
+    a type whose whole purpose is to be usable with no interpreter present, so the
+    disagreement is recorded instead of removed.
+    """
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend), pytest.raises(RuntimeError):
+            gauss_legendre_quadrature(64, 2)
+
+
 def _message_of(fn: Callable[[], object]) -> str:
     """Run ``fn`` and return the text of the ``ValueError`` it raises.
 
@@ -753,6 +772,16 @@ def _message_of(fn: Callable[[], object]) -> str:
         (lambda: gauss_legendre_quadrature(2, [2]), "npts of the wrong length"),
         (lambda: gauss_legendre_quadrature(2, [2, 0]), "an npts entry below one"),
         (lambda: gauss_legendre_quadrature(1, 0), "a scalar npts below one"),
+        # The regression case. A count past the range of the C int that carries it
+        # used to fail in nanobind's caster as a TypeError under the C++ backend
+        # while the Python one raised ValueError from inside numpy, so
+        # PANTR_BACKEND decided which exception a caller had to catch. Both are
+        # refused above the boundary now, before either backend allocates
+        # anything -- which is also why the value here is 2**31 and not the
+        # largest legal one: a rule of 2**31 - 1 points is legal and would take
+        # 17 GB to build.
+        (lambda: gauss_legendre_quadrature(1, 2**31), "an npts entry past a C int"),
+        (lambda: gauss_legendre_quadrature(2, [2, 10**20]), "an npts entry past any C type"),
     ],
 )
 def test_error_messages_agree_verbatim(build: Callable[[], object], what: str) -> None:

--- a/tests/parity/test_quad_rule.py
+++ b/tests/parity/test_quad_rule.py
@@ -25,10 +25,12 @@ consult ``__fp_contract__`` at all.
 
 Its premise is numpy's reduction order, which is not ours. `np.sum` blocks
 pairwise from 8 elements up; `np.multiply.reduce` does not, and nothing obliges it
-to stay that way. Measured before these assertions were written: 480 random rules
-of 1 to 8 axes, and zero of the 480 differ in either array. If numpy ever blocks
-its multiplicative reduction the way it blocks its additive one, this is the file
-that will say so, and the fix is a bound rather than a looser equality.
+to stay that way. That premise is not asserted from a measurement taken once and
+written down -- it is re-measured on every run, by
+`test_the_tensor_product_agrees_field_by_field`, whose ``ndim`` parametrization
+reaches 8 for exactly this reason. If numpy ever blocks its multiplicative
+reduction the way it blocks its additive one, that test is where it will say so,
+and the fix is a bound rather than a looser equality.
 
 **The Gauss-Legendre rule is BITWISE on a build that cannot fuse, and BOUNDED on
 one that can.** Everything this ticket adds on top of the 1-D kernel is exact or
@@ -85,8 +87,8 @@ than asserted.** `test_the_composed_weight_bound_survives_a_perturbed_1d_rule`
 perturbs a 1-D rule by exactly its own claimed budget, pushes both through the
 tensor product, and requires the ND difference to stay inside the composed bound.
 It runs on any build, so the BOUNDED branch is not shipped unexercised even though
-this host cannot fuse. Verified offline over a sweep 20x the one that ships; the
-margin is reported in that test's docstring.
+this host cannot fuse. Its helper takes the sweep width as an argument so that
+widening it is a command rather than an edit; that command is on the test.
 
 What these tests would catch that a numeric comparison would not
 ----------------------------------------------------------------
@@ -177,9 +179,9 @@ _THE_SAME_MULTIPLICATIONS: Final = bitwise_parity(
         "contraction has nothing to fuse and this claim does not depend on the "
         "build. Its premise is numpy's reduction order, which is not ours: "
         "np.sum blocks pairwise from 8 elements up and np.multiply.reduce does "
-        "not. Measured before this was asserted: 480 random rules of 1 to 8 axes, "
-        "zero differing values. If numpy ever blocks the multiplicative reduction "
-        "too, this assertion is where it will say so."
+        "not. Nothing here assumes that stays true -- the parametrization reaching "
+        "8 axes re-measures it on every run, and if numpy ever blocks the "
+        "multiplicative reduction too, this assertion is where it will say so."
     )
 )
 
@@ -551,15 +553,28 @@ def test_the_composed_weight_bound_survives_a_perturbed_1d_rule() -> None:
     Two stand-in backends are displaced in opposite directions by their own
     one-sided budgets, which is exactly the worst case the harness's two-sided
     tolerance admits, so the observed ratio approaches 1 from below and must never
-    reach it.
+    reach it. Both halves matter: the assertion inside the helper is that the
+    bound holds, and the assertion here is that it is *approached*, since a bound
+    nothing comes near admits anything.
 
-    Twenty draws per dimension ship. Verified offline at 400 per dimension, 20x
-    what ships: over 2000 rules of 1 to 5 axes no draw exceeded the bound, and the
-    worst ratio was 0.99999999999999934 at ndim = 1, 0.9974 at 2, 0.9969 at 3,
-    0.9952 at 4 and 0.9945 at 5. The bound is therefore tight rather than
-    generous, which is what makes a violation of it informative; the widening
-    slack with dimension is the ``ndim - 1`` product roundings, which the rules
-    drawn here do not fully spend.
+    Twenty draws per dimension ship, which the epic's rule says is not a check of
+    itself. Widen it 20x with
+
+    .. code-block:: console
+
+        PYTHONPATH="$(pwd)/src:$(pwd)" conda run -n pantr python -c "
+        import numpy as np
+        from tests.parity.test_quad_rule import _worst_composed_weight_ratio
+        print(_worst_composed_weight_ratio(np.random.default_rng(20260829),
+                                           dimensions=(1, 2, 3, 4, 5), draws=400))"
+
+    which raises ``AssertionError`` on the first draw that escapes the bound and
+    otherwise prints the worst ratio reached. **The number it prints is not
+    recorded here**: it moves with the generator's stream, so sweeping the five
+    dimensions in one call and sweeping them one at a time give different figures
+    from the same code, and a figure quoted without its command is a figure nobody
+    can reproduce. What is stable and is the claim: no draw exceeds the bound, and
+    the worst ratio is within a percent of 1 at every dimension.
     """
     rng = np.random.default_rng(20260829)
     worst = _worst_composed_weight_ratio(rng, dimensions=(1, 2, 3, 4, 5), draws=20)

--- a/tests/parity/test_quad_rule.py
+++ b/tests/parity/test_quad_rule.py
@@ -1,0 +1,761 @@
+r"""Parity of the C++ `QuadratureRule` against the pure-Python oracle it was ported from.
+
+`cpp/include/pantr/quad/rule.hpp` is the third *type* in the C++ core rather than
+a kernel, after `AABB` and `AffineTransform`, and it is the first whose state is
+two arrays of different shape plus two counts. That is what it costs to use
+`assert_object_parity`, and the answer is: four `Field`s and no special case.
+
+What the claims are, and why each is the strongest available
+------------------------------------------------------------
+
+**Constructing a rule from given points and weights is BITWISE, unconditionally.**
+Neither backend computes anything: both copy the caller's arrays, check them and
+store them. There is no arithmetic for a tolerance to allow for, so a tolerance
+here would hide a defect rather than absorb one.
+
+**The tensor product is BITWISE, unconditionally, and that is the claim with a
+premise worth stating.** Each coordinate of a tensor-product point is a *copy* of
+a 1-D node, so that half is exact by construction. Each weight is a chain of
+``ndim - 1`` multiplications, and the two backends perform them in the same order:
+the oracle's ``np.prod(..., axis=0)`` over an ``(ndim, num_points)`` block reduces
+axis 0 in sequence, and the C++ loop accumulates from axis 0 upwards. **A chain of
+multiplications contains no addition, so a fused multiply-add has nothing to
+fuse** -- which is why this claim, unlike the Gauss-Legendre one below, does not
+consult ``__fp_contract__`` at all.
+
+Its premise is numpy's reduction order, which is not ours. `np.sum` blocks
+pairwise from 8 elements up; `np.multiply.reduce` does not, and nothing obliges it
+to stay that way. Measured before these assertions were written: 480 random rules
+of 1 to 8 axes, and zero of the 480 differ in either array. If numpy ever blocks
+its multiplicative reduction the way it blocks its additive one, this is the file
+that will say so, and the fix is a bound rather than a looser equality.
+
+**The Gauss-Legendre rule is BITWISE on a build that cannot fuse, and BOUNDED on
+one that can.** Everything this ticket adds on top of the 1-D kernel is exact or
+common mode; the whole difference comes from `gauss_legendre_symmetric`, whose
+node and weight bounds are derived in `tests/parity/test_quad_gauss_legendre.py`
+and in `design/backend_parity.md` Rule 4. The constants are **imported from that
+module rather than restated**: they denote the same quantities, and two spellings
+of one bound drift.
+
+Composing the 1-D bound onto the rule, which is this file's own derivation
+--------------------------------------------------------------------------
+
+Write ``u`` for the unit roundoff and ``c_x = 4.5`` for the one-sided
+Gauss-Legendre node displacement in units of ``u``, absolute and flat in ``n``
+(Rule 4). The harness doubles every amplification, so everything below is
+*one-sided*, per backend, against the exact rule.
+
+**Points.** A coordinate is a copy of ``t = fl(fl(x + 1) * 0.5)`` where ``x`` is a
+1-D node on ``[-1, 1]``. Multiplying by ``0.5`` is exact, so the map halves the
+inherited displacement and adds one rounding of its own at the ``x + 1``:
+
+.. math::
+
+    |\delta t| \le \tfrac{1}{2} c_x u + u\,|x + 1| = \left(\tfrac{c_x}{2}
+                 + 2|t|\right) u .
+
+Both terms are needed and `design/backend_parity.md` Rule 1 says why the first one
+has to be *transported* rather than rewritten: an absolute floor re-expressed with
+the mapped magnitude is eleven orders too small at one end of the array.
+
+**Weights.** A tensor weight is ``W = prod_d w_d``, each ``w_d`` a 1-D weight
+already halved by the map -- exactly, so its *relative* error is unchanged. The
+relative errors of a product add, and forming the product costs ``ndim - 1``
+roundings:
+
+.. math::
+
+    \frac{|\delta W|}{|W|} \le \sum_d \frac{|\delta w_d|}{|w_d|} + (ndim - 1) u ,
+    \qquad
+    \frac{|\delta w_d|}{|w_d|} \le \left(c_x A_d + 5\right) u ,
+
+with ``A_d = 2|x_d| / (1 - x_d^2)`` the weight's logarithmic sensitivity at a root
+of ``P_n``, and 5 the roundings of ``2 / ((1 - x*x) d * d)``. Both come from Rule 4.
+
+**``A_d`` is evaluated at the node on ``[-1, 1]``, never at the mapped one, and
+that is a precondition rather than a preference.** ``A`` is even in ``x`` while its
+naive rewrite in ``t`` is not, and the map sends the two singular ends to ``t = 0``
+and ``t = 1`` where only the second is singular -- so half the array would lose its
+singularity, by a factor measured at 1.9e12 by ``n = 2000``. `_weight_claim` below
+therefore takes the unmapped nodes and refuses an array with no negative entry.
+
+**The composition step is the only new content above, and it is checked rather
+than asserted.** `test_the_composed_weight_bound_survives_a_perturbed_1d_rule`
+perturbs a 1-D rule by exactly its own claimed budget, pushes both through the
+tensor product, and requires the ND difference to stay inside the composed bound.
+It runs on any build, so the BOUNDED branch is not shipped unexercised even though
+this host cannot fuse. Verified offline over a sweep 20x the one that ships; the
+margin is reported in that test's docstring.
+
+What these tests would catch that a numeric comparison would not
+----------------------------------------------------------------
+
+That the two implementations agree on **which exception** they raise and,
+verbatim, on **what it says**; that the wrapper's ``__repr__`` and pickle round
+trip do not move with ``PANTR_BACKEND``; and -- the one a parity suite can get
+wrong about itself -- that the two objects really are two implementations, which
+`test_the_two_backends_hold_different_implementations` asserts directly.
+"""
+
+from __future__ import annotations
+
+import functools
+import pickle
+from collections.abc import Callable, Sequence
+from typing import Any, Final, TypeVar
+
+import numpy as np
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.quad import QuadratureRule, gauss_legendre_quadrature, tensor_product_quadrature
+from pantr.quad._rule_nd import _QuadratureRulePython
+from pantr.quad._rules import _gauss_legendre_symmetric
+from tests._parity_harness import (
+    ExactClaim,
+    Field,
+    FloatArray,
+    ParityClaim,
+    Roundings,
+    absolute_tolerance,
+    assert_object_parity,
+    bitwise_parity,
+    bounded_parity,
+    contraction_may_fuse,
+    exact_parity,
+)
+from tests.parity.test_quad_gauss_legendre import (
+    NODE_DISPLACEMENT_UNITS,
+    WEIGHT_FORMULA_ROUNDINGS,
+)
+
+pytestmark = pytest.mark.usefixtures("cpp_backend")
+
+_Result = TypeVar("_Result")
+
+_AxisRule = tuple[np.ndarray[Any, np.dtype[np.float64]], np.ndarray[Any, np.dtype[np.float64]]]
+"""One axis's ``(nodes, weights)`` pair, both 1-D and ``float64``."""
+
+_PRODUCT_ROUNDINGS: Final = Roundings(stages=1, accumulator_per_stage=1, storage_per_stage=1)
+"""The budget every bounded claim here carries.
+
+One stage of one rounding, which reduces :class:`~tests._parity_harness.Roundings`
+to a way of spelling ``u``: the derivation lives in the amplification array, as
+``design/backend_parity.md`` records is the case for any bound that is a derived
+ratio rather than a dependency chain. ``storage_per_stage`` is 1 rather than 0
+because the rule narrows on the way out in principle; it costs nothing here, since
+storage and accumulator are both ``float64`` and the harness charges a store into
+the accumulator's own format at zero.
+"""
+
+_COUNTS_ARE_STRUCTURE: Final = exact_parity(
+    why=(
+        "ndim and num_points are shapes, not quantities: they are the extents of "
+        "the two arrays compared beside them. No rounding can move one, and a "
+        "difference is a differently shaped rule rather than a displaced value, "
+        "which no tolerance could absorb. design/backend_parity.md Rule 11."
+    )
+)
+
+_NOTHING_IS_COMPUTED: Final = bitwise_parity(
+    why=(
+        "constructing a rule from given points and weights performs no arithmetic "
+        "at all: both backends copy the caller's arrays, validate them and store "
+        "them. There is no operation for a fused multiply-add to change and none "
+        "for a tolerance to allow for."
+    )
+)
+
+_THE_SAME_MULTIPLICATIONS: Final = bitwise_parity(
+    why=(
+        "a tensor-product coordinate is a copy of a 1-D node, and a tensor-product "
+        "weight is a chain of ndim - 1 multiplications performed in the same order "
+        "on both sides: the oracle's np.prod(..., axis=0) reduces axis 0 of an "
+        "(ndim, num_points) block in sequence, and the C++ loop accumulates from "
+        "axis 0 upwards. A chain of multiplications contains no addition, so "
+        "contraction has nothing to fuse and this claim does not depend on the "
+        "build. Its premise is numpy's reduction order, which is not ours: "
+        "np.sum blocks pairwise from 8 elements up and np.multiply.reduce does "
+        "not. Measured before this was asserted: 480 random rules of 1 to 8 axes, "
+        "zero differing values. If numpy ever blocks the multiplicative reduction "
+        "too, this assertion is where it will say so."
+    )
+)
+
+_GAUSS_LEGENDRE_IS_EXACT_BY_BUILD: Final = bitwise_parity(
+    why=(
+        "the whole difference would come from gauss_legendre_symmetric, which is "
+        "an operation-for-operation transliteration using only +, -, * and /, "
+        "each pinned by IEEE 754 -- and this build emits no fused multiply-add. "
+        "tests/parity/test_quad_gauss_legendre.py carries the measurement and "
+        "names cos as the only unpinned operation. Everything this rule adds on "
+        "top is exact (the copy of a node, the multiplication by 0.5) or common "
+        "mode (the x + 1 and the weight product, identical operations in an "
+        "identical order)."
+    )
+)
+
+_BOUNDED_BY_FMA: Final = (
+    "this build fuses a multiply-add, so the two backends commit different "
+    "numbers of roundings inside the Legendre recurrence behind each 1-D rule. "
+    "See this module's docstring for how the 1-D bound of "
+    "design/backend_parity.md Rule 4 composes onto the tensor-product rule, and "
+    "tests/parity/test_quad_gauss_legendre.py for the 1-D bound itself."
+)
+
+
+def _both(build: Callable[[], _Result]) -> tuple[_Result, _Result]:
+    """Run a builder once under each backend.
+
+    Args:
+        build (Callable[[], _Result]): A zero-argument callable returning the rule.
+
+    Returns:
+        tuple[_Result, _Result]: The Python result then the C++ result.
+    """
+    with use_backend(Backend.PYTHON):
+        python = build()
+    with use_backend(Backend.CPP):
+        cpp = build()
+    return python, cpp
+
+
+def _fields(claim: ParityClaim | ExactClaim, weight_claim: ParityClaim | ExactClaim) -> list[Field]:
+    """Name the four pieces of state a rule is, and the claim governing each.
+
+    A rule's whole observable content is two counts and two arrays. Nothing is
+    derived and nothing is lazily built, so there is no field this list may
+    reasonably leave out -- unlike a grid, where the harness's docstring records
+    that an expensive accessor is the caller's to reach for.
+
+    Args:
+        claim (ParityClaim | ExactClaim): The claim for ``points``.
+        weight_claim (ParityClaim | ExactClaim): The claim for ``weights``,
+            separate because the two carry different sensitivities under a build
+            that fuses.
+
+    Returns:
+        list[Field]: The four fields, in the order a failure should report them.
+    """
+    return [
+        Field("ndim", _COUNTS_ARE_STRUCTURE),
+        Field("num_points", _COUNTS_ARE_STRUCTURE),
+        Field("points", claim),
+        Field("weights", weight_claim),
+    ]
+
+
+def _sensitivity(reference_nodes: FloatArray) -> FloatArray:
+    """The weight's logarithmic sensitivity ``2|x| / (1 - x^2)`` at a Gauss node.
+
+    From the Legendre differential equation collapsing to ``P'' = 2 x P' / (1 - x^2)``
+    at a root of ``P_n``; see ``design/backend_parity.md`` Rule 4.
+
+    Args:
+        reference_nodes (FloatArray): The nodes **on ``[-1, 1]``**, not the mapped
+            ones. See this module's docstring for why the frame is a precondition.
+
+    Returns:
+        FloatArray: The sensitivity, zero where ``|x| == 1`` (which a Gauss rule
+        never produces, and which keeps the expression finite for a caller that
+        passes a Lobatto rule).
+
+    Raises:
+        ValueError: If the array has no negative entry while holding more than one
+            node, which means it is the rule already mapped onto ``[0, 1]``.
+    """
+    x = np.asarray(reference_nodes, dtype=np.float64)
+    if x.size > 1 and float(np.min(x)) >= 0.0:
+        raise ValueError(
+            "the weight sensitivity is derived at a root of P_n, so it needs the "
+            "nodes on [-1, 1]; this array has no negative entry, so it is the rule "
+            "mapped onto [0, 1]. Un-map it before building the claim"
+        )
+    magnitude = np.abs(x)
+    interior = magnitude < 1.0
+    out = np.zeros_like(magnitude)
+    out[interior] = 2.0 * magnitude[interior] / (1.0 - magnitude[interior] * magnitude[interior])
+    return out
+
+
+def _point_claim(points: FloatArray) -> ParityClaim:
+    """State the claim for the mapped Gauss-Legendre points.
+
+    Args:
+        points (FloatArray): The rule's points, on ``[0, 1]^ndim``, whose
+            magnitude the map's own rounding is proportional to.
+
+    Returns:
+        ParityClaim: BITWISE where the build cannot fuse, otherwise BOUNDED.
+    """
+    if not contraction_may_fuse():
+        return _GAUSS_LEGENDRE_IS_EXACT_BY_BUILD
+    amplification = NODE_DISPLACEMENT_UNITS / 2.0 + 2.0 * np.abs(np.asarray(points))
+    return bounded_parity(
+        roundings=_PRODUCT_ROUNDINGS,
+        accumulator=np.float64,
+        storage=np.float64,
+        amplification=amplification,
+        why=(
+            f"{_BOUNDED_BY_FMA} A coordinate is a copy of "
+            f"t = fl(fl(x + 1) * 0.5). The multiplication by 0.5 is exact, so the "
+            f"map halves the inherited {NODE_DISPLACEMENT_UNITS} u node "
+            f"displacement and adds one rounding of its own at the x + 1, worth "
+            f"u|x + 1| = 2u|t|. The first term is TRANSPORTED rather than "
+            f"rewritten in the mapped magnitude, per Rule 1: rewriting it "
+            f"evaluates an absolute floor at the wrong end of an array spanning "
+            f"six decades and fails by 37.8x on correct code."
+        ),
+    )
+
+
+def _weight_claim(
+    reference_nodes_per_axis: Sequence[FloatArray], weights: FloatArray
+) -> ParityClaim:
+    """State the claim for the tensor-product Gauss-Legendre weights.
+
+    Args:
+        reference_nodes_per_axis (Sequence[FloatArray]): Each axis's nodes **on
+            ``[-1, 1]``**, in axis order. The sensitivity is a function of that
+            coordinate; see this module's docstring.
+        weights (FloatArray): The tensor-product weights, which carry the
+            magnitude. Frame-free, since the relative perturbation is.
+
+    Returns:
+        ParityClaim: BITWISE where the build cannot fuse, otherwise BOUNDED.
+    """
+    if not contraction_may_fuse():
+        return _GAUSS_LEGENDRE_IS_EXACT_BY_BUILD
+    return bounded_parity(
+        roundings=_PRODUCT_ROUNDINGS,
+        accumulator=np.float64,
+        storage=np.float64,
+        amplification=_composed_weight_amplification(reference_nodes_per_axis, weights),
+        why=(
+            f"{_BOUNDED_BY_FMA} A tensor weight is a product of ndim 1-D weights, "
+            f"each already halved by the map -- exactly, so its relative error is "
+            f"unchanged. Relative errors of a product add, and forming the product "
+            f"costs ndim - 1 roundings. Each factor carries "
+            f"({NODE_DISPLACEMENT_UNITS} A_d + {WEIGHT_FORMULA_ROUNDINGS}) u with "
+            f"A_d = 2|x_d|/(1 - x_d^2) evaluated at the node on [-1, 1]: that "
+            f"factor is Theta(n^2) at the outermost node, so a per-element "
+            f"relative bound with a CONSTANT is refuted, and the absolute one "
+            f"survives only because the endpoint weight decays like 1/n^2."
+        ),
+    )
+
+
+def _compose_relative_budgets(
+    per_axis_units: Sequence[FloatArray], weights: FloatArray
+) -> FloatArray:
+    """Compose per-axis relative weight budgets onto the tensor-product weights.
+
+    **This function is the composition claim**, and it is what
+    :func:`test_the_composed_weight_bound_survives_a_perturbed_1d_rule` checks: the
+    relative errors of a product add, and forming the product costs ``ndim - 1``
+    further roundings. Everything else in the weight bound is the 1-D module's.
+
+    Args:
+        per_axis_units (Sequence[FloatArray]): Each axis's relative budget, in
+            units of ``u``, one entry per node on that axis.
+        weights (FloatArray): The tensor-product weights, which carry the
+            magnitude that turns a relative budget into an absolute one.
+
+    Returns:
+        FloatArray: One amplification per weight, in units of ``u``.
+    """
+    ndim = len(per_axis_units)
+    # Same enumeration as the rule itself: last axis fastest.
+    mesh = np.meshgrid(*per_axis_units, indexing="ij")
+    total = np.sum(np.stack([m.ravel() for m in mesh], axis=0), axis=0) + (ndim - 1)
+    return np.asarray(np.abs(np.asarray(weights, dtype=np.float64)) * total, dtype=np.float64)
+
+
+def _composed_weight_amplification(
+    reference_nodes_per_axis: Sequence[FloatArray], weights: FloatArray
+) -> FloatArray:
+    """Build the elementwise amplification of the tensor-product weights.
+
+    Args:
+        reference_nodes_per_axis (Sequence[FloatArray]): Each axis's nodes on
+            ``[-1, 1]``, in axis order.
+        weights (FloatArray): The tensor-product weights.
+
+    Returns:
+        FloatArray: One amplification per weight, in units of ``u`` times the
+        weight's own magnitude.
+    """
+    return _compose_relative_budgets(
+        [
+            NODE_DISPLACEMENT_UNITS * _sensitivity(nodes) + WEIGHT_FORMULA_ROUNDINGS
+            for nodes in reference_nodes_per_axis
+        ],
+        weights,
+    )
+
+
+def _reference_nodes(npts: Sequence[int]) -> list[FloatArray]:
+    """The per-axis Gauss-Legendre nodes on ``[-1, 1]``, from the oracle.
+
+    Taken unmapped rather than reconstructed from the rule's own ``[0, 1]``
+    points, so the sensitivity is evaluated in the coordinate it was derived in
+    with no inverse map to be approximately right about.
+
+    Args:
+        npts (Sequence[int]): Points per axis.
+
+    Returns:
+        list[FloatArray]: One node array per axis.
+    """
+    with use_backend(Backend.PYTHON):
+        return [np.asarray(_gauss_legendre_symmetric(n)[0], dtype=np.float64) for n in npts]
+
+
+# Corner cases chosen for the phenomena rather than for coverage: an ordinary
+# rule, a single point, the closed-cube boundary that Lobatto rules land on, a
+# negative weight (legal, and several real rules carry one), a one-dimensional
+# rule, and a four-dimensional one where the weight product is a longer chain.
+_RULES: Final = [
+    ([[0.25, 0.75], [0.5, 0.5]], [0.4, 0.6]),
+    ([[0.5]], [1.0]),
+    ([[0.0, 0.0], [1.0, 1.0]], [0.5, 0.5]),
+    ([[0.5]], [-1.0]),
+    ([[0.0], [0.5], [1.0]], [0.25, 0.5, 0.25]),
+    ([[0.1, 0.2, 0.3, 0.4]], [0.125]),
+]
+
+
+@pytest.mark.parametrize(("points", "weights"), _RULES)
+def test_the_constructed_rule_agrees_field_by_field(points: Any, weights: Any) -> None:
+    """Every piece of a directly built rule agrees, and the arrays bit for bit."""
+    py, cpp = _both(lambda: QuadratureRule(points, weights))
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(_NOTHING_IS_COMPUTED, _NOTHING_IS_COMPUTED),
+        context=f"QuadratureRule(points={points!r})",
+    )
+
+
+@pytest.mark.parametrize(("points", "weights"), _RULES)
+def test_the_two_backends_hold_different_implementations(points: Any, weights: Any) -> None:
+    """The comparison above is between two implementations, not one with itself.
+
+    The failure this guards against is the one a parity suite cannot see in its own
+    results: if the C++ branch silently fell back to the oracle, every assertion in
+    this file would pass and none of them would mean anything.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    py, cpp = _both(lambda: QuadratureRule(points, weights))
+    assert isinstance(py._impl, _QuadratureRulePython)
+    assert isinstance(cpp._impl, _pantr_cpp.QuadratureRule)
+
+
+@pytest.mark.parametrize("stored", ["points", "weights"])
+def test_both_backends_hand_out_read_only_arrays(stored: str) -> None:
+    """Neither backend lets a caller write through the arrays it hands back."""
+    py, cpp = _both(lambda: QuadratureRule([[0.25, 0.75]], [1.0]))
+    assert not getattr(py, stored).flags.writeable
+    assert not getattr(cpp, stored).flags.writeable
+
+
+def _random_axis_rules(rng: np.random.Generator, ndim: int) -> list[_AxisRule]:
+    """Draw one random ``(nodes, weights)`` pair per axis.
+
+    Nodes are sorted only so the rule reads like a rule; nothing in the tensor
+    product depends on the order. Weights are drawn on ``(0, 1)`` so a product of
+    up to eight of them stays well clear of the subnormal range, where the
+    comparison would be about the format rather than about the port.
+
+    Args:
+        rng (np.random.Generator): The source of the draw.
+        ndim (int): Number of axes.
+
+    Returns:
+        list[_AxisRule]: One pair per axis.
+    """
+    rules: list[_AxisRule] = []
+    for _ in range(ndim):
+        count = int(rng.integers(1, 5))
+        nodes = np.sort(rng.random(count))
+        rules.append((nodes, rng.random(count)))
+    return rules
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3, 4, 8])
+def test_the_tensor_product_agrees_field_by_field(ndim: int) -> None:
+    """The tensor product agrees bit for bit, out to eight axes.
+
+    Eight rather than three, because the claim at risk is the *order* the weight
+    product accumulates in, and a two-axis product has only one association. Eight
+    is also past where `np.sum` starts blocking pairwise, so a reduction that
+    behaved like the additive one would show here and nowhere below it.
+    """
+    rng = np.random.default_rng(20260829 + ndim)
+    for _ in range(20):
+        rules = _random_axis_rules(rng, ndim)
+        py, cpp = _both(functools.partial(tensor_product_quadrature, rules))
+        assert_object_parity(
+            py=py,
+            cpp=cpp,
+            fields=_fields(_THE_SAME_MULTIPLICATIONS, _THE_SAME_MULTIPLICATIONS),
+            context=f"tensor_product_quadrature, ndim={ndim}",
+        )
+
+
+@pytest.mark.parametrize("npts", [(1,), (2,), (5,), (17,), (200,), (2, 3), (4, 4), (2, 3, 4)])
+def test_the_gauss_legendre_rule_agrees_field_by_field(npts: tuple[int, ...]) -> None:
+    """The Gauss-Legendre rule agrees, bit for bit on a build that cannot fuse."""
+    ndim = len(npts)
+    py, cpp = _both(lambda: gauss_legendre_quadrature(ndim, list(npts)))
+    assert_object_parity(
+        py=py,
+        cpp=cpp,
+        fields=_fields(_point_claim(py.points), _weight_claim(_reference_nodes(npts), py.weights)),
+        context=f"gauss_legendre_quadrature{npts}",
+    )
+
+
+def test_the_gauss_legendre_rule_is_the_tensor_product_of_its_axes() -> None:
+    """The factory equals the composition it claims to be, under both backends.
+
+    This is what lets the bound above be *composed* from the 1-D one rather than
+    re-derived: if the C++ factory built its rule by some other route, the 1-D
+    kernel's bound would not be the thing it inherits.
+    """
+    from pantr.quad import get_gauss_legendre_1d  # noqa: PLC0415
+
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            direct = gauss_legendre_quadrature(2, [3, 4])
+            composed = tensor_product_quadrature(
+                [get_gauss_legendre_1d(3), get_gauss_legendre_1d(4)]
+            )
+            assert direct.points.tobytes() == composed.points.tobytes(), backend
+            assert direct.weights.tobytes() == composed.weights.tobytes(), backend
+
+
+def test_the_composed_weight_bound_survives_a_perturbed_1d_rule() -> None:
+    """The composition step of the weight bound holds, on a build that cannot fuse.
+
+    The BOUNDED branch above is unreachable on this host, so the piece of it this
+    ticket actually contributes -- how a 1-D weight bound composes onto a
+    tensor-product weight -- would otherwise ship unexercised. This exercises it
+    directly and without an FMA: perturb each 1-D weight by its own claimed
+    one-sided budget with a random sign, push the perturbed and unperturbed rules
+    through the *same* tensor product, and require the difference to stay inside
+    the composed bound the claim would carry.
+
+    Two stand-in backends are displaced in opposite directions by their own
+    one-sided budgets, which is exactly the worst case the harness's two-sided
+    tolerance admits, so the observed ratio approaches 1 from below and must never
+    reach it.
+
+    Twenty draws per dimension ship. Verified offline at 400 per dimension, 20x
+    what ships: over 2000 rules of 1 to 5 axes no draw exceeded the bound, and the
+    worst ratio was 0.99999999999999934 at ndim = 1, 0.9974 at 2, 0.9969 at 3,
+    0.9952 at 4 and 0.9945 at 5. The bound is therefore tight rather than
+    generous, which is what makes a violation of it informative; the widening
+    slack with dimension is the ``ndim - 1`` product roundings, which the rules
+    drawn here do not fully spend.
+    """
+    rng = np.random.default_rng(20260829)
+    worst = _worst_composed_weight_ratio(rng, dimensions=(1, 2, 3, 4, 5), draws=20)
+    # The bound must be approached, or it would be admitting anything. The
+    # threshold is 0.9 rather than the observed 0.99999 because the observation is
+    # a property of this host's rounding and the claim being made is only that the
+    # bound is of the right order.
+    assert worst > 0.9, f"the composed bound was never approached; worst ratio {worst:.6f}"
+
+
+def _worst_composed_weight_ratio(
+    rng: np.random.Generator, *, dimensions: Sequence[int], draws: int
+) -> float:
+    """Perturb 1-D rules by their own budget and report the worst ratio to the bound.
+
+    Asserts as it goes, so a violation names the rule that produced it; the return
+    value is what lets the caller check the bound is also *approached*. Separated
+    from the test so the offline sweep the docstring quotes runs the same code.
+
+    Args:
+        rng (np.random.Generator): The source of the point counts and the signs.
+        dimensions (Sequence[int]): Spatial dimensions to sweep.
+        draws (int): Rules per dimension.
+
+    Returns:
+        float: The largest observed ratio of difference to the one-sided bound.
+
+    Raises:
+        AssertionError: If any draw exceeds the composed bound.
+    """
+    from pantr.quad import get_gauss_legendre_1d  # noqa: PLC0415
+
+    unit_roundoff = float(np.finfo(np.float64).eps) / 2.0
+    worst = 0.0
+    for ndim in dimensions:
+        for _ in range(draws):
+            npts = [int(rng.integers(2, 12)) for _ in range(ndim)]
+            reference = _reference_nodes(npts)
+            with use_backend(Backend.PYTHON):
+                axes = [get_gauss_legendre_1d(n, dtype=np.float64) for n in npts]
+                budgets = [
+                    unit_roundoff
+                    * (NODE_DISPLACEMENT_UNITS * _sensitivity(x) + WEIGHT_FORMULA_ROUNDINGS)
+                    for x in reference
+                ]
+                # Two stand-in backends, each displaced by its own one-sided
+                # budget in the opposite direction, which is the worst case the
+                # two-sided parity tolerance admits. Perturbing only one of them
+                # and comparing against half the tolerance would leave the second
+                # product's own rounding unaccounted for.
+                shaken = [
+                    [
+                        (nodes, weights * (1.0 + sign * budget))
+                        for (nodes, weights), budget in zip(axes, budgets, strict=True)
+                    ]
+                    for sign in (1.0, -1.0)
+                ]
+                low, high = (tensor_product_quadrature(rules) for rules in shaken)
+
+            # The budget each axis ACTUALLY received, not the one aimed for: the
+            # injection is itself a floating-point multiply and overshoots its
+            # target by up to one rounding. Measuring what landed keeps this a test
+            # of the composition rather than of the test's own arithmetic.
+            landed = [
+                np.maximum(np.abs(plus_weights - weights), np.abs(minus_weights - weights))
+                / np.abs(weights)
+                / unit_roundoff
+                for (_, weights), (_, plus_weights), (_, minus_weights) in zip(
+                    axes, shaken[0], shaken[1], strict=True
+                )
+            ]
+            claim = bounded_parity(
+                roundings=_PRODUCT_ROUNDINGS,
+                accumulator=np.float64,
+                storage=np.float64,
+                amplification=_compose_relative_budgets(landed, low.weights),
+                why="the composed bound under test; see this module's docstring",
+            )
+            tolerance = absolute_tolerance(claim)
+            ratio = float(np.max(np.abs(high.weights - low.weights) / tolerance))
+            worst = max(worst, ratio)
+            assert ratio <= 1.0, (
+                f"ndim={ndim}, npts={npts}: the composed weight bound was exceeded by "
+                f"a factor of {ratio:.4f} by a perturbation at exactly its own budget"
+            )
+    return worst
+
+
+def test_repr_is_the_same_string_under_both_backends() -> None:
+    """The wrapper formats its own repr, so the backend cannot change what it says.
+
+    ``tests/test_quad.py`` pins the exact string for one rule; this pins that the
+    two backends produce the same one, which that test cannot see because it runs
+    under one backend at a time.
+    """
+    py, cpp = _both(lambda: QuadratureRule([[0.5, 0.5]], [1.0]))
+    assert repr(py) == "QuadratureRule(ndim=2, num_points=1)"
+    assert repr(cpp) == repr(py)
+
+
+@pytest.mark.parametrize("reader", [Backend.PYTHON, Backend.CPP])
+@pytest.mark.parametrize("writer", [Backend.PYTHON, Backend.CPP])
+def test_pickle_round_trips_across_every_backend_pair(writer: Backend, reader: Backend) -> None:
+    """A pickle written under one backend loads under the other, all four ways.
+
+    ``__reduce__`` stores points and weights rather than the implementation
+    handle, precisely so the backend switch cannot become a data-format switch.
+    ``pantr.mpi`` sends these across collective calls, so a rule pickled by one
+    rank and unpickled by another must not depend on how each was configured.
+    """
+    with use_backend(writer):
+        original = gauss_legendre_quadrature(2, 3)
+        blob = pickle.dumps(original)
+    with use_backend(reader):
+        restored = pickle.loads(blob)
+
+    assert type(restored) is QuadratureRule
+    assert restored.__module__ == "pantr.quad"
+    assert restored.points.tobytes() == original.points.tobytes()
+    assert restored.weights.tobytes() == original.weights.tobytes()
+    assert restored.ndim == original.ndim
+    assert restored.num_points == original.num_points
+
+
+def _message_of(fn: Callable[[], object]) -> str:
+    """Run ``fn`` and return the text of the ``ValueError`` it raises.
+
+    Args:
+        fn (Callable[[], object]): A zero-argument call expected to raise.
+
+    Returns:
+        str: The exception's message.
+
+    Raises:
+        AssertionError: If ``fn`` did not raise ``ValueError``.
+    """
+    try:
+        fn()
+    except ValueError as exc:
+        return str(exc)
+    raise AssertionError("expected a ValueError and got none")
+
+
+@pytest.mark.parametrize(
+    ("build", "what"),
+    [
+        (lambda: QuadratureRule([0.5, 0.5], [1.0]), "points not 2D"),
+        (lambda: QuadratureRule([[0.5]], [[1.0]]), "weights not 1D"),
+        (lambda: QuadratureRule([[0.5], [0.5]], [1.0]), "length mismatch"),
+        (lambda: QuadratureRule(np.empty((0, 2)), []), "no points"),
+        (lambda: QuadratureRule(np.empty((1, 0)), [1.0]), "no axes"),
+        (lambda: QuadratureRule([[np.inf, 0.5]], [1.0]), "non-finite point"),
+        (lambda: QuadratureRule([[np.nan, 0.5]], [1.0]), "NaN point"),
+        (lambda: QuadratureRule([[0.5, 0.5]], [np.nan]), "non-finite weight"),
+        (lambda: QuadratureRule([[-0.1, 0.5]], [1.0]), "below the cube"),
+        (lambda: QuadratureRule([[0.5, 1.5]], [1.0]), "above the cube"),
+        (lambda: tensor_product_quadrature([]), "no axes at all"),
+        (
+            lambda: tensor_product_quadrature([(np.array([0.5, 0.5]), np.array([1.0]))]),
+            "axis lengths disagree",
+        ),
+        (
+            lambda: tensor_product_quadrature([(np.zeros(0), np.zeros(0))]),
+            "an empty axis",
+        ),
+        (
+            lambda: tensor_product_quadrature([(np.array([[0.5]]), np.array([1.0]))]),
+            "axis nodes not 1D",
+        ),
+        (
+            lambda: tensor_product_quadrature([(np.array([2.0]), np.array([1.0]))]),
+            "an axis node outside the cube",
+        ),
+        (lambda: gauss_legendre_quadrature(0, 3), "ndim zero"),
+        (lambda: gauss_legendre_quadrature(-1, 3), "ndim negative"),
+        (lambda: gauss_legendre_quadrature(2, [2]), "npts of the wrong length"),
+        (lambda: gauss_legendre_quadrature(2, [2, 0]), "an npts entry below one"),
+        (lambda: gauss_legendre_quadrature(1, 0), "a scalar npts below one"),
+    ],
+)
+def test_error_messages_agree_verbatim(build: Callable[[], object], what: str) -> None:
+    """Both backends raise ``ValueError`` and say **exactly** the same thing.
+
+    Verbatim, not a substring. ``tests/parity/test_geometry_aabb.py`` records what
+    a substring match cost there: it passed while five of six messages differed.
+    The message is part of the claim rather than decoration, because a caller that
+    catches on it would otherwise see ``PANTR_BACKEND`` change what the library
+    says rather than only how fast it is.
+
+    The list crosses the two layers this port splits its checks across: the ranks
+    and the ``(ndim, npts)`` convention, which the wrapper owns because no C++
+    exception can reach Python as a ``TypeError``, and everything else, which the
+    C++ type owns.
+    """
+    with use_backend(Backend.PYTHON):
+        oracle = _message_of(build)
+    with use_backend(Backend.CPP):
+        ported = _message_of(build)
+    assert oracle == ported, f"{what}: oracle said {oracle!r}, C++ said {ported!r}"

--- a/tests/test_quad.py
+++ b/tests/test_quad.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pickle
 from collections.abc import Callable
 from math import gamma
 from typing import Any, cast
@@ -606,6 +607,26 @@ class TestQuadratureRule:
         rule = QuadratureRule(points=[[0.0, 0.0], [1.0, 1.0]], weights=[0.5, 0.5])
         assert rule.num_points == 2
 
+    def test_pickle_round_trip_reports_the_public_module(self) -> None:
+        # `pantr.mpi` pickles rules for collective calls, and `__reduce__` names
+        # `type(self)`, so the `__module__` rebinding in `pantr/quad/__init__.py`
+        # is what keeps the pickle loadable. Under the C++ backend this also says
+        # the wrapper pickles its arrays rather than its unpicklable handle;
+        # `tests/parity/test_quad_rule.py` crosses the two backends.
+        rule = gauss_legendre_quadrature(2, 3)
+        restored = pickle.loads(pickle.dumps(rule))
+        assert type(restored) is QuadratureRule
+        assert restored.__module__ == "pantr.quad"
+        nptest.assert_array_equal(restored.points, rule.points)
+        nptest.assert_array_equal(restored.weights, rule.weights)
+
+    def test_the_stored_arrays_are_the_same_object_on_every_read(self) -> None:
+        # Not cosmetic: the C++ binding allocates a fresh copy per access, so an
+        # uncached property would copy the whole table on every `rule.points[i]`.
+        rule = gauss_legendre_quadrature(2, 3)
+        assert rule.points is rule.points
+        assert rule.weights is rule.weights
+
 
 class TestTensorProductQuadrature:
     """Tests for tensor_product_quadrature."""
@@ -617,12 +638,29 @@ class TestTensorProductQuadrature:
         assert rule.points.shape == (6, 2)
 
     def test_c_order_last_axis_fastest(self) -> None:
-        # Axis-0 nodes {0.25, 0.75}, axis-1 nodes {0.5}: C-order has axis 1 fastest.
+        # Both axes need more than one node, or the claim is unobservable: this
+        # test carried a single node on axis 1 and passed against a tensor product
+        # whose odometer ran the other way round, which a mutation of the C++
+        # factory exposed. Every value here is exact in binary, so the comparison
+        # is an equality rather than a tolerance.
         rule = tensor_product_quadrature(
-            [(np.array([0.25, 0.75]), np.array([0.5, 0.5])), (np.array([0.5]), np.array([1.0]))]
+            [
+                (np.array([0.25, 0.75]), np.array([0.25, 0.75])),
+                (np.array([0.125, 0.5, 0.875]), np.array([0.5, 0.25, 0.25])),
+            ]
         )
-        nptest.assert_allclose(rule.points, [[0.25, 0.5], [0.75, 0.5]])
-        nptest.assert_allclose(rule.weights, [0.5, 0.5])
+        nptest.assert_array_equal(
+            rule.points,
+            [
+                [0.25, 0.125],
+                [0.25, 0.5],
+                [0.25, 0.875],
+                [0.75, 0.125],
+                [0.75, 0.5],
+                [0.75, 0.875],
+            ],
+        )
+        nptest.assert_array_equal(rule.weights, [0.125, 0.0625, 0.0625, 0.375, 0.1875, 0.1875])
 
     def test_weights_are_outer_product(self) -> None:
         rule = tensor_product_quadrature(

--- a/tools/adversarial_sweep/_probes_quad.py
+++ b/tools/adversarial_sweep/_probes_quad.py
@@ -12,6 +12,15 @@ corners (0 and -1, which must be rejected, then 1, 2, 3, 4, 5, 17, 64, 200, 1000
 rather than its middle, since off-by-one and int64-wraparound defects live at the
 edges of a count, not in its interior.
 
+**What these probes grade, now that the rule is a wrapper.**
+:class:`~pantr.quad.QuadratureRule` and its two factories are owned by the C++
+core since the 2026-08-27 amendment to ``design/cross_backend_types.md``, and the
+public names below are the Python wrapper in front of it. The sweep runs the
+**Python backend** (``README.md`` in this directory carries that decision and what
+grades the C++ side instead), so every case here still grades the oracle, and the
+contract quoted at each site is the one both backends have to meet.
+``tests/parity/test_quad_rule.py`` is what checks that they do.
+
 **Verdict flags.** Every case here carries ``must_succeed`` or ``must_reject``
 unless the entry point's contract genuinely admits both, and the few that carry
 neither say why at the site. Without them a legal-input failure is graded against
@@ -476,7 +485,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
     del profile  # every construction below is a corner; nothing to widen further
     step = float(np.spacing(np.float64(1.0)))
 
-    # The constructor's `Raises:` (`quad.py:641-644`) is a closed list: not 2D, weights
+    # The constructor's `Raises:` (`QuadratureRule.__init__`) is a closed list: not 2D, weights
     # not 1D, lengths disagree, either empty, non-finite, or a point outside [0, 1].
     # Every case below is on one side or the other of exactly that list.
     yield Case(
@@ -490,7 +499,7 @@ def _quadrature_rule_cases(profile: Profile) -> Iterator[Case]:
         must_succeed=True,
     )
     # A negative weight is legal by construction, and deliberately so: the class
-    # docstring's "weights sum to one" language (`quad.py:622-628`) is scoped to the two
+    # docstring's "weights sum to one" language (`QuadratureRule`) is scoped to the two
     # factories, and `__init__` neither documents nor checks weight sign or sum. Refusing
     # this input would be the finding, not accepting it -- several legitimate rules
     # (Newton-Cotes past degree 8, moment-fitted rules) carry negative weights.
@@ -609,7 +618,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
     weights_b = np.full(3, 1.0 / 3.0)
     rules_2d = [(nodes_a, weights_a), (nodes_b, weights_b)]
     # Matching non-empty 1D pairs with nodes inside [0, 1] satisfy every precondition
-    # the docstring states (`quad.py:731-734`), including the `[0, 1]` bound it defers
+    # the docstring states (`tensor_product_quadrature`), including the `[0, 1]` bound it defers
     # to `QuadratureRule`.
     yield Case(
         GROUP,
@@ -642,7 +651,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_quadrature,
         lambda: tensor_product_quadrature([]),
         {"kind": "empty"},
-        must_reject=True,  # "If ``rules`` is empty" (quad.py:741-744)
+        must_reject=True,  # "If ``rules`` is empty" (tensor_product_quadrature)
     )
 
     if profile is not Profile.FULL:
@@ -655,7 +664,7 @@ def _tensor_product_cases(profile: Profile) -> Iterator[Case]:
         tensor_product_quadrature,
         lambda mismatched=mismatched: tensor_product_quadrature(mismatched),
         {"kind": "mismatched-lengths"},
-        must_reject=True,  # "not a matching pair of ... 1D arrays" (quad.py:741-744)
+        must_reject=True,  # "not a matching pair of ... 1D arrays" (tensor_product_quadrature)
     )
 
 
@@ -673,7 +682,7 @@ def _gauss_legendre_nd_cases(profile: Profile) -> Iterator[Case]:
         Case: One hostile ``(ndim, npts)`` combination.
     """
     npts_values = _GLQ_NPTS_FULL if profile is Profile.FULL else _GLQ_NPTS_SMOKE
-    # The docstring states three preconditions and no more (`quad.py:776-779`):
+    # The docstring states three preconditions and no more (`gauss_legendre_quadrature`):
     # `ndim >= 1`, a sequence of length `ndim` if not a scalar, and every count
     # `>= 1`. Each case below satisfies all three or violates exactly one.
     for ndim in dims(profile, max_dim=3):


### PR DESCRIPTION
Moves `QuadratureRule` and its two factories to C++ ownership, with Python wrapping them.

`Closes #383` — closing keywords do not fire on a non-default base, so close by hand after merge.

**Base is `build/380-shared-files-for-type-port` (PR #406), not `proto/cpp`.** Merge that first.

## Acceptance criteria

| AC | Evidence |
|---|---|
| `AC1` | `ci_local.sh discipline` → `PASS quad stays double-only except modified_chebyshev_nodes`; the grep finds exactly one hit, `simple_rules.hpp:131` |
| `AC2` | `pytest -q` → `7556 passed, 39 skipped, 7 xfailed`; `PANTR_BACKEND=cpp pytest -q` → same |
| `AC3` | `test_repr` passes under both, and a parity test asserts the literal string *and* that the two backends agree — which a single-backend test cannot see |
| `AC4` | pickle round-trips 4/4 writer×reader pairs, asserting `__module__ == "pantr.quad"` and byte equality of both arrays; `copy`/`deepcopy` too |
| `AC5` | bound derived, not fitted — see below |
| `AC6` | three mutations of the ported C++, see below |

Machinery: ruff clean · `mypy Success ... 291 source files` · `ctest --preset gcc` 26/26 ·
`--preset clang` 26/26 · `--preset gcc-debug` (ASan+UBSan) 32/32 · `discipline` 7/7.

**Extension-skip check:** `57 skipped` with the `.so` moved aside, `57 passed` restored. Zero pass
without the extension.

## The derived bound

The only bound stated is the fused-build one. Its derivation is in the module docstring: node
displacement transported through the `[0,1]` map (Rule 1), weight sensitivity evaluated in the
`[-1,1]` frame where it was derived (Rule 4), relative errors composed across the product. The two
1-D constants — `NODE_DISPLACEMENT_UNITS` 4.5, `WEIGHT_FORMULA_ROUNDINGS` 5,
`WEIGHT_AMPLIFICATION_SUP` 2.6 — are **imported** from the 1-D parity module rather than restated,
per the reuse rule: same quantity, one spelling.

Composed point bound `c_x/2 + 2|t|`, weight bound `Σ_d(4.5 A_d + 5) + (ndim−1)`, both in units of
`u`. Rule 3's vacuity guard is live via the harness.

**Verified over a sweep 20x the one that ships** (400 draws per dimension against 20), twice the
10x this epic requires, independently re-run by the coordinator across three seeds and `ndim` 1–5.
The bound held every time and was approached but never reached, which is what makes a violation of
it informative rather than merely possible.

The helper is factored out of the test so the wide sweep runs *the same code*, and takes its width
as an argument, so widening is a command rather than an edit. **The specific ratios have been
deleted rather than corrected**: two runs of the same sweep disagreed in the fourth decimal purely
because one swept all five dimensions from one RNG stream and the other swept them separately —
exactly the ambiguity that makes a quoted figure unusable. The docstring now carries the command.

## Mutation checks

Three mutations of `cpp/include/pantr/quad/rule.hpp`, the **ported** side. Liveness proved by md5:
`cmake --build --preset gcc` rebuilds only the C++ tests, so the extension must be rebuilt and
copied separately or a mutation proves nothing.

| Mutation | C++ ctest | parity suite |
|---|---|---|
| odometer reversed (axis 0 fastest) | FAIL | 7 failed / 47 passed |
| weight product associated right-to-left | **PASS — survived** | 4 failed / 50 passed |
| mapped node moved by **one ulp** | FAIL | 9 failed / 45 passed |

A **one-ulp** displacement is enough to turn the parity suite red, so the severity floor is as low
as it can be. The middle row is worth reading: the C++ unit test cannot see it, because its weights
are binary-exact and any association is exact for them — it was caught only at `ndim ≥ 3` by
parity. Association order is a claim about matching numpy, so parity is its right owner, but the
C++ test alone would have passed a real divergence.

Two earlier mutations changed the tests rather than the code: the odometer mutation initially
survived a C-order test that carried a single node on one axis, making the ordering it names
unobservable. Fixed and re-mutated to confirm it now goes red.

## Findings from this branch's own review round

- **`I` (fixed)** — `gauss_legendre` raised `TypeError` under C++ where the oracle raised
  `ValueError`, for an `npts` past `INT_MAX`. The bound moved into normalization so it fires before
  the branch and both backends say the same thing verbatim. It is checked in Python and that is
  *forced*, not chosen: no C integer type can hold an arbitrary-precision Python int, so any
  declared width dies in the caster first.
- **`R` (fixed)** — `CapacityError` had zero coverage. Now: 64 axes reaches the first guard, 63
  reaches the *second* (the point table, not the count — the two are easy to conflate), 16 must
  still build. Mutation-checked.
- **`C` (fixed)** — the double-only guard greps for the literal `template <`, and this PR's new
  header documented that guard by quoting its search string, so the file explaining the rule became
  a second hit and `AC1` failed. No template was added; the comment was reworded.

## How `assert_object_parity` held up

Cleanly, no workaround. A rule is two counts and two arrays of different rank, and it took four
`Field`s and no special case: `_as_comparable`'s `atleast_1d` handles a `(N, d)` array beside a
`(N,)` one with no reshaping at the call site. Both of the API's deliberate refusals were right
here and neither got in the way.

One note for the six remaining consumers: this type needs **two** claims, because points and
weights carry different sensitivities under a fusing build. That is a property of the type, not a
limit of the API — but a consumer assuming one claim per object will find it does not generalize.
And `assert_object_parity` cannot tell you the two objects are two *implementations*; a separate
test does that, and every consumer should have one, since it is the failure a parity suite cannot
see in its own results.

## Two deliberate deviations from the ticket's letter

The type is `pantr::quad::QuadratureRule`, not `pantr::QuadratureRule`, matching
`pantr::geometry::AABB` and `pantr::transform::AffineTransform` — which the ticket itself names as
the pattern. And the wrapper's selector is split in two rather than one `_impl_class()`, following
`transform.py` rather than `geometry.py`; the per-process property the ticket asks for holds either
way, and splitting it is what lets mypy see a concrete type past the branch.

## Known, carried forward

- `scripts/ci_local.sh`'s g++-10 floor build fails on `geometry/aabb.hpp` — pre-existing,
  independently reproduced against a pristine base, ticket pending. A full `ci_local.sh` run since
  the last commit is still outstanding; every leg that could have moved was re-verified separately.
- Beyond 32 axes the two backends refuse with different messages (numpy's meshgrid ceiling against
  the C++ index type), both `RuntimeError`. Pinned by a test rather than reconciled: making the C++
  side stop at 32 would write numpy's limitation into a type meant to work with no interpreter.
- `cpp/bindings/register.hpp`'s reserved-slot comment says "Every one below is empty today", now
  false and false for all thirteen tickets. Wants one central wording fix, not thirteen per-ticket
  edits — the collision #380 exists to prevent.
