### PR TITLE
feat(grid): own CellTags, FacetTags, Partition and the BVH in C++

### DIFF
--- a/cpp/bindings/grid_bvh.cpp
+++ b/cpp/bindings/grid_bvh.cpp
@@ -1,15 +1,191 @@
 /// \file
-/// nanobind bindings for `pantr::grid::BVH` -- reserved, empty.
+/// nanobind bindings for `pantr::grid::BVH`.
 ///
-/// The module's three assembly points (`pantr_cpp.cpp`, `register.hpp` and
-/// `CMakeLists.txt`) are edited once, here, so the ticket that ports the type
-/// edits this file and nothing else. Thirteen tickets in this milestone would
-/// otherwise collide on those three.
+/// Follows `geometry.cpp`, `grid_tags.cpp` and `grid_partition.cpp`: ownership
+/// moved to C++ under the 2026-08-27 amendment to
+/// `design/cross_backend_types.md`, the Python class wraps one, and this file
+/// validates nothing because the type validates itself.
+///
+/// ## `double` only
+///
+/// The oracle is `float64` throughout -- none of the three grid kernel modules
+/// mentions `float32` -- so registering a `float` tree would create a surface with
+/// no oracle behind it, which `design/backend_parity.md` Rule 8 forbids. The header
+/// stays templated on `Real` and `cpp/tests/test_grid_bvh_type.cpp` instantiates
+/// both.
+///
+/// ## What the wrapper still does
+///
+/// The **dtype** checks. `pantr.grid.BVH.__init__` promises `TypeError` for a
+/// non-`float64` corner array or a non-`int64` index array, and nanobind has no
+/// path producing a `TypeError` from an exception -- it would raise its own, naming
+/// this C++ signature rather than the argument. The wrapper also owns the array
+/// **shape** messages, because the oracle words them in terms of a numpy shape
+/// tuple that is gone once the binding has a span, and it translates
+/// `CapacityError` back to the `ValueError` the pre-port class raised, so that
+/// `PANTR_BACKEND` does not decide which exception a caller catches.
+///
+/// ## The five arrays are views, and the owner is load-bearing
+///
+/// `design/bvh.md` establishes the node arrays as public API, and the oracle
+/// returns its stored arrays directly with `flags.writeable` cleared. So these are
+/// zero-copy views whose owner is the Python object holding the tree -- copying
+/// would make the backend switch a performance switch on the one surface a
+/// consumer is expected to traverse itself.
+///
+/// Two details are easy to get wrong and both are load-bearing. An **ownerless**
+/// `nb::ndarray` return silently *copies* and comes back **writable**, so the owner
+/// is what buys read-only-ness and not just lifetime; `node_lo.base is not None` is
+/// the half of that a test can see. And read-only is enforced against accident, not
+/// against malice -- `ctypes` clears the flag in two lines -- so nothing here
+/// claims that C++-owned memory cannot be written. `bvh_tree.hpp` records what that
+/// costs under issue #359: on this backend a corrupted index is undefined
+/// behaviour where the numba kernel merely returns a defined wrong answer.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/bvh_tree.hpp"
 #include "register.hpp"
 
-void register_grid_bvh(nanobind::module_&) {
-    // Nothing yet: the port adds the `nanobind::class_` for the type here.
+namespace nb = nanobind;
+
+namespace {
+
+using Tree = pantr::grid::BVH<double>;
+
+/// A read-only, contiguous 1D `float64` array as nanobind sees it.
+using const_vec = nb::ndarray<const double, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A read-only, contiguous 2D `float64` array as nanobind sees it.
+using const_mat = nb::ndarray<const double, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// A read-only, contiguous 1D `int64` array as nanobind sees it.
+using const_idx = nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A valid, never-dereferenced address for a zero-length view's data pointer.
+///
+/// `std::vector::data()` on an empty vector may return `nullptr`, which nanobind
+/// reads as "no array" rather than as an empty one. A zero-cell tree is legal and
+/// has empty node arrays, so the views need an address.
+constexpr double kEmptyCoord = 0.0;
+
+/// The same, for the three index arrays.
+constexpr std::int64_t kEmptyIndex = 0;
+
+/// View a 1D nanobind array as a span.
+///
+/// \param a The array.
+/// \return A span over its storage.
+std::span<const double> as_span(const_vec a) {
+    return {a.data(), a.shape(0)};
+}
+
+/// View a 2D nanobind array as a row-major 2D span.
+///
+/// \param a The array.
+/// \return A view over its storage.
+pantr::span2d<const double> as_span2d(const_mat a) {
+    return pantr::span2d<const double>(a.data(), a.shape(0), a.shape(1));
+}
+
+/// Expose one of the two `(n_nodes, ndim)` coordinate arrays as a read-only view.
+///
+/// \param self The Python object holding the tree; becomes the array's owner.
+/// \param block The tree's own storage for that array.
+/// \return A `float64` array of shape `(n_nodes, ndim)`, read-only, aliasing.
+nb::object coordinate_view(nb::object self, pantr::span2d<const double> block) {
+    const double* base = block.size() == 0 ? &kEmptyCoord : block.data_handle();
+    return nb::cast(nb::ndarray<nb::numpy, const double, nb::ndim<2>>(
+        base, {block.extent(0), block.extent(1)}, self));
+}
+
+/// Expose one of the three per-node index arrays as a read-only view.
+///
+/// \param self The Python object holding the tree; becomes the array's owner.
+/// \param block The tree's own storage for that array.
+/// \return An `int64` array of shape `(n_nodes,)`, read-only, aliasing.
+nb::object index_view(nb::object self, std::span<const std::int64_t> block) {
+    const std::int64_t* base = block.empty() ? &kEmptyIndex : block.data();
+    return nb::cast(
+        nb::ndarray<nb::numpy, const std::int64_t, nb::ndim<1>>(base, {block.size()}, self));
+}
+
+}  // namespace
+
+void register_grid_bvh(nb::module_& m) {
+    nb::class_<Tree>(m, "BVH")
+        .def(
+            "__init__",
+            [](Tree* self, const_mat node_lo, const_mat node_hi, const_idx node_left,
+               const_idx node_right, const_idx node_cell, std::int64_t n_cells) {
+                new (self) Tree(as_span2d(node_lo), as_span2d(node_hi),
+                                std::span<const std::int64_t>(node_left.data(),
+                                                              node_left.shape(0)),
+                                std::span<const std::int64_t>(node_right.data(),
+                                                              node_right.shape(0)),
+                                std::span<const std::int64_t>(node_cell.data(),
+                                                              node_cell.shape(0)),
+                                n_cells);
+            },
+            nb::arg("node_lo"), nb::arg("node_hi"), nb::arg("node_left"), nb::arg("node_right"),
+            nb::arg("node_cell"), nb::arg("n_cells"))
+        .def_static(
+            "from_cell_bounds",
+            [](const_mat cell_lo, const_mat cell_hi) {
+                return Tree::from_cell_bounds(as_span2d(cell_lo), as_span2d(cell_hi));
+            },
+            nb::arg("cell_lo"), nb::arg("cell_hi"))
+        .def_prop_ro("ndim", &Tree::ndim)
+        .def_prop_ro("n_cells", &Tree::n_cells)
+        .def_prop_ro("n_nodes", &Tree::n_nodes)
+        .def_prop_ro("node_lo",
+                     [](nb::object self) {
+                         return coordinate_view(self, nb::cast<const Tree&>(self).node_lo());
+                     })
+        .def_prop_ro("node_hi",
+                     [](nb::object self) {
+                         return coordinate_view(self, nb::cast<const Tree&>(self).node_hi());
+                     })
+        .def_prop_ro("node_left",
+                     [](nb::object self) {
+                         return index_view(self, nb::cast<const Tree&>(self).node_left());
+                     })
+        .def_prop_ro("node_right",
+                     [](nb::object self) {
+                         return index_view(self, nb::cast<const Tree&>(self).node_right());
+                     })
+        .def_prop_ro("node_cell",
+                     [](nb::object self) {
+                         return index_view(self, nb::cast<const Tree&>(self).node_cell());
+                     })
+        .def(
+            "query_aabb",
+            [](const Tree& tree, const_vec qlo, const_vec qhi) {
+                const std::vector<std::int64_t> matched =
+                    tree.query_aabb(as_span(qlo), as_span(qhi));
+                auto* owned = new std::vector<std::int64_t>(matched);
+                // A zero-capacity vector's `data()` may be null; one slot of
+                // capacity gives the empty array a valid address without changing
+                // its size.
+                if (owned->empty()) {
+                    owned->reserve(1);
+                }
+                nb::capsule owner(owned, [](void* p) noexcept {
+                    delete static_cast<std::vector<std::int64_t>*>(p);
+                });
+                // Freshly allocated and writeable, matching the oracle, which
+                // returns a `numpy.empty` it filled.
+                return nb::ndarray<nb::numpy, std::int64_t, nb::ndim<1>>(
+                    owned->data(), {owned->size()}, owner);
+            },
+            nb::arg("qlo"), nb::arg("qhi"));
 }

--- a/cpp/bindings/grid_bvh.cpp
+++ b/cpp/bindings/grid_bvh.cpp
@@ -170,12 +170,15 @@ void register_grid_bvh(nb::module_& m) {
         .def(
             "query_aabb",
             [](const Tree& tree, const_vec qlo, const_vec qhi) {
-                const std::vector<std::int64_t> matched =
-                    tree.query_aabb(as_span(qlo), as_span(qhi));
-                auto* owned = new std::vector<std::int64_t>(matched);
+                // Moved rather than copied: `query_aabb` returns a fresh vector, and
+                // a query on a large tree can match many cells.
+                auto* owned =
+                    new std::vector<std::int64_t>(tree.query_aabb(as_span(qlo), as_span(qhi)));
                 // A zero-capacity vector's `data()` may be null; one slot of
                 // capacity gives the empty array a valid address without changing
-                // its size.
+                // its size. The named `kEmpty*` sentinels the read-only views use
+                // are `const` and cannot serve here, because this array is handed
+                // back writeable.
                 if (owned->empty()) {
                     owned->reserve(1);
                 }

--- a/cpp/bindings/grid_partition.cpp
+++ b/cpp/bindings/grid_partition.cpp
@@ -1,15 +1,106 @@
 /// \file
-/// nanobind bindings for `pantr::grid::Partition` -- reserved, empty.
+/// nanobind bindings for `pantr::grid::Partition`.
 ///
-/// The module's three assembly points (`pantr_cpp.cpp`, `register.hpp` and
-/// `CMakeLists.txt`) are edited once, here, so the ticket that ports the type
-/// edits this file and nothing else. Thirteen tickets in this milestone would
-/// otherwise collide on those three.
+/// Follows `geometry.cpp` and `grid_tags.cpp`: ownership moved to C++ under the
+/// 2026-08-27 amendment to `design/cross_backend_types.md`, the Python class wraps
+/// one, and this file validates nothing because the type validates itself and
+/// throws `std::invalid_argument`, which nanobind surfaces as the `ValueError` the
+/// oracle raises.
+///
+/// ## What the wrapper still does
+///
+/// One thing, and it is the same reason as everywhere else in this port: the
+/// "``cell_owner`` must be a 1D integer array" check is a **dtype and rank** check,
+/// and by the time the binding hands C++ a `std::span<const std::int32_t>` both
+/// facts are gone. So the wrapper coerces -- including the narrowing cast to
+/// `int32`, which is part of the contract rather than a detail -- and this file
+/// receives an array that is already the right shape and type.
+///
+/// ## Two returns, two different lifetimes
+///
+/// `cell_owner` is a **zero-copy read-only view** whose owner is the Python object
+/// holding the partition, so the array cannot outlive the storage it aliases. A
+/// partition has no mutator, so nothing can move that storage under a live view.
+/// The owner argument is load-bearing twice: without it nanobind silently *copies*
+/// and returns a **writable** array, which would pass every value assertion and
+/// quietly drop the oracle's read-only contract.
+///
+/// `owned_cells` is a **fresh owning array**, because the ids are computed rather
+/// than stored, and the oracle returns a freshly allocated writeable array from
+/// `numpy.flatnonzero`. Both halves of that -- fresh and writeable -- are
+/// reproduced.
+///
+/// Read-only here means read-only against accident, not against malice: `ctypes`
+/// clears the flag in two lines. What the flag buys is that ordinary code cannot
+/// write into C++-owned storage by mistake.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "pantr/grid/partition.hpp"
 #include "register.hpp"
 
-void register_grid_partition(nanobind::module_&) {
-    // Nothing yet: the port adds the `nanobind::class_` for the type here.
+namespace nb = nanobind;
+
+namespace {
+
+using pantr::grid::Partition;
+
+/// A read-only, contiguous 1D `int32` array as nanobind sees it.
+using const_owners = nb::ndarray<const std::int32_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A valid, never-dereferenced address for a zero-length view's data pointer.
+///
+/// `std::vector::data()` on an empty vector may return `nullptr`, which nanobind
+/// reads as "no array" rather than as an empty one. A partition over zero cells is
+/// legal -- the oracle's own tests build one -- so the view needs an address.
+constexpr std::int32_t kEmptyOwner = 0;
+
+}  // namespace
+
+void register_grid_partition(nb::module_& m) {
+    nb::class_<Partition>(m, "Partition")
+        .def(
+            "__init__",
+            [](Partition* self, const_owners cell_owner, std::int64_t n_parts) {
+                new (self) Partition(std::span<const std::int32_t>(cell_owner.data(),
+                                                                   cell_owner.shape(0)),
+                                     n_parts);
+            },
+            nb::arg("cell_owner"), nb::arg("n_parts"))
+        .def_prop_ro(
+            "cell_owner",
+            [](nb::object self) {
+                const std::span<const std::int32_t> owners =
+                    nb::cast<const Partition&>(self).cell_owner();
+                const std::int32_t* base = owners.empty() ? &kEmptyOwner : owners.data();
+                return nb::ndarray<nb::numpy, const std::int32_t, nb::ndim<1>>(
+                    base, {owners.size()}, self);
+            })
+        .def_prop_ro("n_parts", &Partition::n_parts)
+        .def_prop_ro("n_cells", &Partition::n_cells)
+        .def(
+            "owned_cells",
+            [](const Partition& p, std::int64_t rank) {
+                auto* owned = new std::vector<std::int64_t>(p.owned_cells(rank));
+                // A zero-capacity vector's `data()` may be null; one slot of
+                // capacity gives the empty array a valid address without changing
+                // its size.
+                if (owned->empty()) {
+                    owned->reserve(1);
+                }
+                nb::capsule owner(owned, [](void* p_owned) noexcept {
+                    delete static_cast<std::vector<std::int64_t>*>(p_owned);
+                });
+                return nb::ndarray<nb::numpy, std::int64_t, nb::ndim<1>>(
+                    owned->data(), {owned->size()}, owner);
+            },
+            nb::arg("rank"))
+        .def("__repr__", &Partition::to_string);
 }

--- a/cpp/bindings/grid_partition.cpp
+++ b/cpp/bindings/grid_partition.cpp
@@ -91,7 +91,8 @@ void register_grid_partition(nb::module_& m) {
                 auto* owned = new std::vector<std::int64_t>(p.owned_cells(rank));
                 // A zero-capacity vector's `data()` may be null; one slot of
                 // capacity gives the empty array a valid address without changing
-                // its size.
+                // its size. `kEmptyOwner` cannot serve here: it is `const`, and this
+                // array is handed back writeable to match the oracle.
                 if (owned->empty()) {
                     owned->reserve(1);
                 }

--- a/cpp/bindings/grid_tags.cpp
+++ b/cpp/bindings/grid_tags.cpp
@@ -1,15 +1,254 @@
 /// \file
-/// nanobind bindings for `pantr::grid`'s cell and facet tag registries -- reserved, empty.
+/// nanobind bindings for `pantr::grid::CellTags` and `pantr::grid::FacetTags`.
 ///
-/// The module's three assembly points (`pantr_cpp.cpp`, `register.hpp` and
-/// `CMakeLists.txt`) are edited once, here, so the ticket that ports the type
-/// edits this file and nothing else. Thirteen tickets in this milestone would
-/// otherwise collide on those three.
+/// The third and fourth types this extension exposes, after `AABB` and
+/// `AffineTransform`, and they follow those files' reasoning: ownership moved to
+/// C++ under the 2026-08-27 amendment to `design/cross_backend_types.md`, the
+/// Python classes wrap one, and this file validates nothing because the types
+/// validate themselves.
+///
+/// ## What the wrapper still does, and it is not laziness
+///
+/// Three things stay on the Python side, each because nanobind cannot express
+/// them rather than because they were easier there:
+///
+///  - **`KeyError` for an unregistered name.** `pantr/core/error.hpp` records the
+///    rule: nanobind 2.14.0 maps `std::out_of_range` to `IndexError` and has no
+///    path to `KeyError`. The wrapper checks `__contains__` and raises it itself,
+///    which keeps the message and costs one dictionary-sized lookup.
+///  - **`TypeError` for a non-integer `ids`, `values` or destination `dtype`.**
+///    Same reason: there is no `std::exception` nanobind turns into a `TypeError`.
+///  - **Allocating and filling `to_dense`'s destination.** `numpy.full` is what
+///    decides what an out-of-range `fill` does, and reproducing its `OverflowError`
+///    message by hand would be a second spelling of numpy's contract. So the
+///    wrapper allocates and fills, and `scatter` below writes only the tagged
+///    entries -- the project's ordinary `out` convention, reached for a reason.
+///
+/// ## Zero-copy views, and what keeps them alive
+///
+/// `get` hands back views into the registry's own storage rather than copies,
+/// unlike `geometry.cpp`, whose corners are `ndim` doubles and cheap to copy. A
+/// tag is as long as the tagged subset of the grid, and the oracle hands back its
+/// stored arrays without copying, so copying here would be a performance
+/// difference the backend switch must not introduce.
+///
+/// That makes lifetime the whole question, and `tags.hpp` answers it: each tag is
+/// held behind a `std::shared_ptr<const Tag>`, and every view below carries a
+/// capsule holding its own copy of that pointer. A later `set` on the same name
+/// replaces the registry's pointer and leaves the view's storage alive.
+///
+/// The owner is load-bearing twice over. It is what keeps the storage alive, and
+/// it is also what makes the array read-only: an ownerless `nb::ndarray` return
+/// silently *copies* and comes back writable, which would pass a value assertion
+/// and fail the oracle's read-only contract. `node_lo.base is not None` is the
+/// half of that pair a test can see.
+///
+/// ## Eight `scatter` overloads
+///
+/// The oracle's `to_dense(dtype=...)` accepts any of numpy's eight integer
+/// dtypes, so the destination type is genuinely part of the surface. Each overload
+/// carries `.noconvert()`, without which nanobind would happily convert an `int32`
+/// destination into an `int64` temporary, write the scatter into it and discard it
+/// -- a silent no-op, which is the failure `.noconvert()` exists to prevent
+/// throughout this directory.
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/tags.hpp"
 #include "register.hpp"
 
-void register_grid_tags(nanobind::module_&) {
-    // Nothing yet: the port adds the `nanobind::class_` for the type here.
+namespace nb = nanobind;
+
+namespace {
+
+using pantr::grid::CellTags;
+using pantr::grid::FacetTags;
+
+/// A read-only, contiguous 1D `int64` array as nanobind sees it.
+using const_ids = nb::ndarray<const std::int64_t, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A read-only, contiguous 2D `int64` array as nanobind sees it.
+using const_keys = nb::ndarray<const std::int64_t, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// A writeable, contiguous 1D destination as nanobind sees it.
+template <class T>
+using out_vec = nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu>;
+
+/// A writeable, contiguous 2D destination as nanobind sees it.
+template <class T>
+using out_mat = nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu>;
+
+/// View a 1D nanobind array as a span.
+///
+/// \param a The array.
+/// \return A span over its storage, valid while the array is alive.
+std::span<const std::int64_t> as_span(const_ids a) {
+    return {a.data(), a.shape(0)};
+}
+
+/// View a 2D nanobind array as a row-major 2D span.
+///
+/// \param a The array.
+/// \return A view over its storage.
+pantr::span2d<const std::int64_t> as_span2d(const_keys a) {
+    return pantr::span2d<const std::int64_t>(a.data(), a.shape(0), a.shape(1));
+}
+
+/// Expose one of a tag's arrays as a read-only numpy view that owns its lifetime.
+///
+/// \tparam Tag The registry's tag type.
+/// \param tag The shared handle to keep alive; a copy is stored in the capsule.
+/// \param values The array inside `tag` to view.
+/// \param shape The view's shape, one entry per dimension.
+/// \return An `int64` array, read-only, aliasing the tag's storage.
+template <class Tag, std::size_t Rank>
+nb::object tag_view(std::shared_ptr<const Tag> tag, const std::vector<std::int64_t>& values,
+                    std::array<std::size_t, Rank> shape) {
+    // An empty vector's `data()` may be null, and nanobind reads a null pointer as
+    // "no array" rather than as an empty one. An empty tag is legal -- the oracle's
+    // own tests set one -- so a valid, never-dereferenced address stands in.
+    const std::int64_t* base =
+        values.empty() ? &pantr::grid::detail::kEmptyStorage : values.data();
+    auto* keep = new std::shared_ptr<const Tag>(std::move(tag));
+    nb::capsule owner(keep, [](void* p) noexcept {
+        delete static_cast<std::shared_ptr<const Tag>*>(p);
+    });
+    // The pointer-and-rank constructor rather than the brace-list one: the shape
+    // arrives as a `std::array` because the rank is a template parameter here, and
+    // nanobind's brace-list overload takes an `initializer_list` a runtime array
+    // cannot become.
+    return nb::cast(nb::ndarray<nb::numpy, const std::int64_t, nb::ndim<Rank>>(
+        base, Rank, shape.data(), owner));
+}
+
+/// Register one `scatter` overload on the cell registry.
+///
+/// \tparam IntT The destination integer type.
+/// \param cls The class being built.
+template <class IntT>
+void bind_cell_scatter(nb::class_<CellTags>& cls) {
+    cls.def(
+        "scatter",
+        [](const CellTags& tags, const std::string& name, out_vec<IntT> out) {
+            tags.scatter<IntT>(name, std::span<IntT>(out.data(), out.shape(0)));
+        },
+        nb::arg("name"), nb::arg("out").noconvert());
+}
+
+/// Register one `scatter` overload on the facet registry.
+///
+/// \tparam IntT The destination integer type.
+/// \param cls The class being built.
+template <class IntT>
+void bind_facet_scatter(nb::class_<FacetTags>& cls) {
+    cls.def(
+        "scatter",
+        [](const FacetTags& tags, const std::string& name, out_mat<IntT> out) {
+            tags.scatter<IntT>(name,
+                               pantr::span2d<IntT>(out.data(), out.shape(0), out.shape(1)));
+        },
+        nb::arg("name"), nb::arg("out").noconvert());
+}
+
+/// Register the `scatter` overload set on both registries.
+///
+/// One fold rather than sixteen `def` lines, so that adding a destination type
+/// cannot be done for one registry and forgotten for the other.
+///
+/// \param cells The cell registry class.
+/// \param facets The facet registry class.
+void bind_scatter_overloads(nb::class_<CellTags>& cells, nb::class_<FacetTags>& facets) {
+    const auto bind_one = [&cells, &facets]<class IntT>() {
+        bind_cell_scatter<IntT>(cells);
+        bind_facet_scatter<IntT>(facets);
+    };
+    bind_one.template operator()<std::int8_t>();
+    bind_one.template operator()<std::int16_t>();
+    bind_one.template operator()<std::int32_t>();
+    bind_one.template operator()<std::int64_t>();
+    bind_one.template operator()<std::uint8_t>();
+    bind_one.template operator()<std::uint16_t>();
+    bind_one.template operator()<std::uint32_t>();
+    bind_one.template operator()<std::uint64_t>();
+}
+
+}  // namespace
+
+void register_grid_tags(nb::module_& m) {
+    nb::class_<CellTags> cells(m, "CellTags");
+    cells.def(nb::init<std::int64_t>(), nb::arg("num_cells"))
+        .def_prop_ro("num_cells", &CellTags::num_cells)
+        .def_prop_ro("names", &CellTags::names)
+        .def("__len__", &CellTags::size)
+        .def(
+            "__contains__",
+            [](const CellTags& tags, const std::string& name) { return tags.contains(name); },
+            nb::arg("name"))
+        .def(
+            "set",
+            [](CellTags& tags, const std::string& name, const_ids ids, const_ids values) {
+                tags.set(name, as_span(ids), as_span(values));
+            },
+            nb::arg("name"), nb::arg("ids"), nb::arg("values"))
+        .def(
+            "get",
+            [](const CellTags& tags, const std::string& name) {
+                auto tag = tags.get(name);
+                const std::size_t n = tag->ids.size();
+                return nb::make_tuple(tag_view<CellTags::Tag, 1>(tag, tag->ids, {n}),
+                                      tag_view<CellTags::Tag, 1>(tag, tag->values, {n}));
+            },
+            nb::arg("name"))
+        .def(
+            "remove", [](CellTags& tags, const std::string& name) { tags.remove(name); },
+            nb::arg("name"))
+        .def("__repr__", &CellTags::to_string);
+
+    nb::class_<FacetTags> facets(m, "FacetTags");
+    facets.def(nb::init<std::int64_t, std::int64_t>(), nb::arg("num_cells"),
+               nb::arg("facets_per_cell"))
+        .def_prop_ro("num_cells", &FacetTags::num_cells)
+        .def_prop_ro("facets_per_cell", &FacetTags::facets_per_cell)
+        .def_prop_ro("names", &FacetTags::names)
+        .def("__len__", &FacetTags::size)
+        .def(
+            "__contains__",
+            [](const FacetTags& tags, const std::string& name) { return tags.contains(name); },
+            nb::arg("name"))
+        .def(
+            "set",
+            [](FacetTags& tags, const std::string& name, const_keys keys, const_ids values) {
+                tags.set(name, as_span2d(keys), as_span(values));
+            },
+            nb::arg("name"), nb::arg("keys"), nb::arg("values"))
+        .def(
+            "get",
+            [](const FacetTags& tags, const std::string& name) {
+                auto tag = tags.get(name);
+                const std::size_t rows = tag->rows();
+                return nb::make_tuple(
+                    tag_view<FacetTags::Tag, 2>(tag, tag->keys,
+                                                {rows, pantr::grid::detail::kFacetKeyWidth}),
+                    tag_view<FacetTags::Tag, 1>(tag, tag->values, {rows}));
+            },
+            nb::arg("name"))
+        .def(
+            "remove", [](FacetTags& tags, const std::string& name) { tags.remove(name); },
+            nb::arg("name"))
+        .def("__repr__", &FacetTags::to_string);
+
+    bind_scatter_overloads(cells, facets);
 }

--- a/cpp/include/pantr/grid/bvh.hpp
+++ b/cpp/include/pantr/grid/bvh.hpp
@@ -57,9 +57,23 @@
 /// ## The query is exact for a duller reason
 ///
 /// Both query kernels are comparisons on stored node bounds plus an integer
-/// stack. The overlap test is inclusive on every face, so a query box sharing a
-/// face with a cell is reported -- matching `pantr.geometry.AABB.overlaps` -- and
-/// that too is a discrete verdict decided without arithmetic.
+/// stack. The overlap test is a **separating-axis test and nothing else**: it
+/// reports an overlap unless some axis separates the two intervals, comparing
+/// inclusively, so a query box sharing a face with a cell is reported. That too is
+/// a discrete verdict decided without arithmetic.
+///
+/// **It is not `pantr.geometry.AABB.overlaps`, and this comment used to say it
+/// was.** The box short-circuits on an *empty* operand and reports that an empty
+/// box overlaps nothing; the predicate below has no such branch, so a reversed
+/// query interval that a cell's interval contains passes every separating-axis
+/// check and the leaf is reported. One cell `[0, 10]` in one dimension, queried
+/// with `lo = 5, hi = 3`, returns cell `0` here and `False` from the box. The
+/// divergence is reproduced deliberately: both backends of the BVH behave this
+/// way, they agree with each other, and reconciling them with the box has to move
+/// both at once or the parity claim stops being an equality. So this file
+/// reproduces the query it was ported from, and the claim of agreement with the
+/// box is withdrawn rather than the behaviour changed. Tracked as a divergence
+/// between the two predicates, not as a defect in either.
 ///
 /// Count and emit must agree on the output size, so they share one traversal
 /// order: the left child is pushed first and the right last, so the stack pops
@@ -251,7 +265,12 @@ void bvh_build(span2d<const T> cell_lo, span2d<const T> cell_hi, span2d<T> node_
     }
 }
 
-/// Whether a node's AABB overlaps the query box, inclusive on every face.
+/// Whether no axis separates a node's AABB from the query box, comparing inclusively.
+///
+/// Stated as the separating-axis test it is rather than as "overlaps", because the
+/// two are not the same predicate on an empty box: this one has no emptiness
+/// branch and reports a reversed query interval as overlapping any cell whose own
+/// interval contains it. See the file comment.
 ///
 /// Factored out so that count and emit cannot drift from each other on the tie
 /// contract, which is the one thing about them that is not obviously the same.

--- a/cpp/include/pantr/grid/bvh_tree.hpp
+++ b/cpp/include/pantr/grid/bvh_tree.hpp
@@ -1,0 +1,449 @@
+#pragma once
+
+/// \file
+/// The bounding-volume hierarchy as a type, over the kernels in `bvh.hpp`.
+///
+/// Ports `src/pantr/grid/_bvh.py`, whose class stays as the Python backend under
+/// `PANTR_BACKEND=python`. Ownership moves under `design/cross_backend_types.md`'s
+/// 2026-08-27 amendment: there is one hierarchy, it is this one, and
+/// `pantr.grid.BVH` wraps it. The kernels it calls are unchanged and stay where
+/// they are; this header adds the validation, the invariants and the lifetime that
+/// `_bvh.py` used to own.
+///
+/// ## The layout is a contract, and is ported unchanged
+///
+/// `design/bvh.md` establishes the five node arrays -- `node_lo`, `node_hi`,
+/// `node_left`, `node_right`, `node_cell` -- as **public API rather than
+/// implementation detail**, so this type reproduces them exactly: no leaf
+/// clustering, no `int32` indices, no reordering. That note's improvement 4 is
+/// marked "now or never" and stays closed until an API exists that frees a caller
+/// from reading the arrays; a per-node `traverse(visitor)` callback is not that
+/// API, because `design/user_functions_across_the_boundary.md` records a callback
+/// across the boundary at about a microsecond per call, which is fatal in a
+/// traversal loop.
+///
+/// ## The traversal stack is a limit of this build, not a defect in the argument
+///
+/// A tree deeper than `kBvhStackDepth` is perfectly well formed and this
+/// implementation cannot walk it, so the constructor throws `pantr::CapacityError`
+/// rather than `std::invalid_argument`; `pantr/core/error.hpp` argues why, and this
+/// is the first and only site that throws it. The Python wrapper presents the
+/// pre-port `ValueError` with the same text, because `PANTR_BACKEND` must not
+/// decide which exception a caller catches -- see `src/pantr/grid/_bvh.py`.
+///
+/// The depth is established **once, at construction**, by an explicit walk with an
+/// unbounded stack. It has to be unbounded: the depth is the unknown being
+/// measured, so a fixed buffer would reproduce the very overflow the walk exists to
+/// refuse. The walk stops as soon as it passes the limit, which is all the caller
+/// needs and which also makes it terminate on a node array that is not a tree -- a
+/// cyclic child pointer would otherwise grow the stack without bound, and a
+/// validator that hangs is worse than the out-of-bounds write it replaces.
+///
+/// ## Zero-copy accessors, and what #359 becomes here
+///
+/// The five arrays are exposed as views into this object's own storage; the binding
+/// hands them to numpy read-only, aliasing rather than copying, because the oracle
+/// does the same and copying would make the backend switch a performance switch.
+///
+/// **This widens open issue #359 and the widening is recorded rather than closed.**
+/// The exposure *shape* does not change: `_bvh.py` already returned its stored
+/// array directly with `flags.writeable` cleared. What changes is the consequence
+/// of defeating that flag, which `ctypes` does in two lines. Today a corrupted
+/// child index makes the numba kernel return a defined wrong answer; here the
+/// traversal indexes out of bounds, and `PANTR_PRECONDITION` is `assert`
+/// (`pantr/core/precondition.hpp`), which `NDEBUG` removes. Per-node bounds
+/// checking was rejected on a cost that `precondition.hpp` records as **measured**
+/// against the traversal loop, not estimated. So a caller who clears the read-only
+/// flag and writes into these arrays is outside the contract, and on this backend
+/// that is undefined behaviour rather than a wrong answer.
+///
+/// Read-only here means read-only against accident, not against malice. That is
+/// what the flag buys and it is worth saying plainly, because a docstring claiming
+/// nothing can write into C++-owned memory would be false.
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/core/error.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+#include "pantr/grid/bvh.hpp"
+
+namespace pantr::grid {
+
+/// A bounding-volume hierarchy indexing a fixed collection of cell AABBs.
+///
+/// Stored as the five parallel node arrays `bvh.hpp`'s kernels consume. The root
+/// is node `0`; for `N >= 1` cells the tree has exactly `2N - 1` nodes, and for
+/// `N == 0` it has none. Instances are immutable: nothing changes a tree once it is
+/// built, and every accessor hands back a view of storage that cannot move.
+template <Real T>
+class BVH {
+  public:
+    /// Store the raw node arrays after validating them.
+    ///
+    /// Prefer `from_cell_bounds`; this constructor exists for a caller that has the
+    /// arrays already -- a test poking a specific tree shape, or a round trip
+    /// through serialization.
+    ///
+    /// \param node_lo Per-node AABB lo corners, shape `(n_nodes, ndim)`.
+    /// \param node_hi Per-node AABB hi corners, same shape.
+    /// \param node_left Left-child indices, `-1` on leaves, length `n_nodes`.
+    /// \param node_right Right-child indices, same convention and length.
+    /// \param node_cell Leaf cell ids, `-1` on internal nodes, same length.
+    /// \param n_cells Number of indexed cells, which fixes `n_nodes`.
+    /// \throws std::invalid_argument If the shapes disagree, if `ndim < 1`, if
+    ///         `n_nodes != 2 * n_cells - 1`, if `node_cell` and the child pointers
+    ///         disagree about which nodes are leaves, or if a child index or leaf
+    ///         cell id is out of range.
+    /// \throws pantr::CapacityError If the tree is deeper than the traversal stack
+    ///         this build carries.
+    BVH(span2d<const T> node_lo, span2d<const T> node_hi,
+        std::span<const std::int64_t> node_left, std::span<const std::int64_t> node_right,
+        std::span<const std::int64_t> node_cell, std::int64_t n_cells)
+        : node_lo_(node_lo.data_handle(), node_lo.data_handle() + node_lo.size()),
+          node_hi_(node_hi.data_handle(), node_hi.data_handle() + node_hi.size()),
+          node_left_(node_left.begin(), node_left.end()),
+          node_right_(node_right.begin(), node_right.end()),
+          node_cell_(node_cell.begin(), node_cell.end()),
+          n_nodes_(node_lo.extent(0)),
+          ndim_(node_lo.extent(1)),
+          n_cells_(n_cells) {
+        if (node_hi.extent(0) != n_nodes_ || node_hi.extent(1) != ndim_) {
+            throw std::invalid_argument("node_hi shape (" + std::to_string(node_hi.extent(0))
+                                        + ", " + std::to_string(node_hi.extent(1))
+                                        + ") must match node_lo shape ("
+                                        + std::to_string(n_nodes_) + ", "
+                                        + std::to_string(ndim_) + ").");
+        }
+        if (ndim_ < 1) {
+            throw std::invalid_argument("BVH ndim must be >= 1; got " + std::to_string(ndim_)
+                                        + ".");
+        }
+        for (const auto& [array, name] :
+             {std::pair{&node_left_, "node_left"}, std::pair{&node_right_, "node_right"},
+              std::pair{&node_cell_, "node_cell"}}) {
+            if (array->size() != n_nodes_) {
+                throw std::invalid_argument(std::string(name) + " must have shape ("
+                                            + std::to_string(n_nodes_) + ",); got ("
+                                            + std::to_string(array->size()) + ",).");
+            }
+        }
+        const std::int64_t expected = n_cells > 0 ? 2 * n_cells - 1 : 0;
+        if (static_cast<std::int64_t>(n_nodes_) != expected) {
+            throw std::invalid_argument("BVH: n_cells=" + std::to_string(n_cells)
+                                        + " implies n_nodes=" + std::to_string(expected)
+                                        + "; got node arrays with " + std::to_string(n_nodes_)
+                                        + " rows.");
+        }
+        // Runs before the depth walk below, which indexes the children itself.
+        check_tree_structure();
+        check_depth();
+    }
+
+    /// Build a hierarchy over `n_cells` cell AABBs, by median-of-longest-axis splits.
+    ///
+    /// Cells are sorted by centroid on the longest axis and split at the median, so
+    /// the tree is balanced and each leaf indexes exactly one cell.
+    ///
+    /// \param cell_lo Per-cell lo corners, shape `(n_cells, ndim)` with `ndim >= 1`.
+    /// \param cell_hi Per-cell hi corners, same shape, with `hi >= lo` everywhere.
+    /// \return The hierarchy.
+    /// \throws std::invalid_argument If the shapes disagree, if `ndim < 1`, if a
+    ///         corner is not finite, or if some cell has `hi < lo`.
+    /// \throws pantr::CapacityError If the cell count implies a tree deeper than the
+    ///         traversal stack this build carries.
+    [[nodiscard]] static BVH from_cell_bounds(span2d<const T> cell_lo, span2d<const T> cell_hi) {
+        const std::size_t n_cells = cell_lo.extent(0);
+        const std::size_t ndim = cell_lo.extent(1);
+        if (cell_hi.extent(0) != n_cells || cell_hi.extent(1) != ndim) {
+            throw std::invalid_argument("cell_hi shape (" + std::to_string(cell_hi.extent(0))
+                                        + ", " + std::to_string(cell_hi.extent(1))
+                                        + ") must match cell_lo shape ("
+                                        + std::to_string(n_cells) + ", "
+                                        + std::to_string(ndim) + ").");
+        }
+        if (ndim < 1) {
+            throw std::invalid_argument("BVH ndim must be >= 1; got " + std::to_string(ndim)
+                                        + ".");
+        }
+        for (std::size_t k = 0; k < n_cells * ndim; ++k) {
+            if (!std::isfinite(value_of(cell_lo.data_handle()[k]))
+                || !std::isfinite(value_of(cell_hi.data_handle()[k]))) {
+                throw std::invalid_argument(
+                    "BVH.from_cell_bounds: cell_lo and cell_hi must contain only finite "
+                    "values; got NaN or Inf.");
+            }
+        }
+        for (std::size_t k = 0; k < n_cells * ndim; ++k) {
+            if (value_of(cell_hi.data_handle()[k]) < value_of(cell_lo.data_handle()[k])) {
+                throw std::invalid_argument(
+                    "Every cell must satisfy cell_hi >= cell_lo on every axis; at least one "
+                    "cell violates this.");
+            }
+        }
+        if (n_cells == 0) {
+            return BVH(Unchecked{}, ndim);
+        }
+        // The splits are balanced, so the height follows from the cell count and
+        // needs no tree walk. `bit_width(n - 1)` is `ceil(log2(n))` for n >= 2, in
+        // exact integers; the `+ 1` is the root push. Going through a `double` is
+        // the wrong arithmetic for a question about an integer, and past a
+        // threshold returns a height one too SMALL, which is the unsafe direction
+        // for a bound. scripts/measure_bvh_depth_arithmetic.py enumerates the
+        // disagreements rather than this comment carrying figures nothing
+        // re-derives.
+        const std::int64_t max_depth =
+            n_cells > 1
+                ? static_cast<std::int64_t>(std::bit_width(static_cast<std::uint64_t>(n_cells - 1)))
+                      + 1
+                : 1;
+        if (max_depth > kBvhStackDepth) {
+            throw CapacityError("BVH.from_cell_bounds: " + std::to_string(n_cells)
+                                + " cells would produce a tree of depth >= "
+                                + std::to_string(max_depth)
+                                + ", exceeding the internal stack depth "
+                                + std::to_string(kBvhStackDepth)
+                                + ". This is a library limit; please report this as an issue.");
+        }
+
+        const std::size_t n_nodes = 2 * n_cells - 1;
+        BVH tree(Unchecked{}, ndim);
+        tree.node_lo_.assign(n_nodes * ndim, T{0});
+        tree.node_hi_.assign(n_nodes * ndim, T{0});
+        tree.node_left_.assign(n_nodes, -1);
+        tree.node_right_.assign(n_nodes, -1);
+        tree.node_cell_.assign(n_nodes, -1);
+        tree.n_nodes_ = n_nodes;
+        tree.n_cells_ = static_cast<std::int64_t>(n_cells);
+        bvh_build<T>(cell_lo, cell_hi, span2d<T>(tree.node_lo_.data(), n_nodes, ndim),
+                     span2d<T>(tree.node_hi_.data(), n_nodes, ndim), tree.node_left_,
+                     tree.node_right_, tree.node_cell_);
+        return tree;
+    }
+
+    /// The spatial dimension.
+    ///
+    /// \return The number of axes, `>= 1`.
+    [[nodiscard]] std::size_t ndim() const noexcept { return ndim_; }
+
+    /// The number of indexed cells, equal to the number of leaves.
+    ///
+    /// \return The cell count.
+    [[nodiscard]] std::int64_t n_cells() const noexcept { return n_cells_; }
+
+    /// The total number of nodes.
+    ///
+    /// \return `2 * n_cells - 1`, or `0` when there are no cells.
+    [[nodiscard]] std::size_t n_nodes() const noexcept { return n_nodes_; }
+
+    /// The per-node AABB lower corners.
+    ///
+    /// \return A `(n_nodes, ndim)` view, valid while the tree lives.
+    [[nodiscard]] span2d<const T> node_lo() const noexcept {
+        return span2d<const T>(node_lo_.data(), n_nodes_, ndim_);
+    }
+
+    /// The per-node AABB upper corners.
+    ///
+    /// \return A `(n_nodes, ndim)` view, valid while the tree lives.
+    [[nodiscard]] span2d<const T> node_hi() const noexcept {
+        return span2d<const T>(node_hi_.data(), n_nodes_, ndim_);
+    }
+
+    /// The per-node left-child indices.
+    ///
+    /// \return A length-`n_nodes` view; `-1` on a leaf.
+    [[nodiscard]] std::span<const std::int64_t> node_left() const noexcept { return node_left_; }
+
+    /// The per-node right-child indices.
+    ///
+    /// \return A length-`n_nodes` view; `-1` on a leaf.
+    [[nodiscard]] std::span<const std::int64_t> node_right() const noexcept {
+        return node_right_;
+    }
+
+    /// The per-leaf cell ids.
+    ///
+    /// \return A length-`n_nodes` view; `-1` on an internal node.
+    [[nodiscard]] std::span<const std::int64_t> node_cell() const noexcept { return node_cell_; }
+
+    /// The ids of every leaf cell whose AABB is not separated from the query box.
+    ///
+    /// Named for the query it answers rather than for the geometry it suggests:
+    /// `bvh.hpp`'s predicate is a separating-axis test with no emptiness branch, so
+    /// a **reversed** query interval is reported against any cell whose own
+    /// interval contains it, where `pantr::geometry::AABB::overlaps` would report
+    /// nothing. That divergence is reproduced deliberately and is argued in
+    /// `bvh.hpp`'s file comment.
+    ///
+    /// The ids come back in the traversal's own preorder, which is right to left;
+    /// a caller wanting another order sorts.
+    ///
+    /// \param qlo Query box lo corner, length `ndim`.
+    /// \param qhi Query box hi corner, same length.
+    /// \return The matching cell ids.
+    /// \throws std::invalid_argument If either corner has the wrong length.
+    /// \throws std::runtime_error If the count and emit passes disagree, which is a
+    ///         defect in the kernels rather than in the argument.
+    [[nodiscard]] std::vector<std::int64_t> query_aabb(std::span<const T> qlo,
+                                                       std::span<const T> qhi) const {
+        if (qlo.size() != ndim_ || qhi.size() != ndim_) {
+            throw std::invalid_argument("BVH.query_aabb: aabb.ndim ("
+                                        + std::to_string(qlo.size())
+                                        + ") must match self.ndim (" + std::to_string(ndim_)
+                                        + ").");
+        }
+        if (n_cells_ == 0) {
+            return {};
+        }
+        const std::int64_t count = bvh_query_count<T>(qlo, qhi, node_lo(), node_hi(), node_left_,
+                                                      node_right_, node_cell_);
+        std::vector<std::int64_t> out(static_cast<std::size_t>(count));
+        if (count == 0) {
+            return out;
+        }
+        const std::int64_t written = bvh_query_emit<T>(qlo, qhi, node_lo(), node_hi(), node_left_,
+                                                       node_right_, node_cell_, out);
+        if (written != count) {
+            throw std::runtime_error(
+                "BVH.query_aabb: internal count/emit mismatch (count pass returned "
+                + std::to_string(count) + ", emit pass wrote " + std::to_string(written)
+                + "). This is a bug in the BVH kernel; please report it.");
+        }
+        return out;
+    }
+
+  private:
+    /// Tag for the constructor that builds an empty shell for a factory to fill.
+    struct Unchecked {};
+
+    /// Build a zero-node tree of the given dimension.
+    ///
+    /// \param ndim Spatial dimension.
+    BVH(Unchecked, std::size_t ndim) : n_nodes_(0), ndim_(ndim), n_cells_(0) {}
+
+    /// Reject node arrays the traversal kernels cannot walk.
+    ///
+    /// The kernels decide "leaf or internal" from `node_cell` alone and then push
+    /// both children without testing either against `-1`, so the two encodings of
+    /// leafness have to agree and an internal node's children have to be real
+    /// indices. A child left at `-1`, or any other negative value, indexes out of
+    /// bounds rather than raising.
+    ///
+    /// \throws std::invalid_argument If the encodings disagree or an index is out
+    ///         of range.
+    void check_tree_structure() const {
+        for (std::size_t node = 0; node < n_nodes_; ++node) {
+            const bool is_leaf = node_cell_[node] >= 0;
+            const bool no_children = node_left_[node] == -1 && node_right_[node] == -1;
+            if (is_leaf != no_children) {
+                throw std::invalid_argument(
+                    "BVH: node_cell and the child pointers disagree about which nodes are "
+                    "leaves. A node is a leaf iff node_cell >= 0, and exactly then must "
+                    "node_left and node_right both be -1.");
+            }
+        }
+        check_child_range(node_left_, "node_left");
+        check_child_range(node_right_, "node_right");
+
+        std::int64_t max_cell = -1;
+        for (std::size_t node = 0; node < n_nodes_; ++node) {
+            if (node_cell_[node] >= 0) {
+                max_cell = std::max(max_cell, node_cell_[node]);
+            }
+        }
+        if (max_cell >= n_cells_) {
+            throw std::invalid_argument("BVH: node_cell contains values outside [0, "
+                                        + std::to_string(n_cells_)
+                                        + ") on leaves: maximum is " + std::to_string(max_cell)
+                                        + ".");
+        }
+    }
+
+    /// Reject an internal node's child index outside `[0, n_nodes)`.
+    ///
+    /// Reports the range over internal nodes only, matching the oracle: a leaf's
+    /// `-1` is not a violation.
+    ///
+    /// \param children The child array to check.
+    /// \param name Its name, for the message.
+    /// \throws std::invalid_argument If some internal node's child is out of range.
+    void check_child_range(const std::vector<std::int64_t>& children, const char* name) const {
+        bool any = false;
+        std::int64_t lo = 0;
+        std::int64_t hi = 0;
+        for (std::size_t node = 0; node < n_nodes_; ++node) {
+            if (node_cell_[node] >= 0) {
+                continue;
+            }
+            const std::int64_t child = children[node];
+            lo = any ? std::min(lo, child) : child;
+            hi = any ? std::max(hi, child) : child;
+            any = true;
+        }
+        if (any && (lo < 0 || hi >= static_cast<std::int64_t>(n_nodes_))) {
+            throw std::invalid_argument(std::string(name) + " contains values outside [0, "
+                                        + std::to_string(n_nodes_)
+                                        + ") on internal nodes: range is [" + std::to_string(lo)
+                                        + ", " + std::to_string(hi) + "].");
+        }
+    }
+
+    /// Reject a tree deeper than the traversal stack this build carries.
+    ///
+    /// Walks from the root with an unbounded stack -- the depth is the unknown being
+    /// measured, so a fixed buffer would reproduce the overflow this exists to
+    /// refuse -- and stops as soon as the limit is passed, which also makes it
+    /// terminate on a cyclic child pointer.
+    ///
+    /// \throws pantr::CapacityError If the deepest root-to-leaf path does not fit.
+    void check_depth() const {
+        if (n_nodes_ == 0) {
+            return;
+        }
+        std::vector<std::pair<std::int64_t, std::int64_t>> stack{{0, 1}};
+        std::int64_t max_depth = 0;
+        while (!stack.empty()) {
+            const auto [node, depth] = stack.back();
+            stack.pop_back();
+            max_depth = std::max(max_depth, depth);
+            if (max_depth > kBvhStackDepth) {
+                throw CapacityError(
+                    "BVH: the given node arrays encode a tree of depth "
+                    + std::to_string(max_depth) + " or more, exceeding the stack depth "
+                    + std::to_string(kBvhStackDepth)
+                    + " that the traversal kernels allow. Build the tree more evenly, or use "
+                      "BVH.from_cell_bounds, whose median split keeps the depth logarithmic in "
+                      "the cell count.");
+            }
+            const std::int64_t left = node_left_[static_cast<std::size_t>(node)];
+            const std::int64_t right = node_right_[static_cast<std::size_t>(node)];
+            if (left != -1) {
+                stack.emplace_back(left, depth + 1);
+            }
+            if (right != -1) {
+                stack.emplace_back(right, depth + 1);
+            }
+        }
+    }
+
+    std::vector<T> node_lo_;               ///< Per-node lo corners, row-major.
+    std::vector<T> node_hi_;               ///< Per-node hi corners, row-major.
+    std::vector<std::int64_t> node_left_;  ///< Left-child indices, `-1` on a leaf.
+    std::vector<std::int64_t> node_right_; ///< Right-child indices, `-1` on a leaf.
+    std::vector<std::int64_t> node_cell_;  ///< Leaf cell ids, `-1` on an internal node.
+    std::size_t n_nodes_;                  ///< Node count.
+    std::size_t ndim_;                     ///< Spatial dimension.
+    std::int64_t n_cells_;                 ///< Indexed cell count.
+};
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/partition.hpp
+++ b/cpp/include/pantr/grid/partition.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+/// \file
+/// Cell-ownership partition for distributing a structured grid.
+///
+/// Ports `src/pantr/grid/_partition.py`, whose class stays as the Python backend
+/// under `PANTR_BACKEND=python`. Ownership moves under
+/// `design/cross_backend_types.md`'s 2026-08-27 amendment: there is one partition,
+/// it is this one, and `pantr.grid.Partition` wraps it.
+///
+/// A partition records, for every cell of a grid, which rank owns it -- or `-1`
+/// for an inactive cell excluded from the partition (an exterior or trimmed cell).
+/// It is deliberately space-agnostic: an integer owner per cell and nothing else,
+/// which is what lets the same descriptor serve a grid and the knot-span grid of a
+/// B-spline space.
+///
+/// ## Why `int32` owners
+///
+/// The oracle coerces to `int32` on construction and this reproduces that, cast
+/// included: a rank index needs nothing wider, and the array is one entry per cell
+/// on a mesh that may be large. The **narrowing** is part of the contract rather
+/// than an implementation detail -- a caller handing in an owner above `2^31 - 1`
+/// gets a wrapped value, which the range check below then rejects, in both
+/// backends and in that order.
+///
+/// ## What is deliberately not here
+///
+/// The oracle's `active_mask` is not a method on this type. It is
+/// `cell_owner[i] >= 0`, one line for a C++ caller and a whole `numpy` array for a
+/// Python one, so the wrapper computes it from `cell_owner` where it is a single
+/// vectorised comparison. That keeps this type to the two questions it is the only
+/// one able to answer: what the owner of a cell is, and which cells a rank owns.
+///
+/// ## Immutability, and what the binding may hand out
+///
+/// A partition has no mutator, which is what makes it safe for the binding to
+/// expose `cell_owner` as a zero-copy read-only view rather than a copy. The
+/// oracle exposes its stored array the same way, with `writeable` cleared.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace pantr::grid {
+
+/// A per-cell owner assignment over a grid's cells.
+///
+/// Records, for every cell, the rank that owns it, or `-1` for an inactive cell.
+/// Instances are immutable once constructed.
+class Partition {
+  public:
+    /// Build a partition from a per-cell owner array.
+    ///
+    /// \param cell_owner Per-cell owner ranks, `-1` for an inactive cell. Copied.
+    /// \param n_parts Number of parts (ranks), `>= 1`.
+    /// \throws std::invalid_argument If `n_parts < 1`, or if some owner falls
+    ///         outside `[-1, n_parts)`.
+    Partition(std::span<const std::int32_t> cell_owner, std::int64_t n_parts)
+        : cell_owner_(cell_owner.begin(), cell_owner.end()), n_parts_(n_parts) {
+        if (n_parts < 1) {
+            throw std::invalid_argument("n_parts must be >= 1; got " + std::to_string(n_parts)
+                                        + ".");
+        }
+        if (cell_owner_.empty()) {
+            return;
+        }
+        const auto [min_it, max_it] = std::minmax_element(cell_owner_.begin(), cell_owner_.end());
+        if (*min_it < -1 || static_cast<std::int64_t>(*max_it) >= n_parts) {
+            throw std::invalid_argument("cell_owner values must lie in [-1, "
+                                        + std::to_string(n_parts) + "); got range ["
+                                        + std::to_string(*min_it) + ", "
+                                        + std::to_string(*max_it) + "].");
+        }
+    }
+
+    /// The per-cell owner array.
+    ///
+    /// \return A view of the stored owners, valid while the partition lives.
+    [[nodiscard]] std::span<const std::int32_t> cell_owner() const noexcept {
+        return cell_owner_;
+    }
+
+    /// The number of parts (ranks).
+    ///
+    /// \return The part count, `>= 1`.
+    [[nodiscard]] std::int64_t n_parts() const noexcept { return n_parts_; }
+
+    /// The total number of cells, active and inactive.
+    ///
+    /// \return The length of `cell_owner`.
+    [[nodiscard]] std::size_t n_cells() const noexcept { return cell_owner_.size(); }
+
+    /// The flat ids of the cells owned by `rank`, ascending.
+    ///
+    /// \param rank Owner rank in `[0, n_parts)`.
+    /// \return The ids, in increasing order.
+    /// \throws std::invalid_argument If `rank` is outside `[0, n_parts)`.
+    [[nodiscard]] std::vector<std::int64_t> owned_cells(std::int64_t rank) const {
+        if (rank < 0 || rank >= n_parts_) {
+            throw std::invalid_argument("rank must be in [0, " + std::to_string(n_parts_)
+                                        + "); got " + std::to_string(rank) + ".");
+        }
+        std::vector<std::int64_t> owned;
+        for (std::size_t cell = 0; cell < cell_owner_.size(); ++cell) {
+            if (static_cast<std::int64_t>(cell_owner_[cell]) == rank) {
+                owned.push_back(static_cast<std::int64_t>(cell));
+            }
+        }
+        return owned;
+    }
+
+    /// A compact representation naming the two counts.
+    ///
+    /// The owners themselves are left out: there is one per cell, and a partition
+    /// over a real mesh would print a page of them.
+    ///
+    /// \return `"Partition(n_cells=..., n_parts=...)"`.
+    [[nodiscard]] std::string to_string() const {
+        return "Partition(n_cells=" + std::to_string(cell_owner_.size())
+               + ", n_parts=" + std::to_string(n_parts_) + ")";
+    }
+
+  private:
+    std::vector<std::int32_t> cell_owner_;  ///< Owner rank per cell, `-1` if inactive.
+    std::int64_t n_parts_;                  ///< Number of parts.
+};
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/tags.hpp
+++ b/cpp/include/pantr/grid/tags.hpp
@@ -340,9 +340,12 @@ class CellTags {
     void scatter(std::string_view name, std::span<IntT> out) const {
         const std::shared_ptr<const Tag> tag = get(name);
         if (out.size() != static_cast<std::size_t>(num_cells_)) {
+            // The shape is spelled as numpy spells it -- `(3,)`, not `3` -- because
+            // `_tags.py`'s counterpart interpolates `out.shape`, and the two
+            // messages have to read the same under either backend.
             throw std::invalid_argument("scatter: out must have length "
-                                        + std::to_string(num_cells_) + "; got "
-                                        + std::to_string(out.size()) + ".");
+                                        + std::to_string(num_cells_) + "; got ("
+                                        + std::to_string(out.size()) + ",).");
         }
         detail::require_representable<IntT>(tag->values, "CellTags");
         for (std::size_t k = 0; k < tag->ids.size(); ++k) {

--- a/cpp/include/pantr/grid/tags.hpp
+++ b/cpp/include/pantr/grid/tags.hpp
@@ -1,0 +1,732 @@
+#pragma once
+
+/// \file
+/// Sparse named integer tags over a grid's cells and over its local facets.
+///
+/// Ports `src/pantr/grid/_tags.py`, whose classes stay as the Python backend under
+/// `PANTR_BACKEND=python`. Ownership moves under `design/cross_backend_types.md`'s
+/// 2026-08-27 amendment: there is one registry, it is this one, and
+/// `pantr.grid.CellTags` wraps it.
+///
+/// ## The accumulating container, and why it is allowed to mutate
+///
+/// `CLAUDE.md` says an instance is immutable once created and that a `fit()` which
+/// mutates `self` is the anti-pattern. These two are the reasoned exception it
+/// names: a tag registry *is* an accumulating container, `set` and `remove` are its
+/// whole purpose, and the grid holds one as a member precisely so that a C++
+/// program with no interpreter can tag cells as it classifies them.
+///
+/// ## Four things the port has to get right
+///
+/// **1. A handed-out view must outlive a replacement.** `get` returns the stored
+/// arrays, and the binding hands them to numpy as zero-copy views. If those viewed
+/// a `std::vector` owned directly by the registry, a later `set` on the same name
+/// would free the storage under a live numpy array -- a use-after-free the oracle
+/// cannot have, because Python's own reference counting keeps the replaced arrays
+/// alive. So each tag is held behind a `std::shared_ptr<const Tag>`: `set`
+/// *replaces the pointer* rather than the buffer, and any view that took a copy of
+/// the pointer keeps its own storage alive. Nothing here is thread-safe; the
+/// shared pointer buys lifetime, not concurrency.
+///
+/// **2. `set` on an existing name keeps that name's position.** `__iter__` and
+/// `names` are public, so the order is a contract and both backends have to agree
+/// on it. Python's `dict` replaces in place, so the entries are held in a vector
+/// and a replacement overwrites the entry it found rather than appending. A
+/// `std::unordered_map` plus a separate order vector would work too and was not
+/// chosen: a registry holds a handful of tags, so a linear scan over a contiguous
+/// vector is both faster and impossible to get out of step with itself.
+///
+/// **3. A missing name is a `KeyError`, and that is raised in the Python wrapper.**
+/// `pantr/core/error.hpp` records the rule for the whole port: nanobind 2.14.0's
+/// default translator maps `std::out_of_range` to `IndexError` and has no path to
+/// `KeyError` at all. The methods below throw `std::out_of_range`, which is right
+/// for a C++ caller; the wrapper checks `contains` first, so no Python caller ever
+/// reaches it.
+///
+/// **4. `scatter` writes into the caller's destination integer type**, which is
+/// what the oracle's `to_dense(dtype=...)` parameter means. The *kind* check --
+/// that the destination dtype is an integer at all -- is a `TypeError` and lives in
+/// the wrapper, because nanobind cannot raise one. The *range* check is an
+/// `OverflowError` and lives here, in the template, where the destination type is
+/// known. Two places, two different questions; the docstrings on both sides say so
+/// rather than claiming validation happens in one place.
+///
+/// ## What `scatter` deliberately does not do
+///
+/// It does not fill. The oracle's `to_dense` allocates with `numpy.full(n, fill,
+/// dtype)` and then scatters, and `numpy.full` is itself the thing that decides
+/// what an out-of-range `fill` does -- it raises `OverflowError` with a message
+/// this side would have to reproduce by hand. So the wrapper keeps the allocation
+/// and the fill, which is the project's Layer 2 / `out` convention anyway, and this
+/// method owns only the part that needs the tag: writing the stored values at the
+/// stored positions.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+
+namespace pantr::grid {
+
+namespace detail {
+
+/// A facet key is the pair `(cell_id, local_facet_id)`; stored as `(M, 2)` rows.
+inline constexpr std::size_t kFacetKeyWidth = 2;
+
+/// A valid, never-dereferenced address for a zero-length array's data pointer.
+///
+/// `std::vector::data()` on an empty vector may return `nullptr`, and nanobind
+/// treats a null data pointer as "no array" rather than as an empty one. An empty
+/// tag is legal -- `_tags.py`'s own tests set one -- so the binding needs an
+/// address it can hand over for a shape of `(0,)`.
+inline constexpr std::int64_t kEmptyStorage = 0;
+
+/// Render a tag name the way Python's `repr` renders a `str`.
+///
+/// The oracle's duplicate-key messages interpolate `{name!r}`, so reproducing them
+/// means reproducing that quoting. Python prefers single quotes and switches to
+/// double quotes only for a string that contains a single quote and no double one;
+/// backslash, the delimiter and the three common control characters are escaped.
+///
+/// **The limit is deliberate and worth stating:** a name containing some *other*
+/// control or non-ASCII character prints as itself here, where Python would print a
+/// `\xNN` or `\uNNNN` escape. Tag names come from user code and are identifiers in
+/// every use in this repository, so the divergence needs a name nobody writes; the
+/// alternative is a transliteration of CPython's `unicode_repr`, which is a lot of
+/// code for an error message.
+///
+/// \param name The tag name.
+/// \return Its Python-style quoted form, delimiters included.
+[[nodiscard]] inline std::string quote_name(std::string_view name) {
+    const bool has_single = name.find('\'') != std::string_view::npos;
+    const bool has_double = name.find('"') != std::string_view::npos;
+    const char delim = (has_single && !has_double) ? '"' : '\'';
+    std::string out(1, delim);
+    for (const char c : name) {
+        if (c == '\\' || c == delim) {
+            out += '\\';
+            out += c;
+        } else if (c == '\n') {
+            out += "\\n";
+        } else if (c == '\r') {
+            out += "\\r";
+        } else if (c == '\t') {
+            out += "\\t";
+        } else {
+            out += c;
+        }
+    }
+    out += delim;
+    return out;
+}
+
+/// numpy's name for the destination integer type, as `numpy.dtype.__repr__` shows it.
+///
+/// The oracle's overflow message interpolates `{out_dtype!r}`, which is
+/// `dtype('int8')` and not `int8`, so the quoting is part of the message rather
+/// than decoration.
+///
+/// \tparam IntT The destination integer type.
+/// \return The dtype name, without the surrounding `dtype('...')`.
+template <class IntT>
+[[nodiscard]] consteval std::string_view numpy_dtype_name() {
+    if constexpr (std::is_same_v<IntT, std::int8_t>) {
+        return "int8";
+    } else if constexpr (std::is_same_v<IntT, std::int16_t>) {
+        return "int16";
+    } else if constexpr (std::is_same_v<IntT, std::int32_t>) {
+        return "int32";
+    } else if constexpr (std::is_same_v<IntT, std::int64_t>) {
+        return "int64";
+    } else if constexpr (std::is_same_v<IntT, std::uint8_t>) {
+        return "uint8";
+    } else if constexpr (std::is_same_v<IntT, std::uint16_t>) {
+        return "uint16";
+    } else if constexpr (std::is_same_v<IntT, std::uint32_t>) {
+        return "uint32";
+    } else {
+        static_assert(std::is_same_v<IntT, std::uint64_t>,
+                      "scatter's destination must be one of numpy's eight integer types");
+        return "uint64";
+    }
+}
+
+/// Reject stored values the destination integer type cannot hold.
+///
+/// **The `sizeof(IntT) < 8` guard reproduces the oracle exactly, including where the
+/// oracle is wrong.** `_tags.py` runs its check only when
+/// `out_dtype.itemsize < 8`, and its docstring states that limit as the contract:
+/// "only raised when `dtype` is narrower than `int64`". That is sound for `int64`,
+/// whose range contains every stored value, and unsound for `uint64`, which is
+/// eight bytes wide and cannot hold a negative one -- so a negative tag value
+/// scattered into a `uint64` destination wraps silently, in the oracle and
+/// therefore here. Reported as a contract gap rather than fixed: closing it changes
+/// documented behaviour in both backends at once, which is not a port's decision.
+///
+/// \tparam IntT The destination integer type.
+/// \param values The stored values.
+/// \param who The registry name, for the message.
+/// \throws std::overflow_error If some value is outside `IntT`'s range.
+template <class IntT>
+void require_representable(std::span<const std::int64_t> values, const char* who) {
+    (void)who;
+    if constexpr (sizeof(IntT) < 8) {
+        if (values.empty()) {
+            return;
+        }
+        const auto [min_it, max_it] = std::minmax_element(values.begin(), values.end());
+        const std::int64_t vmin = *min_it;
+        const std::int64_t vmax = *max_it;
+        constexpr auto lo = static_cast<std::int64_t>(std::numeric_limits<IntT>::min());
+        constexpr auto hi = static_cast<std::int64_t>(std::numeric_limits<IntT>::max());
+        if (vmin < lo || vmax > hi) {
+            throw std::overflow_error(
+                "dtype dtype('" + std::string(numpy_dtype_name<IntT>())
+                + "') cannot represent all tag values without truncation; value range ["
+                + std::to_string(vmin) + ", " + std::to_string(vmax) + "] exceeds dtype range ["
+                + std::to_string(lo) + ", " + std::to_string(hi) + "].");
+        }
+    }
+}
+
+}  // namespace detail
+
+/// Sparse named integer tags over a grid's cells.
+///
+/// Each tag named `name` is a pair of parallel `int64` arrays `(ids, values)`
+/// sorted by `ids`; a cell not listed in `ids` is untagged under `name`. Distinct
+/// tag names are independent, and the names keep their insertion order under
+/// iteration -- including across a replacement, which is a contract rather than an
+/// accident. See the file comment for the four decisions this reproduces.
+class CellTags {
+  public:
+    /// One tag's stored arrays.
+    ///
+    /// Held behind a `std::shared_ptr<const Tag>` so that a view handed to a caller
+    /// survives a later `set` on the same name; see the file comment.
+    ///
+    /// Attributes are public because this is a value aggregate with no invariant of
+    /// its own: `CellTags::set` establishes the sorting and the uniqueness before
+    /// one is ever built, and nothing can reach a `Tag` except through a
+    /// `shared_ptr<const Tag>`.
+    struct Tag {
+        std::vector<std::int64_t> ids;     ///< Cell ids, ascending and unique.
+        std::vector<std::int64_t> values;  ///< The value at each id, same length.
+    };
+
+    /// Create an empty cell-tag registry.
+    ///
+    /// \param num_cells Number of cells in the owning grid, `>= 0`.
+    /// \throws std::invalid_argument If `num_cells` is negative.
+    explicit CellTags(std::int64_t num_cells) : num_cells_(num_cells) {
+        if (num_cells < 0) {
+            throw std::invalid_argument("num_cells must be >= 0; got "
+                                        + std::to_string(num_cells) + ".");
+        }
+    }
+
+    /// The number of cells in the owning grid.
+    ///
+    /// \return The cell count; valid cell ids are `[0, num_cells)`.
+    [[nodiscard]] std::int64_t num_cells() const noexcept { return num_cells_; }
+
+    /// The number of registered tags.
+    ///
+    /// \return Count of distinct tag names.
+    [[nodiscard]] std::size_t size() const noexcept { return tags_.size(); }
+
+    /// The registered tag names, in insertion order.
+    ///
+    /// \return The names; a replaced tag keeps the position it first took.
+    [[nodiscard]] std::vector<std::string> names() const {
+        std::vector<std::string> out;
+        out.reserve(tags_.size());
+        for (const Entry& entry : tags_) {
+            out.push_back(entry.name);
+        }
+        return out;
+    }
+
+    /// Whether a tag named `name` exists.
+    ///
+    /// \param name Candidate tag name.
+    /// \return `true` when `name` is registered.
+    [[nodiscard]] bool contains(std::string_view name) const noexcept {
+        return find(name) != tags_.end();
+    }
+
+    /// Create or replace the tag `name` with the association `ids -> values`.
+    ///
+    /// A replacement keeps the name's position among `names()`; see the file
+    /// comment for why that is a contract.
+    ///
+    /// \param name Tag name.
+    /// \param ids Cell ids, each in `[0, num_cells)` and unique. Order is free;
+    ///        the stored pair is sorted by id.
+    /// \param values The value for each id, same length as `ids`.
+    /// \throws std::invalid_argument If an id is out of range, if two ids are
+    ///         equal, or if the two lengths differ.
+    void set(std::string_view name, std::span<const std::int64_t> ids,
+             std::span<const std::int64_t> values) {
+        require_ids_in_range(ids);
+        const std::vector<std::size_t> order = sorted_order(ids);
+        require_unique_ids(name, ids, order);
+        if (values.size() != ids.size()) {
+            throw std::invalid_argument("values must be a scalar or have length "
+                                        + std::to_string(ids.size()) + "; got length "
+                                        + std::to_string(values.size()) + ".");
+        }
+        auto tag = std::make_shared<Tag>();
+        tag->ids.reserve(ids.size());
+        tag->values.reserve(values.size());
+        for (const std::size_t k : order) {
+            tag->ids.push_back(ids[k]);
+            tag->values.push_back(values[k]);
+        }
+        store(name, std::move(tag));
+    }
+
+    /// The stored arrays for tag `name`.
+    ///
+    /// \param name Tag name.
+    /// \return A shared handle to the pair, which keeps its storage alive
+    ///         independently of any later `set` or `remove`.
+    /// \throws std::out_of_range If no tag named `name` exists. Reaches Python as
+    ///         `IndexError`, which is why the wrapper checks `contains` first and
+    ///         raises `KeyError` itself.
+    [[nodiscard]] std::shared_ptr<const Tag> get(std::string_view name) const {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            throw std::out_of_range(std::string(name));
+        }
+        return it->tag;
+    }
+
+    /// Delete the tag `name`.
+    ///
+    /// \param name Tag name.
+    /// \throws std::out_of_range If no tag named `name` exists.
+    void remove(std::string_view name) {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            throw std::out_of_range(std::string(name));
+        }
+        tags_.erase(it);
+    }
+
+    /// Write tag `name`'s values into `out` at its ids.
+    ///
+    /// Does **not** fill: every entry not named by the tag is left as the caller
+    /// left it. See the file comment for why the fill stays with the caller.
+    ///
+    /// \tparam IntT Destination integer type.
+    /// \param name Tag name.
+    /// \param out Destination, length `num_cells`.
+    /// \throws std::out_of_range If no tag named `name` exists.
+    /// \throws std::invalid_argument If `out` is not `num_cells` long.
+    /// \throws std::overflow_error If a stored value is outside `IntT`'s range,
+    ///         subject to the width limit `detail::require_representable` documents.
+    template <class IntT>
+    void scatter(std::string_view name, std::span<IntT> out) const {
+        const std::shared_ptr<const Tag> tag = get(name);
+        if (out.size() != static_cast<std::size_t>(num_cells_)) {
+            throw std::invalid_argument("scatter: out must have length "
+                                        + std::to_string(num_cells_) + "; got "
+                                        + std::to_string(out.size()) + ".");
+        }
+        detail::require_representable<IntT>(tag->values, "CellTags");
+        for (std::size_t k = 0; k < tag->ids.size(); ++k) {
+            out[static_cast<std::size_t>(tag->ids[k])] = static_cast<IntT>(tag->values[k]);
+        }
+    }
+
+    /// A compact representation naming the cell count and the registered tags.
+    ///
+    /// \return `"CellTags(num_cells=..., tags=[...])"`.
+    [[nodiscard]] std::string to_string() const {
+        std::string text = "CellTags(num_cells=" + std::to_string(num_cells_) + ", tags=[";
+        for (std::size_t k = 0; k < tags_.size(); ++k) {
+            if (k != 0) {
+                text += ", ";
+            }
+            text += detail::quote_name(tags_[k].name);
+        }
+        return text + "])";
+    }
+
+  private:
+    /// One registered tag: its name and its shared storage.
+    struct Entry {
+        std::string name;                ///< The tag name.
+        std::shared_ptr<const Tag> tag;  ///< Its arrays, shared with any live view.
+    };
+
+    /// Locate a tag by name.
+    ///
+    /// \param name The name to look for.
+    /// \return An iterator to the entry, or `tags_.end()`.
+    [[nodiscard]] std::vector<Entry>::const_iterator find(std::string_view name) const noexcept {
+        return std::find_if(tags_.begin(), tags_.end(),
+                            [name](const Entry& e) { return e.name == name; });
+    }
+
+    /// Insert a tag, or replace one in place without moving its position.
+    ///
+    /// \param name The tag name.
+    /// \param tag The storage to adopt.
+    void store(std::string_view name, std::shared_ptr<const Tag> tag) {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            tags_.push_back(Entry{std::string(name), std::move(tag)});
+            return;
+        }
+        tags_[static_cast<std::size_t>(it - tags_.begin())].tag = std::move(tag);
+    }
+
+    /// Reject a cell id outside `[0, num_cells)`.
+    ///
+    /// \param ids The ids to check.
+    /// \throws std::invalid_argument If any id is out of range.
+    void require_ids_in_range(std::span<const std::int64_t> ids) const {
+        if (ids.empty()) {
+            return;
+        }
+        const auto [min_it, max_it] = std::minmax_element(ids.begin(), ids.end());
+        if (*min_it < 0 || *max_it >= num_cells_) {
+            throw std::invalid_argument("cell ids must be in [0, " + std::to_string(num_cells_)
+                                        + "); got range [" + std::to_string(*min_it) + ", "
+                                        + std::to_string(*max_it) + "].");
+        }
+    }
+
+    /// The permutation that sorts `ids` ascending, ties in increasing index order.
+    ///
+    /// \param ids The ids to order.
+    /// \return Indices into `ids`.
+    [[nodiscard]] static std::vector<std::size_t> sorted_order(
+        std::span<const std::int64_t> ids) {
+        std::vector<std::size_t> order(ids.size());
+        std::iota(order.begin(), order.end(), std::size_t{0});
+        std::stable_sort(order.begin(), order.end(),
+                         [ids](std::size_t a, std::size_t b) { return ids[a] < ids[b]; });
+        return order;
+    }
+
+    /// Reject a repeated cell id.
+    ///
+    /// Checked on the sorted permutation, so equal ids are adjacent.
+    ///
+    /// \param name The tag name, for the message.
+    /// \param ids The ids.
+    /// \param order The permutation sorting them.
+    /// \throws std::invalid_argument If two ids are equal.
+    static void require_unique_ids(std::string_view name, std::span<const std::int64_t> ids,
+                                   const std::vector<std::size_t>& order) {
+        for (std::size_t k = 1; k < order.size(); ++k) {
+            if (ids[order[k]] == ids[order[k - 1]]) {
+                throw std::invalid_argument("cell ids for tag " + detail::quote_name(name)
+                                            + " must be unique; got duplicates.");
+            }
+        }
+    }
+
+    std::int64_t num_cells_;    ///< The owning grid's cell count.
+    std::vector<Entry> tags_;   ///< The registered tags, in insertion order.
+};
+
+/// Sparse named integer tags over a grid's local facets.
+///
+/// Each facet is addressed by a `(cell_id, local_facet_id)` key with
+/// `local_facet_id` in `[0, facets_per_cell)`. Each tag is a pair `(keys, values)`
+/// where `keys` is an `(M, 2)` block of `(cell_id, local_facet_id)` rows sorted
+/// lexicographically, and `values` is the length-`M` companion. The same four
+/// decisions as `CellTags` apply; see the file comment.
+class FacetTags {
+  public:
+    /// One tag's stored arrays.
+    ///
+    /// As `CellTags::Tag`, with the keys held flat in row-major `(M, 2)` order.
+    struct Tag {
+        std::vector<std::int64_t> keys;    ///< `(M, 2)` rows, flattened, sorted.
+        std::vector<std::int64_t> values;  ///< The value at each key, length `M`.
+
+        /// The number of tagged facets.
+        ///
+        /// \return `M`, the row count of `keys`.
+        [[nodiscard]] std::size_t rows() const noexcept { return values.size(); }
+    };
+
+    /// Create an empty facet-tag registry.
+    ///
+    /// \param num_cells Number of cells in the owning grid, `>= 0`.
+    /// \param facets_per_cell Number of local facets per cell, `>= 1`.
+    /// \throws std::invalid_argument If `num_cells` is negative or
+    ///         `facets_per_cell` is below one.
+    FacetTags(std::int64_t num_cells, std::int64_t facets_per_cell)
+        : num_cells_(num_cells), facets_per_cell_(facets_per_cell) {
+        if (num_cells < 0) {
+            throw std::invalid_argument("num_cells must be >= 0; got "
+                                        + std::to_string(num_cells) + ".");
+        }
+        if (facets_per_cell < 1) {
+            throw std::invalid_argument("facets_per_cell must be >= 1; got "
+                                        + std::to_string(facets_per_cell) + ".");
+        }
+    }
+
+    /// The number of cells in the owning grid.
+    ///
+    /// \return The cell count.
+    [[nodiscard]] std::int64_t num_cells() const noexcept { return num_cells_; }
+
+    /// The number of local facets per cell.
+    ///
+    /// \return `2 * ndim` for an axis-aligned box grid.
+    [[nodiscard]] std::int64_t facets_per_cell() const noexcept { return facets_per_cell_; }
+
+    /// The number of registered tags.
+    ///
+    /// \return Count of distinct tag names.
+    [[nodiscard]] std::size_t size() const noexcept { return tags_.size(); }
+
+    /// The registered tag names, in insertion order.
+    ///
+    /// \return The names; a replaced tag keeps the position it first took.
+    [[nodiscard]] std::vector<std::string> names() const {
+        std::vector<std::string> out;
+        out.reserve(tags_.size());
+        for (const Entry& entry : tags_) {
+            out.push_back(entry.name);
+        }
+        return out;
+    }
+
+    /// Whether a tag named `name` exists.
+    ///
+    /// \param name Candidate tag name.
+    /// \return `true` when `name` is registered.
+    [[nodiscard]] bool contains(std::string_view name) const noexcept {
+        return find(name) != tags_.end();
+    }
+
+    /// Create or replace the tag `name` with the association `keys -> values`.
+    ///
+    /// \param name Tag name.
+    /// \param keys `(M, 2)` rows of `(cell_id, local_facet_id)`, each row unique,
+    ///        with `cell_id` in `[0, num_cells)` and `local_facet_id` in
+    ///        `[0, facets_per_cell)`.
+    /// \param values The value for each row, length `M`.
+    /// \throws std::invalid_argument If `keys` does not have two columns, if a key
+    ///         component is out of range, if two rows are equal, or if the lengths
+    ///         disagree.
+    void set(std::string_view name, span2d<const std::int64_t> keys,
+             std::span<const std::int64_t> values) {
+        if (keys.extent(1) != detail::kFacetKeyWidth) {
+            throw std::invalid_argument("keys must have shape (M, 2); got shape ("
+                                        + std::to_string(keys.extent(0)) + ", "
+                                        + std::to_string(keys.extent(1)) + ").");
+        }
+        const std::size_t rows = keys.extent(0);
+        require_keys_in_range(keys);
+        const std::vector<std::size_t> order = sorted_order(keys);
+        require_unique_keys(name, keys, order);
+        if (values.size() != rows) {
+            throw std::invalid_argument("values must be a scalar or have length "
+                                        + std::to_string(rows) + "; got length "
+                                        + std::to_string(values.size()) + ".");
+        }
+        auto tag = std::make_shared<Tag>();
+        tag->keys.reserve(rows * detail::kFacetKeyWidth);
+        tag->values.reserve(rows);
+        for (const std::size_t k : order) {
+            tag->keys.push_back(at(keys, k, 0));
+            tag->keys.push_back(at(keys, k, 1));
+            tag->values.push_back(values[k]);
+        }
+        store(name, std::move(tag));
+    }
+
+    /// The stored arrays for tag `name`.
+    ///
+    /// \param name Tag name.
+    /// \return A shared handle to the pair, which keeps its storage alive
+    ///         independently of any later `set` or `remove`.
+    /// \throws std::out_of_range If no tag named `name` exists.
+    [[nodiscard]] std::shared_ptr<const Tag> get(std::string_view name) const {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            throw std::out_of_range(std::string(name));
+        }
+        return it->tag;
+    }
+
+    /// Delete the tag `name`.
+    ///
+    /// \param name Tag name.
+    /// \throws std::out_of_range If no tag named `name` exists.
+    void remove(std::string_view name) {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            throw std::out_of_range(std::string(name));
+        }
+        tags_.erase(it);
+    }
+
+    /// Write tag `name`'s values into `out` at its keys.
+    ///
+    /// Does **not** fill; see `CellTags::scatter` and the file comment.
+    ///
+    /// \tparam IntT Destination integer type.
+    /// \param name Tag name.
+    /// \param out Destination, shape `(num_cells, facets_per_cell)`.
+    /// \throws std::out_of_range If no tag named `name` exists.
+    /// \throws std::invalid_argument If `out` does not have the grid's shape.
+    /// \throws std::overflow_error If a stored value is outside `IntT`'s range,
+    ///         subject to the width limit `detail::require_representable` documents.
+    template <class IntT>
+    void scatter(std::string_view name, span2d<IntT> out) const {
+        const std::shared_ptr<const Tag> tag = get(name);
+        if (out.extent(0) != static_cast<std::size_t>(num_cells_)
+            || out.extent(1) != static_cast<std::size_t>(facets_per_cell_)) {
+            throw std::invalid_argument("scatter: out must be (" + std::to_string(num_cells_)
+                                        + ", " + std::to_string(facets_per_cell_) + "); got ("
+                                        + std::to_string(out.extent(0)) + ", "
+                                        + std::to_string(out.extent(1)) + ").");
+        }
+        detail::require_representable<IntT>(tag->values, "FacetTags");
+        for (std::size_t k = 0; k < tag->rows(); ++k) {
+            const auto cid = static_cast<std::size_t>(tag->keys[k * detail::kFacetKeyWidth]);
+            const auto lfid = static_cast<std::size_t>(tag->keys[k * detail::kFacetKeyWidth + 1]);
+            at(out, cid, lfid) = static_cast<IntT>(tag->values[k]);
+        }
+    }
+
+    /// A compact representation, matching the oracle's `__repr__`.
+    ///
+    /// \return `"FacetTags(num_cells=..., facets_per_cell=..., tags=[...])"`.
+    [[nodiscard]] std::string to_string() const {
+        std::string text = "FacetTags(num_cells=" + std::to_string(num_cells_)
+                           + ", facets_per_cell=" + std::to_string(facets_per_cell_) + ", tags=[";
+        for (std::size_t k = 0; k < tags_.size(); ++k) {
+            if (k != 0) {
+                text += ", ";
+            }
+            text += detail::quote_name(tags_[k].name);
+        }
+        return text + "])";
+    }
+
+  private:
+    /// One registered tag: its name and its shared storage.
+    struct Entry {
+        std::string name;                ///< The tag name.
+        std::shared_ptr<const Tag> tag;  ///< Its arrays, shared with any live view.
+    };
+
+    /// Locate a tag by name.
+    ///
+    /// \param name The name to look for.
+    /// \return An iterator to the entry, or `tags_.end()`.
+    [[nodiscard]] std::vector<Entry>::const_iterator find(std::string_view name) const noexcept {
+        return std::find_if(tags_.begin(), tags_.end(),
+                            [name](const Entry& e) { return e.name == name; });
+    }
+
+    /// Insert a tag, or replace one in place without moving its position.
+    ///
+    /// \param name The tag name.
+    /// \param tag The storage to adopt.
+    void store(std::string_view name, std::shared_ptr<const Tag> tag) {
+        const auto it = find(name);
+        if (it == tags_.end()) {
+            tags_.push_back(Entry{std::string(name), std::move(tag)});
+            return;
+        }
+        tags_[static_cast<std::size_t>(it - tags_.begin())].tag = std::move(tag);
+    }
+
+    /// Reject a key component outside its own range.
+    ///
+    /// The two components are checked in the oracle's order -- every cell id, then
+    /// every local facet id -- because a key violating both reports the first.
+    ///
+    /// \param keys The `(M, 2)` keys.
+    /// \throws std::invalid_argument If a component is out of range.
+    void require_keys_in_range(span2d<const std::int64_t> keys) const {
+        const std::size_t rows = keys.extent(0);
+        if (rows == 0) {
+            return;
+        }
+        std::int64_t cid_min = at(keys, 0, 0);
+        std::int64_t cid_max = cid_min;
+        std::int64_t lfid_min = at(keys, 0, 1);
+        std::int64_t lfid_max = lfid_min;
+        for (std::size_t k = 1; k < rows; ++k) {
+            cid_min = std::min(cid_min, at(keys, k, 0));
+            cid_max = std::max(cid_max, at(keys, k, 0));
+            lfid_min = std::min(lfid_min, at(keys, k, 1));
+            lfid_max = std::max(lfid_max, at(keys, k, 1));
+        }
+        if (cid_min < 0 || cid_max >= num_cells_) {
+            throw std::invalid_argument("facet cell ids must be in [0, "
+                                        + std::to_string(num_cells_) + "); got range ["
+                                        + std::to_string(cid_min) + ", "
+                                        + std::to_string(cid_max) + "].");
+        }
+        if (lfid_min < 0 || lfid_max >= facets_per_cell_) {
+            throw std::invalid_argument("local facet ids must be in [0, "
+                                        + std::to_string(facets_per_cell_) + "); got range ["
+                                        + std::to_string(lfid_min) + ", "
+                                        + std::to_string(lfid_max) + "].");
+        }
+    }
+
+    /// The permutation sorting the keys lexicographically by `(cell_id, facet_id)`.
+    ///
+    /// \param keys The `(M, 2)` keys.
+    /// \return Row indices into `keys`.
+    [[nodiscard]] static std::vector<std::size_t> sorted_order(span2d<const std::int64_t> keys) {
+        std::vector<std::size_t> order(keys.extent(0));
+        std::iota(order.begin(), order.end(), std::size_t{0});
+        std::stable_sort(order.begin(), order.end(), [keys](std::size_t a, std::size_t b) {
+            if (at(keys, a, 0) != at(keys, b, 0)) {
+                return at(keys, a, 0) < at(keys, b, 0);
+            }
+            return at(keys, a, 1) < at(keys, b, 1);
+        });
+        return order;
+    }
+
+    /// Reject a repeated key.
+    ///
+    /// \param name The tag name, for the message.
+    /// \param keys The `(M, 2)` keys.
+    /// \param order The permutation sorting them, so equal rows are adjacent.
+    /// \throws std::invalid_argument If two rows are equal.
+    static void require_unique_keys(std::string_view name, span2d<const std::int64_t> keys,
+                                    const std::vector<std::size_t>& order) {
+        for (std::size_t k = 1; k < order.size(); ++k) {
+            if (at(keys, order[k], 0) == at(keys, order[k - 1], 0)
+                && at(keys, order[k], 1) == at(keys, order[k - 1], 1)) {
+                throw std::invalid_argument("facet keys for tag " + detail::quote_name(name)
+                                            + " must be unique; got duplicates.");
+            }
+        }
+    }
+
+    std::int64_t num_cells_;       ///< The owning grid's cell count.
+    std::int64_t facets_per_cell_; ///< Local facets per cell.
+    std::vector<Entry> tags_;      ///< The registered tags, in insertion order.
+};
+
+}  // namespace pantr::grid

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -19,7 +19,8 @@ set(PANTR_TEST_SOURCES
     test_affine.cpp
     test_bezier_type.cpp
     test_quad_rule.cpp
-    test_grid_tags.cpp)
+    test_grid_tags.cpp
+    test_grid_partition.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -38,7 +39,6 @@ set(PANTR_TEST_SOURCES
 # Delete each entry from this list as its ticket fills the slot; when the list is
 # empty, delete the list.
 set(PANTR_PLACEHOLDER_TEST_SOURCES
-    test_grid_partition.cpp
     test_grid_bvh_type.cpp
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ set(PANTR_TEST_SOURCES
     test_bezier_type.cpp
     test_quad_rule.cpp
     test_grid_tags.cpp
-    test_grid_partition.cpp)
+    test_grid_partition.cpp
+    test_grid_bvh_type.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -39,7 +40,6 @@ set(PANTR_TEST_SOURCES
 # Delete each entry from this list as its ticket fills the slot; when the list is
 # empty, delete the list.
 set(PANTR_PLACEHOLDER_TEST_SOURCES
-    test_grid_bvh_type.cpp
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp
     test_bezier_evaluate.cpp

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -18,7 +18,8 @@ set(PANTR_TEST_SOURCES
     test_aabb.cpp
     test_affine.cpp
     test_bezier_type.cpp
-    test_quad_rule.cpp)
+    test_quad_rule.cpp
+    test_grid_tags.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -38,7 +39,6 @@ set(PANTR_TEST_SOURCES
 # empty, delete the list.
 set(PANTR_PLACEHOLDER_TEST_SOURCES
     test_grid_partition.cpp
-    test_grid_tags.cpp
     test_grid_bvh_type.cpp
     test_grid_defaults.cpp
     test_grid_tensor_product.cpp

--- a/cpp/tests/test_grid_bvh_type.cpp
+++ b/cpp/tests/test_grid_bvh_type.cpp
@@ -1,17 +1,339 @@
 /// \file
-/// Reserved slot for the pantr::grid::BVH type tests -- no assertions yet.
+/// Properties of the bounding-volume hierarchy as a type.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// `test_grid_bvh.cpp` covers the kernels. This file covers what the type adds: the
+/// validation, the two boundaries of the traversal-stack limit, and the empty tree.
+///
+/// ## Why these cases and not others
+///
+///  - **The depth limit, from both sides.** A depth-`d` descent occupies at most
+///    `d` stack slots -- the root takes one, then each of the `d - 1` internal
+///    expansions along the deepest path pops one and pushes two, a net `+1` -- so
+///    `d == kBvhStackDepth` fits exactly and `d + 1` does not. Both are asserted,
+///    because a guard that refuses everything passes the refusal half on its own.
+///  - **`CapacityError` rather than `std::invalid_argument`.** The tree is well
+///    formed and this build cannot walk it, which is what `pantr/core/error.hpp`
+///    reserves that type for. Asserted by catching the specific type, since a
+///    `catch (const std::invalid_argument&)` and a `catch (const std::exception&)`
+///    would both be satisfied by the wrong one.
+///  - **A node array that is not a tree.** A cyclic child pointer must be refused
+///    rather than walked forever: a validator that hangs is worse than the
+///    out-of-bounds write it replaces.
+///  - **The structural checks.** The kernels decide leafness from `node_cell` alone
+///    and then push both children unconditionally, so a `-1` child on a node that
+///    does not look like a leaf indexes out of bounds. That arrangement constructed
+///    cleanly and returned the wrong cells before the check existed.
+///  - **The empty tree.** Zero cells is legal, `n_nodes` is 0, and the query must
+///    short-circuit rather than read node 0.
 
-#include <cstdio>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/core/error.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/bvh_tree.hpp"
+
+namespace {
+
+using pantr::grid::BVH;
+using pantr::grid::kBvhStackDepth;
+
+/// The five node arrays of a hand-built tree, kept together so a test can poke one.
+struct Arrays {
+    std::vector<double> node_lo;         ///< Per-node lo corners, row-major.
+    std::vector<double> node_hi;         ///< Per-node hi corners, row-major.
+    std::vector<std::int64_t> node_left;  ///< Left-child indices.
+    std::vector<std::int64_t> node_right; ///< Right-child indices.
+    std::vector<std::int64_t> node_cell;  ///< Leaf cell ids.
+    std::size_t ndim = 1;                 ///< Spatial dimension.
+};
+
+/// Build a tree from an `Arrays`, for brevity below.
+///
+/// \param a The node arrays.
+/// \param n_cells The indexed cell count.
+/// \return The hierarchy.
+BVH<double> build(const Arrays& a, std::int64_t n_cells) {
+    const std::size_t rows = a.node_left.size();
+    return BVH<double>(pantr::span2d<const double>(a.node_lo.data(), rows, a.ndim),
+                       pantr::span2d<const double>(a.node_hi.data(), rows, a.ndim), a.node_left,
+                       a.node_right, a.node_cell, n_cells);
+}
+
+/// Node arrays for a maximally unbalanced (linear-chain) 1-D tree.
+///
+/// Leaf `k` covers the unit cell `[k, k+1]`. Node `i` for `i < n_leaves - 1` is
+/// internal, with left child leaf `i` and right child the next internal node. This
+/// is the deepest tree over `n_leaves` leaves: the longest root-to-leaf path has
+/// exactly `n_leaves` nodes. Mirrors `_chain_bvh_arrays` in `tests/test_grid_bvh.py`.
+///
+/// \param n_leaves Number of leaves, at least 2.
+/// \return The node arrays.
+Arrays chain(std::int64_t n_leaves) {
+    const auto n_internal = static_cast<std::size_t>(n_leaves - 1);
+    const auto n_nodes = static_cast<std::size_t>(2 * n_leaves - 1);
+    Arrays a;
+    a.node_lo.assign(n_nodes, 0.0);
+    a.node_hi.assign(n_nodes, 0.0);
+    a.node_left.assign(n_nodes, -1);
+    a.node_right.assign(n_nodes, -1);
+    a.node_cell.assign(n_nodes, -1);
+    for (std::size_t i = 0; i < n_internal; ++i) {
+        a.node_lo[i] = static_cast<double>(i);
+        a.node_hi[i] = static_cast<double>(n_leaves);
+        a.node_left[i] = static_cast<std::int64_t>(n_internal + i);
+        a.node_right[i] = i < n_internal - 1 ? static_cast<std::int64_t>(i + 1)
+                                             : static_cast<std::int64_t>(n_internal + i + 1);
+    }
+    for (std::size_t k = 0; k < static_cast<std::size_t>(n_leaves); ++k) {
+        const std::size_t leaf = n_internal + k;
+        a.node_lo[leaf] = static_cast<double>(k);
+        a.node_hi[leaf] = static_cast<double>(k + 1);
+        a.node_cell[leaf] = static_cast<std::int64_t>(k);
+    }
+    return a;
+}
+
+/// Per-cell bounds for `n` unit cells laid end to end on one axis.
+///
+/// \param n Number of cells.
+/// \return `(lo, hi)` flattened, one column.
+std::pair<std::vector<double>, std::vector<double>> unit_cells(std::size_t n) {
+    std::vector<double> lo(n);
+    std::vector<double> hi(n);
+    for (std::size_t k = 0; k < n; ++k) {
+        lo[k] = static_cast<double>(k);
+        hi[k] = static_cast<double>(k) + 1.0;
+    }
+    return {lo, hi};
+}
+
+/// Whether calling `fn` throws `std::invalid_argument`.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class Fn>
+bool rejects(Fn&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+/// Whether calling `fn` throws `pantr::CapacityError` specifically.
+///
+/// The specificity is the assertion: `CapacityError` derives from
+/// `std::runtime_error`, so catching the base would pass for either.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw a `CapacityError`.
+template <class Fn>
+bool exceeds_capacity(Fn&& fn) {
+    try {
+        fn();
+    } catch (const pantr::CapacityError&) {
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+    return false;
+}
+
+/// `from_cell_bounds` produces the documented shape and answers a query.
+void test_from_cell_bounds_shape() {
+    const auto [lo, hi] = unit_cells(4);
+    const BVH<double> tree = BVH<double>::from_cell_bounds(
+        pantr::span2d<const double>(lo.data(), 4, 1),
+        pantr::span2d<const double>(hi.data(), 4, 1));
+    PANTR_CHECK(tree.n_cells() == 4);
+    PANTR_CHECK(tree.n_nodes() == 7);
+    PANTR_CHECK(tree.ndim() == 1);
+
+    const std::vector<double> qlo{1.5};
+    const std::vector<double> qhi{2.5};
+    const auto got = tree.query_aabb(qlo, qhi);
+    PANTR_CHECK(got.size() == 2);
+}
+
+/// `from_cell_bounds` refuses a non-finite corner, an inverted cell, a bad shape.
+void test_from_cell_bounds_validates() {
+    const std::vector<double> lo{0.0};
+    const std::vector<double> inverted{-1.0};
+    const std::vector<double> nan_hi{std::numeric_limits<double>::quiet_NaN()};
+    const std::vector<double> inf_hi{std::numeric_limits<double>::infinity()};
+    const auto one = [&](const std::vector<double>& hi) {
+        return BVH<double>::from_cell_bounds(pantr::span2d<const double>(lo.data(), 1, 1),
+                                             pantr::span2d<const double>(hi.data(), 1, 1));
+    };
+    PANTR_CHECK(rejects([&] { return one(nan_hi); }));
+    PANTR_CHECK(rejects([&] { return one(inf_hi); }));
+    PANTR_CHECK(rejects([&] { return one(inverted); }));
+    PANTR_CHECK(rejects([&] {
+        return BVH<double>::from_cell_bounds(pantr::span2d<const double>(lo.data(), 1, 1),
+                                             pantr::span2d<const double>(lo.data(), 1, 0));
+    }));
+}
+
+/// A zero-cell tree is legal, has no nodes, and its query short-circuits.
+void test_the_empty_tree() {
+    const std::vector<double> none{};
+    const BVH<double> tree = BVH<double>::from_cell_bounds(
+        pantr::span2d<const double>(none.data(), 0, 3),
+        pantr::span2d<const double>(none.data(), 0, 3));
+    PANTR_CHECK(tree.n_cells() == 0);
+    PANTR_CHECK(tree.n_nodes() == 0);
+    PANTR_CHECK(tree.ndim() == 3);
+
+    const std::vector<double> qlo{0.0, 0.0, 0.0};
+    const std::vector<double> qhi{1.0, 1.0, 1.0};
+    PANTR_CHECK(tree.query_aabb(qlo, qhi).empty());
+}
+
+/// The node-count relation is enforced, and so is the dimension.
+void test_node_count_and_dimension() {
+    Arrays a = chain(3);
+    PANTR_CHECK(rejects([&] { return build(a, 2); }));
+    PANTR_CHECK(build(a, 3).n_nodes() == 5);
+
+    Arrays zero_dim = chain(2);
+    zero_dim.ndim = 0;
+    zero_dim.node_lo.clear();
+    zero_dim.node_hi.clear();
+    PANTR_CHECK(rejects([&] { return build(zero_dim, 2); }));
+}
+
+/// The structural checks reject each of the three ways the encodings can disagree.
+void test_structure_is_validated() {
+    Arrays missing_child = chain(3);
+    const std::size_t internal = 0;
+    missing_child.node_left[internal] = -1;
+    PANTR_CHECK(rejects([&] { return build(missing_child, 3); }));
+
+    Arrays leaf_marked_internal = chain(3);
+    leaf_marked_internal.node_cell[2] = -1;
+    PANTR_CHECK(rejects([&] { return build(leaf_marked_internal, 3); }));
+
+    Arrays bad_child = chain(3);
+    bad_child.node_right[internal] = -5;
+    PANTR_CHECK(rejects([&] { return build(bad_child, 3); }));
+
+    Arrays bad_cell = chain(3);
+    bad_cell.node_cell[2] = 42;
+    PANTR_CHECK(rejects([&] { return build(bad_cell, 3); }));
+}
+
+/// The depth limit is exact: `kBvhStackDepth` fits and one more does not.
+///
+/// The refusal is `CapacityError` rather than `std::invalid_argument`, because the
+/// arrays describe a perfectly well formed tree that this build cannot walk.
+void test_the_depth_limit_is_exact_and_reports_capacity() {
+    const Arrays at_limit = chain(kBvhStackDepth);
+    const BVH<double> tree = build(at_limit, kBvhStackDepth);
+    const std::vector<double> qlo{50.5};
+    const std::vector<double> qhi{52.5};
+    PANTR_CHECK(tree.query_aabb(qlo, qhi).size() == 3);
+
+    // `exceeds_capacity` returns false for any other exception, so this asserts the
+    // specific type and not merely that something was thrown.
+    const Arrays past_limit = chain(kBvhStackDepth + 1);
+    PANTR_CHECK(exceeds_capacity([&] { return build(past_limit, kBvhStackDepth + 1); }));
+}
+
+/// A cyclic child pointer terminates the depth walk rather than hanging it.
+void test_a_cyclic_node_graph_is_refused_without_hanging() {
+    Arrays cyclic = chain(4);
+    cyclic.node_right[0] = 0;  // the root points back at itself
+    PANTR_CHECK(exceeds_capacity([&] { return build(cyclic, 4); }));
+}
+
+/// The five arrays are readable, and the preorder layout is exactly the declared one.
+///
+/// **Four cells rather than three, and the count is the assertion.** At three cells
+/// the two children of the root claim indices 1 and 2 before either is expanded, and
+/// only one of them splits further, so *reversing the build's push order leaves every
+/// index unchanged* -- a mutation that flips the convention passes a three-cell
+/// check. At four both children split, so the order in which they are expanded
+/// decides whether the left subtree's children are nodes 3 and 4 or nodes 5 and 6.
+/// The preorder determinism the oracle's module docstring declares is that choice,
+/// and this is where it is pinned on this side.
+void test_the_node_arrays_are_readable() {
+    const auto [lo, hi] = unit_cells(4);
+    const BVH<double> tree = BVH<double>::from_cell_bounds(
+        pantr::span2d<const double>(lo.data(), 4, 1),
+        pantr::span2d<const double>(hi.data(), 4, 1));
+    PANTR_CHECK(tree.n_nodes() == 7);
+    PANTR_CHECK(tree.node_left().size() == tree.n_nodes());
+    PANTR_CHECK(tree.node_right().size() == tree.n_nodes());
+    PANTR_CHECK(tree.node_cell().size() == tree.n_nodes());
+    PANTR_CHECK(tree.node_lo().extent(0) == tree.n_nodes());
+    PANTR_CHECK(tree.node_lo().extent(1) == 1);
+
+    PANTR_CHECK(tree.node_left()[0] == 1 && tree.node_right()[0] == 2);
+    PANTR_CHECK(tree.node_cell()[0] == -1);
+    // Left to right: the root's LEFT child is expanded first, so it takes the next
+    // two indices and the right child takes the two after them.
+    PANTR_CHECK_MSG(tree.node_left()[1] == 3 && tree.node_right()[1] == 4,
+                    "the build must expand the left subtree first");
+    PANTR_CHECK_MSG(tree.node_left()[2] == 5 && tree.node_right()[2] == 6,
+                    "the build must expand the left subtree first");
+    PANTR_CHECK(tree.node_cell()[3] == 0 && tree.node_cell()[4] == 1);
+    PANTR_CHECK(tree.node_cell()[5] == 2 && tree.node_cell()[6] == 3);
+}
+
+/// A query whose corners have the wrong length is refused.
+void test_query_validates_its_dimension() {
+    const auto [lo, hi] = unit_cells(2);
+    const BVH<double> tree = BVH<double>::from_cell_bounds(
+        pantr::span2d<const double>(lo.data(), 2, 1),
+        pantr::span2d<const double>(hi.data(), 2, 1));
+    const std::vector<double> wide_lo{0.0, 0.0};
+    const std::vector<double> wide_hi{1.0, 1.0};
+    PANTR_CHECK(rejects([&] { return tree.query_aabb(wide_lo, wide_hi); }));
+}
+
+/// An empty query box is reported against a cell that contains its reversed interval.
+///
+/// This is the divergence from `pantr::geometry::AABB::overlaps` that `bvh.hpp`'s
+/// file comment records. It is pinned here rather than left implicit, so that
+/// reconciling the two predicates has to change a test that says why.
+void test_a_reversed_query_interval_is_reported() {
+    const std::vector<double> lo{0.0};
+    const std::vector<double> hi{10.0};
+    const BVH<double> tree = BVH<double>::from_cell_bounds(
+        pantr::span2d<const double>(lo.data(), 1, 1),
+        pantr::span2d<const double>(hi.data(), 1, 1));
+    const std::vector<double> qlo{5.0};
+    const std::vector<double> qhi{3.0};
+    PANTR_CHECK_MSG(tree.query_aabb(qlo, qhi) == std::vector<std::int64_t>({0}),
+                    "the separating-axis predicate has no emptiness branch");
+}
+
+}  // namespace
+
+// The class is a template, so its member bodies are only instantiated where they
+// are used; naming both instantiations compiles every one of them, which the calls
+// above do not on their own.
+template class pantr::grid::BVH<double>;
+template class pantr::grid::BVH<float>;
 
 int main() {
-    std::puts("PLACEHOLDER: test_grid_bvh_type asserts nothing yet");
+    test_from_cell_bounds_shape();
+    test_from_cell_bounds_validates();
+    test_the_empty_tree();
+    test_node_count_and_dimension();
+    test_structure_is_validated();
+    test_the_depth_limit_is_exact_and_reports_capacity();
+    test_a_cyclic_node_graph_is_refused_without_hanging();
+    test_the_node_arrays_are_readable();
+    test_query_validates_its_dimension();
+    test_a_reversed_query_interval_is_reported();
     return pantr::test::summary("test_grid_bvh_type");
 }

--- a/cpp/tests/test_grid_partition.cpp
+++ b/cpp/tests/test_grid_partition.cpp
@@ -1,17 +1,127 @@
 /// \file
-/// Reserved slot for the pantr::grid::Partition tests -- no assertions yet.
+/// Properties of the cell-ownership partition.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// ## Why these cases and not others
+///
+/// A partition holds integers and answers two questions about them, so there is no
+/// floating point, no rounding and no tolerance anywhere below. What it can get
+/// wrong is small and entirely at the edges, which is what these groups are:
+///
+///  - **The two range checks, on both sides.** `-1` is a legal owner and `n_parts`
+///    is not, so the interesting values are `-2`, `-1`, `n_parts - 1` and
+///    `n_parts`; the same for `owned_cells`' `rank`. An off-by-one on either
+///    boundary passes every ordinary case, which is why they are checked one at a
+///    time rather than by a sweep.
+///  - **The empty partition.** Zero cells is legal, and it is the input that would
+///    make a `min`/`max` over the owners read past the end. `owned_cells` on it
+///    must answer with an empty list rather than refuse.
+///  - **Ordering and completeness of `owned_cells`.** The oracle promises ascending
+///    ids, and the distributed-space machinery indexes with the result.
+///  - **Validation at all.** This type is the C++ counterpart of Layer 2: a caller
+///    with no Python is protected by these throws and by nothing else.
 
-#include <cstdio>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/grid/partition.hpp"
+
+namespace {
+
+using pantr::grid::Partition;
+
+/// Build a partition from a vector, for brevity below.
+///
+/// \param owners Per-cell owner ranks.
+/// \param n_parts Number of parts.
+/// \return The partition.
+Partition part(const std::vector<std::int32_t>& owners, std::int64_t n_parts) {
+    return Partition(std::span<const std::int32_t>(owners), n_parts);
+}
+
+/// Whether calling `fn` throws `std::invalid_argument`.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class Fn>
+bool rejects(Fn&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+/// The constructor accepts what the oracle accepts and refuses what it refuses.
+void test_construction_validates() {
+    const std::vector<std::int32_t> ok{0, 1, 0, -1, 1};
+    PANTR_CHECK(part(ok, 2).n_cells() == 5);
+    PANTR_CHECK(part(ok, 2).n_parts() == 2);
+
+    PANTR_CHECK(rejects([&] { return part(ok, 0); }));
+    PANTR_CHECK(rejects([&] { return part(ok, -3); }));
+    // `n_parts` itself is out of range as an owner, and `-2` is one below the
+    // inactive marker: the two ends of the same interval.
+    PANTR_CHECK(rejects([] { return part({0, 2}, 2); }));
+    PANTR_CHECK(rejects([] { return part({-2, 0}, 2); }));
+    // ... and the two values just inside it are accepted, so the guard cannot pass
+    // merely by refusing everything.
+    PANTR_CHECK(part({-1, 1}, 2).n_cells() == 2);
+}
+
+/// A zero-cell partition is legal, and nothing reads past its end.
+void test_the_empty_partition_is_legal() {
+    const Partition empty = part({}, 1);
+    PANTR_CHECK(empty.n_cells() == 0);
+    PANTR_CHECK(empty.cell_owner().empty());
+    PANTR_CHECK(empty.owned_cells(0).empty());
+}
+
+/// `owned_cells` returns exactly the cells of one rank, ascending.
+void test_owned_cells_is_ascending_and_complete() {
+    const Partition p = part({0, 1, 0, -1, 1, 0}, 2);
+    PANTR_CHECK(p.owned_cells(0) == std::vector<std::int64_t>({0, 2, 5}));
+    PANTR_CHECK(p.owned_cells(1) == std::vector<std::int64_t>({1, 4}));
+
+    // A rank that owns nothing is an ordinary answer, not an error.
+    PANTR_CHECK(part({0, 0, -1}, 3).owned_cells(2).empty());
+}
+
+/// `owned_cells` refuses a rank outside `[0, n_parts)`, on both sides.
+void test_owned_cells_validates_its_rank() {
+    const Partition p = part({0, 1}, 2);
+    PANTR_CHECK(rejects([&] { return p.owned_cells(2); }));
+    PANTR_CHECK(rejects([&] { return p.owned_cells(-1); }));
+    PANTR_CHECK(p.owned_cells(1) == std::vector<std::int64_t>({1}));
+}
+
+/// The stored owners are the caller's values, copied rather than aliased.
+void test_the_owners_are_copied() {
+    std::vector<std::int32_t> owners{0, 1};
+    const Partition p = part(owners, 2);
+    owners[0] = 1;
+    PANTR_CHECK(p.cell_owner()[0] == 0);
+}
+
+/// The representation names the two counts and not the owners.
+void test_to_string_names_the_counts() {
+    PANTR_CHECK_MSG(part({0, 1, -1}, 2).to_string() == "Partition(n_cells=3, n_parts=2)",
+                    part({0, 1, -1}, 2).to_string());
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_grid_partition asserts nothing yet");
+    test_construction_validates();
+    test_the_empty_partition_is_legal();
+    test_owned_cells_is_ascending_and_complete();
+    test_owned_cells_validates_its_rank();
+    test_the_owners_are_copied();
+    test_to_string_names_the_counts();
     return pantr::test::summary("test_grid_partition");
 }

--- a/cpp/tests/test_grid_tags.cpp
+++ b/cpp/tests/test_grid_tags.cpp
@@ -1,17 +1,326 @@
 /// \file
-/// Reserved slot for the cell and facet tag registries tests -- no assertions yet.
+/// Properties of the cell and facet tag registries.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// ## Why these cases and not others
+///
+/// There is no floating point here at all, so nothing in this file is about
+/// rounding and no assertion carries a tolerance. What the registries can get
+/// wrong is structural, and the groups below are the four places the port could
+/// have got it wrong without any test in the Python suite noticing:
+///
+///  - **Lifetime.** A handle taken from `get` must survive a `set` that replaces
+///    the same name, and a `remove` that deletes it. The Python oracle gets this
+///    from reference counting and cannot fail it; this side gets it from a
+///    `shared_ptr` and would otherwise hand a caller freed memory. Nothing in the
+///    Python suite reaches it except through the binding, so it is checked here
+///    where the ownership actually lives.
+///  - **Insertion order across a replacement.** `names()` is public, so the order
+///    is a contract. A `std::unordered_map` would pass every value assertion in
+///    the suite and fail this one.
+///  - **Validation.** The type is the C++ counterpart of Layer 2: a caller with no
+///    Python is protected by these throws and by nothing else.
+///  - **`scatter`'s width behaviour.** The overflow check fires below eight bytes
+///    and, reproducing the oracle, does not fire at eight -- so a negative value
+///    scattered into a `uint64` destination wraps rather than throwing. That is
+///    asserted rather than left implicit, because it is the one place this file
+///    pins behaviour the header itself calls a contract gap.
 
-#include <cstdio>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/grid/tags.hpp"
+
+namespace {
+
+using pantr::grid::CellTags;
+using pantr::grid::FacetTags;
+
+/// View a vector as a read-only span, for brevity below.
+///
+/// \param v The vector.
+/// \return A span over it.
+std::span<const std::int64_t> as_span(const std::vector<std::int64_t>& v) {
+    return {v.data(), v.size()};
+}
+
+/// View a flat vector as an `(M, 2)` key block.
+///
+/// \param v The flattened rows.
+/// \return A 2D view over them.
+pantr::span2d<const std::int64_t> as_keys(const std::vector<std::int64_t>& v) {
+    return pantr::span2d<const std::int64_t>(v.data(), v.size() / 2, 2);
+}
+
+/// Whether calling `fn` throws `std::invalid_argument`.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class Fn>
+bool rejects(Fn&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+/// Whether calling `fn` throws `std::out_of_range`.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class Fn>
+bool reports_missing(Fn&& fn) {
+    try {
+        fn();
+    } catch (const std::out_of_range&) {
+        return true;
+    }
+    return false;
+}
+
+/// Whether calling `fn` throws `std::overflow_error`.
+///
+/// \tparam Fn The callable's type.
+/// \param fn The call to attempt.
+/// \return `true` when it threw.
+template <class Fn>
+bool overflows(Fn&& fn) {
+    try {
+        fn();
+    } catch (const std::overflow_error&) {
+        return true;
+    }
+    return false;
+}
+
+/// The constructors reject what the oracle rejects.
+void test_construction_validates() {
+    PANTR_CHECK(rejects([] { return CellTags(-1); }));
+    PANTR_CHECK(rejects([] { return FacetTags(-1, 4); }));
+    PANTR_CHECK(rejects([] { return FacetTags(4, 0); }));
+    PANTR_CHECK(CellTags(0).num_cells() == 0);
+    PANTR_CHECK(FacetTags(3, 4).facets_per_cell() == 4);
+}
+
+/// A cell tag stores its pair sorted by id, and reads it back.
+void test_cell_set_sorts_by_id() {
+    CellTags tags(10);
+    const std::vector<std::int64_t> ids{4, 1, 7};
+    const std::vector<std::int64_t> values{2, 1, 2};
+    tags.set("location", as_span(ids), as_span(values));
+
+    const auto tag = tags.get("location");
+    PANTR_CHECK(tag->ids == std::vector<std::int64_t>({1, 4, 7}));
+    PANTR_CHECK(tag->values == std::vector<std::int64_t>({1, 2, 2}));
+    PANTR_CHECK(tags.size() == 1);
+    PANTR_CHECK(tags.contains("location"));
+    PANTR_CHECK(!tags.contains("other"));
+}
+
+/// An empty tag is legal and stores two empty arrays.
+void test_an_empty_tag_is_legal() {
+    CellTags tags(4);
+    tags.set("none", {}, {});
+    PANTR_CHECK(tags.get("none")->ids.empty());
+
+    FacetTags facets(4, 4);
+    facets.set("none", pantr::span2d<const std::int64_t>(nullptr, 0, 2), {});
+    PANTR_CHECK(facets.get("none")->rows() == 0);
+}
+
+/// Replacing a tag keeps its position among the names.
+///
+/// The failure this catches is a registry that appends on replace: every value
+/// assertion in the suite still passes, and `names()` silently reorders.
+void test_replacing_a_tag_keeps_its_position() {
+    CellTags tags(10);
+    const std::vector<std::int64_t> one{1};
+    const std::vector<std::int64_t> two{2};
+    tags.set("a", as_span(one), as_span(one));
+    tags.set("b", as_span(one), as_span(one));
+    tags.set("c", as_span(one), as_span(one));
+    tags.set("b", as_span(two), as_span(two));
+
+    PANTR_CHECK(tags.names() == std::vector<std::string>({"a", "b", "c"}));
+    PANTR_CHECK(tags.get("b")->ids == std::vector<std::int64_t>({2}));
+
+    tags.remove("a");
+    PANTR_CHECK(tags.names() == std::vector<std::string>({"b", "c"}));
+}
+
+/// A handle taken from `get` outlives a replacement and a removal.
+///
+/// This is what the `shared_ptr` is for; without it the binding's zero-copy views
+/// would dangle the moment a caller re-tagged the same name.
+void test_a_handle_outlives_a_replacement() {
+    CellTags tags(10);
+    const std::vector<std::int64_t> first{1, 2};
+    const std::vector<std::int64_t> second{5};
+    tags.set("a", as_span(first), as_span(first));
+
+    const std::shared_ptr<const CellTags::Tag> held = tags.get("a");
+    tags.set("a", as_span(second), as_span(second));
+    PANTR_CHECK(held->ids == std::vector<std::int64_t>({1, 2}));
+    PANTR_CHECK(tags.get("a")->ids == std::vector<std::int64_t>({5}));
+
+    tags.remove("a");
+    PANTR_CHECK(held->ids == std::vector<std::int64_t>({1, 2}));
+    PANTR_CHECK(!tags.contains("a"));
+}
+
+/// `set` rejects an out-of-range id, a duplicate, and a length mismatch.
+void test_cell_set_validates() {
+    CellTags tags(5);
+    const std::vector<std::int64_t> oob{5};
+    const std::vector<std::int64_t> negative{-1};
+    const std::vector<std::int64_t> dup{1, 1};
+    const std::vector<std::int64_t> three{0, 1, 2};
+    const std::vector<std::int64_t> two{1, 2};
+    const std::vector<std::int64_t> one{1};
+
+    PANTR_CHECK(rejects([&] { tags.set("a", as_span(oob), as_span(one)); }));
+    PANTR_CHECK(rejects([&] { tags.set("a", as_span(negative), as_span(one)); }));
+    PANTR_CHECK(rejects([&] { tags.set("a", as_span(dup), as_span(two)); }));
+    PANTR_CHECK(rejects([&] { tags.set("a", as_span(three), as_span(two)); }));
+    PANTR_CHECK(tags.size() == 0);
+}
+
+/// A missing name is `std::out_of_range`, which the wrapper turns into `KeyError`.
+void test_a_missing_name_is_reported() {
+    CellTags tags(4);
+    PANTR_CHECK(reports_missing([&] { return tags.get("nope"); }));
+    PANTR_CHECK(reports_missing([&] { tags.remove("nope"); }));
+
+    FacetTags facets(4, 4);
+    PANTR_CHECK(reports_missing([&] { return facets.get("nope"); }));
+}
+
+/// `scatter` writes the stored values at the stored ids and touches nothing else.
+void test_cell_scatter_leaves_the_rest_alone() {
+    CellTags tags(6);
+    const std::vector<std::int64_t> ids{0, 4};
+    const std::vector<std::int64_t> values{1, 2};
+    tags.set("location", as_span(ids), as_span(values));
+
+    std::vector<std::int64_t> out(6, -1);
+    tags.scatter<std::int64_t>("location", std::span<std::int64_t>(out));
+    PANTR_CHECK(out == std::vector<std::int64_t>({1, -1, -1, -1, 2, -1}));
+
+    std::vector<std::int64_t> wrong_size(5, 0);
+    PANTR_CHECK(rejects(
+        [&] { tags.scatter<std::int64_t>("location", std::span<std::int64_t>(wrong_size)); }));
+}
+
+/// The overflow check fires below eight bytes and, as the oracle does, not at eight.
+///
+/// The second half pins the contract gap `detail::require_representable` documents:
+/// a negative value scattered into a `uint64` destination wraps. Asserted rather
+/// than left implicit, so that closing the gap has to change a test that says why.
+void test_scatter_overflow_follows_the_oracle_width_rule() {
+    CellTags tags(4);
+    const std::vector<std::int64_t> ids{0, 1};
+    const std::vector<std::int64_t> big{200, 1};
+    tags.set("big", as_span(ids), as_span(big));
+
+    std::vector<std::int8_t> narrow(4, 0);
+    PANTR_CHECK(
+        overflows([&] { tags.scatter<std::int8_t>("big", std::span<std::int8_t>(narrow)); }));
+
+    std::vector<std::int16_t> wide(4, 0);
+    tags.scatter<std::int16_t>("big", std::span<std::int16_t>(wide));
+    PANTR_CHECK(wide == std::vector<std::int16_t>({200, 1, 0, 0}));
+
+    const std::vector<std::int64_t> one{0};
+    const std::vector<std::int64_t> minus_one{-1};
+    tags.set("neg", as_span(one), as_span(minus_one));
+    std::vector<std::uint64_t> unsigned_out(4, 0);
+    tags.scatter<std::uint64_t>("neg", std::span<std::uint64_t>(unsigned_out));
+    PANTR_CHECK_MSG(unsigned_out[0] == std::numeric_limits<std::uint64_t>::max(),
+                    "the oracle skips its range check at eight bytes, so -1 wraps here too");
+}
+
+/// A facet tag sorts lexicographically by `(cell_id, local_facet_id)`.
+void test_facet_set_sorts_lexicographically() {
+    FacetTags tags(10, 4);
+    const std::vector<std::int64_t> keys{3, 1, 0, 0, 3, 0};
+    const std::vector<std::int64_t> values{7, 5, 6};
+    tags.set("bc", as_keys(keys), as_span(values));
+
+    const auto tag = tags.get("bc");
+    PANTR_CHECK(tag->keys == std::vector<std::int64_t>({0, 0, 3, 0, 3, 1}));
+    PANTR_CHECK(tag->values == std::vector<std::int64_t>({5, 6, 7}));
+}
+
+/// The facet registry rejects a bad width, an out-of-range component, a duplicate.
+void test_facet_set_validates() {
+    FacetTags tags(4, 4);
+    const std::vector<std::int64_t> bad_cid{4, 0};
+    const std::vector<std::int64_t> bad_lfid{0, 4};
+    const std::vector<std::int64_t> dup{0, 0, 0, 0};
+    const std::vector<std::int64_t> one{1};
+    const std::vector<std::int64_t> two{1, 2};
+    const std::vector<std::int64_t> three_wide{0, 0, 0};
+
+    PANTR_CHECK(rejects([&] { tags.set("a", as_keys(bad_cid), as_span(one)); }));
+    PANTR_CHECK(rejects([&] { tags.set("a", as_keys(bad_lfid), as_span(one)); }));
+    PANTR_CHECK(rejects([&] { tags.set("a", as_keys(dup), as_span(two)); }));
+    PANTR_CHECK(rejects([&] {
+        tags.set("a", pantr::span2d<const std::int64_t>(three_wide.data(), 1, 3), as_span(one));
+    }));
+    PANTR_CHECK(tags.size() == 0);
+}
+
+/// `scatter` lands each facet value at its own `(cell, facet)` slot.
+void test_facet_scatter_lands_at_the_key() {
+    FacetTags tags(3, 4);
+    const std::vector<std::int64_t> keys{0, 0, 2, 3};
+    const std::vector<std::int64_t> values{1, 2};
+    tags.set("bc", as_keys(keys), as_span(values));
+
+    std::vector<std::int64_t> storage(3 * 4, -1);
+    tags.scatter<std::int64_t>("bc", pantr::span2d<std::int64_t>(storage.data(), 3, 4));
+    PANTR_CHECK(storage[0] == 1);
+    PANTR_CHECK(storage[2 * 4 + 3] == 2);
+    PANTR_CHECK(storage[1] == -1);
+}
+
+/// Both registries print their counts and their tag names, with Python's quoting.
+void test_to_string_names_the_tags() {
+    CellTags cells(6);
+    const std::vector<std::int64_t> one{1};
+    cells.set("a", as_span(one), as_span(one));
+    PANTR_CHECK_MSG(cells.to_string() == "CellTags(num_cells=6, tags=['a'])", cells.to_string());
+
+    FacetTags facets(3, 4);
+    PANTR_CHECK_MSG(facets.to_string() == "FacetTags(num_cells=3, facets_per_cell=4, tags=[])",
+                    facets.to_string());
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_grid_tags asserts nothing yet");
+    test_construction_validates();
+    test_cell_set_sorts_by_id();
+    test_an_empty_tag_is_legal();
+    test_replacing_a_tag_keeps_its_position();
+    test_a_handle_outlives_a_replacement();
+    test_cell_set_validates();
+    test_a_missing_name_is_reported();
+    test_cell_scatter_leaves_the_rest_alone();
+    test_scatter_overflow_follows_the_oracle_width_rule();
+    test_facet_set_sorts_lexicographically();
+    test_facet_set_validates();
+    test_facet_scatter_lands_at_the_key();
+    test_to_string_names_the_tags();
     return pantr::test::summary("test_grid_tags");
 }

--- a/design/bvh.md
+++ b/design/bvh.md
@@ -13,15 +13,38 @@ below refer to that tree.
 The port **keeps and ports pantr's own BVH** (`src/pantr/grid/_bvh.py` plus
 `_bvh_core.py`, 664 lines) rather than adopting a header-only third-party library.
 
-## Why, and the reason is not the obvious one
+## Why, and the stated reason has changed
 
-**The BVH is not a black box here. It is a public data structure that a consumer traverses
-with its own predicate.** A downstream consumer does not call `query_aabb`; it walks the
-tree itself, stack-iteratively, probing at each *internal* node with its own predicate,
-pruning subtrees and delegating at leaves. So the five-array node layout
-(`node_lo` / `node_hi` / `node_left` / `node_right` / `node_cell`, exposed as properties)
-is **public API**, not an implementation detail, and swapping implementations means
-rewriting that consumer's classifier.
+**The reason first given for this decision is no longer true. It is corrected here rather
+than deleted, because everything below was written under it.**
+
+As written on 2026-08-14 and revalidated on 2026-08-19, the argument was: the BVH is not a
+black box, it is a public data structure that a downstream consumer traverses with its own
+predicate; that consumer does not call `query_aabb` at all, it walks the tree
+stack-iteratively, probing at each *internal* node, pruning subtrees and delegating at
+leaves. The five-array node layout (`node_lo` / `node_hi` / `node_left` / `node_right` /
+`node_cell`) was therefore public API rather than implementation detail, and swapping
+implementations meant rewriting that consumer's classifier.
+
+**A census of that consumer's checkout on 2026-08-29, against its own head of that day,
+found zero references to `BVH`, `node_left` or `query_aabb`, and zero uses of
+`pantr.grid._bvh_core._BVH_STACK_DEPTH`.** The two `node_lo` hits are its own local
+variables in an unrelated file. From this subsystem it imports `Partition` and
+`tensor_product_grid` and nothing else, and it writes no attribute of any pantr object. So
+the caller the paragraph above describes does not exist any more, and **that sentence must
+not be cited again as written.**
+
+Re-run the census before relying on this: the repository moves, and the previous census was
+a week stale when it was contradicted. The command is a grep for `import pantr` over the
+sibling checkouts, then three separate counts -- private symbols, public symbols, and
+**attribute writes**. The last is the one the earlier census omitted, which is how three
+writable `BVH` attributes went unexamined until the port privatised them.
+
+**The decision itself stands, on the remaining grounds.** The layout was kept unchanged
+through the port with this known: a repository that moved once can move back, the node
+arrays are public surface of this library whether or not anyone reads them today, and the
+three secondary reasons below never depended on that consumer at all. `traverse(visitor)`
+is still ordered first among the improvements, for reasons of its own.
 
 Three secondary reasons:
 
@@ -79,9 +102,12 @@ guarantees before adopting any of them.
 ## Epistemic status
 
 - **Verified by reading the code**, revalidated against 0.7.0: the five node-array
-  properties and `query_aabb` as the only query (`_bvh.py`); that a downstream consumer
-  traverses the node arrays directly with its own predicate at internal nodes; that
-  tensor-product point location does not use the tree (`_locate_core.py:4`).
+  properties and `query_aabb` as the only query (`_bvh.py`); that tensor-product point
+  location does not use the tree (`_locate_core.py:4`).
+- **Measured, and now false:** that a downstream consumer traverses the node arrays directly
+  with its own predicate at internal nodes. True when measured on 2026-08-14; **refuted by
+  the 2026-08-29 census**, which found no reference to the BVH at all. See the correction
+  above.
 - **Derived:** that ray-tuned advantages do not transfer to box-overlap queries.
 - **Not measured:** how much a binned SAH build would actually help on the physical
   control-point boxes. That is the experiment that would justify item 2.

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -493,6 +493,33 @@ discipline() {
         record FAIL "Lambert W Halley step count agrees" \
                "Python=${py_halley:-<not found>} C++=${cpp_halley:-<not found>}"
     fi
+
+    # The BVH traversal-stack depth agrees across the two languages.
+    #
+    # The third guard of this shape, and the one with a caller outside this repo.
+    # `_BVH_STACK_DEPTH` is imported by a downstream consumer, so the Python copy is
+    # the source of truth and stays where it is; `kBvhStackDepth` mirrors it, and
+    # since FELIGN/pantr#384 the mirror is what ENFORCES the limit under
+    # PANTR_BACKEND=cpp. Two spellings of one number, each enforcing for one
+    # backend, is exactly the drift a test cannot see: tests/test_grid_reexports.py
+    # pins the Python one by value and the C++ mirror is not exposed to Python at
+    # all, so nothing inside the suite compares them.
+    #
+    # Extracted from both sources by regex rather than hardcoded here, so this guard
+    # does not itself go stale the way a copied number would.
+    local py_bvh_depth cpp_bvh_depth
+    py_bvh_depth="$(sed -n -E 's/^_BVH_STACK_DEPTH: Final\[int\] = ([0-9]+)$/\1/p' \
+                    "$ROOT/src/pantr/grid/_bvh_core.py")"
+    cpp_bvh_depth="$(sed -n -E \
+        's/^inline constexpr std::int64_t kBvhStackDepth = ([0-9]+);$/\1/p' \
+        "$ROOT/cpp/include/pantr/grid/bvh.hpp")"
+
+    if [[ -n "$py_bvh_depth" && -n "$cpp_bvh_depth" && "$py_bvh_depth" == "$cpp_bvh_depth" ]]; then
+        record PASS "BVH traversal stack depth agrees (Python=C++=$py_bvh_depth)"
+    else
+        record FAIL "BVH traversal stack depth agrees" \
+               "Python=${py_bvh_depth:-<not found>} C++=${cpp_bvh_depth:-<not found>}"
+    fi
 }
 
 # --------------------------------------------------------------------------

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -67,6 +67,8 @@ from ._bezier import solve_monotone_root_batch as solve_monotone_root_batch
 from ._bezier import split_bezier_1d as split_bezier_1d
 from ._bezier import yuksel_roots as yuksel_roots
 from ._geometry import AABB as AABB
+from ._grid import CellTags as CellTags
+from ._grid import FacetTags as FacetTags
 from ._grid import bvh_build as bvh_build
 from ._grid import bvh_query_count as bvh_query_count
 from ._grid import bvh_query_emit as bvh_query_emit

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -67,6 +67,7 @@ from ._bezier import solve_monotone_root_batch as solve_monotone_root_batch
 from ._bezier import split_bezier_1d as split_bezier_1d
 from ._bezier import yuksel_roots as yuksel_roots
 from ._geometry import AABB as AABB
+from ._grid import BVH as BVH
 from ._grid import CellTags as CellTags
 from ._grid import FacetTags as FacetTags
 from ._grid import Partition as Partition

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -69,6 +69,7 @@ from ._bezier import yuksel_roots as yuksel_roots
 from ._geometry import AABB as AABB
 from ._grid import CellTags as CellTags
 from ._grid import FacetTags as FacetTags
+from ._grid import Partition as Partition
 from ._grid import bvh_build as bvh_build
 from ._grid import bvh_query_count as bvh_query_count
 from ._grid import bvh_query_emit as bvh_query_emit

--- a/src/pantr/_pantr_cpp/_grid.pyi
+++ b/src/pantr/_pantr_cpp/_grid.pyi
@@ -43,6 +43,62 @@ class CellTags:
     def remove(self, name: str) -> None: ...
     def scatter(self, name: str, out: npt.NDArray[Any]) -> None: ...
 
+class BVH:
+    """Bounding-volume hierarchy over cell AABBs, owned by the C++ core.
+
+    Wrapped by :class:`pantr.grid.BVH`, which is the class a caller holds; this one
+    is reached only through it. The wrapper owns the ``TypeError`` dtype checks and
+    the numpy-shaped messages, and translates ``CapacityError`` back to the
+    ``ValueError`` the pre-port class raised for a tree deeper than the traversal
+    stack.
+
+    The five node arrays are zero-copy read-only views owned by the instance;
+    ``query_aabb`` returns a fresh writeable array.
+
+    Attributes:
+        ndim (int): Spatial dimension of the indexed AABBs.
+        n_cells (int): Number of cells indexed.
+        n_nodes (int): Total number of nodes.
+        node_lo (npt.NDArray[np.float64]): Per-node lo corners, read-only.
+        node_hi (npt.NDArray[np.float64]): Per-node hi corners, read-only.
+        node_left (npt.NDArray[np.int64]): Left-child indices, read-only.
+        node_right (npt.NDArray[np.int64]): Right-child indices, read-only.
+        node_cell (npt.NDArray[np.int64]): Leaf cell ids, read-only.
+    """
+
+    def __init__(
+        self,
+        node_lo: npt.NDArray[np.float64],
+        node_hi: npt.NDArray[np.float64],
+        node_left: npt.NDArray[np.int64],
+        node_right: npt.NDArray[np.int64],
+        node_cell: npt.NDArray[np.int64],
+        n_cells: int,
+    ) -> None: ...
+    @staticmethod
+    def from_cell_bounds(
+        cell_lo: npt.NDArray[np.float64], cell_hi: npt.NDArray[np.float64]
+    ) -> BVH: ...
+    @property
+    def ndim(self) -> int: ...
+    @property
+    def n_cells(self) -> int: ...
+    @property
+    def n_nodes(self) -> int: ...
+    @property
+    def node_lo(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def node_hi(self) -> npt.NDArray[np.float64]: ...
+    @property
+    def node_left(self) -> npt.NDArray[np.int64]: ...
+    @property
+    def node_right(self) -> npt.NDArray[np.int64]: ...
+    @property
+    def node_cell(self) -> npt.NDArray[np.int64]: ...
+    def query_aabb(
+        self, qlo: npt.NDArray[np.float64], qhi: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.int64]: ...
+
 class Partition:
     """A per-cell owner assignment over a grid's cells, owned by the C++ core.
 

--- a/src/pantr/_pantr_cpp/_grid.pyi
+++ b/src/pantr/_pantr_cpp/_grid.pyi
@@ -1,11 +1,79 @@
-"""Grid location, BVH and hierarchical-index kernels of the compiled extension.
+"""Grid kernels and grid types of the compiled extension.
 
-Bound by ``cpp/bindings/grid.cpp``. See ``__init__.pyi`` for what this package
-promises and who has to keep it.
+The free functions are bound by ``cpp/bindings/grid.cpp``; the classes are bound
+by the per-type files beside it (``grid_tags.cpp`` and its siblings). See
+``__init__.pyi`` for what this package promises and who has to keep it.
 """
+
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+
+class CellTags:
+    """Sparse named integer tags over a grid's cells, owned by the C++ core.
+
+    Wrapped by :class:`pantr.grid.CellTags`, which is the class a caller holds;
+    this one is reached only through it. The wrapper is what raises ``KeyError``
+    for an unregistered name and ``TypeError`` for a non-integer argument, because
+    nanobind can produce neither.
+
+    ``scatter`` is registered once per numpy integer dtype and writes only the
+    tagged entries: the wrapper allocates and fills the destination.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        names (list[str]): Registered tag names, in insertion order.
+    """
+
+    def __init__(self, num_cells: int) -> None: ...
+    @property
+    def num_cells(self) -> int: ...
+    @property
+    def names(self) -> list[str]: ...
+    def __len__(self) -> int: ...
+    def __contains__(self, name: str) -> bool: ...
+    def set(
+        self,
+        name: str,
+        ids: npt.NDArray[np.int64],
+        values: npt.NDArray[np.int64],
+    ) -> None: ...
+    def get(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ...
+    def remove(self, name: str) -> None: ...
+    def scatter(self, name: str, out: npt.NDArray[Any]) -> None: ...
+
+class FacetTags:
+    """Sparse named integer tags over a grid's local facets, owned by the C++ core.
+
+    The facet counterpart of :class:`CellTags`; see that class. Keys are
+    ``(cell_id, local_facet_id)`` rows and ``scatter``'s destination is
+    ``(num_cells, facets_per_cell)``.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        facets_per_cell (int): Number of local facets per cell.
+        names (list[str]): Registered tag names, in insertion order.
+    """
+
+    def __init__(self, num_cells: int, facets_per_cell: int) -> None: ...
+    @property
+    def num_cells(self) -> int: ...
+    @property
+    def facets_per_cell(self) -> int: ...
+    @property
+    def names(self) -> list[str]: ...
+    def __len__(self) -> int: ...
+    def __contains__(self, name: str) -> bool: ...
+    def set(
+        self,
+        name: str,
+        keys: npt.NDArray[np.int64],
+        values: npt.NDArray[np.int64],
+    ) -> None: ...
+    def get(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ...
+    def remove(self, name: str) -> None: ...
+    def scatter(self, name: str, out: npt.NDArray[Any]) -> None: ...
 
 def locate_points(
     points: npt.NDArray[np.float64],

--- a/src/pantr/_pantr_cpp/_grid.pyi
+++ b/src/pantr/_pantr_cpp/_grid.pyi
@@ -43,6 +43,33 @@ class CellTags:
     def remove(self, name: str) -> None: ...
     def scatter(self, name: str, out: npt.NDArray[Any]) -> None: ...
 
+class Partition:
+    """A per-cell owner assignment over a grid's cells, owned by the C++ core.
+
+    Wrapped by :class:`pantr.grid.Partition`, which is the class a caller holds;
+    this one is reached only through it. The wrapper is what checks that
+    ``cell_owner`` is a 1-D integer array and performs the narrowing cast to
+    ``int32``, because both facts are gone by the time this receives a span.
+
+    ``cell_owner`` is a zero-copy read-only view owned by the instance;
+    ``owned_cells`` returns a fresh writeable array, matching what the pre-port
+    class returned from ``numpy.flatnonzero``.
+
+    Attributes:
+        cell_owner (npt.NDArray[np.int32]): Per-cell owners, read-only.
+        n_parts (int): Number of parts (ranks).
+        n_cells (int): Number of cells.
+    """
+
+    def __init__(self, cell_owner: npt.NDArray[np.int32], n_parts: int) -> None: ...
+    @property
+    def cell_owner(self) -> npt.NDArray[np.int32]: ...
+    @property
+    def n_parts(self) -> int: ...
+    @property
+    def n_cells(self) -> int: ...
+    def owned_cells(self, rank: int) -> npt.NDArray[np.int64]: ...
+
 class FacetTags:
     """Sparse named integer tags over a grid's local facets, owned by the C++ core.
 

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -441,6 +441,13 @@ class _BVHPython:
         # Guard against the fixed-depth Numba stack in :mod:`pantr.grid._bvh_core`.
         # Median-of-longest-axis splits produce a balanced tree of height
         # ``ceil(log2(n_cells)) + 1``; the ``+ 1`` accounts for the root push.
+        #
+        # This keeps the pre-port float64 form on purpose, where the C++ side uses
+        # `bit_width(n - 1) + 1` -- the same quantity in exact integers. The two
+        # disagree only above a cell count needing petabytes for one coordinate
+        # axis, which `scripts/measure_bvh_depth_arithmetic.py` enumerates; below
+        # that they are equal, so the backends cannot differ on any reachable input
+        # and this line stays the oracle's.
         max_depth = int(np.ceil(np.log2(n_cells))) + 1 if n_cells > 1 else 1
         if max_depth > _BVH_STACK_DEPTH:
             raise ValueError(

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -485,8 +485,7 @@ class _BVHPython:
         """
         if qlo.shape[0] != self._ndim:
             raise ValueError(
-                f"BVH.query_aabb: aabb.ndim ({qlo.shape[0]}) must match self.ndim "
-                f"({self._ndim})."
+                f"BVH.query_aabb: aabb.ndim ({qlo.shape[0]}) must match self.ndim ({self._ndim})."
             )
         if self._n_cells == 0:
             return np.zeros(0, dtype=np.int64)

--- a/src/pantr/grid/_bvh.py
+++ b/src/pantr/grid/_bvh.py
@@ -2,8 +2,7 @@
 
 A simple but efficient BVH that indexes a fixed collection of axis-aligned
 bounding boxes (one per grid cell). The tree is built once by iterative
-median-of-longest-axis splits and queried by iterative descent, both via the
-Layer-3 kernels in :mod:`pantr.grid._bvh_core`.
+median-of-longest-axis splits and queried by iterative descent.
 
 Layout
 ------
@@ -22,20 +21,60 @@ stops at one cell per leaf, so leaves and cells are in one-to-one correspondence
 The construction order (preorder) is deterministic, which keeps query results
 reproducible.
 
+``design/bvh.md`` establishes those five arrays as **public API rather than
+implementation detail**, so the port reproduces the layout exactly: no leaf
+clustering, no ``int32`` indices, no reordering.
+
 Queries
 -------
 
-:meth:`BVH.query_aabb` returns the ids of cells whose AABB overlaps the query
-box. A touching-face pair counts as overlapping (inclusive comparison) to match
-:meth:`pantr.geometry.AABB.overlaps`. Queries run in two passes: a count-only
-descent sizes the output, then an emit descent writes the cell ids. Both passes
-visit the same nodes in the same order, so the result is a fresh, compact
-``int64`` array with no Python-side list growth.
+:meth:`BVH.query_aabb` returns the ids of cells whose AABB is not separated from
+the query box. Queries run in two passes: a count-only descent sizes the output,
+then an emit descent writes the cell ids. Both passes visit the same nodes in the
+same order, so the result is a fresh, compact ``int64`` array with no Python-side
+list growth.
+
+**The overlap test is a separating-axis test and nothing else**, and it is not
+:meth:`pantr.geometry.AABB.overlaps`. It compares inclusively, so a query box
+sharing a face with a cell is reported; but it has no emptiness branch, so a
+*reversed* query interval is reported against any cell whose own interval contains
+it, where the box reports nothing. One cell ``[0, 10]`` in one dimension, queried
+with ``lo = 5, hi = 3``, returns cell ``0`` here. Both backends behave that way and
+agree with each other; this docstring used to claim agreement with the box, and the
+claim is withdrawn rather than the behaviour changed, because reconciling the two
+predicates has to move both backends at once.
+
+A wrapper
+---------
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the hierarchy
+itself is owned by the C++ core (``cpp/include/pantr/grid/bvh_tree.hpp``) and this
+class holds one. Under ``PANTR_BACKEND=python`` the thing held is
+:class:`_BVHPython`, which is the Python **backend** and not merely an oracle.
+
+Where the validation lives, and the one exception the wrapper translates
+------------------------------------------------------------------------
+
+Following the rule ``cpp/include/pantr/core/error.hpp`` states for the whole port,
+the **dtype** checks (``TypeError``) stay here, because nanobind has no path
+producing one; so do the array **shape** messages, which the pre-port class worded
+in terms of a numpy shape tuple that is gone once the binding holds a span. The
+value and structural checks -- the node-count relation, the leaf encodings, the
+child ranges and the tree depth -- live in the C++ type.
+
+The depth is the exception. A tree deeper than the traversal stack is perfectly
+well formed and this build cannot walk it, so the C++ type reports it as
+``pantr._pantr_cpp.CapacityError``, which is what ``core/error.hpp`` reserves that
+type for and the first site in the port to throw it. The pre-port class raised
+``ValueError``, and ``PANTR_BACKEND`` must not decide which exception a caller
+catches, so :meth:`BVH.__init__` translates it back, message unchanged. **That
+translation is a seam**: it exists only while both backends do, and it goes when the
+Python backend does.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Final, Self, TypeAlias
 
 import numpy as np
 
@@ -45,12 +84,108 @@ from ._grid_backend import (
     bvh_query_count_kernel,
     bvh_query_emit_kernel,
 )
-from ._grid_utils import _as_float64
+from ._grid_utils import _as_float64, _python_backend_selected
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from pantr._pantr_cpp import BVH as _CppBVH
+
     from ..geometry import AABB
+
+    _Impl: TypeAlias = "_BVHPython | _CppBVH"
+    """The implementation a :class:`BVH` holds: the Python one, or the C++ one.
+
+    Type-checking only. The two are unrelated nominal types that happen to offer the
+    same surface, which is the port's whole claim; naming the union here is what
+    lets the checker verify it instead of taking it on trust.
+    """
+
+_NODE_ARRAY_NDIM: Final[int] = 2
+"""``node_lo`` and ``node_hi`` are ``(n_nodes, ndim)`` tables, always rank 2."""
+
+
+def _validate_node_array_types(
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+) -> tuple[int, int]:
+    """Check the five node arrays' dtypes and shapes, in the pre-port order.
+
+    Written once and called from both the wrapper and :class:`_BVHPython`, so the
+    two cannot word the same complaint differently. Everything here is a question
+    about a numpy array's *type* or *shape*, which is exactly what does not survive
+    the crossing into a C++ span -- so this is the part that cannot move into the
+    type, and the rest deliberately did.
+
+    Args:
+        node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners.
+        node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners.
+        node_left (npt.NDArray[np.int64]): Left-child indices.
+        node_right (npt.NDArray[np.int64]): Right-child indices.
+        node_cell (npt.NDArray[np.int64]): Leaf cell identifiers.
+
+    Returns:
+        tuple[int, int]: The ``(n_nodes, ndim)`` the arrays imply.
+
+    Raises:
+        TypeError: If any array has the wrong dtype.
+        ValueError: If the shapes are inconsistent.
+    """
+    if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
+        raise TypeError(
+            f"node_lo / node_hi must be float64; got {node_lo.dtype!r} / {node_hi.dtype!r}."
+        )
+    if node_lo.ndim != _NODE_ARRAY_NDIM:
+        raise ValueError(f"node_lo must be 2-D (n_nodes, ndim); got shape {node_lo.shape}.")
+    if node_hi.shape != node_lo.shape:
+        raise ValueError(f"node_hi shape {node_hi.shape} must match node_lo shape {node_lo.shape}.")
+    n_nodes, ndim = int(node_lo.shape[0]), int(node_lo.shape[1])
+    if ndim < 1:
+        raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
+    for arr, name in (
+        (node_left, "node_left"),
+        (node_right, "node_right"),
+        (node_cell, "node_cell"),
+    ):
+        if arr.dtype != np.int64:
+            raise TypeError(f"{name} must be int64; got {arr.dtype!r}.")
+        if arr.shape != (n_nodes,):
+            raise ValueError(f"{name} must have shape ({n_nodes},); got {arr.shape}.")
+    return n_nodes, ndim
+
+
+def _validate_cell_bounds(
+    cell_lo: npt.ArrayLike, cell_hi: npt.ArrayLike
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Coerce and shape-check the per-cell bounds :meth:`BVH.from_cell_bounds` takes.
+
+    The value checks -- finiteness and ``hi >= lo`` -- are deliberately *not* here:
+    they live in the implementation, which is where a caller with no interpreter is
+    protected by them too.
+
+    Args:
+        cell_lo (npt.ArrayLike): Per-cell lo corners.
+        cell_hi (npt.ArrayLike): Per-cell hi corners.
+
+    Returns:
+        tuple: The two arrays as C-contiguous ``float64``.
+
+    Raises:
+        TypeError: If either input cannot be cast to ``float64``.
+        ValueError: If the shapes are inconsistent or ``ndim < 1``.
+    """
+    lo = _as_float64(cell_lo, name="cell_lo")
+    hi = _as_float64(cell_hi, name="cell_hi")
+    if lo.ndim != _NODE_ARRAY_NDIM:
+        raise ValueError(f"cell_lo must be 2-D (n_cells, ndim); got shape {lo.shape}.")
+    if hi.shape != lo.shape:
+        raise ValueError(f"cell_hi shape {hi.shape} must match cell_lo shape {lo.shape}.")
+    if int(lo.shape[1]) < 1:
+        raise ValueError(f"BVH ndim must be >= 1; got {int(lo.shape[1])}.")
+    return np.ascontiguousarray(lo), np.ascontiguousarray(hi)
 
 
 def _check_tree_structure(
@@ -153,34 +288,41 @@ def _max_tree_depth(
     return max_depth
 
 
-class BVH:
-    """Bounding-volume hierarchy indexing a fixed collection of AABBs.
+class _BVHPython:
+    """The pure-Python hierarchy: the backend under ``PANTR_BACKEND=python``.
 
-    Instances are immutable: once built, the internal arrays are flagged
-    read-only. Queries allocate fresh ``int64`` output arrays per call.
+    This was the public :class:`BVH` until the 2026-08-27 amendment to
+    ``design/cross_backend_types.md`` made the hierarchy a C++-owned type. It is not
+    merely a parity oracle: :func:`_impl_class` returns it whenever the Python
+    backend is selected, which is how the package still works in a tree with no
+    compiled extension.
 
-    Build by passing per-cell AABBs to :meth:`from_cell_bounds`; direct
-    construction from the raw array representation is supported via the default
-    constructor but is mostly intended for tests and round-trip serialization.
+    Its surface is deliberately the C++ type's, so that :class:`BVH` can call the
+    same methods on either -- which is why :meth:`query_aabb` takes two corner
+    arrays here and an :class:`~pantr.geometry.AABB` on the wrapper.
+
+    Instances are immutable: the node arrays are flagged read-only and the three
+    counts are read-only properties. **They used to be public writable attributes**,
+    while the class docstring said instances were immutable; ``bvh.ndim = 7``
+    defeated the dimension check in :meth:`query_aabb` and left the kernels indexing
+    a mis-shaped array.
+
+    Attributes:
+        ndim (int): Spatial dimension of the indexed AABBs (``>= 1``).
+        n_cells (int): Number of cells indexed (equal to the number of leaves).
+        n_nodes (int): Total number of nodes (``2 * n_cells - 1``, else ``0``).
     """
 
     __slots__ = (
+        "_n_cells",
+        "_n_nodes",
+        "_ndim",
         "_node_cell",
         "_node_hi",
         "_node_left",
         "_node_lo",
         "_node_right",
-        "n_cells",
-        "n_nodes",
-        "ndim",
     )
-
-    #: Spatial dimension of the indexed AABBs (``>= 1``).
-    ndim: int
-    #: Number of cells indexed (equal to the number of leaves).
-    n_cells: int
-    #: Total number of nodes (``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``).
-    n_nodes: int
 
     def __init__(  # noqa: PLR0913 -- BVH is a five-array flat struct
         self,
@@ -189,23 +331,16 @@ class BVH:
         node_left: npt.NDArray[np.int64],
         node_right: npt.NDArray[np.int64],
         node_cell: npt.NDArray[np.int64],
-        *,
         n_cells: int,
     ) -> None:
         """Store the raw BVH arrays after validating their shapes.
 
-        Callers should prefer :meth:`from_cell_bounds`; this constructor is
-        useful for tests that need to poke specific tree shapes.
-
         Args:
             node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners, shape
                 ``(n_nodes, ndim)``.
-            node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners, shape
-                ``(n_nodes, ndim)``.
-            node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on
-                leaves. Shape ``(n_nodes,)``.
-            node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on
-                leaves.
+            node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners, same shape.
+            node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on leaves.
+            node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on leaves.
             node_cell (npt.NDArray[np.int64]): Leaf cell identifiers; ``-1`` on
                 internal nodes.
             n_cells (int): Number of indexed cells (leaves).
@@ -219,28 +354,9 @@ class BVH:
                 range, or if the tree's root-to-leaf depth exceeds the traversal
                 kernels' stack depth (``_BVH_STACK_DEPTH``).
         """
-        if node_lo.dtype != np.float64 or node_hi.dtype != np.float64:
-            raise TypeError(
-                f"node_lo / node_hi must be float64; got {node_lo.dtype!r} / {node_hi.dtype!r}."
-            )
-        if node_lo.ndim != 2:  # noqa: PLR2004
-            raise ValueError(f"node_lo must be 2-D (n_nodes, ndim); got shape {node_lo.shape}.")
-        if node_hi.shape != node_lo.shape:
-            raise ValueError(
-                f"node_hi shape {node_hi.shape} must match node_lo shape {node_lo.shape}."
-            )
-        n_nodes, ndim = int(node_lo.shape[0]), int(node_lo.shape[1])
-        if ndim < 1:
-            raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
-        for arr, name in (
-            (node_left, "node_left"),
-            (node_right, "node_right"),
-            (node_cell, "node_cell"),
-        ):
-            if arr.dtype != np.int64:
-                raise TypeError(f"{name} must be int64; got {arr.dtype!r}.")
-            if arr.shape != (n_nodes,):
-                raise ValueError(f"{name} must have shape ({n_nodes},); got {arr.shape}.")
+        n_nodes, ndim = _validate_node_array_types(
+            node_lo, node_hi, node_left, node_right, node_cell
+        )
         n_cells_int = int(n_cells)
         expected_nodes = 2 * n_cells_int - 1 if n_cells_int > 0 else 0
         if n_nodes != expected_nodes:
@@ -278,53 +394,41 @@ class BVH:
             self._node_cell,
         ):
             arr_ro.flags.writeable = False
-        self.ndim = ndim
-        self.n_cells = n_cells_int
-        self.n_nodes = n_nodes
+        self._ndim = ndim
+        self._n_cells = n_cells_int
+        self._n_nodes = n_nodes
 
     @classmethod
     def from_cell_bounds(
         cls,
-        cell_lo: npt.ArrayLike,
-        cell_hi: npt.ArrayLike,
+        cell_lo: npt.NDArray[np.float64],
+        cell_hi: npt.NDArray[np.float64],
     ) -> Self:
         """Build a BVH over ``n_cells`` axis-aligned cell AABBs.
 
-        Uses a top-down recursive median-of-longest-axis split. Cells are sorted
-        by centroid on the longest axis; the median splits the list into two
-        halves of equal size (``+/- 1``). Each leaf indexes exactly one cell.
+        Uses a top-down median-of-longest-axis split. Cells are sorted by centroid
+        on the longest axis; the median splits the list into two halves of equal
+        size (``+/- 1``). Each leaf indexes exactly one cell.
 
         Args:
-            cell_lo (npt.ArrayLike): Per-cell lo corners; shape
-                ``(n_cells, ndim)`` with ``ndim >= 1``. Validated, not mutated.
-            cell_hi (npt.ArrayLike): Per-cell hi corners; same shape and
-                conventions as ``cell_lo``. Each entry must satisfy
-                ``cell_hi >= cell_lo``.
+            cell_lo (npt.NDArray[np.float64]): Per-cell lo corners, shape
+                ``(n_cells, ndim)``, already ``float64`` and shape-checked.
+            cell_hi (npt.NDArray[np.float64]): Per-cell hi corners, same shape.
 
         Returns:
             Self: The constructed hierarchy.
 
         Raises:
-            TypeError: If inputs cannot be cast to ``float64``.
-            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, any cell
-                has ``hi < lo``, or the implied tree exceeds the internal stack
-                depth.
+            ValueError: If any cell corner is non-finite, if some cell has
+                ``hi < lo``, or if the implied tree exceeds the internal stack depth.
         """
-        lo = _as_float64(cell_lo, name="cell_lo")
-        hi = _as_float64(cell_hi, name="cell_hi")
-        if lo.ndim != 2:  # noqa: PLR2004
-            raise ValueError(f"cell_lo must be 2-D (n_cells, ndim); got shape {lo.shape}.")
-        if hi.shape != lo.shape:
-            raise ValueError(f"cell_hi shape {hi.shape} must match cell_lo shape {lo.shape}.")
-        n_cells, ndim = int(lo.shape[0]), int(lo.shape[1])
-        if ndim < 1:
-            raise ValueError(f"BVH ndim must be >= 1; got {ndim}.")
-        if not np.all(np.isfinite(lo)) or not np.all(np.isfinite(hi)):
+        n_cells, ndim = int(cell_lo.shape[0]), int(cell_lo.shape[1])
+        if not np.all(np.isfinite(cell_lo)) or not np.all(np.isfinite(cell_hi)):
             raise ValueError(
                 "BVH.from_cell_bounds: cell_lo and cell_hi must contain only finite "
                 "values; got NaN or Inf."
             )
-        if np.any(hi < lo):
+        if np.any(cell_hi < cell_lo):
             raise ValueError(
                 "Every cell must satisfy cell_hi >= cell_lo on every axis; "
                 "at least one cell violates this."
@@ -333,7 +437,7 @@ class BVH:
             empty_lo = np.zeros((0, ndim), dtype=np.float64)
             empty_hi = np.zeros((0, ndim), dtype=np.float64)
             empty_i = np.zeros(0, dtype=np.int64)
-            return cls(empty_lo, empty_hi, empty_i, empty_i, empty_i, n_cells=0)
+            return cls(empty_lo, empty_hi, empty_i, empty_i, empty_i, 0)
         # Guard against the fixed-depth Numba stack in :mod:`pantr.grid._bvh_core`.
         # Median-of-longest-axis splits produce a balanced tree of height
         # ``ceil(log2(n_cells)) + 1``; the ``+ 1`` accounts for the root push.
@@ -350,33 +454,39 @@ class BVH:
         node_left = np.full(max_nodes, -1, dtype=np.int64)
         node_right = np.full(max_nodes, -1, dtype=np.int64)
         node_cell = np.full(max_nodes, -1, dtype=np.int64)
-        bvh_build_kernel()(lo, hi, node_lo, node_hi, node_left, node_right, node_cell)
-        return cls(node_lo, node_hi, node_left, node_right, node_cell, n_cells=n_cells)
+        bvh_build_kernel()(cell_lo, cell_hi, node_lo, node_hi, node_left, node_right, node_cell)
+        return cls(node_lo, node_hi, node_left, node_right, node_cell, n_cells)
 
-    def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
-        """Return the ids of every leaf cell whose AABB overlaps ``aabb``.
+    def query_aabb(
+        self, qlo: npt.NDArray[np.float64], qhi: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.int64]:
+        """Return the ids of every leaf cell the query box is not separated from.
+
+        Takes two corner arrays rather than an :class:`~pantr.geometry.AABB`, so
+        that this class and the C++ type present one surface to :class:`BVH`.
 
         Args:
-            aabb (AABB): Query box; must match :attr:`ndim`.
+            qlo (npt.NDArray[np.float64]): Query box lo corner, length ``ndim``.
+            qhi (npt.NDArray[np.float64]): Query box hi corner, same length.
 
         Returns:
-            npt.NDArray[np.int64]: Overlapping cell ids. Order matches the
-            internal preorder traversal; callers that need a particular order
-            should sort the result.
+            npt.NDArray[np.int64]: Matching cell ids, in the traversal's own order.
 
         Raises:
-            ValueError: If ``aabb.ndim != self.ndim``.
+            ValueError: If the corners do not have length :attr:`ndim`.
+            RuntimeError: If the count and emit passes disagree.
         """
-        if aabb.ndim != self.ndim:
+        if qlo.shape[0] != self._ndim:
             raise ValueError(
-                f"BVH.query_aabb: aabb.ndim ({aabb.ndim}) must match self.ndim ({self.ndim})."
+                f"BVH.query_aabb: aabb.ndim ({qlo.shape[0]}) must match self.ndim "
+                f"({self._ndim})."
             )
-        if self.n_cells == 0:
+        if self._n_cells == 0:
             return np.zeros(0, dtype=np.int64)
         count = int(
             bvh_query_count_kernel()(
-                aabb.lo,
-                aabb.hi,
+                qlo,
+                qhi,
                 self._node_lo,
                 self._node_hi,
                 self._node_left,
@@ -389,8 +499,8 @@ class BVH:
             return out
         written = int(
             bvh_query_emit_kernel()(
-                aabb.lo,
-                aabb.hi,
+                qlo,
+                qhi,
                 self._node_lo,
                 self._node_hi,
                 self._node_left,
@@ -405,6 +515,33 @@ class BVH:
                 f"emit pass wrote {written}). This is a bug in the BVH kernel; please report it."
             )
         return out
+
+    @property
+    def ndim(self) -> int:
+        """Get the spatial dimension of the indexed AABBs.
+
+        Returns:
+            int: The number of axes (``>= 1``).
+        """
+        return self._ndim
+
+    @property
+    def n_cells(self) -> int:
+        """Get the number of cells indexed.
+
+        Returns:
+            int: Equal to the number of leaves.
+        """
+        return self._n_cells
+
+    @property
+    def n_nodes(self) -> int:
+        """Get the total number of nodes.
+
+        Returns:
+            int: ``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``.
+        """
+        return self._n_nodes
 
     @property
     def node_lo(self) -> npt.NDArray[np.float64]:
@@ -451,6 +588,372 @@ class BVH:
             nodes, ``0 <= id < n_cells`` on leaves.
         """
         return self._node_cell
+
+
+def _impl_class() -> type[_BVHPython] | type[_CppBVH]:
+    """The implementation class the active backend selects.
+
+    Returns:
+        type[_BVHPython] | type[_CppBVH]: :class:`_BVHPython` under the Python
+        backend, the bound C++ class otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if _python_backend_selected():
+        return _BVHPython
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.BVH
+
+
+def _capacity_error() -> type[BaseException]:
+    """The exception the C++ type raises for a tree its traversal stack cannot hold.
+
+    Imported lazily and only on the C++ path, so a tree with no compiled extension
+    never reaches it.
+
+    Returns:
+        type[BaseException]: ``pantr._pantr_cpp.CapacityError``.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.CapacityError
+
+
+def _rebuild_bvh(  # noqa: PLR0913 -- BVH is a five-array flat struct
+    node_lo: npt.NDArray[np.float64],
+    node_hi: npt.NDArray[np.float64],
+    node_left: npt.NDArray[np.int64],
+    node_right: npt.NDArray[np.int64],
+    node_cell: npt.NDArray[np.int64],
+    n_cells: int,
+) -> BVH:
+    """Rebuild a :class:`BVH` from its five arrays and its cell count.
+
+    The reconstruction :meth:`BVH.__reduce__` names. A module-level function rather
+    than the class itself, because ``n_cells`` is keyword-only on the constructor
+    and a ``__reduce__`` argument tuple is positional.
+
+    Args:
+        node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners.
+        node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners.
+        node_left (npt.NDArray[np.int64]): Left-child indices.
+        node_right (npt.NDArray[np.int64]): Right-child indices.
+        node_cell (npt.NDArray[np.int64]): Leaf cell identifiers.
+        n_cells (int): Number of indexed cells.
+
+    Returns:
+        BVH: The rebuilt hierarchy, holding whichever implementation the *reading*
+        process's backend selects.
+    """
+    return BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=n_cells)
+
+
+class BVH:
+    """Bounding-volume hierarchy indexing a fixed collection of AABBs.
+
+    Instances are immutable: the node arrays are read-only and the three counts are
+    read-only properties. Queries allocate fresh ``int64`` output arrays per call.
+
+    Build by passing per-cell AABBs to :meth:`from_cell_bounds`; direct
+    construction from the raw array representation is supported via the default
+    constructor but is mostly intended for tests and round-trip serialization.
+
+    **This class is a wrapper**, holding a hierarchy owned by the C++ core (or, under
+    ``PANTR_BACKEND=python``, a :class:`_BVHPython`). See the module docstring for
+    the ownership rule, for where validation lives, and for what the overlap
+    predicate actually tests.
+
+    Attributes:
+        ndim (int): Spatial dimension of the indexed AABBs (``>= 1``).
+        n_cells (int): Number of cells indexed (equal to the number of leaves).
+        n_nodes (int): Total number of nodes (``2 * n_cells - 1``, else ``0``).
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_impl_class`."""
+
+    def __init__(  # noqa: PLR0913 -- BVH is a five-array flat struct
+        self,
+        node_lo: npt.NDArray[np.float64],
+        node_hi: npt.NDArray[np.float64],
+        node_left: npt.NDArray[np.int64],
+        node_right: npt.NDArray[np.int64],
+        node_cell: npt.NDArray[np.int64],
+        *,
+        n_cells: int,
+    ) -> None:
+        """Store the raw BVH arrays after validating their shapes.
+
+        Callers should prefer :meth:`from_cell_bounds`; this constructor is
+        useful for tests that need to poke specific tree shapes.
+
+        Args:
+            node_lo (npt.NDArray[np.float64]): Per-node AABB lo corners, shape
+                ``(n_nodes, ndim)``.
+            node_hi (npt.NDArray[np.float64]): Per-node AABB hi corners, shape
+                ``(n_nodes, ndim)``.
+            node_left (npt.NDArray[np.int64]): Left-child indices; ``-1`` on
+                leaves. Shape ``(n_nodes,)``.
+            node_right (npt.NDArray[np.int64]): Right-child indices; ``-1`` on
+                leaves.
+            node_cell (npt.NDArray[np.int64]): Leaf cell identifiers; ``-1`` on
+                internal nodes.
+            n_cells (int): Number of indexed cells (leaves).
+
+        Raises:
+            TypeError: If any array has the wrong dtype.
+            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``,
+                ``n_nodes != 2 * n_cells - 1`` (``0`` when ``n_cells == 0``), if
+                ``node_cell`` and the child pointers disagree about which nodes are
+                leaves, if an internal node's children or a leaf's cell id are out of
+                range, or if the tree's root-to-leaf depth exceeds the traversal
+                kernels' stack depth (``_BVH_STACK_DEPTH``).
+        """
+        _validate_node_array_types(node_lo, node_hi, node_left, node_right, node_cell)
+        cls = _impl_class()
+        if cls is _BVHPython:
+            impl: _Impl = _BVHPython(
+                node_lo, node_hi, node_left, node_right, node_cell, int(n_cells)
+            )
+        else:
+            try:
+                impl = cls(
+                    np.ascontiguousarray(node_lo),
+                    np.ascontiguousarray(node_hi),
+                    np.ascontiguousarray(node_left),
+                    np.ascontiguousarray(node_right),
+                    np.ascontiguousarray(node_cell),
+                    int(n_cells),
+                )
+            except _capacity_error() as exc:
+                # The C++ type reports the traversal-stack limit as CapacityError,
+                # which is right for a C++ caller: the tree is well formed and this
+                # build cannot walk it. The pre-port class raised ValueError with
+                # this same text, and PANTR_BACKEND must not decide which exception
+                # a caller catches, so the wrapper presents the class it always did.
+                # A seam: it lives exactly as long as the Python backend does.
+                raise ValueError(str(exc)) from exc
+        object.__setattr__(self, "_impl", impl)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Reject post-construction attribute writes.
+
+        ``ndim``, ``n_cells`` and ``n_nodes`` were public writable attributes before
+        the port, while the class docstring said instances were immutable.
+        ``bvh.ndim = 7`` defeated the dimension check in :meth:`query_aabb`, and the
+        kernels then indexed a mis-shaped array.
+
+        Args:
+            name (str): The attribute being set.
+            value (object): The value it would take.
+
+        Raises:
+            AttributeError: Always -- :class:`BVH` is immutable.
+        """
+        raise AttributeError(f"BVH is immutable; cannot set attribute {name!r}.")
+
+    def __delattr__(self, name: str) -> None:
+        """Reject attribute deletion.
+
+        Args:
+            name (str): The attribute being deleted.
+
+        Raises:
+            AttributeError: Always -- :class:`BVH` is immutable.
+        """
+        raise AttributeError(f"BVH is immutable; cannot delete attribute {name!r}.")
+
+    @classmethod
+    def _wrap(cls, impl: _Impl) -> BVH:
+        """Wrap an implementation object that is already valid.
+
+        Args:
+            impl (_Impl): The implementation object to adopt.
+
+        Returns:
+            BVH: A wrapper around ``impl``, with no re-validation.
+        """
+        self = object.__new__(cls)
+        object.__setattr__(self, "_impl", impl)
+        return self
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        """Pickle by the five node arrays, never by the implementation.
+
+        The C++ handle is not picklable and must not become part of the wire format:
+        a pickle written under one backend has to load under the other, or the
+        backend switch would silently become a data-format switch.
+
+        Returns:
+            tuple: :func:`_rebuild_bvh` and the arrays to rebuild from.
+        """
+        return (
+            _rebuild_bvh,
+            (
+                self.node_lo,
+                self.node_hi,
+                self.node_left,
+                self.node_right,
+                self.node_cell,
+                self.n_cells,
+            ),
+        )
+
+    def __repr__(self) -> str:
+        """Return a compact representation naming the three counts.
+
+        Formatted here rather than by the implementation, so that the two backends
+        print identically. The node arrays are left out: there are five of them and
+        ``2 * n_cells - 1`` rows in each.
+
+        Returns:
+            str: ``"BVH(n_cells=..., n_nodes=..., ndim=...)"``.
+        """
+        return f"BVH(n_cells={self.n_cells}, n_nodes={self.n_nodes}, ndim={self.ndim})"
+
+    @staticmethod
+    def from_cell_bounds(cell_lo: npt.ArrayLike, cell_hi: npt.ArrayLike) -> BVH:
+        """Build a BVH over ``n_cells`` axis-aligned cell AABBs.
+
+        Uses a top-down median-of-longest-axis split. Cells are sorted by centroid
+        on the longest axis; the median splits the list into two halves of equal
+        size (``+/- 1``). Each leaf indexes exactly one cell.
+
+        Args:
+            cell_lo (npt.ArrayLike): Per-cell lo corners; shape
+                ``(n_cells, ndim)`` with ``ndim >= 1``. Validated, not mutated.
+            cell_hi (npt.ArrayLike): Per-cell hi corners; same shape and
+                conventions as ``cell_lo``. Each entry must satisfy
+                ``cell_hi >= cell_lo``.
+
+        Returns:
+            BVH: The constructed hierarchy.
+
+        Raises:
+            TypeError: If inputs cannot be cast to ``float64``.
+            ValueError: If shapes are inconsistent, ``ndim`` is ``< 1``, any cell
+                has ``hi < lo``, or the implied tree exceeds the internal stack
+                depth.
+        """
+        lo, hi = _validate_cell_bounds(cell_lo, cell_hi)
+        cls = _impl_class()
+        if cls is _BVHPython:
+            return BVH._wrap(_BVHPython.from_cell_bounds(lo, hi))
+        try:
+            return BVH._wrap(cls.from_cell_bounds(lo, hi))
+        except _capacity_error() as exc:
+            # See BVH.__init__ for why the class is translated back.
+            raise ValueError(str(exc)) from exc
+
+    def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
+        """Return the ids of every leaf cell the query box is not separated from.
+
+        The predicate is inclusive on every face and has **no emptiness branch**, so
+        it is not :meth:`pantr.geometry.AABB.overlaps`; the module docstring gives
+        the case where the two disagree.
+
+        Args:
+            aabb (AABB): Query box; must match :attr:`ndim`.
+
+        Returns:
+            npt.NDArray[np.int64]: Matching cell ids. Order matches the
+            internal preorder traversal; callers that need a particular order
+            should sort the result.
+
+        Raises:
+            ValueError: If ``aabb.ndim != self.ndim``.
+        """
+        qlo = np.ascontiguousarray(aabb.lo, dtype=np.float64)
+        qhi = np.ascontiguousarray(aabb.hi, dtype=np.float64)
+        return np.asarray(self._impl.query_aabb(qlo, qhi), dtype=np.int64)
+
+    @property
+    def ndim(self) -> int:
+        """Get the spatial dimension of the indexed AABBs.
+
+        Returns:
+            int: The number of axes (``>= 1``).
+        """
+        return int(self._impl.ndim)
+
+    @property
+    def n_cells(self) -> int:
+        """Get the number of cells indexed.
+
+        Returns:
+            int: Equal to the number of leaves.
+        """
+        return int(self._impl.n_cells)
+
+    @property
+    def n_nodes(self) -> int:
+        """Get the total number of nodes.
+
+        Returns:
+            int: ``2 * n_cells - 1`` for ``n_cells > 0``, else ``0``.
+        """
+        return int(self._impl.n_nodes)
+
+    @property
+    def node_lo(self) -> npt.NDArray[np.float64]:
+        """Get the read-only view of per-node AABB lo corners.
+
+        Under the C++ backend this aliases the hierarchy's own storage rather than
+        copying it, which is what the pre-port class also handed back, and it is
+        read-only against accident rather than against malice -- ``ctypes`` clears
+        the flag in two lines. ``bvh_tree.hpp`` records what that costs under issue
+        #359: on that backend a corrupted index is undefined behaviour, where the
+        numba kernel merely returns a defined wrong answer.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(n_nodes, ndim)``.
+        """
+        return self._impl.node_lo
+
+    @property
+    def node_hi(self) -> npt.NDArray[np.float64]:
+        """Get the read-only view of per-node AABB hi corners.
+
+        Returns:
+            npt.NDArray[np.float64]: Shape ``(n_nodes, ndim)``. See
+            :attr:`node_lo` for the aliasing contract.
+        """
+        return self._impl.node_hi
+
+    @property
+    def node_left(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-node left-child indices.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on leaves. See
+            :attr:`node_lo` for the aliasing contract.
+        """
+        return self._impl.node_left
+
+    @property
+    def node_right(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-node right-child indices.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on leaves. See
+            :attr:`node_lo` for the aliasing contract.
+        """
+        return self._impl.node_right
+
+    @property
+    def node_cell(self) -> npt.NDArray[np.int64]:
+        """Get the read-only view of per-leaf cell identifiers.
+
+        Returns:
+            npt.NDArray[np.int64]: Shape ``(n_nodes,)``; ``-1`` on internal
+            nodes, ``0 <= id < n_cells`` on leaves. See :attr:`node_lo` for the
+            aliasing contract.
+        """
+        return self._impl.node_cell
 
 
 __all__ = ["BVH"]

--- a/src/pantr/grid/_bvh_core.py
+++ b/src/pantr/grid/_bvh_core.py
@@ -27,9 +27,20 @@ median-split BVH has height ``ceil(log2(N)) + 1``; depth 128 covers any
 realistic cell count on a single process. Layer 2 validates the depth bound at
 construction time so the kernels never overflow their stack.
 
-The AABB overlap test is inclusive on every face so that a query box sharing a
-face with a cell is reported as overlapping, matching
-:meth:`pantr.geometry.AABB.overlaps`.
+The AABB overlap test is a **separating-axis test and nothing else**: it reports a
+match unless some axis separates the two intervals, comparing inclusively, so a
+query box sharing a face with a cell is reported.
+
+**It is not** :meth:`pantr.geometry.AABB.overlaps`, and this docstring used to say
+it was. The box short-circuits on an *empty* operand and reports that an empty box
+overlaps nothing; the kernels below have no such branch, so a reversed query
+interval that a cell's interval contains passes every separating-axis check and the
+leaf is reported. One cell ``[0, 10]`` in one dimension, queried with
+``lo = 5, hi = 3``, returns cell ``0`` here and ``False`` from the box. Both
+backends behave this way and agree with each other; the claim of agreement with the
+box is withdrawn rather than the behaviour changed, because reconciling the two
+predicates has to move both backends at once or the parity claim stops being an
+equality.
 
 Note:
     Inputs are assumed to be correct (no validation performed).

--- a/src/pantr/grid/_grid_utils.py
+++ b/src/pantr/grid/_grid_utils.py
@@ -10,12 +10,45 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._backend import Backend, active_backend, available_backends
 from ..geometry import _as_float64
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-__all__ = ["_as_float64", "_mask_nonfinite_locate"]
+__all__ = ["_as_float64", "_mask_nonfinite_locate", "_python_backend_selected"]
+
+
+def _python_backend_selected() -> bool:
+    """Report whether a wrapped grid type should hold its Python implementation.
+
+    The types this package owns -- :class:`~pantr.grid.CellTags`,
+    :class:`~pantr.grid.FacetTags`, :class:`~pantr.grid.Partition` and
+    :class:`~pantr.grid.BVH` -- all choose an implementation the same way, so the
+    policy is written once here rather than once per type. Each type keeps its own
+    ``_impl_class``, because only that function knows which two classes are on
+    offer; what is shared is the question, not the answer.
+
+    **The choice is per process, not per instance**, and that is load-bearing:
+    :mod:`pantr.geometry` argues it at length for :class:`~pantr.geometry.AABB` and
+    the argument carries over unchanged. Two objects built under different backends
+    could otherwise meet in one operation, and reconciling them would mean
+    converting one implementation into the other -- the shape
+    ``design/cross_backend_types.md`` forbids.
+
+    Returns:
+        bool: ``True`` under the Python backend, ``False`` when the C++ one is
+        selected and available.
+
+    Raises:
+        RuntimeError: If the C++ backend is selected and is not available. An
+            explicit request never falls back silently.
+    """
+    if active_backend() is Backend.PYTHON:
+        return True
+    if Backend.CPP not in available_backends():
+        raise RuntimeError("the CPP backend is not available in this installation")
+    return False
 
 
 def _mask_nonfinite_locate(pts: npt.NDArray[np.floating[Any]], out: npt.NDArray[np.int64]) -> None:

--- a/src/pantr/grid/_partition.py
+++ b/src/pantr/grid/_partition.py
@@ -5,26 +5,99 @@ B-spline space), which rank owns it -- the serial, communication-free descriptor
 consumed by the distributed-space machinery. It is produced either by consuming an
 external partition (for example a dolfinx mesh) or by a native graph partitioner,
 and is intentionally space-agnostic: it stores only an integer owner per cell.
+
+A wrapper
+---------
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the partition
+itself is owned by the C++ core (``cpp/include/pantr/grid/partition.hpp``) and this
+class holds one. Ownership moved rather than being duplicated: there is one
+implementation of a partition and one Python class in front of it. Under
+``PANTR_BACKEND=python`` the thing held is :class:`_PartitionPython`, which is the
+Python **backend** and not merely an oracle -- most of CI runs on it, and
+:mod:`pantr.mpi` builds a partition on every rank.
+
+Where the validation lives
+--------------------------
+
+Following the rule ``cpp/include/pantr/core/error.hpp`` states for the whole port:
+the **dtype and rank** check ("``cell_owner`` must be a 1D integer array") is here,
+because both facts are gone by the time the binding hands C++ a span, and so is the
+narrowing cast to ``int32`` that the pre-port class performed; the **value** checks
+-- ``n_parts >= 1``, every owner in ``[-1, n_parts)``, and ``owned_cells``' rank
+range -- live in the C++ type, where a caller with no interpreter is protected by
+them too.
+
+One consequence, stated rather than left to be discovered: the pre-port class
+checked ``n_parts`` *before* it looked at ``cell_owner``, and the coercion here now
+runs first. An argument that violates **both** contracts at once therefore reports
+the array complaint where it used to report the ``n_parts`` one. Both are
+``ValueError``, both backends agree with each other, and every input that violates
+only one contract is unaffected.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 import numpy as np
+
+from ._grid_utils import _python_backend_selected
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from pantr._pantr_cpp import Partition as _CppPartition
 
-class Partition:
-    """A per-cell owner assignment over a grid's cells.
+    _Impl: TypeAlias = "_PartitionPython | _CppPartition"
+    """The implementation a :class:`Partition` holds: the Python one, or the C++ one.
 
-    Records, for every cell, the rank that owns it -- or ``-1`` for an inactive cell
-    excluded from the partition (e.g. an exterior / trimmed cell). The owner array is
-    coerced to a read-only ``int32`` array on construction and the object is otherwise
-    immutable. Owners and counts are exposed through the :attr:`cell_owner`,
-    :attr:`n_parts`, :attr:`n_cells`, and :attr:`active_mask` properties.
+    Type-checking only. The two are unrelated nominal types that happen to offer the
+    same surface, which is the port's whole claim; naming the union here is what
+    lets the checker verify it instead of taking it on trust.
+    """
+
+
+def _as_int32_owners(cell_owner: npt.ArrayLike) -> npt.NDArray[np.int32]:
+    """Coerce ``cell_owner`` to a C-contiguous 1-D ``int32`` array.
+
+    The cast is narrowing, and that is the pre-port behaviour reproduced
+    deliberately: an owner above ``2**31 - 1`` wraps here and is then rejected by
+    the range check in the C++ type, in that order, under either backend.
+
+    Args:
+        cell_owner (npt.ArrayLike): Per-cell owner ranks.
+
+    Returns:
+        npt.NDArray[np.int32]: The owners, 1-D, ``int32`` and C-contiguous.
+
+    Raises:
+        ValueError: If ``cell_owner`` is not a 1-D integer array.
+    """
+    owner = np.asarray(cell_owner)
+    if owner.ndim != 1 or not np.issubdtype(owner.dtype, np.integer):
+        raise ValueError("cell_owner must be a 1D integer array.")
+    return np.ascontiguousarray(owner, dtype=np.int32)
+
+
+class _PartitionPython:
+    """The pure-Python partition: the backend under ``PANTR_BACKEND=python``.
+
+    This was the public :class:`Partition` until the 2026-08-27 amendment to
+    ``design/cross_backend_types.md`` made the partition a C++-owned type. It is not
+    merely a parity oracle: :func:`_impl_class` returns it whenever the Python
+    backend is selected, which is how the package still works in a tree with no
+    compiled extension.
+
+    Its surface is deliberately the C++ type's, so that :class:`Partition` can call
+    the same methods on either. :attr:`Partition.active_mask` is therefore not here:
+    it is one comparison over :attr:`cell_owner`, computed by the wrapper so that
+    the two backends cannot get it differently.
+
+    Attributes:
+        cell_owner (npt.NDArray[np.int32]): Per-cell owners, read-only.
+        n_parts (int): Number of parts (ranks).
+        n_cells (int): Number of cells.
     """
 
     __slots__ = ("_cell_owner", "_n_parts")
@@ -43,10 +116,7 @@ class Partition:
         """
         if n_parts < 1:
             raise ValueError(f"n_parts must be >= 1; got {n_parts}.")
-        owner = np.asarray(cell_owner)
-        if owner.ndim != 1 or not np.issubdtype(owner.dtype, np.integer):
-            raise ValueError("cell_owner must be a 1D integer array.")
-        owner = np.ascontiguousarray(owner, dtype=np.int32)
+        owner = _as_int32_owners(cell_owner)
         if owner.size and (int(owner.min()) < -1 or int(owner.max()) >= n_parts):
             raise ValueError(
                 f"cell_owner values must lie in [-1, {n_parts}); "
@@ -83,16 +153,6 @@ class Partition:
         """
         return int(self._cell_owner.shape[0])
 
-    @property
-    def active_mask(self) -> npt.NDArray[np.bool_]:
-        r"""Get a boolean mask of the active cells (owned by some rank).
-
-        Returns:
-            npt.NDArray[np.bool\_]: Fresh ``(n_cells,)`` mask; ``True`` where the cell
-            owner is not ``-1``.
-        """
-        return self._cell_owner >= 0
-
     def owned_cells(self, rank: int) -> npt.NDArray[np.int64]:
         """Return the flat ids of the cells owned by ``rank``, ascending.
 
@@ -108,6 +168,195 @@ class Partition:
         if not 0 <= rank < self._n_parts:
             raise ValueError(f"rank must be in [0, {self._n_parts}); got {rank}.")
         return np.flatnonzero(self._cell_owner == rank).astype(np.int64)
+
+
+def _impl_class() -> type[_PartitionPython] | type[_CppPartition]:
+    """The implementation class the active backend selects.
+
+    Returns:
+        type[_PartitionPython] | type[_CppPartition]: :class:`_PartitionPython`
+        under the Python backend, the bound C++ class otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if _python_backend_selected():
+        return _PartitionPython
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.Partition
+
+
+def _new_impl(cell_owner: npt.ArrayLike, n_parts: int) -> _Impl:
+    """Build a partition in whichever implementation the active backend selects.
+
+    Args:
+        cell_owner (npt.ArrayLike): Per-cell owner ranks.
+        n_parts (int): Number of parts (ranks).
+
+    Returns:
+        _Impl: The implementation object; a :class:`_PartitionPython` or a C++
+        handle.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    cls = _impl_class()
+    if cls is _PartitionPython:
+        return _PartitionPython(cell_owner, n_parts)
+    return cls(_as_int32_owners(cell_owner), int(n_parts))
+
+
+class Partition:
+    """A per-cell owner assignment over a grid's cells.
+
+    Records, for every cell, the rank that owns it -- or ``-1`` for an inactive cell
+    excluded from the partition (e.g. an exterior / trimmed cell). The owner array is
+    coerced to a read-only ``int32`` array on construction and the object is otherwise
+    immutable. Owners and counts are exposed through the :attr:`cell_owner`,
+    :attr:`n_parts`, :attr:`n_cells`, and :attr:`active_mask` properties.
+
+    **This class is a wrapper**, holding a partition owned by the C++ core (or, under
+    ``PANTR_BACKEND=python``, a :class:`_PartitionPython`). See the module docstring
+    for the ownership rule and for where validation lives.
+
+    Attributes:
+        cell_owner (npt.NDArray[np.int32]): Per-cell owners, read-only.
+        n_parts (int): Number of parts (ranks).
+        n_cells (int): Number of cells.
+        active_mask (npt.NDArray[np.bool_]): Which cells some rank owns.
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _Impl
+    """The implementation this wrapper holds; see :func:`_impl_class`."""
+
+    def __init__(self, cell_owner: npt.ArrayLike, n_parts: int) -> None:
+        """Build a partition from a per-cell owner array.
+
+        Args:
+            cell_owner (npt.ArrayLike): Per-cell owner ranks (``-1`` for inactive
+                cells); coerced to a read-only 1D ``int32`` array.
+            n_parts (int): Number of parts (ranks); must be ``>= 1``.
+
+        Raises:
+            ValueError: If ``n_parts < 1``, ``cell_owner`` is not 1D integer, or any
+                owner is outside ``[-1, n_parts)``.
+        """
+        object.__setattr__(self, "_impl", _new_impl(cell_owner, n_parts))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Reject post-construction attribute writes.
+
+        Args:
+            name (str): The attribute being set.
+            value (object): The value it would take.
+
+        Raises:
+            AttributeError: Always -- :class:`Partition` is immutable.
+        """
+        raise AttributeError(f"Partition is immutable; cannot set attribute {name!r}.")
+
+    def __delattr__(self, name: str) -> None:
+        """Reject attribute deletion.
+
+        Args:
+            name (str): The attribute being deleted.
+
+        Raises:
+            AttributeError: Always -- :class:`Partition` is immutable.
+        """
+        raise AttributeError(f"Partition is immutable; cannot delete attribute {name!r}.")
+
+    def __reduce__(self) -> tuple[type[Partition], tuple[npt.NDArray[np.int32], int]]:
+        """Pickle by the constructor's own arguments, never by the implementation.
+
+        The C++ handle is not picklable and must not become part of the wire
+        format: a pickle written under one backend has to load under the other, or
+        the backend switch would silently become a data-format switch. This one is
+        load-bearing beyond that -- :mod:`pantr.mpi` moves a partition between ranks
+        through ``mpi4py``, which pickles.
+
+        Returns:
+            tuple: The class and the ``(cell_owner, n_parts)`` pair to rebuild it
+            from.
+        """
+        return (type(self), (self.cell_owner, self.n_parts))
+
+    def __repr__(self) -> str:
+        """Return a compact representation naming the two counts.
+
+        Formatted here rather than by the implementation, so that the two backends
+        print identically. The owners are left out: there is one per cell, and a
+        partition over a real mesh would print a page of them.
+
+        Returns:
+            str: ``"Partition(n_cells=..., n_parts=...)"``.
+        """
+        return f"Partition(n_cells={self.n_cells}, n_parts={self.n_parts})"
+
+    @property
+    def cell_owner(self) -> npt.NDArray[np.int32]:
+        """Get the read-only per-cell owner array.
+
+        Under the C++ backend this is a zero-copy view into the partition's own
+        storage rather than a copy, which is what the pre-port class also handed
+        back. A partition has no mutator, so nothing can move that storage while a
+        view is alive.
+
+        Returns:
+            npt.NDArray[np.int32]: ``(n_cells,)`` owners; ``-1`` for inactive cells.
+        """
+        return self._impl.cell_owner
+
+    @property
+    def n_parts(self) -> int:
+        """Get the number of parts (ranks).
+
+        Returns:
+            int: The part count (``>= 1``).
+        """
+        return int(self._impl.n_parts)
+
+    @property
+    def n_cells(self) -> int:
+        """Get the total number of cells (active and inactive).
+
+        Returns:
+            int: Length of :attr:`cell_owner`.
+        """
+        return int(self._impl.n_cells)
+
+    @property
+    def active_mask(self) -> npt.NDArray[np.bool_]:
+        r"""Get a boolean mask of the active cells (owned by some rank).
+
+        Computed here rather than by the implementation: it is one comparison over
+        :attr:`cell_owner`, which both backends hand back as the same values, so
+        deriving it in one place is what makes it impossible for the two to
+        disagree.
+
+        Returns:
+            npt.NDArray[np.bool\_]: Fresh ``(n_cells,)`` mask; ``True`` where the cell
+            owner is not ``-1``.
+        """
+        return np.asarray(self.cell_owner >= 0)
+
+    def owned_cells(self, rank: int) -> npt.NDArray[np.int64]:
+        """Return the flat ids of the cells owned by ``rank``, ascending.
+
+        Args:
+            rank (int): Owner rank in ``[0, n_parts)``.
+
+        Returns:
+            npt.NDArray[np.int64]: A fresh, writeable array of the cell ids with
+            ``cell_owner == rank``, in increasing order.
+
+        Raises:
+            ValueError: If ``rank`` is outside ``[0, n_parts)``.
+        """
+        return np.asarray(self._impl.owned_cells(int(rank)), dtype=np.int64)
 
 
 __all__ = ["Partition"]

--- a/src/pantr/grid/_partition.py
+++ b/src/pantr/grid/_partition.py
@@ -29,11 +29,18 @@ range -- live in the C++ type, where a caller with no interpreter is protected b
 them too.
 
 One consequence, stated rather than left to be discovered: the pre-port class
-checked ``n_parts`` *before* it looked at ``cell_owner``, and the coercion here now
-runs first. An argument that violates **both** contracts at once therefore reports
-the array complaint where it used to report the ``n_parts`` one. Both are
-``ValueError``, both backends agree with each other, and every input that violates
-only one contract is unaffected.
+checked ``n_parts`` *before* it looked at ``cell_owner``, and :func:`_new_impl` now
+coerces first. An argument that violates **both** contracts at once therefore
+reports the array complaint where it used to report the ``n_parts`` one. Both are
+``ValueError``, and every input that violates only one contract is unaffected.
+
+**The coercion runs before the backend is chosen, and that is what makes the two
+agree.** Doing it inside the C++ branch alone left ``PANTR_BACKEND`` deciding which
+of two simultaneous violations a caller was told about --
+``Partition(numpy.array([1.5, 2.5]), 0)`` reported the ``n_parts`` complaint under
+the Python backend and the array one under C++. That is the one thing the backend
+switch must never change, and ``tests/test_grid_partition.py`` pins it on exactly
+that input.
 """
 
 from __future__ import annotations
@@ -201,10 +208,17 @@ def _new_impl(cell_owner: npt.ArrayLike, n_parts: int) -> _Impl:
     Raises:
         RuntimeError: If the C++ backend is requested and is not available.
     """
+    # Coerced BEFORE the backend is looked at, and that ordering is the contract
+    # rather than a convenience. Evaluating it inside the C++ branch alone made
+    # `PANTR_BACKEND` decide which of two simultaneous violations was reported --
+    # `Partition(numpy.array([1.5, 2.5]), 0)` said "n_parts must be >= 1" under one
+    # backend and "cell_owner must be a 1D integer array" under the other. Doing it
+    # once, unconditionally, is what `_bvh.py` and `_tags.py` already do.
+    owner = _as_int32_owners(cell_owner)
     cls = _impl_class()
     if cls is _PartitionPython:
-        return _PartitionPython(cell_owner, n_parts)
-    return cls(_as_int32_owners(cell_owner), int(n_parts))
+        return _PartitionPython(owner, n_parts)
+    return cls(owner, int(n_parts))
 
 
 class Partition:

--- a/src/pantr/grid/_tags.py
+++ b/src/pantr/grid/_tags.py
@@ -18,22 +18,94 @@ Both registries are created lazily by :class:`pantr.grid.Grid` and stay empty
 (zero per-cell footprint) until the first :meth:`set` call. Classification logic
 (deciding which cells are inside / outside / cut) is the consumer's
 responsibility; these classes only store the result.
+
+Both are wrappers
+-----------------
+
+Since the 2026-08-27 amendment to ``design/cross_backend_types.md`` the registries
+themselves are owned by the C++ core (``cpp/include/pantr/grid/tags.hpp``) and
+these classes hold one. Ownership moved rather than being duplicated: there is one
+implementation of a registry and one Python class in front of it. Under
+``PANTR_BACKEND=python`` the thing held is :class:`_CellTagsPython` or
+:class:`_FacetTagsPython` instead, which is the Python **backend** and not merely
+an oracle -- most of CI runs on it.
+
+Where the validation lives, and why it is in two places
+-------------------------------------------------------
+
+The split is honest rather than tidy, and ``cpp/include/pantr/core/error.hpp``
+states the rule for the whole port: **type-kind checks and key lookups stay in this
+wrapper; value and range checks live in the C++ type.** nanobind 2.14.0 has no path
+producing a ``TypeError`` and maps ``std::out_of_range`` to ``IndexError`` rather
+than ``KeyError``, so neither a dtype complaint nor a missing-name lookup could be
+raised from C++ with the message the oracle raises. So:
+
+- **here:** the integer-dtype checks on ``ids``, ``keys``, ``values`` and
+  ``to_dense``'s ``dtype`` (``TypeError``); the array *shape* checks, since a numpy
+  shape is gone by the time the binding hands C++ a span; the scalar broadcast;
+  ``KeyError`` for an unregistered name; and allocating and filling
+  :meth:`CellTags.to_dense`'s destination, because ``numpy.full`` is what decides
+  what an out-of-range ``fill`` does and reproducing its message by hand would be a
+  second spelling of numpy's own contract;
+- **in the type:** the id and key ranges, uniqueness, the two arrays' lengths, and
+  the ``OverflowError`` when a stored value does not fit the destination dtype.
+
+One consequence is worth stating rather than leaving to be discovered. The
+wrapper's coercions all run *before* the type's value checks, while the pre-port
+class interleaved them, so an input violating **two** contracts at once now reports
+the wrapper's complaint where it used to report the value one --
+``set("a", [5], [1, 2])`` on a five-cell grid, say, which is both out of range and
+the wrong length. The two backends agree with each other, which is what the backend
+switch has to guarantee; what changed is which of two simultaneous violations is
+named first.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
 import numpy as np
+
+from ._grid_utils import _python_backend_selected
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     import numpy.typing as npt
 
+    from pantr._pantr_cpp import CellTags as _CppCellTags
+    from pantr._pantr_cpp import FacetTags as _CppFacetTags
+
+    _CellImpl: TypeAlias = "_CellTagsPython | _CppCellTags"
+    """The implementation a :class:`CellTags` holds: the Python one, or the C++ one.
+
+    Type-checking only. The two are unrelated nominal types that happen to offer the
+    same surface, which is the port's whole claim; naming the union here is what
+    lets the checker verify it instead of taking it on trust.
+    """
+
+    _FacetImpl: TypeAlias = "_FacetTagsPython | _CppFacetTags"
+    """The implementation a :class:`FacetTags` holds. See :data:`_CellImpl`."""
+
+    _TagPair: TypeAlias = "tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]"
+    """A tag's two parallel arrays, as :meth:`CellTags.__getitem__` returns them."""
+
 
 # A facet key is the pair (cell_id, local_facet_id); stored as a (M, 2) array.
 _FACET_KEY_WIDTH: Final[int] = 2
+
+_NARROWER_THAN_INT64: Final[int] = 8
+"""Destination width, in bytes, at or above which ``to_dense`` runs no range check.
+
+Mirrors the `sizeof(IntT) < 8` condition in ``tags.hpp``, and both reproduce the
+pre-port class's `out_dtype.itemsize < 8`. It is sound for ``int64``, whose range
+contains every stored value, and unsound for ``uint64``, which is equally wide and
+still cannot hold a negative one -- so a negative tag value scattered into a
+``uint64`` destination wraps silently in both backends. Reproduced rather than
+fixed: the docstrings state the limit as the contract ("only raised when ``dtype``
+is narrower than ``int64``"), and closing it changes documented behaviour in both
+backends at once, which is not a port's decision to take.
+"""
 
 
 def _as_int64_1d(values: npt.ArrayLike, *, name: str) -> npt.NDArray[np.int64]:
@@ -56,6 +128,29 @@ def _as_int64_1d(values: npt.ArrayLike, *, name: str) -> npt.NDArray[np.int64]:
     arr = np.ascontiguousarray(arr.astype(np.int64, copy=False))
     if arr.ndim != 1:
         raise ValueError(f"{name} must be 1-D; got shape {arr.shape}.")
+    return arr
+
+
+def _as_int64_keys(keys: npt.ArrayLike) -> npt.NDArray[np.int64]:
+    """Coerce ``keys`` to a C-contiguous ``(M, 2)`` ``int64`` array.
+
+    Args:
+        keys (npt.ArrayLike): Integer array-like of ``(cell_id, local_facet_id)``
+            rows.
+
+    Returns:
+        npt.NDArray[np.int64]: The keys, ``(M, 2)`` and C-contiguous.
+
+    Raises:
+        TypeError: If ``keys`` does not have an integer dtype.
+        ValueError: If ``keys`` does not have shape ``(M, 2)``.
+    """
+    raw = np.asarray(keys)
+    if raw.dtype.kind not in ("i", "u"):
+        raise TypeError(f"keys must have an integer dtype; got {raw.dtype!r}.")
+    arr = np.ascontiguousarray(raw.astype(np.int64, copy=False))
+    if arr.ndim != _FACET_KEY_WIDTH or arr.shape[1] != _FACET_KEY_WIDTH:
+        raise ValueError(f"keys must have shape (M, 2); got shape {arr.shape}.")
     return arr
 
 
@@ -91,13 +186,51 @@ def _broadcast_values(
     return flat
 
 
-class CellTags:
-    """Sparse named integer tags over a grid's cells.
+def _require_representable(values: npt.NDArray[np.int64], out_dtype: np.dtype[Any]) -> None:
+    """Reject stored values the destination dtype cannot hold.
 
-    Each tag named ``name`` is a pair of parallel ``int64`` arrays
-    ``(ids, values)`` sorted by ``ids``; a cell not listed in ``ids`` is
-    untagged under ``name``. Distinct tag names are independent. The owning
-    grid's cell count is exposed through the :attr:`num_cells` property.
+    Mirrors ``pantr::grid::detail::require_representable`` in ``tags.hpp``, message
+    included, so that :meth:`CellTags.to_dense` reads the same under either
+    backend. The width condition is :data:`_NARROWER_THAN_INT64`, which documents
+    what it is unsound about.
+
+    Args:
+        values (npt.NDArray[np.int64]): The stored values.
+        out_dtype (np.dtype[Any]): The destination integer dtype.
+
+    Raises:
+        OverflowError: If some value is outside ``out_dtype``'s range.
+    """
+    if values.shape[0] == 0 or out_dtype.itemsize >= _NARROWER_THAN_INT64:
+        return
+    info = np.iinfo(out_dtype)
+    vmin, vmax = int(values.min()), int(values.max())
+    if vmin < info.min or vmax > info.max:
+        raise OverflowError(
+            f"dtype {out_dtype!r} cannot represent all tag values without "
+            f"truncation; value range [{vmin}, {vmax}] exceeds "
+            f"dtype range [{info.min}, {info.max}]."
+        )
+
+
+class _CellTagsPython:
+    """The pure-Python cell-tag registry: the backend under ``PANTR_BACKEND=python``.
+
+    This was the public :class:`CellTags` until the 2026-08-27 amendment to
+    ``design/cross_backend_types.md`` made the registry a C++-owned type. It is not
+    merely a parity oracle: :func:`_cell_impl_class` returns it whenever the Python
+    backend is selected, which is how the package still works in a tree with no
+    compiled extension.
+
+    Its surface is deliberately the one the C++ class exposes -- ``get``,
+    ``scatter``, ``names``, ``__contains__``, ``__len__`` -- so that
+    :class:`CellTags` can call the same methods on either. The Python-facing
+    conveniences this class used to carry (``__getitem__``, ``to_dense``) moved up
+    into that wrapper, where they are written once for both backends.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        names (tuple[str, ...]): Registered tag names, in insertion order.
     """
 
     __slots__ = ("_num_cells", "_tags")
@@ -114,7 +247,7 @@ class CellTags:
         if int(num_cells) < 0:
             raise ValueError(f"num_cells must be >= 0; got {num_cells}.")
         self._num_cells = int(num_cells)
-        self._tags: dict[str, tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]] = {}
+        self._tags: dict[str, _TagPair] = {}
 
     @property
     def num_cells(self) -> int:
@@ -125,8 +258,39 @@ class CellTags:
         """
         return self._num_cells
 
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._tags)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._tags)
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag.
+        """
+        return name in self._tags
+
     def set(self, name: str, ids: npt.ArrayLike, values: npt.ArrayLike) -> None:
         """Create or replace the tag ``name`` with the association ``ids -> values``.
+
+        A replacement keeps the name's position among :attr:`names`, which a Python
+        ``dict`` gives for free and which the C++ registry reproduces on purpose.
 
         Args:
             name (str): Tag name. Replaces any existing tag with the same name.
@@ -157,7 +321,7 @@ class CellTags:
         sorted_vals.flags.writeable = False
         self._tags[str(name)] = (sorted_ids, sorted_vals)
 
-    def __getitem__(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    def get(self, name: str) -> _TagPair:
         """Return the ``(ids, values)`` arrays for tag ``name``.
 
         Args:
@@ -168,45 +332,11 @@ class CellTags:
             ``(ids, values)`` arrays sorted by ``ids``.
 
         Raises:
-            KeyError: If no tag named ``name`` exists.
+            KeyError: If no tag named ``name`` exists. :class:`CellTags` checks
+                membership before calling, so no wrapped caller reaches it; the C++
+                counterpart raises ``std::out_of_range`` here for the same reason.
         """
         return self._tags[name]
-
-    def __contains__(self, name: object) -> bool:
-        """Return whether a tag named ``name`` exists.
-
-        Args:
-            name (object): Candidate tag name.
-
-        Returns:
-            bool: ``True`` iff ``name`` is a registered tag.
-        """
-        return name in self._tags
-
-    def __iter__(self) -> Iterator[str]:
-        """Iterate over the registered tag names.
-
-        Returns:
-            Iterator[str]: Iterator over tag names in insertion order.
-        """
-        return iter(self._tags)
-
-    def __len__(self) -> int:
-        """Return the number of registered tags.
-
-        Returns:
-            int: Count of distinct tag names.
-        """
-        return len(self._tags)
-
-    @property
-    def names(self) -> tuple[str, ...]:
-        """Get the registered tag names.
-
-        Returns:
-            tuple[str, ...]: Tag names in insertion order.
-        """
-        return tuple(self._tags)
 
     def remove(self, name: str) -> None:
         """Delete the tag ``name``.
@@ -219,65 +349,41 @@ class CellTags:
         """
         del self._tags[name]
 
-    def to_dense(
-        self,
-        name: str,
-        *,
-        fill: int = 0,
-        dtype: npt.DTypeLike = np.int64,
-    ) -> npt.NDArray[Any]:
-        r"""Scatter tag ``name`` into a dense ``(num_cells,)`` array.
+    def scatter(self, name: str, out: npt.NDArray[Any]) -> None:
+        """Write tag ``name``'s values into ``out`` at its ids.
 
-        Untagged cells receive ``fill``. Useful when a downstream Numba kernel
-        wants a per-cell label array rather than the sparse representation.
+        Does **not** fill: every entry the tag does not name is left as the caller
+        left it. :meth:`CellTags.to_dense` allocates and fills, so that
+        ``numpy.full`` keeps deciding what an out-of-range ``fill`` does.
 
         Args:
             name (str): Tag name.
-            fill (int): Value for untagged cells. Defaults to ``0``.
-            dtype (npt.DTypeLike): Output integer dtype. Defaults to
-                ``numpy.int64``. Values are stored as ``int64`` internally; if
-                ``dtype`` is narrower than ``int64`` and any stored value falls
-                outside the dtype's representable range, an ``OverflowError`` is
-                raised rather than silently truncating the value.
-
-        Returns:
-            npt.NDArray[Any]: Fresh, writeable ``(num_cells,)`` array with
-            ``dtype`` as the scalar type.
+            out (npt.NDArray[Any]): Destination of shape ``(num_cells,)`` with an
+                integer dtype; written in place.
 
         Raises:
             KeyError: If no tag named ``name`` exists.
-            TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
-            OverflowError: If any stored value cannot be represented exactly in
-                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``).
+            ValueError: If ``out`` does not have shape ``(num_cells,)``.
+            OverflowError: If a stored value is outside ``out.dtype``'s range,
+                subject to the width limit :data:`_NARROWER_THAN_INT64` documents.
         """
-        out_dtype = np.dtype(dtype)
-        if out_dtype.kind not in ("i", "u"):
-            raise TypeError(f"dtype must be an integer dtype; got {out_dtype!r}.")
         ids, values = self._tags[name]
-        if ids.shape[0] > 0 and out_dtype.itemsize < 8:  # noqa: PLR2004
-            info = np.iinfo(out_dtype)
-            vmin, vmax = int(values.min()), int(values.max())
-            if vmin < info.min or vmax > info.max:
-                raise OverflowError(
-                    f"dtype {out_dtype!r} cannot represent all tag values without "
-                    f"truncation; value range [{vmin}, {vmax}] exceeds "
-                    f"dtype range [{info.min}, {info.max}]."
-                )
-        out = np.full(self._num_cells, fill, dtype=out_dtype)
+        if out.shape != (self._num_cells,):
+            raise ValueError(f"scatter: out must have length {self._num_cells}; got {out.shape}.")
+        _require_representable(values, out.dtype)
         out[ids] = values
-        return out
 
 
-class FacetTags:
-    """Sparse named integer tags over a grid's local facets.
+class _FacetTagsPython:
+    """The pure-Python facet-tag registry: the backend under ``PANTR_BACKEND=python``.
 
-    Each facet is addressed by a ``(cell_id, local_facet_id)`` key, with
-    ``local_facet_id`` in ``[0, facets_per_cell)``. Each tag named ``name`` is a
-    pair ``(keys, values)`` where ``keys`` is an ``(M, 2)`` ``int64`` array of
-    ``(cell_id, local_facet_id)`` rows and ``values`` is a length-``M``
-    ``int64`` array, sorted lexicographically by key. The owning grid's cell
-    count and per-cell facet count are exposed through the :attr:`num_cells` and
-    :attr:`facets_per_cell` properties.
+    The counterpart of :class:`_CellTagsPython` for facets; see that class for why
+    it survives the port and why its surface is the C++ one.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        facets_per_cell (int): Number of local facets per cell.
+        names (tuple[str, ...]): Registered tag names, in insertion order.
     """
 
     __slots__ = ("_facets_per_cell", "_num_cells", "_tags")
@@ -299,7 +405,7 @@ class FacetTags:
             raise ValueError(f"facets_per_cell must be >= 1; got {facets_per_cell}.")
         self._num_cells = int(num_cells)
         self._facets_per_cell = int(facets_per_cell)
-        self._tags: dict[str, tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]] = {}
+        self._tags: dict[str, _TagPair] = {}
 
     @property
     def num_cells(self) -> int:
@@ -319,6 +425,34 @@ class FacetTags:
         """
         return self._facets_per_cell
 
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._tags)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._tags)
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag.
+        """
+        return name in self._tags
+
     def set(self, name: str, keys: npt.ArrayLike, values: npt.ArrayLike) -> None:
         """Create or replace the tag ``name`` with the association ``keys -> values``.
 
@@ -337,12 +471,7 @@ class FacetTags:
                 duplicate or out-of-range key, or ``values`` has a length other
                 than ``M``.
         """
-        key_raw = np.asarray(keys)
-        if key_raw.dtype.kind not in ("i", "u"):
-            raise TypeError(f"keys must have an integer dtype; got {key_raw.dtype!r}.")
-        key_arr = np.ascontiguousarray(key_raw.astype(np.int64, copy=False))
-        if key_arr.ndim != _FACET_KEY_WIDTH or key_arr.shape[1] != _FACET_KEY_WIDTH:
-            raise ValueError(f"keys must have shape (M, 2); got shape {key_arr.shape}.")
+        key_arr = _as_int64_keys(keys)
         if key_arr.shape[0] > 0:
             cids = key_arr[:, 0]
             lfids = key_arr[:, 1]
@@ -367,7 +496,7 @@ class FacetTags:
         sorted_vals.flags.writeable = False
         self._tags[str(name)] = (sorted_keys, sorted_vals)
 
-    def __getitem__(self, name: str) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    def get(self, name: str) -> _TagPair:
         """Return the ``(keys, values)`` arrays for tag ``name``.
 
         Args:
@@ -379,45 +508,10 @@ class FacetTags:
             lexicographically.
 
         Raises:
-            KeyError: If no tag named ``name`` exists.
+            KeyError: If no tag named ``name`` exists. See
+                :meth:`_CellTagsPython.get`.
         """
         return self._tags[name]
-
-    def __contains__(self, name: object) -> bool:
-        """Return whether a tag named ``name`` exists.
-
-        Args:
-            name (object): Candidate tag name.
-
-        Returns:
-            bool: ``True`` iff ``name`` is a registered tag.
-        """
-        return name in self._tags
-
-    def __iter__(self) -> Iterator[str]:
-        """Iterate over the registered tag names.
-
-        Returns:
-            Iterator[str]: Iterator over tag names in insertion order.
-        """
-        return iter(self._tags)
-
-    def __len__(self) -> int:
-        """Return the number of registered tags.
-
-        Returns:
-            int: Count of distinct tag names.
-        """
-        return len(self._tags)
-
-    @property
-    def names(self) -> tuple[str, ...]:
-        """Get the registered tag names.
-
-        Returns:
-            tuple[str, ...]: Tag names in insertion order.
-        """
-        return tuple(self._tags)
 
     def remove(self, name: str) -> None:
         """Delete the tag ``name``.
@@ -430,6 +524,564 @@ class FacetTags:
         """
         del self._tags[name]
 
+    def scatter(self, name: str, out: npt.NDArray[Any]) -> None:
+        """Write tag ``name``'s values into ``out`` at its keys.
+
+        Does **not** fill; see :meth:`_CellTagsPython.scatter`.
+
+        Args:
+            name (str): Tag name.
+            out (npt.NDArray[Any]): Destination of shape
+                ``(num_cells, facets_per_cell)`` with an integer dtype; written in
+                place.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+            ValueError: If ``out`` does not have the grid's shape.
+            OverflowError: If a stored value is outside ``out.dtype``'s range,
+                subject to the width limit :data:`_NARROWER_THAN_INT64` documents.
+        """
+        keys, values = self._tags[name]
+        shape = (self._num_cells, self._facets_per_cell)
+        if out.shape != shape:
+            raise ValueError(f"scatter: out must be {shape}; got {out.shape}.")
+        _require_representable(values, out.dtype)
+        if keys.shape[0] > 0:
+            out[keys[:, 0], keys[:, 1]] = values
+
+
+def _cell_impl_class() -> type[_CellTagsPython] | type[_CppCellTags]:
+    """The cell-registry implementation class the active backend selects.
+
+    Returns:
+        type[_CellTagsPython] | type[_CppCellTags]: :class:`_CellTagsPython` under
+        the Python backend, the bound C++ class otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if _python_backend_selected():
+        return _CellTagsPython
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.CellTags
+
+
+def _facet_impl_class() -> type[_FacetTagsPython] | type[_CppFacetTags]:
+    """The facet-registry implementation class the active backend selects.
+
+    Returns:
+        type[_FacetTagsPython] | type[_CppFacetTags]: :class:`_FacetTagsPython`
+        under the Python backend, the bound C++ class otherwise.
+
+    Raises:
+        RuntimeError: If the C++ backend is requested and is not available.
+    """
+    if _python_backend_selected():
+        return _FacetTagsPython
+    from pantr import _pantr_cpp  # noqa: PLC0415  (optional, imported only when selected)
+
+    return _pantr_cpp.FacetTags
+
+
+def _rebuild_cell_tags(
+    num_cells: int,
+    tags: tuple[tuple[str, npt.NDArray[np.int64], npt.NDArray[np.int64]], ...],
+) -> CellTags:
+    """Rebuild a :class:`CellTags` from its constructor argument and its tags.
+
+    The reconstruction :meth:`CellTags.__reduce__` names. A module-level function
+    rather than a ``__setstate__``, because a registry is built by :meth:`set` calls
+    and replaying them in order is what restores the insertion order a pickle has to
+    preserve.
+
+    Args:
+        num_cells (int): The owning grid's cell count.
+        tags (tuple): One ``(name, ids, values)`` triple per tag, in insertion
+            order.
+
+    Returns:
+        CellTags: The rebuilt registry, holding whichever implementation the
+        *reading* process's backend selects.
+    """
+    registry = CellTags(num_cells)
+    for name, ids, values in tags:
+        registry.set(name, ids, values)
+    return registry
+
+
+def _rebuild_facet_tags(
+    num_cells: int,
+    facets_per_cell: int,
+    tags: tuple[tuple[str, npt.NDArray[np.int64], npt.NDArray[np.int64]], ...],
+) -> FacetTags:
+    """Rebuild a :class:`FacetTags` from its constructor arguments and its tags.
+
+    See :func:`_rebuild_cell_tags`.
+
+    Args:
+        num_cells (int): The owning grid's cell count.
+        facets_per_cell (int): Local facets per cell.
+        tags (tuple): One ``(name, keys, values)`` triple per tag, in insertion
+            order.
+
+    Returns:
+        FacetTags: The rebuilt registry.
+    """
+    registry = FacetTags(num_cells, facets_per_cell)
+    for name, keys, values in tags:
+        registry.set(name, keys, values)
+    return registry
+
+
+class CellTags:
+    """Sparse named integer tags over a grid's cells.
+
+    Each tag named ``name`` is a pair of parallel ``int64`` arrays
+    ``(ids, values)`` sorted by ``ids``; a cell not listed in ``ids`` is
+    untagged under ``name``. Distinct tag names are independent. The owning
+    grid's cell count is exposed through the :attr:`num_cells` property.
+
+    **This class is a wrapper**, holding a registry owned by the C++ core (or, under
+    ``PANTR_BACKEND=python``, a :class:`_CellTagsPython`). See the module docstring
+    for the ownership rule and for where validation lives.
+
+    Iteration order is insertion order, and a :meth:`set` that replaces an existing
+    name leaves that name where it was. Both backends guarantee it, because
+    :meth:`__iter__` and :attr:`names` are public and a caller can see it.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        names (tuple[str, ...]): Registered tag names, in insertion order.
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _CellImpl
+    """The implementation this wrapper holds; see :func:`_cell_impl_class`."""
+
+    def __init__(self, num_cells: int) -> None:
+        """Create an empty cell-tag registry.
+
+        Args:
+            num_cells (int): Number of cells in the owning grid (``>= 0``).
+
+        Raises:
+            ValueError: If ``num_cells`` is negative.
+        """
+        object.__setattr__(self, "_impl", _cell_impl_class()(int(num_cells)))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Reject attribute writes.
+
+        The registry accumulates through :meth:`set` and :meth:`remove`; the
+        implementation it holds is not something a caller may swap, and neither is
+        the cell count it was sized for.
+
+        Args:
+            name (str): The attribute being set.
+            value (object): The value it would take.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"CellTags has no settable attribute {name!r}.")
+
+    def __delattr__(self, name: str) -> None:
+        """Reject attribute deletion.
+
+        Args:
+            name (str): The attribute being deleted.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"CellTags has no deletable attribute {name!r}.")
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        """Pickle by the constructor argument and the tags, never by the handle.
+
+        The C++ handle is not picklable and must not become part of the wire
+        format: a pickle written under one backend has to load under the other, or
+        the backend switch would silently become a data-format switch.
+
+        Returns:
+            tuple: :func:`_rebuild_cell_tags` and the arguments to replay.
+        """
+        tags = tuple((name, *self[name]) for name in self.names)
+        return (_rebuild_cell_tags, (self.num_cells, tags))
+
+    def __repr__(self) -> str:
+        """Return a concise representation showing the cell count and tag names.
+
+        Formatted here rather than by the implementation, so that the two backends
+        print identically.
+
+        Note:
+            The pre-port classes gave a ``__repr__`` to :class:`FacetTags` only.
+            This one is a deliberate, small addition made in the same change, so
+            that the two registries are not gratuitously different: a registry that
+            prints as ``<... object at 0x...>`` beside a sibling that names its tags
+            is a difference with no reason behind it.
+
+        Returns:
+            str: ``"CellTags(num_cells=..., tags=[...])"``.
+        """
+        return f"CellTags(num_cells={self.num_cells}, tags={list(self.names)!r})"
+
+    @property
+    def num_cells(self) -> int:
+        """Get the number of cells in the owning grid.
+
+        Returns:
+            int: The cell count; valid cell ids are ``[0, num_cells)``.
+        """
+        return int(self._impl.num_cells)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._impl.names)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._impl)
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the registered tag names.
+
+        Returns:
+            Iterator[str]: Iterator over tag names in insertion order.
+        """
+        return iter(self.names)
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        A non-string is reported as absent rather than passed on: :meth:`set`
+        stores ``str(name)``, so no other kind of key can exist, and the C++
+        registry's own ``__contains__`` takes a ``str``.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag.
+        """
+        return isinstance(name, str) and name in self._impl
+
+    def set(self, name: str, ids: npt.ArrayLike, values: npt.ArrayLike) -> None:
+        """Create or replace the tag ``name`` with the association ``ids -> values``.
+
+        Args:
+            name (str): Tag name. Replaces any existing tag with the same name,
+                keeping the position it holds in :attr:`names`.
+            ids (npt.ArrayLike): 1-D integer array-like of cell ids; each must
+                satisfy ``0 <= id < num_cells`` and be unique.
+            values (npt.ArrayLike): Scalar integer (broadcast to every id) or a
+                1-D integer array-like of the same length as ``ids``.
+
+        Raises:
+            TypeError: If ``ids`` or ``values`` is not integer-typed.
+            ValueError: If ``ids`` is not 1-D, contains duplicates, or has an id
+                out of range, or if ``values`` has a length other than
+                ``len(ids)``.
+        """
+        id_arr = _as_int64_1d(ids, name="ids")
+        val_arr = _broadcast_values(values, id_arr.shape[0], name="values")
+        self._impl.set(str(name), id_arr, val_arr)
+
+    def __getitem__(self, name: str) -> _TagPair:
+        """Return the ``(ids, values)`` arrays for tag ``name``.
+
+        Under the C++ backend the two arrays are read-only views into the
+        registry's own storage, and they stay valid past a later :meth:`set` or
+        :meth:`remove` on the same name: a tag's storage is reference-counted, so a
+        handed-out view holds it alive. That is what the Python backend gets from
+        its own reference counting, and the port would otherwise have introduced a
+        use-after-free the pre-port class could not have.
+
+        Args:
+            name (str): Tag name.
+
+        Returns:
+            tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: Read-only
+            ``(ids, values)`` arrays sorted by ``ids``.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        if name not in self:
+            raise KeyError(name)
+        return self._impl.get(name)
+
+    def remove(self, name: str) -> None:
+        """Delete the tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        if name not in self:
+            raise KeyError(name)
+        self._impl.remove(name)
+
+    def to_dense(
+        self,
+        name: str,
+        *,
+        fill: int = 0,
+        dtype: npt.DTypeLike = np.int64,
+    ) -> npt.NDArray[Any]:
+        r"""Scatter tag ``name`` into a dense ``(num_cells,)`` array.
+
+        Untagged cells receive ``fill``. Useful when a downstream Numba kernel
+        wants a per-cell label array rather than the sparse representation.
+
+        Allocated and filled here rather than by the implementation, so that
+        ``numpy.full`` keeps deciding what an out-of-range ``fill`` does; the
+        implementation writes only the tagged entries.
+
+        Args:
+            name (str): Tag name.
+            fill (int): Value for untagged cells. Defaults to ``0``.
+            dtype (npt.DTypeLike): Output integer dtype. Defaults to
+                ``numpy.int64``. Values are stored as ``int64`` internally; if
+                ``dtype`` is narrower than ``int64`` and any stored value falls
+                outside the dtype's representable range, an ``OverflowError`` is
+                raised rather than silently truncating the value.
+
+        Returns:
+            npt.NDArray[Any]: Fresh, writeable ``(num_cells,)`` array with
+            ``dtype`` as the scalar type.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+            TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
+            OverflowError: If any stored value cannot be represented exactly in
+                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``),
+                or if ``fill`` itself does not fit ``dtype``, which is
+                ``numpy.full``'s own refusal rather than this method's.
+        """
+        out_dtype = np.dtype(dtype)
+        if out_dtype.kind not in ("i", "u"):
+            raise TypeError(f"dtype must be an integer dtype; got {out_dtype!r}.")
+        if name not in self:
+            raise KeyError(name)
+        out = np.full(self.num_cells, fill, dtype=out_dtype)
+        self._impl.scatter(name, out)
+        return out
+
+
+class FacetTags:
+    """Sparse named integer tags over a grid's local facets.
+
+    Each facet is addressed by a ``(cell_id, local_facet_id)`` key, with
+    ``local_facet_id`` in ``[0, facets_per_cell)``. Each tag named ``name`` is a
+    pair ``(keys, values)`` where ``keys`` is an ``(M, 2)`` ``int64`` array of
+    ``(cell_id, local_facet_id)`` rows and ``values`` is a length-``M``
+    ``int64`` array, sorted lexicographically by key. The owning grid's cell
+    count and per-cell facet count are exposed through the :attr:`num_cells` and
+    :attr:`facets_per_cell` properties.
+
+    **This class is a wrapper**; see :class:`CellTags` and the module docstring.
+
+    Attributes:
+        num_cells (int): Number of cells in the owning grid.
+        facets_per_cell (int): Number of local facets per cell.
+        names (tuple[str, ...]): Registered tag names, in insertion order.
+    """
+
+    __slots__ = ("_impl",)
+
+    _impl: _FacetImpl
+    """The implementation this wrapper holds; see :func:`_facet_impl_class`."""
+
+    def __init__(self, num_cells: int, facets_per_cell: int) -> None:
+        """Create an empty facet-tag registry.
+
+        Args:
+            num_cells (int): Number of cells in the owning grid (``>= 0``).
+            facets_per_cell (int): Number of local facets per cell (``>= 1``).
+
+        Raises:
+            ValueError: If ``num_cells`` is negative or ``facets_per_cell`` is
+                ``< 1``.
+        """
+        impl = _facet_impl_class()(int(num_cells), int(facets_per_cell))
+        object.__setattr__(self, "_impl", impl)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Reject attribute writes.
+
+        Args:
+            name (str): The attribute being set.
+            value (object): The value it would take.
+
+        Raises:
+            AttributeError: Always. See :meth:`CellTags.__setattr__`.
+        """
+        raise AttributeError(f"FacetTags has no settable attribute {name!r}.")
+
+    def __delattr__(self, name: str) -> None:
+        """Reject attribute deletion.
+
+        Args:
+            name (str): The attribute being deleted.
+
+        Raises:
+            AttributeError: Always.
+        """
+        raise AttributeError(f"FacetTags has no deletable attribute {name!r}.")
+
+    def __reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        """Pickle by the constructor arguments and the tags, never by the handle.
+
+        See :meth:`CellTags.__reduce__`.
+
+        Returns:
+            tuple: :func:`_rebuild_facet_tags` and the arguments to replay.
+        """
+        tags = tuple((name, *self[name]) for name in self.names)
+        return (_rebuild_facet_tags, (self.num_cells, self.facets_per_cell, tags))
+
+    def __repr__(self) -> str:
+        """Return a concise representation showing the cell/facet counts and tag names.
+
+        Formatted here rather than by the implementation, so that the two backends
+        print identically.
+
+        Returns:
+            str: ``"FacetTags(num_cells=..., facets_per_cell=..., tags=[...])"``
+        """
+        return (
+            f"FacetTags(num_cells={self.num_cells}, "
+            f"facets_per_cell={self.facets_per_cell}, "
+            f"tags={list(self.names)!r})"
+        )
+
+    @property
+    def num_cells(self) -> int:
+        """Get the number of cells in the owning grid.
+
+        Returns:
+            int: The cell count.
+        """
+        return int(self._impl.num_cells)
+
+    @property
+    def facets_per_cell(self) -> int:
+        """Get the number of local facets per cell.
+
+        Returns:
+            int: ``2 * ndim`` for an axis-aligned box grid.
+        """
+        return int(self._impl.facets_per_cell)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Get the registered tag names.
+
+        Returns:
+            tuple[str, ...]: Tag names in insertion order.
+        """
+        return tuple(self._impl.names)
+
+    def __len__(self) -> int:
+        """Return the number of registered tags.
+
+        Returns:
+            int: Count of distinct tag names.
+        """
+        return len(self._impl)
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the registered tag names.
+
+        Returns:
+            Iterator[str]: Iterator over tag names in insertion order.
+        """
+        return iter(self.names)
+
+    def __contains__(self, name: object) -> bool:
+        """Return whether a tag named ``name`` exists.
+
+        Args:
+            name (object): Candidate tag name.
+
+        Returns:
+            bool: ``True`` iff ``name`` is a registered tag. See
+            :meth:`CellTags.__contains__` for why a non-string is absent rather
+            than an error.
+        """
+        return isinstance(name, str) and name in self._impl
+
+    def set(self, name: str, keys: npt.ArrayLike, values: npt.ArrayLike) -> None:
+        """Create or replace the tag ``name`` with the association ``keys -> values``.
+
+        Args:
+            name (str): Tag name. Replaces any existing tag with the same name,
+                keeping the position it holds in :attr:`names`.
+            keys (npt.ArrayLike): ``(M, 2)`` integer array-like of
+                ``(cell_id, local_facet_id)`` rows; each row must be unique with
+                ``0 <= cell_id < num_cells`` and
+                ``0 <= local_facet_id < facets_per_cell``.
+            values (npt.ArrayLike): Scalar integer (broadcast to every key) or a
+                1-D integer array-like of length ``M``.
+
+        Raises:
+            TypeError: If ``keys`` or ``values`` is not integer-typed.
+            ValueError: If ``keys`` does not have shape ``(M, 2)``, contains a
+                duplicate or out-of-range key, or ``values`` has a length other
+                than ``M``.
+        """
+        key_arr = _as_int64_keys(keys)
+        val_arr = _broadcast_values(values, key_arr.shape[0], name="values")
+        self._impl.set(str(name), key_arr, val_arr)
+
+    def __getitem__(self, name: str) -> _TagPair:
+        """Return the ``(keys, values)`` arrays for tag ``name``.
+
+        See :meth:`CellTags.__getitem__` for the lifetime the returned views have.
+
+        Args:
+            name (str): Tag name.
+
+        Returns:
+            tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: Read-only
+            ``(keys, values)`` where ``keys`` has shape ``(M, 2)`` and is sorted
+            lexicographically.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        if name not in self:
+            raise KeyError(name)
+        return self._impl.get(name)
+
+    def remove(self, name: str) -> None:
+        """Delete the tag ``name``.
+
+        Args:
+            name (str): Tag name.
+
+        Raises:
+            KeyError: If no tag named ``name`` exists.
+        """
+        if name not in self:
+            raise KeyError(name)
+        self._impl.remove(name)
+
     def to_dense(
         self,
         name: str,
@@ -440,7 +1092,8 @@ class FacetTags:
         r"""Scatter tag ``name`` into a dense ``(num_cells, facets_per_cell)`` array.
 
         Untagged facets receive ``fill``. Useful when a downstream Numba kernel
-        wants a per-facet label array rather than the sparse representation.
+        wants a per-facet label array rather than the sparse representation. See
+        :meth:`CellTags.to_dense` for why the allocation stays here.
 
         Args:
             name (str): Tag name.
@@ -459,37 +1112,17 @@ class FacetTags:
             KeyError: If no tag named ``name`` exists.
             TypeError: If ``dtype`` is not an integer or unsigned-integer dtype.
             OverflowError: If any stored value cannot be represented exactly in
-                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``).
+                ``dtype`` (only raised when ``dtype`` is narrower than ``int64``),
+                or if ``fill`` itself does not fit ``dtype``.
         """
         out_dtype = np.dtype(dtype)
         if out_dtype.kind not in ("i", "u"):
             raise TypeError(f"dtype must be an integer dtype; got {out_dtype!r}.")
-        keys, values = self._tags[name]
-        if keys.shape[0] > 0 and out_dtype.itemsize < 8:  # noqa: PLR2004
-            info = np.iinfo(out_dtype)
-            vmin, vmax = int(values.min()), int(values.max())
-            if vmin < info.min or vmax > info.max:
-                raise OverflowError(
-                    f"dtype {out_dtype!r} cannot represent all tag values without "
-                    f"truncation; value range [{vmin}, {vmax}] exceeds "
-                    f"dtype range [{info.min}, {info.max}]."
-                )
-        out = np.full((self._num_cells, self._facets_per_cell), fill, dtype=out_dtype)
-        if keys.shape[0] > 0:
-            out[keys[:, 0], keys[:, 1]] = values
+        if name not in self:
+            raise KeyError(name)
+        out = np.full((self.num_cells, self.facets_per_cell), fill, dtype=out_dtype)
+        self._impl.scatter(name, out)
         return out
-
-    def __repr__(self) -> str:
-        """Return a concise representation showing the cell/facet counts and tag names.
-
-        Returns:
-            str: ``"FacetTags(num_cells=..., facets_per_cell=..., tags=[...])"``
-        """
-        return (
-            f"FacetTags(num_cells={self._num_cells}, "
-            f"facets_per_cell={self._facets_per_cell}, "
-            f"tags={list(self._tags)!r})"
-        )
 
 
 __all__ = ["CellTags", "FacetTags"]

--- a/tests/parity/test_grid.py
+++ b/tests/parity/test_grid.py
@@ -68,7 +68,13 @@ from pantr.grid import (
     hierarchical_grid,
     uniform_grid,
 )
-from tests._parity_harness import assert_parity, bitwise_parity
+from tests._parity_harness import (
+    Field,
+    assert_object_parity,
+    assert_parity,
+    bitwise_parity,
+    exact_parity,
+)
 
 _LOCATE_WHY = (
     "the kernel performs no floating-point arithmetic: every binary operation is on "
@@ -179,6 +185,40 @@ def _random_boxes(n: int, ndim: int) -> tuple[npt.NDArray[np.float64], npt.NDArr
     return lo, hi
 
 
+_BVH_EXACT_WHY = (
+    "the node indices, the leaf cell ids and the three counts are the tree's SHAPE. "
+    "design/backend_parity.md Rule 11: a differing verdict is not a displaced value, "
+    "so there is no bound to derive and nothing but a reason to state -- and a "
+    "comparison of elements cannot see two answers of different length at all"
+)
+
+
+def _bvh_fields() -> tuple[Field, ...]:
+    """The state two BVHs have to agree on, and the claim governing each piece.
+
+    Eight fields rather than five, because a hierarchy is its arrays *and* its
+    counts, and a port that got `ndim` wrong on an empty tree would leave every
+    array empty and equal.
+
+    **The two float arrays carry ``bitwise_parity`` and the six integer pieces carry
+    ``exact_parity``, and that is the same claim rather than a weaker one.** The
+    harness is float-only under a ``ParityClaim`` by construction -- it compares
+    through a bit view and computes a difference in ``float64`` -- and its BITWISE
+    failure message tells the reader to check ``__fp_contract__``, which decides
+    nothing about a node index. ``exact_parity`` is elementwise ``!=`` with a reason
+    attached: no tolerance is introduced anywhere here, and none may be.
+
+    Returns:
+        tuple[Field, ...]: The fields, in the order a failure should be read.
+    """
+    coordinates = ("node_lo", "node_hi")
+    shape = ("node_left", "node_right", "node_cell", "ndim", "n_cells", "n_nodes")
+    return (
+        *(Field(name, bitwise_parity(why=_BVH_WHY)) for name in coordinates),
+        *(Field(name, exact_parity(why=_BVH_EXACT_WHY)) for name in shape),
+    )
+
+
 @pytest.mark.parametrize("n_cells", [1, 2, 3, 9, 64])
 @pytest.mark.parametrize("ndim", [1, 2, 3])
 def test_bvh_node_arrays_are_bitwise(cpp_backend: None, n_cells: int, ndim: int) -> None:
@@ -198,21 +238,15 @@ def test_bvh_node_arrays_are_bitwise(cpp_backend: None, n_cells: int, ndim: int)
 
     reference, actual = _both(lambda: BVH.from_cell_bounds(lo, hi))
 
-    for name in ("node_lo", "node_hi"):
-        assert_parity(
-            getattr(actual, name),
-            getattr(reference, name),
-            bitwise_parity(why=_BVH_WHY),
-            context=f"BVH.from_cell_bounds {name}, {n_cells} cells in {ndim}-D",
-        )
-    for name in ("node_left", "node_right", "node_cell"):
-        np.testing.assert_array_equal(
-            getattr(actual, name),
-            getattr(reference, name),
-            err_msg=f"BVH.from_cell_bounds {name} differs at {n_cells} cells in {ndim}-D. "
-            "The two backends built trees of different SHAPE, which no tolerance could "
-            f"bound. {_BVH_WHY}",
-        )
+    # `_both` returns (reference, actual); `assert_object_parity` takes (py, cpp).
+    # The two orders differ across this suite's modules, so the keywords are used
+    # rather than the position -- the harness's own docstring says why.
+    assert_object_parity(
+        py=reference,
+        cpp=actual,
+        fields=_bvh_fields(),
+        context=f"BVH.from_cell_bounds, {n_cells} cells in {ndim}-D",
+    )
 
 
 @pytest.mark.parametrize("n_cells", [1, 5, 40])

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -479,9 +479,7 @@ def both_backends() -> None:
     demand_cpp_backend()
 
 
-@pytest.mark.parametrize(
-    "name", ["node_lo", "node_hi", "node_left", "node_right", "node_cell"]
-)
+@pytest.mark.parametrize("name", ["node_lo", "node_hi", "node_left", "node_right", "node_cell"])
 def test_the_node_arrays_are_read_only_views_that_own_their_storage(
     both_backends: None, name: str
 ) -> None:

--- a/tests/test_grid_bvh.py
+++ b/tests/test_grid_bvh.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import pickle
+
 import numpy as np
 import numpy.typing as npt
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.geometry import AABB
 from pantr.grid import BVH
+from pantr.grid._bvh_core import _BVH_STACK_DEPTH
+from tests._parity_harness import demand_cpp_backend
 
 
 def _grid_cells(nx: int, ny: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
@@ -423,14 +428,258 @@ def test_from_cell_bounds_always_satisfies_the_consistency_invariant() -> None:
         )
 
 
-def test_stack_overflow_guard(monkeypatch: pytest.MonkeyPatch) -> None:
-    """from_cell_bounds raises when the tree depth would overflow the kernel stack."""
-    import pantr.grid._bvh as _bvh_mod  # noqa: PLC0415
+def test_the_depth_guard_follows_the_stack_depth_constant() -> None:
+    """The refused depth is exactly one past ``_BVH_STACK_DEPTH``, derived not hardcoded.
 
-    monkeypatch.setattr(_bvh_mod, "_BVH_STACK_DEPTH", 1)
-    lo, hi = _grid_cells(2, 2)  # 4 cells → depth 3 > 1
+    **This replaces a monkeypatching test, and the replacement is the point.** The
+    old ``test_stack_overflow_guard`` set ``pantr.grid._bvh._BVH_STACK_DEPTH`` to 1
+    and built four cells. That worked while the module global was the only thing
+    enforcing the limit. Under ``PANTR_BACKEND=cpp`` the enforcing constant is
+    ``kBvhStackDepth``, a C++ ``constexpr`` the monkeypatch cannot reach, so the
+    test passed while testing nothing -- which is worse than not having it.
+
+    So the boundary is exercised for real, on both sides, with the leaf counts
+    **derived from the constant** rather than written as 128 and 129. Its three
+    siblings above pin the same boundary with literal counts; this one is what fails
+    if the Python constant moves and the guard does not move with it. The other
+    drift -- Python against the C++ mirror -- is not visible from here at all, and
+    ``scripts/ci_local.sh`` carries a guard that extracts both by regex.
+    """
+    at_limit = _chain_bvh_arrays(_BVH_STACK_DEPTH)
+    tree = BVH(*at_limit, n_cells=_BVH_STACK_DEPTH)
+    assert tree.n_cells == _BVH_STACK_DEPTH
+
+    past_limit = _chain_bvh_arrays(_BVH_STACK_DEPTH + 1)
     with pytest.raises(ValueError, match="stack depth"):
-        BVH.from_cell_bounds(lo, hi)
+        BVH(*past_limit, n_cells=_BVH_STACK_DEPTH + 1)
+
+
+# ---------------------------------------------------------------------------
+# The port to C++ ownership (FELIGN/pantr#384)
+# ---------------------------------------------------------------------------
+
+
+def _backend_pairs() -> list[tuple[Backend, Backend]]:
+    """Every ordered pair of backends, for the serialization round trips.
+
+    Returns:
+        list[tuple[Backend, Backend]]: The four ``(writer, reader)`` pairs.
+    """
+    return [(writer, reader) for writer in Backend for reader in Backend]
+
+
+@pytest.fixture
+def both_backends() -> None:
+    """Require the compiled extension for a test that uses both backends at once.
+
+    Routed through the parity harness rather than a bare ``skipif``: a bare skip is
+    silent, and a suite that skips its way to green has let real failures through in
+    this repository.
+    """
+    demand_cpp_backend()
+
+
+@pytest.mark.parametrize(
+    "name", ["node_lo", "node_hi", "node_left", "node_right", "node_cell"]
+)
+def test_the_node_arrays_are_read_only_views_that_own_their_storage(
+    both_backends: None, name: str
+) -> None:
+    """Each of the five arrays is read-only, and under C++ it aliases rather than copies.
+
+    ``base is not None`` is the half that catches the ownerless binding: an
+    ``nb::ndarray`` returned with no owner silently *copies* and comes back
+    **writable**, which would pass every value assertion in this file while dropping
+    the read-only contract and turning the backend switch into a performance switch
+    on the one surface ``design/bvh.md`` calls public API.
+
+    Asserted for the C++ backend only, because the Python one hands back the array
+    it stores and ``numpy.ascontiguousarray`` returns that array itself, base and
+    all.
+    """
+    del both_backends
+    lo, hi = _grid_cells(2, 2)
+    with use_backend(Backend.PYTHON):
+        py = BVH.from_cell_bounds(lo, hi)
+    with use_backend(Backend.CPP):
+        cpp = BVH.from_cell_bounds(lo, hi)
+
+    # Only the flags are asserted here. Whether the two backends built the same tree
+    # is `tests/parity/test_grid.py`'s claim, and stating it twice would put the
+    # parity failure message under a test named for read-only-ness.
+    for tree in (py, cpp):
+        assert not getattr(tree, name).flags.writeable
+
+    assert getattr(cpp, name).base is not None, (
+        f"the C++ view for {name} must carry an owner: without one nanobind copies, "
+        f"and the copy comes back writable"
+    )
+
+
+def test_an_empty_tree_has_no_nodes_and_short_circuits_its_query() -> None:
+    """Zero cells builds, reports ``n_nodes == 0``, and answers without touching a node.
+
+    The short-circuit is what makes this safe rather than merely correct: with no
+    nodes there is no node ``0`` for the traversal to read, so a query that did not
+    return early would index an empty array.
+    """
+    tree = BVH.from_cell_bounds(np.zeros((0, 3)), np.zeros((0, 3)))
+    assert tree.n_cells == 0
+    assert tree.n_nodes == 0
+    assert tree.ndim == 3
+    assert tree.node_lo.shape == (0, 3)
+    assert tree.node_left.shape == (0,)
+
+    matched = tree.query_aabb(AABB([0.0, 0.0, 0.0], [1.0, 1.0, 1.0]))
+    assert matched.shape == (0,)
+    assert matched.dtype == np.int64
+
+
+@pytest.mark.parametrize("name", ["ndim", "n_cells", "n_nodes"])
+def test_the_three_counts_are_not_writable(name: str) -> None:
+    """``bvh.ndim = 7`` raises ``AttributeError`` rather than corrupting the tree.
+
+    The three were plain public writable attributes before the port, while the class
+    docstring said instances were immutable. ``bvh.ndim = 7`` defeated the dimension
+    check in ``query_aabb`` and the kernels then indexed a mis-shaped array. The
+    2026-08-28 census of the downstream consumer found no writes to any of them.
+    """
+    tree = BVH.from_cell_bounds(np.zeros((2, 1)), np.ones((2, 1)))
+    with pytest.raises(AttributeError):
+        setattr(tree, name, 7)
+    assert tree.ndim == 1
+
+
+def test_a_reversed_query_interval_is_reported_by_both_backends(both_backends: None) -> None:
+    """An empty query box matches a cell whose interval contains its reversed one.
+
+    ``BVH.query_aabb`` is a separating-axis test with no emptiness branch, so it is
+    **not** :meth:`pantr.geometry.AABB.overlaps`, which reports that an empty box
+    overlaps nothing. Both backends behave this way and agree with each other; the
+    divergence is between the predicate and the box, and reconciling them has to
+    move both backends at once.
+
+    Pinned so that a later reconciliation has to change a test that says why, and
+    with the box's own answer asserted beside it so the disagreement is on the
+    record rather than implied.
+    """
+    del both_backends
+    cell = AABB([0.0], [10.0])
+    query = AABB([5.0], [3.0])
+    assert query.is_empty()
+    assert cell.overlaps(query) is False
+
+    for backend in (Backend.PYTHON, Backend.CPP):
+        with use_backend(backend):
+            tree = BVH.from_cell_bounds(np.array([[0.0]]), np.array([[10.0]]))
+            assert tree.query_aabb(query).tolist() == [0], backend
+
+
+def test_the_capacity_error_reaches_python_as_its_own_type(both_backends: None) -> None:
+    """The C++ type's traversal-stack refusal arrives as ``CapacityError``, not ``RuntimeError``.
+
+    ``pantr::CapacityError`` derives publicly from ``std::runtime_error``, and
+    nanobind's default translator maps that base to ``RuntimeError``. **That the
+    specific ``nb::exception<CapacityError>`` wins over the generic catch was an
+    assumption until this test**, and it is the first site in the port to throw one.
+    Asserted on the exact type rather than with ``isinstance``, which the generic
+    mapping would also satisfy.
+
+    Reached through the raw handle deliberately: :class:`BVH` translates it back to
+    the ``ValueError`` the pre-port class raised, so the wrapper is exactly where
+    this cannot be observed.
+    """
+    del both_backends
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    arrays = _chain_bvh_arrays(_BVH_STACK_DEPTH + 1)
+    with pytest.raises(_pantr_cpp.CapacityError) as excinfo:
+        _pantr_cpp.BVH(*arrays, _BVH_STACK_DEPTH + 1)
+
+    assert type(excinfo.value) is _pantr_cpp.CapacityError, (
+        "nanobind fell back to the generic std::runtime_error translator, so the "
+        "specific exception this port registered is not being preferred"
+    )
+    assert issubclass(_pantr_cpp.CapacityError, RuntimeError)
+    assert "stack depth" in str(excinfo.value)
+
+    # And the wrapper presents the class a caller has always caught.
+    with use_backend(Backend.CPP), pytest.raises(ValueError, match="stack depth"):
+        BVH(*arrays, n_cells=_BVH_STACK_DEPTH + 1)
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_pickle_round_trips_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """A pickled tree written under one backend loads under the other.
+
+    The pre-port class had no ``__reduce__`` and pickled through its ``__slots__``.
+    A C++ handle cannot pickle at all, so the port had to add one; this is what says
+    the wire format did not quietly become backend-specific.
+    """
+    del both_backends
+    lo, hi = _grid_cells(3, 3)
+    with use_backend(writer):
+        original = BVH.from_cell_bounds(lo, hi)
+        blob = pickle.dumps(original)
+
+    with use_backend(reader):
+        loaded = pickle.loads(blob)
+        assert loaded.n_cells == 9
+        assert loaded.n_nodes == 17
+        assert loaded.ndim == 2
+        for name in ("node_lo", "node_hi", "node_left", "node_right", "node_cell"):
+            np.testing.assert_array_equal(getattr(loaded, name), getattr(original, name))
+        assert sorted(loaded.query_aabb(AABB([0.0, 0.0], [1.5, 1.5])).tolist()) == [0, 1, 3, 4]
+
+
+def test_repr_is_byte_identical_under_both_backends(both_backends: None) -> None:
+    """``repr`` is computed by the wrapper, so ``PANTR_BACKEND`` cannot move it."""
+    del both_backends
+    lo, hi = _grid_cells(2, 2)
+    with use_backend(Backend.PYTHON):
+        from_python = repr(BVH.from_cell_bounds(lo, hi))
+    with use_backend(Backend.CPP):
+        from_cpp = repr(BVH.from_cell_bounds(lo, hi))
+
+    assert from_python == from_cpp
+    assert from_python == "BVH(n_cells=4, n_nodes=7, ndim=2)"
+
+
+def test_both_backends_agree_on_the_messages_a_caller_reads(both_backends: None) -> None:
+    """Every rejection carries the same class and the same text under either backend.
+
+    Includes the traversal-stack refusal, which is the one the C++ type reports as a
+    different exception class and the wrapper translates back.
+    """
+    del both_backends
+    node_lo, node_hi, node_left, node_right, node_cell = _three_leaf_arrays()
+    deep = _chain_bvh_arrays(_BVH_STACK_DEPTH + 1)
+
+    def messages() -> list[str]:
+        out: list[str] = []
+        for call in (
+            lambda: BVH.from_cell_bounds(np.array([[1.0, 1.0]]), np.array([[0.0, 0.0]])),
+            lambda: BVH.from_cell_bounds(np.zeros((3, 2)), np.zeros((3, 3))),
+            lambda: BVH.from_cell_bounds(np.array([[np.nan, 0.0]]), np.array([[1.0, 1.0]])),
+            lambda: BVH(node_lo, node_hi, node_left, node_right, node_cell, n_cells=2),
+            lambda: BVH(*deep, n_cells=_BVH_STACK_DEPTH + 1),
+            lambda: BVH.from_cell_bounds(np.zeros((2, 1)), np.ones((2, 1))).query_aabb(
+                AABB([0.0, 0.0], [1.0, 1.0])
+            ),
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                call()
+            out.append(f"{type(excinfo.value).__name__}: {excinfo.value}")
+        return out
+
+    with use_backend(Backend.PYTHON):
+        from_python = messages()
+    with use_backend(Backend.CPP):
+        from_cpp = messages()
+
+    assert from_cpp == from_python
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grid_partition.py
+++ b/tests/test_grid_partition.py
@@ -209,9 +209,15 @@ def test_both_backends_agree_on_the_messages_a_caller_reads(both_backends: None)
     """Every rejection carries the same class and the same text under either backend.
 
     A port that changed what a caller reads or catches would pass every value
-    assertion above. Each case below violates exactly one contract, which is what
-    makes the comparison a statement about the message rather than about the order
-    two checks happen to run in.
+    assertion above.
+
+    **The last case violates two contracts at once, and it is the one that caught a
+    real divergence.** ``Partition(numpy.array([1.5, 2.5]), 0)`` is both a
+    non-integer array and a bad part count, and while the wrapper coerced inside the
+    C++ branch only, the Python backend reported the ``n_parts`` complaint and the
+    C++ one reported the array complaint. Which of two simultaneous violations is
+    named is precisely what ``PANTR_BACKEND`` must not decide, so it is asserted
+    rather than left to the cases that violate exactly one thing.
     """
     del both_backends
 
@@ -226,6 +232,7 @@ def test_both_backends_agree_on_the_messages_a_caller_reads(both_backends: None)
             lambda: Partition([-2, 0], 2),
             lambda: part.owned_cells(2),
             lambda: part.owned_cells(-1),
+            lambda: Partition(np.array([1.5, 2.5]), 0),
         ):
             with pytest.raises(ValueError) as excinfo:
                 call()

--- a/tests/test_grid_partition.py
+++ b/tests/test_grid_partition.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import copy
+import inspect
+import pickle
+
 import numpy as np
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.grid import Partition
+from tests._parity_harness import demand_cpp_backend
 
 
 def test_construction_and_n_cells() -> None:
@@ -87,3 +93,184 @@ def test_empty_partition() -> None:
 def test_owned_cells_dtype() -> None:
     p = Partition([0, 1, 0, 1], n_parts=2)
     assert p.owned_cells(0).dtype == np.int64
+
+
+# ---------------------------------------------------------------------------
+# The port to C++ ownership (FELIGN/pantr#381)
+# ---------------------------------------------------------------------------
+#
+# Everything above ran against the pure-Python partition and now runs against
+# whichever implementation ``PANTR_BACKEND`` selects, unchanged. What follows is
+# what the port added: the pickle that has to cross the backends, the repr that has
+# to be byte-identical across them, and the messages a caller catches.
+
+
+def _backend_pairs() -> list[tuple[Backend, Backend]]:
+    """Every ordered pair of backends, for the serialization round trips.
+
+    Returns:
+        list[tuple[Backend, Backend]]: The four ``(writer, reader)`` pairs.
+    """
+    return [(writer, reader) for writer in Backend for reader in Backend]
+
+
+@pytest.fixture
+def both_backends() -> None:
+    """Require the compiled extension for a test that uses both backends at once.
+
+    Routed through the parity harness rather than a bare ``skipif``: a bare skip is
+    silent, and a suite that skips its way to green has let real failures through in
+    this repository.
+    """
+    demand_cpp_backend()
+
+
+def test_cell_owner_is_a_read_only_view_that_owns_its_storage(both_backends: None) -> None:
+    """The owner array is read-only under both backends and aliases under C++.
+
+    The second half is what catches the ownerless binding: a return with no owner
+    silently *copies* and comes back writable, which would pass every value
+    assertion and drop the read-only contract. ``base is not None`` is asserted only
+    for the C++ backend, because the Python one hands back the array it stores and
+    ``numpy.ascontiguousarray`` returns that array itself, base and all.
+    """
+    del both_backends
+    with use_backend(Backend.PYTHON):
+        py = Partition([0, 1, -1], 2)
+    with use_backend(Backend.CPP):
+        cpp = Partition([0, 1, -1], 2)
+
+    for part in (py, cpp):
+        assert not part.cell_owner.flags.writeable
+        with pytest.raises(ValueError, match=r"read-only|assignment"):
+            part.cell_owner[0] = 1
+
+    assert cpp.cell_owner.base is not None, (
+        "the C++ view must carry an owner: without one nanobind copies, and the copy "
+        "comes back writable"
+    )
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_pickle_round_trips_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """A pickled partition written under one backend loads under the other.
+
+    Asserted on the reconstructed field values rather than on the absence of an
+    exception. This one is load-bearing beyond the backend switch: ``pantr.mpi``
+    moves a partition between ranks through ``mpi4py``, which pickles.
+    """
+    del both_backends
+    with use_backend(writer):
+        original = Partition([0, 1, -1, 1, 0], 2)
+        blob = pickle.dumps(original)
+
+    with use_backend(reader):
+        loaded = pickle.loads(blob)
+        assert loaded.n_parts == 2
+        assert loaded.n_cells == 5
+        assert loaded.cell_owner.dtype == np.int32
+        np.testing.assert_array_equal(loaded.cell_owner, [0, 1, -1, 1, 0])
+        np.testing.assert_array_equal(loaded.owned_cells(0), [0, 4])
+        np.testing.assert_array_equal(loaded.active_mask, [True, True, False, True, True])
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_deepcopy_round_trips_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """``deepcopy`` goes through the same reduction, so it crosses backends too."""
+    del both_backends
+    with use_backend(writer):
+        original = Partition([1, -1, 0], 2)
+
+    with use_backend(reader):
+        clone = copy.deepcopy(original)
+
+    assert clone.n_parts == 2
+    np.testing.assert_array_equal(clone.cell_owner, [1, -1, 0])
+    np.testing.assert_array_equal(clone.owned_cells(1), [0])
+
+
+def test_repr_is_byte_identical_under_both_backends(both_backends: None) -> None:
+    """``repr`` is computed by the wrapper, so ``PANTR_BACKEND`` cannot move it."""
+    del both_backends
+    with use_backend(Backend.PYTHON):
+        from_python = repr(Partition([0, 1, -1], 2))
+    with use_backend(Backend.CPP):
+        from_cpp = repr(Partition([0, 1, -1], 2))
+
+    assert from_python == from_cpp
+    assert from_python == "Partition(n_cells=3, n_parts=2)"
+
+
+def test_both_backends_agree_on_the_messages_a_caller_reads(both_backends: None) -> None:
+    """Every rejection carries the same class and the same text under either backend.
+
+    A port that changed what a caller reads or catches would pass every value
+    assertion above. Each case below violates exactly one contract, which is what
+    makes the comparison a statement about the message rather than about the order
+    two checks happen to run in.
+    """
+    del both_backends
+
+    def messages() -> list[str]:
+        part = Partition([0, 1], 2)
+        out: list[str] = []
+        for call in (
+            lambda: Partition([0, 0], 0),
+            lambda: Partition(np.zeros((2, 2), dtype=np.int32), 1),
+            lambda: Partition(np.array([0.0, 1.0]), 2),
+            lambda: Partition([0, 2], 2),
+            lambda: Partition([-2, 0], 2),
+            lambda: part.owned_cells(2),
+            lambda: part.owned_cells(-1),
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                call()
+            out.append(f"{type(excinfo.value).__name__}: {excinfo.value}")
+        return out
+
+    with use_backend(Backend.PYTHON):
+        from_python = messages()
+    with use_backend(Backend.CPP):
+        from_cpp = messages()
+
+    assert from_cpp == from_python
+
+
+def test_two_backends_in_one_process_cannot_meet_in_an_operation(both_backends: None) -> None:
+    """Two partitions built under different backends hold unrelated implementations.
+
+    ``design/cross_backend_types.md`` forbids reconciling two implementations of one
+    type by converting between them, and :class:`pantr.geometry.AABB` enforces that
+    with a ``TypeError`` from ``_peer`` on every binary operation. **A partition has
+    no binary operation**, so there is no site at which two of them could meet and
+    nothing for such a guard to sit on -- and adding one would be dead code. This
+    test pins both halves of that: the per-process selection really does produce two
+    unrelated implementations in one process, and the public surface really does
+    take no second partition.
+    """
+    del both_backends
+    with use_backend(Backend.PYTHON):
+        py = Partition([0, 1], 2)
+    with use_backend(Backend.CPP):
+        cpp = Partition([0, 1], 2)
+
+    assert type(py) is type(cpp) is Partition
+    assert type(py._impl) is not type(cpp._impl)
+
+    takes_a_partition = [
+        name
+        for name, member in inspect.getmembers(Partition, callable)
+        if not name.startswith("__")
+        and any(
+            parameter.annotation in (Partition, "Partition")
+            for parameter in inspect.signature(member).parameters.values()
+        )
+    ]
+    assert takes_a_partition == [], (
+        f"{takes_a_partition} take a second Partition, so two backends CAN now meet in "
+        f"one operation and each needs the refusal AABB._peer performs"
+    )

--- a/tests/test_grid_tags.py
+++ b/tests/test_grid_tags.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import copy
+import pickle
+
 import numpy as np
 import pytest
 
+from pantr._backend import Backend, use_backend
 from pantr.grid import CellTags, FacetTags, uniform_grid
+from tests._parity_harness import demand_cpp_backend
 
 
 def test_cell_tags_set_get() -> None:
@@ -239,3 +244,275 @@ def test_facet_tags_to_dense_overflow_raises() -> None:
     tags.set("bc", [[0, 0]], [200])
     with pytest.raises(OverflowError, match="truncation"):
         tags.to_dense("bc", dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# The port to C++ ownership (FELIGN/pantr#382)
+# ---------------------------------------------------------------------------
+#
+# Everything above ran against the pure-Python registries and now runs against
+# whichever implementation ``PANTR_BACKEND`` selects, unchanged. What follows is
+# the part the port added, and each case is here because nothing above could see
+# it: a view's lifetime, the insertion order across a replacement, and a pickle
+# crossing between the two backends.
+
+
+def _backend_pairs() -> list[tuple[Backend, Backend]]:
+    """Every ordered pair of backends, for the serialization round trips.
+
+    Returns:
+        list[tuple[Backend, Backend]]: The four ``(writer, reader)`` pairs.
+    """
+    return [(writer, reader) for writer in Backend for reader in Backend]
+
+
+@pytest.fixture
+def both_backends() -> None:
+    """Require the compiled extension for a test that uses both backends at once.
+
+    Routed through the parity harness rather than a bare ``skipif`` for the reason
+    that function's docstring gives: a bare skip is silent, and a suite that skips
+    its way to green has let real failures through in this repository.
+    """
+    demand_cpp_backend()
+
+
+def test_a_view_taken_before_a_replacement_still_holds_the_old_values() -> None:
+    """``__getitem__``'s arrays survive a later ``set`` on the same name.
+
+    The C++ registry hands back zero-copy views into its own storage, so a ``set``
+    that replaced the buffer in place would free memory under a live numpy array --
+    a use-after-free the pure-Python registry cannot have, because a replaced tuple
+    stays alive as long as someone holds it. ``tags.hpp`` holds each tag behind a
+    ``shared_ptr`` for exactly this, and nothing else in the suite reads a view
+    across a replacement.
+    """
+    tags = CellTags(num_cells=10)
+    tags.set("a", [1, 2], [10, 20])
+    ids, values = tags["a"]
+
+    tags.set("a", [5], [50])
+
+    assert ids.tolist() == [1, 2]
+    assert values.tolist() == [10, 20]
+    assert tags["a"][0].tolist() == [5]
+
+    tags.remove("a")
+    assert ids.tolist() == [1, 2]
+    assert values.tolist() == [10, 20]
+
+
+def test_a_facet_view_taken_before_a_replacement_still_holds_the_old_values() -> None:
+    """The facet registry's ``(keys, values)`` views have the same lifetime."""
+    tags = FacetTags(num_cells=6, facets_per_cell=4)
+    tags.set("bc", [[0, 1], [2, 3]], [7, 9])
+    keys, values = tags["bc"]
+
+    tags.set("bc", [[1, 0]], [4])
+
+    assert keys.tolist() == [[0, 1], [2, 3]]
+    assert values.tolist() == [7, 9]
+
+
+def test_replacing_a_cell_tag_leaves_its_position_unchanged() -> None:
+    """A replaced name keeps its index in ``names`` and in iteration.
+
+    Asserted by position rather than by comparing the two backends: a registry that
+    moved a replaced name to the end would be wrong in both backends at once, and a
+    comparison between them would pass.
+    """
+    tags = CellTags(num_cells=10)
+    for i, name in enumerate(("a", "b", "c")):
+        tags.set(name, [i], 1)
+
+    tags.set("b", [7], 99)
+
+    assert list(tags.names) == ["a", "b", "c"]
+    assert list(iter(tags)) == ["a", "b", "c"]
+    assert tags["b"][0].tolist() == [7]
+
+    tags.remove("a")
+    assert list(tags.names) == ["b", "c"]
+
+
+def test_replacing_a_facet_tag_leaves_its_position_unchanged() -> None:
+    """The facet registry keeps insertion order across a replacement too."""
+    tags = FacetTags(num_cells=6, facets_per_cell=4)
+    for i, name in enumerate(("first", "second", "third")):
+        tags.set(name, [[i, 0]], 1)
+
+    tags.set("second", [[5, 3]], 42)
+
+    assert list(tags.names) == ["first", "second", "third"]
+    assert tags["second"][0].tolist() == [[5, 3]]
+
+
+def test_remove_reports_an_unregistered_name_as_a_key_error() -> None:
+    """``remove`` raises ``KeyError``, which nanobind cannot produce on its own.
+
+    The registry's own C++ lookup throws ``std::out_of_range``, which nanobind maps
+    to ``IndexError``; the wrapper checks membership first so that a caller catches
+    what the docstring promises. ``__getitem__`` and ``to_dense`` are covered above.
+    """
+    tags = CellTags(num_cells=4)
+    with pytest.raises(KeyError):
+        tags.remove("nonexistent")
+
+    facets = FacetTags(num_cells=4, facets_per_cell=4)
+    with pytest.raises(KeyError):
+        facets.remove("nonexistent")
+
+
+def test_a_non_string_name_is_absent_rather_than_an_error() -> None:
+    """``5 in tags`` is ``False`` and ``tags[5]`` is a ``KeyError``.
+
+    ``set`` stores ``str(name)``, so no non-string key can exist. The C++
+    registry's ``__contains__`` takes a ``str`` and would raise ``TypeError``, so
+    the wrapper answers this itself.
+    """
+    tags = CellTags(num_cells=4)
+    tags.set("5", [0], 1)
+    assert 5 not in tags
+    assert "5" in tags
+    with pytest.raises(KeyError):
+        tags[5]  # type: ignore[index]
+
+
+def test_the_registries_print_their_counts_and_their_tags() -> None:
+    """Both registries have a ``__repr__``, formatted by the wrapper.
+
+    ``FacetTags`` had one before the port and ``CellTags`` did not; the addition is
+    deliberate and is made on both sides at once, so the two backends and the two
+    registries cannot drift apart. Computed by the wrapper, so the string does not
+    depend on ``PANTR_BACKEND``.
+    """
+    cells = CellTags(num_cells=6)
+    cells.set("inside", [0, 1], 1)
+    assert repr(cells) == "CellTags(num_cells=6, tags=['inside'])"
+
+    facets = FacetTags(num_cells=3, facets_per_cell=4)
+    assert repr(facets) == "FacetTags(num_cells=3, facets_per_cell=4, tags=[])"
+    facets.set("bc", [[0, 0]], 2)
+    assert repr(facets) == "FacetTags(num_cells=3, facets_per_cell=4, tags=['bc'])"
+
+
+def test_the_registries_refuse_attribute_writes() -> None:
+    """A registry accumulates through ``set``; its own attributes are not settable."""
+    tags = CellTags(num_cells=4)
+    with pytest.raises(AttributeError):
+        tags.num_cells = 9  # type: ignore[misc]
+
+    facets = FacetTags(num_cells=4, facets_per_cell=4)
+    with pytest.raises(AttributeError):
+        facets.facets_per_cell = 9  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_cell_tags_round_trip_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """A pickled registry written under one backend loads under the other.
+
+    Asserted on the reconstructed contents rather than on the absence of an
+    exception: the failure this guards against is a wire format that quietly became
+    backend-specific, and a handle that pickled to *something* would still fail
+    that way.
+    """
+    del both_backends
+    with use_backend(writer):
+        tags = CellTags(num_cells=6)
+        tags.set("labels", [3, 1], [30, 10])
+        tags.set("inside", [0], 1)
+        blob = pickle.dumps(tags)
+
+    with use_backend(reader):
+        loaded = pickle.loads(blob)
+        assert loaded.num_cells == 6
+        assert loaded.names == ("labels", "inside")
+        np.testing.assert_array_equal(loaded["labels"][0], [1, 3])
+        np.testing.assert_array_equal(loaded["labels"][1], [10, 30])
+        np.testing.assert_array_equal(loaded["inside"][1], [1])
+        assert loaded.to_dense("labels", fill=-1).tolist() == [-1, 10, -1, 30, -1, -1]
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_facet_tags_round_trip_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """The facet registry pickles across the same four pairs."""
+    del both_backends
+    with use_backend(writer):
+        tags = FacetTags(num_cells=3, facets_per_cell=4)
+        tags.set("bc", [[2, 3], [0, 0]], [2, 1])
+        blob = pickle.dumps(tags)
+
+    with use_backend(reader):
+        loaded = pickle.loads(blob)
+        assert loaded.num_cells == 3
+        assert loaded.facets_per_cell == 4
+        np.testing.assert_array_equal(loaded["bc"][0], [[0, 0], [2, 3]])
+        np.testing.assert_array_equal(loaded["bc"][1], [1, 2])
+
+
+@pytest.mark.parametrize(("writer", "reader"), _backend_pairs())
+def test_deepcopy_round_trips_across_every_backend_pair(
+    both_backends: None, writer: Backend, reader: Backend
+) -> None:
+    """``deepcopy`` goes through the same reduction, so it crosses backends too.
+
+    The copy is taken under ``reader`` while the original was built under
+    ``writer``, which is the one arrangement that exercises the reduction rather
+    than a same-backend shortcut.
+    """
+    del both_backends
+    with use_backend(writer):
+        tags = CellTags(num_cells=5)
+        tags.set("m", [4, 2], [40, 20])
+
+    with use_backend(reader):
+        clone = copy.deepcopy(tags)
+        assert clone.names == ("m",)
+        np.testing.assert_array_equal(clone["m"][0], [2, 4])
+        np.testing.assert_array_equal(clone["m"][1], [20, 40])
+        clone.set("m", [0], 7)
+
+    assert tags["m"][0].tolist() == [2, 4], "the copy must not share the original's storage"
+
+
+def test_both_backends_agree_on_the_messages_a_caller_reads(both_backends: None) -> None:
+    """Every rejection carries the same text under either backend.
+
+    A port that changed what a caller reads or catches would pass every value
+    assertion above. The pairs below are the ones the wrapper does *not* raise
+    itself, so they are the ones that could have drifted.
+    """
+    del both_backends
+
+    def messages() -> list[str]:
+        tags = CellTags(num_cells=5)
+        facets = FacetTags(num_cells=4, facets_per_cell=4)
+        tags.set("m", [0, 1], [200, 1])
+        facets.set("bc", [[0, 0]], [200])
+        out: list[str] = []
+        for call in (
+            lambda: CellTags(num_cells=-1),
+            lambda: tags.set("a", [5], 1),
+            lambda: tags.set("a", [1, 1], 1),
+            lambda: tags.set("a", [0, 1, 2], [1, 2]),
+            lambda: tags.to_dense("m", dtype=np.int8),
+            lambda: facets.set("a", [[4, 0]], 1),
+            lambda: facets.set("a", [[0, 4]], 1),
+            lambda: facets.set("a", [[0, 0], [0, 0]], 1),
+            lambda: facets.to_dense("bc", dtype=np.int8),
+        ):
+            with pytest.raises((ValueError, TypeError, OverflowError)) as excinfo:
+                call()
+            out.append(f"{type(excinfo.value).__name__}: {excinfo.value}")
+        return out
+
+    with use_backend(Backend.PYTHON):
+        from_python = messages()
+    with use_backend(Backend.CPP):
+        from_cpp = messages()
+
+    assert from_cpp == from_python


### PR DESCRIPTION
Moves `CellTags`/`FacetTags`, `Partition` and the `BVH` to C++ ownership, with Python wrapping
them. Three tickets, one branch, one commit group each in dependency order.

`Closes #382, #381, #384` — closing keywords do not fire on a non-default base, so close all three
by hand after merge.

**Base is `build/380-shared-files-for-type-port` (PR #406), not `proto/cpp`.** Merge that first.

**Why one branch for three tickets.** They are independent in the DAG but all three edit
`src/pantr/_pantr_cpp/_grid.pyi` and `tools/adversarial_sweep/_probes_grid.py` — #380 split the
type stub per *area*, not per *type*, so that collision survived the prep ticket. The DAG has no
edge for "touches the same file". One engineer held all three so the wrapper pattern was decided
once rather than three times.

Commit order: #382 `3d7ce61` → #381 `e2c9f74` → #384 `2daf7fe` → self-review `a574c97`.

## Acceptance criteria

**Shared evidence.** `pytest -q` → `7547 passed, 39 skipped, 7 xfailed`; `PANTR_BACKEND=cpp
pytest -q` → identical. `ctest --preset gcc` 26/26. ruff clean, `mypy Success ... 291 source
files`, `lint-imports` 2 kept.

**Extension-skip check:** `tests/parity/test_grid.py` gives `31 skipped` with the `.so` moved
aside and `32 passed` restored, so the parity suite is comparing two implementations rather than
the oracle with itself.

| Ticket | ACs | Notes |
|---|---|---|
| **#382** tags | AC1–AC5 met, AC7 below | AC3b was checked the strong way: the `KeyError` assertions at `tests/test_grid_tags.py:66,168` were `diff`ed against the base and are **byte-identical**, only displaced by the import block — stronger than "the tests still pass" |
| **#381** partition | AC1–AC4 met, **AC5 amended**, AC7 below | see below |
| **#384** BVH | AC1–AC5 and AC7 met, AC8 below | AC5's sync guard was independently re-demonstrated in all four directions with different values; AC6's field list **adds** `ndim`, `n_cells` and `n_nodes`, which the pre-port test compared *not at all* |

### #381 `AC5` is amended, not met

AC5 asks for a test that builds a `Partition` under each backend and asserts that **combining
them** raises `TypeError`. **`Partition` has no binary operation**, so there is no site at which
two of them could meet and nothing for such a guard to sit on; adding one would be dead code.
Established three independent ways: by `inspect` over the public surface, by
`grep -rn "Partition" src/pantr` confirming every hit takes exactly one `Partition`, and by a
third check at review time. The AC assumed a surface that does not exist.

What replaces it is better than what it asked for, and is recorded as the amendment. The test pins
both halves — that per-process selection really does produce two unrelated implementations in one
process, *and* that the public surface really does take no second `Partition`, failing with a
message naming the refusal `AABB._peer` performs if that ever changes. **An AC that cannot be met
became a tripwire that fires the moment it can be.**

## The BVH ports faithfully, and a false claim is withdrawn

`BVH.query_aabb` reports hits for an **empty** query box, while `AABB.overlaps` says an empty box
overlaps nothing. Reproduced: one cell `[0, 10]` in one dimension, queried with `lo = 5, hi = 3`,
returns cell `0` from the BVH and `False` from the box. The predicate is a separating-axis test
with no emptiness branch, in **both** backends.

**Ruled: port faithfully, keep the divergence, correct the comment.** Whenever the semantics is
fixed it must move both backends together or the parity claim stops being an equality, so fixing
it during a port costs the clean oracle and buys nothing. But `bvh.hpp` claimed the test matched
`pantr.geometry.AABB.overlaps`, and that claim is false — so the claim is withdrawn, the
reproduction is written into the header, and the reason the behaviour is unchanged is recorded
next to it. Tracked as a divergence between two predicates, not a defect in either.

## Mutation checks

| # | Ticket | Mutation | C++ ctest | Python |
|---|---|---|---|---|
| 1 | #382 | `tags.hpp` `store()`: replace-in-place became erase+append, so a replaced tag moves to the end | caught, 2 failures | caught, 2 failed / 43 passed |
| 2 | #382 | `require_ids_in_range`: `>= num_cells_` weakened to `>`, accepting `id == num_cells` | caught, 2 failures | caught, 2 failed / 43 passed |
| 3 | #381 | `partition.hpp`: owner upper bound `>= n_parts` weakened to `>` | caught, 1 failure | caught, 2 failed / 24 passed |
| 4 | #381 | `owned_cells`: rank lower bound `< 0` tightened to `<= 0`, refusing rank 0 | caught, as a hard abort | caught, 5 failed / 21 passed |
| 5 | #384 | `bvh_build`: child-order convention flipped, right subtree expanded first | **SURVIVED** — see below | caught |
| 6 | #384 | `node_overlaps`: `<` weakened to `<=`, making the shared face exclusive | caught, *"a box on the shared face must meet BOTH cells"* | caught, 4 failed / 82 passed |

**Mutation 5 survived the C++ suite, and why it did is the useful part.** The test built a
**3-cell** tree. At three cells the root's two children claim indices 1 and 2 before either is
expanded, and only one of them splits further — so reversing the push order leaves every index
unchanged and the assertion was true under *both* conventions. Strengthened to **4 cells**, where
both children split and the expansion order decides whether the left subtree's children are nodes
3 and 4 or 5 and 6; re-running the same mutation then produced three failures reading *"the build
must expand the left subtree first"*. The strengthening is in `2daf7fe`.

**One honest caveat on row 5's Python column.** Those tests were red partly because they also
compared the two backends' arrays at the time. The `a574c97` self-review deliberately removed that
value comparison, so cross-backend equality is now claimed only by `tests/parity/test_grid.py`.
The figures above are as-measured and are **not reproducible as stated today**: the flip is now
caught by the parity tests and the strengthened C++ test instead. Recorded rather than quietly
restated, because a mutation result that no longer reproduces is worth more as a dated
observation than as a corrected number.

## Scaffolding

The three Python oracle classes and their backend branches — the port's oracles, removed when the
C++ core stops being optional, together with `AABB`'s and `AffineTransform`'s. The same seam, not
a new one. No compat shim, no flag, no adapter.

## Known, carried forward

- **`scripts/ci_local.sh` fails at the g++-10 floor build** on `geometry/aabb.hpp` — floating-point
  `std::to_chars` needs libstdc++ 11. Pre-existing, independently reproduced against a pristine
  base, ticket pending.
- **`pantr::CapacityError` still has no throw round-trip from this branch.** #380 registered it and
  its translator for the BVH's fixed traversal stack; that stack's guard needs more than 2^127
  cells and cannot fire today, so nanobind preferring the specific `nb::exception<CapacityError>`
  over the generic `std::runtime_error` catch remains an assumption. #383 exercises the same
  translator from the quadrature side and pins it there.
- **The adversarial sweep's `grid` group runs last**, so an unscoped `--profile full` never reaches
  the grid probes — it crashes earlier, in a group this branch does not touch
  (`tools/adversarial_sweep/` has zero diff across all four commits). The AC6 evidence is therefore
  a scoped `--group grid` run: 518 cases, 0 BUG. Worth knowing before gating anything else in this
  milestone on an unscoped sweep.
