### PR TITLE
feat(grid): own the generic Grid operations in C++ as a closed hierarchy

### DIFF
--- a/cpp/include/pantr/grid/grid.hpp
+++ b/cpp/include/pantr/grid/grid.hpp
@@ -35,7 +35,9 @@
 /// ## The three primitives
 ///
 /// A grid supplies exactly three members, and `GridLike` pins each to an EXACT
-/// member-pointer type rather than to callability:
+/// member-pointer type rather than to callability. Three here against five in
+/// `src/pantr/grid/_grid.py`, and the difference is not a disagreement: `ndim` and
+/// `num_cells` are abstract there and base state here, for the reason given below.
 ///
 /// ```cpp
 /// void cell_bounds(std::int64_t cid, std::span<T> lo, std::span<T> hi) const;
@@ -77,8 +79,11 @@
 /// `D` does not redeclare it, and `R (D::*)(...)` when it does. The two are the same
 /// type exactly when the hook is absent, and that stays true when the hook's return
 /// type is wrong or a parameter is const-qualified, where a `requires` probe answers
-/// `true`. Known limit, and it is a loud one: `&D::name` is ill-formed if `D` overloads
-/// the name or makes it a template. Both are design errors here.
+/// `true`. Known limits, and they are loud: `&D::name` is ill-formed if `D` overloads
+/// the name or makes it a template, and a primitive declared `noexcept` has a different
+/// member-pointer type and so fails `GridLike` rather than the census. All three are
+/// design errors here; the third is worth knowing because its diagnostic says only
+/// "not a grid".
 ///
 /// The differential oracle a specialisation owes its default is the qualified call:
 /// `g.pantr::grid::GridBase<G>::boundary_facets()` reaches the hidden default. A
@@ -125,7 +130,6 @@
 #include <vector>
 
 #include "pantr/core/mdspan.hpp"
-#include "pantr/core/precondition.hpp"
 #include "pantr/core/scalar.hpp"
 #include "pantr/geometry/aabb.hpp"
 #include "pantr/grid/bvh_tree.hpp"
@@ -400,8 +404,7 @@ class GridBase {
     /// \param lo Output lo corner, length `ndim`.
     /// \param hi Output hi corner, length `ndim`.
     /// \throws std::out_of_range If `cid` or `lfid` is out of range.
-    /// \note `lo` and `hi` must both have length `ndim`; a shorter span is indexed out
-    ///       of bounds. Checked by `PANTR_PRECONDITION`.
+    /// \throws std::invalid_argument If `lo` or `hi` is not length `ndim`.
     void local_facet_bounds(std::int64_t cid, std::int64_t lfid, std::span<scalar_type> lo,
                             std::span<scalar_type> hi) const {
         require_corner_spans(lo, hi);
@@ -433,7 +436,10 @@ class GridBase {
     /// exploitable structure replaces it. This is the loop the CRTP shape was measured
     /// on.
     ///
-    /// \return `2 * n` values, row-major `(cid, lfid)` pairs, sorted by construction.
+    /// \return `2 * n` values: `n` row-major `(cid, lfid)` pairs, sorted by
+    ///         construction. Flat rather than a vector of pairs because a binding
+    ///         reshapes it to the `(n, 2)` array the Python side returns; divide the
+    ///         size by two to get the row count.
     [[nodiscard]] std::vector<std::int64_t> boundary_facets() const {
         std::vector<std::int64_t> rows;
         for (std::int64_t cid = 0; cid < num_cells_; ++cid) {
@@ -474,11 +480,11 @@ class GridBase {
     ///
     /// \param points `(npts, ndim)` row-major view of query points.
     /// \return `npts` cell ids; `-1` for a point outside every cell.
-    /// \note `points.extent(1)` must equal `ndim`. Checked by `PANTR_PRECONDITION`.
+    /// \throws std::invalid_argument If `points.extent(1)` is not `ndim`.
     [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const scalar_type> points) const {
         const auto n = static_cast<std::size_t>(ndim_);
-        PANTR_PRECONDITION(points.extent(1) == n, "points must have ndim columns");
         const std::size_t npts = points.extent(0);
+        require_shape(points, npts, "points");
         std::vector<std::int64_t> out(npts);
         for (std::size_t i = 0; i < npts; ++i) {
             const std::span<const scalar_type> pt(&at(points, i, std::size_t{0}), n);
@@ -493,12 +499,12 @@ class GridBase {
     /// Backed by `cell_bvh()`. The overlap test is inclusive on every axis, so cells
     /// touching `box` on a face, an edge or a corner are included.
     ///
-    /// \param box Query box; must match `ndim`.
+    /// \param aabb Query box; must match `ndim`.
     /// \return The overlapping cell ids, unordered.
-    /// \throws std::invalid_argument If `box.ndim()` does not match.
+    /// \throws std::invalid_argument If `aabb.ndim()` does not match.
     [[nodiscard]] std::vector<std::int64_t> query_aabb(
-        const geometry::AABB<scalar_type>& box) const {
-        return cell_bvh().query_aabb(box.lo(), box.hi());
+        const geometry::AABB<scalar_type>& aabb) const {
+        return cell_bvh().query_aabb(aabb.lo(), aabb.hi());
     }
 
     /// The cached BVH over the grid's cell AABBs, built on first use.
@@ -507,7 +513,8 @@ class GridBase {
     /// is never queried never pays for it. Not specialisable, and the cache slot is
     /// private -- nothing can hand it out.
     ///
-    /// \return The grid's spatial index.
+    /// \return A reference to a member of this grid, valid for as long as the grid is.
+    ///         Nothing invalidates it: the cache is filled once and never replaced.
     /// \warning Not fully thread-safe. Concurrent first calls may each build a valid
     ///          tree and one write wins, costing redundant construction. Call this once
     ///          on the main thread before sharing the grid across threads.
@@ -533,14 +540,12 @@ class GridBase {
     ///
     /// \param cell_lo Output lo corners, shape `(num_cells, ndim)`.
     /// \param cell_hi Output hi corners, same shape.
-    /// \note Both views must have exactly that shape. Checked by `PANTR_PRECONDITION`.
+    /// \throws std::invalid_argument If either view is not shaped `(num_cells, ndim)`.
     void collect_cell_bounds(span2d<scalar_type> cell_lo, span2d<scalar_type> cell_hi) const {
         const auto n = static_cast<std::size_t>(num_cells_);
         const auto d = static_cast<std::size_t>(ndim_);
-        PANTR_PRECONDITION(cell_lo.extent(0) == n && cell_lo.extent(1) == d,
-                           "cell_lo must have shape (num_cells, ndim)");
-        PANTR_PRECONDITION(cell_hi.extent(0) == n && cell_hi.extent(1) == d,
-                           "cell_hi must have shape (num_cells, ndim)");
+        require_shape(cell_lo, n, "cell_lo");
+        require_shape(cell_hi, n, "cell_hi");
         for (std::size_t row = 0; row < n; ++row) {
             self().cell_bounds(static_cast<std::int64_t>(row),
                                std::span<scalar_type>(&at(cell_lo, row, std::size_t{0}), d),
@@ -557,7 +562,10 @@ class GridBase {
     /// Eager rather than lazy: an empty registry has no per-cell footprint, so laziness
     /// would buy one allocation and cost a `mutable` and a branch.
     ///
-    /// \return A mutable reference to the registry, valid for the grid's lifetime.
+    /// \return A mutable reference to a member of this grid. It is valid for as long
+    ///         as the grid is, and is invalidated by nothing else; a binding must say
+    ///         so to nanobind with `rv_policy::reference_internal`, or the default
+    ///         policy copies and a write through the result is silently lost.
     [[nodiscard]] CellTags& cell_tags() noexcept { return cell_tags_; }
 
     /// The grid's sparse cell-tag registry, read only.
@@ -567,7 +575,8 @@ class GridBase {
 
     /// The grid's sparse facet-tag registry, sized `2 * ndim` facets per cell.
     ///
-    /// \return A mutable reference to the registry, valid for the grid's lifetime.
+    /// \return A mutable reference to a member of this grid, with the same lifetime
+    ///         and the same binding requirement as `cell_tags()`.
     [[nodiscard]] FacetTags& facet_tags() noexcept { return facet_tags_; }
 
     /// The grid's sparse facet-tag registry, read only.
@@ -661,18 +670,46 @@ class GridBase {
         return num_cells;
     }
 
-    /// Assert that two corner spans are both length `ndim`.
+    /// Reject two corner spans that are not both length `ndim`.
+    ///
+    /// Unconditional rather than `PANTR_PRECONDITION`, and the distinction is the one
+    /// `core/precondition.hpp` draws: that macro is `assert`, so it vanishes under
+    /// `NDEBUG` and the release build would index out of bounds instead of reporting.
+    /// A caller-supplied output span is exactly the case the sibling types check
+    /// unconditionally -- `CellTags::scatter` and `BVH::query_aabb` both throw on a
+    /// wrongly sized argument -- and the cost is one comparison per call, not per
+    /// element.
     ///
     /// \param lo Candidate lo corner.
     /// \param hi Candidate hi corner.
+    /// \throws std::invalid_argument If either span's length differs from `ndim`.
     void require_corner_spans(std::span<const scalar_type> lo,
                               std::span<const scalar_type> hi) const {
         const auto n = static_cast<std::size_t>(ndim_);
-        PANTR_PRECONDITION(lo.size() == n, "lo must have length ndim");
-        PANTR_PRECONDITION(hi.size() == n, "hi must have length ndim");
-        static_cast<void>(lo);
-        static_cast<void>(hi);
-        static_cast<void>(n);
+        if (lo.size() != n || hi.size() != n) {
+            throw std::invalid_argument("lo (" + std::to_string(lo.size()) + ") and hi ("
+                                        + std::to_string(hi.size())
+                                        + ") must both have length ndim ("
+                                        + std::to_string(n) + ").");
+        }
+    }
+
+    /// Reject a two-dimensional view that is not shaped `(rows, ndim)`.
+    ///
+    /// Unconditional, for the reason `require_corner_spans` gives.
+    ///
+    /// \param view The candidate view.
+    /// \param rows The row count it must have.
+    /// \param what The parameter's name, for the message.
+    /// \throws std::invalid_argument If either extent is wrong.
+    void require_shape(span2d<const scalar_type> view, std::size_t rows, const char* what) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        if (view.extent(0) != rows || view.extent(1) != n) {
+            throw std::invalid_argument(
+                std::string(what) + " must have shape (" + std::to_string(rows) + ", "
+                + std::to_string(n) + "); got (" + std::to_string(view.extent(0)) + ", "
+                + std::to_string(view.extent(1)) + ").");
+        }
     }
 
     std::int64_t ndim_;                            ///< Number of axes.

--- a/cpp/include/pantr/grid/grid.hpp
+++ b/cpp/include/pantr/grid/grid.hpp
@@ -835,6 +835,12 @@ PANTR_GRID_DECLARE_HOOK(num_local_facets, std::int64_t (D::*)(std::int64_t) cons
 
 /// Assert one hook against the grid's declaration, in both directions.
 ///
+/// The first assertion is the two-way agreement between the class and the bitmask. The
+/// second is keyed on whether the class REDECLARES the name rather than on whether the
+/// bitmask names it, so that a hook declared and never written fires the first message
+/// alone -- "the signature is wrong" would be an odd thing to say about a member that
+/// does not exist.
+///
 /// \param GRID The grid type. Must not contain a comma at the top level.
 /// \param NAME The hook's member name.
 #define PANTR_GRID_CENSUS_HOOK(GRID, NAME)                                                    \
@@ -845,8 +851,7 @@ PANTR_GRID_DECLARE_HOOK(num_local_facets, std::int64_t (D::*)(std::int64_t) cons
                   "disagree -- either the hook is written and not declared, in which case "   \
                   "it runs and nothing says so, or it is declared and not written, in which " \
                   "case the default runs and nothing says so");                               \
-    static_assert(!::pantr::grid::declares(::pantr::grid::grid_traits<GRID>::hooks,           \
-                                           ::pantr::grid::Hook::NAME)                         \
+    static_assert(!::pantr::grid::detail::redeclares_##NAME<GRID>()                            \
                       || ::pantr::grid::detail::hook_signature_matches_##NAME<GRID>(),        \
                   "pantr grid census (" #GRID ", " #NAME "): the hook does not have the "     \
                   "signature of the default it replaces")

--- a/cpp/include/pantr/grid/grid.hpp
+++ b/cpp/include/pantr/grid/grid.hpp
@@ -1,0 +1,898 @@
+#pragma once
+
+/// \file
+/// The generic grid layer: a CRTP mixin holding its own state, dispatching by name
+/// hiding, and carrying no vtable at all.
+///
+/// The reasoning behind every choice below is `design/grid_hierarchy_port.md`; what
+/// follows is the part a reader of this header needs in order to write a grid.
+///
+/// ## Writing a grid: three things, in this order
+///
+/// ```cpp
+/// template <class T> class MyGrid;                      // 1. forward declaration
+///
+/// template <class T> struct pantr::grid::grid_traits<MyGrid<T>> {
+///     using scalar_type = T;
+///     static constexpr Hook hooks = Hook::locate_many;  // 2. the traits
+/// };
+///
+/// template <class T>
+/// class MyGrid : public pantr::grid::GridBase<MyGrid<T>> {  // 3. the class
+///     ...
+/// };
+///
+/// PANTR_GRID_CENSUS(MyGrid<double>)                     // once per instantiation
+/// ```
+///
+/// `grid_traits` is a separate template rather than a nested typedef because
+/// `using scalar_type = typename Derived::scalar_type;` inside a CRTP base is
+/// ill-formed: `Derived` is incomplete where the base is instantiated. The primary
+/// template is deliberately left undefined, so a grid that forgets its traits is
+/// rejected at its own definition rather than at the first default that needs the
+/// scalar.
+///
+/// ## The three primitives
+///
+/// A grid supplies exactly three members, and `GridLike` pins each to an EXACT
+/// member-pointer type rather than to callability:
+///
+/// ```cpp
+/// void cell_bounds(std::int64_t cid, std::span<T> lo, std::span<T> hi) const;
+/// std::optional<std::int64_t> locate(std::span<const T> pt) const;
+/// std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+///                                                   std::int64_t lfid) const;
+/// ```
+///
+/// Exactness is load-bearing and the reason is not obvious. `std::span<T>` converts
+/// implicitly to `std::span<const T>`, so a concept written as a callability probe --
+/// `requires(std::span<T> out) { g.cell_bounds(cid, out, out); }` -- is satisfied by a
+/// `cell_bounds` whose output spans are `std::span<const T>` and which therefore
+/// CANNOT WRITE ITS OUTPUT. Measured: such a grid was accepted by g++ 14.4, g++ 10.5,
+/// clang++ 18.1 and clang++ 10.0 alike under `-Wall -Wextra -Werror`, compiled, and
+/// returned whatever was already in the caller's buffer. Pinning the member-pointer
+/// type rejects it on all four.
+///
+/// `ndim` and `num_cells` are NOT primitives. They are base state, passed up from the
+/// derived constructor, which is what lets `cell_tags()` have ordinary const and
+/// non-const overloads with no `const_cast` anywhere near them, keeps the BVH cache
+/// slot private, and makes `num_cells()` a field read in the hot loops. It assumes a
+/// grid's cell count is fixed at construction; FELIGN/pantr#378 makes refinement
+/// return a new grid, which is what makes that true for the hierarchical grid too.
+///
+/// ## Specialisation: name hiding dispatches, the bitmask is checked
+///
+/// A default is an ordinary non-virtual member of the mixin, so a `Derived` that
+/// declares the same name HIDES it, and every call -- from outside, and from inside
+/// another default through `self()` -- reaches the specialisation. Nothing reads
+/// `grid_traits<G>::hooks` to route a call.
+///
+/// The bitmask is a DECLARATION, and `PANTR_GRID_CENSUS` checks the class against it
+/// in both directions. That is the point: under bitmask dispatch, a hook written but
+/// not declared is silently ignored and the default runs, which is a wrong answer with
+/// no diagnostic. Here it is a compile error.
+///
+/// Detection compares member-pointer TYPES, not a `requires` probe:
+/// `&D::locate_many` names the mixin's member -- type `R (GridBase<D>::*)(...)` -- when
+/// `D` does not redeclare it, and `R (D::*)(...)` when it does. The two are the same
+/// type exactly when the hook is absent, and that stays true when the hook's return
+/// type is wrong or a parameter is const-qualified, where a `requires` probe answers
+/// `true`. Known limit, and it is a loud one: `&D::name` is ill-formed if `D` overloads
+/// the name or makes it a template. Both are design errors here.
+///
+/// The differential oracle a specialisation owes its default is the qualified call:
+/// `g.pantr::grid::GridBase<G>::boundary_facets()` reaches the hidden default. A
+/// derived class must therefore NOT privately alias its base. This is the C++ analogue
+/// of `Grid.boundary_facets(g)` in `tests/test_grid_hierarchical.py`.
+///
+/// ## What is deliberately not hookable
+///
+/// `num_local_facets` is fixed at `2 * ndim` because `facet_tags_` is sized `2 * ndim`
+/// once, at construction; a grid that changed it would desynchronise the registry from
+/// the geometry. The census asserts it is not redeclared. `cell_tags`, `facet_tags` and
+/// `cell_bvh` are base-owned state and are called directly rather than through
+/// `self()`, so hiding one cannot change what another default sees.
+///
+/// ## What CRTP costs
+///
+/// There is no runtime grid type: `std::vector<Grid*>`, a grid chosen from a config
+/// file, and a non-template function taking any grid are all unavailable without a
+/// hand-written variant. Nothing in pantr does any of these. Every generic algorithm
+/// over grids is a template, so it lives in a header and its errors are template
+/// errors. What it buys is inlining: measured on the generic `boundary_facets`
+/// neighbour loop, CRTP against a virtual base with the dynamic type hidden behind a
+/// factory in another translation unit was 15.1x on the neighbour queries and 6.8x on
+/// the whole method. `design/grid_hierarchy_port.md` carries the numbers, the machine
+/// and the command, and records that a first attempt measured 1.05x because GCC
+/// devirtualized the call and compared CRTP against CRTP.
+///
+/// ## Thread safety
+///
+/// `cell_bvh()` fills a `mutable std::optional` with no lock, no atomic and no
+/// `std::once_flag`. That is the contract the Python oracle documents and no more:
+/// concurrent first calls may each build a valid tree and one write wins, costing
+/// redundant construction; a caller sharing a grid across threads should call
+/// `cell_bvh()` once first. Everything else here is const and shares nothing.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/precondition.hpp"
+#include "pantr/core/scalar.hpp"
+#include "pantr/geometry/aabb.hpp"
+#include "pantr/grid/bvh_tree.hpp"
+#include "pantr/grid/tags.hpp"
+#include "pantr/transform/affine.hpp"
+
+namespace pantr::grid {
+
+// ---------------------------------------------------------------------------
+// Traits and the specialisation declaration
+// ---------------------------------------------------------------------------
+
+/// The defaults a grid may replace, as a bitmask.
+///
+/// A grid names the ones it writes in `grid_traits<G>::hooks`. Nothing reads this to
+/// dispatch -- name hiding does that. `PANTR_GRID_CENSUS` reads it, and rejects a class
+/// that disagrees with its own declaration in either direction.
+///
+/// Absent by design: `num_local_facets` (fixed at `2 * ndim`, see the file header),
+/// and `cell_tags` / `facet_tags` / `cell_bvh` (base-owned state).
+enum class Hook : std::uint32_t {
+    none = 0,                          ///< Every default is inherited.
+    cell_aabb = 1U << 0U,              ///< `cell_aabb`.
+    cell_level = 1U << 1U,             ///< `cell_level`.
+    child_cells = 1U << 2U,            ///< `child_cells`.
+    reference_map = 1U << 3U,          ///< `reference_map`.
+    neighbors = 1U << 4U,              ///< `neighbors`.
+    restrict = 1U << 5U,               ///< `restrict`.
+    local_facet_axis_side = 1U << 6U,  ///< `local_facet_axis_side`.
+    local_facet_bounds = 1U << 7U,     ///< `local_facet_bounds`.
+    is_mesh_boundary_facet = 1U << 8U, ///< `is_mesh_boundary_facet`.
+    boundary_facets = 1U << 9U,        ///< `boundary_facets`.
+    hanging_neighbors = 1U << 10U,     ///< `hanging_neighbors`.
+    locate_many = 1U << 11U,           ///< `locate_many`.
+    query_aabb = 1U << 12U,            ///< `query_aabb`.
+    collect_cell_bounds = 1U << 13U,   ///< `collect_cell_bounds`.
+};
+
+/// Combine two hook flags.
+///
+/// \param a Left operand.
+/// \param b Right operand.
+/// \return The union of the two masks.
+[[nodiscard]] constexpr Hook operator|(Hook a, Hook b) noexcept {
+    return static_cast<Hook>(static_cast<std::uint32_t>(a) | static_cast<std::uint32_t>(b));
+}
+
+/// Test whether a mask names a hook.
+///
+/// \param mask The grid's declared hooks.
+/// \param hook The hook to look for.
+/// \return `true` iff `hook` is set in `mask`.
+[[nodiscard]] constexpr bool declares(Hook mask, Hook hook) noexcept {
+    return (static_cast<std::uint32_t>(mask) & static_cast<std::uint32_t>(hook)) != 0U;
+}
+
+/// What the generic layer needs to know about a grid before the grid is complete.
+///
+/// Every grid specialises this, supplying `scalar_type` and a `static constexpr Hook
+/// hooks`. The primary template is deliberately left UNDEFINED: a grid deriving from
+/// `GridBase` without a specialisation is then rejected at its own definition, with
+/// `grid_traits` named in the diagnostic, rather than at whichever default first
+/// needed the scalar.
+///
+/// \tparam Derived The grid type.
+template <class Derived>
+struct grid_traits;
+
+// ---------------------------------------------------------------------------
+// GridRestriction
+// ---------------------------------------------------------------------------
+
+/// A windowed sub-grid plus the index maps relating it to the grid it came from.
+///
+/// The C++ counterpart of `pantr.grid.GridRestriction`. Deliberately UNCONSTRAINED in
+/// `G`: a constrained `GridRestriction<G>` named as a return type *inside* the grid
+/// being defined gives "satisfaction of atomic constraint depends on itself" on both
+/// compiler families, and reordering the declarations does not help. The constraint
+/// lives on `make_restriction` instead, which also gives the size-agreement check a
+/// home.
+///
+/// Two things are lost by that and are worth stating rather than discovering: the type
+/// is nameable for a non-grid, and aggregate initialisation bypasses the factory.
+///
+/// `in_subset` is `std::uint8_t` rather than `bool` because `std::vector<bool>` is a
+/// bit-packed proxy container with no `data()`, which nothing downstream can hand to
+/// nanobind or to a span.
+///
+/// \tparam G The grid type, which is the same concrete type as the grid restricted.
+template <class G>
+struct GridRestriction {
+    G grid;                                          ///< The windowed sub-grid.
+    std::vector<std::int64_t> local_to_global_cell;  ///< Sub-grid cell id to this grid's.
+    std::vector<std::uint8_t> in_subset;             ///< `1` if requested, `0` if fill.
+};
+
+// ---------------------------------------------------------------------------
+// The mixin
+// ---------------------------------------------------------------------------
+
+/// The generic grid layer: state, the fourteen replaceable defaults, and four that are not.
+///
+/// Every grid is a `GridBase<itself>`; `GridLike` says exactly that in one line. See the
+/// file header for how to write one and for why the dispatch is name hiding.
+///
+/// \tparam Derived The grid deriving from this mixin.
+template <class Derived>
+class GridBase {
+  public:
+    /// The floating-point type this grid's coordinates are stored in.
+    using scalar_type = typename grid_traits<Derived>::scalar_type;
+
+    static_assert(Real<scalar_type>, "a grid's scalar_type must satisfy pantr::Real");
+
+    // ----------------------------------------------------------------
+    // State
+    // ----------------------------------------------------------------
+
+    /// The spatial dimension of the grid.
+    ///
+    /// \return The number of axes, `>= 1`.
+    [[nodiscard]] std::int64_t ndim() const noexcept { return ndim_; }
+
+    /// The number of cells in this (local) grid.
+    ///
+    /// \return The non-negative cell count.
+    [[nodiscard]] std::int64_t num_cells() const noexcept { return num_cells_; }
+
+    // ----------------------------------------------------------------
+    // Cell accessors
+    // ----------------------------------------------------------------
+
+    /// The axis-aligned bounding box of cell `cid`.
+    ///
+    /// \param cid Cell identifier.
+    /// \return `AABB(lo, hi)` for the cell's corners.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] geometry::AABB<scalar_type> cell_aabb(std::int64_t cid) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        std::vector<scalar_type> lo(n);
+        std::vector<scalar_type> hi(n);
+        self().cell_bounds(cid, std::span<scalar_type>(lo), std::span<scalar_type>(hi));
+        return geometry::AABB<scalar_type>(std::span<const scalar_type>(lo),
+                                           std::span<const scalar_type>(hi));
+    }
+
+    /// The refinement level of cell `cid`.
+    ///
+    /// Flat grids are all level zero; a hierarchical grid replaces this.
+    ///
+    /// \param cid Cell identifier.
+    /// \return `0`.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::int64_t cell_level(std::int64_t cid) const {
+        check_cid(cid);
+        return 0;
+    }
+
+    /// The immediate refinement children of cell `cid`.
+    ///
+    /// \param cid Cell identifier.
+    /// \return An empty vector; a flat grid has no children.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::vector<std::int64_t> child_cells(std::int64_t cid) const {
+        check_cid(cid);
+        return {};
+    }
+
+    /// The affine map from the unit cube onto cell `cid`.
+    ///
+    /// For an axis-aligned cell this is `T(u) = diag(hi - lo) u + lo`.
+    ///
+    /// \param cid Cell identifier.
+    /// \return The push-forward from `[0, 1]^ndim` to the cell.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] transform::AffineTransform<scalar_type> reference_map(std::int64_t cid) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        std::vector<scalar_type> lo(n);
+        std::vector<scalar_type> hi(n);
+        self().cell_bounds(cid, std::span<scalar_type>(lo), std::span<scalar_type>(hi));
+        std::vector<scalar_type> matrix(n * n, scalar_type{0});
+        for (std::size_t k = 0; k < n; ++k) {
+            matrix[(k * n) + k] = hi[k] - lo[k];
+        }
+        return transform::AffineTransform<scalar_type>(
+            span2d<const scalar_type>(matrix.data(), n, n), std::span<const scalar_type>(lo));
+    }
+
+    /// The facet-neighbour cell ids of `cid`.
+    ///
+    /// Collects `neighbor_across_facet` over every local facet and drops the boundary
+    /// ones.
+    ///
+    /// \param cid Cell identifier.
+    /// \return The neighbouring cell ids, in local facet order.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::vector<std::int64_t> neighbors(std::int64_t cid) const {
+        const std::int64_t n_facets = num_local_facets(cid);
+        std::vector<std::int64_t> out;
+        out.reserve(static_cast<std::size_t>(n_facets));
+        for (std::int64_t lfid = 0; lfid < n_facets; ++lfid) {
+            if (const std::optional<std::int64_t> nbr = self().neighbor_across_facet(cid, lfid)) {
+                out.push_back(*nbr);
+            }
+        }
+        return out;
+    }
+
+    // ----------------------------------------------------------------
+    // Restriction
+    // ----------------------------------------------------------------
+
+    /// The structured sub-grid spanning a subset of cells.
+    ///
+    /// Restriction is an OPTIONAL grid capability and this default throws, exactly as
+    /// `pantr.grid.Grid.restrict` raises `NotImplementedError`. It is a default rather
+    /// than a fourth primitive so that the C++ layer does not change the documented
+    /// contract of a public method for a reason internal to itself. The usual
+    /// objection -- a base advertising an operation not every subtype supports -- does
+    /// not bind here, because nobody holds a `GridBase<D>&` polymorphically and so
+    /// there is no substitutability to violate.
+    ///
+    /// A binding owes the Python side the translation to `NotImplementedError`;
+    /// nanobind's default translator maps `std::logic_error` to `RuntimeError`.
+    ///
+    /// \param cell_ids Flat cell identifiers to span.
+    /// \return Never returns.
+    /// \throws std::logic_error Always.
+    [[nodiscard]] GridRestriction<Derived> restrict(std::span<const std::int64_t> cell_ids) const {
+        static_cast<void>(cell_ids);
+        throw std::logic_error("this grid kind does not support restrict().");
+    }
+
+    // ----------------------------------------------------------------
+    // Facet accessors
+    // ----------------------------------------------------------------
+
+    /// The number of local facets of cell `cid`.
+    ///
+    /// Always `2 * ndim`, and NOT specialisable: `facet_tags_` is sized `2 * ndim` once
+    /// at construction, so a grid that changed this would desynchronise the registry
+    /// from the geometry. `PANTR_GRID_CENSUS` asserts no grid redeclares it.
+    ///
+    /// \param cid Cell identifier.
+    /// \return `2 * ndim`.
+    /// \throws std::out_of_range If `cid` is out of range.
+    [[nodiscard]] std::int64_t num_local_facets(std::int64_t cid) const {
+        check_cid(cid);
+        return 2 * ndim_;
+    }
+
+    /// The `(axis, side)` of local facet `lfid` of cell `cid`.
+    ///
+    /// Uses the `lfid = 2 * axis + side` encoding, with `side == 0` the low face.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier in `[0, 2 * ndim)`.
+    /// \return `(axis, side)`.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] std::pair<std::int64_t, std::int64_t> local_facet_axis_side(
+        std::int64_t cid, std::int64_t lfid) const {
+        check_lfid(cid, lfid);
+        return {lfid / 2, lfid % 2};
+    }
+
+    /// The degenerate `(lo, hi)` box of local facet `lfid` of cell `cid`.
+    ///
+    /// Both corners coincide on the facet's normal axis; the others span the cell.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier in `[0, 2 * ndim)`.
+    /// \param lo Output lo corner, length `ndim`.
+    /// \param hi Output hi corner, length `ndim`.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    /// \note `lo` and `hi` must both have length `ndim`; a shorter span is indexed out
+    ///       of bounds. Checked by `PANTR_PRECONDITION`.
+    void local_facet_bounds(std::int64_t cid, std::int64_t lfid, std::span<scalar_type> lo,
+                            std::span<scalar_type> hi) const {
+        require_corner_spans(lo, hi);
+        const auto [axis, side] = self().local_facet_axis_side(cid, lfid);
+        self().cell_bounds(cid, lo, hi);
+        const auto k = static_cast<std::size_t>(axis);
+        if (side == 0) {
+            hi[k] = lo[k];
+        } else {
+            lo[k] = hi[k];
+        }
+    }
+
+    /// Whether local facet `lfid` of cell `cid` lies on the grid's outer boundary.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier.
+    /// \return `true` iff no neighbouring cell shares the facet.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] bool is_mesh_boundary_facet(std::int64_t cid, std::int64_t lfid) const {
+        return !self().neighbor_across_facet(cid, lfid).has_value();
+    }
+
+    /// Every outer-boundary facet, as `(cid, lfid)` rows.
+    ///
+    /// Only the outer boundary: a facet shared with any neighbour is excluded, whether
+    /// that neighbour is conforming, coarser or finer. Costs
+    /// `O(num_cells * 2 * ndim)` neighbour queries, which is why a grid with
+    /// exploitable structure replaces it. This is the loop the CRTP shape was measured
+    /// on.
+    ///
+    /// \return `2 * n` values, row-major `(cid, lfid)` pairs, sorted by construction.
+    [[nodiscard]] std::vector<std::int64_t> boundary_facets() const {
+        std::vector<std::int64_t> rows;
+        for (std::int64_t cid = 0; cid < num_cells_; ++cid) {
+            const std::int64_t n_facets = num_local_facets(cid);
+            for (std::int64_t lfid = 0; lfid < n_facets; ++lfid) {
+                if (self().is_mesh_boundary_facet(cid, lfid)) {
+                    rows.push_back(cid);
+                    rows.push_back(lfid);
+                }
+            }
+        }
+        return rows;
+    }
+
+    /// Every active cell sharing local facet `lfid` of `cid`.
+    ///
+    /// For a conforming grid this is `neighbor_across_facet` in a vector. A grid with
+    /// hanging nodes, where one coarse face abuts several fine cells, replaces it.
+    ///
+    /// \param cid Cell identifier.
+    /// \param lfid Local facet identifier.
+    /// \return The neighbouring cell ids; empty on an outer-boundary facet.
+    /// \throws std::out_of_range If `cid` or `lfid` is out of range.
+    [[nodiscard]] std::vector<std::int64_t> hanging_neighbors(std::int64_t cid,
+                                                              std::int64_t lfid) const {
+        const std::optional<std::int64_t> nbr = self().neighbor_across_facet(cid, lfid);
+        if (!nbr) {
+            return {};
+        }
+        return {*nbr};
+    }
+
+    // ----------------------------------------------------------------
+    // Point location and spatial queries
+    // ----------------------------------------------------------------
+
+    /// Locate a batch of points, one cell id per point.
+    ///
+    /// \param points `(npts, ndim)` row-major view of query points.
+    /// \return `npts` cell ids; `-1` for a point outside every cell.
+    /// \note `points.extent(1)` must equal `ndim`. Checked by `PANTR_PRECONDITION`.
+    [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const scalar_type> points) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        PANTR_PRECONDITION(points.extent(1) == n, "points must have ndim columns");
+        const std::size_t npts = points.extent(0);
+        std::vector<std::int64_t> out(npts);
+        for (std::size_t i = 0; i < npts; ++i) {
+            const std::span<const scalar_type> pt(&at(points, i, std::size_t{0}), n);
+            const std::optional<std::int64_t> cid = self().locate(pt);
+            out[i] = cid.value_or(-1);
+        }
+        return out;
+    }
+
+    /// The ids of every cell whose AABB overlaps `box`.
+    ///
+    /// Backed by `cell_bvh()`. The overlap test is inclusive on every axis, so cells
+    /// touching `box` on a face, an edge or a corner are included.
+    ///
+    /// \param box Query box; must match `ndim`.
+    /// \return The overlapping cell ids, unordered.
+    /// \throws std::invalid_argument If `box.ndim()` does not match.
+    [[nodiscard]] std::vector<std::int64_t> query_aabb(
+        const geometry::AABB<scalar_type>& box) const {
+        return cell_bvh().query_aabb(box.lo(), box.hi());
+    }
+
+    /// The cached BVH over the grid's cell AABBs, built on first use.
+    ///
+    /// Building materialises `O(num_cells)` node arrays, so it is deferred: a grid that
+    /// is never queried never pays for it. Not specialisable, and the cache slot is
+    /// private -- nothing can hand it out.
+    ///
+    /// \return The grid's spatial index.
+    /// \warning Not fully thread-safe. Concurrent first calls may each build a valid
+    ///          tree and one write wins, costing redundant construction. Call this once
+    ///          on the main thread before sharing the grid across threads.
+    [[nodiscard]] const BVH<scalar_type>& cell_bvh() const {
+        if (!bvh_.has_value()) {
+            const auto n = static_cast<std::size_t>(num_cells_);
+            const auto d = static_cast<std::size_t>(ndim_);
+            std::vector<scalar_type> cell_lo(n * d);
+            std::vector<scalar_type> cell_hi(n * d);
+            self().collect_cell_bounds(span2d<scalar_type>(cell_lo.data(), n, d),
+                                       span2d<scalar_type>(cell_hi.data(), n, d));
+            bvh_ = BVH<scalar_type>::from_cell_bounds(
+                span2d<const scalar_type>(cell_lo.data(), n, d),
+                span2d<const scalar_type>(cell_hi.data(), n, d));
+        }
+        return *bvh_;
+    }
+
+    /// Materialise per-cell `(lo, hi)` into `(num_cells, ndim)` views.
+    ///
+    /// Iterates `cell_bounds` over every cell in id order. A grid with structure
+    /// replaces it with a vectorised construction.
+    ///
+    /// \param cell_lo Output lo corners, shape `(num_cells, ndim)`.
+    /// \param cell_hi Output hi corners, same shape.
+    /// \note Both views must have exactly that shape. Checked by `PANTR_PRECONDITION`.
+    void collect_cell_bounds(span2d<scalar_type> cell_lo, span2d<scalar_type> cell_hi) const {
+        const auto n = static_cast<std::size_t>(num_cells_);
+        const auto d = static_cast<std::size_t>(ndim_);
+        PANTR_PRECONDITION(cell_lo.extent(0) == n && cell_lo.extent(1) == d,
+                           "cell_lo must have shape (num_cells, ndim)");
+        PANTR_PRECONDITION(cell_hi.extent(0) == n && cell_hi.extent(1) == d,
+                           "cell_hi must have shape (num_cells, ndim)");
+        for (std::size_t row = 0; row < n; ++row) {
+            self().cell_bounds(static_cast<std::int64_t>(row),
+                               std::span<scalar_type>(&at(cell_lo, row, std::size_t{0}), d),
+                               std::span<scalar_type>(&at(cell_hi, row, std::size_t{0}), d));
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Tagging
+    // ----------------------------------------------------------------
+
+    /// The grid's sparse cell-tag registry.
+    ///
+    /// Eager rather than lazy: an empty registry has no per-cell footprint, so laziness
+    /// would buy one allocation and cost a `mutable` and a branch.
+    ///
+    /// \return A mutable reference to the registry, valid for the grid's lifetime.
+    [[nodiscard]] CellTags& cell_tags() noexcept { return cell_tags_; }
+
+    /// The grid's sparse cell-tag registry, read only.
+    ///
+    /// \return A const reference to the registry.
+    [[nodiscard]] const CellTags& cell_tags() const noexcept { return cell_tags_; }
+
+    /// The grid's sparse facet-tag registry, sized `2 * ndim` facets per cell.
+    ///
+    /// \return A mutable reference to the registry, valid for the grid's lifetime.
+    [[nodiscard]] FacetTags& facet_tags() noexcept { return facet_tags_; }
+
+    /// The grid's sparse facet-tag registry, read only.
+    ///
+    /// \return A const reference to the registry.
+    [[nodiscard]] const FacetTags& facet_tags() const noexcept { return facet_tags_; }
+
+  protected:
+    /// Establish the size metadata and the two tag registries.
+    ///
+    /// Protected because a `GridBase` is never constructed on its own. `Derived`
+    /// computes the two sizes from its own constructor arguments and passes them up;
+    /// the mixin cannot read them back out of `self()`, because `Derived` is not yet
+    /// constructed when the base's own constructor runs.
+    ///
+    /// \param ndim Number of axes, `>= 1`.
+    /// \param num_cells Number of cells, `>= 0`.
+    /// \throws std::invalid_argument If `ndim < 1` or `num_cells < 0`.
+    GridBase(std::int64_t ndim, std::int64_t num_cells)
+        : ndim_(require_ndim(ndim)),
+          num_cells_(require_num_cells(num_cells)),
+          cell_tags_(num_cells),
+          facet_tags_(num_cells, 2 * ndim) {}
+
+    /// This object as the derived grid.
+    ///
+    /// \return A const reference to `Derived`.
+    [[nodiscard]] const Derived& self() const noexcept {
+        return static_cast<const Derived&>(*this);
+    }
+
+    /// This object as the derived grid.
+    ///
+    /// \return A mutable reference to `Derived`.
+    [[nodiscard]] Derived& self() noexcept { return static_cast<Derived&>(*this); }
+
+    /// Reject a cell id outside `[0, num_cells)`.
+    ///
+    /// The message is the Python oracle's verbatim, and the exception type is chosen so
+    /// that nanobind's default translator reaches `IndexError` with `what()` preserved.
+    ///
+    /// \param cid Candidate cell identifier.
+    /// \throws std::out_of_range If `cid` is negative or `>= num_cells`.
+    void check_cid(std::int64_t cid) const {
+        if (cid < 0 || cid >= num_cells_) {
+            throw std::out_of_range("cell id " + std::to_string(cid) + " is out of range [0, "
+                                    + std::to_string(num_cells_) + ").");
+        }
+    }
+
+    /// Reject a local facet id that is not a facet of `cid`.
+    ///
+    /// \param cid Cell identifier, validated first.
+    /// \param lfid Candidate local facet identifier.
+    /// \throws std::out_of_range If `cid` is out of range, or `lfid` is not in
+    ///         `[0, num_local_facets(cid))`.
+    void check_lfid(std::int64_t cid, std::int64_t lfid) const {
+        const std::int64_t n_facets = num_local_facets(cid);
+        if (lfid < 0 || lfid >= n_facets) {
+            throw std::out_of_range("local facet id " + std::to_string(lfid)
+                                    + " is out of range [0, " + std::to_string(n_facets) + ").");
+        }
+    }
+
+  private:
+    /// Check the spatial dimension on the way into the member initialiser list.
+    ///
+    /// A free-standing check in the constructor body would run AFTER `facet_tags_` had
+    /// already thrown its own, less specific, message for the same bad value.
+    ///
+    /// \param ndim The candidate dimension.
+    /// \return `ndim`.
+    /// \throws std::invalid_argument If `ndim < 1`.
+    [[nodiscard]] static std::int64_t require_ndim(std::int64_t ndim) {
+        if (ndim < 1) {
+            throw std::invalid_argument("ndim must be >= 1; got " + std::to_string(ndim) + ".");
+        }
+        return ndim;
+    }
+
+    /// Check the cell count on the way into the member initialiser list.
+    ///
+    /// \param num_cells The candidate cell count.
+    /// \return `num_cells`.
+    /// \throws std::invalid_argument If `num_cells < 0`.
+    [[nodiscard]] static std::int64_t require_num_cells(std::int64_t num_cells) {
+        if (num_cells < 0) {
+            throw std::invalid_argument("num_cells must be >= 0; got "
+                                        + std::to_string(num_cells) + ".");
+        }
+        return num_cells;
+    }
+
+    /// Assert that two corner spans are both length `ndim`.
+    ///
+    /// \param lo Candidate lo corner.
+    /// \param hi Candidate hi corner.
+    void require_corner_spans(std::span<const scalar_type> lo,
+                              std::span<const scalar_type> hi) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        PANTR_PRECONDITION(lo.size() == n, "lo must have length ndim");
+        PANTR_PRECONDITION(hi.size() == n, "hi must have length ndim");
+        static_cast<void>(lo);
+        static_cast<void>(hi);
+        static_cast<void>(n);
+    }
+
+    std::int64_t ndim_;                            ///< Number of axes.
+    std::int64_t num_cells_;                       ///< Number of cells.
+    CellTags cell_tags_;                           ///< The cell-tag registry.
+    FacetTags facet_tags_;                         ///< The facet-tag registry.
+    mutable std::optional<BVH<scalar_type>> bvh_;  ///< The lazily built spatial index.
+};
+
+// ---------------------------------------------------------------------------
+// The concept
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+/// The scalar a grid's traits declare, as an alias.
+///
+/// \tparam D The grid type.
+template <class D>
+using scalar_t = typename grid_traits<D>::scalar_type;
+
+/// Satisfied when `D` has a `grid_traits` specialisation naming a scalar.
+///
+/// Written as a type-requirement so it is a substitution failure rather than a hard
+/// error, and placed FIRST in `GridLike`'s conjunction so the short-circuit keeps the
+/// remaining atomic constraints from being evaluated for a type that has no traits.
+template <class D>
+concept HasGridTraits = requires { typename grid_traits<D>::scalar_type; };
+
+/// Satisfied when `D::cell_bounds` has EXACTLY the primitive's signature.
+///
+/// The exactness is what rejects an output span of `std::span<const T>`; see the file
+/// header.
+template <class D>
+concept HasCellBounds = requires {
+    {
+        &D::cell_bounds
+    } -> std::same_as<void (D::*)(std::int64_t, std::span<scalar_t<D>>,
+                                  std::span<scalar_t<D>>) const>;
+};
+
+/// Satisfied when `D::locate` has exactly the primitive's signature.
+template <class D>
+concept HasLocate = requires {
+    {
+        &D::locate
+    } -> std::same_as<std::optional<std::int64_t> (D::*)(std::span<const scalar_t<D>>) const>;
+};
+
+/// Satisfied when `D::neighbor_across_facet` has exactly the primitive's signature.
+template <class D>
+concept HasNeighborAcrossFacet = requires {
+    {
+        &D::neighbor_across_facet
+    } -> std::same_as<std::optional<std::int64_t> (D::*)(std::int64_t, std::int64_t) const>;
+};
+
+}  // namespace detail
+
+/// A grid: derived from its own `GridBase` and supplying the three primitives.
+///
+/// "Closed hierarchy" is `std::derived_from<G, GridBase<G>>` and nothing more -- not a
+/// variant, not a sealed virtual base. Each primitive is pinned to an exact
+/// member-pointer type rather than to callability, which is the only form that rejects
+/// a `cell_bounds` unable to write its output.
+///
+/// \tparam G The candidate grid type.
+template <class G>
+concept GridLike = detail::HasGridTraits<G> && std::derived_from<G, GridBase<G>>
+                   && detail::HasCellBounds<G> && detail::HasLocate<G>
+                   && detail::HasNeighborAcrossFacet<G>;
+
+/// Build a `GridRestriction`, checking what the unconstrained aggregate cannot.
+///
+/// This is where `GridLike` is enforced and where the two index arrays are checked
+/// against the sub-grid they describe. Aggregate initialisation of `GridRestriction`
+/// still bypasses both, which is the price of the type being unconstrained; see its
+/// documentation.
+///
+/// \tparam G The grid type.
+/// \param grid The windowed sub-grid.
+/// \param local_to_global_cell Sub-grid cell id to the originating grid's, in sub-grid
+///        cell-id order.
+/// \param in_subset `1` for a requested cell, `0` for bounding-box fill.
+/// \return The assembled restriction.
+/// \throws std::invalid_argument If either array's length differs from
+///         `grid.num_cells()`.
+template <GridLike G>
+[[nodiscard]] GridRestriction<G> make_restriction(G grid,
+                                                  std::vector<std::int64_t> local_to_global_cell,
+                                                  std::vector<std::uint8_t> in_subset) {
+    const auto n = static_cast<std::size_t>(grid.num_cells());
+    if (local_to_global_cell.size() != n || in_subset.size() != n) {
+        throw std::invalid_argument(
+            "make_restriction: local_to_global_cell (" + std::to_string(local_to_global_cell.size())
+            + ") and in_subset (" + std::to_string(in_subset.size())
+            + ") must both have length grid.num_cells() (" + std::to_string(n) + ").");
+    }
+    return GridRestriction<G>{std::move(grid), std::move(local_to_global_cell),
+                              std::move(in_subset)};
+}
+
+// ---------------------------------------------------------------------------
+// The census
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+/// Declare the detector and the signature check for one replaceable default.
+///
+/// `__VA_ARGS__` is the hook's member-pointer type written in terms of `D`; it is a
+/// variadic parameter because that type contains commas.
+#define PANTR_GRID_DECLARE_HOOK(NAME, ...)                                                 \
+    /** The member-pointer type `NAME` must have when it is written. */                    \
+    template <class D>                                                                     \
+    using hook_signature_##NAME##_t = __VA_ARGS__;                                         \
+    /** Whether `D` redeclares `NAME`, by member-pointer type rather than by probe. */     \
+    template <class D>                                                                     \
+    [[nodiscard]] constexpr bool redeclares_##NAME() noexcept {                            \
+        return !std::is_same_v<decltype(&D::NAME), decltype(&GridBase<D>::NAME)>;           \
+    }                                                                                      \
+    /** Whether `D`'s `NAME` has the signature of the default it replaces. */              \
+    template <class D>                                                                     \
+    [[nodiscard]] constexpr bool hook_signature_matches_##NAME() noexcept {                \
+        return std::is_same_v<decltype(&D::NAME), hook_signature_##NAME##_t<D>>;           \
+    }
+
+PANTR_GRID_DECLARE_HOOK(cell_aabb, geometry::AABB<scalar_t<D>> (D::*)(std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(cell_level, std::int64_t (D::*)(std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(child_cells, std::vector<std::int64_t> (D::*)(std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(reference_map,
+                        transform::AffineTransform<scalar_t<D>> (D::*)(std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(neighbors, std::vector<std::int64_t> (D::*)(std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(restrict,
+                        GridRestriction<D> (D::*)(std::span<const std::int64_t>) const)
+PANTR_GRID_DECLARE_HOOK(local_facet_axis_side,
+                        std::pair<std::int64_t, std::int64_t> (D::*)(std::int64_t, std::int64_t)
+                            const)
+PANTR_GRID_DECLARE_HOOK(local_facet_bounds,
+                        void (D::*)(std::int64_t, std::int64_t, std::span<scalar_t<D>>,
+                                    std::span<scalar_t<D>>) const)
+PANTR_GRID_DECLARE_HOOK(is_mesh_boundary_facet, bool (D::*)(std::int64_t, std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(boundary_facets, std::vector<std::int64_t> (D::*)() const)
+PANTR_GRID_DECLARE_HOOK(hanging_neighbors,
+                        std::vector<std::int64_t> (D::*)(std::int64_t, std::int64_t) const)
+PANTR_GRID_DECLARE_HOOK(locate_many,
+                        std::vector<std::int64_t> (D::*)(span2d<const scalar_t<D>>) const)
+PANTR_GRID_DECLARE_HOOK(query_aabb, std::vector<std::int64_t> (D::*)(
+                                        const geometry::AABB<scalar_t<D>>&) const)
+PANTR_GRID_DECLARE_HOOK(collect_cell_bounds,
+                        void (D::*)(span2d<scalar_t<D>>, span2d<scalar_t<D>>) const)
+
+// Not a hook, and the detector exists so the census can assert that. `2 * ndim` is an
+// invariant of the base's own `facet_tags_`, not a policy a grid may restate.
+PANTR_GRID_DECLARE_HOOK(num_local_facets, std::int64_t (D::*)(std::int64_t) const)
+
+}  // namespace detail
+
+#undef PANTR_GRID_DECLARE_HOOK
+
+/// Assert one hook against the grid's declaration, in both directions.
+///
+/// \param GRID The grid type. Must not contain a comma at the top level.
+/// \param NAME The hook's member name.
+#define PANTR_GRID_CENSUS_HOOK(GRID, NAME)                                                    \
+    static_assert(::pantr::grid::detail::redeclares_##NAME<GRID>()                            \
+                      == ::pantr::grid::declares(::pantr::grid::grid_traits<GRID>::hooks,     \
+                                                 ::pantr::grid::Hook::NAME),                  \
+                  "pantr grid census (" #GRID ", " #NAME "): the class and its grid_traits "  \
+                  "disagree -- either the hook is written and not declared, in which case "   \
+                  "it runs and nothing says so, or it is declared and not written, in which " \
+                  "case the default runs and nothing says so");                               \
+    static_assert(!::pantr::grid::declares(::pantr::grid::grid_traits<GRID>::hooks,           \
+                                           ::pantr::grid::Hook::NAME)                         \
+                      || ::pantr::grid::detail::hook_signature_matches_##NAME<GRID>(),        \
+                  "pantr grid census (" #GRID ", " #NAME "): the hook does not have the "     \
+                  "signature of the default it replaces")
+
+/// Assert a grid against its own `grid_traits`, and force every default body.
+///
+/// Expand this once per instantiation, at namespace scope, in the grid's own
+/// translation unit. It does four things, and the fourth is why it exists at all:
+///
+///  1. asserts `GridLike<GRID>`, which is where the three primitives are pinned;
+///  2. asserts, per replaceable default, that the class and the bitmask agree;
+///  3. asserts, per declared hook, that its signature is the default's;
+///  4. explicitly instantiates `GridBase<GRID>`, which forces every default BODY --
+///     so a default that would not compile for this grid, at a scalar nothing calls,
+///     is a compile error here rather than a surprise at the first call.
+///
+/// What it does NOT establish: that a hook computes the same function as the default
+/// it replaces. That is a differential test's job, and the qualified call
+/// `g.pantr::grid::GridBase<GRID>::name()` is how it reaches the hidden default.
+///
+/// \param GRID The grid type. Must not contain a comma at the top level; wrap such a
+///        type in an alias first.
+#define PANTR_GRID_CENSUS(GRID)                                                               \
+    static_assert(::pantr::grid::GridLike<GRID>,                                              \
+                  "pantr grid census (" #GRID "): not a grid -- it must derive from "         \
+                  "GridBase<itself> and declare cell_bounds, locate and "                     \
+                  "neighbor_across_facet with exactly the primitive signatures");             \
+    static_assert(!::pantr::grid::detail::redeclares_num_local_facets<GRID>(),                \
+                  "pantr grid census (" #GRID "): num_local_facets is not specialisable. "    \
+                  "facet_tags_ is sized 2 * ndim once at construction, so a grid that "       \
+                  "changed the facet count would desynchronise the registry from the "        \
+                  "geometry");                                                                \
+    PANTR_GRID_CENSUS_HOOK(GRID, cell_aabb);                                                  \
+    PANTR_GRID_CENSUS_HOOK(GRID, cell_level);                                                 \
+    PANTR_GRID_CENSUS_HOOK(GRID, child_cells);                                                \
+    PANTR_GRID_CENSUS_HOOK(GRID, reference_map);                                              \
+    PANTR_GRID_CENSUS_HOOK(GRID, neighbors);                                                  \
+    PANTR_GRID_CENSUS_HOOK(GRID, restrict);                                                   \
+    PANTR_GRID_CENSUS_HOOK(GRID, local_facet_axis_side);                                      \
+    PANTR_GRID_CENSUS_HOOK(GRID, local_facet_bounds);                                         \
+    PANTR_GRID_CENSUS_HOOK(GRID, is_mesh_boundary_facet);                                     \
+    PANTR_GRID_CENSUS_HOOK(GRID, boundary_facets);                                            \
+    PANTR_GRID_CENSUS_HOOK(GRID, hanging_neighbors);                                          \
+    PANTR_GRID_CENSUS_HOOK(GRID, locate_many);                                                \
+    PANTR_GRID_CENSUS_HOOK(GRID, query_aabb);                                                 \
+    PANTR_GRID_CENSUS_HOOK(GRID, collect_cell_bounds);                                        \
+    template class ::pantr::grid::GridBase<GRID>
+
+}  // namespace pantr::grid

--- a/cpp/include/pantr/grid/grid.hpp
+++ b/cpp/include/pantr/grid/grid.hpp
@@ -483,8 +483,10 @@ class GridBase {
     /// \throws std::invalid_argument If `points.extent(1)` is not `ndim`.
     [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const scalar_type> points) const {
         const auto n = static_cast<std::size_t>(ndim_);
+        // Only the trailing extent is a contract: the caller chooses how many points to
+        // pass, and the row count is whatever they passed.
+        require_ndim_columns(points, "points");
         const std::size_t npts = points.extent(0);
-        require_shape(points, npts, "points");
         std::vector<std::int64_t> out(npts);
         for (std::size_t i = 0; i < npts; ++i) {
             const std::span<const scalar_type> pt(&at(points, i, std::size_t{0}), n);
@@ -691,6 +693,22 @@ class GridBase {
                                         + std::to_string(hi.size())
                                         + ") must both have length ndim ("
                                         + std::to_string(n) + ").");
+        }
+    }
+
+    /// Reject a two-dimensional view whose trailing extent is not `ndim`.
+    ///
+    /// Unconditional, for the reason `require_corner_spans` gives.
+    ///
+    /// \param view The candidate view.
+    /// \param what The parameter's name, for the message.
+    /// \throws std::invalid_argument If `view.extent(1)` is not `ndim`.
+    void require_ndim_columns(span2d<const scalar_type> view, const char* what) const {
+        const auto n = static_cast<std::size_t>(ndim_);
+        if (view.extent(1) != n) {
+            throw std::invalid_argument(std::string(what) + " must have " + std::to_string(n)
+                                        + " columns (ndim); got "
+                                        + std::to_string(view.extent(1)) + ".");
         }
     }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -66,6 +66,68 @@ message(STATUS
     "(ctest -L placeholder)")
 
 # ---------------------------------------------------------------------------
+# Negative translation units (FELIGN/pantr#386)
+# ---------------------------------------------------------------------------
+#
+# Each of these is a program that MUST NOT COMPILE. The test builds it, and the pass
+# criterion is the DIAGNOSTIC'S OWN TEXT rather than a non-zero exit -- the same
+# distinction the precondition tests below make, and for the same reason. A negative
+# translation unit rejected for the wrong reason (a typo, a moved header, a stale
+# include path) also fails to build, so an exit-code test would pass while asserting
+# nothing. Matching the message is what ties each file to the mechanism it exists for.
+#
+# Most of these are rejected by a `static_assert` inside PANTR_GRID_CENSUS, so their
+# expected text is the assertion's own and is identical on every compiler. Where the
+# rejection is a language rule instead, the pattern below is the substring all four
+# compilers were MEASURED to print; the measurement is in the file's own header.
+#
+# The targets are OBJECT libraries -- nothing to link, no `main` to write -- and
+# EXCLUDE_FROM_ALL, so `cmake --build` never tries to build them and only ctest does.
+# They share a RESOURCE_LOCK because each drives a build of this same tree, and two
+# concurrent ninja invocations in one directory contend.
+
+function(pantr_add_negative_test _name _message)
+  add_library(${_name} OBJECT EXCLUDE_FROM_ALL "negative/${_name}.cpp")
+  target_link_libraries(${_name} PRIVATE pantr::core pantr::cxx_flags)
+  target_include_directories(${_name} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/negative")
+  add_test(NAME ${_name}
+           COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}"
+                   --target ${_name} --config $<CONFIG>)
+  set_tests_properties(${_name} PROPERTIES
+      PASS_REGULAR_EXPRESSION "${_message}"
+      RESOURCE_LOCK pantr_negative_build
+      LABELS "negative")
+endfunction()
+
+# The ticket's six, with two departures the design records and one addition.
+#
+#   * "a const grid invalidating its cache" became "nothing hands out the cache slot".
+#     This ticket ships no `invalidate_caches()`: FELIGN/pantr#378 makes refinement
+#     return a new grid, so there is nothing to invalidate, and the property the
+#     mechanism existed to protect is that the slot is private and `cell_bvh()` yields
+#     only a const reference to it.
+#   * "a grid defined without its traits" is rejected at the grid's own definition,
+#     which is why the pattern names the traits template rather than a census message.
+#
+# The three additions are `num_local_facets` -- a `2 * ndim` invariant of the base's own
+# `facet_tags_`, which nothing else asserts negatively -- and the two directions of a
+# hook disagreeing with its declaration, which are what make the bitmask trustworthy and
+# which the acceptance criteria did not list.
+pantr_add_negative_test(neg_cache_handed_out_mutably "binding reference of type")
+pantr_add_negative_test(neg_const_grid_mutates_tags "'this' argument")
+pantr_add_negative_test(neg_grid_without_traits "grid_traits<TraitlessGrid>")
+pantr_add_negative_test(neg_primitive_const_output_span "not a grid")
+pantr_add_negative_test(neg_hook_wrong_return_type
+                        "does not have the signature of the default")
+pantr_add_negative_test(neg_hook_hardcodes_double_at_float "FloatGrid, locate_many")
+pantr_add_negative_test(neg_hook_written_not_declared
+                        "the class and its grid_traits disagree")
+pantr_add_negative_test(neg_hook_declared_not_written
+                        "the class and its grid_traits disagree")
+pantr_add_negative_test(neg_num_local_facets_specialised
+                        "num_local_facets is not specialisable")
+
+# ---------------------------------------------------------------------------
 # Precondition tests (FELIGN/pantr#359)
 # ---------------------------------------------------------------------------
 #

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ set(PANTR_TEST_SOURCES
     test_quad_rule.cpp
     test_grid_tags.cpp
     test_grid_partition.cpp
-    test_grid_bvh_type.cpp)
+    test_grid_bvh_type.cpp
+    test_grid_defaults.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -40,7 +41,6 @@ set(PANTR_TEST_SOURCES
 # Delete each entry from this list as its ticket fills the slot; when the list is
 # empty, delete the list.
 set(PANTR_PLACEHOLDER_TEST_SOURCES
-    test_grid_defaults.cpp
     test_grid_tensor_product.cpp
     test_bezier_evaluate.cpp
     test_bezier_degree.cpp

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -78,8 +78,14 @@ message(STATUS
 #
 # Most of these are rejected by a `static_assert` inside PANTR_GRID_CENSUS, so their
 # expected text is the assertion's own and is identical on every compiler. Where the
-# rejection is a language rule instead, the pattern below is the substring all four
-# compilers were MEASURED to print; the measurement is in the file's own header.
+# rejection is a language rule instead, the pattern is the substring all four compilers
+# were MEASURED to print; the measurement is in the file's own header.
+#
+# No pattern may contain a QUOTE around a compiler-quoted identifier, and that rule was
+# bought the hard way. GCC renders its `%<...%>` quoting as U+2018/U+2019 in a UTF-8
+# locale, so a pattern written with ASCII apostrophes matches on one GCC build and not
+# on another -- measured: g++ 10.5 prints `as âthisâ argument`, where the conda g++ 14
+# prints `as 'this' argument`. Match text the compiler writes as prose instead.
 #
 # The targets are OBJECT libraries -- nothing to link, no `main` to write -- and
 # EXCLUDE_FROM_ALL, so `cmake --build` never tries to build them and only ctest does.
@@ -99,7 +105,7 @@ function(pantr_add_negative_test _name _message)
       LABELS "negative")
 endfunction()
 
-# The ticket's six, with two departures the design records and one addition.
+# The ticket's six, with two departures the design records and five additions.
 #
 #   * "a const grid invalidating its cache" became "nothing hands out the cache slot".
 #     This ticket ships no `invalidate_caches()`: FELIGN/pantr#378 makes refinement
@@ -109,21 +115,24 @@ endfunction()
 #   * "a grid defined without its traits" is rejected at the grid's own definition,
 #     which is why the pattern names the traits template rather than a census message.
 #
-# The three additions are `num_local_facets` -- a `2 * ndim` invariant of the base's own
-# `facet_tags_`, which nothing else asserts negatively -- and the two directions of a
-# hook disagreeing with its declaration, which are what make the bitmask trustworthy and
-# which the acceptance criteria did not list.
+# Five are additions: `num_local_facets` -- a `2 * ndim` invariant of the base's own
+# `facet_tags_`, which nothing else asserts negatively -- the two directions of a hook
+# disagreeing with its declaration, which are what make the bitmask trustworthy and
+# which the acceptance criteria did not list, and the const-output-span trap on the two
+# primitives the ticket did not name.
 pantr_add_negative_test(neg_cache_handed_out_mutably "binding reference of type")
-pantr_add_negative_test(neg_const_grid_mutates_tags "'this' argument")
+pantr_add_negative_test(neg_const_grid_mutates_tags "discards qualifiers|not marked const")
 pantr_add_negative_test(neg_grid_without_traits "grid_traits<TraitlessGrid>")
 pantr_add_negative_test(neg_primitive_const_output_span "not a grid")
+pantr_add_negative_test(neg_locate_const_ref_point "not a grid")
+pantr_add_negative_test(neg_neighbor_wrong_return "not a grid")
 pantr_add_negative_test(neg_hook_wrong_return_type
                         "does not have the signature of the default")
 pantr_add_negative_test(neg_hook_hardcodes_double_at_float "FloatGrid, locate_many")
 pantr_add_negative_test(neg_hook_written_not_declared
-                        "the class and its grid_traits disagree")
+                        "UndeclaredHookGrid, boundary_facets.: the class and its grid_traits")
 pantr_add_negative_test(neg_hook_declared_not_written
-                        "the class and its grid_traits disagree")
+                        "UnwrittenHookGrid, boundary_facets.: the class and its grid_traits")
 pantr_add_negative_test(neg_num_local_facets_specialised
                         "num_local_facets is not specialisable")
 

--- a/cpp/tests/negative/README.md
+++ b/cpp/tests/negative/README.md
@@ -1,0 +1,15 @@
+# Negative translation units
+
+Each file here is a program that **must not compile**, and each is registered with ctest
+by `pantr_add_negative_test` in `cpp/tests/CMakeLists.txt`. The test command builds the
+translation unit; the pass criterion is the **diagnostic's own text**, not a non-zero
+exit.
+
+That distinction is the whole test, and it is the same one the precondition tests make.
+A negative translation unit rejected for the wrong reason -- a typo, a missing include,
+a header that moved -- still fails to compile, so a test that only checked the exit code
+would pass while asserting nothing. Matching the message is what ties each file to the
+mechanism it was written for.
+
+Every one is built by whichever compiler configured the build directory, so
+`scripts/ci_local.sh` runs them on g++ 14, clang++ 18 and the g++ 10 / clang++ 10 floor.

--- a/cpp/tests/negative/_fixture.hpp
+++ b/cpp/tests/negative/_fixture.hpp
@@ -3,11 +3,12 @@
 /// \file
 /// The well-formed grid every negative translation unit starts from.
 ///
-/// The two files that include it introduce exactly ONE defect on top of it, so that the
-/// diagnostic they are matched against can only have come from that defect. The other
-/// seven negative translation units define their own grid rather than including this
+/// The files that include it introduce exactly ONE defect on top of it, so that the
+/// diagnostic they are matched against can only have come from that defect. The rest
+/// of the negative translation units define their own grid rather than including this
 /// one, because their defect IS in the grid's definition and cannot be layered on a
-/// well-formed class from outside.
+/// well-formed class from outside. Which files fall on which side is not stated here:
+/// a count in a comment rots the next time one is added, as this one did.
 
 #include <cstdint>
 #include <optional>

--- a/cpp/tests/negative/_fixture.hpp
+++ b/cpp/tests/negative/_fixture.hpp
@@ -3,11 +3,11 @@
 /// \file
 /// The well-formed grid every negative translation unit starts from.
 ///
-/// Each of them introduces exactly ONE defect on top of this, so that the diagnostic
-/// they are matched against can only have come from that defect. Keeping the fixture
-/// shared is also what keeps the files honest: if this header stopped compiling, every
-/// negative test would still fail to build and none of them would still match its
-/// message.
+/// The two files that include it introduce exactly ONE defect on top of it, so that the
+/// diagnostic they are matched against can only have come from that defect. The other
+/// seven negative translation units define their own grid rather than including this
+/// one, because their defect IS in the grid's definition and cannot be layered on a
+/// well-formed class from outside.
 
 #include <cstdint>
 #include <optional>

--- a/cpp/tests/negative/_fixture.hpp
+++ b/cpp/tests/negative/_fixture.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+/// \file
+/// The well-formed grid every negative translation unit starts from.
+///
+/// Each of them introduces exactly ONE defect on top of this, so that the diagnostic
+/// they are matched against can only have come from that defect. Keeping the fixture
+/// shared is also what keeps the files honest: if this header stopped compiling, every
+/// negative test would still fail to build and none of them would still match its
+/// message.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "pantr/grid/grid.hpp"
+
+class GoodGrid;
+
+template <>
+struct pantr::grid::grid_traits<GoodGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+/// A one-dimensional grid of `n` unit cells, declaring no specialisations.
+class GoodGrid : public pantr::grid::GridBase<GoodGrid> {
+  public:
+    using Base = pantr::grid::GridBase<GoodGrid>;
+
+    explicit GoodGrid(std::int64_t n) : Base(1, n) {}
+
+    void cell_bounds(std::int64_t cid, std::span<double> lo, std::span<double> hi) const {
+        this->check_cid(cid);
+        lo[0] = static_cast<double>(cid);
+        hi[0] = static_cast<double>(cid + 1);
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double> pt) const {
+        const auto k = static_cast<std::int64_t>(pt[0]);
+        if (k < 0 || k >= this->num_cells()) {
+            return std::nullopt;
+        }
+        return k;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+                                                                    std::int64_t lfid) const {
+        this->check_lfid(cid, lfid);
+        const std::int64_t nbr = (lfid == 0) ? cid - 1 : cid + 1;
+        if (nbr < 0 || nbr >= this->num_cells()) {
+            return std::nullopt;
+        }
+        return nbr;
+    }
+};

--- a/cpp/tests/negative/neg_cache_handed_out_mutably.cpp
+++ b/cpp/tests/negative/neg_cache_handed_out_mutably.cpp
@@ -1,0 +1,16 @@
+/// \file
+/// Nothing may hand out the BVH cache slot itself.
+///
+/// The ticket asked for "a const grid invalidating its cache". This ticket ships no
+/// `invalidate_caches()` -- FELIGN/pantr#378 makes refinement return a new grid, so
+/// there is nothing to invalidate -- and the property that survives is the one the
+/// mechanism existed to protect: the slot is private, `cell_bvh()` is the only way to
+/// it, and it yields a reference through which nothing can be replaced.
+
+#include "_fixture.hpp"
+
+void take_the_cache() {
+    const GoodGrid g(4);
+    pantr::grid::BVH<double>& tree = g.cell_bvh();
+    static_cast<void>(tree);
+}

--- a/cpp/tests/negative/neg_const_grid_mutates_tags.cpp
+++ b/cpp/tests/negative/neg_const_grid_mutates_tags.cpp
@@ -1,0 +1,16 @@
+/// \file
+/// A const grid may read its tag registries and may not write them.
+///
+/// This is the const polarity the ticket's mechanism 3 was about. Holding the sizes in
+/// the mixin rather than in `Derived` is what lets `cell_tags()` be an ordinary pair of
+/// overloads, so the guarantee costs no `const_cast` and is the compiler's rather than
+/// a convention's.
+
+#include "_fixture.hpp"
+
+void write_through_a_const_grid() {
+    const GoodGrid g(4);
+    const std::vector<std::int64_t> ids = {0};
+    const std::vector<std::int64_t> values = {1};
+    g.cell_tags().set("a", ids, values);
+}

--- a/cpp/tests/negative/neg_grid_without_traits.cpp
+++ b/cpp/tests/negative/neg_grid_without_traits.cpp
@@ -1,0 +1,28 @@
+/// \file
+/// A grid that forgets its `grid_traits` specialisation is rejected at its own definition.
+///
+/// The primary template is deliberately left undefined so this is the diagnostic, rather
+/// than a failure inside whichever default first needed the scalar. `grid_traits` is
+/// named in the message, which is what makes the mistake self-explaining.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class TraitlessGrid : public pantr::grid::GridBase<TraitlessGrid> {
+  public:
+    TraitlessGrid() : pantr::grid::GridBase<TraitlessGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double>, std::span<double>) const {}
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+};

--- a/cpp/tests/negative/neg_hook_declared_not_written.cpp
+++ b/cpp/tests/negative/neg_hook_declared_not_written.cpp
@@ -1,0 +1,43 @@
+/// \file
+/// A hook declared in the grid's `grid_traits` but never written.
+///
+/// The other direction of the same disagreement. Left unchecked it is a claim the
+/// bitmask makes and the class does not honour, so the default runs where a reader of
+/// the traits expects a specialisation -- and the census is what makes the bitmask
+/// trustworthy enough to read at all. Also not in the ticket's list.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class UnwrittenHookGrid;
+
+template <>
+struct pantr::grid::grid_traits<UnwrittenHookGrid> {
+    using scalar_type = double;
+    // The defect: the class below writes no `boundary_facets`.
+    static constexpr Hook hooks = Hook::boundary_facets;
+};
+
+class UnwrittenHookGrid : public pantr::grid::GridBase<UnwrittenHookGrid> {
+  public:
+    UnwrittenHookGrid() : pantr::grid::GridBase<UnwrittenHookGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        hi[0] = 1.0;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+};
+
+PANTR_GRID_CENSUS(UnwrittenHookGrid);

--- a/cpp/tests/negative/neg_hook_hardcodes_double_at_float.cpp
+++ b/cpp/tests/negative/neg_hook_hardcodes_double_at_float.cpp
@@ -1,0 +1,52 @@
+/// \file
+/// A hook that hard-codes `double`, censused at a `float` grid.
+///
+/// It is well formed at `double` and wrong at `float`, so nothing but an instantiation
+/// at the second scalar can see it. That is what the `float` census device is for: it
+/// forces every default body and every declared hook's signature at a scalar no binding
+/// registers, and it opens no parity claim because it is never bound and never compared.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "pantr/grid/grid.hpp"
+
+template <class T>
+class HardCodedScalarGrid;
+
+template <class T>
+struct pantr::grid::grid_traits<HardCodedScalarGrid<T>> {
+    using scalar_type = T;
+    static constexpr Hook hooks = Hook::locate_many;
+};
+
+template <class T>
+class HardCodedScalarGrid : public pantr::grid::GridBase<HardCodedScalarGrid<T>> {
+  public:
+    HardCodedScalarGrid() : pantr::grid::GridBase<HardCodedScalarGrid<T>>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<T> lo, std::span<T> hi) const {
+        lo[0] = T{0};
+        hi[0] = T{1};
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const T>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+
+    // The defect: `double` rather than `T`. Correct at one instantiation, wrong at the other.
+    [[nodiscard]] std::vector<std::int64_t> locate_many(pantr::span2d<const double>) const {
+        return {};
+    }
+};
+
+using FloatGrid = HardCodedScalarGrid<float>;
+
+PANTR_GRID_CENSUS(FloatGrid);

--- a/cpp/tests/negative/neg_hook_written_not_declared.cpp
+++ b/cpp/tests/negative/neg_hook_written_not_declared.cpp
@@ -1,0 +1,48 @@
+/// \file
+/// A hook written but not declared in the grid's `grid_traits`.
+///
+/// This is the failure mode that decided the dispatch mechanism. Under name hiding the
+/// hook RUNS, so the bitmask and the class disagree and nothing at the call site says
+/// so; under the alternative -- dispatch reading the bitmask -- the hook is silently
+/// ignored and the default runs, which is a wrong answer with no diagnostic at all.
+/// Either way the disagreement has to be a compile error, and this is the direction the
+/// ticket's acceptance criteria did not list.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "pantr/grid/grid.hpp"
+
+class UndeclaredHookGrid;
+
+template <>
+struct pantr::grid::grid_traits<UndeclaredHookGrid> {
+    using scalar_type = double;
+    // The defect: the class below writes `boundary_facets` and this says it does not.
+    static constexpr Hook hooks = Hook::none;
+};
+
+class UndeclaredHookGrid : public pantr::grid::GridBase<UndeclaredHookGrid> {
+  public:
+    UndeclaredHookGrid() : pantr::grid::GridBase<UndeclaredHookGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        hi[0] = 1.0;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::vector<std::int64_t> boundary_facets() const { return {}; }
+};
+
+PANTR_GRID_CENSUS(UndeclaredHookGrid);

--- a/cpp/tests/negative/neg_hook_wrong_return_type.cpp
+++ b/cpp/tests/negative/neg_hook_wrong_return_type.cpp
@@ -1,0 +1,48 @@
+/// \file
+/// A hook whose return type differs from the default it replaces.
+///
+/// A `requires`-based probe answers `true` here, which is why detection compares
+/// member-pointer types instead. The census then asserts the declared hook's exact
+/// signature, so the width of the returned integer is not something a caller has to
+/// discover at the call site.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "pantr/grid/grid.hpp"
+
+class NarrowReturnGrid;
+
+template <>
+struct pantr::grid::grid_traits<NarrowReturnGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::locate_many;
+};
+
+class NarrowReturnGrid : public pantr::grid::GridBase<NarrowReturnGrid> {
+  public:
+    NarrowReturnGrid() : pantr::grid::GridBase<NarrowReturnGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        hi[0] = 1.0;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+
+    // The defect: int32 where the default returns int64.
+    [[nodiscard]] std::vector<std::int32_t> locate_many(pantr::span2d<const double>) const {
+        return {};
+    }
+};
+
+PANTR_GRID_CENSUS(NarrowReturnGrid);

--- a/cpp/tests/negative/neg_locate_const_ref_point.cpp
+++ b/cpp/tests/negative/neg_locate_const_ref_point.cpp
@@ -1,0 +1,44 @@
+/// \file
+/// A `locate` whose point argument is a reference to a span, not a span.
+///
+/// The same shape as the `cell_bounds` trap on the neighbouring file, aimed at the
+/// second primitive: the body compiles, the call `self().locate(pt)` binds, and only
+/// the exact member-pointer form of `GridLike` notices that the signature is not the
+/// one every generic default was written against. The ticket named the trap on the
+/// hooks; it lands on the primitives, and it lands on all three of them.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class RefPointGrid;
+
+template <>
+struct pantr::grid::grid_traits<RefPointGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+class RefPointGrid : public pantr::grid::GridBase<RefPointGrid> {
+  public:
+    RefPointGrid() : pantr::grid::GridBase<RefPointGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        hi[0] = 1.0;
+    }
+
+    // The defect: `const std::span<const double>&` rather than `std::span<const double>`.
+    [[nodiscard]] std::optional<std::int64_t> locate(const std::span<const double>&) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+};
+
+PANTR_GRID_CENSUS(RefPointGrid);

--- a/cpp/tests/negative/neg_neighbor_wrong_return.cpp
+++ b/cpp/tests/negative/neg_neighbor_wrong_return.cpp
@@ -1,0 +1,46 @@
+/// \file
+/// A `neighbor_across_facet` returning a sentinel instead of an optional.
+///
+/// The third primitive, and the most dangerous of the three to get wrong: every generic
+/// default that walks the connectivity -- `neighbors`, `is_mesh_boundary_facet`,
+/// `hanging_neighbors`, `boundary_facets` -- decides "is this a boundary?" by asking
+/// whether the optional is engaged. A grid returning `-1` for "no neighbour" would make
+/// `std::optional<std::int64_t>(-1)` engaged, so every boundary facet would read as
+/// interior and `boundary_facets()` would come back empty, with nothing to notice.
+///
+/// `GridLike` rejects it because the return type is part of the member-pointer type.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class SentinelNeighborGrid;
+
+template <>
+struct pantr::grid::grid_traits<SentinelNeighborGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+class SentinelNeighborGrid : public pantr::grid::GridBase<SentinelNeighborGrid> {
+  public:
+    SentinelNeighborGrid() : pantr::grid::GridBase<SentinelNeighborGrid>(1, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        hi[0] = 1.0;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    // The defect: a sentinel where the contract is an optional.
+    [[nodiscard]] std::int64_t neighbor_across_facet(std::int64_t, std::int64_t) const {
+        return -1;
+    }
+};
+
+PANTR_GRID_CENSUS(SentinelNeighborGrid);

--- a/cpp/tests/negative/neg_num_local_facets_specialised.cpp
+++ b/cpp/tests/negative/neg_num_local_facets_specialised.cpp
@@ -1,0 +1,48 @@
+/// \file
+/// `num_local_facets` is not specialisable.
+///
+/// `facet_tags_` is sized `2 * ndim` once, at construction, so a grid that reported a
+/// different facet count would desynchronise the registry from the geometry -- and it
+/// would do so silently, since nothing reads the two together. The Python version
+/// leaves the coupling implicit; holding the sizes in the mixin is what makes it
+/// assertable, so it is asserted rather than left to be discovered.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class ExtraFacetsGrid;
+
+template <>
+struct pantr::grid::grid_traits<ExtraFacetsGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+class ExtraFacetsGrid : public pantr::grid::GridBase<ExtraFacetsGrid> {
+  public:
+    ExtraFacetsGrid() : pantr::grid::GridBase<ExtraFacetsGrid>(2, 1) {}
+
+    void cell_bounds(std::int64_t, std::span<double> lo, std::span<double> hi) const {
+        lo[0] = 0.0;
+        lo[1] = 0.0;
+        hi[0] = 1.0;
+        hi[1] = 1.0;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+
+    // The defect: a triangle's worth of facets on a box grid whose tag registry has four.
+    [[nodiscard]] std::int64_t num_local_facets(std::int64_t) const { return 3; }
+};
+
+PANTR_GRID_CENSUS(ExtraFacetsGrid);

--- a/cpp/tests/negative/neg_primitive_const_output_span.cpp
+++ b/cpp/tests/negative/neg_primitive_const_output_span.cpp
@@ -1,0 +1,44 @@
+/// \file
+/// A `cell_bounds` that cannot write its output is not a grid.
+///
+/// This is the trap the concept is written against, and it is on the PRIMITIVES rather
+/// than among the hooks, where the ticket placed it. `std::span<T>` converts implicitly
+/// to `std::span<const T>`, so a callability-based concept -- `requires(std::span<T>
+/// out) { g.cell_bounds(cid, out, out); }` -- is satisfied by the grid below, which
+/// compiles and hands back whatever was already in the caller's buffer. Measured
+/// accepted by g++ 14.4, g++ 10.5, clang++ 18.1 and clang++ 10.0 alike under
+/// `-Wall -Wextra -Werror`. Pinning the primitive to an exact member-pointer type is
+/// what rejects it.
+
+#include <cstdint>
+#include <optional>
+#include <span>
+
+#include "pantr/grid/grid.hpp"
+
+class ConstSpanGrid;
+
+template <>
+struct pantr::grid::grid_traits<ConstSpanGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+class ConstSpanGrid : public pantr::grid::GridBase<ConstSpanGrid> {
+  public:
+    ConstSpanGrid() : pantr::grid::GridBase<ConstSpanGrid>(1, 1) {}
+
+    // The defect: the output spans are const, so nothing can be written through them.
+    void cell_bounds(std::int64_t, std::span<const double>, std::span<const double>) const {}
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+};
+
+PANTR_GRID_CENSUS(ConstSpanGrid);

--- a/cpp/tests/test_grid_defaults.cpp
+++ b/cpp/tests/test_grid_defaults.cpp
@@ -1,17 +1,592 @@
 /// \file
-/// Reserved slot for the grid types' default construction and defaults tests -- no assertions yet.
+/// The generic grid layer's defaults, checked against hand-computed values on a
+/// synthetic grid that declares no specialisations at all.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// Two fixtures, and the split is the point:
+///
+///   * `BoxGrid<T>` declares `Hook::none`, so every one of the fourteen replaceable
+///     defaults RUNS here, and the census asserts the negative. Comparing the defaults
+///     against a real specialisation belongs to the `TensorProductGrid` ticket, which
+///     is where the specialisations first exist.
+///   * `HookedGrid<T>` declares two hooks, and exists to pin the two halves of the
+///     dispatch mechanism the next ticket depends on: name hiding reaches the hook, and
+///     the qualified call `g.Base::name()` still reaches the hidden default. That
+///     qualified call is the C++ analogue of `Grid.boundary_facets(g)` in
+///     `tests/test_grid_hierarchical.py`, and it is what a differential test needs.
+///
+/// Both are censused at `float` AND at `double`. The `float` instantiation is a
+/// COMPILE-TIME census device and nothing else: it forces every default body at a
+/// scalar no binding registers, which is what catches a hook that hard-codes `double`.
+/// It is never bound and never compared, so it does not open a parity claim --
+/// `design/backend_parity.md` Rule 8 forbids one where there is no oracle behind it,
+/// and `src/pantr/grid/_grid_backend.py` records that `pantr.grid`'s oracle is
+/// `float64`-only.
 
-#include <cstdio>
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/grid/grid.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::geometry::AABB;
+using pantr::grid::GridBase;
+using pantr::grid::GridLike;
+using pantr::grid::GridRestriction;
+using pantr::grid::Hook;
+
+// ---------------------------------------------------------------------------
+// The zero-hook fixture
+// ---------------------------------------------------------------------------
+
+template <class T>
+class BoxGrid;
+
+}  // namespace
+
+template <class T>
+struct pantr::grid::grid_traits<BoxGrid<T>> {
+    using scalar_type = T;
+    static constexpr Hook hooks = Hook::none;
+};
+
+namespace {
+
+/// A `nx` by `ny` grid of unit cells with its lo corner at the origin.
+///
+/// Row-major cell ids: `cid = i * ny + j`, cell `(i, j)` spanning
+/// `[i, i + 1] x [j, j + 1]`. Everything about it is computable by hand, which is the
+/// only property it needs.
+template <class T>
+class BoxGrid : public GridBase<BoxGrid<T>> {
+  public:
+    /// The mixin, named publicly so a differential test can reach the hidden defaults.
+    using Base = GridBase<BoxGrid<T>>;
+
+    BoxGrid(std::int64_t nx, std::int64_t ny) : Base(2, nx * ny), nx_(nx), ny_(ny) {}
+
+    void cell_bounds(std::int64_t cid, std::span<T> lo, std::span<T> hi) const {
+        this->check_cid(cid);
+        ++cell_bounds_calls_;
+        const std::int64_t i = cid / ny_;
+        const std::int64_t j = cid % ny_;
+        lo[0] = static_cast<T>(i);
+        lo[1] = static_cast<T>(j);
+        hi[0] = static_cast<T>(i + 1);
+        hi[1] = static_cast<T>(j + 1);
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const T> pt) const {
+        const std::optional<std::int64_t> i = axis_index(pt[0], nx_);
+        const std::optional<std::int64_t> j = axis_index(pt[1], ny_);
+        if (!i || !j) {
+            return std::nullopt;
+        }
+        return (*i * ny_) + *j;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+                                                                    std::int64_t lfid) const {
+        this->check_lfid(cid, lfid);
+        std::int64_t i = cid / ny_;
+        std::int64_t j = cid % ny_;
+        const std::int64_t axis = lfid / 2;
+        const std::int64_t step = (lfid % 2 == 0) ? -1 : 1;
+        (axis == 0 ? i : j) += step;
+        if (i < 0 || i >= nx_ || j < 0 || j >= ny_) {
+            return std::nullopt;
+        }
+        return (i * ny_) + j;
+    }
+
+    /// How many times the primitive ran; the only way to see the BVH cache from outside.
+    [[nodiscard]] std::int64_t cell_bounds_calls() const noexcept { return cell_bounds_calls_; }
+
+  private:
+    /// The cell index containing `x` along an axis of `n` unit cells, closed at the top.
+    [[nodiscard]] static std::optional<std::int64_t> axis_index(T x, std::int64_t n) {
+        using pantr::value_of;
+        const auto v = value_of(x);
+        if (v < 0 || v > static_cast<decltype(v)>(n)) {
+            return std::nullopt;
+        }
+        std::int64_t k = 0;
+        while (k + 1 < n && v >= static_cast<decltype(v)>(k + 1)) {
+            ++k;
+        }
+        return k;
+    }
+
+    std::int64_t nx_;
+    std::int64_t ny_;
+    mutable std::int64_t cell_bounds_calls_ = 0;
+};
+
+// ---------------------------------------------------------------------------
+// A minimal grid, for the base's own construction checks
+// ---------------------------------------------------------------------------
+
+class RawGrid;
+
+}  // namespace
+
+template <>
+struct pantr::grid::grid_traits<RawGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+namespace {
+
+/// The smallest thing that is a grid: it forwards `(ndim, num_cells)` to the mixin
+/// unchanged, which is what lets the base's own construction checks be reached.
+class RawGrid : public GridBase<RawGrid> {
+  public:
+    RawGrid(std::int64_t ndim, std::int64_t num_cells) : GridBase<RawGrid>(ndim, num_cells) {}
+
+    void cell_bounds(std::int64_t cid, std::span<double> lo, std::span<double> hi) const {
+        this->check_cid(cid);
+        std::fill(lo.begin(), lo.end(), 0.0);
+        std::fill(hi.begin(), hi.end(), 1.0);
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+                                                                    std::int64_t lfid) const {
+        this->check_lfid(cid, lfid);
+        return std::nullopt;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// The two-hook fixture
+// ---------------------------------------------------------------------------
+
+template <class T>
+class HookedGrid;
+
+}  // namespace
+
+template <class T>
+struct pantr::grid::grid_traits<HookedGrid<T>> {
+    using scalar_type = T;
+    static constexpr Hook hooks = Hook::boundary_facets | Hook::locate_many;
+};
+
+namespace {
+
+/// The same geometry, with two defaults replaced by deliberately WRONG answers.
+///
+/// Wrong on purpose: a hook agreeing with its default would prove nothing about which
+/// of the two ran.
+template <class T>
+class HookedGrid : public GridBase<HookedGrid<T>> {
+  public:
+    /// The mixin, named publicly so the qualified call below can reach it.
+    using Base = GridBase<HookedGrid<T>>;
+
+    HookedGrid(std::int64_t nx, std::int64_t ny) : Base(2, nx * ny), inner_(nx, ny) {}
+
+    void cell_bounds(std::int64_t cid, std::span<T> lo, std::span<T> hi) const {
+        inner_.cell_bounds(cid, lo, hi);
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const T> pt) const {
+        return inner_.locate(pt);
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t cid,
+                                                                    std::int64_t lfid) const {
+        return inner_.neighbor_across_facet(cid, lfid);
+    }
+
+    [[nodiscard]] std::vector<std::int64_t> boundary_facets() const { return {-1, -1}; }
+
+    [[nodiscard]] std::vector<std::int64_t> locate_many(span2d<const T> points) const {
+        return std::vector<std::int64_t>(points.extent(0), -7);
+    }
+
+  private:
+    BoxGrid<T> inner_;
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// The census (AC7): both fixtures, both scalars
+// ---------------------------------------------------------------------------
+
+PANTR_GRID_CENSUS(RawGrid);
+PANTR_GRID_CENSUS(BoxGrid<double>);
+PANTR_GRID_CENSUS(BoxGrid<float>);
+PANTR_GRID_CENSUS(HookedGrid<double>);
+PANTR_GRID_CENSUS(HookedGrid<float>);
+
+namespace {
+
+// The concept is a claim about what a grid IS, so it is worth pinning positively as
+// well as through the census, and pinning what it excludes.
+static_assert(GridLike<BoxGrid<double>>);
+static_assert(GridLike<HookedGrid<float>>);
+static_assert(!GridLike<int>);
+
+/// A grid whose `cell_bounds` cannot write its output.
+///
+/// It satisfies a callability-based concept -- `std::span<T>` converts implicitly to
+/// `std::span<const T>` -- and compiles, and returns whatever was already in the
+/// caller's buffer. Measured accepted by g++ 14.4, g++ 10.5, clang++ 18.1 and
+/// clang++ 10.0 alike. The exact member-pointer form of `GridLike` is what rejects it,
+/// and this is the assertion that says so.
+class UnwritableBoundsGrid;
+
+}  // namespace
+
+template <>
+struct pantr::grid::grid_traits<UnwritableBoundsGrid> {
+    using scalar_type = double;
+    static constexpr Hook hooks = Hook::none;
+};
+
+namespace {
+
+class UnwritableBoundsGrid : public GridBase<UnwritableBoundsGrid> {
+  public:
+    UnwritableBoundsGrid() : GridBase<UnwritableBoundsGrid>(1, 1) {}
+
+    // NOT `std::span<double>`: this is the trap.
+    void cell_bounds(std::int64_t, std::span<const double>, std::span<const double>) const {}
+
+    [[nodiscard]] std::optional<std::int64_t> locate(std::span<const double>) const {
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> neighbor_across_facet(std::int64_t,
+                                                                    std::int64_t) const {
+        return std::nullopt;
+    }
+};
+
+static_assert(!GridLike<UnwritableBoundsGrid>,
+              "a cell_bounds that cannot write its output must not satisfy GridLike");
+
+// The detector itself, in both directions, on the two fixtures.
+static_assert(!pantr::grid::detail::redeclares_boundary_facets<BoxGrid<double>>());
+static_assert(pantr::grid::detail::redeclares_boundary_facets<HookedGrid<double>>());
+static_assert(!pantr::grid::detail::redeclares_locate_many<BoxGrid<double>>());
+static_assert(pantr::grid::detail::redeclares_locate_many<HookedGrid<double>>());
+static_assert(!pantr::grid::detail::redeclares_num_local_facets<BoxGrid<double>>());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+using Grid2 = BoxGrid<double>;
+
+/// `(axis, side)`, aliased because the comma in the template argument list would
+/// otherwise be read as a second macro argument by `PANTR_CHECK`.
+using AxisSide = std::pair<std::int64_t, std::int64_t>;
+
+/// The cell corners as a pair of vectors, for comparison against literals.
+std::pair<std::vector<double>, std::vector<double>> bounds_of(const Grid2& g, std::int64_t cid) {
+    std::vector<double> lo(2);
+    std::vector<double> hi(2);
+    g.cell_bounds(cid, lo, hi);
+    return {lo, hi};
+}
+
+bool spans_equal(std::span<const double> a, std::initializer_list<double> b) {
+    return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
+}
+
+// ---------------------------------------------------------------------------
+// The defaults, against hand-computed values
+// ---------------------------------------------------------------------------
+
+/// Whether `GridBase` refuses these sizes with `std::invalid_argument`.
+bool rejects_construction(std::int64_t ndim, std::int64_t num_cells) {
+    try {
+        const RawGrid bad(ndim, num_cells);
+        static_cast<void>(bad);
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+void test_state() {
+    const Grid2 g(3, 2);
+    PANTR_CHECK(g.ndim() == 2);
+    PANTR_CHECK(g.num_cells() == 6);
+
+    // The mixin's own construction checks, reached through the grid that forwards
+    // `(ndim, num_cells)` unchanged. Both must be rejected BEFORE the tag registries
+    // see them, or the message blames `facets_per_cell` for a bad `ndim`.
+    PANTR_CHECK(rejects_construction(0, 4));
+    PANTR_CHECK(rejects_construction(-1, 4));
+    PANTR_CHECK(rejects_construction(2, -1));
+
+    const RawGrid empty(3, 0);
+    PANTR_CHECK_MSG(empty.num_cells() == 0, "a grid with no cells is well formed");
+    PANTR_CHECK(empty.boundary_facets().empty());
+    PANTR_CHECK(empty.facet_tags().facets_per_cell() == 6);
+}
+
+void test_cell_accessors() {
+    const Grid2 g(3, 2);
+
+    // cid 3 is (i, j) = (1, 1), spanning [1, 2] x [1, 2].
+    const auto [lo, hi] = bounds_of(g, 3);
+    PANTR_CHECK(lo[0] == 1.0 && lo[1] == 1.0 && hi[0] == 2.0 && hi[1] == 2.0);
+
+    const AABB<double> box = g.cell_aabb(3);
+    PANTR_CHECK(spans_equal(box.lo(), {1.0, 1.0}));
+    PANTR_CHECK(spans_equal(box.hi(), {2.0, 2.0}));
+
+    PANTR_CHECK(g.cell_level(3) == 0);
+    PANTR_CHECK(g.child_cells(3).empty());
+
+    // reference_map is diag(hi - lo) u + lo, so the unit cube's hi corner is the cell's.
+    const auto map = g.reference_map(3);
+    PANTR_CHECK(map.dim() == 2);
+    PANTR_CHECK(spans_equal(map.offset(), {1.0, 1.0}));
+    PANTR_CHECK(pantr::at(map.matrix(), 0, 0) == 1.0);
+    PANTR_CHECK(pantr::at(map.matrix(), 1, 1) == 1.0);
+    PANTR_CHECK(pantr::at(map.matrix(), 0, 1) == 0.0);
+    PANTR_CHECK(pantr::at(map.matrix(), 1, 0) == 0.0);
+}
+
+void test_neighbors() {
+    const Grid2 g(3, 2);
+    // Cell 0 = (0, 0): a corner, so two neighbours -- (1, 0) = 2 and (0, 1) = 1.
+    PANTR_CHECK(g.neighbors(0) == std::vector<std::int64_t>({2, 1}));
+    // Cell 2 = (1, 0): an edge cell, three neighbours -- (0, 0), (2, 0), (1, 1).
+    PANTR_CHECK(g.neighbors(2) == std::vector<std::int64_t>({0, 4, 3}));
+    // hanging_neighbors wraps the same answer, and is empty on the boundary.
+    PANTR_CHECK(g.hanging_neighbors(0, 1) == std::vector<std::int64_t>({2}));
+    PANTR_CHECK(g.hanging_neighbors(0, 0).empty());
+}
+
+void test_facets() {
+    const Grid2 g(3, 2);
+    PANTR_CHECK(g.num_local_facets(0) == 4);
+    PANTR_CHECK(g.local_facet_axis_side(0, 3) == AxisSide(1, 1));
+    PANTR_CHECK(g.local_facet_axis_side(0, 0) == AxisSide(0, 0));
+
+    // Facet 0 of cell 0 is the low face on axis 0: degenerate there, full extent on axis 1.
+    std::vector<double> lo(2);
+    std::vector<double> hi(2);
+    g.local_facet_bounds(0, 0, lo, hi);
+    PANTR_CHECK(lo[0] == 0.0 && hi[0] == 0.0);
+    PANTR_CHECK(lo[1] == 0.0 && hi[1] == 1.0);
+
+    g.local_facet_bounds(0, 3, lo, hi);
+    PANTR_CHECK(lo[1] == 1.0 && hi[1] == 1.0);
+    PANTR_CHECK(lo[0] == 0.0 && hi[0] == 1.0);
+
+    PANTR_CHECK(g.is_mesh_boundary_facet(0, 0));
+    PANTR_CHECK(!g.is_mesh_boundary_facet(0, 1));
+}
+
+void test_boundary_facets() {
+    const Grid2 g(3, 2);
+    const std::vector<std::int64_t> rows = g.boundary_facets();
+    // Every cell of a 3 x 2 grid touches the boundary. Interior facet count is
+    // 2 * (2 * 2 + 3 * 1) = 14 of the 24, leaving 10 boundary facets.
+    PANTR_CHECK(rows.size() == 20);
+    const std::vector<std::int64_t> expected = {
+        0, 0, 0, 2,   // cell (0,0): low-x and low-y
+        1, 0, 1, 3,   // cell (0,1): low-x and high-y
+        2, 2,         // cell (1,0): low-y
+        3, 3,         // cell (1,1): high-y
+        4, 1, 4, 2,   // cell (2,0): high-x and low-y
+        5, 1, 5, 3};  // cell (2,1): high-x and high-y
+    PANTR_CHECK(rows == expected);
+}
+
+void test_locate_many() {
+    const Grid2 g(3, 2);
+    const std::vector<double> pts = {0.5, 0.5, 2.5, 1.5, -1.0, 0.5, 0.5, 9.0};
+    const std::vector<std::int64_t> got =
+        g.locate_many(span2d<const double>(pts.data(), 4, 2));
+    PANTR_CHECK(got == std::vector<std::int64_t>({0, 5, -1, -1}));
+}
+
+void test_collect_cell_bounds() {
+    const Grid2 g(3, 2);
+    std::vector<double> lo(12);
+    std::vector<double> hi(12);
+    g.collect_cell_bounds(span2d<double>(lo.data(), 6, 2), span2d<double>(hi.data(), 6, 2));
+    const std::vector<double> expected_lo = {0, 0, 0, 1, 1, 0, 1, 1, 2, 0, 2, 1};
+    const std::vector<double> expected_hi = {1, 1, 1, 2, 2, 1, 2, 2, 3, 1, 3, 2};
+    PANTR_CHECK(lo == expected_lo);
+    PANTR_CHECK(hi == expected_hi);
+}
+
+/// AC3, restated: the cache builds on first use and is REUSED thereafter.
+///
+/// The ticket's third clause -- "and rebuilds after invalidation" -- has nothing to
+/// assert here, because this ticket ships no `invalidate_caches()`. It was asked for so
+/// that `HierarchicalGrid::_rebuild` could drop its base's caches, and
+/// FELIGN/pantr#378 makes refinement return a NEW grid instead, so by the time the
+/// hierarchical port runs there is nothing to invalidate: the new grid's caches are
+/// empty and the old grid's are still valid. A protected mutator nothing calls is the
+/// kind of seam that becomes load-bearing by accident.
+void test_lazy_bvh_cache() {
+    const Grid2 g(3, 2);
+    PANTR_CHECK_MSG(g.cell_bounds_calls() == 0, "the cache must not be built at construction");
+
+    const pantr::grid::BVH<double>& first = g.cell_bvh();
+    const std::int64_t after_build = g.cell_bounds_calls();
+    PANTR_CHECK_MSG(after_build == 6, "building the cache visits every cell exactly once");
+    PANTR_CHECK(first.n_cells() == 6);
+
+    const pantr::grid::BVH<double>& second = g.cell_bvh();
+    PANTR_CHECK_MSG(&first == &second, "cell_bvh must hand back the same tree");
+    PANTR_CHECK_MSG(g.cell_bounds_calls() == after_build, "a reused cache rebuilds nothing");
+
+    // query_aabb rides on the same cache.
+    std::vector<std::int64_t> hits = g.query_aabb(AABB<double>(std::vector<double>{1.5, 0.5},
+                                                               std::vector<double>{1.6, 0.6}));
+    PANTR_CHECK(hits == std::vector<std::int64_t>({2}));
+    PANTR_CHECK(g.cell_bounds_calls() == after_build);
+}
+
+void test_tags() {
+    Grid2 g(3, 2);
+    PANTR_CHECK(g.cell_tags().num_cells() == 6);
+    PANTR_CHECK(g.facet_tags().num_cells() == 6);
+    PANTR_CHECK_MSG(g.facet_tags().facets_per_cell() == 4,
+                    "facet_tags is sized 2 * ndim facets per cell");
+
+    const std::vector<std::int64_t> ids = {0, 2};
+    const std::vector<std::int64_t> values = {7, 9};
+    g.cell_tags().set("a", ids, values);
+
+    // The const overload reads the very same registry the non-const one mutated.
+    const Grid2& cg = g;
+    PANTR_CHECK(cg.cell_tags().contains("a"));
+    PANTR_CHECK(&cg.cell_tags() == &g.cell_tags());
+}
+
+void test_validation_messages() {
+    const Grid2 g(3, 2);
+    std::string cid_message;
+    try {
+        static_cast<void>(g.cell_level(6));
+    } catch (const std::out_of_range& e) {
+        cid_message = e.what();
+    }
+    PANTR_CHECK_MSG(cid_message == "cell id 6 is out of range [0, 6).", cid_message);
+
+    std::string lfid_message;
+    try {
+        static_cast<void>(g.local_facet_axis_side(0, 4));
+    } catch (const std::out_of_range& e) {
+        lfid_message = e.what();
+    }
+    PANTR_CHECK_MSG(lfid_message == "local facet id 4 is out of range [0, 4).", lfid_message);
+
+    bool negative_threw = false;
+    try {
+        static_cast<void>(g.num_local_facets(-1));
+    } catch (const std::out_of_range&) {
+        negative_threw = true;
+    }
+    PANTR_CHECK(negative_threw);
+}
+
+void test_restrict_default_throws() {
+    const Grid2 g(3, 2);
+    const std::vector<std::int64_t> ids = {0, 1};
+    bool threw = false;
+    try {
+        static_cast<void>(g.restrict(ids));
+    } catch (const std::logic_error& e) {
+        threw = std::string(e.what()).find("restrict()") != std::string::npos;
+    }
+    PANTR_CHECK_MSG(threw, "the default restrict must throw, as the Python contract does");
+}
+
+void test_make_restriction() {
+    Grid2 sub(1, 2);
+    const GridRestriction<Grid2> r =
+        pantr::grid::make_restriction(sub, std::vector<std::int64_t>{4, 5},
+                                      std::vector<std::uint8_t>{1, 0});
+    PANTR_CHECK(r.grid.num_cells() == 2);
+    PANTR_CHECK(r.local_to_global_cell == std::vector<std::int64_t>({4, 5}));
+    PANTR_CHECK(r.in_subset == std::vector<std::uint8_t>({1, 0}));
+
+    bool threw = false;
+    try {
+        static_cast<void>(pantr::grid::make_restriction(Grid2(1, 2),
+                                                        std::vector<std::int64_t>{4},
+                                                        std::vector<std::uint8_t>{1, 0}));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    PANTR_CHECK_MSG(threw, "make_restriction must reject index arrays of the wrong length");
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch: name hiding reaches the hook, the qualified call reaches the default
+// ---------------------------------------------------------------------------
+
+void test_name_hiding_dispatch() {
+    const HookedGrid<double> g(3, 2);
+    const BoxGrid<double> plain(3, 2);
+
+    PANTR_CHECK_MSG(g.boundary_facets() == std::vector<std::int64_t>({-1, -1}),
+                    "an unqualified call must reach the hook");
+    PANTR_CHECK_MSG(g.Base::boundary_facets() == plain.boundary_facets(),
+                    "the qualified call must reach the hidden default");
+
+    const std::vector<double> pts = {0.5, 0.5, 2.5, 1.5};
+    const span2d<const double> view(pts.data(), 2, 2);
+    PANTR_CHECK(g.locate_many(view) == std::vector<std::int64_t>({-7, -7}));
+    PANTR_CHECK(g.Base::locate_many(view) == plain.locate_many(view));
+
+    // A default that calls another default through `self()` sees the hook too:
+    // `neighbors` is generic here, and it reaches the grid's own primitives.
+    PANTR_CHECK(g.neighbors(0) == plain.neighbors(0));
+}
+
+/// The `float` census device, exercised once at run time so it is not merely compiled.
+void test_float_instantiation() {
+    const BoxGrid<float> g(2, 2);
+    std::vector<float> lo(2);
+    std::vector<float> hi(2);
+    g.cell_bounds(3, lo, hi);
+    PANTR_CHECK(lo[0] == 1.0F && hi[1] == 2.0F);
+    PANTR_CHECK(g.boundary_facets().size() == 16);
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_grid_defaults asserts nothing yet");
+    test_state();
+    test_cell_accessors();
+    test_neighbors();
+    test_facets();
+    test_boundary_facets();
+    test_locate_many();
+    test_collect_cell_bounds();
+    test_lazy_bvh_cache();
+    test_tags();
+    test_validation_messages();
+    test_restrict_default_throws();
+    test_make_restriction();
+    test_name_hiding_dispatch();
+    test_float_instantiation();
     return pantr::test::summary("test_grid_defaults");
 }

--- a/cpp/tests/test_grid_defaults.cpp
+++ b/cpp/tests/test_grid_defaults.cpp
@@ -310,6 +310,32 @@ std::pair<std::vector<double>, std::vector<double>> bounds_of(const Grid2& g, st
     return {lo, hi};
 }
 
+/// Whether `fn` throws `std::invalid_argument`.
+template <class F>
+bool throws_invalid_argument(F fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+/// Whether `fn` throws `std::out_of_range`.
+template <class F>
+bool throws_out_of_range(F fn) {
+    try {
+        fn();
+    } catch (const std::out_of_range&) {
+        return true;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
 bool spans_equal(std::span<const double> a, std::initializer_list<double> b) {
     return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
 }
@@ -543,6 +569,74 @@ void test_make_restriction() {
     PANTR_CHECK_MSG(threw, "make_restriction must reject index arrays of the wrong length");
 }
 
+/// The out-parameter shape checks, which must survive a release build.
+///
+/// They are ordinary `if`/`throw`, not `PANTR_PRECONDITION`: that macro is `assert` and
+/// vanishes under `NDEBUG`, so a release build would index a short span out of bounds
+/// instead of reporting it. This test runs in every configuration, which is the point.
+void test_output_span_validation() {
+    const Grid2 g(3, 2);
+    std::vector<double> two(2);
+    std::vector<double> one(1);
+
+    PANTR_CHECK(throws_invalid_argument([&] { g.local_facet_bounds(0, 0, one, two); }));
+    PANTR_CHECK(throws_invalid_argument([&] { g.local_facet_bounds(0, 0, two, one); }));
+
+    std::vector<double> small(4);
+    const span2d<double> short_view(small.data(), 2, 2);
+    PANTR_CHECK(
+        throws_invalid_argument([&] { g.collect_cell_bounds(short_view, short_view); }));
+
+    const std::vector<double> pts = {0.5, 0.5, 1.5};
+    PANTR_CHECK(throws_invalid_argument(
+        [&] { static_cast<void>(g.locate_many(span2d<const double>(pts.data(), 1, 3))); }));
+}
+
+/// A one-dimensional grid: the facet count, the encoding and the tag registry follow it.
+///
+/// Every default is written against `2 * ndim`, and `ndim == 1` is the smallest value
+/// that exercises the arithmetic without the two axes masking a mixed-up index.
+void test_one_dimensional_grid() {
+    const RawGrid g(1, 3);
+    PANTR_CHECK(g.ndim() == 1);
+    PANTR_CHECK(g.num_local_facets(0) == 2);
+    PANTR_CHECK(g.facet_tags().facets_per_cell() == 2);
+    PANTR_CHECK(g.local_facet_axis_side(0, 0) == AxisSide(0, 0));
+    PANTR_CHECK(g.local_facet_axis_side(0, 1) == AxisSide(0, 1));
+    PANTR_CHECK(throws_out_of_range([&] { static_cast<void>(g.local_facet_axis_side(0, 2)); }));
+    // RawGrid has no neighbours at all, so every one of the six facets is a boundary.
+    PANTR_CHECK(g.boundary_facets().size() == 12);
+}
+
+/// A single-cell grid: no neighbours, every facet on the boundary.
+void test_single_cell_grid() {
+    const Grid2 g(1, 1);
+    PANTR_CHECK(g.num_cells() == 1);
+    PANTR_CHECK(g.neighbors(0).empty());
+    PANTR_CHECK(g.boundary_facets() == std::vector<std::int64_t>({0, 0, 0, 1, 0, 2, 0, 3}));
+    PANTR_CHECK(g.cell_bvh().n_cells() == 1);
+    PANTR_CHECK(g.hanging_neighbors(0, 0).empty());
+}
+
+/// A point exactly on an interior cell face lands in one cell, and always the same one.
+///
+/// The tie cannot be avoided -- a face belongs to both cells geometrically -- so what is
+/// asserted is that the fixture's rule (a face belongs to the cell above it) is applied
+/// consistently by `locate` and by the generic `locate_many` built on it.
+void test_locate_on_a_cell_boundary() {
+    const Grid2 g(3, 2);
+    const std::vector<double> pts = {1.0, 0.5, 0.0, 0.0, 3.0, 2.0};
+    const std::vector<std::int64_t> got = g.locate_many(span2d<const double>(pts.data(), 3, 2));
+    // (1.0, 0.5) is on the face between cells 0 and 2, and goes to the upper one.
+    // (0.0, 0.0) is the grid's lo corner; (3.0, 2.0) is its hi corner, and the top of the
+    // range is closed, so it lands in the last cell rather than outside.
+    PANTR_CHECK(got == std::vector<std::int64_t>({2, 0, 5}));
+    for (std::size_t i = 0; i < 3; ++i) {
+        const std::span<const double> pt(&pts[i * 2], 2);
+        PANTR_CHECK(g.locate(pt).value_or(-1) == got[i]);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Dispatch: name hiding reaches the hook, the qualified call reaches the default
 // ---------------------------------------------------------------------------
@@ -561,8 +655,9 @@ void test_name_hiding_dispatch() {
     PANTR_CHECK(g.locate_many(view) == std::vector<std::int64_t>({-7, -7}));
     PANTR_CHECK(g.Base::locate_many(view) == plain.locate_many(view));
 
-    // A default that calls another default through `self()` sees the hook too:
-    // `neighbors` is generic here, and it reaches the grid's own primitives.
+    // `neighbors` is generic on BOTH grids, so this says only that hiding two unrelated
+    // names left it alone. That is the claim worth making here -- name hiding is
+    // per-name, and a hook must not perturb a default that does not mention it.
     PANTR_CHECK(g.neighbors(0) == plain.neighbors(0));
 }
 
@@ -591,6 +686,10 @@ int main() {
     test_validation_messages();
     test_restrict_default_throws();
     test_make_restriction();
+    test_output_span_validation();
+    test_one_dimensional_grid();
+    test_single_cell_grid();
+    test_locate_on_a_cell_boundary();
     test_name_hiding_dispatch();
     test_float_instantiation();
     return pantr::test::summary("test_grid_defaults");

--- a/cpp/tests/test_grid_defaults.cpp
+++ b/cpp/tests/test_grid_defaults.cpp
@@ -280,6 +280,11 @@ class UnwritableBoundsGrid : public GridBase<UnwritableBoundsGrid> {
 static_assert(!GridLike<UnwritableBoundsGrid>,
               "a cell_bounds that cannot write its output must not satisfy GridLike");
 
+// Pins that the fixture above differs from a good grid in its PRIMITIVE and in nothing
+// else -- and, incidentally, keeps clang from reporting `hooks` unused, which it does
+// for the traits of any grid in an anonymous namespace that the census never reads.
+static_assert(pantr::grid::grid_traits<UnwritableBoundsGrid>::hooks == Hook::none);
+
 // The detector itself, in both directions, on the two fixtures.
 static_assert(!pantr::grid::detail::redeclares_boundary_facets<BoxGrid<double>>());
 static_assert(pantr::grid::detail::redeclares_boundary_facets<HookedGrid<double>>());

--- a/design/grid_hierarchy_port.md
+++ b/design/grid_hierarchy_port.md
@@ -1,0 +1,721 @@
+# Porting the `Grid` hierarchy: where the vtable goes, and where it does not
+
+**Status:** proposed, 2026-08-30. Written for ticket #386, and binding on #387 and #395 if
+adopted. **Sections marked *(provisional)* were not compiled or run at the time of writing.**
+**Date:** 2026-08-30.
+**Scope:** the C++ shape of the generic `Grid` layer, how inheritance crosses the backend
+seam, which of the base's concrete methods move, and what the Python surface becomes.
+Not how the two backends are compared, which is `design/backend_parity.md`.
+**Companions:** `design/cross_backend_types.md` (the ownership ruling this obeys),
+`design/bvh.md` (the cache this layer owns), `design/backend_parity.md` Rule 8 (why the
+`float` axis stays out of the bindings).
+
+**Validated against:** `proto/cpp` at `1fe9849`, worktree `feat/386-grid-hierarchy`. Every
+line number below was read in that tree. Python behaviour was measured on the `pantr`
+environment's CPython **3.14.6**.
+
+## The decision in one paragraph
+
+The generic layer becomes a **CRTP mixin, `pantr::grid::GridBase<Derived, T>`, holding its own
+state and dispatching by name hiding**; there is no vtable, and a C++ grid is a compile-time
+type. **Inheritance does not cross the seam at all** -- after the port the Python side has no
+implementation inheritance between grids, only a `typing.Protocol` named `Grid` for annotation
+and a private ABC named `_GridPython` for the temporary oracle. A Python-defined grid remains
+possible and remains a *Python* grid; it can never become a C++ one, and no callback bridge
+should be built to pretend otherwise. The wrapper classes are siblings that each forward to a
+handle, sharing forwarding code through a private, stateless `_GridWrapper` base.
+
+## Findings against the ticket as written
+
+Three of these are measured refutations, not opinions. They are listed first because they
+change what #386 must do.
+
+### F1 (critical). Turning `Grid` into a body-less Protocol breaks a must-not-edit test
+
+`tests/test_grid_hierarchical.py:1721` is
+
+```python
+np_testing.assert_array_equal(g.boundary_facets(), Grid.boundary_facets(g))
+```
+
+inside `TestBoundaryFacets.test_override_agrees_with_abc_default`. It calls `Grid`'s default
+**unbound**, passing a `HierarchicalGrid` as `self`, to check the specialisation against the
+generic. `Grid` is imported from `pantr.grid` at `tests/test_grid_hierarchical.py:16`, and
+that file is on #386's *must pass without being edited* list.
+
+If `Grid` becomes a Protocol whose members are `...`, `Grid.boundary_facets(g)` returns
+`None`, and `numpy.testing.assert_array_equal(array, None)` raises `AssertionError`
+(measured). The test fails.
+
+**The repair is available and cheap: a `typing.Protocol` may carry default implementations,
+and an unbound call through it works.** Measured on 3.14.6: for a Protocol `G` with a real
+`default()` body, `G.default(duck_typed_object)` returns the correct value. So `Grid` keeps
+the nineteen concrete bodies verbatim; only the six primitives become `...`.
+
+This has a consequence worth stating plainly, because it is the opposite of what the ticket
+implies: **the Python `Grid` does not stop carrying the generic algorithm.** It stops being
+*inherited from*. Those are different retirements and only the second one happens here.
+
+### F2 (important). Only one of the two `test_grid_abc.py` tests actually breaks
+
+The ticket says to delete both `:57-60` and `:63-76` because "that string is `ABCMeta`'s; a
+Protocol raises a different message". Measured on 3.14.6:
+
+| construct | result |
+|---|---|
+| `G()` where `G` is a Protocol | `TypeError: Protocols cannot be instantiated` -- does **not** match `"abstract"` |
+| explicit subclass of a Protocol omitting a **plain** member | instantiates fine, no error |
+| explicit subclass of a Protocol omitting an `@abc.abstractmethod` member | `TypeError: Can't instantiate abstract class _Incomplete without an implementation for abstract method 'prim'` -- **matches `"abstract"`** |
+
+`typing.Protocol`'s metaclass `typing._ProtocolMeta` derives from `abc.ABCMeta` (verified),
+so abstract enforcement is still live for anything that *explicitly* inherits.
+
+So `test_grid_is_abstract` (`:57-60`) does break and should go. `test_incomplete_subclass_is_abstract`
+(`:63-76`) **survives unchanged** provided the six primitives keep their `@abc.abstractmethod`
+decorators -- which they must anyway, on `_GridPython`. Re-point it at `_GridPython` and it
+keeps testing exactly what it tested before. One deletion, not two.
+
+### F3 (important). A Protocol without `__slots__ = ()` silently gives every explicit subclass a `__dict__`
+
+Measured: `abc.ABC.__slots__` is `()`, `Protocol.__slots__` is `()`, but `Generic` declares
+none. A Protocol that omits `__slots__ = ()` therefore leaks a `__dict__` into every explicit
+subclass even when that subclass declares `__slots__ = ()`. `Grid` today is slot-clean
+(`src/pantr/grid/_grid.py:71`) and both concrete grids depend on that.
+
+**Write `__slots__ = ()` on the `Grid` Protocol.** With it, an explicit subclass declaring
+`__slots__ = ()` has no `__dict__` (measured). This is a one-line requirement that nothing
+would have caught: no test asserts the absence of `__dict__`, and the failure is a silent
+per-instance memory regression plus the quiet return of settable attributes.
+
+### F4 (important). The Protocol cannot be both the consumer's contract and the implementer's
+
+`Grid` today plays two roles that inheritance fuses and structural typing cannot:
+
+- **what a consumer may rely on** -- all twenty-four public members, because `src/pantr/viz/_grid.py:54`
+  annotates `grid: Grid` and `src/pantr/grid/_cell_quadrature.py:31` does too;
+- **what an implementer must supply** -- six primitives, the rest being inherited.
+
+A Protocol has no "inherited" half, so it can only express the first. Consequently `Grid` must
+list all twenty-four public members, and #386's `AC6` -- "a class that omits **one of the six
+primitives**" -- does not test what it says: omitting `cell_aabb` fails identically. Restate
+`AC6` as *a class that does not satisfy the `Grid` Protocol is rejected where a `Grid` is
+expected*, and keep the six-primitive claim where it is actually enforced, which is
+`_GridPython`'s `__abstractmethods__` (F2) and the C++ concept.
+
+### F5 (recommended). The `float` instantiation contradicts a written module decision, and must be scoped
+
+`src/pantr/grid/_grid_backend.py` states that `pantr.grid`'s oracle is `float64`-only, that
+there is therefore no dtype axis, and that **the C++ registers no `float` overload** -- citing
+`design/backend_parity.md` Rule 8, that a parity claim is only defined where the comparison can
+say something.
+
+#386's `AC1`/`AC7` require the mixin to be instantiated at `float` as a census device, and a
+negative TU for "a hook hard-coding `double` at a `float` grid". Those are good compile-time
+checks and they do not conflict with Rule 8 -- but only because the `float` instantiation is
+**never bound and never compared**. Say so in the header, or the next ticket binds
+`TensorProductGridFloat32` for symmetry with `Bezier32`/`Bezier64` and opens a parity claim
+Rule 8 forbids.
+
+## The C++ shape
+
+Everything in this section was **compiled and run** before it was written down. See
+"What was compiled" for the artefacts and the commands.
+
+### `GridBase<Derived>`: a CRTP mixin that owns its state, dispatching by name hiding
+
+```cpp
+template <class Derived> struct grid_traits;          // primary, deliberately undefined
+
+template <class Derived>
+class GridBase {
+  public:
+    using scalar_type = typename grid_traits<Derived>::scalar_type;
+
+    std::int64_t ndim() const noexcept;               // base state, not a primitive
+    std::int64_t num_cells() const noexcept;          // base state, not a primitive
+
+    /* the generic defaults, as ordinary non-virtual members */
+
+    CellTags&       cell_tags() noexcept;             // eager member
+    const CellTags& cell_tags() const noexcept;
+    const BVH<scalar_type>& cell_bvh() const;         // fills a mutable std::optional
+
+  protected:
+    GridBase(std::int64_t ndim, std::int64_t num_cells);
+    const Derived& self() const noexcept;
+    Derived&       self() noexcept;
+
+  private:
+    std::int64_t ndim_, num_cells_;
+    CellTags cell_tags_;
+    FacetTags facet_tags_;
+    mutable std::optional<BVH<scalar_type>> bvh_;
+};
+```
+
+**"Closed" means: every grid is a `GridBase<itself>`, and the concept says so in one line**
+(`std::derived_from<G, GridBase<G>>`). Not a variant, not a sealed virtual base. There is no
+runtime grid type and no heterogeneous container of grids -- which is a real cost, stated
+below, and one nothing in the tree pays today.
+
+### Four departures from the ticket, each of which removes machinery rather than adding it
+
+**D-a. `ndim` and `num_cells` are base state, so there are four primitives, not six** (and
+three once `restrict` becomes a default -- see below).
+The ticket's mechanism 3 -- "grow the concept with a non-const state accessor and delete the
+cache accessor" -- exists to solve a problem that only arises if the state lives in `Derived`.
+It does not have to. A CRTP base cannot initialise members from `self()` in its own constructor
+(`Derived` is not yet constructed), which is presumably why the state was pushed outward; the
+ordinary repair is to **pass the two sizes up from `Derived`'s constructor**, computed from
+`Derived`'s own constructor arguments by a static helper. Then:
+
+- `cell_tags()` has trivial const and non-const overloads and no `const_cast` is near it;
+- `facet_tags_` is sized `2 * ndim` once, at construction;
+- `num_cells()` is a field read inside the hot loops rather than a forwarded call;
+- nothing can hand out the cache slot, because the slot is `private` in the mixin;
+- the concept shrinks to the handful of things a grid author actually writes.
+
+The invariant this makes legible, which the Python version leaves implicit: **`facet_tags_`
+hard-codes `2 * ndim` facets per cell, so `num_local_facets` is not a specialisable hook.**
+Assert that (`num_local_facets` must not appear in any grid's traits bitmask) rather than
+leaving it to be discovered.
+
+This departure has a dependency: it assumes a grid's cell count is fixed at construction.
+`HierarchicalGrid` mutates today (`_rebuild`, `src/pantr/grid/_hierarchical_grid.py:523-579`),
+but **#378 makes refinement return a new grid**, and #378 blocks #393/#394, which block #395.
+The DAG already guarantees the ordering. **If #378 is ever dropped, this departure must be
+revisited** -- that is the one thing that would reverse it.
+
+**D-b. Name hiding does the dispatch; the traits bitmask is a *declaration*, checked, never a
+dispatch input.** A default is an ordinary member of the mixin, so a `Derived` that declares
+the same name hides it, and every call -- from the outside and from inside another default via
+`self()` -- picks the specialisation. Nothing needs to read the bitmask at runtime or at
+compile time to route a call.
+
+This matters because the ticket's alternative (dispatch reads the bitmask) has a failure mode
+name hiding does not: **a hook that is written but not declared is silently ignored, and the
+default runs.** That is a wrong answer with no diagnostic. Under name hiding the hook is used,
+and the census below turns the inconsistency into a compile error instead. Verified: the
+"written but undeclared" translation unit is rejected by all four compilers.
+
+**D-c. Detect a hook by its member-pointer *type*, not by a `requires` probe.** The ticket
+rejects detection because a `requires` probe answers `true` for a hook with the wrong return
+type and for one with a const-qualified output span, "both measured". Both observations are
+correct and neither refutes detection -- they refute *that* probe. Compare instead:
+
+```cpp
+template <class D> constexpr bool redeclares_locate_many() noexcept {
+    return !std::is_same_v<decltype(&D::locate_many), decltype(&GridBase<D>::locate_many)>;
+}
+```
+
+If `D` does not redeclare the hook, `&D::locate_many` names the mixin's member and has type
+`R (GridBase<D>::*)(...)`. If it does, the type is `R (D::*)(...)`. The two are the same type
+exactly when the hook is absent -- and this stays correct when the return type is wrong or a
+parameter is const-qualified, because those still yield a `D::*` type. So detection is
+reliable, and the bitmask stops being the only source of truth and becomes something to
+check *against*.
+
+Known limits, worth writing in the header: `&D::name` is ill-formed if `D` overloads the name
+or makes it a template. Both are design errors here, and both fail loudly.
+
+**D-d. The census asserts the signature, so the convention is enforced rather than documented.**
+Two `static_assert`s per hook, one line each in the grid's own translation unit:
+
+```cpp
+static_assert(declares<G>(Hook::locate_many) == detail::redeclares_locate_many<G>(), "...");
+static_assert(!declares<G>(Hook::locate_many)
+              || std::is_same_v<decltype(&G::locate_many),
+                                std::vector<std::int64_t> (G::*)(std::span<const T>) const>, "...");
+```
+
+plus `template class GridBase<G>;` to force every default body. The ticket asks for the hook
+signature convention to be *stated* in the header before any negative test is written, because
+"a negative translation unit cannot be written against a convention that has not been written
+down". Correct -- and the stronger form is available: state it **as the assertion**, once, in
+a macro the grid's census expands. A convention nobody can paraphrase cannot drift.
+
+### The trap that the concept has to be written against, and it is not the one the ticket names
+
+`std::span<T>` **converts implicitly to** `std::span<const T>` (measured). So a concept written
+as `requires(std::span<T> out) { g.cell_bounds(cid, out, out); }` is satisfied by a
+`cell_bounds` taking `std::span<const T>` -- which cannot write to its output at all. The
+grid compiles, satisfies the concept, and returns whatever was in the caller's buffer.
+
+**Measured: that translation unit was accepted by g++ 14.4, g++ 10.5, clang++ 18.1 and
+clang++ 10.0 alike, with `-Wall -Wextra -Werror`.** It is rejected once the concept pins the
+primitives by exact member-pointer type rather than by callability:
+
+```cpp
+template <class G>
+concept GridLike =
+    std::derived_from<G, GridBase<G>>
+    && std::is_same_v<decltype(&G::cell_bounds),
+                      void (G::*)(std::int64_t, std::span<typename G::scalar_type>,
+                                  std::span<typename G::scalar_type>) const>
+    && /* locate, neighbor_across_facet the same way */;
+```
+
+The ticket places this failure mode among the *hooks*. It lands on the **primitives**, where
+the output spans actually are, and the hook census would never have looked.
+
+### `GridRestriction` and the self-referential constraint
+
+The ticket's mechanism 2 holds and is adopted unchanged: `GridRestriction<G>` is
+**unconstrained**, and `make_restriction` carries the `GridLike` constraint plus the
+size-agreement check. Verified: a grid whose own `restrict()` returns
+`GridRestriction<Derived>` -- naming the template from inside the class being defined --
+compiles on all four compilers. What is lost is what the ticket says is lost: the type is
+nameable for a non-grid, and aggregate initialisation bypasses the factory.
+
+### What it costs at the call site
+
+Nothing at all in the ordinary case: a default is a non-virtual member and `self()` is a
+`static_cast`, so a whole default inlines into its caller.
+
+In the hot loop the difference against a virtual base is large, and it is an **inlining**
+difference rather than an indirect-call difference -- the primitive's body and its
+`std::optional` return cannot cross the call.
+
+Measured 2026-08-30 with `g++ 14.4 -O2`, one core via `taskset`, on the generic
+`boundary_facets` loop over a 100^3 grid, 6e6 neighbour queries. The harness is described
+under "What was compiled" below and is not committed:
+
+| | CRTP | virtual | ratio |
+|---|---|---|---|
+| neighbour queries only | 5.7 ms | 85.8 ms | **15.1x** |
+| the full loop, with the row `push_back` | 10.8 ms | 73.7 ms | **6.8x** |
+
+**A first version of this benchmark reported 1.05x and was wrong.** It held the virtual grid
+in a `const VBase&` bound to a local, so GCC devirtualized the call and measured CRTP against
+CRTP. The number above hides the dynamic type behind a factory in a separate translation unit.
+Anyone re-running this should check the same thing before believing a small ratio.
+
+Why this loop and not another: `boundary_facets` is generic for **both** concrete grids at the
+point #386 lands -- `TensorProductGrid` does not specialise it, and it is `O(num_cells * 2 * ndim)`
+neighbour queries by construction. It is the largest generic loop in the layer.
+
+Two honest caveats. The ratio is a property of a *cheap* primitive; a heavier one amortises the
+call. And `HierarchicalGrid` **does** specialise `boundary_facets`
+(`src/pantr/grid/_hierarchical_grid.py:975-1036`), so this measures the path a tensor-product
+grid takes, not every grid.
+
+### What CRTP costs, stated rather than waved past
+
+- **There is no runtime grid type.** `std::vector<Grid*>`, "a grid chosen from a config file",
+  and a non-template function taking any grid are all unavailable to a C++ consumer without
+  writing their own variant or interface. Nothing in pantr does any of these today: the census
+  found four `Grid` subclasses, and every one of the twenty-six grid `isinstance` sites in the
+  tree tests a **concrete** type, never the base.
+- **Every generic algorithm over grids is a template**, so it lives in a header and its errors
+  are template errors. `cell_quadrature` (#388) is the first one that will feel this.
+- **Compile time and code size** scale with grids x scalar types. Two grids x two scalars is
+  four instantiations of nineteen defaults, which is nothing; it is worth a note only because
+  the census deliberately forces all of them.
+
+
+### `restrict` is a throwing default, not a fourth primitive
+
+The ticket's mechanism 6 makes `restrict` required. **It does not have to be, and the compiler
+is not what forces it.** Verified on all four compilers: a mixin default
+
+```cpp
+[[nodiscard]] GridRestriction<Derived> restrict(std::span<const std::int64_t>) const {
+    throw std::logic_error("this grid kind does not support restrict().");
+}
+```
+
+compiles and throws. No `Derived` is constructed, so nothing needs `Derived` to be
+default-constructible, and `GridRestriction<Derived>` is only instantiated at the explicit
+instantiation, where `Derived` is complete.
+
+Three reasons to prefer it:
+
+- **It preserves the Python contract verbatim.** `src/pantr/grid/_grid.py:290-300` states
+  "Restriction is an *optional* grid capability" and raises `NotImplementedError`. Making it
+  required changes the documented contract of a public method for a reason internal to the C++
+  layer, which is the wrong direction of causation.
+- **The ticket already contradicts itself on this.** It calls the base's `NotImplementedError`
+  "reachable only through the test subclass this ticket removes", and then, three paragraphs
+  later, preserves that subclass by re-basing `_PlainGrid` onto `_GridPython`. `_PlainGrid`
+  supplies no `restrict`, so the path stays reachable.
+- **The stated argument does not support the stated conclusion.** "One concept that excludes no
+  grid is weight without enforcement" is an argument against adding a second `Restrictable`
+  concept. It is not an argument for promoting `restrict` to a primitive; a throwing default is
+  the third option and it costs three lines.
+
+The usual objection -- a base advertising an operation not every subtype supports is a Liskov
+violation -- does not bind in the C++ layer, because **nobody holds a `GridBase<D>&`
+polymorphically**; there is no substitutability to violate. It binds on the *Python* `Grid`
+Protocol, which is the real substitutability abstraction here -- and there `restrict` must
+appear regardless, because consumers annotate `Grid`, with `NotImplementedError` documented
+exactly as it is today.
+
+So: `restrict` is `Hook::restrict`, censused like the rest, with signature
+`GridRestriction<G> (G::*)(std::span<const std::int64_t>) const`. The concept has **three**
+primitives: `cell_bounds`, `locate`, `neighbor_across_facet`.
+
+## How inheritance crosses the seam: it does not
+
+**After the port there is no implementation inheritance between grids on the Python side, and
+no inheritance relationship crosses the boundary in either direction.** The Python surface
+becomes three separate things that today are one:
+
+| name | what it is | who uses it |
+|---|---|---|
+| `pantr.grid.Grid` | a `typing.Protocol`, `__slots__ = ()`, five `@abc.abstractmethod` primitives and **nineteen real default bodies** | annotations (`viz/_grid.py:54`, `_cell_quadrature.py:31`, `mpi/_create.py`), and the unbound differential call at `test_grid_hierarchical.py:1721` |
+| `pantr.grid._GridPython` | today's ABC verbatim: `abc.ABC`, `__slots__`, the same five abstract and nineteen concrete methods | the temporary Python oracle -- base of `_TensorProductGridPython`, of `HierarchicalGrid` until #395, and of `_PlainGrid` |
+| `pantr.grid._GridWrapper` | a private, **stateless** forwarding base: every method is `return self._impl.foo(...)` plus the wrap/unwrap of domain types | `TensorProductGrid` (#387) and `HierarchicalGrid` (#395), the two wrappers |
+
+`_GridPython` **must not inherit from `Grid`.** Structural typing makes it satisfy the Protocol
+without inheriting, and inheriting buys nothing while risking F3's `__dict__` leak. The same
+goes for `_GridWrapper`.
+
+### Who holds the vtable
+
+Nobody. There is no vtable anywhere in the design: C++ dispatches by name hiding at compile
+time, and the Python wrappers are unrelated classes that happen to satisfy the same Protocol.
+What was one dispatch mechanism (Python MRO) becomes two independent ones that never meet.
+
+### Can a Python-defined grid still exist? Yes -- as a *Python* grid, and only that
+
+A user (or a test) subclasses `_GridPython`, supplies the primitives, and gets the nineteen
+Python defaults. That keeps working under both backends and costs nothing new, because it is
+what `_PlainGrid` already is.
+
+What such a grid can **never** be is a C++ grid. `GridBase<Derived>` is a template; `Derived`
+must be a compile-time type; there is no runtime extension point to register into.
+
+### The callback bridge is buildable, and must not be built
+
+For completeness, because "impossible" would be wrong: a single C++ type
+`PyGrid : GridBase<PyGrid>` closing over a `nb::object` and forwarding the three primitives
+into Python would compile and work. It is rejected on two independent grounds.
+
+- **It is the shape `design/cross_backend_types.md` forbids**, in the form the amendment
+  singles out: an object that is half one implementation and half the other, with values
+  converted across the boundary per call.
+- **It re-imports the cost the port exists to remove, into the loop that motivates it.**
+  The generic `boundary_facets` makes `num_cells * 2 * ndim` primitive calls -- 6e6 on a
+  100^3 grid. A C++-to-Python call with argument conversion is on the order of a hundred
+  nanoseconds *at best*, against the 0.95 ns measured for the inlined native primitive. That
+  is the object-mode-in-the-inner-loop failure the house rules name for Numba, arriving at a
+  different boundary.
+
+And it is unnecessary: the ruling is that the backend becomes C++ only, so a permanent
+two-way bridge would be scaffolding built to be deleted.
+
+### What actually breaks, and it is not "user subclassing"
+
+The ticket measured zero `isinstance(x, Grid)` sites on the base; an independent census over
+`src`, `tests`, `tools` and `scripts` reproduced that -- all twenty-six grid `isinstance` sites
+test a concrete type. So no dispatch breaks. Three things do:
+
+1. **`Grid()` stops raising a message containing "abstract"** -- `test_grid_abc.py:57-60`. Delete
+   it, or re-point it at `_GridPython`.
+2. **`isinstance(x, Grid)` becomes a `TypeError`** rather than `False`, because `Grid` should
+   **not** be `@runtime_checkable`. Making it runtime-checkable would launder an unearned
+   guarantee: a `runtime_checkable` Protocol checks only that the *names* exist, never the
+   signatures, so it would answer `True` for an object that cannot actually serve as a grid.
+   There are no such sites today; the cost is that a future one gets an error instead of a
+   wrong answer, which is the right trade.
+3. **A `Grid`-typed value loses `__init__`.** Nothing constructs a `Grid` today, so this is
+   only a documentation change.
+
+## The split: which of the nineteen defaults move
+
+Reasons by group, since per-method reasons would be nineteen restatements of five.
+
+**Group A -- moves, because it is a loop over the primitives.** `boundary_facets`,
+`is_mesh_boundary_facet`, `neighbors`, `hanging_neighbors`, `locate_many`,
+`collect_cell_bounds`. Each is `O(num_cells)` or `O(num_cells * 2 * ndim)` interpreter-level
+calls today. **This group is the entire measurable payoff of the ticket**; see the 15x above.
+
+**Group B -- moves, because it constructs a C++-owned domain type.** `cell_aabb` (`AABB`),
+`reference_map` (`AffineTransform`), `cell_bvh` and `query_aabb` (`BVH`), `cell_tags` and
+`facet_tags` (`CellTags`/`FacetTags`), `restrict` (a grid). All seven of those types are
+already C++-owned. A Python method that pulled arrays across the seam and reassembled one
+would be reassembly-on-the-far-side -- the move `design/cross_backend_types.md` names as where
+an invariant gets dropped. Moving them means the wrapper only ever re-wraps a handle.
+
+**Group C -- moves, because a concrete grid specialises it, or will.** `cell_level`,
+`child_cells`, `num_local_facets`, `local_facet_axis_side`, `local_facet_bounds`. Individually
+trivial; that is not the criterion. **A hook and the default it replaces must live in the same
+language**, or the differential test that compares them -- the mechanism that caught defects in
+the already-merged ports, and #387's `AC4` -- has nothing to compare against in one place.
+`cell_level` is the concrete case: `HierarchicalGrid` specialises it
+(`src/pantr/grid/_hierarchical_grid.py:1131-1145`).
+
+**Group D -- moves, and is *duplicated* in the wrapper, deliberately.** `_check_cid`,
+`_check_lfid`. C++ must validate, because the amendment's premise is a C++ program with no
+interpreter above it. Python keeps its own only where the *message* is contractual. Measured:
+nanobind maps `std::out_of_range` to `IndexError` **preserving `what()`**
+(`nanobind/src/nb_internals.cpp:160-161`), and the must-pass assertions are
+`pytest.raises(IndexError, match="out of range")`
+(`tests/test_grid_hierarchical.py:1162,1164,1171,1610,1612`). So a C++ `std::out_of_range`
+carrying today's text satisfies them with **no** wrapper-side check. Duplicate only where a
+different exception *type* is owed -- the precedent is the tag registries, which raise
+`KeyError` from the wrapper because nanobind has no path to it (`cpp/bindings/grid_tags.cpp:15-17`).
+
+**Group E -- stays in Python, because it is about Python's calling convention, not about grids.**
+`_normalize_points` (`npt.ArrayLike` coercion, the `(ndim,)` to `(1, ndim)` promotion, and the
+exact `ValueError` text), `iter_cells` (returns a Python iterator over `range`), `__repr__`,
+`__reduce__`. C++ takes a typed span; deciding what a `list[list[float]]` means is the
+wrapper's job permanently. Precedent: `AABB.__init__` coerces, then hands down ravelled float64
+(`src/pantr/geometry.py:566-568`).
+
+**Nothing in Group A, B or C stays behind.** The one method that looks like it should and does
+not is `iter_cells`: it is in Group E because its *return type* is a Python iterator, not
+because the work is small.
+
+## The wrapper's shape
+
+`_GridWrapper` is a **private, stateless forwarding base**: `__slots__ = ()`, no `__init__`, and
+every method a one-liner over `self._impl` plus the wrap/unwrap of a domain type. Each concrete
+wrapper declares `__slots__ = ("_impl", "_cell_tags", "_facet_tags", "_bvh")` and its own
+`__init__`, `__repr__`, `__reduce__`, and grid-specific surface.
+
+This is inheritance used for reuse, which is normally the shape to refuse. It is right here for
+one reason and it should be stated rather than assumed: **the docstring is the user-facing
+contract** (`CLAUDE.md`, Layer 1), so twenty-four forwarders duplicated across `TensorProductGrid`
+and `HierarchicalGrid` is forty-eight docstrings and **two copies of the contract that will drift**.
+The base holds no state and imposes no protocol beyond "you have `_impl`", so nothing about the
+usual objection applies. The composition alternative -- a module of free functions
+`_fwd_cell_aabb(impl, cid)` -- still needs twenty-four call sites per wrapper and saves nothing.
+
+`_GridWrapper` must not inherit from `Grid` (F3) and must not inherit from `_GridPython` (that
+would be the mixed object `cross_backend_types.md` forbids: Python defaults over a C++ handle,
+inside a class the C++ backend hands to users).
+
+### Three things the wrapper must get right, all of them silent when got wrong
+
+**W1 (critical). `cell_tags()` must be bound with `nb::rv_policy::reference_internal`.**
+Verified at the nanobind source (`nb_cast.h:461-464`): for a method returning `T&`, both
+`automatic` and `automatic_reference` resolve to **`rv_policy::copy`**. With the default policy
+`g.cell_tags.set(...)` mutates a temporary and the write is silently lost. `reference_internal`
+also ties the returned object's lifetime to the grid, which is the second thing needed.
+`rv_policy` appears exactly **once** in the whole binding tree today
+(`cpp/bindings/geometry.cpp:84`), so this is unexercised ground and no existing binding models it.
+
+**W2 (important). The wrapper must memoise the `CellTags`, `FacetTags` and `BVH` wrappers, and
+identity is asserted.** `tests/test_grid_tags.py:152` is `assert ct is g.cell_tags  # cached` and
+`tests/test_grid_tensor_product.py:185` is `assert g.cell_bvh() is g.cell_bvh()`. #387 names the
+BVH case; it does not name the tags identity assertion. Memoising also removes a worse failure
+mode than identity: a property that *constructed* a fresh `CellTags(num_cells)` instead of
+wrapping the existing handle would hand back an empty registry, and every assertion about a
+tag set earlier would fail far from the cause.
+
+**W3 (important, and it lands on #387 rather than here).
+`tests/test_grid_tags.py:149-150` reads `g._cell_tags` and `g._facet_tags` directly**, asserting
+they are `None` before first use. That file is on **#387's** must-pass-*without-being-edited*
+list. A `__slots__`-based wrapper has no such attribute under those names unless the memo slots
+are deliberately named `_cell_tags`/`_facet_tags` **and** initialised to `None`, which is
+achievable and is the cheapest fix. #387 spotted the identical problem at
+`tests/test_grid_tensor_product.py:180` for `_bvh` and proposed a `bvh_is_built()` predicate;
+it did not spot these two. Either name the memo slots to match, or move
+`test_grid_tags.py` onto #387's editable list -- but the choice has to be made, because as
+written #387's must-pass set is not satisfiable.
+
+Since eager C++ tags mean the registry is never `None` on the C++ side, "has it been touched"
+becomes a different question there. Keeping the wrapper's memo slots `None` until first access
+preserves both the assertion and the laziness the Python contract advertises, at the cost of one
+extra branch per property read.
+
+### What `_GridPython` is for, and when it dies
+
+It is the **oracle**, and nothing else. Three consumers: `_TensorProductGridPython` (#387),
+`HierarchicalGrid` until #395, and `_PlainGrid` in `tests/test_grid_abc.py`. It is exactly
+today's `Grid` class body, renamed, with the module docstring's "abstract base class" prose
+moved to `Grid`.
+
+It needs `docs/conf.py`'s `nitpick_ignore` because `HierarchicalGrid` is public, documented with
+`:show-inheritance:` (`docs/api/reference.md:67-69`), `nitpicky = True` is set
+(`docs/conf.py:212`), and the docs build under `-W`. Add `("py:class", "_GridPython")` beside
+`("py:class", "_AffineMap")` at `docs/conf.py:234`, which is already there for exactly this
+reason. **Add `("py:class", "_GridWrapper")` at the same time** -- #387's `TensorProductGrid` will
+show it, and discovering that during #387's docs build costs a round trip.
+
+It dies when the last of the three is gone, which is #395 plus whatever retires the Python
+backend. **It is scaffolding and should be documented as scaffolding**, so that "keep parity with
+`_GridPython`" never becomes a reason not to improve the C++.
+
+## What #387 and #395 inherit from this
+
+**#387, `TensorProductGrid`.** Declares `Hook::locate_many | Hook::collect_cell_bounds |
+Hook::restrict` in its `grid_traits`; the census then rejects a fourth hook written by accident
+and a declared hook never written. Its `AC4` -- "compares each of the three specialised defaults
+against the generic one on the same input" -- is served directly by
+`g.pantr::grid::GridBase<G>::collect_cell_bounds()`, the qualified call that reaches the hidden
+default (verified compiling and running on all four compilers). **The derived class must not
+privately alias its base**, or the differential test cannot name it; that cost me a compile in
+the prototype. This is the exact C++ analogue of `Grid.boundary_facets(g)` at
+`test_grid_hierarchical.py:1721`, which is a pleasing symmetry and worth preserving on purpose.
+
+**#395, `HierarchicalGrid`.** Three inheritances, one of them a release:
+
+- Its five hooks (`locate_many`, `collect_cell_bounds`, `hanging_neighbors`, `boundary_facets`,
+  `cell_level`) go in the bitmask; nothing else changes.
+- The `invalidate_caches()` that #395 asks for is **probably unnecessary and should not be
+  built here.** #395 wants it because `_rebuild` writes the base's private slots today
+  (`src/pantr/grid/_hierarchical_grid.py:541-544`). But #378 makes refinement return a *new*
+  grid, and #378 blocks #393/#394, which block #395 -- so by the time #395 runs, there is
+  nothing to invalidate: the new grid has fresh empty caches and the old one's are still valid.
+  **The consequence is worth naming: with #378, a C++ grid is immutable after construction
+  except for the BVH memo, so construct-then-freeze finally holds for grids** -- it does not
+  today. Ship #386 without `invalidate_caches()`; let #395 add three lines if it turns out to
+  be needed. A protected mutator nothing calls is the kind of seam that becomes load-bearing by
+  accident.
+- Five private-slot reads in the must-pass `tests/test_grid_hierarchical.py`
+  (`:353`, `:359`, `:536`, `:549`, `:1090`) survive #386 unchanged, because `HierarchicalGrid`
+  stays on `_GridPython` here. **They break at #395**, and W3 above is the same problem one
+  ticket earlier. #395 should inherit W3's resolution rather than rediscover it.
+
+**A latent gap, unrelated to the port but surfaced by the census:** `HierarchicalGrid` does
+**not** override `child_cells`, so the one grid kind that has refinement children returns `()`
+from the method that reports them. That is a defect in today's Python, not something the port
+introduces; it should be a ticket, not a fix folded into #386.
+
+## Migration order
+
+1. `cpp/include/pantr/grid/grid.hpp` -- traits, `Hook`, the mixin, the concept,
+   `GridRestriction` + `make_restriction`, and the census macros. Nothing Python.
+2. `cpp/tests/test_grid_defaults.cpp` -- the synthetic zero-hook grid and the hand-computed
+   expectations, plus the lazy-cache build/reuse test (`AC3`).
+3. The negative translation units, **eight of them** (the ticket's six plus written-but-undeclared
+   and declared-but-unwritten), each asserted *rejected* by both dev compilers.
+4. Python: `Grid` becomes the Protocol with bodies; `_GridPython` is the renamed ABC;
+   `pantr/grid/__init__.py:16-20` prose updated; `docs/conf.py` gains two `nitpick_ignore`
+   entries.
+5. `tests/test_grid_abc.py`: `_PlainGrid` re-based on `_GridPython`; **one** test deleted;
+   `test_incomplete_subclass_is_abstract` re-pointed at `_GridPython` and kept.
+6. `tests/typing/` -- the mypy negative harness, restated per F4.
+
+Steps 1 to 3 touch no Python and can land before step 4. That matters because step 4 is the only
+part that can break a must-pass file.
+
+## Alternatives rejected
+
+**A virtual base with a sealed derivation set.** Simpler in every respect: one binding, a
+non-templated `GridRestriction`, a runtime grid type, generic algorithms as ordinary functions,
+and a Python subclass reachable through a trampoline. Rejected on the measurement: **15.1x** on
+the generic `boundary_facets` neighbour loop, **6.8x** on the whole method, and the loss is
+inlining rather than the indirect call, so it does not shrink with better branch prediction.
+`boundary_facets` is generic for `TensorProductGrid` and `O(num_cells * 2 * ndim)` by
+construction. **What would change this:** if a C++ consumer needs to hold a grid whose kind is
+decided at run time, or if `cell_quadrature`-style generic algorithms become numerous enough
+that header-only templates hurt more than the loop gains. Neither is true today.
+
+**`std::variant<TensorProductGrid<T>, HierarchicalGrid<T>>` plus free-function defaults.** The
+most literal reading of "closed hierarchy", and it keeps a runtime type. Rejected because it
+buys the runtime type at the price of editing the variant for every new grid *and* losing the
+`Derived`-typed `restrict` return, while the CRTP shape gives the same closure guarantee in one
+concept line. It stays available as a thin façade over the CRTP types if a runtime grid is ever
+needed; that is a strictly additive change.
+
+**A `PyGrid` trampoline so a Python subclass can be a C++ grid.** Buildable; rejected on the two
+grounds in the seam section. **What would change this:** a decision to keep Python as a
+permanent extension point, which contradicts the standing ruling that the backend becomes C++
+only.
+
+**Dispatching on the traits bitmask (the ticket's mechanism 4).** Rejected in favour of name
+hiding: bitmask dispatch silently ignores a hook that was written but not declared, and it forces
+distinct names for hook and default. See D-b.
+
+**`Grid` as a five-member Protocol (what an implementer supplies).** Rejected: every site
+annotating `Grid` loses the methods it uses -- `src/pantr/viz/_grid.py:54`,
+`src/pantr/grid/_cell_quadrature.py:31`, `src/pantr/grid/_partition_grid.py:34`, and
+`src/pantr/mpi/_create.py:87`, which is a real local annotation (`grid: Grid`) satisfied by a
+`HierarchicalGrid` on one branch and a `TensorProductGrid` on another. The first of those must
+not be edited. See F4.
+
+**`Grid` as `@runtime_checkable`.** Rejected: it checks names, not signatures, so it would answer
+`True` for objects that cannot serve as grids. Zero sites need it.
+
+## Bad practices flagged, for the user's inspection rather than for fixing here
+
+- **`CLAUDE.md`'s "Validation lives exclusively in Layer 2" no longer describes the code.** Once
+  a C++ program links pantr with no interpreter above it, validation *must* be in C++, and the
+  Python layer's job becomes coercion plus exception-type translation. Group D above is written
+  against the new reality; the prose should be updated once, rather than each port deciding
+  locally what the rule now means.
+- **`src/pantr/grid/_grid_backend.py`'s "no `float` overload" and #386's `float` census pull in
+  opposite directions.** Both are right; the reconciliation (instantiate, never bind) has to be
+  written down or the next ticket resolves it the other way. See F5.
+- **`HierarchicalGrid._rebuild` writing its base class's private slots**
+  (`_hierarchical_grid.py:541-544` against `_grid.py:71`) is already on the record as something
+  #395 must fix. Noted here only because #378 may delete the need for it entirely, which is a
+  better outcome than the protected accessor #395 currently plans.
+
+## Epistemic status
+
+- **Compiled and run, 2026-08-30, on g++ 14.4.0, clang++ 18.1.8, g++ 10.5.0 and clang++ 10.0.0,
+  all with `-std=c++20 -Wall -Wextra -Werror`:** the mixin with base-held state; traits-supplied
+  `scalar_type`; name-hiding dispatch, including the qualified call that reaches the hidden
+  default; the member-pointer-type detector; the two-assertion census; explicit instantiation at
+  `float` and `double`; `GridRestriction<G>` unconstrained with a constrained factory, named as a
+  return type inside the class being defined; the lazy `mutable std::optional` cache built from a
+  const grid; and a throwing default `restrict`. Eight negative translation units rejected by all
+  four.
+- **Measured, 2026-08-30, on this machine:** the `span<T>` to `span<const T>` conversion that
+  makes a callability-based concept accept an unwritable output span, and its repair; the
+  CRTP-versus-virtual ratios, with the first, devirtualized attempt recorded as wrong.
+- **Measured on CPython 3.14.6:** every Protocol claim in F1 to F4 -- unbound calls through a
+  Protocol default, the two instantiation messages, `_ProtocolMeta` deriving from `ABCMeta`, and
+  the `__slots__`/`__dict__` behaviour.
+- **Verified by reading the source:** nanobind's `rv_policy` resolution for an lvalue-reference
+  return (`nb_cast.h:461-464`) and its `std::out_of_range` to `IndexError` mapping
+  (`nb_internals.cpp:160-161`).
+- **Verified by reading the tree:** the override census for all four `Grid` subclasses; the
+  twenty-six grid `isinstance` sites, none on the base; every private-slot read in the must-pass
+  files.
+- **Asserted, not measured:** the cost of a `nb::object` callback in the rejected trampoline. The
+  argument does not depend on the figure -- any per-call cost above a few nanoseconds settles it
+  against 0.95 ns -- but the number itself is an estimate.
+- **Not investigated:** whether the not-yet-public downstream consumer imports any of
+  `_grid.py`'s private names. **`_grid.py` defines `_check_cid`, `_check_lfid` and
+  `_normalize_points`, and this design moves all three. Nothing in pantr's CI can see that
+  repository, so the check is owed before #386 lands.** `Grid` itself changing kind is the
+  larger exposure: a consumer subclassing `Grid` would have to move to `_GridPython`.
+
+## What was compiled, and how to reproduce it
+
+The prototype is **not committed**: it exists to settle the mechanisms, and its home is
+`cpp/include/pantr/grid/grid.hpp` plus `cpp/tests/` once #386 is built. What follows is enough
+to rebuild it from this note.
+
+**Eleven translation units**, each self-contained on pantr-free stand-ins for `BVH`, `CellTags`
+and `FacetTags`, so that the mechanism is isolated from pantr's own headers:
+
+| TU | asserts |
+|---|---|
+| `t_positive` | a zero-hook synthetic grid: every default runs and agrees with a hand-computed value; the BVH cache is unbuilt, then built, then the *same object*; a const grid reads tags but the non-const one mutates the same object; `facet_tags` is sized `2 * ndim`; `restrict` round-trips |
+| `t_hooked` | a two-hook grid: name hiding routes the call to the hook, and `g.GridBase<G>::boundary_facets()` still reaches the hidden default -- the differential oracle |
+| `t_restrict_default` | a grid with no `restrict`: compiles, throws at run time |
+| `n1` | a const grid calling `invalidate_caches()` -- **rejected** |
+| `n2` | a const grid calling `cell_tags().set(...)` -- **rejected** |
+| `n3` | a hook returning `vector<int32_t>` where the default returns `vector<int64_t>` -- **rejected** |
+| `n4` | a primitive whose output span is `span<const T>` -- **rejected**, but only after the concept was changed from callability to exact member-pointer type |
+| `n5` | a hook hard-coding `double`, at the `float` instantiation -- **rejected** |
+| `n6` | a grid derived from `GridBase` with no `grid_traits` specialisation -- **rejected at the grid's own definition** |
+| `n7` | a hook written but not declared in the traits -- **rejected** |
+| `n8` | a hook declared in the traits but not written -- **rejected** |
+
+Every one was run against all four compilers:
+
+```bash
+for cxx in g++ clang++ g++-10 clang++-10; do
+  $cxx -std=c++20 -Wall -Wextra -Werror -I. -fsyntax-only "$tu".cpp
+done
+```
+
+`n7` and `n8` are **not** in the ticket's `AC2` list and should be added: together they are what
+makes the traits bitmask trustworthy, since without them a declaration can disagree with the
+class in either direction.
+
+The CRTP-versus-virtual benchmark is two implementations of one `boundary_facets` loop over a
+`nx * ny * nz` box grid whose `neighbor_across_facet` is index arithmetic returning
+`std::optional<std::int64_t>`. The **only** subtlety, and the one that produced a wrong answer
+first time: the virtual grid must be reached through a `std::unique_ptr<VBase>` returned by a
+factory **compiled in a separate translation unit**, or GCC devirtualizes the call and the
+benchmark compares CRTP against CRTP. Both a count-only and a `push_back`ing variant were timed,
+with warm-up passes, on one pinned core.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -237,8 +237,13 @@ nitpick_ignore = [
     # oracle and it goes away with the last Python grid. `_GridWrapper` is its
     # successor as the wrappers' base and arrives with the TensorProductGrid port;
     # listing it here now costs one line and saves that build a round trip.
-    ("py:class", "_GridPython"),
-    ("py:class", "_GridWrapper"),
+    #
+    # FULLY QUALIFIED, unlike `_AffineMap` above: :show-inheritance: emits the base's
+    # `module.qualname`. Prose about a private class is written in double backticks
+    # rather than as a `:class:` role, so there is no bare-name form to ignore here --
+    # a role that can never resolve is a broken link rather than a suppressible one.
+    ("py:class", "pantr.grid._grid._GridPython"),
+    ("py:class", "pantr.grid._grid._GridWrapper"),
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,6 +232,13 @@ nitpick_ignore = [
     ("py:class", "Path"),
     # Private structural protocol; not in __all__ and not cross-referenceable
     ("py:class", "_AffineMap"),
+    # The Python grid base, shown by :show-inheritance: on HierarchicalGrid and
+    # TensorProductGrid. Private, and deliberately so: it is the port's parity
+    # oracle and it goes away with the last Python grid. `_GridWrapper` is its
+    # successor as the wrappers' base and arrives with the TensorProductGrid port;
+    # listing it here now costs one line and saves that build a round trip.
+    ("py:class", "_GridPython"),
+    ("py:class", "_GridWrapper"),
     ("py:class", "CellIndex"),
     ("py:class", "CellIndicesBatch"),
     ("py:class", "Target"),

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,13 @@ no_implicit_optional = True
 show_error_context = True
 mypy_path = src
 
+# The type-level case modules do not type-check by construction: a mypy error is their
+# expected result, and tests/test_grid_typing.py asserts which ones. Excluding them here
+# keeps `make mypy` green while leaving them reachable, because this setting suppresses
+# directory DISCOVERY only -- a file named on the command line is still checked, which is
+# how the harness reaches them, and it means both runs share one cache and one set of flags.
+exclude = (?x)(^tests/typing/cases/)
+
 [mypy-tests.*]
 disallow_untyped_defs = False
 disallow_untyped_decorators = False

--- a/src/pantr/grid/__init__.py
+++ b/src/pantr/grid/__init__.py
@@ -14,9 +14,11 @@ proportional to its breakpoints, not its cell count.
 
 Main exports:
 
-- :class:`Grid`: abstract base class defining the grid contract and supplying
-  axis-aligned box defaults for facets, neighbours, reference maps, batch point
-  location, and spatial queries.
+- :class:`Grid`: the grid contract, as a :class:`typing.Protocol` -- satisfied
+  structurally, and carrying axis-aligned box defaults for facets, neighbours,
+  reference maps, batch point location, and spatial queries. A consumer
+  annotates ``grid: Grid``; an implementer derives from the private
+  ``_GridPython``, which is where the five primitives are enforced.
 - :class:`GridRestriction`: result of :meth:`Grid.restrict` -- a windowed
   sub-grid plus local-to-global cell index maps.
 - :class:`TensorProductGrid`: concrete tensor-product grid of axis-aligned boxes

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -1,15 +1,41 @@
-"""Abstract base class for structured cell grids.
+"""The grid contract, and the Python implementation of it that is on its way out.
 
-A :class:`Grid` is a partition of a parametric domain into cells with *implicit*
+A grid is a partition of a parametric domain into cells with *implicit*
 (computed, not stored) connectivity. It is the shared grid abstraction for the
 PaNTr stack: background grids for immersed / unfitted discretizations, knot-span
-grids of B-spline spaces, and (later) hierarchical refinement grids all satisfy
-this contract.
+grids of B-spline spaces, and hierarchical refinement grids all satisfy this
+contract.
+
+Two names, and the split is the point
+-------------------------------------
+
+:class:`Grid` is a :class:`typing.Protocol`. It is what a *consumer* may rely on
+-- every public member, annotated as ``grid: Grid`` throughout the library -- and
+it is satisfied structurally, so a class becomes a grid by having the members
+rather than by inheriting. It carries real default implementations, so
+``Grid.boundary_facets(g)`` computes the generic answer for any ``g`` that
+satisfies it; that unbound call is how a specialization is tested against the
+default it replaces.
+
+:class:`_GridPython` is the abstract base class the concrete Python grids derive
+from. It adds the three cache slots and their ``__init__`` to :class:`Grid` and
+nothing else, so there is exactly one copy of every default. It is also where
+the *implementer's* contract lives: its ``__abstractmethods__`` are the five
+primitives below, and a subclass omitting one cannot be instantiated. The
+:class:`Grid` protocol cannot express that -- structural typing has no
+"inherited" half, so the protocol has to list every member a consumer may call,
+and omitting an inherited default fails the same way as omitting a primitive.
+
+**:class:`_GridPython` is scaffolding.** The grid layer is being ported to C++
+(``cpp/include/pantr/grid/grid.hpp``), where the generic defaults are a CRTP
+mixin and the primitives are a concept. Once the C++ grids are wrapped, this
+class exists only as the parity oracle, and "keep parity with ``_GridPython``"
+is never a reason not to improve the C++.
 
 Design
 ------
 
-The contract is deliberately small. A concrete grid must define only:
+A concrete grid must define only:
 
 - :attr:`Grid.ndim`, :attr:`Grid.num_cells` -- size metadata;
 - :meth:`Grid.cell_bounds` -- the axis-aligned ``(lo, hi)`` corners of a cell;
@@ -42,7 +68,7 @@ per-cell tag footprint. Deciding *what* to tag is the consumer's job.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Protocol
 
 import numpy as np
 
@@ -59,27 +85,42 @@ if TYPE_CHECKING:
     from ._bvh import BVH
 
 
-class Grid(abc.ABC):
-    """Abstract structured cell grid with implicit connectivity.
+class Grid(Protocol):
+    """Structural contract for a cell grid with implicit connectivity.
 
-    See the module docstring for the contract and the set of methods a subclass
-    must implement versus those provided as overridable defaults. The size
-    metadata is exposed through the :attr:`ndim` and :attr:`num_cells`
-    properties.
+    A :class:`typing.Protocol`: any object with these members is a grid, whether
+    or not it inherits anything. See the module docstring for the split between
+    this and :class:`_GridPython`, and for the five primitives a concrete grid
+    must supply.
+
+    The private members below are part of the structural contract, which is
+    unusual enough to say why: the defaults are real implementations, and three
+    of them memoize into named slots. Anything satisfying this protocol
+    therefore owes those three slots under those three names -- which is also
+    what the tag and BVH identity assertions in the test suite read directly.
+
+    Those three writes carry a ``# type: ignore[misc]``. This class declares
+    ``__slots__ = ()`` and never the memo slots themselves, because the storage
+    belongs to whoever implements the protocol; mypy checks ``__slots__``
+    against the class a write appears in rather than against the implementer's.
+
+    Attributes:
+        _bvh (BVH | None): Memoized spatial index; ``None`` until first built.
+        _cell_tags (CellTags | None): Memoized cell-tag registry; ``None`` until
+            first use.
+        _facet_tags (FacetTags | None): Memoized facet-tag registry; ``None``
+            until first use.
     """
 
-    __slots__ = ("_bvh", "_cell_tags", "_facet_tags")
+    # `Generic` does not declare `__slots__`, so a Protocol that omits this one
+    # line gives every explicit subclass a `__dict__` even where that subclass
+    # declares `__slots__` itself. Nothing in the suite would catch it: the cost
+    # is per-instance memory plus the quiet return of settable attributes.
+    __slots__ = ()
 
-    def __init__(self) -> None:
-        """Initialize the lazy spatial-index and tag-registry slots.
-
-        Subclasses must call ``super().__init__()`` before use so the lazy
-        :attr:`cell_tags`, :attr:`facet_tags`, and :meth:`query_aabb` caches are
-        available.
-        """
-        self._bvh: BVH | None = None
-        self._cell_tags: CellTags | None = None
-        self._facet_tags: FacetTags | None = None
+    _bvh: BVH | None
+    _cell_tags: CellTags | None
+    _facet_tags: FacetTags | None
 
     # ------------------------------------------------------------------
     # Abstract contract
@@ -297,7 +338,13 @@ class Grid(abc.ABC):
             TypeError: If ``cell_ids`` is not integer-valued (in overriding
                 implementations).
         """
-        raise NotImplementedError(f"{type(self).__name__} does not support restrict().")
+        # Two statements rather than a bare `raise`, and the reason is not style.
+        # mypy treats a protocol member whose body is a lone `raise
+        # NotImplementedError` as *abstract*, which would make `restrict` a
+        # required primitive for every explicit subclass -- the opposite of the
+        # documented contract that restriction is optional.
+        message = f"{type(self).__name__} does not support restrict()."
+        raise NotImplementedError(message)
 
     # ------------------------------------------------------------------
     # Facet accessors (axis-aligned box defaults)
@@ -512,7 +559,7 @@ class Grid(abc.ABC):
 
         if self._bvh is None:
             cell_lo, cell_hi = self.collect_cell_bounds()
-            self._bvh = BVH.from_cell_bounds(cell_lo, cell_hi)
+            self._bvh = BVH.from_cell_bounds(cell_lo, cell_hi)  # type: ignore[misc]
         return self._bvh
 
     def collect_cell_bounds(
@@ -550,7 +597,7 @@ class Grid(abc.ABC):
             empty until first use.
         """
         if self._cell_tags is None:
-            self._cell_tags = CellTags(self.num_cells)
+            self._cell_tags = CellTags(self.num_cells)  # type: ignore[misc]
         return self._cell_tags
 
     @property
@@ -563,7 +610,7 @@ class Grid(abc.ABC):
             per cell (an axis-aligned box grid).
         """
         if self._facet_tags is None:
-            self._facet_tags = FacetTags(self.num_cells, 2 * self.ndim)
+            self._facet_tags = FacetTags(self.num_cells, 2 * self.ndim)  # type: ignore[misc]
         return self._facet_tags
 
     # ------------------------------------------------------------------
@@ -622,6 +669,42 @@ class Grid(abc.ABC):
                 f"got shape {arr.shape}."
             )
         return np.ascontiguousarray(arr)
+
+
+class _GridPython(Grid, abc.ABC):
+    """The Python implementation of :class:`Grid`, and the port's parity oracle.
+
+    Adds the three cache slots and their initializer to :class:`Grid` and
+    nothing else, so every default has exactly one body and a specialization
+    tested against ``Grid.<name>(g)`` is tested against the code that actually
+    runs.
+
+    This is where the *implementer's* contract is enforced:
+    ``_GridPython.__abstractmethods__`` is the five primitives, so a subclass
+    that omits one cannot be instantiated. :class:`Grid` cannot express that,
+    because a protocol has no inherited half -- see the module docstring.
+
+    Scaffolding: the grid layer's generic operations are moving to C++, and this
+    class survives only as the oracle they are compared against.
+
+    Attributes:
+        _bvh (BVH | None): Lazily built spatial index.
+        _cell_tags (CellTags | None): Lazily created cell-tag registry.
+        _facet_tags (FacetTags | None): Lazily created facet-tag registry.
+    """
+
+    __slots__ = ("_bvh", "_cell_tags", "_facet_tags")
+
+    def __init__(self) -> None:
+        """Initialize the lazy spatial-index and tag-registry slots.
+
+        Subclasses must call ``super().__init__()`` before use so the lazy
+        :attr:`cell_tags`, :attr:`facet_tags`, and :meth:`query_aabb` caches are
+        available.
+        """
+        self._bvh: BVH | None = None
+        self._cell_tags: CellTags | None = None
+        self._facet_tags: FacetTags | None = None
 
 
 class GridRestriction(NamedTuple):

--- a/src/pantr/grid/_grid.py
+++ b/src/pantr/grid/_grid.py
@@ -17,7 +17,7 @@ rather than by inheriting. It carries real default implementations, so
 satisfies it; that unbound call is how a specialization is tested against the
 default it replaces.
 
-:class:`_GridPython` is the abstract base class the concrete Python grids derive
+``_GridPython`` is the abstract base class the concrete Python grids derive
 from. It adds the three cache slots and their ``__init__`` to :class:`Grid` and
 nothing else, so there is exactly one copy of every default. It is also where
 the *implementer's* contract lives: its ``__abstractmethods__`` are the five
@@ -26,7 +26,7 @@ primitives below, and a subclass omitting one cannot be instantiated. The
 "inherited" half, so the protocol has to list every member a consumer may call,
 and omitting an inherited default fails the same way as omitting a primitive.
 
-**:class:`_GridPython` is scaffolding.** The grid layer is being ported to C++
+**``_GridPython`` is scaffolding.** The grid layer is being ported to C++
 (``cpp/include/pantr/grid/grid.hpp``), where the generic defaults are a CRTP
 mixin and the primitives are a concept. Once the C++ grids are wrapped, this
 class exists only as the parity oracle, and "keep parity with ``_GridPython``"
@@ -90,7 +90,7 @@ class Grid(Protocol):
 
     A :class:`typing.Protocol`: any object with these members is a grid, whether
     or not it inherits anything. See the module docstring for the split between
-    this and :class:`_GridPython`, and for the five primitives a concrete grid
+    this and ``_GridPython``, and for the five primitives a concrete grid
     must supply.
 
     The private members below are part of the structural contract, which is

--- a/src/pantr/grid/_hierarchical_grid.py
+++ b/src/pantr/grid/_hierarchical_grid.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Self
 import numpy as np
 
 from .._numba_compat import wait_for_jit_warmup
-from ._grid import Grid, GridRestriction
+from ._grid import GridRestriction, _GridPython
 from ._grid_backend import (
     decode_flat_id_kernel,
     encode_midx_kernel,
@@ -309,7 +309,7 @@ def _name_marked_cells(mask: npt.NDArray[np.bool_], origin: tuple[int, ...]) -> 
 # ---------------------------------------------------------------------------
 
 
-class HierarchicalGrid(Grid):
+class HierarchicalGrid(_GridPython):
     """Hierarchical grid with a fixed per-direction uniform subdivision factor.
 
     Built on a root :class:`TensorProductGrid`.  Active cells are stored as
@@ -439,7 +439,7 @@ class HierarchicalGrid(Grid):
             levels).
         """
         self = cls.__new__(cls)
-        Grid.__init__(self)
+        _GridPython.__init__(self)
         self._root = root
         self._factor = factor
         normalized = [_normalize_blocks(list(level_blocks)) for level_blocks in blocks]

--- a/src/pantr/grid/_tensor_product_grid.py
+++ b/src/pantr/grid/_tensor_product_grid.py
@@ -37,7 +37,7 @@ import numpy as np
 
 from .._numba_compat import wait_for_jit_warmup
 from ._cell_index import c_order_strides, flat_to_multi, multi_to_flat
-from ._grid import Grid, GridRestriction
+from ._grid import GridRestriction, _GridPython
 from ._grid_backend import locate_points_kernel
 from ._grid_utils import _as_float64, _mask_nonfinite_locate
 
@@ -56,7 +56,7 @@ _UNIFORM_SPACING_ATOL: Final[float] = 1e-10
 _MIN_BREAKPOINTS_PER_AXIS: Final[int] = 2
 
 
-class TensorProductGrid(Grid):
+class TensorProductGrid(_GridPython):
     """Tensor-product grid of axis-aligned boxes with per-axis breakpoints.
 
     Cells are numbered in row-major (C) order over :attr:`cells_per_axis` (last

--- a/tests/test_grid_abc.py
+++ b/tests/test_grid_abc.py
@@ -1,11 +1,16 @@
-"""Tests for the ``pantr.grid.Grid`` abstract base class and its defaults.
+"""Tests for the ``pantr.grid.Grid`` contract and the defaults behind it.
 
-The generic, box-geometry defaults on :class:`Grid` are validated by wrapping a
+The generic, box-geometry defaults are validated by wrapping a
 :class:`TensorProductGrid` in a minimal subclass (:class:`_PlainGrid`) that
-forwards only the five abstract methods and inherits every default. Comparing
-the wrapper's default outputs against the tensor-product grid's specialized
+forwards only the five primitives and inherits every default. Comparing the
+wrapper's default outputs against the tensor-product grid's specialized
 overrides (notably ``locate_many`` and the lazy BVH built from
 ``collect_cell_bounds``) checks the defaults for correctness.
+
+:class:`_PlainGrid` derives from ``_GridPython`` rather than from
+:class:`Grid`, because that is where the primitives are enforced: ``Grid`` is a
+:class:`typing.Protocol` listing every public member, so omitting a primitive
+and omitting an inherited default fail it identically.
 """
 
 from __future__ import annotations
@@ -17,17 +22,18 @@ import pytest
 
 from pantr.geometry import AABB
 from pantr.grid import Grid, TensorProductGrid, uniform_grid
+from pantr.grid._grid import _GridPython
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
 
-class _PlainGrid(Grid):
-    """Minimal Grid: forwards the abstract contract to a wrapped tensor grid.
+class _PlainGrid(_GridPython):
+    """Minimal grid: forwards the five primitives to a wrapped tensor grid.
 
-    Every non-abstract method is left as the :class:`Grid` default, so this
-    class exercises the base-class implementations rather than the
-    tensor-product specializations.
+    Every other method is left as the inherited default, so this class
+    exercises the generic implementations rather than the tensor-product
+    specializations.
     """
 
     __slots__ = ("_inner",)
@@ -55,15 +61,28 @@ class _PlainGrid(Grid):
 
 
 def test_grid_is_abstract() -> None:
-    """Grid cannot be instantiated directly."""
+    """The Grid protocol cannot be instantiated directly.
+
+    It survives the move to a Protocol only because the five primitives keep
+    their ``@abc.abstractmethod`` decorators: ``object.__new__`` refuses an
+    abstract class before ``Protocol.__init__`` gets to raise its own, less
+    specific ``Protocols cannot be instantiated``. Drop those decorators and
+    this is what tells you.
+    """
     with pytest.raises(TypeError, match="abstract"):
-        Grid()  # type: ignore[abstract]
+        Grid()  # type: ignore[misc]
 
 
 def test_incomplete_subclass_is_abstract() -> None:
-    """A subclass missing an abstract method cannot be instantiated."""
+    """A subclass missing a primitive cannot be instantiated.
 
-    class _Incomplete(Grid):
+    Pointed at ``_GridPython``, which is where the implementer's contract lives.
+    ``Grid`` would answer here too -- ``typing._ProtocolMeta`` derives from
+    ``abc.ABCMeta`` -- but it would answer the same way for a class omitting any
+    of the nineteen defaults, which is not what this asserts.
+    """
+
+    class _Incomplete(_GridPython):
         @property
         def ndim(self) -> int:
             return 1
@@ -74,6 +93,60 @@ def test_incomplete_subclass_is_abstract() -> None:
 
     with pytest.raises(TypeError, match="abstract"):
         _Incomplete()  # type: ignore[abstract]
+
+
+def test_grid_python_enforces_exactly_the_five_primitives() -> None:
+    """The implementer's contract is five members, and it is enforced here.
+
+    The ``Grid`` protocol lists all twenty-four public members, because
+    structural typing has no inherited half; this is the only place the smaller
+    claim is checked on the Python side. Its C++ counterpart is the ``GridLike``
+    concept in ``cpp/include/pantr/grid/grid.hpp``.
+    """
+    assert set(_GridPython.__abstractmethods__) == {
+        "ndim",
+        "num_cells",
+        "cell_bounds",
+        "locate",
+        "neighbor_across_facet",
+    }
+
+
+def test_grid_protocol_is_not_runtime_checkable() -> None:
+    """An isinstance check against Grid raises rather than answering.
+
+    Deliberate: a ``runtime_checkable`` protocol checks that the *names* exist
+    and never the signatures, so it would answer ``True`` for an object that
+    cannot serve as a grid. No site needs it; every grid ``isinstance`` in the
+    tree tests a concrete type.
+    """
+    with pytest.raises(TypeError, match="runtime_checkable"):
+        isinstance(uniform_grid([[0.0, 1.0]], 1), Grid)  # type: ignore[misc]
+
+
+def test_concrete_grids_carry_no_instance_dict() -> None:
+    """The protocol's ``__slots__ = ()`` keeps the slot discipline intact.
+
+    ``Grid`` is now in every concrete grid's MRO, and ``Generic`` declares no
+    ``__slots__``: omitting the one line on the protocol would give every grid a
+    ``__dict__`` back, silently. Nothing else in the suite would notice.
+    """
+    for grid in (uniform_grid([[0.0, 2.0]], 2), _PlainGrid(uniform_grid([[0.0, 2.0]], 2))):
+        assert not hasattr(grid, "__dict__")
+
+
+def test_unbound_default_runs_against_a_specialized_grid() -> None:
+    """``Grid.<name>(g)`` reaches the generic default, not the override.
+
+    This is the differential oracle: it is how a specialization is compared
+    against the default it replaces, and it is what would break if the protocol
+    carried ``...`` bodies instead of real ones. ``TensorProductGrid``
+    specializes ``locate_many``; the generic version loops over ``locate``.
+    """
+    tpg = uniform_grid([[0.0, 4.0], [0.0, 3.0]], [4, 3])
+    rng = np.random.default_rng(11)
+    pts = rng.uniform(-1.0, 5.0, size=(30, 2))
+    np.testing.assert_array_equal(Grid.locate_many(tpg, pts), tpg.locate_many(pts))
 
 
 def test_default_locate_many_matches_kernel() -> None:

--- a/tests/test_grid_typing.py
+++ b/tests/test_grid_typing.py
@@ -1,0 +1,88 @@
+"""Run mypy over ``tests/typing/cases`` and check it reports exactly the marked errors.
+
+``Grid`` is a :class:`typing.Protocol`, so satisfying it is a static property: no
+``isinstance`` answers it, and nothing in the rest of the suite can observe a class
+failing to. This module is the harness that can.
+
+See ``tests/typing/README.md`` for the marker convention and for why the case modules
+are excluded from the repo-wide mypy run.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CASES = _REPO_ROOT / "tests" / "typing" / "cases"
+
+_MARKER = re.compile(r"#\s*expect-error:\s*([\w-]+)\s*$")
+_ERROR = re.compile(r"^(?P<path>.+?):(?P<line>\d+): error: .*\[(?P<code>[\w-]+)\]\s*$")
+
+
+def _expected(path: Path) -> set[tuple[str, int, str]]:
+    """Collect the ``# expect-error:`` markers in one case module.
+
+    Args:
+        path (Path): The case module.
+
+    Returns:
+        set[tuple[str, int, str]]: ``(file name, 1-based line, mypy error code)``.
+    """
+    out: set[tuple[str, int, str]] = set()
+    for lineno, text in enumerate(path.read_text().splitlines(), start=1):
+        match = _MARKER.search(text)
+        if match is not None:
+            out.add((path.name, lineno, match.group(1)))
+    return out
+
+
+def _reported(paths: list[Path]) -> set[tuple[str, int, str]]:
+    """Run mypy over the case modules and parse the errors it reports.
+
+    ``MYPYPATH`` is set explicitly because ``pytest.ini``'s ``pythonpath = src`` reaches
+    the pytest process only: a subprocess would otherwise resolve the *installed*
+    ``pantr`` rather than this worktree's.
+
+    Args:
+        paths (list[Path]): The case modules to check.
+
+    Returns:
+        set[tuple[str, int, str]]: ``(file name, 1-based line, mypy error code)``.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", "--config-file", "mypy.ini", *[str(p) for p in paths]],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        env={**os.environ, "MYPYPATH": str(_REPO_ROOT / "src")},
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        pytest.fail(
+            f"mypy failed to run (exit {result.returncode}):\n{result.stdout}{result.stderr}"
+        )
+    out: set[tuple[str, int, str]] = set()
+    for text in result.stdout.splitlines():
+        match = _ERROR.match(text)
+        if match is not None:
+            out.add((Path(match.group("path")).name, int(match.group("line")), match.group("code")))
+    return out
+
+
+def test_type_level_cases_report_exactly_the_marked_errors() -> None:
+    """What mypy reports and the ``# expect-error:`` markers agree, both ways.
+
+    Set equality rather than containment, so this fails when an expected error stops
+    being reported *and* when an unexpected one appears. The marker names the error
+    code, which is what stops a case from passing on the wrong error.
+    """
+    pytest.importorskip("mypy", reason="mypy is in the dev extra; the check suite runs it too")
+    cases = sorted(_CASES.glob("*.py"))
+    assert cases, "no type-level case modules found"
+    assert _reported(cases) == set().union(*(_expected(p) for p in cases))

--- a/tests/typing/README.md
+++ b/tests/typing/README.md
@@ -1,0 +1,26 @@
+# Type-level tests
+
+Modules here are checked by **mypy**, not by running them, and they are the only
+place a type error is an *expected result*. `tests/test_grid_typing.py` runs mypy over
+`cases/` and compares the errors it reports against the lines marked
+
+```python
+some_expression  # expect-error: arg-type
+```
+
+The comparison is a set equality, so an expected error that stops being reported and an
+unexpected one that starts both fail. The marker names the mypy **error code**, which is
+what stops a case from passing on the wrong error.
+
+`mypy.ini` excludes this directory from the repo-wide run. It has to: these modules do
+not type-check by construction, and `make mypy` would go red on them. The exclusion only
+suppresses directory *discovery* -- mypy still checks a file named explicitly on the
+command line, which is how the harness reaches them, and it means both runs share one
+cache and one set of flags.
+
+## Why this exists
+
+`Grid` is a `typing.Protocol`, and a protocol is enforced by a type checker rather than
+at run time: no `isinstance` answers it, and nothing in the ordinary suite can observe a
+class failing to satisfy it. Ticket #386 asked for a type-level test for that reason,
+and there was no harness in the repo; this is the smallest one that works.

--- a/tests/typing/cases/grid_contract.py
+++ b/tests/typing/cases/grid_contract.py
@@ -1,0 +1,188 @@
+"""What the ``Grid`` protocol accepts and refuses, checked by mypy rather than by running.
+
+Three claims, and the pair in the middle is the one that carries the argument.
+
+``_AlmostGrid`` and ``_Duck`` differ by exactly one member -- ``hanging_neighbors`` --
+and neither inherits anything from ``pantr.grid``. So the protocol is satisfiable
+structurally, which is the whole premise of the port's seam, and a class that misses one
+member is refused where a ``Grid`` is expected. Without the accepted half the refused
+half would prove nothing: a harness that rejects everything rejects the bad case too.
+
+The member they differ by is deliberately a **default**, not a primitive. Ticket #386's
+``AC6`` asked for "a class that omits one of the six primitives", and that test cannot be
+written: a protocol has no inherited half, so ``Grid`` must list every public member a
+consumer may call, and omitting ``hanging_neighbors`` fails exactly as omitting
+``cell_bounds`` would. The smaller claim -- that an *implementer* owes five members and
+inherits the rest -- is enforced elsewhere, and the third case below is where: on
+``_GridPython.__abstractmethods__``. Its C++ counterpart is the ``GridLike`` concept in
+``cpp/include/pantr/grid/grid.hpp``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pantr.grid import Grid
+from pantr.grid._grid import _GridPython
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import numpy.typing as npt
+
+    from pantr.geometry import AABB
+    from pantr.grid import BVH, CellTags, FacetTags, GridRestriction
+    from pantr.transform import AffineTransform
+
+
+def take_grid(grid: Grid) -> int:
+    """Stand in for every ``grid: Grid`` annotation in the library.
+
+    Args:
+        grid (Grid): Any object satisfying the protocol.
+
+    Returns:
+        int: The grid's cell count.
+    """
+    return grid.num_cells
+
+
+class _AlmostGrid:
+    """Everything the protocol asks for except ``hanging_neighbors``.
+
+    Inherits nothing from ``pantr.grid``: this is the shape a wrapper over a C++ handle
+    will have, so the file also pins that such a wrapper can satisfy ``Grid`` at all.
+    Every body raises; mypy checks signatures, and nothing here is ever run.
+    """
+
+    __slots__ = ("_bvh", "_cell_tags", "_facet_tags")
+
+    _bvh: BVH | None
+    _cell_tags: CellTags | None
+    _facet_tags: FacetTags | None
+
+    @property
+    def ndim(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def num_cells(self) -> int:
+        raise NotImplementedError
+
+    def cell_bounds(self, cid: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        raise NotImplementedError
+
+    def locate(self, pt: npt.ArrayLike) -> int | None:
+        raise NotImplementedError
+
+    def neighbor_across_facet(self, cid: int, lfid: int) -> int | None:
+        raise NotImplementedError
+
+    def iter_cells(self) -> Iterator[int]:
+        raise NotImplementedError
+
+    def cell_aabb(self, cid: int) -> AABB:
+        raise NotImplementedError
+
+    def cell_level(self, cid: int) -> int:
+        raise NotImplementedError
+
+    def child_cells(self, cid: int) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def reference_map(self, cid: int) -> AffineTransform:
+        raise NotImplementedError
+
+    def neighbors(self, cid: int) -> list[int]:
+        raise NotImplementedError
+
+    def restrict(self, cell_ids: npt.ArrayLike) -> GridRestriction:
+        raise NotImplementedError
+
+    def num_local_facets(self, cid: int) -> int:
+        raise NotImplementedError
+
+    def local_facet_axis_side(self, cid: int, lfid: int) -> tuple[int, int]:
+        raise NotImplementedError
+
+    def local_facet_bounds(
+        self, cid: int, lfid: int
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        raise NotImplementedError
+
+    def is_mesh_boundary_facet(self, cid: int, lfid: int) -> bool:
+        raise NotImplementedError
+
+    def boundary_facets(self) -> npt.NDArray[np.int64]:
+        raise NotImplementedError
+
+    def locate_many(self, points: npt.ArrayLike) -> npt.NDArray[np.int64]:
+        raise NotImplementedError
+
+    def query_aabb(self, aabb: AABB) -> npt.NDArray[np.int64]:
+        raise NotImplementedError
+
+    def cell_bvh(self) -> BVH:
+        raise NotImplementedError
+
+    def collect_cell_bounds(self) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        raise NotImplementedError
+
+    @property
+    def cell_tags(self) -> CellTags:
+        raise NotImplementedError
+
+    @property
+    def facet_tags(self) -> FacetTags:
+        raise NotImplementedError
+
+    def _check_cid(self, cid: int) -> None:
+        raise NotImplementedError
+
+    def _check_lfid(self, cid: int, lfid: int) -> None:
+        raise NotImplementedError
+
+    def _normalize_points(self, points: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        raise NotImplementedError
+
+
+class _Duck(_AlmostGrid):
+    """``_AlmostGrid`` plus the one member it lacks, and so a ``Grid``."""
+
+    __slots__ = ()
+
+    def hanging_neighbors(self, cid: int, lfid: int) -> tuple[int, ...]:
+        raise NotImplementedError
+
+
+class _IncompleteSubclass(_GridPython):
+    """An implementer that supplies four of the five primitives."""
+
+    __slots__ = ()
+
+    @property
+    def ndim(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def num_cells(self) -> int:
+        raise NotImplementedError
+
+    def cell_bounds(self, cid: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+        raise NotImplementedError
+
+    def locate(self, pt: npt.ArrayLike) -> int | None:
+        raise NotImplementedError
+
+
+# Satisfying the protocol without inheriting from it: accepted.
+take_grid(_Duck())
+
+# One public member short: refused, and the member is a default rather than a primitive.
+take_grid(_AlmostGrid())  # expect-error: arg-type
+
+# One primitive short: refused at construction, which is the claim `AC6` wanted and the
+# protocol cannot make.
+_IncompleteSubclass()  # expect-error: abstract


### PR DESCRIPTION
Moves the generic `Grid` operations into C++ as a CRTP mixin with no vtable, and splits the
Python `Grid` contract from the class that implements it. Closes #386 (the base is not `main`,
so that keyword will not fire; the issue is closed by hand).

The design is recorded in `design/grid_hierarchy_port.md`, committed as the first commit of this
branch. Where the ticket and that document disagreed, the document won; the four places this
changed the outcome are listed under *Amendments* below.

## Evidence per acceptance criterion

- **AC1** — `ctest` 37/37 on g++ 14.4, clang++ 18.1.8 and the clang++ 10.0 floor, under the
  project's own flags (a superset of the criterion's: `-Wall -Wextra -Wpedantic -Wshadow
  -Wconversion -Wsign-conversion -Wdouble-promotion -Werror`). g++ 10.5 cannot build the tree at
  all for the pre-existing reason in #376 (`cpp/include/pantr/geometry/aabb.hpp` calls the
  floating-point `std::to_chars`, absent from libstdc++ 10); that is the only error it emits, and
  every grid mechanism was compiled there with `-fsyntax-only`.
- **AC2** — widened from 6 negative translation units to 11, all rejected by all four compilers,
  each matching its own registered diagnostic pattern checked per compiler rather than per build.
  Two of the original six were re-pointed (see *Amendments*), five are additions: a specialised
  `num_local_facets`, both directions of a hook disagreeing with its bitmask, and the
  const-span/return-type trap on the two primitives the ticket did not name.
- **AC3** — `test_lazy_bvh_cache` asserts zero primitive calls before first use, exactly
  `num_cells` on build, pointer identity on reuse, and no rebuild through `query_aabb`. Its
  fourth clause is dropped with cause: see *Amendments*.
- **AC4** — `pytest -q` 7677 passed / 41 skipped / 7 xfailed; under `PANTR_BACKEND=cpp`
  7674 / 44 / 7. No must-not-edit file was touched. Extension-skip check performed: with the
  built extension moved aside, 1375 parity tests **skip** rather than pass, so the parity suite
  is not comparing the oracle against itself.
- **AC5** — **refuted as worded, and shown not to belong to this change.** Clean builds on both
  sides (`rm -rf docs/_build` each time, because a warm Sphinx cache hides warnings from
  unchanged files): 33 warnings and exit 2 at the branch point, the same 33 and exit 2 at this
  branch's head, the two lists byte-identical after path normalisation, with zero
  `_GridPython` / `_GridWrapper` hits in either. The docs gate was already red before this work.
  Root cause of the rot: `scripts/ci_local.sh` has no docs section, so nothing on this base branch
  runs the docs build.
- **AC6** — **verified, restated.** See below.
- **AC7** — `BoxGrid<T>` and `RawGrid` declare `Hook::none`, censused at `float` and `double`;
  every default checked against a literal with its hand-derivation, re-derived independently and
  matched.
- **AC8** — 16 single-point mutations, **16 caught, 0 survived**: 11 in `grid.hpp` and 5 across
  `_grid.py` and the typing case. Inverted `is_mesh_boundary_facet`; `2*ndim` to `ndim`; swapped
  axis and side; the cache rebuilt on every call; an off-by-one in the cell-id check;
  `reference_map` scaling by `hi`; a no-op span check; `hanging_neighbors` always empty;
  `boundary_facets` dropping the facet; the `locate_many` sentinel set to 0; the local-facet
  check disabled; the Protocol losing `__slots__ = ()`; `cell_level` returning 1; `restrict` not
  raising; `hanging_neighbors` leaving the Protocol; and the typing case ceasing to omit a member.

### AC6, restated with its argument

The criterion asks for a type-level test that *a class omitting one of the six primitives* is
rejected. That test cannot be written, and writing something that looks like it would assert
nothing.

A `typing.Protocol` has no inherited half. Consumers annotate `grid: Grid`
(`src/pantr/viz/_grid.py:54`, `src/pantr/viz/_cell_quadrature.py:31`,
`src/pantr/viz/_partition_grid.py:34`, `src/pantr/mpi/_create.py:87`), so `Grid` must list all 24
public members, and omitting `hanging_neighbors` (a default) then fails **identically** to
omitting `cell_bounds` (a primitive). This was not taken on trust: two generated classes, one
omitting a default and one omitting a primitive, produce the same `[arg-type]` error.

The restatement: *a class that does not satisfy the `Grid` protocol is rejected where a `Grid` is
expected.* It is asserted by a minimal pair, `_AlmostGrid` and `_Duck`, differing by exactly one
member and neither inheriting anything from `pantr.grid`. The accepted half is what keeps the
rejected half from being vacuous, and it independently pins that the Protocol is satisfiable
structurally, which is the premise the whole seam rests on.

The narrower five-primitive claim is kept where it is genuinely enforced: `_GridPython`'s
`__abstractmethods__`, asserted directly, and the C++ `GridLike` concept.

The harness is `tests/typing/cases/*.py`, each marked `# expect-error: <code>`, compared by set
equality so that a vanished error and an unexpected one both fail. Proven non-vacuous four ways:
remove the defect gives red, remove the marker gives red, name the wrong error code gives red,
restore gives green.

## Amendments to the ticket, each with its reason

1. **Zero test deletions, not one.** The design predicted `test_grid_is_abstract` would have to
   go. It survives: the primitives keep `@abc.abstractmethod`, and `object.__new__` refuses an
   abstract class before `Protocol.__init__` can raise its own message, so `Grid()` still reports
   `abstract`. `test_incomplete_subclass_is_abstract` is re-pointed at `_GridPython`.
2. **`_GridPython` inherits the Protocol**, where the design said it must not. The stated risk was
   a leaked `__dict__`, and `__slots__ = ()` closes it (verified: no instance `__dict__`).
   Inheriting buys that `Grid.boundary_facets` and the method a grid actually runs are the same
   function object, so the differential oracle at `tests/test_grid_hierarchical.py:1721` cannot
   drift from its subject. The alternative was two copies of roughly 450 lines.
3. **No `invalidate_caches()` ships**, so AC3's "rebuilds after invalidation" is unassertable and
   AC2's corresponding negative case was re-pointed to "nothing hands out the cache slot". #378
   makes refinement return a new grid, so there is nothing left to invalidate.
4. **Two hazards the design did not foresee.** mypy treats a Protocol member whose body is a lone
   `raise NotImplementedError` as abstract, which would have made `restrict` a required primitive
   for every grid, the opposite of its documented contract as an optional capability; its body is
   now two statements. And the Protocol structurally demands six private members (`_check_cid`,
   `_check_lfid`, `_normalize_points`, `_bvh`, `_cell_tags`, `_facet_tags`), because mypy counts
   every member declared in a Protocol body. That is a real constraint on #387's wrapper.

## Self-review round

Six reviewing agents; fixes in two commits. One Critical and six Important, all closed.

The Critical: a negative test matched `'this' argument` with ASCII apostrophes, but GCC renders
that diagnostic with U+2018/U+2019 in a UTF-8 locale and the two GCC builds here disagree, so the
test was failing on the floor compiler for a reason unrelated to what it asserts. Confirmed at
byte level before fixing. The pattern is now quote-free and the rule is written down where the
tests are registered.

The Important ones worth naming: three out-parameter shape checks used `PANTR_PRECONDITION`,
which is `assert` and vanishes under `NDEBUG`, so a release build wrote out of bounds instead of
reporting; they now raise `std::invalid_argument` and are tested in release. The returned
references from `cell_tags()`, `facet_tags()` and `cell_bvh()` did not state their lifetime or the
`rv_policy::reference_internal` a binding owes, which is silent data loss if a binder gets it
wrong. And a helper compared a row count against itself, claiming a check it could not make.

## Scaffolding introduced

`_GridPython`, documented in its own docstring as scaffolding that dies with #395, and the
`pantr.grid._grid._GridWrapper` entry in `docs/conf.py`, which deliberately names a class that
does not exist until #387. `tests/typing/` is not scaffolding: it is the permanent home for
type-level tests.

## Handed up, not fixed here

- A message-parity difference for #387: Python renders a numpy cell id as
  `cell id np.int64(5) is out of range [0, 2).` where C++ renders `cell id 5 ...`. Reproduce with
  `g.cell_level(np.int64(5))` against `g.cell_level(5)`. Changing it would change an existing
  public message.
- The C++ `restrict` throws `std::logic_error`, which nanobind maps to `RuntimeError`, but the
  Python contract is `NotImplementedError`. The binding owes that translation; noted in the header.
- `HierarchicalGrid` does not override `child_cells`, so the one grid kind that has refinement
  children returns `()` from the method that reports them. Pre-existing, unrelated to this port.
- The docs gate is red at 33 pre-existing warnings, and `scripts/ci_local.sh` has no docs section,
  which is why nobody noticed.
