### PR TITLE
fix(bezier): call abs and sqrt unqualified in the degree module

### DIFF
--- a/cpp/include/pantr/bezier/degree.hpp
+++ b/cpp/include/pantr/bezier/degree.hpp
@@ -315,11 +315,13 @@ template <Real T>
         front.swap(back);
     }
 
+    using std::abs;
+
     double total_sum = 0.0;
     for (std::size_t i = 0; i < total; ++i) {
         total_sum += coefficients[i] * front[i];
     }
-    return std::abs(total_sum);
+    return abs(total_sum);
 }
 
 /// The `L2` error a degree reduction would introduce.
@@ -366,6 +368,8 @@ template <Real T>
                                         bezier.net().shape().end() - 1);
     std::vector<double> component(coefficients);
 
+    using std::sqrt;
+
     double total = 0.0;
     for (std::size_t r = 0; r < components; ++r) {
         for (std::size_t i = 0; i < coefficients; ++i) {
@@ -377,7 +381,7 @@ template <Real T>
         }
         total += squared_l2_norm(component, parametric, grams);
     }
-    return std::sqrt(total);
+    return sqrt(total);
 }
 
 }  // namespace pantr::bezier


### PR DESCRIPTION
`scripts/ci_local.sh discipline` went red on `proto/cpp` when #414 merged. Two sites in
`cpp/include/pantr/bezier/degree.hpp` call a qualified `std::` math function, which the guard
forbids in library headers so that argument-dependent lookup can find an overload for a scalar
type that is not a built-in.

**This was my miss, not the branch's.** I verified #414 with ruff, ruff format, mypy,
`lint-imports`, both backend suites, `ctest` and all three CI jobs, and did not run
`scripts/ci_local.sh` — which is the only thing that runs the gates the two-job CI on this branch
does not cover. `degree.hpp` does not exist at the pre-merge base, so the gate was green before
and the violation entered with that merge.

## The fix, and one honest qualification

Both sites accumulate in an explicit `double`, so the guard's own rationale does not bite at
either: the call is on a known type, which is exactly the reasoning `ci_local.sh` gives for
excluding `cpp/tests` and `cpp/benchmark` from the check's scope. They comply anyway rather than
earning an exception, because a header that trips the guard makes every later reader re-decide
whether it may.

The idiom matches the rest of the tree (`kernels_1d.hpp:611`, `root_finding.hpp:226`,
`legendre.hpp:109`, `affine.hpp:571`): a `using std::abs;` / `using std::sqrt;` in the function,
then an unqualified call.

## Verification

- `scripts/ci_local.sh discipline`: **8 of 8 checks pass**, where it previously reported
  `FAIL no qualified std:: math calls, 2 site(s)`.
- `ctest`: 37/37, including `test_bezier_degree`, which covers both functions.
- Behavior is unchanged: for `double` the unqualified call resolves to the same function.
