### PR TITLE
feat(bezier): own Bezier multiplication and composition in C++

### DIFF
--- a/cpp/bindings/bezier.cpp
+++ b/cpp/bindings/bezier.cpp
@@ -1,11 +1,12 @@
 /// \file
 /// nanobind bindings for the `pantr.bezier` arithmetic kernels.
 ///
-/// Twenty-two entry points: the seven of `_bezier_core.py`, the reduction-operator
+/// Twenty-six entry points: the seven of `_bezier_core.py`, the reduction-operator
 /// apply that `pantr.bezier` reaches for through `pantr.bspline`, the two
 /// n-dimensional evaluation entry points of `pantr/bezier/evaluate.hpp`, the three
-/// degree operations of `pantr/bezier/degree.hpp`, and the nine shape operations of
-/// `pantr/bezier/shape.hpp`. The checks in
+/// degree operations of `pantr/bezier/degree.hpp`, the nine shape operations of
+/// `pantr/bezier/shape.hpp`, and the four product and composition entry points of
+/// `pantr/bezier/product.hpp`. The checks in
 /// this file are Layer 2's C++ half, for the reason `basis.cpp` states at length:
 /// a Layer 3 kernel validates nothing, the extension is importable, and every
 /// bound name here is a public attribute of a public module.
@@ -66,6 +67,14 @@
 /// direction, so a direction the caller is not acting on passes an empty array rather
 /// than being absent -- an absent entry would make the list's index stop meaning the
 /// direction, which is the one thing that must not become positional by accident.
+///
+/// ## The product and composition operations take their binomial tables as data
+///
+/// `multiply_bezier` and `compose_bezier` are handed their binomial and
+/// reciprocal-binomial tables as arguments rather than assembling them; see
+/// `pantr/bezier/product.hpp`'s file comment for the argument.
+/// `bezier_product_table_order` and `bezier_composition_table_order` exist so the
+/// table size a call needs is defined once rather than once per language.
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -82,6 +91,7 @@
 #include "pantr/bezier/degree.hpp"
 #include "pantr/bezier/evaluate.hpp"
 #include "pantr/bezier/kernels_1d.hpp"
+#include "pantr/bezier/product.hpp"
 #include "pantr/bezier/shape.hpp"
 #include "pantr/core/binomial.hpp"
 #include "pantr/core/mdspan.hpp"
@@ -539,6 +549,51 @@ pantr::bezier::Bezier<T> bind_collapse(const pantr::bezier::Bezier<T>& bezier, s
         bezier, axis, std::span<const T>(values.data(), values.shape(0)));
 }
 
+/// The largest binomial upper index `multiply_bezier` will read from its tables.
+template <class T>
+int bind_product_table_order(const pantr::bezier::Bezier<T>& a, const pantr::bezier::Bezier<T>& b) {
+    return static_cast<int>(pantr::bezier::product_table_order<T>(a, b));
+}
+
+/// The pointwise product of two Béziers, from caller-supplied binomial tables.
+///
+/// `binomials` and `inverse_binomials` are two adjacent same-dtype same-shape
+/// tables, so a transposed call would give a plausible but wrong Bézier with no
+/// error anywhere -- the same hazard `restrict_bezier_1d`'s `lower`/`upper` and
+/// `split_bezier_1d`'s two outputs carry; see the file comment.
+template <class T>
+pantr::bezier::Bezier<T> bind_multiply(const pantr::bezier::Bezier<T>& a,
+                                       const pantr::bezier::Bezier<T>& b, const_mat<T> binomials,
+                                       const_mat<T> inverse_binomials) {
+    const pantr::span2d<const T> binomials_view(binomials.data(), binomials.shape(0),
+                                                binomials.shape(1));
+    const pantr::span2d<const T> inverse_binomials_view(
+        inverse_binomials.data(), inverse_binomials.shape(0), inverse_binomials.shape(1));
+    return pantr::bezier::multiply<T>(a, b, binomials_view, inverse_binomials_view);
+}
+
+/// The largest binomial upper index `compose_bezier` will read from its tables.
+template <class T>
+int bind_composition_table_order(const pantr::bezier::Bezier<T>& outer,
+                                 const pantr::bezier::Bezier<T>& inner) {
+    return static_cast<int>(pantr::bezier::composition_table_order<T>(outer, inner));
+}
+
+/// The composition `outer(inner(t))`, from caller-supplied binomial tables.
+///
+/// Same transposition hazard between `binomials` and `inverse_binomials` as
+/// `bind_multiply`; see the file comment.
+template <class T>
+pantr::bezier::Bezier<T> bind_compose(const pantr::bezier::Bezier<T>& outer,
+                                      const pantr::bezier::Bezier<T>& inner,
+                                      const_mat<T> binomials, const_mat<T> inverse_binomials) {
+    const pantr::span2d<const T> binomials_view(binomials.data(), binomials.shape(0),
+                                                binomials.shape(1));
+    const pantr::span2d<const T> inverse_binomials_view(
+        inverse_binomials.data(), inverse_binomials.shape(0), inverse_binomials.shape(1));
+    return pantr::bezier::compose<T>(outer, inner, binomials_view, inverse_binomials_view);
+}
+
 }  // namespace
 
 void register_bezier(nb::module_& m) {
@@ -682,4 +737,34 @@ void register_bezier(nb::module_& m) {
           nb::arg("axis"), nb::arg("values").noconvert());
     m.def("collapse_bezier_along_axis", &bind_collapse<float>, nb::arg("bezier"),
           nb::arg("axis"), nb::arg("values").noconvert());
+
+    // The four entry points of `pantr/bezier/product.hpp`. `binomials` and
+    // `inverse_binomials` are two adjacent same-dtype same-shape tables, so a
+    // transposed call gives a plausible but wrong Bézier with no error anywhere --
+    // the same hazard `restrict_bezier_1d`'s `lower`/`upper` and
+    // `split_bezier_1d`'s two outputs carry, which is why `nb::kw_only()` sits in
+    // front of them here too. `.noconvert()` matters for a second reason: without
+    // it nanobind would silently convert a float64 table for a float32 Bézier,
+    // and the table's rounding is part of the parity claim.
+    m.def("bezier_product_table_order", &bind_product_table_order<double>, nb::arg("a"),
+          nb::arg("b"));
+    m.def("bezier_product_table_order", &bind_product_table_order<float>, nb::arg("a"),
+          nb::arg("b"));
+
+    m.def("multiply_bezier", &bind_multiply<double>, nb::arg("a"), nb::arg("b"), nb::kw_only(),
+          nb::arg("binomials").noconvert(), nb::arg("inverse_binomials").noconvert());
+    m.def("multiply_bezier", &bind_multiply<float>, nb::arg("a"), nb::arg("b"), nb::kw_only(),
+          nb::arg("binomials").noconvert(), nb::arg("inverse_binomials").noconvert());
+
+    m.def("bezier_composition_table_order", &bind_composition_table_order<double>,
+          nb::arg("outer"), nb::arg("inner"));
+    m.def("bezier_composition_table_order", &bind_composition_table_order<float>,
+          nb::arg("outer"), nb::arg("inner"));
+
+    m.def("compose_bezier", &bind_compose<double>, nb::arg("outer"), nb::arg("inner"),
+          nb::kw_only(), nb::arg("binomials").noconvert(),
+          nb::arg("inverse_binomials").noconvert());
+    m.def("compose_bezier", &bind_compose<float>, nb::arg("outer"), nb::arg("inner"),
+          nb::kw_only(), nb::arg("binomials").noconvert(),
+          nb::arg("inverse_binomials").noconvert());
 }

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -54,10 +54,13 @@
 ///    is the one rounding either way. That covers `bernstein_product_nd`'s weighting
 ///    of its operands and its final reciprocal scaling.
 ///  - A single **sum** of two `float32` values is not exact in `double`, but double
-///    rounding through it equals single rounding, because `double`'s 53 bits exceed
-///    `2 * 24 + 2` (Figueroa, *Yet another proof of the double rounding theorem*,
-///    1995 -- the same theorem `_binomial_tables` rests on). That covers the
-///    accumulation `d[k] + term`.
+///    rounding through an intermediate format sufficiently wider than the target is
+///    known to equal single rounding, and `double` against `float32` is the instance
+///    that result's condition covers with room to spare (Figueroa, *When is double
+///    rounding innocuous?*, ACM SIGNUM Newsletter 30(3):21-26, 1995,
+///    doi:10.1145/221332.221334 -- the same result `_binomial_tables` rests on, and
+///    the one place in this header that leans on a reference rather than on
+///    arithmetic anyone can redo). That covers the accumulation `d[k] + term`.
 ///  - The **chain** `(coefficient * f_i) * g_j` is where the width bites: widened, the
 ///    intermediate is not narrowed, so the second multiplication receives a different
 ///    operand. Nine `float32` cases move when it is, which is what pins the claim.
@@ -82,15 +85,27 @@
 /// rounded to the storage format once, and are an array by the time anything computes
 /// with them.
 ///
-/// Here the reason is sharper than in either precedent, because it is what the port
-/// exists to preserve. `core::bincoeff` stops at `core::kBincoeffMaxN`, which is 61,
-/// and **the numpy oracle has no limit at all**: `math.comb` is arbitrary precision,
-/// so `Bezier.multiply` is exact at `p + q = 80` where `scalar_bernstein_product_1d`
-/// is outside its int64 envelope and undefined. `design/cross_backend_types.md`
-/// records that difference of domain as one of the three reasons `multiply` keeps
-/// reaching the numpy helper rather than the dispatched kernel. Computing the tables
-/// natively would import the kernel's envelope into an operation that does not have
-/// one, which is a numerics change and not a port.
+/// Here the reason is **different** from the precedent's rather than a stronger form of
+/// it, and the distinction is worth keeping straight. `degree.hpp`'s reduction operator
+/// cannot be computed natively at all: it is the solution of an exact rational system
+/// whose numerators reach 156 bits, so a faithful assembly needs arbitrary precision and
+/// `double` loses eleven digits. A binomial coefficient needs no such thing -- it is an
+/// integer recurrence with no division, and `core::bincoeff` already computes it exactly.
+/// What binds here is **domain**, not precision: `core::bincoeff` stops at
+/// `core::kBincoeffMaxN`, which is 61, and **the numpy oracle has no limit at all**,
+/// because `math.comb` is arbitrary precision. So `Bezier.multiply` is exact at
+/// `p + q = 80` where `scalar_bernstein_product_1d` is outside its int64 envelope and
+/// undefined, and `design/cross_backend_types.md` records that difference of domain as
+/// one of the three reasons `multiply` keeps reaching the numpy helper rather than the
+/// dispatched kernel. Computing the tables from `core::bincoeff` would import the
+/// kernel's envelope into an operation that does not have one, which is a numerics
+/// change and not a port.
+///
+/// Widening the native recurrence would move that envelope rather than remove it:
+/// `unsigned __int128` reaches about degree 130 and then stops for the same reason. The
+/// oracle's domain is unbounded, so a table crossing is what matches it. This is a
+/// smaller gap than `degree.hpp`'s, and it is cheaper to close if anyone decides the
+/// bound is worth having natively -- which is a decision, not an omission.
 ///
 /// **The consequence, stated plainly:** a C++ caller with no Python cannot multiply
 /// or compose unaided, and must supply tables it obtained elsewhere.
@@ -110,7 +125,7 @@
 ///    `k_mat.ravel()`; that is row-major, so coefficient `k` accumulates its terms in
 ///    increasing `i`. Summing in increasing `j`, or over `k`'s own range, is a
 ///    different number.
-///  - **The 1-D product normalises per term; the n-D one normalises at the end.** The
+///  - **The 1-D product normalizes per term; the n-D one normalizes at the end.** The
 ///    oracle folds `1 / C(r, k)` into the `(p+1, q+1)` coefficient table before any
 ///    accumulation, and in the n-D helper multiplies the finished convolution by
 ///    `inv_w_r` afterwards. The two are not the same computation and neither may be
@@ -121,10 +136,39 @@
 ///    last bits, which is precisely the mutation that caught an earlier parity test
 ///    exercising none of the ported code.
 ///
-/// A build with a fused multiply-add is the one thing the equality does not survive:
-/// `d[k] + term` is a contractible site, so on such a build the claim becomes Rule
-/// 10's budget. That is the same conditional shape every other Bézier claim carries,
-/// and the shipped build has no FMA.
+/// ### Contraction, and where these functions are not what the sibling claims assume
+///
+/// Every other Bézier claim is conditional on whether the target ISA has a fused
+/// multiply-add, because every other Bézier kernel writes its accumulation as one
+/// expression, `a + b * c`, which `-ffp-contract=on` may fuse. **These four functions
+/// do not.** `bernstein_product_1d` computes the term into a named local and adds it in
+/// the next statement, and `-ffp-contract=on` is expression-scoped in the compiler this
+/// project builds with, so there is nothing for it to fuse across the statement
+/// boundary.
+///
+/// Measured rather than reasoned, by disassembling an FMA-enabled build and by running
+/// the product at all three contraction settings:
+///
+/// Configure a second build tree with `-DCMAKE_CXX_FLAGS="-mavx2 -mfma"`, then count
+/// `vfmadd` per demangled symbol in `objdump -d` of `bezier.cpp.o`: it is zero in all
+/// four functions here and nonzero in `scalar_bernstein_product_1d`. (No line
+/// continuations in that recipe: a `///` line ending in a backslash is one comment
+/// spanning two lines, which this build rejects under `-Werror=comment`, and it did.)
+///
+/// `off` and `on` agree bit for bit; `=fast` does not, so the site is contractible in
+/// principle and the claim keeps its bounded arm for a build that reaches it. What
+/// follows for a reader:
+///
+///  - **`multiply`'s equality survives an FMA host at this project's own flags.** The
+///    parity harness selects its arm from the ISA rather than from the contraction
+///    scope, so on such a host it asserts the *bounded* claim and observes zero
+///    differing elements. That is sound and slack, not wrong, and
+///    `tests/parity/test_bezier_product.py` says so rather than presenting the bounded
+///    arm as exercised.
+///  - **`compose`'s does not**, and the reason is not its own arithmetic. Its univariate
+///    branch calls `scalar_bernstein_product_1d`, whose accumulation *is* a single
+///    expression and does carry one fused site per instantiation at `-ffp-contract=on`.
+///    So the composition inherits a build dependence the product does not have.
 ///
 /// ## Validating rather than asserting
 ///
@@ -595,6 +639,11 @@ template <Real T>
     for (std::size_t i = 1; i < m; ++i) {
         ScalarNet<T> scaled = scalar_net_product<T>(g_powers[i - 1], one_minus_g_powers[m - i - 1],
                                                     use_1d_kernel, binomials, inverse_binomials);
+        // Read from the table rather than recomputed, and the oracle reaches the same
+        // number by a third spelling -- `float(math.comb(m, i))` applied to an array.
+        // That the two agree is the double-rounding argument `_binomial_tables`'
+        // docstring makes and `test_the_two_spellings_of_a_binomial_agree` checks; the
+        // reliance is here, so the pointer is here.
         const T coefficient = at(binomials, m, i);
         for (T& value : scaled.values) {
             value = coefficient * value;
@@ -677,8 +726,8 @@ template <Real T>
                                  span2d<const T> binomials,
                                  span2d<const T> inverse_binomials) {
     const std::size_t order = product_table_order<T>(a, b);
-    detail::require_table_extents(binomials, order, "binomials");
-    detail::require_table_extents(inverse_binomials, order, "inverse_binomials");
+    detail::require_table_extents<T>(binomials, order, "binomials");
+    detail::require_table_extents<T>(inverse_binomials, order, "inverse_binomials");
 
     std::vector<std::size_t> out_shape;
 

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -1,0 +1,869 @@
+#pragma once
+
+/// \file
+/// The pointwise product of two n-dimensional Béziers, and the composition of one
+/// with another.
+///
+/// Free functions over `Bezier<T>`, as `bezier.hpp` says: the fourth and last of the
+/// operation ports over the value type. `compose` composes over
+/// `scalar_bernstein_product_1d` where the oracle does and over the n-dimensional
+/// product below where the oracle does that instead; neither reimplements the other.
+///
+/// ## What is exactly representable, and what is exactly computed
+///
+/// The product of Béziers of degrees `p` and `q` is a polynomial of degree `p + q`,
+/// so it is **exactly representable** in the Bernstein basis of that degree: no
+/// approximation is made in choosing the output's degree, unlike degree reduction.
+/// The composition of a degree-`m` outer map with a degree-`n` inner one is likewise
+/// exactly representable at degree `m * n` per direction.
+///
+/// **The coefficients are not exact.** Each is a binomial-weighted sum formed in
+/// floating point, so it carries the roundings of that sum. The Python oracle's
+/// docstrings say "the exact pointwise product" and "the exact composition"; read as
+/// a statement about the representation that is true, read as a statement about the
+/// computed numbers it is false, and it is the second reading a caller comparing two
+/// backends will take. Stated here rather than copied, on the ticket's instruction.
+/// `tests/parity/test_bezier_product.py` is where the size of the inexactness is
+/// measured.
+///
+/// ## The arithmetic runs at the STORAGE width, and that is the opposite of a kernel
+///
+/// `design/backend_parity.md` Rule 9: an oracle's accumulation width is a per-kernel
+/// fact. Here the oracle for `multiply` is **numpy**, not numba, and numpy computes a
+/// `float32` expression in `float32`. Every intermediate in `bernstein_product_1d`
+/// and `bernstein_product_nd` below is therefore `T`, never `accumulator_t<T>`. That
+/// is the inverse of `kernels_1d.hpp`, whose numba oracle promotes its `float64`
+/// coefficient tables against a `float32` array and so accumulates in `double`.
+///
+/// Widening here would be the same class of error `shape.hpp` records for a parameter
+/// it narrowed, seen from the other side: the width belongs to the operation, and
+/// reading it off the surrounding module is how a port gets it wrong at `float32`
+/// while agreeing at `float64`.
+///
+/// `compose` mixes the two, because its oracle does. Its Bernstein products go
+/// through `scalar_bernstein_product_1d` for a univariate inner map -- a numba kernel,
+/// so `accumulator_t<T>` inside it -- and through `bernstein_product_nd` above that,
+/// which is numpy and so `T`. Everything else in `compose` -- the `1 - g`, the
+/// binomial scaling of a basis, the accumulation of the tensor terms -- is numpy and
+/// so `T`.
+///
+/// ## The binomial tables cross as data
+///
+/// `multiply`, `compose` and `bernstein_product_nd` take their **binomial and
+/// reciprocal-binomial tables as arguments** rather than assembling them. That is the
+/// ruling `core/reduction_operator.hpp` records and `degree.hpp` extends, applied
+/// again for the same reason: the tables are assembled once from exact arithmetic,
+/// rounded to the storage format once, and are an array by the time anything computes
+/// with them.
+///
+/// Here the reason is sharper than in either precedent, because it is what the port
+/// exists to preserve. `core::bincoeff` stops at `core::kBincoeffMaxN`, which is 61,
+/// and **the numpy oracle has no limit at all**: `math.comb` is arbitrary precision,
+/// so `Bezier.multiply` is exact at `p + q = 80` where `scalar_bernstein_product_1d`
+/// is outside its int64 envelope and undefined. `design/cross_backend_types.md`
+/// records that difference of domain as one of the three reasons `multiply` keeps
+/// reaching the numpy helper rather than the dispatched kernel. Computing the tables
+/// natively would import the kernel's envelope into an operation that does not have
+/// one, which is a numerics change and not a port.
+///
+/// **The consequence, stated plainly:** a C++ caller with no Python cannot multiply
+/// or compose unaided, and must supply tables it obtained elsewhere.
+/// `product_table_order` and `composition_table_order` tell it how large they have to
+/// be, so that the size is defined once rather than once per language. This is the
+/// same gap `degree.hpp` records for its reduction operators, and it is tracked
+/// rather than hidden.
+///
+/// ## Which roundings the equality depends on
+///
+/// The claim these functions carry is an **equality**, not a bound, and it is an
+/// equality only because the operation order is reproduced rather than rearranged.
+/// Three orderings are load-bearing and none of them is the obvious one:
+///
+///  - **The 1-D product accumulates in `i`-major order.** The oracle forms a
+///    `(p+1, q+1)` table of terms and hands it to `np.add.at`, whose index array is
+///    `k_mat.ravel()`; that is row-major, so coefficient `k` accumulates its terms in
+///    increasing `i`. Summing in increasing `j`, or over `k`'s own range, is a
+///    different number.
+///  - **The 1-D product normalises per term; the n-D one normalises at the end.** The
+///    oracle folds `1 / C(r, k)` into the `(p+1, q+1)` coefficient table before any
+///    accumulation, and in the n-D helper multiplies the finished convolution by
+///    `inv_w_r` afterwards. The two are not the same computation and neither may be
+///    substituted for the other.
+///  - **Every product is left-associated exactly as numpy writes it.**
+///    `coeff[i] * cq[j] * inv_cr[k]` is `(cp * cq) * inv_cr`, and
+///    `coeff * b_f * b_g` is `(coeff * b_f) * b_g`. Reassociating either changes the
+///    last bits, which is precisely the mutation that caught an earlier parity test
+///    exercising none of the ported code.
+///
+/// A build with a fused multiply-add is the one thing the equality does not survive:
+/// `d[k] + term` is a contractible site, so on such a build the claim becomes Rule
+/// 10's budget. That is the same conditional shape every other Bézier claim carries,
+/// and the shipped build has no FMA.
+///
+/// ## Validating rather than asserting
+///
+/// Like `bezier.hpp`, `evaluate.hpp`, `degree.hpp` and `shape.hpp`: operations on a
+/// domain type validate and throw `std::invalid_argument` in a release build as much
+/// as a debug one. A caller with no Python cannot be protected by `cpp/bindings/`.
+///
+/// Two of the oracle's checks have no counterpart here and one has a different type.
+/// The dtype check cannot exist: both operands are `Bezier<T>` and the template
+/// parameter carries the format, so the mismatch is unsayable. The rational-operand
+/// rejection in `compose` is the oracle's `TypeError` and is an
+/// `std::invalid_argument` here, which nanobind maps to `ValueError`; the exception
+/// *type* stays in parity because Python's Layer 2 refuses a rational operand above
+/// the backend branch, so the C++ check is reached only by a caller that has no
+/// Python to raise for it.
+
+#include <cstddef>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pantr/bezier/axis_layout.hpp"
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/bezier/degree.hpp"
+#include "pantr/bezier/kernels_1d.hpp"
+#include "pantr/core/mdspan.hpp"
+#include "pantr/core/scalar.hpp"
+
+namespace pantr::bezier {
+
+namespace detail {
+
+/// Refuse two operands the product formula is not defined for.
+///
+/// The messages are the oracle's, character for character
+/// (`_bezier_product._multiply_bezier`), because
+/// `tests/parity/test_bezier_product.py` compares them. The oracle's dtype check
+/// sits between these two and has no counterpart; see the file comment.
+///
+/// \param a First operand.
+/// \param b Second operand.
+/// \throws std::invalid_argument If the dimensions or the ranks differ.
+template <Real T>
+void require_compatible_operands(const Bezier<T>& a, const Bezier<T>& b) {
+    if (a.dim() != b.dim()) {
+        throw std::invalid_argument("Operands must have the same dimension. Got "
+                                    + std::to_string(a.dim()) + " and "
+                                    + std::to_string(b.dim()) + ".");
+    }
+    if (a.rank() != b.rank()) {
+        throw std::invalid_argument("Operands must have the same rank. Got "
+                                    + std::to_string(a.rank()) + " and "
+                                    + std::to_string(b.rank()) + ".");
+    }
+}
+
+/// Refuse a binomial table that does not reach the upper index the operation needs.
+///
+/// \param table The table, `(order + 1, order + 1)` or larger.
+/// \param order The largest upper index that will be read.
+/// \param what The table's argument name, for the message.
+/// \throws std::invalid_argument If either extent is too small.
+template <Real T>
+void require_table_extents(span2d<const T> table, std::size_t order, const char* what) {
+    if (table.extent(0) <= order || table.extent(1) <= order) {
+        throw std::invalid_argument(std::string(what) + " must have shape at least ("
+                                    + std::to_string(order + 1) + ", "
+                                    + std::to_string(order + 1) + "), got ("
+                                    + std::to_string(table.extent(0)) + ", "
+                                    + std::to_string(table.extent(1)) + ").");
+    }
+}
+
+/// Row-major strides for a shape, innermost last.
+///
+/// \param shape The extents.
+/// \return One stride per extent, `strides.back() == 1`.
+[[nodiscard]] inline std::vector<std::size_t> row_major_strides(
+    std::span<const std::size_t> shape) {
+    std::vector<std::size_t> strides(shape.size(), 1);
+    for (std::size_t d = shape.size(); d-- > 1;) {
+        strides[d - 1] = strides[d] * shape[d];
+    }
+    return strides;
+}
+
+/// Decode a flat row-major index into its multi-index.
+///
+/// \param flat The flat index, below the product of `shape`.
+/// \param shape The extents.
+/// \param index Receives one component per extent.
+inline void decode_row_major(std::size_t flat, std::span<const std::size_t> shape,
+                            std::span<std::size_t> index) {
+    for (std::size_t d = shape.size(); d-- > 0;) {
+        index[d] = flat % shape[d];
+        flat /= shape[d];
+    }
+}
+
+/// Reproduce `_bernstein_product_coefficients`: the univariate Bernstein product.
+///
+/// `d_k = (1 / C(r, k)) * sum_{i + j = k} C(p, i) C(q, j) f_i g_j`, formed as the
+/// oracle forms it and in the order the oracle forms it: the reciprocal folded into
+/// the coefficient before any accumulation, the two control values multiplied in
+/// left to right, and the sum for each `k` taken in increasing `i`. See the file
+/// comment for why each of those is load-bearing.
+///
+/// Every intermediate is `T`. The oracle is numpy, which computes a `float32`
+/// expression in `float32`.
+///
+/// \param f Control points of the first curve, `(p + 1, rank)` row-major.
+/// \param g Control points of the second curve, `(q + 1, rank)` row-major.
+/// \param rank Number of components; the trailing extent of both operands.
+/// \param binomials `C(n, k)` in the storage format, at least `(r + 1, r + 1)`.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \param out Product control points, `(r + 1, rank)` row-major. Zeroed, then
+///        written in full.
+///
+/// \note No input validation is performed; the shapes are the caller's to establish.
+template <Real T>
+void bernstein_product_1d(std::span<const T> f, std::span<const T> g, std::size_t rank,
+                          span2d<const T> binomials, span2d<const T> inverse_binomials,
+                          std::span<T> out) {
+    const std::size_t p = (f.size() / rank) - 1;
+    const std::size_t q = (g.size() / rank) - 1;
+    const std::size_t r = p + q;
+
+    for (std::size_t i = 0; i < out.size(); ++i) {
+        out[i] = T(0);
+    }
+
+    for (std::size_t i = 0; i <= p; ++i) {
+        for (std::size_t j = 0; j <= q; ++j) {
+            // `(cp * cq) * inv_cr`, which is how numpy associates
+            // `cp[:, None] * cq[None, :] * inv_cr[k_mat]`.
+            const T coefficient = T(at(binomials, p, i) * at(binomials, q, j))
+                                  * at(inverse_binomials, r, i + j);
+            const std::size_t base = (i + j) * rank;
+            for (std::size_t s = 0; s < rank; ++s) {
+                // `(coeff * b_f) * b_g`, and then one narrowing add per term: the
+                // accumulator IS the output array, exactly as `np.add.at` makes it.
+                const T term = T(coefficient * f[(i * rank) + s]) * g[(j * rank) + s];
+                out[base + s] = out[base + s] + term;
+            }
+        }
+    }
+}
+
+/// Reproduce `_bernstein_product_coefficients_nd`: the tensor-product Bernstein
+/// product.
+///
+/// A different computation from `bernstein_product_1d` rather than a generalisation
+/// of it, and the difference is not incidental: this one weights each operand once,
+/// convolves, and divides the finished convolution by the product of reciprocal
+/// binomials, where the univariate helper folds the reciprocal into every term. The
+/// oracle keeps both and so does this.
+///
+/// Every intermediate is `T`, and every product of per-direction factors is
+/// left-associated over ascending direction, which is what `np.multiply.outer`
+/// applied in a loop produces.
+///
+/// \param f Control points of the first patch, row-major with extents `shape_f`.
+/// \param shape_f Extents of `f`, the component count last.
+/// \param g Control points of the second patch, row-major with extents `shape_g`.
+/// \param shape_g Extents of `g`, the component count last and equal to `shape_f`'s.
+/// \param binomials `C(n, k)` in the storage format, reaching every `r_d`.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \param out Product control points, row-major with extents
+///        `(p_d + q_d + 1, ..., rank)`. Zeroed, then written in full.
+///
+/// \note No input validation is performed; the shapes are the caller's to establish.
+template <Real T>
+void bernstein_product_nd(std::span<const T> f, std::span<const std::size_t> shape_f,
+                          std::span<const T> g, std::span<const std::size_t> shape_g,
+                          span2d<const T> binomials, span2d<const T> inverse_binomials,
+                          std::span<T> out) {
+    const std::size_t ndim = shape_f.size() - 1;
+    const std::size_t rank = shape_f.back();
+
+    // `end() - 1` rather than `begin() + ndim`: the latter adds an unsigned index to an
+    // iterator, which this build rejects under -Wsign-conversion -Werror. `degree.hpp`
+    // drops the component axis the same way.
+    std::vector<std::size_t> extents_f(shape_f.begin(), shape_f.end() - 1);
+    std::vector<std::size_t> extents_g(shape_g.begin(), shape_g.end() - 1);
+    std::vector<std::size_t> extents_h(ndim);
+    for (std::size_t d = 0; d < ndim; ++d) {
+        extents_h[d] = extents_f[d] + extents_g[d] - 1;
+    }
+
+    const std::vector<std::size_t> strides_h = row_major_strides(extents_h);
+    const std::size_t count_f = extent_product(extents_f, 0);
+    const std::size_t count_g = extent_product(extents_g, 0);
+    const std::size_t count_h = extent_product(extents_h, 0);
+
+    // The weighted operands, `w_f[..., None] * b_f` and its twin. One rounding per
+    // stored value, and the weight itself is a left-associated product over ascending
+    // direction.
+    std::vector<std::size_t> index(ndim);
+    std::vector<T> weighted_f(f.size());
+    for (std::size_t a = 0; a < count_f; ++a) {
+        decode_row_major(a, extents_f, index);
+        T weight = at(binomials, extents_f[0] - 1, index[0]);
+        for (std::size_t d = 1; d < ndim; ++d) {
+            weight = weight * at(binomials, extents_f[d] - 1, index[d]);
+        }
+        for (std::size_t s = 0; s < rank; ++s) {
+            weighted_f[(a * rank) + s] = weight * f[(a * rank) + s];
+        }
+    }
+    std::vector<T> weighted_g(g.size());
+    for (std::size_t b = 0; b < count_g; ++b) {
+        decode_row_major(b, extents_g, index);
+        T weight = at(binomials, extents_g[0] - 1, index[0]);
+        for (std::size_t d = 1; d < ndim; ++d) {
+            weight = weight * at(binomials, extents_g[d] - 1, index[d]);
+        }
+        for (std::size_t s = 0; s < rank; ++s) {
+            weighted_g[(b * rank) + s] = weight * g[(b * rank) + s];
+        }
+    }
+
+    for (std::size_t i = 0; i < out.size(); ++i) {
+        out[i] = T(0);
+    }
+
+    // The convolution. The oracle adds a whole `(q + 1, ..., rank)` block per
+    // multi-index of the first operand, iterating those in row-major order, so each
+    // output element accumulates its terms in increasing flat index of `alpha`.
+    std::vector<std::size_t> alpha(ndim);
+    std::vector<std::size_t> beta(ndim);
+    for (std::size_t a = 0; a < count_f; ++a) {
+        decode_row_major(a, extents_f, alpha);
+        for (std::size_t b = 0; b < count_g; ++b) {
+            decode_row_major(b, extents_g, beta);
+            std::size_t flat_h = 0;
+            for (std::size_t d = 0; d < ndim; ++d) {
+                flat_h += (alpha[d] + beta[d]) * strides_h[d];
+            }
+            for (std::size_t s = 0; s < rank; ++s) {
+                const T term = weighted_f[(a * rank) + s] * weighted_g[(b * rank) + s];
+                out[(flat_h * rank) + s] = out[(flat_h * rank) + s] + term;
+            }
+        }
+    }
+
+    // `inv_w_r[..., None] * h_conv`, applied to the finished convolution.
+    for (std::size_t h = 0; h < count_h; ++h) {
+        decode_row_major(h, extents_h, index);
+        T weight = at(inverse_binomials, extents_h[0] - 1, index[0]);
+        for (std::size_t d = 1; d < ndim; ++d) {
+            weight = weight * at(inverse_binomials, extents_h[d] - 1, index[d]);
+        }
+        for (std::size_t s = 0; s < rank; ++s) {
+            out[(h * rank) + s] = weight * out[(h * rank) + s];
+        }
+    }
+}
+
+/// Multiply two control nets of equal dimension and component count.
+///
+/// Dispatches on the dimension exactly as the oracle does: the univariate helper for
+/// a curve, the tensor-product one above it. The two are different computations, so
+/// the dispatch is part of the parity claim rather than an optimisation.
+///
+/// \param f First net, row-major with extents `shape_f`.
+/// \param shape_f Extents of `f`, components last.
+/// \param g Second net, row-major with extents `shape_g`.
+/// \param shape_g Extents of `g`, components last.
+/// \param binomials `C(n, k)` in the storage format.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \param out_shape Receives the product's extents, components last.
+/// \return The product net, row-major with extents `out_shape`.
+template <Real T>
+[[nodiscard]] std::vector<T> multiply_nets(std::span<const T> f,
+                                           std::span<const std::size_t> shape_f,
+                                           std::span<const T> g,
+                                           std::span<const std::size_t> shape_g,
+                                           span2d<const T> binomials,
+                                           span2d<const T> inverse_binomials,
+                                           std::vector<std::size_t>& out_shape) {
+    const std::size_t ndim = shape_f.size() - 1;
+    const std::size_t rank = shape_f.back();
+
+    out_shape.assign(ndim + 1, rank);
+    for (std::size_t d = 0; d < ndim; ++d) {
+        out_shape[d] = shape_f[d] + shape_g[d] - 1;
+    }
+
+    std::vector<T> out(extent_product(out_shape, 0));
+    if (ndim == 1) {
+        bernstein_product_1d<T>(f, g, rank, binomials, inverse_binomials, out);
+    } else {
+        bernstein_product_nd<T>(f, shape_f, g, shape_g, binomials, inverse_binomials, out);
+    }
+    return out;
+}
+
+/// Split a homogeneous net into its numerator and its weight column.
+///
+/// \param values The net, row-major with `components` per coefficient.
+/// \param components The stored component count, weight included.
+/// \param numerator Receives the first `components - 1` of each coefficient.
+/// \param denominator Receives the last one.
+template <Real T>
+void split_weight_column(std::span<const T> values, std::size_t components,
+                         std::vector<T>& numerator, std::vector<T>& denominator) {
+    const std::size_t coefficients = values.size() / components;
+    numerator.assign(coefficients * (components - 1), T(0));
+    denominator.assign(coefficients, T(0));
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        for (std::size_t s = 0; s + 1 < components; ++s) {
+            numerator[(i * (components - 1)) + s] = values[(i * components) + s];
+        }
+        denominator[i] = values[(i * components) + components - 1];
+    }
+}
+
+/// A net in homogeneous form, with a unit weight column added when absent.
+///
+/// The oracle's `_ensure_rational_ctrl`. A promotion writes exact ones and computes
+/// nothing, so it commits no rounding and sits outside the parity claim.
+///
+/// \param bezier The Bézier.
+/// \param shape Receives the homogeneous extents, the component count last.
+/// \return The homogeneous net, row-major.
+template <Real T>
+[[nodiscard]] std::vector<T> homogeneous_net(const Bezier<T>& bezier,
+                                             std::vector<std::size_t>& shape) {
+    const ControlNet<T>& net = bezier.net();
+    shape.assign(net.shape().begin(), net.shape().end());
+    if (bezier.is_rational()) {
+        return std::vector<T>(net.values().begin(), net.values().end());
+    }
+
+    const std::size_t components = net.num_components();
+    const std::size_t coefficients = net.size() / components;
+    shape.back() = components + 1;
+
+    std::vector<T> promoted(coefficients * (components + 1));
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        for (std::size_t s = 0; s < components; ++s) {
+            promoted[(i * (components + 1)) + s] = net.values()[(i * components) + s];
+        }
+        promoted[(i * (components + 1)) + components] = T(1);
+    }
+    return promoted;
+}
+
+/// A scalar-valued intermediate of the composition: one coefficient per index.
+///
+/// `compose` works throughout in the oracle's shape, which keeps the component axis
+/// present with extent one -- `(*extents, 1)` -- because both product helpers read the
+/// component count off the shape's last entry and the univariate one is handed the
+/// column directly.
+template <Real T>
+struct ScalarNet {
+    std::vector<T> values;           ///< Coefficients, row-major, one per index.
+    std::vector<std::size_t> shape;  ///< Extents, with a trailing 1 for the component.
+};
+
+/// The Bernstein product of two scalar intermediates, dispatched as the oracle
+/// dispatches it.
+///
+/// `_product_fn`: the numba kernel for a univariate inner map, the n-dimensional numpy
+/// helper above that. **The two differ by more than shape** -- the kernel accumulates
+/// in `accumulator_t<T>` and divides by `C(r, k)`, the helper accumulates in `T` and
+/// multiplies by a precomputed reciprocal -- so the branch is part of the claim.
+///
+/// \param a First operand.
+/// \param b Second operand, of the same dimension.
+/// \param use_1d_kernel Whether the inner map is univariate.
+/// \param binomials `C(n, k)` in the storage format; unused on the univariate branch,
+///        which builds its own from `core::bincoeff` exactly as its oracle does.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \return The product.
+template <Real T>
+[[nodiscard]] ScalarNet<T> scalar_net_product(const ScalarNet<T>& a, const ScalarNet<T>& b,
+                                              bool use_1d_kernel, span2d<const T> binomials,
+                                              span2d<const T> inverse_binomials) {
+    ScalarNet<T> out;
+    out.shape.assign(a.shape.size(), 1);
+    for (std::size_t d = 0; d + 1 < a.shape.size(); ++d) {
+        out.shape[d] = a.shape[d] + b.shape[d] - 1;
+    }
+    out.values.assign(extent_product(out.shape, 0), T(0));
+
+    if (use_1d_kernel) {
+        scalar_bernstein_product_1d<T>(a.values, b.values, out.values);
+    } else {
+        bernstein_product_nd<T>(a.values, a.shape, b.values, b.shape, binomials,
+                                inverse_binomials, out.values);
+    }
+    return out;
+}
+
+/// Successive powers of a scalar intermediate: `g^1` through `g^max_power`.
+///
+/// `_compute_scalar_powers`, and the recurrence is the oracle's:
+/// `g^k = g^{k-1} * g`, not a balanced tree. Squaring would form fewer products and a
+/// different number.
+///
+/// \param g The base.
+/// \param max_power The highest power, at least 1.
+/// \param use_1d_kernel Whether the inner map is univariate.
+/// \param binomials `C(n, k)` in the storage format.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \return `max_power` nets, entry `k` holding `g^(k + 1)`.
+template <Real T>
+[[nodiscard]] std::vector<ScalarNet<T>> scalar_net_powers(const ScalarNet<T>& g,
+                                                          std::size_t max_power,
+                                                          bool use_1d_kernel,
+                                                          span2d<const T> binomials,
+                                                          span2d<const T> inverse_binomials) {
+    std::vector<ScalarNet<T>> powers;
+    powers.reserve(max_power);
+    powers.push_back(g);
+    for (std::size_t k = 1; k < max_power; ++k) {
+        powers.push_back(scalar_net_product<T>(powers.back(), g, use_1d_kernel, binomials,
+                                               inverse_binomials));
+    }
+    return powers;
+}
+
+/// The Bernstein basis of degree `m` evaluated at a scalar Bézier, in Bézier form.
+///
+/// `_compute_bernstein_bases`: `B_i^m(g) = C(m, i) g^i (1 - g)^(m - i)`, each returned
+/// as a net over the inner map's parametric domain. The binomial scaling is a scalar
+/// times an array in the oracle, so it rounds once per stored value and at the storage
+/// width.
+///
+/// \param g The scalar Bézier the basis is evaluated at.
+/// \param m The Bernstein degree.
+/// \param use_1d_kernel Whether the inner map is univariate.
+/// \param binomials `C(n, k)` in the storage format; read at row `m`.
+/// \param inverse_binomials `1 / C(n, k)` likewise.
+/// \return `m + 1` nets, in the order `B_0^m` through `B_m^m`.
+template <Real T>
+[[nodiscard]] std::vector<ScalarNet<T>> bernstein_bases_at(const ScalarNet<T>& g, std::size_t m,
+                                                           bool use_1d_kernel,
+                                                           span2d<const T> binomials,
+                                                           span2d<const T> inverse_binomials) {
+    if (m == 0) {
+        // `B_0^0 = 1`: a degree-zero net, one coefficient, and the oracle's shape for
+        // it is all ones rather than the inner map's own extents.
+        ScalarNet<T> one;
+        one.shape.assign(g.shape.size(), 1);
+        one.values.assign(1, T(1));
+        return {one};
+    }
+
+    ScalarNet<T> one_minus_g;
+    one_minus_g.shape = g.shape;
+    one_minus_g.values.resize(g.values.size());
+    for (std::size_t i = 0; i < g.values.size(); ++i) {
+        one_minus_g.values[i] = T(1) - g.values[i];
+    }
+
+    const std::vector<ScalarNet<T>> g_powers =
+        scalar_net_powers<T>(g, m, use_1d_kernel, binomials, inverse_binomials);
+    const std::vector<ScalarNet<T>> one_minus_g_powers =
+        scalar_net_powers<T>(one_minus_g, m, use_1d_kernel, binomials, inverse_binomials);
+
+    std::vector<ScalarNet<T>> bases;
+    bases.reserve(m + 1);
+    bases.push_back(one_minus_g_powers[m - 1]);
+    for (std::size_t i = 1; i < m; ++i) {
+        ScalarNet<T> scaled = scalar_net_product<T>(g_powers[i - 1], one_minus_g_powers[m - i - 1],
+                                                    use_1d_kernel, binomials, inverse_binomials);
+        const T coefficient = at(binomials, m, i);
+        for (T& value : scaled.values) {
+            value = coefficient * value;
+        }
+        bases.push_back(std::move(scaled));
+    }
+    bases.push_back(g_powers[m - 1]);
+    return bases;
+}
+
+/// One component of a control net, keeping the component axis at extent one.
+///
+/// The oracle's `_extract_scalar_component`, which is a slice and computes nothing.
+///
+/// \param net The net.
+/// \param component The component index, below `net.num_components()`.
+/// \return The scalar net.
+template <Real T>
+[[nodiscard]] ScalarNet<T> scalar_component(const ControlNet<T>& net, std::size_t component) {
+    const std::size_t components = net.num_components();
+    const std::size_t coefficients = net.size() / components;
+
+    ScalarNet<T> out;
+    out.shape.assign(net.shape().begin(), net.shape().end());
+    out.shape.back() = 1;
+    out.values.resize(coefficients);
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        out.values[i] = net.values()[(i * components) + component];
+    }
+    return out;
+}
+
+}  // namespace detail
+
+/// The largest upper binomial index a product forms.
+///
+/// The size the tables `multiply` needs, defined once so that a caller assembling
+/// them in another language does not have to restate the formula. It is
+/// `max_d (p_d + q_d)`: the product's own degree per direction, and no reciprocal or
+/// coefficient above it is ever read.
+///
+/// \param a First operand.
+/// \param b Second operand.
+/// \return The largest `n` for which `C(n, k)` will be read, so the tables must be
+///         at least `(n + 1, n + 1)`.
+/// \throws std::invalid_argument If the operands are incompatible, with the same
+///         message `multiply` would give.
+template <Real T>
+[[nodiscard]] std::size_t product_table_order(const Bezier<T>& a, const Bezier<T>& b) {
+    detail::require_compatible_operands(a, b);
+
+    std::size_t order = 0;
+    for (std::size_t d = 0; d < a.dim(); ++d) {
+        const std::size_t summed = a.degree(d) + b.degree(d);
+        order = (summed > order) ? summed : order;
+    }
+    return order;
+}
+
+/// The pointwise product of two Béziers.
+///
+/// Degree `p_d + q_d` per direction, which represents the product exactly; the
+/// coefficients carry the roundings of a binomial-weighted sum. See the file comment.
+///
+/// A rational operand makes the result rational: both operands are promoted to
+/// homogeneous form and their numerators and weight columns are multiplied
+/// independently, which is the product of the two projected mappings because the
+/// projection is a quotient.
+///
+/// \param a First operand.
+/// \param b Second operand. Must match `a`'s dimension and rank.
+/// \param binomials `C(n, k)` in the storage format, at least
+///        `(product_table_order + 1)` square. Entries with `k > n` are never read.
+/// \param inverse_binomials `1 / C(n, k)` in the storage format, same shape.
+/// \return The product, rational exactly when either operand is.
+/// \throws std::invalid_argument If the dimensions or ranks differ, or if a table is
+///         too small.
+template <Real T>
+[[nodiscard]] Bezier<T> multiply(const Bezier<T>& a, const Bezier<T>& b,
+                                 span2d<const T> binomials,
+                                 span2d<const T> inverse_binomials) {
+    const std::size_t order = product_table_order<T>(a, b);
+    detail::require_table_extents(binomials, order, "binomials");
+    detail::require_table_extents(inverse_binomials, order, "inverse_binomials");
+
+    std::vector<std::size_t> out_shape;
+
+    if (!a.is_rational() && !b.is_rational()) {
+        const std::vector<T> values = detail::multiply_nets<T>(
+            a.net().values(), a.net().shape(), b.net().values(), b.net().shape(), binomials,
+            inverse_binomials, out_shape);
+        return Bezier<T>(ControlNet<T>(std::span<const T>(values),
+                                       std::span<const std::size_t>(out_shape)),
+                         false);
+    }
+
+    std::vector<std::size_t> shape_a;
+    std::vector<std::size_t> shape_b;
+    const std::vector<T> homogeneous_a = detail::homogeneous_net<T>(a, shape_a);
+    const std::vector<T> homogeneous_b = detail::homogeneous_net<T>(b, shape_b);
+
+    std::vector<T> numerator_a;
+    std::vector<T> denominator_a;
+    std::vector<T> numerator_b;
+    std::vector<T> denominator_b;
+    detail::split_weight_column<T>(homogeneous_a, shape_a.back(), numerator_a, denominator_a);
+    detail::split_weight_column<T>(homogeneous_b, shape_b.back(), numerator_b, denominator_b);
+
+    std::vector<std::size_t> numerator_shape_a(shape_a);
+    std::vector<std::size_t> numerator_shape_b(shape_b);
+    numerator_shape_a.back() -= 1;
+    numerator_shape_b.back() -= 1;
+    std::vector<std::size_t> weight_shape_a(shape_a);
+    std::vector<std::size_t> weight_shape_b(shape_b);
+    weight_shape_a.back() = 1;
+    weight_shape_b.back() = 1;
+
+    std::vector<std::size_t> numerator_out_shape;
+    const std::vector<T> product_numerator = detail::multiply_nets<T>(
+        numerator_a, numerator_shape_a, numerator_b, numerator_shape_b, binomials,
+        inverse_binomials, numerator_out_shape);
+    const std::vector<T> product_weights =
+        detail::multiply_nets<T>(denominator_a, weight_shape_a, denominator_b, weight_shape_b,
+                                 binomials, inverse_binomials, out_shape);
+
+    // `np.concatenate([h_num, h_den], axis=-1)`.
+    const std::size_t rank = numerator_out_shape.back();
+    const std::size_t coefficients = product_weights.size();
+    out_shape.back() = rank + 1;
+
+    std::vector<T> values(coefficients * (rank + 1));
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        for (std::size_t s = 0; s < rank; ++s) {
+            values[(i * (rank + 1)) + s] = product_numerator[(i * rank) + s];
+        }
+        values[(i * (rank + 1)) + rank] = product_weights[i];
+    }
+    return Bezier<T>(
+        ControlNet<T>(std::span<const T>(values), std::span<const std::size_t>(out_shape)), true);
+}
+
+/// The largest upper binomial index a composition forms.
+///
+/// Two sources, and the second is conditional:
+///
+///  - the Bernstein basis of each outer direction needs `C(m_d, i)`, so `max_d m_d`;
+///  - an **n-dimensional** inner map routes every product through
+///    `bernstein_product_nd`, whose reciprocals reach the composed degree
+///    `sum_d m_d * n_s` in direction `s`.
+///
+/// A **univariate** inner map contributes nothing to the second, because its products
+/// go through `scalar_bernstein_product_1d`, which builds its own coefficients from
+/// `core::bincoeff`. Including it anyway would be an upper bound rather than a wrong
+/// answer, and it is left out for a concrete reason: a degree-1 outer map composed with
+/// a very high degree inner one is exempt from the envelope check -- no product is
+/// formed at all -- so the composed degree there is unbounded, and asking a caller to
+/// tabulate `C(n, k)` up to it would refuse a case both backends handle.
+///
+/// Unlike `product_table_order` this validates nothing. It reads only each operand's
+/// own degrees, so no compatibility between them is required to answer.
+///
+/// \param outer The outer map.
+/// \param inner The inner map.
+/// \return The largest `n` for which `C(n, k)` will be read, so the tables must be at
+///         least `(n + 1, n + 1)`.
+template <Real T>
+[[nodiscard]] std::size_t composition_table_order(const Bezier<T>& outer,
+                                                  const Bezier<T>& inner) {
+    std::size_t order = 0;
+    std::size_t total = 0;
+    for (std::size_t d = 0; d < outer.dim(); ++d) {
+        const std::size_t degree = outer.degree(d);
+        order = (degree > order) ? degree : order;
+        total += degree;
+    }
+    if (inner.dim() > 1) {
+        for (std::size_t s = 0; s < inner.dim(); ++s) {
+            const std::size_t composed = total * inner.degree(s);
+            order = (composed > order) ? composed : order;
+        }
+    }
+    return order;
+}
+
+/// The composition `outer(inner(t))`.
+///
+/// Degree `sum_d m_d * n_s` in direction `s`, which represents the composition
+/// exactly; the coefficients carry the roundings of the products that build them. See
+/// the file comment.
+///
+/// Each outer direction's Bernstein basis is evaluated at the corresponding component
+/// of the inner map, giving `m_d + 1` nets over the inner map's parametric domain;
+/// the outer control points then weight the tensor products of those nets.
+///
+/// \param outer The outer map. Must be non-rational.
+/// \param inner The inner map. Must be non-rational and satisfy
+///        `inner.rank() == outer.dim()`.
+/// \param binomials `C(n, k)` in the storage format, at least
+///        `(composition_table_order + 1)` square.
+/// \param inverse_binomials `1 / C(n, k)` in the storage format, same shape.
+/// \return The composed Bézier, of dimension `inner.dim()` and rank `outer.rank()`.
+/// \throws std::invalid_argument If either operand is rational, if the inner map's rank
+///         is not the outer map's dimension, if a univariate inner map would drive the
+///         composed degree past `core::kBincoeffMaxN`, or if a table is too small.
+template <Real T>
+[[nodiscard]] Bezier<T> compose(const Bezier<T>& outer, const Bezier<T>& inner,
+                                span2d<const T> binomials,
+                                span2d<const T> inverse_binomials) {
+    // The oracle's order and the oracle's messages, character for character. The two
+    // rational rejections are its `TypeError`; see the file comment for why they are an
+    // `std::invalid_argument` here without breaking parity.
+    if (outer.is_rational()) {
+        throw std::invalid_argument(
+            "Composition is not supported for rational Béziers (outer is rational).");
+    }
+    if (inner.is_rational()) {
+        throw std::invalid_argument(
+            "Composition is not supported for rational Béziers (inner is rational).");
+    }
+    if (inner.rank() != outer.dim()) {
+        throw std::invalid_argument("Inner Bézier rank (" + std::to_string(inner.rank())
+                                    + ") must equal outer Bézier parametric dimension ("
+                                    + std::to_string(outer.dim()) + ").");
+    }
+
+    const std::size_t dim_outer = outer.dim();
+    const std::size_t dim_inner = inner.dim();
+    const bool use_1d_kernel = dim_inner == 1;
+
+    std::size_t total_degree = 0;
+    for (std::size_t d = 0; d < dim_outer; ++d) {
+        total_degree += outer.degree(d);
+    }
+
+    // The oracle's exemptions, reproduced with its reasoning: only a univariate inner
+    // map reaches `scalar_bernstein_product_1d`, and a univariate outer map of degree
+    // at most one forms no product at all, so `core::bincoeff` is never called. The
+    // message is `_check_bincoeff_envelope`'s.
+    if (use_1d_kernel && (dim_outer > 1 || outer.degree(0) > 1)) {
+        const std::size_t composed = total_degree * inner.degree(0);
+        detail::require_bincoeff_envelope(composed, "Composition to degree "
+                                                        + std::to_string(composed)
+                                                        + " with a 1D inner Bézier");
+    }
+
+    const std::size_t order = composition_table_order<T>(outer, inner);
+    detail::require_table_extents<T>(binomials, order, "binomials");
+    detail::require_table_extents<T>(inverse_binomials, order, "inverse_binomials");
+
+    std::vector<std::vector<detail::ScalarNet<T>>> all_bases;
+    all_bases.reserve(dim_outer);
+    for (std::size_t d = 0; d < dim_outer; ++d) {
+        all_bases.push_back(detail::bernstein_bases_at<T>(
+            detail::scalar_component<T>(inner.net(), d), outer.degree(d), use_1d_kernel,
+            binomials, inverse_binomials));
+    }
+
+    const std::size_t rank = outer.net().num_components();
+    std::vector<std::size_t> result_shape(dim_inner + 1, rank);
+    for (std::size_t s = 0; s < dim_inner; ++s) {
+        result_shape[s] = (total_degree * inner.degree(s)) + 1;
+    }
+    const std::size_t coefficients = detail::extent_product(result_shape, 0) / rank;
+    std::vector<T> result(coefficients * rank, T(0));
+
+    std::vector<std::size_t> outer_extents(dim_outer);
+    for (std::size_t d = 0; d < dim_outer; ++d) {
+        outer_extents[d] = outer.degree(d) + 1;
+    }
+    const std::size_t outer_count = detail::extent_product(outer_extents, 0);
+
+    std::vector<std::size_t> multi_index(dim_outer);
+    for (std::size_t c = 0; c < outer_count; ++c) {
+        detail::decode_row_major(c, outer_extents, multi_index);
+
+        detail::ScalarNet<T> basis = all_bases[0][multi_index[0]];
+        for (std::size_t d = 1; d < dim_outer; ++d) {
+            basis = detail::scalar_net_product<T>(basis, all_bases[d][multi_index[d]],
+                                                  use_1d_kernel, binomials, inverse_binomials);
+        }
+
+        // `result_ctrl += coef * basis`, with `coef` of shape `(rank,)` broadcast
+        // against a basis whose component axis has extent one.
+        const std::span<const T> outer_values = outer.net().values();
+        for (std::size_t h = 0; h < coefficients; ++h) {
+            for (std::size_t s = 0; s < rank; ++s) {
+                const T weighted = outer_values[(c * rank) + s] * basis.values[h];
+                result[(h * rank) + s] = result[(h * rank) + s] + weighted;
+            }
+        }
+    }
+
+    return Bezier<T>(ControlNet<T>(std::span<const T>(result),
+                                   std::span<const std::size_t>(result_shape)),
+                     false);
+}
+
+}  // namespace pantr::bezier

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -163,9 +163,21 @@
 /// continuations in that recipe: a `///` line ending in a backslash is one comment
 /// spanning two lines, which this build rejects under `-Werror=comment`, and it did.)
 ///
-/// `off` and `on` agree bit for bit; `=fast` does not, so the site is contractible in
-/// principle and the claim keeps its bounded arm for a build that reaches it. What
-/// follows for a reader:
+/// The three settings do not order the way one expects, and the two accumulation sites
+/// here disagree with each other, which is why this is stated per site rather than once.
+/// Observed on GCC 14.4.0 at `-O2` and `-O3 -DNDEBUG`, both with `-mavx2 -mfma`; it is
+/// an instruction-selection fact about one toolchain, not a portable consequence of what
+/// `on` and `fast` are defined to permit, so re-measure rather than assume it elsewhere.
+///
+///  - `scalar_bernstein_product_1d` fuses under `=on` and NOT under `off` or `fast`:
+///    `off` and `fast` are bit-identical, and `on` moves about two fifths of the
+///    elements. That is the direction that matters here, because this project compiles
+///    with `-ffp-contract=on` (`CMakeLists.txt`).
+///  - `bernstein_product_1d`, the product's own site, goes the other way: `off` and `on`
+///    agree and `=fast` fuses.
+///
+/// So both sites are contractible in principle, under different settings, and the claim
+/// keeps its bounded arm for a build that reaches either. What follows for a reader:
 ///
 ///  - **`multiply`'s equality survives an FMA host at this project's own flags.** The
 ///    parity harness selects its arm from the ISA rather than from the contraction

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -101,11 +101,19 @@
 /// kernel's envelope into an operation that does not have one, which is a numerics
 /// change and not a port.
 ///
-/// Widening the native recurrence would move that envelope rather than remove it:
-/// `unsigned __int128` reaches about degree 130 and then stops for the same reason. The
-/// oracle's domain is unbounded, so a table crossing is what matches it. This is a
-/// smaller gap than `degree.hpp`'s, and it is cheaper to close if anyone decides the
-/// bound is worth having natively -- which is a decision, not an omission.
+/// Widening the native recurrence would move that envelope rather than remove it.
+/// `binomial.hpp` states the criterion -- the largest intermediate is
+/// `C(n, k) * min(k, n - k)` -- and that criterion reproduces `kBincoeffMaxN`'s 61 for
+/// `int64` exactly, so it is the one to apply. Applied to `__int128` it gives degree
+/// **124** signed and 125 unsigned. The oracle's domain is unbounded either way, so a
+/// table crossing is what matches it; this is a smaller gap than `degree.hpp`'s, and it
+/// is cheaper to close if anyone decides the bound is worth having natively -- which is
+/// a decision, not an omission.
+///
+/// (An earlier draft said "about 130" here. That is what the *central* binomial
+/// `C(n, n/2)` alone gives, dropping the `min(k, n - k)` factor this file had just
+/// named as the binding one. A round number arrived at by a criterion other than the
+/// one stated beside it is the shape of error worth leaving a note about.)
 ///
 /// **The consequence, stated plainly:** a C++ caller with no Python cannot multiply
 /// or compose unaided, and must supply tables it obtained elsewhere.

--- a/cpp/include/pantr/bezier/product.hpp
+++ b/cpp/include/pantr/bezier/product.hpp
@@ -40,6 +40,32 @@
 /// reading it off the surrounding module is how a port gets it wrong at `float32`
 /// while agreeing at `float64`.
 ///
+/// ### Where widening would actually change the answer, and where it provably would not
+///
+/// Worth being precise, because two of the mutations
+/// `tests/parity/test_bezier_product.py` records **survive the parity suite** and a
+/// reader is entitled to know whether that is a gap in the tests or a fact about the
+/// arithmetic. It is the second, and the rule is one line: **widening a single
+/// operation whose result is immediately narrowed back to `T` cannot change it;
+/// widening a chain of two or more can.**
+///
+///  - A single **product** of two `float32` values is *exact* in `double` -- the
+///    result needs at most 48 significand bits and `double` has 53 -- so narrowing it
+///    is the one rounding either way. That covers `bernstein_product_nd`'s weighting
+///    of its operands and its final reciprocal scaling.
+///  - A single **sum** of two `float32` values is not exact in `double`, but double
+///    rounding through it equals single rounding, because `double`'s 53 bits exceed
+///    `2 * 24 + 2` (Figueroa, *Yet another proof of the double rounding theorem*,
+///    1995 -- the same theorem `_binomial_tables` rests on). That covers the
+///    accumulation `d[k] + term`.
+///  - The **chain** `(coefficient * f_i) * g_j` is where the width bites: widened, the
+///    intermediate is not narrowed, so the second multiplication receives a different
+///    operand. Nine `float32` cases move when it is, which is what pins the claim.
+///
+/// So the code says `T` throughout because that is what the oracle says and it is the
+/// simplest form that is right; the paragraph above is what a future reader needs in
+/// order to tell a harmless widening from a defect.
+///
 /// `compose` mixes the two, because its oracle does. Its Bernstein products go
 /// through `scalar_bernstein_product_1d` for a univariate inner map -- a numba kernel,
 /// so `accumulator_t<T>` inside it -- and through `bernstein_product_nd` above that,

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -25,7 +25,8 @@ set(PANTR_TEST_SOURCES
     test_grid_tags.cpp
     test_grid_partition.cpp
     test_grid_bvh_type.cpp
-    test_grid_defaults.cpp)
+    test_grid_defaults.cpp
+    test_bezier_product.cpp)
 
 # Reserved slots (FELIGN/pantr#380): registered ahead of the port so the thirteen
 # tickets this milestone unblocks do not collide on this file. Each asserts nothing
@@ -44,8 +45,7 @@ set(PANTR_TEST_SOURCES
 # Delete each entry from this list as its ticket fills the slot; when the list is
 # empty, delete the list.
 set(PANTR_PLACEHOLDER_TEST_SOURCES
-    test_grid_tensor_product.cpp
-    test_bezier_product.cpp)
+    test_grid_tensor_product.cpp)
 
 foreach(_src IN LISTS PANTR_TEST_SOURCES PANTR_PLACEHOLDER_TEST_SOURCES)
   cmake_path(GET _src STEM _name)

--- a/cpp/tests/test_bezier_product.cpp
+++ b/cpp/tests/test_bezier_product.cpp
@@ -1,17 +1,1409 @@
 /// \file
-/// Reserved slot for the Bezier products tests -- no assertions yet.
+/// Mathematical properties of `pantr::bezier::multiply`, `pantr::bezier::compose`
+/// and their table-sizing helpers, from `pantr/bezier/product.hpp`.
 ///
-/// Registered ahead of the port so the ticket that writes these tests does not
-/// edit `cpp/tests/CMakeLists.txt`, which thirteen tickets in this milestone
-/// would otherwise collide on. It passes because it checks nothing, and says so
-/// on stdout: a green ctest line from this file means "not written yet", never
-/// "the port is correct".
+/// ## This is NOT a parity test
+///
+/// `tests/parity/test_bezier_product.py` compares both entry points against
+/// their NumPy/Numba oracles. Nothing here repeats that comparison, and nothing
+/// here compares the two backends at all. Every assertion below is against a
+/// property the mathematics fixes exactly, against an independently-derived
+/// bound on the floating-point rounding a computation carries, or against a
+/// second computation of the same quantity by a different route (a division
+/// where the code multiplies, or `evaluate` where the code did not evaluate at
+/// all) -- the same discipline `test_bezier_shape.cpp` and
+/// `test_bezier_degree.cpp` already use, and for the same reason: a comparison
+/// against an oracle cannot catch a bug the port and the oracle share.
+///
+/// ## Where every tolerance comes from
+///
+/// Three related budgets recur, all built from Higham's standard bound for a
+/// chain of `n` relative perturbations of size at most `eps` each, composed in
+/// any order: `gamma_n = n*eps / (1 - n*eps)` (Higham, *Accuracy and Stability
+/// of Numerical Algorithms*, 2nd ed., Lemma 3.1).
+///
+///  1. **`multiply`'s own construction budget.** Every intermediate in
+///     `bernstein_product_1d` and `bernstein_product_nd` is `T` (product.hpp's
+///     file comment), and a coefficient at index `gamma` carries at most
+///     `S + 6` roundings, where `S = prod_d (min(p_d, q_d) + 1)` is the largest
+///     number of terms landing in one output coefficient. Because the
+///     Bernstein product's weights `C(p,i)C(q,j)/C(p+q,k)` are non-negative and
+///     sum to one over the terms reaching a given `k` (Vandermonde's identity),
+///     the *reachable* magnitude at `gamma` is exactly the same product run on
+///     the absolute values of both operands -- call that array `A`. So
+///     `|h_gamma - exact_gamma| <= gamma_n(S + 6, eps) * A_gamma`, and
+///     contracting with the (non-negative, partition-of-unity) Bernstein basis
+///     gives `|h_exact(t) - f_exact(t) g_exact(t)| <= gamma_n(S + 6, eps) *
+///     evaluate(A_as_a_bezier, t)`.
+///  2. **`evaluate`'s own contraction budget**, `gamma_n(stages, eps)` with
+///     `stages = sum_d (degree_d + 1)`, exactly as `evaluate.hpp`'s file
+///     comment and `test_bezier_evaluate.cpp` derive it.
+///  3. **Products of independently-evaluated quantities** carry one further
+///     `gamma_n` per multiplication or division committed combining them.
+///
+/// `check_product_evaluated_equals_product_of_evaluations` composes budgets 1
+/// and 2 (once for `h`, once each for `f` and `g`, the latter multiplied
+/// together per budget 3). `check_rational_product_projects_correctly`
+/// propagates that same numerator budget through the rational quotient.
+/// `check_composition_evaluated_matches_outer_at_inner_value` composes an
+/// analogous *chain* budget for `compose`, admittedly coarser: see that
+/// check's own comment for where the margin is charged.
+///
+/// Every companion "run on the absolute values" (`A`, `|f|`, `|g|`, `|h|`, ...)
+/// is computed in `double` regardless of `T`, because these are *magnitudes
+/// bounding the true budget*, not results the port claims to reproduce; running
+/// them at `T` would let the companion itself go slack from `T`'s own rounding
+/// and silently loosen the bound it is supposed to certify. The `gamma_n`
+/// prefactor is still evaluated at `T`'s own epsilon, because that is what
+/// actually governs the rounding of the real, `T`-typed computation being
+/// bounded.
+///
+/// ## What each check would catch
+///
+///  - **P1** (`check_product_evaluated_equals_product_of_evaluations`): a wrong
+///    binomial weight, a term routed to the wrong output coefficient, or an
+///    accumulation order that silently drifts outside its own stated budget.
+///  - **P2** (`check_product_shape_and_rationality`): a wrong output degree, a
+///    dropped rank or dimension, or a rationality flag that does not follow
+///    "rational whenever either operand is."
+///  - **P3** (`check_product_is_commutative_within_budget`): an asymmetric bug
+///    that only one operand order exercises -- a swapped `f`/`g` inside a
+///    single branch, for instance -- while still asserting a genuine floating-
+///    point (not bit-exact) claim, since the two operand orders are different
+///    computations.
+///  - **P4** (`check_rational_product_projects_correctly`): a wrong
+///    numerator/denominator split, or the weight column leaking into the
+///    linear part of the product.
+///  - **P5** (`check_product_table_order`, `check_product_rejections`): a wrong
+///    table-sizing formula, or a validation whose message has drifted from the
+///    oracle's.
+///  - **C1** (`check_composing_with_identity_reproduces_outer`): a wrong
+///    `bernstein_bases_at` recurrence, caught at the one point where the
+///    algebra collapses to "reproduce the input," in both the 1-D and the
+///    n-D (`bernstein_product_nd`-routed) composition path.
+///  - **C2** (`check_composition_evaluated_matches_outer_at_inner_value`): a
+///    wrong composition formula in general (not merely at the identity), on
+///    configurations exercising every routing combination `use_1d_kernel`
+///    chooses between.
+///  - **C3** (`check_composition_shape`, `check_composition_rejections`): a
+///    wrong composed degree formula, a wrong `composition_table_order` branch,
+///    or a validation message that has drifted from the oracle's.
+///
+/// ## Test-scaffolding binomial tables
+///
+/// `multiply` and `compose` take their binomial tables as arguments (the
+/// library assembles them once, in exact arithmetic, on the Python side; see
+/// `product.hpp`'s file comment). A C++-only caller -- this file -- has to
+/// build its own, and `math.comb` has no C++ equivalent that reaches the
+/// degrees this file exercises. `build_binomial_tables` below does it with a
+/// Pascal-triangle recurrence in `long double`, cast down to `T` at the end.
+/// **This is test scaffolding, not what the library does**: production tables
+/// come from Python's arbitrary-precision `math.comb`, rounded once.
+/// `check_binomial_table_matches_bincoeff` checks this scaffolding's low-degree
+/// entries against `pantr::core::bincoeff` exactly, so a defective table here
+/// cannot silently make every other check in this file pass for the wrong
+/// reason.
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "check.hpp"
+#include "pantr/bezier/bezier.hpp"
+#include "pantr/bezier/evaluate.hpp"
+#include "pantr/bezier/product.hpp"
+#include "pantr/core/binomial.hpp"
+#include "pantr/core/mdspan.hpp"
+
+namespace {
+
+using pantr::span2d;
+using pantr::bezier::Bezier;
+using pantr::bezier::ControlNet;
+using pantr::bezier::evaluate;
+
+/// Alias for the functions under test, matching `test_bezier_shape.cpp`'s
+/// convention.
+namespace ops = pantr::bezier;
+
+/// Higham's standard bound for a chain of `n` relative perturbations of size at
+/// most `eps` each, composed in any order: `gamma_n = n*eps / (1 - n*eps)`
+/// (Higham, *Accuracy and Stability of Numerical Algorithms*, 2nd ed., Lemma
+/// 3.1). The same helper every other `test_bezier_*.cpp` file defines for the
+/// same reason.
+///
+/// \param n The number of perturbations composed.
+/// \param eps The scalar type's machine epsilon.
+/// \return The relative bound `gamma_n`.
+double gamma_n(std::size_t n, double eps) {
+    const double n_eps = static_cast<double>(n) * eps;
+    return n_eps / (1.0 - n_eps);
+}
+
+/// The total number of terms `evaluate`'s own contraction sums across every
+/// parametric direction: `sum_d (degree_d + 1)`, `evaluate.hpp`'s own `stages`.
+///
+/// \param degrees One degree per direction.
+/// \return The summed extent.
+std::size_t stages_of(const std::vector<std::size_t>& degrees) {
+    std::size_t total = 0;
+    for (const std::size_t d : degrees) {
+        total += d + 1;
+    }
+    return total;
+}
+
+/// Build a Bézier from a flat coefficient list and a shape, for brevity below.
+///
+/// \param values The coefficients, row-major.
+/// \param shape The control-net shape, `(extent(0), ..., num_components())`.
+/// \param is_rational Whether the last component is a homogeneous weight.
+/// \return The Bézier.
+template <class T>
+Bezier<T> make_bezier(std::vector<T> values, std::vector<std::size_t> shape, bool is_rational) {
+    return Bezier<T>(
+        ControlNet<T>(std::span<const T>(values), std::span<const std::size_t>(shape)),
+        is_rational);
+}
+
+/// Evaluate `bez` at a list of parameter points, for brevity below.
+///
+/// \param bez The Bézier.
+/// \param samples One parameter tuple per sample, `bez.dim()` entries each.
+/// \return The values, row-major flattened as `(samples.size(), bez.rank())`
+///         but returned as a flat vector since every call site here reads a
+///         single sample.
+template <class T>
+std::vector<T> evaluate_at(const Bezier<T>& bez, const std::vector<std::vector<T>>& samples) {
+    const std::size_t dim = bez.dim();
+    const std::size_t rank = bez.rank();
+    std::vector<T> pts(samples.size() * dim);
+    for (std::size_t k = 0; k < samples.size(); ++k) {
+        for (std::size_t d = 0; d < dim; ++d) {
+            pts[(k * dim) + d] = samples[k][d];
+        }
+    }
+    const span2d<const T> pts_view(pts.data(), samples.size(), dim);
+    std::vector<T> out(samples.size() * rank);
+    const span2d<T> out_view(out.data(), samples.size(), rank);
+    evaluate<T>(bez, pts_view, out_view);
+    return out;
+}
+
+/// Evaluate `bez` at one parameter tuple.
+///
+/// \param bez The Bézier.
+/// \param t The parameter tuple, `bez.dim()` entries.
+/// \return The `bez.rank()` values at `t`.
+template <class T>
+std::vector<T> evaluate_one(const Bezier<T>& bez, const std::vector<T>& t) {
+    return evaluate_at<T>(bez, {t});
+}
+
+/// The message of the `std::invalid_argument` that `fn` throws.
+///
+/// \param fn The call to attempt.
+/// \return The exception's `what()`, or a marker saying what happened instead.
+template <class F>
+std::string message_of(F&& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument& e) {
+        return e.what();
+    } catch (...) {
+        return "<threw something other than std::invalid_argument>";
+    }
+    return "<did not throw>";
+}
+
+// ---------------------------------------------------------------------------
+// A tiny, deterministic PRNG (test scaffolding, not the library).
+// ---------------------------------------------------------------------------
+
+/// A 64-bit linear congruential generator, seeded explicitly by every caller.
+///
+/// Deliberately not `<random>`'s default engine: this file wants a fixed,
+/// portable sequence from a fixed seed so a failure is reproducible across
+/// machines, and a hand-rolled LCG is a few lines against `<random>`'s
+/// unspecified-by-standard engine internals.
+class Lcg64 {
+  public:
+    explicit Lcg64(std::uint64_t seed) : state_(seed | std::uint64_t{1}) {}
+
+    /// The next value, uniform in `[0, 1)`.
+    double uniform01() {
+        state_ = (state_ * kMultiplier) + kIncrement;
+        const std::uint64_t bits = state_ >> 11;
+        return static_cast<double>(bits) * kScale;
+    }
+
+  private:
+    static constexpr std::uint64_t kMultiplier = 6364136223846793005ULL;
+    static constexpr std::uint64_t kIncrement = 1442695040888963407ULL;
+    static constexpr double kScale = 1.0 / 9007199254740992.0;  // 2^-53
+
+    std::uint64_t state_;
+};
+
+/// A pseudo-random value spanning about three decades, `[1e-1, 1e2]` in
+/// magnitude, signed.
+///
+/// \param rng The generator, advanced by two draws.
+/// \return The value.
+double random_value_three_decades(Lcg64& rng) {
+    const double magnitude = std::pow(10.0, -1.0 + (3.0 * rng.uniform01()));
+    const double sign = (rng.uniform01() < 0.5) ? -1.0 : 1.0;
+    return sign * magnitude;
+}
+
+/// A pseudo-random value in `[0, 1]`, for an inner map's coefficients.
+///
+/// \param rng The generator, advanced by one draw.
+/// \return The value.
+double random_value_unit(Lcg64& rng) { return rng.uniform01(); }
+
+/// A non-rational Bézier with pseudo-random control points spanning about
+/// three decades in magnitude, signed.
+///
+/// \param degrees The degree in every parametric direction.
+/// \param rank The number of value components.
+/// \param seed The generator seed; distinct seeds give distinct nets.
+/// \return The Bézier.
+template <class T>
+Bezier<T> random_bezier(const std::vector<std::size_t>& degrees, std::size_t rank,
+                        std::uint64_t seed) {
+    Lcg64 rng(seed);
+    const std::size_t dim = degrees.size();
+    std::vector<std::size_t> shape(dim + 1);
+    for (std::size_t d = 0; d < dim; ++d) {
+        shape[d] = degrees[d] + 1;
+    }
+    shape.back() = rank;
+
+    std::size_t total = 1;
+    for (const std::size_t extent : shape) {
+        total *= extent;
+    }
+    std::vector<T> values(total);
+    for (std::size_t i = 0; i < total; ++i) {
+        values[i] = static_cast<T>(random_value_three_decades(rng));
+    }
+    return make_bezier<T>(std::move(values), shape, false);
+}
+
+/// A non-rational Bézier with pseudo-random control points in `[0, 1]`, for
+/// use as an inner map: the composition budget's absolute-value companion is
+/// exact only while the inner map's own coefficients are non-negative.
+///
+/// \param degrees The degree in every parametric direction.
+/// \param rank The number of value components.
+/// \param seed The generator seed.
+/// \return The Bézier.
+template <class T>
+Bezier<T> random_unit_bezier(const std::vector<std::size_t>& degrees, std::size_t rank,
+                             std::uint64_t seed) {
+    Lcg64 rng(seed);
+    const std::size_t dim = degrees.size();
+    std::vector<std::size_t> shape(dim + 1);
+    for (std::size_t d = 0; d < dim; ++d) {
+        shape[d] = degrees[d] + 1;
+    }
+    shape.back() = rank;
+
+    std::size_t total = 1;
+    for (const std::size_t extent : shape) {
+        total *= extent;
+    }
+    std::vector<T> values(total);
+    for (std::size_t i = 0; i < total; ++i) {
+        values[i] = static_cast<T>(random_value_unit(rng));
+    }
+    return make_bezier<T>(std::move(values), shape, false);
+}
+
+/// A rational Bézier with pseudo-random numerator control points spanning
+/// about three decades and weights bounded in `[0.5, 2]`, so that no division
+/// in `check_rational_product_projects_correctly` amplifies wildly.
+///
+/// \param degrees The degree in every parametric direction.
+/// \param rank The number of value components, weight column excluded.
+/// \param seed The generator seed.
+/// \return The rational Bézier.
+template <class T>
+Bezier<T> random_rational_bezier(const std::vector<std::size_t>& degrees, std::size_t rank,
+                                 std::uint64_t seed) {
+    Lcg64 rng(seed);
+    const std::size_t dim = degrees.size();
+    std::vector<std::size_t> shape(dim + 1);
+    for (std::size_t d = 0; d < dim; ++d) {
+        shape[d] = degrees[d] + 1;
+    }
+    shape.back() = rank + 1;
+
+    std::size_t coefficients = 1;
+    for (std::size_t d = 0; d < dim; ++d) {
+        coefficients *= shape[d];
+    }
+    std::vector<T> values(coefficients * (rank + 1));
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        for (std::size_t s = 0; s < rank; ++s) {
+            values[(i * (rank + 1)) + s] = static_cast<T>(random_value_three_decades(rng));
+        }
+        const double weight = 0.5 + (1.5 * rng.uniform01());  // [0.5, 2]
+        values[(i * (rank + 1)) + rank] = static_cast<T>(weight);
+    }
+    return make_bezier<T>(std::move(values), shape, true);
+}
+
+/// A copy of `bez` widened to `double`, with every stored value replaced by
+/// its absolute value: the magnitude companion `A`, `|f|`, `|h|`, ... every
+/// bounded check below is stated in terms of, and always computed in `double`
+/// regardless of the source's storage type. See the file comment.
+///
+/// \param bez The Bézier to widen and take the absolute value of.
+/// \return The companion, non-rational (the weight column, if any, is treated
+///         as an ordinary stored value; every caller below only ever applies
+///         this to a non-rational operand).
+template <class T>
+Bezier<double> abs_double_bezier(const Bezier<T>& bez) {
+    const std::span<const T> src = bez.net().values();
+    std::vector<double> values(src.size());
+    for (std::size_t i = 0; i < src.size(); ++i) {
+        values[i] = std::abs(static_cast<double>(src[i]));
+    }
+    const std::span<const std::size_t> shape = bez.net().shape();
+    return make_bezier<double>(std::move(values),
+                               std::vector<std::size_t>(shape.begin(), shape.end()), false);
+}
+
+/// A copy of `bez` widened to `double`, values unchanged.
+///
+/// \param bez The Bézier to widen.
+/// \return The widened Bézier, same rationality flag.
+template <class T>
+Bezier<double> to_double_bezier(const Bezier<T>& bez) {
+    const std::span<const T> src = bez.net().values();
+    std::vector<double> values(src.size());
+    for (std::size_t i = 0; i < src.size(); ++i) {
+        values[i] = static_cast<double>(src[i]);
+    }
+    const std::span<const std::size_t> shape = bez.net().shape();
+    return make_bezier<double>(std::move(values),
+                               std::vector<std::size_t>(shape.begin(), shape.end()),
+                               bez.is_rational());
+}
+
+/// One parameter tuple, widened to `double`.
+///
+/// \param t The tuple, at `T`.
+/// \return The same tuple, at `double`.
+template <class T>
+std::vector<double> widen(const std::vector<T>& t) {
+    return std::vector<double>(t.begin(), t.end());
+}
+
+/// A non-rational Bézier holding only the numerator of a rational one: the
+/// first `rank` stored components of every coefficient.
+///
+/// \param rational The rational Bézier.
+/// \return The numerator net, rank `rational.rank()`, non-rational.
+template <class T>
+Bezier<T> extract_numerator(const Bezier<T>& rational) {
+    const ControlNet<T>& net = rational.net();
+    const std::size_t components = net.num_components();
+    const std::size_t rank = components - 1;
+    const std::size_t coefficients = net.size() / components;
+    std::vector<T> values(coefficients * rank);
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        for (std::size_t s = 0; s < rank; ++s) {
+            values[(i * rank) + s] = net.values()[(i * components) + s];
+        }
+    }
+    std::vector<std::size_t> shape(net.shape().begin(), net.shape().end());
+    shape.back() = rank;
+    return make_bezier<T>(std::move(values), std::move(shape), false);
+}
+
+/// A rank-1, non-rational Bézier holding only the weight column of a rational
+/// one.
+///
+/// \param rational The rational Bézier.
+/// \return The weight net, rank 1, non-rational.
+template <class T>
+Bezier<T> extract_weight(const Bezier<T>& rational) {
+    const ControlNet<T>& net = rational.net();
+    const std::size_t components = net.num_components();
+    const std::size_t coefficients = net.size() / components;
+    std::vector<T> values(coefficients);
+    for (std::size_t i = 0; i < coefficients; ++i) {
+        values[i] = net.values()[(i * components) + components - 1];
+    }
+    std::vector<std::size_t> shape(net.shape().begin(), net.shape().end());
+    shape.back() = 1;
+    return make_bezier<T>(std::move(values), std::move(shape), false);
+}
+
+// ---------------------------------------------------------------------------
+// Test-scaffolding binomial tables (see the file comment).
+// ---------------------------------------------------------------------------
+
+/// `C(n, k)` and `1 / C(n, k)` at the storage format, for every `n, k <=
+/// order`, built by a Pascal-triangle recurrence in `long double` and cast
+/// down at the end.
+///
+/// Test scaffolding only: the library never assembles these itself (see the
+/// file comment and `product.hpp`'s own).
+template <class T>
+struct BinomialTables {
+    std::vector<T> binom;      ///< `(order + 1, order + 1)` row-major, `C(n, k)`.
+    std::vector<T> inv_binom;  ///< Likewise, `1 / C(n, k)`.
+    std::size_t order = 0;     ///< The largest upper index the tables reach.
+
+    /// A view suitable for `multiply`'s or `compose`'s `binomials` argument.
+    [[nodiscard]] span2d<const T> binom_view() const {
+        return span2d<const T>(binom.data(), order + 1, order + 1);
+    }
+
+    /// A view suitable for `multiply`'s or `compose`'s `inverse_binomials`
+    /// argument.
+    [[nodiscard]] span2d<const T> inv_view() const {
+        return span2d<const T>(inv_binom.data(), order + 1, order + 1);
+    }
+};
+
+/// Build `BinomialTables<T>` reaching upper index `order`.
+///
+/// \param order The largest `n` (and `k`) the tables must answer for.
+/// \return The tables, `(order + 1, order + 1)` each.
+template <class T>
+BinomialTables<T> build_binomial_tables(std::size_t order) {
+    const std::size_t width = order + 1;
+    std::vector<long double> pascal(width * width, 0.0L);
+    const auto at_ld = [&](std::size_t n, std::size_t k) -> long double& {
+        return pascal[(n * width) + k];
+    };
+    for (std::size_t n = 0; n <= order; ++n) {
+        at_ld(n, 0) = 1.0L;
+        for (std::size_t k = 1; k <= n; ++k) {
+            const long double left = at_ld(n - 1, k - 1);
+            const long double right = (k <= n - 1) ? at_ld(n - 1, k) : 0.0L;
+            at_ld(n, k) = left + right;
+        }
+    }
+
+    BinomialTables<T> tables;
+    tables.order = order;
+    tables.binom.assign(width * width, T(0));
+    tables.inv_binom.assign(width * width, T(0));
+    for (std::size_t n = 0; n <= order; ++n) {
+        for (std::size_t k = 0; k <= n; ++k) {
+            const long double c = at_ld(n, k);
+            tables.binom[(n * width) + k] = static_cast<T>(c);
+            tables.inv_binom[(n * width) + k] = static_cast<T>(1.0L / c);
+        }
+    }
+    return tables;
+}
+
+/// The scaffolding's `C(n, k)` agrees with `pantr::core::bincoeff` exactly for
+/// every `n <= 20`: every such binomial is well under `2^53`, so both routes
+/// are exact integers and there is no rounding to argue a tolerance over. Pins
+/// the scaffolding itself, so a defective table cannot make every other check
+/// below pass for the wrong reason.
+void check_binomial_table_matches_bincoeff() {
+    const BinomialTables<double> tables = build_binomial_tables<double>(20);
+    for (int n = 0; n <= 20; ++n) {
+        for (int k = 0; k <= n; ++k) {
+            const double expected = pantr::core::bincoeff(n, k);
+            const double got =
+                tables.binom[(static_cast<std::size_t>(n) * 21) + static_cast<std::size_t>(k)];
+            PANTR_CHECK_MSG(got == expected,
+                            "the test's own Pascal-recurrence binomial table disagreed with "
+                            "pantr::core::bincoeff for n <= 20, where both must be exact");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P1: the product evaluated equals the product of the evaluations.
+// ---------------------------------------------------------------------------
+
+/// The per-sample error model for `multiply(f, g, ...)`, composing budgets 1
+/// through 3 of the file comment. Reused unchanged for the rational
+/// numerator's own budget in `check_rational_product_projects_correctly`,
+/// since a rational product's numerator is exactly a non-rational product of
+/// the two numerator nets.
+template <class T>
+struct ProductErrorModel {
+    Bezier<T> h;             ///< `multiply<T>(f, g, ...)`.
+    Bezier<double> a;        ///< Budget 1's companion, `multiply<double>(|f|, |g|, ...)`.
+    Bezier<double> f_abs_d;  ///< Budget 3's companion, `|f|` at `double`.
+    Bezier<double> g_abs_d;  ///< Budget 3's companion, `|g|` at `double`.
+    Bezier<double> h_abs_d;  ///< Budget 2's companion, `|h|` at `double`.
+    double gamma_construction = 0.0;  ///< `gamma_n(S + 6, eps_t)`.
+    double gamma_evaluate_h = 0.0;    ///< `gamma_n(E_h, eps_t)`.
+    double gamma_evaluate_fg = 0.0;   ///< `gamma_n(E_f + E_g + 1, eps_t)`.
+
+    ProductErrorModel(const Bezier<T>& f, const Bezier<T>& g, span2d<const T> binom_t,
+                      span2d<const T> inv_t, span2d<const double> binom_d,
+                      span2d<const double> inv_d)
+        : h(ops::multiply<T>(f, g, binom_t, inv_t)),
+          a(ops::multiply<double>(abs_double_bezier<T>(f), abs_double_bezier<T>(g), binom_d,
+                                  inv_d)),
+          f_abs_d(abs_double_bezier<T>(f)),
+          g_abs_d(abs_double_bezier<T>(g)),
+          h_abs_d(abs_double_bezier<T>(h)) {
+        const double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+        std::size_t s_terms = 1;
+        for (std::size_t d = 0; d < f.dim(); ++d) {
+            const std::size_t min_pq = std::min(f.degree(d), g.degree(d));
+            s_terms *= (min_pq + 1);
+        }
+        const std::size_t e_h = stages_of(h.degree());
+        const std::size_t e_f = stages_of(f.degree());
+        const std::size_t e_g = stages_of(g.degree());
+        gamma_construction = gamma_n(s_terms + 6, eps_t);
+        gamma_evaluate_h = gamma_n(e_h, eps_t);
+        gamma_evaluate_fg = gamma_n(e_f + e_g + 1, eps_t);
+    }
+
+    /// The bound on `|evaluate(h, t)[s] - evaluate(f, t)[s] * evaluate(g, t)[s]|`
+    /// at every component `s`.
+    ///
+    /// \param t The parameter tuple, at `T`.
+    /// \return One bound per component of `h`.
+    [[nodiscard]] std::vector<double> bound_at(const std::vector<T>& t) const {
+        const std::vector<double> t_d = widen<T>(t);
+        const std::vector<double> a_val = evaluate_one<double>(a, t_d);
+        const std::vector<double> h_abs_val = evaluate_one<double>(h_abs_d, t_d);
+        const std::vector<double> f_abs_val = evaluate_one<double>(f_abs_d, t_d);
+        const std::vector<double> g_abs_val = evaluate_one<double>(g_abs_d, t_d);
+        const std::size_t rank = h.rank();
+        std::vector<double> bound(rank);
+        for (std::size_t s = 0; s < rank; ++s) {
+            bound[s] = (gamma_construction * a_val[s]) + (gamma_evaluate_h * h_abs_val[s])
+                     + (gamma_evaluate_fg * f_abs_val[s] * g_abs_val[s]);
+        }
+        return bound;
+    }
+};
+
+/// One parameter tuple per "corner-ish" value, plus a couple of mixed tuples
+/// once `dim > 1` so no direction is left untested against the others: `0, 1,
+/// 0.9, 0.1` (per the ticket) and two interior values.
+///
+/// \param dim The number of parametric directions.
+/// \return The tuples, each of length `dim`.
+std::vector<std::vector<double>> unit_sample_tuples(std::size_t dim) {
+    static const std::vector<double> kBase{0.0, 1.0, 0.9, 0.1, 0.37, 0.63};
+    std::vector<std::vector<double>> samples;
+    for (const double v : kBase) {
+        samples.emplace_back(dim, v);
+    }
+    if (dim > 1) {
+        std::vector<double> mixed_a(dim);
+        std::vector<double> mixed_b(dim);
+        for (std::size_t d = 0; d < dim; ++d) {
+            mixed_a[d] = kBase[d % kBase.size()];
+            mixed_b[d] = kBase[(d + 2) % kBase.size()];
+        }
+        samples.push_back(mixed_a);
+        samples.push_back(mixed_b);
+    }
+    return samples;
+}
+
+/// One product configuration: the degrees of the two operands.
+struct ProductCase {
+    std::vector<std::size_t> degrees_f;
+    std::vector<std::size_t> degrees_g;
+};
+
+/// The configurations `check_product_evaluated_equals_product_of_evaluations`
+/// and `check_product_is_commutative_within_budget` share, at ranks 1 and 3:
+/// two univariate pairs at unequal small degrees, one with a degree-0 operand
+/// (`S = 1`, the minimal overlap), one surface and one volume.
+const std::vector<ProductCase>& product_cases() {
+    static const std::vector<ProductCase> kCases{
+        {{3}, {2}}, {{1}, {5}}, {{0}, {4}}, {{2, 2}, {1, 3}}, {{1, 1, 1}, {2, 1, 2}}};
+    return kCases;
+}
+
+/// P1: `evaluate(multiply(f, g, ...), t)` equals `evaluate(f, t) *
+/// evaluate(g, t)` componentwise, within `ProductErrorModel`'s bound, at
+/// every configuration of `product_cases()`, at ranks 1 and 3, at a spread of
+/// parameter tuples including the domain's corners. Would catch a wrong
+/// binomial weight, a misrouted term, or an accumulation order that drifts
+/// past its own stated budget.
+///
+/// \param label The scalar type's name, for the worst-ratio report.
+template <class T>
+void check_product_evaluated_equals_product_of_evaluations(const char* label) {
+    double worst_ratio = 0.0;
+    std::size_t case_index = 0;
+    for (const ProductCase& c : product_cases()) {
+        for (const std::size_t rank : {std::size_t{1}, std::size_t{3}}) {
+            const std::uint64_t seed_f = (1000ULL * case_index) + (10ULL * rank) + 1ULL;
+            const std::uint64_t seed_g = (1000ULL * case_index) + (10ULL * rank) + 2ULL;
+            const Bezier<T> f = random_bezier<T>(c.degrees_f, rank, seed_f);
+            const Bezier<T> g = random_bezier<T>(c.degrees_g, rank, seed_g);
+
+            const std::size_t order = ops::product_table_order<T>(f, g);
+            const BinomialTables<T> tables_t = build_binomial_tables<T>(order);
+            const BinomialTables<double> tables_d = build_binomial_tables<double>(order);
+            const ProductErrorModel<T> model(f, g, tables_t.binom_view(), tables_t.inv_view(),
+                                             tables_d.binom_view(), tables_d.inv_view());
+
+            const std::size_t dim = c.degrees_f.size();
+            for (const std::vector<double>& sample_d : unit_sample_tuples(dim)) {
+                std::vector<T> t(dim);
+                for (std::size_t d = 0; d < dim; ++d) {
+                    t[d] = static_cast<T>(sample_d[d]);
+                }
+                const std::vector<T> h_val = evaluate_one<T>(model.h, t);
+                const std::vector<T> f_val = evaluate_one<T>(f, t);
+                const std::vector<T> g_val = evaluate_one<T>(g, t);
+                const std::vector<double> bound = model.bound_at(t);
+
+                for (std::size_t s = 0; s < rank; ++s) {
+                    const double diff =
+                        std::abs(static_cast<double>(h_val[s])
+                                 - (static_cast<double>(f_val[s]) * static_cast<double>(g_val[s])));
+                    PANTR_CHECK_MSG(diff <= bound[s],
+                                    "the product evaluated did not equal the product of the "
+                                    "evaluations within its construction-plus-evaluation budget");
+                    if (bound[s] > 0.0) {
+                        worst_ratio = std::max(worst_ratio, diff / bound[s]);
+                    } else {
+                        PANTR_CHECK_MSG(diff == 0.0,
+                                        "a zero bound was not met by an exactly zero difference");
+                    }
+                }
+            }
+        }
+        ++case_index;
+    }
+    std::printf("P1[%s] worst observed ratio |diff|/bound = %.6e\n", label, worst_ratio);
+}
+
+// ---------------------------------------------------------------------------
+// P2: shape, degree, rank and rationality.
+// ---------------------------------------------------------------------------
+
+/// P2: `multiply` gives degree `p_d + q_d` per direction, `dim` and `rank`
+/// unchanged, and is rational exactly when either operand is. Integer facts,
+/// asserted exactly. Would catch a wrong output degree, a dropped rank or
+/// dimension, or a rationality flag that does not follow "rational whenever
+/// either operand is."
+template <class T>
+void check_product_shape_and_rationality() {
+    for (const ProductCase& c : product_cases()) {
+        const std::size_t rank = 2;
+        const Bezier<T> f = random_bezier<T>(c.degrees_f, rank, 1);
+        const Bezier<T> g = random_bezier<T>(c.degrees_g, rank, 2);
+        const std::size_t order = ops::product_table_order<T>(f, g);
+        const BinomialTables<T> tables = build_binomial_tables<T>(order);
+        const Bezier<T> h = ops::multiply<T>(f, g, tables.binom_view(), tables.inv_view());
+
+        std::vector<std::size_t> expected_degree(c.degrees_f.size());
+        for (std::size_t d = 0; d < c.degrees_f.size(); ++d) {
+            expected_degree[d] = c.degrees_f[d] + c.degrees_g[d];
+        }
+        PANTR_CHECK(h.degree() == expected_degree);
+        PANTR_CHECK(h.dim() == f.dim());
+        PANTR_CHECK(h.rank() == rank);
+        PANTR_CHECK_MSG(!h.is_rational(), "two non-rational operands gave a rational product");
+    }
+
+    // One rational, one not, both orders: rational exactly when either is.
+    const std::vector<std::size_t> degrees{2};
+    const Bezier<T> plain = random_bezier<T>(degrees, 2, 3);
+    const Bezier<T> rational = random_rational_bezier<T>(degrees, 2, 4);
+    const std::size_t order = ops::product_table_order<T>(plain, rational);
+    const BinomialTables<T> tables = build_binomial_tables<T>(order);
+
+    const Bezier<T> mixed_a =
+        ops::multiply<T>(plain, rational, tables.binom_view(), tables.inv_view());
+    PANTR_CHECK_MSG(mixed_a.is_rational(),
+                    "a non-rational-times-rational product was not reported rational");
+    const Bezier<T> mixed_b =
+        ops::multiply<T>(rational, plain, tables.binom_view(), tables.inv_view());
+    PANTR_CHECK_MSG(mixed_b.is_rational(),
+                    "a rational-times-non-rational product was not reported rational");
+
+    const Bezier<T> rational_b = random_rational_bezier<T>(degrees, 2, 5);
+    const Bezier<T> both =
+        ops::multiply<T>(rational, rational_b, tables.binom_view(), tables.inv_view());
+    PANTR_CHECK_MSG(both.is_rational(), "two rational operands did not give a rational product");
+}
+
+// ---------------------------------------------------------------------------
+// P3: the product is commutative, within the construction budget.
+// ---------------------------------------------------------------------------
+
+/// P3: `multiply(f, g)` and `multiply(g, f)` are the same polynomial computed
+/// two different ways -- the accumulation order differs -- so they agree
+/// coefficient for coefficient within `2 * gamma_n(S + 6, eps) * A_gamma`
+/// (twice budget 1, once per operand order), never bit for bit. Would catch an
+/// asymmetric bug that only one operand order exercises.
+///
+/// \param label The scalar type's name, for the worst-ratio report.
+template <class T>
+void check_product_is_commutative_within_budget(const char* label) {
+    double worst_ratio = 0.0;
+    std::size_t case_index = 0;
+    for (const ProductCase& c : product_cases()) {
+        const std::size_t rank = 2;
+        const std::uint64_t seed_f = (2000ULL * case_index) + 1ULL;
+        const std::uint64_t seed_g = (2000ULL * case_index) + 2ULL;
+        const Bezier<T> f = random_bezier<T>(c.degrees_f, rank, seed_f);
+        const Bezier<T> g = random_bezier<T>(c.degrees_g, rank, seed_g);
+
+        const std::size_t order = ops::product_table_order<T>(f, g);
+        const BinomialTables<T> tables_t = build_binomial_tables<T>(order);
+        const BinomialTables<double> tables_d = build_binomial_tables<double>(order);
+
+        const Bezier<T> h1 = ops::multiply<T>(f, g, tables_t.binom_view(), tables_t.inv_view());
+        const Bezier<T> h2 = ops::multiply<T>(g, f, tables_t.binom_view(), tables_t.inv_view());
+        PANTR_CHECK(h1.degree() == h2.degree());
+
+        const Bezier<double> a = ops::multiply<double>(
+            abs_double_bezier<T>(f), abs_double_bezier<T>(g), tables_d.binom_view(),
+            tables_d.inv_view());
+
+        double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+        std::size_t s_terms = 1;
+        for (std::size_t d = 0; d < f.dim(); ++d) {
+            s_terms *= (std::min(f.degree(d), g.degree(d)) + 1);
+        }
+        const double per_coeff_gamma = 2.0 * gamma_n(s_terms + 6, eps_t);
+
+        const std::span<const T> h1_vals = h1.net().values();
+        const std::span<const T> h2_vals = h2.net().values();
+        const std::span<const double> a_vals = a.net().values();
+        PANTR_CHECK(h1_vals.size() == a_vals.size());
+        for (std::size_t i = 0; i < h1_vals.size(); ++i) {
+            const double diff =
+                std::abs(static_cast<double>(h1_vals[i]) - static_cast<double>(h2_vals[i]));
+            const double bound = per_coeff_gamma * a_vals[i];
+            PANTR_CHECK_MSG(diff <= bound,
+                            "multiply(f, g) and multiply(g, f) disagreed beyond twice the "
+                            "construction budget");
+            if (bound > 0.0) {
+                worst_ratio = std::max(worst_ratio, diff / bound);
+            } else {
+                PANTR_CHECK_MSG(diff == 0.0, "a zero commutative bound was not met exactly");
+            }
+        }
+        ++case_index;
+    }
+    std::printf("P3[%s] worst observed ratio |diff|/bound = %.6e\n", label, worst_ratio);
+}
+
+// ---------------------------------------------------------------------------
+// P4: a rational product projects to the product of the projections.
+// ---------------------------------------------------------------------------
+
+/// One P4 configuration: the degrees of the two rational operands and the
+/// (shared) rank.
+struct RationalProductCase {
+    std::vector<std::size_t> degrees_f;
+    std::vector<std::size_t> degrees_g;
+    std::size_t rank;
+};
+
+/// P4: for rational `f`, `g` with weights bounded in `[0.5, 2]`, `h = f * g`
+/// satisfies `h_num(t)/h_w(t) == (f_num(t)/f_w(t)) * (g_num(t)/g_w(t))` within
+/// `ProductErrorModel`'s numerator budget (applied to the two numerator nets,
+/// since a rational product's numerator is exactly the non-rational product
+/// of the numerators) propagated through the quotient by `|h_w(t)|`, plus
+/// `gamma_n(3, eps)` for the three divisions (`f`'s, `g`'s and `h`'s own
+/// rational projection inside `evaluate`) and the one multiplication
+/// combining the two projected factors. Would catch a wrong numerator/
+/// denominator split or the weight column leaking into the linear part.
+///
+/// \param label The scalar type's name, for the worst-ratio report.
+template <class T>
+void check_rational_product_projects_correctly(const char* label) {
+    double worst_ratio = 0.0;
+    const std::vector<RationalProductCase> cases{
+        {{2}, {1}, 2}, {{1, 1}, {2, 1}, 1}, {{0}, {3}, 2}};
+    std::size_t case_index = 0;
+    for (const RationalProductCase& c : cases) {
+        const std::uint64_t seed_f = (3000ULL * case_index) + 1ULL;
+        const std::uint64_t seed_g = (3000ULL * case_index) + 2ULL;
+        const Bezier<T> f = random_rational_bezier<T>(c.degrees_f, c.rank, seed_f);
+        const Bezier<T> g = random_rational_bezier<T>(c.degrees_g, c.rank, seed_g);
+
+        const std::size_t order = ops::product_table_order<T>(f, g);
+        const BinomialTables<T> tables_t = build_binomial_tables<T>(order);
+        const BinomialTables<double> tables_d = build_binomial_tables<double>(order);
+        const Bezier<T> h = ops::multiply<T>(f, g, tables_t.binom_view(), tables_t.inv_view());
+        PANTR_CHECK_MSG(h.is_rational(), "two rational operands did not give a rational product");
+
+        const Bezier<T> f_num = extract_numerator<T>(f);
+        const Bezier<T> g_num = extract_numerator<T>(g);
+        const Bezier<T> h_w = extract_weight<T>(h);
+        const ProductErrorModel<T> numerator_model(f_num, g_num, tables_t.binom_view(),
+                                                   tables_t.inv_view(), tables_d.binom_view(),
+                                                   tables_d.inv_view());
+
+        const double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+        const std::size_t dim = c.degrees_f.size();
+        for (const std::vector<double>& sample_d : unit_sample_tuples(dim)) {
+            std::vector<T> t(dim);
+            for (std::size_t d = 0; d < dim; ++d) {
+                t[d] = static_cast<T>(sample_d[d]);
+            }
+            const std::vector<T> h_proj = evaluate_one<T>(h, t);
+            const std::vector<T> f_proj = evaluate_one<T>(f, t);
+            const std::vector<T> g_proj = evaluate_one<T>(g, t);
+            const std::vector<T> h_w_val = evaluate_one<T>(h_w, t);
+            const double h_w_double = std::abs(static_cast<double>(h_w_val[0]));
+            const std::vector<double> numerator_bound = numerator_model.bound_at(t);
+
+            for (std::size_t s = 0; s < c.rank; ++s) {
+                const double rhs =
+                    static_cast<double>(f_proj[s]) * static_cast<double>(g_proj[s]);
+                const double diff = std::abs(static_cast<double>(h_proj[s]) - rhs);
+                const double bound = (numerator_bound[s] / h_w_double)
+                                    + (gamma_n(3, eps_t) * std::abs(rhs));
+                PANTR_CHECK_MSG(diff <= bound,
+                                "a rational product's projection did not equal the product of "
+                                "the projections within budget");
+                if (bound > 0.0) {
+                    worst_ratio = std::max(worst_ratio, diff / bound);
+                }
+            }
+        }
+        ++case_index;
+    }
+    std::printf("P4[%s] worst observed ratio |diff|/bound = %.6e\n", label, worst_ratio);
+}
+
+// ---------------------------------------------------------------------------
+// P5: product_table_order, and what a bad table does.
+// ---------------------------------------------------------------------------
+
+/// P5: `product_table_order` returns `max_d (p_d + q_d)`, exactly, for several
+/// configurations; the two operand-compatibility rejections and the two
+/// table-too-small rejections carry the oracle's messages verbatim (the first
+/// two duplicate `require_compatible_operands`'s own doc comment, restated
+/// here because a caller of `product_table_order` alone hits them without
+/// ever reaching `multiply`).
+template <class T>
+void check_product_table_order() {
+    for (const ProductCase& c : product_cases()) {
+        const Bezier<T> f = random_bezier<T>(c.degrees_f, 1, 10);
+        const Bezier<T> g = random_bezier<T>(c.degrees_g, 1, 11);
+        std::size_t expected = 0;
+        for (std::size_t d = 0; d < c.degrees_f.size(); ++d) {
+            const std::size_t summed = c.degrees_f[d] + c.degrees_g[d];
+            expected = std::max(expected, summed);
+        }
+        PANTR_CHECK(ops::product_table_order<T>(f, g) == expected);
+    }
+
+    {
+        const Bezier<T> a2d = random_bezier<T>({2, 3}, 1, 12);
+        const Bezier<T> a1d = random_bezier<T>({2}, 1, 13);
+        PANTR_CHECK_MSG(
+            message_of([&] { (void)ops::product_table_order<T>(a2d, a1d); })
+                == "Operands must have the same dimension. Got 2 and 1.",
+            "product_table_order did not reject mismatched dimensions with the expected "
+            "message");
+    }
+    {
+        const Bezier<T> rank1 = random_bezier<T>({2}, 1, 14);
+        const Bezier<T> rank2 = random_bezier<T>({2}, 2, 15);
+        PANTR_CHECK_MSG(
+            message_of([&] { (void)ops::product_table_order<T>(rank1, rank2); })
+                == "Operands must have the same rank. Got 1 and 2.",
+            "product_table_order did not reject mismatched ranks with the expected message");
+    }
+}
+
+/// P5's second half: `multiply` refuses a table one row short of
+/// `product_table_order + 1`, naming which table.
+template <class T>
+void check_product_rejections() {
+    const Bezier<T> f = random_bezier<T>({2}, 1, 20);
+    const Bezier<T> g = random_bezier<T>({2}, 1, 21);
+    const std::size_t order = ops::product_table_order<T>(f, g);
+    const BinomialTables<T> full = build_binomial_tables<T>(order);
+    const BinomialTables<T> short_table = build_binomial_tables<T>(order - 1);
+
+    {
+        // binomials one row short, inverse_binomials full size.
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::multiply<T>(f, g, short_table.binom_view(), full.inv_view());
+            }) == "binomials must have shape at least (" + std::to_string(order + 1) + ", "
+                   + std::to_string(order + 1) + "), got (" + std::to_string(order) + ", "
+                   + std::to_string(order) + ").",
+            "multiply did not reject an undersized binomials table with the expected message");
+    }
+    {
+        // inverse_binomials one row short, binomials full size.
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::multiply<T>(f, g, full.binom_view(), short_table.inv_view());
+            }) == "inverse_binomials must have shape at least (" + std::to_string(order + 1)
+                   + ", " + std::to_string(order + 1) + "), got (" + std::to_string(order) + ", "
+                   + std::to_string(order) + ").",
+            "multiply did not reject an undersized inverse_binomials table with the expected "
+            "message");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C1: composing with the identity reproduces the outer map.
+// ---------------------------------------------------------------------------
+
+/// The degree-1 identity curve, `{0, 1}`, rank 1: `t -> t`.
+///
+/// \return The Bézier.
+template <class T>
+Bezier<T> identity_1d() {
+    return make_bezier<T>({T(0), T(1)}, {2, 1}, false);
+}
+
+/// The bilinear identity map `(u, v) -> (u, v)`, rank 2, degree `(1, 1)`.
+///
+/// \return The Bézier.
+template <class T>
+Bezier<T> identity_2d() {
+    // Row-major (2, 2, 2): index (i, j, c) -> i if c == 0, j if c == 1.
+    return make_bezier<T>({T(0), T(0), T(0), T(1), T(1), T(0), T(1), T(1)}, {2, 2, 2}, false);
+}
+
+/// C1, univariate: composing a degree-`m` outer map with the degree-1
+/// identity inner map reproduces the outer map's own control points, within
+/// `gamma_n(4, eps)` per the file comment on the recurrence
+/// `fl(C(m, i) * fl(1 / C(m, i)))`. Would catch a wrong `bernstein_bases_at`
+/// recurrence.
+///
+/// \param worst_ratio Updated with the worst observed ratio seen so far.
+/// \param m The outer map's degree; see the caller for why several are swept.
+template <class T>
+void check_composing_with_identity_1d(double& worst_ratio, std::size_t m) {
+    const std::size_t rank = 2;
+    const Bezier<T> outer = random_bezier<T>({m}, rank, 30 + static_cast<std::uint64_t>(m));
+    const Bezier<T> inner = identity_1d<T>();
+    PANTR_CHECK(inner.rank() == outer.dim());
+
+    const std::size_t order = ops::composition_table_order<T>(outer, inner);
+    const BinomialTables<T> tables = build_binomial_tables<T>(order);
+    const Bezier<T> composed =
+        ops::compose<T>(outer, inner, tables.binom_view(), tables.inv_view());
+
+    PANTR_CHECK(composed.degree() == std::vector<std::size_t>{m});
+    PANTR_CHECK(composed.dim() == 1);
+    PANTR_CHECK(composed.rank() == outer.rank());
+
+    const double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+    const std::span<const T> outer_vals = outer.net().values();
+    const std::span<const T> composed_vals = composed.net().values();
+    for (std::size_t i = 0; i <= m; ++i) {
+        for (std::size_t c = 0; c < rank; ++c) {
+            const double outer_val = static_cast<double>(outer_vals[(i * rank) + c]);
+            const double composed_val = static_cast<double>(composed_vals[(i * rank) + c]);
+            const double diff = std::abs(composed_val - outer_val);
+            const double bound = gamma_n(4, eps_t) * std::abs(outer_val);
+            PANTR_CHECK_MSG(diff <= bound,
+                            "composing a univariate outer map with the identity did not "
+                            "reproduce its control points within budget");
+            if (bound > 0.0) {
+                worst_ratio = std::max(worst_ratio, diff / bound);
+            }
+        }
+    }
+}
+
+/// C1, 2-D: composing a 2-D outer map -- degree `m` in direction 0, degree 0
+/// (a single row) in direction 1 -- with the bilinear identity inner map
+/// reproduces the outer map's control points, broadcast across the composed
+/// shape's new rows in direction 1 (a degree-0 direction composed with the
+/// identity commits no rounding of its own: `bernstein_bases_at`'s `m == 0`
+/// branch returns the literal `1.0` with no arithmetic). Routes through
+/// `bernstein_product_nd` because the inner map is 2-D. Same bound as the
+/// univariate case, `gamma_n(4, eps)`, since the only rounding is direction
+/// 0's own identity recurrence.
+///
+/// \param worst_ratio Updated with the worst observed ratio seen so far.
+template <class T>
+void check_composing_with_identity_2d(double& worst_ratio) {
+    const std::size_t m = 4;
+    const std::size_t rank = 2;
+    const Bezier<T> outer = random_bezier<T>({m, 0}, rank, 31);
+    const Bezier<T> inner = identity_2d<T>();
+    PANTR_CHECK(inner.rank() == outer.dim());
+
+    const std::size_t order = ops::composition_table_order<T>(outer, inner);
+    const BinomialTables<T> tables = build_binomial_tables<T>(order);
+    const Bezier<T> composed =
+        ops::compose<T>(outer, inner, tables.binom_view(), tables.inv_view());
+
+    PANTR_CHECK(composed.dim() == 2);
+    PANTR_CHECK(composed.rank() == outer.rank());
+    PANTR_CHECK(composed.degree() == std::vector<std::size_t>({m, m}));
+
+    const double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+    const std::span<const T> outer_vals = outer.net().values();
+    const std::span<const T> composed_vals = composed.net().values();
+    for (std::size_t i0 = 0; i0 <= m; ++i0) {
+        const double outer_val_base = static_cast<double>(outer_vals[i0 * rank]);
+        for (std::size_t j = 0; j <= m; ++j) {
+            for (std::size_t c = 0; c < rank; ++c) {
+                const double outer_val = static_cast<double>(outer_vals[(i0 * rank) + c]);
+                const std::size_t flat_h = ((i0 * (m + 1)) + j) * rank;
+                const double composed_val = static_cast<double>(composed_vals[flat_h + c]);
+                const double diff = std::abs(composed_val - outer_val);
+                const double bound = gamma_n(4, eps_t) * std::abs(outer_val);
+                PANTR_CHECK_MSG(diff <= bound,
+                                "composing a 2-D outer map with the bilinear identity did not "
+                                "reproduce its control points, broadcast across the new "
+                                "direction, within budget");
+                if (bound > 0.0) {
+                    worst_ratio = std::max(worst_ratio, diff / bound);
+                }
+            }
+        }
+        (void)outer_val_base;
+    }
+}
+
+/// C1: both the univariate and 2-D identity-composition checks, sharing one
+/// worst-ratio report.
+///
+/// \param label The scalar type's name, for the worst-ratio report.
+template <class T>
+void check_composing_with_identity_reproduces_outer(const char* label) {
+    double worst_ratio = 0.0;
+    // Four degrees, and the two large ones are not decoration. `fl(C(m,i) * fl(1/C(m,i)))`
+    // is exactly 1 for every `i` at every degree below 11 in `float` and below 17 in
+    // `double`, so a case list of small degrees checks this bound only against an exact
+    // case -- which is not checking it. Degree 11 is the first that makes it inexact at
+    // `float`, 17 the first at `double`, and 18 has the most such `i`. Measured: at 5
+    // alone the worst ratio was 0 at `double`.
+    for (const std::size_t m : {std::size_t{5}, std::size_t{11}, std::size_t{17},
+                                std::size_t{18}}) {
+        check_composing_with_identity_1d<T>(worst_ratio, m);
+    }
+    check_composing_with_identity_2d<T>(worst_ratio);
+    std::printf("C1[%s] worst observed ratio |diff|/bound = %.6e\n", label, worst_ratio);
+}
+
+// ---------------------------------------------------------------------------
+// C2: the composition evaluated equals the outer map at the inner map's
+// value.
+// ---------------------------------------------------------------------------
+
+/// One C2 configuration.
+struct ComposeCase {
+    std::vector<std::size_t> outer_degrees;
+    std::size_t outer_rank;
+    std::vector<std::size_t> inner_degrees;
+    std::size_t inner_rank;  ///< Must equal `outer_degrees.size()`.
+};
+
+/// C2: `evaluate(compose(outer, inner, ...), t)` equals
+/// `evaluate(outer, evaluate(inner, t))`, within a coarse, admittedly
+/// over-charged bound. The chain from an input coefficient to an output one
+/// is at most `L = max_d m_d + dim_outer` products (power products building
+/// each direction's Bernstein basis, plus cross products combining
+/// directions); each product commits at most `S_max + 6` roundings by P1's
+/// own count, with `S_max` the composed result's own coefficient count (an
+/// over-estimate of any single product's term count); the binomial scaling
+/// adds one more rounding, and the final accumulation over the outer's own
+/// control points adds at most `prod_d (m_d + 1)` terms. So
+/// `N = L * (S_max + 6) + 1 + prod_d (m_d + 1)`, and
+/// `|composed_gamma - exact_gamma| <= gamma_n(N, eps) * A_gamma`, with `A`
+/// `compose`'s own construction run on the absolute value of the outer net
+/// (the inner map's coefficients are kept in `[0, 1]`, so its Bernstein bases
+/// are non-negative and the absolute value never has to touch it). Added to
+/// that: `evaluate`'s own budget for the composed map, for the outer map (at
+/// the inner map's -- possibly slightly wrong -- value) and, admittedly
+/// coarsely, for the inner map itself. That last term has no natural home in
+/// the same units as the other three (an error in the *input* to `outer`
+/// is not, in general, an equal-sized error in `outer`'s *output* without a
+/// sensitivity/Lipschitz factor this file does not derive), so it is charged
+/// at its own scale, summed over every component of the inner map's value,
+/// uniformly against every output component -- an admitted, coarse
+/// over-estimate rather than a tight propagation, exactly the margin this
+/// check's own docstring warns a reader to expect and to report rather than
+/// to silently tighten.
+///
+/// \param label The scalar type's name, for the worst-ratio report.
+template <class T>
+void check_composition_evaluated_matches_outer_at_inner_value(const char* label) {
+    double worst_ratio = 0.0;
+    const std::vector<ComposeCase> cases{
+        {{2}, 2, {2}, 1},
+        {{3}, 1, {1, 1}, 1},
+        {{1, 2}, 2, {2}, 2},
+        {{1, 2}, 1, {1, 1}, 2},
+    };
+    std::size_t case_index = 0;
+    for (const ComposeCase& c : cases) {
+        const std::uint64_t outer_seed = (4000ULL * case_index) + 1ULL;
+        const std::uint64_t inner_seed = (4000ULL * case_index) + 2ULL;
+        const Bezier<T> outer = random_bezier<T>(c.outer_degrees, c.outer_rank, outer_seed);
+        const Bezier<T> inner = random_unit_bezier<T>(c.inner_degrees, c.inner_rank, inner_seed);
+        PANTR_CHECK(inner.rank() == outer.dim());
+
+        const std::size_t order = ops::composition_table_order<T>(outer, inner);
+        const BinomialTables<T> tables_t = build_binomial_tables<T>(order);
+        const BinomialTables<double> tables_d = build_binomial_tables<double>(order);
+        const Bezier<T> composed =
+            ops::compose<T>(outer, inner, tables_t.binom_view(), tables_t.inv_view());
+
+        const Bezier<double> outer_abs_d = abs_double_bezier<T>(outer);
+        const Bezier<double> inner_double = to_double_bezier<T>(inner);
+        const Bezier<double> a =
+            ops::compose<double>(outer_abs_d, inner_double, tables_d.binom_view(),
+                                 tables_d.inv_view());
+        const Bezier<double> composed_abs_d = abs_double_bezier<T>(composed);
+        const Bezier<double> outer_abs_only = abs_double_bezier<T>(outer);
+        const Bezier<double> inner_abs_d = abs_double_bezier<T>(inner);
+
+        std::size_t max_outer_degree = 0;
+        std::size_t outer_coeff_count = 1;
+        for (const std::size_t d : outer.degree()) {
+            max_outer_degree = std::max(max_outer_degree, d);
+            outer_coeff_count *= (d + 1);
+        }
+        std::size_t s_max = 1;
+        for (const std::size_t d : composed.degree()) {
+            s_max *= (d + 1);
+        }
+        const std::size_t chain_length = max_outer_degree + outer.dim();
+        const std::size_t big_n = (chain_length * (s_max + 6)) + 1 + outer_coeff_count;
+
+        const double eps_t = static_cast<double>(std::numeric_limits<T>::epsilon());
+        const double gamma_construction = gamma_n(big_n, eps_t);
+        const double gamma_composed = gamma_n(stages_of(composed.degree()), eps_t);
+        const double gamma_outer = gamma_n(stages_of(outer.degree()), eps_t);
+        const double gamma_inner = gamma_n(stages_of(inner.degree()), eps_t);
+
+        const std::size_t dim_inner = c.inner_degrees.size();
+        for (const std::vector<double>& sample_d : unit_sample_tuples(dim_inner)) {
+            std::vector<T> t(dim_inner);
+            for (std::size_t d = 0; d < dim_inner; ++d) {
+                t[d] = static_cast<T>(sample_d[d]);
+            }
+            const std::vector<T> inner_val = evaluate_one<T>(inner, t);
+            const std::vector<T> outer_at_inner = evaluate_one<T>(outer, inner_val);
+            const std::vector<T> composed_val = evaluate_one<T>(composed, t);
+
+            const std::vector<double> t_d = widen<T>(t);
+            const std::vector<double> a_val = evaluate_one<double>(a, t_d);
+            const std::vector<double> composed_abs_val = evaluate_one<double>(composed_abs_d, t_d);
+            const std::vector<double> inner_val_d = evaluate_one<double>(inner_double, t_d);
+            const std::vector<double> outer_abs_val =
+                evaluate_one<double>(outer_abs_only, inner_val_d);
+            const std::vector<double> inner_abs_val = evaluate_one<double>(inner_abs_d, t_d);
+            double inner_abs_total = 0.0;
+            for (const double v : inner_abs_val) {
+                inner_abs_total += v;
+            }
+            const double inner_term = gamma_inner * inner_abs_total;
+
+            for (std::size_t s = 0; s < c.outer_rank; ++s) {
+                const double diff = std::abs(static_cast<double>(composed_val[s])
+                                             - static_cast<double>(outer_at_inner[s]));
+                const double bound = (gamma_construction * a_val[s])
+                                    + (gamma_composed * composed_abs_val[s])
+                                    + (gamma_outer * outer_abs_val[s]) + inner_term;
+                PANTR_CHECK_MSG(diff <= bound,
+                                "the composition evaluated did not equal the outer map at the "
+                                "inner map's value within its (coarse) budget");
+                if (bound > 0.0) {
+                    worst_ratio = std::max(worst_ratio, diff / bound);
+                }
+            }
+        }
+        ++case_index;
+    }
+    std::printf("C2[%s] worst observed ratio |diff|/bound = %.6e\n", label, worst_ratio);
+}
+
+// ---------------------------------------------------------------------------
+// C3: composition shape and refusals.
+// ---------------------------------------------------------------------------
+
+/// C3, shape: `dim` is `inner.dim()`, `rank` is `outer.rank()`, and degree in
+/// direction `s` is `sum_d m_d * n_s`, exactly.
+template <class T>
+void check_composition_shape() {
+    const Bezier<T> outer = random_bezier<T>({2, 3}, 2, 40);
+    const Bezier<T> inner = random_unit_bezier<T>({1, 1}, 2, 41);
+    const std::size_t order = ops::composition_table_order<T>(outer, inner);
+    const BinomialTables<T> tables = build_binomial_tables<T>(order);
+    const Bezier<T> composed =
+        ops::compose<T>(outer, inner, tables.binom_view(), tables.inv_view());
+    PANTR_CHECK(composed.dim() == inner.dim());
+    PANTR_CHECK(composed.rank() == outer.rank());
+    PANTR_CHECK(composed.degree() == std::vector<std::size_t>({5, 5}));
+
+    const Bezier<T> outer_1d = random_bezier<T>({4}, 1, 42);
+    const Bezier<T> inner_1d = random_unit_bezier<T>({2}, 1, 43);
+    const std::size_t order_1d = ops::composition_table_order<T>(outer_1d, inner_1d);
+    const BinomialTables<T> tables_1d = build_binomial_tables<T>(order_1d);
+    const Bezier<T> composed_1d =
+        ops::compose<T>(outer_1d, inner_1d, tables_1d.binom_view(), tables_1d.inv_view());
+    PANTR_CHECK(composed_1d.dim() == 1);
+    PANTR_CHECK(composed_1d.rank() == 1);
+    PANTR_CHECK(composed_1d.degree() == std::vector<std::size_t>{8});
+}
+
+/// C3, `composition_table_order`: `max_d m_d` for a univariate inner map,
+/// `max(max_d m_d, max_s (sum_d m_d) * n_s)` otherwise, exact for several
+/// configurations including one where the two candidates in the max differ
+/// in which one wins.
+template <class T>
+void check_composition_table_order() {
+    {
+        // Univariate inner: only max_d m_d.
+        const Bezier<T> outer = random_bezier<T>({4, 2}, 1, 50);
+        const Bezier<T> inner = random_unit_bezier<T>({3}, 1, 51);
+        PANTR_CHECK(ops::composition_table_order<T>(outer, inner) == 4);
+    }
+    {
+        // Multi-d inner, second candidate wins: total = 1 + 2 = 3, n_s = 3 both
+        // directions, so 3 * 3 = 9 beats max_d m_d = 2.
+        const Bezier<T> outer = random_bezier<T>({1, 2}, 1, 52);
+        const Bezier<T> inner = random_unit_bezier<T>({3, 3}, 2, 53);
+        PANTR_CHECK(ops::composition_table_order<T>(outer, inner) == 9);
+    }
+    {
+        // Multi-d inner, first candidate wins: inner degree 0 in both
+        // directions makes the second candidate 0, so max_d m_d = 5 wins.
+        const Bezier<T> outer = random_bezier<T>({5, 1}, 1, 54);
+        const Bezier<T> inner = random_unit_bezier<T>({0, 0}, 2, 55);
+        PANTR_CHECK(ops::composition_table_order<T>(outer, inner) == 5);
+    }
+}
+
+/// C3, refusals: every documented rejection of `compose`, message asserted
+/// verbatim, plus the two exemptions honoured rather than refused.
+template <class T>
+void check_composition_rejections() {
+    const BinomialTables<T> tiny = build_binomial_tables<T>(1);
+
+    {
+        const Bezier<T> outer = random_rational_bezier<T>({2}, 1, 60);
+        const Bezier<T> inner = random_unit_bezier<T>({2}, 1, 61);
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::compose<T>(outer, inner, tiny.binom_view(), tiny.inv_view());
+            }) == "Composition is not supported for rational Béziers (outer is rational).",
+            "compose did not reject a rational outer map with the expected message");
+    }
+    {
+        const Bezier<T> outer = random_bezier<T>({2}, 1, 62);
+        const Bezier<T> inner = random_rational_bezier<T>({2}, 1, 63);
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::compose<T>(outer, inner, tiny.binom_view(), tiny.inv_view());
+            }) == "Composition is not supported for rational Béziers (inner is rational).",
+            "compose did not reject a rational inner map with the expected message");
+    }
+    {
+        const Bezier<T> outer = random_bezier<T>({1, 1}, 1, 64);  // dim 2
+        const Bezier<T> inner = random_unit_bezier<T>({2}, 1, 65);  // rank 1
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::compose<T>(outer, inner, tiny.binom_view(), tiny.inv_view());
+            }) == "Inner Bézier rank (1) must equal outer Bézier parametric dimension (2).",
+            "compose did not reject a rank/dimension mismatch with the expected message");
+    }
+    {
+        // Univariate outer of degree 30, univariate inner of degree 3:
+        // composed degree 90 exceeds kBincoeffMaxN (61).
+        const Bezier<T> outer = random_bezier<T>({30}, 1, 66);
+        const Bezier<T> inner = random_unit_bezier<T>({3}, 1, 67);
+        const std::string message = message_of([&] {
+            (void)ops::compose<T>(outer, inner, tiny.binom_view(), tiny.inv_view());
+        });
+        const std::string expected_prefix =
+            "Composition to degree 90 with a 1D inner Bézier needs binomial coefficients up "
+            "to C(90, k), beyond the largest upper index 61";
+        PANTR_CHECK_MSG(message.rfind(expected_prefix, 0) == 0,
+                        "compose did not reject a degree past the binomial envelope with the "
+                        "expected message prefix");
+    }
+    {
+        // Exemption: a degree-1 (or degree-0) univariate outer map forms no
+        // product at all, so a very high degree univariate inner map must not
+        // throw regardless of the composed degree.
+        const Bezier<T> outer = random_bezier<T>({1}, 1, 68);
+        const Bezier<T> inner = random_unit_bezier<T>({70}, 1, 69);
+        const std::size_t order = ops::composition_table_order<T>(outer, inner);
+        const BinomialTables<T> tables = build_binomial_tables<T>(order);
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::compose<T>(outer, inner, tables.binom_view(), tables.inv_view());
+            }) == "<did not throw>",
+            "compose refused a degree-1 outer map with a very high degree univariate inner "
+            "map, which forms no product and must be exempt from the binomial envelope");
+    }
+    {
+        // Exemption: an n-dimensional inner map is never checked against the
+        // binomial envelope at all, at any degree (the check only fires for
+        // use_1d_kernel). Supply a table sized to the genuine
+        // composition_table_order, which for a 2-D inner map does depend on
+        // its degree and here comfortably exceeds kBincoeffMaxN.
+        const Bezier<T> outer = random_bezier<T>({2, 2}, 1, 70);
+        const Bezier<T> inner = random_unit_bezier<T>({20, 20}, 2, 71);
+        const std::size_t order = ops::composition_table_order<T>(outer, inner);
+        PANTR_CHECK(order > static_cast<std::size_t>(pantr::core::kBincoeffMaxN));
+        const BinomialTables<T> tables = build_binomial_tables<T>(order);
+        PANTR_CHECK_MSG(
+            message_of([&] {
+                (void)ops::compose<T>(outer, inner, tables.binom_view(), tables.inv_view());
+            }) == "<did not throw>",
+            "compose refused an n-dimensional inner map at a degree past kBincoeffMaxN, which "
+            "the envelope check does not (and must not) apply to");
+    }
+}
+
+}  // namespace
 
 int main() {
-    std::puts("PLACEHOLDER: test_bezier_product asserts nothing yet");
+    check_binomial_table_matches_bincoeff();
+
+    check_product_evaluated_equals_product_of_evaluations<double>("double");
+    check_product_evaluated_equals_product_of_evaluations<float>("float");
+    check_product_shape_and_rationality<double>();
+    check_product_shape_and_rationality<float>();
+    check_product_is_commutative_within_budget<double>("double");
+    check_product_is_commutative_within_budget<float>("float");
+    check_rational_product_projects_correctly<double>("double");
+    check_rational_product_projects_correctly<float>("float");
+    check_product_table_order<double>();
+    check_product_table_order<float>();
+    check_product_rejections<double>();
+    check_product_rejections<float>();
+
+    check_composing_with_identity_reproduces_outer<double>("double");
+    check_composing_with_identity_reproduces_outer<float>("float");
+    check_composition_evaluated_matches_outer_at_inner_value<double>("double");
+    check_composition_evaluated_matches_outer_at_inner_value<float>("float");
+    check_composition_shape<double>();
+    check_composition_shape<float>();
+    check_composition_table_order<double>();
+    check_composition_table_order<float>();
+    check_composition_rejections<double>();
+    check_composition_rejections<float>();
+
     return pantr::test::summary("test_bezier_product");
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -57,8 +57,21 @@ user-facing, and the ports change what it affects.
   because these kernels contain fused-multiply-add sites and the shipped build targets a baseline
   ISA that has no such instruction; and the evaluation kernel's seed is a `pow`, which no standard
   requires to be correctly rounded, so its exactness is measured rather than derived.
-  `Bezier.multiply` is deliberately **not** part of this: it goes through a numpy helper that no
-  kernel backs, and is unaffected by `PANTR_BACKEND`.
+- **`Bezier.multiply` is ported too**, closing the Bézier front, so `PANTR_BACKEND=cpp` now
+  reaches it as well as everything in the entry above. It goes through a pure-numpy helper that
+  no kernel backs, and that helper stays the oracle: the C++ port reproduces *it* rather than
+  routing through the scalar Bernstein product kernel it resembles. The two are not
+  interchangeable, which is the point. They differ by about 2 eps, and their domains differ,
+  the numpy path staying exact at `p + q = 80` where the kernel's int64 binomials are
+  undefined. So the port takes its binomial tables as data, assembled once by `math.comb` on
+  the Python side, rather than computing them and inheriting the kernel's envelope.
+  Both agree bit for bit with their oracles on a build with no fused multiply-add, and carry
+  Rule 10's budget on one that has it. One consequence a caller can see: like every other
+  Bézier-level operation, a Bézier built under one backend can no longer be multiplied or
+  composed under the other.
+  Two docstrings were corrected rather than ported: `Bezier.multiply` promised "the exact
+  pointwise product" and `Bezier.compose` "the exact composition". The *degree* is exact; the
+  control points are a binomial-weighted sum in floating point and are not.
 - **Eigen is now a build dependency of the wheel**, where before it was fetched only for the C++
   tests. `pantr.change_basis` needs a dense solve and `pantr.bezier` will need a truncated SVD,
   and neither is a thing to hand-roll. A cold `pip install -e .` goes from 7.56 s to 12.19 s on

--- a/src/pantr/_pantr_cpp/__init__.pyi
+++ b/src/pantr/_pantr_cpp/__init__.pyi
@@ -54,9 +54,12 @@ from ._bezier import Bezier32 as Bezier32
 from ._bezier import Bezier64 as Bezier64
 from ._bezier import apply_reduction_operator as apply_reduction_operator
 from ._bezier import bezier_boundary as bezier_boundary
+from ._bezier import bezier_composition_table_order as bezier_composition_table_order
 from ._bezier import bezier_degree_reduction_error as bezier_degree_reduction_error
+from ._bezier import bezier_product_table_order as bezier_product_table_order
 from ._bezier import clip_roots as clip_roots
 from ._bezier import collapse_bezier_along_axis as collapse_bezier_along_axis
+from ._bezier import compose_bezier as compose_bezier
 from ._bezier import dedup_roots as dedup_roots
 from ._bezier import degree_elevate_bezier_1d as degree_elevate_bezier_1d
 from ._bezier import elevate_bezier_degree as elevate_bezier_degree
@@ -65,6 +68,7 @@ from ._bezier import evaluate_bezier_1d as evaluate_bezier_1d
 from ._bezier import evaluate_bezier_deriv_1d as evaluate_bezier_deriv_1d
 from ._bezier import evaluate_bezier_on_lattice as evaluate_bezier_on_lattice
 from ._bezier import find_roots_batch as find_roots_batch
+from ._bezier import multiply_bezier as multiply_bezier
 from ._bezier import permute_bezier_directions as permute_bezier_directions
 from ._bezier import reduce_bezier_degree as reduce_bezier_degree
 from ._bezier import restrict_bezier as restrict_bezier

--- a/src/pantr/_pantr_cpp/_bezier.pyi
+++ b/src/pantr/_pantr_cpp/_bezier.pyi
@@ -780,6 +780,167 @@ def collapse_bezier_along_axis(
             ``bezier.dim - 1`` entries, or if a value leaves ``[0, 1]``.
     """
 
+def bezier_product_table_order(
+    a: Bezier32 | Bezier64,
+    b: Bezier32 | Bezier64,
+) -> int:
+    """The largest binomial upper index :func:`multiply_bezier` will read.
+
+    ``multiply_bezier``'s ``binomials`` and ``inverse_binomials`` must reach at
+    least ``(order + 1, order + 1)``, where ``order`` is
+    ``max_d (a.degree[d] + b.degree[d])`` -- the product's own degree per
+    direction, and no larger index is ever read. Also validates that ``a`` and
+    ``b`` are compatible, raising the same message :func:`multiply_bezier`
+    would.
+
+    Args:
+        a (Bezier32 | Bezier64): First operand.
+        b (Bezier32 | Bezier64): Second operand. Must be the same concrete
+            class as ``a``, and share its dimension and rank.
+
+    Returns:
+        int: The largest ``n`` for which ``C(n, k)`` will be read; the tables
+            must be at least ``(n + 1, n + 1)``.
+
+    Raises:
+        TypeError: If ``a`` and ``b`` are not the same concrete class, since
+            no overload then matches.
+        ValueError: If ``a`` and ``b`` differ in dimension or rank.
+    """
+
+def multiply_bezier(
+    a: Bezier32 | Bezier64,
+    b: Bezier32 | Bezier64,
+    *,
+    binomials: npt.NDArray[np.float32 | np.float64],
+    inverse_binomials: npt.NDArray[np.float32 | np.float64],
+) -> Bezier32 | Bezier64:
+    """The pointwise product of two Béziers.
+
+    Degree ``p_d + q_d`` per direction, which represents the product exactly;
+    the coefficients carry the roundings of a binomial-weighted sum formed at
+    ``a``'s and ``b``'s own storage width. A rational operand makes the result
+    rational: both operands are promoted to homogeneous form and their
+    numerators and weight columns are multiplied independently.
+
+    ``binomials`` and ``inverse_binomials`` are two adjacent same-dtype
+    same-shape tables, so passing them the wrong way round gives a plausible
+    but wrong Bézier with no error anywhere -- the same hazard
+    ``restrict_bezier_1d``'s ``lower``/``upper`` and ``split_bezier_1d``'s two
+    outputs already carry. Both are keyword-only for that reason and both
+    ``.noconvert()``: without it a ``float64`` table would be silently cast
+    for a ``float32`` Bézier, and the table's own rounding is part of the
+    parity claim.
+
+    Call :func:`bezier_product_table_order` first to size the tables.
+
+    Args:
+        a (Bezier32 | Bezier64): First operand.
+        b (Bezier32 | Bezier64): Second operand. Must be the same concrete
+            class as ``a``, and share its dimension and rank.
+        binomials (npt.NDArray[np.float32 | np.float64]): ``C(n, k)`` in
+            ``a``'s and ``b``'s storage dtype, at least
+            ``(bezier_product_table_order(a, b) + 1)`` square, C-contiguous.
+            Entries with ``k > n`` are never read. Keyword-only.
+        inverse_binomials (npt.NDArray[np.float32 | np.float64]):
+            ``1 / C(n, k)``, same dtype, shape and requirements. Keyword-only.
+
+    Returns:
+        Bezier32 | Bezier64: The product, matching ``a``'s and ``b``'s class,
+            rational exactly when either operand is.
+
+    Raises:
+        TypeError: If ``a`` and ``b`` are not the same concrete class, if
+            either table has the wrong dtype or rank, is not C-contiguous, or
+            if either table is passed positionally.
+        ValueError: If ``a`` and ``b`` differ in dimension or rank, or if
+            either table is smaller than
+            ``bezier_product_table_order(a, b) + 1`` square.
+    """
+
+def bezier_composition_table_order(
+    outer: Bezier32 | Bezier64,
+    inner: Bezier32 | Bezier64,
+) -> int:
+    """The largest binomial upper index :func:`compose_bezier` will read.
+
+    Two sources: the Bernstein basis of each outer direction needs
+    ``C(m_d, i)`` up to ``max_d m_d``, and an n-dimensional inner map routes
+    every product through the n-dimensional Bernstein product, whose
+    reciprocals reach the composed degree ``sum_d m_d * n_s`` in direction
+    ``s``. A univariate inner map contributes nothing to that second bound,
+    since its products go through a separate kernel that builds its own
+    coefficients.
+
+    Unlike :func:`bezier_product_table_order` this validates nothing: it
+    reads only ``outer``'s and ``inner``'s own degrees, so no compatibility
+    between them is required to answer.
+
+    Args:
+        outer (Bezier32 | Bezier64): The outer map.
+        inner (Bezier32 | Bezier64): The inner map. Must be the same concrete
+            class as ``outer``.
+
+    Returns:
+        int: The largest ``n`` for which ``C(n, k)`` will be read; the tables
+            must be at least ``(n + 1, n + 1)``.
+
+    Raises:
+        TypeError: If ``outer`` and ``inner`` are not the same concrete
+            class, since no overload then matches.
+    """
+
+def compose_bezier(
+    outer: Bezier32 | Bezier64,
+    inner: Bezier32 | Bezier64,
+    *,
+    binomials: npt.NDArray[np.float32 | np.float64],
+    inverse_binomials: npt.NDArray[np.float32 | np.float64],
+) -> Bezier32 | Bezier64:
+    """The composition ``outer(inner(t))``.
+
+    Degree ``sum_d m_d * n_s`` in direction ``s``, which represents the
+    composition exactly; the coefficients carry the roundings of the products
+    that build them. Each outer direction's Bernstein basis is evaluated at
+    the corresponding component of ``inner``, and the outer control points
+    weight the tensor products of those bases.
+
+    ``binomials`` and ``inverse_binomials`` carry the same transposition
+    hazard as :func:`multiply_bezier`'s tables, for the same reason, and are
+    keyword-only and ``.noconvert()`` for the same two reasons.
+
+    Call :func:`bezier_composition_table_order` first to size the tables.
+
+    Args:
+        outer (Bezier32 | Bezier64): The outer map. Must be non-rational.
+        inner (Bezier32 | Bezier64): The inner map. Must be the same concrete
+            class as ``outer``, non-rational, and satisfy
+            ``inner.rank == outer.dim``.
+        binomials (npt.NDArray[np.float32 | np.float64]): ``C(n, k)`` in
+            ``outer``'s and ``inner``'s storage dtype, at least
+            ``(bezier_composition_table_order(outer, inner) + 1)`` square,
+            C-contiguous. Entries with ``k > n`` are never read.
+            Keyword-only.
+        inverse_binomials (npt.NDArray[np.float32 | np.float64]):
+            ``1 / C(n, k)``, same dtype, shape and requirements.
+            Keyword-only.
+
+    Returns:
+        Bezier32 | Bezier64: The composed Bézier, of dimension ``inner.dim``
+            and rank ``outer.rank``, matching ``outer``'s and ``inner``'s
+            class.
+
+    Raises:
+        TypeError: If ``outer`` and ``inner`` are not the same concrete
+            class, if either table has the wrong dtype or rank, is not
+            C-contiguous, or if either table is passed positionally.
+        ValueError: If ``outer`` or ``inner`` is rational, if ``inner.rank``
+            does not equal ``outer.dim``, if a univariate ``inner`` would
+            drive the composed degree past the exact-integer binomial
+            envelope, or if either table is smaller than
+            ``bezier_composition_table_order(outer, inner) + 1`` square.
+    """
+
 def yuksel_roots(
     coeff: npt.NDArray[np.float32 | np.float64],
     param_tol: float,

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -855,12 +855,18 @@ class Bezier:
     # ------------------------------------------------------------------
 
     def multiply(self, other: Bezier) -> Bezier:
-        """Return the exact pointwise product of this Bézier and another.
+        """Return the pointwise product of this Bézier and another.
 
         Given Bézier ``self`` and ``other`` over the same parametric domain
         ``[0, 1]^dim``, returns a new Bézier ``h`` such that
         ``h(t) = self(t) * other(t)``. The result has degree ``p_d + q_d``
         per direction.
+
+        That degree represents the product **exactly**: no approximation is made
+        in choosing it. The control points are not exact, and this docstring used
+        to say they were. Each is a binomial-weighted sum evaluated in floating
+        point, so each carries that sum's roundings; the size of them is measured
+        in ``tests/parity/test_bezier_product.py``.
 
         Args:
             other (Bezier): The second Bézier operand. Must have the same
@@ -896,10 +902,15 @@ class Bezier:
     def compose(self, inner: Bezier) -> Bezier:
         """Compose this Bézier with another: ``result(t) = self(inner(t))``.
 
-        Computes the exact composition of two non-rational Bézier objects.
-        The result is a new Bézier with parametric dimension equal to
-        ``inner.dim``, rank equal to ``self.rank``, and degree
-        ``sum(self.degree) * inner.degree[s]`` in each direction ``s``.
+        Composes two non-rational Bézier objects. The result is a new Bézier with
+        parametric dimension equal to ``inner.dim``, rank equal to ``self.rank``,
+        and degree ``sum(self.degree) * inner.degree[s]`` in each direction ``s``.
+
+        That degree represents the composition **exactly**; the control points do
+        not, and this docstring used to call the composition itself exact. They
+        are built from repeated Bernstein products in floating point -- one per
+        power of the inner map and one per tensor term -- and carry every one of
+        those roundings.
 
         Args:
             inner (Bezier): The inner Bézier (reparametrization). Must be

--- a/src/pantr/bezier/_bezier.py
+++ b/src/pantr/bezier/_bezier.py
@@ -923,6 +923,12 @@ class Bezier:
             TypeError: If either Bézier is rational.
             ValueError: If ``inner.rank != self.dim``.
             ValueError: If the operands have different dtypes.
+            ValueError: If a one-dimensional ``inner`` would drive the composed
+                degree past the exactness envelope of the binomial-coefficient
+                kernel. The envelope is *multiplicative* in the two degrees, so it
+                binds at far lower inputs than degree elevation's additive one. See
+                ``pantr.bezier._bezier_compose._compose_bezier`` for which
+                configurations are exempt and why.
 
         Example:
             >>> f = Bezier(np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]]))

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -86,9 +86,12 @@ that do not still hand Layer 2 an array to fill before wrapping it in a
   composition, which likewise take Béziers.  Their C++ side is handed the
   binomial tables as data; see :func:`_cpp_multiply`.
 
-This list is meant to be exhaustive.  It was not: an earlier version named seven
-of the seventeen accessors then in the file, which is the same failure as the
-stale count above and is why both are called out here rather than quietly fixed.
+This list is meant to be exhaustive, and an earlier version was not: it named
+some of the accessors in the file and read as though it named all of them.  That
+is called out here rather than quietly fixed, because the next accessor added is
+what breaks it again.  No count appears in this note on purpose: the first
+attempt to record the omission stated the wrong figures, which is the very
+failure it was describing.
 """
 
 from __future__ import annotations

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -8,12 +8,15 @@ reason: a catalogue imports the kernels it hands out, so keeping each one beside
 its own kernels is what stops the policy module from importing the library it has
 to stay independent of.
 
-Nine accessors over ten implementations
----------------------------------------
+One accessor per operation, and one record
+-----------------------------------------
 
-Six are bare callables and one is a record, which is the rule
+Every accessor here returns a bare callable but one, which is the rule
 ``design/cross_backend_types.md`` states: a record when a consumer needs more
-than one kernel at once, a bare callable when it does not.
+than one kernel at once, a bare callable when it does not.  (An earlier version
+of this heading counted the accessors.  The count was wrong by eight before this
+module was next edited, so it is gone rather than corrected: the rule is what a
+reader needs and the rule does not depend on how many there are.)
 :func:`~pantr.bezier._bezier_degree._minimize_degree_bezier` is the consumer that
 needs two. Inside one call it reduces a degree and then re-elevates the result so
 the trial can be compared against the original, so it reaches for the reduction
@@ -28,7 +31,7 @@ each lookup, and that the dependency is stated in a signature rather than read f
 ambient state. :class:`DegreeKernels` is the convenient shape for two kernels always
 fetched together, not a safety mechanism.
 
-The other six call sites use exactly one kernel each, so they get one callable.
+Every other call site uses exactly one kernel, so it gets one callable.
 
 The accessors are named ``*_kernel`` rather than ``*_core``, following
 :mod:`pantr.quad._quad_backend` and :mod:`pantr.change_basis._change_basis_backend`.
@@ -72,6 +75,9 @@ that do not still hand Layer 2 an array to fill before wrapping it in a
 - :func:`evaluate_nd_kernel`, :func:`evaluate_nd_lattice_kernel`: the two
   n-dimensional contraction schedules, which take the Bézier rather than its
   arrays.
+- :func:`multiply_kernel`, :func:`compose_kernel`: the product and the
+  composition, which likewise take Béziers.  Their C++ side is handed the
+  binomial tables as data; see :func:`_cpp_multiply`.
 """
 
 from __future__ import annotations
@@ -213,6 +219,24 @@ rational result is the caller's, which is where the oracle puts it too.
 
 _CollapseFunc = Callable[["Bezier", int, _Array], "Bezier"]
 """Signature of the collapse: ``(bezier, axis, values) -> Bezier``."""
+
+_MultiplyFunc = Callable[["Bezier", "Bezier"], "Bezier"]
+"""Signature of the pointwise product: ``(a, b) -> Bezier``.
+
+Takes and returns Béziers rather than arrays, for the same reason the n-dimensional
+evaluation accessors do: this is an operation on a domain type, not a kernel, and the
+type is owned by C++ since the 2026-08-27 amendment to
+``design/cross_backend_types.md``.
+"""
+
+_ComposeFunc = Callable[["Bezier", "Bezier"], "Bezier"]
+"""Signature of the composition: ``(outer, inner) -> Bezier``.
+
+A separate accessor from :data:`_MultiplyFunc` rather than a branch inside it, because
+the two are separate operations with separate oracles: composition reaches the scalar
+product *kernel* for a univariate inner map and the numpy nD helper above that, where
+the product reaches the numpy helpers only.
+"""
 
 _ReduceApplyFunc = Callable[[npt.NDArray[np.float64], _Array, _Array], None]
 """Signature of the reduction-operator apply: ``(operator, ctrl, out) -> None``.
@@ -720,6 +744,86 @@ def _cpp_collapse(bezier: Bezier, axis: int, values: _Array) -> Bezier:
     )
 
 
+def _cpp_binomial_tables(
+    order: int, dtype: npt.DTypeLike
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Assemble the binomial tables the C++ product and composition are handed.
+
+    Args:
+        order (int): Largest upper index the operation will read.
+        dtype (npt.DTypeLike): The Bézier's storage format.
+
+    Returns:
+        tuple: The coefficient table and the reciprocal table.
+    """
+    from ._bezier_product import _binomial_tables  # noqa: PLC0415  (cycle)
+
+    return _binomial_tables(order, dtype)
+
+
+def _cpp_multiply(a: Bezier, b: Bezier) -> Bezier:
+    """Multiply two Béziers through the C++ binding.
+
+    The binding is handed the two binomial tables rather than assembling them, which
+    is the ruling ``cpp/include/pantr/bezier/product.hpp`` records: the numpy oracle's
+    :func:`math.comb` has no envelope and the C++ exact-integer recurrence stops at
+    61, so a native assembly would refuse the ``p + q = 80`` case both backends
+    otherwise handle.  The required size comes from the binding too, so the formula
+    for it exists once rather than once per language.
+
+    Args:
+        a (~pantr.bezier.Bezier): First operand, holding a C++ handle.
+        b (~pantr.bezier.Bezier): Second operand, holding a C++ handle.
+
+    Returns:
+        ~pantr.bezier.Bezier: The product, wrapping a C++ handle.
+
+    Note:
+        No input validation is performed here; Layer 2 did it above the branch.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bezier import Bezier as BezierCls  # noqa: PLC0415  (cycle)
+
+    impl_a = _cpp_handle(a)
+    impl_b = _cpp_handle(b)
+    order = _pantr_cpp.bezier_product_table_order(impl_a, impl_b)
+    binomials, inverse_binomials = _cpp_binomial_tables(order, a.dtype)
+    return BezierCls._wrap(
+        _pantr_cpp.multiply_bezier(
+            impl_a, impl_b, binomials=binomials, inverse_binomials=inverse_binomials
+        )
+    )
+
+
+def _cpp_compose(outer: Bezier, inner: Bezier) -> Bezier:
+    """Compose two Béziers through the C++ binding.
+
+    Args:
+        outer (~pantr.bezier.Bezier): The outer map, holding a C++ handle.
+        inner (~pantr.bezier.Bezier): The inner map, holding a C++ handle.
+
+    Returns:
+        ~pantr.bezier.Bezier: The composition, wrapping a C++ handle.
+
+    Note:
+        No input validation is performed here; see :func:`_cpp_multiply`.
+    """
+    from pantr import _pantr_cpp  # noqa: PLC0415  (resolved against the .pyi stub)
+
+    from ._bezier import Bezier as BezierCls  # noqa: PLC0415  (cycle)
+
+    impl_outer = _cpp_handle(outer)
+    impl_inner = _cpp_handle(inner)
+    order = _pantr_cpp.bezier_composition_table_order(impl_outer, impl_inner)
+    binomials, inverse_binomials = _cpp_binomial_tables(order, outer.dtype)
+    return BezierCls._wrap(
+        _pantr_cpp.compose_bezier(
+            impl_outer, impl_inner, binomials=binomials, inverse_binomials=inverse_binomials
+        )
+    )
+
+
 # Hoisted to module level rather than rebuilt inside each accessor. An accessor
 # that closed over a fresh function object would return a different callable on
 # every call, which defeats identity comparison in the tests and re-creates a
@@ -782,6 +886,12 @@ _CPP_SLICE_POINT: Final[_SlicePointFunc] = _cpp_slice_point
 
 _CPP_COLLAPSE: Final[_CollapseFunc] = _cpp_collapse
 """The collapse of the C++ backend."""
+
+_CPP_MULTIPLY: Final[_MultiplyFunc] = _cpp_multiply
+"""The pointwise product of the C++ backend."""
+
+_CPP_COMPOSE: Final[_ComposeFunc] = _cpp_compose
+"""The composition of the C++ backend."""
 
 
 def evaluate_kernel(backend: Backend | None = None) -> _EvaluateFunc:
@@ -1097,3 +1207,39 @@ def collapse_kernel(backend: Backend | None = None) -> _CollapseFunc:
     from ._bezier_collapse import _collapse_python  # noqa: PLC0415  (cycle)
 
     return _select(backend, _collapse_python, _CPP_COLLAPSE)
+
+
+def multiply_kernel(backend: Backend | None = None) -> _MultiplyFunc:
+    """Return the pointwise product of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _MultiplyFunc: Callable as ``(a, b) -> Bezier``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    from ._bezier_product import _multiply_python  # noqa: PLC0415  (cycle)
+
+    return _select(backend, _multiply_python, _CPP_MULTIPLY)
+
+
+def compose_kernel(backend: Backend | None = None) -> _ComposeFunc:
+    """Return the composition of the requested backend.
+
+    Args:
+        backend (Backend | None): The backend to use. ``None`` means the backend
+            currently in effect. Defaults to None.
+
+    Returns:
+        _ComposeFunc: Callable as ``(outer, inner) -> Bezier``.
+
+    Raises:
+        RuntimeError: If ``backend`` is given and is not available.
+    """
+    from ._bezier_compose import _compose_python  # noqa: PLC0415  (cycle)
+
+    return _select(backend, _compose_python, _CPP_COMPOSE)

--- a/src/pantr/bezier/_bezier_backend.py
+++ b/src/pantr/bezier/_bezier_backend.py
@@ -71,13 +71,24 @@ that do not still hand Layer 2 an array to fill before wrapping it in a
 - :class:`DegreeKernels`: the elevation and reduction-apply kernels of one backend.
 - :func:`evaluate_kernel`, :func:`evaluate_deriv_kernel`, :func:`slice_kernel`,
   :func:`split_kernel`, :func:`restrict_kernel`, :func:`product_kernel`,
-  :func:`degree_kernels`: the accessors over the 1D kernels.
+  :func:`degree_kernels`: the accessors over the 1D kernels, which take arrays.
 - :func:`evaluate_nd_kernel`, :func:`evaluate_nd_lattice_kernel`: the two
   n-dimensional contraction schedules, which take the Bézier rather than its
   arrays.
+- :func:`elevate_degree_kernel`, :func:`reduce_degree_kernel`,
+  :func:`degree_reduction_error_kernel`: the three n-dimensional degree
+  operations, which take the Bézier and, for the latter two, matrices assembled
+  in exact arithmetic on the Python side.
+- :func:`restrict_nd_kernel`, :func:`split_nd_kernel`, :func:`slice_nd_kernel`,
+  :func:`slice_point_kernel`, :func:`collapse_kernel`: the shape operations that
+  are dispatched.
 - :func:`multiply_kernel`, :func:`compose_kernel`: the product and the
   composition, which likewise take Béziers.  Their C++ side is handed the
   binomial tables as data; see :func:`_cpp_multiply`.
+
+This list is meant to be exhaustive.  It was not: an earlier version named seven
+of the seventeen accessors then in the file, which is the same failure as the
+stale count above and is why both are called out here rather than quietly fixed.
 """
 
 from __future__ import annotations
@@ -747,18 +758,24 @@ def _cpp_collapse(bezier: Bezier, axis: int, values: _Array) -> Bezier:
 def _cpp_binomial_tables(
     order: int, dtype: npt.DTypeLike
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
-    """Assemble the binomial tables the C++ product and composition are handed.
+    """Fetch the binomial tables the C++ product and composition are handed.
+
+    Normalising the dtype is the whole of this function beyond the lazy import.
+    :func:`~pantr.bezier._bezier_product._binomial_tables` is cached on its arguments,
+    and ``np.float32`` and ``np.dtype("float32")`` are equal without being identical,
+    so a caller that reached the cache with either spelling would get two entries for
+    one table and no error to say so.
 
     Args:
         order (int): Largest upper index the operation will read.
-        dtype (npt.DTypeLike): The Bézier's storage format.
+        dtype (npt.DTypeLike): The Bézier's storage format, in any spelling.
 
     Returns:
-        tuple: The coefficient table and the reciprocal table.
+        tuple: The coefficient table and the reciprocal table, read-only.
     """
     from ._bezier_product import _binomial_tables  # noqa: PLC0415  (cycle)
 
-    return _binomial_tables(order, dtype)
+    return _binomial_tables(order, np.dtype(dtype))
 
 
 def _cpp_multiply(a: Bezier, b: Bezier) -> Bezier:

--- a/src/pantr/bezier/_bezier_compose.py
+++ b/src/pantr/bezier/_bezier_compose.py
@@ -1,11 +1,20 @@
 """Bézier composition.
 
-This module provides :func:`_compose_bezier`, which computes the exact
-composition of two non-rational Bézier objects: ``outer(inner(t))``.
+This module provides :func:`_compose_bezier`, which composes two non-rational
+Bézier objects: ``outer(inner(t))``.
 
 The algorithm decomposes each scalar component of the inner Bézier into
 Bernstein basis evaluations of the outer's degree, then combines them
 with the outer's control points via a multi-index weighted summation.
+
+The composed degree ``sum(outer.degree) * inner.degree[s]`` represents the
+composition **exactly**; this module used to call the composition itself exact,
+which is true of the representation and false of the coefficients.  Those are
+built from repeated Bernstein products in floating point and carry every one of
+their roundings, and there are many: a composition runs the product once per
+power of the inner map and again per tensor term.
+``cpp/include/pantr/bezier/product.hpp`` states the same distinction for the C++
+port.
 """
 
 from __future__ import annotations
@@ -18,7 +27,7 @@ import numpy as np
 import numpy.typing as npt
 
 from ..bspline._bspline_degree_core import _check_bincoeff_envelope
-from ._bezier_backend import product_kernel
+from ._bezier_backend import compose_kernel, product_kernel
 from ._bezier_product import _bernstein_product_coefficients_nd
 
 if TYPE_CHECKING:
@@ -68,7 +77,7 @@ def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
     # reaches the largest product degree formed.  That is the full composed degree
     # ``sum(outer.degree) * inner.degree[0]``: the per-direction power ladder in
     # ``_compute_scalar_powers`` climbs to ``outer.degree[d] * inner.degree[0]``, and
-    # the cross-direction accumulation in ``_compose_impl`` then multiplies the
+    # the cross-direction accumulation in ``_compose_python`` then multiplies the
     # per-direction bases together.  The envelope is therefore *multiplicative* in the
     # operands and binds at far lower input degrees than degree elevation's additive
     # one: an outer of degree 6 composed with an inner of degree 11 already asks for
@@ -89,11 +98,11 @@ def _compose_bezier(outer: Bezier, inner: Bezier) -> Bezier:
             composed, f"Composition to degree {composed} with a 1D inner Bézier"
         )
 
-    return _compose_impl(outer, inner)
+    return compose_kernel()(outer, inner)
 
 
-def _compose_impl(outer: Bezier, inner: Bezier) -> Bezier:
-    """Compute the composition of two non-rational Bézier objects.
+def _compose_python(outer: Bezier, inner: Bezier) -> Bezier:
+    """Compose with NumPy and the Numba product kernel: the oracle for the port.
 
     Implements the Bernstein basis decomposition algorithm:
 
@@ -112,8 +121,7 @@ def _compose_impl(outer: Bezier, inner: Bezier) -> Bezier:
         ~pantr.bezier.Bezier: The composed Bézier.
 
     Note:
-        Validation is performed by :func:`_compose_bezier`; this function
-        assumes both operands have already been validated.
+        No input validation is performed here; Layer 2 did it above the branch.
     """
     from . import Bezier as BezierCls  # noqa: PLC0415
 

--- a/src/pantr/bezier/_bezier_product.py
+++ b/src/pantr/bezier/_bezier_product.py
@@ -23,6 +23,7 @@ resemble.
 
 from __future__ import annotations
 
+import functools
 import itertools
 import math
 from typing import TYPE_CHECKING
@@ -169,10 +170,11 @@ def _bernstein_product_coefficients_nd(
 # ---------------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=64)
 def _binomial_tables(
-    order: int, dtype: npt.DTypeLike
+    order: int, dtype: np.dtype[np.float32] | np.dtype[np.float64]
 ) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
-    """Tabulate ``C(n, k)`` and ``1 / C(n, k)`` for ``n <= order``, in one dtype.
+    """Return the cached, read-only ``C(n, k)`` and ``1 / C(n, k)`` for ``n <= order``.
 
     The two tables the C++ product and composition are handed instead of assembling
     their own; ``cpp/include/pantr/bezier/product.hpp`` argues why they cross as data
@@ -189,25 +191,47 @@ def _binomial_tables(
     expression, ``float(math.comb(m, i))`` multiplied into an array, and that value is
     the same as this table's for every argument.  A ``float32`` table is reached there
     by rounding the exact integer to ``float64`` and then to ``float32``, and here in
-    one step; the two agree because ``float64`` carries 53 significand bits against
-    ``float32``'s 24 and double rounding through an intermediate of at least
-    ``2 * 24 + 2`` bits is equal to single rounding (Figueroa, *Yet another proof of
-    the double rounding theorem*, 1995).  ``float64`` storage is the trivial case,
-    where both spellings are one correctly rounded conversion.
-    ``test_the_two_spellings_of_a_binomial_agree`` in
-    ``tests/parity/test_bezier_product.py`` checks it over the whole range these
-    operations reach, because the argument is a theorem about a hypothesis this code
-    has to satisfy rather than about this code.
+    one step, and double rounding through an intermediate format sufficiently wider
+    than the target is known to equal single rounding (Figueroa, *When is double
+    rounding innocuous?*, ACM SIGNUM Newsletter 30(3):21-26, 1995,
+    :doi:`10.1145/221332.221334`; ``float64``/``float32`` is the instance its
+    condition on the intermediate precision covers with room to spare).  ``float64``
+    storage is the trivial case, where both spellings are one correctly rounded
+    conversion.
+
+    **That argument is why the two are expected to agree; what establishes it is
+    a test.**  ``test_the_two_spellings_of_a_binomial_agree`` in
+    ``tests/parity/test_bezier_product.py`` drives the oracle's own expression --
+    the scalar multiplied into an array, promotion rules included -- against this
+    table over the whole range these operations reach.
+
+    **Why this is cached.**  The tables depend on nothing but ``order`` and ``dtype``,
+    both bounded, and building them is ``O(order**2)`` where the product that consumes
+    them reads three rows.  Uncached, the build dominated the whole C++ call and the
+    port was at parity with the numpy path it replaced; the commit that added this
+    cache carries the measurement and the command that produced it.  The same
+    treatment, for the same reason, as the reduction operators in
+    :mod:`~pantr.bezier._bezier_degree`, and the arrays are returned read-only for the
+    same reason too: a cache hit hands out the same object every time.
+
+    Not :func:`~pantr._backend.backend_keyed_cache`, which exists to stop one
+    backend's value being served to another.  These tables come from
+    :func:`math.comb` and are the same whichever backend asked.
 
     Entries with ``k > n`` are zero and are never read.
 
     Args:
         order (int): Largest upper index to tabulate, so the tables are
             ``(order + 1, order + 1)``.
-        dtype (npt.DTypeLike): Storage format, matching the Bézier's.
+        dtype (np.dtype[np.float32] | np.dtype[np.float64]): Storage format, matching
+            the Bézier's.  A concrete :class:`numpy.dtype` rather than anything
+            :obj:`~numpy.typing.DTypeLike` accepts, because it is a cache key and
+            ``np.float32`` and ``np.dtype("float32")`` are equal but not identical,
+            so admitting both would halve the hit rate silently.
 
     Returns:
-        tuple: The coefficient table and the reciprocal table, both C-contiguous.
+        tuple: The coefficient table and the reciprocal table, both C-contiguous and
+        both read-only.
     """
     size = order + 1
     binomials = np.zeros((size, size), dtype=dtype)
@@ -216,6 +240,8 @@ def _binomial_tables(
         exact = [math.comb(n, k) for k in range(n + 1)]
         binomials[n, : n + 1] = np.array(exact, dtype=dtype)
         inverse_binomials[n, : n + 1] = np.array([1.0 / c for c in exact], dtype=dtype)
+    binomials.flags.writeable = False
+    inverse_binomials.flags.writeable = False
     return binomials, inverse_binomials
 
 

--- a/src/pantr/bezier/_bezier_product.py
+++ b/src/pantr/bezier/_bezier_product.py
@@ -1,12 +1,24 @@
 """Bézier pointwise product.
 
-This module provides :func:`_multiply_bezier`, which computes the exact
-pointwise product of two Bézier objects via the Bernstein product formula.
-The result is a Bézier of degree ``p_d + q_d`` per direction.
+This module provides :func:`_multiply_bezier`, which computes the pointwise
+product of two Bézier objects via the Bernstein product formula.  The result is a
+Bézier of degree ``p_d + q_d`` per direction.
+
+That degree represents the product **exactly**: no approximation is made in
+choosing it, unlike degree reduction.  The coefficients are another matter, and
+this module used to call them exact too.  Each is a binomial-weighted sum formed
+in floating point, so each carries the roundings of that sum; the claim of
+exactness is about the representation and not about the computed numbers.
+``cpp/include/pantr/bezier/product.hpp`` states the same distinction for the C++
+port, and ``tests/parity/test_bezier_product.py`` measures how far the two
+backends' coefficients agree.
 
 The core Bernstein product formulas (:func:`_bernstein_product_coefficients`
 and :func:`_bernstein_product_coefficients_nd`) are also used by the B-spline
-product modules.
+product modules, and are **not** dispatched: they stay pure numpy on either
+backend.  ``design/cross_backend_types.md`` records why, and the C++ port
+reproduces them rather than routing through the scalar product kernel they
+resemble.
 """
 
 from __future__ import annotations
@@ -19,6 +31,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .._control_points_utils import _append_unit_weight_column
+from ._bezier_backend import multiply_kernel
 
 if TYPE_CHECKING:
     from . import Bezier
@@ -156,11 +169,64 @@ def _bernstein_product_coefficients_nd(
 # ---------------------------------------------------------------------------
 
 
-def _multiply_bezier(a: Bezier, b: Bezier) -> Bezier:
-    """Compute the exact pointwise product of two Bézier objects.
+def _binomial_tables(
+    order: int, dtype: npt.DTypeLike
+) -> tuple[npt.NDArray[np.float32 | np.float64], npt.NDArray[np.float32 | np.float64]]:
+    """Tabulate ``C(n, k)`` and ``1 / C(n, k)`` for ``n <= order``, in one dtype.
 
-    Validates that both operands have matching dimension, dtype, and rank,
-    then dispatches to the non-rational or rational implementation.
+    The two tables the C++ product and composition are handed instead of assembling
+    their own; ``cpp/include/pantr/bezier/product.hpp`` argues why they cross as data
+    rather than being computed natively.  The short of it: :func:`math.comb` is exact
+    at any size and the C++ exact-integer recurrence stops at ``61``, so a native
+    assembly would import an envelope into an operation that does not have one.
+
+    Every entry is built by **exactly the expression the numpy oracle uses**, which is
+    what makes the comparison a comparison of the product rather than of two table
+    assemblies: ``np.array([math.comb(n, k) ...], dtype=dtype)`` for the coefficients
+    and ``np.array([1.0 / math.comb(n, k) ...], dtype=dtype)`` for the reciprocals.
+
+    :mod:`~pantr.bezier._bezier_compose` reaches its binomials through a third
+    expression, ``float(math.comb(m, i))`` multiplied into an array, and that value is
+    the same as this table's for every argument.  A ``float32`` table is reached there
+    by rounding the exact integer to ``float64`` and then to ``float32``, and here in
+    one step; the two agree because ``float64`` carries 53 significand bits against
+    ``float32``'s 24 and double rounding through an intermediate of at least
+    ``2 * 24 + 2`` bits is equal to single rounding (Figueroa, *Yet another proof of
+    the double rounding theorem*, 1995).  ``float64`` storage is the trivial case,
+    where both spellings are one correctly rounded conversion.
+    ``test_the_two_spellings_of_a_binomial_agree`` in
+    ``tests/parity/test_bezier_product.py`` checks it over the whole range these
+    operations reach, because the argument is a theorem about a hypothesis this code
+    has to satisfy rather than about this code.
+
+    Entries with ``k > n`` are zero and are never read.
+
+    Args:
+        order (int): Largest upper index to tabulate, so the tables are
+            ``(order + 1, order + 1)``.
+        dtype (npt.DTypeLike): Storage format, matching the Bézier's.
+
+    Returns:
+        tuple: The coefficient table and the reciprocal table, both C-contiguous.
+    """
+    size = order + 1
+    binomials = np.zeros((size, size), dtype=dtype)
+    inverse_binomials = np.zeros((size, size), dtype=dtype)
+    for n in range(size):
+        exact = [math.comb(n, k) for k in range(n + 1)]
+        binomials[n, : n + 1] = np.array(exact, dtype=dtype)
+        inverse_binomials[n, : n + 1] = np.array([1.0 / c for c in exact], dtype=dtype)
+    return binomials, inverse_binomials
+
+
+def _multiply_bezier(a: Bezier, b: Bezier) -> Bezier:
+    """Compute the pointwise product of two Bézier objects.
+
+    Validates that both operands have matching dimension, dtype, and rank, then
+    hands the pair to the active backend.  The result has degree ``p_d + q_d`` per
+    direction, which represents the product exactly; its coefficients are a
+    binomial-weighted sum in floating point and carry that sum's roundings.  See the
+    module docstring.
 
     Args:
         a (~pantr.bezier.Bezier): First operand.
@@ -180,6 +246,22 @@ def _multiply_bezier(a: Bezier, b: Bezier) -> Bezier:
     if a.rank != b.rank:
         raise ValueError(f"Operands must have the same rank. Got {a.rank} and {b.rank}.")
 
+    return multiply_kernel()(a, b)
+
+
+def _multiply_python(a: Bezier, b: Bezier) -> Bezier:
+    """Multiply with NumPy: the oracle for the port.
+
+    Args:
+        a (~pantr.bezier.Bezier): First operand.
+        b (~pantr.bezier.Bezier): Second operand.
+
+    Returns:
+        ~pantr.bezier.Bezier: The product.
+
+    Note:
+        No input validation is performed here; Layer 2 did it above the branch.
+    """
     if a.is_rational or b.is_rational:
         return _multiply_rational(a, b)
     return _multiply_nonrational(a, b)

--- a/tests/parity/test_bezier_arithmetic.py
+++ b/tests/parity/test_bezier_arithmetic.py
@@ -1121,12 +1121,19 @@ def test_compose_is_bitwise(
 
     Driven through :meth:`Bezier.compose` and **not** through
     :meth:`Bezier.multiply`, which is the route a first draft of this test took and
-    which exercises none of the ported code. For a 1D Bézier ``multiply`` goes to
-    ``_bernstein_product_coefficients`` (and to its ``_nd`` sibling above 1D), both
-    pure-numpy helpers that are not dispatched at all; the scalar 1D product kernel
-    is reached only from ``compose``, and only when the inner map is univariate. The
-    mistake was caught by mutation: reassociating the kernel's accumulation left the
-    ``multiply`` version passing.
+    which exercised none of the ported code: at the time ``multiply`` reached
+    ``_bernstein_product_coefficients`` and its ``_nd`` sibling, pure-numpy helpers
+    with no C++ counterpart. The mistake was caught by mutation, reassociating the
+    kernel's accumulation left the ``multiply`` version passing, and
+    ``tests/parity/test_bezier_product.py`` records what closing it took.
+
+    ``multiply`` has since been ported (FELIGN/pantr#392) and is dispatched, but it
+    is still the wrong route to **this** kernel: the port reproduces those two numpy
+    helpers rather than routing through the scalar product kernel, which
+    ``design/cross_backend_types.md`` rules on and which the two products' differing
+    domains at ``p + q = 80`` are the sharpest reason for. So the scalar 1D product
+    kernel is still reached only from ``compose``, and only when the inner map is
+    univariate.
 
     A composition runs the kernel many times over -- once per Bernstein basis power
     of the inner map, then again for each tensor term -- so a single case here
@@ -1143,13 +1150,18 @@ def test_compose_is_bitwise(
     # at fault: measured, 1e6 to the eighth is 1e48 against a float32 ceiling near
     # 3.4e38. Three decades still spans enough scale for cancellation to bite.
     spread = (-1, 2)
-    outer = Bezier(_mixed_control_points((outer_degree + 1, 2), dtype, 11, spread))
-    inner = Bezier(_mixed_control_points((inner_degree + 1, 1), dtype, 22, spread))
+    outer_net = _mixed_control_points((outer_degree + 1, 2), dtype, 11, spread)
+    inner_net = _mixed_control_points((inner_degree + 1, 1), dtype, 22, spread)
 
+    # Constructed inside each context rather than once outside, which is what every
+    # other Bezier-level parity test does: since FELIGN/pantr#392 ported `compose`
+    # itself, a Bezier carries its backend's implementation and cannot be composed
+    # under the other one -- the same rule `evaluate`, `split` and `elevate_degree`
+    # already impose, and `_bezier_backend._cpp_handle` refuses rather than converts.
     with use_backend(Backend.PYTHON):
-        reference = outer.compose(inner).control_points
+        reference = Bezier(outer_net).compose(Bezier(inner_net)).control_points
     with use_backend(Backend.CPP):
-        actual = outer.compose(inner).control_points
+        actual = Bezier(outer_net).compose(Bezier(inner_net)).control_points
 
     assert_parity(
         actual,

--- a/tests/parity/test_bezier_product.py
+++ b/tests/parity/test_bezier_product.py
@@ -1,0 +1,762 @@
+r"""Parity of the Bézier product and composition against their NumPy oracles.
+
+`cpp/include/pantr/bezier/product.hpp` names this file as the place its parity
+claims are measured.
+
+Both claims are **equalities**, and for `multiply` that is not a happy accident:
+the oracle is `_bernstein_product_coefficients` and its `_nd` sibling, pure NumPy
+helpers whose operation order the port reproduces term for term. Reassociating any
+one of the three orderings `product.hpp` enumerates changes the last bits, and the
+mutation section below records what each is worth.
+
+The oracle is NumPy, not Numba, and that changes two things
+----------------------------------------------------------
+
+**The arithmetic runs at the storage width.** NumPy computes a ``float32``
+expression in ``float32``, so every intermediate in the port is ``T`` and the
+accumulator of these claims is the storage format rather than ``float64``. That
+inverts `test_bezier_arithmetic.py`, whose kernels promote their ``float64``
+coefficient tables against a narrow array and so accumulate wide. The practical
+consequence for the bound is that Rule 10's *storage* roundings are charged at zero
+here -- there is no narrowing store to straddle a boundary, because the accumulator
+is the output array itself -- and only the three accumulator roundings remain.
+
+**No claim here needs :func:`demand_the_compiled_kernel`, except one.**
+``NUMBA_DISABLE_JIT=1`` replaces the *Numba* kernels with interpreted Python, which
+is Rule 12's whole subject; it does nothing at all to NumPy. `multiply` reaches no
+Numba, so its ``float32`` claim stands under interpretation. `compose` reaches the
+Numba product kernel and only for a **univariate** inner map, so exactly that
+parametrization is gated and the n-dimensional one is not.
+
+`p + q = 80`, which is the point of the tables crossing as data
+--------------------------------------------------------------
+
+`test_the_product_stays_exact_where_the_kernel_leaves_its_envelope` multiplies two
+degree-40 curves. The result's binomials reach ``C(80, 40)``, which is nineteen
+above ``_BINCOEFF_MAX_N``: `scalar_bernstein_product_1d` is undefined there and the
+NumPy helper is not, because :func:`math.comb` is arbitrary precision. That
+difference of domain is one of the three reasons
+``design/cross_backend_types.md`` gives for `multiply` never routing through the
+kernel, and it is why the C++ port is handed its tables rather than computing them.
+A port that had assembled them from ``core::bincoeff`` would agree on every case in
+this file but that one.
+
+Where the composition's fused-build coverage actually comes from
+---------------------------------------------------------------
+
+On a build with a fused multiply-add the composition's parity test skips, for the
+reason `test_bezier_arithmetic.py`'s ``_OPERANDS_NOT_OBSERVABLE`` already records
+and which the whole-composition port does not improve: the products' operands are
+formed inside the composition, so the only amplification available from the public
+surface is the companion run on absolute values, and against an outer net spanning
+three decades whose result cancels that bound is one the harness refuses as
+vacuous.
+
+What covers the arithmetic there instead, stated so the gap is not larger than it
+looks: the composition's products are the same two implementations `multiply` uses,
+and both have a bounded arm here;
+``test_the_product_kernel_matches_the_oracle_at_its_own_entry`` in
+`test_bezier_arithmetic.py` covers the univariate kernel at its own entry. What is
+**not** covered on a fusing build is the composition's own final accumulation,
+``result += coef * basis``, and that is a real residual gap rather than an
+oversight.
+
+The mutation record
+-------------------
+
+AC5 of FELIGN/pantr#392 makes a mutation check mandatory here rather than
+customary, because this is the exact place a parity test in this repo once
+exercised none of the ported code. Seven mutations were applied one at a time to
+`cpp/include/pantr/bezier/product.hpp`, the extension rebuilt for each, and this
+file run against it; the baseline is **80 passed**.
+
+Five are caught:
+
+1. **Accumulate the univariate product in ``j``-major order** (swap the two loops of
+   ``bernstein_product_1d``): 9 failed.
+2. **Reverse the n-dimensional convolution's multi-index order** (count ``alpha``
+   down instead of up): 25 failed.
+3. **Reassociate ``(coeff * f_i) * g_j`` to ``coeff * (f_i * g_j)``**: 20 failed.
+4. **Compute the univariate term in ``accumulator_t<T>``** rather than at the storage
+   width: 9 failed, every one of them ``float32``, which is the whole point of Rule 9.
+5. **Swap the operands of the power recurrence** in ``scalar_net_powers``
+   (``g * g^(k-1)`` for ``g^(k-1) * g``): 8 failed. This one reaches only through
+   ``compose``, so it is what pins that the composition is ported rather than merely
+   dispatched.
+
+Two survive, and that is a fact about the arithmetic rather than a gap here:
+
+6. **Accumulate ``d[k] + term`` in ``accumulator_t<T>``**: 80 passed.
+7. **Weight the n-dimensional operands in ``accumulator_t<T>``**: 80 passed.
+
+Both widen a **single** operation and narrow it straight back, which cannot move the
+result: a product of two ``float32`` values is exact in ``double``, and a sum of two
+of them is subject to the double-rounding theorem `product.hpp`'s width section
+cites. Mutation 3 and mutation 4 are the ones that widen a *chain*, and both are
+caught. Nothing here would notice a widening that is provably a no-op, and nothing
+should.
+
+The counts are in this docstring rather than beside an assertion because they are
+counts over a particular parametrization, and a reader deciding whether to believe
+one wants the parametrization.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Final, cast
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pantr._backend import Backend, use_backend
+from pantr.bezier import Bezier
+from pantr.bspline._bspline_degree_core import _BINCOEFF_MAX_N
+from tests._parity_harness import (
+    ParityClaim,
+    Roundings,
+    assert_parity,
+    bitwise_parity,
+    bounded_parity,
+    contraction_may_fuse,
+    demand_the_compiled_kernel,
+)
+from tests.parity.test_bezier_arithmetic import (
+    _ACCUMULATOR_ROUNDINGS_PER_STAGE,
+    _FUSED_PREFIX,
+    _STORAGE_ROUNDINGS_PER_STAGE,
+    demand_a_bound_the_claim_can_carry,
+)
+
+DTYPES: Final = (np.float64, np.float32)
+"""Both storage formats."""
+
+DEGREE_PAIRS: Final = (
+    ((3,), (2,)),
+    ((1,), (5,)),
+    ((0,), (4,)),
+    ((2, 2), (1, 3)),
+    ((3, 1), (0, 2)),
+    ((1, 1, 1), (2, 1, 2)),
+)
+"""Operand degree tuples, dim 1 to 3, including a degree-0 direction on either side.
+
+A degree-0 direction is not decoration: it is the case where one operand contributes
+a single coefficient along an axis, so an off-by-one in the convolution's extents
+still produces an array of the right total size in one dimension and the wrong one
+above.
+"""
+
+RANKS: Final = (1, 3)
+"""Output ranks: a scalar field and a vector one."""
+
+_TINY: Final = float(np.finfo(np.float64).tiny)
+"""Floor for an amplification, so a tolerance is never identically zero."""
+
+_PRODUCT_WHY: Final = (
+    "both backends run the same NumPy expression in the same order over +, * and /, "
+    "each pinned by IEEE 754 to one correctly rounded result: the reciprocal binomial "
+    "folded into the coefficient before any accumulation for a curve and applied to "
+    "the finished convolution above one, the two control values multiplied in left to "
+    "right, and each coefficient's sum taken in the order np.add.at applies its index "
+    "array, which is i-major. The binomial tables cross as data, assembled once by "
+    "math.comb and rounded to the storage format by the same expression the oracle "
+    "uses, so neither backend assembles its own. No fused multiply-add on this build"
+)
+
+_PRODUCT_FUSED_WHY: Final = (
+    "one fused site per accumulated term, `d[k] + coeff * f_i * g_j`, so the chain is "
+    "as long as the number of terms reaching one coefficient. The weights "
+    "C(p,i) C(q,j) / C(p+q,k) are non-negative and sum to one over the terms of "
+    "coefficient k, by Vandermonde's identity, so the amplification is the exact "
+    "convex sum of |f_i g_j| -- obtained by running the same product on |c|, which is "
+    "that sum term for term. The ACCUMULATOR IS THE STORAGE FORMAT here, unlike every "
+    "other Bezier claim: the oracle is NumPy rather than Numba and accumulates "
+    "directly into the output array, so there is no narrowing store and Rule 10's "
+    "storage roundings are charged at zero rather than at two"
+)
+
+_COMPOSITION_WHY: Final = (
+    "the composition is a fixed sequence of Bernstein products, binomial scalings and "
+    "accumulations, and both backends run it in the same order: the powers of the "
+    "inner map built by repeated multiplication by g rather than by squaring, the "
+    "bases assembled as B_0 then the scaled interior then B_m, the tensor terms "
+    "multiplied in ascending direction, and the result accumulated in row-major order "
+    "over the outer control points. Each product is dispatched exactly as the oracle "
+    "dispatches it -- the Numba scalar kernel for a univariate inner map, the NumPy "
+    "n-dimensional helper above that -- and those two differ in accumulation width and "
+    "in where they normalise, so the branch is part of this claim rather than an "
+    "implementation detail. No fused multiply-add on this build"
+)
+
+_COMPOSITION_OPERANDS_NOT_OBSERVABLE: Final = (
+    "this build can fuse, and every product's operands are formed inside the "
+    "composition. The only amplification the public surface offers is the companion "
+    "run on absolute values, which the harness refuses as vacuous against a net whose "
+    "result cancels. test_bezier_arithmetic.py records the same conclusion for the "
+    "same reason; porting the whole composition rather than only its kernel does not "
+    "make the intermediates observable. The module docstring names what covers the "
+    "arithmetic on such a build and what is left uncovered."
+)
+
+
+def _net(
+    degrees: tuple[int, ...], rank: int, dtype: npt.DTypeLike, seed: int, *, rational: bool
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build a control net spanning many magnitudes, weights bounded away from zero.
+
+    Three decades rather than the twelve `_mixed_control_points` defaults to, because
+    a product multiplies its operands: two entries of 1e6 make 1e12, and a
+    composition raises one operand to the outer degree, so the wide default overflows
+    ``float32`` well before any port is at fault.
+
+    Args:
+        degrees (tuple[int, ...]): Degree per direction.
+        rank (int): Number of value components, weight excluded.
+        dtype (npt.DTypeLike): Storage format.
+        seed (int): Generator seed.
+        rational (bool): Whether to append a weight column.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The control net.
+    """
+    rng = np.random.default_rng(seed)
+    components = rank + 1 if rational else rank
+    shape = (*(degree + 1 for degree in degrees), components)
+    net = rng.standard_normal(shape) * 10.0 ** rng.integers(-1, 2, shape)
+    net = np.ascontiguousarray(net, dtype=dtype)
+    if rational:
+        net[..., -1] = np.asarray(rng.uniform(0.5, 2.0, net.shape[:-1]), dtype=dtype)
+    return net
+
+
+def _reparametrization(
+    degrees: tuple[int, ...], rank: int, dtype: npt.DTypeLike, seed: int
+) -> npt.NDArray[np.float32 | np.float64]:
+    """Build an inner map whose coefficients live in the unit interval.
+
+    A genuine reparametrization, and the only kind whose powers stay bounded: the
+    composition raises the inner map to the outer degree, so a coefficient of 10
+    composed with a degree-8 outer map is 1e8 before anything is at fault.
+
+    The first two coefficients are pinned to 0.9 and 0.1, neither representable in
+    ``float32``. `shape.hpp` records what a power-of-two fraction hides, and the same
+    trap applies to a value that reaches the port through a table or a subtraction.
+
+    Args:
+        degrees (tuple[int, ...]): Degree per direction.
+        rank (int): Number of components, which must be the outer map's dimension.
+        dtype (npt.DTypeLike): Storage format.
+        seed (int): Generator seed.
+
+    Returns:
+        npt.NDArray[np.float32 | np.float64]: The control net.
+    """
+    rng = np.random.default_rng(seed)
+    shape = (*(degree + 1 for degree in degrees), rank)
+    net = np.ascontiguousarray(rng.uniform(0.0, 1.0, shape), dtype=dtype)
+    # Assigned as Python floats and narrowed by the array's own dtype, which is one
+    # rounding and the same one a coefficient read from a file would carry.
+    flat = net.reshape(-1)
+    flat[0] = 0.9
+    if flat.size > 1:
+        flat[1] = 0.1
+    return net
+
+
+def _companion(values: npt.NDArray[Any]) -> npt.NDArray[np.float64]:
+    """Floor an amplification so a tolerance is never identically zero.
+
+    Args:
+        values (npt.NDArray[Any]): The reachable magnitudes.
+
+    Returns:
+        npt.NDArray[np.float64]: The same, floored at the smallest normal double.
+    """
+    return np.asarray(np.maximum(np.abs(np.asarray(values, dtype=np.float64)), _TINY))
+
+
+def _storage_width_claim(
+    why: str,
+    fused_why: str,
+    *,
+    stages: int,
+    amplification: npt.NDArray[np.float64],
+    dtype: npt.DTypeLike,
+) -> ParityClaim:
+    """Bitwise where the build cannot fuse, Rule 10's budget where it can.
+
+    The same shape as `test_bezier_shape.py`'s ``_inherited`` and
+    `test_bezier_arithmetic.py`'s ``_parity_claim``, with one deliberate difference:
+    the accumulator is the **storage** format, because the oracle here is NumPy and
+    accumulates into the output array. That makes the harness charge Rule 10's
+    storage roundings at zero, which is correct rather than convenient -- there is no
+    narrowing store for two nearby values to straddle.
+
+    Args:
+        why (str): The derivation for the bitwise arm.
+        fused_why (str): The derivation for the fused arm, prefixed with the shared
+            contraction argument.
+        stages (int): Length of the dependency chain the fused sites sit on.
+        amplification (npt.NDArray[np.float64]): Elementwise magnitude.
+        dtype (npt.DTypeLike): Storage format, and the accumulator too.
+
+    Returns:
+        ParityClaim: BITWISE or BOUNDED, whichever this build supports.
+    """
+    if not contraction_may_fuse():
+        return bitwise_parity(why=why)
+    return bounded_parity(
+        roundings=Roundings(
+            stages=stages,
+            accumulator_per_stage=_ACCUMULATOR_ROUNDINGS_PER_STAGE,
+            storage_per_stage=_STORAGE_ROUNDINGS_PER_STAGE,
+        ),
+        accumulator=dtype,
+        storage=dtype,
+        amplification=amplification,
+        why=f"{_FUSED_PREFIX}{fused_why}",
+    )
+
+
+def _product_stages(left: tuple[int, ...], right: tuple[int, ...]) -> int:
+    """The most terms that reach one coefficient of the product.
+
+    ``prod_d (min(p_d, q_d) + 1)``: coefficient ``gamma`` accumulates one term per
+    multi-index ``alpha`` with ``alpha <= gamma <= alpha + q``, and the widest such
+    range in direction ``d`` has ``min(p_d, q_d) + 1`` entries. The univariate case
+    is the same formula at one direction, which is the stage count
+    `test_bezier_arithmetic.py` uses for the kernel.
+
+    Args:
+        left (tuple[int, ...]): Degrees of the first operand.
+        right (tuple[int, ...]): Degrees of the second.
+
+    Returns:
+        int: The stage count, at least 1.
+    """
+    stages = 1
+    for p_d, q_d in zip(left, right, strict=True):
+        stages *= min(p_d, q_d) + 1
+    return stages
+
+
+def _product_amplification(
+    left: npt.NDArray[Any], right: npt.NDArray[Any], *, rational: bool
+) -> npt.NDArray[np.float64]:
+    """The exact convex sum of ``|f_alpha g_beta|`` reaching each output coefficient.
+
+    Run the same product on the absolute values of both nets, in ``float64`` and on
+    the Python backend. The Bernstein product's weights are non-negative and sum to
+    one over the terms of a coefficient, so the absolute-value companion is that
+    convex sum term for term rather than a bound on it. This is the licence
+    `test_bezier_arithmetic.py`'s ``_absolute_companion`` states, applied to an
+    operation of two arguments.
+
+    Args:
+        left (npt.NDArray[Any]): First control net.
+        right (npt.NDArray[Any]): Second control net.
+        rational (bool): Whether both nets carry a weight column.
+
+    Returns:
+        npt.NDArray[np.float64]: Elementwise magnitude, never exactly zero.
+    """
+    with use_backend(Backend.PYTHON):
+        companion = Bezier(
+            np.abs(np.asarray(left, dtype=np.float64)), is_rational=rational
+        ) * Bezier(np.abs(np.asarray(right, dtype=np.float64)), is_rational=rational)
+    return _companion(companion.control_points)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("rational", [False, True])
+@pytest.mark.parametrize("rank", RANKS)
+@pytest.mark.parametrize(("left_degrees", "right_degrees"), DEGREE_PAIRS)
+def test_the_product_agrees_with_the_oracle(  # noqa: PLR0913 -- four parametrization axes
+    cpp_backend: None,
+    left_degrees: tuple[int, ...],
+    right_degrees: tuple[int, ...],
+    rank: int,
+    rational: bool,
+    dtype: npt.DTypeLike,
+) -> None:
+    """The pointwise product agrees bit for bit, reciprocal binomials included.
+
+    Driven through :meth:`Bezier.multiply`, which is the entry point the port
+    replaced. That is worth saying because the opposite mistake is on record here:
+    `test_bezier_arithmetic.py`'s ``test_compose_is_bitwise`` had to be driven through
+    ``compose`` precisely because ``multiply`` reached no ported code at the time.
+    It does now, and ``test_the_product_reaches_the_port`` pins that structurally so
+    a future refactor cannot quietly undo it.
+
+    The rational arm is a separate computation rather than a variation: the operands
+    are promoted to homogeneous form and their numerators and weight columns are
+    multiplied independently, so it exercises the product twice at two different
+    component counts and then a concatenation.
+    """
+    del cpp_backend
+
+    left = _net(left_degrees, rank, dtype, seed=20260831, rational=rational)
+    right = _net(right_degrees, rank, dtype, seed=20260832, rational=rational)
+
+    with use_backend(Backend.PYTHON):
+        reference = np.asarray(
+            (
+                Bezier(left, is_rational=rational) * Bezier(right, is_rational=rational)
+            ).control_points
+        )
+    with use_backend(Backend.CPP):
+        actual = np.asarray(
+            (
+                Bezier(left, is_rational=rational) * Bezier(right, is_rational=rational)
+            ).control_points
+        )
+
+    assert_parity(
+        actual,
+        reference,
+        _storage_width_claim(
+            _PRODUCT_WHY,
+            _PRODUCT_FUSED_WHY,
+            stages=_product_stages(left_degrees, right_degrees),
+            amplification=_product_amplification(left, right, rational=rational),
+            dtype=dtype,
+        ),
+        context=(
+            f"multiply {left_degrees} by {right_degrees} rank {rank} "
+            f"rational {rational} {np.dtype(dtype).name}"
+        ),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_product_stays_exact_where_the_kernel_leaves_its_envelope(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """Two degree-40 curves multiply to degree 80, where the 1-D kernel is undefined.
+
+    ``AC4`` of FELIGN/pantr#392. This is the configuration the two one-dimensional
+    Bernstein products do not share: the NumPy helper reaches ``C(80, 40)`` through
+    :func:`math.comb`, which is arbitrary precision, while
+    ``scalar_bernstein_product_1d`` computes its binomials in ``int64`` and is
+    undefined past ``C(61, k)``. The assertion on ``_BINCOEFF_MAX_N`` is what keeps
+    this test's premise honest: raise that constant above 80 and the test stops being
+    about the divergence and should be retargeted rather than left passing.
+
+    So the port cannot assemble its own tables here, and would silently agree
+    everywhere else if it did.
+    """
+    del cpp_backend
+
+    left_degree = 40
+    right_degree = 40
+    assert left_degree + right_degree > _BINCOEFF_MAX_N, (
+        f"this test exists because the summed degree {left_degree + right_degree} is "
+        f"outside the exact-integer binomial envelope {_BINCOEFF_MAX_N}; inside it, "
+        f"the two 1-D products no longer differ in domain and the test measures "
+        f"nothing it claims to"
+    )
+
+    left = _net((left_degree,), 1, dtype, seed=20260833, rational=False)
+    right = _net((right_degree,), 1, dtype, seed=20260834, rational=False)
+
+    with use_backend(Backend.PYTHON):
+        reference = np.asarray((Bezier(left) * Bezier(right)).control_points)
+    with use_backend(Backend.CPP):
+        actual = np.asarray((Bezier(left) * Bezier(right)).control_points)
+
+    assert actual.shape == (left_degree + right_degree + 1, 1)
+    assert_parity(
+        actual,
+        reference,
+        _storage_width_claim(
+            _PRODUCT_WHY,
+            _PRODUCT_FUSED_WHY,
+            stages=_product_stages((left_degree,), (right_degree,)),
+            amplification=_product_amplification(left, right, rational=False),
+            dtype=dtype,
+        ),
+        context=f"multiply degree 40 by 40 {np.dtype(dtype).name}",
+    )
+
+
+_COMPOSITIONS: Final = (
+    ((3,), (4,), 1),
+    ((8,), (2,), 1),
+    ((1,), (7,), 1),
+    ((0,), (5,), 1),
+    ((2, 3), (2,), 2),
+    ((1, 1), (4,), 2),
+    ((2,), (2, 1), 1),
+    ((3,), (1, 2), 1),
+    ((1, 2), (1, 1), 2),
+    ((2, 1), (2, 2), 2),
+)
+"""``(outer degrees, inner degrees, outer rank)`` configurations.
+
+The inner map's rank is the outer map's dimension, which the composition requires,
+so it is not a free parameter. The first six have a **univariate** inner map and so
+route every product through the Numba scalar kernel; the last four have a
+two-dimensional one and route through the NumPy n-dimensional helper, which no
+parity test reached before this file. ``((0,), (5,), 1)`` and ``((1,), (7,), 1)``
+are the two configurations the oracle exempts from its binomial-envelope check,
+because neither forms a product at all.
+"""
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(("outer_degrees", "inner_degrees", "rank"), _COMPOSITIONS)
+def test_the_composition_agrees_with_the_oracle(
+    cpp_backend: None,
+    outer_degrees: tuple[int, ...],
+    inner_degrees: tuple[int, ...],
+    rank: int,
+    dtype: npt.DTypeLike,
+) -> None:
+    """The composition agrees bit for bit, across both of its product branches.
+
+    `test_bezier_arithmetic.py`'s ``test_compose_is_bitwise`` reaches the univariate
+    branch through the same public method and is not duplicated here: what this adds
+    is the **n-dimensional** branch, which routes through
+    ``_bernstein_product_coefficients_nd`` and which no parity test reached before,
+    plus the degree-0 and degree-1 outer maps the oracle exempts from its envelope
+    check.
+
+    Gated at ``float32`` only where the oracle reaches Numba, which is the univariate
+    branch. Above one dimension the oracle is NumPy end to end and interpretation
+    changes nothing, so gating there would skip a claim that holds.
+    """
+    del cpp_backend
+    if len(inner_degrees) == 1:
+        demand_the_compiled_kernel(dtype)
+    demand_a_bound_the_claim_can_carry(_COMPOSITION_OPERANDS_NOT_OBSERVABLE)
+
+    outer_net = _net(outer_degrees, rank, dtype, seed=20260835, rational=False)
+    inner_net = _reparametrization(inner_degrees, len(outer_degrees), dtype, seed=20260836)
+
+    with use_backend(Backend.PYTHON):
+        reference = np.asarray(Bezier(outer_net).compose(Bezier(inner_net)).control_points)
+    with use_backend(Backend.CPP):
+        actual = np.asarray(Bezier(outer_net).compose(Bezier(inner_net)).control_points)
+
+    expected_degree = tuple(sum(outer_degrees) * n for n in inner_degrees)
+    assert actual.shape == (*(n + 1 for n in expected_degree), rank)
+
+    assert_parity(
+        actual,
+        reference,
+        bitwise_parity(why=_COMPOSITION_WHY),
+        context=(
+            f"compose {outer_degrees} with {inner_degrees} rank {rank} {np.dtype(dtype).name}"
+        ),
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_product_reaches_the_port(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """The C++ backend's product returns a C++ value, and the catalogue routes to it.
+
+    ``AC2`` asks the test to demonstrate that it reaches the ported code, and this is
+    the structural half of that demonstration: the mutation record in the module
+    docstring is the empirical half. Both are needed. A mutation proves the code ran
+    for the tree it was applied to; this assertion is what fails on a later refactor
+    that reroutes :meth:`Bezier.multiply` back to the NumPy helper without touching
+    the numbers, which is precisely the failure that went unnoticed here once.
+
+    The composition is asserted alongside it because its adapter is the same shape
+    and would fail the same way.
+    """
+    del cpp_backend
+
+    from pantr import _pantr_cpp  # noqa: PLC0415
+    from pantr.bezier import _bezier_backend as backend  # noqa: PLC0415
+    from pantr.bezier._bezier_compose import _compose_python  # noqa: PLC0415
+    from pantr.bezier._bezier_product import _multiply_python  # noqa: PLC0415
+
+    assert backend.multiply_kernel(Backend.CPP) is backend._cpp_multiply
+    assert backend.multiply_kernel(Backend.PYTHON) is _multiply_python
+    assert backend.compose_kernel(Backend.CPP) is backend._cpp_compose
+    assert backend.compose_kernel(Backend.PYTHON) is _compose_python
+
+    handles = (_pantr_cpp.Bezier32, _pantr_cpp.Bezier64)
+    curve = _net((2,), 1, dtype, seed=20260837, rational=False)
+    reparametrization = _reparametrization((2,), 1, dtype, seed=20260838)
+    with use_backend(Backend.CPP):
+        product = Bezier(curve) * Bezier(curve)
+        composition = Bezier(curve).compose(Bezier(reparametrization))
+        assert isinstance(product._impl, handles)
+        assert isinstance(composition._impl, handles)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_two_spellings_of_a_binomial_agree(dtype: npt.DTypeLike) -> None:
+    """The table's entries equal the composition oracle's ``float(math.comb(...))``.
+
+    A hypothesis of ``_binomial_tables``' docstring, and one this code has to satisfy
+    rather than one the theorem behind it can be trusted to supply. The oracle reaches
+    a binomial two ways: ``np.array([math.comb(n, k) ...], dtype=dtype)`` in the two
+    product helpers, and ``float(math.comb(m, i))`` multiplied into an array in
+    ``_compute_bernstein_bases``. The first rounds the exact integer to the storage
+    format once; the second rounds it to ``float64`` and then, under NEP 50's weak
+    scalar rule, to the storage format again.
+
+    Double rounding through an intermediate of at least ``2 * 24 + 2 = 50`` bits
+    equals single rounding, and ``float64`` has 53, so the two agree -- but that is a
+    theorem about real numbers rounded twice, and what it is applied to here is a
+    particular expression in a particular language. This checks the application, over
+    the whole range these operations reach and slightly past it.
+
+    Its reciprocal twin needs no such check: both spellings divide in ``float64``
+    before any narrowing, so they are the same expression.
+    """
+    from pantr.bezier._bezier_product import _binomial_tables  # noqa: PLC0415
+
+    order = 96
+    binomials, _ = _binomial_tables(order, dtype)
+    for n in range(order + 1):
+        direct = binomials[n, : n + 1]
+        # `float()` first, so the exact integer is rounded to float64 and then to the
+        # storage format: the composition oracle's two-step route, spelled out.
+        via_double = np.asarray([float(math.comb(n, k)) for k in range(n + 1)], dtype=dtype)
+        assert np.array_equal(direct, via_double), (
+            f"the two spellings of C({n}, k) differ at {np.dtype(dtype).name}; the "
+            f"composition oracle reaches its binomials through float(math.comb(...)) "
+            f"and the product helpers through np.array(..., dtype=dtype), and "
+            f"_binomial_tables serves both"
+        )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_both_backends_refuse_the_same_operands(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """A rejected argument gets one message, whichever backend is active.
+
+    The checks live in Layer 2, above the backend branch, so this is what pins that
+    they were not duplicated into the adapter with different wording. The C++ header
+    carries its own copies for a caller with no Python, and those are compared
+    against the same strings by ``cpp/tests/test_bezier_product.cpp``.
+    """
+    del cpp_backend
+
+    curve = Bezier(_net((2,), 1, dtype, seed=20260839, rational=False))
+    surface = Bezier(_net((2, 2), 1, dtype, seed=20260840, rational=False))
+    vector = Bezier(_net((2,), 3, dtype, seed=20260841, rational=False))
+    weighted = Bezier(_net((2,), 1, dtype, seed=20260842, rational=True), is_rational=True)
+
+    cases: tuple[tuple[Any, Any, type[Exception], str], ...] = (
+        (curve, surface, ValueError, "Operands must have the same dimension."),
+        (curve, vector, ValueError, "Operands must have the same rank."),
+    )
+    for left, right, error, fragment in cases:
+        messages = []
+        for which in (Backend.PYTHON, Backend.CPP):
+            with use_backend(which), pytest.raises(error) as info:
+                left.multiply(right)
+            messages.append(str(info.value))
+        assert fragment in messages[0]
+        assert messages[0] == messages[1], (
+            f"the two backends worded the same rejection differently: "
+            f"{messages[0]!r} against {messages[1]!r}"
+        )
+
+    for which in (Backend.PYTHON, Backend.CPP):
+        with use_backend(which), pytest.raises(TypeError, match="rational"):
+            curve.compose(weighted)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_binding_refuses_a_table_that_is_too_small(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """A short table is refused rather than read past, and the tables cannot be swapped.
+
+    Neither is reachable through :class:`Bezier`, which sizes the tables from the
+    binding's own accessor and passes them by keyword. Both are reachable by a caller
+    that uses the extension directly, which ``cpp/bindings/bezier.cpp`` is explicit
+    about protecting: the two tables have the same dtype and the same shape, so
+    nothing but keyword-only arguments separates them, and transposing them returns a
+    plausible Bézier rather than an error.
+    """
+    del cpp_backend
+
+    from pantr import _pantr_cpp  # noqa: PLC0415
+
+    curve = _net((3,), 1, dtype, seed=20260843, rational=False)
+    # The class is chosen from the array's own dtype one expression earlier, which is a
+    # correlation between a value and a type the checker cannot state; `test_bezier_shape.py`
+    # stands in for it the same way.
+    handle_type = _pantr_cpp.Bezier32 if np.dtype(dtype) == np.float32 else _pantr_cpp.Bezier64
+    handle = handle_type(cast("Any", curve))
+
+    order = _pantr_cpp.bezier_product_table_order(handle, handle)
+    assert order == 6, "two degree-3 curves multiply to degree 6"
+
+    from pantr.bezier._bezier_product import _binomial_tables  # noqa: PLC0415
+
+    binomials, inverse_binomials = _binomial_tables(order, dtype)
+    short, short_inverse = _binomial_tables(order - 1, dtype)
+
+    with pytest.raises(ValueError, match="binomials must have shape at least"):
+        _pantr_cpp.multiply_bezier(
+            handle, handle, binomials=short, inverse_binomials=inverse_binomials
+        )
+    with pytest.raises(ValueError, match="inverse_binomials must have shape at least"):
+        _pantr_cpp.multiply_bezier(
+            handle, handle, binomials=binomials, inverse_binomials=short_inverse
+        )
+    with pytest.raises(TypeError):
+        _pantr_cpp.multiply_bezier(handle, handle, binomials, inverse_binomials)  # type: ignore[misc]
+    assert short_inverse.shape == (order, order)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_product_agrees_over_a_random_sweep(cpp_backend: None, dtype: npt.DTypeLike) -> None:
+    """Sweep the product over many nets, so one seed's luck cannot carry the claim.
+
+    Twenty configurations per dtype, each with its own net, drawn over dimensions one
+    to three and over both rationalities. The per-case parametrization above fixes
+    its seeds so a failure is reproducible; this exists because a fixed seed is
+    exactly what a port can accidentally be tuned to.
+    """
+    del cpp_backend
+
+    rng = np.random.default_rng(20260844)
+    for trial in range(20):
+        dim = int(rng.integers(1, 4))
+        left_degrees = tuple(int(rng.integers(0, 5)) for _ in range(dim))
+        right_degrees = tuple(int(rng.integers(0, 5)) for _ in range(dim))
+        rank = int(rng.integers(1, 4))
+        rational = bool(rng.integers(0, 2))
+
+        left = _net(left_degrees, rank, dtype, seed=90000 + trial, rational=rational)
+        right = _net(right_degrees, rank, dtype, seed=95000 + trial, rational=rational)
+
+        with use_backend(Backend.PYTHON):
+            reference = np.asarray(
+                (
+                    Bezier(left, is_rational=rational) * Bezier(right, is_rational=rational)
+                ).control_points
+            )
+        with use_backend(Backend.CPP):
+            actual = np.asarray(
+                (
+                    Bezier(left, is_rational=rational) * Bezier(right, is_rational=rational)
+                ).control_points
+            )
+
+        assert_parity(
+            actual,
+            reference,
+            _storage_width_claim(
+                _PRODUCT_WHY,
+                _PRODUCT_FUSED_WHY,
+                stages=_product_stages(left_degrees, right_degrees),
+                amplification=_product_amplification(left, right, rational=rational),
+                dtype=dtype,
+            ),
+            context=(
+                f"sweep trial {trial}: multiply {left_degrees} by {right_degrees} "
+                f"rank {rank} rational {rational} {np.dtype(dtype).name}"
+            ),
+        )

--- a/tests/parity/test_bezier_product.py
+++ b/tests/parity/test_bezier_product.py
@@ -41,6 +41,29 @@ kernel, and it is why the C++ port is handed its tables rather than computing th
 A port that had assembled them from ``core::bincoeff`` would agree on every case in
 this file but that one.
 
+The bounded arm is selected on an FMA host and is not exercised by one
+----------------------------------------------------------------------
+
+This is worth stating plainly, because "the bounded arm passes" would otherwise read
+as evidence it does not carry. On a host whose ISA offers a fused multiply-add,
+:func:`~tests._parity_harness.contraction_may_fuse` is true and every `multiply` claim
+below becomes Rule 10's budget. Measured on such a build: **zero elements differ**
+across all forty-eight configurations at both dtypes, so the bounded arm is satisfied
+with nothing to satisfy it against.
+
+That is not a defect in the bound. It is because the product's accumulation is written
+as two statements and this project's `-ffp-contract=on` is expression-scoped, so the
+site it would fuse is not fused; `product.hpp`'s contraction section carries the
+disassembly and the three-way `off`/`on`/`fast` comparison that establish it.
+`-ffp-contract=fast` does fuse it and does move the result, which is why the bounded
+arm stays rather than being replaced by an unconditional equality.
+
+So: **the amplification and stage count below have never been exercised against a real
+disagreement**, and the honest reading of a green bounded arm on an FMA host is "the
+claim is weaker than the truth there", not "the bound was checked". What has been
+checked, on the shipped configuration, is the equality -- and the mutation record below
+is what shows that check has teeth.
+
 Where the composition's fused-build coverage actually comes from
 ---------------------------------------------------------------
 
@@ -51,6 +74,11 @@ formed inside the composition, so the only amplification available from the publ
 surface is the companion run on absolute values, and against an outer net spanning
 three decades whose result cancels that bound is one the harness refuses as
 vacuous.
+
+Unlike `multiply`, the composition's build dependence is real rather than nominal, and
+it comes from somewhere specific: its univariate branch calls
+``scalar_bernstein_product_1d``, whose accumulation is a single expression and does
+carry a fused site at ``-ffp-contract=on``. So the skip is not over-caution.
 
 What covers the arithmetic there instead, stated so the gap is not larger than it
 looks: the composition's products are the same two implementations `multiply` uses,
@@ -186,7 +214,7 @@ _COMPOSITION_WHY: Final = (
     "over the outer control points. Each product is dispatched exactly as the oracle "
     "dispatches it -- the Numba scalar kernel for a univariate inner map, the NumPy "
     "n-dimensional helper above that -- and those two differ in accumulation width and "
-    "in where they normalise, so the branch is part of this claim rather than an "
+    "in where they normalize, so the branch is part of this claim rather than an "
     "implementation detail. No fused multiply-add on this build"
 )
 
@@ -596,16 +624,22 @@ def test_the_two_spellings_of_a_binomial_agree(dtype: npt.DTypeLike) -> None:
     A hypothesis of ``_binomial_tables``' docstring, and one this code has to satisfy
     rather than one the theorem behind it can be trusted to supply. The oracle reaches
     a binomial two ways: ``np.array([math.comb(n, k) ...], dtype=dtype)`` in the two
-    product helpers, and ``float(math.comb(m, i))`` multiplied into an array in
+    product helpers, and ``float(math.comb(m, i)) * prod`` in
     ``_compute_bernstein_bases``. The first rounds the exact integer to the storage
-    format once; the second rounds it to ``float64`` and then, under NEP 50's weak
-    scalar rule, to the storage format again.
+    format once; the second rounds it to ``float64`` and then, when numpy applies the
+    ``float64`` scalar to a narrower array, to the storage format again.
 
-    Double rounding through an intermediate of at least ``2 * 24 + 2 = 50`` bits
-    equals single rounding, and ``float64`` has 53, so the two agree -- but that is a
-    theorem about real numbers rounded twice, and what it is applied to here is a
-    particular expression in a particular language. This checks the application, over
-    the whole range these operations reach and slightly past it.
+    Double rounding through a sufficiently wider intermediate equals single rounding,
+    which is why the two are expected to agree -- but that is a theorem about real
+    numbers rounded twice, and what it is applied to here is a particular expression
+    in a particular library. **So this test performs the oracle's expression rather
+    than a paraphrase of it**: it multiplies the scalar into an array of ones of the
+    storage dtype and reads the result back, which is exactly what
+    ``_compute_bernstein_bases`` does and which therefore carries whatever promotion
+    rule the installed numpy applies. An earlier version of this test compared
+    ``np.asarray([float(...)], dtype=dtype)`` instead, which is a plain conversion and
+    does not exercise scalar-array promotion at all -- it would have passed under a
+    numpy whose promotion rule made the oracle disagree.
 
     Its reciprocal twin needs no such check: both spellings divide in ``float64``
     before any narrowing, so they are the same expression.
@@ -613,17 +647,21 @@ def test_the_two_spellings_of_a_binomial_agree(dtype: npt.DTypeLike) -> None:
     from pantr.bezier._bezier_product import _binomial_tables  # noqa: PLC0415
 
     order = 96
-    binomials, _ = _binomial_tables(order, dtype)
+    binomials, _ = _binomial_tables(order, np.dtype(dtype))
+    ones = np.ones(1, dtype=dtype)
     for n in range(order + 1):
         direct = binomials[n, : n + 1]
-        # `float()` first, so the exact integer is rounded to float64 and then to the
-        # storage format: the composition oracle's two-step route, spelled out.
-        via_double = np.asarray([float(math.comb(n, k)) for k in range(n + 1)], dtype=dtype)
-        assert np.array_equal(direct, via_double), (
+        # The oracle's own expression: a Python float scalar times an array of the
+        # storage dtype. `float()` rounds the exact integer to float64, and numpy's
+        # promotion decides what the multiplication then rounds to.
+        via_the_oracles_route = np.asarray(
+            [(float(math.comb(n, k)) * ones)[0] for k in range(n + 1)], dtype=dtype
+        )
+        assert np.array_equal(direct, via_the_oracles_route), (
             f"the two spellings of C({n}, k) differ at {np.dtype(dtype).name}; the "
             f"composition oracle reaches its binomials through float(math.comb(...)) "
-            f"and the product helpers through np.array(..., dtype=dtype), and "
-            f"_binomial_tables serves both"
+            f"multiplied into an array and the product helpers through "
+            f"np.array(..., dtype=dtype), and _binomial_tables serves both"
         )
 
 
@@ -633,8 +671,9 @@ def test_both_backends_refuse_the_same_operands(cpp_backend: None, dtype: npt.DT
 
     The checks live in Layer 2, above the backend branch, so this is what pins that
     they were not duplicated into the adapter with different wording. The C++ header
-    carries its own copies for a caller with no Python, and those are compared
-    against the same strings by ``cpp/tests/test_bezier_product.cpp``.
+    carries its own copies for a caller with no Python, and those are compared against
+    the same strings by ``check_product_rejections`` and
+    ``check_composition_rejections`` in ``cpp/tests/test_bezier_product.cpp``.
     """
     del cpp_backend
 
@@ -693,8 +732,8 @@ def test_the_binding_refuses_a_table_that_is_too_small(
 
     from pantr.bezier._bezier_product import _binomial_tables  # noqa: PLC0415
 
-    binomials, inverse_binomials = _binomial_tables(order, dtype)
-    short, short_inverse = _binomial_tables(order - 1, dtype)
+    binomials, inverse_binomials = _binomial_tables(order, np.dtype(dtype))
+    short, short_inverse = _binomial_tables(order - 1, np.dtype(dtype))
 
     with pytest.raises(ValueError, match="binomials must have shape at least"):
         _pantr_cpp.multiply_bezier(
@@ -707,6 +746,69 @@ def test_the_binding_refuses_a_table_that_is_too_small(
     with pytest.raises(TypeError):
         _pantr_cpp.multiply_bezier(handle, handle, binomials, inverse_binomials)  # type: ignore[misc]
     assert short_inverse.shape == (order, order)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_the_composition_binding_refuses_what_the_header_says_it_does(
+    cpp_backend: None, dtype: npt.DTypeLike
+) -> None:
+    """``compose_bezier``'s own failure paths, at the extension rather than through Bezier.
+
+    The sibling above covers ``multiply_bezier`` this way and this one did not, which
+    matters more for the composition than for the product: three of its four
+    documented rejections cannot be reached through :meth:`Bezier.compose` at all,
+    because Layer 2 refuses the same arguments first and with a **different exception
+    type**. The rational rejection is the sharp case -- ``TypeError`` from Python and
+    ``ValueError`` from C++ -- and that asymmetry is argued in ``product.hpp``'s file
+    comment rather than being an accident, so it is worth pinning where it is
+    observable.
+    """
+    del cpp_backend
+
+    from pantr import _pantr_cpp  # noqa: PLC0415
+    from pantr.bezier._bezier_product import _binomial_tables  # noqa: PLC0415
+
+    handle_type = _pantr_cpp.Bezier32 if np.dtype(dtype) == np.float32 else _pantr_cpp.Bezier64
+    outer = handle_type(cast("Any", _net((2, 3), 2, dtype, seed=20260845, rational=False)))
+    inner = handle_type(cast("Any", _reparametrization((2,), 2, dtype, seed=20260846)))
+    rational = handle_type(cast("Any", _net((2,), 1, dtype, seed=20260847, rational=True)), True)
+
+    # `max_d m_d = 3` for a univariate inner map, which contributes no composed-degree
+    # term; the header's own formula, checked against the binding rather than restated.
+    order = _pantr_cpp.bezier_composition_table_order(outer, inner)
+    assert order == 3, "a degree-(2, 3) outer map with a univariate inner map reads C(3, k)"
+    binomials, inverse_binomials = _binomial_tables(order, np.dtype(dtype))
+    short, short_inverse = _binomial_tables(order - 1, np.dtype(dtype))
+
+    with pytest.raises(ValueError, match="binomials must have shape at least"):
+        _pantr_cpp.compose_bezier(
+            outer, inner, binomials=short, inverse_binomials=inverse_binomials
+        )
+    with pytest.raises(ValueError, match="inverse_binomials must have shape at least"):
+        _pantr_cpp.compose_bezier(
+            outer, inner, binomials=binomials, inverse_binomials=short_inverse
+        )
+    with pytest.raises(TypeError):
+        _pantr_cpp.compose_bezier(outer, inner, binomials, inverse_binomials)  # type: ignore[misc]
+
+    # A rational operand: ValueError here, TypeError through `Bezier.compose`. Both
+    # spellings of the message are the oracle's, character for character.
+    with pytest.raises(ValueError, match=r"\(outer is rational\)\."):
+        _pantr_cpp.compose_bezier(
+            rational, inner, binomials=binomials, inverse_binomials=inverse_binomials
+        )
+    with pytest.raises(ValueError, match=r"\(inner is rational\)\."):
+        _pantr_cpp.compose_bezier(
+            outer, rational, binomials=binomials, inverse_binomials=inverse_binomials
+        )
+
+    # `inner.rank` is 2 and a univariate outer map has dim 1.
+    univariate = handle_type(cast("Any", _net((2,), 1, dtype, seed=20260848, rational=False)))
+    with pytest.raises(ValueError, match=r"must equal outer Bézier parametric dimension"):
+        _pantr_cpp.compose_bezier(
+            univariate, inner, binomials=binomials, inverse_binomials=inverse_binomials
+        )
+    assert short.shape == (order, order)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Moves Bézier multiplication and composition into C++. Closes #392 (the base is not `main`, so the
keyword will not fire; the issue is closed by hand). Last of the four bezier tickets in this
milestone.

## Evidence per acceptance criterion

- **AC1** Full suite green both ways on the rebased tree: 8285 passed / 45 skipped / 7 xfailed,
  and under `PANTR_BACKEND=cpp` 8282 / 48 / 7. `ctest` 37/37. Both dtypes are parametrisation
  axes in the new test file rather than an assumption. `scripts/ci_local.sh python`, which sets
  the reference-host flag and enables the liveness guards, passes all nine checks.
- **AC2** `test_the_product_reaches_the_port` asserts that the kernel selected under the C++
  backend *is* the C++ entry point, and that the result's implementation handle is a C++ type. It
  fails if `multiply` is quietly rerouted to the numpy helper **without any number changing** —
  which is the failure that went unnoticed here before.
- **AC3** The exactness qualification is stated in both methods, both module docstrings, the C++
  header and the changelog, verified by grepping every file this branch touches.
- **AC4** `test_the_product_stays_exact_where_the_kernel_leaves_its_envelope`, two degree-40
  curves, with an assertion on the binomial-table ceiling so the premise cannot rot silently.
- **AC5** Seven mutations, recorded in the module docstring. **Five caught** (9, 25, 20, 9 and 8
  failures of 82). **Two survive, and the reason was chased rather than reported as a number:**
  both widen a *single* operation that is narrowed straight back, which cannot move the result.
  The two that widen a *chain* are caught.

## Parity claims

Both are **equalities**, not bounds.

- **`multiply`.** Both sides run the same expressions in the same order: accumulation is i-major,
  the reciprocal folds in per term in the 1-D path and at the end in the n-D path, and every
  product is left-associated. Arithmetic is at **storage** width rather than the accumulator
  width, which is the inverse of every sibling kernel here — deliberately, because the oracle is
  numpy.
- **`compose`**, over both product branches. The n-D branch had no parity test before this.

## Self-review round

**Important — the port was slower than the code it replaced.** The binomial tables were rebuilt on
every call, quadratic in the order to read three rows: 66% to 97% of the entire C++ multiply, and
at degree 20 the C++ path was *slower* than numpy. Now cached and read-only. Measured after the
fix: 3.3x to 18x faster at every degree.

**Important — a contraction claim of mine was false.** I had written that one accumulation site is
contractible, so the equality would not survive an FMA build. Measured: the four functions emit
**zero** fused multiply-adds on an FMA build, and the two relevant compiler settings agree
bit-for-bit. The bounded arm is therefore selected on an FMA host and satisfied by **zero
differing elements** — sound but slack, and the test now says that rather than presenting it as
exercised.

**Important — a fabricated citation.** An invented title, corrected to Figueroa, *When is double
rounding innocuous?*, ACM SIGNUM 30(3):21-26, 1995, doi:10.1145/221332.221334. The threshold
number it was supposedly supporting is dropped; the claim now stands on the test.

**Important — and the correction was itself wrong.** An overstated parallel with the degree module
was replaced with "about degree 130", derived from the central binomial alone. The criterion the
binomial header actually states — the one that reproduces its own published ceiling exactly —
gives **124**. Corrected again, with the criterion named.

**Important — a promotion test that did not test promotion**; it compared a plain conversion, and
now runs the oracle's actual expression. Plus: untested raw-binding failure paths, an incomplete
`Raises:` section, an accessor list naming 11 of 19, and a changelog still claiming this operation
was unported.

## On bounds exercised by data

Following the finding on the previous branch, that a corrected bound was never exercised because
its test data was exact:

- One ratio in the C++ test was **exactly 0.00**, because the round trip through a binomial
  coefficient and its reciprocal is exact at `double` below degree 17. The sweep was widened;
  every ratio is now nonzero, from 0.029 to 0.55.
- **Reverting the bound turns the test red**, checked both ways: tightening the rounding factor a
  hundredfold fails it, and dropping the reciprocal from the product fails it. Both restored
  byte-for-byte afterwards.
- **One bound could not be exercised**: no configuration produces a real disagreement on the
  parity bounded arm. That is stated in the docstring rather than letting a green run read as
  coverage.

## Out of scope, reported not fixed

1. **The Bézier layer never calls the JIT warmup barrier** despite six `parallel=True` kernels in
   its core, where `CLAUDE.md` requires it and only the root-finding module does. A reviewer saw a
   segfault roughly 1 run in 10 on a three-file combination; **it could not be reproduced in 14
   attempts** with a warm cache. The detour was aborted rather than guessed at: the certain part
   is the missing barrier, the uncertain part is whether it explains that crash.
2. `Bezier.reverse`, `.permute_directions` and `.transform` still never dispatch to C++ although
   the bindings exist. Carried from #389.
3. **`-march=native` does not build**: Eigen's AVX-512 path trips `-Werror=maybe-uninitialized`,
   so one measurement script's reproduction path is broken on this host. Explicit AVX2 and FMA
   flags work.
4. The GIL is not released in the Bézier-returning bindings (a pre-existing pattern), and one
   scalar type is deep-copied inside the composition loop.

## Open question for review

The C++ signature takes the binomial table and its reciprocal **positionally**, and transposing
them returns a plausible wrong Bézier. The bindings are keyword-only, so only a headless C++
caller is exposed. A small struct would close it — but this is the fourth instance of the same
adjacent-same-typed-parameter pattern in this tree, and fixing one site alone is half a fix.
