### PR TITLE
fix(bezier): write out the accumulator widening the shape tests rely on

### DIFF
--- a/cpp/tests/test_bezier_shape.cpp
+++ b/cpp/tests/test_bezier_shape.cpp
@@ -580,7 +580,7 @@ void check_split_reproduces_the_curve() {
 
     for (std::size_t direction = 0; direction < degrees.size(); ++direction) {
         for (const T value : {T(0.3), T(0.6)}) {
-            std::pair<Bezier<T>, Bezier<T>> halves = ops::split<T>(bez, direction, value);
+            std::pair<Bezier<T>, Bezier<T>> halves = ops::split<T>(bez, direction, static_cast<pantr::accumulator_t<T>>(value));
             const Bezier<T>& left = halves.first;
             const Bezier<T>& right = halves.second;
             PANTR_CHECK(left.degree() == bez.degree());
@@ -673,7 +673,7 @@ void check_slice_reproduces_a_fixed_direction() {
     for (std::size_t axis = 0; axis < degrees.size(); ++axis) {
         const std::size_t other_dir = 1 - axis;
         for (const T v : {T(0.0), T(0.35), T(1.0)}) {
-            const Bezier<T> sliced = ops::slice<T>(bez, axis, v);
+            const Bezier<T> sliced = ops::slice<T>(bez, axis, static_cast<pantr::accumulator_t<T>>(v));
             PANTR_CHECK(sliced.dim() == 1);
             PANTR_CHECK(sliced.degree(0) == degrees[other_dir]);
 
@@ -714,7 +714,7 @@ void check_slice_point_matches_evaluate() {
     const std::size_t stages = stages_of(degrees);
 
     for (const T v : {T(0), T(1)}) {
-        const std::vector<T> sp = ops::slice_point<T>(bez, v);
+        const std::vector<T> sp = ops::slice_point<T>(bez, static_cast<pantr::accumulator_t<T>>(v));
         const std::vector<T> ev = evaluate_at<T>(bez, {{v}});
         for (std::size_t c = 0; c < rank; ++c) {
             PANTR_CHECK_MSG(sp[c] == ev[c],
@@ -728,8 +728,14 @@ void check_slice_point_matches_evaluate() {
     // runs evaluate_bezier_1d's Bernstein ratio recurrence instead.
     const double bound = de_casteljau_pass_bound(degrees[0], eps_t, max_abs_ctrl)
                         + (gamma_n(stages, eps_t) * max_abs_ctrl);
+    // The parameter is `accumulator_t<T>` by design -- narrowing it was the defect this
+    // file's own history records -- so the widening is written out rather than left
+    // implicit, which clang reports under `-Wdouble-promotion`. It converts from `T` and
+    // not from a `double` literal on purpose: at `T = float`, `double(float(0.3))` is
+    // 0.30000001192092896 and `double(0.3)` is not, so the shorter spelling would move
+    // the value this bound is tested against.
     for (const T v : {T(0.3), T(0.5), T(0.8)}) {
-        const std::vector<T> sp = ops::slice_point<T>(bez, v);
+        const std::vector<T> sp = ops::slice_point<T>(bez, static_cast<pantr::accumulator_t<T>>(v));
         const std::vector<T> ev = evaluate_at<T>(bez, {{v}});
         for (std::size_t c = 0; c < rank; ++c) {
             const double diff = std::abs(static_cast<double>(sp[c]) - static_cast<double>(ev[c]));
@@ -752,7 +758,7 @@ void check_boundary_matches_slice_and_corners() {
     for (std::size_t axis = 0; axis < degrees.size(); ++axis) {
         for (const int side : {0, 1}) {
             const Bezier<T> b = ops::boundary<T>(bez, axis, side);
-            const Bezier<T> s = ops::slice<T>(bez, axis, side == 0 ? T(0) : T(1));
+            const Bezier<T> s = ops::slice<T>(bez, axis, static_cast<pantr::accumulator_t<T>>(side == 0 ? T(0) : T(1)));
             const std::span<const T> b_vals = b.net().values();
             const std::span<const T> s_vals = s.net().values();
             for (std::size_t i = 0; i < b_vals.size(); ++i) {
@@ -771,7 +777,7 @@ void check_boundary_matches_slice_and_corners() {
     for (const int side0 : {0, 1}) {
         for (const int side1 : {0, 1}) {
             const Bezier<T> face = ops::boundary<T>(bez, 0, side0);
-            const std::vector<T> corner = ops::slice_point<T>(face, side1 == 0 ? T(0) : T(1));
+            const std::vector<T> corner = ops::slice_point<T>(face, static_cast<pantr::accumulator_t<T>>(side1 == 0 ? T(0) : T(1)));
             for (std::size_t c = 0; c < rank; ++c) {
                 const std::vector<std::size_t> idx{side0 == 0 ? std::size_t{0} : degrees[0],
                                                     side1 == 0 ? std::size_t{0} : degrees[1], c};


### PR DESCRIPTION
`scripts/ci_local.sh cxx`'s clang legs went red on `proto/cpp` when #414 merged. Six call sites in `cpp/tests/test_bezier_shape.cpp` pass a storage-width value to a parameter declared at the accumulator width, leaving the promotion implicit; clang rejects that under `-Wdouble-promotion`, which the project builds with `-Werror`. gcc does not warn, which is why it was invisible.

**This was my miss.** I verified #414 with ruff, ruff format, mypy, `lint-imports`, both backend suites, `ctest` and all three CI jobs, and ran only the `discipline` section of `ci_local.sh` rather than the whole thing. Two engineers then found it independently while working on later tickets. It is the second gate I let past today; #415 was the first.

## The fix, and why it is not a mechanical cast

The widening is **written out** rather than removed. The parameter is `accumulator_t<T>` on purpose: taking it at `T` and narrowing before the kernel was the Critical that #391's own review round found, and it failed 38 float32 cases. So the correction belongs in the test's spelling, not in the signature.

It converts **from `T`**, not from a `double` literal, and that distinction is the whole of it: at `T = float`, `double(float(0.3))` is `0.30000001192092896` and `double(0.3)` is not. The shorter spelling would compile, silence the warning, and silently move the value the error bound is tested against. For the endpoints `0` and `1` the two agree; the cast is used there as well so all six sites read alike.

## Verification

`scripts/ci_local.sh cxx`, all fifteen legs: **gcc configure/build/ctest, clang configure/build/ctest, gcc-debug (asan+ubsan) configure/build/ctest, and the clang++-10 floor all pass.** `clang++-10` was red for this same reason and is now green, which is what confirms the six sites were the whole of it.

`ctest` 37/37 under gcc. The **g++-10 floor legs stay red** for the unrelated pre-existing reason in #376.

No production code is touched: the diff is one test file.